### PR TITLE
docs: add Spotless formatting rule to java8-rules skill

### DIFF
--- a/.github/skills/neqsim-java8-rules/SKILL.md
+++ b/.github/skills/neqsim-java8-rules/SKILL.md
@@ -47,6 +47,23 @@ import org.apache.commons.lang3.StringUtils;
 // Usage: StringUtils.repeat("=", 70)
 ```
 
+## Code Formatting (Spotless) — MANDATORY
+
+AI-generated Java is NOT auto-formatted. After creating or editing ANY `.java`
+file, reformat it before committing — do not rely on local pre-commit hooks
+being installed:
+
+```bash
+./mvnw spotless:apply    # reformats Java to the project style (Eclipse profile)
+./mvnw spotless:check    # verifies formatting — this is what CI runs
+```
+
+- Formatter profile: `.config/neqsim_formatter.xml` (configured in `pom.xml`),
+  applied to `src/main/java` and `src/test/java`.
+- CI runs `./mvnw spotless:check` and FAILS the build on any unformatted file.
+- Run `spotless:apply`, then `git add` the reformatted files, then commit.
+- NEVER bypass the gate with `git commit --no-verify`.
+
 ## API Verification (MANDATORY)
 
 Before using any NeqSim class in code or examples:


### PR DESCRIPTION
## What

Adds a **Code Formatting (Spotless)** section to the `neqsim-java8-rules` skill.

## Why

AI-generated Java is **not** auto-formatted at generation time. It only gets reformatted automatically at commit time, and **only if** the developer/agent has the pre-commit hooks installed (`pre-commit install`). An agent that writes Java and commits directly — or in a sandbox without hooks — produces unformatted code and a PR that fails the CI `./mvnw spotless:check` gate.

`AGENTS.md` and `.github/copilot-instructions.md` already state this rule, but the `neqsim-java8-rules` skill — which is the file agents load whenever they write Java — did not mention formatting. This mirrors the rule there so it travels with the Java-writing guidance.

## Rule added

> After creating or editing any `.java` file, run `./mvnw spotless:apply` before committing. CI runs `./mvnw spotless:check` and fails on any unformatted file. Do not rely on local pre-commit hooks; never use `git commit --no-verify`.

## Scope

Docs/skill only — no code changes. `AGENTS.md` and `copilot-instructions.md` already carry this guidance and are unchanged.
