### PR TITLE
refact: typo atractive -> attractive

### DIFF
--- a/src/main/java/neqsim/physicalProperties/physicalPropertyMethods/commonPhasePhysicalProperties/viscosity/FrictionTheoryViscosityMethod.java
+++ b/src/main/java/neqsim/physicalProperties/physicalPropertyMethods/commonPhasePhysicalProperties/viscosity/FrictionTheoryViscosityMethod.java
@@ -102,15 +102,15 @@ public class FrictionTheoryViscosityMethod extends Viscosity
         }
         visk0 = Math.exp(visk0);
         double Prepulsive = 1;
-        double Patractive = 1;
+        double Pattractive = 1;
         try {
             // frictional term
             Prepulsive = ((neqsim.thermo.phase.PhaseEosInterface) phase.getPhase())
                     .getPressureRepulsive();
-            Patractive = ((neqsim.thermo.phase.PhaseEosInterface) phase.getPhase())
-                    .getPressureAtractive();
+            Pattractive = ((neqsim.thermo.phase.PhaseEosInterface) phase.getPhase())
+                    .getPressureAttractive();
             // logger.info("P rep " + Prepulsive);
-            // logger.info("P atr " + Patractive);
+            // logger.info("P atr " + Pattractive);
         } catch (Exception e) {
             logger.error("error", e);
         }
@@ -141,7 +141,7 @@ public class FrictionTheoryViscosityMethod extends Viscosity
             kaprrmx += zi * nci * kaprri / (phase.getPhase().getComponent(i).getPC()
                     * phase.getPhase().getComponent(i).getPC());
         }
-        visk1 = kaprmx * Prepulsive + kapamx * Patractive + kaprrmx * Prepulsive * Prepulsive;
+        visk1 = kaprmx * Prepulsive + kapamx * Pattractive + kaprrmx * Prepulsive * Prepulsive;
 
         if ((visk0 + visk1) < 1e-20) {
             return 1e-6;

--- a/src/main/java/neqsim/physicalProperties/util/parameterFitting/pureComponentParameterFitting/pureCompInterfaceTension/TestInfluenceParamGTFunction.java
+++ b/src/main/java/neqsim/physicalProperties/util/parameterFitting/pureComponentParameterFitting/pureCompInterfaceTension/TestInfluenceParamGTFunction.java
@@ -12,7 +12,9 @@ import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.util.database.NeqSimDataBase;
 
 /**
- * <p>TestInfluenceParamGTFunction class.</p>
+ * <p>
+ * TestInfluenceParamGTFunction class.
+ * </p>
  *
  * @author Even Solbraa
  * @version $Id: $Id
@@ -21,7 +23,9 @@ public class TestInfluenceParamGTFunction {
     static Logger logger = LogManager.getLogger(TestInfluenceParamGTFunction.class);
 
     /**
-     * <p>main.</p>
+     * <p>
+     * main.
+     * </p>
      *
      * @param args an array of {@link java.lang.String} objects
      */
@@ -83,7 +87,7 @@ public class TestInfluenceParamGTFunction {
                 // / 1.0e3, 0);
                 // logger.error(testSystem.getTemperature() + " " + influenceParam);
                 // double factor = influenceParam /
-                // (testSystem.getPhase(0).getComponent(0).getAtractiveTerm().aT(testSystem.getTemperature())
+                // (testSystem.getPhase(0).getComponent(0).getAttractiveTerm().aT(testSystem.getTemperature())
                 // * 1.0e-5) / Math.pow(((ComponentEosInterface)
                 // testSystem.getPhase(0).getComponent(0)).calcb() * 1e-5, 2.0 / 3.0);
                 // sample.setDescription((1.0 - testSystem.getTemperature() /
@@ -123,7 +127,7 @@ public class TestInfluenceParamGTFunction {
          * ((GTSurfaceTension) testSystem.getInterphaseProperties().getSurfaceTensionModel(0)).
          * getInfluenceParameter(surfTens / 1.0e3, 0); logger.error(testSystem.getTemperature() +
          * " " + influenceParam); double factor = influenceParam /
-         * (testSystem.getPhase(0).getComponent(0).getAtractiveTerm().aT(testSystem.
+         * (testSystem.getPhase(0).getComponent(0).getAttractiveTerm().aT(testSystem.
          * getTemperature()) * 1.0e-5) / Math.pow(((ComponentEosInterface)
          * testSystem.getPhase(0).getComponent(0)).calcb() * 1e-5, 2.0 / 3.0);
          * sample.setDescription((1.0 - testSystem.getTemperature() /

--- a/src/main/java/neqsim/thermo/component/Component.java
+++ b/src/main/java/neqsim/thermo/component/Component.java
@@ -9,7 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.thermo.ThermodynamicConstantsInterface;
 import neqsim.thermo.atomElement.Element;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermInterface;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermInterface;
 import neqsim.thermo.phase.PhaseInterface;
 import neqsim.util.database.NeqSimDataBase;
 
@@ -17,7 +17,7 @@ abstract class Component implements ComponentInterface {
     private static final long serialVersionUID = 1000;
 
     double[] surfTensInfluenceParam = {0.28367, -0.05164, -0.81594, 1.06810, -1.1147};
-    protected int index, componentNumber, atractiveTermNumber = 0, numberOfAssociationSites = 0;
+    protected int index, componentNumber, attractiveTermNumber = 0, numberOfAssociationSites = 0;
     protected double logFugasityCoeffisient = 0.0, associationVolume = 0.0, associationEnergy = 0.0,
             aCPA = 0.0, bCPA = 0.0, mCPA = 0.0, srkacentricFactor = 0.0;
     protected String componentName = "default", referenceStateType = "solvent",
@@ -1341,7 +1341,7 @@ abstract class Component implements ComponentInterface {
     @Override
     public void setAcentricFactor(double val) {
         acentricFactor = val;
-        getAtractiveTerm().init();
+        getAttractiveTerm().init();
     }
 
     /** {@inheritDoc} */
@@ -1352,13 +1352,13 @@ abstract class Component implements ComponentInterface {
 
     /** {@inheritDoc} */
     @Override
-    public void setAtractiveTerm(int i) {
-        atractiveTermNumber = i;
+    public void setAttractiveTerm(int i) {
+        attractiveTermNumber = i;
     }
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermInterface getAtractiveTerm() {
+    public AttractiveTermInterface getAttractiveTerm() {
         return null;
     }
 
@@ -1497,11 +1497,11 @@ abstract class Component implements ComponentInterface {
     /**
      * {@inheritDoc}
      *
-     * Getter for property atractiveTermNumber.
+     * Getter for property attractiveTermNumber.
      */
     @Override
-    public final int getAtractiveTermNumber() {
-        return atractiveTermNumber;
+    public final int getAttractiveTermNumber() {
+        return attractiveTermNumber;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/ComponentElectrolyteCPA.java
+++ b/src/main/java/neqsim/thermo/component/ComponentElectrolyteCPA.java
@@ -74,7 +74,7 @@ public class ComponentElectrolyteCPA extends ComponentModifiedFurstElectrolyteEo
                 a = aCPA;
                 b = bCPA;
             }
-            setAtractiveTerm(0);
+            setAttractiveTerm(0);
         }
         // double[] surfTensInfluenceParamtemp = {-0.0286407191587279700,
         // -1.85760887578596, 0.520588, -0.1386439759, 1.1216308727071944};
@@ -113,7 +113,7 @@ public class ComponentElectrolyteCPA extends ComponentModifiedFurstElectrolyteEo
                 a = aCPA;
                 b = bCPA;
             }
-            setAtractiveTerm(0);
+            setAttractiveTerm(0);
         }
         // double[] surfTensInfluenceParamtemp = {-0.0286407191587279700,
         // -1.85760887578596, 0.520588, -0.1386439759, 1.1216308727071944};
@@ -166,10 +166,10 @@ public class ComponentElectrolyteCPA extends ComponentModifiedFurstElectrolyteEo
 
     /** {@inheritDoc} */
     @Override
-    public void setAtractiveTerm(int i) {
-        super.setAtractiveTerm(i);
+    public void setAttractiveTerm(int i) {
+        super.setAttractiveTerm(i);
         if (Math.abs(aCPA) > 1e-6 && cpaon == 1) {
-            getAtractiveTerm().setm(mCPA);
+            getAttractiveTerm().setm(mCPA);
         }
     }
 

--- a/src/main/java/neqsim/thermo/component/ComponentElectrolyteCPAOld.java
+++ b/src/main/java/neqsim/thermo/component/ComponentElectrolyteCPAOld.java
@@ -75,7 +75,7 @@ public class ComponentElectrolyteCPAOld extends ComponentModifiedFurstElectrolyt
                 a = aCPA;
                 b = bCPA;
             }
-            setAtractiveTerm(0);
+            setAttractiveTerm(0);
         }
     }
 
@@ -109,7 +109,7 @@ public class ComponentElectrolyteCPAOld extends ComponentModifiedFurstElectrolyt
                 a = aCPA;
                 b = bCPA;
             }
-            setAtractiveTerm(0);
+            setAttractiveTerm(0);
         }
     }
 
@@ -152,10 +152,10 @@ public class ComponentElectrolyteCPAOld extends ComponentModifiedFurstElectrolyt
 
     /** {@inheritDoc} */
     @Override
-    public void setAtractiveTerm(int i) {
-        super.setAtractiveTerm(i);
+    public void setAttractiveTerm(int i) {
+        super.setAttractiveTerm(i);
         if (Math.abs(aCPA) > 1e-6 && cpaon == 1) {
-            getAtractiveTerm().setm(mCPA);
+            getAttractiveTerm().setm(mCPA);
         }
     }
 

--- a/src/main/java/neqsim/thermo/component/ComponentEos.java
+++ b/src/main/java/neqsim/thermo/component/ComponentEos.java
@@ -7,26 +7,26 @@ package neqsim.thermo.component;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermCPAstatoil;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermGERG;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermInterface;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermMatCop;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermMatCopPR;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermMatCopPRUMR;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermMollerup;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermPr;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermPr1978;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermPrDanesh;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermPrDelft1998;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermPrGassem2001;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermRk;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermSchwartzentruber;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermSrk;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermTwu;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermTwuCoon;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermTwuCoonParam;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermUMRPRU;
-import neqsim.thermo.component.atractiveEosTerm.AttractiveTermTwuCoonStatoil;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermCPAstatoil;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermGERG;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermInterface;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermMatCop;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermMatCopPR;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermMatCopPRUMR;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermMollerup;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermPr;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermPr1978;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermPrDanesh;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermPrDelft1998;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermPrGassem2001;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermRk;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermSchwartzentruber;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermSrk;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermTwu;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermTwuCoon;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermTwuCoonParam;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermTwuCoonStatoil;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermUMRPRU;
 import neqsim.thermo.phase.PhaseInterface;
 
 /**
@@ -44,7 +44,7 @@ abstract class ComponentEos extends Component implements ComponentEosInterface {
     protected double aDern = 0, aDerT = 0, aDerTT = 0, aDerTn = 0, bDern = 0, bDerTn = 0;
     protected double dAdndn[] = new double[MAX_NUMBER_OF_COMPONENTS];
     protected double dBdndn[] = new double[MAX_NUMBER_OF_COMPONENTS];
-    private AtractiveTermInterface atractiveParameter;
+    private AttractiveTermInterface attractiveParameter;
     static Logger logger = LogManager.getLogger(ComponentEos.class);
 
     /**
@@ -94,7 +94,7 @@ abstract class ComponentEos extends Component implements ComponentEosInterface {
             logger.error("Cloning failed.", e);
         }
 
-        clonedComponent.setAtractiveParameter(this.getAtractiveParameter().clone());
+        clonedComponent.setAttractiveParameter(this.getAttractiveParameter().clone());
 
         return clonedComponent;
     }
@@ -139,50 +139,50 @@ abstract class ComponentEos extends Component implements ComponentEosInterface {
 
     /** {@inheritDoc} */
     @Override
-    public void setAtractiveTerm(int i) {
-        atractiveTermNumber = i;
+    public void setAttractiveTerm(int i) {
+        attractiveTermNumber = i;
         if (i == 0) {
-            setAtractiveParameter(new AtractiveTermSrk(this));
+            setAttractiveParameter(new AttractiveTermSrk(this));
         } else if (i == 1) {
-            setAtractiveParameter(new AtractiveTermPr(this));
+            setAttractiveParameter(new AttractiveTermPr(this));
         } else if (i == 2) {
-            setAtractiveParameter(
-                    new AtractiveTermSchwartzentruber(this, getSchwartzentruberParams()));
+            setAttractiveParameter(
+                    new AttractiveTermSchwartzentruber(this, getSchwartzentruberParams()));
         } else if (i == 3) {
-            setAtractiveParameter(new AtractiveTermMollerup(this, getSchwartzentruberParams()));
+            setAttractiveParameter(new AttractiveTermMollerup(this, getSchwartzentruberParams()));
         } else if (i == 4) {
-            setAtractiveParameter(new AtractiveTermMatCop(this, getMatiascopemanParams()));
+            setAttractiveParameter(new AttractiveTermMatCop(this, getMatiascopemanParams()));
         } else if (i == 5) {
-            setAtractiveParameter(new AtractiveTermRk(this));
+            setAttractiveParameter(new AttractiveTermRk(this));
         } else if (i == 6) {
-            setAtractiveParameter(new AtractiveTermPr1978(this));
+            setAttractiveParameter(new AttractiveTermPr1978(this));
         } else if (i == 7) {
-            setAtractiveParameter(new AtractiveTermPrDelft1998(this));
+            setAttractiveParameter(new AttractiveTermPrDelft1998(this));
         } else if (i == 8) {
-            setAtractiveParameter(new AtractiveTermPrGassem2001(this));
+            setAttractiveParameter(new AttractiveTermPrGassem2001(this));
         } else if (i == 9) {
-            setAtractiveParameter(new AtractiveTermPrDanesh(this));
+            setAttractiveParameter(new AttractiveTermPrDanesh(this));
         } else if (i == 10) {
-            setAtractiveParameter(new AtractiveTermGERG(this));
+            setAttractiveParameter(new AttractiveTermGERG(this));
         } else if (i == 11) {
-            setAtractiveParameter(new AtractiveTermTwuCoon(this));
+            setAttractiveParameter(new AttractiveTermTwuCoon(this));
         } else if (i == 12) {
-            setAtractiveParameter(new AtractiveTermTwuCoonParam(this, getTwuCoonParams()));
+            setAttractiveParameter(new AttractiveTermTwuCoonParam(this, getTwuCoonParams()));
         } else if (i == 13) {
-            setAtractiveParameter(new AtractiveTermMatCopPR(this, getMatiascopemanParamsPR()));
+            setAttractiveParameter(new AttractiveTermMatCopPR(this, getMatiascopemanParamsPR()));
         } else if (i == 14) {
-            setAtractiveParameter(new AtractiveTermTwu(this));
+            setAttractiveParameter(new AttractiveTermTwu(this));
         } else if (i == 15) {
-            setAtractiveParameter(new AtractiveTermCPAstatoil(this));
+            setAttractiveParameter(new AttractiveTermCPAstatoil(this));
         } else if (i == 16) {
-            setAtractiveParameter(new AtractiveTermUMRPRU(this));
+            setAttractiveParameter(new AttractiveTermUMRPRU(this));
         } else if (i == 17) {
-            setAtractiveParameter(new AtractiveTermMatCopPRUMR(this));
+            setAttractiveParameter(new AttractiveTermMatCopPRUMR(this));
         } else if (i == 18) {
             if (componentName.equals("mercury")) {
-                setAtractiveParameter(new AttractiveTermTwuCoonStatoil(this, getTwuCoonParams()));
+                setAttractiveParameter(new AttractiveTermTwuCoonStatoil(this, getTwuCoonParams()));
             } else {
-                setAtractiveParameter(new AtractiveTermSrk(this));
+                setAttractiveParameter(new AttractiveTermSrk(this));
             }
         } else {
             logger.error("error selecting an alpha formultaion term");
@@ -192,8 +192,8 @@ abstract class ComponentEos extends Component implements ComponentEosInterface {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermInterface getAtractiveTerm() {
-        return this.getAtractiveParameter();
+    public AttractiveTermInterface getAttractiveTerm() {
+        return this.getAttractiveParameter();
     }
 
     /**
@@ -511,13 +511,13 @@ abstract class ComponentEos extends Component implements ComponentEosInterface {
      * @return a double
      */
     public double alpha(double temperature) {
-        return getAtractiveParameter().alpha(temperature);
+        return getAttractiveParameter().alpha(temperature);
     }
 
     /** {@inheritDoc} */
     @Override
     public double aT(double temperature) {
-        return getAtractiveParameter().aT(temperature);
+        return getAttractiveParameter().aT(temperature);
     }
 
     /**
@@ -529,7 +529,7 @@ abstract class ComponentEos extends Component implements ComponentEosInterface {
      * @return a double
      */
     public double diffalphaT(double temperature) {
-        return getAtractiveParameter().diffalphaT(temperature);
+        return getAttractiveParameter().diffalphaT(temperature);
     }
 
     /**
@@ -541,19 +541,19 @@ abstract class ComponentEos extends Component implements ComponentEosInterface {
      * @return a double
      */
     public double diffdiffalphaT(double temperature) {
-        return getAtractiveParameter().diffdiffalphaT(temperature);
+        return getAttractiveParameter().diffdiffalphaT(temperature);
     }
 
     /** {@inheritDoc} */
     @Override
     public double diffaT(double temperature) {
-        return getAtractiveParameter().diffaT(temperature);
+        return getAttractiveParameter().diffaT(temperature);
     }
 
     /** {@inheritDoc} */
     @Override
     public double diffdiffaT(double temperature) {
-        return getAtractiveParameter().diffdiffaT(temperature);
+        return getAttractiveParameter().diffdiffaT(temperature);
     }
 
     /** {@inheritDoc} */
@@ -615,14 +615,14 @@ abstract class ComponentEos extends Component implements ComponentEosInterface {
 
         // System.out.println("scale1 " + scale1);
         // return scale1;
-        // getAtractiveTerm().alpha(temperature)*1e-5 * Math.pow(b*1e-5, 2.0 / 3.0) *
+        // getAttractiveTerm().alpha(temperature)*1e-5 * Math.pow(b*1e-5, 2.0 / 3.0) *
         // Math.exp(a_inf + b_inf * Math.log(TR) + c_inf * (Math.pow(Math.log(TR),
         // 2.0)))/ Math.pow(ThermodynamicConstantsInterface.avagadroNumber, 8.0 / 3.0);
 
         double AA = -1.0e-16 / (1.2326 + 1.3757 * getAcentricFactor());
         double BB = 1.0e-16 / (0.9051 + 1.541 * getAcentricFactor());
 
-        // double scale2 = getAtractiveTerm().alpha(temperature) * 1e-5 * Math.pow(b * 1e-5, 2.0 /
+        // double scale2 = getAttractiveTerm().alpha(temperature) * 1e-5 * Math.pow(b * 1e-5, 2.0 /
         // 3.0) * (AA * TR + BB);
         // System.out.println("scale2 " + scale2);
         return aT * 1e-5 * Math.pow(b * 1e-5, 2.0 / 3.0) * (AA * TR + BB);/// Math.pow(ThermodynamicConstantsInterface.avagadroNumber,
@@ -720,24 +720,24 @@ abstract class ComponentEos extends Component implements ComponentEosInterface {
 
     /**
      * <p>
-     * Getter for the field <code>atractiveParameter</code>.
+     * Getter for the field <code>attractiveParameter</code>.
      * </p>
      *
-     * @return a {@link neqsim.thermo.component.atractiveEosTerm.AtractiveTermInterface} object
+     * @return a {@link neqsim.thermo.component.attractiveEosTerm.AttractiveTermInterface} object
      */
-    public AtractiveTermInterface getAtractiveParameter() {
-        return atractiveParameter;
+    public AttractiveTermInterface getAttractiveParameter() {
+        return attractiveParameter;
     }
 
     /**
      * <p>
-     * Setter for the field <code>atractiveParameter</code>.
+     * Setter for the field <code>attractiveParameter</code>.
      * </p>
      *
-     * @param atractiveParameter a
-     *        {@link neqsim.thermo.component.atractiveEosTerm.AtractiveTermInterface} object
+     * @param attractiveParameter a
+     *        {@link neqsim.thermo.component.attractiveEosTerm.AttractiveTermInterface} object
      */
-    public void setAtractiveParameter(AtractiveTermInterface atractiveParameter) {
-        this.atractiveParameter = atractiveParameter;
+    public void setAttractiveParameter(AttractiveTermInterface attractiveParameter) {
+        this.attractiveParameter = attractiveParameter;
     }
 }

--- a/src/main/java/neqsim/thermo/component/ComponentInterface.java
+++ b/src/main/java/neqsim/thermo/component/ComponentInterface.java
@@ -7,7 +7,7 @@ package neqsim.thermo.component;
 
 import neqsim.thermo.ThermodynamicConstantsInterface;
 import neqsim.thermo.atomElement.Element;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermInterface;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermInterface;
 import neqsim.thermo.phase.PhaseInterface;
 
 /**
@@ -1210,21 +1210,21 @@ public interface ComponentInterface extends ThermodynamicConstantsInterface, Clo
 
     /**
      * <p>
-     * setAtractiveTerm.
+     * setAttractiveTerm.
      * </p>
      *
      * @param i a int
      */
-    public void setAtractiveTerm(int i);
+    public void setAttractiveTerm(int i);
 
     /**
      * <p>
-     * getAtractiveTerm.
+     * getAttractiveTerm.
      * </p>
      *
-     * @return a {@link neqsim.thermo.component.atractiveEosTerm.AtractiveTermInterface} object
+     * @return a {@link neqsim.thermo.component.attractiveEosTerm.AttractiveTermInterface} object
      */
-    public AtractiveTermInterface getAtractiveTerm();
+    public AttractiveTermInterface getAttractiveTerm();
 
     /**
      * <p>
@@ -1605,12 +1605,12 @@ public interface ComponentInterface extends ThermodynamicConstantsInterface, Clo
 
     /**
      * <p>
-     * getAtractiveTermNumber.
+     * getAttractiveTermNumber.
      * </p>
      *
      * @return a int
      */
-    public int getAtractiveTermNumber();
+    public int getAttractiveTermNumber();
 
     /**
      * <p>

--- a/src/main/java/neqsim/thermo/component/ComponentModifiedFurstElectrolyteEos.java
+++ b/src/main/java/neqsim/thermo/component/ComponentModifiedFurstElectrolyteEos.java
@@ -68,8 +68,8 @@ public class ComponentModifiedFurstElectrolyteEos extends ComponentSrk {
                         * 1e5
                 : b;
         a = ionicCharge != 0 ? 1.0e-35 : a;
-        setAtractiveParameter(
-                new neqsim.thermo.component.atractiveEosTerm.AtractiveTermSchwartzentruber(this));
+        setAttractiveParameter(
+                new neqsim.thermo.component.attractiveEosTerm.AttractiveTermSchwartzentruber(this));
         lennardJonesMolecularDiameter = ionicCharge != 0
                 ? Math.pow((6.0 * b / 1.0e5) / (pi * avagadroNumber), 1.0 / 3.0) * 1e10
                 : lennardJonesMolecularDiameter;

--- a/src/main/java/neqsim/thermo/component/ComponentModifiedFurstElectrolyteEosMod2004.java
+++ b/src/main/java/neqsim/thermo/component/ComponentModifiedFurstElectrolyteEosMod2004.java
@@ -67,8 +67,8 @@ public class ComponentModifiedFurstElectrolyteEosMod2004 extends ComponentSrk {
                         * 1e5
                 : b;
         a = ionicCharge != 0 ? 1.0e-35 : a;
-        setAtractiveParameter(
-                new neqsim.thermo.component.atractiveEosTerm.AtractiveTermSchwartzentruber(this));
+        setAttractiveParameter(
+                new neqsim.thermo.component.attractiveEosTerm.AttractiveTermSchwartzentruber(this));
         lennardJonesMolecularDiameter = ionicCharge != 0
                 ? Math.pow((6.0 * b / 1.0e5) / (pi * avagadroNumber), 1.0 / 3.0) * 1e10
                 : lennardJonesMolecularDiameter;

--- a/src/main/java/neqsim/thermo/component/ComponentPR.java
+++ b/src/main/java/neqsim/thermo/component/ComponentPR.java
@@ -1,6 +1,6 @@
 package neqsim.thermo.component;
 
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermPr;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermPr;
 
 /**
  * <p>
@@ -51,7 +51,7 @@ public class ComponentPR extends ComponentEos {
 
         delta1 = 1.0 + Math.sqrt(2.0);
         delta2 = 1.0 - Math.sqrt(2.0);
-        setAtractiveParameter(new AtractiveTermPr(this));
+        setAttractiveParameter(new AttractiveTermPr(this));
 
         double[] surfTensInfluenceParamtemp = {1.3192, 1.6606, 1.1173, 0.8443};
         this.surfTensInfluenceParam = surfTensInfluenceParamtemp;

--- a/src/main/java/neqsim/thermo/component/ComponentPrCPA.java
+++ b/src/main/java/neqsim/thermo/component/ComponentPrCPA.java
@@ -55,7 +55,7 @@ abstract class ComponentPrCPA extends ComponentPR implements ComponentCPAInterfa
             }
             a = aCPA;
             b = bCPA;
-            setAtractiveTerm(1);
+            setAttractiveTerm(1);
         }
     }
 
@@ -81,7 +81,7 @@ abstract class ComponentPrCPA extends ComponentPR implements ComponentCPAInterfa
             a = aCPA;
             b = bCPA;
         }
-        setAtractiveTerm(1);
+        setAttractiveTerm(1);
     }
 
     /** {@inheritDoc} */
@@ -134,10 +134,10 @@ abstract class ComponentPrCPA extends ComponentPR implements ComponentCPAInterfa
 
     /** {@inheritDoc} */
     @Override
-    public void setAtractiveTerm(int i) {
-        super.setAtractiveTerm(i);
+    public void setAttractiveTerm(int i) {
+        super.setAttractiveTerm(i);
         if ((getNumberOfAssociationSites() > 0 || Math.abs(aCPA) > 1e-6) && cpaon == 1) {
-            getAtractiveTerm().setm(mCPA);
+            getAttractiveTerm().setm(mCPA);
         }
     }
 

--- a/src/main/java/neqsim/thermo/component/ComponentRK.java
+++ b/src/main/java/neqsim/thermo/component/ComponentRK.java
@@ -1,6 +1,6 @@
 package neqsim.thermo.component;
 
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermRk;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermRk;
 
 /**
  * <p>
@@ -49,7 +49,7 @@ public class ComponentRK extends ComponentEos {
         b = (Math.pow(2.0, 1.0 / 3.0) - 1.0) / 3.0 * R * criticalTemperature / criticalPressure;
         delta1 = 1.0;
         delta2 = 0.0;
-        setAtractiveParameter(new AtractiveTermRk(this));
+        setAttractiveParameter(new AttractiveTermRk(this));
     }
 
     /**

--- a/src/main/java/neqsim/thermo/component/ComponentSolid.java
+++ b/src/main/java/neqsim/thermo/component/ComponentSolid.java
@@ -242,8 +242,8 @@ public class ComponentSolid extends ComponentSrk {
                     refPhase.addcomponent("methane", 10.0, 10.0, 0);
                     refPhase.getComponent("methane").setComponentName(componentName);
                 }
-                refPhase.getComponent(componentName).setAtractiveTerm(
-                        phase.getComponent(componentName).getAtractiveTermNumber());
+                refPhase.getComponent(componentName).setAttractiveTerm(
+                        phase.getComponent(componentName).getAttractiveTermNumber());
                 refPhase.init(refPhase.getNumberOfMolesInPhase(), 1, 0, 1, 1.0);
             }
         } catch (Exception e) {

--- a/src/main/java/neqsim/thermo/component/ComponentSrk.java
+++ b/src/main/java/neqsim/thermo/component/ComponentSrk.java
@@ -1,7 +1,7 @@
 package neqsim.thermo.component;
 
 import neqsim.thermo.ThermodynamicConstantsInterface;
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermSrk;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermSrk;
 
 /**
  * <p>
@@ -57,8 +57,8 @@ public class ComponentSrk extends ComponentEos {
         delta1 = 1.0;
         delta2 = 0.0;
         // System.out.println("a " + a);
-        // atractiveParameter = new AtractiveTermSchwartzentruber(this);
-        setAtractiveParameter(new AtractiveTermSrk(this));
+        // attractiveParameter = new AttractiveTermSchwartzentruber(this);
+        setAttractiveParameter(new AttractiveTermSrk(this));
 
         double[] surfTensInfluenceParamtemp =
                 {-0.7708158524, 0.4990571549, 0.8645478315, -0.3509810630, -0.1611763157};

--- a/src/main/java/neqsim/thermo/component/ComponentSrkCPA.java
+++ b/src/main/java/neqsim/thermo/component/ComponentSrkCPA.java
@@ -74,7 +74,7 @@ public class ComponentSrkCPA extends ComponentSrk implements ComponentCPAInterfa
                 a = aCPA;
                 b = bCPA;
             }
-            setAtractiveTerm(0);
+            setAttractiveTerm(0);
         }
         // double[] surfTensInfluenceParamtemp = {-0.0286407191587279700,
         // -1.85760887578596, 0.520588, -0.1386439759, 1.1216308727071944};
@@ -112,7 +112,7 @@ public class ComponentSrkCPA extends ComponentSrk implements ComponentCPAInterfa
                 a = aCPA;
                 b = bCPA;
             }
-            setAtractiveTerm(0);
+            setAttractiveTerm(0);
         }
         // double[] surfTensInfluenceParamtemp = {-0.0286407191587279700,
         // -1.85760887578596, 0.520588, -0.1386439759, 1.1216308727071944};
@@ -165,10 +165,10 @@ public class ComponentSrkCPA extends ComponentSrk implements ComponentCPAInterfa
 
     /** {@inheritDoc} */
     @Override
-    public void setAtractiveTerm(int i) {
-        super.setAtractiveTerm(i);
+    public void setAttractiveTerm(int i) {
+        super.setAttractiveTerm(i);
         if (Math.abs(aCPA) > 1e-6 && cpaon == 1) {
-            getAtractiveTerm().setm(mCPA);
+            getAttractiveTerm().setm(mCPA);
         }
     }
 

--- a/src/main/java/neqsim/thermo/component/ComponentSrkPeneloux.java
+++ b/src/main/java/neqsim/thermo/component/ComponentSrkPeneloux.java
@@ -1,6 +1,6 @@
 package neqsim.thermo.component;
 
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermSrk;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermSrk;
 
 /**
  * <p>
@@ -55,8 +55,8 @@ public class ComponentSrkPeneloux extends ComponentSrk {
         delta1 = 1.0;
         delta2 = 0.0;
         // System.out.println("a " + a);
-        // atractiveParameter = new AtractiveTermSchwartzentruber(this);
-        setAtractiveParameter(new AtractiveTermSrk(this));
+        // attractiveParameter = new AttractiveTermSchwartzentruber(this);
+        setAttractiveParameter(new AttractiveTermSrk(this));
 
         double[] surfTensInfluenceParamtemp =
                 {-0.7708158524, 0.4990571549, 0.8645478315, -0.3509810630, -0.1611763157};

--- a/src/main/java/neqsim/thermo/component/ComponentTST.java
+++ b/src/main/java/neqsim/thermo/component/ComponentTST.java
@@ -1,6 +1,6 @@
 package neqsim.thermo.component;
 
-import neqsim.thermo.component.atractiveEosTerm.AtractiveTermTwu;
+import neqsim.thermo.component.attractiveEosTerm.AttractiveTermTwu;
 
 /**
  * <p>
@@ -51,7 +51,7 @@ public class ComponentTST extends ComponentEos {
 
         delta1 = 1.0 + Math.sqrt(2.0);
         delta2 = 1.0 - Math.sqrt(2.0);
-        setAtractiveParameter(new AtractiveTermTwu(this));
+        setAttractiveParameter(new AttractiveTermTwu(this));
     }
 
     /**

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermBaseClass.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermBaseClass.java
@@ -1,9 +1,9 @@
 /*
- * AtractiveTermBaseClass.java
+ * AttractiveTermBaseClass.java
  *
  * Created on 13. mai 2001, 21:58
  */
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,13 +11,13 @@ import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermBaseClass class.
+ * AttractiveTermBaseClass class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermBaseClass implements AtractiveTermInterface {
+public class AttractiveTermBaseClass implements AttractiveTermInterface {
     private static final long serialVersionUID = 1000;
 
     private ComponentEosInterface component = null;
@@ -25,23 +25,23 @@ public class AtractiveTermBaseClass implements AtractiveTermInterface {
     protected double parameters[] = new double[3];
     protected double parametersSolid[] = new double[3];
 
-    static Logger logger = LogManager.getLogger(AtractiveTermBaseClass.class);
+    static Logger logger = LogManager.getLogger(AttractiveTermBaseClass.class);
 
     /**
      * <p>
-     * Constructor for AtractiveTermBaseClass.
+     * Constructor for AttractiveTermBaseClass.
      * </p>
      */
-    public AtractiveTermBaseClass() {}
+    public AttractiveTermBaseClass() {}
 
     /**
      * <p>
-     * Constructor for AtractiveTermBaseClass.
+     * Constructor for AttractiveTermBaseClass.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermBaseClass(ComponentEosInterface component) {
+    public AttractiveTermBaseClass(ComponentEosInterface component) {
         this.setComponent(component);
     }
 
@@ -54,19 +54,19 @@ public class AtractiveTermBaseClass implements AtractiveTermInterface {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermBaseClass clone() {
-        AtractiveTermBaseClass atractiveTerm = null;
+    public AttractiveTermBaseClass clone() {
+        AttractiveTermBaseClass attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermBaseClass) super.clone();
+            attractiveTerm = (AttractiveTermBaseClass) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
         // atSystem.out.println("m " + m);ractiveTerm.parameters = (double[])
         // parameters.clone();
-        // System.arraycopy(parameters,0, atractiveTerm.parameters, 0,
+        // System.arraycopy(parameters,0, attractiveTerm.parameters, 0,
         // parameters.length);
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermCPAstatoil.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermCPAstatoil.java
@@ -1,83 +1,92 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermMatCop class.
+ * AttractiveTermCPAstatoil class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermMatCop extends AtractiveTermSrk {
+public class AttractiveTermCPAstatoil extends AttractiveTermSrk {
     private static final long serialVersionUID = 1000;
 
     double orgpar = 0.0;
 
     /**
      * <p>
-     * Constructor for AtractiveTermMatCop.
+     * Constructor for AttractiveTermCPAstatoil.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermMatCop(ComponentEosInterface component) {
+    public AttractiveTermCPAstatoil(ComponentEosInterface component) {
         super(component);
         m = (0.48 + 1.574 * component.getAcentricFactor()
-                - 0.175 * component.getAcentricFactor() * component.getAcentricFactor());
-    }
-
-    /**
-     * <p>
-     * Constructor for AtractiveTermMatCop.
-     * </p>
-     *
-     * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
-     * @param params an array of {@link double} objects
-     */
-    public AtractiveTermMatCop(ComponentEosInterface component, double[] params) {
-        this(component);
-        System.arraycopy(params, 0, this.parameters, 0, params.length);
-        orgpar = parameters[0];
-        if (Math.abs(parameters[0]) < 1e-12) {
+                - 0.176 * component.getAcentricFactor() * component.getAcentricFactor());
+        if (component.getName().equals("waterG")) {
+            parameters[0] = 0.7892765953;
+            parameters[1] = -1.0606510837;
+            parameters[2] = 2.2071936510;
+        } else if (component.getName().equals("MEG2")) {
+            parameters[0] = 0.8581331725;
+            parameters[1] = -1.0053180150;
+            parameters[2] = 1.2736063639;
+        } else if (component.getName().equals("TEG2")) {
+            parameters[0] = 1.0008858863;
+            parameters[1] = 1.8649645470;
+            parameters[2] = -4.6720397496;
+        } else if (component.getName().equals("TEG")) {
+            parameters[0] = 0.903477158616734;
+            parameters[1] = 1.514853438;
+            parameters[2] = -1.86430399826;
+        } else {
             parameters[0] = m;
+            parameters[1] = 0;
+            parameters[2] = 0;
         }
     }
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermMatCop clone() {
-        AtractiveTermMatCop atractiveTerm = null;
+    public AttractiveTermCPAstatoil clone() {
+        AttractiveTermCPAstatoil attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermMatCop) super.clone();
+            attractiveTerm = (AttractiveTermCPAstatoil) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
-
-        return atractiveTerm;
+        // attractiveTerm.parameters = (double[]) parameters.clone();
+        // System.arraycopy(parameters,0, attractiveTerm.parameters, 0,
+        // parameters.length);
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */
     @Override
     public void init() {
         super.init();
-        parameters[0] = m;
+        if (!getComponent().getName().equals("TEG")) {
+            parameters[0] = m;
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public double alpha(double temperature) {
         double Tr = temperature / getComponent().getTC();
-        return Math.pow(1.0 + parameters[0] * (1.0 - Math.sqrt(Tr))
-                + parameters[1] * Math.pow(1.0 - Math.sqrt(Tr), 2.0)
-                + parameters[2] * Math.pow(1.0 - Math.sqrt(Tr), 3.0), 2.0);
+        double temp1 = 1.0 - Math.sqrt(Tr);
+        double var = 1.0 + parameters[0] * temp1 + parameters[1] * temp1 * temp1
+                + parameters[2] * temp1 * temp1 * temp1;
+        return var * var;// Math.pow(1.0+parameters[0]*(1.0-Math.sqrt(Tr))+parameters[1]*temp1*temp1+parameters[2]*temp1*temp1*temp1,2.0);
     }
 
     /** {@inheritDoc} */
     @Override
     public double aT(double temperature) {
-        if (temperature / getComponent().getTC() > 10000.0) {
+        if (temperature / getComponent().getTC() > 1.0) {
             return super.aT(temperature);
         } else {
             return getComponent().geta() * alpha(temperature);
@@ -126,7 +135,7 @@ public class AtractiveTermMatCop extends AtractiveTermSrk {
     /** {@inheritDoc} */
     @Override
     public double diffaT(double temperature) {
-        if (temperature / getComponent().getTC() > 10000.0) {
+        if (temperature / getComponent().getTC() > 1.0) {
             return super.diffaT(temperature);
         } else {
             return getComponent().geta() * diffalphaT(temperature);
@@ -136,7 +145,7 @@ public class AtractiveTermMatCop extends AtractiveTermSrk {
     /** {@inheritDoc} */
     @Override
     public double diffdiffaT(double temperature) {
-        if (temperature / getComponent().getTC() > 10000.0) {
+        if (temperature / getComponent().getTC() > 1.0) {
             return super.diffdiffaT(temperature);
         } else {
             return getComponent().geta() * diffdiffalphaT(temperature);

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermGERG.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermGERG.java
@@ -1,28 +1,28 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermGERG class.
+ * AttractiveTermGERG class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermGERG extends AtractiveTermPr {
+public class AttractiveTermGERG extends AttractiveTermPr {
     private static final long serialVersionUID = 1000;
     protected double parametersGERG[] = {0.905436, -0.213781, 0.26005};
     protected double parametersSolidGERG[] = {0.106025, 2.683845, -4.75638};
 
     /**
      * <p>
-     * Constructor for AtractiveTermGERG.
+     * Constructor for AttractiveTermGERG.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermGERG(ComponentEosInterface component) {
+    public AttractiveTermGERG(ComponentEosInterface component) {
         super(component);
         if (component.getName().equals("water")) {
             System.arraycopy(component.getMatiascopemanParams(), 0, this.parameters, 0,
@@ -34,20 +34,20 @@ public class AtractiveTermGERG extends AtractiveTermPr {
 
     /**
      * <p>
-     * AtractiveTermGERG.
+     * AttractiveTermGERG.
      * </p>
      *
      * @return a {@link java.lang.Object} object
      */
-    public Object AtractiveTermGERG() {
-        AtractiveTermGERG atractiveTerm = null;
+    public Object AttractiveTermGERG() {
+        AttractiveTermGERG attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermGERG) super.clone();
+            attractiveTerm = (AttractiveTermGERG) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermInterface.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermInterface.java
@@ -1,19 +1,19 @@
 /*
- * AtractiveTermInterface.java
+ * AttractiveTermInterface.java
  *
  * Created on 13. mai 2001, 21:54
  */
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 /**
  * <p>
- * AtractiveTermInterface interface.
+ * AttractiveTermInterface interface.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public interface AtractiveTermInterface extends Cloneable, java.io.Serializable {
+public interface AttractiveTermInterface extends Cloneable, java.io.Serializable {
     /**
      * <p>
      * init.
@@ -115,7 +115,7 @@ public interface AtractiveTermInterface extends Cloneable, java.io.Serializable 
      * clone.
      * </p>
      *
-     * @return a {@link neqsim.thermo.component.atractiveEosTerm.AtractiveTermInterface} object
+     * @return a {@link neqsim.thermo.component.attractiveEosTerm.AttractiveTermInterface} object
      */
-    public AtractiveTermInterface clone();
+    public AttractiveTermInterface clone();
 }

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermMatCop.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermMatCop.java
@@ -1,92 +1,83 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermCPAstatoil class.
+ * AttractiveTermMatCop class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermCPAstatoil extends AtractiveTermSrk {
+public class AttractiveTermMatCop extends AttractiveTermSrk {
     private static final long serialVersionUID = 1000;
 
     double orgpar = 0.0;
 
     /**
      * <p>
-     * Constructor for AtractiveTermCPAstatoil.
+     * Constructor for AttractiveTermMatCop.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermCPAstatoil(ComponentEosInterface component) {
+    public AttractiveTermMatCop(ComponentEosInterface component) {
         super(component);
         m = (0.48 + 1.574 * component.getAcentricFactor()
-                - 0.176 * component.getAcentricFactor() * component.getAcentricFactor());
-        if (component.getName().equals("waterG")) {
-            parameters[0] = 0.7892765953;
-            parameters[1] = -1.0606510837;
-            parameters[2] = 2.2071936510;
-        } else if (component.getName().equals("MEG2")) {
-            parameters[0] = 0.8581331725;
-            parameters[1] = -1.0053180150;
-            parameters[2] = 1.2736063639;
-        } else if (component.getName().equals("TEG2")) {
-            parameters[0] = 1.0008858863;
-            parameters[1] = 1.8649645470;
-            parameters[2] = -4.6720397496;
-        } else if (component.getName().equals("TEG")) {
-            parameters[0] = 0.903477158616734;
-            parameters[1] = 1.514853438;
-            parameters[2] = -1.86430399826;
-        } else {
+                - 0.175 * component.getAcentricFactor() * component.getAcentricFactor());
+    }
+
+    /**
+     * <p>
+     * Constructor for AttractiveTermMatCop.
+     * </p>
+     *
+     * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
+     * @param params an array of {@link double} objects
+     */
+    public AttractiveTermMatCop(ComponentEosInterface component, double[] params) {
+        this(component);
+        System.arraycopy(params, 0, this.parameters, 0, params.length);
+        orgpar = parameters[0];
+        if (Math.abs(parameters[0]) < 1e-12) {
             parameters[0] = m;
-            parameters[1] = 0;
-            parameters[2] = 0;
         }
     }
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermCPAstatoil clone() {
-        AtractiveTermCPAstatoil atractiveTerm = null;
+    public AttractiveTermMatCop clone() {
+        AttractiveTermMatCop attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermCPAstatoil) super.clone();
+            attractiveTerm = (AttractiveTermMatCop) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
-        // atractiveTerm.parameters = (double[]) parameters.clone();
-        // System.arraycopy(parameters,0, atractiveTerm.parameters, 0,
-        // parameters.length);
-        return atractiveTerm;
+
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */
     @Override
     public void init() {
         super.init();
-        if (!getComponent().getName().equals("TEG")) {
-            parameters[0] = m;
-        }
+        parameters[0] = m;
     }
 
     /** {@inheritDoc} */
     @Override
     public double alpha(double temperature) {
         double Tr = temperature / getComponent().getTC();
-        double temp1 = 1.0 - Math.sqrt(Tr);
-        double var = 1.0 + parameters[0] * temp1 + parameters[1] * temp1 * temp1
-                + parameters[2] * temp1 * temp1 * temp1;
-        return var * var;// Math.pow(1.0+parameters[0]*(1.0-Math.sqrt(Tr))+parameters[1]*temp1*temp1+parameters[2]*temp1*temp1*temp1,2.0);
+        return Math.pow(1.0 + parameters[0] * (1.0 - Math.sqrt(Tr))
+                + parameters[1] * Math.pow(1.0 - Math.sqrt(Tr), 2.0)
+                + parameters[2] * Math.pow(1.0 - Math.sqrt(Tr), 3.0), 2.0);
     }
 
     /** {@inheritDoc} */
     @Override
     public double aT(double temperature) {
-        if (temperature / getComponent().getTC() > 1.0) {
+        if (temperature / getComponent().getTC() > 10000.0) {
             return super.aT(temperature);
         } else {
             return getComponent().geta() * alpha(temperature);
@@ -135,7 +126,7 @@ public class AtractiveTermCPAstatoil extends AtractiveTermSrk {
     /** {@inheritDoc} */
     @Override
     public double diffaT(double temperature) {
-        if (temperature / getComponent().getTC() > 1.0) {
+        if (temperature / getComponent().getTC() > 10000.0) {
             return super.diffaT(temperature);
         } else {
             return getComponent().geta() * diffalphaT(temperature);
@@ -145,7 +136,7 @@ public class AtractiveTermCPAstatoil extends AtractiveTermSrk {
     /** {@inheritDoc} */
     @Override
     public double diffdiffaT(double temperature) {
-        if (temperature / getComponent().getTC() > 1.0) {
+        if (temperature / getComponent().getTC() > 10000.0) {
             return super.diffdiffaT(temperature);
         } else {
             return getComponent().geta() * diffdiffalphaT(temperature);

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermMatCopPR.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermMatCopPR.java
@@ -1,16 +1,16 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermMatCopPR class.
+ * AttractiveTermMatCopPR class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermMatCopPR extends AtractiveTermPr {
+public class AttractiveTermMatCopPR extends AttractiveTermPr {
     private static final long serialVersionUID = 1000;
 
     double orgpar = 0.0;
@@ -18,12 +18,12 @@ public class AtractiveTermMatCopPR extends AtractiveTermPr {
 
     /**
      * <p>
-     * Constructor for AtractiveTermMatCopPR.
+     * Constructor for AttractiveTermMatCopPR.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermMatCopPR(ComponentEosInterface component) {
+    public AttractiveTermMatCopPR(ComponentEosInterface component) {
         super(component);
         m = (0.37464 + 1.54226 * component.getAcentricFactor()
                 - 0.26992 * component.getAcentricFactor() * component.getAcentricFactor());
@@ -42,13 +42,13 @@ public class AtractiveTermMatCopPR extends AtractiveTermPr {
 
     /**
      * <p>
-     * Constructor for AtractiveTermMatCopPR.
+     * Constructor for AttractiveTermMatCopPR.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      * @param params an array of {@link double} objects
      */
-    public AtractiveTermMatCopPR(ComponentEosInterface component, double[] params) {
+    public AttractiveTermMatCopPR(ComponentEosInterface component, double[] params) {
         this(component);
         System.arraycopy(params, 0, this.parameters, 0, params.length);
         orgpar = parameters[0];
@@ -70,15 +70,15 @@ public class AtractiveTermMatCopPR extends AtractiveTermPr {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermMatCopPR clone() {
-        AtractiveTermMatCopPR atractiveTerm = null;
+    public AttractiveTermMatCopPR clone() {
+        AttractiveTermMatCopPR attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermMatCopPR) super.clone();
+            attractiveTerm = (AttractiveTermMatCopPR) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermMatCopPRUMR.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermMatCopPRUMR.java
@@ -1,28 +1,28 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermMatCopPRUMR class.
+ * AttractiveTermMatCopPRUMR class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermMatCopPRUMR extends AtractiveTermPr {
+public class AttractiveTermMatCopPRUMR extends AttractiveTermPr {
     private static final long serialVersionUID = 1000;
     double orgpar = 0.0;
     boolean useStandardAlphaForSupercritical = false;
 
     /**
      * <p>
-     * Constructor for AtractiveTermMatCopPRUMR.
+     * Constructor for AttractiveTermMatCopPRUMR.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermMatCopPRUMR(ComponentEosInterface component) {
+    public AttractiveTermMatCopPRUMR(ComponentEosInterface component) {
         super(component);
         m = (0.384401 + 1.52276 * component.getAcentricFactor()
                 - 0.213808 * component.getAcentricFactor() * component.getAcentricFactor()
@@ -43,13 +43,13 @@ public class AtractiveTermMatCopPRUMR extends AtractiveTermPr {
 
     /**
      * <p>
-     * Constructor for AtractiveTermMatCopPRUMR.
+     * Constructor for AttractiveTermMatCopPRUMR.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      * @param params an array of {@link double} objects
      */
-    public AtractiveTermMatCopPRUMR(ComponentEosInterface component, double[] params) {
+    public AttractiveTermMatCopPRUMR(ComponentEosInterface component, double[] params) {
         this(component);
         System.arraycopy(params, 0, this.parameters, 0, params.length);
         orgpar = parameters[0];
@@ -71,15 +71,15 @@ public class AtractiveTermMatCopPRUMR extends AtractiveTermPr {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermMatCopPRUMR clone() {
-        AtractiveTermMatCopPRUMR atractiveTerm = null;
+    public AttractiveTermMatCopPRUMR clone() {
+        AttractiveTermMatCopPRUMR attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermMatCopPRUMR) super.clone();
+            attractiveTerm = (AttractiveTermMatCopPRUMR) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermMollerup.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermMollerup.java
@@ -1,53 +1,53 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermMollerup class.
+ * AttractiveTermMollerup class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermMollerup extends AtractiveTermBaseClass {
+public class AttractiveTermMollerup extends AttractiveTermBaseClass {
     private static final long serialVersionUID = 1000;
 
     /**
      * <p>
-     * Constructor for AtractiveTermMollerup.
+     * Constructor for AttractiveTermMollerup.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermMollerup(ComponentEosInterface component) {
+    public AttractiveTermMollerup(ComponentEosInterface component) {
         super(component);
     }
 
     /**
      * <p>
-     * Constructor for AtractiveTermMollerup.
+     * Constructor for AttractiveTermMollerup.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      * @param params an array of {@link double} objects
      */
-    public AtractiveTermMollerup(ComponentEosInterface component, double[] params) {
+    public AttractiveTermMollerup(ComponentEosInterface component, double[] params) {
         this(component);
         System.arraycopy(params, 0, this.parameters, 0, params.length);
     }
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermMollerup clone() {
-        AtractiveTermMollerup atractiveTerm = null;
+    public AttractiveTermMollerup clone() {
+        AttractiveTermMollerup attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermMollerup) super.clone();
+            attractiveTerm = (AttractiveTermMollerup) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermPr.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermPr.java
@@ -1,26 +1,26 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermPr class.
+ * AttractiveTermPr class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermPr extends AtractiveTermBaseClass {
+public class AttractiveTermPr extends AttractiveTermBaseClass {
     private static final long serialVersionUID = 1000;
 
     /**
      * <p>
-     * Constructor for AtractiveTermPr.
+     * Constructor for AttractiveTermPr.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermPr(ComponentEosInterface component) {
+    public AttractiveTermPr(ComponentEosInterface component) {
         super(component);
         m = (0.37464 + 1.54226 * component.getAcentricFactor()
                 - 0.26992 * component.getAcentricFactor() * component.getAcentricFactor());
@@ -28,14 +28,14 @@ public class AtractiveTermPr extends AtractiveTermBaseClass {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermPr clone() {
-        AtractiveTermPr atractiveTerm = null;
+    public AttractiveTermPr clone() {
+        AttractiveTermPr attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermPr) super.clone();
+            attractiveTerm = (AttractiveTermPr) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermPr1978.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermPr1978.java
@@ -1,26 +1,26 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermPr1978 class.
+ * AttractiveTermPr1978 class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermPr1978 extends AtractiveTermPr {
+public class AttractiveTermPr1978 extends AttractiveTermPr {
     private static final long serialVersionUID = 1000;
 
     /**
      * <p>
-     * Constructor for AtractiveTermPr1978.
+     * Constructor for AttractiveTermPr1978.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermPr1978(ComponentEosInterface component) {
+    public AttractiveTermPr1978(ComponentEosInterface component) {
         super(component);
         if (component.getAcentricFactor() > 0.49) {
             m = (0.379642 + 1.48503 * component.getAcentricFactor()
@@ -34,15 +34,15 @@ public class AtractiveTermPr1978 extends AtractiveTermPr {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermPr1978 clone() {
-        AtractiveTermPr1978 atractiveTerm = null;
+    public AttractiveTermPr1978 clone() {
+        AttractiveTermPr1978 attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermPr1978) super.clone();
+            attractiveTerm = (AttractiveTermPr1978) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermPrDanesh.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermPrDanesh.java
@@ -1,42 +1,42 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermPrDanesh class.
+ * AttractiveTermPrDanesh class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermPrDanesh extends AtractiveTermPr1978 {
+public class AttractiveTermPrDanesh extends AttractiveTermPr1978 {
     private static final long serialVersionUID = 1000;
 
     double mMod = 0;
 
     /**
      * <p>
-     * Constructor for AtractiveTermPrDanesh.
+     * Constructor for AttractiveTermPrDanesh.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermPrDanesh(ComponentEosInterface component) {
+    public AttractiveTermPrDanesh(ComponentEosInterface component) {
         super(component);
     }
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermPrDanesh clone() {
-        AtractiveTermPrDanesh atractiveTerm = null;
+    public AttractiveTermPrDanesh clone() {
+        AttractiveTermPrDanesh attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermPrDanesh) super.clone();
+            attractiveTerm = (AttractiveTermPrDanesh) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermPrDelft1998.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermPrDelft1998.java
@@ -1,28 +1,28 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermPrDelft1998 class.
+ * AttractiveTermPrDelft1998 class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermPrDelft1998 extends AtractiveTermPr1978 {
+public class AttractiveTermPrDelft1998 extends AttractiveTermPr1978 {
     private static final long serialVersionUID = 1000;
 
     boolean isMethane = false;
 
     /**
      * <p>
-     * Constructor for AtractiveTermPrDelft1998.
+     * Constructor for AttractiveTermPrDelft1998.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermPrDelft1998(ComponentEosInterface component) {
+    public AttractiveTermPrDelft1998(ComponentEosInterface component) {
         super(component);
         if (component.getName().equals("methane")) {
             isMethane = true;
@@ -31,15 +31,15 @@ public class AtractiveTermPrDelft1998 extends AtractiveTermPr1978 {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermPrDelft1998 clone() {
-        AtractiveTermPrDelft1998 atractiveTerm = null;
+    public AttractiveTermPrDelft1998 clone() {
+        AttractiveTermPrDelft1998 attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermPrDelft1998) super.clone();
+            attractiveTerm = (AttractiveTermPrDelft1998) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermPrGassem2001.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermPrGassem2001.java
@@ -1,42 +1,42 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermPrGassem2001 class.
+ * AttractiveTermPrGassem2001 class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermPrGassem2001 extends AtractiveTermPr {
+public class AttractiveTermPrGassem2001 extends AttractiveTermPr {
     private static final long serialVersionUID = 1000;
 
     protected double A = 2.0, B = 0.836, C = 0.134, D = 0.508, E = -0.0467;
 
     /**
      * <p>
-     * Constructor for AtractiveTermPrGassem2001.
+     * Constructor for AttractiveTermPrGassem2001.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermPrGassem2001(ComponentEosInterface component) {
+    public AttractiveTermPrGassem2001(ComponentEosInterface component) {
         super(component);
     }
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermPrGassem2001 clone() {
-        AtractiveTermPrGassem2001 atractiveTerm = null;
+    public AttractiveTermPrGassem2001 clone() {
+        AttractiveTermPrGassem2001 attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermPrGassem2001) super.clone();
+            attractiveTerm = (AttractiveTermPrGassem2001) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermRk.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermRk.java
@@ -1,40 +1,40 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermRk class.
+ * AttractiveTermRk class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermRk extends AtractiveTermBaseClass {
+public class AttractiveTermRk extends AttractiveTermBaseClass {
     private static final long serialVersionUID = 1000;
 
     /**
      * <p>
-     * Constructor for AtractiveTermRk.
+     * Constructor for AttractiveTermRk.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermRk(ComponentEosInterface component) {
+    public AttractiveTermRk(ComponentEosInterface component) {
         super(component);
     }
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermRk clone() {
-        AtractiveTermRk atractiveTerm = null;
+    public AttractiveTermRk clone() {
+        AttractiveTermRk attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermRk) super.clone();
+            attractiveTerm = (AttractiveTermRk) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermSchwartzentruber.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermSchwartzentruber.java
@@ -1,28 +1,28 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermSchwartzentruber class.
+ * AttractiveTermSchwartzentruber class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermSchwartzentruber extends AtractiveTermBaseClass {
+public class AttractiveTermSchwartzentruber extends AttractiveTermBaseClass {
     private static final long serialVersionUID = 1000;
 
     private double c = 0.0, d = 0.0;
 
     /**
      * <p>
-     * Constructor for AtractiveTermSchwartzentruber.
+     * Constructor for AttractiveTermSchwartzentruber.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermSchwartzentruber(ComponentEosInterface component) {
+    public AttractiveTermSchwartzentruber(ComponentEosInterface component) {
         super(component);
         m = (0.48508 + 1.55191 * component.getAcentricFactor()
                 - 0.15613 * component.getAcentricFactor() * component.getAcentricFactor());
@@ -30,13 +30,13 @@ public class AtractiveTermSchwartzentruber extends AtractiveTermBaseClass {
 
     /**
      * <p>
-     * Constructor for AtractiveTermSchwartzentruber.
+     * Constructor for AttractiveTermSchwartzentruber.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      * @param params an array of {@link double} objects
      */
-    public AtractiveTermSchwartzentruber(ComponentEosInterface component, double[] params) {
+    public AttractiveTermSchwartzentruber(ComponentEosInterface component, double[] params) {
         this(component);
         System.arraycopy(params, 0, this.parameters, 0, params.length);
         d = 1.0 + m / 2.0 - parameters[0] * (1.0 + parameters[1] + parameters[2]);
@@ -45,15 +45,15 @@ public class AtractiveTermSchwartzentruber extends AtractiveTermBaseClass {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermSchwartzentruber clone() {
-        AtractiveTermSchwartzentruber atractiveTerm = null;
+    public AttractiveTermSchwartzentruber clone() {
+        AttractiveTermSchwartzentruber attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermSchwartzentruber) super.clone();
+            attractiveTerm = (AttractiveTermSchwartzentruber) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermSrk.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermSrk.java
@@ -1,33 +1,33 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermSrk class.
+ * AttractiveTermSrk class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermSrk extends AtractiveTermBaseClass {
+public class AttractiveTermSrk extends AttractiveTermBaseClass {
     private static final long serialVersionUID = 1000;
 
     /**
      * <p>
-     * Constructor for AtractiveTermSrk.
+     * Constructor for AttractiveTermSrk.
      * </p>
      */
-    public AtractiveTermSrk() {}
+    public AttractiveTermSrk() {}
 
     /**
      * <p>
-     * Constructor for AtractiveTermSrk.
+     * Constructor for AttractiveTermSrk.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermSrk(ComponentEosInterface component) {
+    public AttractiveTermSrk(ComponentEosInterface component) {
         super(component);
         m = (0.48 + 1.574 * component.getAcentricFactor()
                 - 0.176 * component.getAcentricFactor() * component.getAcentricFactor());
@@ -35,14 +35,14 @@ public class AtractiveTermSrk extends AtractiveTermBaseClass {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermSrk clone() {
-        AtractiveTermSrk atractiveTerm = null;
+    public AttractiveTermSrk clone() {
+        AttractiveTermSrk attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermSrk) super.clone();
+            attractiveTerm = (AttractiveTermSrk) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermTwu.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermTwu.java
@@ -1,40 +1,40 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermTwu class.
+ * AttractiveTermTwu class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermTwu extends AtractiveTermSrk {
+public class AttractiveTermTwu extends AttractiveTermSrk {
     private static final long serialVersionUID = 1000;
 
     /**
      * <p>
-     * Constructor for AtractiveTermTwu.
+     * Constructor for AttractiveTermTwu.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermTwu(ComponentEosInterface component) {
+    public AttractiveTermTwu(ComponentEosInterface component) {
         super(component);
     }
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermTwu clone() {
-        AtractiveTermTwu atractiveTerm = null;
+    public AttractiveTermTwu clone() {
+        AttractiveTermTwu attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermTwu) super.clone();
+            attractiveTerm = (AttractiveTermTwu) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermTwuCoon.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermTwuCoon.java
@@ -1,16 +1,16 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermTwuCoon class.
+ * AttractiveTermTwuCoon class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermTwuCoon extends AtractiveTermBaseClass {
+public class AttractiveTermTwuCoon extends AttractiveTermBaseClass {
     private static final long serialVersionUID = 1000;
 
     private double a = -0.201158, b = 0.141599, c = 2.29528, d = -0.660145, e = 0.500315,
@@ -18,17 +18,17 @@ public class AtractiveTermTwuCoon extends AtractiveTermBaseClass {
 
     /**
      * <p>
-     * Constructor for AtractiveTermTwuCoon.
+     * Constructor for AttractiveTermTwuCoon.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermTwuCoon(ComponentEosInterface component) {
+    public AttractiveTermTwuCoon(ComponentEosInterface component) {
         super(component);
         m = component.getAcentricFactor();
     }
 
-    // public AtractiveTermTwuCoon(ComponentEosInterface component, double[] params) {
+    // public AttractiveTermTwuCoon(ComponentEosInterface component, double[] params) {
     // this(component);
     // System.arraycopy(params,0,this.parameters,0,params.length);
     // // c = 1+m/2.0-parameters[0]*(1.0+parameters[1]+parameters[2]);
@@ -36,15 +36,15 @@ public class AtractiveTermTwuCoon extends AtractiveTermBaseClass {
     // }
 
     @Override
-    public AtractiveTermTwuCoon clone() {
-        AtractiveTermTwuCoon atractiveTerm = null;
+    public AttractiveTermTwuCoon clone() {
+        AttractiveTermTwuCoon attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermTwuCoon) super.clone();
+            attractiveTerm = (AttractiveTermTwuCoon) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermTwuCoonParam.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermTwuCoonParam.java
@@ -1,28 +1,28 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AttractiveTermTwuCoonStatoil class.
+ * AttractiveTermTwuCoonParam class.
  * </p>
  *
- * @author asmund
+ * @author esol
  * @version $Id: $Id
  */
-public class AttractiveTermTwuCoonStatoil extends AtractiveTermBaseClass {
+public class AttractiveTermTwuCoonParam extends AttractiveTermBaseClass {
     private static final long serialVersionUID = 1000;
 
     private double a = 0.0, b = 0.0, c = 0.0;
 
     /**
      * <p>
-     * Constructor for AttractiveTermTwuCoonStatoil.
+     * Constructor for AttractiveTermTwuCoonParam.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AttractiveTermTwuCoonStatoil(ComponentEosInterface component) {
+    public AttractiveTermTwuCoonParam(ComponentEosInterface component) {
         super(component);
         a = this.parameters[0];
         b = this.parameters[1];
@@ -31,13 +31,13 @@ public class AttractiveTermTwuCoonStatoil extends AtractiveTermBaseClass {
 
     /**
      * <p>
-     * Constructor for AttractiveTermTwuCoonStatoil.
+     * Constructor for AttractiveTermTwuCoonParam.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      * @param params an array of {@link double} objects
      */
-    public AttractiveTermTwuCoonStatoil(ComponentEosInterface component, double[] params) {
+    public AttractiveTermTwuCoonParam(ComponentEosInterface component, double[] params) {
         this(component);
         // this.parameters [0] for aa benytte gitte input parametre
         System.arraycopy(params, 0, this.parameters, 0, params.length);
@@ -45,15 +45,15 @@ public class AttractiveTermTwuCoonStatoil extends AtractiveTermBaseClass {
 
     /** {@inheritDoc} */
     @Override
-    public AttractiveTermTwuCoonStatoil clone() {
-        AttractiveTermTwuCoonStatoil atractiveTerm = null;
+    public AttractiveTermTwuCoonParam clone() {
+        AttractiveTermTwuCoonParam attractiveTerm = null;
         try {
-            atractiveTerm = (AttractiveTermTwuCoonStatoil) super.clone();
+            attractiveTerm = (AttractiveTermTwuCoonParam) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermTwuCoonStatoil.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermTwuCoonStatoil.java
@@ -1,28 +1,28 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermTwuCoonParam class.
+ * AttractiveTermTwuCoonStatoil class.
  * </p>
  *
- * @author esol
+ * @author asmund
  * @version $Id: $Id
  */
-public class AtractiveTermTwuCoonParam extends AtractiveTermBaseClass {
+public class AttractiveTermTwuCoonStatoil extends AttractiveTermBaseClass {
     private static final long serialVersionUID = 1000;
 
     private double a = 0.0, b = 0.0, c = 0.0;
 
     /**
      * <p>
-     * Constructor for AtractiveTermTwuCoonParam.
+     * Constructor for AttractiveTermTwuCoonStatoil.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermTwuCoonParam(ComponentEosInterface component) {
+    public AttractiveTermTwuCoonStatoil(ComponentEosInterface component) {
         super(component);
         a = this.parameters[0];
         b = this.parameters[1];
@@ -31,13 +31,13 @@ public class AtractiveTermTwuCoonParam extends AtractiveTermBaseClass {
 
     /**
      * <p>
-     * Constructor for AtractiveTermTwuCoonParam.
+     * Constructor for AttractiveTermTwuCoonStatoil.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      * @param params an array of {@link double} objects
      */
-    public AtractiveTermTwuCoonParam(ComponentEosInterface component, double[] params) {
+    public AttractiveTermTwuCoonStatoil(ComponentEosInterface component, double[] params) {
         this(component);
         // this.parameters [0] for aa benytte gitte input parametre
         System.arraycopy(params, 0, this.parameters, 0, params.length);
@@ -45,15 +45,15 @@ public class AtractiveTermTwuCoonParam extends AtractiveTermBaseClass {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermTwuCoonParam clone() {
-        AtractiveTermTwuCoonParam atractiveTerm = null;
+    public AttractiveTermTwuCoonStatoil clone() {
+        AttractiveTermTwuCoonStatoil attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermTwuCoonParam) super.clone();
+            attractiveTerm = (AttractiveTermTwuCoonStatoil) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermUMRPRU.java
+++ b/src/main/java/neqsim/thermo/component/attractiveEosTerm/AttractiveTermUMRPRU.java
@@ -1,26 +1,26 @@
-package neqsim.thermo.component.atractiveEosTerm;
+package neqsim.thermo.component.attractiveEosTerm;
 
 import neqsim.thermo.component.ComponentEosInterface;
 
 /**
  * <p>
- * AtractiveTermUMRPRU class.
+ * AttractiveTermUMRPRU class.
  * </p>
  *
  * @author esol
  * @version $Id: $Id
  */
-public class AtractiveTermUMRPRU extends AtractiveTermPr {
+public class AttractiveTermUMRPRU extends AttractiveTermPr {
     private static final long serialVersionUID = 1000;
 
     /**
      * <p>
-     * Constructor for AtractiveTermUMRPRU.
+     * Constructor for AttractiveTermUMRPRU.
      * </p>
      *
      * @param component a {@link neqsim.thermo.component.ComponentEosInterface} object
      */
-    public AtractiveTermUMRPRU(ComponentEosInterface component) {
+    public AttractiveTermUMRPRU(ComponentEosInterface component) {
         super(component);
         m = (0.384401 + 1.52276 * component.getAcentricFactor()
                 - 0.213808 * component.getAcentricFactor() * component.getAcentricFactor()
@@ -30,15 +30,15 @@ public class AtractiveTermUMRPRU extends AtractiveTermPr {
 
     /** {@inheritDoc} */
     @Override
-    public AtractiveTermUMRPRU clone() {
-        AtractiveTermUMRPRU atractiveTerm = null;
+    public AttractiveTermUMRPRU clone() {
+        AttractiveTermUMRPRU attractiveTerm = null;
         try {
-            atractiveTerm = (AtractiveTermUMRPRU) super.clone();
+            attractiveTerm = (AttractiveTermUMRPRU) super.clone();
         } catch (Exception e) {
             logger.error("Cloning failed.", e);
         }
 
-        return atractiveTerm;
+        return attractiveTerm;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/phase/Phase.java
+++ b/src/main/java/neqsim/thermo/phase/Phase.java
@@ -566,9 +566,9 @@ abstract class Phase implements PhaseInterface {
 
     /** {@inheritDoc} */
     @Override
-    public void setAtractiveTerm(int i) {
+    public void setAttractiveTerm(int i) {
         for (int k = 0; k < numberOfComponents; k++) {
-            componentArray[k].setAtractiveTerm(i);
+            componentArray[k].setAttractiveTerm(i);
         }
     }
 
@@ -1325,7 +1325,7 @@ abstract class Phase implements PhaseInterface {
                 } else {
                     refPhase[i].addcomponent(getComponent(i).getComponentName(), 10.0, 10.0, 0);
                 }
-                refPhase[i].setAtractiveTerm(this.getComponent(i).getAtractiveTermNumber());
+                refPhase[i].setAttractiveTerm(this.getComponent(i).getAttractiveTermNumber());
                 refPhase[i].setMixingRule(this.getMixingRuleNumber());
                 refPhase[i].setPhaseType(this.getPhaseType());
                 refPhase[i].init(refPhase[i].getNumberOfMolesInPhase(), 1, 0, this.getPhaseType(),
@@ -1346,7 +1346,7 @@ abstract class Phase implements PhaseInterface {
                             0);
                 }
                 refPhase[i].addcomponent(name, 10.0, 10.0, 1);
-                refPhase[i].setAtractiveTerm(this.getComponent(i).getAtractiveTermNumber());
+                refPhase[i].setAttractiveTerm(this.getComponent(i).getAttractiveTermNumber());
                 refPhase[i].setMixingRule(this.getMixingRuleNumber());
                 refPhase[i].init(refPhase[i].getNumberOfMolesInPhase(), 2, 0, this.getPhaseType(),
                         1.0);

--- a/src/main/java/neqsim/thermo/phase/PhaseEos.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseEos.java
@@ -383,7 +383,7 @@ abstract class PhaseEos extends Phase implements PhaseEosInterface {
 
     /** {@inheritDoc} */
     @Override
-    public double getPressureAtractive() {
+    public double getPressureAttractive() {
         double presrep = R * temperature / (getMolarVolume() - getb());
         double presatr = pressure - presrep;
         // presatr = getaT()/((molarVolume+delta1)*(molarVolume+delta2));

--- a/src/main/java/neqsim/thermo/phase/PhaseEosInterface.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseEosInterface.java
@@ -67,12 +67,12 @@ public interface PhaseEosInterface extends PhaseInterface {
 
     /**
      * <p>
-     * getPressureAtractive.
+     * getPressureAttractive.
      * </p>
      *
      * @return a double
      */
-    public double getPressureAtractive();
+    public double getPressureAttractive();
 
     /**
      * <p>

--- a/src/main/java/neqsim/thermo/phase/PhaseEosInterface_1.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseEosInterface_1.java
@@ -53,12 +53,12 @@ public interface PhaseEosInterface_1 extends PhaseInterface {
 
     /**
      * <p>
-     * getPressureAtractive.
+     * getPressureAttractive.
      * </p>
      *
      * @return a double
      */
-    public double getPressureAtractive();
+    public double getPressureAttractive();
     // public double getA();
     // public double getB();
     // double calcA(ComponentEosInterface[] compArray, double temperature, double

--- a/src/main/java/neqsim/thermo/phase/PhaseGEUnifacUMRPRU.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseGEUnifacUMRPRU.java
@@ -51,7 +51,7 @@ public class PhaseGEUnifacUMRPRU extends PhaseGEUnifac {
                     phase.getComponents()[i].getNumberOfmoles(),
                     phase.getComponents()[i].getNumberOfMolesInPhase(),
                     phase.getComponents()[i].getComponentNumber());
-            componentArray[i].setAtractiveTerm(phase.getComponents()[i].getAtractiveTermNumber());
+            componentArray[i].setAttractiveTerm(phase.getComponents()[i].getAttractiveTermNumber());
         }
         this.setMixingRule(2);
     }
@@ -180,7 +180,7 @@ public class PhaseGEUnifacUMRPRU extends PhaseGEUnifac {
 
         for (int i = 0; i < ((ComponentGEUnifac) getComponent(0)).getNumberOfUNIFACgroups(); i++) {
             try {
-                if (getPhase().getComponent(0).getAtractiveTermNumber() == 13) {
+                if (getPhase().getComponent(0).getAttractiveTermNumber() == 13) {
                     dataSet = database
                             .getResultSet(("SELECT * FROM unifacinterparama_umrmc WHERE MainGroup="
                                     + ((ComponentGEUnifac) getComponent(0)).getUnifacGroup(i)
@@ -243,7 +243,7 @@ public class PhaseGEUnifacUMRPRU extends PhaseGEUnifac {
 
         for (int i = 0; i < ((ComponentGEUnifac) getComponent(0)).getNumberOfUNIFACgroups(); i++) {
             try {
-                if (getPhase().getComponent(0).getAtractiveTermNumber() == 13) {
+                if (getPhase().getComponent(0).getAttractiveTermNumber() == 13) {
                     dataSet = database
                             .getResultSet(("SELECT * FROM unifacinterparamb_umrmc WHERE MainGroup="
                                     + ((ComponentGEUnifac) getComponent(0)).getUnifacGroup(i)
@@ -306,7 +306,7 @@ public class PhaseGEUnifacUMRPRU extends PhaseGEUnifac {
 
         for (int i = 0; i < ((ComponentGEUnifac) getComponent(0)).getNumberOfUNIFACgroups(); i++) {
             try {
-                if (getPhase().getComponent(0).getAtractiveTermNumber() == 13) {
+                if (getPhase().getComponent(0).getAttractiveTermNumber() == 13) {
                     dataSet = database
                             .getResultSet(("SELECT * FROM unifacinterparamc_umrmc WHERE MainGroup="
                                     + ((ComponentGEUnifac) getComponent(0)).getUnifacGroup(i)

--- a/src/main/java/neqsim/thermo/phase/PhaseInterface.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseInterface.java
@@ -638,12 +638,12 @@ public interface PhaseInterface extends ThermodynamicConstantsInterface, Cloneab
 
     /**
      * <p>
-     * setAtractiveTerm.
+     * setAttractiveTerm.
      * </p>
      *
      * @param i a int
      */
-    public void setAtractiveTerm(int i);
+    public void setAttractiveTerm(int i);
 
     /**
      * <p>

--- a/src/main/java/neqsim/thermo/system/SystemInterface.java
+++ b/src/main/java/neqsim/thermo/system/SystemInterface.java
@@ -1474,12 +1474,12 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
 
     /**
      * <p>
-     * setAtractiveTerm.
+     * setAttractiveTerm.
      * </p>
      *
      * @param i a int
      */
-    public void setAtractiveTerm(int i);
+    public void setAttractiveTerm(int i);
 
     /**
      * <p>

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -843,7 +843,7 @@ abstract class SystemThermo implements SystemInterface {
                 refSystem.getPhase(i).getComponent(0).setComponentType("TBPfraction");
                 refSystem.getPhase(i).getComponent(0).setIsTBPfraction(true);
                 if (characterization.getTBPModel().isCalcm()) {
-                    refSystem.getPhase(i).getComponent(0).getAtractiveTerm().setm(m);
+                    refSystem.getPhase(i).getComponent(0).getAttractiveTerm().setm(m);
                     acs = refSystem.getPhase(i).getComponent(0).getAcentricFactor();
                 }
             }
@@ -895,7 +895,7 @@ abstract class SystemThermo implements SystemInterface {
         double cpd = 0.0;
 
         for (int i = 0; i < numberOfPhases; i++) {
-            getPhase(i).setAtractiveTerm(attractiveTermNumber);
+            getPhase(i).setAttractiveTerm(attractiveTermNumber);
             getPhase(i).getComponent(componentName).setMolarMass(molarMass);
             getPhase(i).getComponent(componentName).setComponentType("TBPfraction");
             getPhase(i).getComponent(componentName).setNormalLiquidDensity(density);
@@ -981,7 +981,7 @@ abstract class SystemThermo implements SystemInterface {
                 refSystem.getPhase(i).getComponent(0).setComponentType("TBPfraction");
                 refSystem.getPhase(i).getComponent(0).setIsTBPfraction(true);
                 if (characterization.getTBPModel().isCalcm()) {
-                    refSystem.getPhase(i).getComponent(0).getAtractiveTerm().setm(m);
+                    refSystem.getPhase(i).getComponent(0).getAttractiveTerm().setm(m);
                     acs = refSystem.getPhase(i).getComponent(0).getAcentricFactor();
                 }
             }
@@ -1033,7 +1033,7 @@ abstract class SystemThermo implements SystemInterface {
         double cpd = 0.0;
 
         for (int i = 0; i < numberOfPhases; i++) {
-            getPhase(i).setAtractiveTerm(attractiveTermNumber);
+            getPhase(i).setAttractiveTerm(attractiveTermNumber);
             getPhase(i).getComponent(componentName).setMolarMass(molarMass);
             getPhase(i).getComponent(componentName).setComponentType("TBPfraction");
             getPhase(i).getComponent(componentName).setNormalLiquidDensity(density);
@@ -1199,7 +1199,7 @@ abstract class SystemThermo implements SystemInterface {
             componentNames.add(componentName);
             for (int i = 0; i < getMaxNumberOfPhases(); i++) {
                 getPhase(i).addcomponent(componentName, moles, moles, numberOfComponents);
-                getPhase(i).setAtractiveTerm(attractiveTermNumber);
+                getPhase(i).setAttractiveTerm(attractiveTermNumber);
             }
             numberOfComponents++;
         } else {
@@ -1255,7 +1255,7 @@ abstract class SystemThermo implements SystemInterface {
                     k = 1.0e-30;
                 }
                 getPhase(i).addcomponent(componentName, moles, moles * k, numberOfComponents);
-                getPhase(i).setAtractiveTerm(attractiveTermNumber);
+                getPhase(i).setAttractiveTerm(attractiveTermNumber);
             }
             numberOfComponents++;
         } else {
@@ -3026,9 +3026,9 @@ abstract class SystemThermo implements SystemInterface {
 
     /** {@inheritDoc} */
     @Override
-    public void setAtractiveTerm(int i) {
+    public void setAttractiveTerm(int i) {
         for (int k = 0; k < getMaxNumberOfPhases(); k++) {
-            phaseArray[k].setAtractiveTerm(i);
+            phaseArray[k].setAttractiveTerm(i);
         }
     }
 

--- a/src/main/java/neqsim/thermo/util/parameterFitting/binaryInteractionParameterFitting/EosInteractionParameterFitting/CPAParameterFittingToDewPointData.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/binaryInteractionParameterFitting/EosInteractionParameterFitting/CPAParameterFittingToDewPointData.java
@@ -58,8 +58,8 @@ public class CPAParameterFittingToDewPointData extends LevenbergMarquardtFunctio
             system.getPhases()[1].getComponents()[1].setb(value);
         }
         if (i == 3) {
-            system.getPhase(0).getComponent(1).getAtractiveTerm().setm(value);
-            system.getPhases()[1].getComponents()[1].getAtractiveTerm().setm(value);
+            system.getPhase(0).getComponent(1).getAttractiveTerm().setm(value);
+            system.getPhases()[1].getComponents()[1].getAttractiveTerm().setm(value);
         }
         if (i == 5) {
             system.getPhase(0).getComponent(1).setAssociationEnergy(value);

--- a/src/main/java/neqsim/thermo/util/parameterFitting/binaryInteractionParameterFitting/EosInteractionParameterFitting/CPAParameterFittingToSolubilityData.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/binaryInteractionParameterFitting/EosInteractionParameterFitting/CPAParameterFittingToSolubilityData.java
@@ -123,8 +123,8 @@ public class CPAParameterFittingToSolubilityData extends LevenbergMarquardtFunct
             system.getPhases()[1].getComponents()[1].setb(value);
         }
         if (i == 3) {
-            system.getPhase(0).getComponent(1).getAtractiveTerm().setm(value);
-            system.getPhases()[1].getComponents()[1].getAtractiveTerm().setm(value);
+            system.getPhase(0).getComponent(1).getAttractiveTerm().setm(value);
+            system.getPhases()[1].getComponents()[1].getAttractiveTerm().setm(value);
         }
         if (i == 5) {
             system.getPhase(0).getComponent(1).setAssociationEnergy(value);

--- a/src/main/java/neqsim/thermo/util/parameterFitting/binaryInteractionParameterFitting/EosInteractionParameterFitting/CPAParameterFittingToSolubilityData_Vap.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/binaryInteractionParameterFitting/EosInteractionParameterFitting/CPAParameterFittingToSolubilityData_Vap.java
@@ -50,8 +50,8 @@ public class CPAParameterFittingToSolubilityData_Vap extends LevenbergMarquardtF
             system.getPhases()[1].getComponents()[1].setb(value);
         }
         if (i == 3) {
-            system.getPhase(0).getComponent(1).getAtractiveTerm().setm(value);
-            system.getPhases()[1].getComponents()[1].getAtractiveTerm().setm(value);
+            system.getPhase(0).getComponent(1).getAttractiveTerm().setm(value);
+            system.getPhases()[1].getComponents()[1].getAttractiveTerm().setm(value);
         }
         if (i == 5) {
             system.getPhase(0).getComponent(1).setAssociationEnergy(value);

--- a/src/main/java/neqsim/thermo/util/parameterFitting/binaryInteractionParameterFitting/EosInteractionParameterFitting/TestEosParameterFittingToMercurySolubility.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/binaryInteractionParameterFitting/EosInteractionParameterFitting/TestEosParameterFittingToMercurySolubility.java
@@ -56,8 +56,8 @@ public class TestEosParameterFittingToMercurySolubility {
                 SystemInterface testSystem = new SystemSrkEos(290, 1.0);
                 testSystem.addComponent("mercury", 10.0);
                 testSystem.addComponent("n-hexane", 10.0);
-                testSystem.getPhase(0).getComponent("mercury").setAtractiveTerm(12);
-                testSystem.getPhase(1).getComponent("mercury").setAtractiveTerm(12);
+                testSystem.getPhase(0).getComponent("mercury").setAttractiveTerm(12);
+                testSystem.getPhase(1).getComponent("mercury").setAttractiveTerm(12);
                 testSystem.createDatabase(true);
                 testSystem.setMultiPhaseCheck(true);
                 testSystem.setTemperature(Double.parseDouble(dataSet.getString("Temperature")));

--- a/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/AntoineParameter/AntoineSolidFunction.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/AntoineParameter/AntoineSolidFunction.java
@@ -13,7 +13,6 @@ import neqsim.statistics.parameterFitting.nonLinearParameterFitting.LevenbergMar
  * @version $Id: $Id
  */
 public class AntoineSolidFunction extends LevenbergMarquardtFunction {
-    private static final long serialVersionUID = 1000;
     static Logger logger = LogManager.getLogger(AntoineSolidFunction.class);
 
     /**

--- a/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/acentricFactorFitting/AcentricFunctionScwartzentruber.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/acentricFactorFitting/AcentricFunctionScwartzentruber.java
@@ -55,7 +55,7 @@ public class AcentricFunctionScwartzentruber extends LevenbergMarquardtFunction 
         params[i] = value;
         system.getPhases()[0].getComponents()[0].setSchwartzentruberParams(i, value);
         system.getPhases()[1].getComponents()[0].setSchwartzentruberParams(i, value);
-        system.getPhases()[0].getComponents()[0].getAtractiveTerm().setParameters(i, value);
-        system.getPhases()[1].getComponents()[0].getAtractiveTerm().setParameters(i, value);
+        system.getPhases()[0].getComponents()[0].getAttractiveTerm().setParameters(i, value);
+        system.getPhases()[1].getComponents()[0].getAttractiveTerm().setParameters(i, value);
     }
 }

--- a/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/acentricFactorFitting/MathiasCopeman.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/acentricFactorFitting/MathiasCopeman.java
@@ -54,7 +54,7 @@ public class MathiasCopeman extends LevenbergMarquardtFunction {
         params[i] = value;
         system.getPhases()[0].getComponents()[0].setMatiascopemanParams(i, value);
         system.getPhases()[1].getComponents()[0].setMatiascopemanParams(i, value);
-        system.getPhases()[0].getComponents()[0].getAtractiveTerm().setParameters(i, value);
-        system.getPhases()[1].getComponents()[0].getAtractiveTerm().setParameters(i, value);
+        system.getPhases()[0].getComponents()[0].getAttractiveTerm().setParameters(i, value);
+        system.getPhases()[1].getComponents()[0].getAttractiveTerm().setParameters(i, value);
     }
 }

--- a/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/acentricFactorFitting/MathiasCopemanToDewPoint.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/acentricFactorFitting/MathiasCopemanToDewPoint.java
@@ -79,17 +79,17 @@ public class MathiasCopemanToDewPoint extends LevenbergMarquardtFunction {
             }
 
             system.getPhases()[1].getComponent(0).setMatiascopemanParams(i, value);
-            system.getPhases()[0].getComponent(0).getAtractiveTerm().setParameters(i, value);
-            system.getPhases()[1].getComponent(0).getAtractiveTerm().setParameters(i, value);
+            system.getPhases()[0].getComponent(0).getAttractiveTerm().setParameters(i, value);
+            system.getPhases()[1].getComponent(0).getAttractiveTerm().setParameters(i, value);
             return;
         }
 
         if (system.getPhase(0).hasComponent("methane") && i < 3) {
             system.getPhases()[0].getComponent("methane").setMatiascopemanParams(i, value);
             system.getPhases()[1].getComponent("methane").setMatiascopemanParams(i, value);
-            system.getPhases()[0].getComponent("methane").getAtractiveTerm().setParameters(i,
+            system.getPhases()[0].getComponent("methane").getAttractiveTerm().setParameters(i,
                     value);
-            system.getPhases()[1].getComponent("methane").getAtractiveTerm().setParameters(i,
+            system.getPhases()[1].getComponent("methane").getAttractiveTerm().setParameters(i,
                     value);
             return;
         }
@@ -97,9 +97,9 @@ public class MathiasCopemanToDewPoint extends LevenbergMarquardtFunction {
         if (system.getPhase(0).hasComponent("ethane") && i < 6) {
             system.getPhases()[0].getComponent("ethane").setMatiascopemanParams(i - 3, value);
             system.getPhases()[1].getComponent("ethane").setMatiascopemanParams(i - 3, value);
-            system.getPhases()[0].getComponent("ethane").getAtractiveTerm().setParameters(i - 3,
+            system.getPhases()[0].getComponent("ethane").getAttractiveTerm().setParameters(i - 3,
                     value);
-            system.getPhases()[1].getComponent("ethane").getAtractiveTerm().setParameters(i - 3,
+            system.getPhases()[1].getComponent("ethane").getAttractiveTerm().setParameters(i - 3,
                     value);
             return;
         }
@@ -107,9 +107,9 @@ public class MathiasCopemanToDewPoint extends LevenbergMarquardtFunction {
         if (system.getPhase(0).hasComponent("propane") && i < 9) {
             system.getPhases()[0].getComponent("propane").setMatiascopemanParams(i - 6, value);
             system.getPhases()[1].getComponent("propane").setMatiascopemanParams(i - 6, value);
-            system.getPhases()[0].getComponent("propane").getAtractiveTerm().setParameters(i - 6,
+            system.getPhases()[0].getComponent("propane").getAttractiveTerm().setParameters(i - 6,
                     value);
-            system.getPhases()[1].getComponent("propane").getAtractiveTerm().setParameters(i - 6,
+            system.getPhases()[1].getComponent("propane").getAttractiveTerm().setParameters(i - 6,
                     value);
             return;
         }
@@ -117,9 +117,9 @@ public class MathiasCopemanToDewPoint extends LevenbergMarquardtFunction {
         if (system.getPhase(0).hasComponent("n-butane") && i < 12) {
             system.getPhases()[0].getComponent("n-butane").setMatiascopemanParams(i - 9, value);
             system.getPhases()[1].getComponent("n-butane").setMatiascopemanParams(i - 9, value);
-            system.getPhases()[0].getComponent("n-butane").getAtractiveTerm().setParameters(i - 9,
+            system.getPhases()[0].getComponent("n-butane").getAttractiveTerm().setParameters(i - 9,
                     value);
-            system.getPhases()[1].getComponent("n-butane").getAtractiveTerm().setParameters(i - 9,
+            system.getPhases()[1].getComponent("n-butane").getAttractiveTerm().setParameters(i - 9,
                     value);
             return;
         }
@@ -127,9 +127,9 @@ public class MathiasCopemanToDewPoint extends LevenbergMarquardtFunction {
         if (system.getPhase(0).hasComponent("i-butane") && i < 15) {
             system.getPhases()[0].getComponent("i-butane").setMatiascopemanParams(i - 12, value);
             system.getPhases()[1].getComponent("i-butane").setMatiascopemanParams(i - 12, value);
-            system.getPhases()[0].getComponent("i-butane").getAtractiveTerm().setParameters(i - 12,
+            system.getPhases()[0].getComponent("i-butane").getAttractiveTerm().setParameters(i - 12,
                     value);
-            system.getPhases()[1].getComponent("i-butane").getAtractiveTerm().setParameters(i - 12,
+            system.getPhases()[1].getComponent("i-butane").getAttractiveTerm().setParameters(i - 12,
                     value);
             return;
         }
@@ -137,19 +137,19 @@ public class MathiasCopemanToDewPoint extends LevenbergMarquardtFunction {
         if (system.getPhase(0).hasComponent("n-pentane") && i < 18) {
             system.getPhases()[0].getComponent("n-pentane").setMatiascopemanParams(i - 15, value);
             system.getPhases()[1].getComponent("n-pentane").setMatiascopemanParams(i - 15, value);
-            system.getPhases()[0].getComponent("n-pentane").getAtractiveTerm().setParameters(i - 15,
-                    value);
-            system.getPhases()[1].getComponent("n-pentane").getAtractiveTerm().setParameters(i - 15,
-                    value);
+            system.getPhases()[0].getComponent("n-pentane").getAttractiveTerm()
+                    .setParameters(i - 15, value);
+            system.getPhases()[1].getComponent("n-pentane").getAttractiveTerm()
+                    .setParameters(i - 15, value);
             return;
         }
 
         if (system.getPhase(0).hasComponent("c-hexane") && i < 21) {
             system.getPhases()[0].getComponent("c-hexane").setMatiascopemanParams(i - 18, value);
             system.getPhases()[1].getComponent("c-hexane").setMatiascopemanParams(i - 18, value);
-            system.getPhases()[0].getComponent("c-hexane").getAtractiveTerm().setParameters(i - 18,
+            system.getPhases()[0].getComponent("c-hexane").getAttractiveTerm().setParameters(i - 18,
                     value);
-            system.getPhases()[1].getComponent("c-hexane").getAtractiveTerm().setParameters(i - 18,
+            system.getPhases()[1].getComponent("c-hexane").getAttractiveTerm().setParameters(i - 18,
                     value);
             return;
         }
@@ -157,9 +157,9 @@ public class MathiasCopemanToDewPoint extends LevenbergMarquardtFunction {
         if (system.getPhase(0).hasComponent("benzene") && i < 24) {
             system.getPhases()[0].getComponent("benzene").setMatiascopemanParams(i - 21, value);
             system.getPhases()[1].getComponent("benzene").setMatiascopemanParams(i - 21, value);
-            system.getPhases()[0].getComponent("benzene").getAtractiveTerm().setParameters(i - 21,
+            system.getPhases()[0].getComponent("benzene").getAttractiveTerm().setParameters(i - 21,
                     value);
-            system.getPhases()[1].getComponent("benzene").getAtractiveTerm().setParameters(i - 21,
+            system.getPhases()[1].getComponent("benzene").getAttractiveTerm().setParameters(i - 21,
                     value);
             return;
         }
@@ -167,10 +167,10 @@ public class MathiasCopemanToDewPoint extends LevenbergMarquardtFunction {
         if (system.getPhase(0).hasComponent("n-heptane") && i < 27) {
             system.getPhases()[0].getComponent("n-heptane").setMatiascopemanParams(i - 24, value);
             system.getPhases()[1].getComponent("n-heptane").setMatiascopemanParams(i - 24, value);
-            system.getPhases()[0].getComponent("n-heptane").getAtractiveTerm().setParameters(i - 24,
-                    value);
-            system.getPhases()[1].getComponent("n-heptane").getAtractiveTerm().setParameters(i - 24,
-                    value);
+            system.getPhases()[0].getComponent("n-heptane").getAttractiveTerm()
+                    .setParameters(i - 24, value);
+            system.getPhases()[1].getComponent("n-heptane").getAttractiveTerm()
+                    .setParameters(i - 24, value);
         }
     }
 }

--- a/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/acentricFactorFitting/TestAcentricSchwartzentruber.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/acentricFactorFitting/TestAcentricSchwartzentruber.java
@@ -75,7 +75,7 @@ public class TestAcentricSchwartzentruber {
                 // SystemInterface testSystem = new SystemSrkSchwartzentruberEos(280, 0.101);
                 SystemInterface testSystem = new SystemSrkTwuCoonParamEos(280, 0.01);
                 // SystemInterface testSystem = new SystemPrEos1978(280, 0.01);
-                // testSystem.setAtractiveTerm(13);
+                // testSystem.setAttractiveTerm(13);
                 testSystem.addComponent(dataSet.getString("ComponentName"), 100.0);
                 // testSystem.createDatabase(true);
                 double sample1[] = {Double.parseDouble(dataSet.getString("Temperature"))}; // temperature

--- a/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/acentricFactorFitting/TwuCoon.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/acentricFactorFitting/TwuCoon.java
@@ -54,7 +54,7 @@ public class TwuCoon extends LevenbergMarquardtFunction {
         params[i] = value;
         system.getPhases()[0].getComponents()[0].setTwuCoonParams(i, value);
         system.getPhases()[1].getComponents()[0].setTwuCoonParams(i, value);
-        system.getPhases()[0].getComponents()[0].getAtractiveTerm().setParameters(i, value);
-        system.getPhases()[1].getComponents()[0].getAtractiveTerm().setParameters(i, value);
+        system.getPhases()[0].getComponents()[0].getAttractiveTerm().setParameters(i, value);
+        system.getPhases()[1].getComponents()[0].getAttractiveTerm().setParameters(i, value);
     }
 }

--- a/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/cpaParam/CPAFunction.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/cpaParam/CPAFunction.java
@@ -60,8 +60,8 @@ public class CPAFunction extends LevenbergMarquardtFunction {
             system.getPhases()[1].getComponents()[0].setb(value);
         }
         if (i == 12) {
-            system.getPhase(0).getComponent(0).getAtractiveTerm().setm(value);
-            system.getPhases()[1].getComponents()[0].getAtractiveTerm().setm(value);
+            system.getPhase(0).getComponent(0).getAttractiveTerm().setm(value);
+            system.getPhases()[1].getComponents()[0].getAttractiveTerm().setm(value);
         }
         if (i == 14) {
             system.getPhase(0).getComponent(0).setAssociationEnergy(value * 1e4);
@@ -73,14 +73,16 @@ public class CPAFunction extends LevenbergMarquardtFunction {
         }
 
         if (i == 15) {
-            system.getPhase(0).getComponent(0).getAtractiveTerm().setm(value);
-            system.getPhases()[1].getComponents()[0].getAtractiveTerm().setm(value);
+            system.getPhase(0).getComponent(0).getAttractiveTerm().setm(value);
+            system.getPhases()[1].getComponents()[0].getAttractiveTerm().setm(value);
         }
         if (i >= 5 && i < 8) {
             system.getPhases()[0].getComponents()[0].setMatiascopemanParams(i - 5, value);
             system.getPhases()[1].getComponents()[0].setMatiascopemanParams(i - 5, value);
-            system.getPhases()[0].getComponents()[0].getAtractiveTerm().setParameters(i - 5, value);
-            system.getPhases()[1].getComponents()[0].getAtractiveTerm().setParameters(i - 5, value);
+            system.getPhases()[0].getComponents()[0].getAttractiveTerm().setParameters(i - 5,
+                    value);
+            system.getPhases()[1].getComponents()[0].getAttractiveTerm().setParameters(i - 5,
+                    value);
         }
         if (i == 0) {
             system.getPhases()[0].getComponents()[0].setRacketZCPA(value);

--- a/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/cpaParam/CPAFunctionStatoil.java
+++ b/src/main/java/neqsim/thermo/util/parameterFitting/pureComponentParameterFitting/cpaParam/CPAFunctionStatoil.java
@@ -49,20 +49,20 @@ public class CPAFunctionStatoil extends LevenbergMarquardtFunction {
     public void setFittingParams(int i, double value) {
         params[i] = value;
         if (i == 0) {
-            system.getPhase(0).getComponent(0).getAtractiveTerm().setm(value);
-            system.getPhases()[1].getComponents()[0].getAtractiveTerm().setm(value);
+            system.getPhase(0).getComponent(0).getAttractiveTerm().setm(value);
+            system.getPhases()[1].getComponents()[0].getAttractiveTerm().setm(value);
         }
         system.getPhases()[0].getComponents()[0].setMatiascopemanParams(i, value);
         system.getPhases()[1].getComponents()[0].setMatiascopemanParams(i, value);
-        system.getPhases()[0].getComponents()[0].getAtractiveTerm().setParameters(i, value);
-        system.getPhases()[1].getComponents()[0].getAtractiveTerm().setParameters(i, value);
+        system.getPhases()[0].getComponents()[0].getAttractiveTerm().setParameters(i, value);
+        system.getPhases()[1].getComponents()[0].getAttractiveTerm().setParameters(i, value);
 
         // value = 0.0;
         // for(int j=1;j<3;j++){
         // system.getPhases()[0].getComponents()[0].setSchwartzentruberParams(j, value);
         // system.getPhases()[1].getComponents()[0].setSchwartzentruberParams(j, value);
-        // system.getPhases()[0].getComponents()[0].getAtractiveTerm().setParameters(j, value);
-        // system.getPhases()[1].getComponents()[0].getAtractiveTerm().setParameters(j, value);
+        // system.getPhases()[0].getComponents()[0].getAttractiveTerm().setParameters(j, value);
+        // system.getPhases()[1].getComponents()[0].getAttractiveTerm().setParameters(j, value);
         // }
     }
 }

--- a/src/test/java/neqsim/thermo/util/example/TestUMRPRUMC.java
+++ b/src/test/java/neqsim/thermo/util/example/TestUMRPRUMC.java
@@ -19,7 +19,9 @@ public class TestUMRPRUMC {
     static Logger logger = LogManager.getLogger(TestUMRPRUMC.class);
 
     /**
-     * <p>main.</p>
+     * <p>
+     * main.
+     * </p>
      *
      * @param args an array of {@link java.lang.String} objects
      */
@@ -93,7 +95,7 @@ public class TestUMRPRUMC {
         testSystem.init(0);
         ThermodynamicOperations testOps = new ThermodynamicOperations(testSystem);
 
-        // testSystem.setAtractiveTerm(13);
+        // testSystem.setAttractiveTerm(13);
         try {
             testOps.TPflash();
             testSystem.display();


### PR DESCRIPTION
A lot of public classes and methods are changed so if this change is implemented, the version should be increased to notify there is no backwards compatability. An option might be to introduce copies and mark the ones with typos as deprecated first.