### PR TITLE
Add engineering discipline orchestration

### DIFF
--- a/.github/agents/engineering.deliverables.agent.md
+++ b/.github/agents/engineering.deliverables.agent.md
@@ -53,6 +53,14 @@ infer SIL, final voting, trip set points, valve fail action, credible relief
 causes or shutdown effects solely from equipment class or a normal operating
 point.
 
+When automatic discipline configuration is requested, require an explicit
+`EngineeringAutoConfigurationPolicy` for every recognized equipment item and
+every `ProcessModel` area. Stop on `isExecutionReady()==false`, report each
+blocker, retain the configuration fingerprint and dependency graph, and
+regenerate every artifact listed by `compareWith` after a revision. Treat
+shared-stream area dependencies as conservative invalidation links, not as an
+approved utility or relief concurrency basis.
+
 For qualification work, use the open actions in
 `engineering-qualification-plan.json`. Execute exact-version reference cases
 through `EngineeringBenchmarkDataset`, named-product semantic round trips

--- a/.github/agents/engineering.deliverables.agent.md
+++ b/.github/agents/engineering.deliverables.agent.md
@@ -61,6 +61,13 @@ regenerate every artifact listed by `compareWith` after a revision. Treat
 shared-stream area dependencies as conservative invalidation links, not as an
 approved utility or relief concurrency basis.
 
+When a controlled concurrency basis exists, encode it with
+`EngineeringSharedSystemPolicy` and link every demand to a converged design
+variable. Treat missing variables, unit mismatches and single-area definitions
+as blockers. For revisions, use dependency-propagated incremental execution and
+report which areas were executed or reused; validate the coordinated root
+manifest before deliverable handoff.
+
 For qualification work, use the open actions in
 `engineering-qualification-plan.json`. Execute exact-version reference cases
 through `EngineeringBenchmarkDataset`, named-product semantic round trips

--- a/.github/skills/neqsim-pid-process-operations/SKILL.md
+++ b/.github/skills/neqsim-pid-process-operations/SKILL.md
@@ -466,6 +466,14 @@ engineering-simulator contracts over mutating the live process:
 
 For process-to-engineering work, configure discipline modules with
 `ProcessToEngineeringDesignBuilder` and execute `ProcessToEngineeringSimulator`.
+For revision-controlled automatic configuration, use an explicit
+`EngineeringAutoConfigurationPolicy` and require
+`EngineeringAutoConfigurator.Result.isExecutionReady()` before running or
+publishing results. Inspect its dependency graph, configuration fingerprint and
+revision impact; never suppress an unconfigured recognized equipment blocker.
+For a `ProcessModel`, use `ProcessModelEngineeringSimulator` with one policy and
+controlled case set per area, then review shared-stream dependencies in
+`process-model-engineering-manifest.json`.
 The `EngineeringDesignLoop` must converge both case simulations and physical
 design variables. Use `EngineeringDesignUpdate.Applier` only against the
 isolated working process; the source `ProcessSystem` must remain unchanged.

--- a/.github/skills/neqsim-pid-process-operations/SKILL.md
+++ b/.github/skills/neqsim-pid-process-operations/SKILL.md
@@ -474,6 +474,12 @@ revision impact; never suppress an unconfigured recognized equipment blocker.
 For a `ProcessModel`, use `ProcessModelEngineeringSimulator` with one policy and
 controlled case set per area, then review shared-stream dependencies in
 `process-model-engineering-manifest.json`.
+Represent utility, flare, blowdown, electrical and other common systems with
+`EngineeringSharedSystemPolicy`; require controlled concurrency and evidence
+references. Use `runIncremental` only with a retained baseline result and review
+both `executedAreas` and `reusedAreas`. Never reuse an area invalidated through
+a shared stream or shared-system dependency. Validate the root manifest with
+`ProcessModelEngineeringPackageValidator` before release.
 The `EngineeringDesignLoop` must converge both case simulations and physical
 design variables. Use `EngineeringDesignUpdate.Applier` only against the
 isolated working process; the source `ProcessSystem` must remain unchanged.

--- a/docs/integration/process-to-engineering-simulator.md
+++ b/docs/integration/process-to-engineering-simulator.md
@@ -298,6 +298,29 @@ The compiler creates an area package below each area name and a
 cross-area dependencies; a change invalidates all connected areas. Utility demand simultaneity, flare/blowdown group
 concurrency and safety scenario credibility still require explicit project inputs and review.
 
+Declare those shared-system inputs with controlled references rather than deriving concurrency from topology:
+
+```java
+EngineeringSharedSystemPolicy coordination = new EngineeringSharedSystemPolicy("field-a-shared-systems", "A")
+    .add(new EngineeringSharedSystemPolicy.Definition("main-power",
+        EngineeringSharedSystemPolicy.Type.ELECTRICAL_SYSTEM,
+        "ELECTRICAL-LOAD-BASIS-A", "CALC-EL-001-A")
+        .addDemand("inlet", "10-PA-001.driverRatedPower", 1.0)
+        .addDemand("compression", "20-KA-001.driverRatedPower", 1.0));
+
+ProcessModelEngineeringSimulator.Result first =
+    ProcessModelEngineeringSimulator.run("Field A", processModel, areas, coordination, 4);
+ProcessModelEngineeringSimulator.Result next = ProcessModelEngineeringSimulator.runIncremental(
+    "Field A", revisedModel, revisedAreas, coordination, first, 4);
+```
+
+The shared-system result reports each governing design value, its controlled simultaneity factor and the total demand.
+Missing variables, inconsistent units, or fewer than two participating areas block package compilation. Incremental
+execution compares area and coordination fingerprints, reruns every changed area, propagates invalidation through
+shared streams and declared shared systems, and reuses only unaffected baseline results. The root manifest records
+`executedAreas` and `reusedAreas`, is checked by `ProcessModelEngineeringPackageValidator`, and is distributed with its
+versioned JSON schema.
+
 Compilation always writes the schema-registered `engineering-production-readiness.json` artifact. Its maturity levels
 are `NOT_READY`, `EXPERIMENTAL`, `VALIDATED_PRELIMINARY` and `QUALIFIED_FEED_SUPPORT`. A green result means only that
 the supplied preliminary/FEED-support evidence gates have passed. The artifact deliberately fixes

--- a/docs/integration/process-to-engineering-simulator.md
+++ b/docs/integration/process-to-engineering-simulator.md
@@ -232,7 +232,7 @@ The explicit automatic-configuration path is:
 EngineeringAutoConfigurationPolicy policy = new EngineeringAutoConfigurationPolicy("offshore-gas", "A")
     .addInletCompressionExportSlice(
         "20-VA-001", "20-KA-001", "20-PL-001", "20-PV-001", "20-PIT-001",
-        800.0, 0.107, 120.0, // separator gas time, Souders-Brown K, liquid time
+        800.0, 0.107, 120.0, // liquid density, Souders-Brown K, liquid retention time
         20.0, 0.5,           // maximum line velocity and pressure gradient
         0.10,                // compressor driver margin
         3000.0, 5000.0, 7500.0, 10000.0);
@@ -244,6 +244,59 @@ project.setProductionReadinessBasis(
 // Or configure, record the coverage evidence, and run in one call:
 EngineeringSimulationResult result = ProcessToEngineeringSimulator.run(project, policy, 4);
 ```
+
+### Automatic discipline orchestration and invalidation
+
+`EngineeringAutoConfigurator` discovers recognized equipment in the process, applies only the explicit rules in the
+revision-controlled policy, and records both configured and unconfigured items. It deliberately does not infer design
+limits, relief causes, SIL, valve failure action or shared-system concurrency from topology. The simulator overload
+that accepts a policy now fails before the design loop when any recognized item is unconfigured, a hidden screening
+default was selected, no executable case exists, or no discipline module was created.
+
+The result supplies a deterministic configuration fingerprint, conservative module dependencies and executable
+blockers:
+
+```java
+EngineeringAutoConfigurator.Result orchestration =
+    project.getProductionReadinessBasis().getAutoConfigurationResult();
+
+if (!orchestration.isExecutionReady()) {
+  throw new IllegalStateException(orchestration.getExecutionBlockers().toString());
+}
+
+Map<String, List<String>> dependencyGraph = orchestration.getModuleDependencies();
+EngineeringAutoConfigurator.RevisionImpact impact = orchestration.compareWith(previousOrchestration);
+```
+
+A changed policy, process topology, case set or module graph changes the fingerprint. `compareWith` then invalidates
+the affected discipline chain conservatively and lists the package artifacts that must be regenerated. Compilation
+writes this evidence to `engineering-discipline-orchestration.json`; it also remains embedded in
+`engineering-production-readiness.json`.
+
+### Coordinated multi-area ProcessModel execution
+
+Use `ProcessModelEngineeringSimulator` when the source is a `ProcessModel`. One explicit policy and controlled case
+set is required per area:
+
+```java
+Map<String, ProcessModelEngineeringSimulator.AreaConfiguration> areas = new LinkedHashMap<>();
+areas.put("inlet", new ProcessModelEngineeringSimulator.AreaConfiguration(inletPolicy)
+    .addDesignCase(inletNormal).addDesignCase(inletMaximum));
+areas.put("compression", new ProcessModelEngineeringSimulator.AreaConfiguration(compressionPolicy)
+    .addDesignCase(compressionNormal).addDesignCase(compressionMaximum));
+
+ProcessModelEngineeringSimulator.Result plant =
+    ProcessModelEngineeringSimulator.run("Field A", processModel, areas, 4);
+if (!plant.isComplete()) {
+  throw new IllegalStateException(plant.getBlockers().toString());
+}
+Path manifest = plant.compile(Paths.get("build/field-a-engineering"));
+```
+
+The compiler creates an area package below each area name and a
+`process-model-engineering-manifest.json` at the root. Stream objects shared between area equipment are registered as
+cross-area dependencies; a change invalidates all connected areas. Utility demand simultaneity, flare/blowdown group
+concurrency and safety scenario credibility still require explicit project inputs and review.
 
 Compilation always writes the schema-registered `engineering-production-readiness.json` artifact. Its maturity levels
 are `NOT_READY`, `EXPERIMENTAL`, `VALIDATED_PRELIMINARY` and `QUALIFIED_FEED_SUPPORT`. A green result means only that
@@ -326,6 +379,9 @@ and reviewer string with controlled project evidence before assessing readiness.
 See the executable
 [production-readiness notebook](../../examples/notebooks/engineering_production_readiness.ipynb) for explicit
 auto-configuration, executed-method discovery, a regression-evidence rejection, and the compiled gate report.
+The companion
+[discipline-orchestration notebook](../../examples/notebooks/engineering_discipline_orchestration.ipynb) focuses on
+execution blockers, dependency fingerprints, revision invalidation and the multi-area `ProcessModel` API.
 
 ## Required engineering review
 

--- a/examples/notebooks/engineering_discipline_orchestration.ipynb
+++ b/examples/notebooks/engineering_discipline_orchestration.ipynb
@@ -70,6 +70,29 @@
     "\n",
     "Successful execution does not establish credible HAZOP scenarios, SIL/voting, final set points, valve failure positions, metallurgy, utility simultaneity, flare/blowdown concurrency, vendor guarantees or final approval. Supply those through controlled project evidence and qualification workflows."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SharedPolicy = jpype.JClass('neqsim.process.engineering.production.EngineeringSharedSystemPolicy')\n",
+    "SharedDefinition = jpype.JClass('neqsim.process.engineering.production.EngineeringSharedSystemPolicy$Definition')\n",
+    "SharedType = jpype.JClass('neqsim.process.engineering.production.EngineeringSharedSystemPolicy$Type')\n",
+    "MultiArea = jpype.JClass('neqsim.process.engineering.production.ProcessModelEngineeringSimulator')\n",
+    "\n",
+    "coordination = SharedPolicy('field-a-shared-systems', 'A').add(\n",
+    "    SharedDefinition('main-power', SharedType.ELECTRICAL_SYSTEM,\n",
+    "                     'ELECTRICAL-LOAD-BASIS-A', 'CALC-EL-001-A')\n",
+    "        .addDemand('inlet', '10-PA-001.driverRatedPower', 1.0)\n",
+    "        .addDemand('compression', '20-KA-001.driverRatedPower', 1.0))\n",
+    "# first = MultiArea.run('Field A', process_model, area_configurations, coordination, 4)\n",
+    "# revised = MultiArea.runIncremental(\n",
+    "#     'Field A', revised_model, revised_area_configurations, coordination, first, 4)\n",
+    "# print('executed', list(revised.getExecutedAreas()))\n",
+    "# print('reused', list(revised.getReusedAreas()))\n"
+   ]
   }
  ],
  "metadata": {

--- a/examples/notebooks/engineering_discipline_orchestration.ipynb
+++ b/examples/notebooks/engineering_discipline_orchestration.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Automatic engineering discipline orchestration\n",
+    "\n",
+    "This notebook demonstrates the post-#2460 execution layer: explicit policy configuration, fail-closed coverage, dependency fingerprints, revision impact and coordinated multi-area packaging. The values are illustrative preliminary inputs and all results remain review-required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import jpype\n",
+    "import jpype.imports\n",
+    "\n",
+    "ROOT = Path.cwd().resolve()\n",
+    "while ROOT.name != 'neqsim' and ROOT.parent != ROOT:\n",
+    "    ROOT = ROOT.parent\n",
+    "if not jpype.isJVMStarted():\n",
+    "    jpype.startJVM(classpath=[str(ROOT / 'target' / 'classes')])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Build and run a normal NeqSim `ProcessSystem`, then create the governed project and controlled cases as shown in `process_to_engineering_simulator.ipynb`. The policy below contains explicit values instead of library screening defaults."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Policy = jpype.JClass('neqsim.process.engineering.production.EngineeringAutoConfigurationPolicy')\n",
+    "Simulator = jpype.JClass('neqsim.process.engineering.ProcessToEngineeringSimulator')\n",
+    "\n",
+    "policy = Policy('offshore-gas', 'A').addInletCompressionExportSlice(\n",
+    "    'INLET-SEP', 'EXPORT-COMP', 'EXPORT-LINE', '', 'PIT-100',\n",
+    "    800.0, 0.107, 120.0, 25.0, 5.0, 0.10,\n",
+    "    500.0, 1000.0, 2000.0, 3000.0, 5000.0, 7500.0, 10000.0)\n",
+    "# result = Simulator.run(project, policy, 2)\n",
+    "# orchestration = project.getProductionReadinessBasis().getAutoConfigurationResult()\n",
+    "# assert orchestration.isExecutionReady(), list(orchestration.getExecutionBlockers())\n",
+    "# print(orchestration.getConfigurationFingerprint())\n",
+    "# print(dict(orchestration.getModuleDependencies()))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Revision and multi-area workflow\n",
+    "\n",
+    "Store the prior `EngineeringAutoConfigurator.Result` with the revision. Call `current.compareWith(previous)` before reuse; regenerate every listed artifact when the fingerprint changes. For a `ProcessModel`, create one `ProcessModelEngineeringSimulator.AreaConfiguration` per area, attach controlled cases, call `run`, and then `compile`. The root manifest records area package paths and shared-stream invalidation links. Missing area policies and incomplete equipment coverage are blockers, not warnings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Engineering boundary\n",
+    "\n",
+    "Successful execution does not establish credible HAZOP scenarios, SIL/voting, final set points, valve failure positions, metallurgy, utility simultaneity, flare/blowdown concurrency, vendor guarantees or final approval. Supply those through controlled project evidence and qualification workflows."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/main/java/neqsim/process/engineering/ProcessToEngineeringSimulator.java
+++ b/src/main/java/neqsim/process/engineering/ProcessToEngineeringSimulator.java
@@ -46,6 +46,10 @@ public final class ProcessToEngineeringSimulator {
       project.setProductionReadinessBasis(basis);
     }
     basis.autoConfigurationResult(configuration);
+    if (!configuration.isExecutionReady()) {
+      throw new IllegalStateException(
+          "Automatic engineering configuration is not execution-ready: " + configuration.getExecutionBlockers());
+    }
     return run(project, caseParallelism);
   }
 }

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
@@ -285,6 +285,25 @@ public final class EngineeringDeliverableCompiler {
     Path productionReadinessFile = outputDirectory.resolve("engineering-production-readiness.json");
     write(productionReadinessFile, GSON.toJson(
         EngineeringProductionReadinessAssessment.assess(project, project.getProductionReadinessBasis()).toMap()));
+    Path orchestrationFile = outputDirectory.resolve("engineering-discipline-orchestration.json");
+    Map<String, Object> orchestration = new LinkedHashMap<String, Object>();
+    orchestration.put("schemaVersion", EngineeringSchemaCatalog.DISCIPLINE_ORCHESTRATION);
+    orchestration.put("schemaUri",
+        EngineeringSchemaCatalog.schemaUri(EngineeringSchemaCatalog.DISCIPLINE_ORCHESTRATION));
+    orchestration.put("projectId", project.getProjectId());
+    orchestration.put("revision", project.getRevision());
+    orchestration.put("configuration",
+        project.getProductionReadinessBasis() == null
+            || project.getProductionReadinessBasis().getAutoConfigurationResult() == null ? null
+                : project.getProductionReadinessBasis().getAutoConfigurationResult().toMap());
+    orchestration.put("status",
+        project.getProductionReadinessBasis() != null
+            && project.getProductionReadinessBasis().getAutoConfigurationResult() != null
+            && project.getProductionReadinessBasis().getAutoConfigurationResult().isExecutionReady()
+                ? "EXECUTED_REVIEW_REQUIRED" : "NOT_EXECUTION_READY");
+    orchestration.put("governance",
+        "Dependency completion does not replace HAZOP/LOPA, vendor validation or accountable approval");
+    write(orchestrationFile, GSON.toJson(orchestration));
     Path qualificationPlanFile = outputDirectory.resolve("engineering-qualification-plan.json");
     write(qualificationPlanFile,
         GSON.toJson(EngineeringQualificationPlan.build(project, project.getProductionReadinessBasis())));
@@ -319,7 +338,8 @@ public final class EngineeringDeliverableCompiler {
         "process-design-basis.json", "equipment-datasheets.json", "valve-list.json", "io-list.json",
         "alarm-trip-schedule.json", "shutdown-narratives.json", "psv-datasheets.json", "flare-blowdown-report.json",
         "utility-summary.json", "materials-selection-report.json", "unresolved-engineering-actions.json",
-        "revision-impact-report.json", "engineering-production-readiness.json", "engineering-qualification-plan.json" };
+        "revision-impact-report.json", "engineering-production-readiness.json", "engineering-qualification-plan.json",
+        "engineering-discipline-orchestration.json" };
     for (String document : documents) {
       String nodeId = EngineeringIds.nodeId(EngineeringNode.Kind.DOCUMENT, document);
       graph.addNode(new EngineeringNode(nodeId, EngineeringNode.Kind.DOCUMENT, document, document)
@@ -531,6 +551,7 @@ public final class EngineeringDeliverableCompiler {
     artifacts.add("engineering-diagram-layout.json");
     artifacts.add("engineering-schema-catalog.json");
     artifacts.add("engineering-validation-report.json");
+    artifacts.add("engineering-discipline-orchestration.json");
     artifacts.add("plant.dexpi.xml");
     artifacts.add("plant-proteus.xml");
     artifacts.add("plant-pydexpi.xml");

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
@@ -300,7 +300,8 @@ public final class EngineeringDeliverableCompiler {
         project.getProductionReadinessBasis() != null
             && project.getProductionReadinessBasis().getAutoConfigurationResult() != null
             && project.getProductionReadinessBasis().getAutoConfigurationResult().isExecutionReady()
-                ? "EXECUTED_REVIEW_REQUIRED" : "NOT_EXECUTION_READY");
+                ? "EXECUTED_REVIEW_REQUIRED"
+                : "NOT_EXECUTION_READY");
     orchestration.put("governance",
         "Dependency completion does not replace HAZOP/LOPA, vendor validation or accountable approval");
     write(orchestrationFile, GSON.toJson(orchestration));

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphBuilder.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphBuilder.java
@@ -53,8 +53,8 @@ public final class EngineeringGraphBuilder {
     }
     if (project.getProductionReadinessBasis() != null
         && project.getProductionReadinessBasis().getAutoConfigurationResult() != null) {
-      projectNode.putProperty("engineeringConfigurationFingerprint", project.getProductionReadinessBasis()
-          .getAutoConfigurationResult().getConfigurationFingerprint());
+      projectNode.putProperty("engineeringConfigurationFingerprint",
+          project.getProductionReadinessBasis().getAutoConfigurationResult().getConfigurationFingerprint());
       projectNode.putProperty("engineeringConfigurationExecutionReady",
           Boolean.valueOf(project.getProductionReadinessBasis().getAutoConfigurationResult().isExecutionReady()));
       projectNode.putProperty("engineeringModuleDependencies",

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphBuilder.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphBuilder.java
@@ -51,6 +51,15 @@ public final class EngineeringGraphBuilder {
       projectNode.putProperty("engineeringDesignIterationCount",
           Double.valueOf(project.getLatestEngineeringDesignLoopResult().getIterations().size()));
     }
+    if (project.getProductionReadinessBasis() != null
+        && project.getProductionReadinessBasis().getAutoConfigurationResult() != null) {
+      projectNode.putProperty("engineeringConfigurationFingerprint", project.getProductionReadinessBasis()
+          .getAutoConfigurationResult().getConfigurationFingerprint());
+      projectNode.putProperty("engineeringConfigurationExecutionReady",
+          Boolean.valueOf(project.getProductionReadinessBasis().getAutoConfigurationResult().isExecutionReady()));
+      projectNode.putProperty("engineeringModuleDependencies",
+          project.getProductionReadinessBasis().getAutoConfigurationResult().getModuleDependencies());
+    }
     graph.addNode(projectNode);
 
     Map<String, String> processElementIds = addProcessElements(project, graph, projectNodeId);

--- a/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurationPolicy.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurationPolicy.java
@@ -19,7 +19,7 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
     final String lineTag;
     final String valveTag;
     final String instrumentTag;
-    final double separatorGasResidenceTimeSeconds;
+    final double separatorLiquidDensityKgM3;
     final double separatorSoudersBrownCoefficient;
     final double separatorLiquidRetentionTimeSeconds;
     final double maximumLineVelocityMPerS;
@@ -29,7 +29,7 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
     final boolean explicitDesignInputs;
 
     SliceRule(String separatorTag, String compressorTag, String lineTag, String valveTag, String instrumentTag,
-        double separatorGasResidenceTimeSeconds, double separatorSoudersBrownCoefficient,
+        double separatorLiquidDensityKgM3, double separatorSoudersBrownCoefficient,
         double separatorLiquidRetentionTimeSeconds, double maximumLineVelocityMPerS,
         double maximumPressureGradientBarPerKm, double compressorDriverMarginFraction,
         double[] compressorDriverCandidatesKw, boolean explicitDesignInputs) {
@@ -38,7 +38,7 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
       this.lineTag = text(lineTag, "lineTag");
       this.valveTag = optional(valveTag);
       this.instrumentTag = optional(instrumentTag);
-      this.separatorGasResidenceTimeSeconds = separatorGasResidenceTimeSeconds;
+      this.separatorLiquidDensityKgM3 = separatorLiquidDensityKgM3;
       this.separatorSoudersBrownCoefficient = separatorSoudersBrownCoefficient;
       this.separatorLiquidRetentionTimeSeconds = separatorLiquidRetentionTimeSeconds;
       this.maximumLineVelocityMPerS = maximumLineVelocityMPerS;
@@ -181,12 +181,12 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
 
   /** Adds a slice with all project-specific calculation limits and discrete driver candidates stated explicitly. */
   public EngineeringAutoConfigurationPolicy addInletCompressionExportSlice(String separatorTag, String compressorTag,
-      String lineTag, String valveTag, String instrumentTag, double separatorGasResidenceTimeSeconds,
+      String lineTag, String valveTag, String instrumentTag, double separatorLiquidDensityKgM3,
       double separatorSoudersBrownCoefficient, double separatorLiquidRetentionTimeSeconds,
       double maximumLineVelocityMPerS, double maximumPressureGradientBarPerKm, double compressorDriverMarginFraction,
       double... compressorDriverCandidatesKw) {
     slices.add(new SliceRule(separatorTag, compressorTag, lineTag, valveTag, instrumentTag,
-        positive(separatorGasResidenceTimeSeconds, "separatorGasResidenceTimeSeconds"),
+        positive(separatorLiquidDensityKgM3, "separatorLiquidDensityKgM3"),
         positive(separatorSoudersBrownCoefficient, "separatorSoudersBrownCoefficient"),
         positive(separatorLiquidRetentionTimeSeconds, "separatorLiquidRetentionTimeSeconds"),
         positive(maximumLineVelocityMPerS, "maximumLineVelocityMPerS"),
@@ -232,11 +232,11 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
     return this;
   }
 
-  String getId() {
+  public String getId() {
     return id;
   }
 
-  String getRevision() {
+  public String getRevision() {
     return revision;
   }
 
@@ -266,6 +266,48 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
 
   List<NetworkRule> getNetworks() {
     return Collections.unmodifiableList(networks);
+  }
+
+  String fingerprintMaterial() {
+    StringBuilder value = new StringBuilder(id).append('|').append(revision);
+    for (SliceRule rule : slices) {
+      value.append("|slice:").append(rule.separatorTag).append(':').append(rule.compressorTag).append(':')
+          .append(rule.lineTag).append(':').append(rule.valveTag).append(':').append(rule.instrumentTag).append(':')
+          .append(rule.separatorLiquidDensityKgM3).append(':').append(rule.separatorSoudersBrownCoefficient).append(':')
+          .append(rule.separatorLiquidRetentionTimeSeconds).append(':').append(rule.maximumLineVelocityMPerS)
+          .append(':').append(rule.maximumPressureGradientBarPerKm).append(':')
+          .append(rule.compressorDriverMarginFraction).append(':')
+          .append(java.util.Arrays.toString(rule.compressorDriverCandidatesKw)).append(':')
+          .append(rule.explicitDesignInputs);
+    }
+    for (PumpRule rule : pumps) {
+      value.append("|pump:").append(rule.tag).append(':').append(rule.margin).append(':')
+          .append(rule.minimumNpshMarginM).append(':').append(java.util.Arrays.toString(rule.drivers));
+    }
+    for (HeatExchangerRule rule : exchangers) {
+      value.append("|exchanger:").append(rule.tag).append(':').append(rule.overallU).append(':').append(rule.lmtd)
+          .append(':').append(rule.margin).append(':').append(java.util.Arrays.toString(rule.areas));
+    }
+    for (InventoryRule rule : inventories) {
+      value.append("|inventory:").append(rule.tag).append(':').append(rule.workingTime).append(':')
+          .append(rule.usableFraction).append(':').append(java.util.Arrays.toString(rule.volumes));
+    }
+    for (ControlValveRule rule : controlValves) {
+      value.append("|valve:").append(rule.tag).append(':').append(rule.designOpening).append(':')
+          .append(rule.maximumOpening).append(':').append(java.util.Arrays.toString(rule.cvCandidates));
+    }
+    for (RatedCapacityRule rule : ratedCapacities) {
+      value.append("|capacity:").append(rule.tag).append(':').append(rule.metric.getId()).append(':')
+          .append(rule.capacityName).append(':').append(rule.unit).append(':').append(rule.margin).append(':')
+          .append(java.util.Arrays.toString(rule.candidates));
+    }
+    for (NetworkRule rule : networks) {
+      value.append("|network:").append(rule.id).append(':').append(rule.rulePack.toMap()).append(':');
+      for (PipingNetworkDesignModule.SegmentDefinition segment : rule.segments) {
+        value.append(segment.getLineTag()).append(',');
+      }
+    }
+    return value.toString();
   }
 
   private static String optional(String value) {

--- a/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurator.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurator.java
@@ -1,6 +1,9 @@
 package neqsim.process.engineering.production;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -37,7 +40,7 @@ public final class EngineeringAutoConfigurator {
       if (configuredCoreItems == 0) {
         if (rule.explicitDesignInputs) {
           builder
-              .separatorBasis(rule.separatorGasResidenceTimeSeconds, rule.separatorSoudersBrownCoefficient,
+              .separatorBasis(rule.separatorLiquidDensityKgM3, rule.separatorSoudersBrownCoefficient,
                   rule.separatorLiquidRetentionTimeSeconds)
               .exportLineLimits(rule.maximumLineVelocityMPerS, rule.maximumPressureGradientBarPerKm)
               .compressorDrivers(rule.compressorDriverMarginFraction, rule.compressorDriverCandidatesKw);
@@ -110,13 +113,97 @@ public final class EngineeringAutoConfigurator {
       row.put("family", family(unit));
       row.put("configured", Boolean.valueOf(configured));
       row.put("action", configured ? "NONE" : "ADD_EXPLICIT_PROJECT_POLICY_RULE");
+      row.put("simulatedOperatingState", finiteState(unit));
+      row.put("operatingStateSource", "PROCESS_MODEL_PRIMARY_OUTLET");
       inventory.add(row);
       if (!configured) {
         unconfigured.add(unit.getName());
       }
     }
+    Map<String, List<String>> dependencies = dependencyGraph(project.getEngineeringDesignModules());
+    List<String> blockers = new ArrayList<String>();
+    if (project.getExecutableDesignCases().isEmpty()) {
+      blockers.add("NO_EXECUTABLE_DESIGN_CASES");
+    }
+    if (project.getEngineeringDesignModules().isEmpty()) {
+      blockers.add("NO_ENGINEERING_DESIGN_MODULES");
+    }
+    if (hiddenDefaultsUsed) {
+      blockers.add("HIDDEN_SCREENING_DEFAULTS_USED");
+    }
+    for (String tag : unconfigured) {
+      blockers.add("UNCONFIGURED_RECOGNIZED_EQUIPMENT:" + tag);
+    }
+    String fingerprint = fingerprint(project, policy, dependencies);
     return new Result(policy.getId(), policy.getRevision(), configuredTags, unconfigured, inventory,
-        project.getEngineeringDesignModules().size(), hiddenDefaultsUsed);
+        project.getEngineeringDesignModules().size(), hiddenDefaultsUsed, dependencies, blockers, fingerprint);
+  }
+
+  private static Map<String, Map<String, Object>> finiteState(ProcessEquipmentInterface unit) {
+    Map<String, Map<String, Object>> result = new LinkedHashMap<String, Map<String, Object>>();
+    for (Map.Entry<String, Map<String, Object>> entry : unit.getEquipmentState("C", "bara", "kg/hr").entrySet()) {
+      Object value = entry.getValue().get("value");
+      if (!(value instanceof Number) || Double.isFinite(((Number) value).doubleValue())) {
+        result.put(entry.getKey(), new LinkedHashMap<String, Object>(entry.getValue()));
+      }
+    }
+    return result;
+  }
+
+  private static Map<String, List<String>> dependencyGraph(List<EngineeringDesignModule> modules) {
+    Map<String, List<String>> result = new LinkedHashMap<String, List<String>>();
+    for (EngineeringDesignModule module : modules) {
+      List<String> prerequisites = new ArrayList<String>();
+      int rank = disciplineRank(module.getId());
+      for (EngineeringDesignModule candidate : modules) {
+        int candidateRank = disciplineRank(candidate.getId());
+        if (candidateRank < rank && candidateRank >= Math.max(10, rank - 30)) {
+          prerequisites.add(candidate.getId());
+        }
+      }
+      result.put(module.getId(), Collections.unmodifiableList(prerequisites));
+    }
+    return Collections.unmodifiableMap(result);
+  }
+
+  private static int disciplineRank(String moduleId) {
+    if (moduleId != null && moduleId.length() >= 2) {
+      try {
+        return Integer.parseInt(moduleId.substring(0, 2));
+      } catch (NumberFormatException ignored) {
+        // Non-numbered project modules execute after the standard discipline chain.
+      }
+    }
+    return 99;
+  }
+
+  private static String fingerprint(EngineeringProject project, EngineeringAutoConfigurationPolicy policy,
+      Map<String, List<String>> dependencies) {
+    StringBuilder canonical = new StringBuilder();
+    canonical.append(policy.fingerprintMaterial()).append('|').append(project.getRevision()).append('|');
+    for (ProcessEquipmentInterface unit : project.getProcessSystem().getUnitOperations()) {
+      if (unit != null) {
+        canonical.append(unit.getName()).append(':').append(unit.getClass().getName()).append(':')
+            .append(finiteState(unit)).append(';');
+      }
+    }
+    for (neqsim.process.engineering.designcase.EngineeringDesignCase designCase : project.getExecutableDesignCases()) {
+      canonical.append("case:").append(designCase.toMap()).append(';');
+    }
+    for (Map.Entry<String, List<String>> entry : dependencies.entrySet()) {
+      canonical.append("module:").append(entry.getKey()).append("<-").append(entry.getValue()).append(';');
+    }
+    try {
+      byte[] digest = MessageDigest.getInstance("SHA-256")
+          .digest(canonical.toString().getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder();
+      for (byte value : digest) {
+        hex.append(String.format("%02x", value & 0xff));
+      }
+      return hex.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is required by the Java runtime", exception);
+    }
   }
 
   private static Set<String> existingConfiguredTags(EngineeringProject project) {
@@ -201,9 +288,14 @@ public final class EngineeringAutoConfigurator {
     private final List<Map<String, Object>> equipmentInventory;
     private final int moduleCount;
     private final boolean hiddenDefaultsUsed;
+    private final Map<String, List<String>> moduleDependencies;
+    private final List<String> executionBlockers;
+    private final String configurationFingerprint;
 
     Result(String policyId, String policyRevision, Set<String> configuredTags, List<String> unconfigured,
-        List<Map<String, Object>> equipmentInventory, int moduleCount, boolean hiddenDefaultsUsed) {
+        List<Map<String, Object>> equipmentInventory, int moduleCount, boolean hiddenDefaultsUsed,
+        Map<String, List<String>> moduleDependencies, List<String> executionBlockers,
+        String configurationFingerprint) {
       this.policyId = policyId;
       this.policyRevision = policyRevision;
       this.configuredTags = Collections.unmodifiableSet(new LinkedHashSet<String>(configuredTags));
@@ -211,14 +303,66 @@ public final class EngineeringAutoConfigurator {
       this.equipmentInventory = Collections.unmodifiableList(new ArrayList<Map<String, Object>>(equipmentInventory));
       this.moduleCount = moduleCount;
       this.hiddenDefaultsUsed = hiddenDefaultsUsed;
+      this.moduleDependencies = moduleDependencies;
+      this.executionBlockers = Collections.unmodifiableList(new ArrayList<String>(executionBlockers));
+      this.configurationFingerprint = configurationFingerprint;
     }
 
     public boolean isComplete() {
       return moduleCount > 0 && unconfiguredRecognizedTags.isEmpty() && !hiddenDefaultsUsed;
     }
 
+    /** @return true when configuration and executable case inputs are sufficient to start the design loop */
+    public boolean isExecutionReady() {
+      return isComplete() && executionBlockers.isEmpty();
+    }
+
     public Set<String> getConfiguredTags() {
       return configuredTags;
+    }
+
+    public List<String> getUnconfiguredRecognizedTags() {
+      return unconfiguredRecognizedTags;
+    }
+
+    public List<Map<String, Object>> getEquipmentInventory() {
+      return equipmentInventory;
+    }
+
+    public Map<String, List<String>> getModuleDependencies() {
+      return moduleDependencies;
+    }
+
+    public List<String> getExecutionBlockers() {
+      return executionBlockers;
+    }
+
+    public String getConfigurationFingerprint() {
+      return configurationFingerprint;
+    }
+
+    /** Conservatively identifies calculations and package artifacts invalidated by a configuration revision. */
+    public RevisionImpact compareWith(Result baseline) {
+      if (baseline == null) {
+        return new RevisionImpact("NO_BASELINE", new ArrayList<String>(moduleDependencies.keySet()),
+            standardInvalidatedArtifacts());
+      }
+      if (configurationFingerprint.equals(baseline.configurationFingerprint)) {
+        return new RevisionImpact("UNCHANGED", Collections.<String>emptyList(), Collections.<String>emptyList());
+      }
+      Set<String> modules = new LinkedHashSet<String>();
+      modules.addAll(baseline.moduleDependencies.keySet());
+      modules.addAll(moduleDependencies.keySet());
+      return new RevisionImpact("CONFIGURATION_CHANGED", new ArrayList<String>(modules),
+          standardInvalidatedArtifacts());
+    }
+
+    private static List<String> standardInvalidatedArtifacts() {
+      List<String> artifacts = new ArrayList<String>();
+      Collections.addAll(artifacts, "design-case-envelope.json", "engineering-calculation-dag.json",
+          "engineering-model.json", "equipment-register.json", "line-register.json", "valve-list.json",
+          "instrument-register.json", "engineering-production-readiness.json", "plant.dexpi.xml");
+      return artifacts;
     }
 
     public Map<String, Object> toMap() {
@@ -231,6 +375,45 @@ public final class EngineeringAutoConfigurator {
       result.put("moduleCount", Integer.valueOf(moduleCount));
       result.put("complete", Boolean.valueOf(isComplete()));
       result.put("hiddenDefaultsUsed", Boolean.valueOf(hiddenDefaultsUsed));
+      result.put("executionReady", Boolean.valueOf(isExecutionReady()));
+      result.put("executionBlockers", executionBlockers);
+      result.put("moduleDependencies", moduleDependencies);
+      result.put("configurationFingerprint", configurationFingerprint);
+      return result;
+    }
+  }
+
+  /** Immutable conservative invalidation result between two controlled configuration revisions. */
+  public static final class RevisionImpact implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String status;
+    private final List<String> invalidatedModules;
+    private final List<String> invalidatedArtifacts;
+
+    RevisionImpact(String status, List<String> invalidatedModules, List<String> invalidatedArtifacts) {
+      this.status = status;
+      this.invalidatedModules = Collections.unmodifiableList(new ArrayList<String>(invalidatedModules));
+      this.invalidatedArtifacts = Collections.unmodifiableList(new ArrayList<String>(invalidatedArtifacts));
+    }
+
+    public String getStatus() {
+      return status;
+    }
+
+    public List<String> getInvalidatedModules() {
+      return invalidatedModules;
+    }
+
+    public List<String> getInvalidatedArtifacts() {
+      return invalidatedArtifacts;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("status", status);
+      result.put("invalidatedModules", invalidatedModules);
+      result.put("invalidatedArtifacts", invalidatedArtifacts);
+      result.put("requiresRerun", Boolean.valueOf(!invalidatedModules.isEmpty()));
       return result;
     }
   }

--- a/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurator.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurator.java
@@ -294,8 +294,7 @@ public final class EngineeringAutoConfigurator {
 
     Result(String policyId, String policyRevision, Set<String> configuredTags, List<String> unconfigured,
         List<Map<String, Object>> equipmentInventory, int moduleCount, boolean hiddenDefaultsUsed,
-        Map<String, List<String>> moduleDependencies, List<String> executionBlockers,
-        String configurationFingerprint) {
+        Map<String, List<String>> moduleDependencies, List<String> executionBlockers, String configurationFingerprint) {
       this.policyId = policyId;
       this.policyRevision = policyRevision;
       this.configuredTags = Collections.unmodifiableSet(new LinkedHashSet<String>(configuredTags));

--- a/src/main/java/neqsim/process/engineering/production/EngineeringSharedSystemPolicy.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringSharedSystemPolicy.java
@@ -1,0 +1,166 @@
+package neqsim.process.engineering.production;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Explicit utility, flare, blowdown, electrical, or other shared-system coordination basis. */
+public final class EngineeringSharedSystemPolicy implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Supported shared-system coordination families. */
+  public enum Type {
+    UTILITY_HEADER, FLARE_HEADER, BLOWDOWN_GROUP, ELECTRICAL_SYSTEM, SHARED_EQUIPMENT, OTHER
+  }
+
+  /** One area demand linked to a converged engineering design variable. */
+  public static final class Demand implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String areaName;
+    private final String designVariable;
+    private final double simultaneityFactor;
+
+    public Demand(String areaName, String designVariable, double simultaneityFactor) {
+      this.areaName = text(areaName, "areaName");
+      this.designVariable = text(designVariable, "designVariable");
+      if (!Double.isFinite(simultaneityFactor) || simultaneityFactor < 0.0 || simultaneityFactor > 1.0) {
+        throw new IllegalArgumentException("simultaneityFactor must be between zero and one");
+      }
+      this.simultaneityFactor = simultaneityFactor;
+    }
+
+    public String getAreaName() {
+      return areaName;
+    }
+
+    public String getDesignVariable() {
+      return designVariable;
+    }
+
+    public double getSimultaneityFactor() {
+      return simultaneityFactor;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("areaName", areaName);
+      result.put("designVariable", designVariable);
+      result.put("simultaneityFactor", Double.valueOf(simultaneityFactor));
+      return result;
+    }
+  }
+
+  /** Controlled definition for one shared system. */
+  public static final class Definition implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String id;
+    private final Type type;
+    private final String concurrencyBasisReference;
+    private final String evidenceReference;
+    private final List<Demand> demands = new ArrayList<Demand>();
+
+    public Definition(String id, Type type, String concurrencyBasisReference, String evidenceReference) {
+      this.id = text(id, "id");
+      if (type == null) {
+        throw new IllegalArgumentException("type must not be null");
+      }
+      this.type = type;
+      this.concurrencyBasisReference = text(concurrencyBasisReference, "concurrencyBasisReference");
+      this.evidenceReference = text(evidenceReference, "evidenceReference");
+    }
+
+    public Definition addDemand(String areaName, String designVariable, double simultaneityFactor) {
+      demands.add(new Demand(areaName, designVariable, simultaneityFactor));
+      return this;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public Type getType() {
+      return type;
+    }
+
+    public List<Demand> getDemands() {
+      return Collections.unmodifiableList(demands);
+    }
+
+    public Set<String> getAreaNames() {
+      Set<String> result = new LinkedHashSet<String>();
+      for (Demand demand : demands) {
+        result.add(demand.areaName);
+      }
+      return Collections.unmodifiableSet(result);
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("id", id);
+      result.put("type", type.name());
+      result.put("concurrencyBasisReference", concurrencyBasisReference);
+      result.put("evidenceReference", evidenceReference);
+      List<Map<String, Object>> demandRows = new ArrayList<Map<String, Object>>();
+      for (Demand demand : demands) {
+        demandRows.add(demand.toMap());
+      }
+      result.put("demands", demandRows);
+      result.put("approvalStatus", "REVIEW_REQUIRED");
+      return result;
+    }
+  }
+
+  private final String id;
+  private final String revision;
+  private final List<Definition> definitions = new ArrayList<Definition>();
+
+  public EngineeringSharedSystemPolicy(String id, String revision) {
+    this.id = text(id, "id");
+    this.revision = text(revision, "revision");
+  }
+
+  public EngineeringSharedSystemPolicy add(Definition definition) {
+    if (definition == null) {
+      throw new IllegalArgumentException("definition must not be null");
+    }
+    for (Definition existing : definitions) {
+      if (existing.id.equals(definition.id)) {
+        throw new IllegalArgumentException("Duplicate shared-system definition " + definition.id);
+      }
+    }
+    definitions.add(definition);
+    return this;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getRevision() {
+    return revision;
+  }
+
+  public List<Definition> getDefinitions() {
+    return Collections.unmodifiableList(definitions);
+  }
+
+  String fingerprintMaterial() {
+    StringBuilder result = new StringBuilder(id).append('|').append(revision);
+    for (Definition definition : definitions) {
+      result.append('|').append(definition.toMap());
+    }
+    return result.toString();
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/ProcessModelEngineeringPackageValidator.java
+++ b/src/main/java/neqsim/process/engineering/production/ProcessModelEngineeringPackageValidator.java
@@ -1,0 +1,73 @@
+package neqsim.process.engineering.production;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Structural and governance validation for the coordinated multi-area engineering manifest. */
+public final class ProcessModelEngineeringPackageValidator {
+  private ProcessModelEngineeringPackageValidator() {
+  }
+
+  /** Returns immutable validation findings; an empty list means the manifest is structurally valid. */
+  public static List<String> validate(Map<String, Object> manifest) {
+    List<String> findings = new ArrayList<String>();
+    if (manifest == null) {
+      findings.add("MANIFEST_MISSING");
+      return Collections.unmodifiableList(findings);
+    }
+    require(manifest, "schemaVersion", "neqsim_process_model_engineering_manifest.v1", findings);
+    require(manifest, "schemaUri", "urn:neqsim:schema:process-model-engineering-manifest:v1", findings);
+    if (!Boolean.TRUE.equals(manifest.get("complete"))) {
+      findings.add("RESULT_NOT_COMPLETE");
+    }
+    Object blockers = manifest.get("blockers");
+    if (!(blockers instanceof List<?>) || !((List<?>) blockers).isEmpty()) {
+      findings.add("OPEN_BLOCKERS");
+    }
+    requireFingerprint(manifest, "fingerprint", findings);
+    requireFingerprint(manifest, "coordinationFingerprint", findings);
+    if (!(manifest.get("areas") instanceof Map<?, ?>) || ((Map<?, ?>) manifest.get("areas")).isEmpty()) {
+      findings.add("AREA_RESULTS_MISSING");
+    }
+    if (!(manifest.get("areaPackages") instanceof Map<?, ?>) || ((Map<?, ?>) manifest.get("areaPackages")).isEmpty()) {
+      findings.add("AREA_PACKAGES_MISSING");
+    } else if (manifest.get("areas") instanceof Map<?, ?>) {
+      Set<?> areaNames = ((Map<?, ?>) manifest.get("areas")).keySet();
+      Set<?> packageNames = ((Map<?, ?>) manifest.get("areaPackages")).keySet();
+      if (!areaNames.equals(packageNames)) {
+        findings.add("AREA_PACKAGE_SET_MISMATCH");
+      }
+    }
+    if (!(manifest.get("sharedStreamDependencies") instanceof List<?>)) {
+      findings.add("SHARED_STREAM_DEPENDENCIES_MISSING");
+    }
+    if (!(manifest.get("sharedSystemResults") instanceof List<?>)) {
+      findings.add("SHARED_SYSTEM_RESULTS_MISSING");
+    }
+    return Collections.unmodifiableList(findings);
+  }
+
+  /** Throws when a manifest cannot be released as a coordinated package. */
+  public static void validateOrThrow(Map<String, Object> manifest) {
+    List<String> findings = validate(manifest);
+    if (!findings.isEmpty()) {
+      throw new IllegalStateException("Invalid process-model engineering manifest: " + findings);
+    }
+  }
+
+  private static void require(Map<String, Object> manifest, String field, String expected, List<String> findings) {
+    if (!expected.equals(manifest.get(field))) {
+      findings.add("INVALID_" + field.toUpperCase());
+    }
+  }
+
+  private static void requireFingerprint(Map<String, Object> manifest, String field, List<String> findings) {
+    Object value = manifest.get(field);
+    if (!(value instanceof String) || !((String) value).matches("[0-9a-f]{64}")) {
+      findings.add("INVALID_" + field.toUpperCase());
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/ProcessModelEngineeringSimulator.java
+++ b/src/main/java/neqsim/process/engineering/production/ProcessModelEngineeringSimulator.java
@@ -1,14 +1,17 @@
 package neqsim.process.engineering.production;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -22,6 +25,7 @@ import neqsim.process.engineering.EngineeringSimulationResult;
 import neqsim.process.engineering.NorsokOffshoreEngineeringBuilder;
 import neqsim.process.engineering.ProcessToEngineeringSimulator;
 import neqsim.process.engineering.deliverables.EngineeringDeliverableCompiler;
+import neqsim.process.engineering.design.EngineeringDesignValue;
 import neqsim.process.engineering.designcase.EngineeringDesignCase;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.stream.StreamInterface;
@@ -66,11 +70,34 @@ public final class ProcessModelEngineeringSimulator {
   /** Runs every configured area and records conservative dependencies created by shared stream identities. */
   public static Result run(String projectName, ProcessModel model, Map<String, AreaConfiguration> configurations,
       int caseParallelism) {
+    return runIncremental(projectName, model, configurations,
+        new EngineeringSharedSystemPolicy("topology-only", "1"), null, caseParallelism);
+  }
+
+  /** Runs every area with explicit shared-system demand and concurrency inputs. */
+  public static Result run(String projectName, ProcessModel model, Map<String, AreaConfiguration> configurations,
+      EngineeringSharedSystemPolicy sharedSystemPolicy, int caseParallelism) {
+    return runIncremental(projectName, model, configurations, sharedSystemPolicy, null, caseParallelism);
+  }
+
+  /**
+   * Reruns changed areas and all connected dependants while reusing unchanged results from a controlled baseline.
+   */
+  public static Result runIncremental(String projectName, ProcessModel model,
+      Map<String, AreaConfiguration> configurations, EngineeringSharedSystemPolicy sharedSystemPolicy, Result baseline,
+      int caseParallelism) {
     if (projectName == null || projectName.trim().isEmpty() || model == null || configurations == null) {
       throw new IllegalArgumentException("projectName, model and configurations are required");
     }
+    if (sharedSystemPolicy == null) {
+      throw new IllegalArgumentException("sharedSystemPolicy must not be null");
+    }
+    List<Map<String, Object>> sharedStreams = sharedStreamDependencies(model);
+    String coordinationFingerprint = coordinationFingerprint(sharedSystemPolicy, sharedStreams);
+    Map<String, PreparedArea> prepared = new LinkedHashMap<String, PreparedArea>();
     Map<String, AreaResult> areas = new LinkedHashMap<String, AreaResult>();
     List<String> blockers = new ArrayList<String>();
+    Set<String> invalidatedAreas = new LinkedHashSet<String>();
     for (String areaName : model.getProcessSystemNames()) {
       AreaConfiguration configuration = configurations.get(areaName);
       if (configuration == null) {
@@ -85,16 +112,61 @@ public final class ProcessModelEngineeringSimulator {
         project.addDesignCase(designCase);
       }
       try {
-        EngineeringSimulationResult simulation = ProcessToEngineeringSimulator.run(project, configuration.policy,
+        EngineeringAutoConfigurator.Result configured = EngineeringAutoConfigurator.configure(project,
+            configuration.policy);
+        EngineeringProductionReadinessBasis readiness = new EngineeringProductionReadinessBasis()
+            .autoConfigurationResult(configured);
+        project.setProductionReadinessBasis(readiness);
+        if (!configured.isExecutionReady()) {
+          blockers.add("AREA_NOT_EXECUTION_READY:" + areaName + ":" + configured.getExecutionBlockers());
+          continue;
+        }
+        prepared.put(areaName, new PreparedArea(project, configured));
+        AreaResult baselineArea = baseline == null ? null : baseline.areas.get(areaName);
+        if (baselineArea == null || !configured.getConfigurationFingerprint()
+            .equals(baselineArea.configuration.getConfigurationFingerprint())) {
+          invalidatedAreas.add(areaName);
+        }
+      } catch (RuntimeException exception) {
+        blockers.add("AREA_CONFIGURATION_FAILED:" + areaName + ":" + exception.getMessage());
+      }
+    }
+    if (baseline == null || !coordinationFingerprint.equals(baseline.coordinationFingerprint)) {
+      invalidatedAreas.addAll(prepared.keySet());
+    }
+    propagateInvalidation(invalidatedAreas, dependencyGroups(sharedStreams, sharedSystemPolicy));
+
+    Set<String> executedAreas = new LinkedHashSet<String>();
+    Set<String> reusedAreas = new LinkedHashSet<String>();
+    for (Map.Entry<String, PreparedArea> entry : prepared.entrySet()) {
+      String areaName = entry.getKey();
+      if (!invalidatedAreas.contains(areaName) && baseline != null && baseline.areas.containsKey(areaName)) {
+        areas.put(areaName, baseline.areas.get(areaName));
+        reusedAreas.add(areaName);
+        continue;
+      }
+      try {
+        EngineeringSimulationResult simulation = ProcessToEngineeringSimulator.run(entry.getValue().project,
             caseParallelism);
-        areas.put(areaName, new AreaResult(project, simulation,
-            project.getProductionReadinessBasis().getAutoConfigurationResult()));
+        areas.put(areaName, new AreaResult(entry.getValue().project, simulation, entry.getValue().configuration));
+        executedAreas.add(areaName);
       } catch (RuntimeException exception) {
         blockers.add("AREA_EXECUTION_FAILED:" + areaName + ":" + exception.getMessage());
       }
     }
-    List<Map<String, Object>> sharedStreams = sharedStreamDependencies(model);
-    return new Result(areas, sharedStreams, blockers);
+    List<Map<String, Object>> sharedSystemResults = evaluateSharedSystems(sharedSystemPolicy, areas, blockers);
+    return new Result(areas, sharedStreams, sharedSystemPolicy, sharedSystemResults, executedAreas, reusedAreas,
+        blockers, coordinationFingerprint);
+  }
+
+  private static final class PreparedArea {
+    private final EngineeringProject project;
+    private final EngineeringAutoConfigurator.Result configuration;
+
+    PreparedArea(EngineeringProject project, EngineeringAutoConfigurator.Result configuration) {
+      this.project = project;
+      this.configuration = configuration;
+    }
   }
 
   private static List<Map<String, Object>> sharedStreamDependencies(ProcessModel model) {
@@ -131,6 +203,12 @@ public final class ProcessModelEngineeringSimulator {
       row.put("invalidationRule", "CHANGE_INVALIDATES_ALL_CONNECTED_AREAS");
       result.add(row);
     }
+    Collections.sort(result, new Comparator<Map<String, Object>>() {
+      @Override
+      public int compare(Map<String, Object> left, Map<String, Object> right) {
+        return String.valueOf(left.get("stream")).compareTo(String.valueOf(right.get("stream")));
+      }
+    });
     return result;
   }
 
@@ -147,6 +225,92 @@ public final class ProcessModelEngineeringSimulator {
       }
       areas.add(areaName);
     }
+  }
+
+  private static List<Set<String>> dependencyGroups(List<Map<String, Object>> sharedStreams,
+      EngineeringSharedSystemPolicy policy) {
+    List<Set<String>> result = new ArrayList<Set<String>>();
+    for (Map<String, Object> sharedStream : sharedStreams) {
+      Set<String> group = new LinkedHashSet<String>();
+      Object areas = sharedStream.get("areas");
+      if (areas instanceof Iterable<?>) {
+        for (Object area : (Iterable<?>) areas) {
+          group.add(String.valueOf(area));
+        }
+      }
+      if (group.size() > 1) {
+        result.add(group);
+      }
+    }
+    for (EngineeringSharedSystemPolicy.Definition definition : policy.getDefinitions()) {
+      if (definition.getAreaNames().size() > 1) {
+        result.add(new LinkedHashSet<String>(definition.getAreaNames()));
+      }
+    }
+    return result;
+  }
+
+  private static void propagateInvalidation(Set<String> invalidatedAreas, List<Set<String>> groups) {
+    boolean changed;
+    do {
+      changed = false;
+      for (Set<String> group : groups) {
+        if (!Collections.disjoint(group, invalidatedAreas)) {
+          changed |= invalidatedAreas.addAll(group);
+        }
+      }
+    } while (changed);
+  }
+
+  private static List<Map<String, Object>> evaluateSharedSystems(EngineeringSharedSystemPolicy policy,
+      Map<String, AreaResult> areas, List<String> blockers) {
+    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    for (EngineeringSharedSystemPolicy.Definition definition : policy.getDefinitions()) {
+      Map<String, Object> row = new LinkedHashMap<String, Object>(definition.toMap());
+      List<Map<String, Object>> contributions = new ArrayList<Map<String, Object>>();
+      double simultaneousDemand = 0.0;
+      String commonUnit = "";
+      boolean valid = definition.getAreaNames().size() >= 2;
+      if (!valid) {
+        blockers.add("SHARED_SYSTEM_REQUIRES_AT_LEAST_TWO_DEMANDS:" + definition.getId());
+      }
+      for (EngineeringSharedSystemPolicy.Demand demand : definition.getDemands()) {
+        AreaResult area = areas.get(demand.getAreaName());
+        EngineeringDesignValue designValue = area == null || area.simulation.getEngineeringDesignLoopResult() == null
+            ? null
+            : area.simulation.getEngineeringDesignLoopResult().getState().getValues().get(demand.getDesignVariable());
+        if (designValue == null) {
+          blockers.add("SHARED_SYSTEM_DEMAND_NOT_AVAILABLE:" + definition.getId() + ":" + demand.getAreaName() + ":"
+              + demand.getDesignVariable());
+          valid = false;
+          continue;
+        }
+        if (commonUnit.isEmpty()) {
+          commonUnit = designValue.getUnit();
+        } else if (!commonUnit.equals(designValue.getUnit())) {
+          blockers.add("SHARED_SYSTEM_UNIT_MISMATCH:" + definition.getId());
+          valid = false;
+        }
+        double contribution = designValue.getValue() * demand.getSimultaneityFactor();
+        simultaneousDemand += contribution;
+        Map<String, Object> contributionRow = new LinkedHashMap<String, Object>(demand.toMap());
+        contributionRow.put("governingValue", Double.valueOf(designValue.getValue()));
+        contributionRow.put("unit", designValue.getUnit());
+        contributionRow.put("simultaneousContribution", Double.valueOf(contribution));
+        contributions.add(contributionRow);
+      }
+      row.put("contributions", contributions);
+      row.put("simultaneousDemand", valid ? Double.valueOf(simultaneousDemand) : null);
+      row.put("unit", commonUnit);
+      row.put("calculationStatus", valid ? "CALCULATED_REVIEW_REQUIRED" : "BLOCKED");
+      results.add(row);
+    }
+    return results;
+  }
+
+  private static String coordinationFingerprint(EngineeringSharedSystemPolicy policy,
+      List<Map<String, Object>> sharedStreams) {
+    return sha256(policy.fingerprintMaterial() + "|" + GSON.toJson(sharedStreams));
   }
 
   /** Immutable result for one area. */
@@ -179,15 +343,27 @@ public final class ProcessModelEngineeringSimulator {
   public static final class Result {
     private final Map<String, AreaResult> areas;
     private final List<Map<String, Object>> sharedStreamDependencies;
+    private final EngineeringSharedSystemPolicy sharedSystemPolicy;
+    private final List<Map<String, Object>> sharedSystemResults;
+    private final Set<String> executedAreas;
+    private final Set<String> reusedAreas;
     private final List<String> blockers;
+    private final String coordinationFingerprint;
     private final String fingerprint;
 
-    Result(Map<String, AreaResult> areas, List<Map<String, Object>> sharedStreamDependencies, List<String> blockers) {
+    Result(Map<String, AreaResult> areas, List<Map<String, Object>> sharedStreamDependencies,
+        EngineeringSharedSystemPolicy sharedSystemPolicy, List<Map<String, Object>> sharedSystemResults,
+        Set<String> executedAreas, Set<String> reusedAreas, List<String> blockers, String coordinationFingerprint) {
       this.areas = Collections.unmodifiableMap(new LinkedHashMap<String, AreaResult>(areas));
       this.sharedStreamDependencies = Collections
           .unmodifiableList(new ArrayList<Map<String, Object>>(sharedStreamDependencies));
+      this.sharedSystemPolicy = sharedSystemPolicy;
+      this.sharedSystemResults = Collections.unmodifiableList(new ArrayList<Map<String, Object>>(sharedSystemResults));
+      this.executedAreas = Collections.unmodifiableSet(new LinkedHashSet<String>(executedAreas));
+      this.reusedAreas = Collections.unmodifiableSet(new LinkedHashSet<String>(reusedAreas));
       this.blockers = Collections.unmodifiableList(new ArrayList<String>(blockers));
-      this.fingerprint = fingerprint(areas, sharedStreamDependencies);
+      this.coordinationFingerprint = coordinationFingerprint;
+      this.fingerprint = fingerprint(areas, sharedStreamDependencies, sharedSystemResults, coordinationFingerprint);
     }
 
     public boolean isComplete() {
@@ -206,12 +382,31 @@ public final class ProcessModelEngineeringSimulator {
       return sharedStreamDependencies;
     }
 
+    public List<Map<String, Object>> getSharedSystemResults() {
+      return sharedSystemResults;
+    }
+
+    public Set<String> getExecutedAreas() {
+      return executedAreas;
+    }
+
+    public Set<String> getReusedAreas() {
+      return reusedAreas;
+    }
+
+    public String getCoordinationFingerprint() {
+      return coordinationFingerprint;
+    }
+
     public String getFingerprint() {
       return fingerprint;
     }
 
     /** Compiles one governed package per area plus a process-model coordination manifest. */
     public Path compile(Path outputDirectory) throws IOException {
+      if (!isComplete()) {
+        throw new IllegalStateException("Cannot compile an incomplete multi-area engineering result: " + blockers);
+      }
       Files.createDirectories(outputDirectory);
       Map<String, Object> packages = new LinkedHashMap<String, Object>();
       for (Map.Entry<String, AreaResult> entry : areas.entrySet()) {
@@ -227,6 +422,20 @@ public final class ProcessModelEngineeringSimulator {
       }
       Map<String, Object> manifest = toMap();
       manifest.put("areaPackages", packages);
+      ProcessModelEngineeringPackageValidator.validateOrThrow(manifest);
+      Path schemaDirectory = outputDirectory.resolve("schemas");
+      Files.createDirectories(schemaDirectory);
+      Path schemaFile = schemaDirectory.resolve("process-model-engineering-manifest.schema.json");
+      InputStream schema = ProcessModelEngineeringSimulator.class.getResourceAsStream(
+          "/neqsim/process/engineering/schema/process-model-engineering-manifest.schema.json");
+      if (schema == null) {
+        throw new IOException("Bundled process-model engineering manifest schema is missing");
+      }
+      try {
+        Files.copy(schema, schemaFile, StandardCopyOption.REPLACE_EXISTING);
+      } finally {
+        schema.close();
+      }
       Path file = outputDirectory.resolve("process-model-engineering-manifest.json");
       Files.write(file, GSON.toJson(manifest).getBytes(StandardCharsets.UTF_8));
       return file;
@@ -235,10 +444,17 @@ public final class ProcessModelEngineeringSimulator {
     public Map<String, Object> toMap() {
       Map<String, Object> result = new LinkedHashMap<String, Object>();
       result.put("schemaVersion", "neqsim_process_model_engineering_manifest.v1");
+      result.put("schemaUri", "urn:neqsim:schema:process-model-engineering-manifest:v1");
       result.put("complete", Boolean.valueOf(isComplete()));
       result.put("blockers", blockers);
       result.put("fingerprint", fingerprint);
+      result.put("coordinationPolicyId", sharedSystemPolicy.getId());
+      result.put("coordinationPolicyRevision", sharedSystemPolicy.getRevision());
+      result.put("coordinationFingerprint", coordinationFingerprint);
+      result.put("executedAreas", new ArrayList<String>(executedAreas));
+      result.put("reusedAreas", new ArrayList<String>(reusedAreas));
       result.put("sharedStreamDependencies", sharedStreamDependencies);
+      result.put("sharedSystemResults", sharedSystemResults);
       Map<String, Object> areaRows = new LinkedHashMap<String, Object>();
       for (Map.Entry<String, AreaResult> entry : areas.entrySet()) {
         areaRows.put(entry.getKey(), entry.getValue().configuration.toMap());
@@ -250,15 +466,20 @@ public final class ProcessModelEngineeringSimulator {
     }
   }
 
-  private static String fingerprint(Map<String, AreaResult> areas, List<Map<String, Object>> sharedStreams) {
+  private static String fingerprint(Map<String, AreaResult> areas, List<Map<String, Object>> sharedStreams,
+      List<Map<String, Object>> sharedSystems, String coordinationFingerprint) {
     StringBuilder value = new StringBuilder();
     for (Map.Entry<String, AreaResult> entry : areas.entrySet()) {
       value.append(entry.getKey()).append(':').append(entry.getValue().configuration.getConfigurationFingerprint())
           .append(';');
     }
-    value.append(GSON.toJson(sharedStreams));
+    value.append(GSON.toJson(sharedStreams)).append(GSON.toJson(sharedSystems)).append(coordinationFingerprint);
+    return sha256(value.toString());
+  }
+
+  private static String sha256(String value) {
     try {
-      byte[] digest = MessageDigest.getInstance("SHA-256").digest(value.toString().getBytes(StandardCharsets.UTF_8));
+      byte[] digest = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
       StringBuilder hex = new StringBuilder();
       for (byte item : digest) {
         hex.append(String.format("%02x", item & 0xff));

--- a/src/main/java/neqsim/process/engineering/production/ProcessModelEngineeringSimulator.java
+++ b/src/main/java/neqsim/process/engineering/production/ProcessModelEngineeringSimulator.java
@@ -1,0 +1,271 @@
+package neqsim.process.engineering.production;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import neqsim.process.engineering.EngineeringProject;
+import neqsim.process.engineering.EngineeringSimulationResult;
+import neqsim.process.engineering.NorsokOffshoreEngineeringBuilder;
+import neqsim.process.engineering.ProcessToEngineeringSimulator;
+import neqsim.process.engineering.deliverables.EngineeringDeliverableCompiler;
+import neqsim.process.engineering.designcase.EngineeringDesignCase;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+
+/** Coordinates explicit process-to-engineering policies across every area in a {@link ProcessModel}. */
+public final class ProcessModelEngineeringSimulator {
+  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+  private ProcessModelEngineeringSimulator() {
+  }
+
+  /** Controlled configuration for one process area. */
+  public static final class AreaConfiguration implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final EngineeringAutoConfigurationPolicy policy;
+    private final List<EngineeringDesignCase> designCases = new ArrayList<EngineeringDesignCase>();
+    private boolean registerProposedInstruments;
+
+    public AreaConfiguration(EngineeringAutoConfigurationPolicy policy) {
+      if (policy == null) {
+        throw new IllegalArgumentException("policy must not be null");
+      }
+      this.policy = policy;
+    }
+
+    public AreaConfiguration addDesignCase(EngineeringDesignCase designCase) {
+      if (designCase == null) {
+        throw new IllegalArgumentException("designCase must not be null");
+      }
+      designCases.add(designCase);
+      return this;
+    }
+
+    public AreaConfiguration registerProposedInstruments(boolean value) {
+      registerProposedInstruments = value;
+      return this;
+    }
+  }
+
+  /** Runs every configured area and records conservative dependencies created by shared stream identities. */
+  public static Result run(String projectName, ProcessModel model, Map<String, AreaConfiguration> configurations,
+      int caseParallelism) {
+    if (projectName == null || projectName.trim().isEmpty() || model == null || configurations == null) {
+      throw new IllegalArgumentException("projectName, model and configurations are required");
+    }
+    Map<String, AreaResult> areas = new LinkedHashMap<String, AreaResult>();
+    List<String> blockers = new ArrayList<String>();
+    for (String areaName : model.getProcessSystemNames()) {
+      AreaConfiguration configuration = configurations.get(areaName);
+      if (configuration == null) {
+        blockers.add("MISSING_AREA_CONFIGURATION:" + areaName);
+        continue;
+      }
+      ProcessSystem process = model.get(areaName).copy();
+      EngineeringProject project = NorsokOffshoreEngineeringBuilder.from(projectName + " - " + areaName, process)
+          .projectId(projectName.replaceAll("[^A-Za-z0-9_-]", "-") + "-" + areaName)
+          .registerProposedInstruments(configuration.registerProposedInstruments).build();
+      for (EngineeringDesignCase designCase : configuration.designCases) {
+        project.addDesignCase(designCase);
+      }
+      try {
+        EngineeringSimulationResult simulation = ProcessToEngineeringSimulator.run(project, configuration.policy,
+            caseParallelism);
+        areas.put(areaName, new AreaResult(project, simulation,
+            project.getProductionReadinessBasis().getAutoConfigurationResult()));
+      } catch (RuntimeException exception) {
+        blockers.add("AREA_EXECUTION_FAILED:" + areaName + ":" + exception.getMessage());
+      }
+    }
+    List<Map<String, Object>> sharedStreams = sharedStreamDependencies(model);
+    return new Result(areas, sharedStreams, blockers);
+  }
+
+  private static List<Map<String, Object>> sharedStreamDependencies(ProcessModel model) {
+    Map<StreamInterface, Set<String>> producers = new IdentityHashMap<StreamInterface, Set<String>>();
+    Map<StreamInterface, Set<String>> consumers = new IdentityHashMap<StreamInterface, Set<String>>();
+    for (String areaName : model.getProcessSystemNames()) {
+      for (ProcessEquipmentInterface unit : model.get(areaName).getUnitOperations()) {
+        if (unit == null) {
+          continue;
+        }
+        addArea(producers, unit.getOutletStreams(), areaName);
+        addArea(consumers, unit.getInletStreams(), areaName);
+      }
+    }
+    List<Map<String, Object>> result = new ArrayList<Map<String, Object>>();
+    Set<StreamInterface> all = Collections.newSetFromMap(new IdentityHashMap<StreamInterface, Boolean>());
+    all.addAll(producers.keySet());
+    all.addAll(consumers.keySet());
+    for (StreamInterface stream : all) {
+      Set<String> sourceAreas = producers.containsKey(stream) ? producers.get(stream) : Collections.<String>emptySet();
+      Set<String> targetAreas = consumers.containsKey(stream) ? consumers.get(stream) : Collections.<String>emptySet();
+      Set<String> combined = new LinkedHashSet<String>();
+      combined.addAll(sourceAreas);
+      combined.addAll(targetAreas);
+      if (combined.size() < 2) {
+        continue;
+      }
+      Map<String, Object> row = new LinkedHashMap<String, Object>();
+      row.put("stream", stream.getName());
+      row.put("sourceAreas", new ArrayList<String>(sourceAreas));
+      row.put("targetAreas", new ArrayList<String>(targetAreas));
+      row.put("areas", new ArrayList<String>(combined));
+      row.put("coordinationStatus", "REVIEW_REQUIRED");
+      row.put("invalidationRule", "CHANGE_INVALIDATES_ALL_CONNECTED_AREAS");
+      result.add(row);
+    }
+    return result;
+  }
+
+  private static void addArea(Map<StreamInterface, Set<String>> target, List<StreamInterface> streams,
+      String areaName) {
+    for (StreamInterface stream : streams) {
+      if (stream == null) {
+        continue;
+      }
+      Set<String> areas = target.get(stream);
+      if (areas == null) {
+        areas = new LinkedHashSet<String>();
+        target.put(stream, areas);
+      }
+      areas.add(areaName);
+    }
+  }
+
+  /** Immutable result for one area. */
+  public static final class AreaResult {
+    private final EngineeringProject project;
+    private final EngineeringSimulationResult simulation;
+    private final EngineeringAutoConfigurator.Result configuration;
+
+    AreaResult(EngineeringProject project, EngineeringSimulationResult simulation,
+        EngineeringAutoConfigurator.Result configuration) {
+      this.project = project;
+      this.simulation = simulation;
+      this.configuration = configuration;
+    }
+
+    public EngineeringProject getProject() {
+      return project;
+    }
+
+    public EngineeringSimulationResult getSimulation() {
+      return simulation;
+    }
+
+    public EngineeringAutoConfigurator.Result getConfiguration() {
+      return configuration;
+    }
+  }
+
+  /** Coordinated multi-area result and package compiler. */
+  public static final class Result {
+    private final Map<String, AreaResult> areas;
+    private final List<Map<String, Object>> sharedStreamDependencies;
+    private final List<String> blockers;
+    private final String fingerprint;
+
+    Result(Map<String, AreaResult> areas, List<Map<String, Object>> sharedStreamDependencies, List<String> blockers) {
+      this.areas = Collections.unmodifiableMap(new LinkedHashMap<String, AreaResult>(areas));
+      this.sharedStreamDependencies = Collections
+          .unmodifiableList(new ArrayList<Map<String, Object>>(sharedStreamDependencies));
+      this.blockers = Collections.unmodifiableList(new ArrayList<String>(blockers));
+      this.fingerprint = fingerprint(areas, sharedStreamDependencies);
+    }
+
+    public boolean isComplete() {
+      return !areas.isEmpty() && blockers.isEmpty();
+    }
+
+    public Map<String, AreaResult> getAreas() {
+      return areas;
+    }
+
+    public List<String> getBlockers() {
+      return blockers;
+    }
+
+    public List<Map<String, Object>> getSharedStreamDependencies() {
+      return sharedStreamDependencies;
+    }
+
+    public String getFingerprint() {
+      return fingerprint;
+    }
+
+    /** Compiles one governed package per area plus a process-model coordination manifest. */
+    public Path compile(Path outputDirectory) throws IOException {
+      Files.createDirectories(outputDirectory);
+      Map<String, Object> packages = new LinkedHashMap<String, Object>();
+      for (Map.Entry<String, AreaResult> entry : areas.entrySet()) {
+        Path areaDirectory = outputDirectory.resolve(entry.getKey());
+        EngineeringDeliverableCompiler.CompilationResult compilation = EngineeringDeliverableCompiler
+            .compile(entry.getValue().project, areaDirectory);
+        Map<String, Object> packageRow = new LinkedHashMap<String, Object>();
+        packageRow.put("directory", entry.getKey());
+        packageRow.put("graph", outputDirectory.relativize(compilation.getEngineeringGraphFile()).toString());
+        packageRow.put("dexpi", outputDirectory.relativize(compilation.getDexpiResult().getDexpi20File()).toString());
+        packageRow.put("configurationFingerprint", entry.getValue().configuration.getConfigurationFingerprint());
+        packages.put(entry.getKey(), packageRow);
+      }
+      Map<String, Object> manifest = toMap();
+      manifest.put("areaPackages", packages);
+      Path file = outputDirectory.resolve("process-model-engineering-manifest.json");
+      Files.write(file, GSON.toJson(manifest).getBytes(StandardCharsets.UTF_8));
+      return file;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", "neqsim_process_model_engineering_manifest.v1");
+      result.put("complete", Boolean.valueOf(isComplete()));
+      result.put("blockers", blockers);
+      result.put("fingerprint", fingerprint);
+      result.put("sharedStreamDependencies", sharedStreamDependencies);
+      Map<String, Object> areaRows = new LinkedHashMap<String, Object>();
+      for (Map.Entry<String, AreaResult> entry : areas.entrySet()) {
+        areaRows.put(entry.getKey(), entry.getValue().configuration.toMap());
+      }
+      result.put("areas", areaRows);
+      result.put("governance",
+          "Shared-system concurrency, HAZOP/LOPA decisions and final discipline approvals remain controlled inputs");
+      return result;
+    }
+  }
+
+  private static String fingerprint(Map<String, AreaResult> areas, List<Map<String, Object>> sharedStreams) {
+    StringBuilder value = new StringBuilder();
+    for (Map.Entry<String, AreaResult> entry : areas.entrySet()) {
+      value.append(entry.getKey()).append(':').append(entry.getValue().configuration.getConfigurationFingerprint())
+          .append(';');
+    }
+    value.append(GSON.toJson(sharedStreams));
+    try {
+      byte[] digest = MessageDigest.getInstance("SHA-256").digest(value.toString().getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder();
+      for (byte item : digest) {
+        hex.append(String.format("%02x", item & 0xff));
+      }
+      return hex.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is required by the Java runtime", exception);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/ProcessModelEngineeringSimulator.java
+++ b/src/main/java/neqsim/process/engineering/production/ProcessModelEngineeringSimulator.java
@@ -70,8 +70,8 @@ public final class ProcessModelEngineeringSimulator {
   /** Runs every configured area and records conservative dependencies created by shared stream identities. */
   public static Result run(String projectName, ProcessModel model, Map<String, AreaConfiguration> configurations,
       int caseParallelism) {
-    return runIncremental(projectName, model, configurations,
-        new EngineeringSharedSystemPolicy("topology-only", "1"), null, caseParallelism);
+    return runIncremental(projectName, model, configurations, new EngineeringSharedSystemPolicy("topology-only", "1"),
+        null, caseParallelism);
   }
 
   /** Runs every area with explicit shared-system demand and concurrency inputs. */
@@ -426,8 +426,8 @@ public final class ProcessModelEngineeringSimulator {
       Path schemaDirectory = outputDirectory.resolve("schemas");
       Files.createDirectories(schemaDirectory);
       Path schemaFile = schemaDirectory.resolve("process-model-engineering-manifest.schema.json");
-      InputStream schema = ProcessModelEngineeringSimulator.class.getResourceAsStream(
-          "/neqsim/process/engineering/schema/process-model-engineering-manifest.schema.json");
+      InputStream schema = ProcessModelEngineeringSimulator.class
+          .getResourceAsStream("/neqsim/process/engineering/schema/process-model-engineering-manifest.schema.json");
       if (schema == null) {
         throw new IOException("Bundled process-model engineering manifest schema is missing");
       }

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidator.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidator.java
@@ -223,6 +223,11 @@ public final class EngineeringPackageValidator {
       requireArray(root, "actions", artifactName, report);
       requireString(root, "readinessLevel", artifactName, report);
       requireFalse(root, "fitnessForConstruction", artifactName, report);
+    } else if ("engineering-discipline-orchestration.json".equals(artifactName)) {
+      requireString(root, "projectId", artifactName, report);
+      requireString(root, "revision", artifactName, report);
+      requireString(root, "status", artifactName, report);
+      requireString(root, "governance", artifactName, report);
     }
     return report;
   }

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringSchemaCatalog.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringSchemaCatalog.java
@@ -33,6 +33,7 @@ public final class EngineeringSchemaCatalog {
   public static final String VALIDATION_REPORT = "neqsim_engineering_validation_report.v1";
   public static final String PRODUCTION_READINESS = "neqsim_engineering_production_readiness.v1";
   public static final String QUALIFICATION_PLAN = "neqsim_engineering_qualification_plan.v1";
+  public static final String DISCIPLINE_ORCHESTRATION = "neqsim_engineering_discipline_orchestration.v1";
 
   /** One immutable schema registration. */
   public static final class Definition {
@@ -106,6 +107,8 @@ public final class EngineeringSchemaCatalog {
         "engineering-production-readiness.schema.json"));
     values.add(definition("engineering-qualification-plan.json", QUALIFICATION_PLAN,
         "engineering-qualification-plan.schema.json"));
+    values.add(definition("engineering-discipline-orchestration.json", DISCIPLINE_ORCHESTRATION,
+        "engineering-discipline-orchestration.schema.json"));
     DEFINITIONS = Collections.unmodifiableList(values);
     Map<String, Definition> artifacts = new LinkedHashMap<String, Definition>();
     Map<String, Definition> versions = new LinkedHashMap<String, Definition>();

--- a/src/main/resources/neqsim/process/engineering/schema/engineering-discipline-orchestration.schema.json
+++ b/src/main/resources/neqsim/process/engineering/schema/engineering-discipline-orchestration.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:neqsim:schema:engineering-discipline-orchestration:v1",
+  "title": "NeqSim engineering discipline orchestration evidence",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "schemaUri",
+    "projectId",
+    "revision",
+    "configuration",
+    "status",
+    "governance"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "neqsim_engineering_discipline_orchestration.v1"},
+    "schemaUri": {"const": "urn:neqsim:schema:engineering-discipline-orchestration:v1"},
+    "projectId": {"type": "string", "minLength": 1},
+    "revision": {"type": "string", "minLength": 1},
+    "configuration": {"type": ["object", "null"]},
+    "status": {"enum": ["EXECUTED_REVIEW_REQUIRED", "NOT_EXECUTION_READY"]},
+    "governance": {"type": "string", "minLength": 1}
+  },
+  "additionalProperties": false
+}

--- a/src/main/resources/neqsim/process/engineering/schema/process-model-engineering-manifest.schema.json
+++ b/src/main/resources/neqsim/process/engineering/schema/process-model-engineering-manifest.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:neqsim:schema:process-model-engineering-manifest:v1",
+  "title": "NeqSim coordinated multi-area engineering package manifest",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "schemaUri",
+    "complete",
+    "blockers",
+    "fingerprint",
+    "coordinationPolicyId",
+    "coordinationPolicyRevision",
+    "coordinationFingerprint",
+    "executedAreas",
+    "reusedAreas",
+    "sharedStreamDependencies",
+    "sharedSystemResults",
+    "areas",
+    "areaPackages",
+    "governance"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "neqsim_process_model_engineering_manifest.v1"},
+    "schemaUri": {"const": "urn:neqsim:schema:process-model-engineering-manifest:v1"},
+    "complete": {"const": true},
+    "blockers": {"type": "array", "maxItems": 0},
+    "fingerprint": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "coordinationPolicyId": {"type": "string", "minLength": 1},
+    "coordinationPolicyRevision": {"type": "string", "minLength": 1},
+    "coordinationFingerprint": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "executedAreas": {"type": "array", "items": {"type": "string"}},
+    "reusedAreas": {"type": "array", "items": {"type": "string"}},
+    "sharedStreamDependencies": {"type": "array", "items": {"type": "object"}},
+    "sharedSystemResults": {"type": "array", "items": {"type": "object"}},
+    "areas": {"type": "object", "minProperties": 1},
+    "areaPackages": {"type": "object", "minProperties": 1},
+    "governance": {"type": "string", "minLength": 1}
+  },
+  "additionalProperties": false
+}

--- a/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
+++ b/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
@@ -152,8 +152,8 @@ class ProcessToEngineeringSimulatorTest {
     assertEquals(initial.getFingerprint(), unchanged.getFingerprint());
 
     Map<String, Object> manifest = new LinkedHashMap<String, Object>(unchanged.toMap());
-    manifest.put("areaPackages", Collections.singletonMap("compression", Collections.singletonMap("directory",
-        "compression")));
+    manifest.put("areaPackages",
+        Collections.singletonMap("compression", Collections.singletonMap("directory", "compression")));
     assertTrue(ProcessModelEngineeringPackageValidator.validate(manifest).isEmpty());
   }
 

--- a/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
+++ b/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
@@ -57,12 +57,11 @@ class ProcessToEngineeringSimulatorTest {
         new EngineeringAutoConfigurationPolicy("legacy-policy", "A").addInletCompressionExportSlice("INLET-SEP",
             "EXPORT-COMP", "EXPORT-LINE", "", "PIT-100"));
     assertFalse(hiddenDefaultConfiguration.isComplete());
-    assertEquals("CONFIGURATION_CHANGED",
+    assertEquals("CONFIGURATION_CHANGED", hiddenDefaultConfiguration
+        .compareWith(project.getProductionReadinessBasis().getAutoConfigurationResult()).getStatus());
+    assertFalse(
         hiddenDefaultConfiguration.compareWith(project.getProductionReadinessBasis().getAutoConfigurationResult())
-            .getStatus());
-    assertFalse(hiddenDefaultConfiguration
-        .compareWith(project.getProductionReadinessBasis().getAutoConfigurationResult()).getInvalidatedArtifacts()
-        .isEmpty());
+            .getInvalidatedArtifacts().isEmpty());
 
     assertNotNull(result.getEngineeringDesignLoopResult());
     assertTrue(result.getEngineeringDesignLoopResult().isConverged());
@@ -134,10 +133,9 @@ class ProcessToEngineeringSimulatorTest {
     ProcessModel model = new ProcessModel();
     model.add("compression", process());
     EngineeringAutoConfigurationPolicy policy = new EngineeringAutoConfigurationPolicy("offshore-gas", "A")
-        .addInletCompressionExportSlice("INLET-SEP", "EXPORT-COMP", "EXPORT-LINE", "", "PIT-100", 800.0, 0.107,
-            120.0, 25.0, 5.0, 0.10, 500.0, 1000.0, 2000.0, 3000.0, 5000.0, 7500.0, 10000.0);
-    Map<String, ProcessModelEngineeringSimulator.AreaConfiguration> configurations =
-        new LinkedHashMap<String, ProcessModelEngineeringSimulator.AreaConfiguration>();
+        .addInletCompressionExportSlice("INLET-SEP", "EXPORT-COMP", "EXPORT-LINE", "", "PIT-100", 800.0, 0.107, 120.0,
+            25.0, 5.0, 0.10, 500.0, 1000.0, 2000.0, 3000.0, 5000.0, 7500.0, 10000.0);
+    Map<String, ProcessModelEngineeringSimulator.AreaConfiguration> configurations = new LinkedHashMap<String, ProcessModelEngineeringSimulator.AreaConfiguration>();
     configurations.put("compression", new ProcessModelEngineeringSimulator.AreaConfiguration(policy)
         .addDesignCase(flowCase("normal", 8000.0, 10)).addDesignCase(flowCase("maximum", 12000.0, 20)));
     EngineeringSharedSystemPolicy coordination = new EngineeringSharedSystemPolicy("plant-coordination", "A");

--- a/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
+++ b/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
@@ -3,18 +3,22 @@ package neqsim.process.engineering;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import neqsim.process.engineering.deliverables.EngineeringDeliverableCompiler;
 import neqsim.process.engineering.designcase.EngineeringDesignCase;
 import neqsim.process.engineering.production.EngineeringAutoConfigurationPolicy;
 import neqsim.process.engineering.production.EngineeringAutoConfigurator;
+import neqsim.process.engineering.production.ProcessModelEngineeringSimulator;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.pipeline.AdiabaticPipe;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -40,10 +44,21 @@ class ProcessToEngineeringSimulatorTest {
             25.0, 5.0, 0.10, 500.0, 1000.0, 2000.0, 3000.0, 5000.0, 7500.0, 10000.0);
     EngineeringSimulationResult result = ProcessToEngineeringSimulator.run(project, policy, 2);
     assertTrue(project.getProductionReadinessBasis().getAutoConfigurationResult().isComplete());
+    assertTrue(project.getProductionReadinessBasis().getAutoConfigurationResult().isExecutionReady());
+    assertFalse(project.getProductionReadinessBasis().getAutoConfigurationResult().getModuleDependencies().isEmpty());
+    assertFalse(project.getProductionReadinessBasis().getAutoConfigurationResult().getEquipmentInventory().isEmpty());
+    assertEquals(64,
+        project.getProductionReadinessBasis().getAutoConfigurationResult().getConfigurationFingerprint().length());
     EngineeringAutoConfigurator.Result hiddenDefaultConfiguration = EngineeringAutoConfigurator.configure(project,
         new EngineeringAutoConfigurationPolicy("legacy-policy", "A").addInletCompressionExportSlice("INLET-SEP",
             "EXPORT-COMP", "EXPORT-LINE", "", "PIT-100"));
     assertFalse(hiddenDefaultConfiguration.isComplete());
+    assertEquals("CONFIGURATION_CHANGED",
+        hiddenDefaultConfiguration.compareWith(project.getProductionReadinessBasis().getAutoConfigurationResult())
+            .getStatus());
+    assertFalse(hiddenDefaultConfiguration
+        .compareWith(project.getProductionReadinessBasis().getAutoConfigurationResult()).getInvalidatedArtifacts()
+        .isEmpty());
 
     assertNotNull(result.getEngineeringDesignLoopResult());
     assertTrue(result.getEngineeringDesignLoopResult().isConverged());
@@ -62,6 +77,7 @@ class ProcessToEngineeringSimulatorTest {
         temporaryDirectory);
     assertTrue(Files.isRegularFile(compilation.getProductionReadinessFile()));
     assertTrue(Files.isRegularFile(compilation.getQualificationPlanFile()));
+    assertTrue(Files.isRegularFile(temporaryDirectory.resolve("engineering-discipline-orchestration.json")));
     String[] coordinatedArtifacts = new String[] { "process-design-basis.json", "equipment-datasheets.json",
         "valve-list.json", "io-list.json", "alarm-trip-schedule.json", "shutdown-narratives.json",
         "psv-datasheets.json", "flare-blowdown-report.json", "utility-summary.json", "materials-selection-report.json",
@@ -89,6 +105,24 @@ class ProcessToEngineeringSimulatorTest {
         Files.readAllBytes(temporaryDirectory.resolve("engineering-qualification-plan.json")), StandardCharsets.UTF_8);
     assertTrue(qualificationPlan.contains("\"externalEvidenceMayNotBeGeneratedBySimulator\": true"));
     assertTrue(qualificationPlan.contains("\"METHOD_BENCHMARK\""));
+  }
+
+  @Test
+  void failsClosedForImplicitDefaultsAndMissingAreaPolicies() {
+    EngineeringProject project = NorsokOffshoreEngineeringBuilder.from("Fail closed", process()).build();
+    project.addDesignCase(flowCase("normal", 8000.0, 10));
+    EngineeringAutoConfigurationPolicy implicit = new EngineeringAutoConfigurationPolicy("legacy", "A")
+        .addInletCompressionExportSlice("INLET-SEP", "EXPORT-COMP", "EXPORT-LINE", "", "PIT-100");
+    IllegalStateException exception = assertThrows(IllegalStateException.class,
+        () -> ProcessToEngineeringSimulator.run(project, implicit));
+    assertTrue(exception.getMessage().contains("HIDDEN_SCREENING_DEFAULTS_USED"));
+
+    ProcessModel model = new ProcessModel();
+    model.add("compression", process());
+    ProcessModelEngineeringSimulator.Result result = ProcessModelEngineeringSimulator.run("multi-area", model,
+        Collections.<String, ProcessModelEngineeringSimulator.AreaConfiguration>emptyMap(), 1);
+    assertFalse(result.isComplete());
+    assertTrue(result.getBlockers().contains("MISSING_AREA_CONFIGURATION:compression"));
   }
 
   private EngineeringDesignCase flowCase(String id, final double flowKgHr, int priority) {

--- a/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
+++ b/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
@@ -9,11 +9,15 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import neqsim.process.engineering.deliverables.EngineeringDeliverableCompiler;
 import neqsim.process.engineering.designcase.EngineeringDesignCase;
 import neqsim.process.engineering.production.EngineeringAutoConfigurationPolicy;
 import neqsim.process.engineering.production.EngineeringAutoConfigurator;
 import neqsim.process.engineering.production.ProcessModelEngineeringSimulator;
+import neqsim.process.engineering.production.EngineeringSharedSystemPolicy;
+import neqsim.process.engineering.production.ProcessModelEngineeringPackageValidator;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.pipeline.AdiabaticPipe;
 import neqsim.process.equipment.separator.Separator;
@@ -123,6 +127,36 @@ class ProcessToEngineeringSimulatorTest {
         Collections.<String, ProcessModelEngineeringSimulator.AreaConfiguration>emptyMap(), 1);
     assertFalse(result.isComplete());
     assertTrue(result.getBlockers().contains("MISSING_AREA_CONFIGURATION:compression"));
+  }
+
+  @Test
+  void reusesUnchangedAreaAndValidatesCoordinatedManifest() {
+    ProcessModel model = new ProcessModel();
+    model.add("compression", process());
+    EngineeringAutoConfigurationPolicy policy = new EngineeringAutoConfigurationPolicy("offshore-gas", "A")
+        .addInletCompressionExportSlice("INLET-SEP", "EXPORT-COMP", "EXPORT-LINE", "", "PIT-100", 800.0, 0.107,
+            120.0, 25.0, 5.0, 0.10, 500.0, 1000.0, 2000.0, 3000.0, 5000.0, 7500.0, 10000.0);
+    Map<String, ProcessModelEngineeringSimulator.AreaConfiguration> configurations =
+        new LinkedHashMap<String, ProcessModelEngineeringSimulator.AreaConfiguration>();
+    configurations.put("compression", new ProcessModelEngineeringSimulator.AreaConfiguration(policy)
+        .addDesignCase(flowCase("normal", 8000.0, 10)).addDesignCase(flowCase("maximum", 12000.0, 20)));
+    EngineeringSharedSystemPolicy coordination = new EngineeringSharedSystemPolicy("plant-coordination", "A");
+
+    ProcessModelEngineeringSimulator.Result initial = ProcessModelEngineeringSimulator.run("incremental", model,
+        configurations, coordination, 1);
+    assertTrue(initial.isComplete());
+    assertTrue(initial.getExecutedAreas().contains("compression"));
+    ProcessModelEngineeringSimulator.Result unchanged = ProcessModelEngineeringSimulator.runIncremental("incremental",
+        model, configurations, coordination, initial, 1);
+    assertTrue(unchanged.isComplete());
+    assertTrue(unchanged.getExecutedAreas().isEmpty());
+    assertTrue(unchanged.getReusedAreas().contains("compression"));
+    assertEquals(initial.getFingerprint(), unchanged.getFingerprint());
+
+    Map<String, Object> manifest = new LinkedHashMap<String, Object>(unchanged.toMap());
+    manifest.put("areaPackages", Collections.singletonMap("compression", Collections.singletonMap("directory",
+        "compression")));
+    assertTrue(ProcessModelEngineeringPackageValidator.validate(manifest).isEmpty());
   }
 
   private EngineeringDesignCase flowCase(String id, final double flowKgHr, int priority) {


### PR DESCRIPTION
## Summary

Adds the next production-hardening layers above the closed process-to-engineering simulator merged in #2460.

- makes explicit discipline auto-configuration fail closed before execution
- extracts recognized equipment coverage and simulated operating-state evidence
- records deterministic configuration fingerprints, module dependencies, blockers, and conservative revision invalidation
- adds coordinated multi-area `ProcessModelEngineeringSimulator` execution with one controlled policy/case set per area
- detects shared-stream area dependencies and compiles one governed package per area plus a root coordination manifest
- adds `EngineeringSharedSystemPolicy` for controlled utility, flare, blowdown, electrical, and shared-equipment demand/concurrency inputs
- calculates simultaneous shared-system demand from converged design variables and blocks missing variables, mixed units, or single-area definitions
- adds dependency-propagated `runIncremental` execution with explicit executed/reused area evidence
- adds a versioned root multi-area manifest schema and `ProcessModelEngineeringPackageValidator`
- embeds orchestration evidence in the canonical engineering graph and a schema-validated `engineering-discipline-orchestration.json` artifact
- corrects the explicit separator policy parameter to liquid density
- adds regression coverage, documentation, a notebook, and agent/skill guidance

## Engineering boundary

The implementation does not infer HAZOP/LOPA credibility, SIL/voting, final trip settings, valve failure positions, materials approval, relief/flare concurrency, vendor guarantees, or final engineering approval. Shared-system concurrency and simultaneity must be supplied with controlled project references and remain review-required.

## Validation

- Java 8-compatible main-source compilation completed using the JDK compiler against the existing project classes.
- Updated test source compiled successfully against the expanded API.
- Notebook and both new JSON schemas parse successfully.
- `git diff --check` passed.
- Smoke checks passed for missing area policy and missing executable case/module blockers.
- First GitHub run: CodeQL, skills/agents lint, and PaperLab gates passed.
- The first pre-commit failure was isolated to Spotless formatting; the reported corrections are included in commit 2.
- GitHub Actions is the authoritative full Maven, Spotless, test, and Javadoc matrix.
