### PR TITLE
fix: Heat Exchangers wrong Enthalpy calculations

### DIFF
--- a/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/HeatExchanger.java
+++ b/src/main/java/neqsim/processSimulation/processEquipment/heatExchanger/HeatExchanger.java
@@ -260,6 +260,7 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
+
     if (getSpecification().equals("out stream")) {
       runSpecifiedStream(id);
     } else if (firstTime) {
@@ -278,6 +279,11 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
       // streamToCalculate = 1;
       // streamToSet = 0;
       // }
+      
+      // Make sure these streams to run because of the issues with enthalpy calculations if not run 
+      for (StreamInterface stream : inStream) {
+        stream.run();
+      }
 
       int streamToSet = 1;
       SystemInterface systemOut0 = inStream[streamToSet].getThermoSystem().clone();


### PR DESCRIPTION
When run HEX with UA value equal to 0, I got duty which was > 0 (and temperature change). This pull request fixes the problem by firstly running all the input streams