### PR TITLE
Fix lifecycle power aggregation for inactive equipment

### DIFF
--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.compressor.CompressorChartInterface;
+import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.fielddevelopment.economics.CashFlowEngine;
 import neqsim.process.fielddevelopment.economics.CashFlowEngine.CashFlowResult;
@@ -625,7 +626,39 @@ public class FieldLifecycleSimulator {
   }
 
   private double getProcessPower(FieldLifecycleModel model, String unit) {
-    return model.hasProcessModel() ? model.getProcessModel().getPower(unit) : model.getProcessSystem().getPower(unit);
+    double reportedPower = model.hasProcessModel() ? model.getProcessModel().getPower(unit)
+        : model.getProcessSystem().getPower(unit);
+    if (Double.isFinite(reportedPower)) {
+      return reportedPower;
+    }
+
+    double finitePower = 0.0;
+    if (model.hasProcessModel()) {
+      for (String areaName : model.getProcessModel().getProcessSystemNames()) {
+        finitePower += sumFiniteProcessPower(model.getProcessModel().get(areaName), unit);
+      }
+    } else {
+      finitePower = sumFiniteProcessPower(model.getProcessSystem(), unit);
+    }
+    logger.warn("Process {} reported non-finite total power; using {} {} from finite equipment duties",
+        model.getName(), finitePower, unit);
+    return finitePower;
+  }
+
+  private double sumFiniteProcessPower(ProcessSystem process, String unit) {
+    double finitePower = 0.0;
+    for (ProcessEquipmentInterface equipment : process.getUnitOperations()) {
+      double equipmentPower = Double.NaN;
+      if (equipment instanceof Compressor) {
+        equipmentPower = ((Compressor) equipment).getPower(unit);
+      } else if (equipment instanceof Pump) {
+        equipmentPower = ((Pump) equipment).getPower(unit);
+      }
+      if (Double.isFinite(equipmentPower)) {
+        finitePower += equipmentPower;
+      }
+    }
+    return finitePower;
   }
 
   private int autoSizeProcess(FieldLifecycleModel model, double designMargin) {

--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
@@ -640,8 +640,8 @@ public class FieldLifecycleSimulator {
     } else {
       finitePower = sumFiniteProcessPower(model.getProcessSystem(), unit);
     }
-    logger.warn("Process {} reported non-finite total power; using {} {} from finite equipment duties",
-        model.getName(), finitePower, unit);
+    logger.warn("Process {} reported non-finite total power; using {} {} from finite equipment duties", model.getName(),
+        finitePower, unit);
     return finitePower;
   }
 


### PR DESCRIPTION
## Summary

Fixes lifecycle energy and emissions reporting when a detailed facility contains an inactive zero-flow compressor or pump whose equipment duty is non-finite.

## Cause

`ProcessSystem.getPower(...)` aggregates all compressor and pump duties. A non-finite duty from one inactive train can make the total non-finite even while the active oil, export-gas, and injection trains consume valid power. That propagated into annual MWh and caused the integrated gas-injection lifecycle regression to fail.

## Change

- keep the normal process-wide power result whenever it is finite
- if the aggregate is non-finite, sum the finite compressor and pump duties across the supplied `ProcessSystem` or every area of a supplied `ProcessModel`
- emit a warning with the recovered total and unit
- preserve the stricter invalid-compression check for active pressure-raising compressors

## Validation

The existing `NorwegianOilFieldLifecycleTest#gasInjectionCaseRunsFromReservoirToEconomics` regression requires positive lifecycle energy and exercises the exact full reservoir-to-export case. GitHub CI is the authoritative runtime validation because the local sandbox could not download Maven dependencies.

This is a focused follow-up to merged PR #2502.