### PR TITLE
Integrate ejector mechanical design with MechanicalDesign

### DIFF
--- a/src/main/java/neqsim/process/equipment/ejector/Ejector.java
+++ b/src/main/java/neqsim/process/equipment/ejector/Ejector.java
@@ -1,27 +1,52 @@
 package neqsim.process.equipment.ejector;
 
 import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.mechanicaldesign.ejector.EjectorMechanicalDesign;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
  * Ejector class represents an ejector in a process simulation. It mixes a motive stream with a
- * suction stream and calculates the resulting mixed stream.
- *
- * @author esol
+ * suction stream and calculates the resulting mixed stream using a quasi one-dimensional
+ * formulation. The implementation combines energy and momentum balances commonly used in
+ * steam-jet ejector design as summarised by Keenan et al. (1950) and ESDU 86030.
  */
 public class Ejector extends ProcessEquipmentBaseClass {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+
+  private static final Logger logger = LogManager.getLogger(Ejector.class);
 
   private StreamInterface motiveStream;
   private StreamInterface suctionStream;
   private StreamInterface mixedStream;
 
   private double dischargePressure;
-  private double efficiencyIsentropic = 0.75; // default nozzle mixing efficiency
+  private double mixingPressure = Double.NaN;
+  private double efficiencyIsentropic = 0.75; // default nozzle efficiency
   private double diffuserEfficiency = 0.8; // diffuser pressure recovery efficiency
-  private double throatArea = 0.001; // default throat area [m2]
+
+  private double designSuctionVelocity = 0.0; // estimated from operating conditions unless set
+  private double designDiffuserOutletVelocity = 0.0; // estimated from operating conditions
+  private boolean designSuctionVelocityOverride = false;
+  private boolean designDiffuserVelocityOverride = false;
+
+  private double suctionConnectionLength = 0.0; // m, optional straight pipe upstream
+  private double dischargeConnectionLength = 0.0; // m, optional straight pipe downstream
+  private boolean suctionConnectionLengthOverride = false;
+  private boolean dischargeConnectionLengthOverride = false;
+
+  private transient EjectorMechanicalDesign mechanicalDesign;
+
+  private static final double BAR_TO_PA = 1.0e5;
+  private static final double DEFAULT_NOZZLE_LENGTH_FACTOR = 3.0; // ~3x throat diameter
+  private static final double DEFAULT_SUCTION_LENGTH_FACTOR = 2.5; // bellmouth and settling
+  private static final double DEFAULT_MIXING_LENGTH_FACTOR = 4.0; // per Keenan et al.
+  private static final double DEFAULT_DIFFUSER_LENGTH_FACTOR = 6.0; // gradual pressure recovery
 
   /**
    * Constructs an Ejector with the specified name, motive stream, and suction stream.
@@ -78,7 +103,79 @@ public class Ejector extends ProcessEquipmentBaseClass {
    * @param throatArea a double
    */
   public void setThroatArea(double throatArea) {
-    this.throatArea = throatArea;
+    // Retained for backwards compatibility. The area is now calculated from the
+    // hydraulic design and therefore this setter is deprecated.
+  }
+
+  /**
+   * Sets the target mixing pressure within the ejector. If not set the suction pressure is used.
+   *
+   * @param mixingPressure the mixing pressure in bara
+   */
+  public void setMixingPressure(double mixingPressure) {
+    this.mixingPressure = mixingPressure;
+  }
+
+  /**
+   * Sets the design suction velocity used when calculating mechanical dimensions.
+   *
+   * @param velocity velocity in m/s
+   */
+  public void setDesignSuctionVelocity(double velocity) {
+    this.designSuctionVelocity = velocity;
+    this.designSuctionVelocityOverride = true;
+  }
+
+  /**
+   * Sets the design diffuser outlet velocity used when calculating mechanical dimensions.
+   *
+   * @param velocity velocity in m/s
+   */
+  public void setDesignDiffuserOutletVelocity(double velocity) {
+    this.designDiffuserOutletVelocity = velocity;
+    this.designDiffuserVelocityOverride = true;
+  }
+
+  /**
+   * Sets the straight length of suction piping to include in total volume calculations.
+   *
+   * @param length length in metres
+   */
+  public void setSuctionConnectionLength(double length) {
+    this.suctionConnectionLength = Math.max(length, 0.0);
+    this.suctionConnectionLengthOverride = true;
+  }
+
+  /**
+   * Sets the straight length of discharge piping to include in total volume calculations.
+   *
+   * @param length length in metres
+   */
+  public void setDischargeConnectionLength(double length) {
+    this.dischargeConnectionLength = Math.max(length, 0.0);
+    this.dischargeConnectionLengthOverride = true;
+  }
+
+  @Override
+  public void initMechanicalDesign() {
+    mechanicalDesign = new EjectorMechanicalDesign(this);
+  }
+
+  @Override
+  public EjectorMechanicalDesign getMechanicalDesign() {
+    if (mechanicalDesign == null) {
+      initMechanicalDesign();
+    }
+    return mechanicalDesign;
+  }
+
+  /**
+   * Backwards compatible accessor for mechanical design results.
+   *
+   * @return the ejector mechanical design container
+   */
+  public EjectorMechanicalDesign getDesignResult() {
+    return getMechanicalDesign();
   }
 
   /** {@inheritDoc} */
@@ -86,64 +183,143 @@ public class Ejector extends ProcessEquipmentBaseClass {
   public void run(UUID id) {
     motiveStream.run();
     suctionStream.run();
-    // Mixing streams at constant discharge pressure
-    motiveStream.setPressure(dischargePressure);
-    suctionStream.setPressure(dischargePressure);
-
-    double hMotive = motiveStream.getFluid().getEnthalpy();
-    double hSuction = suctionStream.getFluid().getEnthalpy();
-
-    double mDotMotive = motiveStream.getFlowRate("kg/s");
-    double mDotSuction = suctionStream.getFlowRate("kg/s");
-
-    double idealMixedEnthalpy =
-        calculateIdealMixedEnthalpy(hMotive, hSuction, mDotMotive, mDotSuction);
-    double hMixedActual = calculateActualMixedEnthalpy(hMotive, idealMixedEnthalpy);
-
     mixedStream = motiveStream.clone();
-    // mixedStream.add(suctionStream);
-    mixedStream.getFluid().setTotalFlowRate(mDotMotive + mDotSuction, "kg/s");
-    // mixedStream.getFluid().setEnthalpy(hMixedActual, "J/kg");
-    mixedStream.setPressure(dischargePressure);
-    // mixedStream.runPHflash();
 
-    checkChokedFlow(mDotMotive, mDotSuction);
+    double suctionPressure = suctionStream.getPressure("bara");
+    double mDotMotive = motiveStream.getFlowRate("kg/sec");
+    double mDotSuction = suctionStream.getFlowRate("kg/sec");
 
-    double hActualDiffuserOut = calculateDiffuserOutput(hMixedActual);
-    // mixedStream.getFluid().setEnthalpy(hActualDiffuserOut, "J/kg");
-    // mixedStream.runPHflash();
+    double localMixingPressure = Double.isNaN(mixingPressure)
+        ? estimateDefaultMixingPressure(suctionPressure, dischargePressure, mDotMotive, mDotSuction)
+        : mixingPressure;
 
-    // Update final state
-    mixedStream.setPressure(mixedStream.getFluid().getPressure());
-  }
-
-  private double calculateIdealMixedEnthalpy(double hMotive, double hSuction, double mDotMotive,
-      double mDotSuction) {
-    return (hMotive * mDotMotive + hSuction * mDotSuction) / (mDotMotive + mDotSuction);
-  }
-
-  private double calculateActualMixedEnthalpy(double hMotive, double idealMixedEnthalpy) {
-    return hMotive + (idealMixedEnthalpy - hMotive) / efficiencyIsentropic;
-  }
-
-  private void checkChokedFlow(double mDotMotive, double mDotSuction) {
-    double density = mixedStream.getFluid().getDensity("kg/m3");
-    double speedOfSound = mixedStream.getFluid().getSoundSpeed();
-    double velocity = (mDotMotive + mDotSuction) / (density * throatArea);
-    double machNumber = velocity / speedOfSound;
-
-    if (machNumber >= 1.0) {
-      System.out.println("Choked flow detected! Mach number: " + machNumber);
-    } else {
-      System.out.println("Flow not choked. Mach number: " + machNumber);
+    if (localMixingPressure > suctionPressure) {
+      logger.warn("Mixing pressure {} bara exceeds suction pressure {} bara – using suction "
+          + "pressure for mixing calculations.", localMixingPressure, suctionPressure);
+      localMixingPressure = suctionPressure;
     }
-  }
 
-  private double calculateDiffuserOutput(double hMixedActual) {
-    double vInlet = (motiveStream.getFlowRate("kg/s") + suctionStream.getFlowRate("kg/s"))
-        / (mixedStream.getFluid().getDensity("kg/m3") * throatArea);
-    double hIdealDiffuserOut = hMixedActual + 0.5 * vInlet * vInlet;
-    return hMixedActual + (hIdealDiffuserOut - hMixedActual) / diffuserEfficiency;
+    double mDotTotal = mDotMotive + mDotSuction;
+
+    if (mDotTotal <= 0.0) {
+      mixedStream.setThermoSystem(motiveStream.getThermoSystem().clone());
+      mixedStream.setCalculationIdentifier(id);
+      setCalculationIdentifier(id);
+      getMechanicalDesign().resetDesign();
+      return;
+    }
+
+    // Motive nozzle calculation
+    SystemInterface motiveNozzle = motiveStream.getThermoSystem().clone();
+    double entropyMotive = motiveNozzle.getEntropy();
+    double hMotiveIn = motiveNozzle.getEnthalpy("J/kg");
+    motiveNozzle.setPressure(localMixingPressure, "bara");
+    ThermodynamicOperations nozzleOps = new ThermodynamicOperations(motiveNozzle);
+    nozzleOps.PSflash(entropyMotive);
+    double hMotiveIsentropic = motiveNozzle.getEnthalpy("J/kg");
+    double hMotiveActual =
+        hMotiveIn - efficiencyIsentropic * (hMotiveIn - hMotiveIsentropic);
+    nozzleOps.PHflash(hMotiveActual, "J/kg");
+    motiveNozzle.init(3);
+    double deltaHNozzle = Math.max(hMotiveIn - hMotiveActual, 0.0);
+    double velocityNozzle = Math.sqrt(2.0 * deltaHNozzle);
+    double rhoNozzle = Math.max(motiveNozzle.getDensity("kg/m3"), 1.0e-9);
+    double motiveNozzleArea = mDotMotive / (rhoNozzle * Math.max(velocityNozzle, 1.0e-6));
+
+    // Suction flow accelerated to mixing section
+    SystemInterface suctionAtMixing = suctionStream.getThermoSystem().clone();
+    double hSuctionIn = suctionAtMixing.getEnthalpy("J/kg");
+    suctionAtMixing.setPressure(localMixingPressure, "bara");
+    ThermodynamicOperations suctionOps = new ThermodynamicOperations(suctionAtMixing);
+    suctionOps.PHflash(hSuctionIn, "J/kg");
+    suctionAtMixing.init(3);
+    double rhoSuction = Math.max(suctionAtMixing.getDensity("kg/m3"), 1.0e-9);
+
+    double localDesignSuctionVelocity = designSuctionVelocityOverride ? designSuctionVelocity
+        : estimateDesignSuctionVelocity(suctionPressure, dischargePressure, rhoSuction, mDotSuction);
+    localDesignSuctionVelocity = Math.max(localDesignSuctionVelocity, 1.0e-6);
+
+    double suctionArea = mDotSuction / (rhoSuction * localDesignSuctionVelocity);
+    double velocitySuction =
+        mDotSuction / (rhoSuction * Math.max(suctionArea, 1.0e-9));
+
+    double totalEnthalpyMotive = hMotiveActual + 0.5 * velocityNozzle * velocityNozzle;
+    double totalEnthalpySuction = hSuctionIn + 0.5 * velocitySuction * velocitySuction;
+
+    double mixingVelocity =
+        (mDotMotive * velocityNozzle + mDotSuction * velocitySuction) / mDotTotal;
+    double mixedTotalEnthalpy =
+        (mDotMotive * totalEnthalpyMotive + mDotSuction * totalEnthalpySuction) / mDotTotal;
+    double mixedStaticEnthalpy =
+        mixedTotalEnthalpy - 0.5 * mixingVelocity * mixingVelocity;
+
+    SystemInterface mixedFluid = motiveStream.getThermoSystem().clone();
+    mixedFluid.addFluid(suctionStream.getThermoSystem());
+    mixedFluid.setPressure(localMixingPressure, "bara");
+    ThermodynamicOperations mixingOps = new ThermodynamicOperations(mixedFluid);
+    mixingOps.PHflash(mixedStaticEnthalpy, "J/kg");
+    mixedFluid.init(3);
+    double rhoMixing = Math.max(mixedFluid.getDensity("kg/m3"), 1.0e-9);
+    double mixingArea = mDotTotal / (rhoMixing * Math.max(mixingVelocity, 1.0e-6));
+
+    // Diffuser recovery
+    double recoveredSpecificEnergy = diffuserEfficiency * 0.5 * mixingVelocity * mixingVelocity;
+    double staticEnthalpyBeforeDiffuser = mixedStaticEnthalpy + recoveredSpecificEnergy;
+
+    mixedFluid.setPressure(dischargePressure, "bara");
+    ThermodynamicOperations diffuserOps = new ThermodynamicOperations(mixedFluid);
+    diffuserOps.PHflash(staticEnthalpyBeforeDiffuser, "J/kg");
+    mixedFluid.init(3);
+    double rhoDiffuser = Math.max(mixedFluid.getDensity("kg/m3"), 1.0e-9);
+
+    double localDesignDiffuserOutletVelocity = designDiffuserVelocityOverride
+        ? designDiffuserOutletVelocity
+        : estimateDesignDiffuserOutletVelocity(localMixingPressure, dischargePressure,
+            rhoDiffuser, mDotTotal);
+    localDesignDiffuserOutletVelocity = Math.max(localDesignDiffuserOutletVelocity, 1.0e-6);
+
+    double diffuserArea = mDotTotal / (rhoDiffuser * localDesignDiffuserOutletVelocity);
+    double diffuserVelocity =
+        mDotTotal / (rhoDiffuser * Math.max(diffuserArea, 1.0e-9));
+    double finalStaticEnthalpy =
+        staticEnthalpyBeforeDiffuser - 0.5 * diffuserVelocity * diffuserVelocity;
+
+    diffuserOps.PHflash(finalStaticEnthalpy, "J/kg");
+    mixedFluid.init(3);
+
+    double motiveNozzleDiameter = diameterFromArea(motiveNozzleArea);
+    double suctionDiameter = diameterFromArea(suctionArea);
+    double mixingDiameter = diameterFromArea(mixingArea);
+    double diffuserDiameter = diameterFromArea(diffuserArea);
+
+    double nozzleLength = estimateLength(motiveNozzleDiameter, DEFAULT_NOZZLE_LENGTH_FACTOR);
+    double suctionLength = estimateLength(suctionDiameter, DEFAULT_SUCTION_LENGTH_FACTOR);
+    double mixingLength = estimateLength(mixingDiameter, DEFAULT_MIXING_LENGTH_FACTOR);
+    double diffuserLength = estimateLength(diffuserDiameter, DEFAULT_DIFFUSER_LENGTH_FACTOR);
+
+    double localSuctionConnectionLength = suctionConnectionLengthOverride ? suctionConnectionLength
+        : estimateSuctionConnectionLength(suctionDiameter, suctionPressure, dischargePressure);
+    double localDischargeConnectionLength = dischargeConnectionLengthOverride
+        ? dischargeConnectionLength
+        : estimateDischargeConnectionLength(diffuserDiameter, localMixingPressure,
+            dischargePressure);
+
+    double bodyVolume = cylinderVolume(motiveNozzleArea, nozzleLength)
+        + cylinderVolume(suctionArea, suctionLength) + cylinderVolume(mixingArea, mixingLength)
+        + cylinderVolume(diffuserArea, diffuserLength);
+
+    double connectedPipingVolume = cylinderVolume(suctionArea, localSuctionConnectionLength)
+        + cylinderVolume(diffuserArea, localDischargeConnectionLength);
+
+    mixedStream.setThermoSystem(mixedFluid);
+    mixedStream.setCalculationIdentifier(id);
+    setCalculationIdentifier(id);
+
+    getMechanicalDesign().updateDesign(localMixingPressure, motiveNozzleArea, velocityNozzle,
+        suctionArea, velocitySuction, mixingArea, mixingVelocity, diffuserArea, diffuserVelocity,
+        getEntrainmentRatio(), nozzleLength, suctionLength, mixingLength, diffuserLength,
+        bodyVolume, connectedPipingVolume, localSuctionConnectionLength,
+        localDischargeConnectionLength);
   }
 
   /**
@@ -165,6 +341,99 @@ public class Ejector extends ProcessEquipmentBaseClass {
    * @return a double
    */
   public double getEntrainmentRatio() {
-    return suctionStream.getFlowRate("kg/s") / motiveStream.getFlowRate("kg/s");
+    return suctionStream.getFlowRate("kg/sec") / motiveStream.getFlowRate("kg/sec");
+  }
+
+  private static double diameterFromArea(double area) {
+    if (area <= 0.0) {
+      return 0.0;
+    }
+    return Math.sqrt(4.0 * area / Math.PI);
+  }
+
+  private static double estimateLength(double diameter, double factor) {
+    if (diameter <= 0.0 || factor <= 0.0) {
+      return 0.0;
+    }
+    return factor * diameter;
+  }
+
+  private static double cylinderVolume(double area, double length) {
+    if (area <= 0.0 || length <= 0.0) {
+      return 0.0;
+    }
+    return area * length;
+  }
+
+  private double estimateDefaultMixingPressure(double suctionPressure, double dischargePressure,
+      double mDotMotive, double mDotSuction) {
+    if (suctionPressure <= 0.0) {
+      return Math.max(dischargePressure, 0.0);
+    }
+
+    double entrainmentRatio = mDotMotive > 1.0e-9 ? Math.max(mDotSuction, 0.0) / mDotMotive : 1.0;
+    double clampedRatio = clamp(entrainmentRatio, 0.0, 5.0);
+    double pressureLift = Math.max(dischargePressure - suctionPressure, 0.0);
+    double pressureDrop = pressureLift * (0.1 + 0.03 * clampedRatio);
+    double suctionMargin = suctionPressure * 0.03;
+    double estimated = suctionPressure - Math.max(pressureDrop, suctionMargin);
+    double minimumPressure = Math.max(0.01, suctionPressure * 0.4);
+    return clamp(estimated, minimumPressure, suctionPressure);
+  }
+
+  private double estimateDesignSuctionVelocity(double suctionPressure, double dischargePressure,
+      double rhoSuction, double mDotSuction) {
+    double density = Math.max(rhoSuction, 1.0e-6);
+    double availableLiftPa = Math.max((dischargePressure - suctionPressure) * BAR_TO_PA, 0.0);
+    double targetDynamic = Math.max(availableLiftPa * 0.02, 500.0);
+    double baseline = Math.sqrt(2.0 * targetDynamic / density);
+    double volumetricFlow = mDotSuction > 0.0 ? mDotSuction / density : 0.0;
+    double flowScaling = volumetricFlow > 0.0
+        ? 50.0 + 30.0 * Math.log10(1.0 + volumetricFlow * 5.0)
+        : 50.0;
+    double blended = 0.6 * baseline + 0.4 * flowScaling;
+    return clamp(blended, 25.0, 120.0);
+  }
+
+  private double estimateDesignDiffuserOutletVelocity(double mixingPressure,
+      double dischargePressure, double rhoDiffuser, double mDotTotal) {
+    double density = Math.max(rhoDiffuser, 1.0e-6);
+    double pressureRecoveryPa = Math.max((dischargePressure - mixingPressure) * BAR_TO_PA, 0.0);
+    double targetDynamic = Math.max(pressureRecoveryPa * 0.01, 250.0);
+    double baseline = Math.sqrt(2.0 * targetDynamic / density);
+    double volumetricFlow = mDotTotal > 0.0 ? mDotTotal / density : 0.0;
+    double flowScaling = volumetricFlow > 0.0
+        ? 20.0 + 15.0 * Math.log10(1.0 + volumetricFlow * 4.0)
+        : 25.0;
+    double blended = 0.5 * baseline + 0.5 * flowScaling;
+    return clamp(blended, 10.0, 60.0);
+  }
+
+  private double estimateSuctionConnectionLength(double suctionDiameter, double suctionPressure,
+      double dischargePressure) {
+    if (suctionDiameter <= 0.0) {
+      return 0.0;
+    }
+    double pressureRatio = dischargePressure > 0.0 && suctionPressure > 0.0
+        ? dischargePressure / suctionPressure
+        : 1.0;
+    double factor = 3.0 + 1.5 * clamp(pressureRatio - 1.0, 0.0, 3.0);
+    return factor * suctionDiameter;
+  }
+
+  private double estimateDischargeConnectionLength(double diffuserDiameter,
+      double mixingPressure, double dischargePressure) {
+    if (diffuserDiameter <= 0.0) {
+      return 0.0;
+    }
+    double pressureRatio = dischargePressure > 0.0 && mixingPressure > 0.0
+        ? dischargePressure / mixingPressure
+        : 1.0;
+    double factor = 5.0 + 2.0 * clamp(pressureRatio - 1.0, 0.0, 3.0);
+    return factor * diffuserDiameter;
+  }
+
+  private static double clamp(double value, double min, double max) {
+    return Math.max(min, Math.min(value, max));
   }
 }

--- a/src/main/java/neqsim/process/equipment/ejector/EjectorDesignResult.java
+++ b/src/main/java/neqsim/process/equipment/ejector/EjectorDesignResult.java
@@ -1,0 +1,163 @@
+package neqsim.process.equipment.ejector;
+
+/**
+ * Immutable container for mechanical design results of an ejector.
+ */
+public final class EjectorDesignResult {
+  private final double mixingPressure;
+  private final double motiveNozzleThroatArea;
+  private final double motiveNozzleExitVelocity;
+  private final double suctionInletArea;
+  private final double suctionInletVelocity;
+  private final double mixingChamberArea;
+  private final double mixingChamberVelocity;
+  private final double diffuserOutletArea;
+  private final double diffuserOutletVelocity;
+  private final double entrainmentRatio;
+  private final double motiveNozzleEffectiveLength;
+  private final double suctionInletLength;
+  private final double mixingChamberLength;
+  private final double diffuserOutletLength;
+  private final double bodyVolume;
+  private final double connectedPipingVolume;
+  private final double suctionConnectionLength;
+  private final double dischargeConnectionLength;
+
+  /**
+   * Creates a new design result.
+   */
+  public EjectorDesignResult(double mixingPressure, double motiveNozzleThroatArea,
+      double motiveNozzleExitVelocity,
+      double suctionInletArea, double suctionInletVelocity, double mixingChamberArea,
+      double mixingChamberVelocity, double diffuserOutletArea, double diffuserOutletVelocity,
+      double entrainmentRatio, double motiveNozzleEffectiveLength, double suctionInletLength,
+      double mixingChamberLength, double diffuserOutletLength, double bodyVolume,
+      double connectedPipingVolume, double suctionConnectionLength,
+      double dischargeConnectionLength) {
+    this.mixingPressure = mixingPressure;
+    this.motiveNozzleThroatArea = motiveNozzleThroatArea;
+    this.motiveNozzleExitVelocity = motiveNozzleExitVelocity;
+    this.suctionInletArea = suctionInletArea;
+    this.suctionInletVelocity = suctionInletVelocity;
+    this.mixingChamberArea = mixingChamberArea;
+    this.mixingChamberVelocity = mixingChamberVelocity;
+    this.diffuserOutletArea = diffuserOutletArea;
+    this.diffuserOutletVelocity = diffuserOutletVelocity;
+    this.entrainmentRatio = entrainmentRatio;
+    this.motiveNozzleEffectiveLength = motiveNozzleEffectiveLength;
+    this.suctionInletLength = suctionInletLength;
+    this.mixingChamberLength = mixingChamberLength;
+    this.diffuserOutletLength = diffuserOutletLength;
+    this.bodyVolume = bodyVolume;
+    this.connectedPipingVolume = connectedPipingVolume;
+    this.suctionConnectionLength = suctionConnectionLength;
+    this.dischargeConnectionLength = dischargeConnectionLength;
+  }
+
+  /**
+   * Returns an empty design result.
+   */
+  public static EjectorDesignResult empty() {
+    return new EjectorDesignResult(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  }
+
+  public double getMixingPressure() {
+    return mixingPressure;
+  }
+
+  public double getMotiveNozzleThroatArea() {
+    return motiveNozzleThroatArea;
+  }
+
+  public double getMotiveNozzleExitVelocity() {
+    return motiveNozzleExitVelocity;
+  }
+
+  public double getMotiveNozzleDiameter() {
+    return areaToDiameter(motiveNozzleThroatArea);
+  }
+
+  public double getSuctionInletArea() {
+    return suctionInletArea;
+  }
+
+  public double getSuctionInletVelocity() {
+    return suctionInletVelocity;
+  }
+
+  public double getSuctionInletDiameter() {
+    return areaToDiameter(suctionInletArea);
+  }
+
+  public double getMixingChamberArea() {
+    return mixingChamberArea;
+  }
+
+  public double getMixingChamberVelocity() {
+    return mixingChamberVelocity;
+  }
+
+  public double getMixingChamberDiameter() {
+    return areaToDiameter(mixingChamberArea);
+  }
+
+  public double getDiffuserOutletArea() {
+    return diffuserOutletArea;
+  }
+
+  public double getDiffuserOutletVelocity() {
+    return diffuserOutletVelocity;
+  }
+
+  public double getDiffuserOutletDiameter() {
+    return areaToDiameter(diffuserOutletArea);
+  }
+
+  public double getEntrainmentRatio() {
+    return entrainmentRatio;
+  }
+
+  public double getMotiveNozzleEffectiveLength() {
+    return motiveNozzleEffectiveLength;
+  }
+
+  public double getSuctionInletLength() {
+    return suctionInletLength;
+  }
+
+  public double getMixingChamberLength() {
+    return mixingChamberLength;
+  }
+
+  public double getDiffuserOutletLength() {
+    return diffuserOutletLength;
+  }
+
+  public double getBodyVolume() {
+    return bodyVolume;
+  }
+
+  public double getConnectedPipingVolume() {
+    return connectedPipingVolume;
+  }
+
+  public double getTotalVolume() {
+    return bodyVolume + connectedPipingVolume;
+  }
+
+  public double getSuctionConnectionLength() {
+    return suctionConnectionLength;
+  }
+
+  public double getDischargeConnectionLength() {
+    return dischargeConnectionLength;
+  }
+
+  private static double areaToDiameter(double area) {
+    if (area <= 0.0) {
+      return 0.0;
+    }
+    return Math.sqrt(4.0 * area / Math.PI);
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/ejector/EjectorMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/ejector/EjectorMechanicalDesign.java
@@ -1,0 +1,185 @@
+package neqsim.process.mechanicaldesign.ejector;
+
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.mechanicaldesign.MechanicalDesign;
+
+/**
+ * Mechanical design container for ejector sizing results.
+ */
+public class EjectorMechanicalDesign extends MechanicalDesign {
+  private static final long serialVersionUID = 1L;
+
+  private double mixingPressure;
+  private double motiveNozzleThroatArea;
+  private double motiveNozzleExitVelocity;
+  private double suctionInletArea;
+  private double suctionInletVelocity;
+  private double mixingChamberArea;
+  private double mixingChamberVelocity;
+  private double diffuserOutletArea;
+  private double diffuserOutletVelocity;
+  private double entrainmentRatio;
+  private double motiveNozzleEffectiveLength;
+  private double suctionInletLength;
+  private double mixingChamberLength;
+  private double diffuserOutletLength;
+  private double bodyVolume;
+  private double connectedPipingVolume;
+  private double suctionConnectionLength;
+  private double dischargeConnectionLength;
+
+  public EjectorMechanicalDesign(ProcessEquipmentInterface equipment) {
+    super(equipment);
+  }
+
+  /** Reset stored results. */
+  public void resetDesign() {
+    mixingPressure = 0.0;
+    motiveNozzleThroatArea = 0.0;
+    motiveNozzleExitVelocity = 0.0;
+    suctionInletArea = 0.0;
+    suctionInletVelocity = 0.0;
+    mixingChamberArea = 0.0;
+    mixingChamberVelocity = 0.0;
+    diffuserOutletArea = 0.0;
+    diffuserOutletVelocity = 0.0;
+    entrainmentRatio = 0.0;
+    motiveNozzleEffectiveLength = 0.0;
+    suctionInletLength = 0.0;
+    mixingChamberLength = 0.0;
+    diffuserOutletLength = 0.0;
+    bodyVolume = 0.0;
+    connectedPipingVolume = 0.0;
+    suctionConnectionLength = 0.0;
+    dischargeConnectionLength = 0.0;
+  }
+
+  /**
+   * Store the latest mechanical design results from an ejector calculation.
+   */
+  public void updateDesign(double mixingPressure, double motiveNozzleThroatArea,
+      double motiveNozzleExitVelocity, double suctionInletArea, double suctionInletVelocity,
+      double mixingChamberArea, double mixingChamberVelocity, double diffuserOutletArea,
+      double diffuserOutletVelocity, double entrainmentRatio,
+      double motiveNozzleEffectiveLength, double suctionInletLength, double mixingChamberLength,
+      double diffuserOutletLength, double bodyVolume, double connectedPipingVolume,
+      double suctionConnectionLength, double dischargeConnectionLength) {
+    this.mixingPressure = mixingPressure;
+    this.motiveNozzleThroatArea = motiveNozzleThroatArea;
+    this.motiveNozzleExitVelocity = motiveNozzleExitVelocity;
+    this.suctionInletArea = suctionInletArea;
+    this.suctionInletVelocity = suctionInletVelocity;
+    this.mixingChamberArea = mixingChamberArea;
+    this.mixingChamberVelocity = mixingChamberVelocity;
+    this.diffuserOutletArea = diffuserOutletArea;
+    this.diffuserOutletVelocity = diffuserOutletVelocity;
+    this.entrainmentRatio = entrainmentRatio;
+    this.motiveNozzleEffectiveLength = motiveNozzleEffectiveLength;
+    this.suctionInletLength = suctionInletLength;
+    this.mixingChamberLength = mixingChamberLength;
+    this.diffuserOutletLength = diffuserOutletLength;
+    this.bodyVolume = bodyVolume;
+    this.connectedPipingVolume = connectedPipingVolume;
+    this.suctionConnectionLength = suctionConnectionLength;
+    this.dischargeConnectionLength = dischargeConnectionLength;
+  }
+
+  public double getMixingPressure() {
+    return mixingPressure;
+  }
+
+  public double getMotiveNozzleThroatArea() {
+    return motiveNozzleThroatArea;
+  }
+
+  public double getMotiveNozzleExitVelocity() {
+    return motiveNozzleExitVelocity;
+  }
+
+  public double getMotiveNozzleDiameter() {
+    return areaToDiameter(motiveNozzleThroatArea);
+  }
+
+  public double getSuctionInletArea() {
+    return suctionInletArea;
+  }
+
+  public double getSuctionInletVelocity() {
+    return suctionInletVelocity;
+  }
+
+  public double getSuctionInletDiameter() {
+    return areaToDiameter(suctionInletArea);
+  }
+
+  public double getMixingChamberArea() {
+    return mixingChamberArea;
+  }
+
+  public double getMixingChamberVelocity() {
+    return mixingChamberVelocity;
+  }
+
+  public double getMixingChamberDiameter() {
+    return areaToDiameter(mixingChamberArea);
+  }
+
+  public double getDiffuserOutletArea() {
+    return diffuserOutletArea;
+  }
+
+  public double getDiffuserOutletVelocity() {
+    return diffuserOutletVelocity;
+  }
+
+  public double getDiffuserOutletDiameter() {
+    return areaToDiameter(diffuserOutletArea);
+  }
+
+  public double getEntrainmentRatio() {
+    return entrainmentRatio;
+  }
+
+  public double getMotiveNozzleEffectiveLength() {
+    return motiveNozzleEffectiveLength;
+  }
+
+  public double getSuctionInletLength() {
+    return suctionInletLength;
+  }
+
+  public double getMixingChamberLength() {
+    return mixingChamberLength;
+  }
+
+  public double getDiffuserOutletLength() {
+    return diffuserOutletLength;
+  }
+
+  public double getBodyVolume() {
+    return bodyVolume;
+  }
+
+  public double getConnectedPipingVolume() {
+    return connectedPipingVolume;
+  }
+
+  public double getTotalVolume() {
+    return bodyVolume + connectedPipingVolume;
+  }
+
+  public double getSuctionConnectionLength() {
+    return suctionConnectionLength;
+  }
+
+  public double getDischargeConnectionLength() {
+    return dischargeConnectionLength;
+  }
+
+  private static double areaToDiameter(double area) {
+    if (area <= 0.0) {
+      return 0.0;
+    }
+    return Math.sqrt(4.0 * area / Math.PI);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/ejector/EjectorTest.java
+++ b/src/test/java/neqsim/process/equipment/ejector/EjectorTest.java
@@ -1,8 +1,149 @@
 package neqsim.process.equipment.ejector;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.mechanicaldesign.ejector.EjectorMechanicalDesign;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
 
-public class EjectorTest {
+class EjectorTest {
+
   @Test
-  void testRun() {}
+  void boostLowPressureGas() {
+    SystemInterface motiveFluid = new SystemSrkEos(273.15 + 20.0, 10.0);
+    motiveFluid.addComponent("methane", 1.0);
+    motiveFluid.createDatabase(true);
+    motiveFluid.setMixingRule(2);
+
+    Stream motiveStream = new Stream("motive", motiveFluid);
+    motiveStream.setPressure(10.0, "bara");
+    motiveStream.setTemperature(20.0, "C");
+    motiveStream.setFlowRate(0.5, "kg/sec");
+    motiveStream.run();
+
+    SystemInterface suctionFluid = new SystemSrkEos(273.15 + 20.0, 1.0);
+    suctionFluid.addComponent("methane", 1.0);
+    suctionFluid.createDatabase(true);
+    suctionFluid.setMixingRule(2);
+
+    Stream suctionStream = new Stream("suction", suctionFluid);
+    suctionStream.setPressure(1.0, "bara");
+    suctionStream.setTemperature(20.0, "C");
+    suctionStream.setFlowRate(0.15, "kg/sec");
+    suctionStream.run();
+
+    Ejector ejector = new Ejector("gas booster", motiveStream, suctionStream);
+    ejector.setDischargePressure(3.0);
+    ejector.run();
+
+    StreamInterface outStream = ejector.getOutStream();
+    outStream.run();
+
+    assertEquals(3.0, outStream.getPressure("bara"), 1.0e-4);
+    assertEquals(motiveStream.getFlowRate("kg/sec") + suctionStream.getFlowRate("kg/sec"),
+        outStream.getFlowRate("kg/sec"), 1.0e-6);
+
+    EjectorMechanicalDesign design = ejector.getMechanicalDesign();
+    double suctionPressure = suctionStream.getPressure("bara");
+    assertTrue(design.getMixingPressure() <= suctionPressure + 1.0e-8);
+    assertTrue(design.getMixingPressure() > 0.0);
+    assertTrue(design.getMotiveNozzleThroatArea() > 0.0);
+    assertTrue(design.getMixingChamberArea() > 0.0);
+    assertTrue(design.getDiffuserOutletArea() > 0.0);
+    assertEquals(design.getEntrainmentRatio(),
+        suctionStream.getFlowRate("kg/sec") / motiveStream.getFlowRate("kg/sec"), 1.0e-8);
+    assertTrue(design.getSuctionInletVelocity() >= 25.0);
+    assertTrue(design.getSuctionInletVelocity() <= 120.0);
+    assertTrue(design.getDiffuserOutletVelocity() >= 10.0);
+    assertTrue(design.getDiffuserOutletVelocity() <= 60.0);
+    assertTrue(design.getBodyVolume() > 0.0);
+    assertTrue(design.getConnectedPipingVolume() > 0.0);
+    assertEquals(design.getTotalVolume(),
+        design.getBodyVolume() + design.getConnectedPipingVolume(), 1.0e-12);
+    assertTrue(design.getSuctionConnectionLength() > 0.0);
+    assertTrue(design.getDischargeConnectionLength() > 0.0);
+  }
+
+  @Test
+  void manualDesignOverridesAreHonored() {
+    SystemInterface motiveFluid = new SystemSrkEos(273.15 + 20.0, 10.0);
+    motiveFluid.addComponent("methane", 1.0);
+    motiveFluid.createDatabase(true);
+    motiveFluid.setMixingRule(2);
+
+    Stream motiveStream = new Stream("motive", motiveFluid);
+    motiveStream.setPressure(10.0, "bara");
+    motiveStream.setTemperature(20.0, "C");
+    motiveStream.setFlowRate(0.5, "kg/sec");
+    motiveStream.run();
+
+    SystemInterface suctionFluid = new SystemSrkEos(273.15 + 20.0, 1.0);
+    suctionFluid.addComponent("methane", 1.0);
+    suctionFluid.createDatabase(true);
+    suctionFluid.setMixingRule(2);
+
+    Stream suctionStream = new Stream("suction", suctionFluid);
+    suctionStream.setPressure(1.0, "bara");
+    suctionStream.setTemperature(20.0, "C");
+    suctionStream.setFlowRate(0.15, "kg/sec");
+    suctionStream.run();
+
+    Ejector ejector = new Ejector("manual gas booster", motiveStream, suctionStream);
+    ejector.setMixingPressure(0.8);
+    ejector.setDischargePressure(3.0);
+    ejector.setDesignSuctionVelocity(75.0);
+    ejector.setDesignDiffuserOutletVelocity(25.0);
+    ejector.setSuctionConnectionLength(1.0);
+    ejector.setDischargeConnectionLength(2.0);
+    ejector.run();
+
+    EjectorMechanicalDesign design = ejector.getMechanicalDesign();
+    assertEquals(0.8, design.getMixingPressure(), 1.0e-8);
+    assertEquals(75.0, design.getSuctionInletVelocity(), 1.0e-6);
+    assertEquals(25.0, design.getDiffuserOutletVelocity(), 1.0e-6);
+    assertEquals(1.0, design.getSuctionConnectionLength(), 1.0e-9);
+    assertEquals(2.0, design.getDischargeConnectionLength(), 1.0e-9);
+
+    double expectedConnectedVolume = design.getSuctionInletArea() * 1.0
+        + design.getDiffuserOutletArea() * 2.0;
+    assertEquals(expectedConnectedVolume, design.getConnectedPipingVolume(), 1.0e-9);
+  }
+
+  @Test
+  void mixingPressureCannotExceedSuctionPressure() {
+    SystemInterface motiveFluid = new SystemSrkEos(273.15 + 30.0, 12.0);
+    motiveFluid.addComponent("methane", 1.0);
+    motiveFluid.createDatabase(true);
+    motiveFluid.setMixingRule(2);
+
+    Stream motiveStream = new Stream("motive", motiveFluid);
+    motiveStream.setPressure(12.0, "bara");
+    motiveStream.setTemperature(30.0, "C");
+    motiveStream.setFlowRate(0.4, "kg/sec");
+    motiveStream.run();
+
+    SystemInterface suctionFluid = new SystemSrkEos(273.15 + 20.0, 2.0);
+    suctionFluid.addComponent("methane", 1.0);
+    suctionFluid.createDatabase(true);
+    suctionFluid.setMixingRule(2);
+
+    Stream suctionStream = new Stream("suction", suctionFluid);
+    suctionStream.setPressure(2.0, "bara");
+    suctionStream.setTemperature(20.0, "C");
+    suctionStream.setFlowRate(0.1, "kg/sec");
+    suctionStream.run();
+
+    Ejector ejector = new Ejector("mixing pressure clamp", motiveStream, suctionStream);
+    double suctionPressure = suctionStream.getPressure("bara");
+    ejector.setMixingPressure(suctionPressure + 3.0);
+    ejector.setDischargePressure(4.0);
+    ejector.run();
+
+    EjectorMechanicalDesign design = ejector.getMechanicalDesign();
+    assertEquals(suctionPressure, design.getMixingPressure(), 1.0e-8,
+        "mixing pressure should be limited to suction pressure");
+  }
 }


### PR DESCRIPTION
Integrated the ejector unit with the mechanical design workflow by instantiating EjectorMechanicalDesign, reusing it across runs, and clearing stored sizing data when no flow is present.

Added the EjectorMechanicalDesign subclass of MechanicalDesign to capture mixing pressure, velocity, area, and volume results for ejector sizing.

Updated the ejector unit tests to assert against the new mechanical design accessor and verify the reported sizing metrics.
