### PR TITLE
docs: verify thermal conductivity API examples

### DIFF
--- a/docs/physical_properties/thermal_conductivity_models.md
+++ b/docs/physical_properties/thermal_conductivity_models.md
@@ -6,10 +6,12 @@ description: This guide documents the thermal conductivity calculation methods a
 This guide documents the thermal conductivity calculation methods available in NeqSim for gas, liquid, and multiphase systems.
 
 ## Table of Contents
+
 - [Overview](#overview)
 - [Available Models](#available-models)
   - [PFCT (Pedersen)](#pfct-pedersen)
   - [Chung Method](#chung-method)
+  - [Chung Dense Method](#chung-dense-method)
   - [Polynomial Correlation](#polynomial-correlation)
   - [CO₂ Reference](#co2-reference)
 - [Model Selection Guide](#model-selection-guide)
@@ -29,10 +31,15 @@ Thermal conductivity ($\lambda$ or $k$) describes a material's ability to conduc
 
 **Setting a conductivity model:**
 ```java
-fluid.initPhysicalProperties();
 fluid.getPhase("gas").getPhysicalProperties().setConductivityModel("Chung");
 fluid.getPhase("oil").getPhysicalProperties().setConductivityModel("PFCT");
+fluid.getPhase("gas").initPhysicalProperties();
+fluid.getPhase("oil").initPhysicalProperties();
 ```
+
+Select the model after the flash and initial property calculation, then reinitialize each changed
+phase as shown. Model keys are case-sensitive. Unsupported keys currently fall back to `PFCT`, so
+use one of the documented keys and cover model selection in tests.
 
 ---
 
@@ -107,6 +114,26 @@ where $G_2$ and $B$ terms account for density effects.
 **Usage:**
 ```java
 fluid.getPhase("gas").getPhysicalProperties().setConductivityModel("Chung");
+fluid.getPhase("gas").initPhysicalProperties();
+```
+
+---
+
+### Chung Dense Method
+
+`Chung-dense` implements the full Chung et al. correlation, including dilute-gas and
+density-dependent contributions. Use it when pressure or liquid-like density makes the dilute
+`Chung` model insufficient.
+
+**Class:** `ChungDenseConductivityMethod`
+
+**Applicable phases:** Gas and liquid
+
+**Usage:**
+
+```java
+fluid.getPhase("gas").getPhysicalProperties().setConductivityModel("Chung-dense");
+fluid.getPhase("gas").initPhysicalProperties();
 ```
 
 ---
@@ -136,20 +163,22 @@ $$\lambda_{mix} = \sum_i x_i \lambda_i$$
 **Usage:**
 ```java
 fluid.getPhase("oil").getPhysicalProperties().setConductivityModel("polynom");
+fluid.getPhase("oil").initPhysicalProperties();
 ```
 
 ---
 
 ### CO2 Reference
 
-High-accuracy thermal conductivity for CO₂ based on the Vesovic et al. correlation.
+Pure-CO₂ thermal conductivity model implemented as a polynomial fit to reference data generated
+with CoolProp. The implementation is checked against NIST values in
+`CO2ConductivityMethodTest` and uses Span-Wagner properties if a usable density is unavailable.
 
 **Class:** `CO2ConductivityMethod`
 
-**Coverage:**
-- Temperature: 200-1500 K
-- Pressure: Up to 300 MPa
-- All phases (gas, liquid, supercritical)
+**Constraint:** The phase must contain pure CO₂. The implementation rejects mixtures; do not use
+`CO2Model` for CO₂-rich multicomponent streams. NeqSim does not enforce a temperature-pressure
+validity envelope for this polynomial, so validate extrapolated states independently.
 
 **Best for:**
 - Pure CO₂ systems
@@ -159,6 +188,7 @@ High-accuracy thermal conductivity for CO₂ based on the Vesovic et al. correla
 **Usage:**
 ```java
 fluid.getPhase("gas").getPhysicalProperties().setConductivityModel("CO2Model");
+fluid.getPhase("gas").initPhysicalProperties();
 ```
 
 ---
@@ -168,11 +198,16 @@ fluid.getPhase("gas").getPhysicalProperties().setConductivityModel("CO2Model");
 | Application | Recommended Model | Notes |
 |-------------|-------------------|-------|
 | Petroleum mixtures | PFCT | Corresponding states with MW correction |
-| Gas processing | Chung | Good for gases |
+| Low-density gas | Chung | Dilute-gas contribution |
+| Dense gas or liquid | Chung-dense | Includes density-dependent contribution |
 | Simple liquid mixtures | polynom | Uses database parameters |
-| Pure CO₂ | CO2Model | High accuracy |
+| Pure CO₂ | CO2Model | Rejects mixtures; validate extrapolation |
 | Wide P-T range | PFCT | Robust extrapolation |
 | Polar systems | Chung | Includes polar corrections |
+
+Additional implemented keys are `friction theory`, `Filippov`, `WaterModel`, and `H2Model`.
+They are specialized models and should be selected only with a composition and phase appropriate
+to the underlying correlation.
 
 ---
 
@@ -182,6 +217,7 @@ fluid.getPhase("gas").getPhysicalProperties().setConductivityModel("CO2Model");
 
 ```java
 import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 // Create and flash fluid
@@ -199,25 +235,30 @@ fluid.initPhysicalProperties();
 
 // Get thermal conductivity
 double gasConductivity = fluid.getPhase("gas").getThermalConductivity("W/mK");
-System.out.println("Gas thermal conductivity: " + gasConductivity + " W/(m·K)");
+if (!(gasConductivity > 0.0)) {
+    throw new IllegalStateException("Expected positive gas thermal conductivity");
+}
 ```
 
 ### Comparing Conductivity Models
 
 ```java
-String[] models = {"PFCT", "Chung"};
+String[] models = {"PFCT", "Chung-dense"};
+double[] conductivities = new double[models.length];
 
-for (String model : models) {
-    SystemInterface fluid = createFluid();
+for (int i = 0; i < models.length; i++) {
+    SystemInterface fluid = new SystemSrkEos(350.0, 50.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.05);
+    fluid.setMixingRule("classic");
     ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
     ops.TPflash();
-    fluid.initPhysicalProperties();
+    fluid.initProperties();
     
-    fluid.getPhase("gas").getPhysicalProperties().setConductivityModel(model);
-    fluid.initPhysicalProperties();
-    
-    double k = fluid.getPhase("gas").getThermalConductivity("W/mK");
-    System.out.println(model + ": " + k + " W/(m·K)");
+    fluid.getPhase("gas").getPhysicalProperties().setConductivityModel(models[i]);
+    fluid.getPhase("gas").initPhysicalProperties();
+    conductivities[i] = fluid.getPhase("gas").getThermalConductivity("W/mK");
 }
 ```
 
@@ -228,18 +269,18 @@ SystemInterface baseFluid = new SystemSrkEos(350.0, 10.0);
 baseFluid.addComponent("methane", 1.0);
 baseFluid.setMixingRule("classic");
 
-double[] pressures = {10, 50, 100, 150, 200};  // bar
+double[] pressuresBara = {10, 50, 100, 150, 200};
+double[] conductivities = new double[pressuresBara.length];
 
-for (double P : pressures) {
+for (int i = 0; i < pressuresBara.length; i++) {
     SystemInterface fluid = baseFluid.clone();
-    fluid.setPressure(P, "bar");
+    fluid.setPressure(pressuresBara[i], "bara");
     
     ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
     ops.TPflash();
     fluid.initPhysicalProperties();
     
-    double k = fluid.getPhase(0).getThermalConductivity("W/mK");
-    System.out.println("P=" + P + " bar: " + k + " W/(m·K)");
+    conductivities[i] = fluid.getPhase(0).getThermalConductivity("W/mK");
 }
 ```
 
@@ -256,14 +297,10 @@ ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
 ops.TPflash();
 fluid.initPhysicalProperties();
 
-if (fluid.hasPhaseType("gas")) {
-    System.out.println("Gas k: " + 
-        fluid.getPhase("gas").getThermalConductivity("W/mK") + " W/(m·K)");
-}
-if (fluid.hasPhaseType("oil")) {
-    System.out.println("Oil k: " + 
-        fluid.getPhase("oil").getThermalConductivity("W/mK") + " W/(m·K)");
-}
+double gasConductivity = fluid.hasPhaseType("gas")
+    ? fluid.getPhase("gas").getThermalConductivity("W/mK") : Double.NaN;
+double oilConductivity = fluid.hasPhaseType("oil")
+    ? fluid.getPhase("oil").getThermalConductivity("W/mK") : Double.NaN;
 ```
 
 ---
@@ -323,5 +360,6 @@ The PFCT method accounts for this through corresponding states mapping to refere
 
 1. Pedersen, K.S., et al. (1989). Thermal Conductivity of Crude Oils. Chem. Eng. Sci.
 2. Chung, T.H., et al. (1988). Generalized Multiparameter Correlation. I&EC Res.
-3. Vesovic, V., et al. (1990). The Transport Properties of Carbon Dioxide. J. Phys. Chem. Ref. Data.
-4. Poling, B.E., et al. (2001). The Properties of Gases and Liquids, 5th Ed.
+3. Huber, M.L., et al. (2016). New International Formulation for the Thermal Conductivity of CO₂. J. Phys. Chem. Ref. Data.
+4. Scalabrin, G., et al. (2006). A Reference Multiparameter Thermal Conductivity Equation for Carbon Dioxide. J. Phys. Chem. Ref. Data.
+5. Poling, B.E., et al. (2001). The Properties of Gases and Liquids, 5th Ed.

--- a/src/test/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/conductivity/ThermalConductivityDocumentationTest.java
+++ b/src/test/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/conductivity/ThermalConductivityDocumentationTest.java
@@ -1,0 +1,156 @@
+package neqsim.physicalproperties.methods.commonphasephysicalproperties.conductivity;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSpanWagnerEos;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Verifies every Java API pattern in the thermal-conductivity documentation. */
+public class ThermalConductivityDocumentationTest {
+  private static void flashAndInitialize(SystemInterface fluid) {
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+    fluid.initProperties();
+  }
+
+  private static void assertPositiveFinite(double value) {
+    assertTrue(Double.isFinite(value), "Conductivity must be finite");
+    assertTrue(value > 0.0, "Conductivity must be positive: " + value);
+  }
+
+  /** Verifies the basic natural-gas example, including its formerly missing interface import. */
+  @Test
+  void basicConductivityExample() {
+    SystemInterface fluid = new SystemSrkEos(350.0, 50.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.05);
+    fluid.setMixingRule("classic");
+
+    flashAndInitialize(fluid);
+
+    assertPositiveFinite(fluid.getPhase("gas").getThermalConductivity("W/mK"));
+  }
+
+  /** Verifies the self-contained model-comparison example. */
+  @Test
+  void compareConductivityModelsExample() {
+    String[] models = { "PFCT", "Chung-dense" };
+    double[] conductivities = new double[models.length];
+
+    for (int i = 0; i < models.length; i++) {
+      SystemInterface fluid = new SystemSrkEos(350.0, 50.0);
+      fluid.addComponent("methane", 0.85);
+      fluid.addComponent("ethane", 0.10);
+      fluid.addComponent("propane", 0.05);
+      fluid.setMixingRule("classic");
+      flashAndInitialize(fluid);
+
+      fluid.getPhase("gas").getPhysicalProperties().setConductivityModel(models[i]);
+      fluid.getPhase("gas").initPhysicalProperties();
+      conductivities[i] = fluid.getPhase("gas").getThermalConductivity("W/mK");
+      assertPositiveFinite(conductivities[i]);
+    }
+  }
+
+  /** Verifies cloning, pressure units, flashing, and property access in the pressure sweep. */
+  @Test
+  void conductivityPressureSweepExample() {
+    SystemInterface baseFluid = new SystemSrkEos(350.0, 10.0);
+    baseFluid.addComponent("methane", 1.0);
+    baseFluid.setMixingRule("classic");
+
+    double[] pressuresBara = { 10, 50, 100, 150, 200 };
+    for (double pressureBara : pressuresBara) {
+      SystemInterface fluid = baseFluid.clone();
+      fluid.setPressure(pressureBara, "bara");
+      flashAndInitialize(fluid);
+      assertPositiveFinite(fluid.getPhase(0).getThermalConductivity("W/mK"));
+    }
+  }
+
+  /** Verifies phase-name guards and conductivity access for the multiphase example. */
+  @Test
+  void twoPhaseConductivityExample() {
+    SystemInterface fluid = new SystemSrkEos(280.0, 30.0);
+    fluid.addComponent("methane", 0.5);
+    fluid.addComponent("n-pentane", 0.5);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    flashAndInitialize(fluid);
+
+    assertTrue(fluid.hasPhaseType("gas"), "Expected a gas phase");
+    assertTrue(fluid.hasPhaseType("oil"), "Expected an oil phase");
+    assertPositiveFinite(fluid.getPhase("gas").getThermalConductivity("W/mK"));
+    assertPositiveFinite(fluid.getPhase("oil").getThermalConductivity("W/mK"));
+  }
+
+  /** Verifies the case-sensitive model keys used by the page's model-specific snippets. */
+  @Test
+  void documentedConductivityModelKeys() {
+    SystemInterface gas = new SystemSrkEos(300.0, 50.0);
+    gas.addComponent("methane", 0.9);
+    gas.addComponent("ethane", 0.1);
+    gas.setMixingRule("classic");
+    flashAndInitialize(gas);
+    for (String model : new String[] { "PFCT", "Chung", "Chung-dense" }) {
+      gas.getPhase("gas").getPhysicalProperties().setConductivityModel(model);
+      gas.getPhase("gas").initPhysicalProperties();
+      assertPositiveFinite(gas.getPhase("gas").getThermalConductivity("W/mK"));
+    }
+    gas.getPhase("gas").getPhysicalProperties().setConductivityModel("friction theory");
+    gas.getPhase("gas").initPhysicalProperties();
+    assertPositiveFinite(gas.getPhase("gas").getThermalConductivity("W/mK"));
+
+    SystemInterface liquid = new SystemSrkEos(300.0, 10.0);
+    liquid.addComponent("n-heptane", 1.0);
+    liquid.setMixingRule("classic");
+    flashAndInitialize(liquid);
+    liquid.getPhase("oil").getPhysicalProperties().setConductivityModel("polynom");
+    liquid.getPhase("oil").initPhysicalProperties();
+    assertPositiveFinite(liquid.getPhase("oil").getThermalConductivity("W/mK"));
+
+    SystemInterface carbonDioxide = new SystemSpanWagnerEos(300.0, 10.0);
+    flashAndInitialize(carbonDioxide);
+    carbonDioxide.getPhase(0).getPhysicalProperties().setConductivityModel("CO2Model");
+    carbonDioxide.getPhase(0).initPhysicalProperties();
+    assertPositiveFinite(carbonDioxide.getPhase(0).getThermalConductivity("W/mK"));
+
+    SystemInterface water = new SystemSrkEos(400.0, 1.0);
+    water.addComponent("water", 1.0);
+    water.setMixingRule("classic");
+    flashAndInitialize(water);
+    water.getPhase(0).getPhysicalProperties().setConductivityModel("WaterModel");
+    water.getPhase(0).initPhysicalProperties();
+    assertPositiveFinite(water.getPhase(0).getThermalConductivity("W/mK"));
+
+    SystemInterface hydrogen = new SystemSrkEos(300.0, 1.0);
+    hydrogen.addComponent("hydrogen", 1.0);
+    hydrogen.setMixingRule("classic");
+    flashAndInitialize(hydrogen);
+    hydrogen.getPhase(0).getPhysicalProperties().setConductivityModel("H2Model");
+    hydrogen.getPhase(0).initPhysicalProperties();
+    assertPositiveFinite(hydrogen.getPhase(0).getThermalConductivity("W/mK"));
+
+    SystemInterface aqueous = new SystemSrkCPAstatoil(298.15, 1.013);
+    aqueous.addComponent("water", 0.7);
+    aqueous.addComponent("MEG", 0.3);
+    aqueous.setMixingRule(10);
+    aqueous.setMultiPhaseCheck(true);
+    flashAndInitialize(aqueous);
+    int aqueousPhaseIndex = 0;
+    for (int i = 0; i < aqueous.getNumberOfPhases(); i++) {
+      String phaseType = aqueous.getPhase(i).getType().toString();
+      if (phaseType.contains("LIQUID") || phaseType.contains("AQUEOUS")) {
+        aqueousPhaseIndex = i;
+        break;
+      }
+    }
+    aqueous.getPhase(aqueousPhaseIndex).getPhysicalProperties().setConductivityModel("Filippov");
+    aqueous.getPhase(aqueousPhaseIndex).initPhysicalProperties();
+    assertPositiveFinite(aqueous.getPhase(aqueousPhaseIndex).getThermalConductivity("W/mK"));
+  }
+}


### PR DESCRIPTION
## Campaign

Relates to #2499.

## Scan scope

D003 — executable API audit of one bounded physical-properties page:

- `docs/physical_properties/thermal_conductivity_models.md`
- current conductivity model selection in `PhysicalProperties`
- current model implementations and conductivity tests

No other physical-property guide was changed.

## Confirmed defects

1. **High — non-compiling example:** the basic Java example declared `SystemInterface` without importing it.
2. **High — incomplete example:** the comparison example called an undefined `createFluid()` helper.
3. **Medium — stale model-selection workflow:** model-specific snippets did not reinitialize the changed phase, so a reader could retrieve a stale result.
4. **Medium — inaccurate CO2 provenance:** the page described the implementation as the Vesovic correlation, while current source implements a polynomial fit to CoolProp reference data and identifies Huber/Scalabrin.
5. **Medium — unsafe applicability claim:** the page advertised broad CO2 pressure/temperature/all-phase coverage without stating that `CO2Model` rejects mixtures or that the implementation does not enforce a validity envelope.
6. **Medium — incomplete/current API guidance:** `Chung-dense` and the other implemented case-sensitive model keys were absent; the pressure sweep also used ambiguous `bar` rather than `bara`.

## Fixes

- Made all four usage examples self-contained and Java 8 compatible.
- Added the missing import and removed the undefined helper.
- Recalculate the selected phase after every model switch.
- Use explicit `bara` pressure units and result arrays rather than console output.
- Document `Chung-dense`, all currently implemented keys, case sensitivity, and the current unknown-key fallback.
- Correct the CO2 implementation description, pure-component constraint, extrapolation warning, and references.
- Add `ThermalConductivityDocumentationTest`, exercising every documented API pattern and all nine model keys with positive/finite assertions.

## Validation performed

- Read current `PhysicalProperties.setConductivityModel`, phase/system initialization code, CO2 and Chung implementations, and existing conductivity tests.
- NeqSim 3.16.0 runtime smoke test through the Java gateway: **all nine documented model keys returned positive finite conductivity**.
- Page structure: front matter, code fences, supported KaTeX delimiters, and all table-of-contents anchors passed.
- `python devtools/check_documentation_search.py`: **619 Markdown pages and 1 standalone HTML page passed**.
- External links in this bounded page: none.
- Java source style: no lines over 120 characters.
- Hosted pre-commit checks: **passed**.
- Hosted Jekyll documentation build, generated search coverage, and JavaScript syntax checks: **passed**.
- Hosted Java 21 Javadoc: **passed**.
- Hosted CodeQL security analysis: **passed**.

## Pending hosted verification

The Ubuntu full test/JaCoCo job and Windows fast-test job are still running. The local environment has a Java runtime but no `javac`; Maven could not resolve its pinned enforcer plugin because Maven Central DNS was unavailable. Therefore this PR remains draft and D003 remains `validating`; it does **not** claim a completed JUnit gate yet.

## Compatibility and impact

Documentation and tests only; no production API, default, model parameter, or numerical behavior changes.

## Next scope

After this PR is merged, continue D003 with one bounded viscosity or diffusivity API-example page and focused executable coverage.
