### PR TITLE
Fix MCP server Docker image crash (UnsupportedClassVersionError): use JRE 21 base

### DIFF
--- a/neqsim-mcp-server/Dockerfile
+++ b/neqsim-mcp-server/Dockerfile
@@ -11,7 +11,7 @@
 #   cd .. && ./mvnw install -DskipTests -Dmaven.javadoc.skip=true
 #   cd neqsim-mcp-server && ../mvnw package -DskipTests -Dmaven.javadoc.skip=true
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 LABEL org.opencontainers.image.source="https://github.com/equinor/neqsim"
 LABEL org.opencontainers.image.description="NeqSim MCP Server — rigorous thermodynamics for LLMs"


### PR DESCRIPTION
## Problem

The published `ghcr.io/equinor/neqsim-mcp-server:latest` image crashes on start with:

```
java.lang.UnsupportedClassVersionError: ... class file version 65.0
```

## Root cause

The runtime base image and the compile target disagree:

| Where | Java | Class file version |
|-------|------|--------------------|
| Build (`neqsim-mcp-server/pom.xml` `<release>21</release>`, CI `java-version: '21'`) | 21 | 65.0 |
| Runtime (`Dockerfile` base `eclipse-temurin:17-jre-alpine`) | 17 | max 61.0 |

JRE 17 cannot load Java 21 bytecode, so the container fails immediately.

## Fix

Change the Dockerfile base image to `eclipse-temurin:21-jre-alpine` to match the compile target and the CI JDK.

## Note for users

Docker will not re-pull a tag whose digest it already has locally. After a new `:latest` is published, users must run `docker pull ghcr.io/equinor/neqsim-mcp-server:latest` to pick up the fix.

Thanks to the reporter for the precise diagnosis.