### PR TITLE
chore: mark deprecated constructors for removal

### DIFF
--- a/src/main/java/neqsim/chemicalReactions/chemicalReaction/ChemicalReaction.java
+++ b/src/main/java/neqsim/chemicalReactions/chemicalReaction/ChemicalReaction.java
@@ -49,7 +49,7 @@ public class ChemicalReaction extends NamedBaseClass
    *             {@link #ChemicalReaction(String, String[], double[], double[], double, double, double)}
    *             instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public ChemicalReaction() {
     super("ChemicalReaction");
   }

--- a/src/main/java/neqsim/fluidMechanics/geometryDefinitions/internalGeometry/packings/Packing.java
+++ b/src/main/java/neqsim/fluidMechanics/geometryDefinitions/internalGeometry/packings/Packing.java
@@ -30,7 +30,7 @@ public class Packing extends NamedBaseClass implements PackingInterface {
    * Constructor for Packing.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Packing() {
     super("Packing");
   }

--- a/src/main/java/neqsim/fluidMechanics/geometryDefinitions/internalGeometry/packings/PallRingPacking.java
+++ b/src/main/java/neqsim/fluidMechanics/geometryDefinitions/internalGeometry/packings/PallRingPacking.java
@@ -22,7 +22,7 @@ public class PallRingPacking extends Packing {
    * Constructor for PallRingPacking.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public PallRingPacking() {
     this("PallRingPacking");
   }

--- a/src/main/java/neqsim/fluidMechanics/geometryDefinitions/internalGeometry/packings/RachigRingPacking.java
+++ b/src/main/java/neqsim/fluidMechanics/geometryDefinitions/internalGeometry/packings/RachigRingPacking.java
@@ -16,7 +16,7 @@ public class RachigRingPacking extends Packing {
    * Constructor for RachigRingPacking.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public RachigRingPacking() {
     this("RachigRingPacking");
   }

--- a/src/main/java/neqsim/physicalProperties/interfaceProperties/solidAdsorption/AdsorptionInterface.java
+++ b/src/main/java/neqsim/physicalProperties/interfaceProperties/solidAdsorption/AdsorptionInterface.java
@@ -26,7 +26,7 @@ public interface AdsorptionInterface extends neqsim.thermo.ThermodynamicConstant
    * @param phase a int
    * @deprecated Replaced by {@link calcAdsorption}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public default void calcAdorption(int phase) {
     calcAdsorption(phase);
   }
@@ -50,7 +50,7 @@ public interface AdsorptionInterface extends neqsim.thermo.ThermodynamicConstant
    * @return a double
    * @deprecated Replaced by {@link getSurfaceExcess}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public default double getSurfaceExess(int component) {
     return getSurfaceExcess(component);
   }

--- a/src/main/java/neqsim/processSimulation/measurementDevice/pHProbe.java
+++ b/src/main/java/neqsim/processSimulation/measurementDevice/pHProbe.java
@@ -122,7 +122,7 @@ public class pHProbe extends StreamMeasurementDeviceBaseClass {
    * @return the alkalinity
    * @deprecated Replaced by {@link getAlkalinity}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public double getAlkanility() {
     return getAlkalinity();
   }
@@ -146,7 +146,7 @@ public class pHProbe extends StreamMeasurementDeviceBaseClass {
    * @param alkalinity the alkalinity to set
    * @deprecated Replaced by {@link setAlkalinity}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public void setAlkanility(double alkalinity) {
     setAlkalinity(alkalinity);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/TwoPortInterface.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/TwoPortInterface.java
@@ -20,8 +20,9 @@ public interface TwoPortInterface {
    * Get inlet Stream of twoport.
    *
    * @return a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface} object
+   * @deprecated use {@link #getInletStream()} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public default StreamInterface getInStream() {
     return getInletStream();
   }
@@ -53,7 +54,7 @@ public interface TwoPortInterface {
    * @return outlet Stream of TwoPortEquipment
    * @deprecated use {@link #getOutletStream()} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public default StreamInterface getOutStream() {
     return getOutletStream();
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/absorber/SimpleAbsorber.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/absorber/SimpleAbsorber.java
@@ -37,7 +37,7 @@ public class SimpleAbsorber extends Separator implements AbsorberInterface {
    * Constructor for SimpleAbsorber.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SimpleAbsorber() {
     this("SimpleAbsorber");
   }
@@ -49,7 +49,7 @@ public class SimpleAbsorber extends Separator implements AbsorberInterface {
    *
    * @param inStream1 a {@link neqsim.processSimulation.processEquipment.stream.Stream} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SimpleAbsorber(StreamInterface inStream1) {
     this("SimpleAbsorber", inStream1);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/absorber/SimpleTEGAbsorber.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/absorber/SimpleTEGAbsorber.java
@@ -49,7 +49,7 @@ public class SimpleTEGAbsorber extends SimpleAbsorber {
    * Constructor for SimpleTEGAbsorber.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SimpleTEGAbsorber() {}
 
   /**

--- a/src/main/java/neqsim/processSimulation/processEquipment/absorber/WaterStripperColumn.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/absorber/WaterStripperColumn.java
@@ -51,7 +51,7 @@ public class WaterStripperColumn extends SimpleAbsorber {
    * Constructor for WaterStripperColumn.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public WaterStripperColumn() {}
 
   /**

--- a/src/main/java/neqsim/processSimulation/processEquipment/adsorber/SimpleAdsorber.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/adsorber/SimpleAdsorber.java
@@ -38,7 +38,7 @@ public class SimpleAdsorber extends ProcessEquipmentBaseClass {
    * Constructor for SimpleAdsorber.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SimpleAdsorber() {
     this("SimpleAdsorber");
   }
@@ -51,28 +51,9 @@ public class SimpleAdsorber extends ProcessEquipmentBaseClass {
    * @param inStream1 a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SimpleAdsorber(StreamInterface inStream1) {
-    this("SimpleAdsorber");
-    this.inStream[0] = inStream1;
-    this.inStream[1] = inStream1;
-    outStream[0] = (Stream) inStream1.clone();
-    outStream[1] = (Stream) inStream1.clone();
-
-    SystemInterface systemOut1 = inStream1.getThermoSystem().clone();
-    outStream[0].setThermoSystem(systemOut1);
-
-    double molCO2 = inStream1.getThermoSystem().getPhase(0).getComponent("CO2").getNumberOfmoles();
-    System.out.println("mol CO2 " + molCO2);
-    SystemInterface systemOut0 = inStream1.getThermoSystem().clone();
-    systemOut0.init(0);
-    systemOut0.addComponent("MDEA", molCO2 * absorptionEfficiency);
-    systemOut0.addComponent("water", molCO2 * absorptionEfficiency * 10.0);
-    systemOut0.chemicalReactionInit();
-    systemOut0.createDatabase(true);
-    systemOut0.setMixingRule(4);
-    outStream[1].setThermoSystem(systemOut0);
-    outStream[1].run();
+    this("SimpleAdsorber", inStream1);
   }
 
   /**

--- a/src/main/java/neqsim/processSimulation/processEquipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/compressor/Compressor.java
@@ -60,7 +60,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
    * Constructor for Compressor.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Compressor() {
     this("Compressor");
   }
@@ -73,7 +73,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Compressor(StreamInterface inletStream) {
     this();
     setInletStream(inletStream);
@@ -86,7 +86,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
    *
    * @param interpolateMapLookup a boolean
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Compressor(boolean interpolateMapLookup) {
     this("Compressor", interpolateMapLookup);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/expander/Expander.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/expander/Expander.java
@@ -21,7 +21,7 @@ public class Expander extends Compressor implements ExpanderInterface {
    * Constructor for Expander.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Expander() {
     super();
   }
@@ -34,9 +34,9 @@ public class Expander extends Compressor implements ExpanderInterface {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Expander(StreamInterface inletStream) {
-    super(inletStream);
+    this("Expander", inletStream);
   }
 
   /**

--- a/src/main/java/neqsim/processSimulation/processEquipment/expander/ExpanderOld.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/expander/ExpanderOld.java
@@ -37,7 +37,7 @@ public class ExpanderOld extends TwoPortEquipment implements ExpanderInterface {
    * Constructor for ExpanderOld.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public ExpanderOld() {
     this("ExpanderOld");
   }
@@ -50,7 +50,7 @@ public class ExpanderOld extends TwoPortEquipment implements ExpanderInterface {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public ExpanderOld(StreamInterface inletStream) {
     this("ExpanderOld", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/filter/CharCoalFilter.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/filter/CharCoalFilter.java
@@ -21,7 +21,7 @@ public class CharCoalFilter extends Filter {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public CharCoalFilter(StreamInterface inStream) {
     super(inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/filter/Filter.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/filter/Filter.java
@@ -29,7 +29,7 @@ public class Filter extends TwoPortEquipment {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Filter(StreamInterface inStream) {
     this("Filter", inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/Cooler.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/Cooler.java
@@ -18,7 +18,7 @@ public class Cooler extends Heater {
    * Constructor for Cooler.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Cooler() {
     super();
   }
@@ -31,7 +31,7 @@ public class Cooler extends Heater {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Cooler(StreamInterface inStream) {
     super(inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/HeatExchanger.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/HeatExchanger.java
@@ -49,7 +49,7 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
    * Constructor for HeatExchanger.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public HeatExchanger() {
     this("HeatExchanger");
   }
@@ -62,7 +62,7 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
    * @param inStream1 a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public HeatExchanger(StreamInterface inStream1) {
     this("HeatExchanger", inStream1);
   }
@@ -77,7 +77,7 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
    * @param inStream2 a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public HeatExchanger(StreamInterface inStream1, StreamInterface inStream2) {
     this("HeatExchanger", inStream1, inStream2);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/Heater.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/Heater.java
@@ -39,7 +39,7 @@ public class Heater extends TwoPortEquipment implements HeaterInterface {
    * Constructor for Heater.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Heater() {
     super("Heater");
   }
@@ -52,7 +52,7 @@ public class Heater extends TwoPortEquipment implements HeaterInterface {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Heater(StreamInterface inStream) {
     this("Heater", inStream);
   }
@@ -289,7 +289,7 @@ public class Heater extends TwoPortEquipment implements HeaterInterface {
    *
    * @param outStream the outStream to set
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public void setOutStream(StreamInterface outStream) {
     setOutletStream(outStream);
   }
@@ -297,14 +297,12 @@ public class Heater extends TwoPortEquipment implements HeaterInterface {
   /** {@inheritDoc} */
   @Override
   public double getEntropyProduction(String unit) {
-    double entrop = 0.0;
-
     inStream.run();
     inStream.getFluid().init(3);
     outStream.run();
     outStream.getFluid().init(3);
 
-    entrop +=
+    double entrop =
         outStream.getThermoSystem().getEntropy(unit) - inStream.getThermoSystem().getEntropy(unit);
 
     return entrop;

--- a/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/NeqHeater.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/NeqHeater.java
@@ -23,7 +23,7 @@ public class NeqHeater extends Heater {
    * Constructor for NeqHeater.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public NeqHeater() {
     this("NeqHeater");
   }
@@ -36,7 +36,7 @@ public class NeqHeater extends Heater {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public NeqHeater(StreamInterface inStream) {
     this("NeqHeater", inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/ReBoiler.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/ReBoiler.java
@@ -26,7 +26,7 @@ public class ReBoiler extends TwoPortEquipment {
    * Constructor for ReBoiler.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public ReBoiler() {
     super("ReBoiler");
   }
@@ -39,7 +39,7 @@ public class ReBoiler extends TwoPortEquipment {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public ReBoiler(StreamInterface inStream) {
     this("ReBoiler", inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/mixer/Mixer.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/mixer/Mixer.java
@@ -42,7 +42,7 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface {
    * Constructor for Mixer.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Mixer() {
     super("Mixer");
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/mixer/MixerInterface.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/mixer/MixerInterface.java
@@ -46,7 +46,7 @@ public interface MixerInterface extends ProcessEquipmentInterface {
    * @return a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface} object
    * @deprecated use {@link #getOutletStream} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public default StreamInterface getOutStream() {
     return getOutletStream();
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/mixer/StaticMixer.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/mixer/StaticMixer.java
@@ -25,7 +25,7 @@ public class StaticMixer extends Mixer {
    * Constructor for StaticMixer.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public StaticMixer() {}
 
   /**

--- a/src/main/java/neqsim/processSimulation/processEquipment/mixer/StaticNeqMixer.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/mixer/StaticNeqMixer.java
@@ -26,7 +26,7 @@ public class StaticNeqMixer extends StaticMixer {
    * Constructor for StaticNeqMixer.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public StaticNeqMixer() {}
 
   /**

--- a/src/main/java/neqsim/processSimulation/processEquipment/mixer/StaticPhaseMixer.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/mixer/StaticPhaseMixer.java
@@ -18,7 +18,7 @@ public class StaticPhaseMixer extends StaticMixer {
    * Constructor for StaticPhaseMixer.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public StaticPhaseMixer() {}
 
   /**

--- a/src/main/java/neqsim/processSimulation/processEquipment/pipeline/AdiabaticPipe.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/pipeline/AdiabaticPipe.java
@@ -41,7 +41,7 @@ public class AdiabaticPipe extends Pipeline {
    * Constructor for AdiabaticPipe.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public AdiabaticPipe() {
     this("AdiabaticPipe");
   }
@@ -54,7 +54,7 @@ public class AdiabaticPipe extends Pipeline {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public AdiabaticPipe(StreamInterface inStream) {
     this("AdiabaticPipe", inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/pipeline/AdiabaticTwoPhasePipe.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/pipeline/AdiabaticTwoPhasePipe.java
@@ -49,7 +49,7 @@ public class AdiabaticTwoPhasePipe extends Pipeline {
    * Constructor for AdiabaticTwoPhasePipe.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public AdiabaticTwoPhasePipe() {}
 
   /**
@@ -60,7 +60,7 @@ public class AdiabaticTwoPhasePipe extends Pipeline {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public AdiabaticTwoPhasePipe(StreamInterface inStream) {
     this("AdiabaticTwoPhasePipe", inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/pipeline/IncompressiblePipeFlow.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/pipeline/IncompressiblePipeFlow.java
@@ -25,7 +25,7 @@ public class IncompressiblePipeFlow extends AdiabaticPipe {
    * Constructor for IncompressiblePipeFlow.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public IncompressiblePipeFlow() {
     super("IncompressiblePipeFlow");
   }
@@ -38,7 +38,7 @@ public class IncompressiblePipeFlow extends AdiabaticPipe {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public IncompressiblePipeFlow(StreamInterface inStream) {
     this("IncompressiblePipeFlow", inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/pipeline/OnePhasePipeLine.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/pipeline/OnePhasePipeLine.java
@@ -27,7 +27,7 @@ public class OnePhasePipeLine extends Pipeline {
    * Constructor for OnePhasePipeLine.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public OnePhasePipeLine() {
     this("OnePhasePipeLine");
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/pipeline/PipeBeggsAndBrills.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/pipeline/PipeBeggsAndBrills.java
@@ -92,7 +92,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * Constructor for AdiabaticTwoPhasePipe.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public PipeBeggsAndBrills() {}
 
   /**
@@ -103,7 +103,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public PipeBeggsAndBrills(StreamInterface inStream) {
     this("PipeBeggsAndBrills", inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/pipeline/Pipeline.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/pipeline/Pipeline.java
@@ -51,7 +51,7 @@ public class Pipeline extends TwoPortEquipment implements PipeLineInterface {
    * Constructor for Pipeline.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Pipeline() {
     this("Pipeline");
   }
@@ -64,7 +64,7 @@ public class Pipeline extends TwoPortEquipment implements PipeLineInterface {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Pipeline(StreamInterface inStream) {
     this("Pipeline", inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/pipeline/SimpleTPoutPipeline.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/pipeline/SimpleTPoutPipeline.java
@@ -25,7 +25,7 @@ public class SimpleTPoutPipeline extends Pipeline {
    * Constructor for SimpleTPoutPipeline.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SimpleTPoutPipeline() {}
 
   /**
@@ -36,7 +36,7 @@ public class SimpleTPoutPipeline extends Pipeline {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SimpleTPoutPipeline(StreamInterface inStream) {
     this("SimpleTPoutPipeline", inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/pipeline/TwoPhasePipeLine.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/pipeline/TwoPhasePipeLine.java
@@ -26,7 +26,7 @@ public class TwoPhasePipeLine extends Pipeline {
    * Constructor for TwoPhasePipeLine.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public TwoPhasePipeLine() {
     this("TwoPhasePipeLine");
   }
@@ -38,7 +38,7 @@ public class TwoPhasePipeLine extends Pipeline {
    *
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.Stream} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public TwoPhasePipeLine(StreamInterface inStream) {
     this("TwoPhasePipeLine", inStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/powerGeneration/GasTurbine.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/powerGeneration/GasTurbine.java
@@ -41,6 +41,7 @@ public class GasTurbine extends TwoPortEquipment {
    * Constructor for GasTurbine.
    * </p>
    */
+  @Deprecated(forRemoval = true)
   public GasTurbine() {
     this("GasTurbine");
   }
@@ -72,7 +73,7 @@ public class GasTurbine extends TwoPortEquipment {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public GasTurbine(StreamInterface inletStream) {
     this();
     setInletStream(inletStream);

--- a/src/main/java/neqsim/processSimulation/processEquipment/pump/Pump.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/pump/Pump.java
@@ -45,7 +45,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface {
    * Constructor for Pump.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Pump() {
     super("Pump");
   }
@@ -58,7 +58,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Pump(StreamInterface inletStream) {
     this();
     setInletStream(inletStream);

--- a/src/main/java/neqsim/processSimulation/processEquipment/reservoir/SimpleReservoir.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/reservoir/SimpleReservoir.java
@@ -52,7 +52,7 @@ public class SimpleReservoir extends ProcessEquipmentBaseClass {
    * Constructor for SimpleReservoir.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SimpleReservoir() {
     this("SimpleReservoir");
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/reservoir/Well.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/reservoir/Well.java
@@ -17,7 +17,9 @@ public class Well extends NamedBaseClass {
   private static final long serialVersionUID = 1000;
 
   private StreamInterface stream = null;
-  double x, y, z;
+  double x;
+  double y;
+  double z;
 
   /**
    * <p>
@@ -26,7 +28,7 @@ public class Well extends NamedBaseClass {
    *
    * @deprecated use {@link #Well(String)} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Well() {
     this("Well");
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/separator/GasScrubber.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/separator/GasScrubber.java
@@ -42,7 +42,7 @@ public class GasScrubber extends Separator {
    * Constructor for GasScrubber.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public GasScrubber() {
     this("GasScrubber");
   }
@@ -54,7 +54,7 @@ public class GasScrubber extends Separator {
    *
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.Stream} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public GasScrubber(StreamInterface inletStream) {
     this("GasScrubber", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/separator/GasScrubberSimple.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/separator/GasScrubberSimple.java
@@ -38,7 +38,7 @@ public class GasScrubberSimple extends Separator {
    * Constructor for GasScrubberSimple.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public GasScrubberSimple() {
     this("GasScrubberSimple");
   }
@@ -50,7 +50,7 @@ public class GasScrubberSimple extends Separator {
    *
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.Stream} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public GasScrubberSimple(StreamInterface inletStream) {
     this("GasScrubberSimple", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/separator/Hydrocyclone.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/separator/Hydrocyclone.java
@@ -29,7 +29,7 @@ public class Hydrocyclone extends Separator {
    * Constructor for Hydrocyclone.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Hydrocyclone() {
     this("Hydrocyclone");
   }
@@ -42,7 +42,7 @@ public class Hydrocyclone extends Separator {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Hydrocyclone(StreamInterface inletStream) {
     this("Hydrocyclone", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/separator/NeqGasScrubber.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/separator/NeqGasScrubber.java
@@ -37,7 +37,7 @@ public class NeqGasScrubber extends Separator {
    * Constructor for NeqGasScrubber.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public NeqGasScrubber() {
     this("NeqGasScrubber");
   }
@@ -50,7 +50,7 @@ public class NeqGasScrubber extends Separator {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public NeqGasScrubber(StreamInterface inletStream) {
     this("NeqGasScrubber", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/separator/Separator.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/separator/Separator.java
@@ -71,7 +71,7 @@ public class Separator extends ProcessEquipmentBaseClass implements SeparatorInt
   /**
    * Constructor for Separator.
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Separator() {
     super("Separator");
     setCalculateSteadyState(false);
@@ -83,7 +83,7 @@ public class Separator extends ProcessEquipmentBaseClass implements SeparatorInt
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Separator(StreamInterface inletStream) {
     this("Separator", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/separator/ThreePhaseSeparator.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/separator/ThreePhaseSeparator.java
@@ -42,7 +42,7 @@ public class ThreePhaseSeparator extends Separator {
    * Constructor for ThreePhaseSeparator.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public ThreePhaseSeparator() {
     this("ThreePhaseSeparator");
   }
@@ -55,7 +55,7 @@ public class ThreePhaseSeparator extends Separator {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public ThreePhaseSeparator(StreamInterface inletStream) {
     this("ThreePhaseSeparator", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/separator/TwoPhaseSeparator.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/separator/TwoPhaseSeparator.java
@@ -32,7 +32,7 @@ public class TwoPhaseSeparator extends Separator {
    * Constructor for TwoPhaseSeparator.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public TwoPhaseSeparator() {
     this("TwoPhaseSeparator");
   }
@@ -45,7 +45,7 @@ public class TwoPhaseSeparator extends Separator {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public TwoPhaseSeparator(StreamInterface inletStream) {
     this("TwoPhaseSeparator", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/splitter/Splitter.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/splitter/Splitter.java
@@ -50,7 +50,7 @@ public class Splitter extends ProcessEquipmentBaseClass implements SplitterInter
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Splitter(StreamInterface inletStream) {
     this();
     this.setInletStream(inletStream);

--- a/src/main/java/neqsim/processSimulation/processEquipment/stream/EquilibriumStream.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/stream/EquilibriumStream.java
@@ -23,7 +23,7 @@ public class EquilibriumStream extends Stream {
    * Constructor for EquilibriumStream.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public EquilibriumStream() {}
 
   /**
@@ -33,7 +33,7 @@ public class EquilibriumStream extends Stream {
    *
    * @param thermoSystem a {@link neqsim.thermo.system.SystemInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public EquilibriumStream(SystemInterface thermoSystem) {
     super(thermoSystem);
   }
@@ -45,7 +45,7 @@ public class EquilibriumStream extends Stream {
    *
    * @param stream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public EquilibriumStream(StreamInterface stream) {
     this("EquilibriumStream", stream.getThermoSystem());
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/stream/IronIonSaturationStream.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/stream/IronIonSaturationStream.java
@@ -31,7 +31,7 @@ public class IronIonSaturationStream extends Stream {
    * Constructor for IronIonSaturationStream.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public IronIonSaturationStream() {
     this("IronIonSaturationStream");
   }
@@ -43,7 +43,7 @@ public class IronIonSaturationStream extends Stream {
    *
    * @param thermoSystem a {@link neqsim.thermo.system.SystemInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public IronIonSaturationStream(SystemInterface thermoSystem) {
     this("IronIonSaturationStream", thermoSystem);
   }
@@ -55,7 +55,7 @@ public class IronIonSaturationStream extends Stream {
    *
    * @param stream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public IronIonSaturationStream(StreamInterface stream) {
     this("IronIonSaturationStream", stream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/stream/NeqStream.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/stream/NeqStream.java
@@ -22,7 +22,7 @@ public class NeqStream extends Stream {
    * Constructor for NeqStream.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public NeqStream() {
     super("NeqStream");
   }
@@ -34,7 +34,7 @@ public class NeqStream extends Stream {
    *
    * @param thermoSystem a {@link neqsim.thermo.system.SystemInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public NeqStream(SystemInterface thermoSystem) {
     super(thermoSystem);
   }
@@ -46,7 +46,7 @@ public class NeqStream extends Stream {
    *
    * @param stream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public NeqStream(StreamInterface stream) {
     super(stream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/stream/ScalePotentialCheckStream.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/stream/ScalePotentialCheckStream.java
@@ -25,7 +25,7 @@ public class ScalePotentialCheckStream extends Stream {
    * Constructor for ScalePotentialCheckStream.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public ScalePotentialCheckStream() {
     super("ScalePotentialCheckStream");
   }
@@ -48,7 +48,7 @@ public class ScalePotentialCheckStream extends Stream {
    *
    * @param stream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public ScalePotentialCheckStream(StreamInterface stream) {
     super("ScalePotentialCheckStream", stream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/stream/Stream.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/stream/Stream.java
@@ -39,7 +39,7 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
    * Constructor for Stream.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Stream() {
     super("Stream");
   }
@@ -51,7 +51,7 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
    *
    * @param stream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Stream(StreamInterface stream) {
     this("Stream", stream);
   }
@@ -63,7 +63,7 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
    *
    * @param thermoSystem a {@link neqsim.thermo.system.SystemInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Stream(SystemInterface thermoSystem) {
     this("Stream", thermoSystem);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/subsea/SimpleFlowLine.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/subsea/SimpleFlowLine.java
@@ -30,7 +30,7 @@ public class SimpleFlowLine extends TwoPortEquipment {
    * @param inStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SimpleFlowLine(StreamInterface inStream) {
     this("SimpleFlowLine", inStream);
 

--- a/src/main/java/neqsim/processSimulation/processEquipment/subsea/SubseaWell.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/subsea/SubseaWell.java
@@ -32,7 +32,7 @@ public class SubseaWell extends TwoPortEquipment {
    * @param instream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SubseaWell(StreamInterface instream) {
     super("SubseaWell");
     this.inStream = instream;

--- a/src/main/java/neqsim/processSimulation/processEquipment/tank/Tank.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/tank/Tank.java
@@ -50,7 +50,7 @@ public class Tank extends ProcessEquipmentBaseClass {
    * Constructor for Tank.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Tank() {
     super("Tank");
     setCalculateSteadyState(false);
@@ -64,7 +64,7 @@ public class Tank extends ProcessEquipmentBaseClass {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Tank(StreamInterface inletStream) {
     this("Tank", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/util/Adjuster.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/util/Adjuster.java
@@ -44,7 +44,7 @@ public class Adjuster extends ProcessEquipmentBaseClass {
    * Constructor for Adjuster.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Adjuster() {
     this("Adjuster");
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/util/GORfitter.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/util/GORfitter.java
@@ -30,10 +30,10 @@ public class GORfitter extends TwoPortEquipment {
   String unitT = "C";
   String unitP = "bara";
 
-  @Deprecated
   /**
    * <p>Constructor for GORfitter.</p>
    */
+  @Deprecated(forRemoval = true)
   public GORfitter() {
     super("GOR fitter");
   }
@@ -45,7 +45,7 @@ public class GORfitter extends TwoPortEquipment {
    *
    * @param stream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public GORfitter(StreamInterface stream) {
     this("GORfitter", stream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/util/Recycle.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/util/Recycle.java
@@ -79,7 +79,7 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
    * Constructor for Recycle.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Recycle() {
     this("Recycle");
   }
@@ -258,7 +258,7 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
    *
    * @return a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface} object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public StreamInterface getOutStream() {
     return mixedStream;
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/util/SetPoint.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/util/SetPoint.java
@@ -43,7 +43,7 @@ public class SetPoint extends ProcessEquipmentBaseClass {
    * Constructor for SetPoint.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SetPoint() {
     this("SetPoint");
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/util/StreamSaturatorUtil.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/util/StreamSaturatorUtil.java
@@ -30,7 +30,7 @@ public class StreamSaturatorUtil extends TwoPortEquipment {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public StreamSaturatorUtil(StreamInterface inletStream) {
     this("StreamSaturatorUtil", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/util/StreamTransition.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/util/StreamTransition.java
@@ -22,7 +22,7 @@ public class StreamTransition extends TwoPortEquipment {
    * Constructor for StreamTransition.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public StreamTransition() {
     super("StreamTransition");
   }
@@ -37,7 +37,7 @@ public class StreamTransition extends TwoPortEquipment {
    * @param outletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public StreamTransition(StreamInterface inletStream, StreamInterface outletStream) {
     this("StreamTransition", inletStream, outletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/valve/SafetyValve.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/valve/SafetyValve.java
@@ -21,7 +21,7 @@ public class SafetyValve extends ThrottlingValve {
    * Constructor for SafetyValve.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SafetyValve() {
     this("SafetyValve");
   }
@@ -34,7 +34,7 @@ public class SafetyValve extends ThrottlingValve {
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public SafetyValve(StreamInterface inletStream) {
     this("SafetyValve", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/processEquipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/valve/ThrottlingValve.java
@@ -50,7 +50,7 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface 
    * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
    *        object
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public ThrottlingValve(StreamInterface inletStream) {
     this("ThrottlingValve", inletStream);
   }

--- a/src/main/java/neqsim/processSimulation/util/monitor/Fluid.java
+++ b/src/main/java/neqsim/processSimulation/util/monitor/Fluid.java
@@ -30,7 +30,7 @@ public class Fluid extends NamedBaseClass {
    * Constructor for Fluid.
    * </p>
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Fluid() {
     this("Fluid");
   }

--- a/src/main/java/neqsim/standards/salesContract/ContractSpecification.java
+++ b/src/main/java/neqsim/standards/salesContract/ContractSpecification.java
@@ -20,19 +20,23 @@ import neqsim.util.NamedBaseClass;
 public class ContractSpecification extends NamedBaseClass {
   private static final long serialVersionUID = 1L;
   StandardInterface standard = null;
-  String description = "dew point temperature specification";
+  String description = "";
   private String country = "";
   private String terminal = "";
   private double minValue = 0;
   private double maxValue = 0;
-  private double referenceTemperatureMeasurement = 0, referenceTemperatureCombustion = 0;
+  private double referenceTemperatureMeasurement = 0;
+  private double referenceTemperatureCombustion = 0;
   private double referencePressure = 0;
-  private String unit = "", comments = "";
+  private String unit = "";
+  private String comments = "";
 
-  @Deprecated
   /**
-   * <p>Constructor for ContractSpecification.</p>
+   * <p>
+   * Constructor for ContractSpecification.
+   * </p>
    */
+  @Deprecated(forRemoval = true)
   public ContractSpecification() {
     super("ContractSpecification");
   }


### PR DESCRIPTION
refact: some constructors are optimized
style: some checkstyle violations are autofixed

Marking for removal means that the constructors shall be removed in the next major release, e.g., 2.6.0/3.0.0