### PR TITLE
Bump NeqSim version to 3.15.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -87,7 +87,7 @@ git add <the reformatted files>
 - **Package and Update Python**: When the user says "package and update python" or similar, run these commands:
   ```powershell
   .\mvnw.cmd package -DskipTests
-   Copy-Item -Path "C:\Users\ESOL\Documents\GitHub\neqsim\target\neqsim-3.12.0.jar" -Destination "C:\Users\ESOL\AppData\Roaming\Python\Python312\site-packages\neqsim\lib\java11\" -Force
+   Copy-Item -Path "C:\Users\ESOL\Documents\GitHub\neqsim\target\neqsim-3.15.0.jar" -Destination "C:\Users\ESOL\AppData\Roaming\Python\Python312\site-packages\neqsim\lib\java11\" -Force
   ```
   This builds the NeqSim JAR and copies it to the Python neqsim package for immediate use.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
   - PVT
   - oil-and-gas
   - CCS
-version: "3.14.0"
+version: "3.15.0"
 date-released: "2026-06-15"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,7 @@ runs the full workflow including PR creation.
 
 Java library for thermodynamic fluid properties and process simulation.
 Developed at NTNU, maintained by Equinor. Apache-2.0 license.
-`com.equinor.neqsim:neqsim` version 3.12.0 — **must compile with Java 8**.
+`com.equinor.neqsim:neqsim` version 3.15.0 — **must compile with Java 8**.
 
 ## Repo Map
 
@@ -122,7 +122,7 @@ devtools/                Unified CLI (`neqsim` command), Jupyter dev setup, task
 
 # Package JAR + copy to Python
 .\mvnw.cmd package -DskipTests
-Copy-Item target\neqsim-3.12.0.jar C:\Users\ESOL\AppData\Roaming\Python\Python312\site-packages\neqsim\lib\java11\ -Force
+Copy-Item target\neqsim-3.15.0.jar C:\Users\ESOL\AppData\Roaming\Python\Python312\site-packages\neqsim\lib\java11\ -Force
 ```
 
 ## Code Patterns — Copy-Paste Starters

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See [neqsim-python](https://github.com/equinor/neqsim-python) for more details.
 <dependency>
   <groupId>com.equinor.neqsim</groupId>
   <artifactId>neqsim</artifactId>
-  <version>3.12.0</version>
+  <version>3.15.0</version>
 </dependency>
 ```
 
@@ -264,7 +264,7 @@ The agent creates a task folder, runs NeqSim simulations, validates results, and
 <dependency>
   <groupId>com.equinor.neqsim</groupId>
   <artifactId>neqsim</artifactId>
-  <version>3.12.0</version>
+  <version>3.15.0</version>
 </dependency>
 ```
 

--- a/neqsim-mcp-server/pom.xml
+++ b/neqsim-mcp-server/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.version>3.37.0</quarkus.version>
         <mcp-server.version>1.13.0</mcp-server.version>
         <!-- Keep in sync with ../pom.xml <revision> property until a parent/module build is used. -->
-        <revision>3.14.0</revision>
+        <revision>3.15.0</revision>
         <neqsim.version>${revision}</neqsim.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	</scm>
 
 	<properties>
-		<revision>3.14.0</revision>
+		<revision>3.15.0</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<checkstyle.config.location>.config/checkstyle_neqsim.xml</checkstyle.config.location>

--- a/pomJava8.xml
+++ b/pomJava8.xml
@@ -19,7 +19,7 @@
 	</scm>
 
 	<properties>
-		<revision>3.14.0</revision>
+		<revision>3.15.0</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<sha1 />


### PR DESCRIPTION
Bumps the NeqSim library version from 3.14.0 to 3.15.0 across all canonical version-reference files, including the MCP server module.

**Updated files:**
- pom.xml (revision)
- pomJava8.xml (revision)
- neqsim-mcp-server/pom.xml (revision; MCP server inherits neqsim via neqsim.version=revision)
- CITATION.cff (version)
- README.md (both Maven dependency snippets)
- CONTEXT.md (version note + JAR copy command)
- .github/copilot-instructions.md (JAR copy command)

Release workflows derive the version dynamically from project.version, so they pick up 3.15.0 automatically. Unrelated Maven plugin versions and Python language versions were intentionally left unchanged.