### PR TITLE
fix: stability-trial NaN guard + compressor/valve MPC guard + bounded anti-surge step

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -584,7 +584,8 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
         || outTemperature != lastOutTemperature || isentropicEfficiency != lastIsentropicEfficiency
         || polytropicEfficiency != lastPolytropicEfficiency || dH != lastPower
         || numberOfCompressorCalcSteps != lastNumberOfCompressorCalcSteps
-        || useOutTemperature != lastUseOutTemperature || useCompressionRatio != lastUseCompressionRatio
+        || useOutTemperature != lastUseOutTemperature
+        || useCompressionRatio != lastUseCompressionRatio
         || usePolytropicCalc != lastUsePolytropicCalc || powerSet != lastPowerSet
         || calcPressureOut != lastCalcPressureOut || solveSpeed != lastSolveSpeed
         || compressorChart.isUseCompressorChart() != lastUseCompressorChart
@@ -650,6 +651,38 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
       outStream.setCalculationIdentifier(id);
     }
     setCalculationIdentifier(id);
+  }
+
+  /**
+   * Run a PH flash and retry with the multi-phase check temporarily disabled if the first attempt
+   * raises an IsNaN-derived RuntimeException. Compressor outlet conditions often sit close to the
+   * cricondenbar where the PR #2099 supplementary stability trials can seed a non-physical 2-phase
+   * split, producing PhasePrEos:molarVolumeAnalytical NaN. Falling back to a single-phase flash
+   * recovers gracefully without changing the result for well-posed cases.
+   *
+   * @param thermoOps thermodynamic operations bound to the compressor thermo system
+   * @param hout target total enthalpy in J
+   */
+  private void runPHflashWithNaNRetry(ThermodynamicOperations thermoOps, double hout) {
+    try {
+      thermoOps.PHflash(hout, 0);
+    } catch (RuntimeException ex) {
+      Throwable cause = ex.getCause();
+      boolean isNaN = (ex.getMessage() != null && ex.getMessage().contains("NaN"))
+          || (cause != null && cause.getMessage() != null && cause.getMessage().contains("NaN"));
+      if (!isNaN) {
+        throw ex;
+      }
+      logger.debug("PHflash produced NaN; retrying with multi-phase check disabled");
+      boolean savedMpc = getThermoSystem().doMultiPhaseCheck();
+      getThermoSystem().setMultiPhaseCheck(false);
+      try {
+        getThermoSystem().init(0);
+        thermoOps.PHflash(hout, 0);
+      } finally {
+        getThermoSystem().setMultiPhaseCheck(savedMpc);
+      }
+    }
   }
 
   /**
@@ -808,9 +841,18 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
     // additional phase can appear during compression. For multi-phase inlets (e.g.
     // gas + aqueous), stability analysis must remain active to maintain the correct
     // phase structure as pressure increases.
+    // Also treat phantom phases (beta < 1e-10) as single-phase, otherwise the
+    // phantom phase carries non-physical Z values that can seed NaN in
+    // PhasePrEos:molarVolumeAnalytical when MPC is left enabled.
     boolean originalMultiPhaseCheck = getThermoSystem().doMultiPhaseCheck();
     int inletPhases = getThermoSystem().getNumberOfPhases();
-    if (inletPhases <= 1 && originalMultiPhaseCheck) {
+    int realPhases = 0;
+    for (int phaseIdx = 0; phaseIdx < inletPhases; phaseIdx++) {
+      if (getThermoSystem().getPhase(phaseIdx).getBeta() > 1.0e-10) {
+        realPhases++;
+      }
+    }
+    if (realPhases <= 1 && originalMultiPhaseCheck) {
       getThermoSystem().setMultiPhaseCheck(false);
     }
 
@@ -1299,7 +1341,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
         double hout = hinn * (1 - 0 + fractionAntiSurge) + dH;
         thermoSystem.setPressure(pressure, pressureUnit);
         thermoOps = new ThermodynamicOperations(getThermoSystem());
-        thermoOps.PHflash(hout, 0);
+        runPHflashWithNaNRetry(thermoOps, hout);
         if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
           thermoOps.PHflashGERG2008(hout);
         }
@@ -1363,7 +1405,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
               newEnt = VegaProps[7] * getThermoSystem().getPhase(0).getNumberOfMolesInPhase();
             }
             double hout = hinn + (newEnt - hinn) / polytropicEfficiency;
-            thermoOps.PHflash(hout, 0);
+            runPHflashWithNaNRetry(thermoOps, hout);
             if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
               thermoOps.PHflashGERG2008(hout);
             }
@@ -1426,7 +1468,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
               * (Math.pow(getOutletPressure() / presinn, 1.0 / term) - 1.0) / polytropicEfficiency;
           double hout = hinn + dH;
           thermoOps = new ThermodynamicOperations(getThermoSystem());
-          thermoOps.PHflash(hout, 0);
+          runPHflashWithNaNRetry(thermoOps, hout);
           if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
             thermoOps.PHflashGERG2008(hout);
           }
@@ -1481,7 +1523,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
               * (Math.pow(getOutletPressure() / presinn, 1.0 / term) - 1.0);
           double hout = hinn + dH;
           thermoOps = new ThermodynamicOperations(getThermoSystem());
-          thermoOps.PHflash(hout, 0);
+          runPHflashWithNaNRetry(thermoOps, hout);
           if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
             thermoOps.PHflashGERG2008(hout);
           }
@@ -1538,7 +1580,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
       polytropicEfficiency = isentropicEfficiency;
       dH = hout - hinn;
       thermoOps = new ThermodynamicOperations(getThermoSystem());
-      thermoOps.PHflash(hout, 0);
+      runPHflashWithNaNRetry(thermoOps, hout);
       if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
         thermoOps.PHflashGERG2008(hout);
       }

--- a/src/main/java/neqsim/process/equipment/util/Calculator.java
+++ b/src/main/java/neqsim/process/equipment/util/Calculator.java
@@ -99,16 +99,61 @@ public class Calculator extends ProcessEquipmentBaseClass {
 
     Splitter antiSurgeSplitter = (Splitter) outputVariable;
 
-    double inletFlow = compressor.getInletStream().getFlowRate("Sm3/hr");
-    double currentRecycleFlow = antiSurgeSplitter.getSplitStream(1).getFlowRate("MSm3/day");
-    if (!Double.isFinite(inletFlow) || !Double.isFinite(currentRecycleFlow)) {
-      logger.warn("Invalid flow rate detected during anti-surge calculation");
+    double inletFlow = compressor.getInletStream().getFlowRate("m3/hr");
+    double surgeFlow = compressor.getSurgeFlowRate();
+    double currentRecycle = antiSurgeSplitter.getSplitStream(1).getFlowRate("m3/hr");
+    double splitterInlet = antiSurgeSplitter.getInletStream().getFlowRate("m3/hr");
+
+    // Guard against non-finite state coming from a failed compressor run or an
+    // inactive surge curve. Without this the proportional update below can
+    // propagate NaN into the splitter setpoint and deadlock the recycle loop.
+    if (!Double.isFinite(inletFlow) || !Double.isFinite(surgeFlow)
+        || !Double.isFinite(currentRecycle) || !Double.isFinite(splitterInlet)
+        || surgeFlow <= 0.0) {
+      logger.warn("Anti-surge calc skipped: non-finite input (inlet=" + inletFlow + " m3/hr"
+          + ", surge=" + surgeFlow + " m3/hr, current=" + currentRecycle + " m3/hr, splitterIn="
+          + splitterInlet + " m3/hr)");
+      setCalculationIdentifier(id);
       return;
     }
 
-    double flowAntiSurge = antiSurgeSplitter.getSplitStream(1).getFlowRate("m3/hr")
-        + 0.5 * (compressor.getSurgeFlowRate() - compressor.getInletStream().getFlowRate("m3/hr"));
-    flowAntiSurge = Math.max(flowAntiSurge, compressor.getInletStream().getFlowRate("m3/hr") / 1e6);
+    // Physical upper bound: the splitter cannot recycle more than what it
+    // receives from the compressor outlet. Asking for more pegs split[0] to
+    // zero and feeds the downstream throttling valve a poorly conditioned
+    // micro-flow that crashes the EOS during the recycle iteration. Reserve a
+    // small forward fraction so split[0] never collapses to identically zero.
+    double maxRecycleFromSplitter = Math.max(0.0, 0.999 * splitterInlet);
+
+    // If we are comfortably above the surge line, close the recycle valve to
+    // (effectively) zero. This short-circuit avoids the proportional step
+    // overshooting when the compressor is operating far from surge.
+    if (inletFlow > 1.2 * surgeFlow) {
+      double minRecycle = Math.max(inletFlow / 1.0e6, 1.0e-6);
+      antiSurgeSplitter.setFlowRates(new double[] {-1, minRecycle}, "m3/hr");
+      antiSurgeSplitter.getSplitStream(1).setFlowRate(minRecycle, "m3/hr");
+      antiSurgeSplitter.getSplitStream(1).run();
+      antiSurgeSplitter.setCalculationIdentifier(id);
+      return;
+    }
+
+    // Proportional anti-surge step with a per-iteration bound. The unbounded
+    // step (0.5 * (surgeFlow - inletFlow)) caused 1000x overshoots when the
+    // recycle seed was tiny relative to the surge spec, leaving the splitter
+    // pinned to a physically impossible setpoint and crashing the EOS on the
+    // next iteration.
+    double rawStep = 0.5 * (surgeFlow - inletFlow);
+    double maxStep = 0.25 * Math.max(currentRecycle, Math.max(inletFlow, surgeFlow));
+    double cappedStep = Math.max(-maxStep, Math.min(maxStep, rawStep));
+    double flowAntiSurge = Math.max(currentRecycle + cappedStep, inletFlow / 1.0e6);
+
+    // Clamp to what the splitter can physically deliver. When primary feed is
+    // near zero this caps the recycle to ~splitterInlet, lets the recycle loop
+    // converge to a self-consistent low-flow state, and keeps the throttling
+    // valve's flash inside a numerically safe region.
+    if (maxRecycleFromSplitter > 0.0 && flowAntiSurge > maxRecycleFromSplitter) {
+      flowAntiSurge = maxRecycleFromSplitter;
+    }
+
     antiSurgeSplitter.setFlowRates(new double[] {-1, flowAntiSurge}, "m3/hr");
     antiSurgeSplitter.getSplitStream(1).setFlowRate(flowAntiSurge, "m3/hr");
     antiSurgeSplitter.getSplitStream(1).run();

--- a/src/main/java/neqsim/process/equipment/util/Calculator.java
+++ b/src/main/java/neqsim/process/equipment/util/Calculator.java
@@ -102,27 +102,17 @@ public class Calculator extends ProcessEquipmentBaseClass {
     double inletFlow = compressor.getInletStream().getFlowRate("m3/hr");
     double surgeFlow = compressor.getSurgeFlowRate();
     double currentRecycle = antiSurgeSplitter.getSplitStream(1).getFlowRate("m3/hr");
-    double splitterInlet = antiSurgeSplitter.getInletStream().getFlowRate("m3/hr");
 
     // Guard against non-finite state coming from a failed compressor run or an
     // inactive surge curve. Without this the proportional update below can
     // propagate NaN into the splitter setpoint and deadlock the recycle loop.
     if (!Double.isFinite(inletFlow) || !Double.isFinite(surgeFlow)
-        || !Double.isFinite(currentRecycle) || !Double.isFinite(splitterInlet)
-        || surgeFlow <= 0.0) {
+        || !Double.isFinite(currentRecycle) || surgeFlow <= 0.0) {
       logger.warn("Anti-surge calc skipped: non-finite input (inlet=" + inletFlow + " m3/hr"
-          + ", surge=" + surgeFlow + " m3/hr, current=" + currentRecycle + " m3/hr, splitterIn="
-          + splitterInlet + " m3/hr)");
+          + ", surge=" + surgeFlow + " m3/hr, current=" + currentRecycle + " m3/hr)");
       setCalculationIdentifier(id);
       return;
     }
-
-    // Physical upper bound: the splitter cannot recycle more than what it
-    // receives from the compressor outlet. Asking for more pegs split[0] to
-    // zero and feeds the downstream throttling valve a poorly conditioned
-    // micro-flow that crashes the EOS during the recycle iteration. Reserve a
-    // small forward fraction so split[0] never collapses to identically zero.
-    double maxRecycleFromSplitter = Math.max(0.0, 0.999 * splitterInlet);
 
     // If we are comfortably above the surge line, close the recycle valve to
     // (effectively) zero. This short-circuit avoids the proportional step
@@ -145,14 +135,6 @@ public class Calculator extends ProcessEquipmentBaseClass {
     double maxStep = 0.25 * Math.max(currentRecycle, Math.max(inletFlow, surgeFlow));
     double cappedStep = Math.max(-maxStep, Math.min(maxStep, rawStep));
     double flowAntiSurge = Math.max(currentRecycle + cappedStep, inletFlow / 1.0e6);
-
-    // Clamp to what the splitter can physically deliver. When primary feed is
-    // near zero this caps the recycle to ~splitterInlet, lets the recycle loop
-    // converge to a self-consistent low-flow state, and keeps the throttling
-    // valve's flash inside a numerically safe region.
-    if (maxRecycleFromSplitter > 0.0 && flowAntiSurge > maxRecycleFromSplitter) {
-      flowAntiSurge = maxRecycleFromSplitter;
-    }
 
     antiSurgeSplitter.setFlowRates(new double[] {-1, flowAntiSurge}, "m3/hr");
     antiSurgeSplitter.getSplitStream(1).setFlowRate(flowAntiSurge, "m3/hr");

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -424,30 +424,12 @@ public class ThrottlingValve extends TwoPortEquipment
     }
 
     ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
-    // Guard against PR #2099 supplementary-stability trials producing NaN Z-factor
-    // when a single-phase inlet is flashed across a large pressure drop. The trials
-    // can commit non-physical K-values into the cached phases, leading to
-    // PhasePrEos:molarVolumeAnalytical NaN inside the outer PH-flash Newton loop.
-    // Disable multi-phase check for single-phase inlets (mirrors PR #2153 Compressor fix).
-    boolean originalMultiPhaseCheck = thermoSystem.doMultiPhaseCheck();
-    int inletPhases = thermoSystem.getNumberOfPhases();
-    boolean toggledMultiPhaseCheck = false;
-    if (inletPhases <= 1 && originalMultiPhaseCheck) {
-      thermoSystem.setMultiPhaseCheck(false);
-      toggledMultiPhaseCheck = true;
-    }
-    try {
-      if (isIsoThermal() || Math.abs(pressure - inStream.getThermoSystem().getPressure()) < 1e-6
-          || thermoSystem.getTotalNumberOfMoles() < 1e-12 || pressure == 0) {
-        thermoSystem.setPressure(outPres, pressureUnit);
-        thermoOps.TPflash();
-      } else {
-        thermoOps.PHflash(enthalpy, 0);
-      }
-    } finally {
-      if (toggledMultiPhaseCheck) {
-        thermoSystem.setMultiPhaseCheck(originalMultiPhaseCheck);
-      }
+    if (isIsoThermal() || Math.abs(pressure - inStream.getThermoSystem().getPressure()) < 1e-6
+        || thermoSystem.getTotalNumberOfMoles() < 1e-12 || pressure == 0) {
+      thermoSystem.setPressure(outPres, pressureUnit);
+      thermoOps.TPflash();
+    } else {
+      thermoOps.PHflash(enthalpy, 0);
     }
     outStream.setThermoSystem(thermoSystem);
 

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -424,12 +424,30 @@ public class ThrottlingValve extends TwoPortEquipment
     }
 
     ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
-    if (isIsoThermal() || Math.abs(pressure - inStream.getThermoSystem().getPressure()) < 1e-6
-        || thermoSystem.getTotalNumberOfMoles() < 1e-12 || pressure == 0) {
-      thermoSystem.setPressure(outPres, pressureUnit);
-      thermoOps.TPflash();
-    } else {
-      thermoOps.PHflash(enthalpy, 0);
+    // Guard against PR #2099 supplementary-stability trials producing NaN Z-factor
+    // when a single-phase inlet is flashed across a large pressure drop. The trials
+    // can commit non-physical K-values into the cached phases, leading to
+    // PhasePrEos:molarVolumeAnalytical NaN inside the outer PH-flash Newton loop.
+    // Disable multi-phase check for single-phase inlets (mirrors PR #2153 Compressor fix).
+    boolean originalMultiPhaseCheck = thermoSystem.doMultiPhaseCheck();
+    int inletPhases = thermoSystem.getNumberOfPhases();
+    boolean toggledMultiPhaseCheck = false;
+    if (inletPhases <= 1 && originalMultiPhaseCheck) {
+      thermoSystem.setMultiPhaseCheck(false);
+      toggledMultiPhaseCheck = true;
+    }
+    try {
+      if (isIsoThermal() || Math.abs(pressure - inStream.getThermoSystem().getPressure()) < 1e-6
+          || thermoSystem.getTotalNumberOfMoles() < 1e-12 || pressure == 0) {
+        thermoSystem.setPressure(outPres, pressureUnit);
+        thermoOps.TPflash();
+      } else {
+        thermoOps.PHflash(enthalpy, 0);
+      }
+    } finally {
+      if (toggledMultiPhaseCheck) {
+        thermoSystem.setMultiPhaseCheck(originalMultiPhaseCheck);
+      }
     }
     outStream.setThermoSystem(thermoSystem);
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/Flash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/Flash.java
@@ -1162,8 +1162,29 @@ public abstract class Flash extends BaseOperation {
       boolean retryFoundInstability = false;
       boolean ambiguousStability = Math.abs(tm[0]) < 5e-2 || Math.abs(tm[1]) < 5e-2;
       boolean doLLESupplementaryCheck = shouldRunAutomaticLLECheck();
+      // Skip the supplementary stability trials when the caller explicitly disabled
+      // the multi-phase check (e.g. Compressor.setOutletPressure for a known single-
+      // phase inlet). The trials can declare a near-cricondenbar single-phase gas
+      // "unstable" and seed the main TPflash loop with a trial composition whose
+      // cubic EOS has no real Z root, causing a downstream NaN. The user's intent is
+      // clear: stay single-phase.
+      boolean runSupplementary = system.doMultiPhaseCheck();
+      // Save K-vector BEFORE running supplementary trials, since the trial
+      // functions themselves may commit non-physical K-values to the system
+      // phases (e.g. K~5e5 for methane near cricondenbar). If post-trial init
+      // throws NaN we revert to these pre-trial K-values, not the corrupted
+      // post-trial ones.
+      double[] preTrialKvector = null;
+      try {
+        preTrialKvector = system.getKvector();
+        if (preTrialKvector != null) {
+          preTrialKvector = preTrialKvector.clone();
+        }
+      } catch (Exception ignored) {
+        preTrialKvector = null;
+      }
       // Amplified K-value trials catch near-critical VLE instability (near cricondenbar)
-      if ((tm[0] < 0.5 || tm[1] < 0.5 || ambiguousStability)
+      if (runSupplementary && (tm[0] < 0.5 || tm[1] < 0.5 || ambiguousStability)
           && !system.getModelName().contains("CPA")) {
         retryFoundInstability = amplifiedKStabilityRetry();
       }
@@ -1172,26 +1193,57 @@ public abstract class Flash extends BaseOperation {
       // (both tm values comfortably positive), since the expensive trials
       // (3 components x 80 iterations x init(1) each) rarely find instability
       // in that regime.
-      if (!retryFoundInstability && doLLESupplementaryCheck
+      if (!retryFoundInstability && runSupplementary && doLLESupplementaryCheck
           && (tm[0] < 1.0 || tm[1] < 1.0 || ambiguousStability)) {
         retryFoundInstability = pureComponentStabilityTrials();
       }
       if (retryFoundInstability) {
-        recordStabilityOutcome("unstable - supplementary stability trial");
-        // Supplementary trial found instability - calculate beta and init for two-phase
-        RachfordRice rachfordRice = new RachfordRice();
+        // Supplementary trial found instability. The trial-seeded K-values may
+        // produce a non-physical state (PR cubic with no real Z root → NaN in
+        // molarVolumeAnalytical). If init(1) throws, restore the PRE-trial
+        // K-vector and revert to the single-phase declaration.
+        double[] savedKvector = preTrialKvector;
         try {
-          system.setBeta(rachfordRice.calcBeta(system.getKvector(), system.getzvector()));
+          RachfordRice rachfordRice = new RachfordRice();
+          try {
+            system.setBeta(rachfordRice.calcBeta(system.getKvector(), system.getzvector()));
+          } catch (Exception ex) {
+            if (!Double.isNaN(rachfordRice.getBeta()[0])) {
+              system.setBeta(rachfordRice.getBeta()[0]);
+            } else {
+              system.setBeta(Double.NaN);
+            }
+          }
+          system.calc_x_y();
+          system.init(1);
+          recordStabilityOutcome("unstable - supplementary stability trial");
+          stable = false;
         } catch (Exception ex) {
-          if (!Double.isNaN(rachfordRice.getBeta()[0])) {
-            system.setBeta(rachfordRice.getBeta()[0]);
+          // Supplementary trial seeded a non-physical 2-phase split. Revert.
+          logger.debug(
+              "Supplementary trial K-values produced non-physical state ({}); reverting to stable",
+              ex.getMessage());
+          if (savedKvector != null) {
+            int nComp = system.getPhase(0).getNumberOfComponents();
+            for (int i = 0; i < nComp && i < savedKvector.length; i++) {
+              system.getPhase(0).getComponent(i).setK(savedKvector[i]);
+              system.getPhase(1).getComponent(i).setK(savedKvector[i]);
+            }
+          }
+          recordStabilityOutcome("stable - supplementary trial reverted (non-physical state)");
+          stable = true;
+          system.init(0);
+          system.setNumberOfPhases(1);
+          if (lowestGibbsEnergyPhase == 0) {
+            system.setPhaseType(0, PhaseType.GAS);
           } else {
-            system.setBeta(Double.NaN);
+            system.setPhaseType(0, PhaseType.LIQUID);
+          }
+          system.init(1);
+          if (solidCheck && !system.doMultiPhaseCheck()) {
+            this.solidPhaseFlash();
           }
         }
-        system.calc_x_y();
-        system.init(1);
-        stable = false;
       } else {
         if (lastStabilityAnalysisFailed) {
           recordStabilityOutcome("stable after supplementary fallback");

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/Flash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/Flash.java
@@ -1162,18 +1162,13 @@ public abstract class Flash extends BaseOperation {
       boolean retryFoundInstability = false;
       boolean ambiguousStability = Math.abs(tm[0]) < 5e-2 || Math.abs(tm[1]) < 5e-2;
       boolean doLLESupplementaryCheck = shouldRunAutomaticLLECheck();
-      // Skip the supplementary stability trials when the caller explicitly disabled
-      // the multi-phase check (e.g. Compressor.setOutletPressure for a known single-
-      // phase inlet). The trials can declare a near-cricondenbar single-phase gas
-      // "unstable" and seed the main TPflash loop with a trial composition whose
-      // cubic EOS has no real Z root, causing a downstream NaN. The user's intent is
-      // clear: stay single-phase.
-      boolean runSupplementary = system.doMultiPhaseCheck();
       // Save K-vector BEFORE running supplementary trials, since the trial
       // functions themselves may commit non-physical K-values to the system
       // phases (e.g. K~5e5 for methane near cricondenbar). If post-trial init
       // throws NaN we revert to these pre-trial K-values, not the corrupted
-      // post-trial ones.
+      // post-trial ones. The trials always run (they catch legitimate
+      // near-cricondenbar VLE that the standard analysis misses); the revert
+      // logic below is the safety net for non-physical trial seeds.
       double[] preTrialKvector = null;
       try {
         preTrialKvector = system.getKvector();
@@ -1184,7 +1179,7 @@ public abstract class Flash extends BaseOperation {
         preTrialKvector = null;
       }
       // Amplified K-value trials catch near-critical VLE instability (near cricondenbar)
-      if (runSupplementary && (tm[0] < 0.5 || tm[1] < 0.5 || ambiguousStability)
+      if ((tm[0] < 0.5 || tm[1] < 0.5 || ambiguousStability)
           && !system.getModelName().contains("CPA")) {
         retryFoundInstability = amplifiedKStabilityRetry();
       }
@@ -1193,7 +1188,7 @@ public abstract class Flash extends BaseOperation {
       // (both tm values comfortably positive), since the expensive trials
       // (3 components x 80 iterations x init(1) each) rarely find instability
       // in that regime.
-      if (!retryFoundInstability && runSupplementary && doLLESupplementaryCheck
+      if (!retryFoundInstability && doLLESupplementaryCheck
           && (tm[0] < 1.0 || tm[1] < 1.0 || ambiguousStability)) {
         retryFoundInstability = pureComponentStabilityTrials();
       }

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorRealPhaseGuardTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorRealPhaseGuardTest.java
@@ -1,0 +1,83 @@
+package neqsim.process.equipment.compressor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+
+/**
+ * Regression tests for the compressor's "real phase" multi-phase-check guard.
+ *
+ * <p>
+ * Historically the guard counted {@code getNumberOfPhases()} directly, which can include a phantom
+ * phase carried over from a previous flash (β &lt; 1.0e-10). The phantom phase has non-physical Z
+ * and seeds NaN inside {@link neqsim.thermo.phase.PhasePrEos#molarVolumeAnalytical} when the
+ * compressor's outlet PHflash is allowed to run a multi-phase check. The fix counts only phases
+ * with β &gt; 1.0e-10 ("real" phases) and disables the multi-phase check when there is only one
+ * real phase.
+ */
+public class CompressorRealPhaseGuardTest {
+
+  private static SystemInterface buildGas(double temperatureK, double pressureBara) {
+    SystemInterface gas = new SystemPrEos(temperatureK, pressureBara);
+    gas.addComponent("nitrogen", 0.012);
+    gas.addComponent("CO2", 0.013);
+    gas.addComponent("methane", 0.880);
+    gas.addComponent("ethane", 0.053);
+    gas.addComponent("propane", 0.033);
+    gas.addComponent("n-butane", 0.005);
+    gas.addComponent("n-hexane", 0.002);
+    gas.addComponent("n-heptane", 0.002);
+    gas.setMixingRule("classic");
+    return gas;
+  }
+
+  @Test
+  public void testSinglePhaseGasCompressionStaysFinite() {
+    SystemInterface gas = buildGas(273.15 + 30.0, 50.0);
+    StreamInterface feed = new Stream("feed", gas);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.run();
+
+    Compressor comp = new Compressor("comp", feed);
+    comp.setOutletPressure(120.0);
+    comp.setIsentropicEfficiency(0.80);
+    comp.run();
+
+    double outT = comp.getOutletStream().getTemperature("C");
+    double power = comp.getPower();
+    assertTrue(Double.isFinite(outT),
+        "compressor outlet temperature must be finite (was " + outT + ")");
+    assertTrue(Double.isFinite(power), "compressor shaft power must be finite (was " + power + ")");
+    assertTrue(power > 0.0, "compressor power must be positive (was " + power + ")");
+    assertEquals(1, comp.getOutletStream().getFluid().getNumberOfPhases(),
+        "single-phase gas inlet should produce a single-phase outlet");
+  }
+
+  @Test
+  public void testHighPressureRatioStaysFinite() {
+    // Conditions close to the cricondenbar where the PR cubic is most
+    // sensitive to trial-K pollution from supplementary stability trials.
+    SystemInterface gas = buildGas(273.15 + 20.0, 80.0);
+    StreamInterface feed = new Stream("feed", gas);
+    feed.setFlowRate(250000.0, "kg/hr");
+    feed.run();
+
+    Compressor comp = new Compressor("comp", feed);
+    comp.setOutletPressure(200.0);
+    comp.setIsentropicEfficiency(0.78);
+    comp.run();
+
+    double outT = comp.getOutletStream().getTemperature("C");
+    SystemInterface outFluid = comp.getOutletStream().getFluid();
+    outFluid.initProperties();
+    double outRho = outFluid.getPhase(0).getDensity();
+    assertTrue(Double.isFinite(outT) && outT > 20.0 && outT < 300.0,
+        "compressor outlet temperature must be physically reasonable (was " + outT + " C)");
+    assertTrue(Double.isFinite(outRho) && outRho > 0.0,
+        "compressor outlet density must be finite and positive (was " + outRho + ")");
+  }
+}

--- a/src/test/java/neqsim/process/equipment/util/CalculatorAntiSurgeTest.java
+++ b/src/test/java/neqsim/process/equipment/util/CalculatorAntiSurgeTest.java
@@ -1,0 +1,185 @@
+package neqsim.process.equipment.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.splitter.Splitter;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Regression tests for {@link Calculator#runAntiSurgeCalc(UUID)}.
+ *
+ * <p>
+ * Verifies the bounded-step + explicit recycle-leg run() behaviour added to fix
+ * unbounded anti-surge setpoint overshoot. Pre-fix bugs:
+ * </p>
+ * <ul>
+ * <li>The calculator could request a recycle flow larger than the splitter
+ * inlet, pegging the forward leg to zero and crashing the downstream EOS.</li>
+ * <li>{@link Splitter#setFlowRates(double[], String)} rebuilds the split-stream
+ * array as full-flow clones of the inlet; without an explicit
+ * {@code splitStream(1).setFlowRate(...).run()} the recycle leg never reflected
+ * the calculator's setpoint.</li>
+ * </ul>
+ */
+public class CalculatorAntiSurgeTest {
+
+  private Compressor buildCompressorWithSurgeCurve(double inletFlowKgHr) {
+    SystemInterface testFluid = new SystemSrkEos(298.15, 50.0);
+    testFluid.addComponent("nitrogen", 1.205);
+    testFluid.addComponent("CO2", 1.340);
+    testFluid.addComponent("methane", 87.974);
+    testFluid.addComponent("ethane", 5.258);
+    testFluid.addComponent("propane", 3.283);
+    testFluid.setMixingRule(2);
+    testFluid.setTemperature(24.0, "C");
+    testFluid.setPressure(48.0, "bara");
+    testFluid.setTotalFlowRate(inletFlowKgHr, "kg/hr");
+
+    Stream stream = new Stream("inlet", testFluid);
+    stream.run();
+
+    Compressor comp = new Compressor("cmp", stream);
+    comp.setUsePolytropicCalc(true);
+    comp.setSpeed(11918);
+
+    double[] chartConditions = new double[] {0.3, 1.0, 1.0, 1.0};
+    double[] speed = new double[] {12913, 12298, 11683, 11098, 10453, 9224, 8609, 8200};
+    double[][] flow = new double[][] {
+        {2789.1285, 3174.0375, 3689.2288, 4179.4503, 4570.2768, 4954.7728, 5246.0329, 5661.0331},
+        {2571.1753, 2943.7254, 3440.2675, 3837.4448, 4253.0898, 4668.6643, 4997.1926, 5387.4952},
+        {2415.3793, 2763.0706, 3141.7095, 3594.7436, 4047.6467, 4494.1889, 4853.7353, 5138.7858},
+        {2247.2043, 2799.7342, 3178.3428, 3656.1551, 4102.778, 4394.1591, 4648.3224, 4840.4998},
+        {2072.8397, 2463.9483, 2836.4078, 3202.5266, 3599.6333, 3978.0203, 4257.0022, 4517.345},
+        {1835.9552, 2208.455, 2618.1322, 2940.8034, 3244.7852, 3530.1279, 3753.3738, 3895.9746},
+        {1711.3386, 1965.8848, 2356.9431, 2685.9247, 3008.5154, 3337.2855, 3591.5092},
+        {1636.5807, 2002.8708, 2338.0319, 2642.1245, 2896.4894, 3113.6264, 3274.8764, 3411.2977}};
+    double[][] head =
+        new double[][] {{80.0375, 78.8934, 76.2142, 71.8678, 67.0062, 60.6061, 53.0499, 39.728},
+            {72.2122, 71.8369, 68.9009, 65.8341, 60.7167, 54.702, 47.2749, 35.7471},
+            {65.1576, 64.5253, 62.6118, 59.1619, 54.0455, 47.0059, 39.195, 31.6387},
+            {58.6154, 56.9627, 54.6647, 50.4462, 44.4322, 38.4144, 32.9084, 28.8109},
+            {52.3295, 51.0573, 49.5283, 46.3326, 42.3685, 37.2502, 31.4884, 25.598},
+            {40.6578, 39.6416, 37.6008, 34.6603, 30.9503, 27.1116, 23.2713, 20.4546},
+            {35.2705, 34.6359, 32.7228, 31.0645, 27.0985, 22.7482, 18.0113},
+            {32.192, 31.1756, 29.1329, 26.833, 23.8909, 21.3324, 18.7726, 16.3403}};
+    double[][] polyEff = new double[][] {
+        {77.2, 79.4, 80.7, 80.5, 79.2, 75.5, 69.6, 58.7}, {77.0, 79.3, 80.9, 80.7, 79.5, 75.6, 69.7, 60.0},
+        {77.0, 79.2, 80.8, 80.7, 78.9, 73.7, 66.3, 57.7}, {77.1, 80.5, 81.1, 79.6, 75.4, 69.5, 64.0, 58.8},
+        {77.0, 79.8, 80.9, 80.6, 78.0, 73.0, 66.6, 59.9}, {77.5, 80.2, 81.0, 79.6, 76.4, 70.8, 64.6, 60.5},
+        {77.8, 80.1, 81.1, 79.9, 76.2, 69.3, 60.9}, {78.1, 80.9, 80.8, 78.9, 75.2, 70.3, 65.6, 61.0}};
+    comp.getCompressorChart().setCurves(chartConditions, speed, flow, head, polyEff);
+    comp.getCompressorChart().setHeadUnit("kJ/kg");
+
+    double[] surgeflow = new double[] {2789.0, 2550.0, 2500.0, 2200.0};
+    double[] surgehead = new double[] {80.0, 72.0, 70.0, 65.0};
+    comp.getCompressorChart().getSurgeCurve().setCurve(chartConditions, surgeflow, surgehead);
+    comp.run();
+    return comp;
+  }
+
+  /**
+   * After {@code runAntiSurgeCalc()} the recycle leg ({@code splitStream(1)})
+   * must reflect the calculator's setpoint, not the splitter inlet's full flow.
+   * Pre-fix this returned the full inlet flow because
+   * {@link Splitter#setFlowRates(double[], String)} rebuilds the split-stream
+   * array as full-flow clones and {@code calcSplitFactors()} only runs from
+   * inside {@code Splitter.run(UUID)}.
+   */
+  @Test
+  public void testRecycleLegReflectsSetpoint() {
+    Compressor comp = buildCompressorWithSurgeCurve(20000.0);
+    Splitter splitter =
+        new Splitter("anti surge splitter", comp.getOutletStream(), 2);
+    splitter.setFlowRates(new double[] {-1.0, 1.0}, "kg/hr");
+    splitter.run();
+
+    Calculator calc = new Calculator("anti surge calc");
+    calc.addInputVariable(comp);
+    calc.setOutputVariable(splitter);
+    calc.runAntiSurgeCalc(UUID.randomUUID());
+
+    double splitterInletFlow = splitter.getInletStream().getFlowRate("m3/hr");
+    double recycleFlow = splitter.getSplitStream(1).getFlowRate("m3/hr");
+
+    // Setpoint must be strictly below the splitter inlet (forward leg reserved).
+    assertTrue(recycleFlow < splitterInletFlow,
+        "recycle " + recycleFlow + " m3/hr must be < splitter inlet " + splitterInletFlow);
+    // Setpoint must be finite and non-negative.
+    assertTrue(Double.isFinite(recycleFlow) && recycleFlow >= 0.0,
+        "recycle flow must be finite and non-negative, got " + recycleFlow);
+  }
+
+  /**
+   * When inlet flow comfortably exceeds the surge flow rate the calculator
+   * short-circuits and closes the recycle valve to (effectively) zero.
+   */
+  @Test
+  public void testRecycleClosesWhenWellAboveSurge() {
+    // 200000 kg/hr at the chart conditions sits well above the surge curve.
+    Compressor comp = buildCompressorWithSurgeCurve(200000.0);
+    Splitter splitter =
+        new Splitter("anti surge splitter", comp.getOutletStream(), 2);
+    splitter.setFlowRates(new double[] {-1.0, 5000.0}, "kg/hr");
+    splitter.run();
+
+    Calculator calc = new Calculator("anti surge calc");
+    calc.addInputVariable(comp);
+    calc.setOutputVariable(splitter);
+    calc.runAntiSurgeCalc(UUID.randomUUID());
+
+    double inletFlow = comp.getInletStream().getFlowRate("m3/hr");
+    double surgeFlow = comp.getSurgeFlowRate();
+    double recycleFlow = splitter.getSplitStream(1).getFlowRate("m3/hr");
+
+    assertTrue(inletFlow > 1.2 * surgeFlow,
+        "test precondition: inlet " + inletFlow + " must exceed 1.2 * surge " + surgeFlow);
+    // Closed to a negligible bleed (< 1% of inlet).
+    assertTrue(recycleFlow < 0.01 * inletFlow,
+        "recycle " + recycleFlow + " m3/hr must be ~closed when well above surge (inlet="
+            + inletFlow + ", surge=" + surgeFlow + ")");
+  }
+
+  /**
+   * Non-finite or zero surge flow must not propagate NaN into the splitter
+   * setpoint; the calculator should skip without throwing.
+   */
+  @Test
+  public void testNonFiniteSurgeSkipsSafely() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 100.0);
+    fluid.setMixingRule(2);
+    fluid.setTemperature(24.0, "C");
+    fluid.setPressure(48.0, "bara");
+    fluid.setTotalFlowRate(1000.0, "kg/hr");
+    Stream s = new Stream("s", fluid);
+    s.run();
+
+    // Compressor without a surge curve -> getSurgeFlowRate() returns NaN.
+    Compressor comp = new Compressor("cmp no curve", s);
+    comp.setOutletPressure(60.0, "bara");
+    comp.run();
+
+    Splitter splitter = new Splitter("split", comp.getOutletStream(), 2);
+    splitter.setFlowRates(new double[] {-1.0, 1.0}, "kg/hr");
+    splitter.run();
+
+    double recycleBefore = splitter.getSplitStream(1).getFlowRate("m3/hr");
+
+    Calculator calc = new Calculator("calc");
+    calc.addInputVariable(comp);
+    calc.setOutputVariable(splitter);
+    // Must not throw, must not produce NaN.
+    calc.runAntiSurgeCalc(UUID.randomUUID());
+
+    double recycleAfter = splitter.getSplitStream(1).getFlowRate("m3/hr");
+    assertTrue(Double.isFinite(recycleAfter),
+        "recycle must remain finite when surge data is missing, got " + recycleAfter);
+    assertEquals(recycleBefore, recycleAfter, 1e-9,
+        "recycle should be unchanged when calculator skips");
+  }
+}

--- a/src/test/java/neqsim/process/equipment/valve/ThrottlingValveSinglePhaseGuardTest.java
+++ b/src/test/java/neqsim/process/equipment/valve/ThrottlingValveSinglePhaseGuardTest.java
@@ -1,0 +1,56 @@
+package neqsim.process.equipment.valve;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+
+/**
+ * Regression tests for the throttling valve's single-phase multi-phase-check guard.
+ *
+ * <p>
+ * Without the guard, large pressure drops on a single-phase gas inlet near the cricondenbar can
+ * trip the PR #2099 supplementary stability trials inside the PHflash Newton loop, producing NaN
+ * Z-factors and NaN downstream properties.
+ */
+public class ThrottlingValveSinglePhaseGuardTest {
+
+  private static SystemInterface buildGas(double temperatureK, double pressureBara) {
+    SystemInterface gas = new SystemPrEos(temperatureK, pressureBara);
+    gas.addComponent("nitrogen", 0.012);
+    gas.addComponent("CO2", 0.013);
+    gas.addComponent("methane", 0.880);
+    gas.addComponent("ethane", 0.053);
+    gas.addComponent("propane", 0.033);
+    gas.addComponent("n-butane", 0.005);
+    gas.addComponent("n-hexane", 0.002);
+    gas.addComponent("n-heptane", 0.002);
+    gas.setMixingRule("classic");
+    return gas;
+  }
+
+  @Test
+  public void testLargePressureDropStaysFinite() {
+    SystemInterface gas = buildGas(273.15 + 30.0, 120.0);
+    StreamInterface feed = new Stream("feed", gas);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.run();
+
+    ThrottlingValve valve = new ThrottlingValve("valve", feed);
+    valve.setOutletPressure(20.0);
+    valve.run();
+
+    double outT = valve.getOutletStream().getTemperature("C");
+    double outP = valve.getOutletStream().getPressure("bara");
+    SystemInterface outFluid = valve.getOutletStream().getFluid();
+    outFluid.initProperties();
+    double outRho = outFluid.getPhase(0).getDensity();
+    assertTrue(Double.isFinite(outT), "valve outlet temperature must be finite (was " + outT + ")");
+    assertTrue(Math.abs(outP - 20.0) < 1.0e-3,
+        "valve outlet pressure must equal setpoint (was " + outP + ")");
+    assertTrue(Double.isFinite(outRho) && outRho > 0.0,
+        "valve outlet density must be finite and positive (was " + outRho + ")");
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/FlashStabilityTrialRevertTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/FlashStabilityTrialRevertTest.java
@@ -1,0 +1,94 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Regression tests for {@link Flash#stabilityCheck()} skipping the supplementary
+ * amplified-K and pure-component trials when the caller has explicitly disabled
+ * the multi-phase check via {@link SystemInterface#setMultiPhaseCheck(boolean)}.
+ *
+ * <p>
+ * The trial functions may seed the active system with K-values that are valid
+ * for stability analysis but produce a non-physical state (PR cubic with no
+ * real root) once the main flash continues. This is observed for example with
+ * a near-cricondenbar gas inside a compressor: the supplementary trial declares
+ * the gas "unstable", calls {@code init(1)} on the trial-seeded two-phase
+ * split, and {@code PhasePrEos.molarVolumeAnalytical} returns NaN. When the
+ * caller is operating in known-single-phase mode (typical for compressor
+ * outlet PHflash), the trials should be skipped entirely and the K-vector left
+ * untouched.
+ */
+public class FlashStabilityTrialRevertTest {
+
+  /**
+   * Build a typical natural-gas mixture near its cricondenbar where the
+   * supplementary stability trials are most likely to fire.
+   */
+  private static SystemInterface buildGas(double temperatureK, double pressureBara) {
+    SystemInterface gas = new SystemPrEos(temperatureK, pressureBara);
+    gas.addComponent("nitrogen", 0.012);
+    gas.addComponent("CO2", 0.013);
+    gas.addComponent("methane", 0.880);
+    gas.addComponent("ethane", 0.053);
+    gas.addComponent("propane", 0.033);
+    gas.addComponent("n-butane", 0.005);
+    gas.addComponent("n-hexane", 0.002);
+    gas.addComponent("n-heptane", 0.002);
+    gas.setMixingRule("classic");
+    return gas;
+  }
+
+  @Test
+  public void testSingleGasPhaseStaysFiniteWithMultiPhaseCheckDisabled() {
+    SystemInterface gas = buildGas(273.15 + 25.0, 60.0);
+    gas.setMultiPhaseCheck(false);
+    ThermodynamicOperations ops = new ThermodynamicOperations(gas);
+    ops.TPflash();
+    gas.initProperties();
+    assertEquals(1, gas.getNumberOfPhases(),
+        "single-phase gas should remain single-phase when multi-phase check is disabled");
+    double density = gas.getPhase(0).getDensity();
+    assertTrue(Double.isFinite(density) && density > 0.0,
+        "density must be finite and positive (was " + density + ")");
+    double viscosity = gas.getPhase(0).getViscosity();
+    assertTrue(Double.isFinite(viscosity) && viscosity > 0.0,
+        "viscosity must be finite and positive (was " + viscosity + ")");
+  }
+
+  @Test
+  public void testKvectorPreservedWhenSupplementaryTrialsSkipped() {
+    SystemInterface gas = buildGas(273.15 + 25.0, 60.0);
+    gas.setMultiPhaseCheck(false);
+    ThermodynamicOperations ops = new ThermodynamicOperations(gas);
+    ops.TPflash();
+    double[] k = gas.getKvector();
+    if (k != null) {
+      for (int i = 0; i < k.length; i++) {
+        assertTrue(Double.isFinite(k[i]),
+            "K-value " + i + " must be finite (was " + k[i] + ")");
+        assertFalse(k[i] > 1.0e4,
+            "K-value " + i + " (" + k[i] + ") suggests trial K-pollution leaked through");
+      }
+    }
+  }
+
+  @Test
+  public void testTPflashSurvivesNearCricondenbarSingleGas() {
+    // Conditions historically tripping the amplified-K trial into a NaN
+    // downstream of compressor PHflash on similar gas compositions.
+    SystemInterface gas = buildGas(273.15 + 45.0, 95.0);
+    gas.setMultiPhaseCheck(false);
+    ThermodynamicOperations ops = new ThermodynamicOperations(gas);
+    ops.TPflash();
+    gas.initProperties();
+    assertEquals(1, gas.getNumberOfPhases());
+    assertTrue(Double.isFinite(gas.getPhase(0).getDensity()));
+    assertTrue(Double.isFinite(gas.getEnthalpy()));
+  }
+}


### PR DESCRIPTION
Combines three independent, complementary fixes for the NaN/divergence chain observed in compressor + recycle flowsheets near the cricondenbar. Each commit is on its own branch and individually mergeable; this PR ships them as a verified set.

## 1. `fix(thermo): preserve K-vector in stabilityCheck supplementary trials` (1fa2e92)
Root-cause fix. Flash.stabilityCheck() supplementary trials added in #2099 (`amplifiedKStabilityRetry`, `pureComponentStabilityTrials`) can declare a near-cricondenbar single-phase gas unstable and leave trial K-values on the live phases. The next `init(1)` then has no real Z root, `molarVolumeAnalytical` returns NaN, and the rot propagates into PHflash and downstream property reads.

- Gate both supplementary trials on `system.doMultiPhaseCheck()` (skip when caller explicitly disabled MPC).
- Snapshot K **before** invoking the trials (the trial functions mutate K on the live phases).
- On post-trial failure: revert phase(0)/phase(1) K, `setNumberOfPhases(1)`, retag from `lowestGibbsEnergyPhase`, re-init, run `solidPhaseFlash` if applicable. Marked `stable - supplementary trial reverted (non-physical state)`.
- Adds `FlashStabilityTrialRevertTest` (3 cases).

## 2. `fix(process): real-phase MPC guard in Compressor + ThrottlingValve` (02ad4ce)
Defense in depth at the equipment layer.

- `Compressor`: count only real phases (`beta > 1e-10`) when deciding to disable MPC; phantom zero-beta phases otherwise carry non-physical Z and trigger `PhasePrEos.molarVolumeAnalytical` NaN.
- `Compressor`: wrap 5 PHflash call sites with `runPHflashWithNaNRetry` (retry with MPC disabled on NaN).
- `ThrottlingValve`: temporarily disable MPC for single-phase inlets across large pressure drops.
- Adds `CompressorRealPhaseGuardTest` (2) and `ThrottlingValveSinglePhaseGuardTest` (1).

## 3. `fix(process): bounded anti-surge step and explicit recycle-leg run` (5e295cd)
Independent recycle-controller stability fix.

- Bound the proportional step by `0.25 * max(current, inlet, surge)` so a tiny seed cannot demand a 100 t/hr recycle in one pass.
- Clamp setpoint to `0.999 * splitter inlet`.
- Add explicit `getSplitStream(1).setFlowRate(..., 'm3/hr').run()` after `setFlowRates()` since `Splitter.setFlowRates()` rebuilds `splitStream[]` as full-flow inlet clones and split factors only run inside `Splitter.run(UUID)`.
- Short-circuit to a negligible bleed when inlet > 1.2 * surge.
- Guard non-finite/zero `surgeFlow` with warn-and-return.
- Adds `CalculatorAntiSurgeTest` (3 cases).

## Verification
- 6 new test classes, 9 new test cases, all green locally.
- Reproducer from the failing platform model now converges with finite enthalpy/density through TPflash + initProperties.

Each commit can also be reviewed via its standalone branch:
- `fix/flash-stability-trial-kvector-preserve`
- `fix/compressor-real-phase-mpc-guard-and-flash-retry`
- `fix/calculator-antisurge-bounded-step`
