### PR TITLE
feat(oilquality): RvpMethod enum + structured RvpResult for ASTM D6377

### DIFF
--- a/docs/standards/astm_d6377_rvp.md
+++ b/docs/standards/astm_d6377_rvp.md
@@ -88,6 +88,71 @@ Standard_ASTM_D6377 rvpStandard = new Standard_ASTM_D6377(thermoSystem);
 | `setMethodRVP(method)` | Select RVP calculation method |
 | `getMethodRVP()` | Get current method |
 
+### Type-Safe Method Selection and Structured Result
+
+In addition to the legacy string-based API, an `RvpMethod` enum and an immutable `RvpResult`
+are available for type-safe selection and robust result handling. The enum and the string
+labels are interchangeable — each constant carries its legacy label.
+
+```java
+import neqsim.standards.oilquality.Standard_ASTM_D6377;
+import neqsim.standards.oilquality.Standard_ASTM_D6377.RvpMethod;
+import neqsim.standards.oilquality.Standard_ASTM_D6377.RvpResult;
+
+Standard_ASTM_D6377 rvp = new Standard_ASTM_D6377(crude);
+
+// Type-safe method selection (equivalent to setMethodRVP("VPCR4"))
+rvp.setMethodRVP(RvpMethod.VPCR4);
+rvp.calculate();
+
+// Structured result for the current method
+RvpResult result = rvp.getRvpResult();
+if (result.isValid()) {
+  System.out.printf("RVP = %.4f bara (%s)%n",
+      result.getValue(), result.getMethod().getLabel());
+}
+
+// Or request a specific method directly
+RvpResult d6377 = rvp.getRvpResult(RvpMethod.RVP_ASTM_D6377);
+```
+
+#### RvpMethod constants
+
+| Constant | Legacy label | Description |
+|----------|--------------|-------------|
+| `RVP_ASTM_D6377` | `RVP_ASTM_D6377` | ASTM D6377 RVPE (RVP equivalent), derived from VPCR4 |
+| `RVP_ASTM_D323_73_79` | `RVP_ASTM_D323_73_79` | ASTM D323-73/79 dry method (water removed before flash) |
+| `RVP_ASTM_D323_82` | `RVP_ASTM_D323_82` | ASTM D323-82 correlation |
+| `VPCR4` | `VPCR4` | Vapor pressure at V/L = 4 (default) |
+| `VPCR4_NO_WATER` | `VPCR4_no_water` | VPCR4 with water removed |
+
+`RvpMethod.fromLabel(label)` resolves a constant from either its legacy string label or its
+enum name, throwing `IllegalArgumentException` for an unknown label.
+
+#### RvpResult fields
+
+`RvpResult` bundles the computed value with its context so callers — especially agentic
+workflows — can detect a failed calculation instead of silently receiving `0` or `NaN`.
+A result is **valid** only when its value is a finite positive number.
+
+| Method | Description |
+|--------|-------------|
+| `getValue()` | Computed RVP value in bara |
+| `getMethod()` | The `RvpMethod` used |
+| `getReferenceTemperatureC()` | Reference temperature in °C |
+| `isValid()` | True if the value is finite and positive |
+| `toJson()` | JSON representation (`value`, `unit`, `method`, `referenceTemperatureC`, `valid`) |
+
+```json
+{
+  "value": 0.4521,
+  "unit": "bara",
+  "method": "VPCR4",
+  "referenceTemperatureC": 37.8,
+  "valid": true
+}
+```
+
 ---
 
 ## Usage Examples

--- a/src/main/java/neqsim/standards/oilquality/Standard_ASTM_D6377.java
+++ b/src/main/java/neqsim/standards/oilquality/Standard_ASTM_D6377.java
@@ -38,6 +38,162 @@ public class Standard_ASTM_D6377 extends neqsim.standards.Standard {
   private double RVP_ASTM_D323_82 = 0.0;
 
   /**
+   * Enumeration of the supported Reid Vapor Pressure (RVP) / vapor-pressure correlation methods.
+   *
+   * <p>
+   * Each constant carries the legacy string label used by the string-based
+   * {@link Standard_ASTM_D6377#setMethodRVP(String)} API so the two APIs stay interchangeable.
+   * </p>
+   *
+   * @author NeqSim
+   * @version 1.0
+   */
+  public enum RvpMethod {
+    /** ASTM D6377 RVPE (RVP equivalent), derived from VPCR4. */
+    RVP_ASTM_D6377("RVP_ASTM_D6377"),
+    /** ASTM D323-73/79 dry method (water removed before flash). */
+    RVP_ASTM_D323_73_79("RVP_ASTM_D323_73_79"),
+    /** ASTM D323-82 correlation. */
+    RVP_ASTM_D323_82("RVP_ASTM_D323_82"),
+    /** Vapor pressure at vapor/liquid ratio 4:1 (default). */
+    VPCR4("VPCR4"),
+    /** Vapor pressure at vapor/liquid ratio 4:1 with water removed. */
+    VPCR4_NO_WATER("VPCR4_no_water");
+
+    /** Legacy string label associated with this method. */
+    private final String label;
+
+    /**
+     * Creates a method constant with its legacy string label.
+     *
+     * @param label the legacy string label used by the string-based API
+     */
+    RvpMethod(String label) {
+      this.label = label;
+    }
+
+    /**
+     * Gets the legacy string label for this method.
+     *
+     * @return the legacy string label
+     */
+    public String getLabel() {
+      return label;
+    }
+
+    /**
+     * Resolves an {@link RvpMethod} from its legacy string label or enum name.
+     *
+     * @param label the legacy string label (for example {@code "VPCR4"}) or the enum constant name
+     * @return the matching {@link RvpMethod}
+     * @throws IllegalArgumentException if no method matches the supplied label
+     */
+    public static RvpMethod fromLabel(String label) {
+      if (label != null) {
+        for (RvpMethod method : values()) {
+          if (method.label.equals(label) || method.name().equals(label)) {
+            return method;
+          }
+        }
+      }
+      throw new IllegalArgumentException("Unknown RVP method: " + label);
+    }
+  }
+
+  /**
+   * Immutable structured result of an RVP calculation.
+   *
+   * <p>
+   * Bundles the computed value with the method, reference temperature and a validity flag so callers
+   * (especially agentic workflows) can detect a failed calculation instead of silently receiving a
+   * zero or {@link Double#NaN}. A result is considered valid when its value is a finite positive
+   * number.
+   * </p>
+   *
+   * @author NeqSim
+   * @version 1.0
+   */
+  public static final class RvpResult {
+    /** Computed RVP value in bara. */
+    private final double value;
+
+    /** Method used to compute the value. */
+    private final RvpMethod method;
+
+    /** Reference temperature in degrees Celsius. */
+    private final double referenceTemperatureC;
+
+    /** Whether the value is a finite positive number. */
+    private final boolean valid;
+
+    /**
+     * Creates an RVP result.
+     *
+     * @param value computed RVP value in bara
+     * @param method method used to compute the value
+     * @param referenceTemperatureC reference temperature in degrees Celsius
+     */
+    public RvpResult(double value, RvpMethod method, double referenceTemperatureC) {
+      this.value = value;
+      this.method = method;
+      this.referenceTemperatureC = referenceTemperatureC;
+      this.valid = !Double.isNaN(value) && !Double.isInfinite(value) && value > 0.0;
+    }
+
+    /**
+     * Gets the computed RVP value.
+     *
+     * @return the RVP value in bara
+     */
+    public double getValue() {
+      return value;
+    }
+
+    /**
+     * Gets the method used to compute the value.
+     *
+     * @return the RVP method
+     */
+    public RvpMethod getMethod() {
+      return method;
+    }
+
+    /**
+     * Gets the reference temperature.
+     *
+     * @return the reference temperature in degrees Celsius
+     */
+    public double getReferenceTemperatureC() {
+      return referenceTemperatureC;
+    }
+
+    /**
+     * Indicates whether the result represents a successful calculation.
+     *
+     * @return true if the value is a finite positive number, false otherwise
+     */
+    public boolean isValid() {
+      return valid;
+    }
+
+    /**
+     * Serializes this result to a compact JSON string.
+     *
+     * @return a JSON representation with {@code value}, {@code method}, {@code referenceTemperatureC}
+     *         and {@code valid} fields
+     */
+    public String toJson() {
+      com.google.gson.JsonObject root = new com.google.gson.JsonObject();
+      root.addProperty("value", value);
+      root.addProperty("unit", "bara");
+      root.addProperty("method", method.getLabel());
+      root.addProperty("referenceTemperatureC", referenceTemperatureC);
+      root.addProperty("valid", valid);
+      return root.toString();
+    }
+  }
+
+  /**
    * Gets the method used for measuring Reid Vapor Pressure (RVP).
    *
    * <p>
@@ -73,6 +229,76 @@ public class Standard_ASTM_D6377 extends neqsim.standards.Standard {
    */
   public void setMethodRVP(String methodRVP) {
     this.methodRVP = methodRVP;
+  }
+
+  /**
+   * Sets the method used for measuring Reid Vapor Pressure (RVP) using the type-safe enum.
+   *
+   * @param method the {@link RvpMethod} to use; must not be null
+   * @throws IllegalArgumentException if {@code method} is null
+   */
+  public void setMethodRVP(RvpMethod method) {
+    if (method == null) {
+      throw new IllegalArgumentException("RVP method must not be null");
+    }
+    this.methodRVP = method.getLabel();
+  }
+
+  /**
+   * Returns the RVP value (in bara) computed for the supplied method during the last
+   * {@link #calculate()} call.
+   *
+   * @param method the method whose value should be returned
+   * @return the RVP value in bara for the requested method
+   */
+  private double valueForMethod(RvpMethod method) {
+    switch (method) {
+      case RVP_ASTM_D6377:
+        return RVP_ASTM_D6377;
+      case RVP_ASTM_D323_73_79:
+        return RVP_ASTM_D323_73_79;
+      case RVP_ASTM_D323_82:
+        return RVP_ASTM_D323_82;
+      case VPCR4_NO_WATER:
+        return VPCR4_no_water;
+      case VPCR4:
+      default:
+        return VPCR4;
+    }
+  }
+
+  /**
+   * Returns a structured RVP result for the currently configured method.
+   *
+   * <p>
+   * Call {@link #calculate()} first. The returned {@link RvpResult} carries the value, the method,
+   * the reference temperature and a validity flag so a failed calculation (which historically left
+   * the value at zero) is detectable via {@link RvpResult#isValid()}.
+   * </p>
+   *
+   * @return the structured RVP result for the configured method
+   */
+  public RvpResult getRvpResult() {
+    return getRvpResult(RvpMethod.fromLabel(methodRVP));
+  }
+
+  /**
+   * Returns a structured RVP result for a specific method.
+   *
+   * <p>
+   * Call {@link #calculate()} first. All method values are populated by a single
+   * {@link #calculate()} call, so this does not trigger a recalculation.
+   * </p>
+   *
+   * @param method the method whose result should be returned; must not be null
+   * @return the structured RVP result for the requested method
+   * @throws IllegalArgumentException if {@code method} is null
+   */
+  public RvpResult getRvpResult(RvpMethod method) {
+    if (method == null) {
+      throw new IllegalArgumentException("RVP method must not be null");
+    }
+    return new RvpResult(valueForMethod(method), method, referenceTemperature);
   }
 
   /**

--- a/src/test/java/neqsim/standards/oilquality/Standard_ASTM_D6377Test.java
+++ b/src/test/java/neqsim/standards/oilquality/Standard_ASTM_D6377Test.java
@@ -139,4 +139,76 @@ public class Standard_ASTM_D6377Test {
     return waterFreeFluid.getPressure();
   }
 
+  @Test
+  void testRvpMethodEnumMatchesStringApi() {
+    SystemInterface testSystem = new SystemSrkEos(273.15 + 2.0, 1.0);
+    testSystem.addComponent("methane", 0.0006538);
+    testSystem.addComponent("ethane", 0.006538);
+    testSystem.addComponent("propane", 0.06538);
+    testSystem.addComponent("n-pentane", 0.1545);
+    testSystem.addComponent("nC10", 0.545);
+    testSystem.setMixingRule(2);
+    testSystem.init(0);
+
+    Standard_ASTM_D6377 standard = new Standard_ASTM_D6377(testSystem);
+    standard.setReferenceTemperature(37.8, "C");
+    standard.calculate();
+
+    // The enum setter and the legacy string setter must agree.
+    standard.setMethodRVP(Standard_ASTM_D6377.RvpMethod.RVP_ASTM_D6377);
+    double viaEnum = standard.getValue("RVP", "bara");
+    standard.setMethodRVP("RVP_ASTM_D6377");
+    double viaString = standard.getValue("RVP", "bara");
+    Assertions.assertEquals(viaString, viaEnum, 1e-9);
+
+    // fromLabel resolves both the legacy label and the enum name.
+    Assertions.assertEquals(Standard_ASTM_D6377.RvpMethod.VPCR4,
+        Standard_ASTM_D6377.RvpMethod.fromLabel("VPCR4"));
+    Assertions.assertEquals(Standard_ASTM_D6377.RvpMethod.VPCR4_NO_WATER,
+        Standard_ASTM_D6377.RvpMethod.fromLabel("VPCR4_no_water"));
+    Assertions.assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+      @Override
+      public void execute() {
+        Standard_ASTM_D6377.RvpMethod.fromLabel("not_a_method");
+      }
+    });
+  }
+
+  @Test
+  void testStructuredRvpResult() {
+    SystemInterface testSystem = new SystemSrkEos(273.15 + 2.0, 1.0);
+    testSystem.addComponent("methane", 0.0006538);
+    testSystem.addComponent("ethane", 0.006538);
+    testSystem.addComponent("propane", 0.06538);
+    testSystem.addComponent("n-pentane", 0.1545);
+    testSystem.addComponent("nC10", 0.545);
+    testSystem.setMixingRule(2);
+    testSystem.init(0);
+
+    Standard_ASTM_D6377 standard = new Standard_ASTM_D6377(testSystem);
+    standard.setReferenceTemperature(37.8, "C");
+    standard.setMethodRVP(Standard_ASTM_D6377.RvpMethod.VPCR4);
+    standard.calculate();
+
+    Standard_ASTM_D6377.RvpResult result = standard.getRvpResult();
+    Assertions.assertTrue(result.isValid(), "Result should be valid for a normal oil");
+    Assertions.assertEquals(Standard_ASTM_D6377.RvpMethod.VPCR4, result.getMethod());
+    Assertions.assertEquals(37.8, result.getReferenceTemperatureC(), 1e-9);
+    Assertions.assertEquals(standard.getValue("RVP", "bara"), result.getValue(), 1e-9);
+
+    // JSON serializes and carries the expected fields.
+    String json = result.toJson();
+    com.google.gson.JsonObject obj =
+        com.google.gson.JsonParser.parseString(json).getAsJsonObject();
+    Assertions.assertEquals("VPCR4", obj.get("method").getAsString());
+    Assertions.assertEquals("bara", obj.get("unit").getAsString());
+    Assertions.assertTrue(obj.get("valid").getAsBoolean());
+
+    // Specific-method overload returns each populated value without recalculating.
+    Standard_ASTM_D6377.RvpResult d6377 =
+        standard.getRvpResult(Standard_ASTM_D6377.RvpMethod.RVP_ASTM_D6377);
+    Assertions.assertEquals(Standard_ASTM_D6377.RvpMethod.RVP_ASTM_D6377, d6377.getMethod());
+  }
+
 }
+


### PR DESCRIPTION
## Summary
Replaces stringly-typed RVP method selection in `Standard_ASTM_D6377` with a type-safe enum and a structured result, while keeping the existing String API fully backward compatible.

- `RvpMethod` enum — `RVP_ASTM_D6377`, `RVP_ASTM_D323_73_79`, `RVP_ASTM_D323_82`, `VPCR4`, `VPCR4_NO_WATER`. Each constant carries the legacy string label (e.g. `"VPCR4_no_water"`); `fromLabel(...)` resolves either the legacy label or the enum name.
- `setMethodRVP(RvpMethod)` overload alongside the existing `setMethodRVP(String)`.
- `RvpResult` immutable value object — `value` (bara), `method`, `referenceTemperatureC`, `valid` flag and `toJson()`.
- `getRvpResult()` / `getRvpResult(RvpMethod)` — return the structured result for the configured or a specific method.

### Motivation
The class selected the RVP method via magic strings and `getValue("RVP")` could silently return `0.0`/`NaN` on a failed calculation. From an agentic study perspective this is a trap: there was no way to distinguish a real zero from a failure. `RvpResult.isValid()` makes failure detectable, and the enum removes the magic-string footgun. The legacy String API and all existing numerical results are unchanged.

### Tests
`Standard_ASTM_D6377Test` (7 tests total, all passing — 5 existing + 2 new):
- enum setter matches the legacy string setter; `fromLabel` resolves labels/names and rejects unknown values
- structured `RvpResult` carries value/method/refT/valid, equals `getValue("RVP","bara")`, and serializes to JSON

Java 8 compatible. No change to existing RVP/TVP numerical behavior.
