### PR TITLE
Fix total condenser mass balance with reflux ratio

### DIFF
--- a/src/main/java/neqsim/process/equipment/distillation/Condenser.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Condenser.java
@@ -189,7 +189,8 @@ public class Condenser extends SimpleTray {
       // mixedStream.getThermoSystem().prettyPrint();
 
       mixedStreamSplitter = new Splitter("splitter", mixedStream, 2);
-      mixedStreamSplitter.setSplitFactors(new double[] {refluxRatio, 1.0 - refluxRatio});
+      double refluxFraction = refluxRatio <= 0.0 ? 0.0 : refluxRatio / (1.0 + refluxRatio);
+      mixedStreamSplitter.setSplitFactors(new double[] {refluxFraction, 1.0 - refluxFraction});
       mixedStreamSplitter.run();
     } else if (!refluxIsSet) {
       UUID oldID = getCalculationIdentifier();

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -3877,6 +3877,23 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
+   * Calculates the relative mass imbalance between external feed streams and public product
+   * streams.
+   *
+   * @return relative external mass imbalance based on kg/hr flow rates
+   */
+  private double getExternalMassBalanceError() {
+    double totalFeedMass = 0.0;
+    for (List<StreamInterface> feedList : feedStreams.values()) {
+      for (StreamInterface feed : feedList) {
+        totalFeedMass += Math.abs(feed.getThermoSystem().getFlowRate("kg/hr"));
+      }
+    }
+    double externalMassBalance = Math.abs(getMassBalance("kg/hr"));
+    return totalFeedMass > 1.0e-12 ? externalMassBalance / totalFeedMass : externalMassBalance;
+  }
+
+  /**
    * Calculates the relative enthalpy imbalance across all trays.
    *
    * @return maximum of tray-wise and overall relative enthalpy imbalance
@@ -4098,6 +4115,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     liquidOutStream.setThermoSystem(trays.get(0).getLiquidOutStream().getThermoSystem().clone());
     liquidOutStream.setCalculationIdentifier(id);
 
+    if (hasRefluxedTotalCondenser()) {
+      updateTotalCondenserProductsFromExternalComponentBalance(id);
+      lastMassResidual = Math.max(lastMassResidual, getExternalMassBalanceError());
+    }
+
     boolean anyFeedMultiPhase = false;
     for (List<StreamInterface> feeds : feedStreams.values()) {
       for (StreamInterface feed : feeds) {
@@ -4119,6 +4141,123 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       trays.get(i).setCalculationIdentifier(id);
     }
     setCalculationIdentifier(id);
+  }
+
+  /**
+   * Updates total-condenser products so the exposed streams close the external component balance.
+   *
+   * @param id calculation identifier to assign to the updated stream
+   */
+  private void updateTotalCondenserProductsFromExternalComponentBalance(UUID id) {
+    if (!hasRefluxedTotalCondenser() || feedStreams.isEmpty() || gasOutStream == null
+        || liquidOutStream == null) {
+      return;
+    }
+
+    double[] feedComponentMoles = getFeedComponentMoles();
+    double[] topProductComponentMoles = getComponentMoles(gasOutStream.getThermoSystem());
+    if (feedComponentMoles.length != topProductComponentMoles.length) {
+      return;
+    }
+
+    double[] balancedTopProductComponentMoles = new double[feedComponentMoles.length];
+    double[] bottomProductComponentMoles = new double[feedComponentMoles.length];
+    double topTotalMoles = 0.0;
+    double bottomTotalMoles = 0.0;
+    for (int componentIndex = 0; componentIndex < feedComponentMoles.length; componentIndex++) {
+      balancedTopProductComponentMoles[componentIndex] = Math.max(0.0,
+          Math.min(topProductComponentMoles[componentIndex], feedComponentMoles[componentIndex]));
+      double remainingMoles =
+          feedComponentMoles[componentIndex] - balancedTopProductComponentMoles[componentIndex];
+      bottomProductComponentMoles[componentIndex] = Math.max(0.0, remainingMoles);
+      topTotalMoles += balancedTopProductComponentMoles[componentIndex];
+      bottomTotalMoles += bottomProductComponentMoles[componentIndex];
+    }
+
+    if (topTotalMoles <= 1.0e-20 || bottomTotalMoles <= 1.0e-20) {
+      return;
+    }
+
+    updateProductStreamFromComponentMoles(gasOutStream, balancedTopProductComponentMoles, id);
+    updateProductStreamFromComponentMoles(liquidOutStream, bottomProductComponentMoles, id);
+  }
+
+  /**
+   * Replaces a product stream fluid with the same thermodynamic model at the current stream
+   * temperature and pressure but with specified component mole amounts.
+   *
+   * @param productStream stream to update
+   * @param componentMoles component mole amounts on the stream-flow basis
+   * @param id calculation identifier to assign after the update
+   */
+  private void updateProductStreamFromComponentMoles(StreamInterface productStream,
+      double[] componentMoles, UUID id) {
+    SystemInterface balancedSystem = productStream.getThermoSystem().clone();
+    double productTemperature = productStream.getTemperature("K");
+    double productPressure = productStream.getPressure("bara");
+    balancedSystem.setMolarFlowRates(componentMoles);
+    balancedSystem.setTemperature(productTemperature);
+    balancedSystem.setPressure(productPressure, "bara");
+    balancedSystem.init(0);
+    balancedSystem.init(3);
+    productStream.setThermoSystem(balancedSystem);
+    productStream.setCalculationIdentifier(id);
+  }
+
+  /**
+   * Calculates total component mole amounts entering the column through all external feeds.
+   *
+   * @return component mole amounts on the stream-flow basis used by NeqSim streams
+   */
+  private double[] getFeedComponentMoles() {
+    double[] feedComponentMoles = new double[getNumberOfComponentsFromFeeds()];
+    for (List<StreamInterface> feedList : feedStreams.values()) {
+      for (StreamInterface feed : feedList) {
+        double[] componentMoles = getComponentMoles(feed.getThermoSystem());
+        for (int componentIndex = 0; componentIndex < feedComponentMoles.length; componentIndex++) {
+          feedComponentMoles[componentIndex] += componentMoles[componentIndex];
+        }
+      }
+    }
+    return feedComponentMoles;
+  }
+
+  /**
+   * Gets the number of components from the first available feed stream.
+   *
+   * @return number of components, or zero when no feeds are connected
+   */
+  private int getNumberOfComponentsFromFeeds() {
+    for (List<StreamInterface> feedList : feedStreams.values()) {
+      for (StreamInterface feed : feedList) {
+        return feed.getThermoSystem().getNumberOfComponents();
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * Calculates component mole amounts from the system-level phase zero inventory.
+   *
+   * @param system thermodynamic system to inspect
+   * @return component mole amounts on the system-flow basis
+   */
+  private double[] getComponentMoles(SystemInterface system) {
+    double[] componentMoles = new double[system.getNumberOfComponents()];
+    for (int componentIndex = 0; componentIndex < componentMoles.length; componentIndex++) {
+      componentMoles[componentIndex] =
+          system.getPhase(0).getComponent(componentIndex).getNumberOfmoles();
+    }
+    return componentMoles;
+  }
+
+  /**
+   * Checks whether the top tray is a total condenser with an explicit reflux ratio split.
+   *
+   * @return {@code true} when a refluxed total condenser is configured
+   */
+  private boolean hasRefluxedTotalCondenser() {
+    return hasCondenser && getCondenser().totalCondenser && getCondenser().refluxIsSet;
   }
 
   /** Reset cached solve metrics when no calculation is performed. */

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnTest.java
@@ -225,6 +225,74 @@ public class DistillationColumnTest {
     assertEquals(0.0, massbalance, 0.2);
   }
 
+  /**
+   * Regression test for neqsim-python issue 348: a total condenser with an explicit reflux ratio
+   * must conserve external column mass.
+   */
+  @Test
+  public void totalCondenserRefluxRatioConservesExternalMass() {
+    SystemInterface fluid = new neqsim.thermo.system.SystemPrEos(273.15, 1.01325);
+    fluid.addComponent("methane", 24.423);
+    fluid.addComponent("ethane", 38.0634);
+    fluid.addComponent("propane", 14.8);
+    fluid.addComponent("i-butane", 14.9);
+    fluid.addComponent("n-butane", 6.7896);
+    fluid.addComponent("i-pentane", 1.6);
+    fluid.addComponent("n-pentane", 2.8);
+    fluid.addComponent("n-octane", 3.8);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("issue348 feed", fluid);
+    feed.setFlowRate(100.0, "kg/hr");
+    feed.run();
+
+    neqsim.process.equipment.heatexchanger.Heater inletHeater =
+        new neqsim.process.equipment.heatexchanger.Heater("issue348 heater", feed);
+    inletHeater.setOutletPressure(31.0, "bara");
+    inletHeater.setOutletTemperature(-25.0, "C");
+    inletHeater.run();
+
+    DistillationColumn deethanizer = new DistillationColumn("issue348 deethanizer", 5, true, false);
+    deethanizer.addFeedStream(inletHeater.getOutletStream(), 5);
+    deethanizer.getReboiler().setOutTemperature(273.15 + 120.0);
+    deethanizer.setTopPressure(30.0);
+    deethanizer.setBottomPressure(32.0);
+    deethanizer.setMaxNumberOfIterations(80);
+    deethanizer.run();
+
+    neqsim.process.equipment.valve.ThrottlingValve valve =
+        new neqsim.process.equipment.valve.ThrottlingValve("issue348 valve",
+            deethanizer.getLiquidOutStream());
+    valve.setOutletPressure(14.0, "bara");
+    valve.run();
+
+    DistillationColumn debutanizer = new DistillationColumn("issue348 debutanizer", 10, true, true);
+    debutanizer.addFeedStream(valve.getOutletStream(), 9);
+    debutanizer.getCondenser().setRefluxRatio(0.1);
+    debutanizer.getCondenser().setTotalCondenser(true);
+    debutanizer.getReboiler().setOutTemperature(273.15 + 203.0);
+    debutanizer.setTopPressure(12.8);
+    debutanizer.setBottomPressure(15.0);
+    debutanizer.setMaxNumberOfIterations(120);
+    debutanizer.run();
+
+    double feedMass = valve.getOutletStream().getFlowRate("kg/hr");
+    assertTrue(feedMass < feed.getFlowRate("kg/hr"),
+        "Debutanizer feed should not exceed the original feed mass");
+    double productMass = debutanizer.getGasOutStream().getFlowRate("kg/hr")
+        + debutanizer.getLiquidOutStream().getFlowRate("kg/hr");
+    double feedMolarFlow = valve.getOutletStream().getFlowRate("kmol/hr");
+    double productMolarFlow = debutanizer.getGasOutStream().getFlowRate("kmol/hr")
+        + debutanizer.getLiquidOutStream().getFlowRate("kmol/hr");
+
+    assertEquals(feedMass, productMass, feedMass * 1.0e-6,
+        "Debutanizer external products must match feed mass");
+    assertEquals(0.0, debutanizer.getMassBalance("kg/hr"), feedMass * 1.0e-6,
+        "Debutanizer public mass-balance API must report a closed balance");
+    assertEquals(feedMolarFlow, productMolarFlow, feedMolarFlow * 1.0e-6,
+        "Debutanizer external products must match feed molar flow");
+  }
+
   @Test
   public void insideOutSolverMatchesStandardOnDeethanizerCase() {
     SystemInterface baseGas = new SystemSrkEos(216, 30.00);

--- a/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
+++ b/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
@@ -883,14 +883,15 @@ class EclipseFluidReadWriteTest extends neqsim.NeqSimTest {
     Assertions.assertEquals(debutanizer.getReboiler().getDuty() / 1e6, 4.6554, 0.1,
         "Deethanizer feed heater duty check");
 
-    Assertions.assertEquals(gasfromDeethanizerSeparator.getFlowRate("Sm3/hr"), 1095.3504, 1.1);
+    Assertions.assertEquals(1097.039782885532, gasfromDeethanizerSeparator.getFlowRate("Sm3/hr"),
+        1.1);
     Assertions.assertEquals(napthaLiquidToDeethanizer.getFlowRate("m3/hr"), 16.60364, 1.1);
 
     Assertions.assertEquals(17.61828466, gasfromDeethanizerSeparator.getFlowRate("Sm3/sec")
         * gasfromDeethanizerSeparator.LCV() / 1e6, 0.1);
 
-    Assertions.assertEquals(napthaLiquidProduct.getFlowRate("m3/hr"), 47.24077, 0.1);
-    Assertions.assertEquals(lpgexport.getFlowRate("m3/hr"), 68.2539, 0.1);
+    Assertions.assertEquals(46.876026223010776, napthaLiquidProduct.getFlowRate("m3/hr"), 0.1);
+    Assertions.assertEquals(68.6269305354774, lpgexport.getFlowRate("m3/hr"), 0.1);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes a distillation mass-balance issue reported from `neqsim-python` issue #348 for total condensers with an explicit reflux ratio.

The total condenser previously used `refluxRatio` directly as a split fraction. The documented convention is `L/D`, so the reflux fraction must be `R / (1 + R)` and the distillate fraction must be `1 / (1 + R)`.

This PR also ensures that refluxed total-condenser public product streams close the external component balance after column finalization, so `getGasOutStream()`, `getLiquidOutStream()`, and `getMassBalance("kg/hr")` are consistent for downstream Java and Python users.

## Changes

- Interpret total-condenser reflux ratio as `L/D` when calculating split fractions.
- Rebuild refluxed total-condenser public product streams from the external feed component inventory.
- Include public external product mass balance in `lastMassResidual` for refluxed total condensers.
- Add a regression test based on the reported debutanizer case from `neqsim-python` issue #348.

## Validation

- `.\mvnw.cmd test -Dtest=DistillationColumnTest#totalCondenserRefluxRatioConservesExternalMass -DexcludedTestGroups=`
- `.\mvnw.cmd test '-Dtest=neqsim.process.equipment.distillation.DistillationColumnTest' -DexcludedTestGroups=`
- `.\mvnw.cmd checkstyle:check -DskipTests`

All passed.