### PR TITLE
[codex] Fix unit SI value conversions

### DIFF
--- a/src/main/java/neqsim/util/unit/EnergyUnit.java
+++ b/src/main/java/neqsim/util/unit/EnergyUnit.java
@@ -55,6 +55,12 @@ public class EnergyUnit extends neqsim.util.unit.BaseUnit {
 
   /** {@inheritDoc} */
   @Override
+  public double getSIvalue() {
+    return getValue("J");
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public double getValue(double val, String fromunit, String tounit) {
     invalue = val;
     return getConversionFactor(fromunit) / getConversionFactor(tounit) * invalue;

--- a/src/main/java/neqsim/util/unit/PowerUnit.java
+++ b/src/main/java/neqsim/util/unit/PowerUnit.java
@@ -49,6 +49,12 @@ public class PowerUnit extends neqsim.util.unit.BaseUnit {
 
   /** {@inheritDoc} */
   @Override
+  public double getSIvalue() {
+    return getValue("W");
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public double getValue(double val, String fromunit, String tounit) {
     invalue = val;
     return getConversionFactor(fromunit) / getConversionFactor(tounit) * invalue;

--- a/src/main/java/neqsim/util/unit/PressureUnit.java
+++ b/src/main/java/neqsim/util/unit/PressureUnit.java
@@ -118,6 +118,12 @@ public class PressureUnit extends neqsim.util.unit.BaseUnit {
 
   /** {@inheritDoc} */
   @Override
+  public double getSIvalue() {
+    return getValue("Pa");
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public double getValue(double val, String fromunit, String tounit) {
     double absBar = toAbsoluteBar(val, fromunit);
     return fromAbsoluteBar(absBar, tounit);

--- a/src/test/java/neqsim/util/unit/EnergyUnitTest.java
+++ b/src/test/java/neqsim/util/unit/EnergyUnitTest.java
@@ -1,0 +1,12 @@
+package neqsim.util.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+class EnergyUnitTest extends neqsim.NeqSimTest {
+  @Test
+  void testSIValue() {
+    assertEquals(1000.0, new EnergyUnit(1.0, "kJ").getSIvalue(), 1e-12);
+    assertEquals(3.6e6, new EnergyUnit(1.0, "kWh").getSIvalue(), 1e-6);
+  }
+}

--- a/src/test/java/neqsim/util/unit/PowerUnitTest.java
+++ b/src/test/java/neqsim/util/unit/PowerUnitTest.java
@@ -1,0 +1,12 @@
+package neqsim.util.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+class PowerUnitTest extends neqsim.NeqSimTest {
+  @Test
+  void testSIValue() {
+    assertEquals(1000.0, new PowerUnit(1.0, "kW").getSIvalue(), 1e-12);
+    assertEquals(745.699872, new PowerUnit(1.0, "hp").getSIvalue(), 1e-12);
+  }
+}

--- a/src/test/java/neqsim/util/unit/PressureUnitTest.java
+++ b/src/test/java/neqsim/util/unit/PressureUnitTest.java
@@ -81,5 +81,10 @@ class PressureUnitTest extends neqsim.NeqSimTest {
     assertEquals(expectedPsi, psi, 1e-6);
     assertEquals(1.0, converter.getValue(psi, "psi", "atm"), 1e-6);
   }
-}
 
+  @Test
+  public void testSIValue() {
+    assertEquals(101325.0, new PressureUnit(0.0, "barg").getSIvalue(), 1e-6);
+    assertEquals(1100000.0, new PressureUnit(11.0, "bara").getSIvalue(), 1e-6);
+  }
+}


### PR DESCRIPTION
## Summary
- Implement `getSIvalue()` for `PressureUnit`, `EnergyUnit`, and `PowerUnit`.
- Add regression tests for Pa, J, and W SI conversions.

## Root cause
These unit classes inherited `BaseUnit#getSIvalue()`, which returns the default `SIvalue` field initialized to `0.0`, even though the classes already had working `getValue(...)` conversions.

## Validation
- `./mvnw.cmd -q '-Dtest=PressureUnitTest,EnergyUnitTest,PowerUnitTest' test`
- `./mvnw.cmd -q checkstyle:check`