### PR TITLE
fix: use correct iso standard for lng ship calculations

### DIFF
--- a/src/main/java/neqsim/fluidMechanics/flowSystem/twoPhaseFlowSystem/shipSystem/LNGship.java
+++ b/src/main/java/neqsim/fluidMechanics/flowSystem/twoPhaseFlowSystem/shipSystem/LNGship.java
@@ -97,11 +97,11 @@ public class LNGship
    */
   public void useStandardVersion(String isoName, String version) {
     if (version.equals("2016")) {
-      setStandardISO6976(new Standard_ISO6976(thermoSystem, getStandardISO6976().getVolRefT(),
+      setStandardISO6976(new Standard_ISO6976_2016(thermoSystem, getStandardISO6976().getVolRefT(),
           getStandardISO6976().getEnergyRefT(), "volume"));
       logger.info("using  ISO6976 version 2016");
     } else {
-      setStandardISO6976(new Standard_ISO6976_2016(thermoSystem, getStandardISO6976().getVolRefT(),
+      setStandardISO6976(new Standard_ISO6976(thermoSystem, getStandardISO6976().getVolRefT(),
           getStandardISO6976().getEnergyRefT(), "volume"));
       logger.info("using  ISO6976 version 1995");
     }


### PR DESCRIPTION
Seems like the logic to select which ISO standard version to use was inverted. Suggested a fix