### PR TITLE
exergy analysis

### DIFF
--- a/docs/REFERENCE_MANUAL_INDEX.md
+++ b/docs/REFERENCE_MANUAL_INDEX.md
@@ -255,6 +255,7 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 | DEXPI Architecture    | [docs/process/processmodel/DIAGRAM_ARCHITECTURE_DEXPI_SYNERGY.md](process/processmodel/DIAGRAM_ARCHITECTURE_DEXPI_SYNERGY) | DEXPI integration         |
 | Simulation Hooks      | [docs/process/simulation-hooks-and-events.md](process/simulation-hooks-and-events)                                         | Lifecycle hooks, ProcessEventBus, auto-validation for ProcessSystem and ProcessModel |
 | **UniSim/HYSYS Conversion** | [docs/process/unisim-to-neqsim-conversion.md](process/unisim-to-neqsim-conversion)                                  | **Convert UniSim Design (.usc) models to NeqSim and export NeqSim back to UniSim — COM automation, mapping tables, topology reconstruction, verification** |
+| **Exergy Analysis**   | [docs/process/exergy-analysis.md](process/exergy-analysis)                                                                 | **Plant-wide exergy destruction hotspots — ProcessSystem, ProcessModel, ExergyAnalysisReport API, JSON export** |
 
 ### Chapter 13: Streams & Mixers
 

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -47,6 +47,7 @@ This documentation is organized into the following sections:
 | [safety/](safety/) | Safety systems (PSV, ESD, blowdown) |
 | [controllers.md](controllers) | Process controllers and logic |
 | [unisim-to-neqsim-conversion.md](unisim-to-neqsim-conversion) | **UniSim/HYSYS conversion** — convert `.usc` models to NeqSim and export back to UniSim |
+| [exergy-analysis.md](exergy-analysis) | **Exergy analysis** — plant-wide destruction hotspots for ProcessSystem and ProcessModel |
 
 ### Process Design Guide
 

--- a/docs/process/exergy-analysis.md
+++ b/docs/process/exergy-analysis.md
@@ -1,0 +1,206 @@
+---
+title: "Exergy Analysis for Process Systems and Plant Models"
+description: "Plant-wide exergy destruction analysis for NeqSim — identify thermodynamic inefficiency hotspots across ProcessSystem and multi-area ProcessModel flowsheets using the ExergyAnalysisReport API."
+---
+
+# Exergy Analysis
+
+Exergy analysis quantifies the **thermodynamic inefficiency** (lost work) of each unit operation. Unlike energy balance alone, exergy destruction pinpoints *where* in the plant useful work is being wasted — the prime leverage points for efficiency improvement.
+
+NeqSim provides a unified exergy API at three levels:
+
+| Level | Class | Use When |
+|-------|-------|----------|
+| Single unit | `ProcessEquipmentInterface` | Check one piece of equipment |
+| Flowsheet | `ProcessSystem` | One process area / single flowsheet |
+| Multi-area plant | `ProcessModel` | Full plants composed of multiple `ProcessSystem` areas |
+
+Results are returned as an [`ExergyAnalysisReport`](../../src/main/java/neqsim/process/util/exergy/ExergyAnalysisReport.java) — a structured, JSON-exportable object designed for large plants with hundreds of units.
+
+---
+
+## Theory (one equation)
+
+For any control volume operating with surroundings at dead-state temperature $T_0$ (K):
+
+$$
+\dot{E}_{\text{destroyed}} \;=\; T_0 \cdot \dot{S}_{\text{gen}} \;\geq\; 0
+$$
+
+where $\dot{S}_{\text{gen}}$ is the entropy production rate of the unit. This is the Gouy–Stodola theorem and is **universal** for adiabatic equipment (compressors, expanders, valves, mixers, separators).
+
+Exergy destruction is always non-negative; NeqSim clamps small negative numerical noise to zero.
+
+**Caveat — heaters and coolers.** When the external heat source/sink temperature is not modelled, the default destruction uses only stream-side entropy production. This underestimates irreversibility caused by the finite temperature difference across the heat transfer surface. Model the utility side explicitly (e.g., using a heat exchanger with a utility stream) for a full picture.
+
+---
+
+## Quick start — single flowsheet
+
+```java
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.util.exergy.ExergyAnalysisReport;
+
+ProcessSystem process = new ProcessSystem();
+// ... build flowsheet, process.run() ...
+
+process.setSurroundingTemperature(288.15); // dead-state T0 (K)
+
+double exergyChange_kW      = process.getExergyChange("kW");
+double exergyDestruction_kW = process.getExergyDestruction("kW");
+
+ExergyAnalysisReport report = process.getExergyAnalysis();
+System.out.println(report.toString("kW"));
+```
+
+The ranked table lists every unit in the flowsheet, sorted by destruction:
+
+```text
+Exergy analysis report (unit: kW)
+==================================================================
+#   Unit name              Type         Destruction   Change
+------------------------------------------------------------------
+1   MainCompressor         Compressor        42.18     -215.30
+2   JT-Valve               ThrottlingValve   18.72        0.00
+3   InterCooler            Cooler             5.31      -87.11
+...
+Total destruction: 66.21 kW
+Total change:     -302.41 kW
+```
+
+Supported units: `J`, `kJ`, `MJ`, `W`, `kW`, `MW`.
+
+---
+
+## Plant-wide analysis — multi-area `ProcessModel`
+
+Large plants are usually split into multiple `ProcessSystem` areas (separation, compression, utilities, export) and composed in a `ProcessModel`. The exergy report aggregates automatically, labelling each entry with its area name.
+
+```java
+import neqsim.process.processmodel.ProcessModel;
+
+ProcessModel plant = new ProcessModel();
+plant.add("Separation", separationArea);
+plant.add("Compression", compressionArea);
+plant.add("Export", exportArea);
+plant.run();
+
+ExergyAnalysisReport report = plant.getExergyAnalysis();
+
+// Top-10 hotspots across the entire plant:
+for (ExergyAnalysisReport.Entry e : report.getTopDestructionHotspots(10)) {
+    System.out.printf("%-20s [%s]  %.2f kW%n",
+        e.getName(), e.getArea(), e.getExergyDestructionJ() / 1000.0);
+}
+
+// Aggregate destruction by area:
+Map<String, Double> byArea = report.getDestructionByArea("kW");
+
+// Aggregate by equipment type:
+Map<String, Double> byType = report.getDestructionByType("kW");
+
+// Serialise for dashboards / reports:
+String json = report.toJson();
+```
+
+`getTopDestructionHotspots(0)` or any `n ≤ 0` returns the full sorted list.
+
+---
+
+## API reference
+
+### ProcessSystem
+
+| Method | Purpose |
+|--------|---------|
+| `getExergyChange(String unit)` | Net exergy change using the system's surrounding temperature |
+| `getExergyChange(String unit, double T0)` | Net exergy change at specified $T_0$ (K) |
+| `getExergyDestruction(String unit)` | Total destruction across all units (= $T_0 \sum \dot{S}_{\text{gen}}$) |
+| `getExergyDestruction(String unit, double T0)` | Same, at specified $T_0$ |
+| `getExergyAnalysis()` | Build structured `ExergyAnalysisReport` |
+| `getExergyAnalysis(double T0)` | Same, at specified $T_0$ |
+
+### ProcessModel
+
+| Method | Purpose |
+|--------|---------|
+| `getExergyChange(String unit)` | Plant-wide sum across all areas |
+| `getExergyDestruction(String unit)` | Plant-wide destruction |
+| `getExergyAnalysis()` | Combined report with `area` tag on every entry |
+
+### ExergyAnalysisReport
+
+| Method | Returns |
+|--------|---------|
+| `getEntries()` | All entries (unit, type, area, change, destruction) |
+| `getTopDestructionHotspots(int n)` | Top-n entries sorted descending by destruction (`n ≤ 0` returns all) |
+| `getTotalExergyDestruction(String unit)` | Sum of destruction, converted |
+| `getTotalExergyChange(String unit)` | Sum of change, converted |
+| `getDestructionByArea(String unit)` | Destruction grouped by area |
+| `getDestructionByType(String unit)` | Destruction grouped by equipment type |
+| `toString(String unit)` | Ranked human-readable table |
+| `toJson()` | JSON string for dashboards / results.json |
+
+### ProcessEquipmentInterface
+
+Every equipment class now supports:
+
+```java
+double d_J  = unit.getExergyDestruction("J");
+double d_kW = unit.getExergyDestruction("kW");
+double d_T0 = unit.getExergyDestruction("kW", 293.15);
+```
+
+The default implementation uses $T_0 \cdot \dot{S}_{\text{gen}}$ from the equipment's entropy production, clamped at zero.
+
+---
+
+## Python example
+
+```python
+from neqsim import jneqsim
+
+plant = jneqsim.process.processmodel.ProcessModel()
+plant.add("Compression", compression)
+plant.add("Export", export)
+plant.run()
+
+report = plant.getExergyAnalysis()
+print(report.toString("kW"))
+
+hotspots = list(report.getTopDestructionHotspots(5))
+for e in hotspots:
+    print(f"{e.getName():<20}  {e.getArea():<12}  {e.getExergyDestructionJ()/1000:.2f} kW")
+
+# Export structured JSON (e.g. for results.json in the task-solving workflow)
+with open("exergy.json", "w") as f:
+    f.write(str(report.toJson()))
+```
+
+---
+
+## Using exergy results in task reports
+
+The JSON from `report.toJson()` is well-suited for embedding in task `results.json`:
+
+```python
+import json
+results["exergy"] = {
+    "T0_K": 288.15,
+    "total_destruction_kW": plant.getExergyDestruction("kW"),
+    "by_area_kW": dict(report.getDestructionByArea("kW")),
+    "by_type_kW": dict(report.getDestructionByType("kW")),
+    "hotspots": json.loads(str(report.toJson()))["entries"][:10],
+}
+```
+
+Downstream the task report generator can render these as tables and tornado charts.
+
+---
+
+## Related documentation
+
+- [Process Simulation Package](README.md)
+- [ProcessModel for Multi-Area Plants](processmodel/)
+- [Controllers and Logic](controllers.md)
+- [Thermodynamic Operations](../thermodynamicoperations/index.md)

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentInterface.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentInterface.java
@@ -391,7 +391,50 @@ public interface ProcessEquipmentInterface extends ProcessElementInterface, Simu
    * @return a double
    */
   public default double getExergyChange(String unit) {
-    return 0.0;
+    return getExergyChange(unit, 288.15);
+  }
+
+  /**
+   * Exergy destruction rate of the unit operation, based on the universal relation
+   * {@code E_destroyed = T0 * S_gen} where {@code S_gen} is the entropy generation across the unit
+   * and {@code T0} is the surrounding ("dead state") temperature. The returned value is always
+   * non-negative.
+   *
+   * <p>
+   * The default implementation uses {@link #getEntropyProduction(String)} expressed in J/K. For
+   * adiabatic equipment (valves, separators, mixers, compressors, pumps) this gives the exact
+   * exergy destruction. For units with heat crossing the boundary at a known source temperature
+   * (heaters, coolers), override this method to include the Carnot-weighted heat exergy.
+   * </p>
+   *
+   * @param unit target unit, one of J, kJ, MJ, W, kW, MW
+   * @param surroundingTemperature surrounding (dead-state) temperature in K
+   * @return non-negative exergy destruction rate in the requested unit
+   */
+  public default double getExergyDestruction(String unit, double surroundingTemperature) {
+    double sGenJperK = getEntropyProduction("J/K");
+    double destructionJ = Math.max(0.0, surroundingTemperature * sGenJperK);
+    if (unit == null || "J".equals(unit) || "W".equals(unit)) {
+      return destructionJ;
+    }
+    if ("kJ".equals(unit) || "kW".equals(unit)) {
+      return destructionJ / 1.0e3;
+    }
+    if ("MJ".equals(unit) || "MW".equals(unit)) {
+      return destructionJ / 1.0e6;
+    }
+    return destructionJ;
+  }
+
+  /**
+   * Exergy destruction rate with a default surrounding temperature of 288.15 K (15 degC). See
+   * {@link #getExergyDestruction(String, double)} for details.
+   *
+   * @param unit target unit
+   * @return exergy destruction in the requested unit
+   */
+  public default double getExergyDestruction(String unit) {
+    return getExergyDestruction(unit, 288.15);
   }
 
   /**

--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -19,8 +19,7 @@ import neqsim.util.validation.ValidationResult;
 
 /**
  * <p>
- * ProcessModel class. Manages a collection of processes that can be run in
- * steps or continuously.
+ * ProcessModel class. Manages a collection of processes that can be run in steps or continuously.
  * </p>
  *
  * <p>
@@ -42,22 +41,19 @@ public class ProcessModel implements Runnable, Serializable {
   private boolean useOptimizedExecution = true;
 
   /**
-   * Transient listener for model-level progress callbacks. Marked transient to
-   * avoid serialization
+   * Transient listener for model-level progress callbacks. Marked transient to avoid serialization
    * issues.
    */
   private transient ModelProgressListener progressListener = null;
 
   /**
-   * When true, lifecycle events are published to the ProcessEventBus singleton
-   * during model
+   * When true, lifecycle events are published to the ProcessEventBus singleton during model
    * execution. Default is false for zero overhead when not needed.
    */
   private boolean publishEvents = false;
 
   /**
-   * When true, validateSetup() is called on each ProcessSystem before the first
-   * iteration.
+   * When true, validateSetup() is called on each ProcessSystem before the first iteration.
    * Validation warnings are logged but do not abort execution.
    */
   private boolean autoValidate = false;
@@ -72,10 +68,8 @@ public class ProcessModel implements Runnable, Serializable {
   private String checkpointPath = null;
 
   /**
-   * Interface for monitoring ProcessModel execution progress. Implementations
-   * receive callbacks at
-   * the model level: before/after each process area runs, before/after each outer
-   * iteration, and
+   * Interface for monitoring ProcessModel execution progress. Implementations receive callbacks at
+   * the model level: before/after each process area runs, before/after each outer iteration, and
    * when the model starts/completes.
    *
    * <p>
@@ -93,10 +87,10 @@ public class ProcessModel implements Runnable, Serializable {
     /**
      * Called after a process area completes a single execution pass.
      *
-     * @param areaName        the name of the process area
-     * @param process         the ProcessSystem that completed
-     * @param areaIndex       zero-based index of the area in execution order
-     * @param totalAreas      total number of process areas
+     * @param areaName the name of the process area
+     * @param process the ProcessSystem that completed
+     * @param areaIndex zero-based index of the area in execution order
+     * @param totalAreas total number of process areas
      * @param iterationNumber current outer iteration number (starts at 1)
      */
     void onProcessAreaComplete(String areaName, ProcessSystem process, int areaIndex,
@@ -105,10 +99,10 @@ public class ProcessModel implements Runnable, Serializable {
     /**
      * Called before a process area is executed.
      *
-     * @param areaName        the name of the process area about to run
-     * @param process         the ProcessSystem about to run
-     * @param areaIndex       zero-based index of the area
-     * @param totalAreas      total number of process areas
+     * @param areaName the name of the process area about to run
+     * @param process the ProcessSystem about to run
+     * @param areaIndex zero-based index of the area
+     * @param totalAreas total number of process areas
      * @param iterationNumber current outer iteration number (starts at 1)
      */
     default void onBeforeProcessArea(String areaName, ProcessSystem process, int areaIndex,
@@ -120,8 +114,8 @@ public class ProcessModel implements Runnable, Serializable {
      * Called when an outer iteration of the model completes.
      *
      * @param iterationNumber the iteration that just completed (starts at 1)
-     * @param converged       true if the model has converged
-     * @param maxError        maximum relative error across all variables
+     * @param converged true if the model has converged
+     * @param maxError maximum relative error across all variables
      */
     default void onIterationComplete(int iterationNumber, boolean converged, double maxError) {
       // Default does nothing
@@ -149,7 +143,7 @@ public class ProcessModel implements Runnable, Serializable {
      * Called once when the model finishes execution.
      *
      * @param totalIterations total number of iterations performed
-     * @param converged       true if the model converged
+     * @param converged true if the model converged
      */
     default void onModelComplete(int totalIterations, boolean converged) {
       // Default does nothing
@@ -158,8 +152,8 @@ public class ProcessModel implements Runnable, Serializable {
     /**
      * Called if a process area encounters an error during execution.
      *
-     * @param areaName  name of the area that failed
-     * @param process   the ProcessSystem that failed
+     * @param areaName name of the area that failed
+     * @param process the ProcessSystem that failed
      * @param exception the exception that was thrown
      * @return true to continue with next area, false to abort
      */
@@ -203,8 +197,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Check if optimized execution is enabled for individual ProcessSystems.
    *
    * <p>
-   * When enabled (default), each ProcessSystem uses
-   * {@link ProcessSystem#runOptimized()} which
+   * When enabled (default), each ProcessSystem uses {@link ProcessSystem#runOptimized()} which
    * auto-selects the best execution strategy based on topology.
    * </p>
    *
@@ -218,12 +211,9 @@ public class ProcessModel implements Runnable, Serializable {
    * Enable or disable optimized execution for individual ProcessSystems.
    *
    * <p>
-   * When enabled (default), each ProcessSystem uses
-   * {@link ProcessSystem#runOptimized()} which
-   * auto-selects the best execution strategy (parallel for feed-forward, hybrid
-   * for recycle
-   * processes). When disabled, uses standard sequential
-   * {@link ProcessSystem#run()}.
+   * When enabled (default), each ProcessSystem uses {@link ProcessSystem#runOptimized()} which
+   * auto-selects the best execution strategy (parallel for feed-forward, hybrid for recycle
+   * processes). When disabled, uses standard sequential {@link ProcessSystem#run()}.
    * </p>
    *
    * @param useOptimizedExecution true to enable optimized execution
@@ -262,8 +252,7 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Set flow tolerance for convergence check (relative error).
    *
-   * @param flowTolerance relative tolerance for flow rate convergence (e.g., 1e-4
-   *                      = 0.01%)
+   * @param flowTolerance relative tolerance for flow rate convergence (e.g., 1e-4 = 0.01%)
    */
   public void setFlowTolerance(double flowTolerance) {
     this.flowTolerance = flowTolerance;
@@ -308,8 +297,7 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Set all tolerances at once.
    *
-   * @param tolerance relative tolerance for all variables (flow, temperature,
-   *                  pressure)
+   * @param tolerance relative tolerance for all variables (flow, temperature, pressure)
    */
   public void setTolerance(double tolerance) {
     this.flowTolerance = tolerance;
@@ -366,8 +354,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Get the maximum error across all variables (flow, temperature, pressure).
    *
    * <p>
-   * This is the largest relative error from the last iteration, useful for quick
-   * convergence check.
+   * This is the largest relative error from the last iteration, useful for quick convergence check.
    * </p>
    *
    * @return maximum relative error across all variables
@@ -395,10 +382,8 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Enables or disables event publishing to the ProcessEventBus singleton. When
-   * enabled, lifecycle
-   * events (model start/complete, area errors, convergence) are published during
-   * execution.
+   * Enables or disables event publishing to the ProcessEventBus singleton. When enabled, lifecycle
+   * events (model start/complete, area errors, convergence) are published during execution.
    *
    * @param publish true to enable event publishing, false to disable (default)
    */
@@ -409,18 +394,15 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Returns whether event publishing is enabled.
    *
-   * @return true if events are published to ProcessEventBus during model
-   *         execution
+   * @return true if events are published to ProcessEventBus during model execution
    */
   public boolean isPublishEvents() {
     return this.publishEvents;
   }
 
   /**
-   * Enables or disables automatic validation of each ProcessSystem before the
-   * first iteration. When
-   * enabled, validateSetup() is called on each ProcessSystem. Validation failures
-   * are logged as
+   * Enables or disables automatic validation of each ProcessSystem before the first iteration. When
+   * enabled, validateSetup() is called on each ProcessSystem. Validation failures are logged as
    * warnings but do not abort execution.
    *
    * @param validate true to enable auto-validation, false to disable (default)
@@ -441,7 +423,7 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Adds a process to the model.
    *
-   * @param name    a {@link java.lang.String} object
+   * @param name a {@link java.lang.String} object
    * @param process a {@link neqsim.process.processmodel.ProcessSystem} object
    * @return a boolean
    */
@@ -499,8 +481,7 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Generates IEC 81346 reference designations for all equipment across all
-   * process areas in this
+   * Generates IEC 81346 reference designations for all equipment across all process areas in this
    * model. Each area receives a unique function sub-level (A1, A2, A3, ...).
    *
    * <p>
@@ -508,24 +489,21 @@ public class ProcessModel implements Runnable, Serializable {
    * {@link neqsim.process.equipment.iec81346.ReferenceDesignationGenerator}.
    * </p>
    *
-   * @param locationPrefix the location-aspect prefix (e.g. "P1" for a specific
-   *                       platform)
+   * @param locationPrefix the location-aspect prefix (e.g. "P1" for a specific platform)
    * @return the generator instance (for further queries such as {@code toJson()})
    */
   public neqsim.process.equipment.iec81346.ReferenceDesignationGenerator generateReferenceDesignations(
       String locationPrefix) {
-    neqsim.process.equipment.iec81346.ReferenceDesignationGenerator gen = new neqsim.process.equipment.iec81346.ReferenceDesignationGenerator(
-        this);
+    neqsim.process.equipment.iec81346.ReferenceDesignationGenerator gen =
+        new neqsim.process.equipment.iec81346.ReferenceDesignationGenerator(this);
     gen.setLocationPrefix(locationPrefix);
     gen.generate();
     return gen;
   }
 
   /**
-   * Generates IEC 81346 reference designations with hierarchical function
-   * structure. Each area
-   * receives a nested function sub-level under the given prefix (e.g. "A1.A1",
-   * "A1.A2").
+   * Generates IEC 81346 reference designations with hierarchical function structure. Each area
+   * receives a nested function sub-level under the given prefix (e.g. "A1.A1", "A1.A2").
    *
    * @param functionPrefix the top-level function prefix (e.g. "A1")
    * @param locationPrefix the location-aspect prefix (e.g. "P1")
@@ -533,8 +511,8 @@ public class ProcessModel implements Runnable, Serializable {
    */
   public neqsim.process.equipment.iec81346.ReferenceDesignationGenerator generateReferenceDesignations(
       String functionPrefix, String locationPrefix) {
-    neqsim.process.equipment.iec81346.ReferenceDesignationGenerator gen = new neqsim.process.equipment.iec81346.ReferenceDesignationGenerator(
-        this);
+    neqsim.process.equipment.iec81346.ReferenceDesignationGenerator gen =
+        new neqsim.process.equipment.iec81346.ReferenceDesignationGenerator(this);
     gen.setFunctionPrefix(functionPrefix);
     gen.setLocationPrefix(locationPrefix);
     gen.setUseHierarchicalFunctions(true);
@@ -543,8 +521,7 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Looks up a process equipment unit across all process areas by its IEC 81346
-   * reference
+   * Looks up a process equipment unit across all process areas by its IEC 81346 reference
    * designation string (e.g. {@code "=A1.B1"}, {@code "-B1"}).
    *
    * @param refDesignation the reference designation string to match
@@ -556,7 +533,8 @@ public class ProcessModel implements Runnable, Serializable {
       return null;
     }
     for (ProcessSystem system : processes.values()) {
-      neqsim.process.equipment.ProcessEquipmentInterface found = system.getUnitByReferenceDesignation(refDesignation);
+      neqsim.process.equipment.ProcessEquipmentInterface found =
+          system.getUnitByReferenceDesignation(refDesignation);
       if (found != null) {
         return found;
       }
@@ -575,14 +553,13 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Apply an acceleration method to every
-   * {@link neqsim.process.equipment.util.Recycle Recycle}
+   * Apply an acceleration method to every {@link neqsim.process.equipment.util.Recycle Recycle}
    * unit across all areas in this {@code ProcessModel}.
    *
    * <p>
-   * For large multi-area plants with many recycle loops, Wegstein acceleration
-   * typically reduces outer-loop iteration count by 2-3x over the default
-   * direct substitution. This is a bulk convenience that delegates to
+   * For large multi-area plants with many recycle loops, Wegstein acceleration typically reduces
+   * outer-loop iteration count by 2-3x over the default direct substitution. This is a bulk
+   * convenience that delegates to
    * {@link ProcessSystem#setRecycleAccelerationMethod(neqsim.process.equipment.util.AccelerationMethod)}
    * on every registered area.
    * </p>
@@ -590,8 +567,7 @@ public class ProcessModel implements Runnable, Serializable {
    * @param method acceleration method to apply (must not be {@code null})
    * @return total number of {@code Recycle} units updated across all areas
    */
-  public int setRecycleAccelerationMethod(
-      neqsim.process.equipment.util.AccelerationMethod method) {
+  public int setRecycleAccelerationMethod(neqsim.process.equipment.util.AccelerationMethod method) {
     if (method == null) {
       throw new IllegalArgumentException("AccelerationMethod must not be null");
     }
@@ -603,20 +579,92 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
+   * Total change in stream exergy (outlet − inlet) aggregated over every unit operation in every
+   * process area. Each area contributes using its own
+   * {@link ProcessSystem#getSurroundingTemperature() surrounding temperature}.
+   *
+   * @param unit energy / power unit of the returned value (J, kJ, MJ, W, kW, MW)
+   * @return total exergy change in the requested unit
+   */
+  public double getExergyChange(String unit) {
+    double totalJ = 0.0;
+    for (ProcessSystem ps : processes.values()) {
+      totalJ += ps.getExergyChange("J");
+    }
+    return convertEnergy(totalJ, unit);
+  }
+
+  /**
+   * Total exergy destruction rate aggregated over every unit operation in every process area. Each
+   * area contributes using its own surrounding temperature.
+   *
+   * @param unit energy / power unit of the returned value
+   * @return total exergy destruction in the requested unit
+   */
+  public double getExergyDestruction(String unit) {
+    double totalJ = 0.0;
+    for (ProcessSystem ps : processes.values()) {
+      totalJ += ps.getExergyDestruction("J");
+    }
+    return convertEnergy(totalJ, unit);
+  }
+
+  /**
+   * Build a structured {@link neqsim.process.util.exergy.ExergyAnalysisReport} covering every unit
+   * operation in every process area, with each entry tagged by its area name. The surrounding
+   * temperature of the report is taken from the first registered area (or 288.15 K if the model is
+   * empty).
+   *
+   * @return a new report suitable for ranking destruction hot-spots across a plant-wide flowsheet
+   */
+  public neqsim.process.util.exergy.ExergyAnalysisReport getExergyAnalysis() {
+    double t0 = 288.15;
+    if (!processes.isEmpty()) {
+      t0 = processes.values().iterator().next().getSurroundingTemperature();
+    }
+    neqsim.process.util.exergy.ExergyAnalysisReport report =
+        new neqsim.process.util.exergy.ExergyAnalysisReport(t0);
+    for (Map.Entry<String, ProcessSystem> e : processes.entrySet()) {
+      e.getValue().populateExergyAnalysis(report, e.getValue().getSurroundingTemperature(),
+          e.getKey());
+    }
+    return report;
+  }
+
+  /**
+   * Convert Joules to the requested energy / power unit.
+   *
+   * @param valueJ value in Joules (treated identically to watts for rate quantities)
+   * @param unit target unit (J, kJ, MJ, W, kW, MW)
+   * @return converted value
+   */
+  private static double convertEnergy(double valueJ, String unit) {
+    if (unit == null) {
+      return valueJ;
+    }
+    if ("J".equals(unit) || "W".equals(unit)) {
+      return valueJ;
+    }
+    if ("kJ".equals(unit) || "kW".equals(unit)) {
+      return valueJ / 1.0e3;
+    }
+    if ("MJ".equals(unit) || "MW".equals(unit)) {
+      return valueJ / 1.0e6;
+    }
+    return valueJ;
+  }
+
+  /**
    * {@inheritDoc}
    *
    * <p>
-   * - If runStep == true, each process is run in "step" mode exactly once. -
-   * Otherwise (continuous
-   * mode), it loops up to maxIterations or until all processes are finished
-   * (isFinished() == true).
-   * If forceIteration is true, the loop runs all maxIterations regardless of
-   * convergence.
+   * - If runStep == true, each process is run in "step" mode exactly once. - Otherwise (continuous
+   * mode), it loops up to maxIterations or until all processes are finished (isFinished() == true).
+   * If forceIteration is true, the loop runs all maxIterations regardless of convergence.
    * </p>
    *
    * <p>
-   * When {@link #isUseOptimizedExecution()} is true (default), each ProcessSystem
-   * uses
+   * When {@link #isUseOptimizedExecution()} is true (default), each ProcessSystem uses
    * {@link ProcessSystem#runOptimized()} for best performance.
    * </p>
    */
@@ -693,8 +741,9 @@ public class ProcessModel implements Runnable, Serializable {
 
         // Check if model has converged
         boolean allProcessesSolved = isFinished();
-        boolean valuesConverged = lastMaxFlowError < flowTolerance && lastMaxTemperatureError < temperatureTolerance
-            && lastMaxPressureError < pressureTolerance;
+        boolean valuesConverged =
+            lastMaxFlowError < flowTolerance && lastMaxTemperatureError < temperatureTolerance
+                && lastMaxPressureError < pressureTolerance;
 
         if (logger.isDebugEnabled()) {
           logger.debug("Iteration " + iterations + ": flowErr=" + lastMaxFlowError + ", tempErr="
@@ -742,10 +791,8 @@ public class ProcessModel implements Runnable, Serializable {
    * Runs all ProcessSystems, using parallel execution for independent systems.
    *
    * <p>
-   * If there are multiple independent ProcessSystems (no shared streams between
-   * them), they are
-   * executed concurrently using the NeqSim thread pool. Systems that depend on
-   * each other are
+   * If there are multiple independent ProcessSystems (no shared streams between them), they are
+   * executed concurrently using the NeqSim thread pool. Systems that depend on each other are
    * executed sequentially in insertion order.
    * </p>
    */
@@ -802,10 +849,8 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Runs all ProcessSystems with listener hooks, firing before/after area
-   * callbacks sequentially.
-   * For dependent processes (shared streams), runs sequentially with hooks. For
-   * independent
+   * Runs all ProcessSystems with listener hooks, firing before/after area callbacks sequentially.
+   * For dependent processes (shared streams), runs sequentially with hooks. For independent
    * processes without a listener, delegates to the parallel strategy.
    *
    * @param iterationNumber current outer iteration number (starts at 1)
@@ -880,13 +925,11 @@ public class ProcessModel implements Runnable, Serializable {
    * Finds groups of independent ProcessSystems that can run in parallel.
    *
    * <p>
-   * Two ProcessSystems are dependent if any outlet stream of one is used as an
-   * inlet stream of
+   * Two ProcessSystems are dependent if any outlet stream of one is used as an inlet stream of
    * another. Independent systems have no shared stream references.
    * </p>
    *
-   * @return list of groups, where systems within each group are independent of
-   *         each other
+   * @return list of groups, where systems within each group are independent of each other
    */
   private List<List<ProcessSystem>> findIndependentProcessGroups() {
     List<ProcessSystem> allProcesses = new ArrayList<>(processes.values());
@@ -900,7 +943,8 @@ public class ProcessModel implements Runnable, Serializable {
     // Collect all stream objects for each process
     List<java.util.Set<Object>> processStreams = new ArrayList<>();
     for (ProcessSystem process : allProcesses) {
-      java.util.Set<Object> streams = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+      java.util.Set<Object> streams =
+          java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
       for (Object unit : process.getUnitOperations()) {
         if (unit instanceof StreamInterface) {
           streams.add(unit);
@@ -938,21 +982,18 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Partitions ProcessSystems into execution levels based on inter-area stream
-   * dependencies. Areas at the same level share no producer/consumer link and
-   * can run in parallel; areas at level N+1 start only after all areas at
-   * level N complete.
+   * Partitions ProcessSystems into execution levels based on inter-area stream dependencies. Areas
+   * at the same level share no producer/consumer link and can run in parallel; areas at level N+1
+   * start only after all areas at level N complete.
    *
    * <p>
-   * Direction is inferred from stream ownership: if a stream is an outlet of
-   * some equipment in area A and also present (directly or as a consumed
-   * inlet) in area B, then A is the producer and B is the consumer, so
-   * A → B in the meta-graph. Ambiguous links (stream is produced in both
-   * areas) fall back to insertion order to preserve legacy behaviour.
+   * Direction is inferred from stream ownership: if a stream is an outlet of some equipment in area
+   * A and also present (directly or as a consumed inlet) in area B, then A is the producer and B is
+   * the consumer, so A → B in the meta-graph. Ambiguous links (stream is produced in both areas)
+   * fall back to insertion order to preserve legacy behaviour.
    * </p>
    *
-   * @return ordered list of execution levels; each level contains areas that
-   *         can run in parallel
+   * @return ordered list of execution levels; each level contains areas that can run in parallel
    */
   private List<List<ProcessSystem>> buildAreaExecutionLevels() {
     List<ProcessSystem> allProcesses = new ArrayList<>(processes.values());
@@ -972,16 +1013,18 @@ public class ProcessModel implements Runnable, Serializable {
     List<java.util.Set<Object>> outputs = new ArrayList<>(n);
     List<java.util.Set<Object>> members = new ArrayList<>(n);
     for (ProcessSystem p : allProcesses) {
-      java.util.Set<Object> outs = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
-      java.util.Set<Object> mem = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+      java.util.Set<Object> outs =
+          java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+      java.util.Set<Object> mem =
+          java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
       for (Object unit : p.getUnitOperations()) {
         if (unit instanceof StreamInterface) {
           mem.add(unit);
         }
         if (unit instanceof neqsim.process.equipment.ProcessEquipmentInterface) {
           try {
-            java.util.List<StreamInterface> outletStreams = ((neqsim.process.equipment.ProcessEquipmentInterface) unit)
-                .getOutletStreams();
+            java.util.List<StreamInterface> outletStreams =
+                ((neqsim.process.equipment.ProcessEquipmentInterface) unit).getOutletStreams();
             if (outletStreams != null) {
               outs.addAll(outletStreams);
             }
@@ -989,8 +1032,8 @@ public class ProcessModel implements Runnable, Serializable {
             // Not all equipment implements getOutletStreams cleanly; ignore.
           }
           try {
-            java.util.List<StreamInterface> inletStreams = ((neqsim.process.equipment.ProcessEquipmentInterface) unit)
-                .getInletStreams();
+            java.util.List<StreamInterface> inletStreams =
+                ((neqsim.process.equipment.ProcessEquipmentInterface) unit).getInletStreams();
             if (inletStreams != null) {
               mem.addAll(inletStreams);
             }
@@ -1109,19 +1152,17 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Capture current state of streams in all processes, optionally restricted to
-   * the supplied boundary set.
+   * Capture current state of streams in all processes, optionally restricted to the supplied
+   * boundary set.
    *
    * <p>
-   * For multi-area {@link ProcessModel}s, inter-area convergence is driven
-   * only by streams that cross area boundaries. Passing the boundary set
-   * avoids scanning every stream in every iteration (O(N×M) → O(boundary)).
-   * When {@code boundaryStreams} is {@code null} or empty, all streams are
+   * For multi-area {@link ProcessModel}s, inter-area convergence is driven only by streams that
+   * cross area boundaries. Passing the boundary set avoids scanning every stream in every iteration
+   * (O(N×M) → O(boundary)). When {@code boundaryStreams} is {@code null} or empty, all streams are
    * captured (backward-compatible behaviour).
    * </p>
    *
-   * @param boundaryStreams identity-set of streams to capture, or {@code null}
-   *                        for all streams
+   * @param boundaryStreams identity-set of streams to capture, or {@code null} for all streams
    * @return map of stream name to [flowRate, temperature, pressure]
    */
   private Map<String, double[]> captureStreamStates(java.util.Set<Object> boundaryStreams) {
@@ -1143,7 +1184,7 @@ public class ProcessModel implements Runnable, Serializable {
           double flow = stream.getFlowRate("kg/hr");
           double temp = stream.getTemperature("K");
           double press = stream.getPressure("bara");
-          states.put(key, new double[] { flow, temp, press });
+          states.put(key, new double[] {flow, temp, press});
         } catch (Exception e) {
           // Skip streams that can't be read
         }
@@ -1153,21 +1194,23 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Collect the identity-set of streams that cross area boundaries in the
-   * current {@link ProcessModel}. A stream is a boundary stream if it appears
-   * in at least two {@link ProcessSystem}s.
+   * Collect the identity-set of streams that cross area boundaries in the current
+   * {@link ProcessModel}. A stream is a boundary stream if it appears in at least two
+   * {@link ProcessSystem}s.
    *
    * @return identity-based set of boundary streams (may be empty)
    */
   private java.util.Set<Object> collectBoundaryStreams() {
-    java.util.Set<Object> boundary = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+    java.util.Set<Object> boundary =
+        java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
     if (processes.size() < 2) {
       return boundary;
     }
     // For each stream object count how many processes contain it as a unit.
     java.util.Map<Object, Integer> counts = new java.util.IdentityHashMap<>();
     for (ProcessSystem process : processes.values()) {
-      java.util.Set<Object> seen = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+      java.util.Set<Object> seen =
+          java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
       for (Object unit : process.getUnitOperations()) {
         if (unit instanceof StreamInterface && seen.add(unit)) {
           counts.merge(unit, 1, Integer::sum);
@@ -1186,7 +1229,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Calculate maximum relative errors between previous and current stream states.
    *
    * @param previous previous stream states
-   * @param current  current stream states
+   * @param current current stream states
    * @return array of [maxFlowError, maxTempError, maxPressError]
    */
   private double[] calculateConvergenceErrors(Map<String, double[]> previous,
@@ -1217,7 +1260,7 @@ public class ProcessModel implements Runnable, Serializable {
       }
     }
 
-    return new double[] { maxFlowErr, maxTempErr, maxPressErr };
+    return new double[] {maxFlowErr, maxTempErr, maxPressErr};
   }
 
   /**
@@ -1252,8 +1295,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Gets a combined execution partition analysis for all ProcessSystems.
    *
    * <p>
-   * This method provides insight into how each ProcessSystem will be executed,
-   * including:
+   * This method provides insight into how each ProcessSystem will be executed, including:
    * </p>
    * <ul>
    * <li>Whether each system has recycle loops</li>
@@ -1291,15 +1333,12 @@ public class ProcessModel implements Runnable, Serializable {
    * Runs this model in a separate thread using the global NeqSim thread pool.
    *
    * <p>
-   * This method submits the model to the shared
-   * {@link neqsim.util.NeqSimThreadPool} and returns a
-   * {@link java.util.concurrent.Future} that can be used to monitor completion,
-   * cancel the task, or
+   * This method submits the model to the shared {@link neqsim.util.NeqSimThreadPool} and returns a
+   * {@link java.util.concurrent.Future} that can be used to monitor completion, cancel the task, or
    * retrieve any exceptions that occurred.
    * </p>
    *
-   * @return a {@link java.util.concurrent.Future} representing the pending
-   *         completion of the task
+   * @return a {@link java.util.concurrent.Future} representing the pending completion of the task
    * @see neqsim.util.NeqSimThreadPool
    */
   public java.util.concurrent.Future<?> runAsTask() {
@@ -1310,8 +1349,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Starts this model in a new thread and returns that thread.
    *
    * @return a {@link java.lang.Thread} object
-   * @deprecated Use {@link #runAsTask()} instead for better resource management.
-   *             This method
+   * @deprecated Use {@link #runAsTask()} instead for better resource management. This method
    *             creates a new unmanaged thread directly.
    */
   @Deprecated
@@ -1375,8 +1413,7 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Retrieves a list of all processes.
    *
-   * @return a {@link java.util.Collection} of
-   *         {@link neqsim.process.processmodel.ProcessSystem}
+   * @return a {@link java.util.Collection} of {@link neqsim.process.processmodel.ProcessSystem}
    *         objects
    */
   public Collection<ProcessSystem> getAllProcesses() {
@@ -1387,15 +1424,16 @@ public class ProcessModel implements Runnable, Serializable {
    * Check mass balance of all unit operations in all processes.
    *
    * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
-   * @return a map with process name and unit operation name as key and mass
-   *         balance result as value
+   * @return a map with process name and unit operation name as key and mass balance result as value
    */
   public Map<String, Map<String, ProcessSystem.MassBalanceResult>> checkMassBalance(String unit) {
-    Map<String, Map<String, ProcessSystem.MassBalanceResult>> allMassBalanceResults = new LinkedHashMap<>();
+    Map<String, Map<String, ProcessSystem.MassBalanceResult>> allMassBalanceResults =
+        new LinkedHashMap<>();
     for (Map.Entry<String, ProcessSystem> entry : processes.entrySet()) {
       String processName = entry.getKey();
       ProcessSystem process = entry.getValue();
-      Map<String, ProcessSystem.MassBalanceResult> massBalanceResults = process.checkMassBalance(unit);
+      Map<String, ProcessSystem.MassBalanceResult> massBalanceResults =
+          process.checkMassBalance(unit);
       allMassBalanceResults.put(processName, massBalanceResults);
     }
     return allMassBalanceResults;
@@ -1404,8 +1442,7 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Check mass balance of all unit operations in all processes using kg/sec.
    *
-   * @return a map with process name and unit operation name as key and mass
-   *         balance result as value
+   * @return a map with process name and unit operation name as key and mass balance result as value
    *         in kg/sec
    */
   public Map<String, Map<String, ProcessSystem.MassBalanceResult>> checkMassBalance() {
@@ -1413,24 +1450,23 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Get unit operations that failed mass balance check in all processes based on
-   * percentage error
+   * Get unit operations that failed mass balance check in all processes based on percentage error
    * threshold.
    *
-   * @param unit             unit for mass flow rate (e.g., "kg/sec", "kg/hr",
-   *                         "mole/sec")
+   * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
    * @param percentThreshold percentage error threshold (default: 0.1%)
-   * @return a map with process name and a map of failed unit operation names and
-   *         their mass balance
+   * @return a map with process name and a map of failed unit operation names and their mass balance
    *         results
    */
   public Map<String, Map<String, ProcessSystem.MassBalanceResult>> getFailedMassBalance(String unit,
       double percentThreshold) {
-    Map<String, Map<String, ProcessSystem.MassBalanceResult>> allFailedResults = new LinkedHashMap<>();
+    Map<String, Map<String, ProcessSystem.MassBalanceResult>> allFailedResults =
+        new LinkedHashMap<>();
     for (Map.Entry<String, ProcessSystem> entry : processes.entrySet()) {
       String processName = entry.getKey();
       ProcessSystem process = entry.getValue();
-      Map<String, ProcessSystem.MassBalanceResult> failedResults = process.getFailedMassBalance(unit, percentThreshold);
+      Map<String, ProcessSystem.MassBalanceResult> failedResults =
+          process.getFailedMassBalance(unit, percentThreshold);
       if (!failedResults.isEmpty()) {
         allFailedResults.put(processName, failedResults);
       }
@@ -1439,16 +1475,15 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Get unit operations that failed mass balance check in all processes using
-   * kg/sec and default
+   * Get unit operations that failed mass balance check in all processes using kg/sec and default
    * threshold.
    *
-   * @return a map with process name and a map of failed unit operation names and
-   *         their mass balance
+   * @return a map with process name and a map of failed unit operation names and their mass balance
    *         results
    */
   public Map<String, Map<String, ProcessSystem.MassBalanceResult>> getFailedMassBalance() {
-    Map<String, Map<String, ProcessSystem.MassBalanceResult>> allFailedResults = new LinkedHashMap<>();
+    Map<String, Map<String, ProcessSystem.MassBalanceResult>> allFailedResults =
+        new LinkedHashMap<>();
     for (ProcessSystem process : processes.values()) {
       Map<String, ProcessSystem.MassBalanceResult> failedResults = process.getFailedMassBalance();
       if (!failedResults.isEmpty()) {
@@ -1459,12 +1494,10 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Get unit operations that failed mass balance check in all processes using
-   * specified threshold.
+   * Get unit operations that failed mass balance check in all processes using specified threshold.
    *
    * @param percentThreshold percentage error threshold
-   * @return a map with process name and a map of failed unit operation names and
-   *         their mass balance
+   * @return a map with process name and a map of failed unit operation names and their mass balance
    *         results in kg/sec
    */
   public Map<String, Map<String, ProcessSystem.MassBalanceResult>> getFailedMassBalance(
@@ -1514,16 +1547,14 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Get a formatted report of failed mass balance checks for all processes.
    *
-   * @param unit             unit for mass flow rate (e.g., "kg/sec", "kg/hr",
-   *                         "mole/sec")
+   * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
    * @param percentThreshold percentage error threshold
-   * @return a formatted string report with process name and failed unit
-   *         operations
+   * @return a formatted string report with process name and failed unit operations
    */
   public String getFailedMassBalanceReport(String unit, double percentThreshold) {
     StringBuilder report = new StringBuilder();
-    Map<String, Map<String, ProcessSystem.MassBalanceResult>> failedResults = getFailedMassBalance(unit,
-        percentThreshold);
+    Map<String, Map<String, ProcessSystem.MassBalanceResult>> failedResults =
+        getFailedMassBalance(unit, percentThreshold);
 
     if (failedResults.isEmpty()) {
       report.append("All unit operations passed mass balance check.\n");
@@ -1546,25 +1577,21 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Get a formatted report of failed mass balance checks for all processes using
-   * kg/sec and default
+   * Get a formatted report of failed mass balance checks for all processes using kg/sec and default
    * threshold.
    *
-   * @return a formatted string report with process name and failed unit
-   *         operations
+   * @return a formatted string report with process name and failed unit operations
    */
   public String getFailedMassBalanceReport() {
     return getFailedMassBalanceReport("kg/sec", 0.1);
   }
 
   /**
-   * Get a formatted report of failed mass balance checks for all processes using
-   * specified
+   * Get a formatted report of failed mass balance checks for all processes using specified
    * threshold.
    *
    * @param percentThreshold percentage error threshold
-   * @return a formatted string report with process name and failed unit
-   *         operations
+   * @return a formatted string report with process name and failed unit operations
    */
   public String getFailedMassBalanceReport(double percentThreshold) {
     return getFailedMassBalanceReport("kg/sec", percentThreshold);
@@ -1582,16 +1609,12 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Exports this ProcessModel to a JSON string containing all named process
-   * areas.
+   * Exports this ProcessModel to a JSON string containing all named process areas.
    *
    * <p>
-   * The exported JSON has a top-level "areas" object where each key is the
-   * process area name and
-   * each value is a JSON object in the {@link JsonProcessBuilder} schema (with
-   * "fluid" and
-   * "process" sections). This format can be used to reconstruct the model or to
-   * export individual
+   * The exported JSON has a top-level "areas" object where each key is the process area name and
+   * each value is a JSON object in the {@link JsonProcessBuilder} schema (with "fluid" and
+   * "process" sections). This format can be used to reconstruct the model or to export individual
    * areas to external simulators (e.g., UniSim Design via COM automation).
    * </p>
    *
@@ -1601,8 +1624,7 @@ public class ProcessModel implements Runnable, Serializable {
    * <pre>{@code { "areas": { "separation": { "fluid": {...}, "process": [...] }, "compression": {
    * "fluid": {...}, "process": [...] } } } }</pre>
    *
-   * @return JSON string representing all process areas @see
-   *         JsonProcessExporter @see
+   * @return JSON string representing all process areas @see JsonProcessExporter @see
    *         ProcessSystem#toJson()
    */
   public String toJson() {
@@ -1646,22 +1668,21 @@ public class ProcessModel implements Runnable, Serializable {
    * "fluid": {...}, "process": [...] } } } }</pre>
    *
    * <p>
-   * Each area is built independently using {@link JsonProcessBuilder}. If any
-   * area fails to build,
+   * Each area is built independently using {@link JsonProcessBuilder}. If any area fails to build,
    * it is skipped and a warning is logged.
    * </p>
    *
    * @param json the JSON string with the "areas" structure
    * @return the built ProcessModel (not yet run)
-   * @throws IllegalArgumentException if JSON is null, empty, or missing the
-   *                                  "areas" key
+   * @throws IllegalArgumentException if JSON is null, empty, or missing the "areas" key
    * @see #toJson()
    */
   public static ProcessModel fromJson(String json) {
     if (json == null || json.trim().isEmpty()) {
       throw new IllegalArgumentException("JSON input is null or empty");
     }
-    com.google.gson.JsonObject root = com.google.gson.JsonParser.parseString(json).getAsJsonObject();
+    com.google.gson.JsonObject root =
+        com.google.gson.JsonParser.parseString(json).getAsJsonObject();
     if (!root.has("areas")) {
       throw new IllegalArgumentException(
           "JSON must have an 'areas' object with named process systems");
@@ -1687,15 +1708,13 @@ public class ProcessModel implements Runnable, Serializable {
    * Builds and immediately runs a ProcessModel from a JSON string.
    *
    * <p>
-   * Convenience method that combines {@link #fromJson(String)} and {@link #run()}
-   * in a single call.
+   * Convenience method that combines {@link #fromJson(String)} and {@link #run()} in a single call.
    * This is the round-trip counterpart to {@link #toJson()}.
    * </p>
    *
    * @param json the JSON string with the "areas" structure
    * @return the built and executed ProcessModel
-   * @throws IllegalArgumentException if JSON is null, empty, or missing the
-   *                                  "areas" key
+   * @throws IllegalArgumentException if JSON is null, empty, or missing the "areas" key
    */
   public static ProcessModel fromJsonAndRun(String json) {
     ProcessModel model = fromJson(json);
@@ -1707,15 +1726,12 @@ public class ProcessModel implements Runnable, Serializable {
    * Validates the setup of all processes in this model.
    *
    * <p>
-   * This method iterates through all ProcessSystems and validates each one. The
-   * results are
-   * aggregated into a single ValidationResult. Use this method before running the
-   * model to identify
+   * This method iterates through all ProcessSystems and validates each one. The results are
+   * aggregated into a single ValidationResult. Use this method before running the model to identify
    * configuration issues.
    * </p>
    *
-   * @return a {@link neqsim.util.validation.ValidationResult} containing all
-   *         validation issues
+   * @return a {@link neqsim.util.validation.ValidationResult} containing all validation issues
    *         across all processes
    */
   public ValidationResult validateSetup() {
@@ -1752,13 +1768,11 @@ public class ProcessModel implements Runnable, Serializable {
    * Validates all processes and returns results organized by process name.
    *
    * <p>
-   * This method provides detailed validation results for each ProcessSystem
-   * separately, making it
+   * This method provides detailed validation results for each ProcessSystem separately, making it
    * easier to identify which process has issues.
    * </p>
    *
-   * @return a {@link java.util.Map} mapping process names to their validation
-   *         results
+   * @return a {@link java.util.Map} mapping process names to their validation results
    */
   public Map<String, ValidationResult> validateAll() {
     Map<String, ValidationResult> results = new LinkedHashMap<>();
@@ -1785,8 +1799,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Checks if all processes in the model are ready to run.
    *
    * <p>
-   * This is a convenience method that returns true if no CRITICAL validation
-   * errors exist across
+   * This is a convenience method that returns true if no CRITICAL validation errors exist across
    * all processes. Use this for a quick go/no-go check before running the model.
    * </p>
    *
@@ -1807,8 +1820,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Get a formatted validation report for all processes.
    *
    * <p>
-   * This method provides a human-readable summary of all validation issues across
-   * all processes in
+   * This method provides a human-readable summary of all validation issues across all processes in
    * the model.
    * </p>
    *
@@ -1862,12 +1874,10 @@ public class ProcessModel implements Runnable, Serializable {
   // ============ NEQSIM FILE SERIALIZATION ============
 
   /**
-   * Saves this ProcessModel (with all ProcessSystems) to a compressed .neqsim
-   * file.
+   * Saves this ProcessModel (with all ProcessSystems) to a compressed .neqsim file.
    *
    * <p>
-   * This is the recommended format for production use, providing compact storage
-   * with full model
+   * This is the recommended format for production use, providing compact storage with full model
    * state preservation including all ProcessSystems. The file can be loaded with
    * {@link #loadFromNeqsim(String)}.
    * </p>
@@ -1900,8 +1910,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Loads a ProcessModel from a compressed .neqsim file.
    *
    * <p>
-   * After loading, the model is automatically run to reinitialize calculations.
-   * This ensures the
+   * After loading, the model is automatically run to reinitialize calculations. This ensures the
    * internal state is consistent for all ProcessSystems.
    * </p>
    *
@@ -1937,15 +1946,13 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Saves this ProcessModel with automatic format detection based on file
-   * extension.
+   * Saves this ProcessModel with automatic format detection based on file extension.
    *
    * <p>
    * File format is determined by extension:
    * <ul>
    * <li>.neqsim → XStream compressed XML (full serialization)</li>
-   * <li>.json → JSON state (lightweight, Git-friendly, requires
-   * ProcessModelState)</li>
+   * <li>.json → JSON state (lightweight, Git-friendly, requires ProcessModelState)</li>
    * <li>other → Java binary serialization (legacy)</li>
    * </ul>
    *
@@ -1959,7 +1966,8 @@ public class ProcessModel implements Runnable, Serializable {
       return saveStateToFile(filename);
     } else {
       // Legacy binary serialization
-      try (java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(new java.io.FileOutputStream(filename))) {
+      try (java.io.ObjectOutputStream oos =
+          new java.io.ObjectOutputStream(new java.io.FileOutputStream(filename))) {
         oos.writeObject(this);
         logger.info("ProcessModel saved (binary) to: " + filename);
         return true;
@@ -1977,8 +1985,7 @@ public class ProcessModel implements Runnable, Serializable {
    * File format is determined by extension:
    * <ul>
    * <li>.neqsim → XStream compressed XML (full serialization)</li>
-   * <li>.json → JSON state (requires matching ProcessSystems already
-   * configured)</li>
+   * <li>.json → JSON state (requires matching ProcessSystems already configured)</li>
    * <li>other → Java binary serialization (legacy)</li>
    * </ul>
    *
@@ -1992,7 +1999,8 @@ public class ProcessModel implements Runnable, Serializable {
       return loadStateFromFile(filename);
     } else {
       // Legacy binary serialization
-      try (java.io.ObjectInputStream ois = new java.io.ObjectInputStream(new java.io.FileInputStream(filename))) {
+      try (java.io.ObjectInputStream ois =
+          new java.io.ObjectInputStream(new java.io.FileInputStream(filename))) {
         ProcessModel model = (ProcessModel) ois.readObject();
         model.run();
         logger.info("ProcessModel loaded (binary) from: " + filename);
@@ -2010,8 +2018,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Exports the current state of this ProcessModel to a JSON file.
    *
    * <p>
-   * This exports state for all ProcessSystems in the model. The JSON format is
-   * Git-friendly and
+   * This exports state for all ProcessSystems in the model. The JSON format is Git-friendly and
    * human-readable, suitable for version control and diffing.
    * </p>
    *
@@ -2020,8 +2027,8 @@ public class ProcessModel implements Runnable, Serializable {
    */
   public boolean saveStateToFile(String filename) {
     try {
-      neqsim.process.processmodel.lifecycle.ProcessModelState state = neqsim.process.processmodel.lifecycle.ProcessModelState
-          .fromProcessModel(this);
+      neqsim.process.processmodel.lifecycle.ProcessModelState state =
+          neqsim.process.processmodel.lifecycle.ProcessModelState.fromProcessModel(this);
       state.saveToFile(filename);
       logger.info("ProcessModel state saved to: " + filename);
       return true;
@@ -2035,8 +2042,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Loads ProcessModel state from a JSON file.
    *
    * <p>
-   * Note: This returns a new ProcessModel with ProcessSystems initialized from
-   * the saved state.
+   * Note: This returns a new ProcessModel with ProcessSystems initialized from the saved state.
    * Full reconstruction requires the original equipment configuration.
    * </p>
    *
@@ -2045,8 +2051,8 @@ public class ProcessModel implements Runnable, Serializable {
    */
   public static ProcessModel loadStateFromFile(String filename) {
     try {
-      neqsim.process.processmodel.lifecycle.ProcessModelState state = neqsim.process.processmodel.lifecycle.ProcessModelState
-          .loadFromFile(filename);
+      neqsim.process.processmodel.lifecycle.ProcessModelState state =
+          neqsim.process.processmodel.lifecycle.ProcessModelState.loadFromFile(filename);
       ProcessModel model = state.toProcessModel();
       logger.info("ProcessModel state loaded from: " + filename);
       return model;
@@ -2057,8 +2063,7 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Exports the current state of this ProcessModel for inspection or
-   * modification.
+   * Exports the current state of this ProcessModel for inspection or modification.
    *
    * @return a ProcessModelState snapshot of the current model
    */
@@ -2073,16 +2078,13 @@ public class ProcessModel implements Runnable, Serializable {
    * {@link neqsim.process.design.AutoSizeable}.
    *
    * <p>
-   * This method iterates through all process systems in the model and calls
-   * autoSize() on each
-   * equipment that implements the AutoSizeable interface. The equipment is sized
-   * using the default
+   * This method iterates through all process systems in the model and calls autoSize() on each
+   * equipment that implements the AutoSizeable interface. The equipment is sized using the default
    * safety factor (1.2 = 20% margin).
    * </p>
    *
    * <p>
-   * <strong>Important:</strong> This method should be called AFTER running the
-   * process model so
+   * <strong>Important:</strong> This method should be called AFTER running the process model so
    * that flow rates and conditions are known for sizing calculations.
    * </p>
    *
@@ -2109,13 +2111,11 @@ public class ProcessModel implements Runnable, Serializable {
    * Auto-sizes all equipment in this model with the specified safety factor.
    *
    * <p>
-   * This method iterates through all process systems in the model and calls
-   * autoSize() on each
+   * This method iterates through all process systems in the model and calls autoSize() on each
    * equipment that implements the AutoSizeable interface.
    * </p>
    *
-   * @param safetyFactor multiplier for design capacity, typically 1.1-1.3 (10-30%
-   *                     over design)
+   * @param safetyFactor multiplier for design capacity, typically 1.1-1.3 (10-30% over design)
    * @return the number of equipment items that were auto-sized
    */
   public int autoSizeEquipment(double safetyFactor) {
@@ -2127,19 +2127,15 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Auto-sizes all equipment in this model using company-specific design
-   * standards.
+   * Auto-sizes all equipment in this model using company-specific design standards.
    *
    * <p>
-   * This method applies design rules from the specified company's technical
-   * requirements (TR)
+   * This method applies design rules from the specified company's technical requirements (TR)
    * documents. The standards are loaded from the NeqSim design database.
    * </p>
    *
-   * @param companyStandard company name (e.g., "Equinor", "Shell",
-   *                        "TotalEnergies")
-   * @param trDocument      TR document reference (e.g., "TR2000",
-   *                        "DEP-31.38.01.11")
+   * @param companyStandard company name (e.g., "Equinor", "Shell", "TotalEnergies")
+   * @param trDocument TR document reference (e.g., "TR2000", "DEP-31.38.01.11")
    * @return the number of equipment items that were auto-sized
    */
   public int autoSizeEquipment(String companyStandard, String trDocument) {
@@ -2151,12 +2147,10 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Enables or disables capacity analysis for all equipment in all process
-   * systems.
+   * Enables or disables capacity analysis for all equipment in all process systems.
    *
    * <p>
-   * This is a convenience method that applies the setting to all equipment in all
-   * processes. When
+   * This is a convenience method that applies the setting to all equipment in all processes. When
    * disabled, equipment is excluded from:
    * <ul>
    * <li>System bottleneck detection</li>
@@ -2165,8 +2159,7 @@ public class ProcessModel implements Runnable, Serializable {
    * <li>Optimization constraint checking</li>
    * </ul>
    *
-   * @param enabled true to enable capacity analysis for all equipment, false to
-   *                disable
+   * @param enabled true to enable capacity analysis for all equipment, false to disable
    * @return the number of equipment items that were updated
    */
   public int setCapacityAnalysisEnabled(boolean enabled) {
@@ -2198,7 +2191,7 @@ public class ProcessModel implements Runnable, Serializable {
    * Notify the listener that the model has completed.
    *
    * @param totalIterations total iterations performed
-   * @param converged       whether the model converged
+   * @param converged whether the model converged
    */
   private void notifyModelComplete(int totalIterations, boolean converged) {
     if (progressListener != null) {
@@ -2230,8 +2223,8 @@ public class ProcessModel implements Runnable, Serializable {
    * Notify the listener that an iteration has completed.
    *
    * @param iterationNumber the iteration that completed
-   * @param converged       whether convergence was achieved
-   * @param maxError        maximum relative error across all variables
+   * @param converged whether convergence was achieved
+   * @param maxError maximum relative error across all variables
    */
   private void notifyIterationComplete(int iterationNumber, boolean converged, double maxError) {
     if (progressListener != null) {
@@ -2247,10 +2240,10 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Notify the listener that a process area is about to run.
    *
-   * @param areaName        name of the area
-   * @param process         the ProcessSystem
-   * @param areaIndex       area index
-   * @param totalAreas      total number of areas
+   * @param areaName name of the area
+   * @param process the ProcessSystem
+   * @param areaIndex area index
+   * @param totalAreas total number of areas
    * @param iterationNumber current iteration
    */
   private void notifyBeforeProcessArea(String areaName, ProcessSystem process, int areaIndex,
@@ -2269,10 +2262,10 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Notify the listener that a process area has completed.
    *
-   * @param areaName        name of the area
-   * @param process         the ProcessSystem
-   * @param areaIndex       area index
-   * @param totalAreas      total number of areas
+   * @param areaName name of the area
+   * @param process the ProcessSystem
+   * @param areaIndex area index
+   * @param totalAreas total number of areas
    * @param iterationNumber current iteration
    */
   private void notifyProcessAreaComplete(String areaName, ProcessSystem process, int areaIndex,
@@ -2291,8 +2284,8 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Notify the listener that a process area encountered an error.
    *
-   * @param areaName  name of the failed area
-   * @param process   the ProcessSystem that failed
+   * @param areaName name of the failed area
+   * @param process the ProcessSystem that failed
    * @param exception the exception
    * @return true to continue execution, false to abort
    */
@@ -2310,12 +2303,11 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Publish a model-level event to the ProcessEventBus if event publishing is
-   * enabled.
+   * Publish a model-level event to the ProcessEventBus if event publishing is enabled.
    *
-   * @param type        the event type
+   * @param type the event type
    * @param description event description
-   * @param severity    event severity
+   * @param severity event severity
    */
   private void publishModelEvent(ProcessEvent.EventType type, String description,
       ProcessEvent.Severity severity) {
@@ -2331,8 +2323,7 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Run auto-validation on all ProcessSystems. Called once before the first
-   * iteration when
+   * Run auto-validation on all ProcessSystems. Called once before the first iteration when
    * autoValidate is enabled. Validation failures are logged as warnings.
    */
   private void runModelAutoValidation() {
@@ -2414,10 +2405,8 @@ public class ProcessModel implements Runnable, Serializable {
   // ========================== Automation API ==========================
 
   /**
-   * Returns an automation facade for this process model. The facade provides a
-   * stable,
-   * string-addressable API for scripts and AI agents to interact with all process
-   * areas using
+   * Returns an automation facade for this process model. The facade provides a stable,
+   * string-addressable API for scripts and AI agents to interact with all process areas using
    * area-qualified addresses like {@code "AreaName::UnitName.property"}.
    *
    * @return a {@link neqsim.process.automation.ProcessAutomation} facade
@@ -2427,8 +2416,7 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Returns the names of all unit operations across all process areas. Names are
-   * area-qualified in
+   * Returns the names of all unit operations across all process areas. Names are area-qualified in
    * the format {@code "AreaName::UnitName"}. Convenience delegate for
    * {@link neqsim.process.automation.ProcessAutomation#getUnitList()}.
    *
@@ -2449,8 +2437,7 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Returns the names of unit operations in a specific process area. Convenience
-   * delegate for
+   * Returns the names of unit operations in a specific process area. Convenience delegate for
    * {@link neqsim.process.automation.ProcessAutomation#getUnitList(String)}.
    *
    * @param areaName the name of the process area
@@ -2462,8 +2449,7 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Returns all available variables for the named unit operation. The
-   * {@code unitName} may be
+   * Returns all available variables for the named unit operation. The {@code unitName} may be
    * area-qualified: {@code "AreaName::UnitName"}. Convenience delegate for
    * {@link neqsim.process.automation.ProcessAutomation#getVariableList(String)}.
    *
@@ -2476,14 +2462,11 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Reads the current value of a simulation variable by its address. The address
-   * should be
-   * area-qualified: {@code "AreaName::unitName.property"}. Convenience delegate
-   * for
+   * Reads the current value of a simulation variable by its address. The address should be
+   * area-qualified: {@code "AreaName::unitName.property"}. Convenience delegate for
    * {@link neqsim.process.automation.ProcessAutomation#getVariableValue(String, String)}.
    *
-   * @param address       the area-qualified address, e.g. "Separation::HP
-   *                      Sep.gasOutStream.temperature"
+   * @param address the area-qualified address, e.g. "Separation::HP Sep.gasOutStream.temperature"
    * @param unitOfMeasure the desired unit, e.g. "C", "bara", "kg/hr"
    * @return the variable value in the requested unit
    * @throws IllegalArgumentException if the address cannot be resolved
@@ -2493,17 +2476,14 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
-   * Sets the value of a simulation input variable. The address should be
-   * area-qualified:
+   * Sets the value of a simulation input variable. The address should be area-qualified:
    * {@code "AreaName::Compressor.outletPressure"}. Convenience delegate for
    * {@link neqsim.process.automation.ProcessAutomation#setVariableValue(String, double, String)}.
    *
-   * @param address       the area-qualified address, e.g.
-   *                      "Compression::Compressor.outletPressure"
-   * @param value         the value to set
+   * @param address the area-qualified address, e.g. "Compression::Compressor.outletPressure"
+   * @param value the value to set
    * @param unitOfMeasure the unit of the provided value, e.g. "bara", "C"
-   * @throws IllegalArgumentException if the address cannot be resolved or the
-   *                                  variable is read-only
+   * @throws IllegalArgumentException if the address cannot be resolved or the variable is read-only
    */
   public void setVariableValue(String address, double value, String unitOfMeasure) {
     getAutomation().setVariableValue(address, value, unitOfMeasure);

--- a/src/main/java/neqsim/process/processmodel/ProcessModuleBaseClass.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModuleBaseClass.java
@@ -205,7 +205,7 @@ public abstract class ProcessModuleBaseClass extends SimulationBaseClass
   /** {@inheritDoc} */
   @Override
   public double getEntropyProduction(String unit) {
-    return 0.0;
+    return getOperations().getEntropyProduction(unit);
   }
 
   /** {@inheritDoc} */
@@ -217,7 +217,18 @@ public abstract class ProcessModuleBaseClass extends SimulationBaseClass
   /** {@inheritDoc} */
   @Override
   public double getExergyChange(String unit, double surroundingTemperature) {
-    return 0.0;
+    return getOperations().getExergyChange(unit, surroundingTemperature);
+  }
+
+  /**
+   * Exergy destruction rate aggregated over all unit operations contained in this module.
+   *
+   * @param unit energy / power unit of the returned value
+   * @param surroundingTemperature dead-state temperature in K
+   * @return total exergy destruction in the requested unit
+   */
+  public double getExergyDestruction(String unit, double surroundingTemperature) {
+    return getOperations().getExergyDestruction(unit, surroundingTemperature);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4025,39 +4025,157 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * <p>
-   * getEntropyProduction.
-   * </p>
+   * Sum of the entropy production across all unit operations in this process system. Individual
+   * entries are <em>not</em> logged to avoid flooding stdout on large flowsheets; iterate with
+   * {@link #getUnitOperations()} if per-unit detail is required.
    *
-   * @param unit a {@link java.lang.String} object
-   * @return a double
+   * @param unit target unit passed straight through to
+   *        {@link ProcessEquipmentInterface#getEntropyProduction(String)}
+   * @return total entropy production
    */
   public double getEntropyProduction(String unit) {
     double entropyProduction = 0.0;
     for (int i = 0; i < unitOperations.size(); i++) {
       entropyProduction += unitOperations.get(i).getEntropyProduction(unit);
-      System.out.println("unit " + unitOperations.get(i).getName() + " entropy production "
-          + unitOperations.get(i).getEntropyProduction(unit));
     }
     return entropyProduction;
   }
 
   /**
-   * <p>
-   * getExergyChange.
-   * </p>
+   * Net change in stream exergy (outlet minus inlet) aggregated over all unit operations, using
+   * this system's {@link #getSurroundingTemperature() surrounding temperature} as the dead state.
+   * The returned value is in the requested {@code unit} (supported values:
+   * {@code J, kJ, MJ, W, kW, MW}); unknown units fall back to J.
    *
-   * @param unit a {@link java.lang.String} object
-   * @return a double
+   * @param unit energy / power unit of the returned value
+   * @return total exergy change across all units in the requested unit
    */
   public double getExergyChange(String unit) {
-    double exergyChange = 0.0;
+    return getExergyChange(unit, getSurroundingTemperature());
+  }
+
+  /**
+   * Net change in stream exergy aggregated over all unit operations using an explicit surrounding
+   * temperature.
+   *
+   * @param unit energy / power unit of the returned value
+   * @param surroundingTemperature dead-state temperature in K
+   * @return total exergy change across all units
+   */
+  public double getExergyChange(String unit, double surroundingTemperature) {
+    double exergyChangeJ = 0.0;
     for (int i = 0; i < unitOperations.size(); i++) {
-      exergyChange += unitOperations.get(i).getExergyChange("J", getSurroundingTemperature());
-      System.out.println("unit " + unitOperations.get(i).getName() + " exergy change  "
-          + unitOperations.get(i).getExergyChange("J", getSurroundingTemperature()));
+      exergyChangeJ += unitOperations.get(i).getExergyChange("J", surroundingTemperature);
     }
-    return exergyChange;
+    return convertEnergy(exergyChangeJ, unit);
+  }
+
+  /**
+   * Total exergy destruction rate aggregated over all unit operations, using this system's
+   * {@link #getSurroundingTemperature() surrounding temperature}.
+   *
+   * @param unit energy / power unit of the returned value
+   * @return total exergy destruction in the requested unit
+   */
+  public double getExergyDestruction(String unit) {
+    return getExergyDestruction(unit, getSurroundingTemperature());
+  }
+
+  /**
+   * Total exergy destruction rate aggregated over all unit operations using an explicit surrounding
+   * temperature.
+   *
+   * @param unit energy / power unit of the returned value
+   * @param surroundingTemperature dead-state temperature in K
+   * @return total exergy destruction in the requested unit
+   */
+  public double getExergyDestruction(String unit, double surroundingTemperature) {
+    double destructionJ = 0.0;
+    for (int i = 0; i < unitOperations.size(); i++) {
+      destructionJ += unitOperations.get(i).getExergyDestruction("J", surroundingTemperature);
+    }
+    return convertEnergy(destructionJ, unit);
+  }
+
+  /**
+   * Build a structured {@link neqsim.process.util.exergy.ExergyAnalysisReport} with one entry per
+   * unit operation. Useful for identifying exergy-destruction hot spots on large flowsheets.
+   *
+   * @return a new report using this system's surrounding temperature
+   */
+  public neqsim.process.util.exergy.ExergyAnalysisReport getExergyAnalysis() {
+    return getExergyAnalysis(getSurroundingTemperature());
+  }
+
+  /**
+   * Build a structured {@link neqsim.process.util.exergy.ExergyAnalysisReport} with one entry per
+   * unit operation using an explicit dead-state temperature.
+   *
+   * @param surroundingTemperature dead-state temperature in K
+   * @return a new report
+   */
+  public neqsim.process.util.exergy.ExergyAnalysisReport getExergyAnalysis(
+      double surroundingTemperature) {
+    neqsim.process.util.exergy.ExergyAnalysisReport report =
+        new neqsim.process.util.exergy.ExergyAnalysisReport(surroundingTemperature);
+    populateExergyAnalysis(report, surroundingTemperature, null);
+    return report;
+  }
+
+  /**
+   * Populate an existing report with entries for this process system. Intended to be called by
+   * {@link neqsim.process.processmodel.ProcessModel#getExergyAnalysis()} so that multi-area
+   * aggregation keeps area labels on every row.
+   *
+   * @param report report instance to append to
+   * @param surroundingTemperature dead-state temperature in K
+   * @param areaName optional area name tag; may be {@code null}
+   */
+  public void populateExergyAnalysis(neqsim.process.util.exergy.ExergyAnalysisReport report,
+      double surroundingTemperature, String areaName) {
+    if (report == null) {
+      return;
+    }
+    for (int i = 0; i < unitOperations.size(); i++) {
+      ProcessEquipmentInterface op = unitOperations.get(i);
+      double dEJ = 0.0;
+      double dDestJ = 0.0;
+      try {
+        dEJ = op.getExergyChange("J", surroundingTemperature);
+      } catch (RuntimeException ex) {
+        logger.debug("getExergyChange failed for {}: {}", op.getName(), ex.getMessage());
+      }
+      try {
+        dDestJ = op.getExergyDestruction("J", surroundingTemperature);
+      } catch (RuntimeException ex) {
+        logger.debug("getExergyDestruction failed for {}: {}", op.getName(), ex.getMessage());
+      }
+      report.addEntry(new neqsim.process.util.exergy.ExergyAnalysisReport.Entry(op.getName(),
+          op.getClass().getSimpleName(), areaName, dEJ, dDestJ));
+    }
+  }
+
+  /**
+   * Convert a value in Joules to the requested unit.
+   *
+   * @param valueJ value in Joules (or watts, treated identically)
+   * @param unit target unit: J, kJ, MJ, W, kW, MW (unknown falls back to J)
+   * @return converted value
+   */
+  private static double convertEnergy(double valueJ, String unit) {
+    if (unit == null) {
+      return valueJ;
+    }
+    if ("J".equals(unit) || "W".equals(unit)) {
+      return valueJ;
+    }
+    if ("kJ".equals(unit) || "kW".equals(unit)) {
+      return valueJ / 1.0e3;
+    }
+    if ("MJ".equals(unit) || "MW".equals(unit)) {
+      return valueJ / 1.0e6;
+    }
+    return valueJ;
   }
 
   /**

--- a/src/main/java/neqsim/process/util/exergy/ExergyAnalysisReport.java
+++ b/src/main/java/neqsim/process/util/exergy/ExergyAnalysisReport.java
@@ -1,0 +1,390 @@
+package neqsim.process.util.exergy;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Structured result of an exergy analysis over a {@code ProcessSystem} or {@code ProcessModel}.
+ * Contains one row per unit operation with its exergy change across material streams and its exergy
+ * destruction rate, plus convenience aggregation / ranking / reporting helpers suitable for large
+ * flowsheets.
+ *
+ * <p>
+ * All energies are stored internally in Joules (J). For steady-state process simulations in NeqSim,
+ * stream enthalpy/entropy are per-second quantities so "J" is equivalent to "W" and may be reported
+ * as such via {@link #toString(String)}.
+ * </p>
+ *
+ * @author esol
+ * @version 1.0
+ */
+public class ExergyAnalysisReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /**
+   * One row of an exergy analysis: the exergy balance for a single unit operation or process area.
+   */
+  public static class Entry implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final String type;
+    private final String area;
+    private final double exergyChangeJ;
+    private final double exergyDestructionJ;
+
+    /**
+     * Create a new entry.
+     *
+     * @param name unit name
+     * @param type simple class name of the unit
+     * @param area process area name (may be {@code null} for flat ProcessSystem)
+     * @param exergyChangeJ net change in stream exergy across the unit (outlet − inlet) in Joules
+     * @param exergyDestructionJ exergy destruction rate in Joules (always non-negative)
+     */
+    public Entry(String name, String type, String area, double exergyChangeJ,
+        double exergyDestructionJ) {
+      this.name = name;
+      this.type = type;
+      this.area = area;
+      this.exergyChangeJ = exergyChangeJ;
+      this.exergyDestructionJ = Math.max(0.0, exergyDestructionJ);
+    }
+
+    /**
+     * @return unit operation name
+     */
+    public String getName() {
+      return name;
+    }
+
+    /**
+     * @return simple class name of the unit
+     */
+    public String getType() {
+      return type;
+    }
+
+    /**
+     * @return area name (may be {@code null})
+     */
+    public String getArea() {
+      return area;
+    }
+
+    /**
+     * @return exergy change across the unit in Joules
+     */
+    public double getExergyChangeJ() {
+      return exergyChangeJ;
+    }
+
+    /**
+     * @return exergy destruction in Joules
+     */
+    public double getExergyDestructionJ() {
+      return exergyDestructionJ;
+    }
+
+    /**
+     * @param unit unit of the returned value ("J", "kJ", "MJ", "W", "kW", "MW")
+     * @return exergy change in requested unit
+     */
+    public double getExergyChange(String unit) {
+      return convert(exergyChangeJ, unit);
+    }
+
+    /**
+     * @param unit unit of the returned value
+     * @return exergy destruction in requested unit
+     */
+    public double getExergyDestruction(String unit) {
+      return convert(exergyDestructionJ, unit);
+    }
+  }
+
+  private final double surroundingTemperatureK;
+  private final List<Entry> entries = new ArrayList<Entry>();
+
+  /**
+   * Create an empty report.
+   *
+   * @param surroundingTemperatureK surrounding ("dead-state") temperature in K used when computing
+   *        exergy
+   */
+  public ExergyAnalysisReport(double surroundingTemperatureK) {
+    this.surroundingTemperatureK = surroundingTemperatureK;
+  }
+
+  /**
+   * Append an entry to the report.
+   *
+   * @param entry row to add
+   */
+  public void addEntry(Entry entry) {
+    if (entry != null) {
+      entries.add(entry);
+    }
+  }
+
+  /**
+   * @return surrounding temperature used for exergy calculations (K)
+   */
+  public double getSurroundingTemperatureK() {
+    return surroundingTemperatureK;
+  }
+
+  /**
+   * @return an unmodifiable view of all entries in insertion order
+   */
+  public List<Entry> getEntries() {
+    return Collections.unmodifiableList(entries);
+  }
+
+  /**
+   * @return number of rows in the report
+   */
+  public int size() {
+    return entries.size();
+  }
+
+  /**
+   * Returns the top-N entries with the largest exergy destruction. Useful for hot-spot
+   * identification on large processes.
+   *
+   * @param n number of entries to return; values &lt;= 0 return the full list sorted
+   * @return a new list of entries sorted by descending destruction
+   */
+  public List<Entry> getTopDestructionHotspots(int n) {
+    List<Entry> sorted = new ArrayList<Entry>(entries);
+    Collections.sort(sorted, new Comparator<Entry>() {
+      @Override
+      public int compare(Entry a, Entry b) {
+        return Double.compare(b.exergyDestructionJ, a.exergyDestructionJ);
+      }
+    });
+    if (n <= 0 || n >= sorted.size()) {
+      return sorted;
+    }
+    return new ArrayList<Entry>(sorted.subList(0, n));
+  }
+
+  /**
+   * @param unit energy unit ("J", "kJ", "MJ", "W", "kW", "MW")
+   * @return total exergy destruction summed over all entries
+   */
+  public double getTotalExergyDestruction(String unit) {
+    double sum = 0.0;
+    for (Entry e : entries) {
+      sum += e.exergyDestructionJ;
+    }
+    return convert(sum, unit);
+  }
+
+  /**
+   * @param unit energy unit
+   * @return total exergy change summed over all entries
+   */
+  public double getTotalExergyChange(String unit) {
+    double sum = 0.0;
+    for (Entry e : entries) {
+      sum += e.exergyChangeJ;
+    }
+    return convert(sum, unit);
+  }
+
+  /**
+   * Groups the total exergy destruction by process area. Returns an empty map when no entries carry
+   * an area.
+   *
+   * @param unit energy unit
+   * @return map from area name to total destruction in the requested unit
+   */
+  public Map<String, Double> getDestructionByArea(String unit) {
+    Map<String, Double> out = new LinkedHashMap<String, Double>();
+    for (Entry e : entries) {
+      if (e.area == null) {
+        continue;
+      }
+      Double prev = out.get(e.area);
+      double cur = prev == null ? 0.0 : prev.doubleValue();
+      out.put(e.area, cur + convert(e.exergyDestructionJ, unit));
+    }
+    return out;
+  }
+
+  /**
+   * Groups the total exergy destruction by unit type (simple class name).
+   *
+   * @param unit energy unit
+   * @return map from class name to total destruction
+   */
+  public Map<String, Double> getDestructionByType(String unit) {
+    Map<String, Double> out = new LinkedHashMap<String, Double>();
+    for (Entry e : entries) {
+      String key = e.type == null ? "Unknown" : e.type;
+      Double prev = out.get(key);
+      double cur = prev == null ? 0.0 : prev.doubleValue();
+      out.put(key, cur + convert(e.exergyDestructionJ, unit));
+    }
+    return out;
+  }
+
+  /**
+   * Pretty-print the report as a plain-text table ranked by exergy destruction.
+   *
+   * @param unit energy unit to display
+   * @return a human-readable table
+   */
+  public String toString(String unit) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Exergy analysis (T0 = ").append(String.format("%.2f", surroundingTemperatureK))
+        .append(" K, unit = ").append(unit).append(")\n");
+    sb.append(String.format("%-30s %-20s %-15s %15s %15s%n", "Unit", "Type", "Area",
+        "dE (" + unit + ")", "Destr (" + unit + ")"));
+    sb.append(repeat('-', 100)).append('\n');
+    List<Entry> sorted = getTopDestructionHotspots(0);
+    for (Entry e : sorted) {
+      sb.append(String.format("%-30s %-20s %-15s %15.3f %15.3f%n", clip(e.name, 30),
+          clip(e.type == null ? "" : e.type, 20), clip(e.area == null ? "" : e.area, 15),
+          e.getExergyChange(unit), e.getExergyDestruction(unit)));
+    }
+    sb.append(repeat('-', 100)).append('\n');
+    sb.append(String.format("%-67s %15.3f %15.3f%n", "TOTAL", getTotalExergyChange(unit),
+        getTotalExergyDestruction(unit)));
+    return sb.toString();
+  }
+
+  @Override
+  public String toString() {
+    return toString("kW");
+  }
+
+  /**
+   * Serialize the report to JSON. Output contains surrounding temperature, totals and an array of
+   * per-unit rows.
+   *
+   * @return a JSON string
+   */
+  public String toJson() {
+    StringBuilder sb = new StringBuilder();
+    sb.append('{');
+    sb.append("\"surroundingTemperatureK\":").append(surroundingTemperatureK).append(',');
+    sb.append("\"totalExergyDestructionJ\":").append(getTotalExergyDestruction("J")).append(',');
+    sb.append("\"totalExergyChangeJ\":").append(getTotalExergyChange("J")).append(',');
+    sb.append("\"entries\":[");
+    for (int i = 0; i < entries.size(); i++) {
+      Entry e = entries.get(i);
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append('{').append("\"name\":\"").append(escape(e.name)).append('\"').append(',')
+          .append("\"type\":\"").append(escape(e.type == null ? "" : e.type)).append('\"')
+          .append(',').append("\"area\":")
+          .append(e.area == null ? "null" : ("\"" + escape(e.area) + "\"")).append(',')
+          .append("\"exergyChangeJ\":").append(e.exergyChangeJ).append(',')
+          .append("\"exergyDestructionJ\":").append(e.exergyDestructionJ).append('}');
+    }
+    sb.append("]}");
+    return sb.toString();
+  }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Convert Joules to the requested unit.
+   *
+   * @param valueJ value in Joules
+   * @param unit target unit ("J", "kJ", "MJ", "W", "kW", "MW")
+   * @return converted value
+   */
+  private static double convert(double valueJ, String unit) {
+    if (unit == null) {
+      return valueJ;
+    }
+    if (unit.equals("J") || unit.equals("W")) {
+      return valueJ;
+    }
+    if (unit.equals("kJ") || unit.equals("kW")) {
+      return valueJ / 1.0e3;
+    }
+    if (unit.equals("MJ") || unit.equals("MW")) {
+      return valueJ / 1.0e6;
+    }
+    return valueJ;
+  }
+
+  /**
+   * Java-8 compatible string repeat.
+   *
+   * @param c character to repeat
+   * @param n number of repetitions
+   * @return the resulting string
+   */
+  private static String repeat(char c, int n) {
+    char[] buf = new char[Math.max(0, n)];
+    for (int i = 0; i < buf.length; i++) {
+      buf[i] = c;
+    }
+    return new String(buf);
+  }
+
+  /**
+   * Truncate {@code s} to at most {@code max} characters.
+   *
+   * @param s input string (may be {@code null})
+   * @param max maximum length
+   * @return truncated string, never {@code null}
+   */
+  private static String clip(String s, int max) {
+    if (s == null) {
+      return "";
+    }
+    if (s.length() <= max) {
+      return s;
+    }
+    return s.substring(0, Math.max(0, max - 1)) + "…";
+  }
+
+  /**
+   * Escape a string for inclusion in a JSON literal.
+   *
+   * @param s input
+   * @return escaped string
+   */
+  private static String escape(String s) {
+    if (s == null) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder(s.length());
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      switch (c) {
+        case '"':
+          sb.append("\\\"");
+          break;
+        case '\\':
+          sb.append("\\\\");
+          break;
+        case '\n':
+          sb.append("\\n");
+          break;
+        case '\r':
+          sb.append("\\r");
+          break;
+        case '\t':
+          sb.append("\\t");
+          break;
+        default:
+          sb.append(c);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/src/test/java/neqsim/process/util/exergy/ExergyAnalysisTest.java
+++ b/src/test/java/neqsim/process/util/exergy/ExergyAnalysisTest.java
@@ -1,0 +1,116 @@
+package neqsim.process.util.exergy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Unit tests for the plant-wide exergy analysis API on {@link ProcessSystem} and
+ * {@link ProcessModel}.
+ */
+public class ExergyAnalysisTest {
+
+  /**
+   * Build a minimal compression + cooling + valve train for testing.
+   *
+   * @return a freshly run ProcessSystem
+   */
+  private ProcessSystem buildTrain() {
+    SystemInterface fluid = new SystemSrkEos(273.15 + 25.0, 60.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    feed.setTemperature(25.0, "C");
+    feed.setPressure(60.0, "bara");
+
+    Compressor comp = new Compressor("comp", feed);
+    comp.setOutletPressure(150.0);
+    comp.setIsentropicEfficiency(0.75);
+
+    Cooler cooler = new Cooler("cooler", comp.getOutletStream());
+    cooler.setOutTemperature(273.15 + 30.0);
+
+    ThrottlingValve valve = new ThrottlingValve("valve", cooler.getOutletStream());
+    valve.setOutletPressure(80.0);
+
+    ProcessSystem p = new ProcessSystem();
+    p.add(feed);
+    p.add(comp);
+    p.add(cooler);
+    p.add(valve);
+    p.run();
+    return p;
+  }
+
+  @Test
+  void testProcessSystemExergyChangeHonorsUnits() {
+    ProcessSystem p = buildTrain();
+    double j = p.getExergyChange("J");
+    double kj = p.getExergyChange("kJ");
+    double mj = p.getExergyChange("MJ");
+    assertEquals(j / 1.0e3, kj, Math.abs(j) * 1.0e-9 + 1.0e-9);
+    assertEquals(j / 1.0e6, mj, Math.abs(j) * 1.0e-9 + 1.0e-9);
+  }
+
+  @Test
+  void testProcessSystemExergyDestructionIsNonNegative() {
+    ProcessSystem p = buildTrain();
+    double destr = p.getExergyDestruction("kW");
+    assertTrue(destr >= 0.0, "exergy destruction must be non-negative, got " + destr);
+  }
+
+  @Test
+  void testExergyAnalysisReportHasEntryPerUnit() {
+    ProcessSystem p = buildTrain();
+    ExergyAnalysisReport report = p.getExergyAnalysis();
+    assertNotNull(report);
+    assertEquals(4, report.size(), "expected one entry per unit operation");
+
+    double total = report.getTotalExergyDestruction("kW");
+    assertTrue(total >= 0.0);
+    assertEquals(p.getExergyDestruction("kW"), total, Math.abs(total) * 1.0e-9 + 1.0e-9);
+
+    List<ExergyAnalysisReport.Entry> top = report.getTopDestructionHotspots(2);
+    assertEquals(2, top.size());
+    assertTrue(top.get(0).getExergyDestructionJ() >= top.get(1).getExergyDestructionJ());
+
+    String json = report.toJson();
+    assertTrue(json.contains("\"entries\""));
+    assertTrue(json.contains("\"comp\""));
+  }
+
+  @Test
+  void testProcessModelAggregatesAreas() {
+    ProcessSystem a = buildTrain();
+    ProcessSystem b = buildTrain();
+    ProcessModel plant = new ProcessModel();
+    plant.add("Area-A", a);
+    plant.add("Area-B", b);
+
+    double sumAreas = a.getExergyDestruction("kW") + b.getExergyDestruction("kW");
+    assertEquals(sumAreas, plant.getExergyDestruction("kW"),
+        Math.max(Math.abs(sumAreas), 1.0) * 1.0e-9);
+
+    ExergyAnalysisReport report = plant.getExergyAnalysis();
+    assertEquals(8, report.size(), "expected 4 units per area × 2 areas");
+
+    Map<String, Double> byArea = report.getDestructionByArea("kW");
+    assertEquals(2, byArea.size());
+    assertTrue(byArea.containsKey("Area-A"));
+    assertTrue(byArea.containsKey("Area-B"));
+  }
+}


### PR DESCRIPTION
Exergy analysis review and improvement complete.

**Code changes** (all Java 8, all tests pass — 4/4 new + 62/62 related regression tests green):
- **NEW** ExergyAnalysisReport.java — structured report with per-unit entries, top-N hotspot ranking, grouping by area/type, JSON export, unit conversion (J/kJ/MJ/W/kW/MW).
- **FIXED** ProcessSystem.java — `getExergyChange(unit)` previously ignored the unit parameter (silently returned J); removed `System.out.println` spam; added `getExergyDestruction`, `getExergyAnalysis`, and a `populateExergyAnalysis` hook reusable by `ProcessModel`.
- **UPDATED** ProcessEquipmentInterface.java — default `getExergyDestruction(unit)` and `getExergyDestruction(unit, T0)` using the universal $T_0 \cdot \dot{S}_{\text{gen}}$ formula (clamped ≥ 0).
- **UPDATED** ProcessModel.java — new `getExergyChange`, `getExergyDestruction`, `getExergyAnalysis` that aggregate all areas with area-tagged entries.
- **FIXED** ProcessModuleBaseClass.java — delegates exergy/entropy methods to inner operations (was returning 0).
- **NEW** ExergyAnalysisTest.java — 4 tests covering units, non-negativity, report contents, multi-area aggregation.

**Documentation:**
- **NEW** exergy-analysis.md — theory, quick start, plant-wide API, Python example, reference tables, results.json integration.
- Indexed in README.md and REFERENCE_MANUAL_INDEX.md. 