### PR TITLE
Added ability to specify connection string from outside NeqSimDatabase

### DIFF
--- a/src/main/java/neqsim/util/database/NeqSimDataBase.java
+++ b/src/main/java/neqsim/util/database/NeqSimDataBase.java
@@ -85,8 +85,7 @@ public final class NeqSimDataBase implements neqsim.util.util.FileSystemSettings
                 return DriverManager.getConnection("jdbc:odbc:DRIVER={Microsoft Access Driver (*.mdb)};DBQ=" + dir + "\\data\\NeqSimDatabase");
                 
             } else if (dataBaseType.equals("H2")) {
-                Path path = FileSystems.getDefault().getPath(dataBasePath);
-                return DriverManager.getConnection ("jdbc:h2:" + path.toAbsolutePath().toString() + ";DATABASE_TO_UPPER=false", "sa",""); 
+                return DriverManager.getConnection(connectionString, "sa",""); 
             } else if (dataBaseType.equals("MSAccessUCanAccess")) {
                 return DriverManager.getConnection("jdbc:ucanaccess://" + dataBasePath + ";memory=true");
             } else if (dataBaseType.equals("mySQL") || dataBaseType.equals("mySQLNTNU") || dataBaseType.equals("Derby")) {
@@ -152,7 +151,14 @@ public final class NeqSimDataBase implements neqsim.util.util.FileSystemSettings
     }
 
     public static void setDataBaseType(String aDataBaseType) {
+        setDataBaseType(aDataBaseType, null);
+    }
+    
+    public static void setDataBaseType(String aDataBaseType, String connectionString) {
         dataBaseType = aDataBaseType;
+        if (connectionString!=null) {
+            NeqSimDataBase.connectionString = connectionString;
+        }
         try {
             if (dataBaseType.equals("MSAccess")) {
                 Class.forName("sun.jdbc.odbc.JdbcOdbcDriver").newInstance();


### PR DESCRIPTION
I've added the ability to set connection string directly for H2 databases from outside the NeqSimDataBase class. 

We need this in order to set scaling parameters in runtime.