### PR TITLE
fix(TPflash): collapse trivial two-phase splits to a single phase (fixes near-critical dew-point inflation)

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -43,6 +43,12 @@ public class TPflash extends Flash {
    * result to a single phase. Avoids false triggers from numerical noise.
    */
   private static final double SPURIOUS_MULTIPHASE_GIBBS_DROP_THRESHOLD_J = 1.0;
+  /**
+   * Maximum per-component mole-fraction difference below which two converged phases are treated as identical, i.e. a
+   * trivial (non-physical) split of the feed into two copies of itself. Genuine two-phase splits differ by far more
+   * than this even when the incipient phase fraction is tiny.
+   */
+  private static final double TRIVIAL_SPLIT_COMPOSITION_TOLERANCE = 1.0e-6;
   /** Guard preventing recursive rescue attempts while the local seed flash is running. */
   private static final ThreadLocal<Boolean> MULTIPHASE_RESCUE_ACTIVE = new ThreadLocal<Boolean>() {
     @Override
@@ -536,6 +542,12 @@ public class TPflash extends Flash {
           }
           system.init(1);
         }
+        // The multiphase flash above is run precisely because the single-phase stability test may
+        // miss a genuine second phase, so a real split found here must be preserved. Only remove a
+        // trivial split (two phases with essentially identical composition) — a non-physical
+        // solution of the flash equations. The Gibbs-based spurious rescue is intentionally NOT
+        // applied on this path, as it can discard a genuine split the stability test overlooked.
+        collapseTrivialMultiphaseSplit();
         return;
       }
     }
@@ -716,6 +728,7 @@ public class TPflash extends Flash {
     }
     rescueSinglePhaseMultiphaseEndpoint();
     rescueSpuriousMultiphaseEndpoint();
+    collapseTrivialMultiphaseSplit();
     normalizeActivePhaseFractions();
 
     // Final chemical equilibrium call after all phase reordering
@@ -1004,7 +1017,50 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Collapses the active phase set to the cached single-phase reference root.
+   * Collapses a converged two-phase result to a single phase when the two phases are essentially identical, i.e. a
+   * trivial solution of the flash equations.
+   *
+   * <p>
+   * Near the critical point and along the dew line a TP flash can converge to a trivial split in which both phases
+   * carry the overall feed composition (all K-values approximately unity, equal densities). Such a split has the same
+   * Gibbs energy as the single-phase feed, so {@link #rescueSpuriousMultiphaseEndpoint()} — which only collapses
+   * results whose Gibbs energy is strictly higher than the single-phase reference — does not catch it. Splitting a
+   * fluid into two identical copies is physically meaningless (it is a single phase), so this guard removes the
+   * artifact and keeps the reported phase boundary consistent with the phase-envelope saturation solver. Only the
+   * two-phase case is handled; genuine two-phase splits have compositionally distinct phases (even when the incipient
+   * phase fraction is tiny) and are left untouched. Skipped for chemical / electrolyte systems.
+   * </p>
+   */
+  private void collapseTrivialMultiphaseSplit() {
+    if (system.getNumberOfPhases() != 2 || !system.doMultiPhaseCheck() || referenceSinglePhaseType == null
+        || system.isChemicalSystem() || system.hasIons()) {
+      return;
+    }
+    neqsim.thermo.phase.PhaseInterface phaseA = system.getPhase(0);
+    neqsim.thermo.phase.PhaseInterface phaseB = system.getPhase(1);
+    int numberOfComponents = phaseA.getNumberOfComponents();
+    if (numberOfComponents <= 1) {
+      return;
+    }
+    double maxCompositionDifference = 0.0;
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      double difference = Math
+          .abs(phaseA.getComponent(componentIndex).getx() - phaseB.getComponent(componentIndex).getx());
+      if (difference > maxCompositionDifference) {
+        maxCompositionDifference = difference;
+      }
+    }
+    if (maxCompositionDifference >= TRIVIAL_SPLIT_COMPOSITION_TOLERANCE) {
+      return;
+    }
+    if (logger.isDebugEnabled()) {
+      logger.debug("Collapsing trivial two-phase split: max composition difference {} < {}", maxCompositionDifference,
+          TRIVIAL_SPLIT_COMPOSITION_TOLERANCE);
+    }
+    collapseToReferenceSinglePhase();
+  }
+
+  /**
    *
    * <p>
    * The collapse must not call {@code system.init(0)} because that method resets a

--- a/src/test/java/neqsim/pvtsimulation/simulation/SaturationPressureTest.java
+++ b/src/test/java/neqsim/pvtsimulation/simulation/SaturationPressureTest.java
@@ -33,4 +33,54 @@ class SaturationPressureTest extends neqsim.NeqSimTest {
     satPresSim.run();
     assertEquals(satPresSim.getThermoSystem().getPressure(), 126.195102691, 0.1);
   }
+
+  /**
+   * Regression test for the trivial-split dew-point artifact.
+   *
+   * <p>
+   * This near-critical retrograde gas (UMR-PRU, HV / UNIFAC_UMRPRU) has its upper dew point at 0 degC around 106.2
+   * bara. Above that pressure the TP flash can converge to a trivial split — two phases with essentially identical
+   * composition and density — which is a non-physical solution of the flash equations. Before the trivial-split
+   * collapse guard in {@code TPflash}, the saturation pressure search treated those identical-phase points as two-phase
+   * and returned a spurious value near 109 bara. The correct dew point is confirmed by the phase-envelope saturation
+   * solver (~105.9 bara). This test guards against reintroducing the regression.
+   * </p>
+   */
+  @Test
+  void testTrivialSplitDoesNotInflateDewPointPressure() {
+    double f = 0.6185035705566406;
+    SystemInterface fluid = new neqsim.thermo.system.SystemUMRPRUMCEos(273.15, 10.0);
+    fluid.addComponent("CO2", 0.016177945);
+    fluid.addComponent("nitrogen", 0.006857943);
+    fluid.addComponent("methane", 0.784699957);
+    fluid.addComponent("ethane", 0.095835435);
+    fluid.addComponent("propane", 0.058808079);
+    fluid.addComponent("i-butane", 0.007946427);
+    fluid.addComponent("n-butane", 0.018245426);
+    fluid.addComponent("i-pentane", 0.003795847);
+    fluid.addComponent("n-pentane", 0.003870575);
+    fluid.addComponent("2-m-C5", f * 0.000556670);
+    fluid.addComponent("3-m-C5", f * 0.000284215);
+    fluid.addComponent("n-hexane", f * 0.000755472);
+    fluid.addComponent("n-heptane", f * 0.000334932);
+    fluid.addComponent("c-hexane", f * 0.000783208);
+    fluid.addComponent("c-C7", f * 0.0002968081);
+    fluid.addComponent("benzene", f * 0.000156906);
+    fluid.addComponent("n-octane", f * 0.00006321321);
+    fluid.addComponent("toluene", f * 0.00007374866);
+    fluid.addComponent("c-C8", f * 0.00002366789);
+    fluid.addComponent("n-nonane", f * 0.00001558264);
+    fluid.addComponent("m-Xylene", f * 0.00002170802);
+    fluid.addComponent("nC10", f * 0.00001768925);
+    fluid.addComponent("nC11", f * 0.00000009800553);
+    fluid.addComponent("nC12", f * 0.0000004900277);
+    fluid.setMixingRule("HV", "UNIFAC_UMRPRU");
+    fluid.setTemperature(0.0, "C");
+
+    SaturationPressure satPresSim = new SaturationPressure(fluid);
+    satPresSim.run();
+
+    // Correct upper dew point ~106.2 bara; the trivial-split regression returned ~109 bara.
+    assertEquals(106.2, satPresSim.getSaturationPressure(), 1.0);
+  }
 }


### PR DESCRIPTION
## Summary

Fixes a regression in `TPflash` where, near the critical point / along the dew line, the flash could converge to a **trivial two-phase split** — two phases with essentially identical composition and density (all K‑values ≈ 1). Splitting a fluid into two identical copies of itself is a non‑physical solution of the flash equations (it is really a single phase), but the flash was accepting it as a genuine two‑phase result.

This inflated saturation‑pressure / dew‑point results for near‑critical **retrograde gases** (UMR‑PRU gas‑condensate), reporting dew points several bar too high.

## Root cause

A trivial split has the **same Gibbs energy** as the single‑phase feed, so the existing Gibbs‑based `rescueSpuriousMultiphaseEndpoint()` (added in #2219) — which only collapses a two‑phase result whose Gibbs energy is *strictly higher* than the single‑phase reference (`> 1 J`) — never triggered on it (ΔG ≈ 0). The identical‑phase split therefore survived, and the `SaturationPressure` bracket/bisection (which counts phases via `getNumberOfPhases()`) treated those points as two‑phase and returned a spurious, inflated pressure.

## Fix

Add `collapseTrivialMultiphaseSplit()`: after a two‑phase flash converges, if the two phases are compositionally identical to within `TRIVIAL_SPLIT_COMPOSITION_TOLERANCE` (`1e‑6` max per‑component mole‑fraction difference) the result is collapsed to the single‑phase reference root.

- It is invoked in **two** places: at the end of `runInternal()` and on the *single‑phase‑stable* early‑return path (where the internal `TPmultiflash` can re‑open the trivial split).
- On the single‑phase‑stable path **only** the trivial‑split guard is applied — the Gibbs‑based spurious rescue is intentionally **not** run there, because that path runs `TPmultiflash` precisely to recover a genuine second phase the single‑phase stability test may have missed.
- Genuine two‑phase splits (compositionally distinct phases) are left untouched, **even when the incipient phase fraction is tiny** (a true dew/bubble point). Skipped for chemical / electrolyte systems.

## Evidence (Njord‑A UMR‑PRU gas‑condensate, dew point at 0 °C)

| Method | dew‑point pressure |
|---|---|
| Phase envelope (Michelsen, robust reference) | **105.94 bara** |
| TP‑flash of two "phases" at 107 / 108 bara | identical phases: `densityRatio = 1.0000`, `max|K−1| = 0` (trivial) |
| `SaturationPressure` **before** fix | 109.02 bara ❌ (≈2.8 bar above the true dew point / cricondenbar‑inconsistent) |
| `SaturationPressure` **after** fix | **106.24 bara** ✅ |

The corrected value matches the phase‑envelope saturation solver and the historical (pre‑3.15.0) result.

## Validation

- New regression test `SaturationPressureTest.testTrivialSplitDoesNotInflateDewPointPressure` (UMR‑PRU retrograde gas) — **passes** (asserts ≈106.2 bara, not the spurious ≈109).
- `SaturationPressureTest` 2/2, `SaturationTemperatureTest` 2/2, `TPFlashTest` 14/14 — all pass. `TPFlashTest.testRun5` (a **genuine** methane/ethane/n‑pentane/nC16 split, β ≈ 0.104) is preserved, confirming genuine splits are not collapsed.
- End‑to‑end against the downstream NeqSimAPI `sphaseopt` models (jneqsim 3.15.0 with this jar):
  - **Njord‑A (NJA)**: dew‑point pressure `109.02 → 106.24` (now matches expected 106.238), cricondenbar and heavy‑tail tuning factor unchanged — **both integration tests pass**.
  - **AHA**: dew‑point pressure returns to **104.68** (the original pre‑3.15.0 value). The NeqSimAPI PR that bumped jneqsim to 3.15.0 had re‑baselined AHA to 104.44 to accommodate this bug; with this fix the downstream baseline should be reverted to 104.68.

## Notes

- No public API change; behavior change is confined to collapsing non‑physical identical‑phase splits.
- Also improves robustness of any workflow relying on near‑critical phase counting (dew/bubble‑point searches, retrograde‑gas flow assurance).
