### PR TITLE
Add Horizon-3 hydrogen foundation utilities

### DIFF
--- a/.github/skills/neqsim-hydrogen-production/SKILL.md
+++ b/.github/skills/neqsim-hydrogen-production/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neqsim-hydrogen-production
-description: "Hydrogen production routes (SMR/ATR, electrolysis, ammonia cracking) with NeqSim. USE WHEN: modeling pressure-swing adsorption (PSA) purification of syngas, water electrolyzers (PEM/Alkaline/SOEC/AEM), stack I-V curves, hydrogen plant cost estimation, or blue/green H2 plant flowsheets. Covers PressureSwingAdsorptionBed, Electrolyzer with technology-specific defaults, ElectrolyzerIVCharacteristic (Tafel + ohmic), and ElectrolyzerCostEstimate."
+description: "Hydrogen production routes (SMR/ATR, electrolysis, ammonia cracking) with NeqSim. USE WHEN: modeling pressure-swing adsorption (PSA) purification of syngas, water electrolyzers (PEM/Alkaline/SOEC/AEM), stack I-V curves, hydrogen plant cost estimation, para/ortho hydrogen conversion, catalyst deactivation, or blue/green H2 plant flowsheets. Covers PressureSwingAdsorptionBed, PSACascade, Electrolyzer, ParaOrthoH2Correction, CatalystDeactivationKinetics, and cost estimates."
 last_verified: "2026-05-27"
 ---
 
@@ -19,6 +19,8 @@ PSA purification (blue H2) and water electrolysis (green/pink H2). Companion to
 - Stack voltage modeling from current density (I-V curves)
 - Specific energy consumption (kWh/kg H₂)
 - Hydrogen plant CAPEX estimation
+- Cryogenic para/ortho H₂ conversion screening
+- Catalyst activity decay for SMR/WGS/ammonia cracking studies
 - Blue vs green H₂ techno-economic comparison
 
 ## Applicable Standards
@@ -51,6 +53,13 @@ PSA purification (blue H2) and water electrolysis (green/pink H2). Companion to
 |---|---|---|
 | `PSACascade` | `neqsim.process.equipment.adsorber` | Multi-bed Skarstrom cascade (2/4/6/8/10/12 beds) with recovery uplift from pressure equalisation |
 | `PSACostEstimate` | `neqsim.process.costestimation.adsorber` | Per-bed vessel + valve skid + sorbent inventory × CEPCI |
+
+## Core Classes (Horizon 3 foundations)
+
+| Class | Package | Purpose |
+|---|---|---|
+| `ParaOrthoH2Correction` | `neqsim.thermo.util.hydrogen` | Equilibrium para fraction, normal-to-equilibrium heat release, Cp correction, thermal-conductivity factor, conversion time |
+| `CatalystDeactivationKinetics` | `neqsim.process.equipment.reactor` | First-order activity decay for sulfur/chloride poisoning, coking, and thermal sintering |
 
 ## Recipe 1 — Blue H₂ (SMR + WGS + PSA)
 
@@ -168,6 +177,44 @@ double usd = cost.getPurchasedEquipmentCost();
 - Balance-of-plant strip (`setIncludeBalanceOfPlant(false)`) removes ~25 % for vessel-only quotes.
 - CEPCI 2024 = 800 reference; multiply by `CostEstimationCalculator.getCurrentCepci()/800`.
 
+## Recipe 6 — Para/ortho H₂ correction for cryogenic screening
+
+```java
+double para20K = ParaOrthoH2Correction.getEquilibriumParaFraction(20.0);
+double heatJPerKg = ParaOrthoH2Correction.getNormalToEquilibriumHeatJPerKg(20.0);
+double cpCorrection = ParaOrthoH2Correction.getCpCorrectionJPerKgK(40.0);
+double conductivityFactor = ParaOrthoH2Correction.getThermalConductivityCorrectionFactor(20.0);
+double tauSeconds = ParaOrthoH2Correction.estimateEquilibrationTimeSeconds(
+    77.0, ParaOrthoH2Correction.ConversionCatalyst.HYDROUS_FERRIC_OXIDE);
+```
+
+- Normal hydrogen is 25% para; equilibrium hydrogen approaches >99% para near 20 K.
+- `getNormalToEquilibriumHeatJPerKg(T)` returns positive exothermic heat release.
+- `getCpCorrectionJPerKgK(T)` is equilibrium minus frozen-normal rotational heat capacity.
+- Thermal-conductivity correction factors are bounded screening multipliers for normal-H₂ correlations.
+
+## Recipe 7 — Catalyst deactivation activity factor
+
+```java
+CatalystBed bed = new CatalystBed();
+CatalystDeactivationKinetics kinetics = new CatalystDeactivationKinetics(
+    CatalystDeactivationKinetics.CatalystFamily.NICKEL_REFORMING)
+        .setTemperature(973.15)
+        .setSulfurPpmv(0.05)
+        .setCarbonPotential(0.5)
+        .setSteamToCarbonRatio(2.5)
+        .setOperationHours(8000.0);
+
+double activity = kinetics.applyTo(bed);
+double timeTo80 = kinetics.estimateTimeToActivity(0.80);
+String mechanism = kinetics.getDominantMechanism();
+```
+
+- Families: `NICKEL_REFORMING`, `IRON_CHROMIUM_HT_SHIFT`, `COPPER_ZINC_LT_SHIFT`,
+  `RUTHENIUM_AMMONIA_CRACKING`.
+- Mechanisms: sulfur poisoning, chloride poisoning, coking, and thermal sintering.
+- Use vendor/lab/historian coefficients before detailed run-length guarantees.
+
 ## Recipe 3 — Electrolyzer CAPEX
 
 ```java
@@ -208,6 +255,10 @@ double usd = cost.getPurchasedEquipmentCost();
   predicting >100% LHV efficiency — recheck inputs.
 - **Cost estimate**: requires `mech.calcDesign()` before construction so
   `totalPowerKW > 0`.
+- **Para/ortho scope**: `ParaOrthoH2Correction` is a screening correction, not a
+  complete liquefaction process model.
+- **Catalyst life scope**: `CatalystDeactivationKinetics` default coefficients are
+  order-of-magnitude values. Tune them to vendor or historian data for plant-specific forecasts.
 
 ## Tests for verification
 
@@ -216,6 +267,8 @@ double usd = cost.getPurchasedEquipmentCost();
 | `PressureSwingAdsorptionBedTest` | Defaults, recovery cap, mass balance, composition, sorbent switch |
 | `PSACascadeTest` | Cascade uplift, bed-count monotonicity, 0.93 cap, tail-gas mass balance |
 | `PSACostEstimateTest` | Bed-count linearity, sorbent ordering, BoP toggle, order of magnitude |
+| `ParaOrthoH2CorrectionTest` | Para equilibrium limits, conversion heat, Cp correction, conductivity factor, catalyst time ranking |
+| `CatalystDeactivationKineticsTest` | Catalyst-family sensitivity, coking, sintering, dominant mechanism, CatalystBed activity update |
 | `ElectrolyzerTechnologyTest` | Per-tech default consistency |
 | `ElectrolyzerIVCharacteristicTest` | E_rev vs T, Tafel monotonicity, technology ordering |
 | `ElectrolyzerTest` | Backward compat + η_F + I-V + specific-energy band |
@@ -224,8 +277,8 @@ double usd = cost.getPurchasedEquipmentCost();
 ## Deferred (Horizon 2/3)
 
 - Rate-based amine absorber for CO₂ capture upstream of blue H₂
-- Cryogenic H₂ liquefaction with ortho/para conversion
+- Full cryogenic H₂ liquefaction train with expanders and heat integration
 - Reformer furnace radiation coupling
 - Ammonia cracking kinetics for H₂ delivery from NH₃
 - Hydrogen LCA per production step
-- LOHC, photo-electrolysis, catalyst deactivation
+- LOHC and photo-electrolysis

--- a/.github/skills/skill-index.json
+++ b/.github/skills/skill-index.json
@@ -766,7 +766,7 @@
   "mdmt": ["neqsim-depressurization-mdmt"],
   "minimum design metal temperature": ["neqsim-depressurization-mdmt"],
   "ucs-66": ["neqsim-depressurization-mdmt"],
-  "api 521": ["neqsim-depressurization-mdmt"],
+  "api 521": ["neqsim-depressurization-mdmt", "neqsim-relief-flare-network"],
   "low temperature embrittlement": ["neqsim-depressurization-mdmt"],
   "pinch analysis": ["neqsim-heat-integration"],
   "heat integration": ["neqsim-heat-integration"],
@@ -791,7 +791,6 @@
   "relief valve": ["neqsim-relief-flare-network"],
   "pressure safety valve": ["neqsim-relief-flare-network"],
   "api 520": ["neqsim-relief-flare-network"],
-  "api 521": ["neqsim-relief-flare-network"],
   "api 526": ["neqsim-relief-flare-network"],
   "api 537": ["neqsim-relief-flare-network"],
   "flare radiation": ["neqsim-relief-flare-network"],
@@ -873,5 +872,13 @@
   "multi-bed psa": ["neqsim-hydrogen-production"],
   "skarstrom cycle": ["neqsim-hydrogen-production"],
   "psa cost": ["neqsim-hydrogen-production"],
-  "psa capex": ["neqsim-hydrogen-production"]
+  "psa capex": ["neqsim-hydrogen-production"],
+  "para ortho hydrogen": ["neqsim-hydrogen-production"],
+  "ortho para conversion": ["neqsim-hydrogen-production"],
+  "para hydrogen fraction": ["neqsim-hydrogen-production"],
+  "hydrogen liquefaction correction": ["neqsim-hydrogen-production"],
+  "catalyst deactivation": ["neqsim-hydrogen-production", "neqsim-reaction-engineering"],
+  "catalyst activity factor": ["neqsim-hydrogen-production", "neqsim-reaction-engineering"],
+  "smr catalyst life": ["neqsim-hydrogen-production", "neqsim-reaction-engineering"],
+  "ammonia cracking catalyst": ["neqsim-hydrogen-production", "neqsim-reaction-engineering"]
 }

--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,42 @@
 
 ---
 
+## 2026-05-27 — Horizon-3 Hydrogen Foundations
+
+### Summary
+Added the first Horizon-3 hydrogen-production foundation utilities: cryogenic
+para/ortho H₂ correction factors and catalyst deactivation activity screening.
+
+### New classes
+- `neqsim.thermo.util.hydrogen.ParaOrthoH2Correction` — rigid-rotor
+  para/ortho partition-function utility for equilibrium para fraction,
+  normal-to-equilibrium conversion heat, equilibrium-vs-frozen Cp correction,
+  bounded thermal-conductivity correction factor and catalyst conversion time
+  screening.
+- `neqsim.process.equipment.reactor.CatalystDeactivationKinetics` — first-order
+  activity decay model for `CatalystBed`, covering sulfur poisoning, chloride
+  poisoning, coking and thermal sintering for nickel reforming, iron-chromium
+  HT-shift, copper-zinc LT-shift and ruthenium ammonia-cracking catalysts.
+
+### Skill and docs
+- `neqsim-hydrogen-production` skill: added Horizon-3 foundation class table,
+  para/ortho correction recipe and catalyst deactivation recipe.
+- `skill-index.json`: added para/ortho hydrogen and catalyst-life keywords.
+- `docs/process/hydrogen_production.md`: added cryogenic spin-isomer and
+  catalyst-deactivation screening sections.
+
+### Tests
+- `ParaOrthoH2CorrectionTest` — equilibrium para-fraction limits, conversion
+  heat, Cp correction, thermal-conductivity factor and catalyst time ranking.
+- `CatalystDeactivationKineticsTest` — catalyst family sensitivity, coking,
+  thermal sintering, dominant mechanism, JSON output and `CatalystBed` activity
+  update.
+
+### Compatibility
+No breaking changes. Existing Leachman, reactor and CatalystBed APIs are unchanged.
+
+---
+
 ## 2026-05-27 — Horizon-1.5 PSA Cascade and Cost Estimate
 
 ### Summary

--- a/docs/process/hydrogen_production.md
+++ b/docs/process/hydrogen_production.md
@@ -1,6 +1,6 @@
 ---
 title: Hydrogen Production with NeqSim
-description: Modeling guide for hydrogen production routes — pressure-swing adsorption (PSA) purification of SMR/WGS syngas (blue H2) and water electrolysis (green/pink H2). Covers PressureSwingAdsorptionBed, PSACascade, Electrolyzer with PEM/Alkaline/SOEC/AEM technology selector, I-V characteristic, and CAPEX estimation.
+description: Modeling guide for hydrogen production routes — pressure-swing adsorption (PSA) purification of SMR/WGS syngas (blue H2) and water electrolysis (green/pink H2). Covers PressureSwingAdsorptionBed, PSACascade, Electrolyzer with PEM/Alkaline/SOEC/AEM technology selector, I-V characteristic, CAPEX estimation, para/ortho hydrogen corrections, and catalyst deactivation screening.
 ---
 
 # Hydrogen Production with NeqSim
@@ -14,8 +14,9 @@ NeqSim covers two hydrogen production routes natively:
    stacks.
 
 This page documents the Horizon-1 classes added on
-[PR #2221](https://github.com/equinor/neqsim/pull/2221) plus the Horizon-1.5
-PSA cascade and PSA CAPEX additions. Companion guides:
+[PR #2221](https://github.com/equinor/neqsim/pull/2221), the Horizon-1.5
+PSA cascade and PSA CAPEX additions, and the first Horizon-3 foundation utilities
+for cryogenic H₂ spin-isomer corrections and catalyst life screening. Companion guides:
 [CCS and hydrogen transport](../ccs_hydrogen/index.md) and the
 [reaction engineering](../chemicalreactions/index.md) reformer kinetics.
 
@@ -43,6 +44,8 @@ PSA cascade and PSA CAPEX additions. Companion guides:
 | `ElectrolyzerIVCharacteristic` | `neqsim.process.equipment.electrolyzer` | Tafel + ohmic voltage model |
 | `ElectrolyzerCostEstimate` | `neqsim.process.costestimation.electrolyzer` | Specific-CAPEX × scale × CEPCI |
 | `PSACostEstimate` | `neqsim.process.costestimation.adsorber` | PSA vessel + switching valve skid + sorbent inventory CAPEX |
+| `ParaOrthoH2Correction` | `neqsim.thermo.util.hydrogen` | Equilibrium para fraction, conversion heat, Cp and thermal-conductivity correction factors |
+| `CatalystDeactivationKinetics` | `neqsim.process.equipment.reactor` | Sulfur/chloride/coking/sintering activity decay for H₂-production catalysts |
 
 ## Blue H₂ — PSA purification
 
@@ -192,6 +195,55 @@ scale exponent 0.6, USD 60 000 switching-valve skid per bed, activated carbon at
 USD 4/kg, Zeolite 13X at USD 10/kg, and CEPCI 800 reference. This is an AACE
 Class 4–5 screening estimate.
 
+## Cryogenic H₂ spin-isomer corrections
+
+Normal hydrogen is approximately 25% para and 75% ortho at ambient temperature.
+In liquid-hydrogen service the equilibrium mixture shifts strongly toward
+para-hydrogen, releasing conversion heat that must be removed in liquefaction
+and storage systems. `ParaOrthoH2Correction` provides a compact screening model:
+
+```java
+double para20K = ParaOrthoH2Correction.getEquilibriumParaFraction(20.0);
+double heatJPerKg = ParaOrthoH2Correction.getNormalToEquilibriumHeatJPerKg(20.0);
+double cpCorrection = ParaOrthoH2Correction.getCpCorrectionJPerKgK(40.0);
+double conductivityFactor = ParaOrthoH2Correction.getThermalConductivityCorrectionFactor(20.0);
+double tauSeconds = ParaOrthoH2Correction.estimateEquilibrationTimeSeconds(
+  77.0, ParaOrthoH2Correction.ConversionCatalyst.HYDROUS_FERRIC_OXIDE);
+```
+
+The partition-function model approaches 25% para at warm temperatures and >99%
+para near 20 K. The conversion heat is positive for exothermic conversion from
+normal hydrogen to the lower-energy equilibrium mixture. Thermal-conductivity
+factors are bounded screening multipliers for normal-H₂ correlations, not a
+replacement for detailed Leachman/NIST transport data.
+
+## Catalyst deactivation screening
+
+Hydrogen-production catalysts can lose activity through sulfur poisoning,
+chloride poisoning, coking, and thermal sintering. `CatalystDeactivationKinetics`
+provides first-order screening rates for nickel SMR catalysts, iron-chromium
+HT-shift catalysts, copper-zinc LT-shift catalysts, and ruthenium ammonia-cracking
+catalysts:
+
+```java
+CatalystBed bed = new CatalystBed();
+CatalystDeactivationKinetics kinetics = new CatalystDeactivationKinetics(
+  CatalystDeactivationKinetics.CatalystFamily.NICKEL_REFORMING)
+    .setTemperature(973.15)
+    .setSulfurPpmv(0.05)
+    .setCarbonPotential(0.5)
+    .setSteamToCarbonRatio(2.5)
+    .setOperationHours(8000.0);
+
+double activity = kinetics.applyTo(bed);
+double timeTo80 = kinetics.estimateTimeToActivity(0.80);
+String mechanism = kinetics.getDominantMechanism();
+```
+
+Use this as an early design or digital-twin input for activity-factor studies.
+Replace the default coefficients with vendor or plant-history data before using
+the result for guaranteed catalyst run length.
+
 ## Color taxonomy
 
 | Color | Route | NeqSim primitives |
@@ -219,6 +271,12 @@ Class 4–5 screening estimate.
 - **PSA cascade estimate**: `PSACostEstimate(PSACascade)` uses the template bed
   geometry. Set `setBedDiameter()` and `setBedLength()` before constructing the
   cost object if the default 2 m × 4 m bed is not appropriate.
+- **Para/ortho correction scope**: `ParaOrthoH2Correction` gives screening
+  corrections for cryogenic service. Detailed liquefaction design still needs a
+  full heat-exchanger/expander flowsheet with validated hydrogen property data.
+- **Catalyst deactivation scope**: default deactivation constants are
+  conservative screening values. Use vendor, laboratory, or historian-tuned
+  coefficients for life guarantees.
 
 ## Tests
 
@@ -231,15 +289,17 @@ Class 4–5 screening estimate.
 | `ElectrolyzerCostEstimateTest` | Per-tech ordering, BoP toggle, scale economy |
 | `PSACascadeTest` | Bed-count uplift, 0.93 recovery cap, tail-gas balance, invalid inputs |
 | `PSACostEstimateTest` | Bed-count cost scaling, sorbent cost ordering, BoP toggle, cascade constructor |
+| `ParaOrthoH2CorrectionTest` | Equilibrium para fraction, conversion heat, Cp correction, conductivity factor, catalyst time ranking |
+| `CatalystDeactivationKineticsTest` | Catalyst-family sensitivity, coking, sintering, dominant mechanism, CatalystBed activity update |
 
 ## Deferred to Horizon 2 / 3
 
 - Rate-based amine absorber for CO₂ capture upstream of blue H₂
-- Cryogenic H₂ liquefaction with ortho/para conversion
+- Full cryogenic H₂ liquefaction train with expanders and heat integration
 - Reformer furnace radiation coupling
 - Ammonia cracking kinetics for H₂ delivery from NH₃
 - Hydrogen LCA per production step
-- LOHC, photo-electrolysis, catalyst deactivation
+- LOHC and photo-electrolysis
 
 ## Related documentation
 

--- a/src/main/java/neqsim/process/equipment/reactor/CatalystDeactivationKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/CatalystDeactivationKinetics.java
@@ -1,0 +1,432 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Screening model for hydrogen-production catalyst deactivation.
+ *
+ * <p>
+ * The model combines simple first-order damage rates for sulfur poisoning, chloride poisoning,
+ * coking and thermal sintering. It is intended for early SMR, WGS and ammonia-cracking studies
+ * where a reactor or {@link CatalystBed} needs a transparent activity factor over operating time.
+ * </p>
+ *
+ * <p>
+ * The constants are deliberately conservative order-of-magnitude defaults. Vendor-specific
+ * catalysts should replace the defaults with measured rates before detailed design.
+ * </p>
+ *
+ * @author ESOL
+ * @version 1.0
+ */
+public class CatalystDeactivationKinetics implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final double GAS_CONSTANT = 8.314462618;
+
+  /** Catalyst families used in hydrogen production and carrier cracking service. */
+  public enum CatalystFamily {
+    /** Nickel reforming catalyst for SMR, pre-reforming and methanation side service. */
+    NICKEL_REFORMING("Nickel reforming", 1.5e-4, 4.0e-5, 2.0e-4, 2.0e7, 220000.0, 923.15),
+    /** Iron-chromium high-temperature shift catalyst. */
+    IRON_CHROMIUM_HT_SHIFT("Iron-chromium HT shift", 3.0e-5, 2.0e-5, 1.0e-5, 5.0e6, 210000.0,
+        673.15),
+    /** Copper-zinc low-temperature shift catalyst. */
+    COPPER_ZINC_LT_SHIFT("Copper-zinc LT shift", 8.0e-4, 2.5e-4, 5.0e-6, 1.0e5, 140000.0, 523.15),
+    /** Ruthenium catalyst for ammonia cracking. */
+    RUTHENIUM_AMMONIA_CRACKING("Ruthenium ammonia cracking", 4.0e-4, 1.0e-4, 5.0e-5, 1.0e7,
+        200000.0, 823.15);
+
+    private final String displayName;
+    private final double sulfurCoefficientPerHourPerPpm;
+    private final double chlorideCoefficientPerHourPerPpm;
+    private final double cokingCoefficientPerHour;
+    private final double sinteringPreExponentialPerHour;
+    private final double sinteringActivationEnergyJPerMol;
+    private final double sinteringOnsetTemperatureK;
+
+    /**
+     * Creates a catalyst-family default data set.
+     *
+     * @param displayName human-readable catalyst name
+     * @param sulfurCoefficientPerHourPerPpm sulfur poisoning coefficient in 1/(h ppmv)
+     * @param chlorideCoefficientPerHourPerPpm chloride poisoning coefficient in 1/(h ppmv)
+     * @param cokingCoefficientPerHour coking damage coefficient in 1/h
+     * @param sinteringPreExponentialPerHour sintering pre-exponential factor in 1/h
+     * @param sinteringActivationEnergyJPerMol sintering activation energy in J/mol
+     * @param sinteringOnsetTemperatureK sintering onset temperature in K
+     */
+    CatalystFamily(String displayName, double sulfurCoefficientPerHourPerPpm,
+        double chlorideCoefficientPerHourPerPpm, double cokingCoefficientPerHour,
+        double sinteringPreExponentialPerHour, double sinteringActivationEnergyJPerMol,
+        double sinteringOnsetTemperatureK) {
+      this.displayName = displayName;
+      this.sulfurCoefficientPerHourPerPpm = sulfurCoefficientPerHourPerPpm;
+      this.chlorideCoefficientPerHourPerPpm = chlorideCoefficientPerHourPerPpm;
+      this.cokingCoefficientPerHour = cokingCoefficientPerHour;
+      this.sinteringPreExponentialPerHour = sinteringPreExponentialPerHour;
+      this.sinteringActivationEnergyJPerMol = sinteringActivationEnergyJPerMol;
+      this.sinteringOnsetTemperatureK = sinteringOnsetTemperatureK;
+    }
+
+    /**
+     * Gets a human-readable catalyst-family name.
+     *
+     * @return display name
+     */
+    public String getDisplayName() {
+      return displayName;
+    }
+  }
+
+  private CatalystFamily catalystFamily = CatalystFamily.NICKEL_REFORMING;
+  private double temperatureK = 973.15;
+  private double operationHours = 0.0;
+  private double sulfurPpmv = 0.0;
+  private double chloridePpmv = 0.0;
+  private double carbonPotential = 0.0;
+  private double steamToCarbonRatio = 3.0;
+
+  /**
+   * Creates a catalyst deactivation model with nickel reforming defaults.
+   */
+  public CatalystDeactivationKinetics() {}
+
+  /**
+   * Creates a catalyst deactivation model for a catalyst family.
+   *
+   * @param catalystFamily catalyst family, not null
+   */
+  public CatalystDeactivationKinetics(CatalystFamily catalystFamily) {
+    setCatalystFamily(catalystFamily);
+  }
+
+  /**
+   * Sets the catalyst family.
+   *
+   * @param catalystFamily catalyst family, not null
+   * @return this deactivation model
+   */
+  public CatalystDeactivationKinetics setCatalystFamily(CatalystFamily catalystFamily) {
+    if (catalystFamily == null) {
+      throw new IllegalArgumentException("catalystFamily cannot be null");
+    }
+    this.catalystFamily = catalystFamily;
+    return this;
+  }
+
+  /**
+   * Sets the catalyst-bed operating temperature.
+   *
+   * @param temperatureK temperature in K, must be greater than 0
+   * @return this deactivation model
+   */
+  public CatalystDeactivationKinetics setTemperature(double temperatureK) {
+    if (!Double.isFinite(temperatureK) || temperatureK <= 0.0) {
+      throw new IllegalArgumentException("temperatureK must be finite and greater than 0");
+    }
+    this.temperatureK = temperatureK;
+    return this;
+  }
+
+  /**
+   * Sets operating time.
+   *
+   * @param operationHours operating time in hours, must be non-negative
+   * @return this deactivation model
+   */
+  public CatalystDeactivationKinetics setOperationHours(double operationHours) {
+    validateNonNegative(operationHours, "operationHours");
+    this.operationHours = operationHours;
+    return this;
+  }
+
+  /**
+   * Sets sulfur slip to the catalyst bed.
+   *
+   * @param sulfurPpmv sulfur compounds as H2S-equivalent ppmv, must be non-negative
+   * @return this deactivation model
+   */
+  public CatalystDeactivationKinetics setSulfurPpmv(double sulfurPpmv) {
+    validateNonNegative(sulfurPpmv, "sulfurPpmv");
+    this.sulfurPpmv = sulfurPpmv;
+    return this;
+  }
+
+  /**
+   * Sets chloride slip to the catalyst bed.
+   *
+   * @param chloridePpmv chloride compounds as HCl-equivalent ppmv, must be non-negative
+   * @return this deactivation model
+   */
+  public CatalystDeactivationKinetics setChloridePpmv(double chloridePpmv) {
+    validateNonNegative(chloridePpmv, "chloridePpmv");
+    this.chloridePpmv = chloridePpmv;
+    return this;
+  }
+
+  /**
+   * Sets a dimensionless carbon-formation driving force.
+   *
+   * @param carbonPotential carbon potential, where 0 is no coking drive and 1 is severe
+   * @return this deactivation model
+   */
+  public CatalystDeactivationKinetics setCarbonPotential(double carbonPotential) {
+    validateNonNegative(carbonPotential, "carbonPotential");
+    this.carbonPotential = carbonPotential;
+    return this;
+  }
+
+  /**
+   * Sets steam-to-carbon ratio for coking suppression.
+   *
+   * @param steamToCarbonRatio steam-to-carbon molar ratio, must be non-negative
+   * @return this deactivation model
+   */
+  public CatalystDeactivationKinetics setSteamToCarbonRatio(double steamToCarbonRatio) {
+    validateNonNegative(steamToCarbonRatio, "steamToCarbonRatio");
+    this.steamToCarbonRatio = steamToCarbonRatio;
+    return this;
+  }
+
+  /**
+   * Gets the sulfur poisoning damage rate.
+   *
+   * @return sulfur poisoning rate in 1/h
+   */
+  public double getSulfurPoisoningRatePerHour() {
+    double temperatureFactor = Math.sqrt(getReferenceTemperatureK() / temperatureK);
+    return catalystFamily.sulfurCoefficientPerHourPerPpm * sulfurPpmv * temperatureFactor;
+  }
+
+  /**
+   * Gets the chloride poisoning damage rate.
+   *
+   * @return chloride poisoning rate in 1/h
+   */
+  public double getChloridePoisoningRatePerHour() {
+    double temperatureFactor = Math.sqrt(getReferenceTemperatureK() / temperatureK);
+    return catalystFamily.chlorideCoefficientPerHourPerPpm * chloridePpmv * temperatureFactor;
+  }
+
+  /**
+   * Gets the coking damage rate.
+   *
+   * @return coking rate in 1/h
+   */
+  public double getCokingRatePerHour() {
+    double steamProtection = Math.exp(-0.6 * Math.max(0.0, steamToCarbonRatio - 1.0));
+    double lowSteamPenalty = steamToCarbonRatio < 2.0 ? 1.0 + (2.0 - steamToCarbonRatio) : 1.0;
+    return catalystFamily.cokingCoefficientPerHour * carbonPotential * steamProtection
+        * lowSteamPenalty;
+  }
+
+  /**
+   * Gets the thermal sintering damage rate.
+   *
+   * @return thermal sintering rate in 1/h
+   */
+  public double getThermalSinteringRatePerHour() {
+    if (temperatureK <= catalystFamily.sinteringOnsetTemperatureK) {
+      return 0.0;
+    }
+    double arrhenius = catalystFamily.sinteringPreExponentialPerHour * Math
+        .exp(-catalystFamily.sinteringActivationEnergyJPerMol / (GAS_CONSTANT * temperatureK));
+    double severity = 1.0 + (temperatureK - catalystFamily.sinteringOnsetTemperatureK) / 100.0;
+    return arrhenius * severity;
+  }
+
+  /**
+   * Calculates the total first-order deactivation rate.
+   *
+   * @return total deactivation rate in 1/h
+   */
+  public double getTotalDeactivationRatePerHour() {
+    return getSulfurPoisoningRatePerHour() + getChloridePoisoningRatePerHour()
+        + getCokingRatePerHour() + getThermalSinteringRatePerHour();
+  }
+
+  /**
+   * Calculates remaining catalyst activity after the configured operating time.
+   *
+   * @return catalyst activity factor in the range 0 to 1
+   */
+  public double calculateActivity() {
+    double rate = getTotalDeactivationRatePerHour();
+    double activity = Math.exp(-rate * operationHours);
+    return Math.max(0.0, Math.min(1.0, activity));
+  }
+
+  /**
+   * Applies the calculated activity to a CatalystBed instance.
+   *
+   * @param catalystBed catalyst bed to update, not null
+   * @return applied activity factor
+   */
+  public double applyTo(CatalystBed catalystBed) {
+    if (catalystBed == null) {
+      throw new IllegalArgumentException("catalystBed cannot be null");
+    }
+    double activity = calculateActivity();
+    catalystBed.setActivityFactor(activity);
+    return activity;
+  }
+
+  /**
+   * Estimates operating time until the catalyst reaches a target activity.
+   *
+   * @param activityThreshold target activity in the interval (0, 1]
+   * @return time in hours, or positive infinity when no deactivation rate is present
+   */
+  public double estimateTimeToActivity(double activityThreshold) {
+    if (!Double.isFinite(activityThreshold) || activityThreshold <= 0.0
+        || activityThreshold > 1.0) {
+      throw new IllegalArgumentException("activityThreshold must be in the interval (0, 1]");
+    }
+    double rate = getTotalDeactivationRatePerHour();
+    if (rate <= 0.0) {
+      return Double.POSITIVE_INFINITY;
+    }
+    return -Math.log(activityThreshold) / rate;
+  }
+
+  /**
+   * Identifies the largest deactivation mechanism at the current conditions.
+   *
+   * @return mechanism name
+   */
+  public String getDominantMechanism() {
+    Map<String, Double> rates = getRateBreakdown();
+    String dominant = "none";
+    double maxRate = 0.0;
+    for (Map.Entry<String, Double> entry : rates.entrySet()) {
+      if (entry.getValue() > maxRate) {
+        dominant = entry.getKey();
+        maxRate = entry.getValue();
+      }
+    }
+    return dominant;
+  }
+
+  /**
+   * Gets a rate breakdown for all deactivation mechanisms.
+   *
+   * @return ordered map of mechanism names to rates in 1/h
+   */
+  public Map<String, Double> getRateBreakdown() {
+    Map<String, Double> rates = new LinkedHashMap<String, Double>();
+    rates.put("sulfur_poisoning", getSulfurPoisoningRatePerHour());
+    rates.put("chloride_poisoning", getChloridePoisoningRatePerHour());
+    rates.put("coking", getCokingRatePerHour());
+    rates.put("thermal_sintering", getThermalSinteringRatePerHour());
+    return rates;
+  }
+
+  /**
+   * Serializes the current calculation state and rates to JSON.
+   *
+   * @return pretty-printed JSON string
+   */
+  public String toJson() {
+    Map<String, Object> data = new LinkedHashMap<String, Object>();
+    data.put("catalystFamily", catalystFamily.name());
+    data.put("displayName", catalystFamily.getDisplayName());
+    data.put("temperatureK", temperatureK);
+    data.put("operationHours", operationHours);
+    data.put("sulfurPpmv", sulfurPpmv);
+    data.put("chloridePpmv", chloridePpmv);
+    data.put("carbonPotential", carbonPotential);
+    data.put("steamToCarbonRatio", steamToCarbonRatio);
+    data.put("ratesPerHour", getRateBreakdown());
+    data.put("totalRatePerHour", getTotalDeactivationRatePerHour());
+    data.put("activity", calculateActivity());
+    data.put("dominantMechanism", getDominantMechanism());
+    return new GsonBuilder().setPrettyPrinting().create().toJson(data);
+  }
+
+  /**
+   * Gets the configured catalyst family.
+   *
+   * @return catalyst family
+   */
+  public CatalystFamily getCatalystFamily() {
+    return catalystFamily;
+  }
+
+  /**
+   * Gets the configured temperature.
+   *
+   * @return temperature in K
+   */
+  public double getTemperatureK() {
+    return temperatureK;
+  }
+
+  /**
+   * Gets the configured operating time.
+   *
+   * @return operating time in hours
+   */
+  public double getOperationHours() {
+    return operationHours;
+  }
+
+  /**
+   * Gets sulfur concentration.
+   *
+   * @return sulfur concentration in ppmv
+   */
+  public double getSulfurPpmv() {
+    return sulfurPpmv;
+  }
+
+  /**
+   * Gets chloride concentration.
+   *
+   * @return chloride concentration in ppmv
+   */
+  public double getChloridePpmv() {
+    return chloridePpmv;
+  }
+
+  /**
+   * Gets carbon potential.
+   *
+   * @return carbon potential
+   */
+  public double getCarbonPotential() {
+    return carbonPotential;
+  }
+
+  /**
+   * Gets steam-to-carbon ratio.
+   *
+   * @return steam-to-carbon ratio
+   */
+  public double getSteamToCarbonRatio() {
+    return steamToCarbonRatio;
+  }
+
+  /**
+   * Returns a common reference temperature for poisoning damage normalization.
+   *
+   * @return reference temperature in K
+   */
+  private static double getReferenceTemperatureK() {
+    return 673.15;
+  }
+
+  /**
+   * Validates a finite non-negative input.
+   *
+   * @param value value to validate
+   * @param name parameter name for diagnostics
+   */
+  private static void validateNonNegative(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and non-negative");
+    }
+  }
+}

--- a/src/main/java/neqsim/thermo/util/hydrogen/ParaOrthoH2Correction.java
+++ b/src/main/java/neqsim/thermo/util/hydrogen/ParaOrthoH2Correction.java
@@ -1,0 +1,323 @@
+package neqsim.thermo.util.hydrogen;
+
+import java.io.Serializable;
+
+/**
+ * Utility calculations for para/ortho hydrogen spin-isomer corrections.
+ *
+ * <p>
+ * The model uses the rigid-rotor rotational partition function for molecular hydrogen with the
+ * correct nuclear spin statistical weights. It is intended for cryogenic hydrogen screening,
+ * liquefaction pre-design and agent workflows where normal hydrogen properties need a first-order
+ * correction for equilibrium para-hydrogen enrichment below about 100 K.
+ * </p>
+ *
+ * <p>
+ * The class does not replace detailed NIST/Leachman property calls. Use it to estimate the
+ * equilibrium para fraction, heat released by conversion from normal hydrogen, additional
+ * equilibrium rotational heat capacity, a bounded thermal-conductivity correction factor and a
+ * screening conversion time for common catalysts.
+ * </p>
+ *
+ * @author ESOL
+ * @version 1.0
+ */
+public final class ParaOrthoH2Correction implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final double GAS_CONSTANT = 8.314462618;
+  private static final double MOLAR_MASS_H2_KG_PER_MOL = 2.01588e-3;
+  private static final double ROTATIONAL_TEMPERATURE_K = 85.3;
+  private static final double NORMAL_PARA_FRACTION = 0.25;
+  private static final double REFERENCE_CONVERSION_TEMPERATURE_K = 77.0;
+  private static final int MAX_ROTATIONAL_QUANTUM_NUMBER = 80;
+
+  /** Catalyst families used for para/ortho conversion time screening. */
+  public enum ConversionCatalyst {
+    /** No catalyst present; conversion is effectively frozen for engineering screening. */
+    NONE(Double.POSITIVE_INFINITY, 0.0),
+    /** Activated carbon or charcoal conversion bed. */
+    ACTIVATED_CHARCOAL(1800.0, 180.0),
+    /** Hydrous ferric oxide conversion catalyst. */
+    HYDROUS_FERRIC_OXIDE(600.0, 140.0),
+    /** Generic paramagnetic oxide such as chromium, manganese or rare-earth oxide. */
+    PARAMAGNETIC_OXIDE(300.0, 120.0);
+
+    private final double referenceTimeSeconds;
+    private final double activationTemperatureK;
+
+    /**
+     * Creates a catalyst entry for conversion-time screening.
+     *
+     * @param referenceTimeSeconds time constant at 77 K in seconds
+     * @param activationTemperatureK empirical temperature sensitivity in K
+     */
+    ConversionCatalyst(double referenceTimeSeconds, double activationTemperatureK) {
+      this.referenceTimeSeconds = referenceTimeSeconds;
+      this.activationTemperatureK = activationTemperatureK;
+    }
+  }
+
+  /**
+   * Private constructor for utility class.
+   */
+  private ParaOrthoH2Correction() {}
+
+  /**
+   * Returns the normal hydrogen para fraction at room-temperature equilibrium.
+   *
+   * @return para fraction of normal hydrogen, equal to 0.25
+   */
+  public static double getNormalParaFraction() {
+    return NORMAL_PARA_FRACTION;
+  }
+
+  /**
+   * Calculates the equilibrium para-hydrogen fraction at the specified temperature.
+   *
+   * @param temperatureK hydrogen temperature in K, must be greater than 0
+   * @return equilibrium para fraction in the range 0 to 1
+   */
+  public static double getEquilibriumParaFraction(double temperatureK) {
+    validateTemperature(temperatureK);
+    RotationalPartition para = calculatePartition(temperatureK, true);
+    RotationalPartition ortho = calculatePartition(temperatureK, false);
+    double paraWeighted = para.partitionFunction;
+    double orthoWeighted = 3.0 * ortho.partitionFunction;
+    return paraWeighted / (paraWeighted + orthoWeighted);
+  }
+
+  /**
+   * Calculates the equilibrium ortho-hydrogen fraction at the specified temperature.
+   *
+   * @param temperatureK hydrogen temperature in K, must be greater than 0
+   * @return equilibrium ortho fraction in the range 0 to 1
+   */
+  public static double getEquilibriumOrthoFraction(double temperatureK) {
+    return 1.0 - getEquilibriumParaFraction(temperatureK);
+  }
+
+  /**
+   * Calculates the heat released when hydrogen converts from normal composition to equilibrium.
+   *
+   * @param temperatureK hydrogen temperature in K, must be greater than 0
+   * @return exothermic conversion heat in J/kg, positive when heat is released
+   */
+  public static double getNormalToEquilibriumHeatJPerKg(double temperatureK) {
+    return getConversionHeatJPerKg(NORMAL_PARA_FRACTION, getEquilibriumParaFraction(temperatureK),
+        temperatureK);
+  }
+
+  /**
+   * Calculates the heat released between two spin-isomer compositions at fixed temperature.
+   *
+   * @param initialParaFraction initial para fraction in the range 0 to 1
+   * @param finalParaFraction final para fraction in the range 0 to 1
+   * @param temperatureK hydrogen temperature in K, must be greater than 0
+   * @return heat released in J/kg, positive when the final state has lower rotational energy
+   */
+  public static double getConversionHeatJPerKg(double initialParaFraction, double finalParaFraction,
+      double temperatureK) {
+    validateFraction(initialParaFraction, "initialParaFraction");
+    validateFraction(finalParaFraction, "finalParaFraction");
+    validateTemperature(temperatureK);
+    double initialEnergy = rotationalEnergyJPerMol(temperatureK, initialParaFraction);
+    double finalEnergy = rotationalEnergyJPerMol(temperatureK, finalParaFraction);
+    return (initialEnergy - finalEnergy) / MOLAR_MASS_H2_KG_PER_MOL;
+  }
+
+  /**
+   * Calculates equilibrium rotational heat capacity for spin-equilibrated hydrogen.
+   *
+   * @param temperatureK hydrogen temperature in K, must be greater than 0
+   * @return rotational heat capacity in J/(kg K)
+   */
+  public static double getEquilibriumRotationalCpJPerKgK(double temperatureK) {
+    validateTemperature(temperatureK);
+    return numericalCp(temperatureK, true);
+  }
+
+  /**
+   * Calculates rotational heat capacity for frozen normal hydrogen spin composition.
+   *
+   * @param temperatureK hydrogen temperature in K, must be greater than 0
+   * @return rotational heat capacity in J/(kg K)
+   */
+  public static double getFrozenNormalRotationalCpJPerKgK(double temperatureK) {
+    validateTemperature(temperatureK);
+    return numericalCp(temperatureK, false);
+  }
+
+  /**
+   * Calculates the extra rotational heat capacity from para/ortho equilibration.
+   *
+   * @param temperatureK hydrogen temperature in K, must be greater than 0
+   * @return equilibrium minus frozen-normal rotational heat capacity in J/(kg K)
+   */
+  public static double getCpCorrectionJPerKgK(double temperatureK) {
+    return getEquilibriumRotationalCpJPerKgK(temperatureK)
+        - getFrozenNormalRotationalCpJPerKgK(temperatureK);
+  }
+
+  /**
+   * Estimates the thermal-conductivity correction factor for equilibrium hydrogen.
+   *
+   * @param temperatureK hydrogen temperature in K, must be greater than 0
+   * @return factor to multiply normal-hydrogen thermal conductivity by
+   */
+  public static double getThermalConductivityCorrectionFactor(double temperatureK) {
+    return getThermalConductivityCorrectionFactor(temperatureK,
+        getEquilibriumParaFraction(temperatureK));
+  }
+
+  /**
+   * Estimates a bounded thermal-conductivity correction factor from para content.
+   *
+   * <p>
+   * The correlation is deliberately conservative: it approaches 1.0 above cryogenic temperatures
+   * and limits the correction to a narrow band for screening use.
+   * </p>
+   *
+   * @param temperatureK hydrogen temperature in K, must be greater than 0
+   * @param paraFraction para-hydrogen fraction in the range 0 to 1
+   * @return factor to multiply normal-hydrogen thermal conductivity by
+   */
+  public static double getThermalConductivityCorrectionFactor(double temperatureK,
+      double paraFraction) {
+    validateTemperature(temperatureK);
+    validateFraction(paraFraction, "paraFraction");
+    double cryogenicWeight = 1.0 / (1.0 + Math.exp((temperatureK - 120.0) / 20.0));
+    double enrichment = (paraFraction - NORMAL_PARA_FRACTION) / (1.0 - NORMAL_PARA_FRACTION);
+    double factor = 1.0 - 0.08 * cryogenicWeight * enrichment;
+    return Math.max(0.90, Math.min(1.04, factor));
+  }
+
+  /**
+   * Estimates para/ortho conversion time for a catalyst family.
+   *
+   * @param temperatureK hydrogen temperature in K, must be greater than 0
+   * @param catalyst conversion catalyst family, not null
+   * @return first-order conversion time constant in seconds
+   */
+  public static double estimateEquilibrationTimeSeconds(double temperatureK,
+      ConversionCatalyst catalyst) {
+    validateTemperature(temperatureK);
+    if (catalyst == null) {
+      throw new IllegalArgumentException("catalyst cannot be null");
+    }
+    if (catalyst == ConversionCatalyst.NONE) {
+      return Double.POSITIVE_INFINITY;
+    }
+    double exponent = catalyst.activationTemperatureK
+        * (1.0 / temperatureK - 1.0 / REFERENCE_CONVERSION_TEMPERATURE_K);
+    double time = catalyst.referenceTimeSeconds * Math.exp(exponent);
+    return Math.max(1.0, Math.min(1.0e12, time));
+  }
+
+  /**
+   * Calculates a rotational partition function for either para or ortho states.
+   *
+   * @param temperatureK hydrogen temperature in K
+   * @param para true for even-J para states, false for odd-J ortho states
+   * @return partition function and average rotational energy data
+   */
+  private static RotationalPartition calculatePartition(double temperatureK, boolean para) {
+    double q = 0.0;
+    double energyWeighted = 0.0;
+    int start = para ? 0 : 1;
+    for (int j = start; j <= MAX_ROTATIONAL_QUANTUM_NUMBER; j += 2) {
+      double jTerm = j * (j + 1.0);
+      double degeneracy = 2.0 * j + 1.0;
+      double boltzmann = Math.exp(-ROTATIONAL_TEMPERATURE_K * jTerm / temperatureK);
+      double weight = degeneracy * boltzmann;
+      q += weight;
+      energyWeighted += weight * GAS_CONSTANT * ROTATIONAL_TEMPERATURE_K * jTerm;
+    }
+    return new RotationalPartition(q, energyWeighted / q);
+  }
+
+  /**
+   * Calculates mixture rotational energy at a fixed para fraction.
+   *
+   * @param temperatureK hydrogen temperature in K
+   * @param paraFraction para fraction in the range 0 to 1
+   * @return rotational energy in J/mol
+   */
+  private static double rotationalEnergyJPerMol(double temperatureK, double paraFraction) {
+    RotationalPartition para = calculatePartition(temperatureK, true);
+    RotationalPartition ortho = calculatePartition(temperatureK, false);
+    return paraFraction * para.averageEnergyJPerMol
+        + (1.0 - paraFraction) * ortho.averageEnergyJPerMol;
+  }
+
+  /**
+   * Calculates heat capacity by finite-difference differentiation of rotational energy.
+   *
+   * @param temperatureK hydrogen temperature in K
+   * @param equilibrium true for spin-equilibrium composition, false for frozen normal composition
+   * @return heat capacity in J/(kg K)
+   */
+  private static double numericalCp(double temperatureK, boolean equilibrium) {
+    double delta = Math.max(0.01, temperatureK * 1.0e-4);
+    if (temperatureK - delta <= 0.0) {
+      double upper = rotationalEnergyForCp(temperatureK + delta, equilibrium);
+      double center = rotationalEnergyForCp(temperatureK, equilibrium);
+      return (upper - center) / delta / MOLAR_MASS_H2_KG_PER_MOL;
+    }
+    double upper = rotationalEnergyForCp(temperatureK + delta, equilibrium);
+    double lower = rotationalEnergyForCp(temperatureK - delta, equilibrium);
+    return (upper - lower) / (2.0 * delta) / MOLAR_MASS_H2_KG_PER_MOL;
+  }
+
+  /**
+   * Calculates rotational energy for the finite-difference heat capacity routine.
+   *
+   * @param temperatureK hydrogen temperature in K
+   * @param equilibrium true for spin-equilibrium composition, false for frozen normal composition
+   * @return rotational energy in J/mol
+   */
+  private static double rotationalEnergyForCp(double temperatureK, boolean equilibrium) {
+    double paraFraction =
+        equilibrium ? getEquilibriumParaFraction(temperatureK) : NORMAL_PARA_FRACTION;
+    return rotationalEnergyJPerMol(temperatureK, paraFraction);
+  }
+
+  /**
+   * Validates temperature input.
+   *
+   * @param temperatureK temperature in K
+   */
+  private static void validateTemperature(double temperatureK) {
+    if (!Double.isFinite(temperatureK) || temperatureK <= 0.0) {
+      throw new IllegalArgumentException("temperatureK must be finite and greater than 0");
+    }
+  }
+
+  /**
+   * Validates a composition fraction.
+   *
+   * @param fraction fraction value
+   * @param name parameter name for diagnostics
+   */
+  private static void validateFraction(double fraction, String name) {
+    if (!Double.isFinite(fraction) || fraction < 0.0 || fraction > 1.0) {
+      throw new IllegalArgumentException(name + " must be finite and in the range [0, 1]");
+    }
+  }
+
+  /** Rotational partition data for one spin-isomer family. */
+  private static final class RotationalPartition {
+    private final double partitionFunction;
+    private final double averageEnergyJPerMol;
+
+    /**
+     * Creates rotational partition data.
+     *
+     * @param partitionFunction rotational partition function
+     * @param averageEnergyJPerMol average rotational energy in J/mol
+     */
+    private RotationalPartition(double partitionFunction, double averageEnergyJPerMol) {
+      this.partitionFunction = partitionFunction;
+      this.averageEnergyJPerMol = averageEnergyJPerMol;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/CatalystDeactivationKineticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/CatalystDeactivationKineticsTest.java
@@ -1,0 +1,91 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.reactor.CatalystDeactivationKinetics.CatalystFamily;
+
+/**
+ * Tests for hydrogen-production catalyst deactivation kinetics.
+ */
+public class CatalystDeactivationKineticsTest extends neqsim.NeqSimTest {
+
+  @Test
+  public void testFreshCleanCatalystRetainsActivity() {
+    CatalystDeactivationKinetics kinetics =
+        new CatalystDeactivationKinetics().setTemperature(800.0).setOperationHours(1000.0);
+
+    assertEquals(1.0, kinetics.calculateActivity(), 1.0e-12);
+    assertEquals("none", kinetics.getDominantMechanism());
+  }
+
+  @Test
+  public void testCopperZincShiftIsMoreSulfurSensitiveThanIronChromium() {
+    CatalystDeactivationKinetics copper =
+        new CatalystDeactivationKinetics(CatalystFamily.COPPER_ZINC_LT_SHIFT).setTemperature(500.0)
+            .setSulfurPpmv(0.1).setOperationHours(1000.0);
+    CatalystDeactivationKinetics iron =
+        new CatalystDeactivationKinetics(CatalystFamily.IRON_CHROMIUM_HT_SHIFT)
+            .setTemperature(650.0).setSulfurPpmv(0.1).setOperationHours(1000.0);
+
+    assertTrue(copper.getSulfurPoisoningRatePerHour() > iron.getSulfurPoisoningRatePerHour());
+    assertTrue(copper.calculateActivity() < iron.calculateActivity());
+  }
+
+  @Test
+  public void testLowSteamPromotesNickelCoking() {
+    CatalystDeactivationKinetics lowSteam = new CatalystDeactivationKinetics()
+        .setCarbonPotential(1.0).setSteamToCarbonRatio(1.2).setOperationHours(2000.0);
+    CatalystDeactivationKinetics highSteam = new CatalystDeactivationKinetics()
+        .setCarbonPotential(1.0).setSteamToCarbonRatio(4.0).setOperationHours(2000.0);
+
+    assertTrue(lowSteam.getCokingRatePerHour() > highSteam.getCokingRatePerHour());
+    assertTrue(lowSteam.calculateActivity() < highSteam.calculateActivity());
+  }
+
+  @Test
+  public void testThermalSinteringIncreasesAboveOnsetTemperature() {
+    CatalystDeactivationKinetics moderate =
+        new CatalystDeactivationKinetics().setTemperature(900.0).setOperationHours(1000.0);
+    CatalystDeactivationKinetics hot =
+        new CatalystDeactivationKinetics().setTemperature(1173.15).setOperationHours(1000.0);
+
+    assertEquals(0.0, moderate.getThermalSinteringRatePerHour(), 1.0e-15);
+    assertTrue(hot.getThermalSinteringRatePerHour() > 0.0);
+    assertTrue(hot.calculateActivity() < moderate.calculateActivity());
+  }
+
+  @Test
+  public void testDominantMechanismAndTimeToActivity() {
+    CatalystDeactivationKinetics kinetics =
+        new CatalystDeactivationKinetics(CatalystFamily.RUTHENIUM_AMMONIA_CRACKING)
+            .setTemperature(850.0).setSulfurPpmv(0.5).setOperationHours(1000.0);
+
+    assertEquals("sulfur_poisoning", kinetics.getDominantMechanism());
+    assertTrue(kinetics.estimateTimeToActivity(0.8) > 0.0);
+    assertTrue(kinetics.estimateTimeToActivity(0.8) < Double.POSITIVE_INFINITY);
+  }
+
+  @Test
+  public void testApplyToCatalystBed() {
+    CatalystBed bed = new CatalystBed();
+    CatalystDeactivationKinetics kinetics = new CatalystDeactivationKinetics().setSulfurPpmv(0.2)
+        .setCarbonPotential(0.5).setOperationHours(1000.0);
+
+    double activity = kinetics.applyTo(bed);
+
+    assertEquals(activity, bed.getActivityFactor(), 1.0e-12);
+    assertTrue(bed.getActivityFactor() < 1.0);
+  }
+
+  @Test
+  public void testJsonContainsActivityAndMechanism() {
+    CatalystDeactivationKinetics kinetics =
+        new CatalystDeactivationKinetics().setSulfurPpmv(0.1).setOperationHours(100.0);
+
+    String json = kinetics.toJson();
+
+    assertTrue(json.contains("activity"));
+    assertTrue(json.contains("dominantMechanism"));
+  }
+}

--- a/src/test/java/neqsim/thermo/util/hydrogen/ParaOrthoH2CorrectionTest.java
+++ b/src/test/java/neqsim/thermo/util/hydrogen/ParaOrthoH2CorrectionTest.java
@@ -1,0 +1,67 @@
+package neqsim.thermo.util.hydrogen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.util.hydrogen.ParaOrthoH2Correction.ConversionCatalyst;
+
+/**
+ * Tests for para/ortho hydrogen correction utilities.
+ */
+public class ParaOrthoH2CorrectionTest extends neqsim.NeqSimTest {
+
+  @Test
+  public void testEquilibriumParaFractionLimits() {
+    assertEquals(0.25, ParaOrthoH2Correction.getNormalParaFraction(), 1.0e-12);
+
+    double roomTemperature = ParaOrthoH2Correction.getEquilibriumParaFraction(300.0);
+    double liquidNitrogenTemperature = ParaOrthoH2Correction.getEquilibriumParaFraction(77.0);
+    double liquidHydrogenTemperature = ParaOrthoH2Correction.getEquilibriumParaFraction(20.0);
+
+    assertTrue(roomTemperature > 0.24 && roomTemperature < 0.27);
+    assertTrue(liquidNitrogenTemperature > 0.45 && liquidNitrogenTemperature < 0.60);
+    assertTrue(liquidHydrogenTemperature > 0.995);
+  }
+
+  @Test
+  public void testNormalToEquilibriumConversionHeatAtLiquidHydrogenTemperature() {
+    double heatJPerKg = ParaOrthoH2Correction.getNormalToEquilibriumHeatJPerKg(20.0);
+
+    assertTrue(heatJPerKg > 4.0e5);
+    assertTrue(heatJPerKg < 6.5e5);
+  }
+
+  @Test
+  public void testCpCorrectionIsCryogenicAndPositive() {
+    double cryogenicCorrection = ParaOrthoH2Correction.getCpCorrectionJPerKgK(40.0);
+    double warmCorrection = Math.abs(ParaOrthoH2Correction.getCpCorrectionJPerKgK(300.0));
+
+    assertTrue(cryogenicCorrection > 0.0);
+    assertTrue(warmCorrection < 50.0);
+  }
+
+  @Test
+  public void testThermalConductivityCorrectionRelaxesAtWarmTemperature() {
+    double cryogenicFactor = ParaOrthoH2Correction.getThermalConductivityCorrectionFactor(20.0);
+    double warmFactor = ParaOrthoH2Correction.getThermalConductivityCorrectionFactor(300.0);
+
+    assertTrue(cryogenicFactor < 1.0);
+    assertEquals(1.0, warmFactor, 0.02);
+  }
+
+  @Test
+  public void testCatalystEquilibrationTimesRankCorrectly() {
+    double charcoal = ParaOrthoH2Correction.estimateEquilibrationTimeSeconds(77.0,
+        ConversionCatalyst.ACTIVATED_CHARCOAL);
+    double ferricOxide = ParaOrthoH2Correction.estimateEquilibrationTimeSeconds(77.0,
+        ConversionCatalyst.HYDROUS_FERRIC_OXIDE);
+    double noCatalyst =
+        ParaOrthoH2Correction.estimateEquilibrationTimeSeconds(77.0, ConversionCatalyst.NONE);
+    double coldFerricOxide = ParaOrthoH2Correction.estimateEquilibrationTimeSeconds(40.0,
+        ConversionCatalyst.HYDROUS_FERRIC_OXIDE);
+
+    assertTrue(ferricOxide < charcoal);
+    assertTrue(Double.isInfinite(noCatalyst));
+    assertTrue(coldFerricOxide > ferricOxide);
+  }
+}


### PR DESCRIPTION
Stacked on PR #2222 / branch eature/h2-production-h1.5. Merge or retarget after the Horizon-1 and Horizon-1.5 PRs land.

## Summary
- Add ParaOrthoH2Correction for cryogenic H2 spin-isomer screening: equilibrium para fraction, normal-to-equilibrium heat release, Cp correction, thermal-conductivity correction factor, and conversion time by catalyst family.
- Add CatalystDeactivationKinetics for H2-production catalyst activity decay across sulfur poisoning, chloride poisoning, coking, and thermal sintering mechanisms.
- Cover nickel reforming, iron-chromium HT-shift, copper-zinc LT-shift, and ruthenium ammonia-cracking catalyst families.
- Document the H3 foundation APIs in the hydrogen production guide, 
eqsim-hydrogen-production skill, skill-index keywords, and changelog.

## Validation
- Focused H3 tests: 12 passed, 0 failed.
- Checkstyle on touched H3 Java/test files: 0 violations.
- python -m json.tool .github/skills/skill-index.json: passed.
- python devtools/verify_skills_agents.py: 0 errors, 0 warnings.
- ./mvnw.cmd javadoc:javadoc -DskipTests: BUILD SUCCESS. Existing repo-wide JavaDoc warnings remain in older classes, not these H3 additions.
- ./mvnw.cmd checkstyle:check spotbugs:check pmd:check: BUILD SUCCESS. SpotBugs/PMD reported the existing repo baseline in phase-envelope/property-generator/database/util classes; no new findings pointed at the H3 files.
- git diff --cached --check: passed before commit.

## Roadmap Status
This starts Horizon 3 with two low-coupling foundation capabilities: para/ortho H2 correction support for later liquefaction work and catalyst deactivation activity factors for future SMR/WGS/ammonia-cracking life studies. Full cryogenic liquefaction trains, LOHC carriers, photo-electrolysis, LCA, and calibrated digital-twin loops remain future H3/H2 work.