### PR TITLE
docs: repair physical-property page rendering

### DIFF
--- a/docs/physical_properties/README.md
+++ b/docs/physical_properties/README.md
@@ -3,8 +3,6 @@ title: Physical Properties Package
 description: This documentation covers NeqSim's physical properties calculation system, including transport properties (viscosity, thermal conductivity, diffusivity), interfacial properties (surface tension), and ...
 ---
 
-# Physical Properties Package
-
 This documentation covers NeqSim's physical properties calculation system, including transport properties (viscosity, thermal conductivity, diffusivity), interfacial properties (surface tension), and density correlations.
 
 ## Contents

--- a/docs/physical_properties/density_models.md
+++ b/docs/physical_properties/density_models.md
@@ -4,8 +4,6 @@ description: "Density correction models in NeqSim: COSTALD (Hankinson-Thomson), 
 keywords: "COSTALD, density, liquid density, Hankinson-Thomson, Peneloux, volume translation, Rackett, molar volume, specific gravity, TBP fraction, pseudo-component, aqueous, polar, water density, MEG, TEG, glycol, methanol, ethanol, setLiquidDensityModel, compressed liquid, characteristic volume, V-star"
 ---
 
-# Density Models
-
 This guide documents the density correction models available in NeqSim for improving volumetric predictions.
 
 ## Table of Contents

--- a/docs/physical_properties/diffusivity_models.md
+++ b/docs/physical_properties/diffusivity_models.md
@@ -3,8 +3,6 @@ title: Diffusivity Models
 description: "Diffusion coefficient calculation methods in NeqSim: Chapman-Enskog, Wilke-Lee, Fuller-Schettler-Giddings for gases; Siddiqi-Lucas, Wilke-Chang, Tyn-Calus, Hayduk-Minhas for liquids. Includes validation against experimental data."
 ---
 
-# Diffusivity Models
-
 This guide documents the diffusion coefficient calculation methods available in NeqSim for gas and liquid systems.
 
 ## Table of Contents

--- a/docs/physical_properties/interfacial_properties.md
+++ b/docs/physical_properties/interfacial_properties.md
@@ -3,8 +3,6 @@ title: Interfacial Properties
 description: This guide documents the interfacial property calculations available in NeqSim, including surface tension and related phenomena.
 ---
 
-# Interfacial Properties
-
 This guide documents the interfacial property calculations available in NeqSim, including surface tension and related phenomena.
 
 ## Table of Contents

--- a/docs/physical_properties/scale_potential.md
+++ b/docs/physical_properties/scale_potential.md
@@ -3,8 +3,6 @@ title: Scale Potential Calculation in NeqSim
 description: Scale formation is a critical challenge in oil and gas production, water treatment, and geothermal systems. When water becomes supersaturated with certain minerals, precipitation (scaling) can occur o...
 ---
 
-# Scale Potential Calculation in NeqSim
-
 ## Introduction
 
 Scale formation is a critical challenge in oil and gas production, water treatment, and geothermal systems. When water becomes supersaturated with certain minerals, precipitation (scaling) can occur on equipment surfaces, leading to reduced flow, equipment damage, and costly interventions.

--- a/docs/physical_properties/thermal_conductivity_models.md
+++ b/docs/physical_properties/thermal_conductivity_models.md
@@ -3,8 +3,6 @@ title: Thermal Conductivity Models
 description: This guide documents the thermal conductivity calculation methods available in NeqSim for gas, liquid, and multiphase systems.
 ---
 
-# Thermal Conductivity Models
-
 This guide documents the thermal conductivity calculation methods available in NeqSim for gas, liquid, and multiphase systems.
 
 ## Table of Contents
@@ -142,7 +140,7 @@ fluid.getPhase("oil").getPhysicalProperties().setConductivityModel("polynom");
 
 ---
 
-### CO₂ Reference
+### CO2 Reference
 
 High-accuracy thermal conductivity for CO₂ based on the Vesovic et al. correlation.
 

--- a/docs/physical_properties/viscosity_models.md
+++ b/docs/physical_properties/viscosity_models.md
@@ -3,8 +3,6 @@ title: Viscosity Models
 description: This guide documents the viscosity calculation methods available in NeqSim for gas, liquid, and multiphase systems.
 ---
 
-# Viscosity Models
-
 This guide documents the viscosity calculation methods available in NeqSim for gas, liquid, and multiphase systems.
 
 ## Table of Contents

--- a/docs/thermo/physical_properties.md
+++ b/docs/thermo/physical_properties.md
@@ -4,8 +4,6 @@ description: "NeqSim computes phase and mixture properties after thermodynamic i
 keywords: "physical properties, transport properties, viscosity, thermal conductivity, surface tension, diffusion coefficient, density, Cp, Cv, speed of sound"
 ---
 
-# Physical Property Calculations
-
 NeqSim computes phase and mixture properties after thermodynamic initialization. This guide highlights the most used methods and how to choose appropriate models.
 
 ## Density and Compressibility

--- a/docs/wiki/viscosity_models.md
+++ b/docs/wiki/viscosity_models.md
@@ -3,8 +3,6 @@ title: "Viscosity Models in NeqSim"
 description: "NeqSim provides a comprehensive suite of methods for calculating fluid viscosity, ranging from standard empirical correlations to advanced corresponding states models and specialized pure-component eq..."
 ---
 
-# Viscosity Models in NeqSim
-
 NeqSim provides a comprehensive suite of methods for calculating fluid viscosity, ranging from standard empirical correlations to advanced corresponding states models and specialized pure-component equations. This document details the available models, their applications, and how to use them in simulations.
 
 ## Overview


### PR DESCRIPTION
## Campaign

Relates to #2499.

## Scan scope

D002 — physical-properties rendering and navigation:

- `docs/physical_properties/*.md`
- `docs/thermo/physical_properties.md`
- `docs/wiki/viscosity_models.md`

The active PVT characterization and LNG process PR files were deliberately excluded.

## Defects and evidence

- **Nine medium-severity rendering defects:** each affected page repeated its Jekyll front-matter title as a Markdown H1, causing duplicate rendered titles and violating the documentation agent rule.
- **One medium-severity navigation defect:** the thermal-conductivity table of contents linked to `#co2-reference`, while the Unicode `CO₂ Reference` heading did not generate that anchor under the repository link scanner.

## Fixes

- Removed the duplicate H1 from nine pages while preserving front-matter titles and all page content.
- Changed the thermal-conductivity subsection heading to `CO2 Reference`, preserving the visible technical meaning and making the existing `#co2-reference` link deterministic.

No code block, equation, API call, image, index entry, or external link was changed.

## Validation performed

- D002 structural/link scanner: **10 pages, 78 internal links, 0 missing targets/anchors**
- Front matter: title and description present on all 10 pages
- Duplicate-title check: **0 remaining**
- Code fences: **204 delimiters, balanced**
- Unsupported KaTeX delimiters: **0**
- Local images: **0 missing**
- External links in the bounded batch: none
- `python devtools/check_documentation_search.py`: **619 Markdown pages and 1 standalone HTML page passed**
- `git diff --check`: passed
- Complete Java/Python examples changed: **none**, so no documentation example test was added or altered
- GitHub `Run build, test and javadoc`: **passed**
- GitHub `Pre-commit checks`: **passed**
- GitHub `Documentation search coverage`: **passed**, including the Jekyll site build

## Rendering and infrastructure

Ruby, Bundler, Docker, and Podman were unavailable locally, so no local render or screenshot was claimed. GitHub workflow `Documentation search coverage` supplied the authoritative site-build gate: source contracts, Jekyll documentation build, generated search coverage, and search JavaScript syntax all completed successfully.

## Regression coverage

The batch scanner was rerun after the fixes and returned zero structural, link, anchor, image, fence, or delimiter errors.

## Exclusions and next scope

- Executable API-example correctness is intentionally deferred to the next D002 sub-batch; this PR does not modify or claim validation of the existing code examples.
- Next scan: bounded thermodynamics/physical-properties API examples, checked against current source with focused executable tests.

This is an AI-assisted documentation repair and remains a draft for maintainer review.