### PR TITLE
feat(processmodel): runUntilConverged + getConvergenceReportJson for multi-area models

### DIFF
--- a/docs/process/processmodel/process_model.md
+++ b/docs/process/processmodel/process_model.md
@@ -188,6 +188,67 @@ double maxErr = model.getError();
 System.out.println(model.getConvergenceSummary());
 ```
 
+### Run Until Converged (Agent-Friendly)
+
+`runUntilConverged(maxIterations, tolerance)` is an explicit wrapper around `run()` that
+guarantees iterating (multi-area) mode and applies the iteration limit and tolerance in one
+call — so you do not need to manually configure `setRunStep(false)`, `setMaxIterations(...)`,
+`setTolerance(...)` and write your own outer loop.
+
+```java
+boolean converged = model.runUntilConverged(100, 1e-5);
+if (!converged) {
+  System.out.println("Model did not converge: " + model.getConvergenceReportJson());
+}
+```
+
+It throws `IllegalArgumentException` if `maxIterations < 1` or `tolerance` is not a finite
+positive number.
+
+### Structured Convergence Report (JSON)
+
+`getConvergenceReportJson()` is the machine-readable counterpart to `getConvergenceSummary()`.
+It is schema-versioned and includes the per-area solved status and the names of any unsolved
+units, so an agent can pinpoint exactly where a large multi-area model failed to converge.
+
+```java
+String json = model.getConvergenceReportJson();
+```
+
+```json
+{
+  "schemaVersion": "1.0",
+  "converged": false,
+  "iterations": 100,
+  "maxIterations": 100,
+  "boundaryStreamCount": 2,
+  "boundaryValuesConverged": false,
+  "allProcessesSolved": false,
+  "maxError": 0.0042,
+  "errors": {
+    "flow":        { "value": 0.0042, "tolerance": 1e-5, "converged": false },
+    "temperature": { "value": 8.0e-6, "tolerance": 1e-5, "converged": true },
+    "pressure":    { "value": 1.2e-6, "tolerance": 1e-5, "converged": true }
+  },
+  "areas": [
+    { "name": "Separation",  "solved": true,  "unsolvedUnits": [] },
+    { "name": "Compression", "solved": false, "unsolvedUnits": ["Recycle"] }
+  ]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `schemaVersion` | JSON schema version (`"1.0"`) |
+| `converged` | Whether the model converged on the last run |
+| `iterations` / `maxIterations` | Outer iterations performed / the configured limit |
+| `boundaryStreamCount` | Number of cross-area boundary (tear) streams |
+| `boundaryValuesConverged` | Whether all boundary stream values converged |
+| `allProcessesSolved` | Whether every contained process reported solved |
+| `maxError` | Largest relative error across flow/temperature/pressure |
+| `errors` | Per-variable `value` / `tolerance` / `converged` for flow, temperature, pressure |
+| `areas` | One entry per area with `name`, `solved`, and `unsolvedUnits` |
+
 ---
 
 ## Validation

--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -2247,6 +2247,115 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
+   * Runs the model in continuous (multi-area) mode until convergence or the iteration limit.
+   *
+   * <p>
+   * This is an explicit, agent-friendly convenience wrapper around {@link #run()}. It guarantees the
+   * model runs in iterating mode (not step mode) and applies the supplied iteration limit and
+   * tolerance before running. Use this instead of manually configuring {@link #setRunStep(boolean)},
+   * {@link #setMaxIterations(int)} and {@link #setTolerance(double)} and hard-coding an outer loop.
+   * </p>
+   *
+   * <p>
+   * After this call returns, inspect {@link #isModelConverged()}, {@link #getLastIterationCount()},
+   * {@link #getError()} or {@link #getConvergenceReportJson()} for the outcome.
+   * </p>
+   *
+   * @param maxIterations maximum number of outer iterations to attempt; must be at least 1
+   * @param tolerance relative convergence tolerance applied to flow, temperature and pressure; must
+   *        be a finite positive value
+   * @return true if the model converged within the iteration limit, false otherwise
+   * @throws IllegalArgumentException if maxIterations is less than 1 or tolerance is not a finite
+   *         positive number
+   */
+  public boolean runUntilConverged(int maxIterations, double tolerance) {
+    if (maxIterations < 1) {
+      throw new IllegalArgumentException(
+          "maxIterations must be at least 1, was " + maxIterations);
+    }
+    if (Double.isNaN(tolerance) || Double.isInfinite(tolerance) || tolerance <= 0.0) {
+      throw new IllegalArgumentException(
+          "tolerance must be a finite positive number, was " + tolerance);
+    }
+    setRunStep(false);
+    setMaxIterations(maxIterations);
+    setTolerance(tolerance);
+    run();
+    return modelConverged;
+  }
+
+  /**
+   * Builds a machine-readable JSON convergence report for the last model run.
+   *
+   * <p>
+   * This is the structured counterpart to {@link #getConvergenceSummary()}, intended for agentic
+   * workflows that need to parse the convergence outcome rather than read a formatted string. The
+   * report is schema-versioned and includes the per-area solved status and the names of any unsolved
+   * units, so an agent can pinpoint where a large multi-area model failed to converge.
+   * </p>
+   *
+   * <p>
+   * Top-level fields: {@code schemaVersion}, {@code converged}, {@code iterations},
+   * {@code maxIterations}, {@code boundaryStreamCount}, {@code boundaryValuesConverged},
+   * {@code allProcessesSolved}, {@code maxError}, an {@code errors} object (flow/temperature/pressure
+   * value, tolerance and converged flag) and an {@code areas} array (one object per process area
+   * with {@code name}, {@code solved} and {@code unsolvedUnits}).
+   * </p>
+   *
+   * @return a JSON string describing the convergence outcome of the last run
+   */
+  public String getConvergenceReportJson() {
+    JsonObject root = new JsonObject();
+    root.addProperty("schemaVersion", "1.0");
+    root.addProperty("converged", modelConverged);
+    root.addProperty("iterations", lastIterationCount);
+    root.addProperty("maxIterations", maxIterations);
+    root.addProperty("boundaryStreamCount", lastBoundaryStreamCount);
+    root.addProperty("boundaryValuesConverged", lastBoundaryValuesConverged);
+    root.addProperty("allProcessesSolved", lastAllProcessesSolved);
+    root.addProperty("maxError", getError());
+
+    JsonObject errors = new JsonObject();
+    errors.add("flow", buildErrorEntry(lastMaxFlowError, flowTolerance));
+    errors.add("temperature", buildErrorEntry(lastMaxTemperatureError, temperatureTolerance));
+    errors.add("pressure", buildErrorEntry(lastMaxPressureError, pressureTolerance));
+    root.add("errors", errors);
+
+    JsonArray areas = new JsonArray();
+    for (Map.Entry<String, ProcessSystem> entry : processes.entrySet()) {
+      JsonObject area = new JsonObject();
+      area.addProperty("name", entry.getKey());
+      boolean processSolved = entry.getValue().solved();
+      area.addProperty("solved", processSolved);
+      JsonArray unsolved = new JsonArray();
+      if (!processSolved) {
+        for (String unitName : getUnsolvedUnitNames(entry.getValue())) {
+          unsolved.add(unitName);
+        }
+      }
+      area.add("unsolvedUnits", unsolved);
+      areas.add(area);
+    }
+    root.add("areas", areas);
+    return root.toString();
+  }
+
+  /**
+   * Builds a single error entry for {@link #getConvergenceReportJson()}.
+   *
+   * @param error the relative error value for the variable
+   * @param tolerance the convergence tolerance for the variable
+   * @return a JSON object with {@code value}, {@code tolerance} and {@code converged} fields
+   */
+  private JsonObject buildErrorEntry(double error, double tolerance) {
+    JsonObject entry = new JsonObject();
+    entry.addProperty("value", error);
+    entry.addProperty("tolerance", tolerance);
+    entry.addProperty("converged", error < tolerance);
+    return entry;
+  }
+
+  /**
    * Gets names of unit operations that currently report unsolved status.
    *
    * @param process process system to inspect

--- a/src/test/java/neqsim/process/processmodel/ProcessModelRunUntilConvergedTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessModelRunUntilConvergedTest.java
@@ -1,0 +1,134 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests for {@link ProcessModel#runUntilConverged(int, double)} and
+ * {@link ProcessModel#getConvergenceReportJson()}.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+class ProcessModelRunUntilConvergedTest {
+
+  /**
+   * Creates a small single-component gas fluid.
+   *
+   * @return configured gas fluid
+   */
+  private static SystemInterface createGasFluid() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  /**
+   * Builds a simple two-area model: an upstream area with a separator feeding a downstream area.
+   *
+   * @return a runnable two-area ProcessModel
+   */
+  private static ProcessModel buildTwoAreaModel() {
+    Stream feed = new Stream("feed", createGasFluid());
+    feed.setFlowRate(1000.0, "kg/hr");
+    feed.setTemperature(25.0, "C");
+    feed.setPressure(50.0, "bara");
+    Separator separator = new Separator("separator", feed);
+
+    ProcessSystem upstream = new ProcessSystem("upstream");
+    upstream.add(feed);
+    upstream.add(separator);
+
+    StreamInterface gasOut = separator.getGasOutStream();
+    Separator downstreamSep = new Separator("downstream separator", gasOut);
+    ProcessSystem downstream = new ProcessSystem("downstream");
+    downstream.add(gasOut);
+    downstream.add(downstreamSep);
+
+    ProcessModel model = new ProcessModel();
+    model.add("upstream", upstream);
+    model.add("downstream", downstream);
+    return model;
+  }
+
+  /**
+   * runUntilConverged should run in iterating mode and report convergence for a simple model.
+   */
+  @Test
+  void testRunUntilConvergedConverges() {
+    ProcessModel model = buildTwoAreaModel();
+    boolean converged = model.runUntilConverged(25, 1e-4);
+
+    assertTrue(converged, "Simple feed-forward model should converge");
+    assertTrue(model.isModelConverged(), "isModelConverged should agree with the return value");
+    assertFalse(model.isRunStep(), "runUntilConverged must force iterating mode");
+    assertTrue(model.getLastIterationCount() >= 1, "At least one iteration should run");
+    assertEquals(25, model.getMaxIterations(), "maxIterations should be applied");
+  }
+
+  /**
+   * The JSON convergence report should be parseable and describe each area.
+   */
+  @Test
+  void testConvergenceReportJson() {
+    ProcessModel model = buildTwoAreaModel();
+    model.runUntilConverged(25, 1e-4);
+
+    String json = model.getConvergenceReportJson();
+    JsonObject report = JsonParser.parseString(json).getAsJsonObject();
+
+    assertEquals("1.0", report.get("schemaVersion").getAsString());
+    assertTrue(report.get("converged").getAsBoolean(), "Report should show converged");
+    assertTrue(report.has("errors"), "Report should include an errors block");
+    assertTrue(report.getAsJsonObject("errors").getAsJsonObject("flow").has("tolerance"));
+
+    JsonArray areas = report.getAsJsonArray("areas");
+    assertEquals(2, areas.size(), "Both process areas should be reported");
+    JsonObject firstArea = areas.get(0).getAsJsonObject();
+    assertTrue(firstArea.has("name"));
+    assertTrue(firstArea.has("solved"));
+    assertTrue(firstArea.has("unsolvedUnits"));
+  }
+
+  /**
+   * Invalid arguments should be rejected before running.
+   */
+  @Test
+  void testRunUntilConvergedValidatesArguments() {
+    ProcessModel model = buildTwoAreaModel();
+    assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+      /** {@inheritDoc} */
+      @Override
+      public void execute() {
+        model.runUntilConverged(0, 1e-4);
+      }
+    });
+    assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+      /** {@inheritDoc} */
+      @Override
+      public void execute() {
+        model.runUntilConverged(10, -1.0);
+      }
+    });
+    assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+      /** {@inheritDoc} */
+      @Override
+      public void execute() {
+        model.runUntilConverged(10, Double.NaN);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Adds two agent-friendly methods to `ProcessModel` for big multi-area models:

- `runUntilConverged(int maxIterations, double tolerance)` — explicit, self-documenting convenience wrapper that forces iterating mode (`runStep=false`), applies the iteration limit and tolerance, runs, and returns the converged flag. Replaces the boilerplate of `setRunStep(false)` + `setMaxIterations()` + `setTolerance()` + a hand-rolled outer loop. Validates its arguments.
- `getConvergenceReportJson()` — machine-readable counterpart to the existing `getConvergenceSummary()` string. Schema-versioned (`schemaVersion=1.0`) JSON with `converged`, `iterations`, `maxIterations`, boundary-stream stats, an `errors` block (flow/temperature/pressure value + tolerance + converged flag) and an `areas` array listing each process area's solved status and any unsolved unit names.

### Motivation
From an agentic study on a large topside model: `ProcessModel.run()` already auto-iterates to convergence, but agents had to remember the configuration sequence and could only read a human-formatted summary string. These additions make the convergence loop callable in one line and the outcome machine-parseable, so an agent can pinpoint which area/unit failed to converge.

### Tests
`ProcessModelRunUntilConvergedTest` (3 tests, all passing):
- two-area model converges and reports iterating mode + iteration count
- JSON report parses and lists both areas with `name`/`solved`/`unsolvedUnits`
- invalid arguments (maxIter<1, negative/NaN tolerance) throw `IllegalArgumentException`

Java 8 compatible. No change to the existing `run()` convergence behavior.
