### PR TITLE
feat: Add runAsThread method to ProcessModule & make ProcessModule serializable

### DIFF
--- a/src/main/java/neqsim/processSimulation/processSystem/ProcessModule.java
+++ b/src/main/java/neqsim/processSimulation/processSystem/ProcessModule.java
@@ -1,5 +1,5 @@
 package neqsim.processSimulation.processSystem;
-
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -21,7 +21,7 @@ If no recycle in the module then run only once.
 
 */
 
-public class ProcessModule extends SimulationBaseClass {
+public class ProcessModule extends SimulationBaseClass implements Serializable{
 
     private static final long serialVersionUID = 1000;
     private static final Logger logger = LogManager.getLogger(ProcessModule.class);
@@ -206,6 +206,19 @@ public class ProcessModule extends SimulationBaseClass {
     @Override
     public boolean solved() {
         return solved;
+    }
+
+    /**
+     * <p>
+     * runAsThread.
+     * </p>
+     *
+     * @return a {@link java.lang.Thread} object
+     */
+    public Thread runAsThread() {
+      Thread processThread = new Thread(this);
+      processThread.start();
+      return processThread;
     }
 
 }

--- a/src/test/java/neqsim/processSimulation/processSystem/GlycolModulesTest.java
+++ b/src/test/java/neqsim/processSimulation/processSystem/GlycolModulesTest.java
@@ -314,6 +314,11 @@ public class GlycolModulesTest extends  neqsim.NeqSimTest {
       modules.add(module2);
       modules.add(module3); 
       modules.add(module4);     
-      modules.run();
+
+      Thread runThr = modules.runAsThread();
+      try {
+        runThr.join(100000);
+      } catch (Exception ex) {
+      }
   }
 }


### PR DESCRIPTION
This pull request adds two new features to the `ProcessModule` class: the ability to run a module as a thread and serialization support. 

The `runAsThread` method allows a module to be run as a separate thread, which can be useful when running multiple modules concurrently. 

To enable serialization, the `ProcessModule` class now implements the `Serializable` interface