### PR TITLE
Add setRecycleMinimumFlow convenience methods to ProcessSystem and Pr…

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -2583,6 +2583,25 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
+   * Sets the minimum tear-stream flow on every {@link neqsim.process.equipment.util.Recycle} unit across all
+   * process-area {@link ProcessSystem}s of this model.
+   *
+   * @param minimumFlowKgPerHr the minimum recycle flow rate in kg/hr; must be non-negative
+   * @return the total number of recycle units updated across all areas
+   * @throws IllegalArgumentException if {@code minimumFlowKgPerHr} is negative
+   */
+  public int setRecycleMinimumFlow(double minimumFlowKgPerHr) {
+    if (minimumFlowKgPerHr < 0.0) {
+      throw new IllegalArgumentException("minimumFlowKgPerHr cannot be negative");
+    }
+    int total = 0;
+    for (ProcessSystem area : processes.values()) {
+      total += area.setRecycleMinimumFlow(minimumFlowKgPerHr);
+    }
+    return total;
+  }
+
+  /**
    * Creates a Graphviz exporter for common plant-wide and per-area DOT diagrams.
    *
    * @return a new {@link ProcessModelGraphvizExporter} for this model

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -831,6 +831,32 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
+   * Sets the minimum tear-stream flow on every {@link Recycle} unit in this process system.
+   *
+   * <p>
+   * The minimum flow acts as a lower bound on the recycle tear-stream flow rate and helps stabilize recycle loops that
+   * would otherwise collapse to a near-zero flow.
+   * </p>
+   *
+   * @param minimumFlowKgPerHr the minimum recycle flow rate in kg/hr; must be non-negative
+   * @return the number of {@link Recycle} units updated
+   * @throws IllegalArgumentException if {@code minimumFlowKgPerHr} is negative
+   */
+  public int setRecycleMinimumFlow(double minimumFlowKgPerHr) {
+    if (minimumFlowKgPerHr < 0.0) {
+      throw new IllegalArgumentException("minimumFlowKgPerHr cannot be negative");
+    }
+    int count = 0;
+    for (ProcessEquipmentInterface unit : unitOperations) {
+      if (unit instanceof Recycle) {
+        ((Recycle) unit).setMinimumFlow(minimumFlowKgPerHr);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
    * Validates the process system setup before execution.
    *
    * <p>

--- a/src/test/java/neqsim/process/processmodel/RecycleAccelerationConvenienceTest.java
+++ b/src/test/java/neqsim/process/processmodel/RecycleAccelerationConvenienceTest.java
@@ -1,0 +1,106 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.util.AccelerationMethod;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests for the recycle-acceleration convenience methods on {@link ProcessSystem} and {@link ProcessModel}.
+ */
+class RecycleAccelerationConvenienceTest {
+  private static StreamInterface makeStream(String name) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream(name, fluid);
+    stream.setFlowRate(10.0, "kg/hr");
+    return stream;
+  }
+
+  private static ProcessSystem makeProcessWithRecycles(String prefix, int numberOfRecycles) {
+    ProcessSystem process = new ProcessSystem();
+    for (int i = 0; i < numberOfRecycles; i++) {
+      Recycle recycle = new Recycle(prefix + " recycle " + i);
+      recycle.addStream(makeStream(prefix + " feed " + i));
+      process.add(recycle);
+    }
+    return process;
+  }
+
+  @Test
+  void testProcessSystemSetsWegsteinOnAllRecycles() {
+    ProcessSystem process = makeProcessWithRecycles("A", 3);
+    // add a non-recycle unit to confirm it is ignored
+    process.add(makeStream("plain feed"));
+
+    int updated = process.setRecycleAccelerationMethod(AccelerationMethod.WEGSTEIN);
+
+    assertEquals(3, updated);
+    for (neqsim.process.equipment.ProcessEquipmentInterface unit : process.getUnitOperations()) {
+      if (unit instanceof Recycle) {
+        assertEquals(AccelerationMethod.WEGSTEIN, ((Recycle) unit).getAccelerationMethod());
+      }
+    }
+  }
+
+  @Test
+  void testProcessSystemSetsMinimumFlow() {
+    ProcessSystem process = makeProcessWithRecycles("A", 2);
+
+    int updated = process.setRecycleMinimumFlow(5.0);
+
+    assertEquals(2, updated);
+    for (neqsim.process.equipment.ProcessEquipmentInterface unit : process.getUnitOperations()) {
+      if (unit instanceof Recycle) {
+        assertEquals(5.0, ((Recycle) unit).getMinimumFlow(), 1e-12);
+      }
+    }
+  }
+
+  @Test
+  void testProcessSystemNullMethodThrows() {
+    ProcessSystem process = makeProcessWithRecycles("A", 1);
+    assertThrows(IllegalArgumentException.class, () -> process.setRecycleAccelerationMethod(null));
+  }
+
+  @Test
+  void testProcessSystemNegativeMinimumFlowThrows() {
+    ProcessSystem process = makeProcessWithRecycles("A", 1);
+    assertThrows(IllegalArgumentException.class, () -> process.setRecycleMinimumFlow(-1.0));
+  }
+
+  @Test
+  void testProcessModelSetsWegsteinAcrossAllAreas() {
+    ProcessModel model = new ProcessModel();
+    model.add("area A", makeProcessWithRecycles("A", 2));
+    model.add("area B", makeProcessWithRecycles("B", 3));
+
+    int updated = model.setRecycleAccelerationMethod(AccelerationMethod.WEGSTEIN);
+
+    assertEquals(5, updated);
+    for (ProcessSystem area : model.getAllProcesses()) {
+      for (neqsim.process.equipment.ProcessEquipmentInterface unit : area.getUnitOperations()) {
+        if (unit instanceof Recycle) {
+          assertEquals(AccelerationMethod.WEGSTEIN, ((Recycle) unit).getAccelerationMethod());
+        }
+      }
+    }
+  }
+
+  @Test
+  void testProcessModelSetsMinimumFlowAcrossAllAreas() {
+    ProcessModel model = new ProcessModel();
+    model.add("area A", makeProcessWithRecycles("A", 1));
+    model.add("area B", makeProcessWithRecycles("B", 2));
+
+    int updated = model.setRecycleMinimumFlow(7.5);
+
+    assertEquals(3, updated);
+  }
+}


### PR DESCRIPTION
…ocessModel

Sets the minimum tear-stream flow on every Recycle unit in a ProcessSystem (or across all areas of a ProcessModel) in one call, complementing the existing setRecycleAccelerationMethod. Helps stabilize low-flow recycle loops that would otherwise collapse to near-zero flow. Adds RecycleAccelerationConvenienceTest covering counts, value propagation, and argument validation.

# Pull Request

Thank you for contributing to NeqSim! Please complete the following checklist before requesting review:

- [ ] Confirm `./mvnw test` runs successfully
- [ ] Verify code formatting using Checkstyle
- [ ] Update any relevant docs/README
- [ ] Link to an associated issue or discussion

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution process.
