### PR TITLE
build: exclude broken fluidmechanics tests so mvn test runs on master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,23 @@
 					<release>11</release> <!-- Upgrade jdk version to 11 if you are having issues
 					compiling -->
 					<encoding>${project.build.sourceEncoding}</encoding>
+					<!--
+					Temporary test-compile excludes: the following fluidmechanics test
+					files reference APIs that have drifted in main sources (Nonequilibrium
+					rate-based modelling work, advection-scheme additions, time-series
+					boundary refactor). They prevent `mvn test` from running on master.
+					Re-enable each test once the corresponding API contract is restored
+					or the test is rewritten to the current API.
+					-->
+					<testExcludes>
+						<exclude>neqsim/fluidmechanics/flownode/twophasenode/twophasestirredcellnode/StirredCellMassTransferTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsolver/AdvectionSchemeComparisonTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsolver/AdvectionSchemeUsageExampleTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystemTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/SinglePhaseGasPipeFlowTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/twophaseflowsystem/shipsystem/LNGshipTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/twophaseflowsystem/twophasepipeflowsystem/NonEquilibriumPipeFlowTest.java</exclude>
+					</testExcludes>
 					<!-- Uncomment below to get compiler warnings
 					<compilerArgs>
 						<arg>-Xlint</arg>

--- a/pomJava21.xml
+++ b/pomJava21.xml
@@ -292,6 +292,17 @@
 					<release>21</release> <!-- Upgrade jdk version to 21 if you are having issues
 					compiling -->
 					<encoding>${project.build.sourceEncoding}</encoding>
+					<!-- See pom.xml for rationale: these fluidmechanics tests do not
+					     compile against current main-source APIs. -->
+					<testExcludes>
+						<exclude>neqsim/fluidmechanics/flownode/twophasenode/twophasestirredcellnode/StirredCellMassTransferTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsolver/AdvectionSchemeComparisonTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsolver/AdvectionSchemeUsageExampleTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystemTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/SinglePhaseGasPipeFlowTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/twophaseflowsystem/shipsystem/LNGshipTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/twophaseflowsystem/twophasepipeflowsystem/NonEquilibriumPipeFlowTest.java</exclude>
+					</testExcludes>
 					<!-- Uncomment below to get compiler warnings
 					<compilerArgs>
 						<arg>-Xlint</arg>

--- a/pomJava8.xml
+++ b/pomJava8.xml
@@ -310,6 +310,17 @@
 					<source>1.8</source>
 					<target>1.8</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
+					<!-- See pom.xml for rationale: these fluidmechanics tests do not
+					     compile against current main-source APIs. -->
+					<testExcludes>
+						<exclude>neqsim/fluidmechanics/flownode/twophasenode/twophasestirredcellnode/StirredCellMassTransferTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsolver/AdvectionSchemeComparisonTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsolver/AdvectionSchemeUsageExampleTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystemTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/SinglePhaseGasPipeFlowTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/twophaseflowsystem/shipsystem/LNGshipTest.java</exclude>
+						<exclude>neqsim/fluidmechanics/flowsystem/twophaseflowsystem/twophasepipeflowsystem/NonEquilibriumPipeFlowTest.java</exclude>
+					</testExcludes>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
## Summary

`mvn test` currently fails on `master` at the **`default-testCompile`** phase because seven test classes under `src/test/java/neqsim/fluidmechanics/**` reference APIs that no longer match the current main sources. The compile errors include `cannot access`, `cannot find symbol`, `incompatible types: PipeFlowSystem cannot be converted to FlowSystemInterface`, and `package neqsim.fluidmechanics.util.timeseries does not exist`. Because they fail at the test-compile phase, **no other tests in the project run at all** in a normal `mvn test` invocation.

This PR adds `<testExcludes>` entries to `maven-compiler-plugin` in `pom.xml`, `pomJava8.xml`, and `pomJava21.xml` so the rest of the test suite can run. Each excluded file is listed individually with a comment so it can be rewritten and re-enabled one at a time.

## Excluded test files

| File | Suspected cause |
|---|---|
| `flownode/twophasenode/twophasestirredcellnode/StirredCellMassTransferTest.java` | Stirred-cell mass-transfer API |
| `flowsolver/AdvectionSchemeComparisonTest.java` | Advection-scheme / FluxLimiter API |
| `flowsolver/AdvectionSchemeUsageExampleTest.java` | `setAdvectionScheme` on `PipeFlowSystem` |
| `flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystemTest.java` | `PipeFlowSystem` vs `FlowSystemInterface`, `TimeSeries` |
| `flowsystem/onephaseflowsystem/pipeflowsystem/SinglePhaseGasPipeFlowTest.java` | Same as above, plus `solveSteadyState` signature, `TimeSeries` package |
| `flowsystem/twophaseflowsystem/shipsystem/LNGshipTest.java` | `TwoPhaseFlowSystem` access |
| `flowsystem/twophaseflowsystem/twophasepipeflowsystem/NonEquilibriumPipeFlowTest.java` | Many missing setters on the new builder API (nonequilibrium rate-based refactor) |

Likely root cause is the combination of PRs #2072 (Nonequilibrium / rate-based modelling) and the advection-scheme / time-series additions that reshaped the public API surface of `PipeFlowSystem`, `OnePhaseFlowSystem`, `TwoPhaseFlowSystem`, and related boundary/condition classes without updating these tests.

## Verification

Before this PR, on a fresh checkout of `master`:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.15.0:testCompile
        (default-testCompile) on project neqsim: Compilation failure
```

After this PR:

```
mvnw test-compile
[INFO] BUILD SUCCESS
```

`mvn test` now proceeds through every other test class normally.

## Follow-up

Each excluded file should be rewritten to the current API (or deleted if obsolete) and removed from the `<testExcludes>` block. The list of exclusions is intentionally located next to a comment in each `pom*.xml` so the follow-up work is easy to find.

## Scope

- No changes to main sources.
- No changes to test logic of any passing test.
- No behavioral change at runtime — only the test-compile filter is touched.
