### PR TITLE
Stabilize DEXPI XML output across supported JDKs

### DIFF
--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
@@ -264,6 +264,9 @@ public final class Dexpi20XmlWriter {
     factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
     Transformer transformer = factory.newTransformer();
     transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+    // The JDK 8 transformer requires an explicit indentation width, while newer JDKs default
+    // to four spaces. Declare it so golden DEXPI documents are byte-stable across supported JDKs.
+    transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
     transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
     transformer.transform(new DOMSource(document), new StreamResult(outputStream));
   }


### PR DESCRIPTION
## What changed

- makes DEXPI 2.0 XML indentation explicit in the serializer
- removes the JDK-dependent output difference exposed by the Java 8 matrix after #2465 was merged
- preserves the existing four-space golden DEXPI representation used by newer JDKs

## Root cause

JDK 21's built-in transformer defaults to four-space indentation when `OutputKeys.INDENT=yes`; the JDK 8 transformer requires the XSLT indentation-width property to be set explicitly. The generated models were semantically identical, but the cross-JDK golden-file regression correctly detected that they were not byte-stable.

## Validation

- DEXPI golden-file and semantic regression: passed
- Java 8 tests on Ubuntu: passed
- Java 8 tests on Windows: passed
- Java 21 tests on Ubuntu with coverage: passed
- Java 21 tests on Windows: passed
- Java 21 Javadoc: passed
- Spotless/pre-commit: passed
- CodeQL: passed
- PaperLab and agent/skill gates: passed