### PR TITLE
Add health endpoints to MCP server for hosted deployments

### DIFF
--- a/neqsim-mcp-server/pom.xml
+++ b/neqsim-mcp-server/pom.xml
@@ -85,6 +85,14 @@
             <artifactId>quarkus-oidc</artifactId>
         </dependency>
 
+        <!-- SmallRye Health — Kubernetes-style liveness/readiness endpoints
+             (/q/health, /q/health/live, /q/health/ready) for hosted deployments
+             (e.g. Equinor Radix probes). Zero effect on STDIO / desktop use. -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
## What

Adds `quarkus-smallrye-health` to `neqsim-mcp-server/pom.xml` (managed by the Quarkus BOM, no version pin). The container then exposes:

- `/q/health` — overall status
- `/q/health/live` — liveness probe
- `/q/health/ready` — readiness probe

## Why

Preparing a hosted deployment of the MCP server on Equinor Radix (remote streamable-HTTP endpoint, follow-up to #2398). Kubernetes-style platforms need liveness/readiness probes to manage the container; the image currently has no health endpoint.

## Verification (2026-07-08, local build on JDK 21)

- `/q/health` → `{"status":"UP"}`; `/q/health/live` and `/q/health/ready` → 200
- `/mcp` initialize → 200 on the same container (routes coexist, MCP unaffected)
- STDIO transport unaffected (the extension only adds HTTP routes)

## Note for the release

Like #2398, the published image picks this up on the next `mcp_server_release.yml` **workflow_dispatch** (push-to-master builds the jar but skips the Docker push).

_(Replaces #2399, which was from a fork and couldn't satisfy master's branch protection.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)