### PR TITLE
Establish trustworthy RCA scoring, provenance, and verification

### DIFF
--- a/.github/agents/root.cause.agent.md
+++ b/.github/agents/root.cause.agent.md
@@ -23,7 +23,7 @@ ALWAYS read these skills before proceeding:
 2. **Gather data**: Collect historian time-series, STID design docs, OREDA data
 3. **Build or load process model**: Need a running ProcessSystem for simulation verification
 4. **Run RCA**: Use RootCauseAnalyzer orchestrator
-5. **Interpret results**: Separate supporting evidence, contradictory evidence, and neutral simulation limitations
+5. **Interpret results**: Separate evaluated evidence from unknown, unsupported, and failed stages; report simulation coverage
 6. **Recommend actions**: Provide prioritized corrective action list with immediate safe-operation checks
 
 ## Workflow
@@ -85,6 +85,12 @@ If user has an existing model:
 
 ```java
 RootCauseAnalyzer rca = new RootCauseAnalyzer(processSystem, equipmentName);
+DiagnosisCase diagnosisCase = new DiagnosisCase(equipmentName)
+    .setCaseId(caseId)
+    .setTimeWindow(windowStartEpochSeconds, windowEndEpochSeconds)
+    .setProcessModel(modelId, modelRevision)
+    .addDataSource("historian", historianQueryReference);
+rca.setDiagnosisCase(diagnosisCase);
 rca.setSymptom(symptom);
 rca.setHistorianData(historianMap, timestamps);
 rca.setStidData(stidMap);
@@ -98,7 +104,7 @@ RootCauseReport report = rca.analyze();
 Present the report to the user with:
 1. **Top hypothesis**: Name, confidence %, category
 2. **Key evidence**: What data supports this conclusion
-3. **Simulation verification**: Did the simulation reproduce the observed behavior?
+3. **Simulation verification**: Status, KPI coverage, and whether direction and normalized magnitude matched
 4. **Alternative hypotheses**: Other possibilities ranked by confidence
 5. **Recommended actions**: Prioritized list from the top hypothesis
 
@@ -179,7 +185,7 @@ historian tag or STID document, making the diagnosis fully auditable.
 - **Missing design limits**: Without design limits, threshold analysis cannot run
 - **Simulation without calibration**: Process model must match current operating conditions
 - **Ignoring correlations**: Parameter correlations often point to the root cause faster than individual trends
-- **Over-reading simulation verification**: A neutral score means the current process model could not test that hypothesis; it is not a pass/fail verdict
+- **Over-reading simulation verification**: `UNKNOWN`, `UNSUPPORTED`, and `FAILED` are neutral but distinct; only `EVALUATED` scores are evidence, and low coverage limits the conclusion
 
 ## Post-Trip Analysis: Detect → Trace → Restart
 
@@ -213,7 +219,7 @@ FailurePropagationTracer.PropagationResult propagation = tracer.trace(trips.get(
 // 3. Generate restart sequence
 RestartSequenceGenerator generator = new RestartSequenceGenerator(processSystem);
 RestartSequenceGenerator.RestartPlan plan = generator.generate(propagation);
-System.out.println(plan.toTextReport());
+String restartPlanReport = plan.toTextReport();
 ```
 
 See the `neqsim-root-cause-analysis` skill for full API reference.

--- a/.github/skills/neqsim-autonomous-investigation/SKILL.md
+++ b/.github/skills/neqsim-autonomous-investigation/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: neqsim-autonomous-investigation
-version: "1.0.0"
+version: "1.1.0"
 description: "Autonomous investigation loop for operational and engineering anomalies — turns an agent from 'told what to look for' into 'discovers relationships and hypotheses on its own'. USE WHEN: solving a PEPR action, root-cause, or operational study where the symptom, driver, or important relationships are NOT given up front. Runs an observe -> hypothesize -> predict -> test -> discriminate loop, using neqsim.process.diagnostics.RelationshipGraph for unsupervised lead-lag relationship discovery across historian tags, then hands the discovered relationships to neqsim-root-cause-analysis. Anchors on neqsim.process.diagnostics classes."
-last_verified: "2026-07-11"
+last_verified: "2026-07-19"
 requires:
   java_packages: [neqsim.process.diagnostics, neqsim.process.automation]
 ---
@@ -74,7 +74,7 @@ graph.setTimestamps(timestamps);      // optional: enables lag in seconds
 graph.setMaxLagSamples(10);           // search +/- 10 samples
 graph.setMinAbsCorrelation(0.5);      // only report |r| >= 0.5
 List<RelationshipGraph.Relationship> edges = graph.analyze(historianData);
-System.out.println(graph.toTextReport(edges));
+String relationshipReport = graph.toTextReport(edges);
 
 for (RelationshipGraph.Relationship r : edges) {
   // r.getSource() leads r.getTarget() (candidate cause -> candidate effect)
@@ -145,8 +145,9 @@ List<CausalTopologyModel.CausalEdge> edges = model.classify(relationships);
 
 The three steps above plus the Bayesian scoring are chained in a single entry
 point. **No symptom is required** — the analyzer scans anomalies, infers the
-symptom, discovers relationships, and (with a tag-to-equipment map) classifies
-them against topology, then runs the standard analysis.
+symptom, discovers relationships, and classifies them against topology, then converts
+hypothesis-matched anomaly and physically consistent topology findings into weighted
+evidence used in ranking.
 
 ```java
 RootCauseAnalyzer rca = new RootCauseAnalyzer(processSystem, "Compressor-1");
@@ -162,6 +163,11 @@ rca.getLastAnomalies();     // what looked abnormal
 rca.getLastRelationships(); // who leads whom
 rca.getLastCausalEdges();   // causal candidate vs common-cause/artifact
 ```
+
+Only `LOCAL` and `CAUSAL_CANDIDATE` edges matching a hypothesis fingerprint affect
+ranking. `COUNTER_FLOW`, `COMMON_CAUSE_OR_ARTIFACT`, and `UNKNOWN` findings remain
+reportable but are not treated as causal support. This conservative admission rule
+prevents correlation alone from inflating confidence.
 
 Python: get the classes with `ns.JClass("neqsim.process.diagnostics.AnomalyScanner")`,
 `...RelationshipGraph`, `...CausalTopologyModel`, `...RootCauseAnalyzer`.

--- a/.github/skills/neqsim-root-cause-analysis/SKILL.md
+++ b/.github/skills/neqsim-root-cause-analysis/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: neqsim-root-cause-analysis
-version: "1.1.0"
+version: "1.2.0"
 description: "Root cause analysis (RCA) framework for process equipment — Bayesian-inspired diagnosis integrating multi-source reliability data (IOGP/SINTEF, CCPS, IEEE 493, Lees, OREDA) as prior, plant historian evidence (likelihood), and NeqSim simulation verification. USE WHEN: diagnosing compressor trips, high vibration, efficiency loss, separator carryover, heat exchanger fouling, or any operational anomaly. Anchors on neqsim.process.diagnostics classes."
-last_verified: "2026-05-10"
+last_verified: "2026-07-19"
 requires:
   java_packages: [neqsim.process.diagnostics, neqsim.process.equipment.failure, neqsim.process.automation]
 ---
@@ -52,7 +52,8 @@ No commercial license is required for the default data.
 | `Hypothesis` | Candidate root cause with expected signal fingerprints, evidence, prior/likelihood/verification scores |
 | `HypothesisGenerator` | Generates candidate hypotheses from built-in libraries and reliability-data-adjusted priors per equipment type |
 | `EvidenceCollector` | Analyzes historian/STID data and attaches only hypothesis-relevant supporting or contradictory evidence |
-| `SimulationVerifier` | Clones process, applies physical perturbation, compares simulated vs observed KPI directions |
+| `DiagnosisCase` | Captures equipment, window, provenance, process-model identity, context, and data quality |
+| `SimulationVerifier` | Clones process and reports explicit status, KPI coverage, and magnitude-aware comparison |
 | `RootCauseReport` | Ranked output with JSON and text report generation |
 
 ### Package Location
@@ -91,7 +92,7 @@ rca.setStidData(stidData);
 RootCauseReport report = rca.analyze();
 
 // 7. Get results
-System.out.println(report.toTextReport());
+String textReport = report.toTextReport();
 String json = report.toJson();
 Hypothesis topCause = report.getTopHypothesis();
 ```
@@ -209,12 +210,14 @@ Compares current (latest) values to STID design values.
 ## Simulation Verification
 
 The verifier clones the process system, applies a perturbation matching each
-hypothesis, runs the modified process, and compares the direction of KPI changes
-to the historian data pattern.
+hypothesis, runs the modified process, and compares both direction and normalized
+response magnitude to the historian data pattern where a defensible KPI match exists.
 
-Unsupported hypotheses or equipment types return a neutral verification score
-(`0.5`) with an explicit simulation limitation. Treat this as "not verified by
-the current process model", not as evidence for or against the hypothesis.
+Every likelihood and verification stage has an explicit `EvaluationStatus`:
+`UNKNOWN`, `EVALUATED`, `UNSUPPORTED`, or `FAILED`. Unknown, unsupported, and failed
+stages are neutral in confidence multiplication. An `EVALUATED` zero correctly drives
+the raw hypothesis score to zero. Reports also expose verification coverage and
+comparison count; do not present low-coverage verification as conclusive.
 
 ### Perturbation Examples
 
@@ -228,10 +231,13 @@ the current process model", not as evidence for or against the hypothesis.
 
 ### Verification Score
 
-The score (0-1) is based on direction matching:
-- Count how many KPIs changed in the same direction (sim vs historian)
-- Score = matching directions / total comparisons
-- 1.0 = perfect match, 0.5 = neutral, 0.0 = opposite
+The score (0-1) combines direction and the ratio of normalized simulated/observed
+response magnitudes, then qualifies it by comparable-KPI coverage. Opposite directions
+score zero. No defensible comparison yields `UNKNOWN`, not an invented midpoint score.
+
+For operational decisions, attach a `DiagnosisCase` with the historian query/reference,
+process-model ID and revision, operating mode, and known quality qualifications. It is
+emitted in `RootCauseReport.toJson()` and MCP JSON.
 
 ## Integration with Other Skills
 
@@ -252,7 +258,9 @@ hands the candidate causes here for Bayesian scoring + simulation verification.
 The one-call path is `RootCauseAnalyzer.analyzeAutonomous()` (or
 `analyzeAutonomous(tagToEquipment)` to also classify relationships against the
 flowsheet topology) — it infers the symptom with `AnomalyScanner`, discovers
-relationships with `RelationshipGraph`, then runs the standard analysis.
+relationships with `RelationshipGraph`, classifies them with `CausalTopologyModel`, and
+adds matched anomaly/topology findings to hypothesis evidence before ranking. Ambiguous,
+counter-flow, and common-cause edges remain visible but do not silently boost scores.
 
 ## MCP Tool
 
@@ -267,7 +275,13 @@ Use `runRootCauseAnalysis` MCP tool for programmatic access:
     "symptom": "HIGH_VIBRATION",
     "historianCsv": "timestamp,vibration,temperature\n0,3.5,150\n3600,3.8,152\n...",
     "designLimits": {"vibration": [null, 7.1], "temperature": [null, 180]},
-    "simulationEnabled": true
+    "simulationEnabled": true,
+    "diagnosisCase": {
+      "caseId": "trip-2026-07-19",
+      "processModelId": "export-compression",
+      "processModelRevision": "model-rev-7",
+      "dataSources": {"PI": "query-id-42"}
+    }
   }
 }
 ```
@@ -284,6 +298,12 @@ Use `runRootCauseAnalysis` MCP tool for programmatic access:
   "timestamp": "2026-06-15T10:30:00",
   "dataPointsAnalyzed": 2400,
   "parametersAnalyzed": 8,
+  "diagnosisCase": {
+    "caseId": "trip-2026-07-19",
+    "equipmentName": "Compressor-1",
+    "processModelId": "export-compression",
+    "processModelRevision": "model-rev-7"
+  },
   "summary": "Most likely root cause: Bearing wear (72.3% confidence)...",
   "hypotheses": [
     {
@@ -295,6 +315,10 @@ Use `runRootCauseAnalysis` MCP tool for programmatic access:
       "priorProbability": 0.3000,
       "likelihoodScore": 0.8500,
       "verificationScore": 0.8500,
+      "likelihoodStatus": "EVALUATED",
+      "verificationStatus": "EVALUATED",
+      "verificationCoverage": 0.75,
+      "verificationComparisonCount": 3,
       "evidence": [
         {
           "parameter": "vibration_mm_s",
@@ -478,13 +502,13 @@ List<TripEvent> trips = detector.check(simulationTime);
 // ── Step 2: Trace propagation ──
 FailurePropagationTracer tracer = new FailurePropagationTracer(processSystem);
 FailurePropagationTracer.PropagationResult propagation = tracer.trace(trips.get(0));
-System.out.println(propagation.toTextSummary());
+String propagationSummary = propagation.toTextSummary();
 
 // ── Step 3: Generate restart plan ──
 RestartSequenceGenerator generator = new RestartSequenceGenerator(processSystem);
 generator.setCustomRampUpTime("Compressor-1", 300.0);  // 5 min ramp-up
 RestartSequenceGenerator.RestartPlan plan = generator.generate(propagation);
-System.out.println(plan.toTextReport());
+String restartPlanReport = plan.toTextReport();
 String json = plan.toJson();
 ```
 
@@ -534,4 +558,3 @@ print(str(plan.toTextReport()))
 - **Equipment-specific actions**: auto-selects restart actions by equipment type (compressor, separator, pump, HX, valve, column, pipe)
 - **Output**: `RestartPlan` with `toJson()`, `toTextReport()`
 - **Plan structure**: Safety check → Root cause verification → Utilities → Equipment (upstream-first) → System verification
-

--- a/docs/diagnostics/root_cause_analysis.md
+++ b/docs/diagnostics/root_cause_analysis.md
@@ -12,7 +12,8 @@ sources via Bayesian-inspired confidence scoring:
 1. **Reliability Data** — Prior probabilities from public reliability databases (IOGP/SINTEF, CCPS 1989, IEEE 493-2007, Lees 2012, SINTEF PDS) with optional OREDA overlay
 2. **Historian** — Likelihood scoring from time-series trend, threshold, and correlation analysis
 3. **STID** — Cross-reference against design conditions
-4. **Simulation** — Verification scoring from NeqSim process model perturbation
+4. **Autonomous findings** — Hypothesis-specific anomaly and topology evidence
+5. **Simulation** — Coverage-qualified, magnitude-aware verification from NeqSim perturbation
 
 ## Architecture
 
@@ -31,7 +32,8 @@ Symptom (enum)
     │       ├── Rate-of-change step detection (3σ)
     │       └── Pearson correlation (|r| > 0.7)
     │
-    ├── SimulationVerifier    →  Clone ProcessSystem, perturb, compare
+    ├── AnomalyScanner + topology → Add matched autonomous evidence to ranking
+    ├── SimulationVerifier    →  Clone, perturb, compare normalized response magnitude
     │
     └── RootCauseReport       →  Ranked hypotheses with confidence scores
 ```
@@ -54,7 +56,31 @@ $$
 Where:
 - $P_{\text{prior}}$ — Prior probability from reliability data (IOGP/SINTEF, CCPS, IEEE 493, etc.)
 - $L_{\text{historian}}$ — Likelihood score from time-series evidence
-- $V_{\text{simulation}}$ — Verification score from simulation direction-of-change matching
+- $V_{\text{simulation}}$ — Verification score from direction and normalized response-magnitude matching
+
+Likelihood and verification each carry an `EvaluationStatus`: `UNKNOWN`, `EVALUATED`,
+`UNSUPPORTED`, or `FAILED`. Only `EVALUATED` scores participate in the product. An
+evaluated score of exactly zero is contradictory evidence, while a stage that was not
+run or could not run remains explicitly neutral. JSON includes both statuses plus
+simulation KPI coverage and comparison count.
+
+## Reproducible Diagnosis Cases
+
+`DiagnosisCase` records the equipment, historian time window, source provenance,
+process-model identity/revision, operating context, and data-quality metadata. Attach an
+explicit case when source query IDs or model revisions are known; otherwise the analyzer
+derives a minimal case and historian quality counts.
+
+```java
+DiagnosisCase diagnosisCase = new DiagnosisCase("Export Compressor")
+    .setCaseId("trip-2026-07-19")
+    .setTimeWindow(1784480400.0, 1784484000.0)
+    .setProcessModel("export-compression", "model-rev-7")
+    .addDataSource("PI", "compressed-query-id-42")
+    .addOperatingContext("mode", "recycle")
+    .addDataQuality("coverage", "98%");
+rca.setDiagnosisCase(diagnosisCase);
+```
 
 ## Data Sources
 
@@ -111,7 +137,7 @@ rca.setDesignLimit("vibration_mm_s", 0.0, 4.5);
 RootCauseReport report = rca.analyze();
 
 // Output
-System.out.println(report.toTextReport());
+String textReport = report.toTextReport();
 String json = report.toJson();
 ```
 
@@ -143,12 +169,22 @@ The `runRootCauseAnalysis` MCP tool exposes this framework to LLM agents:
     "symptom": "HIGH_VIBRATION",
     "historianCsv": "timestamp,vibration,bearing_temp\n0,2.1,65\n1,2.3,67\n2,2.8,72",
     "designLimits": { "vibration": [0, 4.5] },
-    "simulationEnabled": true
+    "simulationEnabled": true,
+    "diagnosisCase": {
+        "caseId": "trip-2026-07-19",
+        "processModelId": "export-compression",
+        "processModelRevision": "model-rev-7",
+        "dataSources": { "PI": "compressed-query-id-42" },
+        "operatingContext": { "mode": "recycle" },
+        "dataQuality": { "coverage": "98%" }
+    }
 }
 ```
 
 `processJson` is passed as a JSON string to the MCP runner. The schema catalog
 entry `run_root_cause_analysis` shows the exact input fields and output shape.
+The returned `diagnosisCase` object and per-hypothesis evaluation statuses are additive,
+so consumers of the existing report fields continue to work.
 
 ## Custom Hypotheses
 
@@ -179,6 +215,7 @@ rca.setHypothesisGenerator(generator);
 | `Hypothesis` | Ranked failure hypothesis with evidence, confidence, and actions |
 | `HypothesisGenerator` | Registry-based generator with built-in equipment libraries |
 | `EvidenceCollector` | Time-series analysis (trend, threshold, correlation) |
-| `SimulationVerifier` | Process model perturbation and direction-of-change scoring |
+| `DiagnosisCase` | Reproducible window, provenance, model identity, context, and quality metadata |
+| `SimulationVerifier` | Process perturbation with explicit status, KPI coverage, and magnitude-aware scoring |
 | `RootCauseReport` | Ranked report with JSON, text, and results map output |
 | `RootCauseAnalyzer` | Main orchestrator integrating all components |

--- a/src/main/java/neqsim/mcp/runners/RootCauseRunner.java
+++ b/src/main/java/neqsim/mcp/runners/RootCauseRunner.java
@@ -14,6 +14,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import neqsim.process.diagnostics.AnomalyScanner;
 import neqsim.process.diagnostics.CausalTopologyModel;
+import neqsim.process.diagnostics.DiagnosisCase;
 import neqsim.process.diagnostics.RelationshipGraph;
 import neqsim.process.diagnostics.RootCauseAnalyzer;
 import neqsim.process.diagnostics.RootCauseReport;
@@ -40,6 +41,7 @@ import neqsim.process.processmodel.SimulationResult;
  * <li>{@code designLimits} — optional map of parameter to [min, max] design limits</li>
  * <li>{@code stidData} — optional map of STID design values</li>
  * <li>{@code simulationEnabled} — whether to run simulation verification (default true)</li>
+ * <li>{@code diagnosisCase} — optional reproducibility, provenance, and operating-context metadata</li>
  * </ul>
  *
  * @author Even Solbraa
@@ -102,6 +104,43 @@ public final class RootCauseRunner {
       RootCauseAnalyzer rca = new RootCauseAnalyzer(process, equipmentName);
       if (symptom != null) {
         rca.setSymptom(symptom);
+      }
+
+      // Optional reproducibility and provenance context. Missing fields are allowed for incremental adoption.
+      if (input.has("diagnosisCase") && input.get("diagnosisCase").isJsonObject()) {
+        JsonObject caseJson = input.getAsJsonObject("diagnosisCase");
+        DiagnosisCase diagnosisCase = new DiagnosisCase(equipmentName);
+        if (caseJson.has("caseId")) {
+          diagnosisCase.setCaseId(caseJson.get("caseId").getAsString());
+        }
+        if (caseJson.has("windowStartEpochSeconds") && caseJson.has("windowEndEpochSeconds")) {
+          diagnosisCase.setTimeWindow(caseJson.get("windowStartEpochSeconds").getAsDouble(),
+              caseJson.get("windowEndEpochSeconds").getAsDouble());
+        }
+        String modelId = caseJson.has("processModelId") ? caseJson.get("processModelId").getAsString()
+            : process.getClass().getName();
+        String modelRevision = caseJson.has("processModelRevision") ? caseJson.get("processModelRevision").getAsString()
+            : "runtime-instance";
+        diagnosisCase.setProcessModel(modelId, modelRevision);
+        addStringMap(caseJson, "dataSources", new StringMapConsumer() {
+          @Override
+          public void accept(String key, String value) {
+            diagnosisCase.addDataSource(key, value);
+          }
+        });
+        addStringMap(caseJson, "operatingContext", new StringMapConsumer() {
+          @Override
+          public void accept(String key, String value) {
+            diagnosisCase.addOperatingContext(key, value);
+          }
+        });
+        addStringMap(caseJson, "dataQuality", new StringMapConsumer() {
+          @Override
+          public void accept(String key, String value) {
+            diagnosisCase.addDataQuality(key, value);
+          }
+        });
+        rca.setDiagnosisCase(diagnosisCase);
       }
 
       // Optional: simulation enabled
@@ -237,6 +276,21 @@ public final class RootCauseRunner {
       return Symptom.valueOf(str.toUpperCase().trim());
     } catch (IllegalArgumentException e) {
       return null;
+    }
+  }
+
+  /** Callback used while copying JSON string maps into a diagnosis case. */
+  private interface StringMapConsumer {
+    void accept(String key, String value);
+  }
+
+  /** Copies a JSON object's scalar members to a callback as strings. */
+  private static void addStringMap(JsonObject parent, String field, StringMapConsumer consumer) {
+    if (!parent.has(field) || !parent.get(field).isJsonObject()) {
+      return;
+    }
+    for (Map.Entry<String, JsonElement> entry : parent.getAsJsonObject(field).entrySet()) {
+      consumer.accept(entry.getKey(), entry.getValue().getAsString());
     }
   }
 

--- a/src/main/java/neqsim/process/diagnostics/DiagnosisCase.java
+++ b/src/main/java/neqsim/process/diagnostics/DiagnosisCase.java
@@ -1,0 +1,254 @@
+package neqsim.process.diagnostics;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Reproducible context for a root-cause investigation.
+ *
+ * <p>
+ * A diagnosis case records what equipment and time window were evaluated, where the data came from, which process model
+ * was used, and the operating and data-quality context needed to reproduce or audit the result. All fields are optional
+ * except the equipment name so existing callers can adopt the model incrementally.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class DiagnosisCase implements Serializable {
+
+  private static final long serialVersionUID = 1000L;
+
+  private String caseId;
+  private final String equipmentName;
+  private Double windowStartEpochSeconds;
+  private Double windowEndEpochSeconds;
+  private String processModelId = "";
+  private String processModelRevision = "";
+  private final Map<String, String> dataSources = new LinkedHashMap<String, String>();
+  private final Map<String, String> operatingContext = new LinkedHashMap<String, String>();
+  private final Map<String, String> dataQuality = new LinkedHashMap<String, String>();
+
+  /**
+   * Creates a diagnosis case for an equipment item.
+   *
+   * @param equipmentName diagnosed equipment name
+   */
+  public DiagnosisCase(String equipmentName) {
+    if (equipmentName == null || equipmentName.trim().isEmpty()) {
+      throw new IllegalArgumentException("equipmentName must not be null or empty");
+    }
+    this.equipmentName = equipmentName;
+    this.caseId = equipmentName;
+  }
+
+  /**
+   * Creates a diagnosis case populated from a historian window.
+   *
+   * @param equipmentName diagnosed equipment name
+   * @param timestamps historian timestamps in epoch seconds, or {@code null}
+   * @param historianData historian series keyed by tag
+   * @return populated diagnosis case
+   */
+  public static DiagnosisCase fromHistorian(String equipmentName, double[] timestamps,
+      Map<String, double[]> historianData) {
+    DiagnosisCase diagnosisCase = new DiagnosisCase(equipmentName);
+    if (timestamps != null && timestamps.length > 0) {
+      double minimum = Double.POSITIVE_INFINITY;
+      double maximum = Double.NEGATIVE_INFINITY;
+      for (double timestamp : timestamps) {
+        if (!Double.isNaN(timestamp)) {
+          minimum = Math.min(minimum, timestamp);
+          maximum = Math.max(maximum, timestamp);
+        }
+      }
+      if (minimum != Double.POSITIVE_INFINITY) {
+        diagnosisCase.setTimeWindow(minimum, maximum);
+      }
+    }
+
+    int tagCount = historianData == null ? 0 : historianData.size();
+    int validCount = 0;
+    int missingCount = 0;
+    if (historianData != null) {
+      for (double[] values : historianData.values()) {
+        if (values == null) {
+          missingCount++;
+          continue;
+        }
+        for (double value : values) {
+          if (Double.isNaN(value) || Double.isInfinite(value)) {
+            missingCount++;
+          } else {
+            validCount++;
+          }
+        }
+      }
+    }
+    diagnosisCase.addDataSource("historian", "in-memory historian series");
+    diagnosisCase.addDataQuality("tagCount", Integer.toString(tagCount));
+    diagnosisCase.addDataQuality("validValueCount", Integer.toString(validCount));
+    diagnosisCase.addDataQuality("missingOrInvalidValueCount", Integer.toString(missingCount));
+    return diagnosisCase;
+  }
+
+  /**
+   * Returns the stable caller-supplied or derived case identifier.
+   *
+   * @return case identifier
+   */
+  public String getCaseId() {
+    return caseId;
+  }
+
+  /**
+   * Sets a stable identifier used to correlate repeated analysis of the same case.
+   *
+   * @param caseId case identifier
+   * @return this instance
+   */
+  public DiagnosisCase setCaseId(String caseId) {
+    this.caseId = caseId == null || caseId.trim().isEmpty() ? equipmentName : caseId;
+    return this;
+  }
+
+  /**
+   * Returns the diagnosed equipment name.
+   *
+   * @return equipment name
+   */
+  public String getEquipmentName() {
+    return equipmentName;
+  }
+
+  /**
+   * Returns the time-window start.
+   *
+   * @return window start in epoch seconds, or {@code null}
+   */
+  public Double getWindowStartEpochSeconds() {
+    return windowStartEpochSeconds;
+  }
+
+  /**
+   * Returns the time-window end.
+   *
+   * @return window end in epoch seconds, or {@code null}
+   */
+  public Double getWindowEndEpochSeconds() {
+    return windowEndEpochSeconds;
+  }
+
+  /**
+   * Sets the historian time window.
+   *
+   * @param startEpochSeconds start in epoch seconds
+   * @param endEpochSeconds end in epoch seconds
+   * @return this instance
+   */
+  public DiagnosisCase setTimeWindow(double startEpochSeconds, double endEpochSeconds) {
+    if (endEpochSeconds < startEpochSeconds) {
+      throw new IllegalArgumentException("time-window end must not precede start");
+    }
+    this.windowStartEpochSeconds = startEpochSeconds;
+    this.windowEndEpochSeconds = endEpochSeconds;
+    this.caseId = equipmentName + "@" + Double.toString(startEpochSeconds) + "-" + Double.toString(endEpochSeconds);
+    return this;
+  }
+
+  /**
+   * Returns the process-model identifier.
+   *
+   * @return process-model identifier
+   */
+  public String getProcessModelId() {
+    return processModelId;
+  }
+
+  /**
+   * Returns the process-model revision.
+   *
+   * @return process-model revision
+   */
+  public String getProcessModelRevision() {
+    return processModelRevision;
+  }
+
+  /**
+   * Sets process-model identity and revision.
+   *
+   * @param modelId model identifier
+   * @param revision model revision, commit, or configuration version
+   * @return this instance
+   */
+  public DiagnosisCase setProcessModel(String modelId, String revision) {
+    this.processModelId = modelId == null ? "" : modelId;
+    this.processModelRevision = revision == null ? "" : revision;
+    return this;
+  }
+
+  /**
+   * Adds source provenance.
+   *
+   * @param source source name
+   * @param reference source reference, query, dataset, or version
+   * @return this instance
+   */
+  public DiagnosisCase addDataSource(String source, String reference) {
+    dataSources.put(source, reference);
+    return this;
+  }
+
+  /**
+   * Adds an operating-context item.
+   *
+   * @param key context key
+   * @param value context value including units where applicable
+   * @return this instance
+   */
+  public DiagnosisCase addOperatingContext(String key, String value) {
+    operatingContext.put(key, value);
+    return this;
+  }
+
+  /**
+   * Adds a data-quality item.
+   *
+   * @param key quality metric or qualification
+   * @param value metric value or qualification
+   * @return this instance
+   */
+  public DiagnosisCase addDataQuality(String key, String value) {
+    dataQuality.put(key, value);
+    return this;
+  }
+
+  /**
+   * Returns source provenance.
+   *
+   * @return unmodifiable source-provenance map
+   */
+  public Map<String, String> getDataSources() {
+    return Collections.unmodifiableMap(dataSources);
+  }
+
+  /**
+   * Returns operating context.
+   *
+   * @return unmodifiable operating-context map
+   */
+  public Map<String, String> getOperatingContext() {
+    return Collections.unmodifiableMap(operatingContext);
+  }
+
+  /**
+   * Returns data-quality metadata.
+   *
+   * @return unmodifiable data-quality map
+   */
+  public Map<String, String> getDataQuality() {
+    return Collections.unmodifiableMap(dataQuality);
+  }
+}

--- a/src/main/java/neqsim/process/diagnostics/EvidenceCollector.java
+++ b/src/main/java/neqsim/process/diagnostics/EvidenceCollector.java
@@ -175,6 +175,90 @@ public class EvidenceCollector implements Serializable {
   }
 
   /**
+   * Converts autonomous anomaly and topology findings into hypothesis-specific evidence.
+   *
+   * <p>
+   * Only findings that match an expected signal fingerprint are admitted. Anomalies retain their observed direction and
+   * can therefore support or contradict a hypothesis. Topology edges are supporting only when the statistical
+   * relationship is local or follows process flow; ambiguous, counter-flow, and common-cause verdicts remain reportable
+   * findings but do not affect ranking.
+   * </p>
+   *
+   * @param hypothesis hypothesis being evaluated
+   * @param anomalies anomalies detected by {@link AnomalyScanner}
+   * @param causalEdges relationships classified by {@link CausalTopologyModel}
+   * @return autonomous evidence relevant to the hypothesis
+   */
+  public List<Hypothesis.Evidence> collectAutonomousEvidence(Hypothesis hypothesis,
+      List<AnomalyScanner.Anomaly> anomalies, List<CausalTopologyModel.CausalEdge> causalEdges) {
+    List<Hypothesis.Evidence> evidence = new ArrayList<Hypothesis.Evidence>();
+    if (anomalies != null) {
+      for (AnomalyScanner.Anomaly anomaly : anomalies) {
+        ExpectedBehavior behavior = anomalyBehavior(anomaly.getKind());
+        Hypothesis.EvidenceStrength strength = anomaly.getSeverity() >= 0.85 ? Hypothesis.EvidenceStrength.STRONG
+            : anomaly.getSeverity() >= 0.60 ? Hypothesis.EvidenceStrength.MODERATE : Hypothesis.EvidenceStrength.WEAK;
+        Hypothesis.Evidence item = createEvidenceForObservedBehavior(anomaly.getTag(), anomaly.getDescription(),
+            strength, "autonomous-anomaly", behavior, hypothesis);
+        if (item != null) {
+          evidence.add(item);
+        }
+      }
+    }
+    if (causalEdges != null && !hypothesis.getExpectedSignals().isEmpty()) {
+      for (CausalTopologyModel.CausalEdge edge : causalEdges) {
+        if (edge.getVerdict() != CausalTopologyModel.Verdict.CAUSAL_CANDIDATE
+            && edge.getVerdict() != CausalTopologyModel.Verdict.LOCAL) {
+          continue;
+        }
+        RelationshipGraph.Relationship relationship = edge.getRelationship();
+        ExpectedSignal signal = matchingSignalForEitherTag(hypothesis, relationship.getSource(),
+            relationship.getTarget());
+        if (signal == null) {
+          continue;
+        }
+        double correlation = Math.abs(relationship.getCorrelation());
+        Hypothesis.EvidenceStrength strength = correlation >= 0.9 ? Hypothesis.EvidenceStrength.STRONG
+            : Hypothesis.EvidenceStrength.MODERATE;
+        String observation = relationship.toString() + "; topology verdict " + edge.getVerdict().name() + " ("
+            + edge.getRationale() + ")";
+        evidence.add(new Hypothesis.Evidence(relationship.getSource() + " -> " + relationship.getTarget(), observation,
+            strength, "causal-topology", true, signal.getWeight() * correlation,
+            "leaderEquipment=" + edge.getLeaderEquipment() + ";followerEquipment=" + edge.getFollowerEquipment()));
+      }
+    }
+    return evidence;
+  }
+
+  /** Returns the observed behavior represented by an anomaly kind. */
+  private ExpectedBehavior anomalyBehavior(AnomalyScanner.AnomalyKind kind) {
+    switch (kind) {
+    case THRESHOLD_HIGH:
+      return ExpectedBehavior.HIGH_LIMIT;
+    case THRESHOLD_LOW:
+      return ExpectedBehavior.LOW_LIMIT;
+    case SPIKE_HIGH:
+    case TREND_UP:
+      return ExpectedBehavior.INCREASE;
+    case SPIKE_LOW:
+    case TREND_DOWN:
+      return ExpectedBehavior.DECREASE;
+    default:
+      return ExpectedBehavior.ANY_CHANGE;
+    }
+  }
+
+  /** Finds an expected signal matching either endpoint of a relationship. */
+  private ExpectedSignal matchingSignalForEitherTag(Hypothesis hypothesis, String source, String target) {
+    for (ExpectedSignal signal : hypothesis.getExpectedSignals()) {
+      if (matchesPattern(source, signal.getParameterPattern())
+          || matchesPattern(target, signal.getParameterPattern())) {
+        return signal;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Calculates the aggregate likelihood score from evidence items.
    *
    * @param evidenceList evidence items

--- a/src/main/java/neqsim/process/diagnostics/Hypothesis.java
+++ b/src/main/java/neqsim/process/diagnostics/Hypothesis.java
@@ -51,6 +51,18 @@ public class Hypothesis implements Serializable, Comparable<Hypothesis> {
     EXTERNAL
   }
 
+  /** Status of an evidence or simulation evaluation. */
+  public enum EvaluationStatus {
+    /** Evaluation has not been attempted or produced no comparable observations. */
+    UNKNOWN,
+    /** Evaluation completed and the associated score is meaningful, including an exact zero. */
+    EVALUATED,
+    /** The current implementation cannot evaluate this hypothesis or equipment type. */
+    UNSUPPORTED,
+    /** Evaluation was attempted but failed because of a model or execution error. */
+    FAILED
+  }
+
   /**
    * Strength of a piece of evidence.
    */
@@ -274,6 +286,10 @@ public class Hypothesis implements Serializable, Comparable<Hypothesis> {
   private double likelihoodScore;
   private double verificationScore;
   private double confidenceScore;
+  private EvaluationStatus likelihoodStatus;
+  private EvaluationStatus verificationStatus;
+  private double verificationCoverage;
+  private int verificationComparisonCount;
   private final List<Evidence> evidenceList;
   private final List<ExpectedSignal> expectedSignals;
   private final List<String> recommendedActions;
@@ -288,6 +304,10 @@ public class Hypothesis implements Serializable, Comparable<Hypothesis> {
     this.likelihoodScore = 0.0;
     this.verificationScore = 0.0;
     this.confidenceScore = builder.priorProbability;
+    this.likelihoodStatus = EvaluationStatus.UNKNOWN;
+    this.verificationStatus = EvaluationStatus.UNKNOWN;
+    this.verificationCoverage = 0.0;
+    this.verificationComparisonCount = 0;
     this.evidenceList = new ArrayList<>(builder.evidenceList);
     this.expectedSignals = new ArrayList<>(builder.expectedSignals);
     this.recommendedActions = new ArrayList<>(builder.recommendedActions);
@@ -369,6 +389,42 @@ public class Hypothesis implements Serializable, Comparable<Hypothesis> {
   }
 
   /**
+   * Returns the status of historian and autonomous evidence evaluation.
+   *
+   * @return likelihood evaluation status
+   */
+  public EvaluationStatus getLikelihoodStatus() {
+    return likelihoodStatus;
+  }
+
+  /**
+   * Returns the status of process-simulation verification.
+   *
+   * @return verification evaluation status
+   */
+  public EvaluationStatus getVerificationStatus() {
+    return verificationStatus;
+  }
+
+  /**
+   * Returns simulation verification coverage.
+   *
+   * @return fraction of simulation KPI changes compared with historian observations
+   */
+  public double getVerificationCoverage() {
+    return verificationCoverage;
+  }
+
+  /**
+   * Returns the number of simulation-to-historian KPI comparisons.
+   *
+   * @return number of KPI comparisons
+   */
+  public int getVerificationComparisonCount() {
+    return verificationComparisonCount;
+  }
+
+  /**
    * Gets the evidence list.
    *
    * @return unmodifiable list of evidence items
@@ -431,7 +487,18 @@ public class Hypothesis implements Serializable, Comparable<Hypothesis> {
    * @param score score in range 0 to 1
    */
   public void setLikelihoodScore(double score) {
+    setLikelihoodEvaluation(score, EvaluationStatus.EVALUATED);
+  }
+
+  /**
+   * Sets the likelihood result and its explicit evaluation status.
+   *
+   * @param score score in range 0 to 1
+   * @param status evaluation status
+   */
+  public void setLikelihoodEvaluation(double score, EvaluationStatus status) {
     this.likelihoodScore = Math.max(0.0, Math.min(1.0, score));
+    this.likelihoodStatus = status == null ? EvaluationStatus.UNKNOWN : status;
     updateConfidence();
   }
 
@@ -441,8 +508,30 @@ public class Hypothesis implements Serializable, Comparable<Hypothesis> {
    * @param score score in range 0 to 1
    */
   public void setVerificationScore(double score) {
+    setVerificationEvaluation(score, EvaluationStatus.EVALUATED);
+  }
+
+  /**
+   * Sets the simulation result and its explicit evaluation status.
+   *
+   * @param score score in range 0 to 1
+   * @param status evaluation status
+   */
+  public void setVerificationEvaluation(double score, EvaluationStatus status) {
     this.verificationScore = Math.max(0.0, Math.min(1.0, score));
+    this.verificationStatus = status == null ? EvaluationStatus.UNKNOWN : status;
     updateConfidence();
+  }
+
+  /**
+   * Records how much of the simulated response could be compared with observations.
+   *
+   * @param coverage fraction in range 0 to 1
+   * @param comparisonCount number of comparable KPIs
+   */
+  public void setVerificationCoverage(double coverage, int comparisonCount) {
+    this.verificationCoverage = Math.max(0.0, Math.min(1.0, coverage));
+    this.verificationComparisonCount = Math.max(0, comparisonCount);
   }
 
   /**
@@ -465,11 +554,11 @@ public class Hypothesis implements Serializable, Comparable<Hypothesis> {
 
   /**
    * Updates the combined confidence score using Bayesian-inspired formula: confidence = prior x likelihood x
-   * verification. If likelihood or verification are 0 (not yet evaluated), they are treated as 1.0 (neutral).
+   * verification. Unknown, unsupported, and failed stages are neutral. An evaluated score of zero remains zero.
    */
   void updateConfidence() {
-    double lik = likelihoodScore > 0 ? likelihoodScore : 1.0;
-    double ver = verificationScore > 0 ? verificationScore : 1.0;
+    double lik = likelihoodStatus == EvaluationStatus.EVALUATED ? likelihoodScore : 1.0;
+    double ver = verificationStatus == EvaluationStatus.EVALUATED ? verificationScore : 1.0;
     this.confidenceScore = priorProbability * lik * ver;
   }
 

--- a/src/main/java/neqsim/process/diagnostics/RootCauseAnalyzer.java
+++ b/src/main/java/neqsim/process/diagnostics/RootCauseAnalyzer.java
@@ -35,7 +35,7 @@ import neqsim.process.processmodel.ProcessSystem;
  * rca.setStidData(stidMap);
  * rca.setDesignLimit("vibration_mm_s", Double.NaN, 7.1);
  * RootCauseReport report = rca.analyze();
- * System.out.println(report.toTextReport());
+ * String textReport = report.toTextReport();
  * </pre>
  *
  * @author NeqSim Development Team
@@ -84,6 +84,12 @@ public class RootCauseAnalyzer implements Serializable {
 
   /** Topology-classified causal edges from the most recent autonomous analysis. */
   private List<CausalTopologyModel.CausalEdge> lastCausalEdges = new ArrayList<>();
+
+  /** Reproducibility and provenance context for the analysis. */
+  private DiagnosisCase diagnosisCase;
+
+  /** Whether the current analysis should consume the most recent autonomous findings. */
+  private transient boolean autonomousEvidenceActive;
 
   /**
    * Creates a root cause analyzer.
@@ -171,6 +177,24 @@ public class RootCauseAnalyzer implements Serializable {
   }
 
   /**
+   * Sets caller-supplied reproducibility and provenance context.
+   *
+   * @param diagnosisCase diagnosis case, or {@code null} to derive one from the historian data
+   */
+  public void setDiagnosisCase(DiagnosisCase diagnosisCase) {
+    this.diagnosisCase = diagnosisCase;
+  }
+
+  /**
+   * Returns the configured diagnosis case.
+   *
+   * @return diagnosis case, or {@code null} before it is configured or derived by analysis
+   */
+  public DiagnosisCase getDiagnosisCase() {
+    return diagnosisCase;
+  }
+
+  /**
    * Runs an autonomous root cause analysis that discovers the symptom and relationships on its own.
    *
    * <p>
@@ -236,8 +260,13 @@ public class RootCauseAnalyzer implements Serializable {
       this.lastCausalEdges = new ArrayList<>();
     }
 
-    // Step D: run the standard Bayesian analysis with the (now set) symptom.
-    return analyze();
+    // Step D: run the standard analysis while admitting relevant autonomous findings as evidence.
+    this.autonomousEvidenceActive = true;
+    try {
+      return analyze();
+    } finally {
+      this.autonomousEvidenceActive = false;
+    }
   }
 
   /**
@@ -374,11 +403,18 @@ public class RootCauseAnalyzer implements Serializable {
 
     for (Hypothesis h : hypotheses) {
       List<Hypothesis.Evidence> evidence = collector.collectEvidence(h);
+      if (autonomousEvidenceActive) {
+        evidence.addAll(collector.collectAutonomousEvidence(h, lastAnomalies, lastCausalEdges));
+      }
       for (Hypothesis.Evidence e : evidence) {
         h.addEvidence(e);
       }
-      double likelihood = collector.calculateLikelihoodScore(evidence);
-      h.setLikelihoodScore(likelihood);
+      if (evidence.isEmpty()) {
+        h.setLikelihoodEvaluation(0.5, Hypothesis.EvaluationStatus.UNKNOWN);
+      } else {
+        double likelihood = collector.calculateLikelihoodScore(evidence);
+        h.setLikelihoodEvaluation(likelihood, Hypothesis.EvaluationStatus.EVALUATED);
+      }
     }
 
     // Step 6: Simulation verification (if enabled and process available)
@@ -401,6 +437,17 @@ public class RootCauseAnalyzer implements Serializable {
     // Step 8: Build report
     String eqType = equipment != null ? generator.classifyEquipment(equipment) : "unknown";
     RootCauseReport report = new RootCauseReport(equipmentName, eqType, symptom);
+    if (diagnosisCase == null) {
+      diagnosisCase = DiagnosisCase.fromHistorian(equipmentName, timestamps, historianData)
+          .setProcessModel(processSystem.getClass().getName(), "runtime-instance");
+      if (!stidData.isEmpty()) {
+        diagnosisCase.addDataSource("STID", "in-memory design metadata");
+      }
+      if (!designLimits.isEmpty()) {
+        diagnosisCase.addDataSource("designLimits", "configured analysis limits");
+      }
+    }
+    report.setDiagnosisCase(diagnosisCase);
     report.setHypotheses(hypotheses);
     report.setDataPointsAnalyzed(totalDataPoints);
     report.setParametersAnalyzed(historianData.size());

--- a/src/main/java/neqsim/process/diagnostics/RootCauseReport.java
+++ b/src/main/java/neqsim/process/diagnostics/RootCauseReport.java
@@ -52,6 +52,9 @@ public class RootCauseReport implements Serializable {
   /** Number of parameters analyzed. */
   private int parametersAnalyzed;
 
+  /** Reproducibility and provenance context for this report. */
+  private DiagnosisCase diagnosisCase;
+
   /** Gson serializer for stable pretty-printed JSON output. */
   private static final transient Gson GSON = new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues()
       .create();
@@ -88,6 +91,24 @@ public class RootCauseReport implements Serializable {
    */
   public void setAnalysisSummary(String summary) {
     this.analysisSummary = summary;
+  }
+
+  /**
+   * Sets the reproducible diagnosis case.
+   *
+   * @param diagnosisCase case context
+   */
+  public void setDiagnosisCase(DiagnosisCase diagnosisCase) {
+    this.diagnosisCase = diagnosisCase;
+  }
+
+  /**
+   * Returns the reproducible diagnosis case.
+   *
+   * @return diagnosis case, or {@code null} for reports created by legacy callers
+   */
+  public DiagnosisCase getDiagnosisCase() {
+    return diagnosisCase;
   }
 
   /**
@@ -213,6 +234,9 @@ public class RootCauseReport implements Serializable {
     root.addProperty("timestamp", new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(new Date(analysisTimestamp)));
     root.addProperty("dataPointsAnalyzed", dataPointsAnalyzed);
     root.addProperty("parametersAnalyzed", parametersAnalyzed);
+    if (diagnosisCase != null) {
+      root.add("diagnosisCase", GSON.toJsonTree(diagnosisCase));
+    }
 
     if (analysisSummary != null) {
       root.addProperty("summary", analysisSummary);
@@ -230,6 +254,10 @@ public class RootCauseReport implements Serializable {
       hypothesisJson.addProperty("priorProbability", hypothesis.getPriorProbability());
       hypothesisJson.addProperty("likelihoodScore", hypothesis.getLikelihoodScore());
       hypothesisJson.addProperty("verificationScore", hypothesis.getVerificationScore());
+      hypothesisJson.addProperty("likelihoodStatus", hypothesis.getLikelihoodStatus().name());
+      hypothesisJson.addProperty("verificationStatus", hypothesis.getVerificationStatus().name());
+      hypothesisJson.addProperty("verificationCoverage", hypothesis.getVerificationCoverage());
+      hypothesisJson.addProperty("verificationComparisonCount", hypothesis.getVerificationComparisonCount());
 
       if (hypothesis.getDescription() != null) {
         hypothesisJson.addProperty("description", hypothesis.getDescription());
@@ -289,6 +317,11 @@ public class RootCauseReport implements Serializable {
         .append("\n");
     sb.append("Data points:  ").append(dataPointsAnalyzed).append("\n");
     sb.append("Parameters:   ").append(parametersAnalyzed).append("\n\n");
+    if (diagnosisCase != null) {
+      sb.append("Case ID:      ").append(diagnosisCase.getCaseId()).append("\n");
+      sb.append("Process model:").append(" ").append(diagnosisCase.getProcessModelId()).append(" @ ")
+          .append(diagnosisCase.getProcessModelRevision()).append("\n\n");
+    }
 
     if (analysisSummary != null) {
       sb.append("Summary: ").append(analysisSummary).append("\n\n");
@@ -302,8 +335,11 @@ public class RootCauseReport implements Serializable {
       Hypothesis h = rankedHypotheses.get(i);
       sb.append(String.format("#%d  %s  (Confidence: %.1f%%)\n", i + 1, h.getName(), h.getConfidenceScore() * 100));
       sb.append(String.format("    Category: %s\n", h.getCategory().name()));
-      sb.append(String.format("    Prior: %.3f | Likelihood: %.3f | Verification: %.3f\n", h.getPriorProbability(),
-          h.getLikelihoodScore(), h.getVerificationScore()));
+      sb.append(String.format("    Prior: %.3f | Likelihood: %.3f (%s) | Verification: %.3f (%s)\n",
+          h.getPriorProbability(), h.getLikelihoodScore(), h.getLikelihoodStatus().name(), h.getVerificationScore(),
+          h.getVerificationStatus().name()));
+      sb.append(String.format("    Verification coverage: %.1f%% (%d KPI comparisons)\n",
+          h.getVerificationCoverage() * 100.0, h.getVerificationComparisonCount()));
 
       if (h.getDescription() != null) {
         sb.append("    Description: ").append(h.getDescription()).append("\n");
@@ -350,6 +386,9 @@ public class RootCauseReport implements Serializable {
     result.put("symptom", symptom.name());
     result.put("dataPointsAnalyzed", dataPointsAnalyzed);
     result.put("parametersAnalyzed", parametersAnalyzed);
+    if (diagnosisCase != null) {
+      result.put("diagnosisCase", diagnosisCase);
+    }
 
     Hypothesis top = getTopHypothesis();
     if (top != null) {
@@ -360,6 +399,9 @@ public class RootCauseReport implements Serializable {
       topResult.put("confidenceScore", top.getConfidenceScore());
       topResult.put("evidenceCount", top.getEvidenceList().size());
       topResult.put("contradictoryEvidenceCount", countContradictoryEvidence(top));
+      topResult.put("likelihoodStatus", top.getLikelihoodStatus().name());
+      topResult.put("verificationStatus", top.getVerificationStatus().name());
+      topResult.put("verificationCoverage", top.getVerificationCoverage());
       result.put("topHypothesis", topResult);
     }
 

--- a/src/main/java/neqsim/process/diagnostics/SimulationVerifier.java
+++ b/src/main/java/neqsim/process/diagnostics/SimulationVerifier.java
@@ -69,6 +69,16 @@ public class SimulationVerifier implements Serializable {
    * @param hypothesis hypothesis to verify
    */
   public void verify(Hypothesis hypothesis) {
+    verifyWithResult(hypothesis);
+  }
+
+  /**
+   * Verifies a hypothesis and returns structured coverage and status information.
+   *
+   * @param hypothesis hypothesis to verify
+   * @return structured verification result
+   */
+  public VerificationResult verifyWithResult(Hypothesis hypothesis) {
     try {
       ProcessSystem modifiedProcess = baseProcess.copy();
       modifiedProcess.run();
@@ -78,23 +88,33 @@ public class SimulationVerifier implements Serializable {
 
       PerturbationResult perturbation = applyPerturbation(modifiedProcess, hypothesis);
       if (!perturbation.isApplied()) {
-        hypothesis.setVerificationScore(0.5);
+        hypothesis.setVerificationEvaluation(0.0, Hypothesis.EvaluationStatus.UNSUPPORTED);
+        hypothesis.setVerificationCoverage(0.0, 0);
         hypothesis.setSimulationSummary("Simulation verification neutral: " + perturbation.getDescription());
-        return;
+        return new VerificationResult(Hypothesis.EvaluationStatus.UNSUPPORTED, 0.0, 0.0, 0,
+            perturbation.getDescription());
       }
 
       modifiedProcess.run();
       ProcessAutomation modifiedAuto = new ProcessAutomation(modifiedProcess);
       Map<String, Double> modifiedKpis = readKpis(modifiedAuto);
 
-      double score = compareToHistorian(baselineKpis, modifiedKpis);
-      hypothesis.setVerificationScore(score);
-      hypothesis.setSimulationSummary(buildSummary(perturbation, baselineKpis, modifiedKpis, score));
-      logger.info("Hypothesis '{}' verification score: {}", hypothesis.getName(), score);
+      ComparisonResult comparison = compareToHistorian(baselineKpis, modifiedKpis);
+      hypothesis.setVerificationEvaluation(comparison.score, comparison.status);
+      hypothesis.setVerificationCoverage(comparison.coverage, comparison.comparisonCount);
+      String summary = buildSummary(perturbation, baselineKpis, modifiedKpis, comparison);
+      hypothesis.setSimulationSummary(summary);
+      logger.info("Hypothesis '{}' verification status {}, score {}, coverage {}", hypothesis.getName(),
+          comparison.status, comparison.score, comparison.coverage);
+      return new VerificationResult(comparison.status, comparison.score, comparison.coverage,
+          comparison.comparisonCount, summary);
     } catch (Exception e) {
       logger.warn("Simulation verification failed for '{}': {}", hypothesis.getName(), e.getMessage());
-      hypothesis.setVerificationScore(0.3);
+      hypothesis.setVerificationEvaluation(0.0, Hypothesis.EvaluationStatus.FAILED);
+      hypothesis.setVerificationCoverage(0.0, 0);
       hypothesis.setSimulationSummary("Simulation failed: " + e.getMessage());
+      return new VerificationResult(Hypothesis.EvaluationStatus.FAILED, 0.0, 0.0, 0,
+          "Simulation failed: " + e.getMessage());
     }
   }
 
@@ -390,37 +410,53 @@ public class SimulationVerifier implements Serializable {
    *
    * @param baseline baseline KPI values
    * @param modified modified KPI values after perturbation
-   * @return match score in range 0 to 1
+   * @return comparison result with score and coverage
    */
-  private double compareToHistorian(Map<String, Double> baseline, Map<String, Double> modified) {
+  private ComparisonResult compareToHistorian(Map<String, Double> baseline, Map<String, Double> modified) {
     if (historianData.isEmpty() || baseline.isEmpty() || modified.isEmpty()) {
-      return 0.5;
+      return ComparisonResult.unknown();
     }
 
-    int matchCount = 0;
+    double totalScore = 0.0;
     int totalComparisons = 0;
+    int changedKpis = 0;
     for (Map.Entry<String, Double> entry : modified.entrySet()) {
       String kpi = entry.getKey();
       Double baseVal = baseline.get(kpi);
       if (baseVal == null || Math.abs(baseVal) < 1e-10) {
         continue;
       }
+      double simulationChange = entry.getValue() - baseVal;
+      if (Math.abs(simulationChange) < 1e-12) {
+        continue;
+      }
+      changedKpis++;
       double[] historianValues = findHistorianValuesForKpi(kpi);
       if (historianValues == null || historianValues.length < 2) {
         continue;
       }
 
-      double simulationChange = entry.getValue() - baseVal;
       double observedChange = historianValues[historianValues.length - 1] - historianValues[0];
-      if (Math.abs(simulationChange) < 1e-12 || Math.abs(observedChange) < 1e-12) {
+      double observedBase = historianValues[0];
+      if (Math.abs(observedChange) < 1e-12 || Math.abs(observedBase) < 1e-10) {
         continue;
       }
       if (Math.signum(simulationChange) == Math.signum(observedChange)) {
-        matchCount++;
+        double simulatedFraction = Math.abs(simulationChange / baseVal);
+        double observedFraction = Math.abs(observedChange / observedBase);
+        double magnitudeRatio = Math.min(simulatedFraction, observedFraction)
+            / Math.max(simulatedFraction, observedFraction);
+        totalScore += 0.5 + 0.5 * magnitudeRatio;
       }
       totalComparisons++;
     }
-    return totalComparisons == 0 ? 0.5 : (double) matchCount / totalComparisons;
+    if (totalComparisons == 0) {
+      return ComparisonResult.unknown();
+    }
+    double coverage = changedKpis == 0 ? 0.0 : (double) totalComparisons / changedKpis;
+    double score = totalScore / totalComparisons;
+    score *= 0.5 + 0.5 * coverage;
+    return new ComparisonResult(Hypothesis.EvaluationStatus.EVALUATED, score, coverage, totalComparisons);
   }
 
   /**
@@ -477,11 +513,11 @@ public class SimulationVerifier implements Serializable {
    * @param perturbation perturbation that was applied
    * @param baseline baseline KPI values
    * @param modified modified KPI values
-   * @param score verification score
+   * @param comparison verification comparison
    * @return summary text
    */
   private String buildSummary(PerturbationResult perturbation, Map<String, Double> baseline,
-      Map<String, Double> modified, double score) {
+      Map<String, Double> modified, ComparisonResult comparison) {
     StringBuilder summary = new StringBuilder();
     summary.append("Applied ").append(perturbation.getChangedVariable()).append(": ")
         .append(perturbation.getDescription()).append(". KPI changes: ");
@@ -492,8 +528,92 @@ public class SimulationVerifier implements Serializable {
         summary.append(String.format(Locale.US, "%s %.1f%%; ", entry.getKey(), changePct));
       }
     }
-    summary.append(String.format(Locale.US, "direction match score %.2f", score));
+    summary.append(String.format(Locale.US, "magnitude-aware score %.2f; coverage %.0f%% (%d comparisons)",
+        comparison.score, comparison.coverage * 100.0, comparison.comparisonCount));
     return summary.toString();
+  }
+
+  /** Structured public result of a simulation verification attempt. */
+  public static final class VerificationResult implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final Hypothesis.EvaluationStatus status;
+    private final double score;
+    private final double coverage;
+    private final int comparisonCount;
+    private final String summary;
+
+    private VerificationResult(Hypothesis.EvaluationStatus status, double score, double coverage, int comparisonCount,
+        String summary) {
+      this.status = status;
+      this.score = score;
+      this.coverage = coverage;
+      this.comparisonCount = comparisonCount;
+      this.summary = summary;
+    }
+
+    /**
+     * Returns the evaluation status.
+     *
+     * @return evaluation status
+     */
+    public Hypothesis.EvaluationStatus getStatus() {
+      return status;
+    }
+
+    /**
+     * Returns the verification score.
+     *
+     * @return verification score in range 0 to 1
+     */
+    public double getScore() {
+      return score;
+    }
+
+    /**
+     * Returns comparable-KPI coverage.
+     *
+     * @return fraction of changed simulated KPIs compared with observations
+     */
+    public double getCoverage() {
+      return coverage;
+    }
+
+    /**
+     * Returns the number of KPI comparisons.
+     *
+     * @return number of KPI comparisons
+     */
+    public int getComparisonCount() {
+      return comparisonCount;
+    }
+
+    /**
+     * Returns the human-readable verification summary.
+     *
+     * @return verification summary
+     */
+    public String getSummary() {
+      return summary;
+    }
+  }
+
+  /** Internal aggregate of KPI comparisons. */
+  private static final class ComparisonResult {
+    private final Hypothesis.EvaluationStatus status;
+    private final double score;
+    private final double coverage;
+    private final int comparisonCount;
+
+    private ComparisonResult(Hypothesis.EvaluationStatus status, double score, double coverage, int comparisonCount) {
+      this.status = status;
+      this.score = score;
+      this.coverage = coverage;
+      this.comparisonCount = comparisonCount;
+    }
+
+    private static ComparisonResult unknown() {
+      return new ComparisonResult(Hypothesis.EvaluationStatus.UNKNOWN, 0.0, 0.0, 0);
+    }
   }
 
   /**

--- a/src/test/java/neqsim/process/diagnostics/AutonomousInvestigationTest.java
+++ b/src/test/java/neqsim/process/diagnostics/AutonomousInvestigationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,6 +87,15 @@ class AutonomousInvestigationTest {
     assertFalse(rca.getLastCausalEdges().isEmpty(), "causal edges should be produced without a supplied tag map");
     assertEquals(CausalTopologyModel.Verdict.LOCAL, rca.getLastCausalEdges().get(0).getVerdict(),
         "both tags belong to the same compressor, so the edge is LOCAL");
+    boolean autonomousEvidenceUsed = false;
+    for (Hypothesis hypothesis : report.getRankedHypotheses()) {
+      for (Hypothesis.Evidence evidence : hypothesis.getEvidenceList()) {
+        if ("autonomous-anomaly".equals(evidence.getSource()) || "causal-topology".equals(evidence.getSource())) {
+          autonomousEvidenceUsed = true;
+        }
+      }
+    }
+    assertTrue(autonomousEvidenceUsed, "autonomous findings should feed hypothesis evidence and ranking");
   }
 
   /**

--- a/src/test/java/neqsim/process/diagnostics/RootCauseAnalyzerTest.java
+++ b/src/test/java/neqsim/process/diagnostics/RootCauseAnalyzerTest.java
@@ -180,6 +180,76 @@ class RootCauseAnalyzerTest {
     assertEquals(0.360, h.getConfidenceScore(), 0.001);
   }
 
+  /** Ensures an evaluated contradictory zero is not confused with an unevaluated score. */
+  @Test
+  void testEvaluatedZeroIsNotNeutral() {
+    Hypothesis h = Hypothesis.builder().name("contradicted").priorProbability(0.4).build();
+
+    assertEquals(Hypothesis.EvaluationStatus.UNKNOWN, h.getLikelihoodStatus());
+    assertEquals(0.4, h.getConfidenceScore(), 0.001);
+
+    h.setLikelihoodScore(0.0);
+    assertEquals(Hypothesis.EvaluationStatus.EVALUATED, h.getLikelihoodStatus());
+    assertEquals(0.0, h.getConfidenceScore(), 0.001);
+
+    h.setLikelihoodEvaluation(0.0, Hypothesis.EvaluationStatus.UNSUPPORTED);
+    assertEquals(0.4, h.getConfidenceScore(), 0.001, "unsupported evaluation must be explicit and neutral");
+  }
+
+  /** Verifies diagnosis provenance and evaluation states are serialized without breaking legacy fields. */
+  @Test
+  void testDiagnosisCaseAndEvaluationStatusSerialization() {
+    RootCauseAnalyzer rca = new RootCauseAnalyzer(process, compressorName);
+    rca.setSymptom(Symptom.HIGH_VIBRATION);
+    rca.setSimulationEnabled(false);
+    DiagnosisCase diagnosisCase = new DiagnosisCase(compressorName).setCaseId("case-2026-07")
+        .setTimeWindow(1000.0, 2000.0).setCaseId("case-2026-07").setProcessModel("export-compression", "model-rev-7")
+        .addDataSource("PI", "query-42").addOperatingContext("mode", "recycle").addDataQuality("coverage", "98%");
+    rca.setDiagnosisCase(diagnosisCase);
+
+    RootCauseReport report = rca.analyze();
+    String json = report.toJson();
+
+    assertEquals(diagnosisCase, report.getDiagnosisCase());
+    assertTrue(json.contains("\"diagnosisCase\""));
+    assertTrue(json.contains("\"caseId\": \"case-2026-07\""));
+    assertTrue(json.contains("\"likelihoodStatus\""));
+    assertTrue(json.contains("\"verificationStatus\": \"UNKNOWN\""));
+    assertTrue(json.contains("\"equipment\": \"" + compressorName + "\""));
+  }
+
+  /** Verifies unsupported simulation is explicit and does not penalize confidence. */
+  @Test
+  void testUnsupportedSimulationVerificationStatus() {
+    Hypothesis h = Hypothesis.builder().name("unknown perturbation").priorProbability(0.4).build();
+    SimulationVerifier verifier = new SimulationVerifier(process, "missing-equipment");
+
+    SimulationVerifier.VerificationResult result = verifier.verifyWithResult(h);
+
+    assertEquals(Hypothesis.EvaluationStatus.UNSUPPORTED, result.getStatus());
+    assertEquals(Hypothesis.EvaluationStatus.UNSUPPORTED, h.getVerificationStatus());
+    assertEquals(0.0, result.getCoverage(), 0.001);
+    assertEquals(0.4, h.getConfidenceScore(), 0.001);
+  }
+
+  /** Verifies comparable KPI responses produce evaluated, magnitude-aware results with coverage. */
+  @Test
+  void testSimulationVerificationReportsCoverage() {
+    Hypothesis h = Hypothesis.builder().name("compressor fouling").failureMode("fouling")
+        .category(Hypothesis.Category.MECHANICAL).priorProbability(0.4).build();
+    SimulationVerifier verifier = new SimulationVerifier(process, compressorName);
+    Map<String, double[]> historian = new HashMap<String, double[]>();
+    historian.put("polytropicEfficiency", new double[] { 1.0, 0.85 });
+    verifier.setHistorianData(historian);
+
+    SimulationVerifier.VerificationResult result = verifier.verifyWithResult(h);
+
+    assertEquals(Hypothesis.EvaluationStatus.EVALUATED, result.getStatus());
+    assertTrue(result.getComparisonCount() > 0);
+    assertTrue(result.getCoverage() > 0.0);
+    assertTrue(result.getSummary().contains("magnitude-aware score"));
+  }
+
   /**
    * Tests richer evidence metadata.
    */

--- a/src/test/java/neqsim/process/diagnostics/RootCauseAnalyzerTest.java
+++ b/src/test/java/neqsim/process/diagnostics/RootCauseAnalyzerTest.java
@@ -194,6 +194,9 @@ class RootCauseAnalyzerTest {
 
     h.setLikelihoodEvaluation(0.0, Hypothesis.EvaluationStatus.UNSUPPORTED);
     assertEquals(0.4, h.getConfidenceScore(), 0.001, "unsupported evaluation must be explicit and neutral");
+
+    h.setLikelihoodEvaluation(0.0, Hypothesis.EvaluationStatus.FAILED);
+    assertEquals(0.4, h.getConfidenceScore(), 0.001, "failed evaluation must be explicit and neutral");
   }
 
   /** Verifies diagnosis provenance and evaluation states are serialized without breaking legacy fields. */

--- a/src/test/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrillsHoldupTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrillsHoldupTest.java
@@ -39,8 +39,7 @@ class PipeBeggsAndBrillsHoldupTest {
 
     Stream inlet = new Stream("liquid-rich inlet", fluid);
     inlet.run();
-    PipeBeggsAndBrills pipe =
-        new PipeBeggsAndBrills("holdup regression pipe", inlet);
+    PipeBeggsAndBrills pipe = new PipeBeggsAndBrills("holdup regression pipe", inlet);
     pipe.setLength(10000.0);
     pipe.setDiameter(0.25);
     pipe.setElevation(0.0);
@@ -56,10 +55,6 @@ class PipeBeggsAndBrillsHoldupTest {
       maximumHoldup = Math.max(maximumHoldup, holdup);
     }
 
-    assertEquals(
-        1.0,
-        maximumHoldup,
-        1.0e-12,
-        "This liquid-rich regression case should exercise the upper bound");
+    assertEquals(1.0, maximumHoldup, 1.0e-12, "This liquid-rich regression case should exercise the upper bound");
   }
 }


### PR DESCRIPTION
## Summary

Establishes a trustworthy, auditable foundation for general process-equipment root-cause analysis.

- distinguishes evaluated zero scores from unknown, unsupported, and failed evaluations while preserving existing score setters and report fields
- admits hypothesis-matched anomaly and physically consistent topology findings into evidence and likelihood ranking
- adds a serializable `DiagnosisCase` with equipment, time window, data provenance, process-model identity, operating context, and data-quality metadata
- exposes diagnosis context and evaluation/coverage metadata in `RootCauseReport`, results maps, and MCP JSON
- makes simulation verification magnitude-aware and reports comparable-KPI coverage; unsupported and execution failures remain explicit and neutral
- updates focused regression/integration/serialization coverage plus RCA and autonomous-investigation documentation/skills

## Why

The prior confidence calculation used score value `0` as a proxy for “not evaluated,” so a genuinely contradictory zero became neutral. Autonomous anomaly/topology discoveries were retained for reporting but did not affect ranking. Simulation verification also collapsed unsupported, failed, no-coverage, and direction-only outcomes into numeric scores without enough audit context.

## Compatibility

Existing constructors, `setLikelihoodScore`, `setVerificationScore`, `verify(Hypothesis)`, legacy JSON fields, and results-map fields remain available. New status, coverage, and diagnosis-case fields are additive. The implementation uses Java 8-compatible APIs.

## Validation

Completed on final head `dd38c0fb`:

- Javadocs/main compilation: passed
- CodeQL Security Analysis: passed
- Skills and agents lint: passed
- Agent-skill cross-reference validation: passed
- Documentation search coverage: passed
- PaperLab Replication Gate: passed
- Spotless format-patch workflow: passed; generated formatting was applied to every changed RCA file
- Ubuntu and Windows repository test jobs: running on the latest head

The global pre-commit and Spotless checks now pass. The formatter-only correction to `src/test/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrillsHoldupTest.java` was included after the pre-existing master formatting drift blocked the repository-wide check.

Local Spotless/Maven execution was attempted but unavailable because build plugins were not cached and Maven Central was unreachable in the execution environment.

Focused tests added here cover evaluated-zero/failed semantics, unsupported verification, magnitude-aware coverage, `DiagnosisCase` serialization, and autonomous evidence admission.

Supersedes closed draft #2514, whose head could not be resynchronized after applying the formatter-generated replacement commit.