### PR TITLE
Complete production engineering qualification gaps

### DIFF
--- a/.github/agents/engineering.deliverables.agent.md
+++ b/.github/agents/engineering.deliverables.agent.md
@@ -102,6 +102,16 @@ unreferenced two-phase relief methods. A calculated PSV orifice remains
 review-required until certified device data and inlet, outlet, header, stability,
 flare and depressurization checks are complete.
 
+For technical completion, execute and attach the exact typed results from
+`TransientPipingQualificationCalculation`, `CompressorProtectionQualificationCalculation`,
+`ValveInstrumentQualificationCalculation`, `MechanicalIntegrityQualificationCalculation`,
+and `FlareConsequenceCalculation` to `EngineeringProductionReadinessBasis`. Use actual
+distributed-solver histories and `distributedTransientModel=approved` for the transient-piping input, and require
+`consequenceMethodApplicability=approved` for production flare screening. Review all five
+independent readiness gates and their exact-version benchmark/method-qualification actions.
+Never reinterpret a passing numerical constraint as vendor, HAZOP, code, CAE-tool, pilot,
+or construction approval.
+
 ### 1. StudyClass Enum
 Controls which deliverables are produced:
 

--- a/.github/skills/neqsim-capability-map/SKILL.md
+++ b/.github/skills/neqsim-capability-map/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-capability-map
 description: "Structured inventory of NeqSim's capabilities by engineering discipline. USE WHEN: checking what NeqSim can do, planning implementations, assessing gaps for engineering tasks, or routing work to the right agent. Covers thermodynamics, process equipment, PVT, standards, mechanical design, flow assurance, safety, and economics."
-last_verified: "2026-07-10"
+last_verified: "2026-07-18"
 ---
 
 # NeqSim Capability Map
@@ -9,7 +9,7 @@ last_verified: "2026-07-10"
 Structured reference of what NeqSim can do, organized by engineering discipline.
 Use this to quickly check if a capability exists before searching the source code.
 
-**Last updated:** 2026-07-09
+**Last updated:** 2026-07-18
 
 ---
 
@@ -527,7 +527,7 @@ transport properties (viscosity, thermal conductivity, density).
 | **Membrane separation** | Basic membrane model | No detailed permeation |
 | **BWRS EOS** | Only CH4 + C2H6 parameterized | Use SRK/PR instead |
 | **NACE MR0175 material selection** | No systematic material logic | Manual standard lookup |
-| **Detailed flare modeling** | No radiation / noise model | Source term only |
+| **Site-specific flare consequences** | Point-source radiation, neutral Gaussian centerline dispersion, spherical noise, tip-Mach screening and API 537 flame geometry are available | Use validated specialist models for complex terrain/weather, toxic/combustion detail and final siting |
 | **API 2000 tank venting** | No in-/out-breathing tank vent sizing (thermal + pump-in/out) | Use general relief methods manually; flag as gap in `capability_assessment.md` |
 | **Full pipeline network** | LoopedPipeNetwork: NR-GGA solver, 120+ wells, IPR (PI/Vogel/Fetkovich), chokes, tubing VLP, Beggs-Brill multiphase, compressors, regulators, artificial lift (gas lift/ESP/jet/rod pump), water handling, sand erosion (DNV RP O501), corrosion (de Waard-Milliams/NORSOK M-506), GHG emissions tracking | Full-featured production network |
 
@@ -663,4 +663,3 @@ API 520 omega method) is **already present** and must not be re-flagged as
 missing. Confirmed live gaps (e.g. **API 2000 tank venting**) are recorded in
 section J; add newly confirmed gaps there so the next scout does not repeat the
 search.
-

--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -343,6 +343,16 @@ carry the dynamic response. The application layer reports
 `NOT_CERTIFIED_FOR_PROTECTION` and is for simulation/advisory studies, not a
 certified machinery-protection package.
 
+For production-readiness evidence, pass the actual compressor cases and transient response
+limits to `CompressorProtectionQualificationCalculation`; it checks map margins,
+extrapolation, driver/start-up/rundown, response time, rotor separation, settle-out and
+vendor acceptance without certifying the protection system. For piping, pass ordered
+`TwoFluidPipe`, water-hammer, or externally governed solver samples to
+`TransientPipingQualificationCalculation`. That module checks acoustic resolution and
+line-pack balance before pressure, slug, velocity and stress limits, and deliberately does
+not treat a quasi-steady time series as distributed-transient evidence. Production mode
+requires the controlled context attribute `distributedTransientModel=approved`.
+
 ## Running Dynamic Simulation
 
 ```java

--- a/.github/skills/neqsim-relief-flare-network/SKILL.md
+++ b/.github/skills/neqsim-relief-flare-network/SKILL.md
@@ -251,6 +251,15 @@ FlareDispersionSurrogateDTO disp = flare.getDispersionSurrogate();
 // Use to bound H2S / SO2 ground concentration vs. IDLH/ERPG-2
 ```
 
+For a governed production-readiness record, use
+`neqsim.process.engineering.safety.FlareConsequenceCalculation`. It combines explicit
+point-source radiation, neutral Gaussian centerline dispersion, spherical noise spreading,
+and tip-Mach constraints in one typed result with uncertainty and provenance. Set
+`productionQualification=true` only with standards/evidence references and
+`consequenceMethodApplicability=approved`. This is a screening interface, not a substitute
+for validated complex-terrain, stability-class, toxic, combustion, or detailed acoustic
+modeling.
+
 ## Common Mistakes
 
 | Mistake                                                   | Fix                                                                  |

--- a/docs/integration/engineering-production-vertical-slice.md
+++ b/docs/integration/engineering-production-vertical-slice.md
@@ -135,8 +135,10 @@ cooler duty, discharge temperature and extrapolation flag. The common design loo
 maximum temperature and map extrapolation. Changing these limits changes the automatic-configuration fingerprint and
 therefore invalidates dependent calculations and package artifacts.
 
-The module requires an active map, surge curve and stonewall curve. It does not qualify vendor guarantees, starting
-torque, rotor dynamics or the dynamic anti-surge controller. Those remain controlled vendor and project evidence.
+The module requires an active map, surge curve and stonewall curve. It does not by itself qualify vendor guarantees,
+starting torque, rotor dynamics or the dynamic anti-surge controller. Supply those controlled results to
+`CompressorProtectionQualificationCalculation`; its checks remain review-required and cannot replace vendor or
+accountable machinery approval.
 
 ## Qualification gates
 
@@ -172,8 +174,10 @@ Passing all nine gates means only `qualifiedForControlledPilot=true`. It always 
 
 Production method qualification remains governed by `EngineeringProductionReadinessAssessment`: independent
 benchmarks, named-tool DEXPI qualification, accepted pilots, approved safety-lifecycle evidence and release-quality
-evidence are separate requirements. HAZOP/LOPA/SRS decisions, scenario credibility, SIL, valve failure actions,
-materials approval, vendor selection and final shutdown actions cannot be manufactured by the simulator.
+evidence are separate requirements. The assessment also has independent gates for distributed piping transients,
+compressor protection/machinery, valve/instrument response and installation, detailed mechanical integrity, and flare
+radiation/dispersion/noise. HAZOP/LOPA/SRS decisions, scenario credibility, SIL, valve failure actions, materials
+approval, vendor selection and final shutdown actions cannot be manufactured by the simulator.
 
 See the [controlled-pilot notebook](../../examples/notebooks/engineering_vertical_slice_controlled_pilot.ipynb) for
 the executable API pattern.

--- a/docs/integration/process-to-engineering-simulator.md
+++ b/docs/integration/process-to-engineering-simulator.md
@@ -400,6 +400,33 @@ method and reference. The built-in relief calculation selects from the project d
 cases, but certified coefficients, stability, inlet/outlet losses and disposal-network interaction remain separate
 review gates.
 
+### Technical production-completion evidence
+
+Five typed qualification modules close the remaining numerical evidence interfaces without claiming external
+engineering authority:
+
+- `TransientPipingQualificationCalculation` consumes ordered output from a distributed transient solver and checks
+  acoustic time resolution, line-pack mass balance, pressure limits and pulsation, liquid inventory, velocity and
+  equivalent pipe stress. Production mode also requires `distributedTransientModel=approved`; a quasi-steady line
+  calculation is not accepted as distributed-transient evidence.
+- `CompressorProtectionQualificationCalculation` checks surge/stonewall margins, map extrapolation, temperature,
+  driver and start-up limits, rundown, anti-surge response, rotor separation, settle-out pressure and vendor
+  guarantee acceptance.
+- `ValveInstrumentQualificationCalculation` independently checks actuator and shutoff capability, leakage, total
+  response time, transmitter range/uncertainty, thermowell screening, failure action, installation, tuning and
+  permissive/reset/restart evidence.
+- `MechanicalIntegrityQualificationCalculation` checks internal/external pressure, wall thickness, buckling,
+  fatigue, external loads, nozzle reinforcement, MDMT, corrosion allowance and controlled code/material/fabrication/
+  NDE records.
+- `FlareConsequenceCalculation` provides explicit point-source radiation, neutral Gaussian centerline dispersion,
+  spherical noise-spreading and tip-Mach screening. Production use requires an approved method-applicability record;
+  projects outside those assumptions require an appropriate validated consequence tool.
+
+Attach the five results to `EngineeringProductionReadinessBasis`. They become independent fail-closed readiness
+gates, exact `method@version` entries in the benchmark and project-qualification backlog, canonical calculation nodes
+in the engineering graph/DAG, and evidence in the relevant coordinated package reports. A numerically passing result
+retains `CALCULATED_REVIEW_REQUIRED` until its standards, evidence, vendor and accountable review records are valid.
+
 See `examples/notebooks/engineering_production_qualification_workflow.ipynb` for benchmark, DEXPI, pilot, release and
 relief workflow examples. The notebook uses synthetic references only to demonstrate the API; replace every such value
 and reviewer string with controlled project evidence before assessing readiness.
@@ -419,7 +446,7 @@ replace accountable discipline work for:
 - HAZOP/LOPA scenario credibility, SIL selection or SRS approval;
 - vendor compressor, pump, exchanger, valve or instrument guarantees;
 - final two-phase relief method and disposal-system network verification;
-- code mechanical design, fatigue, external loads, nozzle reinforcement or fabrication;
+- final code mechanical design, fatigue/load-model acceptance, nozzle design or fabrication release;
 - corrosion assessment, welding and material approval;
 - plot plan, maintainability, escape, access, fire and gas coverage; or
 - construction, commissioning and operating approval.

--- a/src/main/java/neqsim/process/engineering/calculation/EngineeringCalculationResult.java
+++ b/src/main/java/neqsim/process/engineering/calculation/EngineeringCalculationResult.java
@@ -81,6 +81,33 @@ public final class EngineeringCalculationResult<T> implements Serializable {
     return calculationId;
   }
 
+  /**
+   * Gets the stable calculation method identifier.
+   *
+   * @return method identifier
+   */
+  public String getMethod() {
+    return method;
+  }
+
+  /**
+   * Gets the calculation method version.
+   *
+   * @return method version
+   */
+  public String getMethodVersion() {
+    return methodVersion;
+  }
+
+  /**
+   * Gets the controlled execution context used by the calculation.
+   *
+   * @return calculation context containing case, standards, evidence, and method attributes
+   */
+  public EngineeringCalculationContext getContext() {
+    return context;
+  }
+
   public Status getStatus() {
     return status;
   }
@@ -91,6 +118,15 @@ public final class EngineeringCalculationResult<T> implements Serializable {
 
   public CalculationReadiness getReadiness() {
     return readiness;
+  }
+
+  /**
+   * Gets the human-readable calculation outcome message.
+   *
+   * @return outcome message, or an empty string when none was supplied
+   */
+  public String getMessage() {
+    return message;
   }
 
   public Map<String, Object> toMap() {

--- a/src/main/java/neqsim/process/engineering/calculation/EngineeringConstraintResult.java
+++ b/src/main/java/neqsim/process/engineering/calculation/EngineeringConstraintResult.java
@@ -1,0 +1,11 @@
+package neqsim.process.engineering.calculation;
+
+/** Common contract for typed engineering results that expose an explicit constraint verdict. */
+public interface EngineeringConstraintResult {
+  /**
+   * Tests whether every declared engineering constraint is satisfied.
+   *
+   * @return true only when at least one constraint exists and all declared constraints pass
+   */
+  boolean allConstraintsSatisfied();
+}

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringCoordinatedPackage.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringCoordinatedPackage.java
@@ -17,6 +17,7 @@ import neqsim.process.engineering.model.EngineeringGraph;
 import neqsim.process.engineering.model.EngineeringGraphDiff;
 import neqsim.process.engineering.model.EngineeringNode;
 import neqsim.process.engineering.production.EngineeringProductionReadinessAssessment;
+import neqsim.process.engineering.production.EngineeringProductionReadinessBasis;
 
 /** Builds coordinated, traceable engineering documents from the canonical project and graph. */
 final class EngineeringCoordinatedPackage {
@@ -88,6 +89,13 @@ final class EngineeringCoordinatedPackage {
     }
     result.put("datasheets", rows);
     result.put("rowCount", Integer.valueOf(rows.size()));
+    EngineeringProductionReadinessBasis basis = project.getProductionReadinessBasis();
+    result.put("compressorProtectionQualification",
+        basis == null || basis.getCompressorProtectionQualification() == null ? null
+            : basis.getCompressorProtectionQualification().toMap());
+    result.put("mechanicalIntegrityQualification",
+        basis == null || basis.getMechanicalIntegrityQualification() == null ? null
+            : basis.getMechanicalIntegrityQualification().toMap());
     return result;
   }
 
@@ -104,6 +112,10 @@ final class EngineeringCoordinatedPackage {
     }
     result.put("rows", rows);
     result.put("rowCount", Integer.valueOf(rows.size()));
+    EngineeringProductionReadinessBasis basis = project.getProductionReadinessBasis();
+    result.put("valveInstrumentQualification",
+        basis == null || basis.getValveInstrumentQualification() == null ? null
+            : basis.getValveInstrumentQualification().toMap());
     return result;
   }
 
@@ -187,6 +199,13 @@ final class EngineeringCoordinatedPackage {
     result.put("dynamicScenarioCount", Integer.valueOf(project.getDynamicSafetyScenarios().size()));
     result.put("requiredInterfaces", java.util.Arrays.asList("flare network hydraulics", "radiation", "dispersion",
         "noise", "minimum metal temperature"));
+    EngineeringProductionReadinessBasis basis = project.getProductionReadinessBasis();
+    result.put("flareConsequenceQualification",
+        basis == null || basis.getFlareConsequenceQualification() == null ? null
+            : basis.getFlareConsequenceQualification().toMap());
+    result.put("transientPipingQualification",
+        basis == null || basis.getTransientPipingQualification() == null ? null
+            : basis.getTransientPipingQualification().toMap());
     result.put("approvalStatus", "REVIEW_REQUIRED");
     return result;
   }
@@ -221,6 +240,10 @@ final class EngineeringCoordinatedPackage {
       }
     }
     result.put("calculatedValues", values);
+    EngineeringProductionReadinessBasis basis = project.getProductionReadinessBasis();
+    result.put("mechanicalIntegrityQualification",
+        basis == null || basis.getMechanicalIntegrityQualification() == null ? null
+            : basis.getMechanicalIntegrityQualification().toMap());
     result.put("standard", "NORSOK M-001:2025");
     result.put("finalMetallurgyApproved", Boolean.FALSE);
     return result;

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringCoordinatedPackage.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringCoordinatedPackage.java
@@ -113,9 +113,8 @@ final class EngineeringCoordinatedPackage {
     result.put("rows", rows);
     result.put("rowCount", Integer.valueOf(rows.size()));
     EngineeringProductionReadinessBasis basis = project.getProductionReadinessBasis();
-    result.put("valveInstrumentQualification",
-        basis == null || basis.getValveInstrumentQualification() == null ? null
-            : basis.getValveInstrumentQualification().toMap());
+    result.put("valveInstrumentQualification", basis == null || basis.getValveInstrumentQualification() == null ? null
+        : basis.getValveInstrumentQualification().toMap());
     return result;
   }
 
@@ -200,12 +199,10 @@ final class EngineeringCoordinatedPackage {
     result.put("requiredInterfaces", java.util.Arrays.asList("flare network hydraulics", "radiation", "dispersion",
         "noise", "minimum metal temperature"));
     EngineeringProductionReadinessBasis basis = project.getProductionReadinessBasis();
-    result.put("flareConsequenceQualification",
-        basis == null || basis.getFlareConsequenceQualification() == null ? null
-            : basis.getFlareConsequenceQualification().toMap());
-    result.put("transientPipingQualification",
-        basis == null || basis.getTransientPipingQualification() == null ? null
-            : basis.getTransientPipingQualification().toMap());
+    result.put("flareConsequenceQualification", basis == null || basis.getFlareConsequenceQualification() == null ? null
+        : basis.getFlareConsequenceQualification().toMap());
+    result.put("transientPipingQualification", basis == null || basis.getTransientPipingQualification() == null ? null
+        : basis.getTransientPipingQualification().toMap());
     result.put("approvalStatus", "REVIEW_REQUIRED");
     return result;
   }

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
@@ -251,6 +251,11 @@ public final class EngineeringDeliverableCompiler {
     }
     List<EngineeringCalculation> dagCalculations = new ArrayList<EngineeringCalculation>(project.getCalculations());
     dagCalculations.addAll(envelopeCalculations);
+    if (project.getProductionReadinessBasis() != null) {
+      String projectNodeId = EngineeringIds.nodeId(EngineeringNode.Kind.PROJECT, project.getProjectId());
+      dagCalculations
+          .addAll(project.getProductionReadinessBasis().getTechnicalQualificationCalculations(projectNodeId));
+    }
     EngineeringCalculationDag calculationDag = EngineeringCalculationDag.from(dagCalculations);
     EngineeringGraph graph = EngineeringGraphBuilder.fromProject(project, envelopeCalculations);
     addDocumentNodes(graph, project);

--- a/src/main/java/neqsim/process/engineering/instrumentation/ValveInstrumentQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/instrumentation/ValveInstrumentQualificationCalculation.java
@@ -255,6 +255,11 @@ public final class ValveInstrumentQualificationCalculation implements
     if (!readiness.isReady()) {
       return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
     }
+    if (input == null) {
+      return output.status(EngineeringCalculationResult.Status.BLOCKED)
+          .warning("Calculation input is missing")
+          .build();
+    }
     double totalResponseSeconds = input.valveStrokeSeconds + input.instrumentResponseSeconds
         + input.logicSolverResponseSeconds;
     double rangeSpan = input.calibratedUpperRange - input.calibratedLowerRange;

--- a/src/main/java/neqsim/process/engineering/instrumentation/ValveInstrumentQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/instrumentation/ValveInstrumentQualificationCalculation.java
@@ -1,0 +1,341 @@
+package neqsim.process.engineering.instrumentation;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import neqsim.process.engineering.calculation.CalculationReadiness;
+import neqsim.process.engineering.calculation.EngineeringCalculationContext;
+import neqsim.process.engineering.calculation.EngineeringCalculationModule;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+import neqsim.process.engineering.calculation.EngineeringConstraintResult;
+
+/**
+ * Qualifies valve actuation and instrument installation evidence for one protective or control loop.
+ *
+ * <p>
+ * Hydraulic Cv/noise/cavitation calculations, valve mechanical-design output, transmitter data,
+ * {@code ThermowellDesignCalculator} output and dynamic loop tests can be mapped into this input. Failure action,
+ * leakage class, permissive/reset/restart logic and final tuning remain controlled HAZOP, SRS, vendor and project
+ * inputs.
+ * </p>
+ */
+public final class ValveInstrumentQualificationCalculation implements
+    EngineeringCalculationModule<ValveInstrumentQualificationCalculation.Input, ValveInstrumentQualificationCalculation.Result> {
+
+  /** Controlled valve, instrument and response-budget input. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String loopId;
+    private final String valveTag;
+    private final String instrumentTag;
+    private final double requiredActuatorThrustN;
+    private final double selectedActuatorThrustN;
+    private final double requiredShutoffDifferentialPressureBar;
+    private final double actuatorShutoffRatingBar;
+    private final double measuredLeakageRateKgS;
+    private final double allowableLeakageRateKgS;
+    private final double valveStrokeSeconds;
+    private final double instrumentResponseSeconds;
+    private final double logicSolverResponseSeconds;
+    private final double processSafetyTimeSeconds;
+    private final double processMinimum;
+    private final double processMaximum;
+    private final double calibratedLowerRange;
+    private final double calibratedUpperRange;
+    private final double measurementUncertainty;
+    private final double maximumAllowableUncertainty;
+    private final double thermowellFrequencyRatio;
+    private final double minimumThermowellFrequencyRatio;
+    private final double thermowellStressUtilization;
+    private final boolean failureActionApproved;
+    private final boolean vendorSizingAccepted;
+    private final boolean tapAndImpulseLineApproved;
+    private final boolean tuningDynamicallyValidated;
+    private final boolean permissiveResetRestartApproved;
+
+    private Input(Builder builder) {
+      loopId = text(builder.loopId, "loopId");
+      valveTag = text(builder.valveTag, "valveTag");
+      instrumentTag = text(builder.instrumentTag, "instrumentTag");
+      requiredActuatorThrustN = positive(builder.requiredActuatorThrustN, "requiredActuatorThrustN");
+      selectedActuatorThrustN = positive(builder.selectedActuatorThrustN, "selectedActuatorThrustN");
+      requiredShutoffDifferentialPressureBar = nonNegative(builder.requiredShutoffDifferentialPressureBar,
+          "requiredShutoffDifferentialPressureBar");
+      actuatorShutoffRatingBar = nonNegative(builder.actuatorShutoffRatingBar, "actuatorShutoffRatingBar");
+      measuredLeakageRateKgS = nonNegative(builder.measuredLeakageRateKgS, "measuredLeakageRateKgS");
+      allowableLeakageRateKgS = nonNegative(builder.allowableLeakageRateKgS, "allowableLeakageRateKgS");
+      valveStrokeSeconds = nonNegative(builder.valveStrokeSeconds, "valveStrokeSeconds");
+      instrumentResponseSeconds = nonNegative(builder.instrumentResponseSeconds, "instrumentResponseSeconds");
+      logicSolverResponseSeconds = nonNegative(builder.logicSolverResponseSeconds, "logicSolverResponseSeconds");
+      processSafetyTimeSeconds = positive(builder.processSafetyTimeSeconds, "processSafetyTimeSeconds");
+      processMinimum = finite(builder.processMinimum, "processMinimum");
+      processMaximum = finite(builder.processMaximum, "processMaximum");
+      calibratedLowerRange = finite(builder.calibratedLowerRange, "calibratedLowerRange");
+      calibratedUpperRange = finite(builder.calibratedUpperRange, "calibratedUpperRange");
+      if (processMaximum < processMinimum || calibratedUpperRange <= calibratedLowerRange) {
+        throw new IllegalArgumentException("process and calibrated ranges must be ordered");
+      }
+      measurementUncertainty = nonNegative(builder.measurementUncertainty, "measurementUncertainty");
+      maximumAllowableUncertainty = nonNegative(builder.maximumAllowableUncertainty,
+          "maximumAllowableUncertainty");
+      thermowellFrequencyRatio = nonNegative(builder.thermowellFrequencyRatio, "thermowellFrequencyRatio");
+      minimumThermowellFrequencyRatio = nonNegative(builder.minimumThermowellFrequencyRatio,
+          "minimumThermowellFrequencyRatio");
+      thermowellStressUtilization = nonNegative(builder.thermowellStressUtilization,
+          "thermowellStressUtilization");
+      failureActionApproved = builder.failureActionApproved;
+      vendorSizingAccepted = builder.vendorSizingAccepted;
+      tapAndImpulseLineApproved = builder.tapAndImpulseLineApproved;
+      tuningDynamicallyValidated = builder.tuningDynamicallyValidated;
+      permissiveResetRestartApproved = builder.permissiveResetRestartApproved;
+    }
+
+    public static Builder builder(String loopId, String valveTag, String instrumentTag) {
+      return new Builder(loopId, valveTag, instrumentTag);
+    }
+
+    /** Builder for controlled valve and instrument evidence. */
+    public static final class Builder {
+      private final String loopId;
+      private final String valveTag;
+      private final String instrumentTag;
+      private double requiredActuatorThrustN;
+      private double selectedActuatorThrustN;
+      private double requiredShutoffDifferentialPressureBar;
+      private double actuatorShutoffRatingBar;
+      private double measuredLeakageRateKgS;
+      private double allowableLeakageRateKgS;
+      private double valveStrokeSeconds;
+      private double instrumentResponseSeconds;
+      private double logicSolverResponseSeconds;
+      private double processSafetyTimeSeconds;
+      private double processMinimum;
+      private double processMaximum;
+      private double calibratedLowerRange;
+      private double calibratedUpperRange;
+      private double measurementUncertainty;
+      private double maximumAllowableUncertainty;
+      private double thermowellFrequencyRatio;
+      private double minimumThermowellFrequencyRatio;
+      private double thermowellStressUtilization;
+      private boolean failureActionApproved;
+      private boolean vendorSizingAccepted;
+      private boolean tapAndImpulseLineApproved;
+      private boolean tuningDynamicallyValidated;
+      private boolean permissiveResetRestartApproved;
+
+      private Builder(String loopId, String valveTag, String instrumentTag) {
+        this.loopId = loopId;
+        this.valveTag = valveTag;
+        this.instrumentTag = instrumentTag;
+      }
+
+      public Builder actuator(double requiredThrustN, double selectedThrustN, double requiredShutoffBar,
+          double shutoffRatingBar) {
+        requiredActuatorThrustN = requiredThrustN;
+        selectedActuatorThrustN = selectedThrustN;
+        requiredShutoffDifferentialPressureBar = requiredShutoffBar;
+        actuatorShutoffRatingBar = shutoffRatingBar;
+        return this;
+      }
+
+      public Builder leakage(double measuredKgS, double allowableKgS) {
+        measuredLeakageRateKgS = measuredKgS;
+        allowableLeakageRateKgS = allowableKgS;
+        return this;
+      }
+
+      public Builder responseBudget(double valveSeconds, double instrumentSeconds, double logicSeconds,
+          double safetyTimeSeconds) {
+        valveStrokeSeconds = valveSeconds;
+        instrumentResponseSeconds = instrumentSeconds;
+        logicSolverResponseSeconds = logicSeconds;
+        processSafetyTimeSeconds = safetyTimeSeconds;
+        return this;
+      }
+
+      public Builder transmitterRange(double processMinimum, double processMaximum, double calibratedLower,
+          double calibratedUpper, double uncertainty, double allowableUncertainty) {
+        this.processMinimum = processMinimum;
+        this.processMaximum = processMaximum;
+        calibratedLowerRange = calibratedLower;
+        calibratedUpperRange = calibratedUpper;
+        measurementUncertainty = uncertainty;
+        maximumAllowableUncertainty = allowableUncertainty;
+        return this;
+      }
+
+      public Builder thermowell(double frequencyRatio, double minimumFrequencyRatio, double stressUtilization) {
+        thermowellFrequencyRatio = frequencyRatio;
+        minimumThermowellFrequencyRatio = minimumFrequencyRatio;
+        thermowellStressUtilization = stressUtilization;
+        return this;
+      }
+
+      public Builder approvals(boolean failureAction, boolean vendorSizing, boolean installation,
+          boolean dynamicTuning, boolean permissiveResetRestart) {
+        failureActionApproved = failureAction;
+        vendorSizingAccepted = vendorSizing;
+        tapAndImpulseLineApproved = installation;
+        tuningDynamicallyValidated = dynamicTuning;
+        permissiveResetRestartApproved = permissiveResetRestart;
+        return this;
+      }
+
+      public Input build() {
+        return new Input(this);
+      }
+    }
+  }
+
+  /** Immutable qualification metrics and constraints. */
+  public static final class Result implements EngineeringConstraintResult, Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Map<String, Double> metrics;
+    private final Map<String, Boolean> constraints;
+
+    private Result(Map<String, Double> metrics, Map<String, Boolean> constraints) {
+      this.metrics = Collections.unmodifiableMap(new LinkedHashMap<String, Double>(metrics));
+      this.constraints = Collections.unmodifiableMap(new LinkedHashMap<String, Boolean>(constraints));
+    }
+
+    @Override
+    public boolean allConstraintsSatisfied() {
+      for (Boolean value : constraints.values()) {
+        if (!value.booleanValue()) {
+          return false;
+        }
+      }
+      return !constraints.isEmpty();
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("metrics", new LinkedHashMap<String, Double>(metrics));
+      result.put("constraints", new LinkedHashMap<String, Boolean>(constraints));
+      result.put("allConstraintsSatisfied", Boolean.valueOf(allConstraintsSatisfied()));
+      result.put("failureActionRequiresHazopOrSrsApproval", Boolean.TRUE);
+      result.put("engineeringApprovalRequired", Boolean.TRUE);
+      return result;
+    }
+  }
+
+  @Override
+  public String getMethod() {
+    return "valve-instrument-installation-and-response-qualification";
+  }
+
+  @Override
+  public String getMethodVersion() {
+    return "1.0";
+  }
+
+  @Override
+  public CalculationReadiness assess(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness.Builder readiness = CalculationReadiness.builder();
+    if (input == null) {
+      return readiness.addBlocker("VALVE_INSTRUMENT_INPUT", "Valve and instrument input is required",
+          "Supply valve, transmitter, installation and response evidence").build();
+    }
+    if (productionQualification(context)
+        && (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty())) {
+      readiness.addBlocker("VALVE_INSTRUMENT_PRODUCTION_EVIDENCE",
+          "Production qualification requires vendor, installation, SRS and standards evidence",
+          "Attach controlled vendor data, loop calculations, installation review and SRS references");
+    }
+    return readiness.build();
+  }
+
+  @Override
+  public EngineeringCalculationResult<Result> calculate(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness readiness = assess(input, context);
+    EngineeringCalculationResult.Builder<Result> output = EngineeringCalculationResult
+        .<Result>builder("valve-instrument:" + (input == null ? "unassigned" : input.loopId), getMethod(),
+            getMethodVersion())
+        .context(context).readiness(readiness);
+    if (!readiness.isReady()) {
+      return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
+    }
+    double totalResponseSeconds = input.valveStrokeSeconds + input.instrumentResponseSeconds
+        + input.logicSolverResponseSeconds;
+    double rangeSpan = input.calibratedUpperRange - input.calibratedLowerRange;
+    double processSpan = input.processMaximum - input.processMinimum;
+
+    Map<String, Double> metrics = new LinkedHashMap<String, Double>();
+    metrics.put("actuatorThrustMarginN",
+        Double.valueOf(input.selectedActuatorThrustN - input.requiredActuatorThrustN));
+    metrics.put("shutoffPressureMarginBar",
+        Double.valueOf(input.actuatorShutoffRatingBar - input.requiredShutoffDifferentialPressureBar));
+    metrics.put("leakageMarginKgS",
+        Double.valueOf(input.allowableLeakageRateKgS - input.measuredLeakageRateKgS));
+    metrics.put("totalSafetyResponseSeconds", Double.valueOf(totalResponseSeconds));
+    metrics.put("processSafetyTimeMarginSeconds",
+        Double.valueOf(input.processSafetyTimeSeconds - totalResponseSeconds));
+    metrics.put("calibratedSpan", Double.valueOf(rangeSpan));
+    metrics.put("processSpan", Double.valueOf(processSpan));
+    metrics.put("measurementUncertainty", Double.valueOf(input.measurementUncertainty));
+    metrics.put("thermowellFrequencyRatio", Double.valueOf(input.thermowellFrequencyRatio));
+    metrics.put("thermowellStressUtilization", Double.valueOf(input.thermowellStressUtilization));
+
+    Map<String, Boolean> constraints = new LinkedHashMap<String, Boolean>();
+    constraints.put("ACTUATOR_THRUST",
+        Boolean.valueOf(input.selectedActuatorThrustN >= input.requiredActuatorThrustN));
+    constraints.put("SHUTOFF_DIFFERENTIAL_PRESSURE",
+        Boolean.valueOf(input.actuatorShutoffRatingBar >= input.requiredShutoffDifferentialPressureBar));
+    constraints.put("LEAKAGE_RATE",
+        Boolean.valueOf(input.measuredLeakageRateKgS <= input.allowableLeakageRateKgS));
+    constraints.put("PROCESS_SAFETY_TIME", Boolean.valueOf(totalResponseSeconds <= input.processSafetyTimeSeconds));
+    constraints.put("TRANSMITTER_RANGE", Boolean.valueOf(input.calibratedLowerRange <= input.processMinimum
+        && input.calibratedUpperRange >= input.processMaximum));
+    constraints.put("MEASUREMENT_UNCERTAINTY",
+        Boolean.valueOf(input.measurementUncertainty <= input.maximumAllowableUncertainty));
+    constraints.put("THERMOWELL_FREQUENCY_SEPARATION",
+        Boolean.valueOf(input.thermowellFrequencyRatio >= input.minimumThermowellFrequencyRatio));
+    constraints.put("THERMOWELL_STRESS", Boolean.valueOf(input.thermowellStressUtilization <= 1.0));
+    constraints.put("FAILURE_ACTION_APPROVED", Boolean.valueOf(input.failureActionApproved));
+    constraints.put("VENDOR_SIZING_ACCEPTED", Boolean.valueOf(input.vendorSizingAccepted));
+    constraints.put("TAP_AND_IMPULSE_LINE_APPROVED", Boolean.valueOf(input.tapAndImpulseLineApproved));
+    constraints.put("DYNAMIC_TUNING_VALIDATED", Boolean.valueOf(input.tuningDynamicallyValidated));
+    constraints.put("PERMISSIVE_RESET_RESTART_APPROVED",
+        Boolean.valueOf(input.permissiveResetRestartApproved));
+
+    return output.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED)
+        .input("loopId", input.loopId).input("valveTag", input.valveTag)
+        .input("instrumentTag", input.instrumentTag).value(new Result(metrics, constraints))
+        .warning("Valve leakage class, final actuator selection, installation and loop tuning require approval")
+        .build();
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double positive(double value, String field) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and positive");
+    }
+    return value;
+  }
+
+  private static double nonNegative(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and non-negative");
+    }
+    return value;
+  }
+
+  private static double finite(double value, String field) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(field + " must be finite");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/instrumentation/ValveInstrumentQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/instrumentation/ValveInstrumentQualificationCalculation.java
@@ -77,13 +77,11 @@ public final class ValveInstrumentQualificationCalculation implements
         throw new IllegalArgumentException("process and calibrated ranges must be ordered");
       }
       measurementUncertainty = nonNegative(builder.measurementUncertainty, "measurementUncertainty");
-      maximumAllowableUncertainty = nonNegative(builder.maximumAllowableUncertainty,
-          "maximumAllowableUncertainty");
+      maximumAllowableUncertainty = nonNegative(builder.maximumAllowableUncertainty, "maximumAllowableUncertainty");
       thermowellFrequencyRatio = nonNegative(builder.thermowellFrequencyRatio, "thermowellFrequencyRatio");
       minimumThermowellFrequencyRatio = nonNegative(builder.minimumThermowellFrequencyRatio,
           "minimumThermowellFrequencyRatio");
-      thermowellStressUtilization = nonNegative(builder.thermowellStressUtilization,
-          "thermowellStressUtilization");
+      thermowellStressUtilization = nonNegative(builder.thermowellStressUtilization, "thermowellStressUtilization");
       failureActionApproved = builder.failureActionApproved;
       vendorSizingAccepted = builder.vendorSizingAccepted;
       tapAndImpulseLineApproved = builder.tapAndImpulseLineApproved;
@@ -173,8 +171,8 @@ public final class ValveInstrumentQualificationCalculation implements
         return this;
       }
 
-      public Builder approvals(boolean failureAction, boolean vendorSizing, boolean installation,
-          boolean dynamicTuning, boolean permissiveResetRestart) {
+      public Builder approvals(boolean failureAction, boolean vendorSizing, boolean installation, boolean dynamicTuning,
+          boolean permissiveResetRestart) {
         failureActionApproved = failureAction;
         vendorSizingAccepted = vendorSizing;
         tapAndImpulseLineApproved = installation;
@@ -263,12 +261,10 @@ public final class ValveInstrumentQualificationCalculation implements
     double processSpan = input.processMaximum - input.processMinimum;
 
     Map<String, Double> metrics = new LinkedHashMap<String, Double>();
-    metrics.put("actuatorThrustMarginN",
-        Double.valueOf(input.selectedActuatorThrustN - input.requiredActuatorThrustN));
+    metrics.put("actuatorThrustMarginN", Double.valueOf(input.selectedActuatorThrustN - input.requiredActuatorThrustN));
     metrics.put("shutoffPressureMarginBar",
         Double.valueOf(input.actuatorShutoffRatingBar - input.requiredShutoffDifferentialPressureBar));
-    metrics.put("leakageMarginKgS",
-        Double.valueOf(input.allowableLeakageRateKgS - input.measuredLeakageRateKgS));
+    metrics.put("leakageMarginKgS", Double.valueOf(input.allowableLeakageRateKgS - input.measuredLeakageRateKgS));
     metrics.put("totalSafetyResponseSeconds", Double.valueOf(totalResponseSeconds));
     metrics.put("processSafetyTimeMarginSeconds",
         Double.valueOf(input.processSafetyTimeSeconds - totalResponseSeconds));
@@ -279,15 +275,13 @@ public final class ValveInstrumentQualificationCalculation implements
     metrics.put("thermowellStressUtilization", Double.valueOf(input.thermowellStressUtilization));
 
     Map<String, Boolean> constraints = new LinkedHashMap<String, Boolean>();
-    constraints.put("ACTUATOR_THRUST",
-        Boolean.valueOf(input.selectedActuatorThrustN >= input.requiredActuatorThrustN));
+    constraints.put("ACTUATOR_THRUST", Boolean.valueOf(input.selectedActuatorThrustN >= input.requiredActuatorThrustN));
     constraints.put("SHUTOFF_DIFFERENTIAL_PRESSURE",
         Boolean.valueOf(input.actuatorShutoffRatingBar >= input.requiredShutoffDifferentialPressureBar));
-    constraints.put("LEAKAGE_RATE",
-        Boolean.valueOf(input.measuredLeakageRateKgS <= input.allowableLeakageRateKgS));
+    constraints.put("LEAKAGE_RATE", Boolean.valueOf(input.measuredLeakageRateKgS <= input.allowableLeakageRateKgS));
     constraints.put("PROCESS_SAFETY_TIME", Boolean.valueOf(totalResponseSeconds <= input.processSafetyTimeSeconds));
-    constraints.put("TRANSMITTER_RANGE", Boolean.valueOf(input.calibratedLowerRange <= input.processMinimum
-        && input.calibratedUpperRange >= input.processMaximum));
+    constraints.put("TRANSMITTER_RANGE", Boolean.valueOf(
+        input.calibratedLowerRange <= input.processMinimum && input.calibratedUpperRange >= input.processMaximum));
     constraints.put("MEASUREMENT_UNCERTAINTY",
         Boolean.valueOf(input.measurementUncertainty <= input.maximumAllowableUncertainty));
     constraints.put("THERMOWELL_FREQUENCY_SEPARATION",
@@ -297,12 +291,11 @@ public final class ValveInstrumentQualificationCalculation implements
     constraints.put("VENDOR_SIZING_ACCEPTED", Boolean.valueOf(input.vendorSizingAccepted));
     constraints.put("TAP_AND_IMPULSE_LINE_APPROVED", Boolean.valueOf(input.tapAndImpulseLineApproved));
     constraints.put("DYNAMIC_TUNING_VALIDATED", Boolean.valueOf(input.tuningDynamicallyValidated));
-    constraints.put("PERMISSIVE_RESET_RESTART_APPROVED",
-        Boolean.valueOf(input.permissiveResetRestartApproved));
+    constraints.put("PERMISSIVE_RESET_RESTART_APPROVED", Boolean.valueOf(input.permissiveResetRestartApproved));
 
-    return output.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED)
-        .input("loopId", input.loopId).input("valveTag", input.valveTag)
-        .input("instrumentTag", input.instrumentTag).value(new Result(metrics, constraints))
+    return output.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED).input("loopId", input.loopId)
+        .input("valveTag", input.valveTag).input("instrumentTag", input.instrumentTag)
+        .value(new Result(metrics, constraints))
         .warning("Valve leakage class, final actuator selection, installation and loop tuning require approval")
         .build();
   }

--- a/src/main/java/neqsim/process/engineering/mechanical/MechanicalIntegrityQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/mechanical/MechanicalIntegrityQualificationCalculation.java
@@ -1,0 +1,315 @@
+package neqsim.process.engineering.mechanical;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import neqsim.process.engineering.calculation.CalculationReadiness;
+import neqsim.process.engineering.calculation.EngineeringCalculationContext;
+import neqsim.process.engineering.calculation.EngineeringCalculationModule;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+import neqsim.process.engineering.calculation.EngineeringConstraintResult;
+
+/**
+ * Qualifies detailed pressure-boundary evidence without replacing the applicable mechanical design code.
+ *
+ * <p>
+ * Results from equipment-specific {@code MechanicalDesign} implementations or a project-qualified external code
+ * calculation are supplied explicitly. Internal pressure, external pressure, buckling, fatigue, nozzle reinforcement,
+ * external loads, MDMT, corrosion allowance and fabrication controls remain separate checks. This prevents a passing
+ * membrane-thickness calculation from being reported as a complete mechanical design.
+ * </p>
+ */
+public final class MechanicalIntegrityQualificationCalculation implements
+    EngineeringCalculationModule<MechanicalIntegrityQualificationCalculation.Input, MechanicalIntegrityQualificationCalculation.Result> {
+
+  /** Controlled pressure-boundary calculation and fabrication evidence. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String equipmentTag;
+    private final String sourceCalculation;
+    private final String sourceCalculationVersion;
+    private final double designPressureBara;
+    private final double calculatedMawpBara;
+    private final double requiredStructuralThicknessMm;
+    private final double availableStructuralThicknessMm;
+    private final double externalDesignPressureBar;
+    private final double allowableExternalPressureBar;
+    private final double bucklingUtilization;
+    private final double fatigueUsageFactor;
+    private final double requiredNozzleReinforcementAreaMm2;
+    private final double availableNozzleReinforcementAreaMm2;
+    private final double externalLoadUtilization;
+    private final double designMinimumTemperatureC;
+    private final double materialQualifiedMdmtC;
+    private final double requiredCorrosionAllowanceMm;
+    private final double specifiedCorrosionAllowanceMm;
+    private final boolean designCodeBasisApproved;
+    private final boolean materialSpecificationApproved;
+    private final boolean fabricationProcedureApproved;
+    private final boolean ndePlanApproved;
+
+    private Input(Builder builder) {
+      equipmentTag = text(builder.equipmentTag, "equipmentTag");
+      sourceCalculation = text(builder.sourceCalculation, "sourceCalculation");
+      sourceCalculationVersion = text(builder.sourceCalculationVersion, "sourceCalculationVersion");
+      designPressureBara = positive(builder.designPressureBara, "designPressureBara");
+      calculatedMawpBara = positive(builder.calculatedMawpBara, "calculatedMawpBara");
+      requiredStructuralThicknessMm = positive(builder.requiredStructuralThicknessMm,
+          "requiredStructuralThicknessMm");
+      availableStructuralThicknessMm = positive(builder.availableStructuralThicknessMm,
+          "availableStructuralThicknessMm");
+      externalDesignPressureBar = nonNegative(builder.externalDesignPressureBar, "externalDesignPressureBar");
+      allowableExternalPressureBar = nonNegative(builder.allowableExternalPressureBar,
+          "allowableExternalPressureBar");
+      bucklingUtilization = nonNegative(builder.bucklingUtilization, "bucklingUtilization");
+      fatigueUsageFactor = nonNegative(builder.fatigueUsageFactor, "fatigueUsageFactor");
+      requiredNozzleReinforcementAreaMm2 = nonNegative(builder.requiredNozzleReinforcementAreaMm2,
+          "requiredNozzleReinforcementAreaMm2");
+      availableNozzleReinforcementAreaMm2 = nonNegative(builder.availableNozzleReinforcementAreaMm2,
+          "availableNozzleReinforcementAreaMm2");
+      externalLoadUtilization = nonNegative(builder.externalLoadUtilization, "externalLoadUtilization");
+      designMinimumTemperatureC = finite(builder.designMinimumTemperatureC, "designMinimumTemperatureC");
+      materialQualifiedMdmtC = finite(builder.materialQualifiedMdmtC, "materialQualifiedMdmtC");
+      requiredCorrosionAllowanceMm = nonNegative(builder.requiredCorrosionAllowanceMm,
+          "requiredCorrosionAllowanceMm");
+      specifiedCorrosionAllowanceMm = nonNegative(builder.specifiedCorrosionAllowanceMm,
+          "specifiedCorrosionAllowanceMm");
+      designCodeBasisApproved = builder.designCodeBasisApproved;
+      materialSpecificationApproved = builder.materialSpecificationApproved;
+      fabricationProcedureApproved = builder.fabricationProcedureApproved;
+      ndePlanApproved = builder.ndePlanApproved;
+    }
+
+    public static Builder builder(String equipmentTag, String sourceCalculation, String sourceCalculationVersion) {
+      return new Builder(equipmentTag, sourceCalculation, sourceCalculationVersion);
+    }
+
+    /** Builder for detailed mechanical qualification input. */
+    public static final class Builder {
+      private final String equipmentTag;
+      private final String sourceCalculation;
+      private final String sourceCalculationVersion;
+      private double designPressureBara;
+      private double calculatedMawpBara;
+      private double requiredStructuralThicknessMm;
+      private double availableStructuralThicknessMm;
+      private double externalDesignPressureBar;
+      private double allowableExternalPressureBar;
+      private double bucklingUtilization;
+      private double fatigueUsageFactor;
+      private double requiredNozzleReinforcementAreaMm2;
+      private double availableNozzleReinforcementAreaMm2;
+      private double externalLoadUtilization;
+      private double designMinimumTemperatureC;
+      private double materialQualifiedMdmtC;
+      private double requiredCorrosionAllowanceMm;
+      private double specifiedCorrosionAllowanceMm;
+      private boolean designCodeBasisApproved;
+      private boolean materialSpecificationApproved;
+      private boolean fabricationProcedureApproved;
+      private boolean ndePlanApproved;
+
+      private Builder(String equipmentTag, String sourceCalculation, String sourceCalculationVersion) {
+        this.equipmentTag = equipmentTag;
+        this.sourceCalculation = sourceCalculation;
+        this.sourceCalculationVersion = sourceCalculationVersion;
+      }
+
+      public Builder internalPressure(double designPressureBara, double mawpBara, double requiredThicknessMm,
+          double availableThicknessMm) {
+        this.designPressureBara = designPressureBara;
+        calculatedMawpBara = mawpBara;
+        requiredStructuralThicknessMm = requiredThicknessMm;
+        availableStructuralThicknessMm = availableThicknessMm;
+        return this;
+      }
+
+      public Builder externalPressureAndBuckling(double externalPressureBar, double allowablePressureBar,
+          double bucklingUtilization) {
+        externalDesignPressureBar = externalPressureBar;
+        allowableExternalPressureBar = allowablePressureBar;
+        this.bucklingUtilization = bucklingUtilization;
+        return this;
+      }
+
+      public Builder fatigueAndExternalLoads(double fatigueUsage, double loadUtilization) {
+        fatigueUsageFactor = fatigueUsage;
+        externalLoadUtilization = loadUtilization;
+        return this;
+      }
+
+      public Builder nozzleReinforcement(double requiredAreaMm2, double availableAreaMm2) {
+        requiredNozzleReinforcementAreaMm2 = requiredAreaMm2;
+        availableNozzleReinforcementAreaMm2 = availableAreaMm2;
+        return this;
+      }
+
+      public Builder temperatureAndCorrosion(double designMinimumTemperatureC, double materialMdmtC,
+          double requiredCorrosionAllowanceMm, double specifiedCorrosionAllowanceMm) {
+        this.designMinimumTemperatureC = designMinimumTemperatureC;
+        materialQualifiedMdmtC = materialMdmtC;
+        this.requiredCorrosionAllowanceMm = requiredCorrosionAllowanceMm;
+        this.specifiedCorrosionAllowanceMm = specifiedCorrosionAllowanceMm;
+        return this;
+      }
+
+      public Builder approvals(boolean designCode, boolean material, boolean fabrication, boolean nde) {
+        designCodeBasisApproved = designCode;
+        materialSpecificationApproved = material;
+        fabricationProcedureApproved = fabrication;
+        ndePlanApproved = nde;
+        return this;
+      }
+
+      public Input build() {
+        return new Input(this);
+      }
+    }
+  }
+
+  /** Immutable mechanical-integrity metrics and constraints. */
+  public static final class Result implements EngineeringConstraintResult, Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Map<String, Double> metrics;
+    private final Map<String, Boolean> constraints;
+
+    private Result(Map<String, Double> metrics, Map<String, Boolean> constraints) {
+      this.metrics = Collections.unmodifiableMap(new LinkedHashMap<String, Double>(metrics));
+      this.constraints = Collections.unmodifiableMap(new LinkedHashMap<String, Boolean>(constraints));
+    }
+
+    @Override
+    public boolean allConstraintsSatisfied() {
+      for (Boolean value : constraints.values()) {
+        if (!value.booleanValue()) {
+          return false;
+        }
+      }
+      return !constraints.isEmpty();
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("metrics", new LinkedHashMap<String, Double>(metrics));
+      result.put("constraints", new LinkedHashMap<String, Boolean>(constraints));
+      result.put("allConstraintsSatisfied", Boolean.valueOf(allConstraintsSatisfied()));
+      result.put("qualificationConstraintsSatisfied", Boolean.valueOf(allConstraintsSatisfied()));
+      result.put("finalCodeDesignComplete", Boolean.FALSE);
+      result.put("fitnessForConstruction", Boolean.FALSE);
+      result.put("engineeringApprovalRequired", Boolean.TRUE);
+      return result;
+    }
+  }
+
+  @Override
+  public String getMethod() {
+    return "pressure-boundary-mechanical-integrity-qualification";
+  }
+
+  @Override
+  public String getMethodVersion() {
+    return "1.0";
+  }
+
+  @Override
+  public CalculationReadiness assess(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness.Builder readiness = CalculationReadiness.builder();
+    if (input == null) {
+      return readiness.addBlocker("MECHANICAL_INTEGRITY_INPUT", "Mechanical-integrity input is required",
+          "Supply the applicable code calculation and fabrication evidence").build();
+    }
+    if (productionQualification(context)
+        && (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty())) {
+      readiness.addBlocker("MECHANICAL_INTEGRITY_PRODUCTION_EVIDENCE",
+          "Production qualification requires code, material, load and fabrication evidence",
+          "Attach the controlled mechanical calculation and project code basis");
+    }
+    return readiness.build();
+  }
+
+  @Override
+  public EngineeringCalculationResult<Result> calculate(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness readiness = assess(input, context);
+    EngineeringCalculationResult.Builder<Result> output = EngineeringCalculationResult
+        .<Result>builder("mechanical-integrity:" + (input == null ? "unassigned" : input.equipmentTag), getMethod(),
+            getMethodVersion())
+        .context(context).readiness(readiness);
+    if (!readiness.isReady()) {
+      return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
+    }
+
+    Map<String, Double> metrics = new LinkedHashMap<String, Double>();
+    metrics.put("mawpMarginBar", Double.valueOf(input.calculatedMawpBara - input.designPressureBara));
+    metrics.put("structuralThicknessMarginMm",
+        Double.valueOf(input.availableStructuralThicknessMm - input.requiredStructuralThicknessMm));
+    metrics.put("externalPressureMarginBar",
+        Double.valueOf(input.allowableExternalPressureBar - input.externalDesignPressureBar));
+    metrics.put("bucklingUtilization", Double.valueOf(input.bucklingUtilization));
+    metrics.put("fatigueUsageFactor", Double.valueOf(input.fatigueUsageFactor));
+    metrics.put("nozzleReinforcementAreaMarginMm2", Double
+        .valueOf(input.availableNozzleReinforcementAreaMm2 - input.requiredNozzleReinforcementAreaMm2));
+    metrics.put("externalLoadUtilization", Double.valueOf(input.externalLoadUtilization));
+    metrics.put("mdmtMarginC", Double.valueOf(input.designMinimumTemperatureC - input.materialQualifiedMdmtC));
+    metrics.put("corrosionAllowanceMarginMm",
+        Double.valueOf(input.specifiedCorrosionAllowanceMm - input.requiredCorrosionAllowanceMm));
+
+    Map<String, Boolean> constraints = new LinkedHashMap<String, Boolean>();
+    constraints.put("INTERNAL_PRESSURE_MAWP",
+        Boolean.valueOf(input.calculatedMawpBara >= input.designPressureBara));
+    constraints.put("STRUCTURAL_THICKNESS",
+        Boolean.valueOf(input.availableStructuralThicknessMm >= input.requiredStructuralThicknessMm));
+    constraints.put("EXTERNAL_PRESSURE",
+        Boolean.valueOf(input.allowableExternalPressureBar >= input.externalDesignPressureBar));
+    constraints.put("BUCKLING", Boolean.valueOf(input.bucklingUtilization <= 1.0));
+    constraints.put("FATIGUE", Boolean.valueOf(input.fatigueUsageFactor <= 1.0));
+    constraints.put("NOZZLE_REINFORCEMENT", Boolean
+        .valueOf(input.availableNozzleReinforcementAreaMm2 >= input.requiredNozzleReinforcementAreaMm2));
+    constraints.put("EXTERNAL_LOADS", Boolean.valueOf(input.externalLoadUtilization <= 1.0));
+    constraints.put("MINIMUM_DESIGN_METAL_TEMPERATURE",
+        Boolean.valueOf(input.designMinimumTemperatureC >= input.materialQualifiedMdmtC));
+    constraints.put("CORROSION_ALLOWANCE",
+        Boolean.valueOf(input.specifiedCorrosionAllowanceMm >= input.requiredCorrosionAllowanceMm));
+    constraints.put("DESIGN_CODE_BASIS_APPROVED", Boolean.valueOf(input.designCodeBasisApproved));
+    constraints.put("MATERIAL_SPECIFICATION_APPROVED", Boolean.valueOf(input.materialSpecificationApproved));
+    constraints.put("FABRICATION_PROCEDURE_APPROVED", Boolean.valueOf(input.fabricationProcedureApproved));
+    constraints.put("NDE_PLAN_APPROVED", Boolean.valueOf(input.ndePlanApproved));
+
+    return output.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED)
+        .input("equipmentTag", input.equipmentTag).input("sourceCalculation", input.sourceCalculation)
+        .input("sourceCalculationVersion", input.sourceCalculationVersion).value(new Result(metrics, constraints))
+        .warning("Final fabrication release and construction approval remain accountable project decisions").build();
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double positive(double value, String field) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and positive");
+    }
+    return value;
+  }
+
+  private static double nonNegative(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and non-negative");
+    }
+    return value;
+  }
+
+  private static double finite(double value, String field) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(field + " must be finite");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/mechanical/MechanicalIntegrityQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/mechanical/MechanicalIntegrityQualificationCalculation.java
@@ -235,6 +235,9 @@ public final class MechanicalIntegrityQualificationCalculation implements
     if (!readiness.isReady()) {
       return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
     }
+    if (input == null) {
+      return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
+    }
 
     Map<String, Double> metrics = new LinkedHashMap<String, Double>();
     metrics.put("mawpMarginBar", Double.valueOf(input.calculatedMawpBara - input.designPressureBara));

--- a/src/main/java/neqsim/process/engineering/mechanical/MechanicalIntegrityQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/mechanical/MechanicalIntegrityQualificationCalculation.java
@@ -55,13 +55,11 @@ public final class MechanicalIntegrityQualificationCalculation implements
       sourceCalculationVersion = text(builder.sourceCalculationVersion, "sourceCalculationVersion");
       designPressureBara = positive(builder.designPressureBara, "designPressureBara");
       calculatedMawpBara = positive(builder.calculatedMawpBara, "calculatedMawpBara");
-      requiredStructuralThicknessMm = positive(builder.requiredStructuralThicknessMm,
-          "requiredStructuralThicknessMm");
+      requiredStructuralThicknessMm = positive(builder.requiredStructuralThicknessMm, "requiredStructuralThicknessMm");
       availableStructuralThicknessMm = positive(builder.availableStructuralThicknessMm,
           "availableStructuralThicknessMm");
       externalDesignPressureBar = nonNegative(builder.externalDesignPressureBar, "externalDesignPressureBar");
-      allowableExternalPressureBar = nonNegative(builder.allowableExternalPressureBar,
-          "allowableExternalPressureBar");
+      allowableExternalPressureBar = nonNegative(builder.allowableExternalPressureBar, "allowableExternalPressureBar");
       bucklingUtilization = nonNegative(builder.bucklingUtilization, "bucklingUtilization");
       fatigueUsageFactor = nonNegative(builder.fatigueUsageFactor, "fatigueUsageFactor");
       requiredNozzleReinforcementAreaMm2 = nonNegative(builder.requiredNozzleReinforcementAreaMm2,
@@ -71,8 +69,7 @@ public final class MechanicalIntegrityQualificationCalculation implements
       externalLoadUtilization = nonNegative(builder.externalLoadUtilization, "externalLoadUtilization");
       designMinimumTemperatureC = finite(builder.designMinimumTemperatureC, "designMinimumTemperatureC");
       materialQualifiedMdmtC = finite(builder.materialQualifiedMdmtC, "materialQualifiedMdmtC");
-      requiredCorrosionAllowanceMm = nonNegative(builder.requiredCorrosionAllowanceMm,
-          "requiredCorrosionAllowanceMm");
+      requiredCorrosionAllowanceMm = nonNegative(builder.requiredCorrosionAllowanceMm, "requiredCorrosionAllowanceMm");
       specifiedCorrosionAllowanceMm = nonNegative(builder.specifiedCorrosionAllowanceMm,
           "specifiedCorrosionAllowanceMm");
       designCodeBasisApproved = builder.designCodeBasisApproved;
@@ -247,24 +244,23 @@ public final class MechanicalIntegrityQualificationCalculation implements
         Double.valueOf(input.allowableExternalPressureBar - input.externalDesignPressureBar));
     metrics.put("bucklingUtilization", Double.valueOf(input.bucklingUtilization));
     metrics.put("fatigueUsageFactor", Double.valueOf(input.fatigueUsageFactor));
-    metrics.put("nozzleReinforcementAreaMarginMm2", Double
-        .valueOf(input.availableNozzleReinforcementAreaMm2 - input.requiredNozzleReinforcementAreaMm2));
+    metrics.put("nozzleReinforcementAreaMarginMm2",
+        Double.valueOf(input.availableNozzleReinforcementAreaMm2 - input.requiredNozzleReinforcementAreaMm2));
     metrics.put("externalLoadUtilization", Double.valueOf(input.externalLoadUtilization));
     metrics.put("mdmtMarginC", Double.valueOf(input.designMinimumTemperatureC - input.materialQualifiedMdmtC));
     metrics.put("corrosionAllowanceMarginMm",
         Double.valueOf(input.specifiedCorrosionAllowanceMm - input.requiredCorrosionAllowanceMm));
 
     Map<String, Boolean> constraints = new LinkedHashMap<String, Boolean>();
-    constraints.put("INTERNAL_PRESSURE_MAWP",
-        Boolean.valueOf(input.calculatedMawpBara >= input.designPressureBara));
+    constraints.put("INTERNAL_PRESSURE_MAWP", Boolean.valueOf(input.calculatedMawpBara >= input.designPressureBara));
     constraints.put("STRUCTURAL_THICKNESS",
         Boolean.valueOf(input.availableStructuralThicknessMm >= input.requiredStructuralThicknessMm));
     constraints.put("EXTERNAL_PRESSURE",
         Boolean.valueOf(input.allowableExternalPressureBar >= input.externalDesignPressureBar));
     constraints.put("BUCKLING", Boolean.valueOf(input.bucklingUtilization <= 1.0));
     constraints.put("FATIGUE", Boolean.valueOf(input.fatigueUsageFactor <= 1.0));
-    constraints.put("NOZZLE_REINFORCEMENT", Boolean
-        .valueOf(input.availableNozzleReinforcementAreaMm2 >= input.requiredNozzleReinforcementAreaMm2));
+    constraints.put("NOZZLE_REINFORCEMENT",
+        Boolean.valueOf(input.availableNozzleReinforcementAreaMm2 >= input.requiredNozzleReinforcementAreaMm2));
     constraints.put("EXTERNAL_LOADS", Boolean.valueOf(input.externalLoadUtilization <= 1.0));
     constraints.put("MINIMUM_DESIGN_METAL_TEMPERATURE",
         Boolean.valueOf(input.designMinimumTemperatureC >= input.materialQualifiedMdmtC));

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphBuilder.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphBuilder.java
@@ -71,6 +71,10 @@ public final class EngineeringGraphBuilder {
     addDesignCases(project, graph, projectNodeId);
     List<EngineeringCalculation> allCalculations = new ArrayList<EngineeringCalculation>(project.getCalculations());
     allCalculations.addAll(additionalCalculations);
+    if (project.getProductionReadinessBasis() != null) {
+      allCalculations
+          .addAll(project.getProductionReadinessBasis().getTechnicalQualificationCalculations(projectNodeId));
+    }
     addCalculations(allCalculations, graph, projectNodeId);
     addApprovals(project, graph, projectNodeId);
     return graph;

--- a/src/main/java/neqsim/process/engineering/piping/TransientPipingQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/piping/TransientPipingQualificationCalculation.java
@@ -16,11 +16,11 @@ import neqsim.process.engineering.calculation.EngineeringConstraintResult;
  * Qualifies a distributed piping-transient profile for engineering use.
  *
  * <p>
- * The hydraulic transient remains the responsibility of the declared source model, for example
- * {@code TwoFluidPipe}, {@code WaterHammerPipe}, or a project-qualified external solver. This calculation verifies
- * that the exported profile resolves the acoustic time scale, closes the line-pack balance, and satisfies explicit
- * pressure, slug, acoustic, vibration and stress constraints. It does not turn a quasi-steady line calculation into a
- * distributed transient model.
+ * The hydraulic transient remains the responsibility of the declared source model, for example {@code TwoFluidPipe},
+ * {@code WaterHammerPipe}, or a project-qualified external solver. This calculation verifies that the exported profile
+ * resolves the acoustic time scale, closes the line-pack balance, and satisfies explicit pressure, slug, acoustic,
+ * vibration and stress constraints. It does not turn a quasi-steady line calculation into a distributed transient
+ * model.
  * </p>
  */
 public final class TransientPipingQualificationCalculation implements

--- a/src/main/java/neqsim/process/engineering/piping/TransientPipingQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/piping/TransientPipingQualificationCalculation.java
@@ -64,11 +64,9 @@ public final class TransientPipingQualificationCalculation implements
       if (maximumPressureBara < minimumPressureBara) {
         throw new IllegalArgumentException("maximumPressureBara must not be below minimumPressureBara");
       }
-      this.maximumLiquidHoldupFraction = fraction(maximumLiquidHoldupFraction,
-          "maximumLiquidHoldupFraction");
+      this.maximumLiquidHoldupFraction = fraction(maximumLiquidHoldupFraction, "maximumLiquidHoldupFraction");
       this.maximumVelocityMPerS = nonNegative(maximumVelocityMPerS, "maximumVelocityMPerS");
-      this.maximumEquivalentStressMpa = nonNegative(maximumEquivalentStressMpa,
-          "maximumEquivalentStressMpa");
+      this.maximumEquivalentStressMpa = nonNegative(maximumEquivalentStressMpa, "maximumEquivalentStressMpa");
     }
   }
 
@@ -102,16 +100,13 @@ public final class TransientPipingQualificationCalculation implements
           "maximumTimeStepToTransitFraction");
       maximumLinePackBalanceErrorFraction = nonNegative(builder.maximumLinePackBalanceErrorFraction,
           "maximumLinePackBalanceErrorFraction");
-      maximumAllowablePressureBara = positive(builder.maximumAllowablePressureBara,
-          "maximumAllowablePressureBara");
-      minimumAllowablePressureBara = nonNegative(builder.minimumAllowablePressureBara,
-          "minimumAllowablePressureBara");
+      maximumAllowablePressureBara = positive(builder.maximumAllowablePressureBara, "maximumAllowablePressureBara");
+      minimumAllowablePressureBara = nonNegative(builder.minimumAllowablePressureBara, "minimumAllowablePressureBara");
       maximumSlugVolumeM3 = nonNegative(builder.maximumSlugVolumeM3, "maximumSlugVolumeM3");
       maximumAcousticMach = positive(builder.maximumAcousticMach, "maximumAcousticMach");
       maximumPressurePulsationPercent = nonNegative(builder.maximumPressurePulsationPercent,
           "maximumPressurePulsationPercent");
-      allowableEquivalentStressMpa = positive(builder.allowableEquivalentStressMpa,
-          "allowableEquivalentStressMpa");
+      allowableEquivalentStressMpa = positive(builder.allowableEquivalentStressMpa, "allowableEquivalentStressMpa");
       samples = Collections.unmodifiableList(new ArrayList<Sample>(builder.samples));
     }
 
@@ -150,23 +145,20 @@ public final class TransientPipingQualificationCalculation implements
         return this;
       }
 
-      public Builder resolutionAndBalanceLimits(double timeStepToTransitFraction,
-          double linePackBalanceErrorFraction) {
+      public Builder resolutionAndBalanceLimits(double timeStepToTransitFraction, double linePackBalanceErrorFraction) {
         maximumTimeStepToTransitFraction = timeStepToTransitFraction;
         maximumLinePackBalanceErrorFraction = linePackBalanceErrorFraction;
         return this;
       }
 
-      public Builder pressureLimits(double minimumBara, double maximumBara,
-          double maximumPulsationPercent) {
+      public Builder pressureLimits(double minimumBara, double maximumBara, double maximumPulsationPercent) {
         minimumAllowablePressureBara = minimumBara;
         maximumAllowablePressureBara = maximumBara;
         maximumPressurePulsationPercent = maximumPulsationPercent;
         return this;
       }
 
-      public Builder responseLimits(double slugVolumeM3, double acousticMach,
-          double equivalentStressMpa) {
+      public Builder responseLimits(double slugVolumeM3, double acousticMach, double equivalentStressMpa) {
         maximumSlugVolumeM3 = slugVolumeM3;
         maximumAcousticMach = acousticMach;
         allowableEquivalentStressMpa = equivalentStressMpa;
@@ -288,10 +280,8 @@ public final class TransientPipingQualificationCalculation implements
       Sample sample = input.samples.get(i);
       minimumPressureBara = Math.min(minimumPressureBara, sample.minimumPressureBara);
       maximumPressureBara = Math.max(maximumPressureBara, sample.maximumPressureBara);
-      maximumOfMinimumPressureBara = Math.max(maximumOfMinimumPressureBara,
-          sample.minimumPressureBara);
-      minimumOfMaximumPressureBara = Math.min(minimumOfMaximumPressureBara,
-          sample.maximumPressureBara);
+      maximumOfMinimumPressureBara = Math.max(maximumOfMinimumPressureBara, sample.minimumPressureBara);
+      minimumOfMaximumPressureBara = Math.min(minimumOfMaximumPressureBara, sample.maximumPressureBara);
       maximumHoldup = Math.max(maximumHoldup, sample.maximumLiquidHoldupFraction);
       maximumVelocity = Math.max(maximumVelocity, sample.maximumVelocityMPerS);
       maximumStress = Math.max(maximumStress, sample.maximumEquivalentStressMpa);
@@ -308,8 +298,8 @@ public final class TransientPipingQualificationCalculation implements
         - input.samples.get(0).linePackMassKg;
     double balanceDenominator = Math.max(1.0,
         Math.max(Math.abs(integratedBoundaryImbalanceKg), Math.abs(observedLinePackChangeKg)));
-    double linePackBalanceErrorFraction = Math
-        .abs(integratedBoundaryImbalanceKg - observedLinePackChangeKg) / balanceDenominator;
+    double linePackBalanceErrorFraction = Math.abs(integratedBoundaryImbalanceKg - observedLinePackChangeKg)
+        / balanceDenominator;
     double acousticTransitSeconds = input.hydraulicLengthM / input.waveSpeedMPerS;
     double pressureMean = Math.max(0.5 * (maximumPressureBara + minimumPressureBara), 1.0e-12);
     double pressureExcursionBara = Math.max(maximumOfMinimumPressureBara - minimumPressureBara,
@@ -332,26 +322,22 @@ public final class TransientPipingQualificationCalculation implements
     metrics.put("maximumEquivalentStressMpa", Double.valueOf(maximumStress));
 
     Map<String, Boolean> constraints = new LinkedHashMap<String, Boolean>();
-    constraints.put("TRANSIENT_TIME_RESOLUTION", Boolean
-        .valueOf(maximumTimeStepSeconds <= acousticTransitSeconds * input.maximumTimeStepToTransitFraction));
+    constraints.put("TRANSIENT_TIME_RESOLUTION",
+        Boolean.valueOf(maximumTimeStepSeconds <= acousticTransitSeconds * input.maximumTimeStepToTransitFraction));
     constraints.put("LINE_PACK_MASS_BALANCE",
         Boolean.valueOf(linePackBalanceErrorFraction <= input.maximumLinePackBalanceErrorFraction));
-    constraints.put("MINIMUM_PRESSURE",
-        Boolean.valueOf(minimumPressureBara >= input.minimumAllowablePressureBara));
-    constraints.put("MAXIMUM_PRESSURE",
-        Boolean.valueOf(maximumPressureBara <= input.maximumAllowablePressureBara));
+    constraints.put("MINIMUM_PRESSURE", Boolean.valueOf(minimumPressureBara >= input.minimumAllowablePressureBara));
+    constraints.put("MAXIMUM_PRESSURE", Boolean.valueOf(maximumPressureBara <= input.maximumAllowablePressureBara));
     constraints.put("PRESSURE_PULSATION",
         Boolean.valueOf(pressurePulsationPercent <= input.maximumPressurePulsationPercent));
-    constraints.put("TRANSIENT_SLUG_INVENTORY",
-        Boolean.valueOf(maximumSlugVolumeM3 <= input.maximumSlugVolumeM3));
+    constraints.put("TRANSIENT_SLUG_INVENTORY", Boolean.valueOf(maximumSlugVolumeM3 <= input.maximumSlugVolumeM3));
     constraints.put("ACOUSTIC_VELOCITY", Boolean.valueOf(maximumAcousticMach <= input.maximumAcousticMach));
-    constraints.put("EQUIVALENT_PIPE_STRESS",
-        Boolean.valueOf(maximumStress <= input.allowableEquivalentStressMpa));
+    constraints.put("EQUIVALENT_PIPE_STRESS", Boolean.valueOf(maximumStress <= input.allowableEquivalentStressMpa));
 
     return output.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED)
         .input("networkId", input.networkId).input("sourceModel", input.sourceModel)
-        .input("sourceModelVersion", input.sourceModelVersion).input("sampleCount", Integer.valueOf(input.samples.size()))
-        .value(new Result(metrics, constraints))
+        .input("sourceModelVersion", input.sourceModelVersion)
+        .input("sampleCount", Integer.valueOf(input.samples.size())).value(new Result(metrics, constraints))
         .warning("Final stress, support, acoustic-induced vibration and fatigue acceptance require discipline review")
         .build();
   }

--- a/src/main/java/neqsim/process/engineering/piping/TransientPipingQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/piping/TransientPipingQualificationCalculation.java
@@ -1,0 +1,397 @@
+package neqsim.process.engineering.piping;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.engineering.calculation.CalculationReadiness;
+import neqsim.process.engineering.calculation.EngineeringCalculationContext;
+import neqsim.process.engineering.calculation.EngineeringCalculationModule;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+import neqsim.process.engineering.calculation.EngineeringConstraintResult;
+
+/**
+ * Qualifies a distributed piping-transient profile for engineering use.
+ *
+ * <p>
+ * The hydraulic transient remains the responsibility of the declared source model, for example
+ * {@code TwoFluidPipe}, {@code WaterHammerPipe}, or a project-qualified external solver. This calculation verifies
+ * that the exported profile resolves the acoustic time scale, closes the line-pack balance, and satisfies explicit
+ * pressure, slug, acoustic, vibration and stress constraints. It does not turn a quasi-steady line calculation into a
+ * distributed transient model.
+ * </p>
+ */
+public final class TransientPipingQualificationCalculation implements
+    EngineeringCalculationModule<TransientPipingQualificationCalculation.Input, TransientPipingQualificationCalculation.Result> {
+
+  /** One ordered transient sample exported by the source hydraulic model. */
+  public static final class Sample implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double timeSeconds;
+    private final double inletMassFlowKgS;
+    private final double outletMassFlowKgS;
+    private final double linePackMassKg;
+    private final double minimumPressureBara;
+    private final double maximumPressureBara;
+    private final double maximumLiquidHoldupFraction;
+    private final double maximumVelocityMPerS;
+    private final double maximumEquivalentStressMpa;
+
+    /**
+     * Creates one profile sample.
+     *
+     * @param timeSeconds elapsed time in seconds
+     * @param inletMassFlowKgS inlet mass flow in kg/s
+     * @param outletMassFlowKgS outlet mass flow in kg/s
+     * @param linePackMassKg total fluid inventory in kg
+     * @param minimumPressureBara minimum pressure anywhere in the network in bara
+     * @param maximumPressureBara maximum pressure anywhere in the network in bara
+     * @param maximumLiquidHoldupFraction maximum liquid holdup fraction
+     * @param maximumVelocityMPerS maximum local mixture velocity in m/s
+     * @param maximumEquivalentStressMpa maximum calculated equivalent pipe stress in MPa
+     */
+    public Sample(double timeSeconds, double inletMassFlowKgS, double outletMassFlowKgS, double linePackMassKg,
+        double minimumPressureBara, double maximumPressureBara, double maximumLiquidHoldupFraction,
+        double maximumVelocityMPerS, double maximumEquivalentStressMpa) {
+      this.timeSeconds = nonNegative(timeSeconds, "timeSeconds");
+      this.inletMassFlowKgS = finite(inletMassFlowKgS, "inletMassFlowKgS");
+      this.outletMassFlowKgS = finite(outletMassFlowKgS, "outletMassFlowKgS");
+      this.linePackMassKg = nonNegative(linePackMassKg, "linePackMassKg");
+      this.minimumPressureBara = nonNegative(minimumPressureBara, "minimumPressureBara");
+      this.maximumPressureBara = nonNegative(maximumPressureBara, "maximumPressureBara");
+      if (maximumPressureBara < minimumPressureBara) {
+        throw new IllegalArgumentException("maximumPressureBara must not be below minimumPressureBara");
+      }
+      this.maximumLiquidHoldupFraction = fraction(maximumLiquidHoldupFraction,
+          "maximumLiquidHoldupFraction");
+      this.maximumVelocityMPerS = nonNegative(maximumVelocityMPerS, "maximumVelocityMPerS");
+      this.maximumEquivalentStressMpa = nonNegative(maximumEquivalentStressMpa,
+          "maximumEquivalentStressMpa");
+    }
+  }
+
+  /** Controlled transient profile and project acceptance limits. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String networkId;
+    private final String sourceModel;
+    private final String sourceModelVersion;
+    private final double hydraulicLengthM;
+    private final double internalVolumeM3;
+    private final double waveSpeedMPerS;
+    private final double maximumTimeStepToTransitFraction;
+    private final double maximumLinePackBalanceErrorFraction;
+    private final double maximumAllowablePressureBara;
+    private final double minimumAllowablePressureBara;
+    private final double maximumSlugVolumeM3;
+    private final double maximumAcousticMach;
+    private final double maximumPressurePulsationPercent;
+    private final double allowableEquivalentStressMpa;
+    private final List<Sample> samples;
+
+    private Input(Builder builder) {
+      networkId = text(builder.networkId, "networkId");
+      sourceModel = text(builder.sourceModel, "sourceModel");
+      sourceModelVersion = text(builder.sourceModelVersion, "sourceModelVersion");
+      hydraulicLengthM = positive(builder.hydraulicLengthM, "hydraulicLengthM");
+      internalVolumeM3 = positive(builder.internalVolumeM3, "internalVolumeM3");
+      waveSpeedMPerS = positive(builder.waveSpeedMPerS, "waveSpeedMPerS");
+      maximumTimeStepToTransitFraction = positive(builder.maximumTimeStepToTransitFraction,
+          "maximumTimeStepToTransitFraction");
+      maximumLinePackBalanceErrorFraction = nonNegative(builder.maximumLinePackBalanceErrorFraction,
+          "maximumLinePackBalanceErrorFraction");
+      maximumAllowablePressureBara = positive(builder.maximumAllowablePressureBara,
+          "maximumAllowablePressureBara");
+      minimumAllowablePressureBara = nonNegative(builder.minimumAllowablePressureBara,
+          "minimumAllowablePressureBara");
+      maximumSlugVolumeM3 = nonNegative(builder.maximumSlugVolumeM3, "maximumSlugVolumeM3");
+      maximumAcousticMach = positive(builder.maximumAcousticMach, "maximumAcousticMach");
+      maximumPressurePulsationPercent = nonNegative(builder.maximumPressurePulsationPercent,
+          "maximumPressurePulsationPercent");
+      allowableEquivalentStressMpa = positive(builder.allowableEquivalentStressMpa,
+          "allowableEquivalentStressMpa");
+      samples = Collections.unmodifiableList(new ArrayList<Sample>(builder.samples));
+    }
+
+    public static Builder builder(String networkId, String sourceModel, String sourceModelVersion) {
+      return new Builder(networkId, sourceModel, sourceModelVersion);
+    }
+
+    /** Builder for controlled transient qualification input. */
+    public static final class Builder {
+      private final String networkId;
+      private final String sourceModel;
+      private final String sourceModelVersion;
+      private double hydraulicLengthM;
+      private double internalVolumeM3;
+      private double waveSpeedMPerS;
+      private double maximumTimeStepToTransitFraction;
+      private double maximumLinePackBalanceErrorFraction;
+      private double maximumAllowablePressureBara;
+      private double minimumAllowablePressureBara;
+      private double maximumSlugVolumeM3;
+      private double maximumAcousticMach;
+      private double maximumPressurePulsationPercent;
+      private double allowableEquivalentStressMpa;
+      private final List<Sample> samples = new ArrayList<Sample>();
+
+      private Builder(String networkId, String sourceModel, String sourceModelVersion) {
+        this.networkId = networkId;
+        this.sourceModel = sourceModel;
+        this.sourceModelVersion = sourceModelVersion;
+      }
+
+      public Builder geometry(double lengthM, double volumeM3, double acousticWaveSpeedMPerS) {
+        hydraulicLengthM = lengthM;
+        internalVolumeM3 = volumeM3;
+        waveSpeedMPerS = acousticWaveSpeedMPerS;
+        return this;
+      }
+
+      public Builder resolutionAndBalanceLimits(double timeStepToTransitFraction,
+          double linePackBalanceErrorFraction) {
+        maximumTimeStepToTransitFraction = timeStepToTransitFraction;
+        maximumLinePackBalanceErrorFraction = linePackBalanceErrorFraction;
+        return this;
+      }
+
+      public Builder pressureLimits(double minimumBara, double maximumBara,
+          double maximumPulsationPercent) {
+        minimumAllowablePressureBara = minimumBara;
+        maximumAllowablePressureBara = maximumBara;
+        maximumPressurePulsationPercent = maximumPulsationPercent;
+        return this;
+      }
+
+      public Builder responseLimits(double slugVolumeM3, double acousticMach,
+          double equivalentStressMpa) {
+        maximumSlugVolumeM3 = slugVolumeM3;
+        maximumAcousticMach = acousticMach;
+        allowableEquivalentStressMpa = equivalentStressMpa;
+        return this;
+      }
+
+      public Builder addSample(Sample sample) {
+        if (sample == null) {
+          throw new IllegalArgumentException("sample must not be null");
+        }
+        samples.add(sample);
+        return this;
+      }
+
+      public Input build() {
+        return new Input(this);
+      }
+    }
+  }
+
+  /** Immutable qualification metrics and independently visible constraints. */
+  public static final class Result implements EngineeringConstraintResult, Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Map<String, Double> metrics;
+    private final Map<String, Boolean> constraints;
+
+    private Result(Map<String, Double> metrics, Map<String, Boolean> constraints) {
+      this.metrics = Collections.unmodifiableMap(new LinkedHashMap<String, Double>(metrics));
+      this.constraints = Collections.unmodifiableMap(new LinkedHashMap<String, Boolean>(constraints));
+    }
+
+    @Override
+    public boolean allConstraintsSatisfied() {
+      for (Boolean value : constraints.values()) {
+        if (!value.booleanValue()) {
+          return false;
+        }
+      }
+      return !constraints.isEmpty();
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("metrics", new LinkedHashMap<String, Double>(metrics));
+      result.put("constraints", new LinkedHashMap<String, Boolean>(constraints));
+      result.put("allConstraintsSatisfied", Boolean.valueOf(allConstraintsSatisfied()));
+      result.put("distributedTransientModelRequired", Boolean.TRUE);
+      result.put("approvalStatus", "REVIEW_REQUIRED");
+      return result;
+    }
+  }
+
+  @Override
+  public String getMethod() {
+    return "distributed-piping-transient-qualification";
+  }
+
+  @Override
+  public String getMethodVersion() {
+    return "1.0";
+  }
+
+  @Override
+  public CalculationReadiness assess(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness.Builder readiness = CalculationReadiness.builder();
+    if (input == null) {
+      return readiness.addBlocker("TRANSIENT_INPUT", "Transient piping input is required",
+          "Export a controlled distributed transient profile").build();
+    }
+    if (input.samples.size() < 2) {
+      readiness.addBlocker("TRANSIENT_SAMPLES", "At least two transient samples are required",
+          "Supply an ordered transient profile");
+    }
+    double previous = -1.0;
+    for (Sample sample : input.samples) {
+      if (sample.timeSeconds <= previous) {
+        readiness.addBlocker("TRANSIENT_TIME_ORDER", "Transient sample times must increase strictly",
+            "Correct the source-model export");
+        break;
+      }
+      previous = sample.timeSeconds;
+    }
+    if (productionQualification(context)
+        && (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty())) {
+      readiness.addBlocker("TRANSIENT_PRODUCTION_EVIDENCE",
+          "Production qualification requires model-validation and standards evidence",
+          "Attach the hydraulic model validation and project piping basis");
+    }
+    if (productionQualification(context)
+        && !"approved".equalsIgnoreCase(context.getAttributes().get("distributedTransientModel"))) {
+      readiness.addBlocker("DISTRIBUTED_TRANSIENT_MODEL",
+          "The source profile has not been approved as a distributed transient-model result",
+          "Approve the model applicability or attach controlled external-solver results");
+    }
+    return readiness.build();
+  }
+
+  @Override
+  public EngineeringCalculationResult<Result> calculate(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness readiness = assess(input, context);
+    EngineeringCalculationResult.Builder<Result> output = EngineeringCalculationResult
+        .<Result>builder("transient-piping:" + (input == null ? "unassigned" : input.networkId), getMethod(),
+            getMethodVersion())
+        .context(context).readiness(readiness);
+    if (!readiness.isReady()) {
+      return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
+    }
+
+    double integratedBoundaryImbalanceKg = 0.0;
+    double maximumTimeStepSeconds = 0.0;
+    double minimumPressureBara = Double.POSITIVE_INFINITY;
+    double maximumPressureBara = 0.0;
+    double maximumOfMinimumPressureBara = 0.0;
+    double minimumOfMaximumPressureBara = Double.POSITIVE_INFINITY;
+    double maximumHoldup = 0.0;
+    double maximumVelocity = 0.0;
+    double maximumStress = 0.0;
+    for (int i = 0; i < input.samples.size(); i++) {
+      Sample sample = input.samples.get(i);
+      minimumPressureBara = Math.min(minimumPressureBara, sample.minimumPressureBara);
+      maximumPressureBara = Math.max(maximumPressureBara, sample.maximumPressureBara);
+      maximumOfMinimumPressureBara = Math.max(maximumOfMinimumPressureBara,
+          sample.minimumPressureBara);
+      minimumOfMaximumPressureBara = Math.min(minimumOfMaximumPressureBara,
+          sample.maximumPressureBara);
+      maximumHoldup = Math.max(maximumHoldup, sample.maximumLiquidHoldupFraction);
+      maximumVelocity = Math.max(maximumVelocity, sample.maximumVelocityMPerS);
+      maximumStress = Math.max(maximumStress, sample.maximumEquivalentStressMpa);
+      if (i > 0) {
+        Sample previous = input.samples.get(i - 1);
+        double dt = sample.timeSeconds - previous.timeSeconds;
+        maximumTimeStepSeconds = Math.max(maximumTimeStepSeconds, dt);
+        double previousImbalance = previous.inletMassFlowKgS - previous.outletMassFlowKgS;
+        double currentImbalance = sample.inletMassFlowKgS - sample.outletMassFlowKgS;
+        integratedBoundaryImbalanceKg += 0.5 * (previousImbalance + currentImbalance) * dt;
+      }
+    }
+    double observedLinePackChangeKg = input.samples.get(input.samples.size() - 1).linePackMassKg
+        - input.samples.get(0).linePackMassKg;
+    double balanceDenominator = Math.max(1.0,
+        Math.max(Math.abs(integratedBoundaryImbalanceKg), Math.abs(observedLinePackChangeKg)));
+    double linePackBalanceErrorFraction = Math
+        .abs(integratedBoundaryImbalanceKg - observedLinePackChangeKg) / balanceDenominator;
+    double acousticTransitSeconds = input.hydraulicLengthM / input.waveSpeedMPerS;
+    double pressureMean = Math.max(0.5 * (maximumPressureBara + minimumPressureBara), 1.0e-12);
+    double pressureExcursionBara = Math.max(maximumOfMinimumPressureBara - minimumPressureBara,
+        maximumPressureBara - minimumOfMaximumPressureBara);
+    double pressurePulsationPercent = 100.0 * pressureExcursionBara / pressureMean;
+    double maximumSlugVolumeM3 = maximumHoldup * input.internalVolumeM3;
+    double maximumAcousticMach = maximumVelocity / input.waveSpeedMPerS;
+
+    Map<String, Double> metrics = new LinkedHashMap<String, Double>();
+    metrics.put("acousticTransitSeconds", Double.valueOf(acousticTransitSeconds));
+    metrics.put("maximumTimeStepSeconds", Double.valueOf(maximumTimeStepSeconds));
+    metrics.put("integratedBoundaryImbalanceKg", Double.valueOf(integratedBoundaryImbalanceKg));
+    metrics.put("observedLinePackChangeKg", Double.valueOf(observedLinePackChangeKg));
+    metrics.put("linePackBalanceErrorFraction", Double.valueOf(linePackBalanceErrorFraction));
+    metrics.put("minimumPressureBara", Double.valueOf(minimumPressureBara));
+    metrics.put("maximumPressureBara", Double.valueOf(maximumPressureBara));
+    metrics.put("pressurePulsationPercent", Double.valueOf(pressurePulsationPercent));
+    metrics.put("maximumSlugVolumeM3", Double.valueOf(maximumSlugVolumeM3));
+    metrics.put("maximumAcousticMach", Double.valueOf(maximumAcousticMach));
+    metrics.put("maximumEquivalentStressMpa", Double.valueOf(maximumStress));
+
+    Map<String, Boolean> constraints = new LinkedHashMap<String, Boolean>();
+    constraints.put("TRANSIENT_TIME_RESOLUTION", Boolean
+        .valueOf(maximumTimeStepSeconds <= acousticTransitSeconds * input.maximumTimeStepToTransitFraction));
+    constraints.put("LINE_PACK_MASS_BALANCE",
+        Boolean.valueOf(linePackBalanceErrorFraction <= input.maximumLinePackBalanceErrorFraction));
+    constraints.put("MINIMUM_PRESSURE",
+        Boolean.valueOf(minimumPressureBara >= input.minimumAllowablePressureBara));
+    constraints.put("MAXIMUM_PRESSURE",
+        Boolean.valueOf(maximumPressureBara <= input.maximumAllowablePressureBara));
+    constraints.put("PRESSURE_PULSATION",
+        Boolean.valueOf(pressurePulsationPercent <= input.maximumPressurePulsationPercent));
+    constraints.put("TRANSIENT_SLUG_INVENTORY",
+        Boolean.valueOf(maximumSlugVolumeM3 <= input.maximumSlugVolumeM3));
+    constraints.put("ACOUSTIC_VELOCITY", Boolean.valueOf(maximumAcousticMach <= input.maximumAcousticMach));
+    constraints.put("EQUIVALENT_PIPE_STRESS",
+        Boolean.valueOf(maximumStress <= input.allowableEquivalentStressMpa));
+
+    return output.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED)
+        .input("networkId", input.networkId).input("sourceModel", input.sourceModel)
+        .input("sourceModelVersion", input.sourceModelVersion).input("sampleCount", Integer.valueOf(input.samples.size()))
+        .value(new Result(metrics, constraints))
+        .warning("Final stress, support, acoustic-induced vibration and fatigue acceptance require discipline review")
+        .build();
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double positive(double value, String field) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and positive");
+    }
+    return value;
+  }
+
+  private static double nonNegative(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and non-negative");
+    }
+    return value;
+  }
+
+  private static double fraction(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0 || value > 1.0) {
+      throw new IllegalArgumentException(field + " must be between zero and one");
+    }
+    return value;
+  }
+
+  private static double finite(double value, String field) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(field + " must be finite");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/piping/TransientPipingQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/piping/TransientPipingQualificationCalculation.java
@@ -266,6 +266,9 @@ public final class TransientPipingQualificationCalculation implements
     if (!readiness.isReady()) {
       return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
     }
+    if (input == null || input.samples == null || input.samples.isEmpty()) {
+      return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
+    }
 
     double integratedBoundaryImbalanceKg = 0.0;
     double maximumTimeStepSeconds = 0.0;

--- a/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessAssessment.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessAssessment.java
@@ -97,25 +97,20 @@ public final class EngineeringProductionReadinessAssessment {
         release == null ? "Attach release quality evidence" : release.getMissingGates().toString()));
 
     boolean transientPiping = transientPipingPasses(evidence.getTransientPipingQualification());
-    gates.put("DISTRIBUTED_TRANSIENT_PIPING",
-        gate(transientPiping,
-            "Attach a passing distributed transient profile with line-pack, wave, slug, acoustic and stress checks"));
+    gates.put("DISTRIBUTED_TRANSIENT_PIPING", gate(transientPiping,
+        "Attach a passing distributed transient profile with line-pack, wave, slug, acoustic and stress checks"));
     boolean compressorProtection = compressorProtectionPasses(evidence.getCompressorProtectionQualification());
-    gates.put("COMPRESSOR_PROTECTION_AND_MACHINERY",
-        gate(compressorProtection,
-            "Close compressor map, startup, rundown, anti-surge, rotor, settle-out and vendor constraints"));
+    gates.put("COMPRESSOR_PROTECTION_AND_MACHINERY", gate(compressorProtection,
+        "Close compressor map, startup, rundown, anti-surge, rotor, settle-out and vendor constraints"));
     boolean valveInstrument = valveInstrumentPasses(evidence.getValveInstrumentQualification());
-    gates.put("VALVE_AND_INSTRUMENT_QUALIFICATION",
-        gate(valveInstrument,
-            "Close actuator, leakage, response, installation, thermowell, tuning and logic constraints"));
+    gates.put("VALVE_AND_INSTRUMENT_QUALIFICATION", gate(valveInstrument,
+        "Close actuator, leakage, response, installation, thermowell, tuning and logic constraints"));
     boolean mechanicalIntegrity = mechanicalIntegrityPasses(evidence.getMechanicalIntegrityQualification());
-    gates.put("DETAILED_MECHANICAL_INTEGRITY",
-        gate(mechanicalIntegrity,
-            "Close pressure, external load, buckling, fatigue, nozzle, MDMT and fabrication constraints"));
+    gates.put("DETAILED_MECHANICAL_INTEGRITY", gate(mechanicalIntegrity,
+        "Close pressure, external load, buckling, fatigue, nozzle, MDMT and fabrication constraints"));
     boolean flareConsequence = flareConsequencePasses(evidence.getFlareConsequenceQualification());
-    gates.put("FLARE_RADIATION_DISPERSION_AND_NOISE",
-        gate(flareConsequence,
-            "Attach passing project-qualified flare radiation, dispersion, noise and tip-velocity evidence"));
+    gates.put("FLARE_RADIATION_DISPERSION_AND_NOISE", gate(flareConsequence,
+        "Attach passing project-qualified flare radiation, dispersion, noise and tip-velocity evidence"));
 
     boolean all = true;
     for (Gate value : gates.values()) {
@@ -168,7 +163,8 @@ public final class EngineeringProductionReadinessAssessment {
     return value != null && calculated(value) && value.getValue() != null && value.getValue().allConstraintsSatisfied();
   }
 
-  private static boolean flareConsequencePasses(EngineeringCalculationResult<FlareConsequenceCalculation.Result> value) {
+  private static boolean flareConsequencePasses(
+      EngineeringCalculationResult<FlareConsequenceCalculation.Result> value) {
     return value != null && calculated(value) && value.getValue() != null && value.getValue().allConstraintsSatisfied();
   }
 

--- a/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessAssessment.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessAssessment.java
@@ -9,8 +9,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import neqsim.process.engineering.EngineeringProject;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
 import neqsim.process.engineering.design.EngineeringDesignIteration;
 import neqsim.process.engineering.design.EngineeringDesignModuleResult;
+import neqsim.process.engineering.instrumentation.ValveInstrumentQualificationCalculation;
+import neqsim.process.engineering.mechanical.MechanicalIntegrityQualificationCalculation;
+import neqsim.process.engineering.piping.TransientPipingQualificationCalculation;
+import neqsim.process.engineering.rotating.CompressorProtectionQualificationCalculation;
+import neqsim.process.engineering.safety.FlareConsequenceCalculation;
 import neqsim.process.engineering.validation.EngineeringSchemaCatalog;
 
 /** Aggregates technical and accountable evidence without ever authorizing final or construction design. */
@@ -35,6 +41,7 @@ public final class EngineeringProductionReadinessAssessment {
 
     EngineeringBenchmarkSuite.Report benchmark = evidence.getBenchmarkReport();
     Set<String> executedMethods = executedMethods(project);
+    executedMethods.addAll(evidence.getTechnicalMethodKeys());
     Set<String> unbenchmarkedMethods = new LinkedHashSet<String>(executedMethods);
     if (benchmark != null) {
       unbenchmarkedMethods.removeAll(benchmark.getQualifyingMethods());
@@ -89,12 +96,35 @@ public final class EngineeringProductionReadinessAssessment {
     gates.put("RELEASE_QUALITY", gate(release != null && release.isPassed(),
         release == null ? "Attach release quality evidence" : release.getMissingGates().toString()));
 
+    boolean transientPiping = transientPipingPasses(evidence.getTransientPipingQualification());
+    gates.put("DISTRIBUTED_TRANSIENT_PIPING",
+        gate(transientPiping,
+            "Attach a passing distributed transient profile with line-pack, wave, slug, acoustic and stress checks"));
+    boolean compressorProtection = compressorProtectionPasses(evidence.getCompressorProtectionQualification());
+    gates.put("COMPRESSOR_PROTECTION_AND_MACHINERY",
+        gate(compressorProtection,
+            "Close compressor map, startup, rundown, anti-surge, rotor, settle-out and vendor constraints"));
+    boolean valveInstrument = valveInstrumentPasses(evidence.getValveInstrumentQualification());
+    gates.put("VALVE_AND_INSTRUMENT_QUALIFICATION",
+        gate(valveInstrument,
+            "Close actuator, leakage, response, installation, thermowell, tuning and logic constraints"));
+    boolean mechanicalIntegrity = mechanicalIntegrityPasses(evidence.getMechanicalIntegrityQualification());
+    gates.put("DETAILED_MECHANICAL_INTEGRITY",
+        gate(mechanicalIntegrity,
+            "Close pressure, external load, buckling, fatigue, nozzle, MDMT and fabrication constraints"));
+    boolean flareConsequence = flareConsequencePasses(evidence.getFlareConsequenceQualification());
+    gates.put("FLARE_RADIATION_DISPERSION_AND_NOISE",
+        gate(flareConsequence,
+            "Attach passing project-qualified flare radiation, dispersion, noise and tip-velocity evidence"));
+
     boolean all = true;
     for (Gate value : gates.values()) {
       all &= value.passed;
     }
+    boolean technicalCompletion = transientPiping && compressorProtection && valveInstrument && mechanicalIntegrity
+        && flareConsequence;
     boolean validated = designLoop && benchmarkPassed && methods && automation != null && automation.isComplete()
-        && safety.isPassed();
+        && safety.isPassed() && technicalCompletion;
     Level level = all ? Level.QUALIFIED_FEED_SUPPORT
         : validated ? Level.VALIDATED_PRELIMINARY : designLoop ? Level.EXPERIMENTAL : Level.NOT_READY;
     return new Result(project.getProjectId(), project.getRevision(), level, gates, safety, evidence, all);
@@ -116,6 +146,35 @@ public final class EngineeringProductionReadinessAssessment {
 
   private static Gate gate(boolean passed, String action) {
     return new Gate(passed, action);
+  }
+
+  private static boolean transientPipingPasses(
+      EngineeringCalculationResult<TransientPipingQualificationCalculation.Result> value) {
+    return value != null && calculated(value) && value.getValue() != null && value.getValue().allConstraintsSatisfied();
+  }
+
+  private static boolean compressorProtectionPasses(
+      EngineeringCalculationResult<CompressorProtectionQualificationCalculation.Result> value) {
+    return value != null && calculated(value) && value.getValue() != null && value.getValue().allConstraintsSatisfied();
+  }
+
+  private static boolean valveInstrumentPasses(
+      EngineeringCalculationResult<ValveInstrumentQualificationCalculation.Result> value) {
+    return value != null && calculated(value) && value.getValue() != null && value.getValue().allConstraintsSatisfied();
+  }
+
+  private static boolean mechanicalIntegrityPasses(
+      EngineeringCalculationResult<MechanicalIntegrityQualificationCalculation.Result> value) {
+    return value != null && calculated(value) && value.getValue() != null && value.getValue().allConstraintsSatisfied();
+  }
+
+  private static boolean flareConsequencePasses(EngineeringCalculationResult<FlareConsequenceCalculation.Result> value) {
+    return value != null && calculated(value) && value.getValue() != null && value.getValue().allConstraintsSatisfied();
+  }
+
+  private static boolean calculated(EngineeringCalculationResult<?> value) {
+    return value.getStatus() == EngineeringCalculationResult.Status.CALCULATED
+        || value.getStatus() == EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED;
   }
 
   private static final class Gate implements Serializable {

--- a/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessBasis.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessBasis.java
@@ -163,8 +163,9 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
   /**
    * Adapts the typed technical qualification results to canonical calculation records.
    *
-   * <p>This keeps the calculation DAG, engineering graph, and production-readiness evidence on the
-   * same identifiers without weakening the typed calculation API.
+   * <p>
+   * This keeps the calculation DAG, engineering graph, and production-readiness evidence on the same identifiers
+   * without weakening the typed calculation API.
    *
    * @param subjectNodeId canonical project node governed by the qualification results
    * @return canonical calculation records in stable discipline order

--- a/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessBasis.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessBasis.java
@@ -205,8 +205,8 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
     }
   }
 
-  private static void addCalculation(List<EngineeringCalculation> target,
-      EngineeringCalculationResult<?> value, String subjectNodeId) {
+  private static void addCalculation(List<EngineeringCalculation> target, EngineeringCalculationResult<?> value,
+      String subjectNodeId) {
     if (value == null) {
       return;
     }
@@ -215,8 +215,8 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
         .setDesignCaseId(value.getContext().getDesignCaseId()).setMessage(value.getMessage())
         .setStandardsRequired(true);
     if (value.getValue() instanceof EngineeringConstraintResult) {
-      calculation.setResult(
-          ((EngineeringConstraintResult) value.getValue()).allConstraintsSatisfied() ? 1.0 : 0.0, "fraction");
+      calculation.setResult(((EngineeringConstraintResult) value.getValue()).allConstraintsSatisfied() ? 1.0 : 0.0,
+          "fraction");
     }
     for (String standard : value.getContext().getStandardReferences()) {
       calculation.addStandardReference(

--- a/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessBasis.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessBasis.java
@@ -4,8 +4,18 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+import neqsim.process.engineering.calculation.EngineeringConstraintResult;
+import neqsim.process.engineering.instrumentation.ValveInstrumentQualificationCalculation;
+import neqsim.process.engineering.mechanical.MechanicalIntegrityQualificationCalculation;
+import neqsim.process.engineering.model.EngineeringCalculation;
+import neqsim.process.engineering.piping.TransientPipingQualificationCalculation;
+import neqsim.process.engineering.rotating.CompressorProtectionQualificationCalculation;
+import neqsim.process.engineering.safety.FlareConsequenceCalculation;
 
 /** Controlled evidence bundle consumed by the production-readiness assessment. */
 public final class EngineeringProductionReadinessBasis implements Serializable {
@@ -16,6 +26,11 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
   private final List<DexpiToolQualificationEvidence> dexpiEvidence = new ArrayList<DexpiToolQualificationEvidence>();
   private final List<EngineeringPilotProjectEvidence> pilotEvidence = new ArrayList<EngineeringPilotProjectEvidence>();
   private EngineeringReleaseQualityEvidence releaseQualityEvidence;
+  private EngineeringCalculationResult<TransientPipingQualificationCalculation.Result> transientPipingQualification;
+  private EngineeringCalculationResult<CompressorProtectionQualificationCalculation.Result> compressorProtectionQualification;
+  private EngineeringCalculationResult<ValveInstrumentQualificationCalculation.Result> valveInstrumentQualification;
+  private EngineeringCalculationResult<MechanicalIntegrityQualificationCalculation.Result> mechanicalIntegrityQualification;
+  private EngineeringCalculationResult<FlareConsequenceCalculation.Result> flareConsequenceQualification;
 
   public EngineeringProductionReadinessBasis benchmarkReport(EngineeringBenchmarkSuite.Report value) {
     benchmarkReport = value;
@@ -56,6 +71,36 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
     return this;
   }
 
+  public EngineeringProductionReadinessBasis transientPipingQualification(
+      EngineeringCalculationResult<TransientPipingQualificationCalculation.Result> value) {
+    transientPipingQualification = require(value, "transientPipingQualification");
+    return this;
+  }
+
+  public EngineeringProductionReadinessBasis compressorProtectionQualification(
+      EngineeringCalculationResult<CompressorProtectionQualificationCalculation.Result> value) {
+    compressorProtectionQualification = require(value, "compressorProtectionQualification");
+    return this;
+  }
+
+  public EngineeringProductionReadinessBasis valveInstrumentQualification(
+      EngineeringCalculationResult<ValveInstrumentQualificationCalculation.Result> value) {
+    valveInstrumentQualification = require(value, "valveInstrumentQualification");
+    return this;
+  }
+
+  public EngineeringProductionReadinessBasis mechanicalIntegrityQualification(
+      EngineeringCalculationResult<MechanicalIntegrityQualificationCalculation.Result> value) {
+    mechanicalIntegrityQualification = require(value, "mechanicalIntegrityQualification");
+    return this;
+  }
+
+  public EngineeringProductionReadinessBasis flareConsequenceQualification(
+      EngineeringCalculationResult<FlareConsequenceCalculation.Result> value) {
+    flareConsequenceQualification = require(value, "flareConsequenceQualification");
+    return this;
+  }
+
   public EngineeringBenchmarkSuite.Report getBenchmarkReport() {
     return benchmarkReport;
   }
@@ -80,6 +125,60 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
     return releaseQualityEvidence;
   }
 
+  public EngineeringCalculationResult<TransientPipingQualificationCalculation.Result> getTransientPipingQualification() {
+    return transientPipingQualification;
+  }
+
+  public EngineeringCalculationResult<CompressorProtectionQualificationCalculation.Result> getCompressorProtectionQualification() {
+    return compressorProtectionQualification;
+  }
+
+  public EngineeringCalculationResult<ValveInstrumentQualificationCalculation.Result> getValveInstrumentQualification() {
+    return valveInstrumentQualification;
+  }
+
+  public EngineeringCalculationResult<MechanicalIntegrityQualificationCalculation.Result> getMechanicalIntegrityQualification() {
+    return mechanicalIntegrityQualification;
+  }
+
+  public EngineeringCalculationResult<FlareConsequenceCalculation.Result> getFlareConsequenceQualification() {
+    return flareConsequenceQualification;
+  }
+
+  /**
+   * Gets every technical qualification method that must be benchmarked and project-qualified.
+   *
+   * @return stable method keys in {@code method@version} form
+   */
+  public Set<String> getTechnicalMethodKeys() {
+    Set<String> result = new LinkedHashSet<String>();
+    addMethodKey(result, transientPipingQualification);
+    addMethodKey(result, compressorProtectionQualification);
+    addMethodKey(result, valveInstrumentQualification);
+    addMethodKey(result, mechanicalIntegrityQualification);
+    addMethodKey(result, flareConsequenceQualification);
+    return Collections.unmodifiableSet(result);
+  }
+
+  /**
+   * Adapts the typed technical qualification results to canonical calculation records.
+   *
+   * <p>This keeps the calculation DAG, engineering graph, and production-readiness evidence on the
+   * same identifiers without weakening the typed calculation API.
+   *
+   * @param subjectNodeId canonical project node governed by the qualification results
+   * @return canonical calculation records in stable discipline order
+   */
+  public List<EngineeringCalculation> getTechnicalQualificationCalculations(String subjectNodeId) {
+    List<EngineeringCalculation> result = new ArrayList<EngineeringCalculation>();
+    addCalculation(result, transientPipingQualification, subjectNodeId);
+    addCalculation(result, compressorProtectionQualification, subjectNodeId);
+    addCalculation(result, valveInstrumentQualification, subjectNodeId);
+    addCalculation(result, mechanicalIntegrityQualification, subjectNodeId);
+    addCalculation(result, flareConsequenceQualification, subjectNodeId);
+    return Collections.unmodifiableList(result);
+  }
+
   public Map<String, Object> toMap() {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("benchmarkReport", benchmarkReport == null ? null : benchmarkReport.toMap());
@@ -88,7 +187,65 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
     result.put("dexpiToolQualificationEvidence", maps(dexpiEvidence));
     result.put("pilotProjectEvidence", maps(pilotEvidence));
     result.put("releaseQualityEvidence", releaseQualityEvidence == null ? null : releaseQualityEvidence.toMap());
+    result.put("transientPipingQualification", map(transientPipingQualification));
+    result.put("compressorProtectionQualification", map(compressorProtectionQualification));
+    result.put("valveInstrumentQualification", map(valveInstrumentQualification));
+    result.put("mechanicalIntegrityQualification", map(mechanicalIntegrityQualification));
+    result.put("flareConsequenceQualification", map(flareConsequenceQualification));
     return result;
+  }
+
+  private static Map<String, Object> map(EngineeringCalculationResult<?> value) {
+    return value == null ? null : value.toMap();
+  }
+
+  private static void addMethodKey(Set<String> target, EngineeringCalculationResult<?> value) {
+    if (value != null) {
+      target.add(value.getMethod() + "@" + value.getMethodVersion());
+    }
+  }
+
+  private static void addCalculation(List<EngineeringCalculation> target,
+      EngineeringCalculationResult<?> value, String subjectNodeId) {
+    if (value == null) {
+      return;
+    }
+    EngineeringCalculation calculation = new EngineeringCalculation(value.getCalculationId(), subjectNodeId,
+        value.getMethod() + "@" + value.getMethodVersion()).setStatus(status(value.getStatus()))
+        .setDesignCaseId(value.getContext().getDesignCaseId()).setMessage(value.getMessage())
+        .setStandardsRequired(true);
+    if (value.getValue() instanceof EngineeringConstraintResult) {
+      calculation.setResult(
+          ((EngineeringConstraintResult) value.getValue()).allConstraintsSatisfied() ? 1.0 : 0.0, "fraction");
+    }
+    for (String standard : value.getContext().getStandardReferences()) {
+      calculation.addStandardReference(
+          new EngineeringCalculation.StandardReference(standard, "", "", "production qualification"));
+    }
+    for (String evidence : value.getContext().getEvidenceReferences()) {
+      calculation.addEvidenceReference(evidence);
+    }
+    target.add(calculation);
+  }
+
+  private static EngineeringCalculation.Status status(EngineeringCalculationResult.Status value) {
+    if (value == EngineeringCalculationResult.Status.CALCULATED) {
+      return EngineeringCalculation.Status.CALCULATED;
+    }
+    if (value == EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED) {
+      return EngineeringCalculation.Status.REVIEW_REQUIRED;
+    }
+    if (value == EngineeringCalculationResult.Status.FAILED) {
+      return EngineeringCalculation.Status.FAILED;
+    }
+    return EngineeringCalculation.Status.BLOCKED;
+  }
+
+  private static <T> EngineeringCalculationResult<T> require(EngineeringCalculationResult<T> value, String field) {
+    if (value == null) {
+      throw new IllegalArgumentException(field + " must not be null");
+    }
+    return value;
   }
 
   private static List<Map<String, Object>> maps(List<?> values) {

--- a/src/main/java/neqsim/process/engineering/production/EngineeringQualificationPlan.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringQualificationPlan.java
@@ -117,10 +117,8 @@ public final class EngineeringQualificationPlan {
   }
 
   private static boolean isTechnicalCompletionGate(String gate) {
-    return "DISTRIBUTED_TRANSIENT_PIPING".equals(gate)
-        || "COMPRESSOR_PROTECTION_AND_MACHINERY".equals(gate)
-        || "VALVE_AND_INSTRUMENT_QUALIFICATION".equals(gate)
-        || "DETAILED_MECHANICAL_INTEGRITY".equals(gate)
+    return "DISTRIBUTED_TRANSIENT_PIPING".equals(gate) || "COMPRESSOR_PROTECTION_AND_MACHINERY".equals(gate)
+        || "VALVE_AND_INSTRUMENT_QUALIFICATION".equals(gate) || "DETAILED_MECHANICAL_INTEGRITY".equals(gate)
         || "FLARE_RADIATION_DISPERSION_AND_NOISE".equals(gate);
   }
 }

--- a/src/main/java/neqsim/process/engineering/production/EngineeringQualificationPlan.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringQualificationPlan.java
@@ -21,6 +21,7 @@ public final class EngineeringQualificationPlan {
     }
     EngineeringProductionReadinessBasis evidence = basis == null ? new EngineeringProductionReadinessBasis() : basis;
     Set<String> executed = EngineeringProductionReadinessAssessment.executedMethods(project);
+    executed.addAll(evidence.getTechnicalMethodKeys());
     Set<String> benchmarked = evidence.getBenchmarkReport() == null ? new LinkedHashSet<String>()
         : new LinkedHashSet<String>(evidence.getBenchmarkReport().getQualifyingMethods());
     Set<String> qualified = new LinkedHashSet<String>();
@@ -84,6 +85,12 @@ public final class EngineeringQualificationPlan {
     }
     EngineeringProductionReadinessAssessment.Result assessment = EngineeringProductionReadinessAssessment
         .assess(project, evidence);
+    for (String failedGate : assessment.getFailedGates()) {
+      if (isTechnicalCompletionGate(failedGate)) {
+        actions.add(action("TECHNICAL_COMPLETION", failedGate,
+            "Supply a calculated, constraint-satisfying and independently qualified technical result"));
+      }
+    }
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("schemaVersion", EngineeringSchemaCatalog.QUALIFICATION_PLAN);
     result.put("schemaUri", EngineeringSchemaCatalog.schemaUri(EngineeringSchemaCatalog.QUALIFICATION_PLAN));
@@ -107,5 +114,13 @@ public final class EngineeringQualificationPlan {
     result.put("description", description);
     result.put("status", "OPEN");
     return result;
+  }
+
+  private static boolean isTechnicalCompletionGate(String gate) {
+    return "DISTRIBUTED_TRANSIENT_PIPING".equals(gate)
+        || "COMPRESSOR_PROTECTION_AND_MACHINERY".equals(gate)
+        || "VALVE_AND_INSTRUMENT_QUALIFICATION".equals(gate)
+        || "DETAILED_MECHANICAL_INTEGRITY".equals(gate)
+        || "FLARE_RADIATION_DISPERSION_AND_NOISE".equals(gate);
   }
 }

--- a/src/main/java/neqsim/process/engineering/rotating/CompressorProtectionQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/rotating/CompressorProtectionQualificationCalculation.java
@@ -1,0 +1,431 @@
+package neqsim.process.engineering.rotating;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.engineering.calculation.CalculationReadiness;
+import neqsim.process.engineering.calculation.EngineeringCalculationContext;
+import neqsim.process.engineering.calculation.EngineeringCalculationModule;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+import neqsim.process.engineering.calculation.EngineeringConstraintResult;
+
+/**
+ * Qualifies compressor operating, startup, rundown, anti-surge, rotor and settle-out evidence.
+ *
+ * <p>
+ * The input is intended to be assembled from {@code Compressor}, {@code CompressorAntiSurgeApplication},
+ * {@code CompressorMechanicalDesign}, and {@code SettleOutPressureAnalyzer} results. Each protection concern remains an
+ * independent constraint so an acceptable steady operating point cannot hide a failed transient or machinery check.
+ * Vendor guarantees and rotor-dynamic approval are controlled inputs and are never inferred by this calculation.
+ * </p>
+ */
+public final class CompressorProtectionQualificationCalculation implements
+    EngineeringCalculationModule<CompressorProtectionQualificationCalculation.Input, CompressorProtectionQualificationCalculation.Result> {
+
+  /** One compressor-map operating point from the controlled case matrix. */
+  public static final class OperatingCase implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String caseId;
+    private final double actualFlowM3Hr;
+    private final double surgeControlFlowM3Hr;
+    private final double stonewallFlowM3Hr;
+    private final double dischargeTemperatureC;
+    private final double shaftPowerKw;
+    private final double mapExtrapolationFraction;
+
+    public OperatingCase(String caseId, double actualFlowM3Hr, double surgeControlFlowM3Hr,
+        double stonewallFlowM3Hr, double dischargeTemperatureC, double shaftPowerKw,
+        double mapExtrapolationFraction) {
+      this.caseId = text(caseId, "caseId");
+      this.actualFlowM3Hr = positive(actualFlowM3Hr, "actualFlowM3Hr");
+      this.surgeControlFlowM3Hr = positive(surgeControlFlowM3Hr, "surgeControlFlowM3Hr");
+      this.stonewallFlowM3Hr = positive(stonewallFlowM3Hr, "stonewallFlowM3Hr");
+      if (stonewallFlowM3Hr <= surgeControlFlowM3Hr) {
+        throw new IllegalArgumentException("stonewallFlowM3Hr must exceed surgeControlFlowM3Hr");
+      }
+      this.dischargeTemperatureC = finite(dischargeTemperatureC, "dischargeTemperatureC");
+      this.shaftPowerKw = positive(shaftPowerKw, "shaftPowerKw");
+      this.mapExtrapolationFraction = nonNegative(mapExtrapolationFraction, "mapExtrapolationFraction");
+    }
+  }
+
+  /** Controlled compressor package and protection input. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String equipmentTag;
+    private final String sourceModel;
+    private final String sourceModelVersion;
+    private final List<OperatingCase> operatingCases;
+    private final double minimumSurgeMarginFraction;
+    private final double minimumStonewallMarginFraction;
+    private final double maximumDischargeTemperatureC;
+    private final double maximumMapExtrapolationFraction;
+    private final double driverRatedPowerKw;
+    private final double startupRequiredTorqueNm;
+    private final double startupAvailableTorqueNm;
+    private final double minimumRundownSurgeMarginFraction;
+    private final double requiredRundownSurgeMarginFraction;
+    private final double antiSurgeDetectionSeconds;
+    private final double antiSurgeControllerSeconds;
+    private final double antiSurgeInstrumentSeconds;
+    private final double antiSurgeValveTravelSeconds;
+    private final double antiSurgeFinalOpeningPercent;
+    private final double requiredAntiSurgeOpeningPercent;
+    private final double processSafetyTimeSeconds;
+    private final double rotorCriticalSpeedSeparationPercent;
+    private final double requiredRotorSeparationPercent;
+    private final double settleOutPressureBara;
+    private final double suctionSystemRatingBara;
+    private final boolean vendorGuaranteeAccepted;
+    private final boolean rotorDynamicReviewApproved;
+
+    private Input(Builder builder) {
+      equipmentTag = text(builder.equipmentTag, "equipmentTag");
+      sourceModel = text(builder.sourceModel, "sourceModel");
+      sourceModelVersion = text(builder.sourceModelVersion, "sourceModelVersion");
+      operatingCases = Collections.unmodifiableList(new ArrayList<OperatingCase>(builder.operatingCases));
+      minimumSurgeMarginFraction = nonNegative(builder.minimumSurgeMarginFraction,
+          "minimumSurgeMarginFraction");
+      minimumStonewallMarginFraction = nonNegative(builder.minimumStonewallMarginFraction,
+          "minimumStonewallMarginFraction");
+      maximumDischargeTemperatureC = finite(builder.maximumDischargeTemperatureC,
+          "maximumDischargeTemperatureC");
+      maximumMapExtrapolationFraction = nonNegative(builder.maximumMapExtrapolationFraction,
+          "maximumMapExtrapolationFraction");
+      driverRatedPowerKw = positive(builder.driverRatedPowerKw, "driverRatedPowerKw");
+      startupRequiredTorqueNm = positive(builder.startupRequiredTorqueNm, "startupRequiredTorqueNm");
+      startupAvailableTorqueNm = positive(builder.startupAvailableTorqueNm, "startupAvailableTorqueNm");
+      minimumRundownSurgeMarginFraction = finite(builder.minimumRundownSurgeMarginFraction,
+          "minimumRundownSurgeMarginFraction");
+      requiredRundownSurgeMarginFraction = nonNegative(builder.requiredRundownSurgeMarginFraction,
+          "requiredRundownSurgeMarginFraction");
+      antiSurgeDetectionSeconds = nonNegative(builder.antiSurgeDetectionSeconds,
+          "antiSurgeDetectionSeconds");
+      antiSurgeControllerSeconds = nonNegative(builder.antiSurgeControllerSeconds,
+          "antiSurgeControllerSeconds");
+      antiSurgeInstrumentSeconds = nonNegative(builder.antiSurgeInstrumentSeconds,
+          "antiSurgeInstrumentSeconds");
+      antiSurgeValveTravelSeconds = nonNegative(builder.antiSurgeValveTravelSeconds,
+          "antiSurgeValveTravelSeconds");
+      antiSurgeFinalOpeningPercent = percent(builder.antiSurgeFinalOpeningPercent,
+          "antiSurgeFinalOpeningPercent");
+      requiredAntiSurgeOpeningPercent = percent(builder.requiredAntiSurgeOpeningPercent,
+          "requiredAntiSurgeOpeningPercent");
+      processSafetyTimeSeconds = positive(builder.processSafetyTimeSeconds, "processSafetyTimeSeconds");
+      rotorCriticalSpeedSeparationPercent = nonNegative(builder.rotorCriticalSpeedSeparationPercent,
+          "rotorCriticalSpeedSeparationPercent");
+      requiredRotorSeparationPercent = nonNegative(builder.requiredRotorSeparationPercent,
+          "requiredRotorSeparationPercent");
+      settleOutPressureBara = positive(builder.settleOutPressureBara, "settleOutPressureBara");
+      suctionSystemRatingBara = positive(builder.suctionSystemRatingBara, "suctionSystemRatingBara");
+      vendorGuaranteeAccepted = builder.vendorGuaranteeAccepted;
+      rotorDynamicReviewApproved = builder.rotorDynamicReviewApproved;
+    }
+
+    public static Builder builder(String equipmentTag, String sourceModel, String sourceModelVersion) {
+      return new Builder(equipmentTag, sourceModel, sourceModelVersion);
+    }
+
+    /** Builder for compressor protection qualification input. */
+    public static final class Builder {
+      private final String equipmentTag;
+      private final String sourceModel;
+      private final String sourceModelVersion;
+      private final List<OperatingCase> operatingCases = new ArrayList<OperatingCase>();
+      private double minimumSurgeMarginFraction;
+      private double minimumStonewallMarginFraction;
+      private double maximumDischargeTemperatureC;
+      private double maximumMapExtrapolationFraction;
+      private double driverRatedPowerKw;
+      private double startupRequiredTorqueNm;
+      private double startupAvailableTorqueNm;
+      private double minimumRundownSurgeMarginFraction;
+      private double requiredRundownSurgeMarginFraction;
+      private double antiSurgeDetectionSeconds;
+      private double antiSurgeControllerSeconds;
+      private double antiSurgeInstrumentSeconds;
+      private double antiSurgeValveTravelSeconds;
+      private double antiSurgeFinalOpeningPercent;
+      private double requiredAntiSurgeOpeningPercent;
+      private double processSafetyTimeSeconds;
+      private double rotorCriticalSpeedSeparationPercent;
+      private double requiredRotorSeparationPercent;
+      private double settleOutPressureBara;
+      private double suctionSystemRatingBara;
+      private boolean vendorGuaranteeAccepted;
+      private boolean rotorDynamicReviewApproved;
+
+      private Builder(String equipmentTag, String sourceModel, String sourceModelVersion) {
+        this.equipmentTag = equipmentTag;
+        this.sourceModel = sourceModel;
+        this.sourceModelVersion = sourceModelVersion;
+      }
+
+      public Builder addOperatingCase(OperatingCase value) {
+        if (value == null) {
+          throw new IllegalArgumentException("operatingCase must not be null");
+        }
+        operatingCases.add(value);
+        return this;
+      }
+
+      public Builder mapLimits(double surgeMarginFraction, double stonewallMarginFraction,
+          double dischargeTemperatureC, double extrapolationFraction) {
+        minimumSurgeMarginFraction = surgeMarginFraction;
+        minimumStonewallMarginFraction = stonewallMarginFraction;
+        maximumDischargeTemperatureC = dischargeTemperatureC;
+        maximumMapExtrapolationFraction = extrapolationFraction;
+        return this;
+      }
+
+      public Builder driverAndStartup(double ratedPowerKw, double requiredTorqueNm, double availableTorqueNm) {
+        driverRatedPowerKw = ratedPowerKw;
+        startupRequiredTorqueNm = requiredTorqueNm;
+        startupAvailableTorqueNm = availableTorqueNm;
+        return this;
+      }
+
+      public Builder rundown(double minimumSurgeMarginFraction, double requiredSurgeMarginFraction) {
+        minimumRundownSurgeMarginFraction = minimumSurgeMarginFraction;
+        requiredRundownSurgeMarginFraction = requiredSurgeMarginFraction;
+        return this;
+      }
+
+      public Builder antiSurgeResponse(double detectionSeconds, double controllerSeconds,
+          double instrumentSeconds, double valveTravelSeconds, double finalOpeningPercent,
+          double requiredOpeningPercent, double safetyTimeSeconds) {
+        antiSurgeDetectionSeconds = detectionSeconds;
+        antiSurgeControllerSeconds = controllerSeconds;
+        antiSurgeInstrumentSeconds = instrumentSeconds;
+        antiSurgeValveTravelSeconds = valveTravelSeconds;
+        antiSurgeFinalOpeningPercent = finalOpeningPercent;
+        requiredAntiSurgeOpeningPercent = requiredOpeningPercent;
+        processSafetyTimeSeconds = safetyTimeSeconds;
+        return this;
+      }
+
+      public Builder rotorDynamics(double separationPercent, double requiredSeparationPercent,
+          boolean approved) {
+        rotorCriticalSpeedSeparationPercent = separationPercent;
+        requiredRotorSeparationPercent = requiredSeparationPercent;
+        rotorDynamicReviewApproved = approved;
+        return this;
+      }
+
+      public Builder settleOut(double pressureBara, double suctionRatingBara) {
+        settleOutPressureBara = pressureBara;
+        suctionSystemRatingBara = suctionRatingBara;
+        return this;
+      }
+
+      public Builder vendorGuaranteeAccepted(boolean value) {
+        vendorGuaranteeAccepted = value;
+        return this;
+      }
+
+      public Input build() {
+        return new Input(this);
+      }
+    }
+  }
+
+  /** Immutable compressor protection metrics and constraints. */
+  public static final class Result implements EngineeringConstraintResult, Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Map<String, Double> metrics;
+    private final Map<String, Boolean> constraints;
+    private final String governingSurgeCase;
+    private final String governingStonewallCase;
+
+    private Result(Map<String, Double> metrics, Map<String, Boolean> constraints, String governingSurgeCase,
+        String governingStonewallCase) {
+      this.metrics = Collections.unmodifiableMap(new LinkedHashMap<String, Double>(metrics));
+      this.constraints = Collections.unmodifiableMap(new LinkedHashMap<String, Boolean>(constraints));
+      this.governingSurgeCase = governingSurgeCase;
+      this.governingStonewallCase = governingStonewallCase;
+    }
+
+    @Override
+    public boolean allConstraintsSatisfied() {
+      for (Boolean value : constraints.values()) {
+        if (!value.booleanValue()) {
+          return false;
+        }
+      }
+      return !constraints.isEmpty();
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("metrics", new LinkedHashMap<String, Double>(metrics));
+      result.put("constraints", new LinkedHashMap<String, Boolean>(constraints));
+      result.put("governingSurgeCase", governingSurgeCase);
+      result.put("governingStonewallCase", governingStonewallCase);
+      result.put("allConstraintsSatisfied", Boolean.valueOf(allConstraintsSatisfied()));
+      result.put("vendorGuaranteeRequired", Boolean.TRUE);
+      result.put("engineeringApprovalRequired", Boolean.TRUE);
+      return result;
+    }
+  }
+
+  @Override
+  public String getMethod() {
+    return "compressor-protection-and-machinery-qualification";
+  }
+
+  @Override
+  public String getMethodVersion() {
+    return "1.0";
+  }
+
+  @Override
+  public CalculationReadiness assess(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness.Builder readiness = CalculationReadiness.builder();
+    if (input == null) {
+      return readiness.addBlocker("COMPRESSOR_PROTECTION_INPUT", "Compressor protection input is required",
+          "Supply controlled map, transient, machinery and settle-out evidence").build();
+    }
+    if (input.operatingCases.isEmpty()) {
+      readiness.addBlocker("COMPRESSOR_CASES", "At least one compressor operating case is required",
+          "Run the controlled compressor case matrix");
+    }
+    if (productionQualification(context)
+        && (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty())) {
+      readiness.addBlocker("COMPRESSOR_PRODUCTION_EVIDENCE",
+          "Production qualification requires vendor, machinery, dynamic and standards evidence",
+          "Attach the compressor data sheet, map, rotor report, anti-surge study and project basis");
+    }
+    return readiness.build();
+  }
+
+  @Override
+  public EngineeringCalculationResult<Result> calculate(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness readiness = assess(input, context);
+    EngineeringCalculationResult.Builder<Result> output = EngineeringCalculationResult
+        .<Result>builder("compressor-protection:" + (input == null ? "unassigned" : input.equipmentTag), getMethod(),
+            getMethodVersion())
+        .context(context).readiness(readiness);
+    if (!readiness.isReady()) {
+      return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
+    }
+
+    double minimumSurgeMargin = Double.POSITIVE_INFINITY;
+    double minimumStonewallMargin = Double.POSITIVE_INFINITY;
+    double maximumDischargeTemperature = -Double.MAX_VALUE;
+    double maximumShaftPower = 0.0;
+    double maximumExtrapolation = 0.0;
+    String governingSurgeCase = "";
+    String governingStonewallCase = "";
+    for (OperatingCase operatingCase : input.operatingCases) {
+      double surgeMargin = (operatingCase.actualFlowM3Hr - operatingCase.surgeControlFlowM3Hr)
+          / operatingCase.surgeControlFlowM3Hr;
+      double stonewallMargin = (operatingCase.stonewallFlowM3Hr - operatingCase.actualFlowM3Hr)
+          / operatingCase.stonewallFlowM3Hr;
+      if (surgeMargin < minimumSurgeMargin) {
+        minimumSurgeMargin = surgeMargin;
+        governingSurgeCase = operatingCase.caseId;
+      }
+      if (stonewallMargin < minimumStonewallMargin) {
+        minimumStonewallMargin = stonewallMargin;
+        governingStonewallCase = operatingCase.caseId;
+      }
+      maximumDischargeTemperature = Math.max(maximumDischargeTemperature,
+          operatingCase.dischargeTemperatureC);
+      maximumShaftPower = Math.max(maximumShaftPower, operatingCase.shaftPowerKw);
+      maximumExtrapolation = Math.max(maximumExtrapolation, operatingCase.mapExtrapolationFraction);
+    }
+    double totalAntiSurgeResponseSeconds = input.antiSurgeDetectionSeconds + input.antiSurgeControllerSeconds
+        + input.antiSurgeInstrumentSeconds + input.antiSurgeValveTravelSeconds;
+
+    Map<String, Double> metrics = new LinkedHashMap<String, Double>();
+    metrics.put("minimumSurgeControlMarginFraction", Double.valueOf(minimumSurgeMargin));
+    metrics.put("minimumStonewallMarginFraction", Double.valueOf(minimumStonewallMargin));
+    metrics.put("maximumDischargeTemperatureC", Double.valueOf(maximumDischargeTemperature));
+    metrics.put("maximumShaftPowerKw", Double.valueOf(maximumShaftPower));
+    metrics.put("maximumMapExtrapolationFraction", Double.valueOf(maximumExtrapolation));
+    metrics.put("startupTorqueMarginNm",
+        Double.valueOf(input.startupAvailableTorqueNm - input.startupRequiredTorqueNm));
+    metrics.put("minimumRundownSurgeMarginFraction",
+        Double.valueOf(input.minimumRundownSurgeMarginFraction));
+    metrics.put("totalAntiSurgeResponseSeconds", Double.valueOf(totalAntiSurgeResponseSeconds));
+    metrics.put("antiSurgeFinalOpeningPercent", Double.valueOf(input.antiSurgeFinalOpeningPercent));
+    metrics.put("rotorCriticalSpeedSeparationPercent",
+        Double.valueOf(input.rotorCriticalSpeedSeparationPercent));
+    metrics.put("settleOutPressureBara", Double.valueOf(input.settleOutPressureBara));
+
+    Map<String, Boolean> constraints = new LinkedHashMap<String, Boolean>();
+    constraints.put("SURGE_CONTROL_MARGIN",
+        Boolean.valueOf(minimumSurgeMargin >= input.minimumSurgeMarginFraction));
+    constraints.put("STONEWALL_MARGIN",
+        Boolean.valueOf(minimumStonewallMargin >= input.minimumStonewallMarginFraction));
+    constraints.put("DISCHARGE_TEMPERATURE",
+        Boolean.valueOf(maximumDischargeTemperature <= input.maximumDischargeTemperatureC));
+    constraints.put("MAP_EXTRAPOLATION",
+        Boolean.valueOf(maximumExtrapolation <= input.maximumMapExtrapolationFraction));
+    constraints.put("DRIVER_RATED_POWER", Boolean.valueOf(maximumShaftPower <= input.driverRatedPowerKw));
+    constraints.put("STARTUP_TORQUE",
+        Boolean.valueOf(input.startupAvailableTorqueNm >= input.startupRequiredTorqueNm));
+    constraints.put("RUNDOWN_SURGE_MARGIN", Boolean
+        .valueOf(input.minimumRundownSurgeMarginFraction >= input.requiredRundownSurgeMarginFraction));
+    constraints.put("ANTI_SURGE_RESPONSE_TIME",
+        Boolean.valueOf(totalAntiSurgeResponseSeconds <= input.processSafetyTimeSeconds));
+    constraints.put("ANTI_SURGE_PROTECTIVE_OPENING",
+        Boolean.valueOf(input.antiSurgeFinalOpeningPercent >= input.requiredAntiSurgeOpeningPercent));
+    constraints.put("ROTOR_CRITICAL_SPEED_SEPARATION", Boolean
+        .valueOf(input.rotorCriticalSpeedSeparationPercent >= input.requiredRotorSeparationPercent));
+    constraints.put("SETTLE_OUT_PRESSURE",
+        Boolean.valueOf(input.settleOutPressureBara <= input.suctionSystemRatingBara));
+    constraints.put("VENDOR_GUARANTEE_ACCEPTED", Boolean.valueOf(input.vendorGuaranteeAccepted));
+    constraints.put("ROTOR_DYNAMIC_REVIEW_APPROVED", Boolean.valueOf(input.rotorDynamicReviewApproved));
+
+    return output.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED)
+        .input("equipmentTag", input.equipmentTag).input("sourceModel", input.sourceModel)
+        .input("sourceModelVersion", input.sourceModelVersion)
+        .input("operatingCaseCount", Integer.valueOf(input.operatingCases.size()))
+        .value(new Result(metrics, constraints, governingSurgeCase, governingStonewallCase))
+        .warning("Vendor guarantees, torsional/lateral rotor dynamics and final anti-surge tuning require approval")
+        .build();
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double positive(double value, String field) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and positive");
+    }
+    return value;
+  }
+
+  private static double nonNegative(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and non-negative");
+    }
+    return value;
+  }
+
+  private static double percent(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0 || value > 100.0) {
+      throw new IllegalArgumentException(field + " must be between zero and one hundred");
+    }
+    return value;
+  }
+
+  private static double finite(double value, String field) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(field + " must be finite");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/rotating/CompressorProtectionQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/rotating/CompressorProtectionQualificationCalculation.java
@@ -36,9 +36,8 @@ public final class CompressorProtectionQualificationCalculation implements
     private final double shaftPowerKw;
     private final double mapExtrapolationFraction;
 
-    public OperatingCase(String caseId, double actualFlowM3Hr, double surgeControlFlowM3Hr,
-        double stonewallFlowM3Hr, double dischargeTemperatureC, double shaftPowerKw,
-        double mapExtrapolationFraction) {
+    public OperatingCase(String caseId, double actualFlowM3Hr, double surgeControlFlowM3Hr, double stonewallFlowM3Hr,
+        double dischargeTemperatureC, double shaftPowerKw, double mapExtrapolationFraction) {
       this.caseId = text(caseId, "caseId");
       this.actualFlowM3Hr = positive(actualFlowM3Hr, "actualFlowM3Hr");
       this.surgeControlFlowM3Hr = positive(surgeControlFlowM3Hr, "surgeControlFlowM3Hr");
@@ -87,12 +86,10 @@ public final class CompressorProtectionQualificationCalculation implements
       sourceModel = text(builder.sourceModel, "sourceModel");
       sourceModelVersion = text(builder.sourceModelVersion, "sourceModelVersion");
       operatingCases = Collections.unmodifiableList(new ArrayList<OperatingCase>(builder.operatingCases));
-      minimumSurgeMarginFraction = nonNegative(builder.minimumSurgeMarginFraction,
-          "minimumSurgeMarginFraction");
+      minimumSurgeMarginFraction = nonNegative(builder.minimumSurgeMarginFraction, "minimumSurgeMarginFraction");
       minimumStonewallMarginFraction = nonNegative(builder.minimumStonewallMarginFraction,
           "minimumStonewallMarginFraction");
-      maximumDischargeTemperatureC = finite(builder.maximumDischargeTemperatureC,
-          "maximumDischargeTemperatureC");
+      maximumDischargeTemperatureC = finite(builder.maximumDischargeTemperatureC, "maximumDischargeTemperatureC");
       maximumMapExtrapolationFraction = nonNegative(builder.maximumMapExtrapolationFraction,
           "maximumMapExtrapolationFraction");
       driverRatedPowerKw = positive(builder.driverRatedPowerKw, "driverRatedPowerKw");
@@ -102,16 +99,11 @@ public final class CompressorProtectionQualificationCalculation implements
           "minimumRundownSurgeMarginFraction");
       requiredRundownSurgeMarginFraction = nonNegative(builder.requiredRundownSurgeMarginFraction,
           "requiredRundownSurgeMarginFraction");
-      antiSurgeDetectionSeconds = nonNegative(builder.antiSurgeDetectionSeconds,
-          "antiSurgeDetectionSeconds");
-      antiSurgeControllerSeconds = nonNegative(builder.antiSurgeControllerSeconds,
-          "antiSurgeControllerSeconds");
-      antiSurgeInstrumentSeconds = nonNegative(builder.antiSurgeInstrumentSeconds,
-          "antiSurgeInstrumentSeconds");
-      antiSurgeValveTravelSeconds = nonNegative(builder.antiSurgeValveTravelSeconds,
-          "antiSurgeValveTravelSeconds");
-      antiSurgeFinalOpeningPercent = percent(builder.antiSurgeFinalOpeningPercent,
-          "antiSurgeFinalOpeningPercent");
+      antiSurgeDetectionSeconds = nonNegative(builder.antiSurgeDetectionSeconds, "antiSurgeDetectionSeconds");
+      antiSurgeControllerSeconds = nonNegative(builder.antiSurgeControllerSeconds, "antiSurgeControllerSeconds");
+      antiSurgeInstrumentSeconds = nonNegative(builder.antiSurgeInstrumentSeconds, "antiSurgeInstrumentSeconds");
+      antiSurgeValveTravelSeconds = nonNegative(builder.antiSurgeValveTravelSeconds, "antiSurgeValveTravelSeconds");
+      antiSurgeFinalOpeningPercent = percent(builder.antiSurgeFinalOpeningPercent, "antiSurgeFinalOpeningPercent");
       requiredAntiSurgeOpeningPercent = percent(builder.requiredAntiSurgeOpeningPercent,
           "requiredAntiSurgeOpeningPercent");
       processSafetyTimeSeconds = positive(builder.processSafetyTimeSeconds, "processSafetyTimeSeconds");
@@ -172,8 +164,8 @@ public final class CompressorProtectionQualificationCalculation implements
         return this;
       }
 
-      public Builder mapLimits(double surgeMarginFraction, double stonewallMarginFraction,
-          double dischargeTemperatureC, double extrapolationFraction) {
+      public Builder mapLimits(double surgeMarginFraction, double stonewallMarginFraction, double dischargeTemperatureC,
+          double extrapolationFraction) {
         minimumSurgeMarginFraction = surgeMarginFraction;
         minimumStonewallMarginFraction = stonewallMarginFraction;
         maximumDischargeTemperatureC = dischargeTemperatureC;
@@ -194,9 +186,9 @@ public final class CompressorProtectionQualificationCalculation implements
         return this;
       }
 
-      public Builder antiSurgeResponse(double detectionSeconds, double controllerSeconds,
-          double instrumentSeconds, double valveTravelSeconds, double finalOpeningPercent,
-          double requiredOpeningPercent, double safetyTimeSeconds) {
+      public Builder antiSurgeResponse(double detectionSeconds, double controllerSeconds, double instrumentSeconds,
+          double valveTravelSeconds, double finalOpeningPercent, double requiredOpeningPercent,
+          double safetyTimeSeconds) {
         antiSurgeDetectionSeconds = detectionSeconds;
         antiSurgeControllerSeconds = controllerSeconds;
         antiSurgeInstrumentSeconds = instrumentSeconds;
@@ -207,8 +199,7 @@ public final class CompressorProtectionQualificationCalculation implements
         return this;
       }
 
-      public Builder rotorDynamics(double separationPercent, double requiredSeparationPercent,
-          boolean approved) {
+      public Builder rotorDynamics(double separationPercent, double requiredSeparationPercent, boolean approved) {
         rotorCriticalSpeedSeparationPercent = separationPercent;
         requiredRotorSeparationPercent = requiredSeparationPercent;
         rotorDynamicReviewApproved = approved;
@@ -332,8 +323,7 @@ public final class CompressorProtectionQualificationCalculation implements
         minimumStonewallMargin = stonewallMargin;
         governingStonewallCase = operatingCase.caseId;
       }
-      maximumDischargeTemperature = Math.max(maximumDischargeTemperature,
-          operatingCase.dischargeTemperatureC);
+      maximumDischargeTemperature = Math.max(maximumDischargeTemperature, operatingCase.dischargeTemperatureC);
       maximumShaftPower = Math.max(maximumShaftPower, operatingCase.shaftPowerKw);
       maximumExtrapolation = Math.max(maximumExtrapolation, operatingCase.mapExtrapolationFraction);
     }
@@ -348,17 +338,14 @@ public final class CompressorProtectionQualificationCalculation implements
     metrics.put("maximumMapExtrapolationFraction", Double.valueOf(maximumExtrapolation));
     metrics.put("startupTorqueMarginNm",
         Double.valueOf(input.startupAvailableTorqueNm - input.startupRequiredTorqueNm));
-    metrics.put("minimumRundownSurgeMarginFraction",
-        Double.valueOf(input.minimumRundownSurgeMarginFraction));
+    metrics.put("minimumRundownSurgeMarginFraction", Double.valueOf(input.minimumRundownSurgeMarginFraction));
     metrics.put("totalAntiSurgeResponseSeconds", Double.valueOf(totalAntiSurgeResponseSeconds));
     metrics.put("antiSurgeFinalOpeningPercent", Double.valueOf(input.antiSurgeFinalOpeningPercent));
-    metrics.put("rotorCriticalSpeedSeparationPercent",
-        Double.valueOf(input.rotorCriticalSpeedSeparationPercent));
+    metrics.put("rotorCriticalSpeedSeparationPercent", Double.valueOf(input.rotorCriticalSpeedSeparationPercent));
     metrics.put("settleOutPressureBara", Double.valueOf(input.settleOutPressureBara));
 
     Map<String, Boolean> constraints = new LinkedHashMap<String, Boolean>();
-    constraints.put("SURGE_CONTROL_MARGIN",
-        Boolean.valueOf(minimumSurgeMargin >= input.minimumSurgeMarginFraction));
+    constraints.put("SURGE_CONTROL_MARGIN", Boolean.valueOf(minimumSurgeMargin >= input.minimumSurgeMarginFraction));
     constraints.put("STONEWALL_MARGIN",
         Boolean.valueOf(minimumStonewallMargin >= input.minimumStonewallMarginFraction));
     constraints.put("DISCHARGE_TEMPERATURE",
@@ -366,16 +353,15 @@ public final class CompressorProtectionQualificationCalculation implements
     constraints.put("MAP_EXTRAPOLATION",
         Boolean.valueOf(maximumExtrapolation <= input.maximumMapExtrapolationFraction));
     constraints.put("DRIVER_RATED_POWER", Boolean.valueOf(maximumShaftPower <= input.driverRatedPowerKw));
-    constraints.put("STARTUP_TORQUE",
-        Boolean.valueOf(input.startupAvailableTorqueNm >= input.startupRequiredTorqueNm));
-    constraints.put("RUNDOWN_SURGE_MARGIN", Boolean
-        .valueOf(input.minimumRundownSurgeMarginFraction >= input.requiredRundownSurgeMarginFraction));
+    constraints.put("STARTUP_TORQUE", Boolean.valueOf(input.startupAvailableTorqueNm >= input.startupRequiredTorqueNm));
+    constraints.put("RUNDOWN_SURGE_MARGIN",
+        Boolean.valueOf(input.minimumRundownSurgeMarginFraction >= input.requiredRundownSurgeMarginFraction));
     constraints.put("ANTI_SURGE_RESPONSE_TIME",
         Boolean.valueOf(totalAntiSurgeResponseSeconds <= input.processSafetyTimeSeconds));
     constraints.put("ANTI_SURGE_PROTECTIVE_OPENING",
         Boolean.valueOf(input.antiSurgeFinalOpeningPercent >= input.requiredAntiSurgeOpeningPercent));
-    constraints.put("ROTOR_CRITICAL_SPEED_SEPARATION", Boolean
-        .valueOf(input.rotorCriticalSpeedSeparationPercent >= input.requiredRotorSeparationPercent));
+    constraints.put("ROTOR_CRITICAL_SPEED_SEPARATION",
+        Boolean.valueOf(input.rotorCriticalSpeedSeparationPercent >= input.requiredRotorSeparationPercent));
     constraints.put("SETTLE_OUT_PRESSURE",
         Boolean.valueOf(input.settleOutPressureBara <= input.suctionSystemRatingBara));
     constraints.put("VENDOR_GUARANTEE_ACCEPTED", Boolean.valueOf(input.vendorGuaranteeAccepted));

--- a/src/main/java/neqsim/process/engineering/rotating/CompressorProtectionQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/rotating/CompressorProtectionQualificationCalculation.java
@@ -302,6 +302,9 @@ public final class CompressorProtectionQualificationCalculation implements
     if (!readiness.isReady()) {
       return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
     }
+    if (input == null) {
+      return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
+    }
 
     double minimumSurgeMargin = Double.POSITIVE_INFINITY;
     double minimumStonewallMargin = Double.POSITIVE_INFINITY;

--- a/src/main/java/neqsim/process/engineering/safety/FlareConsequenceCalculation.java
+++ b/src/main/java/neqsim/process/engineering/safety/FlareConsequenceCalculation.java
@@ -216,6 +216,9 @@ public final class FlareConsequenceCalculation
     if (!readiness.isReady()) {
       return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
     }
+    if (input == null) {
+      return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
+    }
 
     double heatReleaseW = input.heatReleaseMw * 1.0e6;
     double radiationKwM2 = input.radiativeFraction * input.atmosphericTransmissivity * input.geometryFactor

--- a/src/main/java/neqsim/process/engineering/safety/FlareConsequenceCalculation.java
+++ b/src/main/java/neqsim/process/engineering/safety/FlareConsequenceCalculation.java
@@ -61,8 +61,7 @@ public final class FlareConsequenceCalculation
       targetConcentrationKgM3 = positive(builder.targetConcentrationKgM3, "targetConcentrationKgM3");
       maximumDispersionDistanceM = positive(builder.maximumDispersionDistanceM, "maximumDispersionDistanceM");
       sourceSoundPowerDbA = finite(builder.sourceSoundPowerDbA, "sourceSoundPowerDbA");
-      atmosphericAbsorptionDbPerM = nonNegative(builder.atmosphericAbsorptionDbPerM,
-          "atmosphericAbsorptionDbPerM");
+      atmosphericAbsorptionDbPerM = nonNegative(builder.atmosphericAbsorptionDbPerM, "atmosphericAbsorptionDbPerM");
       maximumNoiseDbA = finite(builder.maximumNoiseDbA, "maximumNoiseDbA");
       flareTipVelocityMPerS = nonNegative(builder.flareTipVelocityMPerS, "flareTipVelocityMPerS");
       speedOfSoundMPerS = positive(builder.speedOfSoundMPerS, "speedOfSoundMPerS");
@@ -110,9 +109,8 @@ public final class FlareConsequenceCalculation
         return this;
       }
 
-      public Builder dispersion(double releaseMassRateKgS, double windSpeedMPerS,
-          double lateralSpreadCoefficient, double verticalSpreadCoefficient, double targetConcentrationKgM3,
-          double maximumDispersionDistanceM) {
+      public Builder dispersion(double releaseMassRateKgS, double windSpeedMPerS, double lateralSpreadCoefficient,
+          double verticalSpreadCoefficient, double targetConcentrationKgM3, double maximumDispersionDistanceM) {
         this.releaseMassRateKgS = releaseMassRateKgS;
         this.windSpeedMPerS = windSpeedMPerS;
         this.lateralSpreadCoefficient = lateralSpreadCoefficient;
@@ -122,8 +120,7 @@ public final class FlareConsequenceCalculation
         return this;
       }
 
-      public Builder noise(double sourceSoundPowerDbA, double atmosphericAbsorptionDbPerM,
-          double maximumNoiseDbA) {
+      public Builder noise(double sourceSoundPowerDbA, double atmosphericAbsorptionDbPerM, double maximumNoiseDbA) {
         this.sourceSoundPowerDbA = sourceSoundPowerDbA;
         this.atmosphericAbsorptionDbPerM = atmosphericAbsorptionDbPerM;
         this.maximumNoiseDbA = maximumNoiseDbA;
@@ -223,9 +220,8 @@ public final class FlareConsequenceCalculation
     double heatReleaseW = input.heatReleaseMw * 1.0e6;
     double radiationKwM2 = input.radiativeFraction * input.atmosphericTransmissivity * input.geometryFactor
         * heatReleaseW / (4.0 * Math.PI * input.receptorDistanceM * input.receptorDistanceM) / 1000.0;
-    double dispersionDistanceM = Math.sqrt(input.releaseMassRateKgS
-        / (2.0 * Math.PI * input.windSpeedMPerS * input.lateralSpreadCoefficient
-            * input.verticalSpreadCoefficient * input.targetConcentrationKgM3));
+    double dispersionDistanceM = Math.sqrt(input.releaseMassRateKgS / (2.0 * Math.PI * input.windSpeedMPerS
+        * input.lateralSpreadCoefficient * input.verticalSpreadCoefficient * input.targetConcentrationKgM3));
     double receptorNoiseDbA = input.sourceSoundPowerDbA - 20.0 * Math.log10(input.receptorDistanceM) - 11.0
         - input.atmosphericAbsorptionDbPerM * input.receptorDistanceM;
     double tipMach = input.flareTipVelocityMPerS / input.speedOfSoundMPerS;
@@ -238,14 +234,12 @@ public final class FlareConsequenceCalculation
 
     Map<String, Boolean> constraints = new LinkedHashMap<String, Boolean>();
     constraints.put("THERMAL_RADIATION", Boolean.valueOf(radiationKwM2 <= input.maximumRadiationKwM2));
-    constraints.put("DISPERSION_DISTANCE",
-        Boolean.valueOf(dispersionDistanceM <= input.maximumDispersionDistanceM));
+    constraints.put("DISPERSION_DISTANCE", Boolean.valueOf(dispersionDistanceM <= input.maximumDispersionDistanceM));
     constraints.put("RECEPTOR_NOISE", Boolean.valueOf(receptorNoiseDbA <= input.maximumNoiseDbA));
     constraints.put("FLARE_TIP_MACH", Boolean.valueOf(tipMach <= input.maximumTipMach));
 
-    return output.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED)
-        .input("studyId", input.studyId).input("receptorDistanceM", Double.valueOf(input.receptorDistanceM))
-        .value(new Result(metrics, constraints))
+    return output.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED).input("studyId", input.studyId)
+        .input("receptorDistanceM", Double.valueOf(input.receptorDistanceM)).value(new Result(metrics, constraints))
         .uncertainty(new EngineeringCalculationResult.Uncertainty(0.7 * radiationKwM2, radiationKwM2,
             1.5 * radiationKwM2, "kW/m2", "Screening correlation range; replace with project uncertainty model"))
         .warning("Complex geometry, crosswind, combustion efficiency and weather classes require qualified modeling")

--- a/src/main/java/neqsim/process/engineering/safety/FlareConsequenceCalculation.java
+++ b/src/main/java/neqsim/process/engineering/safety/FlareConsequenceCalculation.java
@@ -1,0 +1,293 @@
+package neqsim.process.engineering.safety;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import neqsim.process.engineering.calculation.CalculationReadiness;
+import neqsim.process.engineering.calculation.EngineeringCalculationContext;
+import neqsim.process.engineering.calculation.EngineeringCalculationModule;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+import neqsim.process.engineering.calculation.EngineeringConstraintResult;
+
+/**
+ * Versioned flare radiation, dispersion and noise screening calculation.
+ *
+ * <p>
+ * Radiation uses an explicit point-source fraction, atmospheric transmissivity and geometry factor. Dispersion uses a
+ * neutral continuous Gaussian centerline screen with project-supplied lateral and vertical spread coefficients. Noise
+ * uses spherical spreading with project-supplied atmospheric absorption. These correlations are screening interfaces;
+ * production qualification requires applicability evidence or a project-qualified consequence model.
+ * </p>
+ */
+public final class FlareConsequenceCalculation
+    implements EngineeringCalculationModule<FlareConsequenceCalculation.Input, FlareConsequenceCalculation.Result> {
+
+  /** Controlled flare load, receptor and method input. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String studyId;
+    private final double heatReleaseMw;
+    private final double radiativeFraction;
+    private final double atmosphericTransmissivity;
+    private final double geometryFactor;
+    private final double receptorDistanceM;
+    private final double maximumRadiationKwM2;
+    private final double releaseMassRateKgS;
+    private final double windSpeedMPerS;
+    private final double lateralSpreadCoefficient;
+    private final double verticalSpreadCoefficient;
+    private final double targetConcentrationKgM3;
+    private final double maximumDispersionDistanceM;
+    private final double sourceSoundPowerDbA;
+    private final double atmosphericAbsorptionDbPerM;
+    private final double maximumNoiseDbA;
+    private final double flareTipVelocityMPerS;
+    private final double speedOfSoundMPerS;
+    private final double maximumTipMach;
+
+    private Input(Builder builder) {
+      studyId = text(builder.studyId, "studyId");
+      heatReleaseMw = positive(builder.heatReleaseMw, "heatReleaseMw");
+      radiativeFraction = fraction(builder.radiativeFraction, "radiativeFraction");
+      atmosphericTransmissivity = fraction(builder.atmosphericTransmissivity, "atmosphericTransmissivity");
+      geometryFactor = fraction(builder.geometryFactor, "geometryFactor");
+      receptorDistanceM = positive(builder.receptorDistanceM, "receptorDistanceM");
+      maximumRadiationKwM2 = positive(builder.maximumRadiationKwM2, "maximumRadiationKwM2");
+      releaseMassRateKgS = positive(builder.releaseMassRateKgS, "releaseMassRateKgS");
+      windSpeedMPerS = positive(builder.windSpeedMPerS, "windSpeedMPerS");
+      lateralSpreadCoefficient = positive(builder.lateralSpreadCoefficient, "lateralSpreadCoefficient");
+      verticalSpreadCoefficient = positive(builder.verticalSpreadCoefficient, "verticalSpreadCoefficient");
+      targetConcentrationKgM3 = positive(builder.targetConcentrationKgM3, "targetConcentrationKgM3");
+      maximumDispersionDistanceM = positive(builder.maximumDispersionDistanceM, "maximumDispersionDistanceM");
+      sourceSoundPowerDbA = finite(builder.sourceSoundPowerDbA, "sourceSoundPowerDbA");
+      atmosphericAbsorptionDbPerM = nonNegative(builder.atmosphericAbsorptionDbPerM,
+          "atmosphericAbsorptionDbPerM");
+      maximumNoiseDbA = finite(builder.maximumNoiseDbA, "maximumNoiseDbA");
+      flareTipVelocityMPerS = nonNegative(builder.flareTipVelocityMPerS, "flareTipVelocityMPerS");
+      speedOfSoundMPerS = positive(builder.speedOfSoundMPerS, "speedOfSoundMPerS");
+      maximumTipMach = positive(builder.maximumTipMach, "maximumTipMach");
+    }
+
+    public static Builder builder(String studyId) {
+      return new Builder(studyId);
+    }
+
+    /** Builder for flare consequence screening input. */
+    public static final class Builder {
+      private final String studyId;
+      private double heatReleaseMw;
+      private double radiativeFraction;
+      private double atmosphericTransmissivity;
+      private double geometryFactor;
+      private double receptorDistanceM;
+      private double maximumRadiationKwM2;
+      private double releaseMassRateKgS;
+      private double windSpeedMPerS;
+      private double lateralSpreadCoefficient;
+      private double verticalSpreadCoefficient;
+      private double targetConcentrationKgM3;
+      private double maximumDispersionDistanceM;
+      private double sourceSoundPowerDbA;
+      private double atmosphericAbsorptionDbPerM;
+      private double maximumNoiseDbA;
+      private double flareTipVelocityMPerS;
+      private double speedOfSoundMPerS;
+      private double maximumTipMach;
+
+      private Builder(String studyId) {
+        this.studyId = studyId;
+      }
+
+      public Builder radiation(double heatReleaseMw, double radiativeFraction, double transmissivity,
+          double geometryFactor, double receptorDistanceM, double maximumRadiationKwM2) {
+        this.heatReleaseMw = heatReleaseMw;
+        this.radiativeFraction = radiativeFraction;
+        atmosphericTransmissivity = transmissivity;
+        this.geometryFactor = geometryFactor;
+        this.receptorDistanceM = receptorDistanceM;
+        this.maximumRadiationKwM2 = maximumRadiationKwM2;
+        return this;
+      }
+
+      public Builder dispersion(double releaseMassRateKgS, double windSpeedMPerS,
+          double lateralSpreadCoefficient, double verticalSpreadCoefficient, double targetConcentrationKgM3,
+          double maximumDispersionDistanceM) {
+        this.releaseMassRateKgS = releaseMassRateKgS;
+        this.windSpeedMPerS = windSpeedMPerS;
+        this.lateralSpreadCoefficient = lateralSpreadCoefficient;
+        this.verticalSpreadCoefficient = verticalSpreadCoefficient;
+        this.targetConcentrationKgM3 = targetConcentrationKgM3;
+        this.maximumDispersionDistanceM = maximumDispersionDistanceM;
+        return this;
+      }
+
+      public Builder noise(double sourceSoundPowerDbA, double atmosphericAbsorptionDbPerM,
+          double maximumNoiseDbA) {
+        this.sourceSoundPowerDbA = sourceSoundPowerDbA;
+        this.atmosphericAbsorptionDbPerM = atmosphericAbsorptionDbPerM;
+        this.maximumNoiseDbA = maximumNoiseDbA;
+        return this;
+      }
+
+      public Builder flareTip(double velocityMPerS, double speedOfSoundMPerS, double maximumMach) {
+        flareTipVelocityMPerS = velocityMPerS;
+        this.speedOfSoundMPerS = speedOfSoundMPerS;
+        maximumTipMach = maximumMach;
+        return this;
+      }
+
+      public Input build() {
+        return new Input(this);
+      }
+    }
+  }
+
+  /** Immutable flare consequence metrics and constraints. */
+  public static final class Result implements EngineeringConstraintResult, Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Map<String, Double> metrics;
+    private final Map<String, Boolean> constraints;
+
+    private Result(Map<String, Double> metrics, Map<String, Boolean> constraints) {
+      this.metrics = Collections.unmodifiableMap(new LinkedHashMap<String, Double>(metrics));
+      this.constraints = Collections.unmodifiableMap(new LinkedHashMap<String, Boolean>(constraints));
+    }
+
+    @Override
+    public boolean allConstraintsSatisfied() {
+      for (Boolean value : constraints.values()) {
+        if (!value.booleanValue()) {
+          return false;
+        }
+      }
+      return !constraints.isEmpty();
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("metrics", new LinkedHashMap<String, Double>(metrics));
+      result.put("constraints", new LinkedHashMap<String, Boolean>(constraints));
+      result.put("allConstraintsSatisfied", Boolean.valueOf(allConstraintsSatisfied()));
+      result.put("radiationMethod", "POINT_SOURCE_SCREEN");
+      result.put("dispersionMethod", "NEUTRAL_GAUSSIAN_CENTERLINE_SCREEN");
+      result.put("noiseMethod", "SPHERICAL_SPREADING_SCREEN");
+      result.put("approvalStatus", "REVIEW_REQUIRED");
+      return result;
+    }
+  }
+
+  @Override
+  public String getMethod() {
+    return "flare-radiation-dispersion-noise-screening";
+  }
+
+  @Override
+  public String getMethodVersion() {
+    return "1.0";
+  }
+
+  @Override
+  public CalculationReadiness assess(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness.Builder readiness = CalculationReadiness.builder();
+    if (input == null) {
+      return readiness.addBlocker("FLARE_CONSEQUENCE_INPUT", "Flare consequence input is required",
+          "Supply flare load, receptor, atmospheric and acceptance data").build();
+    }
+    if (productionQualification(context)
+        && (context.getEvidenceReferences().isEmpty() || context.getStandardReferences().isEmpty())) {
+      readiness.addBlocker("FLARE_CONSEQUENCE_PRODUCTION_EVIDENCE",
+          "Production qualification requires consequence-method and project standards evidence",
+          "Attach the controlled flare, radiation, dispersion and noise calculation basis");
+    }
+    if (productionQualification(context)
+        && !"approved".equalsIgnoreCase(context.getAttributes().get("consequenceMethodApplicability"))) {
+      readiness.addBlocker("FLARE_METHOD_APPLICABILITY",
+          "The consequence method has not been approved for the release and geometry",
+          "Approve the project consequence method or attach qualified external-model results");
+    }
+    return readiness.build();
+  }
+
+  @Override
+  public EngineeringCalculationResult<Result> calculate(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness readiness = assess(input, context);
+    EngineeringCalculationResult.Builder<Result> output = EngineeringCalculationResult
+        .<Result>builder("flare-consequence:" + (input == null ? "unassigned" : input.studyId), getMethod(),
+            getMethodVersion())
+        .context(context).readiness(readiness);
+    if (!readiness.isReady()) {
+      return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
+    }
+
+    double heatReleaseW = input.heatReleaseMw * 1.0e6;
+    double radiationKwM2 = input.radiativeFraction * input.atmosphericTransmissivity * input.geometryFactor
+        * heatReleaseW / (4.0 * Math.PI * input.receptorDistanceM * input.receptorDistanceM) / 1000.0;
+    double dispersionDistanceM = Math.sqrt(input.releaseMassRateKgS
+        / (2.0 * Math.PI * input.windSpeedMPerS * input.lateralSpreadCoefficient
+            * input.verticalSpreadCoefficient * input.targetConcentrationKgM3));
+    double receptorNoiseDbA = input.sourceSoundPowerDbA - 20.0 * Math.log10(input.receptorDistanceM) - 11.0
+        - input.atmosphericAbsorptionDbPerM * input.receptorDistanceM;
+    double tipMach = input.flareTipVelocityMPerS / input.speedOfSoundMPerS;
+
+    Map<String, Double> metrics = new LinkedHashMap<String, Double>();
+    metrics.put("radiationAtReceptorKwM2", Double.valueOf(radiationKwM2));
+    metrics.put("dispersionTargetDistanceM", Double.valueOf(dispersionDistanceM));
+    metrics.put("noiseAtReceptorDbA", Double.valueOf(receptorNoiseDbA));
+    metrics.put("flareTipMach", Double.valueOf(tipMach));
+
+    Map<String, Boolean> constraints = new LinkedHashMap<String, Boolean>();
+    constraints.put("THERMAL_RADIATION", Boolean.valueOf(radiationKwM2 <= input.maximumRadiationKwM2));
+    constraints.put("DISPERSION_DISTANCE",
+        Boolean.valueOf(dispersionDistanceM <= input.maximumDispersionDistanceM));
+    constraints.put("RECEPTOR_NOISE", Boolean.valueOf(receptorNoiseDbA <= input.maximumNoiseDbA));
+    constraints.put("FLARE_TIP_MACH", Boolean.valueOf(tipMach <= input.maximumTipMach));
+
+    return output.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED)
+        .input("studyId", input.studyId).input("receptorDistanceM", Double.valueOf(input.receptorDistanceM))
+        .value(new Result(metrics, constraints))
+        .uncertainty(new EngineeringCalculationResult.Uncertainty(0.7 * radiationKwM2, radiationKwM2,
+            1.5 * radiationKwM2, "kW/m2", "Screening correlation range; replace with project uncertainty model"))
+        .warning("Complex geometry, crosswind, combustion efficiency and weather classes require qualified modeling")
+        .build();
+  }
+
+  private static boolean productionQualification(EngineeringCalculationContext context) {
+    return context != null && "true".equalsIgnoreCase(context.getAttributes().get("productionQualification"));
+  }
+
+  private static String text(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double positive(double value, String field) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and positive");
+    }
+    return value;
+  }
+
+  private static double nonNegative(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and non-negative");
+    }
+    return value;
+  }
+
+  private static double fraction(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0 || value > 1.0) {
+      throw new IllegalArgumentException(field + " must be between zero and one");
+    }
+    return value;
+  }
+
+  private static double finite(double value, String field) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(field + " must be finite");
+    }
+    return value;
+  }
+}

--- a/src/test/java/neqsim/process/engineering/EngineeringTechnicalCompletionQualificationTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringTechnicalCompletionQualificationTest.java
@@ -49,13 +49,13 @@ class EngineeringTechnicalCompletionQualificationTest {
   void qualifiesCompressorProtectionAcrossSteadyAndTransientEvidence() {
     CompressorProtectionQualificationCalculation.Input input = CompressorProtectionQualificationCalculation.Input
         .builder("K-100", "CompressorAntiSurgeApplication", "1.0")
-        .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("normal", 130.0, 100.0,
-            220.0, 115.0, 4200.0, 0.0))
+        .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("normal", 130.0, 100.0, 220.0,
+            115.0, 4200.0, 0.0))
         .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("turndown", 115.0, 100.0,
             200.0, 120.0, 3900.0, 0.01))
-        .mapLimits(0.10, 0.10, 160.0, 0.02).driverAndStartup(5000.0, 1000.0, 1250.0)
-        .rundown(0.12, 0.10).antiSurgeResponse(0.2, 0.3, 0.2, 1.0, 100.0, 90.0, 3.0)
-        .rotorDynamics(20.0, 15.0, true).settleOut(60.0, 70.0).vendorGuaranteeAccepted(true).build();
+        .mapLimits(0.10, 0.10, 160.0, 0.02).driverAndStartup(5000.0, 1000.0, 1250.0).rundown(0.12, 0.10)
+        .antiSurgeResponse(0.2, 0.3, 0.2, 1.0, 100.0, 90.0, 3.0).rotorDynamics(20.0, 15.0, true).settleOut(60.0, 70.0)
+        .vendorGuaranteeAccepted(true).build();
 
     EngineeringCalculationResult<CompressorProtectionQualificationCalculation.Result> result = new CompressorProtectionQualificationCalculation()
         .calculate(input, productionContext());
@@ -66,11 +66,11 @@ class EngineeringTechnicalCompletionQualificationTest {
 
     CompressorProtectionQualificationCalculation.Input slowProtection = CompressorProtectionQualificationCalculation.Input
         .builder("K-100", "CompressorAntiSurgeApplication", "1.0")
-        .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("normal", 130.0, 100.0,
-            220.0, 115.0, 4200.0, 0.0))
-        .mapLimits(0.10, 0.10, 160.0, 0.02).driverAndStartup(5000.0, 1000.0, 1250.0)
-        .rundown(0.12, 0.10).antiSurgeResponse(0.5, 0.5, 0.5, 3.0, 100.0, 90.0, 3.0)
-        .rotorDynamics(20.0, 15.0, true).settleOut(60.0, 70.0).vendorGuaranteeAccepted(true).build();
+        .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("normal", 130.0, 100.0, 220.0,
+            115.0, 4200.0, 0.0))
+        .mapLimits(0.10, 0.10, 160.0, 0.02).driverAndStartup(5000.0, 1000.0, 1250.0).rundown(0.12, 0.10)
+        .antiSurgeResponse(0.5, 0.5, 0.5, 3.0, 100.0, 90.0, 3.0).rotorDynamics(20.0, 15.0, true).settleOut(60.0, 70.0)
+        .vendorGuaranteeAccepted(true).build();
     EngineeringCalculationResult<CompressorProtectionQualificationCalculation.Result> slowResult = new CompressorProtectionQualificationCalculation()
         .calculate(slowProtection, productionContext());
     assertFalse(slowResult.getValue().allConstraintsSatisfied());
@@ -80,19 +80,17 @@ class EngineeringTechnicalCompletionQualificationTest {
   @Test
   void qualifiesValveInstrumentAndMechanicalFailureModesIndependently() {
     ValveInstrumentQualificationCalculation.Input loop = ValveInstrumentQualificationCalculation.Input
-        .builder("SIF-100", "ESDV-100", "PIT-100").actuator(10000.0, 15000.0, 80.0, 100.0)
-        .leakage(0.001, 0.005).responseBudget(2.0, 0.5, 0.2, 5.0)
-        .transmitterRange(40.0, 90.0, 0.0, 100.0, 0.5, 1.0).thermowell(3.0, 2.0, 0.60)
-        .approvals(true, true, true, true, true).build();
+        .builder("SIF-100", "ESDV-100", "PIT-100").actuator(10000.0, 15000.0, 80.0, 100.0).leakage(0.001, 0.005)
+        .responseBudget(2.0, 0.5, 0.2, 5.0).transmitterRange(40.0, 90.0, 0.0, 100.0, 0.5, 1.0)
+        .thermowell(3.0, 2.0, 0.60).approvals(true, true, true, true, true).build();
     EngineeringCalculationResult<ValveInstrumentQualificationCalculation.Result> loopResult = new ValveInstrumentQualificationCalculation()
         .calculate(loop, productionContext());
     assertTrue(loopResult.getValue().allConstraintsSatisfied());
 
     ValveInstrumentQualificationCalculation.Input slowLoop = ValveInstrumentQualificationCalculation.Input
-        .builder("SIF-100", "ESDV-100", "PIT-100").actuator(10000.0, 15000.0, 80.0, 100.0)
-        .leakage(0.001, 0.005).responseBudget(4.0, 1.0, 1.0, 5.0)
-        .transmitterRange(40.0, 90.0, 0.0, 100.0, 0.5, 1.0).thermowell(3.0, 2.0, 0.60)
-        .approvals(true, true, true, true, true).build();
+        .builder("SIF-100", "ESDV-100", "PIT-100").actuator(10000.0, 15000.0, 80.0, 100.0).leakage(0.001, 0.005)
+        .responseBudget(4.0, 1.0, 1.0, 5.0).transmitterRange(40.0, 90.0, 0.0, 100.0, 0.5, 1.0)
+        .thermowell(3.0, 2.0, 0.60).approvals(true, true, true, true, true).build();
     EngineeringCalculationResult<ValveInstrumentQualificationCalculation.Result> slowLoopResult = new ValveInstrumentQualificationCalculation()
         .calculate(slowLoop, productionContext());
     assertFalse(slowLoopResult.getValue().allConstraintsSatisfied());
@@ -119,9 +117,8 @@ class EngineeringTechnicalCompletionQualificationTest {
   @Test
   void calculatesFlareInterfacesAndFailsClosedWithoutMethodApproval() {
     FlareConsequenceCalculation.Input input = FlareConsequenceCalculation.Input.builder("flare-a")
-        .radiation(100.0, 0.20, 0.90, 1.0, 100.0, 2.5)
-        .dispersion(10.0, 5.0, 0.10, 0.05, 0.01, 150.0).noise(140.0, 0.005, 100.0)
-        .flareTip(100.0, 350.0, 0.50).build();
+        .radiation(100.0, 0.20, 0.90, 1.0, 100.0, 2.5).dispersion(10.0, 5.0, 0.10, 0.05, 0.01, 150.0)
+        .noise(140.0, 0.005, 100.0).flareTip(100.0, 350.0, 0.50).build();
     FlareConsequenceCalculation calculation = new FlareConsequenceCalculation();
     EngineeringCalculationResult<FlareConsequenceCalculation.Result> result = calculation.calculate(input,
         productionContext());
@@ -132,7 +129,8 @@ class EngineeringTechnicalCompletionQualificationTest {
     EngineeringCalculationContext missingApproval = EngineeringCalculationContext.builder().designCaseId("fire")
         .attribute("productionQualification", "true").addStandardReference("PROJECT-FLARE-BASIS")
         .addEvidenceReference("FLARE-CALC-A").build();
-    assertEquals(EngineeringCalculationResult.Status.BLOCKED, calculation.calculate(input, missingApproval).getStatus());
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED,
+        calculation.calculate(input, missingApproval).getStatus());
   }
 
   @Test
@@ -154,8 +152,8 @@ class EngineeringTechnicalCompletionQualificationTest {
     assertTrue(result.getFailedGates().contains("CLOSED_ENGINEERING_DESIGN_LOOP"));
 
     EngineeringGraph graph = EngineeringGraphBuilder.fromProject(project);
-    EngineeringNode transientNode = graph.getNode(EngineeringIds.nodeId(EngineeringNode.Kind.CALCULATION,
-        "transient-piping:export-network"));
+    EngineeringNode transientNode = graph
+        .getNode(EngineeringIds.nodeId(EngineeringNode.Kind.CALCULATION, "transient-piping:export-network"));
     assertTrue(transientNode != null);
     assertEquals(Double.valueOf(1.0), transientNode.getProperties().get("resultValue"));
     assertEquals(5, basis.getTechnicalQualificationCalculations(
@@ -166,42 +164,40 @@ class EngineeringTechnicalCompletionQualificationTest {
     EngineeringCalculationContext context = productionContext();
     CompressorProtectionQualificationCalculation.Input compressor = CompressorProtectionQualificationCalculation.Input
         .builder("K-100", "CompressorAntiSurgeApplication", "1.0")
-        .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("normal", 130.0, 100.0,
-            220.0, 115.0, 4200.0, 0.0))
-        .mapLimits(0.10, 0.10, 160.0, 0.02).driverAndStartup(5000.0, 1000.0, 1250.0)
-        .rundown(0.12, 0.10).antiSurgeResponse(0.2, 0.3, 0.2, 1.0, 100.0, 90.0, 3.0)
-        .rotorDynamics(20.0, 15.0, true).settleOut(60.0, 70.0).vendorGuaranteeAccepted(true).build();
+        .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("normal", 130.0, 100.0, 220.0,
+            115.0, 4200.0, 0.0))
+        .mapLimits(0.10, 0.10, 160.0, 0.02).driverAndStartup(5000.0, 1000.0, 1250.0).rundown(0.12, 0.10)
+        .antiSurgeResponse(0.2, 0.3, 0.2, 1.0, 100.0, 90.0, 3.0).rotorDynamics(20.0, 15.0, true).settleOut(60.0, 70.0)
+        .vendorGuaranteeAccepted(true).build();
     ValveInstrumentQualificationCalculation.Input loop = ValveInstrumentQualificationCalculation.Input
-        .builder("SIF-100", "ESDV-100", "PIT-100").actuator(10000.0, 15000.0, 80.0, 100.0)
-        .leakage(0.001, 0.005).responseBudget(2.0, 0.5, 0.2, 5.0)
-        .transmitterRange(40.0, 90.0, 0.0, 100.0, 0.5, 1.0).thermowell(3.0, 2.0, 0.60)
-        .approvals(true, true, true, true, true).build();
+        .builder("SIF-100", "ESDV-100", "PIT-100").actuator(10000.0, 15000.0, 80.0, 100.0).leakage(0.001, 0.005)
+        .responseBudget(2.0, 0.5, 0.2, 5.0).transmitterRange(40.0, 90.0, 0.0, 100.0, 0.5, 1.0)
+        .thermowell(3.0, 2.0, 0.60).approvals(true, true, true, true, true).build();
     MechanicalIntegrityQualificationCalculation.Input mechanical = MechanicalIntegrityQualificationCalculation.Input
         .builder("V-100", "SeparatorMechanicalDesign", "1.0").internalPressure(90.0, 105.0, 18.0, 22.0)
         .externalPressureAndBuckling(1.0, 2.5, 0.65).fatigueAndExternalLoads(0.40, 0.70)
         .nozzleReinforcement(1200.0, 1600.0).temperatureAndCorrosion(-40.0, -46.0, 3.0, 3.0)
         .approvals(true, true, true, true).build();
     FlareConsequenceCalculation.Input flare = FlareConsequenceCalculation.Input.builder("flare-a")
-        .radiation(100.0, 0.20, 0.90, 1.0, 100.0, 2.5)
-        .dispersion(10.0, 5.0, 0.10, 0.05, 0.01, 150.0).noise(140.0, 0.005, 100.0)
-        .flareTip(100.0, 350.0, 0.50).build();
+        .radiation(100.0, 0.20, 0.90, 1.0, 100.0, 2.5).dispersion(10.0, 5.0, 0.10, 0.05, 0.01, 150.0)
+        .noise(140.0, 0.005, 100.0).flareTip(100.0, 350.0, 0.50).build();
     return new EngineeringProductionReadinessBasis()
-        .transientPipingQualification(new TransientPipingQualificationCalculation().calculate(transientInput(0.5),
-            context))
-        .compressorProtectionQualification(new CompressorProtectionQualificationCalculation().calculate(compressor,
-            context))
+        .transientPipingQualification(
+            new TransientPipingQualificationCalculation().calculate(transientInput(0.5), context))
+        .compressorProtectionQualification(
+            new CompressorProtectionQualificationCalculation().calculate(compressor, context))
         .valveInstrumentQualification(new ValveInstrumentQualificationCalculation().calculate(loop, context))
-        .mechanicalIntegrityQualification(new MechanicalIntegrityQualificationCalculation().calculate(mechanical,
-            context))
+        .mechanicalIntegrityQualification(
+            new MechanicalIntegrityQualificationCalculation().calculate(mechanical, context))
         .flareConsequenceQualification(new FlareConsequenceCalculation().calculate(flare, context));
   }
 
   private TransientPipingQualificationCalculation.Input transientInput(double timeStepSeconds) {
     return TransientPipingQualificationCalculation.Input.builder("export-network", "TwoFluidPipe", "1.0")
-        .geometry(1000.0, 10.0, 400.0).resolutionAndBalanceLimits(0.25, 0.01)
-        .pressureLimits(50.0, 100.0, 10.0).responseLimits(1.0, 0.20, 150.0)
-        .addSample(new TransientPipingQualificationCalculation.Sample(0.0, 10.0, 9.0, 1000.0, 70.0, 72.0, 0.05,
-            20.0, 80.0))
+        .geometry(1000.0, 10.0, 400.0).resolutionAndBalanceLimits(0.25, 0.01).pressureLimits(50.0, 100.0, 10.0)
+        .responseLimits(1.0, 0.20, 150.0)
+        .addSample(
+            new TransientPipingQualificationCalculation.Sample(0.0, 10.0, 9.0, 1000.0, 70.0, 72.0, 0.05, 20.0, 80.0))
         .addSample(new TransientPipingQualificationCalculation.Sample(timeStepSeconds, 10.0, 9.0,
             1000.0 + timeStepSeconds, 69.0, 73.0, 0.05, 20.0, 85.0))
         .build();
@@ -210,10 +206,8 @@ class EngineeringTechnicalCompletionQualificationTest {
   private EngineeringCalculationContext productionContext() {
     return EngineeringCalculationContext.builder().designCaseId("production-qualification")
         .simulationFingerprint("synthetic-regression-a").attribute("productionQualification", "true")
-        .attribute("distributedTransientModel", "approved")
-        .attribute("consequenceMethodApplicability", "approved")
-        .addStandardReference("PROJECT-ENGINEERING-BASIS-A")
-        .addEvidenceReference("INDEPENDENT-CALCULATION-A")
+        .attribute("distributedTransientModel", "approved").attribute("consequenceMethodApplicability", "approved")
+        .addStandardReference("PROJECT-ENGINEERING-BASIS-A").addEvidenceReference("INDEPENDENT-CALCULATION-A")
         .addEvidenceReference("VENDOR-OR-HAZOP-EVIDENCE-A").build();
   }
 }

--- a/src/test/java/neqsim/process/engineering/EngineeringTechnicalCompletionQualificationTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringTechnicalCompletionQualificationTest.java
@@ -1,0 +1,219 @@
+package neqsim.process.engineering;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import neqsim.process.engineering.calculation.EngineeringCalculationContext;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+import neqsim.process.engineering.instrumentation.ValveInstrumentQualificationCalculation;
+import neqsim.process.engineering.mechanical.MechanicalIntegrityQualificationCalculation;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringGraphBuilder;
+import neqsim.process.engineering.model.EngineeringIds;
+import neqsim.process.engineering.model.EngineeringNode;
+import neqsim.process.engineering.piping.TransientPipingQualificationCalculation;
+import neqsim.process.engineering.production.EngineeringProductionReadinessAssessment;
+import neqsim.process.engineering.production.EngineeringProductionReadinessBasis;
+import neqsim.process.engineering.rotating.CompressorProtectionQualificationCalculation;
+import neqsim.process.engineering.safety.FlareConsequenceCalculation;
+import neqsim.process.processmodel.ProcessSystem;
+import org.junit.jupiter.api.Test;
+
+/** Tests the technical production-completion calculations and readiness gates. */
+class EngineeringTechnicalCompletionQualificationTest {
+
+  @Test
+  void qualifiesDistributedTransientAndDetectsUnresolvedTimeScale() {
+    EngineeringCalculationContext context = productionContext();
+    TransientPipingQualificationCalculation calculation = new TransientPipingQualificationCalculation();
+    EngineeringCalculationResult<TransientPipingQualificationCalculation.Result> passing = calculation
+        .calculate(transientInput(0.5), context);
+
+    assertEquals(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED, passing.getStatus());
+    assertTrue(passing.getValue().allConstraintsSatisfied());
+    assertTrue(passing.getValue().toMap().toString().contains("LINE_PACK_MASS_BALANCE"));
+
+    EngineeringCalculationResult<TransientPipingQualificationCalculation.Result> underResolved = calculation
+        .calculate(transientInput(2.0), context);
+    assertFalse(underResolved.getValue().allConstraintsSatisfied());
+    assertTrue(underResolved.getValue().toMap().toString().contains("TRANSIENT_TIME_RESOLUTION=false"));
+
+    EngineeringCalculationContext missingDistributedModelApproval = EngineeringCalculationContext.builder()
+        .attribute("productionQualification", "true").addStandardReference("PROJECT-PIPING-BASIS")
+        .addEvidenceReference("TRANSIENT-RESULT-A").build();
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED,
+        calculation.calculate(transientInput(0.5), missingDistributedModelApproval).getStatus());
+  }
+
+  @Test
+  void qualifiesCompressorProtectionAcrossSteadyAndTransientEvidence() {
+    CompressorProtectionQualificationCalculation.Input input = CompressorProtectionQualificationCalculation.Input
+        .builder("K-100", "CompressorAntiSurgeApplication", "1.0")
+        .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("normal", 130.0, 100.0,
+            220.0, 115.0, 4200.0, 0.0))
+        .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("turndown", 115.0, 100.0,
+            200.0, 120.0, 3900.0, 0.01))
+        .mapLimits(0.10, 0.10, 160.0, 0.02).driverAndStartup(5000.0, 1000.0, 1250.0)
+        .rundown(0.12, 0.10).antiSurgeResponse(0.2, 0.3, 0.2, 1.0, 100.0, 90.0, 3.0)
+        .rotorDynamics(20.0, 15.0, true).settleOut(60.0, 70.0).vendorGuaranteeAccepted(true).build();
+
+    EngineeringCalculationResult<CompressorProtectionQualificationCalculation.Result> result = new CompressorProtectionQualificationCalculation()
+        .calculate(input, productionContext());
+
+    assertTrue(result.getValue().allConstraintsSatisfied());
+    assertTrue(result.getValue().toMap().toString().contains("STARTUP_TORQUE=true"));
+    assertTrue(result.getValue().toMap().toString().contains("ROTOR_DYNAMIC_REVIEW_APPROVED=true"));
+
+    CompressorProtectionQualificationCalculation.Input slowProtection = CompressorProtectionQualificationCalculation.Input
+        .builder("K-100", "CompressorAntiSurgeApplication", "1.0")
+        .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("normal", 130.0, 100.0,
+            220.0, 115.0, 4200.0, 0.0))
+        .mapLimits(0.10, 0.10, 160.0, 0.02).driverAndStartup(5000.0, 1000.0, 1250.0)
+        .rundown(0.12, 0.10).antiSurgeResponse(0.5, 0.5, 0.5, 3.0, 100.0, 90.0, 3.0)
+        .rotorDynamics(20.0, 15.0, true).settleOut(60.0, 70.0).vendorGuaranteeAccepted(true).build();
+    EngineeringCalculationResult<CompressorProtectionQualificationCalculation.Result> slowResult = new CompressorProtectionQualificationCalculation()
+        .calculate(slowProtection, productionContext());
+    assertFalse(slowResult.getValue().allConstraintsSatisfied());
+    assertTrue(slowResult.getValue().toMap().toString().contains("ANTI_SURGE_RESPONSE_TIME=false"));
+  }
+
+  @Test
+  void qualifiesValveInstrumentAndMechanicalFailureModesIndependently() {
+    ValveInstrumentQualificationCalculation.Input loop = ValveInstrumentQualificationCalculation.Input
+        .builder("SIF-100", "ESDV-100", "PIT-100").actuator(10000.0, 15000.0, 80.0, 100.0)
+        .leakage(0.001, 0.005).responseBudget(2.0, 0.5, 0.2, 5.0)
+        .transmitterRange(40.0, 90.0, 0.0, 100.0, 0.5, 1.0).thermowell(3.0, 2.0, 0.60)
+        .approvals(true, true, true, true, true).build();
+    EngineeringCalculationResult<ValveInstrumentQualificationCalculation.Result> loopResult = new ValveInstrumentQualificationCalculation()
+        .calculate(loop, productionContext());
+    assertTrue(loopResult.getValue().allConstraintsSatisfied());
+
+    ValveInstrumentQualificationCalculation.Input slowLoop = ValveInstrumentQualificationCalculation.Input
+        .builder("SIF-100", "ESDV-100", "PIT-100").actuator(10000.0, 15000.0, 80.0, 100.0)
+        .leakage(0.001, 0.005).responseBudget(4.0, 1.0, 1.0, 5.0)
+        .transmitterRange(40.0, 90.0, 0.0, 100.0, 0.5, 1.0).thermowell(3.0, 2.0, 0.60)
+        .approvals(true, true, true, true, true).build();
+    EngineeringCalculationResult<ValveInstrumentQualificationCalculation.Result> slowLoopResult = new ValveInstrumentQualificationCalculation()
+        .calculate(slowLoop, productionContext());
+    assertFalse(slowLoopResult.getValue().allConstraintsSatisfied());
+    assertTrue(slowLoopResult.getValue().toMap().toString().contains("PROCESS_SAFETY_TIME=false"));
+
+    MechanicalIntegrityQualificationCalculation.Input pressureBoundary = MechanicalIntegrityQualificationCalculation.Input
+        .builder("V-100", "SeparatorMechanicalDesign", "1.0").internalPressure(90.0, 105.0, 18.0, 22.0)
+        .externalPressureAndBuckling(1.0, 2.5, 0.65).fatigueAndExternalLoads(0.40, 0.70)
+        .nozzleReinforcement(1200.0, 1600.0).temperatureAndCorrosion(-40.0, -46.0, 3.0, 3.0)
+        .approvals(true, true, true, true).build();
+    EngineeringCalculationResult<MechanicalIntegrityQualificationCalculation.Result> mechanicalResult = new MechanicalIntegrityQualificationCalculation()
+        .calculate(pressureBoundary, productionContext());
+    assertTrue(mechanicalResult.getValue().allConstraintsSatisfied());
+
+    MechanicalIntegrityQualificationCalculation.Input failedFatigue = MechanicalIntegrityQualificationCalculation.Input
+        .builder("V-100", "SeparatorMechanicalDesign", "1.0").internalPressure(90.0, 105.0, 18.0, 22.0)
+        .externalPressureAndBuckling(1.0, 2.5, 0.65).fatigueAndExternalLoads(1.20, 0.70)
+        .nozzleReinforcement(1200.0, 1600.0).temperatureAndCorrosion(-40.0, -46.0, 3.0, 3.0)
+        .approvals(true, true, true, true).build();
+    assertFalse(new MechanicalIntegrityQualificationCalculation().calculate(failedFatigue, productionContext())
+        .getValue().allConstraintsSatisfied());
+  }
+
+  @Test
+  void calculatesFlareInterfacesAndFailsClosedWithoutMethodApproval() {
+    FlareConsequenceCalculation.Input input = FlareConsequenceCalculation.Input.builder("flare-a")
+        .radiation(100.0, 0.20, 0.90, 1.0, 100.0, 2.5)
+        .dispersion(10.0, 5.0, 0.10, 0.05, 0.01, 150.0).noise(140.0, 0.005, 100.0)
+        .flareTip(100.0, 350.0, 0.50).build();
+    FlareConsequenceCalculation calculation = new FlareConsequenceCalculation();
+    EngineeringCalculationResult<FlareConsequenceCalculation.Result> result = calculation.calculate(input,
+        productionContext());
+
+    assertTrue(result.getValue().allConstraintsSatisfied());
+    assertTrue(result.getValue().toMap().toString().contains("THERMAL_RADIATION=true"));
+
+    EngineeringCalculationContext missingApproval = EngineeringCalculationContext.builder().designCaseId("fire")
+        .attribute("productionQualification", "true").addStandardReference("PROJECT-FLARE-BASIS")
+        .addEvidenceReference("FLARE-CALC-A").build();
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED, calculation.calculate(input, missingApproval).getStatus());
+  }
+
+  @Test
+  void technicalCalculationsBecomeIndependentProductionReadinessGates() {
+    EngineeringProductionReadinessBasis basis = passingTechnicalBasis();
+    EngineeringProject project = new EngineeringProject("technical-completion", new ProcessSystem(),
+        new EngineeringDesignBasis());
+    project.setProductionReadinessBasis(basis);
+
+    EngineeringProductionReadinessAssessment.Result result = EngineeringProductionReadinessAssessment.assess(project,
+        basis);
+
+    assertFalse(result.getFailedGates().contains("DISTRIBUTED_TRANSIENT_PIPING"));
+    assertFalse(result.getFailedGates().contains("COMPRESSOR_PROTECTION_AND_MACHINERY"));
+    assertFalse(result.getFailedGates().contains("VALVE_AND_INSTRUMENT_QUALIFICATION"));
+    assertFalse(result.getFailedGates().contains("DETAILED_MECHANICAL_INTEGRITY"));
+    assertFalse(result.getFailedGates().contains("FLARE_RADIATION_DISPERSION_AND_NOISE"));
+    assertEquals(5, basis.getTechnicalMethodKeys().size());
+    assertTrue(result.getFailedGates().contains("CLOSED_ENGINEERING_DESIGN_LOOP"));
+
+    EngineeringGraph graph = EngineeringGraphBuilder.fromProject(project);
+    EngineeringNode transientNode = graph.getNode(EngineeringIds.nodeId(EngineeringNode.Kind.CALCULATION,
+        "transient-piping:export-network"));
+    assertTrue(transientNode != null);
+    assertEquals(Double.valueOf(1.0), transientNode.getProperties().get("resultValue"));
+    assertEquals(5, basis.getTechnicalQualificationCalculations(
+        EngineeringIds.nodeId(EngineeringNode.Kind.PROJECT, project.getProjectId())).size());
+  }
+
+  private EngineeringProductionReadinessBasis passingTechnicalBasis() {
+    EngineeringCalculationContext context = productionContext();
+    CompressorProtectionQualificationCalculation.Input compressor = CompressorProtectionQualificationCalculation.Input
+        .builder("K-100", "CompressorAntiSurgeApplication", "1.0")
+        .addOperatingCase(new CompressorProtectionQualificationCalculation.OperatingCase("normal", 130.0, 100.0,
+            220.0, 115.0, 4200.0, 0.0))
+        .mapLimits(0.10, 0.10, 160.0, 0.02).driverAndStartup(5000.0, 1000.0, 1250.0)
+        .rundown(0.12, 0.10).antiSurgeResponse(0.2, 0.3, 0.2, 1.0, 100.0, 90.0, 3.0)
+        .rotorDynamics(20.0, 15.0, true).settleOut(60.0, 70.0).vendorGuaranteeAccepted(true).build();
+    ValveInstrumentQualificationCalculation.Input loop = ValveInstrumentQualificationCalculation.Input
+        .builder("SIF-100", "ESDV-100", "PIT-100").actuator(10000.0, 15000.0, 80.0, 100.0)
+        .leakage(0.001, 0.005).responseBudget(2.0, 0.5, 0.2, 5.0)
+        .transmitterRange(40.0, 90.0, 0.0, 100.0, 0.5, 1.0).thermowell(3.0, 2.0, 0.60)
+        .approvals(true, true, true, true, true).build();
+    MechanicalIntegrityQualificationCalculation.Input mechanical = MechanicalIntegrityQualificationCalculation.Input
+        .builder("V-100", "SeparatorMechanicalDesign", "1.0").internalPressure(90.0, 105.0, 18.0, 22.0)
+        .externalPressureAndBuckling(1.0, 2.5, 0.65).fatigueAndExternalLoads(0.40, 0.70)
+        .nozzleReinforcement(1200.0, 1600.0).temperatureAndCorrosion(-40.0, -46.0, 3.0, 3.0)
+        .approvals(true, true, true, true).build();
+    FlareConsequenceCalculation.Input flare = FlareConsequenceCalculation.Input.builder("flare-a")
+        .radiation(100.0, 0.20, 0.90, 1.0, 100.0, 2.5)
+        .dispersion(10.0, 5.0, 0.10, 0.05, 0.01, 150.0).noise(140.0, 0.005, 100.0)
+        .flareTip(100.0, 350.0, 0.50).build();
+    return new EngineeringProductionReadinessBasis()
+        .transientPipingQualification(new TransientPipingQualificationCalculation().calculate(transientInput(0.5),
+            context))
+        .compressorProtectionQualification(new CompressorProtectionQualificationCalculation().calculate(compressor,
+            context))
+        .valveInstrumentQualification(new ValveInstrumentQualificationCalculation().calculate(loop, context))
+        .mechanicalIntegrityQualification(new MechanicalIntegrityQualificationCalculation().calculate(mechanical,
+            context))
+        .flareConsequenceQualification(new FlareConsequenceCalculation().calculate(flare, context));
+  }
+
+  private TransientPipingQualificationCalculation.Input transientInput(double timeStepSeconds) {
+    return TransientPipingQualificationCalculation.Input.builder("export-network", "TwoFluidPipe", "1.0")
+        .geometry(1000.0, 10.0, 400.0).resolutionAndBalanceLimits(0.25, 0.01)
+        .pressureLimits(50.0, 100.0, 10.0).responseLimits(1.0, 0.20, 150.0)
+        .addSample(new TransientPipingQualificationCalculation.Sample(0.0, 10.0, 9.0, 1000.0, 70.0, 72.0, 0.05,
+            20.0, 80.0))
+        .addSample(new TransientPipingQualificationCalculation.Sample(timeStepSeconds, 10.0, 9.0,
+            1000.0 + timeStepSeconds, 69.0, 73.0, 0.05, 20.0, 85.0))
+        .build();
+  }
+
+  private EngineeringCalculationContext productionContext() {
+    return EngineeringCalculationContext.builder().designCaseId("production-qualification")
+        .simulationFingerprint("synthetic-regression-a").attribute("productionQualification", "true")
+        .attribute("distributedTransientModel", "approved")
+        .attribute("consequenceMethodApplicability", "approved")
+        .addStandardReference("PROJECT-ENGINEERING-BASIS-A")
+        .addEvidenceReference("INDEPENDENT-CALCULATION-A")
+        .addEvidenceReference("VENDOR-OR-HAZOP-EVIDENCE-A").build();
+  }
+}


### PR DESCRIPTION
## Summary

Completes the remaining in-repository technical production-qualification gaps identified in #2451.

- adds distributed piping-transient qualification with acoustic resolution, line-pack balance, pressure, slug, velocity and stress constraints
- adds compressor protection and machinery qualification covering map margins, driver/startup/rundown, anti-surge response, rotor dynamics, settle-out and vendor evidence
- adds valve/instrument response and installation qualification
- adds detailed mechanical-integrity qualification
- adds flare radiation, dispersion, noise and tip-Mach screening with an explicit method-applicability gate
- integrates all five results into production readiness, exact-version benchmark/method qualification, the canonical graph/DAG and coordinated deliverables
- updates engineering documentation, agent guidance and capability/discipline skills

## Engineering boundary

This remains fail-closed. The implementation does not manufacture HAZOP/LOPA/SRS decisions, vendor guarantees, independent benchmark reviews, named CAE-tool validation, pilot acceptance, code authority or construction approval. Those remain explicit external evidence gates, and `fitnessForConstruction` remains false.

## Validation

- compiled all `neqsim.process.engineering` sources with Java `--release 8` compatibility checks
- executed the focused technical-completion regression suite successfully
- applied the repository's Eclipse 4.35 formatter with `.config/neqsim_formatter.xml`
- verified canonical graph integration and passing/failing constraint paths
- `git diff --check` passed
- full Maven, test and static-analysis verification runs in GitHub Actions

## Issue

Addresses the remaining implementable technical gaps in #2451; external qualification evidence must still be supplied by accountable project parties.