### PR TITLE
chore: add a security-policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+If you discover a security vulnerability in this project, please follow these steps to responsibly disclose it:
+
+1. **Do not** create a public GitHub issue for the vulnerability.
+2. Follow our guideline for Responsible Disclosure Policy at [https://www.equinor.com/about-us/csirt](https://www.equinor.com/about-us/csirt) to report the issue
+
+The following information will help us triage your report more quickly:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer all communications to be in English.


### PR DESCRIPTION
Required to stay complient for public repos in Equinor. Used the Equinor [standard template](https://developer.equinor.com/governance/scm-policy/)