### PR TITLE
Add closed-loop SIF execution evidence

### DIFF
--- a/.github/skills/neqsim-process-safety/SKILL.md
+++ b/.github/skills/neqsim-process-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neqsim-process-safety
-version: "1.1.0"
+version: "1.2.0"
 description: "Process safety methodology — barrier management, PSFs/SCEs, HAZOP guidewords, LOPA worksheets, SIL determination per IEC 61511, bow-tie analysis, risk-matrix scoring, TR3001 overpressure-protection studies, and trapped-liquid fire rupture screening. USE WHEN: a task requires barrier registers, hazard identification, layer-of-protection analysis, safety-integrity-level assignment for an SIF, overpressure relief-cause / governing-case studies, trapped liquid rupture/PFP demand, or quantitative risk evaluation. Anchors on neqsim.process.safety.barrier, neqsim.process.safety.risk, neqsim.process.safety.overpressure, and neqsim.process.safety.rupture classes."
 last_verified: "2026-07-18"
 requires:
@@ -249,6 +249,22 @@ Recommended sequence:
 
 See `docs/process/safety/closed-loop-sif-verification.md`. This simulation evidence does not infer
 SIL or approve the SRS; hand the result to the SIL/LOPA and engineering-approval workflow.
+
+### Method 3e — Reliability uncertainty and degraded/maintenance modes
+
+After the deterministic `SafetyFunctionDesign` screen, use `SafetyFunctionReliabilityStudy` to
+propagate evidence-based failure-rate, diagnostic-coverage, proof-test, repair-time, beta, and bypass
+uncertainty. Always provide a fixed seed and retain P10/P50/P90 PFDavg/PFH, target-met probability,
+iteration count, distributions, and their data sources in the verification package.
+
+Use `SafetyFunctionOperatingMode` plus `SafetyFunctionDegradedModeAssessment` before evaluating a
+bypass or maintenance state. Record every unavailable, forced-trip, or under-repair channel, actual
+proof-test age, authorization reference, compensating measure, elapsed duration, and maximum duration.
+The effective architecture (for example 2oo3 to 2oo2) is a demand-capability screen, not permission to
+preserve the SIL claim or continue operation.
+
+Handoff the assessed mode back to the closed-loop scenario workflow to verify the physical safe state.
+See `docs/process/safety/sif-reliability-and-degraded-modes.md`.
 
 ## Method 4 — Bow-Tie Analysis
 

--- a/.github/skills/neqsim-process-safety/SKILL.md
+++ b/.github/skills/neqsim-process-safety/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: neqsim-process-safety
-version: "1.0.0"
+version: "1.1.0"
 description: "Process safety methodology — barrier management, PSFs/SCEs, HAZOP guidewords, LOPA worksheets, SIL determination per IEC 61511, bow-tie analysis, risk-matrix scoring, TR3001 overpressure-protection studies, and trapped-liquid fire rupture screening. USE WHEN: a task requires barrier registers, hazard identification, layer-of-protection analysis, safety-integrity-level assignment for an SIF, overpressure relief-cause / governing-case studies, trapped liquid rupture/PFP demand, or quantitative risk evaluation. Anchors on neqsim.process.safety.barrier, neqsim.process.safety.risk, neqsim.process.safety.overpressure, and neqsim.process.safety.rupture classes."
-last_verified: "2026-06-27"
+last_verified: "2026-07-18"
 requires:
   java_packages: [neqsim.process.safety.barrier, neqsim.process.safety.risk, neqsim.process.safety.overpressure, neqsim.process.safety.rupture, neqsim.process.safety.risk.sis.nog070, neqsim.process.safety.esd, neqsim.process.safety.api14c, neqsim.process.safety.compliance]
 ---
@@ -20,6 +20,7 @@ sizing (`neqsim-relief-flare-network`).
 - Barrier management for PSFs/SCEs with document evidence and performance standards
 - LOPA for a specific scenario — calculate residual frequency and required RRF
 - SIL determination for an SIF — IEC 61508 / IEC 61511 verification
+- Closed-loop SIF execution from live process signal through MooN voting and final element
 - Bow-tie analysis (top event with threats + barriers + consequences)
 - ALARP / risk-matrix scoring (5×5)
 - Trapped-liquid fire rupture screening for blocked-in liquid-filled segments,
@@ -226,6 +227,28 @@ boolean within = res.isWithinBudget();        // true
 ```
 
 Verified by `EsdResponseTimeSimulatorTest`.
+
+### Method 3d — Closed-loop SIF transient verification
+
+Use `ClosedLoopSafetyFunction` inside a `DynamicSafetyScenario` when a response-time budget must
+be demonstrated against the process model rather than summed from prepared durations. Bind every
+`SafetyFunctionChannel` to the isolated process copy, select the SRS voting pattern, then pass an
+existing `ESDLogic`, `HIPPSLogic`, or other `ProcessLogic` as the final-element sequence.
+
+Recommended sequence:
+
+1. Configure and solve the normal process case.
+2. Apply one controlled initiating event on the scenario copy.
+3. Bind sensor channels to live process properties, including response delay and an explicit
+   `FaultMode` for degraded cases.
+4. Use the SRS MooN `VotingPattern` and logic-solver delay.
+5. Define dynamic criteria for the actual safe state and deadline, such as ESD valve opening,
+   protected pressure, compressor state, or depressuring pressure.
+6. Review `DynamicSafetyScenarioResult.getLogicEvidence()` for readings, bypass/fault state, vote
+   time, final-element actuation, and trace; do not approve from the boolean verdict alone.
+
+See `docs/process/safety/closed-loop-sif-verification.md`. This simulation evidence does not infer
+SIL or approve the SRS; hand the result to the SIL/LOPA and engineering-approval workflow.
 
 ## Method 4 — Bow-Tie Analysis
 

--- a/docs/process/safety/README.md
+++ b/docs/process/safety/README.md
@@ -11,6 +11,7 @@ Documentation for safety systems modeling in NeqSim.
 - [Overview](#overview)
 - [Safety Equipment](#safety-equipment)
 - [Emergency Shutdown (ESD)](#emergency-shutdown-esd)
+- [Closed-loop SIF Verification](closed-loop-sif-verification.md)
 - [Blowdown Systems](#blowdown-systems)
 - [Pressure Safety Valves](#pressure-safety-valves)
 - [Release and Gas Dispersion Scenarios](release-dispersion-scenarios.md)
@@ -82,6 +83,11 @@ esdLogic.addAction(new TripValveAction(inletValve), 0.0);
 Use `neqsim.process.safety.esd.EmergencyShutdownTestRunner` when the ESD sequence needs a
 structured dynamic evidence report with monitored time series, tagreader comparisons, standards
 references, and acceptance criteria.
+
+Use [`ClosedLoopSafetyFunction`](closed-loop-sif-verification.md) with
+`DynamicSafetyScenarioRunner` when the test must include live process detection, channel response
+and fault modes, MooN voting, logic-solver delay, and physical final-element response in one
+isolated transient.
 
 ### ESD Levels
 
@@ -219,6 +225,7 @@ EmergencyShutdownTestResult report = EmergencyShutdownTestRunner.run(process, pl
 - [Release and Gas Dispersion Scenarios](release-dispersion-scenarios.md) - Automatic source-term and cloud endpoint screening from ProcessSystem streams
 - [Open Drain Review](../../safety/open_drain_review.md) - NORSOK S-001 Clause 9 review with NeqSim stream evidence and normalized STID/tagreader inputs
 - [ESD Dynamic Testing Workflow](../../safety/esd_testing_workflow.md) - ESD transient testing with process logic, tagreader evidence, and criteria reports
+- [Closed-loop SIF Verification](closed-loop-sif-verification.md) - Sensor-to-vote-to-final-element transient verification with structured evidence
 - [ESD Blowdown System](../../safety/ESD_BLOWDOWN_SYSTEM) - Detailed ESD guide
 - [HIPPS Summary](../../safety/HIPPS_SUMMARY) - HIPPS overview
 - [PSV Dynamic Sizing](../../safety/psv_dynamic_sizing_example) - PSV sizing example

--- a/docs/process/safety/README.md
+++ b/docs/process/safety/README.md
@@ -12,6 +12,7 @@ Documentation for safety systems modeling in NeqSim.
 - [Safety Equipment](#safety-equipment)
 - [Emergency Shutdown (ESD)](#emergency-shutdown-esd)
 - [Closed-loop SIF Verification](closed-loop-sif-verification.md)
+- [SIF Reliability and Degraded Modes](sif-reliability-and-degraded-modes.md)
 - [Blowdown Systems](#blowdown-systems)
 - [Pressure Safety Valves](#pressure-safety-valves)
 - [Release and Gas Dispersion Scenarios](release-dispersion-scenarios.md)
@@ -226,6 +227,7 @@ EmergencyShutdownTestResult report = EmergencyShutdownTestRunner.run(process, pl
 - [Open Drain Review](../../safety/open_drain_review.md) - NORSOK S-001 Clause 9 review with NeqSim stream evidence and normalized STID/tagreader inputs
 - [ESD Dynamic Testing Workflow](../../safety/esd_testing_workflow.md) - ESD transient testing with process logic, tagreader evidence, and criteria reports
 - [Closed-loop SIF Verification](closed-loop-sif-verification.md) - Sensor-to-vote-to-final-element transient verification with structured evidence
+- [SIF Reliability and Degraded Modes](sif-reliability-and-degraded-modes.md) - Seeded PFD/PFH uncertainty and governed bypass, maintenance, failure, and proof-test assessment
 - [ESD Blowdown System](../../safety/ESD_BLOWDOWN_SYSTEM) - Detailed ESD guide
 - [HIPPS Summary](../../safety/HIPPS_SUMMARY) - HIPPS overview
 - [PSV Dynamic Sizing](../../safety/psv_dynamic_sizing_example) - PSV sizing example

--- a/docs/process/safety/closed-loop-sif-verification.md
+++ b/docs/process/safety/closed-loop-sif-verification.md
@@ -1,0 +1,117 @@
+---
+title: Closed-loop SIF verification
+description: Execute process detection, voting, logic delay, and final-element response in an isolated NeqSim transient.
+---
+
+# Closed-loop SIF verification
+
+`ClosedLoopSafetyFunction` connects process signals to redundant channels, a voting pattern,
+a logic-solver delay, and existing `ProcessLogic` final elements. Run it through
+`DynamicSafetyScenarioRunner` to verify the complete detection-to-safe-state path against an
+isolated copy of a `ProcessSystem`.
+
+This workflow produces simulation evidence for engineering review. It does not assign SIL,
+approve an SRS, establish IPL independence, or replace project validation and functional-safety
+assessment. Those lifecycle activities remain controlled engineering decisions under IEC 61511.
+
+## Execution model
+
+1. The runner copies and initializes the design process.
+2. The initiating event is applied only to the copy.
+3. Each channel reads a live process signal and applies its trip direction, response delay, and
+   explicit fault mode.
+4. The configured `VotingPattern` evaluates the latched channel trips.
+5. After the logic-solver delay, the supplied ESD, HIPPS, or other `ProcessLogic` executes.
+6. Dynamic criteria observe the physical process and final elements until their deadlines.
+7. The result records channel traces, vote time, actuation time, final state, and criteria verdicts.
+
+## 2oo3 high-pressure isolation example
+
+```java
+DynamicSafetyScenario scenario = DynamicSafetyScenario
+    .builder("SIF-HP-101", "HP inlet isolation")
+    .durationSeconds(8.0)
+    .timeStepSeconds(0.25)
+    .initiatingEvent(process ->
+        ((Stream) process.getUnit("FEED")).setPressure(70.0, "bara"))
+    .addLogic(process -> {
+      ESDValve valve = (ESDValve) process.getUnit("ESDV-101");
+      ESDLogic finalElements = new ESDLogic("ESD-101 final elements");
+      finalElements.addAction(new TripValveAction(valve), 0.0);
+
+      SafetyFunctionChannel.SignalExtractor pressure = model ->
+          ((Stream) model.getUnit("FEED")).getPressure("bara");
+      return ClosedLoopSafetyFunction
+          .builder("SIF-HP-101", "2oo3 HP isolation", process,
+              VotingPattern.TWO_OUT_OF_THREE, finalElements)
+          .addChannel(SafetyFunctionChannel
+              .highTrip("PT-101A", "bara", 60.0, pressure)
+              .responseDelaySeconds(0.5).build())
+          .addChannel(SafetyFunctionChannel
+              .highTrip("PT-101B", "bara", 60.0, pressure)
+              .responseDelaySeconds(0.5).build())
+          .addChannel(SafetyFunctionChannel
+              .highTrip("PT-101C", "bara", 60.0, pressure)
+              .responseDelaySeconds(0.5)
+              .faultMode(SafetyFunctionChannel.FaultMode.BYPASSED).build())
+          .logicSolverDelaySeconds(0.25)
+          .build();
+    })
+    .addCriterion(DynamicScenarioCriterion
+        .builder("esdv-closed", "ESD valve closed", "%", process ->
+            ((ESDValve) process.getUnit("ESDV-101"))
+                .getPercentValveOpening())
+        .acceptanceRange(null, 5.0)
+        .deadlineSeconds(5.0)
+        .build())
+    .addEvidenceReference("SRS-SIF-HP-101")
+    .build();
+
+DynamicSafetyScenarioResult result =
+    DynamicSafetyScenarioRunner.run(designProcess, scenario);
+Map<String, Object> sifEvidence =
+    result.getLogicEvidence().get("2oo3 HP isolation");
+```
+
+The example intentionally bypasses one channel. The 2oo3 vote still requires two demanded
+channels, and the evidence exposes the reduced availability for review. A bypass is never treated
+as proof that operation in the degraded state is acceptable.
+
+## Channel fault modes
+
+| Mode | Simulation behavior | Intended verification use |
+| --- | --- | --- |
+| `HEALTHY` | Uses the process signal | Normal demand test |
+| `BYPASSED` | Channel unavailable and cannot vote | Authorized-bypass scenario |
+| `STUCK_NORMAL` | Never demands a trip | Dangerous detected/undetected failure scenario |
+| `STUCK_TRIP` | Always demands a trip | Spurious-trip and voting scenario |
+| `BIASED` | Adds a configured bias to the process signal | Calibration-drift sensitivity |
+
+## Evidence and acceptance
+
+The `dynamic_safety_scenario_result.v2` JSON contains `logicEvidence` alongside the existing
+criterion traces and final logic states. Closed-loop evidence uses
+`closed_loop_sif_evidence.v1` and includes:
+
+- SIF identifier and voting architecture;
+- channel configuration, raw/indicated readings, availability, fault mode, and trip state;
+- first vote and final-element actuation times;
+- final-element logic state and a complete step trace;
+- an explicit `engineeringApprovalRequired` flag.
+
+Define criteria from the SRS response-time and safe-state requirements. Use sufficiently small
+time steps to resolve sensor, logic, and actuator dynamics, and test normal demand, each credited
+degraded mode, reset/restart behavior, and failure to reach the safe state.
+
+## Standards context
+
+- [IEC 61511-1](https://webstore.iec.ch/en/publication/24241) defines functional-safety lifecycle
+  requirements for process-industry SIS.
+- [IEC 61511-2](https://webstore.iec.ch/en/publication/25510) provides application guidance.
+- [IEC 61511-3](https://webstore.iec.ch/en/publication/25480) provides guidance for required SIL
+  determination.
+- [ISO 10418:2019](https://www.iso.org/standard/55440.html) covers offshore production-installation
+  process safety systems.
+
+Project requirements, vendor data, cause-and-effect charts, proof-test procedures, and approved
+SRS values take precedence over screening examples in NeqSim.

--- a/docs/process/safety/sif-reliability-and-degraded-modes.md
+++ b/docs/process/safety/sif-reliability-and-degraded-modes.md
@@ -1,0 +1,83 @@
+---
+title: SIF reliability uncertainty and degraded modes
+description: Seeded PFD/PFH uncertainty and governed SIF bypass, maintenance, failure, and proof-test state assessment.
+---
+
+# SIF reliability uncertainty and degraded modes
+
+`SafetyFunctionDesign` remains the analytical source for low-demand PFDavg and high/continuous-demand
+PFH screening. Two complementary APIs add lifecycle evidence without changing or certifying that model:
+
+- `SafetyFunctionReliabilityStudy` propagates declared input uncertainty with a reproducible seed and
+  reports P10/P50/P90 PFDavg and PFH plus the sampled probability of meeting the supplied SIL target.
+- `SafetyFunctionDegradedModeAssessment` evaluates the effective MooN vote and governance gaps for
+  bypassed, failed, forced-trip, under-repair, and proof-test-overdue states.
+
+Neither result infers a SIL target, authorizes continued operation, validates common-cause independence,
+or replaces a project SIL verification. Every output sets `engineeringApprovalRequired`.
+
+## Reliability uncertainty
+
+Define triangular distributions only where the project has an evidence basis. Failure-rate, proof-test,
+and repair-time distributions are factors on the controlled design values. Diagnostic coverage, beta,
+and bypass probability distributions are absolute fractions.
+
+```java
+SafetyFunctionReliabilityStudy.SubsystemUncertainty sensors =
+    new SafetyFunctionReliabilityStudy.SubsystemUncertainty("2oo3 pressure transmitters")
+        .setFailureRateFactor(TriangularDistribution.of(0.8, 1.0, 1.3))
+        .setDiagnosticCoverage(TriangularDistribution.of(0.55, 0.60, 0.65))
+        .setProofTestIntervalFactor(TriangularDistribution.of(0.9, 1.0, 1.2))
+        .setBetaFactor(TriangularDistribution.of(0.03, 0.05, 0.08));
+
+SafetyFunctionReliabilityStudy.Result reliability =
+    SafetyFunctionReliabilityStudy.run(
+        safetyFunctionDesign, Collections.singletonList(sensors), 10000, 20260718L);
+```
+
+Store the seed, iteration count, distributions, data sources, and deterministic design result together.
+P10 is the lower PFD/PFH percentile and P90 is the higher, more conservative percentile. Do not select
+only a favorable percentile to claim compliance; the acceptance basis belongs in the approved SRS and
+verification plan.
+
+## Degraded and maintenance operation
+
+An operating-mode snapshot uses one-based channel numbers and exact subsystem names from
+`SafetyFunctionDesign`:
+
+```java
+SafetyFunctionOperatingMode mode = SafetyFunctionOperatingMode
+    .builder("PT-C authorized bypass", ModeType.DEGRADED)
+    .authorizationReference("OPS-BYPASS-2026-014")
+    .compensatingMeasure("Continuous pressure watch and restricted throughput")
+    .duration(2.0, 8.0)
+    .channelState("2oo3 pressure transmitters", 3, ChannelState.BYPASSED)
+    .hoursSinceProofTest("2oo3 pressure transmitters", 4000.0)
+    .build();
+
+SafetyFunctionDegradedModeAssessment.Result assessment =
+    SafetyFunctionDegradedModeAssessment.assess(safetyFunctionDesign, mode);
+```
+
+For a 2oo3 group with one bypassed channel, the result reports effective `2oo2`: demand capability
+remains, but redundancy and the original SIL claim are not preserved by this screen. Two unavailable
+channels produce `2oo1` and `NOT_DEMAND_CAPABLE`. A forced-trip channel reduces the remaining vote
+and exposes spurious-trip susceptibility.
+
+Non-normal modes are flagged unless they include an authorization reference, compensating measure,
+and maximum duration. Exceeding the duration is a finding. Proof-test age must be recorded for every
+subsystem; overdue or missing evidence invalidates preservation of the design claim.
+
+## Required review package
+
+- approved SRS and LOPA references;
+- failure-rate and coverage sources, including applicability limits;
+- proof-test and partial-stroke procedures, intervals, coverage, and actual completion records;
+- common-cause, independence, systematic-capability, and architectural-constraint assessment;
+- bypass/maintenance authorization, duration, owner, compensating measures, and restoration test;
+- closed-loop transient evidence for normal and credited degraded states;
+- independent functional-safety assessment where required by the project lifecycle.
+
+See the official [IEC 61511-1](https://webstore.iec.ch/en/publication/24241) lifecycle requirements and
+[IEC 61511-2](https://webstore.iec.ch/en/publication/25510) application guidance for the governing
+project context.

--- a/src/main/java/neqsim/process/engineering/SafetyFunctionDesign.java
+++ b/src/main/java/neqsim/process/engineering/SafetyFunctionDesign.java
@@ -214,6 +214,69 @@ public final class SafetyFunctionDesign implements Serializable {
       return type;
     }
 
+    public String getName() {
+      return name;
+    }
+
+    public int getVotesRequired() {
+      return votesRequired;
+    }
+
+    public int getChannelCount() {
+      return channelCount;
+    }
+
+    public double getDangerousFailureRatePerHour() {
+      return dangerousFailureRatePerHour;
+    }
+
+    public double getDiagnosticCoverage() {
+      return diagnosticCoverage;
+    }
+
+    public double getProofTestIntervalHours() {
+      return proofTestIntervalHours;
+    }
+
+    public double getMeanRepairTimeHours() {
+      return meanRepairTimeHours;
+    }
+
+    public double getBetaFactor() {
+      return betaFactor;
+    }
+
+    public double getBypassProbability() {
+      return bypassProbability;
+    }
+
+    /**
+     * Copies the subsystem while replacing uncertain reliability inputs.
+     *
+     * @param dangerousFailureRate sampled dangerous failure rate in 1/h
+     * @param coverage sampled diagnostic coverage
+     * @param proofInterval sampled proof-test interval in hours
+     * @param repairTime sampled mean repair time in hours
+     * @param beta sampled common-cause beta factor
+     * @param bypass sampled probability of bypass on demand
+     * @return subsystem copy retaining proof-test, PST, mission, architecture, and evidence settings
+     */
+    public Subsystem copyWithReliabilityInputs(double dangerousFailureRate, double coverage, double proofInterval,
+        double repairTime, double beta, double bypass) {
+      Subsystem copy = new Subsystem(name, type, votesRequired, channelCount, dangerousFailureRate, coverage,
+          proofInterval, repairTime, beta);
+      copy.proofTestCoverage = proofTestCoverage;
+      copy.partialStrokeCoverage = partialStrokeCoverage;
+      copy.partialStrokeTestIntervalHours = partialStrokeTestIntervalHours;
+      copy.missionTimeHours = missionTimeHours;
+      copy.bypassProbability = bypass;
+      copy.systematicCapability = systematicCapability;
+      copy.hardwareFaultTolerance = hardwareFaultTolerance;
+      copy.commonCauseGroup = commonCauseGroup;
+      copy.certifiedDataReference = certifiedDataReference;
+      return copy;
+    }
+
     public String getVotingArchitecture() {
       return votesRequired + "oo" + channelCount;
     }
@@ -426,5 +489,9 @@ public final class SafetyFunctionDesign implements Serializable {
 
   public EngineeringApprovalStatus getApprovalStatus() {
     return approvalStatus;
+  }
+
+  public DemandMode getDemandMode() {
+    return demandMode;
   }
 }

--- a/src/main/java/neqsim/process/engineering/safety/SafetyFunctionDegradedModeAssessment.java
+++ b/src/main/java/neqsim/process/engineering/safety/SafetyFunctionDegradedModeAssessment.java
@@ -1,0 +1,243 @@
+package neqsim.process.engineering.safety;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.engineering.SafetyFunctionDesign;
+import neqsim.process.engineering.safety.SafetyFunctionOperatingMode.ChannelState;
+import neqsim.process.engineering.safety.SafetyFunctionOperatingMode.ModeType;
+
+/** Evaluates effective voting and governance gaps for a declared SIF operating mode. */
+public final class SafetyFunctionDegradedModeAssessment {
+  private SafetyFunctionDegradedModeAssessment() {
+  }
+
+  /** Effective voting result for one SIF subsystem. */
+  public static final class SubsystemResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String subsystemName;
+    private final String designArchitecture;
+    private final String effectiveArchitecture;
+    private final int availableChannels;
+    private final int unavailableChannels;
+    private final int forcedTripChannels;
+    private final boolean demandCapable;
+    private final boolean tripAlreadyDemanded;
+    private final boolean proofTestAgeRecorded;
+    private final boolean proofTestOverdue;
+
+    private SubsystemResult(SafetyFunctionDesign.Subsystem subsystem, SafetyFunctionOperatingMode mode) {
+      subsystemName = subsystem.getName();
+      designArchitecture = subsystem.getVotingArchitecture();
+      Map<Integer, ChannelState> states = mode.getChannelStates(subsystemName);
+      int available = 0;
+      int forced = 0;
+      for (int channel = 1; channel <= subsystem.getChannelCount(); channel++) {
+        ChannelState state = states.containsKey(Integer.valueOf(channel)) ? states.get(Integer.valueOf(channel))
+            : ChannelState.AVAILABLE;
+        if (state == ChannelState.AVAILABLE) {
+          available++;
+        } else if (state == ChannelState.FORCED_TRIP) {
+          forced++;
+        }
+      }
+      availableChannels = available;
+      forcedTripChannels = forced;
+      unavailableChannels = subsystem.getChannelCount() - available - forced;
+      int remainingVotes = Math.max(0, subsystem.getVotesRequired() - forced);
+      demandCapable = available >= remainingVotes;
+      tripAlreadyDemanded = forced >= subsystem.getVotesRequired();
+      effectiveArchitecture = remainingVotes + "oo" + available;
+      Double proofAge = mode.getHoursSinceProofTest(subsystemName);
+      proofTestAgeRecorded = proofAge != null;
+      proofTestOverdue = proofAge != null && proofAge.doubleValue() > subsystem.getProofTestIntervalHours() + 1.0e-9;
+    }
+
+    public String getEffectiveArchitecture() {
+      return effectiveArchitecture;
+    }
+
+    public boolean isDemandCapable() {
+      return demandCapable;
+    }
+
+    public boolean isProofTestOverdue() {
+      return proofTestOverdue;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> map = new LinkedHashMap<String, Object>();
+      map.put("subsystemName", subsystemName);
+      map.put("designArchitecture", designArchitecture);
+      map.put("effectiveArchitecture", effectiveArchitecture);
+      map.put("availableChannels", Integer.valueOf(availableChannels));
+      map.put("unavailableChannels", Integer.valueOf(unavailableChannels));
+      map.put("forcedTripChannels", Integer.valueOf(forcedTripChannels));
+      map.put("demandCapable", Boolean.valueOf(demandCapable));
+      map.put("tripAlreadyDemanded", Boolean.valueOf(tripAlreadyDemanded));
+      map.put("proofTestAgeRecorded", Boolean.valueOf(proofTestAgeRecorded));
+      map.put("proofTestOverdue", Boolean.valueOf(proofTestOverdue));
+      return map;
+    }
+  }
+
+  /** Immutable overall mode assessment. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String sifTag;
+    private final SafetyFunctionOperatingMode mode;
+    private final List<SubsystemResult> subsystemResults;
+    private final List<String> findings;
+    private final boolean demandCapable;
+    private final boolean targetSilClaimPreserved;
+    private final String verdict;
+
+    private Result(SafetyFunctionDesign design, SafetyFunctionOperatingMode mode,
+        List<SubsystemResult> subsystemResults, List<String> findings) {
+      sifTag = design.getSifTag();
+      this.mode = mode;
+      this.subsystemResults = Collections.unmodifiableList(new ArrayList<SubsystemResult>(subsystemResults));
+      this.findings = Collections.unmodifiableList(new ArrayList<String>(findings));
+      boolean capable = true;
+      boolean tripDemanded = false;
+      boolean allCurrent = true;
+      boolean fullArchitecture = true;
+      for (SubsystemResult result : subsystemResults) {
+        capable = capable && result.demandCapable;
+        tripDemanded = tripDemanded || result.tripAlreadyDemanded;
+        allCurrent = allCurrent && result.proofTestAgeRecorded && !result.proofTestOverdue;
+        fullArchitecture = fullArchitecture && result.unavailableChannels == 0 && result.forcedTripChannels == 0;
+      }
+      demandCapable = capable;
+      targetSilClaimPreserved = mode.getType() == ModeType.NORMAL && capable && !tripDemanded && allCurrent
+          && fullArchitecture && design.getAchievedSil() >= design.getTargetSil();
+      if (!capable) {
+        verdict = "NOT_DEMAND_CAPABLE";
+      } else if (tripDemanded) {
+        verdict = "TRIP_ALREADY_DEMANDED";
+      } else if (!findings.isEmpty()) {
+        verdict = "RESTRICTED_ENGINEERING_REVIEW";
+      } else {
+        verdict = "REVIEW_REQUIRED";
+      }
+    }
+
+    public boolean isDemandCapable() {
+      return demandCapable;
+    }
+
+    public boolean isTargetSilClaimPreserved() {
+      return targetSilClaimPreserved;
+    }
+
+    public String getVerdict() {
+      return verdict;
+    }
+
+    public List<SubsystemResult> getSubsystemResults() {
+      return subsystemResults;
+    }
+
+    public List<String> getFindings() {
+      return findings;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> map = new LinkedHashMap<String, Object>();
+      map.put("schemaVersion", "sif_degraded_mode_assessment.v1");
+      map.put("sifTag", sifTag);
+      map.put("modeName", mode.getName());
+      map.put("modeType", mode.getType().name());
+      map.put("authorizationReference", mode.getAuthorizationReference());
+      map.put("compensatingMeasure", mode.getCompensatingMeasure());
+      map.put("maximumDurationHours", Double.valueOf(mode.getMaximumDurationHours()));
+      map.put("elapsedDurationHours", Double.valueOf(mode.getElapsedDurationHours()));
+      List<Map<String, Object>> subsystems = new ArrayList<Map<String, Object>>();
+      for (SubsystemResult result : subsystemResults) {
+        subsystems.add(result.toMap());
+      }
+      map.put("subsystems", subsystems);
+      map.put("findings", new ArrayList<String>(findings));
+      map.put("demandCapable", Boolean.valueOf(demandCapable));
+      map.put("targetSilClaimPreserved", Boolean.valueOf(targetSilClaimPreserved));
+      map.put("verdict", verdict);
+      map.put("silTargetInferred", Boolean.FALSE);
+      map.put("engineeringApprovalRequired", Boolean.TRUE);
+      return map;
+    }
+  }
+
+  /**
+   * Assesses a declared operating mode against the design voting architectures and proof-test intervals.
+   *
+   * @param design SIF design basis
+   * @param mode current or proposed operating mode
+   * @return demand-capability and governance findings
+   */
+  public static Result assess(SafetyFunctionDesign design, SafetyFunctionOperatingMode mode) {
+    if (design == null || mode == null) {
+      throw new IllegalArgumentException("design and mode are required");
+    }
+    validateReferences(design, mode);
+    List<SubsystemResult> subsystemResults = new ArrayList<SubsystemResult>();
+    List<String> findings = new ArrayList<String>();
+    for (SafetyFunctionDesign.Subsystem subsystem : design.getSubsystems()) {
+      SubsystemResult result = new SubsystemResult(subsystem, mode);
+      subsystemResults.add(result);
+      if (!result.demandCapable) {
+        findings.add(subsystem.getName() + ": insufficient available channels for the configured vote");
+      }
+      if (result.unavailableChannels > 0) {
+        findings.add(subsystem.getName() + ": design voting is degraded to " + result.effectiveArchitecture);
+      }
+      if (result.forcedTripChannels > 0) {
+        findings.add(subsystem.getName() + ": forced-trip channel reduces spurious-trip tolerance");
+      }
+      if (!result.proofTestAgeRecorded) {
+        findings.add(subsystem.getName() + ": proof-test age is not recorded");
+      } else if (result.proofTestOverdue) {
+        findings.add(subsystem.getName() + ": proof-test interval is overdue");
+      }
+    }
+    if (mode.getType() != ModeType.NORMAL) {
+      if (mode.getAuthorizationReference().isEmpty()) {
+        findings.add("non-normal operation requires an authorization reference");
+      }
+      if (mode.getCompensatingMeasure().isEmpty()) {
+        findings.add("non-normal operation requires a compensating measure");
+      }
+      if (!Double.isFinite(mode.getMaximumDurationHours())) {
+        findings.add("non-normal operation requires a maximum duration");
+      } else if (mode.getElapsedDurationHours() > mode.getMaximumDurationHours() + 1.0e-9) {
+        findings.add("authorized non-normal duration has been exceeded");
+      }
+    }
+    return new Result(design, mode, subsystemResults, findings);
+  }
+
+  private static void validateReferences(SafetyFunctionDesign design, SafetyFunctionOperatingMode mode) {
+    Map<String, SafetyFunctionDesign.Subsystem> known = new LinkedHashMap<String, SafetyFunctionDesign.Subsystem>();
+    for (SafetyFunctionDesign.Subsystem subsystem : design.getSubsystems()) {
+      known.put(subsystem.getName(), subsystem);
+    }
+    for (Map.Entry<String, Map<Integer, ChannelState>> entry : mode.getAllChannelStates().entrySet()) {
+      SafetyFunctionDesign.Subsystem subsystem = known.get(entry.getKey());
+      if (subsystem == null) {
+        throw new IllegalArgumentException("operating mode references unknown subsystem " + entry.getKey());
+      }
+      for (Integer channel : entry.getValue().keySet()) {
+        if (channel.intValue() > subsystem.getChannelCount()) {
+          throw new IllegalArgumentException("channel index exceeds subsystem channel count");
+        }
+      }
+    }
+    for (String subsystemName : mode.getAllProofTestAges().keySet()) {
+      if (!known.containsKey(subsystemName)) {
+        throw new IllegalArgumentException("proof-test age references unknown subsystem " + subsystemName);
+      }
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/safety/SafetyFunctionOperatingMode.java
+++ b/src/main/java/neqsim/process/engineering/safety/SafetyFunctionOperatingMode.java
@@ -1,0 +1,180 @@
+package neqsim.process.engineering.safety;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Declared normal, degraded, or maintenance state used for SIF demand-capability assessment. */
+public final class SafetyFunctionOperatingMode implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Operational classification. */
+  public enum ModeType {
+    NORMAL, DEGRADED, MAINTENANCE
+  }
+
+  /** State of an individual voted channel. */
+  public enum ChannelState {
+    AVAILABLE, BYPASSED, DANGEROUS_FAILED, FORCED_TRIP, UNDER_REPAIR
+  }
+
+  private final String name;
+  private final ModeType type;
+  private final String authorizationReference;
+  private final String compensatingMeasure;
+  private final double maximumDurationHours;
+  private final double elapsedDurationHours;
+  private final Map<String, Map<Integer, ChannelState>> channelStates;
+  private final Map<String, Double> hoursSinceProofTest;
+
+  private SafetyFunctionOperatingMode(Builder builder) {
+    name = requireText(builder.name, "name");
+    type = builder.type;
+    authorizationReference = normalize(builder.authorizationReference);
+    compensatingMeasure = normalize(builder.compensatingMeasure);
+    maximumDurationHours = builder.maximumDurationHours;
+    elapsedDurationHours = nonNegative(builder.elapsedDurationHours, "elapsedDurationHours");
+    Map<String, Map<Integer, ChannelState>> copiedStates = new LinkedHashMap<String, Map<Integer, ChannelState>>();
+    for (Map.Entry<String, Map<Integer, ChannelState>> entry : builder.channelStates.entrySet()) {
+      copiedStates.put(entry.getKey(),
+          Collections.unmodifiableMap(new LinkedHashMap<Integer, ChannelState>(entry.getValue())));
+    }
+    channelStates = Collections.unmodifiableMap(copiedStates);
+    hoursSinceProofTest = Collections.unmodifiableMap(new LinkedHashMap<String, Double>(builder.hoursSinceProofTest));
+  }
+
+  public static Builder builder(String name, ModeType type) {
+    return new Builder(name, type);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ModeType getType() {
+    return type;
+  }
+
+  public String getAuthorizationReference() {
+    return authorizationReference;
+  }
+
+  public String getCompensatingMeasure() {
+    return compensatingMeasure;
+  }
+
+  public double getMaximumDurationHours() {
+    return maximumDurationHours;
+  }
+
+  public double getElapsedDurationHours() {
+    return elapsedDurationHours;
+  }
+
+  Map<Integer, ChannelState> getChannelStates(String subsystemName) {
+    Map<Integer, ChannelState> states = channelStates.get(subsystemName);
+    return states == null ? Collections.<Integer, ChannelState>emptyMap() : states;
+  }
+
+  Double getHoursSinceProofTest(String subsystemName) {
+    return hoursSinceProofTest.get(subsystemName);
+  }
+
+  Map<String, Map<Integer, ChannelState>> getAllChannelStates() {
+    return channelStates;
+  }
+
+  Map<String, Double> getAllProofTestAges() {
+    return hoursSinceProofTest;
+  }
+
+  /** Builder for an operating mode snapshot. */
+  public static final class Builder {
+    private final String name;
+    private final ModeType type;
+    private String authorizationReference = "";
+    private String compensatingMeasure = "";
+    private double maximumDurationHours = Double.NaN;
+    private double elapsedDurationHours;
+    private final Map<String, Map<Integer, ChannelState>> channelStates = new LinkedHashMap<String, Map<Integer, ChannelState>>();
+    private final Map<String, Double> hoursSinceProofTest = new LinkedHashMap<String, Double>();
+
+    private Builder(String name, ModeType type) {
+      if (type == null) {
+        throw new IllegalArgumentException("type must not be null");
+      }
+      this.name = name;
+      this.type = type;
+    }
+
+    public Builder authorizationReference(String value) {
+      authorizationReference = requireText(value, "authorizationReference");
+      return this;
+    }
+
+    public Builder compensatingMeasure(String value) {
+      compensatingMeasure = requireText(value, "compensatingMeasure");
+      return this;
+    }
+
+    public Builder duration(double elapsedHours, double maximumHours) {
+      elapsedDurationHours = nonNegative(elapsedHours, "elapsedDurationHours");
+      if (!Double.isFinite(maximumHours) || maximumHours <= 0.0) {
+        throw new IllegalArgumentException("maximumDurationHours must be finite and positive");
+      }
+      maximumDurationHours = maximumHours;
+      return this;
+    }
+
+    /**
+     * Sets one channel state using a one-based channel index.
+     *
+     * @param subsystemName exact subsystem name from the safety design
+     * @param channelIndex one-based channel number
+     * @param state declared channel state
+     * @return this builder
+     */
+    public Builder channelState(String subsystemName, int channelIndex, ChannelState state) {
+      String normalized = requireText(subsystemName, "subsystemName");
+      if (channelIndex < 1 || state == null) {
+        throw new IllegalArgumentException("channelIndex must be positive and state must not be null");
+      }
+      Map<Integer, ChannelState> states = channelStates.get(normalized);
+      if (states == null) {
+        states = new LinkedHashMap<Integer, ChannelState>();
+        channelStates.put(normalized, states);
+      }
+      states.put(Integer.valueOf(channelIndex), state);
+      return this;
+    }
+
+    public Builder hoursSinceProofTest(String subsystemName, double hours) {
+      hoursSinceProofTest.put(requireText(subsystemName, "subsystemName"),
+          Double.valueOf(nonNegative(hours, "hoursSinceProofTest")));
+      return this;
+    }
+
+    public SafetyFunctionOperatingMode build() {
+      return new SafetyFunctionOperatingMode(this);
+    }
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double nonNegative(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and non-negative");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/safety/SafetyFunctionReliabilityStudy.java
+++ b/src/main/java/neqsim/process/engineering/safety/SafetyFunctionReliabilityStudy.java
@@ -1,0 +1,357 @@
+package neqsim.process.engineering.safety;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import neqsim.process.engineering.SafetyFunctionDesign;
+
+/** Seeded uncertainty propagation around the analytical {@link SafetyFunctionDesign} reliability screen. */
+public final class SafetyFunctionReliabilityStudy {
+  private SafetyFunctionReliabilityStudy() {
+  }
+
+  /** Non-negative triangular distribution used for reliability inputs and multipliers. */
+  public static final class TriangularDistribution implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double low;
+    private final double mode;
+    private final double high;
+
+    private TriangularDistribution(double low, double mode, double high) {
+      if (!Double.isFinite(low) || !Double.isFinite(mode) || !Double.isFinite(high) || low < 0.0 || low > mode
+          || mode > high) {
+        throw new IllegalArgumentException("triangular distribution requires 0 <= low <= mode <= high");
+      }
+      this.low = low;
+      this.mode = mode;
+      this.high = high;
+    }
+
+    public static TriangularDistribution of(double low, double mode, double high) {
+      return new TriangularDistribution(low, mode, high);
+    }
+
+    public static TriangularDistribution constant(double value) {
+      return new TriangularDistribution(value, value, value);
+    }
+
+    double sample(Random random) {
+      if (low == high) {
+        return low;
+      }
+      double u = random.nextDouble();
+      double fractionAtMode = (mode - low) / (high - low);
+      if (u <= fractionAtMode) {
+        return low + Math.sqrt(u * (high - low) * (mode - low));
+      }
+      return high - Math.sqrt((1.0 - u) * (high - low) * (high - mode));
+    }
+
+    boolean isStrictlyPositive() {
+      return low > 0.0;
+    }
+
+    boolean isFraction() {
+      return high <= 1.0;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> map = new LinkedHashMap<String, Object>();
+      map.put("distribution", "TRIANGULAR");
+      map.put("low", Double.valueOf(low));
+      map.put("mode", Double.valueOf(mode));
+      map.put("high", Double.valueOf(high));
+      return map;
+    }
+  }
+
+  /** Uncertainty definition for one named SIF subsystem. */
+  public static final class SubsystemUncertainty implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String subsystemName;
+    private TriangularDistribution failureRateFactor = TriangularDistribution.constant(1.0);
+    private TriangularDistribution diagnosticCoverage;
+    private TriangularDistribution proofTestIntervalFactor = TriangularDistribution.constant(1.0);
+    private TriangularDistribution repairTimeFactor = TriangularDistribution.constant(1.0);
+    private TriangularDistribution betaFactor;
+    private TriangularDistribution bypassProbability;
+
+    public SubsystemUncertainty(String subsystemName) {
+      if (subsystemName == null || subsystemName.trim().isEmpty()) {
+        throw new IllegalArgumentException("subsystemName must not be blank");
+      }
+      this.subsystemName = subsystemName.trim();
+    }
+
+    public SubsystemUncertainty setFailureRateFactor(TriangularDistribution value) {
+      failureRateFactor = requirePositiveDistribution(value, "failureRateFactor");
+      return this;
+    }
+
+    public SubsystemUncertainty setDiagnosticCoverage(TriangularDistribution value) {
+      diagnosticCoverage = requireFractionDistribution(value, "diagnosticCoverage");
+      return this;
+    }
+
+    public SubsystemUncertainty setProofTestIntervalFactor(TriangularDistribution value) {
+      proofTestIntervalFactor = requirePositiveDistribution(value, "proofTestIntervalFactor");
+      return this;
+    }
+
+    public SubsystemUncertainty setRepairTimeFactor(TriangularDistribution value) {
+      repairTimeFactor = requirePositiveDistribution(value, "repairTimeFactor");
+      return this;
+    }
+
+    public SubsystemUncertainty setBetaFactor(TriangularDistribution value) {
+      betaFactor = requireFractionDistribution(value, "betaFactor");
+      return this;
+    }
+
+    public SubsystemUncertainty setBypassProbability(TriangularDistribution value) {
+      bypassProbability = requireFractionDistribution(value, "bypassProbability");
+      return this;
+    }
+
+    private SafetyFunctionDesign.Subsystem sample(SafetyFunctionDesign.Subsystem subsystem, Random random) {
+      double coverage = diagnosticCoverage == null ? subsystem.getDiagnosticCoverage()
+          : diagnosticCoverage.sample(random);
+      double beta = betaFactor == null ? subsystem.getBetaFactor() : betaFactor.sample(random);
+      double bypass = bypassProbability == null ? subsystem.getBypassProbability() : bypassProbability.sample(random);
+      return subsystem.copyWithReliabilityInputs(
+          subsystem.getDangerousFailureRatePerHour() * failureRateFactor.sample(random), coverage,
+          subsystem.getProofTestIntervalHours() * proofTestIntervalFactor.sample(random),
+          subsystem.getMeanRepairTimeHours() * repairTimeFactor.sample(random), beta, bypass);
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> map = new LinkedHashMap<String, Object>();
+      map.put("subsystemName", subsystemName);
+      map.put("failureRateFactor", failureRateFactor.toMap());
+      map.put("diagnosticCoverage", diagnosticCoverage == null ? "DESIGN_VALUE" : diagnosticCoverage.toMap());
+      map.put("proofTestIntervalFactor", proofTestIntervalFactor.toMap());
+      map.put("repairTimeFactor", repairTimeFactor.toMap());
+      map.put("betaFactor", betaFactor == null ? "DESIGN_VALUE" : betaFactor.toMap());
+      map.put("bypassProbability", bypassProbability == null ? "DESIGN_VALUE" : bypassProbability.toMap());
+      return map;
+    }
+  }
+
+  /** Immutable Monte Carlo reliability result. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String sifTag;
+    private final SafetyFunctionDesign.DemandMode demandMode;
+    private final int targetSil;
+    private final int iterations;
+    private final long seed;
+    private final double deterministicPfdAverage;
+    private final double deterministicPfh;
+    private final double p10PfdAverage;
+    private final double p50PfdAverage;
+    private final double p90PfdAverage;
+    private final double p10Pfh;
+    private final double p50Pfh;
+    private final double p90Pfh;
+    private final double targetMetProbability;
+    private final List<Map<String, Object>> uncertaintyDefinitions;
+
+    private Result(SafetyFunctionDesign design, int iterations, long seed, double[] pfdSamples, double[] pfhSamples,
+        int targetMetCount, List<Map<String, Object>> uncertaintyDefinitions) {
+      sifTag = design.getSifTag();
+      demandMode = design.getDemandMode();
+      targetSil = design.getTargetSil();
+      this.iterations = iterations;
+      this.seed = seed;
+      deterministicPfdAverage = design.calculatePfdAverage();
+      deterministicPfh = design.calculatePfh();
+      p10PfdAverage = percentile(pfdSamples, 0.10);
+      p50PfdAverage = percentile(pfdSamples, 0.50);
+      p90PfdAverage = percentile(pfdSamples, 0.90);
+      p10Pfh = percentile(pfhSamples, 0.10);
+      p50Pfh = percentile(pfhSamples, 0.50);
+      p90Pfh = percentile(pfhSamples, 0.90);
+      targetMetProbability = ((double) targetMetCount) / iterations;
+      this.uncertaintyDefinitions = Collections
+          .unmodifiableList(new ArrayList<Map<String, Object>>(uncertaintyDefinitions));
+    }
+
+    public double getP10PfdAverage() {
+      return p10PfdAverage;
+    }
+
+    public double getP50PfdAverage() {
+      return p50PfdAverage;
+    }
+
+    public double getP90PfdAverage() {
+      return p90PfdAverage;
+    }
+
+    public double getP10Pfh() {
+      return p10Pfh;
+    }
+
+    public double getP50Pfh() {
+      return p50Pfh;
+    }
+
+    public double getP90Pfh() {
+      return p90Pfh;
+    }
+
+    public double getDeterministicPfdAverage() {
+      return deterministicPfdAverage;
+    }
+
+    public double getDeterministicPfh() {
+      return deterministicPfh;
+    }
+
+    public int getIterations() {
+      return iterations;
+    }
+
+    public long getSeed() {
+      return seed;
+    }
+
+    public double getTargetMetProbability() {
+      return targetMetProbability;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> map = new LinkedHashMap<String, Object>();
+      map.put("schemaVersion", "sif_reliability_uncertainty.v1");
+      map.put("sifTag", sifTag);
+      map.put("demandMode", demandMode.name());
+      map.put("targetSil", Integer.valueOf(targetSil));
+      map.put("iterations", Integer.valueOf(iterations));
+      map.put("seed", Long.valueOf(seed));
+      map.put("deterministicPfdAverage", Double.valueOf(deterministicPfdAverage));
+      map.put("deterministicPfhPerHour", Double.valueOf(deterministicPfh));
+      map.put("p10PfdAverage", Double.valueOf(p10PfdAverage));
+      map.put("p50PfdAverage", Double.valueOf(p50PfdAverage));
+      map.put("p90PfdAverage", Double.valueOf(p90PfdAverage));
+      map.put("p10PfhPerHour", Double.valueOf(p10Pfh));
+      map.put("p50PfhPerHour", Double.valueOf(p50Pfh));
+      map.put("p90PfhPerHour", Double.valueOf(p90Pfh));
+      map.put("targetMetProbability", Double.valueOf(targetMetProbability));
+      map.put("uncertaintyDefinitions", uncertaintyDefinitions);
+      map.put("silTargetInferred", Boolean.FALSE);
+      map.put("engineeringApprovalRequired", Boolean.TRUE);
+      map.put("method", "SEEDED_TRIANGULAR_MONTE_CARLO_AROUND_SAFETY_FUNCTION_DESIGN");
+      return map;
+    }
+  }
+
+  /**
+   * Runs a seeded uncertainty study.
+   *
+   * @param design analytical SIF design
+   * @param uncertainties subsystem uncertainty definitions
+   * @param iterations number of samples, at least 100
+   * @param seed reproducibility seed
+   * @return percentile and target-probability evidence
+   */
+  public static Result run(SafetyFunctionDesign design, List<SubsystemUncertainty> uncertainties, int iterations,
+      long seed) {
+    if (design == null || uncertainties == null) {
+      throw new IllegalArgumentException("design and uncertainties are required");
+    }
+    if (iterations < 100) {
+      throw new IllegalArgumentException("iterations must be at least 100");
+    }
+    Map<String, SubsystemUncertainty> definitions = index(design, uncertainties);
+    List<Map<String, Object>> definitionMaps = new ArrayList<Map<String, Object>>();
+    for (SubsystemUncertainty uncertainty : uncertainties) {
+      definitionMaps.add(uncertainty.toMap());
+    }
+    Random random = new Random(seed);
+    double[] pfdSamples = new double[iterations];
+    double[] pfhSamples = new double[iterations];
+    int targetMetCount = 0;
+    for (int sampleIndex = 0; sampleIndex < iterations; sampleIndex++) {
+      double success = 1.0;
+      double pfh = 0.0;
+      for (SafetyFunctionDesign.Subsystem subsystem : design.getSubsystems()) {
+        SubsystemUncertainty uncertainty = definitions.get(subsystem.getName());
+        SafetyFunctionDesign.Subsystem sampled = uncertainty == null ? subsystem
+            : uncertainty.sample(subsystem, random);
+        success *= 1.0 - sampled.calculatePfdAverage();
+        pfh += sampled.calculatePfh();
+      }
+      pfdSamples[sampleIndex] = 1.0 - success;
+      pfhSamples[sampleIndex] = pfh;
+      if (achievedSil(design.getDemandMode(), pfdSamples[sampleIndex], pfh) >= design.getTargetSil()) {
+        targetMetCount++;
+      }
+    }
+    return new Result(design, iterations, seed, pfdSamples, pfhSamples, targetMetCount, definitionMaps);
+  }
+
+  private static Map<String, SubsystemUncertainty> index(SafetyFunctionDesign design,
+      List<SubsystemUncertainty> uncertainties) {
+    Map<String, SafetyFunctionDesign.Subsystem> designSubsystems = new LinkedHashMap<String, SafetyFunctionDesign.Subsystem>();
+    for (SafetyFunctionDesign.Subsystem subsystem : design.getSubsystems()) {
+      designSubsystems.put(subsystem.getName(), subsystem);
+    }
+    Map<String, SubsystemUncertainty> result = new LinkedHashMap<String, SubsystemUncertainty>();
+    for (SubsystemUncertainty uncertainty : uncertainties) {
+      if (uncertainty == null || !designSubsystems.containsKey(uncertainty.subsystemName)) {
+        throw new IllegalArgumentException("uncertainty references an unknown subsystem");
+      }
+      if (result.put(uncertainty.subsystemName, uncertainty) != null) {
+        throw new IllegalArgumentException("duplicate uncertainty for " + uncertainty.subsystemName);
+      }
+    }
+    return result;
+  }
+
+  private static int achievedSil(SafetyFunctionDesign.DemandMode demandMode, double pfd, double pfh) {
+    double measure = demandMode == SafetyFunctionDesign.DemandMode.LOW_DEMAND ? pfd : pfh;
+    double firstLimit = demandMode == SafetyFunctionDesign.DemandMode.LOW_DEMAND ? 1.0e-1 : 1.0e-5;
+    if (measure <= 0.0 || measure >= firstLimit) {
+      return 0;
+    }
+    double[] limits = demandMode == SafetyFunctionDesign.DemandMode.LOW_DEMAND
+        ? new double[] { 1.0e-2, 1.0e-3, 1.0e-4, 1.0e-5 }
+        : new double[] { 1.0e-6, 1.0e-7, 1.0e-8, 1.0e-9 };
+    for (int sil = 1; sil <= limits.length; sil++) {
+      if (measure >= limits[sil - 1]) {
+        return sil;
+      }
+    }
+    return demandMode == SafetyFunctionDesign.DemandMode.LOW_DEMAND || measure >= 1.0e-9 ? 4 : 0;
+  }
+
+  private static double percentile(double[] values, double fraction) {
+    double[] sorted = values.clone();
+    java.util.Arrays.sort(sorted);
+    double index = fraction * (sorted.length - 1);
+    int lower = (int) Math.floor(index);
+    int upper = (int) Math.ceil(index);
+    if (lower == upper) {
+      return sorted[lower];
+    }
+    return sorted[lower] + (index - lower) * (sorted[upper] - sorted[lower]);
+  }
+
+  private static TriangularDistribution requirePositiveDistribution(TriangularDistribution value, String name) {
+    if (value == null || !value.isStrictlyPositive()) {
+      throw new IllegalArgumentException(name + " must be strictly positive");
+    }
+    return value;
+  }
+
+  private static TriangularDistribution requireFractionDistribution(TriangularDistribution value, String name) {
+    if (value == null || !value.isFraction()) {
+      throw new IllegalArgumentException(name + " must remain in [0, 1]");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioEvidenceProvider.java
+++ b/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioEvidenceProvider.java
@@ -1,0 +1,14 @@
+package neqsim.process.safety.scenario;
+
+import java.util.Map;
+
+/** Supplies structured evidence from protection logic executed by a dynamic safety scenario. */
+public interface DynamicSafetyScenarioEvidenceProvider {
+
+  /**
+   * Gets a serialization-safe evidence record for the completed or current logic execution.
+   *
+   * @return ordered evidence fields suitable for JSON serialization
+   */
+  Map<String, Object> getDynamicSafetyScenarioEvidence();
+}

--- a/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioResult.java
+++ b/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioResult.java
@@ -67,8 +67,7 @@ public final class DynamicSafetyScenarioResult implements Serializable {
     this.scenarioName = scenarioName;
     this.criterionResults = Collections.unmodifiableMap(new LinkedHashMap<String, CriterionResult>(criterionResults));
     this.finalLogicStates = Collections.unmodifiableMap(new LinkedHashMap<String, String>(finalLogicStates));
-    this.logicEvidence = Collections
-        .unmodifiableMap(new LinkedHashMap<String, Map<String, Object>>(logicEvidence));
+    this.logicEvidence = Collections.unmodifiableMap(new LinkedHashMap<String, Map<String, Object>>(logicEvidence));
     this.errors = Collections.unmodifiableList(new ArrayList<String>(errors));
     this.steadyStateConverged = steadyStateConverged;
   }

--- a/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioResult.java
+++ b/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioResult.java
@@ -56,15 +56,19 @@ public final class DynamicSafetyScenarioResult implements Serializable {
   private final String scenarioName;
   private final Map<String, CriterionResult> criterionResults;
   private final Map<String, String> finalLogicStates;
+  private final Map<String, Map<String, Object>> logicEvidence;
   private final List<String> errors;
   private final boolean steadyStateConverged;
 
   DynamicSafetyScenarioResult(String scenarioId, String scenarioName, Map<String, CriterionResult> criterionResults,
-      Map<String, String> finalLogicStates, List<String> errors, boolean steadyStateConverged) {
+      Map<String, String> finalLogicStates, Map<String, Map<String, Object>> logicEvidence, List<String> errors,
+      boolean steadyStateConverged) {
     this.scenarioId = scenarioId;
     this.scenarioName = scenarioName;
     this.criterionResults = Collections.unmodifiableMap(new LinkedHashMap<String, CriterionResult>(criterionResults));
     this.finalLogicStates = Collections.unmodifiableMap(new LinkedHashMap<String, String>(finalLogicStates));
+    this.logicEvidence = Collections
+        .unmodifiableMap(new LinkedHashMap<String, Map<String, Object>>(logicEvidence));
     this.errors = Collections.unmodifiableList(new ArrayList<String>(errors));
     this.steadyStateConverged = steadyStateConverged;
   }
@@ -90,9 +94,14 @@ public final class DynamicSafetyScenarioResult implements Serializable {
     return criterionResults;
   }
 
+  /** @return structured evidence keyed by protection-logic name */
+  public Map<String, Map<String, Object>> getLogicEvidence() {
+    return logicEvidence;
+  }
+
   public Map<String, Object> toMap() {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
-    result.put("schemaVersion", "dynamic_safety_scenario_result.v1");
+    result.put("schemaVersion", "dynamic_safety_scenario_result.v2");
     result.put("scenarioId", scenarioId);
     result.put("scenarioName", scenarioName);
     result.put("steadyStateConverged", Boolean.valueOf(steadyStateConverged));
@@ -102,6 +111,7 @@ public final class DynamicSafetyScenarioResult implements Serializable {
     }
     result.put("criteria", criteria);
     result.put("finalLogicStates", new LinkedHashMap<String, String>(finalLogicStates));
+    result.put("logicEvidence", new LinkedHashMap<String, Map<String, Object>>(logicEvidence));
     result.put("errors", new ArrayList<String>(errors));
     result.put("passed", Boolean.valueOf(isPassed()));
     result.put("silTargetInferred", Boolean.FALSE);

--- a/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioRunner.java
+++ b/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioRunner.java
@@ -75,11 +75,16 @@ public final class DynamicSafetyScenarioRunner {
     }
 
     Map<String, String> finalStates = new LinkedHashMap<String, String>();
+    Map<String, Map<String, Object>> logicEvidence = new LinkedHashMap<String, Map<String, Object>>();
     for (ProcessLogic item : logic) {
       finalStates.put(item.getName(), item.getState().name());
+      if (item instanceof DynamicSafetyScenarioEvidenceProvider) {
+        logicEvidence.put(item.getName(),
+            ((DynamicSafetyScenarioEvidenceProvider) item).getDynamicSafetyScenarioEvidence());
+      }
     }
     DynamicSafetyScenarioResult result = new DynamicSafetyScenarioResult(scenario.getId(), scenario.getName(), criteria,
-        finalStates, errors, converged);
+        finalStates, logicEvidence, errors, converged);
     logger.info("Dynamic safety scenario '{}' completed with verdict {}", scenario.getId(),
         result.isPassed() ? "PASS" : "FAIL");
     return result;

--- a/src/main/java/neqsim/process/safety/sif/ClosedLoopSafetyFunction.java
+++ b/src/main/java/neqsim/process/safety/sif/ClosedLoopSafetyFunction.java
@@ -1,0 +1,275 @@
+package neqsim.process.safety.sif;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.logic.LogicState;
+import neqsim.process.logic.ProcessLogic;
+import neqsim.process.logic.voting.VotingPattern;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.safety.scenario.DynamicSafetyScenarioEvidenceProvider;
+
+/**
+ * Closed-loop sensor, voting, logic-solver, and final-element execution for dynamic SIF verification.
+ *
+ * <p>The loop is deliberately bound to the isolated {@link ProcessSystem} copy created by the dynamic scenario runner.
+ * It can therefore verify process detection and real final-element response without modifying the design case.</p>
+ */
+public final class ClosedLoopSafetyFunction
+    implements ProcessLogic, DynamicSafetyScenarioEvidenceProvider {
+  private static final long serialVersionUID = 1000L;
+
+  private final String sifId;
+  private final String name;
+  private final ProcessSystem process;
+  private final VotingPattern votingPattern;
+  private final double logicSolverDelaySeconds;
+  private final ProcessLogic finalElementLogic;
+  private final List<SafetyFunctionChannel> channels;
+  private final List<Map<String, Object>> trace = new ArrayList<Map<String, Object>>();
+  private LogicState state = LogicState.IDLE;
+  private double elapsedSeconds;
+  private double voteElapsedSeconds;
+  private Double firstVoteSeconds;
+  private Double finalElementActuationSeconds;
+
+  private ClosedLoopSafetyFunction(Builder builder) {
+    sifId = requireText(builder.sifId, "sifId");
+    name = requireText(builder.name, "name");
+    process = builder.process;
+    votingPattern = builder.votingPattern;
+    logicSolverDelaySeconds = nonNegative(builder.logicSolverDelaySeconds, "logicSolverDelaySeconds");
+    finalElementLogic = builder.finalElementLogic;
+    channels = new ArrayList<SafetyFunctionChannel>(builder.channels);
+    if (channels.size() != votingPattern.getTotalSensors()) {
+      throw new IllegalArgumentException("Voting pattern " + votingPattern + " requires "
+          + votingPattern.getTotalSensors() + " channels but " + channels.size() + " were supplied");
+    }
+  }
+
+  /**
+   * Starts a closed-loop SIF definition.
+   *
+   * @param sifId controlled SIF identifier
+   * @param name descriptive name
+   * @param process isolated process model used by the scenario
+   * @param votingPattern sensor voting pattern
+   * @param finalElementLogic ESD, HIPPS, or other final-element logic
+   * @return SIF builder
+   */
+  public static Builder builder(String sifId, String name, ProcessSystem process, VotingPattern votingPattern,
+      ProcessLogic finalElementLogic) {
+    return new Builder(sifId, name, process, votingPattern, finalElementLogic);
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  /** @return controlled SIF identifier */
+  public String getSifId() {
+    return sifId;
+  }
+
+  @Override
+  public LogicState getState() {
+    return state;
+  }
+
+  @Override
+  public void activate() {
+    if (state == LogicState.IDLE || state == LogicState.COMPLETED || state == LogicState.FAILED) {
+      clearExecutionState();
+      state = LogicState.RUNNING;
+    }
+  }
+
+  @Override
+  public void deactivate() {
+    if (state == LogicState.RUNNING) {
+      state = LogicState.PAUSED;
+      if (finalElementLogic.isActive()) {
+        finalElementLogic.deactivate();
+      }
+    }
+  }
+
+  @Override
+  public boolean reset() {
+    clearExecutionState();
+    state = LogicState.IDLE;
+    return finalElementLogic.reset();
+  }
+
+  @Override
+  public void execute(double timeStep) {
+    if (state != LogicState.RUNNING) {
+      return;
+    }
+    if (!Double.isFinite(timeStep) || timeStep <= 0.0) {
+      throw new IllegalArgumentException("timeStep must be finite and positive");
+    }
+    elapsedSeconds += timeStep;
+    int trippedCount = 0;
+    int availableCount = 0;
+    List<Map<String, Object>> channelEvidence = new ArrayList<Map<String, Object>>();
+    for (SafetyFunctionChannel channel : channels) {
+      SafetyFunctionChannel.Sample sample = channel.sample(process, timeStep);
+      if (sample.isTripped()) {
+        trippedCount++;
+      }
+      if (sample.isAvailable()) {
+        availableCount++;
+      }
+      channelEvidence.add(sample.toMap());
+    }
+
+    boolean vote = votingPattern.evaluate(trippedCount);
+    if (vote) {
+      if (firstVoteSeconds == null) {
+        firstVoteSeconds = Double.valueOf(elapsedSeconds);
+        voteElapsedSeconds = 0.0;
+      } else {
+        voteElapsedSeconds += timeStep;
+      }
+      if (finalElementActuationSeconds == null
+          && voteElapsedSeconds + 1.0e-12 >= logicSolverDelaySeconds) {
+        finalElementLogic.activate();
+        finalElementActuationSeconds = Double.valueOf(elapsedSeconds);
+      }
+    }
+    if (finalElementLogic.isActive()) {
+      finalElementLogic.execute(timeStep);
+    }
+    if (finalElementLogic.isComplete()) {
+      state = LogicState.COMPLETED;
+    }
+
+    Map<String, Object> loopSample = new LinkedHashMap<String, Object>();
+    loopSample.put("timeSeconds", Double.valueOf(elapsedSeconds));
+    loopSample.put("trippedChannelCount", Integer.valueOf(trippedCount));
+    loopSample.put("availableChannelCount", Integer.valueOf(availableCount));
+    loopSample.put("vote", Boolean.valueOf(vote));
+    loopSample.put("channels", channelEvidence);
+    loopSample.put("finalElementState", finalElementLogic.getState().name());
+    trace.add(loopSample);
+  }
+
+  @Override
+  public boolean isActive() {
+    return state == LogicState.RUNNING;
+  }
+
+  @Override
+  public boolean isComplete() {
+    return state == LogicState.COMPLETED;
+  }
+
+  @Override
+  public List<ProcessEquipmentInterface> getTargetEquipment() {
+    return finalElementLogic.getTargetEquipment();
+  }
+
+  @Override
+  public String getStatusDescription() {
+    if (firstVoteSeconds == null) {
+      return name + " - " + state.name() + " (monitoring " + votingPattern + ")";
+    }
+    return name + " - " + state.name() + " (voted at " + firstVoteSeconds + " s; final element "
+        + finalElementLogic.getState().name() + ")";
+  }
+
+  @Override
+  public Map<String, Object> getDynamicSafetyScenarioEvidence() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", "closed_loop_sif_evidence.v1");
+    result.put("sifId", sifId);
+    result.put("name", name);
+    result.put("votingPattern", votingPattern.getNotation());
+    result.put("logicSolverDelaySeconds", Double.valueOf(logicSolverDelaySeconds));
+    List<Map<String, Object>> channelConfiguration = new ArrayList<Map<String, Object>>();
+    for (SafetyFunctionChannel channel : channels) {
+      channelConfiguration.add(channel.configurationMap());
+    }
+    result.put("channelConfiguration", channelConfiguration);
+    result.put("firstVoteSeconds", firstVoteSeconds);
+    result.put("finalElementActuationSeconds", finalElementActuationSeconds);
+    result.put("finalElementLogic", finalElementLogic.getName());
+    result.put("finalElementState", finalElementLogic.getState().name());
+    result.put("trace", new ArrayList<Map<String, Object>>(trace));
+    result.put("engineeringApprovalRequired", Boolean.TRUE);
+    return result;
+  }
+
+  private void clearExecutionState() {
+    elapsedSeconds = 0.0;
+    voteElapsedSeconds = 0.0;
+    firstVoteSeconds = null;
+    finalElementActuationSeconds = null;
+    trace.clear();
+    for (SafetyFunctionChannel channel : channels) {
+      channel.reset();
+    }
+    finalElementLogic.reset();
+  }
+
+  /** Builder for a closed-loop safety function. */
+  public static final class Builder {
+    private final String sifId;
+    private final String name;
+    private final ProcessSystem process;
+    private final VotingPattern votingPattern;
+    private final ProcessLogic finalElementLogic;
+    private final List<SafetyFunctionChannel> channels = new ArrayList<SafetyFunctionChannel>();
+    private double logicSolverDelaySeconds;
+
+    private Builder(String sifId, String name, ProcessSystem process, VotingPattern votingPattern,
+        ProcessLogic finalElementLogic) {
+      if (process == null || votingPattern == null || finalElementLogic == null) {
+        throw new IllegalArgumentException("process, votingPattern, and finalElementLogic are required");
+      }
+      this.sifId = sifId;
+      this.name = name;
+      this.process = process;
+      this.votingPattern = votingPattern;
+      this.finalElementLogic = finalElementLogic;
+    }
+
+    /** @param value sensor channel @return this builder */
+    public Builder addChannel(SafetyFunctionChannel value) {
+      if (value == null) {
+        throw new IllegalArgumentException("channel must not be null");
+      }
+      channels.add(value);
+      return this;
+    }
+
+    /** @param value logic solver delay in seconds @return this builder */
+    public Builder logicSolverDelaySeconds(double value) {
+      logicSolverDelaySeconds = value;
+      return this;
+    }
+
+    /** @return validated closed-loop SIF */
+    public ClosedLoopSafetyFunction build() {
+      return new ClosedLoopSafetyFunction(this);
+    }
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double nonNegative(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and non-negative");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/safety/sif/ClosedLoopSafetyFunction.java
+++ b/src/main/java/neqsim/process/safety/sif/ClosedLoopSafetyFunction.java
@@ -14,11 +14,12 @@ import neqsim.process.safety.scenario.DynamicSafetyScenarioEvidenceProvider;
 /**
  * Closed-loop sensor, voting, logic-solver, and final-element execution for dynamic SIF verification.
  *
- * <p>The loop is deliberately bound to the isolated {@link ProcessSystem} copy created by the dynamic scenario runner.
- * It can therefore verify process detection and real final-element response without modifying the design case.</p>
+ * <p>
+ * The loop is deliberately bound to the isolated {@link ProcessSystem} copy created by the dynamic scenario runner. It
+ * can therefore verify process detection and real final-element response without modifying the design case.
+ * </p>
  */
-public final class ClosedLoopSafetyFunction
-    implements ProcessLogic, DynamicSafetyScenarioEvidenceProvider {
+public final class ClosedLoopSafetyFunction implements ProcessLogic, DynamicSafetyScenarioEvidenceProvider {
   private static final long serialVersionUID = 1000L;
 
   private final String sifId;
@@ -135,8 +136,7 @@ public final class ClosedLoopSafetyFunction
       } else {
         voteElapsedSeconds += timeStep;
       }
-      if (finalElementActuationSeconds == null
-          && voteElapsedSeconds + 1.0e-12 >= logicSolverDelaySeconds) {
+      if (finalElementActuationSeconds == null && voteElapsedSeconds + 1.0e-12 >= logicSolverDelaySeconds) {
         finalElementLogic.activate();
         finalElementActuationSeconds = Double.valueOf(elapsedSeconds);
       }

--- a/src/main/java/neqsim/process/safety/sif/SafetyFunctionChannel.java
+++ b/src/main/java/neqsim/process/safety/sif/SafetyFunctionChannel.java
@@ -34,8 +34,8 @@ public final class SafetyFunctionChannel implements Serializable {
     private final boolean available;
     private final FaultMode faultMode;
 
-    Sample(String tag, double rawValue, double indicatedValue, boolean demand, boolean tripped,
-        boolean available, FaultMode faultMode) {
+    Sample(String tag, double rawValue, double indicatedValue, boolean demand, boolean tripped, boolean available,
+        FaultMode faultMode) {
       this.tag = tag;
       this.rawValue = rawValue;
       this.indicatedValue = indicatedValue;
@@ -168,8 +168,7 @@ public final class SafetyFunctionChannel implements Serializable {
     private FaultMode faultMode = FaultMode.HEALTHY;
     private double bias;
 
-    private Builder(String tag, String unit, double setpoint, TripDirection tripDirection,
-        SignalExtractor extractor) {
+    private Builder(String tag, String unit, double setpoint, TripDirection tripDirection, SignalExtractor extractor) {
       if (extractor == null) {
         throw new IllegalArgumentException("extractor must not be null");
       }

--- a/src/main/java/neqsim/process/safety/sif/SafetyFunctionChannel.java
+++ b/src/main/java/neqsim/process/safety/sif/SafetyFunctionChannel.java
@@ -16,17 +16,12 @@ public final class SafetyFunctionChannel implements Serializable {
 
   /** Direction in which the measured signal demands a trip. */
   public enum TripDirection {
-    HIGH,
-    LOW
+    HIGH, LOW
   }
 
   /** Explicit channel state used for fault-injection and degraded-mode verification. */
   public enum FaultMode {
-    HEALTHY,
-    BYPASSED,
-    STUCK_NORMAL,
-    STUCK_TRIP,
-    BIASED
+    HEALTHY, BYPASSED, STUCK_NORMAL, STUCK_TRIP, BIASED
   }
 
   /** One sampled channel state recorded in the scenario evidence. */

--- a/src/main/java/neqsim/process/safety/sif/SafetyFunctionChannel.java
+++ b/src/main/java/neqsim/process/safety/sif/SafetyFunctionChannel.java
@@ -1,0 +1,238 @@
+package neqsim.process.safety.sif;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import neqsim.process.processmodel.ProcessSystem;
+
+/** Process-bound sensor or switch channel used by a closed-loop safety function. */
+public final class SafetyFunctionChannel implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Reads a scalar process value from the isolated process model. */
+  public interface SignalExtractor extends Serializable {
+    double extract(ProcessSystem process);
+  }
+
+  /** Direction in which the measured signal demands a trip. */
+  public enum TripDirection {
+    HIGH,
+    LOW
+  }
+
+  /** Explicit channel state used for fault-injection and degraded-mode verification. */
+  public enum FaultMode {
+    HEALTHY,
+    BYPASSED,
+    STUCK_NORMAL,
+    STUCK_TRIP,
+    BIASED
+  }
+
+  /** One sampled channel state recorded in the scenario evidence. */
+  static final class Sample {
+    private final String tag;
+    private final double rawValue;
+    private final double indicatedValue;
+    private final boolean demand;
+    private final boolean tripped;
+    private final boolean available;
+    private final FaultMode faultMode;
+
+    Sample(String tag, double rawValue, double indicatedValue, boolean demand, boolean tripped,
+        boolean available, FaultMode faultMode) {
+      this.tag = tag;
+      this.rawValue = rawValue;
+      this.indicatedValue = indicatedValue;
+      this.demand = demand;
+      this.tripped = tripped;
+      this.available = available;
+      this.faultMode = faultMode;
+    }
+
+    boolean isTripped() {
+      return tripped;
+    }
+
+    boolean isAvailable() {
+      return available;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("tag", tag);
+      result.put("rawValue", Double.valueOf(rawValue));
+      result.put("indicatedValue", Double.valueOf(indicatedValue));
+      result.put("demand", Boolean.valueOf(demand));
+      result.put("tripped", Boolean.valueOf(tripped));
+      result.put("available", Boolean.valueOf(available));
+      result.put("faultMode", faultMode.name());
+      return result;
+    }
+  }
+
+  private final String tag;
+  private final String unit;
+  private final double setpoint;
+  private final TripDirection tripDirection;
+  private final double responseDelaySeconds;
+  private final FaultMode faultMode;
+  private final double bias;
+  private final SignalExtractor extractor;
+  private double continuousDemandSeconds;
+  private boolean latchedTrip;
+
+  private SafetyFunctionChannel(Builder builder) {
+    tag = requireText(builder.tag, "tag");
+    unit = requireText(builder.unit, "unit");
+    setpoint = finite(builder.setpoint, "setpoint");
+    tripDirection = builder.tripDirection;
+    responseDelaySeconds = nonNegative(builder.responseDelaySeconds, "responseDelaySeconds");
+    faultMode = builder.faultMode;
+    bias = finite(builder.bias, "bias");
+    extractor = builder.extractor;
+  }
+
+  /**
+   * Starts a high-trip channel definition.
+   *
+   * @param tag instrument tag
+   * @param unit signal engineering unit
+   * @param setpoint high-trip setpoint
+   * @param extractor process signal binding
+   * @return channel builder
+   */
+  public static Builder highTrip(String tag, String unit, double setpoint, SignalExtractor extractor) {
+    return new Builder(tag, unit, setpoint, TripDirection.HIGH, extractor);
+  }
+
+  /**
+   * Starts a low-trip channel definition.
+   *
+   * @param tag instrument tag
+   * @param unit signal engineering unit
+   * @param setpoint low-trip setpoint
+   * @param extractor process signal binding
+   * @return channel builder
+   */
+  public static Builder lowTrip(String tag, String unit, double setpoint, SignalExtractor extractor) {
+    return new Builder(tag, unit, setpoint, TripDirection.LOW, extractor);
+  }
+
+  Sample sample(ProcessSystem process, double timeStepSeconds) {
+    double rawValue = extractor.extract(process);
+    if (!Double.isFinite(rawValue)) {
+      throw new IllegalStateException("Channel " + tag + " returned a non-finite signal");
+    }
+    double indicatedValue = faultMode == FaultMode.BIASED ? rawValue + bias : rawValue;
+    boolean available = faultMode != FaultMode.BYPASSED;
+    boolean demand = tripDirection == TripDirection.HIGH ? indicatedValue >= setpoint : indicatedValue <= setpoint;
+
+    if (faultMode == FaultMode.STUCK_NORMAL || faultMode == FaultMode.BYPASSED) {
+      demand = false;
+    } else if (faultMode == FaultMode.STUCK_TRIP) {
+      demand = true;
+    }
+
+    if (demand && available) {
+      continuousDemandSeconds += timeStepSeconds;
+      if (continuousDemandSeconds + 1.0e-12 >= responseDelaySeconds) {
+        latchedTrip = true;
+      }
+    } else {
+      continuousDemandSeconds = 0.0;
+    }
+    return new Sample(tag, rawValue, indicatedValue, demand, latchedTrip, available, faultMode);
+  }
+
+  void reset() {
+    continuousDemandSeconds = 0.0;
+    latchedTrip = false;
+  }
+
+  Map<String, Object> configurationMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("tag", tag);
+    result.put("unit", unit);
+    result.put("setpoint", Double.valueOf(setpoint));
+    result.put("tripDirection", tripDirection.name());
+    result.put("responseDelaySeconds", Double.valueOf(responseDelaySeconds));
+    result.put("faultMode", faultMode.name());
+    result.put("bias", Double.valueOf(bias));
+    return result;
+  }
+
+  /** Builder for one safety-function channel. */
+  public static final class Builder {
+    private final String tag;
+    private final String unit;
+    private final double setpoint;
+    private final TripDirection tripDirection;
+    private final SignalExtractor extractor;
+    private double responseDelaySeconds;
+    private FaultMode faultMode = FaultMode.HEALTHY;
+    private double bias;
+
+    private Builder(String tag, String unit, double setpoint, TripDirection tripDirection,
+        SignalExtractor extractor) {
+      if (extractor == null) {
+        throw new IllegalArgumentException("extractor must not be null");
+      }
+      this.tag = tag;
+      this.unit = unit;
+      this.setpoint = setpoint;
+      this.tripDirection = tripDirection;
+      this.extractor = extractor;
+    }
+
+    /** @param value channel response delay in seconds @return this builder */
+    public Builder responseDelaySeconds(double value) {
+      responseDelaySeconds = value;
+      return this;
+    }
+
+    /** @param value channel fault mode @return this builder */
+    public Builder faultMode(FaultMode value) {
+      if (value == null) {
+        throw new IllegalArgumentException("faultMode must not be null");
+      }
+      faultMode = value;
+      return this;
+    }
+
+    /** @param value additive signal bias in the channel unit @return this builder */
+    public Builder bias(double value) {
+      bias = value;
+      return this;
+    }
+
+    /** @return validated channel */
+    public SafetyFunctionChannel build() {
+      if (faultMode != FaultMode.BIASED && Math.abs(bias) > 0.0) {
+        throw new IllegalStateException("bias requires BIASED fault mode");
+      }
+      return new SafetyFunctionChannel(this);
+    }
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double finite(double value, String field) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(field + " must be finite");
+    }
+    return value;
+  }
+
+  private static double nonNegative(double value, String field) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(field + " must be finite and non-negative");
+    }
+    return value;
+  }
+}

--- a/src/test/java/neqsim/process/engineering/safety/SafetyFunctionDegradedModeAssessmentTest.java
+++ b/src/test/java/neqsim/process/engineering/safety/SafetyFunctionDegradedModeAssessmentTest.java
@@ -1,0 +1,62 @@
+package neqsim.process.engineering.safety;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import neqsim.process.engineering.SafetyFunctionDesign;
+import neqsim.process.engineering.safety.SafetyFunctionOperatingMode.ChannelState;
+import neqsim.process.engineering.safety.SafetyFunctionOperatingMode.ModeType;
+import org.junit.jupiter.api.Test;
+
+/** Tests effective voting and governance findings for bypass and proof-test states. */
+class SafetyFunctionDegradedModeAssessmentTest {
+
+  @Test
+  void oneBypassedChannelDegradesTwoOutOfThreeToTwoOutOfTwo() {
+    SafetyFunctionOperatingMode mode = SafetyFunctionOperatingMode.builder("PT-C bypass", ModeType.DEGRADED)
+        .authorizationReference("OPS-BYPASS-2026-014").compensatingMeasure("Continuous pressure watch")
+        .duration(2.0, 8.0).channelState("pressure transmitters", 3, ChannelState.BYPASSED)
+        .hoursSinceProofTest("pressure transmitters", 100.0).build();
+
+    SafetyFunctionDegradedModeAssessment.Result result = SafetyFunctionDegradedModeAssessment.assess(design(), mode);
+
+    assertTrue(result.isDemandCapable());
+    assertFalse(result.isTargetSilClaimPreserved());
+    assertEquals("2oo2", result.getSubsystemResults().get(0).getEffectiveArchitecture());
+    assertEquals("RESTRICTED_ENGINEERING_REVIEW", result.getVerdict());
+  }
+
+  @Test
+  void twoUnavailableChannelsCannotMeetTwoOutOfThreeDemand() {
+    SafetyFunctionOperatingMode mode = SafetyFunctionOperatingMode
+        .builder("Two channels in repair", ModeType.MAINTENANCE).authorizationReference("MOC-2026-88")
+        .compensatingMeasure("Process shutdown").duration(1.0, 2.0)
+        .channelState("pressure transmitters", 2, ChannelState.UNDER_REPAIR)
+        .channelState("pressure transmitters", 3, ChannelState.BYPASSED)
+        .hoursSinceProofTest("pressure transmitters", 100.0).build();
+
+    SafetyFunctionDegradedModeAssessment.Result result = SafetyFunctionDegradedModeAssessment.assess(design(), mode);
+
+    assertFalse(result.isDemandCapable());
+    assertEquals("2oo1", result.getSubsystemResults().get(0).getEffectiveArchitecture());
+    assertEquals("NOT_DEMAND_CAPABLE", result.getVerdict());
+  }
+
+  @Test
+  void overdueProofTestInvalidatesSilClaim() {
+    SafetyFunctionOperatingMode mode = SafetyFunctionOperatingMode.builder("Normal operation", ModeType.NORMAL)
+        .hoursSinceProofTest("pressure transmitters", 9000.0).build();
+
+    SafetyFunctionDegradedModeAssessment.Result result = SafetyFunctionDegradedModeAssessment.assess(design(), mode);
+
+    assertTrue(result.isDemandCapable());
+    assertTrue(result.getSubsystemResults().get(0).isProofTestOverdue());
+    assertFalse(result.isTargetSilClaimPreserved());
+    assertTrue(result.getFindings().get(0).contains("overdue"));
+  }
+
+  private static SafetyFunctionDesign design() {
+    return new SafetyFunctionDesign("SIF-HP-101", "REQ-HP-101", 2).addSubsystem(new SafetyFunctionDesign.Subsystem(
+        "pressure transmitters", SafetyFunctionDesign.SubsystemType.SENSOR, 2, 3, 1.0e-6, 0.6, 8760.0, 8.0, 0.05));
+  }
+}

--- a/src/test/java/neqsim/process/engineering/safety/SafetyFunctionReliabilityStudyTest.java
+++ b/src/test/java/neqsim/process/engineering/safety/SafetyFunctionReliabilityStudyTest.java
@@ -1,0 +1,51 @@
+package neqsim.process.engineering.safety;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Collections;
+import neqsim.process.engineering.SafetyFunctionDesign;
+import org.junit.jupiter.api.Test;
+
+/** Tests deterministic and seeded uncertainty propagation for SIF reliability evidence. */
+class SafetyFunctionReliabilityStudyTest {
+
+  @Test
+  void constantInputsReproduceAnalyticalPfd() {
+    SafetyFunctionDesign design = design();
+
+    SafetyFunctionReliabilityStudy.Result result = SafetyFunctionReliabilityStudy.run(design,
+        Collections.<SafetyFunctionReliabilityStudy.SubsystemUncertainty>emptyList(), 100, 42L);
+
+    assertEquals(design.calculatePfdAverage(), result.getP10PfdAverage(), 1.0e-15);
+    assertEquals(design.calculatePfdAverage(), result.getP50PfdAverage(), 1.0e-15);
+    assertEquals(design.calculatePfdAverage(), result.getP90PfdAverage(), 1.0e-15);
+    assertEquals(1.0, result.getTargetMetProbability(), 1.0e-15);
+  }
+
+  @Test
+  void seededStudyIsRepeatableAndOrdersPfdPercentiles() {
+    SafetyFunctionReliabilityStudy.SubsystemUncertainty uncertainty = new SafetyFunctionReliabilityStudy.SubsystemUncertainty(
+        "pressure transmitters")
+        .setFailureRateFactor(SafetyFunctionReliabilityStudy.TriangularDistribution.of(0.5, 1.0, 2.0))
+        .setProofTestIntervalFactor(SafetyFunctionReliabilityStudy.TriangularDistribution.of(0.5, 1.0, 2.0))
+        .setDiagnosticCoverage(SafetyFunctionReliabilityStudy.TriangularDistribution.of(0.0, 0.1, 0.2));
+
+    SafetyFunctionReliabilityStudy.Result first = SafetyFunctionReliabilityStudy.run(design(),
+        Collections.singletonList(uncertainty), 2000, 2486L);
+    SafetyFunctionReliabilityStudy.Result second = SafetyFunctionReliabilityStudy.run(design(),
+        Collections.singletonList(uncertainty), 2000, 2486L);
+
+    assertEquals(first.getP10PfdAverage(), second.getP10PfdAverage(), 0.0);
+    assertEquals(first.getP50PfdAverage(), second.getP50PfdAverage(), 0.0);
+    assertEquals(first.getP90PfdAverage(), second.getP90PfdAverage(), 0.0);
+    assertTrue(first.getP10PfdAverage() <= first.getP50PfdAverage());
+    assertTrue(first.getP50PfdAverage() <= first.getP90PfdAverage());
+    assertTrue(first.getTargetMetProbability() > 0.0 && first.getTargetMetProbability() < 1.0);
+    assertEquals(Boolean.TRUE, first.toMap().get("engineeringApprovalRequired"));
+  }
+
+  private static SafetyFunctionDesign design() {
+    return new SafetyFunctionDesign("SIF-PT-101", "REQ-PT-101", 2).addSubsystem(new SafetyFunctionDesign.Subsystem(
+        "pressure transmitters", SafetyFunctionDesign.SubsystemType.SENSOR, 1, 1, 1.0e-6, 0.0, 8760.0, 8.0, 0.0));
+  }
+}

--- a/src/test/java/neqsim/process/safety/sif/ClosedLoopSafetyFunctionTest.java
+++ b/src/test/java/neqsim/process/safety/sif/ClosedLoopSafetyFunctionTest.java
@@ -53,16 +53,14 @@ class ClosedLoopSafetyFunctionTest {
                 .logicSolverDelaySeconds(0.5).build();
           }
         }).addCriterion(DynamicScenarioCriterion
-            .builder("esdv-closed", "Inlet ESD valve closed", "%",
-                new DynamicScenarioCriterion.Extractor() {
-                  private static final long serialVersionUID = 1000L;
+            .builder("esdv-closed", "Inlet ESD valve closed", "%", new DynamicScenarioCriterion.Extractor() {
+              private static final long serialVersionUID = 1000L;
 
-                  @Override
-                  public double extract(ProcessSystem process) {
-                    return ((ESDValve) process.getUnit("ESDV-101")).getPercentValveOpening();
-                  }
-                })
-            .acceptanceRange(null, Double.valueOf(5.0)).deadlineSeconds(4.0).build())
+              @Override
+              public double extract(ProcessSystem process) {
+                return ((ESDValve) process.getUnit("ESDV-101")).getPercentValveOpening();
+              }
+            }).acceptanceRange(null, Double.valueOf(5.0)).deadlineSeconds(4.0).build())
         .addEvidenceReference("SRS-SIF-HP-101").build();
 
     DynamicSafetyScenarioResult result = DynamicSafetyScenarioRunner.run(base, scenario);
@@ -86,8 +84,7 @@ class ClosedLoopSafetyFunctionTest {
 
     boolean rejected = false;
     try {
-      ClosedLoopSafetyFunction
-          .builder("SIF-BAD", "invalid SIF", process, VotingPattern.TWO_OUT_OF_THREE, finalElements)
+      ClosedLoopSafetyFunction.builder("SIF-BAD", "invalid SIF", process, VotingPattern.TWO_OUT_OF_THREE, finalElements)
           .addChannel(highPressureChannel("PT-A", SafetyFunctionChannel.FaultMode.HEALTHY)).build();
     } catch (IllegalArgumentException expected) {
       rejected = true;
@@ -96,8 +93,7 @@ class ClosedLoopSafetyFunctionTest {
     assertFalse(finalElements.isActive());
   }
 
-  private static SafetyFunctionChannel highPressureChannel(String tag,
-      SafetyFunctionChannel.FaultMode faultMode) {
+  private static SafetyFunctionChannel highPressureChannel(String tag, SafetyFunctionChannel.FaultMode faultMode) {
     return SafetyFunctionChannel.highTrip(tag, "bara", 60.0, new SafetyFunctionChannel.SignalExtractor() {
       private static final long serialVersionUID = 1000L;
 

--- a/src/test/java/neqsim/process/safety/sif/ClosedLoopSafetyFunctionTest.java
+++ b/src/test/java/neqsim/process/safety/sif/ClosedLoopSafetyFunctionTest.java
@@ -45,8 +45,8 @@ class ClosedLoopSafetyFunctionTest {
             ESDLogic finalElements = new ESDLogic("ESD-101 final elements");
             finalElements.addAction(new TripValveAction(valve), 0.0);
             return ClosedLoopSafetyFunction
-                .builder("SIF-HP-101", "2oo3 high-pressure isolation", process,
-                    VotingPattern.TWO_OUT_OF_THREE, finalElements)
+                .builder("SIF-HP-101", "2oo3 high-pressure isolation", process, VotingPattern.TWO_OUT_OF_THREE,
+                    finalElements)
                 .addChannel(highPressureChannel("PT-101A", SafetyFunctionChannel.FaultMode.HEALTHY))
                 .addChannel(highPressureChannel("PT-101B", SafetyFunctionChannel.FaultMode.HEALTHY))
                 .addChannel(highPressureChannel("PT-101C", SafetyFunctionChannel.FaultMode.BYPASSED))

--- a/src/test/java/neqsim/process/safety/sif/ClosedLoopSafetyFunctionTest.java
+++ b/src/test/java/neqsim/process/safety/sif/ClosedLoopSafetyFunctionTest.java
@@ -1,0 +1,126 @@
+package neqsim.process.safety.sif;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Map;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.valve.ESDValve;
+import neqsim.process.logic.action.TripValveAction;
+import neqsim.process.logic.esd.ESDLogic;
+import neqsim.process.logic.voting.VotingPattern;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.safety.scenario.DynamicSafetyScenario;
+import neqsim.process.safety.scenario.DynamicSafetyScenarioResult;
+import neqsim.process.safety.scenario.DynamicSafetyScenarioRunner;
+import neqsim.process.safety.scenario.DynamicScenarioCriterion;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import org.junit.jupiter.api.Test;
+
+/** Verifies process detection, voting, logic delay, and physical final-element response in one loop. */
+class ClosedLoopSafetyFunctionTest {
+
+  @Test
+  void twoOutOfThreePressureVoteTripsCopiedEsdValveWithOneBypassedChannel() {
+    ProcessSystem base = process();
+    ESDValve designValve = (ESDValve) base.getUnit("ESDV-101");
+
+    DynamicSafetyScenario scenario = DynamicSafetyScenario.builder("SIF-HP-101", "HP inlet isolation")
+        .durationSeconds(6.0).timeStepSeconds(1.0).triggerTimeSeconds(0.0)
+        .initiatingEvent(new DynamicSafetyScenario.ProcessManipulator() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public void apply(ProcessSystem process) {
+            ((Stream) process.getUnit("FEED")).setPressure(70.0, "bara");
+          }
+        }).addLogic(new DynamicSafetyScenario.LogicFactory() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public ClosedLoopSafetyFunction create(ProcessSystem process) {
+            ESDValve valve = (ESDValve) process.getUnit("ESDV-101");
+            ESDLogic finalElements = new ESDLogic("ESD-101 final elements");
+            finalElements.addAction(new TripValveAction(valve), 0.0);
+            return ClosedLoopSafetyFunction
+                .builder("SIF-HP-101", "2oo3 high-pressure isolation", process,
+                    VotingPattern.TWO_OUT_OF_THREE, finalElements)
+                .addChannel(highPressureChannel("PT-101A", SafetyFunctionChannel.FaultMode.HEALTHY))
+                .addChannel(highPressureChannel("PT-101B", SafetyFunctionChannel.FaultMode.HEALTHY))
+                .addChannel(highPressureChannel("PT-101C", SafetyFunctionChannel.FaultMode.BYPASSED))
+                .logicSolverDelaySeconds(0.5).build();
+          }
+        }).addCriterion(DynamicScenarioCriterion
+            .builder("esdv-closed", "Inlet ESD valve closed", "%",
+                new DynamicScenarioCriterion.Extractor() {
+                  private static final long serialVersionUID = 1000L;
+
+                  @Override
+                  public double extract(ProcessSystem process) {
+                    return ((ESDValve) process.getUnit("ESDV-101")).getPercentValveOpening();
+                  }
+                })
+            .acceptanceRange(null, Double.valueOf(5.0)).deadlineSeconds(4.0).build())
+        .addEvidenceReference("SRS-SIF-HP-101").build();
+
+    DynamicSafetyScenarioResult result = DynamicSafetyScenarioRunner.run(base, scenario);
+
+    assertTrue(result.isPassed());
+    assertTrue(designValve.isEnergized(), "the design case must remain isolated from scenario execution");
+    assertEquals(100.0, designValve.getPercentValveOpening(), 1.0e-12);
+    Map<String, Object> evidence = result.getLogicEvidence().get("2oo3 high-pressure isolation");
+    assertNotNull(evidence);
+    assertEquals("2oo3", evidence.get("votingPattern"));
+    assertNotNull(evidence.get("firstVoteSeconds"));
+    assertNotNull(evidence.get("finalElementActuationSeconds"));
+    assertTrue(result.toJson().contains("closed_loop_sif_evidence.v1"));
+  }
+
+  @Test
+  void rejectsChannelCountThatDoesNotMatchVotingPattern() {
+    ProcessSystem process = process();
+    ESDLogic finalElements = new ESDLogic("final elements");
+    finalElements.addAction(new TripValveAction((ESDValve) process.getUnit("ESDV-101")), 0.0);
+
+    boolean rejected = false;
+    try {
+      ClosedLoopSafetyFunction
+          .builder("SIF-BAD", "invalid SIF", process, VotingPattern.TWO_OUT_OF_THREE, finalElements)
+          .addChannel(highPressureChannel("PT-A", SafetyFunctionChannel.FaultMode.HEALTHY)).build();
+    } catch (IllegalArgumentException expected) {
+      rejected = true;
+    }
+    assertTrue(rejected);
+    assertFalse(finalElements.isActive());
+  }
+
+  private static SafetyFunctionChannel highPressureChannel(String tag,
+      SafetyFunctionChannel.FaultMode faultMode) {
+    return SafetyFunctionChannel.highTrip(tag, "bara", 60.0, new SafetyFunctionChannel.SignalExtractor() {
+      private static final long serialVersionUID = 1000L;
+
+      @Override
+      public double extract(ProcessSystem process) {
+        return ((Stream) process.getUnit("FEED")).getPressure("bara");
+      }
+    }).responseDelaySeconds(1.0).faultMode(faultMode).build();
+  }
+
+  private static ProcessSystem process() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 50.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("FEED", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    ESDValve isolationValve = new ESDValve("ESDV-101", feed);
+    isolationValve.setCv(500.0);
+    isolationValve.setStrokeTime(2.0);
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(isolationValve);
+    process.run();
+    return process;
+  }
+}


### PR DESCRIPTION
## Summary
- add a process-bound `ClosedLoopSafetyFunction` that executes sensor response, explicit channel faults/bypasses, MooN voting, logic-solver delay, and existing ESD/HIPPS-compatible final-element logic
- extend dynamic safety scenario results with structured, machine-readable logic evidence
- verify a real 2oo3 high-pressure-to-ESD-valve path on an isolated process copy, including one bypassed channel and physical valve stroke
- document the workflow, evidence schema, fault modes, limitations, and IEC 61511 / ISO 10418 context
- update the NeqSim process-safety skill with the new handoff pattern

## Safety boundaries
The API does not infer SIL, approve an SRS, establish IPL independence, or mark an engineering package fit for construction. Evidence remains explicitly subject to engineering approval.

## Validation
- `python devtools/verify_skills_agents.py` — passed
- `git diff --check` — passed
- focused Maven compile/tests and Spotless are delegated to GitHub Actions because Maven Central is not reachable from the current workspace
- new test: `ClosedLoopSafetyFunctionTest`
- existing regression: `DynamicSafetyScenarioRunnerTest`

## Review guide
Start with `docs/process/safety/closed-loop-sif-verification.md`, then review:
1. `SafetyFunctionChannel` fault/delay semantics
2. `ClosedLoopSafetyFunction` voting and actuation sequence
3. `DynamicSafetyScenarioResult.logicEvidence`
4. copied-process isolation and ESD valve response test

## Stack
This is PR 1 of the SIF lifecycle verification series. Later PRs will build on this contract for reliability uncertainty/degraded modes, LOPA-to-SRS, integrated facility response, safety revalidation/benchmarks, and the complete offshore notebook.