### PR TITLE
fix(splitter): splitter fails when setting outlet flowrate higher than inlet with residual

### DIFF
--- a/src/test/java/neqsim/process/equipment/splitter/SplitterTest.java
+++ b/src/test/java/neqsim/process/equipment/splitter/SplitterTest.java
@@ -136,12 +136,11 @@ class SplitterTest {
   }
 
   @Test
-  void testFlowRatesOverRequestMassBalanceFails() {
+  void testFlowRatesOverRequestScalesDownAndConservesMass() {
     // inlet = 10 MSm3/day; requesting 12 out of outlet 0 with a remainder outlet is
-    // unphysical (remainder would be negative). Mass must be conserved (outlets should
-    // sum to the inlet flow rate) regardless of the requested split, but this
-    // over-requested configuration does not add up. This test documents the current
-    // mass-balance failure for this input and is expected to fail.
+    // unphysical on its own (the remainder would be negative). Rather than throwing or
+    // silently zeroing outlets, the fixed outlet rate is scaled down proportionally
+    // (12 -> 10) so the remainder outlet gets 0 and total mass is still conserved.
     Splitter splitter = new Splitter("splitter", inletStream, 2);
     splitter.setFlowRates(new double[] { 12.0, -1.0 }, "MSm3/day");
     splitter.run();
@@ -150,8 +149,12 @@ class SplitterTest {
     double split0Moles = splitter.getSplitStream(0).getThermoSystem().getTotalNumberOfMoles();
     double split1Moles = splitter.getSplitStream(1).getThermoSystem().getTotalNumberOfMoles();
 
+    // The over-requested outlet is capped at the full inlet flow; the remainder gets nothing.
+    assertEquals(1.0, splitter.getSplitFactor(0), 1e-6);
+    assertEquals(0.0, splitter.getSplitFactor(1), 1e-6);
+    // Mass must still be conserved.
     assertEquals(inletMoles, split0Moles + split1Moles, inletMoles * 1e-4,
-        "Mass balance does not hold when requested outlet flow rate exceeds inlet flow rate");
+        "Mass balance must hold even when the requested outlet flow rate exceeds the inlet flow rate");
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/splitter/SplitterTest.java
+++ b/src/test/java/neqsim/process/equipment/splitter/SplitterTest.java
@@ -119,6 +119,42 @@ class SplitterTest {
   }
 
   @Test
+  void testFlowRatesWithFeasibleRemainder() {
+    // inlet = 10 MSm3/day; outlet 0 fixed at 6, outlet 1 (= -1) gets the 4 remainder.
+    Splitter splitter = new Splitter("splitter", inletStream, 2);
+    splitter.setFlowRates(new double[] { 6.0, -1.0 }, "MSm3/day");
+    splitter.run();
+
+    double inletMoles = inletStream.getThermoSystem().getTotalNumberOfMoles();
+    double split0Moles = splitter.getSplitStream(0).getThermoSystem().getTotalNumberOfMoles();
+    double split1Moles = splitter.getSplitStream(1).getThermoSystem().getTotalNumberOfMoles();
+
+    assertEquals(0.6, splitter.getSplitFactor(0), 1e-6);
+    assertEquals(0.4, splitter.getSplitFactor(1), 1e-6);
+    // Mass must be conserved.
+    assertEquals(inletMoles, split0Moles + split1Moles, inletMoles * 1e-4);
+  }
+
+  @Test
+  void testFlowRatesOverRequestMassBalanceFails() {
+    // inlet = 10 MSm3/day; requesting 12 out of outlet 0 with a remainder outlet is
+    // unphysical (remainder would be negative). Mass must be conserved (outlets should
+    // sum to the inlet flow rate) regardless of the requested split, but this
+    // over-requested configuration does not add up. This test documents the current
+    // mass-balance failure for this input and is expected to fail.
+    Splitter splitter = new Splitter("splitter", inletStream, 2);
+    splitter.setFlowRates(new double[] { 12.0, -1.0 }, "MSm3/day");
+    splitter.run();
+
+    double inletMoles = inletStream.getThermoSystem().getTotalNumberOfMoles();
+    double split0Moles = splitter.getSplitStream(0).getThermoSystem().getTotalNumberOfMoles();
+    double split1Moles = splitter.getSplitStream(1).getThermoSystem().getTotalNumberOfMoles();
+
+    assertEquals(inletMoles, split0Moles + split1Moles, inletMoles * 1e-4,
+        "Mass balance does not hold when requested outlet flow rate exceeds inlet flow rate");
+  }
+
+  @Test
   void testGetSplitNumber() {
     Splitter splitter = new Splitter("splitter", inletStream, 4);
     assertEquals(4, splitter.getSplitNumber());


### PR DESCRIPTION
# Pull Request

Thank you for contributing to NeqSim! Please complete the following checklist before requesting review:

- [ ] Confirm `./mvnw test` runs successfully
- [ ] Verify code formatting using Checkstyle
- [ ] Update any relevant docs/README
- [ ] Link to an associated issue or discussion

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution process.
