### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify_build.yml
+++ b/.github/workflows/verify_build.yml
@@ -1,4 +1,6 @@
 name: Run build, test and javadoc
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:  


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/neqsim/security/code-scanning/17](https://github.com/equinor/neqsim/security/code-scanning/17)

To fix this issue, you should add a `permissions` block at the root of the workflow, directly under the workflow `name` and before `on`, so that it applies to all jobs unless a more specific block is added. By specifying `permissions: contents: read`, you ensure the workflow and its jobs only have read access to repository contents via the GITHUB_TOKEN (i.e., reading code, but not pushing, releasing, or writing to contents, issues, etc.), which is the least privilege necessary for all demonstrated workflow steps. No steps require write access to contents, issues, or other repository resources. Place the following YAML block right after the `name:` stanza, on line 2. No further modifications are necessary to the job definitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
