### PR TITLE
docs: verify viscosity model API examples

### DIFF
--- a/docs/physical_properties/viscosity_models.md
+++ b/docs/physical_properties/viscosity_models.md
@@ -6,17 +6,17 @@ description: This guide documents the viscosity calculation methods available in
 This guide documents the viscosity calculation methods available in NeqSim for gas, liquid, and multiphase systems.
 
 ## Table of Contents
+
 - [Overview](#overview)
 - [Available Models](#available-models)
   - [LBC (Lohrenz-Bray-Clark)](#lbc-lohrenz-bray-clark)
   - [Friction Theory](#friction-theory)
   - [PFCT (Pedersen)](#pfct-pedersen)
-  - [Chung Method](#chung-method)
   - [Polynomial Correlation](#polynomial-correlation)
   - [Reference Fluid Methods](#reference-fluid-methods)
 - [Model Selection Guide](#model-selection-guide)
 - [Tuning Parameters](#tuning-parameters)
-    - [CSP PFCT Parameter Tuning](#csp-pfct-parameter-tuning)
+  - [CSP PFCT Parameter Tuning](#csp-pfct-parameter-tuning)
 - [Usage Examples](#usage-examples)
 
 ---
@@ -26,6 +26,7 @@ This guide documents the viscosity calculation methods available in NeqSim for g
 Viscosity describes a fluid's resistance to flow. NeqSim provides several viscosity models suitable for different applications:
 
 **Units:**
+
 - Default output: **Pa·s** (Pascal-seconds)
 - Alternative: **cP** (centipoise), where 1 cP = 0.001 Pa·s
 
@@ -34,7 +35,14 @@ Viscosity describes a fluid's resistance to flow. NeqSim provides several viscos
 fluid.initPhysicalProperties();
 fluid.getPhase("gas").getPhysicalProperties().setViscosityModel("friction theory");
 fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("LBC");
+fluid.getPhase("gas").initPhysicalProperties();
+fluid.getPhase("oil").initPhysicalProperties();
 ```
+
+Select the model after the flash and initial property calculation, then reinitialize each changed
+phase as shown. Model keys are case-sensitive. Unlike conductivity selection, an unsupported
+viscosity key leaves the current model unchanged; verify the selected key in tests rather than
+assuming a fallback.
 
 ---
 
@@ -50,6 +58,7 @@ The Lohrenz-Bray-Clark (1964) method is widely used in reservoir simulation. It 
 $$\eta = \eta^* + \frac{(\eta_r - 0.0001)^4}{\xi}$$
 
 where:
+
 - $\eta^*$ is the dilute gas viscosity
 - $\eta_r$ is a function of reduced density
 - $\xi$ is the inverse viscosity parameter
@@ -62,6 +71,7 @@ $$\eta_r = a_0 + a_1\rho_r + a_2\rho_r^2 + a_3\rho_r^3 + a_4\rho_r^4$$
 **Applicable phases:** Gas, Oil
 
 **Best for:**
+
 - Reservoir simulation
 - Light to medium oils
 - Systems where tuning to lab data is available
@@ -69,6 +79,7 @@ $$\eta_r = a_0 + a_1\rho_r + a_2\rho_r^2 + a_3\rho_r^3 + a_4\rho_r^4$$
 **Usage:**
 ```java
 fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("LBC");
+fluid.getPhase("oil").initPhysicalProperties();
 ```
 
 ---
@@ -83,6 +94,7 @@ The Quiñones-Cisneros and Firoozabadi (2000) friction theory relates viscosity 
 $$\eta = \eta_0 + \kappa_a P_a + \kappa_{aa} P_a^2 + \kappa_r P_r + \kappa_{rr} P_r^2$$
 
 where:
+
 - $\eta_0$ is the dilute gas viscosity (Chung low-density term + Wilke mixture rule)
 - $P_a$ is the attractive pressure from EoS
 - $P_r$ is the repulsive pressure from EoS
@@ -91,6 +103,7 @@ where:
 **Applicable phases:** Gas, Oil (any EoS-based phase)
 
 **Best for:**
+
 - Wide pressure/temperature ranges
 - Near-critical conditions
 - When using SRK or PR EoS
@@ -98,6 +111,7 @@ where:
 **Automatic EoS detection:** The method automatically selects SRK or PR constants based on the phase type.
 
 **Implementation notes in NeqSim (2026 update):**
+
 - SRK and PR friction constants are selected automatically.
 - The dilute-gas baseline now uses **Wilke mixing**, which is the standard state-of-practice for mixture dilute viscosities.
 - The Chung correction factor $F_c$ includes acentric factor, dipole moment, and component viscosity correction term to better handle polar species.
@@ -106,17 +120,22 @@ where:
 **Usage:**
 ```java
 fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("friction theory");
+fluid.getPhase("oil").initPhysicalProperties();
 ```
 
-**Custom constants (for other EoS):**
+**Custom constants (advanced use):**
 ```java
 FrictionTheoryViscosityMethod viscModel =
     (FrictionTheoryViscosityMethod) fluid.getPhase("oil")
         .getPhysicalProperties().getViscosityModel();
 
-// Set custom friction theory constants
+// Values must come from an independently validated parameter set.
 viscModel.setFrictionTheoryConstants(kapac, kaprc, kaprrc, kapa, kapr, kaprr);
 ```
+
+Here `kapac`, `kaprc`, `kaprrc`, and `kaprr` are scalar `double` values; `kapa` and
+`kapr` are `double[][]` matrices. This API replaces the model's complete parameter set and is not
+a general fitting shortcut.
 
 ---
 
@@ -127,6 +146,7 @@ The Pedersen Friction Corresponding States Theory uses methane as a reference fl
 The model can be selected with either `"PFCT"` or `"CSP"`. The `"CSP"` alias is intended for PVT workflows and external reports that label the Pedersen/PFCT viscosity model as CSP viscosity.
 
 **Classes:**
+
 - `PFCTViscosityMethodMod86` - Standard Pedersen method (1987)
 - `PFCTViscosityMethodHeavyOil` - Extended for heavy oils
 
@@ -134,6 +154,7 @@ The model can be selected with either `"PFCT"` or `"CSP"`. The `"CSP"` alias is 
 $$\eta_{mix} = \eta_{ref} \cdot \frac{f_\eta \cdot \alpha_{mix}}{\alpha_0}$$
 
 where:
+
 - $\eta_{ref}$ is the reference fluid (methane) viscosity
 - $f_\eta$ is the shape factor ratio
 - $\alpha$ are molecular weight correction factors
@@ -141,6 +162,7 @@ where:
 **Applicable phases:** Gas, Oil
 
 **Best for:**
+
 - Petroleum mixtures with characterized fractions
 - Heavy oil systems (use `"PFCT-Heavy-Oil"`)
 - Wide-range predictions
@@ -150,42 +172,11 @@ where:
 ```java
 // Standard Pedersen
 fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("PFCT");
-
-// Equivalent CSP alias
-fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("CSP");
-
-// Heavy oil variant
-fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("PFCT-Heavy-Oil");
+fluid.getPhase("oil").initPhysicalProperties();
 ```
 
----
-
-### Chung Method
-
-The Chung method (1984, 1988) is a corresponding states method for dilute gas and dense fluid viscosity.
-
-**Class:** `ChungViscosityMethod`
-
-**Equation (dilute gas):**
-$$\eta_0 = \frac{40.785 F_c \sqrt{M T}}{\Omega_v V_c^{2/3}}$$
-
-where:
-- $F_c$ is the correction factor for polar/associating fluids
-- $\Omega_v$ is the collision integral
-- $V_c$ is critical volume
-- $M$ is molar mass
-
-**Applicable phases:** Primarily gas phase
-
-**Best for:**
-- Dilute gas mixtures
-- Polar gases
-- As baseline for other methods
-
-**Usage:**
-```java
-fluid.getPhase("gas").getPhysicalProperties().setViscosityModel("Chung");
-```
+Use `"CSP"` as an equivalent alias for `"PFCT"`, or select `"PFCT-Heavy-Oil"` for
+characterized heavy fractions. Reinitialize the phase after any selection.
 
 ---
 
@@ -205,12 +196,14 @@ where A, B, C, D are component-specific parameters from COMP database.
 **Applicable phases:** Primarily liquid
 
 **Best for:**
+
 - Pure components with available parameters
 - Simple mixtures with mixing rules
 
 **Usage:**
 ```java
 fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("polynom");
+fluid.getPhase("oil").initPhysicalProperties();
 ```
 
 ---
@@ -220,26 +213,42 @@ fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("polynom");
 Specialized high-accuracy methods for specific fluids:
 
 #### Methane (Reference)
+
 **Class:** `MethaneViscosityMethod`
+
 - Uses Setzmann & Wagner reference equation
 - High accuracy for pure methane
 - Used as reference in PFCT calculations
 
 #### CO₂
+
 **Class:** `CO2ViscosityMethod`
+
 - Fenghour et al. correlation
 - Covers gas, liquid, and supercritical regions
 
 #### Hydrogen
+
 **Classes:** `MuznyViscosityMethod`, `MuznyModViscosityMethod`
+
 - High-accuracy hydrogen viscosity
 - Important for hydrogen energy applications
 
-**Usage:**
+The implemented case-sensitive keys and their constraints are:
+
+| Key | Intended fluid |
+|---|---|
+| `MethaneModel` | Pure methane |
+| `CO2Model` | Pure CO₂ |
+| `Muzny`, `Muzny_mod` | Pure hydrogen |
+| `KTA`, `KTA_mod` | Pure helium |
+| `Salt Water` | Aqueous water/brine phase |
+
+For example, select and recalculate a pure-hydrogen gas phase with:
+
 ```java
-fluid.getPhase("gas").getPhysicalProperties().setViscosityModel("MethaneModel");
-fluid.getPhase("gas").getPhysicalProperties().setViscosityModel("CO2Model");
 fluid.getPhase("gas").getPhysicalProperties().setViscosityModel("Muzny");
+fluid.getPhase("gas").initPhysicalProperties();
 ```
 
 ---
@@ -252,10 +261,11 @@ fluid.getPhase("gas").getPhysicalProperties().setViscosityModel("Muzny");
 | Wide P-T range | Friction Theory | Good near critical |
 | Heavy oils | PFCT-Heavy-Oil | Extended for high MW |
 | Characterized crudes | PFCT | Works with pseudo-components |
-| Gas processing | Chung | Good for gases |
+| General gas processing | Friction theory or PFCT | Validate against representative data |
 | Pure CO₂ | CO2Model | High accuracy |
 | Pure H₂ | Muzny | Reference accuracy |
-| Aqueous systems | Salt Water | Water correlation |
+| Pure helium | KTA | Reference-fluid correlation |
+| Aqueous systems | Salt Water | Water/brine correlation |
 
 ---
 
@@ -266,9 +276,7 @@ fluid.getPhase("gas").getPhysicalProperties().setViscosityModel("Muzny");
 The LBC method is commonly tuned to match laboratory viscosity data:
 
 ```java
-// Get current parameters
-LBCViscosityMethod lbc = (LBCViscosityMethod)
-    fluid.getPhase("oil").getPhysicalProperties().getViscosityModel();
+fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("LBC");
 
 // Set all 5 parameters
 double[] params = {0.1023, 0.023364, 0.058533, -0.040758, 0.0093324};
@@ -276,9 +284,11 @@ fluid.getPhase("oil").getPhysicalProperties().setLbcParameters(params);
 
 // Or tune individual parameters
 fluid.getPhase("oil").getPhysicalProperties().setLbcParameter(0, 0.105);
+fluid.getPhase("oil").initPhysicalProperties();
 ```
 
 **Tuning procedure:**
+
 1. Measure viscosity at multiple P-T conditions
 2. Run flash and calculate properties
 3. Adjust parameters to minimize error
@@ -307,15 +317,13 @@ For automated fitting, add viscosity measurements to `PVTRegression` with `addVi
 
 ```java
 import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 // Create and flash fluid
-SystemInterface fluid = new SystemSrkEos(350.0, 150.0);
-fluid.addComponent("methane", 0.70);
-fluid.addComponent("ethane", 0.10);
-fluid.addComponent("propane", 0.05);
-fluid.addComponent("n-heptane", 0.10);
-fluid.addComponent("n-decane", 0.05);
+SystemInterface fluid = new SystemSrkEos(298.15, 4.0);
+fluid.addComponent("n-heptane", 0.5);
+fluid.addComponent("nC10", 0.5);
 fluid.setMixingRule("classic");
 
 ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
@@ -323,51 +331,57 @@ ops.TPflash();
 
 // Initialize physical properties
 fluid.initPhysicalProperties();
+fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("LBC");
+fluid.getPhase("oil").initPhysicalProperties();
 
-// Get viscosities
-double gasVisc = fluid.getPhase("gas").getViscosity("cP");
+// Get viscosity
 double oilVisc = fluid.getPhase("oil").getViscosity("cP");
-
-System.out.println("Gas viscosity: " + gasVisc + " cP");
-System.out.println("Oil viscosity: " + oilVisc + " cP");
+if (!(oilVisc > 0.0) || !Double.isFinite(oilVisc)) {
+    throw new IllegalStateException("Expected positive finite oil viscosity");
+}
 ```
 
 ### Comparing Viscosity Models
 
 ```java
 String[] models = {"LBC", "friction theory", "PFCT"};
+double[] viscositiesCp = new double[models.length];
 
-for (String model : models) {
-    SystemInterface fluid = createFluid();
+for (int i = 0; i < models.length; i++) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 4.0);
+    fluid.addComponent("n-heptane", 0.5);
+    fluid.addComponent("nC10", 0.5);
+    fluid.setMixingRule("classic");
+    ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
     ops.TPflash();
     fluid.initPhysicalProperties();
 
-    fluid.getPhase("oil").getPhysicalProperties().setViscosityModel(model);
-    fluid.initPhysicalProperties();
-
-    double visc = fluid.getPhase("oil").getViscosity("cP");
-    System.out.println(model + ": " + visc + " cP");
+    fluid.getPhase("oil").getPhysicalProperties().setViscosityModel(models[i]);
+    fluid.getPhase("oil").initPhysicalProperties();
+    viscositiesCp[i] = fluid.getPhase("oil").getViscosity("cP");
 }
 ```
 
 ### Viscosity vs Temperature
 
 ```java
-SystemInterface baseFluid = createFluid();
-baseFluid.initPhysicalProperties();
+SystemInterface baseFluid = new SystemSrkEos(300.0, 20.0);
+baseFluid.addComponent("nC10", 1.0);
+baseFluid.setMixingRule("classic");
 
 double[] temps = {300, 320, 340, 360, 380, 400};  // K
+double[] viscositiesCp = new double[temps.length];
 
-for (double T : temps) {
+for (int i = 0; i < temps.length; i++) {
     SystemInterface fluid = baseFluid.clone();
-    fluid.setTemperature(T, "K");
+    fluid.setTemperature(temps[i], "K");
 
     ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
     ops.TPflash();
     fluid.initPhysicalProperties();
-
-    double visc = fluid.getPhase("oil").getViscosity("cP");
-    System.out.println("T=" + (T-273.15) + "°C: " + visc + " cP");
+    fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("LBC");
+    fluid.getPhase("oil").initPhysicalProperties();
+    viscositiesCp[i] = fluid.getPhase("oil").getViscosity("cP");
 }
 ```
 
@@ -382,13 +396,14 @@ For dilute gases, viscosity is calculated from kinetic theory:
 $$\eta_0 = \frac{5}{16} \frac{\sqrt{\pi m k_B T}}{\pi \sigma^2 \Omega^{(2,2)*}}$$
 
 where:
+
 - $m$ is molecular mass
 - $\sigma$ is Lennard-Jones diameter
 - $\Omega^{(2,2)*}$ is the collision integral
 
 ### Mixing Rules
 
-Most models use molar fraction-weighted mixing:
+Mixing behavior is model-specific. Common forms include logarithmic molar weighting:
 
 $$\eta_{mix} = \exp\left(\sum_i x_i \ln \eta_i\right)$$
 

--- a/src/test/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/ViscosityDocumentationTest.java
+++ b/src/test/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/ViscosityDocumentationTest.java
@@ -1,0 +1,179 @@
+package neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Executable coverage for {@code docs/physical_properties/viscosity_models.md}. */
+class ViscosityDocumentationTest {
+
+  @Test
+  void phaseSpecificSelectionRecalculatesBothPhases() {
+    SystemInterface fluid = new SystemSrkEos(280.0, 30.0);
+    fluid.addComponent("methane", 0.5);
+    fluid.addComponent("n-pentane", 0.5);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    new ThermodynamicOperations(fluid).TPflash();
+    fluid.initPhysicalProperties();
+    assertTrue(fluid.hasPhaseType("gas"));
+    assertTrue(fluid.hasPhaseType("oil"));
+
+    fluid.getPhase("gas").getPhysicalProperties().setViscosityModel("friction theory");
+    fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("LBC");
+    fluid.getPhase("gas").initPhysicalProperties();
+    fluid.getPhase("oil").initPhysicalProperties();
+
+    assertPositiveFinite(fluid.getPhase("gas").getViscosity("cP"));
+    assertPositiveFinite(fluid.getPhase("oil").getViscosity("cP"));
+  }
+
+  @Test
+  void basicCalculationAndComparisonExamplesRun() {
+    String[] models = {"LBC", "friction theory", "PFCT"};
+    String[] expectedClasses = {
+        "LBCViscosityMethod", "FrictionTheoryViscosityMethod", "PFCTViscosityMethodMod86"};
+    double[] viscositiesCp = new double[models.length];
+
+    for (int i = 0; i < models.length; i++) {
+      SystemInterface fluid = createOil(298.15, 4.0);
+      fluid.initPhysicalProperties();
+      fluid.getPhase("oil").getPhysicalProperties().setViscosityModel(models[i]);
+      fluid.getPhase("oil").initPhysicalProperties();
+
+      assertEquals(expectedClasses[i], fluid.getPhase("oil").getPhysicalProperties()
+          .getViscosityModel().getClass().getSimpleName());
+      viscositiesCp[i] = fluid.getPhase("oil").getViscosity("cP");
+      assertPositiveFinite(viscositiesCp[i]);
+    }
+  }
+
+  @Test
+  void temperatureSweepRemainsLiquidAndDecreases() {
+    double[] temperatures = {300.0, 320.0, 340.0, 360.0, 380.0, 400.0};
+    double previousViscosityCp = Double.POSITIVE_INFINITY;
+
+    for (double temperature : temperatures) {
+      SystemInterface fluid = new SystemSrkEos(temperature, 20.0);
+      fluid.addComponent("nC10", 1.0);
+      fluid.setMixingRule("classic");
+      new ThermodynamicOperations(fluid).TPflash();
+      fluid.initPhysicalProperties();
+      assertTrue(fluid.hasPhaseType("oil"));
+
+      fluid.getPhase("oil").getPhysicalProperties().setViscosityModel("LBC");
+      fluid.getPhase("oil").initPhysicalProperties();
+      double viscosityCp = fluid.getPhase("oil").getViscosity("cP");
+      assertPositiveFinite(viscosityCp);
+      assertTrue(viscosityCp < previousViscosityCp);
+      previousViscosityCp = viscosityCp;
+    }
+  }
+
+  @Test
+  void everyDocumentedSpecializedKeySelectsItsImplementation() {
+    assertSpecializedGasModel("MethaneModel", "methane", "MethaneViscosityMethod");
+    assertSpecializedGasModel("CO2Model", "CO2", "CO2ViscosityMethod");
+    assertSpecializedGasModel("Muzny", "hydrogen", "MuznyViscosityMethod");
+    assertSpecializedGasModel("Muzny_mod", "hydrogen", "MuznyModViscosityMethod");
+    assertSpecializedGasModel("KTA", "helium", "KTAViscosityMethod");
+    assertSpecializedGasModel("KTA_mod", "helium", "KTAViscosityMethodMod");
+
+    SystemInterface water = new SystemSrkCPAstatoil(298.15, 10.0);
+    water.addComponent("water", 1.0);
+    water.setMixingRule(10);
+    new ThermodynamicOperations(water).TPflash();
+    water.initPhysicalProperties();
+    water.getPhase("aqueous").getPhysicalProperties().setViscosityModel("Salt Water");
+    water.getPhase("aqueous").initPhysicalProperties();
+
+    assertEquals("Water", water.getPhase("aqueous").getPhysicalProperties()
+        .getViscosityModel().getClass().getSimpleName());
+    assertPositiveFinite(water.getPhase("aqueous").getViscosity("cP"));
+  }
+
+  @Test
+  void tuningAndAdvancedParameterExamplesRun() {
+    SystemInterface oil = createOil(323.15, 20.0);
+    oil.initPhysicalProperties();
+
+    oil.getPhase("oil").getPhysicalProperties().setViscosityModel("LBC");
+    double[] lbcParameters = {0.1023, 0.023364, 0.058533, -0.040758, 0.0093324};
+    oil.getPhase("oil").getPhysicalProperties().setLbcParameters(lbcParameters);
+    oil.getPhase("oil").getPhysicalProperties().setLbcParameter(0, 0.105);
+    oil.getPhase("oil").initPhysicalProperties();
+    lbcParameters[0] = 0.105;
+    assertArrayEquals(lbcParameters,
+        oil.getPhase("oil").getPhysicalProperties().getLbcParameters(), 1.0e-12);
+
+    oil.getPhase("oil").getPhysicalProperties().setViscosityModel("PFCT");
+    double[] cspParameters = {0.95, 1.05, 1.0, 1.0};
+    oil.getPhase("oil").getPhysicalProperties().setCspViscosityParameters(cspParameters);
+    oil.getPhase("oil").getPhysicalProperties().setCspViscosityParameter(3, 0.98);
+    oil.getPhase("oil").initPhysicalProperties();
+    cspParameters[3] = 0.98;
+    assertArrayEquals(cspParameters,
+        oil.getPhase("oil").getPhysicalProperties().getCspViscosityParameters(), 1.0e-12);
+
+    oil.getPhase("oil").getPhysicalProperties().setViscosityModel("friction theory");
+    FrictionTheoryViscosityMethod method = (FrictionTheoryViscosityMethod) oil.getPhase("oil")
+        .getPhysicalProperties().getViscosityModel();
+    double[][] kapa = {{-0.114804, 0.246622, -3.94638e-2},
+        {0.246622, -1.15648e-4, 4.18863e-5}, {-3.94638e-2, 4.18863e-5, -5.91999e-9}};
+    double[][] kapr = {{-0.315903, 0.566713, -7.29995e-2},
+        {0.566713, -1.0086e-4, 5.17459e-5}, {-7.29995e-2, 5.17459e-5, -5.68708e-9}};
+    method.setFrictionTheoryConstants(-0.165302, 6.99574e-3, 1.26358e-3, kapa, kapr,
+        1.35994e-8);
+    oil.getPhase("oil").initPhysicalProperties();
+    assertPositiveFinite(oil.getPhase("oil").getViscosity("cP"));
+  }
+
+  @Test
+  void unsupportedKeyLeavesCurrentModelUnchanged() {
+    SystemInterface gas = new SystemSrkEos(298.15, 10.0);
+    gas.addComponent("methane", 1.0);
+    new ThermodynamicOperations(gas).TPflash();
+    gas.initPhysicalProperties();
+    String before = gas.getPhase("gas").getPhysicalProperties().getViscosityModel().getClass()
+        .getSimpleName();
+
+    gas.getPhase("gas").getPhysicalProperties().setViscosityModel("unsupported-key");
+
+    assertEquals(before, gas.getPhase("gas").getPhysicalProperties().getViscosityModel()
+        .getClass().getSimpleName());
+  }
+
+  private static SystemInterface createOil(double temperature, double pressureBara) {
+    SystemInterface fluid = new SystemSrkEos(temperature, pressureBara);
+    fluid.addComponent("n-heptane", 0.5);
+    fluid.addComponent("nC10", 0.5);
+    fluid.setMixingRule("classic");
+    new ThermodynamicOperations(fluid).TPflash();
+    return fluid;
+  }
+
+  private static void assertSpecializedGasModel(String key, String component,
+      String expectedClass) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent(component, 1.0);
+    new ThermodynamicOperations(fluid).TPflash();
+    fluid.initPhysicalProperties();
+    fluid.getPhase("gas").getPhysicalProperties().setViscosityModel(key);
+    fluid.getPhase("gas").initPhysicalProperties();
+
+    assertEquals(expectedClass, fluid.getPhase("gas").getPhysicalProperties()
+        .getViscosityModel().getClass().getSimpleName());
+    assertPositiveFinite(fluid.getPhase("gas").getViscosity("cP"));
+  }
+
+  private static void assertPositiveFinite(double value) {
+    assertTrue(value > 0.0 && Double.isFinite(value));
+  }
+}

--- a/src/test/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/ViscosityDocumentationTest.java
+++ b/src/test/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/ViscosityDocumentationTest.java
@@ -37,9 +37,8 @@ class ViscosityDocumentationTest {
 
   @Test
   void basicCalculationAndComparisonExamplesRun() {
-    String[] models = {"LBC", "friction theory", "PFCT"};
-    String[] expectedClasses = {
-        "LBCViscosityMethod", "FrictionTheoryViscosityMethod", "PFCTViscosityMethodMod86"};
+    String[] models = { "LBC", "friction theory", "PFCT" };
+    String[] expectedClasses = { "LBCViscosityMethod", "FrictionTheoryViscosityMethod", "PFCTViscosityMethodMod86" };
     double[] viscositiesCp = new double[models.length];
 
     for (int i = 0; i < models.length; i++) {
@@ -48,8 +47,8 @@ class ViscosityDocumentationTest {
       fluid.getPhase("oil").getPhysicalProperties().setViscosityModel(models[i]);
       fluid.getPhase("oil").initPhysicalProperties();
 
-      assertEquals(expectedClasses[i], fluid.getPhase("oil").getPhysicalProperties()
-          .getViscosityModel().getClass().getSimpleName());
+      assertEquals(expectedClasses[i],
+          fluid.getPhase("oil").getPhysicalProperties().getViscosityModel().getClass().getSimpleName());
       viscositiesCp[i] = fluid.getPhase("oil").getViscosity("cP");
       assertPositiveFinite(viscositiesCp[i]);
     }
@@ -57,7 +56,7 @@ class ViscosityDocumentationTest {
 
   @Test
   void temperatureSweepRemainsLiquidAndDecreases() {
-    double[] temperatures = {300.0, 320.0, 340.0, 360.0, 380.0, 400.0};
+    double[] temperatures = { 300.0, 320.0, 340.0, 360.0, 380.0, 400.0 };
     double previousViscosityCp = Double.POSITIVE_INFINITY;
 
     for (double temperature : temperatures) {
@@ -94,8 +93,8 @@ class ViscosityDocumentationTest {
     water.getPhase("aqueous").getPhysicalProperties().setViscosityModel("Salt Water");
     water.getPhase("aqueous").initPhysicalProperties();
 
-    assertEquals("Water", water.getPhase("aqueous").getPhysicalProperties()
-        .getViscosityModel().getClass().getSimpleName());
+    assertEquals("Water",
+        water.getPhase("aqueous").getPhysicalProperties().getViscosityModel().getClass().getSimpleName());
     assertPositiveFinite(water.getPhase("aqueous").getViscosity("cP"));
   }
 
@@ -105,32 +104,29 @@ class ViscosityDocumentationTest {
     oil.initPhysicalProperties();
 
     oil.getPhase("oil").getPhysicalProperties().setViscosityModel("LBC");
-    double[] lbcParameters = {0.1023, 0.023364, 0.058533, -0.040758, 0.0093324};
+    double[] lbcParameters = { 0.1023, 0.023364, 0.058533, -0.040758, 0.0093324 };
     oil.getPhase("oil").getPhysicalProperties().setLbcParameters(lbcParameters);
     oil.getPhase("oil").getPhysicalProperties().setLbcParameter(0, 0.105);
     oil.getPhase("oil").initPhysicalProperties();
     lbcParameters[0] = 0.105;
-    assertArrayEquals(lbcParameters,
-        oil.getPhase("oil").getPhysicalProperties().getLbcParameters(), 1.0e-12);
+    assertArrayEquals(lbcParameters, oil.getPhase("oil").getPhysicalProperties().getLbcParameters(), 1.0e-12);
 
     oil.getPhase("oil").getPhysicalProperties().setViscosityModel("PFCT");
-    double[] cspParameters = {0.95, 1.05, 1.0, 1.0};
+    double[] cspParameters = { 0.95, 1.05, 1.0, 1.0 };
     oil.getPhase("oil").getPhysicalProperties().setCspViscosityParameters(cspParameters);
     oil.getPhase("oil").getPhysicalProperties().setCspViscosityParameter(3, 0.98);
     oil.getPhase("oil").initPhysicalProperties();
     cspParameters[3] = 0.98;
-    assertArrayEquals(cspParameters,
-        oil.getPhase("oil").getPhysicalProperties().getCspViscosityParameters(), 1.0e-12);
+    assertArrayEquals(cspParameters, oil.getPhase("oil").getPhysicalProperties().getCspViscosityParameters(), 1.0e-12);
 
     oil.getPhase("oil").getPhysicalProperties().setViscosityModel("friction theory");
-    FrictionTheoryViscosityMethod method = (FrictionTheoryViscosityMethod) oil.getPhase("oil")
-        .getPhysicalProperties().getViscosityModel();
-    double[][] kapa = {{-0.114804, 0.246622, -3.94638e-2},
-        {0.246622, -1.15648e-4, 4.18863e-5}, {-3.94638e-2, 4.18863e-5, -5.91999e-9}};
-    double[][] kapr = {{-0.315903, 0.566713, -7.29995e-2},
-        {0.566713, -1.0086e-4, 5.17459e-5}, {-7.29995e-2, 5.17459e-5, -5.68708e-9}};
-    method.setFrictionTheoryConstants(-0.165302, 6.99574e-3, 1.26358e-3, kapa, kapr,
-        1.35994e-8);
+    FrictionTheoryViscosityMethod method = (FrictionTheoryViscosityMethod) oil.getPhase("oil").getPhysicalProperties()
+        .getViscosityModel();
+    double[][] kapa = { { -0.114804, 0.246622, -3.94638e-2 }, { 0.246622, -1.15648e-4, 4.18863e-5 },
+        { -3.94638e-2, 4.18863e-5, -5.91999e-9 } };
+    double[][] kapr = { { -0.315903, 0.566713, -7.29995e-2 }, { 0.566713, -1.0086e-4, 5.17459e-5 },
+        { -7.29995e-2, 5.17459e-5, -5.68708e-9 } };
+    method.setFrictionTheoryConstants(-0.165302, 6.99574e-3, 1.26358e-3, kapa, kapr, 1.35994e-8);
     oil.getPhase("oil").initPhysicalProperties();
     assertPositiveFinite(oil.getPhase("oil").getViscosity("cP"));
   }
@@ -141,13 +137,11 @@ class ViscosityDocumentationTest {
     gas.addComponent("methane", 1.0);
     new ThermodynamicOperations(gas).TPflash();
     gas.initPhysicalProperties();
-    String before = gas.getPhase("gas").getPhysicalProperties().getViscosityModel().getClass()
-        .getSimpleName();
+    String before = gas.getPhase("gas").getPhysicalProperties().getViscosityModel().getClass().getSimpleName();
 
     gas.getPhase("gas").getPhysicalProperties().setViscosityModel("unsupported-key");
 
-    assertEquals(before, gas.getPhase("gas").getPhysicalProperties().getViscosityModel()
-        .getClass().getSimpleName());
+    assertEquals(before, gas.getPhase("gas").getPhysicalProperties().getViscosityModel().getClass().getSimpleName());
   }
 
   private static SystemInterface createOil(double temperature, double pressureBara) {
@@ -159,8 +153,7 @@ class ViscosityDocumentationTest {
     return fluid;
   }
 
-  private static void assertSpecializedGasModel(String key, String component,
-      String expectedClass) {
+  private static void assertSpecializedGasModel(String key, String component, String expectedClass) {
     SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
     fluid.addComponent(component, 1.0);
     new ThermodynamicOperations(fluid).TPflash();
@@ -168,8 +161,8 @@ class ViscosityDocumentationTest {
     fluid.getPhase("gas").getPhysicalProperties().setViscosityModel(key);
     fluid.getPhase("gas").initPhysicalProperties();
 
-    assertEquals(expectedClass, fluid.getPhase("gas").getPhysicalProperties()
-        .getViscosityModel().getClass().getSimpleName());
+    assertEquals(expectedClass,
+        fluid.getPhase("gas").getPhysicalProperties().getViscosityModel().getClass().getSimpleName());
     assertPositiveFinite(fluid.getPhase("gas").getViscosity("cP"));
   }
 


### PR DESCRIPTION
## Campaign

Relates to #2499.

## Scan scope

D004 — executable API audit of one bounded physical-properties page:

- `docs/physical_properties/viscosity_models.md`
- current `PhysicalProperties.setViscosityModel` implementation
- viscosity model implementations and existing focused tests

No production code or other documentation page is changed.

## Confirmed defects

1. **High — non-compiling basic example:** `SystemInterface` was used without an import.
2. **High — incomplete comparison example:** it called undefined `createFluid()` and reused an undefined `ops`.
3. **High — incomplete temperature example:** it also depended on undefined `createFluid()`.
4. **High — nonexistent selector:** the guide documented a `Chung` viscosity key and `ChungViscosityMethod`, but current `setViscosityModel` implements neither. The call silently retained the preceding model.
5. **Medium — stale recalculation workflow:** model-selection snippets did not reinitialize the changed phase.
6. **Medium — incomplete applicability guidance:** current `KTA`, `KTA_mod`, `Muzny_mod`, and `Salt Water` keys and their fluid constraints were absent.
7. **Medium — unsafe tuning guidance:** the LBC example read/cast the active model before selecting LBC, and the full friction-theory parameter replacement omitted types and validation boundaries.
8. **Medium — overgeneralized theory:** the mixing-rule text implied one universal viscosity mixing behavior although implementations are model-specific.

## Fixes

- Make all three complete usage examples self-contained and Java 8 compatible.
- Use explicit, stable oil cases; store calculated results; and assert positive finite output in the basic example.
- Reinitialize only the phase whose viscosity model changed.
- Remove the nonexistent standalone Chung selector while retaining Chung's documented role inside the friction-theory dilute baseline.
- Document all current specialized keys, case sensitivity, pure-fluid constraints, and unsupported-key behavior.
- Select LBC before applying tuning parameters and clarify the advanced friction-constant API.
- Qualify mixing behavior as model-specific.
- Add `ViscosityDocumentationTest` covering the complete examples, two-phase selection, temperature trend, all specialized keys, LBC/CSP tuning, friction constants, implementation class selection, and unsupported-key behavior.

## Validation performed

- Read current `PhysicalProperties`, `PhysicalPropertyModel`, `FrictionTheoryViscosityMethod`, `LBCViscosityMethod`, `PFCTViscosityMethodMod86`, and existing model tests.
- NeqSim 3.16.0 runtime smoke:
  - LBC, friction theory, PFCT/CSP, PFCT-Heavy-Oil, and polynomial oil models returned positive finite values.
  - methane, CO2, hydrogen, helium, and salt-water specialized keys selected the expected implementation and returned positive finite values.
  - the documented two-phase gas/oil selection returned positive finite values.
  - the 300–400 K n-decane sweep remained liquid and decreased monotonically from 0.870 to 0.306 cP.
  - LBC and CSP tuning accessors passed round-trip checks.
- Page structure: front matter, 11 internal anchors, balanced code fences, no duplicate H1, and supported KaTeX delimiters passed.
- `python devtools/check_documentation_search.py`: **619 Markdown pages and 1 standalone HTML page passed** locally; hosted audit passed with **620 Markdown pages and 1 standalone HTML page** on the PR merge ref.
- External links in this bounded page: none.
- Java source style: no lines over 120 characters.
- Branch comparison: exactly one documentation page and one focused test; no overlap with other open PRs.

## Hosted verification status

- D004 `ViscosityDocumentationTest`: **6 tests passed, 0 failures, 0 errors** on Windows Java 21.
- Hosted Jekyll build, generated search coverage, and JavaScript syntax: **passed**.
- Java 21 Javadoc: **passed**.
- CodeQL Maven build and security analysis: **passed**.
- Spotless formatting for D004's changed Java file: **clean**.
- Full Windows Java 21 suite executed **10,481 tests** but failed on two tests inherited unchanged from `master`:
  - `NorwegianOilFieldLifecycleTest.gasInjectionCaseRunsFromReservoirToEconomics` — expected true, got false (introduced by merged #2502).
  - `LNGProcessBuilderTest.testIntegratesPipelineWithProcessCapacityFramework` — null compressor thermodynamic system (introduced by merged #2504).
- Ubuntu Java 21 was cancelled after the Windows failure; Java 8 jobs were consequently skipped.
- Repository-wide pre-commit is blocked by 15 field-lifecycle Java files already unformatted on `master`. Neither D004 file appears in the rerun failure.

Current `master` remains at `5704cc00`, the PR base; no upstream repair PR or overlapping viscosity change is open. The inherited failures are deliberately excluded from this two-file documentation PR. D004 therefore remains draft and is marked `blocked`, not ready for review.

The local Maven cache lacks `maven-enforcer-plugin:3.6.3`, and Maven Central is unavailable in this execution environment, so hosted Actions provide the authoritative Java execution evidence.

## Compatibility and impact

Documentation and tests only. No production API, model parameter, default, or numerical behavior changes.

## Exclusions and next scope

No viscosity correlation or production behavior was changed. Once the two inherited repository regressions and baseline formatting violations are repaired and the full matrix is rerun, D004 can advance to ready-review. After merge, continue the physical-properties rotation with the diffusivity API page or advance to process-equipment documentation if the ledger calls for the next rotation scope.
