### PR TITLE
fix(devtools): no-admin installer PATH/venv handling + neqsim skill install --all

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -279,6 +279,9 @@ python -c "import sysconfig; print(sysconfig.get_path('scripts'))"
 $scripts = [System.IO.Path]::Combine($env:APPDATA, 'Python', 'Python312', 'Scripts')
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$scripts", "User")
 # Restart your terminal for the change to take effect.
+# If running neqsim later shows "The term 'neqsim' is not recognized" in a VS Code
+# terminal, fully quit and reopen VS Code (a new integrated terminal is not enough
+# — VS Code captures PATH at launch). A virtualenv avoids this.
 ```
 
 **Linux / macOS — without venv:**

--- a/devtools/ensure_on_path.py
+++ b/devtools/ensure_on_path.py
@@ -97,6 +97,38 @@ def _already_on_path():
     return shutil.which(SCRIPT_NAME)
 
 
+def _same_dir(a, b):
+    """Return whether two paths refer to the same directory.
+
+    Comparison is case- and separator-insensitive (``normcase`` + ``normpath``)
+    so it behaves correctly on Windows.
+
+    @param a first path
+    @param b second path
+    @return ``True`` if both normalize to the same directory
+    """
+    return os.path.normcase(os.path.normpath(a)) == os.path.normcase(
+        os.path.normpath(b)
+    )
+
+
+def _dir_on_path(directory):
+    """Return whether ``directory`` is already on the current process PATH.
+
+    Uses the live ``PATH`` (which reflects machine + user + session entries), so
+    a directory placed on PATH by a global / all-users install is detected and
+    not duplicated into the per-user PATH.
+
+    @param directory the directory to test
+    @return ``True`` if the directory is present on PATH
+    """
+    target = os.path.normcase(os.path.normpath(directory))
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if entry and os.path.normcase(os.path.normpath(entry)) == target:
+            return True
+    return False
+
+
 def _add_to_windows_user_path(new_dir):
     """Append ``new_dir`` to the Windows per-user PATH via the registry.
 
@@ -234,22 +266,52 @@ def _add_to_posix_path(new_dir):
 def main():
     """Entry point: ensure the console-script directory is on PATH.
 
+    Locates the directory where *this* install placed the console script and
+    ensures that specific directory is on PATH -- rather than stopping as soon
+    as any ``neqsim`` resolves. That distinction matters on machines where an
+    elevated / all-users install already put ``neqsim`` on the system PATH: a
+    later non-elevated (per-user) install puts the script in a *different*
+    directory that would otherwise never be added.
+
     Always exits 0 so it never fails an install; prints a manual fallback if it
     cannot update PATH automatically.
 
     @return ``None``
     """
-    resolved = _already_on_path()
-    if resolved:
-        print("'{}' is already on PATH ({}).".format(SCRIPT_NAME, resolved))
-        return
-
     script_dir = find_script_dir()
+
+    # If the script lives in the active virtualenv, it is already on PATH for
+    # that environment; do not persist an ephemeral venv location to the user
+    # PATH.
+    venv = os.environ.get("VIRTUAL_ENV")
+    if venv and script_dir:
+        venv_scripts = os.path.join(venv, "Scripts" if os.name == "nt" else "bin")
+        if _same_dir(script_dir, venv_scripts):
+            print(
+                "'{}' is installed in the active virtualenv and already on "
+                "PATH:\n  {}".format(SCRIPT_NAME, script_dir)
+            )
+            return
+
     if not script_dir:
-        # Install may have used a different layout; module form always works.
+        # We could not find the script where an install would place it. If it
+        # nonetheless resolves from a prior / global install, that is fine;
+        # otherwise tell the user how to run the CLI via the module form.
+        resolved = _already_on_path()
+        if resolved:
+            print("'{}' is already on PATH ({}).".format(SCRIPT_NAME, resolved))
+            return
         print(
             "Could not locate the '{}' script directory. "
             "Use 'py -m neqsim_cli --help' to run the CLI.".format(SCRIPT_NAME)
+        )
+        return
+
+    if _dir_on_path(script_dir):
+        print(
+            "'{}' script directory is already on PATH:\n  {}".format(
+                SCRIPT_NAME, script_dir
+            )
         )
         return
 
@@ -276,6 +338,12 @@ def main():
                 "'{}' directory is already in the user PATH:\n  {}\n"
                 "Open a new terminal to pick it up.".format(SCRIPT_NAME, script_dir)
             )
+        print(
+            "If running '{0}' later shows \"The term '{0}' is not recognized\" "
+            "in a VS Code terminal, fully quit and reopen VS Code -- a new "
+            "integrated terminal is NOT enough (VS Code captures PATH at "
+            "launch). A virtualenv avoids this.".format(SCRIPT_NAME)
+        )
     else:
         # macOS/Linux: append to the shell rc file so a new shell picks it up.
         updated = _add_to_posix_path(script_dir)

--- a/devtools/install_skill.py
+++ b/devtools/install_skill.py
@@ -1329,8 +1329,16 @@ def _install_from_git(skill, dest_file):
 
 
 def cmd_install(skills, args):
-    """Install a skill from the catalog (community or private)."""
+    """Install a skill (or every skill with --all) from the catalog."""
+    if getattr(args, "all", False) or args.name == "*":
+        _install_all_skills(skills, args)
+        return
+
     name = args.name
+    if not name:
+        print("\n  Specify a skill name, or use --all to install every skill.")
+        print("  Run: neqsim skill list\n")
+        sys.exit(1)
     skill = next((s for s in skills if s.get("name") == name), None)
     if not skill:
         print(f"\n  Skill '{name}' not found in catalog.")
@@ -1338,6 +1346,58 @@ def cmd_install(skills, args):
         sys.exit(1)
 
     manifest = load_manifest()
+    if not _install_skill_record(skill, args, manifest):
+        sys.exit(1)
+
+
+def _install_all_skills(skills, args):
+    """Install every catalog skill, continuing past individual failures."""
+    source_filter = getattr(args, "source", "all")
+    seen = set()
+    unique = []
+    for skill in skills:
+        name = skill.get("name", "")
+        if not name or name in seen:
+            continue
+        if source_filter != "all" and skill.get("_source") != source_filter:
+            continue
+        seen.add(name)
+        unique.append(skill)
+
+    total = len(unique)
+    if total == 0:
+        print("\n  No skill(s) matched source '{source}'.\n".format(source=source_filter))
+        return
+    print("\n  Installing {total} {source} skill(s) from the catalog...\n".format(
+        total=total, source=source_filter))
+    manifest = load_manifest()
+    installed = []
+    failed = []
+    for index, skill in enumerate(unique, start=1):
+        name = skill.get("name", "")
+        print("  [{index}/{total}] {name}".format(index=index, total=total, name=name))
+        if _install_skill_record(skill, args, manifest):
+            installed.append(name)
+        else:
+            failed.append(name)
+
+    print("\n  ==== Install summary ====")
+    print("  Installed/OK: {count}".format(count=len(installed)))
+    print("  Failed: {count}".format(count=len(failed)))
+    if failed:
+        print("  Failed skills: {names}".format(names=", ".join(failed)))
+        sys.exit(1)
+
+
+def _install_skill_record(skill, args, manifest):
+    """Install a single resolved skill record.
+
+    @param skill the resolved catalog skill mapping to install
+    @param args the parsed CLI arguments (force + export target options)
+    @param manifest the loaded install manifest (mutated and saved on success)
+    @return True on success, False on failure (never calls sys.exit)
+    """
+    name = skill.get("name")
     if name in manifest and not args.force:
         print(f"\n  Skill '{name}' already installed at {manifest[name]['path']}")
         print(f"  Use --force to reinstall.")
@@ -1345,11 +1405,11 @@ def cmd_install(skills, args):
             source_dir = Path(manifest[name].get("path", "")).parent
             if not source_dir.exists():
                 print(f"  [!!] Installed skill folder is missing: {source_dir}\n")
-                sys.exit(1)
+                return False
             if not _export_installed_skill(name, source_dir, args, manifest):
-                sys.exit(1)
+                return False
         print()
-        return
+        return True
 
     dest_dir = INSTALL_DIR / name
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -1374,7 +1434,7 @@ def cmd_install(skills, args):
             dest_file.unlink()
             dest_dir.rmdir()
             print(f"  [!!] Downloaded content doesn't look like a SKILL.md file.")
-            sys.exit(1)
+            return False
 
         manifest[name] = {
             "path": str(dest_file),
@@ -1399,12 +1459,13 @@ def cmd_install(skills, args):
         print(f"\n  To use in your AI tool, point it at: {dest_dir}\n")
 
         if not _export_installed_skill(name, dest_dir, args, manifest):
-            sys.exit(1)
+            return False
+        return True
 
     except Exception as e:
         print(f"  [!!] Download failed: {e}")
         print(f"  You can manually download from: https://github.com/{skill.get('repo', '')}\n")
-        sys.exit(1)
+        return False
 
 
 def cmd_installed(skills, args):
@@ -2057,6 +2118,8 @@ def main():
         "  neqsim skill install neqsim-example-skill",
         "  neqsim skill install neqsim-example-skill --target vscode",
         "  neqsim skill install neqsim-example-skill --target generic",
+        "  neqsim skill install --all --target vscode",
+        "  neqsim skill install --all --source community --target vscode",
         "  neqsim skill export neqsim-example-skill --target vscode",
         "  neqsim skill export neqsim-example-skill --target generic",
         "  neqsim skill installed",
@@ -2095,8 +2158,15 @@ def main():
     p_info = sub.add_parser("info", help="Show details for a skill")
     p_info.add_argument("name", help="Skill name")
 
-    p_install = sub.add_parser("install", help="Install a skill")
-    p_install.add_argument("name", help="Skill name from catalog")
+    p_install = sub.add_parser("install", help="Install a skill (or every skill with --all)")
+    p_install.add_argument(
+        "name", nargs="?",
+        help="Skill name from catalog (omit when using --all)")
+    p_install.add_argument(
+        "--all", action="store_true", help="Install every skill in the catalog")
+    p_install.add_argument(
+        "--source", choices=["all", "community", "private"], default="all",
+        help="When used with --all, install all sources, community only, or private/enterprise only")
     p_install.add_argument("--force", action="store_true", help="Reinstall if exists")
     p_install.add_argument(
         "--vscode", action="store_true",

--- a/devtools/test_install_skill.py
+++ b/devtools/test_install_skill.py
@@ -599,5 +599,76 @@ class SkillVsCodeExportTest(unittest.TestCase):
         self.assertNotIn("secret", output.lower())
 
 
+class InstallAllSkillsTest(unittest.TestCase):
+    """Regression tests for `neqsim skill install --all` and source filtering."""
+
+    @staticmethod
+    def _args(**overrides):
+        import argparse
+        base = dict(
+            name=None, all=False, source="all", force=False,
+            vscode=False, target=None, vscode_scope="user",
+            vscode_dir=None, export_dir=None,
+        )
+        base.update(overrides)
+        return argparse.Namespace(**base)
+
+    def test_all_installs_every_catalog_skill(self):
+        """--all iterates the whole catalog and installs each skill once."""
+        skills = [
+            {"name": "alpha", "_source": "community"},
+            {"name": "beta", "_source": "community"},
+        ]
+        with mock.patch.object(install_skill, "load_manifest", return_value={}), \
+                mock.patch.object(install_skill, "_install_skill_record", return_value=True) as record:
+            install_skill.cmd_install(skills, self._args(all=True))
+        installed = [call.args[0]["name"] for call in record.call_args_list]
+        self.assertEqual(["alpha", "beta"], installed)
+
+    def test_all_source_filter_limits_to_matching_source(self):
+        """--source private installs only private-sourced skills."""
+        skills = [
+            {"name": "alpha", "_source": "community"},
+            {"name": "priv", "_source": "private"},
+        ]
+        with mock.patch.object(install_skill, "load_manifest", return_value={}), \
+                mock.patch.object(install_skill, "_install_skill_record", return_value=True) as record:
+            install_skill.cmd_install(skills, self._args(all=True, source="private"))
+        installed = [call.args[0]["name"] for call in record.call_args_list]
+        self.assertEqual(["priv"], installed)
+
+    def test_all_deduplicates_repeated_names(self):
+        """A skill appearing twice in the catalog is installed only once."""
+        skills = [
+            {"name": "alpha", "_source": "community"},
+            {"name": "alpha", "_source": "community"},
+        ]
+        with mock.patch.object(install_skill, "load_manifest", return_value={}), \
+                mock.patch.object(install_skill, "_install_skill_record", return_value=True) as record:
+            install_skill.cmd_install(skills, self._args(all=True))
+        self.assertEqual(1, record.call_count)
+
+    def test_all_nonzero_exit_when_a_skill_fails(self):
+        """A failing skill makes the bulk install exit non-zero."""
+        skills = [{"name": "alpha", "_source": "community"}]
+        with mock.patch.object(install_skill, "load_manifest", return_value={}), \
+                mock.patch.object(install_skill, "_install_skill_record", return_value=False):
+            with self.assertRaises(SystemExit) as ctx:
+                install_skill.cmd_install(skills, self._args(all=True))
+        self.assertEqual(1, ctx.exception.code)
+
+    def test_missing_name_without_all_errors_with_guidance(self):
+        """Omitting the name without --all fails with a helpful message."""
+        import io
+        from contextlib import redirect_stdout
+
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            with self.assertRaises(SystemExit) as ctx:
+                install_skill.cmd_install([], self._args())
+        self.assertEqual(1, ctx.exception.code)
+        self.assertIn("--all", stream.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/integration/enterprise_agent_skill_repos.md
+++ b/docs/integration/enterprise_agent_skill_repos.md
@@ -48,12 +48,19 @@ see [devtools/README.md](../../devtools/README.md#recommended-no-admin-runbook-f
    ```
    macOS/Linux: `./install.sh`. This also puts the `neqsim` command on PATH
    (open a new terminal afterwards; or use `py -m neqsim_cli`).
+   > **In VS Code:** if running `neqsim` shows *"The term 'neqsim' is not
+   > recognized"*, a new integrated terminal is **not** enough — VS Code captures
+   > PATH at launch, so fully quit and reopen VS Code. (Installing into an
+   > activated virtualenv avoids this entirely.)
 3. **Install community agents & skills — no auth needed.** These are the default
    catalog and work immediately:
    ```powershell
-   neqsim agent install --all --vscode
-   neqsim skill install --all
+   neqsim agent install --all --vscode    # every agent + each agent's required skills
+   neqsim skill install --all --vscode    # every catalog skill (incl. standalone ones)
    ```
+   Each command prints a per-item progress list (`[1/N] <name>`) and an install
+   summary. `--vscode` also exports them to VS Code (reload/restart VS Code to
+   pick them up). To install just one: `neqsim skill install <name> --vscode`.
 4. **Connect the enterprise repos AND sign in, in one step.** `private-init --login`
    registers the private repo in your per-user catalog **and** launches browser
    SSO (`gh auth login --web`) — so SSO and repo registration happen together:

--- a/install.cmd
+++ b/install.cmd
@@ -7,9 +7,10 @@ REM with a "file is not digitally signed" / execution-policy error -- including
 REM locked-down machines where the execution policy is enforced by Group Policy
 REM (so even "powershell -ExecutionPolicy Bypass" is ignored).
 REM
-REM It finds a working Python (py launcher, python, or python3, skipping the
-REM Microsoft Store stub), bootstraps pip if needed, and installs the devtools
-REM package in editable mode -- exactly what install.ps1 does at its core.
+REM It finds a working Python (preferring an active virtualenv via python /
+REM python3, falling back to the py launcher, and skipping the Microsoft Store
+REM stub), bootstraps pip if needed, and installs the devtools package in
+REM editable mode -- exactly what install.ps1 does at its core.
 REM
 REM Usage (from the repo root, in cmd.exe or by double-clicking):
 REM     install.cmd                 :: install neqsim-dev-setup (editable)
@@ -41,12 +42,19 @@ echo NeqSim devtools installer (batch)
 echo Locating a working Python interpreter...
 
 REM ---- Find a Python that actually prints a version (skips the Store stub) ----
+REM Order matters: prefer interpreters that RESPECT an active virtualenv.
+REM `python` / `python3` resolve to the venv's python when a venv is activated
+REM (its Scripts dir is prepended to PATH), so the package -- and the `neqsim`
+REM console script -- install where the user expects. `py -3` is LAST because
+REM the py launcher IGNORES an active venv and would install into the system
+REM Python instead, putting the script in a per-user Scripts dir that the venv's
+REM PATH does not include. (install.ps1 uses the same ordering.)
 set "PY="
-call :try_python "py" "-3"
-if defined PY goto :found
 call :try_python "python" ""
 if defined PY goto :found
 call :try_python "python3" ""
+if defined PY goto :found
+call :try_python "py" "-3"
 if defined PY goto :found
 
 echo.
@@ -94,6 +102,9 @@ echo Done. Verify with:
 echo   %PY% -m neqsim_cli --help
 echo If the 'neqsim' command is not found in this window, open a NEW terminal
 echo (PATH changes only apply to newly opened terminals), or use the line above.
+echo If running 'neqsim' shows "The term 'neqsim' is not recognized" in a VS Code
+echo terminal, fully quit and reopen VS Code -- a new integrated terminal is NOT
+echo enough (VS Code captures PATH at launch). A virtualenv avoids this.
 exit /b 0
 
 :err_pip_boot

--- a/install.ps1
+++ b/install.ps1
@@ -171,6 +171,9 @@ Write-Host "Done. Verify with:" -ForegroundColor Green
 Write-Host "  $pythonDisplay -m neqsim_cli --help"
 Write-Host "If 'neqsim' is not found in this window, open a NEW terminal (PATH changes"
 Write-Host "only apply to newly opened terminals), or use the line above."
+Write-Host "If running 'neqsim' shows `"The term 'neqsim' is not recognized`" in a VS Code"
+Write-Host "terminal, fully quit and reopen VS Code - a new integrated terminal is NOT"
+Write-Host "enough (VS Code captures PATH at launch). A virtualenv avoids this."
 
 # ── JDK advisory (non-fatal) ─────────────────────────────────────────────
 # The Python devtools do not need Java, but building the NeqSim JAR


### PR DESCRIPTION
## Summary
Two fixes to the no-admin Windows onboarding flow, found while testing `install.cmd` + `neqsim skill install`.

### 1. Installer PATH / virtualenv handling
- **`devtools/ensure_on_path.py`** — target the **specific** Scripts directory this install used, instead of returning as soon as any `neqsim` resolves on PATH. On a machine with an elevated/all-users install already on the system PATH, the old `_already_on_path()` short-circuit skipped the per-user PATH update, so a later non-elevated `--user` install left `neqsim` unusable. Adds `_dir_on_path` / `_same_dir`; an active virtualenv's Scripts dir is not persisted to the user PATH.
- **`install.cmd`** — probe `python` / `python3` before `py -3`, so an **activated virtualenv is respected** (the `py` launcher ignores venvs and would install into the system Python). Matches `install.ps1`'s interpreter ordering.
- **Messages + docs** — `ensure_on_path.py`, `install.cmd`, `install.ps1`, `devtools/README.md` and `docs/integration/enterprise_agent_skill_repos.md` now explain, symptom-first, that after a `--user` install a **new VS Code integrated terminal is not enough** — VS Code captures PATH at launch, so fully quit and reopen it:
  > If running `neqsim` shows *"The term 'neqsim' is not recognized"* in a VS Code terminal, fully quit and reopen VS Code — a new integrated terminal is not enough (VS Code captures PATH at launch). A virtualenv avoids this.

### 2. `neqsim skill install --all`
The onboarding doc told users to run `neqsim skill install --all`, but `skill install` had no `--all` flag (only `agent install` did), so it errored: *"the following arguments are required: name"*.
- Add `--all` and `--source {all,community,private}` to `skill install`, mirroring `agent install`.
- Factor the single-install body into a bool-returning `_install_skill_record`; add `_install_all_skills` (dedup, source filter, `[i/N]` progress, install summary). Skill name is now optional with a friendly message. Single-install behaviour (used by the agent auto-skill-install path) is unchanged.
- Fix the onboarding doc command (`neqsim skill install --all --vscode`) and add expected-output notes.

## Testing
- New regression tests in `devtools/test_install_skill.py` (bulk install, source filter, dedup, non-zero exit on failure, friendly no-arg error). Full `test_install_skill.py` suite passes (27 tests).
- Verified live via the editable install: fresh-venv clean-room install (neqsim lands in the venv), non-venv `--user` PATH-add decision (non-destructive), and `neqsim skill install --all --source community` progress + summary.

No Java changed.
