### PR TITLE
add Xstream serializer and deserializer and test

### DIFF
--- a/src/main/java/neqsim/util/serialization/NeqSimXtream.java
+++ b/src/main/java/neqsim/util/serialization/NeqSimXtream.java
@@ -1,0 +1,57 @@
+package neqsim.util.serialization;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
+
+public class NeqSimXtream {
+  public static Object openNeqsim(String filename) throws IOException {
+    XStream xstream = new XStream();
+    xstream.addPermission(AnyTypePermission.ANY);
+
+    try (BufferedInputStream fin = new BufferedInputStream(new FileInputStream(filename));
+        ZipInputStream zin = new ZipInputStream(fin)) {
+      ZipEntry entry;
+      while ((entry = zin.getNextEntry()) != null) {
+        if ("process.xml".equals(entry.getName())) {
+          try (InputStreamReader reader = new InputStreamReader(zin, "UTF-8")) {
+            return xstream.fromXML(reader);
+          }
+        }
+      }
+      throw new FileNotFoundException("process.xml not found in zip file.");
+    }
+  }
+
+  public static boolean saveNeqsim(Object javaobject, String filename) {
+    XStream xstream = new XStream();
+    xstream.allowTypesByWildcard(new String[] {"neqsim.**"});
+
+    try (BufferedOutputStream fout = new BufferedOutputStream(new FileOutputStream(filename));
+        ZipOutputStream zout = new ZipOutputStream(fout);
+        OutputStreamWriter writer = new OutputStreamWriter(zout, "UTF-8")) {
+      ZipEntry entry = new ZipEntry("process.xml");
+      zout.putNextEntry(entry);
+
+      xstream.toXML(javaobject, writer);
+      writer.flush();
+
+      zout.closeEntry();
+      // writer and zout will be closed automatically by try-with-resources
+      return true;
+    } catch (Exception e) {
+      System.err.println("[saveNeqsim] Error saving file: " + e);
+      return false;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/compressor/SafeSplineSurgeCurveTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/SafeSplineSurgeCurveTest.java
@@ -2,6 +2,7 @@ package neqsim.process.equipment.compressor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.heatexchanger.Cooler;
 import neqsim.process.equipment.mixer.Mixer;
@@ -10,9 +11,11 @@ import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.util.Calculator;
 import neqsim.process.equipment.util.Recycle;
 import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
+import neqsim.util.serialization.NeqSimXtream;
 
 public class SafeSplineSurgeCurveTest {
 
@@ -177,4 +180,17 @@ public class SafeSplineSurgeCurveTest {
     assertEquals(0.04206591466, resyclestream.getFlowRate("kg/hr"), 0.001);
     assertEquals(39001.4299, firstStageCompressor.getInletStream().getFlowRate("kg/hr"), 1);
   }
+
+  // @Test
+  public void testSurgeCurve3() {
+    try {
+      ProcessModel processModel = (ProcessModel) NeqSimXtream.openNeqsim(
+          "/workspaces/neqsim/src/test/java/neqsim/process/equipment/compressor/neqsim_model_base_2.neqsim");
+      processModel.run();
+    } catch (IOException e) {
+      e.printStackTrace();
+      assertTrue(false, "Failed to open neqsim model: " + e.getMessage());
+    }
+  }
+
 }

--- a/src/test/java/neqsim/util/serialization/NeqSimXtreamTest.java
+++ b/src/test/java/neqsim/util/serialization/NeqSimXtreamTest.java
@@ -1,0 +1,87 @@
+package neqsim.util.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import java.io.File;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+public class NeqSimXtreamTest {
+
+  private ProcessSystem testProcess;
+  private String testFileName;
+
+  @TempDir
+  File tempDir;
+
+  @BeforeEach
+  void setUp() {
+    // Create a simple test process system
+    SystemInterface testFluid = new SystemSrkEos(298.15, 50.0);
+    testFluid.addComponent("methane", 10.0);
+    testFluid.addComponent("ethane", 5.0);
+    testFluid.setMixingRule(2);
+
+    testProcess = new ProcessSystem("Test Process");
+    Stream feed = (Stream) testProcess.addUnit("Feed", "stream");
+    feed.setFluid(testFluid);
+
+    testFileName = new File(tempDir, "test_process.neqsim").getAbsolutePath();
+  }
+
+  @AfterEach
+  void cleanup() {
+    File file = new File(testFileName);
+    if (file.exists()) {
+      file.delete();
+    }
+  }
+
+  @Test
+  void testSaveAndOpenNeqsim() {
+    try {
+      // Save the process
+      boolean saved = NeqSimXtream.saveNeqsim(testProcess, testFileName);
+      assertTrue(saved, "Process should be saved successfully");
+
+      // Verify file exists and has content
+      File savedFile = new File(testFileName);
+      assertTrue(savedFile.exists(), "File should exist");
+      assertTrue(savedFile.length() > 0, "File should have content");
+
+      // Open the process
+      Object loadedObject = NeqSimXtream.openNeqsim(testFileName);
+      assertNotNull(loadedObject, "Loaded object should not be null");
+      assertTrue(loadedObject instanceof ProcessSystem, "Should be a ProcessSystem");
+
+      ProcessSystem loadedProcess = (ProcessSystem) loadedObject;
+      assertEquals(testProcess.getName(), loadedProcess.getName(),
+          "Process name should be preserved");
+      assertEquals(testProcess.getUnitOperations().size(), loadedProcess.getUnitOperations().size(),
+          "Number of units should be preserved");
+
+    } catch (IOException e) {
+      fail("Exception thrown: " + e.getMessage());
+    }
+  }
+
+  @Test
+  void testOpenNonExistentFile() {
+    try {
+      NeqSimXtream.openNeqsim("non_existent_file.neqsim");
+      fail("Should throw FileNotFoundException");
+    } catch (IOException e) {
+      // Expected exception
+      assertTrue(e.getMessage().contains("non_existent_file.neqsim"));
+    }
+  }
+}


### PR DESCRIPTION
Description
Added NeqSimXtream.openNeqsim and NeqSimXtream.saveNeqsim methods for loading and saving NEQSim process models as compressed ZIP files with XML (process.xml) inside.
Added and improved unit tests for serialization and deserialization in NeqSimXtreamTest.