### PR TITLE
Burgoyne-Nielsen-Stanko PR correlation

### DIFF
--- a/src/test/java/neqsim/thermo/system/SystemBnsEosParityTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemBnsEosParityTest.java
@@ -8,7 +8,12 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
 public class SystemBnsEosParityTest {
   @Test
   public void testProperties10Bar() {
-    SystemBnsEos sys = new SystemBnsEos(300.0, 10.0, 0.65, 0.02, 0.0, 0.01, 0.0, false);
+    SystemBnsEos sys = new SystemBnsEos();
+    sys.setTemperature(300.0);
+    sys.setPressure(10.0);
+    sys.setAssociatedGas(false);
+    sys.setRelativeDensity(0.65);
+    sys.setComposition(0.02, 0.0, 0.01, 0.0);
     sys.useVolumeCorrection(true);
     sys.setMixingRule(2);
     ThermodynamicOperations ops = new ThermodynamicOperations(sys);
@@ -28,7 +33,12 @@ public class SystemBnsEosParityTest {
 
   @Test
   public void testProperties100Bar() {
-    SystemBnsEos sys = new SystemBnsEos(300.0, 100.0, 0.65, 0.02, 0.0, 0.01, 0.0, false);
+    SystemBnsEos sys = new SystemBnsEos();
+    sys.setTemperature(300.0);
+    sys.setPressure(100.0);
+    sys.setAssociatedGas(false);
+    sys.setRelativeDensity(0.65);
+    sys.setComposition(0.02, 0.0, 0.01, 0.0);
     sys.useVolumeCorrection(true);
     sys.setMixingRule(2);
     ThermodynamicOperations ops = new ThermodynamicOperations(sys);

--- a/src/test/java/neqsim/thermo/system/SystemBnsEosTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemBnsEosTest.java
@@ -1,13 +1,19 @@
 package neqsim.thermo.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.junit.jupiter.api.Test;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 public class SystemBnsEosTest {
   @Test
   public void testZFactor100Bar() {
-    SystemBnsEos sys = new SystemBnsEos(300.0, 100.0, 0.65, 0.02, 0.0, 0.01, 0.0, false);
+    SystemBnsEos sys = new SystemBnsEos();
+    sys.setTemperature(300.0);
+    sys.setPressure(100.0);
+    sys.setAssociatedGas(false);
+    sys.setRelativeDensity(0.65);
+    sys.setComposition(0.02, 0.0, 0.01, 0.0);
     sys.useVolumeCorrection(true);
     sys.setMixingRule(2);
     ThermodynamicOperations ops = new ThermodynamicOperations(sys);
@@ -18,12 +24,31 @@ public class SystemBnsEosTest {
 
   @Test
   public void testZFactor10Bar() {
-    SystemBnsEos sys = new SystemBnsEos(300.0, 10.0, 0.65, 0.02, 0.0, 0.01, 0.0, false);
+    SystemBnsEos sys = new SystemBnsEos();
+    sys.setTemperature(300.0);
+    sys.setPressure(10.0);
+    sys.setAssociatedGas(false);
+    sys.setRelativeDensity(0.65);
+    sys.setComposition(0.02, 0.0, 0.01, 0.0);
     sys.useVolumeCorrection(true);
     sys.setMixingRule(2);
     ThermodynamicOperations ops = new ThermodynamicOperations(sys);
     ops.TPflash();
     double z = sys.getPhase(0).getZ();
     assertEquals(0.9741308690957756, z, 0.01);
+  }
+
+  @Test
+  public void testPseudoCriticalUpdates() {
+    SystemBnsEos sys = new SystemBnsEos();
+    sys.setTemperature(300.0);
+    sys.setPressure(100.0);
+    sys.setAssociatedGas(false);
+    sys.setRelativeDensity(0.65);
+    sys.setComposition(0.02, 0.0, 0.01, 0.0);
+    double tc1 = sys.getPhase(0).getComponent("HC").getTC();
+    sys.setRelativeDensity(0.70);
+    double tc2 = sys.getPhase(0).getComponent("HC").getTC();
+    assertNotEquals(tc1, tc2);
   }
 }


### PR DESCRIPTION
Burgoyne-Nielsen-Stanko PR correlation

allow BNS fluids to be created without preset composition and update pseudo-critical properties when composition or relative density changes
