### PR TITLE
ci: fix duplicate/cancelled build runs on master

### DIFF
--- a/.github/workflows/verify_build.yml
+++ b/.github/workflows/verify_build.yml
@@ -11,17 +11,15 @@ on:
   push:
     branches:
       - master
-  workflow_run:
-    workflows:
-      - Pre-commit checks
-    types:
-      - completed
+  pull_request:
+    branches:
+      - master
 
 jobs:
   changes:
     name: Detect Java/XML changes
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request'
     outputs:
       run_tests: ${{ steps.filter.outputs.run_tests }}
     steps:
@@ -153,7 +151,7 @@ jobs:
   verify_agent_skills:
     name: Verify agent-skill cross-references
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Problem

Every push to `master` produced a red **cancelled** build check. On the merge commit, three competing copies of the `Run build, test and javadoc` jobs appeared (one `success`, one `cancelled`, one `skipped`).

## Root cause

`verify_build.yml` triggered on **both** `push: master` **and** `workflow_run` of *Pre-commit checks*. Because the repo rebase/squash-merges (the PR head SHA becomes the master SHA), a merge fired the build twice against the same commit:

1. via `workflow_run` (chained off the PR's *Pre-commit checks*), and
2. via `push` (the merge itself).

The `verify-build-${{ github.ref }}` concurrency group then cancelled one of the two runs, surfacing the red `cancelled` check.

## Fix

Replace the `workflow_run` trigger with a direct `pull_request: [master]` trigger:

- PRs get the build directly (requirable, no indirection).
- Master pushes still get the full build + coverage.
- No two runs target the same commit, so nothing gets cancelled.

The two job `if:` guards that gated on `github.event.workflow_run.conclusion` are updated to fire on `push`/`pull_request`. The checkout `ref:` expressions now resolve to `github.sha` (the `workflow_run` branch is dead but harmless, left out to keep the diff focused).

The required status check **Run pre-commit checks (PR)** comes from `precommit.yml` and is unaffected.
