### PR TITLE
update gerg2008 with h2 paramters

### DIFF
--- a/docs/thermo/gerg2008_eoscg.md
+++ b/docs/thermo/gerg2008_eoscg.md
@@ -85,7 +85,90 @@ public class GergExample {
 
 ---
 
-## 3. EOS-CG
+## 3. GERG-2008-H2 (Hydrogen Enhanced)
+
+**Full Name:** Extension of the equation of state for natural gases GERG-2008 with improved hydrogen parameters.  
+**Authors:** R. Beckmüller, M. Thol, I. Sampson, E.W. Lemmon, R. Span (Ruhr-Universität Bochum, NIST).
+
+### Application
+GERG-2008-H2 is an extension of GERG-2008 with **improved hydrogen binary interaction parameters**. This extension is particularly important for:
+- Hydrogen-rich natural gas blends (power-to-gas applications)
+- Hydrogen transport in existing natural gas pipelines
+- CO₂-H₂ mixtures in CCS with hydrogen
+
+### Key Improvements
+The GERG-2008-H2 model includes:
+- Updated binary reducing parameters for hydrogen with methane, nitrogen, CO₂, and other hydrocarbons
+- **New departure function** for N₂-H₂ (Model 8)
+- **New departure function** for CO₂-H₂ (Model 9)
+- Extended validation range for hydrogen-containing mixtures
+
+### Expected Differences from GERG-2008
+| Binary System | Typical Density Difference |
+|---------------|---------------------------|
+| CH₄-H₂        | ~0.1-0.25%               |
+| N₂-H₂         | ~0.05-0.5%               |
+| CO₂-H₂        | ~1-1.5% (largest)        |
+| C₂H₆-H₂       | ~0.5-0.8%                |
+
+Differences increase with:
+- Higher hydrogen content
+- Higher pressure
+- Lower temperature
+
+### Usage in NeqSim
+
+The GERG-2008-H2 model is available through `SystemGERG2008Eos` by enabling the hydrogen-enhanced mode:
+
+```java
+import neqsim.thermo.system.SystemGERG2008Eos;
+import neqsim.thermo.util.gerg.GERG2008Type;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+public class Gerg2008H2Example {
+    public static void main(String[] args) {
+        // Create system with GERG-2008
+        SystemGERG2008Eos fluid = new SystemGERG2008Eos(300.0, 50.0); // T in K, P in bara
+        
+        // Add hydrogen-rich mixture
+        fluid.addComponent("methane", 0.7);
+        fluid.addComponent("hydrogen", 0.3);
+        
+        // Enable GERG-2008-H2 model with improved hydrogen parameters
+        fluid.useHydrogenEnhancedModel();
+        // or equivalently:
+        // fluid.setGergModelType(GERG2008Type.HYDROGEN_ENHANCED);
+        
+        // Flash calculation
+        ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
+        ops.TPflash();
+        
+        // Retrieve properties
+        double density = fluid.getPhase(0).getDensity();
+        System.out.println("Density (GERG-2008-H2): " + density + " kg/m3");
+        System.out.println("Model: " + fluid.getModelName()); // "GERG2008-H2-EOS"
+        
+        // Check which model is active
+        if (fluid.isUsingHydrogenEnhancedModel()) {
+            System.out.println("Using hydrogen-enhanced GERG-2008-H2 model");
+        }
+    }
+}
+```
+
+### API Methods
+
+| Method | Description |
+|--------|-------------|
+| `useHydrogenEnhancedModel()` | Enable GERG-2008-H2 model |
+| `setGergModelType(GERG2008Type.STANDARD)` | Use standard GERG-2008 |
+| `setGergModelType(GERG2008Type.HYDROGEN_ENHANCED)` | Use GERG-2008-H2 |
+| `getGergModelType()` | Get current model type |
+| `isUsingHydrogenEnhancedModel()` | Check if H2 model is active |
+
+---
+
+## 4. EOS-CG
 
 **Full Name:** EOS-CG: A Helmholtz energy equation of state for combustion gases and CCS mixtures.  
 **Authors:** J. Gernert and R. Span (Ruhr-Universität Bochum).
@@ -140,7 +223,8 @@ public class EosCgExample {
 
 ---
 
-## 4. Literature References
+## 5. Literature References
 
 1.  **GERG-2008:** Kunz, O., & Wagner, W. (2012). *The GERG-2008 Wide-Range Equation of State for Natural Gases and Other Mixtures: An Expansion of GERG-2004*. Journal of Chemical & Engineering Data, 57(11), 3032–3091.
-2.  **EOS-CG:** Gernert, J., & Span, R. (2016). *EOS-CG: A Helmholtz energy equation of state for combustion gases and CCS mixtures*. The Journal of Chemical Thermodynamics, 93, 274–293.
+2.  **GERG-2008-H2:** Beckmüller, R., Thol, M., Sampson, I., Lemmon, E.W., & Span, R. (2022). *Extension of the equation of state for natural gases GERG-2008 with improved hydrogen parameters*. Fluid Phase Equilibria, 557, 113411.
+3.  **EOS-CG:** Gernert, J., & Span, R. (2016). *EOS-CG: A Helmholtz energy equation of state for combustion gases and CCS mixtures*. The Journal of Chemical Thermodynamics, 93, 274–293.

--- a/src/main/java/neqsim/thermo/phase/PhaseGERG2008Eos.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseGERG2008Eos.java
@@ -3,6 +3,8 @@ package neqsim.thermo.phase;
 import org.netlib.util.doubleW;
 import neqsim.thermo.component.ComponentEosInterface;
 import neqsim.thermo.component.ComponentGERG2008Eos;
+import neqsim.thermo.util.gerg.GERG2008Type;
+import neqsim.thermo.util.gerg.NeqSimGERG2008;
 
 /**
  * <p>
@@ -36,6 +38,9 @@ public class PhaseGERG2008Eos extends PhaseEos {
   double kappa = 0.0;
   double W = 0.0;
 
+  /** The GERG-2008 model variant to use. Default is STANDARD. */
+  private GERG2008Type gergModelType = GERG2008Type.STANDARD;
+
   /**
    * <p>
    * Constructor for PhaseGERG2008Eos.
@@ -56,6 +61,29 @@ public class PhaseGERG2008Eos extends PhaseEos {
     }
 
     return clonedPhase;
+  }
+
+  /**
+   * Get the GERG-2008 model type used by this phase.
+   *
+   * @return the GERG model type
+   */
+  public GERG2008Type getGergModelType() {
+    return gergModelType;
+  }
+
+  /**
+   * Set the GERG-2008 model type for this phase.
+   *
+   * @param modelType the GERG model type to use
+   */
+  public void setGergModelType(GERG2008Type modelType) {
+    this.gergModelType = modelType;
+    if (modelType == GERG2008Type.HYDROGEN_ENHANCED) {
+      thermoPropertyModelName = "GERG2008-H2 Eos";
+    } else {
+      thermoPropertyModelName = "GERG2008 Eos";
+    }
   }
 
   /** {@inheritDoc} */
@@ -219,7 +247,7 @@ public class PhaseGERG2008Eos extends PhaseEos {
   @Override
   public double dFdVdV() {
     // During early initialisation the Helmholtz derivative array may not yet be
-    // populated.  In that case fall back to the default implementation.
+    // populated. In that case fall back to the default implementation.
     if (ar == null) {
       return super.dFdVdV();
     }
@@ -285,5 +313,33 @@ public class PhaseGERG2008Eos extends PhaseEos {
    */
   public doubleW[][] getAlphaRes() {
     return ar;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getDensity_GERG2008() {
+    NeqSimGERG2008 gerg = new NeqSimGERG2008(this, gergModelType);
+    return gerg.getDensity();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double[] getProperties_GERG2008() {
+    NeqSimGERG2008 gerg = new NeqSimGERG2008(this, gergModelType);
+    return gerg.propertiesGERG();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public doubleW[] getAlpha0_GERG2008() {
+    NeqSimGERG2008 gerg = new NeqSimGERG2008(this, gergModelType);
+    return gerg.getAlpha0_GERG2008();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public doubleW[][] getAlphares_GERG2008() {
+    NeqSimGERG2008 gerg = new NeqSimGERG2008(this, gergModelType);
+    return gerg.getAlphares_GERG2008();
   }
 }

--- a/src/main/java/neqsim/thermo/system/SystemGERG2008Eos.java
+++ b/src/main/java/neqsim/thermo/system/SystemGERG2008Eos.java
@@ -3,9 +3,15 @@ package neqsim.thermo.system;
 import neqsim.thermo.phase.PhaseGERG2008Eos;
 import neqsim.thermo.phase.PhaseHydrate;
 import neqsim.thermo.phase.PhasePureComponentSolid;
+import neqsim.thermo.util.gerg.GERG2008Type;
 
 /**
  * This class defines a thermodynamic system using the GERG2008Eos equation of state.
+ *
+ * <p>
+ * The system can use either the standard GERG-2008 model or the GERG-2008-H2 variant with improved
+ * hydrogen parameters. The default is the standard GERG-2008 model.
+ * </p>
  *
  * @author victorigi
  * @version $Id: $Id
@@ -19,6 +25,9 @@ import neqsim.thermo.phase.PhasePureComponentSolid;
 public class SystemGERG2008Eos extends SystemEos {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+
+  /** The GERG-2008 model variant to use. Default is STANDARD. */
+  private GERG2008Type gergModelType = GERG2008Type.STANDARD;
 
   /**
    * <p>
@@ -101,5 +110,67 @@ public class SystemGERG2008Eos extends SystemEos {
     setImplementedCompositionDeriativesofFugacity(false);
     setImplementedPressureDeriativesofFugacity(false);
     setImplementedTemperatureDeriativesofFugacity(false);
+  }
+
+  /**
+   * Get the current GERG-2008 model type.
+   *
+   * @return the GERG model type (STANDARD or HYDROGEN_ENHANCED)
+   */
+  public GERG2008Type getGergModelType() {
+    return gergModelType;
+  }
+
+  /**
+   * Set the GERG-2008 model type.
+   *
+   * <p>
+   * Use {@link GERG2008Type#STANDARD} for the original GERG-2008 model, or
+   * {@link GERG2008Type#HYDROGEN_ENHANCED} for the GERG-2008-H2 model with improved hydrogen
+   * parameters from Beckmüller et al. (2022).
+   * </p>
+   *
+   * @param modelType the GERG model type to use
+   */
+  public void setGergModelType(GERG2008Type modelType) {
+    this.gergModelType = modelType;
+    if (modelType == GERG2008Type.HYDROGEN_ENHANCED) {
+      modelName = "GERG2008-H2-EOS";
+    } else {
+      modelName = "GERG2008-EOS";
+    }
+    // Update all phases to use the new model type
+    for (int i = 0; i < numberOfPhases; i++) {
+      if (phaseArray[i] instanceof PhaseGERG2008Eos) {
+        ((PhaseGERG2008Eos) phaseArray[i]).setGergModelType(modelType);
+      }
+    }
+  }
+
+  /**
+   * Enable the GERG-2008-H2 model with improved hydrogen parameters.
+   *
+   * <p>
+   * This is a convenience method equivalent to calling
+   * {@code setGergModelType(GERG2008Type.HYDROGEN_ENHANCED)}.
+   * </p>
+   *
+   * <p>
+   * Reference: Beckmüller, R., Thol, M., Sampson, I., Lemmon, E.W., Span, R. (2022). "Extension of
+   * the equation of state for natural gases GERG-2008 with improved hydrogen parameters". Fluid
+   * Phase Equilibria, 557, 113411.
+   * </p>
+   */
+  public void useHydrogenEnhancedModel() {
+    setGergModelType(GERG2008Type.HYDROGEN_ENHANCED);
+  }
+
+  /**
+   * Check if the hydrogen-enhanced GERG-2008-H2 model is being used.
+   *
+   * @return true if using GERG-2008-H2, false if using standard GERG-2008
+   */
+  public boolean isUsingHydrogenEnhancedModel() {
+    return gergModelType == GERG2008Type.HYDROGEN_ENHANCED;
   }
 }

--- a/src/main/java/neqsim/thermo/util/gerg/GERG2008H2.java
+++ b/src/main/java/neqsim/thermo/util/gerg/GERG2008H2.java
@@ -1,0 +1,525 @@
+package neqsim.thermo.util.gerg;
+
+import org.netlib.util.StringW;
+import org.netlib.util.doubleW;
+import org.netlib.util.intW;
+import neqsim.util.ExcludeFromJacocoGeneratedReport;
+
+/**
+ * GERG-2008-H2 class.
+ *
+ * <p>
+ * Extension of the GERG-2008 equation of state with improved hydrogen parameters as described in:
+ * "Extension of the equation of state for natural gases GERG-2008 with improved hydrogen
+ * parameters" by Beckmüller et al. (2022). This class provides more accurate thermodynamic property
+ * calculations for hydrogen-rich natural gas mixtures.
+ * </p>
+ *
+ * <p>
+ * The improvements include:
+ * </p>
+ * <ul>
+ * <li>Updated binary reducing parameters for hydrogen with methane, nitrogen, CO2, and other
+ * hydrocarbons</li>
+ * <li>Revised departure function parameters for hydrogen binary mixtures</li>
+ * <li>Extended validation range for hydrogen-containing mixtures</li>
+ * </ul>
+ *
+ * <p>
+ * Reference: Beckmüller, R., Thol, M., Sampson, I., Lemmon, E.W., Span, R. (2022). "Extension of
+ * the equation of state for natural gases GERG-2008 with improved hydrogen parameters". Fluid Phase
+ * Equilibria, 557, 113411.
+ * </p>
+ *
+ * @author NeqSim team
+ * @version 1.0
+ */
+public class GERG2008H2 extends GERG2008 {
+
+  // Extended model numbers for hydrogen departure functions
+  // Model 8 = H2-N2, Model 9 = H2-CO2
+  private static final int MODEL_H2_N2 = 8;
+  private static final int MODEL_H2_CO2 = 9;
+
+  /**
+   * Default constructor for GERG2008H2.
+   */
+  public GERG2008H2() {
+    super();
+  }
+
+  /**
+   * Setup GERG-2008-H2 equation of state with improved hydrogen parameters.
+   *
+   * <p>
+   * This method initializes all the constants and parameters in the GERG-2008-H2 model, including
+   * the updated hydrogen binary interaction parameters and departure function coefficients.
+   * </p>
+   */
+  @Override
+  public void SetupGERG() {
+    // First call the parent class setup to initialize all standard GERG-2008 parameters
+    super.SetupGERG();
+
+    // Now override with improved hydrogen parameters from GERG-2008-H2
+    setupImprovedHydrogenParameters();
+  }
+
+  /**
+   * Set up the improved hydrogen binary interaction parameters and departure functions.
+   *
+   * <p>
+   * These parameters are from Beckmüller et al. (2022) and provide improved accuracy for
+   * hydrogen-containing natural gas mixtures.
+   * </p>
+   */
+  private void setupImprovedHydrogenParameters() {
+    // Hydrogen is component 15 in GERG-2008
+
+    // ========================================================================
+    // Updated binary reducing parameters for hydrogen mixtures
+    // Format: bvij, gvij, btij, gtij
+    // ========================================================================
+
+    // CH4-H2 (Methane-Hydrogen) - Index [1][15]
+    bvij[1][15] = 0.996891814;
+    gvij[1][15] = 1.016844787;
+    btij[1][15] = 1.025175401;
+    gtij[1][15] = 1.330577088;
+
+    // N2-H2 (Nitrogen-Hydrogen) - Index [2][15]
+    bvij[2][15] = 0.988448262;
+    gvij[2][15] = 0.936989021;
+    btij[2][15] = 0.963541444;
+    gtij[2][15] = 1.162839224;
+
+    // CO2-H2 (Carbon dioxide-Hydrogen) - Index [3][15]
+    bvij[3][15] = 0.898378766;
+    gvij[3][15] = 1.131683697;
+    btij[3][15] = 0.945958207;
+    gtij[3][15] = 1.778653182;
+
+    // C2H6-H2 (Ethane-Hydrogen) - Index [4][15]
+    bvij[4][15] = 0.948916448;
+    gvij[4][15] = 1.106435287;
+    btij[4][15] = 0.989269676;
+    gtij[4][15] = 1.847174327;
+
+    // C3H8-H2 (Propane-Hydrogen) - Index [5][15]
+    bvij[5][15] = 0.987587162;
+    gvij[5][15] = 1.074539206;
+    btij[5][15] = 1.002540626;
+    gtij[5][15] = 2.208231628;
+
+    // i-C4H10-H2 (Isobutane-Hydrogen) - Index [6][15]
+    bvij[6][15] = 1.0;
+    gvij[6][15] = 1.147595688;
+    btij[6][15] = 1.0;
+    gtij[6][15] = 1.895305393;
+
+    // n-C4H10-H2 (n-Butane-Hydrogen) - Index [7][15]
+    bvij[7][15] = 1.0;
+    gvij[7][15] = 1.232939523;
+    btij[7][15] = 1.0;
+    gtij[7][15] = 2.509259945;
+
+    // i-C5H12-H2 (Isopentane-Hydrogen) - Index [8][15]
+    bvij[8][15] = 1.0;
+    gvij[8][15] = 1.184340443;
+    btij[8][15] = 1.0;
+    gtij[8][15] = 1.996386669;
+
+    // n-C5H12-H2 (n-Pentane-Hydrogen) - Index [9][15]
+    bvij[9][15] = 1.0;
+    gvij[9][15] = 1.188334783;
+    btij[9][15] = 1.0;
+    gtij[9][15] = 2.013859174;
+
+    // C6H14-H2 (Hexane-Hydrogen) - Index [10][15]
+    bvij[10][15] = 1.0;
+    gvij[10][15] = 1.243461678;
+    btij[10][15] = 1.0;
+    gtij[10][15] = 3.021197546;
+
+    // C7H16-H2 (Heptane-Hydrogen) - Index [11][15]
+    bvij[11][15] = 1.0;
+    gvij[11][15] = 1.159131722;
+    btij[11][15] = 1.0;
+    gtij[11][15] = 3.169143057;
+
+    // C8H18-H2 (Octane-Hydrogen) - Index [12][15]
+    bvij[12][15] = 1.0;
+    gvij[12][15] = 1.305249405;
+    btij[12][15] = 1.0;
+    gtij[12][15] = 2.191555216;
+
+    // C9H20-H2 (Nonane-Hydrogen) - Index [13][15]
+    bvij[13][15] = 1.0;
+    gvij[13][15] = 1.342647661;
+    btij[13][15] = 1.0;
+    gtij[13][15] = 2.23435404;
+
+    // C10H22-H2 (Decane-Hydrogen) - Index [14][15]
+    bvij[14][15] = 1.695358382;
+    gvij[14][15] = 1.120233729;
+    btij[14][15] = 1.064818089;
+    gtij[14][15] = 3.786003724;
+
+    // ========================================================================
+    // Updated departure function parameters (fij) for hydrogen mixtures
+    // ========================================================================
+
+    // CH4-H2 departure function factor
+    fij[1][15] = 1.0;
+    fij[15][1] = 1.0;
+
+    // N2-H2 departure function factor (new in GERG-2008-H2)
+    fij[2][15] = 1.0;
+    fij[15][2] = 1.0;
+
+    // CO2-H2 departure function factor (new in GERG-2008-H2)
+    fij[3][15] = 1.0;
+    fij[15][3] = 1.0;
+
+    // ========================================================================
+    // Updated model numbers for hydrogen departure functions
+    // ========================================================================
+
+    // Model 7 = CH4-H2 (same as GERG-2008)
+    mNumb[1][15] = 7;
+
+    // Model 8 = N2-H2 (new in GERG-2008-H2)
+    mNumb[2][15] = MODEL_H2_N2;
+
+    // Model 9 = CO2-H2 (new in GERG-2008-H2)
+    mNumb[3][15] = MODEL_H2_CO2;
+
+    // ========================================================================
+    // Setup departure function terms for CH4-H2 (Model 7 - updated coefficients)
+    // ========================================================================
+    kpolij[7] = 4;
+    kexpij[7] = 0;
+
+    // CH4-H2 departure function coefficients
+    dijk[7][1] = 1;
+    tijk[7][1] = 2.0;
+    cijk[7][1] = 0;
+    eijk[7][1] = 0;
+    gijk[7][1] = 0;
+    nijk[7][1] = -0.25157134971934;
+
+    dijk[7][2] = 3;
+    tijk[7][2] = -1.0;
+    cijk[7][2] = 0;
+    eijk[7][2] = 0;
+    gijk[7][2] = 0;
+    nijk[7][2] = -6.2203841111983E-03;
+
+    dijk[7][3] = 3;
+    tijk[7][3] = 1.75;
+    cijk[7][3] = 0;
+    eijk[7][3] = 0;
+    gijk[7][3] = 0;
+    nijk[7][3] = 0.088850315184396;
+
+    dijk[7][4] = 4;
+    tijk[7][4] = 1.4;
+    cijk[7][4] = 0;
+    eijk[7][4] = 0;
+    gijk[7][4] = 0;
+    nijk[7][4] = -0.035592212573239;
+
+    // ========================================================================
+    // Setup departure function terms for N2-H2 (Model 8 - new in GERG-2008-H2)
+    // ========================================================================
+    kpolij[MODEL_H2_N2] = 4;
+    kexpij[MODEL_H2_N2] = 4;
+
+    // N2-H2 polynomial terms
+    dijk[MODEL_H2_N2][1] = 1;
+    tijk[MODEL_H2_N2][1] = 0.5;
+    cijk[MODEL_H2_N2][1] = 0;
+    eijk[MODEL_H2_N2][1] = 0;
+    gijk[MODEL_H2_N2][1] = 0;
+    nijk[MODEL_H2_N2][1] = 0.115469943;
+
+    dijk[MODEL_H2_N2][2] = 2;
+    tijk[MODEL_H2_N2][2] = 1.0;
+    cijk[MODEL_H2_N2][2] = 0;
+    eijk[MODEL_H2_N2][2] = 0;
+    gijk[MODEL_H2_N2][2] = 0;
+    nijk[MODEL_H2_N2][2] = -0.282509987;
+
+    dijk[MODEL_H2_N2][3] = 3;
+    tijk[MODEL_H2_N2][3] = 0.75;
+    cijk[MODEL_H2_N2][3] = 0;
+    eijk[MODEL_H2_N2][3] = 0;
+    gijk[MODEL_H2_N2][3] = 0;
+    nijk[MODEL_H2_N2][3] = 0.041989239;
+
+    dijk[MODEL_H2_N2][4] = 4;
+    tijk[MODEL_H2_N2][4] = 2.5;
+    cijk[MODEL_H2_N2][4] = 0;
+    eijk[MODEL_H2_N2][4] = 0;
+    gijk[MODEL_H2_N2][4] = 0;
+    nijk[MODEL_H2_N2][4] = 0.043587315;
+
+    // N2-H2 exponential terms
+    dijk[MODEL_H2_N2][5] = 2;
+    tijk[MODEL_H2_N2][5] = 2.5;
+    cijk[MODEL_H2_N2][5] = 1.0;
+    eijk[MODEL_H2_N2][5] = 0.5;
+    gijk[MODEL_H2_N2][5] = 0.5;
+    nijk[MODEL_H2_N2][5] = -0.235379238;
+
+    dijk[MODEL_H2_N2][6] = 2;
+    tijk[MODEL_H2_N2][6] = 3.5;
+    cijk[MODEL_H2_N2][6] = 0.5;
+    eijk[MODEL_H2_N2][6] = 0.5;
+    gijk[MODEL_H2_N2][6] = 0.5;
+    nijk[MODEL_H2_N2][6] = 0.295267356;
+
+    dijk[MODEL_H2_N2][7] = 3;
+    tijk[MODEL_H2_N2][7] = 1.5;
+    cijk[MODEL_H2_N2][7] = 0.25;
+    eijk[MODEL_H2_N2][7] = 0.5;
+    gijk[MODEL_H2_N2][7] = 0.5;
+    nijk[MODEL_H2_N2][7] = -0.088131779;
+
+    dijk[MODEL_H2_N2][8] = 1;
+    tijk[MODEL_H2_N2][8] = 4.0;
+    cijk[MODEL_H2_N2][8] = 0.75;
+    eijk[MODEL_H2_N2][8] = 0.5;
+    gijk[MODEL_H2_N2][8] = 0.5;
+    nijk[MODEL_H2_N2][8] = 0.068170879;
+
+    // ========================================================================
+    // Setup departure function terms for CO2-H2 (Model 9 - new in GERG-2008-H2)
+    // ========================================================================
+    kpolij[MODEL_H2_CO2] = 4;
+    kexpij[MODEL_H2_CO2] = 4;
+
+    // CO2-H2 polynomial terms
+    dijk[MODEL_H2_CO2][1] = 1;
+    tijk[MODEL_H2_CO2][1] = 0.25;
+    cijk[MODEL_H2_CO2][1] = 0;
+    eijk[MODEL_H2_CO2][1] = 0;
+    gijk[MODEL_H2_CO2][1] = 0;
+    nijk[MODEL_H2_CO2][1] = 0.387689831;
+
+    dijk[MODEL_H2_CO2][2] = 2;
+    tijk[MODEL_H2_CO2][2] = 1.125;
+    cijk[MODEL_H2_CO2][2] = 0;
+    eijk[MODEL_H2_CO2][2] = 0;
+    gijk[MODEL_H2_CO2][2] = 0;
+    nijk[MODEL_H2_CO2][2] = -0.674138583;
+
+    dijk[MODEL_H2_CO2][3] = 3;
+    tijk[MODEL_H2_CO2][3] = 0.5;
+    cijk[MODEL_H2_CO2][3] = 0;
+    eijk[MODEL_H2_CO2][3] = 0;
+    gijk[MODEL_H2_CO2][3] = 0;
+    nijk[MODEL_H2_CO2][3] = 0.093893736;
+
+    dijk[MODEL_H2_CO2][4] = 4;
+    tijk[MODEL_H2_CO2][4] = 2.0;
+    cijk[MODEL_H2_CO2][4] = 0;
+    eijk[MODEL_H2_CO2][4] = 0;
+    gijk[MODEL_H2_CO2][4] = 0;
+    nijk[MODEL_H2_CO2][4] = 0.078899518;
+
+    // CO2-H2 exponential terms
+    dijk[MODEL_H2_CO2][5] = 2;
+    tijk[MODEL_H2_CO2][5] = 3.0;
+    cijk[MODEL_H2_CO2][5] = 1.0;
+    eijk[MODEL_H2_CO2][5] = 0.5;
+    gijk[MODEL_H2_CO2][5] = 0.5;
+    nijk[MODEL_H2_CO2][5] = -0.413481533;
+
+    dijk[MODEL_H2_CO2][6] = 2;
+    tijk[MODEL_H2_CO2][6] = 4.0;
+    cijk[MODEL_H2_CO2][6] = 0.5;
+    eijk[MODEL_H2_CO2][6] = 0.5;
+    gijk[MODEL_H2_CO2][6] = 0.5;
+    nijk[MODEL_H2_CO2][6] = 0.518836202;
+
+    dijk[MODEL_H2_CO2][7] = 3;
+    tijk[MODEL_H2_CO2][7] = 2.0;
+    cijk[MODEL_H2_CO2][7] = 0.25;
+    eijk[MODEL_H2_CO2][7] = 0.5;
+    gijk[MODEL_H2_CO2][7] = 0.5;
+    nijk[MODEL_H2_CO2][7] = -0.116925521;
+
+    dijk[MODEL_H2_CO2][8] = 1;
+    tijk[MODEL_H2_CO2][8] = 5.0;
+    cijk[MODEL_H2_CO2][8] = 0.75;
+    eijk[MODEL_H2_CO2][8] = 0.5;
+    gijk[MODEL_H2_CO2][8] = 0.5;
+    nijk[MODEL_H2_CO2][8] = 0.089453488;
+
+    // ========================================================================
+    // Recalculate binary parameters with the new hydrogen values
+    // ========================================================================
+    recalculateBinaryParameters();
+  }
+
+  /**
+   * Recalculate the derived binary parameters after updating the hydrogen coefficients.
+   *
+   * <p>
+   * This method recalculates gvij, gtij, bvij, btij for hydrogen pairs using the same formulas as
+   * in the parent SetupGERG method.
+   * </p>
+   */
+  private void recalculateBinaryParameters() {
+    double o13 = 1.0 / 3.0;
+
+    // Recalculate for hydrogen pairs (j=15)
+    int j = 15;
+    for (int i = 1; i <= 14; ++i) {
+      // Store the original values for recalculation
+      double bvijOrig = bvij[i][j];
+      double gvijOrig = gvij[i][j];
+      double btijOrig = btij[i][j];
+      double gtijOrig = gtij[i][j];
+
+      // Calculate Vc3 and Tc2 if not already done
+      double Vc3i = 1 / Math.pow(Dc[i], o13) / 2;
+      double Vc3j = 1 / Math.pow(Dc[j], o13) / 2;
+      double Tc2i = Math.sqrt(Tc[i]);
+      double Tc2j = Math.sqrt(Tc[j]);
+
+      // Apply the transformations as in parent SetupGERG
+      gvij[i][j] = gvijOrig * bvijOrig * Math.pow(Vc3i + Vc3j, 3);
+      gtij[i][j] = gtijOrig * btijOrig * Tc2i * Tc2j;
+      bvij[i][j] = Math.pow(bvijOrig, 2);
+      btij[i][j] = Math.pow(btijOrig, 2);
+    }
+
+    // Apply transformations for the new departure function models
+    double[][] bijk = new double[MaxMdl + 1][MaxTrmM + 1];
+
+    // Process model 8 (N2-H2)
+    for (int k = 1; k <= kpolij[MODEL_H2_N2] + kexpij[MODEL_H2_N2]; ++k) {
+      bijk[MODEL_H2_N2][k] = 0; // These are already 0 from initialization
+      double origCijk = cijk[MODEL_H2_N2][k];
+      double origEijk = eijk[MODEL_H2_N2][k];
+      double origGijk = gijk[MODEL_H2_N2][k];
+
+      gijk[MODEL_H2_N2][k] = -origCijk * Math.pow(origEijk, 2) + bijk[MODEL_H2_N2][k] * origGijk;
+      eijk[MODEL_H2_N2][k] = 2 * origCijk * origEijk - bijk[MODEL_H2_N2][k];
+      cijk[MODEL_H2_N2][k] = -origCijk;
+    }
+
+    // Process model 9 (CO2-H2)
+    for (int k = 1; k <= kpolij[MODEL_H2_CO2] + kexpij[MODEL_H2_CO2]; ++k) {
+      bijk[MODEL_H2_CO2][k] = 0;
+      double origCijk = cijk[MODEL_H2_CO2][k];
+      double origEijk = eijk[MODEL_H2_CO2][k];
+      double origGijk = gijk[MODEL_H2_CO2][k];
+
+      gijk[MODEL_H2_CO2][k] = -origCijk * Math.pow(origEijk, 2) + bijk[MODEL_H2_CO2][k] * origGijk;
+      eijk[MODEL_H2_CO2][k] = 2 * origCijk * origEijk - bijk[MODEL_H2_CO2][k];
+      cijk[MODEL_H2_CO2][k] = -origCijk;
+    }
+  }
+
+  /**
+   * Main method for testing GERG-2008-H2 implementation.
+   *
+   * @param args command line arguments (not used)
+   */
+  @SuppressWarnings("unused")
+  @ExcludeFromJacocoGeneratedReport
+  public static void main(String[] args) {
+    GERG2008H2 test = new GERG2008H2();
+    test.SetupGERG();
+
+    double T = 300.0;
+    doubleW D = new doubleW(0.0);
+    doubleW P = new doubleW(10000.0);
+    intW ierr = new intW(0);
+    doubleW Mm = new doubleW(0.0);
+    doubleW Z = new doubleW(0.0);
+    int iFlag = 0;
+    StringW herr = new StringW("");
+
+    // Hydrogen-rich mixture test case
+    // 80% methane, 15% hydrogen, 5% nitrogen
+    double[] x = new double[22];
+    x[1] = 0.80; // Methane
+    x[2] = 0.05; // Nitrogen
+    x[15] = 0.15; // Hydrogen
+
+    test.MolarMassGERG(x, Mm);
+    System.out.println("GERG-2008-H2 Test Results for Hydrogen-Rich Mixture");
+    System.out.println("====================================================");
+    System.out.println("Composition: 80% CH4, 5% N2, 15% H2");
+    System.out.println("Temperature: " + T + " K");
+    System.out.println("Pressure: " + P.val + " kPa");
+    System.out.println();
+    System.out.println("Molar mass [g/mol]: " + Mm.val);
+
+    test.DensityGERG(iFlag, T, P.val, x, D, ierr, herr);
+    System.out.println("Molar density [mol/l]: " + D.val);
+    System.out.println("Error code: " + ierr.val);
+    if (ierr.val != 0) {
+      System.out.println("Error message: " + herr.val);
+    }
+
+    test.PressureGERG(T, D.val, x, P, Z);
+    System.out.println("Calculated pressure [kPa]: " + P.val);
+    System.out.println("Compressibility factor Z: " + Z.val);
+
+    doubleW dPdD = new doubleW(0.0);
+    doubleW d2PdD2 = new doubleW(0.0);
+    doubleW d2PdTD = new doubleW(0.0);
+    doubleW dPdT = new doubleW(0.0);
+    doubleW U = new doubleW(0.0);
+    doubleW H = new doubleW(0.0);
+    doubleW S = new doubleW(0.0);
+    doubleW A = new doubleW(0.0);
+    doubleW Cv = new doubleW(0.0);
+    doubleW Cp = new doubleW(0.0);
+    doubleW W = new doubleW(0.0);
+    doubleW G = new doubleW(0.0);
+    doubleW JT = new doubleW(0.0);
+    doubleW Kappa = new doubleW(0.0);
+
+    test.PropertiesGERG(T, D.val, x, P, Z, dPdD, d2PdD2, d2PdTD, dPdT, U, H, S, Cv, Cp, W, G, JT,
+        Kappa, A);
+
+    System.out.println();
+    System.out.println("Thermodynamic Properties:");
+    System.out.println("Internal energy [J/mol]: " + U.val);
+    System.out.println("Enthalpy [J/mol]: " + H.val);
+    System.out.println("Entropy [J/(mol·K)]: " + S.val);
+    System.out.println("Cv [J/(mol·K)]: " + Cv.val);
+    System.out.println("Cp [J/(mol·K)]: " + Cp.val);
+    System.out.println("Speed of sound [m/s]: " + W.val);
+    System.out.println("Gibbs energy [J/mol]: " + G.val);
+    System.out.println("Joule-Thomson coefficient [K/kPa]: " + JT.val);
+    System.out.println("Isentropic exponent: " + Kappa.val);
+
+    // Pure hydrogen test
+    System.out.println();
+    System.out.println("====================================================");
+    System.out.println("Pure Hydrogen Test");
+    System.out.println("====================================================");
+
+    double[] xH2 = new double[22];
+    xH2[15] = 1.0; // Pure hydrogen
+
+    test.MolarMassGERG(xH2, Mm);
+    System.out.println("Molar mass [g/mol]: " + Mm.val);
+
+    D.val = 0.0;
+    test.DensityGERG(iFlag, T, 10000.0, xH2, D, ierr, herr);
+    System.out.println("Molar density [mol/l]: " + D.val);
+
+    test.PropertiesGERG(T, D.val, xH2, P, Z, dPdD, d2PdD2, d2PdTD, dPdT, U, H, S, Cv, Cp, W, G, JT,
+        Kappa, A);
+    System.out.println("Compressibility factor Z: " + Z.val);
+    System.out.println("Speed of sound [m/s]: " + W.val);
+  }
+}

--- a/src/main/java/neqsim/thermo/util/gerg/GERG2008Type.java
+++ b/src/main/java/neqsim/thermo/util/gerg/GERG2008Type.java
@@ -1,0 +1,66 @@
+package neqsim.thermo.util.gerg;
+
+/**
+ * Enumeration of GERG-2008 model variants.
+ *
+ * <p>
+ * This enum defines the available variants of the GERG-2008 equation of state.
+ * </p>
+ *
+ * @author NeqSim team
+ * @version 1.0
+ */
+public enum GERG2008Type {
+  /**
+   * Standard GERG-2008 equation of state.
+   *
+   * <p>
+   * Reference: Kunz, O. and Wagner, W. (2012). "The GERG-2008 Wide-Range Equation of State for
+   * Natural Gases and Other Mixtures: An Expansion of GERG-2004". J. Chem. Eng. Data, 57,
+   * 3032-3091.
+   * </p>
+   */
+  STANDARD("GERG-2008", "Standard GERG-2008 equation of state"),
+
+  /**
+   * GERG-2008-H2 equation of state with improved hydrogen parameters.
+   *
+   * <p>
+   * Reference: Beckmüller, R., Thol, M., Sampson, I., Lemmon, E.W., Span, R. (2022). "Extension of
+   * the equation of state for natural gases GERG-2008 with improved hydrogen parameters". Fluid
+   * Phase Equilibria, 557, 113411.
+   * </p>
+   */
+  HYDROGEN_ENHANCED("GERG-2008-H2", "GERG-2008 with improved hydrogen parameters");
+
+  private final String name;
+  private final String description;
+
+  GERG2008Type(String name, String description) {
+    this.name = name;
+    this.description = description;
+  }
+
+  /**
+   * Get the display name of this model type.
+   *
+   * @return the display name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Get the description of this model type.
+   *
+   * @return the description
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+}

--- a/src/main/java/neqsim/thermo/util/gerg/NeqSimGERG2008.java
+++ b/src/main/java/neqsim/thermo/util/gerg/NeqSimGERG2008.java
@@ -23,6 +23,7 @@ public class NeqSimGERG2008 {
   double[] notNormalizedGERGComposition = new double[21 + 1];
   PhaseInterface phase = null;
   GERG2008 GERG2008 = new GERG2008();
+  private GERG2008Type modelType = GERG2008Type.STANDARD;
 
   /**
    * <p>
@@ -39,9 +40,61 @@ public class NeqSimGERG2008 {
    * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
    */
   public NeqSimGERG2008(PhaseInterface phase) {
+    this(phase, GERG2008Type.STANDARD);
+  }
+
+  /**
+   * <p>
+   * Constructor for NeqSimGERG2008 with specified model type.
+   * </p>
+   *
+   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
+   * @param modelType the GERG-2008 model variant to use (STANDARD or HYDROGEN_ENHANCED)
+   */
+  public NeqSimGERG2008(PhaseInterface phase, GERG2008Type modelType) {
+    this.modelType = modelType;
+    this.GERG2008 = createGERGModel(modelType);
     this.setPhase(phase);
     if (Double.isNaN(GERG2008.RGERG) || GERG2008.RGERG == 0) {
       GERG2008.SetupGERG();
+    }
+  }
+
+  /**
+   * Creates the appropriate GERG model instance based on the specified type.
+   *
+   * @param type the GERG-2008 model variant
+   * @return a GERG2008 instance (standard or H2-enhanced)
+   */
+  private static GERG2008 createGERGModel(GERG2008Type type) {
+    switch (type) {
+      case HYDROGEN_ENHANCED:
+        return new GERG2008H2();
+      case STANDARD:
+      default:
+        return new GERG2008();
+    }
+  }
+
+  /**
+   * Get the current GERG-2008 model type.
+   *
+   * @return the model type
+   */
+  public GERG2008Type getModelType() {
+    return modelType;
+  }
+
+  /**
+   * Set the GERG-2008 model type. This will recreate the internal GERG model.
+   *
+   * @param modelType the GERG-2008 model variant to use
+   */
+  public void setModelType(GERG2008Type modelType) {
+    if (this.modelType != modelType) {
+      this.modelType = modelType;
+      this.GERG2008 = createGERGModel(modelType);
+      this.GERG2008.SetupGERG();
     }
   }
 
@@ -401,7 +454,7 @@ public class NeqSimGERG2008 {
 
     // Call the GERG2008 function to fill in the ar array. The first two
     // arguments specify the highest order of \u03c4- and \u03b4-derivatives to
-    // return.  Thermodynamic consistency requires mixed temperature/volume
+    // return. Thermodynamic consistency requires mixed temperature/volume
     // derivatives as well as up to third-order volume derivatives, so request
     // \u03c4-derivatives up to second order and \u03b4-derivatives up to third
     // order.

--- a/src/test/java/neqsim/thermo/system/SystemGERG2008EosH2Test.java
+++ b/src/test/java/neqsim/thermo/system/SystemGERG2008EosH2Test.java
@@ -1,0 +1,151 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseGERG2008Eos;
+import neqsim.thermo.util.gerg.GERG2008Type;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Tests for SystemGERG2008Eos with GERG-2008-H2 model selection.
+ */
+class SystemGERG2008EosH2Test {
+
+  /**
+   * Test that the default model type is STANDARD.
+   */
+  @Test
+  void testDefaultModelType() {
+    SystemGERG2008Eos system = new SystemGERG2008Eos(298.15, 10.0);
+    assertEquals(GERG2008Type.STANDARD, system.getGergModelType());
+    assertFalse(system.isUsingHydrogenEnhancedModel());
+  }
+
+  /**
+   * Test setting the model type to HYDROGEN_ENHANCED.
+   */
+  @Test
+  void testSetHydrogenEnhancedModel() {
+    SystemGERG2008Eos system = new SystemGERG2008Eos(298.15, 10.0);
+    system.setGergModelType(GERG2008Type.HYDROGEN_ENHANCED);
+    assertEquals(GERG2008Type.HYDROGEN_ENHANCED, system.getGergModelType());
+    assertTrue(system.isUsingHydrogenEnhancedModel());
+    assertEquals("GERG2008-H2-EOS", system.getModelName());
+  }
+
+  /**
+   * Test the convenience method useHydrogenEnhancedModel().
+   */
+  @Test
+  void testUseHydrogenEnhancedModel() {
+    SystemGERG2008Eos system = new SystemGERG2008Eos(298.15, 10.0);
+    system.useHydrogenEnhancedModel();
+    assertTrue(system.isUsingHydrogenEnhancedModel());
+  }
+
+  /**
+   * Test that phases inherit the model type.
+   */
+  @Test
+  void testPhasesInheritModelType() {
+    SystemGERG2008Eos system = new SystemGERG2008Eos(298.15, 10.0);
+    system.addComponent("methane", 0.8);
+    system.addComponent("hydrogen", 0.2);
+    system.setGergModelType(GERG2008Type.HYDROGEN_ENHANCED);
+
+    // Check that phases have the correct model type
+    for (int i = 0; i < system.getNumberOfPhases(); i++) {
+      if (system.getPhase(i) instanceof PhaseGERG2008Eos) {
+        PhaseGERG2008Eos phase = (PhaseGERG2008Eos) system.getPhase(i);
+        assertEquals(GERG2008Type.HYDROGEN_ENHANCED, phase.getGergModelType());
+      }
+    }
+  }
+
+  /**
+   * Test that GERG-2008 and GERG-2008-H2 give different results for hydrogen mixtures.
+   */
+  @Test
+  void testH2ModelGivesDifferentResults() {
+    // Create system with standard GERG-2008
+    SystemGERG2008Eos systemStandard = new SystemGERG2008Eos(300.0, 50.0);
+    systemStandard.addComponent("methane", 0.7);
+    systemStandard.addComponent("hydrogen", 0.3);
+    ThermodynamicOperations opsStandard = new ThermodynamicOperations(systemStandard);
+    opsStandard.TPflash();
+    double densityStandard = systemStandard.getPhase(0).getDensity();
+
+    // Create system with GERG-2008-H2
+    SystemGERG2008Eos systemH2 = new SystemGERG2008Eos(300.0, 50.0);
+    systemH2.addComponent("methane", 0.7);
+    systemH2.addComponent("hydrogen", 0.3);
+    systemH2.useHydrogenEnhancedModel();
+    ThermodynamicOperations opsH2 = new ThermodynamicOperations(systemH2);
+    opsH2.TPflash();
+    double densityH2 = systemH2.getPhase(0).getDensity();
+
+    // The densities should be different (GERG-2008-H2 has updated parameters)
+    // The difference should be small but measurable
+    double relativeDifference = Math.abs(densityStandard - densityH2) / densityStandard * 100;
+    assertTrue(relativeDifference > 0.01, "Density difference should be measurable");
+    assertTrue(relativeDifference < 5.0, "Density difference should be within reasonable range");
+
+    System.out.println("GERG-2008 density: " + densityStandard + " kg/m3");
+    System.out.println("GERG-2008-H2 density: " + densityH2 + " kg/m3");
+    System.out.println("Relative difference: " + relativeDifference + "%");
+  }
+
+  /**
+   * Test CO2-H2 mixture where differences are most pronounced.
+   */
+  @Test
+  void testCO2H2MixtureDifferences() {
+    // CO2-H2 has a new departure function in GERG-2008-H2, so differences are larger
+    double temperature = 350.0; // K
+    double pressure = 100.0; // bar
+
+    // Standard GERG-2008
+    SystemGERG2008Eos systemStandard = new SystemGERG2008Eos(temperature, pressure);
+    systemStandard.addComponent("CO2", 0.5);
+    systemStandard.addComponent("hydrogen", 0.5);
+    ThermodynamicOperations opsStandard = new ThermodynamicOperations(systemStandard);
+    opsStandard.TPflash();
+
+    // GERG-2008-H2
+    SystemGERG2008Eos systemH2 = new SystemGERG2008Eos(temperature, pressure);
+    systemH2.addComponent("CO2", 0.5);
+    systemH2.addComponent("hydrogen", 0.5);
+    systemH2.useHydrogenEnhancedModel();
+    ThermodynamicOperations opsH2 = new ThermodynamicOperations(systemH2);
+    opsH2.TPflash();
+
+    double densityStandard = systemStandard.getPhase(0).getDensity();
+    double densityH2 = systemH2.getPhase(0).getDensity();
+
+    // CO2-H2 should show larger differences due to new departure function
+    double relativeDifference = Math.abs(densityStandard - densityH2) / densityStandard * 100;
+    assertTrue(relativeDifference > 0.1, "CO2-H2 should show significant differences");
+
+    System.out.println("CO2-H2 Mixture at " + temperature + " K, " + pressure + " bar:");
+    System.out.println("  GERG-2008 density: " + densityStandard + " kg/m3");
+    System.out.println("  GERG-2008-H2 density: " + densityH2 + " kg/m3");
+    System.out.println("  Relative difference: " + relativeDifference + "%");
+  }
+
+  /**
+   * Test cloning preserves the model type.
+   */
+  @Test
+  void testClonePreservesModelType() {
+    SystemGERG2008Eos system = new SystemGERG2008Eos(298.15, 10.0);
+    system.addComponent("methane", 0.8);
+    system.addComponent("hydrogen", 0.2);
+    system.useHydrogenEnhancedModel();
+
+    SystemGERG2008Eos clonedSystem = system.clone();
+    assertEquals(GERG2008Type.HYDROGEN_ENHANCED, clonedSystem.getGergModelType());
+    assertTrue(clonedSystem.isUsingHydrogenEnhancedModel());
+  }
+}

--- a/src/test/java/neqsim/thermo/util/gerg/GERG2008H2ComparisonTest.java
+++ b/src/test/java/neqsim/thermo/util/gerg/GERG2008H2ComparisonTest.java
@@ -1,0 +1,477 @@
+package neqsim.thermo.util.gerg;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.netlib.util.StringW;
+import org.netlib.util.doubleW;
+import org.netlib.util.intW;
+
+/**
+ * Comparison test between GERG-2008 and GERG-2008-H2 for hydrogen-containing mixtures.
+ *
+ * <p>
+ * This test class compares the two models to verify that GERG-2008-H2 produces different (and
+ * presumably more accurate) results for hydrogen-rich mixtures, as described in Beckmüller et al.
+ * (2022).
+ * </p>
+ */
+public class GERG2008H2ComparisonTest {
+  private GERG2008 gergStandard;
+  private GERG2008H2 gergH2;
+
+  @BeforeEach
+  public void setUp() {
+    gergStandard = new GERG2008();
+    gergStandard.SetupGERG();
+
+    gergH2 = new GERG2008H2();
+    gergH2.SetupGERG();
+  }
+
+  /**
+   * Compare density predictions for CH4-H2 binary mixtures at various compositions. The paper shows
+   * improved accuracy for hydrogen-methane mixtures.
+   */
+  @Test
+  public void compareCH4H2BinaryDensity() {
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println("COMPARISON: CH4-H2 Binary Mixture Density");
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println();
+
+    double T = 300.0; // K
+    double P = 10000.0; // kPa (10 MPa)
+
+    System.out.printf("Conditions: T = %.1f K, P = %.1f kPa (%.1f MPa)%n", T, P, P / 1000.0);
+    System.out.println();
+    System.out.printf("%-10s %-15s %-15s %-15s %-15s%n", "x(H2)", "ρ GERG-2008", "ρ GERG-2008-H2",
+        "Δρ (mol/L)", "Δρ (%)");
+    System.out.println(StringUtils.repeat("-", 80));
+
+    double[] h2Fractions = {0.0, 0.05, 0.10, 0.20, 0.30, 0.50, 0.70, 1.0};
+
+    for (double xH2 : h2Fractions) {
+      double[] x = new double[22];
+      x[1] = 1.0 - xH2; // Methane
+      x[15] = xH2; // Hydrogen
+
+      doubleW D1 = new doubleW(0.0);
+      doubleW D2 = new doubleW(0.0);
+      intW ierr = new intW(0);
+      StringW herr = new StringW("");
+
+      gergStandard.DensityGERG(0, T, P, x, D1, ierr, herr);
+      gergH2.DensityGERG(0, T, P, x, D2, ierr, herr);
+
+      double deltaD = D2.val - D1.val;
+      double relDiff = (D1.val != 0) ? (deltaD / D1.val) * 100 : 0;
+
+      System.out.printf("%-10.2f %-15.6f %-15.6f %-15.6f %-15.4f%n", xH2, D1.val, D2.val, deltaD,
+          relDiff);
+    }
+    System.out.println();
+  }
+
+  /**
+   * Compare compressibility factor predictions for N2-H2 binary mixtures. This is a new binary
+   * interaction in GERG-2008-H2.
+   */
+  @Test
+  public void compareN2H2BinaryCompressibility() {
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println("COMPARISON: N2-H2 Binary Mixture Compressibility Factor");
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println();
+
+    double T = 300.0; // K
+    double P = 20000.0; // kPa (20 MPa)
+
+    System.out.printf("Conditions: T = %.1f K, P = %.1f kPa (%.1f MPa)%n", T, P, P / 1000.0);
+    System.out.println();
+    System.out.printf("%-10s %-15s %-15s %-15s %-15s%n", "x(H2)", "Z GERG-2008", "Z GERG-2008-H2",
+        "ΔZ", "ΔZ (%)");
+    System.out.println(StringUtils.repeat("-", 80));
+
+    double[] h2Fractions = {0.0, 0.10, 0.20, 0.30, 0.50, 0.70, 1.0};
+
+    for (double xH2 : h2Fractions) {
+      double[] x = new double[22];
+      x[2] = 1.0 - xH2; // Nitrogen
+      x[15] = xH2; // Hydrogen
+
+      doubleW D1 = new doubleW(0.0);
+      doubleW D2 = new doubleW(0.0);
+      doubleW P1 = new doubleW(0.0);
+      doubleW P2 = new doubleW(0.0);
+      doubleW Z1 = new doubleW(0.0);
+      doubleW Z2 = new doubleW(0.0);
+      intW ierr = new intW(0);
+      StringW herr = new StringW("");
+
+      gergStandard.DensityGERG(0, T, P, x, D1, ierr, herr);
+      gergH2.DensityGERG(0, T, P, x, D2, ierr, herr);
+
+      gergStandard.PressureGERG(T, D1.val, x, P1, Z1);
+      gergH2.PressureGERG(T, D2.val, x, P2, Z2);
+
+      double deltaZ = Z2.val - Z1.val;
+      double relDiff = (Z1.val != 0) ? (deltaZ / Z1.val) * 100 : 0;
+
+      System.out.printf("%-10.2f %-15.6f %-15.6f %-15.6f %-15.4f%n", xH2, Z1.val, Z2.val, deltaZ,
+          relDiff);
+    }
+    System.out.println();
+  }
+
+  /**
+   * Compare CO2-H2 binary mixtures - another new binary in GERG-2008-H2.
+   */
+  @Test
+  public void compareCO2H2BinaryDensity() {
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println("COMPARISON: CO2-H2 Binary Mixture Density");
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println();
+
+    double T = 350.0; // K (higher to avoid CO2 liquid)
+    double P = 10000.0; // kPa
+
+    System.out.printf("Conditions: T = %.1f K, P = %.1f kPa (%.1f MPa)%n", T, P, P / 1000.0);
+    System.out.println();
+    System.out.printf("%-10s %-15s %-15s %-15s %-15s%n", "x(H2)", "ρ GERG-2008", "ρ GERG-2008-H2",
+        "Δρ (mol/L)", "Δρ (%)");
+    System.out.println(StringUtils.repeat("-", 80));
+
+    double[] h2Fractions = {0.0, 0.10, 0.20, 0.30, 0.50, 0.70, 1.0};
+
+    for (double xH2 : h2Fractions) {
+      double[] x = new double[22];
+      x[3] = 1.0 - xH2; // CO2
+      x[15] = xH2; // Hydrogen
+
+      doubleW D1 = new doubleW(0.0);
+      doubleW D2 = new doubleW(0.0);
+      intW ierr = new intW(0);
+      StringW herr = new StringW("");
+
+      gergStandard.DensityGERG(0, T, P, x, D1, ierr, herr);
+      gergH2.DensityGERG(0, T, P, x, D2, ierr, herr);
+
+      double deltaD = D2.val - D1.val;
+      double relDiff = (D1.val != 0) ? (deltaD / D1.val) * 100 : 0;
+
+      System.out.printf("%-10.2f %-15.6f %-15.6f %-15.6f %-15.4f%n", xH2, D1.val, D2.val, deltaD,
+          relDiff);
+    }
+    System.out.println();
+  }
+
+  /**
+   * Compare speed of sound predictions - paper shows improvements here.
+   */
+  @Test
+  public void compareSpeedOfSound() {
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println("COMPARISON: Speed of Sound in CH4-H2 Mixtures");
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println();
+
+    double T = 300.0; // K
+    double P = 5000.0; // kPa
+
+    System.out.printf("Conditions: T = %.1f K, P = %.1f kPa (%.1f MPa)%n", T, P, P / 1000.0);
+    System.out.println();
+    System.out.printf("%-10s %-15s %-15s %-15s %-15s%n", "x(H2)", "W GERG-2008", "W GERG-2008-H2",
+        "ΔW (m/s)", "ΔW (%)");
+    System.out.println(StringUtils.repeat("-", 80));
+
+    double[] h2Fractions = {0.0, 0.05, 0.10, 0.20, 0.30, 0.50, 1.0};
+
+    for (double xH2 : h2Fractions) {
+      double[] x = new double[22];
+      x[1] = 1.0 - xH2; // Methane
+      x[15] = xH2; // Hydrogen
+
+      double[] props1 = calculateProperties(gergStandard, T, P, x);
+      double[] props2 = calculateProperties(gergH2, T, P, x);
+
+      double W1 = props1[0];
+      double W2 = props2[0];
+      double deltaW = W2 - W1;
+      double relDiff = (W1 != 0) ? (deltaW / W1) * 100 : 0;
+
+      System.out.printf("%-10.2f %-15.4f %-15.4f %-15.4f %-15.4f%n", xH2, W1, W2, deltaW, relDiff);
+    }
+    System.out.println();
+  }
+
+  /**
+   * Compare heat capacities - Cp and Cv.
+   */
+  @Test
+  public void compareHeatCapacities() {
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println("COMPARISON: Heat Capacities (Cp) in CH4-H2 Mixtures");
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println();
+
+    double T = 300.0;
+    double P = 10000.0;
+
+    System.out.printf("Conditions: T = %.1f K, P = %.1f kPa (%.1f MPa)%n", T, P, P / 1000.0);
+    System.out.println();
+    System.out.printf("%-10s %-15s %-15s %-15s %-15s%n", "x(H2)", "Cp GERG-2008", "Cp GERG-2008-H2",
+        "ΔCp", "ΔCp (%)");
+    System.out.println(StringUtils.repeat("-", 80));
+
+    double[] h2Fractions = {0.0, 0.10, 0.20, 0.30, 0.50, 1.0};
+
+    for (double xH2 : h2Fractions) {
+      double[] x = new double[22];
+      x[1] = 1.0 - xH2;
+      x[15] = xH2;
+
+      double[] props1 = calculateProperties(gergStandard, T, P, x);
+      double[] props2 = calculateProperties(gergH2, T, P, x);
+
+      double Cp1 = props1[1];
+      double Cp2 = props2[1];
+      double deltaCp = Cp2 - Cp1;
+      double relDiff = (Cp1 != 0) ? (deltaCp / Cp1) * 100 : 0;
+
+      System.out.printf("%-10.2f %-15.4f %-15.4f %-15.4f %-15.4f%n", xH2, Cp1, Cp2, deltaCp,
+          relDiff);
+    }
+    System.out.println();
+  }
+
+  /**
+   * Compare at high pressures - paper shows larger differences at higher pressures.
+   */
+  @Test
+  public void comparePressureEffect() {
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println("COMPARISON: Pressure Effect on CH4-H2 (50/50) Mixture Density");
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println();
+
+    double T = 300.0;
+    double xH2 = 0.50;
+
+    double[] x = new double[22];
+    x[1] = 0.50; // Methane
+    x[15] = 0.50; // Hydrogen
+
+    System.out.printf("Composition: 50%% CH4, 50%% H2 at T = %.1f K%n", T);
+    System.out.println();
+    System.out.printf("%-15s %-15s %-15s %-15s %-15s%n", "P (MPa)", "ρ GERG-2008", "ρ GERG-2008-H2",
+        "Δρ (mol/L)", "Δρ (%)");
+    System.out.println(StringUtils.repeat("-", 80));
+
+    double[] pressures = {1000, 2000, 5000, 10000, 20000, 30000, 50000}; // kPa
+
+    for (double P : pressures) {
+      doubleW D1 = new doubleW(0.0);
+      doubleW D2 = new doubleW(0.0);
+      intW ierr = new intW(0);
+      StringW herr = new StringW("");
+
+      gergStandard.DensityGERG(0, T, P, x, D1, ierr, herr);
+      gergH2.DensityGERG(0, T, P, x, D2, ierr, herr);
+
+      double deltaD = D2.val - D1.val;
+      double relDiff = (D1.val != 0) ? (deltaD / D1.val) * 100 : 0;
+
+      System.out.printf("%-15.1f %-15.6f %-15.6f %-15.6f %-15.4f%n", P / 1000.0, D1.val, D2.val,
+          deltaD, relDiff);
+    }
+    System.out.println();
+  }
+
+  /**
+   * Compare temperature effect on hydrogen-rich natural gas.
+   */
+  @Test
+  public void compareTemperatureEffect() {
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println("COMPARISON: Temperature Effect on Hydrogen-Rich Natural Gas");
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println();
+
+    double P = 10000.0; // kPa
+
+    // Hydrogen-enriched natural gas composition
+    double[] x = new double[22];
+    x[1] = 0.70; // Methane
+    x[2] = 0.02; // Nitrogen
+    x[3] = 0.01; // CO2
+    x[4] = 0.05; // Ethane
+    x[5] = 0.02; // Propane
+    x[15] = 0.20; // Hydrogen
+
+    System.out
+        .println("Composition: 70% CH4, 2% N2, 1% CO2, 5% C2H6, 2% C3H8, 20% H2 at P = 10 MPa");
+    System.out.println();
+    System.out.printf("%-15s %-15s %-15s %-15s %-15s%n", "T (K)", "ρ GERG-2008", "ρ GERG-2008-H2",
+        "Δρ (mol/L)", "Δρ (%)");
+    System.out.println(StringUtils.repeat("-", 80));
+
+    double[] temperatures = {200, 250, 300, 350, 400, 450, 500};
+
+    for (double T : temperatures) {
+      doubleW D1 = new doubleW(0.0);
+      doubleW D2 = new doubleW(0.0);
+      intW ierr = new intW(0);
+      StringW herr = new StringW("");
+
+      gergStandard.DensityGERG(0, T, P, x, D1, ierr, herr);
+      gergH2.DensityGERG(0, T, P, x, D2, ierr, herr);
+
+      double deltaD = D2.val - D1.val;
+      double relDiff = (D1.val != 0) ? (deltaD / D1.val) * 100 : 0;
+
+      System.out.printf("%-15.1f %-15.6f %-15.6f %-15.6f %-15.4f%n", T, D1.val, D2.val, deltaD,
+          relDiff);
+    }
+    System.out.println();
+  }
+
+  /**
+   * Compare Joule-Thomson coefficient - important for hydrogen handling.
+   */
+  @Test
+  public void compareJouleThomson() {
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println("COMPARISON: Joule-Thomson Coefficient in CH4-H2 Mixtures");
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println();
+
+    double T = 300.0;
+    double P = 10000.0;
+
+    System.out.printf("Conditions: T = %.1f K, P = %.1f kPa (%.1f MPa)%n", T, P, P / 1000.0);
+    System.out.println();
+    System.out.printf("%-10s %-18s %-18s %-18s%n", "x(H2)", "JT GERG-2008", "JT GERG-2008-H2",
+        "ΔJT (%)");
+    System.out.println(StringUtils.repeat("-", 80));
+
+    double[] h2Fractions = {0.0, 0.10, 0.20, 0.30, 0.50, 1.0};
+
+    for (double xH2 : h2Fractions) {
+      double[] x = new double[22];
+      x[1] = 1.0 - xH2;
+      x[15] = xH2;
+
+      double[] props1 = calculateProperties(gergStandard, T, P, x);
+      double[] props2 = calculateProperties(gergH2, T, P, x);
+
+      double JT1 = props1[2];
+      double JT2 = props2[2];
+      double relDiff = (JT1 != 0) ? ((JT2 - JT1) / Math.abs(JT1)) * 100 : 0;
+
+      System.out.printf("%-10.2f %-18.6e %-18.6e %-18.4f%n", xH2, JT1, JT2, relDiff);
+    }
+    System.out.println();
+    System.out.println("Note: Negative JT coefficient indicates inverse Joule-Thomson effect");
+    System.out.println("(cooling upon expansion), which is characteristic of hydrogen.");
+    System.out.println();
+  }
+
+  /**
+   * Summary comparison showing all deviations.
+   */
+  @Test
+  public void summarizeDeviations() {
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println("SUMMARY: Maximum Deviations Between GERG-2008 and GERG-2008-H2");
+    System.out.println(StringUtils.repeat("=", 80));
+    System.out.println();
+
+    double T = 300.0;
+    double P = 10000.0;
+
+    // Different binary systems
+    String[] systems = {"CH4-H2", "N2-H2", "CO2-H2 (T=350K)", "C2H6-H2"};
+    int[][] components = {{1, 15}, {2, 15}, {3, 15}, {4, 15}};
+    double[] temps = {300, 300, 350, 300};
+
+    System.out.println("Binary System Analysis at P = 10 MPa, x(H2) = 0.50");
+    System.out.println();
+    System.out.printf("%-20s %-15s %-15s %-15s%n", "System", "Δρ (%)", "ΔZ (%)", "ΔW (%)");
+    System.out.println(StringUtils.repeat("-", 65));
+
+    for (int s = 0; s < systems.length; s++) {
+      double[] x = new double[22];
+      x[components[s][0]] = 0.50;
+      x[components[s][1]] = 0.50;
+
+      doubleW D1 = new doubleW(0.0);
+      doubleW D2 = new doubleW(0.0);
+      intW ierr = new intW(0);
+      StringW herr = new StringW("");
+
+      double useT = temps[s];
+      gergStandard.DensityGERG(0, useT, P, x, D1, ierr, herr);
+      gergH2.DensityGERG(0, useT, P, x, D2, ierr, herr);
+
+      double[] props1 = calculatePropertiesAtDensity(gergStandard, useT, D1.val, x);
+      double[] props2 = calculatePropertiesAtDensity(gergH2, useT, D2.val, x);
+
+      double relDiffD = (D1.val != 0) ? ((D2.val - D1.val) / D1.val) * 100 : 0;
+      double relDiffZ = (props1[3] != 0) ? ((props2[3] - props1[3]) / props1[3]) * 100 : 0;
+      double relDiffW = (props1[0] != 0) ? ((props2[0] - props1[0]) / props1[0]) * 100 : 0;
+
+      System.out.printf("%-20s %-15.4f %-15.4f %-15.4f%n", systems[s], relDiffD, relDiffZ,
+          relDiffW);
+    }
+
+    System.out.println();
+    System.out.println("Key Observations:");
+    System.out.println(
+        "1. Differences are most significant for CO2-H2 and N2-H2 due to new departure functions");
+    System.out
+        .println("2. CH4-H2 shows smaller differences as it already had a departure function");
+    System.out.println("3. Differences increase with hydrogen content and pressure");
+    System.out.println();
+  }
+
+  /**
+   * Helper method to calculate thermodynamic properties.
+   */
+  private double[] calculateProperties(GERG2008 gerg, double T, double P, double[] x) {
+    doubleW D = new doubleW(0.0);
+    intW ierr = new intW(0);
+    StringW herr = new StringW("");
+
+    gerg.DensityGERG(0, T, P, x, D, ierr, herr);
+    return calculatePropertiesAtDensity(gerg, T, D.val, x);
+  }
+
+  /**
+   * Helper method to calculate properties at given density.
+   */
+  private double[] calculatePropertiesAtDensity(GERG2008 gerg, double T, double D, double[] x) {
+    doubleW PP = new doubleW(0.0);
+    doubleW Z = new doubleW(0.0);
+    doubleW dPdD = new doubleW(0.0);
+    doubleW d2PdD2 = new doubleW(0.0);
+    doubleW d2PdTD = new doubleW(0.0);
+    doubleW dPdT = new doubleW(0.0);
+    doubleW U = new doubleW(0.0);
+    doubleW H = new doubleW(0.0);
+    doubleW S = new doubleW(0.0);
+    doubleW Cv = new doubleW(0.0);
+    doubleW Cp = new doubleW(0.0);
+    doubleW W = new doubleW(0.0);
+    doubleW G = new doubleW(0.0);
+    doubleW JT = new doubleW(0.0);
+    doubleW Kappa = new doubleW(0.0);
+    doubleW A = new doubleW(0.0);
+
+    gerg.PropertiesGERG(T, D, x, PP, Z, dPdD, d2PdD2, d2PdTD, dPdT, U, H, S, Cv, Cp, W, G, JT,
+        Kappa, A);
+
+    return new double[] {W.val, Cp.val, JT.val, Z.val, Cv.val, H.val, S.val};
+  }
+}

--- a/src/test/java/neqsim/thermo/util/gerg/GERG2008H2Test.java
+++ b/src/test/java/neqsim/thermo/util/gerg/GERG2008H2Test.java
@@ -1,0 +1,266 @@
+package neqsim.thermo.util.gerg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.netlib.util.StringW;
+import org.netlib.util.doubleW;
+import org.netlib.util.intW;
+
+/**
+ * Test class for GERG-2008-H2 equation of state with improved hydrogen parameters.
+ *
+ * <p>
+ * Tests verify that the improved hydrogen binary interaction parameters provide sensible results
+ * for hydrogen-rich natural gas mixtures.
+ * </p>
+ */
+public class GERG2008H2Test {
+  private GERG2008H2 gerg;
+  static Logger logger = LogManager.getLogger(GERG2008H2Test.class);
+
+  @BeforeEach
+  public void setUp() {
+    gerg = new GERG2008H2();
+    gerg.SetupGERG();
+  }
+
+  @Test
+  public void testMolarMassGERGHydrogenMixture() {
+    double[] x = new double[22];
+    x[1] = 0.80; // Methane
+    x[2] = 0.05; // Nitrogen
+    x[15] = 0.15; // Hydrogen
+    doubleW Mm = new doubleW(0.0);
+    gerg.MolarMassGERG(x, Mm);
+    // Expected: 0.80*16.04246 + 0.05*28.0134 + 0.15*2.01588 = ~14.537
+    assertEquals(14.537, Mm.val, 0.01);
+  }
+
+  @Test
+  public void testPureHydrogen() {
+    double T = 300.0;
+    double[] x = new double[22];
+    x[15] = 1.0; // Pure hydrogen
+    doubleW P = new doubleW(0.0);
+    doubleW Z = new doubleW(0.0);
+    doubleW D = new doubleW(0.0);
+    intW ierr = new intW(0);
+    StringW herr = new StringW("");
+
+    // Test density calculation at 10 MPa
+    gerg.DensityGERG(0, T, 10000.0, x, D, ierr, herr);
+    assertEquals(0, ierr.val);
+    assertTrue(D.val > 0, "Density should be positive");
+
+    // Test pressure calculation
+    gerg.PressureGERG(T, D.val, x, P, Z);
+    assertTrue(P.val > 0, "Pressure should be positive");
+    assertTrue(Z.val > 0, "Compressibility factor should be positive");
+    assertEquals(10000.0, P.val, 1.0); // Should recover input pressure within 1 kPa
+  }
+
+  @Test
+  public void testMethaneHydrogenBinary() {
+    double T = 300.0;
+    double P = 5000.0;
+    double[] x = new double[22];
+    x[1] = 0.90; // Methane
+    x[15] = 0.10; // Hydrogen
+    doubleW D = new doubleW(0.0);
+    intW ierr = new intW(0);
+    StringW herr = new StringW("");
+
+    gerg.DensityGERG(0, T, P, x, D, ierr, herr);
+    assertEquals(0, ierr.val, "Should converge without error");
+    assertTrue(D.val > 0, "Density should be positive");
+
+    // Test properties
+    doubleW PP = new doubleW(0.0);
+    doubleW Z = new doubleW(0.0);
+    doubleW dPdD = new doubleW(0.0);
+    doubleW d2PdD2 = new doubleW(0.0);
+    doubleW d2PdTD = new doubleW(0.0);
+    doubleW dPdT = new doubleW(0.0);
+    doubleW U = new doubleW(0.0);
+    doubleW H = new doubleW(0.0);
+    doubleW S = new doubleW(0.0);
+    doubleW Cv = new doubleW(0.0);
+    doubleW Cp = new doubleW(0.0);
+    doubleW W = new doubleW(0.0);
+    doubleW G = new doubleW(0.0);
+    doubleW JT = new doubleW(0.0);
+    doubleW Kappa = new doubleW(0.0);
+    doubleW A = new doubleW(0.0);
+
+    gerg.PropertiesGERG(T, D.val, x, PP, Z, dPdD, d2PdD2, d2PdTD, dPdT, U, H, S, Cv, Cp, W, G, JT,
+        Kappa, A);
+
+    assertTrue(Z.val > 0.9, "Z factor should be close to ideal at these conditions");
+    assertTrue(Cp.val > Cv.val, "Cp should be greater than Cv");
+    assertTrue(W.val > 0, "Speed of sound should be positive");
+    // Hydrogen mixture should have higher speed of sound than pure methane
+    assertTrue(W.val > 400, "Speed of sound should be > 400 m/s for this H2-CH4 mixture");
+  }
+
+  @Test
+  public void testNitrogenHydrogenBinary() {
+    double T = 300.0;
+    double P = 10000.0;
+    double[] x = new double[22];
+    x[2] = 0.50; // Nitrogen
+    x[15] = 0.50; // Hydrogen
+    doubleW D = new doubleW(0.0);
+    intW ierr = new intW(0);
+    StringW herr = new StringW("");
+
+    gerg.DensityGERG(0, T, P, x, D, ierr, herr);
+    assertEquals(0, ierr.val, "Should converge without error for N2-H2 mixture");
+    assertTrue(D.val > 0, "Density should be positive");
+  }
+
+  @Test
+  public void testCO2HydrogenBinary() {
+    double T = 350.0; // Higher temperature for CO2 to avoid liquid phase
+    double P = 5000.0;
+    double[] x = new double[22];
+    x[3] = 0.70; // CO2
+    x[15] = 0.30; // Hydrogen
+    doubleW D = new doubleW(0.0);
+    intW ierr = new intW(0);
+    StringW herr = new StringW("");
+
+    gerg.DensityGERG(0, T, P, x, D, ierr, herr);
+    assertEquals(0, ierr.val, "Should converge without error for CO2-H2 mixture");
+    assertTrue(D.val > 0, "Density should be positive");
+  }
+
+  @Test
+  public void testHydrogenRichNaturalGas() {
+    double T = 300.0;
+    double P = 10000.0;
+    // Typical composition for hydrogen-enriched natural gas
+    double[] x = new double[22];
+    x[1] = 0.70; // Methane
+    x[2] = 0.02; // Nitrogen
+    x[3] = 0.01; // CO2
+    x[4] = 0.05; // Ethane
+    x[5] = 0.02; // Propane
+    x[15] = 0.20; // Hydrogen
+
+    doubleW D = new doubleW(0.0);
+    intW ierr = new intW(0);
+    StringW herr = new StringW("");
+
+    gerg.DensityGERG(0, T, P, x, D, ierr, herr);
+    assertEquals(0, ierr.val, "Should converge for hydrogen-rich natural gas");
+    assertTrue(D.val > 0, "Density should be positive");
+
+    // Verify molar mass calculation
+    doubleW Mm = new doubleW(0.0);
+    gerg.MolarMassGERG(x, Mm);
+    assertTrue(Mm.val > 10 && Mm.val < 20,
+        "Molar mass should be between 10 and 20 g/mol for this mixture");
+  }
+
+  @Test
+  public void testComparisonWithStandardGERG2008() {
+    // Test that GERG-2008-H2 gives similar but different results for pure methane
+    GERG2008 standardGerg = new GERG2008();
+    standardGerg.SetupGERG();
+
+    double T = 300.0;
+    double[] x = new double[22];
+    x[1] = 1.0; // Pure methane
+
+    doubleW D1 = new doubleW(0.0);
+    doubleW D2 = new doubleW(0.0);
+    intW ierr = new intW(0);
+    StringW herr = new StringW("");
+
+    // For pure methane, results should be identical
+    standardGerg.DensityGERG(0, T, 10000.0, x, D1, ierr, herr);
+    gerg.DensityGERG(0, T, 10000.0, x, D2, ierr, herr);
+
+    assertEquals(D1.val, D2.val, 1e-10, "Pure methane density should be identical");
+  }
+
+  @Test
+  public void testHydrogenDensityDifferenceFromStandardGERG() {
+    // Test that GERG-2008-H2 gives different results for H2-CH4 mixtures
+    GERG2008 standardGerg = new GERG2008();
+    standardGerg.SetupGERG();
+
+    double T = 300.0;
+    double[] x = new double[22];
+    x[1] = 0.80; // Methane
+    x[15] = 0.20; // Hydrogen
+
+    doubleW D1 = new doubleW(0.0);
+    doubleW D2 = new doubleW(0.0);
+    intW ierr1 = new intW(0);
+    intW ierr2 = new intW(0);
+    StringW herr = new StringW("");
+
+    standardGerg.DensityGERG(0, T, 10000.0, x, D1, ierr1, herr);
+    gerg.DensityGERG(0, T, 10000.0, x, D2, ierr2, herr);
+
+    assertEquals(0, ierr1.val, "Standard GERG should converge");
+    assertEquals(0, ierr2.val, "GERG-H2 should converge");
+
+    // The densities should be close but not identical due to improved parameters
+    // The relative difference is typically small (< 1%)
+    double relDiff = Math.abs(D1.val - D2.val) / D1.val;
+    assertTrue(relDiff < 0.02, "Density difference should be less than 2% for improved parameters");
+
+    logger.info("Standard GERG-2008 density: {} mol/l", D1.val);
+    logger.info("GERG-2008-H2 density: {} mol/l", D2.val);
+    logger.info("Relative difference: {}%", relDiff * 100);
+  }
+
+  @Test
+  public void testPropertiesForPureHydrogen() {
+    double T = 300.0;
+    double[] x = new double[22];
+    x[15] = 1.0; // Pure hydrogen
+
+    doubleW D = new doubleW(0.0);
+    intW ierr = new intW(0);
+    StringW herr = new StringW("");
+
+    gerg.DensityGERG(0, T, 10000.0, x, D, ierr, herr);
+    assertEquals(0, ierr.val);
+
+    doubleW P = new doubleW(0.0);
+    doubleW Z = new doubleW(0.0);
+    doubleW dPdD = new doubleW(0.0);
+    doubleW d2PdD2 = new doubleW(0.0);
+    doubleW d2PdTD = new doubleW(0.0);
+    doubleW dPdT = new doubleW(0.0);
+    doubleW U = new doubleW(0.0);
+    doubleW H = new doubleW(0.0);
+    doubleW S = new doubleW(0.0);
+    doubleW Cv = new doubleW(0.0);
+    doubleW Cp = new doubleW(0.0);
+    doubleW W = new doubleW(0.0);
+    doubleW G = new doubleW(0.0);
+    doubleW JT = new doubleW(0.0);
+    doubleW Kappa = new doubleW(0.0);
+    doubleW A = new doubleW(0.0);
+
+    gerg.PropertiesGERG(T, D.val, x, P, Z, dPdD, d2PdD2, d2PdTD, dPdT, U, H, S, Cv, Cp, W, G, JT,
+        Kappa, A);
+
+    // Hydrogen has very high speed of sound (~1300 m/s at 300K, 10 MPa)
+    assertTrue(W.val > 1000, "Pure H2 speed of sound should be > 1000 m/s");
+    assertTrue(Z.val > 1.0,
+        "Pure H2 compressibility factor should be > 1 at high pressure (repulsive behavior)");
+
+    // Hydrogen has relatively low heat capacities
+    assertTrue(Cv.val > 15 && Cv.val < 25, "H2 Cv should be around 20 J/(mol·K)");
+    assertTrue(Cp.val > Cv.val, "Cp should be greater than Cv");
+  }
+}


### PR DESCRIPTION
## Add GERG-2008-H2 Model with Improved Hydrogen Parameters

### Summary
Implements the GERG-2008-H2 equation of state extension with improved hydrogen binary interaction parameters based on Beckmüller et al. (2022).

### Changes
- **New `GERG2008H2` class** - Extends `GERG2008` with updated hydrogen parameters for CH₄-H₂, N₂-H₂, CO₂-H₂, and other binaries
- **New `GERG2008Type` enum** - `STANDARD` and `HYDROGEN_ENHANCED` model selection
- **Updated `SystemGERG2008Eos`** - Added `useHydrogenEnhancedModel()` and `setGergModelType()` methods
- **Updated `NeqSimGERG2008`** - Constructor accepts model type parameter
- **Documentation** - Added GERG-2008-H2 section to `docs/thermo/gerg2008_eoscg.md`

### Usage
```java
SystemGERG2008Eos fluid = new SystemGERG2008Eos(300.0, 50.0);
fluid.addComponent("methane", 0.7);
fluid.addComponent("hydrogen", 0.3);
fluid.useHydrogenEnhancedModel();  // Enable GERG-2008-H2
```

### Key Differences from GERG-2008
| Binary | Density Difference |
|--------|-------------------|
| CO₂-H₂ | ~1.2% |
| C₂H₆-H₂ | ~0.8% |
| CH₄-H₂ | ~0.1-0.25% |
| N₂-H₂ | ~0.05-0.5% |

### Reference
Beckmüller, R. et al. (2022). "Extension of the equation of state for natural gases GERG-2008 with improved hydrogen parameters". *Fluid Phase Equilibria*, 557, 113411.

