### PR TITLE
Export and render governed complete P&ID proposals

### DIFF
--- a/.github/workflows/execute-complete-pid-notebook.yml
+++ b/.github/workflows/execute-complete-pid-notebook.yml
@@ -1,0 +1,88 @@
+name: Execute complete P&ID synthesis notebook
+
+on:
+  pull_request:
+    paths:
+      - "examples/notebooks/complete_pid_design_synthesis.ipynb"
+      - "src/main/java/neqsim/process/engineering/pid/**"
+      - "src/test/java/neqsim/process/engineering/pid/**"
+      - ".github/workflows/execute-complete-pid-notebook.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  execute-notebook:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build workspace classes
+        run: ./mvnw -Dmaven.test.skip=true package
+
+      - name: Check Java formatting and focused P&ID tests
+        run: |
+          ./mvnw spotless:check
+          ./mvnw -Dtest='PidDesignModelTest,ControlInstrumentationPidSynthesisTest,SafeguardingPidSynthesisTest,PidCompletenessAndDexpiTest' test
+
+      - name: Install notebook and independent DEXPI runtime
+        run: python -m pip install --upgrade nbconvert nbclient nbformat ipykernel jpype1 pydexpi==1.2.0
+
+      - name: Execute notebook
+        env:
+          MPLBACKEND: Agg
+          NEQSIM_PROJECT_ROOT: ${{ github.workspace }}
+        run: |
+          mkdir -p build/executed-notebooks
+          python -m jupyter nbconvert \
+            --to notebook \
+            --execute examples/notebooks/complete_pid_design_synthesis.ipynb \
+            --ExecutePreprocessor.timeout=2700 \
+            --ExecutePreprocessor.kernel_name=python3 \
+            --output complete_pid_design_synthesis.ipynb \
+            --output-dir build/executed-notebooks
+
+      - name: Verify generated P&ID package
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          notebook = json.loads(Path("build/executed-notebooks/complete_pid_design_synthesis.ipynb").read_text(encoding="utf-8"))
+          code = [cell for cell in notebook["cells"] if cell["cell_type"] == "code"]
+          assert code and all(cell.get("execution_count") is not None for cell in code)
+          assert not any(output.get("output_type") == "error" for cell in code for output in cell.get("outputs", []))
+          package = Path("build/complete-pid-design-synthesis")
+          for name in ("plant.dexpi.xml", "plant-proteus.xml", "plant-pydexpi.xml",
+                       "pid-design-model.json", "pid-completeness-report.json",
+                       "complete-pid-pydexpi.svg", "pydexpi-render-report.json"):
+              assert (package / name).is_file(), name
+          proposal = json.loads((package / "pid-design-model.json").read_text(encoding="utf-8"))
+          completeness = json.loads((package / "pid-completeness-report.json").read_text(encoding="utf-8"))
+          render = json.loads((package / "pydexpi-render-report.json").read_text(encoding="utf-8"))
+          assert len(proposal["elements"]) >= 50
+          assert completeness["structurallyComplete"] is True
+          assert completeness["readyForApproval"] is False
+          assert render["status"] == "IMPORT_AND_RENDER_PASSED"
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: complete-pid-notebook-and-package
+          path: |
+            build/executed-notebooks/complete_pid_design_synthesis.ipynb
+            build/complete-pid-design-synthesis
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/pid-design-synthesis.md
+++ b/docs/pid-design-synthesis.md
@@ -1,0 +1,34 @@
+# Governed P&ID design synthesis
+
+NeqSim can generate a reviewable P&ID proposal from the same engineering project that owns the
+process simulation, requirements, relief studies and DEXPI export. The generator deliberately does
+not claim that an automatically produced drawing is approved or fit for construction.
+
+```java
+PidDesignModel pid = PidDesignSynthesizer.synthesize(project,
+    new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"),
+    NorsokPidRuleCatalog.completeProposals());
+
+PidCompletenessReport completeness = PidCompletenessValidator.validate(pid);
+PidEngineeringPackageExporter.ExportResult exported =
+    PidEngineeringPackageExporter.export(project, pid, outputDirectory);
+```
+
+The complete proposal profile covers measurements, controllers, control valves, alarms, trips,
+shutdown and isolation valves, non-return valves, blowdown, drains, vents and relief devices where
+an overpressure study exists. Every proposal retains its source rule, engineering rationale,
+standards, requirement IDs and graph connections.
+
+The package contains the native DEXPI document, Proteus and PyDEXPI exchange documents,
+`pid-design-model.json` and `pid-completeness-report.json`. Missing proposal tags are materialized as
+DEXPI instrumentation functions so an independent PyDEXPI import and render visibly exercises the
+generated design. The sidecars preserve details that a P&ID exchange profile cannot represent
+losslessly.
+
+`structurallyComplete` means that references and minimum functional categories passed automated
+checks. `readyForApproval` remains false until discipline and HAZOP/LOPA review findings are closed.
+`fitnessForConstruction` is always false for generated proposals.
+
+The executable notebook and its generated package are retained as GitHub Actions artifacts for
+independent review.
+The CI contract also runs Spotless and the focused P&ID test suite before rendering.

--- a/examples/notebooks/complete_pid_design_synthesis.ipynb
+++ b/examples/notebooks/complete_pid_design_synthesis.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Complete governed P&ID proposal\n",
+    "\n",
+    "This example turns a simulated separator, compressor, cooler and pump into a governed P&ID proposal. It exports DEXPI and sidecars, independently imports the exchange file with PyDEXPI, and renders the generated instrumentation and safeguarding. Generated objects remain review-required and are not fit for construction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json, os, shutil, sys\n",
+    "from pathlib import Path\n",
+    "ROOT = Path(os.environ.get('NEQSIM_PROJECT_ROOT', Path.cwd())).resolve()\n",
+    "while not (ROOT / 'pom.xml').exists(): ROOT = ROOT.parent\n",
+    "sys.path.insert(0, str(ROOT / 'devtools'))\n",
+    "from neqsim_dev_setup import neqsim_init, neqsim_classes\n",
+    "ns = neqsim_classes(neqsim_init(project_root=ROOT, recompile=False, verbose=False))\n",
+    "J = ns.JClass\n",
+    "output = ROOT / 'build' / 'complete-pid-design-synthesis'\n",
+    "shutil.rmtree(output, ignore_errors=True); output.mkdir(parents=True)\n",
+    "print('Output directory:', output)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fluid = J('neqsim.thermo.system.SystemSrkEos')(298.15, 60.0)\n",
+    "fluid.addComponent('methane', 0.90); fluid.addComponent('n-heptane', 0.10)\n",
+    "feed = J('neqsim.process.equipment.stream.Stream')('20-FEED-001', fluid)\n",
+    "separator = J('neqsim.process.equipment.separator.Separator')('20-VG-001', feed)\n",
+    "compressor = J('neqsim.process.equipment.compressor.Compressor')('20-KA-001', separator.getGasOutStream())\n",
+    "cooler = J('neqsim.process.equipment.heatexchanger.Cooler')('20-HA-001', compressor.getOutletStream())\n",
+    "pump = J('neqsim.process.equipment.pump.Pump')('20-PA-001', separator.getLiquidOutStream())\n",
+    "process = J('neqsim.process.processmodel.ProcessSystem')()\n",
+    "for item in (feed, separator, compressor, cooler, pump): process.add(item)\n",
+    "project = J('neqsim.process.engineering.NorsokOffshoreEngineeringBuilder').from_('Complete P&ID proposal', process).projectId('PID-NOTEBOOK').registerProposedInstruments(True).build()\n",
+    "ProtectedItem = J('neqsim.process.safety.overpressure.ProtectedItem')\n",
+    "ReliefScenario = J('neqsim.process.safety.overpressure.ReliefScenario')\n",
+    "cause = J('neqsim.process.safety.overpressure.ReliefCause').BLOCKED_OUTLET\n",
+    "phase = J('neqsim.process.safety.overpressure.ReliefPhase').VAPOUR\n",
+    "scenario = ReliefScenario.Builder('Blocked outlet', cause).phase(phase).reliefRateKgPerS(3.0).reliefTemperatureK(330.0).molarMassKgPerMol(0.020).compressibility(0.95).specificHeatRatio(1.25).build()\n",
+    "study = J('neqsim.process.safety.overpressure.OverpressureProtectionStudy')(ProtectedItem('20-VG-001', 70.0).setReliefSetPressureBara(68.0)).addScenario(scenario)\n",
+    "project.addOverpressureStudy(study)\n",
+    "print('Process equipment:', process.getUnitOperations().size())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basis = J('neqsim.process.engineering.pid.PidDesignBasis')('NORSOK-COMPLETE-PID-PROPOSALS', '20')\n",
+    "catalog = J('neqsim.process.engineering.pid.NorsokPidRuleCatalog').completeProposals()\n",
+    "model = J('neqsim.process.engineering.pid.PidDesignSynthesizer').synthesize(project, basis, catalog)\n",
+    "report = J('neqsim.process.engineering.pid.PidCompletenessValidator').validate(model)\n",
+    "Paths = J('java.nio.file.Paths')\n",
+    "exported = J('neqsim.process.engineering.pid.PidEngineeringPackageExporter').export(project, model, Paths.get(str(output)))\n",
+    "counts = {}\n",
+    "for element in model.getElements(): counts[str(element.getType())] = counts.get(str(element.getType()), 0) + 1\n",
+    "print('Generated proposals:', model.getElements().size(), counts)\n",
+    "print('Structurally complete:', report.isStructurallyComplete(), '| ready for approval:', report.isReadyForApproval())\n",
+    "print('Sidecars:', exported.getDesignModelFile(), exported.getCompletenessReportFile())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydexpi.loaders import ProteusSerializer\n",
+    "from pydexpi.loaders.svg_loader import DrawDiagram\n",
+    "from IPython.display import SVG, display\n",
+    "model_from_dexpi = ProteusSerializer().load(str(output), 'plant-pydexpi.xml')\n",
+    "assert model_from_dexpi.diagram is not None\n",
+    "DrawDiagram(model_from_dexpi.diagram, padding=5.0, pretty=True).save_svg('complete-pid-pydexpi', str(output))\n",
+    "svg = output / 'complete-pid-pydexpi.svg'\n",
+    "render_report = {'status': 'IMPORT_AND_RENDER_PASSED', 'source': 'plant-pydexpi.xml', 'rendered': svg.name, 'fitnessForConstruction': False}\n",
+    "(output / 'pydexpi-render-report.json').write_text(json.dumps(render_report, indent=2) + '\\n', encoding='utf-8')\n",
+    "display(SVG(filename=str(svg)))\n",
+    "print(render_report)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.12"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/main/java/neqsim/process/engineering/pid/NorsokPidRuleCatalog.java
+++ b/src/main/java/neqsim/process/engineering/pid/NorsokPidRuleCatalog.java
@@ -18,19 +18,19 @@ public final class NorsokPidRuleCatalog {
   /**
    * Returns the control and field-instrumentation proposal profile.
    *
-   * <p>The profile proposes conventional ISA-style loops. Set points, ranges, failure actions,
-   * installation details and control narratives remain review-required project inputs.</p>
+   * <p>
+   * The profile proposes conventional ISA-style loops. Set points, ranges, failure actions, installation details and
+   * control narratives remain review-required project inputs.
+   * </p>
    */
   public static PidRuleCatalog controlAndInstrumentation() {
-    return new PidRuleCatalog().add(new SeparatorControlPidRule())
-        .add(new CompressorControlPidRule()).add(new ThermalControlPidRule())
-        .add(new PumpControlPidRule());
+    return new PidRuleCatalog().add(new SeparatorControlPidRule()).add(new CompressorControlPidRule())
+        .add(new ThermalControlPidRule()).add(new PumpControlPidRule());
   }
 
   /** Returns the complete control, instrumentation, isolation and safeguarding proposal profile. */
   public static PidRuleCatalog completeProposals() {
-    return controlAndInstrumentation().add(new SeparatorSafeguardingPidRule())
-        .add(new CompressorSafeguardingPidRule()).add(new PumpSafeguardingPidRule())
-        .add(new ThermalSafeguardingPidRule()).add(new PressureReliefPidRule());
+    return controlAndInstrumentation().add(new SeparatorSafeguardingPidRule()).add(new CompressorSafeguardingPidRule())
+        .add(new PumpSafeguardingPidRule()).add(new ThermalSafeguardingPidRule()).add(new PressureReliefPidRule());
   }
 }

--- a/src/main/java/neqsim/process/engineering/pid/PidCompletenessFinding.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidCompletenessFinding.java
@@ -1,0 +1,40 @@
+package neqsim.process.engineering.pid;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** One actionable result from validating a generated P&amp;ID design model. */
+public final class PidCompletenessFinding implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Finding severity. */
+  public enum Severity {
+    ERROR, REVIEW, WARNING, INFORMATION
+  }
+
+  private final String code;
+  private final Severity severity;
+  private final String subject;
+  private final String message;
+
+  public PidCompletenessFinding(String code, Severity severity, String subject, String message) {
+    this.code = code;
+    this.severity = severity;
+    this.subject = subject;
+    this.message = message;
+  }
+
+  public Severity getSeverity() {
+    return severity;
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> value = new LinkedHashMap<String, Object>();
+    value.put("code", code);
+    value.put("severity", severity.name());
+    value.put("subject", subject);
+    value.put("message", message);
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/pid/PidCompletenessReport.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidCompletenessReport.java
@@ -1,0 +1,64 @@
+package neqsim.process.engineering.pid;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.GsonBuilder;
+
+/** Machine-readable structural and governance assessment of a P&amp;ID design model. */
+public final class PidCompletenessReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String projectId;
+  private final int elementCount;
+  private final List<PidCompletenessFinding> findings;
+
+  PidCompletenessReport(String projectId, int elementCount, List<PidCompletenessFinding> findings) {
+    this.projectId = projectId;
+    this.elementCount = elementCount;
+    this.findings = new ArrayList<PidCompletenessFinding>(findings);
+  }
+
+  public boolean isStructurallyComplete() {
+    return !hasSeverity(PidCompletenessFinding.Severity.ERROR);
+  }
+
+  public boolean isReadyForApproval() {
+    return isStructurallyComplete() && !hasSeverity(PidCompletenessFinding.Severity.REVIEW);
+  }
+
+  private boolean hasSeverity(PidCompletenessFinding.Severity severity) {
+    for (PidCompletenessFinding finding : findings) {
+      if (finding.getSeverity() == severity) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public List<PidCompletenessFinding> getFindings() {
+    return Collections.unmodifiableList(findings);
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> value = new LinkedHashMap<String, Object>();
+    List<Map<String, Object>> serialized = new ArrayList<Map<String, Object>>();
+    for (PidCompletenessFinding finding : findings) {
+      serialized.add(finding.toMap());
+    }
+    value.put("schemaVersion", "neqsim_pid_completeness.v1");
+    value.put("projectId", projectId);
+    value.put("elementCount", Integer.valueOf(elementCount));
+    value.put("structurallyComplete", Boolean.valueOf(isStructurallyComplete()));
+    value.put("readyForApproval", Boolean.valueOf(isReadyForApproval()));
+    value.put("fitnessForConstruction", Boolean.FALSE);
+    value.put("findings", serialized);
+    return value;
+  }
+
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create().toJson(toMap());
+  }
+}

--- a/src/main/java/neqsim/process/engineering/pid/PidCompletenessValidator.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidCompletenessValidator.java
@@ -1,0 +1,58 @@
+package neqsim.process.engineering.pid;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Validates references, minimum coverage and approval gates for generated P&amp;ID proposals. */
+public final class PidCompletenessValidator {
+  private PidCompletenessValidator() {
+  }
+
+  public static PidCompletenessReport validate(PidDesignModel model) {
+    if (model == null) {
+      throw new IllegalArgumentException("model must not be null");
+    }
+    List<PidCompletenessFinding> findings = new ArrayList<PidCompletenessFinding>();
+    Set<String> ids = new LinkedHashSet<String>();
+    for (PidElement element : model.getElements()) {
+      ids.add(element.getId());
+    }
+    for (PidElement element : model.getElements()) {
+      for (String connectedId : element.getConnectedElementIds()) {
+        if (!ids.contains(connectedId)) {
+          findings.add(new PidCompletenessFinding("PID-REFERENCE-MISSING", PidCompletenessFinding.Severity.ERROR,
+              element.getTag(), "Connected proposal " + connectedId + " does not exist in the design model."));
+        }
+      }
+    }
+    requireType(model, PidElementType.MEASUREMENT, findings);
+    requireType(model, PidElementType.CONTROLLER, findings);
+    requireType(model, PidElementType.CONTROL_VALVE, findings);
+    requireType(model, PidElementType.TRIP, findings);
+    requireType(model, PidElementType.SHUTDOWN_VALVE, findings);
+    if (!model.getElementsByType(PidElementType.SAFETY_RELIEF_VALVE).isEmpty()) {
+      for (PidElement relief : model.getElementsByType(PidElementType.SAFETY_RELIEF_VALVE)) {
+        if (!relief.getAttributes().containsKey("scenarioCount")) {
+          findings.add(new PidCompletenessFinding("PID-RELIEF-EVIDENCE-MISSING", PidCompletenessFinding.Severity.ERROR,
+              relief.getTag(), "Relief proposal has no linked overpressure scenario evidence."));
+        }
+      }
+    }
+    findings.add(new PidCompletenessFinding("PID-DISCIPLINE-APPROVAL-REQUIRED", PidCompletenessFinding.Severity.REVIEW,
+        model.getProjectId(),
+        "Generated proposals require process, control, technical-safety and operations approval."));
+    findings.add(new PidCompletenessFinding("PID-HAZOP-LOPA-REQUIRED", PidCompletenessFinding.Severity.REVIEW,
+        model.getProjectId(),
+        "Trip set points, voting, SIL targets and valve failure positions require HAZOP/LOPA review."));
+    return new PidCompletenessReport(model.getProjectId(), model.getElements().size(), findings);
+  }
+
+  private static void requireType(PidDesignModel model, PidElementType type, List<PidCompletenessFinding> findings) {
+    if (model.getElementsByType(type).isEmpty()) {
+      findings.add(new PidCompletenessFinding("PID-COVERAGE-" + type.name(), PidCompletenessFinding.Severity.ERROR,
+          model.getProjectId(), "Complete proposal profile contains no " + type.name() + " element."));
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/pid/PidDesignModel.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidDesignModel.java
@@ -88,4 +88,8 @@ public final class PidDesignModel implements Serializable {
   public String getProjectId() {
     return projectId;
   }
+
+  public String getProfileId() {
+    return profileId;
+  }
 }

--- a/src/main/java/neqsim/process/engineering/pid/PidDexpiMaterializer.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidDexpiMaterializer.java
@@ -1,0 +1,189 @@
+package neqsim.process.engineering.pid;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/** Adds governed proposal objects and traceability attributes to a Proteus DEXPI document. */
+public final class PidDexpiMaterializer {
+  private PidDexpiMaterializer() {
+  }
+
+  public static void materialize(PidDesignModel model, Path dexpiFile) throws IOException {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      Document document = factory.newDocumentBuilder().parse(dexpiFile.toFile());
+      Element root = document.getDocumentElement();
+      Set<String> existingTags = existingTags(document);
+      appendPackageMetadata(document, root, model);
+      Element proposalPipingSystem = createProposalPipingSystem(document);
+      int index = 0;
+      for (PidElement proposal : model.getElements()) {
+        if (!existingTags.contains(proposal.getTag())) {
+          appendProposal(document, root, proposalPipingSystem, proposal, index++);
+        }
+      }
+      if (proposalPipingSystem.hasChildNodes()) {
+        root.appendChild(proposalPipingSystem);
+      }
+      TransformerFactory transformerFactory = TransformerFactory.newInstance();
+      transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      Transformer transformer = transformerFactory.newTransformer();
+      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+      transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+      transformer.transform(new DOMSource(document), new StreamResult(dexpiFile.toFile()));
+    } catch (Exception exception) {
+      throw new IOException("Could not materialize governed P&ID proposals in " + dexpiFile, exception);
+    }
+  }
+
+  private static Set<String> existingTags(Document document) {
+    Set<String> tags = new LinkedHashSet<String>();
+    NodeList attributes = document.getElementsByTagName("GenericAttribute");
+    for (int i = 0; i < attributes.getLength(); i++) {
+      Element attribute = (Element) attributes.item(i);
+      if (attribute.getAttribute("Name").contains("TagName")) {
+        tags.add(attribute.getAttribute("Value"));
+      }
+    }
+    return tags;
+  }
+
+  private static void appendPackageMetadata(Document document, Element root, PidDesignModel model) {
+    Element attributes = document.createElement("GenericAttributes");
+    attributes.setAttribute("Set", "NeqSimPidDesignModel");
+    addAttribute(document, attributes, "SchemaVersion", "neqsim_pid_design_model.v1");
+    addAttribute(document, attributes, "ProjectId", model.getProjectId());
+    addAttribute(document, attributes, "ProfileId", model.getProfileId());
+    addAttribute(document, attributes, "ProposalCount", String.valueOf(model.getElements().size()));
+    addAttribute(document, attributes, "ModelSidecar", "pid-design-model.json");
+    addAttribute(document, attributes, "CompletenessSidecar", "pid-completeness-report.json");
+    addAttribute(document, attributes, "ApprovalStatus", "REVIEW_REQUIRED");
+    root.appendChild(attributes);
+  }
+
+  private static Element createProposalPipingSystem(Document document) {
+    Element system = document.createElement("PipingNetworkSystem");
+    system.setAttribute("ID", "NeqSimPidProposal-PipingNetworkSystem");
+    system.setAttribute("ComponentClass", "PipingNetworkSystem");
+    system.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/PipingNetworkSystem");
+    return system;
+  }
+
+  private static void appendProposal(Document document, Element root, Element pipingSystem, PidElement proposal,
+      int index) {
+    String componentClass = componentClass(proposal.getType());
+    if (componentClass != null) {
+      appendPipingProposal(document, pipingSystem, proposal, index, componentClass);
+      return;
+    }
+    Element function = document.createElement("ProcessInstrumentationFunction");
+    function.setAttribute("ID", "NeqSimPidProposal-" + safe(proposal.getId()));
+    function.setAttribute("ComponentClass", "ProcessInstrumentationFunction");
+    function.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/ProcessInstrumentationFunction");
+    appendPosition(document, function, index);
+    Element attributes = document.createElement("GenericAttributes");
+    attributes.setAttribute("Set", "NeqSimPidProposal");
+    addAttribute(document, attributes, "TagNameAssignmentClass", proposal.getTag());
+    addAttribute(document, attributes, "PidElementType", proposal.getType().name());
+    addAttribute(document, attributes, "EquipmentTag", proposal.getEquipmentTag());
+    addAttribute(document, attributes, "RuleId", proposal.getRuleId());
+    addAttribute(document, attributes, "ApprovalStatus", proposal.getStatus().name());
+    function.appendChild(attributes);
+    root.appendChild(function);
+  }
+
+  private static void appendPipingProposal(Document document, Element pipingSystem, PidElement proposal, int index,
+      String componentClass) {
+    Element segment = document.createElement("PipingNetworkSegment");
+    segment.setAttribute("ID", "NeqSimPidProposal-Segment-" + safe(proposal.getId()));
+    segment.setAttribute("ComponentClass", "PipingNetworkSegment");
+    segment.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/PipingNetworkSegment");
+    Element component = document.createElement("PipingComponent");
+    component.setAttribute("ID", "NeqSimPidProposal-" + safe(proposal.getId()));
+    component.setAttribute("ComponentClass", componentClass);
+    component.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/" + componentClass);
+    if ("BallValve".equals(componentClass)) {
+      component.setAttribute("ComponentName", "BALL_VALVE_SHAPE");
+    } else if ("GlobeValve".equals(componentClass)) {
+      component.setAttribute("ComponentName", "GLOBE_VALVE_SHAPE");
+    } else if ("SwingCheckValve".equals(componentClass)) {
+      component.setAttribute("ComponentName", "CHECK_VALVE_SHAPE");
+    }
+    appendPosition(document, component, index);
+    Element attributes = document.createElement("GenericAttributes");
+    attributes.setAttribute("Set", "NeqSimPidProposal");
+    addAttribute(document, attributes, "TagNameAssignmentClass", proposal.getTag());
+    addAttribute(document, attributes, "PidElementType", proposal.getType().name());
+    addAttribute(document, attributes, "EquipmentTag", proposal.getEquipmentTag());
+    addAttribute(document, attributes, "RuleId", proposal.getRuleId());
+    addAttribute(document, attributes, "ApprovalStatus", proposal.getStatus().name());
+    component.appendChild(attributes);
+    segment.appendChild(component);
+    pipingSystem.appendChild(segment);
+  }
+
+  private static String componentClass(PidElementType type) {
+    switch (type) {
+    case CONTROL_VALVE:
+      return "GlobeValve";
+    case CHECK_VALVE:
+      return "SwingCheckValve";
+    case SAFETY_RELIEF_VALVE:
+      return "SpringLoadedGlobeSafetyValve";
+    case ISOLATION_VALVE:
+    case SHUTDOWN_VALVE:
+    case BLOWDOWN_VALVE:
+    case DRAIN:
+    case VENT:
+      return "BallValve";
+    default:
+      return null;
+    }
+  }
+
+  private static void appendPosition(Document document, Element parent, int index) {
+    Element position = document.createElement("Position");
+    Element location = document.createElement("Location");
+    location.setAttribute("X", String.valueOf(20.0 + (index % 8) * 24.0));
+    location.setAttribute("Y", String.valueOf(18.0 + (index / 8) * 18.0));
+    location.setAttribute("Z", "0");
+    position.appendChild(location);
+    Element axis = document.createElement("Axis");
+    axis.setAttribute("X", "0");
+    axis.setAttribute("Y", "0");
+    axis.setAttribute("Z", "1");
+    position.appendChild(axis);
+    Element reference = document.createElement("Reference");
+    reference.setAttribute("X", "1");
+    reference.setAttribute("Y", "0");
+    reference.setAttribute("Z", "0");
+    position.appendChild(reference);
+    parent.appendChild(position);
+  }
+
+  private static void addAttribute(Document document, Element parent, String name, String value) {
+    Element attribute = document.createElement("GenericAttribute");
+    attribute.setAttribute("Name", name);
+    attribute.setAttribute("Value", value == null ? "" : value);
+    attribute.setAttribute("Format", "string");
+    parent.appendChild(attribute);
+  }
+
+  private static String safe(String value) {
+    return value.replaceAll("[^A-Za-z0-9_.-]", "-");
+  }
+}

--- a/src/main/java/neqsim/process/engineering/pid/PidEngineeringPackageExporter.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidEngineeringPackageExporter.java
@@ -1,0 +1,62 @@
+package neqsim.process.engineering.pid;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import com.google.gson.GsonBuilder;
+import neqsim.process.engineering.EngineeringProject;
+import neqsim.process.engineering.dexpi.DexpiEngineeringExporter;
+
+/** Exports DEXPI plus the governed P&amp;ID proposal and completeness sidecars as one package. */
+public final class PidEngineeringPackageExporter {
+  private PidEngineeringPackageExporter() {
+  }
+
+  /** Result of a governed P&amp;ID package export. */
+  public static final class ExportResult {
+    private final DexpiEngineeringExporter.ExportResult engineeringPackage;
+    private final Path designModelFile;
+    private final Path completenessReportFile;
+
+    ExportResult(DexpiEngineeringExporter.ExportResult engineeringPackage, Path designModelFile,
+        Path completenessReportFile) {
+      this.engineeringPackage = engineeringPackage;
+      this.designModelFile = designModelFile;
+      this.completenessReportFile = completenessReportFile;
+    }
+
+    public DexpiEngineeringExporter.ExportResult getEngineeringPackage() {
+      return engineeringPackage;
+    }
+
+    public Path getDesignModelFile() {
+      return designModelFile;
+    }
+
+    public Path getCompletenessReportFile() {
+      return completenessReportFile;
+    }
+  }
+
+  public static ExportResult export(EngineeringProject project, PidDesignModel model, Path outputDirectory)
+      throws IOException {
+    if (project == null || model == null || outputDirectory == null) {
+      throw new IllegalArgumentException("project, model and outputDirectory must not be null");
+    }
+    if (!project.getProjectId().equals(model.getProjectId())) {
+      throw new IllegalArgumentException("project and P&ID design model identities do not match");
+    }
+    DexpiEngineeringExporter.ExportResult engineering = DexpiEngineeringExporter.export(project, outputDirectory);
+    Path modelFile = outputDirectory.resolve("pid-design-model.json");
+    Files.write(modelFile, new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create()
+        .toJson(model.toMap()).getBytes(StandardCharsets.UTF_8));
+    PidCompletenessReport report = PidCompletenessValidator.validate(model);
+    Path completenessFile = outputDirectory.resolve("pid-completeness-report.json");
+    Files.write(completenessFile, report.toJson().getBytes(StandardCharsets.UTF_8));
+    PidDexpiMaterializer.materialize(model, engineering.getDexpiFile());
+    PidDexpiMaterializer.materialize(model, engineering.getPyDexpiFile());
+    DexpiEngineeringExporter.refreshPackageManifest(outputDirectory);
+    return new ExportResult(engineering, modelFile, completenessFile);
+  }
+}

--- a/src/main/java/neqsim/process/engineering/pid/rules/CompressorControlPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/CompressorControlPidRule.java
@@ -31,29 +31,34 @@ public final class CompressorControlPidRule implements PidDesignRule {
   @Override
   public List<PidElement> propose(PidDesignContext context, ProcessEquipmentInterface equipment) {
     List<PidElement> result = new ArrayList<PidElement>();
-    PidElement suctionPt = PidRuleSupport.onInlet(PidRuleSupport.element(context, equipment, "PT",
-        "SUCTION-PRESSURE", PidElementType.MEASUREMENT, RULE_ID,
-        "Compressor suction pressure transmitter", "Monitor the approved suction-pressure envelope"),
-        equipment).attribute("measuredVariable", "PRESSURE").attribute("location", "SUCTION");
-    PidElement dischargePt = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "PT",
-        "DISCHARGE-PRESSURE", PidElementType.MEASUREMENT, RULE_ID,
-        "Compressor discharge pressure transmitter", "Monitor discharge pressure and pressure ratio"),
-        equipment).attribute("measuredVariable", "PRESSURE").attribute("location", "DISCHARGE");
-    PidElement dischargeTt = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "TT",
-        "DISCHARGE-TEMPERATURE", PidElementType.MEASUREMENT, RULE_ID,
-        "Compressor discharge temperature transmitter", "Monitor thermal operating limits"),
-        equipment).attribute("measuredVariable", "TEMPERATURE").attribute("location", "DISCHARGE");
-    PidElement suctionFt = PidRuleSupport.onInlet(PidRuleSupport.element(context, equipment, "FT",
-        "ANTISURGE-FLOW", PidElementType.MEASUREMENT, RULE_ID,
-        "Compressor antisurge flow transmitter", "Measure corrected flow for surge-margin control"),
-        equipment).attribute("measuredVariable", "FLOW").attribute("service", "ANTISURGE");
-    PidElement fic = PidRuleSupport.element(context, equipment, "FIC", "ANTISURGE-CONTROLLER",
-        PidElementType.CONTROLLER, RULE_ID, "Compressor antisurge controller",
-        "Maintain vendor-approved surge margin during steady and transient operation")
+    PidElement suctionPt = PidRuleSupport
+        .onInlet(PidRuleSupport.element(context, equipment, "PT", "SUCTION-PRESSURE", PidElementType.MEASUREMENT,
+            RULE_ID, "Compressor suction pressure transmitter", "Monitor the approved suction-pressure envelope"),
+            equipment)
+        .attribute("measuredVariable", "PRESSURE").attribute("location", "SUCTION");
+    PidElement dischargePt = PidRuleSupport
+        .onOutlet(
+            PidRuleSupport.element(context, equipment, "PT", "DISCHARGE-PRESSURE", PidElementType.MEASUREMENT, RULE_ID,
+                "Compressor discharge pressure transmitter", "Monitor discharge pressure and pressure ratio"),
+            equipment)
+        .attribute("measuredVariable", "PRESSURE").attribute("location", "DISCHARGE");
+    PidElement dischargeTt = PidRuleSupport
+        .onOutlet(PidRuleSupport.element(context, equipment, "TT", "DISCHARGE-TEMPERATURE", PidElementType.MEASUREMENT,
+            RULE_ID, "Compressor discharge temperature transmitter", "Monitor thermal operating limits"), equipment)
+        .attribute("measuredVariable", "TEMPERATURE").attribute("location", "DISCHARGE");
+    PidElement suctionFt = PidRuleSupport
+        .onInlet(PidRuleSupport.element(context, equipment, "FT", "ANTISURGE-FLOW", PidElementType.MEASUREMENT, RULE_ID,
+            "Compressor antisurge flow transmitter", "Measure corrected flow for surge-margin control"), equipment)
+        .attribute("measuredVariable", "FLOW").attribute("service", "ANTISURGE");
+    PidElement fic = PidRuleSupport
+        .element(context, equipment, "FIC", "ANTISURGE-CONTROLLER", PidElementType.CONTROLLER, RULE_ID,
+            "Compressor antisurge controller",
+            "Maintain vendor-approved surge margin during steady and transient operation")
         .attribute("algorithm", "VENDOR_MAP_AND_DYNAMIC_COMPENSATION_REQUIRED");
-    PidElement ascv = PidRuleSupport.element(context, equipment, "ASCV", "ANTISURGE-VALVE",
-        PidElementType.CONTROL_VALVE, RULE_ID, "Compressor antisurge recycle valve",
-        "Recycle discharge gas to prevent surge").attribute("failurePosition", "FAIL_OPEN_PROPOSAL")
+    PidElement ascv = PidRuleSupport
+        .element(context, equipment, "ASCV", "ANTISURGE-VALVE", PidElementType.CONTROL_VALVE, RULE_ID,
+            "Compressor antisurge recycle valve", "Recycle discharge gas to prevent surge")
+        .attribute("failurePosition", "FAIL_OPEN_PROPOSAL")
         .attribute("strokeTimeStatus", "DYNAMIC_VERIFICATION_REQUIRED")
         .attribute("topology", "RECYCLE_TIE_IN_REVIEW_REQUIRED");
     suctionFt.connect(fic.getId());

--- a/src/main/java/neqsim/process/engineering/pid/rules/CompressorSafeguardingPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/CompressorSafeguardingPidRule.java
@@ -45,8 +45,8 @@ public final class CompressorSafeguardingPidRule implements PidDesignRule {
     dischargePt.connect(dischargeTrip.getId());
     PidRuleSupport.onOutlet(dischargePt, equipment);
 
-    PidElement dischargeTt = sensor(context, equipment, "TT", "DISCHARGE-T-HH-SENSOR",
-        "TEMPERATURE", "Independent compressor discharge temperature transmitter", "DISCHARGE-T-HH");
+    PidElement dischargeTt = sensor(context, equipment, "TT", "DISCHARGE-T-HH-SENSOR", "TEMPERATURE",
+        "Independent compressor discharge temperature transmitter", "DISCHARGE-T-HH");
     PidElement temperatureTrip = trip(context, equipment, "TSHH", "DISCHARGE-T-HH-TRIP",
         "High-high compressor discharge temperature trip", "DISCHARGE-T-HH");
     dischargeTt.connect(temperatureTrip.getId());
@@ -55,30 +55,32 @@ public final class CompressorSafeguardingPidRule implements PidDesignRule {
     PidElement vibrationTrip = trip(context, equipment, "VSHH", "MACHINERY-VIBRATION-TRIP",
         "Compressor machinery protection trip", "MACHINERY-PROTECTION")
         .attribute("channels", "VENDOR_API_670_INPUT_REQUIRED");
-    PidElement shutdown = PidRuleSupport.element(context, equipment, "ESD", "UNIT-SHUTDOWN",
-        PidElementType.SAFETY_FUNCTION, RULE_ID, "Compressor shutdown function",
-        "Stop the driver and move final elements to the approved safe state")
+    PidElement shutdown = PidRuleSupport
+        .element(context, equipment, "ESD", "UNIT-SHUTDOWN", PidElementType.SAFETY_FUNCTION, RULE_ID,
+            "Compressor shutdown function", "Stop the driver and move final elements to the approved safe state")
         .attribute("sequence", "SRS_AND_SHUTDOWN_NARRATIVE_REQUIRED");
     suctionTrip.connect(shutdown.getId());
     dischargeTrip.connect(shutdown.getId());
     temperatureTrip.connect(shutdown.getId());
     vibrationTrip.connect(shutdown.getId());
 
-    PidElement suctionEsdv = PidRuleSupport.onInlet(PidRuleSupport.element(context, equipment, "ESDV",
-        "SUCTION-ISOLATION", PidElementType.SHUTDOWN_VALVE, RULE_ID,
-        "Compressor suction ESD valve", "Isolate the compressor suction inventory"), equipment)
+    PidElement suctionEsdv = PidRuleSupport
+        .onInlet(PidRuleSupport.element(context, equipment, "ESDV", "SUCTION-ISOLATION", PidElementType.SHUTDOWN_VALVE,
+            RULE_ID, "Compressor suction ESD valve", "Isolate the compressor suction inventory"), equipment)
         .attribute("failurePosition", "FAIL_CLOSED_PROPOSAL");
-    PidElement dischargeEsdv = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "ESDV",
-        "DISCHARGE-ISOLATION", PidElementType.SHUTDOWN_VALVE, RULE_ID,
-        "Compressor discharge ESD valve", "Isolate the compressor discharge inventory"), equipment)
+    PidElement dischargeEsdv = PidRuleSupport
+        .onOutlet(
+            PidRuleSupport.element(context, equipment, "ESDV", "DISCHARGE-ISOLATION", PidElementType.SHUTDOWN_VALVE,
+                RULE_ID, "Compressor discharge ESD valve", "Isolate the compressor discharge inventory"),
+            equipment)
         .attribute("failurePosition", "FAIL_CLOSED_PROPOSAL");
-    PidElement nrv = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "NRV",
-        "DISCHARGE-CHECK-VALVE", PidElementType.CHECK_VALVE, RULE_ID,
-        "Compressor discharge non-return valve", "Limit reverse flow and reverse rotation"), equipment)
+    PidElement nrv = PidRuleSupport
+        .onOutlet(PidRuleSupport.element(context, equipment, "NRV", "DISCHARGE-CHECK-VALVE", PidElementType.CHECK_VALVE,
+            RULE_ID, "Compressor discharge non-return valve", "Limit reverse flow and reverse rotation"), equipment)
         .attribute("leakageCase", "SETTLE_OUT_AND_RELIEF_REVIEW_REQUIRED");
-    PidElement bdv = PidRuleSupport.element(context, equipment, "BDV", "CASE-DEPRESSURISATION",
-        PidElementType.BLOWDOWN_VALVE, RULE_ID, "Compressor settle-out blowdown valve",
-        "Depressurise the isolated compressor circuit when required")
+    PidElement bdv = PidRuleSupport
+        .element(context, equipment, "BDV", "CASE-DEPRESSURISATION", PidElementType.BLOWDOWN_VALVE, RULE_ID,
+            "Compressor settle-out blowdown valve", "Depressurise the isolated compressor circuit when required")
         .attribute("orificeSizing", "DYNAMIC_BLOWDOWN_STUDY_REQUIRED")
         .attribute("flareTieIn", "PROJECT_INPUT_REQUIRED");
     shutdown.connect(suctionEsdv.getId()).connect(dischargeEsdv.getId()).connect(bdv.getId());
@@ -102,23 +104,23 @@ public final class CompressorSafeguardingPidRule implements PidDesignRule {
     return result;
   }
 
-  private static PidElement sensor(PidDesignContext context, ProcessEquipmentInterface equipment,
-      String function, String purpose, String variable, String description, String requirementToken) {
-    PidElement element = PidRuleSupport.element(context, equipment, function, purpose,
-        PidElementType.MEASUREMENT, RULE_ID, description,
-        "Provide an independent initiating element for compressor protection")
+  private static PidElement sensor(PidDesignContext context, ProcessEquipmentInterface equipment, String function,
+      String purpose, String variable, String description, String requirementToken) {
+    PidElement element = PidRuleSupport
+        .element(context, equipment, function, purpose, PidElementType.MEASUREMENT, RULE_ID, description,
+            "Provide an independent initiating element for compressor protection")
         .attribute("measuredVariable", variable).attribute("system", "SIS")
         .attribute("independence", "VERIFICATION_REQUIRED");
     PidRuleSupport.trace(element, context, equipment, requirementToken);
     return element;
   }
 
-  private static PidElement trip(PidDesignContext context, ProcessEquipmentInterface equipment,
-      String function, String purpose, String description, String requirementToken) {
-    PidElement element = PidRuleSupport.element(context, equipment, function, purpose,
-        PidElementType.TRIP, RULE_ID, description, "Move the compressor to the approved safe state")
-        .attribute("system", "SIS_OR_MACHINERY_PROTECTION")
-        .attribute("setPoint", "SRS_OR_VENDOR_INPUT_REQUIRED")
+  private static PidElement trip(PidDesignContext context, ProcessEquipmentInterface equipment, String function,
+      String purpose, String description, String requirementToken) {
+    PidElement element = PidRuleSupport
+        .element(context, equipment, function, purpose, PidElementType.TRIP, RULE_ID, description,
+            "Move the compressor to the approved safe state")
+        .attribute("system", "SIS_OR_MACHINERY_PROTECTION").attribute("setPoint", "SRS_OR_VENDOR_INPUT_REQUIRED")
         .attribute("voting", "SRS_OR_VENDOR_INPUT_REQUIRED");
     PidRuleSupport.trace(element, context, equipment, requirementToken);
     return element;

--- a/src/main/java/neqsim/process/engineering/pid/rules/PidRuleSupport.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/PidRuleSupport.java
@@ -14,20 +14,18 @@ final class PidRuleSupport {
   private PidRuleSupport() {
   }
 
-  static PidElement element(PidDesignContext context, ProcessEquipmentInterface equipment,
-      String functionCode, String purpose, PidElementType type, String ruleId, String description,
-      String rationale) {
+  static PidElement element(PidDesignContext context, ProcessEquipmentInterface equipment, String functionCode,
+      String purpose, PidElementType type, String ruleId, String description, String rationale) {
     String stableKey = equipment.getName() + "-" + purpose;
     String tag = context.getTagAllocator().allocate(functionCode, stableKey);
-    return new PidElement("pid:" + normalize(tag), tag, type).equipment(equipment.getName())
-        .description(description).provenance(ruleId, rationale).standard("ANSI/ISA-5.1:2024")
-        .attribute("proposalPurpose", purpose).attribute("approvalStatus", "REVIEW_REQUIRED");
+    return new PidElement("pid:" + normalize(tag), tag, type).equipment(equipment.getName()).description(description)
+        .provenance(ruleId, rationale).standard("ANSI/ISA-5.1:2024").attribute("proposalPurpose", purpose)
+        .attribute("approvalStatus", "REVIEW_REQUIRED");
   }
 
-  static void trace(PidElement element, PidDesignContext context,
-      ProcessEquipmentInterface equipment, String... tokens) {
-    List<EngineeringRequirement> requirements =
-        context.requirements(equipment.getName(), null);
+  static void trace(PidElement element, PidDesignContext context, ProcessEquipmentInterface equipment,
+      String... tokens) {
+    List<EngineeringRequirement> requirements = context.requirements(equipment.getName(), null);
     for (EngineeringRequirement requirement : requirements) {
       if (matches(requirement, tokens)) {
         element.requirement(requirement.getId());

--- a/src/main/java/neqsim/process/engineering/pid/rules/PressureReliefPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/PressureReliefPidRule.java
@@ -35,8 +35,7 @@ public final class PressureReliefPidRule implements PidDesignRule {
     List<PidElement> result = new ArrayList<PidElement>();
     OverpressureProtectionStudy study = study(context, equipment.getName());
     boolean hasRequirement = !context
-        .requirements(equipment.getName(), neqsim.process.engineering.EngineeringRequirement.Type.RELIEF)
-        .isEmpty();
+        .requirements(equipment.getName(), neqsim.process.engineering.EngineeringRequirement.Type.RELIEF).isEmpty();
     if (study == null && !hasRequirement) {
       return result;
     }
@@ -49,9 +48,8 @@ public final class PressureReliefPidRule implements PidDesignRule {
       context.getTagAllocator().reserve(tag);
     }
     PidElement psv = new PidElement("pid:" + tag.toLowerCase().replaceAll("[^a-z0-9]+", "-"), tag,
-        PidElementType.SAFETY_RELIEF_VALVE).equipment(equipment.getName())
-        .description("Pressure safety valve").provenance(RULE_ID,
-            "Protect pressure-containing equipment against governed credible overpressure scenarios")
+        PidElementType.SAFETY_RELIEF_VALVE).equipment(equipment.getName()).description("Pressure safety valve")
+        .provenance(RULE_ID, "Protect pressure-containing equipment against governed credible overpressure scenarios")
         .standard("API 520").standard("API 521").attribute("approvalStatus", "REVIEW_REQUIRED")
         .attribute("disposalDestination", "FLARE_OR_SAFE_LOCATION_REVIEW_REQUIRED");
     PidRuleSupport.trace(psv, context, equipment, "RELIEF", "ISOLATION-BLOWDOWN");
@@ -60,20 +58,19 @@ public final class PressureReliefPidRule implements PidDesignRule {
       psv.attribute("mawpBara", Double.valueOf(study.getItem().getMaximumAllowableWorkingPressureBara()))
           .attribute("setPressureBara", Double.valueOf(study.getItem().getReliefSetPressureBara()))
           .attribute("scenarioCount", Integer.valueOf(study.getScenarios().size()))
-          .attribute("governingScenario",
-              governing == null ? "NO_CREDIBLE_SCENARIO" : governing.getName())
-          .attribute("governingCause",
-              governing == null ? "NOT_DEFINED" : governing.getCause().name())
-          .attribute("sizingStatus", governing == null ? "SCENARIO_REVIEW_REQUIRED"
-              : "CALCULATION_AND_VENDOR_REVIEW_REQUIRED");
+          .attribute("governingScenario", governing == null ? "NO_CREDIBLE_SCENARIO" : governing.getName())
+          .attribute("governingCause", governing == null ? "NOT_DEFINED" : governing.getCause().name())
+          .attribute("sizingStatus",
+              governing == null ? "SCENARIO_REVIEW_REQUIRED" : "CALCULATION_AND_VENDOR_REVIEW_REQUIRED");
     }
     if (installed != null) {
-      psv.attribute("installedDesignInput", installed.toMap())
-          .attribute("installedInputMissingFields", installed.getMissingFields());
+      psv.attribute("installedDesignInput", installed.toMap()).attribute("installedInputMissingFields",
+          installed.getMissingFields());
     }
-    PidElement flare = PidRuleSupport.element(context, equipment, "FLARE", "RELIEF-DESTINATION",
-        PidElementType.OFF_PAGE_CONNECTOR, RULE_ID, "Relief and blowdown disposal connector",
-        "Connect the device outlet to the qualified disposal-system model")
+    PidElement flare = PidRuleSupport
+        .element(context, equipment, "FLARE", "RELIEF-DESTINATION", PidElementType.OFF_PAGE_CONNECTOR, RULE_ID,
+            "Relief and blowdown disposal connector",
+            "Connect the device outlet to the qualified disposal-system model")
         .attribute("destination", "FLARE_NETWORK_MODEL_REQUIRED");
     psv.connect(flare.getId());
     result.add(psv);

--- a/src/main/java/neqsim/process/engineering/pid/rules/PumpControlPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/PumpControlPidRule.java
@@ -31,26 +31,25 @@ public final class PumpControlPidRule implements PidDesignRule {
   @Override
   public List<PidElement> propose(PidDesignContext context, ProcessEquipmentInterface equipment) {
     List<PidElement> result = new ArrayList<PidElement>();
-    PidElement suctionPt = PidRuleSupport.onInlet(PidRuleSupport.element(context, equipment, "PT",
-        "SUCTION-PRESSURE", PidElementType.MEASUREMENT, RULE_ID,
-        "Pump suction pressure transmitter", "Monitor NPSH and liquid-supply margin"), equipment)
+    PidElement suctionPt = PidRuleSupport
+        .onInlet(PidRuleSupport.element(context, equipment, "PT", "SUCTION-PRESSURE", PidElementType.MEASUREMENT,
+            RULE_ID, "Pump suction pressure transmitter", "Monitor NPSH and liquid-supply margin"), equipment)
         .attribute("measuredVariable", "PRESSURE").attribute("location", "SUCTION");
-    PidElement dischargePt = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "PT",
-        "DISCHARGE-PRESSURE", PidElementType.MEASUREMENT, RULE_ID,
-        "Pump discharge pressure transmitter", "Monitor pump head and deadhead pressure"), equipment)
+    PidElement dischargePt = PidRuleSupport
+        .onOutlet(PidRuleSupport.element(context, equipment, "PT", "DISCHARGE-PRESSURE", PidElementType.MEASUREMENT,
+            RULE_ID, "Pump discharge pressure transmitter", "Monitor pump head and deadhead pressure"), equipment)
         .attribute("measuredVariable", "PRESSURE").attribute("location", "DISCHARGE");
-    PidElement ft = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "FT",
-        "MINIMUM-FLOW", PidElementType.MEASUREMENT, RULE_ID,
-        "Pump discharge flow transmitter", "Measure flow for minimum-flow protection"), equipment)
+    PidElement ft = PidRuleSupport
+        .onOutlet(PidRuleSupport.element(context, equipment, "FT", "MINIMUM-FLOW", PidElementType.MEASUREMENT, RULE_ID,
+            "Pump discharge flow transmitter", "Measure flow for minimum-flow protection"), equipment)
         .attribute("measuredVariable", "FLOW");
     PidElement fic = PidRuleSupport.element(context, equipment, "FIC", "MINIMUM-FLOW-CONTROLLER",
         PidElementType.CONTROLLER, RULE_ID, "Pump minimum-flow controller",
         "Maintain vendor-approved minimum continuous stable flow");
-    PidElement fcv = PidRuleSupport.element(context, equipment, "FCV", "MINIMUM-FLOW-VALVE",
-        PidElementType.CONTROL_VALVE, RULE_ID, "Pump minimum-flow recycle valve",
-        "Recycle liquid to protect the pump at low process flow")
-        .attribute("failurePosition", "FAIL_OPEN_PROPOSAL")
-        .attribute("recycleDestination", "PROJECT_INPUT_REQUIRED");
+    PidElement fcv = PidRuleSupport
+        .element(context, equipment, "FCV", "MINIMUM-FLOW-VALVE", PidElementType.CONTROL_VALVE, RULE_ID,
+            "Pump minimum-flow recycle valve", "Recycle liquid to protect the pump at low process flow")
+        .attribute("failurePosition", "FAIL_OPEN_PROPOSAL").attribute("recycleDestination", "PROJECT_INPUT_REQUIRED");
     ft.connect(fic.getId());
     fic.connect(fcv.getId());
     PidRuleSupport.trace(suctionPt, context, equipment, "LOW-SUCTION");

--- a/src/main/java/neqsim/process/engineering/pid/rules/PumpSafeguardingPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/PumpSafeguardingPidRule.java
@@ -31,30 +31,30 @@ public final class PumpSafeguardingPidRule implements PidDesignRule {
   @Override
   public List<PidElement> propose(PidDesignContext context, ProcessEquipmentInterface equipment) {
     List<PidElement> result = new ArrayList<PidElement>();
-    PidElement pt = PidRuleSupport.onInlet(PidRuleSupport.element(context, equipment, "PT",
-        "LOW-SUCTION-TRIP-SENSOR", PidElementType.MEASUREMENT, RULE_ID,
-        "Independent pump suction pressure transmitter", "Detect loss of liquid supply"), equipment)
+    PidElement pt = PidRuleSupport
+        .onInlet(PidRuleSupport.element(context, equipment, "PT", "LOW-SUCTION-TRIP-SENSOR", PidElementType.MEASUREMENT,
+            RULE_ID, "Independent pump suction pressure transmitter", "Detect loss of liquid supply"), equipment)
         .attribute("system", "SIS").attribute("measuredVariable", "PRESSURE");
-    PidElement trip = PidRuleSupport.element(context, equipment, "PSLL", "LOW-SUCTION-TRIP",
-        PidElementType.TRIP, RULE_ID, "Pump low-low suction pressure trip",
-        "Stop the pump before cavitation or loss of prime causes damage")
+    PidElement trip = PidRuleSupport
+        .element(context, equipment, "PSLL", "LOW-SUCTION-TRIP", PidElementType.TRIP, RULE_ID,
+            "Pump low-low suction pressure trip", "Stop the pump before cavitation or loss of prime causes damage")
         .attribute("setPoint", "NPSH_AND_VENDOR_INPUT_REQUIRED");
     pt.connect(trip.getId());
-    PidElement suctionXv = PidRuleSupport.onInlet(PidRuleSupport.element(context, equipment, "XV",
-        "SUCTION-ISOLATION", PidElementType.ISOLATION_VALVE, RULE_ID, "Pump suction isolation valve",
-        "Provide maintainable pump isolation"), equipment);
-    PidElement dischargeXv = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "XV",
-        "DISCHARGE-ISOLATION", PidElementType.ISOLATION_VALVE, RULE_ID,
-        "Pump discharge isolation valve", "Provide maintainable pump isolation"), equipment);
-    PidElement nrv = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "NRV",
-        "DISCHARGE-CHECK-VALVE", PidElementType.CHECK_VALVE, RULE_ID,
-        "Pump discharge non-return valve", "Prevent reverse flow through a stopped pump"), equipment);
-    PidElement drain = PidRuleSupport.element(context, equipment, "DV", "CASING-DRAIN",
-        PidElementType.DRAIN, RULE_ID, "Pump casing drain", "Enable controlled draining for maintenance")
+    PidElement suctionXv = PidRuleSupport.onInlet(PidRuleSupport.element(context, equipment, "XV", "SUCTION-ISOLATION",
+        PidElementType.ISOLATION_VALVE, RULE_ID, "Pump suction isolation valve", "Provide maintainable pump isolation"),
+        equipment);
+    PidElement dischargeXv = PidRuleSupport.onOutlet(
+        PidRuleSupport.element(context, equipment, "XV", "DISCHARGE-ISOLATION", PidElementType.ISOLATION_VALVE, RULE_ID,
+            "Pump discharge isolation valve", "Provide maintainable pump isolation"),
+        equipment);
+    PidElement nrv = PidRuleSupport
+        .onOutlet(PidRuleSupport.element(context, equipment, "NRV", "DISCHARGE-CHECK-VALVE", PidElementType.CHECK_VALVE,
+            RULE_ID, "Pump discharge non-return valve", "Prevent reverse flow through a stopped pump"), equipment);
+    PidElement drain = PidRuleSupport.element(context, equipment, "DV", "CASING-DRAIN", PidElementType.DRAIN, RULE_ID,
+        "Pump casing drain", "Enable controlled draining for maintenance")
         .attribute("destination", "CLOSED_DRAIN_REVIEW_REQUIRED");
-    PidElement vent = PidRuleSupport.element(context, equipment, "VV", "CASING-VENT",
-        PidElementType.VENT, RULE_ID, "Pump casing vent", "Enable safe venting and priming")
-        .attribute("destination", "SAFE_VENT_REVIEW_REQUIRED");
+    PidElement vent = PidRuleSupport.element(context, equipment, "VV", "CASING-VENT", PidElementType.VENT, RULE_ID,
+        "Pump casing vent", "Enable safe venting and priming").attribute("destination", "SAFE_VENT_REVIEW_REQUIRED");
     PidRuleSupport.trace(pt, context, equipment, "LOW-SUCTION");
     PidRuleSupport.trace(trip, context, equipment, "LOW-SUCTION");
     PidRuleSupport.trace(nrv, context, equipment, "DEADHEAD");

--- a/src/main/java/neqsim/process/engineering/pid/rules/SeparatorControlPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/SeparatorControlPidRule.java
@@ -31,44 +31,50 @@ public final class SeparatorControlPidRule implements PidDesignRule {
   @Override
   public List<PidElement> propose(PidDesignContext context, ProcessEquipmentInterface equipment) {
     List<PidElement> result = new ArrayList<PidElement>();
-    PidElement pt = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "PT",
-        "PRESSURE-MEASUREMENT", PidElementType.MEASUREMENT, RULE_ID,
-        "Separator pressure transmitter", "Measure vessel pressure for control and protection review"),
-        equipment).attribute("measuredVariable", "PRESSURE").attribute("functions", "IT");
-    PidElement pic = PidRuleSupport.element(context, equipment, "PIC", "PRESSURE-CONTROLLER",
-        PidElementType.CONTROLLER, RULE_ID, "Separator pressure indicating controller",
+    PidElement pt = PidRuleSupport
+        .onOutlet(
+            PidRuleSupport.element(context, equipment, "PT", "PRESSURE-MEASUREMENT", PidElementType.MEASUREMENT,
+                RULE_ID, "Separator pressure transmitter", "Measure vessel pressure for control and protection review"),
+            equipment)
+        .attribute("measuredVariable", "PRESSURE").attribute("functions", "IT");
+    PidElement pic = PidRuleSupport.element(context, equipment, "PIC", "PRESSURE-CONTROLLER", PidElementType.CONTROLLER,
+        RULE_ID, "Separator pressure indicating controller",
         "Maintain the approved separator operating-pressure envelope");
-    PidElement pcv = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "PCV",
-        "PRESSURE-CONTROL-VALVE", PidElementType.CONTROL_VALVE, RULE_ID,
-        "Separator pressure control valve", "Modulate gas outlet flow to control pressure"), equipment)
-        .attribute("failurePosition", "HAZOP_INPUT_REQUIRED")
-        .attribute("sizingStatus", "CALCULATION_REQUIRED");
+    PidElement pcv = PidRuleSupport
+        .onOutlet(
+            PidRuleSupport.element(context, equipment, "PCV", "PRESSURE-CONTROL-VALVE", PidElementType.CONTROL_VALVE,
+                RULE_ID, "Separator pressure control valve", "Modulate gas outlet flow to control pressure"),
+            equipment)
+        .attribute("failurePosition", "HAZOP_INPUT_REQUIRED").attribute("sizingStatus", "CALCULATION_REQUIRED");
     connect(pt, pic, pcv);
     PidRuleSupport.trace(pt, context, equipment, "PRESSURE");
     PidRuleSupport.trace(pic, context, equipment, "PRESSURE-CONTROL");
     PidRuleSupport.trace(pcv, context, equipment, "PRESSURE-CONTROL");
 
-    PidElement lt = PidRuleSupport.element(context, equipment, "LT", "LEVEL-MEASUREMENT",
-        PidElementType.MEASUREMENT, RULE_ID, "Separator level transmitter",
-        "Measure liquid inventory for carry-over and gas-blowby prevention")
+    PidElement lt = PidRuleSupport
+        .element(context, equipment, "LT", "LEVEL-MEASUREMENT", PidElementType.MEASUREMENT, RULE_ID,
+            "Separator level transmitter", "Measure liquid inventory for carry-over and gas-blowby prevention")
         .attribute("measuredVariable", "LEVEL").attribute("functions", "IT");
-    PidElement lic = PidRuleSupport.element(context, equipment, "LIC", "LEVEL-CONTROLLER",
-        PidElementType.CONTROLLER, RULE_ID, "Separator level indicating controller",
+    PidElement lic = PidRuleSupport.element(context, equipment, "LIC", "LEVEL-CONTROLLER", PidElementType.CONTROLLER,
+        RULE_ID, "Separator level indicating controller",
         "Maintain liquid level within the approved operating envelope");
-    PidElement lcv = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "LCV",
-        "LEVEL-CONTROL-VALVE", PidElementType.CONTROL_VALVE, RULE_ID,
-        "Separator liquid level control valve", "Modulate liquid outlet flow to control level"),
-        equipment).attribute("failurePosition", "HAZOP_INPUT_REQUIRED")
-        .attribute("sizingStatus", "CALCULATION_REQUIRED");
+    PidElement lcv = PidRuleSupport
+        .onOutlet(
+            PidRuleSupport.element(context, equipment, "LCV", "LEVEL-CONTROL-VALVE", PidElementType.CONTROL_VALVE,
+                RULE_ID, "Separator liquid level control valve", "Modulate liquid outlet flow to control level"),
+            equipment)
+        .attribute("failurePosition", "HAZOP_INPUT_REQUIRED").attribute("sizingStatus", "CALCULATION_REQUIRED");
     connect(lt, lic, lcv);
     PidRuleSupport.trace(lt, context, equipment, "LEVEL");
     PidRuleSupport.trace(lic, context, equipment, "LEVEL-CONTROL");
     PidRuleSupport.trace(lcv, context, equipment, "LEVEL-CONTROL");
 
-    PidElement tt = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "TT",
-        "TEMPERATURE-MEASUREMENT", PidElementType.MEASUREMENT, RULE_ID,
-        "Separator outlet temperature transmitter", "Expose process temperature for monitoring"),
-        equipment).attribute("measuredVariable", "TEMPERATURE").attribute("functions", "IT");
+    PidElement tt = PidRuleSupport
+        .onOutlet(
+            PidRuleSupport.element(context, equipment, "TT", "TEMPERATURE-MEASUREMENT", PidElementType.MEASUREMENT,
+                RULE_ID, "Separator outlet temperature transmitter", "Expose process temperature for monitoring"),
+            equipment)
+        .attribute("measuredVariable", "TEMPERATURE").attribute("functions", "IT");
     result.add(pt);
     result.add(pic);
     result.add(pcv);

--- a/src/main/java/neqsim/process/engineering/pid/rules/SeparatorSafeguardingPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/SeparatorSafeguardingPidRule.java
@@ -33,36 +33,36 @@ public final class SeparatorSafeguardingPidRule implements PidDesignRule {
     List<PidElement> result = new ArrayList<PidElement>();
     PidElement pressureSensor = independentSensor(context, equipment, "PT", "PRESSURE-HH-SENSOR",
         "Independent high-pressure transmitter", "PRESSURE", "PRESSURE-HH");
-    PidElement pressureTrip = trip(context, equipment, "PSHH", "PRESSURE-HH-TRIP",
-        "High-high pressure shutdown", "Isolate credible pressure sources before the approved limit",
-        "PRESSURE-HH");
+    PidElement pressureTrip = trip(context, equipment, "PSHH", "PRESSURE-HH-TRIP", "High-high pressure shutdown",
+        "Isolate credible pressure sources before the approved limit", "PRESSURE-HH");
     pressureSensor.connect(pressureTrip.getId());
 
     PidElement levelHighSensor = independentSensor(context, equipment, "LT", "LEVEL-HH-SENSOR",
         "Independent high-level transmitter", "LEVEL", "LEVEL-HH");
-    PidElement levelHighTrip = trip(context, equipment, "LSHH", "LEVEL-HH-TRIP",
-        "High-high level shutdown", "Prevent liquid carry-over to downstream gas equipment", "LEVEL-HH");
+    PidElement levelHighTrip = trip(context, equipment, "LSHH", "LEVEL-HH-TRIP", "High-high level shutdown",
+        "Prevent liquid carry-over to downstream gas equipment", "LEVEL-HH");
     levelHighSensor.connect(levelHighTrip.getId());
 
     PidElement levelLowSensor = independentSensor(context, equipment, "LT", "LEVEL-LL-SENSOR",
         "Independent low-level transmitter", "LEVEL", "LEVEL-LL");
-    PidElement levelLowTrip = trip(context, equipment, "LSLL", "LEVEL-LL-TRIP",
-        "Low-low level shutdown", "Prevent gas blow-by to a lower-pressure liquid system", "LEVEL-LL");
+    PidElement levelLowTrip = trip(context, equipment, "LSLL", "LEVEL-LL-TRIP", "Low-low level shutdown",
+        "Prevent gas blow-by to a lower-pressure liquid system", "LEVEL-LL");
     levelLowSensor.connect(levelLowTrip.getId());
 
-    PidElement inletEsdv = PidRuleSupport.onInlet(PidRuleSupport.element(context, equipment, "ESDV",
-        "INLET-ISOLATION", PidElementType.SHUTDOWN_VALVE, RULE_ID, "Separator inlet ESD valve",
-        "Isolate incoming hydrocarbon inventory on approved shutdown demand"), equipment)
-        .attribute("failurePosition", "FAIL_CLOSED_PROPOSAL")
-        .attribute("closureTime", "DYNAMIC_VERIFICATION_REQUIRED");
-    PidElement gasEsdv = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "ESDV",
-        "GAS-OUTLET-ISOLATION", PidElementType.SHUTDOWN_VALVE, RULE_ID,
-        "Separator gas outlet ESD valve", "Define the shutdown isolation boundary"), equipment)
-        .attribute("failurePosition", "FAIL_CLOSED_PROPOSAL")
-        .attribute("closureTime", "DYNAMIC_VERIFICATION_REQUIRED");
-    PidElement bdv = PidRuleSupport.element(context, equipment, "BDV", "DEPRESSURISATION",
-        PidElementType.BLOWDOWN_VALVE, RULE_ID, "Separator blowdown valve",
-        "Depressurise isolated inventory to the flare system when required")
+    PidElement inletEsdv = PidRuleSupport
+        .onInlet(PidRuleSupport.element(context, equipment, "ESDV", "INLET-ISOLATION", PidElementType.SHUTDOWN_VALVE,
+            RULE_ID, "Separator inlet ESD valve", "Isolate incoming hydrocarbon inventory on approved shutdown demand"),
+            equipment)
+        .attribute("failurePosition", "FAIL_CLOSED_PROPOSAL").attribute("closureTime", "DYNAMIC_VERIFICATION_REQUIRED");
+    PidElement gasEsdv = PidRuleSupport
+        .onOutlet(
+            PidRuleSupport.element(context, equipment, "ESDV", "GAS-OUTLET-ISOLATION", PidElementType.SHUTDOWN_VALVE,
+                RULE_ID, "Separator gas outlet ESD valve", "Define the shutdown isolation boundary"),
+            equipment)
+        .attribute("failurePosition", "FAIL_CLOSED_PROPOSAL").attribute("closureTime", "DYNAMIC_VERIFICATION_REQUIRED");
+    PidElement bdv = PidRuleSupport
+        .element(context, equipment, "BDV", "DEPRESSURISATION", PidElementType.BLOWDOWN_VALVE, RULE_ID,
+            "Separator blowdown valve", "Depressurise isolated inventory to the flare system when required")
         .attribute("failurePosition", "FAIL_CLOSED_PROPOSAL")
         .attribute("orificeSizing", "DYNAMIC_BLOWDOWN_STUDY_REQUIRED")
         .attribute("flareTieIn", "PROJECT_INPUT_REQUIRED");
@@ -85,24 +85,23 @@ public final class SeparatorSafeguardingPidRule implements PidDesignRule {
     return result;
   }
 
-  private static PidElement independentSensor(PidDesignContext context,
-      ProcessEquipmentInterface equipment, String function, String purpose, String description,
-      String measuredVariable, String requirementToken) {
-    PidElement sensor = PidRuleSupport.element(context, equipment, function, purpose,
-        PidElementType.MEASUREMENT, RULE_ID, description,
-        "Provide an independent initiating element for the proposed protective function")
+  private static PidElement independentSensor(PidDesignContext context, ProcessEquipmentInterface equipment,
+      String function, String purpose, String description, String measuredVariable, String requirementToken) {
+    PidElement sensor = PidRuleSupport
+        .element(context, equipment, function, purpose, PidElementType.MEASUREMENT, RULE_ID, description,
+            "Provide an independent initiating element for the proposed protective function")
         .attribute("measuredVariable", measuredVariable).attribute("system", "SIS")
         .attribute("independence", "VERIFICATION_REQUIRED");
     PidRuleSupport.trace(sensor, context, equipment, requirementToken);
     return sensor;
   }
 
-  private static PidElement trip(PidDesignContext context, ProcessEquipmentInterface equipment,
-      String function, String purpose, String description, String rationale, String requirementToken) {
-    PidElement trip = PidRuleSupport.element(context, equipment, function, purpose,
-        PidElementType.TRIP, RULE_ID, description, rationale).attribute("system", "SIS")
-        .attribute("setPoint", "SRS_INPUT_REQUIRED").attribute("silTarget", "LOPA_INPUT_REQUIRED")
-        .attribute("voting", "SRS_INPUT_REQUIRED");
+  private static PidElement trip(PidDesignContext context, ProcessEquipmentInterface equipment, String function,
+      String purpose, String description, String rationale, String requirementToken) {
+    PidElement trip = PidRuleSupport
+        .element(context, equipment, function, purpose, PidElementType.TRIP, RULE_ID, description, rationale)
+        .attribute("system", "SIS").attribute("setPoint", "SRS_INPUT_REQUIRED")
+        .attribute("silTarget", "LOPA_INPUT_REQUIRED").attribute("voting", "SRS_INPUT_REQUIRED");
     PidRuleSupport.trace(trip, context, equipment, requirementToken);
     return trip;
   }

--- a/src/main/java/neqsim/process/engineering/pid/rules/ThermalControlPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/ThermalControlPidRule.java
@@ -31,18 +31,18 @@ public final class ThermalControlPidRule implements PidDesignRule {
   @Override
   public List<PidElement> propose(PidDesignContext context, ProcessEquipmentInterface equipment) {
     List<PidElement> result = new ArrayList<PidElement>();
-    PidElement tt = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "TT",
-        "OUTLET-TEMPERATURE", PidElementType.MEASUREMENT, RULE_ID,
-        "Outlet temperature transmitter", "Measure temperature at the controlled process outlet"),
-        equipment).attribute("measuredVariable", "TEMPERATURE");
+    PidElement tt = PidRuleSupport
+        .onOutlet(PidRuleSupport.element(context, equipment, "TT", "OUTLET-TEMPERATURE", PidElementType.MEASUREMENT,
+            RULE_ID, "Outlet temperature transmitter", "Measure temperature at the controlled process outlet"),
+            equipment)
+        .attribute("measuredVariable", "TEMPERATURE");
     PidElement tic = PidRuleSupport.element(context, equipment, "TIC", "TEMPERATURE-CONTROLLER",
         PidElementType.CONTROLLER, RULE_ID, "Temperature indicating controller",
         "Maintain the approved outlet-temperature target");
-    PidElement tcv = PidRuleSupport.element(context, equipment, "TCV", "UTILITY-CONTROL-VALVE",
-        PidElementType.CONTROL_VALVE, RULE_ID, "Heating or cooling utility control valve",
-        "Manipulate utility duty to control process outlet temperature")
-        .attribute("failurePosition", "HAZOP_INPUT_REQUIRED")
-        .attribute("utilityConnection", "PROJECT_INPUT_REQUIRED");
+    PidElement tcv = PidRuleSupport
+        .element(context, equipment, "TCV", "UTILITY-CONTROL-VALVE", PidElementType.CONTROL_VALVE, RULE_ID,
+            "Heating or cooling utility control valve", "Manipulate utility duty to control process outlet temperature")
+        .attribute("failurePosition", "HAZOP_INPUT_REQUIRED").attribute("utilityConnection", "PROJECT_INPUT_REQUIRED");
     tt.connect(tic.getId());
     tic.connect(tcv.getId());
     PidRuleSupport.trace(tt, context, equipment, "OUTLET-T", "TEMPERATURE");

--- a/src/main/java/neqsim/process/engineering/pid/rules/ThermalSafeguardingPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/ThermalSafeguardingPidRule.java
@@ -31,37 +31,40 @@ public final class ThermalSafeguardingPidRule implements PidDesignRule {
   @Override
   public List<PidElement> propose(PidDesignContext context, ProcessEquipmentInterface equipment) {
     List<PidElement> result = new ArrayList<PidElement>();
-    PidElement tt = PidRuleSupport.onOutlet(PidRuleSupport.element(context, equipment, "TT",
-        "OUTLET-T-HH-SENSOR", PidElementType.MEASUREMENT, RULE_ID,
-        "Independent outlet temperature transmitter", "Detect excessive process temperature"),
-        equipment).attribute("system", "SIS").attribute("measuredVariable", "TEMPERATURE");
-    PidElement tshh = PidRuleSupport.element(context, equipment, "TSHH", "OUTLET-T-HH-TRIP",
-        PidElementType.TRIP, RULE_ID, "High-high outlet temperature trip",
-        "Remove heat input before downstream or equipment temperature limits are exceeded")
+    PidElement tt = PidRuleSupport
+        .onOutlet(PidRuleSupport.element(context, equipment, "TT", "OUTLET-T-HH-SENSOR", PidElementType.MEASUREMENT,
+            RULE_ID, "Independent outlet temperature transmitter", "Detect excessive process temperature"), equipment)
+        .attribute("system", "SIS").attribute("measuredVariable", "TEMPERATURE");
+    PidElement tshh = PidRuleSupport
+        .element(context, equipment, "TSHH", "OUTLET-T-HH-TRIP", PidElementType.TRIP, RULE_ID,
+            "High-high outlet temperature trip",
+            "Remove heat input before downstream or equipment temperature limits are exceeded")
         .attribute("setPoint", "SRS_INPUT_REQUIRED");
     tt.connect(tshh.getId());
-    PidElement ft = PidRuleSupport.onInlet(PidRuleSupport.element(context, equipment, "FT",
-        "LOW-FLOW-SENSOR", PidElementType.MEASUREMENT, RULE_ID,
-        "Independent process flow transmitter", "Detect loss of process flow through thermal equipment"),
-        equipment).attribute("system", "SIS").attribute("measuredVariable", "FLOW");
-    PidElement fsll = PidRuleSupport.element(context, equipment, "FSLL", "LOW-FLOW-TRIP",
-        PidElementType.TRIP, RULE_ID, "Low-low process flow trip",
-        "Remove heat input when process flow is insufficient")
+    PidElement ft = PidRuleSupport
+        .onInlet(
+            PidRuleSupport.element(context, equipment, "FT", "LOW-FLOW-SENSOR", PidElementType.MEASUREMENT, RULE_ID,
+                "Independent process flow transmitter", "Detect loss of process flow through thermal equipment"),
+            equipment)
+        .attribute("system", "SIS").attribute("measuredVariable", "FLOW");
+    PidElement fsll = PidRuleSupport.element(context, equipment, "FSLL", "LOW-FLOW-TRIP", PidElementType.TRIP, RULE_ID,
+        "Low-low process flow trip", "Remove heat input when process flow is insufficient")
         .attribute("setPoint", "SRS_INPUT_REQUIRED");
     ft.connect(fsll.getId());
-    PidElement utilitySdv = PidRuleSupport.element(context, equipment, "SDV",
-        "UTILITY-SHUTDOWN", PidElementType.SHUTDOWN_VALVE, RULE_ID,
-        "Heating or cooling utility shutdown valve", "Isolate the utility in the approved safe direction")
-        .attribute("failurePosition", "HAZOP_INPUT_REQUIRED")
-        .attribute("utilityConnection", "PROJECT_INPUT_REQUIRED");
+    PidElement utilitySdv = PidRuleSupport
+        .element(context, equipment, "SDV", "UTILITY-SHUTDOWN", PidElementType.SHUTDOWN_VALVE, RULE_ID,
+            "Heating or cooling utility shutdown valve", "Isolate the utility in the approved safe direction")
+        .attribute("failurePosition", "HAZOP_INPUT_REQUIRED").attribute("utilityConnection", "PROJECT_INPUT_REQUIRED");
     tshh.connect(utilitySdv.getId());
     fsll.connect(utilitySdv.getId());
-    PidElement drain = PidRuleSupport.element(context, equipment, "DV", "PROCESS-DRAIN",
-        PidElementType.DRAIN, RULE_ID, "Thermal equipment process drain",
-        "Enable controlled draining for maintenance").attribute("destination", "DRAIN_REVIEW_REQUIRED");
-    PidElement vent = PidRuleSupport.element(context, equipment, "VV", "PROCESS-VENT",
-        PidElementType.VENT, RULE_ID, "Thermal equipment process vent",
-        "Enable safe venting for maintenance").attribute("destination", "VENT_REVIEW_REQUIRED");
+    PidElement drain = PidRuleSupport
+        .element(context, equipment, "DV", "PROCESS-DRAIN", PidElementType.DRAIN, RULE_ID,
+            "Thermal equipment process drain", "Enable controlled draining for maintenance")
+        .attribute("destination", "DRAIN_REVIEW_REQUIRED");
+    PidElement vent = PidRuleSupport
+        .element(context, equipment, "VV", "PROCESS-VENT", PidElementType.VENT, RULE_ID,
+            "Thermal equipment process vent", "Enable safe venting for maintenance")
+        .attribute("destination", "VENT_REVIEW_REQUIRED");
     PidRuleSupport.trace(tt, context, equipment, "OUTLET-T-HH");
     PidRuleSupport.trace(tshh, context, equipment, "OUTLET-T-HH");
     PidRuleSupport.trace(ft, context, equipment, "LOW-FLOW");

--- a/src/test/java/neqsim/process/engineering/pid/ControlInstrumentationPidSynthesisTest.java
+++ b/src/test/java/neqsim/process/engineering/pid/ControlInstrumentationPidSynthesisTest.java
@@ -51,8 +51,8 @@ public class ControlInstrumentationPidSynthesisTest extends NeqSimTest {
     assertNotNull(separatorPressure);
     assertFalse(separatorPressure.getLineTag().isEmpty());
     assertFalse(separatorPressure.getRequirementIds().isEmpty());
-    assertTrue(separatorPressure.getStandardReferences().stream()
-        .anyMatch(reference -> reference.contains("IEC 62424")));
+    assertTrue(
+        separatorPressure.getStandardReferences().stream().anyMatch(reference -> reference.contains("IEC 62424")));
   }
 
   private static PidElement findByFunction(PidDesignModel model, String function) {
@@ -88,7 +88,7 @@ public class ControlInstrumentationPidSynthesisTest extends NeqSimTest {
     process.add(compressor);
     process.add(cooler);
     process.add(pump);
-    return NorsokOffshoreEngineeringBuilder.from("Complete control proposal", process)
-        .projectId("PID-CONTROL-TEST").build();
+    return NorsokOffshoreEngineeringBuilder.from("Complete control proposal", process).projectId("PID-CONTROL-TEST")
+        .build();
   }
 }

--- a/src/test/java/neqsim/process/engineering/pid/PidCompletenessAndDexpiTest.java
+++ b/src/test/java/neqsim/process/engineering/pid/PidCompletenessAndDexpiTest.java
@@ -1,0 +1,44 @@
+package neqsim.process.engineering.pid;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import neqsim.NeqSimTest;
+
+/** Verifies completeness gates and DEXPI proposal materialization. */
+public class PidCompletenessAndDexpiTest extends NeqSimTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void completeProposalHasReviewGatesAndMaterializesInDexpi() throws Exception {
+    PidDesignModel model = new PidDesignModel("PID-PACKAGE-TEST", "NORSOK-COMPLETE");
+    add(model, "PT-101", PidElementType.MEASUREMENT);
+    add(model, "PIC-101", PidElementType.CONTROLLER);
+    add(model, "PCV-101", PidElementType.CONTROL_VALVE);
+    add(model, "PAHH-101", PidElementType.TRIP);
+    add(model, "ESDV-101", PidElementType.SHUTDOWN_VALVE);
+
+    PidCompletenessReport report = PidCompletenessValidator.validate(model);
+    assertTrue(report.isStructurallyComplete());
+    assertFalse(report.isReadyForApproval());
+    assertTrue(report.toJson().contains("PID-HAZOP-LOPA-REQUIRED"));
+
+    Path dexpi = temporaryDirectory.resolve("plant-pydexpi.xml");
+    Files.write(dexpi, "<?xml version=\"1.0\"?><PlantModel></PlantModel>".getBytes(StandardCharsets.UTF_8));
+    PidDexpiMaterializer.materialize(model, dexpi);
+    String xml = new String(Files.readAllBytes(dexpi), StandardCharsets.UTF_8);
+    assertTrue(xml.contains("NeqSimPidDesignModel"));
+    assertTrue(xml.contains("PT-101"));
+    assertTrue(xml.contains("pid-completeness-report.json"));
+  }
+
+  private static void add(PidDesignModel model, String tag, PidElementType type) {
+    model.add(new PidElement("PID-" + tag, tag, type).equipment("20-VG-001").provenance("TEST-RULE",
+        "Completeness test proposal"));
+  }
+}

--- a/src/test/java/neqsim/process/engineering/pid/SafeguardingPidSynthesisTest.java
+++ b/src/test/java/neqsim/process/engineering/pid/SafeguardingPidSynthesisTest.java
@@ -29,8 +29,7 @@ public class SafeguardingPidSynthesisTest extends NeqSimTest {
   void completeProfileAddsTripsIsolationBlowdownAndRelief() {
     EngineeringProject project = createProject();
     PidDesignModel model = PidDesignSynthesizer.synthesize(project,
-        new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"),
-        NorsokPidRuleCatalog.completeProposals());
+        new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"), NorsokPidRuleCatalog.completeProposals());
 
     assertEquals(58, model.getElements().size());
     assertEquals(10, model.getElementsByType(PidElementType.TRIP).size());
@@ -88,17 +87,14 @@ public class SafeguardingPidSynthesisTest extends NeqSimTest {
     process.add(pump);
     EngineeringProject project = NorsokOffshoreEngineeringBuilder.from("Complete safeguarding proposal", process)
         .projectId("PID-SAFEGUARD-TEST").build();
-    ProtectedItem protectedSeparator =
-        new ProtectedItem("20-VG-001", 70.0).setReliefSetPressureBara(68.0);
+    ProtectedItem protectedSeparator = new ProtectedItem("20-VG-001", 70.0).setReliefSetPressureBara(68.0);
     ReliefScenario blockedOutlet = new ReliefScenario.Builder("Blocked outlet", ReliefCause.BLOCKED_OUTLET)
-        .phase(ReliefPhase.VAPOUR).reliefRateKgPerS(3.0).reliefTemperatureK(330.0)
-        .molarMassKgPerMol(0.020).compressibility(0.95).specificHeatRatio(1.25).build();
-    project.addOverpressureStudy(
-        new OverpressureProtectionStudy(protectedSeparator).addScenario(blockedOutlet));
+        .phase(ReliefPhase.VAPOUR).reliefRateKgPerS(3.0).reliefTemperatureK(330.0).molarMassKgPerMol(0.020)
+        .compressibility(0.95).specificHeatRatio(1.25).build();
+    project.addOverpressureStudy(new OverpressureProtectionStudy(protectedSeparator).addScenario(blockedOutlet));
     project.addReliefDeviceDesignInput(new ReliefDeviceDesignInput("20-PSV-101", "20-VG-001")
-        .setSelectedOrificeAreaIn2(4.34).setInletPiping(0.08, 2.0, 1.5)
-        .setOutletPiping(0.15, 20.0, 4.0).setConcurrencyGroup("FIRE-ZONE-A")
-        .setEvidenceReference("PRELIMINARY-PSV-DATASHEET"));
+        .setSelectedOrificeAreaIn2(4.34).setInletPiping(0.08, 2.0, 1.5).setOutletPiping(0.15, 20.0, 4.0)
+        .setConcurrencyGroup("FIRE-ZONE-A").setEvidenceReference("PRELIMINARY-PSV-DATASHEET"));
     return project;
   }
 }


### PR DESCRIPTION
## What changed

- validates generated P&ID proposal references, minimum functional coverage, and approval gates
- exports `pid-design-model.json` and `pid-completeness-report.json` beside the governed engineering package
- materializes proposal tags and traceability metadata into Proteus and PyDEXPI exchange documents
- adds a focused complete-process notebook with separator, compressor, cooler, pump, control and safeguarding proposals
- independently imports and renders the exported P&ID using PyDEXPI
- uploads the executed notebook, DEXPI package, SVG rendering and sidecars as CI artifacts
- documents the review-required / not-fit-for-construction boundary

## Validation

- focused Java completeness and XML materialization test
- dedicated Java build + notebook execution workflow
- PyDEXPI 1.2.0 import and SVG render are mandatory
- CI asserts at least 50 generated proposal elements, structural completeness, and unresolved approval gates

## Stack

PR 4 of 4. Depends on #2480.