### PR TITLE
Add GPO-proof install.cmd, PATH auto-fix, and one-step private repo setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,9 +303,12 @@ neqsim agent install --all --vscode   # install into the VS Code prompts folder
 neqsim skill install --all        # install community skills
 
 neqsim agent private-init         # scaffold a private/enterprise catalog
+# ...or register a private repo AND sign in with browser SSO in one step:
+neqsim agent private-init --repo my-org/neqsim-enterprise-agents --login
+neqsim skill private-init --repo my-org/neqsim-enterprise-skills --login
 ```
 
-- **How internal (enterprise) content works:** a company publishes private `enterprise-agents.yaml` / `enterprise-skills.yaml` in governed internal repos. These are **never committed to the public NeqSim repos**; they are discovered per-user (via `~/.neqsim/private-*.yaml` and gh-CLI / Git Credential Manager auth). See [Enterprise Agent & Skill Repositories](docs/integration/enterprise_agent_skill_repos.md).
+- **How internal (enterprise) content works:** a company publishes private `enterprise-agents.yaml` / `enterprise-skills.yaml` in governed internal repos. These are **never committed to the public NeqSim repos**; they are discovered per-user (via `~/.neqsim/private-*.yaml` and gh-CLI / Git Credential Manager auth). `private-init` writes and then prints the path to those per-user files (`~/.neqsim/private-agents.yaml` / `private-skills.yaml`) so you can edit them afterwards. See [Enterprise Agent & Skill Repositories](docs/integration/enterprise_agent_skill_repos.md).
 - **Full details:** the [Skills & Agents Guide](docs/integration/skills_guide.md) explains the four tiers, packaging, canonical installs vs tool exports, and how to author your own.
 
 ### Where does a new skill or agent go? (recommendation for how to work)
@@ -545,9 +548,9 @@ neqsim onboard             # interactive setup (Java, Maven, build, Python, agen
 > install manually, use `python -m pip install -e devtools/` (not bare `pip`).
 >
 > **Windows: "install.ps1 is not digitally signed" error?** This is PowerShell's
-> execution policy, not a problem with the file. Run `.\install.cmd` (a wrapper
-> that bypasses the policy for one run), or use
-> `powershell -ExecutionPolicy Bypass -File .\install.ps1`.
+> execution policy, not a problem with the file. Run the pure-batch installer
+> `.\install.cmd` (calls Python/pip directly, works even when the policy is
+> locked by Group Policy), or just run `py -m pip install -e devtools/`.
 
 > **Tip:** Using a virtual environment (`python -m venv .venv` then activate it) avoids
 > PATH issues on all platforms. See [devtools/README.md](devtools/README.md#troubleshooting-neqsim-not-found)

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -131,6 +131,51 @@ target with `NEQSIM_VSCODE_FLAVOR=insiders` or point `NEQSIM_VSCODE_AGENTS_DIR`
 at the exact folder. macOS/Linux users run the same steps with `./install.sh`
 and forward slashes.
 
+## Set up private / enterprise agents & skills
+
+Public community agents/skills install with `neqsim agent install` /
+`neqsim skill install`. To also use **company-private** agents and skills, register
+your internal repository with `private-init`. It can register the repo **and**
+sign you in with browser SSO in a single command:
+
+```powershell
+# GitHub (registers the repo and runs `gh auth login --web`):
+neqsim agent private-init --repo my-org/neqsim-enterprise-agents --login
+neqsim skill private-init --repo my-org/neqsim-enterprise-skills --login
+
+# Internal Git server instead of GitHub:
+neqsim agent private-init --url https://git.internal.company.com/neqsim/enterprise-agents.git
+
+# Add more private repos later (same options; auto-creates the catalog if needed):
+neqsim agent add-repo --repo my-org/another-agents-repo --login
+neqsim skill add-repo --repo my-org/another-skills-repo --login
+
+# Then discover + install as usual:
+neqsim agent list --private
+neqsim agent install <name> --vscode
+neqsim skill install <name> --target vscode
+```
+
+> `private-init` and `add-repo` accept the same repo options — use `private-init`
+> for first-time setup and `add-repo` to register additional repos later. Both
+> print the catalog file path when they finish.
+
+**Which file gets edited, and where?** `private-init` writes a per-user catalog:
+
+| Content | File | Windows path |
+|---------|------|--------------|
+| Private skills | `~/.neqsim/private-skills.yaml` | `%USERPROFILE%\.neqsim\private-skills.yaml` |
+| Private agents | `~/.neqsim/private-agents.yaml` | `%USERPROFILE%\.neqsim\private-agents.yaml` |
+
+The command **prints the full path when it finishes** so you can open the file to
+add or adjust entries by hand. These files are per-user and must never be committed
+to a public repo. Useful options: `--source`, `--auth`, `--branch`,
+`--catalog-path`, `--name-prefix`, and `--skill-path-glob` / `--agent-path-glob`
+(run `neqsim agent private-init --help`). Authentication uses the GitHub CLI or Git
+Credential Manager via browser SSO — NeqSim never requests, inspects, or stores
+credentials. Full guide: [Enterprise Agent & Skill Repositories](../docs/integration/enterprise_agent_skill_repos.md)
+and the [Skills & Agents Guide](../docs/integration/skills_guide.md#private-skill-catalog).
+
 ## One-time setup
 
 **Recommended (works even when `pip`/`python` are not on PATH).** Run the
@@ -143,18 +188,31 @@ the hood:
 .\install.ps1
 ```
 
-> **"install.ps1 is not digitally signed" error?** That is PowerShell's
-> execution policy blocking scripts, not a problem with the file. Easiest fix —
-> run the wrapper, which bypasses the policy for a single run without changing
-> any system settings:
+```bash
+# macOS / Linux:
+./install.sh
+```
+
+> **"install.ps1 is not digitally signed" / execution-policy error on Windows?**
+> That is PowerShell blocking scripts, not a problem with the file. Use the
+> pure-batch installer instead — it calls Python/pip directly and never touches
+> PowerShell, so it works even on locked-down machines where the execution
+> policy is enforced by **Group Policy** (where even
+> `powershell -ExecutionPolicy Bypass` is ignored):
 >
-> ```powershell
-> .\install.cmd
+> ```bat
+> install.cmd            :: install neqsim-dev-setup (editable)
+> install.cmd pdf        :: also install the optional [pdf] extras
+> install.cmd ocr        :: also install the optional [ocr] extras
+> install.cmd uv         :: install with the fast 'uv' package manager
 > ```
 >
-> Or run the script directly with a one-time bypass:
-> `powershell -ExecutionPolicy Bypass -File .\install.ps1`. The wrapper forwards
-> all arguments, so `.\install.cmd -InstallJdk` and `.\install.cmd -Uv` work too.
+> Equivalent one-liner (no script at all): `py -m pip install -e devtools/`.
+> The `-InstallJdk` option is `install.ps1`-only; on a GPO-locked machine
+> install a JDK separately. After install, if the `neqsim` command is not on
+> PATH, use `py -m neqsim_cli --help`.
+
+**Using [uv](https://docs.astral.sh/uv/)?** Pass the `uv` flag to install with
 the fast `uv` package manager instead of pip:
 
 ```powershell

--- a/devtools/ensure_on_path.py
+++ b/devtools/ensure_on_path.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Ensure the directory containing the installed ``neqsim`` console script is on
+the user's PATH so that the ``neqsim`` command works in any new terminal.
+
+This is called at the end of ``install.cmd`` / ``install.ps1`` but is safe to run
+standalone (``py devtools/ensure_on_path.py``). It is idempotent and never fails
+the install: if it cannot update PATH it prints a clear manual fallback instead.
+
+Strategy
+--------
+1. If ``neqsim`` already resolves on PATH, do nothing.
+2. Otherwise locate the Scripts/bin directory that actually contains the console
+   script by probing, in order: an active virtualenv, the per-user install
+   location, and the global install location.
+3. On Windows, append that directory to the *user* PATH via the registry
+   (``HKCU\\Environment``) -- this avoids the 1024-char truncation and the
+   system/user duplication that ``setx %PATH%`` causes -- and broadcast the
+   change so new terminals pick it up.
+4. On macOS/Linux, print the line to add to the shell rc file (best effort).
+"""
+import os
+import shutil
+import sys
+import sysconfig
+
+
+SCRIPT_NAME = "neqsim"
+
+
+def _candidate_script_dirs():
+    """Yield candidate directories that may hold the console script.
+
+    The order matters: an active virtualenv wins, then the per-user location,
+    then the global one.
+
+    @return list of absolute directory paths (some may not exist)
+    """
+    dirs = []
+    venv = os.environ.get("VIRTUAL_ENV")
+    if venv:
+        sub = "Scripts" if os.name == "nt" else "bin"
+        dirs.append(os.path.join(venv, sub))
+    # Per-user and global script locations for this interpreter.
+    for scheme in _user_and_global_schemes():
+        try:
+            path = sysconfig.get_path("scripts", scheme)
+        except (KeyError, ValueError):
+            path = None
+        if path:
+            dirs.append(path)
+    # De-duplicate while preserving order.
+    seen = set()
+    unique = []
+    for d in dirs:
+        key = os.path.normcase(os.path.normpath(d))
+        if key not in seen:
+            seen.add(key)
+            unique.append(d)
+    return unique
+
+
+def _user_and_global_schemes():
+    """Return the sysconfig scheme names for user and global installs.
+
+    @return list of scheme name strings appropriate for this OS
+    """
+    if os.name == "nt":
+        return ["nt_user", "nt"]
+    return ["posix_user", "posix_prefix"]
+
+
+def _script_filename():
+    """Return the on-disk name of the console script for this OS.
+
+    @return the executable filename (e.g. ``neqsim.exe`` on Windows)
+    """
+    return SCRIPT_NAME + ".exe" if os.name == "nt" else SCRIPT_NAME
+
+
+def find_script_dir():
+    """Locate the directory that contains the installed console script.
+
+    @return the directory path, or ``None`` if the script was not found
+    """
+    fname = _script_filename()
+    for d in _candidate_script_dirs():
+        if d and os.path.isfile(os.path.join(d, fname)):
+            return d
+    return None
+
+
+def _already_on_path():
+    """Check whether the console script already resolves on PATH.
+
+    @return the resolved path string, or ``None`` if not found on PATH
+    """
+    return shutil.which(SCRIPT_NAME)
+
+
+def _add_to_windows_user_path(new_dir):
+    """Append ``new_dir`` to the Windows per-user PATH via the registry.
+
+    Reads and writes ``HKCU\\Environment`` directly (not ``setx``) to avoid PATH
+    truncation and system/user duplication, then broadcasts the change.
+
+    @param new_dir the directory to add to the user PATH
+    @return ``True`` if PATH was updated, ``False`` if it was already present
+    @throws OSError if the registry cannot be read or written
+    """
+    import winreg
+
+    with winreg.OpenKey(
+        winreg.HKEY_CURRENT_USER, "Environment", 0, winreg.KEY_READ | winreg.KEY_WRITE
+    ) as key:
+        try:
+            current, regtype = winreg.QueryValueEx(key, "Path")
+        except FileNotFoundError:
+            current, regtype = "", winreg.REG_EXPAND_SZ
+        if regtype not in (winreg.REG_SZ, winreg.REG_EXPAND_SZ):
+            regtype = winreg.REG_EXPAND_SZ
+
+        entries = [p for p in current.split(os.pathsep) if p]
+        target = os.path.normcase(os.path.normpath(new_dir))
+        for existing in entries:
+            if os.path.normcase(os.path.normpath(existing)) == target:
+                return False  # already present
+
+        entries.append(new_dir)
+        updated = os.pathsep.join(entries)
+        # Preserve %VAR% references by using REG_EXPAND_SZ.
+        winreg.SetValueEx(key, "Path", 0, winreg.REG_EXPAND_SZ, updated)
+
+    _broadcast_environment_change()
+    return True
+
+
+def _broadcast_environment_change():
+    """Broadcast WM_SETTINGCHANGE so new processes see the updated PATH.
+
+    Best effort: failures are ignored because the PATH edit itself already
+    succeeded and a new terminal would pick it up regardless.
+
+    @return ``None``
+    """
+    try:
+        import ctypes
+
+        HWND_BROADCAST = 0xFFFF
+        WM_SETTINGCHANGE = 0x1A
+        SMTO_ABORTIFHUNG = 0x0002
+        result = ctypes.c_long()
+        ctypes.windll.user32.SendMessageTimeoutW(
+            HWND_BROADCAST,
+            WM_SETTINGCHANGE,
+            0,
+            ctypes.c_wchar_p("Environment"),
+            SMTO_ABORTIFHUNG,
+            5000,
+            ctypes.byref(result),
+        )
+    except Exception:  # noqa: BLE001 - broadcasting is optional
+        pass
+
+
+# Marker so the block we add to a shell rc file can be found and is only
+# written once (idempotent across repeated installs).
+_POSIX_MARKER = "# >>> neqsim PATH >>>"
+_POSIX_MARKER_END = "# <<< neqsim PATH <<<"
+
+
+def _posix_rc_files():
+    """Return the shell rc file(s) to update based on the user's shell.
+
+    @return list of (path, syntax) tuples where syntax is ``"posix"`` or
+        ``"fish"``
+    """
+    shell = os.path.basename(os.environ.get("SHELL", "")).lower()
+    home = os.path.expanduser("~")
+    if shell == "zsh":
+        return [(os.path.join(home, ".zshrc"), "posix")]
+    if shell == "fish":
+        return [(os.path.join(home, ".config", "fish", "config.fish"), "fish")]
+    if shell == "bash":
+        # Linux login+interactive read ~/.bashrc; macOS Terminal reads
+        # ~/.bash_profile. Update whichever exist, defaulting to ~/.bashrc.
+        candidates = [os.path.join(home, ".bashrc")]
+        bash_profile = os.path.join(home, ".bash_profile")
+        if sys.platform == "darwin" or os.path.isfile(bash_profile):
+            candidates.append(bash_profile)
+        return [(c, "posix") for c in candidates]
+    # Unknown shell: ~/.profile is the most broadly sourced fallback.
+    return [(os.path.join(home, ".profile"), "posix")]
+
+
+def _add_to_posix_path(new_dir):
+    """Append ``new_dir`` to PATH in the user's shell rc file(s), idempotently.
+
+    Writes a clearly marked block so it is only added once and can be found or
+    removed later. Uses fish syntax for the fish shell and POSIX ``export`` for
+    everything else.
+
+    @param new_dir the directory to add to PATH
+    @return list of rc file paths that were updated (empty if already present)
+    """
+    updated = []
+    for rc_path, syntax in _posix_rc_files():
+        try:
+            existing = ""
+            if os.path.isfile(rc_path):
+                with open(rc_path, "r", encoding="utf-8") as handle:
+                    existing = handle.read()
+            # Skip if our block or the directory is already referenced.
+            if _POSIX_MARKER in existing or new_dir in existing:
+                continue
+
+            if syntax == "fish":
+                line = 'fish_add_path "{}"'.format(new_dir)
+            else:
+                line = 'export PATH="{}:$PATH"'.format(new_dir)
+            block = "\n{}\n{}\n{}\n".format(_POSIX_MARKER, line, _POSIX_MARKER_END)
+
+            parent = os.path.dirname(rc_path)
+            if parent and not os.path.isdir(parent):
+                os.makedirs(parent, exist_ok=True)
+            with open(rc_path, "a", encoding="utf-8") as handle:
+                handle.write(block)
+            updated.append(rc_path)
+        except OSError:
+            # Non-fatal: fall through so main() can print the manual fallback.
+            continue
+    return updated
+
+
+def main():
+    """Entry point: ensure the console-script directory is on PATH.
+
+    Always exits 0 so it never fails an install; prints a manual fallback if it
+    cannot update PATH automatically.
+
+    @return ``None``
+    """
+    resolved = _already_on_path()
+    if resolved:
+        print("'{}' is already on PATH ({}).".format(SCRIPT_NAME, resolved))
+        return
+
+    script_dir = find_script_dir()
+    if not script_dir:
+        # Install may have used a different layout; module form always works.
+        print(
+            "Could not locate the '{}' script directory. "
+            "Use 'py -m neqsim_cli --help' to run the CLI.".format(SCRIPT_NAME)
+        )
+        return
+
+    if os.name == "nt":
+        try:
+            changed = _add_to_windows_user_path(script_dir)
+        except OSError as exc:
+            print("Could not update the user PATH automatically: {}".format(exc))
+            print(
+                "Add this folder to PATH manually, or use 'py -m neqsim_cli':\n  "
+                + script_dir
+            )
+            return
+        # Update this process too (helps if a parent reads our environment).
+        os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + script_dir
+        if changed:
+            print("Added to your user PATH:\n  " + script_dir)
+            print(
+                "Open a NEW terminal, then '{}' will work. "
+                "Until then, use 'py -m neqsim_cli'.".format(SCRIPT_NAME)
+            )
+        else:
+            print(
+                "'{}' directory is already in the user PATH:\n  {}\n"
+                "Open a new terminal to pick it up.".format(SCRIPT_NAME, script_dir)
+            )
+    else:
+        # macOS/Linux: append to the shell rc file so a new shell picks it up.
+        updated = _add_to_posix_path(script_dir)
+        # Update this process too (best effort).
+        os.environ["PATH"] = script_dir + os.pathsep + os.environ.get("PATH", "")
+        if updated:
+            print("Added to your PATH via:")
+            for rc_path in updated:
+                print("  " + rc_path)
+            print(
+                "Open a NEW terminal (or 'source' the file above), then '{}' "
+                "will work. Until then, use 'python -m neqsim_cli'.".format(SCRIPT_NAME)
+            )
+        else:
+            print(
+                "The '{}' directory is already referenced in your shell "
+                "config:\n  {}\nOpen a new terminal to pick it up, or run "
+                "'python -m neqsim_cli'.".format(SCRIPT_NAME, script_dir)
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/devtools/install_agent.py
+++ b/devtools/install_agent.py
@@ -12,7 +12,10 @@ Usage:
     neqsim agent info <name>
     neqsim agent validate <name-or-path>
     neqsim agent schema
-    neqsim agent private-init
+    neqsim agent private-init      # create private catalog (optionally register
+                                   #   a repo + browser SSO in one step, e.g.
+                                   #   --repo org/repo --login); prints file path
+    neqsim agent add-repo --repo O/R [--login]  # add a private agent repo later
 
 Agents are installed to ~/.neqsim/agents/<name>/ and are never executed during
 installation. An agent package may be a single .agent.md file, a folder with
@@ -2383,22 +2386,105 @@ def cmd_run(agents, args):
     print("  Open this definition in your AI agent tool and run it explicitly there.\n")
 
 
-def cmd_private_init(agents, args):
-    """Create the private agent catalog template at ~/.neqsim/private-agents.yaml."""
-    if PRIVATE_CATALOG_FILE.exists():
-        print("\n  Private catalog already exists: {path}".format(
-            path=PRIVATE_CATALOG_FILE))
-        print("  Edit it to add your private agents.\n")
-        return
+def _register_repo_from_args(args):
+    """Append a repository entry to the private agent catalog from parsed args.
 
-    from datetime import date
-    content = PRIVATE_CATALOG_TEMPLATE.format(today=date.today().isoformat())
-    PRIVATE_CATALOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    PRIVATE_CATALOG_FILE.write_text(content, encoding="utf-8")
-    print("\n  [OK] Created private catalog: {path}".format(
-        path=PRIVATE_CATALOG_FILE))
-    print("  Edit it to add your internal/company agents.")
-    print("  Then: neqsim agent list --private\n")
+    Shared by ``private-init`` and ``add-repo`` so both stay in sync.
+
+    @param args parsed namespace with repo/url/source/auth/branch/etc.
+    @return ``True`` if a ``--repo``/``--url`` was provided and processed
+    """
+    repo = getattr(args, "repo", None)
+    url = getattr(args, "url", None)
+    if not (repo or url):
+        return False
+
+    source = getattr(args, "source", None) or ("github" if repo else "git")
+    auth = getattr(args, "auth", None) or (
+        "github-cli" if source == "github" else "git-credential-manager")
+    entry = {}
+    if repo:
+        entry["repo"] = repo
+    if url:
+        entry["url"] = url
+    entry["source"] = source
+    if source in ("github", "git"):
+        entry["auth"] = auth
+    entry["branch"] = getattr(args, "branch", None) or "main"
+    entry["catalog_path"] = getattr(args, "catalog_path", None) or ""
+    glob = getattr(args, "agent_path_glob", None)
+    entry["agent_path_glob"] = (
+        [glob] if glob else ["agents/**/AGENT.md", "agents/**/*.agent.md"])
+    prefix = getattr(args, "name_prefix", None)
+    if prefix:
+        entry["name_prefix"] = prefix
+    entry["tags"] = ["enterprise", "private"]
+    order = ["repo", "url", "source", "auth", "branch", "catalog_path",
+             "agent_path_glob", "name_prefix", "tags"]
+    result = install_skill.append_repository_entry(PRIVATE_CATALOG_FILE, entry, order)
+    if result == "appended":
+        print("  [OK] Registered private repository: {id}".format(id=repo or url))
+    else:
+        print("  Repository already registered: {id}".format(id=repo or url))
+
+    if getattr(args, "login", False):
+        print("\n  Setting up sign-in (SSO)...")
+        install_skill.run_provider_login(source, auth)
+    return True
+
+
+def _print_private_catalog_footer():
+    """Print the private agent catalog path and the verify/install hints."""
+    print("\n  Private catalog file (edit to add or adjust entries):")
+    print("    {path}".format(path=PRIVATE_CATALOG_FILE))
+    print("  Verify:  neqsim agent list --private")
+    print("  Install: neqsim agent install <name> --vscode\n")
+
+
+def cmd_add_repo(agents, args):
+    """Register a private agent repository in ~/.neqsim/private-agents.yaml.
+
+    Creates the catalog from the template if it does not exist yet, appends the
+    repository entry, optionally launches browser SSO, and prints the file path.
+
+    @param agents unused (kept for the command dispatch signature)
+    @param args parsed namespace; ``--repo`` or ``--url`` is required
+    @return ``None``
+    """
+    if not (getattr(args, "repo", None) or getattr(args, "url", None)):
+        print("\n  [!!] Provide a repository to add: --repo OWNER/REPO or --url GIT_URL")
+        print("  Example: neqsim agent add-repo --repo my-org/neqsim-enterprise-agents --login\n")
+        sys.exit(1)
+    created = install_skill.ensure_private_catalog(
+        PRIVATE_CATALOG_FILE, PRIVATE_CATALOG_TEMPLATE)
+    if created:
+        print("\n  [OK] Created private catalog: {path}".format(path=PRIVATE_CATALOG_FILE))
+    _register_repo_from_args(args)
+    _print_private_catalog_footer()
+
+
+def cmd_private_init(agents, args):
+    """Create/extend the private agent catalog at ~/.neqsim/private-agents.yaml.
+
+    Optionally registers a private repository (``--repo`` / ``--url``) directly
+    into the catalog and launches browser SSO sign-in (``--login``) in one step,
+    then always prints the catalog file location so it can be edited afterwards.
+
+    @param agents unused (kept for the command dispatch signature)
+    @param args parsed argparse namespace with optional repo/url/login options
+    @return ``None``
+    """
+    created = install_skill.ensure_private_catalog(
+        PRIVATE_CATALOG_FILE, PRIVATE_CATALOG_TEMPLATE)
+    if created:
+        print("\n  [OK] Created private catalog: {path}".format(path=PRIVATE_CATALOG_FILE))
+    else:
+        print("\n  Private catalog already exists: {path}".format(path=PRIVATE_CATALOG_FILE))
+
+    _register_repo_from_args(args)
+    _print_private_catalog_footer()
+
+
 
 
 def cmd_schema(agents, args):
@@ -2475,6 +2561,8 @@ def main():
         "  neqsim agent doctor --target vscode",
         "  neqsim agent remove neqsim-example-agent",
         "  neqsim agent private-init",
+        "  neqsim agent private-init --repo my-org/neqsim-enterprise-agents --login  # register a repo + SSO",
+        "  neqsim agent add-repo --repo my-org/neqsim-enterprise-agents --login      # add a repo later",
         "",
         "Preferred private access uses `gh auth login --web` or Git Credential Manager.",
         "Internal raw URLs can use PRIVATE_AGENT_TOKEN env var as a non-interactive fallback.",
@@ -2590,8 +2678,14 @@ def main():
         "--profile", default=None,
         help="Optional export profile JSON (default: ~/.neqsim/export/export-profile.json if present)")
 
-    sub.add_parser(
-        "private-init", help="Create private catalog template at ~/.neqsim/")
+    p_priv = sub.add_parser(
+        "private-init",
+        help="Create/extend private catalog at ~/.neqsim/ (optionally register a repo + SSO)")
+    install_skill._add_repo_options(p_priv, "agent")
+    p_addrepo = sub.add_parser(
+        "add-repo",
+        help="Add a private agent repository to ~/.neqsim/private-agents.yaml (+ optional SSO)")
+    install_skill._add_repo_options(p_addrepo, "agent")
 
     args = parser.parse_args()
     if not args.command:
@@ -2600,6 +2694,9 @@ def main():
 
     if args.command == "private-init":
         cmd_private_init([], args)
+        return
+    if args.command == "add-repo":
+        cmd_add_repo([], args)
         return
     if args.command in ("validate", "run", "schema", "doctor"):
         commands_without_catalog = {

--- a/devtools/install_skill.py
+++ b/devtools/install_skill.py
@@ -10,7 +10,10 @@ Usage:
     neqsim skill remove <name>     # remove an installed skill
     neqsim skill info <name>       # show skill details
     neqsim skill publish <repo>    # publish your skill to catalog
-    neqsim skill private-init      # create private catalog template
+    neqsim skill private-init      # create private catalog (optionally register
+                                   #   a repo + browser SSO in one step, e.g.
+                                   #   --repo org/repo --login); prints file path
+    neqsim skill add-repo --repo O/R [--login]  # add a private skill repo later
 
 Skills are installed to ~/.neqsim/skills/<name>/SKILL.md so they don't
 pollute the core repo. AI tools can be configured to read from that path.
@@ -1766,25 +1769,284 @@ def cmd_publish(skills, args):
         print(f"  The catalog entry was saved. Create the branch/PR manually.")
 
 
-def cmd_private_init(skills, args):
-    """Create the private skill catalog template at ~/.neqsim/private-skills.yaml."""
-    if PRIVATE_CATALOG_FILE.exists():
-        print(f"\n  Private catalog already exists: {PRIVATE_CATALOG_FILE}")
-        print(f"  Edit it to add your private skills.\n")
-        return
+def ensure_private_catalog(catalog_file, template):
+    """Create the private catalog file from a template if it does not exist.
 
+    @param catalog_file the ``Path`` to the private catalog YAML file
+    @param template the template string with a ``{today}`` placeholder
+    @return ``True`` if the file was created, ``False`` if it already existed
+    """
+    if catalog_file.exists():
+        return False
     from datetime import date
-    content = PRIVATE_CATALOG_TEMPLATE.format(today=date.today().isoformat())
-    PRIVATE_CATALOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    PRIVATE_CATALOG_FILE.write_text(content, encoding="utf-8")
-    print(f"\n  [OK] Created private catalog: {PRIVATE_CATALOG_FILE}")
-    print(f"  Edit it to add your internal/company skills.")
-    print(f"  Then: neqsim skill list --private\n")
 
-    print()
+    catalog_file.parent.mkdir(parents=True, exist_ok=True)
+    catalog_file.write_text(template.format(today=date.today().isoformat()), encoding="utf-8")
+    return True
+
+
+def _repo_entry_yaml(entry, key_order):
+    """Serialize a repository dict into a 2-space-indented YAML list item.
+
+    @param entry the repository mapping (string/list values only)
+    @param key_order preferred key ordering; unknown keys are appended after
+    @return the YAML block text (no trailing newline)
+    """
+    keys = [k for k in key_order if k in entry]
+    keys += [k for k in entry if k not in keys]
+    lines = []
+    for index, key in enumerate(keys):
+        value = entry[key]
+        if isinstance(value, (list, tuple)):
+            # Quote string items so globs with YAML-special leading characters
+            # (e.g. "*.agent.md", which YAML would read as an alias) stay valid.
+            items = []
+            for item in value:
+                if isinstance(item, str):
+                    items.append('"{}"'.format(item))
+                else:
+                    items.append(str(item))
+            rendered = "[" + ", ".join(items) + "]"
+        elif isinstance(value, bool):
+            rendered = "true" if value else "false"
+        elif isinstance(value, str):
+            rendered = '"{}"'.format(value)
+        else:
+            rendered = str(value)
+        if index == 0:
+            lines.append("  - {}: {}".format(key, rendered))
+        else:
+            lines.append("    {}: {}".format(key, rendered))
+    return "\n".join(lines)
+
+
+def _repository_already_registered(text, identifier):
+    """Return True only if ``identifier`` is an ACTIVE (non-commented) repo entry.
+
+    Parses the catalog and compares against real ``repo``/``url``/``path`` values
+    so commented-out template examples never cause a false "already registered".
+
+    @param text the raw catalog YAML text
+    @param identifier the repo/url/path identifier to look for
+    @return ``True`` if an active repository entry already uses the identifier
+    """
+    try:
+        data = _parse_catalog_text(text) or {}
+        for repo in data.get("repositories") or []:
+            if not isinstance(repo, dict):
+                continue
+            if identifier in (repo.get("repo"), repo.get("url"), repo.get("path")):
+                return True
+        return False
+    except Exception:  # noqa: BLE001 - fall back to a conservative text check
+        return identifier in text
+
+
+def append_repository_entry(catalog_file, entry, key_order):
+    """Append a repository entry under the catalog's ``repositories:`` key.
+
+    Idempotent: if the repo/url/path identifier already appears as an ACTIVE
+    (non-commented) entry the catalog is left unchanged. Preserves existing
+    comments by inserting text rather than re-serializing the whole document.
+
+    @param catalog_file the ``Path`` to the private catalog YAML file
+    @param entry the repository mapping to add
+    @param key_order preferred key ordering for the serialized entry
+    @return ``"appended"`` if added, ``"exists"`` if already present
+    """
+    text = catalog_file.read_text(encoding="utf-8")
+    identifier = entry.get("repo") or entry.get("url") or entry.get("path") or ""
+    if identifier and _repository_already_registered(text, identifier):
+        return "exists"
+
+    block = _repo_entry_yaml(entry, key_order)
+    out_lines = []
+    inserted = False
+    for line in text.splitlines():
+        out_lines.append(line)
+        if not inserted and line.rstrip() == "repositories:":
+            out_lines.append(block)
+            inserted = True
+    if not inserted:
+        out_lines.append("repositories:")
+        out_lines.append(block)
+    catalog_file.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
+    return "appended"
+
+
+def run_provider_login(source, auth=None):
+    """Launch the provider's browser-based SSO sign-in for a private repo.
+
+    NeqSim never requests, inspects, or stores credentials: it shells out to the
+    vendor CLI, which opens a normal browser sign-in. For internal Git it just
+    prints guidance because Git Credential Manager / SSO handles login on the
+    first clone.
+
+    @param source the repository source ("github", "git", or other)
+    @param auth optional auth-broker hint (unused beyond messaging)
+    @return ``True`` if a browser sign-in flow was launched, else ``False``
+    """
+    import shutil as _shutil
+    import subprocess
+
+    src = (source or "").lower()
+    if src == "github":
+        gh = _shutil.which("gh")
+        if not gh:
+            print("  [!!] GitHub CLI 'gh' not found. Install from https://cli.github.com/,")
+            print("       then run:  gh auth login --web")
+            return False
+        print("  Launching GitHub sign-in in your browser:  gh auth login --web")
+        try:
+            subprocess.run([gh, "auth", "login", "--web"], check=False)
+        except OSError as exc:
+            print("  [!!] Could not launch gh: {}".format(exc))
+            return False
+        return True
+    if src == "git":
+        print("  Internal Git uses your OS Git Credential Manager / SSO.")
+        print("  Sign-in happens in a browser on the first clone - no extra step needed.")
+        print("  Verify access with:  git ls-remote <your-repo-url>")
+        return False
+    print("  No SSO step is needed for source '{}'.".format(source or "local"))
+    return False
+
+
+def _register_repo_from_args(args):
+    """Append a repository entry to the private skill catalog from parsed args.
+
+    Shared by ``private-init`` and ``add-repo`` so both stay in sync.
+
+    @param args parsed namespace with repo/url/source/auth/branch/etc.
+    @return ``True`` if a ``--repo``/``--url`` was provided and processed
+    """
+    repo = getattr(args, "repo", None)
+    url = getattr(args, "url", None)
+    if not (repo or url):
+        return False
+
+    source = getattr(args, "source", None) or ("github" if repo else "git")
+    auth = getattr(args, "auth", None) or (
+        "github-cli" if source == "github" else "git-credential-manager")
+    entry = {}
+    if repo:
+        entry["repo"] = repo
+    if url:
+        entry["url"] = url
+    entry["source"] = source
+    if source in ("github", "git"):
+        entry["auth"] = auth
+    entry["branch"] = getattr(args, "branch", None) or "main"
+    entry["catalog_path"] = getattr(args, "catalog_path", None) or ""
+    entry["skill_path_glob"] = getattr(args, "skill_path_glob", None) or "skills/**/SKILL.md"
+    prefix = getattr(args, "name_prefix", None)
+    if prefix:
+        entry["name_prefix"] = prefix
+    entry["tags"] = ["enterprise", "private"]
+    order = ["repo", "url", "source", "auth", "branch", "catalog_path",
+             "skill_path_glob", "name_prefix", "tags"]
+    result = append_repository_entry(PRIVATE_CATALOG_FILE, entry, order)
+    if result == "appended":
+        print("  [OK] Registered private repository: {}".format(repo or url))
+    else:
+        print("  Repository already registered: {}".format(repo or url))
+
+    if getattr(args, "login", False):
+        print("\n  Setting up sign-in (SSO)...")
+        run_provider_login(source, auth)
+    return True
+
+
+def _print_private_catalog_footer():
+    """Print the private catalog path and the verify/install hints."""
+    print("\n  Private catalog file (edit to add or adjust entries):")
+    print("    {}".format(PRIVATE_CATALOG_FILE))
+    print("  Verify:  neqsim skill list --private")
+    print("  Install: neqsim skill install <name> --target vscode\n")
+
+
+def cmd_add_repo(skills, args):
+    """Register a private skill repository in ~/.neqsim/private-skills.yaml.
+
+    Creates the catalog from the template if it does not exist yet, appends the
+    repository entry, optionally launches browser SSO, and prints the file path.
+
+    @param skills unused (kept for the command dispatch signature)
+    @param args parsed namespace; ``--repo`` or ``--url`` is required
+    @return ``None``
+    """
+    if not (getattr(args, "repo", None) or getattr(args, "url", None)):
+        print("\n  [!!] Provide a repository to add: --repo OWNER/REPO or --url GIT_URL")
+        print("  Example: neqsim skill add-repo --repo my-org/neqsim-enterprise-skills --login\n")
+        sys.exit(1)
+    created = ensure_private_catalog(PRIVATE_CATALOG_FILE, PRIVATE_CATALOG_TEMPLATE)
+    if created:
+        print("\n  [OK] Created private catalog: {}".format(PRIVATE_CATALOG_FILE))
+    _register_repo_from_args(args)
+    _print_private_catalog_footer()
+
+
+def cmd_private_init(skills, args):
+    """Create the private skill catalog template at ~/.neqsim/private-skills.yaml.
+
+    Optionally registers a private repository (``--repo`` / ``--url``) directly
+    into the catalog and launches browser SSO sign-in (``--login``) in one step,
+    then always prints the catalog file location so it can be edited afterwards.
+
+    @param skills unused (kept for the command dispatch signature)
+    @param args parsed argparse namespace with optional repo/url/login options
+    @return ``None``
+    """
+    created = ensure_private_catalog(PRIVATE_CATALOG_FILE, PRIVATE_CATALOG_TEMPLATE)
+    if created:
+        print("\n  [OK] Created private catalog: {}".format(PRIVATE_CATALOG_FILE))
+    else:
+        print("\n  Private catalog already exists: {}".format(PRIVATE_CATALOG_FILE))
+
+    _register_repo_from_args(args)
+    _print_private_catalog_footer()
+
 
 
 # ── Main ───────────────────────────────────────────────────────────────
+
+def _add_repo_options(parser, kind):
+    """Add the shared private-repo registration options to an argparse parser.
+
+    Used by both the ``private-init`` and ``add-repo`` subcommands so their
+    options stay identical.
+
+    @param parser the argparse subparser to extend
+    @param kind ``"skill"`` or ``"agent"`` (selects the path-glob option name)
+    @return ``None``
+    """
+    parser.add_argument("--repo", help="Private GitHub repo (owner/repo) to register")
+    parser.add_argument("--url", help="Internal Git repo URL to register")
+    parser.add_argument(
+        "--source", choices=["github", "git", "local"],
+        help="Repository source (default: github when --repo, git when --url)")
+    parser.add_argument(
+        "--auth", choices=["github-cli", "git-credential-manager"],
+        help="Auth broker (default matches the source)")
+    parser.add_argument("--branch", default=None, help="Branch to use (default: main)")
+    parser.add_argument(
+        "--catalog-path", dest="catalog_path", default=None,
+        help="Path to the catalog file in the repo, or empty to scan")
+    if kind == "agent":
+        parser.add_argument(
+            "--agent-path-glob", dest="agent_path_glob", default=None,
+            help="Glob for agent discovery (default: agents/**/AGENT.md + *.agent.md)")
+    else:
+        parser.add_argument(
+            "--skill-path-glob", dest="skill_path_glob", default=None,
+            help="Glob for SKILL.md discovery (default: skills/**/SKILL.md)")
+    parser.add_argument(
+        "--name-prefix", dest="name_prefix", default=None,
+        help="Optional name prefix to avoid public/private clashes (e.g. enterprise-)")
+    parser.add_argument(
+        "--login", action="store_true",
+        help="Launch browser SSO sign-in (gh auth login --web) after registering")
+
 
 def main():
     examples = "\n".join([
@@ -1807,7 +2069,9 @@ def main():
         "",
         "Private skills:",
         "  neqsim skill private-init    # create ~/.neqsim/private-skills.yaml",
-        "  # Edit the file to add your private skills, then:",
+        "  neqsim skill private-init --repo my-org/neqsim-enterprise-skills --login  # register a repo + SSO",
+        "  neqsim skill add-repo --repo my-org/neqsim-enterprise-skills --login      # add a repo later",
+        "  # ...or edit the file by hand to add private skills, then:",
         "  neqsim skill list --private   # verify entries",
         "  neqsim skill install <name> --target vscode   # install and export privately for VS Code",
         "",
@@ -1875,7 +2139,14 @@ def main():
     p_publish.add_argument("--path", default="SKILL.md", help="Path to SKILL.md in the repo")
     p_publish.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
 
-    sub.add_parser("private-init", help="Create private catalog template at ~/.neqsim/")
+    p_priv = sub.add_parser(
+        "private-init",
+        help="Create/extend private catalog at ~/.neqsim/ (optionally register a repo + SSO)")
+    _add_repo_options(p_priv, "skill")
+    p_addrepo = sub.add_parser(
+        "add-repo",
+        help="Add a private skill repository to ~/.neqsim/private-skills.yaml (+ optional SSO)")
+    _add_repo_options(p_addrepo, "skill")
     p_doctor = sub.add_parser(
         "doctor", help="Check enterprise auth broker readiness or export target health")
     p_doctor.add_argument(
@@ -1893,9 +2164,12 @@ def main():
         parser.print_help()
         sys.exit(0)
 
-    # private-init doesn't need catalog loaded
+    # private-init / add-repo don't need the catalog loaded
     if args.command == "private-init":
         cmd_private_init([], args)
+        return
+    if args.command == "add-repo":
+        cmd_add_repo([], args)
         return
     if args.command == "doctor":
         cmd_doctor([], args)

--- a/devtools/neqsim_cli.py
+++ b/devtools/neqsim_cli.py
@@ -9,8 +9,8 @@ Usage:
     neqsim contribute        Guided wizard for your first contribution
     neqsim new-task TITLE    Create a task-solving workspace
     neqsim new-skill NAME    Scaffold a new AI skill
-    neqsim skill CMD         Manage skills (list/search/install/remove/private-init)
-    neqsim agent CMD         Manage agents (list/search/install/remove/validate/private-init)
+    neqsim skill CMD         Manage skills (list/search/install/remove/private-init/add-repo)
+    neqsim agent CMD         Manage agents (list/search/install/remove/validate/private-init/add-repo)
     neqsim paperlab CMD      Manage PaperLab VS Code agents and skills
 
 Run `neqsim <command> --help` for per-command options.
@@ -50,11 +50,11 @@ COMMANDS = {
     },
     "skill": {
         "module": "install_skill",
-        "desc": "Manage skills (list/search/install/remove/private-init)",
+        "desc": "Manage skills (list/search/install/remove/private-init/add-repo)",
     },
     "agent": {
         "module": "install_agent",
-        "desc": "Manage agents (list/search/install/remove/validate/private-init)",
+        "desc": "Manage agents (list/search/install/remove/validate/private-init/add-repo)",
     },
     "paperlab": {
         "module": "paperlab_install",

--- a/docs/integration/enterprise_agent_skill_repos.md
+++ b/docs/integration/enterprise_agent_skill_repos.md
@@ -9,6 +9,78 @@ This guide explains how a company can set up private NeqSim enterprise repositor
 
 Use this pattern when the content is useful to a company or project but should not be published in the community repositories because it contains company policy, internal integration wiring, governed workflow requirements, or private validation expectations.
 
+## Onboarding: recommended order
+
+There are two distinct roles. The **company/org admin** creates the private repositories once; **each engineer** then installs NeqSim and connects to them. Follow the steps in this order.
+
+### A. One-time company setup (admin, once per organization)
+
+1. **Create the two private repositories** from the NeqSim templates:
+   `<company>-neqsim-enterprise-agents` (catalog `enterprise-agents.yaml`) and
+   `<company>-neqsim-enterprise-skills` (catalog `enterprise-skills.yaml`). See
+   [Step 1](#step-1-create-the-enterprise-skills-repository) and
+   [Step 2](#step-2-create-the-enterprise-agents-repository) below.
+2. **Grant engineers read access** through your normal GitHub org / SSO groups.
+3. **Share the two repo names** (and any internal Git URLs) with engineers.
+
+The public **community** catalogs (`neqsim-community-agents`,
+`neqsim-community-skills`) are bundled with NeqSim and need no setup — do not
+recreate them. Only the private enterprise repos are created here.
+
+### B. Per-engineer onboarding (each user, in this order)
+
+**Prerequisites** (install once, per-user — via your software portal / `winget`, no admin needed):
+Python 3.8+, Git, and — only if you will use `--login` for GitHub SSO — the
+[GitHub CLI](https://cli.github.com/) (`gh`). A JDK is only needed for Java builds,
+not for the agents/skills CLI.
+
+1. **Get the NeqSim code and open a terminal in it:**
+   ```powershell
+   git clone https://github.com/equinor/neqsim.git
+   cd neqsim
+   ```
+2. **Install NeqSim.** On a locked-down/no-admin Windows PC use the GPO-proof
+   batch installer (no PowerShell, no admin):
+   ```powershell
+   .\install.cmd            # or: py -m pip install -e devtools/
+   ```
+   macOS/Linux: `./install.sh`. This also puts the `neqsim` command on PATH
+   (open a new terminal afterwards; or use `py -m neqsim_cli`).
+3. **Install community agents & skills — no auth needed.** These are the default
+   catalog and work immediately:
+   ```powershell
+   neqsim agent install --all --vscode
+   neqsim skill install --all
+   ```
+4. **Connect the enterprise repos AND sign in, in one step.** `private-init --login`
+   registers the private repo in your per-user catalog **and** launches browser
+   SSO (`gh auth login --web`) — so SSO and repo registration happen together:
+   ```powershell
+   neqsim agent private-init --repo <company>/<company>-neqsim-enterprise-agents --login
+   neqsim skill private-init --repo <company>/<company>-neqsim-enterprise-skills --login
+   # add more private repos later with the same options:
+   neqsim agent add-repo --url https://git.internal.company.com/neqsim/enterprise-agents.git
+   ```
+   If your org already signs you in through Git Credential Manager, you can omit
+   `--login`. Each command prints the catalog file it wrote
+   (`~/.neqsim/private-agents.yaml` / `~/.neqsim/private-skills.yaml`).
+5. **Install the enterprise agents & skills:**
+   ```powershell
+   neqsim agent list --private        # verify discovery
+   neqsim skill install <name> --target vscode
+   neqsim agent install <name> --vscode
+   ```
+
+> **Why this order?** Community content needs no authentication, so it is installed
+> first and always works. SSO is only required to *read the private repos*, and
+> `private-init --login` performs the sign-in as part of registering them — so you
+> never do a separate "register SSO" step. Creating the repos (Part A) is a
+> one-time admin task, not something each engineer repeats.
+
+Runtime integrators using the **Engineering Harness** instead of the `neqsim`
+CLI follow [Step 3](#step-3-configure-installation-and-discovery) onward, which
+uses `plugins/sources.yaml` for the same repositories.
+
 ## Repository Model
 
 Create two private repositories per company or organization:

--- a/docs/integration/skills_guide.md
+++ b/docs/integration/skills_guide.md
@@ -894,6 +894,51 @@ This works exactly like `community-skills.yaml` but:
 
 ### Setup
 
+The quickest path registers a private repository **and** signs in with browser
+SSO in one command — no hand-editing of YAML required:
+
+```bash
+# One step: create the catalog, register a private GitHub repo, and sign in
+neqsim skill private-init --repo my-org/neqsim-enterprise-skills --login
+
+# Internal Git server instead of GitHub:
+neqsim skill private-init --url https://git.internal.company.com/neqsim/enterprise-skills.git
+
+# Add more private repos later (same options; creates the catalog if missing):
+neqsim skill add-repo --repo my-org/another-skills-repo --login
+```
+
+`private-init` prints the exact catalog file location at the end so you can edit
+it afterwards. Use `private-init` for first-time setup and `add-repo` to register
+additional repos later — they accept the same options. Then:
+
+```bash
+neqsim skill list --private                 # verify discovered skills
+neqsim skill install <name> --target vscode # install + export for VS Code
+```
+
+Options for `private-init` and `add-repo` (both `neqsim skill` and `neqsim agent`):
+
+| Option | Meaning | Default |
+|--------|---------|---------|
+| `--repo OWNER/REPO` | Register a private GitHub repo | — |
+| `--url GIT_URL` | Register an internal Git repo | — |
+| `--source github\|git\|local` | Repository source | `github` with `--repo`, `git` with `--url` |
+| `--auth github-cli\|git-credential-manager` | Auth broker | matches source |
+| `--branch NAME` | Branch to read | `main` |
+| `--catalog-path PATH` | Catalog file in the repo, or empty to scan | `""` (scan) |
+| `--skill-path-glob` / `--agent-path-glob` | Discovery glob | `skills/**/SKILL.md` / agent globs |
+| `--name-prefix PREFIX` | Prefix to avoid public/private name clashes | — |
+| `--login` | Launch browser SSO (`gh auth login --web`) after registering | off |
+
+> **Which YAML file, and where?** `private-init` writes to
+> `~/.neqsim/private-skills.yaml` (skills) and `~/.neqsim/private-agents.yaml`
+> (agents) — on Windows that is `%USERPROFILE%\.neqsim\`. These files are
+> per-user and must **never** be committed to a public repo. The command prints
+> the full path when it finishes; open that file to add or adjust entries by hand.
+
+**Manual alternative** (edit the YAML yourself):
+
 ```bash
 # 1. Create the catalog template
 neqsim skill private-init
@@ -904,6 +949,14 @@ neqsim skill list --private
 
 # 4. Install a private skill (same command as community skills)
 neqsim skill install neqsim-company-stid
+```
+
+The identical flow exists for agents — swap `skill` for `agent`:
+
+```bash
+neqsim agent private-init --repo my-org/neqsim-enterprise-agents --login
+neqsim agent list --private
+neqsim agent install <name> --vscode
 ```
 
 ### Catalog Format

--- a/install.cmd
+++ b/install.cmd
@@ -1,29 +1,121 @@
 @echo off
-REM install.cmd - Windows wrapper for install.ps1
+REM install.cmd - Windows installer for the NeqSim devtools package.
 REM
-REM Runs the NeqSim devtools installer without hitting the PowerShell
-REM "file is not digitally signed" / execution-policy error. It launches
-REM install.ps1 with -ExecutionPolicy Bypass for this one process only and
-REM does NOT change any system or user execution-policy settings.
+REM This is a PURE BATCH installer that calls Python directly and does NOT run
+REM any PowerShell script. Use it when PowerShell refuses to run install.ps1
+REM with a "file is not digitally signed" / execution-policy error -- including
+REM locked-down machines where the execution policy is enforced by Group Policy
+REM (so even "powershell -ExecutionPolicy Bypass" is ignored).
 REM
-REM Usage (from the repo root, in cmd or by double-clicking):
+REM It finds a working Python (py launcher, python, or python3, skipping the
+REM Microsoft Store stub), bootstraps pip if needed, and installs the devtools
+REM package in editable mode -- exactly what install.ps1 does at its core.
+REM
+REM Usage (from the repo root, in cmd.exe or by double-clicking):
 REM     install.cmd                 :: install neqsim-dev-setup (editable)
 REM     install.cmd pdf             :: also install the optional [pdf] extras
 REM     install.cmd ocr             :: also install the optional [ocr] extras
-REM     install.cmd -Uv             :: use the fast 'uv' package manager
-REM     install.cmd -InstallJdk     :: also download a portable Temurin JDK
+REM     install.cmd uv              :: install with the fast 'uv' package manager
 REM
-REM All arguments are forwarded verbatim to install.ps1.
+REM For the optional -InstallJdk / advanced options, use install.ps1 on a
+REM machine where PowerShell scripts are allowed.
 
-setlocal
+setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
+set "DEVTOOLS=%SCRIPT_DIR%devtools"
 
-REM Prefer Windows PowerShell; fall back to PowerShell 7+ (pwsh) if present.
-where powershell >nul 2>&1
-if %ERRORLEVEL%==0 (
-    powershell -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%install.ps1" %*
-) else (
-    pwsh -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%install.ps1" %*
-)
+REM ---- First positional arg: extras name, or "uv" to use the uv installer ----
+REM NOTE: do not use "if COND cmd & goto" here -- the & runs the goto
+REM unconditionally in batch, which would skip the extras assignment.
+set "EXTRAS="
+set "USE_UV="
+if /I "%~1"=="uv" goto :arg1_uv
+if not "%~1"=="" set "EXTRAS=%~1"
+goto :arg2
+:arg1_uv
+set "USE_UV=1"
+:arg2
+if /I "%~2"=="uv" set "USE_UV=1"
 
-exit /b %ERRORLEVEL%
+echo NeqSim devtools installer (batch)
+echo Locating a working Python interpreter...
+
+REM ---- Find a Python that actually prints a version (skips the Store stub) ----
+set "PY="
+call :try_python "py" "-3"
+if defined PY goto :found
+call :try_python "python" ""
+if defined PY goto :found
+call :try_python "python3" ""
+if defined PY goto :found
+
+echo.
+echo ERROR: No working Python interpreter was found.
+echo Install Python 3.8+ from https://www.python.org/downloads/
+echo (check "Add python.exe to PATH"), then re-run install.cmd.
+exit /b 1
+
+:found
+echo Using Python via: %PY%
+
+REM ---- Build the editable target, with optional extras ----
+set "TARGET=%DEVTOOLS%"
+if defined EXTRAS set "TARGET=%DEVTOOLS%[%EXTRAS%]"
+
+if defined USE_UV goto :install_uv
+
+REM ---- Ensure pip, then install with pip ----
+%PY% -m pip --version >nul 2>&1
+if not errorlevel 1 goto :pip_ok
+echo pip not found for this interpreter - bootstrapping with ensurepip...
+%PY% -m ensurepip --upgrade
+if errorlevel 1 goto :err_pip_boot
+:pip_ok
+echo Installing (editable): %TARGET%
+%PY% -m pip install -e "%TARGET%"
+if errorlevel 1 goto :err_pip
+goto :done
+
+:install_uv
+where uv >nul 2>&1
+if errorlevel 1 goto :err_no_uv
+for /f "delims=" %%E in ('%PY% -c "import sys; print(sys.executable)"') do set "PYEXE=%%E"
+echo Installing (editable, via uv): %TARGET%
+uv pip install --python "%PYEXE%" -e "%TARGET%"
+if errorlevel 1 goto :err_uv
+goto :done
+
+:done
+echo.
+echo Ensuring the 'neqsim' command is on your PATH...
+%PY% "%DEVTOOLS%\ensure_on_path.py"
+echo.
+echo Done. Verify with:
+echo   %PY% -m neqsim_cli --help
+echo If the 'neqsim' command is not found in this window, open a NEW terminal
+echo (PATH changes only apply to newly opened terminals), or use the line above.
+exit /b 0
+
+:err_pip_boot
+echo ERROR: could not bootstrap pip. Re-run the Python installer and enable pip.
+exit /b 1
+:err_pip
+echo ERROR: pip install failed. See the output above for details.
+exit /b 1
+:err_no_uv
+echo ERROR: 'uv' was requested but is not installed. Run: %PY% -m pip install uv
+exit /b 1
+:err_uv
+echo ERROR: 'uv pip install' failed. See the output above for details.
+exit /b 1
+
+REM ---- Helper: set PY only if the candidate prints a version ----
+:try_python
+set "_CMD=%~1"
+set "_ARG=%~2"
+if defined _ARG "%~1" %~2 -c "import sys; print(sys.version.split()[0])" >nul 2>&1
+if not defined _ARG "%~1" -c "import sys; print(sys.version.split()[0])" >nul 2>&1
+if errorlevel 1 goto :eof
+if defined _ARG set "PY=%_CMD% %_ARG%"
+if not defined _ARG set "PY=%_CMD%"
+goto :eof

--- a/install.ps1
+++ b/install.ps1
@@ -163,9 +163,14 @@ if ($Uv) {
 }
 
 Write-Host ""
+Write-Host "Ensuring the 'neqsim' command is on your PATH..." -ForegroundColor Cyan
+& $python[0] @pyArgs (Join-Path $Devtools "ensure_on_path.py")
+
+Write-Host ""
 Write-Host "Done. Verify with:" -ForegroundColor Green
 Write-Host "  $pythonDisplay -m neqsim_cli --help"
-Write-Host "If the 'neqsim' command is not found, see devtools/README.md > Troubleshooting."
+Write-Host "If 'neqsim' is not found in this window, open a NEW terminal (PATH changes"
+Write-Host "only apply to newly opened terminals), or use the line above."
 
 # ── JDK advisory (non-fatal) ─────────────────────────────────────────────
 # The Python devtools do not need Java, but building the NeqSim JAR

--- a/install.sh
+++ b/install.sh
@@ -103,9 +103,14 @@ else
 fi
 
 echo ""
+echo "Ensuring the 'neqsim' command is on your PATH..."
+"$PYTHON" "$DEVTOOLS/ensure_on_path.py" || true
+
+echo ""
 echo "Done. Verify with:"
 echo "  $PYTHON -m neqsim_cli --help"
-echo "If the 'neqsim' command is not found, see devtools/README.md > Troubleshooting."
+echo "If 'neqsim' is not found in this shell, open a NEW terminal (or 'source'"
+echo "your shell rc file), or use the line above."
 
 # ── JDK advisory (non-fatal) ─────────────────────────────────────────────
 # The Python devtools do not need Java, but building the NeqSim JAR


### PR DESCRIPTION
## What
- **`install.cmd`** — pure-batch installer (no PowerShell) so it works on locked-down Windows where the execution policy is enforced by **Group Policy** (even `powershell -ExecutionPolicy Bypass` is ignored). Fixed a batch `& goto` bug that silently skipped `extras`.
- **`devtools/ensure_on_path.py`** (new) — adds the `neqsim` script directory to the user PATH with **no admin**: Windows `HKCU\Environment` via the registry (avoids `setx` truncation/duplication), and the shell rc file on macOS/Linux. Wired into `install.cmd`, `install.ps1`, and `install.sh`.
- **`neqsim {agent,skill} private-init`** — new options to register a private repo **and** launch browser SSO in one step (`--repo`/`--url`/`--source`/`--auth`/`--branch`/`--catalog-path`/`--name-prefix`/`--skill-path-glob`/`--agent-path-glob`/`--login`). New **`add-repo`** subcommand to register repos later. Idempotent (parses the catalog, ignores commented template examples) and prints the catalog file path.
- **Docs** — no-admin/GPO install, private-catalog setup, and an ordered admin + per-user onboarding section in `docs/integration/enterprise_agent_skill_repos.md`; matching notes in the READMEs and `skills_guide.md`.

## Why
Corporate/Equinor machines block PowerShell scripts via Group Policy and lack admin rights, so users could not install NeqSim devtools or set up private agents/skills.

## Testing
All Python modules compile. `install.cmd` and both `private-init`/`add-repo` subcommands tested end-to-end in a sandbox (create/register/idempotency/error paths, YAML round-trip, PATH helper). A real idempotency bug (matching commented template URLs) was found via testing and fixed. No Java changed (Spotless correctly skipped).