### PR TITLE
Fix RVP/VPCR4 calculation to use Peneloux volume correction

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TVfractionFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TVfractionFlash.java
@@ -33,6 +33,12 @@ public class TVfractionFlash extends Flash {
   private boolean reportedUncountableState = false;
   /** Flag indicating if the flash calculation converged successfully. */
   private boolean converged = false;
+  /**
+   * Whether the vapor volume fraction objective uses the Peneloux volume-corrected phase volumes.
+   * Enabled by default so vapor/liquid volume ratios (for example the ASTM D6377 VPCR4 4:1 ratio)
+   * reflect the corrected liquid density.
+   */
+  private boolean useVolumeCorrection = true;
 
   /**
    * <p>
@@ -46,6 +52,26 @@ public class TVfractionFlash extends Flash {
     this.system = system;
     this.tpFlash = new TPflash(system);
     this.Vfractionspec = Vfractionspec;
+  }
+
+  /**
+   * Returns whether the vapor volume fraction objective uses Peneloux volume-corrected phase
+   * volumes.
+   *
+   * @return true if volume correction is applied to the vapor fraction objective
+   */
+  public boolean isUseVolumeCorrection() {
+    return useVolumeCorrection;
+  }
+
+  /**
+   * Sets whether the vapor volume fraction objective uses Peneloux volume-corrected phase volumes.
+   *
+   * @param useVolumeCorrection true to apply volume correction (default), false to use raw EOS
+   *        volumes
+   */
+  public void setUseVolumeCorrection(boolean useVolumeCorrection) {
+    this.useVolumeCorrection = useVolumeCorrection;
   }
 
   /**
@@ -69,6 +95,14 @@ public class TVfractionFlash extends Flash {
    * @return a double
    */
   public double calcdQdV() {
+    if (useVolumeCorrection) {
+      // Use Peneloux volume-corrected phase volumes so the vapor/liquid volume ratio reflects the
+      // corrected liquid density (ASTM D6377 VPCR4 is defined on a real 4:1 vapor/liquid volume
+      // ratio).
+      system.initPhysicalProperties("density");
+      double dQ = system.getCorrectedVolumeFraction(0) - Vfractionspec;
+      return dQ;
+    }
     double dQ = system.getPhase(0).getVolume() / system.getVolume() - Vfractionspec;
     return dQ;
   }

--- a/src/test/java/neqsim/standards/oilquality/Standard_ASTM_D6377Test.java
+++ b/src/test/java/neqsim/standards/oilquality/Standard_ASTM_D6377Test.java
@@ -21,7 +21,7 @@ public class Standard_ASTM_D6377Test {
     Standard_ASTM_D6377 standard = new Standard_ASTM_D6377(testSystem);
     standard.setReferenceTemperature(37.8, "C");
     standard.calculate();
-    Assertions.assertEquals(1.10445689545, standard.getValue("RVP", "bara"), 1e-3);
+    Assertions.assertEquals(1.1574422523131047, standard.getValue("RVP", "bara"), 1e-3);
     Assertions.assertEquals(1.666298367, standard.getValue("TVP", "bara"), 1e-3);
   }
 
@@ -41,13 +41,13 @@ public class Standard_ASTM_D6377Test {
     standard.setMethodRVP("VPCR4");
     standard.setReferenceTemperature(37.8, "C");
     standard.calculate();
-    Assertions.assertEquals(3.61452722, standard.getValue("RVP", "bara"), 1e-3);
+    Assertions.assertEquals(3.8285556883808334, standard.getValue("RVP", "bara"), 1e-3);
     Assertions.assertEquals(7.867696779327479, standard.getValue("TVP", "bara"), 1e-3);
 
     standard.setMethodRVP("RVP_ASTM_D6377");
     standard.setReferenceTemperature(37.8, "C");
     standard.calculate();
-    Assertions.assertEquals(3.01451570813, standard.getValue("RVP", "bara"), 1e-3);
+    Assertions.assertEquals(3.1930154441, standard.getValue("RVP", "bara"), 1e-3);
     Assertions.assertEquals(7.867696779327479, standard.getValue("TVP", "bara"), 1e-3);
   }
 
@@ -65,15 +65,16 @@ public class Standard_ASTM_D6377Test {
     standard.setMethodRVP("VPCR4");
     standard.setReferenceTemperature(37.8, "C");
     standard.calculate();
-    Assertions.assertEquals(0.25505060, standard.getValue("RVP", "bara"), 1e-3);
+    Assertions.assertEquals(0.25830597077793843, standard.getValue("RVP", "bara"), 1e-3);
     Assertions.assertEquals(0.261765909821, standard.getValue("TVP", "bara"), 1e-3);
 
     standard.setMethodRVP("RVP_ASTM_D6377");
     standard.setReferenceTemperature(37.8, "C");
     standard.calculate();
-    Assertions.assertEquals(0.2127122042, standard.getValue("RVP", "bara"), 1e-3);
+    Assertions.assertEquals(0.2154271776, standard.getValue("RVP", "bara"), 1e-3);
     Assertions.assertEquals(0.2617659098, standard.getValue("TVP", "bara"), 1e-3);
   }
+
   @Test
   void testWaterFreeRvpUsesWaterFreeFluid() throws Exception {
     SystemInterface testSystem = createWaterBearingOil();
@@ -87,8 +88,8 @@ public class Standard_ASTM_D6377Test {
     double vpcr4NoWater = standard.getValue("RVP", "bara");
 
     Assertions.assertNotEquals(vpcr4WithWater, vpcr4NoWater, 1e-6);
-    Assertions.assertEquals(calculateIndependentWaterFreeVpcr4(createWaterBearingOil()), vpcr4NoWater,
-        1e-6);
+    Assertions.assertEquals(calculateIndependentWaterFreeVpcr4(createWaterBearingOil()),
+        vpcr4NoWater, 1e-6);
   }
 
   @Test
@@ -166,12 +167,13 @@ public class Standard_ASTM_D6377Test {
         Standard_ASTM_D6377.RvpMethod.fromLabel("VPCR4"));
     Assertions.assertEquals(Standard_ASTM_D6377.RvpMethod.VPCR4_NO_WATER,
         Standard_ASTM_D6377.RvpMethod.fromLabel("VPCR4_no_water"));
-    Assertions.assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
-      @Override
-      public void execute() {
-        Standard_ASTM_D6377.RvpMethod.fromLabel("not_a_method");
-      }
-    });
+    Assertions.assertThrows(IllegalArgumentException.class,
+        new org.junit.jupiter.api.function.Executable() {
+          @Override
+          public void execute() {
+            Standard_ASTM_D6377.RvpMethod.fromLabel("not_a_method");
+          }
+        });
   }
 
   @Test
@@ -198,8 +200,7 @@ public class Standard_ASTM_D6377Test {
 
     // JSON serializes and carries the expected fields.
     String json = result.toJson();
-    com.google.gson.JsonObject obj =
-        com.google.gson.JsonParser.parseString(json).getAsJsonObject();
+    com.google.gson.JsonObject obj = com.google.gson.JsonParser.parseString(json).getAsJsonObject();
     Assertions.assertEquals("VPCR4", obj.get("method").getAsString());
     Assertions.assertEquals("bara", obj.get("unit").getAsString());
     Assertions.assertTrue(obj.get("valid").getAsBoolean());


### PR DESCRIPTION
Fixes #2299 — "RVP calc does not use volume correction".

## Problem
The ASTM D6377 Reid Vapor Pressure value is **VPCR4**: the vapor pressure at a real 4:1 vapor/liquid **volume** ratio (80% vapor by volume) at 37.8 °C. The calculation drives `TVfractionFlash(0.8)`, but the flash objective computed the vapor volume fraction from the **raw EOS molar volumes**, ignoring the Peneloux volume translation:

```java
double dQ = system.getPhase(0).getVolume() / system.getVolume() - Vfractionspec; // uncorrected
```

Because volume correction substantially densifies the liquid phase, the 4:1 volume ratio — and therefore the reported RVP — was physically inconsistent with the corrected phase volumes.

## Fix
In `TVfractionFlash`:
- Added a `useVolumeCorrection` flag (default `true`, with getter/setter).
- `calcdQdV()` now evaluates the Peneloux volume‑corrected vapor fraction:

```java
system.initPhysicalProperties("density");
double dQ = system.getCorrectedVolumeFraction(0) - Vfractionspec;
```

- The analytic derivative `calcdQdVdP()` is left unchanged — the Peneloux shift is approximately pressure‑independent, so `dV/dP` is unaffected; it only influences the Newton convergence rate, not the converged solution.

`TVfractionFlash` is RVP-only in production (its sole caller is `Standard_ASTM_D6377`), so the change is well contained. `Stream.getRVP()` and downstream consumers inherit the corrected behavior automatically.

## Validation
- `EclipseFluidReadWriteTest#testGOWRVP` asserts that the **corrected** gas volume fraction equals **0.8** at the computed RVP pressure — this now passes, directly confirming the V/L volume ratio is physically correct.
- Updated the expected RVP/VPCR4 magnitudes in `Standard_ASTM_D6377Test` (they rise ~1–6% due to the denser corrected liquid). The dependent `RVP_ASTM_D6377` values (= 0.834 × VPCR4) were updated accordingly. **TVP values are unchanged**, since the bubble point is independent of volume correction.
- The offshore MPC integration test uses RVP relatively (baseline × 1.02 as the constraint), so it is unaffected.

## Notes
- Java 8 compatible; full JavaDoc added for the new flag/accessors.
- No public API removed; the new flag defaults to the corrected (physically correct) behavior.