### PR TITLE
feat(compressor): structured operating-point accessors (getOperatingPoint / getOperatingPointJson)

### DIFF
--- a/docs/process/equipment/compressors.md
+++ b/docs/process/equipment/compressors.md
@@ -188,6 +188,46 @@ compressor.getCompressorChart().getStoneWallCurve().setCurve(chartConditions, st
 > **📖 See Also:** [Compressor Curves and Performance Maps](compressor_curves) for detailed
 > documentation on curve setup, interpolation methods, and Python examples.
 
+### Structured Operating Point
+
+Instead of calling individual getters one at a time, `getOperatingPoint()` returns the full
+operating state of the compressor as a single map, and `getOperatingPointJson()` returns the
+same data as a schema-versioned JSON string. This is convenient for logging, reporting, and
+agentic workflows.
+
+```java
+Map<String, Object> point = compressor.getOperatingPoint();
+double power = (Double) point.get("power_MW");
+boolean withinChart = (Boolean) point.get("withinChart");
+String limiting = (String) point.get("limitingConstraint");
+
+String json = compressor.getOperatingPointJson();
+```
+
+The map / JSON contains the following fields:
+
+| Field | Unit | Description |
+|-------|------|-------------|
+| `schemaVersion` | — | JSON schema version (`"1.0"`) |
+| `name` | — | Compressor name |
+| `flow_m3hr` | m³/hr | Inlet actual volumetric flow rate |
+| `head_kJkg` | kJ/kg | Polytropic fluid head |
+| `speed_rpm` | rpm | Shaft speed |
+| `polytropicEfficiency` | — | Polytropic efficiency (fraction) |
+| `power_MW` / `power_kW` | MW / kW | Shaft power |
+| `outletPressure_bara` | bara | Discharge pressure |
+| `outletTemperature_C` | °C | Discharge temperature |
+| `chartActive` | — | Whether a performance chart is active |
+| `distanceToSurge` | — | Distance to surge (positive = safe) |
+| `distanceToStoneWall` | — | Distance to stone wall (positive = safe) |
+| `surgeFlowRate_m3hr` | m³/hr | Surge flow rate at current head |
+| `surgeFlowRateMargin_m3hr` | m³/hr | Margin between current flow and surge flow |
+| `withinChart` | — | True if the point is inside the operating envelope |
+| `limitingConstraint` | — | `none`, `surge`, `stonewall`, or `no_chart` |
+
+When no chart is active, `withinChart` is `true` and `limitingConstraint` is `no_chart`.
+Values that cannot be computed are returned as `NaN`.
+
 ---
 
 ## Compressor Staging

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -2412,6 +2412,142 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface,
   }
 
   /**
+   * Safely evaluate a {@code double}-valued supplier, returning {@link Double#NaN} when the
+   * underlying calculation throws or is not yet initialised.
+   *
+   * <p>
+   * This is intended for the machine-readable operating-point accessors, which are frequently
+   * called by automation/AI agents before every quantity has been initialised. Returning
+   * {@code NaN} instead of propagating an exception keeps the result object usable.
+   * </p>
+   *
+   * @param supplier the calculation to evaluate
+   * @return the evaluated value, or {@link Double#NaN} if evaluation fails
+   */
+  private double safeDouble(java.util.function.DoubleSupplier supplier) {
+    try {
+      return supplier.getAsDouble();
+    } catch (Exception | StackOverflowError ex) {
+      return Double.NaN;
+    }
+  }
+
+  /**
+   * Safely evaluate a {@code boolean}-valued supplier, returning {@code false} when the underlying
+   * calculation throws.
+   *
+   * @param supplier the calculation to evaluate
+   * @return the evaluated value, or {@code false} if evaluation fails
+   */
+  private boolean safeBoolean(java.util.function.BooleanSupplier supplier) {
+    try {
+      return supplier.getAsBoolean();
+    } catch (Exception | StackOverflowError ex) {
+      return false;
+    }
+  }
+
+  /**
+   * Return a structured, machine-readable snapshot of the compressor operating point.
+   *
+   * <p>
+   * This is a single aggregation of the quantities an analyst or AI agent normally extracts one
+   * call at a time (flow, head, speed, efficiency, power) together with the compressor-map
+   * constraint picture ({@link #getDistanceToSurge()}, {@link #getDistanceToStoneWall()},
+   * {@link #isSurge()}, {@link #isStoneWall()}). The intent is that the question "is this machine
+   * feasible at this operating point?" becomes a field ({@code withinChart} /
+   * {@code limitingConstraint}) instead of a re-implementation in client code.
+   * </p>
+   *
+   * <p>
+   * Keys carry their unit in the name (for example {@code flow_m3hr}, {@code head_kJkg},
+   * {@code power_MW}). Values that cannot be evaluated are returned as {@link Double#NaN}. When no
+   * compressor chart is in use the chart-related fields are still present:
+   * {@code chartActive} is {@code false}, {@code withinChart} is {@code true} (no map limit to
+   * violate) and {@code limitingConstraint} is {@code "no_chart"}.
+   * </p>
+   *
+   * <table>
+   * <caption>Operating-point keys</caption>
+   * <tr><th>Key</th><th>Meaning</th></tr>
+   * <tr><td>flow_m3hr</td><td>Actual inlet volumetric flow rate</td></tr>
+   * <tr><td>head_kJkg</td><td>Polytropic fluid head</td></tr>
+   * <tr><td>speed_rpm</td><td>Shaft speed</td></tr>
+   * <tr><td>polytropicEfficiency</td><td>Polytropic efficiency (fraction)</td></tr>
+   * <tr><td>power_MW / power_kW</td><td>Shaft power</td></tr>
+   * <tr><td>outletPressure_bara</td><td>Discharge pressure</td></tr>
+   * <tr><td>outletTemperature_C</td><td>Discharge temperature</td></tr>
+   * <tr><td>distanceToSurge</td><td>(flow/surgeFlow - 1); negative means in surge</td></tr>
+   * <tr><td>distanceToStoneWall</td><td>(stoneWallFlow/flow - 1); negative means choked</td></tr>
+   * <tr><td>surgeFlowRate_m3hr</td><td>Surge flow at current head</td></tr>
+   * <tr><td>surgeFlowRateMargin_m3hr</td><td>flow - surgeFlow</td></tr>
+   * <tr><td>chartActive</td><td>Whether a compressor chart is in use</td></tr>
+   * <tr><td>withinChart</td><td>True when not in surge and not in stone wall</td></tr>
+   * <tr><td>limitingConstraint</td><td>"surge", "stonewall", "none" or "no_chart"</td></tr>
+   * </table>
+   *
+   * @return an ordered map describing the operating point (never {@code null})
+   */
+  public Map<String, Object> getOperatingPoint() {
+    Map<String, Object> point = new LinkedHashMap<String, Object>();
+    point.put("schemaVersion", "1.0");
+    point.put("name", getName());
+
+    final StreamInterface in = getInletStream();
+    point.put("flow_m3hr", in == null ? Double.NaN : safeDouble(() -> in.getFlowRate("m3/hr")));
+    point.put("head_kJkg", safeDouble(this::getPolytropicFluidHead));
+    point.put("speed_rpm", safeDouble(this::getSpeed));
+    point.put("polytropicEfficiency", safeDouble(this::getPolytropicEfficiency));
+    point.put("power_MW", safeDouble(() -> getPower("MW")));
+    point.put("power_kW", safeDouble(() -> getPower("kW")));
+    point.put("outletPressure_bara", safeDouble(this::getOutletPressure));
+    point.put("outletTemperature_C", safeDouble(() -> getOutTemperature() - 273.15));
+
+    boolean chartActive = safeBoolean(() -> getCompressorChart() != null
+        && getCompressorChart().isUseCompressorChart());
+    point.put("chartActive", chartActive);
+
+    double distanceToSurge = safeDouble(this::getDistanceToSurge);
+    double distanceToStoneWall = safeDouble(this::getDistanceToStoneWall);
+    point.put("distanceToSurge", distanceToSurge);
+    point.put("distanceToStoneWall", distanceToStoneWall);
+    point.put("surgeFlowRate_m3hr", safeDouble(this::getSurgeFlowRate));
+    point.put("surgeFlowRateMargin_m3hr", safeDouble(this::getSurgeFlowRateMargin));
+
+    if (!chartActive) {
+      point.put("withinChart", true);
+      point.put("limitingConstraint", "no_chart");
+    } else {
+      boolean inSurge = safeBoolean(this::isSurge);
+      boolean inStoneWall = safeBoolean(this::isStoneWall);
+      point.put("withinChart", !inSurge && !inStoneWall);
+      if (inSurge) {
+        point.put("limitingConstraint", "surge");
+      } else if (inStoneWall) {
+        point.put("limitingConstraint", "stonewall");
+      } else {
+        point.put("limitingConstraint", "none");
+      }
+    }
+    return point;
+  }
+
+  /**
+   * Return {@link #getOperatingPoint()} serialised as a JSON string.
+   *
+   * <p>
+   * {@link Double#NaN} and infinite values are serialised (rather than rejected) so the response is
+   * always valid for an agent to parse.
+   * </p>
+   *
+   * @return a JSON document describing the compressor operating point
+   */
+  public String getOperatingPointJson() {
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create()
+        .toJson(getOperatingPoint());
+  }
+
+  /**
    * <p>
    * Setter for the field <code>antiSurge</code>.
    * </p>

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorOperatingPointTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorOperatingPointTest.java
@@ -1,0 +1,127 @@
+package neqsim.process.equipment.compressor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import com.google.gson.Gson;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests for the structured operating-point accessors {@link Compressor#getOperatingPoint()} and
+ * {@link Compressor#getOperatingPointJson()}.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class CompressorOperatingPointTest {
+  private Compressor compressor;
+  private Stream inletStream;
+
+  /**
+   * Builds a single-stage compressor running on a real gas fluid.
+   */
+  @BeforeEach
+  public void setUp() {
+    SystemInterface gas = new SystemSrkEos(298.15, 50.0);
+    gas.addComponent("methane", 0.9);
+    gas.addComponent("ethane", 0.05);
+    gas.addComponent("propane", 0.03);
+    gas.addComponent("n-butane", 0.02);
+    gas.setMixingRule("classic");
+    gas.setMultiPhaseCheck(false);
+
+    inletStream = new Stream("inlet", gas);
+    inletStream.setFlowRate(10000.0, "kg/hr");
+    inletStream.setTemperature(25.0, "C");
+    inletStream.setPressure(50.0, "bara");
+    inletStream.run();
+
+    compressor = new Compressor("test compressor");
+    compressor.setInletStream(inletStream);
+    compressor.setOutletPressure(100.0, "bara");
+    compressor.setUsePolytropicCalc(true);
+    compressor.setPolytropicEfficiency(0.75);
+    compressor.setSpeed(10000);
+    compressor.run();
+  }
+
+  /**
+   * Without a compressor chart the operating point should still be complete, report
+   * {@code chartActive=false}, {@code withinChart=true} and {@code limitingConstraint="no_chart"}.
+   */
+  @Test
+  public void testOperatingPointWithoutChart() {
+    Map<String, Object> point = compressor.getOperatingPoint();
+
+    assertNotNull(point, "Operating point map should not be null");
+    assertEquals("1.0", point.get("schemaVersion"));
+    assertEquals("test compressor", point.get("name"));
+    assertEquals(Boolean.FALSE, point.get("chartActive"), "No chart was set");
+    assertEquals(Boolean.TRUE, point.get("withinChart"),
+        "Without a chart there is no map limit to violate");
+    assertEquals("no_chart", point.get("limitingConstraint"));
+
+    double flow = ((Number) point.get("flow_m3hr")).doubleValue();
+    double head = ((Number) point.get("head_kJkg")).doubleValue();
+    double powerMW = ((Number) point.get("power_MW")).doubleValue();
+    double powerkW = ((Number) point.get("power_kW")).doubleValue();
+    assertTrue(flow > 0.0, "Inlet flow should be positive");
+    assertTrue(head > 0.0, "Polytropic head should be positive");
+    assertTrue(powerMW > 0.0, "Power should be positive");
+    assertEquals(powerMW * 1000.0, powerkW, 1e-6, "MW and kW must be consistent");
+
+    double outP = ((Number) point.get("outletPressure_bara")).doubleValue();
+    assertEquals(100.0, outP, 1.0, "Outlet pressure should match the spec");
+  }
+
+  /**
+   * The JSON variant should be parseable and carry the same keys as the map.
+   */
+  @Test
+  public void testOperatingPointJsonIsValid() {
+    String json = compressor.getOperatingPointJson();
+    assertNotNull(json, "JSON should not be null");
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> parsed = new Gson().fromJson(json, Map.class);
+    assertNotNull(parsed, "Parsed JSON should not be null");
+    assertEquals("test compressor", parsed.get("name"));
+    assertTrue(parsed.containsKey("distanceToSurge"));
+    assertTrue(parsed.containsKey("distanceToStoneWall"));
+    assertTrue(parsed.containsKey("limitingConstraint"));
+  }
+
+  /**
+   * With a generated compressor chart the chart-related fields should be active, the surge distance
+   * should be finite, and {@code withinChart} should be consistent with {@code limitingConstraint}.
+   */
+  @Test
+  public void testOperatingPointWithChart() {
+    CompressorChartGenerator generator = new CompressorChartGenerator(compressor);
+    generator.setChartType("interpolate and extrapolate");
+    CompressorChartInterface chart = generator.generateCompressorChart("normal curves");
+    compressor.setCompressorChart(chart);
+    compressor.run();
+
+    Map<String, Object> point = compressor.getOperatingPoint();
+
+    assertEquals(Boolean.TRUE, point.get("chartActive"), "Chart should be active");
+    double distToSurge = ((Number) point.get("distanceToSurge")).doubleValue();
+    assertFalse(Double.isNaN(distToSurge), "Distance to surge should not be NaN with a chart");
+
+    boolean withinChart = (Boolean) point.get("withinChart");
+    String constraint = (String) point.get("limitingConstraint");
+    if (withinChart) {
+      assertEquals("none", constraint, "withinChart should imply no limiting constraint");
+    } else {
+      assertTrue("surge".equals(constraint) || "stonewall".equals(constraint),
+          "A constrained point must be surge or stonewall, was " + constraint);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds two agent-friendly accessors to `Compressor` for big-model / agentic studies that need a one-call snapshot of compressor state:

- `getOperatingPoint()` — returns a schema-versioned `Map<String,Object>` (`schemaVersion=1.0`) with flow, polytropic head, speed, polytropic efficiency, power (MW + kW), outlet pressure/temperature, chart status, surge/stonewall distances and margins, `withinChart` and `limitingConstraint` (`surge` / `stonewall` / `none` / `no_chart`).
- `getOperatingPointJson()` — serializes the same object to JSON (Gson, special floating point values enabled).

### Motivation
Derived from an agentic study on a large topside model: the surge/stonewall primitives already existed (`getDistanceToSurge`, `getSurgeFlowRateMargin`, `isSurge`, etc.) but had to be assembled call-by-call per compressor. This aggregates them into one structured, machine-readable object.

### Robustness
`safeDouble` / `safeBoolean` helpers wrap each physics call so a snapshot taken before initialization returns `NaN` / `false` instead of throwing — important because agents often probe state mid-build.

### Tests
`CompressorOperatingPointTest` (3 tests, all passing):
- no chart → `chartActive=false`, `withinChart=true`, `limitingConstraint=no_chart`, consistent MW/kW
- JSON parses back to a map with the expected keys
- with a generated chart → finite `distanceToSurge`, `withinChart` consistent with `limitingConstraint`

Java 8 compatible. No behavior change to existing compressor calculations.
