### PR TITLE
Add integrated facility safety response handoff

### DIFF
--- a/.github/skills/neqsim-process-safety/SKILL.md
+++ b/.github/skills/neqsim-process-safety/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-process-safety
-version: "1.3.0"
-description: "Process safety methodology — barrier management, PSFs/SCEs, HAZOP guidewords, LOPA worksheets, SIL determination per IEC 61511, bow-tie analysis, risk-matrix scoring, TR3001 overpressure-protection studies, and trapped-liquid fire rupture screening. USE WHEN: a task requires barrier registers, hazard identification, layer-of-protection analysis, safety-integrity-level assignment for an SIF, overpressure relief-cause / governing-case studies, trapped liquid rupture/PFP demand, or quantitative risk evaluation. Anchors on neqsim.process.safety.barrier, neqsim.process.safety.risk, neqsim.process.safety.overpressure, and neqsim.process.safety.rupture classes."
+version: "1.4.0"
+description: "Process safety methodology — barrier management, PSFs/SCEs, HAZOP guidewords, LOPA worksheets, SIL determination per IEC 61511, integrated facility safety response, bow-tie analysis, risk-matrix scoring, TR3001 overpressure-protection studies, and trapped-liquid fire rupture screening. USE WHEN: a task requires barrier registers, hazard identification, layer-of-protection analysis, safety-integrity-level assignment for an SIF, integrated ESD/compressor-trip/blowdown/relief/flare evidence, overpressure relief-cause / governing-case studies, trapped liquid rupture/PFP demand, or quantitative risk evaluation. Anchors on neqsim.process.safety.barrier, neqsim.process.safety.risk, neqsim.process.safety.overpressure, and neqsim.process.safety.rupture classes."
 last_verified: "2026-07-18"
 requires:
   java_packages: [neqsim.process.safety.barrier, neqsim.process.safety.risk, neqsim.process.safety.overpressure, neqsim.process.safety.rupture, neqsim.process.safety.risk.sis.nog070, neqsim.process.safety.esd, neqsim.process.safety.api14c, neqsim.process.safety.compliance]
@@ -282,6 +282,25 @@ preserve the SIL claim or continue operation.
 
 Handoff the assessed mode back to the closed-loop scenario workflow to verify the physical safe state.
 See `docs/process/safety/sif-reliability-and-degraded-modes.md`.
+
+### Method 3f — Integrated facility safety response
+
+Use `FacilitySafetyResponseStudy` after the individual engines have executed when one review package
+must join closed-loop ESD/HIPPS evidence, compressor anti-surge trip demand and observed response,
+PSV/concurrency results, transient blowdown/flare results, and controlled process limits such as MDMT
+or hydrate margin. Supply the actual `DynamicSafetyScenarioResult` and
+`CoupledReliefBlowdownFlareResult`; the facility study embeds their maps and must not duplicate their
+physics.
+
+Capture compressor response with `CompressorTripResponse.capture(...)`. `AntiSurge.shouldTrip()` is
+the demand signal; separately record whether the trip was observed, its response time, allowable
+deadline, and evidence reference. Add each minimum or maximum with `ProcessSafetyConstraint` and a
+controlled source reference.
+
+Treat `isTechnicallyAcceptable()`, `isEvidenceComplete()`, and `isReadyForEngineeringReview()` as
+review gates, never approval. Inspect `getFindings()` and embedded engine results, then obtain the
+accountable process-safety, rotating-equipment, flare, piping, and mechanical approvals. See
+`docs/process/safety/integrated-facility-safety-response.md`.
 
 ## Method 4 — Bow-Tie Analysis
 

--- a/docs/process/safety/README.md
+++ b/docs/process/safety/README.md
@@ -14,6 +14,7 @@ Documentation for safety systems modeling in NeqSim.
 - [Closed-loop SIF Verification](closed-loop-sif-verification.md)
 - [SIF Reliability and Degraded Modes](sif-reliability-and-degraded-modes.md)
 - [HAZOP/LOPA to Draft SRS Handoff](hazop-lopa-srs-handoff.md)
+- [Integrated Facility Safety Response](integrated-facility-safety-response.md)
 - [Blowdown Systems](#blowdown-systems)
 - [Pressure Safety Valves](#pressure-safety-valves)
 - [Release and Gas Dispersion Scenarios](release-dispersion-scenarios.md)
@@ -36,6 +37,7 @@ NeqSim provides equipment and logic for modeling process safety systems:
 - NORSOK S-001 Clause 9 open-drain review from NeqSim-calculated liquid and hydraulic evidence
 - Automatic release source terms and gas dispersion screening from process streams
 - Formal CFD source-term JSON handoff cases for OpenFOAM, FLACS, KFX, PHAST, and Safeti workflows
+- Integrated ESD, compressor-trip, relief, blowdown, flare, MDMT, and hydrate-margin review handoff
 
 The release, dispersion, and CFD handoff workflow is intended for screening, case generation,
 and auditable source-term transfer. Final facility layout, regulatory QRA, and CFD conclusions
@@ -230,6 +232,7 @@ EmergencyShutdownTestResult report = EmergencyShutdownTestRunner.run(process, pl
 - [Closed-loop SIF Verification](closed-loop-sif-verification.md) - Sensor-to-vote-to-final-element transient verification with structured evidence
 - [SIF Reliability and Degraded Modes](sif-reliability-and-degraded-modes.md) - Seeded PFD/PFH uncertainty and governed bypass, maintenance, failure, and proof-test assessment
 - [HAZOP/LOPA to Draft SRS Handoff](hazop-lopa-srs-handoff.md) - IPL eligibility, LOPA arithmetic, and traceable unapproved SRS drafting
+- [Integrated Facility Safety Response](integrated-facility-safety-response.md) - Executed ESD, compressor-trip, relief, blowdown, flare, and process-limit evidence in one review package
 - [ESD Blowdown System](../../safety/ESD_BLOWDOWN_SYSTEM) - Detailed ESD guide
 - [HIPPS Summary](../../safety/HIPPS_SUMMARY) - HIPPS overview
 - [PSV Dynamic Sizing](../../safety/psv_dynamic_sizing_example) - PSV sizing example

--- a/docs/process/safety/integrated-facility-safety-response.md
+++ b/docs/process/safety/integrated-facility-safety-response.md
@@ -1,0 +1,101 @@
+---
+title: Integrated facility safety response
+description: Join executed ESD, compressor-trip, relief, blowdown, flare, and process-limit evidence without replacing the underlying NeqSim calculations.
+---
+
+# Integrated facility safety response
+
+`FacilitySafetyResponseStudy` creates one review package from safety calculations that have already
+been executed by their owning NeqSim engines. It is intended for scenarios where isolation,
+compressor protection, depressuring, relief, and flare response interact and a reviewer needs to
+see both the system-level verdict and the original structured evidence.
+
+This workflow supports verification handoff under the [IEC 61511 lifecycle](https://webstore.iec.ch/en/publication/24241).
+It does not establish IEC compliance, select a SIL, approve a scenario, or replace accountable
+process-safety, rotating-equipment, flare, piping, and mechanical engineering review.
+
+## Evidence sources
+
+| Response | Owning NeqSim result | Facility check |
+| --- | --- | --- |
+| Sensor, vote, ESD/HIPPS final element | `DynamicSafetyScenarioResult` | Every required dynamic criterion passed |
+| Repeated compressor surge | `AntiSurge` plus `CompressorTripResponse` | Required trip was observed within its controlled deadline |
+| PSV and concurrent steady loads | `CoupledReliefBlowdownFlareResult` | Relief sizing and accumulated-pressure checks are acceptable |
+| Blowdown and flare transient | Same coupled result | Header Mach and configured flare-capacity limits are acceptable |
+| MDMT, hydrate margin, pressure, temperature, or other limits | `ProcessSafetyConstraint` | Every required minimum or maximum is met |
+
+The facility package embeds `DynamicSafetyScenarioResult.toMap()` and
+`CoupledReliefBlowdownFlareResult.toMap()` unchanged. It does not copy their physics or recalculate
+their verdicts.
+
+## Example
+
+```java
+AntiSurge antiSurge = compressor.getAntiSurge();
+CompressorTripResponse trip = CompressorTripResponse.capture(
+    "K-101", antiSurge, tripObserved, 1.8, 3.0, "C&E-K-101-REV-4");
+
+FacilitySafetyResponseStudy study = FacilitySafetyResponseStudy.builder("FACILITY-ESD-001")
+    .scenarioSelectionReviewed(true)
+    .addEvidenceReference("HAZOP-TRAIN-A-REV-6")
+    .addEvidenceReference("SRS-ESD-001-REV-3")
+    .addProtectionResult("2oo3 inlet ESD", dynamicEsdResult)
+    .disposalResult(coupledReliefBlowdownFlareResult)
+    .addCompressorTripResponse(trip)
+    .addConstraint(ProcessSafetyConstraint.minimum(
+        "MDMT-V-101", "Vessel minimum metal temperature", "degC",
+        minimumCalculatedTemperatureC, -29.0, "V-101-DATASHEET-REV-2"))
+    .addConstraint(ProcessSafetyConstraint.minimum(
+        "HYDRATE-MARGIN", "Minimum hydrate margin", "degC",
+        minimumHydrateMarginC, 3.0, "FLOW-ASSURANCE-BASIS-REV-5"))
+    .build();
+
+boolean technical = study.isTechnicallyAcceptable();
+boolean complete = study.isEvidenceComplete();
+boolean readyForReview = study.isReadyForEngineeringReview();
+String reviewPackage = study.toJson();
+```
+
+`readyForReview` is deliberately not an approval flag. The JSON always carries
+`engineeringApprovalRequired: true` and `silTargetInferred: false`.
+
+## Compressor-trip evidence
+
+`CompressorTripResponse.capture(...)` snapshots the surge-cycle count, configured trip-cycle
+threshold, anti-surge valve position, trip demand, observed trip, response time, deadline, and
+controlled evidence reference. `AntiSurge.getMaxSurgeCyclesBeforeTrip()` exposes the configured
+threshold, and `setMaxSurgeCyclesBeforeTrip(...)` rejects zero or negative values so a model cannot
+silently demand a permanent trip.
+
+A trip-demand verdict is acceptable only when the trip was observed and its response time is no
+greater than the controlled deadline. When no repeated-surge trip is demanded, the response does
+not create a false failure, but its evidence reference remains part of the completeness gate.
+
+## Review sequence
+
+1. Approve the initiating events, credibility, concurrency, and controlled limit sources outside
+   the model.
+2. Run each closed-loop protection scenario on an isolated process copy.
+3. Run the coupled PSV, blowdown, header-hydraulics, and flare-capacity calculation.
+4. Capture anti-surge trip demand and the independently observed compressor state/response time.
+5. Add MDMT, hydrate-margin, pressure, temperature, and other project constraints with controlled
+   references.
+6. Review `getFindings()` and the embedded engine results; do not approve from the three aggregate
+   booleans alone.
+7. Record accountable discipline approvals in the project document-control system.
+
+## Required controls and limitations
+
+- A passed process model is evidence for the modeled case only; it is not proof that the HAZOP
+  scenario set is complete.
+- The compressor trip observation must come from the scenario equipment state, test system, or
+  another controlled source. `AntiSurge.shouldTrip()` states the demand, not the final-element proof.
+- Constraint limits must cite an approved datasheet, SRS, design basis, or other controlled source.
+- Relief and flare acceptance remains subject to the assumptions and limitations reported by the
+  coupled calculation.
+- SIL selection and reliability verification remain in the HAZOP/LOPA/SRS and
+  `SafetyFunctionReliabilityStudy` workflows.
+
+The implementation is covered by `FacilitySafetyResponseStudyTest`, which executes a 2oo3 ESD
+valve stroke, a repeated-surge trip demand, a PSV calculation, a transient blowdown/flare case, and
+MDMT/hydrate constraints before building the facility handoff.

--- a/src/main/java/neqsim/process/engineering/safety/CompressorTripResponse.java
+++ b/src/main/java/neqsim/process/engineering/safety/CompressorTripResponse.java
@@ -1,0 +1,104 @@
+package neqsim.process.engineering.safety;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import neqsim.process.equipment.compressor.AntiSurge;
+
+/** Snapshot linking anti-surge demand detection to observed compressor-trip evidence. */
+public final class CompressorTripResponse implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String compressorTag;
+  private final int surgeCycleCount;
+  private final int tripCycleThreshold;
+  private final double antiSurgeValvePosition;
+  private final boolean tripRequired;
+  private final boolean tripObserved;
+  private final Double tripResponseTimeSeconds;
+  private final double allowableResponseTimeSeconds;
+  private final String evidenceReference;
+
+  private CompressorTripResponse(String compressorTag, AntiSurge antiSurge, boolean tripObserved,
+      Double tripResponseTimeSeconds, double allowableResponseTimeSeconds, String evidenceReference) {
+    this.compressorTag = requireText(compressorTag, "compressorTag");
+    if (antiSurge == null) {
+      throw new IllegalArgumentException("antiSurge is required");
+    }
+    surgeCycleCount = antiSurge.getSurgeCycleCount();
+    tripCycleThreshold = antiSurge.getMaxSurgeCyclesBeforeTrip();
+    antiSurgeValvePosition = antiSurge.getValvePosition();
+    tripRequired = antiSurge.shouldTrip();
+    this.tripObserved = tripObserved;
+    if (tripResponseTimeSeconds != null
+        && (!Double.isFinite(tripResponseTimeSeconds.doubleValue()) || tripResponseTimeSeconds.doubleValue() < 0.0)) {
+      throw new IllegalArgumentException("tripResponseTimeSeconds must be finite and non-negative");
+    }
+    this.tripResponseTimeSeconds = tripResponseTimeSeconds;
+    if (!Double.isFinite(allowableResponseTimeSeconds) || allowableResponseTimeSeconds <= 0.0) {
+      throw new IllegalArgumentException("allowableResponseTimeSeconds must be finite and positive");
+    }
+    this.allowableResponseTimeSeconds = allowableResponseTimeSeconds;
+    this.evidenceReference = evidenceReference == null ? "" : evidenceReference.trim();
+  }
+
+  /**
+   * Captures the anti-surge state and the independently observed trip response.
+   *
+   * @param compressorTag controlled compressor tag
+   * @param antiSurge compressor anti-surge model after scenario execution
+   * @param tripObserved whether the compressor trip was observed
+   * @param tripResponseTimeSeconds observed time from trip demand to trip, or null when not observed
+   * @param allowableResponseTimeSeconds maximum response time from the controlled requirement
+   * @param evidenceReference controlled trip-logic or test evidence reference
+   * @return immutable response snapshot
+   */
+  public static CompressorTripResponse capture(String compressorTag, AntiSurge antiSurge, boolean tripObserved,
+      Double tripResponseTimeSeconds, double allowableResponseTimeSeconds, String evidenceReference) {
+    return new CompressorTripResponse(compressorTag, antiSurge, tripObserved, tripResponseTimeSeconds,
+        allowableResponseTimeSeconds, evidenceReference);
+  }
+
+  /** @return whether the observed response satisfies the trip demand and deadline */
+  public boolean isPassed() {
+    if (!tripRequired) {
+      return true;
+    }
+    return tripObserved && tripResponseTimeSeconds != null
+        && tripResponseTimeSeconds.doubleValue() <= allowableResponseTimeSeconds;
+  }
+
+  /** @return whether controlled evidence is present */
+  public boolean isEvidenceComplete() {
+    return !evidenceReference.isEmpty();
+  }
+
+  /** @return controlled compressor tag */
+  public String getCompressorTag() {
+    return compressorTag;
+  }
+
+  /** @return structured trip-response evidence */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("compressorTag", compressorTag);
+    result.put("surgeCycleCount", Integer.valueOf(surgeCycleCount));
+    result.put("tripCycleThreshold", Integer.valueOf(tripCycleThreshold));
+    result.put("antiSurgeValvePosition", Double.valueOf(antiSurgeValvePosition));
+    result.put("tripRequired", Boolean.valueOf(tripRequired));
+    result.put("tripObserved", Boolean.valueOf(tripObserved));
+    result.put("tripResponseTimeSeconds", tripResponseTimeSeconds);
+    result.put("allowableResponseTimeSeconds", Double.valueOf(allowableResponseTimeSeconds));
+    result.put("passed", Boolean.valueOf(isPassed()));
+    result.put("evidenceReference", evidenceReference);
+    return result;
+  }
+
+  private static String requireText(String value, String field) {
+    String normalized = value == null ? "" : value.trim();
+    if (normalized.isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return normalized;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/safety/FacilitySafetyResponseStudy.java
+++ b/src/main/java/neqsim/process/engineering/safety/FacilitySafetyResponseStudy.java
@@ -1,0 +1,275 @@
+package neqsim.process.engineering.safety;
+
+import com.google.gson.GsonBuilder;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.safety.depressurization.CoupledReliefBlowdownFlareResult;
+import neqsim.process.safety.scenario.DynamicSafetyScenarioResult;
+
+/**
+ * Review handoff joining dynamic protection, compressor-trip, disposal-system, and process-limit evidence.
+ *
+ * <p>
+ * This class does not replace any underlying simulation. It preserves the complete structured results from the dynamic
+ * safety-scenario and coupled relief/blowdown/flare calculations, then reports cross-system findings and evidence gaps
+ * for engineering review.
+ * </p>
+ */
+public final class FacilitySafetyResponseStudy implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Named result from an independently executed protection scenario. */
+  private static final class ProtectionResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final DynamicSafetyScenarioResult result;
+
+    private ProtectionResult(String name, DynamicSafetyScenarioResult result) {
+      this.name = requireText(name, "protection result name");
+      if (result == null) {
+        throw new IllegalArgumentException("dynamic protection result is required");
+      }
+      this.result = result;
+    }
+  }
+
+  private final String studyId;
+  private final boolean scenarioSelectionReviewed;
+  private final List<String> evidenceReferences;
+  private final List<ProtectionResult> protectionResults;
+  private final CoupledReliefBlowdownFlareResult disposalResult;
+  private final List<CompressorTripResponse> compressorTripResponses;
+  private final List<ProcessSafetyConstraint> constraints;
+
+  private FacilitySafetyResponseStudy(Builder builder) {
+    studyId = requireText(builder.studyId, "studyId");
+    scenarioSelectionReviewed = builder.scenarioSelectionReviewed;
+    evidenceReferences = Collections.unmodifiableList(new ArrayList<String>(builder.evidenceReferences));
+    protectionResults = Collections.unmodifiableList(new ArrayList<ProtectionResult>(builder.protectionResults));
+    disposalResult = builder.disposalResult;
+    compressorTripResponses = Collections
+        .unmodifiableList(new ArrayList<CompressorTripResponse>(builder.compressorTripResponses));
+    constraints = Collections.unmodifiableList(new ArrayList<ProcessSafetyConstraint>(builder.constraints));
+    if (protectionResults.isEmpty()) {
+      throw new IllegalStateException("at least one dynamic protection result is required");
+    }
+    if (disposalResult == null) {
+      throw new IllegalStateException("coupled relief/blowdown/flare result is required");
+    }
+    if (compressorTripResponses.isEmpty()) {
+      throw new IllegalStateException("at least one compressor-trip response is required");
+    }
+    if (constraints.isEmpty()) {
+      throw new IllegalStateException("at least one process safety constraint is required");
+    }
+  }
+
+  /** @param studyId controlled facility-response study identifier @return study builder */
+  public static Builder builder(String studyId) {
+    return new Builder(studyId);
+  }
+
+  /** @return true only when every modeled response and required process limit is acceptable */
+  public boolean isTechnicallyAcceptable() {
+    for (ProtectionResult protection : protectionResults) {
+      if (!protection.result.isPassed()) {
+        return false;
+      }
+    }
+    if (!disposalResult.isCapacityAcceptable()) {
+      return false;
+    }
+    for (CompressorTripResponse response : compressorTripResponses) {
+      if (!response.isPassed()) {
+        return false;
+      }
+    }
+    for (ProcessSafetyConstraint constraint : constraints) {
+      if (constraint.isRequired() && !constraint.isMet()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** @return true when scenario review and all controlled evidence references are present */
+  public boolean isEvidenceComplete() {
+    if (!scenarioSelectionReviewed || evidenceReferences.isEmpty()) {
+      return false;
+    }
+    for (CompressorTripResponse response : compressorTripResponses) {
+      if (!response.isEvidenceComplete()) {
+        return false;
+      }
+    }
+    for (ProcessSafetyConstraint constraint : constraints) {
+      if (!constraint.isEvidenceComplete()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Indicates that the package may enter accountable engineering review.
+   *
+   * @return technical and evidence gate; never an engineering approval
+   */
+  public boolean isReadyForEngineeringReview() {
+    return isTechnicallyAcceptable() && isEvidenceComplete();
+  }
+
+  /** @return explicit technical and evidence findings */
+  public List<String> getFindings() {
+    List<String> findings = new ArrayList<String>();
+    for (ProtectionResult protection : protectionResults) {
+      if (!protection.result.isPassed()) {
+        findings.add("Dynamic protection scenario failed: " + protection.name);
+      }
+    }
+    if (!disposalResult.isCapacityAcceptable()) {
+      findings.add("Coupled relief/blowdown/flare capacity is not acceptable");
+    }
+    for (CompressorTripResponse response : compressorTripResponses) {
+      if (!response.isPassed()) {
+        findings.add("Compressor-trip response failed: " + response.getCompressorTag());
+      }
+      if (!response.isEvidenceComplete()) {
+        findings.add("Compressor-trip evidence is missing: " + response.getCompressorTag());
+      }
+    }
+    for (ProcessSafetyConstraint constraint : constraints) {
+      if (constraint.isRequired() && !constraint.isMet()) {
+        findings.add("Required process safety constraint failed: " + constraint.getId());
+      }
+      if (!constraint.isEvidenceComplete()) {
+        findings.add("Constraint evidence is missing: " + constraint.getId());
+      }
+    }
+    if (!scenarioSelectionReviewed) {
+      findings.add("Scenario selection has not been reviewed");
+    }
+    if (evidenceReferences.isEmpty()) {
+      findings.add("Facility-level evidence references are missing");
+    }
+    findings.add("Accountable engineering approval remains required");
+    return Collections.unmodifiableList(findings);
+  }
+
+  /** @return structured review package retaining the underlying engine outputs */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", "facility_safety_response_study.v1");
+    result.put("studyId", studyId);
+    result.put("scenarioSelectionReviewed", Boolean.valueOf(scenarioSelectionReviewed));
+    result.put("evidenceReferences", new ArrayList<String>(evidenceReferences));
+    List<Map<String, Object>> protectionMaps = new ArrayList<Map<String, Object>>();
+    for (ProtectionResult protection : protectionResults) {
+      Map<String, Object> item = new LinkedHashMap<String, Object>();
+      item.put("name", protection.name);
+      item.put("result", protection.result.toMap());
+      protectionMaps.add(item);
+    }
+    result.put("dynamicProtectionResults", protectionMaps);
+    result.put("coupledReliefBlowdownFlareResult", disposalResult.toMap());
+    List<Map<String, Object>> compressorMaps = new ArrayList<Map<String, Object>>();
+    for (CompressorTripResponse response : compressorTripResponses) {
+      compressorMaps.add(response.toMap());
+    }
+    result.put("compressorTripResponses", compressorMaps);
+    List<Map<String, Object>> constraintMaps = new ArrayList<Map<String, Object>>();
+    for (ProcessSafetyConstraint constraint : constraints) {
+      constraintMaps.add(constraint.toMap());
+    }
+    result.put("processSafetyConstraints", constraintMaps);
+    result.put("technicallyAcceptable", Boolean.valueOf(isTechnicallyAcceptable()));
+    result.put("evidenceComplete", Boolean.valueOf(isEvidenceComplete()));
+    result.put("readyForEngineeringReview", Boolean.valueOf(isReadyForEngineeringReview()));
+    result.put("findings", new ArrayList<String>(getFindings()));
+    result.put("silTargetInferred", Boolean.FALSE);
+    result.put("engineeringApprovalRequired", Boolean.TRUE);
+    return result;
+  }
+
+  /** @return pretty-printed JSON review package */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create().toJson(toMap());
+  }
+
+  /** Builder for a facility safety-response review package. */
+  public static final class Builder {
+    private final String studyId;
+    private boolean scenarioSelectionReviewed;
+    private final List<String> evidenceReferences = new ArrayList<String>();
+    private final List<ProtectionResult> protectionResults = new ArrayList<ProtectionResult>();
+    private CoupledReliefBlowdownFlareResult disposalResult;
+    private final List<CompressorTripResponse> compressorTripResponses = new ArrayList<CompressorTripResponse>();
+    private final List<ProcessSafetyConstraint> constraints = new ArrayList<ProcessSafetyConstraint>();
+
+    private Builder(String studyId) {
+      this.studyId = studyId;
+    }
+
+    /** @param value true after accountable scenario-selection review @return this builder */
+    public Builder scenarioSelectionReviewed(boolean value) {
+      scenarioSelectionReviewed = value;
+      return this;
+    }
+
+    /** @param value controlled facility-level source reference @return this builder */
+    public Builder addEvidenceReference(String value) {
+      String normalized = value == null ? "" : value.trim();
+      if (!normalized.isEmpty() && !evidenceReferences.contains(normalized)) {
+        evidenceReferences.add(normalized);
+      }
+      return this;
+    }
+
+    /** @param name scenario name @param value executed dynamic result @return this builder */
+    public Builder addProtectionResult(String name, DynamicSafetyScenarioResult value) {
+      protectionResults.add(new ProtectionResult(name, value));
+      return this;
+    }
+
+    /** @param value executed coupled relief/blowdown/flare result @return this builder */
+    public Builder disposalResult(CoupledReliefBlowdownFlareResult value) {
+      disposalResult = value;
+      return this;
+    }
+
+    /** @param value captured compressor-trip response @return this builder */
+    public Builder addCompressorTripResponse(CompressorTripResponse value) {
+      if (value == null) {
+        throw new IllegalArgumentException("compressor-trip response is required");
+      }
+      compressorTripResponses.add(value);
+      return this;
+    }
+
+    /** @param value controlled process-response constraint @return this builder */
+    public Builder addConstraint(ProcessSafetyConstraint value) {
+      if (value == null) {
+        throw new IllegalArgumentException("process safety constraint is required");
+      }
+      constraints.add(value);
+      return this;
+    }
+
+    /** @return validated facility response study */
+    public FacilitySafetyResponseStudy build() {
+      return new FacilitySafetyResponseStudy(this);
+    }
+  }
+
+  private static String requireText(String value, String field) {
+    String normalized = value == null ? "" : value.trim();
+    if (normalized.isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return normalized;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/safety/ProcessSafetyConstraint.java
+++ b/src/main/java/neqsim/process/engineering/safety/ProcessSafetyConstraint.java
@@ -1,0 +1,130 @@
+package neqsim.process.engineering.safety;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Measured process response checked against a controlled safety-study limit. */
+public final class ProcessSafetyConstraint implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Direction in which the measured value must remain acceptable. */
+  public enum LimitType {
+    /** Measured value must not exceed the limit. */
+    MAXIMUM,
+    /** Measured value must not fall below the limit. */
+    MINIMUM
+  }
+
+  private final String id;
+  private final String name;
+  private final String unit;
+  private final LimitType limitType;
+  private final double measuredValue;
+  private final double limitValue;
+  private final boolean required;
+  private final String evidenceReference;
+
+  private ProcessSafetyConstraint(String id, String name, String unit, LimitType limitType, double measuredValue,
+      double limitValue, boolean required, String evidenceReference) {
+    this.id = requireText(id, "id");
+    this.name = requireText(name, "name");
+    this.unit = requireText(unit, "unit");
+    if (limitType == null) {
+      throw new IllegalArgumentException("limitType is required");
+    }
+    this.limitType = limitType;
+    this.measuredValue = finite(measuredValue, "measuredValue");
+    this.limitValue = finite(limitValue, "limitValue");
+    this.required = required;
+    this.evidenceReference = normalize(evidenceReference);
+  }
+
+  /**
+   * Creates a required maximum-value constraint.
+   *
+   * @param id controlled constraint identifier
+   * @param name descriptive constraint name
+   * @param unit engineering unit
+   * @param measuredValue calculated or measured value
+   * @param maximumValue largest acceptable value
+   * @param evidenceReference controlled source for the value and limit
+   * @return immutable constraint
+   */
+  public static ProcessSafetyConstraint maximum(String id, String name, String unit, double measuredValue,
+      double maximumValue, String evidenceReference) {
+    return new ProcessSafetyConstraint(id, name, unit, LimitType.MAXIMUM, measuredValue, maximumValue, true,
+        evidenceReference);
+  }
+
+  /**
+   * Creates a required minimum-value constraint.
+   *
+   * @param id controlled constraint identifier
+   * @param name descriptive constraint name
+   * @param unit engineering unit
+   * @param measuredValue calculated or measured value
+   * @param minimumValue smallest acceptable value
+   * @param evidenceReference controlled source for the value and limit
+   * @return immutable constraint
+   */
+  public static ProcessSafetyConstraint minimum(String id, String name, String unit, double measuredValue,
+      double minimumValue, String evidenceReference) {
+    return new ProcessSafetyConstraint(id, name, unit, LimitType.MINIMUM, measuredValue, minimumValue, true,
+        evidenceReference);
+  }
+
+  /** @return whether the measured value is on the acceptable side of the limit */
+  public boolean isMet() {
+    return limitType == LimitType.MAXIMUM ? measuredValue <= limitValue : measuredValue >= limitValue;
+  }
+
+  /** @return whether the constraint has a controlled evidence reference */
+  public boolean isEvidenceComplete() {
+    return !evidenceReference.isEmpty();
+  }
+
+  /** @return whether this constraint is mandatory for the technical verdict */
+  public boolean isRequired() {
+    return required;
+  }
+
+  /** @return stable constraint identifier */
+  public String getId() {
+    return id;
+  }
+
+  /** @return structured constraint evidence */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("id", id);
+    result.put("name", name);
+    result.put("unit", unit);
+    result.put("limitType", limitType.name());
+    result.put("measuredValue", Double.valueOf(measuredValue));
+    result.put("limitValue", Double.valueOf(limitValue));
+    result.put("required", Boolean.valueOf(required));
+    result.put("met", Boolean.valueOf(isMet()));
+    result.put("evidenceReference", evidenceReference);
+    return result;
+  }
+
+  private static double finite(double value, String field) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(field + " must be finite");
+    }
+    return value;
+  }
+
+  private static String requireText(String value, String field) {
+    String normalized = normalize(value);
+    if (normalized.isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return normalized;
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/AntiSurge.java
+++ b/src/main/java/neqsim/process/equipment/compressor/AntiSurge.java
@@ -499,6 +499,15 @@ public class AntiSurge implements java.io.Serializable {
   }
 
   /**
+   * Get the configured number of surge cycles that demands a compressor trip.
+   *
+   * @return maximum allowed surge cycles before trip
+   */
+  public int getMaxSurgeCyclesBeforeTrip() {
+    return maxSurgeCyclesBeforeTrip;
+  }
+
+  /**
    * Reset the surge cycle counter.
    */
   public void resetSurgeCycleCount() {
@@ -568,6 +577,9 @@ public class AntiSurge implements java.io.Serializable {
    * @param maxCycles maximum cycles
    */
   public void setMaxSurgeCyclesBeforeTrip(int maxCycles) {
+    if (maxCycles <= 0) {
+      throw new IllegalArgumentException("maxCycles must be positive");
+    }
     this.maxSurgeCyclesBeforeTrip = maxCycles;
   }
 

--- a/src/test/java/neqsim/process/engineering/safety/FacilitySafetyResponseStudyTest.java
+++ b/src/test/java/neqsim/process/engineering/safety/FacilitySafetyResponseStudyTest.java
@@ -1,0 +1,178 @@
+package neqsim.process.engineering.safety;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import neqsim.process.engineering.calculation.EngineeringCalculationContext;
+import neqsim.process.engineering.calculation.EngineeringCalculationResult;
+import neqsim.process.equipment.compressor.AntiSurge;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.valve.ESDValve;
+import neqsim.process.logic.action.TripValveAction;
+import neqsim.process.logic.esd.ESDLogic;
+import neqsim.process.logic.voting.VotingPattern;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.safety.depressurization.CoupledReliefBlowdownFlareCalculation;
+import neqsim.process.safety.depressurization.CoupledReliefBlowdownFlareInput;
+import neqsim.process.safety.depressurization.CoupledReliefBlowdownFlareResult;
+import neqsim.process.safety.depressurization.DynamicBlowdownFlareStudyDataSource;
+import neqsim.process.safety.depressurization.DynamicBlowdownFlareStudyDataSource.BlowdownSource;
+import neqsim.process.safety.depressurization.DynamicBlowdownFlareStudyRunner;
+import neqsim.process.safety.overpressure.BlockedOutletRelief;
+import neqsim.process.safety.overpressure.OverpressureProtectionStudy;
+import neqsim.process.safety.overpressure.ProtectedItem;
+import neqsim.process.safety.overpressure.ReliefScenario;
+import neqsim.process.safety.scenario.DynamicSafetyScenario;
+import neqsim.process.safety.scenario.DynamicSafetyScenarioResult;
+import neqsim.process.safety.scenario.DynamicSafetyScenarioRunner;
+import neqsim.process.safety.scenario.DynamicScenarioCriterion;
+import neqsim.process.safety.sif.ClosedLoopSafetyFunction;
+import neqsim.process.safety.sif.SafetyFunctionChannel;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import org.junit.jupiter.api.Test;
+
+/** Verifies the cross-system facility response handoff using executed NeqSim calculations. */
+class FacilitySafetyResponseStudyTest {
+
+  @Test
+  void joinsEsdCompressorTripBlowdownReliefFlareAndProcessConstraints() {
+    DynamicSafetyScenarioResult esdResult = runEsdScenario();
+    CoupledReliefBlowdownFlareResult disposalResult = runDisposalStudy();
+    AntiSurge antiSurge = antiSurgeWithTripDemand();
+    CompressorTripResponse compressorTrip = CompressorTripResponse.capture("K-101", antiSurge, true,
+        Double.valueOf(1.8), 3.0, "C&E-K-101-REV-4");
+
+    FacilitySafetyResponseStudy result = FacilitySafetyResponseStudy.builder("FACILITY-ESD-001")
+        .scenarioSelectionReviewed(true).addEvidenceReference("HAZOP-TRAIN-A-REV-6")
+        .addEvidenceReference("SRS-ESD-001-REV-3").addProtectionResult("2oo3 inlet ESD", esdResult)
+        .disposalResult(disposalResult).addCompressorTripResponse(compressorTrip)
+        .addConstraint(ProcessSafetyConstraint.minimum("MDMT-V-101", "Vessel minimum metal temperature", "degC", -20.0,
+            -29.0, "V-101-DATASHEET-REV-2"))
+        .addConstraint(ProcessSafetyConstraint.minimum("HYDRATE-MARGIN", "Minimum hydrate margin", "degC", 5.0, 3.0,
+            "FLOW-ASSURANCE-BASIS-REV-5"))
+        .build();
+
+    assertTrue(esdResult.isPassed());
+    assertTrue(disposalResult.isCapacityAcceptable());
+    assertTrue(result.isTechnicallyAcceptable());
+    assertTrue(result.isEvidenceComplete());
+    assertTrue(result.isReadyForEngineeringReview());
+    assertTrue(result.toJson().contains("dynamic_safety_scenario_result.v2"));
+    assertTrue(result.toJson().contains("coupled_relief_blowdown_flare_result.v1"));
+    assertTrue(result.toJson().contains("engineeringApprovalRequired"));
+    assertTrue(result.getFindings().contains("Accountable engineering approval remains required"));
+  }
+
+  @Test
+  void antiSurgeTripThresholdMustBePositive() {
+    AntiSurge antiSurge = new AntiSurge();
+
+    assertThrows(IllegalArgumentException.class, () -> antiSurge.setMaxSurgeCyclesBeforeTrip(0));
+    assertEquals(3, antiSurge.getMaxSurgeCyclesBeforeTrip());
+  }
+
+  private DynamicSafetyScenarioResult runEsdScenario() {
+    ProcessSystem base = esdProcess();
+    DynamicSafetyScenario scenario = DynamicSafetyScenario.builder("SIF-HP-101", "HP inlet isolation")
+        .durationSeconds(6.0).timeStepSeconds(1.0).triggerTimeSeconds(0.0)
+        .initiatingEvent(new DynamicSafetyScenario.ProcessManipulator() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public void apply(ProcessSystem process) {
+            ((Stream) process.getUnit("FEED")).setPressure(70.0, "bara");
+          }
+        }).addLogic(new DynamicSafetyScenario.LogicFactory() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public ClosedLoopSafetyFunction create(ProcessSystem process) {
+            ESDValve valve = (ESDValve) process.getUnit("ESDV-101");
+            ESDLogic finalElements = new ESDLogic("ESD-101 final elements");
+            finalElements.addAction(new TripValveAction(valve), 0.0);
+            return ClosedLoopSafetyFunction
+                .builder("SIF-HP-101", "2oo3 high-pressure isolation", process, VotingPattern.TWO_OUT_OF_THREE,
+                    finalElements)
+                .addChannel(highPressureChannel("PT-101A", SafetyFunctionChannel.FaultMode.HEALTHY))
+                .addChannel(highPressureChannel("PT-101B", SafetyFunctionChannel.FaultMode.HEALTHY))
+                .addChannel(highPressureChannel("PT-101C", SafetyFunctionChannel.FaultMode.BYPASSED))
+                .logicSolverDelaySeconds(0.5).build();
+          }
+        }).addCriterion(DynamicScenarioCriterion
+            .builder("esdv-closed", "Inlet ESD valve closed", "%", new DynamicScenarioCriterion.Extractor() {
+              private static final long serialVersionUID = 1000L;
+
+              @Override
+              public double extract(ProcessSystem process) {
+                return ((ESDValve) process.getUnit("ESDV-101")).getPercentValveOpening();
+              }
+            }).acceptanceRange(null, Double.valueOf(5.0)).deadlineSeconds(4.0).build())
+        .addEvidenceReference("SRS-SIF-HP-101").build();
+    return DynamicSafetyScenarioRunner.run(base, scenario);
+  }
+
+  private CoupledReliefBlowdownFlareResult runDisposalStudy() {
+    SystemInterface fluid = fluid(313.15, 60.0);
+    ReliefScenario scenario = new BlockedOutletRelief().setName("Blocked outlet").setInflowRateKgPerS(2.0)
+        .setReliefPressureBara(75.0).setReliefTemperatureC(30.0).setFluid(fluid).calculate();
+    OverpressureProtectionStudy relief = new OverpressureProtectionStudy(
+        new ProtectedItem("V-101", 80.0).setReliefSetPressureBara(75.0).setBackPressureBara(1.5)).addScenario(scenario);
+    BlowdownSource source = BlowdownSource.builder("V-101", fluid).equipmentTag("V-101").vesselVolumeM3(2.0)
+        .orificeDiameterM(0.012).dischargeCoefficient(0.72).backPressureBara(1.5).stopPressureBara(1.5)
+        .api521FireCase(8.0, true, true).psvBasis(75.0, 0.21, false, false).build();
+    DynamicBlowdownFlareStudyDataSource dynamic = DynamicBlowdownFlareStudyDataSource.builder("dynamic")
+        .addSource(source).flareHeader(0.30, 1.5, 288.15, 0.020, 1.30).flareGeometry(0.5, 35.0, 0.20)
+        .flareDesignCapacity(5.0e8, 500.0, 30000.0).build();
+    CoupledReliefBlowdownFlareInput input = CoupledReliefBlowdownFlareInput.builder("coupled-1")
+        .addReliefStudy(relief, "FIRE-ZONE-1").dynamicStudy(dynamic).scenarioSelectionReviewed(true)
+        .addEvidenceReference("RELIEF-BASIS-REV-4").build();
+    CoupledReliefBlowdownFlareCalculation calculation = new CoupledReliefBlowdownFlareCalculation(
+        DynamicBlowdownFlareStudyRunner.builder().timeStepSeconds(5.0).maxTimeSeconds(60.0).build());
+    EngineeringCalculationResult<CoupledReliefBlowdownFlareResult> calculationResult = calculation.calculate(input,
+        EngineeringCalculationContext.builder().designCaseId("FIRE").build());
+    return calculationResult.getValue();
+  }
+
+  private AntiSurge antiSurgeWithTripDemand() {
+    AntiSurge antiSurge = new AntiSurge();
+    antiSurge.setMaxSurgeCyclesBeforeTrip(2);
+    antiSurge.setSurge(true);
+    antiSurge.setSurge(false);
+    antiSurge.setSurge(true);
+    assertTrue(antiSurge.shouldTrip());
+    return antiSurge;
+  }
+
+  private SafetyFunctionChannel highPressureChannel(String tag, SafetyFunctionChannel.FaultMode faultMode) {
+    return SafetyFunctionChannel.highTrip(tag, "bara", 60.0, new SafetyFunctionChannel.SignalExtractor() {
+      private static final long serialVersionUID = 1000L;
+
+      @Override
+      public double extract(ProcessSystem process) {
+        return ((Stream) process.getUnit("FEED")).getPressure("bara");
+      }
+    }).responseDelaySeconds(1.0).faultMode(faultMode).build();
+  }
+
+  private ProcessSystem esdProcess() {
+    Stream feed = new Stream("FEED", fluid(300.0, 50.0));
+    feed.setFlowRate(1000.0, "kg/hr");
+    ESDValve isolationValve = new ESDValve("ESDV-101", feed);
+    isolationValve.setCv(500.0);
+    isolationValve.setStrokeTime(2.0);
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(isolationValve);
+    process.run();
+    return process;
+  }
+
+  private SystemInterface fluid(double temperatureK, double pressureBara) {
+    SystemInterface fluid = new SystemSrkEos(temperatureK, pressureBara);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+}


### PR DESCRIPTION
## Summary
- join executed closed-loop ESD/HIPPS results, compressor anti-surge trip evidence, and the existing coupled PSV/blowdown/flare result in one review package
- add controlled minimum/maximum process constraints for MDMT, hydrate margin, pressure, temperature, and similar limits
- expose and validate the anti-surge trip-cycle threshold
- document the evidence ownership, review sequence, limitations, and engineering-approval boundary
- extend the process-safety skill to route integrated facility-response work consistently

## Safety boundary
This is an evidence and review handoff. It does not select or infer SIL, establish IEC 61511 compliance, approve scenario credibility, or replace discipline engineering approval. The exported result always states that engineering approval is required.

## Validation
- process-safety skill lint: passed
- repository Spotless formatting: passed
- focused `FacilitySafetyResponseStudyTest`: passed in GitHub Actions
- temporary validation workflow removed from the final diff
- full repository and notebook checks rerun after stack normalization

## Stack
PRs #2486, #2487, and #2488 are merged. This PR now targets `master` as one clean commit and contains only the integrated facility-response change set.