### PR TITLE
[codex] Improve two-fluid validation and reporting

### DIFF
--- a/docs/wiki/pipeline_index.md
+++ b/docs/wiki/pipeline_index.md
@@ -22,6 +22,7 @@ This documentation covers pipeline pressure drop, flow, and heat transfer calcul
 |----------|-------------|
 | [Beggs & Brill Correlation](beggs_and_brill_correlation) | Multiphase flow correlation theory and usage |
 | [Two-Fluid Transient Model](two_fluid_model) | 7-equation two-fluid model with slug tracking, virtual mass, and local losses |
+| [TwoFluidPipe Reporting and Validation](two_fluid_reporting_and_validation) | Profile extraction, transient reporting, closure diagnostics, and OLGA/LedaFlow benchmark CSV comparison |
 | [Friction Factor Models](friction_factor_models) | Haaland, Colebrook-White, laminar/turbulent |
 | [Heat Transfer](pipeline_heat_transfer) | Non-adiabatic operation, cooling, Gnielinski |
 | [Transient Simulation](pipeline_transient_simulation) | Dynamic simulation, slow wave propagation |

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -7,6 +7,9 @@ description: "This document describes the two-fluid model implementation in NeqS
 
 This document describes the two-fluid model implementation in NeqSim for transient multiphase pipeline simulation.
 
+For practical result extraction, long-flowline reporting, and comparison with OLGA/LedaFlow or
+field data, see [TwoFluidPipe Reporting and Validation](two_fluid_reporting_and_validation).
+
 ## Overview
 
 The two-fluid model solves separate conservation equations for each phase (gas and liquid), providing more accurate predictions than drift-flux models for:

--- a/docs/wiki/two_fluid_reporting_and_validation.md
+++ b/docs/wiki/two_fluid_reporting_and_validation.md
@@ -1,0 +1,222 @@
+---
+title: "TwoFluidPipe Reporting and Validation"
+description: "How to report long multiphase flowline results from TwoFluidPipe and compare them with OLGA, LedaFlow, or field data."
+---
+
+# TwoFluidPipe Reporting and Validation
+
+This page describes how to extract engineering results from
+`neqsim.process.equipment.pipeline.TwoFluidPipe` for long multiphase flowlines and how to compare
+those results with external simulator or field data.
+
+## Current reporting status
+
+`TwoFluidPipe` exposes detailed profile and summary APIs. The convenience class
+`neqsim.process.equipment.pipeline.twophasepipe.reporting.TwoFluidPipeReport` builds standard CSV,
+text, JSON, event, and benchmark comparison outputs from those APIs.
+
+The recommended production workflow is:
+
+1. Build and run the `TwoFluidPipe` model.
+2. Extract spatial profiles from the pipe, or call `TwoFluidPipeReport` helper methods.
+3. Add summary metrics and flow-assurance indicators.
+4. Export to CSV/JSON for plotting, review, or comparison.
+5. If available, compare against OLGA, LedaFlow, or field data using the benchmark harness.
+
+## Steady-state profile reporting
+
+After `pipe.run()`, the following methods provide one value per pipe section:
+
+| API | Unit | Description |
+|-----|------|-------------|
+| `getPositionProfile()` | m | Section midpoint positions |
+| `getPressureProfile()` | Pa | Pressure profile |
+| `getTemperatureProfile()` | K | Fluid temperature profile |
+| `getTemperatureProfile("C")` | degC | Fluid temperature profile in Celsius |
+| `getLiquidHoldupProfile()` | fraction | Total liquid holdup |
+| `getWaterCutProfile()` | fraction | Water fraction of liquid |
+| `getOilHoldupProfile()` | fraction | Oil holdup |
+| `getWaterHoldupProfile()` | fraction | Water holdup |
+| `getGasVelocityProfile()` | m/s | Gas velocity |
+| `getLiquidVelocityProfile()` | m/s | Liquid velocity |
+| `getOilVelocityProfile()` | m/s | Oil velocity when oil-water slip is active |
+| `getWaterVelocityProfile()` | m/s | Water velocity when oil-water slip is active |
+| `getOilWaterSlipProfile()` | m/s | Oil velocity minus water velocity |
+| `getFlowRegimeProfile()` | enum | Gas-liquid flow regime by section |
+| `getHeatTransferProfile()` | W/(m2 K) | Heat-transfer coefficient profile, when configured |
+| `getSurfaceTemperatureProfile()` | K | Ambient/surface temperature profile, when configured |
+
+Example Java extraction:
+
+```java
+pipe.run();
+
+double[] x = pipe.getPositionProfile();
+double[] pressureBara = pipe.getPressureProfile();
+double[] temperatureC = pipe.getTemperatureProfile("C");
+double[] liquidHoldup = pipe.getLiquidHoldupProfile();
+double[] waterCut = pipe.getWaterCutProfile();
+double[] gasVelocity = pipe.getGasVelocityProfile();
+double[] liquidVelocity = pipe.getLiquidVelocityProfile();
+PipeSection.FlowRegime[] regimes = pipe.getFlowRegimeProfile();
+
+for (int i = 0; i < x.length; i++) {
+  double pBara = pressureBara[i] * 1.0e-5;
+  System.out.printf("%8.1f,%10.4f,%8.3f,%8.5f,%8.5f,%8.3f,%8.3f,%s%n",
+      x[i], pBara, temperatureC[i], liquidHoldup[i], waterCut[i],
+      gasVelocity[i], liquidVelocity[i], regimes[i]);
+}
+```
+
+The same steady-state results can be exported directly:
+
+```java
+String profileCsv = TwoFluidPipeReport.toSteadyStateProfileCsv(pipe);
+String summaryText = TwoFluidPipeReport.toSummaryText(pipe);
+String summaryJson = TwoFluidPipeReport.toSummaryJson(pipe);
+String eventsCsv = TwoFluidPipeReport.toSlugAndFlowAssuranceCsv(pipe);
+```
+
+## Transient reporting
+
+For transient cases, call `runTransient(dt, id)` repeatedly and store a snapshot at the reporting
+interval required by the study. Do not store every internal sub-step for long pipelines unless
+high-frequency pressure waves or slug arrivals are being investigated.
+
+```java
+UUID id = UUID.randomUUID();
+double dt = 1.0;
+int reportEvery = 10;
+
+for (int step = 0; step < 3600; step++) {
+  pipe.runTransient(dt, id);
+
+  if (step % reportEvery == 0) {
+    double time = pipe.getSimulationTime();
+    double[] x = pipe.getPositionProfile();
+    double[] p = pipe.getPressureProfile();
+    double[] hL = pipe.getLiquidHoldupProfile();
+    // Write one row per position with this time stamp.
+  }
+}
+```
+
+Recommended transient CSV columns:
+
+```text
+time_s,position_m,pressure_bara,temperature_C,liquid_holdup,water_cut,
+gas_velocity_m_s,liquid_velocity_m_s,oil_velocity_m_s,water_velocity_m_s,
+flow_regime
+```
+
+## Summary metrics
+
+Use these methods for an executive summary or design report:
+
+| API | Description |
+|-----|-------------|
+| `getInletPressure()` | Inlet pressure in bara |
+| `getOutletPressure()` | Outlet pressure in bara |
+| `getAverageLiquidHoldup()` | Volume-weighted average liquid holdup |
+| `getDominantFlowRegime()` | Most frequent flow regime |
+| `getAverageSuperficialGasVelocity()` | Average superficial gas velocity |
+| `getAverageSuperficialLiquidVelocity()` | Average superficial liquid velocity |
+| `getAverageMixtureDensity()` | Volume-weighted mixture density |
+| `getMaxMixtureVelocity()` | Maximum mixture velocity |
+| `getErosionalVelocity()` | API 14E erosional velocity |
+| `getErosionalVelocityMargin(double)` | Maximum velocity divided by erosional velocity |
+| `getFlowAnalysisSummary()` | Mid-pipe dimensionless flow summary |
+| `getThermalSummary()` | Thermal model summary |
+| `getSlugStatisticsSummary()` | Slug-tracking summary |
+| `getHydrateRiskSections()` | Sections below configured hydrate temperature |
+| `getWaxRiskSections()` | Sections below configured wax appearance temperature |
+
+## Closure diagnostics
+
+The two-fluid closure pass updates additional section-level diagnostics that are useful for model
+review and validation:
+
+| Section API | Description |
+|-------------|-------------|
+| `getOilWaterFlowRegime()` | Oil-water flow configuration |
+| `isWaterWetting()` | Water-wetting indicator for corrosion screening |
+| `isWaterDropoutRisk()` | Water dropout / accumulation risk |
+| `getEntrainmentFraction()` | Estimated liquid entrainment fraction in annular/mist flow |
+| `getEntrainedDropletDiameter()` | Characteristic entrained droplet diameter |
+| `getSevereSluggingNumber()` | Riser-base stability indicator |
+| `isSevereSlugPotential()` | Severe slugging risk flag |
+
+These values are stored on `TwoFluidSection` objects. They are not yet exposed as top-level
+`TwoFluidPipe` profile arrays, so a future report exporter should add profile accessors for them.
+
+## Benchmark comparison format
+
+The validation harness reads external simulator or field data in this CSV format:
+
+```csv
+case,time_s,position_m,variable,value,abs_tolerance,rel_tolerance,source
+```
+
+Supported captured variables include:
+
+```text
+pressure_pa
+pressure_bara
+temperature_k
+liquid_holdup
+water_cut
+oil_holdup
+water_holdup
+gas_velocity_m_s
+liquid_velocity_m_s
+oil_velocity_m_s
+water_velocity_m_s
+```
+
+Example use:
+
+```java
+Path reference = Path.of("olga_export.csv");
+List<TwoFluidBenchmarkHarness.BenchmarkPoint> points =
+    TwoFluidBenchmarkHarness.readCsv(reference);
+
+TwoFluidBenchmarkHarness.Snapshot snapshot = TwoFluidBenchmarkHarness.capture(pipe);
+TwoFluidBenchmarkHarness.Comparison comparison =
+    TwoFluidBenchmarkHarness.compare(snapshot, points);
+
+if (!comparison.isPassed()) {
+  throw new AssertionError(comparison.failureSummary());
+}
+```
+
+For transient comparisons, capture and pass a list of snapshots. The harness interpolates in both
+time and position. Comparison results can be exported as CSV:
+
+```java
+String comparisonCsv = TwoFluidPipeReport.toComparisonCsv(comparison);
+```
+
+## Reporting recommendations for long flowlines
+
+For long oil and gas flowlines, report at least:
+
+- Geometry and discretization: length, diameter, roughness, elevation profile, number of sections,
+  mesh refinement strategy.
+- Boundary conditions: inlet stream, flow rate, outlet pressure, transient changes.
+- Thermodynamics: fluid model, flash interval, mass-transfer relaxation time, heat-transfer setup.
+- Pressure and temperature profiles.
+- Liquid holdup, water cut, phase velocity, and flow-regime profiles.
+- Slug statistics and terrain low-point liquid accumulation.
+- Hydrate/wax/thermal risk sections if thresholds are configured.
+- Erosional velocity margin and maximum mixture velocity.
+- Benchmark comparison table when OLGA, LedaFlow, or field measurements are available.
+
+## Gaps and planned improvements
+
+The current API is adequate for engineering studies and benchmark development. A polished
+industrial report workflow should still add:
+
+- Top-level profile accessors for closure diagnostics such as entrainment fraction, water wetting,
+  and severe slugging number.
+- Plot templates for pressure, temperature, holdup, water cut, flow regime, and slug events.
+- Direct import of OLGA/LedaFlow export formats where licensing allows it.

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -8,8 +8,10 @@ import neqsim.process.equipment.pipeline.twophasepipe.LagrangianSlugTracker;
 import neqsim.process.equipment.pipeline.twophasepipe.LiquidAccumulationTracker;
 import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
 import neqsim.process.equipment.pipeline.twophasepipe.SlugTracker;
+import neqsim.process.equipment.pipeline.twophasepipe.ThermodynamicCoupling;
 import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidConservationEquations;
 import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidSection;
+import neqsim.process.equipment.pipeline.twophasepipe.numerics.ConservativeStateLimiter;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.TimeIntegrator;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
@@ -741,6 +743,7 @@ public class TwoFluidPipe extends Pipeline {
 
     // Store reference fluid for flash calculations
     referenceFluid = inletFluid.clone();
+    equations.setThermodynamicCoupling(new ThermodynamicCoupling(referenceFluid));
 
     // Calculate inlet phase properties - initialize with defaults
     double rhoG = 1.0, rhoL = 800.0, muG = 1e-5, muL = 1e-3;
@@ -3265,13 +3268,23 @@ public class TwoFluidPipe extends Pipeline {
       if (isIMEX) {
         double[] soundSpeeds = new double[numberOfSections];
         double[] densities = new double[numberOfSections];
+        double[] areas = new double[numberOfSections];
+        double[] gasDensities = new double[numberOfSections];
+        double[] oilDensities = new double[numberOfSections];
+        double[] waterDensities = new double[numberOfSections];
         for (int i = 0; i < numberOfSections; i++) {
           TwoFluidSection sec = sections[i];
           double alphaG = sec.getGasHoldup();
           double alphaL = sec.getLiquidHoldup();
           double rhoG = Math.max(sec.getGasDensity(), 0.1);
           double rhoL = Math.max(sec.getLiquidDensity(), 100.0);
+          double rhoO = Math.max(sec.getOilDensity(), rhoL);
+          double rhoW = Math.max(sec.getWaterDensity(), rhoL);
           densities[i] = alphaG * rhoG + alphaL * rhoL;
+          areas[i] = sec.getArea();
+          gasDensities[i] = rhoG;
+          oilDensities[i] = rhoO;
+          waterDensities[i] = rhoW;
           // Mixture sound speed (Wood's equation for two-phase)
           double rhoMix = densities[i];
           double cG = Math.max(sec.getGasSoundSpeed(), 100.0);
@@ -3282,7 +3295,8 @@ public class TwoFluidPipe extends Pipeline {
         }
         boolean outletFixed = (outletBCType == BoundaryCondition.CONSTANT_PRESSURE
             || outletBCType == BoundaryCondition.CHARACTERISTIC);
-        timeIntegrator.setIMEXProperties(soundSpeeds, densities, dx, outletPressure, outletFixed);
+        timeIntegrator.setIMEXProperties(soundSpeeds, densities, areas, gasDensities, oilDensities,
+            waterDensities, dx, outletPressure, outletFixed);
       }
 
       double[][] U_new = timeIntegrator.step(U_prev, rhs, dtFinal);
@@ -3449,40 +3463,8 @@ public class TwoFluidPipe extends Pipeline {
    */
   private void validateAndCorrectState(double[][] U_new, double[][] U_prev) {
     for (int i = 0; i < U_new.length; i++) {
-      for (int j = 0; j < U_new[i].length; j++) {
-        // Check for NaN or Inf
-        if (Double.isNaN(U_new[i][j]) || Double.isInfinite(U_new[i][j])) {
-          U_new[i][j] = U_prev[i][j]; // Revert to previous value
-        }
-      }
-
-      // Ensure mass variables are non-negative (indices 0, 1, 2 for gas, oil, water)
-      U_new[i][0] = Math.max(0, U_new[i][0]); // Gas mass
-      U_new[i][1] = Math.max(0, U_new[i][1]); // Oil mass
-      if (U_new[i].length > 2) {
-        U_new[i][2] = Math.max(0, U_new[i][2]); // Water mass
-      }
-
-      // Limit extreme rate of change to prevent blow-up (50% per sub-step max)
-      // This is a safety limit, not for physics - allows transient dynamics
-      double maxChangeRatio = 0.5;
-      // Apply to all mass variables: gas (0), oil (1), water (2)
-      int numMassVars = Math.min(3, U_new[i].length);
-      for (int j = 0; j < numMassVars; j++) {
-        // Check for valid non-zero previous value before computing ratio
-        if (U_prev[i][j] > 1e-10 && !Double.isNaN(U_prev[i][j])
-            && !Double.isInfinite(U_prev[i][j])) {
-          double ratio = U_new[i][j] / U_prev[i][j];
-          if (Double.isNaN(ratio) || Double.isInfinite(ratio)) {
-            // Invalid ratio - revert to previous value
-            U_new[i][j] = U_prev[i][j];
-          } else if (ratio > 1 + maxChangeRatio) {
-            U_new[i][j] = U_prev[i][j] * (1 + maxChangeRatio);
-          } else if (ratio < 1 - maxChangeRatio && ratio > 0) {
-            U_new[i][j] = U_prev[i][j] * (1 - maxChangeRatio);
-          }
-        }
-      }
+      double[] previous = U_prev != null && i < U_prev.length ? U_prev[i] : null;
+      ConservativeStateLimiter.enforceThreePhaseMassPositivity(U_new[i], previous);
     }
   }
 
@@ -5536,6 +5518,17 @@ public class TwoFluidPipe extends Pipeline {
     this.includeMassTransfer = include;
     if (equations != null) {
       equations.setIncludeMassTransfer(include);
+    }
+  }
+
+  /**
+   * Set relaxation time for flash-driven evaporation/condensation source terms.
+   *
+   * @param relaxationTime relaxation time in seconds
+   */
+  public void setMassTransferRelaxationTime(double relaxationTime) {
+    if (equations != null) {
+      equations.setMassTransferRelaxationTime(relaxationTime);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/ThermodynamicCoupling.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/ThermodynamicCoupling.java
@@ -434,6 +434,60 @@ public class ThermodynamicCoupling implements Serializable {
   }
 
   /**
+   * Calculate a conservative flash-driven gas/liquid mass transfer source per pipe length.
+   *
+   * <p>
+   * Positive values mean evaporation from liquid to gas. The target is the equilibrium liquid
+   * inventory from the local PT flash, expressed on the section area. The method returns kg/(m*s),
+   * which can be split conservatively into gas, oil, and water equations by the hydrodynamic
+   * solver.
+   * </p>
+   *
+   * @param section current pipe section
+   * @param relaxationTime relaxation time toward flash equilibrium (s)
+   * @return gas mass source per length, kg/(m*s)
+   */
+  public double calcMassTransferRatePerLength(TwoFluidSection section, double relaxationTime) {
+    if (referenceFluid == null || relaxationTime <= 0.0 || !Double.isFinite(relaxationTime)) {
+      return 0.0;
+    }
+
+    ThermoProperties eqProps = flashPT(section.getPressure(), section.getTemperature());
+    if (!eqProps.converged) {
+      return 0.0;
+    }
+
+    double gasDensity = Math.max(eqProps.gasDensity, 0.1);
+    double liquidDensity = Math.max(eqProps.liquidDensity, 100.0);
+    double gasMolarMass = Math.max(eqProps.gasMolarMass, 1e-6);
+    double liquidMolarMass = Math.max(eqProps.liquidMolarMass, 1e-6);
+
+    double eqGasVolume = Math.max(eqProps.gasVaporFraction, 0.0) * gasMolarMass / gasDensity;
+    double eqLiquidVolume = Math.max(eqProps.liquidFraction, 0.0) * liquidMolarMass / liquidDensity;
+    double totalEquilibriumVolume = eqGasVolume + eqLiquidVolume;
+    if (totalEquilibriumVolume <= 1e-20) {
+      return 0.0;
+    }
+
+    double equilibriumLiquidHoldup = eqLiquidVolume / totalEquilibriumVolume;
+    equilibriumLiquidHoldup = Math.max(0.0, Math.min(1.0, equilibriumLiquidHoldup));
+
+    double currentLiquidMassPerLength = Math.max(0.0, section.getLiquidMassPerLength());
+    if (currentLiquidMassPerLength <= 0.0) {
+      currentLiquidMassPerLength = Math.max(0.0,
+          section.getOilMassPerLength() + section.getWaterMassPerLength());
+    }
+    double equilibriumLiquidMassPerLength =
+        equilibriumLiquidHoldup * liquidDensity * section.getArea();
+
+    double source = (currentLiquidMassPerLength - equilibriumLiquidMassPerLength) / relaxationTime;
+    source = Math.min(source, currentLiquidMassPerLength / relaxationTime);
+    source = Math.max(source, -Math.max(0.0, section.getGasMassPerLength()) / relaxationTime);
+
+    return Double.isFinite(source) ? source : 0.0;
+  }
+
+  /**
    * Calculate mixture sound speed for wave propagation.
    *
    * <p>

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -79,6 +79,8 @@ public class TwoFluidConservationEquations implements Serializable {
   private InterfacialFriction interfacialFriction;
   private FlowRegimeDetector flowRegimeDetector;
   private GeometryCalculator geometryCalc;
+  private EntrainmentDeposition entrainmentDeposition;
+  private ThermodynamicCoupling thermodynamicCoupling;
 
   // Numerical methods
   private AUSMPlusFluxCalculator fluxCalculator;
@@ -87,6 +89,7 @@ public class TwoFluidConservationEquations implements Serializable {
   // Settings
   private boolean includeEnergyEquation = true;
   private boolean includeMassTransfer = false;
+  private double massTransferRelaxationTime = 30.0;
   private double massTransferCoefficient = 0.01; // kg/(m³·s·Pa)
 
   /** Enable heat transfer to surroundings. */
@@ -135,6 +138,7 @@ public class TwoFluidConservationEquations implements Serializable {
     this.interfacialFriction = new InterfacialFriction();
     this.flowRegimeDetector = new FlowRegimeDetector();
     this.geometryCalc = new GeometryCalculator();
+    this.entrainmentDeposition = new EntrainmentDeposition();
     this.fluxCalculator = new AUSMPlusFluxCalculator();
     this.reconstructor = new MUSCLReconstructor();
   }
@@ -322,6 +326,8 @@ public class TwoFluidConservationEquations implements Serializable {
    */
   private void updateClosureRelations(TwoFluidSection[] sections) {
     for (TwoFluidSection sec : sections) {
+      sec.updateThreePhaseProperties();
+
       // Update flow regime
       sec.setFlowRegime(flowRegimeDetector.detectFlowRegime(sec));
 
@@ -349,7 +355,32 @@ public class TwoFluidConservationEquations implements Serializable {
 
       sec.setInterfacialShear(ifResult.interfacialShear);
       sec.setInterfacialWidth(ifResult.interfacialAreaPerLength);
+
+      EntrainmentDeposition.EntrainmentResult entrainment = entrainmentDeposition.calculate(regime,
+          sec.getGasVelocity(), sec.getLiquidVelocity(), sec.getGasDensity(),
+          sec.getLiquidDensity(), sec.getGasViscosity(), sec.getLiquidViscosity(),
+          sec.getSurfaceTension(), sec.getDiameter(), sec.getLiquidHoldup());
+      sec.setEntrainmentFraction(entrainment.entrainmentFraction);
+      sec.setEntrainedDropletDiameter(entrainment.dropletDiameter);
+
+      double severeSluggingNumber = calcSevereSluggingNumber(sec);
+      sec.setSevereSluggingNumber(severeSluggingNumber);
+      sec.setSevereSlugPotential(severeSluggingNumber < 1.0);
     }
+  }
+
+  private double calcSevereSluggingNumber(TwoFluidSection sec) {
+    if (sec.getInclination() <= Math.toRadians(5.0)) {
+      return Double.POSITIVE_INFINITY;
+    }
+
+    double alphaL = Math.max(sec.getLiquidHoldup(), 1e-6);
+    double rhoG = Math.max(sec.getGasDensity(), 0.1);
+    double rhoL = Math.max(sec.getLiquidDensity(), 100.0);
+    double densityContrast = Math.max(rhoL - rhoG, 1.0);
+    double gasFroude = Math.abs(sec.getSuperficialGasVelocity())
+        / Math.sqrt(GRAVITY * sec.getDiameter() * densityContrast / rhoL);
+    return gasFroude / alphaL;
   }
 
   /**
@@ -833,21 +864,46 @@ public class TwoFluidConservationEquations implements Serializable {
   }
 
   /**
-   * Calculate mass transfer between phases (simplified model).
+   * Calculate conservative mass transfer between gas and liquid phases.
    *
    * @param sec Pipe section
    * @return [gasSource, liquidSource] in kg/(m·s)
    */
-  private double[] calcMassTransfer(TwoFluidSection sec) {
-    // Simple relaxation to equilibrium
-    // Would need flash calculation for accurate implementation
-    double Gamma = 0;
+  double[] calcMassTransfer(TwoFluidSection sec) {
+    if (thermodynamicCoupling != null) {
+      double gamma =
+          thermodynamicCoupling.calcMassTransferRatePerLength(sec, massTransferRelaxationTime);
+      return conservedMassTransferPair(gamma);
+    }
 
-    // Placeholder: could use departure from bubble point pressure
-    // Gamma = k * (P - P_bubble)
-    // Positive = evaporation (liquid to gas)
+    double prescribedRate = sec.getMassTransferRate();
+    if (!Double.isFinite(prescribedRate)) {
+      throw new IllegalStateException("Mass transfer rate must be finite");
+    }
 
-    return new double[] {Gamma, -Gamma}; // Mass conserved
+    double gamma = 0.0;
+    if (Math.abs(prescribedRate) > 0.0) {
+      double sectionLength = sec.getLength();
+      if (!Double.isFinite(sectionLength) || sectionLength <= 0.0) {
+        throw new IllegalStateException("Section length must be positive for mass transfer");
+      }
+      gamma = prescribedRate / sectionLength;
+    }
+
+    return conservedMassTransferPair(gamma);
+  }
+
+  private double[] conservedMassTransferPair(double gasSource) {
+    if (!Double.isFinite(gasSource)) {
+      throw new IllegalStateException("Mass transfer source must be finite");
+    }
+
+    double liquidSource = -gasSource;
+    if (Math.abs(gasSource + liquidSource) > 1e-12) {
+      throw new IllegalStateException("Mass transfer source terms must sum to zero");
+    }
+
+    return new double[] {gasSource, liquidSource};
   }
 
   /**
@@ -1008,6 +1064,17 @@ public class TwoFluidConservationEquations implements Serializable {
     this.includeMassTransfer = includeMassTransfer;
   }
 
+  public void setThermodynamicCoupling(ThermodynamicCoupling thermodynamicCoupling) {
+    this.thermodynamicCoupling = thermodynamicCoupling;
+  }
+
+  public void setMassTransferRelaxationTime(double massTransferRelaxationTime) {
+    if (!Double.isFinite(massTransferRelaxationTime) || massTransferRelaxationTime <= 0.0) {
+      throw new IllegalArgumentException("Mass transfer relaxation time must be finite and positive");
+    }
+    this.massTransferRelaxationTime = massTransferRelaxationTime;
+  }
+
   /**
    * Check if water-oil velocity slip modeling is enabled.
    *
@@ -1036,6 +1103,9 @@ public class TwoFluidConservationEquations implements Serializable {
   }
 
   public void setMassTransferCoefficient(double massTransferCoefficient) {
+    if (!Double.isFinite(massTransferCoefficient) || massTransferCoefficient < 0.0) {
+      throw new IllegalArgumentException("Mass transfer coefficient must be finite and non-negative");
+    }
     this.massTransferCoefficient = massTransferCoefficient;
   }
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSection.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSection.java
@@ -5,6 +5,7 @@ import neqsim.process.equipment.pipeline.twophasepipe.closure.GeometryCalculator
 import neqsim.process.equipment.pipeline.twophasepipe.closure.OilWaterFlowRegimeDetector;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.OilWaterFlowRegimeDetector.OilWaterFlowRegime;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.OilWaterFlowRegimeDetector.OilWaterResult;
+import neqsim.process.equipment.pipeline.twophasepipe.numerics.ConservativeStateLimiter;
 
 /**
  * Extended pipe section state for the two-fluid model.
@@ -175,6 +176,15 @@ public class TwoFluidSection extends PipeSection {
   /** Current oil-water flow regime result (null until first detection). */
   private transient OilWaterResult oilWaterResult;
 
+  /** Liquid entrainment fraction in annular/mist flow. */
+  private double entrainmentFraction = 0.0;
+
+  /** Characteristic entrained droplet diameter (m). */
+  private double entrainedDropletDiameter = 0.0;
+
+  /** Severe slugging stability number. Values below 1 indicate elevated risk. */
+  private double severeSluggingNumber = Double.POSITIVE_INFINITY;
+
   /**
    * Default constructor.
    */
@@ -303,32 +313,22 @@ public class TwoFluidSection extends PipeSection {
    *
    * <p>
    * This is the inverse operation of updateConservativeVariables. Requires equation of state
-   * evaluation for complete solution. Includes stability guards to prevent NaN values.
+   * evaluation for complete solution. Conservative positivity limiting is applied before
+   * converting to primitive variables.
    * </p>
    */
   public void extractPrimitiveVariables() {
     double A = getArea();
 
-    // Guard against negative or NaN conservative variables
-    gasMassPerLength = Math.max(0, gasMassPerLength);
-    oilMassPerLength = Math.max(0, oilMassPerLength);
-    waterMassPerLength = Math.max(0, waterMassPerLength);
+    double[] conservativeState = getStateVector();
+    ConservativeStateLimiter.enforceThreePhaseMassPositivity(conservativeState, null);
+    setStateVector(conservativeState);
     liquidMassPerLength = oilMassPerLength + waterMassPerLength;
+    liquidMomentumPerLength = oilMomentumPerLength + waterMomentumPerLength;
 
-    if (Double.isNaN(gasMassPerLength))
-      gasMassPerLength = 0;
-    if (Double.isNaN(oilMassPerLength))
-      oilMassPerLength = 0;
-    if (Double.isNaN(waterMassPerLength))
-      waterMassPerLength = 0;
-    if (Double.isNaN(liquidMassPerLength))
-      liquidMassPerLength = 0;
-    if (Double.isNaN(gasMomentumPerLength))
-      gasMomentumPerLength = 0;
-    if (Double.isNaN(liquidMomentumPerLength))
-      liquidMomentumPerLength = 0;
-    if (Double.isNaN(energyPerLength))
+    if (!Double.isFinite(energyPerLength)) {
       energyPerLength = 0;
+    }
 
     // Extract holdups from mass per length
     double rhoG = getGasDensity();
@@ -1123,6 +1123,31 @@ public class TwoFluidSection extends PipeSection {
    */
   public boolean isWaterDropoutRisk() {
     return oilWaterResult != null ? oilWaterResult.waterDropoutRisk : false;
+  }
+
+  public double getEntrainmentFraction() {
+    return entrainmentFraction;
+  }
+
+  public void setEntrainmentFraction(double entrainmentFraction) {
+    this.entrainmentFraction = Math.max(0.0, Math.min(1.0, entrainmentFraction));
+  }
+
+  public double getEntrainedDropletDiameter() {
+    return entrainedDropletDiameter;
+  }
+
+  public void setEntrainedDropletDiameter(double entrainedDropletDiameter) {
+    this.entrainedDropletDiameter = Math.max(0.0, entrainedDropletDiameter);
+  }
+
+  public double getSevereSluggingNumber() {
+    return severeSluggingNumber;
+  }
+
+  public void setSevereSluggingNumber(double severeSluggingNumber) {
+    this.severeSluggingNumber =
+        Double.isFinite(severeSluggingNumber) ? severeSluggingNumber : Double.POSITIVE_INFINITY;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/ConservativeStateLimiter.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/ConservativeStateLimiter.java
@@ -1,0 +1,151 @@
+package neqsim.process.equipment.pipeline.twophasepipe.numerics;
+
+/**
+ * Conservative state limiters for transient two-fluid numerics.
+ */
+public final class ConservativeStateLimiter {
+  private static final double EPS = 1e-12;
+
+  private ConservativeStateLimiter() {}
+
+  /**
+   * Enforce non-negative gas, oil, and water masses while preserving total mass whenever the
+   * incoming cell state has a positive total inventory.
+   *
+   * <p>
+   * Momentum is scaled with the phase mass correction so phase velocities are preserved. If the
+   * total mass is non-positive, positivity and conservation cannot both be satisfied; the method
+   * then falls back to the previous finite state when available.
+   * </p>
+   *
+   * @param state conservative cell state [gasMass, oilMass, waterMass, gasMom, oilMom, waterMom,
+   *        energy]
+   * @param fallback previous finite conservative state, or {@code null}
+   */
+  public static void enforceThreePhaseMassPositivity(double[] state, double[] fallback) {
+    if (state == null || state.length == 0) {
+      return;
+    }
+
+    if (hasNonFinite(state)) {
+      restoreFiniteFallback(state, fallback);
+    }
+
+    int massCount = Math.min(3, state.length);
+    double totalMass = 0.0;
+    double positiveMass = 0.0;
+    boolean hasNegativeMass = false;
+
+    for (int i = 0; i < massCount; i++) {
+      double mass = state[i];
+      if (!Double.isFinite(mass)) {
+        restoreFiniteFallback(state, fallback);
+        return;
+      }
+      totalMass += mass;
+      if (mass < 0.0) {
+        hasNegativeMass = true;
+      } else {
+        positiveMass += mass;
+      }
+    }
+
+    if (!hasNegativeMass) {
+      return;
+    }
+
+    if (totalMass > EPS && positiveMass > EPS) {
+      redistributePositiveMass(state, massCount, totalMass, positiveMass);
+      return;
+    }
+
+    if (fallbackHasPositiveMass(fallback, massCount)) {
+      restoreFiniteFallback(state, fallback);
+    } else {
+      zeroMassAndMomentum(state, massCount);
+    }
+  }
+
+  private static boolean hasNonFinite(double[] state) {
+    for (double value : state) {
+      if (!Double.isFinite(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void restoreFiniteFallback(double[] state, double[] fallback) {
+    if (fallback != null) {
+      int n = Math.min(state.length, fallback.length);
+      boolean fallbackFinite = true;
+      for (int i = 0; i < n; i++) {
+        if (!Double.isFinite(fallback[i])) {
+          fallbackFinite = false;
+          break;
+        }
+      }
+      if (fallbackFinite) {
+        System.arraycopy(fallback, 0, state, 0, n);
+        for (int i = n; i < state.length; i++) {
+          if (!Double.isFinite(state[i])) {
+            state[i] = 0.0;
+          }
+        }
+        return;
+      }
+    }
+
+    for (int i = 0; i < state.length; i++) {
+      if (!Double.isFinite(state[i])) {
+        state[i] = 0.0;
+      }
+    }
+  }
+
+  private static void redistributePositiveMass(double[] state, int massCount, double totalMass,
+      double positiveMass) {
+    double massScale = totalMass / positiveMass;
+
+    for (int i = 0; i < massCount; i++) {
+      double oldMass = state[i];
+      double newMass = oldMass > 0.0 ? oldMass * massScale : 0.0;
+      int momentumIndex = i + 3;
+
+      if (momentumIndex < state.length) {
+        if (oldMass > EPS && Double.isFinite(state[momentumIndex])) {
+          state[momentumIndex] *= newMass / oldMass;
+        } else {
+          state[momentumIndex] = 0.0;
+        }
+      }
+
+      state[i] = newMass;
+    }
+  }
+
+  private static boolean fallbackHasPositiveMass(double[] fallback, int massCount) {
+    if (fallback == null || fallback.length < massCount) {
+      return false;
+    }
+
+    double totalMass = 0.0;
+    for (int i = 0; i < massCount; i++) {
+      if (!Double.isFinite(fallback[i]) || fallback[i] < 0.0) {
+        return false;
+      }
+      totalMass += fallback[i];
+    }
+    return totalMass > EPS;
+  }
+
+  private static void zeroMassAndMomentum(double[] state, int massCount) {
+    for (int i = 0; i < massCount; i++) {
+      state[i] = 0.0;
+      int momentumIndex = i + 3;
+      if (momentumIndex < state.length) {
+        state[momentumIndex] = 0.0;
+      }
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
@@ -439,6 +439,14 @@ public class TimeIntegrator implements Serializable {
   /** Cell-averaged mixture densities for IMEX pressure solve. Set by caller before step. */
   private double[] cellDensities;
 
+  /** Cell cross-sectional areas for IMEX pressure/mass corrections. */
+  private double[] cellAreas;
+
+  /** Phase densities for IMEX phase-area momentum correction. */
+  private double[] cellGasDensities;
+  private double[] cellOilDensities;
+  private double[] cellWaterDensities;
+
   /** Cell size for IMEX pressure solve (m). Set by caller before step. */
   private double imexDx = 1.0;
 
@@ -462,9 +470,36 @@ public class TimeIntegrator implements Serializable {
       double outletPressure, boolean outletFixed) {
     this.cellSoundSpeeds = soundSpeeds;
     this.cellDensities = densities;
+    this.cellAreas = null;
+    this.cellGasDensities = null;
+    this.cellOilDensities = null;
+    this.cellWaterDensities = null;
     this.imexDx = dx;
     this.imexOutletPressure = outletPressure;
     this.imexOutletPressureFixed = outletFixed;
+  }
+
+  /**
+   * Set cell and phase properties required for a dimensionally consistent IMEX pressure correction.
+   *
+   * @param soundSpeeds mixture sound speed per cell (m/s)
+   * @param densities mixture density per cell (kg/m3)
+   * @param areas pipe cross-sectional area per cell (m2)
+   * @param gasDensities gas density per cell (kg/m3)
+   * @param oilDensities oil density per cell (kg/m3)
+   * @param waterDensities water density per cell (kg/m3)
+   * @param dx cell size (m)
+   * @param outletPressure outlet boundary pressure (Pa)
+   * @param outletFixed true if outlet pressure is a Dirichlet BC
+   */
+  public void setIMEXProperties(double[] soundSpeeds, double[] densities, double[] areas,
+      double[] gasDensities, double[] oilDensities, double[] waterDensities, double dx,
+      double outletPressure, boolean outletFixed) {
+    setIMEXProperties(soundSpeeds, densities, dx, outletPressure, outletFixed);
+    this.cellAreas = areas;
+    this.cellGasDensities = gasDensities;
+    this.cellOilDensities = oilDensities;
+    this.cellWaterDensities = waterDensities;
   }
 
   /**
@@ -548,16 +583,16 @@ public class TimeIntegrator implements Serializable {
 
     for (int i = 0; i < nCells; i++) {
       double sig = sigma[i];
-      double rho = Math.max(cellDensities[i], 0.1);
       double c = Math.max(cellSoundSpeeds[i], 1.0);
+      double area = getCellArea(i);
 
       diag[i] = 1.0 + 2.0 * sig;
       lower[i] = -sig;
       upper[i] = -sig;
 
       // RHS: pressure correction to absorb the mass residual
-      // dp ~ -c^2 * (mass_residual / rho) to restore proper density-pressure coupling
-      b[i] = -c * c * massResidual[i] / (rho * imexDx);
+      // mass per length = area * density, and density correction is dp / c^2.
+      b[i] = -c * c * massResidual[i] / area;
     }
 
     // Boundary conditions for pressure correction
@@ -600,11 +635,10 @@ public class TimeIntegrator implements Serializable {
         dpdx = (dp[i + 1] - dp[i - 1]) / (2.0 * imexDx);
       }
 
-      // Correct mass equations with implicit pressure contribution
-      // The pressure correction modifies the mass flux divergence
-      double rho = Math.max(cellDensities[i], 0.1);
+      // Correct mass equations with implicit pressure contribution.
       double c = Math.max(cellSoundSpeeds[i], 1.0);
-      double massCorrectionTotal = dp[i] * rho / (c * c) * imexDx;
+      double area = getCellArea(i);
+      double massCorrectionTotal = area * dp[i] / (c * c);
 
       // Distribute mass correction proportionally to existing phase masses
       double totalMass = 0;
@@ -619,26 +653,78 @@ public class TimeIntegrator implements Serializable {
         }
       }
 
-      // Correct momentum equations: subtract pressure gradient
+      // Correct momentum equations using the two-fluid pressure source:
+      // d(alpha_k * rho_k * v_k * A)/dt = -alpha_k * A * dp/dx.
       // Gas momentum (index 3), Oil momentum (index 4), Water momentum (index 5)
+      double gasAreaFallback =
+          (totalMass > 1e-12 && nMassEq > 0) ? Math.max(Ustar[i][0], 0) / totalMass * area : 0.0;
+      double oilAreaFallback =
+          (totalMass > 1e-12 && nMassEq > 1) ? Math.max(Ustar[i][1], 0) / totalMass * area : 0.0;
+      double waterAreaFallback =
+          (totalMass > 1e-12 && nMassEq > 2) ? Math.max(Ustar[i][2], 0) / totalMass * area : 0.0;
+
+      double gasArea = (nVars > 3) ? getPhaseArea(i, Ustar[i][0], cellGasDensities,
+          gasAreaFallback) : 0.0;
+      double oilArea = (nVars > 4) ? getPhaseArea(i, Ustar[i][1], cellOilDensities,
+          oilAreaFallback) : 0.0;
+      double waterArea = (nVars > 5) ? getPhaseArea(i, Ustar[i][2], cellWaterDensities,
+          waterAreaFallback) : 0.0;
+
+      double totalPhaseArea = gasArea + oilArea + waterArea;
+      if (totalPhaseArea > area && totalPhaseArea > 1e-12) {
+        double areaScale = area / totalPhaseArea;
+        gasArea *= areaScale;
+        oilArea *= areaScale;
+        waterArea *= areaScale;
+      }
+
       if (nVars > 3) {
-        // Gas momentum correction
-        double gasAlpha = (totalMass > 1e-12) ? Math.max(Ustar[i][0], 0) / totalMass : 0.33;
-        Unew[i][3] = Ustar[i][3] - dt * gasAlpha * dpdx;
+        Unew[i][3] = Ustar[i][3] - dt * gasArea * dpdx;
       }
       if (nVars > 4) {
-        // Oil momentum correction
-        double oilAlpha = (totalMass > 1e-12) ? Math.max(Ustar[i][1], 0) / totalMass : 0.33;
-        Unew[i][4] = Ustar[i][4] - dt * oilAlpha * dpdx;
+        Unew[i][4] = Ustar[i][4] - dt * oilArea * dpdx;
       }
       if (nVars > 5) {
-        // Water momentum correction
-        double waterAlpha = (totalMass > 1e-12) ? Math.max(Ustar[i][2], 0) / totalMass : 0.33;
-        Unew[i][5] = Ustar[i][5] - dt * waterAlpha * dpdx;
+        Unew[i][5] = Ustar[i][5] - dt * waterArea * dpdx;
       }
     }
 
     return Unew;
+  }
+
+  /**
+   * Get cross-sectional area for a cell, falling back to unit area for legacy API users.
+   *
+   * @param cellIndex cell index
+   * @return cross-sectional area (m2)
+   */
+  private double getCellArea(int cellIndex) {
+    if (cellAreas != null && cellIndex < cellAreas.length && cellAreas[cellIndex] > 1e-12) {
+      return cellAreas[cellIndex];
+    }
+    return 1.0;
+  }
+
+  /**
+   * Convert phase mass per length to phase area alpha*A using the phase density.
+   *
+   * @param cellIndex cell index
+   * @param massPerLength phase mass per length (kg/m)
+   * @param phaseDensities phase densities (kg/m3)
+   * @param fallbackArea fallback phase area (m2)
+   * @return phase area (m2)
+   */
+  private double getPhaseArea(int cellIndex, double massPerLength, double[] phaseDensities,
+      double fallbackArea) {
+    if (massPerLength <= 0.0) {
+      return 0.0;
+    }
+    if (phaseDensities != null && cellIndex < phaseDensities.length
+        && phaseDensities[cellIndex] > 1e-12) {
+      double phaseArea = massPerLength / phaseDensities[cellIndex];
+      return Math.max(0.0, Math.min(getCellArea(cellIndex), phaseArea));
+    }
+    return Math.max(0.0, Math.min(getCellArea(cellIndex), fallbackArea));
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReport.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReport.java
@@ -1,0 +1,328 @@
+package neqsim.process.equipment.pipeline.twophasepipe.reporting;
+
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
+import neqsim.process.equipment.pipeline.twophasepipe.validation.TwoFluidBenchmarkHarness;
+
+/**
+ * Reporting helpers for {@link TwoFluidPipe} profiles, summaries, and benchmark comparisons.
+ */
+public final class TwoFluidPipeReport {
+  private TwoFluidPipeReport() {}
+
+  /**
+   * Immutable snapshot of the profile arrays at one simulation time.
+   */
+  public static final class ProfileSnapshot {
+    private final double timeSeconds;
+    private final double[] positionMeters;
+    private final double[] pressurePa;
+    private final double[] temperatureK;
+    private final double[] liquidHoldup;
+    private final double[] waterCut;
+    private final double[] oilHoldup;
+    private final double[] waterHoldup;
+    private final double[] gasVelocity;
+    private final double[] liquidVelocity;
+    private final double[] oilVelocity;
+    private final double[] waterVelocity;
+    private final FlowRegime[] flowRegime;
+
+    private ProfileSnapshot(TwoFluidPipe pipe) {
+      this.timeSeconds = pipe.getSimulationTime();
+      this.positionMeters = pipe.getPositionProfile();
+      this.pressurePa = pipe.getPressureProfile();
+      this.temperatureK = pipe.getTemperatureProfile();
+      this.liquidHoldup = pipe.getLiquidHoldupProfile();
+      this.waterCut = pipe.getWaterCutProfile();
+      this.oilHoldup = pipe.getOilHoldupProfile();
+      this.waterHoldup = pipe.getWaterHoldupProfile();
+      this.gasVelocity = pipe.getGasVelocityProfile();
+      this.liquidVelocity = pipe.getLiquidVelocityProfile();
+      this.oilVelocity = pipe.getOilVelocityProfile();
+      this.waterVelocity = pipe.getWaterVelocityProfile();
+      this.flowRegime = pipe.getFlowRegimeProfile();
+    }
+
+    public double getTimeSeconds() {
+      return timeSeconds;
+    }
+  }
+
+  /**
+   * Capture all reportable pipe profiles at the current simulation time.
+   *
+   * @param pipe solved pipe
+   * @return profile snapshot
+   */
+  public static ProfileSnapshot capture(TwoFluidPipe pipe) {
+    return new ProfileSnapshot(pipe);
+  }
+
+  /**
+   * Export the current pipe profile as CSV.
+   *
+   * @param pipe solved pipe
+   * @return CSV text
+   */
+  public static String toSteadyStateProfileCsv(TwoFluidPipe pipe) {
+    return toProfileCsvRows(capture(pipe), false);
+  }
+
+  /**
+   * Export transient snapshots as time-position CSV.
+   *
+   * @param snapshots profile snapshots collected during transient simulation
+   * @return CSV text
+   */
+  public static String toTransientProfileCsv(List<ProfileSnapshot> snapshots) {
+    StringBuilder csv = new StringBuilder();
+    boolean headerWritten = false;
+    for (ProfileSnapshot snapshot : snapshots) {
+      String rows = toProfileCsvRows(snapshot, true);
+      if (!headerWritten) {
+        csv.append(rows);
+        headerWritten = true;
+      } else {
+        int firstNewline = rows.indexOf('\n');
+        if (firstNewline >= 0 && firstNewline + 1 < rows.length()) {
+          csv.append(rows.substring(firstNewline + 1));
+        }
+      }
+    }
+    return csv.toString();
+  }
+
+  /**
+   * Build a concise text summary of the solved pipe.
+   *
+   * @param pipe solved pipe
+   * @return text summary
+   */
+  public static String toSummaryText(TwoFluidPipe pipe) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("TwoFluidPipe summary: ").append(pipe.getName()).append(System.lineSeparator());
+    sb.append(String.format(Locale.ROOT, "Simulation time: %.3f s%n", pipe.getSimulationTime()));
+    sb.append(String.format(Locale.ROOT, "Inlet pressure: %.3f bara%n", pipe.getInletPressure()));
+    sb.append(String.format(Locale.ROOT, "Outlet pressure: %.3f bara%n", pipe.getOutletPressure()));
+    sb.append(String.format(Locale.ROOT, "Average liquid holdup: %.5f%n",
+        pipe.getAverageLiquidHoldup()));
+    sb.append("Dominant flow regime: ").append(pipe.getDominantFlowRegime())
+        .append(System.lineSeparator());
+    sb.append(String.format(Locale.ROOT, "Liquid inventory: %.5f m3%n",
+        pipe.getLiquidInventory("m3")));
+    sb.append(String.format(Locale.ROOT, "Maximum mixture velocity: %.5f m/s%n",
+        pipe.getMaxMixtureVelocity()));
+    sb.append(String.format(Locale.ROOT, "Erosional velocity margin: %.5f%n",
+        pipe.getErosionalVelocityMargin(122.0)));
+    sb.append(String.format(Locale.ROOT, "Hydrate risk sections: %d%n",
+        pipe.getHydrateRiskSectionCount()));
+    sb.append("Wax risk: ").append(pipe.hasWaxRisk()).append(System.lineSeparator());
+    sb.append(String.format(Locale.ROOT, "Outlet slug count: %d%n", pipe.getOutletSlugCount()));
+    sb.append(String.format(Locale.ROOT, "Total outlet slug volume: %.5f m3%n",
+        pipe.getTotalSlugVolumeAtOutlet()));
+    return sb.toString();
+  }
+
+  /**
+   * Build a JSON summary of key pipe results.
+   *
+   * @param pipe solved pipe
+   * @return JSON text
+   */
+  public static String toSummaryJson(TwoFluidPipe pipe) {
+    Map<String, Object> summary = new LinkedHashMap<>();
+    summary.put("name", pipe.getName());
+    summary.put("simulationTimeSeconds", pipe.getSimulationTime());
+    summary.put("inletPressureBara", pipe.getInletPressure());
+    summary.put("outletPressureBara", pipe.getOutletPressure());
+    summary.put("averageLiquidHoldup", pipe.getAverageLiquidHoldup());
+    summary.put("dominantFlowRegime", pipe.getDominantFlowRegime());
+    summary.put("liquidInventoryM3", pipe.getLiquidInventory("m3"));
+    summary.put("averageMixtureDensityKgM3", pipe.getAverageMixtureDensity());
+    summary.put("maximumMixtureVelocityMS", pipe.getMaxMixtureVelocity());
+    summary.put("erosionalVelocityMargin", pipe.getErosionalVelocityMargin(122.0));
+    summary.put("hydrateRiskSectionCount", pipe.getHydrateRiskSectionCount());
+    summary.put("hasWaxRisk", pipe.hasWaxRisk());
+    summary.put("outletSlugCount", pipe.getOutletSlugCount());
+    summary.put("totalSlugVolumeAtOutletM3", pipe.getTotalSlugVolumeAtOutlet());
+    summary.put("maxSlugLengthAtOutletM", pipe.getMaxSlugLengthAtOutlet());
+    summary.put("maxSlugVolumeAtOutletM3", pipe.getMaxSlugVolumeAtOutlet());
+    return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create()
+        .toJson(summary);
+  }
+
+  /**
+   * Export slug and flow-assurance events as CSV.
+   *
+   * @param pipe solved pipe
+   * @return CSV text
+   */
+  public static String toSlugAndFlowAssuranceCsv(TwoFluidPipe pipe) {
+    StringBuilder csv = new StringBuilder();
+    csv.append("event_type,position_m,value,unit,description\n");
+    csv.append(csvRow("slug_count", "", pipe.getOutletSlugCount(), "count", "Outlet slug count"));
+    csv.append(csvRow("slug_volume_total", "", pipe.getTotalSlugVolumeAtOutlet(), "m3",
+        "Total outlet slug volume"));
+    csv.append(csvRow("slug_length_max", "", pipe.getMaxSlugLengthAtOutlet(), "m",
+        "Maximum outlet slug length"));
+    csv.append(csvRow("slug_volume_max", "", pipe.getMaxSlugVolumeAtOutlet(), "m3",
+        "Maximum outlet slug volume"));
+
+    double hydrateDistance = pipe.getDistanceToHydrateRisk();
+    if (hydrateDistance >= 0.0) {
+      csv.append(csvRow("hydrate_risk_first", hydrateDistance, 1.0, "flag",
+          "First section below hydrate risk temperature"));
+    }
+    csv.append(csvRow("hydrate_risk_count", "", pipe.getHydrateRiskSectionCount(), "count",
+        "Number of hydrate risk sections"));
+    csv.append(csvRow("wax_risk", "", pipe.hasWaxRisk() ? 1.0 : 0.0, "flag",
+        "At least one section below wax appearance temperature"));
+    csv.append(csvRow("erosion_margin", "", pipe.getErosionalVelocityMargin(122.0), "ratio",
+        "Maximum mixture velocity divided by API 14E erosional velocity"));
+    return csv.toString();
+  }
+
+  /**
+   * Export benchmark comparison results as CSV.
+   *
+   * @param comparison benchmark comparison
+   * @return CSV text
+   */
+  public static String toComparisonCsv(TwoFluidBenchmarkHarness.Comparison comparison) {
+    StringBuilder csv = new StringBuilder();
+    csv.append("case,time_s,position_m,variable,reference,model,abs_error,rel_error,passed,source\n");
+    for (TwoFluidBenchmarkHarness.ComparisonRow row : comparison.getRows()) {
+      TwoFluidBenchmarkHarness.BenchmarkPoint point = row.getReference();
+      csv.append(escape(point.getCaseName())).append(',')
+          .append(format(point.getTimeSeconds())).append(',')
+          .append(format(point.getPositionMeters())).append(',')
+          .append(escape(point.getVariable())).append(',')
+          .append(format(point.getValue())).append(',')
+          .append(format(row.getModelValue())).append(',')
+          .append(format(row.getAbsoluteError())).append(',')
+          .append(format(row.getRelativeError())).append(',')
+          .append(row.isPassed()).append(',')
+          .append(escape(point.getSource())).append('\n');
+    }
+    return csv.toString();
+  }
+
+  public static void writeSteadyStateProfileCsv(TwoFluidPipe pipe, Path path) throws IOException {
+    write(path, toSteadyStateProfileCsv(pipe));
+  }
+
+  public static void writeTransientProfileCsv(List<ProfileSnapshot> snapshots, Path path)
+      throws IOException {
+    write(path, toTransientProfileCsv(snapshots));
+  }
+
+  public static void writeSummaryText(TwoFluidPipe pipe, Path path) throws IOException {
+    write(path, toSummaryText(pipe));
+  }
+
+  public static void writeSummaryJson(TwoFluidPipe pipe, Path path) throws IOException {
+    write(path, toSummaryJson(pipe));
+  }
+
+  public static void writeSlugAndFlowAssuranceCsv(TwoFluidPipe pipe, Path path) throws IOException {
+    write(path, toSlugAndFlowAssuranceCsv(pipe));
+  }
+
+  public static void writeComparisonCsv(TwoFluidBenchmarkHarness.Comparison comparison, Path path)
+      throws IOException {
+    write(path, toComparisonCsv(comparison));
+  }
+
+  private static String toProfileCsvRows(ProfileSnapshot snapshot, boolean includeTime) {
+    validateProfileLengths(snapshot);
+    StringBuilder csv = new StringBuilder();
+    if (includeTime) {
+      csv.append("time_s,");
+    }
+    csv.append("position_m,pressure_bara,temperature_C,liquid_holdup,water_cut,oil_holdup,")
+        .append("water_holdup,gas_velocity_m_s,liquid_velocity_m_s,oil_velocity_m_s,")
+        .append("water_velocity_m_s,flow_regime\n");
+
+    for (int i = 0; i < snapshot.positionMeters.length; i++) {
+      if (includeTime) {
+        csv.append(format(snapshot.timeSeconds)).append(',');
+      }
+      csv.append(format(snapshot.positionMeters[i])).append(',')
+          .append(format(snapshot.pressurePa[i] * 1.0e-5)).append(',')
+          .append(format(snapshot.temperatureK[i] - 273.15)).append(',')
+          .append(format(snapshot.liquidHoldup[i])).append(',')
+          .append(format(valueAt(snapshot.waterCut, i))).append(',')
+          .append(format(valueAt(snapshot.oilHoldup, i))).append(',')
+          .append(format(valueAt(snapshot.waterHoldup, i))).append(',')
+          .append(format(valueAt(snapshot.gasVelocity, i))).append(',')
+          .append(format(valueAt(snapshot.liquidVelocity, i))).append(',')
+          .append(format(valueAt(snapshot.oilVelocity, i))).append(',')
+          .append(format(valueAt(snapshot.waterVelocity, i))).append(',')
+          .append(snapshot.flowRegime.length > i && snapshot.flowRegime[i] != null
+              ? snapshot.flowRegime[i].name()
+              : "")
+          .append('\n');
+    }
+    return csv.toString();
+  }
+
+  private static void validateProfileLengths(ProfileSnapshot snapshot) {
+    int n = snapshot.positionMeters.length;
+    if (snapshot.pressurePa.length != n || snapshot.temperatureK.length != n
+        || snapshot.liquidHoldup.length != n) {
+      throw new IllegalStateException("Core TwoFluidPipe profile lengths differ");
+    }
+  }
+
+  private static double valueAt(double[] values, int index) {
+    return values.length > index ? values[index] : Double.NaN;
+  }
+
+  private static String csvRow(String type, Object position, double value, String unit,
+      String description) {
+    return escape(type) + "," + escape(String.valueOf(position)) + "," + format(value) + ","
+        + escape(unit) + "," + escape(description) + "\n";
+  }
+
+  private static String escape(String value) {
+    if (value == null) {
+      return "";
+    }
+    if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+      return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+    return value;
+  }
+
+  private static String format(double value) {
+    return String.format(Locale.ROOT, "%.10g", value);
+  }
+
+  private static void write(Path path, String content) throws IOException {
+    Path parent = path.toAbsolutePath().getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Convenience container for collecting transient snapshots.
+   *
+   * @return mutable snapshot list
+   */
+  public static List<ProfileSnapshot> newSnapshotList() {
+    return new ArrayList<>();
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
@@ -1,0 +1,398 @@
+package neqsim.process.equipment.pipeline.twophasepipe.validation;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+
+/**
+ * Benchmark comparison harness for TwoFluidPipe profiles against external simulator or field data.
+ *
+ * <p>
+ * The expected CSV columns are:
+ * {@code case,time_s,position_m,variable,value,abs_tolerance,rel_tolerance,source}. This intentionally
+ * uses a simple numeric export format that can be produced from OLGA, LedaFlow, field historians, or
+ * spreadsheet post-processing.
+ * </p>
+ */
+public final class TwoFluidBenchmarkHarness {
+  private TwoFluidBenchmarkHarness() {}
+
+  /**
+   * Read benchmark points from a comma-separated file.
+   *
+   * @param csvPath CSV file path
+   * @return benchmark points
+   * @throws IOException if the file cannot be read
+   */
+  public static List<BenchmarkPoint> readCsv(Path csvPath) throws IOException {
+    List<String> lines = Files.readAllLines(csvPath, StandardCharsets.UTF_8);
+    if (lines.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    Map<String, Integer> header = parseHeader(lines.get(0));
+    List<BenchmarkPoint> points = new ArrayList<>();
+    for (int i = 1; i < lines.size(); i++) {
+      String line = lines.get(i).trim();
+      if (line.isEmpty() || line.startsWith("#")) {
+        continue;
+      }
+
+      String[] fields = line.split(",", -1);
+      points.add(new BenchmarkPoint(getString(fields, header, "case", ""),
+          getDouble(fields, header, "time_s", 0.0), getDouble(fields, header, "position_m", 0.0),
+          getString(fields, header, "variable", ""), getDouble(fields, header, "value", 0.0),
+          getDouble(fields, header, "abs_tolerance", 0.0),
+          getDouble(fields, header, "rel_tolerance", 0.0),
+          getString(fields, header, "source", "")));
+    }
+    return points;
+  }
+
+  /**
+   * Capture a steady-state or transient snapshot from a pipe.
+   *
+   * @param pipe solved pipe model
+   * @return benchmark snapshot
+   */
+  public static Snapshot capture(TwoFluidPipe pipe) {
+    Map<String, double[]> variables = new HashMap<>();
+    double[] pressurePa = pipe.getPressureProfile();
+    variables.put("pressure_pa", pressurePa);
+    variables.put("pressure_bara", scale(pressurePa, 1.0e-5));
+    variables.put("temperature_k", pipe.getTemperatureProfile());
+    variables.put("liquid_holdup", pipe.getLiquidHoldupProfile());
+    variables.put("water_cut", pipe.getWaterCutProfile());
+    variables.put("oil_holdup", pipe.getOilHoldupProfile());
+    variables.put("water_holdup", pipe.getWaterHoldupProfile());
+    variables.put("gas_velocity_m_s", pipe.getGasVelocityProfile());
+    variables.put("liquid_velocity_m_s", pipe.getLiquidVelocityProfile());
+    variables.put("oil_velocity_m_s", pipe.getOilVelocityProfile());
+    variables.put("water_velocity_m_s", pipe.getWaterVelocityProfile());
+    return new Snapshot(pipe.getSimulationTime(), pipe.getPositionProfile(), variables);
+  }
+
+  /**
+   * Compare one snapshot against benchmark points.
+   *
+   * @param snapshot model snapshot
+   * @param referencePoints reference points
+   * @return comparison result
+   */
+  public static Comparison compare(Snapshot snapshot, List<BenchmarkPoint> referencePoints) {
+    return compare(Collections.singletonList(snapshot), referencePoints);
+  }
+
+  /**
+   * Compare transient snapshots against benchmark points using linear interpolation in time and
+   * position.
+   *
+   * @param snapshots model snapshots
+   * @param referencePoints reference points
+   * @return comparison result
+   */
+  public static Comparison compare(List<Snapshot> snapshots, List<BenchmarkPoint> referencePoints) {
+    if (snapshots == null || snapshots.isEmpty()) {
+      throw new IllegalArgumentException("At least one model snapshot is required");
+    }
+
+    List<Snapshot> sortedSnapshots = new ArrayList<>(snapshots);
+    sortedSnapshots.sort(Comparator.comparingDouble(Snapshot::getTimeSeconds));
+
+    List<ComparisonRow> rows = new ArrayList<>();
+    for (BenchmarkPoint point : referencePoints) {
+      double modelValue = interpolate(sortedSnapshots, point);
+      rows.add(new ComparisonRow(point, modelValue));
+    }
+    return new Comparison(rows);
+  }
+
+  private static double interpolate(List<Snapshot> snapshots, BenchmarkPoint point) {
+    if (snapshots.size() == 1) {
+      return snapshots.get(0).valueAt(point.getVariable(), point.getPositionMeters());
+    }
+
+    Snapshot lower = snapshots.get(0);
+    Snapshot upper = snapshots.get(snapshots.size() - 1);
+    for (int i = 0; i < snapshots.size() - 1; i++) {
+      Snapshot left = snapshots.get(i);
+      Snapshot right = snapshots.get(i + 1);
+      if (point.getTimeSeconds() >= left.getTimeSeconds()
+          && point.getTimeSeconds() <= right.getTimeSeconds()) {
+        lower = left;
+        upper = right;
+        break;
+      }
+    }
+
+    double lowerValue = lower.valueAt(point.getVariable(), point.getPositionMeters());
+    double upperValue = upper.valueAt(point.getVariable(), point.getPositionMeters());
+    double dt = upper.getTimeSeconds() - lower.getTimeSeconds();
+    if (Math.abs(dt) < 1e-12) {
+      return lowerValue;
+    }
+
+    double fraction = (point.getTimeSeconds() - lower.getTimeSeconds()) / dt;
+    fraction = Math.max(0.0, Math.min(1.0, fraction));
+    return lowerValue + fraction * (upperValue - lowerValue);
+  }
+
+  private static Map<String, Integer> parseHeader(String line) {
+    String[] fields = line.split(",", -1);
+    Map<String, Integer> header = new HashMap<>();
+    for (int i = 0; i < fields.length; i++) {
+      header.put(normalize(fields[i]), i);
+    }
+    return header;
+  }
+
+  private static String getString(String[] fields, Map<String, Integer> header, String key,
+      String defaultValue) {
+    Integer index = header.get(normalize(key));
+    if (index == null || index >= fields.length) {
+      return defaultValue;
+    }
+    return fields[index].trim();
+  }
+
+  private static double getDouble(String[] fields, Map<String, Integer> header, String key,
+      double defaultValue) {
+    String value = getString(fields, header, key, "");
+    if (value.isEmpty()) {
+      return defaultValue;
+    }
+    return Double.parseDouble(value);
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+  }
+
+  private static double[] scale(double[] values, double factor) {
+    double[] scaled = new double[values.length];
+    for (int i = 0; i < values.length; i++) {
+      scaled[i] = values[i] * factor;
+    }
+    return scaled;
+  }
+
+  /** One reference sample from an external simulator or field data set. */
+  public static final class BenchmarkPoint {
+    private final String caseName;
+    private final double timeSeconds;
+    private final double positionMeters;
+    private final String variable;
+    private final double value;
+    private final double absoluteTolerance;
+    private final double relativeTolerance;
+    private final String source;
+
+    public BenchmarkPoint(String caseName, double timeSeconds, double positionMeters,
+        String variable, double value, double absoluteTolerance, double relativeTolerance,
+        String source) {
+      if (!Double.isFinite(timeSeconds) || !Double.isFinite(positionMeters)
+          || !Double.isFinite(value) || !Double.isFinite(absoluteTolerance)
+          || !Double.isFinite(relativeTolerance)) {
+        throw new IllegalArgumentException("Benchmark point contains non-finite numeric values");
+      }
+      if (absoluteTolerance < 0.0 || relativeTolerance < 0.0) {
+        throw new IllegalArgumentException("Benchmark tolerances must be non-negative");
+      }
+      this.caseName = caseName;
+      this.timeSeconds = timeSeconds;
+      this.positionMeters = positionMeters;
+      this.variable = normalize(variable);
+      this.value = value;
+      this.absoluteTolerance = absoluteTolerance;
+      this.relativeTolerance = relativeTolerance;
+      this.source = source;
+    }
+
+    public String getCaseName() {
+      return caseName;
+    }
+
+    public double getTimeSeconds() {
+      return timeSeconds;
+    }
+
+    public double getPositionMeters() {
+      return positionMeters;
+    }
+
+    public String getVariable() {
+      return variable;
+    }
+
+    public double getValue() {
+      return value;
+    }
+
+    public double getAbsoluteTolerance() {
+      return absoluteTolerance;
+    }
+
+    public double getRelativeTolerance() {
+      return relativeTolerance;
+    }
+
+    public String getSource() {
+      return source;
+    }
+  }
+
+  /** Model profiles captured at one simulation time. */
+  public static final class Snapshot {
+    private final double timeSeconds;
+    private final double[] positionsMeters;
+    private final Map<String, double[]> variables;
+
+    public Snapshot(double timeSeconds, double[] positionsMeters, Map<String, double[]> variables) {
+      if (!Double.isFinite(timeSeconds)) {
+        throw new IllegalArgumentException("Snapshot time must be finite");
+      }
+      this.timeSeconds = timeSeconds;
+      this.positionsMeters = positionsMeters.clone();
+      this.variables = new HashMap<>();
+      for (Map.Entry<String, double[]> entry : variables.entrySet()) {
+        this.variables.put(normalize(entry.getKey()), entry.getValue().clone());
+      }
+    }
+
+    public double getTimeSeconds() {
+      return timeSeconds;
+    }
+
+    public Set<String> getAvailableVariables() {
+      return new HashSet<>(variables.keySet());
+    }
+
+    public double valueAt(String variable, double positionMeters) {
+      double[] values = variables.get(normalize(variable));
+      if (values == null || values.length == 0) {
+        throw new IllegalArgumentException("No model profile for variable: " + variable);
+      }
+      if (positionsMeters.length != values.length) {
+        throw new IllegalArgumentException("Position and value profile lengths differ for "
+            + variable + ": " + positionsMeters.length + " vs " + values.length);
+      }
+      return interpolatePosition(positionMeters, positionsMeters, values);
+    }
+
+    private double interpolatePosition(double x, double[] positions, double[] values) {
+      if (x <= positions[0]) {
+        return values[0];
+      }
+      int last = positions.length - 1;
+      if (x >= positions[last]) {
+        return values[last];
+      }
+      for (int i = 0; i < last; i++) {
+        if (x >= positions[i] && x <= positions[i + 1]) {
+          double dx = positions[i + 1] - positions[i];
+          if (Math.abs(dx) < 1e-12) {
+            return values[i];
+          }
+          double fraction = (x - positions[i]) / dx;
+          return values[i] + fraction * (values[i + 1] - values[i]);
+        }
+      }
+      return values[last];
+    }
+  }
+
+  /** One benchmark comparison row. */
+  public static final class ComparisonRow {
+    private final BenchmarkPoint reference;
+    private final double modelValue;
+
+    private ComparisonRow(BenchmarkPoint reference, double modelValue) {
+      this.reference = reference;
+      this.modelValue = modelValue;
+    }
+
+    public BenchmarkPoint getReference() {
+      return reference;
+    }
+
+    public double getModelValue() {
+      return modelValue;
+    }
+
+    public double getAbsoluteError() {
+      return Math.abs(modelValue - reference.getValue());
+    }
+
+    public double getRelativeError() {
+      double scale = Math.max(Math.abs(reference.getValue()), 1e-12);
+      return getAbsoluteError() / scale;
+    }
+
+    public boolean isPassed() {
+      return getAbsoluteError() <= reference.getAbsoluteTolerance()
+          || getRelativeError() <= reference.getRelativeTolerance();
+    }
+  }
+
+  /** Aggregate comparison result. */
+  public static final class Comparison {
+    private final List<ComparisonRow> rows;
+
+    private Comparison(List<ComparisonRow> rows) {
+      this.rows = Collections.unmodifiableList(new ArrayList<>(rows));
+    }
+
+    public List<ComparisonRow> getRows() {
+      return rows;
+    }
+
+    public boolean isPassed() {
+      return getFailureCount() == 0;
+    }
+
+    public int getFailureCount() {
+      int failures = 0;
+      for (ComparisonRow row : rows) {
+        if (!row.isPassed()) {
+          failures++;
+        }
+      }
+      return failures;
+    }
+
+    public double getMaximumRelativeError() {
+      double max = 0.0;
+      for (ComparisonRow row : rows) {
+        max = Math.max(max, row.getRelativeError());
+      }
+      return max;
+    }
+
+    public String failureSummary() {
+      StringBuilder summary = new StringBuilder();
+      for (ComparisonRow row : rows) {
+        if (!row.isPassed()) {
+          BenchmarkPoint point = row.getReference();
+          summary.append(point.getCaseName()).append(" ").append(point.getVariable())
+              .append(" t=").append(point.getTimeSeconds()).append("s x=")
+              .append(point.getPositionMeters()).append("m ref=").append(point.getValue())
+              .append(" model=").append(row.getModelValue()).append(" absErr=")
+              .append(row.getAbsoluteError()).append(" relErr=").append(row.getRelativeError())
+              .append(System.lineSeparator());
+        }
+      }
+      return summary.toString();
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeImprovementsTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeImprovementsTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.OilWaterFlowRegimeDetector;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.OilWaterFlowRegimeDetector.OilWaterFlowRegime;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.OilWaterFlowRegimeDetector.OilWaterResult;
+import neqsim.process.equipment.pipeline.twophasepipe.numerics.ConservativeStateLimiter;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.TimeIntegrator;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.TimeIntegrator.RHSFunction;
 
@@ -132,12 +133,102 @@ class TwoFluidPipeImprovementsTest {
     }
 
     @Test
+    @DisplayName("IMEX momentum correction scales with phase area")
+    void testIMEXMomentumCorrectionUsesPhaseArea() {
+      TimeIntegrator integrator = new TimeIntegrator(TimeIntegrator.Method.IMEX_PRESSURE_CORRECTION);
+
+      final int n = 3;
+      final int neq = 7;
+      double[][] U0 = new double[n][neq];
+      for (int i = 0; i < n; i++) {
+        U0[i][0] = 5.0; // gas mass per length
+        U0[i][1] = 50.0; // oil mass per length
+        U0[i][2] = 10.0; // water mass per length
+      }
+
+      RHSFunction rhsFunc = (state, time) -> {
+        double[][] dUdt = new double[n][neq];
+        dUdt[1][0] = 1.0; // localized mass imbalance to drive pressure correction
+        return dUdt;
+      };
+
+      double[] soundSpeeds = {350.0, 350.0, 350.0};
+      double[] mixtureDensities = {100.0, 100.0, 100.0};
+      double[] areas = {1.0, 1.0, 1.0};
+      double[] gasDensities = {10.0, 10.0, 10.0};
+      double[] oilDensities = {800.0, 800.0, 800.0};
+      double[] waterDensities = {1000.0, 1000.0, 1000.0};
+
+      integrator.setIMEXProperties(soundSpeeds, mixtureDensities, areas, gasDensities,
+          oilDensities, waterDensities, 100.0, 50e5, true);
+
+      double[][] Unew = integrator.step(U0, rhsFunc, 0.5);
+      double gasMomentumChange = Math.abs(Unew[1][3] - U0[1][3]);
+      double oilMomentumChange = Math.abs(Unew[1][4] - U0[1][4]);
+      double waterMomentumChange = Math.abs(Unew[1][5] - U0[1][5]);
+
+      assertTrue(gasMomentumChange > 0.0, "Pressure correction should affect gas momentum");
+      assertTrue(oilMomentumChange > 0.0, "Pressure correction should affect oil momentum");
+      assertTrue(waterMomentumChange > 0.0, "Pressure correction should affect water momentum");
+
+      double gasMassAfterPredictor = U0[1][0] + 0.5;
+      double expectedGasToOilAreaRatio =
+          (gasMassAfterPredictor / gasDensities[1]) / (U0[1][1] / oilDensities[1]);
+      double expectedOilToWaterAreaRatio =
+          (U0[1][1] / oilDensities[1]) / (U0[1][2] / waterDensities[1]);
+
+      assertEquals(expectedGasToOilAreaRatio, gasMomentumChange / oilMomentumChange, 1e-9);
+      assertEquals(expectedOilToWaterAreaRatio, oilMomentumChange / waterMomentumChange, 1e-9);
+    }
+
+    @Test
     @DisplayName("TwoFluidPipe can set IMEX time integration method")
     void testSetIMEXOnPipe() {
       // Verify that the method enum and setter exist
       TimeIntegrator.Method method = TimeIntegrator.Method.IMEX_PRESSURE_CORRECTION;
       assertNotNull(method);
       assertEquals("IMEX_PRESSURE_CORRECTION", method.name());
+    }
+  }
+
+  // =================================================================
+  // G4: Conservative positivity limiter tests
+  // =================================================================
+
+  @Nested
+  @DisplayName("G4: Conservative positivity limiter")
+  class ConservativePositivityTests {
+
+    @Test
+    @DisplayName("Negative phase mass is redistributed without changing total mass")
+    void testMassPositivityPreservesInventoryAndVelocity() {
+      double[] state = {8.0, -1.0, 3.0, 16.0, -2.0, 6.0, 100.0};
+      double totalMassBefore = state[0] + state[1] + state[2];
+
+      ConservativeStateLimiter.enforceThreePhaseMassPositivity(state, null);
+
+      assertTrue(state[0] >= 0.0);
+      assertTrue(state[1] >= 0.0);
+      assertTrue(state[2] >= 0.0);
+      assertEquals(totalMassBefore, state[0] + state[1] + state[2], 1e-12);
+      assertEquals(2.0, state[3] / state[0], 1e-12,
+          "Gas velocity should be preserved by momentum scaling");
+      assertEquals(0.0, state[4], 1e-12, "Momentum of removed oil phase should be zero");
+      assertEquals(2.0, state[5] / state[2], 1e-12,
+          "Water velocity should be preserved by momentum scaling");
+    }
+
+    @Test
+    @DisplayName("Non-finite state reverts to finite previous state")
+    void testNonFiniteStateUsesPreviousState() {
+      double[] previous = {7.0, 2.0, 2.0, 14.0, 4.0, 4.0, 100.0};
+      double[] state = {8.0, Double.NaN, 3.0, 16.0, -2.0, Double.POSITIVE_INFINITY, 100.0};
+
+      ConservativeStateLimiter.enforceThreePhaseMassPositivity(state, previous);
+
+      for (int i = 0; i < previous.length; i++) {
+        assertEquals(previous[i], state[i], 0.0);
+      }
     }
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
 
 /**
  * Unit tests for TwoFluidSection.
@@ -173,6 +175,126 @@ public class TwoFluidSectionTest {
     assertEquals(10.0, section.getGasMomentumSource(), TOLERANCE);
     assertEquals(-5.0, section.getLiquidMomentumSource(), TOLERANCE);
     assertEquals(1000.0, section.getEnergySource(), TOLERANCE);
+  }
+
+  @Test
+  void testExtractPrimitiveVariablesPreservesTotalMassWhenLimitingPositivity() {
+    section.setGasDensity(10.0);
+    section.setOilDensity(800.0);
+    section.setWaterDensity(1000.0);
+    section.setLiquidDensity(850.0);
+    section.setWaterCut(0.25);
+    section.setStateVector(new double[] {8.0, -1.0, 3.0, 16.0, -2.0, 6.0, 100.0});
+
+    section.extractPrimitiveVariables();
+
+    double totalMass = section.getGasMassPerLength() + section.getOilMassPerLength()
+        + section.getWaterMassPerLength();
+    assertTrue(section.getGasMassPerLength() >= 0.0);
+    assertTrue(section.getOilMassPerLength() >= 0.0);
+    assertTrue(section.getWaterMassPerLength() >= 0.0);
+    assertEquals(10.0, totalMass, 1e-12);
+    assertEquals(0.0, section.getOilMassPerLength(), 1e-12);
+  }
+
+  @Test
+  void testExtractPrimitiveVariablesKeepsMomentumVelocityConsistent() {
+    section.setGasDensity(10.0);
+    section.setOilDensity(800.0);
+    section.setWaterDensity(1000.0);
+    section.setLiquidDensity(850.0);
+    section.setWaterCut(0.4);
+    section.setStateVector(new double[] {5.0, 4.0, 6.0, 25.0, 8.0, 18.0, 100.0});
+
+    section.extractPrimitiveVariables();
+    section.updateWaterOilHoldups();
+
+    assertEquals(section.getGasMomentumPerLength() / section.getGasMassPerLength(),
+        section.getGasVelocity(), 1e-12);
+    assertEquals(section.getOilMomentumPerLength() / section.getOilMassPerLength(),
+        section.getOilVelocity(), 1e-12);
+    assertEquals(section.getWaterMomentumPerLength() / section.getWaterMassPerLength(),
+        section.getWaterVelocity(), 1e-12);
+  }
+
+  @Test
+  void testMassTransferPairIsConservative() {
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    section.setMassTransferRate(2.0);
+
+    double[] massTransfer = equations.calcMassTransfer(section);
+
+    assertEquals(0.2, massTransfer[0], 1e-12);
+    assertEquals(-0.2, massTransfer[1], 1e-12);
+    assertEquals(0.0, massTransfer[0] + massTransfer[1], 1e-12);
+  }
+
+  @Test
+  void testFlashDrivenMassTransferReturnsConservativePair() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 50.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("n-heptane", 0.15);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    section.setPressure(50.0e5);
+    section.setTemperature(300.0);
+    section.setGasDensity(40.0);
+    section.setLiquidDensity(700.0);
+    section.setGasMassPerLength(0.05);
+    section.setLiquidMassPerLength(2.0);
+
+    ThermodynamicCoupling coupling = new ThermodynamicCoupling(fluid);
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    equations.setThermodynamicCoupling(coupling);
+    equations.setMassTransferRelaxationTime(20.0);
+
+    double[] massTransfer = equations.calcMassTransfer(section);
+
+    assertTrue(Double.isFinite(massTransfer[0]));
+    assertTrue(Double.isFinite(massTransfer[1]));
+    assertEquals(0.0, massTransfer[0] + massTransfer[1], 1e-12);
+  }
+
+  @Test
+  void testClosurePassUpdatesEntrainmentAndSevereSlugDiagnostics() {
+    section.setGasDensity(25.0);
+    section.setLiquidDensity(750.0);
+    section.setGasViscosity(1.2e-5);
+    section.setLiquidViscosity(1.0e-3);
+    section.setSurfaceTension(0.02);
+    section.setGasHoldup(0.95);
+    section.setLiquidHoldup(0.05);
+    section.setGasVelocity(35.0);
+    section.setLiquidVelocity(0.5);
+    section.updateDerivedQuantities();
+
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    TwoFluidSection section2 = section.clone();
+    section2.setPosition(section.getLength());
+    equations.calcRHS(new TwoFluidSection[] {section, section2}, section.getLength());
+
+    assertTrue(section.getEntrainmentFraction() >= 0.0);
+    assertTrue(section.getEntrainedDropletDiameter() >= 0.0);
+
+    TwoFluidSection riserBase = new TwoFluidSection(0.0, 10.0, 0.1, Math.toRadians(30.0));
+    riserBase.setGasDensity(20.0);
+    riserBase.setLiquidDensity(800.0);
+    riserBase.setGasViscosity(1.0e-5);
+    riserBase.setLiquidViscosity(1.0e-3);
+    riserBase.setSurfaceTension(0.02);
+    riserBase.setGasHoldup(0.2);
+    riserBase.setLiquidHoldup(0.8);
+    riserBase.setGasVelocity(0.02);
+    riserBase.setLiquidVelocity(0.1);
+    riserBase.updateDerivedQuantities();
+
+    TwoFluidSection riserBase2 = riserBase.clone();
+    riserBase2.setPosition(riserBase.getLength());
+    equations.calcRHS(new TwoFluidSection[] {riserBase, riserBase2}, riserBase.getLength());
+
+    assertTrue(riserBase.getSevereSluggingNumber() < 1.0);
+    assertTrue(riserBase.isSevereSlugPotential());
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReportTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReportTest.java
@@ -1,0 +1,202 @@
+package neqsim.process.equipment.pipeline.twophasepipe.reporting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.google.gson.JsonParser;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.twophasepipe.validation.TwoFluidBenchmarkHarness;
+import neqsim.process.equipment.pipeline.twophasepipe.validation.TwoFluidBenchmarkHarness.BenchmarkPoint;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+class TwoFluidPipeReportTest {
+
+  @Test
+  void testReportExportsProfilesSummariesAndComparisonTable() throws Exception {
+    TwoFluidPipe pipe = runTwoFluidPipe("report-gas", methaneFluid(50.0, 298.15), 25000.0, 1000.0,
+        0.2, 10);
+
+    String steadyCsv = TwoFluidPipeReport.toSteadyStateProfileCsv(pipe);
+    assertTrue(steadyCsv.startsWith("position_m,pressure_bara,temperature_C"));
+    assertTrue(steadyCsv.contains("flow_regime"));
+    assertEquals(pipe.getPositionProfile().length + 1, steadyCsv.split("\\R").length);
+
+    List<TwoFluidPipeReport.ProfileSnapshot> snapshots = TwoFluidPipeReport.newSnapshotList();
+    snapshots.add(TwoFluidPipeReport.capture(pipe));
+    pipe.runTransient(0.1, java.util.UUID.randomUUID());
+    snapshots.add(TwoFluidPipeReport.capture(pipe));
+    String transientCsv = TwoFluidPipeReport.toTransientProfileCsv(snapshots);
+    assertTrue(transientCsv.startsWith("time_s,position_m,pressure_bara"));
+    assertTrue(transientCsv.split("\\R").length >= 2 * pipe.getPositionProfile().length);
+
+    String summary = TwoFluidPipeReport.toSummaryText(pipe);
+    assertTrue(summary.contains("TwoFluidPipe summary"));
+    assertTrue(summary.contains("Average liquid holdup"));
+
+    String json = TwoFluidPipeReport.toSummaryJson(pipe);
+    assertTrue(JsonParser.parseString(json).getAsJsonObject().has("outletPressureBara"));
+
+    String events = TwoFluidPipeReport.toSlugAndFlowAssuranceCsv(pipe);
+    assertTrue(events.startsWith("event_type,position_m,value,unit,description"));
+    assertTrue(events.contains("erosion_margin"));
+
+    BenchmarkPoint point = new BenchmarkPoint("report", pipe.getSimulationTime(),
+        pipe.getPositionProfile()[0], "pressure_bara", pipe.getPressureProfile()[0] * 1e-5, 0.01,
+        0.001, "unit");
+    TwoFluidBenchmarkHarness.Comparison comparison = TwoFluidBenchmarkHarness
+        .compare(TwoFluidBenchmarkHarness.capture(pipe), java.util.Collections.singletonList(point));
+    String comparisonCsv = TwoFluidPipeReport.toComparisonCsv(comparison);
+    assertTrue(comparisonCsv.startsWith("case,time_s,position_m,variable"));
+    assertTrue(comparisonCsv.contains(",true,"));
+
+    Path tempDir = Files.createTempDirectory("twofluid-report-test");
+    Path profilePath = tempDir.resolve("profile.csv");
+    Path summaryPath = tempDir.resolve("summary.json");
+    TwoFluidPipeReport.writeSteadyStateProfileCsv(pipe, profilePath);
+    TwoFluidPipeReport.writeSummaryJson(pipe, summaryPath);
+    assertTrue(Files.readString(profilePath).startsWith("position_m,pressure_bara"));
+    assertTrue(JsonParser.parseString(Files.readString(summaryPath)).getAsJsonObject()
+        .has("averageLiquidHoldup"));
+  }
+
+  @Test
+  void testOnePhaseGasReasonableAgainstBeggsAndBrill() {
+    SystemInterface fluid = methaneFluid(50.0, 298.15);
+    double flowKgHr = 25000.0;
+    TwoFluidPipe tf = runTwoFluidPipe("one-phase-gas", fluid, flowKgHr, 5000.0, 0.2, 25);
+    PipeBeggsAndBrills bb = runBeggsAndBrill("bb-gas", fluid, flowKgHr, 5000.0, 0.2, 25);
+
+    double dpTf = tf.getInletPressure() - tf.getOutletPressure();
+    double dpBb = bb.getInletStream().getPressure("bara") - bb.getOutletStream().getPressure("bara");
+    double ratio = dpTf / dpBb;
+
+    assertTrue(dpTf > 0.0);
+    assertTrue(dpBb > 0.0);
+    assertTrue(ratio > 0.5 && ratio < 2.0,
+        "One-phase gas pressure drop should be close to Beggs & Brill. Ratio=" + ratio);
+  }
+
+  @Test
+  void testTwoPhaseWetGasReasonableAgainstBeggsAndBrillAndLiteratureRange() {
+    SystemInterface fluid = wetGasFluid(80.0, 313.15);
+    double flowKgHr = 30000.0;
+    double length = 10000.0;
+    TwoFluidPipe tf = runTwoFluidPipe("two-phase-wet-gas", fluid, flowKgHr, length, 0.254, 30);
+    PipeBeggsAndBrills bb = runBeggsAndBrill("bb-wet-gas", fluid, flowKgHr, length, 0.254, 30);
+
+    double dpTf = tf.getInletPressure() - tf.getOutletPressure();
+    double dpBb = bb.getInletStream().getPressure("bara") - bb.getOutletStream().getPressure("bara");
+    double dpPerKm = dpTf / (length / 1000.0);
+    double ratio = dpTf / dpBb;
+    double avgHoldup = Arrays.stream(tf.getLiquidHoldupProfile()).average().orElse(0.0);
+
+    assertTrue(dpTf > 0.0);
+    assertTrue(dpBb > 0.0);
+    assertTrue(ratio > 0.3 && ratio < 3.0,
+        "Two-phase pressure drop should be same order as Beggs & Brill. Ratio=" + ratio);
+    assertTrue(dpPerKm > 0.01 && dpPerKm < 5.0,
+        "Wet-gas pressure gradient should be within broad literature range. dP/km=" + dpPerKm);
+    assertTrue(avgHoldup >= 0.0 && avgHoldup <= 1.0);
+  }
+
+  @Test
+  void testThreePhaseReasonableAgainstBeggsAndBrillAndPhysicalRanges() {
+    SystemInterface fluid = threePhaseFluid(60.0, 323.15);
+    double flowKgHr = 25000.0;
+    double length = 5000.0;
+    TwoFluidPipe tf = runTwoFluidPipe("three-phase", fluid, flowKgHr, length, 0.203, 25);
+    PipeBeggsAndBrills bb = runBeggsAndBrill("bb-three-phase", fluid, flowKgHr, length, 0.203, 25);
+
+    double dpTf = tf.getInletPressure() - tf.getOutletPressure();
+    double dpBb = bb.getInletStream().getPressure("bara") - bb.getOutletStream().getPressure("bara");
+    double avgHoldup = Arrays.stream(tf.getLiquidHoldupProfile()).average().orElse(0.0);
+    double avgWaterCut = Arrays.stream(tf.getWaterCutProfile()).average().orElse(0.0);
+    double outletFlow = tf.getOutletStream().getFlowRate("kg/hr");
+
+    assertTrue(dpTf > 0.0);
+    assertTrue(dpBb > 0.0);
+    assertTrue(dpTf / dpBb > 0.2 && dpTf / dpBb < 5.0,
+        "Three-phase dP should be same engineering order as Beggs & Brill");
+    assertTrue(avgHoldup >= 0.0 && avgHoldup <= 1.0);
+    assertTrue(avgWaterCut >= 0.0 && avgWaterCut <= 1.0);
+    assertTrue(Math.abs(outletFlow - flowKgHr) / flowKgHr < 0.05);
+    assertFalse(tf.getDominantFlowRegime().isBlank());
+  }
+
+  private TwoFluidPipe runTwoFluidPipe(String name, SystemInterface fluid, double flowKgHr,
+      double length, double diameter, int sections) {
+    Stream inlet = new Stream(name + "-feed", fluid.clone());
+    inlet.setFlowRate(flowKgHr, "kg/hr");
+    inlet.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe(name, inlet);
+    pipe.setLength(length);
+    pipe.setDiameter(diameter);
+    pipe.setRoughness(4.6e-5);
+    pipe.setNumberOfSections(sections);
+    pipe.setElevationProfile(new double[sections]);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(inlet);
+    process.add(pipe);
+    process.run();
+    return pipe;
+  }
+
+  private PipeBeggsAndBrills runBeggsAndBrill(String name, SystemInterface fluid, double flowKgHr,
+      double length, double diameter, int increments) {
+    Stream inlet = new Stream(name + "-feed", fluid.clone());
+    inlet.setFlowRate(flowKgHr, "kg/hr");
+    inlet.run();
+
+    PipeBeggsAndBrills pipe = new PipeBeggsAndBrills(name, inlet);
+    pipe.setLength(length);
+    pipe.setDiameter(diameter);
+    pipe.setPipeWallRoughness(4.6e-5);
+    pipe.setAngle(0.0);
+    pipe.setNumberOfIncrements(increments);
+    pipe.run();
+    return pipe;
+  }
+
+  private SystemInterface methaneFluid(double pressureBara, double temperatureK) {
+    SystemInterface fluid = new SystemSrkEos(temperatureK, pressureBara);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  private SystemInterface wetGasFluid(double pressureBara, double temperatureK) {
+    SystemInterface fluid = new SystemSrkEos(temperatureK, pressureBara);
+    fluid.addComponent("methane", 0.90);
+    fluid.addComponent("ethane", 0.04);
+    fluid.addComponent("propane", 0.02);
+    fluid.addComponent("n-heptane", 0.04);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  private SystemInterface threePhaseFluid(double pressureBara, double temperatureK) {
+    SystemInterface fluid = new SystemSrkEos(temperatureK, pressureBara);
+    fluid.addComponent("methane", 0.65);
+    fluid.addComponent("ethane", 0.03);
+    fluid.addComponent("propane", 0.02);
+    fluid.addComponent("n-pentane", 0.08);
+    fluid.addComponent("n-heptane", 0.07);
+    fluid.addComponent("nC10", 0.05);
+    fluid.addComponent("water", 0.10);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarnessTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarnessTest.java
@@ -1,0 +1,101 @@
+package neqsim.process.equipment.pipeline.twophasepipe.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.twophasepipe.validation.TwoFluidBenchmarkHarness.BenchmarkPoint;
+import neqsim.process.equipment.pipeline.twophasepipe.validation.TwoFluidBenchmarkHarness.Comparison;
+import neqsim.process.equipment.pipeline.twophasepipe.validation.TwoFluidBenchmarkHarness.Snapshot;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+class TwoFluidBenchmarkHarnessTest {
+
+  @Test
+  void testReadsExternalSimulatorCsvFixture() throws Exception {
+    Path csv = resourcePath("neqsim/process/equipment/pipeline/twophasepipe/validation/"
+        + "ledaflow_olga_export_fixture.csv");
+
+    List<BenchmarkPoint> points = TwoFluidBenchmarkHarness.readCsv(csv);
+
+    assertEquals(4, points.size());
+    assertEquals("pressure_bara", points.get(0).getVariable());
+    assertEquals("OLGA/LedaFlow export fixture", points.get(0).getSource());
+  }
+
+  @Test
+  void testComparesPipeSnapshotAgainstCsvReference() throws Exception {
+    TwoFluidPipe pipe = createSolvedWetGasPipe();
+    Snapshot snapshot = TwoFluidBenchmarkHarness.capture(pipe);
+
+    double inletPressure = pipe.getPressureProfile()[0] * 1e-5;
+    double outletPressure = pipe.getPressureProfile()[pipe.getPressureProfile().length - 1] * 1e-5;
+    double averageHoldup = Arrays.stream(pipe.getLiquidHoldupProfile()).average().orElseThrow();
+    List<BenchmarkPoint> reference = Arrays.asList(
+        new BenchmarkPoint("fixture", 0.0, pipe.getPositionProfile()[0], "pressure_bara",
+            inletPressure, 0.05, 0.001, "generated"),
+        new BenchmarkPoint("fixture", 0.0,
+            pipe.getPositionProfile()[pipe.getPositionProfile().length - 1], "pressure_bara",
+            outletPressure, 0.05, 0.001, "generated"),
+        new BenchmarkPoint("fixture", 0.0, 500.0, "liquid_holdup", averageHoldup, 0.20, 1.0,
+            "generated"));
+
+    Comparison comparison = TwoFluidBenchmarkHarness.compare(snapshot, reference);
+
+    assertTrue(comparison.isPassed(), comparison.failureSummary());
+    assertEquals(0, comparison.getFailureCount());
+  }
+
+  @Test
+  void testInterpolatesTransientSnapshotsInTimeAndPosition() {
+    Snapshot t0 = new Snapshot(0.0, new double[] {0.0, 100.0},
+        java.util.Map.of("pressure_bara", new double[] {50.0, 49.0}));
+    Snapshot t10 = new Snapshot(10.0, new double[] {0.0, 100.0},
+        java.util.Map.of("pressure_bara", new double[] {48.0, 47.0}));
+    BenchmarkPoint point =
+        new BenchmarkPoint("transient", 5.0, 50.0, "pressure_bara", 48.5, 1e-12, 0.0, "unit");
+
+    Comparison comparison = TwoFluidBenchmarkHarness.compare(Arrays.asList(t10, t0),
+        java.util.Collections.singletonList(point));
+
+    assertTrue(comparison.isPassed(), comparison.failureSummary());
+  }
+
+  private TwoFluidPipe createSolvedWetGasPipe() {
+    SystemInterface fluid = new SystemSrkEos(273.15 + 35.0, 60.0);
+    fluid.addComponent("methane", 0.92);
+    fluid.addComponent("ethane", 0.03);
+    fluid.addComponent("propane", 0.02);
+    fluid.addComponent("n-heptane", 0.03);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream inlet = new Stream("benchmark-feed", fluid);
+    inlet.setFlowRate(15000.0, "kg/hr");
+    inlet.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe("benchmark-pipe", inlet);
+    pipe.setLength(1000.0);
+    pipe.setDiameter(0.1524);
+    pipe.setRoughness(4.6e-5);
+    pipe.setNumberOfSections(10);
+    pipe.setElevationProfile(new double[10]);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(inlet);
+    process.add(pipe);
+    process.run();
+    return pipe;
+  }
+
+  private Path resourcePath(String resource) throws URISyntaxException {
+    return Path.of(Thread.currentThread().getContextClassLoader().getResource(resource).toURI());
+  }
+}

--- a/src/test/resources/neqsim/process/equipment/pipeline/twophasepipe/validation/ledaflow_olga_export_fixture.csv
+++ b/src/test/resources/neqsim/process/equipment/pipeline/twophasepipe/validation/ledaflow_olga_export_fixture.csv
@@ -1,0 +1,5 @@
+case,time_s,position_m,variable,value,abs_tolerance,rel_tolerance,source
+fixture,0.0,50.0,pressure_bara,60.0,100.0,1.0,OLGA/LedaFlow export fixture
+fixture,0.0,950.0,pressure_bara,59.0,100.0,1.0,OLGA/LedaFlow export fixture
+fixture,0.0,500.0,liquid_holdup,0.10,1.0,1.0,OLGA/LedaFlow export fixture
+fixture,5.0,500.0,pressure_bara,58.0,100.0,1.0,OLGA/LedaFlow export fixture


### PR DESCRIPTION
## Summary

This PR extends the two-fluid pipeline model toward production-style validation and reporting workflows:

- adds a conservative positivity limiter for three-phase mass states and routes transient state repair through it
- improves IMEX pressure/momentum coupling by using cell areas, phase densities, and phase areas consistently
- adds flash-driven thermodynamic mass-transfer coupling with conservative source limiting and a relaxation-time control
- adds closure diagnostics for entrainment/deposition and severe-slugging indicators
- adds a benchmark harness for OLGA/LedaFlow/field-style exported profiles with time/position interpolation
- adds `TwoFluidPipeReport` CSV/text/JSON exporters for steady-state profiles, transient profiles, summaries, slug/flow-assurance events, and benchmark comparisons
- documents the new reporting and validation workflow in the wiki docs

## Validation

Ran from a clean upstream checkout on branch `codex/twofluid-reporting-validation`:

```bash
.\mvnw.cmd -q "-Dtest=TwoFluidPipeReportTest,TwoFluidBenchmarkHarnessTest,TwoFluidSectionTest,TwoFluidPipeImprovementsTest,TwoFluidPipeBenchmarkTest,TwoFluidPipeValidationTest,TwoFluidPipeIntegrationTest" test
```

The test set passed. It includes one-, two-, and three-phase reporting checks, Beggs & Brill reasonableness comparisons, benchmark CSV import/interpolation checks, conservative positivity tests, mass-transfer conservation checks, and existing two-fluid benchmark/validation/integration tests.

## Notes

This is not a claim of OLGA/LedaFlow parity. The new benchmark harness is intended to make that comparison systematic by running equivalent geometry, fluids, boundary conditions, and transient scenarios against exported commercial-simulator or field data.