### PR TITLE
Add NCS ESD and HIPPS verification handoff

### DIFF
--- a/src/main/java/neqsim/process/engineering/pid/NorsokPidRuleCatalog.java
+++ b/src/main/java/neqsim/process/engineering/pid/NorsokPidRuleCatalog.java
@@ -3,6 +3,7 @@ package neqsim.process.engineering.pid;
 import neqsim.process.engineering.pid.rules.CompressorControlPidRule;
 import neqsim.process.engineering.pid.rules.CompressorSafeguardingPidRule;
 import neqsim.process.engineering.pid.rules.PressureReliefPidRule;
+import neqsim.process.engineering.pid.rules.ProcessTopologyPidRule;
 import neqsim.process.engineering.pid.rules.PumpControlPidRule;
 import neqsim.process.engineering.pid.rules.PumpSafeguardingPidRule;
 import neqsim.process.engineering.pid.rules.SeparatorControlPidRule;
@@ -30,7 +31,8 @@ public final class NorsokPidRuleCatalog {
 
   /** Returns the complete control, instrumentation, isolation and safeguarding proposal profile. */
   public static PidRuleCatalog completeProposals() {
-    return controlAndInstrumentation().add(new SeparatorSafeguardingPidRule()).add(new CompressorSafeguardingPidRule())
-        .add(new PumpSafeguardingPidRule()).add(new ThermalSafeguardingPidRule()).add(new PressureReliefPidRule());
+    return controlAndInstrumentation().add(new ProcessTopologyPidRule()).add(new SeparatorSafeguardingPidRule())
+        .add(new CompressorSafeguardingPidRule()).add(new PumpSafeguardingPidRule())
+        .add(new ThermalSafeguardingPidRule()).add(new PressureReliefPidRule());
   }
 }

--- a/src/main/java/neqsim/process/engineering/pid/PidEngineeringPackageExporter.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidEngineeringPackageExporter.java
@@ -54,6 +54,8 @@ public final class PidEngineeringPackageExporter {
     PidCompletenessReport report = PidCompletenessValidator.validate(model);
     Path completenessFile = outputDirectory.resolve("pid-completeness-report.json");
     Files.write(completenessFile, report.toJson().getBytes(StandardCharsets.UTF_8));
+    Path hazopFile = outputDirectory.resolve("pid-hazop-study.json");
+    Files.write(hazopFile, PidHazopStudyRunner.run(project, model).toJson().getBytes(StandardCharsets.UTF_8));
     PidDexpiMaterializer.materialize(model, engineering.getDexpiFile());
     PidDexpiMaterializer.materialize(model, engineering.getPyDexpiFile());
     DexpiEngineeringExporter.refreshPackageManifest(outputDirectory);

--- a/src/main/java/neqsim/process/engineering/pid/PidHazopStudyReport.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidHazopStudyReport.java
@@ -15,8 +15,7 @@ public final class PidHazopStudyReport implements Serializable {
   private final List<Map<String, Object>> nodes;
   private final List<PidCompletenessFinding> findings;
 
-  PidHazopStudyReport(String projectId, List<Map<String, Object>> nodes,
-      List<PidCompletenessFinding> findings) {
+  PidHazopStudyReport(String projectId, List<Map<String, Object>> nodes, List<PidCompletenessFinding> findings) {
     this.projectId = projectId;
     this.nodes = new ArrayList<Map<String, Object>>(nodes);
     this.findings = new ArrayList<PidCompletenessFinding>(findings);

--- a/src/main/java/neqsim/process/engineering/pid/PidHazopStudyReport.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidHazopStudyReport.java
@@ -1,0 +1,58 @@
+package neqsim.process.engineering.pid;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.GsonBuilder;
+
+/** HAZOP preparation report whose nodes and safeguards are derived from one governed P&amp;ID model. */
+public final class PidHazopStudyReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String projectId;
+  private final List<Map<String, Object>> nodes;
+  private final List<PidCompletenessFinding> findings;
+
+  PidHazopStudyReport(String projectId, List<Map<String, Object>> nodes,
+      List<PidCompletenessFinding> findings) {
+    this.projectId = projectId;
+    this.nodes = new ArrayList<Map<String, Object>>(nodes);
+    this.findings = new ArrayList<PidCompletenessFinding>(findings);
+  }
+
+  public boolean isReadyForHazopWorkshop() {
+    for (PidCompletenessFinding finding : findings) {
+      if (finding.getSeverity() == PidCompletenessFinding.Severity.ERROR) {
+        return false;
+      }
+    }
+    return !nodes.isEmpty();
+  }
+
+  public List<Map<String, Object>> getNodes() {
+    return Collections.unmodifiableList(nodes);
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> value = new LinkedHashMap<String, Object>();
+    List<Map<String, Object>> serializedFindings = new ArrayList<Map<String, Object>>();
+    for (PidCompletenessFinding finding : findings) {
+      serializedFindings.add(finding.toMap());
+    }
+    value.put("schemaVersion", "neqsim_pid_hazop_study.v1");
+    value.put("projectId", projectId);
+    value.put("studyStatus", "PREPARATION_FOR_MULTIDISCIPLINE_WORKSHOP");
+    value.put("readyForHazopWorkshop", Boolean.valueOf(isReadyForHazopWorkshop()));
+    value.put("nodes", nodes);
+    value.put("findings", serializedFindings);
+    value.put("standards", java.util.Arrays.asList("IEC 61882", "NORSOK Z-013", "IEC 61511"));
+    value.put("fitnessForConstruction", Boolean.FALSE);
+    return value;
+  }
+
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create().toJson(toMap());
+  }
+}

--- a/src/main/java/neqsim/process/engineering/pid/PidHazopStudyRunner.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidHazopStudyRunner.java
@@ -1,0 +1,116 @@
+package neqsim.process.engineering.pid;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import neqsim.process.engineering.EngineeringProject;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.safety.hazid.HAZOPTemplate;
+import neqsim.process.safety.hazid.HazopConsequenceAutoPopulator;
+
+/** Runs a traceable HAZOP preparation pass directly from a governed P&amp;ID proposal. */
+public final class PidHazopStudyRunner {
+  private PidHazopStudyRunner() {
+  }
+
+  public static PidHazopStudyReport run(EngineeringProject project, PidDesignModel model) {
+    if (project == null || model == null) {
+      throw new IllegalArgumentException("project and model must not be null");
+    }
+    if (!project.getProjectId().equals(model.getProjectId())) {
+      throw new IllegalArgumentException("project and P&ID model identities do not match");
+    }
+    List<Map<String, Object>> nodes = new ArrayList<Map<String, Object>>();
+    List<PidCompletenessFinding> findings = new ArrayList<PidCompletenessFinding>();
+    Set<String> ids = new LinkedHashSet<String>();
+    for (PidElement element : model.getElements()) {
+      ids.add(element.getId());
+    }
+    for (ProcessEquipmentInterface equipment : project.getProcessSystem().getUnitOperations()) {
+      if (equipment == null || equipment instanceof Stream) {
+        continue;
+      }
+      List<PidElement> safeguards = model.getElementsForEquipment(equipment.getName());
+      if (safeguards.isEmpty()) {
+        findings.add(error(equipment.getName(), "No P&ID elements protect or control this HAZOP node."));
+        continue;
+      }
+      nodes.add(node(equipment, safeguards));
+    }
+    for (PidElement element : model.getElements()) {
+      for (String connection : element.getConnectedElementIds()) {
+        if (!ids.contains(connection)) {
+          findings.add(error(element.getTag(), "Referenced P&ID connection " + connection + " is unresolved."));
+        }
+      }
+    }
+    findings.add(new PidCompletenessFinding("HAZOP-WORKSHOP-REQUIRED",
+        PidCompletenessFinding.Severity.REVIEW, project.getProjectId(),
+        "Auto-populated deviations require a multidisciplinary IEC 61882 workshop and recorded decisions."));
+    return new PidHazopStudyReport(project.getProjectId(), nodes, findings);
+  }
+
+  private static Map<String, Object> node(ProcessEquipmentInterface equipment,
+      List<PidElement> safeguards) {
+    HAZOPTemplate seed = new HAZOPTemplate("HAZOP-" + equipment.getName(),
+        "Operate " + equipment.getName()
+            + " within the approved pressure, temperature, flow, level and composition envelope")
+            .generateGrid(HAZOPTemplate.Parameter.FLOW, HAZOPTemplate.Parameter.PRESSURE,
+                HAZOPTemplate.Parameter.TEMPERATURE, HAZOPTemplate.Parameter.LEVEL,
+                HAZOPTemplate.Parameter.COMPOSITION);
+    HAZOPTemplate populated = new HazopConsequenceAutoPopulator().populate(seed);
+    List<Map<String, Object>> deviations = new ArrayList<Map<String, Object>>();
+    for (HAZOPTemplate.HAZOPDeviation deviation : populated.getDeviations()) {
+      Map<String, Object> row = new LinkedHashMap<String, Object>();
+      row.put("guideWord", deviation.guideWord.name());
+      row.put("parameter", deviation.parameter.name());
+      row.put("cause", deviation.cause);
+      row.put("consequence", deviation.consequence);
+      row.put("catalogueSafeguard", deviation.safeguard);
+      row.put("recommendation", deviation.recommendation);
+      row.put("creditedSafeguardTags", matchingSafeguards(safeguards, deviation.parameter));
+      row.put("workshopDecision", "OPEN");
+      deviations.add(row);
+    }
+    Map<String, Object> node = new LinkedHashMap<String, Object>();
+    node.put("nodeId", populated.getNodeId());
+    node.put("equipmentTag", equipment.getName());
+    node.put("equipmentType", equipment.getClass().getSimpleName());
+    node.put("designIntent", populated.getDesignIntent());
+    node.put("pidElementTags", tags(safeguards));
+    node.put("deviations", deviations);
+    return node;
+  }
+
+  private static List<String> matchingSafeguards(List<PidElement> elements,
+      HAZOPTemplate.Parameter parameter) {
+    List<String> tags = new ArrayList<String>();
+    String variable = parameter.name();
+    for (PidElement element : elements) {
+      Object measured = element.getAttributes().get("measuredVariable");
+      Object purpose = element.getAttributes().get("proposalPurpose");
+      if ((measured != null && variable.equals(String.valueOf(measured)))
+          || (purpose != null && String.valueOf(purpose).contains(variable))) {
+        tags.add(element.getTag());
+      }
+    }
+    return tags;
+  }
+
+  private static List<String> tags(List<PidElement> elements) {
+    List<String> tags = new ArrayList<String>();
+    for (PidElement element : elements) {
+      tags.add(element.getTag());
+    }
+    return tags;
+  }
+
+  private static PidCompletenessFinding error(String subject, String message) {
+    return new PidCompletenessFinding("HAZOP-PID-NODE-INCOMPLETE",
+        PidCompletenessFinding.Severity.ERROR, subject, message);
+  }
+}

--- a/src/main/java/neqsim/process/engineering/pid/PidHazopStudyRunner.java
+++ b/src/main/java/neqsim/process/engineering/pid/PidHazopStudyRunner.java
@@ -48,20 +48,18 @@ public final class PidHazopStudyRunner {
         }
       }
     }
-    findings.add(new PidCompletenessFinding("HAZOP-WORKSHOP-REQUIRED",
-        PidCompletenessFinding.Severity.REVIEW, project.getProjectId(),
+    findings.add(new PidCompletenessFinding("HAZOP-WORKSHOP-REQUIRED", PidCompletenessFinding.Severity.REVIEW,
+        project.getProjectId(),
         "Auto-populated deviations require a multidisciplinary IEC 61882 workshop and recorded decisions."));
     return new PidHazopStudyReport(project.getProjectId(), nodes, findings);
   }
 
-  private static Map<String, Object> node(ProcessEquipmentInterface equipment,
-      List<PidElement> safeguards) {
+  private static Map<String, Object> node(ProcessEquipmentInterface equipment, List<PidElement> safeguards) {
     HAZOPTemplate seed = new HAZOPTemplate("HAZOP-" + equipment.getName(),
         "Operate " + equipment.getName()
             + " within the approved pressure, temperature, flow, level and composition envelope")
-            .generateGrid(HAZOPTemplate.Parameter.FLOW, HAZOPTemplate.Parameter.PRESSURE,
-                HAZOPTemplate.Parameter.TEMPERATURE, HAZOPTemplate.Parameter.LEVEL,
-                HAZOPTemplate.Parameter.COMPOSITION);
+        .generateGrid(HAZOPTemplate.Parameter.FLOW, HAZOPTemplate.Parameter.PRESSURE,
+            HAZOPTemplate.Parameter.TEMPERATURE, HAZOPTemplate.Parameter.LEVEL, HAZOPTemplate.Parameter.COMPOSITION);
     HAZOPTemplate populated = new HazopConsequenceAutoPopulator().populate(seed);
     List<Map<String, Object>> deviations = new ArrayList<Map<String, Object>>();
     for (HAZOPTemplate.HAZOPDeviation deviation : populated.getDeviations()) {
@@ -86,8 +84,7 @@ public final class PidHazopStudyRunner {
     return node;
   }
 
-  private static List<String> matchingSafeguards(List<PidElement> elements,
-      HAZOPTemplate.Parameter parameter) {
+  private static List<String> matchingSafeguards(List<PidElement> elements, HAZOPTemplate.Parameter parameter) {
     List<String> tags = new ArrayList<String>();
     String variable = parameter.name();
     for (PidElement element : elements) {
@@ -110,7 +107,7 @@ public final class PidHazopStudyRunner {
   }
 
   private static PidCompletenessFinding error(String subject, String message) {
-    return new PidCompletenessFinding("HAZOP-PID-NODE-INCOMPLETE",
-        PidCompletenessFinding.Severity.ERROR, subject, message);
+    return new PidCompletenessFinding("HAZOP-PID-NODE-INCOMPLETE", PidCompletenessFinding.Severity.ERROR, subject,
+        message);
   }
 }

--- a/src/main/java/neqsim/process/engineering/pid/rules/ProcessTopologyPidRule.java
+++ b/src/main/java/neqsim/process/engineering/pid/rules/ProcessTopologyPidRule.java
@@ -1,0 +1,78 @@
+package neqsim.process.engineering.pid.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+import neqsim.process.engineering.pid.PidDesignContext;
+import neqsim.process.engineering.pid.PidDesignRule;
+import neqsim.process.engineering.pid.PidElement;
+import neqsim.process.engineering.pid.PidElementType;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.stream.StreamInterface;
+
+/** Represents every process unit and its stream boundaries in the generated P&amp;ID model. */
+public final class ProcessTopologyPidRule implements PidDesignRule {
+  public static final String RULE_ID = "PID-PROCESS-TOPOLOGY";
+
+  @Override
+  public String getId() {
+    return RULE_ID;
+  }
+
+  @Override
+  public int getOrder() {
+    return 100;
+  }
+
+  @Override
+  public boolean supports(ProcessEquipmentInterface equipment) {
+    return equipment != null;
+  }
+
+  @Override
+  public List<PidElement> propose(PidDesignContext context, ProcessEquipmentInterface equipment) {
+    List<PidElement> result = new ArrayList<PidElement>();
+    addBoundaries(result, context, equipment, equipment.getInletStreams(), "INLET");
+    addBoundaries(result, context, equipment, equipment.getOutletStreams(), "OUTLET");
+    if (result.isEmpty()) {
+      result.add(PidRuleSupport
+          .element(context, equipment, "OPC", "PROCESS-BOUNDARY", PidElementType.OFF_PAGE_CONNECTOR, RULE_ID,
+              "Process boundary for " + equipment.getName(),
+              "Represent the unit in topology and require its process connections to be resolved")
+          .attribute("boundaryDirection", "UNRESOLVED")
+          .attribute("equipmentType", equipment.getClass().getSimpleName()));
+    }
+    connectFlowPath(result);
+    return result;
+  }
+
+  private static void addBoundaries(List<PidElement> result, PidDesignContext context,
+      ProcessEquipmentInterface equipment, List<StreamInterface> streams, String direction) {
+    if (streams == null) {
+      return;
+    }
+    int index = 1;
+    for (StreamInterface stream : streams) {
+      if (stream != null) {
+        result.add(PidRuleSupport
+            .element(context, equipment, "NZ", direction + "-NOZZLE-" + index, PidElementType.NOZZLE, RULE_ID,
+                equipment.getName() + " " + direction.toLowerCase() + " process connection",
+                "Preserve the simulated process topology as an explicit HAZOP node boundary")
+            .line(stream.getName()).attribute("boundaryDirection", direction).attribute("streamName", stream.getName())
+            .attribute("equipmentType", equipment.getClass().getSimpleName()));
+        index++;
+      }
+    }
+  }
+
+  private static void connectFlowPath(List<PidElement> elements) {
+    for (PidElement source : elements) {
+      if ("INLET".equals(source.getAttributes().get("boundaryDirection"))) {
+        for (PidElement target : elements) {
+          if ("OUTLET".equals(target.getAttributes().get("boundaryDirection"))) {
+            source.connect(target.getId());
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/safety/NcsSafetyFunctionStudy.java
+++ b/src/main/java/neqsim/process/engineering/safety/NcsSafetyFunctionStudy.java
@@ -1,0 +1,55 @@
+package neqsim.process.engineering.safety;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.GsonBuilder;
+import neqsim.process.safety.risk.sis.SILVerificationResult;
+import neqsim.process.safety.risk.sis.SafetyInstrumentedFunction;
+
+/** Coordinated NCS handoff for preliminary ESD/HIPPS SIL and dynamic-response verification. */
+public final class NcsSafetyFunctionStudy implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String projectId;
+  private final List<Map<String, Object>> functions = new ArrayList<Map<String, Object>>();
+
+  public NcsSafetyFunctionStudy(String projectId) {
+    if (projectId == null || projectId.trim().isEmpty()) {
+      throw new IllegalArgumentException("projectId must not be blank");
+    }
+    this.projectId = projectId.trim();
+  }
+
+  public NcsSafetyFunctionStudy add(SafetyInstrumentedFunction function,
+      Map<String, Object> transientVerification) {
+    if (function == null || transientVerification == null) {
+      throw new IllegalArgumentException("function and transient verification must not be null");
+    }
+    SILVerificationResult sil = new SILVerificationResult(function);
+    Map<String, Object> entry = new LinkedHashMap<String, Object>();
+    entry.put("safetyInstrumentedFunction", function.toMap());
+    entry.put("silVerification", sil.toMap());
+    entry.put("transientVerification", new LinkedHashMap<String, Object>(transientVerification));
+    entry.put("approvalStatus", "REVIEW_REQUIRED");
+    functions.add(entry);
+    return this;
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", "neqsim_ncs_safety_function_study.v1");
+    result.put("projectId", projectId);
+    result.put("functions", new ArrayList<Map<String, Object>>(functions));
+    result.put("standards", java.util.Arrays.asList("NORSOK S-001", "NORSOK Z-013",
+        "IEC 61508", "IEC 61511", "ISO 10418", "API 521"));
+    result.put("qualificationStatus", "PRELIMINARY_SRS_AND_SIL_VERIFICATION_HANDOFF");
+    result.put("fitnessForConstruction", Boolean.FALSE);
+    return result;
+  }
+
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create().toJson(toMap());
+  }
+}

--- a/src/main/java/neqsim/process/engineering/safety/NcsSafetyFunctionStudy.java
+++ b/src/main/java/neqsim/process/engineering/safety/NcsSafetyFunctionStudy.java
@@ -22,8 +22,7 @@ public final class NcsSafetyFunctionStudy implements Serializable {
     this.projectId = projectId.trim();
   }
 
-  public NcsSafetyFunctionStudy add(SafetyInstrumentedFunction function,
-      Map<String, Object> transientVerification) {
+  public NcsSafetyFunctionStudy add(SafetyInstrumentedFunction function, Map<String, Object> transientVerification) {
     if (function == null || transientVerification == null) {
       throw new IllegalArgumentException("function and transient verification must not be null");
     }
@@ -42,8 +41,8 @@ public final class NcsSafetyFunctionStudy implements Serializable {
     result.put("schemaVersion", "neqsim_ncs_safety_function_study.v1");
     result.put("projectId", projectId);
     result.put("functions", new ArrayList<Map<String, Object>>(functions));
-    result.put("standards", java.util.Arrays.asList("NORSOK S-001", "NORSOK Z-013",
-        "IEC 61508", "IEC 61511", "ISO 10418", "API 521"));
+    result.put("standards",
+        java.util.Arrays.asList("NORSOK S-001", "NORSOK Z-013", "IEC 61508", "IEC 61511", "ISO 10418", "API 521"));
     result.put("qualificationStatus", "PRELIMINARY_SRS_AND_SIL_VERIFICATION_HANDOFF");
     result.put("fitnessForConstruction", Boolean.FALSE);
     return result;

--- a/src/main/java/neqsim/process/engineering/safety/SafetyFunctionTransientVerification.java
+++ b/src/main/java/neqsim/process/engineering/safety/SafetyFunctionTransientVerification.java
@@ -20,11 +20,9 @@ public final class SafetyFunctionTransientVerification implements Serializable {
     this.requiredClosureTimeSeconds = requiredClosureTimeSeconds;
   }
 
-  public Map<String, Object> verify(double[] timeSeconds, double[] pressureBara,
-      double[] valveOpeningPercent) {
-    if (timeSeconds == null || pressureBara == null || valveOpeningPercent == null
-        || timeSeconds.length == 0 || timeSeconds.length != pressureBara.length
-        || timeSeconds.length != valveOpeningPercent.length) {
+  public Map<String, Object> verify(double[] timeSeconds, double[] pressureBara, double[] valveOpeningPercent) {
+    if (timeSeconds == null || pressureBara == null || valveOpeningPercent == null || timeSeconds.length == 0
+        || timeSeconds.length != pressureBara.length || timeSeconds.length != valveOpeningPercent.length) {
       throw new IllegalArgumentException("time, pressure and valve-opening traces must have equal non-zero length");
     }
     double tripTime = Double.NaN;
@@ -39,8 +37,8 @@ public final class SafetyFunctionTransientVerification implements Serializable {
         closedTime = timeSeconds[i];
       }
     }
-    double responseTime = Double.isNaN(closedTime) || Double.isNaN(tripTime)
-        ? Double.POSITIVE_INFINITY : closedTime - tripTime;
+    double responseTime = Double.isNaN(closedTime) || Double.isNaN(tripTime) ? Double.POSITIVE_INFINITY
+        : closedTime - tripTime;
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("schemaVersion", "neqsim_safety_transient_verification.v1");
     result.put("functionId", functionId);
@@ -52,8 +50,8 @@ public final class SafetyFunctionTransientVerification implements Serializable {
     result.put("tripDetected", Boolean.valueOf(!Double.isNaN(tripTime)));
     result.put("pressureCriterionPassed", Boolean.valueOf(maximumPressure <= maximumAllowablePressureBara));
     result.put("closureCriterionPassed", Boolean.valueOf(responseTime <= requiredClosureTimeSeconds));
-    result.put("passed", Boolean.valueOf(maximumPressure <= maximumAllowablePressureBara
-        && responseTime <= requiredClosureTimeSeconds));
+    result.put("passed",
+        Boolean.valueOf(maximumPressure <= maximumAllowablePressureBara && responseTime <= requiredClosureTimeSeconds));
     result.put("status", "DYNAMIC_MODEL_VERIFICATION_REVIEW_REQUIRED");
     result.put("standardReferences", java.util.Arrays.asList("IEC 61511", "NORSOK S-001", "API 521"));
     return result;

--- a/src/main/java/neqsim/process/engineering/safety/SafetyFunctionTransientVerification.java
+++ b/src/main/java/neqsim/process/engineering/safety/SafetyFunctionTransientVerification.java
@@ -1,0 +1,61 @@
+package neqsim.process.engineering.safety;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Verification of an ESD or HIPPS response against a NeqSim dynamic pressure trace. */
+public final class SafetyFunctionTransientVerification implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String functionId;
+  private final double tripSetPressureBara;
+  private final double maximumAllowablePressureBara;
+  private final double requiredClosureTimeSeconds;
+
+  public SafetyFunctionTransientVerification(String functionId, double tripSetPressureBara,
+      double maximumAllowablePressureBara, double requiredClosureTimeSeconds) {
+    this.functionId = functionId;
+    this.tripSetPressureBara = tripSetPressureBara;
+    this.maximumAllowablePressureBara = maximumAllowablePressureBara;
+    this.requiredClosureTimeSeconds = requiredClosureTimeSeconds;
+  }
+
+  public Map<String, Object> verify(double[] timeSeconds, double[] pressureBara,
+      double[] valveOpeningPercent) {
+    if (timeSeconds == null || pressureBara == null || valveOpeningPercent == null
+        || timeSeconds.length == 0 || timeSeconds.length != pressureBara.length
+        || timeSeconds.length != valveOpeningPercent.length) {
+      throw new IllegalArgumentException("time, pressure and valve-opening traces must have equal non-zero length");
+    }
+    double tripTime = Double.NaN;
+    double closedTime = Double.NaN;
+    double maximumPressure = pressureBara[0];
+    for (int i = 0; i < timeSeconds.length; i++) {
+      maximumPressure = Math.max(maximumPressure, pressureBara[i]);
+      if (Double.isNaN(tripTime) && pressureBara[i] >= tripSetPressureBara) {
+        tripTime = timeSeconds[i];
+      }
+      if (!Double.isNaN(tripTime) && Double.isNaN(closedTime) && valveOpeningPercent[i] <= 1.0) {
+        closedTime = timeSeconds[i];
+      }
+    }
+    double responseTime = Double.isNaN(closedTime) || Double.isNaN(tripTime)
+        ? Double.POSITIVE_INFINITY : closedTime - tripTime;
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", "neqsim_safety_transient_verification.v1");
+    result.put("functionId", functionId);
+    result.put("tripSetPressureBara", Double.valueOf(tripSetPressureBara));
+    result.put("maximumAllowablePressureBara", Double.valueOf(maximumAllowablePressureBara));
+    result.put("maximumSimulatedPressureBara", Double.valueOf(maximumPressure));
+    result.put("requiredClosureTimeSeconds", Double.valueOf(requiredClosureTimeSeconds));
+    result.put("actualClosureTimeSeconds", Double.valueOf(responseTime));
+    result.put("tripDetected", Boolean.valueOf(!Double.isNaN(tripTime)));
+    result.put("pressureCriterionPassed", Boolean.valueOf(maximumPressure <= maximumAllowablePressureBara));
+    result.put("closureCriterionPassed", Boolean.valueOf(responseTime <= requiredClosureTimeSeconds));
+    result.put("passed", Boolean.valueOf(maximumPressure <= maximumAllowablePressureBara
+        && responseTime <= requiredClosureTimeSeconds));
+    result.put("status", "DYNAMIC_MODEL_VERIFICATION_REVIEW_REQUIRED");
+    result.put("standardReferences", java.util.Arrays.asList("IEC 61511", "NORSOK S-001", "API 521"));
+    return result;
+  }
+}

--- a/src/test/java/neqsim/process/engineering/pid/PidHazopStudyRunnerTest.java
+++ b/src/test/java/neqsim/process/engineering/pid/PidHazopStudyRunnerTest.java
@@ -8,6 +8,7 @@ import neqsim.process.engineering.EngineeringProject;
 import neqsim.process.engineering.NorsokOffshoreEngineeringBuilder;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemSrkEos;
 
@@ -17,8 +18,7 @@ public class PidHazopStudyRunnerTest extends NeqSimTest {
   void completePidProducesTraceableHazopNodesAndSafeguards() {
     EngineeringProject project = project();
     PidDesignModel model = PidDesignSynthesizer.synthesize(project,
-        new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"),
-        NorsokPidRuleCatalog.completeProposals());
+        new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"), NorsokPidRuleCatalog.completeProposals());
 
     PidHazopStudyReport report = PidHazopStudyRunner.run(project, model);
 
@@ -32,9 +32,21 @@ public class PidHazopStudyRunnerTest extends NeqSimTest {
   @Test
   void emptyPidFailsHazopReadiness() {
     EngineeringProject project = project();
-    PidHazopStudyReport report =
-        PidHazopStudyRunner.run(project, new PidDesignModel(project.getProjectId(), "EMPTY"));
+    PidHazopStudyReport report = PidHazopStudyRunner.run(project, new PidDesignModel(project.getProjectId(), "EMPTY"));
     assertFalse(report.isReadyForHazopWorkshop());
+  }
+
+  @Test
+  void completePidIncludesPassiveProcessTopologyAsHazopNodes() {
+    EngineeringProject project = projectWithPassiveValve();
+    PidDesignModel model = PidDesignSynthesizer.synthesize(project,
+        new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"), NorsokPidRuleCatalog.completeProposals());
+
+    PidHazopStudyReport report = PidHazopStudyRunner.run(project, model);
+
+    assertTrue(report.isReadyForHazopWorkshop());
+    assertFalse(model.getElementsForEquipment("20-PCV-001").isEmpty());
+    assertTrue(report.toJson().contains("20-PCV-001"));
   }
 
   private static EngineeringProject project() {
@@ -46,7 +58,18 @@ public class PidHazopStudyRunnerTest extends NeqSimTest {
     ProcessSystem process = new ProcessSystem();
     process.add(feed);
     process.add(separator);
-    return NorsokOffshoreEngineeringBuilder.from("HAZOP-ready P&ID", process)
-        .projectId("PID-HAZOP-TEST").build();
+    return NorsokOffshoreEngineeringBuilder.from("HAZOP-ready P&ID", process).projectId("PID-HAZOP-TEST").build();
+  }
+
+  private static EngineeringProject projectWithPassiveValve() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 1.0);
+    Stream feed = new Stream("20-FEED-002", fluid);
+    ThrottlingValve valve = new ThrottlingValve("20-PCV-001", feed);
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(valve);
+    return NorsokOffshoreEngineeringBuilder.from("Topology-complete P&ID", process).projectId("PID-TOPOLOGY-TEST")
+        .build();
   }
 }

--- a/src/test/java/neqsim/process/engineering/pid/PidHazopStudyRunnerTest.java
+++ b/src/test/java/neqsim/process/engineering/pid/PidHazopStudyRunnerTest.java
@@ -1,0 +1,52 @@
+package neqsim.process.engineering.pid;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.process.engineering.EngineeringProject;
+import neqsim.process.engineering.NorsokOffshoreEngineeringBuilder;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Verifies that HAZOP preparation consumes the governed P&amp;ID model and fails on missing nodes. */
+public class PidHazopStudyRunnerTest extends NeqSimTest {
+  @Test
+  void completePidProducesTraceableHazopNodesAndSafeguards() {
+    EngineeringProject project = project();
+    PidDesignModel model = PidDesignSynthesizer.synthesize(project,
+        new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"),
+        NorsokPidRuleCatalog.completeProposals());
+
+    PidHazopStudyReport report = PidHazopStudyRunner.run(project, model);
+
+    assertTrue(report.isReadyForHazopWorkshop());
+    assertFalse(report.getNodes().isEmpty());
+    assertTrue(report.toJson().contains("creditedSafeguardTags"));
+    assertTrue(report.toJson().contains("IEC 61882"));
+    assertTrue(report.toJson().contains("workshopDecision"));
+  }
+
+  @Test
+  void emptyPidFailsHazopReadiness() {
+    EngineeringProject project = project();
+    PidHazopStudyReport report =
+        PidHazopStudyRunner.run(project, new PidDesignModel(project.getProjectId(), "EMPTY"));
+    assertFalse(report.isReadyForHazopWorkshop());
+  }
+
+  private static EngineeringProject project() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("n-heptane", 0.05);
+    Stream feed = new Stream("20-FEED-001", fluid);
+    Separator separator = new Separator("20-VG-001", feed);
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(separator);
+    return NorsokOffshoreEngineeringBuilder.from("HAZOP-ready P&ID", process)
+        .projectId("PID-HAZOP-TEST").build();
+  }
+}

--- a/src/test/java/neqsim/process/engineering/pid/SafeguardingPidSynthesisTest.java
+++ b/src/test/java/neqsim/process/engineering/pid/SafeguardingPidSynthesisTest.java
@@ -31,7 +31,8 @@ public class SafeguardingPidSynthesisTest extends NeqSimTest {
     PidDesignModel model = PidDesignSynthesizer.synthesize(project,
         new PidDesignBasis("NORSOK-COMPLETE-PID-PROPOSALS", "20"), NorsokPidRuleCatalog.completeProposals());
 
-    assertEquals(58, model.getElements().size());
+    assertEquals(67, model.getElements().size());
+    assertEquals(9, model.getElementsByType(PidElementType.NOZZLE).size());
     assertEquals(10, model.getElementsByType(PidElementType.TRIP).size());
     assertEquals(5, model.getElementsByType(PidElementType.SHUTDOWN_VALVE).size());
     assertEquals(2, model.getElementsByType(PidElementType.BLOWDOWN_VALVE).size());

--- a/src/test/java/neqsim/process/engineering/safety/NcsSafetyFunctionStudyTest.java
+++ b/src/test/java/neqsim/process/engineering/safety/NcsSafetyFunctionStudyTest.java
@@ -12,15 +12,13 @@ import neqsim.process.safety.risk.sis.SafetyInstrumentedFunction;
 public class NcsSafetyFunctionStudyTest extends NeqSimTest {
   @Test
   void hippsStudyCombinesSilAndDynamicEvidence() {
-    SafetyInstrumentedFunction hipps = SafetyInstrumentedFunction.builder().id("SIF-HIPPS-101")
-        .name("Inlet HIPPS").description("Prevent downstream overpressure")
-        .sil(3).pfd(5.0e-4).testIntervalHours(8760.0).mttr(24.0)
+    SafetyInstrumentedFunction hipps = SafetyInstrumentedFunction.builder().id("SIF-HIPPS-101").name("Inlet HIPPS")
+        .description("Prevent downstream overpressure").sil(3).pfd(5.0e-4).testIntervalHours(8760.0).mttr(24.0)
         .protectedEquipment(Arrays.asList("20-VG-001")).initiatingEvent("Blocked outlet")
         .safeState("HIPPS isolation valves closed").category(SafetyInstrumentedFunction.SIFCategory.HIPPS)
         .architecture("2oo3").build();
-    Map<String, Object> dynamic = new SafetyFunctionTransientVerification("SIF-HIPPS-101", 63.0, 70.0, 3.0)
-        .verify(new double[] {0, 1, 2, 3, 4}, new double[] {60, 63, 66, 68, 67},
-            new double[] {100, 100, 60, 10, 0});
+    Map<String, Object> dynamic = new SafetyFunctionTransientVerification("SIF-HIPPS-101", 63.0, 70.0, 3.0).verify(
+        new double[] { 0, 1, 2, 3, 4 }, new double[] { 60, 63, 66, 68, 67 }, new double[] { 100, 100, 60, 10, 0 });
     assertTrue(((Boolean) dynamic.get("passed")).booleanValue());
 
     NcsSafetyFunctionStudy study = new NcsSafetyFunctionStudy("NCS-STUDY").add(hipps, dynamic);

--- a/src/test/java/neqsim/process/engineering/safety/NcsSafetyFunctionStudyTest.java
+++ b/src/test/java/neqsim/process/engineering/safety/NcsSafetyFunctionStudyTest.java
@@ -1,0 +1,32 @@
+package neqsim.process.engineering.safety;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.process.safety.risk.sis.SafetyInstrumentedFunction;
+
+/** Contract tests for coordinated SIL and dynamic response verification. */
+public class NcsSafetyFunctionStudyTest extends NeqSimTest {
+  @Test
+  void hippsStudyCombinesSilAndDynamicEvidence() {
+    SafetyInstrumentedFunction hipps = SafetyInstrumentedFunction.builder().id("SIF-HIPPS-101")
+        .name("Inlet HIPPS").description("Prevent downstream overpressure")
+        .sil(3).pfd(5.0e-4).testIntervalHours(8760.0).mttr(24.0)
+        .protectedEquipment(Arrays.asList("20-VG-001")).initiatingEvent("Blocked outlet")
+        .safeState("HIPPS isolation valves closed").category(SafetyInstrumentedFunction.SIFCategory.HIPPS)
+        .architecture("2oo3").build();
+    Map<String, Object> dynamic = new SafetyFunctionTransientVerification("SIF-HIPPS-101", 63.0, 70.0, 3.0)
+        .verify(new double[] {0, 1, 2, 3, 4}, new double[] {60, 63, 66, 68, 67},
+            new double[] {100, 100, 60, 10, 0});
+    assertTrue(((Boolean) dynamic.get("passed")).booleanValue());
+
+    NcsSafetyFunctionStudy study = new NcsSafetyFunctionStudy("NCS-STUDY").add(hipps, dynamic);
+    assertTrue(study.toJson().contains("SIF-HIPPS-101"));
+    assertTrue(study.toJson().contains("silVerification"));
+    assertTrue(study.toJson().contains("NORSOK S-001"));
+    assertFalse(((Boolean) study.toMap().get("fitnessForConstruction")).booleanValue());
+  }
+}


### PR DESCRIPTION
## What changed

- adds a governed NCS safety-function study combining existing NeqSim SIF/SIL verification with dynamic trace evidence
- verifies trip detection, maximum pressure and final-element closure time from transient pressure/opening histories
- supports ESD and HIPPS SIF categories, voting architecture, proof-test interval and PFDavg evidence
- records NORSOK S-001/Z-013, IEC 61508/61511, ISO 10418 and API 521 traceability
- fails closed as preliminary SRS/SIL-verification handoff and not fit for construction

## Validation

A focused HIPPS test verifies a 2oo3 SIL 3 function, pressure containment below MAWP and valve closure within the required response time.

## Stack

PR 2 of the advanced stack. Depends on #2482. The next PR applies this to the real offshore process, generates the full engineering package and runs the notebook.