### PR TITLE
Add CoolantBoilingMargin helper for gas cooler coolant boiling screening

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -11,6 +11,34 @@
 
 ---
 
+## 2026-07-14 — New: `CoolantBoilingMargin` coolant boiling-margin helper (heatexchanger)
+
+### Summary
+
+Additive utility for liquid-cooled gas coolers / heat exchangers: a one-call screen of the
+coolant-side boiling constraint (coolant must stay sub-cooled relative to the hot process-side
+temperature). Motivated by a Gullfaks A export-cooler (27-HX01A/B) study where the safety limit
+was the coolant boiling pressure at the 140 C gas inlet. No change to existing behaviour.
+
+### New capability
+
+- **`neqsim.process.equipment.heatexchanger.CoolantBoilingMargin`** — static
+  `evaluate(SystemInterface coolant, double coolantPressureBara, double hotSideTemperatureC)`
+  and `evaluate(..., double minimumMarginC)`. Clones the coolant fluid (caller not modified),
+  runs a `bubblePointTemperatureFlash` at the coolant pressure, and returns an immutable
+  `Result` with `getSaturationTemperatureC()`, `getSubcoolingMarginC()` (= Tsat - hotSideT),
+  `isBoiling()` (margin <= 0), and `isWithinMargin()` (margin >= minimumMargin). Saturation
+  temperature is `NaN` (not an exception) if the bubble-point flash does not converge.
+- Tests: `CoolantBoilingMarginTest` (5, all pass): water margin monotonic in pressure, ~0 at
+  the operator 2.5 barg floor at 140 C gas, Tsat ~140 C at the floor, min-margin logic,
+  caller-fluid-not-modified, invalid-input guards. Spotless clean.
+
+### Migration
+
+None (purely additive). Java 8 compatible; log4j2 logging; no `System.out`.
+
+---
+
 ## 2026-07-13 — New: multi-source decision-support helpers in `neqsim.util.agentic`
 
 ### Summary

--- a/src/main/java/neqsim/process/equipment/heatexchanger/CoolantBoilingMargin.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/CoolantBoilingMargin.java
@@ -1,0 +1,202 @@
+package neqsim.process.equipment.heatexchanger;
+
+import java.io.Serializable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Coolant boiling-margin helper for gas coolers and heat exchangers.
+ *
+ * <p>
+ * On a tempered-water / cooling-medium loop the coolant must stay sub-cooled (above its boiling pressure) relative to
+ * the hottest surface it contacts, i.e. the hot process-side inlet temperature. This helper computes the coolant
+ * saturation temperature at a given coolant pressure and the resulting sub-cooling margin against a hot-side
+ * temperature, and flags a boiling risk. It is a screening aid: it evaluates a thermodynamic bubble-point on a clone of
+ * the supplied coolant fluid and never modifies the caller's fluid.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class CoolantBoilingMargin {
+  /** Logger instance. */
+  private static final Logger logger = LogManager.getLogger(CoolantBoilingMargin.class);
+
+  /**
+   * Private constructor to prevent instantiation of this utility class.
+   */
+  private CoolantBoilingMargin() {
+  }
+
+  /**
+   * Immutable result of a coolant boiling-margin evaluation.
+   *
+   * @author NeqSim
+   * @version 1.0
+   */
+  public static class Result implements Serializable {
+    /** Serialization version UID. */
+    private static final long serialVersionUID = 1000L;
+
+    /** Coolant pressure used for the evaluation [bara]. */
+    private final double coolantPressureBara;
+    /** Coolant saturation (boiling) temperature at the coolant pressure [C]. */
+    private final double saturationTemperatureC;
+    /** Hot-side contact temperature the coolant is screened against [C]. */
+    private final double hotSideTemperatureC;
+    /** Sub-cooling margin = saturationTemperature - hotSideTemperature [C]. */
+    private final double subcoolingMarginC;
+    /** Minimum acceptable sub-cooling margin used for the {@code withinMargin} flag [C]. */
+    private final double minimumMarginC;
+
+    /**
+     * Constructor for Result.
+     *
+     * @param coolantPressureBara coolant pressure used for the evaluation [bara]
+     * @param saturationTemperatureC coolant saturation temperature at that pressure [C] (may be {@link Double#NaN} if
+     * the bubble-point flash did not converge)
+     * @param hotSideTemperatureC hot-side contact temperature [C]
+     * @param minimumMarginC minimum acceptable sub-cooling margin [C]
+     */
+    public Result(double coolantPressureBara, double saturationTemperatureC, double hotSideTemperatureC,
+        double minimumMarginC) {
+      this.coolantPressureBara = coolantPressureBara;
+      this.saturationTemperatureC = saturationTemperatureC;
+      this.hotSideTemperatureC = hotSideTemperatureC;
+      this.subcoolingMarginC = saturationTemperatureC - hotSideTemperatureC;
+      this.minimumMarginC = minimumMarginC;
+    }
+
+    /**
+     * Getter for the coolant pressure used.
+     *
+     * @return coolant pressure [bara]
+     */
+    public double getCoolantPressureBara() {
+      return coolantPressureBara;
+    }
+
+    /**
+     * Getter for the coolant saturation temperature.
+     *
+     * @return saturation (boiling) temperature [C], or {@link Double#NaN} if not converged
+     */
+    public double getSaturationTemperatureC() {
+      return saturationTemperatureC;
+    }
+
+    /**
+     * Getter for the hot-side temperature.
+     *
+     * @return hot-side contact temperature [C]
+     */
+    public double getHotSideTemperatureC() {
+      return hotSideTemperatureC;
+    }
+
+    /**
+     * Getter for the sub-cooling margin.
+     *
+     * @return sub-cooling margin = saturationTemperature - hotSideTemperature [C]
+     */
+    public double getSubcoolingMarginC() {
+      return subcoolingMarginC;
+    }
+
+    /**
+     * Getter for the minimum acceptable margin.
+     *
+     * @return minimum acceptable sub-cooling margin [C]
+     */
+    public double getMinimumMarginC() {
+      return minimumMarginC;
+    }
+
+    /**
+     * Indicates whether the coolant would boil at the evaluated pressure, i.e. its saturation temperature is at or
+     * below the hot-side temperature.
+     *
+     * @return true if the sub-cooling margin is not strictly positive
+     */
+    public boolean isBoiling() {
+      return !Double.isNaN(subcoolingMarginC) && subcoolingMarginC <= 0.0;
+    }
+
+    /**
+     * Indicates whether the sub-cooling margin meets the requested minimum margin.
+     *
+     * @return true if the margin is greater than or equal to the minimum acceptable margin
+     */
+    public boolean isWithinMargin() {
+      return !Double.isNaN(subcoolingMarginC) && subcoolingMarginC >= minimumMarginC;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+      return String.format(
+          "CoolantBoilingMargin[P=%.3f bara, Tsat=%.2f C, hotSide=%.2f C, margin=%.2f C, "
+              + "boiling=%b, withinMargin=%b]",
+          coolantPressureBara, saturationTemperatureC, hotSideTemperatureC, subcoolingMarginC, isBoiling(),
+          isWithinMargin());
+    }
+  }
+
+  /**
+   * Evaluate the coolant boiling margin at a given coolant pressure against a hot-side temperature, using a zero
+   * minimum-margin criterion.
+   *
+   * @param coolant coolant fluid (e.g. water / tempered cooling medium); not modified
+   * @param coolantPressureBara coolant pressure to evaluate [bara]; must be positive
+   * @param hotSideTemperatureC hot process-side contact temperature [C]
+   * @return the boiling-margin result
+   * @throws IllegalArgumentException if coolant is null or the pressure is not positive
+   */
+  public static Result evaluate(SystemInterface coolant, double coolantPressureBara, double hotSideTemperatureC) {
+    return evaluate(coolant, coolantPressureBara, hotSideTemperatureC, 0.0);
+  }
+
+  /**
+   * Evaluate the coolant boiling margin at a given coolant pressure against a hot-side temperature.
+   *
+   * <p>
+   * The supplied coolant fluid is cloned; its pressure is set to {@code coolantPressureBara} and a bubble-point
+   * temperature flash gives the coolant saturation temperature. The sub-cooling margin is the saturation temperature
+   * minus the hot-side temperature. If the bubble-point flash does not converge the saturation temperature (and margin)
+   * are {@link Double#NaN}.
+   * </p>
+   *
+   * @param coolant coolant fluid (e.g. water / tempered cooling medium); not modified
+   * @param coolantPressureBara coolant pressure to evaluate [bara]; must be positive
+   * @param hotSideTemperatureC hot process-side contact temperature [C]
+   * @param minimumMarginC minimum acceptable sub-cooling margin [C]; used for the withinMargin flag
+   * @return the boiling-margin result
+   * @throws IllegalArgumentException if coolant is null or the pressure is not positive
+   */
+  public static Result evaluate(SystemInterface coolant, double coolantPressureBara, double hotSideTemperatureC,
+      double minimumMarginC) {
+    if (coolant == null) {
+      throw new IllegalArgumentException("coolant fluid cannot be null");
+    }
+    if (!(coolantPressureBara > 0.0)) {
+      throw new IllegalArgumentException("coolantPressureBara must be positive");
+    }
+    SystemInterface fluid = coolant.clone();
+    fluid.setPressure(coolantPressureBara, "bara");
+    double saturationTemperatureC;
+    try {
+      ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
+      ops.bubblePointTemperatureFlash();
+      saturationTemperatureC = fluid.getTemperature("C");
+      if (Double.isNaN(saturationTemperatureC)) {
+        logger.warn("bubble point temperature flash returned NaN at {} bara", coolantPressureBara);
+      }
+    } catch (Exception ex) {
+      logger.warn("bubble point temperature flash failed at {} bara: {}", coolantPressureBara, ex.getMessage());
+      saturationTemperatureC = Double.NaN;
+    }
+    return new Result(coolantPressureBara, saturationTemperatureC, hotSideTemperatureC, minimumMarginC);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/heatexchanger/CoolantBoilingMarginTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/CoolantBoilingMarginTest.java
@@ -1,0 +1,112 @@
+package neqsim.process.equipment.heatexchanger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+
+/**
+ * Unit tests for {@link CoolantBoilingMargin}.
+ *
+ * <p>
+ * Reproduces the Gullfaks A export-cooler (27-HX01A/B) coolant boiling screening: a tempered-water coolant must stay
+ * above its boiling pressure at the 140 C gas inlet. The operator-quoted 2.5 barg floor corresponds to the water
+ * saturation pressure at 140 C.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class CoolantBoilingMarginTest {
+  /** Standard atmosphere used to convert barg operating points to bara [bar]. */
+  private static final double ATM = 1.01325;
+
+  /**
+   * Build a pure-water coolant fluid using the CPA model.
+   *
+   * @return a single-component water {@link SystemInterface}
+   */
+  private static SystemInterface waterCoolant() {
+    SystemInterface water = new SystemSrkCPAstatoil(273.15 + 100.0, 5.0);
+    water.addComponent("water", 1.0);
+    water.setMixingRule(10);
+    return water;
+  }
+
+  /**
+   * At the 140 C hot-gas temperature the coolant sub-cooling margin should decrease monotonically as the coolant
+   * pressure falls, cross ~zero near the operator's 2.5 barg floor, and stay clearly positive at 4.7 barg.
+   */
+  @Test
+  void marginDecreasesAndCrossesZeroNearFloor() {
+    SystemInterface water = waterCoolant();
+    double hot = 140.0;
+    CoolantBoilingMargin.Result r47 = CoolantBoilingMargin.evaluate(water, 4.7 + ATM, hot);
+    CoolantBoilingMargin.Result r30 = CoolantBoilingMargin.evaluate(water, 3.0 + ATM, hot);
+    CoolantBoilingMargin.Result r25 = CoolantBoilingMargin.evaluate(water, 2.5 + ATM, hot);
+
+    // Monotonic: higher coolant pressure -> higher saturation temperature -> more margin.
+    assertTrue(r47.getSubcoolingMarginC() > r30.getSubcoolingMarginC());
+    assertTrue(r30.getSubcoolingMarginC() > r25.getSubcoolingMarginC());
+
+    // 4.7 barg keeps a large margin (study: ~+17 C), not boiling.
+    assertTrue(r47.getSubcoolingMarginC() > 10.0);
+    assertFalse(r47.isBoiling());
+
+    // 3.0 barg keeps a small positive margin (study: ~+4 C), not boiling.
+    assertTrue(r30.getSubcoolingMarginC() > 1.0);
+    assertFalse(r30.isBoiling());
+
+    // 2.5 barg sits at incipient boiling (study: ~0 C margin).
+    assertTrue(Math.abs(r25.getSubcoolingMarginC()) < 2.0);
+  }
+
+  /**
+   * The saturation temperature at the 2.5 barg floor should be close to the 140 C gas temperature, i.e. the floor is
+   * the coolant saturation pressure at the hot-side temperature.
+   */
+  @Test
+  void saturationTemperatureAtFloorNear140C() {
+    SystemInterface water = waterCoolant();
+    CoolantBoilingMargin.Result r25 = CoolantBoilingMargin.evaluate(water, 2.5 + ATM, 140.0);
+    assertEquals(140.0, r25.getSaturationTemperatureC(), 3.0);
+  }
+
+  /**
+   * The minimum-margin criterion should classify a 3 C required margin as met at 3 barg but not at 2.5 barg.
+   */
+  @Test
+  void withinMarginRespectsMinimum() {
+    SystemInterface water = waterCoolant();
+    double hot = 140.0;
+    double minMargin = 3.0;
+    CoolantBoilingMargin.Result r30 = CoolantBoilingMargin.evaluate(water, 3.0 + ATM, hot, minMargin);
+    CoolantBoilingMargin.Result r25 = CoolantBoilingMargin.evaluate(water, 2.5 + ATM, hot, minMargin);
+    assertTrue(r30.isWithinMargin());
+    assertFalse(r25.isWithinMargin());
+  }
+
+  /**
+   * The evaluation must not modify the caller's coolant fluid (it clones internally).
+   */
+  @Test
+  void callerFluidIsNotModified() {
+    SystemInterface water = waterCoolant();
+    double pBefore = water.getPressure("bara");
+    CoolantBoilingMargin.evaluate(water, 3.0 + ATM, 140.0);
+    assertEquals(pBefore, water.getPressure("bara"), 1.0e-9);
+  }
+
+  /**
+   * Invalid inputs should raise {@link IllegalArgumentException}.
+   */
+  @Test
+  void invalidInputsThrow() {
+    SystemInterface water = waterCoolant();
+    assertThrows(IllegalArgumentException.class, () -> CoolantBoilingMargin.evaluate(null, 3.0, 140.0));
+    assertThrows(IllegalArgumentException.class, () -> CoolantBoilingMargin.evaluate(water, 0.0, 140.0));
+  }
+}


### PR DESCRIPTION
## Summary
Adds `neqsim.process.equipment.heatexchanger.CoolantBoilingMargin` — a one-call screen of the coolant-side boiling constraint for liquid-cooled gas coolers / heat exchangers. On a tempered-water cooling loop the coolant must stay sub-cooled relative to the hottest surface it contacts (the hot process-side inlet). This helper computes the coolant saturation temperature at a given coolant pressure and the sub-cooling margin against a hot-side temperature, and flags a boiling risk.

## API
- `CoolantBoilingMargin.evaluate(SystemInterface coolant, double coolantPressureBara, double hotSideTemperatureC)` and a `minimumMarginC` overload.
- Returns an immutable `Result` with `getSaturationTemperatureC()`, `getSubcoolingMarginC()` (= Tsat − hot-side T), `isBoiling()` (margin ≤ 0), `isWithinMargin()` (margin ≥ minimum).
- Clones the coolant fluid (caller not modified); runs `bubblePointTemperatureFlash`; returns `NaN` (no exception) if the flash does not converge.

## Motivation
Derived from a Gullfaks A export-gas cooler (27-HX01A/B) study where the operating safety limit was the coolant boiling pressure at the 140 °C gas inlet; the operator's 2.5 barg floor equals the water saturation pressure at 140 °C. The margin previously had to be assembled by hand (CPA water flash + Tsat inversion).

## Tests
- `CoolantBoilingMarginTest` — 5 JUnit 5 tests (margin monotonic in pressure, ~0 at the 2.5 barg floor at 140 °C, Tsat ≈ 140 °C at the floor, min-margin logic, caller-fluid-not-modified, invalid-input guards). All pass.
- Java 8 compatible; log4j2 logging (no System.out); Spotless clean.