### PR TITLE
Add executable engineering production qualification

### DIFF
--- a/.github/agents/engineering.deliverables.agent.md
+++ b/.github/agents/engineering.deliverables.agent.md
@@ -39,8 +39,9 @@ instrument/valve/line/SIF/relief register, or safety-design handoff:
 3. Link dynamic `EmergencyShutdownTestResult` evidence to each tested sequence.
 4. Export with `DexpiEngineeringExporter`.
 5. Compile with `EngineeringDeliverableCompiler` and review
-   `engineering-production-readiness.json`, unresolved gaps, engineering
-   registers, `dexpi-validation.json` and `package-manifest.json`.
+   `engineering-production-readiness.json`, `engineering-qualification-plan.json`,
+   unresolved gaps, engineering registers, `dexpi-validation.json` and
+   `package-manifest.json`.
 
 Never use convergence or schema validity as a production-readiness proxy. A
 `QUALIFIED_FEED_SUPPORT` assessment requires the evidence gates defined by
@@ -51,6 +52,22 @@ Never promote generated `REVIEW_REQUIRED` data to approved/IFC status. Never
 infer SIL, final voting, trip set points, valve fail action, credible relief
 causes or shutdown effects solely from equipment class or a normal operating
 point.
+
+For qualification work, use the open actions in
+`engineering-qualification-plan.json`. Execute exact-version reference cases
+through `EngineeringBenchmarkDataset`, named-product semantic round trips
+through `DexpiToolQualificationRunner`, controlled project comparisons through
+`EngineeringPilotQualificationRunner`, and measured release checks through
+`EngineeringReleaseQualificationRunner`. Do not manufacture independent-review,
+commercial-tool, pilot-acceptance, HAZOP/LOPA/SRS, or release-authority records.
+
+Set `productionQualification=true` on typed calculation contexts only when
+controlled standards and evidence are attached. The stricter mode blocks hidden
+equipment defaults, simplified piping scaling, unresolved valve failure actions,
+unapproved instrument installation, missing corrosion/design-code records, and
+unreferenced two-phase relief methods. A calculated PSV orifice remains
+review-required until certified device data and inlet, outlet, header, stability,
+flare and depressurization checks are complete.
 
 ### 1. StudyClass Enum
 Controls which deliverables are produced:

--- a/.github/skills/neqsim-pid-process-operations/SKILL.md
+++ b/.github/skills/neqsim-pid-process-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neqsim-pid-process-operations
-version: "1.5.0"
+version: "1.6.0"
 description: "Bidirectional P&ID/NeqSim workflow. USE WHEN: understanding P&ID symbols, converting P&ID topology into NeqSim simulations, generating governed DEXPI engineering packages from ProcessSystem or ProcessModel, linking tags to historian data, evaluating valve/equipment changes, or preparing water-hammer and blowdown/flare handoffs."
 last_verified: "2026-07-17"
 requires:
@@ -227,6 +227,15 @@ loop and coordinated-package pattern, and
 calculation examples across equipment, piping, valve/instrument, safety,
 materials and preliminary mechanics.
 
+When qualifying rather than screening a typed calculation, build an
+`EngineeringCalculationContext` with `productionQualification=true`, controlled
+standard references and evidence references. In this mode, do not accept
+equipment screening defaults, reference-diameter piping scaling, an unresolved
+valve failure position, or an unreferenced two-phase relief method. Use
+`ReliefSizingCalculation` for governed gas/liquid/steam orifice selection and
+only for two-phase flow when a specialist mass-flux result and controlled method
+reference have been supplied.
+
 Treat `unresolved-engineering-actions.json` as a mandatory review input. A
 calculated DEXPI package is never equivalent to HAZOP/LOPA acceptance, vendor
 certification, code mechanical design, final metallurgy approval or
@@ -240,6 +249,19 @@ explicit no-hidden-default auto-configuration result, named-tool DEXPI
 round-trip evidence, approved safety-lifecycle evidence, three accepted pilots,
 and release-quality evidence. Even that level always retains
 `fitnessForConstruction=false` and does not grant final engineering approval.
+
+Also inspect `engineering-qualification-plan.json`. Use its exact method keys
+and open actions to drive `EngineeringBenchmarkDataset`,
+`DexpiToolQualificationRunner`, `EngineeringPilotQualificationRunner`, and
+`EngineeringReleaseQualificationRunner`. These runners convert actual
+measurements and named external results into evidence; they do not perform an
+independent review or create an acceptance record. Keep missing external
+evidence open.
+
+Use
+`examples/notebooks/engineering_production_qualification_workflow.ipynb` as the
+API pattern for the executable qualification workflows. Its data are synthetic
+and must never be promoted to project evidence.
 
 The calculation handoff automatically runs available equipment mechanical-design
 and materials-screening models. It can run API 520/521 PSV sizing from attached

--- a/docs/integration/process-to-engineering-simulator.md
+++ b/docs/integration/process-to-engineering-simulator.md
@@ -119,7 +119,7 @@ calculations:
 - `EquipmentDesignCalculations.Separator`, `.Compressor`, `.Pump`, `.HeatExchanger`, `.Column` and `.Tank`;
 - `PipingNetworkDesignCalculation` with a versioned `PipingRulePack`;
 - `ValveInstrumentDesignCalculations.Valve` and `.Instrument`;
-- `SafetyScenarioEngineCalculation`; and
+- `SafetyScenarioEngineCalculation` and `ReliefSizingCalculation`; and
 - `MaterialsMechanicalDesignCalculations.MaterialSelection` and `.PreliminaryMechanical`.
 
 Every typed result carries a method identifier/version, input snapshot, design-case context, readiness findings,
@@ -186,6 +186,7 @@ In addition to DEXPI XML, registers, the case matrix, governing envelope and cal
 - `utility-summary.json`;
 - `materials-selection-report.json`;
 - `engineering-diagram-layout.json`;
+- `engineering-qualification-plan.json`;
 - `unresolved-engineering-actions.json`; and
 - `revision-impact-report.json`.
 
@@ -257,6 +258,70 @@ for one revision from silently qualifying another.
 The current built-in calculation modules remain preliminary screening methods until their exact method versions have
 been benchmarked and project-qualified for the stated service. The readiness framework exposes that gap instead of
 silently promoting the results.
+
+### Execute the qualification workflows
+
+The production-readiness gates are backed by executable, serializable workflows. They derive evidence from supplied
+measurements and fail closed when an output, review, tool result or acceptance record is missing:
+
+- `EngineeringBenchmarkDataset` executes versioned scalar reference cases with units and absolute/relative
+  tolerances. A qualifying source must be published, independently calculated or vendor/CAE evidence and must have an
+  independent review record. Every case registered for a method version must qualify; one passing case cannot mask a
+  failed, regression-only or unreviewed case for the same method.
+- `DexpiToolQualificationRunner` compares persistent objects, properties and relationships after import and after
+  export/reimport in a named product/version. Any semantic difference prevents qualification.
+- `EngineeringPilotQualificationRunner` compares simulator values with an independently reviewed project package.
+  An out-of-tolerance material comparison prevents acceptance.
+- `EngineeringReleaseQualificationRunner` derives release evidence from CI state, the supported Java matrix,
+  repeated deterministic fingerprints, measured runtime, API fingerprints, serialization migration and security
+  findings. It also requires an accountable reviewer.
+
+For example, a controlled benchmark case is run against actual calculation outputs rather than copying the expected
+value into the evidence object:
+
+```java
+EngineeringBenchmarkDataset dataset = new EngineeringBenchmarkDataset("separator-reference", "A")
+    .add(new EngineeringBenchmarkDataset.Case(
+        "SEP-CASE-1", "separator-scrubber-preliminary-design", "2.0",
+        EngineeringValidationBenchmark.SourceClass.INDEPENDENT_CALCULATION,
+        "CALC-SEP-001", "A", "Independent checker / CALC-SEP-001-A")
+        .expect("insideDiameterM", 2.0, "m", 0.02, 0.01));
+
+Map<String, Map<String, Double>> actualOutputs = runControlledCases();
+EngineeringBenchmarkDataset.RunResult benchmarkRun = dataset.run(actualOutputs);
+```
+
+Compilation also writes `engineering-qualification-plan.json`. It is an executable backlog keyed to the exact methods
+used in the final loop. It identifies missing independent benchmarks, project qualifications, automatic configuration,
+named-tool DEXPI evidence, pilot scopes, release evidence and safety-lifecycle evidence. It never fabricates external
+acceptance and always reports `fitnessForConstruction=false`.
+
+### Fail-closed production calculation mode
+
+Set `productionQualification=true` in an `EngineeringCalculationContext` when a typed calculation is being exercised
+for qualification:
+
+```java
+EngineeringCalculationContext context = EngineeringCalculationContext.builder()
+    .designCaseId("maximum")
+    .simulationFingerprint("controlled-run-sha256")
+    .addStandardReference("PROJECT-CALCULATION-BASIS-A")
+    .addEvidenceReference("INDEPENDENT-CHECK-001")
+    .attribute("productionQualification", "true")
+    .build();
+```
+
+In this mode the equipment modules reject screening defaults, piping rejects reference-diameter pressure-drop scaling,
+unresolved valve failure position becomes a blocker, and standards/evidence references are mandatory. Instrument,
+materials and mechanical modules additionally require controlled installation, corrosion-assessment and design-code
+records. Two-phase relief cannot be inferred from a normal operating point: supply a controlled specialist mass-flux
+method and reference. The built-in relief calculation selects from the project device table for gas, steam and liquid
+cases, but certified coefficients, stability, inlet/outlet losses and disposal-network interaction remain separate
+review gates.
+
+See `examples/notebooks/engineering_production_qualification_workflow.ipynb` for benchmark, DEXPI, pilot, release and
+relief workflow examples. The notebook uses synthetic references only to demonstrate the API; replace every such value
+and reviewer string with controlled project evidence before assessing readiness.
 
 See the executable
 [production-readiness notebook](../../examples/notebooks/engineering_production_readiness.ipynb) for explicit

--- a/examples/notebooks/engineering_production_qualification_workflow.ipynb
+++ b/examples/notebooks/engineering_production_qualification_workflow.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Executable engineering production-qualification workflow\n",
+    "\n",
+    "This notebook demonstrates the benchmark, named-tool DEXPI, pilot, release and governed relief-sizing APIs added around the process-to-engineering simulator. All references and values below are **synthetic API examples**. A passing cell is not project evidence and does not make a package fit for construction.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, sys\n",
+    "from pathlib import Path\n",
+    "ROOT = Path(os.environ.get('NEQSIM_PROJECT_ROOT', Path.cwd())).resolve()\n",
+    "while not (ROOT / 'pom.xml').exists() and ROOT.parent != ROOT:\n",
+    "    ROOT = ROOT.parent\n",
+    "sys.path.insert(0, str(ROOT / 'devtools'))\n",
+    "from neqsim_dev_setup import neqsim_init, neqsim_classes\n",
+    "ns = neqsim_classes(neqsim_init(project_root=ROOT, recompile=not (ROOT / 'target/classes').exists(), verbose=False))\n",
+    "import jpype\n",
+    "JClass = ns.JClass\n",
+    "HashMap = JClass('java.util.LinkedHashMap')\n",
+    "ArrayList = JClass('java.util.ArrayList')\n",
+    "print('Loaded qualification API from', ROOT)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Run exact-version benchmark data\n",
+    "\n",
+    "Expected values, actual simulator outputs, tolerances, source class and independent-review record stay distinct. Missing actual outputs fail the run instead of being replaced by expected values.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Dataset = JClass('neqsim.process.engineering.production.EngineeringBenchmarkDataset')\n",
+    "Case = JClass('neqsim.process.engineering.production.EngineeringBenchmarkDataset$Case')\n",
+    "SourceClass = JClass('neqsim.process.engineering.production.EngineeringValidationBenchmark$SourceClass')\n",
+    "dataset = Dataset('synthetic-separator-reference', 'A')\n",
+    "case = Case('SEP-CASE-1', 'separator-scrubber-preliminary-design', '2.0',\n",
+    "            SourceClass.INDEPENDENT_CALCULATION, 'SYNTHETIC-CALC-001', 'A',\n",
+    "            'SYNTHETIC-INDEPENDENT-REVIEW')\n",
+    "case.expect('insideDiameterM', 2.0, 'm', 0.02, 0.01)\n",
+    "dataset.add(case)\n",
+    "case_outputs = HashMap(); case_outputs.put('insideDiameterM', 2.01)\n",
+    "actual_outputs = HashMap(); actual_outputs.put('SEP-CASE-1', case_outputs)\n",
+    "benchmark_run = dataset.run(actual_outputs)\n",
+    "print('complete=', benchmark_run.isComplete(), 'passed=', benchmark_run.getReport().isPassed())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Compare named-tool DEXPI semantics\n",
+    "\n",
+    "In a real qualification, importer adapters create the two post-tool snapshots from a named CAE product. Qualification requires zero object, property and relationship differences after import and export/reimport.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Dexpi = JClass('neqsim.process.engineering.production.DexpiToolQualificationRunner')\n",
+    "Snapshot = JClass('neqsim.process.engineering.production.DexpiToolQualificationRunner$Snapshot')\n",
+    "properties = HashMap(); properties.put('tag', '20-VA-001'); properties.put('class', 'Vessel')\n",
+    "reference = Snapshot('DEXPI 2.0').addObject('urn:equipment:1', properties)\n",
+    "after_import = Snapshot('DEXPI 2.0').addObject('urn:equipment:1', properties)\n",
+    "after_roundtrip = Snapshot('DEXPI 2.0').addObject('urn:equipment:1', properties)\n",
+    "dexpi_result = Dexpi.compare('SYNTHETIC-CAE', '2026.1', reference, after_import, after_roundtrip,\n",
+    "                             'SYNTHETIC-DEXPI-EVIDENCE', 'SYNTHETIC-CHECKER')\n",
+    "print('qualified=', dexpi_result.isQualified())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Derive pilot and release gates from measurements\n",
+    "\n",
+    "Material pilot discrepancies block acceptance. Release booleans are derived from CI, Java, repeatability, performance, API, migration and security measurements and require an accountable reviewer.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Pilot = JClass('neqsim.process.engineering.production.EngineeringPilotQualificationRunner')\n",
+    "Comparison = JClass('neqsim.process.engineering.production.EngineeringPilotQualificationRunner$Comparison')\n",
+    "Scope = JClass('neqsim.process.engineering.production.EngineeringPilotProjectEvidence$Scope')\n",
+    "comparisons = ArrayList(); comparisons.add(Comparison('separator diameter', 2.0, 2.01, 'm', 0.02, 0.01, True))\n",
+    "pilot = Pilot.run('SYNTHETIC-PILOT', Scope.SEPARATION_AND_COMPRESSION, 'SYNTHETIC-REFERENCE',\n",
+    "                  comparisons, 'SYNTHETIC-CHECKER', 'SYNTHETIC-ACCEPTANCE')\n",
+    "ReleaseInput = JClass('neqsim.process.engineering.production.EngineeringReleaseQualificationRunner$Input')\n",
+    "ReleaseRunner = JClass('neqsim.process.engineering.production.EngineeringReleaseQualificationRunner')\n",
+    "release_input = (ReleaseInput('2.0-rc1', 'SYNTHETIC-CI-RUN', 'SYNTHETIC-RELEASE-AUTHORITY')\n",
+    "                 .fullCiPassed(True).requireJavaVersion('8').passedJavaVersion('8')\n",
+    "                 .deterministicFingerprint('sha256-a').deterministicFingerprint('sha256-a')\n",
+    "                 .performanceSample(2.0).performanceSample(2.2).maximumAcceptedSeconds(5.0)\n",
+    "                 .apiFingerprints('api-a', 'api-a').serializationMigrationPassed(True)\n",
+    "                 .openHighSeveritySecurityFindings(0))\n",
+    "release = ReleaseRunner.run(release_input)\n",
+    "print('pilot accepted=', pilot.getEvidence().isAccepted(), 'release passed=', release.getEvidence().isPassed())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Use fail-closed relief sizing\n",
+    "\n",
+    "The gas example uses explicit absolute pressures, thermodynamic properties, correction factors and a controlled orifice table. Two-phase flow is blocked unless a specialist mass-flux value and controlled method reference are supplied.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Context = JClass('neqsim.process.engineering.calculation.EngineeringCalculationContext')\n",
+    "Relief = JClass('neqsim.process.engineering.safety.ReliefSizingCalculation')\n",
+    "ReliefInput = JClass('neqsim.process.engineering.safety.ReliefSizingCalculation$Input')\n",
+    "Phase = JClass('neqsim.process.engineering.safety.ReliefSizingCalculation$Phase')\n",
+    "context = (Context.builder().designCaseId('blocked-outlet')\n",
+    "           .addStandardReference('SYNTHETIC-PROJECT-RELIEF-BASIS')\n",
+    "           .addEvidenceReference('SYNTHETIC-RELIEF-CHECK')\n",
+    "           .attribute('productionQualification', 'true').build())\n",
+    "orifices = jpype.JArray(jpype.JDouble)([0.11, 0.196, 0.307, 0.503, 0.785, 1.287])\n",
+    "gas = (ReliefInput.builder('blocked-outlet', Phase.GAS).flowAndPressure(2.0, 60.0, 2.0)\n",
+    "       .gasProperties(320.0, 1.28, 0.95, 20.0).correctionFactors(0.975, 1.0, 1.0)\n",
+    "       .orificeCandidatesIn2(orifices).build())\n",
+    "relief_result = Relief().calculate(gas, context)\n",
+    "print(relief_result.getStatus(), relief_result.getValue().toMap())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Package handoff\n",
+    "\n",
+    "`EngineeringDeliverableCompiler` now writes `engineering-qualification-plan.json` beside `engineering-production-readiness.json`. Work the open plan actions using controlled sources, rerun the assessment, and retain both artifacts in the revisioned package. Even `QUALIFIED_FEED_SUPPORT` remains preliminary, review-required and explicitly not fit for construction.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignCalculations.java
+++ b/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignCalculations.java
@@ -144,7 +144,7 @@ public final class EquipmentDesignCalculations {
 
     @Override
     public String getMethodVersion() {
-      return "1.0";
+      return "2.0";
     }
 
     @Override
@@ -158,6 +158,20 @@ public final class EquipmentDesignCalculations {
         if (!input.values.containsKey(required)) {
           readiness.addBlocker("EQUIPMENT_INPUT_" + required.toUpperCase(), "Missing required input " + required,
               "Supply the value from a converged process/design case");
+        }
+      }
+      if (productionQualification(context)) {
+        for (String required : productionRequiredInputs()) {
+          if (!input.values.containsKey(required)) {
+            readiness.addBlocker("PRODUCTION_INPUT_" + required.toUpperCase(),
+                "Production qualification requires explicit input " + required,
+                "Supply a governed project value; screening defaults cannot qualify this method");
+          }
+        }
+        if (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty()) {
+          readiness.addBlocker("PRODUCTION_METHOD_EVIDENCE",
+              "Production qualification requires standard and evidence references",
+              "Attach the controlled calculation basis and independent evidence");
         }
       }
       return readiness.build();
@@ -185,6 +199,10 @@ public final class EquipmentDesignCalculations {
     abstract Result evaluate(Input input);
 
     abstract double uncertaintyBasis(Result result);
+
+    String[] productionRequiredInputs() {
+      return new String[0];
+    }
   }
 
   /** Separator/scrubber capacity, retention, level-volume and response-time calculation. */
@@ -220,6 +238,12 @@ public final class EquipmentDesignCalculations {
     double uncertaintyBasis(Result result) {
       return result.requireValue("insideDiameterM");
     }
+
+    @Override
+    String[] productionRequiredInputs() {
+      return new String[] { "gasLoadFactorMPerS", "retentionTimeS", "highHighResponseTimeS",
+          "availableTripResponseTimeS" };
+    }
   }
 
   /** Compressor map-envelope, recycle, settle-out and driver screening. */
@@ -252,6 +276,12 @@ public final class EquipmentDesignCalculations {
     double uncertaintyBasis(Result result) {
       return result.requireValue("driverRequiredPowerKw");
     }
+
+    @Override
+    String[] productionRequiredInputs() {
+      return new String[] { "driverMarginFraction", "minimumSurgeMarginFraction", "recycleDifferentialPressureBar",
+          "settleOutPressureBara", "mapExtrapolationFraction", "maxMapExtrapolationFraction", "startupPowerKw" };
+    }
   }
 
   /** Pump system-curve, NPSH, recycle and driver screening. */
@@ -278,6 +308,12 @@ public final class EquipmentDesignCalculations {
     @Override
     double uncertaintyBasis(Result result) {
       return result.requireValue("driverRequiredPowerKw");
+    }
+
+    @Override
+    String[] productionRequiredInputs() {
+      return new String[] { "minimumContinuousFlowM3s", "turndownFlowM3s", "minimumNpshMarginM",
+          "driverMarginFraction" };
     }
   }
 
@@ -308,6 +344,13 @@ public final class EquipmentDesignCalculations {
     double uncertaintyBasis(Result result) {
       return result.requireValue("preliminaryAreaM2");
     }
+
+    @Override
+    String[] productionRequiredInputs() {
+      return new String[] { "areaMarginFraction", "utilitySpecificDutyKJPerKg", "processPressureDropBar",
+          "maximumPressureDropBar", "availableUtilityFlowKgPerS", "highPressureSideBara", "lowPressureSideDesignBara",
+          "maximumDutyKw", "minimumDutyKw" };
+    }
   }
 
   /** Column/absorber flooding, turndown and preliminary diameter screening. */
@@ -334,6 +377,12 @@ public final class EquipmentDesignCalculations {
     @Override
     double uncertaintyBasis(Result result) {
       return result.requireValue("preliminaryDiameterM");
+    }
+
+    @Override
+    String[] productionRequiredInputs() {
+      return new String[] { "targetFloodingFraction", "minimumVaporLoadM3s", "minimumTurndownFraction",
+          "maximumCondenserDutyKw", "maximumReboilerDutyKw" };
     }
   }
 
@@ -365,6 +414,12 @@ public final class EquipmentDesignCalculations {
     double uncertaintyBasis(Result result) {
       return result.requireValue("preliminaryTotalVolumeM3");
     }
+
+    @Override
+    String[] productionRequiredInputs() {
+      return new String[] { "emergencyInflowM3s", "usableVolumeFraction", "normalVentRateM3s",
+          "installedVentCapacityM3s", "blanketingRateM3s" };
+    }
   }
 
   private static Map<String, Double> values(Object... pairs) {
@@ -373,6 +428,10 @@ public final class EquipmentDesignCalculations {
       result.put((String) pairs[i], Double.valueOf(((Number) pairs[i + 1]).doubleValue()));
     }
     return result;
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
   }
 
   private static Map<String, Boolean> constraints(Object... pairs) {

--- a/src/main/java/neqsim/process/engineering/calculation/MaterialsMechanicalDesignCalculations.java
+++ b/src/main/java/neqsim/process/engineering/calculation/MaterialsMechanicalDesignCalculations.java
@@ -74,7 +74,7 @@ public final class MaterialsMechanicalDesignCalculations {
 
     @Override
     public String getMethodVersion() {
-      return "1.0";
+      return "2.0";
     }
 
     @Override
@@ -83,6 +83,16 @@ public final class MaterialsMechanicalDesignCalculations {
       if (input == null) {
         result.addBlocker("MATERIAL_INPUT", "Materials-selection input is required",
             "Supply composition, phases, environment and design conditions");
+      }
+      if (productionQualification(context)) {
+        if (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty()) {
+          result.addBlocker("MATERIAL_PRODUCTION_EVIDENCE", "Materials qualification evidence is incomplete",
+              "Attach the corrosion assessment, process composition and applicable standards");
+        }
+        if (!"approved".equalsIgnoreCase(context.getAttributes().get("corrosionAssessment"))) {
+          result.addBlocker("MATERIAL_CORROSION_ASSESSMENT", "Corrosion assessment is not approved",
+              "Complete degradation-mechanism and corrosion-loop review");
+        }
       }
       return result.build();
     }
@@ -200,7 +210,7 @@ public final class MaterialsMechanicalDesignCalculations {
 
     @Override
     public String getMethodVersion() {
-      return "1.0";
+      return "2.0";
     }
 
     @Override
@@ -209,6 +219,16 @@ public final class MaterialsMechanicalDesignCalculations {
       if (input == null) {
         result.addBlocker("MECHANICAL_INPUT", "Mechanical-design input is required",
             "Supply governed pressure, temperature and geometry");
+      }
+      if (productionQualification(context)) {
+        if (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty()) {
+          result.addBlocker("MECHANICAL_PRODUCTION_EVIDENCE", "Mechanical qualification evidence is incomplete",
+              "Attach design-code, allowable-stress, load and geometry evidence");
+        }
+        if (!"approved".equalsIgnoreCase(context.getAttributes().get("designCodeBasis"))) {
+          result.addBlocker("MECHANICAL_DESIGN_CODE", "Design-code basis is not approved",
+              "Approve the applicable pressure-equipment code and load cases");
+        }
       }
       return result.build();
     }
@@ -264,6 +284,10 @@ public final class MaterialsMechanicalDesignCalculations {
       throw new IllegalArgumentException(field + " must not be blank");
     }
     return value.trim();
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
   }
 
   private static double positive(double value, String field) {

--- a/src/main/java/neqsim/process/engineering/calculation/ValveInstrumentDesignCalculations.java
+++ b/src/main/java/neqsim/process/engineering/calculation/ValveInstrumentDesignCalculations.java
@@ -80,7 +80,7 @@ public final class ValveInstrumentDesignCalculations {
 
     @Override
     public String getMethodVersion() {
-      return "1.0";
+      return "2.0";
     }
 
     @Override
@@ -89,8 +89,18 @@ public final class ValveInstrumentDesignCalculations {
       if (input == null) {
         readiness.addBlocker("VALVE_INPUT", "Valve case-envelope input is required", "Supply IEC 60534 inputs");
       } else if (input.failurePosition == FailurePosition.HAZOP_INPUT_REQUIRED) {
-        readiness.addWarning("VALVE_FAILURE_POSITION", "Failure position has not been selected by HAZOP",
-            "Approve fail-open, fail-closed, or fail-last in the safeguarding review");
+        if (productionQualification(context)) {
+          readiness.addBlocker("VALVE_FAILURE_POSITION", "Failure position has not been selected by HAZOP",
+              "Approve fail-open, fail-closed, or fail-last in the safeguarding review");
+        } else {
+          readiness.addWarning("VALVE_FAILURE_POSITION", "Failure position has not been selected by HAZOP",
+              "Approve fail-open, fail-closed, or fail-last in the safeguarding review");
+        }
+      }
+      if (productionQualification(context)
+          && (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty())) {
+        readiness.addBlocker("VALVE_PRODUCTION_EVIDENCE", "Valve qualification evidence is incomplete",
+            "Attach IEC 60534/project standards, vendor sizing and independent benchmark evidence");
       }
       return readiness.build();
     }
@@ -205,7 +215,7 @@ public final class ValveInstrumentDesignCalculations {
 
     @Override
     public String getMethodVersion() {
-      return "1.0";
+      return "2.0";
     }
 
     @Override
@@ -215,6 +225,16 @@ public final class ValveInstrumentDesignCalculations {
         result.addBlocker("INSTRUMENT_INPUT", "Instrument design input is required", "Supply process envelope");
       } else if (input.upperRangeValue <= input.lowerRangeValue) {
         result.addBlocker("INSTRUMENT_RANGE", "Upper range must exceed lower range", "Correct calibrated range");
+      }
+      if (productionQualification(context)) {
+        if (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty()) {
+          result.addBlocker("INSTRUMENT_PRODUCTION_EVIDENCE", "Instrument qualification evidence is incomplete",
+              "Attach range, uncertainty, response and vendor evidence");
+        }
+        if (!"approved".equalsIgnoreCase(context.getAttributes().get("instrumentInstallationEvidence"))) {
+          result.addBlocker("INSTRUMENT_INSTALLATION", "Tap, impulse-line or thermowell evidence is not approved",
+              "Attach the applicable installation and mechanical verification record");
+        }
       }
       return result.build();
     }
@@ -262,6 +282,10 @@ public final class ValveInstrumentDesignCalculations {
       throw new IllegalArgumentException(field + " must not be blank");
     }
     return value.trim();
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
   }
 
   private static double positive(double value, String field) {

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
@@ -32,6 +32,7 @@ import neqsim.process.engineering.model.EngineeringIds;
 import neqsim.process.engineering.model.EngineeringNode;
 import neqsim.process.engineering.model.EngineeringProvenance;
 import neqsim.process.engineering.production.EngineeringProductionReadinessAssessment;
+import neqsim.process.engineering.production.EngineeringQualificationPlan;
 import neqsim.process.engineering.validation.EngineeringPackageValidationException;
 import neqsim.process.engineering.validation.EngineeringPackageValidationReport;
 import neqsim.process.engineering.validation.EngineeringPackageValidator;
@@ -47,7 +48,7 @@ public final class EngineeringDeliverableCompiler {
       "equipment-datasheets.json", "valve-list.json", "io-list.json", "alarm-trip-schedule.json",
       "shutdown-narratives.json", "psv-datasheets.json", "flare-blowdown-report.json", "utility-summary.json",
       "materials-selection-report.json", "unresolved-engineering-actions.json", "revision-impact-report.json",
-      "engineering-production-readiness.json" };
+      "engineering-production-readiness.json", "engineering-qualification-plan.json" };
 
   private EngineeringDeliverableCompiler() {
   }
@@ -68,6 +69,7 @@ public final class EngineeringDeliverableCompiler {
     private final Path lineRegisterFile;
     private final Path instrumentRegisterFile;
     private final Path productionReadinessFile;
+    private final Path qualificationPlanFile;
     private final Path compilerManifestFile;
     private final Path validationReportFile;
     private final Path revisionDiffFile;
@@ -80,9 +82,10 @@ public final class EngineeringDeliverableCompiler {
         Path engineeringCalculationDagFile, Path engineeringDesignCaseMatrixFile, Path engineeringDisciplinePackageFile,
         Path engineeringApprovalLedgerFile, Path engineeringDexpiRoundTripReportFile,
         Path engineeringAutomationPlanFile, Path designEnvelopeFile, Path equipmentRegisterFile, Path lineRegisterFile,
-        Path instrumentRegisterFile, Path productionReadinessFile, Path compilerManifestFile, Path validationReportFile,
-        Path revisionDiffFile, EngineeringGraph engineeringGraph, EngineeringDesignEnvelope designEnvelope,
-        DexpiEngineeringExporter.ExportResult dexpiResult, EngineeringPackageValidationReport validationReport) {
+        Path instrumentRegisterFile, Path productionReadinessFile, Path qualificationPlanFile,
+        Path compilerManifestFile, Path validationReportFile, Path revisionDiffFile, EngineeringGraph engineeringGraph,
+        EngineeringDesignEnvelope designEnvelope, DexpiEngineeringExporter.ExportResult dexpiResult,
+        EngineeringPackageValidationReport validationReport) {
       this.outputDirectory = outputDirectory;
       this.engineeringGraphFile = engineeringGraphFile;
       this.engineeringConnectivityFile = engineeringConnectivityFile;
@@ -97,6 +100,7 @@ public final class EngineeringDeliverableCompiler {
       this.lineRegisterFile = lineRegisterFile;
       this.instrumentRegisterFile = instrumentRegisterFile;
       this.productionReadinessFile = productionReadinessFile;
+      this.qualificationPlanFile = qualificationPlanFile;
       this.compilerManifestFile = compilerManifestFile;
       this.validationReportFile = validationReportFile;
       this.revisionDiffFile = revisionDiffFile;
@@ -160,6 +164,10 @@ public final class EngineeringDeliverableCompiler {
 
     public Path getProductionReadinessFile() {
       return productionReadinessFile;
+    }
+
+    public Path getQualificationPlanFile() {
+      return qualificationPlanFile;
     }
 
     public Path getCompilerManifestFile() {
@@ -277,6 +285,9 @@ public final class EngineeringDeliverableCompiler {
     Path productionReadinessFile = outputDirectory.resolve("engineering-production-readiness.json");
     write(productionReadinessFile, GSON.toJson(
         EngineeringProductionReadinessAssessment.assess(project, project.getProductionReadinessBasis()).toMap()));
+    Path qualificationPlanFile = outputDirectory.resolve("engineering-qualification-plan.json");
+    write(qualificationPlanFile,
+        GSON.toJson(EngineeringQualificationPlan.build(project, project.getProductionReadinessBasis())));
     Path approvalLedgerFile = outputDirectory.resolve("engineering-approval-ledger.json");
     write(approvalLedgerFile, GSON.toJson(EngineeringApprovalLedger.build(project, graph, diff)));
     Path compilerManifest = outputDirectory.resolve("engineering-compiler-manifest.json");
@@ -291,8 +302,8 @@ public final class EngineeringDeliverableCompiler {
     DexpiEngineeringExporter.refreshPackageManifest(outputDirectory);
     return new CompilationResult(outputDirectory, graphFile, connectivityFile, calculationDagFile, designCaseMatrixFile,
         disciplinePackageFile, approvalLedgerFile, dexpiRoundTripReportFile, automationPlanFile, envelopeFile,
-        equipmentFile, lineFile, instrumentFile, productionReadinessFile, compilerManifest, validationFile, diffFile,
-        graph, envelope, dexpiResult, validation);
+        equipmentFile, lineFile, instrumentFile, productionReadinessFile, qualificationPlanFile, compilerManifest,
+        validationFile, diffFile, graph, envelope, dexpiResult, validation);
   }
 
   private static void addDocumentNodes(EngineeringGraph graph, EngineeringProject project) {
@@ -308,7 +319,7 @@ public final class EngineeringDeliverableCompiler {
         "process-design-basis.json", "equipment-datasheets.json", "valve-list.json", "io-list.json",
         "alarm-trip-schedule.json", "shutdown-narratives.json", "psv-datasheets.json", "flare-blowdown-report.json",
         "utility-summary.json", "materials-selection-report.json", "unresolved-engineering-actions.json",
-        "revision-impact-report.json", "engineering-production-readiness.json" };
+        "revision-impact-report.json", "engineering-production-readiness.json", "engineering-qualification-plan.json" };
     for (String document : documents) {
       String nodeId = EngineeringIds.nodeId(EngineeringNode.Kind.DOCUMENT, document);
       graph.addNode(new EngineeringNode(nodeId, EngineeringNode.Kind.DOCUMENT, document, document)

--- a/src/main/java/neqsim/process/engineering/piping/PipingNetworkDesignCalculation.java
+++ b/src/main/java/neqsim/process/engineering/piping/PipingNetworkDesignCalculation.java
@@ -50,6 +50,9 @@ public final class PipingNetworkDesignCalculation implements
     private final double referenceDiameterM;
     private final double operatingPressureBara;
     private final double densityKgM3;
+    private final double dynamicViscosityPaS;
+    private final double absoluteRoughnessM;
+    private final boolean detailedHydraulics;
 
     public Case(String id, double volumeFlowM3s, double referencePressureDropBar, double referenceDiameterM,
         double operatingPressureBara, double densityKgM3) {
@@ -59,6 +62,29 @@ public final class PipingNetworkDesignCalculation implements
       this.referenceDiameterM = positive(referenceDiameterM, "referenceDiameterM");
       this.operatingPressureBara = positive(operatingPressureBara, "operatingPressureBara");
       this.densityKgM3 = positive(densityKgM3, "densityKgM3");
+      dynamicViscosityPaS = Double.NaN;
+      absoluteRoughnessM = Double.NaN;
+      detailedHydraulics = false;
+    }
+
+    private Case(String id, double volumeFlowM3s, double operatingPressureBara, double densityKgM3,
+        double dynamicViscosityPaS, double absoluteRoughnessM, boolean detailedHydraulics) {
+      this.id = text(id, "id");
+      this.volumeFlowM3s = nonNegative(volumeFlowM3s, "volumeFlowM3s");
+      referencePressureDropBar = 0.0;
+      referenceDiameterM = 1.0;
+      this.operatingPressureBara = positive(operatingPressureBara, "operatingPressureBara");
+      this.densityKgM3 = positive(densityKgM3, "densityKgM3");
+      this.dynamicViscosityPaS = positive(dynamicViscosityPaS, "dynamicViscosityPaS");
+      this.absoluteRoughnessM = nonNegative(absoluteRoughnessM, "absoluteRoughnessM");
+      this.detailedHydraulics = detailedHydraulics;
+    }
+
+    /** Creates a Darcy-Weisbach case using governed density, viscosity and absolute roughness. */
+    public static Case detailed(String id, double volumeFlowM3s, double operatingPressureBara, double densityKgM3,
+        double dynamicViscosityPaS, double absoluteRoughnessM) {
+      return new Case(id, volumeFlowM3s, operatingPressureBara, densityKgM3, dynamicViscosityPaS, absoluteRoughnessM,
+          true);
     }
   }
 
@@ -73,6 +99,7 @@ public final class PipingNetworkDesignCalculation implements
     private final double elevationChangeM;
     private final double multiphaseMultiplier;
     private final double reliefSetPressureBarg;
+    private String simultaneousDemandGroup = "";
     private final List<Case> cases = new ArrayList<Case>();
 
     public Segment(String tag, boolean gasService, boolean reliefInlet, double lengthM, double equivalentLengthM,
@@ -82,9 +109,12 @@ public final class PipingNetworkDesignCalculation implements
       this.reliefInlet = reliefInlet;
       this.lengthM = positive(lengthM, "lengthM");
       this.equivalentLengthM = nonNegative(equivalentLengthM, "equivalentLengthM");
+      if (!Double.isFinite(elevationChangeM)) {
+        throw new IllegalArgumentException("elevationChangeM must be finite");
+      }
       this.elevationChangeM = elevationChangeM;
       this.multiphaseMultiplier = positive(multiphaseMultiplier, "multiphaseMultiplier");
-      this.reliefSetPressureBarg = reliefSetPressureBarg;
+      this.reliefSetPressureBarg = nonNegative(reliefSetPressureBarg, "reliefSetPressureBarg");
     }
 
     public Segment addCase(Case value) {
@@ -92,6 +122,12 @@ public final class PipingNetworkDesignCalculation implements
         throw new IllegalArgumentException("case must not be null");
       }
       cases.add(value);
+      return this;
+    }
+
+    /** Adds a declared utility/header demand group whose simultaneous flow is applied to every case. */
+    public Segment simultaneousDemandGroup(String value) {
+      simultaneousDemandGroup = text(value, "simultaneousDemandGroup");
       return this;
     }
   }
@@ -113,8 +149,18 @@ public final class PipingNetworkDesignCalculation implements
           : Collections.unmodifiableList(new ArrayList<Candidate>(candidates));
       this.segments = segments == null ? Collections.<Segment>emptyList()
           : Collections.unmodifiableList(new ArrayList<Segment>(segments));
-      this.simultaneousDemands = simultaneousDemands == null ? Collections.<String, Double>emptyMap()
-          : Collections.unmodifiableMap(new LinkedHashMap<String, Double>(simultaneousDemands));
+      Map<String, Double> demands = new LinkedHashMap<String, Double>();
+      if (simultaneousDemands != null) {
+        for (Map.Entry<String, Double> demand : simultaneousDemands.entrySet()) {
+          String group = text(demand.getKey(), "simultaneousDemandGroup");
+          Double demandValue = demand.getValue();
+          if (demandValue == null) {
+            throw new IllegalArgumentException("Simultaneous demand for " + group + " must not be null");
+          }
+          demands.put(group, Double.valueOf(nonNegative(demandValue.doubleValue(), "simultaneousDemand")));
+        }
+      }
+      this.simultaneousDemands = Collections.unmodifiableMap(demands);
     }
   }
 
@@ -154,7 +200,7 @@ public final class PipingNetworkDesignCalculation implements
 
   @Override
   public String getMethodVersion() {
-    return "1.0";
+    return "2.0";
   }
 
   @Override
@@ -179,6 +225,26 @@ public final class PipingNetworkDesignCalculation implements
             "Attach operating and design cases");
       }
     }
+    if (productionQualification(context)) {
+      for (Segment segment : input.segments) {
+        for (Case hydraulicCase : segment.cases) {
+          if (!hydraulicCase.detailedHydraulics) {
+            result.addBlocker("PIPING_DETAILED_CASE_" + segment.tag + "_" + hydraulicCase.id,
+                "Production qualification cannot use reference-diameter pressure-drop scaling",
+                "Supply density, viscosity and roughness with Case.detailed");
+          }
+        }
+        if (!segment.simultaneousDemandGroup.isEmpty()
+            && !input.simultaneousDemands.containsKey(segment.simultaneousDemandGroup)) {
+          result.addBlocker("PIPING_SIMULTANEOUS_DEMAND_" + segment.tag,
+              "Declared simultaneous-demand group has no governed demand", "Supply the header demand case");
+        }
+      }
+      if (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty()) {
+        result.addBlocker("PIPING_PRODUCTION_EVIDENCE", "Piping qualification evidence is incomplete",
+            "Attach standards, line-list/hydraulic evidence and independent benchmark references");
+      }
+    }
     return result.build();
   }
 
@@ -201,7 +267,7 @@ public final class PipingNetworkDesignCalculation implements
     });
     Map<String, Map<String, Object>> selections = new LinkedHashMap<String, Map<String, Object>>();
     for (Segment segment : input.segments) {
-      selections.put(segment.tag, select(segment, ordered, input.rulePack));
+      selections.put(segment.tag, select(segment, ordered, input.rulePack, input.simultaneousDemands));
     }
     double demand = 0.0;
     for (Double value : input.simultaneousDemands.values()) {
@@ -214,9 +280,10 @@ public final class PipingNetworkDesignCalculation implements
         .build();
   }
 
-  private static Map<String, Object> select(Segment segment, List<Candidate> candidates, PipingRulePack rules) {
+  private static Map<String, Object> select(Segment segment, List<Candidate> candidates, PipingRulePack rules,
+      Map<String, Double> simultaneousDemands) {
     for (Candidate candidate : candidates) {
-      Map<String, Object> checks = evaluate(segment, candidate, rules);
+      Map<String, Object> checks = evaluate(segment, candidate, rules, simultaneousDemands);
       if (Boolean.TRUE.equals(checks.get("allConstraintsSatisfied"))) {
         checks.put("candidate", candidate.toMap());
         checks.put("governingStatus", "CALCULATED_REVIEW_REQUIRED");
@@ -226,20 +293,36 @@ public final class PipingNetworkDesignCalculation implements
     throw new IllegalStateException("No piping candidate satisfies all cases for " + segment.tag);
   }
 
-  private static Map<String, Object> evaluate(Segment segment, Candidate candidate, PipingRulePack rules) {
+  private static Map<String, Object> evaluate(Segment segment, Candidate candidate, PipingRulePack rules,
+      Map<String, Double> simultaneousDemands) {
     double maximumVelocity = 0.0;
     double minimumVelocity = Double.POSITIVE_INFINITY;
     double maximumGradient = 0.0;
     double maximumDrop = 0.0;
     String governingCase = "";
     boolean pressureRating = true;
+    double maximumReynoldsNumber = 0.0;
+    double maximumFrictionFactor = 0.0;
+    double simultaneousDemand = segment.simultaneousDemandGroup.isEmpty() ? 0.0
+        : value(simultaneousDemands, segment.simultaneousDemandGroup);
     for (Case hydraulicCase : segment.cases) {
-      double velocity = 4.0 * hydraulicCase.volumeFlowM3s
-          / (Math.PI * candidate.insideDiameterM * candidate.insideDiameterM);
+      double effectiveFlow = hydraulicCase.volumeFlowM3s + simultaneousDemand;
+      double velocity = 4.0 * effectiveFlow / (Math.PI * candidate.insideDiameterM * candidate.insideDiameterM);
       double effectiveLength = segment.lengthM + segment.equivalentLengthM;
-      double drop = hydraulicCase.referencePressureDropBar
-          * Math.pow(hydraulicCase.referenceDiameterM / candidate.insideDiameterM, 5.0) * effectiveLength
-          / segment.lengthM * segment.multiphaseMultiplier;
+      double drop;
+      if (hydraulicCase.detailedHydraulics) {
+        double reynolds = hydraulicCase.densityKgM3 * velocity * candidate.insideDiameterM
+            / hydraulicCase.dynamicViscosityPaS;
+        double friction = frictionFactor(reynolds, hydraulicCase.absoluteRoughnessM, candidate.insideDiameterM);
+        drop = friction * effectiveLength / candidate.insideDiameterM * hydraulicCase.densityKgM3 * velocity * velocity
+            / 2.0 / 1.0e5 * segment.multiphaseMultiplier;
+        maximumReynoldsNumber = Math.max(maximumReynoldsNumber, reynolds);
+        maximumFrictionFactor = Math.max(maximumFrictionFactor, friction);
+      } else {
+        drop = hydraulicCase.referencePressureDropBar
+            * Math.pow(hydraulicCase.referenceDiameterM / candidate.insideDiameterM, 5.0) * effectiveLength
+            / segment.lengthM * segment.multiphaseMultiplier;
+      }
       drop = Math.max(drop + hydraulicCase.densityKgM3 * 9.80665 * segment.elevationChangeM / 1.0e5, 0.0);
       double gradient = drop / Math.max(effectiveLength / 1000.0, 1.0e-12);
       if (velocity > maximumVelocity || drop > maximumDrop) {
@@ -264,6 +347,10 @@ public final class PipingNetworkDesignCalculation implements
     result.put("minimumVelocityMPerS", Double.valueOf(minimumVelocity));
     result.put("maximumPressureGradientBarPerKm", Double.valueOf(maximumGradient));
     result.put("maximumPressureDropBar", Double.valueOf(maximumDrop));
+    result.put("maximumReynoldsNumber", Double.valueOf(maximumReynoldsNumber));
+    result.put("maximumDarcyFrictionFactor", Double.valueOf(maximumFrictionFactor));
+    result.put("simultaneousDemandGroup", segment.simultaneousDemandGroup);
+    result.put("simultaneousDemandM3s", Double.valueOf(simultaneousDemand));
     result.put("elevationChangeM", Double.valueOf(segment.elevationChangeM));
     result.put("velocitySatisfied", Boolean.valueOf(velocity));
     result.put("minimumVelocitySatisfied", Boolean.valueOf(minimumVelocitySatisfied));
@@ -282,12 +369,35 @@ public final class PipingNetworkDesignCalculation implements
     return result;
   }
 
+  private static double frictionFactor(double reynolds, double roughness, double diameter) {
+    if (reynolds <= 0.0) {
+      return 0.0;
+    }
+    if (reynolds < 2300.0) {
+      return 64.0 / reynolds;
+    }
+    double argument = roughness / Math.max(3.7 * diameter, 1.0e-12) + 5.74 / Math.pow(reynolds, 0.9);
+    return 0.25 / Math.pow(Math.log10(Math.max(argument, 1.0e-12)), 2.0);
+  }
+
+  private static double value(Map<String, Double> values, String key) {
+    Double value = values.get(key);
+    if (value == null || !Double.isFinite(value.doubleValue()) || value.doubleValue() < 0.0) {
+      throw new IllegalArgumentException("Missing finite non-negative simultaneous demand for group " + key);
+    }
+    return value.doubleValue();
+  }
+
   private static double maximumDensity(Segment segment) {
     double maximum = 0.0;
     for (Case hydraulicCase : segment.cases) {
       maximum = Math.max(maximum, hydraulicCase.densityKgM3);
     }
     return Math.max(maximum, 1.0e-12);
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
   }
 
   private static String text(String value, String field) {

--- a/src/main/java/neqsim/process/engineering/production/DexpiToolQualificationRunner.java
+++ b/src/main/java/neqsim/process/engineering/production/DexpiToolQualificationRunner.java
@@ -1,0 +1,151 @@
+package neqsim.process.engineering.production;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Compares stable DEXPI semantic snapshots before and after a named external-tool round trip. */
+public final class DexpiToolQualificationRunner {
+  private DexpiToolQualificationRunner() {
+  }
+
+  /** Tool-neutral semantic inventory produced by a DEXPI importer adapter. */
+  public static final class Snapshot implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String profile;
+    private final Map<String, Map<String, String>> objects = new LinkedHashMap<String, Map<String, String>>();
+    private final Set<String> connections = new LinkedHashSet<String>();
+
+    public Snapshot(String profile) {
+      this.profile = text(profile, "profile");
+    }
+
+    public Snapshot addObject(String persistentId, Map<String, String> properties) {
+      String id = text(persistentId, "persistentId");
+      if (objects.containsKey(id)) {
+        throw new IllegalArgumentException("Duplicate DEXPI persistent id " + id);
+      }
+      Map<String, String> normalized = new LinkedHashMap<String, String>();
+      if (properties != null) {
+        for (Map.Entry<String, String> property : properties.entrySet()) {
+          normalized.put(text(property.getKey(), "property name"), text(property.getValue(), "property value"));
+        }
+      }
+      objects.put(id, Collections.unmodifiableMap(normalized));
+      return this;
+    }
+
+    public Snapshot addConnection(String sourceId, String relationship, String targetId) {
+      connections.add(
+          text(sourceId, "sourceId") + "|" + text(relationship, "relationship") + "|" + text(targetId, "targetId"));
+      return this;
+    }
+  }
+
+  /** Complete named-tool comparison plus the readiness evidence derived from it. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final DexpiToolQualificationEvidence evidence;
+    private final List<String> semanticDifferences;
+
+    Result(DexpiToolQualificationEvidence evidence, List<String> semanticDifferences) {
+      this.evidence = evidence;
+      this.semanticDifferences = Collections.unmodifiableList(new ArrayList<String>(semanticDifferences));
+    }
+
+    public DexpiToolQualificationEvidence getEvidence() {
+      return evidence;
+    }
+
+    public boolean isQualified() {
+      return evidence.isQualified();
+    }
+
+    public List<String> getSemanticDifferences() {
+      return semanticDifferences;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("evidence", evidence.toMap());
+      result.put("semanticDifferences", new ArrayList<String>(semanticDifferences));
+      result.put("qualified", Boolean.valueOf(isQualified()));
+      return result;
+    }
+  }
+
+  public static Result compare(String product, String version, Snapshot reference, Snapshot afterImport,
+      Snapshot afterExportAndReimport, String evidenceReference, String accountableReviewer) {
+    List<String> differences = new ArrayList<String>();
+    boolean imported = afterImport != null;
+    boolean exported = afterExportAndReimport != null;
+    if (reference == null) {
+      throw new IllegalArgumentException("reference snapshot must not be null");
+    }
+    if (afterImport == null) {
+      differences.add("Named tool did not produce an import snapshot");
+    } else {
+      compareSnapshots("IMPORT", reference, afterImport, differences);
+    }
+    if (afterExportAndReimport == null) {
+      differences.add("Named tool did not produce an export/reimport snapshot");
+    } else {
+      compareSnapshots("EXPORT_REIMPORT", reference, afterExportAndReimport, differences);
+    }
+    DexpiToolQualificationEvidence evidence = new DexpiToolQualificationEvidence(product, version, reference.profile,
+        imported, exported, differences.size(), evidenceReference, accountableReviewer);
+    return new Result(evidence, differences);
+  }
+
+  private static void compareSnapshots(String stage, Snapshot expected, Snapshot actual, List<String> differences) {
+    if (!expected.profile.equals(actual.profile)) {
+      differences.add(stage + " profile expected " + expected.profile + " but found " + actual.profile);
+    }
+    for (Map.Entry<String, Map<String, String>> expectedObject : expected.objects.entrySet()) {
+      Map<String, String> actualProperties = actual.objects.get(expectedObject.getKey());
+      if (actualProperties == null) {
+        differences.add(stage + " missing object " + expectedObject.getKey());
+        continue;
+      }
+      for (Map.Entry<String, String> property : expectedObject.getValue().entrySet()) {
+        String actualValue = actualProperties.get(property.getKey());
+        if (!property.getValue().equals(actualValue)) {
+          differences.add(stage + " object " + expectedObject.getKey() + " property " + property.getKey() + " expected "
+              + property.getValue() + " but found " + String.valueOf(actualValue));
+        }
+      }
+      for (String property : actualProperties.keySet()) {
+        if (!expectedObject.getValue().containsKey(property)) {
+          differences.add(stage + " object " + expectedObject.getKey() + " unexpected property " + property);
+        }
+      }
+    }
+    for (String id : actual.objects.keySet()) {
+      if (!expected.objects.containsKey(id)) {
+        differences.add(stage + " unexpected object " + id);
+      }
+    }
+    for (String connection : expected.connections) {
+      if (!actual.connections.contains(connection)) {
+        differences.add(stage + " missing connection " + connection);
+      }
+    }
+    for (String connection : actual.connections) {
+      if (!expected.connections.contains(connection)) {
+        differences.add(stage + " unexpected connection " + connection);
+      }
+    }
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/EngineeringBenchmarkDataset.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringBenchmarkDataset.java
@@ -1,0 +1,232 @@
+package neqsim.process.engineering.production;
+
+import com.google.gson.GsonBuilder;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Versioned, serializable independent-reference dataset and executable benchmark runner. */
+public final class EngineeringBenchmarkDataset implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** One expected scalar with explicit unit and acceptance tolerance. */
+  public static final class ExpectedValue implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final double expected;
+    private final String unit;
+    private final double absoluteTolerance;
+    private final double relativeTolerance;
+
+    public ExpectedValue(String name, double expected, String unit, double absoluteTolerance,
+        double relativeTolerance) {
+      this.name = text(name, "name");
+      this.unit = text(unit, "unit");
+      if (!Double.isFinite(expected) || !Double.isFinite(absoluteTolerance) || !Double.isFinite(relativeTolerance)
+          || absoluteTolerance < 0.0 || relativeTolerance < 0.0) {
+        throw new IllegalArgumentException("Expected value and tolerances must be finite and non-negative");
+      }
+      this.expected = expected;
+      this.absoluteTolerance = absoluteTolerance;
+      this.relativeTolerance = relativeTolerance;
+    }
+  }
+
+  /** One controlled reference case for an exact calculation method version. */
+  public static final class Case implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String id;
+    private final String methodId;
+    private final String methodVersion;
+    private final EngineeringValidationBenchmark.SourceClass sourceClass;
+    private final String sourceReference;
+    private final String sourceRevision;
+    private final String independentReviewRecord;
+    private final List<ExpectedValue> expectedValues = new ArrayList<ExpectedValue>();
+
+    public Case(String id, String methodId, String methodVersion,
+        EngineeringValidationBenchmark.SourceClass sourceClass, String sourceReference, String sourceRevision,
+        String independentReviewRecord) {
+      this.id = text(id, "id");
+      this.methodId = text(methodId, "methodId");
+      this.methodVersion = text(methodVersion, "methodVersion");
+      if (sourceClass == null) {
+        throw new IllegalArgumentException("sourceClass must not be null");
+      }
+      this.sourceClass = sourceClass;
+      this.sourceReference = text(sourceReference, "sourceReference");
+      this.sourceRevision = text(sourceRevision, "sourceRevision");
+      this.independentReviewRecord = optional(independentReviewRecord);
+    }
+
+    public Case expect(String name, double expected, String unit, double absoluteTolerance, double relativeTolerance) {
+      expectedValues.add(new ExpectedValue(name, expected, unit, absoluteTolerance, relativeTolerance));
+      return this;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getMethodKey() {
+      return methodId + "@" + methodVersion;
+    }
+
+    EngineeringValidationBenchmark evaluate(Map<String, Double> actualValues) {
+      if (expectedValues.isEmpty()) {
+        throw new IllegalStateException("Benchmark case " + id + " has no expected values");
+      }
+      Map<String, Double> actual = actualValues == null ? Collections.<String, Double>emptyMap() : actualValues;
+      EngineeringValidationBenchmark.Builder result = EngineeringValidationBenchmark
+          .builder(id, methodId, methodVersion).source(sourceClass, sourceReference, sourceRevision);
+      if (!independentReviewRecord.isEmpty()) {
+        result.independentReview(independentReviewRecord);
+      }
+      for (ExpectedValue expectedValue : expectedValues) {
+        Double value = actual.get(expectedValue.name);
+        if (value == null || !Double.isFinite(value.doubleValue())) {
+          throw new IllegalArgumentException(
+              "Missing finite actual output " + expectedValue.name + " for benchmark case " + id);
+        }
+        result.check(expectedValue.name, expectedValue.expected, value.doubleValue(), expectedValue.unit,
+            expectedValue.absoluteTolerance, expectedValue.relativeTolerance);
+      }
+      return result.build();
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("id", id);
+      result.put("methodId", methodId);
+      result.put("methodVersion", methodVersion);
+      result.put("methodKey", getMethodKey());
+      result.put("sourceClass", sourceClass.name());
+      result.put("sourceReference", sourceReference);
+      result.put("sourceRevision", sourceRevision);
+      result.put("independentReviewRecord", independentReviewRecord);
+      List<Map<String, Object>> values = new ArrayList<Map<String, Object>>();
+      for (ExpectedValue value : expectedValues) {
+        Map<String, Object> row = new LinkedHashMap<String, Object>();
+        row.put("name", value.name);
+        row.put("expected", Double.valueOf(value.expected));
+        row.put("unit", value.unit);
+        row.put("absoluteTolerance", Double.valueOf(value.absoluteTolerance));
+        row.put("relativeTolerance", Double.valueOf(value.relativeTolerance));
+        values.add(row);
+      }
+      result.put("expectedValues", values);
+      return result;
+    }
+  }
+
+  /** Dataset execution result retaining missing case/output findings. */
+  public static final class RunResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final EngineeringBenchmarkSuite.Report report;
+    private final List<String> findings;
+
+    RunResult(EngineeringBenchmarkSuite.Report report, List<String> findings) {
+      this.report = report;
+      this.findings = Collections.unmodifiableList(new ArrayList<String>(findings));
+    }
+
+    public EngineeringBenchmarkSuite.Report getReport() {
+      return report;
+    }
+
+    public boolean isComplete() {
+      return findings.isEmpty();
+    }
+
+    public List<String> getFindings() {
+      return findings;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("report", report.toMap());
+      result.put("findings", new ArrayList<String>(findings));
+      result.put("complete", Boolean.valueOf(isComplete()));
+      return result;
+    }
+  }
+
+  private final String id;
+  private final String revision;
+  private final List<Case> cases = new ArrayList<Case>();
+
+  public EngineeringBenchmarkDataset(String id, String revision) {
+    this.id = text(id, "id");
+    this.revision = text(revision, "revision");
+  }
+
+  public EngineeringBenchmarkDataset add(Case value) {
+    if (value == null) {
+      throw new IllegalArgumentException("benchmark case must not be null");
+    }
+    for (Case existing : cases) {
+      if (existing.id.equals(value.id)) {
+        throw new IllegalArgumentException("Duplicate benchmark case " + value.id);
+      }
+    }
+    cases.add(value);
+    return this;
+  }
+
+  /** Executes every case against actual outputs keyed first by case id and then output name. */
+  public RunResult run(Map<String, Map<String, Double>> actualOutputs) {
+    Map<String, Map<String, Double>> actual = actualOutputs == null
+        ? Collections.<String, Map<String, Double>>emptyMap()
+        : actualOutputs;
+    EngineeringBenchmarkSuite suite = new EngineeringBenchmarkSuite(id, revision);
+    Set<String> methods = new LinkedHashSet<String>();
+    for (Case item : cases) {
+      methods.add(item.getMethodKey());
+    }
+    for (String method : methods) {
+      suite.requireMethod(method);
+    }
+    List<String> findings = new ArrayList<String>();
+    for (Case item : cases) {
+      try {
+        suite.add(item.evaluate(actual.get(item.id)));
+      } catch (IllegalArgumentException | IllegalStateException ex) {
+        findings.add(ex.getMessage());
+      }
+    }
+    return new RunResult(suite.evaluate(), findings);
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("datasetId", id);
+    result.put("revision", revision);
+    List<Map<String, Object>> rows = new ArrayList<Map<String, Object>>();
+    for (Case item : cases) {
+      rows.add(item.toMap());
+    }
+    result.put("cases", rows);
+    result.put("engineeringApprovalRequired", Boolean.TRUE);
+    return result;
+  }
+
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+  }
+
+  private static String optional(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/EngineeringBenchmarkSuite.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringBenchmarkSuite.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/** Executes acceptance logic over versioned engineering benchmark records. */
+/** Executes acceptance logic over versioned engineering benchmark records; every case for a method must qualify. */
 public final class EngineeringBenchmarkSuite implements Serializable {
   private static final long serialVersionUID = 1000L;
   private final String id;
@@ -53,9 +53,17 @@ public final class EngineeringBenchmarkSuite implements Serializable {
       this.revision = revision;
       this.requiredMethods = Collections.unmodifiableSet(new LinkedHashSet<String>(requiredMethods));
       this.benchmarks = Collections.unmodifiableList(new ArrayList<EngineeringValidationBenchmark>(benchmarks));
+      Map<String, Boolean> methodStatus = new LinkedHashMap<String, Boolean>();
       for (EngineeringValidationBenchmark benchmark : benchmarks) {
-        if (benchmark.isPassed() && benchmark.isIndependentSource() && benchmark.isIndependentlyReviewed()) {
-          qualifyingMethods.add(benchmark.getMethodKey());
+        String method = benchmark.getMethodKey();
+        boolean caseQualifies = benchmark.isPassed() && benchmark.isIndependentSource()
+            && benchmark.isIndependentlyReviewed();
+        Boolean previous = methodStatus.get(method);
+        methodStatus.put(method, Boolean.valueOf((previous == null || previous.booleanValue()) && caseQualifies));
+      }
+      for (Map.Entry<String, Boolean> method : methodStatus.entrySet()) {
+        if (method.getValue().booleanValue()) {
+          qualifyingMethods.add(method.getKey());
         }
       }
     }

--- a/src/main/java/neqsim/process/engineering/production/EngineeringPilotQualificationRunner.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringPilotQualificationRunner.java
@@ -1,0 +1,123 @@
+package neqsim.process.engineering.production;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Quantified comparison of one NeqSim engineering pilot against an independently reviewed reference package. */
+public final class EngineeringPilotQualificationRunner {
+  private EngineeringPilotQualificationRunner() {
+  }
+
+  /** One scalar comparison; material comparisons block pilot acceptance when outside tolerance. */
+  public static final class Comparison implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final double referenceValue;
+    private final double simulatedValue;
+    private final String unit;
+    private final double absoluteTolerance;
+    private final double relativeTolerance;
+    private final boolean material;
+
+    public Comparison(String name, double referenceValue, double simulatedValue, String unit, double absoluteTolerance,
+        double relativeTolerance, boolean material) {
+      this.name = text(name, "name");
+      this.unit = text(unit, "unit");
+      if (!Double.isFinite(referenceValue) || !Double.isFinite(simulatedValue) || !Double.isFinite(absoluteTolerance)
+          || !Double.isFinite(relativeTolerance) || absoluteTolerance < 0.0 || relativeTolerance < 0.0) {
+        throw new IllegalArgumentException("Pilot values and tolerances must be finite and non-negative");
+      }
+      this.referenceValue = referenceValue;
+      this.simulatedValue = simulatedValue;
+      this.absoluteTolerance = absoluteTolerance;
+      this.relativeTolerance = relativeTolerance;
+      this.material = material;
+    }
+
+    public boolean isPassed() {
+      double error = Math.abs(simulatedValue - referenceValue);
+      return error <= absoluteTolerance || error / Math.max(Math.abs(referenceValue), 1.0e-12) <= relativeTolerance;
+    }
+
+    Map<String, Object> toMap() {
+      double absoluteError = Math.abs(simulatedValue - referenceValue);
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("name", name);
+      result.put("referenceValue", Double.valueOf(referenceValue));
+      result.put("simulatedValue", Double.valueOf(simulatedValue));
+      result.put("unit", unit);
+      result.put("absoluteTolerance", Double.valueOf(absoluteTolerance));
+      result.put("relativeTolerance", Double.valueOf(relativeTolerance));
+      result.put("absoluteError", Double.valueOf(absoluteError));
+      result.put("relativeError", Double.valueOf(absoluteError / Math.max(Math.abs(referenceValue), 1.0e-12)));
+      result.put("material", Boolean.valueOf(material));
+      result.put("passed", Boolean.valueOf(isPassed()));
+      return result;
+    }
+  }
+
+  /** Pilot run result and readiness evidence derived from actual comparisons. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final EngineeringPilotProjectEvidence evidence;
+    private final List<Comparison> comparisons;
+
+    Result(EngineeringPilotProjectEvidence evidence, List<Comparison> comparisons) {
+      this.evidence = evidence;
+      this.comparisons = Collections.unmodifiableList(new ArrayList<Comparison>(comparisons));
+    }
+
+    public EngineeringPilotProjectEvidence getEvidence() {
+      return evidence;
+    }
+
+    public List<Comparison> getComparisons() {
+      return comparisons;
+    }
+
+    public boolean isAccepted() {
+      return evidence.isAccepted();
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      List<Map<String, Object>> rows = new ArrayList<Map<String, Object>>();
+      for (Comparison comparison : comparisons) {
+        rows.add(comparison.toMap());
+      }
+      result.put("evidence", evidence.toMap());
+      result.put("comparisons", rows);
+      return result;
+    }
+  }
+
+  public static Result run(String projectId, EngineeringPilotProjectEvidence.Scope scope, String referencePackage,
+      List<Comparison> comparisons, String independentReviewer, String acceptanceRecord) {
+    if (comparisons == null || comparisons.isEmpty()) {
+      throw new IllegalArgumentException("At least one controlled pilot comparison is required");
+    }
+    int materialDiscrepancies = 0;
+    for (Comparison comparison : comparisons) {
+      if (comparison == null) {
+        throw new IllegalArgumentException("Pilot comparisons must not contain null");
+      }
+      if (comparison.material && !comparison.isPassed()) {
+        materialDiscrepancies++;
+      }
+    }
+    EngineeringPilotProjectEvidence evidence = new EngineeringPilotProjectEvidence(projectId, scope, referencePackage,
+        comparisons.size(), materialDiscrepancies, independentReviewer, acceptanceRecord);
+    return new Result(evidence, comparisons);
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessAssessment.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessAssessment.java
@@ -100,7 +100,7 @@ public final class EngineeringProductionReadinessAssessment {
     return new Result(project.getProjectId(), project.getRevision(), level, gates, safety, evidence, all);
   }
 
-  private static Set<String> executedMethods(EngineeringProject project) {
+  public static Set<String> executedMethods(EngineeringProject project) {
     Set<String> result = new LinkedHashSet<String>();
     if (project.getLatestEngineeringDesignLoopResult() == null
         || project.getLatestEngineeringDesignLoopResult().getIterations().isEmpty()) {

--- a/src/main/java/neqsim/process/engineering/production/EngineeringQualificationPlan.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringQualificationPlan.java
@@ -1,0 +1,111 @@
+package neqsim.process.engineering.production;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import neqsim.process.engineering.EngineeringProject;
+import neqsim.process.engineering.validation.EngineeringSchemaCatalog;
+
+/** Produces an executable evidence backlog for every production-qualification gate. */
+public final class EngineeringQualificationPlan {
+  private EngineeringQualificationPlan() {
+  }
+
+  public static Map<String, Object> build(EngineeringProject project, EngineeringProductionReadinessBasis basis) {
+    if (project == null) {
+      throw new IllegalArgumentException("project must not be null");
+    }
+    EngineeringProductionReadinessBasis evidence = basis == null ? new EngineeringProductionReadinessBasis() : basis;
+    Set<String> executed = EngineeringProductionReadinessAssessment.executedMethods(project);
+    Set<String> benchmarked = evidence.getBenchmarkReport() == null ? new LinkedHashSet<String>()
+        : new LinkedHashSet<String>(evidence.getBenchmarkReport().getQualifyingMethods());
+    Set<String> qualified = new LinkedHashSet<String>();
+    for (EngineeringMethodQualification item : evidence.getMethodQualifications()) {
+      if (item.isProjectQualified()) {
+        qualified.add(item.getMethodKey());
+      }
+    }
+    List<Map<String, Object>> methods = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> actions = new ArrayList<Map<String, Object>>();
+    for (String method : executed) {
+      boolean benchmark = benchmarked.contains(method);
+      boolean qualification = qualified.contains(method);
+      Map<String, Object> row = new LinkedHashMap<String, Object>();
+      row.put("methodKey", method);
+      row.put("independentBenchmarkAvailable", Boolean.valueOf(benchmark));
+      row.put("projectQualificationAvailable", Boolean.valueOf(qualification));
+      row.put("ready", Boolean.valueOf(benchmark && qualification));
+      methods.add(row);
+      if (!benchmark) {
+        actions.add(action("METHOD_BENCHMARK", method,
+            "Run an independently reviewed non-regression benchmark for the exact method version"));
+      }
+      if (!qualification) {
+        actions.add(action("METHOD_QUALIFICATION", method,
+            "Approve standards, applicability limits and evidence for the project service"));
+      }
+    }
+    if (evidence.getAutoConfigurationResult() == null || !evidence.getAutoConfigurationResult().isComplete()) {
+      actions.add(action("AUTOMATIC_CONFIGURATION", "project",
+          "Complete explicit configuration coverage without hidden numerical defaults"));
+    }
+    boolean dexpi = false;
+    for (DexpiToolQualificationEvidence item : evidence.getDexpiEvidence()) {
+      dexpi |= item.isQualified();
+    }
+    if (!dexpi) {
+      actions.add(action("DEXPI_TOOL_ROUNDTRIP", "project",
+          "Execute import/export/reimport in a named tool and reconcile every semantic difference"));
+    }
+    Set<EngineeringPilotProjectEvidence.Scope> pilotScopes = EnumSet
+        .noneOf(EngineeringPilotProjectEvidence.Scope.class);
+    for (EngineeringPilotProjectEvidence item : evidence.getPilotEvidence()) {
+      if (item.isAccepted()) {
+        pilotScopes.add(item.getScope());
+      }
+    }
+    for (EngineeringPilotProjectEvidence.Scope scope : EngineeringPilotProjectEvidence.Scope.values()) {
+      if (!pilotScopes.contains(scope)) {
+        actions.add(action("PILOT_PROJECT", scope.name(),
+            "Complete independently reviewed scalar and semantic comparison with no open material discrepancy"));
+      }
+    }
+    if (evidence.getReleaseQualityEvidence() == null || !evidence.getReleaseQualityEvidence().isPassed()) {
+      actions.add(action("RELEASE_QUALITY", "release",
+          "Close CI, Java matrix, determinism, performance, API, migration, security and review evidence"));
+    }
+    EngineeringSafetyLifecycleAssessment.Result safety = EngineeringSafetyLifecycleAssessment.assess(project);
+    if (!safety.isPassed()) {
+      actions.add(action("SAFETY_LIFECYCLE", "project", "Close accountable HAZOP/LOPA/SRS, SIF and shutdown findings"));
+    }
+    EngineeringProductionReadinessAssessment.Result assessment = EngineeringProductionReadinessAssessment
+        .assess(project, evidence);
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", EngineeringSchemaCatalog.QUALIFICATION_PLAN);
+    result.put("schemaUri", EngineeringSchemaCatalog.schemaUri(EngineeringSchemaCatalog.QUALIFICATION_PLAN));
+    result.put("projectId", project.getProjectId());
+    result.put("revision", project.getRevision());
+    result.put("executedMethods", new ArrayList<String>(executed));
+    result.put("methodQualificationMatrix", methods);
+    result.put("actions", actions);
+    result.put("openActionCount", Integer.valueOf(actions.size()));
+    result.put("readinessLevel", assessment.getLevel().name());
+    result.put("preliminaryProductionReady", Boolean.valueOf(assessment.isPreliminaryProductionReady()));
+    result.put("fitnessForConstruction", Boolean.FALSE);
+    result.put("externalEvidenceMayNotBeGeneratedBySimulator", Boolean.TRUE);
+    return result;
+  }
+
+  private static Map<String, Object> action(String type, String subject, String description) {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("type", type);
+    result.put("subject", subject);
+    result.put("description", description);
+    result.put("status", "OPEN");
+    return result;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/EngineeringReleaseQualificationRunner.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringReleaseQualificationRunner.java
@@ -1,0 +1,173 @@
+package neqsim.process.engineering.production;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Derives release-quality evidence from reproducibility, performance and compatibility measurements. */
+public final class EngineeringReleaseQualificationRunner {
+  private EngineeringReleaseQualificationRunner() {
+  }
+
+  /** Controlled release-verification inputs populated by CI and review workflows. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String releaseId;
+    private final String evidenceReference;
+    private final String accountableReviewer;
+    private boolean fullCiPassed;
+    private final Set<String> requiredJavaVersions = new LinkedHashSet<String>();
+    private final Set<String> passedJavaVersions = new LinkedHashSet<String>();
+    private final List<String> deterministicFingerprints = new ArrayList<String>();
+    private final List<Double> elapsedSeconds = new ArrayList<Double>();
+    private double maximumAcceptedSeconds;
+    private String apiBaselineFingerprint = "";
+    private String apiCandidateFingerprint = "";
+    private boolean serializationMigrationPassed;
+    private int openHighSeveritySecurityFindings;
+    private boolean securityReviewSupplied;
+
+    public Input(String releaseId, String evidenceReference, String accountableReviewer) {
+      this.releaseId = text(releaseId, "releaseId");
+      this.evidenceReference = text(evidenceReference, "evidenceReference");
+      this.accountableReviewer = text(accountableReviewer, "accountableReviewer");
+    }
+
+    public Input fullCiPassed(boolean value) {
+      fullCiPassed = value;
+      return this;
+    }
+
+    public Input requireJavaVersion(String value) {
+      requiredJavaVersions.add(text(value, "requiredJavaVersion"));
+      return this;
+    }
+
+    public Input passedJavaVersion(String value) {
+      passedJavaVersions.add(text(value, "passedJavaVersion"));
+      return this;
+    }
+
+    public Input deterministicFingerprint(String value) {
+      deterministicFingerprints.add(text(value, "deterministicFingerprint"));
+      return this;
+    }
+
+    public Input performanceSample(double elapsedSeconds) {
+      if (!Double.isFinite(elapsedSeconds) || elapsedSeconds < 0.0) {
+        throw new IllegalArgumentException("elapsedSeconds must be finite and non-negative");
+      }
+      this.elapsedSeconds.add(Double.valueOf(elapsedSeconds));
+      return this;
+    }
+
+    public Input maximumAcceptedSeconds(double value) {
+      if (!Double.isFinite(value) || value <= 0.0) {
+        throw new IllegalArgumentException("maximumAcceptedSeconds must be finite and positive");
+      }
+      maximumAcceptedSeconds = value;
+      return this;
+    }
+
+    public Input apiFingerprints(String baseline, String candidate) {
+      apiBaselineFingerprint = text(baseline, "apiBaselineFingerprint");
+      apiCandidateFingerprint = text(candidate, "apiCandidateFingerprint");
+      return this;
+    }
+
+    public Input serializationMigrationPassed(boolean value) {
+      serializationMigrationPassed = value;
+      return this;
+    }
+
+    public Input openHighSeveritySecurityFindings(int value) {
+      if (value < 0) {
+        throw new IllegalArgumentException("Security finding count must be non-negative");
+      }
+      openHighSeveritySecurityFindings = value;
+      securityReviewSupplied = true;
+      return this;
+    }
+  }
+
+  /** Release evidence plus the measurements used to derive each boolean gate. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final EngineeringReleaseQualityEvidence evidence;
+    private final Map<String, Object> measurements;
+
+    Result(EngineeringReleaseQualityEvidence evidence, Map<String, Object> measurements) {
+      this.evidence = evidence;
+      this.measurements = Collections.unmodifiableMap(new LinkedHashMap<String, Object>(measurements));
+    }
+
+    public EngineeringReleaseQualityEvidence getEvidence() {
+      return evidence;
+    }
+
+    public Map<String, Object> getMeasurements() {
+      return measurements;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("evidence", evidence.toMap());
+      result.put("measurements", new LinkedHashMap<String, Object>(measurements));
+      return result;
+    }
+  }
+
+  public static Result run(Input input) {
+    if (input == null) {
+      throw new IllegalArgumentException("release qualification input must not be null");
+    }
+    boolean javaMatrix = !input.requiredJavaVersions.isEmpty()
+        && input.passedJavaVersions.containsAll(input.requiredJavaVersions);
+    boolean deterministic = input.deterministicFingerprints.size() >= 2;
+    if (deterministic) {
+      String first = input.deterministicFingerprints.get(0);
+      for (String value : input.deterministicFingerprints) {
+        deterministic &= first.equals(value);
+      }
+    }
+    boolean performance = !input.elapsedSeconds.isEmpty() && input.maximumAcceptedSeconds > 0.0;
+    double maximumElapsed = 0.0;
+    for (Double elapsed : input.elapsedSeconds) {
+      maximumElapsed = Math.max(maximumElapsed, elapsed.doubleValue());
+    }
+    performance &= maximumElapsed <= input.maximumAcceptedSeconds;
+    boolean api = !input.apiBaselineFingerprint.isEmpty()
+        && input.apiBaselineFingerprint.equals(input.apiCandidateFingerprint);
+    boolean security = input.securityReviewSupplied && input.openHighSeveritySecurityFindings == 0;
+    EngineeringReleaseQualityEvidence evidence = new EngineeringReleaseQualityEvidence(input.releaseId)
+        .fullCiPassed(input.fullCiPassed).supportedJavaMatrixPassed(javaMatrix)
+        .deterministicConvergencePassed(deterministic).performanceAcceptancePassed(performance)
+        .apiCompatibilityPassed(api).serializationMigrationPassed(input.serializationMigrationPassed)
+        .securityReviewPassed(security).evidenceReference(input.evidenceReference)
+        .accountableReviewer(input.accountableReviewer);
+    Map<String, Object> measurements = new LinkedHashMap<String, Object>();
+    measurements.put("requiredJavaVersions", new ArrayList<String>(input.requiredJavaVersions));
+    measurements.put("passedJavaVersions", new ArrayList<String>(input.passedJavaVersions));
+    measurements.put("deterministicFingerprints", new ArrayList<String>(input.deterministicFingerprints));
+    measurements.put("elapsedSeconds", new ArrayList<Double>(input.elapsedSeconds));
+    measurements.put("maximumElapsedSeconds", Double.valueOf(maximumElapsed));
+    measurements.put("maximumAcceptedSeconds", Double.valueOf(input.maximumAcceptedSeconds));
+    measurements.put("apiBaselineFingerprint", input.apiBaselineFingerprint);
+    measurements.put("apiCandidateFingerprint", input.apiCandidateFingerprint);
+    measurements.put("openHighSeveritySecurityFindings", Integer.valueOf(input.openHighSeveritySecurityFindings));
+    measurements.put("securityReviewSupplied", Boolean.valueOf(input.securityReviewSupplied));
+    return new Result(evidence, measurements);
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/EngineeringReleaseQualityEvidence.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringReleaseQualityEvidence.java
@@ -18,6 +18,7 @@ public final class EngineeringReleaseQualityEvidence implements Serializable {
   private boolean serializationMigrationPassed;
   private boolean securityReviewPassed;
   private String evidenceReference = "";
+  private String accountableReviewer = "";
 
   public EngineeringReleaseQualityEvidence(String releaseId) {
     if (releaseId == null || releaseId.trim().isEmpty()) {
@@ -69,10 +70,18 @@ public final class EngineeringReleaseQualityEvidence implements Serializable {
     return this;
   }
 
+  public EngineeringReleaseQualityEvidence accountableReviewer(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException("accountableReviewer must not be blank");
+    }
+    accountableReviewer = value.trim();
+    return this;
+  }
+
   public boolean isPassed() {
     return fullCiPassed && supportedJavaMatrixPassed && deterministicConvergencePassed && performanceAcceptancePassed
         && apiCompatibilityPassed && serializationMigrationPassed && securityReviewPassed
-        && !evidenceReference.isEmpty();
+        && !evidenceReference.isEmpty() && !accountableReviewer.isEmpty();
   }
 
   public List<String> getMissingGates() {
@@ -85,6 +94,7 @@ public final class EngineeringReleaseQualityEvidence implements Serializable {
     addIfFalse(result, serializationMigrationPassed, "SERIALIZATION_MIGRATION");
     addIfFalse(result, securityReviewPassed, "SECURITY_REVIEW");
     addIfFalse(result, !evidenceReference.isEmpty(), "EVIDENCE_REFERENCE");
+    addIfFalse(result, !accountableReviewer.isEmpty(), "ACCOUNTABLE_REVIEWER");
     return result;
   }
 
@@ -99,6 +109,7 @@ public final class EngineeringReleaseQualityEvidence implements Serializable {
     result.put("serializationMigrationPassed", Boolean.valueOf(serializationMigrationPassed));
     result.put("securityReviewPassed", Boolean.valueOf(securityReviewPassed));
     result.put("evidenceReference", evidenceReference);
+    result.put("accountableReviewer", accountableReviewer);
     result.put("missingGates", getMissingGates());
     result.put("passed", Boolean.valueOf(isPassed()));
     return result;

--- a/src/main/java/neqsim/process/engineering/safety/ReliefSizingCalculation.java
+++ b/src/main/java/neqsim/process/engineering/safety/ReliefSizingCalculation.java
@@ -1,0 +1,314 @@
+package neqsim.process.engineering.safety;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import neqsim.process.engineering.calculation.CalculationReadiness;
+import neqsim.process.engineering.calculation.EngineeringCalculationContext;
+import neqsim.process.engineering.calculation.EngineeringCalculationModule;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+
+/** Gas, liquid, steam and governed two-phase relief-orifice sizing from relieving-case conditions. */
+public final class ReliefSizingCalculation
+    implements EngineeringCalculationModule<ReliefSizingCalculation.Input, ReliefSizingCalculation.Result> {
+
+  public enum Phase {
+    GAS, LIQUID, STEAM, TWO_PHASE
+  }
+
+  /** Governed relieving-case inputs in explicit SI/absolute-pressure units. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String scenarioId;
+    private final Phase phase;
+    private final double massFlowKgS;
+    private final double relievingPressureBara;
+    private final double backPressureBara;
+    private final double relievingTemperatureK;
+    private final double isentropicExponent;
+    private final double compressibilityFactor;
+    private final double molarMassKgKmol;
+    private final double liquidDensityKgM3;
+    private final double dischargeCoefficient;
+    private final double backPressureCorrection;
+    private final double combinationCorrection;
+    private final double twoPhaseMassFluxKgM2S;
+    private final String twoPhaseMethodReference;
+    private final double[] orificeCandidatesIn2;
+
+    private Input(Builder builder) {
+      scenarioId = text(builder.scenarioId, "scenarioId");
+      if (builder.phase == null) {
+        throw new IllegalArgumentException("phase must not be null");
+      }
+      phase = builder.phase;
+      massFlowKgS = positive(builder.massFlowKgS, "massFlowKgS");
+      relievingPressureBara = positive(builder.relievingPressureBara, "relievingPressureBara");
+      backPressureBara = nonNegative(builder.backPressureBara, "backPressureBara");
+      relievingTemperatureK = builder.relievingTemperatureK;
+      isentropicExponent = builder.isentropicExponent;
+      compressibilityFactor = builder.compressibilityFactor;
+      molarMassKgKmol = builder.molarMassKgKmol;
+      liquidDensityKgM3 = builder.liquidDensityKgM3;
+      dischargeCoefficient = positive(builder.dischargeCoefficient, "dischargeCoefficient");
+      backPressureCorrection = positive(builder.backPressureCorrection, "backPressureCorrection");
+      combinationCorrection = positive(builder.combinationCorrection, "combinationCorrection");
+      twoPhaseMassFluxKgM2S = builder.twoPhaseMassFluxKgM2S;
+      twoPhaseMethodReference = optional(builder.twoPhaseMethodReference);
+      orificeCandidatesIn2 = builder.orificeCandidatesIn2 == null ? new double[0]
+          : builder.orificeCandidatesIn2.clone();
+      Arrays.sort(orificeCandidatesIn2);
+      for (double candidate : orificeCandidatesIn2) {
+        positive(candidate, "orificeCandidatesIn2");
+      }
+    }
+
+    public static Builder builder(String scenarioId, Phase phase) {
+      return new Builder(scenarioId, phase);
+    }
+
+    /** Builder retaining every correction factor as an explicit project input. */
+    public static final class Builder {
+      private final String scenarioId;
+      private final Phase phase;
+      private double massFlowKgS;
+      private double relievingPressureBara;
+      private double backPressureBara;
+      private double relievingTemperatureK = Double.NaN;
+      private double isentropicExponent = Double.NaN;
+      private double compressibilityFactor = Double.NaN;
+      private double molarMassKgKmol = Double.NaN;
+      private double liquidDensityKgM3 = Double.NaN;
+      private double dischargeCoefficient;
+      private double backPressureCorrection = 1.0;
+      private double combinationCorrection = 1.0;
+      private double twoPhaseMassFluxKgM2S = Double.NaN;
+      private String twoPhaseMethodReference = "";
+      private double[] orificeCandidatesIn2 = new double[0];
+
+      private Builder(String scenarioId, Phase phase) {
+        this.scenarioId = scenarioId;
+        this.phase = phase;
+      }
+
+      public Builder flowAndPressure(double massFlowKgS, double relievingPressureBara, double backPressureBara) {
+        this.massFlowKgS = massFlowKgS;
+        this.relievingPressureBara = relievingPressureBara;
+        this.backPressureBara = backPressureBara;
+        return this;
+      }
+
+      public Builder gasProperties(double temperatureK, double isentropicExponent, double compressibilityFactor,
+          double molarMassKgKmol) {
+        relievingTemperatureK = temperatureK;
+        this.isentropicExponent = isentropicExponent;
+        this.compressibilityFactor = compressibilityFactor;
+        this.molarMassKgKmol = molarMassKgKmol;
+        return this;
+      }
+
+      public Builder liquidDensityKgM3(double value) {
+        liquidDensityKgM3 = value;
+        return this;
+      }
+
+      public Builder correctionFactors(double dischargeCoefficient, double backPressureCorrection,
+          double combinationCorrection) {
+        this.dischargeCoefficient = dischargeCoefficient;
+        this.backPressureCorrection = backPressureCorrection;
+        this.combinationCorrection = combinationCorrection;
+        return this;
+      }
+
+      public Builder twoPhaseMethod(double massFluxKgM2S, String methodReference) {
+        twoPhaseMassFluxKgM2S = massFluxKgM2S;
+        twoPhaseMethodReference = methodReference;
+        return this;
+      }
+
+      public Builder orificeCandidatesIn2(double... values) {
+        orificeCandidatesIn2 = values == null ? new double[0] : values.clone();
+        return this;
+      }
+
+      public Input build() {
+        return new Input(this);
+      }
+    }
+  }
+
+  /** Required/selected area, flow regime and selection utilization. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Map<String, Object> values;
+
+    Result(Map<String, Object> values) {
+      this.values = values;
+    }
+
+    public Map<String, Object> toMap() {
+      return new LinkedHashMap<String, Object>(values);
+    }
+  }
+
+  @Override
+  public String getMethod() {
+    return "relief-device-phase-sizing-and-orifice-selection";
+  }
+
+  @Override
+  public String getMethodVersion() {
+    return "1.0";
+  }
+
+  @Override
+  public CalculationReadiness assess(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness.Builder result = CalculationReadiness.builder();
+    if (input == null) {
+      return result.addBlocker("RELIEF_INPUT", "Relief sizing input is required", "Supply the governed relieving case")
+          .build();
+    }
+    if (input.backPressureBara >= input.relievingPressureBara) {
+      result.addBlocker("RELIEF_DIFFERENTIAL_PRESSURE", "Backpressure must be below relieving pressure",
+          "Correct the relieving/disposal-network pressure basis");
+    }
+    if (input.orificeCandidatesIn2.length == 0) {
+      result.addBlocker("RELIEF_ORIFICES", "API/project orifice candidates are required",
+          "Supply the controlled device table");
+    }
+    if (input.phase == Phase.GAS || input.phase == Phase.STEAM) {
+      if (!positiveFinite(input.relievingTemperatureK) || !positiveFinite(input.compressibilityFactor)
+          || !positiveFinite(input.molarMassKgKmol) || !Double.isFinite(input.isentropicExponent)
+          || input.isentropicExponent <= 1.0) {
+        result.addBlocker("RELIEF_GAS_PROPERTIES", "Gas/steam critical-flow properties are incomplete",
+            "Supply T, Z, molar mass and isentropic exponent from the relieving case");
+      }
+    } else if (input.phase == Phase.LIQUID && !positiveFinite(input.liquidDensityKgM3)) {
+      result.addBlocker("RELIEF_LIQUID_DENSITY", "Liquid density is required", "Supply relieving-case density");
+    } else if (input.phase == Phase.TWO_PHASE
+        && (!positiveFinite(input.twoPhaseMassFluxKgM2S) || input.twoPhaseMethodReference.isEmpty())) {
+      result.addBlocker("RELIEF_TWO_PHASE_METHOD", "Approved two-phase mass-flux method is required",
+          "Supply the specialist method result and controlled reference");
+    }
+    if (productionQualification(context)
+        && (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty())) {
+      result.addBlocker("RELIEF_PRODUCTION_EVIDENCE", "Relief qualification evidence is incomplete",
+          "Attach scenario, sizing, disposal-network and standards evidence");
+    }
+    return result.build();
+  }
+
+  @Override
+  public EngineeringCalculationResult<Result> calculate(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness readiness = assess(input, context);
+    EngineeringCalculationResult.Builder<Result> result = EngineeringCalculationResult
+        .<Result>builder("relief-sizing:" + (input == null ? "unassigned" : input.scenarioId), getMethod(),
+            getMethodVersion())
+        .context(context).readiness(readiness);
+    if (!readiness.isReady()) {
+      return result.status(EngineeringCalculationResult.Status.BLOCKED).build();
+    }
+    double massFlux;
+    String regime;
+    if (input.phase == Phase.LIQUID) {
+      massFlux = input.dischargeCoefficient * input.backPressureCorrection * input.combinationCorrection
+          * Math.sqrt(2.0 * input.liquidDensityKgM3 * (input.relievingPressureBara - input.backPressureBara) * 1.0e5);
+      regime = "INCOMPRESSIBLE";
+    } else if (input.phase == Phase.TWO_PHASE) {
+      massFlux = input.twoPhaseMassFluxKgM2S * input.dischargeCoefficient * input.backPressureCorrection
+          * input.combinationCorrection;
+      regime = "APPROVED_TWO_PHASE_MASS_FLUX";
+    } else {
+      double specificGasConstant = 8314.46261815324 / input.molarMassKgKmol;
+      double pressurePa = input.relievingPressureBara * 1.0e5;
+      double pressureRatio = input.backPressureBara / input.relievingPressureBara;
+      double criticalRatio = Math.pow(2.0 / (input.isentropicExponent + 1.0),
+          input.isentropicExponent / (input.isentropicExponent - 1.0));
+      double idealFlux;
+      if (pressureRatio <= criticalRatio) {
+        idealFlux = pressurePa
+            * Math.sqrt(input.isentropicExponent
+                / (input.compressibilityFactor * specificGasConstant * input.relievingTemperatureK))
+            * Math.pow(2.0 / (input.isentropicExponent + 1.0),
+                (input.isentropicExponent + 1.0) / (2.0 * (input.isentropicExponent - 1.0)));
+        regime = "CHOKED_COMPRESSIBLE";
+      } else {
+        double term = Math.pow(pressureRatio, 2.0 / input.isentropicExponent)
+            - Math.pow(pressureRatio, (input.isentropicExponent + 1.0) / input.isentropicExponent);
+        idealFlux = pressurePa
+            * Math.sqrt(2.0 * input.isentropicExponent / (input.compressibilityFactor * specificGasConstant
+                * input.relievingTemperatureK * (input.isentropicExponent - 1.0)) * Math.max(term, 0.0));
+        regime = "SUBCRITICAL_COMPRESSIBLE";
+      }
+      massFlux = idealFlux * input.dischargeCoefficient * input.backPressureCorrection * input.combinationCorrection;
+    }
+    double requiredAreaM2 = input.massFlowKgS / Math.max(massFlux, 1.0e-12);
+    double requiredAreaIn2 = requiredAreaM2 / 0.00064516;
+    double selectedAreaIn2 = select(requiredAreaIn2, input.orificeCandidatesIn2);
+    if (!Double.isFinite(selectedAreaIn2)) {
+      return result.status(EngineeringCalculationResult.Status.BLOCKED)
+          .input("requiredAreaIn2", Double.valueOf(requiredAreaIn2))
+          .message("No supplied relief-orifice candidate satisfies the calculated required area").build();
+    }
+    Map<String, Object> values = new LinkedHashMap<String, Object>();
+    values.put("scenarioId", input.scenarioId);
+    values.put("phase", input.phase.name());
+    values.put("flowRegime", regime);
+    values.put("calculatedMassFluxKgM2S", Double.valueOf(massFlux));
+    values.put("requiredAreaM2", Double.valueOf(requiredAreaM2));
+    values.put("requiredAreaIn2", Double.valueOf(requiredAreaIn2));
+    values.put("selectedOrificeAreaIn2", Double.valueOf(selectedAreaIn2));
+    values.put("orificeUtilization", Double.valueOf(requiredAreaIn2 / selectedAreaIn2));
+    values.put("twoPhaseMethodReference", input.twoPhaseMethodReference);
+    values.put("approvalStatus", "REVIEW_REQUIRED");
+    return result.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED).value(new Result(values))
+        .input("relievingPressureBara", Double.valueOf(input.relievingPressureBara))
+        .input("backPressureBara", Double.valueOf(input.backPressureBara))
+        .warning(
+            "Device stability, certified coefficients, inlet/outlet losses and disposal-network interaction remain required")
+        .build();
+  }
+
+  private static double select(double required, double[] candidates) {
+    for (double candidate : candidates) {
+      if (candidate >= required) {
+        return candidate;
+      }
+    }
+    return Double.NaN;
+  }
+
+  private static boolean positiveFinite(double value) {
+    return Double.isFinite(value) && value > 0.0;
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
+  }
+
+  private static String optional(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double positive(double value, String field) {
+    if (!positiveFinite(value)) {
+      throw new IllegalArgumentException(field + " must be finite and positive");
+    }
+    return value;
+  }
+
+  private static double nonNegative(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and non-negative");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/safety/SafetyScenarioEngineCalculation.java
+++ b/src/main/java/neqsim/process/engineering/safety/SafetyScenarioEngineCalculation.java
@@ -139,7 +139,7 @@ public final class SafetyScenarioEngineCalculation implements
 
   @Override
   public String getMethodVersion() {
-    return "1.0";
+    return "2.0";
   }
 
   @Override
@@ -161,6 +161,20 @@ public final class SafetyScenarioEngineCalculation implements
         readiness.addBlocker("SCENARIO_CREDIBILITY_" + scenario.id,
             "Scenario credibility or hazard-review evidence is incomplete for " + scenario.id,
             "Record the controlled HAZOP decision and reference");
+      }
+    }
+    if (productionQualification(context)) {
+      if (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty()) {
+        readiness.addBlocker("SAFETY_PRODUCTION_EVIDENCE", "Relief and blowdown evidence is incomplete",
+            "Attach HAZOP, calculation, disposal-network and applicable standards evidence");
+      }
+      for (Scenario scenario : input.scenarios) {
+        if (scenario.fluidModel == FluidModel.TWO_PHASE
+            && !"approved".equalsIgnoreCase(context.getAttributes().get("twoPhaseReliefMethod"))) {
+          readiness.addBlocker("TWO_PHASE_METHOD_" + scenario.id,
+              "Two-phase relief method has not been approved for the service",
+              "Select and approve the project two-phase sizing method");
+        }
       }
     }
     return readiness.build();
@@ -232,6 +246,10 @@ public final class SafetyScenarioEngineCalculation implements
       throw new IllegalArgumentException(field + " must not be blank");
     }
     return value.trim();
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
   }
 
   private static double positive(double value, String field) {

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidator.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidator.java
@@ -215,6 +215,14 @@ public final class EngineeringPackageValidator {
       requireObject(root, "evidenceBasis", artifactName, report);
       requireFalse(root, "fitnessForConstruction", artifactName, report);
       requireFalse(root, "finalEngineeringApprovalGranted", artifactName, report);
+    } else if ("engineering-qualification-plan.json".equals(artifactName)) {
+      requireString(root, "projectId", artifactName, report);
+      requireString(root, "revision", artifactName, report);
+      requireArray(root, "executedMethods", artifactName, report);
+      requireArray(root, "methodQualificationMatrix", artifactName, report);
+      requireArray(root, "actions", artifactName, report);
+      requireString(root, "readinessLevel", artifactName, report);
+      requireFalse(root, "fitnessForConstruction", artifactName, report);
     }
     return report;
   }

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringSchemaCatalog.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringSchemaCatalog.java
@@ -32,6 +32,7 @@ public final class EngineeringSchemaCatalog {
   public static final String REVISION_DIFF = "neqsim_engineering_revision_diff.v1";
   public static final String VALIDATION_REPORT = "neqsim_engineering_validation_report.v1";
   public static final String PRODUCTION_READINESS = "neqsim_engineering_production_readiness.v1";
+  public static final String QUALIFICATION_PLAN = "neqsim_engineering_qualification_plan.v1";
 
   /** One immutable schema registration. */
   public static final class Definition {
@@ -103,6 +104,8 @@ public final class EngineeringSchemaCatalog {
     values.add(definition("engineering-validation-report.json", VALIDATION_REPORT, "validation-report.schema.json"));
     values.add(definition("engineering-production-readiness.json", PRODUCTION_READINESS,
         "engineering-production-readiness.schema.json"));
+    values.add(definition("engineering-qualification-plan.json", QUALIFICATION_PLAN,
+        "engineering-qualification-plan.schema.json"));
     DEFINITIONS = Collections.unmodifiableList(values);
     Map<String, Definition> artifacts = new LinkedHashMap<String, Definition>();
     Map<String, Definition> versions = new LinkedHashMap<String, Definition>();

--- a/src/main/resources/neqsim/process/engineering/schema/engineering-qualification-plan.schema.json
+++ b/src/main/resources/neqsim/process/engineering/schema/engineering-qualification-plan.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:neqsim:schema:engineering-qualification-plan:v1",
+  "title": "NeqSim engineering production-qualification action plan",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "schemaUri",
+    "projectId",
+    "revision",
+    "executedMethods",
+    "methodQualificationMatrix",
+    "actions",
+    "openActionCount",
+    "readinessLevel",
+    "preliminaryProductionReady",
+    "fitnessForConstruction",
+    "externalEvidenceMayNotBeGeneratedBySimulator"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "neqsim_engineering_qualification_plan.v1"},
+    "schemaUri": {"const": "urn:neqsim:schema:engineering-qualification-plan:v1"},
+    "projectId": {"type": "string", "minLength": 1},
+    "revision": {"type": "string", "minLength": 1},
+    "executedMethods": {"type": "array", "items": {"type": "string"}},
+    "methodQualificationMatrix": {"type": "array", "items": {"type": "object"}},
+    "actions": {"type": "array", "items": {"type": "object"}},
+    "openActionCount": {"type": "integer", "minimum": 0},
+    "readinessLevel": {
+      "enum": ["NOT_READY", "EXPERIMENTAL", "VALIDATED_PRELIMINARY", "QUALIFIED_FEED_SUPPORT"]
+    },
+    "preliminaryProductionReady": {"type": "boolean"},
+    "fitnessForConstruction": {"const": false},
+    "externalEvidenceMayNotBeGeneratedBySimulator": {"const": true}
+  },
+  "additionalProperties": false
+}

--- a/src/test/java/neqsim/process/engineering/EngineeringProductionQualificationWorkflowTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringProductionQualificationWorkflowTest.java
@@ -1,0 +1,168 @@
+package neqsim.process.engineering;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.engineering.calculation.EngineeringCalculationContext;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+import neqsim.process.engineering.calculation.EquipmentDesignCalculations;
+import neqsim.process.engineering.piping.PipingNetworkDesignCalculation;
+import neqsim.process.engineering.piping.PipingRulePack;
+import neqsim.process.engineering.production.DexpiToolQualificationRunner;
+import neqsim.process.engineering.production.EngineeringBenchmarkDataset;
+import neqsim.process.engineering.production.EngineeringPilotProjectEvidence;
+import neqsim.process.engineering.production.EngineeringPilotQualificationRunner;
+import neqsim.process.engineering.production.EngineeringReleaseQualificationRunner;
+import neqsim.process.engineering.production.EngineeringValidationBenchmark;
+import neqsim.process.engineering.safety.ReliefSizingCalculation;
+import org.junit.jupiter.api.Test;
+
+/** Tests executable production-qualification workflows without fabricating external acceptance. */
+class EngineeringProductionQualificationWorkflowTest {
+
+  @Test
+  void runsControlledIndependentBenchmarkDataset() {
+    EngineeringBenchmarkDataset dataset = new EngineeringBenchmarkDataset("separator-reference", "A")
+        .add(new EngineeringBenchmarkDataset.Case("SEP-CASE-1", "separator-method", "2.0",
+            EngineeringValidationBenchmark.SourceClass.INDEPENDENT_CALCULATION, "CALC-SEP-001", "A",
+            "Independent checker / CALC-SEP-001-A").expect("diameter", 2.0, "m", 0.02, 0.01));
+    Map<String, Map<String, Double>> actual = new LinkedHashMap<String, Map<String, Double>>();
+    Map<String, Double> outputs = new LinkedHashMap<String, Double>();
+    outputs.put("diameter", Double.valueOf(2.01));
+    actual.put("SEP-CASE-1", outputs);
+
+    EngineeringBenchmarkDataset.RunResult result = dataset.run(actual);
+
+    assertTrue(result.isComplete());
+    assertTrue(result.getReport().isPassed());
+    assertTrue(dataset.toJson().contains("CALC-SEP-001"));
+
+    dataset.add(new EngineeringBenchmarkDataset.Case("SEP-CASE-2", "separator-method", "2.0",
+        EngineeringValidationBenchmark.SourceClass.INDEPENDENT_CALCULATION, "CALC-SEP-002", "A",
+        "Independent checker / CALC-SEP-002-A").expect("diameter", 3.0, "m", 0.02, 0.01));
+    Map<String, Double> failingOutputs = new LinkedHashMap<String, Double>();
+    failingOutputs.put("diameter", Double.valueOf(2.0));
+    actual.put("SEP-CASE-2", failingOutputs);
+    assertFalse(dataset.run(actual).getReport().isPassed());
+  }
+
+  @Test
+  void detectsDexpiSemanticDifferencesAndAcceptsExactRoundTrip() {
+    DexpiToolQualificationRunner.Snapshot reference = snapshot("80-VA-001");
+    DexpiToolQualificationRunner.Snapshot changed = snapshot("80-VA-002");
+
+    DexpiToolQualificationRunner.Result failed = DexpiToolQualificationRunner.compare("Named CAE", "2026.1", reference,
+        changed, changed, "DEXPI-TEST-001", "Independent CAE checker");
+    DexpiToolQualificationRunner.Result passed = DexpiToolQualificationRunner.compare("Named CAE", "2026.1", reference,
+        reference, reference, "DEXPI-TEST-002", "Independent CAE checker");
+
+    assertFalse(failed.isQualified());
+    assertTrue(passed.isQualified());
+  }
+
+  @Test
+  void materialPilotDiscrepancyBlocksAcceptance() {
+    List<EngineeringPilotQualificationRunner.Comparison> comparisons = Arrays.asList(
+        new EngineeringPilotQualificationRunner.Comparison("separator diameter", 2.0, 2.01, "m", 0.02, 0.01, true),
+        new EngineeringPilotQualificationRunner.Comparison("driver power", 5000.0, 5600.0, "kW", 50.0, 0.05, true));
+
+    EngineeringPilotQualificationRunner.Result result = EngineeringPilotQualificationRunner.run("PILOT-1",
+        EngineeringPilotProjectEvidence.Scope.SEPARATION_AND_COMPRESSION, "REFERENCE-PACKAGE-A", comparisons,
+        "Independent checker", "PILOT-ACCEPTANCE-A");
+
+    assertFalse(result.getEvidence().isAccepted());
+  }
+
+  @Test
+  void derivesReleaseEvidenceFromMeasurements() {
+    EngineeringReleaseQualificationRunner.Input input = new EngineeringReleaseQualificationRunner.Input("2.0-rc1",
+        "CI-RUN-001", "Release authority").fullCiPassed(true).requireJavaVersion("8").passedJavaVersion("8")
+        .deterministicFingerprint("abc").deterministicFingerprint("abc").performanceSample(2.0).performanceSample(2.2)
+        .maximumAcceptedSeconds(5.0).apiFingerprints("api-a", "api-a").serializationMigrationPassed(true)
+        .openHighSeveritySecurityFindings(0);
+
+    EngineeringReleaseQualificationRunner.Result result = EngineeringReleaseQualificationRunner.run(input);
+
+    assertTrue(result.getEvidence().isPassed());
+
+    EngineeringReleaseQualificationRunner.Input missingSecurityReview = new EngineeringReleaseQualificationRunner.Input(
+        "2.0-rc1", "CI-RUN-002", "Release authority").fullCiPassed(true).requireJavaVersion("8").passedJavaVersion("8")
+        .deterministicFingerprint("abc").deterministicFingerprint("abc").performanceSample(2.0)
+        .maximumAcceptedSeconds(5.0).apiFingerprints("api-a", "api-a").serializationMigrationPassed(true);
+    assertFalse(EngineeringReleaseQualificationRunner.run(missingSecurityReview).getEvidence().isPassed());
+  }
+
+  @Test
+  void productionModeRejectsDefaultsAndUsesDetailedNetworkHydraulics() {
+    EngineeringCalculationContext context = EngineeringCalculationContext.builder().designCaseId("maximum")
+        .simulationFingerprint("simulation-a").addStandardReference("PROJECT-PIPING-BASIS-A")
+        .addEvidenceReference("HYDRAULIC-CALC-A").attribute("productionQualification", "true").build();
+    EquipmentDesignCalculations.Input incompleteSeparator = EquipmentDesignCalculations.Input
+        .builder("V-1", "maximum", "DB-A").value("gasFlowM3s", 1.0).value("liquidFlowM3s", 0.01)
+        .value("gasDensityKgM3", 20.0).value("liquidDensityKgM3", 800.0).build();
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED,
+        new EquipmentDesignCalculations.Separator().calculate(incompleteSeparator, context).getStatus());
+
+    List<PipingNetworkDesignCalculation.Candidate> candidates = Arrays.asList(
+        new PipingNetworkDesignCalculation.Candidate("DN100", "SCH40", 0.102, 100.0),
+        new PipingNetworkDesignCalculation.Candidate("DN200", "SCH40", 0.202, 100.0));
+    PipingNetworkDesignCalculation.Segment segment = new PipingNetworkDesignCalculation.Segment("L-1", true, false,
+        1000.0, 100.0, 10.0, 1.1, 0.0).simultaneousDemandGroup("export-header")
+        .addCase(PipingNetworkDesignCalculation.Case.detailed("maximum", 0.05, 50.0, 20.0, 1.0e-5, 4.6e-5));
+    Map<String, Double> demands = new LinkedHashMap<String, Double>();
+    demands.put("export-header", Double.valueOf(0.01));
+    PipingNetworkDesignCalculation.Input network = new PipingNetworkDesignCalculation.Input("network-a",
+        PipingRulePack.builder("project-piping-a").standard("PROJECT PIPING BASIS").edition("A")
+            .velocityLimits(30.0, 5.0, 0.0).maximumPressureGradientBarPerKm(5.0).build(),
+        candidates, new ArrayList<PipingNetworkDesignCalculation.Segment>(Arrays.asList(segment)), demands);
+
+    EngineeringCalculationResult<PipingNetworkDesignCalculation.Result> result = new PipingNetworkDesignCalculation()
+        .calculate(network, context);
+
+    assertEquals(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED, result.getStatus());
+    assertTrue(result.getValue().toMap().toString().contains("maximumReynoldsNumber"));
+  }
+
+  @Test
+  void sizesGasReliefAndBlocksUnapprovedTwoPhaseMethod() {
+    EngineeringCalculationContext context = EngineeringCalculationContext.builder().designCaseId("blocked-outlet")
+        .addStandardReference("API-520-PROJECT-EDITION").addEvidenceReference("RELIEF-CALC-001")
+        .attribute("productionQualification", "true").build();
+    ReliefSizingCalculation.Input gas = ReliefSizingCalculation.Input
+        .builder("blocked-outlet", ReliefSizingCalculation.Phase.GAS).flowAndPressure(2.0, 60.0, 2.0)
+        .gasProperties(320.0, 1.28, 0.95, 20.0).correctionFactors(0.975, 1.0, 1.0)
+        .orificeCandidatesIn2(0.11, 0.196, 0.307, 0.503, 0.785, 1.287).build();
+    ReliefSizingCalculation.Input twoPhase = ReliefSizingCalculation.Input
+        .builder("fire", ReliefSizingCalculation.Phase.TWO_PHASE).flowAndPressure(2.0, 60.0, 2.0)
+        .correctionFactors(0.85, 1.0, 1.0).orificeCandidatesIn2(0.11, 0.196, 0.307).build();
+    ReliefSizingCalculation.Input undersizedTable = ReliefSizingCalculation.Input
+        .builder("blocked-outlet", ReliefSizingCalculation.Phase.GAS).flowAndPressure(200.0, 60.0, 2.0)
+        .gasProperties(320.0, 1.28, 0.95, 20.0).correctionFactors(0.975, 1.0, 1.0).orificeCandidatesIn2(0.11).build();
+
+    EngineeringCalculationResult<ReliefSizingCalculation.Result> gasResult = new ReliefSizingCalculation()
+        .calculate(gas, context);
+    EngineeringCalculationResult<ReliefSizingCalculation.Result> twoPhaseResult = new ReliefSizingCalculation()
+        .calculate(twoPhase, context);
+    EngineeringCalculationResult<ReliefSizingCalculation.Result> undersizedResult = new ReliefSizingCalculation()
+        .calculate(undersizedTable, context);
+
+    assertEquals(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED, gasResult.getStatus());
+    assertTrue(gasResult.getValue().toMap().containsKey("selectedOrificeAreaIn2"));
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED, twoPhaseResult.getStatus());
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED, undersizedResult.getStatus());
+  }
+
+  private DexpiToolQualificationRunner.Snapshot snapshot(String tag) {
+    Map<String, String> properties = new LinkedHashMap<String, String>();
+    properties.put("tag", tag);
+    properties.put("class", "Vessel");
+    return new DexpiToolQualificationRunner.Snapshot("DEXPI 2.0").addObject("urn:equipment:1", properties)
+        .addObject("urn:nozzle:1", new LinkedHashMap<String, String>())
+        .addConnection("urn:equipment:1", "HAS_NOZZLE", "urn:nozzle:1");
+  }
+}

--- a/src/test/java/neqsim/process/engineering/EngineeringProductionReadinessTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringProductionReadinessTest.java
@@ -95,7 +95,7 @@ class EngineeringProductionReadinessTest {
         .releaseQualityEvidence(new EngineeringReleaseQualityEvidence("release-candidate-1").fullCiPassed(true)
             .supportedJavaMatrixPassed(true).deterministicConvergencePassed(true).performanceAcceptancePassed(true)
             .apiCompatibilityPassed(true).serializationMigrationPassed(true).securityReviewPassed(true)
-            .evidenceReference("RELEASE-EVIDENCE-001"));
+            .evidenceReference("RELEASE-EVIDENCE-001").accountableReviewer("Release authority / RA-001"));
     project.addEvidenceRecord(new EngineeringEvidenceRecord("HAZOP-001", "HAZOP", "A").setTitle("Test hazard review")
         .setSourceOrganization("Independent engineering team").linkEquipment("FEED")
         .approve("Hazop chair / HAZOP-001-A"));

--- a/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
+++ b/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
@@ -61,11 +61,12 @@ class ProcessToEngineeringSimulatorTest {
     EngineeringDeliverableCompiler.CompilationResult compilation = EngineeringDeliverableCompiler.compile(project,
         temporaryDirectory);
     assertTrue(Files.isRegularFile(compilation.getProductionReadinessFile()));
+    assertTrue(Files.isRegularFile(compilation.getQualificationPlanFile()));
     String[] coordinatedArtifacts = new String[] { "process-design-basis.json", "equipment-datasheets.json",
         "valve-list.json", "io-list.json", "alarm-trip-schedule.json", "shutdown-narratives.json",
         "psv-datasheets.json", "flare-blowdown-report.json", "utility-summary.json", "materials-selection-report.json",
         "engineering-diagram-layout.json", "unresolved-engineering-actions.json", "revision-impact-report.json",
-        "engineering-production-readiness.json" };
+        "engineering-production-readiness.json", "engineering-qualification-plan.json" };
     for (String artifact : coordinatedArtifacts) {
       assertTrue(Files.exists(temporaryDirectory.resolve(artifact)), artifact);
     }
@@ -84,6 +85,10 @@ class ProcessToEngineeringSimulatorTest {
         Files.readAllBytes(temporaryDirectory.resolve("engineering-production-readiness.json")),
         StandardCharsets.UTF_8);
     assertTrue(productionReadiness.contains("\"fitnessForConstruction\": false"));
+    String qualificationPlan = new String(
+        Files.readAllBytes(temporaryDirectory.resolve("engineering-qualification-plan.json")), StandardCharsets.UTF_8);
+    assertTrue(qualificationPlan.contains("\"externalEvidenceMayNotBeGeneratedBySimulator\": true"));
+    assertTrue(qualificationPlan.contains("\"METHOD_BENCHMARK\""));
   }
 
   private EngineeringDesignCase flowCase(String id, final double flowKgHr, int priority) {


### PR DESCRIPTION
## What changed

- adds executable, versioned benchmark datasets where every registered case for a method must independently qualify
- adds named-product DEXPI import/export/reimport semantic comparison, controlled pilot comparison, and measured release-quality runners
- adds a schema-validated `engineering-qualification-plan.json` artifact to every coordinated engineering package
- adds fail-closed production-qualification mode across equipment, piping, valves, instruments, safety, materials, and preliminary mechanical calculations
- adds detailed Darcy-Weisbach network cases and governed gas/liquid/steam/two-phase relief-orifice sizing
- adds documentation, an executable API notebook, and updated engineering agent/skill guidance

## Why

The existing process-to-engineering loop and readiness assessment exposed production gaps but did not provide executable workflows for closing them. This change turns those gates into controlled measurement and evidence pipelines while retaining explicit engineering-review boundaries.

## Engineering boundary

This does not generate independent review, commercial-tool acceptance, HAZOP/LOPA/SRS approval, pilot acceptance, vendor certification, or construction authorization. Generated results remain review-required; the package fixes `fitnessForConstruction=false`.

## Validation

- Spotless apply/check: passed
- all `neqsim.process.engineering` tests: passed
- notebook JSON and Python code-cell syntax: passed
- repository-wide Maven tests progressed through hundreds of classes without a failure, but were stopped after about 12 minutes when an unrelated thermodynamic block stopped producing progress; this is not reported as a full-suite pass
