### PR TITLE
fix(thermo): preserve K-vector in stabilityCheck supplementary trials

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/Flash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/Flash.java
@@ -1162,8 +1162,29 @@ public abstract class Flash extends BaseOperation {
       boolean retryFoundInstability = false;
       boolean ambiguousStability = Math.abs(tm[0]) < 5e-2 || Math.abs(tm[1]) < 5e-2;
       boolean doLLESupplementaryCheck = shouldRunAutomaticLLECheck();
+      // Skip the supplementary stability trials when the caller explicitly disabled
+      // the multi-phase check (e.g. Compressor.setOutletPressure for a known single-
+      // phase inlet). The trials can declare a near-cricondenbar single-phase gas
+      // "unstable" and seed the main TPflash loop with a trial composition whose
+      // cubic EOS has no real Z root, causing a downstream NaN. The user's intent is
+      // clear: stay single-phase.
+      boolean runSupplementary = system.doMultiPhaseCheck();
+      // Save K-vector BEFORE running supplementary trials, since the trial
+      // functions themselves may commit non-physical K-values to the system
+      // phases (e.g. K~5e5 for methane near cricondenbar). If post-trial init
+      // throws NaN we revert to these pre-trial K-values, not the corrupted
+      // post-trial ones.
+      double[] preTrialKvector = null;
+      try {
+        preTrialKvector = system.getKvector();
+        if (preTrialKvector != null) {
+          preTrialKvector = preTrialKvector.clone();
+        }
+      } catch (Exception ignored) {
+        preTrialKvector = null;
+      }
       // Amplified K-value trials catch near-critical VLE instability (near cricondenbar)
-      if ((tm[0] < 0.5 || tm[1] < 0.5 || ambiguousStability)
+      if (runSupplementary && (tm[0] < 0.5 || tm[1] < 0.5 || ambiguousStability)
           && !system.getModelName().contains("CPA")) {
         retryFoundInstability = amplifiedKStabilityRetry();
       }
@@ -1172,26 +1193,57 @@ public abstract class Flash extends BaseOperation {
       // (both tm values comfortably positive), since the expensive trials
       // (3 components x 80 iterations x init(1) each) rarely find instability
       // in that regime.
-      if (!retryFoundInstability && doLLESupplementaryCheck
+      if (!retryFoundInstability && runSupplementary && doLLESupplementaryCheck
           && (tm[0] < 1.0 || tm[1] < 1.0 || ambiguousStability)) {
         retryFoundInstability = pureComponentStabilityTrials();
       }
       if (retryFoundInstability) {
-        recordStabilityOutcome("unstable - supplementary stability trial");
-        // Supplementary trial found instability - calculate beta and init for two-phase
-        RachfordRice rachfordRice = new RachfordRice();
+        // Supplementary trial found instability. The trial-seeded K-values may
+        // produce a non-physical state (PR cubic with no real Z root → NaN in
+        // molarVolumeAnalytical). If init(1) throws, restore the PRE-trial
+        // K-vector and revert to the single-phase declaration.
+        double[] savedKvector = preTrialKvector;
         try {
-          system.setBeta(rachfordRice.calcBeta(system.getKvector(), system.getzvector()));
+          RachfordRice rachfordRice = new RachfordRice();
+          try {
+            system.setBeta(rachfordRice.calcBeta(system.getKvector(), system.getzvector()));
+          } catch (Exception ex) {
+            if (!Double.isNaN(rachfordRice.getBeta()[0])) {
+              system.setBeta(rachfordRice.getBeta()[0]);
+            } else {
+              system.setBeta(Double.NaN);
+            }
+          }
+          system.calc_x_y();
+          system.init(1);
+          recordStabilityOutcome("unstable - supplementary stability trial");
+          stable = false;
         } catch (Exception ex) {
-          if (!Double.isNaN(rachfordRice.getBeta()[0])) {
-            system.setBeta(rachfordRice.getBeta()[0]);
+          // Supplementary trial seeded a non-physical 2-phase split. Revert.
+          logger.debug(
+              "Supplementary trial K-values produced non-physical state ({}); reverting to stable",
+              ex.getMessage());
+          if (savedKvector != null) {
+            int nComp = system.getPhase(0).getNumberOfComponents();
+            for (int i = 0; i < nComp && i < savedKvector.length; i++) {
+              system.getPhase(0).getComponent(i).setK(savedKvector[i]);
+              system.getPhase(1).getComponent(i).setK(savedKvector[i]);
+            }
+          }
+          recordStabilityOutcome("stable - supplementary trial reverted (non-physical state)");
+          stable = true;
+          system.init(0);
+          system.setNumberOfPhases(1);
+          if (lowestGibbsEnergyPhase == 0) {
+            system.setPhaseType(0, PhaseType.GAS);
           } else {
-            system.setBeta(Double.NaN);
+            system.setPhaseType(0, PhaseType.LIQUID);
+          }
+          system.init(1);
+          if (solidCheck && !system.doMultiPhaseCheck()) {
+            this.solidPhaseFlash();
           }
         }
-        system.calc_x_y();
-        system.init(1);
-        stable = false;
       } else {
         if (lastStabilityAnalysisFailed) {
           recordStabilityOutcome("stable after supplementary fallback");

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/FlashStabilityTrialRevertTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/FlashStabilityTrialRevertTest.java
@@ -1,0 +1,94 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Regression tests for {@link Flash#stabilityCheck()} skipping the supplementary
+ * amplified-K and pure-component trials when the caller has explicitly disabled
+ * the multi-phase check via {@link SystemInterface#setMultiPhaseCheck(boolean)}.
+ *
+ * <p>
+ * The trial functions may seed the active system with K-values that are valid
+ * for stability analysis but produce a non-physical state (PR cubic with no
+ * real root) once the main flash continues. This is observed for example with
+ * a near-cricondenbar gas inside a compressor: the supplementary trial declares
+ * the gas "unstable", calls {@code init(1)} on the trial-seeded two-phase
+ * split, and {@code PhasePrEos.molarVolumeAnalytical} returns NaN. When the
+ * caller is operating in known-single-phase mode (typical for compressor
+ * outlet PHflash), the trials should be skipped entirely and the K-vector left
+ * untouched.
+ */
+public class FlashStabilityTrialRevertTest {
+
+  /**
+   * Build a typical natural-gas mixture near its cricondenbar where the
+   * supplementary stability trials are most likely to fire.
+   */
+  private static SystemInterface buildGas(double temperatureK, double pressureBara) {
+    SystemInterface gas = new SystemPrEos(temperatureK, pressureBara);
+    gas.addComponent("nitrogen", 0.012);
+    gas.addComponent("CO2", 0.013);
+    gas.addComponent("methane", 0.880);
+    gas.addComponent("ethane", 0.053);
+    gas.addComponent("propane", 0.033);
+    gas.addComponent("n-butane", 0.005);
+    gas.addComponent("n-hexane", 0.002);
+    gas.addComponent("n-heptane", 0.002);
+    gas.setMixingRule("classic");
+    return gas;
+  }
+
+  @Test
+  public void testSingleGasPhaseStaysFiniteWithMultiPhaseCheckDisabled() {
+    SystemInterface gas = buildGas(273.15 + 25.0, 60.0);
+    gas.setMultiPhaseCheck(false);
+    ThermodynamicOperations ops = new ThermodynamicOperations(gas);
+    ops.TPflash();
+    gas.initProperties();
+    assertEquals(1, gas.getNumberOfPhases(),
+        "single-phase gas should remain single-phase when multi-phase check is disabled");
+    double density = gas.getPhase(0).getDensity();
+    assertTrue(Double.isFinite(density) && density > 0.0,
+        "density must be finite and positive (was " + density + ")");
+    double viscosity = gas.getPhase(0).getViscosity();
+    assertTrue(Double.isFinite(viscosity) && viscosity > 0.0,
+        "viscosity must be finite and positive (was " + viscosity + ")");
+  }
+
+  @Test
+  public void testKvectorPreservedWhenSupplementaryTrialsSkipped() {
+    SystemInterface gas = buildGas(273.15 + 25.0, 60.0);
+    gas.setMultiPhaseCheck(false);
+    ThermodynamicOperations ops = new ThermodynamicOperations(gas);
+    ops.TPflash();
+    double[] k = gas.getKvector();
+    if (k != null) {
+      for (int i = 0; i < k.length; i++) {
+        assertTrue(Double.isFinite(k[i]),
+            "K-value " + i + " must be finite (was " + k[i] + ")");
+        assertFalse(k[i] > 1.0e4,
+            "K-value " + i + " (" + k[i] + ") suggests trial K-pollution leaked through");
+      }
+    }
+  }
+
+  @Test
+  public void testTPflashSurvivesNearCricondenbarSingleGas() {
+    // Conditions historically tripping the amplified-K trial into a NaN
+    // downstream of compressor PHflash on similar gas compositions.
+    SystemInterface gas = buildGas(273.15 + 45.0, 95.0);
+    gas.setMultiPhaseCheck(false);
+    ThermodynamicOperations ops = new ThermodynamicOperations(gas);
+    ops.TPflash();
+    gas.initProperties();
+    assertEquals(1, gas.getNumberOfPhases());
+    assertTrue(Double.isFinite(gas.getPhase(0).getDensity()));
+    assertTrue(Double.isFinite(gas.getEnthalpy()));
+  }
+}


### PR DESCRIPTION
### Summary

`Flash.stabilityCheck()` runs two supplementary trial loops (`amplifiedKStabilityRetry()` and `pureComponentStabilityTrials()`, added in #2099) that can declare a near-cricondenbar single-phase gas "unstable" and **commit trial K-values onto the live system phases**. When the main flash then attempts `init(1)` on that trial-seeded two-phase split, the PR cubic EOS has no real Z root and `PhasePrEos.molarVolumeAnalytical` returns NaN. The NaN then propagates into the calling compressor's PHflash and into every downstream property read (density, viscosity, enthalpy).

This was reproducible on a typical natural-gas compressor inlet near its cricondenbar even when the caller had explicitly requested single-phase behaviour via `setMultiPhaseCheck(false)`.

### Fix

Three changes, all in `Flash.stabilityCheck()`:

1. **Gate both supplementary trials on `system.doMultiPhaseCheck()`.** When the caller explicitly disabled the multi-phase check (typical for known-single-phase compressor outlet flashes), skip the trials entirely. The user's intent is clear: stay single-phase.
2. **Snapshot the K-vector BEFORE invoking the trials.** The trial functions themselves mutate K on the live system phases, so we must capture the legal pre-trial K before they run.
3. **Revert on non-physical post-trial init.** If `setBeta` / `calc_x_y` / `init(1)` throws, restore the pre-trial K on `phase(0)` and `phase(1)`, `setNumberOfPhases(1)`, re-tag the phase type from `lowestGibbsEnergyPhase`, re-init, and run `solidPhaseFlash` if applicable. Record `"stable - supplementary trial reverted (non-physical state)"` for diagnostics.

The default behaviour (with multi-phase check enabled and a physically valid trial outcome) is unchanged.

### Tests

Adds `FlashStabilityTrialRevertTest` (3 cases) on a typical natural-gas composition near the cricondenbar:

- `testSingleGasPhaseStaysFiniteWithMultiPhaseCheckDisabled` — gas at 25 °C / 60 bara stays single-phase with finite density and viscosity.
- `testKvectorPreservedWhenSupplementaryTrialsSkipped` — K-vector contains no out-of-range entries left behind by skipped trials.
- `testTPflashSurvivesNearCricondenbarSingleGas` — at 45 °C / 95 bara TPflash + `initProperties` yields finite enthalpy and density.

All three pass locally with `mvn test -Dtest=FlashStabilityTrialRevertTest`.

### Why this is upstream-worthy

The bug is reproducible on plain `SystemPrEos` natural gas with `setMultiPhaseCheck(false)` — i.e. it can fire from any compressor, valve, or recompression train that flashes gas near its cricondenbar. The fix is conservative (only changes the supplementary-trial branch of `stabilityCheck`) and preserves backward compatibility: when the trials succeed, the result is identical; when they would have produced NaN, the flash now gracefully reverts to a stable single-phase state.

Related to upstream PR #2099 which introduced the supplementary trials.
