### PR TITLE
Complete engineering implementation plan evidence integrity

### DIFF
--- a/docs/integration/process-to-engineering-simulator.md
+++ b/docs/integration/process-to-engineering-simulator.md
@@ -460,10 +460,18 @@ EngineeringExternalEvidenceRegister external =
                 "2026-07-18", "workflow://VDR-K-100/C/accepted")
             .build());
 
-project.getProductionReadinessBasis().externalEvidenceRegister(external);
+EngineeringExternalEvidenceDocumentIntegrity documentIntegrity =
+    new EngineeringExternalEvidenceDocumentIntegrity()
+        .addDocument("stid://VDR-K-100/C", Files.readAllBytes(controlledDocumentPath));
+
+project.getProductionReadinessBasis().externalEvidenceRegister(external)
+    .externalEvidenceDocumentIntegrity(documentIntegrity);
 ```
 
-Supply equivalent accepted receipts for every declared requirement. Compilation writes
+Supply equivalent accepted receipts and the actual controlled document bytes for every declared requirement. The
+production-readiness assessment recomputes SHA-256 from those bytes and fails closed when a document is missing or its
+content differs from the receipt. The package records only the computed integrity manifest, not the document content.
+ Compilation writes
 `engineering-external-evidence-register.json`, embeds the assessment in production readiness, and creates an exact
 qualification backlog for missing or conflicting evidence. `constructionAuthorityEvidenceAccepted=true` means that
 the supplied external receipt passed structural and scope checks; `fitnessForConstruction` and
@@ -479,6 +487,28 @@ auto-configuration, executed-method discovery, a regression-evidence rejection, 
 The companion
 [discipline-orchestration notebook](../../examples/notebooks/engineering_discipline_orchestration.ipynb) focuses on
 execution blockers, dependency fingerprints, revision invalidation and the multi-area `ProcessModel` API.
+
+## Implementation-plan completion (#2451)
+
+The software implementation requested by issue #2451 is complete and regression-controlled. The following matrix is
+the canonical mapping from the eight requested workstreams to their executable NeqSim implementation:
+
+| Workstream | Executable implementation |
+| --- | --- |
+| Closed engineering loop | `EngineeringDesignLoop`, physical design candidates, constraints, convergence and isolated reruns |
+| Equipment design | Typed separator, compressor, pump, exchanger, column and tank calculations |
+| Piping and hydraulics | `PipingNetworkDesignCalculation`, rule packs and distributed transient qualification |
+| Valves and instruments | Typed valve/instrument design plus response, installation and logic qualification |
+| Safety scenarios | Governed scenario engine, relief/blowdown/flare coupling and consequence qualification |
+| Materials and mechanical | Material selection, pressure design and detailed mechanical-integrity qualification |
+| Data-centric DEXPI | Canonical engineering graph, deterministic DEXPI 2.0 and semantic round-trip qualification |
+| Coordinated package | Schema-validated registers, datasheets, reports, calculation DAG and revision impact |
+
+The qualified separator → compressor → cooler → export reference facility exercises the full chain across ten controlled
+cases. Production readiness additionally requires the exact-version benchmarks, named-tool round trips, pilots,
+release evidence and accountable external receipts declared by the readiness gates. Accepted external receipts must
+now match the actual supplied document bytes. These evidence requirements are project inputs, not unfinished simulator
+features, and the simulator always retains `fitnessForConstruction=false`.
 
 ## Required engineering review
 

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringCoordinatedPackage.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringCoordinatedPackage.java
@@ -19,6 +19,7 @@ import neqsim.process.engineering.model.EngineeringNode;
 import neqsim.process.engineering.production.EngineeringProductionReadinessAssessment;
 import neqsim.process.engineering.production.EngineeringProductionReadinessBasis;
 import neqsim.process.engineering.production.EngineeringExternalEvidenceAssessment;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceDocumentIntegrity;
 import neqsim.process.engineering.production.EngineeringExternalEvidenceRegister;
 import neqsim.process.engineering.validation.EngineeringSchemaCatalog;
 
@@ -257,10 +258,13 @@ final class EngineeringCoordinatedPackage {
     EngineeringExternalEvidenceRegister register = basis == null ? null : basis.getExternalEvidenceRegister();
     result.put("register", register == null ? null : register.toMap());
     result.put("assessment", EngineeringExternalEvidenceAssessment.assess(register).toMap());
+    EngineeringExternalEvidenceDocumentIntegrity integrity = basis == null ? null
+        : basis.getExternalEvidenceDocumentIntegrity();
+    result.put("documentIntegrity", EngineeringExternalEvidenceDocumentIntegrity.assess(register, integrity).toMap());
     result.put("evidenceGeneratedBySimulator", Boolean.FALSE);
     result.put("approvalGrantedBySimulator", Boolean.FALSE);
     result.put("governance",
-        "Records are controlled receipts from accountable external parties; NeqSim only verifies completeness");
+        "Records are controlled receipts from accountable external parties; NeqSim verifies completeness and content integrity only");
     return result;
   }
 

--- a/src/main/java/neqsim/process/engineering/production/EngineeringExternalEvidenceDocumentIntegrity.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringExternalEvidenceDocumentIntegrity.java
@@ -1,0 +1,193 @@
+package neqsim.process.engineering.production;
+
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Binds external engineering evidence receipts to the actual supplied document bytes.
+ *
+ * <p>
+ * The simulator verifies content integrity only. It does not create, sign, accept, or approve an external decision.
+ */
+public final class EngineeringExternalEvidenceDocumentIntegrity implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final Map<String, Document> documents = new LinkedHashMap<String, Document>();
+
+  /** Adds one controlled document and computes its SHA-256 digest from the supplied bytes. */
+  public EngineeringExternalEvidenceDocumentIntegrity addDocument(String reference, byte[] content) {
+    String controlledReference = requireText(reference, "reference");
+    if (content == null) {
+      throw new IllegalArgumentException("content must not be null");
+    }
+    Document candidate = new Document(controlledReference, sha256(content), content.length);
+    Document existing = documents.get(controlledReference);
+    if (existing != null && !existing.sha256.equals(candidate.sha256)) {
+      throw new IllegalArgumentException("Conflicting content supplied for " + controlledReference);
+    }
+    documents.put(controlledReference, candidate);
+    return this;
+  }
+
+  /** Adds one UTF-8 controlled document. */
+  public EngineeringExternalEvidenceDocumentIntegrity addDocument(String reference, String content) {
+    if (content == null) {
+      throw new IllegalArgumentException("content must not be null");
+    }
+    return addDocument(reference, content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public List<String> getDocumentReferences() {
+    return Collections.unmodifiableList(new ArrayList<String>(documents.keySet()));
+  }
+
+  /** Verifies every complete accepted receipt against independently supplied document content. */
+  public Result assess(EngineeringExternalEvidenceRegister register) {
+    List<Map<String, Object>> findings = new ArrayList<Map<String, Object>>();
+    List<String> verifiedRecordIds = new ArrayList<String>();
+    int acceptedRecords = 0;
+    if (register == null) {
+      findings.add(finding("MISSING_EVIDENCE_REGISTER", "", "Attach the external evidence register"));
+    } else {
+      for (EngineeringExternalEvidenceRecord record : register.getRecords()) {
+        if (!record.isAcceptedAndComplete()) {
+          continue;
+        }
+        acceptedRecords++;
+        Document document = documents.get(record.getDocumentReference());
+        if (document == null) {
+          findings.add(finding("DOCUMENT_NOT_SUPPLIED", record.getId(),
+              "Supply the controlled document bytes for " + record.getDocumentReference()));
+        } else if (!document.sha256.equals(record.getSha256().toLowerCase(Locale.ROOT))) {
+          findings.add(finding("DOCUMENT_HASH_MISMATCH", record.getId(),
+              "Replace the document or receipt so the computed and declared SHA-256 hashes agree"));
+        } else {
+          verifiedRecordIds.add(record.getId());
+        }
+      }
+    }
+    if (acceptedRecords == 0) {
+      findings.add(finding("NO_ACCEPTED_EXTERNAL_DOCUMENTS", "",
+          "Attach complete accepted receipts and their controlled document bytes"));
+    }
+    return new Result(documents, verifiedRecordIds, findings);
+  }
+
+  /** Fail-closed convenience entry point for an optional integrity manifest. */
+  public static Result assess(EngineeringExternalEvidenceRegister register,
+      EngineeringExternalEvidenceDocumentIntegrity integrity) {
+    if (integrity == null) {
+      return new EngineeringExternalEvidenceDocumentIntegrity().assess(register);
+    }
+    return integrity.assess(register);
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    List<Map<String, Object>> values = new ArrayList<Map<String, Object>>();
+    for (Document document : documents.values()) {
+      values.add(document.toMap());
+    }
+    result.put("documents", values);
+    result.put("documentCount", Integer.valueOf(values.size()));
+    return result;
+  }
+
+  private static String sha256(byte[] content) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] value = digest.digest(content);
+      StringBuilder result = new StringBuilder();
+      for (byte item : value) {
+        result.append(String.format("%02x", Integer.valueOf(item & 0xff)));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is not available", ex);
+    }
+  }
+
+  private static Map<String, Object> finding(String code, String recordId, String action) {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("code", code);
+    result.put("recordId", recordId);
+    result.put("severity", "BLOCKER");
+    result.put("requiredAction", action);
+    return result;
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static final class Document implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String reference;
+    private final String sha256;
+    private final long byteLength;
+
+    Document(String reference, String sha256, long byteLength) {
+      this.reference = reference;
+      this.sha256 = sha256;
+      this.byteLength = byteLength;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("reference", reference);
+      result.put("computedSha256", sha256);
+      result.put("byteLength", Long.valueOf(byteLength));
+      return result;
+    }
+  }
+
+  /** Immutable integrity result for package and readiness gates. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Map<String, Document> documents;
+    private final List<String> verifiedRecordIds;
+    private final List<Map<String, Object>> findings;
+
+    Result(Map<String, Document> documents, List<String> verifiedRecordIds, List<Map<String, Object>> findings) {
+      this.documents = new LinkedHashMap<String, Document>(documents);
+      this.verifiedRecordIds = new ArrayList<String>(verifiedRecordIds);
+      this.findings = new ArrayList<Map<String, Object>>(findings);
+    }
+
+    public boolean isPassed() {
+      return !verifiedRecordIds.isEmpty() && findings.isEmpty();
+    }
+
+    public List<String> getVerifiedRecordIds() {
+      return Collections.unmodifiableList(verifiedRecordIds);
+    }
+
+    public List<Map<String, Object>> getFindings() {
+      return Collections.unmodifiableList(findings);
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      List<Map<String, Object>> manifest = new ArrayList<Map<String, Object>>();
+      for (Document document : documents.values()) {
+        manifest.add(document.toMap());
+      }
+      result.put("passed", Boolean.valueOf(isPassed()));
+      result.put("verifiedRecordIds", new ArrayList<String>(verifiedRecordIds));
+      result.put("documents", manifest);
+      result.put("findings", new ArrayList<Map<String, Object>>(findings));
+      result.put("approvalGrantedBySimulator", Boolean.FALSE);
+      return result;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessAssessment.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessAssessment.java
@@ -81,6 +81,10 @@ public final class EngineeringProductionReadinessAssessment {
     EngineeringExternalEvidenceAssessment.Result external = EngineeringExternalEvidenceAssessment
         .assess(evidence.getExternalEvidenceRegister());
     addExternalEvidenceGates(gates, external);
+    EngineeringExternalEvidenceDocumentIntegrity.Result documentIntegrity = EngineeringExternalEvidenceDocumentIntegrity
+        .assess(evidence.getExternalEvidenceRegister(), evidence.getExternalEvidenceDocumentIntegrity());
+    gates.put("EXTERNAL_EVIDENCE_DOCUMENT_INTEGRITY", gate(documentIntegrity.isPassed(),
+        "Supply every accepted controlled document and resolve all SHA-256 mismatches"));
 
     EngineeringSafetyLifecycleAssessment.Result safety = EngineeringSafetyLifecycleAssessment.assess(project,
         evidence.getExternalEvidenceRegister());
@@ -129,12 +133,14 @@ public final class EngineeringProductionReadinessAssessment {
         && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.HAZOP_DECISION)
         && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.LOPA_DECISION)
         && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.SRS_APPROVAL)
-        && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.INDEPENDENT_VALIDATION);
+        && external.isTypePassed(EngineeringExternalEvidenceRecord.Type.INDEPENDENT_VALIDATION)
+        && documentIntegrity.isPassed();
     boolean validated = designLoop && benchmarkPassed && methods && automation != null && automation.isComplete()
         && safety.isPassed() && technicalCompletion && externalValidation;
     Level level = all ? Level.QUALIFIED_FEED_SUPPORT
         : validated ? Level.VALIDATED_PRELIMINARY : designLoop ? Level.EXPERIMENTAL : Level.NOT_READY;
-    return new Result(project.getProjectId(), project.getRevision(), level, gates, safety, external, evidence, all);
+    return new Result(project.getProjectId(), project.getRevision(), level, gates, safety, external, documentIntegrity,
+        evidence, all);
   }
 
   private static void addExternalEvidenceGates(Map<String, Gate> gates,
@@ -233,19 +239,22 @@ public final class EngineeringProductionReadinessAssessment {
     private final Map<String, Gate> gates;
     private final EngineeringSafetyLifecycleAssessment.Result safety;
     private final EngineeringExternalEvidenceAssessment.Result externalEvidence;
+    private final EngineeringExternalEvidenceDocumentIntegrity.Result externalEvidenceDocumentIntegrity;
     private final EngineeringProductionReadinessBasis basis;
     private final boolean preliminaryProductionReady;
 
     Result(String projectId, String revision, Level level, Map<String, Gate> gates,
         EngineeringSafetyLifecycleAssessment.Result safety,
-        EngineeringExternalEvidenceAssessment.Result externalEvidence, EngineeringProductionReadinessBasis basis,
-        boolean preliminaryProductionReady) {
+        EngineeringExternalEvidenceAssessment.Result externalEvidence,
+        EngineeringExternalEvidenceDocumentIntegrity.Result externalEvidenceDocumentIntegrity,
+        EngineeringProductionReadinessBasis basis, boolean preliminaryProductionReady) {
       this.projectId = projectId;
       this.revision = revision;
       this.level = level;
       this.gates = new LinkedHashMap<String, Gate>(gates);
       this.safety = safety;
       this.externalEvidence = externalEvidence;
+      this.externalEvidenceDocumentIntegrity = externalEvidenceDocumentIntegrity;
       this.basis = basis;
       this.preliminaryProductionReady = preliminaryProductionReady;
     }
@@ -283,6 +292,7 @@ public final class EngineeringProductionReadinessAssessment {
       result.put("failedGates", getFailedGates());
       result.put("safetyLifecycle", safety.toMap());
       result.put("externalEngineeringEvidence", externalEvidence.toMap());
+      result.put("externalEvidenceDocumentIntegrity", externalEvidenceDocumentIntegrity.toMap());
       result.put("evidenceBasis", basis.toMap());
       result.put("preliminaryProductionReady", Boolean.valueOf(preliminaryProductionReady));
       result.put("fitnessForConstruction", Boolean.FALSE);

--- a/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessBasis.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringProductionReadinessBasis.java
@@ -27,6 +27,7 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
   private final List<EngineeringPilotProjectEvidence> pilotEvidence = new ArrayList<EngineeringPilotProjectEvidence>();
   private EngineeringReleaseQualityEvidence releaseQualityEvidence;
   private EngineeringExternalEvidenceRegister externalEvidenceRegister;
+  private EngineeringExternalEvidenceDocumentIntegrity externalEvidenceDocumentIntegrity;
   private EngineeringCalculationResult<TransientPipingQualificationCalculation.Result> transientPipingQualification;
   private EngineeringCalculationResult<CompressorProtectionQualificationCalculation.Result> compressorProtectionQualification;
   private EngineeringCalculationResult<ValveInstrumentQualificationCalculation.Result> valveInstrumentQualification;
@@ -78,6 +79,16 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
       throw new IllegalArgumentException("externalEvidenceRegister must not be null");
     }
     externalEvidenceRegister = value;
+    return this;
+  }
+
+  /** Attaches actual document content digests used to verify external evidence receipts. */
+  public EngineeringProductionReadinessBasis externalEvidenceDocumentIntegrity(
+      EngineeringExternalEvidenceDocumentIntegrity value) {
+    if (value == null) {
+      throw new IllegalArgumentException("externalEvidenceDocumentIntegrity must not be null");
+    }
+    externalEvidenceDocumentIntegrity = value;
     return this;
   }
 
@@ -137,6 +148,10 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
 
   public EngineeringExternalEvidenceRegister getExternalEvidenceRegister() {
     return externalEvidenceRegister;
+  }
+
+  public EngineeringExternalEvidenceDocumentIntegrity getExternalEvidenceDocumentIntegrity() {
+    return externalEvidenceDocumentIntegrity;
   }
 
   public EngineeringCalculationResult<TransientPipingQualificationCalculation.Result> getTransientPipingQualification() {
@@ -203,6 +218,8 @@ public final class EngineeringProductionReadinessBasis implements Serializable {
     result.put("pilotProjectEvidence", maps(pilotEvidence));
     result.put("releaseQualityEvidence", releaseQualityEvidence == null ? null : releaseQualityEvidence.toMap());
     result.put("externalEvidenceRegister", externalEvidenceRegister == null ? null : externalEvidenceRegister.toMap());
+    result.put("externalEvidenceDocumentIntegrity",
+        externalEvidenceDocumentIntegrity == null ? null : externalEvidenceDocumentIntegrity.toMap());
     result.put("transientPipingQualification", map(transientPipingQualification));
     result.put("compressorProtectionQualification", map(compressorProtectionQualification));
     result.put("valveInstrumentQualification", map(valveInstrumentQualification));

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidator.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidator.java
@@ -186,6 +186,7 @@ public final class EngineeringPackageValidator {
             "Required register property must be an object or null");
       }
       requireObject(root, "assessment", artifactName, report);
+      requireObject(root, "documentIntegrity", artifactName, report);
       requireFalse(root, "evidenceGeneratedBySimulator", artifactName, report);
       requireFalse(root, "approvalGrantedBySimulator", artifactName, report);
       requireString(root, "governance", artifactName, report);

--- a/src/main/resources/neqsim/process/engineering/schema/engineering-external-evidence-register.schema.json
+++ b/src/main/resources/neqsim/process/engineering/schema/engineering-external-evidence-register.schema.json
@@ -11,6 +11,7 @@
     "engineeringApprovalRequired",
     "register",
     "assessment",
+    "documentIntegrity",
     "evidenceGeneratedBySimulator",
     "approvalGrantedBySimulator",
     "governance"
@@ -54,6 +55,47 @@
         "evidenceOrApprovalGeneratedBySimulator",
         "simulatorGrantedConstructionAuthority"
       ]
+    },
+    "documentIntegrity": {
+      "type": "object",
+      "required": [
+        "passed",
+        "verifiedRecordIds",
+        "documents",
+        "findings",
+        "approvalGrantedBySimulator"
+      ],
+      "properties": {
+        "passed": {
+          "type": "boolean"
+        },
+        "verifiedRecordIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "documents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "reference",
+              "computedSha256",
+              "byteLength"
+            ]
+          }
+        },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "approvalGrantedBySimulator": {
+          "const": false
+        }
+      }
     },
     "evidenceGeneratedBySimulator": {
       "const": false

--- a/src/main/resources/neqsim/process/engineering/schema/engineering-production-readiness.schema.json
+++ b/src/main/resources/neqsim/process/engineering/schema/engineering-production-readiness.schema.json
@@ -12,10 +12,13 @@
     "gates",
     "failedGates",
     "safetyLifecycle",
+    "externalEngineeringEvidence",
+    "externalEvidenceDocumentIntegrity",
     "evidenceBasis",
     "preliminaryProductionReady",
     "fitnessForConstruction",
     "finalEngineeringApprovalGranted",
+    "constructionAuthorityEvidenceAccepted",
     "governance"
   ],
   "properties": {
@@ -41,10 +44,24 @@
     },
     "failedGates": {"type": "array", "items": {"type": "string"}},
     "safetyLifecycle": {"type": "object"},
+    "externalEngineeringEvidence": {"type": "object"},
+    "externalEvidenceDocumentIntegrity": {
+      "type": "object",
+      "required": ["passed", "verifiedRecordIds", "documents", "findings", "approvalGrantedBySimulator"],
+      "properties": {
+        "passed": {"type": "boolean"},
+        "verifiedRecordIds": {"type": "array", "items": {"type": "string"}},
+        "documents": {"type": "array", "items": {"type": "object"}},
+        "findings": {"type": "array", "items": {"type": "object"}},
+        "approvalGrantedBySimulator": {"const": false}
+      },
+      "additionalProperties": false
+    },
     "evidenceBasis": {"type": "object"},
     "preliminaryProductionReady": {"type": "boolean"},
     "fitnessForConstruction": {"const": false},
     "finalEngineeringApprovalGranted": {"const": false},
+    "constructionAuthorityEvidenceAccepted": {"type": "boolean"},
     "governance": {"type": "string", "minLength": 1}
   },
   "additionalProperties": false

--- a/src/test/java/neqsim/process/engineering/EngineeringExternalEvidenceDocumentIntegrityTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringExternalEvidenceDocumentIntegrityTest.java
@@ -1,0 +1,100 @@
+package neqsim.process.engineering;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceDocumentIntegrity;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceRecord;
+import neqsim.process.engineering.production.EngineeringExternalEvidenceRegister;
+import neqsim.process.engineering.production.EngineeringProductionReadinessAssessment;
+import neqsim.process.engineering.production.EngineeringProductionReadinessBasis;
+import neqsim.process.processmodel.ProcessSystem;
+import org.junit.jupiter.api.Test;
+
+/** Verifies that accepted external receipts are bound to the actual supplied document content. */
+class EngineeringExternalEvidenceDocumentIntegrityTest {
+
+  @Test
+  void verifiesEveryAcceptedDocumentWithoutGrantingApproval() throws Exception {
+    String scope = "project:document-integrity";
+    String content = "controlled external engineering evidence revision A";
+    String contentHash = sha256(content);
+    EngineeringExternalEvidenceRegister register = EngineeringExternalEvidenceRegister.productionMinimum(scope);
+    EngineeringExternalEvidenceDocumentIntegrity integrity = new EngineeringExternalEvidenceDocumentIntegrity();
+
+    for (EngineeringExternalEvidenceRecord.Type type : EngineeringExternalEvidenceRecord.Type.values()) {
+      String reference = "memory://" + type.name() + "/A";
+      register.addRecord(accepted(type, scope, reference, contentHash));
+      integrity.addDocument(reference, content);
+    }
+
+    EngineeringExternalEvidenceDocumentIntegrity.Result result = integrity.assess(register);
+    assertTrue(result.isPassed());
+    assertTrue(result.getVerifiedRecordIds().size() == EngineeringExternalEvidenceRecord.Type.values().length);
+    assertTrue(Boolean.FALSE.equals(result.toMap().get("approvalGrantedBySimulator")));
+
+    EngineeringProject project = new EngineeringProject("document-integrity", new ProcessSystem(),
+        new EngineeringDesignBasis());
+    EngineeringProductionReadinessBasis basis = new EngineeringProductionReadinessBasis()
+        .externalEvidenceRegister(register).externalEvidenceDocumentIntegrity(integrity);
+    EngineeringProductionReadinessAssessment.Result readiness = EngineeringProductionReadinessAssessment.assess(project,
+        basis);
+    assertFalse(readiness.getFailedGates().contains("EXTERNAL_EVIDENCE_DOCUMENT_INTEGRITY"));
+    assertTrue(Boolean.FALSE.equals(readiness.toMap().get("fitnessForConstruction")));
+  }
+
+  @Test
+  void failsClosedForMissingOrChangedDocumentContent() throws Exception {
+    String scope = "project:document-integrity-negative";
+    String reference = "memory://VENDOR/A";
+    EngineeringExternalEvidenceRegister register = EngineeringExternalEvidenceRegister.productionMinimum(scope)
+        .addRecord(accepted(EngineeringExternalEvidenceRecord.Type.VENDOR_GUARANTEE, scope, reference,
+            sha256("controlled vendor guarantee")));
+
+    EngineeringExternalEvidenceDocumentIntegrity.Result missing = new EngineeringExternalEvidenceDocumentIntegrity()
+        .assess(register);
+    assertFalse(missing.isPassed());
+    assertTrue(missing.getFindings().toString().contains("DOCUMENT_NOT_SUPPLIED"));
+
+    EngineeringExternalEvidenceDocumentIntegrity changed = new EngineeringExternalEvidenceDocumentIntegrity()
+        .addDocument(reference, "changed vendor guarantee");
+    EngineeringExternalEvidenceDocumentIntegrity.Result mismatch = changed.assess(register);
+    assertFalse(mismatch.isPassed());
+    assertTrue(mismatch.getFindings().toString().contains("DOCUMENT_HASH_MISMATCH"));
+  }
+
+  @Test
+  void rejectsConflictingContentForTheSameControlledReference() {
+    EngineeringExternalEvidenceDocumentIntegrity integrity = new EngineeringExternalEvidenceDocumentIntegrity()
+        .addDocument("memory://DOC/A", "first");
+    assertThrows(IllegalArgumentException.class, () -> integrity.addDocument("memory://DOC/A", "second"));
+  }
+
+  private static EngineeringExternalEvidenceRecord accepted(EngineeringExternalEvidenceRecord.Type type, String scope,
+      String reference, String contentHash) {
+    EngineeringExternalEvidenceRecord.Builder builder = EngineeringExternalEvidenceRecord
+        .builder("EV-" + type.name() + "-A", type, "DOC-" + type.name(), "A")
+        .title(type.name() + " controlled evidence").controlledDocument(reference, contentHash)
+        .issuer("Accountable external organization", "Authorized issuer", "2026-07-18").addScopeReference(scope)
+        .decision(EngineeringExternalEvidenceRecord.Status.ACCEPTED, "Authorized approver", "Technical authority",
+            "2026-07-18", "workflow://" + type.name() + "/accepted");
+    if (type == EngineeringExternalEvidenceRecord.Type.INDEPENDENT_VALIDATION) {
+      builder.independenceStatement("Validator is organizationally independent from the producing team");
+    }
+    if (type == EngineeringExternalEvidenceRecord.Type.CONSTRUCTION_AUTHORITY) {
+      builder.authorityJurisdiction("Norway / project construction authority");
+    }
+    return builder.build();
+  }
+
+  private static String sha256(String value) throws Exception {
+    byte[] bytes = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+    StringBuilder result = new StringBuilder();
+    for (byte item : bytes) {
+      result.append(String.format("%02x", Integer.valueOf(item & 0xff)));
+    }
+    return result.toString();
+  }
+}


### PR DESCRIPTION
## Summary

Completes the final software-closeable gap in #2451.

- binds accepted external engineering receipts to the actual supplied controlled-document bytes
- recomputes SHA-256 and fails closed for missing documents, changed content, or conflicting content at one controlled reference
- adds an explicit production-readiness gate for external-document integrity
- exports the integrity result in the coordinated engineering package and validates it against the registered schema
- adds positive, missing-document, hash-mismatch, duplicate-reference, readiness, and governance regression coverage
- documents the canonical completion mapping for all eight #2451 workstreams

## Governance boundary

NeqSim verifies receipt completeness and document integrity. It does not create, sign, accept, or approve HAZOP/LOPA/SRS decisions, vendor guarantees, independent validation, accountable engineering approval, or construction authority.

`fitnessForConstruction`, final engineering approval, and simulator-granted construction authority remain false.

## Validation

- JSON schema parsed before publication
- source changes checked against the current `master` APIs
- focused Java regression tests added
- GitHub Actions is authoritative for Spotless, Java 8/21 compilation, JUnit, Javadoc, CodeQL, and repository policy gates

Closes #2451