### PR TITLE
docs: make quickstart decision paths accessible

### DIFF
--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -3,8 +3,7 @@ title: Quick Start Guides
 description: Get up and running with NeqSim in 5 minutes. Quick start guides for Java, Python, and Google Colab with copy-paste examples.
 ---
 
-
-Get up and running with NeqSim in 5 minutes! Choose your platform:
+Get up and running with NeqSim in 5 minutes. Choose your platform:
 
 > **Documentation Version:** These guides are for NeqSim 3.x. Check the [Maven Central](https://search.maven.org/search?q=g:%22com.equinor.neqsim%22%20AND%20a:%22neqsim%22) page for the latest version number.
 
@@ -16,24 +15,13 @@ Get up and running with NeqSim in 5 minutes! Choose your platform:
 
 ## Which Should I Choose?
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  "I want to try NeqSim right now without installing anything"│
-│  ➜ Google Colab Quickstart                                   │
-├─────────────────────────────────────────────────────────────┤
-│  "I'm a Python user / data scientist"                        │
-│  ➜ Python Quickstart                                         │
-├─────────────────────────────────────────────────────────────┤
-│  "I'm building a production application"                     │
-│  ➜ Java Quickstart                                           │
-├─────────────────────────────────────────────────────────────┤
-│  "I want to extend or contribute to NeqSim"                  │
-│  ➜ Java Quickstart + Developer Setup                         │
-├─────────────────────────────────────────────────────────────┤
-│  "I want AI to solve an engineering problem for me"           │
-│  ➜ AI-Assisted Task Solving Tutorial                         │
-└─────────────────────────────────────────────────────────────┘
-```
+| Goal | Recommended path |
+|------|------------------|
+| Try NeqSim immediately without installing anything | [Google Colab Quickstart](colab-quickstart) |
+| Use NeqSim from Python, data-science tools, or notebooks | [Python Quickstart](python-quickstart) |
+| Build a production Java application with full API access | [Java Quickstart](java-quickstart) |
+| Extend NeqSim or contribute to the repository | [Java Quickstart](java-quickstart) and [Developer Setup](../development/DEVELOPER_SETUP) |
+| Use AI agents to solve and document an engineering problem | [Solve an Engineering Task](../tutorials/solve-engineering-task) |
 
 ## After the Quickstart
 


### PR DESCRIPTION
## Campaign

Linked to #2499 — D001 navigation, indexes, internal links, and recent documentation changes.

## Frozen scan batch

- `docs/quickstart/index.md`

No other paths were edited. The batch deliberately avoids documentation paths being changed by open PR #2502.

## Confirmed defect

| Severity | Path | Evidence | Root cause |
|---|---|---|---|
| Medium | `docs/quickstart/index.md`, “Which Should I Choose?” | The page’s primary role/goal decision aid was an ASCII diagram inside a fenced code block. Its destinations were plain text rather than links, and the visual box structure did not expose a useful navigation relationship to screen readers. | Navigation information was encoded as presentation-only text instead of semantic Markdown. |

## Fix

- Replaced the inert ASCII decision diagram with a semantic two-column Markdown table.
- Added direct internal links for Colab, Python, Java, developer setup, and AI-assisted engineering-task workflows.
- Preserved the original decision choices and kept the scope limited to navigation/accessibility.

## Validation performed

- Verified Jekyll front matter remains present with `title` and `description`.
- Reviewed Markdown table structure and blank-line separation.
- Verified the added `docs/development/DEVELOPER_SETUP.md` target exists on current `master`.
- Existing targets retained by the page were inspected in the repository, including `docs/examples/index.md` and `docs/thermo/reading_fluid_properties.md`.
- No equations, Java/Python snippets, notebooks, images, or production APIs were changed; code-example compilation and notebook execution are therefore not applicable to this bounded batch.

## Rendering and external links

A local Jekyll/browser rendering environment was not available in this plugin-only execution, so I have not claimed visual rendering verification. GitHub Actions checks on this draft PR are the repository-supported validation path available for the branch. The Maven Central and JavaDoc links were not replaced because no permanent failure was established.

## Regression coverage

No executable regression test was added because the change is navigation-only and contains no API call. The semantic Markdown structure is suitable for the repository’s documentation build/link checks.

## Exclusions

- No broad cleanup of other indexes or duplicate headings.
- No recently added field-development documentation touched because open PR #2502 overlaps that area.
- No production code, tests, notebooks, or generated output changed.

## Next scan scope

After this PR is merged or closed, continue D001 with the master reference index and landing-page internal-link inventory, then advance to D002 only after merged evidence updates the campaign ledger.

Closes no issue; #2499 is a continuing campaign issue.