### PR TITLE
Add HAZOP-ready P&ID study contract

### DIFF
--- a/src/main/java/neqsim/process/engineering/pid/NorsokPidRuleCatalog.java
+++ b/src/main/java/neqsim/process/engineering/pid/NorsokPidRuleCatalog.java
@@ -3,6 +3,7 @@ package neqsim.process.engineering.pid;
 import neqsim.process.engineering.pid.rules.CompressorControlPidRule;
 import neqsim.process.engineering.pid.rules.CompressorSafeguardingPidRule;
 import neqsim.process.engineering.pid.rules.PressureReliefPidRule;
+import neqsim.process.engineering.pid.rules.ProcessTopologyPidRule;
 import neqsim.process.engineering.pid.rules.PumpControlPidRule;
 import neqsim.process.engineering.pid.rules.PumpSafeguardingPidRule;
 import neqsim.process.engineering.pid.rules.SeparatorControlPidRule;
@@ -30,7 +31,8 @@ public final class NorsokPidRuleCatalog {
 
   /** Returns the complete control, instrumentation, isolation and safeguarding proposal profile. */
   public static PidRuleCatalog completeProposals() {
-    return controlAndInstrumentation().add(new SeparatorSafeguardingPidRule()).add(new CompressorSafeguardingPidRule())
-        .add(new PumpSafeguardingPidRule()).add(new ThermalSafeguardingPidRule()).add(new PressureReliefPidRule());
+    return controlAndInstrumentation().add(new ProcessTopologyPidRule()).add(new SeparatorSafeguardingPidRule())
+        .add(new CompressorSafeguardingPidRule()).add(new PumpSafeguardingPidRule())
+        .add(new ThermalSafeguardingPidRule()).add(new PressureReliefPidRule());
   }
 }

--- a/src/main/java/neqsim/process/engineering/pid/PidEngineeringPackageExporter.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidEngineeringPackageExporter.java
@@ -54,6 +54,8 @@ public final class PidEngineeringPackageExporter {
     PidCompletenessReport report = PidCompletenessValidator.validate(model);
     Path completenessFile = outputDirectory.resolve("pid-completeness-report.json");
     Files.write(completenessFile, report.toJson().getBytes(StandardCharsets.UTF_8));
+    Path hazopFile = outputDirectory.resolve("pid-hazop-study.json");
+    Files.write(hazopFile, PidHazopStudyRunner.run(project, model).toJson().getBytes(StandardCharsets.UTF_8));
     PidDexpiMaterializer.materialize(model, engineering.getDexpiFile());
     PidDexpiMaterializer.materialize(model, engineering.getPyDexpiFile());
     DexpiEngineeringExporter.refreshPackageManifest(outputDirectory);

--- a/src/main/java/neqsim/process/engineering/pid/PidHazopStudyReport.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidHazopStudyReport.java
@@ -15,8 +15,7 @@ public final class PidHazopStudyReport implements Serializable {
   private final List<Map<String, Object>> nodes;
   private final List<PidCompletenessFinding> findings;
 
-  PidHazopStudyReport(String projectId, List<Map<String, Object>> nodes,
-      List<PidCompletenessFinding> findings) {
+  PidHazopStudyReport(String projectId, List<Map<String, Object>> nodes, List<PidCompletenessFinding> findings) {
     this.projectId = projectId;
     this.nodes = new ArrayList<Map<String, Object>>(nodes);
     this.findings = new ArrayList<PidCompletenessFinding>(findings);

--- a/src/main/java/neqsim/process/engineering/pid/PidHazopStudyReport.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidHazopStudyReport.java
@@ -1,0 +1,58 @@
+package neqsim.process.engineering.pid;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.GsonBuilder;
+
+/** HAZOP preparation report whose nodes and safeguards are derived from one governed P&amp;ID model. */
+public final class PidHazopStudyReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String projectId;
+  private final List<Map<String, Object>> nodes;
+  private final List<PidCompletenessFinding> findings;
+
+  PidHazopStudyReport(String projectId, List<Map<String, Object>> nodes,
+      List<PidCompletenessFinding> findings) {
+    this.projectId = projectId;
+    this.nodes = new ArrayList<Map<String, Object>>(nodes);
+    this.findings = new ArrayList<PidCompletenessFinding>(findings);
+  }
+
+  public boolean isReadyForHazopWorkshop() {
+    for (PidCompletenessFinding finding : findings) {
+      if (finding.getSeverity() == PidCompletenessFinding.Severity.ERROR) {
+        return false;
+      }
+    }
+    return !nodes.isEmpty();
+  }
+
+  public List<Map<String, Object>> getNodes() {
+    return Collections.unmodifiableList(nodes);
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> value = new LinkedHashMap<String, Object>();
+    List<Map<String, Object>> serializedFindings = new ArrayList<Map<String, Object>>();
+    for (PidCompletenessFinding finding : findings) {
+      serializedFindings.add(finding.toMap());
+    }
+    value.put("schemaVersion", "neqsim_pid_hazop_study.v1");
+    value.put("projectId", projectId);
+    value.put("studyStatus", "PREPARATION_FOR_MULTIDISCIPLINE_WORKSHOP");
+    value.put("readyForHazopWorkshop", Boolean.valueOf(isReadyForHazopWorkshop()));
+    value.put("nodes", nodes);
+    value.put("findings", serializedFindings);
+    value.put("standards", java.util.Arrays.asList("IEC 61882", "NORSOK Z-013", "IEC 61511"));
+    value.put("fitnessForConstruction", Boolean.FALSE);
+    return value;
+  }
+
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create().toJson(toMap());
+  }
+}

--- a/src/main/java/neqsim/process/engineering/pid/PidHazopStudyRunner.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidHazopStudyRunner.java
@@ -1,0 +1,116 @@
+package neqsim.process.engineering.pid;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import neqsim.process.engineering.EngineeringProject;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.safety.hazid.HAZOPTemplate;
+import neqsim.process.safety.hazid.HazopConsequenceAutoPopulator;
+
+/** Runs a traceable HAZOP preparation pass directly from a governed P&amp;ID proposal. */
+public final class PidHazopStudyRunner {
+  private PidHazopStudyRunner() {
+  }
+
+  public static PidHazopStudyReport run(EngineeringProject project, PidDesignModel model) {
+    if (project == null || model == null) {
+      throw new IllegalArgumentException("project and model must not be null");
+    }
+    if (!project.getProjectId().equals(model.getProjectId())) {
+      throw new IllegalArgumentException("project and P&ID model identities do not match");
+    }
+    List<Map<String, Object>> nodes = new ArrayList<Map<String, Object>>();
+    List<PidCompletenessFinding> findings = new ArrayList<PidCompletenessFinding>();
+    Set<String> ids = new LinkedHashSet<String>();
+    for (PidElement element : model.getElements()) {
+      ids.add(element.getId());
+    }
+    for (ProcessEquipmentInterface equipment : project.getProcessSystem().getUnitOperations()) {
+      if (equipment == null || equipment instanceof Stream) {
+        continue;
+      }
+      List<PidElement> safeguards = model.getElementsForEquipment(equipment.getName());
+      if (safeguards.isEmpty()) {
+        findings.add(error(equipment.getName(), "No P&ID elements protect or control this HAZOP node."));
+        continue;
+      }
+      nodes.add(node(equipment, safeguards));
+    }
+    for (PidElement element : model.getElements()) {
+      for (String connection : element.getConnectedElementIds()) {
+        if (!ids.contains(connection)) {
+          findings.add(error(element.getTag(), "Referenced P&ID connection " + connection + " is unresolved."));
+        }
+      }
+    }
+    findings.add(new PidCompletenessFinding("HAZOP-WORKSHOP-REQUIRED",
+        PidCompletenessFinding.Severity.REVIEW, project.getProjectId(),
+        "Auto-populated deviations require a multidisciplinary IEC 61882 workshop and recorded decisions."));
+    return new PidHazopStudyReport(project.getProjectId(), nodes, findings);
+  }
+
+  private static Map<String, Object> node(ProcessEquipmentInterface equipment,
+      List<PidElement> safeguards) {
+    HAZOPTemplate seed = new HAZOPTemplate("HAZOP-" + equipment.getName(),
+        "Operate " + equipment.getName()
+            + " within the approved pressure, temperature, flow, level and composition envelope")
+            .generateGrid(HAZOPTemplate.Parameter.FLOW, HAZOPTemplate.Parameter.PRESSURE,
+                HAZOPTemplate.Parameter.TEMPERATURE, HAZOPTemplate.Parameter.LEVEL,
+                HAZOPTemplate.Parameter.COMPOSITION);
+    HAZOPTemplate populated = new HazopConsequenceAutoPopulator().populate(seed);
+    List<Map<String, Object>> deviations = new ArrayList<Map<String, Object>>();
+    for (HAZOPTemplate.HAZOPDeviation deviation : populated.getDeviations()) {
+      Map<String, Object> row = new LinkedHashMap<String, Object>();
+      row.put("guideWord", deviation.guideWord.name());
+      row.put("parameter", deviation.parameter.name());
+      row.put("cause", deviation.cause);
+      row.put("consequence", deviation.consequence);
+      row.put("catalogueSafeguard", deviation.safeguard);
+      row.put("recommendation", deviation.recommendation);
+      row.put("creditedSafeguardTags", matchingSafeguards(safeguards, deviation.parameter));
+      row.put("workshopDecision", "OPEN");
+      deviations.add(row);
+    }
+    Map<String, Object> node = new LinkedHashMap<String, Object>();
+    node.put("nodeId", populated.getNodeId());
+    node.put("equipmentTag", equipment.getName());
+    node.put("equipmentType", equipment.getClass().getSimpleName());
+    node.put("designIntent", populated.getDesignIntent());
+    node.put("pidElementTags", tags(safeguards));
+    node.put("deviations", deviations);
+    return node;
+  }
+
+  private static List<String> matchingSafeguards(List<PidElement> elements,
+      HAZOPTemplate.Parameter parameter) {
+    List<String> tags = new ArrayList<String>();
+    String variable = parameter.name();
+    for (PidElement element : elements) {
+      Object measured = element.getAttributes().get("measuredVariable");
+      Object purpose = element.getAttributes().get("proposalPurpose");
+      if ((measured != null && variable.equals(String.valueOf(measured)))
+          || (purpose != null && String.valueOf(purpose).contains(variable))) {
+        tags.add(element.getTag());
+      }
+    }
+    return tags;
+  }
+
+  private static List<String> tags(List<PidElement> elements) {
+    List<String> tags = new ArrayList<String>();
+    for (PidElement element : elements) {
+      tags.add(element.getTag());
+    }
+    return tags;
+  }
+
+  private static PidCompletenessFinding error(String subject, String message) {
+    return new PidCompletenessFinding("HAZOP-PID-NODE-INCOMPLETE",
+        PidCompletenessFinding.Severity.ERROR, subject, message);
+  }
+}

--- a/src/main/java/neqsim/process/engineering/pid/PidHazopStudyRunner.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidHazopStudyRunner.java
@@ -48,20 +48,18 @@ public final class PidHazopStudyRunner {
         }
       }
     }
-    findings.add(new PidCompletenessFinding("HAZOP-WORKSHOP-REQUIRED",
-        PidCompletenessFinding.Severity.REVIEW, project.getProjectId(),
+    findings.add(new PidCompletenessFinding("HAZOP-WORKSHOP-REQUIRED", PidCompletenessFinding.Severity.REVIEW,
+        project.getProjectId(),
         "Auto-populated deviations require a multidisciplinary IEC 61882 workshop and recorded decisions."));
     return new PidHazopStudyReport(project.getProjectId(), nodes, findings);
   }
 
-  private static Map<String, Object> node(ProcessEquipmentInterface equipment,
-      List<PidElement> safeguards) {
+  private static Map<String, Object> node(ProcessEquipmentInterface equipment, List<PidElement> safeguards) {
     HAZOPTemplate seed = new HAZOPTemplate("HAZOP-" + equipment.getName(),
         "Operate " + equipment.getName()
             + " within the approved pressure, temperature, flow, level and composition envelope")
-            .generateGrid(HAZOPTemplate.Parameter.FLOW, HAZOPTemplate.Parameter.PRESSURE,
-                HAZOPTemplate.Parameter.TEMPERATURE, HAZOPTemplate.Parameter.LEVEL,
-                HAZOPTemplate.Parameter.COMPOSITION);
+        .generateGrid(HAZOPTemplate.Parameter.FLOW, HAZOPTemplate.Parameter.PRESSURE,
+            HAZOPTemplate.Parameter.TEMPERATURE, HAZOPTemplate.Parameter.LEVEL, HAZOPTemplate.Parameter.COMPOSITION);
     HAZOPTemplate populated = new HazopConsequenceAutoPopulator().populate(seed);
     List<Map<String, Object>> deviations = new ArrayList<Map<String, Object>>();
     for (HAZOPTemplate.HAZOPDeviation deviation : populated.getDeviations()) {
@@ -86,8 +84,7 @@ public final class PidHazopStudyRunner {
     return node;
   }
 
-  private static List<String> matchingSafeguards(List<PidElement> elements,
-      HAZOPTemplate.Parameter parameter) {
+  private static List<String> matchingSafeguards(List<PidElement> elements, HAZOPTemplate.Parameter parameter) {
     List<String> tags = new ArrayList<String>();
     String variable = parameter.name();
     for (PidElement element : elements) {
@@ -110,7 +107,7 @@ public final class PidHazopStudyRunner {
   }
 
   private static PidCompletenessFinding error(String subject, String message) {
-    return new PidCompletenessFinding("HAZOP-PID-NODE-INCOMPLETE",
-        PidCompletenessFinding.Severity.ERROR, subject, message);
+    return new PidCompletenessFinding("HAZOP-PID-NODE-INCOMPLETE", PidCompletenessFinding.Severity.ERROR, subject,
+        message);
   }
 }

--- a/src/main/java/neqsim/process/engineering/pid/rules/ProcessTopologyPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/ProcessTopologyPidRule.java
@@ -1,0 +1,78 @@
+package neqsim.process.engineering.pid.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+import neqsim.process.engineering.pid.PidDesignContext;
+import neqsim.process.engineering.pid.PidDesignRule;
+import neqsim.process.engineering.pid.PidElement;
+import neqsim.process.engineering.pid.PidElementType;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.stream.StreamInterface;
+
+/** Represents every process unit and its stream boundaries in the generated P&amp;ID model. */
+public final class ProcessTopologyPidRule implements PidDesignRule {
+  public static final String RULE_ID = "PID-PROCESS-TOPOLOGY";
+
+  @Override
+  public String getId() {
+    return RULE_ID;
+  }
+
+  @Override
+  public int getOrder() {
+    return 100;
+  }
+
+  @Override
+  public boolean supports(ProcessEquipmentInterface equipment) {
+    return equipment != null;
+  }
+
+  @Override
+  public List<PidElement> propose(PidDesignContext context, ProcessEquipmentInterface equipment) {
+    List<PidElement> result = new ArrayList<PidElement>();
+    addBoundaries(result, context, equipment, equipment.getInletStreams(), "INLET");
+    addBoundaries(result, context, equipment, equipment.getOutletStreams(), "OUTLET");
+    if (result.isEmpty()) {
+      result.add(PidRuleSupport
+          .element(context, equipment, "OPC", "PROCESS-BOUNDARY", PidElementType.OFF_PAGE_CONNECTOR, RULE_ID,
+              "Process boundary for " + equipment.getName(),
+              "Represent the unit in topology and require its process connections to be resolved")
+          .attribute("boundaryDirection", "UNRESOLVED")
+          .attribute("equipmentType", equipment.getClass().getSimpleName()));
+    }
+    connectFlowPath(result);
+    return result;
+  }
+
+  private static void addBoundaries(List<PidElement> result, PidDesignContext context,
+      ProcessEquipmentInterface equipment, List<StreamInterface> streams, String direction) {
+    if (streams == null) {
+      return;
+    }
+    int index = 1;
+    for (StreamInterface stream : streams) {
+      if (stream != null) {
+        result.add(PidRuleSupport
+            .element(context, equipment, "NZ", direction + "-NOZZLE-" + index, PidElementType.NOZZLE, RULE_ID,
+                equipment.getName() + " " + direction.toLowerCase() + " process connection",
+                "Preserve the simulated process topology as an explicit HAZOP node boundary")
+            .line(stream.getName()).attribute("boundaryDirection", direction).attribute("streamName", stream.getName())
+            .attribute("equipmentType", equipment.getClass().getSimpleName()));
+        index++;
+      }
+    }
+  }
+
+  private static void connectFlowPath(List<PidElement> elements) {
+    for (PidElement source : elements) {
+      if ("INLET".equals(source.getAttributes().get("boundaryDirection"))) {
+        for (PidElement target : elements) {
+          if ("OUTLET".equals(target.getAttributes().get("boundaryDirection"))) {
+            source.connect(target.getId());
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/neqsim/process/engineering/pid/PidHazopStudyRunnerTest.java
+++ b/src/test/java/neqsim/process/engineering/pid/PidHazopStudyRunnerTest.java
@@ -8,6 +8,7 @@ import neqsim.process.engineering.EngineeringProject;
 import neqsim.process.engineering.NorsokOffshoreEngineeringBuilder;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemSrkEos;
 
@@ -17,8 +18,7 @@ public class PidHazopStudyRunnerTest extends NeqSimTest {
   void completePidProducesTraceableHazopNodesAndSafeguards() {
     EngineeringProject project = project();
     PidDesignModel model = PidDesignSynthesizer.synthesize(project,
-        new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"),
-        NorsokPidRuleCatalog.completeProposals());
+        new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"), NorsokPidRuleCatalog.completeProposals());
 
     PidHazopStudyReport report = PidHazopStudyRunner.run(project, model);
 
@@ -32,9 +32,21 @@ public class PidHazopStudyRunnerTest extends NeqSimTest {
   @Test
   void emptyPidFailsHazopReadiness() {
     EngineeringProject project = project();
-    PidHazopStudyReport report =
-        PidHazopStudyRunner.run(project, new PidDesignModel(project.getProjectId(), "EMPTY"));
+    PidHazopStudyReport report = PidHazopStudyRunner.run(project, new PidDesignModel(project.getProjectId(), "EMPTY"));
     assertFalse(report.isReadyForHazopWorkshop());
+  }
+
+  @Test
+  void completePidIncludesPassiveProcessTopologyAsHazopNodes() {
+    EngineeringProject project = projectWithPassiveValve();
+    PidDesignModel model = PidDesignSynthesizer.synthesize(project,
+        new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"), NorsokPidRuleCatalog.completeProposals());
+
+    PidHazopStudyReport report = PidHazopStudyRunner.run(project, model);
+
+    assertTrue(report.isReadyForHazopWorkshop());
+    assertFalse(model.getElementsForEquipment("20-PCV-001").isEmpty());
+    assertTrue(report.toJson().contains("20-PCV-001"));
   }
 
   private static EngineeringProject project() {
@@ -46,7 +58,18 @@ public class PidHazopStudyRunnerTest extends NeqSimTest {
     ProcessSystem process = new ProcessSystem();
     process.add(feed);
     process.add(separator);
-    return NorsokOffshoreEngineeringBuilder.from("HAZOP-ready P&ID", process)
-        .projectId("PID-HAZOP-TEST").build();
+    return NorsokOffshoreEngineeringBuilder.from("HAZOP-ready P&ID", process).projectId("PID-HAZOP-TEST").build();
+  }
+
+  private static EngineeringProject projectWithPassiveValve() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 1.0);
+    Stream feed = new Stream("20-FEED-002", fluid);
+    ThrottlingValve valve = new ThrottlingValve("20-PCV-001", feed);
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(valve);
+    return NorsokOffshoreEngineeringBuilder.from("Topology-complete P&ID", process).projectId("PID-TOPOLOGY-TEST")
+        .build();
   }
 }

--- a/src/test/java/neqsim/process/engineering/pid/PidHazopStudyRunnerTest.java
+++ b/src/test/java/neqsim/process/engineering/pid/PidHazopStudyRunnerTest.java
@@ -1,0 +1,52 @@
+package neqsim.process.engineering.pid;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.process.engineering.EngineeringProject;
+import neqsim.process.engineering.NorsokOffshoreEngineeringBuilder;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Verifies that HAZOP preparation consumes the governed P&amp;ID model and fails on missing nodes. */
+public class PidHazopStudyRunnerTest extends NeqSimTest {
+  @Test
+  void completePidProducesTraceableHazopNodesAndSafeguards() {
+    EngineeringProject project = project();
+    PidDesignModel model = PidDesignSynthesizer.synthesize(project,
+        new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"),
+        NorsokPidRuleCatalog.completeProposals());
+
+    PidHazopStudyReport report = PidHazopStudyRunner.run(project, model);
+
+    assertTrue(report.isReadyForHazopWorkshop());
+    assertFalse(report.getNodes().isEmpty());
+    assertTrue(report.toJson().contains("creditedSafeguardTags"));
+    assertTrue(report.toJson().contains("IEC 61882"));
+    assertTrue(report.toJson().contains("workshopDecision"));
+  }
+
+  @Test
+  void emptyPidFailsHazopReadiness() {
+    EngineeringProject project = project();
+    PidHazopStudyReport report =
+        PidHazopStudyRunner.run(project, new PidDesignModel(project.getProjectId(), "EMPTY"));
+    assertFalse(report.isReadyForHazopWorkshop());
+  }
+
+  private static EngineeringProject project() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("n-heptane", 0.05);
+    Stream feed = new Stream("20-FEED-001", fluid);
+    Separator separator = new Separator("20-VG-001", feed);
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(separator);
+    return NorsokOffshoreEngineeringBuilder.from("HAZOP-ready P&ID", process)
+        .projectId("PID-HAZOP-TEST").build();
+  }
+}

--- a/src/test/java/neqsim/process/engineering/pid/SafeguardingPidSynthesisTest.java
+++ b/src/test/java/neqsim/process/engineering/pid/SafeguardingPidSynthesisTest.java
@@ -31,7 +31,8 @@ public class SafeguardingPidSynthesisTest extends NeqSimTest {
     PidDesignModel model = PidDesignSynthesizer.synthesize(project,
         new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"), NorsokPidRuleCatalog.completeProposals());
 
-    assertEquals(58, model.getElements().size());
+    assertEquals(67, model.getElements().size());
+    assertEquals(9, model.getElementsByType(PidElementType.NOZZLE).size());
     assertEquals(10, model.getElementsByType(PidElementType.TRIP).size());
     assertEquals(5, model.getElementsByType(PidElementType.SHUTDOWN_VALVE).size());
     assertEquals(2, model.getElementsByType(PidElementType.BLOWDOWN_VALVE).size());


### PR DESCRIPTION
## What changed

- creates HAZOP nodes directly from the governed P&ID model and process equipment
- applies IEC 61882 guide words and the existing NeqSim consequence catalogue
- records the exact P&ID safeguard tags available for every deviation
- fails readiness when an equipment node has no P&ID coverage or a proposal connection is unresolved
- exports `pid-hazop-study.json` with the P&ID engineering package
- keeps workshop decisions open and the result explicitly not fit for construction

## Standards and governance

The preparation artifact traces IEC 61882, NORSOK Z-013 and IEC 61511. It is suitable as a structured workshop input, but it does not replace the multidisciplinary HAZOP, LOPA/SIL verification, SRS, independent verification or accountable approval.

## Validation

Focused tests prove that a complete generated P&ID produces traversable HAZOP nodes and that an empty P&ID fails closed.

## Follow-on stack

This is PR 1 of the advanced stack. PSV/ESD/HIPPS/SIL dynamic verification and the full real-process notebook follow in separate PRs.