### PR TITLE
chore(vscode): disable Java format-on-save to defer to Spotless

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,18 +25,31 @@
 		}
 	},
 	// Run after container creation: compile Java, install dev tools and dependencies
-	"postCreateCommand": "export PATH=\"$HOME/.local/bin:$PATH\" && chmod +x ./mvnw && ./mvnw compile && pip install --user matplotlib pandas numpy python-docx || true && pip install --user -e devtools/ || true && echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc",
+	"postCreateCommand": "export PATH=\"$HOME/.local/bin:$PATH\" && chmod +x ./mvnw && ./mvnw compile && pip install --user matplotlib pandas numpy python-docx || true && pip install --user -e devtools/ || true && (pip install --user pre-commit && pre-commit install) || true && echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc",
 	"customizations": {
 		"vscode": {
 			"settings": {
 				// Java settings
 				"java.configuration.updateBuildConfiguration": "automatic",
 				"java.compile.nullAnalysis.mode": "automatic",
-				"java.format.settings.url": "neqsim_formatter.xml",
+				"java.format.settings.url": "${workspaceFolder}/.config/neqsim_formatter.xml",
+				"java.format.settings.profile": "neqsim_formatter",
 				"java.checkstyle.configuration": "${workspaceFolder}/.config/checkstyle_neqsim.xml",
 				"java.test.defaultConfig": "default",
 				// Editor settings
 				"editor.formatOnSave": true,
+				// Java formatting is owned by Spotless (Eclipse 4.35, .config/neqsim_formatter.xml),
+				// enforced by the spotless-apply pre-commit hook and the spotless:check CI gate. The
+				// Red Hat Java extension bundles a different Eclipse JDT engine that diverges from
+				// Spotless even with the same profile, so format-on-save is disabled for Java to avoid
+				// spurious working-tree diffs. Organize-imports on save is kept (Spotless does not
+				// manage imports). Mirrors .vscode/settings.json so behaviour matches in Codespaces.
+				"[java]": {
+					"editor.formatOnSave": false,
+					"editor.codeActionsOnSave": {
+						"source.organizeImports": "explicit"
+					}
+				},
 				"editor.rulers": [
 					120
 				],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,11 +3,20 @@
   "java.configuration.updateBuildConfiguration": "automatic",
   "java.compile.nullAnalysis.mode": "automatic",
   "[java]": {
+    // Organize imports on save (Spotless does NOT manage imports, and checkstyle flags unused ones).
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"
     },
+    // Formatting authority for Java in this repo is Spotless (Eclipse formatter 4.35,
+    // .config/neqsim_formatter.xml), enforced by the Maven `spotless:check` CI gate and the
+    // `spotless-apply` pre-commit hook. The Red Hat Java extension bundles a DIFFERENT Eclipse JDT
+    // engine that, even with the same profile, formats some constructs differently (e.g. collapses
+    // empty method bodies to `{}`). Leaving formatOnSave on therefore rewrites files into a state
+    // Spotless rejects, producing spurious working-tree diffs. It is disabled here so Spotless is
+    // the single source of truth — run `./mvnw spotless:apply` (or just commit; the pre-commit hook
+    // applies it automatically).
+    "editor.formatOnSave": false,
     "editor.defaultFormatter": "redhat.java",
-    "editor.formatOnSave": true,
     "editor.tabSize": 2,
     "editor.insertSpaces": true,
     "editor.detectIndentation": false


### PR DESCRIPTION
## Problem

`.vscode/settings.json` enabled `editor.formatOnSave` for Java using the Red Hat Java extension, pointed at the repo Eclipse profile (`.config/neqsim_formatter.xml`).

However, the Java extension bundles a **different Eclipse JDT formatter version** than Spotless (which pins Eclipse **4.35** in `pom.xml`). Even with the same profile, the two engines format some constructs differently — e.g. the editor collapses an empty constructor body to `public TPflash() {}` while Spotless 4.35 keeps `public TPflash() {\n}`.

Result: saving a Java file rewrote it into a state `spotless:check` **rejects**, producing spurious working-tree diffs (a file looking "dirty" right after saving) and risking a red CI spotless gate.

## Fix

Disable `editor.formatOnSave` for Java and make **Spotless the single source of truth**. Safe and lossless because Spotless already runs automatically:
- `spotless-apply` **pre-commit hook** reformats staged Java on every commit, and
- `spotless:check` runs on **pre-push** and in **CI**.

`source.organizeImports` on save is **kept** — Spotless does not manage imports (no importOrder/removeUnusedImports step) and checkstyle flags unused imports.

## Effect

- No more spurious "dirtied" Java files after saving.
- Contributors format via `./mvnw spotless:apply`, or just commit (pre-commit hook applies it).
- No change to the formatting profile itself — only which tool applies it.