### PR TITLE
Avoid nested format placeholder in onboard fallback

### DIFF
--- a/devtools/onboard.py
+++ b/devtools/onboard.py
@@ -441,7 +441,7 @@ except Exception as e:
             "ops.TPflash();"
             "fluid.initProperties();"
             "density = fluid.getDensity('kg/m3');"
-            "print('SUCCESS density={d:.2f} kg/m3'.format(d=density))"
+            "print('SUCCESS density=' + format(density, '.2f') + ' kg/m3')"
         ).format(
             devtools_path=os.path.join(PROJECT_ROOT, "devtools"),
             project_root=PROJECT_ROOT,

--- a/devtools/test_onboard.py
+++ b/devtools/test_onboard.py
@@ -1,0 +1,29 @@
+"""Regression tests for the onboarding wizard."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import onboard
+
+
+def test_step_verify_fallback_script_does_not_format_inner_density_placeholder(monkeypatch):
+    """Fallback script generation should not crash before _run_cmd executes it."""
+    calls = []
+
+    def fake_run_cmd(cmd, cwd=None, timeout=300):
+        calls.append(cmd)
+        if cmd[:3] == [sys.executable, "-c", "import neqsim"]:
+            return False, "", "No Java runtime"
+        if len(cmd) >= 3 and cmd[0] == sys.executable and cmd[1] == "-c":
+            return False, "", "No Java runtime"
+        return False, "", "unexpected command"
+
+    monkeypatch.setattr(onboard, "_run_cmd", fake_run_cmd)
+
+    ok = onboard.step_verify(check_only=False)
+
+    assert not ok
+    assert len(calls) == 2
+    assert "SUCCESS density=" in calls[1][2]
+    assert "{d:.2f}" not in calls[1][2]


### PR DESCRIPTION
Onboarding crashes when java is not in path. 

## Before fix

```console
neqsim git:(master) neqsim onboard

============================================================
  NeqSim Onboarding Wizard
============================================================

  This wizard will set up your NeqSim development environment.
  It checks prerequisites, builds the project, and verifies
  everything works — including the agentic AI system.

  You can skip any step or quit at any time.

  Project root: /Users/FCUR/git/neqsim
  Ready to start? [Enter=yes, s=skip, q=quit] yes

--- Step 1: Java ---
  [!!] Java not found on PATH.

  To fix:
    1. Install JDK 8 or later (e.g., Adoptium Temurin, Oracle JDK)
    2. Add the JDK bin/ directory to your PATH
    3. Verify: java -version

  Download: https://adoptium.net/

--- Step 2: Maven Wrapper ---
  [OK] Maven wrapper found: mvnw
  [..] Testing Maven wrapper...
  [!!] Maven wrapper failed to run.
  Error: The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.

--- Step 3: Build NeqSim JAR ---
  [..] Building NeqSim (this takes 1-3 minutes)...
  [..] Running: mvnw package -DskipTests

  [!!] Build failed (exit code 1)
  Last output:
    The operation couldn’t be completed. Unable to locate a Java Runtime.
    Please visit http://www.java.com for information on installing Java.
    

--- Step 4: Python neqsim Package ---
  [..] Local dev runtime check output: Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys;sys.path.insert(0, '/Users/FCUR/git/neqsim/devtools');from neqsim_dev_setup import neqsim_init, neqsim_classes;
  [!!] Python neqsim package not installed.

  To fix:
    pip install neqsim
    or run from the repo with devtools/neqsim_dev_setup.py available

  Install neqsim now? [Enter=yes, s=skip, q=quit] yes
  [..] Running: pip install neqsim
  [OK] neqsim installed successfully!

--- Step 5: Developer Tools ---
  [OK] devtools package installed (neqsim_dev_setup)
  [OK] Found: devtools/new_task.py
  [OK] Found: devtools/new_skill.py
  [OK] Found: devtools/neqsim_doctor.py

--- Step 6: Agent System ---
  [OK] 31 agents found in .github/agents/
  [OK] 48 skills found in .github/skills/
  [OK] Codex / Claude Code / generic: AGENTS.md
  [OK] Claude Code: CLAUDE.md
  [OK] Cursor: .cursorrules
  [OK] Windsurf: .windsurfrules
  [OK] VS Code Copilot: .github/copilot-instructions.md

--- Step 7: Quick Verification ---
  [..] Running a quick NeqSim simulation via Python...
Traceback (most recent call last):
  File "/Users/FCUR/git/neqsim/.venv/bin/neqsim", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/FCUR/git/neqsim/devtools/neqsim_cli.py", line 121, in main
    mod.main()
    ~~~~~~~~^^
  File "/Users/FCUR/git/neqsim/devtools/onboard.py", line 527, in main
    results.append(step_verify(check_only))
                   ~~~~~~~~~~~^^^^^^^^^^^^
  File "/Users/FCUR/git/neqsim/devtools/onboard.py", line 445, in step_verify
    ).format(
      ~~~~~~^
        devtools_path=os.path.join(PROJECT_ROOT, "devtools"),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        project_root=PROJECT_ROOT,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
KeyError: 'd'
```

## After fix

```console
neqsim git:(onboarding-without-java) neqsim onboard

============================================================
  NeqSim Onboarding Wizard
============================================================

  This wizard will set up your NeqSim development environment.
  It checks prerequisites, builds the project, and verifies
  everything works — including the agentic AI system.

  You can skip any step or quit at any time.

  Project root: /Users/FCUR/git/neqsim
  Ready to start? [Enter=yes, s=skip, q=quit] yes

--- Step 1: Java ---
  [!!] Java not found on PATH.

  To fix:
    1. Install JDK 8 or later (e.g., Adoptium Temurin, Oracle JDK)
    2. Add the JDK bin/ directory to your PATH
    3. Verify: java -version

  Download: https://adoptium.net/

--- Step 2: Maven Wrapper ---
  [OK] Maven wrapper found: mvnw
  [..] Testing Maven wrapper...
  [!!] Maven wrapper failed to run.
  Error: The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.

--- Step 3: Build NeqSim JAR ---
  [..] Building NeqSim (this takes 1-3 minutes)...
  [..] Running: mvnw package -DskipTests

  [!!] Build failed (exit code 1)
  Last output:
    The operation couldn’t be completed. Unable to locate a Java Runtime.
    Please visit http://www.java.com for information on installing Java.
    

--- Step 4: Python neqsim Package ---
  [..] Local dev runtime check output: Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys;sys.path.insert(0, '/Users/FCUR/git/neqsim/devtools');from neqsim_dev_setup import neqsim_init, neqsim_classes;
  [!!] Python neqsim package not installed.

  To fix:
    pip install neqsim
    or run from the repo with devtools/neqsim_dev_setup.py available

  Install neqsim now? [Enter=yes, s=skip, q=quit] yes
  [..] Running: pip install neqsim
  [OK] neqsim installed successfully!

--- Step 5: Developer Tools ---
  [OK] devtools package installed (neqsim_dev_setup)
  [OK] Found: devtools/new_task.py
  [OK] Found: devtools/new_skill.py
  [OK] Found: devtools/neqsim_doctor.py

--- Step 6: Agent System ---
  [OK] 31 agents found in .github/agents/
  [OK] 48 skills found in .github/skills/
  [OK] Codex / Claude Code / generic: AGENTS.md
  [OK] Claude Code: CLAUDE.md
  [OK] Cursor: .cursorrules
  [OK] Windsurf: .windsurfrules
  [OK] VS Code Copilot: .github/copilot-instructions.md

--- Step 7: Quick Verification ---
  [..] Running a quick NeqSim simulation via Python...
  [!!] Simulation test failed.
  stdout: Compiling... FAILED

The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.
  stderr: Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys;sys.path.insert(0, '/Users/FCUR/git/neqsim/devtools');from neqsim_dev_setup import neqsim_init, neqsim_classes;ns = neqsim_init(project_root='/Users/FCUR/git/neqsim', recompile=False, verbose=False);ns = neqsim_

  Common fixes:
  - Rebuild JAR and copy to Python package
  - Check Java is on PATH
  - Try: pip install --upgrade neqsim

============================================================
  Onboarding Complete
============================================================

  3/7 steps passed.

  Some steps had issues — see the [!!] items above.
  Fix them and run this wizard again, or use:
    neqsim doctor
  for a detailed diagnostic.
 ```

# Pull Request

Thank you for contributing to NeqSim! Please complete the following checklist before requesting review:

- [ ] Confirm `./mvnw test` runs successfully
- [ ] Verify code formatting using Checkstyle
- [ ] Update any relevant docs/README
- [ ] Link to an associated issue or discussion

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution process.
