### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release_with_jars.yml
+++ b/.github/workflows/release_with_jars.yml
@@ -1,4 +1,6 @@
 name: Create release (draft)
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:  
@@ -116,6 +118,8 @@ jobs:
   create_release:
     name: Create release v${{ needs.get_versions.outputs.version_8 }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [get_versions, compile_java_8, compile_java_11, compile_java_21]
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/neqsim/security/code-scanning/13](https://github.com/equinor/neqsim/security/code-scanning/13)

The optimal fix is to add a `permissions` key explicitly at the **workflow root** (top-level) in `.github/workflows/release_with_jars.yml`, which sets a default least-privilege permission for all jobs. The strictest sensible default is `contents: read`. Then, for the `create_release` job—which creates and modifies releases and therefore requires `contents: write`—override the permissions at the job level. This pattern ensures all jobs use only the minimum permissions they require.

Edits needed:
- Insert a block at the root of the workflow file (just after `name:` or `on:`) with `permissions: contents: read`.
- Insert a `permissions:` block in the `create_release` job (just after `runs-on` or `needs`) with `contents: write`.

No imports or additional methods are required as this concerns workflow YAML only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
