### PR TITLE
[codex] Implement length and time unit conversions

### DIFF
--- a/src/main/java/neqsim/util/unit/LengthUnit.java
+++ b/src/main/java/neqsim/util/unit/LengthUnit.java
@@ -6,6 +6,8 @@
 
 package neqsim.util.unit;
 
+import neqsim.util.exception.InvalidInputException;
+
 /**
  * <p>
  * LengthUnit class.
@@ -28,5 +30,48 @@ public class LengthUnit extends neqsim.util.unit.BaseUnit {
    */
   public LengthUnit(double value, String name) {
     super(value, name);
+  }
+
+  /**
+   * Get conversion factor to meters (SI unit).
+   *
+   * @param name unit name
+   * @return conversion factor to meters
+   */
+  public double getConversionFactor(String name) {
+    if ("m".equals(name) || "meter".equals(name) || "metre".equals(name)) {
+      return 1.0;
+    } else if ("cm".equals(name)) {
+      return 1.0e-2;
+    } else if ("mm".equals(name)) {
+      return 1.0e-3;
+    } else if ("km".equals(name)) {
+      return 1.0e3;
+    } else if ("in".equals(name) || "inch".equals(name)) {
+      return 0.0254;
+    } else if ("ft".equals(name) || "feet".equals(name)) {
+      return 0.3048;
+    }
+
+    throw new RuntimeException(
+        new InvalidInputException(this, "getConversionFactor", name, "unit not supported"));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getSIvalue() {
+    return getValue("m");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getValue(double val, String fromunit, String tounit) {
+    return getConversionFactor(fromunit) / getConversionFactor(tounit) * val;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getValue(String tounit) {
+    return getValue(invalue, inunit, tounit);
   }
 }

--- a/src/main/java/neqsim/util/unit/TimeUnit.java
+++ b/src/main/java/neqsim/util/unit/TimeUnit.java
@@ -6,6 +6,8 @@
 
 package neqsim.util.unit;
 
+import neqsim.util.exception.InvalidInputException;
+
 /**
  * <p>
  * TimeUnit class.
@@ -28,5 +30,44 @@ public class TimeUnit extends neqsim.util.unit.BaseUnit {
    */
   public TimeUnit(double value, String name) {
     super(value, name);
+  }
+
+  /**
+   * Get conversion factor to seconds (SI unit).
+   *
+   * @param name unit name
+   * @return conversion factor to seconds
+   */
+  public double getConversionFactor(String name) {
+    if ("s".equals(name) || "sec".equals(name) || "second".equals(name)) {
+      return 1.0;
+    } else if ("min".equals(name) || "minute".equals(name)) {
+      return 60.0;
+    } else if ("h".equals(name) || "hr".equals(name) || "hour".equals(name)) {
+      return 3600.0;
+    } else if ("d".equals(name) || "day".equals(name)) {
+      return 86400.0;
+    }
+
+    throw new RuntimeException(
+        new InvalidInputException(this, "getConversionFactor", name, "unit not supported"));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getSIvalue() {
+    return getValue("sec");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getValue(double val, String fromunit, String tounit) {
+    return getConversionFactor(fromunit) / getConversionFactor(tounit) * val;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getValue(String tounit) {
+    return getValue(invalue, inunit, tounit);
   }
 }

--- a/src/test/java/neqsim/util/unit/LengthUnitTest.java
+++ b/src/test/java/neqsim/util/unit/LengthUnitTest.java
@@ -1,0 +1,27 @@
+package neqsim.util.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+class LengthUnitTest extends neqsim.NeqSimTest {
+  @Test
+  void testSIValue() {
+    assertEquals(1.0, new LengthUnit(100.0, "cm").getSIvalue(), 1e-12);
+    assertEquals(0.3048, new LengthUnit(1.0, "ft").getSIvalue(), 1e-12);
+  }
+
+  @Test
+  void testDirectConversions() {
+    LengthUnit length = new LengthUnit(1.0, "m");
+    assertEquals(1000.0, length.getValue("mm"), 1e-12);
+    assertEquals(3.280839895, length.getValue("ft"), 1e-9);
+    assertEquals(12.0, length.getValue(1.0, "ft", "in"), 1e-12);
+  }
+
+  @Test
+  void testUnsupportedUnit() {
+    LengthUnit length = new LengthUnit(1.0, "m");
+    assertThrows(RuntimeException.class, () -> length.getValue("yard"));
+  }
+}

--- a/src/test/java/neqsim/util/unit/TimeUnitTest.java
+++ b/src/test/java/neqsim/util/unit/TimeUnitTest.java
@@ -1,0 +1,27 @@
+package neqsim.util.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+class TimeUnitTest extends neqsim.NeqSimTest {
+  @Test
+  void testSIValue() {
+    assertEquals(3600.0, new TimeUnit(1.0, "hr").getSIvalue(), 1e-12);
+    assertEquals(86400.0, new TimeUnit(1.0, "day").getSIvalue(), 1e-12);
+  }
+
+  @Test
+  void testDirectConversions() {
+    TimeUnit time = new TimeUnit(2.0, "hr");
+    assertEquals(120.0, time.getValue("min"), 1e-12);
+    assertEquals(7200.0, time.getValue("sec"), 1e-12);
+    assertEquals(2.0, time.getValue(7200.0, "sec", "hr"), 1e-12);
+  }
+
+  @Test
+  void testUnsupportedUnit() {
+    TimeUnit time = new TimeUnit(1.0, "sec");
+    assertThrows(RuntimeException.class, () -> time.getValue("week"));
+  }
+}


### PR DESCRIPTION
## Summary
- Implement `LengthUnit` conversions to and from SI meters.
- Implement NeqSim `TimeUnit` conversions to and from SI seconds.
- Add regression tests for SI values, direct conversions, and unsupported units.

## Root cause
`LengthUnit` and `TimeUnit` implemented the `Unit` interface through `BaseUnit` but did not override the conversion methods. As a result, `getValue(...)` threw `UnsupportedOperationException` and `getSIvalue()` returned the base default `0.0` instead of an SI value.

## Current status
- Branch is up to date with `equinor/neqsim:master` as of May 25, 2026.
- PR is mergeable and has no review comments to address.

## Validation
- `./mvnw.cmd -q '-Dtest=LengthUnitTest,TimeUnitTest' test`
- `./mvnw.cmd -q checkstyle:check`