### PR TITLE
Run MCP server container as non-root user

### DIFF
--- a/neqsim-mcp-server/Dockerfile
+++ b/neqsim-mcp-server/Dockerfile
@@ -21,5 +21,9 @@ WORKDIR /app
 
 COPY target/neqsim-mcp-server-*-runner.jar /app/server.jar
 
+# Kubernetes platforms (e.g. Equinor Radix) enforce runAsNonRoot and need a
+# numeric UID to verify it — a root image is refused admission.
+USER 1001:1001
+
 # STDIO transport — stdin/stdout for JSON-RPC, stderr for logs
 ENTRYPOINT ["java", "-jar", "/app/server.jar"]


### PR DESCRIPTION
# Pull Request

Adds a numeric non-root `USER` (1001:1001) to the `neqsim-mcp-server` Dockerfile.

**Why:** Kubernetes platforms that enforce `runAsNonRoot` — including Equinor Radix, where the MCP server is being piloted — refuse to schedule the published image because it currently runs as root. The admission check also requires a *numeric* UID, so `USER 1001:1001` rather than a named user.

**Scope:** Dockerfile only — no Java code, no behavior change for local/STDIO use (Docker still runs the image fine; this only satisfies hardened-cluster admission).

**Verification (local, on this branch):**
- `docker build` succeeds; `docker inspect` shows `User: 1001:1001`
- Container boots healthy as uid 1001 (`/q/health` → UP in ~6 s)
- Real MCP session as uid 1001: `initialize` → `tools/list` (68 tools) → `runFlash` SRK TP-flash returns a correct result; zero filesystem permission errors in the logs
- Also validated against the *published* image with `docker run --user 1001:1001` — identical behavior, confirming no hidden root-only writable paths

- [x] Confirm `./mvnw test` runs successfully — no Java changes; Dockerfile-only
- [x] Verify code formatting using Checkstyle — n/a (no Java changes)
- [x] Update any relevant docs/README — none affected
- [x] Link to an associated issue or discussion — follow-up to #2398/#2403 (hosting the MCP server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)