### PR TITLE
Add governed external engineering evidence

### DIFF
--- a/.github/agents/engineering.deliverables.agent.md
+++ b/.github/agents/engineering.deliverables.agent.md
@@ -112,6 +112,15 @@ independent readiness gates and their exact-version benchmark/method-qualificati
 Never reinterpret a passing numerical constraint as vendor, HAZOP, code, CAE-tool, pilot,
 or construction approval.
 
+For external assurance, create an `EngineeringExternalEvidenceRegister` from explicit
+project-, equipment-, loop- and package-scope requirements. Accept a receipt only through
+`EngineeringExternalEvidenceRecord` with a controlled document revision, SHA-256 content
+hash, issuer, scope, accountable decision identity/role/date and workflow reference. Require
+an independence statement for independent validation and a jurisdiction for construction
+authority evidence. Inspect `engineering-external-evidence-register.json`; draft, rejected,
+incomplete, conflicting and superseded records remain blockers. Never create an accepted
+receipt from a simulator result or agent assertion.
+
 ### 1. StudyClass Enum
 Controls which deliverables are produced:
 

--- a/.github/skills/neqsim-pid-process-operations/SKILL.md
+++ b/.github/skills/neqsim-pid-process-operations/SKILL.md
@@ -241,6 +241,15 @@ calculated DEXPI package is never equivalent to HAZOP/LOPA acceptance, vendor
 certification, code mechanical design, final metallurgy approval or
 construction authorization.
 
+Represent those external decisions with `EngineeringExternalEvidenceRegister`, starting from
+`productionMinimum(projectRevisionScope)` and adding equipment-, SIF- and package-specific
+requirements. `EngineeringExternalEvidenceRecord` must carry the controlled document revision,
+SHA-256 hash, issuer, governed scope, decision authority, decision date and workflow/signature
+reference. Independent validation additionally needs an independence statement; construction
+authority evidence needs the applicable jurisdiction. Inspect
+`engineering-external-evidence-register.json` and keep draft, rejected, incomplete, conflicting
+or superseded evidence open. The register verifies receipts; it never creates approval.
+
 Also inspect `engineering-production-readiness.json`. Do not describe a package
 as production-ready merely because the design loop converged or package
 validation passed. `QUALIFIED_FEED_SUPPORT` additionally requires independent

--- a/docs/integration/process-to-engineering-simulator.md
+++ b/docs/integration/process-to-engineering-simulator.md
@@ -427,6 +427,48 @@ gates, exact `method@version` entries in the benchmark and project-qualification
 in the engineering graph/DAG, and evidence in the relevant coordinated package reports. A numerically passing result
 retains `CALCULATED_REVIEW_REQUIRED` until its standards, evidence, vendor and accountable review records are valid.
 
+### Controlled external engineering evidence
+
+`EngineeringExternalEvidenceRegister` closes the interface to accountable organizations without turning NeqSim into
+an approval authority. `productionMinimum(projectScope)` creates explicit requirements for accountable engineering
+approval, vendor guarantees, HAZOP, LOPA, SRS, independent validation and construction-authority evidence. Add
+equipment-, loop- or package-specific requirements where project scope is more granular.
+
+Each `EngineeringExternalEvidenceRecord` identifies the controlled document and revision, immutable SHA-256 content
+hash, issuing organization and person, issue date, governed scope, decision status, decision maker, accountable role,
+decision date and workflow/signature reference. Independent validation also requires an independence statement;
+construction evidence requires the governing jurisdiction. Draft, rejected, incomplete, conflicting or superseded
+records fail closed.
+
+```java
+String projectScope = "project:compression-rev-C";
+EngineeringExternalEvidenceRegister external =
+    EngineeringExternalEvidenceRegister.productionMinimum(projectScope)
+        .addRequirement(new EngineeringExternalEvidenceRequirement(
+            "VENDOR-K-100", EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE,
+            "equipment:K-100", "Accepted compressor performance and mechanical guarantees"))
+        .addRecord(EngineeringExternalEvidenceRecord
+            .builder("EV-VENDOR-K-100-C", EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE,
+                "VDR-K-100", "C")
+            .title("K-100 certified guarantee package")
+            .controlledDocument("stid://VDR-K-100/C", controlledDocumentSha256)
+            .issuer("Compressor vendor", "Vendor package authority", "2026-07-18")
+            .addScopeReference(projectScope)
+            .addScopeReference("equipment:K-100")
+            .decision(EngineeringExternalEvidenceRecord.Status.ACCEPTED,
+                "Accountable machinery engineer", "Machinery Technical Authority",
+                "2026-07-18", "workflow://VDR-K-100/C/accepted")
+            .build());
+
+project.getProductionReadinessBasis().externalEvidenceRegister(external);
+```
+
+Supply equivalent accepted receipts for every declared requirement. Compilation writes
+`engineering-external-evidence-register.json`, embeds the assessment in production readiness, and creates an exact
+qualification backlog for missing or conflicting evidence. `constructionAuthorityEvidenceAccepted=true` means that
+the supplied external receipt passed structural and scope checks; `fitnessForConstruction` and
+`finalEngineeringApprovalGranted` remain false because the simulator never issues those decisions.
+
 See `examples/notebooks/engineering_production_qualification_workflow.ipynb` for benchmark, DEXPI, pilot, release and
 relief workflow examples. The notebook uses synthetic references only to demonstrate the API; replace every such value
 and reviewer string with controlled project evidence before assessing readiness.
@@ -440,8 +482,9 @@ execution blockers, dependency fingerprints, revision invalidation and the multi
 
 ## Required engineering review
 
-The simulator produces calculated or proposed engineering suitable for concept and pre-FEED development. It does not
-replace accountable discipline work for:
+The simulator produces calculated or proposed engineering suitable for concept and pre-FEED development. It can
+verify controlled receipts for the following decisions, but it does not replace the accountable parties that create
+or approve them:
 
 - HAZOP/LOPA scenario credibility, SIL selection or SRS approval;
 - vendor compressor, pump, exchanger, valve or instrument guarantees;

--- a/src/main/java/neqsim/process/engineering/EngineeringProject.java
+++ b/src/main/java/neqsim/process/engineering/EngineeringProject.java
@@ -787,6 +787,9 @@ public final class EngineeringProject implements Serializable {
       calculationNodes.add(gson.toJsonTree(calculation.toMap()));
     }
     root.add("calculationProvenance", calculationNodes);
+    if (productionReadinessBasis != null) {
+      root.add("productionReadinessBasis", gson.toJsonTree(productionReadinessBasis.toMap()));
+    }
     root.add("validation", gson.toJsonTree(validate().getFindings()));
     return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create().toJson(root);
   }

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringCoordinatedPackage.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringCoordinatedPackage.java
@@ -18,6 +18,9 @@ import neqsim.process.engineering.model.EngineeringGraphDiff;
 import neqsim.process.engineering.model.EngineeringNode;
 import neqsim.process.engineering.production.EngineeringProductionReadinessAssessment;
 import neqsim.process.engineering.production.EngineeringProductionReadinessBasis;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceAssessment;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceRegister;
+import neqsim.process.engineering.validation.EngineeringSchemaCatalog;
 
 /** Builds coordinated, traceable engineering documents from the canonical project and graph. */
 final class EngineeringCoordinatedPackage {
@@ -37,6 +40,7 @@ final class EngineeringCoordinatedPackage {
     documents.put("flare-blowdown-report.json", flareBlowdownReport(project));
     documents.put("utility-summary.json", utilitySummary(project, envelope));
     documents.put("materials-selection-report.json", materialsReport(project));
+    documents.put("engineering-external-evidence-register.json", externalEvidenceRegister(project));
     documents.put("unresolved-engineering-actions.json", unresolvedActions(project));
     documents.put("revision-impact-report.json", revisionImpact(project, diff));
     return documents;
@@ -243,6 +247,20 @@ final class EngineeringCoordinatedPackage {
             : basis.getMechanicalIntegrityQualification().toMap());
     result.put("standard", "NORSOK M-001:2025");
     result.put("finalMetallurgyApproved", Boolean.FALSE);
+    return result;
+  }
+
+  private static Map<String, Object> externalEvidenceRegister(EngineeringProject project) {
+    Map<String, Object> result = header(project, EngineeringSchemaCatalog.EXTERNAL_EVIDENCE_REGISTER);
+    result.put("schemaUri", EngineeringSchemaCatalog.schemaUri(EngineeringSchemaCatalog.EXTERNAL_EVIDENCE_REGISTER));
+    EngineeringProductionReadinessBasis basis = project.getProductionReadinessBasis();
+    EngineeringExternalEvidenceRegister register = basis == null ? null : basis.getExternalEvidenceRegister();
+    result.put("register", register == null ? null : register.toMap());
+    result.put("assessment", EngineeringExternalEvidenceAssessment.assess(register).toMap());
+    result.put("evidenceGeneratedBySimulator", Boolean.FALSE);
+    result.put("approvalGrantedBySimulator", Boolean.FALSE);
+    result.put("governance",
+        "Records are controlled receipts from accountable external parties; NeqSim only verifies completeness");
     return result;
   }
 

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
@@ -47,9 +47,9 @@ public final class EngineeringDeliverableCompiler {
   private static final String[] COORDINATED_ARTIFACTS = new String[] { "process-design-basis.json",
       "equipment-datasheets.json", "valve-list.json", "io-list.json", "alarm-trip-schedule.json",
       "shutdown-narratives.json", "psv-datasheets.json", "flare-blowdown-report.json", "utility-summary.json",
-      "materials-selection-report.json", "unresolved-engineering-actions.json", "revision-impact-report.json",
-      "engineering-production-readiness.json", "engineering-qualification-plan.json",
-      "engineering-vertical-slice-execution-manifest.json" };
+      "materials-selection-report.json", "engineering-external-evidence-register.json",
+      "unresolved-engineering-actions.json", "revision-impact-report.json", "engineering-production-readiness.json",
+      "engineering-qualification-plan.json", "engineering-vertical-slice-execution-manifest.json" };
 
   private EngineeringDeliverableCompiler() {
   }

--- a/src/main/java/neqsim/process/engineering/instrumentation/ValveInstrumentQualificationCalculation.java
+++ b/src/main/java/neqsim/process/engineering/instrumentation/ValveInstrumentQualificationCalculation.java
@@ -256,9 +256,7 @@ public final class ValveInstrumentQualificationCalculation implements
       return output.status(EngineeringCalculationResult.Status.BLOCKED).build();
     }
     if (input == null) {
-      return output.status(EngineeringCalculationResult.Status.BLOCKED)
-          .warning("Calculation input is missing")
-          .build();
+      return output.status(EngineeringCalculationResult.Status.BLOCKED).warning("Calculation input is missing").build();
     }
     double totalResponseSeconds = input.valveStrokeSeconds + input.instrumentResponseSeconds
         + input.logicSolverResponseSeconds;

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphBuilder.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphBuilder.java
@@ -12,6 +12,8 @@ import neqsim.process.engineering.EngineeringRequirement;
 import neqsim.process.engineering.LineDesignInput;
 import neqsim.process.engineering.designcase.EngineeringDesignCase;
 import neqsim.process.engineering.designcase.EngineeringMetric;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceRecord;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceRegister;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
@@ -77,7 +79,36 @@ public final class EngineeringGraphBuilder {
     }
     addCalculations(allCalculations, graph, projectNodeId);
     addApprovals(project, graph, projectNodeId);
+    addExternalEvidence(project, graph, projectNodeId);
     return graph;
+  }
+
+  private static void addExternalEvidence(EngineeringProject project, EngineeringGraph graph, String projectNodeId) {
+    if (project.getProductionReadinessBasis() == null
+        || project.getProductionReadinessBasis().getExternalEvidenceRegister() == null) {
+      return;
+    }
+    EngineeringExternalEvidenceRegister register = project.getProductionReadinessBasis().getExternalEvidenceRegister();
+    for (EngineeringExternalEvidenceRecord evidence : register.getRecords()) {
+      String nodeId = EngineeringIds.nodeId(EngineeringNode.Kind.DOCUMENT, evidence.getId());
+      EngineeringNode node = new EngineeringNode(nodeId, EngineeringNode.Kind.DOCUMENT, evidence.getId(),
+          evidence.getType().name() + " " + evidence.getDocumentId() + "@" + evidence.getRevision())
+          .putProperty("externalEngineeringEvidence", Boolean.TRUE).putProperty("evidence", evidence.toMap())
+          .addProvenance(
+              new EngineeringProvenance("EXTERNAL_EVIDENCE", evidence.getDocumentId() + "@" + evidence.getRevision())
+                  .setApprovalStatus(evidence.getStatus().name()));
+      graph.addNode(node);
+      addEdge(graph, EngineeringEdge.Kind.CONTAINS, projectNodeId, nodeId, "externalEvidenceReceipt");
+    }
+    for (EngineeringExternalEvidenceRecord evidence : register.getRecords()) {
+      if (!evidence.getSupersedesRecordId().isEmpty()) {
+        String nodeId = EngineeringIds.nodeId(EngineeringNode.Kind.DOCUMENT, evidence.getId());
+        String previousId = EngineeringIds.nodeId(EngineeringNode.Kind.DOCUMENT, evidence.getSupersedesRecordId());
+        if (graph.getNode(previousId) != null) {
+          addEdge(graph, EngineeringEdge.Kind.SUPERSEDES, nodeId, previousId, "externalEvidenceRevision");
+        }
+      }
+    }
   }
 
   private static void addApprovals(EngineeringProject project, EngineeringGraph graph, String projectNodeId) {

--- a/src/main/java/neqsim/process/engineering/production/EngineeringExternalEvidenceAssessment.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringExternalEvidenceAssessment.java
@@ -1,0 +1,186 @@
+package neqsim.process.engineering.production;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Deterministically verifies external evidence coverage without creating or approving evidence. */
+public final class EngineeringExternalEvidenceAssessment {
+  private EngineeringExternalEvidenceAssessment() {
+  }
+
+  public static Result assess(EngineeringExternalEvidenceRegister register) {
+    List<EngineeringExternalEvidenceRequirement> requirements = register == null
+        ? new ArrayList<EngineeringExternalEvidenceRequirement>()
+        : register.getRequirements();
+    List<EngineeringExternalEvidenceRecord> records = register == null
+        ? new ArrayList<EngineeringExternalEvidenceRecord>()
+        : register.getRecords();
+    List<Map<String, Object>> findings = new ArrayList<Map<String, Object>>();
+    Map<String, EngineeringExternalEvidenceRecord> recordsById = new LinkedHashMap<String, EngineeringExternalEvidenceRecord>();
+    Set<String> supersededIds = new LinkedHashSet<String>();
+    for (EngineeringExternalEvidenceRecord record : records) {
+      recordsById.put(record.getId(), record);
+      if (!record.getSupersedesRecordId().isEmpty()) {
+        supersededIds.add(record.getSupersedesRecordId());
+      }
+      if (record.getStatus() == EngineeringExternalEvidenceRecord.Status.ACCEPTED
+          && !record.getMissingFields().isEmpty()) {
+        findings.add(finding("INCOMPLETE_ACCEPTED_RECORD", record.getType(), record.getId(),
+            "Accepted evidence is incomplete: " + record.getMissingFields()));
+      }
+    }
+    validateSupersession(records, recordsById, findings);
+
+    Map<EngineeringExternalEvidenceRecord.Type, List<EngineeringExternalEvidenceRequirement>> requirementsByType = new EnumMap<EngineeringExternalEvidenceRecord.Type, List<EngineeringExternalEvidenceRequirement>>(
+        EngineeringExternalEvidenceRecord.Type.class);
+    for (EngineeringExternalEvidenceRecord.Type type : EngineeringExternalEvidenceRecord.Type.values()) {
+      requirementsByType.put(type, new ArrayList<EngineeringExternalEvidenceRequirement>());
+    }
+    for (EngineeringExternalEvidenceRequirement requirement : requirements) {
+      requirementsByType.get(requirement.getType()).add(requirement);
+    }
+
+    Map<EngineeringExternalEvidenceRecord.Type, Boolean> coverage = new EnumMap<EngineeringExternalEvidenceRecord.Type, Boolean>(
+        EngineeringExternalEvidenceRecord.Type.class);
+    Map<String, List<String>> matchedRecords = new LinkedHashMap<String, List<String>>();
+    for (EngineeringExternalEvidenceRecord.Type type : EngineeringExternalEvidenceRecord.Type.values()) {
+      List<EngineeringExternalEvidenceRequirement> typedRequirements = requirementsByType.get(type);
+      boolean typePassed = !typedRequirements.isEmpty();
+      if (typedRequirements.isEmpty()) {
+        findings.add(finding("MISSING_REQUIREMENT_DEFINITION", type, type.name(),
+            "Define the project scope that requires this external evidence class"));
+      }
+      for (EngineeringExternalEvidenceRequirement requirement : typedRequirements) {
+        List<String> accepted = new ArrayList<String>();
+        List<String> rejected = new ArrayList<String>();
+        for (EngineeringExternalEvidenceRecord record : records) {
+          if (supersededIds.contains(record.getId()) || record.getType() != type
+              || !record.getScopeReferences().contains(requirement.getScopeReference())) {
+            continue;
+          }
+          if (requirement.isSatisfiedBy(record)) {
+            accepted.add(record.getId());
+          } else if (record.getStatus() == EngineeringExternalEvidenceRecord.Status.REJECTED) {
+            rejected.add(record.getId());
+          }
+        }
+        matchedRecords.put(requirement.getId(), accepted);
+        if (accepted.isEmpty()) {
+          typePassed = false;
+          findings.add(finding("UNSATISFIED_REQUIREMENT", type, requirement.getId(),
+              "Attach a complete accepted external decision for scope " + requirement.getScopeReference()));
+        }
+        if (!accepted.isEmpty() && !rejected.isEmpty()) {
+          typePassed = false;
+          findings.add(finding("CONFLICTING_ACTIVE_DECISIONS", type, requirement.getId(),
+              "Resolve accepted " + accepted + " versus rejected " + rejected + " evidence revisions"));
+        }
+      }
+      coverage.put(type, Boolean.valueOf(typePassed));
+    }
+    for (Map<String, Object> finding : findings) {
+      EngineeringExternalEvidenceRecord.Type type = EngineeringExternalEvidenceRecord.Type
+          .valueOf(String.valueOf(finding.get("type")));
+      coverage.put(type, Boolean.FALSE);
+    }
+    return new Result(register, coverage, matchedRecords, findings);
+  }
+
+  private static void validateSupersession(List<EngineeringExternalEvidenceRecord> records,
+      Map<String, EngineeringExternalEvidenceRecord> recordsById, List<Map<String, Object>> findings) {
+    for (EngineeringExternalEvidenceRecord record : records) {
+      if (record.getSupersedesRecordId().isEmpty()) {
+        continue;
+      }
+      EngineeringExternalEvidenceRecord superseded = recordsById.get(record.getSupersedesRecordId());
+      if (superseded == null) {
+        findings.add(finding("UNKNOWN_SUPERSEDED_RECORD", record.getType(), record.getId(),
+            "Superseded record does not exist: " + record.getSupersedesRecordId()));
+      } else if (superseded.getType() != record.getType()) {
+        findings.add(finding("CROSS_TYPE_SUPERSESSION", record.getType(), record.getId(),
+            "Evidence may supersede only a record of the same type"));
+      }
+      Set<String> visited = new HashSet<String>();
+      EngineeringExternalEvidenceRecord cursor = record;
+      while (cursor != null && !cursor.getSupersedesRecordId().isEmpty()) {
+        if (!visited.add(cursor.getId())) {
+          findings.add(finding("SUPERSESSION_CYCLE", record.getType(), record.getId(),
+              "Evidence supersession chain contains a cycle"));
+          break;
+        }
+        cursor = recordsById.get(cursor.getSupersedesRecordId());
+      }
+    }
+  }
+
+  private static Map<String, Object> finding(String code, EngineeringExternalEvidenceRecord.Type type, String subject,
+      String action) {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("code", code);
+    result.put("type", type.name());
+    result.put("subject", subject);
+    result.put("requiredAction", action);
+    result.put("severity", "BLOCKER");
+    return result;
+  }
+
+  /** Immutable external assurance result with per-evidence-class coverage. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final EngineeringExternalEvidenceRegister register;
+    private final Map<EngineeringExternalEvidenceRecord.Type, Boolean> coverage;
+    private final Map<String, List<String>> matchedRecords;
+    private final List<Map<String, Object>> findings;
+
+    Result(EngineeringExternalEvidenceRegister register, Map<EngineeringExternalEvidenceRecord.Type, Boolean> coverage,
+        Map<String, List<String>> matchedRecords, List<Map<String, Object>> findings) {
+      this.register = register;
+      this.coverage = new EnumMap<EngineeringExternalEvidenceRecord.Type, Boolean>(coverage);
+      this.matchedRecords = new LinkedHashMap<String, List<String>>();
+      for (Map.Entry<String, List<String>> match : matchedRecords.entrySet()) {
+        this.matchedRecords.put(match.getKey(), new ArrayList<String>(match.getValue()));
+      }
+      this.findings = new ArrayList<Map<String, Object>>(findings);
+    }
+
+    public boolean isPassed() {
+      return findings.isEmpty()
+          && coverage.keySet().containsAll(EnumSet.allOf(EngineeringExternalEvidenceRecord.Type.class))
+          && !coverage.containsValue(Boolean.FALSE);
+    }
+
+    public boolean isTypePassed(EngineeringExternalEvidenceRecord.Type type) {
+      return Boolean.TRUE.equals(coverage.get(type));
+    }
+
+    public List<Map<String, Object>> getFindings() {
+      return new ArrayList<Map<String, Object>>(findings);
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("passed", Boolean.valueOf(isPassed()));
+      Map<String, Object> coverageMap = new LinkedHashMap<String, Object>();
+      for (EngineeringExternalEvidenceRecord.Type type : EngineeringExternalEvidenceRecord.Type.values()) {
+        coverageMap.put(type.name(), Boolean.valueOf(isTypePassed(type)));
+      }
+      result.put("coverage", coverageMap);
+      result.put("matchedRecords", new LinkedHashMap<String, List<String>>(matchedRecords));
+      result.put("findings", getFindings());
+      result.put("register", register == null ? null : register.toMap());
+      result.put("constructionAuthorityEvidenceAccepted",
+          Boolean.valueOf(isTypePassed(EngineeringExternalEvidenceRecord.Type.CONSTRUCTION_AUTHORITY)));
+      result.put("evidenceOrApprovalGeneratedBySimulator", Boolean.FALSE);
+      result.put("simulatorGrantedConstructionAuthority", Boolean.FALSE);
+      return result;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/EngineeringExternalEvidenceRecord.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringExternalEvidenceRecord.java
@@ -1,0 +1,323 @@
+package neqsim.process.engineering.production;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Immutable receipt for a controlled decision or guarantee issued outside the simulator. */
+public final class EngineeringExternalEvidenceRecord implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** External evidence classes that must be closed by accountable organizations. */
+  public enum Type {
+    ACCOUNTABLE_ENGINEERING_APPROVAL, VENDOR_GUARANTEE, HAZOP_DECISION, LOPA_DECISION, SRS_APPROVAL,
+    INDEPENDENT_VALIDATION, CONSTRUCTION_AUTHORITY
+  }
+
+  /** Current controlled decision state for one evidence revision. */
+  public enum Status {
+    DRAFT, ACCEPTED, REJECTED, SUPERSEDED
+  }
+
+  private final String id;
+  private final Type type;
+  private final String documentId;
+  private final String revision;
+  private final String title;
+  private final String documentReference;
+  private final String sha256;
+  private final String issuingOrganization;
+  private final String issuedBy;
+  private final String issuedDate;
+  private final List<String> scopeReferences;
+  private final Status status;
+  private final String decisionBy;
+  private final String decisionRole;
+  private final String decisionDate;
+  private final String decisionReference;
+  private final String independenceStatement;
+  private final String authorityJurisdiction;
+  private final String supersedesRecordId;
+
+  private EngineeringExternalEvidenceRecord(Builder builder) {
+    id = builder.id;
+    type = builder.type;
+    documentId = builder.documentId;
+    revision = builder.revision;
+    title = builder.title;
+    documentReference = builder.documentReference;
+    sha256 = builder.sha256;
+    issuingOrganization = builder.issuingOrganization;
+    issuedBy = builder.issuedBy;
+    issuedDate = builder.issuedDate;
+    scopeReferences = Collections.unmodifiableList(new ArrayList<String>(builder.scopeReferences));
+    status = builder.status;
+    decisionBy = builder.decisionBy;
+    decisionRole = builder.decisionRole;
+    decisionDate = builder.decisionDate;
+    decisionReference = builder.decisionReference;
+    independenceStatement = builder.independenceStatement;
+    authorityJurisdiction = builder.authorityJurisdiction;
+    supersedesRecordId = builder.supersedesRecordId;
+  }
+
+  /** Creates a controlled evidence-record builder. */
+  public static Builder builder(String id, Type type, String documentId, String revision) {
+    return new Builder(id, type, documentId, revision);
+  }
+
+  /** Returns fields that prevent this revision from being accepted as external evidence. */
+  public List<String> getMissingFields() {
+    List<String> missing = new ArrayList<String>();
+    missing(missing, title, "title");
+    missing(missing, documentReference, "documentReference");
+    if (!sha256.matches("[0-9a-fA-F]{64}")) {
+      missing.add("sha256");
+    }
+    missing(missing, issuingOrganization, "issuingOrganization");
+    missing(missing, issuedBy, "issuedBy");
+    date(missing, issuedDate, "issuedDate");
+    if (scopeReferences.isEmpty()) {
+      missing.add("scopeReference");
+    }
+    if (status == Status.ACCEPTED || status == Status.REJECTED) {
+      missing(missing, decisionBy, "decisionBy");
+      missing(missing, decisionRole, "decisionRole");
+      date(missing, decisionDate, "decisionDate");
+      missing(missing, decisionReference, "decisionReference");
+    }
+    if (type == Type.INDEPENDENT_VALIDATION) {
+      missing(missing, independenceStatement, "independenceStatement");
+    }
+    if (type == Type.CONSTRUCTION_AUTHORITY) {
+      missing(missing, authorityJurisdiction, "authorityJurisdiction");
+    }
+    return missing;
+  }
+
+  /** Returns true only for a complete, explicitly accepted external decision. */
+  public boolean isAcceptedAndComplete() {
+    return status == Status.ACCEPTED && getMissingFields().isEmpty();
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public String getDocumentId() {
+    return documentId;
+  }
+
+  public String getRevision() {
+    return revision;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getDocumentReference() {
+    return documentReference;
+  }
+
+  public String getSha256() {
+    return sha256;
+  }
+
+  public String getIssuingOrganization() {
+    return issuingOrganization;
+  }
+
+  public String getIssuedBy() {
+    return issuedBy;
+  }
+
+  public String getIssuedDate() {
+    return issuedDate;
+  }
+
+  public List<String> getScopeReferences() {
+    return scopeReferences;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public String getDecisionRole() {
+    return decisionRole;
+  }
+
+  public String getDecisionBy() {
+    return decisionBy;
+  }
+
+  public String getDecisionDate() {
+    return decisionDate;
+  }
+
+  public String getDecisionReference() {
+    return decisionReference;
+  }
+
+  public String getIndependenceStatement() {
+    return independenceStatement;
+  }
+
+  public String getAuthorityJurisdiction() {
+    return authorityJurisdiction;
+  }
+
+  public String getSupersedesRecordId() {
+    return supersedesRecordId;
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("id", id);
+    result.put("type", type.name());
+    result.put("documentId", documentId);
+    result.put("revision", revision);
+    result.put("title", title);
+    result.put("documentReference", documentReference);
+    result.put("sha256", sha256);
+    result.put("issuingOrganization", issuingOrganization);
+    result.put("issuedBy", issuedBy);
+    result.put("issuedDate", issuedDate);
+    result.put("scopeReferences", new ArrayList<String>(scopeReferences));
+    result.put("status", status.name());
+    result.put("decisionBy", decisionBy);
+    result.put("decisionRole", decisionRole);
+    result.put("decisionDate", decisionDate);
+    result.put("decisionReference", decisionReference);
+    result.put("independenceStatement", independenceStatement);
+    result.put("authorityJurisdiction", authorityJurisdiction);
+    result.put("supersedesRecordId", supersedesRecordId);
+    result.put("missingFields", getMissingFields());
+    result.put("acceptedAndComplete", Boolean.valueOf(isAcceptedAndComplete()));
+    return result;
+  }
+
+  private static void missing(List<String> missing, String value, String field) {
+    if (value.isEmpty()) {
+      missing.add(field);
+    }
+  }
+
+  private static void date(List<String> missing, String value, String field) {
+    if (!value.matches("[0-9]{4}-[0-9]{2}-[0-9]{2}(T.*)?")) {
+      missing.add(field);
+    }
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static String text(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  /** Fluent builder that keeps draft and rejected evidence serializable but never accepted implicitly. */
+  public static final class Builder {
+    private final String id;
+    private final Type type;
+    private final String documentId;
+    private final String revision;
+    private String title = "";
+    private String documentReference = "";
+    private String sha256 = "";
+    private String issuingOrganization = "";
+    private String issuedBy = "";
+    private String issuedDate = "";
+    private final List<String> scopeReferences = new ArrayList<String>();
+    private Status status = Status.DRAFT;
+    private String decisionBy = "";
+    private String decisionRole = "";
+    private String decisionDate = "";
+    private String decisionReference = "";
+    private String independenceStatement = "";
+    private String authorityJurisdiction = "";
+    private String supersedesRecordId = "";
+
+    private Builder(String id, Type type, String documentId, String revision) {
+      this.id = requireText(id, "id");
+      if (type == null) {
+        throw new IllegalArgumentException("type must not be null");
+      }
+      this.type = type;
+      this.documentId = requireText(documentId, "documentId");
+      this.revision = requireText(revision, "revision");
+    }
+
+    public Builder title(String value) {
+      title = requireText(value, "title");
+      return this;
+    }
+
+    public Builder controlledDocument(String reference, String contentSha256) {
+      documentReference = requireText(reference, "documentReference");
+      sha256 = requireText(contentSha256, "sha256");
+      return this;
+    }
+
+    public Builder issuer(String organization, String person, String date) {
+      issuingOrganization = requireText(organization, "issuingOrganization");
+      issuedBy = requireText(person, "issuedBy");
+      issuedDate = requireText(date, "issuedDate");
+      return this;
+    }
+
+    public Builder addScopeReference(String value) {
+      String scope = requireText(value, "scopeReference");
+      if (!scopeReferences.contains(scope)) {
+        scopeReferences.add(scope);
+      }
+      return this;
+    }
+
+    public Builder decision(Status value, String person, String role, String date, String reference) {
+      if (value == null) {
+        throw new IllegalArgumentException("status must not be null");
+      }
+      status = value;
+      decisionBy = text(person);
+      decisionRole = text(role);
+      decisionDate = text(date);
+      decisionReference = text(reference);
+      return this;
+    }
+
+    public Builder independenceStatement(String value) {
+      independenceStatement = requireText(value, "independenceStatement");
+      return this;
+    }
+
+    public Builder authorityJurisdiction(String value) {
+      authorityJurisdiction = requireText(value, "authorityJurisdiction");
+      return this;
+    }
+
+    public Builder supersedes(String recordId) {
+      supersedesRecordId = requireText(recordId, "supersedesRecordId");
+      if (id.equals(supersedesRecordId)) {
+        throw new IllegalArgumentException("Evidence record must not supersede itself");
+      }
+      return this;
+    }
+
+    public EngineeringExternalEvidenceRecord build() {
+      return new EngineeringExternalEvidenceRecord(this);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/EngineeringExternalEvidenceRegister.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringExternalEvidenceRegister.java
@@ -1,0 +1,105 @@
+package neqsim.process.engineering.production;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Revision-controlled external evidence requirements and supplied decision receipts. */
+public final class EngineeringExternalEvidenceRegister implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final List<EngineeringExternalEvidenceRequirement> requirements = new ArrayList<EngineeringExternalEvidenceRequirement>();
+  private final List<EngineeringExternalEvidenceRecord> records = new ArrayList<EngineeringExternalEvidenceRecord>();
+
+  /** Creates the minimum project-level requirement set; projects should add equipment-specific requirements. */
+  public static EngineeringExternalEvidenceRegister productionMinimum(String projectScopeReference) {
+    String scope = requireText(projectScopeReference, "projectScopeReference");
+    EngineeringExternalEvidenceRegister result = new EngineeringExternalEvidenceRegister();
+    result.addRequirement(
+        requirement("EXT-ACCOUNTABLE-APPROVAL", EngineeringExternalEvidenceRecord.Type.ACCOUNTABLE_ENGINEERING_APPROVAL,
+            scope, "Accountable engineering approval for the governed design revision"));
+    result.addRequirement(requirement("EXT-VENDOR-GUARANTEE", EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE,
+        scope, "Accepted vendor guarantee coverage for supplied equipment and instruments"));
+    result.addRequirement(requirement("EXT-HAZOP", EngineeringExternalEvidenceRecord.Type.HAZOP_DECISION, scope,
+        "Approved HAZOP decisions and closed actions for the governed scope"));
+    result.addRequirement(requirement("EXT-LOPA", EngineeringExternalEvidenceRecord.Type.LOPA_DECISION, scope,
+        "Approved LOPA decisions and independent-protection-layer basis"));
+    result.addRequirement(requirement("EXT-SRS", EngineeringExternalEvidenceRecord.Type.SRS_APPROVAL, scope,
+        "Approved safety requirements specification"));
+    result.addRequirement(
+        requirement("EXT-INDEPENDENT-VALIDATION", EngineeringExternalEvidenceRecord.Type.INDEPENDENT_VALIDATION, scope,
+            "Independent validation acceptance covering methods, inputs and results"));
+    result.addRequirement(
+        requirement("EXT-CONSTRUCTION-AUTHORITY", EngineeringExternalEvidenceRecord.Type.CONSTRUCTION_AUTHORITY, scope,
+            "Construction authority release for the governed design revision"));
+    return result;
+  }
+
+  public EngineeringExternalEvidenceRegister addRequirement(EngineeringExternalEvidenceRequirement value) {
+    if (value == null) {
+      throw new IllegalArgumentException("requirement must not be null");
+    }
+    for (EngineeringExternalEvidenceRequirement existing : requirements) {
+      if (existing.getId().equals(value.getId())) {
+        throw new IllegalArgumentException("Duplicate external evidence requirement " + value.getId());
+      }
+    }
+    requirements.add(value);
+    return this;
+  }
+
+  public EngineeringExternalEvidenceRegister addRecord(EngineeringExternalEvidenceRecord value) {
+    if (value == null) {
+      throw new IllegalArgumentException("record must not be null");
+    }
+    for (EngineeringExternalEvidenceRecord existing : records) {
+      if (existing.getId().equals(value.getId())) {
+        throw new IllegalArgumentException("Duplicate external evidence record " + value.getId());
+      }
+      if (existing.getDocumentId().equals(value.getDocumentId())
+          && existing.getRevision().equals(value.getRevision())) {
+        throw new IllegalArgumentException(
+            "Duplicate external evidence document revision " + value.getDocumentId() + "@" + value.getRevision());
+      }
+    }
+    records.add(value);
+    return this;
+  }
+
+  public List<EngineeringExternalEvidenceRequirement> getRequirements() {
+    return Collections.unmodifiableList(requirements);
+  }
+
+  public List<EngineeringExternalEvidenceRecord> getRecords() {
+    return Collections.unmodifiableList(records);
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    List<Map<String, Object>> requirementMaps = new ArrayList<Map<String, Object>>();
+    for (EngineeringExternalEvidenceRequirement requirement : requirements) {
+      requirementMaps.add(requirement.toMap());
+    }
+    List<Map<String, Object>> recordMaps = new ArrayList<Map<String, Object>>();
+    for (EngineeringExternalEvidenceRecord record : records) {
+      recordMaps.add(record.toMap());
+    }
+    result.put("requirements", requirementMaps);
+    result.put("records", recordMaps);
+    return result;
+  }
+
+  private static EngineeringExternalEvidenceRequirement requirement(String id,
+      EngineeringExternalEvidenceRecord.Type type, String scope, String description) {
+    return new EngineeringExternalEvidenceRequirement(id, type, scope, description);
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/EngineeringExternalEvidenceRequirement.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringExternalEvidenceRequirement.java
@@ -1,0 +1,81 @@
+package neqsim.process.engineering.production;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Explicit project requirement for one class and scope of external engineering evidence. */
+public final class EngineeringExternalEvidenceRequirement implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String id;
+  private final EngineeringExternalEvidenceRecord.Type type;
+  private final String scopeReference;
+  private final String description;
+  private final String requiredDecisionRole;
+
+  public EngineeringExternalEvidenceRequirement(String id, EngineeringExternalEvidenceRecord.Type type,
+      String scopeReference, String description) {
+    this(id, type, scopeReference, description, "");
+  }
+
+  public EngineeringExternalEvidenceRequirement(String id, EngineeringExternalEvidenceRecord.Type type,
+      String scopeReference, String description, String requiredDecisionRole) {
+    this.id = requireText(id, "id");
+    if (type == null) {
+      throw new IllegalArgumentException("type must not be null");
+    }
+    this.type = type;
+    this.scopeReference = requireText(scopeReference, "scopeReference");
+    this.description = requireText(description, "description");
+    this.requiredDecisionRole = text(requiredDecisionRole);
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public EngineeringExternalEvidenceRecord.Type getType() {
+    return type;
+  }
+
+  public String getScopeReference() {
+    return scopeReference;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getRequiredDecisionRole() {
+    return requiredDecisionRole;
+  }
+
+  public boolean isSatisfiedBy(EngineeringExternalEvidenceRecord record) {
+    if (record == null || record.getType() != type || !record.isAcceptedAndComplete()
+        || !record.getScopeReferences().contains(scopeReference)) {
+      return false;
+    }
+    return requiredDecisionRole.isEmpty() || requiredDecisionRole.equalsIgnoreCase(record.getDecisionRole());
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("id", id);
+    result.put("type", type.name());
+    result.put("scopeReference", scopeReference);
+    result.put("description", description);
+    result.put("requiredDecisionRole", requiredDecisionRole);
+    return result;
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static String text(String value) {
+    return value == null ? "" : value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessAssessment.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessAssessment.java
@@ -78,7 +78,12 @@ public final class EngineeringProductionReadinessAssessment {
     gates.put("NAMED_DEXPI_TOOL_ROUNDTRIP",
         gate(dexpi, "Record successful named-tool import/export and close every semantic difference"));
 
-    EngineeringSafetyLifecycleAssessment.Result safety = EngineeringSafetyLifecycleAssessment.assess(project);
+    EngineeringExternalEvidenceAssessment.Result external = EngineeringExternalEvidenceAssessment
+        .assess(evidence.getExternalEvidenceRegister());
+    addExternalEvidenceGates(gates, external);
+
+    EngineeringSafetyLifecycleAssessment.Result safety = EngineeringSafetyLifecycleAssessment.assess(project,
+        evidence.getExternalEvidenceRegister());
     gates.put("SAFETY_LIFECYCLE", gate(safety.isPassed(), "Close HAZOP/LOPA/SRS, SIF and shutdown findings"));
 
     Set<EngineeringPilotProjectEvidence.Scope> acceptedPilotScopes = EnumSet
@@ -118,11 +123,39 @@ public final class EngineeringProductionReadinessAssessment {
     }
     boolean technicalCompletion = transientPiping && compressorProtection && valveInstrument && mechanicalIntegrity
         && flareConsequence;
+    boolean externalValidation = external
+        .isTypePassed(EngineeringExternalEvidenceRecord.Type.ACCOUNTABLE_ENGINEERING_APPROVAL)
+        && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE)
+        && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.HAZOP_DECISION)
+        && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.LOPA_DECISION)
+        && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.SRS_APPROVAL)
+        && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.INDEPENDENT_VALIDATION);
     boolean validated = designLoop && benchmarkPassed && methods && automation != null && automation.isComplete()
-        && safety.isPassed() && technicalCompletion;
+        && safety.isPassed() && technicalCompletion && externalValidation;
     Level level = all ? Level.QUALIFIED_FEED_SUPPORT
         : validated ? Level.VALIDATED_PRELIMINARY : designLoop ? Level.EXPERIMENTAL : Level.NOT_READY;
-    return new Result(project.getProjectId(), project.getRevision(), level, gates, safety, evidence, all);
+    return new Result(project.getProjectId(), project.getRevision(), level, gates, safety, external, evidence, all);
+  }
+
+  private static void addExternalEvidenceGates(Map<String, Gate> gates,
+      EngineeringExternalEvidenceAssessment.Result external) {
+    gates.put("ACCOUNTABLE_ENGINEERING_APPROVALS",
+        gate(external.isTypePassed(EngineeringExternalEvidenceRecord.Type.ACCOUNTABLE_ENGINEERING_APPROVAL),
+            "Attach complete, immutable approval receipts from accountable engineering authorities"));
+    gates.put("VENDOR_GUARANTEES", gate(external.isTypePassed(EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE),
+        "Attach accepted vendor guarantees for every declared equipment and instrument scope"));
+    gates.put("HAZOP_DECISIONS", gate(external.isTypePassed(EngineeringExternalEvidenceRecord.Type.HAZOP_DECISION),
+        "Attach approved HAZOP decisions and evidence of action closure"));
+    gates.put("LOPA_DECISIONS", gate(external.isTypePassed(EngineeringExternalEvidenceRecord.Type.LOPA_DECISION),
+        "Attach approved LOPA decisions and independent-protection-layer basis"));
+    gates.put("SRS_APPROVAL", gate(external.isTypePassed(EngineeringExternalEvidenceRecord.Type.SRS_APPROVAL),
+        "Attach the approved safety requirements specification"));
+    gates.put("INDEPENDENT_VALIDATION_ACCEPTANCE",
+        gate(external.isTypePassed(EngineeringExternalEvidenceRecord.Type.INDEPENDENT_VALIDATION),
+            "Attach complete acceptance from a demonstrably independent validator"));
+    gates.put("CONSTRUCTION_AUTHORITY_EVIDENCE",
+        gate(external.isTypePassed(EngineeringExternalEvidenceRecord.Type.CONSTRUCTION_AUTHORITY),
+            "Attach the jurisdiction-specific construction authority release for this design revision"));
   }
 
   public static Set<String> executedMethods(EngineeringProject project) {
@@ -199,17 +232,20 @@ public final class EngineeringProductionReadinessAssessment {
     private final Level level;
     private final Map<String, Gate> gates;
     private final EngineeringSafetyLifecycleAssessment.Result safety;
+    private final EngineeringExternalEvidenceAssessment.Result externalEvidence;
     private final EngineeringProductionReadinessBasis basis;
     private final boolean preliminaryProductionReady;
 
     Result(String projectId, String revision, Level level, Map<String, Gate> gates,
-        EngineeringSafetyLifecycleAssessment.Result safety, EngineeringProductionReadinessBasis basis,
+        EngineeringSafetyLifecycleAssessment.Result safety,
+        EngineeringExternalEvidenceAssessment.Result externalEvidence, EngineeringProductionReadinessBasis basis,
         boolean preliminaryProductionReady) {
       this.projectId = projectId;
       this.revision = revision;
       this.level = level;
       this.gates = new LinkedHashMap<String, Gate>(gates);
       this.safety = safety;
+      this.externalEvidence = externalEvidence;
       this.basis = basis;
       this.preliminaryProductionReady = preliminaryProductionReady;
     }
@@ -246,11 +282,15 @@ public final class EngineeringProductionReadinessAssessment {
       result.put("gates", gateMaps);
       result.put("failedGates", getFailedGates());
       result.put("safetyLifecycle", safety.toMap());
+      result.put("externalEngineeringEvidence", externalEvidence.toMap());
       result.put("evidenceBasis", basis.toMap());
       result.put("preliminaryProductionReady", Boolean.valueOf(preliminaryProductionReady));
       result.put("fitnessForConstruction", Boolean.FALSE);
       result.put("finalEngineeringApprovalGranted", Boolean.FALSE);
-      result.put("governance", "Qualified FEED support still requires accountable discipline and project approval");
+      result.put("constructionAuthorityEvidenceAccepted", Boolean
+          .valueOf(externalEvidence.isTypePassed(EngineeringExternalEvidenceRecord.Type.CONSTRUCTION_AUTHORITY)));
+      result.put("governance",
+          "NeqSim verifies external evidence receipts but does not issue engineering or construction approval");
       return result;
     }
   }

--- a/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessBasis.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessBasis.java
@@ -26,6 +26,7 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
   private final List<DexpiToolQualificationEvidence> dexpiEvidence = new ArrayList<DexpiToolQualificationEvidence>();
   private final List<EngineeringPilotProjectEvidence> pilotEvidence = new ArrayList<EngineeringPilotProjectEvidence>();
   private EngineeringReleaseQualityEvidence releaseQualityEvidence;
+  private EngineeringExternalEvidenceRegister externalEvidenceRegister;
   private EngineeringCalculationResult<TransientPipingQualificationCalculation.Result> transientPipingQualification;
   private EngineeringCalculationResult<CompressorProtectionQualificationCalculation.Result> compressorProtectionQualification;
   private EngineeringCalculationResult<ValveInstrumentQualificationCalculation.Result> valveInstrumentQualification;
@@ -68,6 +69,15 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
 
   public EngineeringProductionReadinessBasis releaseQualityEvidence(EngineeringReleaseQualityEvidence value) {
     releaseQualityEvidence = value;
+    return this;
+  }
+
+  /** Attaches requirements and controlled receipts for evidence issued outside the simulator. */
+  public EngineeringProductionReadinessBasis externalEvidenceRegister(EngineeringExternalEvidenceRegister value) {
+    if (value == null) {
+      throw new IllegalArgumentException("externalEvidenceRegister must not be null");
+    }
+    externalEvidenceRegister = value;
     return this;
   }
 
@@ -123,6 +133,10 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
 
   public EngineeringReleaseQualityEvidence getReleaseQualityEvidence() {
     return releaseQualityEvidence;
+  }
+
+  public EngineeringExternalEvidenceRegister getExternalEvidenceRegister() {
+    return externalEvidenceRegister;
   }
 
   public EngineeringCalculationResult<TransientPipingQualificationCalculation.Result> getTransientPipingQualification() {
@@ -188,6 +202,7 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
     result.put("dexpiToolQualificationEvidence", maps(dexpiEvidence));
     result.put("pilotProjectEvidence", maps(pilotEvidence));
     result.put("releaseQualityEvidence", releaseQualityEvidence == null ? null : releaseQualityEvidence.toMap());
+    result.put("externalEvidenceRegister", externalEvidenceRegister == null ? null : externalEvidenceRegister.toMap());
     result.put("transientPipingQualification", map(transientPipingQualification));
     result.put("compressorProtectionQualification", map(compressorProtectionQualification));
     result.put("valveInstrumentQualification", map(valveInstrumentQualification));

--- a/src/main/java/neqsim/process/engineering/production/EngineeringQualificationPlan.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringQualificationPlan.java
@@ -79,7 +79,14 @@ public final class EngineeringQualificationPlan {
       actions.add(action("RELEASE_QUALITY", "release",
           "Close CI, Java matrix, determinism, performance, API, migration, security and review evidence"));
     }
-    EngineeringSafetyLifecycleAssessment.Result safety = EngineeringSafetyLifecycleAssessment.assess(project);
+    EngineeringExternalEvidenceAssessment.Result external = EngineeringExternalEvidenceAssessment
+        .assess(evidence.getExternalEvidenceRegister());
+    for (Map<String, Object> finding : external.getFindings()) {
+      actions.add(action("EXTERNAL_EVIDENCE", String.valueOf(finding.get("subject")),
+          String.valueOf(finding.get("requiredAction"))));
+    }
+    EngineeringSafetyLifecycleAssessment.Result safety = EngineeringSafetyLifecycleAssessment.assess(project,
+        evidence.getExternalEvidenceRegister());
     if (!safety.isPassed()) {
       actions.add(action("SAFETY_LIFECYCLE", "project", "Close accountable HAZOP/LOPA/SRS, SIF and shutdown findings"));
     }
@@ -98,6 +105,7 @@ public final class EngineeringQualificationPlan {
     result.put("revision", project.getRevision());
     result.put("executedMethods", new ArrayList<String>(executed));
     result.put("methodQualificationMatrix", methods);
+    result.put("externalEvidenceAssessment", external.toMap());
     result.put("actions", actions);
     result.put("openActionCount", Integer.valueOf(actions.size()));
     result.put("readinessLevel", assessment.getLevel().name());

--- a/src/main/java/neqsim/process/engineering/production/EngineeringSafetyLifecycleAssessment.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringSafetyLifecycleAssessment.java
@@ -19,11 +19,19 @@ public final class EngineeringSafetyLifecycleAssessment {
   }
 
   public static Result assess(EngineeringProject project) {
+    return assess(project, null);
+  }
+
+  /** Assesses safety completeness using legacy project records and the controlled external evidence register. */
+  public static Result assess(EngineeringProject project, EngineeringExternalEvidenceRegister externalRegister) {
     if (project == null) {
       throw new IllegalArgumentException("project must not be null");
     }
     List<Map<String, Object>> findings = new ArrayList<Map<String, Object>>();
-    boolean approvedHazopEvidence = false;
+    EngineeringExternalEvidenceAssessment.Result external = externalRegister == null ? null
+        : EngineeringExternalEvidenceAssessment.assess(externalRegister);
+    boolean approvedHazopEvidence = external != null
+        && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.HAZOP_DECISION);
     for (EngineeringEvidenceRecord evidence : project.getEvidenceRecords()) {
       if ("HAZOP".equalsIgnoreCase(evidence.getDocumentType())
           && evidence.getApprovalStatus() == EngineeringApprovalStatus.APPROVED
@@ -33,6 +41,12 @@ public final class EngineeringSafetyLifecycleAssessment {
     }
     if (!approvedHazopEvidence) {
       findings.add(finding("HAZOP_EVIDENCE", "Approved and complete HAZOP evidence is required"));
+    }
+    if (external != null && !external.isTypePassed(EngineeringExternalEvidenceRecord.Type.LOPA_DECISION)) {
+      findings.add(finding("LOPA_EVIDENCE", "Approved and complete LOPA evidence is required"));
+    }
+    if (external != null && !external.isTypePassed(EngineeringExternalEvidenceRecord.Type.SRS_APPROVAL)) {
+      findings.add(finding("SRS_EVIDENCE", "Approved and complete SRS evidence is required"));
     }
     for (ReliefScenarioBasis basis : project.getReliefScenarioBases()) {
       for (String missing : basis.getMissingFields()) {

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidator.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidator.java
@@ -178,6 +178,17 @@ public final class EngineeringPackageValidator {
       requireArray(root, "availableEngines", artifactName, report);
       requireObject(root, "executionBoundary", artifactName, report);
       requireObject(root, "summary", artifactName, report);
+    } else if ("engineering-external-evidence-register.json".equals(artifactName)) {
+      requireString(root, "projectId", artifactName, report);
+      requireString(root, "revision", artifactName, report);
+      if (!root.has("register") || !(root.get("register").isJsonNull() || root.get("register").isJsonObject())) {
+        report.addError("ENG-SCHEMA-013", artifactName, "/register",
+            "Required register property must be an object or null");
+      }
+      requireObject(root, "assessment", artifactName, report);
+      requireFalse(root, "evidenceGeneratedBySimulator", artifactName, report);
+      requireFalse(root, "approvalGrantedBySimulator", artifactName, report);
+      requireString(root, "governance", artifactName, report);
     } else if (artifactName.endsWith("-register.json")) {
       validateRegisterStructure(root, artifactName, report);
     } else if ("design-case-envelope.json".equals(artifactName)) {

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringSchemaCatalog.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringSchemaCatalog.java
@@ -33,6 +33,7 @@ public final class EngineeringSchemaCatalog {
   public static final String VALIDATION_REPORT = "neqsim_engineering_validation_report.v1";
   public static final String PRODUCTION_READINESS = "neqsim_engineering_production_readiness.v1";
   public static final String QUALIFICATION_PLAN = "neqsim_engineering_qualification_plan.v1";
+  public static final String EXTERNAL_EVIDENCE_REGISTER = "neqsim_external_engineering_evidence.v1";
   public static final String DISCIPLINE_ORCHESTRATION = "neqsim_engineering_discipline_orchestration.v1";
   public static final String VERTICAL_SLICE_QUALIFICATION = "neqsim_engineering_vertical_slice_qualification.v1";
   public static final String VERTICAL_SLICE_EXECUTION_MANIFEST = "neqsim_engineering_vertical_slice_execution_manifest.v1";
@@ -109,6 +110,8 @@ public final class EngineeringSchemaCatalog {
         "engineering-production-readiness.schema.json"));
     values.add(definition("engineering-qualification-plan.json", QUALIFICATION_PLAN,
         "engineering-qualification-plan.schema.json"));
+    values.add(definition("engineering-external-evidence-register.json", EXTERNAL_EVIDENCE_REGISTER,
+        "engineering-external-evidence-register.schema.json"));
     values.add(definition("engineering-discipline-orchestration.json", DISCIPLINE_ORCHESTRATION,
         "engineering-discipline-orchestration.schema.json"));
     values.add(definition("engineering-vertical-slice-qualification.json", VERTICAL_SLICE_QUALIFICATION,

--- a/src/main/resources/neqsim/process/engineering/schema/engineering-external-evidence-register.schema.json
+++ b/src/main/resources/neqsim/process/engineering/schema/engineering-external-evidence-register.schema.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:neqsim:schema:engineering-external-evidence-register:v1",
+  "title": "NeqSim external engineering evidence register",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "schemaUri",
+    "projectId",
+    "revision",
+    "engineeringApprovalRequired",
+    "register",
+    "assessment",
+    "evidenceGeneratedBySimulator",
+    "approvalGrantedBySimulator",
+    "governance"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "neqsim_external_engineering_evidence.v1"
+    },
+    "schemaUri": {
+      "const": "urn:neqsim:schema:engineering-external-evidence-register:v1"
+    },
+    "projectId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "revision": {
+      "type": "string",
+      "minLength": 1
+    },
+    "engineeringApprovalRequired": {
+      "const": true
+    },
+    "register": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/register"
+        }
+      ]
+    },
+    "assessment": {
+      "type": "object",
+      "required": [
+        "passed",
+        "coverage",
+        "matchedRecords",
+        "findings",
+        "constructionAuthorityEvidenceAccepted",
+        "evidenceOrApprovalGeneratedBySimulator",
+        "simulatorGrantedConstructionAuthority"
+      ]
+    },
+    "evidenceGeneratedBySimulator": {
+      "const": false
+    },
+    "approvalGrantedBySimulator": {
+      "const": false
+    },
+    "governance": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "$defs": {
+    "register": {
+      "type": "object",
+      "required": [
+        "requirements",
+        "records"
+      ],
+      "properties": {
+        "requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/requirement"
+          }
+        },
+        "records": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/record"
+          }
+        }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "scopeReference",
+        "description",
+        "requiredDecisionRole"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "$ref": "#/$defs/evidenceType"
+        },
+        "scopeReference": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requiredDecisionRole": {
+          "type": "string"
+        }
+      }
+    },
+    "record": {
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "documentId",
+        "revision",
+        "title",
+        "documentReference",
+        "sha256",
+        "issuingOrganization",
+        "issuedBy",
+        "issuedDate",
+        "scopeReferences",
+        "status",
+        "decisionBy",
+        "decisionRole",
+        "decisionDate",
+        "decisionReference",
+        "independenceStatement",
+        "authorityJurisdiction",
+        "supersedesRecordId",
+        "missingFields",
+        "acceptedAndComplete"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "$ref": "#/$defs/evidenceType"
+        },
+        "documentId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "revision": {
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string"
+        },
+        "documentReference": {
+          "type": "string"
+        },
+        "sha256": {
+          "type": "string"
+        },
+        "issuingOrganization": {
+          "type": "string"
+        },
+        "issuedBy": {
+          "type": "string"
+        },
+        "issuedDate": {
+          "type": "string"
+        },
+        "scopeReferences": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "enum": [
+            "DRAFT",
+            "ACCEPTED",
+            "REJECTED",
+            "SUPERSEDED"
+          ]
+        },
+        "decisionBy": {
+          "type": "string"
+        },
+        "decisionRole": {
+          "type": "string"
+        },
+        "decisionDate": {
+          "type": "string"
+        },
+        "decisionReference": {
+          "type": "string"
+        },
+        "independenceStatement": {
+          "type": "string"
+        },
+        "authorityJurisdiction": {
+          "type": "string"
+        },
+        "supersedesRecordId": {
+          "type": "string"
+        },
+        "missingFields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "acceptedAndComplete": {
+          "type": "boolean"
+        }
+      }
+    },
+    "evidenceType": {
+      "enum": [
+        "ACCOUNTABLE_ENGINEERING_APPROVAL",
+        "VENDOR_GUARANTEE",
+        "HAZOP_DECISION",
+        "LOPA_DECISION",
+        "SRS_APPROVAL",
+        "INDEPENDENT_VALIDATION",
+        "CONSTRUCTION_AUTHORITY"
+      ]
+    }
+  }
+}

--- a/src/test/java/neqsim/process/engineering/EngineeringExternalEvidenceAssessmentTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringExternalEvidenceAssessmentTest.java
@@ -1,0 +1,91 @@
+package neqsim.process.engineering;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceAssessment;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceRecord;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceRegister;
+import neqsim.process.engineering.production.EngineeringProductionReadinessAssessment;
+import neqsim.process.engineering.production.EngineeringProductionReadinessBasis;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringGraphBuilder;
+import neqsim.process.engineering.model.EngineeringIds;
+import neqsim.process.engineering.model.EngineeringNode;
+import neqsim.process.processmodel.ProcessSystem;
+import org.junit.jupiter.api.Test;
+
+/** Verifies fail-closed handling of external engineering decisions and guarantees. */
+class EngineeringExternalEvidenceAssessmentTest {
+
+  @Test
+  void acceptsCompleteControlledReceiptsWithoutGrantingAuthority() {
+    String scope = "project:external-evidence";
+    EngineeringExternalEvidenceRegister register = ExternalEvidenceTestSupport.completeRegister(scope);
+    EngineeringExternalEvidenceAssessment.Result result = EngineeringExternalEvidenceAssessment.assess(register);
+
+    assertTrue(result.isPassed());
+    assertTrue(result.isTypePassed(EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE));
+    assertTrue(result.isTypePassed(EngineeringExternalEvidenceRecord.Type.CONSTRUCTION_AUTHORITY));
+    assertTrue(Boolean.FALSE.equals(result.toMap().get("simulatorGrantedConstructionAuthority")));
+
+    EngineeringProject project = new EngineeringProject("external-evidence", new ProcessSystem(),
+        new EngineeringDesignBasis());
+    EngineeringProductionReadinessBasis basis = new EngineeringProductionReadinessBasis()
+        .externalEvidenceRegister(register);
+    project.setProductionReadinessBasis(basis);
+    EngineeringProductionReadinessAssessment.Result readiness = EngineeringProductionReadinessAssessment.assess(project,
+        basis);
+    assertFalse(readiness.getFailedGates().contains("ACCOUNTABLE_ENGINEERING_APPROVALS"));
+    assertFalse(readiness.getFailedGates().contains("VENDOR_GUARANTEES"));
+    assertFalse(readiness.getFailedGates().contains("HAZOP_DECISIONS"));
+    assertFalse(readiness.getFailedGates().contains("LOPA_DECISIONS"));
+    assertFalse(readiness.getFailedGates().contains("SRS_APPROVAL"));
+    assertFalse(readiness.getFailedGates().contains("INDEPENDENT_VALIDATION_ACCEPTANCE"));
+    assertFalse(readiness.getFailedGates().contains("CONSTRUCTION_AUTHORITY_EVIDENCE"));
+    assertTrue(Boolean.FALSE.equals(readiness.toMap().get("fitnessForConstruction")));
+    EngineeringGraph graph = EngineeringGraphBuilder.fromProject(project);
+    assertTrue(graph.getNode(EngineeringIds.nodeId(EngineeringNode.Kind.DOCUMENT, "EV-VENDOR_GUARANTEE-A")) != null);
+  }
+
+  @Test
+  void rejectsIncompleteConflictingAndSupersededDecisions() {
+    String scope = "project:external-conflict";
+    EngineeringExternalEvidenceRegister register = ExternalEvidenceTestSupport.completeRegister(scope);
+    register.addRecord(EngineeringExternalEvidenceRecord
+        .builder("EV-VENDOR-REJECTED", EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE, "DOC-VENDOR-REJECTED",
+            "A")
+        .title("Rejected vendor guarantee")
+        .controlledDocument("stid://DOC-VENDOR-REJECTED/A", ExternalEvidenceTestSupport.SHA256)
+        .issuer("Vendor", "Vendor authority", "2026-07-18").addScopeReference(scope)
+        .decision(EngineeringExternalEvidenceRecord.Status.REJECTED, "Machinery authority", "Technical authority",
+            "2026-07-18", "workflow://vendor/rejected")
+        .build());
+
+    EngineeringExternalEvidenceAssessment.Result conflict = EngineeringExternalEvidenceAssessment.assess(register);
+    assertFalse(conflict.isPassed());
+    assertFalse(conflict.isTypePassed(EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE));
+    assertTrue(conflict.getFindings().toString().contains("CONFLICTING_ACTIVE_DECISIONS"));
+
+    EngineeringExternalEvidenceRegister superseded = ExternalEvidenceTestSupport.completeRegister(scope);
+    superseded.addRecord(EngineeringExternalEvidenceRecord
+        .builder("EV-VENDOR-DRAFT-B", EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE, "DOC-VENDOR-DRAFT", "B")
+        .title("Replacement vendor guarantee")
+        .controlledDocument("stid://DOC-VENDOR-DRAFT/B", ExternalEvidenceTestSupport.SHA256)
+        .issuer("Vendor", "Vendor authority", "2026-07-19").addScopeReference(scope).supersedes("EV-VENDOR_GUARANTEE-A")
+        .build());
+    EngineeringExternalEvidenceAssessment.Result draft = EngineeringExternalEvidenceAssessment.assess(superseded);
+    assertFalse(draft.isTypePassed(EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE));
+
+    EngineeringExternalEvidenceRegister invalidHash = ExternalEvidenceTestSupport.completeRegister(scope);
+    invalidHash.addRecord(EngineeringExternalEvidenceRecord
+        .builder("EV-HAZOP-BAD-HASH", EngineeringExternalEvidenceRecord.Type.HAZOP_DECISION, "DOC-HAZOP-BAD", "A")
+        .title("Hazop decision with unverified content").controlledDocument("stid://DOC-HAZOP-BAD/A", "not-a-hash")
+        .issuer("Hazop team", "Hazop chair", "2026-07-18").addScopeReference(scope)
+        .decision(EngineeringExternalEvidenceRecord.Status.ACCEPTED, "Process safety authority", "Technical authority",
+            "2026-07-18", "workflow://hazop/accepted")
+        .build());
+    EngineeringExternalEvidenceAssessment.Result incomplete = EngineeringExternalEvidenceAssessment.assess(invalidHash);
+    assertFalse(incomplete.isTypePassed(EngineeringExternalEvidenceRecord.Type.HAZOP_DECISION));
+    assertTrue(incomplete.getFindings().toString().contains("INCOMPLETE_ACCEPTED_RECORD"));
+  }
+}

--- a/src/test/java/neqsim/process/engineering/EngineeringProductionReadinessTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringProductionReadinessTest.java
@@ -69,7 +69,7 @@ class EngineeringProductionReadinessTest {
   }
 
   @Test
-  void reachesQualifiedFeedSupportOnlyWithEveryEvidenceGate() {
+  void externalEvidenceDoesNotBypassMissingTechnicalQualification() {
     EngineeringProject project = project();
     ProcessToEngineeringSimulator.run(project);
     EngineeringAutoConfigurator.Result automation = EngineeringAutoConfigurator.configure(project,
@@ -95,7 +95,8 @@ class EngineeringProductionReadinessTest {
         .releaseQualityEvidence(new EngineeringReleaseQualityEvidence("release-candidate-1").fullCiPassed(true)
             .supportedJavaMatrixPassed(true).deterministicConvergencePassed(true).performanceAcceptancePassed(true)
             .apiCompatibilityPassed(true).serializationMigrationPassed(true).securityReviewPassed(true)
-            .evidenceReference("RELEASE-EVIDENCE-001").accountableReviewer("Release authority / RA-001"));
+            .evidenceReference("RELEASE-EVIDENCE-001").accountableReviewer("Release authority / RA-001"))
+        .externalEvidenceRegister(ExternalEvidenceTestSupport.completeRegister("project:production-readiness"));
     project.addEvidenceRecord(new EngineeringEvidenceRecord("HAZOP-001", "HAZOP", "A").setTitle("Test hazard review")
         .setSourceOrganization("Independent engineering team").linkEquipment("FEED")
         .approve("Hazop chair / HAZOP-001-A"));
@@ -103,8 +104,11 @@ class EngineeringProductionReadinessTest {
     EngineeringProductionReadinessAssessment.Result result = EngineeringProductionReadinessAssessment.assess(project,
         basis);
 
-    assertEquals(EngineeringProductionReadinessAssessment.Level.QUALIFIED_FEED_SUPPORT, result.getLevel());
-    assertTrue(result.isPreliminaryProductionReady());
+    assertEquals(EngineeringProductionReadinessAssessment.Level.EXPERIMENTAL, result.getLevel());
+    assertFalse(result.isPreliminaryProductionReady());
+    assertFalse(result.getFailedGates().contains("ACCOUNTABLE_ENGINEERING_APPROVALS"));
+    assertFalse(result.getFailedGates().contains("CONSTRUCTION_AUTHORITY_EVIDENCE"));
+    assertTrue(result.getFailedGates().contains("DISTRIBUTED_TRANSIENT_PIPING"));
     assertFalse(Boolean.TRUE.equals(result.toMap().get("fitnessForConstruction")));
   }
 

--- a/src/test/java/neqsim/process/engineering/ExternalEvidenceTestSupport.java
+++ b/src/test/java/neqsim/process/engineering/ExternalEvidenceTestSupport.java
@@ -1,0 +1,37 @@
+package neqsim.process.engineering;
+
+import neqsim.process.engineering.production.EngineeringExternalEvidenceRecord;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceRegister;
+
+/** Shared controlled external-evidence fixtures. */
+final class ExternalEvidenceTestSupport {
+  static final String SHA256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+  private ExternalEvidenceTestSupport() {
+  }
+
+  static EngineeringExternalEvidenceRegister completeRegister(String scope) {
+    EngineeringExternalEvidenceRegister result = EngineeringExternalEvidenceRegister.productionMinimum(scope);
+    for (EngineeringExternalEvidenceRecord.Type type : EngineeringExternalEvidenceRecord.Type.values()) {
+      result.addRecord(accepted(type, scope, "EV-" + type.name() + "-A"));
+    }
+    return result;
+  }
+
+  static EngineeringExternalEvidenceRecord accepted(EngineeringExternalEvidenceRecord.Type type, String scope,
+      String id) {
+    EngineeringExternalEvidenceRecord.Builder builder = EngineeringExternalEvidenceRecord
+        .builder(id, type, "DOC-" + id, "A").title(type.name() + " controlled evidence")
+        .controlledDocument("stid://DOC-" + id + "/A", SHA256)
+        .issuer("Accountable external organization", "Authorized issuer", "2026-07-18").addScopeReference(scope)
+        .decision(EngineeringExternalEvidenceRecord.Status.ACCEPTED, "Authorized approver", "Technical authority",
+            "2026-07-18", "workflow://" + id + "/accepted");
+    if (type == EngineeringExternalEvidenceRecord.Type.INDEPENDENT_VALIDATION) {
+      builder.independenceStatement("Validator is organizationally independent from the producing team");
+    }
+    if (type == EngineeringExternalEvidenceRecord.Type.CONSTRUCTION_AUTHORITY) {
+      builder.authorityJurisdiction("Norway / project construction authority");
+    }
+    return builder.build();
+  }
+}

--- a/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
+++ b/src/test/java/neqsim/process/engineering/ProcessToEngineeringSimulatorTest.java
@@ -84,8 +84,9 @@ class ProcessToEngineeringSimulatorTest {
     String[] coordinatedArtifacts = new String[] { "process-design-basis.json", "equipment-datasheets.json",
         "valve-list.json", "io-list.json", "alarm-trip-schedule.json", "shutdown-narratives.json",
         "psv-datasheets.json", "flare-blowdown-report.json", "utility-summary.json", "materials-selection-report.json",
-        "engineering-diagram-layout.json", "unresolved-engineering-actions.json", "revision-impact-report.json",
-        "engineering-production-readiness.json", "engineering-qualification-plan.json" };
+        "engineering-external-evidence-register.json", "engineering-diagram-layout.json",
+        "unresolved-engineering-actions.json", "revision-impact-report.json", "engineering-production-readiness.json",
+        "engineering-qualification-plan.json" };
     for (String artifact : coordinatedArtifacts) {
       assertTrue(Files.exists(temporaryDirectory.resolve(artifact)), artifact);
     }
@@ -104,6 +105,11 @@ class ProcessToEngineeringSimulatorTest {
         Files.readAllBytes(temporaryDirectory.resolve("engineering-production-readiness.json")),
         StandardCharsets.UTF_8);
     assertTrue(productionReadiness.contains("\"fitnessForConstruction\": false"));
+    String externalEvidence = new String(
+        Files.readAllBytes(temporaryDirectory.resolve("engineering-external-evidence-register.json")),
+        StandardCharsets.UTF_8);
+    assertTrue(externalEvidence.contains("\"evidenceGeneratedBySimulator\": false"));
+    assertTrue(externalEvidence.contains("\"approvalGrantedBySimulator\": false"));
     String qualificationPlan = new String(
         Files.readAllBytes(temporaryDirectory.resolve("engineering-qualification-plan.json")), StandardCharsets.UTF_8);
     assertTrue(qualificationPlan.contains("\"externalEvidenceMayNotBeGeneratedBySimulator\": true"));


### PR DESCRIPTION
## Summary

Implements the external engineering-evidence layer that remained after the technical qualification work.

- adds typed requirements and immutable receipts for accountable approvals, vendor guarantees, HAZOP decisions, LOPA decisions, SRS approval, independent validation and construction-authority evidence
- requires controlled document/revision identity, SHA-256 content hash, issuer, governed scope and accountable decision metadata
- adds independence and jurisdiction controls for independent validation and construction authority
- fails closed for missing, incomplete, rejected, conflicting, superseded and cyclic evidence
- integrates seven explicit gates into production readiness and HAZOP/LOPA/SRS checks into the safety lifecycle
- materializes external evidence in the canonical engineering graph and qualification backlog
- exports a schema-registered `engineering-external-evidence-register.json` artifact
- documents the API and updates the engineering agent and P&ID/process-operations skill
- adds positive, conflict, invalid-hash and supersession regression coverage

## Governance boundary

NeqSim verifies controlled receipts supplied by accountable external parties. It does not create HAZOP/LOPA/SRS decisions, vendor guarantees, independent validation, engineering approval or construction authority.

Even when construction-authority evidence is structurally accepted, `fitnessForConstruction`, `finalEngineeringApprovalGranted` and `simulatorGrantedConstructionAuthority` remain false.

## Validation

- compiled all `neqsim.process.engineering` sources with Java `--release 8`
- executed the focused external-evidence regression suite successfully
- parsed the new JSON schema successfully
- applied the repository Eclipse formatter
- `git diff --check` passed
- full Maven, package-compilation and platform checks run in GitHub Actions