### PR TITLE
feat: update flow rate adjuster and fix negative change request if value is small (<1e-12)

### DIFF
--- a/src/main/java/neqsim/thermo/component/Component.java
+++ b/src/main/java/neqsim/thermo/component/Component.java
@@ -499,13 +499,19 @@ public abstract class Component implements ComponentInterface {
   @Override
   public void addMolesChemReac(double dn, double totdn) {
     if (numberOfMoles + totdn < 0 || numberOfMolesInPhase + dn < 0) {
-      String msg = "will lead to negative number of moles of component in phase for component "
-          + getComponentName() + "  who has " + numberOfMolesInPhase
-          + " in phase  and chage request was " + dn;
-      neqsim.util.exception.InvalidInputException ex =
-          new neqsim.util.exception.InvalidInputException(this, "addMolesChemReac", "dn", msg);
-      throw new RuntimeException(ex);
-      // logger.error(ex.getMessage());
+      if (Math.abs(dn) < 1e-12){
+        dn = 0;
+        totdn = 0;
+      }
+      else{
+        String msg = "will lead to negative number of moles of component in phase for component "
+            + getComponentName() + "  who has " + numberOfMolesInPhase
+            + " in phase  and chage request was " + dn;
+        neqsim.util.exception.InvalidInputException ex =
+            new neqsim.util.exception.InvalidInputException(this, "addMolesChemReac", "dn", msg);
+        throw new RuntimeException(ex);
+        // logger.error(ex.getMessage());
+      }
     }
     numberOfMoles += totdn;
     numberOfMolesInPhase += dn;


### PR DESCRIPTION
1. Update flow rate adjuster to accept 2 phases only. 
2. If the change request of a component dn is very small < 1e-12 and causes error (I got errors in splitter that component C12 1e-25 and change request was -2e-25 ..), set change request to 0 in this case. 