### PR TITLE
refactor: make abstract implementations of interfaces public

### DIFF
--- a/src/main/java/neqsim/thermo/component/Component.java
+++ b/src/main/java/neqsim/thermo/component/Component.java
@@ -14,7 +14,7 @@ import neqsim.thermo.component.attractiveEosTerm.AttractiveTermInterface;
 import neqsim.thermo.phase.PhaseInterface;
 import neqsim.util.database.NeqSimDataBase;
 
-abstract class Component implements ComponentInterface {
+public abstract class Component implements ComponentInterface {
   private static final long serialVersionUID = 1000;
   static Logger logger = LogManager.getLogger(Component.class);
 

--- a/src/main/java/neqsim/thermo/component/ComponentEos.java
+++ b/src/main/java/neqsim/thermo/component/ComponentEos.java
@@ -34,7 +34,7 @@ import neqsim.thermo.phase.PhaseInterface;
 /**
  * @author Even Solbraa
  */
-abstract class ComponentEos extends Component implements ComponentEosInterface {
+public abstract class ComponentEos extends Component implements ComponentEosInterface {
   private static final long serialVersionUID = 1000;
 
   public double a = 1;

--- a/src/main/java/neqsim/thermo/component/ComponentGE.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGE.java
@@ -15,7 +15,7 @@ import neqsim.thermo.phase.PhaseInterface;
  *
  * @author Even Solbraa
  */
-abstract class ComponentGE extends Component implements ComponentGEInterface {
+public abstract class ComponentGE extends Component implements ComponentGEInterface {
   private static final long serialVersionUID = 1000;
 
   protected double gamma = 0;

--- a/src/main/java/neqsim/thermo/phase/Phase.java
+++ b/src/main/java/neqsim/thermo/phase/Phase.java
@@ -20,7 +20,7 @@ import neqsim.util.exception.InvalidInputException;
  *
  * @author Even Solbraa
  */
-abstract class Phase implements PhaseInterface {
+public abstract class Phase implements PhaseInterface {
   private static final long serialVersionUID = 1000;
   static Logger logger = LogManager.getLogger(Phase.class);
 

--- a/src/main/java/neqsim/thermo/phase/PhaseEos.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseEos.java
@@ -16,7 +16,7 @@ import neqsim.thermo.mixingRule.EosMixingRulesInterface;
  *
  * @author Even Solbraa
  */
-abstract class PhaseEos extends Phase implements PhaseEosInterface {
+public abstract class PhaseEos extends Phase implements PhaseEosInterface {
   private static final long serialVersionUID = 1000;
   static Logger logger = LogManager.getLogger(PhaseEos.class);
 

--- a/src/main/java/neqsim/thermo/system/SystemEos.java
+++ b/src/main/java/neqsim/thermo/system/SystemEos.java
@@ -4,7 +4,7 @@ package neqsim.thermo.system;
  *
  * @author Even Solbraa
  */
-abstract class SystemEos extends neqsim.thermo.system.SystemThermo {
+public abstract class SystemEos extends neqsim.thermo.system.SystemThermo {
   private static final long serialVersionUID = 1000;
 
   /**

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -43,7 +43,7 @@ import neqsim.util.exception.InvalidInputException;
 /**
  * This is the base class of the System classes.
  */
-abstract class SystemThermo implements SystemInterface {
+public abstract class SystemThermo implements SystemInterface {
   private static final long serialVersionUID = 1000;
   static Logger logger = LogManager.getLogger(SystemThermo.class);
 

--- a/src/main/java/neqsim/thermodynamicOperations/flashOps/Flash.java
+++ b/src/main/java/neqsim/thermodynamicOperations/flashOps/Flash.java
@@ -17,7 +17,7 @@ import neqsim.thermodynamicOperations.BaseOperation;
  *
  * @author Even Solbraa
  */
-abstract class Flash extends BaseOperation {
+public abstract class Flash extends BaseOperation {
   private static final long serialVersionUID = 1000;
   static Logger logger = LogManager.getLogger(Flash.class);
 


### PR DESCRIPTION
Needed to expose these abstract classes to generate typing stubs for NeqSimPython