### PR TITLE
Make all NeqSim documentation searchable

### DIFF
--- a/.github/workflows/documentation-search.yml
+++ b/.github/workflows/documentation-search.yml
@@ -1,0 +1,43 @@
+name: Documentation search coverage
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+      - "devtools/check_documentation_search.py"
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/documentation-search.yml"
+
+concurrency:
+  group: documentation-search-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: Build and verify complete search index
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+      - name: Check search source contracts
+        run: python devtools/check_documentation_search.py
+      - name: Build documentation
+        run: bundle exec jekyll build --source docs --destination _site
+      - name: Verify generated search coverage
+        run: python devtools/check_documentation_search.py --site _site
+      - name: Check search JavaScript syntax
+        run: node --check docs/assets/js/search.js

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,14 @@ repos:
         pass_filenames: false
         stages: [pre-push]
         verbose: false
+
+  - repo: local
+    hooks:
+      - id: documentation-search-check
+        name: Documentation Search Coverage
+        entry: python devtools/check_documentation_search.py
+        language: system
+        files: ^(docs/|devtools/check_documentation_search\.py|\.github/workflows/documentation-search\.yml|\.pre-commit-config\.yaml)
+        pass_filenames: false
+        stages: [pre-push]
+        verbose: true

--- a/devtools/check_documentation_search.py
+++ b/devtools/check_documentation_search.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Validate that every NeqSim documentation page is represented in site search."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs"
+SEARCH_TEMPLATE = DOCS / "search-index.json"
+SEARCH_SCRIPT = DOCS / "assets" / "js" / "search.js"
+NON_CONTENT_HTML_DIRS = {"_includes", "_layouts"}
+
+
+def markdown_files() -> List[Path]:
+    """Return every Markdown documentation source that Jekyll should index."""
+    return sorted(DOCS.rglob("*.md"))
+
+
+def content_html_files() -> List[Path]:
+    """Return standalone HTML documentation, excluding Jekyll implementation files."""
+    return sorted(
+        path
+        for path in DOCS.rglob("*.html")
+        if not any(part in NON_CONTENT_HTML_DIRS for part in path.relative_to(DOCS).parts)
+    )
+
+
+def parse_front_matter(path: Path) -> Tuple[Dict[str, str], str]:
+    """Parse the leading flat YAML fields needed by search without external packages."""
+    text = path.read_text(encoding="utf-8-sig")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise ValueError("missing leading YAML front matter")
+
+    try:
+        end = next(index for index in range(1, len(lines)) if lines[index].strip() == "---")
+    except StopIteration as exc:
+        raise ValueError("front matter is not closed") from exc
+
+    front_lines = lines[1:end]
+    fields: Dict[str, str] = {}
+    index = 0
+    while index < len(front_lines):
+        match = re.match(r"^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$", front_lines[index])
+        if not match:
+            index += 1
+            continue
+        key, value = match.group(1), match.group(2).strip()
+        if value in {">", ">-", ">+", "|", "|-", "|+"}:
+            block: List[str] = []
+            index += 1
+            while index < len(front_lines) and (
+                not front_lines[index].strip() or front_lines[index][0].isspace()
+            ):
+                block.append(front_lines[index].strip())
+                index += 1
+            value = " ".join(part for part in block if part)
+            fields[key] = value
+            continue
+        if key in {"title", "description", "keywords"} and ": " in value and not value.startswith(
+            ("\"", "'")
+        ):
+            raise ValueError(f"front-matter {key} contains an unquoted colon")
+        fields[key] = value.strip("\"'")
+        index += 1
+
+    return fields, "\n".join(lines[end + 1 :]).strip()
+
+
+def relative_sources(paths: Iterable[Path]) -> List[str]:
+    """Return source paths in the same form emitted by Jekyll's ``page.path``."""
+    return [path.relative_to(DOCS).as_posix() for path in paths]
+
+
+def source_audit() -> List[str]:
+    """Check source metadata and the contracts that build and consume the index."""
+    errors: List[str] = []
+    markdown = markdown_files()
+    html = content_html_files()
+
+    for path in markdown:
+        try:
+            fields, body = parse_front_matter(path)
+        except ValueError as exc:
+            errors.append(f"{path.relative_to(ROOT)}: {exc}")
+            continue
+        for field in ("title", "description"):
+            if not fields.get(field, "").strip():
+                errors.append(f"{path.relative_to(ROOT)}: front matter needs a non-empty {field}")
+        if not body:
+            errors.append(f"{path.relative_to(ROOT)}: documentation body is empty")
+
+    template = SEARCH_TEMPLATE.read_text(encoding="utf-8")
+    required_template_contracts = {
+        "regular and collection pages": "site.pages | concat: site.documents",
+        "complete content": "doc.content | strip_html | normalize_whitespace",
+        "source-path traceability": '"path": {{ source_path | jsonify }}',
+        "title field": '"title": {{ title | jsonify }}',
+        "description field": '"description": {{ description | jsonify }}',
+        "heading field": '"headings": {{ headings | jsonify }}',
+        "content field": '"content": {{ content_text | jsonify }}',
+    }
+    for contract, marker in required_template_contracts.items():
+        if marker not in template:
+            errors.append(f"docs/search-index.json: missing {contract} contract")
+    if re.search(r"content_text[^\n]*\|\s*truncate", template):
+        errors.append("docs/search-index.json: page content must not be truncated")
+
+    for path in html:
+        relative = path.relative_to(DOCS).as_posix()
+        if relative not in template:
+            errors.append(
+                f"docs/search-index.json: standalone HTML page {relative} needs a discoverable entry"
+            )
+
+    script = SEARCH_SCRIPT.read_text(encoding="utf-8")
+    required_script_contracts = {
+        "path field": "this.field('path'",
+        "complete corpus iteration": "data.forEach(function (doc) { self.add(doc); });",
+        "punctuation-safe queries": "function normalizeQuery(query)",
+    }
+    for contract, marker in required_script_contracts.items():
+        if marker not in script:
+            errors.append(f"docs/assets/js/search.js: missing {contract} contract")
+
+    if not errors:
+        print(
+            "Documentation search source audit passed: "
+            f"{len(markdown)} Markdown pages and {len(html)} standalone HTML page(s)."
+        )
+    return errors
+
+
+def generated_site_audit(site: Path) -> List[str]:
+    """Compare a built Jekyll search corpus with every documentation source."""
+    errors: List[str] = []
+    index_path = site / "search-index.json"
+    if not index_path.is_file():
+        return [f"{index_path}: generated search index is missing"]
+
+    try:
+        entries = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"{index_path}: invalid JSON: {exc}"]
+    if not isinstance(entries, list):
+        return [f"{index_path}: expected a JSON array"]
+
+    expected = set(relative_sources(markdown_files() + content_html_files()))
+    actual: Dict[str, dict] = {}
+    urls: Dict[str, int] = {}
+    for position, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            errors.append(f"search entry {position}: expected an object")
+            continue
+        source = str(entry.get("path", "")).lstrip("/")
+        url = str(entry.get("url", ""))
+        if source:
+            if source in actual:
+                errors.append(f"duplicate search source: {source}")
+            actual[source] = entry
+        if url:
+            urls[url] = urls.get(url, 0) + 1
+        for field in ("url", "title", "description", "path", "content"):
+            if not str(entry.get(field, "")).strip():
+                errors.append(f"search entry {position} ({source or url}): empty {field}")
+
+    missing = sorted(expected - set(actual))
+    for source in missing:
+        errors.append(f"generated search index is missing documentation source: {source}")
+    for url, count in sorted(urls.items()):
+        if count > 1:
+            errors.append(f"duplicate search URL ({count} entries): {url}")
+
+    exactly_cut_off = [
+        source
+        for source, entry in actual.items()
+        if len(str(entry.get("content", ""))) == 10000
+    ]
+    for source in exactly_cut_off:
+        errors.append(f"search content still appears truncated at 10,000 characters: {source}")
+
+    if not errors:
+        total_chars = sum(len(str(entry.get("content", ""))) for entry in entries)
+        print(
+            "Generated search-index audit passed: "
+            f"{len(entries)} unique entries, {len(expected)} documentation sources, "
+            f"{total_chars:,} searchable content characters."
+        )
+    return errors
+
+
+def report(errors: Sequence[str]) -> int:
+    """Print findings and return a process exit status."""
+    if not errors:
+        return 0
+    print("Documentation search audit failed:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--site",
+        type=Path,
+        help="also validate a generated Jekyll destination such as _site",
+    )
+    args = parser.parse_args()
+
+    errors = source_audit()
+    if args.site:
+        errors.extend(generated_site_audit(args.site.resolve()))
+    return report(errors)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -50,6 +50,16 @@
     'depressuring': ['blowdown', 'safety', 'relief valve'],
     'json': ['api', 'builder', 'fromjson'],
     'dexpi': ['pfd', 'pid', 'topology', 'proteus', 'xml'],
+    'p&id': ['pid', 'piping and instrumentation diagram', 'dexpi', 'hazop'],
+    'pid': ['p&id', 'piping and instrumentation diagram', 'dexpi'],
+    'pfd': ['process flow diagram', 'dexpi', 'flowsheet'],
+    'cfihos': ['handover', 'information handover', 'rdl'],
+    'hazop': ['hazard and operability', 'lopa', 'srs', 'safeguarding'],
+    'lopa': ['layer of protection analysis', 'hazop', 'sil', 'srs'],
+    'srs': ['safety requirements specification', 'sil', 'sif', 'lopa'],
+    'hipps': ['high integrity pressure protection system', 'sil', 'esd'],
+    'feed': ['front end engineering design', 'engineering readiness', 'qualification'],
+    'model package': ['neqsimmodelpackage', 'revision', 'change event', 'impact analysis'],
     'fluid': ['thermo', 'system', 'mixture', 'composition'],
     'mixing rule': ['classic', 'huron vidal', 'mixing'],
     'density': ['specific gravity', 'molar volume', 'costald', 'peneloux', 'rackett', 'volume translation'],
@@ -250,6 +260,7 @@
       this.field('description', { boost: 5 });
       this.field('keywords', { boost: 8 });
       this.field('headings', { boost: 6 });
+      this.field('path', { boost: 4 });
       this.field('content');
 
       this.pipeline.remove(lunr.stemmer);
@@ -289,6 +300,13 @@
   /* -------------------------------------------------- */
   /*  Core search                                       */
   /* -------------------------------------------------- */
+  function normalizeQuery(query) {
+    return query.toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
   function performSearch() {
     var query = searchInput.value.trim();
     if (!query || query.length < 2 || !searchIndex) { hideResults(); return; }
@@ -311,25 +329,28 @@
 
   function runSearch(query) {
     var results = [];
+    var safeQuery = normalizeQuery(query);
 
-    try { results = searchIndex.search(query); } catch (e) { /* syntax error */ }
+    if (!safeQuery) return results;
+
+    try { results = searchIndex.search(safeQuery); } catch (e) { /* syntax error */ }
 
     if (results.length === 0) {
       try {
-        var wq = query.split(/\s+/).map(function (t) { return t + '*'; }).join(' ');
+        var wq = safeQuery.split(/\s+/).map(function (t) { return t + '*'; }).join(' ');
         results = searchIndex.search(wq);
       } catch (e) { /* */ }
     }
 
     if (results.length === 0) {
       try {
-        var fq = query.split(/\s+/).map(function (t) { return t + '~1'; }).join(' ');
+        var fq = safeQuery.split(/\s+/).map(function (t) { return t + '~1'; }).join(' ');
         results = searchIndex.search(fq);
       } catch (e) { /* */ }
     }
 
-    if (results.length === 0 && query.indexOf(' ') !== -1) {
-      results = orSearch(query);
+    if (results.length === 0 && safeQuery.indexOf(' ') !== -1) {
+      results = orSearch(safeQuery);
     }
 
     // Synonym expansion
@@ -340,7 +361,9 @@
 
       synonyms.forEach(function (syn) {
         try {
-          var sr = searchIndex.search(syn + '*');
+          var normalizedSynonym = normalizeQuery(syn);
+          var synonymQuery = normalizedSynonym.split(/\s+/).map(function (t) { return t + '*'; }).join(' ');
+          var sr = searchIndex.search(synonymQuery);
           sr.forEach(function (r) {
             if (!existing[r.ref]) {
               r.score = r.score * 0.6;

--- a/docs/process/model-change-events.md
+++ b/docs/process/model-change-events.md
@@ -1,3 +1,9 @@
+---
+title: "Model Change Events"
+description: "Publish deterministic, versioned engineering-model change events with revision identity, evidence references, idempotency, integrity fingerprints, and durable replay."
+keywords: "ModelChangeEvent, engineering model revision, change event, idempotency, event journal, impact analysis"
+---
+
 # Model change events
 
 NeqSim exposes a versioned, transport-neutral event contract for publishing governed engineering-model revisions.

--- a/docs/process/model-impact-analysis.md
+++ b/docs/process/model-impact-analysis.md
@@ -1,3 +1,9 @@
+---
+title: "Generalized Model Impact Analysis"
+description: "Propagate governed model changes through engineering dependencies to identify recalculation, regeneration, revalidation, and reapproval work."
+keywords: "GeneralizedImpactAnalyzer, model impact analysis, recalculation, revalidation, reapproval, engineering graph"
+---
+
 # Generalized model impact analysis
 
 `GeneralizedImpactAnalyzer` converts a model-change event and the canonical engineering graph into a controlled work

--- a/docs/process/optimization/README.md
+++ b/docs/process/optimization/README.md
@@ -1,6 +1,6 @@
 ---
 title: Process Optimization Framework
-description: Entry point for NeqSim process optimization documentation: optimizer selection, getting started, and verified code patterns.
+description: "Entry point for NeqSim process optimization documentation: optimizer selection, getting started, and verified code patterns."
 ---
 
 # Process Optimization Framework

--- a/docs/search-index.json
+++ b/docs/search-index.json
@@ -7,21 +7,25 @@ permalink: /search-index.json
   Build the search corpus from BOTH regular pages (site.pages) AND collection
   documents (site.documents, e.g. the `wiki` collection). Collection docs are
   NOT part of site.pages, so iterating site.pages alone silently dropped every
-  wiki page from search. Concatenate both sources, then filter out assets and
-  non-content files.
+  wiki page from search. Concatenate both sources, then filter out assets,
+  non-content files, and the generated combined manual. The manual is added as
+  a lightweight discoverable entry below because its chapters duplicate the
+  individually indexed source pages.
 {%- endcomment -%}
 {%- assign all_pages = site.pages | concat: site.documents | where_exp: "page", "page.url != '/search-index.json'" -%}
 {%- assign filtered_pages = "" | split: "" -%}
 {%- for page in all_pages -%}
-  {%- unless page.url contains '/assets/' or page.url contains '.xml' or page.url contains '.json' -%}
+  {%- unless page.url contains '/assets/' or page.url contains '.xml' or page.url contains '.json' or page.url == '/manual/neqsim_reference_manual.html' -%}
     {%- assign filtered_pages = filtered_pages | push: page -%}
   {%- endunless -%}
 {%- endfor -%}
 {%- for doc in filtered_pages -%}
-  {%- assign content_text = doc.content | strip_html | normalize_whitespace | truncate: 10000 -%}
+  {%- comment -%}Index the complete page. A fixed character cutoff made later sections of long guides impossible to find.{%- endcomment -%}
+  {%- assign content_text = doc.content | strip_html | normalize_whitespace -%}
   {%- assign title = doc.title | default: doc.name | default: doc.url -%}
   {%- assign description = doc.description | default: '' -%}
   {%- assign keywords = doc.keywords | default: '' -%}
+  {%- assign source_path = doc.path | default: doc.url -%}
   {%- comment -%}Auto-extract heading text so every page is searchable by its sections{%- endcomment -%}
   {%- assign headings = '' -%}
   {%- assign h_parts = doc.content | split: '</h' -%}
@@ -50,7 +54,18 @@ permalink: /search-index.json
     "keywords": {{ keywords | jsonify }},
     "headings": {{ headings | jsonify }},
     "section": {{ section | jsonify }},
+    "path": {{ source_path | jsonify }},
     "content": {{ content_text | jsonify }}
-  }{%- unless forloop.last -%},{%- endunless -%}
+  },
 {%- endfor -%}
+  {
+    "url": {{ '/manual/neqsim_reference_manual.html' | relative_url | jsonify }},
+    "title": "NeqSim Reference Manual",
+    "description": "Combined HTML reference manual for NeqSim thermodynamics, process simulation, engineering, safety, PVT, flow assurance, standards, integration, and development.",
+    "keywords": "NeqSim reference manual complete documentation combined manual API engineering thermodynamics process simulation",
+    "headings": "NeqSim Reference Manual",
+    "section": "manual",
+    "path": "manual/neqsim_reference_manual.html",
+    "content": "Complete combined NeqSim reference manual. Every source chapter is indexed individually with its full content for detailed search results."
+  }
 ]

--- a/docs/search.md
+++ b/docs/search.md
@@ -80,6 +80,7 @@ permalink: /search/
       <div class="sp-tips">
         <h4>Search tips</h4>
         <ul>
+          <li><strong>Complete coverage:</strong> titles, descriptions, keywords, headings, source paths, and full page content are indexed</li>
           <li><strong>Single words</strong> work best: <code>separator</code>, <code>hydrate</code>, <code>compressor</code></li>
           <li><strong>Synonyms are expanded</strong> automatically: searching <em>unisim</em> also finds <em>hysys</em> and <em>converter</em></li>
           <li><strong>Filter by section</strong> using the category buttons that appear above results</li>


### PR DESCRIPTION
## Summary

- index the complete rendered content of every documentation page instead of truncating each entry at 10,000 characters
- retain the generated combined reference manual as a lightweight discoverable entry while indexing all of its source chapters individually
- index source paths so users can search by filenames and documentation locations
- normalize punctuation in queries and add engineering aliases for P&ID, PFD, DEXPI, CFIHOS, HAZOP, LOPA, SRS, HIPPS, FEED, and model packages
- add complete search metadata to the model-change and generalized-impact pages
- correct an unquoted YAML colon that prevented the process-optimization description from reaching the live search index
- add a repository-wide source audit, pre-push hook, and Jekyll-build workflow that verifies generated search coverage

## Audit findings

The live search index before this change contains 618 unique entries, but 303 entries stop at exactly 10,000 content characters. Later sections of those guides are therefore not searchable.

The repository contains 618 Markdown documentation pages and one standalone combined HTML manual. Two Markdown pages lacked front matter, one description was invalid YAML, and the standalone manual was not discoverable through search.

## Coverage contract

The new checker requires:

- non-empty `title`, `description`, and body content for every Markdown page
- all regular pages and collection documents in the Jekyll corpus
- full page content with no fixed truncation
- source-path traceability for every generated entry
- a discoverable entry for each standalone HTML document
- one unique URL per search result
- no missing source pages or suspicious 10,000-character cutoffs after the Jekyll build

## Local validation

- source audit passed for 618 Markdown pages and one standalone HTML manual
- YAML/front matter parsed for all 618 Markdown pages
- JavaScript syntax check passed
- punctuation/synonym smoke searches passed for `P&ID`, `CFIHOS`, `model package`, and filename-style `model-impact-analysis`
- `git diff --check`

The dedicated GitHub workflow will build the site and validate the generated corpus before merge.