### PR TITLE
[codex] fix calculated EOS kij cube-root handling

### DIFF
--- a/src/main/java/neqsim/thermo/mixingrule/EosMixingRuleHandler.java
+++ b/src/main/java/neqsim/thermo/mixingrule/EosMixingRuleHandler.java
@@ -210,12 +210,8 @@ public class EosMixingRuleHandler extends MixingRuleHandler {
               classicOrHV[l][k] = classicOrHV[k][l];
 
               if (isCalcEOSInteractionParameters()) {
-                intparam[k][l] = 1.0 - Math.pow((2.0
-                    * Math.sqrt(Math.pow(phase.getComponent(l).getCriticalVolume(), 1.0 / 3.0)
-                        * Math.pow(phase.getComponent(k).getCriticalVolume(), 1 / 3))
-                    / (Math.pow(phase.getComponent(l).getCriticalVolume(), 1 / 3)
-                        + Math.pow(phase.getComponent(k).getCriticalVolume(), 1 / 3))),
-                    nEOSkij);
+                intparam[k][l] = BIPEstimator.estimateChuehPrausnitz(phase.getComponent(k),
+                    phase.getComponent(l), nEOSkij);
                 intparamT[k][l] = 0.0;
                 // System.out.println("kij " + intparam[k][l]);
               } else {

--- a/src/test/java/neqsim/thermo/mixingrule/EosMixingRulesTest.java
+++ b/src/test/java/neqsim/thermo/mixingrule/EosMixingRulesTest.java
@@ -83,4 +83,26 @@ public class EosMixingRulesTest {
     assertEquals(0.1, kij, 1e-5);
     assertTrue(kij == kij2);
   }
+
+  @Test
+  void testCalculatedInteractionParametersUseCriticalVolumes() {
+    neqsim.thermo.system.SystemPrEos testSystem = new neqsim.thermo.system.SystemPrEos(298.0, 10.0);
+    testSystem.addComponent("methane", 1.0);
+    testSystem.addComponent("n-heptane", 1.0);
+
+    try {
+      testSystem.calcKIJ(true);
+      testSystem.setMixingRule("classic");
+
+      double kij = ((PhaseEos) testSystem.getPhase(0)).getEosMixingRule()
+          .getBinaryInteractionParameter(0, 1);
+      double expected = BIPEstimator.estimateChuehPrausnitz(testSystem.getComponent("methane"),
+          testSystem.getComponent("n-heptane"));
+
+      assertEquals(expected, kij, 1e-12);
+      assertTrue(kij > 0.0, "Calculated critical-volume kij should not collapse to zero");
+    } finally {
+      testSystem.calcKIJ(false);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Fix the calculated EOS binary interaction parameter path so it uses the existing Chueh-Prausnitz helper instead of an inline expression with integer-division cube roots.

## Root cause

When `calcEOSInteractionParameters` is enabled, `EosMixingRuleHandler` calculated critical-volume cube roots using `1 / 3` in several `Math.pow(...)` calls. In Java, `1 / 3` is integer division and evaluates to `0`, so those terms collapsed to `Math.pow(Vc, 0) == 1`. That made the calculated kij independent of the critical volumes and could incorrectly collapse to zero.

## Changes

- Reuse `BIPEstimator.estimateChuehPrausnitz(...)` for the calculated kij branch.
- Add a regression test proving calculated kij matches the helper and remains positive for methane/n-heptane.

## Validation

```powershell
.\mvnw.cmd '-Dtest=EosMixingRulesTest,BIPEstimatorTest' test
```

Result: 12 tests passed, 0 failures.