### PR TITLE
fix(process): Compressor real-phase MPC guard + ThrottlingValve single-phase guard

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -584,7 +584,8 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
         || outTemperature != lastOutTemperature || isentropicEfficiency != lastIsentropicEfficiency
         || polytropicEfficiency != lastPolytropicEfficiency || dH != lastPower
         || numberOfCompressorCalcSteps != lastNumberOfCompressorCalcSteps
-        || useOutTemperature != lastUseOutTemperature || useCompressionRatio != lastUseCompressionRatio
+        || useOutTemperature != lastUseOutTemperature
+        || useCompressionRatio != lastUseCompressionRatio
         || usePolytropicCalc != lastUsePolytropicCalc || powerSet != lastPowerSet
         || calcPressureOut != lastCalcPressureOut || solveSpeed != lastSolveSpeed
         || compressorChart.isUseCompressorChart() != lastUseCompressorChart
@@ -650,6 +651,38 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
       outStream.setCalculationIdentifier(id);
     }
     setCalculationIdentifier(id);
+  }
+
+  /**
+   * Run a PH flash and retry with the multi-phase check temporarily disabled if the first attempt
+   * raises an IsNaN-derived RuntimeException. Compressor outlet conditions often sit close to the
+   * cricondenbar where the PR #2099 supplementary stability trials can seed a non-physical 2-phase
+   * split, producing PhasePrEos:molarVolumeAnalytical NaN. Falling back to a single-phase flash
+   * recovers gracefully without changing the result for well-posed cases.
+   *
+   * @param thermoOps thermodynamic operations bound to the compressor thermo system
+   * @param hout target total enthalpy in J
+   */
+  private void runPHflashWithNaNRetry(ThermodynamicOperations thermoOps, double hout) {
+    try {
+      thermoOps.PHflash(hout, 0);
+    } catch (RuntimeException ex) {
+      Throwable cause = ex.getCause();
+      boolean isNaN = (ex.getMessage() != null && ex.getMessage().contains("NaN"))
+          || (cause != null && cause.getMessage() != null && cause.getMessage().contains("NaN"));
+      if (!isNaN) {
+        throw ex;
+      }
+      logger.debug("PHflash produced NaN; retrying with multi-phase check disabled");
+      boolean savedMpc = getThermoSystem().doMultiPhaseCheck();
+      getThermoSystem().setMultiPhaseCheck(false);
+      try {
+        getThermoSystem().init(0);
+        thermoOps.PHflash(hout, 0);
+      } finally {
+        getThermoSystem().setMultiPhaseCheck(savedMpc);
+      }
+    }
   }
 
   /**
@@ -808,9 +841,18 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
     // additional phase can appear during compression. For multi-phase inlets (e.g.
     // gas + aqueous), stability analysis must remain active to maintain the correct
     // phase structure as pressure increases.
+    // Also treat phantom phases (beta < 1e-10) as single-phase, otherwise the
+    // phantom phase carries non-physical Z values that can seed NaN in
+    // PhasePrEos:molarVolumeAnalytical when MPC is left enabled.
     boolean originalMultiPhaseCheck = getThermoSystem().doMultiPhaseCheck();
     int inletPhases = getThermoSystem().getNumberOfPhases();
-    if (inletPhases <= 1 && originalMultiPhaseCheck) {
+    int realPhases = 0;
+    for (int phaseIdx = 0; phaseIdx < inletPhases; phaseIdx++) {
+      if (getThermoSystem().getPhase(phaseIdx).getBeta() > 1.0e-10) {
+        realPhases++;
+      }
+    }
+    if (realPhases <= 1 && originalMultiPhaseCheck) {
       getThermoSystem().setMultiPhaseCheck(false);
     }
 
@@ -1299,7 +1341,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
         double hout = hinn * (1 - 0 + fractionAntiSurge) + dH;
         thermoSystem.setPressure(pressure, pressureUnit);
         thermoOps = new ThermodynamicOperations(getThermoSystem());
-        thermoOps.PHflash(hout, 0);
+        runPHflashWithNaNRetry(thermoOps, hout);
         if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
           thermoOps.PHflashGERG2008(hout);
         }
@@ -1363,7 +1405,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
               newEnt = VegaProps[7] * getThermoSystem().getPhase(0).getNumberOfMolesInPhase();
             }
             double hout = hinn + (newEnt - hinn) / polytropicEfficiency;
-            thermoOps.PHflash(hout, 0);
+            runPHflashWithNaNRetry(thermoOps, hout);
             if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
               thermoOps.PHflashGERG2008(hout);
             }
@@ -1426,7 +1468,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
               * (Math.pow(getOutletPressure() / presinn, 1.0 / term) - 1.0) / polytropicEfficiency;
           double hout = hinn + dH;
           thermoOps = new ThermodynamicOperations(getThermoSystem());
-          thermoOps.PHflash(hout, 0);
+          runPHflashWithNaNRetry(thermoOps, hout);
           if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
             thermoOps.PHflashGERG2008(hout);
           }
@@ -1481,7 +1523,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
               * (Math.pow(getOutletPressure() / presinn, 1.0 / term) - 1.0);
           double hout = hinn + dH;
           thermoOps = new ThermodynamicOperations(getThermoSystem());
-          thermoOps.PHflash(hout, 0);
+          runPHflashWithNaNRetry(thermoOps, hout);
           if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
             thermoOps.PHflashGERG2008(hout);
           }
@@ -1538,7 +1580,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
       polytropicEfficiency = isentropicEfficiency;
       dH = hout - hinn;
       thermoOps = new ThermodynamicOperations(getThermoSystem());
-      thermoOps.PHflash(hout, 0);
+      runPHflashWithNaNRetry(thermoOps, hout);
       if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
         thermoOps.PHflashGERG2008(hout);
       }

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -424,12 +424,30 @@ public class ThrottlingValve extends TwoPortEquipment
     }
 
     ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
-    if (isIsoThermal() || Math.abs(pressure - inStream.getThermoSystem().getPressure()) < 1e-6
-        || thermoSystem.getTotalNumberOfMoles() < 1e-12 || pressure == 0) {
-      thermoSystem.setPressure(outPres, pressureUnit);
-      thermoOps.TPflash();
-    } else {
-      thermoOps.PHflash(enthalpy, 0);
+    // Guard against PR #2099 supplementary-stability trials producing NaN Z-factor
+    // when a single-phase inlet is flashed across a large pressure drop. The trials
+    // can commit non-physical K-values into the cached phases, leading to
+    // PhasePrEos:molarVolumeAnalytical NaN inside the outer PH-flash Newton loop.
+    // Disable multi-phase check for single-phase inlets (mirrors PR #2153 Compressor fix).
+    boolean originalMultiPhaseCheck = thermoSystem.doMultiPhaseCheck();
+    int inletPhases = thermoSystem.getNumberOfPhases();
+    boolean toggledMultiPhaseCheck = false;
+    if (inletPhases <= 1 && originalMultiPhaseCheck) {
+      thermoSystem.setMultiPhaseCheck(false);
+      toggledMultiPhaseCheck = true;
+    }
+    try {
+      if (isIsoThermal() || Math.abs(pressure - inStream.getThermoSystem().getPressure()) < 1e-6
+          || thermoSystem.getTotalNumberOfMoles() < 1e-12 || pressure == 0) {
+        thermoSystem.setPressure(outPres, pressureUnit);
+        thermoOps.TPflash();
+      } else {
+        thermoOps.PHflash(enthalpy, 0);
+      }
+    } finally {
+      if (toggledMultiPhaseCheck) {
+        thermoSystem.setMultiPhaseCheck(originalMultiPhaseCheck);
+      }
     }
     outStream.setThermoSystem(thermoSystem);
 

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorRealPhaseGuardTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorRealPhaseGuardTest.java
@@ -1,0 +1,83 @@
+package neqsim.process.equipment.compressor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+
+/**
+ * Regression tests for the compressor's "real phase" multi-phase-check guard.
+ *
+ * <p>
+ * Historically the guard counted {@code getNumberOfPhases()} directly, which can include a phantom
+ * phase carried over from a previous flash (β &lt; 1.0e-10). The phantom phase has non-physical Z
+ * and seeds NaN inside {@link neqsim.thermo.phase.PhasePrEos#molarVolumeAnalytical} when the
+ * compressor's outlet PHflash is allowed to run a multi-phase check. The fix counts only phases
+ * with β &gt; 1.0e-10 ("real" phases) and disables the multi-phase check when there is only one
+ * real phase.
+ */
+public class CompressorRealPhaseGuardTest {
+
+  private static SystemInterface buildGas(double temperatureK, double pressureBara) {
+    SystemInterface gas = new SystemPrEos(temperatureK, pressureBara);
+    gas.addComponent("nitrogen", 0.012);
+    gas.addComponent("CO2", 0.013);
+    gas.addComponent("methane", 0.880);
+    gas.addComponent("ethane", 0.053);
+    gas.addComponent("propane", 0.033);
+    gas.addComponent("n-butane", 0.005);
+    gas.addComponent("n-hexane", 0.002);
+    gas.addComponent("n-heptane", 0.002);
+    gas.setMixingRule("classic");
+    return gas;
+  }
+
+  @Test
+  public void testSinglePhaseGasCompressionStaysFinite() {
+    SystemInterface gas = buildGas(273.15 + 30.0, 50.0);
+    StreamInterface feed = new Stream("feed", gas);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.run();
+
+    Compressor comp = new Compressor("comp", feed);
+    comp.setOutletPressure(120.0);
+    comp.setIsentropicEfficiency(0.80);
+    comp.run();
+
+    double outT = comp.getOutletStream().getTemperature("C");
+    double power = comp.getPower();
+    assertTrue(Double.isFinite(outT),
+        "compressor outlet temperature must be finite (was " + outT + ")");
+    assertTrue(Double.isFinite(power), "compressor shaft power must be finite (was " + power + ")");
+    assertTrue(power > 0.0, "compressor power must be positive (was " + power + ")");
+    assertEquals(1, comp.getOutletStream().getFluid().getNumberOfPhases(),
+        "single-phase gas inlet should produce a single-phase outlet");
+  }
+
+  @Test
+  public void testHighPressureRatioStaysFinite() {
+    // Conditions close to the cricondenbar where the PR cubic is most
+    // sensitive to trial-K pollution from supplementary stability trials.
+    SystemInterface gas = buildGas(273.15 + 20.0, 80.0);
+    StreamInterface feed = new Stream("feed", gas);
+    feed.setFlowRate(250000.0, "kg/hr");
+    feed.run();
+
+    Compressor comp = new Compressor("comp", feed);
+    comp.setOutletPressure(200.0);
+    comp.setIsentropicEfficiency(0.78);
+    comp.run();
+
+    double outT = comp.getOutletStream().getTemperature("C");
+    SystemInterface outFluid = comp.getOutletStream().getFluid();
+    outFluid.initProperties();
+    double outRho = outFluid.getPhase(0).getDensity();
+    assertTrue(Double.isFinite(outT) && outT > 20.0 && outT < 300.0,
+        "compressor outlet temperature must be physically reasonable (was " + outT + " C)");
+    assertTrue(Double.isFinite(outRho) && outRho > 0.0,
+        "compressor outlet density must be finite and positive (was " + outRho + ")");
+  }
+}

--- a/src/test/java/neqsim/process/equipment/valve/ThrottlingValveSinglePhaseGuardTest.java
+++ b/src/test/java/neqsim/process/equipment/valve/ThrottlingValveSinglePhaseGuardTest.java
@@ -1,0 +1,56 @@
+package neqsim.process.equipment.valve;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+
+/**
+ * Regression tests for the throttling valve's single-phase multi-phase-check guard.
+ *
+ * <p>
+ * Without the guard, large pressure drops on a single-phase gas inlet near the cricondenbar can
+ * trip the PR #2099 supplementary stability trials inside the PHflash Newton loop, producing NaN
+ * Z-factors and NaN downstream properties.
+ */
+public class ThrottlingValveSinglePhaseGuardTest {
+
+  private static SystemInterface buildGas(double temperatureK, double pressureBara) {
+    SystemInterface gas = new SystemPrEos(temperatureK, pressureBara);
+    gas.addComponent("nitrogen", 0.012);
+    gas.addComponent("CO2", 0.013);
+    gas.addComponent("methane", 0.880);
+    gas.addComponent("ethane", 0.053);
+    gas.addComponent("propane", 0.033);
+    gas.addComponent("n-butane", 0.005);
+    gas.addComponent("n-hexane", 0.002);
+    gas.addComponent("n-heptane", 0.002);
+    gas.setMixingRule("classic");
+    return gas;
+  }
+
+  @Test
+  public void testLargePressureDropStaysFinite() {
+    SystemInterface gas = buildGas(273.15 + 30.0, 120.0);
+    StreamInterface feed = new Stream("feed", gas);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.run();
+
+    ThrottlingValve valve = new ThrottlingValve("valve", feed);
+    valve.setOutletPressure(20.0);
+    valve.run();
+
+    double outT = valve.getOutletStream().getTemperature("C");
+    double outP = valve.getOutletStream().getPressure("bara");
+    SystemInterface outFluid = valve.getOutletStream().getFluid();
+    outFluid.initProperties();
+    double outRho = outFluid.getPhase(0).getDensity();
+    assertTrue(Double.isFinite(outT), "valve outlet temperature must be finite (was " + outT + ")");
+    assertTrue(Math.abs(outP - 20.0) < 1.0e-3,
+        "valve outlet pressure must equal setpoint (was " + outP + ")");
+    assertTrue(Double.isFinite(outRho) && outRho > 0.0,
+        "valve outlet density must be finite and positive (was " + outRho + ")");
+  }
+}


### PR DESCRIPTION
## Summary

Hardens `Compressor` and `ThrottlingValve` against `PhasePrEos.molarVolumeAnalytical` returning `NaN` when the multi-phase check inside a `PHflash`/`TPflash` produces a phantom phase with β ≤ 1e-10 carrying a non-physical Z root. This was observed on single-phase natural-gas streams across large pressure ratios.

## Root cause

Same family of issues addressed by #2231 (`Flash.stabilityCheck` not preserving the pre-trial K-vector). Even after that fix, real-world equipment models occasionally enter the supplementary stability path with a fluid whose `init(...)` decides there is more than one phase but the second β rounds to ~0, leaving its phase state non-physical for the next PR EOS evaluation.

The pre-existing Compressor guard:

```java
if (inletStreamCopy.getFluid().getNumberOfPhases() <= 1) {
    inletStreamCopy.getFluid().setMultiPhaseCheck(false);
}
```

…undercounts: with a phantom β it sees 2 phases and skips the guard.

## Changes

### `Compressor.java`
- **Real-phase MPC guard**: count only phases with β > 1e-10 before deciding to disable the multi-phase check.
- **`runPHflashWithNaNRetry(...)` helper**: wraps `thermoOps.PHflash(...)`; on `NaN`-bearing exceptions, retries once with multi-phase check disabled (defense in depth).
- Wraps 5 `PHflash` call sites (compressor work paths). `findOutPressure`, `runRegularPsFlash`, Schultz, and isentropic helpers are left for a follow-up.

### `ThrottlingValve.java`
- For single-phase inlets, temporarily disables MPC across the PH/TP flash inside `run(UUID)`, restoring it in a `finally` block. Same trial-K pollution mechanism as the compressor case.

### Tests
- `CompressorRealPhaseGuardTest` (2 tests) — single-phase gas compression and a high pressure-ratio case; both must return finite outlet T and density.
- `ThrottlingValveSinglePhaseGuardTest` (1 test) — 120 → 20 bara drop on natural gas.

## Relationship to other PRs

- #2231 fixes the root cause in `Flash.stabilityCheck`. This PR remains useful as an equipment-layer guard for any residual cases (and for codepaths that bypass the stability-trial revert).
- Independent of #2230 (anti-surge bounded step).

## Java 8 compatibility
Verified — no `var`, no `List.of`, no text blocks, no `String.repeat`.

## Test
```
mvnw test -Dtest=CompressorRealPhaseGuardTest,ThrottlingValveSinglePhaseGuardTest
```
→ Tests run: 3, Failures: 0, Errors: 0.
