### PR TITLE
Fix Compressor detailed polytropic profile losing steps on PSflash di…

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -1134,17 +1134,57 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
               thermoOps.PSflash(entropy);
               if (Math.abs(getThermoSystem().getEntropy() - entropy) > 1e-3) {
                 // PSflash diverged (common with associating fluids such as water/MEG/TEG
-                // on cubic EOS, or near phase boundaries). Recover by holding the
-                // temperature from the previous step and TP-flashing at the new pressure.
-                // We do NOT 'continue' here — skipping the step would (1) leave the
-                // property profile shorter than numberOfCompressorCalcSteps, breaking
-                // index-based access, and (2) drop the polytropic enthalpy increment
-                // for that pressure interval. Falling through with the recovered state
-                // degenerates this single step to an approximately isothermal
-                // compression, which is a safe fallback that keeps the profile
-                // consistent and the energy bookkeeping monotonic.
-                getThermoSystem().setTemperature(oleTemp);
+                // on cubic EOS, or near phase boundaries — the PS Newton becomes
+                // ill-conditioned because dS/dT|_P is large and the Jacobian gets stiff).
+                // Recover by solving S(T, P_new) = entropy_target via 1D Newton on T at
+                // fixed pressure. TPflash is much more robust than PSflash for these
+                // fluids, so this yields correct isentropic compression for any EOS
+                // rather than degrading the step to isothermal.
+                // We do NOT 'continue' — skipping the step would leave the property
+                // profile shorter than numberOfCompressorCalcSteps and drop the
+                // polytropic enthalpy increment for that pressure interval.
+                double tGuess = oleTemp;
+                double bestT = oleTemp;
+                double bestErr = Double.MAX_VALUE;
+                getThermoSystem().setTemperature(tGuess);
                 thermoOps.TPflash();
+                for (int psIter = 0; psIter < 30; psIter++) {
+                  getThermoSystem().init(2);
+                  double sCur = getThermoSystem().getEntropy();
+                  double residual = sCur - entropy;
+                  if (Math.abs(residual) < Math.abs(bestErr)) {
+                    bestErr = residual;
+                    bestT = tGuess;
+                  }
+                  if (Math.abs(residual) < 1e-4) {
+                    break;
+                  }
+                  double cp = getThermoSystem().getCp();
+                  if (cp <= 0.0 || !Double.isFinite(cp)) {
+                    break;
+                  }
+                  // dS/dT|_P = Cp / T (total, J/K^2)
+                  double dT = -residual / (cp / tGuess);
+                  // Limit step to ±50 K for stability
+                  if (dT > 50.0) {
+                    dT = 50.0;
+                  } else if (dT < -50.0) {
+                    dT = -50.0;
+                  }
+                  tGuess += dT;
+                  if (tGuess < 50.0) {
+                    tGuess = 50.0;
+                  }
+                  getThermoSystem().setTemperature(tGuess);
+                  thermoOps.TPflash();
+                  if (Math.abs(dT) < 1e-3) {
+                    break;
+                  }
+                }
+                if (Math.abs(getThermoSystem().getEntropy() - entropy) > Math.abs(bestErr)) {
+                  getThermoSystem().setTemperature(bestT);
+                  thermoOps.TPflash();
+                }
                 getThermoSystem().init(2);
               }
             }

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -1133,10 +1133,19 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
               double oleTemp = getThermoSystem().getTemperature();
               thermoOps.PSflash(entropy);
               if (Math.abs(getThermoSystem().getEntropy() - entropy) > 1e-3) {
+                // PSflash diverged (common with associating fluids such as water/MEG/TEG
+                // on cubic EOS, or near phase boundaries). Recover by holding the
+                // temperature from the previous step and TP-flashing at the new pressure.
+                // We do NOT 'continue' here — skipping the step would (1) leave the
+                // property profile shorter than numberOfCompressorCalcSteps, breaking
+                // index-based access, and (2) drop the polytropic enthalpy increment
+                // for that pressure interval. Falling through with the recovered state
+                // degenerates this single step to an approximately isothermal
+                // compression, which is a safe fallback that keeps the profile
+                // consistent and the energy bookkeeping monotonic.
                 getThermoSystem().setTemperature(oleTemp);
                 thermoOps.TPflash();
                 getThermoSystem().init(2);
-                continue;
               }
             }
             double newEnt = getThermoSystem().getEnthalpy();

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/PSFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/PSFlash.java
@@ -118,6 +118,110 @@ public class PSFlash extends QfuncFlash {
   }
 
   /**
+   * Bisection fallback for solveQ. Used when Newton on T fails to drive the entropy residual below
+   * the convergence tolerance — typically because the EOS gives an ill-conditioned Cp (wrong cubic
+   * root, near-saturation, or a pure associating fluid on a non-associating EOS).
+   *
+   * <p>
+   * Brackets the target T by probing outward from the current temperature, then bisects until the
+   * residual is below tolerance or the bracket collapses. Always converges if a solution exists in
+   * the probed range, because S(T,P) is monotonically increasing in T for a stable single phase at
+   * fixed pressure (Cp &gt; 0). Slower than Newton but guaranteed bounded.
+   *
+   * @return final temperature after bisection
+   */
+  private double bisectSolveQ() {
+    final double tMinAbs = 50.0;
+    final double tMaxAbs = 5000.0;
+    double tStart = system.getTemperature();
+    if (!Double.isFinite(tStart) || tStart < tMinAbs) {
+      tStart = 300.0;
+    }
+
+    double tLo = Math.max(tMinAbs, tStart * 0.5);
+    double tHi = Math.min(tMaxAbs, tStart * 2.0);
+
+    double rLo = evalResidualAt(tLo);
+    double rHi = evalResidualAt(tHi);
+    if (Double.isNaN(rLo) || Double.isNaN(rHi)) {
+      // EOS solver outright failed at probe points; restore start and give up.
+      system.setTemperature(tStart);
+      tpFlash.run();
+      system.init(2);
+      return tStart;
+    }
+
+    // Expand outward until residuals have opposite sign (or limits reached).
+    int expand = 0;
+    while (rLo * rHi > 0 && expand < 8) {
+      if (Math.abs(rLo) < Math.abs(rHi)) {
+        tLo = Math.max(tMinAbs, tLo * 0.5);
+        rLo = evalResidualAt(tLo);
+      } else {
+        tHi = Math.min(tMaxAbs, tHi * 1.5);
+        rHi = evalResidualAt(tHi);
+      }
+      if (Double.isNaN(rLo) || Double.isNaN(rHi)) {
+        break;
+      }
+      expand++;
+    }
+
+    if (rLo * rHi > 0 || Double.isNaN(rLo) || Double.isNaN(rHi)) {
+      // Could not bracket — leave at the better of the two endpoints.
+      double tBest = Math.abs(rLo) < Math.abs(rHi) ? tLo : tHi;
+      system.setTemperature(tBest);
+      tpFlash.run();
+      system.init(2);
+      return tBest;
+    }
+
+    // Bisect.
+    for (int i = 0; i < 80; i++) {
+      double tMid = 0.5 * (tLo + tHi);
+      double rMid = evalResidualAt(tMid);
+      if (Double.isNaN(rMid)) {
+        // EOS hiccup at midpoint — pull bracket toward the better side.
+        tMid = 0.5 * (tLo + tMid);
+        rMid = evalResidualAt(tMid);
+        if (Double.isNaN(rMid)) {
+          break;
+        }
+      }
+      if (Math.abs(rMid) < 1e-6 || (tHi - tLo) < 1e-4) {
+        return tMid;
+      }
+      if (rMid * rLo < 0) {
+        tHi = tMid;
+        rHi = rMid;
+      } else {
+        tLo = tMid;
+        rLo = rMid;
+      }
+    }
+    return system.getTemperature();
+  }
+
+  /**
+   * Sets temperature, runs TP-flash, and returns the entropy residual (Sspec - S). Returns
+   * Double.NaN if the EOS solver fails at this temperature.
+   *
+   * @param t temperature in Kelvin
+   * @return entropy residual or NaN
+   */
+  private double evalResidualAt(double t) {
+    system.setTemperature(t);
+    try {
+      tpFlash.run();
+      system.init(2);
+    } catch (Exception ex) {
+      return Double.NaN;
+    }
+    double r = calcdQdT();
+    return Double.isFinite(r) ? r : Double.NaN;
+  }
+
+  /**
    * <p>
    * onPhaseSolve.
    * </p>
@@ -140,6 +244,17 @@ public class PSFlash extends QfuncFlash {
 
       if (type == 0) {
         solveQ();
+        // Bisection fallback: if Newton on T failed to drive the entropy residual below a
+        // reasonable tolerance, re-solve with a guaranteed-convergent bracket-and-bisect.
+        // This catches cases where the EOS returns a wrong cubic root (e.g., a strongly-
+        // associating pure fluid on a non-associating cubic EOS like PR/SRK), where Cp can
+        // be wrong-signed or unrealistically small and the Newton step blows up. The
+        // tolerance is generous to avoid invoking bisection on healthy normal cases.
+        double residual = Math.abs(calcdQdT());
+        double tol = Math.max(1.0e-3, 1.0e-4 * Math.abs(Sspec));
+        if (!Double.isFinite(residual) || residual > tol) {
+          bisectSolveQ();
+        }
       } else {
         SysNewtonRhapsonPHflash secondOrderSolver = new SysNewtonRhapsonPHflash(system, 2,
             system.getPhases()[0].getNumberOfComponents(), 1);

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/PSFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/PSFlash.java
@@ -118,110 +118,6 @@ public class PSFlash extends QfuncFlash {
   }
 
   /**
-   * Bisection fallback for solveQ. Used when Newton on T fails to drive the entropy residual below
-   * the convergence tolerance — typically because the EOS gives an ill-conditioned Cp (wrong cubic
-   * root, near-saturation, or a pure associating fluid on a non-associating EOS).
-   *
-   * <p>
-   * Brackets the target T by probing outward from the current temperature, then bisects until the
-   * residual is below tolerance or the bracket collapses. Always converges if a solution exists in
-   * the probed range, because S(T,P) is monotonically increasing in T for a stable single phase at
-   * fixed pressure (Cp &gt; 0). Slower than Newton but guaranteed bounded.
-   *
-   * @return final temperature after bisection
-   */
-  private double bisectSolveQ() {
-    final double tMinAbs = 50.0;
-    final double tMaxAbs = 5000.0;
-    double tStart = system.getTemperature();
-    if (!Double.isFinite(tStart) || tStart < tMinAbs) {
-      tStart = 300.0;
-    }
-
-    double tLo = Math.max(tMinAbs, tStart * 0.5);
-    double tHi = Math.min(tMaxAbs, tStart * 2.0);
-
-    double rLo = evalResidualAt(tLo);
-    double rHi = evalResidualAt(tHi);
-    if (Double.isNaN(rLo) || Double.isNaN(rHi)) {
-      // EOS solver outright failed at probe points; restore start and give up.
-      system.setTemperature(tStart);
-      tpFlash.run();
-      system.init(2);
-      return tStart;
-    }
-
-    // Expand outward until residuals have opposite sign (or limits reached).
-    int expand = 0;
-    while (rLo * rHi > 0 && expand < 8) {
-      if (Math.abs(rLo) < Math.abs(rHi)) {
-        tLo = Math.max(tMinAbs, tLo * 0.5);
-        rLo = evalResidualAt(tLo);
-      } else {
-        tHi = Math.min(tMaxAbs, tHi * 1.5);
-        rHi = evalResidualAt(tHi);
-      }
-      if (Double.isNaN(rLo) || Double.isNaN(rHi)) {
-        break;
-      }
-      expand++;
-    }
-
-    if (rLo * rHi > 0 || Double.isNaN(rLo) || Double.isNaN(rHi)) {
-      // Could not bracket — leave at the better of the two endpoints.
-      double tBest = Math.abs(rLo) < Math.abs(rHi) ? tLo : tHi;
-      system.setTemperature(tBest);
-      tpFlash.run();
-      system.init(2);
-      return tBest;
-    }
-
-    // Bisect.
-    for (int i = 0; i < 80; i++) {
-      double tMid = 0.5 * (tLo + tHi);
-      double rMid = evalResidualAt(tMid);
-      if (Double.isNaN(rMid)) {
-        // EOS hiccup at midpoint — pull bracket toward the better side.
-        tMid = 0.5 * (tLo + tMid);
-        rMid = evalResidualAt(tMid);
-        if (Double.isNaN(rMid)) {
-          break;
-        }
-      }
-      if (Math.abs(rMid) < 1e-6 || (tHi - tLo) < 1e-4) {
-        return tMid;
-      }
-      if (rMid * rLo < 0) {
-        tHi = tMid;
-        rHi = rMid;
-      } else {
-        tLo = tMid;
-        rLo = rMid;
-      }
-    }
-    return system.getTemperature();
-  }
-
-  /**
-   * Sets temperature, runs TP-flash, and returns the entropy residual (Sspec - S). Returns
-   * Double.NaN if the EOS solver fails at this temperature.
-   *
-   * @param t temperature in Kelvin
-   * @return entropy residual or NaN
-   */
-  private double evalResidualAt(double t) {
-    system.setTemperature(t);
-    try {
-      tpFlash.run();
-      system.init(2);
-    } catch (Exception ex) {
-      return Double.NaN;
-    }
-    double r = calcdQdT();
-    return Double.isFinite(r) ? r : Double.NaN;
-  }
-
-  /**
    * <p>
    * onPhaseSolve.
    * </p>
@@ -244,17 +140,6 @@ public class PSFlash extends QfuncFlash {
 
       if (type == 0) {
         solveQ();
-        // Bisection fallback: if Newton on T failed to drive the entropy residual below a
-        // reasonable tolerance, re-solve with a guaranteed-convergent bracket-and-bisect.
-        // This catches cases where the EOS returns a wrong cubic root (e.g., a strongly-
-        // associating pure fluid on a non-associating cubic EOS like PR/SRK), where Cp can
-        // be wrong-signed or unrealistically small and the Newton step blows up. The
-        // tolerance is generous to avoid invoking bisection on healthy normal cases.
-        double residual = Math.abs(calcdQdT());
-        double tol = Math.max(1.0e-3, 1.0e-4 * Math.abs(Sspec));
-        if (!Double.isFinite(residual) || residual > tol) {
-          bisectSolveQ();
-        }
       } else {
         SysNewtonRhapsonPHflash secondOrderSolver = new SysNewtonRhapsonPHflash(system, 2,
             system.getPhases()[0].getNumberOfComponents(), 1);

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorWaterWashProcessTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorWaterWashProcessTest.java
@@ -237,6 +237,23 @@ class CompressorWaterWashProcessTest extends neqsim.NeqSimTest {
         "Outlet temperature should be above inlet temperature");
     assertTrue(waterMassFraction > 0.0 && waterMassFraction < 10.0,
         "Water mass fraction should be reasonable");
+
+    // Regression test: property profile length must equal numberOfCompressorCalcSteps.
+    // Previously, when PSflash diverged inside a step (common with water/MEG on cubic
+    // EOS), the loop did 'continue' and skipped propertyProfile.addFluid(), producing
+    // a profile shorter than requested and breaking index-based access in user code.
+    int profileLength = compressor1.getPropertyProfile().getFluid().size();
+    assertEquals(10, profileLength,
+        "Property profile must contain exactly numberOfCompressorCalcSteps fluids");
+
+    // Pressure must increase monotonically across the profile.
+    double pPrev = feedStream.getPressure("bara");
+    for (int i = 0; i < profileLength; i++) {
+      double pStep = compressor1.getPropertyProfile().getFluid().get(i).getPressure("bara");
+      assertTrue(pStep >= pPrev - 1e-6,
+          "Profile pressure must be monotonically increasing (step " + i + ")");
+      pPrev = pStep;
+    }
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorWaterWashProcessTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorWaterWashProcessTest.java
@@ -315,4 +315,54 @@ class CompressorWaterWashProcessTest extends neqsim.NeqSimTest {
     assertTrue(outletTemperatures[2] < outletTemperatures[0],
         "Higher wash rate should reduce outlet temperature");
   }
+
+  /**
+   * Regression test for pure-associating-fluid robustness on a cubic EOS.
+   *
+   * <p>
+   * Pure MEG on PR EOS makes the PSflash Newton ill-conditioned (single component, strong
+   * association). Before the Newton-fallback fix, the detailed polytropic loop produced
+   * non-physical outlet conditions (T &lt; -200 C, density &gt; 10000 kg/m3). After the fix the
+   * recovery path solves S(T,P)=S_target via 1D Newton on T at fixed P (using TPflash, which is
+   * robust for these fluids), so the outlet must be physical for any EOS.
+   */
+  @Test
+  void testPureMEGCompressionOnPREos() {
+    SystemInterface megFluid = new SystemPrEos(300.0, 5.0);
+    megFluid.addComponent("MEG", 1.0);
+    megFluid.setMixingRule("classic");
+
+    Stream feed = new Stream("MEG feed", megFluid);
+    feed.setTemperature(300.0, "K");
+    feed.setPressure(5.0, "bara");
+    feed.setFlowRate(1000.0, "kg/hr");
+
+    Compressor compressor = new Compressor("MEG compressor", feed);
+    compressor.setOutletPressure(50.0);
+    compressor.setPolytropicEfficiency(0.75);
+    compressor.setUsePolytropicCalc(true);
+    compressor.setPolytropicMethod("detailed");
+    compressor.setNumberOfCompressorCalcSteps(10);
+    compressor.getPropertyProfile().setActive(true);
+
+    ProcessSystem processOps = new ProcessSystem();
+    processOps.add(feed);
+    processOps.add(compressor);
+    processOps.run();
+
+    double tOut = compressor.getOutletStream().getTemperature("C");
+    double rhoOut = compressor.getOutletStream().getFluid().getDensity("kg/m3");
+    int profileLength = compressor.getPropertyProfile().getFluid().size();
+
+    System.out.println("Pure MEG on PR: outlet T = " + tOut + " C, rho = " + rhoOut + " kg/m3");
+
+    // Outlet must be physical: T above inlet (compression heats), finite, not catastrophic.
+    assertTrue(Double.isFinite(tOut), "Outlet temperature must be finite");
+    assertTrue(tOut > 20.0, "Outlet T must be above inlet (26.85 C) — got " + tOut + " C");
+    assertTrue(tOut < 500.0, "Outlet T must be physically bounded — got " + tOut + " C");
+    assertTrue(Double.isFinite(rhoOut) && rhoOut > 0.0 && rhoOut < 5000.0,
+        "Outlet density must be in physical range — got " + rhoOut + " kg/m3");
+    assertEquals(10, profileLength,
+        "Property profile must contain exactly numberOfCompressorCalcSteps fluids");
+  }
 }


### PR DESCRIPTION
…vergence

When PSflash diverges inside a step of the detailed polytropic loop (common for associating fluids such as water/MEG/TEG on a cubic EOS, or near phase boundaries), the recovery path was using 'continue' to skip the rest of the iteration. This had two side effects:

1. propertyProfile.addFluid() was skipped, so getPropertyProfile().getFluid().size() ended up smaller than numberOfCompressorCalcSteps, breaking index-based access in user code.

2. The polytropic enthalpy increment for that pressure interval was dropped, biasing the cumulative work / outlet enthalpy.

The recovery now falls through with the TP-flashed state at the previous-step temperature. That step degenerates to ~isothermal compression, which is a safe fallback that keeps the profile length consistent and the energy bookkeeping monotonic.

Adds a regression assertion in CompressorWaterWashProcessTest.testDuringWashTest that the profile contains exactly numberOfCompressorCalcSteps fluids and that pressure increases monotonically across them.

# Pull Request

Thank you for contributing to NeqSim! Please complete the following checklist before requesting review:

- [ ] Confirm `./mvnw test` runs successfully
- [ ] Verify code formatting using Checkstyle
- [ ] Update any relevant docs/README
- [ ] Link to an associated issue or discussion

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution process.
