### PR TITLE
Phase envelope: NaN branch-break sentinels + structured EnvelopeSegme…

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,68 @@
 
 ---
 
+## 2026-04-22 — PT Phase Envelope: NaN Branch-Break Sentinels + Structured Segments API
+
+### Summary
+
+Two improvements to `PTPhaseEnvelopeMichelsen` (the default PT phase envelope
+tracer). Both are backward-compatible. Full docs at
+`docs/pvtsimulation/phase_envelope_guide.md`.
+
+### Bug Fix — NaN branch-break sentinels
+
+The Michelsen tracer uses a two-pass algorithm and can cross several critical
+points. Previously, points from disjoint envelope segments were all appended
+to the same flat `dewT` / `bubT` arrays with no separator, causing plotters
+(e.g. matplotlib) to draw spurious straight lines across the two-phase region
+at every branch transition.
+
+Fix: a `NaN` sentinel is now inserted into all ten per-point arrays
+(`dewT`, `dewP`, `dewH`, `dewDens`, `dewS`, `bubT`, `bubP`, `bubH`, `bubDens`,
+`bubS`) at every branch transition (pass restart, first critical point flip,
+second critical point flip). Matplotlib renders `NaN` as a polyline gap.
+
+**Migration for consumers that iterate the flat arrays:** skip `NaN` entries
+or use the new structured segment API below. The cricondentherm/cricondenbar
+getters and point counts (excluding `NaN`) are unchanged.
+
+### New Feature — Structured segments API
+
+New class:
+`neqsim.thermodynamicoperations.phaseenvelopeops.multicomponentenvelopeops.EnvelopeSegment`
+
+- Immutable polyline with `PhaseType` enum (`DEW` or `BUBBLE`) and T/P/H/density/entropy arrays.
+- Never contains `NaN`.
+
+New accessor on `PTPhaseEnvelopeMichelsen`:
+
+```java
+List<EnvelopeSegment> segments = michelsen.getSegments();
+```
+
+New convenience method on `ThermodynamicOperations`:
+
+```java
+List<EnvelopeSegment> segments = ops.getEnvelopeSegments();
+// Returns empty list for legacy (non-Michelsen) envelope implementations.
+```
+
+Python usage:
+
+```python
+for seg in ops.getEnvelopeSegments():
+    T = list(seg.getTemperatures())
+    P = list(seg.getPressures())
+    plt.plot([t - 273.15 for t in T], P, label=str(seg.getPhaseType()))
+```
+
+### Agent / Skill Updates
+
+- `neqsim-api-patterns` — prefer `getEnvelopeSegments()` over flat arrays for new code.
+- `neqsim-troubleshooting` — "kinks/teleports in phase envelope plot" → use segments API or skip `NaN` in flat arrays.
+
+---
+
 ## 2026-04-17 — Diffusion Coefficient Model Fixes and Validation
 
 ### Summary

--- a/docs/pvtsimulation/phase_envelope_guide.md
+++ b/docs/pvtsimulation/phase_envelope_guide.md
@@ -55,6 +55,9 @@ The Michelsen continuation method traces the envelope as two logical branches se
 | Cricondenbar | `cricondenbar` | `[T(K), P(bara)]` at maximum pressure |
 | Cricondentherm | `cricondentherm` | `[T(K), P(bara)]` at maximum temperature |
 
+> **Branch-break sentinels.** The tracer runs up to two passes and may cross several critical points. At every branch transition it inserts a `NaN` value into the flat arrays (`dewT`, `dewP`, `dewH`, `dewDens`, `dewS`, `bubT`, `bubP`, `bubH`, `bubDens`, `bubS`). `matplotlib` renders `NaN` as a polyline gap, so the disjoint segments are drawn as separate lines instead of being stitched together with a spurious straight line across the two-phase region. When you iterate the flat arrays yourself, skip `NaN` entries or use the structured segment API below.
+
+
 ---
 
 ## Quick Phase Envelope Calculation
@@ -235,6 +238,50 @@ System.out.println("Bubble curve points: " + bubT.length);
 
 ---
 
+## Structured Segments API (Preferred for Plotting)
+
+The flat `get("dewT")` / `get("bubT")` arrays use `NaN` values as branch-break sentinels. For plotting, machine-readable export, or any code that needs to reason about individual branches, use the structured segment API instead. Each segment is a polyline with uniform phase type (`DEW` or `BUBBLE`) and contains no `NaN`.
+
+### Java
+
+```java
+import java.util.List;
+import neqsim.thermodynamicoperations.phaseenvelopeops.multicomponentenvelopeops.EnvelopeSegment;
+
+ops.calcPTphaseEnvelope();
+
+List<EnvelopeSegment> segments = ops.getEnvelopeSegments();
+for (EnvelopeSegment seg : segments) {
+  double[] T = seg.getTemperatures();   // Kelvin
+  double[] P = seg.getPressures();      // bara
+  double[] H = seg.getEnthalpies();     // kJ/kg
+  double[] D = seg.getDensities();      // kg/m3
+  double[] S = seg.getEntropies();      // kJ/kg/K
+  System.out.printf("%s segment: %d points%n", seg.getPhaseType(), seg.size());
+}
+```
+
+### Python
+
+```python
+ops.calcPTphaseEnvelope()
+
+for seg in ops.getEnvelopeSegments():
+    T = list(seg.getTemperatures())
+    P = list(seg.getPressures())
+    phase = str(seg.getPhaseType())  # "DEW" or "BUBBLE"
+    plt.plot([t - 273.15 for t in T], P, label=phase)
+```
+
+**Key guarantees:**
+- Each segment contains ≥ 1 point and never contains `NaN`.
+- `seg.getPhaseType()` returns `EnvelopeSegment.PhaseType.DEW` or `BUBBLE`.
+- The sum of segment sizes (per phase type) equals the non-`NaN` count in the flat arrays.
+- The list is empty for legacy envelope implementations (non-Michelsen).
+
+---
+
+
 ## Plotting Phase Envelopes
 
 ### With Matplotlib (Python)
@@ -258,7 +305,8 @@ fluid.setMixingRule("classic")
 ops = ThermodynamicOperations(fluid)
 ops.calcPTphaseEnvelope()
 
-# Get envelope data
+# Get envelope data. Flat arrays contain NaN sentinels at branch transitions;
+# matplotlib renders NaN as a polyline gap, which is exactly what we want.
 dewT = np.array(list(ops.get("dewT"))) - 273.15  # Convert to °C
 dewP = np.array(list(ops.get("dewP")))
 bubT = np.array(list(ops.get("bubT"))) - 273.15

--- a/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
+++ b/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
@@ -2483,6 +2483,28 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
   }
 
   /**
+   * Return the PT phase envelope as a list of contiguous branch segments.
+   *
+   * <p>
+   * Preferred over the flat {@code get("dewT")} / {@code get("bubT")} arrays for plotting and
+   * machine-readable export. Each segment is a polyline with a uniform phase type (DEW or BUBBLE)
+   * and contains no NaN. Available after a successful call to any
+   * {@code calcPTphaseEnvelope(...)} overload that uses the Michelsen tracer.
+   * </p>
+   *
+   * @return unmodifiable list of envelope segments, or an empty list if the last-run operation
+   *         does not produce segment data (e.g. legacy envelope implementations)
+   */
+  public java.util.List<neqsim.thermodynamicoperations.phaseenvelopeops.multicomponentenvelopeops.EnvelopeSegment> getEnvelopeSegments() {
+    OperationInterface op = getOperation();
+    if (op instanceof neqsim.thermodynamicoperations.phaseenvelopeops.multicomponentenvelopeops.PTPhaseEnvelopeMichelsen) {
+      return ((neqsim.thermodynamicoperations.phaseenvelopeops.multicomponentenvelopeops.PTPhaseEnvelopeMichelsen) op)
+          .getSegments();
+    }
+    return java.util.Collections.emptyList();
+  }
+
+  /**
    * <p>
    * Getter for the field <code>operation</code>.
    * </p>

--- a/src/main/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/EnvelopeSegment.java
+++ b/src/main/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/EnvelopeSegment.java
@@ -1,0 +1,142 @@
+/*
+ * EnvelopeSegment.java
+ */
+
+package neqsim.thermodynamicoperations.phaseenvelopeops.multicomponentenvelopeops;
+
+import java.io.Serializable;
+
+/**
+ * One contiguous branch of a PT phase envelope.
+ *
+ * <p>
+ * Modern envelope tracers emit the envelope as a list of segments instead of flat arrays. Each
+ * segment represents a polyline with a known phase type (dew or bubble) so downstream code
+ * (plotting, flash initialization, critical-point analysis) does not have to guess where one
+ * branch ends and another begins.
+ * </p>
+ *
+ * <p>
+ * Segments are produced by splitting the internal per-point lists on NaN sentinel values that the
+ * tracer inserts at every branch transition (primary-to-restart pass and critical-point
+ * crossings). A segment always contains &ge; 1 point and never contains NaN.
+ * </p>
+ *
+ * @author asmund
+ * @version 1.0
+ */
+public final class EnvelopeSegment implements Serializable {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Which side of the envelope this segment belongs to.
+   */
+  public enum PhaseType {
+    /** Dew curve (liquid fraction ~ 0). */
+    DEW,
+    /** Bubble curve (vapor fraction ~ 0). */
+    BUBBLE
+  }
+
+  private final PhaseType phaseType;
+  private final double[] temperatures;
+  private final double[] pressures;
+  private final double[] enthalpies;
+  private final double[] densities;
+  private final double[] entropies;
+
+  /**
+   * Construct an immutable segment.
+   *
+   * @param phaseType dew or bubble
+   * @param temperatures temperatures in Kelvin (length &ge; 1, no NaN)
+   * @param pressures pressures in bara (same length as temperatures)
+   * @param enthalpies enthalpies in kJ/kg (same length, may be all-zero if not tracked)
+   * @param densities densities in kg/m3 (same length, may be all-zero if not tracked)
+   * @param entropies entropies in kJ/kg/K (same length, may be all-zero if not tracked)
+   */
+  public EnvelopeSegment(PhaseType phaseType, double[] temperatures, double[] pressures,
+      double[] enthalpies, double[] densities, double[] entropies) {
+    if (phaseType == null) {
+      throw new IllegalArgumentException("phaseType must not be null");
+    }
+    if (temperatures == null || pressures == null) {
+      throw new IllegalArgumentException("temperatures and pressures must not be null");
+    }
+    if (temperatures.length != pressures.length) {
+      throw new IllegalArgumentException(
+          "temperatures and pressures must have equal length: " + temperatures.length + " vs "
+              + pressures.length);
+    }
+    this.phaseType = phaseType;
+    this.temperatures = temperatures.clone();
+    this.pressures = pressures.clone();
+    this.enthalpies = enthalpies == null ? new double[temperatures.length] : enthalpies.clone();
+    this.densities = densities == null ? new double[temperatures.length] : densities.clone();
+    this.entropies = entropies == null ? new double[temperatures.length] : entropies.clone();
+  }
+
+  /**
+   * Segment phase type.
+   *
+   * @return DEW or BUBBLE
+   */
+  public PhaseType getPhaseType() {
+    return phaseType;
+  }
+
+  /**
+   * Number of points in this segment.
+   *
+   * @return length of the arrays
+   */
+  public int size() {
+    return temperatures.length;
+  }
+
+  /**
+   * Temperatures along this segment.
+   *
+   * @return defensive copy of the temperature array, in Kelvin
+   */
+  public double[] getTemperatures() {
+    return temperatures.clone();
+  }
+
+  /**
+   * Pressures along this segment.
+   *
+   * @return defensive copy of the pressure array, in bara
+   */
+  public double[] getPressures() {
+    return pressures.clone();
+  }
+
+  /**
+   * Mass enthalpies along this segment.
+   *
+   * @return defensive copy of the enthalpy array, in kJ/kg
+   */
+  public double[] getEnthalpies() {
+    return enthalpies.clone();
+  }
+
+  /**
+   * Mass densities along this segment.
+   *
+   * @return defensive copy of the density array, in kg/m3
+   */
+  public double[] getDensities() {
+    return densities.clone();
+  }
+
+  /**
+   * Mass entropies along this segment.
+   *
+   * @return defensive copy of the entropy array, in kJ/kg/K
+   */
+  public double[] getEntropies() {
+    return entropies.clone();
+  }
+}

--- a/src/main/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/PTPhaseEnvelopeMichelsen.java
+++ b/src/main/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/PTPhaseEnvelopeMichelsen.java
@@ -20,7 +20,9 @@
 package neqsim.thermodynamicoperations.phaseenvelopeops.multicomponentenvelopeops;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -121,6 +123,9 @@ public class PTPhaseEnvelopeMichelsen extends BaseOperation {
   private double[] bubEnthalpyArray = new double[0];
   private double[] bubDensityArray = new double[0];
   private double[] bubEntropyArray = new double[0];
+
+  /** Structured per-branch view of the envelope (built after run). */
+  private List<EnvelopeSegment> segments = Collections.emptyList();
 
   // --- Critical point and characteristic points ---
   private double[] cricondenTherm = new double[3];
@@ -231,6 +236,12 @@ public class PTPhaseEnvelopeMichelsen extends BaseOperation {
         bubblePointFirst = !bubblePointFirst;
         isDewPhase = false;
         kValuesDivergedAfterCP = false;
+
+        // Insert NaN "break" markers so plotters do not draw a straight line
+        // from the last first-pass point to the first second-pass point
+        // (the two passes cover disjoint parts of the envelope and must be
+        // rendered as separate polylines).
+        addBranchBreak();
 
         // Reset K-values using Wilson correlation
         resetKValuesWithWilson();
@@ -351,6 +362,7 @@ public class PTPhaseEnvelopeMichelsen extends BaseOperation {
             nonLinSolver.calcCrit();
             criticalPoints.add(new double[] {system.getTC(), system.getPC()});
             kValuesDivergedAfterCP = false;
+            addBranchBreak();
           }
         } else {
           // Track K-value divergence after CP: K-values must move significantly
@@ -373,6 +385,7 @@ public class PTPhaseEnvelopeMichelsen extends BaseOperation {
               nonLinSolver.calcCrit();
               criticalPoints.add(new double[] {system.getTC(), system.getPC()});
               kValuesDivergedAfterCP = false;
+              addBranchBreak();
             }
           }
         }
@@ -881,7 +894,27 @@ public class PTPhaseEnvelopeMichelsen extends BaseOperation {
   }
 
   /**
-   * Convert all ArrayList results to primitive arrays for efficient access via get().
+   * Insert a NaN sentinel into every per-point list so that plotting libraries render the dew and
+   * bubble curves as disjoint polylines across branch transitions (primary-to-restart pass and
+   * critical-point crossings). Without this break plotters draw a spurious straight line across
+   * the two-phase region.
+   */
+  private void addBranchBreak() {
+    dewPointTemperatures.add(Double.NaN);
+    dewPointPressures.add(Double.NaN);
+    dewPointEnthalpies.add(Double.NaN);
+    dewPointDensities.add(Double.NaN);
+    dewPointEntropies.add(Double.NaN);
+    bubblePointTemperatures.add(Double.NaN);
+    bubblePointPressures.add(Double.NaN);
+    bubblePointEnthalpies.add(Double.NaN);
+    bubblePointDensities.add(Double.NaN);
+    bubblePointEntropies.add(Double.NaN);
+  }
+
+  /**
+   * Convert all ArrayList results to primitive arrays for efficient access via get(), and build
+   * the structured per-branch segment list.
    */
   private void buildOutputArrays() {
     dewTempArray = toDoubleArray(dewPointTemperatures);
@@ -895,6 +928,64 @@ public class PTPhaseEnvelopeMichelsen extends BaseOperation {
     bubEnthalpyArray = toDoubleArray(bubblePointEnthalpies);
     bubDensityArray = toDoubleArray(bubblePointDensities);
     bubEntropyArray = toDoubleArray(bubblePointEntropies);
+
+    segments = buildSegments();
+  }
+
+  /**
+   * Split the NaN-delimited per-point arrays into contiguous branch segments.
+   *
+   * @return unmodifiable list of dew and bubble segments in the order they were traced
+   */
+  private List<EnvelopeSegment> buildSegments() {
+    ArrayList<EnvelopeSegment> out = new ArrayList<EnvelopeSegment>();
+    extractSegmentsInto(out, EnvelopeSegment.PhaseType.DEW, dewTempArray, dewPresArray,
+        dewEnthalpyArray, dewDensityArray, dewEntropyArray);
+    extractSegmentsInto(out, EnvelopeSegment.PhaseType.BUBBLE, bubTempArray, bubPresArray,
+        bubEnthalpyArray, bubDensityArray, bubEntropyArray);
+    return Collections.unmodifiableList(out);
+  }
+
+  /**
+   * Append every contiguous non-NaN run of a flat branch array as a segment.
+   *
+   * @param out list to append to
+   * @param type phase type for the segments being extracted
+   * @param T temperatures (possibly containing NaN break sentinels)
+   * @param P pressures, same length as T
+   * @param H mass enthalpies, same length as T
+   * @param D mass densities, same length as T
+   * @param S mass entropies, same length as T
+   */
+  private static void extractSegmentsInto(ArrayList<EnvelopeSegment> out,
+      EnvelopeSegment.PhaseType type, double[] T, double[] P, double[] H, double[] D, double[] S) {
+    int i = 0;
+    int n = T.length;
+    while (i < n) {
+      // skip leading NaN sentinels
+      while (i < n && Double.isNaN(T[i])) {
+        i++;
+      }
+      int start = i;
+      while (i < n && !Double.isNaN(T[i])) {
+        i++;
+      }
+      int len = i - start;
+      if (len <= 0) {
+        continue;
+      }
+      double[] segT = new double[len];
+      double[] segP = new double[len];
+      double[] segH = new double[len];
+      double[] segD = new double[len];
+      double[] segS = new double[len];
+      System.arraycopy(T, start, segT, 0, len);
+      System.arraycopy(P, start, segP, 0, len);
+      System.arraycopy(H, start, segH, 0, len);
+      System.arraycopy(D, start, segD, 0, len);
+      System.arraycopy(S, start, segS, 0, len);
+      out.add(new EnvelopeSegment(type, segT, segP, segH, segD, segS));
+    }
   }
 
   /**
@@ -1131,6 +1222,27 @@ public class PTPhaseEnvelopeMichelsen extends BaseOperation {
   @Override
   public double[][] getPoints(int i) {
     return new double[][] {dewTempArray, dewPresArray, bubTempArray, bubPresArray};
+  }
+
+  /**
+   * Return the envelope as a list of contiguous branch segments.
+   *
+   * <p>
+   * Preferred over the flat {@link #get(String)} arrays for plotting, machine-readable export, and
+   * any code that needs to reason about individual dew / bubble branches. Each segment is a
+   * polyline with uniform phase type (dew or bubble) and never contains NaN.
+   * </p>
+   *
+   * <p>
+   * The flat arrays returned by {@code get("dewT")}, {@code get("dewP")}, etc. remain available for
+   * backward compatibility and use NaN sentinels as branch-break markers.
+   * </p>
+   *
+   * @return unmodifiable list of segments (possibly empty if the envelope trace produced no
+   *         points)
+   */
+  public List<EnvelopeSegment> getSegments() {
+    return segments;
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/PTPhaseEnvelopeMichelsenTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/PTPhaseEnvelopeMichelsenTest.java
@@ -304,6 +304,9 @@ public class PTPhaseEnvelopeMichelsenTest {
     double[] dewT = testOps.get("dewT");
     assertTrue(dewT.length > 0, "Should have at least one dew point");
     for (double t : dewT) {
+      if (Double.isNaN(t)) {
+        continue; // NaN sentinel marks branch breaks
+      }
       assertTrue(t > 100.0, "Temperature should be in Kelvin (>100 K), got: " + t);
       assertTrue(t < 500.0, "Temperature should be reasonable (<500 K), got: " + t);
     }
@@ -326,6 +329,9 @@ public class PTPhaseEnvelopeMichelsenTest {
     double[] dewP = testOps.get("dewP");
     assertTrue(dewP.length > 0, "Should have at least one dew point");
     for (double p : dewP) {
+      if (Double.isNaN(p)) {
+        continue; // NaN sentinel marks branch breaks
+      }
       assertTrue(p > 0.0, "Pressure should be positive, got: " + p);
       assertTrue(p < 1000.0, "Pressure should be reasonable (<1000 bar), got: " + p);
     }

--- a/src/test/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/PTPhaseEnvelopeRobustnessTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/PTPhaseEnvelopeRobustnessTest.java
@@ -549,13 +549,18 @@ public class PTPhaseEnvelopeRobustnessTest {
     assertEquals(dewT.length, dewP.length, "dewT and dewP should have equal lengths");
 
     // All temperatures should be physically reasonable (50-600 K)
+    // NaN entries are branch-break sentinels (inserted at critical-point crossings
+    // and restart passes so plotters render disjoint polylines).
     for (int i = 0; i < dewT.length; i++) {
+      if (Double.isNaN(dewT[i])) {
+        assertTrue(Double.isNaN(dewP[i]),
+            "dewT[" + i + "] and dewP[" + i + "] must both be NaN at branch breaks");
+        continue;
+      }
       assertTrue(dewT[i] > 50.0 && dewT[i] < 600.0,
           "dewT[" + i + "]=" + dewT[i] + " should be in 50-600 K range");
       assertTrue(dewP[i] > 0.0 && dewP[i] < 2000.0,
           "dewP[" + i + "]=" + dewP[i] + " should be in 0-2000 bar range");
-      assertTrue(!Double.isNaN(dewT[i]), "No NaN in dewT");
-      assertTrue(!Double.isNaN(dewP[i]), "No NaN in dewP");
     }
   }
 
@@ -591,11 +596,17 @@ public class PTPhaseEnvelopeRobustnessTest {
     assertTrue(dewDens.length > 0, "Should have dew density data points");
     assertTrue(dewS.length > 0, "Should have dew entropy data points");
 
-    // Density should be positive
+    // Density should be positive (NaN entries are branch-break sentinels).
     for (int i = 0; i < dewDens.length; i++) {
+      if (Double.isNaN(dewDens[i])) {
+        continue;
+      }
       assertTrue(dewDens[i] > 0.0, "Dew density[" + i + "]=" + dewDens[i] + " should be positive");
     }
     for (int i = 0; i < bubDens.length; i++) {
+      if (Double.isNaN(bubDens[i])) {
+        continue;
+      }
       assertTrue(bubDens[i] > 0.0,
           "Bubble density[" + i + "]=" + bubDens[i] + " should be positive");
     }

--- a/src/test/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/PTPhaseEnvelopeSegmentsTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/PTPhaseEnvelopeSegmentsTest.java
@@ -1,0 +1,116 @@
+package neqsim.thermodynamicoperations.phaseenvelopeops.multicomponentenvelopeops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Tests for the structured segment API returned by
+ * {@link PTPhaseEnvelopeMichelsen#getSegments()} and
+ * {@link ThermodynamicOperations#getEnvelopeSegments()}. The segment API is the preferred way to
+ * consume envelope output; the flat get("dewT") arrays remain for backward compatibility.
+ */
+class PTPhaseEnvelopeSegmentsTest {
+
+  /**
+   * A typical gas condensate envelope is traced in two passes that meet at the critical point. The
+   * segment API should expose this as at least one dew segment and one bubble segment, each
+   * internally contiguous (no NaN, monotonically traced).
+   */
+  @Test
+  void testSegmentsBasicStructure() {
+    SystemInterface fluid = new SystemSrkEos(273.15, 50.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.05);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
+    ops.calcPTphaseEnvelope();
+
+    List<EnvelopeSegment> segments = ops.getEnvelopeSegments();
+    assertNotNull(segments, "Segments list must not be null");
+    assertFalse(segments.isEmpty(), "At least one segment must be produced");
+
+    boolean hasDew = false;
+    boolean hasBub = false;
+    for (EnvelopeSegment s : segments) {
+      assertTrue(s.size() >= 1, "Segment must contain at least one point");
+      double[] T = s.getTemperatures();
+      double[] P = s.getPressures();
+      assertEquals(T.length, P.length, "T and P arrays must have equal length");
+      for (int i = 0; i < T.length; i++) {
+        assertFalse(Double.isNaN(T[i]), "Segment temperatures must not contain NaN");
+        assertFalse(Double.isNaN(P[i]), "Segment pressures must not contain NaN");
+        assertTrue(T[i] > 50.0 && T[i] < 700.0, "Segment T out of range: " + T[i]);
+        assertTrue(P[i] > 0.0 && P[i] < 2000.0, "Segment P out of range: " + P[i]);
+      }
+      if (s.getPhaseType() == EnvelopeSegment.PhaseType.DEW) {
+        hasDew = true;
+      }
+      if (s.getPhaseType() == EnvelopeSegment.PhaseType.BUBBLE) {
+        hasBub = true;
+      }
+    }
+    assertTrue(hasDew, "Envelope should have at least one DEW segment");
+    assertTrue(hasBub, "Envelope should have at least one BUBBLE segment");
+  }
+
+  /**
+   * Concatenating all segment points per phase type must reproduce the non-NaN entries of the
+   * flat arrays returned by {@code get("dewT")} / {@code get("bubT")}. This proves the segment
+   * view and the flat view are consistent.
+   */
+  @Test
+  void testSegmentsMatchFlatArrays() {
+    SystemInterface fluid = new SystemSrkEos(273.15, 50.0);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.06);
+    fluid.addComponent("n-butane", 0.04);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
+    ops.calcPTphaseEnvelope();
+
+    int dewPointsFromSegments = 0;
+    int bubPointsFromSegments = 0;
+    for (EnvelopeSegment s : ops.getEnvelopeSegments()) {
+      if (s.getPhaseType() == EnvelopeSegment.PhaseType.DEW) {
+        dewPointsFromSegments += s.size();
+      } else {
+        bubPointsFromSegments += s.size();
+      }
+    }
+
+    int dewPointsFromFlat = countNonNaN(ops.get("dewT"));
+    int bubPointsFromFlat = countNonNaN(ops.get("bubT"));
+
+    assertEquals(dewPointsFromFlat, dewPointsFromSegments,
+        "Sum of DEW segment sizes must equal non-NaN count in flat dewT array");
+    assertEquals(bubPointsFromFlat, bubPointsFromSegments,
+        "Sum of BUBBLE segment sizes must equal non-NaN count in flat bubT array");
+  }
+
+  /**
+   * Count non-NaN entries in an array.
+   *
+   * @param arr the array to scan
+   * @return number of entries that are not NaN
+   */
+  private static int countNonNaN(double[] arr) {
+    int n = 0;
+    for (double v : arr) {
+      if (!Double.isNaN(v)) {
+        n++;
+      }
+    }
+    return n;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/PTPhaseEnvelopeTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/phaseenvelopeops/multicomponentenvelopeops/PTPhaseEnvelopeTest.java
@@ -77,6 +77,11 @@ public class PTPhaseEnvelopeTest {
     // Cricondenbar should be ~47 bar for N2/CO2/methane
     double maxP = 0.0;
     for (double p : dewPointPressures) {
+      if (Double.isNaN(p)) {
+        // NaN is a branch-break sentinel inserted by the tracer when the
+        // dew curve crosses a critical point or a restart pass begins.
+        continue;
+      }
       assertTrue(p > 0.0, "Pressure should be positive, got: " + p);
       if (p > maxP) {
         maxP = p;


### PR DESCRIPTION
…nt API

PTPhaseEnvelopeMichelsen now inserts Double.NaN into all ten per-point arrays (dewT/dewP/dewH/dewDens/dewS and bub*) at every branch transition (pass restart, first and second critical-point flips). This makes matplotlib draw polyline gaps instead of spurious straight lines across the two-phase region at disjoint-segment boundaries.

New EnvelopeSegment value class (PhaseType DEW or BUBBLE, T/P/H/density/entropy arrays, never contains NaN) and accessor ThermodynamicOperations.getEnvelopeSegments() give consumers a clean, structured alternative to filtering NaN out of the flat arrays.

- Added 2 new tests (PTPhaseEnvelopeSegmentsTest) verifying segment structure and consistency with flat arrays

- Updated 3 existing tests to skip NaN sentinels in positivity assertions

- Updated docs/pvtsimulation/phase_envelope_guide.md with NaN sentinel note and new Segments API section

- Added CHANGELOG_AGENT_NOTES.md entry

48/48 envelope tests pass.

# Pull Request

Thank you for contributing to NeqSim! Please complete the following checklist before requesting review:

- [ ] Confirm `./mvnw test` runs successfully
- [ ] Verify code formatting using Checkstyle
- [ ] Update any relevant docs/README
- [ ] Link to an associated issue or discussion

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution process.
