### PR TITLE
[codex] Validate pipe builder units

### DIFF
--- a/src/main/java/neqsim/fluidmechanics/flowsystem/twophaseflowsystem/twophasepipeflowsystem/TwoPhasePipeFlowSystemBuilder.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsystem/twophaseflowsystem/twophasepipeflowsystem/TwoPhasePipeFlowSystemBuilder.java
@@ -249,9 +249,10 @@ public class TwoPhasePipeFlowSystemBuilder {
         this.roughness = roughness * 1e-6;
         break;
       case "m":
-      default:
         this.roughness = roughness;
         break;
+      default:
+        throw new IllegalArgumentException("Unsupported roughness unit: " + unit);
     }
     return this;
   }
@@ -276,9 +277,10 @@ public class TwoPhasePipeFlowSystemBuilder {
         break;
       case "rad":
       case "radians":
-      default:
         this.inclination = angle;
         break;
+      default:
+        throw new IllegalArgumentException("Unsupported inclination unit: " + unit);
     }
     return this;
   }
@@ -515,8 +517,9 @@ public class TwoPhasePipeFlowSystemBuilder {
       case "mi":
         return value * 1609.34;
       case "m":
-      default:
         return value;
+      default:
+        throw new IllegalArgumentException("Unsupported length unit: " + unit);
     }
   }
 
@@ -534,8 +537,9 @@ public class TwoPhasePipeFlowSystemBuilder {
       case "F":
         return (value - 32) * 5.0 / 9.0 + 273.15;
       case "K":
-      default:
         return value;
+      default:
+        throw new IllegalArgumentException("Unsupported temperature unit: " + unit);
     }
   }
 }

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/twophaseflowsystem/twophasepipeflowsystem/TwoPhasePipeFlowSystemBuilderTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/twophaseflowsystem/twophasepipeflowsystem/TwoPhasePipeFlowSystemBuilderTest.java
@@ -151,4 +151,28 @@ class TwoPhasePipeFlowSystemBuilderTest {
 
     assertNotNull(pipe);
   }
+
+  @Test
+  void testUnsupportedLengthUnitThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> TwoPhasePipeFlowSystem.builder().withDiameter(1.0, "yard"));
+  }
+
+  @Test
+  void testUnsupportedRoughnessUnitThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> TwoPhasePipeFlowSystem.builder().withRoughness(1.0, "mil"));
+  }
+
+  @Test
+  void testUnsupportedTemperatureUnitThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> TwoPhasePipeFlowSystem.builder().withWallTemperature(20.0, "degC"));
+  }
+
+  @Test
+  void testUnsupportedInclinationUnitThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> TwoPhasePipeFlowSystem.builder().withInclination(10.0, "grade"));
+  }
 }


### PR DESCRIPTION
## Summary
- Reject unsupported length units in `TwoPhasePipeFlowSystemBuilder` instead of silently treating them as meters.
- Reject unsupported roughness units instead of silently treating them as meters.
- Reject unsupported temperature units instead of silently treating them as Kelvin.
- Reject unsupported inclination units instead of silently treating them as radians.
- Add regression tests for each bad-unit path.

## Root cause
Several unit conversion switches used `default` as the base SI unit case. Typos or unsupported unit labels therefore produced plausible but physically wrong pipe models rather than failing fast.

## Validation
- `./mvnw.cmd -q '-Dtest=TwoPhasePipeFlowSystemBuilderTest' test`
- `./mvnw.cmd -q checkstyle:check`