### PR TITLE
Bound Beggs-Brill liquid holdup to physical limits

### DIFF
--- a/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
@@ -1290,6 +1290,13 @@ public class PipeBeggsAndBrills extends Pipeline implements neqsim.process.desig
           * (Math.sin(1.8 * angle * 0.01745329) - (1.0 / 3.0) * Math.pow(Math.sin(1.8 * angle * 0.01745329), 3.0));
 
       El = BThetta * El;
+
+      // Liquid holdup is a physical volume fraction. The empirical correlation and
+      // inclination correction can exceed unity for low-Froude, liquid-rich flow.
+      // Bound the result by the no-slip liquid fraction and one before it is used
+      // in mixture-density and pressure-drop calculations.
+      El = Math.max(inputVolumeFractionLiquid, Math.min(1.0, El));
+
       if (system.getNumberOfPhases() == 3) {
         mixtureDensity = mixtureLiquidDensity * El + system.getPhase(0).getDensity("lb/ft3") * (1 - El);
       } else {

--- a/src/test/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrillsHoldupTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrillsHoldupTest.java
@@ -1,0 +1,65 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Regression tests for physically bounded Beggs-Brill liquid holdup.
+ */
+class PipeBeggsAndBrillsHoldupTest {
+  @Test
+  void liquidRichLowVelocityHoldupIsBounded() {
+    SystemInterface fluid = new SystemPrEos(308.15, 80.0);
+    fluid.addComponent("nitrogen", 0.5);
+    fluid.addComponent("CO2", 1.0);
+    fluid.addComponent("methane", 45.0);
+    fluid.addComponent("ethane", 5.0);
+    fluid.addComponent("propane", 5.0);
+    fluid.addComponent("i-butane", 2.0);
+    fluid.addComponent("n-butane", 3.0);
+    fluid.addComponent("i-pentane", 2.0);
+    fluid.addComponent("n-pentane", 2.0);
+    fluid.addComponent("n-hexane", 5.0);
+    fluid.addComponent("n-heptane", 8.0);
+    fluid.addComponent("n-octane", 10.0);
+    fluid.addComponent("n-nonane", 6.0);
+    fluid.addComponent("nC10", 5.5);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    fluid.setTotalFlowRate(10000.0, "kg/hr");
+    new ThermodynamicOperations(fluid).TPflash();
+    fluid.initProperties();
+
+    assertTrue(fluid.getNumberOfPhases() > 1, "Regression fluid must be multiphase");
+
+    Stream inlet = new Stream("liquid-rich inlet", fluid);
+    inlet.run();
+    PipeBeggsAndBrills pipe =
+        new PipeBeggsAndBrills("holdup regression pipe", inlet);
+    pipe.setLength(10000.0);
+    pipe.setDiameter(0.25);
+    pipe.setElevation(0.0);
+    pipe.setPipeWallRoughness(5.0e-5);
+    pipe.setNumberOfIncrements(5);
+    pipe.setRunIsothermal(true);
+    pipe.run();
+
+    double maximumHoldup = 0.0;
+    for (double holdup : pipe.getLiquidHoldupProfile()) {
+      assertTrue(holdup >= 0.0, "Liquid holdup must not be negative");
+      assertTrue(holdup <= 1.0, "Liquid holdup must not exceed unity");
+      maximumHoldup = Math.max(maximumHoldup, holdup);
+    }
+
+    assertEquals(
+        1.0,
+        maximumHoldup,
+        1.0e-12,
+        "This liquid-rich regression case should exercise the upper bound");
+  }
+}


### PR DESCRIPTION
## Summary

- bound inclination-corrected Beggs-Brill liquid holdup between the no-slip liquid fraction and unity
- apply the bound before mixture density and pressure-drop calculations
- add a liquid-rich, low-velocity regression case that previously returned holdup above 1.0

## Reproduction

The issue was found while validating a reservoir-fluid multiphase-flow notebook against the current PyPI release, NeqSim 3.16.0. A PR-EOS gas/oil fluid at 80 bara and 35 °C, flowing at 10,000 kg/h through a 10 km horizontal pipe with 0.25 m ID and 50 µm roughness, returned a maximum liquid holdup of approximately 1.097.

Liquid holdup is a volume fraction, so values above unity make the mixture-density and hydrostatic-pressure calculations nonphysical. The correlation can exceed unity in low-Froude, liquid-rich conditions; the standard physical bound is therefore applied after the inclination correction.

## Validation

- reproduced the released-version defect through the Python interface
- regression test asserts every profile value is in [0, 1]
- regression test exercises the upper bound and retains a multiphase inlet
- change is limited to the Beggs-Brill holdup result and one focused test

Full Java CI is expected to run on this pull request.