### PR TITLE
Add repository governance and ownership framework

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,52 @@
+# NeqSim repository ownership
+#
+# @EvenSol is the current repository fallback owner. The subsystem ownership
+# table and the requirement to appoint independent backup maintainers are in
+# MAINTAINERS.md. Replace or extend these entries as Equinor GitHub teams are
+# formally assigned.
+
+* @EvenSol
+
+# Thermodynamics and physical properties
+/src/main/java/neqsim/thermo/ @EvenSol
+/src/main/java/neqsim/thermodynamicoperations/ @EvenSol
+/src/main/java/neqsim/physicalproperties/ @EvenSol
+/src/test/java/neqsim/thermo/ @EvenSol
+/src/test/java/neqsim/thermodynamicoperations/ @EvenSol
+/src/test/java/neqsim/physicalproperties/ @EvenSol
+
+# Process simulation
+/src/main/java/neqsim/process/ @EvenSol
+/src/test/java/neqsim/process/ @EvenSol
+/docs/process/ @EvenSol
+
+# Governed engineering workflows
+/src/main/java/neqsim/process/engineering/ @EvenSol
+/src/test/java/neqsim/process/engineering/ @EvenSol
+/src/main/resources/neqsim/process/engineering/ @EvenSol
+/docs/integration/process-to-engineering-simulator.md @EvenSol
+/docs/integration/engineering-production-vertical-slice.md @EvenSol
+
+# DEXPI and engineering exchange
+/src/main/java/neqsim/process/processmodel/dexpi/ @EvenSol
+/src/test/java/neqsim/process/processmodel/dexpi/ @EvenSol
+/docs/integration/dexpi-engineering-generation.md @EvenSol
+/docs/integration/dexpi-reader.md @EvenSol
+
+# Safety and risk
+/src/main/java/neqsim/process/safety/ @EvenSol
+/src/test/java/neqsim/process/safety/ @EvenSol
+/docs/safety/ @EvenSol
+
+# MCP and agent-facing API
+/src/main/java/neqsim/mcp/ @EvenSol
+/src/test/java/neqsim/mcp/ @EvenSol
+/neqsim-mcp-server/ @EvenSol
+/docs/integration/mcp_server_guide.md @EvenSol
+
+# Repository governance and release controls
+/.github/CODEOWNERS @EvenSol
+/GOVERNANCE.md @EvenSol
+/MAINTAINERS.md @EvenSol
+/CONTRIBUTING.md @EvenSol
+/pom.xml @EvenSol

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,8 @@ Thank you for contributing to NeqSim! Please complete the following checklist be
 - [ ] Verify code formatting using Checkstyle
 - [ ] Update any relevant docs/README
 - [ ] Link to an associated issue or discussion
+- [ ] Request the applicable `CODEOWNERS` and record independent domain review where required
+- [ ] Add an accepted NRC and migration note if this changes a major public contract
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution process.
+See [CONTRIBUTING.md](../CONTRIBUTING.md), [GOVERNANCE.md](../GOVERNANCE.md), and
+[the API lifecycle policy](../docs/development/api-lifecycle.md) for the full contribution process.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,11 @@ pre-commit run --all-files
 4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you
    do not have permission to do that, you may request the second reviewer to merge it for you.
 
+Repository ownership, independent domain-review requirements, and major-design decisions are governed by
+[`GOVERNANCE.md`](GOVERNANCE.md), [`MAINTAINERS.md`](MAINTAINERS.md), and
+[the NeqSim Request for Comments process](docs/development/rfc-process.md). Public contracts follow the
+[API and schema lifecycle policy](docs/development/api-lifecycle.md).
+
 ## AI-Assisted Contributions Welcome
 
 NeqSim embraces AI-assisted development. PRs generated with the help of AI coding agents

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,73 @@
+# NeqSim Governance
+
+NeqSim is an open-source engineering calculation library. Repository governance
+protects the correctness, maintainability, and traceability of the software; it
+does not grant project engineering approval or construction authority.
+
+## Decision model
+
+Routine changes are decided through pull-request review. The subsystem owner in
+`CODEOWNERS` is responsible for finding an appropriately qualified reviewer and
+for ensuring that the change satisfies the repository quality gates.
+
+The following changes require a NeqSim Request for Comments (NRC):
+
+- incompatible public Java, Python, JSON, DEXPI, or MCP API changes;
+- new canonical identities, lifecycle states, schema major versions, or
+  engineering approval semantics;
+- replacement of a thermodynamic or engineering method used by an existing
+  public API;
+- changes to qualification levels or industrial deployment boundaries; and
+- changes affecting two or more owned subsystems.
+
+The NRC process is described in `docs/development/rfc-process.md`.
+
+## Review requirements
+
+| Change class | Minimum review |
+|---|---|
+| Documentation or isolated maintenance | One maintainer |
+| Public API or serialized contract | Subsystem owner plus one independent maintainer |
+| Thermodynamic or engineering method | Subsystem owner plus one independent domain reviewer |
+| Safety, approval, or production-readiness semantics | Safety/engineering owner plus one independent domain reviewer |
+| Major schema or compatibility change | Accepted NRC and two maintainer approvals |
+
+An author cannot provide the independent approval for their own change.
+Automated review and CI evidence support, but do not replace, accountable human
+review.
+
+## Maintainer responsibilities
+
+Maintainers are expected to:
+
+- protect physical and engineering correctness, not only compilation;
+- require reproducible benchmark or regression evidence appropriate to risk;
+- preserve Java 8 compatibility in the core library;
+- apply the API lifecycle and deprecation policy;
+- keep known limitations and qualification boundaries explicit;
+- respond to security reports through Equinor's responsible-disclosure path;
+- identify a backup before planned absence or role transition; and
+- record material architecture decisions through an NRC.
+
+## Release authority
+
+A release may be issued only when the configured CI and security gates pass and
+the release owner confirms the compatibility and migration notes. A software
+release is not evidence that every method is qualified for every engineering
+application. Method-specific applicability and validation evidence remain part
+of the calculation provenance and project engineering basis.
+
+## Ownership changes
+
+Repository administrators appoint or remove maintainers through a reviewed pull
+request updating both `CODEOWNERS` and `MAINTAINERS.md`. Every critical
+subsystem should have a primary and an independent backup. An unfilled backup
+role is a visible governance action and prevents the repository from claiming
+that hero dependency has been closed.
+
+## Conduct and escalation
+
+Contributors follow `CODE_OF_CONDUCT.md`. Technical disagreements should first
+be resolved with evidence in the pull request or NRC. Unresolved cross-domain
+decisions are escalated to the repository maintainers; safety or regulatory
+decisions remain with the accountable external engineering authority.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,38 @@
+# NeqSim Maintainers
+
+This file records accountable repository-maintenance roles. GitHub handles in
+`CODEOWNERS` enforce review routing; this table explains the competence area and
+backup status behind those rules.
+
+The initial ownership mapping uses the current repository maintainer as a
+temporary fallback. Independent backup maintainers must be appointed before the
+governance action is considered complete.
+
+| Area | Paths | Primary | Backup | Status |
+|---|---|---|---|---|
+| Repository and releases | `.github/`, root build and governance files | `@EvenSol` | Unassigned | Backup required |
+| Thermodynamics and physical properties | `thermo`, `thermodynamicoperations`, `physicalproperties` | `@EvenSol` | Unassigned | Backup required |
+| Process simulation | `process` excluding the separately owned areas below | `@EvenSol` | Unassigned | Backup required |
+| Engineering workflows | `process/engineering` and engineering schemas | `@EvenSol` | Unassigned | Backup required |
+| DEXPI and engineering exchange | `process/processmodel/dexpi`, DEXPI documentation | `@EvenSol` | Unassigned | Backup required |
+| Safety and risk | `process/safety`, safety documentation | `@EvenSol` | Unassigned | Backup required |
+| MCP and agent-facing contracts | `mcp`, `neqsim-mcp-server` | `@EvenSol` | Unassigned | Backup required |
+
+## Appointment criteria
+
+A primary or backup maintainer should have:
+
+- demonstrated understanding of the owned code and its engineering domain;
+- capacity to review changes within a reasonable time;
+- familiarity with the relevant validation and compatibility requirements; and
+- agreement from the repository administrators.
+
+Domain reviewers may approve the physical or engineering basis without having
+merge permission. Maintainers remain responsible for verifying that this review
+is recorded and that repository gates pass.
+
+## Updating this file
+
+Ownership changes require a pull request updating this table and
+`.github/CODEOWNERS` together. The pull request should state the incoming
+maintainer's agreement and identify any temporary coverage gap.

--- a/docs/development/api-lifecycle.md
+++ b/docs/development/api-lifecycle.md
@@ -1,0 +1,41 @@
+---
+title: Public API and schema lifecycle
+description: Compatibility, deprecation, and migration rules for NeqSim public contracts.
+---
+
+# Public API and schema lifecycle
+
+NeqSim public contracts include Java and Python APIs, JSON schemas, DEXPI
+representations, MCP tools, command-line interfaces, and persisted model or
+engineering packages.
+
+## Compatibility rules
+
+- Additive optional fields and methods are permitted within a major contract
+  version.
+- Required fields, identifiers, enum meanings, and existing method behavior are
+  not removed or redefined within a major version.
+- Readers reject unknown major schema versions instead of interpreting them as
+  the current contract.
+- Writers emit one declared schema version and include an explicit schema URI.
+- Deterministic artifacts retain stable ordering and content fingerprints.
+
+## Deprecation
+
+Deprecation requires documentation of the replacement and migration path. A
+deprecated public contract remains supported for at least one normal release
+cycle and, when included in an LTS release, until the next LTS line unless a
+security or correctness issue makes that unsafe.
+
+## Breaking changes
+
+A breaking change requires an accepted NRC, a new major contract version,
+migration documentation, compatibility tests, and release notes. Where
+practical, NeqSim should provide a reader or converter for the immediately
+preceding major version.
+
+## Qualification boundary
+
+API stability says that integrations can rely on a contract. It does not say
+that the underlying calculation is qualified for a particular project,
+standard, operating range, or engineering decision.

--- a/docs/development/rfc-process.md
+++ b/docs/development/rfc-process.md
@@ -1,0 +1,52 @@
+---
+title: NeqSim Request for Comments process
+description: Review process for major public contracts, architecture, and engineering-governance changes.
+---
+
+# NeqSim Request for Comments process
+
+A NeqSim Request for Comments (NRC) records a material design decision before
+the implementation makes it expensive to change. Small fixes and additive local
+features do not require an NRC.
+
+## When an NRC is required
+
+Use an NRC for the change classes listed in `GOVERNANCE.md`, especially public
+contract incompatibilities, schema major versions, canonical identity changes,
+and safety or qualification semantics.
+
+## Workflow
+
+1. Create `docs/rfcs/NNNN-short-title.md` from the template below.
+2. Open a draft pull request containing the proposal and no production-code
+   implementation.
+3. Request the owners of every affected subsystem.
+4. Record alternatives, compatibility effects, validation needs, and the
+   engineering-governance boundary.
+5. Resolve material comments and record the decision as `ACCEPTED`, `REJECTED`,
+   or `SUPERSEDED`.
+6. Link implementation pull requests back to the accepted NRC.
+
+## Required sections
+
+```markdown
+# NRC-NNNN: Title
+
+- Status: PROPOSED
+- Owners: GitHub handles
+- Created: YYYY-MM-DD
+- Target release: version or UNPLANNED
+
+## Context and problem
+## Decision
+## Public contracts affected
+## Engineering and safety boundary
+## Compatibility and migration
+## Validation and qualification evidence
+## Alternatives considered
+## Rollback strategy
+## Decision record
+```
+
+Acceptance records architectural agreement. It does not qualify an engineering
+method or approve its use on an asset.


### PR DESCRIPTION
## Summary

Establishes the repository-level governance needed to treat NeqSim model infrastructure as an owned, maintained product rather than a pilot deliverable.

## Scope

- adds repository governance, maintainer roles, escalation paths, and decision rights
- adds CODEOWNERS coverage for thermodynamics, process simulation, engineering, DEXPI, safety, and MCP/agent interfaces
- defines an RFC process and API lifecycle/deprecation policy
- expands the pull request template with ownership, compatibility, and governance checks
- links the contribution guide to the new policies

## Ownership decision required

The bootstrap mapping uses `@EvenSol` as the current accountable/fallback owner. Before this PR is marked ready, the repository should confirm the correct GitHub users or teams for each domain and name backups in `MAINTAINERS.md`.

## Validation

- `git diff --check`
- documentation and ownership-path review

## Governance boundary

CODEOWNERS provides review routing; it does not by itself establish Equinor line accountability or operational support funding.

## Stack

PR 1 of 4. This PR targets `master`; PR 2 is stacked on this branch.