### PR TITLE
Add native DEXPI 2.0 Process conformance

### DIFF
--- a/.github/skills/neqsim-process-modeling/SKILL.md
+++ b/.github/skills/neqsim-process-modeling/SKILL.md
@@ -132,6 +132,9 @@ the governed enterprise checklist and readiness gates use
 - Use `EngineeringNumericalHealthAnalyzer` to capture convergence, mass/energy closure, residual, and sensitivity
   evidence for every process state that governs an engineering decision. Required but absent evidence must remain
   `INCOMPLETE`; never replace unavailable closure data with zero.
+- Use `Dexpi20XmlWriter` for native Plant/P&ID exchange and `Dexpi20ProcessModelWriter` for native Process/PFD/BFD
+  exchange. A Proteus document with a changed header is not native DEXPI 2.0. Preserve the conformance report and still
+  require a named-CAE round-trip before project qualification.
 - Compressor, pump, heat exchanger, separator, and pipeline cases identify applicable
   standards through `neqsim-standards-lookup`.
 

--- a/docs/integration/dexpi-20-conformance.md
+++ b/docs/integration/dexpi-20-conformance.md
@@ -1,0 +1,99 @@
+---
+title: DEXPI 2.0 native exchange and conformance
+description: Official native DEXPI XML Plant and Process model export, deterministic validation, and auditable conformance evidence.
+---
+
+# DEXPI 2.0 native exchange and conformance
+
+DEXPI 2.0.0 was released on 10 October 2025. It combines the Plant/P&ID and Process/PFD/BFD
+information models and introduces DEXPI XML as their common serialization. Native DEXPI XML has a
+`Model` root containing `Import`, `Object`, `Components`, `Data`, and `References` elements; it is
+not Proteus XML with a different namespace.
+
+NeqSim provides two fail-closed native exporters:
+
+| API | Official model imports | Exchange purpose |
+|---|---|---|
+| `Dexpi20XmlWriter` | Core 2.0.0 + Plant 2.0.0 | P&ID plant items, piping, instruments, safeguards, boundaries, and diagram representations |
+| `Dexpi20ProcessModelWriter` | Core 2.0.0 + Process 2.0.0 | PFD/BFD process steps, material ports, streams, and physical state quantities |
+
+The official DEXPI XML V2.0.0 XSD is bundled under CC BY 4.0 for deterministic offline validation.
+`Dexpi20ConformanceAssessment` verifies its reviewed SHA-256 fingerprint before using the result as
+conformance evidence.
+
+## Process-model export
+
+```java
+File exchange = new File("gas-processing-pfd.dexpi.xml");
+Dexpi20ConformanceAssessment.Report report =
+    Dexpi20ProcessModelWriter.writeAndAssess(process, exchange);
+if (!report.isSchemaAndProfileConformant()) {
+  throw new IllegalStateException(report.getErrors().toString());
+}
+Files.write(Paths.get("gas-processing-pfd.conformance.json"),
+    report.toJson().getBytes(StandardCharsets.UTF_8));
+```
+
+Each process connection has a dedicated source and target `MaterialPort`. The ports and
+`Process.Stream` carry reciprocal references, stable identifiers, nominal directions, and explicit
+mass-flow, absolute-pressure, and temperature quantities when finite simulation values are
+available. The exporter uses kilogram/hour, bar absolute, and degree Celsius references from the
+official Core physical-quantity model.
+
+Reviewed NeqSim-to-DEXPI Process mappings are:
+
+| NeqSim equipment | DEXPI 2.0 Process type |
+|---|---|
+| feed or boundary `Stream` | `Source` |
+| unconsumed product outlet | `Sink` |
+| compressor | `Compressing` |
+| pump | `Pumping` |
+| separator | `SeparatingByGravity` |
+| distillation column | `Distilling` |
+| cooler | `Cooling` |
+| heat exchanger | `ExchangingThermalEnergy` |
+| heater | `HeatingInFurnace` |
+| tank | `StoringFluids` |
+| control valve | `RegulatingFlow` |
+| mixer | `MixingSimple` |
+| splitter | `SplittingMaterial` |
+| expander | `TransportingFluids` |
+
+An unmapped equipment class aborts export with its Java type and tag. The exporter never substitutes
+an unreviewed generic DEXPI type merely to make a file validate.
+
+## Conformance layers
+
+`Dexpi20ConformanceAssessment` records separate decisions for:
+
+1. the bundled official V2.0.0 schema fingerprint;
+2. DEXPI XML schema validation;
+3. exact versioned Core plus Plant or Process imports;
+4. unique identities and resolvable references;
+5. NeqSim-supported Plant or Process semantic-profile rules; and
+6. the SHA-256 digest and object/reference counts of the assessed file.
+
+Only a report with all five technical gates passing returns
+`isSchemaAndProfileConformant() == true`. A Plant file assessed as a Process profile, a version-mixed
+model import, dangling reference, missing required port/stream relationship, or unknown generated
+profile type fails explicitly.
+
+The report deliberately states `NOT_A_DEXPI_EV_CERTIFICATE` and
+`namedCaeRoundTripStatus=QUALIFICATION_REQUIRED`. Schema and supported-profile conformance do not
+replace import/export/reimport testing in the exact CAE product and version used by a project.
+Record that separate evidence through `DexpiToolQualificationRunner` and
+`DexpiToolQualificationEvidence`.
+
+## Release and review controls
+
+- Pin exchange evidence to DEXPI 2.0.0 model URIs and the file digest; never silently reinterpret a
+  later DEXPI model release as 2.0.0.
+- Store the conformance JSON, source model revision, generated XML, named-tool round-trip, and
+  accountable semantic-difference review together.
+- Compare the committed native golden fixture and semantic inventory when modifying type mappings,
+  topology, units, or serialization order.
+- Treat graphics, project standard-library restrictions, vendor extensions, and CAE certification as
+  separate qualification scopes.
+
+Official references: [DEXPI Specification 2.0.0](https://dexpi.gitlab.io/-/Specification/-/jobs/11676485644/artifacts/src/.build/html/html/index.html)
+and the [DEXPI specification source](https://gitlab.com/dexpi/Specification), licensed CC BY 4.0.

--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -218,40 +218,29 @@ For consumers that require *unqualified* tag look-ups (such as pyDEXPI), use
 `writeForPyDexpi` / `DexpiDiagramBridge.exportForPyDexpi`, which emit the same content with the
 default `xmlns` omitted (see *pyDEXPI-friendly export* above).
 
-### Schema version selection (Proteus 4.1.1 vs DEXPI 2.0)
+### Proteus compatibility and native DEXPI 2.0
 
-By default the writer targets the **Proteus 4.1.1** schema — the serialization that pyDEXPI and the
-broader DEXPI tooling ecosystem currently read. This is the stable, fully supported output and the
-behavior of `write(...)`, `writeForPyDexpi(...)`, and `writeSheets(...)` is unchanged.
+`DexpiXmlWriter.write(...)`, `writeForPyDexpi(...)`, and `writeSheets(...)` retain the established
+Proteus 4.1.1 path for compatible tools. Do not obtain native DEXPI 2.0 by changing only a Proteus
+header: DEXPI 2.0 uses a different object/property/reference serialization with a `Model` root.
 
-The writer also exposes an experimental **DEXPI 2.0** branch. DEXPI 2.0 (release V2.0.0, October
-2025) unifies the P&ID and Process specifications under a new UML-based Information Model and
-introduces a standardized "DEXPI XML" serialization that replaces the Proteus schema. NeqSim's 2.0
-mode currently re-declares the document header (root namespace, `xsi:schemaLocation`, and
-`PlantInformation/@SchemaVersion="2.0"`) over the existing backward-compatible plant-model body. The
-full DEXPI 2.0 Information Model (PFD/BFD constructs, the UML-derived element model) is future work.
+Use the native writers for the official DEXPI 2.0 information models:
 
 ```java
-// Default: Proteus 4.1.1 (SchemaVersion="4.1.1")
-DexpiXmlWriter.write(process, new File("plant.xml"));
+// Plant model: P&ID equipment, piping, instrumentation, safeguards, and diagrams
+Dexpi20ConformanceAssessment.Report plantReport =
+    Dexpi20XmlWriter.writeAndAssess(process, new File("plant.dexpi.xml"));
 
-// Explicit DEXPI 2.0 header (SchemaVersion="2.0")
-DexpiXmlWriter.writeDexpi20(process, new File("plant.dexpi20.xml"));
-
-// Or toggle the thread-local schema version directly
-DexpiXmlWriter.setSchemaVersion(DexpiXmlWriter.DexpiSchemaVersion.DEXPI_2_0);
-try {
-  DexpiXmlWriter.write(process, new File("plant.dexpi20.xml"));
-} finally {
-  DexpiXmlWriter.setSchemaVersion(DexpiXmlWriter.DexpiSchemaVersion.PROTEUS_4_1_1);
-}
+// Process model: PFD/BFD process steps, material ports, streams, and state quantities
+Dexpi20ConformanceAssessment.Report processReport =
+    Dexpi20ProcessModelWriter.writeAndAssess(process, new File("process.dexpi.xml"));
 ```
 
-The `DexpiSchemaVersion` enum carries each version's `SchemaVersion` attribute, root namespace URI,
-and `schemaLocation`. The `DEXPI_2_0` namespace (`http://www.dexpi.org/dexpi`) and XSD location are
-**placeholders** pending the finalized public DEXPI 2.0 schema; verify them against the official
-release before relying on the 2.0 output for downstream validation. `writeDexpi20(...)` saves and
-restores the previous schema version, so the default 4.1.1 output is never affected.
+Both writers emit the official DEXPI XML structure, import the versioned `Core`, `Plant`, or
+`Process` model at `https://data.dexpi.org/models/2.0.0/`, validate against the bundled official
+V2.0.0 XSD, and run reference and supported-profile semantic checks. See
+[DEXPI 2.0 native exchange and conformance](dexpi-20-conformance.md) for exact scope, mappings, and
+qualification requirements.
 
 ### Line data and NORSOK line numbers
 

--- a/docs/integration/process-to-engineering-simulator.md
+++ b/docs/integration/process-to-engineering-simulator.md
@@ -9,6 +9,9 @@ See also [Numerical health and engineering closure](numerical-health-and-enginee
 convergence, mass/energy closure, residual, and sensitivity evidence that can be embedded in design-case and
 production-readiness reports.
 
+Native [DEXPI 2.0 Plant and Process exchange](dexpi-20-conformance.md) provides separate P&ID and PFD/BFD information
+models with offline official-schema validation and auditable conformance reports.
+
 The process-to-engineering simulator closes the loop between process physics and preliminary engineering design. It
 runs every controlled process case on isolated copies, sizes configured engineering objects, applies selected design
 variables to a separate working flowsheet, reruns the cases, and stops only when no design variable changes and all

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ConformanceAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ConformanceAssessment.java
@@ -1,0 +1,211 @@
+package neqsim.process.processmodel.dexpi;
+
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/** Produces an auditable DEXPI 2.0 schema, model-import, and semantic-profile conformance report. */
+public final class Dexpi20ConformanceAssessment {
+  public static final String SPECIFICATION_VERSION = "2.0.0";
+  public static final String SPECIFICATION_RELEASE_DATE = "2025-10-10";
+  public static final String OFFICIAL_SCHEMA_SHA256 = "0bd6568b7c52fd59ac4ef6d8547ab2b2aa890c009a3a1bfbc5d7cc18c53b36e6";
+  private static final String SCHEMA_RESOURCE = "/dexpi/2.0/DEXPI_XML_Schema.xsd";
+
+  private Dexpi20ConformanceAssessment() {
+  }
+
+  /** Supported official DEXPI 2.0 information-model exchange profiles. */
+  public enum Profile {
+    PLANT_P_ID("Plant", "https://data.dexpi.org/models/2.0.0/Plant.xml"),
+    PROCESS_PFD_BFD("Process", "https://data.dexpi.org/models/2.0.0/Process.xml");
+
+    private final String prefix;
+    private final String modelUri;
+
+    Profile(String prefix, String modelUri) {
+      this.prefix = prefix;
+      this.modelUri = modelUri;
+    }
+  }
+
+  /** Immutable conformance evidence. */
+  public static final class Report implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Profile profile;
+    private final String fileSha256;
+    private final String bundledSchemaSha256;
+    private final boolean officialSchemaVerified;
+    private final boolean schemaValid;
+    private final boolean officialImportsValid;
+    private final boolean semanticProfileValid;
+    private final int objectCount;
+    private final int referenceCount;
+    private final List<String> errors;
+    private final List<String> warnings;
+
+    Report(Profile profile, String fileSha256, String bundledSchemaSha256, boolean officialSchemaVerified,
+        boolean schemaValid, boolean officialImportsValid, boolean semanticProfileValid, int objectCount,
+        int referenceCount, List<String> errors, List<String> warnings) {
+      this.profile = profile;
+      this.fileSha256 = fileSha256;
+      this.bundledSchemaSha256 = bundledSchemaSha256;
+      this.officialSchemaVerified = officialSchemaVerified;
+      this.schemaValid = schemaValid;
+      this.officialImportsValid = officialImportsValid;
+      this.semanticProfileValid = semanticProfileValid;
+      this.objectCount = objectCount;
+      this.referenceCount = referenceCount;
+      this.errors = Collections.unmodifiableList(new ArrayList<String>(errors));
+      this.warnings = Collections.unmodifiableList(new ArrayList<String>(warnings));
+    }
+
+    public boolean isSchemaAndProfileConformant() {
+      return officialSchemaVerified && schemaValid && officialImportsValid && semanticProfileValid;
+    }
+
+    public List<String> getErrors() {
+      return errors;
+    }
+
+    public List<String> getWarnings() {
+      return warnings;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", "neqsim_dexpi_2_0_conformance.v1");
+      result.put("dexpiSpecificationVersion", SPECIFICATION_VERSION);
+      result.put("dexpiSpecificationReleaseDate", SPECIFICATION_RELEASE_DATE);
+      result.put("profile", profile.name());
+      result.put("fileSha256", fileSha256);
+      result.put("bundledOfficialSchemaSha256", bundledSchemaSha256);
+      result.put("officialSchemaVerified", Boolean.valueOf(officialSchemaVerified));
+      result.put("schemaValid", Boolean.valueOf(schemaValid));
+      result.put("officialModelImportsValid", Boolean.valueOf(officialImportsValid));
+      result.put("neqsimSemanticProfileValid", Boolean.valueOf(semanticProfileValid));
+      result.put("objectCount", Integer.valueOf(objectCount));
+      result.put("referenceCount", Integer.valueOf(referenceCount));
+      result.put("status", isSchemaAndProfileConformant() ? "CONFORMANT" : "NONCONFORMANT");
+      result.put("errors", new ArrayList<String>(errors));
+      result.put("warnings", new ArrayList<String>(warnings));
+      result.put("assessmentScope",
+          "Official DEXPI XML 2.0 schema, official model imports, reference integrity, and NeqSim supported semantic profile");
+      result.put("dexpiEvCertificationStatus", "NOT_A_DEXPI_EV_CERTIFICATE");
+      result.put("namedCaeRoundTripStatus", "QUALIFICATION_REQUIRED");
+      return result;
+    }
+
+    public String toJson() {
+      return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+    }
+  }
+
+  /** Assesses one DEXPI XML file without network access. */
+  public static Report assess(Path file, Profile profile) throws IOException {
+    if (file == null || profile == null) {
+      throw new IllegalArgumentException("file and profile must not be null");
+    }
+    List<String> errors = new ArrayList<String>();
+    List<String> warnings = new ArrayList<String>();
+    String schemaSha = resourceSha256();
+    boolean officialSchema = OFFICIAL_SCHEMA_SHA256.equals(schemaSha);
+    if (!officialSchema) {
+      errors.add("Bundled DEXPI XML schema fingerprint does not match the reviewed V2.0.0 resource");
+    }
+    boolean schemaValid = true;
+    try {
+      Dexpi20XmlValidator.validate(file);
+    } catch (SAXException ex) {
+      schemaValid = false;
+      errors.add("Official DEXPI XML schema validation failed: " + ex.getMessage());
+    }
+
+    Document document = parse(file);
+    Map<String, String> imports = imports(document);
+    boolean importsValid = Dexpi20ProcessModelWriter.CORE_MODEL.equals(imports.get("Core"))
+        && profile.modelUri.equals(imports.get(profile.prefix));
+    if (!importsValid) {
+      errors.add("Required official Core and " + profile.prefix + " model imports are missing or version-mismatched");
+    }
+
+    Dexpi20SemanticValidator.ValidationReport semantic = Dexpi20SemanticValidator.validate(document);
+    errors.addAll(semantic.getErrors());
+    warnings.addAll(semantic.getWarnings());
+    NodeList objects = document.getElementsByTagName("Object");
+    NodeList references = document.getElementsByTagName("References");
+    return new Report(profile, sha256(Files.newInputStream(file)), schemaSha, officialSchema, schemaValid, importsValid,
+        semantic.isValid(), objects.getLength(), references.getLength(), errors, warnings);
+  }
+
+  private static Document parse(Path file) throws IOException {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setXIncludeAware(false);
+      factory.setExpandEntityReferences(false);
+      return factory.newDocumentBuilder().parse(file.toFile());
+    } catch (ParserConfigurationException ex) {
+      throw new IOException("Could not configure DEXPI 2.0 conformance parser", ex);
+    } catch (SAXException ex) {
+      throw new IOException("Could not parse DEXPI 2.0 XML", ex);
+    }
+  }
+
+  private static Map<String, String> imports(Document document) {
+    Map<String, String> result = new LinkedHashMap<String, String>();
+    NodeList imports = document.getDocumentElement().getElementsByTagName("Import");
+    for (int index = 0; index < imports.getLength(); index++) {
+      Element item = (Element) imports.item(index);
+      result.put(item.getAttribute("prefix"), item.getAttribute("source"));
+    }
+    return result;
+  }
+
+  private static String resourceSha256() throws IOException {
+    InputStream stream = Dexpi20ConformanceAssessment.class.getResourceAsStream(SCHEMA_RESOURCE);
+    if (stream == null) {
+      throw new IOException("Bundled DEXPI XML schema is unavailable: " + SCHEMA_RESOURCE);
+    }
+    return sha256(stream);
+  }
+
+  private static String sha256(InputStream stream) throws IOException {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] buffer = new byte[8192];
+      try {
+        int count;
+        while ((count = stream.read(buffer)) >= 0) {
+          digest.update(buffer, 0, count);
+        }
+      } finally {
+        stream.close();
+      }
+      StringBuilder result = new StringBuilder();
+      for (byte value : digest.digest()) {
+        result.append(String.format("%02x", Integer.valueOf(value & 0xff)));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is unavailable", ex);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriter.java
@@ -1,0 +1,414 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.distillation.DistillationColumn;
+import neqsim.process.equipment.expander.Expander;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.splitter.Splitter;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.tank.Tank;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.processmodel.ProcessSystem;
+
+/** Writes the official DEXPI 2.0 Process information model for PFD/BFD data exchange. */
+public final class Dexpi20ProcessModelWriter {
+  static final String CORE_MODEL = "https://data.dexpi.org/models/2.0.0/Core.xml";
+  static final String PROCESS_MODEL = "https://data.dexpi.org/models/2.0.0/Process.xml";
+
+  private Dexpi20ProcessModelWriter() {
+  }
+
+  /** Writes and validates a native DEXPI 2.0 Process model. */
+  public static void write(ProcessSystem processSystem, File file) throws IOException {
+    if (file == null) {
+      throw new IllegalArgumentException("file must not be null");
+    }
+    FileOutputStream stream = new FileOutputStream(file);
+    try {
+      write(processSystem, stream);
+    } finally {
+      stream.close();
+    }
+    try {
+      Dexpi20XmlValidator.validate(file.toPath());
+      Dexpi20SemanticValidator.validateOrThrow(file.toPath());
+    } catch (org.xml.sax.SAXException ex) {
+      throw new IOException("Generated DEXPI 2.0 Process XML failed schema validation", ex);
+    }
+  }
+
+  /** Writes a Process exchange and returns its auditable conformance assessment. */
+  public static Dexpi20ConformanceAssessment.Report writeAndAssess(ProcessSystem processSystem, File file)
+      throws IOException {
+    write(processSystem, file);
+    return Dexpi20ConformanceAssessment.assess(file.toPath(), Dexpi20ConformanceAssessment.Profile.PROCESS_PFD_BFD);
+  }
+
+  /** Writes a native DEXPI 2.0 Process model to a stream. */
+  public static void write(ProcessSystem processSystem, OutputStream outputStream) throws IOException {
+    if (processSystem == null || outputStream == null) {
+      throw new IllegalArgumentException("processSystem and outputStream must not be null");
+    }
+    try {
+      Document document = createDocument();
+      Element model = document.createElement("Model");
+      String modelName = identifier(processSystem.getName(), "NeqSimProcessModel");
+      model.setAttribute("name", modelName);
+      model.setAttribute("uri", "urn:neqsim:dexpi:2.0:process:" + modelName);
+      document.appendChild(model);
+      appendImport(document, model, "Core", CORE_MODEL);
+      appendImport(document, model, "Process", PROCESS_MODEL);
+
+      Element engineeringModel = object(document, null, "Core/EngineeringModel");
+      model.appendChild(engineeringModel);
+      Element conceptualModel = components(document, engineeringModel, "ConceptualModel");
+      Element processModel = object(document, "ProcessModel1", "Process/ProcessModel");
+      conceptualModel.appendChild(processModel);
+
+      ModelTopology topology = topology(processSystem);
+      Element processSteps = components(document, processModel, "ProcessSteps");
+      Map<ProcessEquipmentInterface, Step> steps = new IdentityHashMap<ProcessEquipmentInterface, Step>();
+      int stepNumber = 1;
+      for (ProcessEquipmentInterface unit : topology.units) {
+        Step step = appendStep(document, processSteps, "ProcessStep" + stepNumber++, unit.getName(), type(unit));
+        steps.put(unit, step);
+      }
+      for (Link link : topology.links) {
+        if (link.target != null) {
+          continue;
+        }
+        String sinkName = link.source.getName() + " product " + link.number;
+        link.syntheticSink = appendStep(document, processSteps, "ProcessStep" + stepNumber++, sinkName,
+            "Process/Process.Sink");
+      }
+
+      Element processConnections = components(document, processModel, "ProcessConnections");
+      for (Link link : topology.links) {
+        String connectionId = "Stream" + link.number;
+        Step source = steps.get(link.source);
+        Step target = link.target == null ? link.syntheticSink : steps.get(link.target);
+        String sourcePort = appendPort(document, source, connectionId + "SourcePort", connectionId, "Outlet");
+        String targetPort = appendPort(document, target, connectionId + "TargetPort", connectionId, "Inlet");
+        Element stream = object(document, connectionId, "Process/Process.Stream");
+        data(document, stream, "Identifier", connectionId);
+        data(document, stream, "Label", link.stream.getName());
+        references(document, stream, "Source", sourcePort);
+        references(document, stream, "Target", targetPort);
+        physicalQuantity(document, stream, "MassFlow", finite(new ValueSupplier() {
+          @Override
+          public double value() {
+            return link.stream.getFlowRate("kg/hr");
+          }
+        }), "Core/PhysicalQuantities.MassFlowRateUnit.KilogramPerHour");
+        physicalQuantity(document, stream, "Pressure", finite(new ValueSupplier() {
+          @Override
+          public double value() {
+            return link.stream.getPressure("bara");
+          }
+        }), "Core/PhysicalQuantities.PressureAbsoluteUnit.Bar");
+        physicalQuantity(document, stream, "Temperature", finite(new ValueSupplier() {
+          @Override
+          public double value() {
+            return link.stream.getTemperature("C");
+          }
+        }), "Core/PhysicalQuantities.TemperatureUnit.DegreeCelsius");
+        processConnections.appendChild(stream);
+      }
+      transform(document, outputStream);
+    } catch (ParserConfigurationException ex) {
+      throw new IOException("Could not create DEXPI 2.0 Process XML document", ex);
+    } catch (TransformerException ex) {
+      throw new IOException("Could not serialize DEXPI 2.0 Process XML document", ex);
+    }
+  }
+
+  private static ModelTopology topology(ProcessSystem processSystem) {
+    List<ProcessEquipmentInterface> units = new ArrayList<ProcessEquipmentInterface>();
+    Map<StreamInterface, ProcessEquipmentInterface> sourceByStream = new IdentityHashMap<StreamInterface, ProcessEquipmentInterface>();
+    for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
+      if (unit == null) {
+        continue;
+      }
+      type(unit);
+      units.add(unit);
+      if (unit instanceof StreamInterface) {
+        sourceByStream.put((StreamInterface) unit, unit);
+      } else {
+        for (StreamInterface outlet : unit.getOutletStreams()) {
+          if (outlet != null) {
+            sourceByStream.put(outlet, unit);
+          }
+        }
+      }
+    }
+    List<Link> links = new ArrayList<Link>();
+    Map<StreamInterface, Boolean> consumed = new IdentityHashMap<StreamInterface, Boolean>();
+    int number = 1;
+    for (ProcessEquipmentInterface target : units) {
+      if (target instanceof StreamInterface) {
+        continue;
+      }
+      for (StreamInterface inlet : target.getInletStreams()) {
+        ProcessEquipmentInterface source = sourceByStream.get(inlet);
+        if (source != null) {
+          links.add(new Link(number++, source, target, inlet));
+          consumed.put(inlet, Boolean.TRUE);
+        }
+      }
+    }
+    for (ProcessEquipmentInterface source : units) {
+      if (source instanceof StreamInterface) {
+        continue;
+      }
+      for (StreamInterface outlet : source.getOutletStreams()) {
+        if (outlet != null && !consumed.containsKey(outlet)) {
+          links.add(new Link(number++, source, null, outlet));
+        }
+      }
+    }
+    if (links.isEmpty()) {
+      throw new IllegalArgumentException("DEXPI Process export requires at least one material connection");
+    }
+    return new ModelTopology(units, links);
+  }
+
+  private static Step appendStep(Document document, Element processSteps, String id, String name, String type) {
+    Element step = object(document, id, type);
+    data(document, step, "Identifier", name);
+    data(document, step, "Label", name);
+    Element ports = components(document, step, "Ports");
+    processSteps.appendChild(step);
+    return new Step(ports);
+  }
+
+  private static String appendPort(Document document, Step step, String id, String connectionId, String direction) {
+    Element port = object(document, id, "Process/Process.MaterialPort");
+    data(document, port, "Identifier", id);
+    dataReference(document, port, "NominalDirection", "Process/Enumerations.PortDirection." + direction);
+    references(document, port, "ConnectorReference", connectionId);
+    step.ports.appendChild(port);
+    return id;
+  }
+
+  private static String type(ProcessEquipmentInterface unit) {
+    if (unit instanceof StreamInterface) {
+      return "Process/Process.Source";
+    }
+    if (unit instanceof Expander) {
+      return "Process/Process.TransportingFluids";
+    }
+    if (unit instanceof Compressor) {
+      return "Process/Process.Compressing";
+    }
+    if (unit instanceof Pump) {
+      return "Process/Process.Pumping";
+    }
+    if (unit instanceof DistillationColumn) {
+      return "Process/Process.Distilling";
+    }
+    if (unit instanceof Separator) {
+      return "Process/Process.SeparatingByGravity";
+    }
+    if (unit instanceof Cooler) {
+      return "Process/Process.Cooling";
+    }
+    if (unit instanceof HeatExchanger) {
+      return "Process/Process.ExchangingThermalEnergy";
+    }
+    if (unit instanceof Heater) {
+      return "Process/Process.HeatingInFurnace";
+    }
+    if (unit instanceof Tank) {
+      return "Process/Process.StoringFluids";
+    }
+    if (unit instanceof ThrottlingValve) {
+      return "Process/Process.RegulatingFlow";
+    }
+    if (unit instanceof Mixer) {
+      return "Process/Process.MixingSimple";
+    }
+    if (unit instanceof Splitter) {
+      return "Process/Process.SplittingMaterial";
+    }
+    throw new IllegalArgumentException(
+        "No reviewed DEXPI 2.0 Process type mapping for " + unit.getClass().getName() + " (" + unit.getName() + ")");
+  }
+
+  private static void physicalQuantity(Document document, Element stream, String property, Double value,
+      String unitReference) {
+    if (value == null) {
+      return;
+    }
+    Element values = components(document, stream, property);
+    Element qualified = object(document, null, "Core/QualifiedValue");
+    Element data = document.createElement("Data");
+    data.setAttribute("property", "Value");
+    Element quantity = document.createElement("AggregatedDataValue");
+    quantity.setAttribute("type", "Core/PhysicalQuantities.PhysicalQuantity");
+    Element unitData = document.createElement("Data");
+    unitData.setAttribute("property", "Unit");
+    Element unit = document.createElement("DataReference");
+    unit.setAttribute("data", unitReference);
+    unitData.appendChild(unit);
+    quantity.appendChild(unitData);
+    Element valueData = document.createElement("Data");
+    valueData.setAttribute("property", "Value");
+    Element number = document.createElement("Double");
+    number.setTextContent(Double.toString(value.doubleValue()));
+    valueData.appendChild(number);
+    quantity.appendChild(valueData);
+    data.appendChild(quantity);
+    qualified.appendChild(data);
+    values.appendChild(qualified);
+  }
+
+  private static Double finite(ValueSupplier supplier) {
+    try {
+      double value = supplier.value();
+      return Double.isFinite(value) ? Double.valueOf(value) : null;
+    } catch (RuntimeException ex) {
+      return null;
+    }
+  }
+
+  private static Document createDocument() throws ParserConfigurationException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    return factory.newDocumentBuilder().newDocument();
+  }
+
+  private static void appendImport(Document document, Element model, String prefix, String source) {
+    Element item = document.createElement("Import");
+    item.setAttribute("prefix", prefix);
+    item.setAttribute("source", source);
+    model.appendChild(item);
+  }
+
+  private static Element object(Document document, String id, String type) {
+    Element object = document.createElement("Object");
+    if (id != null) {
+      object.setAttribute("id", identifier(id, "Object"));
+    }
+    object.setAttribute("type", type);
+    return object;
+  }
+
+  private static Element components(Document document, Element parent, String property) {
+    Element result = document.createElement("Components");
+    result.setAttribute("property", property);
+    parent.appendChild(result);
+    return result;
+  }
+
+  private static void data(Document document, Element parent, String property, String value) {
+    Element data = document.createElement("Data");
+    data.setAttribute("property", property);
+    Element string = document.createElement("String");
+    string.setTextContent(value == null ? "" : value);
+    data.appendChild(string);
+    parent.appendChild(data);
+  }
+
+  private static void dataReference(Document document, Element parent, String property, String value) {
+    Element data = document.createElement("Data");
+    data.setAttribute("property", property);
+    Element reference = document.createElement("DataReference");
+    reference.setAttribute("data", value);
+    data.appendChild(reference);
+    parent.appendChild(data);
+  }
+
+  private static void references(Document document, Element parent, String property, String id) {
+    Element reference = document.createElement("References");
+    reference.setAttribute("property", property);
+    reference.setAttribute("objects", "#" + identifier(id, "Object"));
+    parent.appendChild(reference);
+  }
+
+  private static String identifier(String value, String fallback) {
+    String result = value == null ? "" : value.trim().replaceAll("[^A-Za-z0-9_]", "_");
+    if (result.isEmpty()) {
+      result = fallback;
+    }
+    if (!Character.isLetter(result.charAt(0)) && result.charAt(0) != '_') {
+      result = "N_" + result;
+    }
+    return result;
+  }
+
+  private static void transform(Document document, OutputStream outputStream) throws TransformerException {
+    TransformerFactory factory = TransformerFactory.newInstance();
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    Transformer transformer = factory.newTransformer();
+    transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+    transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+    transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+    transformer.transform(new DOMSource(document), new StreamResult(outputStream));
+  }
+
+  private interface ValueSupplier {
+    double value();
+  }
+
+  private static final class Step {
+    private final Element ports;
+
+    Step(Element ports) {
+      this.ports = ports;
+    }
+  }
+
+  private static final class Link {
+    private final int number;
+    private final ProcessEquipmentInterface source;
+    private final ProcessEquipmentInterface target;
+    private final StreamInterface stream;
+    private Step syntheticSink;
+
+    Link(int number, ProcessEquipmentInterface source, ProcessEquipmentInterface target, StreamInterface stream) {
+      this.number = number;
+      this.source = source;
+      this.target = target;
+      this.stream = stream;
+    }
+  }
+
+  private static final class ModelTopology {
+    private final List<ProcessEquipmentInterface> units;
+    private final List<Link> links;
+
+    ModelTopology(List<ProcessEquipmentInterface> units, List<Link> links) {
+      this.units = units;
+      this.links = links;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20SemanticValidator.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20SemanticValidator.java
@@ -22,10 +22,11 @@ import org.xml.sax.SAXException;
 public final class Dexpi20SemanticValidator {
   private static final String CORE_MODEL = "https://data.dexpi.org/models/2.0.0/Core.xml";
   private static final String PLANT_MODEL = "https://data.dexpi.org/models/2.0.0/Plant.xml";
-  private static final Set<String> SUPPORTED_TYPES = Collections
-      .unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("Core/EngineeringModel", "Core/Diagram.Diagram",
-          "Core/Diagram.RepresentationGroup", "Core/Diagram.Text", "Core/Diagram.Point", "Plant/PlantModel",
-          "Plant/ProcessEquipment.ProcessEquipment", "Plant/ProcessEquipment.CentrifugalCompressor",
+  private static final String PROCESS_MODEL = "https://data.dexpi.org/models/2.0.0/Process.xml";
+  private static final Set<String> SUPPORTED_TYPES = Collections.unmodifiableSet(new LinkedHashSet<String>(
+      Arrays.asList("Core/EngineeringModel", "Core/QualifiedValue", "Core/PhysicalQuantities.PhysicalQuantity",
+          "Core/Diagram.Diagram", "Core/Diagram.RepresentationGroup", "Core/Diagram.Text", "Core/Diagram.Point",
+          "Plant/PlantModel", "Plant/ProcessEquipment.ProcessEquipment", "Plant/ProcessEquipment.CentrifugalCompressor",
           "Plant/ProcessEquipment.CentrifugalPump", "Plant/ProcessEquipment.Separator",
           "Plant/ProcessEquipment.AirCoolingSystem", "Plant/ProcessEquipment.TubularHeatExchanger",
           "Plant/ProcessEquipment.FiredHeater", "Plant/ProcessEquipment.Tank", "Plant/ProcessEquipment.Nozzle",
@@ -33,7 +34,13 @@ public final class Dexpi20SemanticValidator {
           "Plant/Piping.Pipe", "Plant/Piping.GlobeValve", "Plant/Piping.SpringLoadedGlobeSafetyValve",
           "Plant/Piping.SwingCheckValve", "Plant/Piping.FlowInPipeOffPageConnector",
           "Plant/Piping.FlowOutPipeOffPageConnector", "Plant/Instrumentation.ProcessInstrumentationFunction",
-          "Plant/Instrumentation.ProcessSignalGeneratingFunction", "Plant/Instrumentation.MeasuringLineFunction")));
+          "Plant/Instrumentation.ProcessSignalGeneratingFunction", "Plant/Instrumentation.MeasuringLineFunction",
+          "Process/ProcessModel", "Process/Process.MaterialPort", "Process/Process.Stream", "Process/Process.Source",
+          "Process/Process.Sink", "Process/Process.TransportingFluids", "Process/Process.Compressing",
+          "Process/Process.Pumping", "Process/Process.Distilling", "Process/Process.SeparatingByGravity",
+          "Process/Process.Cooling", "Process/Process.ExchangingThermalEnergy", "Process/Process.HeatingInFurnace",
+          "Process/Process.StoringFluids", "Process/Process.RegulatingFlow", "Process/Process.MixingSimple",
+          "Process/Process.SplittingMaterial")));
 
   private Dexpi20SemanticValidator() {
   }
@@ -105,7 +112,15 @@ public final class Dexpi20SemanticValidator {
 
     Map<String, String> imports = collectImports(root, errors);
     requireImport(imports, "Core", CORE_MODEL, errors);
-    requireImport(imports, "Plant", PLANT_MODEL, errors);
+    if (!imports.containsKey("Plant") && !imports.containsKey("Process")) {
+      errors.add("A DEXPI 2.0 exchange must import the Plant or Process information model.");
+    }
+    if (imports.containsKey("Plant")) {
+      requireImport(imports, "Plant", PLANT_MODEL, errors);
+    }
+    if (imports.containsKey("Process")) {
+      requireImport(imports, "Process", PROCESS_MODEL, errors);
+    }
 
     Map<String, Element> objectsById = new LinkedHashMap<String, Element>();
     Set<String> tagNames = new LinkedHashSet<String>();
@@ -135,6 +150,7 @@ public final class Dexpi20SemanticValidator {
     validateReferences(root, objectsById, errors);
     validateEquipment(objects, errors, warnings);
     validatePipingReferences(root, objectsById, errors);
+    validateProcessModel(objects, objectsById, errors, warnings);
     return new ValidationReport(errors, warnings);
   }
 
@@ -230,6 +246,94 @@ public final class Dexpi20SemanticValidator {
         }
       }
     }
+  }
+
+  private static void validateProcessModel(NodeList objects, Map<String, Element> objectsById, List<String> errors,
+      List<String> warnings) {
+    int processModelCount = 0;
+    int processStepCount = 0;
+    int streamCount = 0;
+    for (int i = 0; i < objects.getLength(); i++) {
+      Element object = (Element) objects.item(i);
+      String type = object.getAttribute("type");
+      if ("Process/ProcessModel".equals(type)) {
+        processModelCount++;
+      } else if ("Process/Process.MaterialPort".equals(type)) {
+        requireDirectStringData(object, "Identifier", errors);
+        requireDirectDataReference(object, "NominalDirection", errors);
+        validateTypedReference(object, "ConnectorReference", "Process/Process.Stream", objectsById, errors);
+      } else if ("Process/Process.Stream".equals(type)) {
+        streamCount++;
+        requireDirectStringData(object, "Identifier", errors);
+        requireDirectStringData(object, "Label", errors);
+        validateTypedReference(object, "Source", "Process/Process.MaterialPort", objectsById, errors);
+        validateTypedReference(object, "Target", "Process/Process.MaterialPort", objectsById, errors);
+      } else if (type.startsWith("Process/Process.")) {
+        processStepCount++;
+        requireDirectStringData(object, "Identifier", errors);
+        if (!hasDirectComponents(object, "Ports")) {
+          warnings
+              .add("DEXPI Process step has no material, energy, or information ports: " + object.getAttribute("id"));
+        }
+      }
+    }
+    if (processModelCount > 1) {
+      errors.add("A DEXPI engineering model contains more than one ProcessModel conceptual model.");
+    }
+    if (processModelCount == 1 && (processStepCount == 0 || streamCount == 0)) {
+      errors.add("A NeqSim DEXPI Process exchange requires at least one process step and material stream.");
+    }
+  }
+
+  private static void validateTypedReference(Element object, String property, String expectedType,
+      Map<String, Element> objectsById, List<String> errors) {
+    Element reference = directReference(object, property);
+    if (reference == null) {
+      errors.add(
+          object.getAttribute("type") + " has no required " + property + " reference: " + object.getAttribute("id"));
+      return;
+    }
+    String values = reference.getAttribute("objects").trim();
+    if (values.indexOf(' ') >= 0) {
+      errors.add(property + " must contain exactly one object reference: " + values);
+      return;
+    }
+    Element target = values.startsWith("#") ? objectsById.get(values.substring(1)) : null;
+    if (target != null && !expectedType.equals(target.getAttribute("type"))) {
+      errors.add(property + " must reference " + expectedType + ": " + values);
+    }
+  }
+
+  private static void requireDirectStringData(Element object, String property, List<String> errors) {
+    if (directStringData(object, property) == null) {
+      errors
+          .add(object.getAttribute("type") + " has no required " + property + " string: " + object.getAttribute("id"));
+    }
+  }
+
+  private static void requireDirectDataReference(Element object, String property, List<String> errors) {
+    for (Node child = object.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (!(child instanceof Element) || !"Data".equals(((Element) child).getTagName())
+          || !property.equals(((Element) child).getAttribute("property"))) {
+        continue;
+      }
+      NodeList references = ((Element) child).getElementsByTagName("DataReference");
+      if (references.getLength() == 1 && !((Element) references.item(0)).getAttribute("data").isEmpty()) {
+        return;
+      }
+    }
+    errors.add(
+        object.getAttribute("type") + " has no required " + property + " data reference: " + object.getAttribute("id"));
+  }
+
+  private static Element directReference(Element object, String property) {
+    for (Node child = object.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "References".equals(((Element) child).getTagName())
+          && property.equals(((Element) child).getAttribute("property"))) {
+        return (Element) child;
+      }
+    }
+    return null;
   }
 
   private static boolean hasDirectComponents(Element object, String property) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
@@ -59,6 +59,13 @@ public final class Dexpi20XmlWriter {
     }
   }
 
+  /** Writes a Plant exchange and returns its auditable conformance assessment. */
+  public static Dexpi20ConformanceAssessment.Report writeAndAssess(ProcessSystem processSystem, File file)
+      throws IOException {
+    write(processSystem, file);
+    return Dexpi20ConformanceAssessment.assess(file.toPath(), Dexpi20ConformanceAssessment.Profile.PLANT_P_ID);
+  }
+
   /** Writes a native DEXPI 2.0 model to a stream. */
   public static void write(ProcessSystem processSystem, OutputStream outputStream) throws IOException {
     if (processSystem == null || outputStream == null) {

--- a/src/main/resources/dexpi/2.0/README.md
+++ b/src/main/resources/dexpi/2.0/README.md
@@ -5,5 +5,8 @@
 - Source: https://gitlab.com/dexpi/Specification
 - Release: `V2.0.0`
 - License: Creative Commons Attribution 4.0 International (CC BY 4.0)
+- Reviewed SHA-256: `0bd6568b7c52fd59ac4ef6d8547ab2b2aa890c009a3a1bfbc5d7cc18c53b36e6`
+- Official model URIs: `https://data.dexpi.org/models/2.0.0/Core.xml`, `Plant.xml`, and `Process.xml`
 
 The schema is bundled so native DEXPI XML exports can be validated deterministically without network access.
+`Dexpi20ConformanceAssessment` verifies the fingerprint before reporting schema-and-profile conformance.

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
@@ -1,0 +1,96 @@
+package neqsim.process.processmodel.dexpi;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Tests official DEXPI 2.0 Process-model serialization and scoped conformance evidence. */
+class Dexpi20ProcessModelWriterTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void writesSchemaValidProcessModelWithStepsPortsStreamsAndPhysicalQuantities() throws Exception {
+    ProcessSystem process = process();
+    Path output = temporaryDirectory.resolve("process-pfd.dexpi.xml");
+
+    Dexpi20ConformanceAssessment.Report report = Dexpi20ProcessModelWriter.writeAndAssess(process, output.toFile());
+    String xml = new String(Files.readAllBytes(output), StandardCharsets.UTF_8);
+
+    assertTrue(report.isSchemaAndProfileConformant(), report.getErrors().toString());
+    assertTrue(xml.contains("type=\"Process/ProcessModel\""));
+    assertTrue(xml.contains("type=\"Process/Process.Compressing\""));
+    assertTrue(xml.contains("type=\"Process/Process.Pumping\""));
+    assertTrue(xml.contains("property=\"ConnectorReference\""));
+    assertTrue(xml.contains("MassFlowRateUnit.KilogramPerHour"));
+    assertTrue(report.toJson().contains("NOT_A_DEXPI_EV_CERTIFICATE"));
+  }
+
+  @Test
+  void plantAndProcessAssessmentsCannotBeInterchanged() throws Exception {
+    Path plant = temporaryDirectory.resolve("plant.dexpi.xml");
+    Dexpi20XmlWriter.write(process(), plant.toFile());
+
+    Dexpi20ConformanceAssessment.Report correct = Dexpi20ConformanceAssessment.assess(plant,
+        Dexpi20ConformanceAssessment.Profile.PLANT_P_ID);
+    Dexpi20ConformanceAssessment.Report wrong = Dexpi20ConformanceAssessment.assess(plant,
+        Dexpi20ConformanceAssessment.Profile.PROCESS_PFD_BFD);
+
+    assertTrue(correct.isSchemaAndProfileConformant(), correct.getErrors().toString());
+    assertFalse(wrong.isSchemaAndProfileConformant());
+    assertTrue(wrong.getErrors().toString().contains("official Core and Process model imports"));
+  }
+
+  @Test
+  void semanticValidationRejectsIncompleteProcessPortAndStreamRelationships() throws Exception {
+    String xml = "<Model name=\"InvalidProcess\" uri=\"urn:invalid:process\">"
+        + "<Import prefix=\"Core\" source=\"https://data.dexpi.org/models/2.0.0/Core.xml\"/>"
+        + "<Import prefix=\"Process\" source=\"https://data.dexpi.org/models/2.0.0/Process.xml\"/>"
+        + "<Object type=\"Core/EngineeringModel\"><Components property=\"ConceptualModel\">"
+        + "<Object id=\"ProcessModel1\" type=\"Process/ProcessModel\">"
+        + "<Components property=\"ProcessSteps\"><Object id=\"Step1\" type=\"Process/Process.Source\">"
+        + "<Data property=\"Identifier\"><String>source</String></Data>"
+        + "<Components property=\"Ports\"><Object id=\"Port1\" type=\"Process/Process.MaterialPort\">"
+        + "<Data property=\"Identifier\"><String>Port1</String></Data>" + "</Object></Components></Object></Components>"
+        + "<Components property=\"ProcessConnections\"><Object id=\"Stream1\" type=\"Process/Process.Stream\">"
+        + "<Data property=\"Identifier\"><String>Stream1</String></Data>"
+        + "</Object></Components></Object></Components></Object></Model>";
+    Path file = temporaryDirectory.resolve("invalid-process.dexpi.xml");
+    Files.write(file, xml.getBytes(StandardCharsets.UTF_8));
+
+    Dexpi20SemanticValidator.ValidationReport report = Dexpi20SemanticValidator.validate(file);
+
+    assertFalse(report.isValid());
+    assertTrue(report.getErrors().toString().contains("NominalDirection"));
+    assertTrue(report.getErrors().toString().contains("ConnectorReference"));
+    assertTrue(report.getErrors().toString().contains("Source reference"));
+  }
+
+  private ProcessSystem process() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-heptane", 0.2);
+    Stream feed = new Stream("10-FEED-001", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    Separator separator = new Separator("10-VA-001", feed);
+    Compressor compressor = new Compressor("10-KA-001", separator.getGasOutStream());
+    Pump pump = new Pump("10-PA-001", separator.getLiquidOutStream());
+    ProcessSystem process = new ProcessSystem();
+    process.setName("DEXPI 2.0 Process exchange");
+    process.add(feed);
+    process.add(separator);
+    process.add(compressor);
+    process.add(pump);
+    return process;
+  }
+}


### PR DESCRIPTION
## Summary
- add genuine native DEXPI XML Process-model export for PFD/BFD process steps, material ports, streams, and physical quantities
- extend semantic validation across the official Core + Plant and Core + Process 2.0.0 profiles
- add auditable schema fingerprint/import/reference/profile conformance reports without claiming DEXPI e.V. certification or skipping named-CAE qualification
- replace obsolete placeholder documentation with official 2.0.0 serialization, mapping, and review guidance

## Validation
- `git diff --check` and Spotless: passed
- focused DEXPI 2.0 schema, semantic, and Process-model tests: passed
- skills lint and PaperLab gate: passed
- temporary validation workflow removed

## Stack
PR3 of 4. Targets #2493 and is mergeable. Merge after #2493; #2495 is stacked on this PR.

## References
- https://dexpi.org/specifications/
- https://dexpi.gitlab.io/-/Specification/-/jobs/11676485644/artifacts/src/.build/html/html/index.html