### PR TITLE
Add paralell for multiport

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -537,13 +537,15 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
   /** {@inheritDoc} */
   @Override
   public boolean needRecalculation() {
-    if (thermoSystem == null) {
+    if (thermoSystem == null || inStream == null || inStream.getThermoSystem() == null) {
       return true;
     }
     if (inStream.getThermoSystem().getTemperature() == thermoSystem.getTemperature()
         && inStream.getThermoSystem().getPressure() == thermoSystem.getPressure()
         && inStream.getThermoSystem().getFlowRate("kg/hr") == thermoSystem.getFlowRate("kg/hr")
-        && Math.abs(pressure - outStream.getPressure(pressureUnit)) < 1e-6) {
+        && Math.abs(pressure - outStream.getPressure(pressureUnit)) < 1e-6
+        && java.util.Arrays.equals(inStream.getThermoSystem().getMolarComposition(),
+            thermoSystem.getMolarComposition())) {
       return false;
     }
     return true;

--- a/src/main/java/neqsim/process/equipment/heatexchanger/Dryer.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Dryer.java
@@ -15,14 +15,18 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * Dryer for removing moisture from wet solids or liquid streams.
  *
  * <p>
- * Models various drying equipment including drum dryers, spray dryers, and flash dryers. The dryer
- * evaporates a specified amount of volatile components (typically water) from the feed to achieve a
+ * Models various drying equipment including drum dryers, spray dryers, and
+ * flash dryers. The dryer
+ * evaporates a specified amount of volatile components (typically water) from
+ * the feed to achieve a
  * target moisture content or outlet temperature.
  * </p>
  *
  * <p>
- * The drying process is modeled as a heated flash: the feed is heated to generate vapor, which is
- * separated from the dried product. The energy input determines how much moisture is removed.
+ * The drying process is modeled as a heated flash: the feed is heated to
+ * generate vapor, which is
+ * separated from the dried product. The energy input determines how much
+ * moisture is removed.
  * </p>
  *
  * <p>
@@ -100,7 +104,7 @@ public class Dryer extends ProcessEquipmentBaseClass {
   /**
    * Constructor for Dryer with inlet stream.
    *
-   * @param name name of the dryer
+   * @param name        name of the dryer
    * @param inletStream the wet feed stream
    */
   public Dryer(String name, StreamInterface inletStream) {
@@ -147,6 +151,28 @@ public class Dryer extends ProcessEquipmentBaseClass {
     return vaporStream;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getInletStreams() {
+    if (inletStream == null) {
+      return java.util.Collections.emptyList();
+    }
+    return java.util.Collections.singletonList(inletStream);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getOutletStreams() {
+    java.util.List<StreamInterface> out = new java.util.ArrayList<>();
+    if (driedProductStream != null) {
+      out.add(driedProductStream);
+    }
+    if (vaporStream != null) {
+      out.add(vaporStream);
+    }
+    return out;
+  }
+
   /**
    * Set the dryer type.
    *
@@ -178,7 +204,7 @@ public class Dryer extends ProcessEquipmentBaseClass {
    * Set the outlet temperature with unit.
    *
    * @param temperature temperature value
-   * @param unit temperature unit ("K", "C", "F")
+   * @param unit        temperature unit ("K", "C", "F")
    */
   public void setOutletTemperature(double temperature, String unit) {
     if ("C".equalsIgnoreCase(unit)) {

--- a/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
@@ -114,6 +114,8 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface, Sta
   private double lastInStream2FlowRate = 0.0;
   /** Cached UA value for needRecalculation check. */
   private double lastUAvalue = 0.0;
+  /** Cached inlet stream 2 composition for needRecalculation check. */
+  private double[] lastInStream2Composition = null;
 
   // Dynamic simulation fields
   /** Metal wall mass in kg. */
@@ -475,6 +477,10 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface, Sta
     if (flow2 > 0 && Math.abs(flow2 - lastInStream2FlowRate) / flow2 > 1e-6) {
       return true;
     }
+    if (lastInStream2Composition == null || !java.util.Arrays
+        .equals(inStream[1].getThermoSystem().getMolarComposition(), lastInStream2Composition)) {
+      return true;
+    }
     return false;
   }
 
@@ -503,6 +509,13 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface, Sta
     lastOutPressure = pressureOut;
     lastOutTemperature = temperatureOut;
     lastPressureDrop = getPressureDrop();
+    // Composition tracking for both streams
+    if (inStream[0] != null && inStream[0].getThermoSystem() != null) {
+      lastComposition = inStream[0].getThermoSystem().getMolarComposition().clone();
+    }
+    if (inStream[1] != null && inStream[1].getThermoSystem() != null) {
+      lastInStream2Composition = inStream[1].getThermoSystem().getMolarComposition().clone();
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
@@ -79,6 +79,7 @@ public class Heater extends TwoPortEquipment implements HeaterInterface,
   protected double lastOutTemperature = 0.0;
   protected double lastDuty = 0.0;
   protected double lastPressureDrop = 0.0;
+  protected double[] lastComposition = null;
 
   protected transient HeatExchangerMechanicalDesign mechanicalDesign;
   HeatExchangerElectricalDesign electricalDesign;
@@ -316,15 +317,19 @@ public class Heater extends TwoPortEquipment implements HeaterInterface,
   /** {@inheritDoc} */
   @Override
   public boolean needRecalculation() {
-    if (inStream == null) {
+    if (inStream == null || inStream.getFluid() == null || lastComposition == null) {
       return true;
     }
-    if (inStream.getFluid().getTemperature() == lastTemperature
-        && inStream.getFluid().getPressure() == lastPressure
-        && Math.abs(inStream.getFluid().getFlowRate("kg/hr") - lastFlowRate)
-            / inStream.getFluid().getFlowRate("kg/hr") < 1e-6
-        && lastDuty == getDuty() && lastOutPressure == pressureOut
-        && lastOutTemperature == temperatureOut && getPressureDrop() == lastPressureDrop) {
+    SystemInterface inFluid = inStream.getFluid();
+    double inFlow = inFluid.getFlowRate("kg/hr");
+    if (inFlow <= 0.0 || lastFlowRate <= 0.0) {
+      return true;
+    }
+    if (inFluid.getTemperature() == lastTemperature && inFluid.getPressure() == lastPressure
+        && Math.abs(inFlow - lastFlowRate) / inFlow < 1e-6 && lastDuty == getDuty()
+        && lastOutPressure == pressureOut && lastOutTemperature == temperatureOut
+        && getPressureDrop() == lastPressureDrop
+        && java.util.Arrays.equals(inFluid.getMolarComposition(), lastComposition)) {
       return false;
     } else {
       return true;
@@ -347,6 +352,7 @@ public class Heater extends TwoPortEquipment implements HeaterInterface,
       lastOutPressure = pressureOut;
       lastOutTemperature = temperatureOut;
       lastPressureDrop = pressureDrop;
+      lastComposition = inStream.getFluid().getMolarComposition().clone();
       setCalculationIdentifier(id);
       return;
     }
@@ -398,6 +404,7 @@ public class Heater extends TwoPortEquipment implements HeaterInterface,
     lastOutPressure = pressureOut;
     lastOutTemperature = temperatureOut;
     lastPressureDrop = pressureDrop;
+    lastComposition = inStream.getFluid().getMolarComposition().clone();
     setCalculationIdentifier(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/heatexchanger/MultiEffectEvaporator.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/MultiEffectEvaporator.java
@@ -17,13 +17,16 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * Multi-effect evaporator for concentration of solutions.
  *
  * <p>
- * Models a series of evaporator effects at decreasing pressures. Each effect uses the vapor from
- * the previous effect as the heating medium, achieving significant steam economy. Commonly used in
+ * Models a series of evaporator effects at decreasing pressures. Each effect
+ * uses the vapor from
+ * the previous effect as the heating medium, achieving significant steam
+ * economy. Commonly used in
  * sugar refining, dairy processing, and bio-product concentration.
  * </p>
  *
  * <p>
- * The model performs sequential flash calculations at decreasing pressures, removing vapor at each
+ * The model performs sequential flash calculations at decreasing pressures,
+ * removing vapor at each
  * stage to concentrate the liquid product.
  * </p>
  *
@@ -100,7 +103,7 @@ public class MultiEffectEvaporator extends ProcessEquipmentBaseClass {
   /**
    * Constructor for MultiEffectEvaporator with inlet stream.
    *
-   * @param name name of the evaporator
+   * @param name        name of the evaporator
    * @param inletStream the feed stream
    */
   public MultiEffectEvaporator(String name, StreamInterface inletStream) {
@@ -145,6 +148,28 @@ public class MultiEffectEvaporator extends ProcessEquipmentBaseClass {
    */
   public StreamInterface getVaporCondensateStream() {
     return vaporCondensateStream;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getInletStreams() {
+    if (inletStream == null) {
+      return java.util.Collections.emptyList();
+    }
+    return java.util.Collections.singletonList(inletStream);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getOutletStreams() {
+    java.util.List<StreamInterface> out = new java.util.ArrayList<>();
+    if (concentrateStream != null) {
+      out.add(concentrateStream);
+    }
+    if (vaporCondensateStream != null) {
+      out.add(vaporCondensateStream);
+    }
+    return out;
   }
 
   /**
@@ -279,8 +304,7 @@ public class MultiEffectEvaporator extends ProcessEquipmentBaseClass {
     for (int i = 0; i < numberOfEffects; i++) {
       double fraction = (double) i / (numberOfEffects - 1);
       // Geometric interpolation
-      double pressure =
-          firstEffectPressure * Math.pow(lastEffectPressure / firstEffectPressure, fraction);
+      double pressure = firstEffectPressure * Math.pow(lastEffectPressure / firstEffectPressure, fraction);
       effectPressures.add(pressure);
     }
   }

--- a/src/main/java/neqsim/process/equipment/membrane/MembraneSeparator.java
+++ b/src/main/java/neqsim/process/equipment/membrane/MembraneSeparator.java
@@ -11,8 +11,10 @@ import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
- * Simple membrane separation unit with one inlet stream and two outlet streams (retentate and
- * permeate). Each component can be assigned a permeate fraction representing the fraction of that
+ * Simple membrane separation unit with one inlet stream and two outlet streams
+ * (retentate and
+ * permeate). Each component can be assigned a permeate fraction representing
+ * the fraction of that
  * component transported to the permeate side.
  *
  * @author esol
@@ -45,8 +47,9 @@ public class MembraneSeparator extends ProcessEquipmentBaseClass {
    * Constructor for MembraneSeparator.
    * </p>
    *
-   * @param name a {@link java.lang.String} object
-   * @param inletStream a {@link neqsim.process.equipment.stream.StreamInterface} object
+   * @param name        a {@link java.lang.String} object
+   * @param inletStream a {@link neqsim.process.equipment.stream.StreamInterface}
+   *                    object
    */
   public MembraneSeparator(String name, StreamInterface inletStream) {
     this(name);
@@ -58,14 +61,13 @@ public class MembraneSeparator extends ProcessEquipmentBaseClass {
    * Setter for the field <code>inletStream</code>.
    * </p>
    *
-   * @param inletStream a {@link neqsim.process.equipment.stream.StreamInterface} object
+   * @param inletStream a {@link neqsim.process.equipment.stream.StreamInterface}
+   *                    object
    */
   public void setInletStream(StreamInterface inletStream) {
     this.inletStream = inletStream;
-    this.permeateStream =
-        new Stream(getName() + " permeate", inletStream.getThermoSystem().clone());
-    this.retentateStream =
-        new Stream(getName() + " retentate", inletStream.getThermoSystem().clone());
+    this.permeateStream = new Stream(getName() + " permeate", inletStream.getThermoSystem().clone());
+    this.retentateStream = new Stream(getName() + " retentate", inletStream.getThermoSystem().clone());
   }
 
   /**
@@ -99,6 +101,28 @@ public class MembraneSeparator extends ProcessEquipmentBaseClass {
     return retentateStream;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getInletStreams() {
+    if (inletStream == null) {
+      return java.util.Collections.emptyList();
+    }
+    return java.util.Collections.singletonList(inletStream);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getOutletStreams() {
+    java.util.List<StreamInterface> out = new java.util.ArrayList<>();
+    if (permeateStream != null) {
+      out.add(permeateStream);
+    }
+    if (retentateStream != null) {
+      out.add(retentateStream);
+    }
+    return out;
+  }
+
   /**
    * Set membrane area used for permeability calculations.
    *
@@ -120,7 +144,7 @@ public class MembraneSeparator extends ProcessEquipmentBaseClass {
   /**
    * Specify permeability coefficient for a component.
    *
-   * @param component component name
+   * @param component    component name
    * @param permeability permeability in mol/(m2*s*Pa)
    */
   public void setPermeability(String component, double permeability) {
@@ -148,7 +172,7 @@ public class MembraneSeparator extends ProcessEquipmentBaseClass {
    * Specify permeate fraction for a component.
    *
    * @param component component name
-   * @param fraction permeate fraction (0-1)
+   * @param fraction  permeate fraction (0-1)
    */
   public void setPermeateFraction(String component, double fraction) {
     permeateFractions.put(component, Math.max(0.0, Math.min(1.0, fraction)));
@@ -192,11 +216,9 @@ public class MembraneSeparator extends ProcessEquipmentBaseClass {
         permeateStream.getThermoSystem().addComponent(name, molesPerm);
       }
 
-      ThermodynamicOperations opsRet =
-          new ThermodynamicOperations(retentateStream.getThermoSystem());
+      ThermodynamicOperations opsRet = new ThermodynamicOperations(retentateStream.getThermoSystem());
       opsRet.TPflash();
-      ThermodynamicOperations opsPerm =
-          new ThermodynamicOperations(permeateStream.getThermoSystem());
+      ThermodynamicOperations opsPerm = new ThermodynamicOperations(permeateStream.getThermoSystem());
       opsPerm.TPflash();
 
       retentateStream.setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/powergeneration/FuelCell.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/FuelCell.java
@@ -50,8 +50,8 @@ public class FuelCell extends TwoPortEquipment {
    * Constructor for FuelCell.
    * </p>
    *
-   * @param name name of unit operation
-   * @param fuelStream inlet fuel stream
+   * @param name          name of unit operation
+   * @param fuelStream    inlet fuel stream
    * @param oxidantStream inlet oxidant stream
    */
   public FuelCell(String name, StreamInterface fuelStream, StreamInterface oxidantStream) {
@@ -60,7 +60,9 @@ public class FuelCell extends TwoPortEquipment {
   }
 
   /**
-   * <p>Setter for the field <code>oxidantStream</code>.</p>
+   * <p>
+   * Setter for the field <code>oxidantStream</code>.
+   * </p>
    *
    * @param stream oxidant stream
    */
@@ -69,7 +71,9 @@ public class FuelCell extends TwoPortEquipment {
   }
 
   /**
-   * <p>Getter for the field <code>oxidantStream</code>.</p>
+   * <p>
+   * Getter for the field <code>oxidantStream</code>.
+   * </p>
    *
    * @return oxidant stream
    */
@@ -77,8 +81,24 @@ public class FuelCell extends TwoPortEquipment {
     return oxidantStream;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getInletStreams() {
+    java.util.List<StreamInterface> in = new java.util.ArrayList<>();
+    StreamInterface fuel = getInletStream();
+    if (fuel != null) {
+      in.add(fuel);
+    }
+    if (oxidantStream != null) {
+      in.add(oxidantStream);
+    }
+    return in;
+  }
+
   /**
-   * <p>Setter for the field <code>efficiency</code>.</p>
+   * <p>
+   * Setter for the field <code>efficiency</code>.
+   * </p>
    *
    * @param efficiency electrical efficiency of the cell
    */
@@ -87,7 +107,9 @@ public class FuelCell extends TwoPortEquipment {
   }
 
   /**
-   * <p>Getter for the field <code>efficiency</code>.</p>
+   * <p>
+   * Getter for the field <code>efficiency</code>.
+   * </p>
    *
    * @return efficiency of the cell
    */
@@ -96,7 +118,9 @@ public class FuelCell extends TwoPortEquipment {
   }
 
   /**
-   * <p>Getter for the field <code>power</code>.</p>
+   * <p>
+   * Getter for the field <code>power</code>.
+   * </p>
    *
    * @return electrical power produced [W]
    */
@@ -105,7 +129,9 @@ public class FuelCell extends TwoPortEquipment {
   }
 
   /**
-   * <p>Getter for the field <code>heatLoss</code>.</p>
+   * <p>
+   * Getter for the field <code>heatLoss</code>.
+   * </p>
    *
    * @return heat lost from the cell [W]
    */
@@ -154,4 +180,3 @@ public class FuelCell extends TwoPortEquipment {
     setCalculationIdentifier(id);
   }
 }
-

--- a/src/main/java/neqsim/process/equipment/separator/Crystallizer.java
+++ b/src/main/java/neqsim/process/equipment/separator/Crystallizer.java
@@ -15,14 +15,18 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * Crystallizer for producing solid crystals from solution.
  *
  * <p>
- * Models a crystallization process where dissolved solutes are brought out of solution as solid
- * crystals. Supports cooling crystallization (reducing temperature), evaporative crystallization
+ * Models a crystallization process where dissolved solutes are brought out of
+ * solution as solid
+ * crystals. Supports cooling crystallization (reducing temperature),
+ * evaporative crystallization
  * (removing solvent), and anti-solvent crystallization.
  * </p>
  *
  * <p>
- * The crystallizer operates by flashing the feed at reduced temperature and/or pressure to
- * concentrate the solution beyond the saturation point, causing crystallization. NeqSim's solid
+ * The crystallizer operates by flashing the feed at reduced temperature and/or
+ * pressure to
+ * concentrate the solution beyond the saturation point, causing
+ * crystallization. NeqSim's solid
  * phase equilibrium capabilities (TPSolidflash) are leveraged when available.
  * </p>
  *
@@ -98,7 +102,7 @@ public class Crystallizer extends ProcessEquipmentBaseClass {
   /**
    * Constructor for Crystallizer with inlet stream.
    *
-   * @param name name of the crystallizer
+   * @param name        name of the crystallizer
    * @param inletStream the feed stream
    */
   public Crystallizer(String name, StreamInterface inletStream) {
@@ -145,6 +149,28 @@ public class Crystallizer extends ProcessEquipmentBaseClass {
     return motherLiquorStream;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getInletStreams() {
+    if (inletStream == null) {
+      return java.util.Collections.emptyList();
+    }
+    return java.util.Collections.singletonList(inletStream);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getOutletStreams() {
+    java.util.List<StreamInterface> out = new java.util.ArrayList<>();
+    if (crystalStream != null) {
+      out.add(crystalStream);
+    }
+    if (motherLiquorStream != null) {
+      out.add(motherLiquorStream);
+    }
+    return out;
+  }
+
   /**
    * Set the crystallization type.
    *
@@ -176,7 +202,7 @@ public class Crystallizer extends ProcessEquipmentBaseClass {
    * Set the outlet temperature with unit.
    *
    * @param temperature temperature value
-   * @param unit temperature unit ("K", "C", "F")
+   * @param unit        temperature unit ("K", "C", "F")
    */
   public void setOutletTemperature(double temperature, String unit) {
     if ("C".equalsIgnoreCase(unit)) {

--- a/src/main/java/neqsim/process/equipment/separator/LiquidLiquidExtractor.java
+++ b/src/main/java/neqsim/process/equipment/separator/LiquidLiquidExtractor.java
@@ -13,16 +13,20 @@ import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
- * Liquid-liquid extractor for separation of components between two immiscible liquid phases.
+ * Liquid-liquid extractor for separation of components between two immiscible
+ * liquid phases.
  *
  * <p>
- * Models a single-stage or multi-stage liquid-liquid extraction unit. Takes a feed stream and a
- * solvent stream, mixes them, and performs a liquid-liquid equilibrium (LLE) flash to separate into
+ * Models a single-stage or multi-stage liquid-liquid extraction unit. Takes a
+ * feed stream and a
+ * solvent stream, mixes them, and performs a liquid-liquid equilibrium (LLE)
+ * flash to separate into
  * extract (solvent-rich) and raffinate (feed-rich) phases.
  * </p>
  *
  * <p>
- * Leverages NeqSim's built-in LLE flash capabilities for thermodynamically rigorous phase
+ * Leverages NeqSim's built-in LLE flash capabilities for thermodynamically
+ * rigorous phase
  * separation.
  * </p>
  *
@@ -87,8 +91,8 @@ public class LiquidLiquidExtractor extends ProcessEquipmentBaseClass {
   /**
    * Constructor for LiquidLiquidExtractor with feed and solvent streams.
    *
-   * @param name name of the extractor
-   * @param feedStream the feed stream
+   * @param name          name of the extractor
+   * @param feedStream    the feed stream
    * @param solventStream the solvent stream
    */
   public LiquidLiquidExtractor(String name, StreamInterface feedStream,
@@ -165,6 +169,32 @@ public class LiquidLiquidExtractor extends ProcessEquipmentBaseClass {
    */
   public StreamInterface getRaffinateStream() {
     return raffinateStream;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getInletStreams() {
+    java.util.List<StreamInterface> in = new java.util.ArrayList<>();
+    if (feedStream != null) {
+      in.add(feedStream);
+    }
+    if (solventStream != null) {
+      in.add(solventStream);
+    }
+    return in;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getOutletStreams() {
+    java.util.List<StreamInterface> out = new java.util.ArrayList<>();
+    if (extractStream != null) {
+      out.add(extractStream);
+    }
+    if (raffinateStream != null) {
+      out.add(raffinateStream);
+    }
+    return out;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/splitter/Splitter.java
+++ b/src/main/java/neqsim/process/equipment/splitter/Splitter.java
@@ -261,11 +261,16 @@ public class Splitter extends ProcessEquipmentBaseClass
     if (inletStream.needRecalculation()) {
       return true;
     }
+    if (lastComposition == null || inletStream.getFluid().getFlowRate("kg/hr") <= 0.0
+        || lastFlowRate <= 0.0) {
+      return true;
+    }
     if (inletStream.getFluid().getTemperature() == lastTemperature
         && inletStream.getFluid().getPressure() == lastPressure
         && Math.abs(inletStream.getFluid().getFlowRate("kg/hr") - lastFlowRate)
             / inletStream.getFluid().getFlowRate("kg/hr") < 1e-6
-        && Arrays.equals(splitFactor, oldSplitFactor)) {
+        && Arrays.equals(splitFactor, oldSplitFactor)
+        && Arrays.equals(inletStream.getFluid().getMolarComposition(), lastComposition)) {
       return false;
     } else {
       return true;
@@ -313,7 +318,7 @@ public class Splitter extends ProcessEquipmentBaseClass
     lastFlowRate = inletStream.getFluid().getFlowRate("kg/hr");
     lastTemperature = inletStream.getFluid().getTemperature();
     lastPressure = inletStream.getFluid().getPressure();
-    lastComposition = inletStream.getFluid().getMolarComposition();
+    lastComposition = inletStream.getFluid().getMolarComposition().clone();
     oldSplitFactor = Arrays.copyOf(splitFactor, splitFactor.length);
 
     setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -328,10 +328,17 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
       }
       thermoSystem = stream.getFluid();
     }
-    if (getFluid().getTemperature() == lastTemperature && getFluid().getPressure() == lastPressure
-        && Math.abs(getFluid().getFlowRate("kg/hr") - lastFlowRate)
-            / getFluid().getFlowRate("kg/hr") < 1e-6
-        && Arrays.equals(getFluid().getMolarComposition(), lastComposition)) {
+    SystemInterface fluid = getFluid();
+    if (fluid == null || lastComposition == null) {
+      return true;
+    }
+    double flow = fluid.getFlowRate("kg/hr");
+    if (flow <= 0.0 || lastFlowRate <= 0.0) {
+      return true;
+    }
+    if (fluid.getTemperature() == lastTemperature && fluid.getPressure() == lastPressure
+        && Math.abs(flow - lastFlowRate) / flow < 1e-6
+        && Arrays.equals(fluid.getMolarComposition(), lastComposition)) {
       return false;
     } else {
       return true;

--- a/src/main/java/neqsim/process/equipment/subsea/SubseaManifold.java
+++ b/src/main/java/neqsim/process/equipment/subsea/SubseaManifold.java
@@ -16,7 +16,8 @@ import neqsim.thermo.system.SystemInterface;
  * Subsea Production Manifold equipment class.
  *
  * <p>
- * A subsea manifold gathers production from multiple wells and routes it to flowlines for transport
+ * A subsea manifold gathers production from multiple wells and routes it to
+ * flowlines for transport
  * to the host facility. Key features include:
  * </p>
  * <ul>
@@ -280,7 +281,7 @@ public class SubseaManifold extends ProcessEquipmentBaseClass {
   /**
    * Constructor with name and number of slots.
    *
-   * @param name equipment name
+   * @param name          equipment name
    * @param numberOfSlots number of well slots
    */
   public SubseaManifold(String name, int numberOfSlots) {
@@ -319,7 +320,7 @@ public class SubseaManifold extends ProcessEquipmentBaseClass {
    * Add well stream with well name.
    *
    * @param wellStream well inlet stream
-   * @param wellName well name
+   * @param wellName   well name
    * @return slot number assigned
    */
   public int addWellStream(StreamInterface wellStream, String wellName) {
@@ -331,8 +332,8 @@ public class SubseaManifold extends ProcessEquipmentBaseClass {
         skid.setActive(true);
 
         // Create production valve
-        ThrottlingValve prodValve =
-            new ThrottlingValve(getName() + " Slot " + skid.getSlotNumber() + " Prod", wellStream);
+        ThrottlingValve prodValve = new ThrottlingValve(getName() + " Slot " + skid.getSlotNumber() + " Prod",
+            wellStream);
         prodValve.setPercentValveOpening(100.0);
         skid.setProductionValve(prodValve);
 
@@ -485,7 +486,7 @@ public class SubseaManifold extends ProcessEquipmentBaseClass {
   /**
    * Apply pressure drop to stream.
    *
-   * @param stream stream to modify
+   * @param stream       stream to modify
    * @param pressureDrop pressure drop in bar
    */
   private void applyPressureDrop(StreamInterface stream, double pressureDrop) {
@@ -514,6 +515,33 @@ public class SubseaManifold extends ProcessEquipmentBaseClass {
    */
   public StreamInterface getTestStream() {
     return testStream;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getInletStreams() {
+    java.util.List<StreamInterface> in = new java.util.ArrayList<>();
+    if (valveSkids != null) {
+      for (ValveSkid skid : valveSkids) {
+        if (skid != null && skid.getConnectedStream() != null) {
+          in.add(skid.getConnectedStream());
+        }
+      }
+    }
+    return in;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public java.util.List<StreamInterface> getOutletStreams() {
+    java.util.List<StreamInterface> out = new java.util.ArrayList<>();
+    if (productionStream != null) {
+      out.add(productionStream);
+    }
+    if (testStream != null) {
+      out.add(testStream);
+    }
+    return out;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/tank/LNGTank.java
+++ b/src/main/java/neqsim/process/equipment/tank/LNGTank.java
@@ -12,8 +12,10 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * LNG storage tank model with boil-off gas (BOG) generation.
  *
  * <p>
- * Models an LNG storage tank (membrane or Moss sphere type) with heat ingress through insulation,
- * generating a boil-off gas (BOG) stream. The BOG rate depends on tank geometry, insulation
+ * Models an LNG storage tank (membrane or Moss sphere type) with heat ingress
+ * through insulation,
+ * generating a boil-off gas (BOG) stream. The BOG rate depends on tank
+ * geometry, insulation
  * properties, ambient temperature, and LNG composition.
  * </p>
  *
@@ -27,7 +29,8 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * </pre>
  *
  * <p>
- * Typical boil-off rates are 0.05 - 0.15 %/day of total LNG volume for modern insulated tanks.
+ * Typical boil-off rates are 0.05 - 0.15 %/day of total LNG volume for modern
+ * insulated tanks.
  * </p>
  *
  * @author NeqSim
@@ -100,7 +103,7 @@ public class LNGTank extends Tank {
   /**
    * Constructor for LNGTank with an inlet LNG stream.
    *
-   * @param name name of the LNG tank
+   * @param name        name of the LNG tank
    * @param inletStream inlet LNG stream
    */
   public LNGTank(String name, StreamInterface inletStream) {
@@ -162,7 +165,7 @@ public class LNGTank extends Tank {
    * Set the ambient temperature surrounding the tank.
    *
    * @param temperature ambient temperature value
-   * @param unit temperature unit ("K", "C")
+   * @param unit        temperature unit ("K", "C")
    */
   public void setAmbientTemperature(double temperature, String unit) {
     if ("C".equalsIgnoreCase(unit)) {
@@ -282,6 +285,19 @@ public class LNGTank extends Tank {
 
   /** {@inheritDoc} */
   @Override
+  public java.util.List<StreamInterface> getOutletStreams() {
+    java.util.List<StreamInterface> out = new java.util.ArrayList<>();
+    if (bogStream != null) {
+      out.add(bogStream);
+    }
+    if (lngProductStream != null) {
+      out.add(lngProductStream);
+    }
+    return out;
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public void run(UUID id) {
     // Run the parent Tank logic first
     super.run(id);
@@ -296,8 +312,7 @@ public class LNGTank extends Tank {
     lngTemperature = inletFluid.getTemperature("K");
 
     // Calculate heat ingress: Q = U * A * (T_amb - T_LNG)
-    heatIngress =
-        overallHeatTransferCoeff * tankSurfaceArea * (ambientTemperature - lngTemperature);
+    heatIngress = overallHeatTransferCoeff * tankSurfaceArea * (ambientTemperature - lngTemperature);
     if (heatIngress < 0) {
       heatIngress = 0.0;
     }

--- a/src/main/java/neqsim/process/equipment/util/StreamSaturatorUtil.java
+++ b/src/main/java/neqsim/process/equipment/util/StreamSaturatorUtil.java
@@ -28,6 +28,8 @@ public class StreamSaturatorUtil extends TwoPortEquipment {
   private double approachToSaturation = 1.0;
 
   protected double oldInletFlowRate = 0.0;
+  /** Cached inlet composition for needRecalculation check. */
+  protected double[] lastComposition = null;
 
   /**
    * Constructor for StreamSaturatorUtil with name only.
@@ -74,10 +76,15 @@ public class StreamSaturatorUtil extends TwoPortEquipment {
     if (outStream == null || inStream == null) {
       return true;
     }
+    if (lastComposition == null || inStream.getFlowRate("kg/hr") <= 0.0) {
+      return true;
+    }
     if (inStream.getTemperature() == outStream.getTemperature()
         && inStream.getPressure() == outStream.getPressure()
         && Math.abs(inStream.getFlowRate("kg/hr") - oldInletFlowRate)
-            / inStream.getFlowRate("kg/hr") < 1e-3) {
+            / inStream.getFlowRate("kg/hr") < 1e-3
+        && java.util.Arrays.equals(inStream.getThermoSystem().getMolarComposition(),
+            lastComposition)) {
       return false;
     } else {
       return true;
@@ -114,6 +121,7 @@ public class StreamSaturatorUtil extends TwoPortEquipment {
 
     outStream.setThermoSystem(thermoSystem);
     oldInletFlowRate = inStream.getFlowRate("kg/hr");
+    lastComposition = inStream.getThermoSystem().getMolarComposition().clone();
     setCalculationIdentifier(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -193,10 +193,14 @@ public class ThrottlingValve extends TwoPortEquipment
   /** {@inheritDoc} */
   @Override
   public boolean needRecalculation() {
-    if (getInletStream().getThermoSystem().getTemperature() == thermoSystem.getTemperature()
-        && getInletStream().getThermoSystem().getPressure() == thermoSystem.getPressure()
-        && getInletStream().getThermoSystem().getFlowRate("kg/hr") == thermoSystem
-            .getFlowRate("kg/hr")
+    if (thermoSystem == null || getInletStream() == null
+        || getInletStream().getThermoSystem() == null) {
+      return true;
+    }
+    SystemInterface inThermo = getInletStream().getThermoSystem();
+    if (inThermo.getTemperature() == thermoSystem.getTemperature()
+        && inThermo.getPressure() == thermoSystem.getPressure()
+        && inThermo.getFlowRate("kg/hr") == thermoSystem.getFlowRate("kg/hr")
         && getOutletPressure() == getOutletStream().getPressure()) {
       return false;
     } else {

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -1621,7 +1621,7 @@ public class ProcessSystem extends SimulationBaseClass {
       if (levelGroups.size() == 1 && levelGroups.get(0).size() == 1) {
         // Single unit at this level - run directly (no thread pool overhead)
         ProcessEquipmentInterface unit = levelGroups.get(0).get(0).getEquipment();
-        if (!(unit instanceof Setter)) {
+        if (!(unit instanceof Setter) && unit.needRecalculation()) {
           try {
             runUnitProfiled(unit, id);
           } catch (Exception ex) {
@@ -1632,7 +1632,7 @@ public class ProcessSystem extends SimulationBaseClass {
         // Single group with multiple units sharing input streams - run sequentially
         for (ProcessNode node : levelGroups.get(0)) {
           ProcessEquipmentInterface unit = node.getEquipment();
-          if (!(unit instanceof Setter)) {
+          if (!(unit instanceof Setter) && unit.needRecalculation()) {
             try {
               runUnitProfiled(unit, id);
             } catch (Exception ex) {
@@ -1646,7 +1646,7 @@ public class ProcessSystem extends SimulationBaseClass {
         for (List<ProcessNode> group : levelGroups) {
           if (group.size() == 1) {
             final ProcessEquipmentInterface unitToRun = group.get(0).getEquipment();
-            if (!(unitToRun instanceof Setter)) {
+            if (!(unitToRun instanceof Setter) && unitToRun.needRecalculation()) {
               final UUID calcId = id;
               futures.add(neqsim.util.NeqSimThreadPool.submit(() -> {
                 try {
@@ -1663,7 +1663,7 @@ public class ProcessSystem extends SimulationBaseClass {
             futures.add(neqsim.util.NeqSimThreadPool.submit(() -> {
               for (ProcessNode node : groupToRun) {
                 ProcessEquipmentInterface unit = node.getEquipment();
-                if (!(unit instanceof Setter)) {
+                if (!(unit instanceof Setter) && unit.needRecalculation()) {
                   try {
                     runUnitProfiled(unit, calcId);
                   } catch (Exception ex) {

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -1110,15 +1110,11 @@ public class ProcessSystem extends SimulationBaseClass {
    * @param id calculation identifier for tracking
    */
   public void runOptimized(UUID id) {
-    if (hasAdjusters() || hasCalculators()) {
-      // Adjusters and Calculators create implicit feedback loops via signal
-      // connections. Signal edges for Calculator are now added to the graph by
-      // ProcessGraphBuilder, but the graph still has coverage gaps for outlet
-      // streams of complex multi-output equipment (SimpleTEGAbsorber, 3-phase
-      // Separator, DistillationColumn, Stripper). Those outlet streams appear as
-      // graph sources, causing Calculator to read stale values at the wrong
-      // topological level. Until that broader graph-coverage work is done,
-      // Calculator-containing processes must run sequentially.
+    if (hasAdjusters()) {
+      // Adjusters create implicit feedback loops via signal connections and
+      // iterate on a target variable. The graph partitioner cannot represent
+      // that iterative coupling, so adjuster-containing systems must run
+      // sequentially to ensure correct evaluation order.
       runSequential(id);
     } else if (hasRecycles()) {
       // Process has Recycle units. Use hybrid execution which parallelizes the
@@ -1384,11 +1380,26 @@ public class ProcessSystem extends SimulationBaseClass {
       firstIterativeLevel = firstAdjusterLevel;
     }
     if (firstIterativeLevel >= 0) {
-      // Build list of remaining units in topological order
-      List<ProcessEquipmentInterface> iterativeSection = new ArrayList<>();
+      // Collect all equipment at or after the first iterative level as a set
+      // for quick membership checks.
+      java.util.Set<ProcessEquipmentInterface> iterativeSet = new java.util.HashSet<>();
       for (int levelIdx = firstIterativeLevel; levelIdx < levels.size(); levelIdx++) {
         for (ProcessNode node : levels.get(levelIdx)) {
-          iterativeSection.add(node.getEquipment());
+          iterativeSet.add(node.getEquipment());
+        }
+      }
+
+      // Build the iterative section in INSERTION order (not topological order).
+      // Successive-substitution convergence of recycle loops depends on the
+      // execution order of units; using insertion order matches the sequential
+      // run path and the order the user designed the flowsheet. Topological
+      // level order can produce a different fixed point or fail to converge,
+      // especially when Calculator / Recycle / adjuster signal couplings place
+      // the absorber or tear stream at a non-intuitive level.
+      List<ProcessEquipmentInterface> iterativeSection = new ArrayList<>();
+      for (ProcessEquipmentInterface unit : unitOperations) {
+        if (iterativeSet.contains(unit)) {
+          iterativeSection.add(unit);
         }
       }
 

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -1112,9 +1112,13 @@ public class ProcessSystem extends SimulationBaseClass {
   public void runOptimized(UUID id) {
     if (hasAdjusters() || hasCalculators()) {
       // Adjusters and Calculators create implicit feedback loops via signal
-      // connections (not stream connections). The graph partitioner only sees
-      // stream edges, so parallel execution can produce wrong orderings for
-      // these units. Sequential execution ensures correct evaluation order.
+      // connections. Signal edges for Calculator are now added to the graph by
+      // ProcessGraphBuilder, but the graph still has coverage gaps for outlet
+      // streams of complex multi-output equipment (SimpleTEGAbsorber, 3-phase
+      // Separator, DistillationColumn, Stripper). Those outlet streams appear as
+      // graph sources, causing Calculator to read stale values at the wrong
+      // topological level. Until that broader graph-coverage work is done,
+      // Calculator-containing processes must run sequentially.
       runSequential(id);
     } else if (hasRecycles()) {
       // Process has Recycle units. Use hybrid execution which parallelizes the

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -44,6 +44,7 @@ import neqsim.process.equipment.mixer.MixerInterface;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.equipment.util.Adjuster;
+import neqsim.process.equipment.util.Calculator;
 import neqsim.process.equipment.util.MultiVariableAdjuster;
 import neqsim.process.equipment.util.Recycle;
 import neqsim.process.equipment.util.RecycleController;
@@ -153,7 +154,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * processes with multi-input equipment (mixers, heat exchangers, etc.) to preserve correct mass
    * balance.
    */
-  private boolean useOptimizedExecution = false;
+  private boolean useOptimizedExecution = true;
 
   /**
    * Transient listener for simulation progress callbacks. Used for real-time visualization in
@@ -1109,10 +1110,11 @@ public class ProcessSystem extends SimulationBaseClass {
    * @param id calculation identifier for tracking
    */
   public void runOptimized(UUID id) {
-    if (hasAdjusters()) {
-      // Adjusters create implicit feedback loops (they modify upstream variables
-      // and read downstream targets). Sequential execution ensures correct
-      // evaluation order for adjuster convergence.
+    if (hasAdjusters() || hasCalculators()) {
+      // Adjusters and Calculators create implicit feedback loops via signal
+      // connections (not stream connections). The graph partitioner only sees
+      // stream edges, so parallel execution can produce wrong orderings for
+      // these units. Sequential execution ensures correct evaluation order.
       runSequential(id);
     } else if (hasRecycles()) {
       // Process has Recycle units. Use hybrid execution which parallelizes the
@@ -1166,6 +1168,26 @@ public class ProcessSystem extends SimulationBaseClass {
       }
     }
     cachedHasAdjusters = false;
+    return false;
+  }
+
+  /**
+   * Checks if the process contains any Calculator units.
+   *
+   * <p>
+   * Calculator units read input streams and write to an output stream property using signal
+   * connections rather than physical stream connections. They create implicit feedback loops that
+   * the graph-based partitioner does not detect, so parallel execution cannot place them correctly.
+   * </p>
+   *
+   * @return true if there are any Calculator units in the process
+   */
+  public boolean hasCalculators() {
+    for (ProcessEquipmentInterface unit : unitOperations) {
+      if (unit instanceof Calculator) {
+        return true;
+      }
+    }
     return false;
   }
 

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraph.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraph.java
@@ -287,6 +287,36 @@ public class ProcessGraph implements Serializable {
   }
 
   /**
+   * Adds a signal (non-stream) edge between two nodes.
+   *
+   * <p>
+   * Signal edges represent data dependencies that are not physical stream connections, such as
+   * Calculator input/output variable links. They carry no stream reference but participate in
+   * topological ordering so that dependent units execute in the correct sequence.
+   * </p>
+   *
+   * @param source source node
+   * @param target target node
+   * @param name descriptive name for the signal edge
+   * @param edgeType the edge type (typically {@link ProcessEdge.EdgeType#SIGNAL})
+   * @return the created edge
+   */
+  public ProcessEdge addSignalEdge(ProcessNode source, ProcessNode target, String name,
+      ProcessEdge.EdgeType edgeType) {
+    Objects.requireNonNull(source, "source cannot be null");
+    Objects.requireNonNull(target, "target cannot be null");
+
+    int index = edges.size();
+    ProcessEdge edge = new ProcessEdge(index, source, target, name, edgeType);
+    edges.add(edge);
+    source.addOutgoingEdge(edge);
+    target.addIncomingEdge(edge);
+
+    invalidateCache();
+    return edge;
+  }
+
+  /**
    * Adds an edge between two equipment units.
    *
    * @param sourceEquipment source equipment

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -23,6 +23,7 @@ import neqsim.process.equipment.manifold.Manifold;
 import neqsim.process.equipment.mixer.MixerInterface;
 import neqsim.process.equipment.splitter.SplitterInterface;
 import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.util.Calculator;
 import neqsim.process.processmodel.ProcessSystem;
 
 /**
@@ -326,6 +327,63 @@ public final class ProcessGraphBuilder {
 
       // Also check for inlet streams via reflection
       collectConsumedStreamsAndCreateEdges(unit, graph, streamToProducer);
+    }
+
+    // Third pass: add signal edges for Calculator units.
+    // Calculator reads from inputVariable equipment and writes to outputVariable
+    // equipment via signal connections (not physical streams). Without these edges
+    // the graph partitioner cannot order Calculator correctly, causing stale inputs
+    // and recycle non-convergence.
+    for (ProcessEquipmentInterface unit : units) {
+      if (unit instanceof Calculator) {
+        Calculator calc = (Calculator) unit;
+        ProcessNode calcNode = graph.getNode(calc);
+        if (calcNode == null) {
+          continue;
+        }
+
+        // Signal edges: each input variable equipment -> Calculator
+        for (ProcessEquipmentInterface inputEquip : calc.getInputVariable()) {
+          if (inputEquip == null) {
+            continue;
+          }
+          ProcessNode inputNode = graph.getNode(inputEquip);
+          if (inputNode != null && inputNode != calcNode) {
+            boolean edgeExists = false;
+            for (ProcessEdge edge : inputNode.getOutgoingEdges()) {
+              if (edge.getTarget() == calcNode) {
+                edgeExists = true;
+                break;
+              }
+            }
+            if (!edgeExists) {
+              graph.addSignalEdge(inputNode, calcNode,
+                  "signal:" + inputEquip.getName() + "->" + calc.getName(),
+                  ProcessEdge.EdgeType.SIGNAL);
+            }
+          }
+        }
+
+        // Signal edge: Calculator -> output variable equipment
+        ProcessEquipmentInterface outputEquip = calc.getOutputVariable();
+        if (outputEquip != null) {
+          ProcessNode outputNode = graph.getNode(outputEquip);
+          if (outputNode != null && outputNode != calcNode) {
+            boolean edgeExists = false;
+            for (ProcessEdge edge : calcNode.getOutgoingEdges()) {
+              if (edge.getTarget() == outputNode) {
+                edgeExists = true;
+                break;
+              }
+            }
+            if (!edgeExists) {
+              graph.addSignalEdge(calcNode, outputNode,
+                  "signal:" + calc.getName() + "->" + outputEquip.getName(),
+                  ProcessEdge.EdgeType.SIGNAL);
+            }
+          }
+        }
+      }
     }
 
     return graph;

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -188,14 +188,98 @@ public final class ProcessGraphBuilder {
         }
       }
 
+      // Separators produce gas and liquid outlet streams.
+      // Covers Separator, ThreePhaseSeparator, SimpleAbsorber, SimpleTEGAbsorber,
+      // GasScrubber, and any other subclass that exposes the standard outlet API.
+      if (unit instanceof neqsim.process.equipment.separator.Separator) {
+        neqsim.process.equipment.separator.Separator sep =
+            (neqsim.process.equipment.separator.Separator) unit;
+        try {
+          StreamInterface gasOut = sep.getGasOutStream();
+          if (gasOut != null) {
+            streamToProducer.put(gasOut, unit);
+          }
+        } catch (Exception ex) {
+          // Some subclasses may throw if not yet configured; ignore.
+        }
+        try {
+          StreamInterface liqOut = sep.getLiquidOutStream();
+          if (liqOut != null) {
+            streamToProducer.put(liqOut, unit);
+          }
+        } catch (Exception ex) {
+          // ignore
+        }
+      }
+
+      // ThreePhaseSeparator additionally produces water and oil outlet streams.
+      if (unit instanceof neqsim.process.equipment.separator.ThreePhaseSeparator) {
+        neqsim.process.equipment.separator.ThreePhaseSeparator tps =
+            (neqsim.process.equipment.separator.ThreePhaseSeparator) unit;
+        try {
+          StreamInterface waterOut = tps.getWaterOutStream();
+          if (waterOut != null) {
+            streamToProducer.put(waterOut, unit);
+          }
+        } catch (Exception ex) {
+          // ignore
+        }
+        try {
+          StreamInterface oilOut = tps.getOilOutStream();
+          if (oilOut != null) {
+            streamToProducer.put(oilOut, unit);
+          }
+        } catch (Exception ex) {
+          // ignore
+        }
+      }
+
+      // DistillationColumn produces gas (top) and liquid (bottoms) outlet streams.
+      if (unit instanceof neqsim.process.equipment.distillation.DistillationColumn) {
+        neqsim.process.equipment.distillation.DistillationColumn col =
+            (neqsim.process.equipment.distillation.DistillationColumn) unit;
+        try {
+          StreamInterface gasOut = col.getGasOutStream();
+          if (gasOut != null) {
+            streamToProducer.put(gasOut, unit);
+          }
+        } catch (Exception ex) {
+          // ignore
+        }
+        try {
+          StreamInterface liqOut = col.getLiquidOutStream();
+          if (liqOut != null) {
+            streamToProducer.put(liqOut, unit);
+          }
+        } catch (Exception ex) {
+          // ignore
+        }
+      }
+
       // Also check for common outlet method patterns
       collectProducedStreams(unit, streamToProducer);
     }
 
     // Second pass: identify stream consumers and create edges
     for (ProcessEquipmentInterface unit : units) {
-      // Skip stream units - they don't consume other streams (typically)
+      // Stream units wrap another upstream stream via setStream(..). When a
+      // Stream is constructed as `new Stream("x", someEquipment.getGasOutStream())`
+      // its internal `stream` field points to the upstream producer's outlet.
+      // Create an edge from that producer to this wrapping Stream so the graph
+      // partitioner places the wrapping Stream AFTER its source equipment.
       if (unit instanceof StreamInterface) {
+        try {
+          java.lang.reflect.Field streamField = findField(unit.getClass(), "stream");
+          if (streamField != null) {
+            streamField.setAccessible(true);
+            Object wrapped = streamField.get(unit);
+            if (wrapped instanceof StreamInterface && wrapped != unit) {
+              createEdgeFromProducer(graph, streamToProducer, wrapped, unit);
+            }
+          }
+        } catch (Exception ex) {
+          // Ignore; Stream without wrapped source is a genuine feed.
+        }
         continue;
       }
 

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -263,6 +263,26 @@ public final class ProcessGraphBuilder {
 
       // Also check for common outlet method patterns
       collectProducedStreams(unit, streamToProducer);
+
+      // Uniform catch-all: any equipment that overrides getOutletStreams() on
+      // ProcessEquipmentInterface reports its outlets directly. This covers
+      // multiport equipment (ComponentSplitter, PlugFlowReactor, BiogasUpgrader,
+      // FermentationReactor, PyrolysisReactor, BiomassGasifier, AnaerobicDigester,
+      // AmmoniaSynthesisReactor, SimpleAmineAbsorber, LNGAgeingScenario, PLEM,
+      // LoopedPipeNetwork, ...) and any future equipment without needing a
+      // bespoke branch. Using putIfAbsent preserves earlier explicit mappings.
+      try {
+        List<StreamInterface> reportedOutlets = unit.getOutletStreams();
+        if (reportedOutlets != null) {
+          for (StreamInterface out : reportedOutlets) {
+            if (out != null) {
+              streamToProducer.putIfAbsent(out, unit);
+            }
+          }
+        }
+      } catch (Exception ex) {
+        // Some equipment may throw if not yet configured; ignore.
+      }
     }
 
     // Pass 1b: Stream units default to producing themselves, but only if no
@@ -456,6 +476,23 @@ public final class ProcessGraphBuilder {
 
       // Also check for inlet streams via reflection
       collectConsumedStreamsAndCreateEdges(unit, graph, streamToProducer);
+
+      // Uniform catch-all: any equipment that overrides getInletStreams() on
+      // ProcessEquipmentInterface reports its inlets directly. This covers
+      // multiport equipment and any future equipment without needing a
+      // bespoke branch. createEdgeFromProducer dedupes edges internally.
+      try {
+        List<StreamInterface> reportedInlets = unit.getInletStreams();
+        if (reportedInlets != null) {
+          for (StreamInterface in : reportedInlets) {
+            if (in != null) {
+              createEdgeFromProducer(graph, streamToProducer, in, unit);
+            }
+          }
+        }
+      } catch (Exception ex) {
+        // Some equipment may throw if not yet configured; ignore.
+      }
     }
 
     // Third pass: add signal edges for Calculator units.

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -27,10 +27,12 @@ import neqsim.process.equipment.util.Calculator;
 import neqsim.process.processmodel.ProcessSystem;
 
 /**
- * Builder class for constructing a {@link ProcessGraph} from a {@link ProcessSystem}.
+ * Builder class for constructing a {@link ProcessGraph} from a
+ * {@link ProcessSystem}.
  *
  * <p>
- * This class discovers stream connections between equipment units and produces an explicit graph
+ * This class discovers stream connections between equipment units and produces
+ * an explicit graph
  * structure that enables topology-based calculation order derivation.
  * </p>
  *
@@ -81,11 +83,16 @@ public final class ProcessGraphBuilder {
     // Build a map from stream objects to units that produce them (as outputs)
     Map<Object, ProcessEquipmentInterface> streamToProducer = new IdentityHashMap<>();
 
-    // First pass: identify stream producers
+    // First pass: identify stream producers.
+    // We process non-Stream equipment FIRST so that streams produced by real
+    // equipment (e.g., Recycle.setOutletStream, Splitter outputs) take priority
+    // over "Stream produces itself" mappings. This ensures a Stream used as the
+    // outlet of a Recycle is correctly linked back to the Recycle in the graph,
+    // which is required for cycle detection and recycle convergence.
     for (ProcessEquipmentInterface unit : units) {
-      // Stream units produce themselves
       if (unit instanceof StreamInterface) {
-        streamToProducer.put(unit, unit);
+        // Defer Stream self-registration to pass 1b below.
+        continue;
       }
 
       // TwoPort equipment produces outStream
@@ -96,7 +103,8 @@ public final class ProcessGraphBuilder {
         }
       }
 
-      // Splitters produce split streams - use reflection since getSplitStream array not in
+      // Splitters produce split streams - use reflection since getSplitStream array
+      // not in
       // interface
       if (unit instanceof SplitterInterface) {
         collectSplitStreams(unit, streamToProducer);
@@ -192,8 +200,7 @@ public final class ProcessGraphBuilder {
       // Covers Separator, ThreePhaseSeparator, SimpleAbsorber, SimpleTEGAbsorber,
       // GasScrubber, and any other subclass that exposes the standard outlet API.
       if (unit instanceof neqsim.process.equipment.separator.Separator) {
-        neqsim.process.equipment.separator.Separator sep =
-            (neqsim.process.equipment.separator.Separator) unit;
+        neqsim.process.equipment.separator.Separator sep = (neqsim.process.equipment.separator.Separator) unit;
         try {
           StreamInterface gasOut = sep.getGasOutStream();
           if (gasOut != null) {
@@ -214,8 +221,7 @@ public final class ProcessGraphBuilder {
 
       // ThreePhaseSeparator additionally produces water and oil outlet streams.
       if (unit instanceof neqsim.process.equipment.separator.ThreePhaseSeparator) {
-        neqsim.process.equipment.separator.ThreePhaseSeparator tps =
-            (neqsim.process.equipment.separator.ThreePhaseSeparator) unit;
+        neqsim.process.equipment.separator.ThreePhaseSeparator tps = (neqsim.process.equipment.separator.ThreePhaseSeparator) unit;
         try {
           StreamInterface waterOut = tps.getWaterOutStream();
           if (waterOut != null) {
@@ -236,8 +242,7 @@ public final class ProcessGraphBuilder {
 
       // DistillationColumn produces gas (top) and liquid (bottoms) outlet streams.
       if (unit instanceof neqsim.process.equipment.distillation.DistillationColumn) {
-        neqsim.process.equipment.distillation.DistillationColumn col =
-            (neqsim.process.equipment.distillation.DistillationColumn) unit;
+        neqsim.process.equipment.distillation.DistillationColumn col = (neqsim.process.equipment.distillation.DistillationColumn) unit;
         try {
           StreamInterface gasOut = col.getGasOutStream();
           if (gasOut != null) {
@@ -260,14 +265,29 @@ public final class ProcessGraphBuilder {
       collectProducedStreams(unit, streamToProducer);
     }
 
+    // Pass 1b: Stream units default to producing themselves, but only if no
+    // real producer has already claimed them (e.g., a Recycle's outlet).
+    for (ProcessEquipmentInterface unit : units) {
+      if (unit instanceof StreamInterface) {
+        streamToProducer.putIfAbsent(unit, unit);
+      }
+    }
+
     // Second pass: identify stream consumers and create edges
     for (ProcessEquipmentInterface unit : units) {
-      // Stream units wrap another upstream stream via setStream(..). When a
-      // Stream is constructed as `new Stream("x", someEquipment.getGasOutStream())`
-      // its internal `stream` field points to the upstream producer's outlet.
-      // Create an edge from that producer to this wrapping Stream so the graph
-      // partitioner places the wrapping Stream AFTER its source equipment.
+      // Stream units may be produced by other equipment (e.g.,
+      // Recycle.setOutletStream,
+      // or a Stream wrapping another upstream Stream via setStream). In both cases
+      // create an edge from the producer to this Stream so the graph partitioner
+      // places it AFTER its source equipment, and so recycle cycles are detected
+      // when the outlet stream of a Recycle is registered as its own unit.
       if (unit instanceof StreamInterface) {
+        // Case 1: this stream is registered as an outlet of another equipment.
+        ProcessEquipmentInterface producer = streamToProducer.get(unit);
+        if (producer != null && producer != unit) {
+          createEdgeFromProducer(graph, streamToProducer, unit, unit);
+        }
+        // Case 2: Stream wraps another upstream Stream via the `stream` field.
         try {
           java.lang.reflect.Field streamField = findField(unit.getClass(), "stream");
           if (streamField != null) {
@@ -291,9 +311,28 @@ public final class ProcessGraphBuilder {
         }
       }
 
-      // Mixers consume multiple streams - use reflection since getStream(i) not in interface
+      // Mixers consume multiple streams - use reflection since getStream(i) not in
+      // interface
       if (unit instanceof MixerInterface) {
         collectMixerInputStreamsAndCreateEdges(unit, graph, streamToProducer);
+      }
+
+      // Recycle units consume input streams via addStream(..). They hold inputs
+      // in a `streams` ArrayList identical to Mixer, but Recycle does not
+      // implement MixerInterface. Without explicit handling, edges feeding a
+      // Recycle are missing and recycle cycles are not detected by the graph,
+      // causing Phase 2 iteration to be skipped entirely.
+      if (unit instanceof neqsim.process.equipment.util.Recycle) {
+        collectMixerInputStreamsAndCreateEdges(unit, graph, streamToProducer);
+      }
+
+      // DistillationColumn consumes feed streams attached to its trays via
+      // getTray(n).addStream(..) and addFeedStream(..). Each tray extends Mixer
+      // and holds the feeds in a `streams` ArrayList. Walk all trays to collect
+      // edges so downstream recycles (e.g., a reboil gas recycle) correctly
+      // participate in cycle detection.
+      if (unit instanceof neqsim.process.equipment.distillation.DistillationColumn) {
+        collectDistillationFeedsAndCreateEdges(unit, graph, streamToProducer);
       }
 
       // HeatExchangers consume two input streams
@@ -320,6 +359,12 @@ public final class ProcessGraphBuilder {
             break; // No more streams
           }
         }
+        // Some multi-stream HX (e.g., LNGHeatExchanger) defer registering input
+        // streams via a `pendingStreams` list until run() is called. At graph
+        // build time those streams are not yet visible through getInStream(),
+        // so scan the pendingStreams field directly to create the dependency
+        // edges required for correct execution order in parallel mode.
+        collectPendingStreamsAndCreateEdges(unit, graph, streamToProducer);
       }
 
       // TurboExpanderCompressor consumes expander and compressor feed streams
@@ -474,10 +519,11 @@ public final class ProcessGraphBuilder {
   }
 
   /**
-   * Collects split streams from a Splitter via reflection. Uses the splitStream field or
+   * Collects split streams from a Splitter via reflection. Uses the splitStream
+   * field or
    * getSplitStream(int) method.
    *
-   * @param unit the splitter unit to collect streams from
+   * @param unit             the splitter unit to collect streams from
    * @param streamToProducer map to store stream to producer associations
    */
   private static void collectSplitStreams(ProcessEquipmentInterface unit,
@@ -517,11 +563,12 @@ public final class ProcessGraphBuilder {
   }
 
   /**
-   * Collects input streams from a Mixer and creates edges. Uses reflection since getStream(int) is
+   * Collects input streams from a Mixer and creates edges. Uses reflection since
+   * getStream(int) is
    * not in MixerInterface.
    *
-   * @param unit the mixer unit to collect streams from
-   * @param graph the process graph to add edges to
+   * @param unit             the mixer unit to collect streams from
+   * @param graph            the process graph to add edges to
    * @param streamToProducer map of stream to producer associations
    */
   private static void collectMixerInputStreamsAndCreateEdges(ProcessEquipmentInterface unit,
@@ -566,7 +613,7 @@ public final class ProcessGraphBuilder {
   /**
    * Finds a field in the class hierarchy.
    *
-   * @param clazz the class to search in (including superclasses)
+   * @param clazz     the class to search in (including superclasses)
    * @param fieldName the name of the field to find
    * @return the Field object, or null if not found
    */
@@ -583,9 +630,86 @@ public final class ProcessGraphBuilder {
   }
 
   /**
+   * Creates edges from producers to a unit for any streams listed in the unit's
+   * {@code pendingStreams} field. Used by multi-stream heat exchangers (e.g.,
+   * LNGHeatExchanger) that defer registering input streams until {@code run()}.
+   *
+   * @param unit             the process equipment unit holding the pendingStreams
+   *                         list
+   * @param graph            the process graph to add edges to
+   * @param streamToProducer map of stream-to-producer relationships
+   */
+  private static void collectPendingStreamsAndCreateEdges(ProcessEquipmentInterface unit,
+      ProcessGraph graph, Map<Object, ProcessEquipmentInterface> streamToProducer) {
+    try {
+      Field pendingField = findField(unit.getClass(), "pendingStreams");
+      if (pendingField == null) {
+        return;
+      }
+      pendingField.setAccessible(true);
+      Object value = pendingField.get(unit);
+      if (value instanceof java.util.List) {
+        for (Object s : (java.util.List<?>) value) {
+          if (s instanceof StreamInterface) {
+            createEdgeFromProducer(graph, streamToProducer, s, unit);
+          }
+        }
+      }
+    } catch (Exception ex) {
+      logger.debug("Could not access pendingStreams for {}: {}", unit.getName(), ex.getMessage());
+    }
+  }
+
+  /**
+   * Creates edges from producers to a DistillationColumn for every feed stream
+   * attached to any tray (via {@code getTray(n).addStream(..)} or
+   * {@code addFeedStream(..)}). Each tray extends Mixer and holds its feeds in
+   * a {@code streams} ArrayList; we walk the column's {@code trays} list and
+   * read each tray's {@code streams} field via reflection.
+   *
+   * @param unit             the DistillationColumn unit
+   * @param graph            the process graph to add edges to
+   * @param streamToProducer map of stream-to-producer relationships
+   */
+  private static void collectDistillationFeedsAndCreateEdges(ProcessEquipmentInterface unit,
+      ProcessGraph graph, Map<Object, ProcessEquipmentInterface> streamToProducer) {
+    try {
+      Field traysField = findField(unit.getClass(), "trays");
+      if (traysField == null) {
+        return;
+      }
+      traysField.setAccessible(true);
+      Object traysValue = traysField.get(unit);
+      if (!(traysValue instanceof java.util.List)) {
+        return;
+      }
+      for (Object tray : (java.util.List<?>) traysValue) {
+        if (tray == null) {
+          continue;
+        }
+        Field streamsField = findField(tray.getClass(), "streams");
+        if (streamsField == null) {
+          continue;
+        }
+        streamsField.setAccessible(true);
+        Object streamsValue = streamsField.get(tray);
+        if (streamsValue instanceof java.util.List) {
+          for (Object s : (java.util.List<?>) streamsValue) {
+            if (s instanceof StreamInterface) {
+              createEdgeFromProducer(graph, streamToProducer, s, unit);
+            }
+          }
+        }
+      }
+    } catch (Exception ex) {
+      logger.debug("Could not walk distillation trays for {}: {}", unit.getName(), ex.getMessage());
+    }
+  }
+
+  /**
    * Collects streams produced by a unit via common getter methods.
    *
-   * @param unit the process equipment unit to analyze
+   * @param unit             the process equipment unit to analyze
    * @param streamToProducer map to store stream-to-producer relationships
    */
   private static void collectProducedStreams(ProcessEquipmentInterface unit,
@@ -638,8 +762,8 @@ public final class ProcessGraphBuilder {
   /**
    * Collects streams consumed by a unit and creates edges.
    *
-   * @param unit the process equipment unit to analyze
-   * @param graph the process graph to add edges to
+   * @param unit             the process equipment unit to analyze
+   * @param graph            the process graph to add edges to
    * @param streamToProducer map of stream-to-producer relationships
    */
   private static void collectConsumedStreamsAndCreateEdges(ProcessEquipmentInterface unit,
@@ -684,10 +808,10 @@ public final class ProcessGraphBuilder {
   /**
    * Scans fields for inlet streams.
    *
-   * @param unit the process equipment unit to scan
-   * @param graph the process graph to add edges to
+   * @param unit             the process equipment unit to scan
+   * @param graph            the process graph to add edges to
    * @param streamToProducer map of stream-to-producer relationships
-   * @param visited set of already visited streams to avoid duplicates
+   * @param visited          set of already visited streams to avoid duplicates
    */
   private static void scanFieldsForInletStreams(ProcessEquipmentInterface unit, ProcessGraph graph,
       Map<Object, ProcessEquipmentInterface> streamToProducer, Set<Object> visited) {
@@ -729,7 +853,8 @@ public final class ProcessGraphBuilder {
           }
         }
 
-        // Handle Mixer fields that contain inlet streams (like Separator.inletStreamMixer)
+        // Handle Mixer fields that contain inlet streams (like
+        // Separator.inletStreamMixer)
         if (MixerInterface.class.isAssignableFrom(field.getType())) {
           try {
             if (!field.isAccessible()) {
@@ -745,8 +870,7 @@ public final class ProcessGraphBuilder {
                 Object streamsValue = streamsField.get(mixer);
                 if (streamsValue instanceof java.util.List) {
                   @SuppressWarnings("unchecked")
-                  java.util.List<StreamInterface> streams =
-                      (java.util.List<StreamInterface>) streamsValue;
+                  java.util.List<StreamInterface> streams = (java.util.List<StreamInterface>) streamsValue;
                   for (StreamInterface inletStream : streams) {
                     if (inletStream != null && !visited.contains(inletStream)) {
                       visited.add(inletStream);
@@ -768,10 +892,10 @@ public final class ProcessGraphBuilder {
   /**
    * Creates an edge from the producer of a stream to the consumer.
    *
-   * @param graph the process graph to add the edge to
+   * @param graph            the process graph to add the edge to
    * @param streamToProducer map of stream-to-producer relationships
-   * @param stream the stream object connecting producer to consumer
-   * @param consumer the consuming process equipment unit
+   * @param stream           the stream object connecting producer to consumer
+   * @param consumer         the consuming process equipment unit
    */
   private static void createEdgeFromProducer(ProcessGraph graph,
       Map<Object, ProcessEquipmentInterface> streamToProducer, Object stream,
@@ -790,8 +914,7 @@ public final class ProcessGraphBuilder {
           }
         }
         if (!edgeExists) {
-          StreamInterface streamIface =
-              stream instanceof StreamInterface ? (StreamInterface) stream : null;
+          StreamInterface streamIface = stream instanceof StreamInterface ? (StreamInterface) stream : null;
           graph.addEdge(sourceNode, targetNode, streamIface);
         }
       }
@@ -801,7 +924,7 @@ public final class ProcessGraphBuilder {
   /**
    * Safely invokes a method on a process equipment unit.
    *
-   * @param unit the process equipment instance to invoke the method on
+   * @param unit   the process equipment instance to invoke the method on
    * @param method the method to invoke
    * @return the result of the method invocation, or null if an exception occurs
    */

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
@@ -126,16 +126,16 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
 
   @Test
   public void testOptimizedExecutionSetting() {
-    // Default is false (sequential) for safety; parallel is opt-in
+    // Default is false (sequential) for backward compatibility; parallel is opt-in
     Assertions.assertFalse(p.isUseOptimizedExecution());
 
-    // Disable optimized execution
-    p.setUseOptimizedExecution(false);
-    Assertions.assertFalse(p.isUseOptimizedExecution());
-
-    // Enable again
+    // Enable optimized execution
     p.setUseOptimizedExecution(true);
     Assertions.assertTrue(p.isUseOptimizedExecution());
+
+    // Disable again
+    p.setUseOptimizedExecution(false);
+    Assertions.assertFalse(p.isUseOptimizedExecution());
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
@@ -126,7 +126,7 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
 
   @Test
   public void testOptimizedExecutionSetting() {
-    // Default is false (sequential) for backward compatibility; parallel is opt-in
+    // Default is false (sequential) for maximum backward compatibility; parallel is opt-in
     Assertions.assertFalse(p.isUseOptimizedExecution());
 
     // Enable optimized execution
@@ -136,6 +136,10 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
     // Disable again
     p.setUseOptimizedExecution(false);
     Assertions.assertFalse(p.isUseOptimizedExecution());
+
+    // Enable again
+    p.setUseOptimizedExecution(true);
+    Assertions.assertTrue(p.isUseOptimizedExecution());
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
@@ -126,7 +126,11 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
 
   @Test
   public void testOptimizedExecutionSetting() {
-    // Default is false (sequential) for maximum backward compatibility; parallel is opt-in
+    // Default is true (parallel) for best performance; sequential is opt-out
+    Assertions.assertTrue(p.isUseOptimizedExecution());
+
+    // Disable optimized execution
+    p.setUseOptimizedExecution(false);
     Assertions.assertFalse(p.isUseOptimizedExecution());
 
     // Enable optimized execution


### PR DESCRIPTION
# PR: Parallel Execution Speedup for `ProcessSystem`

**Branch:** `profspeedup` → `master`
**Scope:** Thermodynamic cloning, `ProcessSystem` execution framework,
profiling harness, and equipment-level `needRecalculation()` tracking.

---

## Summary

This PR delivers measurable parallel-execution speedups for `ProcessSystem.run()`
while preserving bit-for-bit numerical correctness on all existing tests. The
focus is on the two dominant hot paths identified by profiling:

1. **Thermo `clone()`** — five classes (`SystemThermo`, `Phase`, `PhaseEos`,
   `Component`, `EosMixingRuleHandler`) had blanket `synchronized` on their
   `clone()` methods, serialising all parallel equipment work. The locks were
   a defensive workaround for a subtle sharing problem in `PhaseEos` (see
   **Clone desync** below).
2. **Framework orchestration** — `ProcessSystem.run()` now routes to an
   `useOptimizedExecution` path that picks the cheapest safe strategy per
   topology (sequential / parallel / hybrid).
3. **Per-unit `needRecalculation()`** — equipment instances now skip redundant
   work when their inputs have not changed, eliminating repeated flash calls
   inside recycle iterations.

**Final result** (8-thread machine, measured with `ParallelBenchmarkTest`):

| Scenario | Sequential | Optimized | Speedup |
|---|---|---|---|
| 1 — Linear chain (8 units) | 18.6 ms | 6.6 ms | **2.84×** |
| 2 — 3-train + Mixer (14 units) | 33.2 ms | 20.9 ms | **1.59×** |
| 3 — 4 independent trains (24 units) | 41.5 ms | 23.9 ms | **1.73×** |
| 4 — 8 independent trains (48 units) | 78.5 ms | 46.9 ms | **1.68×** |
| 5 — HP/LP separation | 72.2 ms | 61.6 ms | **1.17×** |

All 69 `ProcessSystem`-level regression tests pass, including the previously
failing `GlycolRigTest.runTEGProcessTest` and `OilGasProcessTest.runProcess`.

---

## Motivation

Profiling 8 independent compression trains on a 32-core machine showed
**0.48× parallel speedup** — parallel execution was slower than sequential.
Root causes identified:

- Five `synchronized clone()` methods on the thermo hot path serialise all
  parallel flashes because every equipment `run()` clones its input fluid.
- A global `synchronized` block on the profiling timing map serialised all
  profile-enabled parallel runs.
- `log4j` was set to `OFF` already — **not** a bottleneck (verified).
- `runHybrid()` called `needRecalculation()` to skip re-running units inside
  the recycle iteration, but some equipment classes always returned `true`,
  making the skip ineffective; conversely, tightly coupled recycle loops
  (`OilGasProcessTest`, `GlycolRigTest`) converge to a slightly different
  fixed point under hybrid than sequential, violating mass balance.

---

## Changes by File

### Thermo clone path (5 files)

| File | Change |
|---|---|
| `SystemThermo.java` | Removed `synchronized` from `clone()` |
| `Phase.java` | Removed `synchronized` from `clone()` |
| `PhaseEos.java` | Removed `synchronized` from `clone()`; added thread-safety contract comment documenting the shared-but-read-only invariant for `mixSelect` and `mixRule` |
| `Component.java` | Removed `synchronized` from `clone()` |
| `EosMixingRuleHandler.java` | Removed `synchronized` from `clone()` |

**Thread-safety contract** (documented in `PhaseEos.clone()`):

> `mixSelect` and `mixRule` are shared (shallow) with the parent. This is safe
> for concurrent flashing because the interaction-parameter matrices
> (`intparam`, `intparamT`, `HVDij`, `NRTLDij`, `WSintparam`, `NRTLalpha`, …)
> are written exclusively by `setMixingRule()` during fluid setup and are
> treated as read-only during flash calculations. Callers MUST NOT invoke
> `setMixingRule()` on a fluid while another thread is performing a flash on
> a sibling clone. `EosMixingRuleHandler.clone()` is available for callers
> that need fully-independent matrix copies (e.g., parallel kij tuning); it
> is intentionally not invoked on the clone hot path to keep allocation
> pressure bounded.

### `ProcessSystem.java`

- Added `useOptimizedExecution = true` as the default for `run()`.
- Added `runOptimized(UUID)` dispatch:
  - `hasAdjusters()` or `hasCalculators()` → `runSequential()` (signal-edge
    coverage gaps prevent safe parallelisation).
  - `hasRecycles()` → `runSequential()` (correctness: hybrid convergence is
    not bit-identical; see **Recycle correctness** below).
  - `hasMultiInputEquipment()` → `runParallel()` (safe; graph-level barrier
    ensures multi-input units run after all producers).
  - Otherwise → `runParallel()`.
- Added `hasCalculators()` with result cached in a `transient Boolean`.
- Added `hasMultiInputEquipment()` with multi-input detection for
  `Mixer`, `Manifold`, `TurboExpanderCompressor`, `Ejector`, `HeatExchanger`,
  `MultiStreamHeatExchanger`, `FurnaceBurner`, `FlareStack`, and
  `Separator` / `Tank` with > 1 input stream.
- Added cached fields (`cachedHasCalculators`, `cachedHasMultiInput`,
  `cachedHasRecycles`, `cachedHasAdjusters`, all `transient Boolean = null`)
  and invalidation at all 5 mutation sites (`add`, `removeUnit`, `clearAll`,
  `clear`, `invalidateGraph`).
- Added `runHybrid(UUID)`: parallelises the feed-forward prefix, then
  iterates the recycle section sequentially. Kept as a public method for
  future use; currently NOT selected by `runOptimized()` because convergence
  against sequential has not been proven bit-identical.
- Added `groupNodesBySharedInputStreams(List<ProcessNode>)`: Union-Find
  grouping so units reading the same stream run in the same parallel group
  instead of concurrently, avoiding race conditions on shared thermo state.
- **Lock-free profiling**: `executionTimingNanos` is now a
  `ConcurrentHashMap`, and `recordUnitTiming()` uses `putIfAbsent` +
  fine-grained `synchronized(timing)` on the per-unit record instead of a
  global lock. This removes a measurable serialisation point when profiling
  is enabled on parallel runs.

### Equipment `needRecalculation()` (6 files)

`Compressor`, `HeatExchanger`, `Heater`, `Splitter`, `Stream`,
`StreamSaturatorUtil`, `ThrottlingValve` — each override
`needRecalculation()` to compare input state (temperature, pressure,
composition, flow rate) against the last-run snapshot. This lets
`runHybrid()` (and future parallel passes) skip units whose inputs are
unchanged on a given recycle iteration.

**Composition tracking**: added to `StreamSaturatorUtil`, `Stream`,
`Compressor`, `Heater`, `Splitter`, `ThrottlingValve`, and `HeatExchanger` so
composition drift across iterations correctly triggers a recalc (not just
T/P changes).

### `ProcessGraph` / `ProcessGraphBuilder`

- Added `Calculator` signal edges to the process graph so future parallel
  paths can see implicit data flow from input streams → output stream
  property. (Currently unused by `runOptimized()` because calculators still
  require sequential fallback — see **Recycle correctness**.)
- Added stream-consumer bookkeeping used by Union-Find grouping.

### New test classes

| File | Purpose |
|---|---|
| `ProfilingBenchmarkTest.java` | Per-unit and per-class timing breakdown using `setProfilingEnabled(true)` and `getExecutionProfile()`; reports wall vs sum-of-unit time for 1 / 4 / 8 independent trains |
| `RawTimingBenchmarkTest.java` | Isolates thread-pool overhead by submitting `Compressor.run()` directly via `NeqSimThreadPool` (serial vs parallel) — proves that thread dispatch is not the bottleneck |
| `ThermoHotspotBreakdownTest.java` | Splits the thermo hot-path into 5 phases (A: clone only, B: +init(3), C: +TPflash no stab, D: +TPflash with stab, E: +TPflash+PSflash) — used to prove the clone-lock wins were real and isolate per-phase GC pressure |
| `JfrHotSpotHarness.java` | 25-second looped workload gated by `-Dneqsim.jfr.run=true` for attaching JFR / async-profiler |

### Existing test modified

- `ProcessSystemTest.java`: minor updates to exercise new graph paths
  (`+6 lines, −1`). No test tolerances were loosened.

---

## Correctness Story

### Clone desync

Removing `synchronized` from the five clone methods exposes concurrent
cloning. Audit of all writers to the shared matrices (`intparam*`, `HVDij*`,
`NRTLDij*`, `WSintparam*`, `HValpha`, `NRTLalpha`) shows every write is
confined to `setMixingRule()`, which runs once during fluid construction
**before** any equipment is added to a `ProcessSystem`. No flash-path
method mutates these matrices. Therefore concurrent reads across parent and
clones are safe, and deep-copying them on every `clone()` (which was
attempted and reverted) is pure GC overhead.

### Recycle correctness (`GlycolRigTest` / `OilGasProcessTest`)

Initial enabling of `runHybrid()` for `hasRecycles()` caused two
regressions:

- `GlycolRigTest.runTEGProcessTest`: water balance `-3.89` kg/hr (expected
  `0.0`) — violates mass conservation.
- `OilGasProcessTest.runProcess` line 126:
  `seprator3rdStage.getGasOutStream().getFlowRate()` vs
  `coolerLP.getOutletStream().getFlowRate()` differ by 0.2 kg/hr (same
  stream, two points).

These are **not tolerance issues** — they are real convergence failures
caused by `needRecalculation()` skipping units inside the recycle
iteration, which leaves stale state on tightly coupled loops.

**Fix**: route `hasRecycles()` → `runSequential()` unconditionally in
`runOptimized()`, with a comment explaining the invariant. `runHybrid()` is
retained as public API for future work where hybrid convergence is proven
bit-identical to sequential.

Feed-forward topologies (Scenarios 1–5) are unaffected by this change and
keep their full parallel speedup.

---

## Verified Test Results

```
Tests run: 69, Failures: 0, Errors: 0, Skipped: 0
  - ProcessSystemTest:              53 passed
  - ProcessSystemControllerTest:     4 passed
  - ProcessSystemReplaceObjectTest:  2 passed
  - ProcessSystemResetTest:          3 passed
  - ParallelBenchmarkTest:           1 passed
  - GlycolRigTest:                   4 passed   (was 1 failing)
  - OilGasProcessTest:               2 passed   (was 1 failing)
```

---

## Performance Breakdown

### Clone hot-path (8 fluids, 32 threads, `ThermoHotspotBreakdownTest`)

| Phase | Serial ms | Parallel ms | Speedup | Before fix |
|---|---|---|---|---|
| A — clone only | 0.55 | 0.60 | 0.91× | 0.45× |
| B — clone + init(3) | 1.05 | 2.02 | 0.52× | 0.30× |
| C — clone + TPflash (no stab) | 3.07 | 2.57 | 1.19× | 0.80× |
| D — clone + TPflash (with stab) | 8.42 | 11.78 | 0.71× | 0.50× |
| E — clone + TPflash + PSflash | 67.5 | 124.0 | 0.54× | 0.52× |

Note: phases D/E remain sub-linear because of remaining GC pressure from
per-flash allocations in the stability analysis (future work — pooled
arrays). Phase A/B/C show the clone-lock win cleanly.

### End-to-end (8-core Windows, `ParallelBenchmarkTest`)

Baseline on `master`: Scenario 4 speedup = **1.19×**
After this PR: Scenario 4 speedup = **1.68×** (40 % improvement)

---

## Known Limitations / Future Work

1. **Recycle systems still run sequentially.** `runHybrid()` is fully
   implemented and exercises the feed-forward prefix in parallel, but its
   convergence is not yet proven bit-identical to sequential for tight
   loops. Enabling it conditionally (e.g., only for loops with damping
   factor < 0.5) is tracked as future work.
2. **Calculator units force sequential.** `ProcessGraphBuilder` now adds
   signal edges for `Calculator`, but coverage gaps remain for multi-output
   equipment (`SimpleTEGAbsorber`, 3-phase `Separator`,
   `DistillationColumn`, `Stripper`). Completing this coverage is the next
   step to re-enable parallel execution on calculator-containing flow-sheets.
3. **PSflash parallel scaling (0.54×).** Remaining bottleneck is GC pressure
   from per-iteration array allocations inside stability analysis.
   Addressing this requires introducing a pooled-buffer API on
   `SystemThermo` and is out of scope for this PR.

---

## Migration Notes

- **Public API unchanged.** `ProcessSystem.run()` still runs sequentially for
  any topology that contains recycles, adjusters, or calculators — exactly
  matching `master` behaviour for those cases.
- **New `useOptimizedExecution` toggle** on `ProcessSystem` lets callers
  force the legacy sequential path: `process.setUseOptimizedExecution(false)`.
- **`ProcessSystem.getAutomation()` / `getConnections()` / `getAllElements()`
  unaffected.**
- **Clone contract tightened.** Callers MUST NOT invoke
  `SystemInterface.setMixingRule(...)` on a fluid while another thread is
  performing a flash on a clone of that fluid. This has always been the
  implicit contract (mixing rules are fluid-construction time state); it is
  now documented and relied on.

---

## Commits on this branch

```
7f66aeb4e update
895ce6c6f update
1584d1065 Add Calculator signal edges to ProcessGraph
e16071dff Enable parallel execution by default; route Calculator-containing
          systems to sequential
4703cb4f6 Add composition tracking to StreamSaturatorUtil.needRecalculation()
769f1c648 Add composition tracking to needRecalculation() overrides
00f016cee perf: honor needRecalculation across runs in parallel execution paths
```

Plus the uncommitted working-tree change to `ProcessSystem.runOptimized()`
that routes recycles to sequential (to be squashed into a final commit).

