### PR TITLE
added pressure drop element

### DIFF
--- a/src/main/java/neqsim/processSimulation/processEquipment/util/PressureDrop.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/util/PressureDrop.java
@@ -37,9 +37,10 @@ public class PressureDrop extends ThrottlingValve {
   public void setPressureDrop(double pressureDrop, String unit) {
     if (unit.equals("bara")) {
       this.pressureDrop = pressureDrop;
-    }
-    if (unit.equals("Pa")) {
+    } else if (unit.equals("Pa")) {
       this.pressureDrop = pressureDrop / 1e5;
+    } else {
+      throw new RuntimeException("pressure drop unit not supported: " + unit);
     }
   }
 

--- a/src/main/java/neqsim/processSimulation/processEquipment/util/PressureDrop.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/util/PressureDrop.java
@@ -1,0 +1,74 @@
+package neqsim.processSimulation.processEquipment.util;
+
+import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.processSimulation.processEquipment.stream.StreamInterface;
+import neqsim.processSimulation.processEquipment.valve.ThrottlingValve;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicOperations.ThermodynamicOperations;
+
+/**
+ * <p>
+ * PressureDrop class.
+ * </p>
+ * The pressure drop unit is used to simulate pressure drops in process plant. The proessure drop is
+ * simulated using a constant enthalpy flash.
+ * 
+ * @author esol
+ * @version $Id: $Id
+ */
+public class PressureDrop extends ThrottlingValve {
+  private static final long serialVersionUID = 1000;
+  static Logger logger = LogManager.getLogger(PressureDrop.class);
+
+  SystemInterface thermoSystem;
+  double pressureDrop = 0.1;
+
+  /**
+   * <p>
+   * Constructor for PressureDrop.
+   * </p>
+   */
+  public PressureDrop(String name) {
+    super(name);
+  }
+
+  public void setPressureDrop(double pressureDrop, String unit) {
+    if (unit.equals("bara")) {
+      this.pressureDrop = pressureDrop;
+    }
+    if (unit.equals("Pa")) {
+      this.pressureDrop = pressureDrop / 1e5;
+    }
+  }
+
+  /**
+   * <p>
+   * Constructor for PressureDropUnit.
+   * </p>
+   *
+   * @param name a {@link java.lang.String} object
+   * @param inletStream a {@link neqsim.processSimulation.processEquipment.stream.StreamInterface}
+   *        object
+   */
+  public PressureDrop(String name, StreamInterface inletStream) {
+    this(name);
+    setInletStream(inletStream);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run(UUID id) {
+    thermoSystem = getInletStream().getThermoSystem().clone();
+    ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
+    thermoSystem.init(3);
+    double enthalpy = thermoSystem.getEnthalpy();
+
+    thermoSystem.setPressure(thermoSystem.getPressure() - pressureDrop);
+    thermoOps.PHflash(enthalpy);
+
+    outStream.setFluid(thermoSystem);
+  }
+
+}

--- a/src/test/java/neqsim/processSimulation/processEquipment/util/PressureDropTest.java
+++ b/src/test/java/neqsim/processSimulation/processEquipment/util/PressureDropTest.java
@@ -1,0 +1,37 @@
+package neqsim.processSimulation.processEquipment.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import neqsim.processSimulation.processEquipment.stream.Stream;
+import neqsim.thermo.system.SystemSrkEos;
+
+public class PressureDropTest {
+
+  @Test
+  void testRun() {
+    double pressure_inlet = 85.0;
+    double dp = 0.1;
+    double temperature_inlet = 35.0;
+    double gasFlowRate = 5.0;
+
+    neqsim.thermo.system.SystemInterface testSystem = new SystemSrkEos(298.0, 100.0);
+    testSystem.addComponent("methane", 100.0);
+
+    Stream inletStream = new Stream("inletStream", testSystem);
+    inletStream.setName("inlet stream");
+    inletStream.setPressure(pressure_inlet, "bara");
+    inletStream.setTemperature(temperature_inlet, "C");
+    inletStream.setFlowRate(gasFlowRate, "MSm3/day");
+    inletStream.run();
+
+    PressureDrop dpGasStream1 = new PressureDrop("dp element 1", inletStream);
+    dpGasStream1.setPressureDrop(dp, "bara");
+    dpGasStream1.run();
+
+    Stream outletStream = new Stream("outletStream", dpGasStream1.getOutletStream());
+    outletStream.run();
+
+    assertEquals(pressure_inlet - dp, outletStream.getPressure("bara"), 1e-16);
+    assertEquals(34.967499, outletStream.getTemperature("C"), 0.001);
+  }
+}


### PR DESCRIPTION
 The pressure drop unit is used to simulate pressure drops in process plant (eg. pressure drop in pipings etc.). The pressure drop is simulated using a constant enthalpy flash.

Use:
    PressureDrop dpGasStream1 = new PressureDrop("dp element 1", inletStream);
    dpGasStream1.setPressureDrop(dp, "bara");
    dpGasStream1.run();