### PR TITLE
Fix lifecycle compressor state and pre-run design reports

### DIFF
--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentEvaluator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentEvaluator.java
@@ -31,4 +31,3 @@ public final class AreaDevelopmentEvaluator {
     return new AreaDevelopmentResult(portfolio.getAreaName(), results);
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentEvaluator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentEvaluator.java
@@ -25,10 +25,10 @@ public final class AreaDevelopmentEvaluator {
         if (first.isEligible() != second.isEligible()) {
           return first.isEligible() ? -1 : 1;
         }
-        return Double.compare(second.getLifecycleResult().getNpvMusd(),
-            first.getLifecycleResult().getNpvMusd());
+        return Double.compare(second.getLifecycleResult().getNpvMusd(), first.getLifecycleResult().getNpvMusd());
       }
     });
     return new AreaDevelopmentResult(portfolio.getAreaName(), results);
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentOption.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentOption.java
@@ -73,4 +73,3 @@ public final class AreaDevelopmentOption implements Serializable {
     return lifecycleConcept;
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentOption.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentOption.java
@@ -22,12 +22,11 @@ public final class AreaDevelopmentOption implements Serializable {
 
   private AreaDevelopmentOption(String name, RouteType routeType, String receivingAssetName,
       FieldLifecycleConcept lifecycleConcept) {
-    if (name == null || name.trim().isEmpty() || receivingAssetName == null
-        || receivingAssetName.trim().isEmpty() || lifecycleConcept == null) {
+    if (name == null || name.trim().isEmpty() || receivingAssetName == null || receivingAssetName.trim().isEmpty()
+        || lifecycleConcept == null) {
       throw new IllegalArgumentException("option name, receiving asset, and lifecycle concept are required");
     }
-    FacilityLifecycleStrategy facility =
-        lifecycleConcept.getConfiguration().getFacilityLifecycleStrategy();
+    FacilityLifecycleStrategy facility = lifecycleConcept.getConfiguration().getFacilityLifecycleStrategy();
     if (facility == null) {
       throw new IllegalArgumentException("area-development options require a facility lifecycle strategy");
     }
@@ -74,3 +73,4 @@ public final class AreaDevelopmentOption implements Serializable {
     return lifecycleConcept;
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentResult.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentResult.java
@@ -88,4 +88,3 @@ public final class AreaDevelopmentResult implements Serializable {
     return table.toString();
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentResult.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/AreaDevelopmentResult.java
@@ -33,8 +33,8 @@ public final class AreaDevelopmentResult implements Serializable {
 
     /** Returns whether the option remains eligible under its product-specification policy. */
     public boolean isEligible() {
-      FieldProductSpecifications specifications =
-          option.getLifecycleConcept().getConfiguration().getProductSpecifications();
+      FieldProductSpecifications specifications = option.getLifecycleConcept().getConfiguration()
+          .getProductSpecifications();
       return specifications == null || specifications.getViolationAction() != ViolationAction.REJECT_OPTION
           || lifecycleResult.areAllProductSpecificationsMet();
     }
@@ -78,14 +78,14 @@ public final class AreaDevelopmentResult implements Serializable {
     for (OptionResult optionResult : rankedOptions) {
       AreaDevelopmentOption option = optionResult.getOption();
       FieldLifecycleResult result = optionResult.getLifecycleResult();
-      table.append(String.format("| %s | %s | %s | %s | %.0f | %.1f | %.1f | %.1f | %.1f | %.1f | %d |%n",
-          option.getName(), option.getRouteType(), option.getReceivingAssetName(),
-          optionResult.isEligible() ? "yes" : "no", result.getNpvMusd(),
-          result.getBreakevenOilPriceUsdPerBbl(), result.getCumulativeOilSm3() / 1.0e6,
-          result.getCumulativeDeferredOilSm3() / 1.0e6, result.getPeakFacilityUtilization() * 100.0,
-          result.getPeakUnconstrainedFacilityUtilization() * 100.0,
-          result.getOffSpecificationYears()));
+      table.append(
+          String.format("| %s | %s | %s | %s | %.0f | %.1f | %.1f | %.1f | %.1f | %.1f | %d |%n", option.getName(),
+              option.getRouteType(), option.getReceivingAssetName(), optionResult.isEligible() ? "yes" : "no",
+              result.getNpvMusd(), result.getBreakevenOilPriceUsdPerBbl(), result.getCumulativeOilSm3() / 1.0e6,
+              result.getCumulativeDeferredOilSm3() / 1.0e6, result.getPeakFacilityUtilization() * 100.0,
+              result.getPeakUnconstrainedFacilityUtilization() * 100.0, result.getOffSpecificationYears()));
     }
     return table.toString();
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FacilityModificationPlan.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FacilityModificationPlan.java
@@ -19,9 +19,8 @@ public final class FacilityModificationPlan implements Serializable {
     private final double requiredCapacityMultiplier;
     private final double associatedDeferredOilSm3;
 
-    Candidate(int firstRequiredYear, String bottleneck, String modificationScope,
-        double peakRequestedUtilization, double requiredCapacityMultiplier,
-        double associatedDeferredOilSm3) {
+    Candidate(int firstRequiredYear, String bottleneck, String modificationScope, double peakRequestedUtilization,
+        double requiredCapacityMultiplier, double associatedDeferredOilSm3) {
       this.firstRequiredYear = firstRequiredYear;
       this.bottleneck = bottleneck;
       this.modificationScope = modificationScope;
@@ -65,8 +64,7 @@ public final class FacilityModificationPlan implements Serializable {
   private final double targetUtilization;
   private final List<Candidate> candidates;
 
-  FacilityModificationPlan(String conceptName, double targetUtilization,
-      List<Candidate> candidates) {
+  FacilityModificationPlan(String conceptName, double targetUtilization, List<Candidate> candidates) {
     this.conceptName = conceptName;
     this.targetUtilization = targetUtilization;
     this.candidates = Collections.unmodifiableList(new ArrayList<Candidate>(candidates));
@@ -99,12 +97,11 @@ public final class FacilityModificationPlan implements Serializable {
     table.append("| Capacity multiplier | Deferred oil (MSm3) |\n");
     table.append("|---:|---|---|---:|---:|---:|\n");
     for (Candidate candidate : candidates) {
-      table.append(String.format("| %d | %s | %s | %.1f%% | %.2f | %.2f |%n",
-          candidate.getFirstRequiredYear(), candidate.getBottleneck(),
-          candidate.getModificationScope(), candidate.getPeakRequestedUtilization() * 100.0,
-          candidate.getRequiredCapacityMultiplier(),
-          candidate.getAssociatedDeferredOilSm3() / 1.0e6));
+      table.append(String.format("| %d | %s | %s | %.1f%% | %.2f | %.2f |%n", candidate.getFirstRequiredYear(),
+          candidate.getBottleneck(), candidate.getModificationScope(), candidate.getPeakRequestedUtilization() * 100.0,
+          candidate.getRequiredCapacityMultiplier(), candidate.getAssociatedDeferredOilSm3() / 1.0e6));
     }
     return table.toString();
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FacilityModificationPlan.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FacilityModificationPlan.java
@@ -104,4 +104,3 @@ public final class FacilityModificationPlan implements Serializable {
     return table.toString();
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FacilityModificationPlanner.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FacilityModificationPlanner.java
@@ -98,4 +98,3 @@ public final class FacilityModificationPlanner {
     }
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FacilityModificationPlanner.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FacilityModificationPlanner.java
@@ -15,9 +15,8 @@ public final class FacilityModificationPlanner {
    * Identifies nameplate and detailed-equipment debottleneck candidates.
    *
    * <p>
-   * The multiplier is a screening target. Each candidate must be implemented in a cloned detailed
-   * {@code ProcessSystem} or {@code ProcessModel}, mechanically sized, costed, and rerun as a new lifecycle option
-   * before selection.
+   * The multiplier is a screening target. Each candidate must be implemented in a cloned detailed {@code ProcessSystem}
+   * or {@code ProcessModel}, mechanically sized, costed, and rerun as a new lifecycle option before selection.
    * </p>
    *
    * @param result evaluated field lifecycle
@@ -28,16 +27,14 @@ public final class FacilityModificationPlanner {
     if (result == null) {
       throw new IllegalArgumentException("field lifecycle result is required");
     }
-    if (!(targetUtilization > 0.0) || targetUtilization > 1.0
-        || !Double.isFinite(targetUtilization)) {
+    if (!(targetUtilization > 0.0) || targetUtilization > 1.0 || !Double.isFinite(targetUtilization)) {
       throw new IllegalArgumentException("target utilization must be finite, positive, and at most one");
     }
 
     Map<String, MutableCandidate> grouped = new LinkedHashMap<String, MutableCandidate>();
     for (AnnualResult annual : result.getAnnualResults()) {
       double requestedUtilization = annual.getUnconstrainedFacilityUtilization();
-      if (requestedUtilization <= targetUtilization + 1.0e-9
-          && annual.getCapacityDeferredOilSm3() <= 1.0e-9) {
+      if (requestedUtilization <= targetUtilization + 1.0e-9 && annual.getCapacityDeferredOilSm3() <= 1.0e-9) {
         continue;
       }
       String bottleneck = annual.getUnconstrainedBottleneck();
@@ -52,26 +49,23 @@ public final class FacilityModificationPlanner {
         candidate = new MutableCandidate(annual.getYear(), bottleneck);
         grouped.put(bottleneck, candidate);
       }
-      candidate.peakRequestedUtilization =
-          Math.max(candidate.peakRequestedUtilization, requestedUtilization);
+      candidate.peakRequestedUtilization = Math.max(candidate.peakRequestedUtilization, requestedUtilization);
       candidate.deferredOilSm3 += annual.getCapacityDeferredOilSm3();
     }
 
     List<Candidate> candidates = new ArrayList<Candidate>();
     for (MutableCandidate candidate : grouped.values()) {
       double multiplier = Math.max(1.0, candidate.peakRequestedUtilization / targetUtilization);
-      candidates.add(new Candidate(candidate.firstYear, candidate.bottleneck,
-          modificationScope(candidate.bottleneck), candidate.peakRequestedUtilization, multiplier,
-          candidate.deferredOilSm3));
+      candidates.add(new Candidate(candidate.firstYear, candidate.bottleneck, modificationScope(candidate.bottleneck),
+          candidate.peakRequestedUtilization, multiplier, candidate.deferredOilSm3));
     }
     return new FacilityModificationPlan(result.getConceptName(), targetUtilization, candidates);
   }
 
   private static String modificationScope(String bottleneck) {
     String normalized = bottleneck.toLowerCase(Locale.ROOT);
-    if (normalized.contains("surf") || normalized.contains("flowline")
-        || normalized.contains("pipeline") || normalized.contains("riser")
-        || normalized.contains("subsea")) {
+    if (normalized.contains("surf") || normalized.contains("flowline") || normalized.contains("pipeline")
+        || normalized.contains("riser") || normalized.contains("subsea")) {
       return "rerate the shared SURF route; evaluate pressure support, looping, a new riser, or an alternate tie-in";
     }
     if (normalized.contains("water") || normalized.contains("hydrocyclone")) {
@@ -104,3 +98,4 @@ public final class FacilityModificationPlanner {
     }
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleModel.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleModel.java
@@ -85,14 +85,13 @@ public final class FieldLifecycleModel implements Serializable {
    * @param existingProcessSystem existing plant flowsheet, including its equipment constraints
    * @return connection-point builder
    */
-  public static Builder existingFacility(String name, SimpleReservoir reservoir,
-      ProcessSystem existingProcessSystem) {
+  public static Builder existingFacility(String name, SimpleReservoir reservoir, ProcessSystem existingProcessSystem) {
     return builder(name, reservoir, existingProcessSystem);
   }
 
   /** Starts a builder for an existing facility represented by a multi-area process model. */
-  public static Builder existingFacility(String name, SimpleReservoir reservoir,
-      ProcessModel existingProcessModel, String facilityAreaName) {
+  public static Builder existingFacility(String name, SimpleReservoir reservoir, ProcessModel existingProcessModel,
+      String facilityAreaName) {
     return builder(name, reservoir, existingProcessModel, facilityAreaName);
   }
 
@@ -115,8 +114,8 @@ public final class FieldLifecycleModel implements Serializable {
     ProcessModel infrastructure = new ProcessModel();
     infrastructure.add("existing SURF", existingSurfSystem);
     infrastructure.add("existing facility", existingFacilitySystem);
-    return new Builder(name, reservoir, existingFacilitySystem, infrastructure,
-        "existing facility", existingSurfSystem, "existing SURF");
+    return new Builder(name, reservoir, existingFacilitySystem, infrastructure, "existing facility", existingSurfSystem,
+        "existing SURF");
   }
 
   /**
@@ -129,8 +128,7 @@ public final class FieldLifecycleModel implements Serializable {
     if (surf == facility) {
       throw new IllegalArgumentException("SURF and facility area names must identify distinct process systems");
     }
-    return new Builder(name, reservoir, facility, existingInfrastructure, facilityAreaName, surf,
-        surfAreaName);
+    return new Builder(name, reservoir, facility, existingInfrastructure, facilityAreaName, surf, surfAreaName);
   }
 
   /**
@@ -185,9 +183,9 @@ public final class FieldLifecycleModel implements Serializable {
       StreamInterface reservoirGasInjector, StreamInterface recoveredGas, Splitter gasAllocationSplitter,
       StreamInterface stabilizedOilExport, StreamInterface gasExport, StreamInterface compressedInjectionGas,
       StreamInterface hostOilFeed, StreamInterface hostGasFeed, StreamInterface hostWaterFeed) {
-    this(name, reservoir, processSystem, reservoirOilProducer, reservoirWaterProducer,
-        reservoirGasInjector, recoveredGas, gasAllocationSplitter, stabilizedOilExport, gasExport,
-        compressedInjectionGas, hostOilFeed, hostGasFeed, hostWaterFeed, null);
+    this(name, reservoir, processSystem, reservoirOilProducer, reservoirWaterProducer, reservoirGasInjector,
+        recoveredGas, gasAllocationSplitter, stabilizedOilExport, gasExport, compressedInjectionGas, hostOilFeed,
+        hostGasFeed, hostWaterFeed, null);
   }
 
   /** Creates a tieback-capable lifecycle model with an explicit treated-water discharge stream. */
@@ -197,20 +195,17 @@ public final class FieldLifecycleModel implements Serializable {
       StreamInterface stabilizedOilExport, StreamInterface gasExport, StreamInterface compressedInjectionGas,
       StreamInterface hostOilFeed, StreamInterface hostGasFeed, StreamInterface hostWaterFeed,
       StreamInterface treatedWaterDischarge) {
-    this(name, reservoir, processSystem, null, null, null, null, reservoirOilProducer,
-        reservoirWaterProducer, reservoirGasInjector, recoveredGas, gasAllocationSplitter,
-        stabilizedOilExport, gasExport, compressedInjectionGas, hostOilFeed, hostGasFeed,
-        hostWaterFeed, treatedWaterDischarge);
+    this(name, reservoir, processSystem, null, null, null, null, reservoirOilProducer, reservoirWaterProducer,
+        reservoirGasInjector, recoveredGas, gasAllocationSplitter, stabilizedOilExport, gasExport,
+        compressedInjectionGas, hostOilFeed, hostGasFeed, hostWaterFeed, treatedWaterDischarge);
   }
 
   private FieldLifecycleModel(String name, SimpleReservoir reservoir, ProcessSystem processSystem,
-      ProcessModel processModel, String facilityAreaName, ProcessSystem existingSurfSystem,
-      String surfAreaName, StreamInterface reservoirOilProducer,
-      StreamInterface reservoirWaterProducer, StreamInterface reservoirGasInjector,
-      StreamInterface recoveredGas, Splitter gasAllocationSplitter,
-      StreamInterface stabilizedOilExport, StreamInterface gasExport,
-      StreamInterface compressedInjectionGas, StreamInterface hostOilFeed,
-      StreamInterface hostGasFeed, StreamInterface hostWaterFeed,
+      ProcessModel processModel, String facilityAreaName, ProcessSystem existingSurfSystem, String surfAreaName,
+      StreamInterface reservoirOilProducer, StreamInterface reservoirWaterProducer,
+      StreamInterface reservoirGasInjector, StreamInterface recoveredGas, Splitter gasAllocationSplitter,
+      StreamInterface stabilizedOilExport, StreamInterface gasExport, StreamInterface compressedInjectionGas,
+      StreamInterface hostOilFeed, StreamInterface hostGasFeed, StreamInterface hostWaterFeed,
       StreamInterface treatedWaterDischarge) {
     this.name = require(name, "name");
     this.reservoir = require(reservoir, "reservoir");
@@ -240,15 +235,13 @@ public final class FieldLifecycleModel implements Serializable {
     return value;
   }
 
-  private static ProcessSystem requireArea(ProcessModel processModel, String areaName,
-      String parameterName) {
+  private static ProcessSystem requireArea(ProcessModel processModel, String areaName, String parameterName) {
     require(processModel, "processModel");
     require(areaName, parameterName);
     ProcessSystem area = processModel.get(areaName);
     if (area == null) {
       throw new IllegalArgumentException(parameterName + " '" + areaName
-          + "' is not present in process model; available areas: "
-          + processModel.getProcessSystemNames());
+          + "' is not present in process model; available areas: " + processModel.getProcessSystemNames());
     }
     return area;
   }
@@ -414,9 +407,8 @@ public final class FieldLifecycleModel implements Serializable {
     private FieldProductionPotentialProvider productionPotentialProvider;
     private FieldProductQualityProvider productQualityProvider;
 
-    private Builder(String name, SimpleReservoir reservoir, ProcessSystem processSystem,
-        ProcessModel processModel, String facilityAreaName, ProcessSystem existingSurfSystem,
-        String surfAreaName) {
+    private Builder(String name, SimpleReservoir reservoir, ProcessSystem processSystem, ProcessModel processModel,
+        String facilityAreaName, ProcessSystem existingSurfSystem, String surfAreaName) {
       this.name = require(name, "name");
       this.reservoir = require(reservoir, "reservoir");
       this.processSystem = require(processSystem, "processSystem");
@@ -459,8 +451,7 @@ public final class FieldLifecycleModel implements Serializable {
      * flowsheet determines which shared hydraulic and processing equipment sees the host load.
      * </p>
      */
-    public Builder hostFeeds(StreamInterface oilFeed, StreamInterface gasFeed,
-        StreamInterface waterFeed) {
+    public Builder hostFeeds(StreamInterface oilFeed, StreamInterface gasFeed, StreamInterface waterFeed) {
       hostOilFeed = oilFeed;
       hostGasFeed = gasFeed;
       hostWaterFeed = waterFeed;
@@ -492,14 +483,14 @@ public final class FieldLifecycleModel implements Serializable {
       if (hasAnyHostFeed && !hasAllHostFeeds) {
         throw new IllegalArgumentException("host oil, gas, and water feeds must be supplied together");
       }
-      FieldLifecycleModel model = new FieldLifecycleModel(name, reservoir, processSystem,
-          processModel, facilityAreaName, existingSurfSystem, surfAreaName, reservoirOilProducer,
-          reservoirWaterProducer, reservoirGasInjector, recoveredGas, gasAllocationSplitter,
-          stabilizedOilExport, gasExport, compressedInjectionGas, hostOilFeed, hostGasFeed,
-          hostWaterFeed, treatedWaterDischarge);
+      FieldLifecycleModel model = new FieldLifecycleModel(name, reservoir, processSystem, processModel,
+          facilityAreaName, existingSurfSystem, surfAreaName, reservoirOilProducer, reservoirWaterProducer,
+          reservoirGasInjector, recoveredGas, gasAllocationSplitter, stabilizedOilExport, gasExport,
+          compressedInjectionGas, hostOilFeed, hostGasFeed, hostWaterFeed, treatedWaterDischarge);
       model.setProductionPotentialProvider(productionPotentialProvider);
       model.setProductQualityProvider(productQualityProvider);
       return model;
     }
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleModel.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleModel.java
@@ -493,4 +493,3 @@ public final class FieldLifecycleModel implements Serializable {
     }
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleResult.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleResult.java
@@ -46,37 +46,33 @@ public final class FieldLifecycleResult implements Serializable {
         double co2EmissionsTonnes, double potentialOilRateSm3PerDay, double requestedOilRateSm3PerDay,
         double hostOilRateSm3PerDay, double hostGasRateSm3PerDay, double hostWaterRateSm3PerDay, double holdbackOilSm3,
         double capacityDeferredOilSm3, double maximumFacilityUtilization, String primaryBottleneck) {
-      this(year, oilSm3, gasExportSm3, gasInjectedSm3, waterProducedSm3,
-          averageOilRateSm3PerDay, averageWaterCut, averageReservoirPressureBara, energyMWh,
-          co2EmissionsTonnes, potentialOilRateSm3PerDay, requestedOilRateSm3PerDay,
-          hostOilRateSm3PerDay, hostGasRateSm3PerDay, hostWaterRateSm3PerDay, holdbackOilSm3,
+      this(year, oilSm3, gasExportSm3, gasInjectedSm3, waterProducedSm3, averageOilRateSm3PerDay, averageWaterCut,
+          averageReservoirPressureBara, energyMWh, co2EmissionsTonnes, potentialOilRateSm3PerDay,
+          requestedOilRateSm3PerDay, hostOilRateSm3PerDay, hostGasRateSm3PerDay, hostWaterRateSm3PerDay, holdbackOilSm3,
           capacityDeferredOilSm3, maximumFacilityUtilization, primaryBottleneck,
           ProductSpecificationResult.notEvaluated());
     }
 
-    AnnualResult(int year, double oilSm3, double gasExportSm3, double gasInjectedSm3,
-        double waterProducedSm3, double averageOilRateSm3PerDay, double averageWaterCut,
-        double averageReservoirPressureBara, double energyMWh, double co2EmissionsTonnes,
-        double potentialOilRateSm3PerDay, double requestedOilRateSm3PerDay,
-        double hostOilRateSm3PerDay, double hostGasRateSm3PerDay, double hostWaterRateSm3PerDay,
-        double holdbackOilSm3, double capacityDeferredOilSm3, double maximumFacilityUtilization,
-        String primaryBottleneck, ProductSpecificationResult productSpecificationResult) {
-      this(year, oilSm3, gasExportSm3, gasInjectedSm3, waterProducedSm3,
-          averageOilRateSm3PerDay, averageWaterCut, averageReservoirPressureBara, energyMWh,
-          co2EmissionsTonnes, potentialOilRateSm3PerDay, requestedOilRateSm3PerDay,
-          hostOilRateSm3PerDay, hostGasRateSm3PerDay, hostWaterRateSm3PerDay, holdbackOilSm3,
-          capacityDeferredOilSm3, maximumFacilityUtilization, primaryBottleneck,
-          maximumFacilityUtilization, primaryBottleneck, productSpecificationResult);
+    AnnualResult(int year, double oilSm3, double gasExportSm3, double gasInjectedSm3, double waterProducedSm3,
+        double averageOilRateSm3PerDay, double averageWaterCut, double averageReservoirPressureBara, double energyMWh,
+        double co2EmissionsTonnes, double potentialOilRateSm3PerDay, double requestedOilRateSm3PerDay,
+        double hostOilRateSm3PerDay, double hostGasRateSm3PerDay, double hostWaterRateSm3PerDay, double holdbackOilSm3,
+        double capacityDeferredOilSm3, double maximumFacilityUtilization, String primaryBottleneck,
+        ProductSpecificationResult productSpecificationResult) {
+      this(year, oilSm3, gasExportSm3, gasInjectedSm3, waterProducedSm3, averageOilRateSm3PerDay, averageWaterCut,
+          averageReservoirPressureBara, energyMWh, co2EmissionsTonnes, potentialOilRateSm3PerDay,
+          requestedOilRateSm3PerDay, hostOilRateSm3PerDay, hostGasRateSm3PerDay, hostWaterRateSm3PerDay, holdbackOilSm3,
+          capacityDeferredOilSm3, maximumFacilityUtilization, primaryBottleneck, maximumFacilityUtilization,
+          primaryBottleneck, productSpecificationResult);
     }
 
-    AnnualResult(int year, double oilSm3, double gasExportSm3, double gasInjectedSm3,
-        double waterProducedSm3, double averageOilRateSm3PerDay, double averageWaterCut,
-        double averageReservoirPressureBara, double energyMWh, double co2EmissionsTonnes,
-        double potentialOilRateSm3PerDay, double requestedOilRateSm3PerDay,
-        double hostOilRateSm3PerDay, double hostGasRateSm3PerDay, double hostWaterRateSm3PerDay,
-        double holdbackOilSm3, double capacityDeferredOilSm3, double maximumFacilityUtilization,
-        String primaryBottleneck, double unconstrainedFacilityUtilization,
-        String unconstrainedBottleneck, ProductSpecificationResult productSpecificationResult) {
+    AnnualResult(int year, double oilSm3, double gasExportSm3, double gasInjectedSm3, double waterProducedSm3,
+        double averageOilRateSm3PerDay, double averageWaterCut, double averageReservoirPressureBara, double energyMWh,
+        double co2EmissionsTonnes, double potentialOilRateSm3PerDay, double requestedOilRateSm3PerDay,
+        double hostOilRateSm3PerDay, double hostGasRateSm3PerDay, double hostWaterRateSm3PerDay, double holdbackOilSm3,
+        double capacityDeferredOilSm3, double maximumFacilityUtilization, String primaryBottleneck,
+        double unconstrainedFacilityUtilization, String unconstrainedBottleneck,
+        ProductSpecificationResult productSpecificationResult) {
       this.year = year;
       this.oilSm3 = oilSm3;
       this.gasExportSm3 = gasExportSm3;
@@ -98,8 +94,8 @@ public final class FieldLifecycleResult implements Serializable {
       this.primaryBottleneck = primaryBottleneck;
       this.unconstrainedFacilityUtilization = unconstrainedFacilityUtilization;
       this.unconstrainedBottleneck = unconstrainedBottleneck;
-      this.productSpecificationResult = productSpecificationResult == null
-          ? ProductSpecificationResult.notEvaluated() : productSpecificationResult;
+      this.productSpecificationResult = productSpecificationResult == null ? ProductSpecificationResult.notEvaluated()
+          : productSpecificationResult;
     }
 
     /** Returns the calendar year. */
@@ -398,11 +394,11 @@ public final class FieldLifecycleResult implements Serializable {
    * @return Markdown table row
    */
   public String toMarkdownRow() {
-    return String.format("| %s | %.0f | %.1f | %.1f | %.1f | %.1f | %.1f | %.1f | %.1f | %.1f | %d |",
-        conceptName, getNpvMusd(), getIrr() * 100.0, breakevenOilPriceUsdPerBbl,
-        cumulativeOilSm3 / 1.0e6, cumulativeDeferredOilSm3 / 1.0e6,
-        peakFacilityUtilization * 100.0, getPeakUnconstrainedFacilityUtilization() * 100.0,
-        cumulativeGasInjectedSm3 / 1.0e9, lifecycleCo2Tonnes / 1000.0,
-        getOffSpecificationYears());
+    return String.format("| %s | %.0f | %.1f | %.1f | %.1f | %.1f | %.1f | %.1f | %.1f | %.1f | %d |", conceptName,
+        getNpvMusd(), getIrr() * 100.0, breakevenOilPriceUsdPerBbl, cumulativeOilSm3 / 1.0e6,
+        cumulativeDeferredOilSm3 / 1.0e6, peakFacilityUtilization * 100.0,
+        getPeakUnconstrainedFacilityUtilization() * 100.0, cumulativeGasInjectedSm3 / 1.0e9,
+        lifecycleCo2Tonnes / 1000.0, getOffSpecificationYears());
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleResult.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleResult.java
@@ -401,4 +401,3 @@ public final class FieldLifecycleResult implements Serializable {
         lifecycleCo2Tonnes / 1000.0, getOffSpecificationYears());
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
@@ -321,8 +321,7 @@ public class FieldLifecycleSimulator {
     }
     FacilityCapacity effectiveCapacity = new FacilityCapacity(configured.getOilSm3PerDay(),
         configured.getGasSm3PerDay(), configured.getWaterSm3PerDay(), configured.getLiquidSm3PerDay(), powerCapacity);
-    ProcessEquipmentInterface bottleneck = strategy.isUseDetailedProcessConstraints()
-        ? getProcessBottleneck(model)
+    ProcessEquipmentInterface bottleneck = strategy.isUseDetailedProcessConstraints() ? getProcessBottleneck(model)
         : null;
     double designBottleneckUtilization = strategy.isUseDetailedProcessConstraints()
         ? getProcessBottleneckUtilization(model)
@@ -333,8 +332,7 @@ public class FieldLifecycleSimulator {
     int requiredParallelTrainCount = (int) Math.ceil(detailedCapacityMultiplier - 1.0e-12);
     return new FacilityDesignResult(strategy.getName(), strategy.getDevelopmentMode(), designRates, effectiveCapacity,
         strategy.getDesignMargin(), designPowerKw, autoSizedCount, constraintCount,
-        getProcessBottleneckName(model, bottleneck), designBottleneckUtilization,
-        detailedCapacityMultiplier,
+        getProcessBottleneckName(model, bottleneck), designBottleneckUtilization, detailedCapacityMultiplier,
         requiredParallelTrainCount);
   }
 
@@ -443,8 +441,8 @@ public class FieldLifecycleSimulator {
         double attributedSatelliteOil = Math.min(totalOilExport,
             satellite.getOilSm3PerDay() * satelliteOilRecoveryFactor);
         lastResult = new FacilityOperatingResult(satellite, host, attributedSatelliteOil,
-            totalGasExport * satelliteGasShare, injectionRate, powerKw, maximumUtilization,
-            primaryBottleneck, unconstrainedUtilization, unconstrainedBottleneck);
+            totalGasExport * satelliteGasShare, injectionRate, powerKw, maximumUtilization, primaryBottleneck,
+            unconstrainedUtilization, unconstrainedBottleneck);
         if (maximumUtilization <= strategy.getMaximumDetailedProcessUtilization() + 1.0e-6) {
           return lastResult;
         }
@@ -627,8 +625,7 @@ public class FieldLifecycleSimulator {
   }
 
   private double getProcessPower(FieldLifecycleModel model, String unit) {
-    return model.hasProcessModel() ? model.getProcessModel().getPower(unit)
-        : model.getProcessSystem().getPower(unit);
+    return model.hasProcessModel() ? model.getProcessModel().getPower(unit) : model.getProcessSystem().getPower(unit);
   }
 
   private int autoSizeProcess(FieldLifecycleModel model, double designMargin) {
@@ -664,14 +661,12 @@ public class FieldLifecycleSimulator {
   }
 
   private int applyMechanicalDesignCapacityConstraints(FieldLifecycleModel model) {
-    return model.hasProcessModel()
-        ? model.getProcessModel().applyMechanicalDesignCapacityConstraints()
+    return model.hasProcessModel() ? model.getProcessModel().applyMechanicalDesignCapacityConstraints()
         : model.getProcessSystem().applyMechanicalDesignCapacityConstraints();
   }
 
   private ProcessEquipmentInterface getProcessBottleneck(FieldLifecycleModel model) {
-    return model.hasProcessModel() ? model.getProcessModel().getBottleneck()
-        : model.getProcessSystem().getBottleneck();
+    return model.hasProcessModel() ? model.getProcessModel().getBottleneck() : model.getProcessSystem().getBottleneck();
   }
 
   private double getProcessBottleneckUtilization(FieldLifecycleModel model) {
@@ -679,8 +674,7 @@ public class FieldLifecycleSimulator {
         : model.getProcessSystem().getBottleneckUtilization();
   }
 
-  private String getProcessBottleneckName(FieldLifecycleModel model,
-      ProcessEquipmentInterface bottleneck) {
+  private String getProcessBottleneckName(FieldLifecycleModel model, ProcessEquipmentInterface bottleneck) {
     if (bottleneck == null) {
       return null;
     }
@@ -719,8 +713,7 @@ public class FieldLifecycleSimulator {
       return ProductSpecificationResult.notEvaluated();
     }
     if (model.getProductQualityProvider() != null) {
-      ProductSpecificationResult result =
-          model.getProductQualityProvider().evaluate(model, specifications);
+      ProductSpecificationResult result = model.getProductQualityProvider().evaluate(model, specifications);
       if (result == null) {
         throw new IllegalStateException("product quality provider returned null");
       }
@@ -787,8 +780,7 @@ public class FieldLifecycleSimulator {
   }
 
   /**
-   * Compressor settings that control the thermodynamic operating solve rather than
-   * the retained mechanical design.
+   * Compressor settings that control the thermodynamic operating solve rather than the retained mechanical design.
    */
   private static final class CompressorOperatingMode {
     private final Compressor compressor;
@@ -844,8 +836,8 @@ public class FieldLifecycleSimulator {
 
     private FacilityOperatingResult(FacilityProductionRate satelliteAllocated, FacilityProductionRate hostAllocated,
         double satelliteOilExportRateSm3PerDay, double satelliteGasExportRateSm3PerDay,
-        double gasInjectionRateSm3PerDay, double powerKw, double maximumUtilization,
-        String primaryBottleneck, double unconstrainedUtilization, String unconstrainedBottleneck) {
+        double gasInjectionRateSm3PerDay, double powerKw, double maximumUtilization, String primaryBottleneck,
+        double unconstrainedUtilization, String unconstrainedBottleneck) {
       this.satelliteAllocated = satelliteAllocated;
       this.hostAllocated = hostAllocated;
       this.satelliteOilExportRateSm3PerDay = satelliteOilExportRateSm3PerDay;
@@ -881,8 +873,7 @@ public class FieldLifecycleSimulator {
     private String primaryBottleneck;
     private double unconstrainedFacilityUtilization;
     private String unconstrainedBottleneck;
-    private ProductSpecificationResult productSpecificationResult =
-        ProductSpecificationResult.notEvaluated();
+    private ProductSpecificationResult productSpecificationResult = ProductSpecificationResult.notEvaluated();
 
     private AnnualAccumulator(int year) {
       this.year = year;
@@ -891,8 +882,8 @@ public class FieldLifecycleSimulator {
     private void add(double days, double oil, double gasExport, double gasInjected, double water, double waterCut,
         double pressure, double energy, double emissions, double potentialOilRate, double requestedOilRate,
         double hostOilRate, double hostGasRate, double hostWaterRate, double holdbackOil, double capacityDeferredOil,
-        double facilityUtilization, String bottleneck, double requestedFacilityUtilization,
-        String requestedBottleneck, ProductSpecificationResult productQuality) {
+        double facilityUtilization, String bottleneck, double requestedFacilityUtilization, String requestedBottleneck,
+        ProductSpecificationResult productQuality) {
       calendarDays += days;
       oilSm3 += oil;
       gasExportSm3 += gasExport;

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.compressor.CompressorChartInterface;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.fielddevelopment.economics.CashFlowEngine;
 import neqsim.process.fielddevelopment.economics.CashFlowEngine.CashFlowResult;
@@ -297,7 +299,12 @@ public class FieldLifecycleSimulator {
     int autoSizedCount = 0;
     int constraintCount = 0;
     if (strategy.isAutoSizeDetailedProcess()) {
-      autoSizedCount = autoSizeProcess(model, strategy.getDesignMargin());
+      List<CompressorOperatingMode> compressorOperatingModes = captureCompressorOperatingModes(model);
+      try {
+        autoSizedCount = autoSizeProcess(model, strategy.getDesignMargin());
+      } finally {
+        restoreCompressorOperatingModes(compressorOperatingModes);
+      }
       if (strategy.isUseDetailedProcessConstraints()) {
         constraintCount = applyMechanicalDesignCapacityConstraints(model);
         runProcess(model);
@@ -314,8 +321,7 @@ public class FieldLifecycleSimulator {
     }
     FacilityCapacity effectiveCapacity = new FacilityCapacity(configured.getOilSm3PerDay(),
         configured.getGasSm3PerDay(), configured.getWaterSm3PerDay(), configured.getLiquidSm3PerDay(), powerCapacity);
-    ProcessEquipmentInterface bottleneck = strategy.isUseDetailedProcessConstraints()
-        ? getProcessBottleneck(model)
+    ProcessEquipmentInterface bottleneck = strategy.isUseDetailedProcessConstraints() ? getProcessBottleneck(model)
         : null;
     double designBottleneckUtilization = strategy.isUseDetailedProcessConstraints()
         ? getProcessBottleneckUtilization(model)
@@ -326,8 +332,7 @@ public class FieldLifecycleSimulator {
     int requiredParallelTrainCount = (int) Math.ceil(detailedCapacityMultiplier - 1.0e-12);
     return new FacilityDesignResult(strategy.getName(), strategy.getDevelopmentMode(), designRates, effectiveCapacity,
         strategy.getDesignMargin(), designPowerKw, autoSizedCount, constraintCount,
-        getProcessBottleneckName(model, bottleneck), designBottleneckUtilization,
-        detailedCapacityMultiplier,
+        getProcessBottleneckName(model, bottleneck), designBottleneckUtilization, detailedCapacityMultiplier,
         requiredParallelTrainCount);
   }
 
@@ -436,8 +441,8 @@ public class FieldLifecycleSimulator {
         double attributedSatelliteOil = Math.min(totalOilExport,
             satellite.getOilSm3PerDay() * satelliteOilRecoveryFactor);
         lastResult = new FacilityOperatingResult(satellite, host, attributedSatelliteOil,
-            totalGasExport * satelliteGasShare, injectionRate, powerKw, maximumUtilization,
-            primaryBottleneck, unconstrainedUtilization, unconstrainedBottleneck);
+            totalGasExport * satelliteGasShare, injectionRate, powerKw, maximumUtilization, primaryBottleneck,
+            unconstrainedUtilization, unconstrainedBottleneck);
         if (maximumUtilization <= strategy.getMaximumDetailedProcessUtilization() + 1.0e-6) {
           return lastResult;
         }
@@ -563,15 +568,64 @@ public class FieldLifecycleSimulator {
 
   private void runProcess(FieldLifecycleModel model) {
     if (model.hasProcessModel()) {
-      model.getProcessModel().run();
+      boolean optimizedExecution = model.getProcessModel().isUseOptimizedExecution();
+      model.getProcessModel().setUseOptimizedExecution(false);
+      try {
+        model.getProcessModel().run();
+      } finally {
+        model.getProcessModel().setUseOptimizedExecution(optimizedExecution);
+      }
     } else {
-      model.getProcessSystem().run();
+      boolean optimizedExecution = model.getProcessSystem().isUseOptimizedExecution();
+      model.getProcessSystem().setUseOptimizedExecution(false);
+      try {
+        model.getProcessSystem().run();
+      } finally {
+        model.getProcessSystem().setUseOptimizedExecution(optimizedExecution);
+      }
+    }
+    if (hasInvalidCompressionPower(model)) {
+      throw new IllegalStateException("Process solve for " + model.getName() + " produced invalid compressor work");
     }
   }
 
+  private boolean hasInvalidCompressionPower(FieldLifecycleModel model) {
+    if (model.hasProcessModel()) {
+      for (String areaName : model.getProcessModel().getProcessSystemNames()) {
+        if (hasInvalidCompressionPower(model.getProcessModel().get(areaName))) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return hasInvalidCompressionPower(model.getProcessSystem());
+  }
+
+  private boolean hasInvalidCompressionPower(ProcessSystem processSystem) {
+    for (ProcessEquipmentInterface equipment : processSystem.getUnitOperations()) {
+      if (!(equipment instanceof Compressor)) {
+        continue;
+      }
+      Compressor compressor = (Compressor) equipment;
+      StreamInterface inlet = compressor.getInletStream();
+      if (inlet == null || compressor.getOutletStream() == null || inlet.getFlowRate("kg/sec") <= 1.0e-9
+          || compressor.getOutletStream().getPressure("bara") <= inlet.getPressure("bara") + 1.0e-9) {
+        continue;
+      }
+      try {
+        double powerKw = compressor.getPower("kW");
+        if (!Double.isFinite(powerKw) || powerKw <= 0.0) {
+          return true;
+        }
+      } catch (RuntimeException ex) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private double getProcessPower(FieldLifecycleModel model, String unit) {
-    return model.hasProcessModel() ? model.getProcessModel().getPower(unit)
-        : model.getProcessSystem().getPower(unit);
+    return model.hasProcessModel() ? model.getProcessModel().getPower(unit) : model.getProcessSystem().getPower(unit);
   }
 
   private int autoSizeProcess(FieldLifecycleModel model, double designMargin) {
@@ -579,15 +633,40 @@ public class FieldLifecycleSimulator {
         : model.getProcessSystem().autoSizeEquipment(designMargin);
   }
 
+  private List<CompressorOperatingMode> captureCompressorOperatingModes(FieldLifecycleModel model) {
+    List<CompressorOperatingMode> operatingModes = new ArrayList<CompressorOperatingMode>();
+    if (model.hasProcessModel()) {
+      for (String areaName : model.getProcessModel().getProcessSystemNames()) {
+        captureCompressorOperatingModes(model.getProcessModel().get(areaName), operatingModes);
+      }
+    } else {
+      captureCompressorOperatingModes(model.getProcessSystem(), operatingModes);
+    }
+    return operatingModes;
+  }
+
+  private void captureCompressorOperatingModes(ProcessSystem processSystem,
+      List<CompressorOperatingMode> operatingModes) {
+    for (ProcessEquipmentInterface equipment : processSystem.getUnitOperations()) {
+      if (equipment instanceof Compressor) {
+        operatingModes.add(new CompressorOperatingMode((Compressor) equipment));
+      }
+    }
+  }
+
+  private void restoreCompressorOperatingModes(List<CompressorOperatingMode> operatingModes) {
+    for (CompressorOperatingMode operatingMode : operatingModes) {
+      operatingMode.restore();
+    }
+  }
+
   private int applyMechanicalDesignCapacityConstraints(FieldLifecycleModel model) {
-    return model.hasProcessModel()
-        ? model.getProcessModel().applyMechanicalDesignCapacityConstraints()
+    return model.hasProcessModel() ? model.getProcessModel().applyMechanicalDesignCapacityConstraints()
         : model.getProcessSystem().applyMechanicalDesignCapacityConstraints();
   }
 
   private ProcessEquipmentInterface getProcessBottleneck(FieldLifecycleModel model) {
-    return model.hasProcessModel() ? model.getProcessModel().getBottleneck()
-        : model.getProcessSystem().getBottleneck();
+    return model.hasProcessModel() ? model.getProcessModel().getBottleneck() : model.getProcessSystem().getBottleneck();
   }
 
   private double getProcessBottleneckUtilization(FieldLifecycleModel model) {
@@ -595,8 +674,7 @@ public class FieldLifecycleSimulator {
         : model.getProcessSystem().getBottleneckUtilization();
   }
 
-  private String getProcessBottleneckName(FieldLifecycleModel model,
-      ProcessEquipmentInterface bottleneck) {
+  private String getProcessBottleneckName(FieldLifecycleModel model, ProcessEquipmentInterface bottleneck) {
     if (bottleneck == null) {
       return null;
     }
@@ -635,8 +713,7 @@ public class FieldLifecycleSimulator {
       return ProductSpecificationResult.notEvaluated();
     }
     if (model.getProductQualityProvider() != null) {
-      ProductSpecificationResult result =
-          model.getProductQualityProvider().evaluate(model, specifications);
+      ProductSpecificationResult result = model.getProductQualityProvider().evaluate(model, specifications);
       if (result == null) {
         throw new IllegalStateException("product quality provider returned null");
       }
@@ -702,6 +779,35 @@ public class FieldLifecycleSimulator {
     }
   }
 
+  /**
+   * Compressor settings that control the thermodynamic operating solve rather than
+   * the retained mechanical design.
+   */
+  private static final class CompressorOperatingMode {
+    private final Compressor compressor;
+    private final CompressorChartInterface compressorChart;
+    private final boolean useCompressorChart;
+    private final boolean solveSpeed;
+    private final boolean limitSpeed;
+
+    private CompressorOperatingMode(Compressor compressor) {
+      this.compressor = compressor;
+      this.compressorChart = compressor.getCompressorChart();
+      this.useCompressorChart = compressorChart != null && compressorChart.isUseCompressorChart();
+      this.solveSpeed = compressor.isSolveSpeed();
+      this.limitSpeed = compressor.isLimitSpeed();
+    }
+
+    private void restore() {
+      if (compressorChart != null) {
+        compressor.setCompressorChart(compressorChart);
+        compressorChart.setUseCompressorChart(useCompressorChart);
+      }
+      compressor.setSolveSpeed(solveSpeed);
+      compressor.setLimitSpeed(limitSpeed);
+    }
+  }
+
   private static final class PotentialRates {
     private final double oilRateSm3PerDay;
     private final double gasRateSm3PerDay;
@@ -731,8 +837,8 @@ public class FieldLifecycleSimulator {
 
     private FacilityOperatingResult(FacilityProductionRate satelliteAllocated, FacilityProductionRate hostAllocated,
         double satelliteOilExportRateSm3PerDay, double satelliteGasExportRateSm3PerDay,
-        double gasInjectionRateSm3PerDay, double powerKw, double maximumUtilization,
-        String primaryBottleneck, double unconstrainedUtilization, String unconstrainedBottleneck) {
+        double gasInjectionRateSm3PerDay, double powerKw, double maximumUtilization, String primaryBottleneck,
+        double unconstrainedUtilization, String unconstrainedBottleneck) {
       this.satelliteAllocated = satelliteAllocated;
       this.hostAllocated = hostAllocated;
       this.satelliteOilExportRateSm3PerDay = satelliteOilExportRateSm3PerDay;
@@ -768,8 +874,7 @@ public class FieldLifecycleSimulator {
     private String primaryBottleneck;
     private double unconstrainedFacilityUtilization;
     private String unconstrainedBottleneck;
-    private ProductSpecificationResult productSpecificationResult =
-        ProductSpecificationResult.notEvaluated();
+    private ProductSpecificationResult productSpecificationResult = ProductSpecificationResult.notEvaluated();
 
     private AnnualAccumulator(int year) {
       this.year = year;
@@ -778,8 +883,8 @@ public class FieldLifecycleSimulator {
     private void add(double days, double oil, double gasExport, double gasInjected, double water, double waterCut,
         double pressure, double energy, double emissions, double potentialOilRate, double requestedOilRate,
         double hostOilRate, double hostGasRate, double hostWaterRate, double holdbackOil, double capacityDeferredOil,
-        double facilityUtilization, String bottleneck, double requestedFacilityUtilization,
-        String requestedBottleneck, ProductSpecificationResult productQuality) {
+        double facilityUtilization, String bottleneck, double requestedFacilityUtilization, String requestedBottleneck,
+        ProductSpecificationResult productQuality) {
       calendarDays += days;
       oilSm3 += oil;
       gasExportSm3 += gasExport;

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
@@ -321,7 +321,8 @@ public class FieldLifecycleSimulator {
     }
     FacilityCapacity effectiveCapacity = new FacilityCapacity(configured.getOilSm3PerDay(),
         configured.getGasSm3PerDay(), configured.getWaterSm3PerDay(), configured.getLiquidSm3PerDay(), powerCapacity);
-    ProcessEquipmentInterface bottleneck = strategy.isUseDetailedProcessConstraints() ? getProcessBottleneck(model)
+    ProcessEquipmentInterface bottleneck = strategy.isUseDetailedProcessConstraints()
+        ? getProcessBottleneck(model)
         : null;
     double designBottleneckUtilization = strategy.isUseDetailedProcessConstraints()
         ? getProcessBottleneckUtilization(model)
@@ -332,7 +333,8 @@ public class FieldLifecycleSimulator {
     int requiredParallelTrainCount = (int) Math.ceil(detailedCapacityMultiplier - 1.0e-12);
     return new FacilityDesignResult(strategy.getName(), strategy.getDevelopmentMode(), designRates, effectiveCapacity,
         strategy.getDesignMargin(), designPowerKw, autoSizedCount, constraintCount,
-        getProcessBottleneckName(model, bottleneck), designBottleneckUtilization, detailedCapacityMultiplier,
+        getProcessBottleneckName(model, bottleneck), designBottleneckUtilization,
+        detailedCapacityMultiplier,
         requiredParallelTrainCount);
   }
 
@@ -441,8 +443,8 @@ public class FieldLifecycleSimulator {
         double attributedSatelliteOil = Math.min(totalOilExport,
             satellite.getOilSm3PerDay() * satelliteOilRecoveryFactor);
         lastResult = new FacilityOperatingResult(satellite, host, attributedSatelliteOil,
-            totalGasExport * satelliteGasShare, injectionRate, powerKw, maximumUtilization, primaryBottleneck,
-            unconstrainedUtilization, unconstrainedBottleneck);
+            totalGasExport * satelliteGasShare, injectionRate, powerKw, maximumUtilization,
+            primaryBottleneck, unconstrainedUtilization, unconstrainedBottleneck);
         if (maximumUtilization <= strategy.getMaximumDetailedProcessUtilization() + 1.0e-6) {
           return lastResult;
         }
@@ -625,7 +627,8 @@ public class FieldLifecycleSimulator {
   }
 
   private double getProcessPower(FieldLifecycleModel model, String unit) {
-    return model.hasProcessModel() ? model.getProcessModel().getPower(unit) : model.getProcessSystem().getPower(unit);
+    return model.hasProcessModel() ? model.getProcessModel().getPower(unit)
+        : model.getProcessSystem().getPower(unit);
   }
 
   private int autoSizeProcess(FieldLifecycleModel model, double designMargin) {
@@ -661,12 +664,14 @@ public class FieldLifecycleSimulator {
   }
 
   private int applyMechanicalDesignCapacityConstraints(FieldLifecycleModel model) {
-    return model.hasProcessModel() ? model.getProcessModel().applyMechanicalDesignCapacityConstraints()
+    return model.hasProcessModel()
+        ? model.getProcessModel().applyMechanicalDesignCapacityConstraints()
         : model.getProcessSystem().applyMechanicalDesignCapacityConstraints();
   }
 
   private ProcessEquipmentInterface getProcessBottleneck(FieldLifecycleModel model) {
-    return model.hasProcessModel() ? model.getProcessModel().getBottleneck() : model.getProcessSystem().getBottleneck();
+    return model.hasProcessModel() ? model.getProcessModel().getBottleneck()
+        : model.getProcessSystem().getBottleneck();
   }
 
   private double getProcessBottleneckUtilization(FieldLifecycleModel model) {
@@ -674,7 +679,8 @@ public class FieldLifecycleSimulator {
         : model.getProcessSystem().getBottleneckUtilization();
   }
 
-  private String getProcessBottleneckName(FieldLifecycleModel model, ProcessEquipmentInterface bottleneck) {
+  private String getProcessBottleneckName(FieldLifecycleModel model,
+      ProcessEquipmentInterface bottleneck) {
     if (bottleneck == null) {
       return null;
     }
@@ -713,7 +719,8 @@ public class FieldLifecycleSimulator {
       return ProductSpecificationResult.notEvaluated();
     }
     if (model.getProductQualityProvider() != null) {
-      ProductSpecificationResult result = model.getProductQualityProvider().evaluate(model, specifications);
+      ProductSpecificationResult result =
+          model.getProductQualityProvider().evaluate(model, specifications);
       if (result == null) {
         throw new IllegalStateException("product quality provider returned null");
       }
@@ -837,8 +844,8 @@ public class FieldLifecycleSimulator {
 
     private FacilityOperatingResult(FacilityProductionRate satelliteAllocated, FacilityProductionRate hostAllocated,
         double satelliteOilExportRateSm3PerDay, double satelliteGasExportRateSm3PerDay,
-        double gasInjectionRateSm3PerDay, double powerKw, double maximumUtilization, String primaryBottleneck,
-        double unconstrainedUtilization, String unconstrainedBottleneck) {
+        double gasInjectionRateSm3PerDay, double powerKw, double maximumUtilization,
+        String primaryBottleneck, double unconstrainedUtilization, String unconstrainedBottleneck) {
       this.satelliteAllocated = satelliteAllocated;
       this.hostAllocated = hostAllocated;
       this.satelliteOilExportRateSm3PerDay = satelliteOilExportRateSm3PerDay;
@@ -874,7 +881,8 @@ public class FieldLifecycleSimulator {
     private String primaryBottleneck;
     private double unconstrainedFacilityUtilization;
     private String unconstrainedBottleneck;
-    private ProductSpecificationResult productSpecificationResult = ProductSpecificationResult.notEvaluated();
+    private ProductSpecificationResult productSpecificationResult =
+        ProductSpecificationResult.notEvaluated();
 
     private AnnualAccumulator(int year) {
       this.year = year;
@@ -883,8 +891,8 @@ public class FieldLifecycleSimulator {
     private void add(double days, double oil, double gasExport, double gasInjected, double water, double waterCut,
         double pressure, double energy, double emissions, double potentialOilRate, double requestedOilRate,
         double hostOilRate, double hostGasRate, double hostWaterRate, double holdbackOil, double capacityDeferredOil,
-        double facilityUtilization, String bottleneck, double requestedFacilityUtilization, String requestedBottleneck,
-        ProductSpecificationResult productQuality) {
+        double facilityUtilization, String bottleneck, double requestedFacilityUtilization,
+        String requestedBottleneck, ProductSpecificationResult productQuality) {
       calendarDays += days;
       oilSm3 += oil;
       gasExportSm3 += gasExport;

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldProductQualityProvider.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldProductQualityProvider.java
@@ -14,4 +14,3 @@ public interface FieldProductQualityProvider extends Serializable {
    */
   ProductSpecificationResult evaluate(FieldLifecycleModel model, FieldProductSpecifications specifications);
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldProductQualityProvider.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldProductQualityProvider.java
@@ -12,6 +12,6 @@ public interface FieldProductQualityProvider extends Serializable {
    * @param specifications limits to evaluate
    * @return measured compliance result
    */
-  ProductSpecificationResult evaluate(FieldLifecycleModel model,
-      FieldProductSpecifications specifications);
+  ProductSpecificationResult evaluate(FieldLifecycleModel model, FieldProductSpecifications specifications);
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldProductSpecifications.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldProductSpecifications.java
@@ -131,11 +131,9 @@ public final class FieldProductSpecifications implements Serializable {
   /** Returns whether at least one quality or discharge limit is active. */
   public boolean hasActiveLimits() {
     return Double.isFinite(maximumGasCo2MolePercent) || Double.isFinite(maximumGasH2sPpm)
-        || Double.isFinite(maximumGasOxygenMolePercent)
-        || Double.isFinite(maximumGasWaterDewPointC) || Double.isFinite(maximumGasHydrocarbonDewPointC)
-        || Double.isFinite(minimumGasGrossCalorificValueMjPerSm3)
-        || Double.isFinite(maximumGasGrossCalorificValueMjPerSm3)
-        || Double.isFinite(minimumGasWobbeIndexMjPerSm3)
+        || Double.isFinite(maximumGasOxygenMolePercent) || Double.isFinite(maximumGasWaterDewPointC)
+        || Double.isFinite(maximumGasHydrocarbonDewPointC) || Double.isFinite(minimumGasGrossCalorificValueMjPerSm3)
+        || Double.isFinite(maximumGasGrossCalorificValueMjPerSm3) || Double.isFinite(minimumGasWobbeIndexMjPerSm3)
         || Double.isFinite(maximumGasWobbeIndexMjPerSm3) || Double.isFinite(maximumGasRelativeDensity)
         || Double.isFinite(maximumOilRvpBara) || Double.isFinite(maximumOilBswVolumePercent)
         || Double.isFinite(maximumOilInWaterMgPerL);
@@ -171,8 +169,7 @@ public final class FieldProductSpecifications implements Serializable {
 
     /** Sets the export-gas oxygen maximum in mole percent. */
     public Builder gasOxygen(double maximumOxygenMolePercent) {
-      maximumGasOxygenMolePercent = nonNegative(maximumOxygenMolePercent,
-          "maximumOxygenMolePercent");
+      maximumGasOxygenMolePercent = nonNegative(maximumOxygenMolePercent, "maximumOxygenMolePercent");
       return this;
     }
 
@@ -184,8 +181,7 @@ public final class FieldProductSpecifications implements Serializable {
       }
       gasDewPointReferencePressureBara = referencePressureBara;
       maximumGasWaterDewPointC = finite(maximumWaterDewPointC, "maximumWaterDewPointC");
-      maximumGasHydrocarbonDewPointC = finite(maximumHydrocarbonDewPointC,
-          "maximumHydrocarbonDewPointC");
+      maximumGasHydrocarbonDewPointC = finite(maximumHydrocarbonDewPointC, "maximumHydrocarbonDewPointC");
       return this;
     }
 
@@ -193,16 +189,14 @@ public final class FieldProductSpecifications implements Serializable {
      * Sets ISO 6976 gas energy-content limits at 15 C volume and 25 C combustion reference temperatures.
      */
     public Builder gasEnergyContent(double minimumGrossCalorificValueMjPerSm3,
-        double maximumGrossCalorificValueMjPerSm3, double minimumWobbeIndexMjPerSm3,
-        double maximumWobbeIndexMjPerSm3, double maximumRelativeDensity) {
+        double maximumGrossCalorificValueMjPerSm3, double minimumWobbeIndexMjPerSm3, double maximumWobbeIndexMjPerSm3,
+        double maximumRelativeDensity) {
       minimumGasGrossCalorificValueMjPerSm3 = positive(minimumGrossCalorificValueMjPerSm3,
           "minimumGrossCalorificValueMjPerSm3");
       maximumGasGrossCalorificValueMjPerSm3 = positive(maximumGrossCalorificValueMjPerSm3,
           "maximumGrossCalorificValueMjPerSm3");
-      minimumGasWobbeIndexMjPerSm3 = positive(minimumWobbeIndexMjPerSm3,
-          "minimumWobbeIndexMjPerSm3");
-      maximumGasWobbeIndexMjPerSm3 = positive(maximumWobbeIndexMjPerSm3,
-          "maximumWobbeIndexMjPerSm3");
+      minimumGasWobbeIndexMjPerSm3 = positive(minimumWobbeIndexMjPerSm3, "minimumWobbeIndexMjPerSm3");
+      maximumGasWobbeIndexMjPerSm3 = positive(maximumWobbeIndexMjPerSm3, "maximumWobbeIndexMjPerSm3");
       this.maximumGasRelativeDensity = positive(maximumRelativeDensity, "maximumRelativeDensity");
       if (minimumGasGrossCalorificValueMjPerSm3 > maximumGasGrossCalorificValueMjPerSm3
           || minimumGasWobbeIndexMjPerSm3 > maximumGasWobbeIndexMjPerSm3) {
@@ -214,15 +208,13 @@ public final class FieldProductSpecifications implements Serializable {
     /** Sets stabilized-oil RVP and BS&amp;W maxima. */
     public Builder oilExport(double maximumRvpBara, double maximumBswVolumePercent) {
       maximumOilRvpBara = nonNegative(maximumRvpBara, "maximumRvpBara");
-      maximumOilBswVolumePercent = nonNegative(maximumBswVolumePercent,
-          "maximumBswVolumePercent");
+      maximumOilBswVolumePercent = nonNegative(maximumBswVolumePercent, "maximumBswVolumePercent");
       return this;
     }
 
     /** Sets the produced-water discharge oil-in-water maximum. */
     public Builder producedWater(double maximumOilInWaterMgPerL) {
-      this.maximumOilInWaterMgPerL = nonNegative(maximumOilInWaterMgPerL,
-          "maximumOilInWaterMgPerL");
+      this.maximumOilInWaterMgPerL = nonNegative(maximumOilInWaterMgPerL, "maximumOilInWaterMgPerL");
       return this;
     }
 
@@ -262,3 +254,4 @@ public final class FieldProductSpecifications implements Serializable {
     }
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldProductSpecifications.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldProductSpecifications.java
@@ -254,4 +254,3 @@ public final class FieldProductSpecifications implements Serializable {
     }
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldCase.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldCase.java
@@ -102,8 +102,7 @@ public final class NorwegianOilFieldCase {
         .gasInjection(0.0, recycleFraction, gasInjectionCapacity).gridEmissionFactor(0.018).prices(75.0, 0.28)
         .discountRate(0.08).opex(135.0, 8.5).tariffs(2.0, 0.015).capex(firstOilYear - 3, totalCapexMusd * 0.20)
         .capex(firstOilYear - 2, totalCapexMusd * 0.50).capex(firstOilYear - 1, totalCapexMusd * 0.30)
-        .facilityLifecycleStrategy(facilityStrategy).productSpecifications(createReferenceSpecifications())
-        .build();
+        .facilityLifecycleStrategy(facilityStrategy).productSpecifications(createReferenceSpecifications()).build();
 
     return new FieldLifecycleConcept(fieldConcept, model, configuration);
   }
@@ -120,8 +119,8 @@ public final class NorwegianOilFieldCase {
 
   /** Creates a longer tieback to a second mature host with a different production and capacity envelope. */
   public static FieldLifecycleConcept createRemoteHostTiebackCase() {
-    return createTiebackCase("NCS oil tieback - remote host B", CapacityAllocationPolicy.BASE_FIRST,
-        0.0, 0.0, 25.0, true);
+    return createTiebackCase("NCS oil tieback - remote host B", CapacityAllocationPolicy.BASE_FIRST, 0.0, 0.0, 25.0,
+        true);
   }
 
   /** Returns greenfield, depletion, direct tieback and managed tieback concepts ready for consistent ranking. */
@@ -133,14 +132,13 @@ public final class NorwegianOilFieldCase {
   /** Returns a multi-asset area portfolio with standalone, two-host, and managed-allocation routes. */
   public static AreaDevelopmentPortfolio createAreaDevelopmentPortfolio() {
     return new AreaDevelopmentPortfolio("Synthetic NCS area development")
-        .addOption(AreaDevelopmentOption.greenfield("Standalone FPSO", "New area FPSO",
-            createGasInjectionCase()))
+        .addOption(AreaDevelopmentOption.greenfield("Standalone FPSO", "New area FPSO", createGasInjectionCase()))
         .addOption(AreaDevelopmentOption.tieback("Host A priority tieback", "Existing NCS host A",
             createHostPriorityTiebackCase()))
-        .addOption(AreaDevelopmentOption.tieback("Host A managed tieback", "Existing NCS host A",
-            createManagedTiebackCase()))
-        .addOption(AreaDevelopmentOption.tieback("Remote host B tieback", "Mature NCS host B",
-            createRemoteHostTiebackCase()));
+        .addOption(
+            AreaDevelopmentOption.tieback("Host A managed tieback", "Existing NCS host A", createManagedTiebackCase()))
+        .addOption(
+            AreaDevelopmentOption.tieback("Remote host B tieback", "Mature NCS host B", createRemoteHostTiebackCase()));
   }
 
   static FieldLifecycleConcept createTiebackCase(String name, CapacityAllocationPolicy policy, double hostHoldback,
@@ -155,11 +153,10 @@ public final class NorwegianOilFieldCase {
     FieldConcept fieldConcept = createTiebackScreeningConcept(name, tiebackLengthKm);
     FieldLifecycleModel model = createModel(name, tiebackLengthKm, true, false);
     HostFacility host = HostFacility.builder(remoteHost ? "Mature NCS host B" : "Existing NCS host A")
-        .operator("Reference operator").type(FacilityType.PLATFORM)
-        .waterDepth(remoteHost ? 210.0 : 140.0).oilCapacity(remoteHost ? 120000.0 : 150000.0)
-        .gasCapacity(remoteHost ? 5.0 : 7.0).waterCapacity(remoteHost ? 45000.0 : 32000.0)
-        .liquidCapacity(remoteHost ? 55000.0 : 52000.0).minTieInPressure(45.0)
-        .maxTieInPressure(90.0).processSystem(model.getProcessSystem()).build();
+        .operator("Reference operator").type(FacilityType.PLATFORM).waterDepth(remoteHost ? 210.0 : 140.0)
+        .oilCapacity(remoteHost ? 120000.0 : 150000.0).gasCapacity(remoteHost ? 5.0 : 7.0)
+        .waterCapacity(remoteHost ? 45000.0 : 32000.0).liquidCapacity(remoteHost ? 55000.0 : 52000.0)
+        .minTieInPressure(45.0).maxTieInPressure(90.0).processSystem(model.getProcessSystem()).build();
     ProductionProfileSeries hostProfile = remoteHost ? createRemoteHostProductionProfile()
         : createPrimaryHostProductionProfile();
     FacilityLifecycleStrategy facilityStrategy = FacilityLifecycleStrategy
@@ -212,8 +209,7 @@ public final class NorwegianOilFieldCase {
 
   private static FieldProductSpecifications createReferenceSpecifications() {
     return FieldProductSpecifications.builder().gasComposition(2.5, 5.0).gasOxygen(0.0002)
-        .gasEnergyContent(38.1, 43.7, 48.3, 52.8, 0.70).oilExport(1.0, 0.5)
-        .producedWater(30.0).build();
+        .gasEnergyContent(38.1, 43.7, 48.3, 52.8, 0.70).oilExport(1.0, 0.5).producedWater(30.0).build();
   }
 
   private static FieldConcept createTiebackScreeningConcept(String name, double tiebackLengthKm) {
@@ -364,14 +360,12 @@ public final class NorwegianOilFieldCase {
       process.add(injectionAftercooler);
     }
 
-    FieldLifecycleModel model = new FieldLifecycleModel(name, reservoir, process, oilProducer,
-        waterProducer, reservoirGasInjector,
-        recoveredGasMixer.getOutletStream(), gasAllocation, oilExportPump.getOutletStream(),
+    FieldLifecycleModel model = new FieldLifecycleModel(name, reservoir, process, oilProducer, waterProducer,
+        reservoirGasInjector, recoveredGasMixer.getOutletStream(), gasAllocation, oilExportPump.getOutletStream(),
         gasExportCooler.getOutletStream(), compressedInjectionGas, hostOilFeed, hostGasFeed, hostWaterFeed,
         hpSeparator.getWaterOutStream());
-    model.setProductQualityProvider((lifecycleModel, specifications) ->
-        new ProductSpecificationEvaluator().evaluate(lifecycleModel, specifications,
-            producedWaterTreatment.getOilInWaterMgL()));
+    model.setProductQualityProvider((lifecycleModel, specifications) -> new ProductSpecificationEvaluator()
+        .evaluate(lifecycleModel, specifications, producedWaterTreatment.getOilInWaterMgL()));
     return model;
   }
 
@@ -453,3 +447,4 @@ public final class NorwegianOilFieldCase {
     return oilSm3PerDay / ProductionLoad.BARREL_TO_M3;
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldCase.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldCase.java
@@ -447,4 +447,3 @@ public final class NorwegianOilFieldCase {
     return oilSm3PerDay / ProductionLoad.BARREL_TO_M3;
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/ProductSpecificationEvaluator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/ProductSpecificationEvaluator.java
@@ -254,4 +254,3 @@ public final class ProductSpecificationEvaluator {
     return false;
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/ProductSpecificationEvaluator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/ProductSpecificationEvaluator.java
@@ -15,8 +15,7 @@ public final class ProductSpecificationEvaluator {
   private static final double MINIMUM_FLOW_KG_PER_SECOND = 1.0e-9;
 
   /** Evaluates configured limits using streams exposed by a lifecycle model. */
-  public ProductSpecificationResult evaluate(FieldLifecycleModel model,
-      FieldProductSpecifications specifications) {
+  public ProductSpecificationResult evaluate(FieldLifecycleModel model, FieldProductSpecifications specifications) {
     return evaluate(model, specifications, Double.NaN);
   }
 
@@ -28,8 +27,8 @@ public final class ProductSpecificationEvaluator {
    * @param measuredOilInWaterMgPerL measured treated-water OIW, or NaN to derive it from the water stream
    * @return measured compliance result
    */
-  public ProductSpecificationResult evaluate(FieldLifecycleModel model,
-      FieldProductSpecifications specifications, double measuredOilInWaterMgPerL) {
+  public ProductSpecificationResult evaluate(FieldLifecycleModel model, FieldProductSpecifications specifications,
+      double measuredOilInWaterMgPerL) {
     if (model == null || specifications == null) {
       return ProductSpecificationResult.notEvaluated();
     }
@@ -53,8 +52,8 @@ public final class ProductSpecificationEvaluator {
       gasH2s = gasMoleConcentration(gasExport, "H2S", 1.0e6);
       gasOxygen = gasMoleConcentration(gasExport, "oxygen", 100.0);
       if (Double.isFinite(specifications.getMaximumGasWaterDewPointC())) {
-        waterDewPoint = calculateWaterDewPoint(gasExport,
-            specifications.getGasDewPointReferencePressureBara(), violations);
+        waterDewPoint = calculateWaterDewPoint(gasExport, specifications.getGasDewPointReferencePressureBara(),
+            violations);
       }
       if (Double.isFinite(specifications.getMaximumGasHydrocarbonDewPointC())) {
         hydrocarbonDewPoint = calculateHydrocarbonDewPoint(gasExport,
@@ -86,43 +85,36 @@ public final class ProductSpecificationEvaluator {
     }
 
     if (gasExporting) {
-      checkMaximum("gas CO2", gasCo2, specifications.getMaximumGasCo2MolePercent(), "mol%",
-          violations);
+      checkMaximum("gas CO2", gasCo2, specifications.getMaximumGasCo2MolePercent(), "mol%", violations);
       checkMaximum("gas H2S", gasH2s, specifications.getMaximumGasH2sPpm(), "ppm", violations);
-      checkMaximum("gas oxygen", gasOxygen, specifications.getMaximumGasOxygenMolePercent(),
-          "mol%", violations);
-      checkMaximum("gas water dew point", waterDewPoint,
-          specifications.getMaximumGasWaterDewPointC(), "C", violations);
-      checkMaximum("gas hydrocarbon dew point", hydrocarbonDewPoint,
-          specifications.getMaximumGasHydrocarbonDewPointC(), "C", violations);
+      checkMaximum("gas oxygen", gasOxygen, specifications.getMaximumGasOxygenMolePercent(), "mol%", violations);
+      checkMaximum("gas water dew point", waterDewPoint, specifications.getMaximumGasWaterDewPointC(), "C", violations);
+      checkMaximum("gas hydrocarbon dew point", hydrocarbonDewPoint, specifications.getMaximumGasHydrocarbonDewPointC(),
+          "C", violations);
       checkRange("gas gross calorific value", gasGrossCalorificValue,
           specifications.getMinimumGasGrossCalorificValueMjPerSm3(),
           specifications.getMaximumGasGrossCalorificValueMjPerSm3(), "MJ/Sm3", violations);
-      checkRange("gas Wobbe index", gasWobbeIndex,
-          specifications.getMinimumGasWobbeIndexMjPerSm3(),
+      checkRange("gas Wobbe index", gasWobbeIndex, specifications.getMinimumGasWobbeIndexMjPerSm3(),
           specifications.getMaximumGasWobbeIndexMjPerSm3(), "MJ/Sm3", violations);
-      checkMaximum("gas relative density", gasRelativeDensity,
-          specifications.getMaximumGasRelativeDensity(), "-", violations);
+      checkMaximum("gas relative density", gasRelativeDensity, specifications.getMaximumGasRelativeDensity(), "-",
+          violations);
     }
     if (oilExporting) {
       checkMaximum("oil RVP", oilRvp, specifications.getMaximumOilRvpBara(), "bara", violations);
-      checkMaximum("oil BS&W", oilBsw, specifications.getMaximumOilBswVolumePercent(), "vol%",
-          violations);
+      checkMaximum("oil BS&W", oilBsw, specifications.getMaximumOilBswVolumePercent(), "vol%", violations);
     }
     checkMaximum("oil in water", oilInWater, specifications.getMaximumOilInWaterMgPerL(), "mg/L", violations);
 
-    return new ProductSpecificationResult(specifications.hasActiveLimits(), gasCo2, gasH2s,
-        gasOxygen, waterDewPoint, hydrocarbonDewPoint, gasGrossCalorificValue, gasWobbeIndex,
-        gasRelativeDensity, oilRvp, oilBsw, oilInWater, violations);
+    return new ProductSpecificationResult(specifications.hasActiveLimits(), gasCo2, gasH2s, gasOxygen, waterDewPoint,
+        hydrocarbonDewPoint, gasGrossCalorificValue, gasWobbeIndex, gasRelativeDensity, oilRvp, oilBsw, oilInWater,
+        violations);
   }
 
   private static boolean hasFlow(StreamInterface stream) {
-    return stream != null && stream.getFluid() != null
-        && stream.getFlowRate("kg/sec") > MINIMUM_FLOW_KG_PER_SECOND;
+    return stream != null && stream.getFluid() != null && stream.getFlowRate("kg/sec") > MINIMUM_FLOW_KG_PER_SECOND;
   }
 
-  private static double gasMoleConcentration(StreamInterface stream, String component,
-      double multiplier) {
+  private static double gasMoleConcentration(StreamInterface stream, String component, double multiplier) {
     SystemInterface fluid = stream.getFluid();
     if (!fluid.hasComponent(component)) {
       return 0.0;
@@ -131,8 +123,7 @@ public final class ProductSpecificationEvaluator {
     return phase.getComponent(component).getx() * multiplier;
   }
 
-  private static double calculateWaterDewPoint(StreamInterface stream, double pressureBara,
-      List<String> violations) {
+  private static double calculateWaterDewPoint(StreamInterface stream, double pressureBara, List<String> violations) {
     try {
       if (!stream.getFluid().hasComponent("water")) {
         return Double.NEGATIVE_INFINITY;
@@ -149,8 +140,8 @@ public final class ProductSpecificationEvaluator {
   private static double calculateHydrocarbonDewPoint(StreamInterface stream, double pressureBara,
       List<String> violations) {
     try {
-      HydrocarbonDewPointAnalyser analyser =
-          new HydrocarbonDewPointAnalyser("lifecycle gas hydrocarbon dew point", stream);
+      HydrocarbonDewPointAnalyser analyser = new HydrocarbonDewPointAnalyser("lifecycle gas hydrocarbon dew point",
+          stream);
       analyser.setReferencePressure(pressureBara);
       return analyser.getMeasuredValue("C");
     } catch (RuntimeException ex) {
@@ -167,16 +158,13 @@ public final class ProductSpecificationEvaluator {
         || Double.isFinite(specifications.getMaximumGasRelativeDensity());
   }
 
-  private static double[] calculateGasEnergyQuality(StreamInterface stream,
-      List<String> violations) {
+  private static double[] calculateGasEnergyQuality(StreamInterface stream, List<String> violations) {
     try {
-      Standard_ISO6976_2016 standard =
-          new Standard_ISO6976_2016(stream.getFluid(), 15.0, 25.0, "volume");
+      Standard_ISO6976_2016 standard = new Standard_ISO6976_2016(stream.getFluid(), 15.0, 25.0, "volume");
       standard.setReferenceState("real");
       standard.setReferenceType("volume");
       standard.calculate();
-      return new double[] { standard.getValue("GCV") / 1000.0,
-          standard.getValue("SuperiorWobbeIndex") / 1000.0,
+      return new double[] { standard.getValue("GCV") / 1000.0, standard.getValue("SuperiorWobbeIndex") / 1000.0,
           standard.getValue("RelativeDensity") };
     } catch (RuntimeException ex) {
       violations.add("gas energy quality could not be calculated");
@@ -217,8 +205,7 @@ public final class ProductSpecificationEvaluator {
       PhaseInterface aqueous = fluid.getPhase("aqueous");
       double hydrocarbonWeightFraction = 0.0;
       for (int component = 0; component < aqueous.getNumberOfComponents(); component++) {
-        if (aqueous.getComponent(component).isHydrocarbon()
-            || aqueous.getComponent(component).isIsTBPfraction()) {
+        if (aqueous.getComponent(component).isHydrocarbon() || aqueous.getComponent(component).isIsTBPfraction()) {
           hydrocarbonWeightFraction += aqueous.getWtFrac(component);
         }
       }
@@ -229,8 +216,7 @@ public final class ProductSpecificationEvaluator {
     }
   }
 
-  private static void checkMaximum(String name, double measured, double maximum, String unit,
-      List<String> violations) {
+  private static void checkMaximum(String name, double measured, double maximum, String unit, List<String> violations) {
     if (!Double.isFinite(maximum)) {
       return;
     }
@@ -243,8 +229,8 @@ public final class ProductSpecificationEvaluator {
     }
   }
 
-  private static void checkRange(String name, double measured, double minimum, double maximum,
-      String unit, List<String> violations) {
+  private static void checkRange(String name, double measured, double minimum, double maximum, String unit,
+      List<String> violations) {
     if (!Double.isFinite(minimum) && !Double.isFinite(maximum)) {
       return;
     }
@@ -268,3 +254,4 @@ public final class ProductSpecificationEvaluator {
     return false;
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/ProductSpecificationResult.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/ProductSpecificationResult.java
@@ -155,4 +155,3 @@ public final class ProductSpecificationResult implements Serializable {
     return Math.max(first, second);
   }
 }
-

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/ProductSpecificationResult.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/ProductSpecificationResult.java
@@ -24,10 +24,9 @@ public final class ProductSpecificationResult implements Serializable {
   private final double oilInWaterMgPerL;
   private final List<String> violations;
 
-  ProductSpecificationResult(boolean evaluated, double gasCo2MolePercent, double gasH2sPpm,
-      double gasOxygenMolePercent, double gasWaterDewPointC, double gasHydrocarbonDewPointC,
-      double gasGrossCalorificValueMjPerSm3, double gasWobbeIndexMjPerSm3,
-      double gasRelativeDensity, double oilRvpBara, double oilBswVolumePercent,
+  ProductSpecificationResult(boolean evaluated, double gasCo2MolePercent, double gasH2sPpm, double gasOxygenMolePercent,
+      double gasWaterDewPointC, double gasHydrocarbonDewPointC, double gasGrossCalorificValueMjPerSm3,
+      double gasWobbeIndexMjPerSm3, double gasRelativeDensity, double oilRvpBara, double oilBswVolumePercent,
       double oilInWaterMgPerL, List<String> violations) {
     this.evaluated = evaluated;
     this.gasCo2MolePercent = gasCo2MolePercent;
@@ -46,9 +45,8 @@ public final class ProductSpecificationResult implements Serializable {
 
   /** Returns a result used when no product specifications are configured. */
   public static ProductSpecificationResult notEvaluated() {
-    return new ProductSpecificationResult(false, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
-        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
-        Collections.<String>emptyList());
+    return new ProductSpecificationResult(false, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Collections.<String>emptyList());
   }
 
   /** Returns whether quality was evaluated. */
@@ -123,8 +121,7 @@ public final class ProductSpecificationResult implements Serializable {
 
   /** Returns a compact compliance summary. */
   public String getSummary() {
-    return violations.isEmpty() ? (evaluated ? "on specification" : "not evaluated")
-        : String.join("; ", violations);
+    return violations.isEmpty() ? (evaluated ? "on specification" : "not evaluated") : String.join("; ", violations);
   }
 
   /** Returns a result retaining worst measurements and all violations from both inputs. */
@@ -138,15 +135,14 @@ public final class ProductSpecificationResult implements Serializable {
     Set<String> combinedViolations = new LinkedHashSet<String>(violations);
     combinedViolations.addAll(other.violations);
     return new ProductSpecificationResult(true, maximum(gasCo2MolePercent, other.gasCo2MolePercent),
-        maximum(gasH2sPpm, other.gasH2sPpm),
-        maximum(gasOxygenMolePercent, other.gasOxygenMolePercent),
+        maximum(gasH2sPpm, other.gasH2sPpm), maximum(gasOxygenMolePercent, other.gasOxygenMolePercent),
         maximum(gasWaterDewPointC, other.gasWaterDewPointC),
         maximum(gasHydrocarbonDewPointC, other.gasHydrocarbonDewPointC),
         maximum(gasGrossCalorificValueMjPerSm3, other.gasGrossCalorificValueMjPerSm3),
         maximum(gasWobbeIndexMjPerSm3, other.gasWobbeIndexMjPerSm3),
-        maximum(gasRelativeDensity, other.gasRelativeDensity),
-        maximum(oilRvpBara, other.oilRvpBara), maximum(oilBswVolumePercent, other.oilBswVolumePercent),
-        maximum(oilInWaterMgPerL, other.oilInWaterMgPerL), new ArrayList<String>(combinedViolations));
+        maximum(gasRelativeDensity, other.gasRelativeDensity), maximum(oilRvpBara, other.oilRvpBara),
+        maximum(oilBswVolumePercent, other.oilBswVolumePercent), maximum(oilInWaterMgPerL, other.oilInWaterMgPerL),
+        new ArrayList<String>(combinedViolations));
   }
 
   private static double maximum(double first, double second) {
@@ -159,3 +155,4 @@ public final class ProductSpecificationResult implements Serializable {
     return Math.max(first, second);
   }
 }
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/package-info.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/package-info.java
@@ -2,5 +2,6 @@
  * Integrated field- and area-development simulation from reservoir and wells through new or existing shared SURF,
  * greenfield facility sizing or multi-host brownfield allocation, detailed single- or multi-area process models,
  * bottlenecks, modification candidates, product specifications, export, injection, emissions and economics.
-*/
+ */
 package neqsim.process.fielddevelopment.lifecycle;
+

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/package-info.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/package-info.java
@@ -4,4 +4,3 @@
  * bottlenecks, modification candidates, product specifications, export, injection, emissions and economics.
  */
 package neqsim.process.fielddevelopment.lifecycle;
-

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -7536,16 +7536,20 @@ public class ProcessSystem extends SimulationBaseClass {
         equipReport.addProperty("type", equipment.getClass().getSimpleName());
         equipReport.addProperty("autoSized", sizeable.isAutoSized());
 
-        // Get JSON sizing report if available
-        String jsonReport = sizeable.getSizingReportJson();
-        if (jsonReport != null && !jsonReport.equals("{}")) {
-          try {
+        // Get JSON sizing report if available. A process-level design snapshot may
+        // legitimately be requested before every unit has run, so one unavailable
+        // equipment report must not prevent reporting explicit design constraints
+        // from the rest of the process.
+        try {
+          String jsonReport = sizeable.getSizingReportJson();
+          if (jsonReport != null && !jsonReport.equals("{}")) {
             com.google.gson.JsonObject sizingData = com.google.gson.JsonParser.parseString(jsonReport)
                 .getAsJsonObject();
             equipReport.add("sizingData", sizingData);
-          } catch (Exception e) {
-            equipReport.addProperty("sizingData", jsonReport);
           }
+          equipReport.addProperty("sizingDataAvailable", true);
+        } catch (RuntimeException e) {
+          equipReport.addProperty("sizingDataAvailable", false);
         }
 
         // Add capacity constraints if equipment is capacity-constrained

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -7543,9 +7543,13 @@ public class ProcessSystem extends SimulationBaseClass {
         try {
           String jsonReport = sizeable.getSizingReportJson();
           if (jsonReport != null && !jsonReport.equals("{}")) {
-            com.google.gson.JsonObject sizingData = com.google.gson.JsonParser.parseString(jsonReport)
-                .getAsJsonObject();
-            equipReport.add("sizingData", sizingData);
+            try {
+              com.google.gson.JsonObject sizingData = com.google.gson.JsonParser.parseString(jsonReport)
+                  .getAsJsonObject();
+              equipReport.add("sizingData", sizingData);
+            } catch (Exception e) {
+              equipReport.addProperty("sizingData", jsonReport);
+            }
           }
           equipReport.addProperty("sizingDataAvailable", true);
         } catch (RuntimeException e) {

--- a/src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java
@@ -39,8 +39,7 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertEquals(18000.0, result.getAnnualResults().get(0).getPotentialOilRateSm3PerDay(), 1.0e-6);
     assertTrue(result.getFacilityDesignResult().getAutoSizedEquipmentCount() > 0);
     assertTrue(result.getPeakFacilityUtilization() <= 1.0 + 1.0e-6);
-    ProductSpecificationResult quality =
-        result.getAnnualResults().get(0).getProductSpecificationResult();
+    ProductSpecificationResult quality = result.getAnnualResults().get(0).getProductSpecificationResult();
     assertTrue(quality.isEvaluated());
     assertTrue(Double.isFinite(quality.getGasCo2MolePercent()));
     assertTrue(Double.isFinite(quality.getGasGrossCalorificValueMjPerSm3()));
@@ -70,9 +69,8 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     AreaDevelopmentPortfolio portfolio = new AreaDevelopmentPortfolio("test area")
         .addOption(AreaDevelopmentOption.greenfield("greenfield", "new facility",
             NorwegianOilFieldCase.createCase("short greenfield", 0.85, 5.0e6, 1.0)))
-        .addOption(AreaDevelopmentOption.tieback("host route", "host A",
-            NorwegianOilFieldCase.createTiebackCase("short host route",
-                CapacityAllocationPolicy.BASE_FIRST, 0.0, 0.0, 1.0)));
+        .addOption(AreaDevelopmentOption.tieback("host route", "host A", NorwegianOilFieldCase
+            .createTiebackCase("short host route", CapacityAllocationPolicy.BASE_FIRST, 0.0, 0.0, 1.0)));
 
     AreaDevelopmentResult result = new AreaDevelopmentEvaluator().evaluate(portfolio);
 
@@ -117,27 +115,23 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertTrue(result.getPeakFacilityUtilization() <= 1.0 + 1.0e-6);
     assertTrue(result.getPeakUnconstrainedFacilityUtilization() >= result.getPeakFacilityUtilization());
     assertTrue(result.getAnnualResults().get(0).getPrimaryBottleneck().contains("capacity"));
-    FacilityModificationPlan modificationPlan =
-        new FacilityModificationPlanner().analyse(result, 0.90);
+    FacilityModificationPlan modificationPlan = new FacilityModificationPlanner().analyse(result, 0.90);
     assertTrue(modificationPlan.hasCandidates());
     assertTrue(modificationPlan.toMarkdownTable().contains("Screening modification scope"));
   }
 
   @Test
   void existingDetailedProcessCanBeMappedWithExplicitConnectionPoints() {
-    FieldLifecycleModel original =
-        NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
+    FieldLifecycleModel original = NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
 
     FieldLifecycleModel mapped = FieldLifecycleModel
-        .existingFacility("mapped host process", original.getReservoir(),
-            original.getProcessSystem())
-        .reservoirStreams(original.getReservoirOilProducer(),
-            original.getReservoirWaterProducer(), original.getReservoirGasInjector())
+        .existingFacility("mapped host process", original.getReservoir(), original.getProcessSystem())
+        .reservoirStreams(original.getReservoirOilProducer(), original.getReservoirWaterProducer(),
+            original.getReservoirGasInjector())
         .gasHandling(original.getRecoveredGas(), original.getGasAllocationSplitter(),
             original.getCompressedInjectionGas())
         .exportStreams(original.getStabilizedOilExport(), original.getGasExport())
-        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(),
-            original.getHostWaterFeed())
+        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(), original.getHostWaterFeed())
         .treatedWaterDischarge(original.getTreatedWaterDischarge()).build();
 
     assertTrue(mapped.getProcessSystem() == original.getProcessSystem());
@@ -146,23 +140,21 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
 
   @Test
   void multiAreaProcessModelCanIncludeExistingSurfAndHostFacility() {
-    FieldLifecycleModel original =
-        NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
+    FieldLifecycleModel original = NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
     ProcessSystem existingSurf = new ProcessSystem();
     ProcessModel infrastructure = new ProcessModel();
     infrastructure.add("shared SURF", existingSurf);
     infrastructure.add("host topsides", original.getProcessSystem());
 
     FieldLifecycleModel mapped = FieldLifecycleModel
-        .existingSurfAndFacility("mapped infrastructure", original.getReservoir(),
-            infrastructure, "shared SURF", "host topsides")
-        .reservoirStreams(original.getReservoirOilProducer(),
-            original.getReservoirWaterProducer(), original.getReservoirGasInjector())
+        .existingSurfAndFacility("mapped infrastructure", original.getReservoir(), infrastructure, "shared SURF",
+            "host topsides")
+        .reservoirStreams(original.getReservoirOilProducer(), original.getReservoirWaterProducer(),
+            original.getReservoirGasInjector())
         .gasHandling(original.getRecoveredGas(), original.getGasAllocationSplitter(),
             original.getCompressedInjectionGas())
         .exportStreams(original.getStabilizedOilExport(), original.getGasExport())
-        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(),
-            original.getHostWaterFeed())
+        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(), original.getHostWaterFeed())
         .treatedWaterDischarge(original.getTreatedWaterDischarge()).build();
 
     assertTrue(mapped.getProcessModel() == infrastructure);
@@ -170,9 +162,8 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertTrue(mapped.getExistingSurfSystem() == existingSurf);
     assertEquals("host topsides", mapped.getFacilityAreaName());
     assertEquals("shared SURF", mapped.getSurfAreaName());
-    assertThrows(IllegalArgumentException.class,
-        () -> FieldLifecycleModel.existingFacility("missing area", original.getReservoir(),
-            infrastructure, "not an area"));
+    assertThrows(IllegalArgumentException.class, () -> FieldLifecycleModel.existingFacility("missing area",
+        original.getReservoir(), infrastructure, "not an area"));
   }
 
   @Test
@@ -186,13 +177,11 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertThrows(IllegalArgumentException.class,
         () -> FieldLifecycleConfiguration.builder().gasInjection(0.0, 1.1, 1.0e6).build());
 
-    FieldProductSpecifications specifications = FieldProductSpecifications.builder()
-        .gasComposition(2.5, 5.0).gasOxygen(0.0002).gasDewPoints(70.0, -10.0, 0.0)
-        .gasEnergyContent(38.1, 43.7, 48.3, 52.8, 0.70).oilExport(1.0, 0.5)
-        .producedWater(30.0)
+    FieldProductSpecifications specifications = FieldProductSpecifications.builder().gasComposition(2.5, 5.0)
+        .gasOxygen(0.0002).gasDewPoints(70.0, -10.0, 0.0).gasEnergyContent(38.1, 43.7, 48.3, 52.8, 0.70)
+        .oilExport(1.0, 0.5).producedWater(30.0)
         .violationAction(FieldProductSpecifications.ViolationAction.REJECT_OPTION).build();
-    assertEquals(FieldProductSpecifications.ViolationAction.REJECT_OPTION,
-        specifications.getViolationAction());
+    assertEquals(FieldProductSpecifications.ViolationAction.REJECT_OPTION, specifications.getViolationAction());
     assertTrue(specifications.hasActiveLimits());
   }
 }

--- a/src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java
@@ -39,7 +39,8 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertEquals(18000.0, result.getAnnualResults().get(0).getPotentialOilRateSm3PerDay(), 1.0e-6);
     assertTrue(result.getFacilityDesignResult().getAutoSizedEquipmentCount() > 0);
     assertTrue(result.getPeakFacilityUtilization() <= 1.0 + 1.0e-6);
-    ProductSpecificationResult quality = result.getAnnualResults().get(0).getProductSpecificationResult();
+    ProductSpecificationResult quality =
+        result.getAnnualResults().get(0).getProductSpecificationResult();
     assertTrue(quality.isEvaluated());
     assertTrue(Double.isFinite(quality.getGasCo2MolePercent()));
     assertTrue(Double.isFinite(quality.getGasGrossCalorificValueMjPerSm3()));
@@ -69,8 +70,9 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     AreaDevelopmentPortfolio portfolio = new AreaDevelopmentPortfolio("test area")
         .addOption(AreaDevelopmentOption.greenfield("greenfield", "new facility",
             NorwegianOilFieldCase.createCase("short greenfield", 0.85, 5.0e6, 1.0)))
-        .addOption(AreaDevelopmentOption.tieback("host route", "host A", NorwegianOilFieldCase
-            .createTiebackCase("short host route", CapacityAllocationPolicy.BASE_FIRST, 0.0, 0.0, 1.0)));
+        .addOption(AreaDevelopmentOption.tieback("host route", "host A",
+            NorwegianOilFieldCase.createTiebackCase("short host route",
+                CapacityAllocationPolicy.BASE_FIRST, 0.0, 0.0, 1.0)));
 
     AreaDevelopmentResult result = new AreaDevelopmentEvaluator().evaluate(portfolio);
 
@@ -115,23 +117,27 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertTrue(result.getPeakFacilityUtilization() <= 1.0 + 1.0e-6);
     assertTrue(result.getPeakUnconstrainedFacilityUtilization() >= result.getPeakFacilityUtilization());
     assertTrue(result.getAnnualResults().get(0).getPrimaryBottleneck().contains("capacity"));
-    FacilityModificationPlan modificationPlan = new FacilityModificationPlanner().analyse(result, 0.90);
+    FacilityModificationPlan modificationPlan =
+        new FacilityModificationPlanner().analyse(result, 0.90);
     assertTrue(modificationPlan.hasCandidates());
     assertTrue(modificationPlan.toMarkdownTable().contains("Screening modification scope"));
   }
 
   @Test
   void existingDetailedProcessCanBeMappedWithExplicitConnectionPoints() {
-    FieldLifecycleModel original = NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
+    FieldLifecycleModel original =
+        NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
 
     FieldLifecycleModel mapped = FieldLifecycleModel
-        .existingFacility("mapped host process", original.getReservoir(), original.getProcessSystem())
-        .reservoirStreams(original.getReservoirOilProducer(), original.getReservoirWaterProducer(),
-            original.getReservoirGasInjector())
+        .existingFacility("mapped host process", original.getReservoir(),
+            original.getProcessSystem())
+        .reservoirStreams(original.getReservoirOilProducer(),
+            original.getReservoirWaterProducer(), original.getReservoirGasInjector())
         .gasHandling(original.getRecoveredGas(), original.getGasAllocationSplitter(),
             original.getCompressedInjectionGas())
         .exportStreams(original.getStabilizedOilExport(), original.getGasExport())
-        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(), original.getHostWaterFeed())
+        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(),
+            original.getHostWaterFeed())
         .treatedWaterDischarge(original.getTreatedWaterDischarge()).build();
 
     assertTrue(mapped.getProcessSystem() == original.getProcessSystem());
@@ -140,21 +146,23 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
 
   @Test
   void multiAreaProcessModelCanIncludeExistingSurfAndHostFacility() {
-    FieldLifecycleModel original = NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
+    FieldLifecycleModel original =
+        NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
     ProcessSystem existingSurf = new ProcessSystem();
     ProcessModel infrastructure = new ProcessModel();
     infrastructure.add("shared SURF", existingSurf);
     infrastructure.add("host topsides", original.getProcessSystem());
 
     FieldLifecycleModel mapped = FieldLifecycleModel
-        .existingSurfAndFacility("mapped infrastructure", original.getReservoir(), infrastructure, "shared SURF",
-            "host topsides")
-        .reservoirStreams(original.getReservoirOilProducer(), original.getReservoirWaterProducer(),
-            original.getReservoirGasInjector())
+        .existingSurfAndFacility("mapped infrastructure", original.getReservoir(),
+            infrastructure, "shared SURF", "host topsides")
+        .reservoirStreams(original.getReservoirOilProducer(),
+            original.getReservoirWaterProducer(), original.getReservoirGasInjector())
         .gasHandling(original.getRecoveredGas(), original.getGasAllocationSplitter(),
             original.getCompressedInjectionGas())
         .exportStreams(original.getStabilizedOilExport(), original.getGasExport())
-        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(), original.getHostWaterFeed())
+        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(),
+            original.getHostWaterFeed())
         .treatedWaterDischarge(original.getTreatedWaterDischarge()).build();
 
     assertTrue(mapped.getProcessModel() == infrastructure);
@@ -162,8 +170,9 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertTrue(mapped.getExistingSurfSystem() == existingSurf);
     assertEquals("host topsides", mapped.getFacilityAreaName());
     assertEquals("shared SURF", mapped.getSurfAreaName());
-    assertThrows(IllegalArgumentException.class, () -> FieldLifecycleModel.existingFacility("missing area",
-        original.getReservoir(), infrastructure, "not an area"));
+    assertThrows(IllegalArgumentException.class,
+        () -> FieldLifecycleModel.existingFacility("missing area", original.getReservoir(),
+            infrastructure, "not an area"));
   }
 
   @Test
@@ -177,11 +186,13 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertThrows(IllegalArgumentException.class,
         () -> FieldLifecycleConfiguration.builder().gasInjection(0.0, 1.1, 1.0e6).build());
 
-    FieldProductSpecifications specifications = FieldProductSpecifications.builder().gasComposition(2.5, 5.0)
-        .gasOxygen(0.0002).gasDewPoints(70.0, -10.0, 0.0).gasEnergyContent(38.1, 43.7, 48.3, 52.8, 0.70)
-        .oilExport(1.0, 0.5).producedWater(30.0)
+    FieldProductSpecifications specifications = FieldProductSpecifications.builder()
+        .gasComposition(2.5, 5.0).gasOxygen(0.0002).gasDewPoints(70.0, -10.0, 0.0)
+        .gasEnergyContent(38.1, 43.7, 48.3, 52.8, 0.70).oilExport(1.0, 0.5)
+        .producedWater(30.0)
         .violationAction(FieldProductSpecifications.ViolationAction.REJECT_OPTION).build();
-    assertEquals(FieldProductSpecifications.ViolationAction.REJECT_OPTION, specifications.getViolationAction());
+    assertEquals(FieldProductSpecifications.ViolationAction.REJECT_OPTION,
+        specifications.getViolationAction());
     assertTrue(specifications.hasActiveLimits());
   }
 }

--- a/src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.fielddevelopment.lifecycle.FacilityLifecycleStrategy.DevelopmentMode;
 import neqsim.process.fielddevelopment.tieback.HostFacility;
 import neqsim.process.fielddevelopment.tieback.capacity.CapacityAllocationPolicy;
@@ -37,13 +39,20 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertEquals(18000.0, result.getAnnualResults().get(0).getPotentialOilRateSm3PerDay(), 1.0e-6);
     assertTrue(result.getFacilityDesignResult().getAutoSizedEquipmentCount() > 0);
     assertTrue(result.getPeakFacilityUtilization() <= 1.0 + 1.0e-6);
-    ProductSpecificationResult quality =
-        result.getAnnualResults().get(0).getProductSpecificationResult();
+    ProductSpecificationResult quality = result.getAnnualResults().get(0).getProductSpecificationResult();
     assertTrue(quality.isEvaluated());
     assertTrue(Double.isFinite(quality.getGasCo2MolePercent()));
     assertTrue(Double.isFinite(quality.getGasGrossCalorificValueMjPerSm3()));
     assertTrue(Double.isFinite(quality.getGasWobbeIndexMjPerSm3()));
     assertTrue(Double.isFinite(quality.getOilInWaterMgPerL()));
+    assertTrue(concept.getModel().getProcessSystem().isUseOptimizedExecution());
+    for (ProcessEquipmentInterface equipment : concept.getModel().getProcessSystem().getUnitOperations()) {
+      if (equipment instanceof Compressor) {
+        Compressor compressor = (Compressor) equipment;
+        assertFalse(compressor.isSolveSpeed());
+        assertFalse(compressor.getCompressorChart().isUseCompressorChart());
+      }
+    }
   }
 
   @Test
@@ -60,9 +69,8 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     AreaDevelopmentPortfolio portfolio = new AreaDevelopmentPortfolio("test area")
         .addOption(AreaDevelopmentOption.greenfield("greenfield", "new facility",
             NorwegianOilFieldCase.createCase("short greenfield", 0.85, 5.0e6, 1.0)))
-        .addOption(AreaDevelopmentOption.tieback("host route", "host A",
-            NorwegianOilFieldCase.createTiebackCase("short host route",
-                CapacityAllocationPolicy.BASE_FIRST, 0.0, 0.0, 1.0)));
+        .addOption(AreaDevelopmentOption.tieback("host route", "host A", NorwegianOilFieldCase
+            .createTiebackCase("short host route", CapacityAllocationPolicy.BASE_FIRST, 0.0, 0.0, 1.0)));
 
     AreaDevelopmentResult result = new AreaDevelopmentEvaluator().evaluate(portfolio);
 
@@ -107,27 +115,23 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertTrue(result.getPeakFacilityUtilization() <= 1.0 + 1.0e-6);
     assertTrue(result.getPeakUnconstrainedFacilityUtilization() >= result.getPeakFacilityUtilization());
     assertTrue(result.getAnnualResults().get(0).getPrimaryBottleneck().contains("capacity"));
-    FacilityModificationPlan modificationPlan =
-        new FacilityModificationPlanner().analyse(result, 0.90);
+    FacilityModificationPlan modificationPlan = new FacilityModificationPlanner().analyse(result, 0.90);
     assertTrue(modificationPlan.hasCandidates());
     assertTrue(modificationPlan.toMarkdownTable().contains("Screening modification scope"));
   }
 
   @Test
   void existingDetailedProcessCanBeMappedWithExplicitConnectionPoints() {
-    FieldLifecycleModel original =
-        NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
+    FieldLifecycleModel original = NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
 
     FieldLifecycleModel mapped = FieldLifecycleModel
-        .existingFacility("mapped host process", original.getReservoir(),
-            original.getProcessSystem())
-        .reservoirStreams(original.getReservoirOilProducer(),
-            original.getReservoirWaterProducer(), original.getReservoirGasInjector())
+        .existingFacility("mapped host process", original.getReservoir(), original.getProcessSystem())
+        .reservoirStreams(original.getReservoirOilProducer(), original.getReservoirWaterProducer(),
+            original.getReservoirGasInjector())
         .gasHandling(original.getRecoveredGas(), original.getGasAllocationSplitter(),
             original.getCompressedInjectionGas())
         .exportStreams(original.getStabilizedOilExport(), original.getGasExport())
-        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(),
-            original.getHostWaterFeed())
+        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(), original.getHostWaterFeed())
         .treatedWaterDischarge(original.getTreatedWaterDischarge()).build();
 
     assertTrue(mapped.getProcessSystem() == original.getProcessSystem());
@@ -136,23 +140,21 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
 
   @Test
   void multiAreaProcessModelCanIncludeExistingSurfAndHostFacility() {
-    FieldLifecycleModel original =
-        NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
+    FieldLifecycleModel original = NorwegianOilFieldCase.createHostPriorityTiebackCase().getModel();
     ProcessSystem existingSurf = new ProcessSystem();
     ProcessModel infrastructure = new ProcessModel();
     infrastructure.add("shared SURF", existingSurf);
     infrastructure.add("host topsides", original.getProcessSystem());
 
     FieldLifecycleModel mapped = FieldLifecycleModel
-        .existingSurfAndFacility("mapped infrastructure", original.getReservoir(),
-            infrastructure, "shared SURF", "host topsides")
-        .reservoirStreams(original.getReservoirOilProducer(),
-            original.getReservoirWaterProducer(), original.getReservoirGasInjector())
+        .existingSurfAndFacility("mapped infrastructure", original.getReservoir(), infrastructure, "shared SURF",
+            "host topsides")
+        .reservoirStreams(original.getReservoirOilProducer(), original.getReservoirWaterProducer(),
+            original.getReservoirGasInjector())
         .gasHandling(original.getRecoveredGas(), original.getGasAllocationSplitter(),
             original.getCompressedInjectionGas())
         .exportStreams(original.getStabilizedOilExport(), original.getGasExport())
-        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(),
-            original.getHostWaterFeed())
+        .hostFeeds(original.getHostOilFeed(), original.getHostGasFeed(), original.getHostWaterFeed())
         .treatedWaterDischarge(original.getTreatedWaterDischarge()).build();
 
     assertTrue(mapped.getProcessModel() == infrastructure);
@@ -160,9 +162,8 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertTrue(mapped.getExistingSurfSystem() == existingSurf);
     assertEquals("host topsides", mapped.getFacilityAreaName());
     assertEquals("shared SURF", mapped.getSurfAreaName());
-    assertThrows(IllegalArgumentException.class,
-        () -> FieldLifecycleModel.existingFacility("missing area", original.getReservoir(),
-            infrastructure, "not an area"));
+    assertThrows(IllegalArgumentException.class, () -> FieldLifecycleModel.existingFacility("missing area",
+        original.getReservoir(), infrastructure, "not an area"));
   }
 
   @Test
@@ -176,13 +177,11 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
     assertThrows(IllegalArgumentException.class,
         () -> FieldLifecycleConfiguration.builder().gasInjection(0.0, 1.1, 1.0e6).build());
 
-    FieldProductSpecifications specifications = FieldProductSpecifications.builder()
-        .gasComposition(2.5, 5.0).gasOxygen(0.0002).gasDewPoints(70.0, -10.0, 0.0)
-        .gasEnergyContent(38.1, 43.7, 48.3, 52.8, 0.70).oilExport(1.0, 0.5)
-        .producedWater(30.0)
+    FieldProductSpecifications specifications = FieldProductSpecifications.builder().gasComposition(2.5, 5.0)
+        .gasOxygen(0.0002).gasDewPoints(70.0, -10.0, 0.0).gasEnergyContent(38.1, 43.7, 48.3, 52.8, 0.70)
+        .oilExport(1.0, 0.5).producedWater(30.0)
         .violationAction(FieldProductSpecifications.ViolationAction.REJECT_OPTION).build();
-    assertEquals(FieldProductSpecifications.ViolationAction.REJECT_OPTION,
-        specifications.getViolationAction());
+    assertEquals(FieldProductSpecifications.ViolationAction.REJECT_OPTION, specifications.getViolationAction());
     assertTrue(specifications.hasActiveLimits());
   }
 }

--- a/src/test/java/neqsim/process/lng/LNGProcessBuilderTest.java
+++ b/src/test/java/neqsim/process/lng/LNGProcessBuilderTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -119,6 +121,15 @@ class LNGProcessBuilderTest {
     assertFalse(capacity.isAnyEquipmentOverloaded());
     assertNotNull(capacity.getUtilizationSnapshotJson());
     assertNotNull(capacity.getDesignReportJson());
+    boolean hasUnavailableSizingData = false;
+    for (JsonElement equipmentReport : JsonParser.parseString(capacity.getDesignReportJson()).getAsJsonObject()
+        .getAsJsonArray("equipment")) {
+      if (equipmentReport.getAsJsonObject().has("sizingDataAvailable")
+          && !equipmentReport.getAsJsonObject().get("sizingDataAvailable").getAsBoolean()) {
+        hasUnavailableSizingData = true;
+      }
+    }
+    assertTrue(hasUnavailableSizingData);
   }
 
   @Test

--- a/src/test/java/neqsim/process/lng/LNGProcessBuilderTest.java
+++ b/src/test/java/neqsim/process/lng/LNGProcessBuilderTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -121,15 +119,7 @@ class LNGProcessBuilderTest {
     assertFalse(capacity.isAnyEquipmentOverloaded());
     assertNotNull(capacity.getUtilizationSnapshotJson());
     assertNotNull(capacity.getDesignReportJson());
-    boolean hasUnavailableSizingData = false;
-    for (JsonElement equipmentReport : JsonParser.parseString(capacity.getDesignReportJson()).getAsJsonObject()
-        .getAsJsonArray("equipment")) {
-      if (equipmentReport.getAsJsonObject().has("sizingDataAvailable")
-          && !equipmentReport.getAsJsonObject().get("sizingDataAvailable").getAsBoolean()) {
-        hasUnavailableSizingData = true;
-      }
-    }
-    assertTrue(hasUnavailableSizingData);
+    assertTrue(capacity.getDesignReportJson().contains("\"sizingDataAvailable\": false"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- keep process design reporting available when individual equipment sizing data has not been initialized by a process run
- preserve compressor chart and speed-solving modes across lifecycle auto-sizing
- evaluate serial lifecycle flowsheets deterministically and reject invalid compressor work at meaningful flow
- add regression coverage for both reported CI failures
- apply the repository formatter to the newly merged lifecycle package

## Validation

- compiled the affected production sources with `--release 8`
- reproduced and passed the integrated LNG pipeline capacity scenario
- repeatedly passed the Norwegian gas-injection lifecycle scenario
- passed additional natural-depletion and host-tieback lifecycle smoke checks
- GitHub pre-commit, Spotless, CodeQL, PaperLab, and Javadoc checks pass
- the complete Java 21 Windows test suite passes, including both reported regressions

## CI note

The Java 21 Ubuntu retry is still running. Its first attempt passed both reported regressions but exposed the separate pre-existing `testSmrRouteRunsAndReportsPerformance` exchanger convergence defect from the merged LNG feature; this PR does not modify that SMR flowsheet.