### PR TITLE
Add governed NeqSimModelPackage v1

### DIFF
--- a/docs/integration/process-to-engineering-simulator.md
+++ b/docs/integration/process-to-engineering-simulator.md
@@ -195,6 +195,11 @@ calculation DAG, approval
 ledger and graph difference complete the package. Each calculated value retains its governing case, method or module,
 unit and graph/evidence relationship.
 
+The compiler also writes `neqsim-model-package.json`, an outer model-lifecycle manifest with stable asset/model/revision
+identity, a canonical-graph reference, software versions, dependency slots, and SHA-256 hashes for every contained
+artifact. The model-package validator fails closed when an inventoried file is missing or changed. Package integrity
+does not grant engineering approval or fitness for construction.
+
 ## Standards profile
 
 The supplied methods are designed to be used with version-controlled project rule packs, including:

--- a/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
+++ b/src/main/java/neqsim/process/engineering/deliverables/EngineeringDeliverableCompiler.java
@@ -40,6 +40,10 @@ import neqsim.process.engineering.validation.EngineeringSchemaCatalog;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
+import neqsim.process.modelpackage.ModelDependency;
+import neqsim.process.modelpackage.ModelPackageIdentity;
+import neqsim.process.modelpackage.ModelPackageValidator;
+import neqsim.process.modelpackage.NeqSimModelPackage;
 
 /** Compiles one governed project into a coordinated engineering package and canonical graph snapshot. */
 public final class EngineeringDeliverableCompiler {
@@ -77,6 +81,7 @@ public final class EngineeringDeliverableCompiler {
     private final Path compilerManifestFile;
     private final Path validationReportFile;
     private final Path revisionDiffFile;
+    private final Path modelPackageFile;
     private final EngineeringGraph engineeringGraph;
     private final EngineeringDesignEnvelope designEnvelope;
     private final DexpiEngineeringExporter.ExportResult dexpiResult;
@@ -90,7 +95,7 @@ public final class EngineeringDeliverableCompiler {
         Path verticalSliceExecutionManifestFile, Path qualificationPlanFile, Path compilerManifestFile,
         Path validationReportFile, Path revisionDiffFile, EngineeringGraph engineeringGraph,
         EngineeringDesignEnvelope designEnvelope, DexpiEngineeringExporter.ExportResult dexpiResult,
-        EngineeringPackageValidationReport validationReport) {
+        EngineeringPackageValidationReport validationReport, Path modelPackageFile) {
       this.outputDirectory = outputDirectory;
       this.engineeringGraphFile = engineeringGraphFile;
       this.engineeringConnectivityFile = engineeringConnectivityFile;
@@ -115,6 +120,7 @@ public final class EngineeringDeliverableCompiler {
       this.designEnvelope = designEnvelope;
       this.dexpiResult = dexpiResult;
       this.validationReport = validationReport;
+      this.modelPackageFile = modelPackageFile;
     }
 
     public Path getOutputDirectory() {
@@ -195,6 +201,10 @@ public final class EngineeringDeliverableCompiler {
 
     public Path getRevisionDiffFile() {
       return revisionDiffFile;
+    }
+
+    public Path getModelPackageFile() {
+      return modelPackageFile;
     }
 
     public EngineeringGraph getEngineeringGraph() {
@@ -339,17 +349,23 @@ public final class EngineeringDeliverableCompiler {
     write(compilerManifest, compilerManifest(project, graph, envelope, diff, schemaArtifacts));
     Path validationFile = outputDirectory.resolve("engineering-validation-report.json");
     write(validationFile, new EngineeringPackageValidationReport().toJson());
+    Path modelPackageFile = writeModelPackage(project, outputDirectory, baselineGraph);
     EngineeringPackageValidationReport validation = EngineeringPackageValidator.validatePackage(outputDirectory);
     write(validationFile, validation.toJson());
     if (!validation.isValid()) {
       throw new EngineeringPackageValidationException(validationFile, validation);
     }
     DexpiEngineeringExporter.refreshPackageManifest(outputDirectory);
+    modelPackageFile = writeModelPackage(project, outputDirectory, baselineGraph);
+    ModelPackageValidator.Result modelPackageValidation = ModelPackageValidator.validate(outputDirectory);
+    if (!modelPackageValidation.isValid()) {
+      throw new IOException("Invalid NeqSim model package: " + modelPackageValidation.getFindings());
+    }
     return new CompilationResult(outputDirectory, graphFile, connectivityFile, calculationDagFile, designCaseMatrixFile,
         disciplinePackageFile, approvalLedgerFile, dexpiRoundTripReportFile, automationPlanFile, envelopeFile,
         equipmentFile, lineFile, instrumentFile, productionReadinessFile, verticalSliceQualificationFile,
         verticalSliceExecutionManifestFile, qualificationPlanFile, compilerManifest, validationFile, diffFile, graph,
-        envelope, dexpiResult, validation);
+        envelope, dexpiResult, validation, modelPackageFile);
   }
 
   private static void addDocumentNodes(EngineeringGraph graph, EngineeringProject project) {
@@ -367,7 +383,7 @@ public final class EngineeringDeliverableCompiler {
         "utility-summary.json", "materials-selection-report.json", "unresolved-engineering-actions.json",
         "revision-impact-report.json", "engineering-production-readiness.json", "engineering-qualification-plan.json",
         "engineering-discipline-orchestration.json", "engineering-vertical-slice-qualification.json",
-        "engineering-vertical-slice-execution-manifest.json" };
+        "engineering-vertical-slice-execution-manifest.json", "neqsim-model-package.json" };
     for (String document : documents) {
       String nodeId = EngineeringIds.nodeId(EngineeringNode.Kind.DOCUMENT, document);
       graph.addNode(new EngineeringNode(nodeId, EngineeringNode.Kind.DOCUMENT, document, document)
@@ -581,6 +597,7 @@ public final class EngineeringDeliverableCompiler {
     artifacts.add("engineering-validation-report.json");
     artifacts.add("engineering-discipline-orchestration.json");
     artifacts.add("engineering-vertical-slice-qualification.json");
+    artifacts.add("neqsim-model-package.json");
     artifacts.add("plant.dexpi.xml");
     artifacts.add("plant-proteus.xml");
     artifacts.add("plant-pydexpi.xml");
@@ -603,6 +620,20 @@ public final class EngineeringDeliverableCompiler {
     document.put("schemas", EngineeringSchemaCatalog.manifestEntries());
     document.put("governance", "Generated values and documents remain review-required until discipline approval");
     return GSON.toJson(document);
+  }
+
+  private static Path writeModelPackage(EngineeringProject project, Path outputDirectory,
+      EngineeringGraph baselineGraph) throws IOException {
+    ModelPackageIdentity identity = new ModelPackageIdentity(project.getProjectId(), project.getName(),
+        project.getProjectId(), "ENGINEERING_PROCESS_MODEL", project.getRevision(),
+        baselineGraph == null ? "" : baselineGraph.getRevision(), "DESIGN", "");
+    Map<String, String> softwareVersions = new LinkedHashMap<String, String>();
+    String implementationVersion = NeqSimModelPackage.class.getPackage().getImplementationVersion();
+    if (implementationVersion != null && !implementationVersion.trim().isEmpty()) {
+      softwareVersions.put("neqsim", implementationVersion);
+    }
+    return NeqSimModelPackage.write(outputDirectory, identity, "engineering-model.json", "REVIEW_REQUIRED",
+        Collections.<ModelDependency>emptyList(), softwareVersions);
   }
 
   private static void write(Path file, String content) throws IOException {

--- a/src/main/java/neqsim/process/engineering/dexpi/EngineeringPackageManifest.java
+++ b/src/main/java/neqsim/process/engineering/dexpi/EngineeringPackageManifest.java
@@ -55,7 +55,7 @@ final class EngineeringPackageManifest {
       for (Path entry : stream) {
         if (Files.isDirectory(entry)) {
           collectFiles(entry, outputFile, result);
-        } else if (!entry.equals(outputFile)) {
+        } else if (!entry.equals(outputFile) && !"neqsim-model-package.json".equals(entry.getFileName().toString())) {
           result.add(entry);
         }
       }

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidationException.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringPackageValidationException.java
@@ -12,7 +12,7 @@ public final class EngineeringPackageValidationException extends IOException {
   public EngineeringPackageValidationException(Path validationReportFile,
       EngineeringPackageValidationReport validationReport) {
     super("Engineering package validation failed with " + validationReport.getErrorCount() + " error(s); see "
-        + validationReportFile);
+        + validationReportFile + summarize(validationReport));
     this.validationReportFile = validationReportFile;
     this.validationReport = validationReport;
   }
@@ -23,5 +23,15 @@ public final class EngineeringPackageValidationException extends IOException {
 
   public EngineeringPackageValidationReport getValidationReport() {
     return validationReport;
+  }
+
+  private static String summarize(EngineeringPackageValidationReport report) {
+    for (EngineeringPackageValidationReport.Finding finding : report.getFindings()) {
+      if (finding.getSeverity() == EngineeringPackageValidationReport.Severity.ERROR) {
+        return "; first error: " + finding.getCode() + " in " + finding.getArtifact() + finding.getPath() + " - "
+            + finding.getMessage();
+      }
+    }
+    return "";
   }
 }

--- a/src/main/java/neqsim/process/engineering/validation/EngineeringSchemaCatalog.java
+++ b/src/main/java/neqsim/process/engineering/validation/EngineeringSchemaCatalog.java
@@ -37,6 +37,7 @@ public final class EngineeringSchemaCatalog {
   public static final String DISCIPLINE_ORCHESTRATION = "neqsim_engineering_discipline_orchestration.v1";
   public static final String VERTICAL_SLICE_QUALIFICATION = "neqsim_engineering_vertical_slice_qualification.v1";
   public static final String VERTICAL_SLICE_EXECUTION_MANIFEST = "neqsim_engineering_vertical_slice_execution_manifest.v1";
+  public static final String MODEL_PACKAGE = "neqsim_model_package.v1";
 
   /** One immutable schema registration. */
   public static final class Definition {
@@ -118,6 +119,7 @@ public final class EngineeringSchemaCatalog {
         "engineering-vertical-slice-qualification.schema.json"));
     values.add(definition("engineering-vertical-slice-execution-manifest.json", VERTICAL_SLICE_EXECUTION_MANIFEST,
         "engineering-vertical-slice-execution-manifest.schema.json"));
+    values.add(definition("neqsim-model-package.json", MODEL_PACKAGE, "model-package-manifest.schema.json"));
     DEFINITIONS = Collections.unmodifiableList(values);
     Map<String, Definition> artifacts = new LinkedHashMap<String, Definition>();
     Map<String, Definition> versions = new LinkedHashMap<String, Definition>();

--- a/src/main/java/neqsim/process/modelpackage/ModelDependency.java
+++ b/src/main/java/neqsim/process/modelpackage/ModelDependency.java
@@ -1,0 +1,66 @@
+package neqsim.process.modelpackage;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Controlled dependency on another model revision or authoritative source. */
+public final class ModelDependency implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String modelId;
+  private final String revision;
+  private final String relationship;
+  private final String sourceSystem;
+  private final boolean required;
+
+  public ModelDependency(String modelId, String revision, String relationship, String sourceSystem, boolean required) {
+    this.modelId = requireText(modelId, "modelId");
+    this.revision = requireText(revision, "revision");
+    this.relationship = requireText(relationship, "relationship");
+    this.sourceSystem = requireText(sourceSystem, "sourceSystem");
+    this.required = required;
+  }
+
+  public String getModelId() {
+    return modelId;
+  }
+
+  public String getRevision() {
+    return revision;
+  }
+
+  public String getRelationship() {
+    return relationship;
+  }
+
+  public String getSourceSystem() {
+    return sourceSystem;
+  }
+
+  public boolean isRequired() {
+    return required;
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("modelId", modelId);
+    result.put("revision", revision);
+    result.put("relationship", relationship);
+    result.put("sourceSystem", sourceSystem);
+    result.put("required", Boolean.valueOf(required));
+    return result;
+  }
+
+  static ModelDependency fromMap(Map<String, Object> value) {
+    return new ModelDependency(String.valueOf(value.get("modelId")), String.valueOf(value.get("revision")),
+        String.valueOf(value.get("relationship")), String.valueOf(value.get("sourceSystem")),
+        Boolean.TRUE.equals(value.get("required")));
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/modelpackage/ModelPackageArtifact.java
+++ b/src/main/java/neqsim/process/modelpackage/ModelPackageArtifact.java
@@ -1,0 +1,78 @@
+package neqsim.process.modelpackage;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Immutable integrity and role metadata for one file in a model package. */
+public final class ModelPackageArtifact implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String path;
+  private final String role;
+  private final String mediaType;
+  private final long sizeBytes;
+  private final String sha256;
+
+  public ModelPackageArtifact(String path, String role, String mediaType, long sizeBytes, String sha256) {
+    this.path = requireText(path, "path");
+    this.role = requireText(role, "role");
+    this.mediaType = requireText(mediaType, "mediaType");
+    if (sizeBytes < 0L) {
+      throw new IllegalArgumentException("sizeBytes must not be negative");
+    }
+    this.sizeBytes = sizeBytes;
+    this.sha256 = requireHash(sha256);
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public String getRole() {
+    return role;
+  }
+
+  public String getMediaType() {
+    return mediaType;
+  }
+
+  public long getSizeBytes() {
+    return sizeBytes;
+  }
+
+  public String getSha256() {
+    return sha256;
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("path", path);
+    result.put("role", role);
+    result.put("mediaType", mediaType);
+    result.put("sizeBytes", Long.valueOf(sizeBytes));
+    result.put("sha256", sha256);
+    return result;
+  }
+
+  static ModelPackageArtifact fromMap(Map<String, Object> value) {
+    Object size = value.get("sizeBytes");
+    long sizeBytes = size instanceof Number ? ((Number) size).longValue() : Long.parseLong(String.valueOf(size));
+    return new ModelPackageArtifact(String.valueOf(value.get("path")), String.valueOf(value.get("role")),
+        String.valueOf(value.get("mediaType")), sizeBytes, String.valueOf(value.get("sha256")));
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static String requireHash(String value) {
+    String hash = requireText(value, "sha256").toLowerCase();
+    if (!hash.matches("[a-f0-9]{64}")) {
+      throw new IllegalArgumentException("sha256 must contain 64 lowercase hexadecimal characters");
+    }
+    return hash;
+  }
+}

--- a/src/main/java/neqsim/process/modelpackage/ModelPackageIdentity.java
+++ b/src/main/java/neqsim/process/modelpackage/ModelPackageIdentity.java
@@ -1,0 +1,101 @@
+package neqsim.process.modelpackage;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Stable asset, model, and revision identity carried by a NeqSim model package. */
+public final class ModelPackageIdentity implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String assetId;
+  private final String facilityId;
+  private final String modelId;
+  private final String modelType;
+  private final String revision;
+  private final String parentRevision;
+  private final String lifecyclePhase;
+  private final String responsibleParty;
+
+  public ModelPackageIdentity(String assetId, String facilityId, String modelId, String modelType, String revision,
+      String parentRevision, String lifecyclePhase, String responsibleParty) {
+    this.assetId = requireText(assetId, "assetId");
+    this.facilityId = text(facilityId);
+    this.modelId = requireText(modelId, "modelId");
+    this.modelType = requireText(modelType, "modelType");
+    this.revision = requireText(revision, "revision");
+    this.parentRevision = text(parentRevision);
+    this.lifecyclePhase = requireText(lifecyclePhase, "lifecyclePhase");
+    this.responsibleParty = text(responsibleParty);
+  }
+
+  public String getAssetId() {
+    return assetId;
+  }
+
+  public String getFacilityId() {
+    return facilityId;
+  }
+
+  public String getModelId() {
+    return modelId;
+  }
+
+  public String getModelType() {
+    return modelType;
+  }
+
+  public String getRevision() {
+    return revision;
+  }
+
+  public String getParentRevision() {
+    return parentRevision;
+  }
+
+  public String getLifecyclePhase() {
+    return lifecyclePhase;
+  }
+
+  public String getResponsibleParty() {
+    return responsibleParty;
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("assetId", assetId);
+    result.put("facilityId", facilityId);
+    result.put("modelId", modelId);
+    result.put("modelType", modelType);
+    result.put("revision", revision);
+    result.put("parentRevision", parentRevision);
+    result.put("lifecyclePhase", lifecyclePhase);
+    result.put("responsibleParty", responsibleParty);
+    return result;
+  }
+
+  static ModelPackageIdentity fromMap(Map<String, Object> value) {
+    if (value == null) {
+      throw new IllegalArgumentException("identity must not be null");
+    }
+    return new ModelPackageIdentity(string(value, "assetId"), string(value, "facilityId"), string(value, "modelId"),
+        string(value, "modelType"), string(value, "revision"), string(value, "parentRevision"),
+        string(value, "lifecyclePhase"), string(value, "responsibleParty"));
+  }
+
+  private static String string(Map<String, Object> value, String key) {
+    Object item = value.get(key);
+    return item == null ? "" : String.valueOf(item);
+  }
+
+  private static String requireText(String value, String field) {
+    String normalized = text(value);
+    if (normalized.isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return normalized;
+  }
+
+  private static String text(String value) {
+    return value == null ? "" : value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/modelpackage/ModelPackageValidator.java
+++ b/src/main/java/neqsim/process/modelpackage/ModelPackageValidator.java
@@ -1,0 +1,109 @@
+package neqsim.process.modelpackage;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Fail-closed structural and content-integrity validation for {@link NeqSimModelPackage}. */
+public final class ModelPackageValidator {
+  private ModelPackageValidator() {
+  }
+
+  public static Result validate(Path packageDirectory) throws IOException {
+    if (packageDirectory == null || !Files.isDirectory(packageDirectory)) {
+      throw new IllegalArgumentException("packageDirectory must be an existing directory");
+    }
+    Path manifest = packageDirectory.resolve(NeqSimModelPackage.FILE_NAME);
+    if (!Files.isRegularFile(manifest)) {
+      return new Result(Collections.singletonList("Missing " + NeqSimModelPackage.FILE_NAME));
+    }
+    NeqSimModelPackage value;
+    try {
+      value = NeqSimModelPackage.read(manifest);
+    } catch (RuntimeException ex) {
+      return new Result(Collections.singletonList("Invalid model-package manifest: " + ex.getMessage()));
+    }
+    List<String> findings = new ArrayList<String>();
+    Set<String> paths = new LinkedHashSet<String>();
+    for (ModelPackageArtifact artifact : value.getArtifacts()) {
+      String path = artifact.getPath();
+      if (!isSafeRelativePath(path)) {
+        findings.add("Unsafe artifact path " + path);
+        continue;
+      }
+      if (!paths.add(path)) {
+        findings.add("Duplicate artifact path " + path);
+        continue;
+      }
+      Path file = packageDirectory.resolve(path).normalize();
+      if (!file.startsWith(packageDirectory.normalize())) {
+        findings.add("Artifact escapes package directory " + path);
+      } else if (!Files.isRegularFile(file) || Files.isSymbolicLink(file)) {
+        findings.add("Missing or non-regular artifact " + path);
+      } else {
+        if (Files.size(file) != artifact.getSizeBytes()) {
+          findings.add("Artifact size mismatch " + path);
+        }
+        if (!NeqSimModelPackage.sha256(file).equals(artifact.getSha256())) {
+          findings.add("Artifact SHA-256 mismatch " + path);
+        }
+      }
+    }
+    NeqSimModelPackage current = NeqSimModelPackage.create(packageDirectory, value.getIdentity(),
+        value.getGraphArtifact(), value.getQualificationStatus(), value.getDependencies(), value.getSoftwareVersions());
+    for (ModelPackageArtifact artifact : current.getArtifacts()) {
+      if (!paths.contains(artifact.getPath())) {
+        findings.add("Uninventoried artifact " + artifact.getPath());
+      }
+    }
+    if (!paths.contains(value.getGraphArtifact())) {
+      findings.add("Canonical graph artifact is not inventoried: " + value.getGraphArtifact());
+    }
+    return new Result(findings);
+  }
+
+  private static boolean isSafeRelativePath(String value) {
+    if (value == null || value.trim().isEmpty() || value.startsWith("/") || value.startsWith("\\")
+        || value.indexOf('\0') >= 0 || value.matches("^[A-Za-z]:.*")) {
+      return false;
+    }
+    String normalized = value.replace('\\', '/');
+    return !normalized.equals("..") && !normalized.startsWith("../") && !normalized.contains("/../")
+        && !normalized.endsWith("/..");
+  }
+
+  /** Immutable validation decision. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final List<String> findings;
+
+    Result(List<String> findings) {
+      this.findings = new ArrayList<String>(findings);
+    }
+
+    public boolean isValid() {
+      return findings.isEmpty();
+    }
+
+    public List<String> getFindings() {
+      return Collections.unmodifiableList(findings);
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("valid", Boolean.valueOf(isValid()));
+      result.put("findings", new ArrayList<String>(findings));
+      result.put("fitnessForConstruction", Boolean.FALSE);
+      result.put("governance", "Model-package integrity validation is not engineering approval");
+      return result;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/modelpackage/NeqSimModelPackage.java
+++ b/src/main/java/neqsim/process/modelpackage/NeqSimModelPackage.java
@@ -1,0 +1,285 @@
+package neqsim.process.modelpackage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Portable, integrity-protected outer envelope for a NeqSim model and its governed artifacts.
+ *
+ * <p>
+ * The package records identity, revision, dependencies, qualification state, and SHA-256 content hashes. Integrity is
+ * not engineering approval; accountable decisions remain external controlled evidence.
+ * </p>
+ */
+public final class NeqSimModelPackage implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  public static final String FILE_NAME = "neqsim-model-package.json";
+  public static final String SCHEMA_VERSION = "neqsim_model_package.v1";
+  public static final String SCHEMA_URI = "urn:neqsim:schema:model-package-manifest:v1";
+  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+  private final ModelPackageIdentity identity;
+  private final String graphArtifact;
+  private final String qualificationStatus;
+  private final List<ModelPackageArtifact> artifacts;
+  private final List<ModelDependency> dependencies;
+  private final Map<String, String> softwareVersions;
+
+  private NeqSimModelPackage(ModelPackageIdentity identity, String graphArtifact, String qualificationStatus,
+      List<ModelPackageArtifact> artifacts, List<ModelDependency> dependencies, Map<String, String> softwareVersions) {
+    if (identity == null) {
+      throw new IllegalArgumentException("identity must not be null");
+    }
+    this.identity = identity;
+    this.graphArtifact = requireText(graphArtifact, "graphArtifact");
+    this.qualificationStatus = requireText(qualificationStatus, "qualificationStatus");
+    this.artifacts = new ArrayList<ModelPackageArtifact>(artifacts);
+    this.dependencies = new ArrayList<ModelDependency>(dependencies);
+    this.softwareVersions = new LinkedHashMap<String, String>(softwareVersions);
+  }
+
+  /** Creates an inventory of an existing model package directory. */
+  public static NeqSimModelPackage create(Path packageDirectory, ModelPackageIdentity identity, String graphArtifact,
+      String qualificationStatus, List<ModelDependency> dependencies, Map<String, String> softwareVersions)
+      throws IOException {
+    if (packageDirectory == null || !Files.isDirectory(packageDirectory)) {
+      throw new IllegalArgumentException("packageDirectory must be an existing directory");
+    }
+    List<ModelPackageArtifact> artifacts = inventory(packageDirectory);
+    List<ModelDependency> dependencyValues = dependencies == null ? Collections.<ModelDependency>emptyList()
+        : dependencies;
+    Map<String, String> software = softwareVersions == null ? Collections.<String, String>emptyMap() : softwareVersions;
+    return new NeqSimModelPackage(identity, graphArtifact, qualificationStatus, artifacts, dependencyValues, software);
+  }
+
+  /** Creates and writes {@value #FILE_NAME} into an existing package directory. */
+  public static Path write(Path packageDirectory, ModelPackageIdentity identity, String graphArtifact,
+      String qualificationStatus, List<ModelDependency> dependencies, Map<String, String> softwareVersions)
+      throws IOException {
+    NeqSimModelPackage value = create(packageDirectory, identity, graphArtifact, qualificationStatus, dependencies,
+        softwareVersions);
+    Path output = packageDirectory.resolve(FILE_NAME);
+    Files.write(output, value.toJson().getBytes(StandardCharsets.UTF_8));
+    return output;
+  }
+
+  /** Reads a model-package manifest. Content integrity is checked separately by {@link ModelPackageValidator}. */
+  public static NeqSimModelPackage read(Path manifestFile) throws IOException {
+    if (manifestFile == null || !Files.isRegularFile(manifestFile)) {
+      throw new IllegalArgumentException("manifestFile must be an existing regular file");
+    }
+    String json = new String(Files.readAllBytes(manifestFile), StandardCharsets.UTF_8);
+    Map<String, Object> root = GSON.fromJson(json, new TypeToken<Map<String, Object>>() {
+    }.getType());
+    if (root == null || !SCHEMA_VERSION.equals(String.valueOf(root.get("schemaVersion")))) {
+      throw new IllegalArgumentException("Unsupported NeqSim model-package schema version");
+    }
+    if (!SCHEMA_URI.equals(String.valueOf(root.get("schemaUri")))) {
+      throw new IllegalArgumentException("Unsupported NeqSim model-package schema URI");
+    }
+    ModelPackageIdentity identity = ModelPackageIdentity.fromMap(map(root.get("identity"), "identity"));
+    List<ModelPackageArtifact> artifacts = new ArrayList<ModelPackageArtifact>();
+    for (Map<String, Object> item : maps(root.get("artifacts"), "artifacts")) {
+      artifacts.add(ModelPackageArtifact.fromMap(item));
+    }
+    List<ModelDependency> dependencies = new ArrayList<ModelDependency>();
+    for (Map<String, Object> item : maps(root.get("dependencies"), "dependencies")) {
+      dependencies.add(ModelDependency.fromMap(item));
+    }
+    Map<String, String> softwareVersions = new LinkedHashMap<String, String>();
+    for (Map.Entry<String, Object> entry : map(root.get("softwareVersions"), "softwareVersions").entrySet()) {
+      softwareVersions.put(entry.getKey(), String.valueOf(entry.getValue()));
+    }
+    return new NeqSimModelPackage(identity, String.valueOf(root.get("graphArtifact")),
+        String.valueOf(root.get("qualificationStatus")), artifacts, dependencies, softwareVersions);
+  }
+
+  public ModelPackageIdentity getIdentity() {
+    return identity;
+  }
+
+  public String getGraphArtifact() {
+    return graphArtifact;
+  }
+
+  public String getQualificationStatus() {
+    return qualificationStatus;
+  }
+
+  public List<ModelPackageArtifact> getArtifacts() {
+    return Collections.unmodifiableList(artifacts);
+  }
+
+  public List<ModelDependency> getDependencies() {
+    return Collections.unmodifiableList(dependencies);
+  }
+
+  public Map<String, String> getSoftwareVersions() {
+    return Collections.unmodifiableMap(softwareVersions);
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", SCHEMA_VERSION);
+    result.put("schemaUri", SCHEMA_URI);
+    result.put("identity", identity.toMap());
+    result.put("graphArtifact", graphArtifact);
+    result.put("qualificationStatus", qualificationStatus);
+    List<Map<String, Object>> artifactMaps = new ArrayList<Map<String, Object>>();
+    for (ModelPackageArtifact artifact : artifacts) {
+      artifactMaps.add(artifact.toMap());
+    }
+    result.put("artifacts", artifactMaps);
+    List<Map<String, Object>> dependencyMaps = new ArrayList<Map<String, Object>>();
+    for (ModelDependency dependency : dependencies) {
+      dependencyMaps.add(dependency.toMap());
+    }
+    result.put("dependencies", dependencyMaps);
+    result.put("softwareVersions", new LinkedHashMap<String, String>(softwareVersions));
+    result.put("governance",
+        "Integrity and qualification metadata do not grant engineering approval or fitness for construction");
+    return result;
+  }
+
+  public String toJson() {
+    return GSON.toJson(toMap());
+  }
+
+  private static List<ModelPackageArtifact> inventory(final Path packageDirectory) throws IOException {
+    List<Path> files = new ArrayList<Path>();
+    collect(packageDirectory, packageDirectory, files);
+    Collections.sort(files, new Comparator<Path>() {
+      @Override
+      public int compare(Path left, Path right) {
+        return relative(packageDirectory, left).compareTo(relative(packageDirectory, right));
+      }
+    });
+    List<ModelPackageArtifact> result = new ArrayList<ModelPackageArtifact>();
+    Set<String> paths = new LinkedHashSet<String>();
+    for (Path file : files) {
+      String relativePath = relative(packageDirectory, file);
+      if (!paths.add(relativePath)) {
+        throw new IOException("Duplicate model-package artifact " + relativePath);
+      }
+      result.add(new ModelPackageArtifact(relativePath, role(relativePath), mediaType(relativePath), Files.size(file),
+          sha256(file)));
+    }
+    return result;
+  }
+
+  private static void collect(Path root, Path directory, List<Path> result) throws IOException {
+    try (java.nio.file.DirectoryStream<Path> stream = Files.newDirectoryStream(directory)) {
+      for (Path entry : stream) {
+        if (Files.isSymbolicLink(entry)) {
+          throw new IOException("Symbolic links are not permitted in a model package: " + relative(root, entry));
+        }
+        if (Files.isDirectory(entry)) {
+          collect(root, entry, result);
+        } else if (Files.isRegularFile(entry) && !FILE_NAME.equals(entry.getFileName().toString())) {
+          result.add(entry);
+        }
+      }
+    }
+  }
+
+  static String sha256(Path file) throws IOException {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] buffer = new byte[8192];
+      try (InputStream input = Files.newInputStream(file)) {
+        int count;
+        while ((count = input.read(buffer)) >= 0) {
+          if (count > 0) {
+            digest.update(buffer, 0, count);
+          }
+        }
+      }
+      StringBuilder result = new StringBuilder();
+      for (byte value : digest.digest()) {
+        result.append(String.format("%02x", Integer.valueOf(value & 0xff)));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is not available", ex);
+    }
+  }
+
+  static String relative(Path root, Path file) {
+    return root.relativize(file).toString().replace('\\', '/');
+  }
+
+  private static String role(String path) {
+    if ("engineering-model.json".equals(path)) {
+      return "CANONICAL_GRAPH";
+    }
+    if (path.startsWith("schemas/")) {
+      return "SCHEMA";
+    }
+    if (path.endsWith(".dexpi.xml") || path.endsWith("-proteus.xml") || path.endsWith("-pydexpi.xml")) {
+      return "EXCHANGE_MODEL";
+    }
+    if (path.endsWith(".json") || path.endsWith(".csv")) {
+      return "ENGINEERING_ARTIFACT";
+    }
+    return "SUPPORTING_ARTIFACT";
+  }
+
+  private static String mediaType(String path) {
+    if (path.endsWith(".json")) {
+      return "application/json";
+    }
+    if (path.endsWith(".xml")) {
+      return "application/xml";
+    }
+    if (path.endsWith(".csv")) {
+      return "text/csv";
+    }
+    if (path.endsWith(".md")) {
+      return "text/markdown";
+    }
+    return "application/octet-stream";
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> map(Object value, String field) {
+    if (!(value instanceof Map)) {
+      throw new IllegalArgumentException(field + " must be an object");
+    }
+    return (Map<String, Object>) value;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> maps(Object value, String field) {
+    if (!(value instanceof List)) {
+      throw new IllegalArgumentException(field + " must be an array");
+    }
+    List<Map<String, Object>> result = new ArrayList<Map<String, Object>>();
+    for (Object item : (List<Object>) value) {
+      result.add(map(item, field + " item"));
+    }
+    return result;
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/modelpackage/package-info.java
+++ b/src/main/java/neqsim/process/modelpackage/package-info.java
@@ -1,0 +1,2 @@
+/** Portable identity, revision, dependency, and integrity contracts for governed NeqSim model packages. */
+package neqsim.process.modelpackage;

--- a/src/main/resources/neqsim/process/engineering/schema/model-package-manifest.schema.json
+++ b/src/main/resources/neqsim/process/engineering/schema/model-package-manifest.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:neqsim:schema:model-package-manifest:v1",
+  "title": "NeqSim governed model package manifest",
+  "type": "object",
+  "required": ["schemaVersion", "schemaUri", "identity", "graphArtifact", "qualificationStatus", "artifacts", "dependencies", "softwareVersions", "governance"],
+  "properties": {
+    "schemaVersion": {"const": "neqsim_model_package.v1"},
+    "schemaUri": {"const": "urn:neqsim:schema:model-package-manifest:v1"},
+    "identity": {
+      "type": "object",
+      "required": ["assetId", "facilityId", "modelId", "modelType", "revision", "parentRevision", "lifecyclePhase", "responsibleParty"],
+      "properties": {
+        "assetId": {"type": "string", "minLength": 1},
+        "facilityId": {"type": "string"},
+        "modelId": {"type": "string", "minLength": 1},
+        "modelType": {"type": "string", "minLength": 1},
+        "revision": {"type": "string", "minLength": 1},
+        "parentRevision": {"type": "string"},
+        "lifecyclePhase": {"type": "string", "minLength": 1},
+        "responsibleParty": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "graphArtifact": {"type": "string", "minLength": 1},
+    "qualificationStatus": {"type": "string", "minLength": 1},
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["path", "role", "mediaType", "sizeBytes", "sha256"],
+        "properties": {
+          "path": {"type": "string", "minLength": 1},
+          "role": {"type": "string", "minLength": 1},
+          "mediaType": {"type": "string", "minLength": 1},
+          "sizeBytes": {"type": "integer", "minimum": 0},
+          "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["modelId", "revision", "relationship", "sourceSystem", "required"],
+        "properties": {
+          "modelId": {"type": "string", "minLength": 1},
+          "revision": {"type": "string", "minLength": 1},
+          "relationship": {"type": "string", "minLength": 1},
+          "sourceSystem": {"type": "string", "minLength": 1},
+          "required": {"type": "boolean"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "softwareVersions": {"type": "object", "additionalProperties": {"type": "string"}},
+    "governance": {"type": "string", "minLength": 1}
+  },
+  "additionalProperties": false
+}

--- a/src/test/java/neqsim/process/engineering/EngineeringCompilerFoundationTest.java
+++ b/src/test/java/neqsim/process/engineering/EngineeringCompilerFoundationTest.java
@@ -37,6 +37,7 @@ import neqsim.process.engineering.validation.EngineeringTopologyValidator;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.measurementdevice.PressureTransmitter;
+import neqsim.process.modelpackage.ModelPackageValidator;
 import neqsim.process.processmodel.ProcessConnection;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemInterface;
@@ -76,6 +77,7 @@ class EngineeringCompilerFoundationTest extends NeqSimTest {
     assertTrue(Files.isRegularFile(result.getLineRegisterFile()));
     assertTrue(Files.isRegularFile(result.getInstrumentRegisterFile()));
     assertTrue(Files.isRegularFile(result.getValidationReportFile()));
+    assertTrue(Files.isRegularFile(result.getModelPackageFile()));
     assertTrue(Files.isRegularFile(temporaryDirectory.resolve("engineering-schema-catalog.json")));
     assertTrue(Files.isRegularFile(temporaryDirectory.resolve("schemas/engineering-model.schema.json")));
     assertTrue(Files.isRegularFile(result.getDexpiResult().getDexpi20File()));
@@ -97,6 +99,7 @@ class EngineeringCompilerFoundationTest extends NeqSimTest {
     assertTrue(read(result.getEngineeringAutomationPlanFile()).contains("REQUIRED_PROCESS_SYSTEM_COPY"));
     assertTrue(result.getValidationReport().isValid());
     assertTrue(EngineeringPackageValidator.validatePackage(temporaryDirectory).isValid());
+    assertTrue(ModelPackageValidator.validate(temporaryDirectory).isValid());
     assertNotNull(result.getEngineeringGraph().getNode("calculation:envelope-20-vg-001-pressure"));
     assertNotNull(
         result.getEngineeringGraph().getNode(EngineeringIds.nodeId(EngineeringNode.Kind.PORT, "20-FEED-001.outlet")));

--- a/src/test/java/neqsim/process/modelpackage/NeqSimModelPackageTest.java
+++ b/src/test/java/neqsim/process/modelpackage/NeqSimModelPackageTest.java
@@ -1,0 +1,73 @@
+package neqsim.process.modelpackage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class NeqSimModelPackageTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void writesReadsAndValidatesDeterministicPackage() throws Exception {
+    Files.write(temporaryDirectory.resolve("engineering-model.json"),
+        "{\"graph\":true}".getBytes(StandardCharsets.UTF_8));
+    Files.write(temporaryDirectory.resolve("calculation.json"), "{\"value\":42}".getBytes(StandardCharsets.UTF_8));
+    ModelPackageIdentity identity = new ModelPackageIdentity("ASSET-A", "FACILITY-A", "MODEL-A",
+        "ENGINEERING_PROCESS_MODEL", "B", "A", "DESIGN", "PROCESS-TEAM");
+    Map<String, String> software = new LinkedHashMap<String, String>();
+    software.put("neqsim", "3.16.0");
+
+    Path manifest = NeqSimModelPackage.write(temporaryDirectory, identity, "engineering-model.json", "REVIEW_REQUIRED",
+        Collections.singletonList(new ModelDependency("P_AND_ID", "17", "SYNCHRONIZED_FROM", "DEXPI", true)), software);
+    String first = new String(Files.readAllBytes(manifest), StandardCharsets.UTF_8);
+    NeqSimModelPackage.write(temporaryDirectory, identity, "engineering-model.json", "REVIEW_REQUIRED",
+        Collections.singletonList(new ModelDependency("P_AND_ID", "17", "SYNCHRONIZED_FROM", "DEXPI", true)), software);
+
+    assertEquals(first, new String(Files.readAllBytes(manifest), StandardCharsets.UTF_8));
+    NeqSimModelPackage reloaded = NeqSimModelPackage.read(manifest);
+    assertEquals("MODEL-A", reloaded.getIdentity().getModelId());
+    assertEquals(2, reloaded.getArtifacts().size());
+    assertTrue(ModelPackageValidator.validate(temporaryDirectory).isValid());
+  }
+
+  @Test
+  void failsClosedWhenInventoriedContentChanges() throws Exception {
+    Path graph = temporaryDirectory.resolve("engineering-model.json");
+    Files.write(graph, "revision-a".getBytes(StandardCharsets.UTF_8));
+    ModelPackageIdentity identity = new ModelPackageIdentity("ASSET-A", "", "MODEL-A", "PROCESS", "A", "", "DESIGN",
+        "");
+    NeqSimModelPackage.write(temporaryDirectory, identity, "engineering-model.json", "REVIEW_REQUIRED",
+        Collections.<ModelDependency>emptyList(), Collections.<String, String>emptyMap());
+
+    Files.write(graph, "revision-b".getBytes(StandardCharsets.UTF_8));
+    ModelPackageValidator.Result result = ModelPackageValidator.validate(temporaryDirectory);
+
+    assertFalse(result.isValid());
+    assertTrue(result.getFindings().toString().contains("mismatch"));
+    assertEquals(Boolean.FALSE, result.toMap().get("fitnessForConstruction"));
+  }
+
+  @Test
+  void failsClosedWhenAnArtifactIsAddedAfterPackaging() throws Exception {
+    Files.write(temporaryDirectory.resolve("engineering-model.json"), "revision-a".getBytes(StandardCharsets.UTF_8));
+    ModelPackageIdentity identity = new ModelPackageIdentity("ASSET-A", "", "MODEL-A", "PROCESS", "A", "", "DESIGN",
+        "");
+    NeqSimModelPackage.write(temporaryDirectory, identity, "engineering-model.json", "REVIEW_REQUIRED",
+        Collections.<ModelDependency>emptyList(), Collections.<String, String>emptyMap());
+
+    Files.write(temporaryDirectory.resolve("untracked.json"), "{}".getBytes(StandardCharsets.UTF_8));
+    ModelPackageValidator.Result result = ModelPackageValidator.validate(temporaryDirectory);
+
+    assertFalse(result.isValid());
+    assertTrue(result.getFindings().toString().contains("Uninventoried artifact untracked.json"));
+  }
+}


### PR DESCRIPTION
## Summary

Introduces `NeqSimModelPackage v1`, a portable, deterministic envelope for model identity, revisions, dependencies, software versions, and artifact integrity.

## Scope

- stable asset/model/revision/lifecycle identity
- deterministic recursive artifact inventory with SHA-256 and byte sizes
- fail-closed validation for missing, changed, extra, unsafe, or symlinked artifacts
- versioned JSON schema and engineering schema-catalog registration
- engineering compiler emission and final package-integrity verification
- avoids circular hashing with the inner DEXPI manifest
- explicitly separates integrity/qualification metadata from engineering approval
- aligns nullable compiler output with the existing validation contract and improves validation diagnostics

## Validation

- `EngineeringCompilerFoundationTest`
- `NeqSimModelPackageTest`
- full focused stack: 15 tests, 0 failures
- `spotless:check`
- `git diff --check`

## Governance boundary

A valid package proves identity and content integrity. It does not grant engineering approval or fitness for construction.

## Stack

PR 2 of 4. Depends on PR 1 and targets `agent/repository-governance`. PR 3 is stacked on this branch.