### PR TITLE
Add controlled engineering production vertical slice

### DIFF
--- a/.github/agents/engineering.deliverables.agent.md
+++ b/.github/agents/engineering.deliverables.agent.md
@@ -53,6 +53,16 @@ infer SIL, final voting, trip set points, valve fail action, credible relief
 causes or shutdown effects solely from equipment class or a normal operating
 point.
 
+For the inlet-separation/compression/export production slice, run
+`ProductionVerticalSliceSimulator` with separate revision-controlled
+`EngineeringAutoConfigurationPolicy` and `InletCompressionExportSlicePolicy`
+objects. Require all nine gates in `engineering-vertical-slice-qualification.json`
+to pass before describing the result as a controlled pilot. A passing gate set
+is still not FEED-qualified, fit for construction, or finally approved. Configure
+the compressor map envelope explicitly with `addCompressorOperatingEnvelope`;
+missing surge/stonewall curves, case evidence, dynamic ESD response, or coupled
+relief/blowdown/flare results must remain blockers.
+
 When automatic discipline configuration is requested, require an explicit
 `EngineeringAutoConfigurationPolicy` for every recognized equipment item and
 every `ProcessModel` area. Stop on `isExecutionReady()==false`, report each

--- a/.github/skills/neqsim-pid-process-operations/SKILL.md
+++ b/.github/skills/neqsim-pid-process-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neqsim-pid-process-operations
-version: "1.6.0"
+version: "1.7.0"
 description: "Bidirectional P&ID/NeqSim workflow. USE WHEN: understanding P&ID symbols, converting P&ID topology into NeqSim simulations, generating governed DEXPI engineering packages from ProcessSystem or ProcessModel, linking tags to historian data, evaluating valve/equipment changes, or preparing water-hammer and blowdown/flare handoffs."
 last_verified: "2026-07-17"
 requires:
@@ -249,6 +249,17 @@ explicit no-hidden-default auto-configuration result, named-tool DEXPI
 round-trip evidence, approved safety-lifecycle evidence, three accepted pilots,
 and release-quality evidence. Even that level always retains
 `fitnessForConstruction=false` and does not grant final engineering approval.
+
+For the first complete inlet-separator/compressor/cooler/export facility slice,
+use `ProductionVerticalSliceSimulator` and inspect
+`engineering-vertical-slice-qualification.json`. Require the declared topology,
+ten case types, converged physical design, active compressor surge and
+stonewall curves, zero map extrapolation, executable dynamic safe-state tests,
+coupled PSV/blowdown/flare capacity, controlled standards and evidence. Add the
+map check through the revision-controlled policy with
+`addCompressorOperatingEnvelope`. Passing all vertical-slice gates means only a
+controlled pilot; never translate it to FEED approval or fitness for
+construction.
 
 Also inspect `engineering-qualification-plan.json`. Use its exact method keys
 and open actions to drive `EngineeringBenchmarkDataset`,

--- a/docs/integration/engineering-production-vertical-slice.md
+++ b/docs/integration/engineering-production-vertical-slice.md
@@ -1,0 +1,115 @@
+---
+title: "Controlled-pilot production vertical slice"
+description: "Qualify an inlet separator, compressor, cooler and export system without confusing simulator completion with engineering approval."
+---
+
+# Controlled-pilot production vertical slice
+
+`ProductionVerticalSliceSimulator` is the first fail-closed acceptance layer above the general
+process-to-engineering simulator. It targets one facility section:
+
+```text
+inlet separator -> compressor -> aftercooler -> export line
+                         |              |
+                         +-- recycle ---+
+
+with PCV, level valve, PSV, BDV, suction/discharge ESDVs and a flare connection
+```
+
+The simulator still supports arbitrary preliminary engineering modules. The vertical-slice layer adds a controlled
+topology and evidence contract so a partial model cannot accidentally be described as a completed production
+workflow.
+
+## Configure the run
+
+Declare the numerical design policy separately from the qualification policy. This keeps calculation limits,
+required process objects and external evidence independently revision-controlled.
+
+```java
+EngineeringAutoConfigurationPolicy designPolicy =
+    new EngineeringAutoConfigurationPolicy("compression-design", "A")
+        .addInletCompressionExportSlice(
+            "20-VA-001", "20-KA-001", "20-PL-001", "20-PV-001", "20-PIT-001",
+            800.0, 0.107, 120.0,       // separator basis
+            20.0, 0.5,                // line velocity and pressure-gradient limits
+            0.10,                     // driver margin
+            3000.0, 5000.0, 7500.0, 10000.0)
+        .addHeatExchanger("20-HA-001", 500.0, 25.0, 0.15,
+            50.0, 75.0, 100.0, 150.0, 250.0)
+        .addCompressorOperatingEnvelope("20-KA-001", 0.10, 0.05, 160.0, 0.10)
+        .addReliefDevice("20-PSV-001", "20-VA-001", requiredReliefAreaMetric,
+            0.110, 0.196, 0.307, 0.503, 0.785, 1.287, 1.838, 2.853);
+
+InletCompressionExportSlicePolicy qualificationPolicy =
+    InletCompressionExportSlicePolicy.builder("compression-pilot", "A")
+        .processTags("20-VA-001", "20-KA-001", "20-HA-001", "20-PL-001")
+        .controlTags("20-FV-001", "20-RECYCLE-001", "20-PV-001", "20-LV-001")
+        .safetyTags("20-PSV-001", "20-BDV-001", "20-ESDV-001", "20-ESDV-002",
+            "FLARE-HEADER-20")
+        .addRequiredDynamicScenario("compressor-trip-esd")
+        .addEvidenceReference("HAZOP-20-REV-A")
+        .build();
+
+ProductionVerticalSliceSimulator.Result result = ProductionVerticalSliceSimulator.runAndCompile(
+    project, designPolicy, qualificationPolicy, 4, outputDirectory, baselineGraph);
+```
+
+Every policy evidence reference must resolve to an `EngineeringEvidenceRecord` on the project. A reference string by
+itself does not pass the gate. The record must carry its revision, title, source organization and equipment or
+requirement link; lifecycle approval is assessed separately.
+
+Add all normal, minimum-turndown, maximum-production, start-up, shutdown, equipment-trip, settle-out,
+blocked-outlet, fire and blowdown cases to the project before running. Each case must have controlled scalar inputs
+and evidence references. Add the required executable dynamic scenario with
+`VerticalSliceDynamicScenarioFactory.emergencyShutdown(...)`, and attach the coupled relief/blowdown/flare studies
+selected by the approved hazard review.
+
+## Compressor map evidence
+
+`addCompressorOperatingEnvelope` runs the active compressor map across every case and records the operating point,
+head, speed, efficiency, surge margin, stonewall margin, control-line margin, required recycle fraction, recycle
+cooler duty, discharge temperature and extrapolation flag. The common design loop constrains the minimum margins,
+maximum temperature and map extrapolation. Changing these limits changes the automatic-configuration fingerprint and
+therefore invalidates dependent calculations and package artifacts.
+
+The module requires an active map, surge curve and stonewall curve. It does not qualify vendor guarantees, starting
+torque, rotor dynamics or the dynamic anti-surge controller. Those remain controlled vendor and project evidence.
+
+## Qualification gates
+
+The generated `engineering-vertical-slice-qualification.json` contains nine independent gates:
+
+1. complete process and safety topology;
+2. complete converged case matrix;
+3. converged closed design loop;
+4. required physical design variables;
+5. compressor map and anti-surge envelope;
+6. dynamic safe-state response;
+7. coupled relief, blowdown and flare capacity;
+8. versioned standards basis; and
+9. controlled engineering evidence.
+
+Missing data fails the relevant gate. The artifact is emitted even when the vertical-slice workflow was not
+configured, so downstream systems have an explicit `NOT_CONFIGURED` result instead of inferring success from an
+absent file.
+
+The design loop also detects an exact two-state oscillation in discrete candidates (for example alternate pipe sizes
+on successive iterations) and terminates with `DISCRETE_DESIGN_OSCILLATION_DETECTED` rather than exhausting the
+iteration count without a useful diagnosis.
+
+## Status boundary
+
+Passing all nine gates means only `qualifiedForControlledPilot=true`. It always retains:
+
+- `qualifiedForFeedSupport=false`;
+- `fitnessForConstruction=false`;
+- `finalEngineeringApprovalGranted=false`; and
+- `engineeringApprovalRequired=true`.
+
+Production method qualification remains governed by `EngineeringProductionReadinessAssessment`: independent
+benchmarks, named-tool DEXPI qualification, accepted pilots, approved safety-lifecycle evidence and release-quality
+evidence are separate requirements. HAZOP/LOPA/SRS decisions, scenario credibility, SIL, valve failure actions,
+materials approval, vendor selection and final shutdown actions cannot be manufactured by the simulator.
+
+See the [controlled-pilot notebook](../../examples/notebooks/engineering_vertical_slice_controlled_pilot.ipynb) for
+the executable API pattern.

--- a/docs/integration/process-to-engineering-simulator.md
+++ b/docs/integration/process-to-engineering-simulator.md
@@ -212,6 +212,11 @@ jurisdiction, service, company requirements, standard revisions and project phas
 
 ## Production-readiness qualification
 
+The first facility-level fail-closed acceptance layer is documented in
+[Controlled-pilot production vertical slice](engineering-production-vertical-slice.md). It qualifies the complete
+separator/compressor/cooler/export topology, case matrix, compressor map, dynamic safe state and coupled flare study
+before allowing `qualifiedForControlledPilot=true`; it never grants FEED, construction or final approval.
+
 Convergence and package validity are necessary, but they are not evidence that a calculation method or project is
 qualified for production engineering. Attach an `EngineeringProductionReadinessBasis` to the project to evaluate the
 additional controlled gates:

--- a/examples/notebooks/engineering_vertical_slice_controlled_pilot.ipynb
+++ b/examples/notebooks/engineering_vertical_slice_controlled_pilot.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Controlled-pilot engineering vertical slice\n",
+    "\n",
+    "This notebook demonstrates the new compressor case envelope and fail-closed production-slice qualification. It intentionally uses an incomplete safety topology so the final result shows actionable failed gates. Replace the synthetic inputs with controlled project cases, HAZOP/LOPA/SRS evidence, vendor maps and approved rules. A passing result qualifies only a controlled pilot; it is never construction approval.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, sys\n",
+    "from pathlib import Path\n",
+    "ROOT = Path(os.environ.get('NEQSIM_PROJECT_ROOT', Path.cwd())).resolve()\n",
+    "while not (ROOT / 'pom.xml').exists() and ROOT.parent != ROOT:\n",
+    "    ROOT = ROOT.parent\n",
+    "sys.path.insert(0, str(ROOT / 'devtools'))\n",
+    "from neqsim_dev_setup import neqsim_init, neqsim_classes\n",
+    "ns = neqsim_classes(neqsim_init(project_root=ROOT, recompile=not (ROOT / 'target/classes').exists(), verbose=False))\n",
+    "import jpype\n",
+    "JClass = ns.JClass\n",
+    "print('Loaded NeqSim from', ROOT)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Create the simulated inlet/compression/export core\n",
+    "\n",
+    "The compressor uses an explicit performance map plus surge and stonewall curves. The qualification policy later requires the cooler, recycle, valves and flare topology as well; omitting them here demonstrates that missing engineering cannot pass silently.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "System = JClass('neqsim.thermo.system.SystemSrkEos')\n",
+    "Stream = JClass('neqsim.process.equipment.stream.Stream')\n",
+    "Separator = JClass('neqsim.process.equipment.separator.Separator')\n",
+    "Compressor = JClass('neqsim.process.equipment.compressor.Compressor')\n",
+    "Pipe = JClass('neqsim.process.equipment.pipeline.AdiabaticPipe')\n",
+    "ProcessSystem = JClass('neqsim.process.processmodel.ProcessSystem')\n",
+    "SurgeCurve = JClass('neqsim.process.equipment.compressor.SafeSplineSurgeCurve')\n",
+    "StonewallCurve = JClass('neqsim.process.equipment.compressor.SafeSplineStoneWallCurve')\n",
+    "\n",
+    "fluid = System(300.0, 50.0)\n",
+    "fluid.addComponent('methane', 0.92); fluid.addComponent('ethane', 0.04); fluid.addComponent('n-heptane', 0.04)\n",
+    "fluid.setMixingRule('classic')\n",
+    "feed = Stream('FEED', fluid); feed.setFlowRate(8000.0, 'kg/hr')\n",
+    "separator = Separator('INLET-SEP', feed)\n",
+    "compressor = Compressor('EXPORT-COMP', separator.getGasOutStream())\n",
+    "compressor.setOutletPressure(80.0, 'bara'); compressor.setSpeed(10000.0)\n",
+    "line = Pipe('EXPORT-LINE', compressor.getOutletStream()); line.setLength(1000.0); line.setDiameter(0.2027)\n",
+    "process = ProcessSystem()\n",
+    "for unit in [feed, separator, compressor, line]: process.add(unit)\n",
+    "process.run()\n",
+    "\n",
+    "JDoubleArray = jpype.JArray(jpype.JDouble)\n",
+    "JDoubleMatrix = jpype.JArray(JDoubleArray)\n",
+    "compressor.getCompressorChart().setCurves(\n",
+    "    JDoubleArray([19.0, 300.0, 50.0, 0.90]), JDoubleArray([9000.0, 11000.0]),\n",
+    "    JDoubleMatrix([JDoubleArray([50.0, 100.0, 150.0]), JDoubleArray([70.0, 140.0, 210.0])]),\n",
+    "    JDoubleMatrix([JDoubleArray([75.0, 65.0, 50.0]), JDoubleArray([110.0, 95.0, 72.0])]),\n",
+    "    JDoubleMatrix([JDoubleArray([70.0, 79.0, 73.0]), JDoubleArray([71.0, 80.0, 74.0])]))\n",
+    "compressor.getCompressorChart().setSurgeCurve(SurgeCurve(JDoubleArray([42.0, 55.0, 70.0]), JDoubleArray([110.0, 90.0, 65.0])))\n",
+    "compressor.getCompressorChart().setStoneWallCurve(StonewallCurve(JDoubleArray([170.0, 195.0, 220.0]), JDoubleArray([110.0, 90.0, 65.0])))\n",
+    "compressor.getCompressorChart().setHeadUnit('kJ/kg'); compressor.getCompressorChart().setUseCompressorChart(True)\n",
+    "compressor.getAntiSurge().setActive(True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Declare controlled cases and policies\n",
+    "\n",
+    "JPype cannot conveniently implement the serializable Java case configurator inline. A production application should add all ten `EngineeringDesignCase` types with controlled inputs. This compact notebook reuses a Java-side helper pattern from the test suite; the policy API below is the important part.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Builder = JClass('neqsim.process.engineering.NorsokOffshoreEngineeringBuilder')\n",
+    "AutoPolicy = JClass('neqsim.process.engineering.production.EngineeringAutoConfigurationPolicy')\n",
+    "QualificationPolicy = JClass('neqsim.process.engineering.verticalslice.InletCompressionExportSlicePolicy')\n",
+    "project = Builder.from_('Controlled pilot example', process).projectId('compression-pilot').build()\n",
+    "\n",
+    "design_policy = (AutoPolicy('compression-design', 'A')\n",
+    "    .addInletCompressionExportSlice('INLET-SEP', 'EXPORT-COMP', 'EXPORT-LINE', '', 'PIT-100',\n",
+    "        800.0, 0.107, 120.0, 25.0, 5.0, 0.10, JDoubleArray([500.0, 1000.0, 2000.0, 5000.0, 10000.0]))\n",
+    "    .addCompressorOperatingEnvelope('EXPORT-COMP', 0.05, 0.05, 160.0, 0.10))\n",
+    "qualification_policy = (QualificationPolicy.builder('compression-pilot', 'A')\n",
+    "    .processTags('INLET-SEP', 'EXPORT-COMP', 'AFTERCOOLER', 'EXPORT-LINE')\n",
+    "    .controlTags('ASV', 'ASV-RECYCLE', 'PCV', 'LCV')\n",
+    "    .safetyTags('PSV', 'BDV', 'ESDV-SUCTION', 'ESDV-DISCHARGE', 'FLARE-CONNECTION')\n",
+    "    .addRequiredDynamicScenario('compressor-trip-esd')\n",
+    "    .addEvidenceReference('SYNTHETIC-HAZOP-REQUIRED').build())\n",
+    "print('Policies created:', design_policy.getId(), qualification_policy.getPolicyId())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Run, qualify and compile\n",
+    "\n",
+    "After adding the complete case matrix, dynamic scenario and coupled safety studies, call `ProductionVerticalSliceSimulator.runAndCompile(...)`. Inspect `getFailedGates()` and the generated `engineering-vertical-slice-qualification.json`. Never use the absence of an artifact as success: the compiler emits an explicit `NOT_CONFIGURED` qualification when this layer was not run.\n",
+    "\n",
+    "```java\n",
+    "ProductionVerticalSliceSimulator.Result result = ProductionVerticalSliceSimulator.runAndCompile(\n",
+    "    project, designPolicy, qualificationPolicy, 4, outputDirectory, baselineGraph);\n",
+    "System.out.println(result.getQualification().getFailedGates());\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Required interpretation\n",
+    "\n",
+    "A fully passing artifact sets only `qualifiedForControlledPilot=true`. `qualifiedForFeedSupport`, `fitnessForConstruction`, and `finalEngineeringApprovalGranted` remain false. Independent benchmarks, commercial DEXPI round trips, accepted pilots, safety-lifecycle approval and accountable engineering approval remain separate gates.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/main/java/neqsim/process/engineering/EngineeringProject.java
+++ b/src/main/java/neqsim/process/engineering/EngineeringProject.java
@@ -24,6 +24,7 @@ import neqsim.process.engineering.designcase.EngineeringDesignCase;
 import neqsim.process.engineering.designcase.EngineeringMetric;
 import neqsim.process.engineering.model.EngineeringCalculation;
 import neqsim.process.engineering.production.EngineeringProductionReadinessBasis;
+import neqsim.process.engineering.verticalslice.InletCompressionExportSliceQualification;
 import neqsim.process.materials.MaterialsReviewInput;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.process.safety.depressurization.DynamicBlowdownFlareStudyDataSource;
@@ -69,6 +70,7 @@ public final class EngineeringProject implements Serializable {
   private final Map<String, EmergencyShutdownTestResult> shutdownVerificationResults = new LinkedHashMap<String, EmergencyShutdownTestResult>();
   private MaterialsReviewInput materialsReviewInput;
   private EngineeringProductionReadinessBasis productionReadinessBasis;
+  private transient InletCompressionExportSliceQualification.Result latestVerticalSliceQualification;
 
   EngineeringProject(String name, ProcessSystem processSystem, EngineeringDesignBasis designBasis) {
     this(UUID.randomUUID().toString(), name, processSystem, designBasis);
@@ -151,6 +153,16 @@ public final class EngineeringProject implements Serializable {
   /** @return latest design-loop result, or null when the loop has not been run */
   public EngineeringDesignLoopResult getLatestEngineeringDesignLoopResult() {
     return latestEngineeringDesignLoopResult;
+  }
+
+  /** Records the latest fail-closed inlet/compression/export vertical-slice qualification. */
+  public void recordVerticalSliceQualification(InletCompressionExportSliceQualification.Result result) {
+    latestVerticalSliceQualification = result;
+  }
+
+  /** @return latest vertical-slice qualification, or null when it has not been executed */
+  public InletCompressionExportSliceQualification.Result getLatestVerticalSliceQualification() {
+    return latestVerticalSliceQualification;
   }
 
   /** @return project design basis */
@@ -751,6 +763,9 @@ public final class EngineeringProject implements Serializable {
     root.add("engineeringDesignModules", designModules);
     if (latestEngineeringDesignLoopResult != null) {
       root.add("latestEngineeringDesignLoop", gson.toJsonTree(latestEngineeringDesignLoopResult.toMap()));
+    }
+    if (latestVerticalSliceQualification != null) {
+      root.add("latestVerticalSliceQualification", gson.toJsonTree(latestVerticalSliceQualification.toMap()));
     }
     JsonArray calculationNodes = new JsonArray();
     for (EngineeringCalculation calculation : calculations) {

--- a/src/main/java/neqsim/process/engineering/ProcessToEngineeringDesignBuilder.java
+++ b/src/main/java/neqsim/process/engineering/ProcessToEngineeringDesignBuilder.java
@@ -142,8 +142,8 @@ public final class ProcessToEngineeringDesignBuilder {
 
   /** Adds compressor-map, surge, stonewall, anti-surge and discharge-temperature verification across every case. */
   public ProcessToEngineeringDesignBuilder addCompressorOperatingEnvelopeDesign(String compressorTag,
-      double minimumSurgeMarginFraction, double minimumStonewallMarginFraction,
-      double maximumDischargeTemperatureC, double surgeControlMarginFraction) {
+      double minimumSurgeMarginFraction, double minimumStonewallMarginFraction, double maximumDischargeTemperatureC,
+      double surgeControlMarginFraction) {
     requireUnit(compressorTag);
     addMetricIfMissing(EngineeringMetric.compressorPolytropicHead(compressorTag));
     addMetricIfMissing(EngineeringMetric.compressorSpeed(compressorTag));
@@ -155,9 +155,9 @@ public final class ProcessToEngineeringDesignBuilder {
     addMetricIfMissing(EngineeringMetric.compressorRecycleCoolerDuty(compressorTag));
     addMetricIfMissing(EngineeringMetric.compressorDischargeTemperature(compressorTag));
     addMetricIfMissing(EngineeringMetric.compressorChartExtrapolationFlag(compressorTag));
-    project.addEngineeringDesignModule(new CompressorOperatingEnvelopeDesignModule(compressorTag,
-        minimumSurgeMarginFraction, minimumStonewallMarginFraction, maximumDischargeTemperatureC,
-        surgeControlMarginFraction));
+    project.addEngineeringDesignModule(
+        new CompressorOperatingEnvelopeDesignModule(compressorTag, minimumSurgeMarginFraction,
+            minimumStonewallMarginFraction, maximumDischargeTemperatureC, surgeControlMarginFraction));
     return this;
   }
 

--- a/src/main/java/neqsim/process/engineering/ProcessToEngineeringDesignBuilder.java
+++ b/src/main/java/neqsim/process/engineering/ProcessToEngineeringDesignBuilder.java
@@ -3,6 +3,7 @@ package neqsim.process.engineering;
 import java.util.ArrayList;
 import java.util.List;
 import neqsim.process.engineering.design.modules.CompressorPackageDesignModule;
+import neqsim.process.engineering.design.modules.CompressorOperatingEnvelopeDesignModule;
 import neqsim.process.engineering.design.modules.ControlValveDesignModule;
 import neqsim.process.engineering.design.modules.InstrumentRangeAndResponseDesignModule;
 import neqsim.process.engineering.design.modules.HeatExchangerPreliminaryDesignModule;
@@ -136,6 +137,27 @@ public final class ProcessToEngineeringDesignBuilder {
     addMetricIfMissing(duty);
     project.addEngineeringDesignModule(new HeatExchangerPreliminaryDesignModule(equipmentTag, duty.getId(),
         overallHeatTransferCoefficientWPerM2K, correctedLmtdK, marginFraction, areaCandidatesM2));
+    return this;
+  }
+
+  /** Adds compressor-map, surge, stonewall, anti-surge and discharge-temperature verification across every case. */
+  public ProcessToEngineeringDesignBuilder addCompressorOperatingEnvelopeDesign(String compressorTag,
+      double minimumSurgeMarginFraction, double minimumStonewallMarginFraction,
+      double maximumDischargeTemperatureC, double surgeControlMarginFraction) {
+    requireUnit(compressorTag);
+    addMetricIfMissing(EngineeringMetric.compressorPolytropicHead(compressorTag));
+    addMetricIfMissing(EngineeringMetric.compressorSpeed(compressorTag));
+    addMetricIfMissing(EngineeringMetric.compressorPolytropicEfficiency(compressorTag));
+    addMetricIfMissing(EngineeringMetric.compressorSurgeMargin(compressorTag));
+    addMetricIfMissing(EngineeringMetric.compressorStonewallMargin(compressorTag));
+    addMetricIfMissing(EngineeringMetric.compressorControlLineMargin(compressorTag));
+    addMetricIfMissing(EngineeringMetric.compressorRequiredRecycleFraction(compressorTag));
+    addMetricIfMissing(EngineeringMetric.compressorRecycleCoolerDuty(compressorTag));
+    addMetricIfMissing(EngineeringMetric.compressorDischargeTemperature(compressorTag));
+    addMetricIfMissing(EngineeringMetric.compressorChartExtrapolationFlag(compressorTag));
+    project.addEngineeringDesignModule(new CompressorOperatingEnvelopeDesignModule(compressorTag,
+        minimumSurgeMarginFraction, minimumStonewallMarginFraction, maximumDischargeTemperatureC,
+        surgeControlMarginFraction));
     return this;
   }
 

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
@@ -69,6 +69,7 @@ public final class EngineeringDeliverableCompiler {
     private final Path lineRegisterFile;
     private final Path instrumentRegisterFile;
     private final Path productionReadinessFile;
+    private final Path verticalSliceQualificationFile;
     private final Path qualificationPlanFile;
     private final Path compilerManifestFile;
     private final Path validationReportFile;
@@ -82,10 +83,10 @@ public final class EngineeringDeliverableCompiler {
         Path engineeringCalculationDagFile, Path engineeringDesignCaseMatrixFile, Path engineeringDisciplinePackageFile,
         Path engineeringApprovalLedgerFile, Path engineeringDexpiRoundTripReportFile,
         Path engineeringAutomationPlanFile, Path designEnvelopeFile, Path equipmentRegisterFile, Path lineRegisterFile,
-        Path instrumentRegisterFile, Path productionReadinessFile, Path qualificationPlanFile,
-        Path compilerManifestFile, Path validationReportFile, Path revisionDiffFile, EngineeringGraph engineeringGraph,
-        EngineeringDesignEnvelope designEnvelope, DexpiEngineeringExporter.ExportResult dexpiResult,
-        EngineeringPackageValidationReport validationReport) {
+        Path instrumentRegisterFile, Path productionReadinessFile, Path verticalSliceQualificationFile,
+        Path qualificationPlanFile, Path compilerManifestFile, Path validationReportFile, Path revisionDiffFile,
+        EngineeringGraph engineeringGraph, EngineeringDesignEnvelope designEnvelope,
+        DexpiEngineeringExporter.ExportResult dexpiResult, EngineeringPackageValidationReport validationReport) {
       this.outputDirectory = outputDirectory;
       this.engineeringGraphFile = engineeringGraphFile;
       this.engineeringConnectivityFile = engineeringConnectivityFile;
@@ -100,6 +101,7 @@ public final class EngineeringDeliverableCompiler {
       this.lineRegisterFile = lineRegisterFile;
       this.instrumentRegisterFile = instrumentRegisterFile;
       this.productionReadinessFile = productionReadinessFile;
+      this.verticalSliceQualificationFile = verticalSliceQualificationFile;
       this.qualificationPlanFile = qualificationPlanFile;
       this.compilerManifestFile = compilerManifestFile;
       this.validationReportFile = validationReportFile;
@@ -164,6 +166,10 @@ public final class EngineeringDeliverableCompiler {
 
     public Path getProductionReadinessFile() {
       return productionReadinessFile;
+    }
+
+    public Path getVerticalSliceQualificationFile() {
+      return verticalSliceQualificationFile;
     }
 
     public Path getQualificationPlanFile() {
@@ -305,6 +311,8 @@ public final class EngineeringDeliverableCompiler {
     orchestration.put("governance",
         "Dependency completion does not replace HAZOP/LOPA, vendor validation or accountable approval");
     write(orchestrationFile, GSON.toJson(orchestration));
+    Path verticalSliceQualificationFile = outputDirectory.resolve("engineering-vertical-slice-qualification.json");
+    write(verticalSliceQualificationFile, GSON.toJson(verticalSliceQualification(project)));
     Path qualificationPlanFile = outputDirectory.resolve("engineering-qualification-plan.json");
     write(qualificationPlanFile,
         GSON.toJson(EngineeringQualificationPlan.build(project, project.getProductionReadinessBasis())));
@@ -322,8 +330,8 @@ public final class EngineeringDeliverableCompiler {
     DexpiEngineeringExporter.refreshPackageManifest(outputDirectory);
     return new CompilationResult(outputDirectory, graphFile, connectivityFile, calculationDagFile, designCaseMatrixFile,
         disciplinePackageFile, approvalLedgerFile, dexpiRoundTripReportFile, automationPlanFile, envelopeFile,
-        equipmentFile, lineFile, instrumentFile, productionReadinessFile, qualificationPlanFile, compilerManifest,
-        validationFile, diffFile, graph, envelope, dexpiResult, validation);
+        equipmentFile, lineFile, instrumentFile, productionReadinessFile, verticalSliceQualificationFile,
+        qualificationPlanFile, compilerManifest, validationFile, diffFile, graph, envelope, dexpiResult, validation);
   }
 
   private static void addDocumentNodes(EngineeringGraph graph, EngineeringProject project) {
@@ -340,7 +348,7 @@ public final class EngineeringDeliverableCompiler {
         "alarm-trip-schedule.json", "shutdown-narratives.json", "psv-datasheets.json", "flare-blowdown-report.json",
         "utility-summary.json", "materials-selection-report.json", "unresolved-engineering-actions.json",
         "revision-impact-report.json", "engineering-production-readiness.json", "engineering-qualification-plan.json",
-        "engineering-discipline-orchestration.json" };
+        "engineering-discipline-orchestration.json", "engineering-vertical-slice-qualification.json" };
     for (String document : documents) {
       String nodeId = EngineeringIds.nodeId(EngineeringNode.Kind.DOCUMENT, document);
       graph.addNode(new EngineeringNode(nodeId, EngineeringNode.Kind.DOCUMENT, document, document)
@@ -553,6 +561,7 @@ public final class EngineeringDeliverableCompiler {
     artifacts.add("engineering-schema-catalog.json");
     artifacts.add("engineering-validation-report.json");
     artifacts.add("engineering-discipline-orchestration.json");
+    artifacts.add("engineering-vertical-slice-qualification.json");
     artifacts.add("plant.dexpi.xml");
     artifacts.add("plant-proteus.xml");
     artifacts.add("plant-pydexpi.xml");
@@ -579,5 +588,31 @@ public final class EngineeringDeliverableCompiler {
 
   private static void write(Path file, String content) throws IOException {
     Files.write(file, content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static Map<String, Object> verticalSliceQualification(EngineeringProject project) {
+    if (project.getLatestVerticalSliceQualification() != null) {
+      return project.getLatestVerticalSliceQualification().toMap();
+    }
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", EngineeringSchemaCatalog.VERTICAL_SLICE_QUALIFICATION);
+    result.put("schemaUri", EngineeringSchemaCatalog.schemaUri(EngineeringSchemaCatalog.VERTICAL_SLICE_QUALIFICATION));
+    result.put("projectId", project.getProjectId());
+    result.put("projectRevision", project.getRevision());
+    result.put("policyId", "NOT_CONFIGURED");
+    result.put("policyRevision", "NOT_CONFIGURED");
+    Map<String, Object> gate = new LinkedHashMap<String, Object>();
+    gate.put("passed", Boolean.FALSE);
+    gate.put("findings", Collections.singletonList("Production vertical-slice qualification was not configured"));
+    gate.put("requiredAction", "Run ProductionVerticalSliceSimulator with a controlled acceptance policy");
+    result.put("gates", Collections.singletonMap("CONFIGURATION", gate));
+    result.put("failedGates", Collections.singletonList("CONFIGURATION"));
+    result.put("qualifiedForControlledPilot", Boolean.FALSE);
+    result.put("qualifiedForFeedSupport", Boolean.FALSE);
+    result.put("fitnessForConstruction", Boolean.FALSE);
+    result.put("finalEngineeringApprovalGranted", Boolean.FALSE);
+    result.put("engineeringApprovalRequired", Boolean.TRUE);
+    result.put("governance", "No vertical-slice qualification has been executed");
+    return result;
   }
 }

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignLoop.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignLoop.java
@@ -28,6 +28,7 @@ public final class EngineeringDesignLoop {
     ProcessSystem working = baseProcess.copy();
     EngineeringDesignState state = new EngineeringDesignState();
     List<EngineeringDesignIteration> iterations = new ArrayList<EngineeringDesignIteration>();
+    List<Map<String, Double>> designStateHistory = new ArrayList<Map<String, Double>>();
     Map<String, Double> previousProcessValues = null;
 
     for (int number = 1; number <= options.getMaximumIterations(); number++) {
@@ -74,6 +75,14 @@ public final class EngineeringDesignLoop {
       EngineeringDesignIteration iteration = new EngineeringDesignIteration(number, caseReport, moduleResults,
           constraintResults, appliedUpdates, maximumChange, designVariables, convergence);
       iterations.add(iteration);
+      Map<String, Double> currentDesignState = designStateValues(state);
+      if (options.isDiscreteOscillationDetectionEnabled() && appliedUpdates > 0 && designStateHistory.size() >= 2
+          && sameState(currentDesignState, designStateHistory.get(designStateHistory.size() - 2))
+          && !sameState(currentDesignState, designStateHistory.get(designStateHistory.size() - 1))) {
+        return new EngineeringDesignLoopResult(false, "DISCRETE_DESIGN_OSCILLATION_DETECTED", state, iterations,
+            working);
+      }
+      designStateHistory.add(currentDesignState);
       previousProcessValues = processValues;
       boolean constraintSuccess = !options.isAllConstraintsRequired() || iteration.areAllConstraintsSatisfied();
       if (appliedUpdates == 0 && processStable && caseSuccess && constraintSuccess) {
@@ -145,5 +154,26 @@ public final class EngineeringDesignLoop {
       }
     }
     return count;
+  }
+
+  private static Map<String, Double> designStateValues(EngineeringDesignState state) {
+    Map<String, Double> result = new java.util.LinkedHashMap<String, Double>();
+    for (Map.Entry<String, EngineeringDesignValue> entry : state.getValues().entrySet()) {
+      result.put(entry.getKey(), Double.valueOf(entry.getValue().getValue()));
+    }
+    return result;
+  }
+
+  private static boolean sameState(Map<String, Double> first, Map<String, Double> second) {
+    if (!first.keySet().equals(second.keySet())) {
+      return false;
+    }
+    for (Map.Entry<String, Double> entry : first.entrySet()) {
+      if (Double.doubleToLongBits(entry.getValue().doubleValue()) != Double
+          .doubleToLongBits(second.get(entry.getKey()).doubleValue())) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignLoopOptions.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignLoopOptions.java
@@ -10,6 +10,7 @@ public final class EngineeringDesignLoopOptions implements Serializable {
   private final boolean requireAllConstraints;
   private final double processValueRelativeTolerance;
   private final boolean requireStableProcessValues;
+  private final boolean detectDiscreteOscillation;
 
   private EngineeringDesignLoopOptions(Builder builder) {
     if (builder.maximumIterations < 1) {
@@ -26,6 +27,7 @@ public final class EngineeringDesignLoopOptions implements Serializable {
     }
     processValueRelativeTolerance = builder.processValueRelativeTolerance;
     requireStableProcessValues = builder.requireStableProcessValues;
+    detectDiscreteOscillation = builder.detectDiscreteOscillation;
   }
 
   public static Builder builder() {
@@ -52,12 +54,17 @@ public final class EngineeringDesignLoopOptions implements Serializable {
     return requireStableProcessValues;
   }
 
+  public boolean isDiscreteOscillationDetectionEnabled() {
+    return detectDiscreteOscillation;
+  }
+
   public static final class Builder {
     private int maximumIterations = 12;
     private int caseParallelism = 1;
     private boolean requireAllConstraints = true;
     private double processValueRelativeTolerance = 1.0e-4;
     private boolean requireStableProcessValues = true;
+    private boolean detectDiscreteOscillation = true;
 
     public Builder maximumIterations(int value) {
       maximumIterations = value;
@@ -81,6 +88,11 @@ public final class EngineeringDesignLoopOptions implements Serializable {
 
     public Builder requireStableProcessValues(boolean value) {
       requireStableProcessValues = value;
+      return this;
+    }
+
+    public Builder detectDiscreteOscillation(boolean value) {
+      detectDiscreteOscillation = value;
       return this;
     }
 

--- a/src/main/java/neqsim/process/engineering/design/modules/CompressorOperatingEnvelopeDesignModule.java
+++ b/src/main/java/neqsim/process/engineering/design/modules/CompressorOperatingEnvelopeDesignModule.java
@@ -1,0 +1,220 @@
+package neqsim.process.engineering.design.modules;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.engineering.calculation.EngineeringCalculationContext;
+import neqsim.process.engineering.design.EngineeringDesignConstraint;
+import neqsim.process.engineering.design.EngineeringDesignModule;
+import neqsim.process.engineering.design.EngineeringDesignModuleResult;
+import neqsim.process.engineering.design.EngineeringDesignState;
+import neqsim.process.engineering.design.EngineeringDesignUpdate;
+import neqsim.process.engineering.designcase.DesignCaseResult;
+import neqsim.process.engineering.designcase.EngineeringCaseRunReport;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.processmodel.ProcessSystem;
+
+/** Verifies a charted compressor operating envelope and anti-surge demand across every design case. */
+public final class CompressorOperatingEnvelopeDesignModule implements EngineeringDesignModule {
+  private static final long serialVersionUID = 1000L;
+  private final String compressorTag;
+  private final double minimumSurgeMarginFraction;
+  private final double minimumStonewallMarginFraction;
+  private final double maximumDischargeTemperatureC;
+  private final double surgeControlMarginFraction;
+
+  public CompressorOperatingEnvelopeDesignModule(String compressorTag, double minimumSurgeMarginFraction,
+      double minimumStonewallMarginFraction, double maximumDischargeTemperatureC,
+      double surgeControlMarginFraction) {
+    this.compressorTag = requireText(compressorTag, "compressorTag");
+    this.minimumSurgeMarginFraction = nonNegative(minimumSurgeMarginFraction, "minimumSurgeMarginFraction");
+    this.minimumStonewallMarginFraction = nonNegative(minimumStonewallMarginFraction,
+        "minimumStonewallMarginFraction");
+    this.maximumDischargeTemperatureC = finite(maximumDischargeTemperatureC, "maximumDischargeTemperatureC");
+    this.surgeControlMarginFraction = nonNegative(surgeControlMarginFraction, "surgeControlMarginFraction");
+  }
+
+  @Override
+  public String getId() {
+    return "35-compressor-operating-envelope-" + compressorTag;
+  }
+
+  @Override
+  public EngineeringDesignModuleResult evaluate(ProcessSystem process, EngineeringCaseRunReport caseReport,
+      EngineeringDesignState state, EngineeringCalculationContext context) {
+    if (!(process.getUnit(compressorTag) instanceof Compressor)) {
+      throw new IllegalArgumentException(compressorTag + " is not a Compressor");
+    }
+    Compressor compressor = (Compressor) process.getUnit(compressorTag);
+    if (compressor.getCompressorChart() == null || !compressor.getCompressorChart().isUseCompressorChart()) {
+      throw new IllegalStateException("A governed compressor chart is required for " + compressorTag);
+    }
+    if (compressor.getCompressorChart().getSurgeCurve() == null
+        || !compressor.getCompressorChart().getSurgeCurve().isActive()) {
+      throw new IllegalStateException("An active surge curve is required for " + compressorTag);
+    }
+    if (compressor.getCompressorChart().getStoneWallCurve() == null
+        || !compressor.getCompressorChart().getStoneWallCurve().isActive()) {
+      throw new IllegalStateException("An active stonewall curve is required for " + compressorTag);
+    }
+
+    String surgeMetric = compressorTag + ".surgeMargin";
+    String stonewallMetric = compressorTag + ".stonewallMargin";
+    String controlLineMetric = compressorTag + ".controlLineMargin";
+    String recycleMetric = compressorTag + ".requiredRecycleFraction";
+    String recycleDutyMetric = compressorTag + ".recycleCoolerDuty";
+    String temperatureMetric = compressorTag + ".dischargeTemperature";
+    String extrapolationMetric = compressorTag + ".chartExtrapolated";
+    String speedMetric = compressorTag + ".speed";
+    String headMetric = compressorTag + ".polytropicHead";
+    String efficiencyMetric = compressorTag + ".polytropicEfficiency";
+
+    CaseValue minimumSurge = minimum(caseReport, surgeMetric);
+    CaseValue minimumStonewall = minimum(caseReport, stonewallMetric);
+    CaseValue minimumControlLine = minimum(caseReport, controlLineMetric);
+    CaseValue maximumRecycle = maximum(caseReport, recycleMetric);
+    CaseValue maximumRecycleDuty = maximum(caseReport, recycleDutyMetric);
+    CaseValue maximumTemperature = maximum(caseReport, temperatureMetric);
+    CaseValue maximumExtrapolation = maximum(caseReport, extrapolationMetric);
+    CaseValue maximumSpeed = maximum(caseReport, speedMetric);
+    List<Map<String, Object>> operatingPoints = operatingPoints(caseReport, headMetric, speedMetric, efficiencyMetric,
+        surgeMetric, stonewallMetric, controlLineMetric, recycleMetric, temperatureMetric, extrapolationMetric);
+
+    String surgeKey = compressorTag + ".minimumSurgeMargin";
+    String stonewallKey = compressorTag + ".minimumStonewallMargin";
+    String controlLineKey = compressorTag + ".minimumControlLineMargin";
+    String recycleKey = compressorTag + ".maximumRequiredRecycleFraction";
+    String recycleDutyKey = compressorTag + ".maximumRecycleCoolerDuty";
+    String temperatureKey = compressorTag + ".maximumDischargeTemperature";
+    String extrapolationKey = compressorTag + ".chartExtrapolationCount";
+    String speedKey = compressorTag + ".maximumSpeed";
+    String controlMarginKey = compressorTag + ".surgeControlMargin";
+
+    return EngineeringDesignModuleResult
+        .builder(getId(), "Compressor map, surge, stonewall and anti-surge case-envelope verification", "2.0")
+        .addUpdate(EngineeringDesignUpdate.builder(controlMarginKey, surgeControlMarginFraction, "fraction")
+            .applier(new EngineeringDesignUpdate.Applier() {
+              private static final long serialVersionUID = 1000L;
+
+              @Override
+              public void apply(ProcessSystem working, double value) {
+                ((Compressor) working.getUnit(compressorTag)).setSurgeControlMargin(value);
+              }
+            }).build())
+        .addUpdate(EngineeringDesignUpdate.builder(surgeKey, minimumSurge.value, "fraction")
+            .governingCaseId(minimumSurge.caseId).build())
+        .addUpdate(EngineeringDesignUpdate.builder(stonewallKey, minimumStonewall.value, "fraction")
+            .governingCaseId(minimumStonewall.caseId).build())
+        .addUpdate(EngineeringDesignUpdate.builder(controlLineKey, minimumControlLine.value, "fraction")
+            .governingCaseId(minimumControlLine.caseId).build())
+        .addUpdate(EngineeringDesignUpdate.builder(recycleKey, maximumRecycle.value, "fraction")
+            .governingCaseId(maximumRecycle.caseId).build())
+        .addUpdate(EngineeringDesignUpdate.builder(recycleDutyKey, maximumRecycleDuty.value, "kW")
+            .governingCaseId(maximumRecycleDuty.caseId).build())
+        .addUpdate(EngineeringDesignUpdate.builder(temperatureKey, maximumTemperature.value, "C")
+            .governingCaseId(maximumTemperature.caseId).build())
+        .addUpdate(EngineeringDesignUpdate.builder(extrapolationKey, maximumExtrapolation.value, "flag")
+            .governingCaseId(maximumExtrapolation.caseId).build())
+        .addUpdate(EngineeringDesignUpdate.builder(speedKey, maximumSpeed.value, "rpm")
+            .governingCaseId(maximumSpeed.caseId).build())
+        .addConstraint(new EngineeringDesignConstraint(compressorTag + ".surge-margin",
+            "Minimum distance to surge line", surgeKey, minimumSurgeMarginFraction, "fraction",
+            EngineeringDesignConstraint.Comparison.MINIMUM))
+        .addConstraint(new EngineeringDesignConstraint(compressorTag + ".stonewall-margin",
+            "Minimum distance to stonewall/choke", stonewallKey, minimumStonewallMarginFraction, "fraction",
+            EngineeringDesignConstraint.Comparison.MINIMUM))
+        .addConstraint(new EngineeringDesignConstraint(compressorTag + ".chart-extrapolation",
+            "No compressor-map extrapolation", extrapolationKey, 0.0, "flag",
+            EngineeringDesignConstraint.Comparison.MAXIMUM))
+        .addConstraint(new EngineeringDesignConstraint(compressorTag + ".discharge-temperature",
+            "Maximum compressor discharge temperature", temperatureKey, maximumDischargeTemperatureC, "C",
+            EngineeringDesignConstraint.Comparison.MAXIMUM))
+        .evidence("operatingPoints", operatingPoints)
+        .evidence("surgeControlMarginFraction", Double.valueOf(surgeControlMarginFraction))
+        .warning("Vendor map, transient anti-surge response, driver starting and package guarantees require approval")
+        .build();
+  }
+
+  private static List<Map<String, Object>> operatingPoints(EngineeringCaseRunReport report, String... metricIds) {
+    List<Map<String, Object>> result = new ArrayList<Map<String, Object>>();
+    for (DesignCaseResult designCase : report.getEnvelope().getCaseResults()) {
+      if (!"CALCULATED".equals(designCase.getStatus())) {
+        continue;
+      }
+      Map<String, Object> point = new LinkedHashMap<String, Object>();
+      point.put("caseId", designCase.getDesignCase().getId());
+      point.put("caseType", designCase.getDesignCase().getType().name());
+      for (String metricId : metricIds) {
+        Double value = designCase.getValues().get(metricId);
+        if (value == null || !Double.isFinite(value.doubleValue())) {
+          throw new IllegalStateException("Missing finite compressor metric " + metricId + " for case "
+              + designCase.getDesignCase().getId());
+        }
+        point.put(metricId.substring(metricId.lastIndexOf('.') + 1), value);
+      }
+      result.add(point);
+    }
+    if (result.isEmpty()) {
+      throw new IllegalStateException("No calculated compressor operating points are available");
+    }
+    return result;
+  }
+
+  private static CaseValue minimum(EngineeringCaseRunReport report, String metricId) {
+    return extremum(report, metricId, false);
+  }
+
+  private static CaseValue maximum(EngineeringCaseRunReport report, String metricId) {
+    return extremum(report, metricId, true);
+  }
+
+  private static CaseValue extremum(EngineeringCaseRunReport report, String metricId, boolean maximum) {
+    CaseValue selected = null;
+    for (DesignCaseResult designCase : report.getEnvelope().getCaseResults()) {
+      Double value = designCase.getValues().get(metricId);
+      if (value == null || !Double.isFinite(value.doubleValue())) {
+        continue;
+      }
+      if (selected == null || maximum && value.doubleValue() > selected.value
+          || !maximum && value.doubleValue() < selected.value) {
+        selected = new CaseValue(designCase.getDesignCase().getId(), value.doubleValue());
+      }
+    }
+    if (selected == null) {
+      throw new IllegalStateException("No finite case value is available for " + metricId);
+    }
+    return selected;
+  }
+
+  private static final class CaseValue {
+    private final String caseId;
+    private final double value;
+
+    CaseValue(String caseId, double value) {
+      this.caseId = caseId;
+      this.value = value;
+    }
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double nonNegative(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and non-negative");
+    }
+    return value;
+  }
+
+  private static double finite(double value, String field) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(field + " must be finite");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/design/modules/CompressorOperatingEnvelopeDesignModule.java
+++ b/src/main/java/neqsim/process/engineering/design/modules/CompressorOperatingEnvelopeDesignModule.java
@@ -116,15 +116,15 @@ public final class CompressorOperatingEnvelopeDesignModule implements Engineerin
             .governingCaseId(maximumExtrapolation.caseId).build())
         .addUpdate(EngineeringDesignUpdate.builder(speedKey, maximumSpeed.value, "rpm")
             .governingCaseId(maximumSpeed.caseId).build())
-        .addConstraint(new EngineeringDesignConstraint(compressorTag + ".surge-margin",
-            "Minimum distance to surge line", surgeKey, minimumSurgeMarginFraction, "fraction",
-            EngineeringDesignConstraint.Comparison.MINIMUM))
+        .addConstraint(
+            new EngineeringDesignConstraint(compressorTag + ".surge-margin", "Minimum distance to surge line", surgeKey,
+                minimumSurgeMarginFraction, "fraction", EngineeringDesignConstraint.Comparison.MINIMUM))
         .addConstraint(new EngineeringDesignConstraint(compressorTag + ".stonewall-margin",
             "Minimum distance to stonewall/choke", stonewallKey, minimumStonewallMarginFraction, "fraction",
             EngineeringDesignConstraint.Comparison.MINIMUM))
-        .addConstraint(new EngineeringDesignConstraint(compressorTag + ".chart-extrapolation",
-            "No compressor-map extrapolation", extrapolationKey, 0.0, "flag",
-            EngineeringDesignConstraint.Comparison.MAXIMUM))
+        .addConstraint(
+            new EngineeringDesignConstraint(compressorTag + ".chart-extrapolation", "No compressor-map extrapolation",
+                extrapolationKey, 0.0, "flag", EngineeringDesignConstraint.Comparison.MAXIMUM))
         .addConstraint(new EngineeringDesignConstraint(compressorTag + ".discharge-temperature",
             "Maximum compressor discharge temperature", temperatureKey, maximumDischargeTemperatureC, "C",
             EngineeringDesignConstraint.Comparison.MAXIMUM))
@@ -146,8 +146,8 @@ public final class CompressorOperatingEnvelopeDesignModule implements Engineerin
       for (String metricId : metricIds) {
         Double value = designCase.getValues().get(metricId);
         if (value == null || !Double.isFinite(value.doubleValue())) {
-          throw new IllegalStateException("Missing finite compressor metric " + metricId + " for case "
-              + designCase.getDesignCase().getId());
+          throw new IllegalStateException(
+              "Missing finite compressor metric " + metricId + " for case " + designCase.getDesignCase().getId());
         }
         point.put(metricId.substring(metricId.lastIndexOf('.') + 1), value);
       }

--- a/src/main/java/neqsim/process/engineering/design/modules/CompressorOperatingEnvelopeDesignModule.java
+++ b/src/main/java/neqsim/process/engineering/design/modules/CompressorOperatingEnvelopeDesignModule.java
@@ -25,12 +25,10 @@ public final class CompressorOperatingEnvelopeDesignModule implements Engineerin
   private final double surgeControlMarginFraction;
 
   public CompressorOperatingEnvelopeDesignModule(String compressorTag, double minimumSurgeMarginFraction,
-      double minimumStonewallMarginFraction, double maximumDischargeTemperatureC,
-      double surgeControlMarginFraction) {
+      double minimumStonewallMarginFraction, double maximumDischargeTemperatureC, double surgeControlMarginFraction) {
     this.compressorTag = requireText(compressorTag, "compressorTag");
     this.minimumSurgeMarginFraction = nonNegative(minimumSurgeMarginFraction, "minimumSurgeMarginFraction");
-    this.minimumStonewallMarginFraction = nonNegative(minimumStonewallMarginFraction,
-        "minimumStonewallMarginFraction");
+    this.minimumStonewallMarginFraction = nonNegative(minimumStonewallMarginFraction, "minimumStonewallMarginFraction");
     this.maximumDischargeTemperatureC = finite(maximumDischargeTemperatureC, "maximumDischargeTemperatureC");
     this.surgeControlMarginFraction = nonNegative(surgeControlMarginFraction, "surgeControlMarginFraction");
   }

--- a/src/main/java/neqsim/process/engineering/designcase/EngineeringMetric.java
+++ b/src/main/java/neqsim/process/engineering/designcase/EngineeringMetric.java
@@ -172,6 +172,137 @@ public final class EngineeringMetric implements Serializable {
         });
   }
 
+  /** Creates a maximum compressor polytropic-head metric. */
+  public static EngineeringMetric compressorPolytropicHead(final String equipmentTag) {
+    return new EngineeringMetric(equipmentTag + ".polytropicHead", equipmentTag, "Compressor polytropic head",
+        "kJ/kg", GoverningDirection.MAXIMUM, new Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem process) {
+            return compressor(process, equipmentTag).getPolytropicFluidHead();
+          }
+        });
+  }
+
+  /** Creates a maximum compressor-speed metric. */
+  public static EngineeringMetric compressorSpeed(final String equipmentTag) {
+    return new EngineeringMetric(equipmentTag + ".speed", equipmentTag, "Compressor shaft speed", "rpm",
+        GoverningDirection.MAXIMUM, new Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem process) {
+            return compressor(process, equipmentTag).getSpeed();
+          }
+        });
+  }
+
+  /** Creates a minimum compressor polytropic-efficiency metric. */
+  public static EngineeringMetric compressorPolytropicEfficiency(final String equipmentTag) {
+    return new EngineeringMetric(equipmentTag + ".polytropicEfficiency", equipmentTag,
+        "Compressor polytropic efficiency", "fraction", GoverningDirection.MINIMUM, new Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem process) {
+            return compressor(process, equipmentTag).getPolytropicEfficiency();
+          }
+        });
+  }
+
+  /** Creates a minimum fractional distance to the compressor surge line. */
+  public static EngineeringMetric compressorSurgeMargin(final String equipmentTag) {
+    return new EngineeringMetric(equipmentTag + ".surgeMargin", equipmentTag, "Distance to surge line", "fraction",
+        GoverningDirection.MINIMUM, new Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem process) {
+            return compressor(process, equipmentTag).getDistanceToSurge();
+          }
+        });
+  }
+
+  /** Creates a minimum fractional distance to the compressor stonewall/choke limit. */
+  public static EngineeringMetric compressorStonewallMargin(final String equipmentTag) {
+    return new EngineeringMetric(equipmentTag + ".stonewallMargin", equipmentTag, "Distance to stonewall",
+        "fraction", GoverningDirection.MINIMUM, new Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem process) {
+            return compressor(process, equipmentTag).getDistanceToStoneWall();
+          }
+        });
+  }
+
+  /** Creates a minimum fractional distance to the configured anti-surge control line. */
+  public static EngineeringMetric compressorControlLineMargin(final String equipmentTag) {
+    return new EngineeringMetric(equipmentTag + ".controlLineMargin", equipmentTag,
+        "Distance to anti-surge control line", "fraction", GoverningDirection.MINIMUM, new Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem process) {
+            return compressor(process, equipmentTag).getDistanceToControlLine();
+          }
+        });
+  }
+
+  /** Creates a maximum compressor recycle fraction required to remain on the anti-surge control line. */
+  public static EngineeringMetric compressorRequiredRecycleFraction(final String equipmentTag) {
+    return new EngineeringMetric(equipmentTag + ".requiredRecycleFraction", equipmentTag,
+        "Required anti-surge recycle fraction", "fraction", GoverningDirection.MAXIMUM, new Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem process) {
+            return compressor(process, equipmentTag).getRequiredRecycleFractionToControlLine();
+          }
+        });
+  }
+
+  /** Creates a maximum recycle-cooler duty associated with anti-surge recycle. */
+  public static EngineeringMetric compressorRecycleCoolerDuty(final String equipmentTag) {
+    return new EngineeringMetric(equipmentTag + ".recycleCoolerDuty", equipmentTag,
+        "Anti-surge recycle cooler duty", "kW", GoverningDirection.MAXIMUM, new Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem process) {
+            Compressor compressor = compressor(process, equipmentTag);
+            return compressor.getAntiSurgeRecycleHeatDuty(compressor.getRequiredRecycleFractionToControlLine(), "kW");
+          }
+        });
+  }
+
+  /** Creates a maximum compressor-discharge-temperature metric. */
+  public static EngineeringMetric compressorDischargeTemperature(final String equipmentTag) {
+    return new EngineeringMetric(equipmentTag + ".dischargeTemperature", equipmentTag,
+        "Compressor discharge temperature", "C", GoverningDirection.MAXIMUM, new Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem process) {
+            return compressor(process, equipmentTag).getOutletStream().getTemperature("C");
+          }
+        });
+  }
+
+  /** Creates a numeric flag that is one when a compressor case extrapolates outside its map. */
+  public static EngineeringMetric compressorChartExtrapolationFlag(final String equipmentTag) {
+    return new EngineeringMetric(equipmentTag + ".chartExtrapolated", equipmentTag,
+        "Compressor chart extrapolation flag", "flag", GoverningDirection.MAXIMUM, new Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem process) {
+            return compressor(process, equipmentTag).isChartExtrapolated() ? 1.0 : 0.0;
+          }
+        });
+  }
+
   /** Creates a maximum outlet-volume-flow metric for one equipment outlet. */
   public static EngineeringMetric equipmentOutletVolumeFlow(final String equipmentTag, final int outletIndex,
       String outletName) {
@@ -349,6 +480,14 @@ public final class EngineeringMetric implements Serializable {
       throw new IllegalArgumentException("Unknown equipment " + equipmentTag);
     }
     return unit;
+  }
+
+  private static Compressor compressor(ProcessSystem process, String equipmentTag) {
+    ProcessEquipmentInterface equipment = requireUnit(process, equipmentTag);
+    if (!(equipment instanceof Compressor)) {
+      throw new IllegalArgumentException(equipmentTag + " is not a Compressor");
+    }
+    return (Compressor) equipment;
   }
 
   private static String requireText(String value, String field) {

--- a/src/main/java/neqsim/process/engineering/designcase/EngineeringMetric.java
+++ b/src/main/java/neqsim/process/engineering/designcase/EngineeringMetric.java
@@ -174,8 +174,8 @@ public final class EngineeringMetric implements Serializable {
 
   /** Creates a maximum compressor polytropic-head metric. */
   public static EngineeringMetric compressorPolytropicHead(final String equipmentTag) {
-    return new EngineeringMetric(equipmentTag + ".polytropicHead", equipmentTag, "Compressor polytropic head",
-        "kJ/kg", GoverningDirection.MAXIMUM, new Extractor() {
+    return new EngineeringMetric(equipmentTag + ".polytropicHead", equipmentTag, "Compressor polytropic head", "kJ/kg",
+        GoverningDirection.MAXIMUM, new Extractor() {
           private static final long serialVersionUID = 1000L;
 
           @Override
@@ -226,8 +226,8 @@ public final class EngineeringMetric implements Serializable {
 
   /** Creates a minimum fractional distance to the compressor stonewall/choke limit. */
   public static EngineeringMetric compressorStonewallMargin(final String equipmentTag) {
-    return new EngineeringMetric(equipmentTag + ".stonewallMargin", equipmentTag, "Distance to stonewall",
-        "fraction", GoverningDirection.MINIMUM, new Extractor() {
+    return new EngineeringMetric(equipmentTag + ".stonewallMargin", equipmentTag, "Distance to stonewall", "fraction",
+        GoverningDirection.MINIMUM, new Extractor() {
           private static final long serialVersionUID = 1000L;
 
           @Override
@@ -265,8 +265,8 @@ public final class EngineeringMetric implements Serializable {
 
   /** Creates a maximum recycle-cooler duty associated with anti-surge recycle. */
   public static EngineeringMetric compressorRecycleCoolerDuty(final String equipmentTag) {
-    return new EngineeringMetric(equipmentTag + ".recycleCoolerDuty", equipmentTag,
-        "Anti-surge recycle cooler duty", "kW", GoverningDirection.MAXIMUM, new Extractor() {
+    return new EngineeringMetric(equipmentTag + ".recycleCoolerDuty", equipmentTag, "Anti-surge recycle cooler duty",
+        "kW", GoverningDirection.MAXIMUM, new Extractor() {
           private static final long serialVersionUID = 1000L;
 
           @Override

--- a/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurationPolicy.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurationPolicy.java
@@ -65,6 +65,25 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
     }
   }
 
+  static final class CompressorEnvelopeRule implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    final String tag;
+    final double minimumSurgeMargin;
+    final double minimumStonewallMargin;
+    final double maximumDischargeTemperatureC;
+    final double surgeControlMargin;
+
+    CompressorEnvelopeRule(String tag, double minimumSurgeMargin, double minimumStonewallMargin,
+        double maximumDischargeTemperatureC, double surgeControlMargin) {
+      this.tag = text(tag, "compressorTag");
+      this.minimumSurgeMargin = nonNegative(minimumSurgeMargin, "minimumSurgeMarginFraction");
+      this.minimumStonewallMargin = nonNegative(minimumStonewallMargin, "minimumStonewallMarginFraction");
+      this.maximumDischargeTemperatureC = positive(maximumDischargeTemperatureC,
+          "maximumDischargeTemperatureC");
+      this.surgeControlMargin = nonNegative(surgeControlMargin, "surgeControlMarginFraction");
+    }
+  }
+
   static final class HeatExchangerRule implements Serializable {
     private static final long serialVersionUID = 1000L;
     final String tag;
@@ -141,6 +160,25 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
     }
   }
 
+  static final class ReliefDeviceRule implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    final String deviceTag;
+    final String protectedEquipmentTag;
+    final EngineeringMetric requiredAreaMetric;
+    final double[] orificeCandidatesIn2;
+
+    ReliefDeviceRule(String deviceTag, String protectedEquipmentTag, EngineeringMetric requiredAreaMetric,
+        double[] orificeCandidatesIn2) {
+      this.deviceTag = text(deviceTag, "deviceTag");
+      this.protectedEquipmentTag = text(protectedEquipmentTag, "protectedEquipmentTag");
+      if (requiredAreaMetric == null) {
+        throw new IllegalArgumentException("requiredAreaMetric must not be null");
+      }
+      this.requiredAreaMetric = requiredAreaMetric;
+      this.orificeCandidatesIn2 = positiveCandidates(orificeCandidatesIn2, "orificeCandidatesIn2");
+    }
+  }
+
   static final class NetworkRule implements Serializable {
     private static final long serialVersionUID = 1000L;
     final String id;
@@ -160,11 +198,13 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
   private final String id;
   private final String revision;
   private final List<SliceRule> slices = new ArrayList<SliceRule>();
+  private final List<CompressorEnvelopeRule> compressorEnvelopes = new ArrayList<CompressorEnvelopeRule>();
   private final List<PumpRule> pumps = new ArrayList<PumpRule>();
   private final List<HeatExchangerRule> exchangers = new ArrayList<HeatExchangerRule>();
   private final List<InventoryRule> inventories = new ArrayList<InventoryRule>();
   private final List<ControlValveRule> controlValves = new ArrayList<ControlValveRule>();
   private final List<RatedCapacityRule> ratedCapacities = new ArrayList<RatedCapacityRule>();
+  private final List<ReliefDeviceRule> reliefDevices = new ArrayList<ReliefDeviceRule>();
   private final List<NetworkRule> networks = new ArrayList<NetworkRule>();
 
   public EngineeringAutoConfigurationPolicy(String id, String revision) {
@@ -202,6 +242,15 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
     return this;
   }
 
+  /** Adds governed compressor-map and anti-surge envelope limits for every configured design case. */
+  public EngineeringAutoConfigurationPolicy addCompressorOperatingEnvelope(String compressorTag,
+      double minimumSurgeMarginFraction, double minimumStonewallMarginFraction,
+      double maximumDischargeTemperatureC, double surgeControlMarginFraction) {
+    compressorEnvelopes.add(new CompressorEnvelopeRule(compressorTag, minimumSurgeMarginFraction,
+        minimumStonewallMarginFraction, maximumDischargeTemperatureC, surgeControlMarginFraction));
+    return this;
+  }
+
   public EngineeringAutoConfigurationPolicy addHeatExchanger(String tag, double overallU, double correctedLmtdK,
       double marginFraction, double... areaCandidatesM2) {
     exchangers.add(new HeatExchangerRule(tag, overallU, correctedLmtdK, marginFraction, areaCandidatesM2));
@@ -223,6 +272,14 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
   public EngineeringAutoConfigurationPolicy addRatedCapacity(String tag, EngineeringMetric metric, String capacityName,
       String unit, double marginFraction, double... capacityCandidates) {
     ratedCapacities.add(new RatedCapacityRule(tag, metric, capacityName, unit, marginFraction, capacityCandidates));
+    return this;
+  }
+
+  /** Adds governed API-style discrete PSV-orifice selection to the automatic design loop. */
+  public EngineeringAutoConfigurationPolicy addReliefDevice(String deviceTag, String protectedEquipmentTag,
+      EngineeringMetric requiredAreaMetric, double... apiOrificeCandidatesIn2) {
+    reliefDevices.add(
+        new ReliefDeviceRule(deviceTag, protectedEquipmentTag, requiredAreaMetric, apiOrificeCandidatesIn2));
     return this;
   }
 
@@ -248,6 +305,10 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
     return Collections.unmodifiableList(pumps);
   }
 
+  List<CompressorEnvelopeRule> getCompressorEnvelopes() {
+    return Collections.unmodifiableList(compressorEnvelopes);
+  }
+
   List<HeatExchangerRule> getExchangers() {
     return Collections.unmodifiableList(exchangers);
   }
@@ -262,6 +323,10 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
 
   List<RatedCapacityRule> getRatedCapacities() {
     return Collections.unmodifiableList(ratedCapacities);
+  }
+
+  List<ReliefDeviceRule> getReliefDevices() {
+    return Collections.unmodifiableList(reliefDevices);
   }
 
   List<NetworkRule> getNetworks() {
@@ -284,6 +349,11 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
       value.append("|pump:").append(rule.tag).append(':').append(rule.margin).append(':')
           .append(rule.minimumNpshMarginM).append(':').append(java.util.Arrays.toString(rule.drivers));
     }
+    for (CompressorEnvelopeRule rule : compressorEnvelopes) {
+      value.append("|compressor-envelope:").append(rule.tag).append(':').append(rule.minimumSurgeMargin).append(':')
+          .append(rule.minimumStonewallMargin).append(':').append(rule.maximumDischargeTemperatureC).append(':')
+          .append(rule.surgeControlMargin);
+    }
     for (HeatExchangerRule rule : exchangers) {
       value.append("|exchanger:").append(rule.tag).append(':').append(rule.overallU).append(':').append(rule.lmtd)
           .append(':').append(rule.margin).append(':').append(java.util.Arrays.toString(rule.areas));
@@ -300,6 +370,11 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
       value.append("|capacity:").append(rule.tag).append(':').append(rule.metric.getId()).append(':')
           .append(rule.capacityName).append(':').append(rule.unit).append(':').append(rule.margin).append(':')
           .append(java.util.Arrays.toString(rule.candidates));
+    }
+    for (ReliefDeviceRule rule : reliefDevices) {
+      value.append("|relief:").append(rule.deviceTag).append(':').append(rule.protectedEquipmentTag).append(':')
+          .append(rule.requiredAreaMetric.getId()).append(':')
+          .append(java.util.Arrays.toString(rule.orificeCandidatesIn2));
     }
     for (NetworkRule rule : networks) {
       value.append("|network:").append(rule.id).append(':').append(rule.rulePack.toMap()).append(':');

--- a/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurationPolicy.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurationPolicy.java
@@ -243,8 +243,8 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
 
   /** Adds governed compressor-map and anti-surge envelope limits for every configured design case. */
   public EngineeringAutoConfigurationPolicy addCompressorOperatingEnvelope(String compressorTag,
-      double minimumSurgeMarginFraction, double minimumStonewallMarginFraction,
-      double maximumDischargeTemperatureC, double surgeControlMarginFraction) {
+      double minimumSurgeMarginFraction, double minimumStonewallMarginFraction, double maximumDischargeTemperatureC,
+      double surgeControlMarginFraction) {
     compressorEnvelopes.add(new CompressorEnvelopeRule(compressorTag, minimumSurgeMarginFraction,
         minimumStonewallMarginFraction, maximumDischargeTemperatureC, surgeControlMarginFraction));
     return this;

--- a/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurationPolicy.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurationPolicy.java
@@ -78,8 +78,7 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
       this.tag = text(tag, "compressorTag");
       this.minimumSurgeMargin = nonNegative(minimumSurgeMargin, "minimumSurgeMarginFraction");
       this.minimumStonewallMargin = nonNegative(minimumStonewallMargin, "minimumStonewallMarginFraction");
-      this.maximumDischargeTemperatureC = positive(maximumDischargeTemperatureC,
-          "maximumDischargeTemperatureC");
+      this.maximumDischargeTemperatureC = positive(maximumDischargeTemperatureC, "maximumDischargeTemperatureC");
       this.surgeControlMargin = nonNegative(surgeControlMargin, "surgeControlMarginFraction");
     }
   }

--- a/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurationPolicy.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurationPolicy.java
@@ -277,8 +277,8 @@ public final class EngineeringAutoConfigurationPolicy implements Serializable {
   /** Adds governed API-style discrete PSV-orifice selection to the automatic design loop. */
   public EngineeringAutoConfigurationPolicy addReliefDevice(String deviceTag, String protectedEquipmentTag,
       EngineeringMetric requiredAreaMetric, double... apiOrificeCandidatesIn2) {
-    reliefDevices.add(
-        new ReliefDeviceRule(deviceTag, protectedEquipmentTag, requiredAreaMetric, apiOrificeCandidatesIn2));
+    reliefDevices
+        .add(new ReliefDeviceRule(deviceTag, protectedEquipmentTag, requiredAreaMetric, apiOrificeCandidatesIn2));
     return this;
   }
 

--- a/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurator.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringAutoConfigurator.java
@@ -64,6 +64,13 @@ public final class EngineeringAutoConfigurator {
       }
       configuredTags.add(rule.tag);
     }
+    for (EngineeringAutoConfigurationPolicy.CompressorEnvelopeRule rule : policy.getCompressorEnvelopes()) {
+      if (!hasModule(project, "35-compressor-operating-envelope-" + rule.tag)) {
+        builder.addCompressorOperatingEnvelopeDesign(rule.tag, rule.minimumSurgeMargin, rule.minimumStonewallMargin,
+            rule.maximumDischargeTemperatureC, rule.surgeControlMargin);
+      }
+      configuredTags.add(rule.tag);
+    }
     for (EngineeringAutoConfigurationPolicy.HeatExchangerRule rule : policy.getExchangers()) {
       if (!configuredTags.contains(rule.tag)) {
         builder.addHeatExchangerDesign(rule.tag, rule.overallU, rule.lmtd, rule.margin, rule.areas);
@@ -87,6 +94,13 @@ public final class EngineeringAutoConfigurator {
         builder.addRatedCapacity(rule.tag, rule.metric, rule.capacityName, rule.unit, rule.margin, rule.candidates);
       }
       configuredTags.add(rule.tag);
+    }
+    for (EngineeringAutoConfigurationPolicy.ReliefDeviceRule rule : policy.getReliefDevices()) {
+      if (!hasModule(project, "55-relief-device-design-" + rule.deviceTag)) {
+        builder.addReliefDeviceDesign(rule.deviceTag, rule.protectedEquipmentTag, rule.requiredAreaMetric,
+            rule.orificeCandidatesIn2);
+      }
+      configuredTags.add(rule.deviceTag);
     }
     for (EngineeringAutoConfigurationPolicy.NetworkRule rule : policy.getNetworks()) {
       boolean missing = false;
@@ -148,6 +162,15 @@ public final class EngineeringAutoConfigurator {
       }
     }
     return result;
+  }
+
+  private static boolean hasModule(EngineeringProject project, String moduleId) {
+    for (EngineeringDesignModule module : project.getEngineeringDesignModules()) {
+      if (moduleId.equals(module.getId())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static Map<String, List<String>> dependencyGraph(List<EngineeringDesignModule> modules) {

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidator.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidator.java
@@ -24,7 +24,7 @@ public final class EngineeringPackageValidator {
   private static final Set<String> CONTROLLED_UNITS = new HashSet<String>(Arrays.asList("1", "%", "bara", "barg", "bar",
       "pa", "kpa", "mpa", "c", "k", "f", "kg/hr", "kg/s", "kg/day", "mol/s", "kmol/hr", "sm3/day", "msm3/day", "nm3/hr",
       "m3/hr", "m3/s", "kg/m3", "m/s", "bar/km", "w", "kw", "mw", "j/kg", "kj/kg", "m", "m2", "m3", "mm", "cm", "in",
-      "inch", "in2", "s", "min", "hr", "year", "fraction", "cv"));
+      "inch", "in2", "s", "min", "hr", "year", "fraction", "cv", "rpm", "flag"));
 
   private EngineeringPackageValidator() {
   }
@@ -228,6 +228,15 @@ public final class EngineeringPackageValidator {
       requireString(root, "revision", artifactName, report);
       requireString(root, "status", artifactName, report);
       requireString(root, "governance", artifactName, report);
+    } else if ("engineering-vertical-slice-qualification.json".equals(artifactName)) {
+      requireString(root, "projectId", artifactName, report);
+      requireString(root, "projectRevision", artifactName, report);
+      requireString(root, "policyId", artifactName, report);
+      requireString(root, "policyRevision", artifactName, report);
+      requireObject(root, "gates", artifactName, report);
+      requireArray(root, "failedGates", artifactName, report);
+      requireFalse(root, "fitnessForConstruction", artifactName, report);
+      requireFalse(root, "finalEngineeringApprovalGranted", artifactName, report);
     }
     return report;
   }

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringSchemaCatalog.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringSchemaCatalog.java
@@ -34,6 +34,7 @@ public final class EngineeringSchemaCatalog {
   public static final String PRODUCTION_READINESS = "neqsim_engineering_production_readiness.v1";
   public static final String QUALIFICATION_PLAN = "neqsim_engineering_qualification_plan.v1";
   public static final String DISCIPLINE_ORCHESTRATION = "neqsim_engineering_discipline_orchestration.v1";
+  public static final String VERTICAL_SLICE_QUALIFICATION = "neqsim_engineering_vertical_slice_qualification.v1";
 
   /** One immutable schema registration. */
   public static final class Definition {
@@ -109,6 +110,8 @@ public final class EngineeringSchemaCatalog {
         "engineering-qualification-plan.schema.json"));
     values.add(definition("engineering-discipline-orchestration.json", DISCIPLINE_ORCHESTRATION,
         "engineering-discipline-orchestration.schema.json"));
+    values.add(definition("engineering-vertical-slice-qualification.json", VERTICAL_SLICE_QUALIFICATION,
+        "engineering-vertical-slice-qualification.schema.json"));
     DEFINITIONS = Collections.unmodifiableList(values);
     Map<String, Definition> artifacts = new LinkedHashMap<String, Definition>();
     Map<String, Definition> versions = new LinkedHashMap<String, Definition>();

--- a/src/main/java/neqsim/process/engineering/verticalslice/InletCompressionExportSlicePolicy.java
+++ b/src/main/java/neqsim/process/engineering/verticalslice/InletCompressionExportSlicePolicy.java
@@ -1,0 +1,241 @@
+package neqsim.process.engineering.verticalslice;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import neqsim.process.engineering.designcase.EngineeringDesignCase;
+
+/** Controlled acceptance policy for the inlet-separator, compression, cooling and export vertical slice. */
+public final class InletCompressionExportSlicePolicy implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String policyId;
+  private final String revision;
+  private final String separatorTag;
+  private final String compressorTag;
+  private final String coolerTag;
+  private final String exportLineTag;
+  private final String recycleValveTag;
+  private final String recycleUnitTag;
+  private final String pressureControlValveTag;
+  private final String levelControlValveTag;
+  private final String reliefValveTag;
+  private final String blowdownValveTag;
+  private final String suctionEsdValveTag;
+  private final String dischargeEsdValveTag;
+  private final String flareConnectionTag;
+  private final Set<EngineeringDesignCase.Type> requiredCaseTypes;
+  private final Set<String> requiredDynamicScenarioIds;
+  private final Set<String> requiredStandards;
+  private final List<String> evidenceReferences;
+  private final boolean coupledReliefBlowdownFlareRequired;
+
+  private InletCompressionExportSlicePolicy(Builder builder) {
+    policyId = requireText(builder.policyId, "policyId");
+    revision = requireText(builder.revision, "revision");
+    separatorTag = requireText(builder.separatorTag, "separatorTag");
+    compressorTag = requireText(builder.compressorTag, "compressorTag");
+    coolerTag = requireText(builder.coolerTag, "coolerTag");
+    exportLineTag = requireText(builder.exportLineTag, "exportLineTag");
+    recycleValveTag = requireText(builder.recycleValveTag, "recycleValveTag");
+    recycleUnitTag = requireText(builder.recycleUnitTag, "recycleUnitTag");
+    pressureControlValveTag = requireText(builder.pressureControlValveTag, "pressureControlValveTag");
+    levelControlValveTag = requireText(builder.levelControlValveTag, "levelControlValveTag");
+    reliefValveTag = requireText(builder.reliefValveTag, "reliefValveTag");
+    blowdownValveTag = requireText(builder.blowdownValveTag, "blowdownValveTag");
+    suctionEsdValveTag = requireText(builder.suctionEsdValveTag, "suctionEsdValveTag");
+    dischargeEsdValveTag = requireText(builder.dischargeEsdValveTag, "dischargeEsdValveTag");
+    flareConnectionTag = requireText(builder.flareConnectionTag, "flareConnectionTag");
+    requiredCaseTypes = Collections.unmodifiableSet(EnumSet.copyOf(builder.requiredCaseTypes));
+    requiredDynamicScenarioIds = Collections
+        .unmodifiableSet(new LinkedHashSet<String>(builder.requiredDynamicScenarioIds));
+    requiredStandards = Collections.unmodifiableSet(new LinkedHashSet<String>(builder.requiredStandards));
+    evidenceReferences = Collections.unmodifiableList(new ArrayList<String>(builder.evidenceReferences));
+    coupledReliefBlowdownFlareRequired = builder.coupledReliefBlowdownFlareRequired;
+  }
+
+  public static Builder builder(String policyId, String revision) {
+    return new Builder(policyId, revision);
+  }
+
+  public String getPolicyId() {
+    return policyId;
+  }
+
+  public String getRevision() {
+    return revision;
+  }
+
+  public String getSeparatorTag() {
+    return separatorTag;
+  }
+
+  public String getCompressorTag() {
+    return compressorTag;
+  }
+
+  public String getCoolerTag() {
+    return coolerTag;
+  }
+
+  public String getExportLineTag() {
+    return exportLineTag;
+  }
+
+  public String getRecycleValveTag() {
+    return recycleValveTag;
+  }
+
+  public String getRecycleUnitTag() {
+    return recycleUnitTag;
+  }
+
+  public String getPressureControlValveTag() {
+    return pressureControlValveTag;
+  }
+
+  public String getLevelControlValveTag() {
+    return levelControlValveTag;
+  }
+
+  public String getReliefValveTag() {
+    return reliefValveTag;
+  }
+
+  public String getBlowdownValveTag() {
+    return blowdownValveTag;
+  }
+
+  public String getSuctionEsdValveTag() {
+    return suctionEsdValveTag;
+  }
+
+  public String getDischargeEsdValveTag() {
+    return dischargeEsdValveTag;
+  }
+
+  public String getFlareConnectionTag() {
+    return flareConnectionTag;
+  }
+
+  public Set<EngineeringDesignCase.Type> getRequiredCaseTypes() {
+    return requiredCaseTypes;
+  }
+
+  public Set<String> getRequiredDynamicScenarioIds() {
+    return requiredDynamicScenarioIds;
+  }
+
+  public Set<String> getRequiredStandards() {
+    return requiredStandards;
+  }
+
+  public List<String> getEvidenceReferences() {
+    return evidenceReferences;
+  }
+
+  public boolean isCoupledReliefBlowdownFlareRequired() {
+    return coupledReliefBlowdownFlareRequired;
+  }
+
+  /** Builder with the complete production vertical-slice case and standards basis enabled by default. */
+  public static final class Builder {
+    private final String policyId;
+    private final String revision;
+    private String separatorTag;
+    private String compressorTag;
+    private String coolerTag;
+    private String exportLineTag;
+    private String recycleValveTag;
+    private String recycleUnitTag;
+    private String pressureControlValveTag;
+    private String levelControlValveTag;
+    private String reliefValveTag;
+    private String blowdownValveTag;
+    private String suctionEsdValveTag;
+    private String dischargeEsdValveTag;
+    private String flareConnectionTag;
+    private final Set<EngineeringDesignCase.Type> requiredCaseTypes = EnumSet.of(EngineeringDesignCase.Type.NORMAL,
+        EngineeringDesignCase.Type.MINIMUM_TURNDOWN, EngineeringDesignCase.Type.MAXIMUM_PRODUCTION,
+        EngineeringDesignCase.Type.STARTUP, EngineeringDesignCase.Type.SHUTDOWN,
+        EngineeringDesignCase.Type.EQUIPMENT_TRIP, EngineeringDesignCase.Type.SETTLE_OUT,
+        EngineeringDesignCase.Type.BLOCKED_OUTLET, EngineeringDesignCase.Type.FIRE,
+        EngineeringDesignCase.Type.BLOWDOWN);
+    private final Set<String> requiredDynamicScenarioIds = new LinkedHashSet<String>();
+    private final Set<String> requiredStandards = new LinkedHashSet<String>();
+    private final List<String> evidenceReferences = new ArrayList<String>();
+    private boolean coupledReliefBlowdownFlareRequired = true;
+
+    private Builder(String policyId, String revision) {
+      this.policyId = policyId;
+      this.revision = revision;
+      Collections.addAll(requiredStandards, "DEXPI", "IEC 61511", "API 520", "API 521", "API 617", "API 670",
+          "ANSI/ISA-5.1", "NORSOK P-002", "NORSOK I-001", "NORSOK I-002", "NORSOK M-001");
+    }
+
+    public Builder processTags(String separator, String compressor, String cooler, String exportLine) {
+      separatorTag = separator;
+      compressorTag = compressor;
+      coolerTag = cooler;
+      exportLineTag = exportLine;
+      return this;
+    }
+
+    public Builder controlTags(String recycleValve, String recycleUnit, String pressureControlValve,
+        String levelControlValve) {
+      recycleValveTag = recycleValve;
+      recycleUnitTag = recycleUnit;
+      pressureControlValveTag = pressureControlValve;
+      levelControlValveTag = levelControlValve;
+      return this;
+    }
+
+    public Builder safetyTags(String reliefValve, String blowdownValve, String suctionEsdValve,
+        String dischargeEsdValve, String flareConnection) {
+      reliefValveTag = reliefValve;
+      blowdownValveTag = blowdownValve;
+      suctionEsdValveTag = suctionEsdValve;
+      dischargeEsdValveTag = dischargeEsdValve;
+      flareConnectionTag = flareConnection;
+      return this;
+    }
+
+    public Builder addRequiredDynamicScenario(String scenarioId) {
+      requiredDynamicScenarioIds.add(requireText(scenarioId, "scenarioId"));
+      return this;
+    }
+
+    public Builder addEvidenceReference(String reference) {
+      String normalized = requireText(reference, "evidenceReference");
+      if (!evidenceReferences.contains(normalized)) {
+        evidenceReferences.add(normalized);
+      }
+      return this;
+    }
+
+    public Builder coupledReliefBlowdownFlareRequired(boolean value) {
+      coupledReliefBlowdownFlareRequired = value;
+      return this;
+    }
+
+    public InletCompressionExportSlicePolicy build() {
+      if (requiredDynamicScenarioIds.isEmpty()) {
+        throw new IllegalStateException("At least one controlled dynamic scenario identifier is required");
+      }
+      if (evidenceReferences.isEmpty()) {
+        throw new IllegalStateException("Controlled HAZOP, map, cause-and-effect or design evidence is required");
+      }
+      return new InletCompressionExportSlicePolicy(this);
+    }
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/verticalslice/InletCompressionExportSliceQualification.java
+++ b/src/main/java/neqsim/process/engineering/verticalslice/InletCompressionExportSliceQualification.java
@@ -1,0 +1,370 @@
+package neqsim.process.engineering.verticalslice;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import neqsim.process.engineering.EngineeringEvidenceRecord;
+import neqsim.process.engineering.EngineeringProject;
+import neqsim.process.engineering.EngineeringSimulationResult;
+import neqsim.process.engineering.EngineeringStandard;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+import neqsim.process.engineering.design.EngineeringDesignLoopResult;
+import neqsim.process.engineering.design.EngineeringDesignState;
+import neqsim.process.engineering.designcase.DesignCaseResult;
+import neqsim.process.engineering.designcase.EngineeringDesignCase;
+import neqsim.process.engineering.validation.EngineeringSchemaCatalog;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.process.equipment.valve.BlowdownValve;
+import neqsim.process.equipment.valve.ESDValve;
+import neqsim.process.equipment.valve.SafetyReliefValve;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.safety.depressurization.CoupledReliefBlowdownFlareResult;
+import neqsim.process.safety.scenario.DynamicSafetyScenarioResult;
+
+/** Fail-closed qualification of the first complete process-to-engineering production vertical slice. */
+public final class InletCompressionExportSliceQualification {
+  private InletCompressionExportSliceQualification() {
+  }
+
+  public static Result qualify(EngineeringProject project, EngineeringSimulationResult simulation,
+      InletCompressionExportSlicePolicy policy) {
+    if (project == null || simulation == null || policy == null) {
+      throw new IllegalArgumentException("project, simulation and policy are required");
+    }
+    Map<String, Gate> gates = new LinkedHashMap<String, Gate>();
+    EngineeringDesignLoopResult loop = simulation.getEngineeringDesignLoopResult();
+    ProcessSystem process = loop == null ? project.getEngineeringProcessSystem() : loop.getDesignedProcess();
+
+    List<String> topologyFindings = topologyFindings(process, policy);
+    gates.put("COMPLETE_PROCESS_AND_SAFETY_TOPOLOGY", gate(topologyFindings.isEmpty(), topologyFindings,
+        "Add the separator, charted compressor, cooler, export line, recycle, PCV, LCV, PSV, BDV, ESDVs and flare connection"));
+
+    Set<EngineeringDesignCase.Type> presentTypes = EnumSet.noneOf(EngineeringDesignCase.Type.class);
+    List<String> failedCases = new ArrayList<String>();
+    if (simulation.getCaseRunReport() != null) {
+      for (DesignCaseResult designCase : simulation.getCaseRunReport().getEnvelope().getCaseResults()) {
+        presentTypes.add(designCase.getDesignCase().getType());
+        if (!designCase.isConverged() || !"CALCULATED".equals(designCase.getStatus())) {
+          failedCases.add(designCase.getDesignCase().getId() + ":" + designCase.getStatus());
+        }
+      }
+    }
+    Set<EngineeringDesignCase.Type> missingTypes = EnumSet.copyOf(policy.getRequiredCaseTypes());
+    missingTypes.removeAll(presentTypes);
+    List<String> caseFindings = new ArrayList<String>();
+    if (!missingTypes.isEmpty()) {
+      caseFindings.add("Missing case types " + missingTypes);
+    }
+    if (!failedCases.isEmpty()) {
+      caseFindings.add("Non-converged or failed cases " + failedCases);
+    }
+    gates.put("COMPLETE_CONVERGED_CASE_MATRIX", gate(caseFindings.isEmpty(), caseFindings,
+        "Run normal, turndown, maximum, startup, shutdown, trip, settle-out, blocked-outlet, fire and blowdown cases"));
+
+    gates.put("CLOSED_DESIGN_LOOP", gate(loop != null && loop.isConverged(),
+        singleton(loop == null ? "Engineering design loop was not executed" : loop.getTerminationReason()),
+        "Converge physical design variables, process values and constraints"));
+
+    List<String> missingVariables = missingDesignVariables(loop == null ? null : loop.getState(), policy);
+    gates.put("COUPLED_PHYSICAL_DESIGN", gate(missingVariables.isEmpty(), missingVariables,
+        "Size separator, compressor, cooler, piping, valves, relief, materials and mechanical design in the common loop"));
+
+    List<String> compressorFindings = compressorFindings(process, simulation, policy);
+    gates.put("COMPRESSOR_MAP_AND_ANTI_SURGE", gate(compressorFindings.isEmpty(), compressorFindings,
+        "Attach a vendor-supported map and verify surge, stonewall, extrapolation and recycle demand in every case"));
+
+    List<String> dynamicFindings = dynamicFindings(simulation, policy);
+    gates.put("DYNAMIC_SAFE_STATE_VERIFICATION", gate(dynamicFindings.isEmpty(), dynamicFindings,
+        "Execute the required anti-surge, trip, isolation and depressurization scenarios against response deadlines"));
+
+    List<String> reliefFindings = reliefFindings(simulation, policy);
+    gates.put("COUPLED_RELIEF_BLOWDOWN_FLARE", gate(reliefFindings.isEmpty(), reliefFindings,
+        "Couple credible PSV and blowdown loads to the flare network and close capacity constraints"));
+
+    List<String> standardsFindings = standardsFindings(project, policy);
+    gates.put("VERSIONED_STANDARDS_BASIS", gate(standardsFindings.isEmpty(), standardsFindings,
+        "Register the controlled international and NORSOK project editions"));
+
+    List<String> evidenceFindings = evidenceFindings(project, policy);
+    gates.put("CONTROLLED_ENGINEERING_EVIDENCE", gate(evidenceFindings.isEmpty(), evidenceFindings,
+        "Attach HAZOP, compressor map, cause-and-effect, relief, materials and calculation evidence"));
+
+    boolean passed = true;
+    for (Gate gate : gates.values()) {
+      passed &= gate.passed;
+    }
+    return new Result(project.getProjectId(), project.getRevision(), policy, gates, passed);
+  }
+
+  private static List<String> topologyFindings(ProcessSystem process, InletCompressionExportSlicePolicy policy) {
+    List<String> result = new ArrayList<String>();
+    requireType(process, policy.getSeparatorTag(), Separator.class, result);
+    requireType(process, policy.getCompressorTag(), Compressor.class, result);
+    requireType(process, policy.getCoolerTag(), Cooler.class, result);
+    ProcessEquipmentInterface line = process.getUnit(policy.getExportLineTag());
+    if (line == null || !line.getClass().getSimpleName().toLowerCase().contains("pipe")) {
+      result.add(policy.getExportLineTag() + " is missing or is not piping");
+    }
+    requireType(process, policy.getRecycleValveTag(), ThrottlingValve.class, result);
+    requireType(process, policy.getRecycleUnitTag(), Recycle.class, result);
+    requireType(process, policy.getPressureControlValveTag(), ThrottlingValve.class, result);
+    requireType(process, policy.getLevelControlValveTag(), ThrottlingValve.class, result);
+    requireType(process, policy.getReliefValveTag(), SafetyReliefValve.class, result);
+    requireType(process, policy.getBlowdownValveTag(), BlowdownValve.class, result);
+    requireType(process, policy.getSuctionEsdValveTag(), ESDValve.class, result);
+    requireType(process, policy.getDischargeEsdValveTag(), ESDValve.class, result);
+    if (process.getUnit(policy.getFlareConnectionTag()) == null) {
+      result.add(policy.getFlareConnectionTag() + " flare connection is missing");
+    }
+    return result;
+  }
+
+  private static void requireType(ProcessSystem process, String tag, Class<?> type, List<String> findings) {
+    Object value = process.getUnit(tag);
+    if (!type.isInstance(value)) {
+      findings.add(tag + " is missing or is not " + type.getSimpleName());
+    }
+  }
+
+  private static List<String> missingDesignVariables(EngineeringDesignState state,
+      InletCompressionExportSlicePolicy policy) {
+    List<String> required = new ArrayList<String>();
+    Collections.addAll(required, policy.getSeparatorTag() + ".insideDiameter",
+        policy.getSeparatorTag() + ".tangentLength", policy.getSeparatorTag() + ".liquidRetentionTime",
+        policy.getSeparatorTag() + ".designPressure", policy.getSeparatorTag() + ".proposedPsvSetPressure",
+        policy.getSeparatorTag() + ".minimumDesignMetalTemperature",
+        policy.getSeparatorTag() + ".preliminaryNominalWallThickness",
+        policy.getCompressorTag() + ".driverRatedPower", policy.getCompressorTag() + ".minimumSurgeMargin",
+        policy.getCompressorTag() + ".minimumStonewallMargin",
+        policy.getCompressorTag() + ".maximumRequiredRecycleFraction",
+        policy.getCompressorTag() + ".maximumRecycleCoolerDuty",
+        policy.getCoolerTag() + ".preliminaryHeatTransferArea", policy.getExportLineTag() + ".insideDiameter",
+        policy.getRecycleValveTag() + ".selectedCv", policy.getPressureControlValveTag() + ".selectedCv",
+        policy.getLevelControlValveTag() + ".selectedCv", policy.getReliefValveTag() + ".selectedOrificeArea");
+    List<String> missing = new ArrayList<String>();
+    for (String variable : required) {
+      if (state == null || !state.contains(variable)) {
+        missing.add(variable);
+      }
+    }
+    return missing;
+  }
+
+  private static List<String> compressorFindings(ProcessSystem process, EngineeringSimulationResult simulation,
+      InletCompressionExportSlicePolicy policy) {
+    List<String> result = new ArrayList<String>();
+    ProcessEquipmentInterface unit = process.getUnit(policy.getCompressorTag());
+    if (!(unit instanceof Compressor)) {
+      result.add("Compressor is not available");
+      return result;
+    }
+    Compressor compressor = (Compressor) unit;
+    if (compressor.getCompressorChart() == null || !compressor.getCompressorChart().isUseCompressorChart()) {
+      result.add("Compressor chart is not active");
+      return result;
+    }
+    if (compressor.getCompressorChart().getSurgeCurve() == null
+        || !compressor.getCompressorChart().getSurgeCurve().isActive()) {
+      result.add("Surge curve is not active");
+    }
+    if (compressor.getCompressorChart().getStoneWallCurve() == null
+        || !compressor.getCompressorChart().getStoneWallCurve().isActive()) {
+      result.add("Stonewall curve is not active");
+    }
+    if (simulation.getCaseRunReport() != null) {
+      String extrapolationMetric = policy.getCompressorTag() + ".chartExtrapolated";
+      for (DesignCaseResult designCase : simulation.getCaseRunReport().getEnvelope().getCaseResults()) {
+        Double extrapolated = designCase.getValues().get(extrapolationMetric);
+        if (extrapolated == null) {
+          result.add("Missing chart-extrapolation evidence for " + designCase.getDesignCase().getId());
+        } else if (extrapolated.doubleValue() > 0.5) {
+          result.add("Chart extrapolation in " + designCase.getDesignCase().getId());
+        }
+      }
+    }
+    return result;
+  }
+
+  private static List<String> dynamicFindings(EngineeringSimulationResult simulation,
+      InletCompressionExportSlicePolicy policy) {
+    Map<String, DynamicSafetyScenarioResult> results = new LinkedHashMap<String, DynamicSafetyScenarioResult>();
+    for (DynamicSafetyScenarioResult dynamic : simulation.getDynamicScenarioResults()) {
+      results.put(dynamic.getScenarioId(), dynamic);
+    }
+    List<String> findings = new ArrayList<String>();
+    for (String required : policy.getRequiredDynamicScenarioIds()) {
+      DynamicSafetyScenarioResult result = results.get(required);
+      if (result == null) {
+        findings.add("Missing dynamic scenario " + required);
+      } else if (!result.isPassed()) {
+        findings.add("Dynamic scenario failed " + required);
+      }
+    }
+    return findings;
+  }
+
+  private static List<String> reliefFindings(EngineeringSimulationResult simulation,
+      InletCompressionExportSlicePolicy policy) {
+    List<String> findings = new ArrayList<String>();
+    if (!policy.isCoupledReliefBlowdownFlareRequired()) {
+      return findings;
+    }
+    if (simulation.getCoupledSafetyResults().isEmpty()) {
+      findings.add("No coupled relief/blowdown/flare study was executed");
+      return findings;
+    }
+    for (EngineeringCalculationResult<CoupledReliefBlowdownFlareResult> calculation : simulation
+        .getCoupledSafetyResults()) {
+      if (calculation.getValue() == null || !calculation.getValue().isCapacityAcceptable()) {
+        findings.add("Coupled safety calculation is blocked, incomplete or over capacity");
+      }
+    }
+    return findings;
+  }
+
+  private static List<String> standardsFindings(EngineeringProject project,
+      InletCompressionExportSlicePolicy policy) {
+    Set<String> present = new LinkedHashSet<String>();
+    for (EngineeringStandard standard : project.getDesignBasis().getStandards()) {
+      present.add(standard.getCode());
+    }
+    List<String> missing = new ArrayList<String>();
+    for (String required : policy.getRequiredStandards()) {
+      boolean found = false;
+      for (String available : present) {
+        found |= available.equals(required) || available.startsWith(required + " ");
+      }
+      if (!found) {
+        missing.add(required);
+      }
+    }
+    return missing;
+  }
+
+  private static List<String> evidenceFindings(EngineeringProject project,
+      InletCompressionExportSlicePolicy policy) {
+    List<String> findings = new ArrayList<String>();
+    if (policy.getEvidenceReferences().isEmpty()) {
+      findings.add("No controlled evidence references were required by the policy");
+      return findings;
+    }
+    for (String required : policy.getEvidenceReferences()) {
+      EngineeringEvidenceRecord matched = null;
+      for (EngineeringEvidenceRecord evidence : project.getEvidenceRecords()) {
+        if (required.equals(evidence.getDocumentId())
+            || required.equals(evidence.getDocumentId() + "@" + evidence.getRevision())) {
+          matched = evidence;
+          break;
+        }
+      }
+      if (matched == null) {
+        findings.add("Missing controlled evidence record " + required);
+      } else if (!matched.getMissingFields().isEmpty()) {
+        findings.add("Incomplete controlled evidence record " + required + ": " + matched.getMissingFields());
+      }
+    }
+    return findings;
+  }
+
+  private static Gate gate(boolean passed, List<String> findings, String requiredAction) {
+    return new Gate(passed, findings, passed ? "NONE" : requiredAction);
+  }
+
+  private static List<String> singleton(String value) {
+    List<String> result = new ArrayList<String>();
+    if (value != null && !value.trim().isEmpty()) {
+      result.add(value);
+    }
+    return result;
+  }
+
+  private static final class Gate implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final boolean passed;
+    private final List<String> findings;
+    private final String requiredAction;
+
+    Gate(boolean passed, List<String> findings, String requiredAction) {
+      this.passed = passed;
+      this.findings = Collections.unmodifiableList(new ArrayList<String>(findings));
+      this.requiredAction = requiredAction;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("passed", Boolean.valueOf(passed));
+      result.put("findings", findings);
+      result.put("requiredAction", requiredAction);
+      return result;
+    }
+  }
+
+  /** Immutable vertical-slice qualification record. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String projectId;
+    private final String projectRevision;
+    private final InletCompressionExportSlicePolicy policy;
+    private final Map<String, Gate> gates;
+    private final boolean qualifiedForControlledPilot;
+
+    Result(String projectId, String projectRevision, InletCompressionExportSlicePolicy policy,
+        Map<String, Gate> gates, boolean qualifiedForControlledPilot) {
+      this.projectId = projectId;
+      this.projectRevision = projectRevision;
+      this.policy = policy;
+      this.gates = Collections.unmodifiableMap(new LinkedHashMap<String, Gate>(gates));
+      this.qualifiedForControlledPilot = qualifiedForControlledPilot;
+    }
+
+    public boolean isQualifiedForControlledPilot() {
+      return qualifiedForControlledPilot;
+    }
+
+    public List<String> getFailedGates() {
+      List<String> result = new ArrayList<String>();
+      for (Map.Entry<String, Gate> gate : gates.entrySet()) {
+        if (!gate.getValue().passed) {
+          result.add(gate.getKey());
+        }
+      }
+      return result;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", EngineeringSchemaCatalog.VERTICAL_SLICE_QUALIFICATION);
+      result.put("schemaUri",
+          EngineeringSchemaCatalog.schemaUri(EngineeringSchemaCatalog.VERTICAL_SLICE_QUALIFICATION));
+      result.put("projectId", projectId);
+      result.put("projectRevision", projectRevision);
+      result.put("policyId", policy.getPolicyId());
+      result.put("policyRevision", policy.getRevision());
+      Map<String, Object> gateMaps = new LinkedHashMap<String, Object>();
+      for (Map.Entry<String, Gate> gate : gates.entrySet()) {
+        gateMaps.put(gate.getKey(), gate.getValue().toMap());
+      }
+      result.put("gates", gateMaps);
+      result.put("failedGates", getFailedGates());
+      result.put("qualifiedForControlledPilot", Boolean.valueOf(qualifiedForControlledPilot));
+      result.put("qualifiedForFeedSupport", Boolean.FALSE);
+      result.put("fitnessForConstruction", Boolean.FALSE);
+      result.put("finalEngineeringApprovalGranted", Boolean.FALSE);
+      result.put("engineeringApprovalRequired", Boolean.TRUE);
+      result.put("governance",
+          "Passing the simulator gates qualifies a controlled pilot only; accountable engineering approval remains required");
+      return result;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/verticalslice/InletCompressionExportSliceQualification.java
+++ b/src/main/java/neqsim/process/engineering/verticalslice/InletCompressionExportSliceQualification.java
@@ -149,14 +149,13 @@ public final class InletCompressionExportSliceQualification {
         policy.getSeparatorTag() + ".tangentLength", policy.getSeparatorTag() + ".liquidRetentionTime",
         policy.getSeparatorTag() + ".designPressure", policy.getSeparatorTag() + ".proposedPsvSetPressure",
         policy.getSeparatorTag() + ".minimumDesignMetalTemperature",
-        policy.getSeparatorTag() + ".preliminaryNominalWallThickness",
-        policy.getCompressorTag() + ".driverRatedPower", policy.getCompressorTag() + ".minimumSurgeMargin",
-        policy.getCompressorTag() + ".minimumStonewallMargin",
+        policy.getSeparatorTag() + ".preliminaryNominalWallThickness", policy.getCompressorTag() + ".driverRatedPower",
+        policy.getCompressorTag() + ".minimumSurgeMargin", policy.getCompressorTag() + ".minimumStonewallMargin",
         policy.getCompressorTag() + ".maximumRequiredRecycleFraction",
-        policy.getCompressorTag() + ".maximumRecycleCoolerDuty",
-        policy.getCoolerTag() + ".preliminaryHeatTransferArea", policy.getExportLineTag() + ".insideDiameter",
-        policy.getRecycleValveTag() + ".selectedCv", policy.getPressureControlValveTag() + ".selectedCv",
-        policy.getLevelControlValveTag() + ".selectedCv", policy.getReliefValveTag() + ".selectedOrificeArea");
+        policy.getCompressorTag() + ".maximumRecycleCoolerDuty", policy.getCoolerTag() + ".preliminaryHeatTransferArea",
+        policy.getExportLineTag() + ".insideDiameter", policy.getRecycleValveTag() + ".selectedCv",
+        policy.getPressureControlValveTag() + ".selectedCv", policy.getLevelControlValveTag() + ".selectedCv",
+        policy.getReliefValveTag() + ".selectedOrificeArea");
     List<String> missing = new ArrayList<String>();
     for (String variable : required) {
       if (state == null || !state.contains(variable)) {
@@ -238,8 +237,7 @@ public final class InletCompressionExportSliceQualification {
     return findings;
   }
 
-  private static List<String> standardsFindings(EngineeringProject project,
-      InletCompressionExportSlicePolicy policy) {
+  private static List<String> standardsFindings(EngineeringProject project, InletCompressionExportSlicePolicy policy) {
     Set<String> present = new LinkedHashSet<String>();
     for (EngineeringStandard standard : project.getDesignBasis().getStandards()) {
       present.add(standard.getCode());
@@ -257,8 +255,7 @@ public final class InletCompressionExportSliceQualification {
     return missing;
   }
 
-  private static List<String> evidenceFindings(EngineeringProject project,
-      InletCompressionExportSlicePolicy policy) {
+  private static List<String> evidenceFindings(EngineeringProject project, InletCompressionExportSlicePolicy policy) {
     List<String> findings = new ArrayList<String>();
     if (policy.getEvidenceReferences().isEmpty()) {
       findings.add("No controlled evidence references were required by the policy");
@@ -324,8 +321,8 @@ public final class InletCompressionExportSliceQualification {
     private final Map<String, Gate> gates;
     private final boolean qualifiedForControlledPilot;
 
-    Result(String projectId, String projectRevision, InletCompressionExportSlicePolicy policy,
-        Map<String, Gate> gates, boolean qualifiedForControlledPilot) {
+    Result(String projectId, String projectRevision, InletCompressionExportSlicePolicy policy, Map<String, Gate> gates,
+        boolean qualifiedForControlledPilot) {
       this.projectId = projectId;
       this.projectRevision = projectRevision;
       this.policy = policy;

--- a/src/main/java/neqsim/process/engineering/verticalslice/InletCompressionExportSliceQualification.java
+++ b/src/main/java/neqsim/process/engineering/verticalslice/InletCompressionExportSliceQualification.java
@@ -47,8 +47,10 @@ public final class InletCompressionExportSliceQualification {
     ProcessSystem process = loop == null ? project.getEngineeringProcessSystem() : loop.getDesignedProcess();
 
     List<String> topologyFindings = topologyFindings(process, policy);
-    gates.put("COMPLETE_PROCESS_AND_SAFETY_TOPOLOGY", gate(topologyFindings.isEmpty(), topologyFindings,
-        "Add the separator, charted compressor, cooler, export line, recycle, PCV, LCV, PSV, BDV, ESDVs and flare connection"));
+    gates.put("COMPLETE_PROCESS_AND_SAFETY_TOPOLOGY",
+        gate(topologyFindings.isEmpty(), topologyFindings,
+            "Add the separator, charted compressor, cooler, export line, recycle, PCV, LCV, PSV, BDV, ESDVs "
+                + "and flare connection"));
 
     Set<EngineeringDesignCase.Type> presentTypes = EnumSet.noneOf(EngineeringDesignCase.Type.class);
     List<String> failedCases = new ArrayList<String>();
@@ -77,8 +79,10 @@ public final class InletCompressionExportSliceQualification {
         "Converge physical design variables, process values and constraints"));
 
     List<String> missingVariables = missingDesignVariables(loop == null ? null : loop.getState(), policy);
-    gates.put("COUPLED_PHYSICAL_DESIGN", gate(missingVariables.isEmpty(), missingVariables,
-        "Size separator, compressor, cooler, piping, valves, relief, materials and mechanical design in the common loop"));
+    gates.put("COUPLED_PHYSICAL_DESIGN",
+        gate(missingVariables.isEmpty(), missingVariables,
+            "Size separator, compressor, cooler, piping, valves, relief, materials and mechanical design in the "
+                + "common loop"));
 
     List<String> compressorFindings = compressorFindings(process, simulation, policy);
     gates.put("COMPRESSOR_MAP_AND_ANTI_SURGE", gate(compressorFindings.isEmpty(), compressorFindings,
@@ -362,8 +366,8 @@ public final class InletCompressionExportSliceQualification {
       result.put("fitnessForConstruction", Boolean.FALSE);
       result.put("finalEngineeringApprovalGranted", Boolean.FALSE);
       result.put("engineeringApprovalRequired", Boolean.TRUE);
-      result.put("governance",
-          "Passing the simulator gates qualifies a controlled pilot only; accountable engineering approval remains required");
+      result.put("governance", "Passing the simulator gates qualifies a controlled pilot only; accountable "
+          + "engineering approval remains required");
       return result;
     }
   }

--- a/src/main/java/neqsim/process/engineering/verticalslice/InletCompressionExportSliceQualification.java
+++ b/src/main/java/neqsim/process/engineering/verticalslice/InletCompressionExportSliceQualification.java
@@ -74,9 +74,10 @@ public final class InletCompressionExportSliceQualification {
     gates.put("COMPLETE_CONVERGED_CASE_MATRIX", gate(caseFindings.isEmpty(), caseFindings,
         "Run normal, turndown, maximum, startup, shutdown, trip, settle-out, blocked-outlet, fire and blowdown cases"));
 
-    gates.put("CLOSED_DESIGN_LOOP", gate(loop != null && loop.isConverged(),
-        singleton(loop == null ? "Engineering design loop was not executed" : loop.getTerminationReason()),
-        "Converge physical design variables, process values and constraints"));
+    gates.put("CLOSED_DESIGN_LOOP",
+        gate(loop != null && loop.isConverged(),
+            singleton(loop == null ? "Engineering design loop was not executed" : loop.getTerminationReason()),
+            "Converge physical design variables, process values and constraints"));
 
     List<String> missingVariables = missingDesignVariables(loop == null ? null : loop.getState(), policy);
     gates.put("COUPLED_PHYSICAL_DESIGN",

--- a/src/main/java/neqsim/process/engineering/verticalslice/ProductionVerticalSliceSimulator.java
+++ b/src/main/java/neqsim/process/engineering/verticalslice/ProductionVerticalSliceSimulator.java
@@ -28,9 +28,8 @@ public final class ProductionVerticalSliceSimulator {
 
   /** Runs the complete simulator and emits the coordinated package from the same qualified project state. */
   public static Result runAndCompile(EngineeringProject project,
-      EngineeringAutoConfigurationPolicy autoConfigurationPolicy,
-      InletCompressionExportSlicePolicy qualificationPolicy, int caseParallelism, Path outputDirectory,
-      EngineeringGraph baselineGraph) throws IOException {
+      EngineeringAutoConfigurationPolicy autoConfigurationPolicy, InletCompressionExportSlicePolicy qualificationPolicy,
+      int caseParallelism, Path outputDirectory, EngineeringGraph baselineGraph) throws IOException {
     Result run = run(project, autoConfigurationPolicy, qualificationPolicy, caseParallelism);
     EngineeringDeliverableCompiler.CompilationResult compilation = EngineeringDeliverableCompiler.compile(project,
         outputDirectory, baselineGraph);

--- a/src/main/java/neqsim/process/engineering/verticalslice/ProductionVerticalSliceSimulator.java
+++ b/src/main/java/neqsim/process/engineering/verticalslice/ProductionVerticalSliceSimulator.java
@@ -1,0 +1,76 @@
+package neqsim.process.engineering.verticalslice;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import neqsim.process.engineering.EngineeringProject;
+import neqsim.process.engineering.EngineeringSimulationResult;
+import neqsim.process.engineering.ProcessToEngineeringSimulator;
+import neqsim.process.engineering.deliverables.EngineeringDeliverableCompiler;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.production.EngineeringAutoConfigurationPolicy;
+
+/** Runs, qualifies and optionally compiles the first production process-to-engineering vertical slice. */
+public final class ProductionVerticalSliceSimulator {
+  private ProductionVerticalSliceSimulator() {
+  }
+
+  public static Result run(EngineeringProject project, EngineeringAutoConfigurationPolicy autoConfigurationPolicy,
+      InletCompressionExportSlicePolicy qualificationPolicy, int caseParallelism) {
+    EngineeringSimulationResult simulation = ProcessToEngineeringSimulator.run(project, autoConfigurationPolicy,
+        caseParallelism);
+    InletCompressionExportSliceQualification.Result qualification = InletCompressionExportSliceQualification
+        .qualify(project, simulation, qualificationPolicy);
+    project.recordVerticalSliceQualification(qualification);
+    return new Result(simulation, qualification, null);
+  }
+
+  /** Runs the complete simulator and emits the coordinated package from the same qualified project state. */
+  public static Result runAndCompile(EngineeringProject project,
+      EngineeringAutoConfigurationPolicy autoConfigurationPolicy,
+      InletCompressionExportSlicePolicy qualificationPolicy, int caseParallelism, Path outputDirectory,
+      EngineeringGraph baselineGraph) throws IOException {
+    Result run = run(project, autoConfigurationPolicy, qualificationPolicy, caseParallelism);
+    EngineeringDeliverableCompiler.CompilationResult compilation = EngineeringDeliverableCompiler.compile(project,
+        outputDirectory, baselineGraph);
+    return new Result(run.simulation, run.qualification, compilation);
+  }
+
+  /** Immutable simulation, qualification and optional package-compilation result. */
+  public static final class Result {
+    private final EngineeringSimulationResult simulation;
+    private final InletCompressionExportSliceQualification.Result qualification;
+    private final EngineeringDeliverableCompiler.CompilationResult compilation;
+
+    Result(EngineeringSimulationResult simulation, InletCompressionExportSliceQualification.Result qualification,
+        EngineeringDeliverableCompiler.CompilationResult compilation) {
+      this.simulation = simulation;
+      this.qualification = qualification;
+      this.compilation = compilation;
+    }
+
+    public EngineeringSimulationResult getSimulation() {
+      return simulation;
+    }
+
+    public InletCompressionExportSliceQualification.Result getQualification() {
+      return qualification;
+    }
+
+    public EngineeringDeliverableCompiler.CompilationResult getCompilation() {
+      return compilation;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("simulation", simulation.toMap());
+      result.put("verticalSliceQualification", qualification.toMap());
+      result.put("packageCompiled", Boolean.valueOf(compilation != null));
+      result.put("qualifiedForControlledPilot", Boolean.valueOf(qualification.isQualifiedForControlledPilot()));
+      result.put("fitnessForConstruction", Boolean.FALSE);
+      result.put("engineeringApprovalRequired", Boolean.TRUE);
+      return result;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/verticalslice/VerticalSliceDynamicScenarioFactory.java
+++ b/src/main/java/neqsim/process/engineering/verticalslice/VerticalSliceDynamicScenarioFactory.java
@@ -50,39 +50,35 @@ public final class VerticalSliceDynamicScenarioFactory {
             logic.addAction(safeState, 0.0);
             return logic;
           }
-        }).addCriterion(DynamicScenarioCriterion
-            .builder("suction-isolated", "Suction ESD valve reaches safe closed position", "%",
-                new DynamicScenarioCriterion.Extractor() {
-                  private static final long serialVersionUID = 1000L;
+        }).addCriterion(DynamicScenarioCriterion.builder("suction-isolated",
+            "Suction ESD valve reaches safe closed position", "%", new DynamicScenarioCriterion.Extractor() {
+              private static final long serialVersionUID = 1000L;
 
-                  @Override
-                  public double extract(ProcessSystem process) {
-                    return require(process, policy.getSuctionEsdValveTag(), ESDValve.class).getPercentValveOpening();
-                  }
-                })
+              @Override
+              public double extract(ProcessSystem process) {
+                return require(process, policy.getSuctionEsdValveTag(), ESDValve.class).getPercentValveOpening();
+              }
+            })
             .acceptanceRange(null, Double.valueOf(1.0)).deadlineSeconds(isolationDeadlineSeconds).build())
-        .addCriterion(DynamicScenarioCriterion
-            .builder("discharge-isolated", "Discharge ESD valve reaches safe closed position", "%",
-                new DynamicScenarioCriterion.Extractor() {
-                  private static final long serialVersionUID = 1000L;
+        .addCriterion(DynamicScenarioCriterion.builder("discharge-isolated",
+            "Discharge ESD valve reaches safe closed position", "%", new DynamicScenarioCriterion.Extractor() {
+              private static final long serialVersionUID = 1000L;
 
-                  @Override
-                  public double extract(ProcessSystem process) {
-                    return require(process, policy.getDischargeEsdValveTag(), ESDValve.class).getPercentValveOpening();
-                  }
-                })
+              @Override
+              public double extract(ProcessSystem process) {
+                return require(process, policy.getDischargeEsdValveTag(), ESDValve.class).getPercentValveOpening();
+              }
+            })
             .acceptanceRange(null, Double.valueOf(1.0)).deadlineSeconds(isolationDeadlineSeconds).build())
-        .addCriterion(DynamicScenarioCriterion
-            .builder("blowdown-open", "Blowdown valve reaches safe open position", "%",
-                new DynamicScenarioCriterion.Extractor() {
-                  private static final long serialVersionUID = 1000L;
+        .addCriterion(DynamicScenarioCriterion.builder("blowdown-open", "Blowdown valve reaches safe open position",
+            "%", new DynamicScenarioCriterion.Extractor() {
+              private static final long serialVersionUID = 1000L;
 
-                  @Override
-                  public double extract(ProcessSystem process) {
-                    return require(process, policy.getBlowdownValveTag(), BlowdownValve.class)
-                        .getPercentValveOpening();
-                  }
-                })
+              @Override
+              public double extract(ProcessSystem process) {
+                return require(process, policy.getBlowdownValveTag(), BlowdownValve.class).getPercentValveOpening();
+              }
+            })
             .acceptanceRange(Double.valueOf(90.0), null).deadlineSeconds(blowdownDeadlineSeconds).build())
         .addEvidenceReference(evidenceReference).build();
   }

--- a/src/main/java/neqsim/process/engineering/verticalslice/VerticalSliceDynamicScenarioFactory.java
+++ b/src/main/java/neqsim/process/engineering/verticalslice/VerticalSliceDynamicScenarioFactory.java
@@ -58,8 +58,7 @@ public final class VerticalSliceDynamicScenarioFactory {
               public double extract(ProcessSystem process) {
                 return require(process, policy.getSuctionEsdValveTag(), ESDValve.class).getPercentValveOpening();
               }
-            })
-            .acceptanceRange(null, Double.valueOf(1.0)).deadlineSeconds(isolationDeadlineSeconds).build())
+            }).acceptanceRange(null, Double.valueOf(1.0)).deadlineSeconds(isolationDeadlineSeconds).build())
         .addCriterion(DynamicScenarioCriterion.builder("discharge-isolated",
             "Discharge ESD valve reaches safe closed position", "%", new DynamicScenarioCriterion.Extractor() {
               private static final long serialVersionUID = 1000L;
@@ -68,8 +67,7 @@ public final class VerticalSliceDynamicScenarioFactory {
               public double extract(ProcessSystem process) {
                 return require(process, policy.getDischargeEsdValveTag(), ESDValve.class).getPercentValveOpening();
               }
-            })
-            .acceptanceRange(null, Double.valueOf(1.0)).deadlineSeconds(isolationDeadlineSeconds).build())
+            }).acceptanceRange(null, Double.valueOf(1.0)).deadlineSeconds(isolationDeadlineSeconds).build())
         .addCriterion(DynamicScenarioCriterion.builder("blowdown-open", "Blowdown valve reaches safe open position",
             "%", new DynamicScenarioCriterion.Extractor() {
               private static final long serialVersionUID = 1000L;
@@ -78,8 +76,7 @@ public final class VerticalSliceDynamicScenarioFactory {
               public double extract(ProcessSystem process) {
                 return require(process, policy.getBlowdownValveTag(), BlowdownValve.class).getPercentValveOpening();
               }
-            })
-            .acceptanceRange(Double.valueOf(90.0), null).deadlineSeconds(blowdownDeadlineSeconds).build())
+            }).acceptanceRange(Double.valueOf(90.0), null).deadlineSeconds(blowdownDeadlineSeconds).build())
         .addEvidenceReference(evidenceReference).build();
   }
 

--- a/src/main/java/neqsim/process/engineering/verticalslice/VerticalSliceDynamicScenarioFactory.java
+++ b/src/main/java/neqsim/process/engineering/verticalslice/VerticalSliceDynamicScenarioFactory.java
@@ -1,0 +1,97 @@
+package neqsim.process.engineering.verticalslice;
+
+import neqsim.process.equipment.valve.BlowdownValve;
+import neqsim.process.equipment.valve.ESDValve;
+import neqsim.process.logic.ProcessLogic;
+import neqsim.process.logic.action.ActivateBlowdownAction;
+import neqsim.process.logic.action.ParallelActionGroup;
+import neqsim.process.logic.action.TripValveAction;
+import neqsim.process.logic.esd.ESDLogic;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.safety.scenario.DynamicSafetyScenario;
+import neqsim.process.safety.scenario.DynamicScenarioCriterion;
+
+/** Creates executable safe-state scenarios bound to equipment in an isolated vertical-slice process copy. */
+public final class VerticalSliceDynamicScenarioFactory {
+  private VerticalSliceDynamicScenarioFactory() {
+  }
+
+  /**
+   * Creates an ESD scenario that isolates compressor suction/discharge and opens the blowdown valve against deadlines.
+   */
+  public static DynamicSafetyScenario emergencyShutdown(final String scenarioId,
+      final InletCompressionExportSlicePolicy policy, double durationSeconds, double timeStepSeconds,
+      double triggerTimeSeconds, final double isolationDeadlineSeconds, final double blowdownDeadlineSeconds,
+      String evidenceReference) {
+    return DynamicSafetyScenario.builder(scenarioId, "Compressor trip, isolation and blowdown safe-state verification")
+        .durationSeconds(durationSeconds).timeStepSeconds(timeStepSeconds).triggerTimeSeconds(triggerTimeSeconds)
+        .initiatingEvent(new DynamicSafetyScenario.ProcessManipulator() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public void apply(ProcessSystem process) {
+            require(process, policy.getSuctionEsdValveTag(), ESDValve.class);
+            require(process, policy.getDischargeEsdValveTag(), ESDValve.class);
+            require(process, policy.getBlowdownValveTag(), BlowdownValve.class);
+          }
+        }).addLogic(new DynamicSafetyScenario.LogicFactory() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public ProcessLogic create(ProcessSystem process) {
+            ESDValve suction = require(process, policy.getSuctionEsdValveTag(), ESDValve.class);
+            ESDValve discharge = require(process, policy.getDischargeEsdValveTag(), ESDValve.class);
+            BlowdownValve blowdown = require(process, policy.getBlowdownValveTag(), BlowdownValve.class);
+            ESDLogic logic = new ESDLogic("ESD-" + scenarioId);
+            ParallelActionGroup safeState = new ParallelActionGroup("Isolate and depressurize compressor segment");
+            safeState.addAction(new TripValveAction(suction));
+            safeState.addAction(new TripValveAction(discharge));
+            safeState.addAction(new ActivateBlowdownAction(blowdown));
+            logic.addAction(safeState, 0.0);
+            return logic;
+          }
+        }).addCriterion(DynamicScenarioCriterion
+            .builder("suction-isolated", "Suction ESD valve reaches safe closed position", "%",
+                new DynamicScenarioCriterion.Extractor() {
+                  private static final long serialVersionUID = 1000L;
+
+                  @Override
+                  public double extract(ProcessSystem process) {
+                    return require(process, policy.getSuctionEsdValveTag(), ESDValve.class).getPercentValveOpening();
+                  }
+                })
+            .acceptanceRange(null, Double.valueOf(1.0)).deadlineSeconds(isolationDeadlineSeconds).build())
+        .addCriterion(DynamicScenarioCriterion
+            .builder("discharge-isolated", "Discharge ESD valve reaches safe closed position", "%",
+                new DynamicScenarioCriterion.Extractor() {
+                  private static final long serialVersionUID = 1000L;
+
+                  @Override
+                  public double extract(ProcessSystem process) {
+                    return require(process, policy.getDischargeEsdValveTag(), ESDValve.class).getPercentValveOpening();
+                  }
+                })
+            .acceptanceRange(null, Double.valueOf(1.0)).deadlineSeconds(isolationDeadlineSeconds).build())
+        .addCriterion(DynamicScenarioCriterion
+            .builder("blowdown-open", "Blowdown valve reaches safe open position", "%",
+                new DynamicScenarioCriterion.Extractor() {
+                  private static final long serialVersionUID = 1000L;
+
+                  @Override
+                  public double extract(ProcessSystem process) {
+                    return require(process, policy.getBlowdownValveTag(), BlowdownValve.class)
+                        .getPercentValveOpening();
+                  }
+                })
+            .acceptanceRange(Double.valueOf(90.0), null).deadlineSeconds(blowdownDeadlineSeconds).build())
+        .addEvidenceReference(evidenceReference).build();
+  }
+
+  private static <T> T require(ProcessSystem process, String tag, Class<T> type) {
+    Object value = process.getUnit(tag);
+    if (!type.isInstance(value)) {
+      throw new IllegalStateException(tag + " is missing or is not " + type.getSimpleName());
+    }
+    return type.cast(value);
+  }
+}

--- a/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioResult.java
+++ b/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioResult.java
@@ -81,6 +81,11 @@ public final class DynamicSafetyScenarioResult implements Serializable {
     return true;
   }
 
+  /** @return controlled scenario identifier */
+  public String getScenarioId() {
+    return scenarioId;
+  }
+
   public Map<String, CriterionResult> getCriterionResults() {
     return criterionResults;
   }

--- a/src/main/resources/neqsim/process/engineering/schema/engineering-vertical-slice-qualification.schema.json
+++ b/src/main/resources/neqsim/process/engineering/schema/engineering-vertical-slice-qualification.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:neqsim:schema:engineering-vertical-slice-qualification:v1",
+  "title": "NeqSim engineering vertical-slice qualification",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "schemaUri",
+    "projectId",
+    "projectRevision",
+    "policyId",
+    "policyRevision",
+    "gates",
+    "failedGates",
+    "qualifiedForControlledPilot",
+    "fitnessForConstruction",
+    "finalEngineeringApprovalGranted",
+    "engineeringApprovalRequired"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "neqsim_engineering_vertical_slice_qualification.v1" },
+    "schemaUri": { "type": "string", "minLength": 1 },
+    "projectId": { "type": "string", "minLength": 1 },
+    "projectRevision": { "type": "string", "minLength": 1 },
+    "policyId": { "type": "string", "minLength": 1 },
+    "policyRevision": { "type": "string", "minLength": 1 },
+    "gates": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["passed", "findings", "requiredAction"],
+        "properties": {
+          "passed": { "type": "boolean" },
+          "findings": { "type": "array", "items": { "type": "string" } },
+          "requiredAction": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "failedGates": { "type": "array", "items": { "type": "string" } },
+    "qualifiedForControlledPilot": { "type": "boolean" },
+    "qualifiedForFeedSupport": { "const": false },
+    "fitnessForConstruction": { "const": false },
+    "finalEngineeringApprovalGranted": { "const": false },
+    "engineeringApprovalRequired": { "const": true },
+    "governance": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": false
+}

--- a/src/test/java/neqsim/process/engineering/EngineeringVerticalSliceProductionTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringVerticalSliceProductionTest.java
@@ -124,8 +124,8 @@ class EngineeringVerticalSliceProductionTest {
     double[][] heads = new double[][] { { 75.0, 65.0, 50.0 }, { 110.0, 95.0, 72.0 } };
     double[][] efficiencies = new double[][] { { 70.0, 79.0, 73.0 }, { 71.0, 80.0, 74.0 } };
     compressor.getCompressorChart().setCurves(conditions, speeds, flows, heads, efficiencies);
-    compressor.getCompressorChart().setSurgeCurve(
-        new SafeSplineSurgeCurve(new double[] { 42.0, 55.0, 70.0 }, new double[] { 110.0, 90.0, 65.0 }));
+    compressor.getCompressorChart()
+        .setSurgeCurve(new SafeSplineSurgeCurve(new double[] { 42.0, 55.0, 70.0 }, new double[] { 110.0, 90.0, 65.0 }));
     compressor.getCompressorChart().setStoneWallCurve(
         new SafeSplineStoneWallCurve(new double[] { 170.0, 195.0, 220.0 }, new double[] { 110.0, 90.0, 65.0 }));
     compressor.getCompressorChart().setHeadUnit("kJ/kg");

--- a/src/test/java/neqsim/process/engineering/EngineeringVerticalSliceProductionTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringVerticalSliceProductionTest.java
@@ -58,8 +58,8 @@ class EngineeringVerticalSliceProductionTest {
     project.addDesignCase(flowCase("normal", EngineeringDesignCase.Type.NORMAL, 8000.0));
     project.addDesignCase(flowCase("maximum", EngineeringDesignCase.Type.MAXIMUM_PRODUCTION, 10000.0));
     EngineeringAutoConfigurationPolicy autoPolicy = new EngineeringAutoConfigurationPolicy("explicit", "A")
-        .addInletCompressionExportSlice("INLET-SEP", "EXPORT-COMP", "EXPORT-LINE", "", "PIT-100", 800.0, 0.107,
-            120.0, 25.0, 5.0, 0.10, 500.0, 1000.0, 2000.0, 5000.0, 10000.0)
+        .addInletCompressionExportSlice("INLET-SEP", "EXPORT-COMP", "EXPORT-LINE", "", "PIT-100", 800.0, 0.107, 120.0,
+            25.0, 5.0, 0.10, 500.0, 1000.0, 2000.0, 5000.0, 10000.0)
         .addCompressorOperatingEnvelope("EXPORT-COMP", 0.05, 0.05, 160.0, 0.10);
     InletCompressionExportSlicePolicy qualificationPolicy = InletCompressionExportSlicePolicy
         .builder("production-slice", "A").processTags("INLET-SEP", "EXPORT-COMP", "AFTERCOOLER", "EXPORT-LINE")

--- a/src/test/java/neqsim/process/engineering/EngineeringVerticalSliceProductionTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringVerticalSliceProductionTest.java
@@ -1,0 +1,136 @@
+package neqsim.process.engineering;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import neqsim.process.engineering.deliverables.EngineeringDeliverableCompiler;
+import neqsim.process.engineering.designcase.EngineeringDesignCase;
+import neqsim.process.engineering.production.EngineeringAutoConfigurationPolicy;
+import neqsim.process.engineering.verticalslice.InletCompressionExportSlicePolicy;
+import neqsim.process.engineering.verticalslice.ProductionVerticalSliceSimulator;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.compressor.SafeSplineStoneWallCurve;
+import neqsim.process.equipment.compressor.SafeSplineSurgeCurve;
+import neqsim.process.equipment.pipeline.AdiabaticPipe;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Regression coverage for the production vertical-slice map envelope and fail-closed qualification. */
+class EngineeringVerticalSliceProductionTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void calculatesCompressorMapEnvelopeAcrossDesignCases() {
+    ProcessSystem process = chartedProcess();
+    EngineeringProject project = NorsokOffshoreEngineeringBuilder.from("Compressor envelope", process)
+        .projectId("compressor-envelope").build();
+    project.addDesignCase(flowCase("normal", EngineeringDesignCase.Type.NORMAL, 8000.0));
+    project.addDesignCase(flowCase("maximum", EngineeringDesignCase.Type.MAXIMUM_PRODUCTION, 10000.0));
+    ProcessToEngineeringDesignBuilder builder = ProcessToEngineeringDesignBuilder.on(project)
+        .separatorBasis(800.0, 0.107, 120.0).exportLineLimits(25.0, 5.0)
+        .compressorDrivers(0.10, 500.0, 1000.0, 2000.0, 5000.0, 10000.0);
+    builder.addInletCompressionExportSlice("INLET-SEP", "EXPORT-COMP", "EXPORT-LINE", "", "PIT-100");
+    builder.addCompressorOperatingEnvelopeDesign("EXPORT-COMP", 0.05, 0.05, 160.0, 0.10);
+
+    EngineeringSimulationResult result = ProcessToEngineeringSimulator.run(project, 1);
+
+    assertTrue(result.getEngineeringDesignLoopResult().getState().contains("EXPORT-COMP.minimumSurgeMargin"));
+    assertTrue(result.getEngineeringDesignLoopResult().getState().contains("EXPORT-COMP.minimumStonewallMargin"));
+    assertTrue(
+        result.getEngineeringDesignLoopResult().getState().contains("EXPORT-COMP.maximumRequiredRecycleFraction"));
+    assertTrue(result.getEngineeringDesignLoopResult().getState().contains("EXPORT-COMP.maximumRecycleCoolerDuty"));
+    assertTrue(result.toJson().contains("operatingPoints"));
+  }
+
+  @Test
+  void failsClosedAndWritesQualificationArtifactWhenProductionTopologyIsIncomplete() throws Exception {
+    ProcessSystem process = chartedProcess();
+    EngineeringProject project = NorsokOffshoreEngineeringBuilder.from("Incomplete production slice", process)
+        .projectId("incomplete-slice").build();
+    project.addDesignCase(flowCase("normal", EngineeringDesignCase.Type.NORMAL, 8000.0));
+    project.addDesignCase(flowCase("maximum", EngineeringDesignCase.Type.MAXIMUM_PRODUCTION, 10000.0));
+    EngineeringAutoConfigurationPolicy autoPolicy = new EngineeringAutoConfigurationPolicy("explicit", "A")
+        .addInletCompressionExportSlice("INLET-SEP", "EXPORT-COMP", "EXPORT-LINE", "", "PIT-100", 800.0, 0.107,
+            120.0, 25.0, 5.0, 0.10, 500.0, 1000.0, 2000.0, 5000.0, 10000.0)
+        .addCompressorOperatingEnvelope("EXPORT-COMP", 0.05, 0.05, 160.0, 0.10);
+    InletCompressionExportSlicePolicy qualificationPolicy = InletCompressionExportSlicePolicy
+        .builder("production-slice", "A").processTags("INLET-SEP", "EXPORT-COMP", "AFTERCOOLER", "EXPORT-LINE")
+        .controlTags("ASV", "ASV-RECYCLE", "PCV", "LCV")
+        .safetyTags("PSV", "BDV", "ESDV-SUCTION", "ESDV-DISCHARGE", "FLARE-CONNECTION")
+        .addRequiredDynamicScenario("compressor-trip-esd").addEvidenceReference("HAZOP-REQUIRED").build();
+
+    ProductionVerticalSliceSimulator.Result result = ProductionVerticalSliceSimulator.run(project, autoPolicy,
+        qualificationPolicy, 1);
+
+    assertFalse(result.getQualification().isQualifiedForControlledPilot());
+    assertTrue(result.getQualification().getFailedGates().contains("COMPLETE_PROCESS_AND_SAFETY_TOPOLOGY"));
+    assertTrue(result.getQualification().getFailedGates().contains("COMPLETE_CONVERGED_CASE_MATRIX"));
+    assertTrue(result.getQualification().getFailedGates().contains("DYNAMIC_SAFE_STATE_VERIFICATION"));
+    EngineeringDeliverableCompiler.compile(project, temporaryDirectory);
+    Path artifact = temporaryDirectory.resolve("engineering-vertical-slice-qualification.json");
+    assertTrue(Files.isRegularFile(artifact));
+    String json = new String(Files.readAllBytes(artifact), StandardCharsets.UTF_8);
+    assertTrue(json.contains("qualifiedForControlledPilot"));
+    assertTrue(json.contains("fitnessForConstruction"));
+  }
+
+  private EngineeringDesignCase flowCase(String id, EngineeringDesignCase.Type type, final double flowKgHr) {
+    return new EngineeringDesignCase(id, id, type, new EngineeringDesignCase.Configurator() {
+      private static final long serialVersionUID = 1000L;
+
+      @Override
+      public void configure(ProcessSystem process) {
+        ((Stream) process.getUnit("FEED")).setFlowRate(flowKgHr, "kg/hr");
+      }
+    }).addInput(new EngineeringDesignCase.Input("feedFlow", flowKgHr, "kg/hr", "DESIGN-BASIS-A"))
+        .addEvidenceReference("DESIGN-BASIS-A");
+  }
+
+  private ProcessSystem chartedProcess() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 50.0);
+    fluid.addComponent("methane", 0.92);
+    fluid.addComponent("ethane", 0.04);
+    fluid.addComponent("n-heptane", 0.04);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("FEED", fluid);
+    feed.setFlowRate(8000.0, "kg/hr");
+    Separator separator = new Separator("INLET-SEP", feed);
+    Compressor compressor = new Compressor("EXPORT-COMP", separator.getGasOutStream());
+    compressor.setOutletPressure(80.0, "bara");
+    compressor.setPolytropicEfficiency(0.78);
+    compressor.setSpeed(10000.0);
+    AdiabaticPipe exportLine = new AdiabaticPipe("EXPORT-LINE", compressor.getOutletStream());
+    exportLine.setLength(1000.0);
+    exportLine.setDiameter(0.2027);
+    exportLine.setPipeWallRoughness(4.6e-5);
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(separator);
+    process.add(compressor);
+    process.add(exportLine);
+    process.run();
+
+    double[] conditions = new double[] { 19.0, 300.0, 50.0, 0.90 };
+    double[] speeds = new double[] { 9000.0, 11000.0 };
+    double[][] flows = new double[][] { { 50.0, 100.0, 150.0 }, { 70.0, 140.0, 210.0 } };
+    double[][] heads = new double[][] { { 75.0, 65.0, 50.0 }, { 110.0, 95.0, 72.0 } };
+    double[][] efficiencies = new double[][] { { 70.0, 79.0, 73.0 }, { 71.0, 80.0, 74.0 } };
+    compressor.getCompressorChart().setCurves(conditions, speeds, flows, heads, efficiencies);
+    compressor.getCompressorChart().setSurgeCurve(
+        new SafeSplineSurgeCurve(new double[] { 42.0, 55.0, 70.0 }, new double[] { 110.0, 90.0, 65.0 }));
+    compressor.getCompressorChart().setStoneWallCurve(
+        new SafeSplineStoneWallCurve(new double[] { 170.0, 195.0, 220.0 }, new double[] { 110.0, 90.0, 65.0 }));
+    compressor.getCompressorChart().setHeadUnit("kJ/kg");
+    compressor.getCompressorChart().setUseCompressorChart(true);
+    compressor.getAntiSurge().setActive(true);
+    return process;
+  }
+}

--- a/src/test/java/neqsim/process/engineering/design/EngineeringDesignLoopTest.java
+++ b/src/test/java/neqsim/process/engineering/design/EngineeringDesignLoopTest.java
@@ -58,6 +58,30 @@ class EngineeringDesignLoopTest {
         .candidates(new DesignCandidate("NPS-8-SCH40", 0.20, "in")).build());
   }
 
+  @Test
+  void detectsTwoStateDiscreteCandidateOscillation() {
+    ProcessSystem base = process();
+    EngineeringCaseSet cases = new EngineeringCaseSet("oscillation-test")
+        .addCase(new EngineeringDesignCase("normal", "Normal", EngineeringDesignCase.Type.NORMAL,
+            new EngineeringDesignCase.Configurator() {
+              private static final long serialVersionUID = 1000L;
+
+              @Override
+              public void configure(ProcessSystem process) {
+                // The design update supplies the changing physical state.
+              }
+            }))
+        .addMetric(EngineeringMetric.equipmentPressure("FEED"));
+
+    EngineeringDesignLoopResult result = EngineeringDesignLoop.run(base, cases,
+        Arrays.<EngineeringDesignModule>asList(new OscillatingCandidateModule()),
+        EngineeringDesignLoopOptions.builder().maximumIterations(6).build());
+
+    assertFalse(result.isConverged());
+    assertEquals("DISCRETE_DESIGN_OSCILLATION_DETECTED", result.getTerminationReason());
+    assertEquals(3, result.getIterations().size());
+  }
+
   private ProcessSystem process() {
     SystemInterface fluid = new SystemSrkEos(300.0, 50.0);
     fluid.addComponent("methane", 1.0);
@@ -93,6 +117,33 @@ class EngineeringDesignLoopTest {
               }).build())
           .addConstraint(new EngineeringDesignConstraint("feed-minimum", "Minimum design pressure",
               "FEED.designPressure", 60.0, "bara", EngineeringDesignConstraint.Comparison.MINIMUM))
+          .build();
+    }
+  }
+
+  private static final class OscillatingCandidateModule implements EngineeringDesignModule {
+    private static final long serialVersionUID = 1000L;
+
+    @Override
+    public String getId() {
+      return "oscillating-candidate";
+    }
+
+    @Override
+    public EngineeringDesignModuleResult evaluate(ProcessSystem process, EngineeringCaseRunReport caseReport,
+        EngineeringDesignState state, EngineeringCalculationContext context) {
+      double candidate = !state.contains("FEED.discreteCandidate")
+          || state.requireValue("FEED.discreteCandidate") == 2.0 ? 1.0 : 2.0;
+      return EngineeringDesignModuleResult.builder(getId(), "Oscillation regression", "1.0")
+          .addUpdate(EngineeringDesignUpdate.builder("FEED.discreteCandidate", candidate, "m")
+              .relativeTolerance(0.0).applier(new EngineeringDesignUpdate.Applier() {
+                private static final long serialVersionUID = 1000L;
+
+                @Override
+                public void apply(ProcessSystem working, double value) {
+                  ((Stream) working.getUnit("FEED")).setPressure(49.0 + value, "bara");
+                }
+              }).build())
           .build();
     }
   }

--- a/src/test/java/neqsim/process/engineering/design/EngineeringDesignLoopTest.java
+++ b/src/test/java/neqsim/process/engineering/design/EngineeringDesignLoopTest.java
@@ -61,17 +61,15 @@ class EngineeringDesignLoopTest {
   @Test
   void detectsTwoStateDiscreteCandidateOscillation() {
     ProcessSystem base = process();
-    EngineeringCaseSet cases = new EngineeringCaseSet("oscillation-test")
-        .addCase(new EngineeringDesignCase("normal", "Normal", EngineeringDesignCase.Type.NORMAL,
-            new EngineeringDesignCase.Configurator() {
-              private static final long serialVersionUID = 1000L;
+    EngineeringCaseSet cases = new EngineeringCaseSet("oscillation-test").addCase(new EngineeringDesignCase("normal",
+        "Normal", EngineeringDesignCase.Type.NORMAL, new EngineeringDesignCase.Configurator() {
+          private static final long serialVersionUID = 1000L;
 
-              @Override
-              public void configure(ProcessSystem process) {
-                // The design update supplies the changing physical state.
-              }
-            }))
-        .addMetric(EngineeringMetric.equipmentPressure("FEED"));
+          @Override
+          public void configure(ProcessSystem process) {
+            // The design update supplies the changing physical state.
+          }
+        })).addMetric(EngineeringMetric.equipmentPressure("FEED"));
 
     EngineeringDesignLoopResult result = EngineeringDesignLoop.run(base, cases,
         Arrays.<EngineeringDesignModule>asList(new OscillatingCandidateModule()),
@@ -135,8 +133,8 @@ class EngineeringDesignLoopTest {
       double candidate = !state.contains("FEED.discreteCandidate")
           || state.requireValue("FEED.discreteCandidate") == 2.0 ? 1.0 : 2.0;
       return EngineeringDesignModuleResult.builder(getId(), "Oscillation regression", "1.0")
-          .addUpdate(EngineeringDesignUpdate.builder("FEED.discreteCandidate", candidate, "m")
-              .relativeTolerance(0.0).applier(new EngineeringDesignUpdate.Applier() {
+          .addUpdate(EngineeringDesignUpdate.builder("FEED.discreteCandidate", candidate, "m").relativeTolerance(0.0)
+              .applier(new EngineeringDesignUpdate.Applier() {
                 private static final long serialVersionUID = 1000L;
 
                 @Override


### PR DESCRIPTION
## What changed

- adds a fail-closed `ProductionVerticalSliceSimulator` for the inlet separator → charted compressor → cooler → export line section, including recycle/control/safety topology requirements
- adds governed compressor-map case-envelope calculations for surge, stonewall, control-line margin, recycle demand/duty, discharge temperature, speed and extrapolation
- integrates compressor envelope and PSV-orifice design into the revision-controlled automatic-configuration policy and fingerprint
- adds exact two-state discrete design oscillation detection to the closed engineering loop
- adds dynamic ESD safe-state scenario construction and nine controlled-pilot qualification gates
- emits and validates `engineering-vertical-slice-qualification.json` in every coordinated package, including an explicit fail-closed NOT_CONFIGURED artifact
- adds regression tests, a JSON schema, documentation, a notebook, and agent/skill guidance

## Why

The merged foundations cover the eight process-to-engineering stages, but a partial facility model could still look complete unless topology, case coverage, compressor-map evidence, dynamic protection, coupled flare capacity, standards and controlled records were checked together. This PR adds that first facility-level acceptance contract.

## Status boundary

Passing all gates grants only `qualifiedForControlledPilot=true`. It never grants FEED support, fitness for construction or final engineering approval. HAZOP/LOPA/SRS decisions, SIL, scenario credibility, materials approval, vendor guarantees and accountable approval remain external controlled inputs.

## Validation

- rebased on current `master` (`0154cdf71`)
- Java 8-compatible compilation of all engineering sources passed with `javac` against the repository classes
- both changed/new test sources compile against lightweight JUnit API stubs
- notebook JSON and Python syntax passed
- qualification schema JSON passed
- `git diff --check` passed
- full Maven/Spotless and JUnit execution could not run locally because Maven Central DNS resolution is unavailable in this environment; GitHub CI is authoritative