### PR TITLE
build(deps): sync log4j version in all poms

### DIFF
--- a/pomJava21.xml
+++ b/pomJava21.xml
@@ -39,12 +39,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.22.0</version>
+			<version>2.22.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.22.0</version>
+			<version>2.22.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/pomJava8.xml
+++ b/pomJava8.xml
@@ -28,12 +28,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.20.0</version>
+      <version>2.22.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.20.0</version>
+      <version>2.22.1</version>
     </dependency>
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>


### PR DESCRIPTION
Snyk security update for log4j, needed to update in java 8 and java 21 poms aswell. 

Snyk does not support scanning multiple poms, so it is important to keep the dependencies synced to the one scanned with snyk. Should be fixed in the future