### PR TITLE
docs: repair valve equipment API examples

### DIFF
--- a/docs/process/equipment/valves.md
+++ b/docs/process/equipment/valves.md
@@ -1,443 +1,193 @@
 ---
 title: Valve Equipment
-description: Documentation for valve equipment in NeqSim process simulation.
-keywords: "valve, throttling valve, control valve, JT valve, Joule-Thomson, Cv, pressure drop, valve sizing, choke, relief valve, PSV"
+description: >-
+  Verified NeqSim examples for throttling valves, valve flow coefficients,
+  characteristics, mechanical design, and dynamic travel.
+keywords: "valve, throttling valve, control valve, Joule-Thomson, Cv, Kv, pressure drop, choke, mechanical design"
 ---
 
-# Valve Equipment
+NeqSim represents pressure letdown and control-valve calculations with classes in
+`neqsim.process.equipment.valve`. This page focuses on the current
+`ThrottlingValve` API. For pressure-safety valves and production-choke
+correlations, use the dedicated guides linked below.
 
-Documentation for valve equipment in NeqSim process simulation.
+## Available valve classes
 
-## Table of Contents
-- [Overview](#overview)
-- [Valve Types](#valve-types)
-- [Sizing and Cv](#sizing-and-cv)
-- [Valve Characteristics](#valve-characteristics)
-- [Sizing Standards](#sizing-standards)
-- [Mechanical Design](#mechanical-design)
-- [Usage Examples](#usage-examples)
+| Class | Purpose |
+|---|---|
+| `ThrottlingValve` | Isenthalpic pressure letdown, specified outlet pressure, or Cv/Kv-based calculation |
+| `ControlValve` | Named specialization of `ThrottlingValve` for control applications |
+| `SafetyValve` | Scenario-based relieving valve with transient opening and blowdown behavior |
+| `SafetyReliefValve` | Dynamic PSV model with configurable opening law and rated Cv |
+| `BlowdownValve` | Timed emergency blowdown-valve opening |
+| `ESDValve` | Emergency-shutdown valve with stroke-time behavior |
 
----
+There is no `ChokeValve` class. Represent a production choke with
+`ThrottlingValve` and select a multiphase choke model through its
+`ValveMechanicalDesign` object.
 
-## Overview
+## Complete pressure-letdown example
 
-**Location:** `neqsim.process.equipment.valve`
-
-**Classes:**
-- `ThrottlingValve` - Joule-Thomson throttling valve (control valve)
-- `ValveInterface` - Valve interface
-- `SafetyValve` - Pressure relief valve
-- `SafetyReliefValve` - Full PSV with API sizing
-- `BlowdownValve` - Emergency blowdown valve
-- `ControlValve` - Specialized control valve
-
-> **📖 Additional Valve Documentation:**
-> - [Control Valves Guide](control_valves) - CheckValve, LevelControlValve, PressureControlValve, ESD/PSD valves
-> - [HIPPS Implementation](../../safety/hipps_implementation) - High Integrity Pressure Protection
-
-**Mechanical Design:** `neqsim.process.mechanicaldesign.valve`
-- `ValveMechanicalDesign` - Body sizing, weight, actuator calculations
-- `ControlValveSizing` - IEC 60534 Cv/Kv calculations
-- `ControlValveSizing_IEC_60534` - Full IEC implementation
-- `ControlValveSizing_simple` - Production choke sizing
-
----
-
-## Throttling Valve
-
-### Basic Usage
+The following program creates a gas stream, flashes it through a valve, and
+checks the defining isenthalpic relationship. Pressure units are absolute.
 
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
 
-ThrottlingValve valve = new ThrottlingValve("FV-100", inletStream);
-valve.setOutletPressure(30.0, "bara");
-valve.run();
+public final class ValveLetdownExample {
+  private static final Logger logger = LogManager.getLogger(ValveLetdownExample.class);
 
-// Joule-Thomson cooling
-double Tin = inletStream.getTemperature("C");
-double Tout = valve.getOutletStream().getTemperature("C");
-double deltaT = Tout - Tin;
+  private ValveLetdownExample() {}
 
-System.out.println("Temperature change: " + deltaT + " °C");
+  public static void main(String[] args) {
+    SystemInterface fluid = new SystemSrkEos(273.15 + 30.0, 80.0);
+    fluid.addComponent("methane", 0.90);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.03);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("feed", fluid);
+    inlet.setFlowRate(10_000.0, "kg/hr");
+    inlet.setTemperature(30.0, "C");
+    inlet.setPressure(80.0, "bara");
+    inlet.run();
+
+    double inletEnthalpy = inlet.getFluid().getEnthalpy("J/mol");
+    double inletTemperature = inlet.getTemperature("C");
+
+    ThrottlingValve valve = new ThrottlingValve("PV-100", inlet);
+    valve.setOutletPressure(30.0, "bara");
+    valve.run();
+
+    double outletEnthalpy = valve.getOutletStream().getFluid().getEnthalpy("J/mol");
+    double outletTemperature = valve.getOutletStream().getTemperature("C");
+    double enthalpyResidual = outletEnthalpy - inletEnthalpy;
+
+    logger.info("Outlet temperature: {} C", outletTemperature);
+    logger.info("Temperature change: {} K", outletTemperature - inletTemperature);
+    logger.info("Molar-enthalpy residual: {} J/mol", enthalpyResidual);
+  }
+}
 ```
 
-### Isenthalpic Expansion
+The outlet temperature is calculated by an isenthalpic flash. The sign and
+magnitude of the Joule–Thomson temperature change depend on the fluid,
+temperature, pressure, and thermodynamic model.
 
-Throttling is isenthalpic (constant enthalpy):
+## Cv, Kv, and valve opening
+
+`Cv` uses the US convention and `Kv` the SI convention. NeqSim stores the
+coefficient internally as Kv and converts with $C_v = 1.156K_v$.
 
 ```java
-double H_in = inletStream.getEnthalpy("J/mol");
-double H_out = valve.getOutletStream().getEnthalpy("J/mol");
-// H_in ≈ H_out (within numerical precision)
+ThrottlingValve valve = new ThrottlingValve("FV-100", inlet);
+valve.setCv(150.0, "US");
+valve.setPercentValveOpening(50.0);
+
+double cvUS = valve.getCv("US");
+double kvSI = valve.getCv("SI");
+double opening = valve.getPercentValveOpening();
 ```
 
----
+Setting an outlet pressure and calling `run()` performs a specified-pressure
+letdown. To solve outlet pressure from the inlet flow, coefficient, and opening,
+set the Cv/Kv and call `setIsCalcOutPressure(true)` before running the valve.
+The result depends on the selected gas/liquid sizing behavior and valid inlet
+physical properties.
 
-## Valve Sizing
+## Valve characteristic and mechanical design
 
-### Flow Coefficient (Cv)
-
-```java
-// Set Cv
-valve.setCv(150.0, "US");  // US gallons/min at 1 psi ΔP
-// Or
-valve.setCv(150.0, "SI");  // m³/hr at 1 bar ΔP
-
-// Get Cv at current conditions
-double Cv = valve.getCv("US");
-```
-
-### Valve Opening
-
-```java
-// Set valve position
-valve.setPercentValveOpening(50.0);  // 50% open
-
-// Cv varies with opening (inherent characteristic)
-valve.setValveCharacteristic("linear");
-// or
-valve.setValveCharacteristic("equal_percentage");
-// or
-valve.setValveCharacteristic("quick_opening");
-```
-
-### Calculate Pressure Drop
-
-```java
-// Given Cv and flow, calculate ΔP
-valve.setCv(100.0, "US");
-valve.setPercentValveOpening(75.0);
-valve.run();
-
-double Pin = inletStream.getPressure("bara");
-double Pout = valve.getOutletStream().getPressure("bara");
-double deltaP = Pin - Pout;
-```
-
----
-
-## Valve Characteristics
-
-Control valves have inherent flow characteristics that define how Cv varies with valve opening.
-
-### Available Characteristics
-
-| Characteristic | Description | Best Application |
-|----------------|-------------|------------------|
-| **Linear** | Flow proportional to opening | Constant ΔP systems, bypass valves |
-| **Equal Percentage** | Equal opening increments = equal % flow change | Variable ΔP, most process control |
-| **Quick Opening** | Large flow change at small openings | On/off service, safety applications |
-| **Modified Parabolic** | Compromise between linear and equal % | General purpose |
-
-### Setting Valve Characteristic
+The inherent characteristic belongs to `ValveMechanicalDesign`, not directly to
+`ThrottlingValve`. Supported strings include `linear`, `equal percentage`, and
+`quick opening`.
 
 ```java
 import neqsim.process.mechanicaldesign.valve.ValveMechanicalDesign;
 
-ValveMechanicalDesign mechDesign = (ValveMechanicalDesign) valve.getMechanicalDesign();
-mechDesign.setValveCharacterization("equal percentage");
-```
-
-### Characteristic Curves
-
-```
-         │
-   100%  │                    ●─── Quick Opening
-         │               ●───●
-   Flow  │          ●───●    ●── Linear
-   (Cv)  │     ●───●        ●
-         │ ●───●        ●───── Equal Percentage
-         │●        ●───●
-    0%   └────────────────────
-         0%    Opening    100%
-```
-
----
-
-## Sizing Standards
-
-NeqSim supports multiple valve sizing standards for different applications.
-
-### Available Standards
-
-| Standard | Code | Description |
-|----------|------|-------------|
-| Default | `default` | Simplified IEC 60534 for gas, standard for liquid |
-| IEC 60534 | `IEC 60534` | Full IEC 60534-2-1 implementation |
-| Extended | `IEC 60534 full` | IEC 60534 with all correction factors |
-| Prod Choke | `prod choke` | Production choke with discharge coefficient |
-| **Sachdeva** | `Sachdeva` | **Mechanistic two-phase choke model (SPE 15657)** |
-| **Gilbert** | `Gilbert` | **Empirical two-phase correlation (1954)** |
-| **Baxendell** | `Baxendell` | **Empirical two-phase correlation (1958)** |
-| **Ros** | `Ros` | **Empirical two-phase correlation (1960)** |
-| **Achong** | `Achong` | **Empirical two-phase correlation (1961)** |
-
-### Setting Sizing Standard
-
-```java
-ValveMechanicalDesign mechDesign = (ValveMechanicalDesign) valve.getMechanicalDesign();
-mechDesign.setValveSizingStandard("IEC 60534");
-
-// For multiphase production chokes:
-mechDesign.setValveSizingStandard("Sachdeva");
-mechDesign.setChokeDiameter(0.5, "in");
-```
-
-### Multiphase Choke Sizing
-
-For production chokes handling two-phase (gas-liquid) flow, use the Sachdeva or Gilbert-type models:
-
-```java
-ThrottlingValve choke = new ThrottlingValve("Production Choke", wellStream);
-choke.setOutletPressure(30.0, "bara");
-
-ValveMechanicalDesign design = choke.getMechanicalDesign();
-design.setValveSizingStandard("Sachdeva");  // Mechanistic model
-design.setChokeDiameter(32, "64ths");        // 32/64" = 0.5"
-design.setChokeDischargeCoefficient(0.84);
-
-// Enable flow calculation in transient mode
-choke.setCalculateSteadyState(false);
-choke.runTransient(0.1);
-
-double calculatedFlow = choke.getOutletStream().getFlowRate("kg/hr");
-```
-
-**See:** [Multiphase Choke Flow Models](../MultiphaseChokeFlow) for detailed documentation.
-
-### IEC 60534 Gas Sizing
-
-For compressible fluids (gas/vapor), per IEC 60534-2-1 Section 6.2:
-
-$$K_v = \frac{Q_{std}}{N_9 \cdot P_1 \cdot Y} \sqrt{\frac{M \cdot T \cdot Z}{x}}$$
-
-Where:
-- $Q_{std}$ = volumetric flow at **standard conditions** (273.15 K, 101.325 kPa) [m³/h]
-- $N_9$ = 24.6 (SI constant for Q in m³/h, P in kPa)
-- $P_1$ = inlet pressure (kPa abs)
-- $Y$ = expansion factor
-- $M$ = molecular weight (g/mol)
-- $T$ = inlet temperature (K)
-- $Z$ = compressibility factor at inlet
-- $x$ = $\Delta P / P_1$
-
-> **Important:** The flow rate $Q_{std}$ must be at standard conditions, not at operating
-> conditions. NeqSim automatically converts actual flow to standard flow internally
-> when sizing gas valves. See [GitHub issue #1918](https://github.com/equinor/neqsim/issues/1918)
-> for details on this correction.
-
-### Choked Flow Detection
-
-Flow becomes choked when:
-$$x \geq F_\gamma \cdot x_T$$
-
-Where:
-- $F_\gamma = \gamma / 1.40$ (specific heat ratio factor)
-- $x_T$ = pressure drop ratio at choking (valve-specific, typically 0.13-0.80)
-
----
-
-## Mechanical Design
-
-Complete mechanical design calculations are available for valve body sizing, weight estimation, and actuator requirements.
-
-### Accessing Mechanical Design
-
-```java
-ValveMechanicalDesign mechDesign = (ValveMechanicalDesign) valve.getMechanicalDesign();
-mechDesign.calcDesign();
-```
-
-### Design Results
-
-| Property | Method | Unit |
-|----------|--------|------|
-| ANSI Pressure Class | `getAnsiPressureClass()` | - |
-| Nominal Size | `getNominalSizeInches()` | inches |
-| Face-to-Face | `getFaceToFace()` | mm |
-| Body Wall Thickness | `getBodyWallThickness()` | mm |
-| Design Pressure | `getDesignPressure()` | bara |
-| Design Temperature | `getDesignTemperature()` | °C |
-| Actuator Thrust | `getRequiredActuatorThrust()` | N |
-| Actuator Weight | `getActuatorWeight()` | kg |
-| Total Weight | `getWeightTotal()` | kg |
-
-### Example: Full Mechanical Design
-
-```java
-// Create and run valve
-ThrottlingValve valve = new ThrottlingValve("PCV-101", gasStream);
+ThrottlingValve valve = new ThrottlingValve("PCV-101", inlet);
 valve.setOutletPressure(60.0, "bara");
 valve.run();
 
-// Calculate mechanical design
-ValveMechanicalDesign mechDesign = (ValveMechanicalDesign) valve.getMechanicalDesign();
-mechDesign.calcDesign();
+ValveMechanicalDesign design = valve.getMechanicalDesign();
+design.setValveCharacterization("equal percentage");
+design.setValveSizingStandard("IEC 60534");
+design.calcDesign();
 
-// Print results
-System.out.println("=== VALVE MECHANICAL DESIGN ===");
-System.out.println("Cv: " + valve.getCv());
-System.out.println("ANSI Class: " + mechDesign.getAnsiPressureClass());
-System.out.println("Size: " + mechDesign.getNominalSizeInches() + " inches");
-System.out.println("Face-to-Face: " + mechDesign.getFaceToFace() + " mm");
-System.out.println("Wall Thickness: " + mechDesign.getBodyWallThickness() + " mm");
-System.out.println("Total Weight: " + mechDesign.getWeightTotal() + " kg");
-System.out.println("Actuator Thrust: " + mechDesign.getRequiredActuatorThrust() + " N");
+String characteristic = design.getValveCharacterization();
+int ansiClass = design.getAnsiPressureClass();
+double nominalSize = design.getNominalSizeInches();
+double actuatorThrust = design.getRequiredActuatorThrust();
+double totalWeight = design.getWeightTotal();
 ```
 
-### Detailed Documentation
+Mechanical-design results are preliminary sizing estimates. Review the selected
+standard, service, correction factors, material requirements, vendor data, and
+project design basis before engineering use.
 
-See [Valve Mechanical Design](../ValveMechanicalDesign) for complete documentation including:
-- ANSI pressure class selection criteria
-- Wall thickness calculations per ASME B16.34
-- Actuator sizing methodology
-- Weight estimation correlations
+## Production chokes
 
----
-
-## Critical Flow
-
-For high pressure drops, flow becomes critical (choked).
+Use `ThrottlingValve`; configure the choke correlation through the existing
+mechanical-design object. Do not import or instantiate `ChokeValve`.
 
 ```java
-// Check if flow is critical
-boolean isCritical = valve.isCriticalFlow();
+ThrottlingValve choke = new ThrottlingValve("Production choke", wellStream);
+choke.setOutletPressure(30.0, "bara");
 
-// Critical flow factor
-double Cf = valve.getCriticalFlowFactor();
+ValveMechanicalDesign design = choke.getMechanicalDesign();
+design.setValveSizingStandard("Sachdeva");
+design.setChokeDiameter(32.0, "64ths");
+design.setChokeDischargeCoefficient(0.84);
 ```
 
----
+The available multiphase methods and their input assumptions are documented in
+[Multiphase Choke Flow Models](../MultiphaseChokeFlow.md).
 
-## Safety Valve (PSV)
+## Dynamic valve travel
 
-### Basic Setup
-
-```java
-import neqsim.process.equipment.valve.SafetyValve;
-
-SafetyValve psv = new SafetyValve("PSV-100", vessel);
-psv.setSetPressure(100.0, "barg");  // Set pressure
-psv.setBlowdownPressure(10.0, "%"); // 10% blowdown
-psv.run();
-
-// Check if valve is open
-boolean isOpen = psv.isOpen();
-double relievingFlow = psv.getRelievingFlow("kg/hr");
-```
-
-### Sizing
+`ThrottlingValve` supports linear travel or a first-order lag. The current and
+requested openings are separate during a transient.
 
 ```java
-// Required relieving capacity
-psv.setRequiredCapacity(10000.0, "kg/hr");
+import java.util.UUID;
+import neqsim.process.equipment.valve.ValveTravelModel;
 
-// Get required orifice area
-double area = psv.getRequiredOrificeArea("cm2");
-
-// Select API orifice
-String orifice = psv.selectAPIorifice();  // e.g., "J", "K", "L"
-```
-
----
-
-## Choke Valve
-
-For wellhead and production applications:
-
-```java
-import neqsim.process.equipment.valve.ChokeValve;
-
-ChokeValve choke = new ChokeValve("Wellhead Choke", wellStream);
-choke.setOutletPressure(50.0, "bara");
-choke.run();
-
-// Or specify bean size
-choke.setBeanSize(32, "64ths");  // 32/64" = 0.5"
-choke.run();
-
-double Pout = choke.getOutletStream().getPressure("bara");
-```
-
----
-
-## Dynamic Simulation
-
-```java
-// Valve dynamics
 valve.setCalculateSteadyState(false);
+valve.setTravelModel(ValveTravelModel.LINEAR_RATE_LIMIT);
+valve.setTravelTime(10.0);
+valve.setPercentValveOpening(20.0);
+valve.setTargetPercentValveOpening(80.0);
 
-// Valve stroke time
-valve.setStrokeTime(10.0);  // seconds for 0-100%
+valve.runTransient(1.0, UUID.randomUUID());
 
-// Step change
-valve.setPercentValveOpening(80.0);
-
-for (double t = 0; t < 30; t += 0.1) {
-    valve.runTransient();
-    double opening = valve.getActualOpening();  // Lags setpoint
-}
+double currentOpening = valve.getPercentValveOpening();
+double targetOpening = valve.getTargetPercentValveOpening();
 ```
 
----
+For an on/off emergency function with a prescribed stroke time, use `ESDValve`.
+For blowdown activation logic, use `BlowdownValve`.
 
-## Example: Pressure Letdown Station
+## Physical and numerical checks
 
-```java
-ProcessSystem process = new ProcessSystem();
+For every valve calculation, verify:
 
-// HP gas inlet
-Stream hpGas = new Stream("HP Gas", gasFluid);
-hpGas.setFlowRate(50000.0, "kg/hr");
-hpGas.setTemperature(50.0, "C");
-hpGas.setPressure(100.0, "bara");
-process.add(hpGas);
+- inlet pressure exceeds outlet pressure unless reverse flow is intentionally allowed;
+- mass flow is conserved;
+- a normal throttling calculation preserves specific enthalpy within numerical tolerance;
+- temperature and phase changes are physically plausible for the selected fluid model;
+- Cv/Kv units and pressure basis are explicit;
+- choked-flow and laminar-flow assumptions match the service;
+- valve opening remains within configured minimum and maximum limits.
 
-// Stage 1: 100 -> 50 bar
-ThrottlingValve pv1 = new ThrottlingValve("PV-100", hpGas);
-pv1.setOutletPressure(50.0, "bara");
-pv1.setCv(200.0, "US");
-process.add(pv1);
+## Related documentation
 
-// Heater (compensate JT cooling)
-Heater heater = new Heater("E-100", pv1.getOutletStream());
-heater.setOutTemperature(40.0, "C");
-process.add(heater);
-
-// Stage 2: 50 -> 10 bar
-ThrottlingValve pv2 = new ThrottlingValve("PV-101", heater.getOutletStream());
-pv2.setOutletPressure(10.0, "bara");
-pv2.setCv(300.0, "US");
-process.add(pv2);
-
-process.run();
-
-// JT effects
-System.out.println("After PV-100: " + pv1.getOutletStream().getTemperature("C") + " °C");
-System.out.println("After E-100: " + heater.getOutletStream().getTemperature("C") + " °C");
-System.out.println("After PV-101: " + pv2.getOutletStream().getTemperature("C") + " °C");
-```
-
----
-
-## Joule-Thomson Coefficient
-
-For ideal gases, $\mu_{JT} = 0$. For real gases:
-
-$$\mu_{JT} = \left(\frac{\partial T}{\partial P}\right)_H = \frac{1}{C_p}\left[T\left(\frac{\partial V}{\partial T}\right)_P - V\right]$$
-
-```java
-// Get JT coefficient
-double muJT = inletStream.getJouleThomsonCoefficient();  // K/bar
-```
-
----
-
-## Related Documentation
-
-- [Valve Mechanical Design](../ValveMechanicalDesign) - Complete mechanical design calculations
-- [Compressor Mechanical Design](../CompressorMechanicalDesign) - Similar approach for compressors
-- [Process Package](../) - Package overview
-- [Separators](separators) - Separation equipment
-- [Safety Systems](../safety/) - Safety valve sizing
+- [Control Valves](control_valves.md)
+- [Valve Mechanical Design](../ValveMechanicalDesign.md)
+- [Multiphase Choke Flow Models](../MultiphaseChokeFlow.md)
+- [HIPPS Implementation](../../safety/hipps_implementation.md)
+- [Dynamic PSV sizing](../../safety/psv_dynamic_sizing_example.md)
+- [Process equipment overview](README.md)

--- a/src/test/java/neqsim/process/equipment/valve/ValveDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/valve/ValveDocumentationTest.java
@@ -1,0 +1,112 @@
+package neqsim.process.equipment.valve;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.mechanicaldesign.valve.ValveMechanicalDesign;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import org.junit.jupiter.api.Test;
+
+/** Executable coverage for examples in docs/process/equipment/valves.md. */
+class ValveDocumentationTest {
+  /**
+   * Creates the common gas feed used by the documented valve examples.
+   *
+   * @return initialized gas feed stream
+   */
+  private Stream createGasFeed() {
+    SystemInterface fluid = new SystemSrkEos(273.15 + 30.0, 80.0);
+    fluid.addComponent("methane", 0.90);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.03);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("feed", fluid);
+    inlet.setFlowRate(10000.0, "kg/hr");
+    inlet.setTemperature(30.0, "C");
+    inlet.setPressure(80.0, "bara");
+    inlet.run();
+    return inlet;
+  }
+
+  /** Verifies the complete pressure-letdown example and its isenthalpic invariant. */
+  @Test
+  void pressureLetdownPreservesMolarEnthalpy() {
+    Stream inlet = createGasFeed();
+    double inletEnthalpy = inlet.getFluid().getEnthalpy("J/mol");
+    double inletTemperature = inlet.getTemperature("C");
+
+    ThrottlingValve valve = new ThrottlingValve("PV-100", inlet);
+    valve.setOutletPressure(30.0, "bara");
+    valve.run();
+
+    double outletEnthalpy = valve.getOutletStream().getFluid().getEnthalpy("J/mol");
+    double outletTemperature = valve.getOutletStream().getTemperature("C");
+    double enthalpyTolerance = Math.max(1.0e-6, Math.abs(inletEnthalpy) * 1.0e-8);
+
+    assertEquals(30.0, valve.getOutletStream().getPressure("bara"), 1.0e-8);
+    assertEquals(inletEnthalpy, outletEnthalpy, enthalpyTolerance);
+    assertTrue(Double.isFinite(outletTemperature));
+    assertTrue(Math.abs(outletTemperature - inletTemperature) < 100.0);
+  }
+
+  /** Verifies Cv/Kv conversion, valve opening, and mechanical-design APIs. */
+  @Test
+  void cvOpeningAndMechanicalDesignApisAreExecutable() {
+    Stream inlet = createGasFeed();
+    ThrottlingValve valve = new ThrottlingValve("PCV-101", inlet);
+    valve.setCv(150.0, "US");
+    valve.setPercentValveOpening(50.0);
+
+    assertEquals(150.0, valve.getCv("US"), 1.0e-10);
+    assertEquals(150.0 / 1.156, valve.getCv("SI"), 1.0e-10);
+    assertEquals(50.0, valve.getPercentValveOpening(), 1.0e-10);
+
+    valve.setOutletPressure(60.0, "bara");
+    valve.run();
+
+    ValveMechanicalDesign design = valve.getMechanicalDesign();
+    design.setValveCharacterization("equal percentage");
+    design.setValveSizingStandard("IEC 60534");
+    design.calcDesign();
+
+    assertEquals("equal percentage", design.getValveCharacterization());
+    assertTrue(design.getAnsiPressureClass() > 0);
+    assertTrue(design.getNominalSizeInches() > 0.0);
+    assertTrue(design.getRequiredActuatorThrust() >= 0.0);
+    assertTrue(design.getWeightTotal() > 0.0);
+  }
+
+  /** Verifies production-choke configuration and the documented dynamic-travel APIs. */
+  @Test
+  void productionChokeAndDynamicTravelApisAreExecutable() {
+    Stream inlet = createGasFeed();
+    ThrottlingValve choke = new ThrottlingValve("Production choke", inlet);
+    choke.setOutletPressure(30.0, "bara");
+
+    ValveMechanicalDesign design = choke.getMechanicalDesign();
+    design.setValveSizingStandard("Sachdeva");
+    design.setChokeDiameter(32.0, "64ths");
+    design.setChokeDischargeCoefficient(0.84);
+
+    assertEquals("Sachdeva", design.getValveSizingStandard());
+    assertEquals(0.0127, design.getChokeDiameter(), 1.0e-12);
+
+    choke.run();
+    choke.setCalculateSteadyState(false);
+    choke.setTravelModel(ValveTravelModel.LINEAR_RATE_LIMIT);
+    choke.setTravelTime(10.0);
+    choke.setPercentValveOpening(20.0);
+    choke.setTargetPercentValveOpening(80.0);
+    choke.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(80.0, choke.getTargetPercentValveOpening(), 1.0e-10);
+    assertTrue(choke.getPercentValveOpening() > 20.0);
+    assertTrue(choke.getPercentValveOpening() < 80.0);
+    assertNotNull(choke.getOutletStream());
+  }
+}


### PR DESCRIPTION
## Campaign

Relates to #2499.

## Scan scope

D005 — one bounded process-equipment documentation page:

- `docs/process/equipment/valves.md`
- current valve equipment and `ValveMechanicalDesign` implementations
- focused executable coverage in `ValveDocumentationTest`

Base: `8ad7c339f1f264da16431f090225f0aad96b07e8`. No overlap with current open PR files was found.

## Confirmed defect groups

1. **High — nonexistent production-choke API:** the page imported and instantiated `ChokeValve`, which does not exist, then called nonexistent `setBeanSize`.
2. **High — nonexistent valve-characteristic API:** `setValveCharacteristic` was shown on `ThrottlingValve`; characteristics belong to `ValveMechanicalDesign`.
3. **High — stale SafetyValve example:** constructor, set-pressure, capacity, open-state, and orifice-selection calls did not match current `SafetyValve`.
4. **High — nonexistent critical-flow methods:** `isCriticalFlow` and `getCriticalFlowFactor` do not exist on `ThrottlingValve`.
5. **High — invalid dynamic API:** `setStrokeTime`, `getActualOpening`, and the zero-argument transient call do not exist on `ThrottlingValve`.
6. **High — wrong Joule–Thomson accessor:** `getJouleThomsonCoefficient` was called on a stream although it belongs to the thermodynamic system.
7. **High — incomplete examples:** the primary valve and letdown-station snippets depended on undefined streams, fluids, imports, and process objects.
8. **Medium — misleading Cv/Kv guidance:** the page described `setCv(..., "SI")` as Cv although the implementation stores and returns Kv for SI.
9. **Medium — stale choke transient signature:** the page used the one-argument transient overload without documenting the actual UUID-bearing implementation used by the equipment.
10. **Medium — Jekyll rendering:** front matter was followed by a duplicate H1 title.
11. **Medium — repository policy:** complete examples used `System.out.println`, which is prohibited by current `AGENTS.md`.

## Fixes

- Replaced the page with a current, narrower valve guide based on source-verified APIs.
- Added a complete Java 8-compatible gas-letdown program using Log4j2.
- Documented the Cv/Kv conversion, specified-pressure versus Cv-based modes, and current opening API.
- Moved characteristic configuration to `ValveMechanicalDesign`.
- Replaced the fictitious choke class with `ThrottlingValve` plus Sachdeva mechanical-design configuration.
- Replaced stale transient calls with `ValveTravelModel.LINEAR_RATE_LIMIT`, target opening, travel time, and `runTransient(dt, UUID)`.
- Removed stale PSV, critical-flow, and stream JT snippets; linked to the dedicated verified safety/choke guides.
- Added physical checks and engineering-use limitations.
- Removed the duplicate rendered title and repaired all relative links with explicit Markdown paths.
- Added `ValveDocumentationTest` exercising every API call in the new code examples.

## Validation

Passed locally:

- NeqSim 3.16.0 runtime smoke of all documented valve operations:
  - molar-enthalpy residual: `3.33e-7 J/mol`;
  - JT temperature change: `-24.7079 K`;
  - preliminary mechanical result: ANSI class 600, 4-inch nominal size;
  - dynamic opening: 20% to 30% after one second toward an 80% target.
- Front matter valid; no duplicate H1.
- Five balanced Java code fences; supported inline KaTeX syntax; no unsupported delimiters.
- All six relative documentation targets exist.
- Documentation search audit passed: 620 Markdown pages and one standalone HTML page.
- No external links were added.

Local Maven execution is blocked because this environment cannot resolve the uncached `maven-enforcer-plugin:3.6.3` and Spotless artifacts from Maven Central.

Hosted status:

- Java 21 Javadoc: **passed**.
- Agent/skill cross-reference verification: **passed**.
- Documentation Jekyll build, generated search coverage, and JavaScript syntax: **passed**.
- CodeQL: **passed**.
- Spotless format workflow: **passed**.
- Java 21 Windows fast suite: **passed**.
- Java 21 Ubuntu full suite executed 10,704 tests. The D005 `ValveDocumentationTest` passed all 3 tests with no failures or errors in 0.027 s. The suite's sole error is the inherited `LNGProcessBuilderTest.testSmrRouteRunsAndReportsPerformance` cryogenic-exchanger failure already present on `master`; draft #2516 addresses that root cause.
- Repository-wide pre-commit is blocked only by the unrelated unformatted `PipeBeggsAndBrillsHoldupTest.java` already on `master` from merged #2512. The documentation search audit within that job passed for 621 Markdown pages and one standalone HTML page; neither D005 file appears in the formatting failure.

D005's scoped documentation and executable test gates are clean. The draft remains **blocked** rather than being reported fully green until the two inherited base-branch CI failures are resolved and the complete gate is rerun.

## Compatibility and impact

Documentation and tests only. No production API, parameter, default, numerical model, or runtime behavior changes.

## Exclusions and next scope

This batch does not revise the dedicated PSV, control-valve, or multiphase-choke pages. After D005 is merged, the next process-equipment sub-batch should audit one of those pages or advance according to the campaign rotation.
