### PR TITLE
[codex] fix alarm config non-finite timing values

### DIFF
--- a/src/main/java/neqsim/process/alarm/AlarmConfig.java
+++ b/src/main/java/neqsim/process/alarm/AlarmConfig.java
@@ -113,12 +113,12 @@ public final class AlarmConfig implements Serializable {
     }
 
     public Builder deadband(double value) {
-      this.deadband = Math.max(0.0, value);
+      this.deadband = sanitizeNonNegative(value);
       return this;
     }
 
     public Builder delay(double value) {
-      this.delay = Math.max(0.0, value);
+      this.delay = sanitizeNonNegative(value);
       return this;
     }
 
@@ -129,6 +129,10 @@ public final class AlarmConfig implements Serializable {
 
     public AlarmConfig build() {
       return new AlarmConfig(this);
+    }
+
+    private static double sanitizeNonNegative(double value) {
+      return Double.isFinite(value) ? Math.max(0.0, value) : 0.0;
     }
   }
 }

--- a/src/test/java/neqsim/process/alarm/AlarmConfigTest.java
+++ b/src/test/java/neqsim/process/alarm/AlarmConfigTest.java
@@ -1,0 +1,29 @@
+package neqsim.process.alarm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AlarmConfigTest {
+  @Test
+  void builderSanitizesNonFiniteDeadbandAndDelay() {
+    AlarmConfig config = AlarmConfig.builder().deadband(Double.NaN)
+        .delay(Double.POSITIVE_INFINITY).build();
+
+    assertEquals(0.0, config.getDeadband());
+    assertEquals(0.0, config.getDelay());
+  }
+
+  @Test
+  void nonFiniteDelayDoesNotPreventAlarmActivation() {
+    AlarmConfig config = AlarmConfig.builder().highLimit(10.0).delay(Double.NaN).build();
+    AlarmState state = new AlarmState();
+
+    List<AlarmEvent> events = state.evaluate(config, 11.0, 0.0, 1.0, "pressure");
+
+    assertTrue(state.isActive());
+    assertEquals(1, events.size());
+    assertEquals(AlarmEventType.ACTIVATED, events.get(0).getType());
+  }
+}


### PR DESCRIPTION
## Summary

- sanitize non-finite alarm `deadband` and `delay` builder inputs to `0.0`
- add regression coverage for `NaN`/infinite timing inputs and `NaN` delay alarm activation

## Root Cause

`AlarmConfig.Builder` used `Math.max(0.0, value)` to clamp negative `deadband` and `delay` values, but `Math.max` propagates `NaN` and preserves positive infinity. Those non-finite values can make alarm state comparisons fail indefinitely, for example a `NaN` delay prevents `pendingTimer >= config.getDelay()` from becoming true.

## Validation

- `./mvnw.cmd -q -Dtest=AlarmConfigTest test`

## Notes

Local HTTPS push was blocked by the organization SAML requirement for Git Credential Manager, so this branch was published through the GitHub connector.