### PR TITLE
Add CompressorChartLibrary: multiple named, selectable compressor charts

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -86,6 +86,7 @@ public class Compressor extends TwoPortEquipment
   public boolean powerSet = false;
   public boolean calcPressureOut = false;
   private CompressorChartInterface compressorChart = new CompressorChart();
+  private CompressorChartLibrary chartLibrary = null;
   private AntiSurge antiSurge = new AntiSurge();
   /**
    * Anti-surge control-line flow margin as a fraction of the surge flow (e.g. 0.10 for a control line 10 % to the right
@@ -1950,6 +1951,88 @@ public class Compressor extends TwoPortEquipment
    */
   public void setCompressorChart(CompressorChartInterface compressorChart) {
     this.compressorChart = compressorChart;
+  }
+
+  /**
+   * Get the compressor chart library (bundle) for this compressor, creating an empty one on first access. The library
+   * lets the compressor hold several named performance charts (e.g. vendor expected, as-tested, field-fitted) and
+   * switch between them with {@link #selectChart(String)}.
+   *
+   * @return the chart library (never null)
+   */
+  public CompressorChartLibrary getChartLibrary() {
+    if (chartLibrary == null) {
+      chartLibrary = new CompressorChartLibrary(getName() + " chart library");
+    }
+    return chartLibrary;
+  }
+
+  /**
+   * Set the compressor chart library (bundle) for this compressor.
+   *
+   * @param library the chart library
+   */
+  public void setChartLibrary(CompressorChartLibrary library) {
+    this.chartLibrary = library;
+  }
+
+  /**
+   * Add a named chart to this compressor's library.
+   *
+   * @param name the unique chart name
+   * @param chart the chart to store
+   * @return this compressor for chaining
+   */
+  public Compressor addChart(String name, CompressorChartInterface chart) {
+    getChartLibrary().add(name, chart);
+    return this;
+  }
+
+  /**
+   * Add a named chart with descriptive metadata to this compressor's library.
+   *
+   * @param name the unique chart name
+   * @param chart the chart to store
+   * @param metadata descriptive metadata (may be null)
+   * @return this compressor for chaining
+   */
+  public Compressor addChart(String name, CompressorChartInterface chart, CompressorChartMetadata metadata) {
+    getChartLibrary().add(name, chart, metadata);
+    return this;
+  }
+
+  /**
+   * Select (switch to) a chart from this compressor's library by name and make it the active performance chart. This is
+   * the professional, one-call way to switch between vendor curve bundles.
+   *
+   * @param name the chart name in the library
+   * @return the selected chart
+   * @throws IllegalArgumentException if no chart with that name exists in the library
+   */
+  public CompressorChartInterface selectChart(String name) {
+    CompressorChartInterface chart = getChartLibrary().select(name);
+    setCompressorChart(chart);
+    chart.setUseCompressorChart(true);
+    setUsePolytropicCalc(true);
+    return chart;
+  }
+
+  /**
+   * Get the names of the charts available in this compressor's library.
+   *
+   * @return a list of chart names (empty if no library has been created)
+   */
+  public java.util.List<String> getAvailableCharts() {
+    return chartLibrary == null ? new java.util.ArrayList<String>() : chartLibrary.getNames();
+  }
+
+  /**
+   * Get the name of the currently selected library chart.
+   *
+   * @return the selected chart name, or null if no library has been created
+   */
+  public String getSelectedChartName() {
+    return chartLibrary == null ? null : chartLibrary.getSelectedName();
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorChart.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorChart.java
@@ -211,6 +211,7 @@ public class CompressorChart implements CompressorChartInterface, java.io.Serial
   @Override
   public void setCurves(double[] chartConditions, double[] speed, double[][] flow, double[][] head,
       double[][] flowPolyEff, double[][] polyEff) {
+    this.chartConditions = chartConditions;
     this.speed = speed;
     this.head = head;
     this.polytropicEfficiency = polyEff;

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorChartLibrary.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorChartLibrary.java
@@ -1,0 +1,355 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import com.google.gson.GsonBuilder;
+
+/**
+ * A named library ("bundle" / database) of compressor performance charts.
+ *
+ * <p>
+ * The library lets a compressor hold several performance maps at once - for example the vendor expected curve, the
+ * as-tested curve, and a field-fitted curve - each stored under a unique name together with descriptive
+ * {@link CompressorChartMetadata}. A chart can then be selected professionally by name, and the whole library can be
+ * serialized to and from JSON so that a shared database of vendor curves can be maintained and reused.
+ * </p>
+ *
+ * <p>
+ * Typical use on a {@link Compressor}:
+ * </p>
+ *
+ * <pre>
+ * compressor.getChartLibrary().add("BCL405B-export-design", expectedChart, metadata);
+ * compressor.getChartLibrary().add("BCL405B-export-tested", asTestedChart);
+ * compressor.selectChart("BCL405B-export-tested"); // switch the active chart
+ * </pre>
+ *
+ * @author NeqSim
+ * @version $Id: $Id
+ */
+public class CompressorChartLibrary implements Serializable {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000;
+  /** Logger object for class. */
+  static Logger logger = LogManager.getLogger(CompressorChartLibrary.class);
+
+  private String libraryName = "compressor chart library";
+  private final Map<String, CompressorChartInterface> charts = new LinkedHashMap<String, CompressorChartInterface>();
+  private final Map<String, CompressorChartMetadata> metadata = new LinkedHashMap<String, CompressorChartMetadata>();
+  private String selectedName = null;
+
+  /**
+   * Default constructor.
+   */
+  public CompressorChartLibrary() {
+  }
+
+  /**
+   * Constructor with a library name.
+   *
+   * @param libraryName a descriptive name for the library
+   */
+  public CompressorChartLibrary(String libraryName) {
+    this.libraryName = libraryName;
+  }
+
+  /**
+   * Get the library name.
+   *
+   * @return the library name
+   */
+  public String getLibraryName() {
+    return libraryName;
+  }
+
+  /**
+   * Set the library name.
+   *
+   * @param libraryName the library name
+   */
+  public void setLibraryName(String libraryName) {
+    this.libraryName = libraryName;
+  }
+
+  /**
+   * Add a chart to the library under a unique name (without metadata).
+   *
+   * @param name the unique chart name (must be non-null and non-empty)
+   * @param chart the compressor chart to store
+   * @return this library for chaining
+   */
+  public CompressorChartLibrary add(String name, CompressorChartInterface chart) {
+    return add(name, chart, null);
+  }
+
+  /**
+   * Add a chart to the library under a unique name, with descriptive metadata.
+   *
+   * @param name the unique chart name (must be non-null and non-empty)
+   * @param chart the compressor chart to store (must be non-null)
+   * @param chartMetadata descriptive metadata (may be null)
+   * @return this library for chaining
+   * @throws IllegalArgumentException if name is null/empty or chart is null
+   */
+  public CompressorChartLibrary add(String name, CompressorChartInterface chart,
+      CompressorChartMetadata chartMetadata) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("chart name must not be null or empty");
+    }
+    if (chart == null) {
+      throw new IllegalArgumentException("chart must not be null");
+    }
+    charts.put(name, chart);
+    if (chartMetadata != null) {
+      metadata.put(name, chartMetadata);
+    }
+    if (selectedName == null) {
+      selectedName = name;
+    }
+    return this;
+  }
+
+  /**
+   * Get a chart by name.
+   *
+   * @param name the chart name
+   * @return the chart, or null if not present
+   */
+  public CompressorChartInterface get(String name) {
+    return charts.get(name);
+  }
+
+  /**
+   * Get the metadata for a chart.
+   *
+   * @param name the chart name
+   * @return the metadata, or null if none stored
+   */
+  public CompressorChartMetadata getMetadata(String name) {
+    return metadata.get(name);
+  }
+
+  /**
+   * Check whether a chart with the given name is present.
+   *
+   * @param name the chart name
+   * @return true if present
+   */
+  public boolean contains(String name) {
+    return charts.containsKey(name);
+  }
+
+  /**
+   * Remove a chart from the library.
+   *
+   * @param name the chart name
+   * @return the removed chart, or null if not present
+   */
+  public CompressorChartInterface remove(String name) {
+    metadata.remove(name);
+    CompressorChartInterface removed = charts.remove(name);
+    if (name != null && name.equals(selectedName)) {
+      selectedName = charts.isEmpty() ? null : charts.keySet().iterator().next();
+    }
+    return removed;
+  }
+
+  /**
+   * Get the number of charts in the library.
+   *
+   * @return the chart count
+   */
+  public int size() {
+    return charts.size();
+  }
+
+  /**
+   * Get the names of all charts in insertion order.
+   *
+   * @return a list of chart names
+   */
+  public List<String> getNames() {
+    return new ArrayList<String>(charts.keySet());
+  }
+
+  /**
+   * Select a chart by name and mark it as the active chart.
+   *
+   * @param name the chart name
+   * @return the selected chart
+   * @throws IllegalArgumentException if no chart with that name exists
+   */
+  public CompressorChartInterface select(String name) {
+    if (!charts.containsKey(name)) {
+      throw new IllegalArgumentException("no chart named '" + name + "' in library; available: " + getNames());
+    }
+    selectedName = name;
+    return charts.get(name);
+  }
+
+  /**
+   * Get the currently selected chart.
+   *
+   * @return the selected chart, or null if the library is empty
+   */
+  public CompressorChartInterface getSelected() {
+    return selectedName == null ? null : charts.get(selectedName);
+  }
+
+  /**
+   * Get the name of the currently selected chart.
+   *
+   * @return the selected chart name, or null if the library is empty
+   */
+  public String getSelectedName() {
+    return selectedName;
+  }
+
+  /**
+   * Produce a compact JSON catalog of the library (names + metadata + selected flag) for browsing/selection UIs. The
+   * curve data itself is not included; use {@link #toJson()} for a full round-trippable serialization.
+   *
+   * @return a JSON string describing the available charts
+   */
+  public String describe() {
+    List<Map<String, Object>> entries = new ArrayList<Map<String, Object>>();
+    for (String name : charts.keySet()) {
+      Map<String, Object> e = new LinkedHashMap<String, Object>();
+      e.put("name", name);
+      e.put("selected", name.equals(selectedName));
+      e.put("metadata", metadata.get(name));
+      entries.add(e);
+    }
+    Map<String, Object> root = new LinkedHashMap<String, Object>();
+    root.put("libraryName", libraryName);
+    root.put("selectedName", selectedName);
+    root.put("count", charts.size());
+    root.put("charts", entries);
+    return new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().create().toJson(root);
+  }
+
+  /** Data-transfer object for a single chart entry (JSON round-trip). */
+  private static class ChartEntryDto {
+    String name;
+    CompressorChartMetadata metadata;
+    String headUnit;
+    double[] chartConditions;
+    double[] speeds;
+    double[][] flows;
+    double[][] heads;
+    double[][] polytropicEfficiencies;
+    double[] surgeFlow;
+    double[] surgeHead;
+  }
+
+  /** Data-transfer object for the whole library (JSON round-trip). */
+  private static class LibraryDto {
+    String libraryName;
+    String selectedName;
+    List<ChartEntryDto> charts = new ArrayList<ChartEntryDto>();
+  }
+
+  /**
+   * Serialize the full library (all curves + metadata) to JSON, so it can be stored in a file or database and reloaded
+   * with {@link #fromJson(String)}.
+   *
+   * @return a JSON string
+   */
+  public String toJson() {
+    LibraryDto dto = new LibraryDto();
+    dto.libraryName = libraryName;
+    dto.selectedName = selectedName;
+    for (Map.Entry<String, CompressorChartInterface> entry : charts.entrySet()) {
+      CompressorChartInterface chart = entry.getValue();
+      ChartEntryDto c = new ChartEntryDto();
+      c.name = entry.getKey();
+      c.metadata = metadata.get(entry.getKey());
+      c.headUnit = chart.getHeadUnit();
+      c.chartConditions = chart.getChartConditions();
+      c.speeds = chart.getSpeeds();
+      c.flows = chart.getFlows();
+      c.heads = chart.getHeads();
+      c.polytropicEfficiencies = chart.getPolytropicEfficiencies();
+      SafeSplineSurgeCurve surge = chart.getSurgeCurve();
+      if (surge != null) {
+        c.surgeFlow = surge.getSortedFlow();
+        c.surgeHead = surge.getSortedHead();
+      }
+      dto.charts.add(c);
+    }
+    return new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().create().toJson(dto);
+  }
+
+  /**
+   * Rebuild a library from a JSON string produced by {@link #toJson()}.
+   *
+   * @param json the JSON string
+   * @return the reconstructed library
+   */
+  public static CompressorChartLibrary fromJson(String json) {
+    LibraryDto dto = new GsonBuilder().create().fromJson(json, LibraryDto.class);
+    CompressorChartLibrary library = new CompressorChartLibrary();
+    if (dto == null) {
+      return library;
+    }
+    if (dto.libraryName != null) {
+      library.libraryName = dto.libraryName;
+    }
+    if (dto.charts != null) {
+      for (ChartEntryDto c : dto.charts) {
+        CompressorChart chart = new CompressorChart();
+        if (c.speeds != null && c.flows != null && c.heads != null && c.polytropicEfficiencies != null) {
+          double[] cond = c.chartConditions != null ? c.chartConditions : new double[] { 0.0, 0.0, 0.0, 0.0 };
+          chart.setCurves(cond, c.speeds, c.flows, c.heads, c.polytropicEfficiencies);
+          if (c.chartConditions != null && c.chartConditions.length >= 4) {
+            chart.setReferenceConditions(c.chartConditions[0], c.chartConditions[1], c.chartConditions[2],
+                c.chartConditions[3]);
+          }
+        }
+        if (c.headUnit != null) {
+          chart.setHeadUnit(c.headUnit);
+        }
+        if (c.surgeFlow != null && c.surgeHead != null && c.surgeFlow.length > 0) {
+          chart.setSurgeCurve(new SafeSplineSurgeCurve(c.surgeFlow, c.surgeHead));
+        }
+        chart.setUseCompressorChart(true);
+        library.add(c.name, chart, c.metadata);
+      }
+    }
+    if (dto.selectedName != null && library.contains(dto.selectedName)) {
+      library.selectedName = dto.selectedName;
+    }
+    return library;
+  }
+
+  /**
+   * Save the library to a JSON file.
+   *
+   * @param path the file path
+   * @throws IOException if the file cannot be written
+   */
+  public void saveToFile(String path) throws IOException {
+    Files.write(Paths.get(path), toJson().getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Load a library from a JSON file previously written by {@link #saveToFile(String)}.
+   *
+   * @param path the file path
+   * @return the loaded library
+   * @throws IOException if the file cannot be read
+   */
+  public static CompressorChartLibrary loadFromFile(String path) throws IOException {
+    byte[] bytes = Files.readAllBytes(Paths.get(path));
+    return fromJson(new String(bytes, StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorChartMetadata.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorChartMetadata.java
@@ -1,0 +1,239 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.Serializable;
+
+/**
+ * Descriptive metadata for a single compressor performance chart held in a {@link CompressorChartLibrary}.
+ *
+ * <p>
+ * The metadata makes a chart self-describing so that a library of vendor curves (a "chart database") can be browsed,
+ * filtered and selected professionally: which casing/model the chart belongs to, which service and tag it was issued
+ * for, the source document, whether it is an expected/as-tested/generated curve, and the reference (basis) conditions
+ * the curve was measured at.
+ * </p>
+ *
+ * @author NeqSim
+ * @version $Id: $Id
+ */
+public class CompressorChartMetadata implements Serializable {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000;
+
+  /** Origin of the curve data. */
+  public enum CurveType {
+    /** Vendor expected/predicted performance curve (design). */
+    EXPECTED,
+    /** Vendor as-tested (shop test) performance curve. */
+    AS_TESTED,
+    /** NeqSim-generated curve anchored to a rated point. */
+    GENERATED,
+    /** Curve fitted to field / historian data. */
+    FIELD_FITTED,
+    /** Unspecified origin. */
+    UNSPECIFIED;
+  }
+
+  private String casingModel = "";
+  private String service = "";
+  private String tag = "";
+  private String documentReference = "";
+  private CurveType curveType = CurveType.UNSPECIFIED;
+  private double molecularWeight = Double.NaN;
+  private double referenceTemperature = Double.NaN;
+  private double referencePressure = Double.NaN;
+  private double compressibilityZ = Double.NaN;
+  private String description = "";
+
+  /**
+   * Default constructor.
+   */
+  public CompressorChartMetadata() {
+  }
+
+  /**
+   * Convenience constructor for the most common descriptive fields.
+   *
+   * @param casingModel the compressor casing/model, e.g. "BCL 405/B"
+   * @param service the service description, e.g. "pipeline gas export"
+   * @param tag the equipment tag the chart was issued for, e.g. "27-KA01"
+   * @param documentReference the source document reference, e.g. "8300199-CA-001 sheet 14"
+   * @param curveType the origin of the curve data (never null; null is stored as UNSPECIFIED)
+   */
+  public CompressorChartMetadata(String casingModel, String service, String tag, String documentReference,
+      CurveType curveType) {
+    this.casingModel = casingModel == null ? "" : casingModel;
+    this.service = service == null ? "" : service;
+    this.tag = tag == null ? "" : tag;
+    this.documentReference = documentReference == null ? "" : documentReference;
+    this.curveType = curveType == null ? CurveType.UNSPECIFIED : curveType;
+  }
+
+  /**
+   * Set the reference (basis) conditions the chart was measured at.
+   *
+   * @param molecularWeight reference gas molecular weight in g/mol
+   * @param referenceTemperature reference inlet temperature in Kelvin
+   * @param referencePressure reference inlet pressure in bara
+   * @param compressibilityZ reference compressibility factor Z (dimensionless)
+   * @return this metadata object for chaining
+   */
+  public CompressorChartMetadata setReferenceConditions(double molecularWeight, double referenceTemperature,
+      double referencePressure, double compressibilityZ) {
+    this.molecularWeight = molecularWeight;
+    this.referenceTemperature = referenceTemperature;
+    this.referencePressure = referencePressure;
+    this.compressibilityZ = compressibilityZ;
+    return this;
+  }
+
+  /**
+   * Get the casing/model.
+   *
+   * @return the casing/model string
+   */
+  public String getCasingModel() {
+    return casingModel;
+  }
+
+  /**
+   * Set the casing/model.
+   *
+   * @param casingModel the casing/model string
+   */
+  public void setCasingModel(String casingModel) {
+    this.casingModel = casingModel == null ? "" : casingModel;
+  }
+
+  /**
+   * Get the service description.
+   *
+   * @return the service description
+   */
+  public String getService() {
+    return service;
+  }
+
+  /**
+   * Set the service description.
+   *
+   * @param service the service description
+   */
+  public void setService(String service) {
+    this.service = service == null ? "" : service;
+  }
+
+  /**
+   * Get the equipment tag.
+   *
+   * @return the equipment tag
+   */
+  public String getTag() {
+    return tag;
+  }
+
+  /**
+   * Set the equipment tag.
+   *
+   * @param tag the equipment tag
+   */
+  public void setTag(String tag) {
+    this.tag = tag == null ? "" : tag;
+  }
+
+  /**
+   * Get the source document reference.
+   *
+   * @return the document reference
+   */
+  public String getDocumentReference() {
+    return documentReference;
+  }
+
+  /**
+   * Set the source document reference.
+   *
+   * @param documentReference the document reference
+   */
+  public void setDocumentReference(String documentReference) {
+    this.documentReference = documentReference == null ? "" : documentReference;
+  }
+
+  /**
+   * Get the curve type (origin).
+   *
+   * @return the curve type
+   */
+  public CurveType getCurveType() {
+    return curveType;
+  }
+
+  /**
+   * Set the curve type (origin).
+   *
+   * @param curveType the curve type (null is stored as UNSPECIFIED)
+   */
+  public void setCurveType(CurveType curveType) {
+    this.curveType = curveType == null ? CurveType.UNSPECIFIED : curveType;
+  }
+
+  /**
+   * Get the reference molecular weight.
+   *
+   * @return reference molecular weight in g/mol
+   */
+  public double getMolecularWeight() {
+    return molecularWeight;
+  }
+
+  /**
+   * Get the reference temperature.
+   *
+   * @return reference temperature in Kelvin
+   */
+  public double getReferenceTemperature() {
+    return referenceTemperature;
+  }
+
+  /**
+   * Get the reference pressure.
+   *
+   * @return reference pressure in bara
+   */
+  public double getReferencePressure() {
+    return referencePressure;
+  }
+
+  /**
+   * Get the reference compressibility factor.
+   *
+   * @return reference compressibility Z
+   */
+  public double getCompressibilityZ() {
+    return compressibilityZ;
+  }
+
+  /**
+   * Get the free-text description.
+   *
+   * @return the description
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Set the free-text description.
+   *
+   * @param description the description
+   */
+  public void setDescription(String description) {
+    this.description = description == null ? "" : description;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return "CompressorChartMetadata[model=" + casingModel + ", service=" + service + ", tag=" + tag + ", doc="
+        + documentReference + ", type=" + curveType + "]";
+  }
+}

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorChartLibraryTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorChartLibraryTest.java
@@ -1,0 +1,152 @@
+package neqsim.process.equipment.compressor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests for {@link CompressorChartLibrary}, {@link CompressorChartMetadata} and the {@link Compressor} multi-chart
+ * selection API.
+ */
+public class CompressorChartLibraryTest {
+
+  private CompressorChartInterface makeChart(double headScale) {
+    CompressorChart chart = new CompressorChart();
+    double[] chartConditions = { 18.0, 298.15, 50.0, 0.9 };
+    double[] speeds = { 10000.0, 11000.0 };
+    double[][] flows = { { 1000.0, 2000.0, 3000.0 }, { 1100.0, 2100.0, 3100.0 } };
+    double[][] heads = { { 100.0 * headScale, 90.0 * headScale, 80.0 * headScale },
+        { 110.0 * headScale, 100.0 * headScale, 90.0 * headScale } };
+    double[][] effs = { { 75.0, 80.0, 78.0 }, { 76.0, 81.0, 79.0 } };
+    chart.setCurves(chartConditions, speeds, flows, heads, effs);
+    chart.setHeadUnit("kJ/kg");
+    chart.setUseCompressorChart(true);
+    return chart;
+  }
+
+  @Test
+  public void testAddSelectAndSwitch() {
+    CompressorChartLibrary lib = new CompressorChartLibrary("BCL 405/B bundle");
+    CompressorChartMetadata metaDesign = new CompressorChartMetadata("BCL 405/B", "pipeline gas export", "27-KA01",
+        "8300199-CA-001 sheet 14", CompressorChartMetadata.CurveType.EXPECTED)
+        .setReferenceConditions(19.34, 303.15, 52.76, 0.877);
+
+    lib.add("export-design", makeChart(1.0), metaDesign);
+    lib.add("export-tested", makeChart(1.05));
+
+    assertEquals(2, lib.size());
+    assertTrue(lib.contains("export-design"));
+    assertEquals("export-design", lib.getSelectedName(), "first added chart is selected by default");
+
+    List<String> names = lib.getNames();
+    assertEquals(2, names.size());
+    assertEquals("export-design", names.get(0));
+
+    // metadata retained
+    CompressorChartMetadata m = lib.getMetadata("export-design");
+    assertNotNull(m);
+    assertEquals("BCL 405/B", m.getCasingModel());
+    assertEquals(CompressorChartMetadata.CurveType.EXPECTED, m.getCurveType());
+    assertEquals(19.34, m.getMolecularWeight(), 1e-9);
+
+    // switch selection
+    CompressorChartInterface tested = lib.select("export-tested");
+    assertEquals("export-tested", lib.getSelectedName());
+    assertEquals(tested, lib.getSelected());
+
+    // unknown name throws
+    assertThrows(IllegalArgumentException.class, () -> lib.select("does-not-exist"));
+
+    // remove updates selection
+    lib.remove("export-tested");
+    assertEquals(1, lib.size());
+    assertEquals("export-design", lib.getSelectedName());
+  }
+
+  @Test
+  public void testValidation() {
+    CompressorChartLibrary lib = new CompressorChartLibrary();
+    assertThrows(IllegalArgumentException.class, () -> lib.add("", makeChart(1.0)));
+    assertThrows(IllegalArgumentException.class, () -> lib.add("x", null));
+    assertNull(lib.getSelected());
+    assertEquals(0, lib.size());
+  }
+
+  @Test
+  public void testJsonRoundTrip() {
+    CompressorChartLibrary lib = new CompressorChartLibrary("bundle");
+    lib.add("a", makeChart(1.0), new CompressorChartMetadata("BCL 505", "1st recompr", "23-KA01", "8300199-CA-001",
+        CompressorChartMetadata.CurveType.EXPECTED));
+    lib.add("b", makeChart(1.2));
+    lib.select("b");
+
+    String json = lib.toJson();
+    assertTrue(json.contains("\"a\""));
+    assertTrue(json.contains("BCL 505"));
+
+    CompressorChartLibrary restored = CompressorChartLibrary.fromJson(json);
+    assertEquals(2, restored.size());
+    assertEquals("b", restored.getSelectedName());
+    assertTrue(restored.contains("a"));
+    assertNotNull(restored.getMetadata("a"));
+    assertEquals("BCL 505", restored.getMetadata("a").getCasingModel());
+
+    // reconstructed chart reproduces polytropic head
+    double original = lib.get("a").getPolytropicHead(2000.0, 10000.0);
+    double roundtrip = restored.get("a").getPolytropicHead(2000.0, 10000.0);
+    assertEquals(original, roundtrip, 1e-6);
+  }
+
+  @Test
+  public void testDescribeCatalog() {
+    CompressorChartLibrary lib = new CompressorChartLibrary("bundle");
+    lib.add("a", makeChart(1.0));
+    String catalog = lib.describe();
+    assertTrue(catalog.contains("\"count\": 1"));
+    assertTrue(catalog.contains("\"name\": \"a\""));
+  }
+
+  @Test
+  public void testCompressorSelectChart() {
+    SystemSrkEos gas = new SystemSrkEos(298.15, 50.0);
+    gas.addComponent("methane", 0.9);
+    gas.addComponent("ethane", 0.1);
+    gas.setMixingRule("classic");
+    Stream inlet = new Stream("inlet", gas);
+    inlet.setFlowRate(10000.0, "kg/hr");
+    inlet.setTemperature(25.0, "C");
+    inlet.setPressure(50.0, "bara");
+    inlet.run();
+
+    Compressor comp = new Compressor("test compressor");
+    comp.setInletStream(inlet);
+    comp.setOutletPressure(100.0, "bara");
+    comp.setSpeed(10500);
+
+    CompressorChartInterface design = makeChart(1.0);
+    CompressorChartInterface tested = makeChart(1.1);
+    comp.addChart("design", design, new CompressorChartMetadata("BCL 405/B", "export", "27-KA01", "8300199-CA-001",
+        CompressorChartMetadata.CurveType.EXPECTED));
+    comp.addChart("tested", tested);
+
+    assertEquals(2, comp.getAvailableCharts().size());
+    assertEquals("design", comp.getSelectedChartName(), "first added chart selected by default");
+
+    // switch active chart in one call
+    comp.selectChart("tested");
+    assertEquals("tested", comp.getSelectedChartName());
+    assertEquals(tested, comp.getCompressorChart());
+    assertTrue(comp.getCompressorChart().isUseCompressorChart());
+
+    comp.selectChart("design");
+    assertEquals(design, comp.getCompressorChart());
+
+    assertThrows(IllegalArgumentException.class, () -> comp.selectChart("missing"));
+  }
+}


### PR DESCRIPTION
## Summary
Adds first-class support for **multiple compressor performance charts** that can be held together and selected by name — so a fleet of vendor curves / bundles can live in a database and be switched professionally in one call.

### New classes
- **`CompressorChartLibrary`** — a named bundle/database of `CompressorChartInterface` charts keyed by unique name, with a selected/active chart. `add` / `get` / `contains` / `remove` / `getNames` / `select` / `getSelected` / `describe` (JSON catalog), and full **JSON round-trip** persistence (`toJson` / `fromJson` / `saveToFile` / `loadFromFile`) so a shared curve database can be maintained.
- **`CompressorChartMetadata`** — makes each chart self-describing: casing/model, service, tag, document reference, curve type (`EXPECTED` / `AS_TESTED` / `GENERATED` / `FIELD_FITTED`) and basis (MW, T, P, Z).

### Compressor API (easy switching)
`compressor.addChart(name, chart, metadata)` to register curves, and **`compressor.selectChart(name)`** to switch the active chart in a single call; plus `getChartLibrary` / `getAvailableCharts` / `getSelectedChartName`.

`java
comp.addChart("BCL405B-export-design", expectedChart, meta);
comp.addChart("BCL405B-export-tested", asTestedChart);
comp.selectChart("BCL405B-export-tested");   // switch in one call
`

### Fix
`CompressorChart.setCurves` now stores `chartConditions` (previously dropped), so `getChartConditions()` and the library JSON round-trip work.

## Tests
`CompressorChartLibraryTest` (add/select/switch, validation, JSON round-trip, catalog, Compressor integration). Full compressor-chart suite green (55 tests). Java 8 compatible; Spotless applied.