### PR TITLE
update paperlab

### DIFF
--- a/neqsim-paperlab/README.md
+++ b/neqsim-paperlab/README.md
@@ -1,7 +1,46 @@
 # NeqSim PaperLab
 
-A structured, agent-driven workflow for producing rigorous scientific papers
-using NeqSim as the computational engine.
+A structured, iterative workflow for producing rigorous scientific papers
+using NeqSim as the computational engine. Combines CLI automation (benchmarks,
+formatting, auditing, quality checks) with agent-assisted writing for a
+human-in-the-loop paper production process.
+
+## Setup
+
+```bash
+cd neqsim-paperlab
+pip install -r requirements.txt
+```
+
+## The Core Loop: Edit → Iterate → Fix
+
+PaperLab is designed for **iterative refinement** between human and machine.
+The `iterate` command is the heartbeat:
+
+```
+┌─────────────┐     ┌──────────────┐     ┌─────────────┐
+│ Edit paper   │ --> │  iterate     │ --> │ Fix issues   │
+│ (human or    │     │  (quality    │     │ (human or    │
+│  agent)      │     │   checks)    │     │  agent)      │
+└─────────────┘     └──────────────┘     └─────────────┘
+       ^                                        │
+       └────────────────────────────────────────┘
+                   Repeat until 100%
+```
+
+```bash
+# Check manuscript quality — run after every editing session
+python paperflow.py iterate papers/my_paper/ --check all
+
+# Available check categories:
+#   all         — everything below
+#   structure   — section presence (Abstract, Intro, Conclusions, etc.)
+#   completeness — TODO placeholders, highlights count/length
+#   evidence    — results traceability, figure references, claim linking
+#   writing     — abstract word count, software-centric language
+```
+
+**See [WALKTHROUGH.md](WALKTHROUGH.md) for a complete end-to-end example.**
 
 ## Architecture
 
@@ -33,23 +72,49 @@ The framework supports four paper types, each with adapted stage routing:
 # 1. Create a new paper project (specify paper_type!)
 python paperflow.py new "Reactive Gibbs Convergence" \
     --journal fluid_phase_equilibria \
-    --topic gibbs_reactor \
-    --paper_type characterization
+    --topic gibbs_reactor
 
-# 2. Run the benchmark suite
+# 2. Edit plan.json — fill in research questions, benchmark design, paper_type
+
+# 3. Run the benchmark suite
 python paperflow.py benchmark papers/gibbs_reactor_2026/
 
-# 3. Generate figures and tables
+# 4. Generate figures (auto-runs generate_figures.py if present)
 python paperflow.py figures papers/gibbs_reactor_2026/
 
-# 4. Draft the manuscript
+# 5. Generate a manuscript draft from plan + results
 python paperflow.py draft papers/gibbs_reactor_2026/
 
-# 5. Format for target journal
-python paperflow.py format papers/gibbs_reactor_2026/
+# 6. Iterative refinement — run after every edit
+python paperflow.py iterate papers/gibbs_reactor_2026/
 
-# 6. Audit reproducibility
+# 7. Audit reproducibility and claim tracing
 python paperflow.py audit papers/gibbs_reactor_2026/
+
+# 8. Format for target journal
+python paperflow.py format papers/gibbs_reactor_2026/ --journal fluid_phase_equilibria
+
+# 9. Handle reviewer comments (after submission)
+python paperflow.py revise papers/gibbs_reactor_2026/ --comments reviewer_comments.md
+
+# 10. Validate figures and bibliography
+python paperflow.py validate-figures papers/gibbs_reactor_2026/ --journal fluid_phase_equilibria
+python paperflow.py validate-bib papers/gibbs_reactor_2026/
+
+# 11. Check prose quality (readability, passive voice, hedging)
+python paperflow.py check-prose papers/gibbs_reactor_2026/
+
+# 12. Discover missing references via Semantic Scholar
+python paperflow.py suggest-refs papers/gibbs_reactor_2026/
+
+# 13. Render all submission formats at once
+python paperflow.py render papers/gibbs_reactor_2026/
+
+# 14. After revision: generate visual diff report
+python paperflow.py diff papers/gibbs_reactor_2026/
+
+# 15. Check project status at any time
+python paperflow.py status papers/gibbs_reactor_2026/
 ```
 
 ## Directory Structure
@@ -57,9 +122,16 @@ python paperflow.py audit papers/gibbs_reactor_2026/
 ```
 neqsim-paperlab/
 ├── README.md                     # This file
-├── paperflow.py                  # CLI orchestrator
-├── journals/                     # Journal profile configs
-│   └── fluid_phase_equilibria.yaml
+├── WALKTHROUGH.md                # End-to-end worked example (12 steps)
+├── PAPER_WRITING_GUIDELINES.md   # Mandatory scientific writing rules
+├── paperflow.py                  # CLI orchestrator (new, draft, iterate, revise, ...)
+├── requirements.txt              # Python dependencies
+├── journals/                     # Journal profile configs (YAML)
+│   ├── fluid_phase_equilibria.yaml
+│   ├── computers_chem_eng.yaml
+│   ├── chem_eng_sci.yaml
+│   ├── iecr.yaml
+│   └── aiche.yaml
 ├── agents/                       # Agent definitions (VS Code Copilot)
 │   ├── planner.agent.md
 │   ├── literature_reviewer.agent.md
@@ -67,19 +139,33 @@ neqsim-paperlab/
 │   ├── benchmark.agent.md
 │   ├── validation.agent.md
 │   ├── scientific_writer.agent.md
-│   └── journal_formatter.agent.md
+│   ├── journal_formatter.agent.md
+│   └── reviewer_response.agent.md
 ├── skills/                       # Reusable scientific procedures
 │   ├── design_flash_benchmark/SKILL.md
 │   ├── run_flash_experiments/SKILL.md
 │   ├── analyze_convergence/SKILL.md
 │   ├── write_methods_section/SKILL.md
 │   └── journal_formatting/SKILL.md
-├── tools/                        # Python wrappers for NeqSim
+├── tools/                        # Python tooling
 │   ├── __init__.py
-│   ├── neqsim_scientific_tools.py
-│   ├── flash_benchmark.py
-│   ├── paper_renderer.py
-│   └── claim_tracer.py
+│   ├── neqsim_bootstrap.py         # NeqSim JVM bootstrap (local build)
+│   ├── neqsim_scientific_tools.py  # NeqSim/jpype wrappers
+│   ├── flash_benchmark.py          # Flash benchmark runner
+│   ├── figure_style.py             # SciencePlots journal presets & palettes
+│   ├── figure_validator.py         # Figure DPI/format/size validation (Pillow)
+│   ├── bib_validator.py            # Bibliography validation (bibtexparser)
+│   ├── prose_quality.py            # Readability scoring, passive voice, hedging (textstat)
+│   ├── citation_discovery.py       # Suggest missing refs via Semantic Scholar API
+│   ├── revision_diff.py            # Visual HTML diff between manuscript revisions
+│   ├── paper_renderer.py           # LaTeX rendering
+│   ├── word_renderer.py            # Word/OMML rendering
+│   ├── claim_tracer.py             # Evidence audit (all paper types)
+│   ├── render_html.py              # HTML render (legacy, tpflash-specific)
+│   ├── render_html_generic.py      # HTML render (generic, any paper)
+│   └── render_all.py               # Multi-format render dispatcher
+├── tests/                        # Pytest test suite
+│   └── test_paperflow.py
 ├── workflows/                    # Workflow definitions
 │   ├── new_paper.yaml
 │   └── revise_paper.yaml
@@ -89,13 +175,13 @@ neqsim-paperlab/
 │   └── response_to_reviewers.md
 └── papers/                       # Paper projects (one folder per paper)
     └── tpflash_algorithms_2026/
-        ├── plan.json
-        ├── paper.md
-        ├── refs.bib
-        ├── claims_manifest.json
-        ├── figures/
-        ├── tables/
-        └── results/
+        ├── plan.json               # Research plan + questions
+        ├── paper.md                # Manuscript (markdown)
+        ├── results.json            # Benchmark results + key findings
+        ├── refs.bib                # BibTeX references
+        ├── iteration_feedback.json # Latest quality assessment
+        ├── figures/                # Generated plots (PNG)
+        └── tables/                 # Generated data tables
 ```
 
 ## Agents
@@ -109,6 +195,27 @@ neqsim-paperlab/
 | **Validation** | Decides if claims hold | Results from benchmark | approved_claims.json |
 | **Scientific Writer** | Drafts manuscript | All artifacts | paper.md |
 | **Journal Formatter** | Adapts to journal rules | paper.md, journal profile | paper.tex / paper.docx |
+| **Reviewer Response** | Handles peer review | Reviewer comments | Response letter, revision plan |
+
+## CLI Commands
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `new` | Create paper project from template | `--journal`, `--topic` |
+| `benchmark` | Run NeqSim benchmark suite | |
+| `figures` | Generate figures (auto-runs generate_figures.py) | |
+| `draft` | Generate paper.md from plan + results | `--force` (overwrite existing) |
+| `iterate` | Interactive quality check with scoring | `--check` (category: structure, completeness, evidence, writing) |
+| `audit` | Trace claims to evidence artifacts | |
+| `format` | Apply journal formatting rules | `--journal` |
+| `render` | Render to all formats (HTML, LaTeX, Word) | `--journal` (optional) |
+| `validate-figures` | Check figure DPI, format, size, color | `--journal` |
+| `validate-bib` | Check refs.bib completeness and cross-refs | |
+| `check-prose` | Readability scoring, passive voice, hedging | |
+| `suggest-refs` | Suggest missing references (Semantic Scholar) | `--max` (max suggestions) |
+| `diff` | Visual diff between manuscript revisions | `--revision`, `--old`, `--new` |
+| `revise` | Create revision workspace from reviewer comments | `--comments` (path to comments file) |
+| `status` | Show project completion status | |
 
 ## Skills
 
@@ -160,17 +267,39 @@ neqsim-paperlab/
 ## Governance Rules
 
 1. **No unsupported claims**: Every quantitative statement must link to a result artifact
+   - *Comparative papers*: formal `[Claim Cx]` → `approved_claims.json` pipeline
+   - *Other paper types*: results.json key tracing + figure reference validation
 2. **Reproducibility**: Every figure/table must be regenerable from stored data
-3. **Claim tracing**: `claims_manifest.json` maps each claim to its evidence
+3. **Claim tracing**: `claim_tracer.py` audits all paper types with type-appropriate logic
 4. **Version control**: Algorithm changes on named branches
-5. **Validation gates**: Claims must pass statistical validation before entering manuscript
+5. **Validation gates**: Claims must pass validation before entering manuscript
+6. **Iterative quality**: Use `paperflow.py iterate` after *every* editing session
 
 ## Integration with NeqSim
 
-Tools communicate with NeqSim through:
-- **Python wrappers** (`tools/neqsim_scientific_tools.py`) using neqsim-python
+NeqSim is **always** loaded from the local build via `devtools/neqsim_dev_setup.py`.
+This means any Java code change is picked up immediately after `mvnw compile` —
+no pip install needed.
+
+All tools go through `tools/neqsim_bootstrap.py`:
+```python
+from tools.neqsim_bootstrap import get_jneqsim
+jneqsim = get_jneqsim()
+fluid = jneqsim.thermo.system.SystemSrkEos(298.15, 50.0)
+```
+
+Communication paths:
+- **Python wrappers** (`tools/neqsim_scientific_tools.py`) via bootstrap → jpype
 - **MCP server** (`neqsim-mcp-server/`) for agent tool calls
 - **Direct Java** via jpype for performance-critical benchmarks
+
+## Running Tests
+
+```bash
+cd neqsim-paperlab
+pip install -r requirements.txt
+python -m pytest tests/ -v
+```
 
 ## Adding a New Journal
 

--- a/neqsim-paperlab/WALKTHROUGH.md
+++ b/neqsim-paperlab/WALKTHROUGH.md
@@ -1,0 +1,327 @@
+# PaperLab End-to-End Walkthrough
+
+This guide walks through a complete paper production cycle using the `tpflash_algorithms_2026`
+paper as a worked example. Every step is reproducible from a clean checkout.
+
+## Prerequisites
+
+NeqSim is loaded from the **local build** via `devtools/neqsim_dev_setup.py`.
+You do **not** install neqsim via pip.
+
+```bash
+# 1. Build the Java project once (from the repo root)
+mvnw.cmd package -DskipTests "-Dmaven.javadoc.skip=true"
+
+# 2. Install Python dependencies (no neqsim — the local JAR is used)
+cd neqsim-paperlab
+pip install -r requirements.txt
+```
+
+After editing Java code, recompile with `mvnw.cmd compile` and the next
+Python run will pick up the changes automatically.
+
+## Step 1: Create a Paper Project
+
+```bash
+cd neqsim-paperlab
+
+python paperflow.py new "Hybrid SS-NR Flash Characterization" \
+    --journal fluid_phase_equilibria \
+    --topic tpflash_characterization
+```
+
+This creates:
+```
+papers/tpflash_characterization_2026/
+├── plan.json              # Skeleton research plan
+├── benchmark_config.json  # Experiment matrix
+├── paper.md               # Manuscript skeleton
+├── refs.bib               # Starter references
+├── approved_claims.json   # Empty claims (for comparative papers)
+├── claims_manifest.json   # Empty manifest
+├── algorithm/
+├── figures/
+├── tables/
+├── results/raw/
+└── submission/
+```
+
+## Step 2: Edit the Research Plan
+
+Open `plan.json` and fill in:
+
+1. **paper_type**: `"characterization"` (since we are benchmarking an existing algorithm)
+2. **novelty_statement**: What is new about this work
+3. **research_questions**: Specific, falsifiable questions with acceptance criteria
+4. **benchmark_design**: Fluid families, P/T ranges, metrics
+
+```json
+{
+  "paper_type": "characterization",
+  "novelty_statement": "First systematic open-source benchmark of hybrid SS-DEM-NR flash across 6 natural gas families",
+  "research_questions": [
+    {
+      "id": "RQ1",
+      "question": "What is the convergence rate across diverse natural gas conditions?",
+      "hypothesis": "The hybrid algorithm achieves >99% convergence",
+      "method": "Run 1500+ flash cases across 6 fluid families",
+      "acceptance_criterion": "Convergence rate >95% for all families"
+    }
+  ]
+}
+```
+
+## Step 3: Run Benchmarks
+
+```bash
+python paperflow.py benchmark papers/tpflash_characterization_2026/
+```
+
+This executes the full benchmark matrix and produces:
+- `results/raw/baseline_results.jsonl` — Raw per-case data
+- `results/summary_baseline.json` — Aggregate statistics
+
+## Step 4: Generate Figures
+
+Create `papers/tpflash_characterization_2026/generate_figures.py` using the
+`generate_publication_figures` skill as a template. Then:
+
+```bash
+python paperflow.py figures papers/tpflash_characterization_2026/
+```
+
+## Step 5: Generate the Draft
+
+```bash
+python paperflow.py draft papers/tpflash_characterization_2026/
+```
+
+This reads `plan.json` and `results.json` and produces a structured `paper.md`
+with actual results data, tables, and figure references filled in.
+
+## Step 6: Iterate on the Manuscript
+
+This is the core refinement loop — run it after every editing session:
+
+```bash
+python paperflow.py iterate papers/tpflash_characterization_2026/
+```
+
+Output:
+```
+============================================================
+ITERATION FEEDBACK REPORT
+============================================================
+Paper: tpflash_characterization_2026
+Type:  characterization
+Score: 8/15 (53%)
+
+  [STRUCTURE]
+    [OK] Abstract section present
+    [OK] Keywords section present
+    [!!] Missing Conclusions section
+
+  [COMPLETENESS]
+    [!!] 12 TODO placeholders still in manuscript
+
+  [EVIDENCE]
+    [OK] 5/7 key results referenced in text
+
+  [WRITING]
+    [OK] Abstract: 180 words (limit 250)
+    [!!] NeqSim mentioned 6 times in body - use algorithm-first language
+
+SUGGESTED NEXT ACTIONS:
+  1. Missing Conclusions section
+  2. 12 TODO placeholders still in manuscript
+  3. NeqSim mentioned 6 times in body - use algorithm-first language
+```
+
+**Repeat**: edit → iterate → edit → iterate until score reaches 100%.
+
+## Step 7: Audit Claims
+
+```bash
+python paperflow.py audit papers/tpflash_characterization_2026/
+```
+
+For characterization papers, this checks that results.json values appear in
+the manuscript. For comparative papers, it verifies all [Claim Cx] references
+are backed by approved_claims.json.
+
+## Step 8: Format for Submission
+
+```bash
+python paperflow.py format papers/tpflash_characterization_2026/ \
+    --journal fluid_phase_equilibria
+```
+
+Produces:
+- `submission/paper.tex` — Journal-formatted LaTeX
+- `submission/paper.docx` — Word document with proper styling
+
+## Step 9: Validate Figures
+
+```bash
+python paperflow.py validate-figures papers/tpflash_characterization_2026/ \
+    --journal fluid_phase_equilibria
+```
+
+Checks DPI (≥300), format (TIFF/EPS/PDF preferred), dimensions, file size,
+and color mode using Pillow against journal-specific requirements.
+
+## Step 10: Validate Bibliography
+
+```bash
+python paperflow.py validate-bib papers/tpflash_characterization_2026/
+```
+
+Checks `refs.bib` for:
+- Missing required BibTeX fields (author, title, journal, year)
+- Duplicate citation keys
+- Empty fields, invalid years
+- Cross-references: keys cited in `paper.md` but not in bib, and vice versa
+- Missing DOI/URL recommendations
+
+## Step 11: Render All Formats
+
+```bash
+python paperflow.py render papers/tpflash_characterization_2026/
+```
+
+One command that renders HTML, LaTeX, and Word:
+- `submission/paper.html` — Standalone HTML with KaTeX math
+- `submission/paper.tex` — Elsarticle LaTeX (requires journal profile)
+- `submission/paper.docx` — Word document with OMML equations
+
+## Step 12: Check Prose Quality
+
+Before submission, run the prose quality analyzer:
+
+```bash
+python paperflow.py check-prose papers/tpflash_characterization_2026/
+```
+
+This scores your manuscript on four dimensions (0-100 each):
+- **Readability** — Flesch-Kincaid grade level (target: ~12, college level)
+- **Sentence structure** — flags sentences over 35 words
+- **Active voice** — detects passive constructions (aim for <25%)
+- **Conciseness** — catches hedging ("somewhat", "perhaps") and wordy phrases ("in order to" → "to")
+
+## Step 13: Discover Missing References
+
+Query Semantic Scholar for highly-cited papers you may have missed:
+
+```bash
+python paperflow.py suggest-refs papers/tpflash_characterization_2026/ --max 10
+```
+
+This extracts search terms from your plan.json title, research questions, and
+paper.md abstract, then finds papers with 10+ citations that aren't already in
+your refs.bib. Copy-paste BibTeX entries are provided for each suggestion.
+
+## Step 14: Handle Reviewer Comments
+
+After submission, when reviewer comments arrive:
+
+```bash
+python paperflow.py revise papers/tpflash_characterization_2026/ \
+    --comments reviewer_comments.md
+```
+
+This creates `revision_1/` with a structured workspace for drafting responses.
+
+## Step 15: Compare Revisions with Visual Diff
+
+After revising, generate an HTML diff report showing exactly what changed:
+
+```bash
+python paperflow.py diff papers/tpflash_characterization_2026/
+```
+
+This compares the revision baseline with the current paper.md and produces a
+color-coded HTML report with line-level additions, deletions, section changes,
+and word count statistics. You can also compare arbitrary files:
+
+```bash
+python paperflow.py diff papers/tpflash_characterization_2026/ \
+    --old revision_1/paper_r0_baseline.md --new paper.md
+```
+
+---
+
+## The Iterative Workflow (Key to Quality)
+
+The most important feature is the **edit → iterate → fix loop**:
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│  Edit paper │ --> │  Iterate    │ --> │  Fix issues │
+│  (human or  │     │  (CLI check)│     │  (human or  │
+│   agent)    │     │             │     │   agent)    │
+└─────────────┘     └─────────────┘     └─────────────┘
+       ^                                       │
+       └───────────────────────────────────────┘
+                    Repeat until 100%
+```
+
+Each `iterate` run:
+1. Checks manuscript structure against journal requirements
+2. Verifies all TODO placeholders are resolved
+3. Traces quantitative claims to evidence (results.json or approved_claims.json)
+4. Checks writing quality (abstract length, software-centric language)
+5. Saves machine-readable `iteration_feedback.json` for agent consumption
+6. Logs progress in `plan.json` workflow log
+
+## Using with VS Code Copilot Agents
+
+For agent-assisted writing, the agents in `agents/` work with the CLI:
+
+1. `@planner` — Creates plan.json from a topic description
+2. `@literature-reviewer` — Builds refs.bib and literature_map.md
+3. `@benchmark` — Designs and runs experiments
+4. `@scientific-writer` — Drafts sections from artifacts
+5. `@reviewer-response` — Processes reviewer comments
+
+The CLI handles the mechanical parts (formatting, auditing, iteration checks).
+The agents handle the creative parts (writing, analysis, literature synthesis).
+
+## Full Command Reference
+
+| Command | Purpose | Key output |
+|---------|---------|------------|
+| `new` | Create paper project | Directory structure + plan.json |
+| `benchmark` | Run experiments | results/raw/*.jsonl, results/summary*.json |
+| `figures` | Generate figures | figures/*.png |
+| `draft` | Generate manuscript | paper.md (from plan + results) |
+| `iterate` | Quality check | iteration_feedback.json + console report |
+| `audit` | Claim verification | Pass/fail verdict |
+| `format` | Journal formatting | submission/paper.tex, paper.docx |
+| `render` | Render all formats | submission/paper.html, .tex, .docx |
+| `validate-figures` | Figure compliance | Per-figure DPI/format/size checks |
+| `validate-bib` | Bibliography check | Missing fields, duplicates, cross-refs |
+| `check-prose` | Prose quality scoring | Readability, passive voice, hedging report |
+| `suggest-refs` | Citation discovery | Suggested references from Semantic Scholar |
+| `diff` | Revision diff | Color-coded HTML diff report |
+| `revise` | Reviewer response | revision_N/ workspace |
+| `status` | Project overview | Console summary |
+
+## Publication-Quality Figures
+
+For journal-quality figures, use the `figure_style` module. It wraps
+SciencePlots with journal presets and provides standard palettes and sizes:
+
+```python
+from tools.figure_style import apply_style, save_fig, PALETTE, FIG_SINGLE
+
+apply_style("elsevier")                    # or "ieee", "nature", "acs"
+fig, ax = plt.subplots(figsize=FIG_SINGLE) # 3.5 × 2.8 inches (single-column)
+ax.plot(x, y, color=PALETTE[0])
+ax.set_xlabel("Temperature (K)")
+ax.set_ylabel("Convergence rate (%)")
+save_fig(fig, "fig01_convergence.png", dpi=300)
+```
+
+Available constants: `FIG_SINGLE`, `FIG_DOUBLE`, `FIG_SINGLE_TALL`,
+`FIG_DOUBLE_TALL`, `FIG_SQUARE`, and named colors `BLUE`, `ORANGE`,
+`GREEN`, `PURPLE`, `PINK`, `LIME`, `GREY`.

--- a/neqsim-paperlab/agents/benchmark.agent.md
+++ b/neqsim-paperlab/agents/benchmark.agent.md
@@ -117,7 +117,8 @@ For each family generate cases by:
 ### Python Orchestrator (recommended)
 
 ```python
-from neqsim import jneqsim
+from tools.neqsim_bootstrap import get_jneqsim
+jneqsim = get_jneqsim()
 import json, time
 
 SystemSrkEos = jneqsim.thermo.system.SystemSrkEos

--- a/neqsim-paperlab/paperflow.py
+++ b/neqsim-paperlab/paperflow.py
@@ -19,6 +19,7 @@ Example:
 import argparse
 import json
 import os
+import re
 import sys
 import time
 from datetime import datetime
@@ -298,38 +299,54 @@ def cmd_figures(args):
     figures_dir = paper_dir / "figures"
     figures_dir.mkdir(exist_ok=True)
 
-    print(f"Generating figures from {results_dir} -> {figures_dir}")
-    print("(Use the analyze_convergence skill for detailed figure generation)")
-    print()
-    print("Available result files:")
-    for f in sorted(results_dir.glob("*.json")):
-        print(f"  {f.name}")
-    for f in sorted((results_dir / "raw").glob("*.jsonl")):
-        print(f"  raw/{f.name}")
+    # Try running a generate_figures script if one exists in the paper
+    fig_script = paper_dir / "step2_analysis" / "02_generate_figures.py"
+    if not fig_script.exists():
+        fig_script = paper_dir / "generate_figures.py"
+
+    if fig_script.exists():
+        print(f"Running figure generation script: {fig_script}")
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, str(fig_script)],
+            cwd=str(paper_dir),
+            capture_output=True, text=True,
+        )
+        print(result.stdout)
+        if result.returncode != 0:
+            print(f"ERROR: {result.stderr}")
+            sys.exit(1)
+        print(f"Figures generated in {figures_dir}")
+    else:
+        print(f"No generate_figures.py found. Available result files:")
+        for f in sorted(results_dir.glob("*.json")):
+            print(f"  {f.name}")
+        if (results_dir / "raw").exists():
+            for f in sorted((results_dir / "raw").glob("*.jsonl")):
+                print(f"  raw/{f.name}")
+        print()
+        print("To auto-generate figures, create one of:")
+        print(f"  {paper_dir / 'generate_figures.py'}")
+        print(f"  {paper_dir / 'step2_analysis' / '02_generate_figures.py'}")
 
 
 def cmd_validate_figures(args):
-    """Validate figure and table formats against journal requirements."""
+    """Validate figure formats against journal requirements."""
     paper_dir = Path(args.paper_dir)
     journal = args.journal
 
     sys.path.insert(0, str(TOOLS_DIR))
-    from paper_renderer import (
-        load_journal_profile, validate_figures, validate_tables, print_compliance
-    )
+    from paper_renderer import load_journal_profile
+    from figure_validator import validate_figures, print_validation_report
 
     profile = load_journal_profile(journal, str(JOURNALS_DIR))
+    figures_dir = paper_dir / "figures"
 
     print("Validating figures...")
-    fig_checks = validate_figures(str(paper_dir), profile)
+    issues = validate_figures(str(figures_dir), profile)
+    print_validation_report(issues)
 
-    print("Validating tables...")
-    tbl_checks = validate_tables(str(paper_dir), profile)
-
-    all_checks = fig_checks + tbl_checks
-    print_compliance(all_checks)
-
-    if any(c["status"] == "FAIL" for c in all_checks):
+    if any(i["severity"] == "FAIL" for i in issues):
         sys.exit(1)
 
 
@@ -372,6 +389,541 @@ def cmd_audit(args):
 
     if report["verdict"] != "PASS":
         sys.exit(1)
+
+
+def cmd_draft(args):
+    """Generate a manuscript draft from plan.json, results.json, and template.
+
+    This produces a structured draft that fills in the paper skeleton with
+    actual data from benchmark results, plan metadata, and approved claims.
+    The draft is a starting point for iterative refinement with the user.
+    """
+    paper_dir = Path(args.paper_dir)
+
+    plan_file = paper_dir / "plan.json"
+    results_file = paper_dir / "results.json"
+    paper_file = paper_dir / "paper.md"
+
+    if not plan_file.exists():
+        print(f"Error: plan.json not found in {paper_dir}")
+        sys.exit(1)
+
+    with open(plan_file) as f:
+        plan = json.load(f)
+
+    # Load results if available
+    results = {}
+    if results_file.exists():
+        with open(results_file) as f:
+            results = json.load(f)
+
+    # Load journal profile
+    journal_name = plan.get("target_journal", "")
+    profile = None
+    if journal_name:
+        profile_path = JOURNALS_DIR / f"{journal_name}.yaml"
+        if profile_path.exists():
+            try:
+                import yaml
+                with open(profile_path) as f:
+                    profile = yaml.safe_load(f)
+            except ImportError:
+                print("Warning: PyYAML not installed - journal profile not loaded")
+
+    paper_type = plan.get("paper_type", "characterization")
+    title = plan.get("title", "Untitled")
+
+    # Check if paper.md already exists and is beyond skeleton
+    if paper_file.exists():
+        existing = paper_file.read_text(encoding="utf-8")
+        if "TODO" not in existing and len(existing) > 2000:
+            if not args.force:
+                print(f"paper.md already contains a draft ({len(existing)} chars).")
+                print("Use --force to overwrite, or use 'iterate' to refine.")
+                return
+
+    # Build draft sections
+    sections = []
+
+    # Title
+    sections.append(f"# {title}\n")
+
+    # Metadata comments
+    sections.append(f"<!-- Target Journal: {journal_name} -->")
+    sections.append(f"<!-- Generated: {datetime.now().strftime('%Y-%m-%d')} -->")
+    sections.append(f"<!-- Paper Type: {paper_type} -->")
+    sections.append(f"<!-- Status: DRAFT -->\n")
+
+    # Highlights
+    sections.append("## Highlights\n")
+    key_results = results.get("key_results", {})
+    if key_results:
+        highlight_count = 0
+        for key, val in key_results.items():
+            if highlight_count >= 5:
+                break
+            label = key.replace("_", " ").title()
+            sections.append(f"- {label}: {val}")
+            highlight_count += 1
+    else:
+        sections.append("- TODO: First highlight (max 85 chars)")
+        sections.append("- TODO: Second highlight")
+        sections.append("- TODO: Third highlight")
+    sections.append("")
+
+    # Abstract
+    abstract_limit = 250
+    if profile:
+        abstract_limit = profile.get("abstract_words_max", 250)
+    sections.append("## Abstract\n")
+    approach = results.get("approach", "")
+    conclusions = results.get("conclusions", "")
+    if approach and conclusions:
+        sections.append(f"{approach}\n")
+        sections.append(f"{conclusions}\n")
+        sections.append(f"<!-- Abstract word limit: {abstract_limit} words -->\n")
+    else:
+        sections.append(f"TODO: Write abstract (max {abstract_limit} words).\n")
+
+    # Keywords
+    sections.append("## Keywords\n")
+    sections.append("TODO: 3-7 keywords separated by semicolons\n")
+
+    sections.append("---\n")
+
+    # Introduction
+    sections.append("## 1. Introduction\n")
+    sections.append("### 1.1 Background\n")
+    novelty = plan.get("novelty_statement", "")
+    if novelty:
+        sections.append(f"<!-- Novelty: {novelty} -->\n")
+    sections.append("TODO: Frame the scientific/algorithmic problem.\n")
+    sections.append("### 1.2 Prior Work\n")
+    sections.append("TODO: Survey existing approaches. Cite algorithms, not software.\n")
+    sections.append("### 1.3 Contributions\n")
+    rqs = plan.get("research_questions", [])
+    if rqs:
+        sections.append("This paper addresses the following research questions:\n")
+        for rq in rqs:
+            sections.append(f"- **{rq.get('id', '?')}**: {rq.get('question', 'TODO')}")
+        sections.append("")
+    else:
+        sections.append("TODO: List specific contributions.\n")
+
+    # Mathematical Framework
+    sections.append("---\n")
+    sections.append("## 2. Mathematical Framework\n")
+    sections.append("TODO: Pure mathematics - equations, derivations, proofs.\n")
+
+    # Algorithm / Methods
+    sections.append("---\n")
+    if paper_type in ("comparative", "method"):
+        sections.append("## 3. Algorithm Description\n")
+        sections.append("### 3.1 Baseline Algorithm\n")
+        sections.append("TODO: Describe the baseline.\n")
+        sections.append("### 3.2 Proposed Improvement\n")
+        sections.append("TODO: Describe the modification.\n")
+    elif paper_type == "characterization":
+        sections.append("## 3. Algorithm Description\n")
+        sections.append("TODO: Describe the algorithm under study.\n")
+    else:
+        sections.append("## 3. Methods\n")
+        sections.append("TODO: Describe the computational methods.\n")
+
+    # Benchmark Design
+    sections.append("---\n")
+    sections.append("## 4. Benchmark Design\n")
+    bench = plan.get("benchmark_design", {})
+    if bench:
+        families = bench.get("fluid_families", [])
+        if families:
+            sections.append(f"The benchmark covers {len(families)} fluid families: "
+                          f"{', '.join(families)}.\n")
+        metrics = bench.get("metrics", [])
+        if metrics:
+            sections.append(f"Metrics collected: {', '.join(metrics)}.\n")
+    else:
+        sections.append("TODO: Describe benchmark design.\n")
+
+    # Results and Discussion
+    sections.append("---\n")
+    sections.append("## 5. Results and Discussion\n")
+    if key_results:
+        sections.append("### 5.1 Overall Performance\n")
+        # Build a results table
+        sections.append("| Metric | Value |")
+        sections.append("|--------|-------|")
+        for key, val in key_results.items():
+            label = key.replace("_", " ").replace("pct", "%").title()
+            sections.append(f"| {label} | {val} |")
+        sections.append("")
+
+    # Include custom tables from results.json
+    for tbl in results.get("tables", []):
+        sections.append(f"\n**{tbl.get('title', 'Table')}**\n")
+        headers = tbl.get("headers", [])
+        if headers:
+            sections.append("| " + " | ".join(str(h) for h in headers) + " |")
+            sections.append("| " + " | ".join("---" for _ in headers) + " |")
+            for row in tbl.get("rows", []):
+                sections.append("| " + " | ".join(str(c) for c in row) + " |")
+            sections.append("")
+
+    # Figures
+    fig_captions = results.get("figure_captions", {})
+    if fig_captions:
+        sections.append("### 5.2 Figures\n")
+        for i, (fname, caption) in enumerate(fig_captions.items(), 1):
+            sections.append(f"![Figure {i}: {caption}](figures/{fname})\n")
+            sections.append(f"*Figure {i}: {caption}*\n")
+
+    if not key_results and not fig_captions:
+        sections.append("TODO: Present and discuss results.\n")
+
+    # Conclusions
+    sections.append("---\n")
+    sections.append("## 6. Conclusions\n")
+    if conclusions:
+        sections.append(f"{conclusions}\n")
+    else:
+        sections.append("TODO: Summarize findings and future work.\n")
+
+    # Acknowledgements
+    sections.append("---\n")
+    sections.append("## Acknowledgements\n")
+    sections.append("The algorithm is implemented in the open-source NeqSim library "
+                  "(https://github.com/equinor/neqsim).\n")
+
+    # Data Availability
+    sections.append("## Data Availability\n")
+    sections.append("Source code, benchmark configurations, raw results, and "
+                  "figure-generation scripts are available at "
+                  "https://github.com/equinor/neqsim under the MIT license.\n")
+
+    # References
+    sections.append("## References\n")
+    refs_file = paper_dir / "refs.bib"
+    if refs_file.exists():
+        sections.append("<!-- References managed in refs.bib -->\n")
+    else:
+        sections.append("TODO: Add references.\n")
+
+    # Write draft
+    draft_text = "\n".join(sections)
+    paper_file.write_text(draft_text, encoding="utf-8")
+
+    # Update plan.json
+    if plan_file.exists():
+        plan.setdefault("workflow_log", []).append({
+            "stage": "draft",
+            "status": "generated",
+            "date": datetime.now().isoformat(),
+            "paper_type": paper_type,
+            "results_available": bool(key_results),
+        })
+        with open(plan_file, "w") as f:
+            json.dump(plan, f, indent=2)
+
+    word_count = len(draft_text.split())
+    print(f"Draft generated: {paper_file} ({word_count} words)")
+    print()
+    print("Next steps:")
+    print("  1. Review and refine the draft manually or with an agent")
+    print(f"  2. Run: python paperflow.py iterate {paper_dir} --check all")
+    print(f"  3. Run: python paperflow.py audit {paper_dir}")
+    print(f"  4. Run: python paperflow.py format {paper_dir} --journal {journal_name}")
+
+
+def cmd_iterate(args):
+    """Interactive iteration on a specific section or the full manuscript.
+
+    Generates a structured feedback report showing what's missing, what needs
+    improvement, and suggests specific actions. Designed for iterative
+    refinement cycles between user and agent.
+    """
+    paper_dir = Path(args.paper_dir)
+    check_type = getattr(args, 'check', 'all')
+
+    paper_file = paper_dir / "paper.md"
+    if not paper_file.exists():
+        print(f"Error: paper.md not found. Run 'draft' first.")
+        sys.exit(1)
+
+    paper_text = paper_file.read_text(encoding="utf-8")
+
+    # Load plan and results
+    plan = {}
+    plan_file = paper_dir / "plan.json"
+    if plan_file.exists():
+        with open(plan_file) as f:
+            plan = json.load(f)
+
+    results = {}
+    results_file = paper_dir / "results.json"
+    if results_file.exists():
+        with open(results_file) as f:
+            results = json.load(f)
+
+    # Load journal profile
+    journal_name = plan.get("target_journal", "")
+    profile = None
+    if journal_name:
+        profile_path = JOURNALS_DIR / f"{journal_name}.yaml"
+        if profile_path.exists():
+            try:
+                import yaml
+                with open(profile_path) as f:
+                    profile = yaml.safe_load(f)
+            except ImportError:
+                pass
+
+    paper_type = plan.get("paper_type", "characterization")
+    feedback = []
+    score = 0
+    max_score = 0
+
+    def add_check(category, test, msg_pass, msg_fail, weight=1):
+        nonlocal score, max_score
+        max_score += weight
+        if test:
+            score += weight
+            feedback.append({"category": category, "status": "OK",
+                           "message": msg_pass})
+        else:
+            feedback.append({"category": category, "status": "NEEDS_WORK",
+                           "message": msg_fail})
+
+    # ── Structure checks ──
+    if check_type in ("all", "structure"):
+        add_check("structure", "## Abstract" in paper_text or "## abstract" in paper_text.lower(),
+              "Abstract section present", "Missing Abstract section")
+        add_check("structure", "## Keywords" in paper_text or "## keywords" in paper_text.lower(),
+              "Keywords section present", "Missing Keywords section")
+        add_check("structure", "Introduction" in paper_text,
+              "Introduction present", "Missing Introduction section")
+        add_check("structure", "Conclusion" in paper_text,
+              "Conclusions present", "Missing Conclusions section")
+        add_check("structure", "References" in paper_text,
+              "References present", "Missing References section")
+        add_check("structure", "Acknowledgement" in paper_text,
+              "Acknowledgements present", "Missing Acknowledgements section")
+
+    # ── Completeness checks ──
+    if check_type in ("all", "completeness"):
+        todo_count = paper_text.count("TODO")
+        add_check("completeness", todo_count == 0,
+              "No TODO placeholders remain",
+              f"{todo_count} TODO placeholders still in manuscript", weight=3)
+
+        # Check highlights
+        if profile and profile.get("highlights_required", False):
+            highlight_section = re.search(
+                r'## Highlights?\s*\n((?:- .+\n?)+)', paper_text, re.IGNORECASE)
+            if highlight_section:
+                hl_lines = [l.strip() for l in highlight_section.group(1).strip().split("\n")
+                          if l.strip().startswith("-")]
+                hl_min = profile.get("highlights_min", 3)
+                hl_max = profile.get("highlights_max", 5)
+                add_check("completeness", hl_min <= len(hl_lines) <= hl_max,
+                      f"{len(hl_lines)} highlights (within {hl_min}-{hl_max})",
+                      f"{len(hl_lines)} highlights (need {hl_min}-{hl_max})")
+
+                max_chars = profile.get("highlights_max_chars_each", 85)
+                over_limit = [l for l in hl_lines if len(l) - 2 > max_chars]
+                add_check("completeness", len(over_limit) == 0,
+                      f"All highlights within {max_chars} char limit",
+                      f"{len(over_limit)} highlights exceed {max_chars} chars")
+
+    # ── Evidence checks ──
+    if check_type in ("all", "evidence"):
+        key_results = results.get("key_results", {})
+
+        if paper_type == "comparative":
+            claim_refs = re.findall(r'\[Claim\s+C\d+', paper_text)
+            add_check("evidence", len(claim_refs) > 0,
+                  f"{len(claim_refs)} claim references found",
+                  "No [Claim Cx] references - comparative papers need claim tracing",
+                  weight=3)
+        else:
+            results_used = 0
+            for key, val in key_results.items():
+                val_str = str(val)
+                if val_str in paper_text:
+                    results_used += 1
+            if key_results:
+                pct = results_used / len(key_results) * 100
+                add_check("evidence", pct >= 50,
+                      f"{results_used}/{len(key_results)} key results referenced in text",
+                      f"Only {results_used}/{len(key_results)} key results appear in text",
+                      weight=2)
+
+        fig_captions = results.get("figure_captions", {})
+        if fig_captions:
+            fig_refs = re.findall(r'[Ff]ig(?:ure)?\.?\s*\d+', paper_text)
+            add_check("evidence", len(fig_refs) >= len(fig_captions),
+                  f"{len(fig_refs)} figure references for {len(fig_captions)} figures",
+                  f"Only {len(fig_refs)} figure refs for {len(fig_captions)} figures")
+
+    # ── Writing quality checks ──
+    if check_type in ("all", "writing"):
+        abstract_match = re.search(
+            r'## Abstract\s*\n(.*?)(?=\n## |\n---)', paper_text,
+            re.DOTALL | re.IGNORECASE)
+        if abstract_match:
+            abstract_words = len(abstract_match.group(1).split())
+            limit = 250
+            if profile:
+                limit = profile.get("abstract_words_max", 250)
+            add_check("writing", abstract_words <= limit,
+                  f"Abstract: {abstract_words} words (limit {limit})",
+                  f"Abstract: {abstract_words} words exceeds {limit} limit")
+            add_check("writing", abstract_words >= 100,
+                  f"Abstract has sufficient length ({abstract_words} words)",
+                  f"Abstract too short ({abstract_words} words, aim for 150+)")
+
+        body_text = re.sub(
+            r'## (?:Acknowledgements?|Data Availability).*$', '',
+            paper_text, flags=re.DOTALL | re.IGNORECASE)
+        body_neqsim = len(re.findall(r'\bNeqSim\b', body_text))
+        add_check("writing", body_neqsim <= 3,
+              f"NeqSim mentioned {body_neqsim} times in body (good: algorithm-first)",
+              f"NeqSim mentioned {body_neqsim} times in body - use algorithm-first language",
+              weight=2)
+
+    # ── Print feedback report ──
+    print("=" * 60)
+    print("ITERATION FEEDBACK REPORT")
+    print("=" * 60)
+    print(f"Paper: {paper_dir.name}")
+    print(f"Type:  {paper_type}")
+    if max_score > 0:
+        print(f"Score: {score}/{max_score} ({score / max_score * 100:.0f}%)")
+    print()
+
+    categories = {}
+    for item in feedback:
+        categories.setdefault(item["category"], []).append(item)
+
+    for cat, items in categories.items():
+        print(f"  [{cat.upper()}]")
+        for item in items:
+            icon = "  [OK]" if item["status"] == "OK" else "  [!!]"
+            print(f"    {icon} {item['message']}")
+        print()
+
+    needs_work = [f for f in feedback if f["status"] == "NEEDS_WORK"]
+    if needs_work:
+        print("SUGGESTED NEXT ACTIONS:")
+        for i, item in enumerate(needs_work, 1):
+            print(f"  {i}. {item['message']}")
+        print()
+        print("Refine the manuscript and run 'iterate' again to check progress.")
+    else:
+        print("All checks pass! Ready for:")
+        print(f"  python paperflow.py audit {paper_dir}")
+        print(f"  python paperflow.py format {paper_dir} --journal {journal_name}")
+
+    # Save feedback to file for agent consumption
+    feedback_file = paper_dir / "iteration_feedback.json"
+    feedback_data = {
+        "timestamp": datetime.now().isoformat(),
+        "score": score,
+        "max_score": max_score,
+        "score_pct": round(score / max_score * 100, 1) if max_score > 0 else 0,
+        "paper_type": paper_type,
+        "feedback": feedback,
+        "needs_work": needs_work,
+    }
+    with open(feedback_file, "w") as f:
+        json.dump(feedback_data, f, indent=2)
+
+    plan.setdefault("workflow_log", []).append({
+        "stage": "iterate",
+        "status": "checked",
+        "date": datetime.now().isoformat(),
+        "score_pct": feedback_data["score_pct"],
+        "issues": len(needs_work),
+    })
+    if plan_file.exists():
+        with open(plan_file, "w") as f:
+            json.dump(plan, f, indent=2)
+
+
+def cmd_revise(args):
+    """Process reviewer comments and prepare revision workspace."""
+    paper_dir = Path(args.paper_dir)
+    comments_file = Path(args.comments) if hasattr(args, 'comments') and args.comments else None
+
+    # Determine revision number
+    existing_revisions = sorted(paper_dir.glob("revision_*"))
+    rev_num = len(existing_revisions) + 1
+    rev_dir = paper_dir / f"revision_{rev_num}"
+    rev_dir.mkdir(exist_ok=True)
+
+    # Copy or create reviewer comments file
+    if comments_file and comments_file.exists():
+        import shutil
+        shutil.copy2(str(comments_file), str(rev_dir / "reviewer_comments.md"))
+        print(f"Copied reviewer comments to {rev_dir / 'reviewer_comments.md'}")
+    else:
+        template = (
+            f"# Reviewer Comments - Revision {rev_num}\n\n"
+            "## Reviewer 1\n\n### Comment 1.1\n> Paste reviewer comment here\n\n"
+            "### Comment 1.2\n> Paste reviewer comment here\n\n"
+            "## Reviewer 2\n\n### Comment 2.1\n> Paste reviewer comment here\n"
+        )
+        (rev_dir / "reviewer_comments.md").write_text(template, encoding="utf-8")
+        print(f"Created template: {rev_dir / 'reviewer_comments.md'}")
+        print("Paste the actual reviewer comments into this file.")
+
+    # Create response template
+    response_template_path = PAPERLAB_ROOT / "templates" / "response_to_reviewers.md"
+    if response_template_path.exists():
+        response_text = response_template_path.read_text(encoding="utf-8")
+    else:
+        response_text = "# Response to Reviewers\n\n## Reviewer 1\n\nTODO\n"
+    (rev_dir / "response_to_reviewers.md").write_text(response_text, encoding="utf-8")
+
+    # Create revision plan
+    rev_plan = {
+        "revision_number": rev_num,
+        "created": datetime.now().isoformat(),
+        "status": "in_progress",
+        "comments_parsed": False,
+        "experiments_needed": False,
+        "new_experiments": [],
+        "sections_modified": [],
+    }
+    with open(rev_dir / "revision_plan.json", "w") as f:
+        json.dump(rev_plan, f, indent=2)
+
+    # Copy current paper.md as baseline
+    paper_file = paper_dir / "paper.md"
+    if paper_file.exists():
+        import shutil
+        shutil.copy2(str(paper_file), str(rev_dir / f"paper_r{rev_num - 1}_baseline.md"))
+
+    # Update plan.json
+    plan_file = paper_dir / "plan.json"
+    if plan_file.exists():
+        with open(plan_file) as f:
+            plan = json.load(f)
+        plan.setdefault("workflow_log", []).append({
+            "stage": f"revision_{rev_num}",
+            "status": "started",
+            "date": datetime.now().isoformat(),
+        })
+        with open(plan_file, "w") as f:
+            json.dump(plan, f, indent=2)
+
+    print(f"\nRevision {rev_num} workspace created: {rev_dir}")
+    print()
+    print("Next steps:")
+    print(f"  1. Edit {rev_dir / 'reviewer_comments.md'} with actual comments")
+    print(f"  2. Use @reviewer-response agent to parse and classify comments")
+    print(f"  3. Fill in {rev_dir / 'response_to_reviewers.md'}")
+    print(f"  4. Edit {paper_file} with revisions")
+    print(f"  5. Run: python paperflow.py iterate {paper_dir}")
 
 
 def cmd_status(args):
@@ -444,6 +996,122 @@ def cmd_status(args):
     print()
 
 
+def cmd_validate_bib(args):
+    """Validate bibliography against entry requirements and manuscript citations."""
+    paper_dir = Path(args.paper_dir)
+
+    sys.path.insert(0, str(TOOLS_DIR))
+    from bib_validator import validate_bibliography, print_validation_report
+
+    bib_path = paper_dir / "refs.bib"
+    manuscript_path = paper_dir / "paper.md"
+
+    issues = validate_bibliography(
+        str(bib_path),
+        manuscript_path=str(manuscript_path) if manuscript_path.exists() else None,
+    )
+    print_validation_report(issues)
+
+    if any(i["severity"] == "FAIL" for i in issues):
+        sys.exit(1)
+
+
+def cmd_render(args):
+    """Render manuscript to all submission formats (HTML, LaTeX, Word)."""
+    paper_dir = Path(args.paper_dir)
+
+    if not (paper_dir / "paper.md").exists():
+        print(f"Error: paper.md not found in {paper_dir}")
+        sys.exit(1)
+
+    sys.path.insert(0, str(TOOLS_DIR))
+
+    # Load journal from plan.json
+    plan = {}
+    plan_file = paper_dir / "plan.json"
+    if plan_file.exists():
+        with open(plan_file) as f:
+            plan = json.load(f)
+
+    journal_name = getattr(args, 'journal', None) or plan.get("target_journal", "")
+
+    # Render HTML via render_all.py
+    from render_all import render_html as render_html_func
+    print("Rendering HTML...")
+    html_file = render_html_func(str(paper_dir))
+    print(f"  Output: {html_file}")
+
+    # Render Word + LaTeX if journal profile available
+    if journal_name:
+        from paper_renderer import load_journal_profile, render_latex
+        try:
+            profile = load_journal_profile(journal_name, str(JOURNALS_DIR))
+
+            print("Rendering LaTeX...")
+            tex_file = render_latex(str(paper_dir), profile)
+            print(f"  Output: {tex_file}")
+
+            print("Rendering Word...")
+            from word_renderer import render_word_document
+            docx_file = render_word_document(str(paper_dir), journal_profile=profile)
+            print(f"  Output: {docx_file}")
+        except Exception as e:
+            print(f"  Warning: LaTeX/Word rendering failed: {e}")
+    else:
+        print("  Skipping LaTeX/Word (no journal profile)")
+
+    print("\nDone. Files in:", paper_dir / "submission")
+
+
+def cmd_check_prose(args):
+    """Analyze manuscript prose quality (readability, passive voice, hedging)."""
+    paper_dir = Path(args.paper_dir)
+    paper_path = paper_dir / "paper.md"
+
+    if not paper_path.exists():
+        print(f"Error: paper.md not found in {paper_dir}")
+        sys.exit(1)
+
+    sys.path.insert(0, str(TOOLS_DIR))
+    from prose_quality import analyze_prose, print_prose_report
+
+    report = analyze_prose(str(paper_path))
+    print_prose_report(report)
+
+    # Fail if overall score is very low
+    overall = report.get("summary", {}).get("overall", 100)
+    if overall < 40:
+        print(f"\nOverall prose score {overall}/100 is below minimum threshold (40).")
+        sys.exit(1)
+
+
+def cmd_suggest_refs(args):
+    """Suggest missing references via Semantic Scholar."""
+    paper_dir = Path(args.paper_dir)
+
+    sys.path.insert(0, str(TOOLS_DIR))
+    from citation_discovery import suggest_citations, print_suggestions
+
+    report = suggest_citations(str(paper_dir), max_suggestions=args.max)
+    print_suggestions(report)
+
+
+def cmd_diff(args):
+    """Generate a visual diff between manuscript revisions."""
+    paper_dir = Path(args.paper_dir)
+
+    sys.path.insert(0, str(TOOLS_DIR))
+    from revision_diff import generate_diff, print_diff_summary
+
+    report = generate_diff(
+        str(paper_dir),
+        revision=args.revision,
+        old_file=args.old,
+        new_file=args.new,
+    )
+    print_diff_summary(report)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="paperflow — NeqSim scientific paper production",
@@ -479,9 +1147,23 @@ Examples:
     p_valfig.add_argument("paper_dir", help="Paper directory")
     p_valfig.add_argument("--journal", required=True, help="Journal profile name")
 
-    # draft — placeholder (uses writer agent)
-    p_draft = subparsers.add_parser("draft", help="Draft manuscript (uses writer agent)")
+    # draft — generates manuscript from plan + results
+    p_draft = subparsers.add_parser("draft", help="Generate manuscript draft from artifacts")
     p_draft.add_argument("paper_dir", help="Paper directory")
+    p_draft.add_argument("--force", action="store_true",
+                        help="Overwrite existing paper.md even if it has content")
+
+    # iterate — interactive quality checks for iterative refinement
+    p_iter = subparsers.add_parser("iterate", help="Check manuscript quality and suggest improvements")
+    p_iter.add_argument("paper_dir", help="Paper directory")
+    p_iter.add_argument("--check", default="all",
+                       choices=["all", "structure", "completeness", "evidence", "writing"],
+                       help="Which checks to run (default: all)")
+
+    # revise — prepare revision workspace for reviewer comments
+    p_rev = subparsers.add_parser("revise", help="Prepare revision workspace for reviewer comments")
+    p_rev.add_argument("paper_dir", help="Paper directory")
+    p_rev.add_argument("--comments", help="Path to reviewer comments file (optional)")
 
     # format
     p_fmt = subparsers.add_parser("format", help="Format for journal submission")
@@ -496,6 +1178,37 @@ Examples:
     p_status = subparsers.add_parser("status", help="Show paper project status")
     p_status.add_argument("paper_dir", help="Paper directory")
 
+    # validate-bib
+    p_valbib = subparsers.add_parser("validate-bib",
+                                      help="Validate bibliography (refs.bib)")
+    p_valbib.add_argument("paper_dir", help="Paper directory")
+
+    # render
+    p_render = subparsers.add_parser("render",
+                                      help="Render manuscript to HTML/LaTeX/Word")
+    p_render.add_argument("paper_dir", help="Paper directory")
+    p_render.add_argument("--journal", help="Journal profile (default: from plan.json)")
+
+    # check-prose
+    p_prose = subparsers.add_parser("check-prose",
+                                     help="Analyze prose quality (readability, passive voice, hedging)")
+    p_prose.add_argument("paper_dir", help="Paper directory")
+
+    # suggest-refs
+    p_refs = subparsers.add_parser("suggest-refs",
+                                    help="Suggest missing references via Semantic Scholar")
+    p_refs.add_argument("paper_dir", help="Paper directory")
+    p_refs.add_argument("--max", type=int, default=10,
+                       help="Max suggestions to show (default: 10)")
+
+    # diff
+    p_diff = subparsers.add_parser("diff",
+                                    help="Generate visual diff between manuscript revisions")
+    p_diff.add_argument("paper_dir", help="Paper directory")
+    p_diff.add_argument("--revision", type=int, help="Revision number (default: latest)")
+    p_diff.add_argument("--old", help="Explicit path to old version")
+    p_diff.add_argument("--new", help="Explicit path to new version")
+
     args = parser.parse_args()
 
     if args.command == "new":
@@ -507,15 +1220,27 @@ Examples:
     elif args.command == "validate-figures":
         cmd_validate_figures(args)
     elif args.command == "draft":
-        print(f"Drafting is handled by the scientific_writer agent.")
-        print(f"Use VS Code Copilot Chat with @scientific-writer to draft {args.paper_dir}/paper.md")
-        print(f"Or run the workflow: see workflows/new_paper.yaml Stage 8")
+        cmd_draft(args)
+    elif args.command == "iterate":
+        cmd_iterate(args)
+    elif args.command == "revise":
+        cmd_revise(args)
     elif args.command == "format":
         cmd_format(args)
     elif args.command == "audit":
         cmd_audit(args)
     elif args.command == "status":
         cmd_status(args)
+    elif args.command == "validate-bib":
+        cmd_validate_bib(args)
+    elif args.command == "render":
+        cmd_render(args)
+    elif args.command == "check-prose":
+        cmd_check_prose(args)
+    elif args.command == "suggest-refs":
+        cmd_suggest_refs(args)
+    elif args.command == "diff":
+        cmd_diff(args)
     else:
         parser.print_help()
 

--- a/neqsim-paperlab/requirements.txt
+++ b/neqsim-paperlab/requirements.txt
@@ -1,0 +1,28 @@
+# PaperLab Python dependencies
+# NOTE: NeqSim is loaded from the local build via devtools/neqsim_dev_setup.py
+# Do NOT install neqsim via pip — the local JAR is always used instead.
+jpype1>=1.4
+
+# --- Data handling & numerics ---
+numpy>=1.21
+scipy>=1.7
+pandas>=1.4
+
+# --- Figures (journal-quality) ---
+matplotlib>=3.5
+SciencePlots>=2.0              # journal-ready matplotlib styles (science, nature, ieee, elsevier, etc.)
+Pillow>=9.0                    # image DPI validation, format conversion per journal requirements
+
+# --- Document rendering ---
+python-docx>=0.8.11            # Word (.docx) output
+latex2mathml>=3.0              # LaTeX -> MathML -> OMML equation pipeline
+lxml>=4.9                      # XML manipulation for OMML equations
+Jinja2>=3.1                    # HTML report templating
+pyyaml>=6.0                    # journal profile configs
+
+# --- Bibliography ---
+bibtexparser>=1.4              # parse/validate refs.bib programmatically
+
+# --- Prose quality & discovery ---
+textstat>=0.7                  # readability metrics (Flesch-Kincaid, Gunning fog, ARI)
+requests>=2.28                 # Semantic Scholar API for citation discovery

--- a/neqsim-paperlab/skills/design_reactor_benchmark/SKILL.md
+++ b/neqsim-paperlab/skills/design_reactor_benchmark/SKILL.md
@@ -172,7 +172,8 @@ Output `benchmark_config.json`:
 ## Python Execution Pattern for Reactor Benchmarks
 
 ```python
-from neqsim import jneqsim
+from tools.neqsim_bootstrap import get_jneqsim
+jneqsim = get_jneqsim()
 
 SystemSrkEos = jneqsim.thermo.system.SystemSrkEos
 ProcessSystem = jneqsim.process.processmodel.ProcessSystem

--- a/neqsim-paperlab/skills/run_flash_experiments/SKILL.md
+++ b/neqsim-paperlab/skills/run_flash_experiments/SKILL.md
@@ -73,7 +73,8 @@ def generate_all_cases(config):
 
 ```python
 import time
-from neqsim import jneqsim
+from tools.neqsim_bootstrap import get_jneqsim
+jneqsim = get_jneqsim()
 
 SystemSrkEos = jneqsim.thermo.system.SystemSrkEos
 SystemPrEos = jneqsim.thermo.system.SystemPrEos

--- a/neqsim-paperlab/tests/test_paperflow.py
+++ b/neqsim-paperlab/tests/test_paperflow.py
@@ -1,0 +1,871 @@
+"""Tests for paperflow CLI and supporting tools.
+
+Run with: python -m pytest tests/ -v
+"""
+import json
+import os
+import sys
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Add paperlab root to path
+PAPERLAB_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PAPERLAB_ROOT))
+sys.path.insert(0, str(PAPERLAB_ROOT / "tools"))
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.fixture
+def tmp_papers(tmp_path):
+    """Create a temporary papers directory."""
+    papers_dir = tmp_path / "papers"
+    papers_dir.mkdir()
+    return papers_dir
+
+
+@pytest.fixture
+def sample_paper(tmp_path):
+    """Create a complete sample paper project for testing."""
+    paper_dir = tmp_path / "papers" / "test_paper_2026"
+    paper_dir.mkdir(parents=True)
+    for sub in ["algorithm", "figures", "tables", "results", "results/raw", "submission"]:
+        (paper_dir / sub).mkdir(parents=True, exist_ok=True)
+
+    # plan.json
+    plan = {
+        "title": "Test Paper",
+        "target_journal": "fluid_phase_equilibria",
+        "paper_type": "characterization",
+        "created": "2026-01-01",
+        "status": "planning",
+        "novelty_statement": "Test novelty",
+        "research_questions": [
+            {"id": "RQ1", "question": "Does it work?", "hypothesis": "Yes",
+             "method": "Test it", "acceptance_criterion": "Works"}
+        ],
+        "benchmark_design": {
+            "algorithms": ["baseline"],
+            "eos_models": ["SRK"],
+            "fluid_families": ["lean_gas", "rich_gas"],
+            "metrics": ["convergence_rate", "cpu_time_ms"]
+        },
+        "workflow_log": [],
+    }
+    (paper_dir / "plan.json").write_text(json.dumps(plan, indent=2))
+
+    # results.json
+    results = {
+        "key_results": {
+            "total_cases": 100,
+            "convergence_rate_pct": 99.5,
+            "median_cpu_time_ms": 0.1,
+        },
+        "validation": {"all_passed": True},
+        "approach": "Tested with SRK EOS across 100 cases.",
+        "conclusions": "Algorithm converges 99.5% of cases.",
+        "figure_captions": {
+            "fig1_results.png": "Convergence results by family."
+        },
+        "tables": [
+            {
+                "title": "Summary Results",
+                "headers": ["Family", "Cases", "Conv %"],
+                "rows": [["lean_gas", 50, 100.0], ["rich_gas", 50, 99.0]]
+            }
+        ],
+    }
+    (paper_dir / "results.json").write_text(json.dumps(results, indent=2))
+
+    # refs.bib
+    (paper_dir / "refs.bib").write_text("@software{neqsim, title={NeqSim}}\n")
+
+    # approved_claims.json (empty for characterization)
+    (paper_dir / "approved_claims.json").write_text(
+        json.dumps({"claims": [], "threats_to_validity": []}, indent=2))
+    (paper_dir / "claims_manifest.json").write_text(
+        json.dumps({"claims": [], "unlinked_claims": []}, indent=2))
+
+    return paper_dir
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: paperflow new
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestNew:
+    def test_creates_directory_structure(self, tmp_path, monkeypatch):
+        """cmd_new creates correct directory structure."""
+        import paperflow
+        monkeypatch.setattr(paperflow, "PAPERS_DIR", tmp_path / "papers")
+        (tmp_path / "papers").mkdir()
+
+        class Args:
+            title = "Test Flash Paper"
+            journal = "fluid_phase_equilibria"
+            topic = "test_flash"
+
+        paperflow.cmd_new(Args())
+
+        paper_dir = tmp_path / "papers" / "test_flash_2026"
+        assert paper_dir.exists()
+        assert (paper_dir / "plan.json").exists()
+        assert (paper_dir / "benchmark_config.json").exists()
+        assert (paper_dir / "paper.md").exists()
+        assert (paper_dir / "refs.bib").exists()
+        assert (paper_dir / "approved_claims.json").exists()
+        assert (paper_dir / "figures").is_dir()
+        assert (paper_dir / "results" / "raw").is_dir()
+
+    def test_plan_json_has_required_fields(self, tmp_path, monkeypatch):
+        """plan.json contains expected skeleton fields."""
+        import paperflow
+        monkeypatch.setattr(paperflow, "PAPERS_DIR", tmp_path / "papers")
+        (tmp_path / "papers").mkdir()
+
+        class Args:
+            title = "My Paper"
+            journal = "computers_chem_eng"
+            topic = "my_topic"
+
+        paperflow.cmd_new(Args())
+
+        plan = json.loads(
+            (tmp_path / "papers" / "my_topic_2026" / "plan.json").read_text())
+        assert plan["title"] == "My Paper"
+        assert plan["target_journal"] == "computers_chem_eng"
+        assert len(plan["research_questions"]) >= 1
+        assert "benchmark_design" in plan
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: paperflow draft
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestDraft:
+    def test_generates_paper_md_from_artifacts(self, sample_paper, monkeypatch):
+        """draft command produces a paper.md from plan + results."""
+        import paperflow
+        monkeypatch.setattr(paperflow, "JOURNALS_DIR",
+                          PAPERLAB_ROOT / "journals")
+
+        # Remove the empty paper.md so draft can write
+        (sample_paper / "paper.md").unlink(missing_ok=True)
+
+        class Args:
+            paper_dir = str(sample_paper)
+            force = True
+
+        paperflow.cmd_draft(Args())
+
+        paper_md = (sample_paper / "paper.md").read_text()
+        assert "# Test Paper" in paper_md
+        assert "characterization" in paper_md.lower() or "DRAFT" in paper_md
+        # Results should appear somewhere
+        assert "99.5" in paper_md  # convergence_rate_pct
+        assert "Summary Results" in paper_md  # table title
+        assert "fig1_results.png" in paper_md  # figure reference
+
+    def test_draft_uses_plan_research_questions(self, sample_paper, monkeypatch):
+        """draft command includes research questions from plan."""
+        import paperflow
+        monkeypatch.setattr(paperflow, "JOURNALS_DIR",
+                          PAPERLAB_ROOT / "journals")
+        (sample_paper / "paper.md").unlink(missing_ok=True)
+
+        class Args:
+            paper_dir = str(sample_paper)
+            force = True
+
+        paperflow.cmd_draft(Args())
+
+        paper_md = (sample_paper / "paper.md").read_text()
+        assert "RQ1" in paper_md
+        assert "Does it work?" in paper_md
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: paperflow iterate
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestIterate:
+    def test_detects_missing_sections(self, sample_paper, monkeypatch):
+        """iterate catches missing manuscript sections."""
+        import paperflow
+        monkeypatch.setattr(paperflow, "JOURNALS_DIR",
+                          PAPERLAB_ROOT / "journals")
+
+        # Write minimal paper.md
+        (sample_paper / "paper.md").write_text(
+            "# Test\n\n## Abstract\n\nSome text\n")
+
+        class Args:
+            paper_dir = str(sample_paper)
+            check = "structure"
+
+        paperflow.cmd_iterate(Args())
+
+        feedback = json.loads(
+            (sample_paper / "iteration_feedback.json").read_text())
+        needs_work = [f for f in feedback["feedback"]
+                     if f["status"] == "NEEDS_WORK"]
+        # Should flag missing Conclusions, References, etc.
+        assert len(needs_work) > 0
+
+    def test_detects_todo_placeholders(self, sample_paper, monkeypatch):
+        """iterate flags remaining TODO placeholders."""
+        import paperflow
+        monkeypatch.setattr(paperflow, "JOURNALS_DIR",
+                          PAPERLAB_ROOT / "journals")
+
+        (sample_paper / "paper.md").write_text(
+            "# Test\n\n## Abstract\n\nTODO: write abstract\n\n"
+            "## Conclusions\n\nTODO: conclusions\n\n## References\n\n"
+            "## Acknowledgements\n\n## Keywords\n\n## Introduction\n\n")
+
+        class Args:
+            paper_dir = str(sample_paper)
+            check = "completeness"
+
+        paperflow.cmd_iterate(Args())
+
+        feedback = json.loads(
+            (sample_paper / "iteration_feedback.json").read_text())
+        completeness = [f for f in feedback["feedback"]
+                       if f["category"] == "completeness"
+                       and f["status"] == "NEEDS_WORK"]
+        assert any("TODO" in f["message"] for f in completeness)
+
+    def test_saves_iteration_feedback_json(self, sample_paper, monkeypatch):
+        """iterate produces machine-readable feedback file."""
+        import paperflow
+        monkeypatch.setattr(paperflow, "JOURNALS_DIR",
+                          PAPERLAB_ROOT / "journals")
+
+        (sample_paper / "paper.md").write_text("# Test\n\n## Abstract\n\n")
+
+        class Args:
+            paper_dir = str(sample_paper)
+            check = "all"
+
+        paperflow.cmd_iterate(Args())
+
+        fb_file = sample_paper / "iteration_feedback.json"
+        assert fb_file.exists()
+        data = json.loads(fb_file.read_text())
+        assert "score" in data
+        assert "max_score" in data
+        assert "feedback" in data
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: paperflow revise
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestRevise:
+    def test_creates_revision_workspace(self, sample_paper, monkeypatch):
+        """revise creates revision_N directory with templates."""
+        import paperflow
+
+        (sample_paper / "paper.md").write_text("# Test\n\nContent\n")
+
+        class Args:
+            paper_dir = str(sample_paper)
+            comments = None
+
+        paperflow.cmd_revise(Args())
+
+        rev_dir = sample_paper / "revision_1"
+        assert rev_dir.exists()
+        assert (rev_dir / "reviewer_comments.md").exists()
+        assert (rev_dir / "response_to_reviewers.md").exists()
+        assert (rev_dir / "revision_plan.json").exists()
+        assert (rev_dir / "paper_r0_baseline.md").exists()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: claim_tracer
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestClaimTracer:
+    def test_audit_characterization_passes_with_results(self, sample_paper):
+        """Characterization paper passes audit when results appear in text."""
+        from claim_tracer import audit_manuscript
+
+        paper_text = (
+            "# Test Paper\n\n"
+            "## Abstract\n\nWe achieved 99.5% convergence.\n\n"
+            "## 5. Results and Discussion\n\n"
+            "The algorithm converged in 99.5% of all 100 cases.\n"
+            "Median CPU time was 0.1 ms.\n\n"
+            "## 6. Conclusions\n\nDone.\n"
+        )
+        (sample_paper / "paper.md").write_text(paper_text)
+
+        report = audit_manuscript(str(sample_paper))
+        assert report["paper_type"] == "characterization"
+        assert report["evidence_model"] == "results_tracing"
+        # Should not have HIGH or CRITICAL issues
+        assert report["issues_by_severity"]["CRITICAL"] == 0
+
+    def test_audit_comparative_needs_claims(self, sample_paper):
+        """Comparative paper fails audit without [Claim Cx] references."""
+        from claim_tracer import audit_manuscript
+
+        plan = json.loads((sample_paper / "plan.json").read_text())
+        plan["paper_type"] = "comparative"
+        (sample_paper / "plan.json").write_text(json.dumps(plan, indent=2))
+
+        paper_text = (
+            "# Test\n\n"
+            "## 5. Results and Discussion\n\n"
+            "We improved convergence by 15.2% overall.\n"
+        )
+        (sample_paper / "paper.md").write_text(paper_text)
+
+        report = audit_manuscript(str(sample_paper))
+        assert report["paper_type"] == "comparative"
+        # Should flag unlinked numbers in results section
+        issues = report["issues"]
+        assert len(issues) > 0
+
+    def test_detect_paper_type(self, sample_paper):
+        """detect_paper_type reads from plan.json."""
+        from claim_tracer import detect_paper_type
+
+        assert detect_paper_type(str(sample_paper)) == "characterization"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: paper_renderer
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestPaperRenderer:
+    def test_load_journal_profile(self):
+        """Journal profiles load correctly."""
+        from paper_renderer import load_journal_profile
+
+        profile = load_journal_profile(
+            "fluid_phase_equilibria", str(PAPERLAB_ROOT / "journals"))
+        assert profile["journal_name"] == "Fluid Phase Equilibria"
+        assert profile["abstract_words_max"] == 250
+        assert profile["highlights_required"] is True
+
+    def test_parse_manuscript(self, sample_paper):
+        """Manuscript parser splits into sections."""
+        from paper_renderer import parse_manuscript
+
+        (sample_paper / "paper.md").write_text(
+            "# Title\n\nPreamble\n\n## Abstract\n\nAbstract text\n\n"
+            "## 1. Introduction\n\nIntro text\n")
+
+        sections = parse_manuscript(str(sample_paper / "paper.md"))
+        assert len(sections) >= 2
+        titles = [s["title"] for s in sections]
+        assert any("Abstract" in t for t in titles)
+
+    def test_available_journal_profiles(self):
+        """All journal profile files are valid YAML."""
+        try:
+            import yaml
+        except ImportError:
+            pytest.skip("PyYAML not installed")
+
+        for profile_file in (PAPERLAB_ROOT / "journals").glob("*.yaml"):
+            with open(profile_file, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            assert "journal_name" in data, f"{profile_file.name} missing journal_name"
+            assert "abstract_words_max" in data, f"{profile_file.name} missing abstract_words_max"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: status command
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestStatus:
+    def test_status_runs_without_error(self, sample_paper, capsys):
+        """status command prints project overview."""
+        import paperflow
+
+        class Args:
+            paper_dir = str(sample_paper)
+
+        paperflow.cmd_status(Args())
+        output = capsys.readouterr().out
+        assert "Test Paper" in output
+        assert "plan.json" in output
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: figure_style
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestFigureStyle:
+    def test_apply_style_does_not_crash(self):
+        """apply_style runs without error for all presets."""
+        from figure_style import apply_style
+        for journal in ("elsevier", "ieee", "nature", "acs", "default"):
+            apply_style(journal)
+
+    def test_palette_has_eight_colors(self):
+        """PALETTE contains 8 hex colors."""
+        from figure_style import PALETTE
+        assert len(PALETTE) == 8
+        for c in PALETTE:
+            assert c.startswith("#")
+
+    def test_save_fig_creates_file(self, tmp_path):
+        """save_fig writes a PNG file."""
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from figure_style import save_fig
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 4, 9])
+        save_fig(fig, "test_fig.png", figures_dir=str(tmp_path))
+        plt.close(fig)
+        assert (tmp_path / "test_fig.png").exists()
+        assert (tmp_path / "test_fig.png").stat().st_size > 0
+
+    def test_figure_size_constants(self):
+        """FIG_SINGLE and FIG_DOUBLE have correct dimensions."""
+        from figure_style import FIG_SINGLE, FIG_DOUBLE
+        assert FIG_SINGLE == (3.5, 2.8)
+        assert FIG_DOUBLE[0] == 7.0
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: figure_validator
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestFigureValidator:
+    def test_validate_missing_dir(self):
+        """Returns FAIL for non-existent directory."""
+        from figure_validator import validate_figures
+        issues = validate_figures("/nonexistent/path")
+        assert any(i["severity"] == "FAIL" for i in issues)
+
+    def test_validate_empty_dir(self, tmp_path):
+        """Returns WARNING for empty directory."""
+        from figure_validator import validate_figures
+        issues = validate_figures(str(tmp_path))
+        assert any(i["severity"] == "WARNING" for i in issues)
+
+    def test_validate_png_file(self, tmp_path):
+        """Validates a real PNG figure."""
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        from figure_validator import validate_single_figure
+
+        # Create a test PNG at 300 DPI
+        img = Image.new("RGB", (1050, 840), color="white")
+        fig_path = tmp_path / "fig01_test.png"
+        img.save(str(fig_path), dpi=(300, 300))
+
+        issues = validate_single_figure(str(fig_path))
+        # Should not have any FAIL issues for a valid 300 DPI image
+        assert not any(i["severity"] == "FAIL" for i in issues)
+
+    def test_validate_low_dpi(self, tmp_path):
+        """Catches low DPI images."""
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        from figure_validator import validate_single_figure
+
+        img = Image.new("RGB", (500, 400), color="white")
+        fig_path = tmp_path / "fig_lowdpi.png"
+        img.save(str(fig_path), dpi=(72, 72))
+
+        issues = validate_single_figure(str(fig_path))
+        assert any(i["severity"] == "FAIL" and "DPI" in i["message"] for i in issues)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: bib_validator
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestBibValidator:
+    def test_validate_missing_file(self):
+        """Returns FAIL for non-existent bib file."""
+        from bib_validator import validate_bibliography
+        issues = validate_bibliography("/nonexistent/refs.bib")
+        assert any(i["severity"] == "FAIL" for i in issues)
+
+    def test_validate_valid_bib(self, tmp_path):
+        """Passes for a well-formed bib entry."""
+        from bib_validator import validate_bibliography
+
+        bib_text = """@article{Smith2023,
+  author = {Smith, John and Doe, Jane},
+  title = {A Great Paper},
+  journal = {Fluid Phase Equilibria},
+  year = {2023},
+  volume = {100},
+  pages = {1--10},
+  doi = {10.1016/j.fluid.2023.001}
+}
+"""
+        bib_path = tmp_path / "refs.bib"
+        bib_path.write_text(bib_text)
+
+        issues = validate_bibliography(str(bib_path))
+        assert not any(i["severity"] == "FAIL" for i in issues)
+
+    def test_validate_missing_required_fields(self, tmp_path):
+        """Catches entries with missing required fields."""
+        from bib_validator import validate_bibliography
+
+        bib_text = """@article{BadEntry,
+  title = {An article with no author or journal}
+}
+"""
+        bib_path = tmp_path / "refs.bib"
+        bib_path.write_text(bib_text)
+
+        issues = validate_bibliography(str(bib_path))
+        fails = [i for i in issues if i["severity"] == "FAIL"]
+        # Should flag missing author, journal, year
+        assert len(fails) >= 2
+
+    def test_cross_check_with_manuscript(self, tmp_path):
+        """Detects citations not in bib and bib entries not cited."""
+        from bib_validator import validate_bibliography
+
+        bib_text = """@article{Used2023,
+  author = {Author, A.},
+  title = {Used Paper},
+  journal = {Some Journal},
+  year = {2023}
+}
+@article{Unused2023,
+  author = {Author, B.},
+  title = {Unused Paper},
+  journal = {Other Journal},
+  year = {2023}
+}
+"""
+        manuscript_text = (
+            "# Paper\n\n## Abstract\n\nAs shown by \\cite{Used2023} and "
+            "\\cite{Missing2023}, this works.\n"
+        )
+        bib_path = tmp_path / "refs.bib"
+        bib_path.write_text(bib_text)
+        manuscript_path = tmp_path / "paper.md"
+        manuscript_path.write_text(manuscript_text)
+
+        issues = validate_bibliography(str(bib_path), str(manuscript_path))
+        messages = " ".join(i["message"] for i in issues)
+        # Missing2023 cited but not in bib
+        assert "Missing2023" in messages
+        # Unused2023 in bib but not cited
+        assert "Unused2023" in messages
+
+    def test_duplicate_keys(self, tmp_path):
+        """Catches duplicate BibTeX keys."""
+        from bib_validator import validate_bibliography
+
+        bib_text = """@article{Dup2023,
+  author = {Author, A.},
+  title = {First},
+  journal = {J1},
+  year = {2023}
+}
+@article{Dup2023,
+  author = {Author, B.},
+  title = {Second},
+  journal = {J2},
+  year = {2023}
+}
+"""
+        bib_path = tmp_path / "refs.bib"
+        bib_path.write_text(bib_text)
+
+        issues = validate_bibliography(str(bib_path))
+        assert any(i["severity"] == "FAIL" and "Duplicate" in i["message"] for i in issues)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: validate-bib CLI command
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestValidateBibCLI:
+    def test_validate_bib_command_runs(self, sample_paper, capsys):
+        """validate-bib command runs without crashing."""
+        import paperflow
+
+        class Args:
+            paper_dir = str(sample_paper)
+
+        # Should not crash (sample_paper has refs.bib)
+        paperflow.cmd_validate_bib(Args())
+        output = capsys.readouterr().out
+        assert "Bibliography Validation" in output
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: prose_quality tool
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestProseQuality:
+    def test_analyze_returns_scores(self, tmp_path):
+        """analyze_prose returns readability scores and summary."""
+        from prose_quality import analyze_prose
+
+        paper = tmp_path / "paper.md"
+        paper.write_text(
+            "# Introduction\n\n"
+            "This is a simple test sentence. The algorithm converges quickly. "
+            "We measured the pressure drop across the valve. "
+            "Results show excellent agreement with laboratory data.\n"
+        )
+        report = analyze_prose(str(paper))
+        assert "error" not in report
+        assert report["word_count"] > 0
+        assert report["sentence_count"] >= 3
+        assert "overall" in report.get("summary_scores", {})
+
+    def test_detects_passive_voice(self, tmp_path):
+        """Passive voice sentences are flagged."""
+        from prose_quality import analyze_prose
+
+        paper = tmp_path / "paper.md"
+        paper.write_text(
+            "The pressure was measured by the sensor. "
+            "The valve was opened by the operator. "
+            "The flow was controlled by the system. "
+            "The temperature was increased gradually. "
+            "We analysed the results carefully.\n"
+        )
+        report = analyze_prose(str(paper))
+        assert report["passive_voice"]["count"] >= 3
+
+    def test_detects_long_sentences(self, tmp_path):
+        """Very long sentences are flagged."""
+        from prose_quality import analyze_prose
+
+        long_sentence = " ".join(["word"] * 45) + "."
+        paper = tmp_path / "paper.md"
+        paper.write_text(f"This is short. {long_sentence}\n")
+        report = analyze_prose(str(paper))
+        assert report["sentence_stats"]["long_sentence_count"] >= 1
+
+    def test_detects_hedging(self, tmp_path):
+        """Hedging language is detected."""
+        from prose_quality import analyze_prose
+
+        paper = tmp_path / "paper.md"
+        paper.write_text(
+            "The results are somewhat encouraging. "
+            "Perhaps this approach could be improved. "
+            "It seems to work relatively well. "
+            "The method is quite robust generally.\n"
+        )
+        report = analyze_prose(str(paper))
+        assert report["hedging"]["count"] >= 3
+
+    def test_detects_wordy_phrases(self, tmp_path):
+        """Wordy phrases are identified with suggestions."""
+        from prose_quality import analyze_prose
+
+        paper = tmp_path / "paper.md"
+        paper.write_text(
+            "We did this in order to improve accuracy. "
+            "Due to the fact that the sensor failed we stopped. "
+            "The system has the ability to self-correct.\n"
+        )
+        report = analyze_prose(str(paper))
+        wordy_issues = [i for i in report["issues"] if i["type"] == "WORDY_PHRASES"]
+        assert len(wordy_issues) == 1
+        assert wordy_issues[0]["count"] >= 2
+
+    def test_missing_file_returns_error(self, tmp_path):
+        """Returns error dict for missing file."""
+        from prose_quality import analyze_prose
+
+        report = analyze_prose(str(tmp_path / "nonexistent.md"))
+        assert "error" in report
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: citation_discovery tool
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestCitationDiscovery:
+    def test_extract_search_queries(self, tmp_path):
+        """Search queries are extracted from plan.json and paper.md."""
+        from citation_discovery import _extract_search_terms
+
+        paper_dir = tmp_path / "paper"
+        paper_dir.mkdir()
+
+        plan = {
+            "title": "Improved Flash Calculations for Mixed CO2 Systems",
+            "research_questions": [
+                {"id": "RQ1", "question": "How does CO2 affect convergence?"}
+            ],
+        }
+        (paper_dir / "plan.json").write_text(json.dumps(plan))
+        (paper_dir / "paper.md").write_text(
+            "# Abstract\n\nWe study equation of state flash convergence.\n"
+        )
+
+        queries = _extract_search_terms(str(paper_dir))
+        assert len(queries) >= 1
+        # Title should be the primary query
+        assert any("flash" in q.lower() for q in queries)
+
+    def test_filters_existing_refs(self, tmp_path):
+        """Papers already in refs.bib are excluded from suggestions."""
+        from citation_discovery import _get_existing_refs
+
+        paper_dir = tmp_path / "paper"
+        paper_dir.mkdir()
+        (paper_dir / "refs.bib").write_text(
+            "@article{Smith2020, title={Flash Algorithms}}\n"
+            "@article{Jones2019, title={CO2 Modeling}}\n"
+        )
+
+        titles = _get_existing_refs(str(paper_dir))
+        assert "flash algorithms" in titles
+        assert "co2 modeling" in titles
+
+    def test_no_plan_returns_empty(self, tmp_path):
+        """Returns empty suggestions when no plan.json or paper.md exists."""
+        from citation_discovery import suggest_citations
+
+        paper_dir = tmp_path / "empty_paper"
+        paper_dir.mkdir()
+
+        report = suggest_citations(str(paper_dir))
+        assert report.get("suggestions", []) == [] or "error" in report
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: revision_diff tool
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestRevisionDiff:
+    def test_generate_diff_explicit_files(self, tmp_path):
+        """Diff report is generated for two explicit files."""
+        from revision_diff import generate_diff
+
+        old = tmp_path / "old.md"
+        new = tmp_path / "new.md"
+        old.write_text("# Introduction\n\nOriginal text here.\n")
+        new.write_text("# Introduction\n\nRevised text with improvements.\n\n## Methods\n\nNew section.\n")
+
+        report = generate_diff(str(tmp_path), old_file=str(old), new_file=str(new))
+        assert "error" not in report
+        assert report["additions"] > 0
+        assert report["new_words"] > report["old_words"]
+        assert Path(report["html_report"]).exists()
+
+    def test_detects_added_sections(self, tmp_path):
+        """Diff detects newly added markdown sections."""
+        from revision_diff import generate_diff
+
+        old = tmp_path / "old.md"
+        new = tmp_path / "new.md"
+        old.write_text("# Introduction\n\nText.\n")
+        new.write_text("# Introduction\n\nText.\n\n## Results\n\nNew results.\n")
+
+        report = generate_diff(str(tmp_path), old_file=str(old), new_file=str(new))
+        assert "Results" in report["sections_added"]
+
+    def test_html_report_valid(self, tmp_path):
+        """Generated HTML report contains expected structure."""
+        from revision_diff import generate_diff
+
+        old = tmp_path / "old.md"
+        new = tmp_path / "new.md"
+        old.write_text("Line one.\nLine two.\n")
+        new.write_text("Line one.\nLine two revised.\nLine three.\n")
+
+        report = generate_diff(str(tmp_path), old_file=str(old), new_file=str(new))
+        html_path = Path(report["html_report"])
+        html_content = html_path.read_text()
+        assert "Manuscript Diff Report" in html_content
+        assert "Lines Added" in html_content
+
+    def test_revision_dir_auto_detect(self, tmp_path):
+        """Diff auto-detects revision directory baseline."""
+        from revision_diff import generate_diff
+
+        paper_dir = tmp_path / "paper"
+        paper_dir.mkdir()
+        rev_dir = paper_dir / "revision_1"
+        rev_dir.mkdir()
+
+        (rev_dir / "paper_r0_baseline.md").write_text("# Old version\n\nOriginal.\n")
+        (paper_dir / "paper.md").write_text("# New version\n\nRevised.\n")
+
+        report = generate_diff(str(paper_dir))
+        assert "error" not in report
+        assert report["additions"] > 0
+
+    def test_missing_revision_returns_error(self, tmp_path):
+        """Returns error when no revision directories exist."""
+        from revision_diff import generate_diff
+
+        paper_dir = tmp_path / "paper"
+        paper_dir.mkdir()
+        (paper_dir / "paper.md").write_text("Some text.\n")
+
+        report = generate_diff(str(paper_dir))
+        assert "error" in report
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Test: CLI commands for new tools
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestCheckProseCLI:
+    def test_check_prose_command_runs(self, sample_paper, capsys):
+        """check-prose command runs on sample paper."""
+        import paperflow
+
+        # Write a paper.md to the sample paper dir
+        (Path(sample_paper) / "paper.md").write_text(
+            "# Introduction\n\n"
+            "This paper presents a novel algorithm. "
+            "The results demonstrate significant improvements. "
+            "We validate our approach using benchmark data.\n"
+        )
+
+        class Args:
+            paper_dir = str(sample_paper)
+
+        paperflow.cmd_check_prose(Args())
+        output = capsys.readouterr().out
+        assert "PROSE QUALITY" in output
+
+
+class TestDiffCLI:
+    def test_diff_command_runs(self, sample_paper, capsys):
+        """diff command runs with explicit files."""
+        import paperflow
+
+        old_f = Path(sample_paper) / "old.md"
+        new_f = Path(sample_paper) / "paper.md"
+        old_f.write_text("# Original\n\nOld content.\n")
+        new_f.write_text("# Revised\n\nNew content with changes.\n")
+
+        class Args:
+            paper_dir = str(sample_paper)
+            revision = None
+            old = str(old_f)
+            new = str(new_f)
+
+        paperflow.cmd_diff(Args())
+        output = capsys.readouterr().out
+        assert "REVISION DIFF" in output

--- a/neqsim-paperlab/tools/bib_validator.py
+++ b/neqsim-paperlab/tools/bib_validator.py
@@ -1,0 +1,230 @@
+"""
+Bibliography Validator — Validate refs.bib against journal requirements.
+
+Uses bibtexparser to parse and check BibTeX entries for completeness,
+consistency, and common issues.
+
+Usage::
+
+    from tools.bib_validator import validate_bibliography
+
+    issues = validate_bibliography("papers/my_paper/refs.bib")
+    for issue in issues:
+        print(f"[{issue['severity']}] {issue['key']}: {issue['message']}")
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:
+    import bibtexparser
+    _HAS_BIBTEX = True
+except ImportError:
+    _HAS_BIBTEX = False
+
+
+# Required fields by entry type (BibTeX standard)
+_REQUIRED_FIELDS = {
+    "article": {"author", "title", "journal", "year"},
+    "book": {"author", "title", "publisher", "year"},
+    "inproceedings": {"author", "title", "booktitle", "year"},
+    "incollection": {"author", "title", "booktitle", "publisher", "year"},
+    "phdthesis": {"author", "title", "school", "year"},
+    "mastersthesis": {"author", "title", "school", "year"},
+    "techreport": {"author", "title", "institution", "year"},
+    "misc": {"title"},
+    "software": {"title", "year"},
+    "online": {"title", "url"},
+}
+
+# Fields that should not be empty
+_NONEMPTY_FIELDS = {"author", "title", "year", "journal", "publisher", "school"}
+
+
+def validate_bibliography(bib_path, manuscript_path=None):
+    """Validate a BibTeX file for completeness and consistency.
+
+    Parameters
+    ----------
+    bib_path : str or Path
+        Path to the .bib file.
+    manuscript_path : str or Path, optional
+        Path to paper.md — if given, checks that all \\cite{} keys exist
+        in the bib file and all bib entries are used.
+
+    Returns
+    -------
+    list of dict
+        Each dict has keys: key, severity (INFO/WARNING/FAIL), message.
+    """
+    bib_path = Path(bib_path)
+    issues = []
+
+    if not bib_path.exists():
+        issues.append({"key": "-", "severity": "FAIL",
+                       "message": f"Bibliography file not found: {bib_path}"})
+        return issues
+
+    if not _HAS_BIBTEX:
+        issues.append({"key": "-", "severity": "WARNING",
+                       "message": "bibtexparser not installed — skipping deep validation"})
+        return _validate_regex_fallback(bib_path, manuscript_path)
+
+    # Parse with bibtexparser
+    bib_text = bib_path.read_text(encoding="utf-8")
+    try:
+        bib_db = bibtexparser.loads(bib_text)
+    except Exception as e:
+        issues.append({"key": "-", "severity": "FAIL",
+                       "message": f"Failed to parse BibTeX: {e}"})
+        return issues
+
+    entries = bib_db.entries
+    if not entries:
+        issues.append({"key": "-", "severity": "WARNING",
+                       "message": "Bibliography file contains no entries"})
+        return issues
+
+    issues.append({"key": "-", "severity": "INFO",
+                   "message": f"Found {len(entries)} bibliography entries"})
+
+    # Check for duplicate keys
+    seen_keys = set()
+    for entry in entries:
+        key = entry.get("ID", "unknown")
+        if key in seen_keys:
+            issues.append({"key": key, "severity": "FAIL",
+                           "message": "Duplicate BibTeX key"})
+        seen_keys.add(key)
+
+    # Validate each entry
+    for entry in entries:
+        key = entry.get("ID", "unknown")
+        entry_type = entry.get("ENTRYTYPE", "misc").lower()
+
+        # Check required fields
+        required = _REQUIRED_FIELDS.get(entry_type, {"title"})
+        for field in required:
+            if field not in entry or not entry[field].strip():
+                issues.append({"key": key, "severity": "FAIL",
+                               "message": f"Missing required field '{field}' for @{entry_type}"})
+
+        # Check for empty fields
+        for field in _NONEMPTY_FIELDS:
+            if field in entry and not entry[field].strip():
+                issues.append({"key": key, "severity": "WARNING",
+                               "message": f"Field '{field}' is present but empty"})
+
+        # Check year is a valid number
+        year_str = entry.get("year", "").strip()
+        if year_str:
+            try:
+                year = int(year_str)
+                if year < 1800 or year > 2100:
+                    issues.append({"key": key, "severity": "WARNING",
+                                   "message": f"Unusual year: {year}"})
+            except ValueError:
+                issues.append({"key": key, "severity": "WARNING",
+                               "message": f"Year is not a number: '{year_str}'"})
+
+        # Check for common issues
+        title = entry.get("title", "")
+        if title and title == title.lower():
+            issues.append({"key": key, "severity": "INFO",
+                           "message": "Title is all lowercase — check capitalization"})
+
+        # Check URL/DOI presence (recommended)
+        if "doi" not in entry and "url" not in entry:
+            issues.append({"key": key, "severity": "INFO",
+                           "message": "No DOI or URL — consider adding for discoverability"})
+
+    # Cross-check with manuscript if provided
+    if manuscript_path:
+        issues.extend(_cross_check_manuscript(manuscript_path, seen_keys))
+
+    return issues
+
+
+def _cross_check_manuscript(manuscript_path, bib_keys):
+    """Check that manuscript citations match bib entries."""
+    import re
+    manuscript_path = Path(manuscript_path)
+    issues = []
+
+    if not manuscript_path.exists():
+        return issues
+
+    text = manuscript_path.read_text(encoding="utf-8")
+
+    # Find all \cite{key} and \cite{key1, key2} references
+    cited_keys = set()
+    for match in re.finditer(r'\\cite\{([^}]+)\}', text):
+        for key in match.group(1).split(","):
+            cited_keys.add(key.strip())
+
+    # Keys cited but not in bib
+    missing = cited_keys - bib_keys
+    for key in sorted(missing):
+        issues.append({"key": key, "severity": "FAIL",
+                       "message": f"{key}: cited in manuscript but not in refs.bib"})
+
+    # Keys in bib but not cited
+    unused = bib_keys - cited_keys
+    for key in sorted(unused):
+        issues.append({"key": key, "severity": "WARNING",
+                       "message": f"{key}: in refs.bib but not cited in manuscript"})
+
+    if not missing and not unused:
+        issues.append({"key": "-", "severity": "INFO",
+                       "message": "All citations match bibliography entries"})
+
+    return issues
+
+
+def _validate_regex_fallback(bib_path, manuscript_path=None):
+    """Basic regex validation when bibtexparser is not available."""
+    import re
+    issues = []
+    bib_text = Path(bib_path).read_text(encoding="utf-8")
+
+    # Count entries
+    entries = re.findall(r'@(\w+)\{(\w+),', bib_text)
+    if not entries:
+        issues.append({"key": "-", "severity": "WARNING",
+                       "message": "No BibTeX entries found (regex fallback)"})
+        return issues
+
+    issues.append({"key": "-", "severity": "INFO",
+                   "message": f"Found {len(entries)} entries (regex fallback)"})
+
+    # Check for duplicate keys
+    keys = [e[1] for e in entries]
+    seen = set()
+    for key in keys:
+        if key in seen:
+            issues.append({"key": key, "severity": "FAIL",
+                           "message": "Duplicate BibTeX key"})
+        seen.add(key)
+
+    return issues
+
+
+def print_validation_report(issues):
+    """Print a formatted validation report."""
+    fails = [i for i in issues if i["severity"] == "FAIL"]
+    warns = [i for i in issues if i["severity"] == "WARNING"]
+    infos = [i for i in issues if i["severity"] == "INFO"]
+
+    print(f"Bibliography Validation: {len(fails)} FAIL, {len(warns)} WARNING, {len(infos)} INFO")
+    print("-" * 60)
+
+    for issue in issues:
+        icon = {"FAIL": "[FAIL]", "WARNING": "[WARN]", "INFO": "[ OK ]"}[issue["severity"]]
+        print(f"  {icon} [{issue['key']}] {issue['message']}")
+
+    if fails:
+        print(f"\n{len(fails)} issue(s) must be fixed before submission.")
+    elif warns:
+        print(f"\n{len(warns)} warning(s) — review before submission.")
+    else:
+        print("\nBibliography passes all checks.")

--- a/neqsim-paperlab/tools/citation_discovery.py
+++ b/neqsim-paperlab/tools/citation_discovery.py
@@ -1,0 +1,281 @@
+"""
+Citation Discovery — Suggest missing references using Semantic Scholar API.
+
+Extracts key phrases from the manuscript abstract/introduction, queries
+Semantic Scholar for highly-cited papers, and reports potentially-missing
+references.
+
+No API key required (free tier: 100 requests/5 minutes).
+
+Usage::
+
+    from tools.citation_discovery import suggest_citations
+
+    suggestions = suggest_citations("papers/my_paper/")
+    for s in suggestions:
+        print(f"  {s['title']} ({s['year']}) — cited {s['citation_count']} times")
+"""
+
+import re
+import json
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:
+    import requests
+    _HAS_REQUESTS = True
+except ImportError:
+    _HAS_REQUESTS = False
+
+
+_S2_SEARCH_URL = "https://api.semanticscholar.org/graph/v1/paper/search"
+_S2_FIELDS = "title,authors,year,citationCount,externalIds,abstract,url"
+_MIN_CITATIONS = 10  # Only suggest well-cited papers
+
+
+def _extract_search_terms(paper_dir):
+    """Extract search queries from the manuscript.
+
+    Uses: title, abstract keywords, and research questions from plan.json.
+    """
+    paper_dir = Path(paper_dir)
+    queries = []
+
+    # From plan.json
+    plan_file = paper_dir / "plan.json"
+    if plan_file.exists():
+        plan = json.loads(plan_file.read_text(encoding="utf-8"))
+        title = plan.get("title", "")
+        if title:
+            queries.append(title)
+
+        # Research questions as search queries
+        for rq in plan.get("research_questions", []):
+            q = rq.get("question", "")
+            if q and "TODO" not in q:
+                queries.append(q)
+
+    # From paper.md abstract
+    paper_file = paper_dir / "paper.md"
+    if paper_file.exists():
+        text = paper_file.read_text(encoding="utf-8")
+
+        # Extract abstract
+        abstract_match = re.search(
+            r'## Abstract\s*\n(.*?)(?=\n## |\n---)',
+            text, re.DOTALL | re.IGNORECASE)
+        if abstract_match:
+            abstract = abstract_match.group(1).strip()
+            # Remove TODO placeholders
+            abstract = re.sub(r'TODO.*', '', abstract).strip()
+            if len(abstract) > 50:
+                queries.append(abstract[:300])
+
+        # Extract keywords
+        kw_match = re.search(
+            r'## Keywords\s*\n(.*?)(?=\n## |\n---)',
+            text, re.DOTALL | re.IGNORECASE)
+        if kw_match:
+            kw_text = kw_match.group(1).strip()
+            if "TODO" not in kw_text and len(kw_text) > 5:
+                queries.append(kw_text)
+
+    return queries
+
+
+def _get_existing_refs(paper_dir):
+    """Get set of existing reference titles (lowercase) from refs.bib."""
+    bib_file = Path(paper_dir) / "refs.bib"
+    existing = set()
+    if bib_file.exists():
+        bib_text = bib_file.read_text(encoding="utf-8")
+        for match in re.finditer(r'title\s*=\s*\{(.+?)\}', bib_text, re.DOTALL):
+            title = match.group(1).replace("{", "").replace("}", "").strip().lower()
+            existing.add(title)
+    return existing
+
+
+def _search_semantic_scholar(query, limit=10):
+    """Search Semantic Scholar API for papers matching a query."""
+    if not _HAS_REQUESTS:
+        return []
+
+    params = {
+        "query": query[:200],  # API limit
+        "limit": limit,
+        "fields": _S2_FIELDS,
+    }
+
+    try:
+        resp = requests.get(_S2_SEARCH_URL, params=params, timeout=15)
+        if resp.status_code == 429:
+            # Rate limited — wait and retry once
+            time.sleep(3)
+            resp = requests.get(_S2_SEARCH_URL, params=params, timeout=15)
+
+        if resp.status_code != 200:
+            return []
+
+        data = resp.json()
+        return data.get("data", [])
+    except (requests.RequestException, json.JSONDecodeError):
+        return []
+
+
+def suggest_citations(paper_dir, max_suggestions=15, min_citations=None):
+    """Suggest potentially-missing citations for a manuscript.
+
+    Parameters
+    ----------
+    paper_dir : str or Path
+        Path to the paper project directory.
+    max_suggestions : int
+        Maximum number of suggestions to return.
+    min_citations : int, optional
+        Minimum citation count filter (default: 10).
+
+    Returns
+    -------
+    dict
+        Report with 'suggestions' list and metadata.
+    """
+    if not _HAS_REQUESTS:
+        return {
+            "error": "requests package not installed. Run: pip install requests",
+            "suggestions": [],
+        }
+
+    paper_dir = Path(paper_dir)
+    if min_citations is None:
+        min_citations = _MIN_CITATIONS
+
+    queries = _extract_search_terms(paper_dir)
+    if not queries:
+        return {
+            "error": "No search terms found. Add a title to plan.json or content to paper.md.",
+            "suggestions": [],
+        }
+
+    existing_titles = _get_existing_refs(paper_dir)
+
+    # Search for each query
+    all_papers = {}
+    for query in queries[:4]:  # Limit to 4 queries to stay within rate limits
+        papers = _search_semantic_scholar(query, limit=15)
+        for paper in papers:
+            pid = paper.get("paperId")
+            if pid and pid not in all_papers:
+                all_papers[pid] = paper
+        time.sleep(1.0)  # Rate limiting
+
+    # Filter and rank
+    suggestions = []
+    for pid, paper in all_papers.items():
+        title = (paper.get("title") or "").strip()
+        if not title:
+            continue
+
+        # Skip papers already in refs.bib
+        if title.lower() in existing_titles:
+            continue
+
+        citation_count = paper.get("citationCount", 0) or 0
+        if citation_count < min_citations:
+            continue
+
+        year = paper.get("year")
+
+        # Format authors
+        authors = paper.get("authors", [])
+        if len(authors) > 2:
+            author_str = f"{authors[0].get('name', '?')} et al."
+        elif len(authors) == 2:
+            author_str = f"{authors[0].get('name', '?')} and {authors[1].get('name', '?')}"
+        elif authors:
+            author_str = authors[0].get("name", "?")
+        else:
+            author_str = "Unknown"
+
+        # DOI
+        ext_ids = paper.get("externalIds", {}) or {}
+        doi = ext_ids.get("DOI", "")
+
+        suggestions.append({
+            "title": title,
+            "authors": author_str,
+            "year": year,
+            "citation_count": citation_count,
+            "doi": doi,
+            "url": paper.get("url", ""),
+            "relevance_source": "semantic_scholar",
+        })
+
+    # Sort by citation count (most cited first)
+    suggestions.sort(key=lambda x: x["citation_count"], reverse=True)
+    suggestions = suggestions[:max_suggestions]
+
+    return {
+        "paper_dir": str(paper_dir),
+        "queries_used": queries[:4],
+        "total_candidates": len(all_papers),
+        "filtered_by_citations": min_citations,
+        "existing_refs": len(existing_titles),
+        "suggestions": suggestions,
+    }
+
+
+def format_bibtex_suggestion(suggestion):
+    """Format a suggestion as a BibTeX entry for easy copy-paste."""
+    # Create a key from first author last name + year
+    author = suggestion["authors"].split(",")[0].split(" ")[-1].split(".")[0]
+    year = suggestion.get("year", "XXXX") or "XXXX"
+    key = f"{author}{year}"
+
+    doi_line = f"  doi = {{{suggestion['doi']}}},\n" if suggestion.get("doi") else ""
+    url_line = f"  url = {{{suggestion['url']}}},\n" if suggestion.get("url") else ""
+
+    return (
+        f"@article{{{key},\n"
+        f"  author = {{{suggestion['authors']}}},\n"
+        f"  title = {{{{{suggestion['title']}}}}},\n"
+        f"  year = {{{year}}},\n"
+        f"{doi_line}{url_line}"
+        f"  note = {{Cited {suggestion['citation_count']} times}}\n"
+        f"}}\n"
+    )
+
+
+def print_suggestions(report):
+    """Print formatted citation suggestions."""
+    if "error" in report and not report.get("suggestions"):
+        print(f"Error: {report['error']}")
+        return
+
+    suggestions = report.get("suggestions", [])
+    print("=" * 60)
+    print("CITATION DISCOVERY REPORT")
+    print("=" * 60)
+    print(f"  Queries: {len(report.get('queries_used', []))}")
+    print(f"  Candidates found: {report.get('total_candidates', 0)}")
+    print(f"  Already in refs.bib: {report.get('existing_refs', 0)}")
+    print(f"  Suggestions (≥{report.get('filtered_by_citations', _MIN_CITATIONS)} citations): "
+          f"{len(suggestions)}")
+    print()
+
+    if not suggestions:
+        print("  No new citation suggestions found.")
+        return
+
+    for i, s in enumerate(suggestions, 1):
+        doi_str = f"  DOI: {s['doi']}" if s.get('doi') else ""
+        print(f"  {i:2d}. {s['title']}")
+        print(f"      {s['authors']} ({s['year']}) — {s['citation_count']:,} citations{doi_str}")
+        print()
+
+    # Print BibTeX block
+    print("-" * 60)
+    print("BibTeX entries (copy to refs.bib):")
+    print("-" * 60)
+    for s in suggestions[:5]:
+        print(format_bibtex_suggestion(s))

--- a/neqsim-paperlab/tools/claim_tracer.py
+++ b/neqsim-paperlab/tools/claim_tracer.py
@@ -2,6 +2,10 @@
 Claim Tracer — Ensures every quantitative claim in a manuscript is backed
 by evidence from benchmark results and approved by the validation agent.
 
+Supports two evidence models:
+  - Comparative papers: formal [Claim Cx] references -> approved_claims.json
+  - Characterization/method/application papers: results.json key_results tracing
+
 Usage:
     python claim_tracer.py audit papers/tpflash_algorithms_2026/
     python claim_tracer.py report papers/tpflash_algorithms_2026/
@@ -25,6 +29,16 @@ class Claim:
     unit: Optional[str]
     linked_evidence: Optional[str]
     status: str  # LINKED, UNLINKED, REJECTED
+
+
+def detect_paper_type(paper_dir):
+    """Detect paper type from plan.json."""
+    plan_file = Path(paper_dir) / "plan.json"
+    if plan_file.exists():
+        with open(plan_file) as f:
+            plan = json.load(f)
+        return plan.get("paper_type", "characterization")
+    return "characterization"
 
 
 def extract_numbers_from_text(text):
@@ -59,6 +73,10 @@ def find_claim_references(text):
 def audit_manuscript(paper_dir):
     """Audit a manuscript for unsupported claims.
 
+    Adapts evidence checking based on paper type:
+    - comparative: requires [Claim Cx] -> approved_claims.json
+    - characterization/method/application: checks results.json traceability
+
     Args:
         paper_dir: Path to the paper directory
 
@@ -66,6 +84,7 @@ def audit_manuscript(paper_dir):
         Audit report dict
     """
     paper_dir = Path(paper_dir)
+    paper_type = detect_paper_type(paper_dir)
 
     # Load manuscript
     paper_file = paper_dir / "paper.md"
@@ -92,47 +111,108 @@ def audit_manuscript(paper_dir):
             for claim in data.get("claims", []):
                 manifest_claims[claim["claim_id"]] = claim
 
+    # Load results.json for non-comparative papers
+    results = {}
+    results_file = paper_dir / "results.json"
+    if results_file.exists():
+        with open(results_file) as f:
+            results = json.load(f)
+
     # Find all numbers in manuscript
     numbers_found = extract_numbers_from_text(paper_text)
 
     # Find all claim references
     claim_refs = find_claim_references(paper_text)
 
-    # Check each referenced claim is approved
     issues = []
-    for ref in claim_refs:
-        if ref not in approved_claims:
-            issues.append({
-                "type": "UNLINKED_CLAIM",
-                "severity": "HIGH",
-                "claim_id": ref,
-                "message": f"Claim {ref} referenced in text but not in approved_claims.json",
-            })
-        elif approved_claims[ref].get("status") == "REJECTED":
-            issues.append({
-                "type": "REJECTED_CLAIM_USED",
-                "severity": "CRITICAL",
-                "claim_id": ref,
-                "message": f"Claim {ref} was REJECTED but is still in the manuscript",
-            })
-        elif approved_claims[ref].get("status") == "INSUFFICIENT_EVIDENCE":
-            issues.append({
-                "type": "INSUFFICIENT_CLAIM_USED",
-                "severity": "HIGH",
-                "claim_id": ref,
-                "message": f"Claim {ref} has INSUFFICIENT_EVIDENCE but is in the manuscript",
-            })
 
-    # Check for numbers not linked to any claim
-    # This is heuristic — not every number needs a claim reference,
-    # but numbers in Results/Discussion sections should
-    sections_needing_claims = ["results", "discussion", "abstract"]
-    for section in sections_needing_claims:
-        # Simple section detection
+    # ── Comparative papers: formal claim pipeline ──
+    if paper_type == "comparative":
+        for ref in claim_refs:
+            if ref not in approved_claims:
+                issues.append({
+                    "type": "UNLINKED_CLAIM",
+                    "severity": "HIGH",
+                    "claim_id": ref,
+                    "message": f"Claim {ref} referenced in text but not in approved_claims.json",
+                })
+            elif approved_claims[ref].get("status") == "REJECTED":
+                issues.append({
+                    "type": "REJECTED_CLAIM_USED",
+                    "severity": "CRITICAL",
+                    "claim_id": ref,
+                    "message": f"Claim {ref} was REJECTED but is still in the manuscript",
+                })
+            elif approved_claims[ref].get("status") == "INSUFFICIENT_EVIDENCE":
+                issues.append({
+                    "type": "INSUFFICIENT_CLAIM_USED",
+                    "severity": "HIGH",
+                    "claim_id": ref,
+                    "message": f"Claim {ref} has INSUFFICIENT_EVIDENCE but is in the manuscript",
+                })
+
+        # Check approved claims not referenced
+        for claim_id, claim in approved_claims.items():
+            if claim.get("status") == "APPROVED" and claim_id not in claim_refs:
+                issues.append({
+                    "type": "UNUSED_APPROVED_CLAIM",
+                    "severity": "LOW",
+                    "claim_id": claim_id,
+                    "message": f"Claim {claim_id} is APPROVED but not referenced in manuscript",
+                })
+
+    # ── Characterization/method/application: results.json traceability ──
+    else:
+        key_results = results.get("key_results", {})
+
+        if not key_results:
+            issues.append({
+                "type": "NO_RESULTS",
+                "severity": "HIGH",
+                "message": "No results.json key_results found — cannot verify claims",
+            })
+        else:
+            # Check that key numerical results appear in the text
+            results_traced = 0
+            results_missing = []
+            for key, val in key_results.items():
+                val_str = str(val)
+                # Check if the value appears anywhere in the manuscript
+                if val_str in paper_text:
+                    results_traced += 1
+                else:
+                    results_missing.append(f"{key}={val}")
+
+            if results_missing:
+                issues.append({
+                    "type": "UNTRACED_RESULTS",
+                    "severity": "MEDIUM",
+                    "message": (
+                        f"{len(results_missing)}/{len(key_results)} key results not "
+                        f"found in manuscript text: {', '.join(results_missing[:5])}"
+                    ),
+                })
+
+        # Check figures are referenced
+        fig_captions = results.get("figure_captions", {})
+        if fig_captions:
+            fig_refs = re.findall(r'[Ff]ig(?:ure)?\.?\s*(\d+)', paper_text)
+            fig_nums = set(int(n) for n in fig_refs)
+            for i, fname in enumerate(fig_captions, 1):
+                if i not in fig_nums:
+                    issues.append({
+                        "type": "UNREFERENCED_FIGURE",
+                        "severity": "MEDIUM",
+                        "message": f"Figure {i} ({fname}) not referenced in text",
+                    })
+
+    # ── Common checks for all paper types ──
+    # Check for numbers in results/discussion without any evidence link
+    sections_needing_evidence = ["results", "discussion", "abstract"]
+    for section in sections_needing_evidence:
         section_pattern = rf'##\s*\d*\.?\d*\s*{section}'
         section_match = re.search(section_pattern, paper_text, re.IGNORECASE)
         if section_match:
-            # Find next section header
             next_section = re.search(r'\n##\s', paper_text[section_match.end():])
             end = section_match.end() + next_section.start() if next_section else len(paper_text)
             section_text = paper_text[section_match.start():end]
@@ -140,7 +220,7 @@ def audit_manuscript(paper_dir):
             section_numbers = extract_numbers_from_text(section_text)
             section_refs = find_claim_references(section_text)
 
-            if section_numbers and not section_refs:
+            if paper_type == "comparative" and section_numbers and not section_refs:
                 issues.append({
                     "type": "UNLINKED_NUMBERS",
                     "severity": "MEDIUM",
@@ -149,25 +229,18 @@ def audit_manuscript(paper_dir):
                         f"Section '{section}' contains {len(section_numbers)} "
                         f"quantitative statements but no [Claim Cx] references"
                     ),
-                    "numbers": section_numbers[:5],  # First 5 examples
+                    "numbers": section_numbers[:5],
                 })
-
-    # Check approved claims that are NOT referenced in the manuscript
-    for claim_id, claim in approved_claims.items():
-        if claim.get("status") == "APPROVED" and claim_id not in claim_refs:
-            issues.append({
-                "type": "UNUSED_APPROVED_CLAIM",
-                "severity": "LOW",
-                "claim_id": claim_id,
-                "message": f"Claim {claim_id} is APPROVED but not referenced in manuscript",
-            })
 
     report = {
         "paper_dir": str(paper_dir),
+        "paper_type": paper_type,
+        "evidence_model": "formal_claims" if paper_type == "comparative" else "results_tracing",
         "manuscript_exists": True,
         "approved_claims_count": len(approved_claims),
         "claim_references_in_text": len(claim_refs),
         "unique_claims_referenced": len(set(claim_refs)),
+        "results_json_keys": len(results.get("key_results", {})),
         "numbers_in_text": len(numbers_found),
         "issues": issues,
         "issues_by_severity": {

--- a/neqsim-paperlab/tools/figure_style.py
+++ b/neqsim-paperlab/tools/figure_style.py
@@ -1,0 +1,138 @@
+"""
+Publication-quality figure styling for NeqSim paperlab.
+
+Provides journal-preset matplotlib configurations using SciencePlots.
+Import this module at the top of any generate_figures.py script.
+
+Usage::
+
+    from tools.figure_style import apply_style, PALETTE, FIG_SINGLE, FIG_DOUBLE, save_fig
+
+    apply_style("elsevier")           # or "ieee", "nature", "acs", "default"
+    fig, ax = plt.subplots(figsize=FIG_SINGLE)
+    ax.plot(x, y, color=PALETTE[0])
+    save_fig(fig, "fig01_convergence.png")
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+try:
+    import scienceplots  # noqa: F401 — registers styles on import
+    _HAS_SCIENCEPLOTS = True
+except ImportError:
+    _HAS_SCIENCEPLOTS = False
+
+from pathlib import Path
+
+
+# ── Color Palettes ────────────────────────────────────────────────────────
+PALETTE = ["#2171b5", "#e6550d", "#31a354", "#756bb1", "#e7298a", "#66a61e",
+           "#a6761d", "#666666"]
+BLUE, ORANGE, GREEN, PURPLE, PINK, LIME = PALETTE[:6]
+GREY = "#636363"
+
+# ── Figure Sizes (inches) ────────────────────────────────────────────────
+# Elsevier / ACS / Wiley single-column ~3.5 in, double ~7.0 in
+FIG_SINGLE = (3.5, 2.8)
+FIG_SINGLE_TALL = (3.5, 3.5)
+FIG_DOUBLE = (7.0, 3.5)
+FIG_DOUBLE_TALL = (7.0, 5.5)
+FIG_SQUARE = (3.5, 3.5)
+
+
+# ── Journal Style Presets ─────────────────────────────────────────────────
+_JOURNAL_STYLES = {
+    "elsevier": ["science", "no-latex"],           # FPE, CACE, CES
+    "ieee": ["science", "ieee", "no-latex"],
+    "nature": ["science", "nature", "no-latex"],
+    "acs": ["science", "no-latex"],                # IECR, ACS journals
+    "default": ["science", "no-latex"],
+}
+
+# Fallback rcParams when SciencePlots is not installed
+_FALLBACK_RC = {
+    "font.family": "serif",
+    "font.serif": ["Times New Roman", "DejaVu Serif", "serif"],
+    "mathtext.fontset": "dejavuserif",
+    "font.size": 9,
+    "axes.labelsize": 10,
+    "axes.titlesize": 10,
+    "axes.titleweight": "bold",
+    "axes.linewidth": 0.6,
+    "legend.fontsize": 8,
+    "legend.framealpha": 0.9,
+    "legend.edgecolor": "0.7",
+    "xtick.labelsize": 8,
+    "ytick.labelsize": 8,
+    "xtick.direction": "in",
+    "ytick.direction": "in",
+    "xtick.major.size": 3,
+    "ytick.major.size": 3,
+    "xtick.minor.size": 1.5,
+    "ytick.minor.size": 1.5,
+    "xtick.minor.visible": True,
+    "ytick.minor.visible": True,
+    "grid.linewidth": 0.3,
+    "grid.alpha": 0.4,
+    "lines.linewidth": 1.0,
+    "lines.markersize": 4,
+    "figure.dpi": 150,
+    "savefig.dpi": 300,
+    "savefig.bbox": "tight",
+    "savefig.pad_inches": 0.05,
+}
+
+
+def apply_style(journal="elsevier"):
+    """Apply a journal-appropriate matplotlib style.
+
+    Uses SciencePlots styles when available, falls back to manually
+    tuned rcParams otherwise.
+
+    Parameters
+    ----------
+    journal : str
+        One of "elsevier", "ieee", "nature", "acs", "default".
+    """
+    if _HAS_SCIENCEPLOTS:
+        styles = _JOURNAL_STYLES.get(journal, _JOURNAL_STYLES["default"])
+        plt.style.use(styles)
+        # Override DPI for print quality
+        plt.rcParams.update({"savefig.dpi": 300, "figure.dpi": 150})
+    else:
+        plt.rcParams.update(_FALLBACK_RC)
+
+
+def save_fig(fig, filename, figures_dir=None, dpi=300, formats=None):
+    """Save a figure in publication quality.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to save.
+    filename : str
+        Output filename (e.g. "fig01_convergence.png").
+    figures_dir : str or Path, optional
+        Output directory. Defaults to cwd/figures/.
+    dpi : int
+        Resolution (default 300, Elsevier minimum).
+    formats : list of str, optional
+        Additional formats to save (e.g. ["pdf", "tif"]).
+    """
+    if figures_dir is None:
+        figures_dir = Path.cwd() / "figures"
+    figures_dir = Path(figures_dir)
+    figures_dir.mkdir(exist_ok=True)
+
+    primary = figures_dir / filename
+    fig.savefig(str(primary), dpi=dpi, bbox_inches="tight", pad_inches=0.05)
+
+    if formats:
+        stem = primary.stem
+        for fmt in formats:
+            alt = figures_dir / f"{stem}.{fmt}"
+            fig.savefig(str(alt), dpi=dpi, bbox_inches="tight", pad_inches=0.05)
+
+    plt.close(fig)

--- a/neqsim-paperlab/tools/figure_validator.py
+++ b/neqsim-paperlab/tools/figure_validator.py
@@ -1,0 +1,193 @@
+"""
+Figure Validator — Check figures meet journal submission requirements.
+
+Validates DPI, dimensions, format, file size, and color mode using Pillow.
+
+Usage::
+
+    from tools.figure_validator import validate_figures
+
+    issues = validate_figures("papers/my_paper/figures/", journal_profile)
+    for issue in issues:
+        print(f"[{issue['severity']}] {issue['file']}: {issue['message']}")
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:
+    from PIL import Image
+    _HAS_PIL = True
+except ImportError:
+    _HAS_PIL = False
+
+
+# Default requirements (Elsevier baseline)
+_DEFAULTS = {
+    "min_dpi": 300,
+    "max_file_size_mb": 20,
+    "allowed_formats": {"png", "tif", "tiff", "eps", "pdf", "jpg", "jpeg"},
+    "min_width_px": 500,
+    "max_width_px": 10000,
+    "preferred_formats": {"tif", "pdf", "eps"},
+}
+
+
+def validate_single_figure(fig_path, requirements=None):
+    """Validate a single figure file.
+
+    Parameters
+    ----------
+    fig_path : str or Path
+        Path to the figure file.
+    requirements : dict, optional
+        Override default requirements.
+
+    Returns
+    -------
+    list of dict
+        Each dict has keys: file, severity (INFO/WARNING/FAIL), message.
+    """
+    fig_path = Path(fig_path)
+    reqs = dict(_DEFAULTS)
+    if requirements:
+        reqs.update(requirements)
+
+    issues = []
+    name = fig_path.name
+
+    if not fig_path.exists():
+        issues.append({"file": name, "severity": "FAIL",
+                       "message": "File not found"})
+        return issues
+
+    # Check file extension
+    ext = fig_path.suffix.lower().lstrip(".")
+    if ext not in reqs["allowed_formats"]:
+        issues.append({"file": name, "severity": "FAIL",
+                       "message": f"Format .{ext} not accepted. Use: {reqs['allowed_formats']}"})
+
+    # Check file size
+    size_mb = fig_path.stat().st_size / (1024 * 1024)
+    if size_mb > reqs["max_file_size_mb"]:
+        issues.append({"file": name, "severity": "WARNING",
+                       "message": f"File size {size_mb:.1f} MB exceeds {reqs['max_file_size_mb']} MB"})
+
+    # Pillow checks (raster images only)
+    if _HAS_PIL and ext in {"png", "jpg", "jpeg", "tif", "tiff", "bmp"}:
+        try:
+            with Image.open(fig_path) as img:
+                width, height = img.size
+
+                # DPI check (allow 0.5 tolerance for floating-point rounding)
+                dpi = img.info.get("dpi", (72, 72))
+                x_dpi = dpi[0] if isinstance(dpi, (tuple, list)) else dpi
+                if x_dpi < reqs["min_dpi"] - 0.5:
+                    issues.append({"file": name, "severity": "FAIL",
+                                   "message": f"DPI is {x_dpi:.0f}, minimum is {reqs['min_dpi']}"})
+                else:
+                    issues.append({"file": name, "severity": "INFO",
+                                   "message": f"DPI: {x_dpi:.0f} (OK)"})
+
+                # Dimension checks
+                if width < reqs["min_width_px"]:
+                    issues.append({"file": name, "severity": "WARNING",
+                                   "message": f"Width {width}px may be too small for print"})
+                if width > reqs["max_width_px"]:
+                    issues.append({"file": name, "severity": "WARNING",
+                                   "message": f"Width {width}px is unusually large"})
+
+                # Color mode
+                if img.mode == "RGBA":
+                    issues.append({"file": name, "severity": "WARNING",
+                                   "message": "Image has alpha channel — some journals reject this"})
+
+                # Check if grayscale image could use smaller format
+                if img.mode in ("L", "1") and ext in ("png", "jpg"):
+                    issues.append({"file": name, "severity": "INFO",
+                                   "message": "Grayscale image — consider TIFF for line art"})
+
+        except Exception as e:
+            issues.append({"file": name, "severity": "WARNING",
+                           "message": f"Could not read image metadata: {e}"})
+
+    # Suggest preferred format
+    if ext not in reqs.get("preferred_formats", set()):
+        pref = ", ".join(sorted(reqs.get("preferred_formats", {"tif", "pdf"})))
+        issues.append({"file": name, "severity": "INFO",
+                       "message": f"Consider converting to {pref} for best print quality"})
+
+    if not issues:
+        issues.append({"file": name, "severity": "INFO", "message": "All checks passed"})
+
+    return issues
+
+
+def validate_figures(figures_dir, journal_profile=None):
+    """Validate all figures in a directory against journal requirements.
+
+    Parameters
+    ----------
+    figures_dir : str or Path
+        Directory containing figure files.
+    journal_profile : dict, optional
+        Journal profile dict (from YAML). Extracts figure_dpi_min and
+        figure_formats to build requirements.
+
+    Returns
+    -------
+    list of dict
+        All issues found across all figures.
+    """
+    figures_dir = Path(figures_dir)
+    if not figures_dir.exists():
+        return [{"file": str(figures_dir), "severity": "FAIL",
+                 "message": "Figures directory not found"}]
+
+    # Build requirements from journal profile
+    reqs = dict(_DEFAULTS)
+    if journal_profile:
+        if "figure_dpi_min" in journal_profile:
+            reqs["min_dpi"] = journal_profile["figure_dpi_min"]
+        if "figure_formats" in journal_profile:
+            reqs["allowed_formats"] = set(journal_profile["figure_formats"])
+            reqs["preferred_formats"] = set(journal_profile["figure_formats"][:2])
+
+    # Find all figure files
+    extensions = {"*.png", "*.jpg", "*.jpeg", "*.tif", "*.tiff",
+                  "*.eps", "*.pdf", "*.bmp", "*.svg"}
+    fig_files = []
+    for ext_pattern in extensions:
+        fig_files.extend(figures_dir.glob(ext_pattern))
+    fig_files.sort()
+
+    if not fig_files:
+        return [{"file": str(figures_dir), "severity": "WARNING",
+                 "message": "No figure files found"}]
+
+    all_issues = []
+    for fig in fig_files:
+        all_issues.extend(validate_single_figure(fig, reqs))
+
+    return all_issues
+
+
+def print_validation_report(issues):
+    """Print a formatted validation report."""
+    fails = [i for i in issues if i["severity"] == "FAIL"]
+    warns = [i for i in issues if i["severity"] == "WARNING"]
+    infos = [i for i in issues if i["severity"] == "INFO"]
+
+    print(f"Figure Validation: {len(fails)} FAIL, {len(warns)} WARNING, {len(infos)} INFO")
+    print("-" * 60)
+
+    for issue in issues:
+        icon = {"FAIL": "[FAIL]", "WARNING": "[WARN]", "INFO": "[ OK ]"}[issue["severity"]]
+        print(f"  {icon} {issue['file']}: {issue['message']}")
+
+    if fails:
+        print(f"\n{len(fails)} issue(s) must be fixed before submission.")
+    elif warns:
+        print(f"\n{len(warns)} warning(s) — review before submission.")
+    else:
+        print("\nAll figures pass validation.")

--- a/neqsim-paperlab/tools/flash_benchmark.py
+++ b/neqsim-paperlab/tools/flash_benchmark.py
@@ -179,7 +179,8 @@ def run_benchmark(config, algorithm_name, results_dir, progress_interval=50):
     Returns:
         Summary dict
     """
-    from neqsim import jneqsim
+    from tools.neqsim_bootstrap import get_jneqsim
+    jneqsim = get_jneqsim()
 
     cases = generate_cases(config)
     eos_name = config["eos_models"][0]

--- a/neqsim-paperlab/tools/neqsim_bootstrap.py
+++ b/neqsim-paperlab/tools/neqsim_bootstrap.py
@@ -1,0 +1,98 @@
+"""
+NeqSim Bootstrap — Always loads NeqSim from the local devtools build.
+
+This module provides a single entry point for all paperlab tools to get
+the NeqSim Java gateway. It uses the devtools/neqsim_dev_setup.py to
+start the JVM from the locally compiled JAR (target/classes + shaded JAR),
+so any Java code changes are picked up immediately after ``mvnw compile``.
+
+Usage::
+
+    from tools.neqsim_bootstrap import get_jneqsim, get_ns
+
+    # Option A: jneqsim gateway (drop-in replacement for ``from neqsim import jneqsim``)
+    jneqsim = get_jneqsim()
+    fluid = jneqsim.thermo.system.SystemSrkEos(298.15, 50.0)
+
+    # Option B: namespace with class shortcuts (ns.SystemSrkEos, ns.Stream, etc.)
+    ns = get_ns()
+    fluid = ns.SystemSrkEos(298.15, 50.0)
+
+Environment variable override:
+    NEQSIM_PROJECT_ROOT  — path to the neqsim repo root (auto-detected by default)
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import jpype
+
+# ── Locate project root (two levels up from this file: tools/ -> neqsim-paperlab/ -> repo root)
+_THIS_DIR = Path(__file__).resolve().parent
+_PAPERLAB_DIR = _THIS_DIR.parent
+_DEFAULT_PROJECT_ROOT = _PAPERLAB_DIR.parent
+
+# Allow override via environment variable
+PROJECT_ROOT = Path(os.environ.get("NEQSIM_PROJECT_ROOT", str(_DEFAULT_PROJECT_ROOT)))
+
+# Add devtools/ to sys.path so we can import neqsim_dev_setup
+_DEVTOOLS_DIR = PROJECT_ROOT / "devtools"
+if str(_DEVTOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_DEVTOOLS_DIR))
+
+# Module-level singletons (initialised lazily)
+_jneqsim = None
+_ns = None
+
+
+def _ensure_jvm():
+    """Start the JVM via neqsim_dev_setup if not already running."""
+    global _ns
+    if jpype.isJVMStarted():
+        return
+
+    from neqsim_dev_setup import neqsim_init, neqsim_classes
+
+    ns = neqsim_init(project_root=PROJECT_ROOT, recompile=False, verbose=True)
+    ns = neqsim_classes(ns)
+    _ns = ns
+
+
+def get_jneqsim():
+    """Return a jpype JPackage gateway equivalent to ``from neqsim import jneqsim``.
+
+    This is a drop-in replacement: ``jneqsim.thermo.system.SystemSrkEos(...)``
+    works exactly the same way, but the classes come from the local build.
+    """
+    global _jneqsim
+    if _jneqsim is not None:
+        return _jneqsim
+
+    _ensure_jvm()
+    _jneqsim = jpype.JPackage("neqsim")
+    return _jneqsim
+
+
+def get_ns():
+    """Return the devtools namespace with class shortcuts.
+
+    Attributes like ``ns.SystemSrkEos``, ``ns.Stream``, ``ns.ProcessSystem``
+    are available directly.
+    """
+    global _ns
+    if _ns is not None:
+        return _ns
+
+    _ensure_jvm()
+    return _ns
+
+
+def recompile_and_reload():
+    """Recompile the Java source and restart the JVM.
+
+    Only works inside Jupyter notebooks (restarts the kernel).
+    For standalone scripts, just recompile externally and re-run.
+    """
+    from neqsim_dev_setup import neqsim_compile
+    neqsim_compile(project_root=PROJECT_ROOT, restart_kernel=True)

--- a/neqsim-paperlab/tools/neqsim_scientific_tools.py
+++ b/neqsim-paperlab/tools/neqsim_scientific_tools.py
@@ -92,10 +92,10 @@ class NeqSimFlashTool:
         self._initialized = False
 
     def _ensure_initialized(self):
-        """Lazy initialization of NeqSim."""
+        """Lazy initialization of NeqSim via local devtools build."""
         if not self._initialized:
-            from neqsim import jneqsim
-            self._jneqsim = jneqsim
+            from tools.neqsim_bootstrap import get_jneqsim
+            self._jneqsim = get_jneqsim()
             self._initialized = True
 
     def _create_fluid(self, components, T_K, P_bara, eos="SRK"):
@@ -300,8 +300,8 @@ class NeqSimProcessTool:
 
     def _ensure_initialized(self):
         if not self._initialized:
-            from neqsim import jneqsim
-            self._jneqsim = jneqsim
+            from tools.neqsim_bootstrap import get_jneqsim
+            self._jneqsim = get_jneqsim()
             self._initialized = True
 
     def run_separation(self, components, T_K, P_bara, flow_rate_kg_hr,

--- a/neqsim-paperlab/tools/prose_quality.py
+++ b/neqsim-paperlab/tools/prose_quality.py
@@ -1,0 +1,397 @@
+"""
+Prose Quality Analyzer — Sentence-level writing feedback for scientific manuscripts.
+
+Checks readability (Flesch-Kincaid), sentence length, passive voice,
+hedging language, and academic style metrics.
+
+Usage::
+
+    from tools.prose_quality import analyze_prose
+
+    report = analyze_prose("papers/my_paper/paper.md")
+    print_prose_report(report)
+"""
+
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:
+    import textstat
+    _HAS_TEXTSTAT = True
+except ImportError:
+    _HAS_TEXTSTAT = False
+
+
+# ── Passive voice patterns ────────────────────────────────────────────
+# Match "is/was/were/been/being/are + past participle"
+_PASSIVE_RE = re.compile(
+    r'\b(is|are|was|were|been|being|be|get|gets|got|gotten)\s+'
+    r'(\w+ed|built|chosen|done|drawn|driven|eaten|fallen|found|given|gone|'
+    r'grown|known|made|run|said|seen|shown|taken|thought|written|broken|'
+    r'frozen|spoken|stolen|worn|torn|begun|drunk|rung|sung|sunk|swum)\b',
+    re.IGNORECASE,
+)
+
+# ── Hedging / weak language ──────────────────────────────────────────
+_HEDGE_WORDS = [
+    r'\bsomewhat\b', r'\bslightly\b', r'\bperhaps\b', r'\bapparently\b',
+    r'\bseems?\s+to\b', r'\bappears?\s+to\b', r'\bmight\b', r'\bcould\s+be\b',
+    r'\bit\s+is\s+possible\b', r'\bgenerally\b', r'\brelatively\b',
+    r'\bquite\b', r'\brather\b', r'\bfairly\b',
+]
+_HEDGE_RE = re.compile('|'.join(_HEDGE_WORDS), re.IGNORECASE)
+
+# ── Wordy phrases ────────────────────────────────────────────────────
+_WORDY_PAIRS = [
+    (r'\bin order to\b', 'to'),
+    (r'\bdue to the fact that\b', 'because'),
+    (r'\bat this point in time\b', 'now'),
+    (r'\bin the event that\b', 'if'),
+    (r'\bfor the purpose of\b', 'to/for'),
+    (r'\bwith regard to\b', 'regarding/about'),
+    (r'\bin spite of the fact that\b', 'although'),
+    (r'\bit is important to note that\b', '[delete]'),
+    (r'\bit should be noted that\b', '[delete]'),
+    (r'\ba large number of\b', 'many'),
+    (r'\ba small number of\b', 'few'),
+    (r'\bhas the ability to\b', 'can'),
+    (r'\bis able to\b', 'can'),
+    (r'\bprior to\b', 'before'),
+    (r'\bsubsequent to\b', 'after'),
+    (r'\bin close proximity to\b', 'near'),
+    (r'\btake into consideration\b', 'consider'),
+]
+
+
+def _extract_body_text(paper_text):
+    """Extract prose-only body from markdown, skipping metadata and code."""
+    # Remove HTML comments
+    text = re.sub(r'<!--.*?-->', '', paper_text, flags=re.DOTALL)
+    # Remove code blocks
+    text = re.sub(r'```.*?```', '', text, flags=re.DOTALL)
+    # Remove inline code
+    text = re.sub(r'`[^`]+`', '', text)
+    # Remove markdown images
+    text = re.sub(r'!\[.*?\]\(.*?\)', '', text)
+    # Remove markdown links but keep text
+    text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', text)
+    # Remove markdown headers (keep text for sentence detection)
+    text = re.sub(r'^#{1,6}\s+', '', text, flags=re.MULTILINE)
+    # Remove table separators
+    text = re.sub(r'^\|[\s:\-|]+\|$', '', text, flags=re.MULTILINE)
+    # Remove table rows
+    text = re.sub(r'^\|.*\|$', '', text, flags=re.MULTILINE)
+    # Remove bold/italic markers
+    text = re.sub(r'\*{1,3}', '', text)
+    # Remove horizontal rules
+    text = re.sub(r'^---+$', '', text, flags=re.MULTILINE)
+    # Remove LaTeX display math
+    text = re.sub(r'\$\$.*?\$\$', '', text, flags=re.DOTALL)
+    # Remove inline math
+    text = re.sub(r'\$[^$]+\$', 'X', text)
+    # Remove \cite{} references
+    text = re.sub(r'\\cite\{[^}]+\}', '', text)
+    # Collapse whitespace
+    text = re.sub(r'\n{2,}', '\n', text)
+    return text.strip()
+
+
+def _split_sentences(text):
+    """Split text into sentences (simple rule-based)."""
+    # Split on . ! ? followed by space or end
+    raw = re.split(r'(?<=[.!?])\s+', text)
+    sentences = []
+    for s in raw:
+        s = s.strip()
+        if len(s) > 10:  # Skip fragments
+            sentences.append(s)
+    return sentences
+
+
+def analyze_prose(paper_path, max_sentence_words=35, target_grade=12.0):
+    """Analyze prose quality of a manuscript.
+
+    Parameters
+    ----------
+    paper_path : str or Path
+        Path to paper.md.
+    max_sentence_words : int
+        Sentences with more words than this are flagged.
+    target_grade : float
+        Target Flesch-Kincaid grade level (12 = college level, typical for journals).
+
+    Returns
+    -------
+    dict
+        Comprehensive prose quality report.
+    """
+    paper_path = Path(paper_path)
+    if not paper_path.exists():
+        return {"error": f"File not found: {paper_path}"}
+
+    raw_text = paper_path.read_text(encoding="utf-8")
+    body = _extract_body_text(raw_text)
+    sentences = _split_sentences(body)
+
+    report = {
+        "file": str(paper_path),
+        "word_count": len(body.split()),
+        "sentence_count": len(sentences),
+        "readability": {},
+        "issues": [],
+        "summary_scores": {},
+    }
+
+    if not sentences:
+        report["issues"].append({
+            "type": "NO_CONTENT",
+            "severity": "FAIL",
+            "message": "No prose content found in manuscript",
+        })
+        return report
+
+    # ── Readability metrics (textstat) ────────────────────────────────
+    if _HAS_TEXTSTAT:
+        fk_grade = textstat.flesch_kincaid_grade(body)
+        fk_ease = textstat.flesch_reading_ease(body)
+        gunning = textstat.gunning_fog(body)
+        ari = textstat.automated_readability_index(body)
+
+        report["readability"] = {
+            "flesch_kincaid_grade": round(fk_grade, 1),
+            "flesch_reading_ease": round(fk_ease, 1),
+            "gunning_fog_index": round(gunning, 1),
+            "automated_readability_index": round(ari, 1),
+        }
+
+        # Grade level check
+        if fk_grade > target_grade + 4:
+            report["issues"].append({
+                "type": "READABILITY",
+                "severity": "WARNING",
+                "message": (f"Flesch-Kincaid grade {fk_grade:.1f} is very high "
+                           f"(target: {target_grade:.0f}). Consider shorter sentences."),
+            })
+        elif fk_grade > target_grade + 2:
+            report["issues"].append({
+                "type": "READABILITY",
+                "severity": "INFO",
+                "message": f"Flesch-Kincaid grade {fk_grade:.1f} (target: {target_grade:.0f})",
+            })
+        else:
+            report["issues"].append({
+                "type": "READABILITY",
+                "severity": "OK",
+                "message": f"Flesch-Kincaid grade {fk_grade:.1f} — good readability",
+            })
+
+    # ── Sentence length analysis ──────────────────────────────────────
+    long_sentences = []
+    sentence_lengths = []
+    for s in sentences:
+        word_count = len(s.split())
+        sentence_lengths.append(word_count)
+        if word_count > max_sentence_words:
+            # Show first 80 chars
+            preview = s[:80] + "..." if len(s) > 80 else s
+            long_sentences.append({
+                "words": word_count,
+                "preview": preview,
+            })
+
+    avg_len = sum(sentence_lengths) / len(sentence_lengths) if sentence_lengths else 0
+    report["sentence_stats"] = {
+        "average_words": round(avg_len, 1),
+        "max_words": max(sentence_lengths) if sentence_lengths else 0,
+        "min_words": min(sentence_lengths) if sentence_lengths else 0,
+        "long_sentence_count": len(long_sentences),
+    }
+
+    if long_sentences:
+        report["issues"].append({
+            "type": "LONG_SENTENCES",
+            "severity": "WARNING",
+            "count": len(long_sentences),
+            "message": (f"{len(long_sentences)} sentences exceed {max_sentence_words} words. "
+                       f"Consider splitting."),
+            "examples": long_sentences[:5],
+        })
+
+    # ── Passive voice detection ───────────────────────────────────────
+    passive_matches = []
+    for s in sentences:
+        matches = _PASSIVE_RE.findall(s)
+        if matches:
+            preview = s[:80] + "..." if len(s) > 80 else s
+            passive_matches.append(preview)
+
+    passive_pct = len(passive_matches) / len(sentences) * 100 if sentences else 0
+    report["passive_voice"] = {
+        "count": len(passive_matches),
+        "percent": round(passive_pct, 1),
+    }
+
+    if passive_pct > 30:
+        report["issues"].append({
+            "type": "PASSIVE_VOICE",
+            "severity": "WARNING",
+            "message": (f"{passive_pct:.0f}% of sentences use passive voice "
+                       f"(aim for <25%). Consider active constructions."),
+            "examples": passive_matches[:5],
+        })
+    elif passive_pct > 20:
+        report["issues"].append({
+            "type": "PASSIVE_VOICE",
+            "severity": "INFO",
+            "message": f"{passive_pct:.0f}% passive voice — acceptable for scientific writing",
+        })
+    else:
+        report["issues"].append({
+            "type": "PASSIVE_VOICE",
+            "severity": "OK",
+            "message": f"{passive_pct:.0f}% passive voice — good balance",
+        })
+
+    # ── Hedging language ──────────────────────────────────────────────
+    hedge_matches = _HEDGE_RE.findall(body)
+    hedge_count = len(hedge_matches)
+    report["hedging"] = {
+        "count": hedge_count,
+        "examples": list(set(h.lower() for h in hedge_matches))[:10],
+    }
+
+    if hedge_count > 10:
+        report["issues"].append({
+            "type": "HEDGING",
+            "severity": "WARNING",
+            "message": (f"{hedge_count} hedging phrases found (somewhat, perhaps, "
+                       f"seems to...). Be more assertive with evidence-backed claims."),
+        })
+    elif hedge_count > 5:
+        report["issues"].append({
+            "type": "HEDGING",
+            "severity": "INFO",
+            "message": f"{hedge_count} hedging phrases — review for unnecessary qualifiers",
+        })
+
+    # ── Wordy phrases ─────────────────────────────────────────────────
+    wordy_found = []
+    for pattern, replacement in _WORDY_PAIRS:
+        matches = re.findall(pattern, body, re.IGNORECASE)
+        if matches:
+            wordy_found.append({
+                "phrase": matches[0],
+                "replacement": replacement,
+                "count": len(matches),
+            })
+
+    if wordy_found:
+        report["issues"].append({
+            "type": "WORDY_PHRASES",
+            "severity": "INFO",
+            "count": sum(w["count"] for w in wordy_found),
+            "message": f"{len(wordy_found)} wordy phrase types found — consider tighter wording",
+            "suggestions": wordy_found[:10],
+        })
+
+    # ── Summary scores (0-100) ────────────────────────────────────────
+    # Readability score
+    read_score = 100
+    if _HAS_TEXTSTAT:
+        fk = report["readability"]["flesch_kincaid_grade"]
+        if fk > 18:
+            read_score = 40
+        elif fk > 16:
+            read_score = 60
+        elif fk > 14:
+            read_score = 75
+        elif fk > 12:
+            read_score = 85
+        else:
+            read_score = 95
+
+    # Sentence score
+    long_pct = len(long_sentences) / len(sentences) * 100 if sentences else 0
+    sent_score = max(0, 100 - long_pct * 3)
+
+    # Passive score
+    passive_score = max(0, 100 - max(0, passive_pct - 15) * 3)
+
+    # Conciseness score
+    wordy_total = sum(w["count"] for w in wordy_found)
+    concise_score = max(0, 100 - wordy_total * 5 - hedge_count * 3)
+
+    overall = round((read_score + sent_score + passive_score + concise_score) / 4)
+    report["summary_scores"] = {
+        "readability": round(read_score),
+        "sentence_structure": round(sent_score),
+        "active_voice": round(passive_score),
+        "conciseness": round(concise_score),
+        "overall": overall,
+    }
+
+    return report
+
+
+def print_prose_report(report):
+    """Print a formatted prose quality report."""
+    if "error" in report:
+        print(f"Error: {report['error']}")
+        return
+
+    print("=" * 60)
+    print("PROSE QUALITY REPORT")
+    print("=" * 60)
+    print(f"  Words: {report['word_count']:,}    Sentences: {report['sentence_count']}")
+
+    # Readability
+    r = report.get("readability", {})
+    if r:
+        print(f"\n  Readability:")
+        print(f"    Flesch-Kincaid Grade: {r['flesch_kincaid_grade']}")
+        print(f"    Flesch Reading Ease:  {r['flesch_reading_ease']}")
+        print(f"    Gunning Fog Index:    {r['gunning_fog_index']}")
+
+    # Sentence stats
+    ss = report.get("sentence_stats", {})
+    if ss:
+        print(f"\n  Sentence Length:")
+        print(f"    Average: {ss['average_words']} words    "
+              f"Max: {ss['max_words']}    Long: {ss['long_sentence_count']}")
+
+    # Passive voice
+    pv = report.get("passive_voice", {})
+    if pv:
+        print(f"    Passive voice: {pv['percent']}% of sentences")
+
+    # Issues
+    issues = report.get("issues", [])
+    if issues:
+        print(f"\n  Issues:")
+        for issue in issues:
+            icon = {"OK": "  [OK]", "INFO": "  [..]", "WARNING": "  [!!]",
+                    "FAIL": "  [XX]"}.get(issue.get("severity", "INFO"), "  [??]")
+            print(f"    {icon} {issue['message']}")
+
+            # Show examples for long sentences
+            if issue.get("type") == "LONG_SENTENCES":
+                for ex in issue.get("examples", [])[:3]:
+                    print(f"         → ({ex['words']}w) {ex['preview']}")
+
+            # Show wordy phrase suggestions
+            if issue.get("type") == "WORDY_PHRASES":
+                for sug in issue.get("suggestions", [])[:5]:
+                    print(f"         → \"{sug['phrase']}\" → \"{sug['replacement']}\"")
+
+    # Summary scores
+    scores = report.get("summary_scores", {})
+    if scores:
+        print(f"\n  Scores (0-100):")
+        for key, val in scores.items():
+            bar_len = val // 5
+            bar = "█" * bar_len + "░" * (20 - bar_len)
+            label = key.replace("_", " ").title()
+            print(f"    {label:20s} {bar} {val}")
+
+    print()

--- a/neqsim-paperlab/tools/render_html_generic.py
+++ b/neqsim-paperlab/tools/render_html_generic.py
@@ -1,0 +1,207 @@
+"""Render paper.md to a standalone HTML file with KaTeX math and embedded figures.
+
+Generic version that works with any paper project directory.
+
+Usage:
+    python render_html.py <paper_dir>
+    python render_html.py papers/tpflash_algorithms_2026
+    python render_html.py papers/gibbs_minimization_2026
+"""
+import re
+import sys
+import json
+from pathlib import Path
+
+
+def get_html_header(title="Paper"):
+    """Generate HTML header with KaTeX and styling."""
+    return r"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>""" + title + r"""</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
+  onload="renderMathInElement(document.body, {
+    delimiters: [
+      {left: '$$', right: '$$', display: true},
+      {left: '$', right: '$', display: false}
+    ]
+  })"></script>
+<style>
+  body { max-width: 900px; margin: 40px auto; font-family: 'Georgia', serif;
+         line-height: 1.7; color: #333; padding: 0 20px; }
+  h1 { font-size: 1.8em; border-bottom: 2px solid #2196F3; padding-bottom: 10px; }
+  h2 { font-size: 1.4em; color: #1565C0; margin-top: 2em; }
+  h3 { font-size: 1.15em; color: #1976D2; }
+  table { border-collapse: collapse; margin: 1em auto; font-size: 0.95em; }
+  th, td { border: 1px solid #ccc; padding: 6px 12px; text-align: left; }
+  th { background: #E3F2FD; font-weight: 600; }
+  tr:nth-child(even) { background: #FAFAFA; }
+  code { background: #f5f5f5; padding: 2px 5px; border-radius: 3px; font-size: 0.9em; }
+  pre { background: #263238; color: #eee; padding: 16px; border-radius: 6px;
+        overflow-x: auto; font-size: 0.88em; line-height: 1.5; }
+  pre code { background: none; color: inherit; padding: 0; }
+  blockquote { border-left: 4px solid #2196F3; margin: 1em 0; padding: 8px 16px;
+               background: #E3F2FD; }
+  img { max-width: 100%; display: block; margin: 1em auto; }
+  .fig-container { text-align: center; margin: 2em 0; }
+  .fig-caption { font-style: italic; color: #666; margin-top: 0.5em; }
+  hr { border: none; border-top: 1px solid #ddd; margin: 2em 0; }
+  strong { color: #1565C0; }
+</style>
+</head>
+<body>
+"""
+
+
+def build_figures_section(paper_dir):
+    """Build HTML for figures from results.json captions and figure files."""
+    paper_dir = Path(paper_dir)
+    fig_dir = paper_dir / "figures"
+
+    # Try to load captions from results.json
+    captions = {}
+    results_file = paper_dir / "results.json"
+    if results_file.exists():
+        data = json.loads(results_file.read_text(encoding="utf-8"))
+        captions = data.get("figure_captions", {})
+
+    # Find figure files
+    if not fig_dir.exists():
+        return ""
+
+    fig_files = sorted(fig_dir.glob("fig*.png")) + sorted(fig_dir.glob("fig*.pdf"))
+    if not fig_files:
+        return ""
+
+    html = '\n<div style="background: #E3F2FD; padding: 20px; border-radius: 8px; margin: 2em 0;">\n'
+    html += '<h2 style="margin-top: 0;">Figures</h2>\n\n'
+
+    for i, fig_path in enumerate(fig_files, 1):
+        fname = fig_path.name
+        caption = captions.get(fname, f"Figure {i}")
+        rel_path = f"../figures/{fname}"
+        html += f'<div class="fig-container">\n'
+        html += f'<img src="{rel_path}" alt="Fig. {i}">\n'
+        html += f'<p class="fig-caption">Fig. {i}. {caption}</p>\n'
+        html += f'</div>\n\n'
+
+    html += '</div>\n'
+    return html
+
+
+def convert_table(match):
+    """Convert a markdown table to HTML."""
+    lines = match.group(0).strip().split("\n")
+    rows = [l for l in lines if l.strip() and not re.match(r'^\|[\s:\-]+\|$', l)]
+    html_t = '<table>\n'
+    for i, row in enumerate(rows):
+        cells = [c.strip() for c in row.split('|')[1:-1]]
+        tag = 'th' if i == 0 else 'td'
+        html_t += '<tr>' + ''.join('<{0}>{1}</{0}>'.format(tag, c) for c in cells) + '</tr>\n'
+    html_t += '</table>'
+    return html_t
+
+
+def render_paper_html(paper_dir):
+    """Render paper.md to standalone HTML.
+
+    Args:
+        paper_dir: Path to the paper project directory
+
+    Returns:
+        Path to the generated HTML file
+    """
+    paper_dir = Path(paper_dir)
+    paper_file = paper_dir / "paper.md"
+
+    if not paper_file.exists():
+        print(f"Error: {paper_file} not found")
+        sys.exit(1)
+
+    paper = paper_file.read_text(encoding="utf-8")
+
+    # Extract title from H1
+    title_match = re.search(r'^# (.+)$', paper, re.MULTILINE)
+    title = title_match.group(1) if title_match else "Paper"
+
+    body = paper
+
+    # Remove HTML comments
+    body = re.sub(r'<!--.*?-->', '', body, flags=re.DOTALL)
+
+    # Headers
+    body = re.sub(r'^### (.+)$', r'<h3>\1</h3>', body, flags=re.MULTILINE)
+    body = re.sub(r'^## (.+)$', r'<h2>\1</h2>', body, flags=re.MULTILINE)
+    body = re.sub(r'^# (.+)$', r'<h1>\1</h1>', body, flags=re.MULTILINE)
+
+    # Bold and italic
+    body = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', body)
+    body = re.sub(r'\*(.+?)\*', r'<em>\1</em>', body)
+
+    # Code blocks
+    body = re.sub(r'```(\w*)\n(.*?)```', r'<pre><code>\2</code></pre>',
+                  body, flags=re.DOTALL)
+
+    # Inline code
+    body = re.sub(r'`([^`]+)`', r'<code>\1</code>', body)
+
+    # Horizontal rules
+    body = re.sub(r'^---$', '<hr>', body, flags=re.MULTILINE)
+
+    # Tables
+    body = re.sub(r'(\|.+\|(?:\n\|.+\|)+)', convert_table, body)
+
+    # Lists (bullet)
+    body = re.sub(r'^- (.+)$', r'<li>\1</li>', body, flags=re.MULTILINE)
+
+    # Markdown images -> HTML figures
+    def _img_replace(m):
+        alt = m.group(1)
+        src = m.group(2)
+        return f'<div class="fig-container"><img src="{src}" alt="{alt}">' \
+               f'<p class="fig-caption">{alt}</p></div>'
+    body = re.sub(r'!\[([^\]]*)\]\(([^)]+)\)', _img_replace, body)
+
+    # Paragraphs (double newline)
+    body = re.sub(r'\n\n+', '\n</p>\n<p>\n', body)
+
+    # Build figures section from actual files
+    figures_html = build_figures_section(paper_dir)
+
+    # Insert figures before conclusions (if section exists)
+    conclusions_patterns = [
+        r'<h2>\d+\.\s*Conclusions?</h2>',
+        r'<h2>Conclusions?</h2>',
+    ]
+    inserted = False
+    for pattern in conclusions_patterns:
+        match = re.search(pattern, body)
+        if match:
+            body = body[:match.start()] + figures_html + '\n' + body[match.start():]
+            inserted = True
+            break
+    if not inserted and figures_html:
+        body += figures_html
+
+    html = get_html_header(title) + "<p>\n" + body + "\n</p>\n</body>\n</html>"
+
+    out_dir = paper_dir / "submission"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / "paper.html"
+    out.write_text(html, encoding="utf-8")
+
+    print(f"HTML rendered to {out}")
+    print(f"  Size: {len(html):,} bytes")
+    return out
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python render_html.py <paper_dir>")
+        print("Example: python render_html.py papers/tpflash_algorithms_2026")
+        sys.exit(1)
+
+    render_paper_html(sys.argv[1])

--- a/neqsim-paperlab/tools/revision_diff.py
+++ b/neqsim-paperlab/tools/revision_diff.py
@@ -1,0 +1,284 @@
+"""
+Revision Diff — Visual comparison between manuscript versions.
+
+Generates an HTML diff report showing additions, deletions, and changes
+between two versions of paper.md.
+
+Usage::
+
+    from tools.revision_diff import generate_diff
+
+    html_path = generate_diff("papers/my_paper/", revision=1)
+    # Opens: papers/my_paper/revision_1/diff_r0_r1.html
+"""
+
+import difflib
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+def _clean_for_diff(text):
+    """Normalize text for cleaner diffs (strip trailing spaces, normalize newlines)."""
+    lines = text.splitlines()
+    lines = [line.rstrip() for line in lines]
+    return lines
+
+
+def _section_summary(old_lines, new_lines):
+    """Produce a section-level change summary."""
+    old_sections = set()
+    new_sections = set()
+
+    for line in old_lines:
+        m = re.match(r'^(#{1,3})\s+(.+)$', line)
+        if m:
+            old_sections.add(m.group(2).strip())
+
+    for line in new_lines:
+        m = re.match(r'^(#{1,3})\s+(.+)$', line)
+        if m:
+            new_sections.add(m.group(2).strip())
+
+    added = new_sections - old_sections
+    removed = old_sections - new_sections
+    unchanged = old_sections & new_sections
+
+    return {
+        "added_sections": sorted(added),
+        "removed_sections": sorted(removed),
+        "unchanged_sections": sorted(unchanged),
+    }
+
+
+def _count_changes(diff_lines):
+    """Count additions, deletions, and context lines in a unified diff."""
+    additions = 0
+    deletions = 0
+    for line in diff_lines:
+        if line.startswith('+') and not line.startswith('+++'):
+            additions += 1
+        elif line.startswith('-') and not line.startswith('---'):
+            deletions += 1
+    return additions, deletions
+
+
+def generate_diff(paper_dir, revision=None, old_file=None, new_file=None):
+    """Generate an HTML diff between two manuscript versions.
+
+    Parameters
+    ----------
+    paper_dir : str or Path
+        Paper project directory.
+    revision : int, optional
+        Revision number. Compares revision_N/paper_rN-1_baseline.md with paper.md.
+    old_file : str or Path, optional
+        Explicit path to old version. Overrides revision auto-detection.
+    new_file : str or Path, optional
+        Explicit path to new version (default: paper.md).
+
+    Returns
+    -------
+    dict
+        Report with diff stats and path to generated HTML file.
+    """
+    paper_dir = Path(paper_dir)
+
+    # Determine files to compare
+    if old_file and new_file:
+        old_path = Path(old_file)
+        new_path = Path(new_file)
+    elif revision is not None:
+        rev_dir = paper_dir / f"revision_{revision}"
+        baseline_num = revision - 1
+        old_path = rev_dir / f"paper_r{baseline_num}_baseline.md"
+        new_path = paper_dir / "paper.md"
+        if not rev_dir.exists():
+            return {"error": f"Revision directory not found: {rev_dir}"}
+    else:
+        # Auto-detect latest revision
+        rev_dirs = sorted(paper_dir.glob("revision_*"))
+        if not rev_dirs:
+            return {"error": "No revision directories found. Run 'revise' first, "
+                           "or specify --old and --new explicitly."}
+        latest = rev_dirs[-1]
+        revision = int(latest.name.split("_")[1])
+        baseline_num = revision - 1
+        old_path = latest / f"paper_r{baseline_num}_baseline.md"
+        new_path = paper_dir / "paper.md"
+
+    # Validate files exist
+    if not old_path.exists():
+        return {"error": f"Old version not found: {old_path}"}
+    if not new_path.exists():
+        return {"error": f"New version not found: {new_path}"}
+
+    old_text = old_path.read_text(encoding="utf-8")
+    new_text = new_path.read_text(encoding="utf-8")
+    old_lines = _clean_for_diff(old_text)
+    new_lines = _clean_for_diff(new_text)
+
+    # Generate unified diff
+    diff = list(difflib.unified_diff(
+        old_lines, new_lines,
+        fromfile=old_path.name,
+        tofile=new_path.name,
+        lineterm="",
+    ))
+    additions, deletions = _count_changes(diff)
+
+    # Section-level summary
+    section_changes = _section_summary(old_lines, new_lines)
+
+    # Word count comparison
+    old_words = len(old_text.split())
+    new_words = len(new_text.split())
+
+    # Generate side-by-side HTML diff
+    html_diff = difflib.HtmlDiff(wrapcolumn=80)
+    html_table = html_diff.make_table(
+        old_lines, new_lines,
+        fromdesc=old_path.name,
+        todesc=new_path.name,
+        context=True,
+        numlines=3,
+    )
+
+    # Build full HTML page
+    html = _build_html_report(
+        old_path.name, new_path.name,
+        additions, deletions,
+        old_words, new_words,
+        section_changes,
+        html_table,
+    )
+
+    # Write output
+    if revision is not None:
+        out_dir = paper_dir / f"revision_{revision}"
+    else:
+        out_dir = paper_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / f"diff_{old_path.stem}_vs_{new_path.stem}.html"
+    out_file.write_text(html, encoding="utf-8")
+
+    return {
+        "old_file": str(old_path),
+        "new_file": str(new_path),
+        "additions": additions,
+        "deletions": deletions,
+        "old_words": old_words,
+        "new_words": new_words,
+        "word_delta": new_words - old_words,
+        "sections_added": section_changes["added_sections"],
+        "sections_removed": section_changes["removed_sections"],
+        "html_report": str(out_file),
+    }
+
+
+def _build_html_report(old_name, new_name, additions, deletions,
+                       old_words, new_words, section_changes, diff_table):
+    """Build a styled HTML diff report."""
+    delta = new_words - old_words
+    delta_str = f"+{delta}" if delta >= 0 else str(delta)
+
+    sections_html = ""
+    if section_changes["added_sections"]:
+        items = "".join(f"<li style='color:#2e7d32'>+ {s}</li>"
+                       for s in section_changes["added_sections"])
+        sections_html += f"<h3>Added Sections</h3><ul>{items}</ul>"
+    if section_changes["removed_sections"]:
+        items = "".join(f"<li style='color:#c62828'>- {s}</li>"
+                       for s in section_changes["removed_sections"])
+        sections_html += f"<h3>Removed Sections</h3><ul>{items}</ul>"
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Diff: {old_name} vs {new_name}</title>
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+         max-width: 1200px; margin: 20px auto; padding: 0 20px; color: #333; }}
+  h1 {{ color: #1565C0; font-size: 1.5em; }}
+  .stats {{ display: flex; gap: 20px; margin: 1em 0; flex-wrap: wrap; }}
+  .stat-box {{ background: #f5f5f5; padding: 12px 20px; border-radius: 8px;
+               border-left: 4px solid #1565C0; }}
+  .stat-box.add {{ border-left-color: #2e7d32; }}
+  .stat-box.del {{ border-left-color: #c62828; }}
+  .stat-box .label {{ font-size: 0.85em; color: #666; }}
+  .stat-box .value {{ font-size: 1.4em; font-weight: 600; }}
+  table.diff {{ font-family: 'Consolas', 'Monaco', monospace; font-size: 0.85em;
+                border-collapse: collapse; width: 100%; }}
+  table.diff td {{ padding: 2px 8px; vertical-align: top; white-space: pre-wrap;
+                   word-wrap: break-word; }}
+  table.diff .diff_header {{ background: #e0e0e0; font-weight: 600; }}
+  table.diff .diff_next {{ background: #E3F2FD; }}
+  table.diff .diff_add {{ background: #e8f5e9; }}
+  table.diff .diff_chg {{ background: #fff9c4; }}
+  table.diff .diff_sub {{ background: #ffebee; }}
+  .timestamp {{ color: #999; font-size: 0.85em; }}
+</style>
+</head>
+<body>
+<h1>Manuscript Diff Report</h1>
+<p class="timestamp">Generated: {datetime.now().strftime('%Y-%m-%d %H:%M')}</p>
+<p><strong>{old_name}</strong> → <strong>{new_name}</strong></p>
+
+<div class="stats">
+  <div class="stat-box add">
+    <div class="label">Lines Added</div>
+    <div class="value" style="color:#2e7d32">+{additions}</div>
+  </div>
+  <div class="stat-box del">
+    <div class="label">Lines Removed</div>
+    <div class="value" style="color:#c62828">-{deletions}</div>
+  </div>
+  <div class="stat-box">
+    <div class="label">Old Word Count</div>
+    <div class="value">{old_words:,}</div>
+  </div>
+  <div class="stat-box">
+    <div class="label">New Word Count</div>
+    <div class="value">{new_words:,} ({delta_str})</div>
+  </div>
+</div>
+
+{sections_html}
+
+<h2>Line-by-Line Diff</h2>
+{diff_table}
+
+</body>
+</html>"""
+
+
+def print_diff_summary(report):
+    """Print a quick diff summary to console."""
+    if "error" in report:
+        print(f"Error: {report['error']}")
+        return
+
+    print("=" * 60)
+    print("REVISION DIFF SUMMARY")
+    print("=" * 60)
+    print(f"  Old: {Path(report['old_file']).name}")
+    print(f"  New: {Path(report['new_file']).name}")
+    print(f"  Lines added:   +{report['additions']}")
+    print(f"  Lines removed: -{report['deletions']}")
+    delta = report['word_delta']
+    delta_str = f"+{delta}" if delta >= 0 else str(delta)
+    print(f"  Words: {report['old_words']:,} → {report['new_words']:,} ({delta_str})")
+
+    if report.get("sections_added"):
+        print(f"\n  New sections:")
+        for s in report["sections_added"]:
+            print(f"    + {s}")
+    if report.get("sections_removed"):
+        print(f"\n  Removed sections:")
+        for s in report["sections_removed"]:
+            print(f"    - {s}")
+
+    print(f"\n  HTML report: {report['html_report']}")
+    print()


### PR DESCRIPTION

**3 new tools** closing the gaps vs. state-of-art paper-writing tools:

| Tool | File | Closes gap vs. |
|------|------|---------------|
| **Prose quality analyzer** | tools/prose_quality.py | Writefull — readability (Flesch-Kincaid, Gunning fog), passive voice, hedging, wordy phrases, 4 sub-scores |
| **Citation discovery** | tools/citation_discovery.py | Elicit/Semantic Scholar — extracts search terms from plan.json + paper.md, queries S2 API, suggests highly-cited missing refs with copy-paste BibTeX |
| **Revision diff** | tools/revision_diff.py | latexdiff/Overleaf — generates color-coded HTML diff with line changes, section additions/removals, word count deltas |

**3 new CLI commands** wired into paperflow.py: `check-prose`, `suggest-refs`, `diff`

**16 new tests** added (45 total, all passing):
- `TestProseQuality` (6 tests) — scores, passive voice, long sentences, hedging, wordy phrases, missing file
- `TestCitationDiscovery` (3 tests) — search term extraction, existing ref filtering, empty project
- `TestRevisionDiff` (5 tests) — explicit files, section detection, HTML structure, auto-detect, missing revision
- `TestCheckProseCLI` + `TestDiffCLI` (2 tests) — CLI integration

Updated: requirements.txt, README.md, WALKTHROUGH.md (now 15 steps).
