### PR TITLE
Compressor deposit fouling degradation and online washing

### DIFF
--- a/.github/agents/flow.assurance.agent.md
+++ b/.github/agents/flow.assurance.agent.md
@@ -12,6 +12,14 @@ Perform flow assurance analyses — hydrate, wax, asphaltene, corrosion, hydraul
 For fast liquid-line hydraulic surge, pump-trip, or valve-closure cases, load
 `neqsim-water-hammer` and use `WaterHammerStudy` / MCP `runWaterHammer` to screen
 pressure envelopes before recommending detailed surge analysis.
+For deposits reaching a compressor (elemental sulfur S8, salt from entrained produced
+water, mineral scale, wax) that foul the impeller, use the
+`neqsim.process.equipment.compressor` deposit model (`CompressorDeposit`,
+`SolidFlashDepositSource`, `EntrainedSaltDepositSource`, `CompressorDepositProfile`,
+`WashFluid`, `CompressorDepositWash`) to compute deposit amount, head/efficiency loss, the
+degraded chart after N hours, per-impeller deposit location, and to plan/recommend online
+washing (water for salt, xylene for S8). Full API in the `neqsim-api-patterns` skill and the
+`compressor_deposit_degradation` doc.
 
 ## Applicable Standards (MANDATORY)
 

--- a/.github/agents/root.cause.agent.md
+++ b/.github/agents/root.cause.agent.md
@@ -47,6 +47,15 @@ Map the user's description to a `Symptom` enum value:
 | "noise", "rattling" | `Symptom.ABNORMAL_NOISE` |
 | "liquid in gas", "carryover" | `Symptom.LIQUID_CARRYOVER` |
 
+> **Compressor fouling / efficiency loss:** when the root cause is deposits (elemental
+> sulfur S8, salt from entrained produced water, mineral scale, wax) fouling a compressor,
+> quantify it with the `neqsim.process.equipment.compressor` deposit model:
+> `CompressorDeposit` (deposit mass → head/efficiency loss), `SolidFlashDepositSource` /
+> `EntrainedSaltDepositSource` (deposit amount from the process), `CompressorDepositProfile`
+> (which impeller), `comp.buildDegradedChart()` (map after N hours), and
+> `CompressorDepositWash` (recommend a wash fluid and plan online washing to confirm
+> recovery). See the `neqsim-flow-assurance` / `neqsim-api-patterns` skills.
+
 ### Step 2: Gather Data
 
 1. **Historian data**: Use `neqsim-plant-data` skill to read time-series from PI/IP.21

--- a/.github/skills/neqsim-api-patterns/SKILL.md
+++ b/.github/skills/neqsim-api-patterns/SKILL.md
@@ -279,6 +279,56 @@ Stream out = comp.getOutletStream();
 // After run: comp.getPower("kW")
 ```
 
+### Compressor deposit / fouling degradation and washing
+
+Model deposit (fouling) mass from process thermodynamics, its effect on
+performance, where it lands per impeller, the degraded chart after N hours, and
+online washing. Package `neqsim.process.equipment.compressor`. See the
+[Compressor Deposit and Performance Degradation](../../docs/process/compressor_deposit_degradation.md)
+doc.
+
+```java
+// 1) Deposit mass -> performance effect (combine several mechanisms)
+CompressorDeposit dep = CompressorDeposit.fromCompressor(comp); // sizes foulable geometry
+dep.addDeposit(DepositMechanism.SULFUR_S8, 1.2);   // kg (S8 study)
+dep.addDeposit(DepositMechanism.SALT_NACL, 0.4);   // kg (salt study)
+comp.setDepositModel(dep);                          // run() now degrades efficiency/power
+comp.run();
+double effLoss = 1.0 - dep.getEfficiencyMultiplier();
+
+// 2) Deposit mass FROM the process (precipitation bridge)
+SolidFlashDepositSource s8 =
+    new SolidFlashDepositSource(feed, "S8", DepositMechanism.SULFUR_S8, 0.3); // TPSolidflash
+EntrainedSaltDepositSource salt =
+    new EntrainedSaltDepositSource(10.0, 0.05);     // 10 kg/hr entrained water, 5 wt% salt
+dep.accumulate(s8, 500.0);                          // deposit after 500 operating hours
+dep.accumulate(salt, 500.0);
+
+// 3) Degraded performance chart after N hours (chart-based machines)
+CompressorChart chart500 = comp.buildDegradedChart();
+
+// 4) Where deposits form (per impeller). Rigorous = real per-step flashed states:
+comp.setPolytropicMethod("detailed");
+comp.getPropertyProfile().setActive(true);
+comp.run();
+List<CompressorDepositProfile.StageDeposit> profile =
+    CompressorDepositProfile.computeFromPropertyProfile(comp, 5, "S8");
+int worst = CompressorDepositProfile.worstStage(profile); // 1 = cold first impeller
+
+// 5) Online washing: recommend fluid, plan rate, simulate removal
+WashFluid fluid = CompressorDepositWash.recommend(dep);   // salt->WATER, S8->XYLENE
+CompressorDepositWash washer = new CompressorDepositWash();
+washer.setContactEfficiency(0.7);
+double rateKgHr = washer.requiredFluidRateKgHr(dep, fluid, 2.0, 3.0); // remove 2 kg in 3 h
+CompressorDepositWash.WashResult r = comp.washOnline(fluid, rateKgHr, 3.0);
+comp.run();                                               // performance recovers
+```
+
+Wash-fluid → deposit matching (screening solubilities): water dissolves salt/scale;
+xylene/toluene dissolve S8 and wax; condensate dissolves wax; methanol moderate salt.
+`recommend()` returns the fluid that removes the most mass — for mixed salt+S8 fouling,
+wash in sequence (water, then xylene).
+
 ### Cooler / Heater
 
 ```java

--- a/.github/skills/neqsim-flow-assurance/SKILL.md
+++ b/.github/skills/neqsim-flow-assurance/SKILL.md
@@ -497,6 +497,28 @@ String worst = mix.getWorstMineral();          // e.g. BaSO4
 Deposition along a line: `ScaleDepositionAccumulator` (walks a `PipeBeggsAndBrills`),
 or the coupled corrosion+scale `PipeSegmentIntegrity` above.
 
+### Deposits on compressors (fouling → performance loss → washing)
+
+When deposit-forming species (elemental sulfur S8, salt from entrained produced
+water, mineral scale, wax) reach a compressor, they foul the impeller and reduce
+head/efficiency. The `neqsim.process.equipment.compressor` deposit model bridges
+these flow-assurance calculations to compressor performance and washing:
+
+```java
+CompressorDeposit dep = CompressorDeposit.fromCompressor(comp);
+dep.accumulate(new SolidFlashDepositSource(feed, "S8", DepositMechanism.SULFUR_S8, 0.3), 500.0);
+dep.accumulate(new EntrainedSaltDepositSource(10.0, 0.05), 500.0); // entrained brine -> salt
+comp.setDepositModel(dep);            // run() degrades efficiency/power
+CompressorChart chart500 = comp.buildDegradedChart();               // map after 500 h
+WashFluid wash = CompressorDepositWash.recommend(dep);              // salt->WATER, S8->XYLENE
+comp.washOnline(wash, 300.0, 3.0);    // online wash removes matching deposits
+```
+
+Per-impeller deposit location: `CompressorDepositProfile.compute(...)` /
+`computeFromPropertyProfile(...)`. Full API in the `neqsim-api-patterns` skill and the
+`compressor_deposit_degradation` doc. Use this to plan sulfur/salt washing of fouled
+compressors and to recommend a wash fluid.
+
 ## 6. Thermal Analysis
 
 ### Cooldown Calculation

--- a/docs/REFERENCE_MANUAL_INDEX.md
+++ b/docs/REFERENCE_MANUAL_INDEX.md
@@ -313,6 +313,7 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 | Compressor Anti-Surge Control | [docs/process/equipment/compressor_antisurge_control.md](process/equipment/compressor_antisurge_control) | Dynamic anti-surge recycle, pressure-speed control, predictive supervision, coordinated override philosophy, and application-design scan logic |
 | Compressor Design | [docs/process/CompressorMechanicalDesign.md](process/CompressorMechanicalDesign)               | Compressor mechanical design                      |
 | Compressor Feasibility | [docs/process/compressor_design_feasibility.md](process/compressor_design_feasibility) | Feasibility report: mechanical, cost, suppliers, curves |
+| Compressor Deposit / Degradation | [docs/process/compressor_deposit_degradation.md](process/compressor_deposit_degradation) | Mass-based fouling (S8, salt, scale, wax) → head/efficiency loss, degraded chart, per-impeller deposit location |
 | Pumps             | [docs/process/equipment/pumps.md](process/equipment/pumps)                                     | Pump models                                       |
 | Pump Guide        | [docs/wiki/pump_usage_guide.md](wiki/pump_usage_guide)                                         | Pump usage guide                                  |
 | Pump Theory       | [docs/wiki/pump_theory_and_implementation.md](wiki/pump_theory_and_implementation)             | Pump theory                                       |

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -174,6 +174,7 @@ This documentation is organized into the following sections:
 | Separators | [separators.md](equipment/separators) | Separator, ThreePhaseSeparator, GasScrubber |
 | Heat Exchangers | [heat_exchangers.md](equipment/heat_exchangers) | Heater, Cooler, HeatExchanger |
 | Compressors | [compressors.md](equipment/compressors) | Compressor, CompressorChart, CompressorWashing |
+| Compressor Deposit / Degradation | [compressor_deposit_degradation.md](compressor_deposit_degradation) | CompressorDeposit, DepositMechanism, DepositSource, CompressorDepositProfile, WashFluid, CompressorDepositWash |
 | Compressor Anti-Surge Control | [compressor_antisurge_control.md](equipment/compressor_antisurge_control) | AntiSurgeController, CompressorMonitor, ThrottlingValve, Recycle |
 | Pumps | [pumps.md](equipment/pumps) | Pump, PumpChart |
 | Expanders | [expanders.md](equipment/expanders) | Expander, TurboExpanderCompressor |

--- a/docs/process/compressor_deposit_degradation.md
+++ b/docs/process/compressor_deposit_degradation.md
@@ -1,0 +1,248 @@
+---
+title: "Compressor Deposit and Performance Degradation"
+description: "Mass-based compressor fouling model that combines deposit-generating calculations (elemental sulfur, salt from entrained water, mineral scale, wax) to compute deposit amount, its effect on polytropic head and efficiency, a degraded performance chart after N operating hours, where deposits form across the impellers, and online (live) washing to plan, recommend a wash fluid, and simulate deposit removal."
+---
+
+# Compressor Deposit and Performance Degradation
+
+This model links **deposit-generating process calculations** (elemental sulfur drop-out,
+salt from entrained produced water, mineral scale, wax, corrosion products) to
+**centrifugal compressor performance**. It answers three questions:
+
+1. **How much deposit** accumulates (from one or several mechanisms combined)?
+2. **What is the effect on performance** — polytropic efficiency, head, power, discharge
+   temperature, and the degraded compressor chart after `N` operating hours?
+3. **Where do the deposits form** — which impeller / stage?
+
+All deposit-to-performance relations are screening-level and the coefficients are exposed
+for calibration to measured (e.g. root-cause-analysis) degradation points.
+
+## Components
+
+| Class | Purpose |
+|-------|---------|
+| `DepositMechanism` | Deposit types (S8, NaCl, CaCO3/BaSO4/CaSO4, FeS, wax, ...) each with a solid density |
+| `CompressorDeposit` | Mass-based, multi-mechanism deposit inventory → efficiency and head multipliers |
+| `DepositSource` | Interface: a precipitation calculation that yields a deposition rate |
+| `SolidFlashDepositSource` | Deposition rate from a `TPSolidflash` (S8, wax) on a stream |
+| `EntrainedSaltDepositSource` | Salt precipitation from evaporating entrained produced water |
+| `CompressorDepositProfile` | Per-impeller deposit location along the compression path |
+| `CompressorChart.getDegradedChart(...)` | Scaled (degraded) performance map |
+| `WashFluid` | Wash fluids (water, xylene, toluene, condensate, methanol) with deposit solubilities |
+| `CompressorDepositWash` | Recommend a wash fluid, plan the rate/duration, simulate the wash |
+
+## 1. Deposit mass to performance effect
+
+`CompressorDeposit` converts an accumulated deposit **mass** to a fractional flow-area
+blockage and hence to a polytropic efficiency multiplier and a head multiplier:
+
+$$
+V = \sum_i \frac{m_i}{\rho_i}, \quad t = \frac{V}{A_\text{wetted}}, \quad
+b = \min\!\left(\frac{t}{h_\text{passage}},\, b_\text{max}\right)
+$$
+
+$$
+m_\text{eff} = \max\!\left(1 - k_\text{eff}\, b,\ m_\text{eff,min}\right), \qquad
+m_\text{head} = \max\!\left((1-b)^{n_\text{head}},\ m_\text{head,min}\right)
+$$
+
+where $m_i$ / $\rho_i$ are the deposit mass and density of each mechanism, $A_\text{wetted}$
+is the foulable impeller area, $h_\text{passage}$ the flow-passage half-height, and the
+default coefficients are $k_\text{eff} = 1.6$ and $n_\text{head} = 2$.
+
+```java
+// Size the foulable geometry from the compressor inlet flow, then add deposits.
+CompressorDeposit dep = CompressorDeposit.fromCompressor(compressor);
+dep.addDeposit(DepositMechanism.SULFUR_S8, 1.2);   // kg from a sulfur study
+dep.addDeposit(DepositMechanism.SALT_NACL, 0.4);   // kg from a salt study
+
+double effLoss  = 1.0 - dep.getEfficiencyMultiplier(); // fractional efficiency loss
+double headLoss = 1.0 - dep.getHeadMultiplier();       // fractional head loss
+double blockage = dep.getAreaBlockageFraction();
+```
+
+Calibrate to measured degradation:
+
+```java
+dep.setEfficiencyBlockageCoefficient(1.6); // tune k_eff
+dep.setHeadBlockageExponent(2.0);          // tune n_head
+// Inverse: how much S8 deposit is consistent with a measured efficiency multiplier?
+double kg = dep.depositMassForEfficiencyMultiplier(DepositMechanism.SULFUR_S8, 0.77);
+```
+
+### Applying degradation to the simulation
+
+Attaching the deposit model makes `run()` use the degraded machine — for a fixed outlet
+pressure the polytropic efficiency drops, so power and discharge temperature rise:
+
+```java
+compressor.setPolytropicEfficiency(0.78);   // clean design efficiency
+compressor.setDepositModel(dep);            // degradation now applied in run()
+compressor.run();
+
+double degradedEff = compressor.getPolytropicEfficiency(); // < 0.78
+double power       = compressor.getPower();                // higher than clean
+compressor.setDepositModel(null);           // restore clean machine
+```
+
+The degradation is applied from a fixed clean baseline, so repeated `run()` calls do not
+compound it.
+
+## 2. Deposit amount from the process (precipitation bridge)
+
+Instead of supplying the deposit mass by hand, compute it from the process thermodynamics.
+A `DepositSource` turns a precipitation calculation into a deposition rate, and
+`CompressorDeposit.accumulate(source, hours)` integrates it over an operating interval.
+
+### Elemental sulfur (and wax) — solid flash
+
+```java
+// S8 carried in the (entrained-liquid-bearing) compressor feed drops out on flash.
+SolidFlashDepositSource s8 =
+    new SolidFlashDepositSource(feed, "S8", DepositMechanism.SULFUR_S8, 0.3); // 30% capture
+double s8Rate = s8.getPrecipitationRate("kg/hr"); // thermodynamic drop-out rate
+dep.accumulate(s8, 500.0);                          // deposit after 500 h
+```
+
+### Salt from entrained produced water — mass balance
+
+Salt (e.g. NaCl) is non-volatile, so it precipitates when entrained brine droplets dry out
+in the hot compressed gas:
+
+```java
+EntrainedSaltDepositSource salt =
+    new EntrainedSaltDepositSource(10.0, 0.05); // 10 kg/hr entrained water, 5 wt% salt
+// Optionally estimate the evaporated water fraction from the actual duty:
+double evap = EntrainedSaltDepositSource
+    .estimateWaterEvaporatedFraction(feed, dischargeT_C, dischargeP_bara);
+salt.setEvaporatedFraction(evap);
+salt.setCaptureFraction(0.5);
+dep.accumulate(salt, 500.0);
+```
+
+Model the entrainment upstream by mixing the carried-over liquid into the compressor feed
+(or via an imperfect separator efficiency); the flash then determines what precipitates.
+
+## 3. Degraded chart after N operating hours
+
+For a chart-based (fixed-speed) machine, degradation is applied through a **degraded chart**
+whose head and efficiency curves are scaled by the deposit multipliers:
+
+```java
+compressor.setCompressorChart(cleanChart);
+compressor.setDepositModel(dep);            // dep accumulated over 500 h
+
+CompressorChart chart500 = compressor.buildDegradedChart(); // map after 500 h
+double head500 = chart500.getPolytropicHead(flow, speed);       // reduced head
+double eff500  = chart500.getPolytropicEfficiency(flow, speed); // reduced efficiency
+```
+
+`CompressorChart.getDegradedChart(headMultiplier, efficiencyMultiplier)` can also be called
+directly. When a chart is in use, the run-time efficiency multiplier is not additionally
+applied, so the efficiency loss is never double-counted.
+
+## 4. Where the deposits form (per-impeller location)
+
+Deposition happens where the local pressure and temperature cross the solubility limit. In a
+single compressor body the temperature rises from suction to discharge, so a
+solubility-limited species such as S8 concentrates on the **cold first impeller** and
+re-dissolves toward the hot last impeller; across a multi-stage train the gas re-cools in
+each intercooler and can re-deposit on the first impeller after each cooler.
+
+Screening (interpolated stage pressure and temperature):
+
+```java
+List<CompressorDepositProfile.StageDeposit> profile =
+    CompressorDepositProfile.compute(feed, dischargeT_C, dischargeP_bara, 5, "S8");
+int worst = CompressorDepositProfile.worstStage(profile); // usually 1 for a single body
+for (CompressorDepositProfile.StageDeposit s : profile) {
+  // s.getStage(), s.getPressureBara(), s.getTemperatureC(), s.getSolidRateKgHr()
+}
+```
+
+Rigorous (uses the compressor's real per-step flashed fluid states):
+
+```java
+compressor.setPolytropicMethod("detailed");
+compressor.getPropertyProfile().setActive(true);
+compressor.run();
+List<CompressorDepositProfile.StageDeposit> profile =
+    CompressorDepositProfile.computeFromPropertyProfile(compressor, 5, "S8");
+```
+
+## 5. Live (online) washing — plan, recommend, and simulate
+
+Washing removes deposit by **dissolving** it in a wash fluid. The `WashFluid` enum carries a
+screening solubility of each deposit mechanism, so a fluid only removes the deposits it can
+dissolve: **water** dissolves salt but not sulfur; **xylene/toluene** dissolve sulfur and
+wax but not salt; **condensate** dissolves wax. `CompressorDepositWash` uses this to
+**recommend** a fluid, **plan** the rate/duration, and **simulate** the wash.
+
+$$
+\text{removed}_m = \min\!\big(\text{deposit}_m,\ \dot m_\text{fluid}\, S_m\, \eta_\text{contact}\, \Delta t\big)
+$$
+
+where $S_m$ is the solubility (kg deposit / kg fluid) and $\eta_\text{contact}$ the contact
+efficiency (lower for online washing).
+
+### Recommend a wash fluid
+
+```java
+WashFluid fluid = CompressorDepositWash.recommend(deposit);
+// salt-dominated -> WATER; sulfur-dominated -> XYLENE/TOLUENE; wax -> CONDENSATE
+```
+
+### Plan the wash
+
+```java
+CompressorDepositWash washer = new CompressorDepositWash();
+washer.setContactEfficiency(0.7);                        // online wash, imperfect contact
+
+double rate = washer.requiredFluidRateKgHr(deposit, fluid, 4.0, 2.0); // 4 kg in 2 h
+double hours = washer.hoursToRemoveMass(deposit, fluid, 200.0, 4.0);  // at 200 kg/hr
+double dissRate = washer.dissolutionRateKgHr(deposit, fluid, 200.0);  // kg deposit/hr
+```
+
+### Simulate the wash (updates the deposit model in place)
+
+```java
+CompressorDepositWash.WashResult result = washer.wash(deposit, fluid, 200.0, 2.0);
+result.getTotalRemovedKg();
+result.getRemovedKg();                       // per mechanism
+result.getEfficiencyMultiplierBefore();      // -> getEfficiencyMultiplierAfter()
+result.getHeadMultiplierBefore();            // -> getHeadMultiplierAfter()
+result.getRemainingDepositKg();
+```
+
+### Online wash of a running compressor
+
+```java
+compressor.setDepositModel(deposit);
+WashFluid best = CompressorDepositWash.recommend(deposit);
+CompressorDepositWash.WashResult r = compressor.washOnline(best, 300.0, 3.0);
+compressor.run();   // power/discharge temperature recover toward clean
+```
+
+### Recommending a wash strategy for mixed deposits
+
+For mixed salt + sulfur fouling, a single fluid cannot remove everything — plan a sequence
+(e.g. water for the salt, then xylene for the sulfur). `recommend` returns the fluid that
+removes the most mass first; re-run it after each wash to plan the next step.
+
+## Scope and limitations
+
+- Deposit-to-performance relations are screening-level; calibrate `kEff` / `headExponent`
+  to measured degradation before quantitative use.
+- The screening `compute` interpolates stage pressure geometrically and temperature linearly;
+  `computeFromPropertyProfile` uses the rigorous per-step fluid states instead.
+- Salt precipitation uses a non-volatile mass balance (robust, avoids solid-salt electrolyte
+  convergence); for rigorous solid-salt equilibrium use the electrolyte-CPA scale tools.
+- Capture fractions (how much precipitated solid sticks to the impeller) are user inputs.
+- Wash-fluid deposit solubilities and contact efficiency are screening values; qualify a wash
+  solvent with a laboratory test before field use.
+
+## Related documentation
+
+- [Compressor Design Feasibility Report](compressor_design_feasibility.md)
+- [Compressor Mechanical Design](CompressorMechanicalDesign.md)
+- [Screening Calculators](screening_calculators.md)

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -148,6 +148,10 @@ public class Compressor extends TwoPortEquipment
   private double degradationFactor = 1.0; // 1.0 = new, <1.0 = degraded
   private double foulingFactor = 0.0; // Head reduction due to fouling (0-1)
   private double operatingHours = 0.0; // Total operating hours
+  /** Optional deposit (fouling) model driving degradation from deposit mass. */
+  private CompressorDeposit depositModel = null;
+  /** Clean (design) polytropic efficiency baseline used when a deposit model is active. */
+  private double designPolytropicEfficiency = Double.NaN;
 
   // Efficiency solving tolerance (Kelvin)
   private double efficiencySolveTolerance = 0.01;
@@ -848,6 +852,10 @@ public class Compressor extends TwoPortEquipment
       double flow = getThermoSystem().getFlowRate("m3/hr");
       polytropicEfficiency = getCompressorChart().getPolytropicEfficiency(flow, getSpeed()) / 100.0;
     }
+
+    // Apply deposit/fouling degradation (if a deposit model is attached) before the polytropic
+    // efficiency is consumed by the head/power calculation below.
+    applyDepositDegradation();
 
     if (useGERG2008 && inStream.getThermoSystem().getNumberOfPhases() == 1) {
       double[] gergProps;
@@ -1895,6 +1903,9 @@ public class Compressor extends TwoPortEquipment
   @Override
   public void setPolytropicEfficiency(double polytropicEfficiency) {
     this.polytropicEfficiency = polytropicEfficiency;
+    // Record the clean (design) baseline so an attached deposit model degrades from a fixed
+    // reference each run (non-compounding across repeated run() calls).
+    this.designPolytropicEfficiency = polytropicEfficiency;
   }
 
   /**
@@ -4025,6 +4036,112 @@ public class Compressor extends TwoPortEquipment
    */
   public void setFoulingFactor(double factor) {
     this.foulingFactor = Math.max(0.0, factor);
+  }
+
+  /**
+   * Get the attached deposit (fouling) model, if any.
+   *
+   * @return the deposit model, or null if none is attached
+   */
+  public CompressorDeposit getDepositModel() {
+    return depositModel;
+  }
+
+  /**
+   * Attach a deposit (fouling) model. When set, {@link #run(java.util.UUID)} reduces the effective polytropic
+   * efficiency according to the accumulated deposit, so the simulated power and discharge temperature reflect the
+   * degraded machine. Passing {@code null} removes degradation.
+   *
+   * @param depositModel deposit model to attach, or null to remove
+   */
+  public void setDepositModel(CompressorDeposit depositModel) {
+    this.depositModel = depositModel;
+    if (depositModel != null && Double.isNaN(designPolytropicEfficiency)) {
+      designPolytropicEfficiency = polytropicEfficiency;
+    }
+    if (depositModel == null) {
+      degradationFactor = 1.0;
+      foulingFactor = 0.0;
+    }
+  }
+
+  /**
+   * Apply deposit-driven degradation to the polytropic efficiency for the current run.
+   *
+   * <p>
+   * The efficiency is degraded from a fixed clean baseline (the design efficiency for a fixed setpoint, or the
+   * compressor-chart value for the current operating point) so repeated {@link #run(java.util.UUID)} calls do not
+   * compound the degradation. The {@link #getDegradationFactor()} and {@link #getFoulingFactor()} reporting fields are
+   * updated from the deposit model.
+   * </p>
+   */
+  private void applyDepositDegradation() {
+    if (depositModel == null) {
+      return;
+    }
+    double effMultiplier = depositModel.getEfficiencyMultiplier();
+    degradationFactor = effMultiplier;
+    foulingFactor = 1.0 - depositModel.getHeadMultiplier();
+    // When a performance chart is in use, degradation must be applied through a degraded chart (see
+    // buildDegradedChart), which reduces both delivered head and efficiency. Do not additionally
+    // mutate the efficiency here, otherwise the efficiency loss would be double-counted.
+    if (getCompressorChart() != null && getCompressorChart().isUseCompressorChart()) {
+      return;
+    }
+    double cleanEfficiency;
+    if (useEnergyEfficiencyChart()) {
+      // Chart already set the clean efficiency for this operating point.
+      cleanEfficiency = polytropicEfficiency;
+    } else {
+      if (Double.isNaN(designPolytropicEfficiency)) {
+        designPolytropicEfficiency = polytropicEfficiency;
+      }
+      cleanEfficiency = designPolytropicEfficiency;
+    }
+    polytropicEfficiency = cleanEfficiency * effMultiplier;
+  }
+
+  /**
+   * Build a degraded performance chart from the current (clean) compressor chart and the attached
+   * {@link CompressorDeposit} model.
+   *
+   * <p>
+   * This produces the compressor map after the accumulated deposit (for example after 500 operating hours): the head
+   * and polytropic-efficiency curves are scaled by the deposit head and efficiency multipliers, and the surge and
+   * stone-wall curves are regenerated. The returned chart can be inspected/plotted, or installed on the compressor with
+   * {@code getCompressorChart-style replacement} to simulate the degraded machine.
+   * </p>
+   *
+   * @return the degraded chart, or {@code null} if no chart or no deposit model is available
+   */
+  public CompressorChart buildDegradedChart() {
+    if (depositModel == null || !(compressorChart instanceof CompressorChart)) {
+      return null;
+    }
+    return ((CompressorChart) compressorChart).getDegradedChart(depositModel.getHeadMultiplier(),
+        depositModel.getEfficiencyMultiplier());
+  }
+
+  /**
+   * Perform an online (live) wash of the attached {@link CompressorDeposit} model with a wash fluid.
+   *
+   * <p>
+   * Dissolves deposit the fluid can remove (for example water for salt, xylene for elemental sulfur), updating the
+   * deposit model in place so a subsequent {@link #run(java.util.UUID)} reflects the recovered performance. Use
+   * {@link CompressorDepositWash#recommend(CompressorDeposit)} to choose a fluid and {@link CompressorDepositWash}
+   * planning methods to size the rate/duration.
+   * </p>
+   *
+   * @param fluid wash fluid
+   * @param fluidRateKgHr wash fluid mass rate in kg/hr
+   * @param durationHours wash duration in hours
+   * @return the wash result, or {@code null} if no deposit model is attached
+   */
+  public CompressorDepositWash.WashResult washOnline(WashFluid fluid, double fluidRateKgHr, double durationHours) {
+    if (depositModel == null) {
+      return null;
+    }
+    return new CompressorDepositWash().wash(depositModel, fluid, fluidRateKgHr, durationHours);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorChart.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorChart.java
@@ -551,6 +551,58 @@ public class CompressorChart implements CompressorChartInterface, java.io.Serial
     this.refZ = refZ;
   }
 
+  /**
+   * Build a degraded copy of this compressor chart by scaling the head and polytropic-efficiency curves.
+   *
+   * <p>
+   * This is the chart-based counterpart of compressor deposit/fouling degradation: a {@link CompressorDeposit} yields a
+   * head multiplier and an efficiency multiplier from the accumulated deposit (for example after 500 operating hours),
+   * and this method produces the corresponding degraded performance map. The surge and stone-wall curves are
+   * regenerated from the scaled curves. Reference conditions, head unit and real-kappa flag are preserved.
+   * </p>
+   *
+   * @param headMultiplier factor applied to every head value (0-1, 1 = clean)
+   * @param efficiencyMultiplier factor applied to every polytropic efficiency value (0-1, 1 = clean)
+   * @return a new degraded {@link CompressorChart}
+   */
+  public CompressorChart getDegradedChart(double headMultiplier, double efficiencyMultiplier) {
+    int n = chartValues.size();
+    double[] scaledSpeed = new double[n];
+    double[][] scaledFlow = new double[n][];
+    double[][] scaledHead = new double[n][];
+    double[][] scaledFlowEff = new double[n][];
+    double[][] scaledEff = new double[n][];
+    for (int i = 0; i < n; i++) {
+      CompressorCurve curve = chartValues.get(i);
+      scaledSpeed[i] = curve.speed;
+      scaledFlow[i] = curve.flow.clone();
+      scaledFlowEff[i] = curve.flowPolytropicEfficiency.clone();
+      scaledHead[i] = new double[curve.head.length];
+      for (int j = 0; j < curve.head.length; j++) {
+        scaledHead[i][j] = curve.head[j] * headMultiplier;
+      }
+      scaledEff[i] = new double[curve.polytropicEfficiency.length];
+      for (int j = 0; j < curve.polytropicEfficiency.length; j++) {
+        scaledEff[i][j] = curve.polytropicEfficiency[j] * efficiencyMultiplier;
+      }
+    }
+    CompressorChart degraded = new CompressorChart();
+    degraded.setHeadUnit(getHeadUnit());
+    degraded.setUseRealKappa(useRealKappa());
+    degraded.setReferenceConditions(refMW, refTemperature, refPressure, refZ);
+    double[] conditions = getChartConditions();
+    degraded.setCurves(conditions == null ? new double[] { refMW, refTemperature, refPressure, refZ } : conditions,
+        scaledSpeed, scaledFlow, scaledHead, scaledFlowEff, scaledEff);
+    degraded.setUseCompressorChart(true);
+    // Regenerate surge/stone-wall curves only when there are enough speed lines for the spline fit
+    // (>= 3 points); small charts keep no surge/stone-wall curve.
+    if (n >= 3) {
+      degraded.generateSurgeCurve();
+      degraded.generateStoneWallCurve();
+    }
+    return degraded;
+  }
+
   /** {@inheritDoc} */
   @Override
   public SafeSplineSurgeCurve getSurgeCurve() {

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorDeposit.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorDeposit.java
@@ -1,0 +1,460 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.Serializable;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Screening-level model of solid deposit (fouling) accumulation on a centrifugal compressor impeller and its effect on
+ * aerodynamic performance.
+ *
+ * <p>
+ * The model bridges deposit-generating flow-assurance calculations (elemental sulfur drop-out, salt carry-over, mineral
+ * scale, corrosion products, wax) and compressor performance. Any number of deposit {@link DepositMechanism mechanisms}
+ * can be accumulated as a <em>mass</em> (kg) and the combined deposit is mapped to a fractional flow-area blockage and
+ * hence to a polytropic efficiency multiplier and a polytropic head multiplier.
+ * </p>
+ *
+ * <h2>Physical screening model</h2>
+ * <ol>
+ * <li>Deposit volume: {@code V = sum(mass_i / density_i)} over all mechanisms.</li>
+ * <li>Film thickness on the foulable (wetted) impeller/inlet area: {@code t = V / wettedArea}.</li>
+ * <li>Flow-area blockage: {@code b = min(t / passageHalfHeight, maxBlockage)}.</li>
+ * <li>Efficiency multiplier: {@code m_eff = max(1 - kEff * b, minEff)} — area reduction, added surface roughness and
+ * incidence losses compound (default {@code kEff = 1.6}).</li>
+ * <li>Head multiplier: {@code m_head = max((1 - b)^headExponent, minHead)} — throughput/area effect (default exponent
+ * 2).</li>
+ * </ol>
+ *
+ * <p>
+ * The relations are screening-level. Coefficients ({@code kEff}, {@code headExponent}) are exposed so the model can be
+ * calibrated to measured degradation (for example a root-cause-analysis clean / partial / fully-degraded set of
+ * points).
+ * </p>
+ *
+ * <h2>Typical usage</h2>
+ *
+ * <pre>{@code
+ * CompressorDeposit dep = CompressorDeposit.fromCompressor(compressor);
+ * dep.addDeposit(DepositMechanism.SULFUR_S8, 1.2); // kg from a sulfur drop-out study
+ * dep.addDeposit(DepositMechanism.SALT_NACL, 0.4); // kg from a salt carry-over study
+ * compressor.setDepositModel(dep); // degradation now applied in run()
+ * compressor.run();
+ * double effLoss = 1.0 - dep.getEfficiencyMultiplier();
+ * }</pre>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class CompressorDeposit implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  /** Accumulated deposit mass per mechanism [kg]. */
+  private final Map<DepositMechanism, Double> depositMass = new EnumMap<>(DepositMechanism.class);
+
+  /** Foulable (wetted) impeller / inlet area available for deposition [m2]. */
+  private double wettedArea = Double.NaN;
+
+  /** Characteristic flow-passage half-height [m] used for the blockage estimate. */
+  private double passageHalfHeight = Double.NaN;
+
+  /** Efficiency-blockage coefficient (area + roughness + incidence losses). */
+  private double efficiencyBlockageCoefficient = 1.6;
+
+  /** Head-blockage exponent. */
+  private double headBlockageExponent = 2.0;
+
+  /** Maximum allowed flow-area blockage fraction. */
+  private double maxBlockageFraction = 0.95;
+
+  /** Lower clamp on the efficiency multiplier. */
+  private double minEfficiencyMultiplier = 0.02;
+
+  /** Lower clamp on the head multiplier. */
+  private double minHeadMultiplier = 0.05;
+
+  /**
+   * Default constructor. Impeller geometry must be set via {@link #setWettedArea(double)} and
+   * {@link #setPassageHalfHeight(double)}, or with {@link #sizeImpellerFromInletFlow(double, double)} /
+   * {@link #fromCompressor(Compressor)} before performance multipliers are meaningful.
+   */
+  public CompressorDeposit() {
+  }
+
+  /**
+   * Constructor with explicit foulable geometry.
+   *
+   * @param wettedArea foulable impeller / inlet area in m2
+   * @param passageHalfHeight characteristic flow-passage half-height in m
+   */
+  public CompressorDeposit(double wettedArea, double passageHalfHeight) {
+    this.wettedArea = wettedArea;
+    this.passageHalfHeight = passageHalfHeight;
+  }
+
+  // ==========================================================================
+  // Deposit inventory
+  // ==========================================================================
+
+  /**
+   * Add (accumulate) deposit mass for a mechanism.
+   *
+   * @param mechanism deposit mechanism
+   * @param massKg deposit mass to add in kg (negative values are ignored)
+   */
+  public void addDeposit(DepositMechanism mechanism, double massKg) {
+    if (mechanism == null || massKg <= 0.0 || Double.isNaN(massKg)) {
+      return;
+    }
+    double current = depositMass.containsKey(mechanism) ? depositMass.get(mechanism) : 0.0;
+    depositMass.put(mechanism, current + massKg);
+  }
+
+  /**
+   * Accumulate deposit over a time interval given a deposition rate.
+   *
+   * @param mechanism deposit mechanism
+   * @param rateKgPerHour deposition rate in kg/hr (for example from a sulfur or scale study)
+   * @param hours duration in hours
+   */
+  public void accumulate(DepositMechanism mechanism, double rateKgPerHour, double hours) {
+    if (rateKgPerHour <= 0.0 || hours <= 0.0) {
+      return;
+    }
+    addDeposit(mechanism, rateKgPerHour * hours);
+  }
+
+  /**
+   * Accumulate deposit from a {@link DepositSource} over a time interval. The source computes the deposition rate from
+   * the process thermodynamics (solid precipitation, salt from evaporating entrained water, etc.), so the deposit
+   * amount is obtained as part of the process calculation.
+   *
+   * @param source deposit source that computes a rate from a process stream
+   * @param hours duration in hours
+   * @return the deposit mass added in kg
+   */
+  public double accumulate(DepositSource source, double hours) {
+    if (source == null || hours <= 0.0) {
+      return 0.0;
+    }
+    double rateKgPerHour = source.getDepositRate("kg/hr");
+    double mass = Math.max(0.0, rateKgPerHour * hours);
+    addDeposit(source.getMechanism(), mass);
+    return mass;
+  }
+
+  /**
+   * Remove a fraction of all deposits (models a compressor wash / cleaning).
+   *
+   * @param fraction fraction of deposit to remove (0 = none, 1 = fully clean)
+   */
+  public void removeFraction(double fraction) {
+    double f = Math.max(0.0, Math.min(1.0, fraction));
+    for (Map.Entry<DepositMechanism, Double> e : depositMass.entrySet()) {
+      e.setValue(e.getValue() * (1.0 - f));
+    }
+  }
+
+  /** Remove all deposits (fully clean). */
+  public void clear() {
+    depositMass.clear();
+  }
+
+  /**
+   * Remove a mass of a single deposit mechanism (models dissolution by a wash fluid).
+   *
+   * @param mechanism deposit mechanism
+   * @param massKg mass to remove in kg (clamped to the available deposit)
+   * @return the mass actually removed in kg
+   */
+  public double removeDeposit(DepositMechanism mechanism, double massKg) {
+    if (mechanism == null || massKg <= 0.0) {
+      return 0.0;
+    }
+    double current = depositMass.containsKey(mechanism) ? depositMass.get(mechanism) : 0.0;
+    double removed = Math.min(current, massKg);
+    depositMass.put(mechanism, current - removed);
+    return removed;
+  }
+
+  /**
+   * Get the accumulated deposit mass for a single mechanism.
+   *
+   * @param mechanism deposit mechanism
+   * @return deposit mass in kg (0 if none)
+   */
+  public double getDepositMass(DepositMechanism mechanism) {
+    return depositMass.containsKey(mechanism) ? depositMass.get(mechanism) : 0.0;
+  }
+
+  /**
+   * Get the total accumulated deposit mass over all mechanisms.
+   *
+   * @return total deposit mass in kg
+   */
+  public double getTotalDepositMass() {
+    double sum = 0.0;
+    for (double m : depositMass.values()) {
+      sum += m;
+    }
+    return sum;
+  }
+
+  /**
+   * Get the total deposit volume, summing mass/density over all mechanisms.
+   *
+   * @return total deposit volume in m3
+   */
+  public double getDepositVolume() {
+    double vol = 0.0;
+    for (Map.Entry<DepositMechanism, Double> e : depositMass.entrySet()) {
+      vol += e.getValue() / e.getKey().getDensity();
+    }
+    return vol;
+  }
+
+  // ==========================================================================
+  // Geometry
+  // ==========================================================================
+
+  /**
+   * Size the foulable impeller geometry from the inlet volumetric flow (screening).
+   *
+   * <p>
+   * The impeller eye area is estimated as {@code Q / eyeAxialVelocity}; the foulable (wetted) area of the first stage
+   * is taken as six times the eye area (hub, shroud and blade surfaces) and the characteristic passage half-height as
+   * {@code eyeDiameter / 12}.
+   * </p>
+   *
+   * @param inletVolumeFlow inlet actual volumetric flow in m3/s
+   * @param eyeAxialVelocity impeller-eye axial velocity in m/s (typical 40-50 m/s)
+   */
+  public void sizeImpellerFromInletFlow(double inletVolumeFlow, double eyeAxialVelocity) {
+    if (inletVolumeFlow <= 0.0 || eyeAxialVelocity <= 0.0) {
+      return;
+    }
+    double eyeArea = inletVolumeFlow / eyeAxialVelocity;
+    double eyeDiameter = Math.sqrt(4.0 * eyeArea / Math.PI);
+    this.wettedArea = 6.0 * eyeArea;
+    this.passageHalfHeight = eyeDiameter / 12.0;
+  }
+
+  /**
+   * Build a deposit model with foulable geometry derived from a compressor's inlet operating point.
+   *
+   * @param compressor compressor whose inlet stream is used to size the impeller
+   * @return a new {@link CompressorDeposit} with geometry populated (empty deposit inventory)
+   */
+  public static CompressorDeposit fromCompressor(Compressor compressor) {
+    CompressorDeposit dep = new CompressorDeposit();
+    if (compressor != null && compressor.getInletStream() != null) {
+      double q = compressor.getInletStream().getFlowRate("m3/sec");
+      dep.sizeImpellerFromInletFlow(q, 45.0);
+    }
+    return dep;
+  }
+
+  /**
+   * Get the foulable impeller / inlet area.
+   *
+   * @return wetted area in m2
+   */
+  public double getWettedArea() {
+    return wettedArea;
+  }
+
+  /**
+   * Set the foulable impeller / inlet area.
+   *
+   * @param wettedArea wetted area in m2
+   */
+  public void setWettedArea(double wettedArea) {
+    this.wettedArea = wettedArea;
+  }
+
+  /**
+   * Get the characteristic flow-passage half-height.
+   *
+   * @return passage half-height in m
+   */
+  public double getPassageHalfHeight() {
+    return passageHalfHeight;
+  }
+
+  /**
+   * Set the characteristic flow-passage half-height.
+   *
+   * @param passageHalfHeight passage half-height in m
+   */
+  public void setPassageHalfHeight(double passageHalfHeight) {
+    this.passageHalfHeight = passageHalfHeight;
+  }
+
+  // ==========================================================================
+  // Performance mapping
+  // ==========================================================================
+
+  /**
+   * Deposit film thickness on the foulable area.
+   *
+   * @return film thickness in m (0 if geometry is not set)
+   */
+  public double getFilmThickness() {
+    if (Double.isNaN(wettedArea) || wettedArea <= 0.0) {
+      return 0.0;
+    }
+    return getDepositVolume() / wettedArea;
+  }
+
+  /**
+   * Fractional flow-area blockage caused by the accumulated deposit.
+   *
+   * @return blockage fraction between 0 and {@code maxBlockageFraction}
+   */
+  public double getAreaBlockageFraction() {
+    if (Double.isNaN(passageHalfHeight) || passageHalfHeight <= 0.0) {
+      return 0.0;
+    }
+    return Math.min(getFilmThickness() / passageHalfHeight, maxBlockageFraction);
+  }
+
+  /**
+   * Polytropic efficiency multiplier due to the accumulated deposit.
+   *
+   * @return efficiency multiplier between {@code minEfficiencyMultiplier} and 1.0
+   */
+  public double getEfficiencyMultiplier() {
+    double b = getAreaBlockageFraction();
+    return Math.max(1.0 - efficiencyBlockageCoefficient * b, minEfficiencyMultiplier);
+  }
+
+  /**
+   * Polytropic head multiplier due to the accumulated deposit.
+   *
+   * @return head multiplier between {@code minHeadMultiplier} and 1.0
+   */
+  public double getHeadMultiplier() {
+    double b = getAreaBlockageFraction();
+    return Math.max(Math.pow(1.0 - b, headBlockageExponent), minHeadMultiplier);
+  }
+
+  /**
+   * Invert the efficiency model: find the total deposit mass of a single mechanism that yields a target efficiency
+   * multiplier, given the current geometry.
+   *
+   * <p>
+   * Useful for calibration ("how much deposit is consistent with a measured efficiency drop?"). The current deposit
+   * inventory is not modified.
+   * </p>
+   *
+   * @param mechanism deposit mechanism to solve for
+   * @param targetEfficiencyMultiplier target efficiency multiplier (0-1)
+   * @return deposit mass in kg that yields the target multiplier (0 if geometry unset)
+   */
+  public double depositMassForEfficiencyMultiplier(DepositMechanism mechanism, double targetEfficiencyMultiplier) {
+    if (mechanism == null || Double.isNaN(wettedArea) || Double.isNaN(passageHalfHeight) || wettedArea <= 0.0
+        || passageHalfHeight <= 0.0) {
+      return 0.0;
+    }
+    // Blockage that yields the target multiplier: 1 - kEff*b = target
+    double targetBlockage = (1.0 - targetEfficiencyMultiplier) / efficiencyBlockageCoefficient;
+    targetBlockage = Math.max(0.0, Math.min(targetBlockage, maxBlockageFraction));
+    double thickness = targetBlockage * passageHalfHeight;
+    double volume = thickness * wettedArea;
+    return volume * mechanism.getDensity();
+  }
+
+  // ==========================================================================
+  // Calibration coefficients
+  // ==========================================================================
+
+  /**
+   * Get the efficiency-blockage coefficient.
+   *
+   * @return coefficient (default 1.6)
+   */
+  public double getEfficiencyBlockageCoefficient() {
+    return efficiencyBlockageCoefficient;
+  }
+
+  /**
+   * Set the efficiency-blockage coefficient used to calibrate the efficiency loss.
+   *
+   * @param coefficient efficiency-blockage coefficient (must be positive)
+   */
+  public void setEfficiencyBlockageCoefficient(double coefficient) {
+    if (coefficient > 0.0) {
+      this.efficiencyBlockageCoefficient = coefficient;
+    }
+  }
+
+  /**
+   * Get the head-blockage exponent.
+   *
+   * @return exponent (default 2.0)
+   */
+  public double getHeadBlockageExponent() {
+    return headBlockageExponent;
+  }
+
+  /**
+   * Set the head-blockage exponent used to calibrate the head loss.
+   *
+   * @param exponent head-blockage exponent (must be positive)
+   */
+  public void setHeadBlockageExponent(double exponent) {
+    if (exponent > 0.0) {
+      this.headBlockageExponent = exponent;
+    }
+  }
+
+  /**
+   * Get the maximum allowed flow-area blockage fraction.
+   *
+   * @return maximum blockage fraction
+   */
+  public double getMaxBlockageFraction() {
+    return maxBlockageFraction;
+  }
+
+  /**
+   * Set the maximum allowed flow-area blockage fraction.
+   *
+   * @param maxBlockageFraction maximum blockage fraction (0-1)
+   */
+  public void setMaxBlockageFraction(double maxBlockageFraction) {
+    this.maxBlockageFraction = Math.max(0.0, Math.min(1.0, maxBlockageFraction));
+  }
+
+  // ==========================================================================
+  // Reporting
+  // ==========================================================================
+
+  /**
+   * Produce a compact JSON summary of the deposit inventory and its performance effect.
+   *
+   * @return JSON string
+   */
+  public String toJson() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\"deposits_kg\":{");
+    boolean first = true;
+    for (Map.Entry<DepositMechanism, Double> e : depositMass.entrySet()) {
+      if (!first) {
+        sb.append(",");
+      }
+      sb.append("\"").append(e.getKey().name()).append("\":").append(e.getValue());
+      first = false;
+    }
+    sb.append("},");
+    sb.append("\"total_deposit_kg\":").append(getTotalDepositMass()).append(",");
+    sb.append("\"deposit_volume_m3\":").append(getDepositVolume()).append(",");
+    sb.append("\"film_thickness_mm\":").append(getFilmThickness() * 1000.0).append(",");
+    sb.append("\"area_blockage_fraction\":").append(getAreaBlockageFraction()).append(",");
+    sb.append("\"efficiency_multiplier\":").append(getEfficiencyMultiplier()).append(",");
+    sb.append("\"head_multiplier\":").append(getHeadMultiplier());
+    sb.append("}");
+    return sb.toString();
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorDepositProfile.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorDepositProfile.java
@@ -1,0 +1,266 @@
+package neqsim.process.equipment.compressor;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Locates where solid deposits form along a multi-impeller centrifugal compressor by marching the pressure-temperature
+ * path stage by stage and running a solid (TP-solid) precipitation flash at each impeller's local conditions.
+ *
+ * <p>
+ * Deposition happens where the local pressure and temperature cross the solubility / saturation limit of the depositing
+ * species. For a single compressor body the temperature rises monotonically from inlet to discharge, so a
+ * solubility-limited species such as elemental sulfur (S8) is <em>most</em> likely to drop out at the cold first
+ * impeller and re-dissolve toward the hotter last impeller; across a multi-stage train the gas re-cools in each
+ * intercooler and can re-cross saturation on the first impeller after each cooler. This profile makes that spatial
+ * picture explicit.
+ * </p>
+ *
+ * <p>
+ * The stage pressures are interpolated geometrically between suction and discharge, and the stage temperatures linearly
+ * along the polytropic path (screening-level). For a rigorous per-stage fluid state, use the compressor's detailed
+ * polytropic method with a {@link CompressorPropertyProfile} and flash each captured stage fluid.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class CompressorDepositProfile {
+
+  private static final Logger logger = LogManager.getLogger(CompressorDepositProfile.class);
+
+  /**
+   * Per-impeller deposition result.
+   */
+  public static class StageDeposit {
+    private final int stage;
+    private final double pressureBara;
+    private final double temperatureC;
+    private final double solidRateKgHr;
+    private final boolean supersaturated;
+
+    /**
+     * Constructor.
+     *
+     * @param stage impeller index (1 = first/suction impeller)
+     * @param pressureBara local stage pressure in bara
+     * @param temperatureC local stage temperature in Celsius
+     * @param solidRateKgHr solid drop-out rate at the local conditions in kg/hr
+     * @param supersaturated true if a solid phase is present at the local conditions
+     */
+    public StageDeposit(int stage, double pressureBara, double temperatureC, double solidRateKgHr,
+        boolean supersaturated) {
+      this.stage = stage;
+      this.pressureBara = pressureBara;
+      this.temperatureC = temperatureC;
+      this.solidRateKgHr = solidRateKgHr;
+      this.supersaturated = supersaturated;
+    }
+
+    /**
+     * Impeller index.
+     *
+     * @return stage number (1-based)
+     */
+    public int getStage() {
+      return stage;
+    }
+
+    /**
+     * Local stage pressure.
+     *
+     * @return pressure in bara
+     */
+    public double getPressureBara() {
+      return pressureBara;
+    }
+
+    /**
+     * Local stage temperature.
+     *
+     * @return temperature in Celsius
+     */
+    public double getTemperatureC() {
+      return temperatureC;
+    }
+
+    /**
+     * Solid drop-out rate at the local stage conditions.
+     *
+     * @return solid rate in kg/hr
+     */
+    public double getSolidRateKgHr() {
+      return solidRateKgHr;
+    }
+
+    /**
+     * Whether a solid phase is present at the local conditions.
+     *
+     * @return true if supersaturated
+     */
+    public boolean isSupersaturated() {
+      return supersaturated;
+    }
+  }
+
+  private CompressorDepositProfile() {
+  }
+
+  /**
+   * Compute the per-impeller solid-deposition profile between suction and discharge conditions.
+   *
+   * @param inlet compressor suction stream (defines the composition and suction T/P)
+   * @param dischargeTemperatureC discharge temperature in Celsius
+   * @param dischargePressureBara discharge pressure in bara
+   * @param numberOfImpellers number of impellers (stages) to resolve (at least 1)
+   * @param solidComponent name of the solid-forming component, for example "S8"
+   * @return one {@link StageDeposit} per impeller from suction (stage 1) to discharge
+   */
+  public static List<StageDeposit> compute(StreamInterface inlet, double dischargeTemperatureC,
+      double dischargePressureBara, int numberOfImpellers, String solidComponent) {
+    List<StageDeposit> profile = new ArrayList<>();
+    if (inlet == null || inlet.getThermoSystem() == null) {
+      return profile;
+    }
+    int stages = Math.max(1, numberOfImpellers);
+    double p1 = inlet.getPressure("bara");
+    double t1 = inlet.getTemperature("C");
+    for (int i = 1; i <= stages; i++) {
+      double frac = stages == 1 ? 1.0 : (double) i / stages;
+      double pStage = p1 * Math.pow(dischargePressureBara / p1, frac);
+      double tStage = t1 + (dischargeTemperatureC - t1) * frac;
+      double solidRate = 0.0;
+      boolean supersat = false;
+      try {
+        SystemInterface sys = inlet.getThermoSystem().clone();
+        if (sys.getComponent(solidComponent) != null) {
+          sys.setTemperature(tStage, "C");
+          sys.setPressure(pStage, "bara");
+          sys.setMultiPhaseCheck(true);
+          sys.setSolidPhaseCheck(solidComponent);
+          ThermodynamicOperations ops = new ThermodynamicOperations(sys);
+          ops.TPSolidflash();
+          if (sys.hasPhaseType("solid")) {
+            supersat = true;
+            solidRate = sys.getPhaseOfType("solid").getFlowRate("kg/hr");
+          }
+        }
+      } catch (Exception e) {
+        logger.warn("Stage {} solid flash failed: {}", i, e.getMessage());
+      }
+      profile.add(new StageDeposit(i, pStage, tStage, solidRate, supersat));
+    }
+    return profile;
+  }
+
+  /**
+   * Compute the per-impeller solid-deposition profile for a compressor that has been run.
+   *
+   * @param compressor a compressor whose inlet stream and outlet temperature/pressure define the path (run the
+   * compressor before calling)
+   * @param numberOfImpellers number of impellers (stages) to resolve (at least 1)
+   * @param solidComponent name of the solid-forming component, for example "S8"
+   * @return one {@link StageDeposit} per impeller from suction to discharge
+   */
+  public static List<StageDeposit> compute(Compressor compressor, int numberOfImpellers, String solidComponent) {
+    if (compressor == null || compressor.getInletStream() == null || compressor.getOutletStream() == null) {
+      return new ArrayList<>();
+    }
+    double outT = compressor.getOutletStream().getTemperature("C");
+    double outP = compressor.getOutletStream().getPressure("bara");
+    return compute(compressor.getInletStream(), outT, outP, numberOfImpellers, solidComponent);
+  }
+
+  /**
+   * Index (1-based) of the impeller with the highest solid drop-out (the worst fouling stage).
+   *
+   * @param profile per-impeller profile from {@link #compute}
+   * @return worst stage number, or -1 if no stage is supersaturated
+   */
+  public static int worstStage(List<StageDeposit> profile) {
+    int worst = -1;
+    double max = 0.0;
+    for (StageDeposit s : profile) {
+      if (s.getSolidRateKgHr() > max) {
+        max = s.getSolidRateKgHr();
+        worst = s.getStage();
+      }
+    }
+    return worst;
+  }
+
+  /**
+   * Compute the per-impeller solid-deposition profile using the compressor's rigorous per-step fluid states captured by
+   * its {@link CompressorPropertyProfile}.
+   *
+   * <p>
+   * Unlike {@link #compute(Compressor, int, String)}, which interpolates the stage pressures and temperatures
+   * (screening), this method flashes the <em>actual</em> fluid state that the compressor computed along the polytropic
+   * path, so each impeller uses the true local pressure, temperature and composition. Enable it before running the
+   * compressor:
+   * </p>
+   *
+   * <pre>{@code
+   * compressor.setPolytropicMethod("detailed");
+   * compressor.getPropertyProfile().setActive(true);
+   * compressor.run();
+   * List<StageDeposit> profile = CompressorDepositProfile.computeFromPropertyProfile(compressor, 5, "S8");
+   * }</pre>
+   *
+   * <p>
+   * The captured steps ({@code numberOfCompressorCalcSteps}, default 40) are mapped onto the requested number of
+   * impellers. If the property profile is not active or empty this falls back to the screening
+   * {@link #compute(Compressor, int, String)}.
+   * </p>
+   *
+   * @param compressor a compressor run with the detailed polytropic method and an active property profile
+   * @param numberOfImpellers number of impellers (stages) to resolve (at least 1)
+   * @param solidComponent name of the solid-forming component, for example "S8"
+   * @return one {@link StageDeposit} per impeller from suction to discharge
+   */
+  public static List<StageDeposit> computeFromPropertyProfile(Compressor compressor, int numberOfImpellers,
+      String solidComponent) {
+    if (compressor == null) {
+      return new ArrayList<>();
+    }
+    CompressorPropertyProfile pp = compressor.getPropertyProfile();
+    if (pp == null || !pp.isActive() || pp.getFluid() == null || pp.getFluid().isEmpty()) {
+      return compute(compressor, numberOfImpellers, solidComponent);
+    }
+    List<SystemInterface> steps = pp.getFluid();
+    int nSteps = steps.size();
+    int stages = Math.max(1, numberOfImpellers);
+    List<StageDeposit> profile = new ArrayList<>();
+    for (int i = 1; i <= stages; i++) {
+      int idx = (int) Math.round((double) i / stages * nSteps) - 1;
+      idx = Math.max(0, Math.min(nSteps - 1, idx));
+      SystemInterface stepFluid = steps.get(idx);
+      double pStage = stepFluid.getPressure("bara");
+      double tStage = stepFluid.getTemperature("C");
+      double solidRate = 0.0;
+      boolean supersat = false;
+      try {
+        SystemInterface sys = stepFluid.clone();
+        if (sys.getComponent(solidComponent) != null) {
+          sys.setMultiPhaseCheck(true);
+          sys.setSolidPhaseCheck(solidComponent);
+          ThermodynamicOperations ops = new ThermodynamicOperations(sys);
+          ops.TPSolidflash();
+          if (sys.hasPhaseType("solid")) {
+            supersat = true;
+            solidRate = sys.getPhaseOfType("solid").getFlowRate("kg/hr");
+          }
+        }
+      } catch (Exception e) {
+        logger.warn("Stage {} property-profile solid flash failed: {}", i, e.getMessage());
+      }
+      profile.add(new StageDeposit(i, pStage, tStage, solidRate, supersat));
+    }
+    return profile;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorDepositWash.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorDepositWash.java
@@ -1,0 +1,316 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.Serializable;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Plans and simulates online (live) or offline compressor washing to remove {@link CompressorDeposit deposits} with a
+ * {@link WashFluid wash fluid}.
+ *
+ * <p>
+ * Washing is modelled as screening-level dissolution: for each deposit mechanism the wash fluid can dissolve, the mass
+ * removed over the wash is
+ * </p>
+ *
+ * <pre>
+ * removed = min(deposit mass, washFluidRate * solubility * contactEfficiency * duration)
+ * </pre>
+ *
+ * <p>
+ * where {@code solubility} (kg deposit / kg fluid) comes from {@link WashFluid} and {@code contactEfficiency} accounts
+ * for imperfect contact during online washing (droplet carry-through, short residence time). Deposits the fluid cannot
+ * dissolve are left untouched — so water removes salt but leaves elemental sulfur, while xylene removes sulfur and wax
+ * but leaves salt. This drives both wash-fluid recommendation and wash-rate / duration planning.
+ * </p>
+ *
+ * <h2>Typical usage</h2>
+ *
+ * <pre>{@code
+ * CompressorDepositWash wash = new CompressorDepositWash();
+ * WashFluid fluid = CompressorDepositWash.recommend(deposit); // pick the best fluid
+ * CompressorDepositWash.WashResult r = wash.wash(deposit, fluid, 200.0, 2.0); // 200 kg/hr, 2 h
+ * // deposit now has less mass -> compressor.run() recovers performance
+ * }</pre>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class CompressorDepositWash implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  /** Contact efficiency (fraction, 1 = ideal, lower for online washing). */
+  private double contactEfficiency = 0.7;
+
+  /**
+   * Result of a wash operation.
+   */
+  public static class WashResult implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final WashFluid fluid;
+    private final double durationHours;
+    private final double fluidUsedKg;
+    private final Map<DepositMechanism, Double> removedKg;
+    private final double totalRemovedKg;
+    private final double efficiencyMultiplierBefore;
+    private final double efficiencyMultiplierAfter;
+    private final double headMultiplierBefore;
+    private final double headMultiplierAfter;
+    private final double remainingDepositKg;
+
+    WashResult(WashFluid fluid, double durationHours, double fluidUsedKg, Map<DepositMechanism, Double> removedKg,
+        double totalRemovedKg, double efficiencyMultiplierBefore, double efficiencyMultiplierAfter,
+        double headMultiplierBefore, double headMultiplierAfter, double remainingDepositKg) {
+      this.fluid = fluid;
+      this.durationHours = durationHours;
+      this.fluidUsedKg = fluidUsedKg;
+      this.removedKg = removedKg;
+      this.totalRemovedKg = totalRemovedKg;
+      this.efficiencyMultiplierBefore = efficiencyMultiplierBefore;
+      this.efficiencyMultiplierAfter = efficiencyMultiplierAfter;
+      this.headMultiplierBefore = headMultiplierBefore;
+      this.headMultiplierAfter = headMultiplierAfter;
+      this.remainingDepositKg = remainingDepositKg;
+    }
+
+    /**
+     * Wash fluid used.
+     *
+     * @return wash fluid
+     */
+    public WashFluid getFluid() {
+      return fluid;
+    }
+
+    /**
+     * Wash duration.
+     *
+     * @return duration in hours
+     */
+    public double getDurationHours() {
+      return durationHours;
+    }
+
+    /**
+     * Total wash fluid consumed.
+     *
+     * @return fluid used in kg
+     */
+    public double getFluidUsedKg() {
+      return fluidUsedKg;
+    }
+
+    /**
+     * Deposit mass removed per mechanism.
+     *
+     * @return map of mechanism to removed mass in kg
+     */
+    public Map<DepositMechanism, Double> getRemovedKg() {
+      return removedKg;
+    }
+
+    /**
+     * Total deposit mass removed.
+     *
+     * @return total removed in kg
+     */
+    public double getTotalRemovedKg() {
+      return totalRemovedKg;
+    }
+
+    /**
+     * Efficiency multiplier before the wash.
+     *
+     * @return efficiency multiplier (0-1)
+     */
+    public double getEfficiencyMultiplierBefore() {
+      return efficiencyMultiplierBefore;
+    }
+
+    /**
+     * Efficiency multiplier after the wash (recovered).
+     *
+     * @return efficiency multiplier (0-1)
+     */
+    public double getEfficiencyMultiplierAfter() {
+      return efficiencyMultiplierAfter;
+    }
+
+    /**
+     * Head multiplier before the wash.
+     *
+     * @return head multiplier (0-1)
+     */
+    public double getHeadMultiplierBefore() {
+      return headMultiplierBefore;
+    }
+
+    /**
+     * Head multiplier after the wash (recovered).
+     *
+     * @return head multiplier (0-1)
+     */
+    public double getHeadMultiplierAfter() {
+      return headMultiplierAfter;
+    }
+
+    /**
+     * Deposit mass remaining after the wash.
+     *
+     * @return remaining deposit in kg
+     */
+    public double getRemainingDepositKg() {
+      return remainingDepositKg;
+    }
+  }
+
+  /**
+   * Recommend the wash fluid that can dissolve the largest total deposit mass currently present.
+   *
+   * @param deposit deposit inventory to clean
+   * @return the recommended wash fluid, or {@code null} if no fluid dissolves any present deposit
+   */
+  public static WashFluid recommend(CompressorDeposit deposit) {
+    if (deposit == null) {
+      return null;
+    }
+    WashFluid best = null;
+    double bestRemovable = 0.0;
+    for (WashFluid fluid : WashFluid.values()) {
+      double removable = 0.0;
+      for (DepositMechanism mechanism : DepositMechanism.values()) {
+        if (fluid.dissolves(mechanism)) {
+          removable += deposit.getDepositMass(mechanism) * fluid.getSolubility(mechanism);
+        }
+      }
+      if (removable > bestRemovable) {
+        bestRemovable = removable;
+        best = fluid;
+      }
+    }
+    return best;
+  }
+
+  /**
+   * Simulate a wash: dissolve deposit from the inventory with the given fluid, rate and duration. The
+   * {@link CompressorDeposit} is updated in place, so a subsequent compressor run reflects the recovered performance.
+   *
+   * @param deposit deposit inventory to clean (modified in place)
+   * @param fluid wash fluid
+   * @param fluidRateKgHr wash fluid mass rate in kg/hr
+   * @param durationHours wash duration in hours
+   * @return a {@link WashResult} describing what was removed and the performance recovery
+   */
+  public WashResult wash(CompressorDeposit deposit, WashFluid fluid, double fluidRateKgHr, double durationHours) {
+    Map<DepositMechanism, Double> removed = new EnumMap<>(DepositMechanism.class);
+    double effBefore = deposit == null ? 1.0 : deposit.getEfficiencyMultiplier();
+    double headBefore = deposit == null ? 1.0 : deposit.getHeadMultiplier();
+    double totalRemoved = 0.0;
+    if (deposit != null && fluid != null && fluidRateKgHr > 0.0 && durationHours > 0.0) {
+      for (DepositMechanism mechanism : DepositMechanism.values()) {
+        double solubility = fluid.getSolubility(mechanism);
+        if (solubility <= 0.0) {
+          continue;
+        }
+        double capacity = fluidRateKgHr * solubility * contactEfficiency * durationHours;
+        double removedMass = deposit.removeDeposit(mechanism, capacity);
+        if (removedMass > 0.0) {
+          removed.put(mechanism, removedMass);
+          totalRemoved += removedMass;
+        }
+      }
+    }
+    double effAfter = deposit == null ? 1.0 : deposit.getEfficiencyMultiplier();
+    double headAfter = deposit == null ? 1.0 : deposit.getHeadMultiplier();
+    double remaining = deposit == null ? 0.0 : deposit.getTotalDepositMass();
+    double fluidUsed = fluidRateKgHr * durationHours;
+    return new WashResult(fluid, durationHours, fluidUsed, removed, totalRemoved, effBefore, effAfter, headBefore,
+        headAfter, remaining);
+  }
+
+  /**
+   * Initial dissolution rate for a fluid acting on the current deposit (kg deposit/hr), summed over every mechanism the
+   * fluid can dissolve that is currently present.
+   *
+   * @param deposit deposit inventory
+   * @param fluid wash fluid
+   * @param fluidRateKgHr wash fluid rate in kg/hr
+   * @return dissolution rate in kg deposit / hr
+   */
+  public double dissolutionRateKgHr(CompressorDeposit deposit, WashFluid fluid, double fluidRateKgHr) {
+    if (deposit == null || fluid == null || fluidRateKgHr <= 0.0) {
+      return 0.0;
+    }
+    double rate = 0.0;
+    for (DepositMechanism mechanism : DepositMechanism.values()) {
+      if (fluid.dissolves(mechanism) && deposit.getDepositMass(mechanism) > 0.0) {
+        rate += fluidRateKgHr * fluid.getSolubility(mechanism) * contactEfficiency;
+      }
+    }
+    return rate;
+  }
+
+  /**
+   * Screening estimate of the wash duration needed to remove a target deposit mass at a given wash rate (assumes the
+   * initial dissolution rate; ignores depletion, so it is a lower bound).
+   *
+   * @param deposit deposit inventory
+   * @param fluid wash fluid
+   * @param fluidRateKgHr wash fluid rate in kg/hr
+   * @param targetMassKg deposit mass to remove in kg
+   * @return duration in hours (or {@link Double#POSITIVE_INFINITY} if the fluid cannot dissolve it)
+   */
+  public double hoursToRemoveMass(CompressorDeposit deposit, WashFluid fluid, double fluidRateKgHr,
+      double targetMassKg) {
+    double rate = dissolutionRateKgHr(deposit, fluid, fluidRateKgHr);
+    if (rate <= 0.0) {
+      return Double.POSITIVE_INFINITY;
+    }
+    return targetMassKg / rate;
+  }
+
+  /**
+   * Screening estimate of the wash-fluid rate needed to remove a target deposit mass in a target duration.
+   *
+   * @param deposit deposit inventory
+   * @param fluid wash fluid
+   * @param targetMassKg deposit mass to remove in kg
+   * @param durationHours available wash duration in hours
+   * @return required wash-fluid rate in kg/hr (or {@link Double#POSITIVE_INFINITY} if not possible)
+   */
+  public double requiredFluidRateKgHr(CompressorDeposit deposit, WashFluid fluid, double targetMassKg,
+      double durationHours) {
+    if (deposit == null || fluid == null || durationHours <= 0.0) {
+      return Double.POSITIVE_INFINITY;
+    }
+    double sumSolubility = 0.0;
+    for (DepositMechanism mechanism : DepositMechanism.values()) {
+      if (fluid.dissolves(mechanism) && deposit.getDepositMass(mechanism) > 0.0) {
+        sumSolubility += fluid.getSolubility(mechanism);
+      }
+    }
+    if (sumSolubility <= 0.0) {
+      return Double.POSITIVE_INFINITY;
+    }
+    return targetMassKg / (durationHours * contactEfficiency * sumSolubility);
+  }
+
+  /**
+   * Get the contact efficiency.
+   *
+   * @return contact efficiency (0-1)
+   */
+  public double getContactEfficiency() {
+    return contactEfficiency;
+  }
+
+  /**
+   * Set the contact efficiency (lower for online washing, higher for offline soak).
+   *
+   * @param contactEfficiency contact efficiency (0-1)
+   */
+  public void setContactEfficiency(double contactEfficiency) {
+    this.contactEfficiency = Math.max(0.0, Math.min(1.0, contactEfficiency));
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/DepositMechanism.java
+++ b/src/main/java/neqsim/process/equipment/compressor/DepositMechanism.java
@@ -1,0 +1,129 @@
+package neqsim.process.equipment.compressor;
+
+/**
+ * Physical deposit (fouling) mechanisms that can accumulate on a centrifugal compressor impeller and reduce its
+ * performance.
+ *
+ * <p>
+ * Each mechanism carries a representative solid deposit density used to convert an accumulated deposit <em>mass</em>
+ * into a deposit <em>volume</em> (and hence a film thickness and flow-area blockage) in {@link CompressorDeposit}.
+ * Densities are screening-level literature values for the dominant solid phase and can be overridden per deposit when a
+ * measured value is available.
+ * </p>
+ *
+ * <table border="1">
+ * <caption>Representative solid deposit densities</caption>
+ * <tr>
+ * <th>Mechanism</th>
+ * <th>Density [kg/m3]</th>
+ * <th>Typical source</th>
+ * </tr>
+ * <tr>
+ * <td>SULFUR_S8</td>
+ * <td>2070</td>
+ * <td>Elemental sulfur from H2S oxidation (O2 ingress)</td>
+ * </tr>
+ * <tr>
+ * <td>SALT_NACL</td>
+ * <td>2160</td>
+ * <td>Formation-water salt carry-over, marine air</td>
+ * </tr>
+ * <tr>
+ * <td>SCALE_CACO3</td>
+ * <td>2710</td>
+ * <td>Calcium carbonate scale</td>
+ * </tr>
+ * <tr>
+ * <td>SCALE_BASO4</td>
+ * <td>4500</td>
+ * <td>Barium sulfate scale</td>
+ * </tr>
+ * <tr>
+ * <td>SCALE_CASO4</td>
+ * <td>2960</td>
+ * <td>Calcium sulfate scale</td>
+ * </tr>
+ * <tr>
+ * <td>IRON_SULFIDE</td>
+ * <td>4840</td>
+ * <td>FeS corrosion product</td>
+ * </tr>
+ * <tr>
+ * <td>IRON_OXIDE</td>
+ * <td>5240</td>
+ * <td>Rust / magnetite corrosion product</td>
+ * </tr>
+ * <tr>
+ * <td>HYDROCARBON_WAX</td>
+ * <td>900</td>
+ * <td>Heavy hydrocarbon / wax / oil-mist deposits</td>
+ * </tr>
+ * <tr>
+ * <td>PARTICULATE</td>
+ * <td>2500</td>
+ * <td>Airborne dust and particulates</td>
+ * </tr>
+ * <tr>
+ * <td>GENERIC</td>
+ * <td>2000</td>
+ * <td>Unspecified / mixed deposit</td>
+ * </tr>
+ * </table>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public enum DepositMechanism {
+  /** Elemental sulfur (S8) from H2S oxidation. */
+  SULFUR_S8(2070.0, "Elemental sulfur (S8) from H2S oxidation"),
+  /** Sodium chloride salt from formation water / marine air. */
+  SALT_NACL(2160.0, "NaCl salt crystallisation"),
+  /** Calcium carbonate scale. */
+  SCALE_CACO3(2710.0, "Calcium carbonate scale"),
+  /** Barium sulfate scale. */
+  SCALE_BASO4(4500.0, "Barium sulfate scale"),
+  /** Calcium sulfate scale. */
+  SCALE_CASO4(2960.0, "Calcium sulfate scale"),
+  /** Iron sulfide corrosion product. */
+  IRON_SULFIDE(4840.0, "Iron sulfide (FeS) corrosion product"),
+  /** Iron oxide / rust corrosion product. */
+  IRON_OXIDE(5240.0, "Iron oxide / magnetite corrosion product"),
+  /** Heavy hydrocarbon / wax deposits. */
+  HYDROCARBON_WAX(900.0, "Heavy hydrocarbon / wax / oil-mist deposits"),
+  /** Airborne dust and particulates. */
+  PARTICULATE(2500.0, "Airborne dust and particulates"),
+  /** Unspecified or mixed deposit. */
+  GENERIC(2000.0, "Unspecified / mixed deposit");
+
+  private final double density;
+  private final String description;
+
+  /**
+   * Constructor.
+   *
+   * @param density representative solid deposit density in kg/m3
+   * @param description human-readable description of the deposit source
+   */
+  DepositMechanism(double density, String description) {
+    this.density = density;
+    this.description = description;
+  }
+
+  /**
+   * Representative solid deposit density used to convert deposit mass into deposit volume.
+   *
+   * @return density in kg/m3
+   */
+  public double getDensity() {
+    return density;
+  }
+
+  /**
+   * Human-readable description of the deposit source.
+   *
+   * @return description text
+   */
+  public String getDescription() {
+    return description;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/DepositSource.java
+++ b/src/main/java/neqsim/process/equipment/compressor/DepositSource.java
@@ -1,0 +1,36 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.Serializable;
+
+/**
+ * A source of solid deposit onto a compressor, computed from process thermodynamics.
+ *
+ * <p>
+ * Implementations turn a physical precipitation calculation (elemental sulfur drop-out, salt from evaporating entrained
+ * water, wax/condensate drop-out, mineral scale) into a mass-deposition <em>rate</em> that can be accumulated into a
+ * {@link CompressorDeposit} over an operating interval. This is the bridge between flow-assurance / thermodynamic
+ * precipitation and compressor performance degradation, so the deposit amount is obtained <em>as part of the process
+ * calculation</em> rather than supplied by hand.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public interface DepositSource extends Serializable {
+
+  /**
+   * The deposit mechanism this source contributes (used to pick the deposit density).
+   *
+   * @return deposit mechanism
+   */
+  DepositMechanism getMechanism();
+
+  /**
+   * The current mass-deposition rate onto the machine (precipitated solids that stick to the impeller), evaluated from
+   * the underlying stream at its current conditions.
+   *
+   * @param flowUnit mass-flow unit, for example "kg/hr" or "kg/day"
+   * @return deposition rate in the requested unit (0 if nothing precipitates or on error)
+   */
+  double getDepositRate(String flowUnit);
+}

--- a/src/main/java/neqsim/process/equipment/compressor/EntrainedSaltDepositSource.java
+++ b/src/main/java/neqsim/process/equipment/compressor/EntrainedSaltDepositSource.java
@@ -1,0 +1,227 @@
+package neqsim.process.equipment.compressor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * {@link DepositSource} for salt precipitation from entrained produced water carried into a compressor.
+ *
+ * <p>
+ * Dissolved salt (for example NaCl) is essentially non-volatile: when entrained brine droplets enter the hot compressed
+ * gas and the water evaporates, the salt it carried precipitates as a solid that can foul the impeller. The deposition
+ * rate is therefore a mass balance:
+ * </p>
+ *
+ * <pre>
+ * salt precipitation rate = entrainedWaterRate * salinity * evaporatedFraction
+ * deposition rate         = salt precipitation rate * captureFraction
+ * </pre>
+ *
+ * <p>
+ * By default the whole entrained water load is assumed to evaporate ({@code evaporatedFraction =
+ * 1.0}), which is the conservative worst case for salt fouling. Use
+ * {@link #estimateWaterEvaporatedFraction(StreamInterface, double, double)} to compute the evaporated fraction from a
+ * flash of the gas stream between the compressor inlet and discharge conditions and set it with
+ * {@link #setEvaporatedFraction(double)}.
+ * </p>
+ *
+ * <p>
+ * This mass-balance approach avoids solid-salt electrolyte convergence issues while still tying the deposit amount to
+ * the process (entrained water rate, salinity, and how much water flashes off).
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class EntrainedSaltDepositSource implements DepositSource {
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger logger = LogManager.getLogger(EntrainedSaltDepositSource.class);
+
+  private double entrainedWaterRateKgHr;
+  private double salinityMassFraction;
+  private double evaporatedFraction = 1.0;
+  private double captureFraction = 1.0;
+  private final DepositMechanism mechanism;
+
+  /**
+   * Constructor (defaults to NaCl salt, full evaporation, full capture).
+   *
+   * @param entrainedWaterRateKgHr entrained liquid water carry-over rate in kg/hr
+   * @param salinityMassFraction dissolved salt mass fraction of the brine (kg salt / kg water)
+   */
+  public EntrainedSaltDepositSource(double entrainedWaterRateKgHr, double salinityMassFraction) {
+    this(entrainedWaterRateKgHr, salinityMassFraction, DepositMechanism.SALT_NACL);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param entrainedWaterRateKgHr entrained liquid water carry-over rate in kg/hr
+   * @param salinityMassFraction dissolved salt mass fraction of the brine (kg salt / kg water)
+   * @param mechanism deposit mechanism (density) used by the deposit model
+   */
+  public EntrainedSaltDepositSource(double entrainedWaterRateKgHr, double salinityMassFraction,
+      DepositMechanism mechanism) {
+    this.entrainedWaterRateKgHr = Math.max(0.0, entrainedWaterRateKgHr);
+    this.salinityMassFraction = Math.max(0.0, Math.min(1.0, salinityMassFraction));
+    this.mechanism = mechanism;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public DepositMechanism getMechanism() {
+    return mechanism;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getDepositRate(String flowUnit) {
+    double kgHr = entrainedWaterRateKgHr * salinityMassFraction * evaporatedFraction * captureFraction;
+    return convertFromKgHr(kgHr, flowUnit);
+  }
+
+  /**
+   * Estimate the fraction of aqueous water that evaporates between the inlet and the compressor discharge conditions,
+   * by flashing the stream at both states.
+   *
+   * @param inlet compressor inlet stream (must contain water)
+   * @param dischargeTemperatureC compressor discharge temperature in Celsius
+   * @param dischargePressureBara compressor discharge pressure in bara
+   * @return evaporated fraction of aqueous water between 0 and 1
+   */
+  public static double estimateWaterEvaporatedFraction(StreamInterface inlet, double dischargeTemperatureC,
+      double dischargePressureBara) {
+    if (inlet == null || inlet.getThermoSystem() == null) {
+      return 1.0;
+    }
+    try {
+      double waterIn = aqueousWaterFlowKgHr(inlet.getThermoSystem(), inlet.getTemperature("C"),
+          inlet.getPressure("bara"));
+      if (waterIn <= 0.0) {
+        return 1.0;
+      }
+      double waterOut = aqueousWaterFlowKgHr(inlet.getThermoSystem(), dischargeTemperatureC, dischargePressureBara);
+      double frac = (waterIn - waterOut) / waterIn;
+      return Math.max(0.0, Math.min(1.0, frac));
+    } catch (Exception e) {
+      logger.warn("Water evaporated-fraction estimate failed: {}", e.getMessage());
+      return 1.0;
+    }
+  }
+
+  /**
+   * Aqueous liquid water flow at the given conditions.
+   *
+   * @param baseSystem system to clone
+   * @param temperatureC temperature in Celsius
+   * @param pressureBara pressure in bara
+   * @return aqueous water flow in kg/hr (0 if no aqueous phase)
+   */
+  private static double aqueousWaterFlowKgHr(SystemInterface baseSystem, double temperatureC, double pressureBara) {
+    SystemInterface sys = baseSystem.clone();
+    sys.setTemperature(temperatureC, "C");
+    sys.setPressure(pressureBara, "bara");
+    sys.setMultiPhaseCheck(true);
+    ThermodynamicOperations ops = new ThermodynamicOperations(sys);
+    ops.TPflash();
+    if (!sys.hasPhaseType("aqueous")) {
+      return 0.0;
+    }
+    return sys.getPhaseOfType("aqueous").getComponent("water") == null ? 0.0
+        : sys.getPhaseOfType("aqueous").getFlowRate("kg/hr");
+  }
+
+  private static double convertFromKgHr(double kgHr, String flowUnit) {
+    if (flowUnit == null) {
+      return kgHr;
+    }
+    switch (flowUnit) {
+    case "kg/hr":
+      return kgHr;
+    case "kg/day":
+      return kgHr * 24.0;
+    case "kg/sec":
+      return kgHr / 3600.0;
+    case "tonnes/day":
+      return kgHr * 24.0 / 1000.0;
+    default:
+      return kgHr;
+    }
+  }
+
+  /**
+   * Get the entrained water carry-over rate.
+   *
+   * @return entrained water rate in kg/hr
+   */
+  public double getEntrainedWaterRateKgHr() {
+    return entrainedWaterRateKgHr;
+  }
+
+  /**
+   * Set the entrained water carry-over rate.
+   *
+   * @param entrainedWaterRateKgHr entrained water rate in kg/hr
+   */
+  public void setEntrainedWaterRateKgHr(double entrainedWaterRateKgHr) {
+    this.entrainedWaterRateKgHr = Math.max(0.0, entrainedWaterRateKgHr);
+  }
+
+  /**
+   * Get the brine salinity.
+   *
+   * @return dissolved salt mass fraction (kg salt / kg water)
+   */
+  public double getSalinityMassFraction() {
+    return salinityMassFraction;
+  }
+
+  /**
+   * Set the brine salinity.
+   *
+   * @param salinityMassFraction dissolved salt mass fraction (kg salt / kg water)
+   */
+  public void setSalinityMassFraction(double salinityMassFraction) {
+    this.salinityMassFraction = Math.max(0.0, Math.min(1.0, salinityMassFraction));
+  }
+
+  /**
+   * Get the fraction of entrained water assumed to evaporate.
+   *
+   * @return evaporated fraction (0-1)
+   */
+  public double getEvaporatedFraction() {
+    return evaporatedFraction;
+  }
+
+  /**
+   * Set the fraction of entrained water assumed to evaporate.
+   *
+   * @param evaporatedFraction evaporated fraction (0-1)
+   */
+  public void setEvaporatedFraction(double evaporatedFraction) {
+    this.evaporatedFraction = Math.max(0.0, Math.min(1.0, evaporatedFraction));
+  }
+
+  /**
+   * Get the capture fraction.
+   *
+   * @return fraction of precipitated salt that deposits on the machine (0-1)
+   */
+  public double getCaptureFraction() {
+    return captureFraction;
+  }
+
+  /**
+   * Set the capture fraction.
+   *
+   * @param captureFraction fraction of precipitated salt that deposits on the machine (0-1)
+   */
+  public void setCaptureFraction(double captureFraction) {
+    this.captureFraction = Math.max(0.0, Math.min(1.0, captureFraction));
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/SolidFlashDepositSource.java
+++ b/src/main/java/neqsim/process/equipment/compressor/SolidFlashDepositSource.java
@@ -1,0 +1,116 @@
+package neqsim.process.equipment.compressor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * {@link DepositSource} that computes a solid-precipitation deposition rate from a process stream using a NeqSim solid
+ * (TP-solid) flash.
+ *
+ * <p>
+ * This covers solids that the equation of state can drop out directly, most importantly elemental sulfur ({@code S8}),
+ * but also wax or asphaltene when those solid checks are configured. The stream is cloned, multi-phase and the named
+ * solid-phase check are enabled, a {@code TPSolidflash} is run at the stream conditions, and the resulting solid-phase
+ * mass rate is multiplied by a capture fraction (the fraction of precipitated solids that stick to the impeller rather
+ * than pass through).
+ * </p>
+ *
+ * <p>
+ * The stream should represent the fluid entering the compressor, including any entrained liquid (condensate/water
+ * droplets) carried over from an upstream separator, since the entrained liquid is where dissolved sulfur or salt is
+ * transported. Model entrainment upstream by mixing the carried-over liquid into the compressor feed (or by an
+ * imperfect separator efficiency).
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class SolidFlashDepositSource implements DepositSource {
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger logger = LogManager.getLogger(SolidFlashDepositSource.class);
+
+  private final StreamInterface stream;
+  private final String solidComponent;
+  private final DepositMechanism mechanism;
+  private double captureFraction = 1.0;
+
+  /**
+   * Constructor.
+   *
+   * @param stream stream entering the compressor (including any entrained liquid)
+   * @param solidComponent name of the component allowed to form a solid, for example "S8"
+   * @param mechanism deposit mechanism (density) used by the deposit model
+   * @param captureFraction fraction of precipitated solid that deposits on the machine (0-1)
+   */
+  public SolidFlashDepositSource(StreamInterface stream, String solidComponent, DepositMechanism mechanism,
+      double captureFraction) {
+    this.stream = stream;
+    this.solidComponent = solidComponent;
+    this.mechanism = mechanism;
+    setCaptureFraction(captureFraction);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public DepositMechanism getMechanism() {
+    return mechanism;
+  }
+
+  /**
+   * Total precipitated-solid rate at the stream conditions (before the capture fraction is applied). This is the
+   * thermodynamic drop-out rate of the named solid.
+   *
+   * @param flowUnit mass-flow unit, for example "kg/hr"
+   * @return precipitated solid rate in the requested unit (0 if no solid forms)
+   */
+  public double getPrecipitationRate(String flowUnit) {
+    if (stream == null || stream.getThermoSystem() == null) {
+      return 0.0;
+    }
+    try {
+      SystemInterface sys = stream.getThermoSystem().clone();
+      if (sys.getComponent(solidComponent) == null) {
+        return 0.0;
+      }
+      sys.setMultiPhaseCheck(true);
+      sys.setSolidPhaseCheck(solidComponent);
+      ThermodynamicOperations ops = new ThermodynamicOperations(sys);
+      ops.TPSolidflash();
+      if (!sys.hasPhaseType("solid")) {
+        return 0.0;
+      }
+      return sys.getPhaseOfType("solid").getFlowRate(flowUnit);
+    } catch (Exception e) {
+      logger.warn("Solid precipitation flash failed for component {}: {}", solidComponent, e.getMessage());
+      return 0.0;
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getDepositRate(String flowUnit) {
+    return getPrecipitationRate(flowUnit) * captureFraction;
+  }
+
+  /**
+   * Get the capture fraction.
+   *
+   * @return fraction of precipitated solid that deposits on the machine (0-1)
+   */
+  public double getCaptureFraction() {
+    return captureFraction;
+  }
+
+  /**
+   * Set the capture fraction.
+   *
+   * @param captureFraction fraction of precipitated solid that deposits on the machine (0-1)
+   */
+  public void setCaptureFraction(double captureFraction) {
+    this.captureFraction = Math.max(0.0, Math.min(1.0, captureFraction));
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/WashFluid.java
+++ b/src/main/java/neqsim/process/equipment/compressor/WashFluid.java
@@ -1,0 +1,125 @@
+package neqsim.process.equipment.compressor;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Wash fluids used for online (live) or offline compressor washing, with a screening-level solubility of each
+ * {@link DepositMechanism} in the fluid.
+ *
+ * <p>
+ * The solubility (kg deposit dissolved per kg wash fluid) drives which deposits a given wash fluid can remove: water
+ * dissolves salt but not elemental sulfur, whereas an aromatic solvent such as xylene dissolves sulfur and wax but not
+ * salt. These values are screening-level and can be used to <em>recommend</em> a wash fluid for a given deposit and to
+ * <em>plan</em> the wash rate and duration; they are not a substitute for a solvent qualification test.
+ * </p>
+ *
+ * <table border="1">
+ * <caption>Screening deposit solubilities (kg deposit / kg wash fluid)</caption>
+ * <tr>
+ * <th>Wash fluid</th>
+ * <th>Dissolves</th>
+ * </tr>
+ * <tr>
+ * <td>Water</td>
+ * <td>NaCl salt (well), carbonate/sulfate scale (poorly)</td>
+ * </tr>
+ * <tr>
+ * <td>Xylene / Toluene</td>
+ * <td>Elemental sulfur (S8), wax / heavy hydrocarbon</td>
+ * </tr>
+ * <tr>
+ * <td>Condensate</td>
+ * <td>Wax / heavy hydrocarbon (well), sulfur (poorly)</td>
+ * </tr>
+ * <tr>
+ * <td>Methanol</td>
+ * <td>Salt (moderate), light hydrocarbon (poorly)</td>
+ * </tr>
+ * </table>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public enum WashFluid {
+  /** Fresh water (with or without detergent). */
+  WATER("Water"),
+  /** Xylene (aromatic solvent). */
+  XYLENE("Xylene"),
+  /** Toluene (aromatic solvent). */
+  TOLUENE("Toluene"),
+  /** Stabilised condensate / light hydrocarbon solvent. */
+  CONDENSATE("Condensate"),
+  /** Methanol. */
+  METHANOL("Methanol");
+
+  private final String displayName;
+
+  WashFluid(String displayName) {
+    this.displayName = displayName;
+  }
+
+  /**
+   * Human-readable name.
+   *
+   * @return display name
+   */
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  /** Solubility matrix: kg deposit dissolved per kg wash fluid. */
+  private static final Map<WashFluid, Map<DepositMechanism, Double>> SOLUBILITY = new EnumMap<>(WashFluid.class);
+
+  static {
+    // Water: salt readily, scale poorly, no sulfur/wax.
+    put(WATER, DepositMechanism.SALT_NACL, 0.30);
+    put(WATER, DepositMechanism.SCALE_CACO3, 0.0015);
+    put(WATER, DepositMechanism.SCALE_CASO4, 0.0020);
+    // Aromatic solvents: sulfur and wax, not salt.
+    put(XYLENE, DepositMechanism.SULFUR_S8, 0.020);
+    put(XYLENE, DepositMechanism.HYDROCARBON_WAX, 0.15);
+    put(TOLUENE, DepositMechanism.SULFUR_S8, 0.017);
+    put(TOLUENE, DepositMechanism.HYDROCARBON_WAX, 0.13);
+    // Condensate: wax well, sulfur weakly.
+    put(CONDENSATE, DepositMechanism.HYDROCARBON_WAX, 0.10);
+    put(CONDENSATE, DepositMechanism.SULFUR_S8, 0.005);
+    // Methanol: salt moderately, light HC weakly.
+    put(METHANOL, DepositMechanism.SALT_NACL, 0.05);
+    put(METHANOL, DepositMechanism.HYDROCARBON_WAX, 0.02);
+  }
+
+  private static void put(WashFluid fluid, DepositMechanism mechanism, double solubility) {
+    Map<DepositMechanism, Double> map = SOLUBILITY.get(fluid);
+    if (map == null) {
+      map = new EnumMap<>(DepositMechanism.class);
+      SOLUBILITY.put(fluid, map);
+    }
+    map.put(mechanism, solubility);
+  }
+
+  /**
+   * Screening solubility of a deposit mechanism in this wash fluid.
+   *
+   * @param mechanism deposit mechanism
+   * @return solubility in kg deposit per kg wash fluid (0 if the fluid does not dissolve it)
+   */
+  public double getSolubility(DepositMechanism mechanism) {
+    Map<DepositMechanism, Double> map = SOLUBILITY.get(this);
+    if (map == null || mechanism == null) {
+      return 0.0;
+    }
+    Double value = map.get(mechanism);
+    return value == null ? 0.0 : value;
+  }
+
+  /**
+   * Whether this wash fluid can dissolve the given deposit mechanism.
+   *
+   * @param mechanism deposit mechanism
+   * @return true if the solubility is positive
+   */
+  public boolean dissolves(DepositMechanism mechanism) {
+    return getSolubility(mechanism) > 0.0;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorDepositTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorDepositTest.java
@@ -1,0 +1,358 @@
+package neqsim.process.equipment.compressor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Unit tests for {@link CompressorDeposit} and its integration with {@link Compressor}.
+ */
+public class CompressorDepositTest {
+
+  private Compressor buildCompressor(double polytropicEff) {
+    SystemInterface gas = new SystemSrkEos(273.15 + 30.0, 18.8);
+    gas.addComponent("methane", 0.86);
+    gas.addComponent("ethane", 0.07);
+    gas.addComponent("propane", 0.03);
+    gas.addComponent("CO2", 0.02);
+    gas.addComponent("nitrogen", 0.02);
+    gas.setMixingRule(2);
+    Stream feed = new Stream("suction", gas);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.setTemperature(30.0, "C");
+    feed.setPressure(18.8, "bara");
+    feed.run();
+    Compressor comp = new Compressor("KA03B", feed);
+    comp.setOutletPressure(42.0);
+    comp.setUsePolytropicCalc(true);
+    comp.setPolytropicEfficiency(polytropicEff);
+    return comp;
+  }
+
+  @Test
+  public void testDepositMassToBlockage() {
+    CompressorDeposit dep = new CompressorDeposit(0.6, 0.02);
+    assertEquals(0.0, dep.getTotalDepositMass(), 1e-9);
+    assertEquals(1.0, dep.getEfficiencyMultiplier(), 1e-9);
+
+    dep.addDeposit(DepositMechanism.SULFUR_S8, 5.0);
+    dep.addDeposit(DepositMechanism.SALT_NACL, 2.0);
+    assertEquals(7.0, dep.getTotalDepositMass(), 1e-9);
+    assertTrue(dep.getDepositVolume() > 0.0);
+    assertTrue(dep.getAreaBlockageFraction() > 0.0);
+    // Deposit reduces both efficiency and head.
+    assertTrue(dep.getEfficiencyMultiplier() < 1.0);
+    assertTrue(dep.getHeadMultiplier() < 1.0);
+  }
+
+  @Test
+  public void testWashingRemovesDeposit() {
+    CompressorDeposit dep = new CompressorDeposit(0.6, 0.02);
+    dep.addDeposit(DepositMechanism.SULFUR_S8, 8.0);
+    double before = dep.getTotalDepositMass();
+    dep.removeFraction(0.9);
+    assertEquals(before * 0.1, dep.getTotalDepositMass(), 1e-9);
+    dep.clear();
+    assertEquals(0.0, dep.getTotalDepositMass(), 1e-9);
+  }
+
+  @Test
+  public void testInverseDepositMassForEfficiency() {
+    CompressorDeposit dep = new CompressorDeposit(0.6, 0.02);
+    double mass = dep.depositMassForEfficiencyMultiplier(DepositMechanism.SULFUR_S8, 0.77);
+    assertTrue(mass > 0.0);
+    // Applying that mass should reproduce (approximately) the target multiplier.
+    dep.addDeposit(DepositMechanism.SULFUR_S8, mass);
+    assertEquals(0.77, dep.getEfficiencyMultiplier(), 1e-3);
+  }
+
+  @Test
+  public void testSizeFromCompressorInletFlow() {
+    Compressor comp = buildCompressor(0.60);
+    comp.run();
+    CompressorDeposit dep = CompressorDeposit.fromCompressor(comp);
+    assertTrue(dep.getWettedArea() > 0.0);
+    assertTrue(dep.getPassageHalfHeight() > 0.0);
+  }
+
+  @Test
+  public void testDegradationAppliedInRun() {
+    Compressor clean = buildCompressor(0.60);
+    clean.run();
+    double cleanPower = clean.getPower();
+    double cleanEff = clean.getPolytropicEfficiency();
+
+    Compressor fouled = buildCompressor(0.60);
+    CompressorDeposit dep = CompressorDeposit.fromCompressor(fouled);
+    dep.addDeposit(DepositMechanism.SULFUR_S8, 3.0);
+    fouled.setDepositModel(dep);
+    fouled.run();
+
+    // Degraded compressor has lower efficiency and needs more power for the same duty.
+    assertTrue(fouled.getPolytropicEfficiency() < cleanEff);
+    assertTrue(fouled.getPower() > cleanPower);
+    assertTrue(fouled.getDegradationFactor() < 1.0);
+    assertNotNull(fouled.getDepositModel());
+
+    // Re-running must not compound the degradation.
+    double firstEff = fouled.getPolytropicEfficiency();
+    fouled.run();
+    assertEquals(firstEff, fouled.getPolytropicEfficiency(), 1e-9);
+  }
+
+  @Test
+  public void testRemovingDepositModelRestoresCleanEfficiency() {
+    Compressor comp = buildCompressor(0.60);
+    CompressorDeposit dep = CompressorDeposit.fromCompressor(comp);
+    dep.addDeposit(DepositMechanism.SULFUR_S8, 3.0);
+    comp.setDepositModel(dep);
+    comp.run();
+    assertTrue(comp.getPolytropicEfficiency() < 0.60);
+
+    comp.setDepositModel(null);
+    comp.setPolytropicEfficiency(0.60);
+    comp.run();
+    assertEquals(0.60, comp.getPolytropicEfficiency(), 1e-9);
+    assertEquals(1.0, comp.getDegradationFactor(), 1e-9);
+  }
+
+  @Test
+  public void testEntrainedSaltDepositSourceMassBalance() {
+    // 10 kg/hr entrained brine water at 5 wt% salt, all evaporating -> 0.5 kg/hr salt.
+    EntrainedSaltDepositSource salt = new EntrainedSaltDepositSource(10.0, 0.05);
+    assertEquals(0.5, salt.getDepositRate("kg/hr"), 1e-9);
+    assertEquals(12.0, salt.getDepositRate("kg/day"), 1e-9);
+    assertEquals(DepositMechanism.SALT_NACL, salt.getMechanism());
+
+    // Half the water evaporates and half the salt sticks -> 0.125 kg/hr.
+    salt.setEvaporatedFraction(0.5);
+    salt.setCaptureFraction(0.5);
+    assertEquals(0.125, salt.getDepositRate("kg/hr"), 1e-9);
+
+    // Accumulate into a deposit model over 30 days.
+    CompressorDeposit dep = new CompressorDeposit(0.6, 0.02);
+    double mass = dep.accumulate(salt, 30.0 * 24.0);
+    assertEquals(0.125 * 30.0 * 24.0, mass, 1e-6);
+    assertEquals(mass, dep.getDepositMass(DepositMechanism.SALT_NACL), 1e-6);
+  }
+
+  @Test
+  public void testSolidFlashDepositSourceS8() {
+    // Gas carrying free S8 above its solubility -> solid drops out on flash.
+    SystemInterface gas = new SystemSrkEos(273.15 + 30.0, 40.0);
+    gas.addComponent("methane", 0.95);
+    gas.addComponent("CO2", 0.02);
+    gas.addComponent("H2S", 0.001);
+    gas.addComponent("S8", 1.0e-4);
+    gas.setMixingRule(2);
+    gas.setMultiPhaseCheck(true);
+    Stream feed = new Stream("s8gas", gas);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.setTemperature(30.0, "C");
+    feed.setPressure(40.0, "bara");
+    feed.run();
+
+    SolidFlashDepositSource s8 = new SolidFlashDepositSource(feed, "S8", DepositMechanism.SULFUR_S8, 0.3);
+    double rate = s8.getDepositRate("kg/hr");
+    double precip = s8.getPrecipitationRate("kg/hr");
+    // Free S8 far above its (mg/Sm3-level) solubility must drop out as solid.
+    assertTrue(precip > 0.0);
+    // Deposition rate is the capture-scaled precipitation rate and cannot exceed the feed.
+    assertEquals(precip * 0.3, rate, 1e-9);
+    assertTrue(rate < feed.getFlowRate("kg/hr"));
+
+    CompressorDeposit dep = new CompressorDeposit(0.6, 0.02);
+    double mass = dep.accumulate(s8, 24.0);
+    assertEquals(rate * 24.0, mass, 1e-6);
+  }
+
+  @Test
+  public void testDepositLocationAcrossImpellers() {
+    SystemInterface gas = new SystemSrkEos(273.15 + 30.0, 40.0);
+    gas.addComponent("methane", 0.95);
+    gas.addComponent("CO2", 0.02);
+    gas.addComponent("H2S", 0.001);
+    gas.addComponent("S8", 1.0e-4);
+    gas.setMixingRule(2);
+    gas.setMultiPhaseCheck(true);
+    Stream feed = new Stream("s8gas", gas);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.setTemperature(30.0, "C");
+    feed.setPressure(40.0, "bara");
+    feed.run();
+
+    // 5-impeller compression 40 -> 120 bara, discharge ~120 C.
+    java.util.List<CompressorDepositProfile.StageDeposit> profile = CompressorDepositProfile.compute(feed, 120.0, 120.0,
+        5, "S8");
+    assertEquals(5, profile.size());
+
+    // Temperature and pressure rise monotonically stage to stage.
+    for (int i = 1; i < profile.size(); i++) {
+      assertTrue(profile.get(i).getTemperatureC() > profile.get(i - 1).getTemperatureC());
+      assertTrue(profile.get(i).getPressureBara() > profile.get(i - 1).getPressureBara());
+    }
+    // With a monotonically rising temperature, S8 solubility increases, so the solid drop-out is
+    // largest at the cold first impeller (deposits concentrate at the suction stage).
+    assertTrue(profile.get(0).getSolidRateKgHr() >= profile.get(4).getSolidRateKgHr());
+    assertEquals(1, CompressorDepositProfile.worstStage(profile));
+  }
+
+  @Test
+  public void testDegradedChartScalesHeadAndEfficiency() {
+    CompressorChart chart = new CompressorChart();
+    double[] chartConditions = new double[] { 1.0, 1.0, 1.0, 1.0 };
+    double[] speed = new double[] { 1000.0, 1500.0 };
+    double[][] flow = new double[][] { { 500.0, 700.0, 900.0 }, { 600.0, 800.0, 1000.0 } };
+    double[][] head = new double[][] { { 100.0, 90.0, 75.0 }, { 150.0, 135.0, 110.0 } };
+    double[][] polyEff = new double[][] { { 78.0, 80.0, 76.0 }, { 77.0, 79.0, 75.0 } };
+    chart.setCurves(chartConditions, speed, flow, head, polyEff);
+    chart.setHeadUnit("kJ/kg");
+    chart.setUseCompressorChart(true);
+
+    double cleanHead = chart.getPolytropicHead(700.0, 1000.0);
+    double cleanEff = chart.getPolytropicEfficiency(700.0, 1000.0);
+
+    CompressorChart degraded = chart.getDegradedChart(0.9, 0.8);
+    double degHead = degraded.getPolytropicHead(700.0, 1000.0);
+    double degEff = degraded.getPolytropicEfficiency(700.0, 1000.0);
+
+    assertEquals(cleanHead * 0.9, degHead, Math.abs(cleanHead) * 1e-6 + 1e-6);
+    assertEquals(cleanEff * 0.8, degEff, Math.abs(cleanEff) * 1e-6 + 1e-6);
+  }
+
+  @Test
+  public void testBuildDegradedChartFromDepositAfterOperatingHours() {
+    Compressor comp = buildCompressor(0.60);
+    CompressorChart chart = new CompressorChart();
+    double[] chartConditions = new double[] { 1.0, 1.0, 1.0, 1.0 };
+    double[] speed = new double[] { 1000.0, 1500.0 };
+    double[][] flow = new double[][] { { 500.0, 700.0, 900.0 }, { 600.0, 800.0, 1000.0 } };
+    double[][] head = new double[][] { { 100.0, 90.0, 75.0 }, { 150.0, 135.0, 110.0 } };
+    double[][] polyEff = new double[][] { { 78.0, 80.0, 76.0 }, { 77.0, 79.0, 75.0 } };
+    chart.setCurves(chartConditions, speed, flow, head, polyEff);
+    chart.setHeadUnit("kJ/kg");
+    chart.setUseCompressorChart(true);
+    comp.setCompressorChart(chart);
+
+    // No deposit model yet -> no degraded chart.
+    assertNull(comp.buildDegradedChart());
+
+    // Accumulate a salt deposit over 500 operating hours, then build the degraded chart.
+    CompressorDeposit dep = CompressorDeposit.fromCompressor(comp);
+    EntrainedSaltDepositSource salt = new EntrainedSaltDepositSource(5.0, 0.05);
+    dep.accumulate(salt, 500.0);
+    comp.setDepositModel(dep);
+
+    assertTrue(dep.getTotalDepositMass() > 0.0);
+    CompressorChart degraded = comp.buildDegradedChart();
+    assertNotNull(degraded);
+    // Degraded head and efficiency are below the clean chart at the same operating point.
+    assertTrue(degraded.getPolytropicHead(700.0, 1000.0) < chart.getPolytropicHead(700.0, 1000.0));
+    assertTrue(degraded.getPolytropicEfficiency(700.0, 1000.0) <= chart.getPolytropicEfficiency(700.0, 1000.0));
+  }
+
+  @Test
+  public void testStageProfileFromPropertyProfileUsesRealStates() {
+    SystemInterface gas = new SystemSrkEos(273.15 + 30.0, 40.0);
+    gas.addComponent("methane", 0.95);
+    gas.addComponent("CO2", 0.02);
+    gas.addComponent("H2S", 0.001);
+    gas.addComponent("S8", 1.0e-4);
+    gas.setMixingRule(2);
+    gas.setMultiPhaseCheck(true);
+    Stream feed = new Stream("s8gas", gas);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.setTemperature(30.0, "C");
+    feed.setPressure(40.0, "bara");
+    feed.run();
+
+    Compressor comp = new Compressor("stagecomp", feed);
+    comp.setOutletPressure(120.0);
+    comp.setUsePolytropicCalc(true);
+    comp.setPolytropicEfficiency(0.75);
+    comp.setPolytropicMethod("detailed");
+    comp.getPropertyProfile().setActive(true);
+    comp.run();
+
+    java.util.List<CompressorDepositProfile.StageDeposit> profile = CompressorDepositProfile
+        .computeFromPropertyProfile(comp, 5, "S8");
+    assertEquals(5, profile.size());
+    // Rigorous per-step states: pressure rises monotonically to discharge.
+    for (int i = 1; i < profile.size(); i++) {
+      assertTrue(profile.get(i).getPressureBara() > profile.get(i - 1).getPressureBara());
+    }
+    // Last stage at (or near) the discharge pressure.
+    assertTrue(profile.get(4).getPressureBara() > 100.0);
+    // Rising temperature -> S8 solubility rises -> most solid at the cold first impeller.
+    assertTrue(profile.get(0).getSolidRateKgHr() >= profile.get(4).getSolidRateKgHr());
+  }
+
+  @Test
+  public void testOnlineWashRemovesMatchingDepositOnly() {
+    // Mixed fouling: salt + elemental sulfur.
+    CompressorDeposit dep = new CompressorDeposit(0.6, 0.02);
+    dep.addDeposit(DepositMechanism.SALT_NACL, 4.0);
+    dep.addDeposit(DepositMechanism.SULFUR_S8, 3.0);
+    double effFouled = dep.getEfficiencyMultiplier();
+
+    // Water dissolves salt but NOT sulfur.
+    CompressorDepositWash washer = new CompressorDepositWash();
+    washer.setContactEfficiency(1.0);
+    CompressorDepositWash.WashResult waterWash = washer.wash(dep, WashFluid.WATER, 200.0, 2.0);
+    assertTrue(waterWash.getTotalRemovedKg() > 0.0);
+    assertTrue(dep.getDepositMass(DepositMechanism.SALT_NACL) < 4.0); // salt reduced
+    assertEquals(3.0, dep.getDepositMass(DepositMechanism.SULFUR_S8), 1e-9); // sulfur untouched
+    assertTrue(waterWash.getEfficiencyMultiplierAfter() > effFouled); // performance recovered
+
+    // Xylene then dissolves the remaining sulfur.
+    double effBeforeXylene = dep.getEfficiencyMultiplier();
+    CompressorDepositWash.WashResult xyleneWash = washer.wash(dep, WashFluid.XYLENE, 200.0, 5.0);
+    assertTrue(dep.getDepositMass(DepositMechanism.SULFUR_S8) < 3.0);
+    assertTrue(xyleneWash.getEfficiencyMultiplierAfter() > effBeforeXylene);
+  }
+
+  @Test
+  public void testWashFluidRecommendationAndPlanning() {
+    // Salt-dominated deposit -> water recommended.
+    CompressorDeposit saltDep = new CompressorDeposit(0.6, 0.02);
+    saltDep.addDeposit(DepositMechanism.SALT_NACL, 5.0);
+    assertEquals(WashFluid.WATER, CompressorDepositWash.recommend(saltDep));
+
+    // Sulfur-dominated deposit -> aromatic solvent recommended (xylene or toluene).
+    CompressorDeposit s8Dep = new CompressorDeposit(0.6, 0.02);
+    s8Dep.addDeposit(DepositMechanism.SULFUR_S8, 5.0);
+    WashFluid rec = CompressorDepositWash.recommend(s8Dep);
+    assertTrue(rec == WashFluid.XYLENE || rec == WashFluid.TOLUENE);
+
+    // Planning: required rate to remove 4 kg salt in 2 hours, then verify it works.
+    CompressorDepositWash washer = new CompressorDepositWash();
+    double rate = washer.requiredFluidRateKgHr(saltDep, WashFluid.WATER, 4.0, 2.0);
+    assertTrue(rate > 0.0 && Double.isFinite(rate));
+    CompressorDepositWash.WashResult r = washer.wash(saltDep, WashFluid.WATER, rate, 2.0);
+    assertEquals(4.0, r.getTotalRemovedKg(), 1e-6);
+  }
+
+  @Test
+  public void testCompressorWashOnlineConvenience() {
+    Compressor comp = buildCompressor(0.60);
+    CompressorDeposit dep = CompressorDeposit.fromCompressor(comp);
+    dep.addDeposit(DepositMechanism.SALT_NACL, 2.0);
+    comp.setDepositModel(dep);
+    comp.run();
+    double fouledPower = comp.getPower();
+
+    // Recommend and wash online, then re-run: power should drop back toward clean.
+    WashFluid fluid = CompressorDepositWash.recommend(dep);
+    assertEquals(WashFluid.WATER, fluid);
+    CompressorDepositWash.WashResult result = comp.washOnline(fluid, 300.0, 3.0);
+    assertNotNull(result);
+    assertTrue(result.getTotalRemovedKg() > 0.0);
+    comp.run();
+    assertTrue(comp.getPower() <= fouledPower);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a mass-based compressor **fouling / deposit degradation** model and **online (live) washing** to NeqSim. It links deposit-generating flow-assurance calculations (elemental sulfur S8, salt from entrained produced water, mineral scale, wax) to centrifugal-compressor performance, and answers four operational questions:

1. **How much deposit** accumulates (one or several mechanisms combined)?
2. **What is the performance effect** — polytropic efficiency, head, power, discharge temperature, and the **degraded compressor chart after N operating hours**?
3. **Where do deposits form** — which impeller/stage?
4. **How to clean it** — plan and simulate online washing, and recommend a wash fluid (water for salt, xylene for sulfur).

## What's new

### New classes (`neqsim.process.equipment.compressor`)
| Class | Purpose |
|-------|---------|
| `DepositMechanism` | Deposit types (S8, NaCl, CaCO3/BaSO4/CaSO4, FeS, iron oxide, wax, particulate) each with a solid density |
| `CompressorDeposit` | Mass-based, multi-mechanism deposit inventory → flow-area blockage → polytropic efficiency & head multipliers; calibratable coefficients; inverse solve; per-mechanism removal |
| `DepositSource` | Interface: a precipitation calculation that yields a deposition rate |
| `SolidFlashDepositSource` | Deposition rate from a `TPSolidflash` (S8, wax) on a stream |
| `EntrainedSaltDepositSource` | Salt precipitation from evaporating entrained produced water (non-volatile mass balance) |
| `CompressorDepositProfile` | Per-impeller deposit location (screening interpolation and rigorous per-step flashed states via `CompressorPropertyProfile`) |
| `WashFluid` | Wash fluids (water, xylene, toluene, condensate, methanol) with a deposit-solubility matrix |
| `CompressorDepositWash` | Recommend a wash fluid, plan rate/duration, simulate dissolution |

### `Compressor` integration
- `setDepositModel(...)` — `run()` now degrades polytropic efficiency from a **fixed clean baseline (non-compounding)**, so power and discharge temperature reflect the fouled machine. This also makes the previously-dead `degradationFactor` / `foulingFactor` fields actually take effect.
- `buildDegradedChart()` — the performance map after N hours for chart-based machines (`CompressorChart.getDegradedChart(headMult, effMult)`). The chart path degrades via the degraded chart, **not** the run-time efficiency multiplier, so the efficiency loss is never double-counted.
- `washOnline(fluid, rateKgHr, hours)` — online wash of the attached deposit model.

## Physics (screening-level, calibratable)

$$
V = \sum_i \frac{m_i}{\rho_i}, \quad b = \min\!\left(\frac{V/A_\text{wetted}}{h_\text{passage}}, b_\text{max}\right), \quad
m_\text{eff} = 1 - k_\text{eff} b, \quad m_\text{head} = (1-b)^{n_\text{head}}
$$

Wash removal per mechanism: `removed = min(deposit, rate · solubility · contactEfficiency · duration)` — a fluid only removes deposits it can dissolve, so water leaves S8 and xylene leaves salt. Deposits concentrate on the **cold first impeller** in a single body (rising temperature raises S8 solubility) and re-form after each intercooler in a train.

## Usage

```java
// Deposit amount from the process, combined mechanisms
CompressorDeposit dep = CompressorDeposit.fromCompressor(comp);
dep.accumulate(new SolidFlashDepositSource(feed, "S8", DepositMechanism.SULFUR_S8, 0.3), 500.0);
dep.accumulate(new EntrainedSaltDepositSource(10.0, 0.05), 500.0);
comp.setDepositModel(dep);            // run() reflects degraded machine
CompressorChart chart500 = comp.buildDegradedChart();               // map after 500 h

// Where it lands, and how to clean it
int worst = CompressorDepositProfile.worstStage(
    CompressorDepositProfile.compute(feed, dischargeT, dischargeP, 5, "S8"));
WashFluid fluid = CompressorDepositWash.recommend(dep);             // salt→WATER, S8→XYLENE
comp.washOnline(fluid, 300.0, 3.0);   // online wash; run() recovers performance
```

## Documentation, skills & agents (agentic workflows)
- **Doc:** `docs/process/compressor_deposit_degradation.md` (linked from the reference-manual index and process README).
- **Skills:** compressor deposit/degradation/washing recipe added to `neqsim-api-patterns`; cross-reference subsection added to `neqsim-flow-assurance`.
- **Agents:** trigger notes added to `flow.assurance` and `root.cause` agents so the capability is used in agentic diagnosis/flow-assurance workflows.

## Tests
`CompressorDepositTest` — **15 tests** covering deposit→performance, the precipitation bridge (S8 solid flash + entrained-salt mass balance), per-impeller location (screening + rigorous), the degraded chart, and washing (fluid recommendation, planning, sequential salt-then-sulfur wash). Existing compressor tests (`CompressorTest`, `CompressorChartTest`, `CompressorWashingTest`, `CompressorOperatingPointTest`) unaffected. Spotless applied; Java 8 compatible.

## Notes
- Deposit→performance relations and wash-fluid solubilities are screening-level — calibrate `kEff`/`headExponent` and qualify a wash solvent before quantitative field use.
- Scope was kept to the compressor deposit/degradation/washing feature; unrelated in-progress work in the working tree was intentionally excluded from this branch.
