### PR TITLE
characterizeToReference: add inheritReferenceProperties option (Pedersen Ch. 5.6 common slate)

### DIFF
--- a/src/main/java/neqsim/thermo/characterization/CharacterizationOptions.java
+++ b/src/main/java/neqsim/thermo/characterization/CharacterizationOptions.java
@@ -44,6 +44,7 @@ public class CharacterizationOptions {
   private final NamingScheme namingScheme;
   private final boolean generateValidationReport;
   private final double compositionTolerance;
+  private final boolean inheritReferenceProperties;
 
   private CharacterizationOptions(Builder builder) {
     this.transferBinaryInteractionParameters = builder.transferBinaryInteractionParameters;
@@ -51,6 +52,7 @@ public class CharacterizationOptions {
     this.namingScheme = builder.namingScheme;
     this.generateValidationReport = builder.generateValidationReport;
     this.compositionTolerance = builder.compositionTolerance;
+    this.inheritReferenceProperties = builder.inheritReferenceProperties;
   }
 
   /**
@@ -99,6 +101,28 @@ public class CharacterizationOptions {
   }
 
   /**
+   * Whether the characterized fluid should inherit the reference fluid's pseudo-component
+   * properties (molar mass, density, critical constants, etc.).
+   *
+   * <p>
+   * When {@code true} (the default), the characterized fluid reproduces the Pedersen et al.
+   * (Chapter 5.6) "Common EoS" slate: every fluid characterized to the same reference shares an
+   * identical set of pseudo-component properties and differs only in the mole fractions. This is
+   * required when several fluids must be mixed or compared on a common equation-of-state basis.
+   *
+   * <p>
+   * When {@code false}, the characterized fluid keeps the grid-only behaviour of the bare
+   * {@link PseudoComponentCombiner#characterizeToReference(neqsim.thermo.system.SystemInterface,
+   * neqsim.thermo.system.SystemInterface)} method: only the reference cut boundaries are reused and
+   * the lump properties are recomputed from the source fluid's mass.
+   *
+   * @return true if reference pseudo-component properties should be inherited
+   */
+  public boolean isInheritReferenceProperties() {
+    return inheritReferenceProperties;
+  }
+
+  /**
    * Creates a new builder with default options.
    *
    * @return a new builder instance
@@ -134,6 +158,7 @@ public class CharacterizationOptions {
     private NamingScheme namingScheme = NamingScheme.REFERENCE;
     private boolean generateValidationReport = false;
     private double compositionTolerance = 1e-10;
+    private boolean inheritReferenceProperties = true;
 
     /**
      * Set whether to transfer binary interaction parameters from the reference fluid.
@@ -199,6 +224,24 @@ public class CharacterizationOptions {
      */
     public Builder compositionTolerance(double tolerance) {
       this.compositionTolerance = tolerance;
+      return this;
+    }
+
+    /**
+     * Set whether the characterized fluid should inherit the reference fluid's pseudo-component
+     * properties (molar mass, density, critical constants, etc.).
+     *
+     * <p>
+     * Enabled by default to reproduce the Pedersen et al. (Chapter 5.6) "Common EoS" slate, in
+     * which every fluid characterized to the same reference shares an identical set of
+     * pseudo-component properties and differs only in the mole fractions. Set to {@code false} to
+     * keep the grid-only behaviour where lump properties are recomputed from the source fluid.
+     *
+     * @param inherit true to inherit reference pseudo-component properties
+     * @return this builder
+     */
+    public Builder inheritReferenceProperties(boolean inherit) {
+      this.inheritReferenceProperties = inherit;
       return this;
     }
 

--- a/src/main/java/neqsim/thermo/characterization/PseudoComponentCombiner.java
+++ b/src/main/java/neqsim/thermo/characterization/PseudoComponentCombiner.java
@@ -162,6 +162,27 @@ public final class PseudoComponentCombiner {
    * @return characterized fluid containing pseudo components compatible with the reference fluid
    */
   public static SystemInterface characterizeToReference(SystemInterface source, SystemInterface reference) {
+    return characterizeToReferenceCore(source, reference, false);
+  }
+
+  /**
+   * Core implementation of {@link #characterizeToReference(SystemInterface, SystemInterface)}.
+   *
+   * <p>
+   * When {@code inheritReferenceProperties} is {@code true} the characterized pseudo-components
+   * inherit the reference fluid's lump properties (molar mass, density, critical constants, etc.),
+   * reproducing the Pedersen et al. (Chapter 5.6) "Common EoS" slate: every fluid characterized to
+   * the same reference shares an identical pseudo-component property set and differs only in the
+   * mole fractions. When {@code false} the lump properties are recomputed from the source fluid's
+   * mass (grid-only behaviour using the reference cut boundaries).
+   *
+   * @param source                     fluid to characterize
+   * @param reference                  fluid defining the pseudo component characterization
+   * @param inheritReferenceProperties whether to inherit the reference lump properties
+   * @return characterized fluid containing pseudo components compatible with the reference fluid
+   */
+  private static SystemInterface characterizeToReferenceCore(SystemInterface source, SystemInterface reference,
+      boolean inheritReferenceProperties) {
     Objects.requireNonNull(source, "source");
     Objects.requireNonNull(reference, "reference");
 
@@ -191,8 +212,11 @@ public final class PseudoComponentCombiner {
       }
 
       String referenceName = referenceExtraction.pseudoComponents.get(i).name;
+      PseudoComponentContribution referencePc = referenceExtraction.pseudoComponents.get(i);
       String baseName = stripPcSuffix(referenceName);
-      characterized.addTBPfraction(baseName, profile.getMoles(), profile.getMolarMass(), profile.getDensity());
+      double molarMass = inheritReferenceProperties ? referencePc.molarMass : profile.getMolarMass();
+      double density = inheritReferenceProperties ? referencePc.density : profile.getDensity();
+      characterized.addTBPfraction(baseName, profile.getMoles(), molarMass, density);
 
       ComponentInterface component = characterized.getComponent(baseName + "_PC");
       if (component == null) {
@@ -200,7 +224,11 @@ public final class PseudoComponentCombiner {
 	continue;
       }
 
-      profile.applyTo(component);
+      if (inheritReferenceProperties) {
+	applyReferenceProperties(component, referencePc);
+      } else {
+	profile.applyTo(component);
+      }
     }
 
     finalizeFluid(characterized);
@@ -222,7 +250,8 @@ public final class PseudoComponentCombiner {
       CharacterizationOptions options) {
     Objects.requireNonNull(options, "options");
 
-    SystemInterface characterized = characterizeToReference(source, reference);
+    SystemInterface characterized =
+        characterizeToReferenceCore(source, reference, options.isInheritReferenceProperties());
 
     if (options.isTransferBinaryInteractionParameters()) {
       transferBinaryInteractionParameters(reference, characterized);
@@ -239,6 +268,75 @@ public final class PseudoComponentCombiner {
     }
 
     return characterized;
+  }
+
+  /**
+   * Copy the reference pseudo-component's properties onto a newly characterized component.
+   *
+   * <p>
+   * Used by the Pedersen et al. (Chapter 5.6) "Common EoS" slate path so that fluids characterized
+   * to the same reference share an identical pseudo-component property set. Each property is applied
+   * only when the reference value is finite, leaving NeqSim's correlated default in place otherwise.
+   *
+   * @param component the characterized component to update
+   * @param reference the reference pseudo-component contribution to inherit from
+   */
+  private static void applyReferenceProperties(ComponentInterface component,
+      PseudoComponentContribution reference) {
+    Objects.requireNonNull(component, "component");
+    Objects.requireNonNull(reference, "reference");
+
+    if (Double.isFinite(reference.normalBoilingPoint)) {
+      component.setNormalBoilingPoint(reference.normalBoilingPoint);
+    }
+    if (Double.isFinite(reference.criticalTemperature)) {
+      component.setTC(reference.criticalTemperature);
+    }
+    if (Double.isFinite(reference.criticalPressure)) {
+      component.setPC(reference.criticalPressure);
+    }
+    if (Double.isFinite(reference.acentricFactor)) {
+      component.setAcentricFactor(reference.acentricFactor);
+    }
+    if (Double.isFinite(reference.criticalVolume)) {
+      component.setCriticalVolume(reference.criticalVolume);
+    }
+    if (Double.isFinite(reference.racketZ)) {
+      component.setRacketZ(reference.racketZ);
+    }
+    if (Double.isFinite(reference.racketZCpa)) {
+      component.setRacketZCPA(reference.racketZCpa);
+    }
+    if (Double.isFinite(reference.parachor)) {
+      component.setParachorParameter(reference.parachor);
+    }
+    if (Double.isFinite(reference.criticalViscosity)) {
+      component.setCriticalViscosity(reference.criticalViscosity);
+    }
+    if (Double.isFinite(reference.triplePointTemperature)) {
+      component.setTriplePointTemperature(reference.triplePointTemperature);
+    }
+    if (Double.isFinite(reference.heatOfFusion)) {
+      component.setHeatOfFusion(reference.heatOfFusion);
+    }
+    if (Double.isFinite(reference.idealGasEnthalpyOfFormation)) {
+      component.setIdealGasEnthalpyOfFormation(reference.idealGasEnthalpyOfFormation);
+    }
+    if (Double.isFinite(reference.cpA)) {
+      component.setCpA(reference.cpA);
+    }
+    if (Double.isFinite(reference.cpB)) {
+      component.setCpB(reference.cpB);
+    }
+    if (Double.isFinite(reference.cpC)) {
+      component.setCpC(reference.cpC);
+    }
+    if (Double.isFinite(reference.cpD)) {
+      component.setCpD(reference.cpD);
+    }
+    if (Double.isFinite(reference.attractiveM) && component.getAttractiveTerm() != null) {
+      component.getAttractiveTerm().setm(reference.attractiveM);
+    }
   }
 
   /**

--- a/src/test/java/neqsim/thermo/characterization/CharacterizeToReferenceCommonSlateTest.java
+++ b/src/test/java/neqsim/thermo/characterization/CharacterizeToReferenceCommonSlateTest.java
@@ -1,0 +1,122 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+
+/**
+ * Tests the Pedersen et al. (Chapter 5.6) "Common EoS" slate produced by
+ * {@link PseudoComponentCombiner#characterizeToReference(SystemInterface, SystemInterface,
+ * CharacterizationOptions)} when {@link CharacterizationOptions#isInheritReferenceProperties()} is
+ * enabled (the default).
+ *
+ * <p>
+ * Two different source fluids characterized to the same reference must end up with an identical set
+ * of pseudo-component properties (molar mass, critical constants, acentric factor) and may differ
+ * only in their mole fractions. The bare two-argument overload must remain grid-only for backward
+ * compatibility.
+ */
+class CharacterizeToReferenceCommonSlateTest {
+  private static final double TOLERANCE = 1e-6;
+
+  private static SystemInterface referenceFluid() {
+    SystemInterface fluid = new SystemPrEos(298.15, 60.0);
+    fluid.addComponent("methane", 0.6);
+
+    fluid.addTBPfraction("C7", 0.20, 0.090, 0.74);
+    ComponentInterface c7 = fluid.getComponent("C7_PC");
+    c7.setTC(530.0);
+    c7.setPC(29.0);
+    c7.setAcentricFactor(0.31);
+
+    fluid.addTBPfraction("C8", 0.12, 0.110, 0.76);
+    ComponentInterface c8 = fluid.getComponent("C8_PC");
+    c8.setTC(550.0);
+    c8.setPC(27.0);
+    c8.setAcentricFactor(0.33);
+
+    fluid.addTBPfraction("C9", 0.08, 0.150, 0.79);
+    ComponentInterface c9 = fluid.getComponent("C9_PC");
+    c9.setTC(570.0);
+    c9.setPC(25.0);
+    c9.setAcentricFactor(0.35);
+    return fluid;
+  }
+
+  private static SystemInterface source(double pcA, double pcB, double pcC, double tailMolarMass) {
+    SystemInterface fluid = new SystemPrEos(298.15, 60.0);
+    fluid.addComponent("methane", 0.5);
+    fluid.addTBPfraction("PCA", pcA, 0.085, 0.73);
+    fluid.addTBPfraction("PCB", pcB, 0.120, 0.77);
+    fluid.addTBPfraction("PCC", pcC, tailMolarMass, 0.80);
+    return fluid;
+  }
+
+  @Test
+  @DisplayName("inheritReferenceProperties defaults to true")
+  void testDefaultIsInheritReferenceProperties() {
+    assertTrue(CharacterizationOptions.builder().build().isInheritReferenceProperties());
+  }
+
+  @Test
+  @DisplayName("common slate: two sources share identical lump properties, only mole fractions differ")
+  void testCommonSlate() {
+    SystemInterface reference = referenceFluid();
+    CharacterizationOptions options = CharacterizationOptions.builder().build();
+
+    SystemInterface a =
+        PseudoComponentCombiner.characterizeToReference(source(0.05, 0.06, 0.07, 0.150), reference, options);
+    SystemInterface b =
+        PseudoComponentCombiner.characterizeToReference(source(0.10, 0.12, 0.15, 0.200), reference, options);
+
+    String[] lumps = {"C7_PC", "C8_PC", "C9_PC"};
+    double[] refTc = {530.0, 550.0, 570.0};
+    double[] refPc = {29.0, 27.0, 25.0};
+    double[] refOmega = {0.31, 0.33, 0.35};
+    double[] refMw = {0.090, 0.110, 0.150};
+
+    boolean someMoleFractionDiffers = false;
+    for (int i = 0; i < lumps.length; i++) {
+      ComponentInterface ca = a.getComponent(lumps[i]);
+      ComponentInterface cb = b.getComponent(lumps[i]);
+
+      // Lump properties are inherited from the reference and identical between the two sources.
+      assertEquals(refMw[i], ca.getMolarMass(), TOLERANCE, lumps[i] + " molar mass A");
+      assertEquals(ca.getMolarMass(), cb.getMolarMass(), TOLERANCE, lumps[i] + " molar mass A vs B");
+      assertEquals(refTc[i], ca.getTC(), TOLERANCE, lumps[i] + " Tc A");
+      assertEquals(ca.getTC(), cb.getTC(), TOLERANCE, lumps[i] + " Tc A vs B");
+      assertEquals(refPc[i], ca.getPC(), TOLERANCE, lumps[i] + " Pc A");
+      assertEquals(ca.getPC(), cb.getPC(), TOLERANCE, lumps[i] + " Pc A vs B");
+      assertEquals(refOmega[i], ca.getAcentricFactor(), TOLERANCE, lumps[i] + " omega A");
+      assertEquals(ca.getAcentricFactor(), cb.getAcentricFactor(), TOLERANCE, lumps[i] + " omega A vs B");
+
+      if (Math.abs(ca.getz() - cb.getz()) > 1e-4) {
+        someMoleFractionDiffers = true;
+      }
+    }
+    assertTrue(someMoleFractionDiffers, "mole fractions must differ between the two sources");
+  }
+
+  @Test
+  @DisplayName("bare two-arg overload stays grid-only (lump properties recomputed from source)")
+  void testTwoArgRemainsGridOnly() {
+    SystemInterface reference = referenceFluid();
+
+    SystemInterface a =
+        PseudoComponentCombiner.characterizeToReference(source(0.05, 0.06, 0.07, 0.150), reference);
+    SystemInterface b =
+        PseudoComponentCombiner.characterizeToReference(source(0.10, 0.12, 0.15, 0.200), reference);
+
+    // Grid-only: lump molar mass is recomputed from each source's mass, so the heaviest lump
+    // (which carries the differing tail) differs between the two sources and does not match the
+    // inherited reference molar mass.
+    double mwA = a.getComponent("C9_PC").getMolarMass();
+    double mwB = b.getComponent("C9_PC").getMolarMass();
+    assertFalse(Math.abs(mwA - mwB) < TOLERANCE, "grid-only C9_PC molar mass should differ between sources");
+  }
+}


### PR DESCRIPTION
Adds a `CharacterizationOptions.inheritReferenceProperties` flag (default **true**) to `PseudoComponentCombiner.characterizeToReference`.

## What & why

When several fluids are characterized to the same reference fluid they should end up on an **identical pseudo-component property slate** (MW, Tc, Pc, ω, density, …) and differ **only in mole fractions** — this is the Pedersen et al. *Chapter 5.6 "Common EoS"* slate, required when fluids are mixed or compared on a common equation-of-state basis.

Previously the 3-arg `characterizeToReference(source, reference, options)` only re-used the reference cut boundaries and recomputed lump properties from each source's mass (grid-only), so two different sources got **different** lump properties and could not be mixed consistently.

## Change

- `CharacterizationOptions`: new `inheritReferenceProperties` flag (builder default `true`) + getter.
- `PseudoComponentCombiner`: the bare 2-arg `characterizeToReference` stays **grid-only** (backward compatible); the 3-arg options overload now inherits the reference lump properties when the flag is set, via a new private `applyReferenceProperties` helper.
- New `CharacterizeToReferenceCommonSlateTest`: two different sources characterized to the same reference get **identical** lump MW/Tc/Pc/ω and differ only in z; the 2-arg path remains grid-only.

## Validation

- Compiles with Java 17 (matching current master target).
- Existing `PseudoComponentCombinerTest` and `CharacterizationOptionsTest` are unchanged and pass; new test passes (15/15 locally).
- Backward compatible: the only property-value assertions in the existing suite are on the 2-arg overload, which is unchanged.
