### PR TITLE
perf: honor needRecalculation across runs in parallel execution paths

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -537,13 +537,15 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
   /** {@inheritDoc} */
   @Override
   public boolean needRecalculation() {
-    if (thermoSystem == null) {
+    if (thermoSystem == null || inStream == null || inStream.getThermoSystem() == null) {
       return true;
     }
     if (inStream.getThermoSystem().getTemperature() == thermoSystem.getTemperature()
         && inStream.getThermoSystem().getPressure() == thermoSystem.getPressure()
         && inStream.getThermoSystem().getFlowRate("kg/hr") == thermoSystem.getFlowRate("kg/hr")
-        && Math.abs(pressure - outStream.getPressure(pressureUnit)) < 1e-6) {
+        && Math.abs(pressure - outStream.getPressure(pressureUnit)) < 1e-6
+        && java.util.Arrays.equals(inStream.getThermoSystem().getMolarComposition(),
+            thermoSystem.getMolarComposition())) {
       return false;
     }
     return true;

--- a/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
@@ -114,6 +114,8 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface, Sta
   private double lastInStream2FlowRate = 0.0;
   /** Cached UA value for needRecalculation check. */
   private double lastUAvalue = 0.0;
+  /** Cached inlet stream 2 composition for needRecalculation check. */
+  private double[] lastInStream2Composition = null;
 
   // Dynamic simulation fields
   /** Metal wall mass in kg. */
@@ -475,6 +477,10 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface, Sta
     if (flow2 > 0 && Math.abs(flow2 - lastInStream2FlowRate) / flow2 > 1e-6) {
       return true;
     }
+    if (lastInStream2Composition == null || !java.util.Arrays
+        .equals(inStream[1].getThermoSystem().getMolarComposition(), lastInStream2Composition)) {
+      return true;
+    }
     return false;
   }
 
@@ -503,6 +509,13 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface, Sta
     lastOutPressure = pressureOut;
     lastOutTemperature = temperatureOut;
     lastPressureDrop = getPressureDrop();
+    // Composition tracking for both streams
+    if (inStream[0] != null && inStream[0].getThermoSystem() != null) {
+      lastComposition = inStream[0].getThermoSystem().getMolarComposition().clone();
+    }
+    if (inStream[1] != null && inStream[1].getThermoSystem() != null) {
+      lastInStream2Composition = inStream[1].getThermoSystem().getMolarComposition().clone();
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
@@ -79,6 +79,7 @@ public class Heater extends TwoPortEquipment implements HeaterInterface,
   protected double lastOutTemperature = 0.0;
   protected double lastDuty = 0.0;
   protected double lastPressureDrop = 0.0;
+  protected double[] lastComposition = null;
 
   protected transient HeatExchangerMechanicalDesign mechanicalDesign;
   HeatExchangerElectricalDesign electricalDesign;
@@ -316,15 +317,19 @@ public class Heater extends TwoPortEquipment implements HeaterInterface,
   /** {@inheritDoc} */
   @Override
   public boolean needRecalculation() {
-    if (inStream == null) {
+    if (inStream == null || inStream.getFluid() == null || lastComposition == null) {
       return true;
     }
-    if (inStream.getFluid().getTemperature() == lastTemperature
-        && inStream.getFluid().getPressure() == lastPressure
-        && Math.abs(inStream.getFluid().getFlowRate("kg/hr") - lastFlowRate)
-            / inStream.getFluid().getFlowRate("kg/hr") < 1e-6
-        && lastDuty == getDuty() && lastOutPressure == pressureOut
-        && lastOutTemperature == temperatureOut && getPressureDrop() == lastPressureDrop) {
+    SystemInterface inFluid = inStream.getFluid();
+    double inFlow = inFluid.getFlowRate("kg/hr");
+    if (inFlow <= 0.0 || lastFlowRate <= 0.0) {
+      return true;
+    }
+    if (inFluid.getTemperature() == lastTemperature && inFluid.getPressure() == lastPressure
+        && Math.abs(inFlow - lastFlowRate) / inFlow < 1e-6 && lastDuty == getDuty()
+        && lastOutPressure == pressureOut && lastOutTemperature == temperatureOut
+        && getPressureDrop() == lastPressureDrop
+        && java.util.Arrays.equals(inFluid.getMolarComposition(), lastComposition)) {
       return false;
     } else {
       return true;
@@ -347,6 +352,7 @@ public class Heater extends TwoPortEquipment implements HeaterInterface,
       lastOutPressure = pressureOut;
       lastOutTemperature = temperatureOut;
       lastPressureDrop = pressureDrop;
+      lastComposition = inStream.getFluid().getMolarComposition().clone();
       setCalculationIdentifier(id);
       return;
     }
@@ -398,6 +404,7 @@ public class Heater extends TwoPortEquipment implements HeaterInterface,
     lastOutPressure = pressureOut;
     lastOutTemperature = temperatureOut;
     lastPressureDrop = pressureDrop;
+    lastComposition = inStream.getFluid().getMolarComposition().clone();
     setCalculationIdentifier(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/splitter/Splitter.java
+++ b/src/main/java/neqsim/process/equipment/splitter/Splitter.java
@@ -261,11 +261,16 @@ public class Splitter extends ProcessEquipmentBaseClass
     if (inletStream.needRecalculation()) {
       return true;
     }
+    if (lastComposition == null || inletStream.getFluid().getFlowRate("kg/hr") <= 0.0
+        || lastFlowRate <= 0.0) {
+      return true;
+    }
     if (inletStream.getFluid().getTemperature() == lastTemperature
         && inletStream.getFluid().getPressure() == lastPressure
         && Math.abs(inletStream.getFluid().getFlowRate("kg/hr") - lastFlowRate)
             / inletStream.getFluid().getFlowRate("kg/hr") < 1e-6
-        && Arrays.equals(splitFactor, oldSplitFactor)) {
+        && Arrays.equals(splitFactor, oldSplitFactor)
+        && Arrays.equals(inletStream.getFluid().getMolarComposition(), lastComposition)) {
       return false;
     } else {
       return true;
@@ -313,7 +318,7 @@ public class Splitter extends ProcessEquipmentBaseClass
     lastFlowRate = inletStream.getFluid().getFlowRate("kg/hr");
     lastTemperature = inletStream.getFluid().getTemperature();
     lastPressure = inletStream.getFluid().getPressure();
-    lastComposition = inletStream.getFluid().getMolarComposition();
+    lastComposition = inletStream.getFluid().getMolarComposition().clone();
     oldSplitFactor = Arrays.copyOf(splitFactor, splitFactor.length);
 
     setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -328,10 +328,17 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
       }
       thermoSystem = stream.getFluid();
     }
-    if (getFluid().getTemperature() == lastTemperature && getFluid().getPressure() == lastPressure
-        && Math.abs(getFluid().getFlowRate("kg/hr") - lastFlowRate)
-            / getFluid().getFlowRate("kg/hr") < 1e-6
-        && Arrays.equals(getFluid().getMolarComposition(), lastComposition)) {
+    SystemInterface fluid = getFluid();
+    if (fluid == null || lastComposition == null) {
+      return true;
+    }
+    double flow = fluid.getFlowRate("kg/hr");
+    if (flow <= 0.0 || lastFlowRate <= 0.0) {
+      return true;
+    }
+    if (fluid.getTemperature() == lastTemperature && fluid.getPressure() == lastPressure
+        && Math.abs(flow - lastFlowRate) / flow < 1e-6
+        && Arrays.equals(fluid.getMolarComposition(), lastComposition)) {
       return false;
     } else {
       return true;

--- a/src/main/java/neqsim/process/equipment/util/StreamSaturatorUtil.java
+++ b/src/main/java/neqsim/process/equipment/util/StreamSaturatorUtil.java
@@ -28,6 +28,8 @@ public class StreamSaturatorUtil extends TwoPortEquipment {
   private double approachToSaturation = 1.0;
 
   protected double oldInletFlowRate = 0.0;
+  /** Cached inlet composition for needRecalculation check. */
+  protected double[] lastComposition = null;
 
   /**
    * Constructor for StreamSaturatorUtil with name only.
@@ -74,10 +76,15 @@ public class StreamSaturatorUtil extends TwoPortEquipment {
     if (outStream == null || inStream == null) {
       return true;
     }
+    if (lastComposition == null || inStream.getFlowRate("kg/hr") <= 0.0) {
+      return true;
+    }
     if (inStream.getTemperature() == outStream.getTemperature()
         && inStream.getPressure() == outStream.getPressure()
         && Math.abs(inStream.getFlowRate("kg/hr") - oldInletFlowRate)
-            / inStream.getFlowRate("kg/hr") < 1e-3) {
+            / inStream.getFlowRate("kg/hr") < 1e-3
+        && java.util.Arrays.equals(inStream.getThermoSystem().getMolarComposition(),
+            lastComposition)) {
       return false;
     } else {
       return true;
@@ -114,6 +121,7 @@ public class StreamSaturatorUtil extends TwoPortEquipment {
 
     outStream.setThermoSystem(thermoSystem);
     oldInletFlowRate = inStream.getFlowRate("kg/hr");
+    lastComposition = inStream.getThermoSystem().getMolarComposition().clone();
     setCalculationIdentifier(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -193,10 +193,14 @@ public class ThrottlingValve extends TwoPortEquipment
   /** {@inheritDoc} */
   @Override
   public boolean needRecalculation() {
-    if (getInletStream().getThermoSystem().getTemperature() == thermoSystem.getTemperature()
-        && getInletStream().getThermoSystem().getPressure() == thermoSystem.getPressure()
-        && getInletStream().getThermoSystem().getFlowRate("kg/hr") == thermoSystem
-            .getFlowRate("kg/hr")
+    if (thermoSystem == null || getInletStream() == null
+        || getInletStream().getThermoSystem() == null) {
+      return true;
+    }
+    SystemInterface inThermo = getInletStream().getThermoSystem();
+    if (inThermo.getTemperature() == thermoSystem.getTemperature()
+        && inThermo.getPressure() == thermoSystem.getPressure()
+        && inThermo.getFlowRate("kg/hr") == thermoSystem.getFlowRate("kg/hr")
         && getOutletPressure() == getOutletStream().getPressure()) {
       return false;
     } else {

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -86,8 +86,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * List of unit operations in the process system.
    */
   private List<ProcessEquipmentInterface> unitOperations = new ArrayList<>();
-  List<MeasurementDeviceInterface> measurementDevices =
-      new ArrayList<MeasurementDeviceInterface>(0);
+  List<MeasurementDeviceInterface> measurementDevices = new ArrayList<MeasurementDeviceInterface>(0);
   List<ControllerDeviceInterface> controllerDevices = new ArrayList<ControllerDeviceInterface>(0);
   private List<ProcessConnection> connections = new ArrayList<ProcessConnection>(0);
   private ProcessAlarmManager alarmManager = new ProcessAlarmManager();
@@ -128,7 +127,9 @@ public class ProcessSystem extends SimulationBaseClass {
   private double maxTimestep = 10.0;
   /** Relative tolerance for adaptive timestep error control. */
   private double adaptiveTimestepTolerance = 0.01;
-  /** Whether multi-threaded equipment execution is enabled for transient steps. */
+  /**
+   * Whether multi-threaded equipment execution is enabled for transient steps.
+   */
   private boolean parallelTransientEnabled = false;
   /** Thread pool size for parallel transient execution. */
   private int transientThreadPoolSize = Runtime.getRuntime().availableProcessors();
@@ -138,63 +139,86 @@ public class ProcessSystem extends SimulationBaseClass {
   private transient ProcessGraph cachedGraph = null;
   /** Flag indicating if the cached graph needs to be rebuilt. */
   private boolean graphDirty = true;
-  /** Cached parallel execution plan: grouped nodes per level for runParallel(). */
+  /**
+   * Cached parallel execution plan: grouped nodes per level for runParallel().
+   */
   private transient List<List<List<ProcessNode>>> cachedParallelPlan = null;
   /** Cached result of hasAdjusters() - null means not yet computed. */
   private transient Boolean cachedHasAdjusters = null;
   /** Cached result of hasRecycles() - null means not yet computed. */
   private transient Boolean cachedHasRecycles = null;
+  /** Cached result of hasCalculators() - null means not yet computed. */
+  private transient Boolean cachedHasCalculators = null;
+  /** Cached result of hasMultiInputEquipment() - null means not yet computed. */
+  private transient Boolean cachedHasMultiInput = null;
   /** Whether to use graph-based execution order instead of insertion order. */
   private boolean useGraphBasedExecution = false;
   /**
-   * Whether to use optimized execution (parallel/hybrid) by default when run() is called. When
-   * true, run() delegates to runOptimized() which automatically selects the best strategy. When
-   * false, run() uses sequential execution in insertion order (legacy behavior). Default is true
-   * for optimal performance - runOptimized() automatically falls back to sequential execution for
-   * processes with multi-input equipment (mixers, heat exchangers, etc.) to preserve correct mass
+   * Whether to use optimized execution (parallel/hybrid) by default when run() is
+   * called. When
+   * true, run() delegates to runOptimized() which automatically selects the best
+   * strategy. When
+   * false, run() uses sequential execution in insertion order (legacy behavior).
+   * Default is true
+   * for optimal performance - runOptimized() automatically falls back to
+   * sequential execution for
+   * processes with multi-input equipment (mixers, heat exchangers, etc.) to
+   * preserve correct mass
    * balance.
    */
   private boolean useOptimizedExecution = true;
 
   /**
-   * Transient listener for simulation progress callbacks. Used for real-time visualization in
-   * Jupyter notebooks and digital twin dashboards. Marked transient to avoid serialization issues.
+   * Transient listener for simulation progress callbacks. Used for real-time
+   * visualization in
+   * Jupyter notebooks and digital twin dashboards. Marked transient to avoid
+   * serialization issues.
    */
   private transient SimulationProgressListener progressListener = null;
 
   /**
-   * When true, lifecycle events are published to the ProcessEventBus singleton during simulation.
-   * Default is false for zero overhead when not needed. Enable via setPublishEvents(true).
+   * When true, lifecycle events are published to the ProcessEventBus singleton
+   * during simulation.
+   * Default is false for zero overhead when not needed. Enable via
+   * setPublishEvents(true).
    */
   private boolean publishEvents = false;
 
   /**
-   * When true, validateSetup() is auto-invoked on each equipment unit before the first iteration.
-   * Validation warnings are logged but do not abort execution. Enable via setAutoValidate(true).
+   * When true, validateSetup() is auto-invoked on each equipment unit before the
+   * first iteration.
+   * Validation warnings are logged but do not abort execution. Enable via
+   * setAutoValidate(true).
    */
   private boolean autoValidate = false;
 
   /**
-   * When true, per-unit execution timing is recorded during simulation. After run() completes, call
-   * {@link #getExecutionProfile()} to retrieve a map from equipment name to cumulative execution
+   * When true, per-unit execution timing is recorded during simulation. After
+   * run() completes, call
+   * {@link #getExecutionProfile()} to retrieve a map from equipment name to
+   * cumulative execution
    * time in milliseconds. Enable via {@link #setProfilingEnabled(boolean)}.
    */
   private transient boolean profilingEnabled = false;
 
   /**
-   * Stores cumulative execution time per equipment unit in nanoseconds. Keyed by equipment name.
+   * Stores cumulative execution time per equipment unit in nanoseconds. Keyed by
+   * equipment name.
    * Populated during simulation when {@link #profilingEnabled} is true.
    */
   private transient Map<String, long[]> executionTimingNanos = null;
 
   /**
-   * Stores the total elapsed wall-clock time of the last run() call in nanoseconds.
+   * Stores the total elapsed wall-clock time of the last run() call in
+   * nanoseconds.
    */
   private transient long lastRunElapsedNanos = 0;
 
   /**
-   * Interface for monitoring simulation progress during execution. Implementations receive
-   * callbacks after each unit operation completes, enabling real-time visualization, progress
+   * Interface for monitoring simulation progress during execution.
+   * Implementations receive
+   * callbacks after each unit operation completes, enabling real-time
+   * visualization, progress
    * tracking, and early termination detection.
    *
    * <p>
@@ -213,21 +237,24 @@ public class ProcessSystem extends SimulationBaseClass {
     /**
      * Called after each unit operation completes successfully.
      *
-     * @param unit the completed unit operation
-     * @param unitIndex zero-based index of current unit in execution order
-     * @param totalUnits total number of unit operations in the system
-     * @param iterationNumber current iteration number (for recycle loops, starts at 1)
+     * @param unit            the completed unit operation
+     * @param unitIndex       zero-based index of current unit in execution order
+     * @param totalUnits      total number of unit operations in the system
+     * @param iterationNumber current iteration number (for recycle loops, starts at
+     *                        1)
      */
     void onUnitComplete(ProcessEquipmentInterface unit, int unitIndex, int totalUnits,
         int iterationNumber);
 
     /**
-     * Called when an iteration of the process system completes. For systems with recycles, this is
+     * Called when an iteration of the process system completes. For systems with
+     * recycles, this is
      * called after each complete pass through all units.
      *
      * @param iterationNumber the iteration that just completed (starts at 1)
-     * @param converged true if all recycles have converged
-     * @param recycleError maximum relative error across all recycle streams (0.0 if no recycles)
+     * @param converged       true if all recycles have converged
+     * @param recycleError    maximum relative error across all recycle streams (0.0
+     *                        if no recycles)
      */
     default void onIterationComplete(int iterationNumber, boolean converged, double recycleError) {
       // Default implementation does nothing
@@ -236,7 +263,7 @@ public class ProcessSystem extends SimulationBaseClass {
     /**
      * Called if a unit operation encounters an error during execution.
      *
-     * @param unit the unit operation that failed
+     * @param unit      the unit operation that failed
      * @param exception the exception that was thrown
      * @return true to continue with next unit, false to abort simulation
      */
@@ -245,12 +272,13 @@ public class ProcessSystem extends SimulationBaseClass {
     }
 
     /**
-     * Called before each unit operation is executed. Useful for state inspection, cache warming, or
+     * Called before each unit operation is executed. Useful for state inspection,
+     * cache warming, or
      * injecting external data before a unit runs.
      *
-     * @param unit the unit about to be executed
-     * @param unitIndex zero-based index of the unit in execution order
-     * @param totalUnits total number of unit operations
+     * @param unit            the unit about to be executed
+     * @param unitIndex       zero-based index of the unit in execution order
+     * @param totalUnits      total number of unit operations
      * @param iterationNumber current iteration number (starts at 1)
      */
     default void onBeforeUnit(ProcessEquipmentInterface unit, int unitIndex, int totalUnits,
@@ -259,7 +287,8 @@ public class ProcessSystem extends SimulationBaseClass {
     }
 
     /**
-     * Called at the start of each iteration before any units are executed. Useful for resetting
+     * Called at the start of each iteration before any units are executed. Useful
+     * for resetting
      * state, applying external data, or logging iteration starts.
      *
      * @param iterationNumber the iteration about to start (starts at 1)
@@ -281,7 +310,7 @@ public class ProcessSystem extends SimulationBaseClass {
      * Called once when the simulation ends, after all iterations complete.
      *
      * @param totalIterations total number of iterations performed
-     * @param converged true if the simulation converged
+     * @param converged       true if the simulation converged
      */
     default void onSimulationComplete(int totalIterations, boolean converged) {
       // Default implementation does nothing
@@ -311,7 +340,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Add to end.
    * </p>
    *
-   * @param operation a {@link neqsim.process.equipment.ProcessEquipmentInterface} object
+   * @param operation a {@link neqsim.process.equipment.ProcessEquipmentInterface}
+   *                  object
    */
   public synchronized void add(ProcessEquipmentInterface operation) {
     // Add to end
@@ -323,8 +353,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * Add to specific position.
    * </p>
    *
-   * @param position 0-based position
-   * @param operation a {@link neqsim.process.equipment.ProcessEquipmentInterface} object
+   * @param position  0-based position
+   * @param operation a {@link neqsim.process.equipment.ProcessEquipmentInterface}
+   *                  object
    */
   public synchronized void add(int position, ProcessEquipmentInterface operation) {
     List<ProcessEquipmentInterface> units = this.getUnitOperations();
@@ -348,6 +379,8 @@ public class ProcessSystem extends SimulationBaseClass {
     cachedParallelPlan = null;
     cachedHasAdjusters = null;
     cachedHasRecycles = null;
+    cachedHasCalculators = null;
+    cachedHasMultiInput = null;
     if (operation instanceof ModuleInterface) {
       ((ModuleInterface) operation).initializeModule();
     }
@@ -358,8 +391,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * Add measurementdevice.
    * </p>
    *
-   * @param measurementDevice a {@link neqsim.process.measurementdevice.MeasurementDeviceInterface}
-   *        object
+   * @param measurementDevice a
+   *                          {@link neqsim.process.measurementdevice.MeasurementDeviceInterface}
+   *                          object
    */
   public synchronized void add(MeasurementDeviceInterface measurementDevice) {
     measurementDevices.add(measurementDevice);
@@ -367,18 +401,21 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Add a standalone controller device to the process system. Controllers added here participate in
+   * Add a standalone controller device to the process system. Controllers added
+   * here participate in
    * the explicit controller scan during {@code runTransient}.
    *
-   * @param controllerDevice a {@link neqsim.process.controllerdevice.ControllerDeviceInterface}
-   *        object
+   * @param controllerDevice a
+   *                         {@link neqsim.process.controllerdevice.ControllerDeviceInterface}
+   *                         object
    */
   public synchronized void add(ControllerDeviceInterface controllerDevice) {
     controllerDevices.add(controllerDevice);
   }
 
   /**
-   * Returns an unmodifiable list of all process elements — equipment, measurement devices, and
+   * Returns an unmodifiable list of all process elements — equipment, measurement
+   * devices, and
    * controllers — registered in this system.
    *
    * @return list of all {@link neqsim.process.ProcessElementInterface} objects
@@ -411,15 +448,17 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Declares an explicit connection between two equipment ports. This is a metadata record; it does
-   * not create or wire stream objects. Interchange formats like DEXPI and topology analyses can
+   * Declares an explicit connection between two equipment ports. This is a
+   * metadata record; it does
+   * not create or wire stream objects. Interchange formats like DEXPI and
+   * topology analyses can
    * query the connection list via {@link #getConnections()}.
    *
    * @param sourceEquipment name of upstream equipment
-   * @param sourcePort port name on source (e.g. "gasOut")
+   * @param sourcePort      port name on source (e.g. "gasOut")
    * @param targetEquipment name of downstream equipment
-   * @param targetPort port name on target (e.g. "inlet")
-   * @param type connection type
+   * @param targetPort      port name on target (e.g. "inlet")
+   * @param type            connection type
    */
   public void connect(String sourceEquipment, String sourcePort, String targetEquipment,
       String targetPort, ProcessConnection.ConnectionType type) {
@@ -428,7 +467,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Declares a material connection between two equipment ports with default port names.
+   * Declares a material connection between two equipment ports with default port
+   * names.
    *
    * @param sourceEquipment name of upstream equipment
    * @param targetEquipment name of downstream equipment
@@ -451,8 +491,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * Add multiple process equipment to end.
    * </p>
    *
-   * @param operations an array of {@link neqsim.process.equipment.ProcessEquipmentInterface}
-   *        objects
+   * @param operations an array of
+   *                   {@link neqsim.process.equipment.ProcessEquipmentInterface}
+   *                   objects
    */
   public void add(ProcessEquipmentInterface[] operations) {
     getUnitOperations().addAll(Arrays.asList(operations));
@@ -463,7 +504,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * Replace a unitoperation.
    * </p>
    *
-   * @param name Name of the object to replace
+   * @param name      Name of the object to replace
    * @param newObject the object to replace it with
    * @return a {@link java.lang.Boolean} object
    */
@@ -510,7 +551,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Looks up a process equipment unit by its IEC 81346 reference designation string (e.g.
+   * Looks up a process equipment unit by its IEC 81346 reference designation
+   * string (e.g.
    * {@code "=A1.B1"}, {@code "-B1"}).
    *
    * @param refDesignation the reference designation string to match
@@ -525,8 +567,7 @@ public class ProcessSystem extends SimulationBaseClass {
       if (unit instanceof ModuleInterface) {
         for (int j = 0; j < ((ModuleInterface) unit).getOperations().getUnitOperations()
             .size(); j++) {
-          ProcessEquipmentInterface inner =
-              ((ModuleInterface) unit).getOperations().getUnitOperations().get(j);
+          ProcessEquipmentInterface inner = ((ModuleInterface) unit).getOperations().getUnitOperations().get(j);
           if (refDesignation.equals(inner.getReferenceDesignationString())) {
             return inner;
           }
@@ -539,18 +580,20 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Generates IEC 81346 reference designations for all equipment in this process system. This is a
+   * Generates IEC 81346 reference designations for all equipment in this process
+   * system. This is a
    * convenience wrapper around
    * {@link neqsim.process.equipment.iec81346.ReferenceDesignationGenerator}.
    *
-   * @param functionPrefix the function-aspect prefix (e.g. "A1" for the first process area)
-   * @param locationPrefix the location-aspect prefix (e.g. "G1" for a specific platform)
+   * @param functionPrefix the function-aspect prefix (e.g. "A1" for the first
+   *                       process area)
+   * @param locationPrefix the location-aspect prefix (e.g. "G1" for a specific
+   *                       platform)
    * @return the generator instance (for further queries such as {@code toJson()})
    */
   public neqsim.process.equipment.iec81346.ReferenceDesignationGenerator generateReferenceDesignations(
       String functionPrefix, String locationPrefix) {
-    neqsim.process.equipment.iec81346.ReferenceDesignationGenerator gen =
-        new neqsim.process.equipment.iec81346.ReferenceDesignationGenerator();
+    neqsim.process.equipment.iec81346.ReferenceDesignationGenerator gen = new neqsim.process.equipment.iec81346.ReferenceDesignationGenerator();
     gen.setFunctionPrefix(functionPrefix);
     gen.setLocationPrefix(locationPrefix);
     gen.generate(this);
@@ -579,7 +622,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * </p>
    *
    * @param name Name of measurement device
-   * @return a {@link neqsim.process.measurementdevice.MeasurementDeviceInterface} object
+   * @return a {@link neqsim.process.measurementdevice.MeasurementDeviceInterface}
+   *         object
    */
   public MeasurementDeviceInterface getMeasurementDevice(String name) {
     for (int i = 0; i < measurementDevices.size(); i++) {
@@ -592,11 +636,13 @@ public class ProcessSystem extends SimulationBaseClass {
 
   /**
    * Look up a measurement device by its instrument tag. Tags are assigned via
-   * {@link MeasurementDeviceInterface#setTag(String)} and typically correspond to plant historian
+   * {@link MeasurementDeviceInterface#setTag(String)} and typically correspond to
+   * plant historian
    * signal identifiers (e.g. "PT-101", "TT-201").
    *
    * @param tag the instrument tag to search for
-   * @return the matching device, or {@code null} if no device carries the given tag
+   * @return the matching device, or {@code null} if no device carries the given
+   *         tag
    */
   public MeasurementDeviceInterface getMeasurementDeviceByTag(String tag) {
     for (int i = 0; i < measurementDevices.size(); i++) {
@@ -626,9 +672,12 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Sets field data values on measurement devices identified by their instrument tags. Devices with
-   * role {@link neqsim.process.measurementdevice.InstrumentTagRole#INPUT INPUT} will push the
-   * values into the model via {@link MeasurementDeviceInterface#applyFieldValue()}.
+   * Sets field data values on measurement devices identified by their instrument
+   * tags. Devices with
+   * role {@link neqsim.process.measurementdevice.InstrumentTagRole#INPUT INPUT}
+   * will push the
+   * values into the model via
+   * {@link MeasurementDeviceInterface#applyFieldValue()}.
    *
    * @param fieldData map of instrument tag to field value
    */
@@ -642,8 +691,10 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Applies field values from all {@link neqsim.process.measurementdevice.InstrumentTagRole#INPUT
-   * INPUT} instruments to their connected streams or equipment. Call this before running the
+   * Applies field values from all
+   * {@link neqsim.process.measurementdevice.InstrumentTagRole#INPUT
+   * INPUT} instruments to their connected streams or equipment. Call this before
+   * running the
    * process to push field boundary conditions into the model.
    */
   public void applyFieldInputs() {
@@ -658,7 +709,8 @@ public class ProcessSystem extends SimulationBaseClass {
 
   /**
    * Returns a map of instrument tag to deviation (model minus field) for all
-   * {@link neqsim.process.measurementdevice.InstrumentTagRole#BENCHMARK BENCHMARK} instruments that
+   * {@link neqsim.process.measurementdevice.InstrumentTagRole#BENCHMARK
+   * BENCHMARK} instruments that
    * have field data. Useful for model validation and parameter optimisation.
    *
    * @return map of tag to deviation value
@@ -705,8 +757,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * replaceObject.
    * </p>
    *
-   * @param unitName a {@link java.lang.String} object
-   * @param operation a {@link neqsim.process.equipment.ProcessEquipmentBaseClass} object
+   * @param unitName  a {@link java.lang.String} object
+   * @param operation a {@link neqsim.process.equipment.ProcessEquipmentBaseClass}
+   *                  object
    */
   public synchronized void replaceObject(String unitName, ProcessEquipmentBaseClass operation) {
     Objects.requireNonNull(unitName, "unitName");
@@ -770,8 +823,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * @return validation result with errors and warnings for all equipment
    */
   public neqsim.util.validation.ValidationResult validateSetup() {
-    neqsim.util.validation.ValidationResult result =
-        new neqsim.util.validation.ValidationResult(getName());
+    neqsim.util.validation.ValidationResult result = new neqsim.util.validation.ValidationResult(getName());
 
     // Check: Has unit operations
     if (unitOperations.isEmpty()) {
@@ -835,16 +887,17 @@ public class ProcessSystem extends SimulationBaseClass {
    * Validates all equipment in the process system and returns individual results.
    *
    * <p>
-   * Unlike {@link #validateSetup()} which returns a combined result, this method returns a map of
-   * equipment names to their individual validation results, making it easier to identify specific
+   * Unlike {@link #validateSetup()} which returns a combined result, this method
+   * returns a map of
+   * equipment names to their individual validation results, making it easier to
+   * identify specific
    * issues.
    * </p>
    *
    * @return map of equipment names to their validation results
    */
   public java.util.Map<String, neqsim.util.validation.ValidationResult> validateAll() {
-    java.util.Map<String, neqsim.util.validation.ValidationResult> results =
-        new java.util.LinkedHashMap<>();
+    java.util.Map<String, neqsim.util.validation.ValidationResult> results = new java.util.LinkedHashMap<>();
 
     for (int i = 0; i < unitOperations.size(); i++) {
       ProcessEquipmentInterface equipment = unitOperations.get(i);
@@ -864,7 +917,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Checks if the process system is ready to run.
    *
    * <p>
-   * Convenience method that returns true if validateSetup() finds no critical errors.
+   * Convenience method that returns true if validateSetup() finds no critical
+   * errors.
    * </p>
    *
    * @return true if process system passes validation, false otherwise
@@ -877,7 +931,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Validates the process setup and returns a structured SimulationResult.
    *
    * <p>
-   * Converts ValidationResult issues into SimulationResult.ErrorDetail objects for web API
+   * Converts ValidationResult issues into SimulationResult.ErrorDetail objects
+   * for web API
    * consumption. Returns a success result if no critical errors are found.
    * </p>
    *
@@ -909,8 +964,10 @@ public class ProcessSystem extends SimulationBaseClass {
    * Runs the process system and returns a structured SimulationResult.
    *
    * <p>
-   * Validates the setup first, then runs the simulation. Returns a structured result containing the
-   * full JSON report on success, or detailed errors on failure. Designed for web API integration.
+   * Validates the setup first, then runs the simulation. Returns a structured
+   * result containing the
+   * full JSON report on success, or detailed errors on failure. Designed for web
+   * API integration.
    * </p>
    *
    * @return a SimulationResult with the simulation report or errors
@@ -952,6 +1009,8 @@ public class ProcessSystem extends SimulationBaseClass {
         cachedParallelPlan = null;
         cachedHasAdjusters = null;
         cachedHasRecycles = null;
+        cachedHasCalculators = null;
+        cachedHasMultiInput = null;
       }
     }
   }
@@ -967,6 +1026,8 @@ public class ProcessSystem extends SimulationBaseClass {
     cachedParallelPlan = null;
     cachedHasAdjusters = null;
     cachedHasRecycles = null;
+    cachedHasCalculators = null;
+    cachedHasMultiInput = null;
   }
 
   /**
@@ -980,6 +1041,8 @@ public class ProcessSystem extends SimulationBaseClass {
     cachedParallelPlan = null;
     cachedHasAdjusters = null;
     cachedHasRecycles = null;
+    cachedHasCalculators = null;
+    cachedHasMultiInput = null;
   }
 
   /**
@@ -987,8 +1050,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * setFluid.
    * </p>
    *
-   * @param fluid1 a {@link neqsim.thermo.system.SystemInterface} object
-   * @param fluid2 a {@link neqsim.thermo.system.SystemInterface} object
+   * @param fluid1           a {@link neqsim.thermo.system.SystemInterface} object
+   * @param fluid2           a {@link neqsim.thermo.system.SystemInterface} object
    * @param addNewComponents a boolean
    */
   public void setFluid(SystemInterface fluid1, SystemInterface fluid2, boolean addNewComponents) {
@@ -1060,12 +1123,15 @@ public class ProcessSystem extends SimulationBaseClass {
    * Runs this process in a separate thread using the global NeqSim thread pool.
    *
    * <p>
-   * This method submits the process to the shared {@link neqsim.util.NeqSimThreadPool} and returns
-   * a {@link java.util.concurrent.Future} that can be used to monitor completion, cancel the task,
+   * This method submits the process to the shared
+   * {@link neqsim.util.NeqSimThreadPool} and returns
+   * a {@link java.util.concurrent.Future} that can be used to monitor completion,
+   * cancel the task,
    * or retrieve any exceptions that occurred.
    * </p>
    *
-   * @return a {@link java.util.concurrent.Future} representing the pending completion of the task
+   * @return a {@link java.util.concurrent.Future} representing the pending
+   *         completion of the task
    * @see neqsim.util.NeqSimThreadPool
    */
   public java.util.concurrent.Future<?> runAsTask() {
@@ -1073,18 +1139,22 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Runs the process system using the optimal execution strategy based on topology analysis.
+   * Runs the process system using the optimal execution strategy based on
+   * topology analysis.
    *
    * <p>
    * This method automatically selects the best execution mode:
    * </p>
    * <ul>
-   * <li>For processes WITHOUT recycles: uses parallel execution for maximum speed</li>
-   * <li>For processes WITH recycles: uses graph-based execution with optimized ordering</li>
+   * <li>For processes WITHOUT recycles: uses parallel execution for maximum
+   * speed</li>
+   * <li>For processes WITH recycles: uses graph-based execution with optimized
+   * ordering</li>
    * </ul>
    *
    * <p>
-   * This is the recommended method for most use cases as it provides the best performance without
+   * This is the recommended method for most use cases as it provides the best
+   * performance without
    * requiring manual configuration.
    * </p>
    */
@@ -1093,18 +1163,23 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Runs the process system using the optimal execution strategy based on topology analysis.
+   * Runs the process system using the optimal execution strategy based on
+   * topology analysis.
    *
    * <p>
    * This method automatically selects the best execution mode:
    * </p>
    * <ul>
-   * <li>For processes with adjusters: sequential execution (adjusters modify upstream variables and
+   * <li>For processes with adjusters: sequential execution (adjusters modify
+   * upstream variables and
    * read downstream targets, creating implicit feedback loops)</li>
-   * <li>For processes with recycles (no adjusters): sequential execution for full convergence</li>
-   * <li>For processes with multi-input equipment (Mixer, Manifold, HeatExchanger, etc.): sequential
+   * <li>For processes with recycles (no adjusters): sequential execution for full
+   * convergence</li>
+   * <li>For processes with multi-input equipment (Mixer, Manifold, HeatExchanger,
+   * etc.): sequential
    * execution to ensure correct mass balance</li>
-   * <li>For simple feed-forward processes: parallel execution for maximum speed</li>
+   * <li>For simple feed-forward processes: parallel execution for maximum
+   * speed</li>
    * </ul>
    *
    * @param id calculation identifier for tracking
@@ -1144,7 +1219,8 @@ public class ProcessSystem extends SimulationBaseClass {
         runSequential(id);
       }
     } else {
-      // Feed-forward process with single-input equipment only - use parallel execution.
+      // Feed-forward process with single-input equipment only - use parallel
+      // execution.
       // Units at the same level (no dependencies) run concurrently for maximum speed.
       try {
         runParallel(id);
@@ -1157,7 +1233,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Checks if the process contains any Adjuster units that require iterative convergence.
+   * Checks if the process contains any Adjuster units that require iterative
+   * convergence.
    *
    * @return true if there are Adjuster units in the process
    */
@@ -1179,19 +1256,27 @@ public class ProcessSystem extends SimulationBaseClass {
    * Checks if the process contains any Calculator units.
    *
    * <p>
-   * Calculator units read input streams and write to an output stream property using signal
-   * connections rather than physical stream connections. They create implicit feedback loops that
-   * the graph-based partitioner does not detect, so parallel execution cannot place them correctly.
+   * Calculator units read input streams and write to an output stream property
+   * using signal
+   * connections rather than physical stream connections. They create implicit
+   * feedback loops that
+   * the graph-based partitioner does not detect, so parallel execution cannot
+   * place them correctly.
    * </p>
    *
    * @return true if there are any Calculator units in the process
    */
   public boolean hasCalculators() {
+    if (cachedHasCalculators != null) {
+      return cachedHasCalculators;
+    }
     for (ProcessEquipmentInterface unit : unitOperations) {
       if (unit instanceof Calculator) {
+        cachedHasCalculators = true;
         return true;
       }
     }
+    cachedHasCalculators = false;
     return false;
   }
 
@@ -1199,7 +1284,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Checks if the process contains any Recycle units.
    *
    * <p>
-   * This method directly checks for Recycle units in the process, which is more reliable than
+   * This method directly checks for Recycle units in the process, which is more
+   * reliable than
    * graph-based cycle detection for determining if iterative execution is needed.
    * </p>
    *
@@ -1223,45 +1309,53 @@ public class ProcessSystem extends SimulationBaseClass {
    * Checks if the process contains any multi-input equipment.
    *
    * <p>
-   * Multi-input equipment (Mixer, Manifold, TurboExpanderCompressor, Ejector, HeatExchanger,
-   * MultiStreamHeatExchanger) require sequential execution to ensure correct mass balance. Parallel
-   * execution can change the order in which input streams are processed, leading to incorrect
+   * Multi-input equipment (Mixer, Manifold, TurboExpanderCompressor, Ejector,
+   * HeatExchanger,
+   * MultiStreamHeatExchanger) require sequential execution to ensure correct mass
+   * balance. Parallel
+   * execution can change the order in which input streams are processed, leading
+   * to incorrect
    * results.
    * </p>
    *
    * @return true if there are multi-input equipment units in the process
    */
   public boolean hasMultiInputEquipment() {
+    if (cachedHasMultiInput != null) {
+      return cachedHasMultiInput;
+    }
     for (ProcessEquipmentInterface unit : unitOperations) {
       if (unit instanceof MixerInterface || unit instanceof Manifold
           || unit instanceof TurboExpanderCompressor || unit instanceof Ejector
           || unit instanceof HeatExchanger || unit instanceof MultiStreamHeatExchangerInterface
           || unit instanceof FurnaceBurner || unit instanceof FlareStack) {
+        cachedHasMultiInput = true;
         return true;
       }
       // Check if Separator has multiple input streams (uses internal mixer)
       if (unit instanceof neqsim.process.equipment.separator.Separator) {
-        neqsim.process.equipment.separator.Separator sep =
-            (neqsim.process.equipment.separator.Separator) unit;
+        neqsim.process.equipment.separator.Separator sep = (neqsim.process.equipment.separator.Separator) unit;
         if (sep.numberOfInputStreams > 1) {
+          cachedHasMultiInput = true;
           return true;
         }
       }
-      // Check if Tank has multiple input streams (uses internal mixer like Separator)
+      // Check if Tank has multiple input streams (uses internal mixer like
+      // Separator).
+      // Use the generic inlet-streams API instead of reflection on a private field.
       if (unit instanceof neqsim.process.equipment.tank.Tank) {
         try {
-          java.lang.reflect.Field field =
-              neqsim.process.equipment.tank.Tank.class.getDeclaredField("numberOfInputStreams");
-          field.setAccessible(true);
-          int numInputs = field.getInt(unit);
-          if (numInputs > 1) {
+          java.util.List<neqsim.process.equipment.stream.StreamInterface> inlets = unit.getInletStreams();
+          if (inlets != null && inlets.size() > 1) {
+            cachedHasMultiInput = true;
             return true;
           }
         } catch (Exception e) {
-          // Ignore reflection errors
+          // Fall through - conservative default (no multi-input)
         }
       }
     }
+    cachedHasMultiInput = false;
     return false;
   }
 
@@ -1272,14 +1366,17 @@ public class ProcessSystem extends SimulationBaseClass {
    * This method partitions the process into:
    * </p>
    * <ul>
-   * <li>Feed-forward section: Units at the beginning with no recycle dependencies - run in
+   * <li>Feed-forward section: Units at the beginning with no recycle dependencies
+   * - run in
    * parallel</li>
-   * <li>Recycle section: Units that are part of or depend on recycle loops - run with graph-based
+   * <li>Recycle section: Units that are part of or depend on recycle loops - run
+   * with graph-based
    * iteration</li>
    * </ul>
    *
    * @param id calculation identifier for tracking
-   * @throws InterruptedException if thread is interrupted during parallel execution
+   * @throws InterruptedException if thread is interrupted during parallel
+   *                              execution
    */
   public synchronized void runHybrid(UUID id) throws InterruptedException {
     ProcessGraph graph = buildGraph();
@@ -1577,18 +1674,23 @@ public class ProcessSystem extends SimulationBaseClass {
    * Runs the process system using parallel execution for independent equipment.
    *
    * <p>
-   * This method uses the process graph to identify equipment that can run in parallel (i.e.,
-   * equipment with no dependencies between them). Equipment at the same "level" in the dependency
+   * This method uses the process graph to identify equipment that can run in
+   * parallel (i.e.,
+   * equipment with no dependencies between them). Equipment at the same "level"
+   * in the dependency
    * graph are executed concurrently using the NeqSim thread pool.
    * </p>
    *
    * <p>
-   * Note: This method does not handle recycles or adjusters - use regular {@link #run()} for
-   * processes with recycle loops. This is suitable for feed-forward processes where maximum
+   * Note: This method does not handle recycles or adjusters - use regular
+   * {@link #run()} for
+   * processes with recycle loops. This is suitable for feed-forward processes
+   * where maximum
    * parallelism is desired.
    * </p>
    *
-   * @throws InterruptedException if the thread is interrupted while waiting for tasks
+   * @throws InterruptedException if the thread is interrupted while waiting for
+   *                              tasks
    */
   public void runParallel() throws InterruptedException {
     runParallel(UUID.randomUUID());
@@ -1598,13 +1700,16 @@ public class ProcessSystem extends SimulationBaseClass {
    * Runs the process system using parallel execution for independent equipment.
    *
    * <p>
-   * This method uses the process graph to identify equipment that can run in parallel (i.e.,
-   * equipment with no dependencies between them). Equipment at the same "level" in the dependency
+   * This method uses the process graph to identify equipment that can run in
+   * parallel (i.e.,
+   * equipment with no dependencies between them). Equipment at the same "level"
+   * in the dependency
    * graph are executed concurrently using the NeqSim thread pool.
    * </p>
    *
    * @param id calculation identifier for tracking
-   * @throws InterruptedException if the thread is interrupted while waiting for tasks
+   * @throws InterruptedException if the thread is interrupted while waiting for
+   *                              tasks
    */
   public synchronized void runParallel(UUID id) throws InterruptedException {
     // Publish simulation start event
@@ -1727,14 +1832,18 @@ public class ProcessSystem extends SimulationBaseClass {
    * Groups nodes by shared input streams for parallel execution safety.
    *
    * <p>
-   * Units that share the same input stream cannot safely run in parallel because they would
-   * concurrently read from the same thermo system. This method uses Union-Find to group nodes that
-   * share any input stream, so they can be run sequentially within their group while different
+   * Units that share the same input stream cannot safely run in parallel because
+   * they would
+   * concurrently read from the same thermo system. This method uses Union-Find to
+   * group nodes that
+   * share any input stream, so they can be run sequentially within their group
+   * while different
    * groups run in parallel.
    * </p>
    *
    * @param nodes list of nodes at the same execution level
-   * @return list of groups, where each group contains nodes that share input streams
+   * @return list of groups, where each group contains nodes that share input
+   *         streams
    */
   private List<List<ProcessNode>> groupNodesBySharedInputStreams(List<ProcessNode> nodes) {
     // Use Union-Find to group nodes that share input streams
@@ -1745,16 +1854,15 @@ public class ProcessSystem extends SimulationBaseClass {
     }
 
     // Find with path compression
-    java.util.function.Function<ProcessNode, ProcessNode> find =
-        new java.util.function.Function<ProcessNode, ProcessNode>() {
-          @Override
-          public ProcessNode apply(ProcessNode node) {
-            if (parent.get(node) != node) {
-              parent.put(node, this.apply(parent.get(node)));
-            }
-            return parent.get(node);
-          }
-        };
+    java.util.function.Function<ProcessNode, ProcessNode> find = new java.util.function.Function<ProcessNode, ProcessNode>() {
+      @Override
+      public ProcessNode apply(ProcessNode node) {
+        if (parent.get(node) != node) {
+          parent.put(node, this.apply(parent.get(node)));
+        }
+        return parent.get(node);
+      }
+    };
 
     // Union operation
     java.util.function.BiConsumer<ProcessNode, ProcessNode> union = (a, b) -> {
@@ -1806,8 +1914,10 @@ public class ProcessSystem extends SimulationBaseClass {
    * Gets the parallel execution partition for this process.
    *
    * <p>
-   * This method returns information about how the process can be parallelized, including: - The
-   * number of parallel levels - Maximum parallelism (max units that can run concurrently) - Which
+   * This method returns information about how the process can be parallelized,
+   * including: - The
+   * number of parallel levels - Maximum parallelism (max units that can run
+   * concurrently) - Which
    * units are at each level
    * </p>
    *
@@ -1824,9 +1934,12 @@ public class ProcessSystem extends SimulationBaseClass {
    * <p>
    * Parallel execution is considered beneficial when:
    * <ul>
-   * <li>There are at least 2 units that can run in parallel (maxParallelism &gt;= 2)</li>
-   * <li>The process has no recycle loops (which require iterative sequential execution)</li>
-   * <li>There are enough units to justify thread overhead (typically &gt; 4 units)</li>
+   * <li>There are at least 2 units that can run in parallel (maxParallelism &gt;=
+   * 2)</li>
+   * <li>The process has no recycle loops (which require iterative sequential
+   * execution)</li>
+   * <li>There are enough units to justify thread overhead (typically &gt; 4
+   * units)</li>
    * </ul>
    *
    * @return true if parallel execution is recommended
@@ -1865,16 +1978,21 @@ public class ProcessSystem extends SimulationBaseClass {
    * Runs the process using the optimal execution strategy.
    *
    * <p>
-   * This method automatically determines whether to use parallel or sequential execution based on
+   * This method automatically determines whether to use parallel or sequential
+   * execution based on
    * the process structure. It will use parallel execution if:
    * <ul>
-   * <li>The process has independent branches that can benefit from parallelism</li>
-   * <li>There are no recycle loops or adjusters requiring iterative execution</li>
-   * <li>The process is large enough to justify the thread management overhead</li>
+   * <li>The process has independent branches that can benefit from
+   * parallelism</li>
+   * <li>There are no recycle loops or adjusters requiring iterative
+   * execution</li>
+   * <li>The process is large enough to justify the thread management
+   * overhead</li>
    * </ul>
    *
    * <p>
-   * For processes with recycles or adjusters, this method falls back to the standard sequential
+   * For processes with recycles or adjusters, this method falls back to the
+   * standard sequential
    * {@link #run()} method which properly handles convergence iterations.
    */
   public void runOptimal() {
@@ -1882,7 +2000,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Runs the process using the optimal execution strategy with calculation ID tracking.
+   * Runs the process using the optimal execution strategy with calculation ID
+   * tracking.
    *
    * @param id calculation identifier for tracking
    * @see #runOptimal()
@@ -1907,7 +2026,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * </p>
    *
    * @return a {@link java.lang.Thread} object
-   * @deprecated Use {@link #runAsTask()} instead for better resource management. This method
+   * @deprecated Use {@link #runAsTask()} instead for better resource management.
+   *             This method
    *             creates a new unmanaged thread directly.
    */
   @Deprecated
@@ -1939,8 +2059,10 @@ public class ProcessSystem extends SimulationBaseClass {
    * Runs the process system using sequential execution.
    *
    * <p>
-   * This method executes units in insertion order (or topological order if useGraphBasedExecution
-   * is enabled). It handles recycle loops by iterating until convergence. This is the legacy
+   * This method executes units in insertion order (or topological order if
+   * useGraphBasedExecution
+   * is enabled). It handles recycle loops by iterating until convergence. This is
+   * the legacy
    * execution mode preserved for backward compatibility.
    * </p>
    *
@@ -2084,7 +2206,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Set a listener to receive progress updates during simulation. Useful for real-time
+   * Set a listener to receive progress updates during simulation. Useful for
+   * real-time
    * visualization in Jupyter notebooks and digital twin dashboards.
    *
    * <p>
@@ -2115,8 +2238,10 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Enables or disables event publishing to the ProcessEventBus singleton. When enabled, lifecycle
-   * events (simulation start/complete, unit errors, threshold crossings) are published to the event
+   * Enables or disables event publishing to the ProcessEventBus singleton. When
+   * enabled, lifecycle
+   * events (simulation start/complete, unit errors, threshold crossings) are
+   * published to the event
    * bus during steady-state and transient execution.
    *
    * @param publish true to enable event publishing, false to disable (default)
@@ -2135,8 +2260,10 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Enables or disables automatic equipment validation before the first simulation iteration. When
-   * enabled, validateSetup() is called on each equipment unit before the first run. Validation
+   * Enables or disables automatic equipment validation before the first
+   * simulation iteration. When
+   * enabled, validateSetup() is called on each equipment unit before the first
+   * run. Validation
    * failures are logged as warnings but do not abort execution.
    *
    * @param validate true to enable auto-validation, false to disable (default)
@@ -2155,9 +2282,12 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Enables or disables per-unit execution timing profiling. When enabled, each call to an
-   * equipment unit's run() method is timed and accumulated. After simulation completes, use
-   * {@link #getExecutionProfile()} to retrieve timing data and {@link #printExecutionProfile()} to
+   * Enables or disables per-unit execution timing profiling. When enabled, each
+   * call to an
+   * equipment unit's run() method is timed and accumulated. After simulation
+   * completes, use
+   * {@link #getExecutionProfile()} to retrieve timing data and
+   * {@link #printExecutionProfile()} to
    * print it.
    *
    * @param enabled true to enable profiling, false to disable (default)
@@ -2165,7 +2295,7 @@ public class ProcessSystem extends SimulationBaseClass {
   public void setProfilingEnabled(boolean enabled) {
     this.profilingEnabled = enabled;
     if (enabled && executionTimingNanos == null) {
-      executionTimingNanos = new java.util.LinkedHashMap<>();
+      executionTimingNanos = new java.util.concurrent.ConcurrentHashMap<>();
     }
   }
 
@@ -2183,10 +2313,12 @@ public class ProcessSystem extends SimulationBaseClass {
    *
    * <p>
    * The returned map contains equipment names as keys and arrays of
-   * {@code [total_time_ms, call_count]} as values. Equipment is sorted by total time descending.
+   * {@code [total_time_ms, call_count]} as values. Equipment is sorted by total
+   * time descending.
    * </p>
    *
-   * @return map from equipment name to [total_time_ms, call_count], or empty map if profiling is
+   * @return map from equipment name to [total_time_ms, call_count], or empty map
+   *         if profiling is
    *         disabled
    */
   public Map<String, double[]> getExecutionProfile() {
@@ -2199,13 +2331,14 @@ public class ProcessSystem extends SimulationBaseClass {
     Collections.sort(entries, (a, b) -> Long.compare(b.getValue()[0], a.getValue()[0]));
     for (Map.Entry<String, long[]> entry : entries) {
       long[] nanos = entry.getValue();
-      result.put(entry.getKey(), new double[] {nanos[0] / 1e6, nanos[1]});
+      result.put(entry.getKey(), new double[] { nanos[0] / 1e6, nanos[1] });
     }
     return result;
   }
 
   /**
-   * Returns the total wall-clock elapsed time of the last run() call in milliseconds.
+   * Returns the total wall-clock elapsed time of the last run() call in
+   * milliseconds.
    *
    * @return elapsed time in milliseconds, or 0 if no run has been executed
    */
@@ -2217,7 +2350,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Prints the execution profile to System.out in a formatted table.
    *
    * <p>
-   * Shows each equipment unit's total execution time, percentage of total, and call count. Useful
+   * Shows each equipment unit's total execution time, percentage of total, and
+   * call count. Useful
    * for identifying bottleneck equipment in large process simulations.
    * </p>
    */
@@ -2247,19 +2381,34 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Records execution time for a unit operation when profiling is enabled.
    *
-   * @param unitName the name of the equipment unit
+   * <p>
+   * Uses a {@link java.util.concurrent.ConcurrentHashMap} and
+   * {@link java.util.concurrent.atomic.AtomicLong} fields on the per-unit timing
+   * record to avoid
+   * lock contention when multiple units run in parallel. Previously this method
+   * used a global
+   * {@code synchronized(map)} block which serialized all concurrent unit runs and
+   * hid real
+   * parallel speedup when profiling was enabled.
+   * </p>
+   *
+   * @param unitName     the name of the equipment unit
    * @param elapsedNanos the elapsed time in nanoseconds
    */
   private void recordUnitTiming(String unitName, long elapsedNanos) {
     if (!profilingEnabled || executionTimingNanos == null) {
       return;
     }
-    synchronized (executionTimingNanos) {
-      long[] timing = executionTimingNanos.get(unitName);
-      if (timing == null) {
-        timing = new long[] {0, 0};
-        executionTimingNanos.put(unitName, timing);
-      }
+    long[] timing = executionTimingNanos.get(unitName);
+    if (timing == null) {
+      long[] fresh = new long[] { 0L, 0L };
+      long[] existing = ((java.util.concurrent.ConcurrentHashMap<String, long[]>) executionTimingNanos)
+          .putIfAbsent(unitName, fresh);
+      timing = (existing != null) ? existing : fresh;
+    }
+    // Fine-grained synchronization only on the per-unit record (no cross-unit
+    // contention).
+    synchronized (timing) {
       timing[0] += elapsedNanos;
       timing[1]++;
     }
@@ -2271,7 +2420,7 @@ public class ProcessSystem extends SimulationBaseClass {
   private void resetExecutionProfile() {
     if (profilingEnabled) {
       if (executionTimingNanos == null) {
-        executionTimingNanos = new java.util.LinkedHashMap<>();
+        executionTimingNanos = new java.util.concurrent.ConcurrentHashMap<>();
       } else {
         executionTimingNanos.clear();
       }
@@ -2282,7 +2431,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * Runs a single equipment unit with optional profiling.
    *
    * @param unit the equipment unit to run
-   * @param id the calculation identifier
+   * @param id   the calculation identifier
    */
   private void runUnitProfiled(ProcessEquipmentInterface unit, UUID id) {
     if (profilingEnabled) {
@@ -2295,8 +2444,10 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Run simulation with a simple callback for each completed unit operation. This is a convenience
-   * method for Python/Jupyter integration where implementing the full SimulationProgressListener
+   * Run simulation with a simple callback for each completed unit operation. This
+   * is a convenience
+   * method for Python/Jupyter integration where implementing the full
+   * SimulationProgressListener
    * interface may be cumbersome.
    *
    * <p>
@@ -2311,8 +2462,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * process.runWithCallback(on_complete)
    * </pre>
    *
-   * @param callback Consumer function called with each completed unit operation. May be null for no
-   *        callbacks (equivalent to regular run()).
+   * @param callback Consumer function called with each completed unit operation.
+   *                 May be null for no
+   *                 callbacks (equivalent to regular run()).
    */
   public void runWithCallback(java.util.function.Consumer<ProcessEquipmentInterface> callback) {
     runWithCallback(callback, UUID.randomUUID());
@@ -2322,7 +2474,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * Run simulation with a simple callback for each completed unit operation.
    *
    * @param callback Consumer function called with each completed unit operation
-   * @param id calculation identifier for tracking
+   * @param id       calculation identifier for tracking
    */
   public void runWithCallback(java.util.function.Consumer<ProcessEquipmentInterface> callback,
       UUID id) {
@@ -2347,12 +2499,15 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Run simulation with full progress monitoring. This method executes the process system and
-   * invokes the registered SimulationProgressListener after each unit operation and iteration
+   * Run simulation with full progress monitoring. This method executes the
+   * process system and
+   * invokes the registered SimulationProgressListener after each unit operation
+   * and iteration
    * completes.
    *
    * <p>
-   * This is the primary method for digital twin applications requiring real-time feedback. It
+   * This is the primary method for digital twin applications requiring real-time
+   * feedback. It
    * supports:
    * <ul>
    * <li>Progress callbacks after each unit operation</li>
@@ -2510,9 +2665,9 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Notify the progress listener that a unit operation has completed.
    *
-   * @param unit the completed unit
-   * @param unitIndex index of the unit
-   * @param totalUnits total number of units
+   * @param unit            the completed unit
+   * @param unitIndex       index of the unit
+   * @param totalUnits      total number of units
    * @param iterationNumber current iteration
    */
   private void notifyUnitComplete(ProcessEquipmentInterface unit, int unitIndex, int totalUnits,
@@ -2530,8 +2685,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Notify the progress listener that an iteration has completed.
    *
    * @param iterationNumber the completed iteration
-   * @param converged whether the system has converged
-   * @param recycleError maximum recycle error
+   * @param converged       whether the system has converged
+   * @param recycleError    maximum recycle error
    */
   private void notifyIterationComplete(int iterationNumber, boolean converged,
       double recycleError) {
@@ -2547,7 +2702,7 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Notify the progress listener that a unit operation encountered an error.
    *
-   * @param unit the unit that failed
+   * @param unit      the unit that failed
    * @param exception the exception
    * @return true to continue, false to abort
    */
@@ -2565,9 +2720,9 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Notify the progress listener that a unit operation is about to start.
    *
-   * @param unit the unit about to run
-   * @param unitIndex index of the unit
-   * @param totalUnits total number of units
+   * @param unit            the unit about to run
+   * @param unitIndex       index of the unit
+   * @param totalUnits      total number of units
    * @param iterationNumber current iteration
    */
   private void notifyBeforeUnit(ProcessEquipmentInterface unit, int unitIndex, int totalUnits,
@@ -2615,7 +2770,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * Notify the progress listener that the simulation has completed.
    *
    * @param totalIterations total number of iterations executed
-   * @param converged whether the simulation converged
+   * @param converged       whether the simulation converged
    */
   private void notifySimulationComplete(int totalIterations, boolean converged) {
     if (progressListener != null) {
@@ -2644,7 +2799,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Run auto-validation on all equipment units. Called once before the first iteration when
+   * Run auto-validation on all equipment units. Called once before the first
+   * iteration when
    * autoValidate is enabled.
    *
    * @param executionOrder the list of units to validate
@@ -2670,12 +2826,17 @@ public class ProcessSystem extends SimulationBaseClass {
   /*
    * signalDB = new String[1000][1 + 3 * measurementDevices.size()];
    *
-   * signalDB[timeStepNumber] = new String[1 + 3 * measurementDevices.size()]; for (int i = 0; i <
-   * measurementDevices.size(); i++) { signalDB[timeStepNumber][0] = Double.toString(time);
-   * signalDB[timeStepNumber][3 * i + 1] = ((MeasurementDeviceInterface) measurementDevices.get(i))
+   * signalDB[timeStepNumber] = new String[1 + 3 * measurementDevices.size()]; for
+   * (int i = 0; i <
+   * measurementDevices.size(); i++) { signalDB[timeStepNumber][0] =
+   * Double.toString(time);
+   * signalDB[timeStepNumber][3 * i + 1] = ((MeasurementDeviceInterface)
+   * measurementDevices.get(i))
    * .getName(); signalDB[timeStepNumber][3 * i + 2] = Double
-   * .toString(((MeasurementDeviceInterface) measurementDevices.get(i)).getMeasuredValue());
-   * signalDB[timeStepNumber][3 * i + 3] = ((MeasurementDeviceInterface) measurementDevices.get(i))
+   * .toString(((MeasurementDeviceInterface)
+   * measurementDevices.get(i)).getMeasuredValue());
+   * signalDB[timeStepNumber][3 * i + 3] = ((MeasurementDeviceInterface)
+   * measurementDevices.get(i))
    * .getUnit(); }
    */
 
@@ -2749,7 +2910,8 @@ public class ProcessSystem extends SimulationBaseClass {
     }
 
     // Explicit controller scan phase: run standalone controllers registered via
-    // add(ControllerDeviceInterface). Equipment-embedded controllers already ran above
+    // add(ControllerDeviceInterface). Equipment-embedded controllers already ran
+    // above
     // inside each equipment's runTransient() for backward compatibility.
     for (int i = 0; i < controllerDevices.size(); i++) {
       ControllerDeviceInterface ctrl = controllerDevices.get(i);
@@ -2784,18 +2946,19 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Runs all equipment transient calculations in parallel using an ExecutorService. Each equipment
-   * unit is submitted as an independent task. This is suitable when equipment units are loosely
+   * Runs all equipment transient calculations in parallel using an
+   * ExecutorService. Each equipment
+   * unit is submitted as an independent task. This is suitable when equipment
+   * units are loosely
    * coupled (no data dependencies within a single timestep).
    *
    * @param dt time step in seconds
    * @param id calculation identifier
    */
   private void runEquipmentTransientParallel(double dt, UUID id) {
-    java.util.concurrent.ExecutorService executor =
-        java.util.concurrent.Executors.newFixedThreadPool(transientThreadPoolSize);
-    List<java.util.concurrent.Future<?>> futures =
-        new ArrayList<java.util.concurrent.Future<?>>(unitOperations.size());
+    java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors
+        .newFixedThreadPool(transientThreadPoolSize);
+    List<java.util.concurrent.Future<?>> futures = new ArrayList<java.util.concurrent.Future<?>>(unitOperations.size());
     for (int i = 0; i < unitOperations.size(); i++) {
       final ProcessEquipmentInterface unit = unitOperations.get(i);
       final double stepSize = dt;
@@ -2818,12 +2981,15 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Runs a single transient step with adaptive timestep control. This method compares a full-step
-   * result with two half-step results to estimate the local truncation error and adjusts dt
+   * Runs a single transient step with adaptive timestep control. This method
+   * compares a full-step
+   * result with two half-step results to estimate the local truncation error and
+   * adjusts dt
    * accordingly.
    *
    * <p>
-   * Usage: call this instead of runTransient(dt, id) when adaptive control is desired.
+   * Usage: call this instead of runTransient(dt, id) when adaptive control is
+   * desired.
    * </p>
    *
    * @param dt the requested timestep in seconds
@@ -2838,7 +3004,8 @@ public class ProcessSystem extends SimulationBaseClass {
 
     double currentDt = Math.min(Math.max(dt, minTimestep), maxTimestep);
 
-    // Save state for error estimation: use temperature of first equipment's outlet as reference
+    // Save state for error estimation: use temperature of first equipment's outlet
+    // as reference
     double refTempBefore = 0.0;
     if (!unitOperations.isEmpty()) {
       ProcessEquipmentInterface firstUnit = unitOperations.get(0);
@@ -2862,12 +3029,15 @@ public class ProcessSystem extends SimulationBaseClass {
       }
     }
 
-    // Estimate error from the step (Richardson extrapolation would require two half steps,
-    // but that doubles computation. Use a simplified check based on temperature change rate.)
+    // Estimate error from the step (Richardson extrapolation would require two half
+    // steps,
+    // but that doubles computation. Use a simplified check based on temperature
+    // change rate.)
     double tempChange = Math.abs(refTempFullStep - refTempBefore);
     double relError = refTempBefore > 0 ? tempChange / Math.abs(refTempBefore) : tempChange;
 
-    // Adjust timestep using standard adaptive formula: dt_new = dt * (tol / err)^0.5
+    // Adjust timestep using standard adaptive formula: dt_new = dt * (tol /
+    // err)^0.5
     if (relError > 0 && relError > adaptiveTimestepTolerance) {
       double factor = Math.sqrt(adaptiveTimestepTolerance / relError);
       currentDt = Math.max(minTimestep, currentDt * Math.max(0.2, factor));
@@ -2969,7 +3139,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Set the maximum number of iterations within each transient time step.
    *
    * <p>
-   * Multiple iterations help converge circular dependencies between equipment. Default is 3. Set to
+   * Multiple iterations help converge circular dependencies between equipment.
+   * Default is 3. Set to
    * 1 to disable iterative convergence.
    * </p>
    *
@@ -3012,7 +3183,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Enables or disables adaptive timestep control. When enabled, the timestep is adjusted based on
+   * Enables or disables adaptive timestep control. When enabled, the timestep is
+   * adjusted based on
    * local error estimates by comparing a full step with two half-steps.
    *
    * @param enabled true to enable adaptive timestep
@@ -3085,7 +3257,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Enables or disables multi-threaded equipment execution during transient steps.
+   * Enables or disables multi-threaded equipment execution during transient
+   * steps.
    *
    * @param enabled true to enable parallel execution
    */
@@ -3157,9 +3330,12 @@ public class ProcessSystem extends SimulationBaseClass {
     }
 
     /*
-     * JFrame frame = new JFrame(); frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-     * frame.setLayout(new GridLayout(1, 0, 5, 5)); JTextArea area1 = new JTextArea(10, 10); JTable
-     * Jtab = new JTable(reportResults(), reportResults()[0]); frame.add(area1); frame.pack();
+     * JFrame frame = new JFrame();
+     * frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+     * frame.setLayout(new GridLayout(1, 0, 5, 5)); JTextArea area1 = new
+     * JTextArea(10, 10); JTable
+     * Jtab = new JTable(reportResults(), reportResults()[0]); frame.add(area1);
+     * frame.pack();
      * frame.setLocationRelativeTo(null); frame.setVisible(true);
      */
   }
@@ -3211,8 +3387,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * @return a {@link neqsim.process.processmodel.ProcessSystem} object
    */
   public static ProcessSystem open(String filePath) {
-    try (ObjectInputStream objectinputstream =
-        new ObjectInputStream(new FileInputStream(filePath))) {
+    try (ObjectInputStream objectinputstream = new ObjectInputStream(new FileInputStream(filePath))) {
       return (ProcessSystem) objectinputstream.readObject();
       // logger.info("process file open ok: " + filePath);
     } catch (Exception ex) {
@@ -3241,12 +3416,16 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Returns a consolidated formatted stream summary table showing key properties for all streams in
-   * this process system. Similar to the Workbook/Stream Summary in commercial process simulators.
+   * Returns a consolidated formatted stream summary table showing key properties
+   * for all streams in
+   * this process system. Similar to the Workbook/Stream Summary in commercial
+   * process simulators.
    *
    * <p>
-   * The table includes: stream name, temperature (C), pressure (bara), total molar flow (kmole/hr),
-   * mass flow (kg/hr), vapor fraction, molar mass (kg/kmol), and mole fraction of each component.
+   * The table includes: stream name, temperature (C), pressure (bara), total
+   * molar flow (kmole/hr),
+   * mass flow (kg/hr), vapor fraction, molar mass (kg/kmol), and mole fraction of
+   * each component.
    * </p>
    *
    * @return formatted string table of all stream properties
@@ -3366,8 +3545,10 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Returns a consolidated stream summary as a JSON string. Each stream is a key in the JSON object
-   * containing temperature, pressure, flow rates, vapor fraction, molar mass, and composition.
+   * Returns a consolidated stream summary as a JSON string. Each stream is a key
+   * in the JSON object
+   * containing temperature, pressure, flow rates, vapor fraction, molar mass, and
+   * composition.
    *
    * @return JSON string with stream summary data
    */
@@ -3412,7 +3593,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Returns a list of all streams in this process system. Collects all inlet and outlet streams
+   * Returns a list of all streams in this process system. Collects all inlet and
+   * outlet streams
    * from all equipment, removing duplicates.
    *
    * @return list of unique streams in the process
@@ -3435,15 +3617,15 @@ public class ProcessSystem extends SimulationBaseClass {
    * @param filename a {@link java.lang.String} object
    */
   public void printLogFile(String filename) {
-    neqsim.datapresentation.filehandling.TextFile tempFile =
-        new neqsim.datapresentation.filehandling.TextFile();
+    neqsim.datapresentation.filehandling.TextFile tempFile = new neqsim.datapresentation.filehandling.TextFile();
     tempFile.setOutputFileName(filename);
     tempFile.setValues(measurementHistory.toArray());
     tempFile.createFile();
   }
 
   /**
-   * Clears all stored transient measurement history entries and resets the time step counter.
+   * Clears all stored transient measurement history entries and resets the time
+   * step counter.
    */
   public void clearHistory() {
     measurementHistory.clear();
@@ -3479,27 +3661,32 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Sets the maximum number of entries retained in the measurement history. A value less than or
+   * Sets the maximum number of entries retained in the measurement history. A
+   * value less than or
    * equal to zero disables truncation (unbounded history).
    *
-   * @param maxEntries maximum number of entries to keep, or non-positive for unlimited
+   * @param maxEntries maximum number of entries to keep, or non-positive for
+   *                   unlimited
    */
   public void setHistoryCapacity(int maxEntries) {
     measurementHistory.setMaxSize(maxEntries);
   }
 
   /**
-   * Returns the configured history capacity. A value less than or equal to zero means the history
+   * Returns the configured history capacity. A value less than or equal to zero
+   * means the history
    * grows without bounds.
    *
-   * @return configured maximum number of history entries or non-positive for unlimited
+   * @return configured maximum number of history entries or non-positive for
+   *         unlimited
    */
   public int getHistoryCapacity() {
     return measurementHistory.getMaxSize();
   }
 
   /**
-   * Stores a snapshot of the current process system state that can later be restored with
+   * Stores a snapshot of the current process system state that can later be
+   * restored with
    * {@link #reset()}.
    */
   public void storeInitialState() {
@@ -3507,7 +3694,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Restores the process system to the stored initial state. The initial state is captured
+   * Restores the process system to the stored initial state. The initial state is
+   * captured
    * automatically the first time a transient run is executed, or manually via
    * {@link #storeInitialState()}.
    */
@@ -3804,7 +3992,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Check mass balance of all unit operations in the process system.
    *
    * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
-   * @return a map with unit operation name as key and mass balance result as value
+   * @return a map with unit operation name as key and mass balance result as
+   *         value
    */
   public Map<String, MassBalanceResult> checkMassBalance(String unit) {
     Map<String, MassBalanceResult> massBalanceResults = new HashMap<>();
@@ -3827,16 +4016,19 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Check mass balance of all unit operations in the process system using kg/sec.
    *
-   * @return a map with unit operation name as key and mass balance result as value in kg/sec
+   * @return a map with unit operation name as key and mass balance result as
+   *         value in kg/sec
    */
   public Map<String, MassBalanceResult> checkMassBalance() {
     return checkMassBalance("kg/sec");
   }
 
   /**
-   * Get unit operations that failed mass balance check based on percentage error threshold.
+   * Get unit operations that failed mass balance check based on percentage error
+   * threshold.
    *
-   * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
+   * @param unit             unit for mass flow rate (e.g., "kg/sec", "kg/hr",
+   *                         "mole/sec")
    * @param percentThreshold percentage error threshold (default: 0.1%)
    * @return a map with failed unit operation names and their mass balance results
    */
@@ -3873,7 +4065,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Get unit operations that failed mass balance check using kg/sec and default threshold.
+   * Get unit operations that failed mass balance check using kg/sec and default
+   * threshold.
    *
    * @return a map with failed unit operation names and their mass balance results
    */
@@ -3885,7 +4078,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Get unit operations that failed mass balance check using specified threshold.
    *
    * @param percentThreshold percentage error threshold
-   * @return a map with failed unit operation names and their mass balance results in kg/sec
+   * @return a map with failed unit operation names and their mass balance results
+   *         in kg/sec
    */
   public Map<String, MassBalanceResult> getFailedMassBalance(double percentThreshold) {
     return getFailedMassBalance("kg/sec", percentThreshold);
@@ -3925,7 +4119,8 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Get a formatted report of failed mass balance checks for this process system.
    *
-   * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
+   * @param unit             unit for mass flow rate (e.g., "kg/sec", "kg/hr",
+   *                         "mole/sec")
    * @param percentThreshold percentage error threshold
    * @return a formatted string report with failed unit operations
    */
@@ -3946,7 +4141,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Get a formatted report of failed mass balance checks for this process system using kg/sec and
+   * Get a formatted report of failed mass balance checks for this process system
+   * using kg/sec and
    * default threshold.
    *
    * @return a formatted string report with failed unit operations
@@ -3956,7 +4152,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Get a formatted report of failed mass balance checks for this process system using specified
+   * Get a formatted report of failed mass balance checks for this process system
+   * using specified
    * threshold.
    *
    * @param percentThreshold percentage error threshold
@@ -3985,7 +4182,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Set the minimum flow threshold for mass balance error checking. Units with inlet flow below
+   * Set the minimum flow threshold for mass balance error checking. Units with
+   * inlet flow below
    * this threshold are not considered errors.
    *
    * @param minimumFlow minimum flow in kg/sec (e.g., 1e-6)
@@ -4034,8 +4232,8 @@ public class ProcessSystem extends SimulationBaseClass {
      * Constructor for MassBalanceResult.
      *
      * @param absoluteError absolute mass balance error (outlet - inlet)
-     * @param percentError percentage error
-     * @param unit unit of measurement
+     * @param percentError  percentage error
+     * @param unit          unit of measurement
      */
     public MassBalanceResult(double absoluteError, double percentError, String unit) {
       this.absoluteError = absoluteError;
@@ -4124,9 +4322,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * addUnit.
    * </p>
    *
-   * @param name a {@link java.lang.String} object
+   * @param name          a {@link java.lang.String} object
    * @param equipmentType a {@link java.lang.String} object
-   * @param <T> a T class
+   * @param <T>           a T class
    * @return a T object
    */
   @SuppressWarnings("unchecked")
@@ -4154,9 +4352,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * addUnit.
    * </p>
    *
-   * @param name a {@link java.lang.String} object
+   * @param name          a {@link java.lang.String} object
    * @param equipmentEnum a {@link neqsim.process.equipment.EquipmentEnum} object
-   * @param <T> a T class
+   * @param <T>           a T class
    * @return a T object
    */
   @SuppressWarnings("unchecked")
@@ -4171,7 +4369,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * </p>
    *
    * @param equipmentType a {@link java.lang.String} object
-   * @param <T> a T class
+   * @param <T>           a T class
    * @return a T object
    */
   @SuppressWarnings("unchecked")
@@ -4186,7 +4384,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * </p>
    *
    * @param equipmentEnum a {@link neqsim.process.equipment.EquipmentEnum} object
-   * @param <T> a T class
+   * @param <T>           a T class
    * @return a T object
    */
   @SuppressWarnings("unchecked")
@@ -4195,12 +4393,14 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Adds a new process equipment unit of the specified type and name, and sets its inlet stream.
+   * Adds a new process equipment unit of the specified type and name, and sets
+   * its inlet stream.
    *
-   * @param <T> the type of process equipment
-   * @param name the name of the equipment (if null or empty, a unique name is generated)
+   * @param <T>           the type of process equipment
+   * @param name          the name of the equipment (if null or empty, a unique
+   *                      name is generated)
    * @param equipmentType the type of equipment to create (as a String)
-   * @param stream the inlet stream to set for the new equipment
+   * @param stream        the inlet stream to set for the new equipment
    * @return the created and added process equipment unit
    */
   public <T extends ProcessEquipmentInterface> T addUnit(String name, String equipmentType,
@@ -4233,8 +4433,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * addUnit.
    * </p>
    *
-   * @param name a {@link java.lang.String} object
-   * @param equipment a {@link neqsim.process.equipment.ProcessEquipmentInterface} object
+   * @param name      a {@link java.lang.String} object
+   * @param equipment a {@link neqsim.process.equipment.ProcessEquipmentInterface}
+   *                  object
    * @return a {@link neqsim.process.equipment.ProcessEquipmentInterface} object
    */
   public ProcessEquipmentInterface addUnit(String name, ProcessEquipmentInterface equipment) {
@@ -4250,7 +4451,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * addUnit.
    * </p>
    *
-   * @param equipment a {@link neqsim.process.equipment.ProcessEquipmentInterface} object
+   * @param equipment a {@link neqsim.process.equipment.ProcessEquipmentInterface}
+   *                  object
    * @return a {@link neqsim.process.equipment.ProcessEquipmentInterface} object
    */
   public ProcessEquipmentInterface addUnit(ProcessEquipmentInterface equipment) {
@@ -4378,7 +4580,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Export the process to Graphviz with configurable stream annotations.
    *
    * @param filename the Graphviz output file
-   * @param options export options controlling stream annotations and table output
+   * @param options  export options controlling stream annotations and table
+   *                 output
    */
   public void exportToGraphviz(String filename,
       ProcessSystemGraphvizExporter.GraphvizExportOptions options) {
@@ -4402,8 +4605,10 @@ public class ProcessSystem extends SimulationBaseClass {
    * Builds a ProcessSystem from a JSON process definition string.
    *
    * <p>
-   * This is the primary entry point for web API and Python integration. Accepts a declarative JSON
-   * definition of fluids, equipment, and stream connections and returns a structured result with
+   * This is the primary entry point for web API and Python integration. Accepts a
+   * declarative JSON
+   * definition of fluids, equipment, and stream connections and returns a
+   * structured result with
    * the built ProcessSystem or detailed error information.
    * </p>
    *
@@ -4416,11 +4621,14 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Exports this ProcessSystem to the JSON schema consumed by {@link JsonProcessBuilder}.
+   * Exports this ProcessSystem to the JSON schema consumed by
+   * {@link JsonProcessBuilder}.
    *
    * <p>
-   * The exported JSON is round-trippable: the output can be fed back into {@link #fromJson(String)}
-   * to reconstruct an equivalent ProcessSystem. This enables exporting NeqSim process models to
+   * The exported JSON is round-trippable: the output can be fed back into
+   * {@link #fromJson(String)}
+   * to reconstruct an equivalent ProcessSystem. This enables exporting NeqSim
+   * process models to
    * external simulators (e.g., UniSim Design via COM automation).
    * </p>
    *
@@ -4436,12 +4644,14 @@ public class ProcessSystem extends SimulationBaseClass {
    * Builds and immediately runs a ProcessSystem from a JSON definition.
    *
    * <p>
-   * Convenience method that combines building and execution in a single call. The result contains
+   * Convenience method that combines building and execution in a single call. The
+   * result contains
    * the full simulation report JSON.
    * </p>
    *
    * @param json the JSON process definition string
-   * @return a SimulationResult containing the executed process and report, or errors
+   * @return a SimulationResult containing the executed process and report, or
+   *         errors
    * @see JsonProcessBuilder#buildAndRun(String)
    */
   public static SimulationResult fromJsonAndRun(String json) {
@@ -4449,19 +4659,25 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Builds and runs a process simulation from a JSON definition using a pre-built fluid.
+   * Builds and runs a process simulation from a JSON definition using a pre-built
+   * fluid.
    *
    * <p>
-   * This overload is used when the fluid has been loaded from an external source (e.g., an Eclipse
-   * E300 file via {@link neqsim.thermo.util.readwrite.EclipseFluidReadWrite}) and should be used
-   * instead of parsing the fluid section in the JSON. The pre-built fluid preserves all component
+   * This overload is used when the fluid has been loaded from an external source
+   * (e.g., an Eclipse
+   * E300 file via {@link neqsim.thermo.util.readwrite.EclipseFluidReadWrite}) and
+   * should be used
+   * instead of parsing the fluid section in the JSON. The pre-built fluid
+   * preserves all component
    * critical properties (Tc, Pc, acentric factor, MW, BIPs) for both standard and
    * hypothetical/pseudo components.
    * </p>
    *
-   * @param json the JSON process definition string (the 'fluid' section is ignored)
+   * @param json  the JSON process definition string (the 'fluid' section is
+   *              ignored)
    * @param fluid the pre-built thermodynamic system to use
-   * @return a SimulationResult containing the executed process and report, or errors
+   * @return a SimulationResult containing the executed process and report, or
+   *         errors
    * @see JsonProcessBuilder#buildAndRun(String, SystemInterface)
    */
   public static SimulationResult fromJsonAndRun(String json, SystemInterface fluid) {
@@ -4536,14 +4752,16 @@ public class ProcessSystem extends SimulationBaseClass {
               // fall through to default outlet
             }
           }
-          // Handle HeatExchanger which uses getOutStream(int) instead of getOutletStream()
+          // Handle HeatExchanger which uses getOutStream(int) instead of
+          // getOutletStream()
           if (unit instanceof HeatExchanger) {
             return ((HeatExchanger) unit).getOutStream(0);
           }
           return (StreamInterface) unit.getClass().getMethod("getOutletStream").invoke(unit);
       }
     } catch (NoSuchMethodException e) {
-      // Fallback chain: getOutStream(int) -> getOutletStreams().get(0) -> getOutStream()
+      // Fallback chain: getOutStream(int) -> getOutletStreams().get(0) ->
+      // getOutStream()
       try {
         return (StreamInterface) unit.getClass().getMethod("getOutStream", int.class).invoke(unit,
             0);
@@ -4575,7 +4793,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * </p>
    *
    * @param targetUnitName the name of the equipment to wire the inlet to
-   * @param sourceRef the stream reference (e.g., "feed", "HP Sep.gasOut")
+   * @param sourceRef      the stream reference (e.g., "feed", "HP Sep.gasOut")
    * @return true if wiring succeeded, false if source or target not found
    */
   public boolean wireStream(String targetUnitName, String sourceRef) {
@@ -4592,14 +4810,12 @@ public class ProcessSystem extends SimulationBaseClass {
     }
 
     try {
-      java.lang.reflect.Method setInlet =
-          target.getClass().getMethod("setInletStream", StreamInterface.class);
+      java.lang.reflect.Method setInlet = target.getClass().getMethod("setInletStream", StreamInterface.class);
       setInlet.invoke(target, stream);
       return true;
     } catch (NoSuchMethodException e) {
       try {
-        java.lang.reflect.Method addStream =
-            target.getClass().getMethod("addStream", StreamInterface.class);
+        java.lang.reflect.Method addStream = target.getClass().getMethod("addStream", StreamInterface.class);
         addStream.invoke(target, stream);
         return true;
       } catch (Exception ex) {
@@ -4619,7 +4835,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * </p>
    *
    * <p>
-   * Identifies the equipment with the highest capacity utilization. This method checks both:
+   * Identifies the equipment with the highest capacity utilization. This method
+   * checks both:
    * </p>
    * <ul>
    * <li>Traditional capacity: {@code getCapacityDuty() / getCapacityMax()}</li>
@@ -4627,7 +4844,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * {@link neqsim.process.equipment.capacity.CapacityConstrainedEquipment}</li>
    * </ul>
    *
-   * @return a {@link neqsim.process.equipment.ProcessEquipmentInterface} object representing the
+   * @return a {@link neqsim.process.equipment.ProcessEquipmentInterface} object
+   *         representing the
    *         bottleneck, or null if no equipment has capacity defined
    */
   public ProcessEquipmentInterface getBottleneck() {
@@ -4639,8 +4857,7 @@ public class ProcessSystem extends SimulationBaseClass {
 
       // Check if equipment implements CapacityConstrainedEquipment (multi-constraint)
       if (unit instanceof neqsim.process.equipment.capacity.CapacityConstrainedEquipment) {
-        neqsim.process.equipment.capacity.CapacityConstrainedEquipment constrained =
-            (neqsim.process.equipment.capacity.CapacityConstrainedEquipment) unit;
+        neqsim.process.equipment.capacity.CapacityConstrainedEquipment constrained = (neqsim.process.equipment.capacity.CapacityConstrainedEquipment) unit;
         utilization = constrained.getMaxUtilization();
       } else {
         // Fall back to traditional single capacity metric
@@ -4691,7 +4908,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * <p>
    * The graph representation enables:
    * <ul>
-   * <li>Automatic detection of calculation order (derived from topology, not insertion order)</li>
+   * <li>Automatic detection of calculation order (derived from topology, not
+   * insertion order)</li>
    * <li>Partitioning for parallel execution</li>
    * <li>AI agents to reason about flowsheet structure</li>
    * <li>Cycle detection for recycle handling</li>
@@ -4729,7 +4947,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Forces a rebuild of the process graph on next access.
    *
    * <p>
-   * Use this method when you have made structural changes to the process that the automatic
+   * Use this method when you have made structural changes to the process that the
+   * automatic
    * detection may have missed (e.g., modifying stream connections directly).
    * </p>
    */
@@ -4739,18 +4958,23 @@ public class ProcessSystem extends SimulationBaseClass {
     cachedParallelPlan = null;
     cachedHasAdjusters = null;
     cachedHasRecycles = null;
+    cachedHasCalculators = null;
+    cachedHasMultiInput = null;
   }
 
   /**
    * Sets whether to use graph-based execution order.
    *
    * <p>
-   * When enabled, the run() method will execute units in topological order derived from stream
-   * connections rather than the order units were added. This can be safer when unit insertion order
+   * When enabled, the run() method will execute units in topological order
+   * derived from stream
+   * connections rather than the order units were added. This can be safer when
+   * unit insertion order
    * doesn't match the physical flow.
    * </p>
    *
-   * @param useGraphBased true to use topological execution order, false to use insertion order
+   * @param useGraphBased true to use topological execution order, false to use
+   *                      insertion order
    */
   public void setUseGraphBasedExecution(boolean useGraphBased) {
     this.useGraphBasedExecution = useGraphBased;
@@ -4766,23 +4990,30 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Sets whether to use optimized execution (parallel/hybrid) by default when run() is called.
+   * Sets whether to use optimized execution (parallel/hybrid) by default when
+   * run() is called.
    *
    * <p>
-   * When enabled (default), run() automatically selects the best execution strategy:
+   * When enabled (default), run() automatically selects the best execution
+   * strategy:
    * </p>
    * <ul>
-   * <li>For processes WITHOUT recycles: parallel execution for maximum speed (28-57% faster)</li>
-   * <li>For processes WITH recycles: hybrid execution - parallel for feed-forward sections, then
+   * <li>For processes WITHOUT recycles: parallel execution for maximum speed
+   * (28-57% faster)</li>
+   * <li>For processes WITH recycles: hybrid execution - parallel for feed-forward
+   * sections, then
    * iterative for recycle sections (28-38% faster)</li>
    * </ul>
    *
    * <p>
-   * When disabled, run() uses sequential execution in insertion order (legacy behavior). This may
-   * be useful for debugging or when deterministic single-threaded execution is required.
+   * When disabled, run() uses sequential execution in insertion order (legacy
+   * behavior). This may
+   * be useful for debugging or when deterministic single-threaded execution is
+   * required.
    * </p>
    *
-   * @param useOptimized true to use optimized execution (default), false for sequential execution
+   * @param useOptimized true to use optimized execution (default), false for
+   *                     sequential execution
    */
   public void setUseOptimizedExecution(boolean useOptimized) {
     this.useOptimizedExecution = useOptimized;
@@ -4792,7 +5023,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Returns whether optimized execution is enabled.
    *
    * <p>
-   * When true (default), run() delegates to runOptimized() which automatically selects the best
+   * When true (default), run() delegates to runOptimized() which automatically
+   * selects the best
    * execution strategy based on process topology.
    * </p>
    *
@@ -4806,9 +5038,12 @@ public class ProcessSystem extends SimulationBaseClass {
    * Gets the calculation order derived from process topology.
    *
    * <p>
-   * This method returns units in the order they should be calculated based on stream connections,
-   * not the order they were added to the ProcessSystem. This is safer than relying on insertion
-   * order, which can lead to wrong results if units are rearranged or recycles are added late.
+   * This method returns units in the order they should be calculated based on
+   * stream connections,
+   * not the order they were added to the ProcessSystem. This is safer than
+   * relying on insertion
+   * order, which can lead to wrong results if units are rearranged or recycles
+   * are added late.
    * </p>
    *
    * @return list of equipment in topology-derived calculation order
@@ -4832,7 +5067,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Gets the number of levels for parallel execution.
    *
    * <p>
-   * Units at the same level have no dependencies on each other and can be executed in parallel.
+   * Units at the same level have no dependencies on each other and can be
+   * executed in parallel.
    * </p>
    *
    * @return number of parallel execution levels
@@ -4885,7 +5121,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Gets the strongly connected components (SCCs) in the process graph.
    *
    * <p>
-   * SCCs with more than one unit represent recycle loops that require iterative convergence. This
+   * SCCs with more than one unit represent recycle loops that require iterative
+   * convergence. This
    * method uses Tarjan's algorithm to identify these components.
    * </p>
    *
@@ -4963,11 +5200,14 @@ public class ProcessSystem extends SimulationBaseClass {
   // ============ DIGITAL TWIN LIFECYCLE & SUSTAINABILITY ============
 
   /**
-   * Exports the current state of this process system for checkpointing or versioning.
+   * Exports the current state of this process system for checkpointing or
+   * versioning.
    *
    * <p>
-   * This method captures all equipment states, fluid compositions, and operating conditions into a
-   * serializable format that can be saved to disk, stored in a database, or used for model
+   * This method captures all equipment states, fluid compositions, and operating
+   * conditions into a
+   * serializable format that can be saved to disk, stored in a database, or used
+   * for model
    * versioning in digital twin applications.
    * </p>
    *
@@ -5001,15 +5241,16 @@ public class ProcessSystem extends SimulationBaseClass {
    * Loads process state from a JSON file and applies it to this system.
    *
    * <p>
-   * Note: This method updates equipment states but does not recreate equipment. The process
+   * Note: This method updates equipment states but does not recreate equipment.
+   * The process
    * structure must match the saved state.
    * </p>
    *
    * @param filename the file path to load state from
    */
   public void loadStateFromFile(String filename) {
-    neqsim.process.processmodel.lifecycle.ProcessSystemState state =
-        neqsim.process.processmodel.lifecycle.ProcessSystemState.loadFromFile(filename);
+    neqsim.process.processmodel.lifecycle.ProcessSystemState state = neqsim.process.processmodel.lifecycle.ProcessSystemState
+        .loadFromFile(filename);
     if (state != null) {
       state.applyTo(this);
     }
@@ -5018,11 +5259,14 @@ public class ProcessSystem extends SimulationBaseClass {
   // ============ NEQSIM FILE SERIALIZATION ============
 
   /**
-   * Saves this process system to a compressed .neqsim file using XStream serialization.
+   * Saves this process system to a compressed .neqsim file using XStream
+   * serialization.
    *
    * <p>
-   * This is the recommended format for production use, providing compact storage with full process
-   * state preservation. The file can be loaded with {@link #loadFromNeqsim(String)}.
+   * This is the recommended format for production use, providing compact storage
+   * with full process
+   * state preservation. The file can be loaded with
+   * {@link #loadFromNeqsim(String)}.
    * </p>
    *
    * <p>
@@ -5045,7 +5289,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Loads a process system from a compressed .neqsim file.
    *
    * <p>
-   * After loading, the process is automatically run to reinitialize calculations. This ensures the
+   * After loading, the process is automatically run to reinitialize calculations.
+   * This ensures the
    * internal state is consistent.
    * </p>
    *
@@ -5166,8 +5411,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * @see neqsim.process.sustainability.EmissionsTracker
    */
   public neqsim.process.sustainability.EmissionsTracker.EmissionsReport getEmissions() {
-    neqsim.process.sustainability.EmissionsTracker tracker =
-        new neqsim.process.sustainability.EmissionsTracker(this);
+    neqsim.process.sustainability.EmissionsTracker tracker = new neqsim.process.sustainability.EmissionsTracker(this);
     return tracker.calculateEmissions();
   }
 
@@ -5175,18 +5419,19 @@ public class ProcessSystem extends SimulationBaseClass {
    * Calculates emissions using a custom grid emission factor.
    *
    * <p>
-   * Different regions have different electricity grid carbon intensities. Use this method to apply
+   * Different regions have different electricity grid carbon intensities. Use
+   * this method to apply
    * location-specific emission factors.
    * </p>
    *
-   * @param gridEmissionFactor kg CO2 per kWh of electricity (e.g., 0.05 for Norway, 0.4 for global
-   *        average)
+   * @param gridEmissionFactor kg CO2 per kWh of electricity (e.g., 0.05 for
+   *                           Norway, 0.4 for global
+   *                           average)
    * @return emissions report with equipment breakdown
    */
   public neqsim.process.sustainability.EmissionsTracker.EmissionsReport getEmissions(
       double gridEmissionFactor) {
-    neqsim.process.sustainability.EmissionsTracker tracker =
-        new neqsim.process.sustainability.EmissionsTracker(this);
+    neqsim.process.sustainability.EmissionsTracker tracker = new neqsim.process.sustainability.EmissionsTracker(this);
     tracker.setGridEmissionFactor(gridEmissionFactor);
     return tracker.calculateEmissions();
   }
@@ -5195,7 +5440,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Gets total CO2-equivalent emissions from this process in kg/hr.
    *
    * <p>
-   * This is a convenience method for quick emission checks. For detailed breakdown, use
+   * This is a convenience method for quick emission checks. For detailed
+   * breakdown, use
    * {@link #getEmissions()}.
    * </p>
    *
@@ -5208,22 +5454,24 @@ public class ProcessSystem extends SimulationBaseClass {
   // ============ BATCH STUDY & OPTIMIZATION ============
 
   /**
-   * Creates a batch study builder for running parallel parameter studies on this process.
+   * Creates a batch study builder for running parallel parameter studies on this
+   * process.
    *
    * <p>
-   * Batch studies allow exploring the design space by running many variations of this process in
-   * parallel. Useful for concept screening, sensitivity analysis, and optimization.
+   * Batch studies allow exploring the design space by running many variations of
+   * this process in
+   * parallel. Useful for concept screening, sensitivity analysis, and
+   * optimization.
    * </p>
    *
    * <p>
    * Example usage:
    *
    * <pre>
-   * BatchStudy study =
-   *     system.createBatchStudy().addParameter("separator1", "pressure", 30.0, 50.0, 70.0)
-   *         .addParameter("compressor1", "outletPressure", 80.0, 100.0, 120.0)
-   *         .addObjective("totalPower", true) // minimize
-   *         .withParallelism(4).build();
+   * BatchStudy study = system.createBatchStudy().addParameter("separator1", "pressure", 30.0, 50.0, 70.0)
+   *     .addParameter("compressor1", "outletPressure", 80.0, 100.0, 120.0)
+   *     .addObjective("totalPower", true) // minimize
+   *     .withParallelism(4).build();
    * BatchStudyResult result = study.run();
    * </pre>
    *
@@ -5240,7 +5488,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Generates automatic safety scenarios based on equipment failure modes.
    *
    * <p>
-   * This method analyzes the process structure and generates scenarios for common failure modes
+   * This method analyzes the process structure and generates scenarios for common
+   * failure modes
    * such as:
    * <ul>
    * <li>Cooling system failure</li>
@@ -5266,8 +5515,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * @see neqsim.process.safety.scenario.AutomaticScenarioGenerator
    */
   public List<neqsim.process.safety.ProcessSafetyScenario> generateSafetyScenarios() {
-    neqsim.process.safety.scenario.AutomaticScenarioGenerator generator =
-        new neqsim.process.safety.scenario.AutomaticScenarioGenerator(this);
+    neqsim.process.safety.scenario.AutomaticScenarioGenerator generator = new neqsim.process.safety.scenario.AutomaticScenarioGenerator(
+        this);
     return generator.enableAllFailureModes().generateSingleFailures();
   }
 
@@ -5278,13 +5527,14 @@ public class ProcessSystem extends SimulationBaseClass {
    * This is useful for analyzing cascading failures and common-cause scenarios.
    * </p>
    *
-   * @param maxSimultaneousFailures maximum number of failures to combine (2-3 recommended)
+   * @param maxSimultaneousFailures maximum number of failures to combine (2-3
+   *                                recommended)
    * @return list of combination scenarios
    */
   public List<neqsim.process.safety.ProcessSafetyScenario> generateCombinationScenarios(
       int maxSimultaneousFailures) {
-    neqsim.process.safety.scenario.AutomaticScenarioGenerator generator =
-        new neqsim.process.safety.scenario.AutomaticScenarioGenerator(this);
+    neqsim.process.safety.scenario.AutomaticScenarioGenerator generator = new neqsim.process.safety.scenario.AutomaticScenarioGenerator(
+        this);
     return generator.enableAllFailureModes().generateCombinations(maxSimultaneousFailures);
   }
 
@@ -5294,7 +5544,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Exports the process as a DOT format diagram string.
    *
    * <p>
-   * Generates a professional oil &amp; gas style process flow diagram (PFD) following industry
+   * Generates a professional oil &amp; gas style process flow diagram (PFD)
+   * following industry
    * conventions:
    * </p>
    * <ul>
@@ -5324,7 +5575,8 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Exports the process as a DOT format diagram with specified detail level.
    *
-   * @param detailLevel the level of detail to include (CONCEPTUAL, ENGINEERING, DEBUG)
+   * @param detailLevel the level of detail to include (CONCEPTUAL, ENGINEERING,
+   *                    DEBUG)
    * @return Graphviz DOT format string
    * @see neqsim.process.processmodel.diagram.DiagramDetailLevel
    */
@@ -5384,19 +5636,24 @@ public class ProcessSystem extends SimulationBaseClass {
   // ==================== Capacity Constraint Methods ====================
 
   /**
-   * Enables or disables capacity analysis for all equipment in this process system.
+   * Enables or disables capacity analysis for all equipment in this process
+   * system.
    *
    * <p>
-   * This is a convenience method that applies the setting to all equipment that extends
+   * This is a convenience method that applies the setting to all equipment that
+   * extends
    * {@link ProcessEquipmentBaseClass}. When disabled, equipment is excluded from:
    * <ul>
    * <li>System bottleneck detection ({@code findBottleneck()})</li>
-   * <li>Capacity utilization summaries ({@code getCapacityUtilizationSummary()})</li>
-   * <li>Equipment near capacity lists ({@code getEquipmentNearCapacityLimit()})</li>
+   * <li>Capacity utilization summaries
+   * ({@code getCapacityUtilizationSummary()})</li>
+   * <li>Equipment near capacity lists
+   * ({@code getEquipmentNearCapacityLimit()})</li>
    * <li>Optimization constraint checking</li>
    * </ul>
    *
-   * @param enabled true to enable capacity analysis for all equipment, false to disable
+   * @param enabled true to enable capacity analysis for all equipment, false to
+   *                disable
    * @return the number of equipment items that were updated
    */
   public int setCapacityAnalysisEnabled(boolean enabled) {
@@ -5414,15 +5671,15 @@ public class ProcessSystem extends SimulationBaseClass {
    * Gets all capacity-constrained equipment in the process.
    *
    * <p>
-   * Returns equipment that implements the CapacityConstrainedEquipment interface, such as
+   * Returns equipment that implements the CapacityConstrainedEquipment interface,
+   * such as
    * separators, compressors, pumps, etc.
    * </p>
    *
    * @return list of capacity-constrained equipment
    */
   public java.util.List<neqsim.process.equipment.capacity.CapacityConstrainedEquipment> getConstrainedEquipment() {
-    java.util.List<neqsim.process.equipment.capacity.CapacityConstrainedEquipment> result =
-        new java.util.ArrayList<>();
+    java.util.List<neqsim.process.equipment.capacity.CapacityConstrainedEquipment> result = new java.util.ArrayList<>();
     for (ProcessEquipmentInterface unit : unitOperations) {
       if (unit instanceof neqsim.process.equipment.capacity.CapacityConstrainedEquipment) {
         result.add((neqsim.process.equipment.capacity.CapacityConstrainedEquipment) unit);
@@ -5435,17 +5692,22 @@ public class ProcessSystem extends SimulationBaseClass {
    * Finds the process bottleneck with detailed constraint information.
    *
    * <p>
-   * This method extends {@link #getBottleneck()} by returning detailed information about which
-   * specific constraint is limiting the bottleneck equipment. Uses the universal constraint API on
-   * {@link ProcessEquipmentInterface} so ALL equipment types are checked, not just those
+   * This method extends {@link #getBottleneck()} by returning detailed
+   * information about which
+   * specific constraint is limiting the bottleneck equipment. Uses the universal
+   * constraint API on
+   * {@link ProcessEquipmentInterface} so ALL equipment types are checked, not
+   * just those
    * implementing CapacityConstrainedEquipment.
    * </p>
    *
    * <p>
-   * For simple bottleneck detection without constraint details, use {@link #getBottleneck()}.
+   * For simple bottleneck detection without constraint details, use
+   * {@link #getBottleneck()}.
    * </p>
    *
-   * @return BottleneckResult containing the bottleneck equipment, limiting constraint, and
+   * @return BottleneckResult containing the bottleneck equipment, limiting
+   *         constraint, and
    *         utilization; returns empty result if no constrained equipment found
    * @see #getBottleneck()
    */
@@ -5460,8 +5722,7 @@ public class ProcessSystem extends SimulationBaseClass {
           && !((ProcessEquipmentBaseClass) unit).isCapacityAnalysisEnabled()) {
         continue;
       }
-      neqsim.process.equipment.capacity.CapacityConstraint constraint =
-          unit.getBottleneckConstraint();
+      neqsim.process.equipment.capacity.CapacityConstraint constraint = unit.getBottleneckConstraint();
       if (constraint != null && constraint.isEnabled()) {
         double util = constraint.getUtilization();
         if (!Double.isNaN(util) && util > maxUtil) {
@@ -5480,11 +5741,14 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Checks if any equipment in the process is overloaded (exceeds design capacity).
+   * Checks if any equipment in the process is overloaded (exceeds design
+   * capacity).
    *
    * <p>
-   * All equipment with capacity constraints is checked, not just those implementing
-   * CapacityConstrainedEquipment. Only equipment with capacity analysis enabled is checked.
+   * All equipment with capacity constraints is checked, not just those
+   * implementing
+   * CapacityConstrainedEquipment. Only equipment with capacity analysis enabled
+   * is checked.
    * </p>
    *
    * @return true if any equipment has capacity utilization above 100%
@@ -5506,7 +5770,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Checks if any equipment exceeds a HARD capacity limit.
    *
    * <p>
-   * HARD limits represent absolute equipment limits that cannot be exceeded without trip or damage,
+   * HARD limits represent absolute equipment limits that cannot be exceeded
+   * without trip or damage,
    * such as maximum compressor speed or surge limits. All equipment is checked.
    * </p>
    *
@@ -5529,7 +5794,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Gets a summary of capacity utilization for all equipment with constraints.
    *
    * <p>
-   * Returns a map of equipment names to their maximum constraint utilization. Only equipment with
+   * Returns a map of equipment names to their maximum constraint utilization.
+   * Only equipment with
    * capacity analysis enabled and at least one enabled constraint is included.
    * </p>
    *
@@ -5554,7 +5820,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Gets equipment that is near its capacity limit (above warning threshold).
    *
    * <p>
-   * Returns equipment where at least one constraint is above its warning threshold (typically 90%
+   * Returns equipment where at least one constraint is above its warning
+   * threshold (typically 90%
    * of design). All equipment is checked.
    * </p>
    *
@@ -5578,12 +5845,15 @@ public class ProcessSystem extends SimulationBaseClass {
    * Disables all capacity constraints on all equipment in the process system.
    *
    * <p>
-   * Use this for what-if scenarios where you want to ignore capacity limits and see what the
-   * process would do without constraints. To re-enable, call {@link #enableAllConstraints()}.
+   * Use this for what-if scenarios where you want to ignore capacity limits and
+   * see what the
+   * process would do without constraints. To re-enable, call
+   * {@link #enableAllConstraints()}.
    * </p>
    *
    * <p>
-   * This method also sets {@code capacityAnalysisEnabled = false} on each equipment, which prevents
+   * This method also sets {@code capacityAnalysisEnabled = false} on each
+   * equipment, which prevents
    * the optimizer from using fallback capacity rules for equipment types.
    * </p>
    *
@@ -5602,12 +5872,14 @@ public class ProcessSystem extends SimulationBaseClass {
    * Enables all capacity constraints on all equipment in the process system.
    *
    * <p>
-   * Re-enables all constraints that were previously disabled. This restores normal capacity
+   * Re-enables all constraints that were previously disabled. This restores
+   * normal capacity
    * analysis mode for the entire process.
    * </p>
    *
    * <p>
-   * This method also sets {@code capacityAnalysisEnabled = true} on each equipment.
+   * This method also sets {@code capacityAnalysisEnabled = true} on each
+   * equipment.
    * </p>
    *
    * @return the total number of constraints that were enabled
@@ -5626,12 +5898,16 @@ public class ProcessSystem extends SimulationBaseClass {
   // ==========================================================================
 
   /**
-   * Automatically sizes all equipment in the process system that implements AutoSizeable.
+   * Automatically sizes all equipment in the process system that implements
+   * AutoSizeable.
    *
    * <p>
-   * This method iterates through all unit operations and calls autoSize() on each one that
-   * implements the {@link neqsim.process.design.AutoSizeable} interface. Equipment dimensions are
-   * calculated based on current flow conditions, so the process should be run before calling this
+   * This method iterates through all unit operations and calls autoSize() on each
+   * one that
+   * implements the {@link neqsim.process.design.AutoSizeable} interface.
+   * Equipment dimensions are
+   * calculated based on current flow conditions, so the process should be run
+   * before calling this
    * method.
    * </p>
    *
@@ -5652,16 +5928,21 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Automatically sizes all equipment in the process system with specified safety factor.
+   * Automatically sizes all equipment in the process system with specified safety
+   * factor.
    *
    * <p>
-   * This method iterates through all unit operations and calls autoSize() on each one that
-   * implements the {@link neqsim.process.design.AutoSizeable} interface. Equipment dimensions are
-   * calculated based on current flow conditions, so the process should be run before calling this
+   * This method iterates through all unit operations and calls autoSize() on each
+   * one that
+   * implements the {@link neqsim.process.design.AutoSizeable} interface.
+   * Equipment dimensions are
+   * calculated based on current flow conditions, so the process should be run
+   * before calling this
    * method.
    * </p>
    *
-   * @param safetyFactor multiplier for design capacity, typically 1.1-1.3 (10-30% over design)
+   * @param safetyFactor multiplier for design capacity, typically 1.1-1.3 (10-30%
+   *                     over design)
    * @return the number of equipment items that were auto-sized
    */
   public int autoSizeEquipment(double safetyFactor) {
@@ -5679,12 +5960,15 @@ public class ProcessSystem extends SimulationBaseClass {
    * Automatically sizes all equipment using company-specific design standards.
    *
    * <p>
-   * This method applies design rules from the specified company's technical requirements (TR)
+   * This method applies design rules from the specified company's technical
+   * requirements (TR)
    * documents. The standards are loaded from the NeqSim design database.
    * </p>
    *
-   * @param companyStandard company name (e.g., "Equinor", "Shell", "TotalEnergies")
-   * @param trDocument TR document reference (e.g., "TR2000", "DEP-31.38.01.11")
+   * @param companyStandard company name (e.g., "Equinor", "Shell",
+   *                        "TotalEnergies")
+   * @param trDocument      TR document reference (e.g., "TR2000",
+   *                        "DEP-31.38.01.11")
    * @return the number of equipment items that were auto-sized
    */
   public int autoSizeEquipment(String companyStandard, String trDocument) {
@@ -5702,8 +5986,10 @@ public class ProcessSystem extends SimulationBaseClass {
    * Gets the design report for all auto-sized equipment in JSON format.
    *
    * <p>
-   * Returns a JSON object containing design reports for all equipment that implements AutoSizeable.
-   * Each equipment's report includes design basis, calculated dimensions, and capacity constraints.
+   * Returns a JSON object containing design reports for all equipment that
+   * implements AutoSizeable.
+   * Each equipment's report includes design basis, calculated dimensions, and
+   * capacity constraints.
    * </p>
    *
    * <p>
@@ -5728,8 +6014,7 @@ public class ProcessSystem extends SimulationBaseClass {
 
     for (ProcessEquipmentInterface equipment : unitOperations) {
       if (equipment instanceof neqsim.process.design.AutoSizeable) {
-        neqsim.process.design.AutoSizeable sizeable =
-            (neqsim.process.design.AutoSizeable) equipment;
+        neqsim.process.design.AutoSizeable sizeable = (neqsim.process.design.AutoSizeable) equipment;
 
         com.google.gson.JsonObject equipReport = new com.google.gson.JsonObject();
         equipReport.addProperty("name", equipment.getName());
@@ -5740,8 +6025,8 @@ public class ProcessSystem extends SimulationBaseClass {
         String jsonReport = sizeable.getSizingReportJson();
         if (jsonReport != null && !jsonReport.equals("{}")) {
           try {
-            com.google.gson.JsonObject sizingData =
-                com.google.gson.JsonParser.parseString(jsonReport).getAsJsonObject();
+            com.google.gson.JsonObject sizingData = com.google.gson.JsonParser.parseString(jsonReport)
+                .getAsJsonObject();
             equipReport.add("sizingData", sizingData);
           } catch (Exception e) {
             equipReport.addProperty("sizingData", jsonReport);
@@ -5750,8 +6035,7 @@ public class ProcessSystem extends SimulationBaseClass {
 
         // Add capacity constraints if equipment is capacity-constrained
         if (equipment instanceof neqsim.process.equipment.capacity.CapacityConstrainedEquipment) {
-          neqsim.process.equipment.capacity.CapacityConstrainedEquipment constrained =
-              (neqsim.process.equipment.capacity.CapacityConstrainedEquipment) equipment;
+          neqsim.process.equipment.capacity.CapacityConstrainedEquipment constrained = (neqsim.process.equipment.capacity.CapacityConstrainedEquipment) equipment;
 
           com.google.gson.JsonObject capacityData = new com.google.gson.JsonObject();
           capacityData.addProperty("maxUtilization", constrained.getMaxUtilization() * 100.0);
@@ -5801,8 +6085,7 @@ public class ProcessSystem extends SimulationBaseClass {
 
     for (ProcessEquipmentInterface equipment : unitOperations) {
       if (equipment instanceof neqsim.process.design.AutoSizeable) {
-        neqsim.process.design.AutoSizeable sizeable =
-            (neqsim.process.design.AutoSizeable) equipment;
+        neqsim.process.design.AutoSizeable sizeable = (neqsim.process.design.AutoSizeable) equipment;
         sb.append("--- ").append(equipment.getName()).append(" (")
             .append(equipment.getClass().getSimpleName()).append(") ---\n");
         sb.append("Auto-sized: ").append(sizeable.isAutoSized()).append("\n");
@@ -5821,7 +6104,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Creates a ProcessOptimizationEngine for this process system.
    *
    * <p>
-   * The optimization engine provides advanced optimization capabilities including:
+   * The optimization engine provides advanced optimization capabilities
+   * including:
    * </p>
    * <ul>
    * <li>Maximum throughput optimization</li>
@@ -5850,11 +6134,12 @@ public class ProcessSystem extends SimulationBaseClass {
    * Creates a FlowRateOptimizer for this process system.
    *
    * <p>
-   * The FlowRateOptimizer provides detailed flow rate optimization capabilities including lift
+   * The FlowRateOptimizer provides detailed flow rate optimization capabilities
+   * including lift
    * curve generation and Eclipse VFP export.
    * </p>
    *
-   * @param inletStreamName name of the inlet stream
+   * @param inletStreamName  name of the inlet stream
    * @param outletStreamName name of the outlet stream (or equipment)
    * @return a new FlowRateOptimizer configured for this process
    */
@@ -5867,21 +6152,23 @@ public class ProcessSystem extends SimulationBaseClass {
    * Finds the maximum throughput for given pressure boundaries.
    *
    * <p>
-   * This is a convenience method that creates an optimizer, runs the optimization, and returns the
-   * result. For more control over the optimization process, use {@link #createOptimizer()}.
+   * This is a convenience method that creates an optimizer, runs the
+   * optimization, and returns the
+   * result. For more control over the optimization process, use
+   * {@link #createOptimizer()}.
    * </p>
    *
-   * @param inletPressure inlet pressure in bara
+   * @param inletPressure  inlet pressure in bara
    * @param outletPressure outlet pressure in bara
-   * @param minFlow minimum flow rate to consider in kg/hr
-   * @param maxFlow maximum flow rate to consider in kg/hr
+   * @param minFlow        minimum flow rate to consider in kg/hr
+   * @param maxFlow        maximum flow rate to consider in kg/hr
    * @return the maximum feasible flow rate in kg/hr, or NaN if optimization fails
    */
   public double findMaxThroughput(double inletPressure, double outletPressure, double minFlow,
       double maxFlow) {
     ProcessOptimizationEngine engine = createOptimizer();
-    ProcessOptimizationEngine.OptimizationResult result =
-        engine.findMaximumThroughput(inletPressure, outletPressure, minFlow, maxFlow);
+    ProcessOptimizationEngine.OptimizationResult result = engine.findMaximumThroughput(inletPressure, outletPressure,
+        minFlow, maxFlow);
     return result.getOptimalValue();
   }
 
@@ -5892,7 +6179,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * Uses default minimum flow of 100 kg/hr and maximum flow of 1,000,000 kg/hr.
    * </p>
    *
-   * @param inletPressure inlet pressure in bara
+   * @param inletPressure  inlet pressure in bara
    * @param outletPressure outlet pressure in bara
    * @return the maximum feasible flow rate in kg/hr, or NaN if optimization fails
    */
@@ -5904,14 +6191,15 @@ public class ProcessSystem extends SimulationBaseClass {
    * Optimizes the process throughput and returns detailed results.
    *
    * <p>
-   * This method provides a complete optimization result including the optimal flow rate, constraint
+   * This method provides a complete optimization result including the optimal
+   * flow rate, constraint
    * status, and bottleneck information.
    * </p>
    *
-   * @param inletPressure inlet pressure in bara
+   * @param inletPressure  inlet pressure in bara
    * @param outletPressure outlet pressure in bara
-   * @param minFlow minimum flow rate to consider in kg/hr
-   * @param maxFlow maximum flow rate to consider in kg/hr
+   * @param minFlow        minimum flow rate to consider in kg/hr
+   * @param maxFlow        maximum flow rate to consider in kg/hr
    * @return optimization result with detailed information
    */
   public ProcessOptimizationEngine.OptimizationResult optimizeThroughput(double inletPressure,
@@ -5924,8 +6212,10 @@ public class ProcessSystem extends SimulationBaseClass {
    * Evaluates all equipment constraints in the process.
    *
    * <p>
-   * Returns a detailed report of all capacity constraints across all equipment in the process.
-   * Useful for understanding the current operating status and identifying potential bottlenecks.
+   * Returns a detailed report of all capacity constraints across all equipment in
+   * the process.
+   * Useful for understanding the current operating status and identifying
+   * potential bottlenecks.
    * </p>
    *
    * @return constraint report with utilization information for all equipment
@@ -5939,14 +6229,15 @@ public class ProcessSystem extends SimulationBaseClass {
    * Generates a lift curve for this process.
    *
    * <p>
-   * Creates a table of maximum flow rates for different pressure and temperature conditions. The
+   * Creates a table of maximum flow rates for different pressure and temperature
+   * conditions. The
    * result can be exported to Eclipse VFP format for reservoir simulation.
    * </p>
    *
-   * @param pressures array of pressures to evaluate (bara)
+   * @param pressures    array of pressures to evaluate (bara)
    * @param temperatures array of temperatures to evaluate (K)
-   * @param waterCuts array of water cuts as fraction
-   * @param GORs array of gas-oil ratios in Sm3/Sm3
+   * @param waterCuts    array of water cuts as fraction
+   * @param GORs         array of gas-oil ratios in Sm3/Sm3
    * @return lift curve data
    */
   public ProcessOptimizationEngine.LiftCurveData generateLiftCurve(double[] pressures,
@@ -5959,12 +6250,13 @@ public class ProcessSystem extends SimulationBaseClass {
    * Performs sensitivity analysis at the given flow rate.
    *
    * <p>
-   * Calculates how sensitive the process is to changes in flow rate, identifying which constraints
+   * Calculates how sensitive the process is to changes in flow rate, identifying
+   * which constraints
    * become binding and the rate of change of key variables.
    * </p>
    *
-   * @param optimalFlow optimal flow rate to analyze in kg/hr
-   * @param inletPressure inlet pressure in bara
+   * @param optimalFlow    optimal flow rate to analyze in kg/hr
+   * @param inletPressure  inlet pressure in bara
    * @param outletPressure outlet pressure in bara
    * @return sensitivity analysis result
    */
@@ -5978,7 +6270,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Creates a fluent optimization builder for this process.
    *
    * <p>
-   * The builder provides a convenient way to configure and run optimizations with method chaining.
+   * The builder provides a convenient way to configure and run optimizations with
+   * method chaining.
    * </p>
    *
    * <p>
@@ -6009,8 +6302,7 @@ public class ProcessSystem extends SimulationBaseClass {
     private double outletPressure = 10.0;
     private double minFlow = 100.0;
     private double maxFlow = 1000000.0;
-    private ProcessOptimizationEngine.SearchAlgorithm algorithm =
-        ProcessOptimizationEngine.SearchAlgorithm.GOLDEN_SECTION;
+    private ProcessOptimizationEngine.SearchAlgorithm algorithm = ProcessOptimizationEngine.SearchAlgorithm.GOLDEN_SECTION;
     private int maxIterations = 50;
     private double tolerance = 1e-4;
 
@@ -6026,7 +6318,7 @@ public class ProcessSystem extends SimulationBaseClass {
     /**
      * Sets the inlet and outlet pressures.
      *
-     * @param inlet inlet pressure in bara
+     * @param inlet  inlet pressure in bara
      * @param outlet outlet pressure in bara
      * @return this builder for chaining
      */
@@ -6092,8 +6384,8 @@ public class ProcessSystem extends SimulationBaseClass {
       engine.setSearchAlgorithm(algorithm);
       engine.setMaxIterations(maxIterations);
       engine.setTolerance(tolerance);
-      ProcessOptimizationEngine.OptimizationResult result =
-          engine.findMaximumThroughput(inletPressure, outletPressure, minFlow, maxFlow);
+      ProcessOptimizationEngine.OptimizationResult result = engine.findMaximumThroughput(inletPressure, outletPressure,
+          minFlow, maxFlow);
       return result.getOptimalValue();
     }
 
@@ -6113,10 +6405,10 @@ public class ProcessSystem extends SimulationBaseClass {
     /**
      * Generates a lift curve with the configured settings.
      *
-     * @param pressures array of pressures to evaluate (bara)
+     * @param pressures    array of pressures to evaluate (bara)
      * @param temperatures array of temperatures to evaluate (K)
-     * @param waterCuts array of water cuts as fraction
-     * @param GORs array of gas-oil ratios in Sm3/Sm3
+     * @param waterCuts    array of water cuts as fraction
+     * @param GORs         array of gas-oil ratios in Sm3/Sm3
      * @return lift curve data
      */
     public ProcessOptimizationEngine.LiftCurveData generateLiftCurve(double[] pressures,
@@ -6130,8 +6422,10 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /*
-   * @XmlRootElement private class Report extends Object{ public Double name; public
-   * ArrayList<ReportInterface> unitOperationsReports = new ArrayList<ReportInterface>();
+   * @XmlRootElement private class Report extends Object{ public Double name;
+   * public
+   * ArrayList<ReportInterface> unitOperationsReports = new
+   * ArrayList<ReportInterface>();
    *
    * Report(){ name= getName();
    *
@@ -6155,12 +6449,14 @@ public class ProcessSystem extends SimulationBaseClass {
    * Initialize mechanical design for all equipment in the process.
    *
    * <p>
-   * This method calls initMechanicalDesign() on each equipment item, preparing them for mechanical
+   * This method calls initMechanicalDesign() on each equipment item, preparing
+   * them for mechanical
    * design calculations. Should be called after process simulation has run.
    * </p>
    *
    * <p>
-   * Workflow: ProcessSystem.run() → initAllMechanicalDesigns() → runAllMechanicalDesigns() →
+   * Workflow: ProcessSystem.run() → initAllMechanicalDesigns() →
+   * runAllMechanicalDesigns() →
    * getCostEstimate()
    * </p>
    */
@@ -6176,12 +6472,15 @@ public class ProcessSystem extends SimulationBaseClass {
    * Run mechanical design calculations for all equipment in the process.
    *
    * <p>
-   * This method calls calcDesign() on each equipment's mechanical design. Equipment must have had
-   * initMechanicalDesign() called first, or this method will call it automatically.
+   * This method calls calcDesign() on each equipment's mechanical design.
+   * Equipment must have had
+   * initMechanicalDesign() called first, or this method will call it
+   * automatically.
    * </p>
    *
    * <p>
-   * Workflow: ProcessSystem.run() → initAllMechanicalDesigns() → runAllMechanicalDesigns() →
+   * Workflow: ProcessSystem.run() → initAllMechanicalDesigns() →
+   * runAllMechanicalDesigns() →
    * getCostEstimate()
    * </p>
    */
@@ -6190,8 +6489,7 @@ public class ProcessSystem extends SimulationBaseClass {
       if (equipment != null) {
         // Ensure mechanical design is initialized
         equipment.initMechanicalDesign();
-        neqsim.process.mechanicaldesign.MechanicalDesign mecDesign =
-            equipment.getMechanicalDesign();
+        neqsim.process.mechanicaldesign.MechanicalDesign mecDesign = equipment.getMechanicalDesign();
         if (mecDesign != null) {
           mecDesign.calcDesign();
         }
@@ -6203,7 +6501,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Get the system-level mechanical design aggregator.
    *
    * <p>
-   * The SystemMechanicalDesign provides aggregated views of all equipment mechanical designs,
+   * The SystemMechanicalDesign provides aggregated views of all equipment
+   * mechanical designs,
    * including total weights, dimensions, and utility requirements.
    * </p>
    *
@@ -6234,12 +6533,15 @@ public class ProcessSystem extends SimulationBaseClass {
    * Get the process-level cost estimate.
    *
    * <p>
-   * The ProcessCostEstimate provides comprehensive cost estimation for the entire process,
-   * including purchased equipment cost, bare module cost, total module cost, and grass roots cost.
+   * The ProcessCostEstimate provides comprehensive cost estimation for the entire
+   * process,
+   * including purchased equipment cost, bare module cost, total module cost, and
+   * grass roots cost.
    * </p>
    *
    * <p>
-   * Workflow: ProcessSystem.run() → getCostEstimate() → calculateAllCosts() → toJson()
+   * Workflow: ProcessSystem.run() → getCostEstimate() → calculateAllCosts() →
+   * toJson()
    * </p>
    *
    * <p>
@@ -6312,8 +6614,10 @@ public class ProcessSystem extends SimulationBaseClass {
    * Get a comprehensive JSON report of mechanical design and cost estimation.
    *
    * <p>
-   * This method runs the full mechanical design and cost estimation workflow if not already done,
-   * then returns a combined JSON report including both mechanical design data and cost estimates.
+   * This method runs the full mechanical design and cost estimation workflow if
+   * not already done,
+   * then returns a combined JSON report including both mechanical design data and
+   * cost estimates.
    * </p>
    *
    * @return JSON string with combined mechanical design and cost estimate data
@@ -6412,7 +6716,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Initialize electrical design for all equipment in the process.
    *
    * <p>
-   * Calls initElectricalDesign() on each equipment item, preparing them for electrical design
+   * Calls initElectricalDesign() on each equipment item, preparing them for
+   * electrical design
    * calculations. Should be called after process simulation has run.
    * </p>
    */
@@ -6428,15 +6733,15 @@ public class ProcessSystem extends SimulationBaseClass {
    * Run electrical design calculations for all equipment in the process.
    *
    * <p>
-   * Calls calcDesign() on each equipment's electrical design. Automatically initializes electrical
+   * Calls calcDesign() on each equipment's electrical design. Automatically
+   * initializes electrical
    * designs that have not been initialized.
    * </p>
    */
   public void runAllElectricalDesigns() {
     for (ProcessEquipmentInterface equipment : unitOperations) {
       if (equipment != null) {
-        neqsim.process.electricaldesign.ElectricalDesign elecDesign =
-            equipment.getElectricalDesign();
+        neqsim.process.electricaldesign.ElectricalDesign elecDesign = equipment.getElectricalDesign();
         if (elecDesign != null) {
           elecDesign.calcDesign();
         }
@@ -6448,7 +6753,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Get the electrical load list for all equipment in the process.
    *
    * <p>
-   * Aggregates electrical loads from all equipment into a single load list with summary
+   * Aggregates electrical loads from all equipment into a single load list with
+   * summary
    * calculations for transformer and generator sizing.
    * </p>
    *
@@ -6469,8 +6775,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * @return the electrical load list
    */
   public neqsim.process.electricaldesign.loadanalysis.ElectricalLoadList getElectricalLoadList() {
-    neqsim.process.electricaldesign.loadanalysis.ElectricalLoadList loadList =
-        new neqsim.process.electricaldesign.loadanalysis.ElectricalLoadList(getName());
+    neqsim.process.electricaldesign.loadanalysis.ElectricalLoadList loadList = new neqsim.process.electricaldesign.loadanalysis.ElectricalLoadList(
+        getName());
 
     for (ProcessEquipmentInterface equipment : unitOperations) {
       if (equipment == null) {
@@ -6481,9 +6787,9 @@ public class ProcessSystem extends SimulationBaseClass {
         continue;
       }
 
-      neqsim.process.electricaldesign.loadanalysis.LoadItem item =
-          new neqsim.process.electricaldesign.loadanalysis.LoadItem(equipment.getName(),
-              equipment.getClass().getSimpleName(), elecDesign.getMotor().getRatedPowerKW());
+      neqsim.process.electricaldesign.loadanalysis.LoadItem item = new neqsim.process.electricaldesign.loadanalysis.LoadItem(
+          equipment.getName(),
+          equipment.getClass().getSimpleName(), elecDesign.getMotor().getRatedPowerKW());
       item.setAbsorbedPowerKW(elecDesign.getElectricalInputKW());
       item.setApparentPowerKVA(elecDesign.getApparentPowerKVA());
       item.setPowerFactor(elecDesign.getPowerFactor());
@@ -6522,30 +6828,33 @@ public class ProcessSystem extends SimulationBaseClass {
    * Create a system-level electrical design for the entire process.
    *
    * <p>
-   * Runs all equipment-level electrical designs and produces a plant-wide summary including utility
+   * Runs all equipment-level electrical designs and produces a plant-wide summary
+   * including utility
    * loads, UPS loads, and main transformer/generator sizing.
    * </p>
    *
    * @return the system electrical design with aggregated results
    */
   public neqsim.process.electricaldesign.system.SystemElectricalDesign getSystemElectricalDesign() {
-    neqsim.process.electricaldesign.system.SystemElectricalDesign systemDesign =
-        new neqsim.process.electricaldesign.system.SystemElectricalDesign(this);
+    neqsim.process.electricaldesign.system.SystemElectricalDesign systemDesign = new neqsim.process.electricaldesign.system.SystemElectricalDesign(
+        this);
     systemDesign.calcDesign();
     return systemDesign;
   }
 
   /**
    * <p>
-   * Get a system-wide instrument design summary that aggregates instrument lists, I/O counts, DCS
-   * and SIS cabinet sizing, and cost estimates across all equipment in this process system.
+   * Get a system-wide instrument design summary that aggregates instrument lists,
+   * I/O counts, DCS
+   * and SIS cabinet sizing, and cost estimates across all equipment in this
+   * process system.
    * </p>
    *
    * @return the system instrument design with aggregated results
    */
   public neqsim.process.instrumentdesign.system.SystemInstrumentDesign getSystemInstrumentDesign() {
-    neqsim.process.instrumentdesign.system.SystemInstrumentDesign systemDesign =
-        new neqsim.process.instrumentdesign.system.SystemInstrumentDesign(this);
+    neqsim.process.instrumentdesign.system.SystemInstrumentDesign systemDesign = new neqsim.process.instrumentdesign.system.SystemInstrumentDesign(
+        this);
     systemDesign.calcDesign();
     return systemDesign;
   }
@@ -6553,8 +6862,10 @@ public class ProcessSystem extends SimulationBaseClass {
   // ========================== Automation API ==========================
 
   /**
-   * Returns an automation facade for this process system. The facade provides a stable,
-   * string-addressable API for scripts and AI agents to interact with the simulation without
+   * Returns an automation facade for this process system. The facade provides a
+   * stable,
+   * string-addressable API for scripts and AI agents to interact with the
+   * simulation without
    * navigating Java object hierarchies.
    *
    * @return a {@link neqsim.process.automation.ProcessAutomation} facade
@@ -6564,7 +6875,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Returns the names of all unit operations in this process system. Convenience delegate for
+   * Returns the names of all unit operations in this process system. Convenience
+   * delegate for
    * {@link neqsim.process.automation.ProcessAutomation#getUnitList()}.
    *
    * @return unmodifiable list of unit operation names
@@ -6574,7 +6886,8 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Returns all available variables for the named unit operation. Convenience delegate for
+   * Returns all available variables for the named unit operation. Convenience
+   * delegate for
    * {@link neqsim.process.automation.ProcessAutomation#getVariableList(String)}.
    *
    * @param unitName the name of the unit operation
@@ -6586,11 +6899,13 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Reads the current value of a simulation variable by its dot-notation address. Convenience
+   * Reads the current value of a simulation variable by its dot-notation address.
+   * Convenience
    * delegate for
    * {@link neqsim.process.automation.ProcessAutomation#getVariableValue(String, String)}.
    *
-   * @param address the dot-notation address, e.g. "separator-1.gasOutStream.temperature"
+   * @param address       the dot-notation address, e.g.
+   *                      "separator-1.gasOutStream.temperature"
    * @param unitOfMeasure the desired unit, e.g. "C", "bara", "kg/hr"
    * @return the variable value in the requested unit
    * @throws IllegalArgumentException if the address cannot be resolved
@@ -6603,10 +6918,12 @@ public class ProcessSystem extends SimulationBaseClass {
    * Sets the value of a simulation input variable. Convenience delegate for
    * {@link neqsim.process.automation.ProcessAutomation#setVariableValue(String, double, String)}.
    *
-   * @param address the dot-notation address, e.g. "Compressor.outletPressure"
-   * @param value the value to set
+   * @param address       the dot-notation address, e.g.
+   *                      "Compressor.outletPressure"
+   * @param value         the value to set
    * @param unitOfMeasure the unit of the provided value, e.g. "bara", "C"
-   * @throws IllegalArgumentException if the address cannot be resolved or the variable is read-only
+   * @throws IllegalArgumentException if the address cannot be resolved or the
+   *                                  variable is read-only
    */
   public void setVariableValue(String address, double value, String unitOfMeasure) {
     getAutomation().setVariableValue(address, value, unitOfMeasure);

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -1621,7 +1621,7 @@ public class ProcessSystem extends SimulationBaseClass {
       if (levelGroups.size() == 1 && levelGroups.get(0).size() == 1) {
         // Single unit at this level - run directly (no thread pool overhead)
         ProcessEquipmentInterface unit = levelGroups.get(0).get(0).getEquipment();
-        if (!(unit instanceof Setter)) {
+        if (!(unit instanceof Setter) && unit.needRecalculation()) {
           try {
             runUnitProfiled(unit, id);
           } catch (Exception ex) {
@@ -1632,7 +1632,7 @@ public class ProcessSystem extends SimulationBaseClass {
         // Single group with multiple units sharing input streams - run sequentially
         for (ProcessNode node : levelGroups.get(0)) {
           ProcessEquipmentInterface unit = node.getEquipment();
-          if (!(unit instanceof Setter)) {
+          if (!(unit instanceof Setter) && unit.needRecalculation()) {
             try {
               runUnitProfiled(unit, id);
             } catch (Exception ex) {
@@ -1646,7 +1646,7 @@ public class ProcessSystem extends SimulationBaseClass {
         for (List<ProcessNode> group : levelGroups) {
           if (group.size() == 1) {
             final ProcessEquipmentInterface unitToRun = group.get(0).getEquipment();
-            if (!(unitToRun instanceof Setter)) {
+            if (!(unitToRun instanceof Setter) && unitToRun.needRecalculation()) {
               final UUID calcId = id;
               futures.add(neqsim.util.NeqSimThreadPool.submit(() -> {
                 try {
@@ -1663,7 +1663,7 @@ public class ProcessSystem extends SimulationBaseClass {
             futures.add(neqsim.util.NeqSimThreadPool.submit(() -> {
               for (ProcessNode node : groupToRun) {
                 ProcessEquipmentInterface unit = node.getEquipment();
-                if (!(unit instanceof Setter)) {
+                if (!(unit instanceof Setter) && unit.needRecalculation()) {
                   try {
                     runUnitProfiled(unit, calcId);
                   } catch (Exception ex) {

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -1196,15 +1196,14 @@ public class ProcessSystem extends SimulationBaseClass {
       // Calculator-containing processes must run sequentially.
       runSequential(id);
     } else if (hasRecycles()) {
-      // Process has Recycle units. Use hybrid execution which parallelizes the
-      // feed-forward levels before the recycle section and iterates on the rest.
-      try {
-        runHybrid(id);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        logger.warn("Hybrid execution interrupted, falling back to sequential");
-        runSequential(id);
-      }
+      // Process has Recycle units. runHybrid() uses needRecalculation() to skip
+      // unit re-runs on subsequent iterations, which converges to a slightly
+      // different fixed point than runSequential() for tightly coupled loops
+      // (e.g., OilGasProcessTest, GlycolRigTest water-balance). Until hybrid
+      // convergence is proven bit-identical to sequential, route recycle systems
+      // to sequential to preserve correctness. The feed-forward phase of hybrid
+      // was a minor win; real speedup comes from recycle-free parallel trains.
+      runSequential(id);
     } else if (hasMultiInputEquipment()) {
       // Process has multi-input equipment (Mixer, HeatExchanger, etc.) but no
       // recycles or adjusters. The graph correctly places multi-input equipment

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -1112,9 +1112,13 @@ public class ProcessSystem extends SimulationBaseClass {
   public void runOptimized(UUID id) {
     if (hasAdjusters() || hasCalculators()) {
       // Adjusters and Calculators create implicit feedback loops via signal
-      // connections (not stream connections). The graph partitioner only sees
-      // stream edges, so parallel execution can produce wrong orderings for
-      // these units. Sequential execution ensures correct evaluation order.
+      // connections. Signal edges for Calculator are now added to the graph by
+      // ProcessGraphBuilder, but the graph still has coverage gaps for outlet
+      // streams of complex multi-output equipment (SimpleTEGAbsorber, 3-phase
+      // Separator, DistillationColumn, Stripper). Those outlet streams appear as
+      // graph sources, causing Calculator to read stale values at the wrong
+      // topological level. Until that broader graph-coverage work is done,
+      // Calculator-containing processes must run sequentially.
       runSequential(id);
     } else if (hasRecycles()) {
       // Process has Recycle units. Use hybrid execution which parallelizes the

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -44,6 +44,7 @@ import neqsim.process.equipment.mixer.MixerInterface;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.equipment.util.Adjuster;
+import neqsim.process.equipment.util.Calculator;
 import neqsim.process.equipment.util.MultiVariableAdjuster;
 import neqsim.process.equipment.util.Recycle;
 import neqsim.process.equipment.util.RecycleController;
@@ -153,7 +154,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * processes with multi-input equipment (mixers, heat exchangers, etc.) to preserve correct mass
    * balance.
    */
-  private boolean useOptimizedExecution = false;
+  private boolean useOptimizedExecution = true;
 
   /**
    * Transient listener for simulation progress callbacks. Used for real-time visualization in
@@ -1109,10 +1110,11 @@ public class ProcessSystem extends SimulationBaseClass {
    * @param id calculation identifier for tracking
    */
   public void runOptimized(UUID id) {
-    if (hasAdjusters()) {
-      // Adjusters create implicit feedback loops (they modify upstream variables
-      // and read downstream targets). Sequential execution ensures correct
-      // evaluation order for adjuster convergence.
+    if (hasAdjusters() || hasCalculators()) {
+      // Adjusters and Calculators create implicit feedback loops via signal
+      // connections (not stream connections). The graph partitioner only sees
+      // stream edges, so parallel execution can produce wrong orderings for
+      // these units. Sequential execution ensures correct evaluation order.
       runSequential(id);
     } else if (hasRecycles()) {
       // Process has Recycle units. Use hybrid execution which parallelizes the
@@ -1166,6 +1168,26 @@ public class ProcessSystem extends SimulationBaseClass {
       }
     }
     cachedHasAdjusters = false;
+    return false;
+  }
+
+  /**
+   * Checks if the process contains any Calculator units.
+   *
+   * <p>
+   * Calculator units read input streams and write to an output stream property using signal
+   * connections rather than physical stream connections. They create implicit feedback loops that
+   * the graph-based partitioner does not detect, so parallel execution cannot place them correctly.
+   * </p>
+   *
+   * @return true if there are any Calculator units in the process
+   */
+  public boolean hasCalculators() {
+    for (ProcessEquipmentInterface unit : unitOperations) {
+      if (unit instanceof Calculator) {
+        return true;
+      }
+    }
     return false;
   }
 

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraph.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraph.java
@@ -287,6 +287,36 @@ public class ProcessGraph implements Serializable {
   }
 
   /**
+   * Adds a signal (non-stream) edge between two nodes.
+   *
+   * <p>
+   * Signal edges represent data dependencies that are not physical stream connections, such as
+   * Calculator input/output variable links. They carry no stream reference but participate in
+   * topological ordering so that dependent units execute in the correct sequence.
+   * </p>
+   *
+   * @param source source node
+   * @param target target node
+   * @param name descriptive name for the signal edge
+   * @param edgeType the edge type (typically {@link ProcessEdge.EdgeType#SIGNAL})
+   * @return the created edge
+   */
+  public ProcessEdge addSignalEdge(ProcessNode source, ProcessNode target, String name,
+      ProcessEdge.EdgeType edgeType) {
+    Objects.requireNonNull(source, "source cannot be null");
+    Objects.requireNonNull(target, "target cannot be null");
+
+    int index = edges.size();
+    ProcessEdge edge = new ProcessEdge(index, source, target, name, edgeType);
+    edges.add(edge);
+    source.addOutgoingEdge(edge);
+    target.addIncomingEdge(edge);
+
+    invalidateCache();
+    return edge;
+  }
+
+  /**
    * Adds an edge between two equipment units.
    *
    * @param sourceEquipment source equipment

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -23,6 +23,7 @@ import neqsim.process.equipment.manifold.Manifold;
 import neqsim.process.equipment.mixer.MixerInterface;
 import neqsim.process.equipment.splitter.SplitterInterface;
 import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.util.Calculator;
 import neqsim.process.processmodel.ProcessSystem;
 
 /**
@@ -326,6 +327,63 @@ public final class ProcessGraphBuilder {
 
       // Also check for inlet streams via reflection
       collectConsumedStreamsAndCreateEdges(unit, graph, streamToProducer);
+    }
+
+    // Third pass: add signal edges for Calculator units.
+    // Calculator reads from inputVariable equipment and writes to outputVariable
+    // equipment via signal connections (not physical streams). Without these edges
+    // the graph partitioner cannot order Calculator correctly, causing stale inputs
+    // and recycle non-convergence.
+    for (ProcessEquipmentInterface unit : units) {
+      if (unit instanceof Calculator) {
+        Calculator calc = (Calculator) unit;
+        ProcessNode calcNode = graph.getNode(calc);
+        if (calcNode == null) {
+          continue;
+        }
+
+        // Signal edges: each input variable equipment -> Calculator
+        for (ProcessEquipmentInterface inputEquip : calc.getInputVariable()) {
+          if (inputEquip == null) {
+            continue;
+          }
+          ProcessNode inputNode = graph.getNode(inputEquip);
+          if (inputNode != null && inputNode != calcNode) {
+            boolean edgeExists = false;
+            for (ProcessEdge edge : inputNode.getOutgoingEdges()) {
+              if (edge.getTarget() == calcNode) {
+                edgeExists = true;
+                break;
+              }
+            }
+            if (!edgeExists) {
+              graph.addSignalEdge(inputNode, calcNode,
+                  "signal:" + inputEquip.getName() + "->" + calc.getName(),
+                  ProcessEdge.EdgeType.SIGNAL);
+            }
+          }
+        }
+
+        // Signal edge: Calculator -> output variable equipment
+        ProcessEquipmentInterface outputEquip = calc.getOutputVariable();
+        if (outputEquip != null) {
+          ProcessNode outputNode = graph.getNode(outputEquip);
+          if (outputNode != null && outputNode != calcNode) {
+            boolean edgeExists = false;
+            for (ProcessEdge edge : calcNode.getOutgoingEdges()) {
+              if (edge.getTarget() == outputNode) {
+                edgeExists = true;
+                break;
+              }
+            }
+            if (!edgeExists) {
+              graph.addSignalEdge(calcNode, outputNode,
+                  "signal:" + calc.getName() + "->" + outputEquip.getName(),
+                  ProcessEdge.EdgeType.SIGNAL);
+            }
+          }
+        }
+      }
     }
 
     return graph;

--- a/src/main/java/neqsim/thermo/component/Component.java
+++ b/src/main/java/neqsim/thermo/component/Component.java
@@ -560,7 +560,7 @@ public abstract class Component implements ComponentInterface {
 
   /** {@inheritDoc} */
   @Override
-  public synchronized Component clone() {
+  public Component clone() {
     Component clonedComponent = null;
     try {
       clonedComponent = (Component) super.clone();

--- a/src/main/java/neqsim/thermo/component/Component.java
+++ b/src/main/java/neqsim/thermo/component/Component.java
@@ -32,7 +32,7 @@ public abstract class Component implements ComponentInterface {
   /** Conversion factor from mmHg to bar. */
   private static final double MMHG_TO_BAR = 1.0 / 750.061683;
 
-  double[] surfTensInfluenceParam = {0.28367, -0.05164, -0.81594, 1.06810, -1.1147};
+  double[] surfTensInfluenceParam = { 0.28367, -0.05164, -0.81594, 1.06810, -1.1147 };
   /** Index number of Component in database. */
   protected int index;
   /** Index number of Component in Phase object component array. */
@@ -42,7 +42,8 @@ public abstract class Component implements ComponentInterface {
 
   // TODO: what does "HC", "inert" and "Component" mean?
   /**
-   * Type of component. Can be "normal", "TBP", "plus", "ion", but what does "HC", "inert" and
+   * Type of component. Can be "normal", "TBP", "plus", "ion", but what does "HC",
+   * "inert" and
    * "Component?" do?
    */
   private String componentType = "Component";
@@ -56,7 +57,10 @@ public abstract class Component implements ComponentInterface {
    * <code>numberOfMoles = totalNumberOfMoles * z</code>.
    */
   protected double numberOfMoles = 0.0;
-  /** Number of moles of Component in Phase. Ideally <code>totalNumberOfMoles * x * beta</code>. */
+  /**
+   * Number of moles of Component in Phase. Ideally
+   * <code>totalNumberOfMoles * x * beta</code>.
+   */
   protected double numberOfMolesInPhase = 0.0;
   protected double K;
 
@@ -188,7 +192,8 @@ public abstract class Component implements ComponentInterface {
   private double associationEnergySAFT = 0;
   private double associationEnergySAFTVRMie = 0;
   /**
-   * SAFT-VR Mie bond volume K_HB in m^3 (Lafitte 2013 Eq. 39). For water: 101.69 Angstrom^3 =
+   * SAFT-VR Mie bond volume K_HB in m^3 (Lafitte 2013 Eq. 39). For water: 101.69
+   * Angstrom^3 =
    * 1.0169e-28 m^3. If zero, falls back to kappa * sigma^3 (PC-SAFT convention).
    */
   private double associationVolumeSAFTVRMie = 0;
@@ -199,11 +204,11 @@ public abstract class Component implements ComponentInterface {
    * </p>
    *
    * @param number a int. Not used.
-   * @param TC Critical temperature [K]
-   * @param PC Critical pressure [bara]
-   * @param M Molar mass
-   * @param a Acentric factor
-   * @param moles Total number of moles of component.
+   * @param TC     Critical temperature [K]
+   * @param PC     Critical pressure [bara]
+   * @param M      Molar mass
+   * @param a      Acentric factor
+   * @param moles  Total number of moles of component.
    */
   public Component(int number, double TC, double PC, double M, double a, double moles) {
     criticalPressure = PC;
@@ -218,10 +223,11 @@ public abstract class Component implements ComponentInterface {
    * Constructor for Component.
    * </p>
    *
-   * @param name Name of component.
-   * @param moles Total number of moles of component.
+   * @param name         Name of component.
+   * @param moles        Total number of moles of component.
    * @param molesInPhase Number of moles in phase.
-   * @param compIndex Index number of component in phase object component array.
+   * @param compIndex    Index number of component in phase object component
+   *                     array.
    */
   public Component(String name, double moles, double molesInPhase, int compIndex) {
     createComponent(name, moles, molesInPhase, compIndex);
@@ -388,12 +394,9 @@ public abstract class Component implements ComponentInterface {
         TwuCoonParams[1] = Double.parseDouble(dataSet.getString("TwuCoon2"));
         TwuCoonParams[2] = Double.parseDouble(dataSet.getString("TwuCoon3"));
 
-        liquidConductivityParameter[0] =
-            Double.parseDouble(dataSet.getString("liquidConductivity1"));
-        liquidConductivityParameter[1] =
-            Double.parseDouble(dataSet.getString("liquidConductivity2"));
-        liquidConductivityParameter[2] =
-            Double.parseDouble(dataSet.getString("liquidConductivity3"));
+        liquidConductivityParameter[0] = Double.parseDouble(dataSet.getString("liquidConductivity1"));
+        liquidConductivityParameter[1] = Double.parseDouble(dataSet.getString("liquidConductivity2"));
+        liquidConductivityParameter[2] = Double.parseDouble(dataSet.getString("liquidConductivity3"));
 
         if (this.getClass().getName().equals("neqsim.thermo.component.ComponentSrkCPA")
             || this.getClass().getName().equals("neqsim.thermo.component.ComponentSrkCPAs")) {
@@ -417,16 +420,13 @@ public abstract class Component implements ComponentInterface {
         idealGasAbsoluteEntropy = Double.parseDouble(dataSet.getString("AbsoluteEntropy"));
 
         for (int i = 0; i < 5; i++) {
-          solidDensityCoefs[i] =
-              Double.parseDouble((dataSet.getString("solidDensityCoefs" + (i + 1))));
+          solidDensityCoefs[i] = Double.parseDouble((dataSet.getString("solidDensityCoefs" + (i + 1))));
         }
         for (int i = 0; i < 5; i++) {
-          liquidDensityCoefs[i] =
-              Double.parseDouble((dataSet.getString("liquidDensityCoefs" + (i + 1))));
+          liquidDensityCoefs[i] = Double.parseDouble((dataSet.getString("liquidDensityCoefs" + (i + 1))));
         }
         for (int i = 0; i < 5; i++) {
-          heatOfVaporizationCoefs[i] =
-              Double.parseDouble((dataSet.getString("heatOfVaporizationCoefs" + (i + 1))));
+          heatOfVaporizationCoefs[i] = Double.parseDouble((dataSet.getString("heatOfVaporizationCoefs" + (i + 1))));
         }
         // disse maa settes inn fra database ssociationsites
         numberOfAssociationSites = Integer.parseInt(dataSet.getString("associationsites"));
@@ -448,8 +448,7 @@ public abstract class Component implements ComponentInterface {
           mCPA = Double.parseDouble(dataSet.getString("mCPA_PR"));
         } else {
           // System.out.println("srk-cpa");
-          associationVolume =
-              Double.parseDouble(dataSet.getString("associationboundingvolume_SRK"));
+          associationVolume = Double.parseDouble(dataSet.getString("associationboundingvolume_SRK"));
           aCPA = Double.parseDouble(dataSet.getString("aCPA_SRK"));
           bCPA = Double.parseDouble(dataSet.getString("bCPA_SRK"));
           mCPA = Double.parseDouble(dataSet.getString("mCPA_SRK"));
@@ -457,9 +456,8 @@ public abstract class Component implements ComponentInterface {
 
         criticalViscosity = Double.parseDouble(dataSet.getString("criticalViscosity"));
         if (criticalViscosity < 1e-20) {
-          criticalViscosity =
-              7.94830 * Math.sqrt(1e3 * molarMass) * Math.pow(criticalPressure, 2.0 / 3.0)
-                  / Math.pow(criticalTemperature, 1.0 / 6.0) * 1e-7;
+          criticalViscosity = 7.94830 * Math.sqrt(1e3 * molarMass) * Math.pow(criticalPressure, 2.0 / 3.0)
+              / Math.pow(criticalTemperature, 1.0 / 6.0) * 1e-7;
         }
         mSAFTi = Double.parseDouble(dataSet.getString("mSAFT"));
         sigmaSAFTi = Double.parseDouble(dataSet.getString("sigmaSAFT")) / 1.0e10;
@@ -497,12 +495,12 @@ public abstract class Component implements ComponentInterface {
             associationVolumeSAFTVRMie = kHB;
           }
         } catch (Exception ex) {
-          // Column not available or zero - will compute from PCSAFT kappa * sigma^3 as fallback
+          // Column not available or zero - will compute from PCSAFT kappa * sigma^3 as
+          // fallback
         }
         if (Math.abs(criticalViscosity) < 1e-12) {
-          criticalViscosity =
-              7.94830 * Math.sqrt(molarMass * 1e3) * Math.pow(criticalPressure, 2.0 / 3.0)
-                  / Math.pow(criticalTemperature, 1.0 / 6.0) * 1e-7;
+          criticalViscosity = 7.94830 * Math.sqrt(molarMass * 1e3) * Math.pow(criticalPressure, 2.0 / 3.0)
+              / Math.pow(criticalTemperature, 1.0 / 6.0) * 1e-7;
         }
         // System.out.println("crit visc " + criticalViscosity);
         if (normalLiquidDensity == 0) {
@@ -658,7 +656,8 @@ public abstract class Component implements ComponentInterface {
   /** {@inheritDoc} */
   @Override
   public void Finit(PhaseInterface phase, double temp, double pres, double totMoles, double beta,
-      int numberOfComponents, int initType) {}
+      int numberOfComponents, int initType) {
+  }
 
   /** {@inheritDoc} */
   @Override
@@ -765,8 +764,7 @@ public abstract class Component implements ComponentInterface {
   /** {@inheritDoc} */
   @Override
   public final double getTC(String unit) {
-    neqsim.util.unit.TemperatureUnit tempConversion =
-        new neqsim.util.unit.TemperatureUnit(criticalTemperature, "K");
+    neqsim.util.unit.TemperatureUnit tempConversion = new neqsim.util.unit.TemperatureUnit(criticalTemperature, "K");
     return tempConversion.getValue(unit);
   }
 
@@ -817,8 +815,7 @@ public abstract class Component implements ComponentInterface {
   /** {@inheritDoc} */
   @Override
   public final double getPC(String unit) {
-    neqsim.util.unit.PressureUnit presConversion =
-        new neqsim.util.unit.PressureUnit(criticalPressure, "bara");
+    neqsim.util.unit.PressureUnit presConversion = new neqsim.util.unit.PressureUnit(criticalPressure, "bara");
     return presConversion.getValue(unit);
   }
 
@@ -1158,7 +1155,8 @@ public abstract class Component implements ComponentInterface {
   @Override
   public double logfugcoefdT(PhaseInterface phase) {
     dfugdt = 0.0;
-    // this.fugcoefDiffTemp(phase, phase.getNumberOfComponents(), phase.getTemperature(),
+    // this.fugcoefDiffTemp(phase, phase.getNumberOfComponents(),
+    // phase.getTemperature(),
     // phase.getPressure());
     return dfugdt;
   }
@@ -1167,7 +1165,8 @@ public abstract class Component implements ComponentInterface {
   @Override
   public double logfugcoefdP(PhaseInterface phase) {
     dfugdp = 0.0;
-    // this.fugcoefDiffPres(phase, phase.getNumberOfComponents(), phase.getTemperature(),
+    // this.fugcoefDiffPres(phase, phase.getNumberOfComponents(),
+    // phase.getTemperature(),
     // phase.getPressure());
     return dfugdp;
   }
@@ -1295,7 +1294,7 @@ public abstract class Component implements ComponentInterface {
    * getFugacitydN.
    * </p>
    *
-   * @param i a int
+   * @param i     a int
    * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
    * @return a double
    */
@@ -1331,7 +1330,7 @@ public abstract class Component implements ComponentInterface {
    * getChemicalPotentialdP.
    * </p>
    *
-   * @param i a int
+   * @param i     a int
    * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
    * @return a double
    */
@@ -1711,7 +1710,7 @@ public abstract class Component implements ComponentInterface {
    * Setter for the field <code>matiascopemanParamsPR</code>.
    * </p>
    *
-   * @param index a int
+   * @param index               a int
    * @param matiascopemanParams a double
    */
   public void setMatiascopemanParamsPR(int index, double matiascopemanParams) {
@@ -1793,8 +1792,8 @@ public abstract class Component implements ComponentInterface {
   /** {@inheritDoc} */
   @Override
   public double getNormalBoilingPoint(String unit) {
-    neqsim.util.unit.TemperatureUnit tempConversion =
-        new neqsim.util.unit.TemperatureUnit(getNormalBoilingPoint(), "K");
+    neqsim.util.unit.TemperatureUnit tempConversion = new neqsim.util.unit.TemperatureUnit(getNormalBoilingPoint(),
+        "K");
     return tempConversion.getValue(unit);
   }
 
@@ -2108,7 +2107,8 @@ public abstract class Component implements ComponentInterface {
   /**
    * Setter for property matiascopemanSolidParams.
    *
-   * @param matiascopemanSolidParams New value of property matiascopemanSolidParams.
+   * @param matiascopemanSolidParams New value of property
+   *                                 matiascopemanSolidParams.
    */
   public void setMatiascopemanSolidParams(double[] matiascopemanSolidParams) {
     this.matiascopemanSolidParams = matiascopemanSolidParams;

--- a/src/main/java/neqsim/thermo/mixingrule/EosMixingRuleHandler.java
+++ b/src/main/java/neqsim/thermo/mixingrule/EosMixingRuleHandler.java
@@ -136,7 +136,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
    * getMixingRule.
    * </p>
    *
-   * @param mr a int
+   * @param mr    a int
    * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
    * @return a {@link neqsim.thermo.mixingrule.EosMixingRulesInterface} object
    */
@@ -256,19 +256,16 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
                   String componenti = component_name;
                   String componentj = component_name2;
                   double acentricFactori = phase.getComponent(k).getAcentricFactor();
-                  double reducedTemperaturei =
-                      phase.getComponent(k).reducedTemperature(phase.getTemperature());
-                  double salinityConcentration =
-                      ((PhaseSoreideWhitson) phase).getSalinityConcentration();
+                  double reducedTemperaturei = phase.getComponent(k).reducedTemperature(phase.getTemperature());
+                  double salinityConcentration = ((PhaseSoreideWhitson) phase).getSalinityConcentration();
                   double kij = 0.0;
 
                   if (componentj.equalsIgnoreCase("water") || componentj.equalsIgnoreCase("H2O")) {
                     if (componenti.equalsIgnoreCase("N2")
                         || componenti.equalsIgnoreCase("nitrogen")) {
-                      kij =
-                          0.997 * (-1.70235 * (1 + 0.025587 * Math.pow(salinityConcentration, 0.75))
-                              + 0.44338 * (1 + 0.08126 * Math.pow(salinityConcentration, 0.75))
-                                  * reducedTemperaturei);
+                      kij = 0.997 * (-1.70235 * (1 + 0.025587 * Math.pow(salinityConcentration, 0.75))
+                          + 0.44338 * (1 + 0.08126 * Math.pow(salinityConcentration, 0.75))
+                              * reducedTemperaturei);
                     } else if (componenti.equalsIgnoreCase("CO2")) {
                       double multipK = 1.0;
                       if (salinityConcentration > 3.5) {
@@ -534,7 +531,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
    * resetMixingRule.
    * </p>
    *
-   * @param i a int
+   * @param i     a int
    * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
    * @return a {@link neqsim.thermo.mixingrule.EosMixingRulesInterface} object
    */
@@ -782,7 +779,8 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
       return intparam;
     }
 
-    public void prettyPrintKij() {}
+    public void prettyPrintKij() {
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -874,7 +872,8 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
     /**
      * Setter for property CalcEOSInteractionParameters.
      *
-     * @param CalcEOSInteractionParameters2 New value of property CalcEOSInteractionParameters.
+     * @param CalcEOSInteractionParameters2 New value of property
+     *                                      CalcEOSInteractionParameters.
      */
     @Override
     public void setCalcEOSInteractionParameters(boolean CalcEOSInteractionParameters2) {
@@ -1348,7 +1347,8 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
   public class ClassicSRKT extends ClassicSRK {
     int type = 0;
 
-    public ClassicSRKT() {}
+    public ClassicSRKT() {
+    }
 
     public ClassicSRKT(int type) {
       this.type = type;
@@ -1693,8 +1693,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
         for (int j = 0; j < numbcomp; j++) {
           aij = -Math.sqrt(compArray[i].getaT() * compArray[j].getaT())
               * getkijdndn(compNumb, compNumbj, phase, temperature, i, j);
-          A2 +=
-              compArray[i].getNumberOfMolesInPhase() * compArray[j].getNumberOfMolesInPhase() * aij;
+          A2 += compArray[i].getNumberOfMolesInPhase() * compArray[j].getNumberOfMolesInPhase() * aij;
         }
       }
 
@@ -2056,10 +2055,9 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
         String[][] mixRule) {
       ComponentEosInterface[] compArray = (ComponentEosInterface[]) phase.getcomponentArray();
       this.orgPhase = phase;
-      hwfc =
-          1.0 / (compArray[0].getDeltaEosParameters()[1] - compArray[0].getDeltaEosParameters()[0])
-              * Math.log((1.0 + compArray[0].getDeltaEosParameters()[1])
-                  / (1.0 + compArray[0].getDeltaEosParameters()[0]));
+      hwfc = 1.0 / (compArray[0].getDeltaEosParameters()[1] - compArray[0].getDeltaEosParameters()[0])
+          * Math.log((1.0 + compArray[0].getDeltaEosParameters()[1])
+              / (1.0 + compArray[0].getDeltaEosParameters()[0]));
       gePhase = new PhaseGENRTLmodifiedHV(orgPhase, HValpha, HVDij, mixRule, intparam);
       gePhase.getExcessGibbsEnergy(phase, phase.getNumberOfComponents(), phase.getTemperature(),
           phase.getPressure(), PhaseType.GAS);
@@ -2070,10 +2068,9 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
         double[][] HVDijT, String[][] mixRule) {
       ComponentEosInterface[] compArray = (ComponentEosInterface[]) phase.getcomponentArray();
       this.orgPhase = phase;
-      hwfc =
-          1.0 / (compArray[0].getDeltaEosParameters()[1] - compArray[0].getDeltaEosParameters()[0])
-              * Math.log((1.0 + compArray[0].getDeltaEosParameters()[1])
-                  / (1.0 + compArray[0].getDeltaEosParameters()[0]));
+      hwfc = 1.0 / (compArray[0].getDeltaEosParameters()[1] - compArray[0].getDeltaEosParameters()[0])
+          * Math.log((1.0 + compArray[0].getDeltaEosParameters()[1])
+              / (1.0 + compArray[0].getDeltaEosParameters()[0]));
       gePhase = new PhaseGENRTLmodifiedHV(orgPhase, HValpha, HVDij, HVDijT, mixRule, intparam);
       gePhase.getExcessGibbsEnergy(phase, phase.getNumberOfComponents(), phase.getTemperature(),
           phase.getPressure(), PhaseType.GAS);
@@ -2328,9 +2325,9 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
     /**
      * Constructor for SRKHuronVidal2.
      *
-     * @param phase the phase interface
+     * @param phase   the phase interface
      * @param HValpha the HV alpha parameter matrix
-     * @param HVDij the HV Dij parameter matrix
+     * @param HVDij   the HV Dij parameter matrix
      * @param mixRule the mixing rule matrix
      */
     public SRKHuronVidal2(PhaseInterface phase, double[][] HValpha, double[][] HVDij,
@@ -2384,10 +2381,10 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
     /**
      * init.
      *
-     * @param phase Phase to initialize for.
+     * @param phase       Phase to initialize for.
      * @param temperature Temperature to initialize at.
-     * @param pressure Pressure to initialize at.
-     * @param numbcomp Number of components.
+     * @param pressure    Pressure to initialize at.
+     * @param numbcomp    Number of components.
      */
     public void init(PhaseInterface phase, double temperature, double pressure, int numbcomp) {
       ComponentEosInterface[] compArray = (ComponentEosInterface[]) phase.getcomponentArray();
@@ -2435,12 +2432,11 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
         if (phase.getInitType() > 1) {
           qPuredT[i] = -compArray[i].getaT() / (compArray[i].getb() * R * temperature * temperature)
               + compArray[i].diffaT(temperature) / (compArray[i].getb() * R * temperature);
-          qPuredTdT[i] =
-              2.0 * compArray[i].getaT() / (compArray[i].getb() * R * Math.pow(temperature, 3.0))
-                  - compArray[i].getaDiffT() / (compArray[i].getb() * R * temperature * temperature)
-                  + compArray[i].getaDiffDiffT() / (compArray[i].getb() * R * temperature)
-                  - compArray[i].getaDiffT()
-                      / (compArray[i].getb() * R * temperature * temperature);
+          qPuredTdT[i] = 2.0 * compArray[i].getaT() / (compArray[i].getb() * R * Math.pow(temperature, 3.0))
+              - compArray[i].getaDiffT() / (compArray[i].getb() * R * temperature * temperature)
+              + compArray[i].getaDiffDiffT() / (compArray[i].getb() * R * temperature)
+              - compArray[i].getaDiffT()
+                  / (compArray[i].getb() * R * temperature * temperature);
         }
       }
 
@@ -2450,16 +2446,14 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
       double term = 0.0;
       double dubdert = 0.0;
       for (int i = 0; i < numbcomp; i++) {
-        term =
-            qPure[i] + hwfc * Math.log(((ComponentGEInterface) gePhase.getComponent(i)).getGamma());
+        term = qPure[i] + hwfc * Math.log(((ComponentGEInterface) gePhase.getComponent(i)).getGamma());
         alpha_mix += phase.getComponent(i).getNumberOfMolesInPhase()
             / phase.getNumberOfMolesInPhase() * term;
         ader[i] = term;
         compArray[i].setAder(ader[i]);
 
         if (phase.getInitType() > 1) {
-          term =
-              qPuredT[i] + hwfc * ((ComponentGEInterface) gePhase.getComponent(i)).getLnGammadt();
+          term = qPuredT[i] + hwfc * ((ComponentGEInterface) gePhase.getComponent(i)).getLnGammadt();
           dubdert += (qPuredTdT[i]
               + hwfc * ((ComponentGEInterface) gePhase.getComponent(i)).getLnGammadtdt())
               * phase.getComponent(i).getNumberOfMolesInPhase() / phase.getNumberOfMolesInPhase();
@@ -2764,11 +2758,10 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
         qPure[i] = compArray[i].getaT() / (compArray[i].getb() * R * temperature);
         qPuredT[i] = -compArray[i].getaT() / (compArray[i].getb() * R * temperature * temperature)
             + compArray[i].diffaT(temperature) / (compArray[i].getb() * R * temperature);
-        qPuredTdT[i] =
-            2.0 * compArray[i].getaT() / (compArray[i].getb() * R * Math.pow(temperature, 3.0))
-                - compArray[i].getaDiffT() / (compArray[i].getb() * R * Math.pow(temperature, 2.0))
-                + compArray[i].getaDiffDiffT() / (compArray[i].getb() * R * temperature)
-                - compArray[i].getaDiffT() / (compArray[i].getb() * R * Math.pow(temperature, 2.0));
+        qPuredTdT[i] = 2.0 * compArray[i].getaT() / (compArray[i].getb() * R * Math.pow(temperature, 3.0))
+            - compArray[i].getaDiffT() / (compArray[i].getb() * R * Math.pow(temperature, 2.0))
+            + compArray[i].getaDiffDiffT() / (compArray[i].getb() * R * temperature)
+            - compArray[i].getaDiffT() / (compArray[i].getb() * R * Math.pow(temperature, 2.0));
       }
 
       double sd2 = (2 * hex - cpex * temperature) / Math.pow(temperature, 3.0);
@@ -2781,8 +2774,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
       alpha_mix = 0.0;
       dadt = 0.0;
       for (int i = 0; i < numbcomp; i++) {
-        double term =
-            qPure[i] + hwfc * Math.log(((ComponentGEInterface) gePhase.getComponent(i)).getGamma());
+        double term = qPure[i] + hwfc * Math.log(((ComponentGEInterface) gePhase.getComponent(i)).getGamma());
         alpha_mix += phase.getComponent(i).getNumberOfMolesInPhase()
             / phase.getNumberOfMolesInPhase() * term;
         ader[i] = term;
@@ -2818,8 +2810,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
           ssi += (1.0 - WSintparam[i][j]) * (abft2[i] + abft2[j])
               * phase.getComponent(j).getNumberOfMolesInPhase() / phase.getNumberOfMolesInPhase();
         }
-        dd2 +=
-            phase.getComponent(i).getNumberOfMolesInPhase() / phase.getNumberOfMolesInPhase() * ssi;
+        dd2 += phase.getComponent(i).getNumberOfMolesInPhase() / phase.getNumberOfMolesInPhase() * ssi;
       }
       dd2 = 0.5 * dd2;
 
@@ -2850,8 +2841,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
               / phase.getNumberOfMolesInPhase();
         }
         QFTD[i] = sst;
-        QT +=
-            phase.getComponent(i).getNumberOfMolesInPhase() / phase.getNumberOfMolesInPhase() * sst;
+        QT += phase.getComponent(i).getNumberOfMolesInPhase() / phase.getNumberOfMolesInPhase() * sst;
       }
       double d_mix = 0.5 * Q;
       double d_mixt = 0.5 * QT;
@@ -2874,8 +2864,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
 
       for (int i = 0; i < numbcomp; i++) {
         for (int j = 0; j < numbcomp; j++) {
-          bd2[i][j] =
-              (qf2[i][j] + b_mix * ad2[i][j] + BDER[j] * ader[i] + BDER[i] * ader[j]) * enumr;
+          bd2[i][j] = (qf2[i][j] + b_mix * ad2[i][j] + BDER[j] * ader[i] + BDER[i] * ader[j]) * enumr;
           compArray[i].setdBdndn(j, ad2[i][j]);
         }
       }
@@ -3030,8 +3019,10 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
     private static final long serialVersionUID = 1000;
 
     /**
-     * Flag to enable predictive descriptor-based Wij model. When true, uses solvent dielectric
-     * constant to compute Wij parameters universally. When false (default), uses solvent-specific
+     * Flag to enable predictive descriptor-based Wij model. When true, uses solvent
+     * dielectric
+     * constant to compute Wij parameters universally. When false (default), uses
+     * solvent-specific
      * fitted parameter tables.
      */
     private boolean usePredictiveModel = false;
@@ -3049,8 +3040,9 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
     /**
      * Enable or disable the predictive descriptor-based Wij model.
      *
-     * @param usePredictive true to use predictive model based on dielectric constant, false to use
-     *        solvent-specific fitted parameters
+     * @param usePredictive true to use predictive model based on dielectric
+     *                      constant, false to use
+     *                      solvent-specific fitted parameters
      */
     public void setUsePredictiveModel(boolean usePredictive) {
       this.usePredictiveModel = usePredictive;
@@ -3114,137 +3106,119 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
               if (solventName.equals("water")) {
                 // Water: use water-fitted CPA parameters
                 if (isDivalent) {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(6)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamCPA(7);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(6)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamCPA(7);
                 } else {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(2)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamCPA(3);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(2)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamCPA(3);
                 }
               } else if (solventName.equals("MDEA")) {
                 // MDEA: use MDEA-specific parameters
                 if (isDivalent) {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMDEA(6)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamMDEA(7);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMDEA(6)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamMDEA(7);
                 } else {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMDEA(2)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamMDEA(3);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMDEA(2)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamMDEA(3);
                 }
               } else if (solventName.equals("Piperazine")) {
                 // Piperazine: use water parameters as approximation (no specific data)
                 if (isDivalent) {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(6)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamCPA(7);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(6)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamCPA(7);
                 } else {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(2)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamCPA(3);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(2)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamCPA(3);
                 }
               } else if (solventName.equals("MEG") || solventName.equals("ethylene glycol")) {
                 // MEG: use MEG-specific parameters
                 if (isDivalent) {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEG(6)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamMEG(7);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEG(6)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamMEG(7);
                 } else {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEG(2)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamMEG(3);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEG(2)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamMEG(3);
                 }
               } else if (solventName.equals("methanol")) {
                 // Methanol: use methanol-specific parameters
                 if (isDivalent) {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMeOH(6)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamMeOH(7);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMeOH(6)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamMeOH(7);
                 } else {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMeOH(2)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamMeOH(3);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMeOH(2)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamMeOH(3);
                 }
               } else if (solventName.equals("TEG") || solventName.equals("triethylene glycol")) {
                 // TEG: use MEG parameters as approximation (similar glycol structure)
                 if (isDivalent) {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEG(6)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamMEG(7);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEG(6)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamMEG(7);
                 } else {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEG(2)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamMEG(3);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEG(2)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamMEG(3);
                 }
               } else if (solventName.equals("ethanol")) {
                 // Ethanol: use ethanol-specific parameters
                 if (isDivalent) {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamEtOH(6)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamEtOH(7);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamEtOH(6)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamEtOH(7);
                 } else {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamEtOH(2)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamEtOH(3);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamEtOH(2)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamEtOH(3);
                 }
               } else if (solventName.equals("MEA")) {
                 // MEA (monoethanolamine): use MEA-specific parameters
                 if (isDivalent) {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEA(6)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamMEA(7);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEA(6)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamMEA(7);
                 } else {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEA(2)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamMEA(3);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMEA(2)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamMEA(3);
                 }
               } else if (solventName.equals("TEG")) {
                 // TEG (triethylene glycol): use TEG-specific parameters
                 if (isDivalent) {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTEG(6)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamTEG(7);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTEG(6)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamTEG(7);
                 } else {
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTEG(2)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamTEG(3);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTEG(2)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamTEG(3);
                 }
               } else if (compArray[j].getIonicCharge() == 0) {
                 // Unknown neutral solvent: use predictive model based on dielectric constant
@@ -3252,8 +3226,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
                 double solventEpsilon = compArray[j].getDielectricConstant(298.15);
                 if (solventEpsilon < 1.0) {
                   // Fallback for components without dielectric data: use water parameters
-                  solventEpsilon =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.EPSILON_WATER_REF;
+                  solventEpsilon = neqsim.thermo.util.constants.FurstElectrolyteConstants.EPSILON_WATER_REF;
                 }
                 wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants
                     .getPredictiveWij(solventEpsilon, stokesDiam, isDivalent);
@@ -3267,48 +3240,41 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
 
                 if (isDivalent) {
                   // Divalent cation-anion
-                  wij[0][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(8)
-                          * diamSum4
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamCPA(9);
+                  wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(8)
+                      * diamSum4
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamCPA(9);
                   // Temperature-dependent terms for divalent cation-anion
-                  wij[1][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(12)
-                          * diamSum4
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamTDep(13);
-                  wij[2][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(14)
-                          * diamSum4
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamTDep(15);
+                  wij[1][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(12)
+                      * diamSum4
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamTDep(13);
+                  wij[2][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(14)
+                      * diamSum4
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamTDep(15);
                 } else {
                   // Monovalent cation-anion: use water-fitted parameters
                   if (compArray[i].getComponentName().equals("MDEA+")) {
-                    wij[0][i][j] =
-                        neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMDEA(4)
-                            * diamSum4
-                            + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                                .getFurstParamMDEA(5);
+                    wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamMDEA(4)
+                        * diamSum4
+                        + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                            .getFurstParamMDEA(5);
                   } else {
-                    wij[0][i][j] =
-                        neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(4)
-                            * diamSum4
-                            + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                                .getFurstParamCPA(5);
+                    wij[0][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamCPA(4)
+                        * diamSum4
+                        + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                            .getFurstParamCPA(5);
                   }
                   // Temperature-dependent terms for monovalent cation-anion
-                  wij[1][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(4)
-                          * diamSum4
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamTDep(5);
-                  wij[2][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(6)
-                          * diamSum4
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamTDep(7);
+                  wij[1][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(4)
+                      * diamSum4
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamTDep(5);
+                  wij[2][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(6)
+                      * diamSum4
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamTDep(7);
                 }
               } else if (compArray[j].getIonicCharge() == 0) {
                 // Cation-solvent: add temperature-dependent terms
@@ -3316,27 +3282,23 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
                   wij[1][i][j] = 0.0;
                   wij[2][i][j] = 0.0;
                 } else if (isDivalent) {
-                  wij[1][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(8)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamTDep(9);
-                  wij[2][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(10)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamTDep(11);
+                  wij[1][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(8)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamTDep(9);
+                  wij[2][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(10)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamTDep(11);
                 } else {
-                  wij[1][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(0)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamTDep(1);
-                  wij[2][i][j] =
-                      neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(2)
-                          * stokesDiam
-                          + neqsim.thermo.util.constants.FurstElectrolyteConstants
-                              .getFurstParamTDep(3);
+                  wij[1][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(0)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamTDep(1);
+                  wij[2][i][j] = neqsim.thermo.util.constants.FurstElectrolyteConstants.getFurstParamTDep(2)
+                      * stokesDiam
+                      + neqsim.thermo.util.constants.FurstElectrolyteConstants
+                          .getFurstParamTDep(3);
                 }
               }
               wij[0][j][i] = wij[0][i][j];
@@ -3348,14 +3310,16 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
       }
 
       // Handle gas-ion interactions for salting out effect
-      // CO2, CH4, and other hydrocarbons have specific interaction parameters with ions
+      // CO2, CH4, and other hydrocarbons have specific interaction parameters with
+      // ions
       // The Wij compensates for implicit salting effect from FSR2eps*epsi term
       //
       // The implicit salting effect from FSR2eps*epsi varies significantly across
       // different ion types in complex ways that depend on ion size, charge, and
       // ion-solvent interactions. Simple correlations cannot capture this complexity.
       //
-      // Current approach: Use fixed parameters calibrated for Na+/Cl- (the most common
+      // Current approach: Use fixed parameters calibrated for Na+/Cl- (the most
+      // common
       // electrolyte in process simulations). This gives ~10% salting out at 1 mol/kg,
       // matching the experimental Setchenow coefficient k_s ~ 0.1 L/mol.
       //
@@ -3363,8 +3327,10 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
       // gas-ion interaction parameters to exhibit correct salting-out behavior.
       // Without these, adding hydrocarbons can cause incorrect salting-in effects.
       //
-      // Limitations: Other ion pairs (K+, MDEA+, HCO3-, Ca++, etc.) may show different
-      // salting behavior. For accurate predictions with specific ion pairs, ion-specific
+      // Limitations: Other ion pairs (K+, MDEA+, HCO3-, Ca++, etc.) may show
+      // different
+      // salting behavior. For accurate predictions with specific ion pairs,
+      // ion-specific
       // parameters should be fitted and stored in the database.
       //
       // Reference: Na+/Cl- validation at 298 K:
@@ -3394,8 +3360,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
         boolean isH2 = nameI.equals("hydrogen") || nameI.equals("h2");
 
         // Check if this is a non-polar gas/hydrocarbon that needs gas-ion parameters
-        boolean isNonPolarGas =
-            isCO2 || isCH4 || isC2H6 || isC3H8 || isC4 || isC5plus || isN2 || isH2S || isH2;
+        boolean isNonPolarGas = isCO2 || isCH4 || isC2H6 || isC3H8 || isC4 || isC5plus || isN2 || isH2S || isH2;
 
         if (isNonPolarGas) {
           for (int j = 0; j < numbcomp; j++) {
@@ -3450,8 +3415,10 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
         }
       }
 
-      // Handle organic inhibitor-ion (OI-ion) interactions for additive hydrate inhibition
-      // Per Hu-Lee-Sum correlation (AIChE Journal, 2017-2018), the water activity effects
+      // Handle organic inhibitor-ion (OI-ion) interactions for additive hydrate
+      // inhibition
+      // Per Hu-Lee-Sum correlation (AIChE Journal, 2017-2018), the water activity
+      // effects
       // from salts and organic inhibitors should be ADDITIVE:
       // ln(a_w) = ln(a_w^salt) + ln(a_w^OI)
       //
@@ -3652,7 +3619,8 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
    * </p>
    *
    * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
-   * @return a {@link neqsim.thermo.mixingrule.ElectrolyteMixingRulesInterface} object
+   * @return a {@link neqsim.thermo.mixingrule.ElectrolyteMixingRulesInterface}
+   *         object
    */
   public ElectrolyteMixingRulesInterface getElectrolyteMixingRule(PhaseInterface phase) {
     return new ElectrolyteMixRule(phase);
@@ -3805,7 +3773,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
    * </p>
    *
    * @param intType a {@link java.lang.String} object
-   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
+   * @param phase   a {@link neqsim.thermo.phase.PhaseInterface} object
    */
   @ExcludeFromJacocoGeneratedReport
   public void displayInteractionCoefficients(String intType, PhaseInterface phase) {
@@ -3820,8 +3788,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
 
     // String[][] table = new String[getPhases()[0].getNumberOfComponents() +
     // 30][7];
-    String[][] interactTable =
-        new String[phase.getNumberOfComponents() + 1][phase.getNumberOfComponents() + 1];
+    String[][] interactTable = new String[phase.getNumberOfComponents() + 1][phase.getNumberOfComponents() + 1];
     String[] names = new String[phase.getNumberOfComponents() + 1];
     names[0] = "";
     for (int i = 0; i < phase.getNumberOfComponents(); i++) {

--- a/src/main/java/neqsim/thermo/mixingrule/EosMixingRuleHandler.java
+++ b/src/main/java/neqsim/thermo/mixingrule/EosMixingRuleHandler.java
@@ -595,7 +595,7 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
 
   /** {@inheritDoc} */
   @Override
-  public synchronized EosMixingRuleHandler clone() {
+  public EosMixingRuleHandler clone() {
     EosMixingRuleHandler clonedSystem = null;
     try {
       clonedSystem = (EosMixingRuleHandler) super.clone();

--- a/src/main/java/neqsim/thermo/phase/Phase.java
+++ b/src/main/java/neqsim/thermo/phase/Phase.java
@@ -27,14 +27,19 @@ import neqsim.util.exception.InvalidInputException;
  * Abstract Phase class. All Phase classes shall subclass this class.
  *
  * <p>
- * From wiki: A phase is a region of a space (a thermodynamic system), in neqsim named a
- * SystemInterface, throughout which all physical properties of a material are essentially uniform.
+ * From wiki: A phase is a region of a space (a thermodynamic system), in neqsim
+ * named a
+ * SystemInterface, throughout which all physical properties of a material are
+ * essentially uniform.
  * A SystemInterface can contain a single or multiple PhaseInterface objects.
  *
- * See PhaseType for the types of Phases that NeqSim is aware of. See also StateOfMatter.
+ * See PhaseType for the types of Phases that NeqSim is aware of. See also
+ * StateOfMatter.
  *
- * In NeqSim, there are multiple Phase classes, each representing a specific set of Equations Of
- * State. Phases have corresponding Component classes and System classes to ensure same EoS is used
+ * In NeqSim, there are multiple Phase classes, each representing a specific set
+ * of Equations Of
+ * State. Phases have corresponding Component classes and System classes to
+ * ensure same EoS is used
  * throughout.
  * </p>
  *
@@ -47,7 +52,8 @@ public abstract class Phase implements PhaseInterface {
   static Logger logger = LogManager.getLogger(Phase.class);
 
   /**
-   * Inverse of water molality (1/55.51 mol/kg). Used for converting activity coefficients from mole
+   * Inverse of water molality (1/55.51 mol/kg). Used for converting activity
+   * coefficients from mole
    * fraction scale to molality scale: γ_m = γ_x * x_w / 55.51
    */
   private static final double INV_WATER_MOLALITY = 1.0 / 55.51;
@@ -74,13 +80,15 @@ public abstract class Phase implements PhaseInterface {
 
   /**
    * Mole fraction of this phase of system.
-   * <code>beta = numberOfMolesInPhase/numberOfMolesInSystem</code>. NB! numberOfMolesInSystem is
+   * <code>beta = numberOfMolesInPhase/numberOfMolesInSystem</code>. NB!
+   * numberOfMolesInSystem is
    * not known to the phase.
    */
   double beta = 1.0;
 
   /**
-   * Number of moles in phase. <code>numberOfMolesInPhase = numberOfMolesInSystem*beta</code>. NB!
+   * Number of moles in phase.
+   * <code>numberOfMolesInPhase = numberOfMolesInSystem*beta</code>. NB!
    * numberOfMolesInSystem is not known to the phase.
    */
   public double numberOfMolesInPhase = 0;
@@ -139,8 +147,8 @@ public abstract class Phase implements PhaseInterface {
    * NB! Does not actually add component to componentarray.
    * </p>
    *
-   * @param name Name of component to add.
-   * @param moles Number of moles of component to add to phase.
+   * @param name       Name of component to add.
+   * @param moles      Number of moles of component to add to phase.
    * @param compNumber component number in fluid
    */
   public void addComponent(String name, double moles, int compNumber) {
@@ -242,7 +250,8 @@ public abstract class Phase implements PhaseInterface {
       String msg = "will lead to negative number of moles in phase." + newPhaseMoles;
       /*
        * neqsim.util.exception.InvalidInputException ex = new
-       * neqsim.util.exception.InvalidInputException(this, "addMolesChemReac", "dn", msg);
+       * neqsim.util.exception.InvalidInputException(this, "addMolesChemReac", "dn",
+       * msg);
        */
       logger.debug(msg);
       dn = -numberOfMolesInPhase;
@@ -350,8 +359,7 @@ public abstract class Phase implements PhaseInterface {
   /** {@inheritDoc} */
   @Override
   public double getTemperature(String unit) {
-    neqsim.util.unit.TemperatureUnit tempConversion =
-        new neqsim.util.unit.TemperatureUnit(getTemperature(), "K");
+    neqsim.util.unit.TemperatureUnit tempConversion = new neqsim.util.unit.TemperatureUnit(getTemperature(), "K");
     return tempConversion.getValue(unit);
   }
 
@@ -364,8 +372,7 @@ public abstract class Phase implements PhaseInterface {
   /** {@inheritDoc} */
   @Override
   public final double getPressure(String unit) {
-    neqsim.util.unit.PressureUnit presConversion =
-        new neqsim.util.unit.PressureUnit(getPressure(), "bara");
+    neqsim.util.unit.PressureUnit presConversion = new neqsim.util.unit.PressureUnit(getPressure(), "bara");
     return presConversion.getValue(unit);
   }
 
@@ -586,11 +593,11 @@ public abstract class Phase implements PhaseInterface {
    * calcA.
    * </p>
    *
-   * @param comp a int
-   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
+   * @param comp        a int
+   * @param phase       a {@link neqsim.thermo.phase.PhaseInterface} object
    * @param temperature a double
-   * @param pressure a double
-   * @param numbcomp a int
+   * @param pressure    a double
+   * @param numbcomp    a int
    * @return a double
    */
   public double calcA(int comp, PhaseInterface phase, double temperature, double pressure,
@@ -1056,11 +1063,13 @@ public abstract class Phase implements PhaseInterface {
   }
 
   /**
-   * Calculates the heat capacity at constant pressure (Cp) in the specified units. {@inheritDoc}
+   * Calculates the heat capacity at constant pressure (Cp) in the specified
+   * units. {@inheritDoc}
    */
   @Override
   public double getCp(String unit) {
-    // The reference heat capacity (refCp) is the total heat capacity for the phase in J/K.
+    // The reference heat capacity (refCp) is the total heat capacity for the phase
+    // in J/K.
     double refCp = getCp();
 
     switch (unit) {
@@ -1068,7 +1077,8 @@ public abstract class Phase implements PhaseInterface {
         // No conversion needed as the base unit is J/K.
         return refCp;
       case "J/molK":
-        // To get molar heat capacity, divide the total heat capacity by the number of moles.
+        // To get molar heat capacity, divide the total heat capacity by the number of
+        // moles.
         if (getNumberOfMolesInPhase() == 0) {
           throw new ArithmeticException(
               "Number of moles in phase cannot be zero for J/molK conversion.");
@@ -1081,7 +1091,8 @@ public abstract class Phase implements PhaseInterface {
         }
         return refCp / getNumberOfMolesInPhase() / 1000.0;
       case "J/kgK": {
-        // To get specific heat capacity, divide the total heat capacity by the total mass.
+        // To get specific heat capacity, divide the total heat capacity by the total
+        // mass.
         // Total mass = moles in phase * molar mass (in kg/mol).
         double totalMass = getNumberOfMolesInPhase() * getMolarMass();
         if (totalMass == 0) {
@@ -1126,11 +1137,13 @@ public abstract class Phase implements PhaseInterface {
   }
 
   /**
-   * Calculates the heat capacity at constant volume (Cv) in the specified units. {@inheritDoc}
+   * Calculates the heat capacity at constant volume (Cv) in the specified units.
+   * {@inheritDoc}
    */
   @Override
   public double getCv(String unit) {
-    // The reference heat capacity (refCv) is the total heat capacity for the phase in J/K.
+    // The reference heat capacity (refCv) is the total heat capacity for the phase
+    // in J/K.
     double refCv = getCv();
 
     switch (unit) {
@@ -1138,7 +1151,8 @@ public abstract class Phase implements PhaseInterface {
         // No conversion needed as the base unit is J/K.
         return refCv;
       case "J/molK":
-        // To get molar heat capacity, divide the total heat capacity by the number of moles.
+        // To get molar heat capacity, divide the total heat capacity by the number of
+        // moles.
         if (getNumberOfMolesInPhase() == 0) {
           throw new ArithmeticException(
               "Number of moles in phase cannot be zero for J/molK conversion.");
@@ -1151,7 +1165,8 @@ public abstract class Phase implements PhaseInterface {
         }
         return refCv / getNumberOfMolesInPhase() / 1000.0;
       case "J/kgK": {
-        // To get specific heat capacity, divide the total heat capacity by the total mass.
+        // To get specific heat capacity, divide the total heat capacity by the total
+        // mass.
         // Total mass = moles in phase * molar mass (in kg/mol).
         double totalMass = getNumberOfMolesInPhase() * getMolarMass();
         if (totalMass == 0) {
@@ -1212,7 +1227,8 @@ public abstract class Phase implements PhaseInterface {
    */
   @Override
   public double getEnthalpy(String unit) {
-    // The reference enthalpy (refEnthalpy) is the total enthalpy for the phase in Joules.
+    // The reference enthalpy (refEnthalpy) is the total enthalpy for the phase in
+    // Joules.
     double refEnthalpy = getEnthalpy();
 
     switch (unit) {
@@ -1273,7 +1289,8 @@ public abstract class Phase implements PhaseInterface {
   /** {@inheritDoc} */
   @Override
   public double getInternalEnergy(String unit) {
-    // The reference internal energy (refInternalEnergy) is the total internal energy for the phase
+    // The reference internal energy (refInternalEnergy) is the total internal
+    // energy for the phase
     // in Joules.
     double refInternalEnergy = getInternalEnergy();
 
@@ -1535,7 +1552,7 @@ public abstract class Phase implements PhaseInterface {
    * </p>
    *
    * @param onlyPure a boolean
-   * @param name a {@link java.lang.String} object
+   * @param name     a {@link java.lang.String} object
    */
   public void initRefPhases(boolean onlyPure, String name) {
     refPhase = new PhaseInterface[numberOfComponents];
@@ -1588,7 +1605,7 @@ public abstract class Phase implements PhaseInterface {
    * getLogPureComponentFugacity.
    * </p>
    *
-   * @param k a int
+   * @param k    a int
    * @param pure a boolean
    * @return a double
    */
@@ -1746,7 +1763,8 @@ public abstract class Phase implements PhaseInterface {
 
     // Conversion from mole fraction to molality scale:
     // From a_i = γ_x * x_i = γ_m * m_i / m° and m_i = (x_i / x_w) * (1000 / M_w)
-    // we get: γ_m = γ_x * x_w / 55.51 (where 55.51 mol/kg is molality of pure water)
+    // we get: γ_m = γ_x * x_w / 55.51 (where 55.51 mol/kg is molality of pure
+    // water)
     // Note: This conversion is independent of total molality and component i
     if (scale.equalsIgnoreCase("molality")) {
       return gammaX * xWater * INV_WATER_MOLALITY;
@@ -1797,9 +1815,12 @@ public abstract class Phase implements PhaseInterface {
    * {@inheritDoc}
    *
    * <p>
-   * Calculates the mean ionic activity coefficient on the molality scale. NeqSim uses the
-   * unsymmetric convention for ions (γ → 1 as x → 0, i.e., infinite dilution reference state). The
-   * conversion from unsymmetric mole fraction scale (γ±,x) to molality scale (γ±,m) is:
+   * Calculates the mean ionic activity coefficient on the molality scale. NeqSim
+   * uses the
+   * unsymmetric convention for ions (γ → 1 as x → 0, i.e., infinite dilution
+   * reference state). The
+   * conversion from unsymmetric mole fraction scale (γ±,x) to molality scale
+   * (γ±,m) is:
    * </p>
    *
    * <pre>
@@ -1807,14 +1828,18 @@ public abstract class Phase implements PhaseInterface {
    * </pre>
    *
    * <p>
-   * This relationship arises because the unsymmetric standard state (infinite dilution) already
-   * incorporates the 1/55.51 factor that would appear in the symmetric convention. For the
-   * symmetric convention (γ → 1 as x → 1), the full formula would be: γ±,m = γ±,x(sym) * x_water /
+   * This relationship arises because the unsymmetric standard state (infinite
+   * dilution) already
+   * incorporates the 1/55.51 factor that would appear in the symmetric
+   * convention. For the
+   * symmetric convention (γ → 1 as x → 1), the full formula would be: γ±,m =
+   * γ±,x(sym) * x_water /
    * 55.51
    * </p>
    *
    * <p>
-   * Reference: Robinson, R.A. and Stokes, R.H. "Electrolyte Solutions", 2nd ed., Butterworths,
+   * Reference: Robinson, R.A. and Stokes, R.H. "Electrolyte Solutions", 2nd ed.,
+   * Butterworths,
    * London, 1965, Appendix 8.10.
    * </p>
    */
@@ -1830,7 +1855,8 @@ public abstract class Phase implements PhaseInterface {
 
     double xWater = getComponent(watNumb).getx();
 
-    // Get activity coefficients on mole fraction scale, raised to stoichiometric powers
+    // Get activity coefficients on mole fraction scale, raised to stoichiometric
+    // powers
     // For electrolyte C_ν+ A_ν-: γ± = (γ+^ν+ * γ-^ν-)^(1/(ν+ + ν-))
     double nuPlus = Math.abs(getComponent(comp2).getIonicCharge()); // stoichiometric coeff of comp1
     double nuMinus = Math.abs(getComponent(comp1).getIonicCharge()); // stoichiometric coeff of
@@ -1862,7 +1888,8 @@ public abstract class Phase implements PhaseInterface {
    * {@inheritDoc}
    *
    * <p>
-   * Calculates the osmotic coefficient using the Robinson &amp; Stokes (1965) definition on the
+   * Calculates the osmotic coefficient using the Robinson &amp; Stokes (1965)
+   * definition on the
    * molality scale. The formula used is mathematically equivalent to:
    * </p>
    *
@@ -1879,7 +1906,8 @@ public abstract class Phase implements PhaseInterface {
    * </pre>
    *
    * <p>
-   * where a_w is water activity, x_w is water mole fraction, and Σx_i is sum of ion mole fractions.
+   * where a_w is water activity, x_w is water mole fraction, and Σx_i is sum of
+   * ion mole fractions.
    * </p>
    */
   @Override
@@ -2192,7 +2220,8 @@ public abstract class Phase implements PhaseInterface {
    * {@inheritDoc}
    *
    * <p>
-   * Default uses activity-based pH since NeqSim's chemical reaction equilibrium constants are
+   * Default uses activity-based pH since NeqSim's chemical reaction equilibrium
+   * constants are
    * defined on the mole fraction scale.
    * </p>
    */
@@ -2217,12 +2246,14 @@ public abstract class Phase implements PhaseInterface {
     }
     if (method.equalsIgnoreCase("activity")) {
     }
-    // Default to activity (consistent with mole fraction-based equilibrium constants)
+    // Default to activity (consistent with mole fraction-based equilibrium
+    // constants)
     return getpH_activity();
   }
 
   /**
-   * Calculate pH based on molarity (mol/L) with molarity-scale activity coefficient.
+   * Calculate pH based on molarity (mol/L) with molarity-scale activity
+   * coefficient.
    *
    * @return pH value: -log10(gamma_c * [H3O+]) where [H3O+] is in mol/L
    */
@@ -2254,10 +2285,12 @@ public abstract class Phase implements PhaseInterface {
   }
 
   /**
-   * Calculate pH based on molality (IUPAC standard: mol H3O+ / kg water) with molality-scale
+   * Calculate pH based on molality (IUPAC standard: mol H3O+ / kg water) with
+   * molality-scale
    * activity coefficient.
    *
-   * @return pH value: -log10(gamma_m * m_H3O+ / m_standard) where m_standard = 1 mol/kg
+   * @return pH value: -log10(gamma_m * m_H3O+ / m_standard) where m_standard = 1
+   *         mol/kg
    */
   private double getpH_molality() {
     for (int i = 0; i < numberOfComponents; i++) {
@@ -2298,7 +2331,8 @@ public abstract class Phase implements PhaseInterface {
   /**
    * Calculate pH based on activity (mole fraction * activity coefficient).
    *
-   * @return pH value based on H3O+ activity, or NaN if result is physically unrealistic
+   * @return pH value based on H3O+ activity, or NaN if result is physically
+   *         unrealistic
    */
   private double getpH_activity() {
     for (int i = 0; i < numberOfComponents; i++) {
@@ -2308,8 +2342,7 @@ public abstract class Phase implements PhaseInterface {
           watNumb = getComponent("water").getComponentNumber();
         }
 
-        double gamma =
-            watNumb >= 0 ? getActivityCoefficient(i, watNumb) : getActivityCoefficient(i);
+        double gamma = watNumb >= 0 ? getActivityCoefficient(i, watNumb) : getActivityCoefficient(i);
 
         double activity = componentArray[i].getx() * gamma;
         // Check for numerically invalid activity (essentially zero or numerical noise)
@@ -2413,7 +2446,8 @@ public abstract class Phase implements PhaseInterface {
   /** {@inheritDoc} */
   @Override
   public void setParams(PhaseInterface phase, double[][] alpha, double[][] Dij, double[][] DijT,
-      String[][] mixRule, double[][] intparam) {}
+      String[][] mixRule, double[][] intparam) {
+  }
 
   /** {@inheritDoc} */
   @Override
@@ -2779,8 +2813,8 @@ public abstract class Phase implements PhaseInterface {
   /** {@inheritDoc} */
   @Override
   public double getDensity_Leachman(String hydrogenType) {
-    neqsim.thermo.util.leachman.NeqSimLeachman test =
-        new neqsim.thermo.util.leachman.NeqSimLeachman(this, hydrogenType);
+    neqsim.thermo.util.leachman.NeqSimLeachman test = new neqsim.thermo.util.leachman.NeqSimLeachman(this,
+        hydrogenType);
     return test.getDensity();
   }
 
@@ -2788,8 +2822,10 @@ public abstract class Phase implements PhaseInterface {
    * {@inheritDoc}
    *
    * <p>
-   * If no hydrogenType is specified it checks the component name and chooses the correct hydrogen.
-   * Checks for other components in the phase and throws an exception if the phase is not pure.
+   * If no hydrogenType is specified it checks the component name and chooses the
+   * correct hydrogen.
+   * Checks for other components in the phase and throws an exception if the phase
+   * is not pure.
    * </p>
    */
   @Override
@@ -2827,8 +2863,8 @@ public abstract class Phase implements PhaseInterface {
   /** {@inheritDoc} */
   @Override
   public double[] getProperties_Leachman(String hydrogenType) {
-    neqsim.thermo.util.leachman.NeqSimLeachman test =
-        new neqsim.thermo.util.leachman.NeqSimLeachman(this, hydrogenType);
+    neqsim.thermo.util.leachman.NeqSimLeachman test = new neqsim.thermo.util.leachman.NeqSimLeachman(this,
+        hydrogenType);
     return test.propertiesLeachman();
   }
 
@@ -2836,8 +2872,10 @@ public abstract class Phase implements PhaseInterface {
    * {@inheritDoc}
    *
    * <p>
-   * If no hydrogentype is specified it checks the component name and chooses the correct hydrogen.
-   * Checks for other components in the phase and throws an exception if the phase is not pure.
+   * If no hydrogentype is specified it checks the component name and chooses the
+   * correct hydrogen.
+   * Checks for other components in the phase and throws an exception if the phase
+   * is not pure.
    * </p>
    */
   @Override
@@ -2875,8 +2913,8 @@ public abstract class Phase implements PhaseInterface {
   /** {@inheritDoc} */
   @Override
   public doubleW[] getAlpha0_Leachman(String hydrogenType) {
-    neqsim.thermo.util.leachman.NeqSimLeachman test =
-        new neqsim.thermo.util.leachman.NeqSimLeachman(this, hydrogenType);
+    neqsim.thermo.util.leachman.NeqSimLeachman test = new neqsim.thermo.util.leachman.NeqSimLeachman(this,
+        hydrogenType);
     return test.getAlpha0_Leachman();
   }
 
@@ -2884,8 +2922,10 @@ public abstract class Phase implements PhaseInterface {
    * {@inheritDoc}
    *
    * <p>
-   * If no hydrogentype is specified it checks the component name and chooses the correct hydrogen.
-   * Checks for other components in the phase and throws an exception if the phase is not pure.
+   * If no hydrogentype is specified it checks the component name and chooses the
+   * correct hydrogen.
+   * Checks for other components in the phase and throws an exception if the phase
+   * is not pure.
    * </p>
    */
   @Override
@@ -2923,8 +2963,8 @@ public abstract class Phase implements PhaseInterface {
   /** {@inheritDoc} */
   @Override
   public doubleW[][] getAlphares_Leachman(String hydrogenType) {
-    neqsim.thermo.util.leachman.NeqSimLeachman test =
-        new neqsim.thermo.util.leachman.NeqSimLeachman(this, hydrogenType);
+    neqsim.thermo.util.leachman.NeqSimLeachman test = new neqsim.thermo.util.leachman.NeqSimLeachman(this,
+        hydrogenType);
     return test.getAlphares_Leachman();
   }
 
@@ -2932,8 +2972,10 @@ public abstract class Phase implements PhaseInterface {
    * {@inheritDoc}
    *
    * <p>
-   * If no hydrogentype is specified it checks the component name and chooses the correct hydrogen.
-   * Checks for other components in the phase and throws an exception if the phase is not pure.
+   * If no hydrogentype is specified it checks the component name and chooses the
+   * correct hydrogen.
+   * Checks for other components in the phase and throws an exception if the phase
+   * is not pure.
    * </p>
    */
   @Override
@@ -2971,8 +3013,7 @@ public abstract class Phase implements PhaseInterface {
   /** {@inheritDoc} */
   @Override
   public double getDensity_AGA8() {
-    neqsim.thermo.util.gerg.NeqSimAGA8Detail test =
-        new neqsim.thermo.util.gerg.NeqSimAGA8Detail(this);
+    neqsim.thermo.util.gerg.NeqSimAGA8Detail test = new neqsim.thermo.util.gerg.NeqSimAGA8Detail(this);
     return test.getDensity();
   }
 

--- a/src/main/java/neqsim/thermo/phase/Phase.java
+++ b/src/main/java/neqsim/thermo/phase/Phase.java
@@ -117,7 +117,7 @@ public abstract class Phase implements PhaseInterface {
 
   /** {@inheritDoc} */
   @Override
-  public synchronized Phase clone() {
+  public Phase clone() {
     Phase clonedPhase = null;
 
     try {

--- a/src/main/java/neqsim/thermo/phase/PhaseEos.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseEos.java
@@ -44,7 +44,7 @@ public abstract class PhaseEos extends Phase implements PhaseEosInterface {
 
   /** {@inheritDoc} */
   @Override
-  public synchronized PhaseEos clone() {
+  public PhaseEos clone() {
     PhaseEos clonedPhase = null;
     try {
       clonedPhase = (PhaseEos) super.clone();
@@ -52,12 +52,17 @@ public abstract class PhaseEos extends Phase implements PhaseEosInterface {
       logger.error("Cloning failed.", ex);
     }
 
-    // Note: This is a shallow copy for mixSelect and mixRule.
-    // The cloned phase shares the same mixing rule handler as the original.
-    // For thread-safe parallel execution, synchronization must be used when
-    // accessing shared mixing rule state.
-    // Deep copy was attempted but caused issues with CPA mixing rules where
-    // getMixingRule(int) doesn't fully initialize the mixing rule parameters.
+    // Thread-safety contract: mixSelect and mixRule are shared (shallow) with the
+    // parent. This is safe for concurrent flashing on parent and clone because the
+    // interaction-parameter matrices (intparam, intparamT, HVDij, NRTLDij,
+    // WSintparam,
+    // NRTLalpha, ...) are written exclusively by setMixingRule() during fluid setup
+    // and are treated as read-only during flash calculations. Callers MUST NOT
+    // invoke setMixingRule() on a fluid (or any of its clones) while another thread
+    // is performing a flash on a sibling clone. EosMixingRuleHandler.clone() is
+    // available for callers that need fully-independent matrix copies (e.g., when
+    // tuning kij in parallel); it is intentionally not invoked here to keep clone()
+    // cheap on the hot path.
     return clonedPhase;
   }
 

--- a/src/main/java/neqsim/thermo/phase/PhaseEos.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseEos.java
@@ -229,13 +229,13 @@ public abstract class PhaseEos extends Phase implements PhaseEosInterface {
    * molarVolume2.
    * </p>
    *
-   * @param pressure a double
+   * @param pressure    a double
    * @param temperature a double
-   * @param A a double
-   * @param B a double
-   * @param pt the PhaseType of the phase
+   * @param A           a double
+   * @param B           a double
+   * @param pt          the PhaseType of the phase
    * @return a double
-   * @throws neqsim.util.exception.IsNaNException if any.
+   * @throws neqsim.util.exception.IsNaNException             if any.
    * @throws neqsim.util.exception.TooManyIterationsException if any.
    */
   public double molarVolume2(double pressure, double temperature, double A, double B, PhaseType pt)
@@ -317,12 +317,13 @@ public abstract class PhaseEos extends Phase implements PhaseEosInterface {
   }
 
   /**
-   * Analytic molar volume solver for cubic equations of state. Used as a fallback when the
+   * Analytic molar volume solver for cubic equations of state. Used as a fallback
+   * when the
    * numerical solver does not converge.
    *
-   * @param pressure system pressure
+   * @param pressure    system pressure
    * @param temperature system temperature
-   * @param pt phase type (gas or liquid)
+   * @param pt          phase type (gas or liquid)
    * @return molar volume [m3/mol * 1e5]
    * @throws neqsim.util.exception.IsNaNException if no real roots are found
    */
@@ -548,10 +549,10 @@ public abstract class PhaseEos extends Phase implements PhaseEosInterface {
    * calcAT.
    * </p>
    *
-   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
+   * @param phase       a {@link neqsim.thermo.phase.PhaseInterface} object
    * @param temperature a double
-   * @param pressure a double
-   * @param numbcomp a int
+   * @param pressure    a double
+   * @param numbcomp    a int
    * @return a double
    */
   public double calcAT(PhaseInterface phase, double temperature, double pressure, int numbcomp) {
@@ -564,10 +565,10 @@ public abstract class PhaseEos extends Phase implements PhaseEosInterface {
    * calcATT.
    * </p>
    *
-   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
+   * @param phase       a {@link neqsim.thermo.phase.PhaseInterface} object
    * @param temperature a double
-   * @param pressure a double
-   * @param numbcomp a int
+   * @param pressure    a double
+   * @param numbcomp    a int
    * @return a double
    */
   public double calcATT(PhaseInterface phase, double temperature, double pressure, int numbcomp) {
@@ -1312,8 +1313,7 @@ public abstract class PhaseEos extends Phase implements PhaseEosInterface {
     }
 
     for (int i = 0; i < numberOfComponents; i++) {
-      matrix[i][numberOfComponents] =
-          (FBT + FBD * AT) * Bi[i] + FDT * Ai[i] + FD * componentArray[i].getAiT(); // dFdndT
+      matrix[i][numberOfComponents] = (FBT + FBD * AT) * Bi[i] + FDT * Ai[i] + FD * componentArray[i].getAiT(); // dFdndT
       matrix[numberOfComponents][i] = matrix[i][numberOfComponents];
 
       matrix[i][numberOfComponents + 1] = FnV + FBV * Bi[i] + FDV * Ai[i]; // dFdndV

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -1449,7 +1449,7 @@ public abstract class SystemThermo implements SystemInterface {
 
   /** {@inheritDoc} */
   @Override
-  public synchronized SystemThermo clone() {
+  public SystemThermo clone() {
     SystemThermo clonedSystem = null;
     try {
       clonedSystem = (SystemThermo) super.clone();

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -57,7 +57,7 @@ public abstract class SystemThermo implements SystemInterface {
 
   /** Fraction of moles_in_phase / moles_in_system. Cached. */
   protected double[] beta = new double[MAX_PHASES];
-  protected String[] CapeOpenProperties10 = {"molecularWeight", "speedOfSound",
+  protected String[] CapeOpenProperties10 = { "molecularWeight", "speedOfSound",
       "jouleThomsonCoefficient", "energy", "energy.Dtemperature", "gibbsFreeEnergy",
       "helmholtzFreeEnergy", "fugacityCoefficient", "logFugacityCoefficient",
       "logFugacityCoefficient.Dtemperature", "logFugacityCoefficient.Dpressure",
@@ -66,9 +66,9 @@ public abstract class SystemThermo implements SystemInterface {
       "entropy.Dmoles", "heatCapacity", "heatCapacityCv", "density", "density.Dtemperature",
       "density.Dpressure", "density.Dmoles", "volume", "volume.Dpressure", "volume.Dtemperature",
       "molecularWeight.Dtemperature", "molecularWeight.Dpressure", "molecularWeight.Dmoles",
-      "compressibilityFactor"};
+      "compressibilityFactor" };
   // protected ArrayList<String> resultArray1 = new ArrayList<String>();
-  protected String[] CapeOpenProperties11 = {"molecularWeight", "speedOfSound",
+  protected String[] CapeOpenProperties11 = { "molecularWeight", "speedOfSound",
       "jouleThomsonCoefficient", "internalEnergy", "internalEnergy.Dtemperature", "gibbsEnergy",
       "helmholtzEnergy", "fugacityCoefficient", "logFugacityCoefficient",
       "logFugacityCoefficient.Dtemperature", "logFugacityCoefficient.Dpressure",
@@ -77,7 +77,7 @@ public abstract class SystemThermo implements SystemInterface {
       "entropy.Dmoles", "heatCapacityCp", "heatCapacityCv", "density", "density.Dtemperature",
       "density.Dpressure", "density.Dmoles", "volume", "volume.Dpressure", "volume.Dtemperature",
       "molecularWeight.Dtemperature", "molecularWeight.Dpressure", "molecularWeight.Dmoles",
-      "compressibilityFactor"};
+      "compressibilityFactor" };
 
   public neqsim.thermo.characterization.Characterise characterization = null;
   protected boolean checkStability = true;
@@ -130,12 +130,14 @@ public abstract class SystemThermo implements SystemInterface {
   protected boolean numericDerivatives = false;
 
   /**
-   * Array containing all phases of System. NB! Phases are reorered according to density, use
+   * Array containing all phases of System. NB! Phases are reorered according to
+   * density, use
    * phaseIndex to keep track of the creation order.
    */
   protected PhaseInterface[] phaseArray = new PhaseInterface[MAX_PHASES];
   /**
-   * Array of indexes to phaseArray keeping track of the creation order of the phases where 0 is the
+   * Array of indexes to phaseArray keeping track of the creation order of the
+   * phases where 0 is the
    * first created phase and the lowest number is the phase created last.
    */
   protected int[] phaseIndex;
@@ -167,8 +169,8 @@ public abstract class SystemThermo implements SystemInterface {
    * Constructor for SystemThermo.
    * </p>
    *
-   * @param T The temperature in unit Kelvin
-   * @param P The pressure in unit bara (absolute pressure)
+   * @param T              The temperature in unit Kelvin
+   * @param P              The pressure in unit bara (absolute pressure)
    * @param checkForSolids Set true to do solid phase check and calculations
    */
   public SystemThermo(double T, double P, boolean checkForSolids) {
@@ -365,7 +367,8 @@ public abstract class SystemThermo implements SystemInterface {
       getPhase(i).getComponent(componentName).setTC(TC);
       getPhase(i).getComponent(componentName).setPC(PC);
       getPhase(i).getComponent(componentName).setAcentricFactor(acs);
-      // Set isPlusFraction for components with "_PC" suffix (plus fraction components)
+      // Set isPlusFraction for components with "_PC" suffix (plus fraction
+      // components)
       if (componentName.endsWith("_PC")) {
         getPhase(i).getComponent(componentName).setIsPlusFraction(true);
       }
@@ -430,8 +433,7 @@ public abstract class SystemThermo implements SystemInterface {
     double stddens = 0.0;
     double boilp = 0.0;
     try (neqsim.util.database.NeqSimDataBase database = new neqsim.util.database.NeqSimDataBase();
-        java.sql.ResultSet dataSet =
-            database.getResultSet(("SELECT * FROM comp WHERE name='" + componentName + "'"))) {
+        java.sql.ResultSet dataSet = database.getResultSet(("SELECT * FROM comp WHERE name='" + componentName + "'"))) {
       dataSet.next();
       molarmass = Double.parseDouble(dataSet.getString("molarmass")) / 1000.0;
       stddens = Double.parseDouble(dataSet.getString("stddens"));
@@ -440,8 +442,7 @@ public abstract class SystemThermo implements SystemInterface {
       // todo: mole amount may be not set. should not be caught?
       logger.error("failed ", ex);
     }
-    neqsim.util.unit.Unit unit =
-        new neqsim.util.unit.RateUnit(value, unitName, molarmass, stddens, boilp);
+    neqsim.util.unit.Unit unit = new neqsim.util.unit.RateUnit(value, unitName, molarmass, stddens, boilp);
     double SIval = unit.getSIvalue();
     // System.out.println("number of moles " + SIval);
     this.addComponent(componentName, SIval);
@@ -461,8 +462,7 @@ public abstract class SystemThermo implements SystemInterface {
     double stddens = 0.0;
     double boilp = 0.0;
     try (neqsim.util.database.NeqSimDataBase database = new neqsim.util.database.NeqSimDataBase();
-        java.sql.ResultSet dataSet =
-            database.getResultSet(("SELECT * FROM comp WHERE name='" + componentName + "'"))) {
+        java.sql.ResultSet dataSet = database.getResultSet(("SELECT * FROM comp WHERE name='" + componentName + "'"))) {
       dataSet.next();
       molarmass = Double.parseDouble(dataSet.getString("molarmass")) / 1000.0;
       stddens = Double.parseDouble(dataSet.getString("stddens"));
@@ -471,8 +471,7 @@ public abstract class SystemThermo implements SystemInterface {
       logger.error("failed ", ex);
       throw new RuntimeException(ex);
     }
-    neqsim.util.unit.Unit unit =
-        new neqsim.util.unit.RateUnit(value, name, molarmass, stddens, boilp);
+    neqsim.util.unit.Unit unit = new neqsim.util.unit.RateUnit(value, name, molarmass, stddens, boilp);
     double SIval = unit.getSIvalue();
     // System.out.println("number of moles " + SIval);
     this.addComponent(componentName, SIval, phaseNum);
@@ -670,19 +669,24 @@ public abstract class SystemThermo implements SystemInterface {
   @Override
   public void addPhase() {
     /*
-     * if (maxNumberOfPhases < 6 && !hydrateCheck) { ArrayList phaseList = new ArrayList(0); for
-     * (int i = 0; i < numberOfPhases; i++) { phaseList.add(phaseArray[i]); } // add the new phase
-     * phaseList.add(phaseArray[0].clone()); beta[phaseList.size() - 1] = 1.0e-8; // beta[1] -=
+     * if (maxNumberOfPhases < 6 && !hydrateCheck) { ArrayList phaseList = new
+     * ArrayList(0); for
+     * (int i = 0; i < numberOfPhases; i++) { phaseList.add(phaseArray[i]); } // add
+     * the new phase
+     * phaseList.add(phaseArray[0].clone()); beta[phaseList.size() - 1] = 1.0e-8; //
+     * beta[1] -=
      * beta[1]/1.0e5;
      *
      * PhaseInterface[] phaseArray2 = new PhaseInterface[numberOfPhases + 1];
      *
-     * for (int i = 0; i < numberOfPhases + 1; i++) { phaseArray2[i] = (PhaseInterface)
+     * for (int i = 0; i < numberOfPhases + 1; i++) { phaseArray2[i] =
+     * (PhaseInterface)
      * phaseList.get(i); }
      *
      * phaseArray = phaseArray2;
      *
-     * System.out.println("number of phases " + numberOfPhases); if (maxNumberOfPhases <
+     * System.out.println("number of phases " + numberOfPhases); if
+     * (maxNumberOfPhases <
      * numberOfPhases) { maxNumberOfPhases = numberOfPhases; } }
      */
     numberOfPhases++;
@@ -1568,14 +1572,14 @@ public abstract class SystemThermo implements SystemInterface {
       table[j + 1][1] = nf.format(getPhase(0).getComponent(j).getz(), buf, test).toString();
     }
     buf = new StringBuffer();
-    table[getPhases()[0].getNumberOfComponents() + 4][1] =
-        nf.format(getMolarMass(Units.getSymbol("Molar Mass")), buf, test).toString();
+    table[getPhases()[0].getNumberOfComponents() + 4][1] = nf
+        .format(getMolarMass(Units.getSymbol("Molar Mass")), buf, test).toString();
     buf = new StringBuffer();
-    table[getPhases()[0].getNumberOfComponents() + 9][1] =
-        nf.format(getEnthalpy(Units.getSymbol("enthalpy")), buf, test).toString();
+    table[getPhases()[0].getNumberOfComponents() + 9][1] = nf
+        .format(getEnthalpy(Units.getSymbol("enthalpy")), buf, test).toString();
     buf = new StringBuffer();
-    table[getPhases()[0].getNumberOfComponents() + 10][1] =
-        nf.format(getEntropy(Units.getSymbol("entropy")), buf, test).toString();
+    table[getPhases()[0].getNumberOfComponents() + 10][1] = nf.format(getEntropy(Units.getSymbol("entropy")), buf, test)
+        .toString();
 
     for (int i = 0; i < numberOfPhases; i++) {
       for (int j = 0; j < getPhases()[0].getNumberOfComponents(); j++) {
@@ -1587,114 +1591,112 @@ public abstract class SystemThermo implements SystemInterface {
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 2][0] = "Density";
-      table[getPhases()[0].getNumberOfComponents() + 2][i + 2] =
-          nf.format(getPhase(i).getDensity(Units.activeUnits.get("density").symbol), buf, test)
-              .toString();
-      table[getPhases()[0].getNumberOfComponents() + 2][6] =
-          Units.activeUnits.get("density").symbol;
+      table[getPhases()[0].getNumberOfComponents() + 2][i + 2] = nf
+          .format(getPhase(i).getDensity(Units.activeUnits.get("density").symbol), buf, test)
+          .toString();
+      table[getPhases()[0].getNumberOfComponents() + 2][6] = Units.activeUnits.get("density").symbol;
 
       // Double.longValue(system.getPhase(i).getBeta());
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 3][0] = "Phase Fraction";
-      table[getPhases()[0].getNumberOfComponents() + 3][i + 2] =
-          nf.format(getPhase(i).getBeta(), buf, test).toString();
+      table[getPhases()[0].getNumberOfComponents() + 3][i + 2] = nf.format(getPhase(i).getBeta(), buf, test).toString();
       table[getPhases()[0].getNumberOfComponents() + 3][6] = "[mole fraction]";
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 4][0] = "Molar Mass";
-      table[getPhases()[0].getNumberOfComponents() + 4][i + 2] =
-          nf.format(getPhase(i).getMolarMass(Units.activeUnits.get("Molar Mass").symbol), buf, test)
-              .toString();
-      table[getPhases()[0].getNumberOfComponents() + 4][6] =
-          Units.activeUnits.get("Molar Mass").symbol;
+      table[getPhases()[0].getNumberOfComponents() + 4][i + 2] = nf
+          .format(getPhase(i).getMolarMass(Units.activeUnits.get("Molar Mass").symbol), buf, test)
+          .toString();
+      table[getPhases()[0].getNumberOfComponents() + 4][6] = Units.activeUnits.get("Molar Mass").symbol;
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 5][0] = "Z factor";
-      table[getPhases()[0].getNumberOfComponents() + 5][i + 2] =
-          nf.format(getPhase(i).getZvolcorr(), buf, test).toString();
+      table[getPhases()[0].getNumberOfComponents() + 5][i + 2] = nf.format(getPhase(i).getZvolcorr(), buf, test)
+          .toString();
       table[getPhases()[0].getNumberOfComponents() + 5][6] = "[-]";
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 6][0] = "Heat Capacity (Cp)";
-      table[getPhases()[0].getNumberOfComponents() + 6][i + 2] =
-          nf.format((getPhase(i).getCp(Units.activeUnits.get("Heat Capacity (Cp)").symbol)), buf,
-              test).toString();
-      table[getPhases()[0].getNumberOfComponents() + 6][6] =
-          Units.activeUnits.get("Heat Capacity (Cp)").symbol;
+      table[getPhases()[0].getNumberOfComponents() + 6][i + 2] = nf
+          .format((getPhase(i).getCp(Units.activeUnits.get("Heat Capacity (Cp)").symbol)), buf,
+              test)
+          .toString();
+      table[getPhases()[0].getNumberOfComponents() + 6][6] = Units.activeUnits.get("Heat Capacity (Cp)").symbol;
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 7][0] = "Heat Capacity (Cv)";
-      table[getPhases()[0].getNumberOfComponents() + 7][i + 2] =
-          nf.format((getPhase(i).getCv(Units.activeUnits.get("Heat Capacity (Cv)").symbol)), buf,
-              test).toString();
-      table[getPhases()[0].getNumberOfComponents() + 7][6] =
-          Units.activeUnits.get("Heat Capacity (Cv)").symbol;
+      table[getPhases()[0].getNumberOfComponents() + 7][i + 2] = nf
+          .format((getPhase(i).getCv(Units.activeUnits.get("Heat Capacity (Cv)").symbol)), buf,
+              test)
+          .toString();
+      table[getPhases()[0].getNumberOfComponents() + 7][6] = Units.activeUnits.get("Heat Capacity (Cv)").symbol;
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 8][0] = "Speed of Sound";
-      table[getPhases()[0].getNumberOfComponents() + 8][i + 2] =
-          nf.format((getPhase(i).getSoundSpeed(Units.getSymbol("speed of sound"))), buf, test)
-              .toString();
+      table[getPhases()[0].getNumberOfComponents() + 8][i + 2] = nf
+          .format((getPhase(i).getSoundSpeed(Units.getSymbol("speed of sound"))), buf, test)
+          .toString();
       table[getPhases()[0].getNumberOfComponents() + 8][6] = Units.getSymbol("speed of sound");
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 9][0] = "Enthalpy";
-      table[getPhases()[0].getNumberOfComponents() + 9][i + 2] =
-          nf.format((getPhase(i).getEnthalpy(Units.getSymbol("enthalpy"))), buf, test).toString();
+      table[getPhases()[0].getNumberOfComponents() + 9][i + 2] = nf
+          .format((getPhase(i).getEnthalpy(Units.getSymbol("enthalpy"))), buf, test).toString();
       table[getPhases()[0].getNumberOfComponents() + 9][6] = Units.getSymbol("enthalpy");
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 10][0] = "Entropy";
-      table[getPhases()[0].getNumberOfComponents() + 10][i + 2] =
-          nf.format((getPhase(i).getEntropy(Units.getSymbol("entropy"))), buf, test).toString();
+      table[getPhases()[0].getNumberOfComponents() + 10][i + 2] = nf
+          .format((getPhase(i).getEntropy(Units.getSymbol("entropy"))), buf, test).toString();
       table[getPhases()[0].getNumberOfComponents() + 10][6] = Units.getSymbol("entropy");
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 11][0] = "JT coefficient";
-      table[getPhases()[0].getNumberOfComponents() + 11][i + 2] =
-          nf.format((getPhase(i).getJouleThomsonCoefficient(Units.getSymbol("JT coefficient"))),
-              buf, test).toString();
+      table[getPhases()[0].getNumberOfComponents() + 11][i + 2] = nf
+          .format((getPhase(i).getJouleThomsonCoefficient(Units.getSymbol("JT coefficient"))),
+              buf, test)
+          .toString();
       table[getPhases()[0].getNumberOfComponents() + 11][6] = Units.getSymbol("JT coefficient");
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 13][0] = "Viscosity";
-      table[getPhases()[0].getNumberOfComponents() + 13][i + 2] =
-          nf.format((getPhase(i).getViscosity(Units.getSymbol("viscosity"))), buf, test).toString();
+      table[getPhases()[0].getNumberOfComponents() + 13][i + 2] = nf
+          .format((getPhase(i).getViscosity(Units.getSymbol("viscosity"))), buf, test).toString();
       table[getPhases()[0].getNumberOfComponents() + 13][6] = Units.getSymbol("viscosity");
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 14][0] = "Thermal Conductivity";
-      table[getPhases()[0].getNumberOfComponents() + 14][i + 2] =
-          nf.format(getPhase(i).getThermalConductivity(Units.getSymbol("thermal conductivity")),
-              buf, test).toString();
-      table[getPhases()[0].getNumberOfComponents() + 14][6] =
-          Units.getSymbol("thermal conductivity");
+      table[getPhases()[0].getNumberOfComponents() + 14][i + 2] = nf
+          .format(getPhase(i).getThermalConductivity(Units.getSymbol("thermal conductivity")),
+              buf, test)
+          .toString();
+      table[getPhases()[0].getNumberOfComponents() + 14][6] = Units.getSymbol("thermal conductivity");
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 15][0] = "Surface Tension";
       try {
         if (i < numberOfPhases - 1) {
-          table[getPhases()[0].getNumberOfComponents() + 15][2] =
-              nf.format(getInterphaseProperties().getSurfaceTension(0, 1), buf, test).toString();
+          table[getPhases()[0].getNumberOfComponents() + 15][2] = nf
+              .format(getInterphaseProperties().getSurfaceTension(0, 1), buf, test).toString();
           buf = new StringBuffer();
-          table[getPhases()[0].getNumberOfComponents() + 15][3] =
-              nf.format(getInterphaseProperties().getSurfaceTension(0, 1), buf, test).toString();
+          table[getPhases()[0].getNumberOfComponents() + 15][3] = nf
+              .format(getInterphaseProperties().getSurfaceTension(0, 1), buf, test).toString();
           buf = new StringBuffer();
           if (i == 1) {
-            table[getPhases()[0].getNumberOfComponents() + 17][2] =
-                nf.format(getInterphaseProperties().getSurfaceTension(0, 2), buf, test).toString();
+            table[getPhases()[0].getNumberOfComponents() + 17][2] = nf
+                .format(getInterphaseProperties().getSurfaceTension(0, 2), buf, test).toString();
             buf = new StringBuffer();
-            table[getPhases()[0].getNumberOfComponents() + 17][4] =
-                nf.format(getInterphaseProperties().getSurfaceTension(0, 2), buf, test).toString();
+            table[getPhases()[0].getNumberOfComponents() + 17][4] = nf
+                .format(getInterphaseProperties().getSurfaceTension(0, 2), buf, test).toString();
             table[getPhases()[0].getNumberOfComponents() + 17][6] = "[N/m]";
           }
           if (i == 1) {
             buf = new StringBuffer();
-            table[getPhases()[0].getNumberOfComponents() + 16][3] =
-                nf.format(getInterphaseProperties().getSurfaceTension(1, 2), buf, test).toString();
+            table[getPhases()[0].getNumberOfComponents() + 16][3] = nf
+                .format(getInterphaseProperties().getSurfaceTension(1, 2), buf, test).toString();
             buf = new StringBuffer();
-            table[getPhases()[0].getNumberOfComponents() + 16][4] =
-                nf.format(getInterphaseProperties().getSurfaceTension(1, 2), buf, test).toString();
+            table[getPhases()[0].getNumberOfComponents() + 16][4] = nf
+                .format(getInterphaseProperties().getSurfaceTension(1, 2), buf, test).toString();
             table[getPhases()[0].getNumberOfComponents() + 16][6] = "[N/m]";
           }
         }
@@ -1705,14 +1707,14 @@ public abstract class SystemThermo implements SystemInterface {
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 19][0] = "Pressure";
-      table[getPhases()[0].getNumberOfComponents() + 19][i + 2] =
-          Double.toString(getPhase(i).getPressure(Units.getSymbol("pressure")));
+      table[getPhases()[0].getNumberOfComponents() + 19][i + 2] = Double
+          .toString(getPhase(i).getPressure(Units.getSymbol("pressure")));
       table[getPhases()[0].getNumberOfComponents() + 19][6] = Units.getSymbol("pressure");
 
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 20][0] = "Temperature";
-      table[getPhases()[0].getNumberOfComponents() + 20][i + 2] =
-          Double.toString(getPhase(i).getTemperature(Units.getSymbol("temperature")));
+      table[getPhases()[0].getNumberOfComponents() + 20][i + 2] = Double
+          .toString(getPhase(i).getTemperature(Units.getSymbol("temperature")));
       table[getPhases()[0].getNumberOfComponents() + 20][6] = Units.getSymbol("temperature");
       Double.toString(getPhase(i).getTemperature());
 
@@ -1724,8 +1726,8 @@ public abstract class SystemThermo implements SystemInterface {
       buf = new StringBuffer();
       table[getPhases()[0].getNumberOfComponents() + 23][0] = "Mixing Rule";
       try {
-        table[getPhases()[0].getNumberOfComponents() + 23][i + 2] =
-            ((PhaseEosInterface) getPhase(i)).getMixingRuleName();
+        table[getPhases()[0].getNumberOfComponents() + 23][i + 2] = ((PhaseEosInterface) getPhase(i))
+            .getMixingRuleName();
       } catch (Exception ex) {
         table[getPhases()[0].getNumberOfComponents() + 23][i + 2] = "?";
         // logger.error(ex.getMessage(),e);
@@ -1909,7 +1911,7 @@ public abstract class SystemThermo implements SystemInterface {
     java.awt.Container dialogContentPane = dialog.getContentPane();
     dialogContentPane.setLayout(new java.awt.BorderLayout());
 
-    String[] names = {"", "Feed", "Phase 1", "Phase 2", "Phase 3", "Phase 4", "Unit"};
+    String[] names = { "", "Feed", "Phase 1", "Phase 2", "Phase 3", "Phase 4", "Unit" };
     String[][] table = createTable(name);
     javax.swing.JTable Jtab = new javax.swing.JTable(table, names);
     javax.swing.JScrollPane scrollpane = new javax.swing.JScrollPane(Jtab);
@@ -1952,7 +1954,8 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public final double getBeta() {
-    // Returns beta of the first phase (lightest/gas by convention after phase identification)
+    // Returns beta of the first phase (lightest/gas by convention after phase
+    // identification)
     return beta[0];
   }
 
@@ -2070,7 +2073,8 @@ public abstract class SystemThermo implements SystemInterface {
   }
 
   /**
-   * Calculates the heat capacity at constant pressure (Cp) in the specified units. {@inheritDoc}
+   * Calculates the heat capacity at constant pressure (Cp) in the specified
+   * units. {@inheritDoc}
    */
   @Override
   public double getCp(String unit) {
@@ -2083,7 +2087,8 @@ public abstract class SystemThermo implements SystemInterface {
         return refCp;
 
       case "J/molK":
-        // To get molar heat capacity, divide the total heat capacity by the total number of moles.
+        // To get molar heat capacity, divide the total heat capacity by the total
+        // number of moles.
         if (getTotalNumberOfMoles() == 0) {
           throw new ArithmeticException(
               "Total number of moles cannot be zero for J/molK conversion.");
@@ -2098,7 +2103,8 @@ public abstract class SystemThermo implements SystemInterface {
         return refCp / getTotalNumberOfMoles() / 1000.0;
 
       case "J/kgK": {
-        // To get specific heat capacity, divide the total heat capacity by the total mass.
+        // To get specific heat capacity, divide the total heat capacity by the total
+        // mass.
         // Total mass = total moles * molar mass (in kg/mol).
         double totalMass = getTotalNumberOfMoles() * getMolarMass();
         if (totalMass == 0) {
@@ -2149,11 +2155,13 @@ public abstract class SystemThermo implements SystemInterface {
   }
 
   /**
-   * Calculates the heat capacity at constant volume (Cv) in the specified units. {@inheritDoc}
+   * Calculates the heat capacity at constant volume (Cv) in the specified units.
+   * {@inheritDoc}
    */
   @Override
   public double getCv(String unit) {
-    // The reference heat capacity (refCv) is the total heat capacity at constant volume in J/K.
+    // The reference heat capacity (refCv) is the total heat capacity at constant
+    // volume in J/K.
     double refCv = getCv();
 
     switch (unit) {
@@ -2162,7 +2170,8 @@ public abstract class SystemThermo implements SystemInterface {
         return refCv;
 
       case "J/molK":
-        // To get molar heat capacity, divide the total heat capacity by the total number of moles.
+        // To get molar heat capacity, divide the total heat capacity by the total
+        // number of moles.
         if (getTotalNumberOfMoles() == 0) {
           throw new ArithmeticException(
               "Total number of moles cannot be zero for J/molK conversion.");
@@ -2177,7 +2186,8 @@ public abstract class SystemThermo implements SystemInterface {
         return refCv / getTotalNumberOfMoles() / 1000.0;
 
       case "J/kgK": {
-        // To get specific heat capacity, divide the total heat capacity by the total mass.
+        // To get specific heat capacity, divide the total heat capacity by the total
+        // mass.
         // Total mass = total moles * molar mass (in kg/mol).
         double totalMass = getTotalNumberOfMoles() * getMolarMass();
         if (totalMass == 0) {
@@ -2318,8 +2328,7 @@ public abstract class SystemThermo implements SystemInterface {
       phaseNumber = j;
       double phaseMoles = 0.0;
       for (int i = 0; i < getPhase(j).getNumberOfComponents(); i++) {
-        double scaledMoles =
-            getPhase(phaseNumber).getComponent(i).getNumberOfMolesInPhase() / scaleFactor;
+        double scaledMoles = getPhase(phaseNumber).getComponent(i).getNumberOfMolesInPhase() / scaleFactor;
         newSystem.getPhase(j).getComponent(i).setNumberOfmoles(scaledMoles);
         newSystem.getPhase(j).getComponent(i).setNumberOfMolesInPhase(scaledMoles);
         phaseMoles += scaledMoles;
@@ -2915,8 +2924,7 @@ public abstract class SystemThermo implements SystemInterface {
 
     double totalMass = 0.0;
     for (int compNumb = 0; compNumb < numberOfComponents; compNumb++) {
-      totalMass +=
-          phase.getComponent(compNumb).getz() * phase.getComponent(compNumb).getMolarMass();
+      totalMass += phase.getComponent(compNumb).getz() * phase.getComponent(compNumb).getMolarMass();
     }
 
     for (int compNumb = 0; compNumb < numberOfComponents; compNumb++) {
@@ -2931,8 +2939,7 @@ public abstract class SystemThermo implements SystemInterface {
   public double getMolarMass() {
     double tempVar = 0;
     for (int i = 0; i < phaseArray[0].getNumberOfComponents(); i++) {
-      tempVar +=
-          phaseArray[0].getComponent(i).getz() * phaseArray[0].getComponent(i).getMolarMass();
+      tempVar += phaseArray[0].getComponent(i).getz() * phaseArray[0].getComponent(i).getMolarMass();
     }
     return tempVar;
   }
@@ -3213,7 +3220,8 @@ public abstract class SystemThermo implements SystemInterface {
       if (getPhase(i).getType() == pt) {
         return i;
       }
-      // ASPHALTENE and LIQUID_ASPHALTENE are asphaltene-related phases, match when looking for
+      // ASPHALTENE and LIQUID_ASPHALTENE are asphaltene-related phases, match when
+      // looking for
       // either
       if (pt == PhaseType.ASPHALTENE && getPhase(i).getType() == PhaseType.LIQUID_ASPHALTENE) {
         return i;
@@ -3262,8 +3270,7 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public final double getPressure(String unit) {
-    neqsim.util.unit.PressureUnit presConversion =
-        new neqsim.util.unit.PressureUnit(getPressure(), "bara");
+    neqsim.util.unit.PressureUnit presConversion = new neqsim.util.unit.PressureUnit(getPressure(), "bara");
     return presConversion.getValue(unit);
   }
 
@@ -3430,8 +3437,7 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public final double getTemperature(String unit) {
-    neqsim.util.unit.TemperatureUnit tempConversion =
-        new neqsim.util.unit.TemperatureUnit(getTemperature(), "K");
+    neqsim.util.unit.TemperatureUnit tempConversion = new neqsim.util.unit.TemperatureUnit(getTemperature(), "K");
     return tempConversion.getValue(unit);
   }
 
@@ -3695,8 +3701,10 @@ public abstract class SystemThermo implements SystemInterface {
    * initAnalytic.
    * </p>
    *
-   * @param type a int. 0 to initialize and 1 to reset, 2 to calculate T and P derivatives, 3 to
-   *        calculate all derivatives and 4 to calculate all derivatives numerically
+   * @param type a int. 0 to initialize and 1 to reset, 2 to calculate T and P
+   *             derivatives, 3 to
+   *             calculate all derivatives and 4 to calculate all derivatives
+   *             numerically
    */
   public void initAnalytic(int type) {
     if (type == 0) {
@@ -3778,7 +3786,7 @@ public abstract class SystemThermo implements SystemInterface {
    * initAnalytic.
    * </p>
    *
-   * @param type a int
+   * @param type     a int
    * @param phaseNum a int
    */
   public void initAnalytic(int type, int phaseNum) {
@@ -3811,7 +3819,8 @@ public abstract class SystemThermo implements SystemInterface {
 
     // Only reclassify the initialized phase (not all phases).
     // Phase 0 is the reference phase and is allowed to remain GAS.
-    // This is consistent with initAnalytic(type) which only reclassifies phases >= 1.
+    // This is consistent with initAnalytic(type) which only reclassifies phases >=
+    // 1.
     if (phaseNum >= 1 && getPhase(phaseNum).getType() == PhaseType.GAS) {
       getPhase(phaseNum).setType(PhaseType.OIL);
     }
@@ -3961,7 +3970,7 @@ public abstract class SystemThermo implements SystemInterface {
    * </p>
    *
    * @param initType a int
-   * @param phasen a int
+   * @param phasen   a int
    */
   public void initNumeric(int initType, int phasen) {
     if (initType < 2) {
@@ -4210,7 +4219,8 @@ public abstract class SystemThermo implements SystemInterface {
         }
 
         // Get effective density for comparison
-        // Solid phases (SOLID, ASPHALTENE, WAX, HYDRATE) should always be last (densest)
+        // Solid phases (SOLID, ASPHALTENE, WAX, HYDRATE) should always be last
+        // (densest)
         double density1 = getEffectiveDensityForOrdering(i - 1);
         double density2 = getEffectiveDensityForOrdering(i);
 
@@ -4226,7 +4236,8 @@ public abstract class SystemThermo implements SystemInterface {
   }
 
   /**
-   * Get effective density for phase ordering. Solid-like phases (SOLID, ASPHALTENE, WAX, HYDRATE)
+   * Get effective density for phase ordering. Solid-like phases (SOLID,
+   * ASPHALTENE, WAX, HYDRATE)
    * return a very high density to ensure they sort to the end.
    *
    * @param phaseNum phase number
@@ -4339,8 +4350,7 @@ public abstract class SystemThermo implements SystemInterface {
   public void readFluid(String fluidName) {
     this.fluidName = fluidName;
     try {
-      neqsim.util.database.NeqSimFluidDataBase database =
-          new neqsim.util.database.NeqSimFluidDataBase();
+      neqsim.util.database.NeqSimFluidDataBase database = new neqsim.util.database.NeqSimFluidDataBase();
       java.sql.ResultSet dataSet = null;
       dataSet = database.getResultSet("SELECT * FROM " + fluidName);
 
@@ -4374,8 +4384,7 @@ public abstract class SystemThermo implements SystemInterface {
   @Override
   public SystemInterface readObject(int ID) {
     SystemThermo tempSystem = null;
-    neqsim.util.database.NeqSimBlobDatabase database =
-        new neqsim.util.database.NeqSimBlobDatabase();
+    neqsim.util.database.NeqSimBlobDatabase database = new neqsim.util.database.NeqSimBlobDatabase();
     java.sql.Connection con = null;
     java.sql.PreparedStatement ps = null;
     java.sql.ResultSet rs = null;
@@ -4386,8 +4395,7 @@ public abstract class SystemThermo implements SystemInterface {
       rs = ps.executeQuery();
 
       if (rs.next()) {
-        try (ObjectInputStream ins =
-            new ObjectInputStream(new ByteArrayInputStream(rs.getBytes("FLUID")))) {
+        try (ObjectInputStream ins = new ObjectInputStream(new ByteArrayInputStream(rs.getBytes("FLUID")))) {
           tempSystem = (SystemThermo) ins.readObject();
         }
       }
@@ -4422,8 +4430,7 @@ public abstract class SystemThermo implements SystemInterface {
   @Override
   public SystemInterface readObjectFromFile(String filePath, String fluidName) {
     SystemThermo tempSystem = null;
-    try (ObjectInputStream objectinputstream =
-        new ObjectInputStream(new FileInputStream(filePath))) {
+    try (ObjectInputStream objectinputstream = new ObjectInputStream(new FileInputStream(filePath))) {
       tempSystem = (SystemThermo) objectinputstream.readObject();
     } catch (Exception ex) {
       logger.error(ex.getMessage(), ex);
@@ -4432,7 +4439,8 @@ public abstract class SystemThermo implements SystemInterface {
   }
 
   /**
-   * Re-initialize phasetype, beta and phaseindex arrays, same initialization which is used in
+   * Re-initialize phasetype, beta and phaseindex arrays, same initialization
+   * which is used in
    * constructor.
    */
   public void reInitPhaseInformation() {
@@ -4444,7 +4452,7 @@ public abstract class SystemThermo implements SystemInterface {
       beta[i] = 1.0;
     }
 
-    phaseIndex = new int[] {0, 1, 2, 3, 4, 5};
+    phaseIndex = new int[] { 0, 1, 2, 3, 4, 5 };
   }
 
   /** {@inheritDoc} */
@@ -4640,8 +4648,7 @@ public abstract class SystemThermo implements SystemInterface {
     byte[] byteObject = fout.toByteArray();
     ByteArrayInputStream inpStream = new ByteArrayInputStream(byteObject);
 
-    neqsim.util.database.NeqSimBlobDatabase database =
-        new neqsim.util.database.NeqSimBlobDatabase();
+    neqsim.util.database.NeqSimBlobDatabase database = new neqsim.util.database.NeqSimBlobDatabase();
     java.sql.Connection con = null;
     java.sql.PreparedStatement ps = null;
     try {
@@ -4654,7 +4661,8 @@ public abstract class SystemThermo implements SystemInterface {
       ps.executeUpdate();
       /*
        * if (!text.isEmpty()) { ps = con.prepareStatement(
-       * "REPLACE INTO fluidinfo (ID, TEXT) VALUES (?,?)"); ps.setInt(1, ID); ps.setString(2, text);
+       * "REPLACE INTO fluidinfo (ID, TEXT) VALUES (?,?)"); ps.setInt(1, ID);
+       * ps.setString(2, text);
        * }
        *
        * ps.executeUpdate();
@@ -4702,9 +4710,8 @@ public abstract class SystemThermo implements SystemInterface {
       database.execute("delete FROM systemreport");
       int i = 0;
       for (; i < numberOfComponents; i++) {
-        String sqlString =
-            "'" + Integer.toString(i + 1) + "', '" + getPhase(0).getComponent(i).getName() + "', "
-                + "'molfrac[-] ', '" + Double.toString(getPhase(0).getComponent(i).getz()) + "'";
+        String sqlString = "'" + Integer.toString(i + 1) + "', '" + getPhase(0).getComponent(i).getName() + "', "
+            + "'molfrac[-] ', '" + Double.toString(getPhase(0).getComponent(i).getz()) + "'";
 
         int j = 0;
         for (; j < numberOfPhases; j++) {
@@ -4965,8 +4972,7 @@ public abstract class SystemThermo implements SystemInterface {
    * @return a boolean
    */
   public boolean setLastTBPasPlus() {
-    neqsim.thermo.characterization.PlusCharacterize temp =
-        new neqsim.thermo.characterization.PlusCharacterize(this);
+    neqsim.thermo.characterization.PlusCharacterize temp = new neqsim.thermo.characterization.PlusCharacterize(this);
     if (temp.hasPlusFraction()) {
       return false;
     } else {
@@ -5033,15 +5039,13 @@ public abstract class SystemThermo implements SystemInterface {
         tempModel = new SystemSrkSchwartzentruberEos(getPhase(0).getTemperature(),
             getPhase(0).getPressure());
       } else if (model.equals("Electrolyte-ScRK-EOS")) {
-        tempModel =
-            new SystemFurstElectrolyteEos(getPhase(0).getTemperature(), getPhase(0).getPressure());
+        tempModel = new SystemFurstElectrolyteEos(getPhase(0).getTemperature(), getPhase(0).getPressure());
       } else if (model.equals("GERG-water-EOS")) {
         tempModel = new SystemGERGwaterEos(getPhase(0).getTemperature(), getPhase(0).getPressure());
       } else if (model.equals("CPAs-SRK-EOS")) {
         tempModel = new SystemSrkCPAs(getPhase(0).getTemperature(), getPhase(0).getPressure());
       } else if (model.equals("CPAs-SRK-EOS-statoil")) {
-        tempModel =
-            new SystemSrkCPAstatoil(getPhase(0).getTemperature(), getPhase(0).getPressure());
+        tempModel = new SystemSrkCPAstatoil(getPhase(0).getTemperature(), getPhase(0).getPressure());
       } else if (model.equals("Electrolyte-CPA-EOS-statoil")
           || model.equals("Electrolyte-CPA-EOS")) {
         tempModel = new SystemElectrolyteCPAstatoil(getPhase(0).getTemperature(),
@@ -5053,11 +5057,9 @@ public abstract class SystemThermo implements SystemInterface {
       } else if (model.equals("GERG-2008-EoS")) {
         tempModel = new SystemGERG2004Eos(getPhase(0).getTemperature(), getPhase(0).getPressure());
       } else if (model.equals("SRK-TwuCoon-Statoil-EOS") || model.equals("SRK-TwuCoon-EOS")) {
-        tempModel =
-            new SystemSrkTwuCoonStatoilEos(getPhase(0).getTemperature(), getPhase(0).getPressure());
+        tempModel = new SystemSrkTwuCoonStatoilEos(getPhase(0).getTemperature(), getPhase(0).getPressure());
       } else if (model.equals("SRK-TwuCoon-Param-EOS")) {
-        tempModel =
-            new SystemSrkTwuCoonParamEos(getPhase(0).getTemperature(), getPhase(0).getPressure());
+        tempModel = new SystemSrkTwuCoonParamEos(getPhase(0).getTemperature(), getPhase(0).getPressure());
       } else if (model.equals("Duan-Sun")) {
         tempModel = new SystemDuanSun(getPhase(0).getTemperature(), getPhase(0).getPressure());
       } else {
@@ -5223,10 +5225,11 @@ public abstract class SystemThermo implements SystemInterface {
   }
 
   /**
-   * Wrapper function for addComponent to set fluid type and specify mole fractions.
+   * Wrapper function for addComponent to set fluid type and specify mole
+   * fractions.
    *
    * @param molefractions Component mole fraction of each component.
-   * @param type Type of fluid. Supports "PlusFluid", "Plus" and default.
+   * @param type          Type of fluid. Supports "PlusFluid", "Plus" and default.
    */
   private void setMolarFractions(double[] molefractions, String type) {
     double sum = 0;
@@ -5466,8 +5469,10 @@ public abstract class SystemThermo implements SystemInterface {
     // Following code was from public void setPhaseType(int phaseToChange, String
     // phaseTypeName) {
     /*
-     * int newPhaseType = 0; if (phaseTypeName.equals("gas")) { newPhaseType = 1; } else if
-     * (StateOfMatter.isLiquid(PhaseType.byDesc(phaseTypeName))) { newPhaseType = 0; } else {
+     * int newPhaseType = 0; if (phaseTypeName.equals("gas")) { newPhaseType = 1; }
+     * else if
+     * (StateOfMatter.isLiquid(PhaseType.byDesc(phaseTypeName))) { newPhaseType = 0;
+     * } else {
      * newPhaseType = 0; }
      */
 
@@ -5491,8 +5496,7 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public final void setPressure(double newPressure, String unit) {
-    neqsim.util.unit.PressureUnit presConversion =
-        new neqsim.util.unit.PressureUnit(newPressure, unit);
+    neqsim.util.unit.PressureUnit presConversion = new neqsim.util.unit.PressureUnit(newPressure, unit);
     setPressure(presConversion.getValue("bara"));
   }
 
@@ -5615,8 +5619,7 @@ public abstract class SystemThermo implements SystemInterface {
         || flowunit.equals("gallons/min")) {
       density = getIdealLiquidDensity("kg/m3");
     }
-    neqsim.util.unit.Unit unit =
-        new neqsim.util.unit.RateUnit(flowRate, flowunit, getMolarMass(), density, 0);
+    neqsim.util.unit.Unit unit = new neqsim.util.unit.RateUnit(flowRate, flowunit, getMolarMass(), density, 0);
     double SIval = unit.getSIvalue();
     double totalNumberOfMolesLocal = totalNumberOfMoles;
     for (int i = 0; i < numberOfComponents; i++) {
@@ -5624,9 +5627,8 @@ public abstract class SystemThermo implements SystemInterface {
         setEmptyFluid();
       } else if (totalNumberOfMolesLocal > 1e-100) {
         // (SIval / totalNumberOfMolesLocal - 1) * ...
-        double change =
-            SIval / totalNumberOfMolesLocal * getPhase(0).getComponent(i).getNumberOfmoles()
-                - getPhase(0).getComponent(i).getNumberOfmoles();
+        double change = SIval / totalNumberOfMolesLocal * getPhase(0).getComponent(i).getNumberOfmoles()
+            - getPhase(0).getComponent(i).getNumberOfmoles();
         if (Math.abs(change) > 1e-12) {
           addComponent(i, change);
         }
@@ -5641,7 +5643,8 @@ public abstract class SystemThermo implements SystemInterface {
   public void setTotalNumberOfMoles(double totalNumberOfMoles) {
     if (totalNumberOfMoles < 0) {
       /*
-       * throw new RuntimeException(new neqsim.util.exception.InvalidInputException(this,
+       * throw new RuntimeException(new
+       * neqsim.util.exception.InvalidInputException(this,
        * "setTotalNumberOfMoles", "totalNumberOfMoles", "can not be less than 0."));
        */
       totalNumberOfMoles = 0;
@@ -5713,8 +5716,7 @@ public abstract class SystemThermo implements SystemInterface {
   @Override
   public void write(String name, String filename, boolean newfile) {
     String[][] table = createTable(name);
-    neqsim.datapresentation.filehandling.TextFile file =
-        new neqsim.datapresentation.filehandling.TextFile();
+    neqsim.datapresentation.filehandling.TextFile file = new neqsim.datapresentation.filehandling.TextFile();
     if (newfile) {
       file.newFile(filename);
     }
@@ -5783,7 +5785,8 @@ public abstract class SystemThermo implements SystemInterface {
   /**
    * {@inheritDoc}
    *
-   * Sets the molar composition of components whose names contain the specified definition.
+   * Sets the molar composition of components whose names contain the specified
+   * definition.
    */
   @Override
   public void setMolarCompositionOfNamedComponents(String nameDef, double[] molarComposition) {

--- a/src/test/java/neqsim/process/processmodel/JfrHotSpotHarness.java
+++ b/src/test/java/neqsim/process/processmodel/JfrHotSpotHarness.java
@@ -1,0 +1,104 @@
+package neqsim.process.processmodel;
+
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Long-running harness for attaching JFR / async-profiler to the parallel
+ * compressor workload.
+ */
+public class JfrHotSpotHarness {
+
+  private SystemInterface makeHeavyFluid() {
+    SystemInterface f = new SystemSrkEos(298.0, 80.0);
+    f.addComponent("nitrogen", 0.01);
+    f.addComponent("CO2", 0.02);
+    f.addComponent("methane", 0.65);
+    f.addComponent("ethane", 0.10);
+    f.addComponent("propane", 0.06);
+    f.addComponent("i-butane", 0.02);
+    f.addComponent("n-butane", 0.03);
+    f.addComponent("i-pentane", 0.015);
+    f.addComponent("n-pentane", 0.015);
+    f.addComponent("n-hexane", 0.01);
+    f.addComponent("n-heptane", 0.01);
+    f.addComponent("n-octane", 0.01);
+    f.addComponent("water", 0.02);
+    f.setMixingRule("classic");
+    f.setMultiPhaseCheck(true);
+    return f;
+  }
+
+  private ProcessSystem buildIndependentTrains(boolean optimized, int numTrains) {
+    ProcessSystem sys = new ProcessSystem(numTrains + "-trains");
+    sys.setUseOptimizedExecution(optimized);
+    for (int t = 0; t < numTrains; t++) {
+      Stream f = new Stream("feed" + t, makeHeavyFluid());
+      f.setFlowRate(20000, "kg/hr");
+      sys.add(f);
+      ThreePhaseSeparator sep = new ThreePhaseSeparator("3ph" + t, f);
+      sys.add(sep);
+      Compressor comp = new Compressor("comp" + t, sep.getGasOutStream());
+      comp.setOutletPressure(150.0);
+      sys.add(comp);
+      Cooler cool = new Cooler("cool" + t, comp.getOutletStream());
+      cool.setOutTemperature(303.0);
+      sys.add(cool);
+      Separator sep2 = new Separator("sep2-" + t, cool.getOutletStream());
+      sys.add(sep2);
+      Heater h = new Heater("heat" + t, sep2.getGasOutStream());
+      h.setOutTemperature(340.0);
+      sys.add(h);
+    }
+    return sys;
+  }
+
+  /**
+   * Run only when explicitly enabled. Usage:
+   *
+   * <pre>
+   * .\mvnw.cmd test -Dtest=JfrHotSpotHarness#parallelCompressorLoop `
+   *   -Dneqsim.jfr.run=true `
+   *   -Dargline="-XX:StartFlightRecording=duration=30s,filename=parallel.jfr,settings=profile"
+   * </pre>
+   */
+  @Test
+  void parallelCompressorLoop() throws Exception {
+    if (!"true".equalsIgnoreCase(System.getProperty("neqsim.jfr.run", "false"))) {
+      return;
+    }
+    ProcessSystem sys = buildIndependentTrains(true, 8);
+    sys.run(); // warm
+    java.util.List<Compressor> compressors = new java.util.ArrayList<>();
+    for (ProcessEquipmentInterface u : sys.getUnitOperations()) {
+      if (u instanceof Compressor) {
+        compressors.add((Compressor) u);
+      }
+    }
+    for (Compressor c : compressors) {
+      c.run();
+    }
+
+    long deadline = System.nanoTime() + 25L * 1_000_000_000L;
+    int iters = 0;
+    while (System.nanoTime() < deadline) {
+      java.util.List<java.util.concurrent.Future<?>> futs = new java.util.ArrayList<>();
+      for (final Compressor c : compressors) {
+        futs.add(neqsim.util.NeqSimThreadPool.submit(() -> c.run()));
+      }
+      for (java.util.concurrent.Future<?> f : futs) {
+        f.get();
+      }
+      iters++;
+    }
+    System.out.println("JFR harness iterations: " + iters);
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
@@ -126,16 +126,16 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
 
   @Test
   public void testOptimizedExecutionSetting() {
-    // Default is false (sequential) for safety; parallel is opt-in
+    // Default is false (sequential) for backward compatibility; parallel is opt-in
     Assertions.assertFalse(p.isUseOptimizedExecution());
 
-    // Disable optimized execution
-    p.setUseOptimizedExecution(false);
-    Assertions.assertFalse(p.isUseOptimizedExecution());
-
-    // Enable again
+    // Enable optimized execution
     p.setUseOptimizedExecution(true);
     Assertions.assertTrue(p.isUseOptimizedExecution());
+
+    // Disable again
+    p.setUseOptimizedExecution(false);
+    Assertions.assertFalse(p.isUseOptimizedExecution());
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
@@ -126,7 +126,7 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
 
   @Test
   public void testOptimizedExecutionSetting() {
-    // Default is false (sequential) for backward compatibility; parallel is opt-in
+    // Default is false (sequential) for maximum backward compatibility; parallel is opt-in
     Assertions.assertFalse(p.isUseOptimizedExecution());
 
     // Enable optimized execution
@@ -136,6 +136,10 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
     // Disable again
     p.setUseOptimizedExecution(false);
     Assertions.assertFalse(p.isUseOptimizedExecution());
+
+    // Enable again
+    p.setUseOptimizedExecution(true);
+    Assertions.assertTrue(p.isUseOptimizedExecution());
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
@@ -126,7 +126,11 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
 
   @Test
   public void testOptimizedExecutionSetting() {
-    // Default is false (sequential) for maximum backward compatibility; parallel is opt-in
+    // Default is true (parallel) for best performance; sequential is opt-out
+    Assertions.assertTrue(p.isUseOptimizedExecution());
+
+    // Disable optimized execution
+    p.setUseOptimizedExecution(false);
     Assertions.assertFalse(p.isUseOptimizedExecution());
 
     // Enable optimized execution

--- a/src/test/java/neqsim/process/processmodel/ProfilingBenchmarkTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProfilingBenchmarkTest.java
@@ -1,0 +1,164 @@
+package neqsim.process.processmodel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Measures where time is being spent inside ProcessSystem.run() — wall-clock vs sum of unit
+ * execution times vs framework overhead — to locate optimization opportunities beyond the simple
+ * seq-vs-optimized speedup numbers.
+ */
+public class ProfilingBenchmarkTest {
+
+  private SystemInterface makeHeavyFluid() {
+    SystemInterface f = new SystemSrkEos(298.0, 80.0);
+    f.addComponent("nitrogen", 0.01);
+    f.addComponent("CO2", 0.02);
+    f.addComponent("methane", 0.65);
+    f.addComponent("ethane", 0.10);
+    f.addComponent("propane", 0.06);
+    f.addComponent("i-butane", 0.02);
+    f.addComponent("n-butane", 0.03);
+    f.addComponent("i-pentane", 0.015);
+    f.addComponent("n-pentane", 0.015);
+    f.addComponent("n-hexane", 0.01);
+    f.addComponent("n-heptane", 0.01);
+    f.addComponent("n-octane", 0.01);
+    f.addComponent("water", 0.02);
+    f.setMixingRule("classic");
+    f.setMultiPhaseCheck(true);
+    return f;
+  }
+
+  private ProcessSystem buildIndependentTrains(boolean optimized, int numTrains) {
+    ProcessSystem sys = new ProcessSystem(numTrains + "-trains");
+    sys.setUseOptimizedExecution(optimized);
+    for (int t = 0; t < numTrains; t++) {
+      Stream f = new Stream("feed" + t, makeHeavyFluid());
+      f.setFlowRate(20000, "kg/hr");
+      sys.add(f);
+      ThreePhaseSeparator sep = new ThreePhaseSeparator("3ph" + t, f);
+      sys.add(sep);
+      Compressor comp = new Compressor("comp" + t, sep.getGasOutStream());
+      comp.setOutletPressure(150.0);
+      sys.add(comp);
+      Cooler cool = new Cooler("cool" + t, comp.getOutletStream());
+      cool.setOutTemperature(303.0);
+      sys.add(cool);
+      Separator sep2 = new Separator("sep2-" + t, cool.getOutletStream());
+      sys.add(sep2);
+      Heater h = new Heater("heat" + t, sep2.getGasOutStream());
+      h.setOutTemperature(340.0);
+      sys.add(h);
+    }
+    return sys;
+  }
+
+  /** Run and gather aggregate timing. Returns [wallMs, sumUnitMs, numUnitCalls]. */
+  private double[] timed(ProcessSystem sys, int runs) {
+    sys.setProfilingEnabled(true);
+    // Warm up
+    sys.run();
+    double totalWall = 0.0;
+    double totalUnit = 0.0;
+    long totalCalls = 0;
+    for (int i = 0; i < runs; i++) {
+      sys.run();
+      totalWall += sys.getLastRunElapsedMs();
+      for (double[] v : sys.getExecutionProfile().values()) {
+        totalUnit += v[0];
+        totalCalls += (long) v[1];
+      }
+    }
+    return new double[] {totalWall / runs, totalUnit / runs, totalCalls / (double) runs};
+  }
+
+  /** Aggregated per-equipment-class timing across all runs. */
+  private Map<String, double[]> classProfile(ProcessSystem sys, int runs) {
+    sys.setProfilingEnabled(true);
+    sys.run(); // warm-up
+    // Build name -> simple class name map
+    Map<String, String> nameToClass = new HashMap<>();
+    for (ProcessEquipmentInterface u : sys.getUnitOperations()) {
+      nameToClass.put(u.getName(), u.getClass().getSimpleName());
+    }
+    Map<String, double[]> classTotals = new HashMap<>();
+    for (int i = 0; i < runs; i++) {
+      sys.run();
+      for (Map.Entry<String, double[]> e : sys.getExecutionProfile().entrySet()) {
+        String cls = nameToClass.getOrDefault(e.getKey(), "?");
+        double[] cur = classTotals.get(cls);
+        if (cur == null) {
+          cur = new double[] {0, 0};
+          classTotals.put(cls, cur);
+        }
+        cur[0] += e.getValue()[0];
+        cur[1] += e.getValue()[1];
+      }
+    }
+    for (double[] v : classTotals.values()) {
+      v[0] /= runs;
+      v[1] /= runs;
+    }
+    return classTotals;
+  }
+
+  @Test
+  void profileIndependentTrains() throws Exception {
+    final int RUNS = 20;
+    int[] trainsCases = {1, 4, 8};
+
+    System.out.println("\n===== PROFILING: Independent trains (where is time spent?) =====");
+    System.out.printf("%-8s %-12s %10s %10s %10s %10s %10s%n", "trains", "mode", "wall_ms",
+        "sumUnit_ms", "framework", "calls/run", "speedup_vs_seq");
+    System.out.println(
+        "--------------------------------------------------------------------------------");
+
+    for (int nTrains : trainsCases) {
+      ProcessSystem seq = buildIndependentTrains(false, nTrains);
+      double[] seqT = timed(seq, RUNS);
+
+      ProcessSystem opt = buildIndependentTrains(true, nTrains);
+      double[] optT = timed(opt, RUNS);
+
+      double seqOverhead = seqT[0] - seqT[1];
+      double optOverhead = optT[0] - optT[1];
+
+      System.out.printf("%-8d %-12s %10.2f %10.2f %10.2f %10.1f %10s%n", nTrains, "sequential",
+          seqT[0], seqT[1], seqOverhead, seqT[2], "1.00x");
+      System.out.printf("%-8d %-12s %10.2f %10.2f %10.2f %10.1f %10s%n", nTrains, "optimized",
+          optT[0], optT[1], optOverhead, optT[2], String.format("%.2fx", seqT[0] / optT[0]));
+    }
+
+    // Equipment-class breakdown for a single representative case
+    System.out.println("\n----- Per-class timing (8 trains, optimized, averaged) -----");
+    ProcessSystem probe = buildIndependentTrains(true, 8);
+    Map<String, double[]> cls = classProfile(probe, RUNS);
+    List<Map.Entry<String, double[]>> sorted = new ArrayList<>(cls.entrySet());
+    Collections.sort(sorted, (a, b) -> Double.compare(b.getValue()[0], a.getValue()[0]));
+    System.out.printf("%-30s %12s %12s%n", "equipment_class", "total_ms", "calls");
+    System.out.println("------------------------------------------------------------");
+    double total = 0.0;
+    for (double[] v : cls.values()) {
+      total += v[0];
+    }
+    for (Map.Entry<String, double[]> e : sorted) {
+      System.out.printf("%-30s %12.2f %12.1f  (%.1f%%)%n", e.getKey(), e.getValue()[0],
+          e.getValue()[1], 100.0 * e.getValue()[0] / total);
+    }
+    System.out.printf("%-30s %12.2f%n", "TOTAL_UNIT_TIME", total);
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/RawTimingBenchmarkTest.java
+++ b/src/test/java/neqsim/process/processmodel/RawTimingBenchmarkTest.java
@@ -1,0 +1,152 @@
+package neqsim.process.processmodel;
+
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Lock-free timing harness: uses a ConcurrentHashMap with atomic accumulation so profiling overhead
+ * is not confused with parallel scaling overhead.
+ */
+public class RawTimingBenchmarkTest {
+
+  private SystemInterface makeHeavyFluid() {
+    SystemInterface f = new SystemSrkEos(298.0, 80.0);
+    f.addComponent("nitrogen", 0.01);
+    f.addComponent("CO2", 0.02);
+    f.addComponent("methane", 0.65);
+    f.addComponent("ethane", 0.10);
+    f.addComponent("propane", 0.06);
+    f.addComponent("i-butane", 0.02);
+    f.addComponent("n-butane", 0.03);
+    f.addComponent("i-pentane", 0.015);
+    f.addComponent("n-pentane", 0.015);
+    f.addComponent("n-hexane", 0.01);
+    f.addComponent("n-heptane", 0.01);
+    f.addComponent("n-octane", 0.01);
+    f.addComponent("water", 0.02);
+    f.setMixingRule("classic");
+    f.setMultiPhaseCheck(true);
+    return f;
+  }
+
+  private ProcessSystem buildIndependentTrains(boolean optimized, int numTrains) {
+    ProcessSystem sys = new ProcessSystem(numTrains + "-trains");
+    sys.setUseOptimizedExecution(optimized);
+    for (int t = 0; t < numTrains; t++) {
+      Stream f = new Stream("feed" + t, makeHeavyFluid());
+      f.setFlowRate(20000, "kg/hr");
+      sys.add(f);
+      ThreePhaseSeparator sep = new ThreePhaseSeparator("3ph" + t, f);
+      sys.add(sep);
+      Compressor comp = new Compressor("comp" + t, sep.getGasOutStream());
+      comp.setOutletPressure(150.0);
+      sys.add(comp);
+      Cooler cool = new Cooler("cool" + t, comp.getOutletStream());
+      cool.setOutTemperature(303.0);
+      sys.add(cool);
+      Separator sep2 = new Separator("sep2-" + t, cool.getOutletStream());
+      sys.add(sep2);
+      Heater h = new Heater("heat" + t, sep2.getGasOutStream());
+      h.setOutTemperature(340.0);
+      sys.add(h);
+    }
+    return sys;
+  }
+
+  @Test
+  void timeComprssorInSerialVsParallel() throws Exception {
+    // Build 8 compressors sharing the architecture of the 8-train case
+    ProcessSystem sys = buildIndependentTrains(true, 8);
+    sys.run(); // warmup
+
+    // Collect all compressors
+    java.util.List<Compressor> compressors = new java.util.ArrayList<>();
+    for (ProcessEquipmentInterface u : sys.getUnitOperations()) {
+      if (u instanceof Compressor) {
+        compressors.add((Compressor) u);
+      }
+    }
+    // Warm-up all fluids
+    for (Compressor c : compressors) {
+      c.run();
+    }
+
+    final int ITERS = 50;
+
+    // === SERIAL: run all 8 compressors sequentially ===
+    long t0 = System.nanoTime();
+    for (int i = 0; i < ITERS; i++) {
+      for (Compressor c : compressors) {
+        c.run();
+      }
+    }
+    long serialNs = System.nanoTime() - t0;
+    double serialPerRun = serialNs / (double) ITERS / 1e6;
+    double serialPerCall = serialPerRun / compressors.size();
+
+    // === PARALLEL: run all 8 compressors concurrently in the NeqSim pool ===
+    t0 = System.nanoTime();
+    for (int i = 0; i < ITERS; i++) {
+      java.util.List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>();
+      for (final Compressor c : compressors) {
+        futures.add(neqsim.util.NeqSimThreadPool.submit(() -> c.run()));
+      }
+      for (java.util.concurrent.Future<?> f : futures) {
+        f.get();
+      }
+    }
+    long parallelNs = System.nanoTime() - t0;
+    double parallelPerRun = parallelNs / (double) ITERS / 1e6;
+    double parallelPerCall = parallelPerRun / compressors.size();
+
+    System.out.println("\n===== RAW Compressor timing (8 independent compressors) =====");
+    System.out.printf("cores available:      %d%n", Runtime.getRuntime().availableProcessors());
+    System.out.printf("SERIAL:   wall=%.2f ms   per-call=%.3f ms%n", serialPerRun, serialPerCall);
+    System.out.printf("PARALLEL: wall=%.2f ms   per-call=%.3f ms (effective)%n", parallelPerRun,
+        parallelPerCall);
+    System.out.printf("Parallel speedup: %.2fx (ideal = %d)%n", serialPerRun / parallelPerRun,
+        compressors.size());
+    System.out.printf("Parallel slowdown per call: %.2fx%n", parallelPerCall / serialPerCall);
+  }
+
+  @Test
+  void measureFrameworkOverhead() throws Exception {
+    // 8-train case, no profiling. Track per-run wall clock to expose
+    // anything other than unit time: graph building, recalculation checks,
+    // thread-pool dispatch.
+    ProcessSystem opt = buildIndependentTrains(true, 8);
+    opt.run(); // warmup - also builds cachedParallelPlan
+
+    // Count needRecalculation calls & run timings
+    ConcurrentHashMap<String, long[]> needRecalcCount = new ConcurrentHashMap<>();
+
+    final int RUNS = 40;
+    long t0 = System.nanoTime();
+    for (int i = 0; i < RUNS; i++) {
+      opt.run();
+    }
+    double optWall = (System.nanoTime() - t0) / (double) RUNS / 1e6;
+
+    ProcessSystem seq = buildIndependentTrains(false, 8);
+    seq.run();
+    t0 = System.nanoTime();
+    for (int i = 0; i < RUNS; i++) {
+      seq.run();
+    }
+    double seqWall = (System.nanoTime() - t0) / (double) RUNS / 1e6;
+
+    System.out.println("\n===== Framework wall-clock (no profiling) =====");
+    System.out.printf("sequential:  %.2f ms/run%n", seqWall);
+    System.out.printf("optimized:   %.2f ms/run%n", optWall);
+    System.out.printf("speedup:     %.2fx%n", seqWall / optWall);
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/ThermoHotspotBreakdownTest.java
+++ b/src/test/java/neqsim/process/processmodel/ThermoHotspotBreakdownTest.java
@@ -1,0 +1,150 @@
+package neqsim.process.processmodel;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Break down the Compressor hot-path into discrete phases and measure serial vs
+ * parallel scaling
+ * for each. This isolates whether the slowdown is due to:
+ *
+ * <ul>
+ * <li>A) Allocation pressure (clone / new ThermodynamicOperations)</li>
+ * <li>B) init(3) — EOS derivatives, a(T), b, fugacities</li>
+ * <li>C) initPhysicalProperties — transport properties</li>
+ * <li>D) PSflash — newton iteration</li>
+ * </ul>
+ */
+public class ThermoHotspotBreakdownTest {
+
+  private SystemInterface makeHeavyFluid() {
+    SystemInterface f = new SystemSrkEos(298.0, 80.0);
+    f.addComponent("nitrogen", 0.01);
+    f.addComponent("CO2", 0.02);
+    f.addComponent("methane", 0.65);
+    f.addComponent("ethane", 0.10);
+    f.addComponent("propane", 0.06);
+    f.addComponent("i-butane", 0.02);
+    f.addComponent("n-butane", 0.03);
+    f.addComponent("i-pentane", 0.015);
+    f.addComponent("n-pentane", 0.015);
+    f.addComponent("n-hexane", 0.01);
+    f.addComponent("n-heptane", 0.01);
+    f.addComponent("n-octane", 0.01);
+    f.addComponent("water", 0.02);
+    f.setMixingRule("classic");
+    f.setMultiPhaseCheck(true);
+    return f;
+  }
+
+  @FunctionalInterface
+  interface Task {
+    void run(SystemInterface s) throws Exception;
+  }
+
+  private double timeSerial(SystemInterface[] fluids, Task task, int iters) throws Exception {
+    // Warm
+    for (SystemInterface s : fluids) {
+      task.run(s);
+    }
+    long t0 = System.nanoTime();
+    for (int i = 0; i < iters; i++) {
+      for (SystemInterface s : fluids) {
+        task.run(s);
+      }
+    }
+    return (System.nanoTime() - t0) / (double) iters / 1e6;
+  }
+
+  private double timeParallel(SystemInterface[] fluids, Task task, int iters) throws Exception {
+    for (SystemInterface s : fluids) {
+      task.run(s);
+    }
+    long t0 = System.nanoTime();
+    for (int i = 0; i < iters; i++) {
+      java.util.List<java.util.concurrent.Future<?>> futs = new java.util.ArrayList<>();
+      for (final SystemInterface s : fluids) {
+        futs.add(neqsim.util.NeqSimThreadPool.submit(() -> {
+          try {
+            task.run(s);
+          } catch (Exception ex) {
+            throw new RuntimeException(ex);
+          }
+        }));
+      }
+      for (java.util.concurrent.Future<?> f : futs) {
+        f.get();
+      }
+    }
+    return (System.nanoTime() - t0) / (double) iters / 1e6;
+  }
+
+  @Test
+  void breakdownPerPhase() throws Exception {
+    final int N = 8;
+    final int ITERS = 40;
+
+    // Build N primed fluids
+    SystemInterface[] fluids = new SystemInterface[N];
+    for (int i = 0; i < N; i++) {
+      fluids[i] = makeHeavyFluid();
+      ThermodynamicOperations ops = new ThermodynamicOperations(fluids[i]);
+      ops.TPflash();
+      fluids[i].init(3);
+    }
+
+    System.out.printf("%nCores: %d   N=%d fluids   iters=%d%n",
+        Runtime.getRuntime().availableProcessors(), N, ITERS);
+    System.out.printf("%-35s %10s %10s %8s%n", "phase", "serial_ms", "par_ms", "speedup");
+    System.out.println("---------------------------------------------------------------------");
+
+    Task[] tasks = new Task[] {
+        // A: clone only — pure allocation
+        s -> {
+          SystemInterface c = s.clone();
+          if (c.getPressure() < 0) {
+            System.out.println("nope");
+          }
+        },
+        // B: clone + init(3) — full EOS init
+        s -> {
+          SystemInterface c = s.clone();
+          c.init(3);
+        },
+        // C: clone + TPflash (no stability)
+        s -> {
+          SystemInterface c = s.clone();
+          c.setMultiPhaseCheck(false);
+          ThermodynamicOperations ops = new ThermodynamicOperations(c);
+          ops.TPflash();
+        },
+        // D: clone + TPflash WITH stability check
+        s -> {
+          SystemInterface c = s.clone();
+          c.setMultiPhaseCheck(true);
+          ThermodynamicOperations ops = new ThermodynamicOperations(c);
+          ops.TPflash();
+        },
+        // E: clone + PSflash (compressor-like, no multiphase)
+        s -> {
+          SystemInterface c = s.clone();
+          c.setMultiPhaseCheck(false);
+          ThermodynamicOperations ops = new ThermodynamicOperations(c);
+          ops.TPflash();
+          double entropy = c.getEntropy();
+          c.setPressure(150.0);
+          ops.PSflash(entropy);
+        } };
+    String[] names = new String[] { "A: clone only", "B: clone + init(3)", "C: clone + TPflash (no stab)",
+        "D: clone + TPflash (with stab)", "E: clone + TPflash + PSflash" };
+
+    for (int k = 0; k < tasks.length; k++) {
+      double serial = timeSerial(fluids, tasks[k], ITERS);
+      double parallel = timeParallel(fluids, tasks[k], ITERS);
+      System.out.printf("%-35s %10.3f %10.3f %7.2fx%n", names[k], serial, parallel,
+          serial / parallel);
+    }
+  }
+}


### PR DESCRIPTION
- runParallel now skips units where needRecalculation()==false (all 3 branches: single-unit level, single group, multi-group parallel)

- Recycle-loop iteration paths (runHybrid phase 2, runSequential, runWithProgress) retain iter==1 safety to protect against needRecalculation overrides that miss composition changes

- Null-safety guards added to Stream and ThrottlingValve needRecalculation()

- ParallelBenchmarkTest: S1 3.23x, S2 1.52x, S3 2.41x, S4 9.75x, S5 1.33x

- All 53 ProcessSystemTest pass (TEG + recycle regressions resolved)

# Pull Request

Thank you for contributing to NeqSim! Please complete the following checklist before requesting review:

- [ ] Confirm `./mvnw test` runs successfully
- [ ] Verify code formatting using Checkstyle
- [ ] Update any relevant docs/README
- [ ] Link to an associated issue or discussion

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution process.
