### PR TITLE
Add IDAES steam reforming Gibbs benchmark

### DIFF
--- a/docs/process/gibbs-reactor-documentation.md
+++ b/docs/process/gibbs-reactor-documentation.md
@@ -308,7 +308,16 @@ int niter = reactor.getActualIterations();         // Iterations performed
 double err = reactor.getFinalConvergenceError();   // Final ||Δx|| norm
 double mbErr = reactor.getMassBalanceError();       // Mass balance error (%)
 boolean mbOk = reactor.getMassBalanceConverged();   // Mass balance < 0.001%?
+double elementMbErr = reactor.getElementMassBalanceError();
+boolean elementMbOk = reactor.getElementMassBalanceConverged();
 ```
+
+For reacting systems, prefer the element-derived diagnostic when verifying
+physical conservation. It converts the conserved C/H/O/N/S/Ar inventories to
+mass with one consistent set of atomic molar masses. The legacy stream-based
+diagnostic uses component molar masses, which are rounded independently and can
+show a small apparent imbalance even when every element is conserved exactly.
+The legacy methods remain unchanged for compatibility.
 
 ### 3.5 Results — Thermodynamic Quantities
 

--- a/src/main/java/neqsim/process/equipment/reactor/GibbsReactor.java
+++ b/src/main/java/neqsim/process/equipment/reactor/GibbsReactor.java
@@ -94,6 +94,42 @@ public class GibbsReactor extends TwoPortEquipment {
     return !Double.isNaN(error) && error < 1e-3;
   }
 
+  /**
+   * Get the element-derived relative mass balance error as a percentage.
+   *
+   * <p>
+   * This diagnostic converts the inlet and outlet C/H/O/N/S/Ar element inventories to mass using one internally
+   * consistent set of atomic molar masses. It is useful for reacting systems because independently rounded component
+   * molar masses can create a small apparent imbalance in {@link #getMassBalanceError()} even when every element is
+   * conserved exactly.
+   * </p>
+   *
+   * @return element-derived relative mass balance error in percent, or {@link Double#NaN} when no supported element
+   *         inventory is available
+   */
+  public double getElementMassBalanceError() {
+    double elementalMassIn = 0.0;
+    double elementalMassOut = 0.0;
+    for (int i = 0; i < ELEMENT_MOLAR_MASSES.length; i++) {
+      elementalMassIn += elementMoleBalanceIn[i] * ELEMENT_MOLAR_MASSES[i];
+      elementalMassOut += elementMoleBalanceOut[i] * ELEMENT_MOLAR_MASSES[i];
+    }
+    if (elementalMassIn <= 0.0) {
+      return Double.NaN;
+    }
+    return 100.0 * Math.abs(elementalMassIn - elementalMassOut) / elementalMassIn;
+  }
+
+  /**
+   * Check whether the element-derived relative mass balance error is less than 0.001%.
+   *
+   * @return true if the element-derived mass balance is converged, false otherwise
+   */
+  public boolean getElementMassBalanceConverged() {
+    double error = getElementMassBalanceError();
+    return !Double.isNaN(error) && error < 1e-3;
+  }
+
   // Thread-local reusable system for fugacity calculations to minimize cloning
   private transient ThreadLocal<neqsim.thermo.system.SystemInterface> tempFugacitySystem = new ThreadLocal<>();
 
@@ -306,6 +342,12 @@ public class GibbsReactor extends TwoPortEquipment {
 
   /** Small threshold for detecting zero element coefficients. */
   private static final double ELEMENT_ZERO_THRESHOLD = 1e-6;
+
+  /**
+   * Element molar masses in kg/mol, ordered as O, N, C, H, S, Ar, and charge. The charge entry has zero mass.
+   */
+  private static final double[] ELEMENT_MOLAR_MASSES = {0.015999, 0.014007, 0.012011, 0.001008, 0.03206,
+      0.039948, 0.0};
 
   /** Logger object for class. */
   private static final Logger logger = LogManager.getLogger(GibbsReactor.class);

--- a/src/main/java/neqsim/process/equipment/reactor/GibbsReactor.java
+++ b/src/main/java/neqsim/process/equipment/reactor/GibbsReactor.java
@@ -105,7 +105,7 @@ public class GibbsReactor extends TwoPortEquipment {
    * </p>
    *
    * @return element-derived relative mass balance error in percent, or {@link Double#NaN} when no supported element
-   *         inventory is available
+   * inventory is available
    */
   public double getElementMassBalanceError() {
     double elementalMassIn = 0.0;
@@ -346,8 +346,8 @@ public class GibbsReactor extends TwoPortEquipment {
   /**
    * Element molar masses in kg/mol, ordered as O, N, C, H, S, Ar, and charge. The charge entry has zero mass.
    */
-  private static final double[] ELEMENT_MOLAR_MASSES = {0.015999, 0.014007, 0.012011, 0.001008, 0.03206,
-      0.039948, 0.0};
+  private static final double[] ELEMENT_MOLAR_MASSES = { 0.015999, 0.014007, 0.012011, 0.001008, 0.03206, 0.039948,
+      0.0 };
 
   /** Logger object for class. */
   private static final Logger logger = LogManager.getLogger(GibbsReactor.class);

--- a/src/test/java/neqsim/process/equipment/reactor/IdaesSteamMethaneReformingBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/IdaesSteamMethaneReformingBenchmarkTest.java
@@ -1,0 +1,125 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+
+/**
+ * Cross-tool benchmark of steam methane reforming equilibrium against the IDAES 2.4.0 Gibbs reactor example.
+ *
+ * <p>
+ * Reference: IDAES Examples, "Flowsheet Gibbs Reactor Simulation and Optimization of Steam Methane Reforming",
+ * updated 2023-06-01.
+ * </p>
+ */
+class IdaesSteamMethaneReformingBenchmarkTest {
+  private static final String[] COMPONENTS = { "methane", "water", "hydrogen", "CO", "CO2" };
+  private static final double MOLE_FRACTION_RMSE_TOLERANCE = 0.005;
+  private static final double MOLE_FRACTION_MAX_ERROR_TOLERANCE = 0.010;
+  private static final double CONVERSION_TOLERANCE = 0.010;
+
+  @Test
+  void reproducesPrimaryAndHoldoutEquilibriumStates() {
+    BenchmarkResult primary = runCase(920.80, 2.0,
+        new double[] { 0.034965, 0.32532, 0.49984, 0.059609, 0.080265 }, 0.800);
+    BenchmarkResult holdout = runCase(1087.385, 10.0,
+        new double[] { 0.016892, 0.31609, 0.51498, 0.093140, 0.058900 }, 0.900);
+
+    assertBenchmark(primary);
+    assertBenchmark(holdout);
+
+    assertTrue(holdout.actual[0] < primary.actual[0], "methane should decrease at the hotter state");
+    assertTrue(holdout.actual[1] < primary.actual[1], "water should decrease at the hotter state");
+    assertTrue(holdout.actual[2] > primary.actual[2], "hydrogen should increase at the hotter state");
+    assertTrue(holdout.actual[3] > primary.actual[3], "carbon monoxide should increase at the hotter state");
+  }
+
+  private static BenchmarkResult runCase(double temperatureK, double pressureBar, double[] reference,
+      double referenceConversion) {
+    double normalization = 1.0 + 4.0e-5;
+    double methaneIn = (75.0 + 234.0e-5) / normalization;
+
+    SystemInterface system = new SystemPrEos(temperatureK, pressureBar);
+    system.addComponent("methane", methaneIn);
+    system.addComponent("water", (234.0 + 75.0e-5) / normalization);
+    system.addComponent("hydrogen", 309.0e-5 / normalization);
+    system.addComponent("CO", 309.0e-5 / normalization);
+    system.addComponent("CO2", 309.0e-5 / normalization);
+    system.setMixingRule(2);
+
+    Stream inlet = new Stream("IDAES SMR feed", system);
+    inlet.run();
+
+    GibbsReactor reactor = new GibbsReactor("IDAES SMR Gibbs reactor", inlet);
+    reactor.setUseAllDatabaseSpecies(false);
+    reactor.setEnergyMode(GibbsReactor.EnergyMode.ISOTHERMAL);
+    reactor.setDampingComposition(0.01);
+    reactor.setUseAdaptiveStepSize(true);
+    reactor.setMinIterations(3);
+    reactor.setMaxIterations(10000);
+    reactor.setConvergenceTolerance(1e-8);
+    reactor.run();
+
+    SystemInterface outlet = reactor.getOutletStream().getThermoSystem();
+    double[] actual = new double[COMPONENTS.length];
+    double sumSquaredError = 0.0;
+    double maxError = 0.0;
+    for (int i = 0; i < COMPONENTS.length; i++) {
+      actual[i] = outlet.getComponent(COMPONENTS[i]).getz();
+      double error = Math.abs(actual[i] - reference[i]);
+      sumSquaredError += error * error;
+      maxError = Math.max(maxError, error);
+    }
+    double conversion = (methaneIn - outlet.getComponent("methane").getNumberOfmoles()) / methaneIn;
+
+    return new BenchmarkResult(actual, Math.sqrt(sumSquaredError / COMPONENTS.length), maxError, conversion,
+        referenceConversion, reactor.hasConverged(), reactor.getFinalConvergenceError(),
+        reactor.getElementMassBalanceError());
+  }
+
+  private static void assertBenchmark(BenchmarkResult result) {
+    assertTrue(result.converged, "Gibbs solver should converge");
+    assertTrue(result.residual < 1e-6, "final Gibbs residual should be below 1e-6");
+    assertTrue(result.massBalanceError < 1e-3, "mass balance error should be below 0.001%");
+    assertTrue(result.rmse <= MOLE_FRACTION_RMSE_TOLERANCE, "mole-fraction RMSE exceeds frozen tolerance");
+    assertTrue(result.maxError <= MOLE_FRACTION_MAX_ERROR_TOLERANCE,
+        "maximum mole-fraction error exceeds frozen tolerance");
+    assertEquals(result.referenceConversion, result.conversion, CONVERSION_TOLERANCE,
+        "methane conversion differs from the IDAES reference");
+
+    double sum = 0.0;
+    for (double moleFraction : result.actual) {
+      assertTrue(Double.isFinite(moleFraction) && moleFraction >= 0.0,
+          "mole fractions must be finite and non-negative");
+      sum += moleFraction;
+    }
+    assertEquals(1.0, sum, 1e-8, "mole fractions should sum to one");
+  }
+
+  private static final class BenchmarkResult {
+    private final double[] actual;
+    private final double rmse;
+    private final double maxError;
+    private final double conversion;
+    private final double referenceConversion;
+    private final boolean converged;
+    private final double residual;
+    private final double massBalanceError;
+
+    private BenchmarkResult(double[] actual, double rmse, double maxError, double conversion,
+        double referenceConversion, boolean converged, double residual, double massBalanceError) {
+      this.actual = actual;
+      this.rmse = rmse;
+      this.maxError = maxError;
+      this.conversion = conversion;
+      this.referenceConversion = referenceConversion;
+      this.converged = converged;
+      this.residual = residual;
+      this.massBalanceError = massBalanceError;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/IdaesSteamMethaneReformingBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/IdaesSteamMethaneReformingBenchmarkTest.java
@@ -12,8 +12,8 @@ import neqsim.thermo.system.SystemPrEos;
  * Cross-tool benchmark of steam methane reforming equilibrium against the IDAES 2.4.0 Gibbs reactor example.
  *
  * <p>
- * Reference: IDAES Examples, "Flowsheet Gibbs Reactor Simulation and Optimization of Steam Methane Reforming",
- * updated 2023-06-01.
+ * Reference: IDAES Examples, "Flowsheet Gibbs Reactor Simulation and Optimization of Steam Methane Reforming", updated
+ * 2023-06-01.
  * </p>
  */
 class IdaesSteamMethaneReformingBenchmarkTest {
@@ -24,10 +24,10 @@ class IdaesSteamMethaneReformingBenchmarkTest {
 
   @Test
   void reproducesPrimaryAndHoldoutEquilibriumStates() {
-    BenchmarkResult primary = runCase(920.80, 2.0,
-        new double[] { 0.034965, 0.32532, 0.49984, 0.059609, 0.080265 }, 0.800);
-    BenchmarkResult holdout = runCase(1087.385, 10.0,
-        new double[] { 0.016892, 0.31609, 0.51498, 0.093140, 0.058900 }, 0.900);
+    BenchmarkResult primary = runCase(920.80, 2.0, new double[] { 0.034965, 0.32532, 0.49984, 0.059609, 0.080265 },
+        0.800);
+    BenchmarkResult holdout = runCase(1087.385, 10.0, new double[] { 0.016892, 0.31609, 0.51498, 0.093140, 0.058900 },
+        0.900);
 
     assertBenchmark(primary);
     assertBenchmark(holdout);


### PR DESCRIPTION
Related to #2498. This is benchmark B001; it does not mark the campaign ledger as merged or complete.

## Source and frozen comparison

Reference: [IDAES Examples 2.4.0 — Flowsheet Gibbs Reactor Simulation and Optimization of Steam Methane Reforming](https://idaes-examples.readthedocs.io/en/2.4.0/docs/unit_models/reactors/gibbs_reactor_doc.html), Brandon Paul, updated 2023-06-01.

The source uses a vapor-only Peng–Robinson property package for CH4/H2O/H2/CO/CO2. The comparison evaluates NeqSim at the two reported reactor outlet temperature/pressure states, with the source feed normalization reproduced exactly. This isolates Gibbs equilibrium from compressor, heater, conversion-constraint, heat-duty, and reference-state conventions.

The source reports displayed precision but no uncertainty interval. Before running NeqSim, the following cross-tool tolerances were frozen:

- five-species mole-fraction RMSE <= 0.005
- maximum absolute mole-fraction error <= 0.010
- methane-conversion absolute error <= 0.010
- physical mass-balance error < 0.001%
- final Gibbs residual < 1e-6
- identical gates for the primary point and untouched holdout

No parameter fitting was performed.

## Baseline results

| Case | Reference / NeqSim CH4 conversion | Mole-fraction RMSE | Maximum absolute error | Iterations | Final residual |
|---|---:|---:|---:|---:|---:|
| Primary: 920.80 K, 2 bar(a) | 0.800000 / 0.798934 | 0.002158 | 0.002650 | 13 | 2.13e-9 |
| Holdout: 1087.385 K, 10 bar(a) | 0.900000 / 0.895229 | 0.002379 | 0.003504 | 14 | 1.43e-9 |

Both cases pass the frozen composition, conversion, convergence, non-negativity, summation, and temperature-trend criteria.

The existing stream-based mass diagnostic reports 0.001106% and 0.001239%, narrowly outside the frozen gate, while the maximum absolute C/H/O inventory difference is only 2.84e-14 mol.

## Root cause

NeqSim's component molar masses are rounded independently:

- methane 0.016043 kg/mol
- water 0.018015 kg/mol
- hydrogen 0.002016 kg/mol
- CO 0.028011 kg/mol
- CO2 0.044010 kg/mol

For CH4 + H2O -> CO + 3H2, those stored values differ by exactly 1e-6 kg per mole of reaction. Multiplying by the 60–67.5 mol/s reforming extent reproduces the apparent mass increase. Tightening the Gibbs residual does not change it; element inventories remain conserved to machine precision. This is a diagnostic/data-rounding effect, not an equilibrium-model or numerical defect.

## Implementation

- Add `getElementMassBalanceError()` and `getElementMassBalanceConverged()` to `GibbsReactor`.
- Calculate reacting-system mass closure from the already conserved O/N/C/H/S/Ar inventories using one internally consistent atomic-mass vector.
- Keep `getMassBalanceError()` and `getMassBalanceConverged()` unchanged for compatibility.
- Add a compact independent IDAES primary/holdout Java regression benchmark.
- Document when to use the stream-based and element-derived diagnostics.

No EOS parameter, thermochemical datum, solver default, equilibrium composition, or energy result changes.

## Validation evidence

The runner could not resolve Maven Central, so the repository's current `GibbsReactor.java` was compiled directly with the installed JDK compiler module against the bundled NeqSim 3.16.0 dependency jar and loaded ahead of that jar. The exact benchmark test logic passed end-to-end.

Additional selected regressions executed with the modified class:

- ideal-gas equilibrium composition: pass
- Armijo + adaptive Gibbs case: pass; legacy diagnostic remains 0.000226%
- existing combustion composition and legacy mass gate: pass; legacy diagnostic remains 0.000907%
- B001 primary and holdout element-derived mass error: 0.0% at displayed precision

The Task Solver results schema validates with zero errors. The task workspace is intentionally not committed.

## Compatibility, performance, and limitations

The change is additive and backward compatible. It adds one seven-element loop per diagnostic call; reactor solve runtime is unaffected.

Full Maven, Spotless, Javadoc, Java 8/21, and repository-wide CI remain required before review. The IDAES reference has no reported uncertainty, and this benchmark validates equilibrium states rather than full flowsheet duties or economics.

## Next step

Let CI run the complete repository gates. If they pass, record B001 as validated in #2498 while keeping the benchmark unmerged until this PR is actually merged.