### PR TITLE
Fix LNG recycle expansion warm starts

### DIFF
--- a/src/main/java/neqsim/process/lng/LNGProcessBuilder.java
+++ b/src/main/java/neqsim/process/lng/LNGProcessBuilder.java
@@ -361,6 +361,8 @@ public class LNGProcessBuilder {
 
     ThrottlingValve mrValve = new ThrottlingValve(name + " MR JT valve", mche.getOutStream(1));
     mrValve.setOutletPressure(3.0, "bara");
+    initializeExpansionInlet(mche.getOutStream(1), -150.0, 30.0);
+    mrValve.run();
     mche.addInStreamMSHE(mrValve.getOutletStream(), "cold", null);
     context.exchangers.add(mche);
 
@@ -409,6 +411,8 @@ public class LNGProcessBuilder {
 
     ThrottlingValve mrValve = new ThrottlingValve(name + " MR JT valve", mche.getOutStream(1));
     mrValve.setOutletPressure(4.0, "bara");
+    initializeExpansionInlet(mche.getOutStream(1), -150.0, 45.0);
+    mrValve.run();
     mche.addInStreamMSHE(mrValve.getOutletStream(), "cold", null);
     context.exchangers.add(mche);
     context.process.add(mche);
@@ -459,6 +463,8 @@ public class LNGProcessBuilder {
 
     ThrottlingValve coldValve = new ThrottlingValve(name + " cold MR JT valve", mche.getOutStream(1));
     coldValve.setOutletPressure(3.0, "bara");
+    initializeExpansionInlet(mche.getOutStream(1), -150.0, 38.0);
+    coldValve.run();
     mche.addInStreamMSHE(coldValve.getOutletStream(), "cold", null);
     context.exchangers.add(mche);
     context.process.add(mche);
@@ -489,6 +495,8 @@ public class LNGProcessBuilder {
     Expander expander = new Expander(name + " nitrogen expander", mche.getOutStream(1));
     expander.setOutletPressure(8.0, "bara");
     expander.setIsentropicEfficiency(expanderEfficiency);
+    initializeExpansionInlet(mche.getOutStream(1), -105.0, 55.0);
+    expander.run();
     context.expanders.add(expander);
     mche.addInStreamMSHE(expander.getOutletStream(), "cold", null);
     context.exchangers.add(mche);
@@ -647,6 +655,26 @@ public class LNGProcessBuilder {
     exchanger.setTemperatureApproach(minimumApproachC);
     exchanger.setFlowMaldistributionFactor(0.97);
     return exchanger;
+  }
+
+  /**
+   * Initializes the high-pressure exchanger outlet before its expansion device is first evaluated.
+   *
+   * <p>
+   * The main exchanger and its downstream valve or expander form a recycle loop. The exchanger executes first in
+   * insertion order, so its cold-side inlet needs a thermodynamically consistent first-iteration state. The normal unit
+   * operations overwrite this seed as the recycle converges.
+   * </p>
+   *
+   * @param highPressureStream exchanger outlet feeding the expansion device
+   * @param temperatureC specified exchanger outlet temperature in Celsius
+   * @param pressureBara high-side pressure in bara
+   */
+  private void initializeExpansionInlet(StreamInterface highPressureStream, double temperatureC,
+      double pressureBara) {
+    highPressureStream.setTemperature(temperatureC, "C");
+    highPressureStream.setPressure(pressureBara, "bara");
+    highPressureStream.run();
   }
 
   /**

--- a/src/main/java/neqsim/process/lng/LNGProcessBuilder.java
+++ b/src/main/java/neqsim/process/lng/LNGProcessBuilder.java
@@ -670,8 +670,7 @@ public class LNGProcessBuilder {
    * @param temperatureC specified exchanger outlet temperature in Celsius
    * @param pressureBara high-side pressure in bara
    */
-  private void initializeExpansionInlet(StreamInterface highPressureStream, double temperatureC,
-      double pressureBara) {
+  private void initializeExpansionInlet(StreamInterface highPressureStream, double temperatureC, double pressureBara) {
     highPressureStream.setTemperature(temperatureC, "C");
     highPressureStream.setPressure(pressureBara, "bara");
     highPressureStream.run();

--- a/src/test/java/neqsim/process/lng/LNGProcessBuilderTest.java
+++ b/src/test/java/neqsim/process/lng/LNGProcessBuilderTest.java
@@ -14,6 +14,7 @@ import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.distillation.DistillationColumn;
+import neqsim.process.equipment.heatexchanger.LNGHeatExchanger;
 import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
@@ -43,6 +44,13 @@ class LNGProcessBuilderTest {
     assertEquals(2, model.getOutputStreams().size());
     assertTrue(model.getCompressors().size() >= 2);
     assertTrue(model.getCryogenicHeatExchangers().size() >= 1);
+
+    LNGHeatExchanger mainExchanger = model.getCryogenicHeatExchangers()
+        .get(model.getCryogenicHeatExchangers().size() - 1);
+    double coldSideInletC = mainExchanger.getInStream(2).getTemperature("C");
+    double coldestHotOutletC = Math.min(mainExchanger.getOutTemperature(0), mainExchanger.getOutTemperature(1));
+    assertTrue(coldSideInletC < coldestHotOutletC,
+        cycle + " cold-side warm start must be colder than the specified hot-stream outlets");
 
     if (cycle == LNGProcessCycle.NITROGEN_EXPANDER) {
       assertEquals(1, model.getExpanders().size());


### PR DESCRIPTION
## Summary

- initialize the specified high-pressure main-exchanger refrigerant outlet before evaluating its downstream JT valve or expander
- use the resulting thermodynamically consistent expanded state as the cold-side first-iteration warm start
- retain the normal NeqSim valve/expander and recycle calculations, which overwrite the seed during convergence
- cover SMR, C3MR, DMR, and nitrogen-expander main exchangers
- add a fast construction-level regression assertion that every main-exchanger cold-side seed is colder than its specified hot-stream outlets

## Root cause

The main exchanger and expansion device form a recycle strongly connected component. In insertion order the exchanger runs first. Before the expansion device has run, its outlet still carries the warm construction-time state. In the SMR regression this made the requested hot-side cooling physically impossible and the multi-stream exchanger exhausted 1000 initialization attempts with a hot/cold duty ratio of 241.817.

## Validation

- traced the failing hosted Java 21 Ubuntu stack through `LNGProcessBuilderTest.testSmrRouteRunsAndReportsPerformance` to `MultiStreamHeatExchanger2.resetOfExtremesAndStalls`
- retained the existing slow end-to-end SMR regression and added a fast warm-start invariant across all four routes
- Java 21 Javadoc/main-source compilation: passed
- CodeQL Security Analysis: passed
- PaperLab Replication Gate: passed
- agent-skill cross-reference validation: passed
- repository Spotless formatter applied to the changed LNG source; a fresh formatter run reports no LNG-file changes
- Java 21 Windows fast suite and Ubuntu complete suite: running on head `079e3401`

The global pre-commit job is blocked only by the pre-existing unformatted `src/test/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrillsHoldupTest.java` on `master`. Neither file changed by this PR is listed in that failure.

Local Maven execution is unavailable in this workspace; the hosted Actions runs are the authoritative execution gates.
