### PR TITLE
Add controlled CFIHOS 2.0 engineering handover

### DIFF
--- a/.github/skills/neqsim-process-modeling/SKILL.md
+++ b/.github/skills/neqsim-process-modeling/SKILL.md
@@ -135,6 +135,10 @@ the governed enterprise checklist and readiness gates use
 - Use `Dexpi20XmlWriter` for native Plant/P&ID exchange and `Dexpi20ProcessModelWriter` for native Process/PFD/BFD
   exchange. A Proteus document with a changed header is not native DEXPI 2.0. Preserve the conformance report and still
   require a named-CAE round-trip before project qualification.
+- Use `Cfihos20HandoverExporter` only with an exact project-controlled CFIHOS 2.0 Core or Extended RDL delivery.
+  Verify its digest from controlled bytes, map canonical nodes/properties/documents to exact RDL identifiers, record
+  mapping approval, and close the generated gap register. Its CSVs are staging data; Principal transformation,
+  target-system validation, contractual completeness, and information acceptance remain external decisions.
 - Compressor, pump, heat exchanger, separator, and pipeline cases identify applicable
   standards through `neqsim-standards-lookup`.
 

--- a/.github/workflows/execute-process-to-engineering-simulator.yml
+++ b/.github/workflows/execute-process-to-engineering-simulator.yml
@@ -1,0 +1,100 @@
+name: Execute process-to-engineering simulator notebook
+
+on:
+  pull_request:
+    paths:
+      - "examples/notebooks/process_to_engineering_simulator.ipynb"
+      - "src/main/java/neqsim/process/engineering/**"
+      - "src/main/java/neqsim/process/processmodel/dexpi/**"
+      - "src/test/java/neqsim/process/engineering/**"
+      - "src/test/java/neqsim/process/processmodel/dexpi/**"
+      - ".github/workflows/execute-process-to-engineering-simulator.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  execute-notebook:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build workspace classes
+        run: ./mvnw -B -ntp -Dmaven.test.skip=true package
+
+      - name: Check formatting and focused handover tests
+        run: |
+          ./mvnw -B -ntp -DskipTests spotless:check
+          ./mvnw -B -ntp -Dtest=Cfihos20HandoverExporterTest,Dexpi20ProcessModelWriterTest,EngineeringNumericalHealthAnalyzerTest test
+
+      - name: Install notebook runtime
+        run: python -m pip install --upgrade nbconvert nbclient nbformat ipykernel pandas matplotlib numpy jpype1
+
+      - name: Execute notebook
+        env:
+          MPLBACKEND: Agg
+          NEQSIM_PROJECT_ROOT: ${{ github.workspace }}
+        run: |
+          mkdir -p build/executed-notebooks
+          python -m jupyter nbconvert --to notebook --execute examples/notebooks/process_to_engineering_simulator.ipynb --ExecutePreprocessor.timeout=2700 --ExecutePreprocessor.kernel_name=python3 --output process_to_engineering_simulator.ipynb --output-dir build/executed-notebooks
+
+      - name: Verify notebook and handover package
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          executed = Path("build/executed-notebooks/process_to_engineering_simulator.ipynb")
+          notebook = json.loads(executed.read_text(encoding="utf-8"))
+          code = [cell for cell in notebook["cells"] if cell["cell_type"] == "code"]
+          assert code and all(cell.get("execution_count") is not None for cell in code)
+          assert not any(
+              output.get("output_type") == "error"
+              for cell in code
+              for output in cell.get("outputs", [])
+          )
+
+          package = Path("/tmp/neqsim-process-to-engineering-package")
+          numerical = json.loads((package / "engineering-numerical-health.json").read_text(encoding="utf-8"))
+          assert numerical["status"] != "FAILED"
+          assert (package / "process-model.dexpi.xml").is_file()
+
+          handover = package / "cfihos-20-staging"
+          assessment = json.loads((handover / "cfihos-20-assessment.json").read_text(encoding="utf-8"))
+          manifest = json.loads((handover / "cfihos-20-manifest.json").read_text(encoding="utf-8"))
+          assert assessment["status"] == "INCOMPLETE"
+          assert assessment["cfihosConformanceClaim"] is False
+          assert manifest["targetSystemTransformationRequired"] is True
+          for name in (
+              "cfihos-tags.csv",
+              "cfihos-equipment.csv",
+              "cfihos-properties.csv",
+              "cfihos-documents.csv",
+              "cfihos-relationships.csv",
+              "cfihos-unmapped.csv",
+          ):
+              assert (handover / name).is_file(), name
+          print(f"Verified {len(code)} executed code cells")
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: process-to-engineering-simulator
+          path: |
+            build/executed-notebooks/process_to_engineering_simulator.ipynb
+            /tmp/neqsim-process-to-engineering-package
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/integration/cfihos-20-engineering-handover.md
+++ b/docs/integration/cfihos-20-engineering-handover.md
@@ -1,0 +1,110 @@
+---
+title: Controlled CFIHOS 2.0 engineering handover
+description: Deterministic staging files, verified RDL mappings, gap registers, and fail-closed readiness evidence for CFIHOS 2.0 handover.
+---
+
+# Controlled CFIHOS 2.0 engineering handover
+
+CFIHOS 2.0 was published as a major release in November 2025. It provides Core and
+Extended Reference Data Library deliveries, an updated data model and dictionary, implementation
+guides, and supporting templates. The standard separates the information requirements, data model,
+implementation guidance, RDL, and software requirements used to specify, validate, stage, map, and
+transfer project information.
+
+NeqSim implements the controlled staging part of that workflow. It does not bundle CFIHOS RDL
+content, invent RDL identifiers, reproduce a Principal information requirements, or claim CFIHOS
+conformance. Cfihos20HandoverExporter maps the canonical EngineeringGraph through an explicit
+project-owned RDL mapping and produces deterministic CSV and JSON evidence for target-system
+transformation by the Principal.
+
+## Required mapping controls
+
+Cfihos20ReferenceDataMapping records:
+
+- whether the project uses the CFIHOS 2.0 Core or Extended RDL;
+- a URI for the exact controlled RDL delivery;
+- a SHA-256 calculated from the supplied RDL bytes;
+- the accountable mapping authority and mapping revision;
+- exact tag and equipment class identifiers per canonical node;
+- exact property and applicable unit-of-measure identifiers; and
+- exact document-type identifiers.
+
+Use verifiedSource, not a copied digest, for release evidence:
+
+~~~java
+Cfihos20ReferenceDataMapping mapping = Cfihos20ReferenceDataMapping
+    .builder(Cfihos20ReferenceDataMapping.Edition.CORE)
+    .verifiedSource("urn:company:cfihos:2.0:core:project-rev-c", controlledRdlFile)
+    .approvedBy("Project Information Manager", "MAPPING-REV-C")
+    .mapNode("equipment:20-vg-001", exactTagClassId, exactEquipmentClassId)
+    .mapProperty("designPressure", exactPropertyId, exactUomId)
+    .mapDocument("20-VG-001-datasheet.pdf", exactDocumentTypeId)
+    .build();
+
+Cfihos20HandoverExporter.Result result =
+    Cfihos20HandoverExporter.export(graph, mapping, outputDirectory);
+if (!result.getReport().isReadyForPrincipalTransformation()) {
+  throw new IllegalStateException(result.getReport().getFindings().toString());
+}
+~~~
+
+The API validates identity presence and mapping controls, but it cannot decide whether an identifier
+is semantically correct for a project. That decision belongs to the approved RDL mapping and the
+Principal information-management review.
+
+## Staging package
+
+| File | Purpose |
+|---|---|
+| cfihos-tags.csv | Functional tag identity, description, exact tag class, project, and revision |
+| cfihos-equipment.csv | Physical equipment identity, exact equipment class, and realized tag |
+| cfihos-properties.csv | Scalar values mapped to exact property and UOM identifiers |
+| cfihos-documents.csv | Document identity, type, title, and controlled file reference |
+| cfihos-relationships.csv | Canonical graph relationships plus equipment-realizes-tag links |
+| cfihos-unmapped.csv | Every unclassified node, document, or optional scalar property |
+| cfihos-20-assessment.json | Counts, findings, mapping evidence, file digests, and readiness decision |
+| cfihos-20-manifest.json | Ordered inventory and SHA-256 digest for every staged payload |
+
+The CSV column set is the versioned NEQSIM_CONTROLLED_CFIHOS_2_0_STAGING_V1 profile. It is
+intentionally a neutral staging shape, not an official or vendor-specific bulk-loader template. The
+Principal must transform it to the contracted CFIHOS exchange templates and target-system schema.
+
+## Fail-closed decisions
+
+The assessment is INCOMPLETE when:
+
+- the RDL digest was declared rather than verified from controlled bytes;
+- the mapping revision lacks project approval;
+- a tag-bearing graph node lacks an exact tag-class mapping;
+- physical equipment lacks an exact equipment-class mapping;
+- a mapped numeric property lacks an exact unit-of-measure mapping;
+- a handover document lacks an exact document-type mapping; or
+- the graph contains no transferable tag-like nodes.
+
+Unmapped scalar properties are retained in the gap register as warnings because the Principal
+contractual data requirements determine whether each property is required. A production release
+must reconcile those warnings against the project requirement matrix; absence of a blocker is not
+proof of contractual completeness.
+
+Both JSON files state:
+
+- cfihosConformanceClaim=false;
+- principalAcceptanceRequired=true; and
+- targetSystemTransformationRequired=true.
+
+These controls prevent a deterministic export from being mistaken for information acceptance,
+operational readiness, or construction authorization.
+
+## Industrial handover sequence
+
+1. Freeze the CFIHOS 2.0 Core or Extended RDL delivery and calculate its digest.
+2. Derive the project information requirement matrix and contract deliverable scope.
+3. Approve exact node, property, UOM, and document mappings.
+4. Compile the canonical engineering graph and export the staging package.
+5. Close every blocker and reconcile every optional-property warning with the requirement matrix.
+6. Transform to the Principal templates and validate in the named staging/target system.
+7. Record review comments, load receipts, rejected records, accepted revisions, and final handover
+   authority outside NeqSim.
+
+Official references: [CFIHOS 2.0 standards and downloads](https://www.jip36-cfihos.org/cfihos-standards/)
+and [CFIHOS implementation workflow](https://www.jip36-cfihos.org/how-it-works/).

--- a/docs/integration/dexpi-20-conformance.md
+++ b/docs/integration/dexpi-20-conformance.md
@@ -58,6 +58,7 @@ Reviewed NeqSim-to-DEXPI Process mappings are:
 | mixer | `MixingSimple` |
 | splitter | `SplittingMaterial` |
 | expander | `TransportingFluids` |
+| pipeline or pipe segment | `TransportingFluids` |
 
 An unmapped equipment class aborts export with its Java type and tag. The exporter never substitutes
 an unreviewed generic DEXPI type merely to make a file validate.

--- a/docs/integration/process-to-engineering-simulator.md
+++ b/docs/integration/process-to-engineering-simulator.md
@@ -1,6 +1,6 @@
 ---
 title: "Process-to-engineering simulator"
-description: "Iterate NeqSim process cases into review-governed equipment, piping, valve, instrument, safety, material, mechanical, and DEXPI design outputs."
+description: "Iterate NeqSim process cases into review-governed design, exchange, numerical-health, and handover outputs."
 ---
 
 # Process-to-engineering simulator
@@ -11,6 +11,10 @@ production-readiness reports.
 
 Native [DEXPI 2.0 Plant and Process exchange](dexpi-20-conformance.md) provides separate P&ID and PFD/BFD information
 models with offline official-schema validation and auditable conformance reports.
+
+Controlled [CFIHOS 2.0 engineering handover](cfihos-20-engineering-handover.md) maps the canonical graph through a
+verified, project-approved RDL mapping into deterministic staging files, gap registers, digests, and a fail-closed
+readiness assessment.
 
 The process-to-engineering simulator closes the loop between process physics and preliminary engineering design. It
 runs every controlled process case on isolated copies, sizes configured engineering objects, applies selected design
@@ -528,6 +532,10 @@ release evidence and accountable external receipts declared by the readiness gat
 now match the actual supplied document bytes. These evidence requirements are project inputs, not unfinished simulator
 features, and the simulator always retains `fitnessForConstruction=false`.
 
+After compilation, `Cfihos20HandoverExporter` can stage tags, physical equipment, properties, documents, and graph
+relationships against exact CFIHOS 2.0 RDL identifiers. The Principal still owns contractual completeness,
+target-system transformation, load validation, and final information acceptance.
+
 ## Required engineering review
 
 The simulator produces calculated or proposed engineering suitable for concept and pre-FEED development. It can
@@ -544,6 +552,7 @@ or approve them:
 
 See the executed
 [process-to-engineering notebook](../../examples/notebooks/process_to_engineering_simulator.ipynb) for the full
-vertical slice, process/design convergence plots and coordinated package. The executed
+vertical slice, process/design convergence plots, numerical-health report, native DEXPI Process assessment, and
+controlled CFIHOS staging example. The executed
 [engineering-roadmap workbench](../../examples/notebooks/engineering_roadmap_steps_1_to_8.ipynb) demonstrates every
 new typed equipment, piping, valve/instrument, safety, materials and preliminary mechanical calculation family.

--- a/examples/notebooks/process_to_engineering_simulator.ipynb
+++ b/examples/notebooks/process_to_engineering_simulator.ipynb
@@ -441,7 +441,7 @@
      "text": [
       "Package valid: True\n",
       "DEXPI 2.0: /tmp/neqsim-process-to-engineering-package/plant.dexpi.xml\n",
-      "Generated top-level artifacts: 40\n"
+      "Generated top-level artifacts: 41\n"
      ]
     }
    ],
@@ -474,6 +474,88 @@
    "metadata": {},
    "source": [
     "The package uses the isolated designed geometry and carries calculated values into the canonical graph, DEXPI references, registers, and calculation evidence. HAZOP/LOPA, SIL approval, vendor guarantees, final code design, materials approval, and construction authorization remain accountable engineering activities."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b6d2f41",
+   "metadata": {},
+   "source": [
+    "## 5. Check numerical health and native DEXPI 2.0 Process exchange\n",
+    "\n",
+    "The compiler now emits numerical-health evidence for the governed process. The native Process exporter separately proves the official Core plus Process schema/profile used for PFD/BFD exchange; named CAE round-trip qualification is still required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a9f67e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NumericalHealthAnalyzer = JClass('neqsim.process.engineering.numerics.EngineeringNumericalHealthAnalyzer')\n",
+    "DexpiProcessWriter = JClass('neqsim.process.processmodel.dexpi.Dexpi20ProcessModelWriter')\n",
+    "JavaFile = JClass('java.io.File')\n",
+    "numerical_health = NumericalHealthAnalyzer.analyze(project.getEngineeringProcessSystem())\n",
+    "process_exchange = package_dir / 'process-model.dexpi.xml'\n",
+    "process_conformance = DexpiProcessWriter.writeAndAssess(project.getEngineeringProcessSystem(), JavaFile(str(process_exchange)))\n",
+    "print('Numerical health:', numerical_health.getStatus().name())\n",
+    "print('Native Process profile conformant:', process_conformance.isSchemaAndProfileConformant())\n",
+    "print('Named CAE status:', process_conformance.toMap().get('namedCaeRoundTripStatus'))\n",
+    "assert numerical_health.getStatus().name() != 'FAILED'\n",
+    "assert process_conformance.isSchemaAndProfileConformant()\n",
+    "assert (package_dir / 'engineering-numerical-health.json').exists()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f038c155",
+   "metadata": {},
+   "source": [
+    "## 6. Stage a controlled CFIHOS 2.0 handover\n",
+    "\n",
+    "This notebook uses explicit EXAMPLE identifiers and intentionally withholds project mapping approval. The exporter therefore writes the deterministic tags, equipment, properties, documents, relationships, manifest, and gap register, but correctly reports INCOMPLETE. Replace every example identifier with the exact controlled Core or Extended RDL identifier and record accountable approval before a project handover."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cb7e1d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CfihosMapping = JClass('neqsim.process.engineering.handover.Cfihos20ReferenceDataMapping')\n",
+    "CfihosEdition = JClass('neqsim.process.engineering.handover.Cfihos20ReferenceDataMapping$Edition')\n",
+    "CfihosExporter = JClass('neqsim.process.engineering.handover.Cfihos20HandoverExporter')\n",
+    "example_rdl = package_dir / 'notebook-example-cfihos-rdl.txt'\n",
+    "example_rdl.write_text('Notebook-only example mapping; not an official CFIHOS RDL delivery.\\n', encoding='utf-8')\n",
+    "mapping_builder = CfihosMapping.builder(CfihosEdition.CORE).verifiedSource('urn:neqsim:notebook:example-rdl', Paths.get(str(example_rdl)))\n",
+    "for node in compiled.getEngineeringGraph().getNodes().values():\n",
+    "    kind = str(node.getKind().name())\n",
+    "    if kind in ('EQUIPMENT', 'LINE', 'INSTRUMENT', 'BOUNDARY'):\n",
+    "        equipment_class = 'EXAMPLE-EQUIPMENT-CLASS' if kind == 'EQUIPMENT' else None\n",
+    "        mapping_builder.mapNode(node.getId(), 'EXAMPLE-TAG-CLASS-' + kind, equipment_class)\n",
+    "    elif kind == 'DOCUMENT':\n",
+    "        mapping_builder.mapDocument(node.getExternalKey(), 'EXAMPLE-DOCUMENT-TYPE')\n",
+    "cfihos_mapping = mapping_builder.build()\n",
+    "cfihos_dir = package_dir / 'cfihos-20-staging'\n",
+    "shutil.rmtree(cfihos_dir, ignore_errors=True)\n",
+    "cfihos = CfihosExporter.export(compiled.getEngineeringGraph(), cfihos_mapping, Paths.get(str(cfihos_dir)))\n",
+    "print('CFIHOS staging status:', cfihos.getReport().getStatus().name())\n",
+    "print('Manifest:', cfihos.getManifestFile())\n",
+    "print('Gap register:', cfihos.getUnmappedFile())\n",
+    "assert cfihos.getReport().getStatus().name() == 'INCOMPLETE'\n",
+    "assert (cfihos_dir / 'cfihos-20-manifest.json').exists()\n",
+    "assert (cfihos_dir / 'cfihos-tags.csv').exists()\n",
+    "assert (cfihos_dir / 'cfihos-unmapped.csv').exists()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "691e48ac",
+   "metadata": {},
+   "source": [
+    "The staging CSVs are a NeqSim neutral profile, not a Principal bulk-loader template and not a CFIHOS conformance certificate. The Principal remains responsible for contractual data requirements, approved mappings, target-system transformation, validation, load receipts, and final information acceptance."
    ]
   }
  ],

--- a/src/main/java/neqsim/process/engineering/handover/Cfihos20HandoverExporter.java
+++ b/src/main/java/neqsim/process/engineering/handover/Cfihos20HandoverExporter.java
@@ -1,0 +1,375 @@
+package neqsim.process.engineering.handover;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import neqsim.process.engineering.handover.Cfihos20HandoverReport.Finding;
+import neqsim.process.engineering.handover.Cfihos20ReferenceDataMapping.NodeClassification;
+import neqsim.process.engineering.handover.Cfihos20ReferenceDataMapping.PropertyDefinition;
+import neqsim.process.engineering.model.EngineeringEdge;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringNode;
+
+/**
+ * Exports a deterministic, auditable staging package for project-controlled CFIHOS 2.0 transformation.
+ *
+ * <p>
+ * The emitted CSVs are a NeqSim staging profile, not an official Principal bulk-loader template. Exact target-system
+ * transformation and CFIHOS acceptance remain outside the exporter.
+ */
+public final class Cfihos20HandoverExporter {
+  private static final Gson GSON = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
+  private static final String TAGS = "cfihos-tags.csv";
+  private static final String EQUIPMENT = "cfihos-equipment.csv";
+  private static final String PROPERTIES = "cfihos-properties.csv";
+  private static final String DOCUMENTS = "cfihos-documents.csv";
+  private static final String RELATIONSHIPS = "cfihos-relationships.csv";
+  private static final String UNMAPPED = "cfihos-unmapped.csv";
+  private static final String ASSESSMENT = "cfihos-20-assessment.json";
+  private static final String MANIFEST = "cfihos-20-manifest.json";
+
+  private Cfihos20HandoverExporter() {
+  }
+
+  /** Files and in-memory readiness evidence produced by one export. */
+  public static final class Result {
+    private final Path outputDirectory;
+    private final Path manifestFile;
+    private final Path assessmentFile;
+    private final Path unmappedFile;
+    private final Cfihos20HandoverReport report;
+
+    Result(Path outputDirectory, Path manifestFile, Path assessmentFile, Path unmappedFile,
+        Cfihos20HandoverReport report) {
+      this.outputDirectory = outputDirectory;
+      this.manifestFile = manifestFile;
+      this.assessmentFile = assessmentFile;
+      this.unmappedFile = unmappedFile;
+      this.report = report;
+    }
+
+    public Path getOutputDirectory() {
+      return outputDirectory;
+    }
+
+    public Path getManifestFile() {
+      return manifestFile;
+    }
+
+    public Path getAssessmentFile() {
+      return assessmentFile;
+    }
+
+    public Path getUnmappedFile() {
+      return unmappedFile;
+    }
+
+    public Cfihos20HandoverReport getReport() {
+      return report;
+    }
+  }
+
+  /** Creates the complete staging package and a fail-closed readiness assessment. */
+  public static Result export(EngineeringGraph graph, Cfihos20ReferenceDataMapping mapping, Path outputDirectory)
+      throws IOException {
+    if (graph == null) {
+      throw new IllegalArgumentException("graph must not be null");
+    }
+    if (mapping == null) {
+      throw new IllegalArgumentException("mapping must not be null");
+    }
+    if (outputDirectory == null) {
+      throw new IllegalArgumentException("outputDirectory must not be null");
+    }
+    Files.createDirectories(outputDirectory);
+
+    Rows rows = buildRows(graph, mapping);
+    LinkedHashMap<String, Path> csvFiles = new LinkedHashMap<String, Path>();
+    csvFiles.put(TAGS, writeCsv(outputDirectory.resolve(TAGS), Arrays.asList("tag_id", "tag_name", "tag_description",
+        "cfihos_tag_class_id", "source_node_id", "project_id", "revision"), rows.tags));
+    csvFiles.put(EQUIPMENT, writeCsv(outputDirectory.resolve(EQUIPMENT), Arrays.asList("equipment_id", "equipment_name",
+        "cfihos_equipment_class_id", "realizes_tag_id", "source_node_id"), rows.equipment));
+    csvFiles.put(PROPERTIES, writeCsv(outputDirectory.resolve(PROPERTIES),
+        Arrays.asList("owner_id", "cfihos_property_id", "value", "cfihos_uom_id", "source_property"), rows.properties));
+    csvFiles.put(DOCUMENTS, writeCsv(outputDirectory.resolve(DOCUMENTS),
+        Arrays.asList("document_id", "document_title", "cfihos_document_type_id", "file_reference", "source_node_id"),
+        rows.documents));
+    csvFiles.put(RELATIONSHIPS, writeCsv(outputDirectory.resolve(RELATIONSHIPS),
+        Arrays.asList("relationship_id", "source_id", "target_id", "relationship_type", "role"), rows.relationships));
+    csvFiles.put(UNMAPPED, writeCsv(outputDirectory.resolve(UNMAPPED),
+        Arrays.asList("source_node_id", "source_kind", "source_item", "gap_type", "required_action"), rows.unmapped));
+
+    Map<String, String> csvDigests = digests(csvFiles);
+    Map<String, Integer> counts = new LinkedHashMap<String, Integer>();
+    counts.put("tags", Integer.valueOf(rows.tags.size()));
+    counts.put("equipment", Integer.valueOf(rows.equipment.size()));
+    counts.put("properties", Integer.valueOf(rows.properties.size()));
+    counts.put("documents", Integer.valueOf(rows.documents.size()));
+    counts.put("relationships", Integer.valueOf(rows.relationships.size()));
+    counts.put("unmapped", Integer.valueOf(rows.unmapped.size()));
+    addMappingControlFindings(mapping, rows.findings);
+    if (rows.tags.isEmpty()) {
+      rows.findings.add(
+          blocker("NO_HANDOVER_TAGS", graph.getProjectId(), "No tag-like engineering nodes were available for handover",
+              "Build the canonical engineering graph and classify its tag-bearing nodes"));
+    }
+
+    Cfihos20HandoverReport report = new Cfihos20HandoverReport(graph.getProjectId(), graph.getRevision(), mapping,
+        counts, rows.findings, csvDigests);
+    Path assessmentFile = outputDirectory.resolve(ASSESSMENT);
+    write(assessmentFile, report.toJson());
+
+    LinkedHashMap<String, Path> manifestedFiles = new LinkedHashMap<String, Path>(csvFiles);
+    manifestedFiles.put(ASSESSMENT, assessmentFile);
+    Path manifestFile = outputDirectory.resolve(MANIFEST);
+    write(manifestFile, manifest(graph, mapping, report, digests(manifestedFiles)));
+    return new Result(outputDirectory, manifestFile, assessmentFile, outputDirectory.resolve(UNMAPPED), report);
+  }
+
+  private static Rows buildRows(EngineeringGraph graph, Cfihos20ReferenceDataMapping mapping) {
+    Rows rows = new Rows();
+    Map<String, String> transferredIds = new LinkedHashMap<String, String>();
+    List<EngineeringNode> nodes = new ArrayList<EngineeringNode>(graph.getNodes().values());
+    Collections.sort(nodes, Comparator.comparing(EngineeringNode::getId));
+    for (EngineeringNode node : nodes) {
+      if (isTagKind(node.getKind())) {
+        addTag(graph, mapping, node, rows, transferredIds);
+      } else if (node.getKind() == EngineeringNode.Kind.DOCUMENT) {
+        addDocument(mapping, node, rows, transferredIds);
+      }
+    }
+    addGraphRelationships(graph, transferredIds, rows);
+    Collections.sort(rows.relationships, Comparator.comparing(values -> values.get(0)));
+    return rows;
+  }
+
+  private static void addTag(EngineeringGraph graph, Cfihos20ReferenceDataMapping mapping, EngineeringNode node,
+      Rows rows, Map<String, String> transferredIds) {
+    NodeClassification classification = mapping.getNodeClassification(node.getId());
+    if (classification == null) {
+      rows.unmapped.add(gap(node, node.getExternalKey(), "MISSING_NODE_CLASSIFICATION",
+          "Map the canonical node to an exact CFIHOS 2.0 tag class id"));
+      rows.findings.add(blocker("MISSING_NODE_CLASSIFICATION", node.getId(),
+          "No CFIHOS tag class is mapped for " + node.getExternalKey(),
+          "Approve an exact RDL tag-class mapping for this node"));
+      return;
+    }
+    String transferId = node.getId();
+    transferredIds.put(node.getId(), transferId);
+    rows.tags.add(Arrays.asList(transferId, node.getExternalKey(), node.getLabel(), classification.getTagClassId(),
+        node.getId(), graph.getProjectId(), graph.getRevision()));
+
+    if (node.getKind() == EngineeringNode.Kind.EQUIPMENT) {
+      if (classification.getEquipmentClassId().isEmpty()) {
+        rows.unmapped.add(gap(node, node.getExternalKey(), "MISSING_EQUIPMENT_CLASSIFICATION",
+            "Map the physical equipment to an exact CFIHOS 2.0 equipment class id"));
+        rows.findings.add(
+            blocker("MISSING_EQUIPMENT_CLASSIFICATION", node.getId(), "Equipment node has no CFIHOS equipment class",
+                "Approve an exact RDL equipment-class mapping for this node"));
+      } else {
+        String equipmentId = "physical:" + node.getId();
+        rows.equipment.add(Arrays.asList(equipmentId, node.getLabel(), classification.getEquipmentClassId(), transferId,
+            node.getId()));
+        rows.relationships.add(
+            Arrays.asList("realizes:" + node.getId(), equipmentId, transferId, "EQUIPMENT_REALIZES_TAG", "realizes"));
+      }
+    }
+    addProperties(mapping, node, transferId, rows);
+  }
+
+  private static void addProperties(Cfihos20ReferenceDataMapping mapping, EngineeringNode node, String transferId,
+      Rows rows) {
+    for (Map.Entry<String, Object> property : new TreeMap<String, Object>(node.getProperties()).entrySet()) {
+      if (!isScalar(property.getValue())) {
+        continue;
+      }
+      PropertyDefinition definition = mapping.getPropertyDefinition(property.getKey());
+      if (definition == null) {
+        rows.unmapped.add(gap(node, property.getKey(), "UNMAPPED_OPTIONAL_PROPERTY",
+            "Map this property if it is required by the project CFIHOS data requirements"));
+        rows.findings.add(warning("UNMAPPED_OPTIONAL_PROPERTY", node.getId(),
+            "Canonical property " + property.getKey() + " was not transferred",
+            "Confirm it is out of scope or map its CFIHOS property and UOM ids"));
+        continue;
+      }
+      if (property.getValue() instanceof Number && definition.getUnitOfMeasureId().isEmpty()) {
+        rows.unmapped.add(gap(node, property.getKey(), "MISSING_NUMERIC_PROPERTY_UOM",
+            "Map the numeric property to an exact CFIHOS 2.0 unit-of-measure id"));
+        rows.findings.add(blocker("MISSING_NUMERIC_PROPERTY_UOM", node.getId(),
+            "Numeric property " + property.getKey() + " has no CFIHOS UOM mapping",
+            "Approve an exact RDL unit-of-measure mapping for this property"));
+        continue;
+      }
+      rows.properties.add(Arrays.asList(transferId, definition.getPropertyId(), String.valueOf(property.getValue()),
+          definition.getUnitOfMeasureId(), property.getKey()));
+    }
+  }
+
+  private static void addDocument(Cfihos20ReferenceDataMapping mapping, EngineeringNode node, Rows rows,
+      Map<String, String> transferredIds) {
+    String documentTypeId = mapping.getDocumentTypeId(node.getExternalKey());
+    if (documentTypeId == null) {
+      rows.unmapped.add(gap(node, node.getExternalKey(), "MISSING_DOCUMENT_TYPE",
+          "Map the document to an exact CFIHOS 2.0 document-type id"));
+      rows.findings.add(blocker("MISSING_DOCUMENT_TYPE", node.getId(),
+          "No CFIHOS document type is mapped for " + node.getExternalKey(),
+          "Approve an exact RDL document-type mapping or remove the document from handover scope"));
+      return;
+    }
+    String fileReference = node.getProperties().containsKey("file") ? String.valueOf(node.getProperties().get("file"))
+        : node.getExternalKey();
+    rows.documents.add(Arrays.asList(node.getId(), node.getLabel(), documentTypeId, fileReference, node.getId()));
+    transferredIds.put(node.getId(), node.getId());
+  }
+
+  private static void addGraphRelationships(EngineeringGraph graph, Map<String, String> transferredIds, Rows rows) {
+    List<EngineeringEdge> edges = new ArrayList<EngineeringEdge>(graph.getEdges().values());
+    Collections.sort(edges, Comparator.comparing(EngineeringEdge::getId));
+    for (EngineeringEdge edge : edges) {
+      String sourceId = transferredIds.get(edge.getSourceId());
+      String targetId = transferredIds.get(edge.getTargetId());
+      if (sourceId != null && targetId != null) {
+        rows.relationships.add(Arrays.asList(edge.getId(), sourceId, targetId, edge.getKind().name(), edge.getRole()));
+      }
+    }
+  }
+
+  private static void addMappingControlFindings(Cfihos20ReferenceDataMapping mapping, List<Finding> findings) {
+    if (!mapping.isSourceDigestVerified()) {
+      findings.add(blocker("RDL_DIGEST_NOT_VERIFIED", mapping.getSourceUri(),
+          "The configured RDL digest was declared but not calculated from controlled bytes",
+          "Use verifiedSource with the exact project RDL delivery"));
+    }
+    if (!mapping.isApprovedForProject()) {
+      findings.add(blocker("MAPPING_NOT_PROJECT_APPROVED", mapping.getMappingRevision(),
+          "The RDL mapping revision has not been approved for this project",
+          "Record approval by the accountable project information-management authority"));
+    }
+  }
+
+  private static String manifest(EngineeringGraph graph, Cfihos20ReferenceDataMapping mapping,
+      Cfihos20HandoverReport report, Map<String, String> digests) {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", "neqsim_cfihos_20_staging_manifest.v1");
+    result.put("packageProfile", "NEQSIM_CONTROLLED_CFIHOS_2_0_STAGING_V1");
+    result.put("projectId", graph.getProjectId());
+    result.put("revision", graph.getRevision());
+    result.put("cfihosVersion", "2.0");
+    result.put("status", report.getStatus().name());
+    result.put("referenceDataMapping", mapping.toMap());
+    List<Map<String, Object>> files = new ArrayList<Map<String, Object>>();
+    for (Map.Entry<String, String> item : digests.entrySet()) {
+      Map<String, Object> file = new LinkedHashMap<String, Object>();
+      file.put("file", item.getKey());
+      file.put("sha256", item.getValue());
+      file.put("mediaType", item.getKey().endsWith(".csv") ? "text/csv" : "application/json");
+      files.add(file);
+    }
+    result.put("files", files);
+    result.put("cfihosConformanceClaim", Boolean.FALSE);
+    result.put("principalAcceptanceRequired", Boolean.TRUE);
+    result.put("targetSystemTransformationRequired", Boolean.TRUE);
+    return GSON.toJson(result);
+  }
+
+  private static Path writeCsv(Path file, List<String> headers, List<List<String>> rows) throws IOException {
+    StringBuilder content = new StringBuilder();
+    appendCsvRow(content, headers);
+    for (List<String> row : rows) {
+      appendCsvRow(content, row);
+    }
+    write(file, content.toString());
+    return file;
+  }
+
+  private static void appendCsvRow(StringBuilder content, List<String> values) {
+    for (int index = 0; index < values.size(); index++) {
+      if (index > 0) {
+        content.append(',');
+      }
+      content.append(csv(values.get(index)));
+    }
+    content.append('\n');
+  }
+
+  private static String csv(String value) {
+    String text = value == null ? "" : value;
+    if (text.indexOf(',') >= 0 || text.indexOf('"') >= 0 || text.indexOf('\n') >= 0 || text.indexOf('\r') >= 0) {
+      return "\"" + text.replace("\"", "\"\"") + "\"";
+    }
+    return text;
+  }
+
+  private static void write(Path file, String content) throws IOException {
+    Files.write(file, content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static Map<String, String> digests(Map<String, Path> files) throws IOException {
+    Map<String, String> result = new LinkedHashMap<String, String>();
+    for (Map.Entry<String, Path> file : files.entrySet()) {
+      result.put(file.getKey(), digest(Files.readAllBytes(file.getValue())));
+    }
+    return result;
+  }
+
+  private static String digest(byte[] content) {
+    try {
+      byte[] hash = MessageDigest.getInstance("SHA-256").digest(content);
+      StringBuilder result = new StringBuilder();
+      for (byte value : hash) {
+        result.append(String.format("%02x", value & 0xff));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is not available", ex);
+    }
+  }
+
+  private static boolean isTagKind(EngineeringNode.Kind kind) {
+    return kind == EngineeringNode.Kind.EQUIPMENT || kind == EngineeringNode.Kind.LINE
+        || kind == EngineeringNode.Kind.INSTRUMENT || kind == EngineeringNode.Kind.BOUNDARY;
+  }
+
+  private static boolean isScalar(Object value) {
+    return value instanceof String || value instanceof Number || value instanceof Boolean;
+  }
+
+  private static List<String> gap(EngineeringNode node, String item, String type, String action) {
+    return Arrays.asList(node.getId(), node.getKind().name(), item, type, action);
+  }
+
+  private static Finding blocker(String code, String sourceId, String message, String action) {
+    return new Finding("BLOCKER", code, safe(sourceId), message, action);
+  }
+
+  private static Finding warning(String code, String sourceId, String message, String action) {
+    return new Finding("WARNING", code, safe(sourceId), message, action);
+  }
+
+  private static String safe(String value) {
+    return value == null ? "" : value;
+  }
+
+  private static final class Rows {
+    private final List<List<String>> tags = new ArrayList<List<String>>();
+    private final List<List<String>> equipment = new ArrayList<List<String>>();
+    private final List<List<String>> properties = new ArrayList<List<String>>();
+    private final List<List<String>> documents = new ArrayList<List<String>>();
+    private final List<List<String>> relationships = new ArrayList<List<String>>();
+    private final List<List<String>> unmapped = new ArrayList<List<String>>();
+    private final List<Finding> findings = new ArrayList<Finding>();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/handover/Cfihos20HandoverReport.java
+++ b/src/main/java/neqsim/process/engineering/handover/Cfihos20HandoverReport.java
@@ -1,0 +1,119 @@
+package neqsim.process.engineering.handover;
+
+import com.google.gson.GsonBuilder;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Fail-closed assessment of a NeqSim staging package prepared for CFIHOS 2.0 transformation. */
+public final class Cfihos20HandoverReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Readiness decision for the staging package. */
+  public enum Status {
+    READY_FOR_PRINCIPAL_TRANSFORMATION, INCOMPLETE
+  }
+
+  /** One actionable mapping or package finding. */
+  public static final class Finding implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String severity;
+    private final String code;
+    private final String sourceId;
+    private final String message;
+    private final String requiredAction;
+
+    Finding(String severity, String code, String sourceId, String message, String requiredAction) {
+      this.severity = severity;
+      this.code = code;
+      this.sourceId = sourceId;
+      this.message = message;
+      this.requiredAction = requiredAction;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity);
+      result.put("code", code);
+      result.put("sourceId", sourceId);
+      result.put("message", message);
+      result.put("requiredAction", requiredAction);
+      return result;
+    }
+  }
+
+  private final String projectId;
+  private final String revision;
+  private final Cfihos20ReferenceDataMapping referenceDataMapping;
+  private final Map<String, Integer> recordCounts;
+  private final List<Finding> findings;
+  private final Map<String, String> fileDigests;
+  private final Status status;
+
+  Cfihos20HandoverReport(String projectId, String revision, Cfihos20ReferenceDataMapping referenceDataMapping,
+      Map<String, Integer> recordCounts, List<Finding> findings, Map<String, String> fileDigests) {
+    this.projectId = projectId;
+    this.revision = revision;
+    this.referenceDataMapping = referenceDataMapping;
+    this.recordCounts = Collections.unmodifiableMap(new LinkedHashMap<String, Integer>(recordCounts));
+    this.findings = Collections.unmodifiableList(new ArrayList<Finding>(findings));
+    this.fileDigests = Collections.unmodifiableMap(new LinkedHashMap<String, String>(fileDigests));
+    status = hasBlockers(findings) ? Status.INCOMPLETE : Status.READY_FOR_PRINCIPAL_TRANSFORMATION;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public boolean isReadyForPrincipalTransformation() {
+    return status == Status.READY_FOR_PRINCIPAL_TRANSFORMATION;
+  }
+
+  public List<Finding> getFindings() {
+    return findings;
+  }
+
+  public Map<String, String> getFileDigests() {
+    return fileDigests;
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", "neqsim_cfihos_20_handover_assessment.v1");
+    result.put("projectId", projectId);
+    result.put("revision", revision);
+    result.put("cfihosVersion", "2.0");
+    result.put("status", status.name());
+    result.put("readyForPrincipalTransformation", Boolean.valueOf(isReadyForPrincipalTransformation()));
+    result.put("referenceDataMapping", referenceDataMapping.toMap());
+    result.put("recordCounts", recordCounts);
+    List<Map<String, Object>> findingMaps = new ArrayList<Map<String, Object>>();
+    for (Finding finding : findings) {
+      findingMaps.add(finding.toMap());
+    }
+    result.put("findings", findingMaps);
+    result.put("fileDigests", fileDigests);
+    result.put("cfihosConformanceClaim", Boolean.FALSE);
+    result.put("principalAcceptanceRequired", Boolean.TRUE);
+    result.put("targetSystemTransformationRequired", Boolean.TRUE);
+    result.put("governance",
+        "NeqSim prepares a controlled staging package; the Principal owns CFIHOS acceptance, contract requirements and target-system loading");
+    return result;
+  }
+
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+  }
+
+  private static boolean hasBlockers(List<Finding> findings) {
+    for (Finding finding : findings) {
+      if ("BLOCKER".equals(finding.severity)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/handover/Cfihos20ReferenceDataMapping.java
+++ b/src/main/java/neqsim/process/engineering/handover/Cfihos20ReferenceDataMapping.java
@@ -1,0 +1,286 @@
+package neqsim.process.engineering.handover;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Project-controlled mapping from NeqSim engineering identities to CFIHOS 2.0 reference-data identifiers.
+ *
+ * <p>
+ * The class deliberately does not ship or invent CFIHOS RDL identifiers. A project information manager must load exact
+ * identifiers from the controlled Core or Extended RDL and approve the mapping revision used for a handover.
+ */
+public final class Cfihos20ReferenceDataMapping implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** CFIHOS 2.0 Reference Data Library delivery used by the project. */
+  public enum Edition {
+    CORE, EXTENDED
+  }
+
+  /** Tag and optional physical-equipment classification for one canonical graph node. */
+  public static final class NodeClassification implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String tagClassId;
+    private final String equipmentClassId;
+
+    private NodeClassification(String tagClassId, String equipmentClassId) {
+      this.tagClassId = requireText(tagClassId, "tagClassId");
+      this.equipmentClassId = optionalText(equipmentClassId);
+    }
+
+    public String getTagClassId() {
+      return tagClassId;
+    }
+
+    public String getEquipmentClassId() {
+      return equipmentClassId;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("tagClassId", tagClassId);
+      result.put("equipmentClassId", equipmentClassId);
+      return result;
+    }
+  }
+
+  /** CFIHOS property and unit-of-measure identifiers for one canonical property name. */
+  public static final class PropertyDefinition implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String propertyId;
+    private final String unitOfMeasureId;
+
+    private PropertyDefinition(String propertyId, String unitOfMeasureId) {
+      this.propertyId = requireText(propertyId, "propertyId");
+      this.unitOfMeasureId = optionalText(unitOfMeasureId);
+    }
+
+    public String getPropertyId() {
+      return propertyId;
+    }
+
+    public String getUnitOfMeasureId() {
+      return unitOfMeasureId;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("propertyId", propertyId);
+      result.put("unitOfMeasureId", unitOfMeasureId);
+      return result;
+    }
+  }
+
+  private final Edition edition;
+  private final String sourceUri;
+  private final String sourceSha256;
+  private final boolean sourceDigestVerified;
+  private final String mappingAuthority;
+  private final String mappingRevision;
+  private final boolean approvedForProject;
+  private final Map<String, NodeClassification> nodeClassifications;
+  private final Map<String, PropertyDefinition> propertyDefinitions;
+  private final Map<String, String> documentTypeIds;
+
+  private Cfihos20ReferenceDataMapping(Builder builder) {
+    edition = builder.edition;
+    sourceUri = builder.sourceUri;
+    sourceSha256 = builder.sourceSha256;
+    sourceDigestVerified = builder.sourceDigestVerified;
+    mappingAuthority = builder.mappingAuthority;
+    mappingRevision = builder.mappingRevision;
+    approvedForProject = builder.approvedForProject;
+    nodeClassifications = Collections
+        .unmodifiableMap(new LinkedHashMap<String, NodeClassification>(builder.nodeClassifications));
+    propertyDefinitions = Collections
+        .unmodifiableMap(new LinkedHashMap<String, PropertyDefinition>(builder.propertyDefinitions));
+    documentTypeIds = Collections.unmodifiableMap(new LinkedHashMap<String, String>(builder.documentTypeIds));
+  }
+
+  public static Builder builder(Edition edition) {
+    return new Builder(edition);
+  }
+
+  public Edition getEdition() {
+    return edition;
+  }
+
+  public String getSourceUri() {
+    return sourceUri;
+  }
+
+  public String getSourceSha256() {
+    return sourceSha256;
+  }
+
+  public boolean isSourceDigestVerified() {
+    return sourceDigestVerified;
+  }
+
+  public String getMappingAuthority() {
+    return mappingAuthority;
+  }
+
+  public String getMappingRevision() {
+    return mappingRevision;
+  }
+
+  public boolean isApprovedForProject() {
+    return approvedForProject;
+  }
+
+  public NodeClassification getNodeClassification(String nodeId) {
+    return nodeClassifications.get(nodeId);
+  }
+
+  public PropertyDefinition getPropertyDefinition(String propertyName) {
+    return propertyDefinitions.get(propertyName);
+  }
+
+  public String getDocumentTypeId(String externalKey) {
+    return documentTypeIds.get(externalKey);
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("cfihosVersion", "2.0");
+    result.put("rdlEdition", edition.name());
+    result.put("rdlSourceUri", sourceUri);
+    result.put("rdlSourceSha256", sourceSha256);
+    result.put("rdlSourceDigestVerified", Boolean.valueOf(sourceDigestVerified));
+    result.put("mappingAuthority", mappingAuthority);
+    result.put("mappingRevision", mappingRevision);
+    result.put("approvedForProject", Boolean.valueOf(approvedForProject));
+    Map<String, Object> classifications = new LinkedHashMap<String, Object>();
+    for (Map.Entry<String, NodeClassification> item : new TreeMap<String, NodeClassification>(nodeClassifications)
+        .entrySet()) {
+      classifications.put(item.getKey(), item.getValue().toMap());
+    }
+    result.put("nodeClassifications", classifications);
+    Map<String, Object> properties = new LinkedHashMap<String, Object>();
+    for (Map.Entry<String, PropertyDefinition> item : new TreeMap<String, PropertyDefinition>(propertyDefinitions)
+        .entrySet()) {
+      properties.put(item.getKey(), item.getValue().toMap());
+    }
+    result.put("propertyDefinitions", properties);
+    result.put("documentTypeIds", new TreeMap<String, String>(documentTypeIds));
+    return result;
+  }
+
+  /** Builder for an auditable, project-specific RDL mapping. */
+  public static final class Builder {
+    private final Edition edition;
+    private String sourceUri = "";
+    private String sourceSha256 = "";
+    private boolean sourceDigestVerified;
+    private String mappingAuthority = "";
+    private String mappingRevision = "";
+    private boolean approvedForProject;
+    private final Map<String, NodeClassification> nodeClassifications = new LinkedHashMap<String, NodeClassification>();
+    private final Map<String, PropertyDefinition> propertyDefinitions = new LinkedHashMap<String, PropertyDefinition>();
+    private final Map<String, String> documentTypeIds = new LinkedHashMap<String, String>();
+
+    private Builder(Edition edition) {
+      if (edition == null) {
+        throw new IllegalArgumentException("edition must not be null");
+      }
+      this.edition = edition;
+    }
+
+    /** Records the controlled RDL source and its content digest. */
+    public Builder source(String uri, String sha256) {
+      sourceUri = requireText(uri, "sourceUri");
+      sourceSha256 = requireSha256(sha256);
+      sourceDigestVerified = false;
+      return this;
+    }
+
+    /** Reads a controlled local RDL delivery and records its verified SHA-256 digest. */
+    public Builder verifiedSource(String uri, Path file) throws IOException {
+      if (file == null || !Files.isRegularFile(file)) {
+        throw new IllegalArgumentException("file must identify a regular RDL delivery");
+      }
+      sourceUri = requireText(uri, "sourceUri");
+      sourceSha256 = digest(Files.readAllBytes(file));
+      sourceDigestVerified = true;
+      return this;
+    }
+
+    /** Records approval of this exact mapping revision by the accountable project authority. */
+    public Builder approvedBy(String authority, String revision) {
+      mappingAuthority = requireText(authority, "mappingAuthority");
+      mappingRevision = requireText(revision, "mappingRevision");
+      approvedForProject = true;
+      return this;
+    }
+
+    /** Maps one canonical node id to exact CFIHOS tag and optional equipment class ids. */
+    public Builder mapNode(String nodeId, String tagClassId, String equipmentClassId) {
+      String key = requireText(nodeId, "nodeId");
+      nodeClassifications.put(key, new NodeClassification(tagClassId, equipmentClassId));
+      return this;
+    }
+
+    /** Maps one canonical node property to exact CFIHOS property and, when applicable, UOM ids. */
+    public Builder mapProperty(String propertyName, String propertyId, String unitOfMeasureId) {
+      propertyDefinitions.put(requireText(propertyName, "propertyName"),
+          new PropertyDefinition(propertyId, unitOfMeasureId));
+      return this;
+    }
+
+    /** Maps one canonical document external key to an exact CFIHOS document-type id. */
+    public Builder mapDocument(String externalKey, String documentTypeId) {
+      documentTypeIds.put(requireText(externalKey, "externalKey"), requireText(documentTypeId, "documentTypeId"));
+      return this;
+    }
+
+    public Cfihos20ReferenceDataMapping build() {
+      if (approvedForProject && (sourceUri.isEmpty() || sourceSha256.isEmpty())) {
+        throw new IllegalStateException("Approved mappings require a controlled RDL source and SHA-256");
+      }
+      return new Cfihos20ReferenceDataMapping(this);
+    }
+  }
+
+  private static String optionalText(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private static String requireText(String value, String name) {
+    String result = optionalText(value);
+    if (result.isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return result;
+  }
+
+  private static String requireSha256(String value) {
+    String result = requireText(value, "sha256").toLowerCase();
+    if (!result.matches("[0-9a-f]{64}")) {
+      throw new IllegalArgumentException("sha256 must contain exactly 64 hexadecimal characters");
+    }
+    return result;
+  }
+
+  private static String digest(byte[] content) {
+    try {
+      byte[] hash = MessageDigest.getInstance("SHA-256").digest(content);
+      StringBuilder result = new StringBuilder();
+      for (byte value : hash) {
+        result.append(String.format("%02x", value & 0xff));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is not available", ex);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriter.java
@@ -27,6 +27,7 @@ import neqsim.process.equipment.heatexchanger.Cooler;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
 import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.pipeline.PipeLineInterface;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.splitter.Splitter;
@@ -220,6 +221,9 @@ public final class Dexpi20ProcessModelWriter {
       return "Process/Process.Source";
     }
     if (unit instanceof Expander) {
+      return "Process/Process.TransportingFluids";
+    }
+    if (unit instanceof PipeLineInterface) {
       return "Process/Process.TransportingFluids";
     }
     if (unit instanceof Compressor) {

--- a/src/test/java/neqsim/process/engineering/handover/Cfihos20HandoverExporterTest.java
+++ b/src/test/java/neqsim/process/engineering/handover/Cfihos20HandoverExporterTest.java
@@ -1,0 +1,103 @@
+package neqsim.process.engineering.handover;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import neqsim.process.engineering.handover.Cfihos20ReferenceDataMapping.Edition;
+import neqsim.process.engineering.model.EngineeringEdge;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringIds;
+import neqsim.process.engineering.model.EngineeringNode;
+
+/** Verifies deterministic and fail-closed CFIHOS 2.0 staging handover. */
+class Cfihos20HandoverExporterTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void exportsControlledDeterministicPackage() throws Exception {
+    EngineeringGraph graph = graph();
+    Path rdl = temporaryDirectory.resolve("project-cfihos-rdl.csv");
+    Files.write(rdl, "controlled example RDL bytes\n".getBytes(StandardCharsets.UTF_8));
+    Cfihos20ReferenceDataMapping mapping = Cfihos20ReferenceDataMapping.builder(Edition.CORE)
+        .verifiedSource("urn:project:cfihos-rdl:2.0:rev-a", rdl).approvedBy("Project Information Manager", "MAP-A")
+        .mapNode("equipment:20-vg-001", "CFIHOS-TAG-CLASS-ID", "CFIHOS-EQUIPMENT-CLASS-ID")
+        .mapProperty("designPressure", "CFIHOS-PROPERTY-ID", "CFIHOS-UOM-ID")
+        .mapProperty("service", "CFIHOS-SERVICE-PROPERTY-ID", null)
+        .mapDocument("20-VG-001-datasheet.pdf", "CFIHOS-DOCUMENT-TYPE-ID").build();
+
+    Cfihos20HandoverExporter.Result first = Cfihos20HandoverExporter.export(graph, mapping,
+        temporaryDirectory.resolve("first"));
+    Cfihos20HandoverExporter.Result second = Cfihos20HandoverExporter.export(graph, mapping,
+        temporaryDirectory.resolve("second"));
+
+    assertTrue(first.getReport().isReadyForPrincipalTransformation());
+    assertEquals(first.getReport().getFileDigests(), second.getReport().getFileDigests());
+    assertTrue(Files.isRegularFile(first.getManifestFile()));
+    assertTrue(Files.isRegularFile(first.getAssessmentFile()));
+    assertTrue(read(first.getManifestFile()).contains("\"cfihosConformanceClaim\": false"));
+    assertTrue(read(first.getAssessmentFile()).contains("READY_FOR_PRINCIPAL_TRANSFORMATION"));
+    assertTrue(read(temporaryDirectory.resolve("first/cfihos-tags.csv")).contains("\"Separator, inlet\""));
+    assertTrue(read(temporaryDirectory.resolve("first/cfihos-properties.csv")).contains("\"gas, condensate\""));
+    assertTrue(read(temporaryDirectory.resolve("first/cfihos-relationships.csv")).contains("EQUIPMENT_REALIZES_TAG"));
+    assertEquals("source_node_id,source_kind,source_item,gap_type,required_action\n", read(first.getUnmappedFile()));
+  }
+
+  @Test
+  void missingMappingsAndUnverifiedRdlBlockReadiness() throws Exception {
+    Cfihos20ReferenceDataMapping mapping = Cfihos20ReferenceDataMapping.builder(Edition.EXTENDED)
+        .source("urn:unverified:rdl", repeat("0", 64)).build();
+
+    Cfihos20HandoverExporter.Result result = Cfihos20HandoverExporter.export(graph(), mapping,
+        temporaryDirectory.resolve("incomplete"));
+
+    assertFalse(result.getReport().isReadyForPrincipalTransformation());
+    String assessment = read(result.getAssessmentFile());
+    assertTrue(assessment.contains("RDL_DIGEST_NOT_VERIFIED"));
+    assertTrue(assessment.contains("MAPPING_NOT_PROJECT_APPROVED"));
+    assertTrue(assessment.contains("MISSING_NODE_CLASSIFICATION"));
+    assertTrue(assessment.contains("MISSING_DOCUMENT_TYPE"));
+  }
+
+  @Test
+  void approvedMappingsRequireControlledRdlEvidence() {
+    assertThrows(IllegalStateException.class,
+        () -> Cfihos20ReferenceDataMapping.builder(Edition.CORE).approvedBy("Authority", "A").build());
+    assertThrows(IllegalArgumentException.class,
+        () -> Cfihos20ReferenceDataMapping.builder(Edition.CORE).source("urn:rdl", "not-a-digest"));
+  }
+
+  private static EngineeringGraph graph() {
+    EngineeringGraph graph = new EngineeringGraph("PROJECT-20", "A");
+    EngineeringNode project = new EngineeringNode("project:project-20", EngineeringNode.Kind.PROJECT, "PROJECT-20",
+        "Project 20");
+    EngineeringNode equipment = new EngineeringNode("equipment:20-vg-001", EngineeringNode.Kind.EQUIPMENT, "20-VG-001",
+        "Separator, inlet").putProperty("designPressure", Double.valueOf(80.0))
+        .putProperty("service", "gas, condensate");
+    EngineeringNode document = new EngineeringNode("document:20-vg-001-datasheet-pdf", EngineeringNode.Kind.DOCUMENT,
+        "20-VG-001-datasheet.pdf", "Separator datasheet").putProperty("file", "documents/20-VG-001-datasheet.pdf");
+    graph.addNode(project).addNode(equipment).addNode(document);
+    graph.addEdge(new EngineeringEdge(
+        EngineeringIds.edgeId(EngineeringEdge.Kind.REFERENCES, equipment.getId(), document.getId(), "datasheet"),
+        equipment.getId(), document.getId(), EngineeringEdge.Kind.REFERENCES, "datasheet"));
+    return graph;
+  }
+
+  private static String read(Path file) throws Exception {
+    return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+  }
+
+  private static String repeat(String value, int count) {
+    StringBuilder result = new StringBuilder();
+    for (int index = 0; index < count; index++) {
+      result.append(value);
+    }
+    return result.toString();
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.pipeline.AdiabaticPipe;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
@@ -31,6 +32,7 @@ class Dexpi20ProcessModelWriterTest {
     assertTrue(xml.contains("type=\"Process/ProcessModel\""));
     assertTrue(xml.contains("type=\"Process/Process.Compressing\""));
     assertTrue(xml.contains("type=\"Process/Process.Pumping\""));
+    assertTrue(xml.contains("type=\"Process/Process.TransportingFluids\""));
     assertTrue(xml.contains("property=\"ConnectorReference\""));
     assertTrue(xml.contains("MassFlowRateUnit.KilogramPerHour"));
     assertTrue(report.toJson().contains("NOT_A_DEXPI_EV_CERTIFICATE"));
@@ -84,12 +86,14 @@ class Dexpi20ProcessModelWriterTest {
     feed.setFlowRate(1000.0, "kg/hr");
     Separator separator = new Separator("10-VA-001", feed);
     Compressor compressor = new Compressor("10-KA-001", separator.getGasOutStream());
+    AdiabaticPipe pipeline = new AdiabaticPipe("10-PL-001", compressor.getOutletStream());
     Pump pump = new Pump("10-PA-001", separator.getLiquidOutStream());
     ProcessSystem process = new ProcessSystem();
     process.setName("DEXPI 2.0 Process exchange");
     process.add(feed);
     process.add(separator);
     process.add(compressor);
+    process.add(pipeline);
     process.add(pump);
     return process;
   }


### PR DESCRIPTION
## Summary
- add a deterministic NeqSim staging profile for CFIHOS 2.0 tags, physical equipment, properties, documents, and graph relationships
- require exact project-owned Core or Extended RDL identifiers, verified RDL bytes, mapping revision, and accountable mapping approval
- emit a complete gap register, per-file SHA-256 digests, manifest, and fail-closed readiness assessment
- state explicitly that the package is not a CFIHOS conformance claim or Principal bulk-loader template
- extend native DEXPI Process mapping to pipelines and add permanent execution coverage for the process-to-engineering notebook
- update the example notebook to exercise numerical health, native DEXPI 2.0 Process conformance, and safe CFIHOS staging

## Governance boundary
NeqSim prepares a controlled neutral staging package. The Principal remains responsible for contractual information requirements, semantic mapping approval, transformation to the contracted CFIHOS templates and target system, load validation, receipts, and final information acceptance.

The notebook deliberately uses EXAMPLE identifiers and omits project mapping approval, so its CFIHOS assessment remains `INCOMPLETE` rather than presenting synthetic data as release evidence.

## Validation
- `git diff --check`, Spotless, focused CFIHOS/DEXPI/numerical-health tests, and notebook JSON validation: passed
- permanent process-to-engineering workflow built NeqSim, executed every notebook cell, verified numerical-health, native DEXPI Process, and CFIHOS outputs, and uploaded the package: passed
- complete offshore engineering notebook, skills lint, and PaperLab gate: passed
- temporary validation workflow removed; the exact merge candidate passed the permanent regression workflow

## Stack
PR4 of 4. This PR targets #2494 and should merge after it.

## References
- https://www.jip36-cfihos.org/cfihos-standards/
- https://www.jip36-cfihos.org/how-it-works/