### PR TITLE
GasTurbine simple-cycle efficiency, compressor-chart surge JSON arrays, tunable anti-surge gain

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -2210,15 +2210,55 @@ public class Compressor extends TwoPortEquipment
     }
     json.append("  ],\n");
 
-    // Surge and stonewall info
-    json.append("  \"surgeCurve\": { \"active\": ").append(compressorChart.getSurgeCurve() != null).append(" },\n");
-    json.append("  \"stonewallCurve\": { \"active\": ")
-        .append(compressorChart.getStoneWallCurve() != null && compressorChart.getStoneWallCurve().isActive())
-        .append(" }\n");
+    // Surge curve (flow/head arrays included when available, so consumers do not have to
+    // reconstruct the surge line from the lowest-flow point of each speed curve).
+    SafeSplineSurgeCurve surge = compressorChart.getSurgeCurve();
+    json.append("  \"surgeCurve\": { \"active\": ").append(surge != null);
+    if (surge != null && surge.getSortedFlow() != null && surge.getSortedHead() != null
+        && surge.getSortedFlow().length > 0) {
+      json.append(", \"flow_m3h\": ");
+      appendDoubleArray(json, surge.getSortedFlow());
+      json.append(", \"head_kJkg\": ");
+      appendDoubleArray(json, surge.getSortedHead());
+    }
+    json.append(" },\n");
+
+    // Stonewall (choke) curve (flow/head arrays included when a spline stonewall curve is present).
+    StoneWallCurve stone = compressorChart.getStoneWallCurve();
+    json.append("  \"stonewallCurve\": { \"active\": ").append(stone != null && stone.isActive());
+    if (stone instanceof SafeSplineStoneWallCurve) {
+      SafeSplineStoneWallCurve splineStone = (SafeSplineStoneWallCurve) stone;
+      if (splineStone.getSortedFlow() != null && splineStone.getSortedHead() != null
+          && splineStone.getSortedFlow().length > 0) {
+        json.append(", \"flow_m3h\": ");
+        appendDoubleArray(json, splineStone.getSortedFlow());
+        json.append(", \"head_kJkg\": ");
+        appendDoubleArray(json, splineStone.getSortedHead());
+      }
+    }
+    json.append(" }\n");
 
     json.append("}");
 
     return json.toString();
+  }
+
+  /**
+   * Append a double array to a JSON string builder as a bracketed, comma-separated list with two-decimal US-locale
+   * formatting.
+   *
+   * @param json the string builder to append to
+   * @param values the values to append
+   */
+  private static void appendDoubleArray(StringBuilder json, double[] values) {
+    json.append("[");
+    for (int i = 0; i < values.length; i++) {
+      json.append(String.format(java.util.Locale.US, "%.2f", values[i]));
+      if (i < values.length - 1) {
+        json.append(", ");
+      }
+    }
+    json.append("]");
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/powergeneration/GasTurbine.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/GasTurbine.java
@@ -53,6 +53,14 @@ public class GasTurbine extends TwoPortEquipment implements CapacityConstrainedE
   double compressorPower = 0.0;
   private double heat = 0.0;
 
+  /**
+   * Optional simple-cycle thermal efficiency (net shaft power / fuel lower heating value). When set to a value in (0,
+   * 1], {@link #run(UUID)} reports {@link #getPower()} directly from the fuel LHV, giving a realistic driver power for
+   * screening studies independent of the detailed air-compressor / expander pressure-ratio assumptions. The default of
+   * 0 keeps the detailed Brayton-cycle power balance.
+   */
+  private double thermalEfficiency = 0.0;
+
   public double power = 0.0;
 
   /** Rated (maximum) power output in Watts. Used for capacity constraint calculations. */
@@ -202,6 +210,15 @@ public class GasTurbine extends TwoPortEquipment implements CapacityConstrainedE
     // (-expanderPower) - compressorPower.
     power = -expanderPower - compressorPower;
     this.heat = cooler1.getDuty();
+
+    // Simple-cycle override: when a thermal efficiency (or heat rate) is set, report the net shaft
+    // power directly from the fuel lower heating value and treat the remainder as exhaust heat. This
+    // gives a realistic driver power out of the box for screening studies, independent of the
+    // detailed air-compressor / expander pressure-ratio assumptions of the Brayton cycle above.
+    if (thermalEfficiency > 0.0) {
+      power = thermalEfficiency * heatOfCombustion;
+      this.heat = heatOfCombustion - power;
+    }
     setCalculationIdentifier(id);
   }
 
@@ -314,6 +331,51 @@ public class GasTurbine extends TwoPortEquipment implements CapacityConstrainedE
    */
   public void setExcessAirFactor(double excessAirFactor) {
     this.excessAirFactor = excessAirFactor;
+  }
+
+  /**
+   * Get the simple-cycle thermal efficiency used to report net shaft power.
+   *
+   * @return thermal efficiency (0 = disabled, detailed Brayton-cycle balance used)
+   */
+  public double getThermalEfficiency() {
+    return thermalEfficiency;
+  }
+
+  /**
+   * Set a simple-cycle thermal efficiency so {@link #getPower()} is reported directly from the fuel lower heating
+   * value. Typical simple-cycle gas turbines are 0.30-0.42 (aeroderivative up to ~0.42). Set to 0 to restore the
+   * detailed Brayton-cycle power balance.
+   *
+   * @param thermalEfficiency net shaft power divided by fuel lower heating value, in the range [0, 1]
+   */
+  public void setThermalEfficiency(double thermalEfficiency) {
+    if (thermalEfficiency < 0.0 || thermalEfficiency > 1.0) {
+      throw new IllegalArgumentException("thermal efficiency must be between 0 and 1");
+    }
+    this.thermalEfficiency = thermalEfficiency;
+  }
+
+  /**
+   * Get the heat rate implied by the current simple-cycle thermal efficiency.
+   *
+   * @return heat rate in kJ of fuel (LHV) per kWh of net shaft power, or {@link Double#NaN} when no efficiency is set
+   */
+  public double getHeatRate() {
+    return thermalEfficiency > 0.0 ? 3600.0 / thermalEfficiency : Double.NaN;
+  }
+
+  /**
+   * Set the simple-cycle heat rate. This is an alternative to {@link #setThermalEfficiency(double)}; the two are
+   * related by efficiency = 3600 / heatRate. For example 10286 kJ/kWh corresponds to 35 % efficiency.
+   *
+   * @param heatRateKJperKWh heat rate in kJ of fuel (LHV) per kWh of net shaft power (must be positive)
+   */
+  public void setHeatRate(double heatRateKJperKWh) {
+    if (heatRateKJperKWh <= 0.0) {
+      throw new IllegalArgumentException("heat rate must be positive");
+    }
+    this.thermalEfficiency = 3600.0 / heatRateKJperKWh;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/util/Calculator.java
+++ b/src/main/java/neqsim/process/equipment/util/Calculator.java
@@ -41,12 +41,42 @@ public class Calculator extends ProcessEquipmentBaseClass {
   private static final double ANTI_SURGE_MAX_RECYCLE_FACTOR = 2.0;
 
   /**
+   * Anti-surge: proportional (relaxation) gain applied to the surge-inlet flow gap when stepping the recycle setpoint.
+   * The default of 0.5 reproduces the legacy behaviour. Lowering it (e.g. 0.2-0.3) damps the recycle response and
+   * suppresses run-to-run oscillation at deep turndown at the cost of slower convergence.
+   */
+  private double antiSurgeProportionalGain = 0.5;
+
+  /**
    * Constructor for Calculator.
    *
    * @param name a {@link java.lang.String} object
    */
   public Calculator(String name) {
     super(name);
+  }
+
+  /**
+   * Get the anti-surge proportional (relaxation) gain applied to the surge-inlet flow gap.
+   *
+   * @return the proportional gain (default 0.5)
+   */
+  public double getAntiSurgeProportionalGain() {
+    return antiSurgeProportionalGain;
+  }
+
+  /**
+   * Set the anti-surge proportional (relaxation) gain applied to the surge-inlet flow gap when stepping the recycle
+   * setpoint. Values in (0, 1]; the default 0.5 reproduces the legacy response, lower values damp run-to-run
+   * oscillation at deep turndown.
+   *
+   * @param antiSurgeProportionalGain the proportional gain, must be greater than 0 and not greater than 1
+   */
+  public void setAntiSurgeProportionalGain(double antiSurgeProportionalGain) {
+    if (antiSurgeProportionalGain <= 0.0 || antiSurgeProportionalGain > 1.0) {
+      throw new IllegalArgumentException("anti-surge proportional gain must be in the range (0, 1]");
+    }
+    this.antiSurgeProportionalGain = antiSurgeProportionalGain;
   }
 
   /**
@@ -161,7 +191,7 @@ public class Calculator extends ProcessEquipmentBaseClass {
     // the fixed point is inletFlow == surgeFlow regardless of the recycle
     // path topology. This matches the legacy formula exactly while adding a
     // 25%-of-max-flow per-iteration cap to prevent single-step overshoot.
-    double rawStep = 0.5 * (surgeFlow - inletFlow);
+    double rawStep = antiSurgeProportionalGain * (surgeFlow - inletFlow);
     double maxStep = 0.25 * Math.max(currentRecycle, Math.max(inletFlow, surgeFlow));
     double cappedStep = Math.max(-maxStep, Math.min(maxStep, rawStep));
     double flowAntiSurge = Math.max(currentRecycle + cappedStep, inletFlow / 1.0e6);

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorChartGeneratorTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorChartGeneratorTest.java
@@ -114,6 +114,31 @@ public class CompressorChartGeneratorTest {
   }
 
   /**
+   * Test that the compressor chart JSON exposes the surge curve flow/head arrays so consumers do not have to
+   * reconstruct the surge line from the lowest-flow point of each speed curve.
+   */
+  @Test
+  public void testCompressorChartJsonIncludesSurgeCurveArrays() {
+    CompressorChartGenerator generator = new CompressorChartGenerator(compressor);
+    CompressorChartInterface chart = generator.generateCompressorChart("normal curves", 5);
+    compressor.setCompressorChart(chart);
+    compressor.getCompressorChart().setUseCompressorChart(true);
+
+    double[] surgeFlow = { 5000.0, 6000.0, 7000.0 };
+    double[] surgeHead = { 90.0, 100.0, 110.0 };
+    compressor.getCompressorChart().getSurgeCurve().setCurve(null, surgeFlow, surgeHead);
+
+    String json = compressor.getCompressorChartAsJson();
+
+    int surgeIdx = json.indexOf("\"surgeCurve\"");
+    assertTrue(surgeIdx >= 0, "JSON should contain a surgeCurve object");
+    String surgeSection = json.substring(surgeIdx, json.indexOf("}", surgeIdx));
+    assertTrue(surgeSection.contains("\"flow_m3h\""), "surge curve section should expose a flow array");
+    assertTrue(surgeSection.contains("\"head_kJkg\""), "surge curve section should expose a head array");
+    assertTrue(surgeSection.contains("5000.00"), "surge curve flow array should contain the fitted flow values");
+  }
+
+  /**
    * Test that template-based chart generation works with "interpolate and extrapolate".
    */
   @Test

--- a/src/test/java/neqsim/process/equipment/powergeneration/GasTurbineTest.java
+++ b/src/test/java/neqsim/process/equipment/powergeneration/GasTurbineTest.java
@@ -89,4 +89,45 @@ public class GasTurbineTest extends neqsim.NeqSimTest {
     double AFR = gasturb.calcIdealAirFuelRatio();
     assertEquals(15.8430086719654, AFR, 0.0001);
   }
+
+  @Test
+  void testSimpleCycleThermalEfficiencyPower() {
+    SystemSrkEos fuel = new SystemSrkEos(298.15, 20.0);
+    fuel.addComponent("methane", 0.9);
+    fuel.addComponent("ethane", 0.1);
+    fuel.setMixingRule("classic");
+    Stream fuelStream = new Stream("fuel", fuel);
+    fuelStream.setFlowRate(5000.0, "kg/hr");
+    fuelStream.setTemperature(25.0, "C");
+    fuelStream.setPressure(20.0, "bara");
+    fuelStream.run();
+
+    double fuelHeat = fuelStream.LCV() * fuelStream.getFlowRate("mole/sec");
+
+    GasTurbine gasturb = new GasTurbine("turbine", fuelStream);
+    gasturb.setThermalEfficiency(0.35);
+    gasturb.run();
+
+    // Net shaft power must equal efficiency x fuel LHV, and exhaust heat the remainder.
+    assertEquals(0.35 * fuelHeat, gasturb.getPower(), Math.abs(0.35 * fuelHeat) * 1e-6);
+    assertEquals(fuelHeat - gasturb.getPower(), gasturb.getHeat(), Math.abs(fuelHeat) * 1e-6);
+    // Realistic simple-cycle efficiency, unlike the very low detailed-cycle default at 2.5 bara.
+    Assertions.assertTrue(gasturb.getPower() / fuelHeat > 0.30, "simple-cycle efficiency must be realistic");
+  }
+
+  @Test
+  void testHeatRateMapsToEfficiency() {
+    GasTurbine gasturb = new GasTurbine("turbine");
+    gasturb.setHeatRate(10286.0);
+    assertEquals(0.35, gasturb.getThermalEfficiency(), 1e-3);
+    assertEquals(10286.0, gasturb.getHeatRate(), 1.0);
+  }
+
+  @Test
+  void testThermalEfficiencyValidation() {
+    GasTurbine gasturb = new GasTurbine("turbine");
+    Assertions.assertThrows(IllegalArgumentException.class, () -> gasturb.setThermalEfficiency(1.5));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> gasturb.setThermalEfficiency(-0.1));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> gasturb.setHeatRate(0.0));
+  }
 }

--- a/src/test/java/neqsim/process/equipment/util/AntiSurgeCalculatorTest.java
+++ b/src/test/java/neqsim/process/equipment/util/AntiSurgeCalculatorTest.java
@@ -188,4 +188,22 @@ public class AntiSurgeCalculatorTest {
     recycleOut[0] = splitter.getSplitStream(1).getFlowRate("m3/hr");
     return compressor.getSurgeFlowRate();
   }
+
+  /**
+   * The anti-surge proportional (relaxation) gain defaults to 0.5 (legacy behaviour) and can be tuned in (0, 1] to damp
+   * run-to-run oscillation at deep turndown. Out-of-range values are rejected.
+   */
+  @Test
+  public void testAntiSurgeProportionalGain() {
+    AntiSurgeCalculator calc = new AntiSurgeCalculator("AS-gain");
+    assertEquals(0.5, calc.getAntiSurgeProportionalGain(), 1e-12);
+
+    calc.setAntiSurgeProportionalGain(0.25);
+    assertEquals(0.25, calc.getAntiSurgeProportionalGain(), 1e-12);
+
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+        () -> calc.setAntiSurgeProportionalGain(0.0));
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+        () -> calc.setAntiSurgeProportionalGain(1.5));
+  }
 }


### PR DESCRIPTION
## Summary
Three small, non-breaking process-equipment improvements discovered while building a full topside process model (compressor recompression/export trains with anti-surge and gas-turbine drivers).

### 1. GasTurbine — simple-cycle efficiency / heat-rate API
The detailed Brayton-cycle balance at the default 2.5 bara combustion pressure yields ~1 % net efficiency, so `getPower()` is not usable for driver screening out of the box.
- Add `setThermalEfficiency(double)` / `getThermalEfficiency()` and `setHeatRate(double kJ/kWh)` / `getHeatRate()`.
- When a thermal efficiency is set, `run()` reports net shaft power directly from the fuel LHV (`power = eff x LHV`) and the remainder as exhaust heat.
- Opt-in: default (efficiency 0) keeps the existing detailed-cycle behaviour, so no existing behaviour changes.

### 2. Compressor.getCompressorChartAsJson — surge/stonewall arrays
Previously emitted `"surgeCurve": { "active": true }` with no data, forcing consumers to reconstruct the surge line from the lowest-flow point of each speed curve. Now includes `flow_m3h` / `head_kJkg` arrays for the surge curve (and stonewall curve when a spline curve is present). Purely additive.

### 3. Calculator — tunable anti-surge relaxation gain
The anti-surge recycle step used a hard-coded proportional gain of 0.5, which can oscillate run-to-run at deep turndown. Add `setAntiSurgeProportionalGain(double)` / `getAntiSurgeProportionalGain()` (default 0.5 = legacy behaviour; lower values damp oscillation).

## Tests
Added JUnit tests for all three (`GasTurbineTest`, `CompressorChartGeneratorTest`, `AntiSurgeCalculatorTest`). Full affected + regression suite green (107 tests across compressor / power-generation / util / combustion / mechanical-design). Java 8 compatible; Spotless applied.