### PR TITLE
Add finite-rate pipeline evaporation and gas dissolution model

### DIFF
--- a/docs/fluidmechanics/EvaporationDissolutionTutorial.md
+++ b/docs/fluidmechanics/EvaporationDissolutionTutorial.md
@@ -199,6 +199,12 @@ thermodynamic and transport inputs. `PipelineEvaporationStudy` supplies those co
 
 ### 3.2 Java Implementation
 
+> **Important:** hydrodynamic gas fraction or liquid holdup is not an injected-gas inventory. It cannot be used to
+> calculate percent dissolved or a dissolution completion distance. The general two-fluid example below is useful when
+> pressure drop and holdup are required, but use
+> [`PipelineDissolutionStudy`](PipelineLiquidEvaporation#gas-dissolution-example) for a conservative tracked-inventory
+> completion distance, bubble slip, and a defined incomplete result when gas remains.
+
 ```java
 import neqsim.fluidmechanics.flowsystem.twophaseflowsystem.twophasepipeflowsystem.TwoPhasePipeFlowSystem;
 import neqsim.fluidmechanics.flowsolver.twophaseflowsolver.twophasepipeflowsolver.TwoPhaseFixedStaggeredGridSolver.MassTransferMode;
@@ -274,69 +280,35 @@ public class GasDissolutionExample {
                 position, gasFraction, liquidHoldup[i], pressure[i]);
         }
         
-        // Calculate dissolution progress
-        double inletGasFraction = 1.0 - liquidHoldup[0];
-        double outletGasFraction = 1.0 - liquidHoldup[numNodes - 1];
-        double dissolutionPercent = (inletGasFraction - outletGasFraction) / inletGasFraction * 100;
-        
-        System.out.printf("%nDissolution: %.1f%% of gas dissolved%n", dissolutionPercent);
-        
         // Get mass transfer rate
         double massTransferRate = pipe.getTotalMassTransferRate(0);  // methane (component 0)
         System.out.printf("Methane mass transfer rate: %.4f mol/s%n", massTransferRate);
         System.out.println("(Positive = dissolution into liquid)");
-        
-        // Find complete dissolution point
-        for (int i = 0; i < numNodes; i++) {
-            double gasFrac = 1.0 - liquidHoldup[i];
-            if (gasFrac < 0.001) {  // Less than 0.1% gas remaining
-                double distance = i * pipeLength / (numNodes - 1);
-                System.out.printf("Complete dissolution at: %.1f m%n", distance);
-                break;
-            }
-        }
+
+        // Do not infer dissolved inventory or completion distance from liquidHoldup.
+        // Use PipelineDissolutionStudy for that calculation.
     }
 }
 ```
 
-### 3.3 Expected Results
+### 3.3 Result interpretation
 
-For this high-pressure dissolution case:
-
-```
-Number of phases: 2
-Inlet gas fraction: 0.028118
-
-=== Methane Dissolution Profile ===
-Position [m]   Gas Fraction   Liquid Holdup   P [bar]
-----------------------------------------------------
-     0.0      0.028118       0.971882        120.00
-    10.0      0.016401       0.983599        119.99
-    20.0      0.008234       0.991766        119.99
-    30.0      0.004156       0.995844        119.99
-    40.0      0.002089       0.997911        119.99
-    50.0      0.001052       0.998948        119.99
-    60.0      0.000529       0.999471        119.98
-    70.0      0.000266       0.999734        119.98
-    80.0      0.000134       0.999866        119.98
-    90.0      0.000067       0.999933        119.98
-   100.0      0.000034       0.999966        119.98
-
-Dissolution: 99.9% of gas dissolved
-Methane mass transfer rate: 0.6537 mol/s
-(Positive = dissolution into liquid)
-Complete dissolution at: 72.3 m
-```
+The two-fluid result reports hydraulic state and local transfer rates. It does not by itself establish what fraction of
+the initially injected gas remains. For `PipelineDissolutionStudy`, inspect `isCompleteDissolution()` and
+`getCompleteDissolutionDistance()`. When completion is not reached, the distance is `NaN`, the profile extends to the
+configured pipe outlet, and `getRemainingTrackedPhaseFraction()` reports the remaining injected-gas mass fraction.
 
 ### 3.4 Key Observations
 
 1. **High pressure is critical**: At 120 bar, methane has high solubility in n-decane. At 10 bar, dissolution would be much slower.
 
-2. **Exponential approach to saturation**: The dissolution rate slows as the liquid approaches saturation
+2. **Approach to saturation**: The dissolution rate slows as the liquid approaches saturation; complete dissolution may
+   be thermodynamically impossible for the specified liquid inventory and local conditions.
 
 3. **Bubble flow provides large area**: Small bubbles have high surface area per volume, accelerating mass transfer
 
-4. **Sign convention**: Positive mass transfer rate = transfer TO liquid phase
+4. **Sign convention**: Positive mass transfer rate = transfer TO liquid phase. Completion is nevertheless based on the
+   tracked injected-gas inventory, not on the sign of a total flux or on holdup.
 
 ---
 

--- a/docs/fluidmechanics/EvaporationDissolutionTutorial.md
+++ b/docs/fluidmechanics/EvaporationDissolutionTutorial.md
@@ -73,6 +73,11 @@ When one phase is nearly depleted (e.g., last liquid droplets evaporating), nume
 
 ## 2. Complete Liquid Evaporation
 
+> **Completion-distance calculations:** use the dedicated
+> [finite-rate pipeline liquid evaporation model](PipelineLiquidEvaporation). Hydrodynamic liquid holdup is not a
+> remaining-liquid inventory and must not be used to calculate percent evaporated or a completion distance. The older
+> two-fluid example below is retained only to illustrate general non-equilibrium pipe setup.
+
 ### 2.1 Scenario: Water Droplets in Dry Gas
 
 **Physical situation:** Small water droplets carried in a hot, dry methane gas stream. The droplets evaporate as they travel through the pipeline.
@@ -156,48 +161,21 @@ public class WaterEvaporationExample {
                 position, liquidHoldup[i], 1.0 - liquidHoldup[i], temperature[i]);
         }
         
-        // Calculate evaporation progress
-        double inletHoldup = liquidHoldup[0];
-        double outletHoldup = liquidHoldup[numNodes - 1];
-        double evaporationPercent = (inletHoldup - outletHoldup) / inletHoldup * 100;
-        
-        System.out.printf("%nEvaporation: %.1f%% of liquid evaporated%n", evaporationPercent);
-        
-        // Find complete evaporation point
-        for (int i = 0; i < numNodes; i++) {
-            if (liquidHoldup[i] < 1e-6) {
-                double distance = i * pipeLength / (numNodes - 1);
-                System.out.printf("Complete evaporation at: %.1f m%n", distance);
-                break;
-            }
-        }
+        // Holdup is a hydrodynamic result. Do not infer evaporated inventory from it.
+        // Use PipelineEvaporationStudy when the required output is completion distance.
     }
 }
 ```
 
-### 2.3 Expected Results
+### 2.3 Interpreting Results
 
-For this configuration, typical output:
-
-```
-=== Water Evaporation Profile ===
-Position [m]   Liquid Holdup   Gas Fraction   T [K]
---------------------------------------------------
-     0.0      0.000015        0.999985       350.0
-     5.0      0.000012        0.999988       350.0
-    10.0      0.000008        0.999992       350.0
-    15.0      0.000004        0.999996       350.0
-    20.0      0.000001        0.999999       350.0
-    25.0      0.000000        1.000000       350.0
-    ...
-
-Evaporation: 96.5% of liquid evaporated
-Complete evaporation at: 22.5 m
-```
+No fixed completion distance is asserted for this illustrative two-fluid setup. A defensible result requires explicit
+droplet or film area, component inventory tracking, coupled heat transfer, numerical refinement, and validation of the
+thermodynamic and transport inputs. `PipelineEvaporationStudy` supplies those completion-distance-specific elements.
 
 ### 2.4 Key Observations
 
-1. **Exponential decay**: Liquid holdup decreases exponentially (not linearly) because the driving force decreases as the gas becomes more saturated
+1. **Inventory, not holdup**: component flow inventories determine percent evaporated; holdup is a hydraulic state
 
 2. **Temperature effect**: At constant temperature (isothermal case), evaporation is driven purely by concentration difference
 

--- a/docs/fluidmechanics/MASS_TRANSFER_MODEL_IMPROVEMENTS.md
+++ b/docs/fluidmechanics/MASS_TRANSFER_MODEL_IMPROVEMENTS.md
@@ -9,12 +9,31 @@ description: This document provides a technical review of NeqSim's evaporation a
 
 This document provides a technical review of NeqSim's evaporation and dissolution model, identifying specific areas for improvement in accuracy, stability, and usability.
 
-**STATUS: IMPLEMENTED** - All recommendations in this document have been implemented as of the current version. See the Implementation Status section at the end of this document.
+**STATUS:** Core Maxwell-Stefan, transfer-correlation, configuration, and phase-depletion safeguards are implemented.
+Items still marked as recommendations below, especially external validation and uncertainty quantification, are not
+claimed as complete.
 
 **Related Documentation:**
 - [MassTransferAPI.md](MassTransferAPI) - **Complete API reference with method signatures, parameters, and examples**
 - [EvaporationDissolutionTutorial.md](EvaporationDissolutionTutorial) - Practical tutorial with worked examples
 - [InterphaseHeatMassTransfer.md](InterphaseHeatMassTransfer) - Theory background
+- [PipelineLiquidEvaporation.md](PipelineLiquidEvaporation) - Dedicated droplet/film completion-distance model and
+  validation limits
+
+## Completion-Distance Audit
+
+The general two-fluid pipeline solver is useful when both phases persist and hydraulic holdup, pressure, and momentum
+coupling are required. It is not a reliable completion-distance metric to interpret a small calculated liquid holdup as
+the remaining fraction of injected material. Holdup also changes with density, velocity, and flow regime.
+
+`PipelineEvaporationStudy` is the recommended path when the engineering question is "how many metres until the injected
+liquid has evaporated?" It retains the Krishna Maxwell-Stefan boundary but adds explicit injected-inventory tracking,
+droplet or wall-film area evolution, conservative component updates, separate phase energy balances, adaptive axial
+steps, and an interpolated mass-based completion criterion. The model reports conservation residuals and warnings.
+
+The automated evidence is equation-level correlation checks, positivity and conservation checks, and short axial
+droplet/film calculations. Absolute completion-distance validation against spray or wetted-wall experiments remains a
+project responsibility; see the validation ladder and Daïf et al. target case in the dedicated documentation.
 
 ## Current Implementation Overview
 
@@ -435,4 +454,3 @@ String report = solver.validateMassTransferAgainstLiterature();
 6. Lamont, J.C., & Scott, D.S. (1970). An eddy cell model of mass transfer into the surface of a turbulent liquid. *AIChE Journal*, 16(4), 513-519.
 
 7. Springer, T.G., & Pigford, R.L. (1970). Influence of surface turbulence and surfactants on gas transport through liquid interfaces. *Industrial & Engineering Chemistry Fundamentals*, 9(3), 458-465.
-

--- a/docs/fluidmechanics/PipelineLiquidEvaporation.md
+++ b/docs/fluidmechanics/PipelineLiquidEvaporation.md
@@ -1,25 +1,28 @@
 ---
-title: "Finite-rate Liquid Evaporation in Gas Pipelines"
-description: "Maxwell-Stefan mass transfer, heat transfer, droplets, films, completion distance, and validation limits."
+title: "Finite-rate Evaporation and Gas Dissolution in Pipelines"
+description: "Maxwell-Stefan mass transfer, heat transfer, droplets, bubbles, films, slip, and completion distance."
 ---
 
-# Finite-rate Liquid Evaporation in Gas Pipelines
+# Finite-rate Evaporation and Gas Dissolution in Pipelines
 
 ## What this model answers
 
 `PipelineEvaporationStudy` estimates the axial distance needed for an injected hydrocarbon liquid to fall below a
-specified remaining mass fraction. It supports two prescribed liquid geometries:
+specified remaining mass fraction. `PipelineDissolutionStudy` applies the same finite-rate calculation to injected gas
+bubbles dissolving into oil or water. The supported geometries are:
 
 - spherical droplets represented by an evolving Sauter mean diameter, $d_{32}$; and
-- a wall film represented by an evolving thickness and wetted-perimeter fraction.
+- a wall film represented by an evolving thickness and wetted-perimeter fraction; and
+- spherical gas bubbles represented by an evolving Sauter mean diameter.
 
-The completion criterion is the remaining fraction of the *initially injected liquid inventory*. Liquid holdup is not
-used as an evaporation measure. Holdup can change because velocities, densities, or the flow regime change even if no
-component evaporates.
+The completion criterion is the remaining fraction of the *initially injected dispersed-phase inventory*: liquid for
+evaporation and gas for dissolution. Hydrodynamic holdup or void fraction is never used as a transfer measure. If the
+continuous liquid reaches thermodynamic saturation before the injected gas meets the criterion, the result is
+incomplete and reports the full profile to the pipe outlet; the solver does not force phase removal.
 
 ## Model formulation
 
-At each accepted axial position the model creates a local NeqSim droplet or annular flow node and solves the
+At each accepted axial position the model creates a local NeqSim droplet, bubble, or annular flow node and solves the
 `KrishnaStandartFilmModel` boundary. This gives:
 
 1. EOS fugacity equality at the gas-liquid interface;
@@ -28,9 +31,9 @@ At each accepted axial position the model creates a local NeqSim droplet or annu
 4. thermodynamic-factor and finite-flux corrections; and
 5. simultaneous interphase heat and component fluxes.
 
-Droplet transfer coefficients use Ranz-Marshall externally and Kronig-Brink internally. The optional
+Droplet and bubble transfer coefficients use Ranz-Marshall in the continuous phase and Kronig-Brink internally. The optional
 Abramzon-Sirignano correction uses the aggregate injected-vapor *mass fraction* to calculate the Spalding mass-transfer
-number. Film calculations use the annular-flow transfer correlations.
+number and is applied only to evaporating liquid droplets. Film calculations use the annular-flow transfer correlations.
 
 The sign convention is positive from gas to liquid. Therefore an evaporating liquid component normally has a negative
 flux.
@@ -51,11 +54,30 @@ For a wall film,
 \delta=\delta_0\frac{\dot V_L}{\dot V_{L,0}}.
 \]
 
+For bubbles, the equivalent conserved-population relation is
+
+\[
+\frac{A_i}{L}=\frac{6\dot V_G}{u_G d_{32}}, \qquad
+d_{32}=d_{32,0}\left(\frac{\dot V_G}{\dot V_{G,0}}\right)^{1/3}.
+\]
+
 The geometry follows total liquid-phase volume, so gas absorbed into the liquid can grow a droplet or film even while
 the tracked injected material evaporates. Completion still uses only the mass provenance of the initial liquid phase.
 
 These relations do not model breakup, coalescence, entrainment, deposition, or dry-patch formation. Supply a realistic
 inlet $d_{32}$, film thickness, and wetted fraction, and perform sensitivity cases.
+
+### Slip and residence time
+
+`USER_SPECIFIED` retains separate user-supplied actual gas and liquid velocities. `TERMINAL_VELOCITY` recalculates a
+local Schiller-Naumann force balance as particle diameter and phase properties change. The terminal speed is used in the
+Ranz-Marshall particle Reynolds number. Its gravity-aligned component is projected onto the pipe axis, so it also
+changes dispersed-phase residence time and area per pipe length. Pipe inclination is in radians and positive uphill.
+For a horizontal pipe, terminal rise or settling is transverse: it enhances transfer but does not create an axial
+gravity-slip component.
+
+The force-balance option represents dilute spherical particles. Use prescribed velocities or an external hydraulic
+profile for dense dispersions, churn/slug flow, annular films, and cases governed by pressure-gradient momentum closure.
 
 ### Conservative axial integration
 
@@ -67,7 +89,7 @@ The component update over a step is
 
 with equal and opposite changes in the two phases. Donor inventories are bounded so component flows cannot become
 negative. Separate gas and liquid enthalpy targets use the boundary heat fluxes; optional wall heat is added to the gas
-for droplets and to the liquid for a wall film. The step is halved until both the maximum donor depletion and estimated
+for droplets and to the liquid for bubbles or a wall film. The step is halved until both the maximum donor depletion and estimated
 temperature change meet their configured limits.
 
 No TP flash is run between steps. A TP flash would impose instantaneous phase equilibrium and erase the finite-rate
@@ -132,6 +154,55 @@ settings.setInitialFilmThickness(0.50e-3);
 settings.setWettedPerimeterFraction(1.0);
 ```
 
+## Gas dissolution example
+
+Use an explicit injected gas in phase 0 and an undersaturated continuous liquid in phase 1. For water-rich systems,
+prefer CPA or electrolyte CPA with validated gas-water interaction parameters.
+
+```java
+import neqsim.process.equipment.pipeline.evaporation.DispersedPhaseSlipModel;
+import neqsim.process.equipment.pipeline.evaporation.EvaporationProfilePoint;
+import neqsim.process.equipment.pipeline.evaporation.PipelineDissolutionResult;
+import neqsim.process.equipment.pipeline.evaporation.PipelineDissolutionStudy;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+
+SystemInterface inlet = new SystemSrkCPAstatoil(295.15, 50.0);
+inlet.addComponent("CO2", 0.10, 0);   // injected gas flow, mol/s
+inlet.addComponent("water", 20.0, 1); // continuous liquid flow, mol/s
+inlet.createDatabase(true);
+inlet.setMixingRule(10);
+inlet.setPhaseType(0, PhaseType.GAS);
+inlet.setPhaseType(1, PhaseType.AQUEOUS);
+inlet.initBeta();
+inlet.init_x_y();
+inlet.init(3);
+inlet.initPhysicalProperties();
+inlet.setPhaseType(1, PhaseType.AQUEOUS);
+inlet.getPhase(1).setType(PhaseType.AQUEOUS);
+
+PipelineEvaporationConfig settings = new PipelineEvaporationConfig();
+settings.setPipeLength(100.0);
+settings.setPipeDiameter(0.10);
+settings.setLiquidVelocity(0.30);
+settings.setGasVelocity(0.50);
+settings.setInitialBubbleDiameter(1.0e-3);
+settings.setSlipModel(DispersedPhaseSlipModel.TERMINAL_VELOCITY);
+settings.setPipeInclinationAngle(Math.toRadians(5.0));
+settings.setCompletionFraction(1.0e-4); // 99.99% of injected gas dissolved
+
+PipelineDissolutionResult result = new PipelineDissolutionStudy(inlet, settings).run();
+if (result.isCompleteDissolution()) {
+  System.out.println("Dissolution distance [m]: " + result.getCompleteDissolutionDistance());
+} else {
+  EvaporationProfilePoint outlet = result.getProfile().get(result.getProfile().size() - 1);
+  System.out.println("Injected gas remaining at outlet: " + outlet.getRemainingTrackedPhaseFraction());
+}
+```
+
+“Complete dissolution” means the configured tracked-gas mass threshold was reached. “Solubility” is the equilibrium
+capacity predicted by the selected thermodynamic model. A finite gas phase can legitimately remain because the pipe is
+too short, transfer is too slow, the liquid saturates, or local conditions favor reverse transfer.
+
 Run at least coarse and fine numerical cases. A practical grid check is to halve
 `maximumDonorFractionPerStep` and `maximumTemperatureChangePerStep`; the reported completion distance should be stable
 for the intended engineering decision.
@@ -145,8 +216,10 @@ for the intended engineering decision.
 | Interface equilibrium | EOS fugacity equality | EOS and binary-interaction parameters; validate VLE first |
 | Multicomponent diffusion | Krishna Maxwell-Stefan matrices with thermodynamic and finite-flux corrections | Binary diffusivity model and conditioning at trace composition |
 | Droplet coefficients | Equation-level Ranz-Marshall, Kronig-Brink, and Abramzon-Sirignano tests | Isolated-sphere assumptions; no breakup or coalescence |
+| Bubble coefficients | Ranz-Marshall/Kronig-Brink with explicit local relative speed | Spherical dilute-bubble assumption; no swarm or contamination correction |
+| Slip closure | Schiller-Naumann force balance and separate axial/total relative velocity | Not a replacement for coupled momentum equations in dense or regime-transition flow |
 | Film coefficients | Existing annular-flow correlations | Waves, entrainment, dry patches, and wetted perimeter |
-| Axial solver | Adaptive donor/temperature limits and inventory positivity | Prescribed velocities; no momentum or pressure-drop solution |
+| Axial solver | Adaptive donor/temperature limits and inventory positivity | No pressure-drop or full momentum-equation solution |
 
 The correlation layer is traceable to Ranz and Marshall (1952) and Abramzon and Sirignano (1989). A useful published
 multicomponent validation target is the forced-convection n-heptane/n-decane droplet experiment of Daïf et al. (1998):
@@ -171,13 +244,14 @@ Recommended project validation is:
   multicomponent film coupling.
 - A process simulator equilibrium flash answers whether liquid *can* remain at an equilibrium outlet state. It does not
   determine the finite distance required to reach that state.
-- A full NeqSim two-fluid pipe solver is appropriate when pressure drop and hydrodynamic holdup are the primary coupled
-  problem. Near complete phase depletion, use this dedicated inventory model for the completion distance and couple it
-  piecewise to a hydraulic pressure/velocity profile.
+- A full NeqSim two-fluid pipe solver is appropriate when pressure drop, flow-regime transitions, and hydrodynamic
+  holdup are the primary coupled problem. Near complete phase depletion, use this dedicated inventory model for the
+  completion distance and couple it piecewise to a hydraulic pressure/velocity profile.
 
 ## References
 
 - W. E. Ranz and W. R. Marshall, *Evaporation from Drops*, Chemical Engineering Progress 48 (1952), parts I and II.
+- L. Schiller and A. Naumann, *A Drag Coefficient Correlation*, VDI Zeitung 77 (1935), 318-320.
 - B. Abramzon and W. A. Sirignano, *Droplet vaporization model for spray combustion calculations*, International
   Journal of Heat and Mass Transfer 32 (1989), 1605-1618,
   [doi:10.1016/0017-9310(89)90043-4](https://doi.org/10.1016/0017-9310(89)90043-4).

--- a/docs/fluidmechanics/PipelineLiquidEvaporation.md
+++ b/docs/fluidmechanics/PipelineLiquidEvaporation.md
@@ -10,7 +10,7 @@ description: "Maxwell-Stefan mass transfer, heat transfer, droplets, films, comp
 `PipelineEvaporationStudy` estimates the axial distance needed for an injected hydrocarbon liquid to fall below a
 specified remaining mass fraction. It supports two prescribed liquid geometries:
 
-- spherical droplets represented by an evolving Sauter mean diameter, (d_{32}); and
+- spherical droplets represented by an evolving Sauter mean diameter, $d_{32}$; and
 - a wall film represented by an evolving thickness and wetted-perimeter fraction.
 
 The completion criterion is the remaining fraction of the *initially injected liquid inventory*. Liquid holdup is not
@@ -55,7 +55,7 @@ The geometry follows total liquid-phase volume, so gas absorbed into the liquid 
 the tracked injected material evaporates. Completion still uses only the mass provenance of the initial liquid phase.
 
 These relations do not model breakup, coalescence, entrainment, deposition, or dry-patch formation. Supply a realistic
-inlet (d_{32}), film thickness, and wetted fraction, and perform sensitivity cases.
+inlet $d_{32}$, film thickness, and wetted fraction, and perform sensitivity cases.
 
 ### Conservative axial integration
 
@@ -159,7 +159,7 @@ Recommended project validation is:
 
 1. reproduce mixture VLE and transport properties independently;
 2. compare a single-droplet time history with Daïf et al. or project-specific spray data;
-3. measure or bound (d_{32}), relative velocity, film coverage, and wall heat transfer;
+3. measure or bound $d_{32}$, relative velocity, film coverage, and wall heat transfer;
 4. compare outlet liquid carryover at two or more pipeline lengths; and
 5. calibrate geometry parameters on one case and validate on another.
 

--- a/docs/fluidmechanics/PipelineLiquidEvaporation.md
+++ b/docs/fluidmechanics/PipelineLiquidEvaporation.md
@@ -1,0 +1,190 @@
+---
+title: "Finite-rate Liquid Evaporation in Gas Pipelines"
+description: "Maxwell-Stefan mass transfer, heat transfer, droplets, films, completion distance, and validation limits."
+---
+
+# Finite-rate Liquid Evaporation in Gas Pipelines
+
+## What this model answers
+
+`PipelineEvaporationStudy` estimates the axial distance needed for an injected hydrocarbon liquid to fall below a
+specified remaining mass fraction. It supports two prescribed liquid geometries:
+
+- spherical droplets represented by an evolving Sauter mean diameter, (d_{32}); and
+- a wall film represented by an evolving thickness and wetted-perimeter fraction.
+
+The completion criterion is the remaining fraction of the *initially injected liquid inventory*. Liquid holdup is not
+used as an evaporation measure. Holdup can change because velocities, densities, or the flow regime change even if no
+component evaporates.
+
+## Model formulation
+
+At each accepted axial position the model creates a local NeqSim droplet or annular flow node and solves the
+`KrishnaStandartFilmModel` boundary. This gives:
+
+1. EOS fugacity equality at the gas-liquid interface;
+2. binary diffusivities from NeqSim physical-property models;
+3. coupled Maxwell-Stefan resistance matrices in gas and liquid;
+4. thermodynamic-factor and finite-flux corrections; and
+5. simultaneous interphase heat and component fluxes.
+
+Droplet transfer coefficients use Ranz-Marshall externally and Kronig-Brink internally. The optional
+Abramzon-Sirignano correction uses the aggregate injected-vapor *mass fraction* to calculate the Spalding mass-transfer
+number. Film calculations use the annular-flow transfer correlations.
+
+The sign convention is positive from gas to liquid. Therefore an evaporating liquid component normally has a negative
+flux.
+
+### Interfacial area
+
+For droplets, conservation of droplet number gives
+
+\[
+\frac{A_i}{L}=\frac{6\dot V_L}{u_L d_{32}}, \qquad
+d_{32}=d_{32,0}\left(\frac{\dot V_L}{\dot V_{L,0}}\right)^{1/3}.
+\]
+
+For a wall film,
+
+\[
+\frac{A_i}{L}=f_w\pi(D-2\delta), \qquad
+\delta=\delta_0\frac{\dot V_L}{\dot V_{L,0}}.
+\]
+
+The geometry follows total liquid-phase volume, so gas absorbed into the liquid can grow a droplet or film even while
+the tracked injected material evaporates. Completion still uses only the mass provenance of the initial liquid phase.
+
+These relations do not model breakup, coalescence, entrainment, deposition, or dry-patch formation. Supply a realistic
+inlet (d_{32}), film thickness, and wetted fraction, and perform sensitivity cases.
+
+### Conservative axial integration
+
+The component update over a step is
+
+\[
+\Delta\dot n_i=N_i A_i,
+\]
+
+with equal and opposite changes in the two phases. Donor inventories are bounded so component flows cannot become
+negative. Separate gas and liquid enthalpy targets use the boundary heat fluxes; optional wall heat is added to the gas
+for droplets and to the liquid for a wall film. The step is halved until both the maximum donor depletion and estimated
+temperature change meet their configured limits.
+
+No TP flash is run between steps. A TP flash would impose instantaneous phase equilibrium and erase the finite-rate
+question being solved.
+
+## Java example
+
+```java
+import neqsim.process.equipment.pipeline.evaporation.LiquidDistribution;
+import neqsim.process.equipment.pipeline.evaporation.PipelineEvaporationConfig;
+import neqsim.process.equipment.pipeline.evaporation.PipelineEvaporationResult;
+import neqsim.process.equipment.pipeline.evaporation.PipelineEvaporationStudy;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+SystemInterface inlet = new SystemSrkEos(335.15, 10.0);
+inlet.addComponent("methane", 500.0, "kg/hr", 0);
+inlet.addComponent("ethane", 20.0, "kg/hr", 0);
+inlet.addComponent("n-heptane", 1.0, "kg/hr", 1);
+inlet.addComponent("nC10", 1.0, "kg/hr", 1);
+inlet.createDatabase(true);
+inlet.setMixingRule(2);
+inlet.setPhaseType(0, PhaseType.GAS);
+inlet.setPhaseType(1, PhaseType.OIL);
+inlet.getPhase(0).setTemperature(335.15);
+inlet.getPhase(1).setTemperature(295.15);
+inlet.initBeta();
+inlet.init_x_y();
+inlet.init(3);
+inlet.initPhysicalProperties();
+
+PipelineEvaporationConfig settings = new PipelineEvaporationConfig();
+settings.setLiquidDistribution(LiquidDistribution.DROPLETS);
+settings.setPipeLength(100.0);
+settings.setPipeDiameter(0.20);
+settings.setGasVelocity(10.0);          // actual phase velocity, m/s
+settings.setLiquidVelocity(0.5);        // droplet velocity, m/s
+settings.setInitialDropletDiameter(200.0e-6);
+settings.setOverallWallHeatTransferCoefficient(8.0); // W/(m2 K)
+settings.setAmbientTemperature(323.15);
+settings.setCompletionFraction(1.0e-4); // 99.99% of injected mass evaporated
+
+PipelineEvaporationResult result = new PipelineEvaporationStudy(inlet, settings).run();
+if (result.isCompleteEvaporation()) {
+  System.out.println("Completion distance [m]: " + result.getCompleteEvaporationDistance());
+} else {
+  System.out.println("Remaining fraction: "
+      + result.getProfile().get(result.getProfile().size() - 1)
+          .getRemainingInjectedLiquidFraction());
+}
+System.out.println("Maximum component balance error [mol/s]: "
+    + result.getMaximumComponentMolarBalanceError());
+System.out.println("Relative energy balance error: " + result.getRelativeEnergyBalanceError());
+```
+
+For a film, change the distribution and specify the geometry:
+
+```java
+settings.setLiquidDistribution(LiquidDistribution.WALL_FILM);
+settings.setInitialFilmThickness(0.50e-3);
+settings.setWettedPerimeterFraction(1.0);
+```
+
+Run at least coarse and fine numerical cases. A practical grid check is to halve
+`maximumDonorFractionPerStep` and `maximumTemperatureChangePerStep`; the reported completion distance should be stable
+for the intended engineering decision.
+
+## Accuracy and validation status
+
+| Layer | Implemented check | Main uncertainty or limitation |
+|---|---|---|
+| Component conservation | Equal-and-opposite inventory update; reported molar residual | Floating-point tolerance |
+| Energy conservation | Separate phase enthalpy targets; reported overall residual | Accuracy of enthalpy and heat-transfer closure |
+| Interface equilibrium | EOS fugacity equality | EOS and binary-interaction parameters; validate VLE first |
+| Multicomponent diffusion | Krishna Maxwell-Stefan matrices with thermodynamic and finite-flux corrections | Binary diffusivity model and conditioning at trace composition |
+| Droplet coefficients | Equation-level Ranz-Marshall, Kronig-Brink, and Abramzon-Sirignano tests | Isolated-sphere assumptions; no breakup or coalescence |
+| Film coefficients | Existing annular-flow correlations | Waves, entrainment, dry patches, and wetted perimeter |
+| Axial solver | Adaptive donor/temperature limits and inventory positivity | Prescribed velocities; no momentum or pressure-drop solution |
+
+The correlation layer is traceable to Ranz and Marshall (1952) and Abramzon and Sirignano (1989). A useful published
+multicomponent validation target is the forced-convection n-heptane/n-decane droplet experiment of Daïf et al. (1998):
+21.3 mass-% n-heptane, initial radius 743 µm, initial droplet temperature 294 K, air at 345 K and 0.1 MPa, and 3.1 m/s
+relative velocity. The paper reports radius and temperature histories. Those experimental points are not distributed
+with NeqSim, so the present automated suite validates the equations, conservation, bounds, and short axial integration,
+but it does **not** claim an absolute completion-distance accuracy against that experiment.
+
+Recommended project validation is:
+
+1. reproduce mixture VLE and transport properties independently;
+2. compare a single-droplet time history with Daïf et al. or project-specific spray data;
+3. measure or bound (d_{32}), relative velocity, film coverage, and wall heat transfer;
+4. compare outlet liquid carryover at two or more pipeline lengths; and
+5. calibrate geometry parameters on one case and validate on another.
+
+## Relation to other tools
+
+- OpenFOAM Lagrangian spray models resolve droplet trajectories, breakup, and local CFD fields and include
+  liquid-evaporation/boiling submodels. They are appropriate when spatial mixing and spray dynamics determine the answer.
+  This NeqSim model is a faster one-dimensional engineering calculation with rigorous EOS equilibrium and
+  multicomponent film coupling.
+- A process simulator equilibrium flash answers whether liquid *can* remain at an equilibrium outlet state. It does not
+  determine the finite distance required to reach that state.
+- A full NeqSim two-fluid pipe solver is appropriate when pressure drop and hydrodynamic holdup are the primary coupled
+  problem. Near complete phase depletion, use this dedicated inventory model for the completion distance and couple it
+  piecewise to a hydraulic pressure/velocity profile.
+
+## References
+
+- W. E. Ranz and W. R. Marshall, *Evaporation from Drops*, Chemical Engineering Progress 48 (1952), parts I and II.
+- B. Abramzon and W. A. Sirignano, *Droplet vaporization model for spray combustion calculations*, International
+  Journal of Heat and Mass Transfer 32 (1989), 1605-1618,
+  [doi:10.1016/0017-9310(89)90043-4](https://doi.org/10.1016/0017-9310(89)90043-4).
+- A. Daïf et al., *Comparison of multicomponent fuel droplet vaporization experiments in forced convection with the
+  Sirignano model*, Experimental Thermal and Fluid Science 18 (1998), 282-290,
+  [doi:10.1016/S0894-1777(98)10035-3](https://doi.org/10.1016/S0894-1777(98)10035-3).
+- E. Solbraa, *Equilibrium and Non-Equilibrium Thermodynamics of Natural Gas Processing*, NTNU (2002),
+  [hdl:11250/231326](https://hdl.handle.net/11250/231326).
+- OpenFOAM Foundation, `LiquidEvaporationBoil` source documentation,
+  [cpp.openfoam.org](https://cpp.openfoam.org/v4/LiquidEvaporationBoil_8C_source.html).

--- a/docs/fluidmechanics/README.md
+++ b/docs/fluidmechanics/README.md
@@ -28,6 +28,7 @@ The `fluidmechanics` package provides models for pipeline flow, pressure drop ca
 |----------|-------------|
 | [MassTransferAPI.md](MassTransferAPI) | **Complete API documentation** for mass transfer with methods, parameters, and examples |
 | [EvaporationDissolutionTutorial.md](EvaporationDissolutionTutorial) | **Practical tutorial** for liquid evaporation and gas dissolution with worked examples |
+| [PipelineLiquidEvaporation.md](PipelineLiquidEvaporation) | Finite-rate droplet/film evaporation distance with Maxwell-Stefan mass transfer and coupled heat transfer |
 | [MASS_TRANSFER_MODEL_IMPROVEMENTS.md](MASS_TRANSFER_MODEL_IMPROVEMENTS) | **Technical review** of mass transfer model with improvement recommendations |
 | [InterphaseHeatMassTransfer.md](InterphaseHeatMassTransfer) | Complete theory for interphase mass and heat transfer |
 | [droplet_flow_correlations.md](droplet_flow_correlations) | Ranz-Marshall, Kronig-Brink, Abramzon-Sirignano for droplet/bubble flow |

--- a/src/main/java/neqsim/fluidmechanics/flownode/DispersedPhaseSlipCalculator.java
+++ b/src/main/java/neqsim/fluidmechanics/flownode/DispersedPhaseSlipCalculator.java
@@ -1,0 +1,52 @@
+package neqsim.fluidmechanics.flownode;
+
+/** Force-balance slip correlation for spherical bubbles and droplets. */
+public final class DispersedPhaseSlipCalculator {
+  private static final double GRAVITY = 9.80665;
+
+  private DispersedPhaseSlipCalculator() {
+  }
+
+  /**
+   * Calculate the magnitude of the terminal particle velocity relative to its continuous phase.
+   *
+   * <p>
+   * The iterative Schiller-Naumann drag correlation is used: {@code Cd=24/Re*(1+0.15*Re^0.687)} below Re=1000 and
+   * {@code Cd=0.44} above it. The result is a speed; density ordering is handled separately when projecting buoyancy or
+   * settling onto the pipe axis.
+   * </p>
+   *
+   * @param diameter particle Sauter mean diameter in m
+   * @param continuousDensity continuous-phase density in kg/m3
+   * @param dispersedDensity dispersed-phase density in kg/m3
+   * @param continuousViscosity continuous-phase dynamic viscosity in Pa s
+   * @return terminal relative speed in m/s
+   */
+  public static double terminalVelocityMagnitude(double diameter, double continuousDensity, double dispersedDensity,
+      double continuousViscosity) {
+    if (!(diameter > 0.0) || !(continuousDensity > 0.0) || !(continuousViscosity > 0.0) || !Double.isFinite(diameter)
+        || !Double.isFinite(continuousDensity) || !Double.isFinite(dispersedDensity)
+        || !Double.isFinite(continuousViscosity)) {
+      return 0.0;
+    }
+    double densityDifference = Math.abs(dispersedDensity - continuousDensity);
+    if (densityDifference < 1.0e-12) {
+      return 0.0;
+    }
+
+    double velocity = diameter * diameter * densityDifference * GRAVITY / (18.0 * continuousViscosity);
+    for (int iteration = 0; iteration < 50; iteration++) {
+      double reynoldsNumber = continuousDensity * Math.max(velocity, 1.0e-30) * diameter / continuousViscosity;
+      double dragCoefficient = reynoldsNumber < 1000.0
+          ? 24.0 / reynoldsNumber * (1.0 + 0.15 * Math.pow(reynoldsNumber, 0.687))
+          : 0.44;
+      double updatedVelocity = Math
+          .sqrt(4.0 * GRAVITY * diameter * densityDifference / (3.0 * dragCoefficient * continuousDensity));
+      if (Math.abs(updatedVelocity - velocity) <= 1.0e-8 * Math.max(1.0, updatedVelocity)) {
+        return updatedVelocity;
+      }
+      velocity = 0.5 * (velocity + updatedVelocity);
+    }
+    return velocity;
+  }
+}

--- a/src/main/java/neqsim/fluidmechanics/flownode/fluidboundary/interphasetransportcoefficient/interphasetwophase/interphasepipeflow/InterphaseDropletFlow.java
+++ b/src/main/java/neqsim/fluidmechanics/flownode/fluidboundary/interphasetransportcoefficient/interphasetwophase/interphasepipeflow/InterphaseDropletFlow.java
@@ -132,6 +132,16 @@ public class InterphaseDropletFlow extends InterphaseTwoPhasePipeFlow
     return 100.0e-6; // default 100 micron
   }
 
+  /** Return the total particle-relative speed used in transfer correlations. */
+  private double getParticleRelativeVelocity(FlowNodeInterface node) {
+    if (node instanceof DropletFlowNode) {
+      return ((DropletFlowNode) node).getDispersedPhaseRelativeVelocity();
+    } else if (node instanceof BubbleFlowNode) {
+      return ((BubbleFlowNode) node).getDispersedPhaseRelativeVelocity();
+    }
+    return Math.abs(node.getVelocity(0) - node.getVelocity(1));
+  }
+
   /**
    * {@inheritDoc}
    *
@@ -217,11 +227,7 @@ public class InterphaseDropletFlow extends InterphaseTwoPhasePipeFlow
       // Continuous phase: Ranz-Marshall with particle Re
       int continuousPhase = isBubbleFlow ? 1 : 0;
       int dispersedPhase = isBubbleFlow ? 0 : 1;
-      double relativeVelocity = Math.abs(node.getVelocity(continuousPhase) - node.getVelocity(dispersedPhase));
-      double contVelocity = Math.abs(node.getVelocity(continuousPhase));
-      if (relativeVelocity < 0.01 * contVelocity) {
-        relativeVelocity = Math.max(0.1 * contVelocity, 0.01);
-      }
+      double relativeVelocity = getParticleRelativeVelocity(node);
       double nuContinuous = node.getBulkSystem().getPhase(continuousPhase).getPhysicalProperties()
           .getKinematicViscosity();
       if (nuContinuous < 1e-15) {
@@ -299,11 +305,7 @@ public class InterphaseDropletFlow extends InterphaseTwoPhasePipeFlow
       // Continuous phase: Ranz-Marshall with particle Re
       int continuousPhase = isBubbleFlow ? 1 : 0;
       int dispersedPhase = isBubbleFlow ? 0 : 1;
-      double relativeVelocity = Math.abs(node.getVelocity(continuousPhase) - node.getVelocity(dispersedPhase));
-      double contVelocity = Math.abs(node.getVelocity(continuousPhase));
-      if (relativeVelocity < 0.01 * contVelocity) {
-        relativeVelocity = Math.max(0.1 * contVelocity, 0.01);
-      }
+      double relativeVelocity = getParticleRelativeVelocity(node);
 
       double nuContinuous = node.getBulkSystem().getPhase(continuousPhase).getPhysicalProperties()
           .getKinematicViscosity();

--- a/src/main/java/neqsim/fluidmechanics/flownode/twophasenode/twophasepipeflownode/BubbleFlowNode.java
+++ b/src/main/java/neqsim/fluidmechanics/flownode/twophasenode/twophasepipeflownode/BubbleFlowNode.java
@@ -23,6 +23,7 @@ public class BubbleFlowNode extends TwoPhaseFlowNode {
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(BubbleFlowNode.class);
   private double averageBubbleDiameter = 0.001;
+  private double specifiedDispersedPhaseRelativeVelocity = Double.NaN;
 
   /**
    * Constructor for BubbleFlowNode.
@@ -115,7 +116,7 @@ public class BubbleFlowNode extends TwoPhaseFlowNode {
     double surfaceAreaOfBubble = 4.0 * Math.PI * Math.pow(averageBubbleDiameter / 2.0, 2.0);
 
     double numbDropletsPerTime = getBulkSystem().getPhase(0).getVolume("m3") / volumeOfBubble;
-    interphaseContactLength[0] = numbDropletsPerTime * surfaceAreaOfBubble / velocity[0];
+    interphaseContactLength[0] = numbDropletsPerTime * surfaceAreaOfBubble / Math.max(1.0e-12, Math.abs(velocity[0]));
     interphaseContactLength[1] = interphaseContactLength[0];
 
     return wallContactLength[0];
@@ -256,5 +257,27 @@ public class BubbleFlowNode extends TwoPhaseFlowNode {
    */
   public void setAverageBubbleDiameter(double averageBubbleDiameter) {
     this.averageBubbleDiameter = averageBubbleDiameter;
+  }
+
+  /**
+   * Set a particle-relative speed for heat and mass transfer without changing axial phase velocities.
+   *
+   * @param relativeVelocity non-negative relative speed in m/s, or NaN to use the axial velocity difference
+   */
+  public void setSpecifiedDispersedPhaseRelativeVelocity(double relativeVelocity) {
+    if (!Double.isNaN(relativeVelocity) && (!Double.isFinite(relativeVelocity) || relativeVelocity < 0.0)) {
+      throw new IllegalArgumentException("relative velocity must be finite and non-negative, or NaN");
+    }
+    specifiedDispersedPhaseRelativeVelocity = relativeVelocity;
+  }
+
+  /**
+   * Get the relative speed used by dispersed-particle transfer correlations.
+   *
+   * @return specified speed, or the absolute axial gas-liquid velocity difference in m/s
+   */
+  public double getDispersedPhaseRelativeVelocity() {
+    return Double.isFinite(specifiedDispersedPhaseRelativeVelocity) ? specifiedDispersedPhaseRelativeVelocity
+        : Math.abs(getVelocity(0) - getVelocity(1));
   }
 }

--- a/src/main/java/neqsim/fluidmechanics/flownode/twophasenode/twophasepipeflownode/DropletFlowNode.java
+++ b/src/main/java/neqsim/fluidmechanics/flownode/twophasenode/twophasepipeflownode/DropletFlowNode.java
@@ -20,6 +20,7 @@ public class DropletFlowNode extends TwoPhaseFlowNode {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
   private double averageDropletDiameter = 100.0e-6;
+  private double specifiedDispersedPhaseRelativeVelocity = Double.NaN;
 
   /**
    * Constructor for DropletFlowNode.
@@ -111,7 +112,7 @@ public class DropletFlowNode extends TwoPhaseFlowNode {
     double surfaceAreaOfDroplet = 4.0 * Math.PI * Math.pow(averageDropletDiameter / 2.0, 2.0);
 
     double numbDropletsPerTime = getBulkSystem().getPhase(1).getVolume("m3") / volumeOfDroplet;
-    interphaseContactLength[0] = numbDropletsPerTime * surfaceAreaOfDroplet / velocity[0];
+    interphaseContactLength[0] = numbDropletsPerTime * surfaceAreaOfDroplet / Math.max(1.0e-12, Math.abs(velocity[1]));
     interphaseContactLength[1] = interphaseContactLength[0];
 
     return wallContactLength[0];
@@ -351,5 +352,27 @@ public class DropletFlowNode extends TwoPhaseFlowNode {
    */
   public void setAverageDropletDiameter(double averageDropletDiameter) {
     this.averageDropletDiameter = averageDropletDiameter;
+  }
+
+  /**
+   * Set a particle-relative speed for heat and mass transfer without changing axial phase velocities.
+   *
+   * @param relativeVelocity non-negative relative speed in m/s, or NaN to use the axial velocity difference
+   */
+  public void setSpecifiedDispersedPhaseRelativeVelocity(double relativeVelocity) {
+    if (!Double.isNaN(relativeVelocity) && (!Double.isFinite(relativeVelocity) || relativeVelocity < 0.0)) {
+      throw new IllegalArgumentException("relative velocity must be finite and non-negative, or NaN");
+    }
+    specifiedDispersedPhaseRelativeVelocity = relativeVelocity;
+  }
+
+  /**
+   * Get the relative speed used by dispersed-particle transfer correlations.
+   *
+   * @return specified speed, or the absolute axial gas-liquid velocity difference in m/s
+   */
+  public double getDispersedPhaseRelativeVelocity() {
+    return Double.isFinite(specifiedDispersedPhaseRelativeVelocity) ? specifiedDispersedPhaseRelativeVelocity
+        : Math.abs(getVelocity(0) - getVelocity(1));
   }
 }

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/DispersedPhaseSlipModel.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/DispersedPhaseSlipModel.java
@@ -1,0 +1,9 @@
+package neqsim.process.equipment.pipeline.evaporation;
+
+/** Axial-velocity and particle-relative-velocity closure for a dispersed phase. */
+public enum DispersedPhaseSlipModel {
+  /** Use the gas and liquid actual velocities supplied in {@link PipelineEvaporationConfig}. */
+  USER_SPECIFIED,
+  /** Recalculate slip from a local Schiller-Naumann terminal force balance. */
+  TERMINAL_VELOCITY
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/EvaporationProfilePoint.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/EvaporationProfilePoint.java
@@ -1,6 +1,6 @@
 package neqsim.process.equipment.pipeline.evaporation;
 
-/** One accepted axial state from a pipeline evaporation calculation. */
+/** One accepted axial state from a pipeline evaporation or gas-dissolution calculation. */
 public class EvaporationProfilePoint {
   private final double distance;
   private final double remainingInjectedLiquidFraction;
@@ -10,6 +10,9 @@ public class EvaporationProfilePoint {
   private final double interfacialAreaPerLength;
   private final double totalMolarFlux;
   private final double[] componentMolarFluxes;
+  private final double gasVelocity;
+  private final double liquidVelocity;
+  private final double dispersedPhaseRelativeVelocity;
 
   /**
    * Constructor.
@@ -26,6 +29,15 @@ public class EvaporationProfilePoint {
   public EvaporationProfilePoint(double distance, double remainingInjectedLiquidFraction,
       double characteristicLiquidSize, double gasTemperature, double liquidTemperature, double interfacialAreaPerLength,
       double totalMolarFlux, double[] componentMolarFluxes) {
+    this(distance, remainingInjectedLiquidFraction, characteristicLiquidSize, gasTemperature, liquidTemperature,
+        interfacialAreaPerLength, totalMolarFlux, componentMolarFluxes, Double.NaN, Double.NaN, Double.NaN);
+  }
+
+  /** Constructor including the local slip state. */
+  public EvaporationProfilePoint(double distance, double remainingInjectedLiquidFraction,
+      double characteristicLiquidSize, double gasTemperature, double liquidTemperature, double interfacialAreaPerLength,
+      double totalMolarFlux, double[] componentMolarFluxes, double gasVelocity, double liquidVelocity,
+      double dispersedPhaseRelativeVelocity) {
     this.distance = distance;
     this.remainingInjectedLiquidFraction = remainingInjectedLiquidFraction;
     this.characteristicLiquidSize = characteristicLiquidSize;
@@ -34,6 +46,9 @@ public class EvaporationProfilePoint {
     this.interfacialAreaPerLength = interfacialAreaPerLength;
     this.totalMolarFlux = totalMolarFlux;
     this.componentMolarFluxes = componentMolarFluxes.clone();
+    this.gasVelocity = gasVelocity;
+    this.liquidVelocity = liquidVelocity;
+    this.dispersedPhaseRelativeVelocity = dispersedPhaseRelativeVelocity;
   }
 
   /** @return axial distance in m */
@@ -46,8 +61,26 @@ public class EvaporationProfilePoint {
     return remainingInjectedLiquidFraction;
   }
 
+  /**
+   * Return the remaining fraction of the initially tracked dispersed-phase mass.
+   *
+   * <p>
+   * This is injected liquid for evaporation and injected gas for dissolution.
+   * </p>
+   *
+   * @return remaining tracked mass fraction
+   */
+  public double getRemainingTrackedPhaseFraction() {
+    return remainingInjectedLiquidFraction;
+  }
+
   /** @return droplet diameter or film thickness in m */
   public double getCharacteristicLiquidSize() {
+    return characteristicLiquidSize;
+  }
+
+  /** @return droplet diameter, bubble diameter, or film thickness in m */
+  public double getCharacteristicDispersedPhaseSize() {
     return characteristicLiquidSize;
   }
 
@@ -74,5 +107,20 @@ public class EvaporationProfilePoint {
   /** @return component molar fluxes, positive from gas to liquid, in mol/(m2 s) */
   public double[] getComponentMolarFluxes() {
     return componentMolarFluxes.clone();
+  }
+
+  /** @return local actual gas velocity in m/s */
+  public double getGasVelocity() {
+    return gasVelocity;
+  }
+
+  /** @return local actual liquid velocity in m/s */
+  public double getLiquidVelocity() {
+    return liquidVelocity;
+  }
+
+  /** @return total particle-relative speed used in transfer correlations in m/s */
+  public double getDispersedPhaseRelativeVelocity() {
+    return dispersedPhaseRelativeVelocity;
   }
 }

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/EvaporationProfilePoint.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/EvaporationProfilePoint.java
@@ -1,0 +1,78 @@
+package neqsim.process.equipment.pipeline.evaporation;
+
+/** One accepted axial state from a pipeline evaporation calculation. */
+public class EvaporationProfilePoint {
+  private final double distance;
+  private final double remainingInjectedLiquidFraction;
+  private final double characteristicLiquidSize;
+  private final double gasTemperature;
+  private final double liquidTemperature;
+  private final double interfacialAreaPerLength;
+  private final double totalMolarFlux;
+  private final double[] componentMolarFluxes;
+
+  /**
+   * Constructor.
+   *
+   * @param distance axial distance in m
+   * @param remainingInjectedLiquidFraction remaining injected-liquid mass fraction
+   * @param characteristicLiquidSize droplet diameter or film thickness in m
+   * @param gasTemperature gas temperature in K
+   * @param liquidTemperature liquid temperature in K
+   * @param interfacialAreaPerLength interfacial area per axial length in m2/m
+   * @param totalMolarFlux total gas-to-liquid molar flux in mol/(m2 s)
+   * @param componentMolarFluxes gas-to-liquid component fluxes in mol/(m2 s)
+   */
+  public EvaporationProfilePoint(double distance, double remainingInjectedLiquidFraction,
+      double characteristicLiquidSize, double gasTemperature, double liquidTemperature, double interfacialAreaPerLength,
+      double totalMolarFlux, double[] componentMolarFluxes) {
+    this.distance = distance;
+    this.remainingInjectedLiquidFraction = remainingInjectedLiquidFraction;
+    this.characteristicLiquidSize = characteristicLiquidSize;
+    this.gasTemperature = gasTemperature;
+    this.liquidTemperature = liquidTemperature;
+    this.interfacialAreaPerLength = interfacialAreaPerLength;
+    this.totalMolarFlux = totalMolarFlux;
+    this.componentMolarFluxes = componentMolarFluxes.clone();
+  }
+
+  /** @return axial distance in m */
+  public double getDistance() {
+    return distance;
+  }
+
+  /** @return remaining fraction of the initially injected liquid mass */
+  public double getRemainingInjectedLiquidFraction() {
+    return remainingInjectedLiquidFraction;
+  }
+
+  /** @return droplet diameter or film thickness in m */
+  public double getCharacteristicLiquidSize() {
+    return characteristicLiquidSize;
+  }
+
+  /** @return gas temperature in K */
+  public double getGasTemperature() {
+    return gasTemperature;
+  }
+
+  /** @return liquid temperature in K */
+  public double getLiquidTemperature() {
+    return liquidTemperature;
+  }
+
+  /** @return interfacial area per axial length in m2/m */
+  public double getInterfacialAreaPerLength() {
+    return interfacialAreaPerLength;
+  }
+
+  /** @return total molar flux, positive from gas to liquid, in mol/(m2 s) */
+  public double getTotalMolarFlux() {
+    return totalMolarFlux;
+  }
+
+  /** @return component molar fluxes, positive from gas to liquid, in mol/(m2 s) */
+  public double[] getComponentMolarFluxes() {
+    return componentMolarFluxes.clone();
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/LiquidDistribution.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/LiquidDistribution.java
@@ -1,0 +1,10 @@
+package neqsim.process.equipment.pipeline.evaporation;
+
+/** Geometry used to represent injected liquid in a gas pipeline. */
+public enum LiquidDistribution {
+  /** Spherical droplets represented by a Sauter mean diameter. */
+  DROPLETS,
+
+  /** A wetted wall film represented by its thickness and wetted perimeter. */
+  WALL_FILM
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineDissolutionResult.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineDissolutionResult.java
@@ -1,0 +1,11 @@
+package neqsim.process.equipment.pipeline.evaporation;
+
+/** Result of an axial injected-gas dissolution study. */
+public class PipelineDissolutionResult extends PipelineEvaporationResult {
+  /** Constructor used by {@link PipelineDissolutionStudy}. */
+  PipelineDissolutionResult(PipelineEvaporationResult result) {
+    super(result.getProfile(), result.isCompleteTransfer(), result.getCompletionDistance(),
+        result.getMaximumComponentMolarBalanceError(), result.getRelativeEnergyBalanceError(), result.getWarnings(),
+        result.getOutletSystem(), true);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineDissolutionStudy.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineDissolutionStudy.java
@@ -1,0 +1,30 @@
+package neqsim.process.equipment.pipeline.evaporation;
+
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Estimates the distance required for injected gas bubbles to dissolve into oil or water.
+ *
+ * <p>
+ * Phase 0 is the tracked injected gas and phase 1 is the continuous oil, liquid, or aqueous phase. The calculation uses
+ * the same coupled Maxwell-Stefan and heat-transfer boundary as {@link PipelineEvaporationStudy}, with bubble-flow
+ * transport coefficients and an evolving Sauter mean bubble diameter.
+ * </p>
+ */
+public class PipelineDissolutionStudy extends PipelineEvaporationStudy {
+  /**
+   * Constructor.
+   *
+   * @param inletSystem explicit two-phase inlet system, injected gas in phase 0 and liquid in phase 1
+   * @param config geometry and numerical settings; initial bubble diameter is configured here
+   */
+  public PipelineDissolutionStudy(SystemInterface inletSystem, PipelineEvaporationConfig config) {
+    super(inletSystem, config, true);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PipelineDissolutionResult run() {
+    return new PipelineDissolutionResult(super.run());
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationConfig.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationConfig.java
@@ -1,7 +1,7 @@
 package neqsim.process.equipment.pipeline.evaporation;
 
 /**
- * Numerical and geometric settings for {@link PipelineEvaporationStudy}.
+ * Numerical and geometric settings for {@link PipelineEvaporationStudy} and {@link PipelineDissolutionStudy}.
  *
  * <p>
  * Velocities are actual phase velocities, not superficial velocities. SI units are used throughout.
@@ -15,6 +15,7 @@ public class PipelineEvaporationConfig {
   private double gasVelocity = 10.0;
   private double liquidVelocity = 0.5;
   private double initialDropletDiameter = 200.0e-6;
+  private double initialBubbleDiameter = 1.0e-3;
   private double initialFilmThickness = 0.50e-3;
   private double wettedPerimeterFraction = 1.0;
   private double ambientTemperature = 288.15;
@@ -27,6 +28,8 @@ public class PipelineEvaporationConfig {
   private double completionFraction = 1.0e-4;
   private int maximumNumberOfSteps = 100000;
   private boolean useAbramzonSirignano = true;
+  private DispersedPhaseSlipModel slipModel = DispersedPhaseSlipModel.USER_SPECIFIED;
+  private double pipeInclinationAngle = 0.0;
 
   /** @return liquid geometry model */
   public LiquidDistribution getLiquidDistribution() {
@@ -96,6 +99,16 @@ public class PipelineEvaporationConfig {
   /** @param initialDropletDiameter initial droplet Sauter mean diameter in m */
   public void setInitialDropletDiameter(double initialDropletDiameter) {
     this.initialDropletDiameter = initialDropletDiameter;
+  }
+
+  /** @return initial bubble Sauter mean diameter in m */
+  public double getInitialBubbleDiameter() {
+    return initialBubbleDiameter;
+  }
+
+  /** @param initialBubbleDiameter initial bubble Sauter mean diameter in m */
+  public void setInitialBubbleDiameter(double initialBubbleDiameter) {
+    this.initialBubbleDiameter = initialBubbleDiameter;
   }
 
   /** @return initial film thickness in m */
@@ -188,12 +201,12 @@ public class PipelineEvaporationConfig {
     this.maximumTemperatureChangePerStep = change;
   }
 
-  /** @return remaining injected-liquid fraction defining complete evaporation */
+  /** @return remaining tracked dispersed-phase fraction defining completion */
   public double getCompletionFraction() {
     return completionFraction;
   }
 
-  /** @param completionFraction remaining injected-liquid fraction defining complete evaporation */
+  /** @param completionFraction remaining tracked dispersed-phase fraction defining completion */
   public void setCompletionFraction(double completionFraction) {
     this.completionFraction = completionFraction;
   }
@@ -218,17 +231,40 @@ public class PipelineEvaporationConfig {
     this.useAbramzonSirignano = useAbramzonSirignano;
   }
 
+  /** @return dispersed-phase slip closure */
+  public DispersedPhaseSlipModel getSlipModel() {
+    return slipModel;
+  }
+
+  /** @param slipModel dispersed-phase slip closure */
+  public void setSlipModel(DispersedPhaseSlipModel slipModel) {
+    this.slipModel = slipModel;
+  }
+
+  /** @return pipe inclination from horizontal in radians, positive uphill */
+  public double getPipeInclinationAngle() {
+    return pipeInclinationAngle;
+  }
+
+  /** @param pipeInclinationAngle pipe inclination from horizontal in radians, positive uphill */
+  public void setPipeInclinationAngle(double pipeInclinationAngle) {
+    this.pipeInclinationAngle = pipeInclinationAngle;
+  }
+
   /** Validate all settings before a calculation. */
   public void validate() {
     require(liquidDistribution != null, "liquid distribution must be specified");
+    require(slipModel != null, "slip model must be specified");
     requirePositive(pipeLength, "pipe length");
     requirePositive(pipeDiameter, "pipe diameter");
     requireNonNegative(pipeRoughness, "pipe roughness");
     requirePositive(gasVelocity, "gas velocity");
     requirePositive(liquidVelocity, "liquid velocity");
     requirePositive(initialDropletDiameter, "initial droplet diameter");
+    requirePositive(initialBubbleDiameter, "initial bubble diameter");
     requirePositive(initialFilmThickness, "initial film thickness");
     require(initialDropletDiameter < pipeDiameter, "initial droplet diameter must be smaller than the pipe diameter");
+    require(initialBubbleDiameter < pipeDiameter, "initial bubble diameter must be smaller than the pipe diameter");
     require(2.0 * initialFilmThickness < pipeDiameter, "initial film thickness must be smaller than the pipe radius");
     require(wettedPerimeterFraction > 0.0 && wettedPerimeterFraction <= 1.0,
         "wetted perimeter fraction must be in (0, 1]");
@@ -244,6 +280,8 @@ public class PipelineEvaporationConfig {
     requirePositive(maximumTemperatureChangePerStep, "maximum temperature change");
     require(completionFraction > 0.0 && completionFraction < 1.0, "completion fraction must be in (0, 1)");
     require(maximumNumberOfSteps > 0, "maximum number of steps must be positive");
+    require(Double.isFinite(pipeInclinationAngle) && Math.abs(pipeInclinationAngle) <= 0.5 * Math.PI,
+        "pipe inclination angle must be finite and between -pi/2 and pi/2");
   }
 
   private static void requirePositive(double value, String name) {

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationConfig.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationConfig.java
@@ -1,0 +1,262 @@
+package neqsim.process.equipment.pipeline.evaporation;
+
+/**
+ * Numerical and geometric settings for {@link PipelineEvaporationStudy}.
+ *
+ * <p>
+ * Velocities are actual phase velocities, not superficial velocities. SI units are used throughout.
+ * </p>
+ */
+public class PipelineEvaporationConfig {
+  private LiquidDistribution liquidDistribution = LiquidDistribution.DROPLETS;
+  private double pipeLength = 100.0;
+  private double pipeDiameter = 0.20;
+  private double pipeRoughness = 1.0e-5;
+  private double gasVelocity = 10.0;
+  private double liquidVelocity = 0.5;
+  private double initialDropletDiameter = 200.0e-6;
+  private double initialFilmThickness = 0.50e-3;
+  private double wettedPerimeterFraction = 1.0;
+  private double ambientTemperature = 288.15;
+  private double overallWallHeatTransferCoefficient = 0.0;
+  private double initialStepLength = 0.25;
+  private double minimumStepLength = 1.0e-12;
+  private double maximumStepLength = 2.0;
+  private double maximumDonorFractionPerStep = 0.05;
+  private double maximumTemperatureChangePerStep = 2.0;
+  private double completionFraction = 1.0e-4;
+  private int maximumNumberOfSteps = 100000;
+  private boolean useAbramzonSirignano = true;
+
+  /** @return liquid geometry model */
+  public LiquidDistribution getLiquidDistribution() {
+    return liquidDistribution;
+  }
+
+  /** @param liquidDistribution liquid geometry model */
+  public void setLiquidDistribution(LiquidDistribution liquidDistribution) {
+    this.liquidDistribution = liquidDistribution;
+  }
+
+  /** @return pipe length in m */
+  public double getPipeLength() {
+    return pipeLength;
+  }
+
+  /** @param pipeLength pipe length in m */
+  public void setPipeLength(double pipeLength) {
+    this.pipeLength = pipeLength;
+  }
+
+  /** @return pipe inside diameter in m */
+  public double getPipeDiameter() {
+    return pipeDiameter;
+  }
+
+  /** @param pipeDiameter pipe inside diameter in m */
+  public void setPipeDiameter(double pipeDiameter) {
+    this.pipeDiameter = pipeDiameter;
+  }
+
+  /** @return pipe roughness in m */
+  public double getPipeRoughness() {
+    return pipeRoughness;
+  }
+
+  /** @param pipeRoughness pipe roughness in m */
+  public void setPipeRoughness(double pipeRoughness) {
+    this.pipeRoughness = pipeRoughness;
+  }
+
+  /** @return actual gas velocity in m/s */
+  public double getGasVelocity() {
+    return gasVelocity;
+  }
+
+  /** @param gasVelocity actual gas velocity in m/s */
+  public void setGasVelocity(double gasVelocity) {
+    this.gasVelocity = gasVelocity;
+  }
+
+  /** @return actual liquid velocity in m/s */
+  public double getLiquidVelocity() {
+    return liquidVelocity;
+  }
+
+  /** @param liquidVelocity actual liquid velocity in m/s */
+  public void setLiquidVelocity(double liquidVelocity) {
+    this.liquidVelocity = liquidVelocity;
+  }
+
+  /** @return initial droplet Sauter mean diameter in m */
+  public double getInitialDropletDiameter() {
+    return initialDropletDiameter;
+  }
+
+  /** @param initialDropletDiameter initial droplet Sauter mean diameter in m */
+  public void setInitialDropletDiameter(double initialDropletDiameter) {
+    this.initialDropletDiameter = initialDropletDiameter;
+  }
+
+  /** @return initial film thickness in m */
+  public double getInitialFilmThickness() {
+    return initialFilmThickness;
+  }
+
+  /** @param initialFilmThickness initial film thickness in m */
+  public void setInitialFilmThickness(double initialFilmThickness) {
+    this.initialFilmThickness = initialFilmThickness;
+  }
+
+  /** @return fraction of the pipe perimeter covered by film */
+  public double getWettedPerimeterFraction() {
+    return wettedPerimeterFraction;
+  }
+
+  /** @param wettedPerimeterFraction fraction of the pipe perimeter covered by film */
+  public void setWettedPerimeterFraction(double wettedPerimeterFraction) {
+    this.wettedPerimeterFraction = wettedPerimeterFraction;
+  }
+
+  /** @return ambient temperature in K */
+  public double getAmbientTemperature() {
+    return ambientTemperature;
+  }
+
+  /** @param ambientTemperature ambient temperature in K */
+  public void setAmbientTemperature(double ambientTemperature) {
+    this.ambientTemperature = ambientTemperature;
+  }
+
+  /** @return overall wall heat-transfer coefficient in W/(m2 K) */
+  public double getOverallWallHeatTransferCoefficient() {
+    return overallWallHeatTransferCoefficient;
+  }
+
+  /** @param coefficient overall wall heat-transfer coefficient in W/(m2 K) */
+  public void setOverallWallHeatTransferCoefficient(double coefficient) {
+    this.overallWallHeatTransferCoefficient = coefficient;
+  }
+
+  /** @return initial axial step in m */
+  public double getInitialStepLength() {
+    return initialStepLength;
+  }
+
+  /** @param initialStepLength initial axial step in m */
+  public void setInitialStepLength(double initialStepLength) {
+    this.initialStepLength = initialStepLength;
+  }
+
+  /** @return minimum axial step in m */
+  public double getMinimumStepLength() {
+    return minimumStepLength;
+  }
+
+  /** @param minimumStepLength minimum axial step in m */
+  public void setMinimumStepLength(double minimumStepLength) {
+    this.minimumStepLength = minimumStepLength;
+  }
+
+  /** @return maximum axial step in m */
+  public double getMaximumStepLength() {
+    return maximumStepLength;
+  }
+
+  /** @param maximumStepLength maximum axial step in m */
+  public void setMaximumStepLength(double maximumStepLength) {
+    this.maximumStepLength = maximumStepLength;
+  }
+
+  /** @return maximum fraction removed from any donor component in one step */
+  public double getMaximumDonorFractionPerStep() {
+    return maximumDonorFractionPerStep;
+  }
+
+  /** @param fraction maximum fraction removed from any donor component in one step */
+  public void setMaximumDonorFractionPerStep(double fraction) {
+    this.maximumDonorFractionPerStep = fraction;
+  }
+
+  /** @return maximum estimated phase temperature change in one step in K */
+  public double getMaximumTemperatureChangePerStep() {
+    return maximumTemperatureChangePerStep;
+  }
+
+  /** @param change maximum estimated phase temperature change in one step in K */
+  public void setMaximumTemperatureChangePerStep(double change) {
+    this.maximumTemperatureChangePerStep = change;
+  }
+
+  /** @return remaining injected-liquid fraction defining complete evaporation */
+  public double getCompletionFraction() {
+    return completionFraction;
+  }
+
+  /** @param completionFraction remaining injected-liquid fraction defining complete evaporation */
+  public void setCompletionFraction(double completionFraction) {
+    this.completionFraction = completionFraction;
+  }
+
+  /** @return maximum number of accepted axial steps */
+  public int getMaximumNumberOfSteps() {
+    return maximumNumberOfSteps;
+  }
+
+  /** @param maximumNumberOfSteps maximum number of accepted axial steps */
+  public void setMaximumNumberOfSteps(int maximumNumberOfSteps) {
+    this.maximumNumberOfSteps = maximumNumberOfSteps;
+  }
+
+  /** @return whether the droplet Stefan-flow correction is enabled */
+  public boolean isUseAbramzonSirignano() {
+    return useAbramzonSirignano;
+  }
+
+  /** @param useAbramzonSirignano whether the droplet Stefan-flow correction is enabled */
+  public void setUseAbramzonSirignano(boolean useAbramzonSirignano) {
+    this.useAbramzonSirignano = useAbramzonSirignano;
+  }
+
+  /** Validate all settings before a calculation. */
+  public void validate() {
+    require(liquidDistribution != null, "liquid distribution must be specified");
+    requirePositive(pipeLength, "pipe length");
+    requirePositive(pipeDiameter, "pipe diameter");
+    requireNonNegative(pipeRoughness, "pipe roughness");
+    requirePositive(gasVelocity, "gas velocity");
+    requirePositive(liquidVelocity, "liquid velocity");
+    requirePositive(initialDropletDiameter, "initial droplet diameter");
+    requirePositive(initialFilmThickness, "initial film thickness");
+    require(initialDropletDiameter < pipeDiameter, "initial droplet diameter must be smaller than the pipe diameter");
+    require(2.0 * initialFilmThickness < pipeDiameter, "initial film thickness must be smaller than the pipe radius");
+    require(wettedPerimeterFraction > 0.0 && wettedPerimeterFraction <= 1.0,
+        "wetted perimeter fraction must be in (0, 1]");
+    requirePositive(ambientTemperature, "ambient temperature");
+    requireNonNegative(overallWallHeatTransferCoefficient, "wall heat-transfer coefficient");
+    requirePositive(initialStepLength, "initial step length");
+    requirePositive(minimumStepLength, "minimum step length");
+    requirePositive(maximumStepLength, "maximum step length");
+    require(minimumStepLength <= initialStepLength && initialStepLength <= maximumStepLength,
+        "step lengths must satisfy minimum <= initial <= maximum");
+    require(maximumDonorFractionPerStep > 0.0 && maximumDonorFractionPerStep < 1.0,
+        "maximum donor fraction must be in (0, 1)");
+    requirePositive(maximumTemperatureChangePerStep, "maximum temperature change");
+    require(completionFraction > 0.0 && completionFraction < 1.0, "completion fraction must be in (0, 1)");
+    require(maximumNumberOfSteps > 0, "maximum number of steps must be positive");
+  }
+
+  private static void requirePositive(double value, String name) {
+    require(Double.isFinite(value) && value > 0.0, name + " must be finite and positive");
+  }
+
+  private static void requireNonNegative(double value, String name) {
+    require(Double.isFinite(value) && value >= 0.0, name + " must be finite and non-negative");
+  }
+
+  private static void require(boolean condition, String message) {
+    if (!condition) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationResult.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationResult.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import neqsim.thermo.system.SystemInterface;
 
-/** Result of an axial pipeline evaporation study. */
+/** Result of an axial pipeline evaporation study, with generic aliases used by gas dissolution. */
 public class PipelineEvaporationResult {
   private final List<EvaporationProfilePoint> profile;
   private final boolean completeEvaporation;
@@ -14,6 +14,7 @@ public class PipelineEvaporationResult {
   private final double relativeEnergyBalanceError;
   private final List<String> warnings;
   private final SystemInterface outletSystem;
+  private final boolean gasDissolution;
 
   /**
    * Constructor used by the solver.
@@ -29,6 +30,14 @@ public class PipelineEvaporationResult {
   PipelineEvaporationResult(List<EvaporationProfilePoint> profile, boolean completeEvaporation,
       double completeEvaporationDistance, double maximumComponentMolarBalanceError, double relativeEnergyBalanceError,
       List<String> warnings, SystemInterface outletSystem) {
+    this(profile, completeEvaporation, completeEvaporationDistance, maximumComponentMolarBalanceError,
+        relativeEnergyBalanceError, warnings, outletSystem, false);
+  }
+
+  /** Constructor used by the evaporation and dissolution solvers. */
+  PipelineEvaporationResult(List<EvaporationProfilePoint> profile, boolean completeEvaporation,
+      double completeEvaporationDistance, double maximumComponentMolarBalanceError, double relativeEnergyBalanceError,
+      List<String> warnings, SystemInterface outletSystem, boolean gasDissolution) {
     this.profile = Collections.unmodifiableList(new ArrayList<EvaporationProfilePoint>(profile));
     this.completeEvaporation = completeEvaporation;
     this.completeEvaporationDistance = completeEvaporationDistance;
@@ -36,6 +45,11 @@ public class PipelineEvaporationResult {
     this.relativeEnergyBalanceError = relativeEnergyBalanceError;
     this.warnings = Collections.unmodifiableList(new ArrayList<String>(warnings));
     this.outletSystem = outletSystem.clone();
+    if (outletSystem.getNumberOfPhases() > 1) {
+      this.outletSystem.setPhaseType(1, outletSystem.getPhase(1).getType());
+      this.outletSystem.getPhase(1).setType(outletSystem.getPhase(1).getType());
+    }
+    this.gasDissolution = gasDissolution;
   }
 
   /** @return immutable axial profile */
@@ -45,12 +59,37 @@ public class PipelineEvaporationResult {
 
   /** @return whether the configured completion criterion was reached */
   public boolean isCompleteEvaporation() {
+    return !gasDissolution && completeEvaporation;
+  }
+
+  /** @return whether the configured tracked-inventory completion criterion was reached */
+  public boolean isCompleteTransfer() {
     return completeEvaporation;
+  }
+
+  /** @return whether the injected-gas dissolution criterion was reached */
+  public boolean isCompleteDissolution() {
+    return gasDissolution && completeEvaporation;
   }
 
   /** @return interpolated completion distance in m, or NaN when incomplete */
   public double getCompleteEvaporationDistance() {
+    return gasDissolution ? Double.NaN : completeEvaporationDistance;
+  }
+
+  /** @return interpolated transfer completion distance in m, or NaN when incomplete */
+  public double getCompletionDistance() {
     return completeEvaporationDistance;
+  }
+
+  /** @return interpolated complete-dissolution distance in m, or NaN when inapplicable or incomplete */
+  public double getCompleteDissolutionDistance() {
+    return gasDissolution ? completeEvaporationDistance : Double.NaN;
+  }
+
+  /** @return true when this result tracks injected gas dissolving into liquid */
+  public boolean isGasDissolutionStudy() {
+    return gasDissolution;
   }
 
   /** @return largest absolute component molar balance error in mol/s */
@@ -70,6 +109,11 @@ public class PipelineEvaporationResult {
 
   /** @return defensive clone of the final two-phase system */
   public SystemInterface getOutletSystem() {
-    return outletSystem.clone();
+    SystemInterface copy = outletSystem.clone();
+    if (outletSystem.getNumberOfPhases() > 1) {
+      copy.setPhaseType(1, outletSystem.getPhase(1).getType());
+      copy.getPhase(1).setType(outletSystem.getPhase(1).getType());
+    }
+    return copy;
   }
 }

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationResult.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationResult.java
@@ -1,0 +1,75 @@
+package neqsim.process.equipment.pipeline.evaporation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import neqsim.thermo.system.SystemInterface;
+
+/** Result of an axial pipeline evaporation study. */
+public class PipelineEvaporationResult {
+  private final List<EvaporationProfilePoint> profile;
+  private final boolean completeEvaporation;
+  private final double completeEvaporationDistance;
+  private final double maximumComponentMolarBalanceError;
+  private final double relativeEnergyBalanceError;
+  private final List<String> warnings;
+  private final SystemInterface outletSystem;
+
+  /**
+   * Constructor used by the solver.
+   *
+   * @param profile axial profile
+   * @param completeEvaporation whether the configured completion criterion was reached
+   * @param completeEvaporationDistance interpolated completion distance in m, or NaN
+   * @param maximumComponentMolarBalanceError largest component balance error in mol/s
+   * @param relativeEnergyBalanceError relative overall energy balance error
+   * @param warnings calculation warnings
+   * @param outletSystem final two-phase system
+   */
+  PipelineEvaporationResult(List<EvaporationProfilePoint> profile, boolean completeEvaporation,
+      double completeEvaporationDistance, double maximumComponentMolarBalanceError, double relativeEnergyBalanceError,
+      List<String> warnings, SystemInterface outletSystem) {
+    this.profile = Collections.unmodifiableList(new ArrayList<EvaporationProfilePoint>(profile));
+    this.completeEvaporation = completeEvaporation;
+    this.completeEvaporationDistance = completeEvaporationDistance;
+    this.maximumComponentMolarBalanceError = maximumComponentMolarBalanceError;
+    this.relativeEnergyBalanceError = relativeEnergyBalanceError;
+    this.warnings = Collections.unmodifiableList(new ArrayList<String>(warnings));
+    this.outletSystem = outletSystem.clone();
+  }
+
+  /** @return immutable axial profile */
+  public List<EvaporationProfilePoint> getProfile() {
+    return profile;
+  }
+
+  /** @return whether the configured completion criterion was reached */
+  public boolean isCompleteEvaporation() {
+    return completeEvaporation;
+  }
+
+  /** @return interpolated completion distance in m, or NaN when incomplete */
+  public double getCompleteEvaporationDistance() {
+    return completeEvaporationDistance;
+  }
+
+  /** @return largest absolute component molar balance error in mol/s */
+  public double getMaximumComponentMolarBalanceError() {
+    return maximumComponentMolarBalanceError;
+  }
+
+  /** @return relative overall energy balance error */
+  public double getRelativeEnergyBalanceError() {
+    return relativeEnergyBalanceError;
+  }
+
+  /** @return immutable calculation warning list */
+  public List<String> getWarnings() {
+    return warnings;
+  }
+
+  /** @return defensive clone of the final two-phase system */
+  public SystemInterface getOutletSystem() {
+    return outletSystem.clone();
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationStudy.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationStudy.java
@@ -1,0 +1,608 @@
+package neqsim.process.equipment.pipeline.evaporation;
+
+import java.util.ArrayList;
+import java.util.List;
+import neqsim.fluidmechanics.flownode.fluidboundary.interphasetransportcoefficient.interphasetwophase.interphasepipeflow.InterphaseDropletFlow;
+import neqsim.fluidmechanics.flownode.twophasenode.TwoPhaseFlowNode;
+import neqsim.fluidmechanics.flownode.twophasenode.twophasepipeflownode.AnnularFlow;
+import neqsim.fluidmechanics.flownode.twophasenode.twophasepipeflownode.DropletFlowNode;
+import neqsim.fluidmechanics.geometrydefinitions.pipe.PipeData;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Estimates the distance required to evaporate an injected hydrocarbon liquid in a gas pipeline.
+ *
+ * <p>
+ * The axial marching calculation uses NeqSim's Krishna standard film boundary. The boundary solves fugacity equality at
+ * the interface and a full multicomponent Maxwell-Stefan resistance matrix in both phases. Finite-flux and
+ * thermodynamic-factor corrections are enabled. Ranz-Marshall/Kronig-Brink coefficients are used for droplets and the
+ * annular-flow correlations are used for a wall film.
+ * </p>
+ *
+ * <p>
+ * Component flow inventories are advanced conservatively. The two phase energy equations use the boundary's coupled
+ * interphase heat fluxes, including the enthalpy carried by mass transfer, and optional wall heat. An adaptive axial
+ * step limits donor depletion and temperature changes. Completion is based on a tracked fraction of the initially
+ * injected liquid, never on hydrodynamic liquid holdup.
+ * </p>
+ *
+ * <p>
+ * The supplied system must contain gas as phase 0 and hydrocarbon liquid as phase 1. Its phase mole inventories are
+ * interpreted as molar flow rates in mol/s, consistent with NeqSim flow-node calculations. No equilibrium flash is
+ * performed between axial steps because doing so would replace the finite-rate model with instantaneous equilibrium.
+ * </p>
+ */
+public class PipelineEvaporationStudy {
+  private static final double MINIMUM_INVENTORY = 1.0e-20;
+  private final SystemInterface inletSystem;
+  private final PipelineEvaporationConfig config;
+
+  /**
+   * Constructor.
+   *
+   * @param inletSystem explicit two-phase inlet system, gas in phase 0 and injected liquid in phase 1
+   * @param config geometry and numerical settings
+   */
+  public PipelineEvaporationStudy(SystemInterface inletSystem, PipelineEvaporationConfig config) {
+    if (inletSystem == null) {
+      throw new IllegalArgumentException("inlet system cannot be null");
+    }
+    if (config == null) {
+      throw new IllegalArgumentException("configuration cannot be null");
+    }
+    this.inletSystem = inletSystem.clone();
+    this.config = config;
+  }
+
+  /**
+   * Run the adaptive axial calculation.
+   *
+   * @return evaporation result and profile
+   */
+  public PipelineEvaporationResult run() {
+    config.validate();
+    SystemInterface state = inletSystem.clone();
+    validateSystem(state);
+    state.init(3);
+    state.initPhysicalProperties();
+
+    int componentCount = state.getPhase(0).getNumberOfComponents();
+    double[] initialComponentTotals = componentTotals(state, componentCount);
+    double[] trackedLiquidMoles = new double[componentCount];
+    for (int i = 0; i < componentCount; i++) {
+      trackedLiquidMoles[i] = state.getPhase(1).getComponent(i).getNumberOfMolesInPhase();
+    }
+
+    double initialTrackedMass = trackedMass(state, trackedLiquidMoles);
+    if (!(initialTrackedMass > 0.0)) {
+      throw new IllegalArgumentException("phase 1 must contain a positive injected-liquid flow");
+    }
+    double initialLiquidDensity = state.getPhase(1).getPhysicalProperties().getDensity();
+    if (!Double.isFinite(initialLiquidDensity) || initialLiquidDensity <= 0.0) {
+      throw new IllegalArgumentException("phase 1 liquid density must be finite and positive");
+    }
+    double initialLiquidVolumeFlow = initialTrackedMass / initialLiquidDensity;
+    double initialEnthalpy = totalEnthalpy(state);
+
+    List<EvaporationProfilePoint> profile = new ArrayList<EvaporationProfilePoint>();
+    List<String> warnings = new ArrayList<String>();
+    double distance = 0.0;
+    double stepLength = config.getInitialStepLength();
+    double cumulativeWallHeat = 0.0;
+    double remainingFraction = 1.0;
+    double completionDistance = Double.NaN;
+    boolean complete = false;
+
+    profile.add(new EvaporationProfilePoint(0.0, 1.0, characteristicSize(1.0), state.getPhase(0).getTemperature(),
+        state.getPhase(1).getTemperature(), interfacialAreaPerLength(1.0, initialLiquidVolumeFlow), 0.0,
+        new double[componentCount]));
+
+    int acceptedSteps = 0;
+    while (distance < config.getPipeLength() && remainingFraction > config.getCompletionFraction()
+        && acceptedSteps < config.getMaximumNumberOfSteps()) {
+      state.init(3);
+      state.initPhysicalProperties();
+      double liquidVolumeRatio = phaseVolumeFlow(state, 1) / initialLiquidVolumeFlow;
+      double characteristicSize = characteristicSize(liquidVolumeRatio);
+      LocalClosure closure = calculateLocalClosure(state, characteristicSize, trackedLiquidMoles);
+      validateClosure(closure);
+      if (closure.usedHeatFluxFallback) {
+        addWarningOnce(warnings, "The coupled boundary returned a non-finite heat flux near phase depletion; "
+            + "a bounded two-film enthalpy closure was used for that axial state.");
+      }
+
+      double areaPerLength = interfacialAreaPerLength(liquidVolumeRatio, initialLiquidVolumeFlow);
+      double candidateStep = Math.min(stepLength, config.getPipeLength() - distance);
+      StepEstimate estimate = estimateStep(state, closure, areaPerLength, candidateStep);
+
+      while ((estimate.maximumDonorFraction > config.getMaximumDonorFractionPerStep()
+          || estimate.maximumTemperatureChange > config.getMaximumTemperatureChangePerStep())
+          && candidateStep > config.getMinimumStepLength()) {
+        candidateStep = Math.max(config.getMinimumStepLength(), 0.5 * candidateStep);
+        estimate = estimateStep(state, closure, areaPerLength, candidateStep);
+      }
+
+      double effectiveArea = areaPerLength * candidateStep;
+      double previousFraction = remainingFraction;
+      double enthalpyBefore = totalEnthalpy(state);
+      double[] transfer = new double[componentCount];
+      double[] liquidInventoryBefore = new double[componentCount];
+      for (int i = 0; i < componentCount; i++) {
+        liquidInventoryBefore[i] = state.getPhase(1).getComponent(i).getNumberOfMolesInPhase();
+        transfer[i] = closure.componentMolarFluxes[i] * effectiveArea;
+        int donorPhase = transfer[i] >= 0.0 ? 0 : 1;
+        double donorInventory = state.getPhase(donorPhase).getComponent(i).getNumberOfMolesInPhase();
+        double maximumTransfer = 0.999 * Math.max(0.0, donorInventory);
+        if (Math.abs(transfer[i]) > maximumTransfer) {
+          transfer[i] = Math.copySign(maximumTransfer, transfer[i]);
+          addWarningOnce(warnings, "A closure flux pointed out of a depleted component inventory; "
+              + "a conservative component limiter was applied.");
+        }
+        state.getPhase(0).addMoles(i, -transfer[i]);
+        state.getPhase(1).addMoles(i, transfer[i]);
+
+        if (transfer[i] < 0.0 && liquidInventoryBefore[i] > MINIMUM_INVENTORY) {
+          double trackedShare = Math.min(1.0, trackedLiquidMoles[i] / liquidInventoryBefore[i]);
+          trackedLiquidMoles[i] = Math.max(0.0, trackedLiquidMoles[i] + transfer[i] * trackedShare);
+        }
+      }
+
+      double gasTemperature = state.getPhase(0).getTemperature();
+      double liquidTemperature = state.getPhase(1).getTemperature();
+      state.initBeta();
+      state.init_x_y();
+      state.init(3);
+
+      double wallHeat = wallHeat(candidateStep, gasTemperature, liquidTemperature);
+      double gasWallHeat = config.getLiquidDistribution() == LiquidDistribution.DROPLETS ? wallHeat : 0.0;
+      double liquidWallHeat = config.getLiquidDistribution() == LiquidDistribution.WALL_FILM ? wallHeat : 0.0;
+      double gasTargetEnthalpy = state.getPhase(0).getEnthalpy("J") + closure.interphaseHeatFluxes[0] * effectiveArea
+          + gasWallHeat;
+      double liquidTargetEnthalpy = state.getPhase(1).getEnthalpy("J") + closure.interphaseHeatFluxes[1] * effectiveArea
+          + liquidWallHeat;
+
+      solvePhaseTemperature(state, 0, gasTargetEnthalpy, gasTemperature);
+      solvePhaseTemperature(state, 1, liquidTargetEnthalpy, liquidTemperature);
+      solveTotalEnergy(state, enthalpyBefore + wallHeat);
+      state.init(3);
+      state.initPhysicalProperties();
+
+      double stepEnergyResidual = totalEnthalpy(state) - enthalpyBefore - wallHeat;
+      double stepEnergyScale = Math.max(1.0, Math.abs(enthalpyBefore) + Math.abs(wallHeat));
+      if (Math.abs(stepEnergyResidual) / stepEnergyScale > 1.0e-3) {
+        addWarningOnce(warnings,
+            "The local energy residual exceeded 0.1%; reduce the maximum temperature change or axial step.");
+      }
+
+      distance += candidateStep;
+      cumulativeWallHeat += wallHeat;
+      acceptedSteps++;
+      remainingFraction = trackedMass(state, trackedLiquidMoles) / initialTrackedMass;
+      remainingFraction = Math.max(0.0, Math.min(1.0, remainingFraction));
+
+      double totalFlux = 0.0;
+      double[] appliedFluxes = new double[componentCount];
+      for (int i = 0; i < componentCount; i++) {
+        appliedFluxes[i] = transfer[i] / effectiveArea;
+        totalFlux += appliedFluxes[i];
+      }
+      double outletLiquidVolumeRatio = phaseVolumeFlow(state, 1) / initialLiquidVolumeFlow;
+      profile.add(new EvaporationProfilePoint(distance, remainingFraction, characteristicSize(outletLiquidVolumeRatio),
+          state.getPhase(0).getTemperature(), state.getPhase(1).getTemperature(),
+          interfacialAreaPerLength(outletLiquidVolumeRatio, initialLiquidVolumeFlow), totalFlux, appliedFluxes));
+
+      if (remainingFraction <= config.getCompletionFraction()) {
+        double denominator = previousFraction - remainingFraction;
+        double completedStepFraction = denominator > 0.0
+            ? (previousFraction - config.getCompletionFraction()) / denominator
+            : 1.0;
+        completionDistance = distance - candidateStep + candidateStep * completedStepFraction;
+        complete = true;
+      }
+
+      if (estimate.maximumDonorFraction < 0.25 * config.getMaximumDonorFractionPerStep()
+          && estimate.maximumTemperatureChange < 0.25 * config.getMaximumTemperatureChangePerStep()) {
+        stepLength = Math.min(config.getMaximumStepLength(), 1.5 * candidateStep);
+      } else {
+        stepLength = candidateStep;
+      }
+    }
+
+    if (acceptedSteps >= config.getMaximumNumberOfSteps() && !complete) {
+      addWarningOnce(warnings, "The maximum number of axial steps was reached before completion.");
+    }
+    if (!complete && remainingFraction > config.getCompletionFraction()) {
+      addWarningOnce(warnings, "The injected liquid did not reach the completion criterion within the pipe length.");
+    }
+
+    double maxComponentBalanceError = maximumComponentBalanceError(state, initialComponentTotals);
+    double finalEnthalpy = totalEnthalpy(state);
+    double energyScale = Math.max(1.0, Math.abs(initialEnthalpy) + Math.abs(cumulativeWallHeat));
+    double relativeEnergyError = Math.abs(finalEnthalpy - initialEnthalpy - cumulativeWallHeat) / energyScale;
+    return new PipelineEvaporationResult(profile, complete, completionDistance, maxComponentBalanceError,
+        relativeEnergyError, warnings, state);
+  }
+
+  private void validateSystem(SystemInterface system) {
+    if (system.getNumberOfPhases() < 2) {
+      throw new IllegalArgumentException("an explicit gas and liquid phase are required");
+    }
+    if (system.getPhase(0).getType() != PhaseType.GAS) {
+      throw new IllegalArgumentException("phase 0 must be gas");
+    }
+    PhaseType liquidType = system.getPhase(1).getType();
+    if (liquidType != PhaseType.OIL && liquidType != PhaseType.LIQUID) {
+      throw new IllegalArgumentException("phase 1 must be a hydrocarbon liquid or oil phase");
+    }
+    if (system.getPhase(0).getNumberOfComponents() < 2) {
+      throw new IllegalArgumentException("Maxwell-Stefan transfer requires at least two components");
+    }
+  }
+
+  private LocalClosure calculateLocalClosure(SystemInterface state, double characteristicSize,
+      double[] trackedLiquidMoles) {
+    PipeData pipe = new PipeData(config.getPipeDiameter(), config.getPipeRoughness());
+    SystemInterface localSystem = state.clone();
+    TwoPhaseFlowNode node;
+    if (config.getLiquidDistribution() == LiquidDistribution.DROPLETS) {
+      DropletFlowNode dropletNode = new DropletFlowNode(localSystem, pipe);
+      dropletNode.setAverageDropletDiameter(characteristicSize);
+      node = dropletNode;
+    } else {
+      node = new AnnularFlow(localSystem, pipe);
+    }
+
+    setLocalHydrodynamics(node, localSystem, pipe);
+    node.setLengthOfNode(1.0);
+    node.getFluidBoundary().setMassTransferCalc(true);
+    node.getFluidBoundary().setHeatTransferCalc(true);
+    node.getFluidBoundary().useFiniteFluxCorrection(true);
+    node.getFluidBoundary().useThermodynamicCorrections(true);
+    node.init();
+    node.calcFluxes();
+
+    if (node instanceof DropletFlowNode && config.isUseAbramzonSirignano()) {
+      InterphaseDropletFlow transferModel = (InterphaseDropletFlow) node.getInterphaseTransportCoefficient();
+      double spaldingNumber = calculateSpaldingMassTransferNumber(node, trackedLiquidMoles);
+      transferModel.setSpaldingMassTransferNumber(spaldingNumber);
+      transferModel.setUseAbramzonSirignano(true);
+      node.calcFluxes();
+    }
+
+    int componentCount = state.getPhase(0).getNumberOfComponents();
+    double[] fluxes = new double[componentCount];
+    for (int i = 0; i < componentCount; i++) {
+      fluxes[i] = node.getFluidBoundary().getInterphaseMolarFlux(i);
+    }
+    double[] heatFluxes = new double[] { node.getFluidBoundary().getInterphaseHeatFlux(0),
+        node.getFluidBoundary().getInterphaseHeatFlux(1) };
+    boolean usedHeatFluxFallback = !allFinite(heatFluxes);
+    if (usedHeatFluxFallback) {
+      heatFluxes = calculateFallbackHeatFluxes(node, fluxes);
+    }
+    return new LocalClosure(fluxes, heatFluxes, usedHeatFluxFallback);
+  }
+
+  private static double[] calculateFallbackHeatFluxes(TwoPhaseFlowNode node, double[] fluxes) {
+    double[] heatTransferCoefficients = new double[2];
+    for (int phase = 0; phase < 2; phase++) {
+      double moles = Math.max(MINIMUM_INVENTORY, node.getBulkSystem().getPhase(phase).getNumberOfMolesInPhase());
+      double molarMass = Math.max(MINIMUM_INVENTORY, node.getBulkSystem().getPhase(phase).getMolarMass());
+      double conductivity = Math.max(MINIMUM_INVENTORY,
+          node.getBulkSystem().getPhase(phase).getPhysicalProperties().getConductivity());
+      double prandtlNumber = node.getBulkSystem().getPhase(phase).getCp() / moles / molarMass
+          * node.getBulkSystem().getPhase(phase).getPhysicalProperties().getViscosity() / conductivity;
+      heatTransferCoefficients[phase] = node.getInterphaseTransportCoefficient()
+          .calcInterphaseHeatTransferCoefficient(phase, prandtlNumber, node);
+      if (!Double.isFinite(heatTransferCoefficients[phase]) || heatTransferCoefficients[phase] <= 0.0) {
+        double safeConductivity = Double.isFinite(conductivity) && conductivity > 1.0e-12 ? conductivity
+            : (phase == 0 ? 0.02 : 0.10);
+        double characteristicLength = node instanceof DropletFlowNode
+            ? ((DropletFlowNode) node).getAverageDropletDiameter()
+            : 0.01 * node.getGeometry().getDiameter();
+        double stagnantNusseltNumber = node instanceof DropletFlowNode && phase == 1 ? 17.66 : 2.0;
+        heatTransferCoefficients[phase] = stagnantNusseltNumber * safeConductivity
+            / Math.max(1.0e-8, characteristicLength);
+      }
+    }
+
+    double enthalpyFlux = 0.0;
+    double interfaceTemperature = 0.5
+        * (node.getBulkSystem().getPhase(0).getTemperature() + node.getBulkSystem().getPhase(1).getTemperature());
+    for (int i = 0; i < fluxes.length; i++) {
+      double evaluationTemperature = Math.min(interfaceTemperature,
+          0.999 * node.getBulkSystem().getPhase(0).getComponent(i).getTC());
+      double vaporizationEnthalpy = node.getBulkSystem().getPhase(0).getComponent(i)
+          .getPureComponentHeatOfVaporization(evaluationTemperature) * 1000.0;
+      if (Double.isFinite(vaporizationEnthalpy) && vaporizationEnthalpy > 0.0) {
+        enthalpyFlux += fluxes[i] * vaporizationEnthalpy;
+      }
+    }
+
+    double coefficientSum = heatTransferCoefficients[0] + heatTransferCoefficients[1];
+    if (!Double.isFinite(coefficientSum) || coefficientSum <= 0.0) {
+      throw new IllegalStateException("unable to calculate a finite fallback interphase heat flux");
+    }
+    interfaceTemperature = (enthalpyFlux
+        + heatTransferCoefficients[0] * node.getBulkSystem().getPhase(0).getTemperature()
+        + heatTransferCoefficients[1] * node.getBulkSystem().getPhase(1).getTemperature()) / coefficientSum;
+    interfaceTemperature = Math.max(1.0, Math.min(
+        Math.max(node.getBulkSystem().getPhase(0).getTemperature(), node.getBulkSystem().getPhase(1).getTemperature())
+            + 100.0,
+        interfaceTemperature));
+    return new double[] {
+        -heatTransferCoefficients[0] * (node.getBulkSystem().getPhase(0).getTemperature() - interfaceTemperature),
+        -heatTransferCoefficients[1] * (node.getBulkSystem().getPhase(1).getTemperature() - interfaceTemperature) };
+  }
+
+  private void setLocalHydrodynamics(TwoPhaseFlowNode node, SystemInterface system, PipeData pipe) {
+    double gasVolumeFlow = phaseVolumeFlow(system, 0);
+    double liquidVolumeFlow = phaseVolumeFlow(system, 1);
+    double gasAreaDemand = gasVolumeFlow / config.getGasVelocity();
+    double liquidAreaDemand = liquidVolumeFlow / config.getLiquidVelocity();
+    double totalAreaDemand = gasAreaDemand + liquidAreaDemand;
+    double gasFraction = totalAreaDemand > 0.0 ? gasAreaDemand / totalAreaDemand : 0.999;
+    gasFraction = Math.max(1.0e-6, Math.min(1.0 - 1.0e-6, gasFraction));
+    node.setPhaseFraction(0, gasFraction);
+    node.setPhaseFraction(1, 1.0 - gasFraction);
+    node.setVelocity(0, config.getGasVelocity());
+    node.setVelocity(1, config.getLiquidVelocity());
+    pipe.setNodeLength(1.0);
+  }
+
+  private double calculateSpaldingMassTransferNumber(TwoPhaseFlowNode node, double[] trackedLiquidMoles) {
+    double surfaceNumerator = 0.0;
+    double surfaceDenominator = 0.0;
+    double bulkNumerator = 0.0;
+    double bulkDenominator = 0.0;
+    double trackedMass = 0.0;
+    int componentCount = trackedLiquidMoles.length;
+    for (int i = 0; i < componentCount; i++) {
+      trackedMass += trackedLiquidMoles[i] * node.getBulkSystem().getPhase(0).getComponent(i).getMolarMass();
+    }
+    for (int i = 0; i < componentCount; i++) {
+      double molarMass = node.getBulkSystem().getPhase(0).getComponent(i).getMolarMass();
+      double surfaceMass = node.getInterphaseSystem().getPhase(0).getComponent(i).getx() * molarMass;
+      double bulkMass = node.getBulkSystem().getPhase(0).getComponent(i).getx() * molarMass;
+      surfaceDenominator += surfaceMass;
+      bulkDenominator += bulkMass;
+      if (trackedLiquidMoles[i] * molarMass > 1.0e-12 * trackedMass) {
+        surfaceNumerator += surfaceMass;
+        bulkNumerator += bulkMass;
+      }
+    }
+    if (surfaceDenominator <= 0.0 || bulkDenominator <= 0.0) {
+      return 0.0;
+    }
+    double surfaceMassFraction = surfaceNumerator / surfaceDenominator;
+    double bulkMassFraction = bulkNumerator / bulkDenominator;
+    if (surfaceMassFraction <= bulkMassFraction || surfaceMassFraction >= 1.0 - 1.0e-12) {
+      return 0.0;
+    }
+    return (surfaceMassFraction - bulkMassFraction) / (1.0 - surfaceMassFraction);
+  }
+
+  private StepEstimate estimateStep(SystemInterface state, LocalClosure closure, double areaPerLength,
+      double stepLength) {
+    double area = areaPerLength * stepLength;
+    double maximumDonorFraction = 0.0;
+    for (int i = 0; i < closure.componentMolarFluxes.length; i++) {
+      double transfer = closure.componentMolarFluxes[i] * area;
+      int donorPhase = transfer >= 0.0 ? 0 : 1;
+      double donor = state.getPhase(donorPhase).getComponent(i).getNumberOfMolesInPhase();
+      if (donor > MINIMUM_INVENTORY) {
+        maximumDonorFraction = Math.max(maximumDonorFraction, Math.abs(transfer) / donor);
+      }
+    }
+
+    double wallHeat = wallHeat(stepLength, state.getPhase(0).getTemperature(), state.getPhase(1).getTemperature());
+    double gasWallHeat = config.getLiquidDistribution() == LiquidDistribution.DROPLETS ? wallHeat : 0.0;
+    double liquidWallHeat = config.getLiquidDistribution() == LiquidDistribution.WALL_FILM ? wallHeat : 0.0;
+    double gasCp = safeHeatCapacity(state.getPhase(0).getCp());
+    double liquidCp = safeHeatCapacity(state.getPhase(1).getCp());
+    double gasChange = Math.abs(closure.interphaseHeatFluxes[0] * area + gasWallHeat) / gasCp;
+    double liquidChange = Math.abs(closure.interphaseHeatFluxes[1] * area + liquidWallHeat) / liquidCp;
+    return new StepEstimate(maximumDonorFraction, Math.max(gasChange, liquidChange));
+  }
+
+  private double interfacialAreaPerLength(double liquidVolumeRatio, double initialLiquidVolumeFlow) {
+    if (config.getLiquidDistribution() == LiquidDistribution.DROPLETS) {
+      double diameter = characteristicSize(liquidVolumeRatio);
+      double currentVolumeFlow = initialLiquidVolumeFlow * Math.max(0.0, liquidVolumeRatio);
+      return dropletAreaPerLength(currentVolumeFlow, config.getLiquidVelocity(), diameter);
+    }
+    double filmThickness = characteristicSize(liquidVolumeRatio);
+    return filmAreaPerLength(config.getPipeDiameter(), filmThickness, config.getWettedPerimeterFraction());
+  }
+
+  /**
+   * Calculate the surface area of a spherical-droplet population per axial length.
+   *
+   * @param liquidVolumeFlow dispersed liquid volume flow in m3/s
+   * @param liquidVelocity droplet velocity in m/s
+   * @param sauterMeanDiameter Sauter mean diameter in m
+   * @return interfacial area per length in m2/m
+   */
+  static double dropletAreaPerLength(double liquidVolumeFlow, double liquidVelocity, double sauterMeanDiameter) {
+    if (liquidVolumeFlow <= 0.0 || liquidVelocity <= 0.0 || sauterMeanDiameter <= 0.0) {
+      return 0.0;
+    }
+    return 6.0 * liquidVolumeFlow / liquidVelocity / sauterMeanDiameter;
+  }
+
+  /**
+   * Calculate wall-film interfacial area per axial length.
+   *
+   * @param pipeDiameter pipe inside diameter in m
+   * @param filmThickness film thickness in m
+   * @param wettedFraction wetted perimeter fraction
+   * @return interfacial area per length in m2/m
+   */
+  static double filmAreaPerLength(double pipeDiameter, double filmThickness, double wettedFraction) {
+    double interfaceDiameter = Math.max(1.0e-12, pipeDiameter - 2.0 * filmThickness);
+    return wettedFraction * Math.PI * interfaceDiameter;
+  }
+
+  private double characteristicSize(double liquidVolumeRatio) {
+    double boundedRatio = Math.max(0.0, liquidVolumeRatio);
+    if (config.getLiquidDistribution() == LiquidDistribution.DROPLETS) {
+      return config.getInitialDropletDiameter() * Math.cbrt(boundedRatio);
+    }
+    return config.getInitialFilmThickness() * boundedRatio;
+  }
+
+  private double wallHeat(double stepLength, double gasTemperature, double liquidTemperature) {
+    double receivingTemperature = config.getLiquidDistribution() == LiquidDistribution.DROPLETS ? gasTemperature
+        : liquidTemperature;
+    return config.getOverallWallHeatTransferCoefficient() * Math.PI * config.getPipeDiameter() * stepLength
+        * (config.getAmbientTemperature() - receivingTemperature);
+  }
+
+  private static double phaseVolumeFlow(SystemInterface system, int phase) {
+    double massFlow = system.getPhase(phase).getNumberOfMolesInPhase() * system.getPhase(phase).getMolarMass();
+    double density = system.getPhase(phase).getPhysicalProperties().getDensity();
+    return density > 0.0 ? massFlow / density : 0.0;
+  }
+
+  private static void solvePhaseTemperature(SystemInterface state, int phaseNumber, double targetEnthalpy,
+      double initialTemperature) {
+    double temperature = initialTemperature;
+    for (int iteration = 0; iteration < 12; iteration++) {
+      state.getPhase(phaseNumber).setTemperature(temperature);
+      state.init(3);
+      double error = targetEnthalpy - state.getPhase(phaseNumber).getEnthalpy("J");
+      double heatCapacity = state.getPhase(phaseNumber).getCp();
+      if (!Double.isFinite(error) || !Double.isFinite(heatCapacity) || Math.abs(heatCapacity) < 1.0e-12) {
+        return;
+      }
+      if (Math.abs(error) <= 1.0e-8 * Math.max(1.0, Math.abs(targetEnthalpy))) {
+        return;
+      }
+      double change = error / heatCapacity;
+      change = Math.max(-20.0, Math.min(20.0, change));
+      temperature = Math.max(1.0, temperature + change);
+    }
+    state.getPhase(phaseNumber).setTemperature(temperature);
+    state.init(3);
+  }
+
+  private static void solveTotalEnergy(SystemInterface state, double targetEnthalpy) {
+    for (int iteration = 0; iteration < 50; iteration++) {
+      state.init(3);
+      double error = targetEnthalpy - totalEnthalpy(state);
+      if (!Double.isFinite(error)) {
+        throw new IllegalStateException("unable to evaluate overall energy balance");
+      }
+      if (Math.abs(error) <= 1.0e-9 * Math.max(1.0, Math.abs(targetEnthalpy))) {
+        return;
+      }
+      double[] heatCapacities = new double[] { state.getPhase(0).getCp(), state.getPhase(1).getCp() };
+      int correctionPhase = -1;
+      double correctionHeatCapacity = 0.0;
+      for (int phase = 0; phase < 2; phase++) {
+        if (Double.isFinite(heatCapacities[phase]) && heatCapacities[phase] > correctionHeatCapacity) {
+          correctionPhase = phase;
+          correctionHeatCapacity = heatCapacities[phase];
+        }
+      }
+      if (correctionPhase < 0 || correctionHeatCapacity < 1.0e-12) {
+        throw new IllegalStateException("unable to close overall energy balance");
+      }
+      double temperatureChange = error / correctionHeatCapacity;
+      temperatureChange = Math.max(-100.0, Math.min(100.0, temperatureChange));
+      state.getPhase(correctionPhase)
+          .setTemperature(Math.max(1.0, state.getPhase(correctionPhase).getTemperature() + temperatureChange));
+    }
+    state.init(3);
+    double finalError = targetEnthalpy - totalEnthalpy(state);
+    if (!Double.isFinite(finalError) || Math.abs(finalError) > 1.0e-6 * Math.max(1.0, Math.abs(targetEnthalpy))) {
+      throw new IllegalStateException("overall energy balance did not converge");
+    }
+  }
+
+  private static double[] componentTotals(SystemInterface system, int componentCount) {
+    double[] totals = new double[componentCount];
+    for (int i = 0; i < componentCount; i++) {
+      totals[i] = system.getPhase(0).getComponent(i).getNumberOfMolesInPhase()
+          + system.getPhase(1).getComponent(i).getNumberOfMolesInPhase();
+    }
+    return totals;
+  }
+
+  private static double maximumComponentBalanceError(SystemInterface system, double[] initialTotals) {
+    double maximumError = 0.0;
+    for (int i = 0; i < initialTotals.length; i++) {
+      double finalTotal = system.getPhase(0).getComponent(i).getNumberOfMolesInPhase()
+          + system.getPhase(1).getComponent(i).getNumberOfMolesInPhase();
+      maximumError = Math.max(maximumError, Math.abs(finalTotal - initialTotals[i]));
+    }
+    return maximumError;
+  }
+
+  private static double trackedMass(SystemInterface system, double[] trackedMoles) {
+    double mass = 0.0;
+    for (int i = 0; i < trackedMoles.length; i++) {
+      mass += trackedMoles[i] * system.getPhase(1).getComponent(i).getMolarMass();
+    }
+    return mass;
+  }
+
+  private static double totalEnthalpy(SystemInterface system) {
+    return system.getPhase(0).getEnthalpy("J") + system.getPhase(1).getEnthalpy("J");
+  }
+
+  private static double safeHeatCapacity(double heatCapacity) {
+    return Double.isFinite(heatCapacity) && Math.abs(heatCapacity) > 1.0e-12 ? Math.abs(heatCapacity) : 1.0e-12;
+  }
+
+  private static void validateClosure(LocalClosure closure) {
+    for (int i = 0; i < closure.componentMolarFluxes.length; i++) {
+      if (!Double.isFinite(closure.componentMolarFluxes[i])) {
+        throw new IllegalStateException("non-finite Maxwell-Stefan component flux at index " + i);
+      }
+    }
+    for (int i = 0; i < closure.interphaseHeatFluxes.length; i++) {
+      if (!Double.isFinite(closure.interphaseHeatFluxes[i])) {
+        throw new IllegalStateException("non-finite interphase heat flux for phase " + i);
+      }
+    }
+  }
+
+  private static boolean allFinite(double[] values) {
+    for (int i = 0; i < values.length; i++) {
+      if (!Double.isFinite(values[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static void addWarningOnce(List<String> warnings, String warning) {
+    if (!warnings.contains(warning)) {
+      warnings.add(warning);
+    }
+  }
+
+  private static final class LocalClosure {
+    private final double[] componentMolarFluxes;
+    private final double[] interphaseHeatFluxes;
+    private final boolean usedHeatFluxFallback;
+
+    private LocalClosure(double[] componentMolarFluxes, double[] interphaseHeatFluxes, boolean usedHeatFluxFallback) {
+      this.componentMolarFluxes = componentMolarFluxes;
+      this.interphaseHeatFluxes = interphaseHeatFluxes;
+      this.usedHeatFluxFallback = usedHeatFluxFallback;
+    }
+  }
+
+  private static final class StepEstimate {
+    private final double maximumDonorFraction;
+    private final double maximumTemperatureChange;
+
+    private StepEstimate(double maximumDonorFraction, double maximumTemperatureChange) {
+      this.maximumDonorFraction = maximumDonorFraction;
+      this.maximumTemperatureChange = maximumTemperatureChange;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationStudy.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationStudy.java
@@ -2,9 +2,11 @@ package neqsim.process.equipment.pipeline.evaporation;
 
 import java.util.ArrayList;
 import java.util.List;
+import neqsim.fluidmechanics.flownode.DispersedPhaseSlipCalculator;
 import neqsim.fluidmechanics.flownode.fluidboundary.interphasetransportcoefficient.interphasetwophase.interphasepipeflow.InterphaseDropletFlow;
 import neqsim.fluidmechanics.flownode.twophasenode.TwoPhaseFlowNode;
 import neqsim.fluidmechanics.flownode.twophasenode.twophasepipeflownode.AnnularFlow;
+import neqsim.fluidmechanics.flownode.twophasenode.twophasepipeflownode.BubbleFlowNode;
 import neqsim.fluidmechanics.flownode.twophasenode.twophasepipeflownode.DropletFlowNode;
 import neqsim.fluidmechanics.geometrydefinitions.pipe.PipeData;
 import neqsim.thermo.phase.PhaseType;
@@ -37,6 +39,7 @@ public class PipelineEvaporationStudy {
   private static final double MINIMUM_INVENTORY = 1.0e-20;
   private final SystemInterface inletSystem;
   private final PipelineEvaporationConfig config;
+  private final boolean gasDissolution;
 
   /**
    * Constructor.
@@ -45,6 +48,12 @@ public class PipelineEvaporationStudy {
    * @param config geometry and numerical settings
    */
   public PipelineEvaporationStudy(SystemInterface inletSystem, PipelineEvaporationConfig config) {
+    this(inletSystem, config, false);
+  }
+
+  /** Constructor used by the gas-dissolution specialization. */
+  protected PipelineEvaporationStudy(SystemInterface inletSystem, PipelineEvaporationConfig config,
+      boolean gasDissolution) {
     if (inletSystem == null) {
       throw new IllegalArgumentException("inlet system cannot be null");
     }
@@ -53,6 +62,7 @@ public class PipelineEvaporationStudy {
     }
     this.inletSystem = inletSystem.clone();
     this.config = config;
+    this.gasDissolution = gasDissolution;
   }
 
   /**
@@ -64,25 +74,29 @@ public class PipelineEvaporationStudy {
     config.validate();
     SystemInterface state = inletSystem.clone();
     validateSystem(state);
+    PhaseType configuredLiquidPhaseType = state.getPhase(1).getType();
     state.init(3);
+    setLiquidPhaseType(state, configuredLiquidPhaseType);
     state.initPhysicalProperties();
 
     int componentCount = state.getPhase(0).getNumberOfComponents();
     double[] initialComponentTotals = componentTotals(state, componentCount);
-    double[] trackedLiquidMoles = new double[componentCount];
+    int trackedPhase = gasDissolution ? 0 : 1;
+    double[][] trackedMolesByPhase = new double[2][componentCount];
     for (int i = 0; i < componentCount; i++) {
-      trackedLiquidMoles[i] = state.getPhase(1).getComponent(i).getNumberOfMolesInPhase();
+      trackedMolesByPhase[trackedPhase][i] = state.getPhase(trackedPhase).getComponent(i).getNumberOfMolesInPhase();
     }
 
-    double initialTrackedMass = trackedMass(state, trackedLiquidMoles);
+    double initialTrackedMass = trackedMass(state, trackedMolesByPhase[trackedPhase], trackedPhase);
     if (!(initialTrackedMass > 0.0)) {
-      throw new IllegalArgumentException("phase 1 must contain a positive injected-liquid flow");
+      throw new IllegalArgumentException(gasDissolution ? "phase 0 must contain a positive injected-gas flow"
+          : "phase 1 must contain a positive injected-liquid flow");
     }
-    double initialLiquidDensity = state.getPhase(1).getPhysicalProperties().getDensity();
-    if (!Double.isFinite(initialLiquidDensity) || initialLiquidDensity <= 0.0) {
-      throw new IllegalArgumentException("phase 1 liquid density must be finite and positive");
+    double initialDispersedDensity = state.getPhase(trackedPhase).getPhysicalProperties().getDensity();
+    if (!Double.isFinite(initialDispersedDensity) || initialDispersedDensity <= 0.0) {
+      throw new IllegalArgumentException("dispersed-phase density must be finite and positive");
     }
-    double initialLiquidVolumeFlow = initialTrackedMass / initialLiquidDensity;
+    double initialDispersedVolumeFlow = initialTrackedMass / initialDispersedDensity;
     double initialEnthalpy = totalEnthalpy(state);
 
     List<EvaporationProfilePoint> profile = new ArrayList<EvaporationProfilePoint>();
@@ -94,25 +108,32 @@ public class PipelineEvaporationStudy {
     double completionDistance = Double.NaN;
     boolean complete = false;
 
+    LocalHydrodynamics initialHydrodynamics = calculateLocalHydrodynamics(state, characteristicSize(1.0));
     profile.add(new EvaporationProfilePoint(0.0, 1.0, characteristicSize(1.0), state.getPhase(0).getTemperature(),
-        state.getPhase(1).getTemperature(), interfacialAreaPerLength(1.0, initialLiquidVolumeFlow), 0.0,
-        new double[componentCount]));
+        state.getPhase(1).getTemperature(),
+        interfacialAreaPerLength(1.0, initialDispersedVolumeFlow,
+            initialHydrodynamics.dispersedPhaseVelocity(gasDissolution)),
+        0.0, new double[componentCount], initialHydrodynamics.gasVelocity, initialHydrodynamics.liquidVelocity,
+        initialHydrodynamics.relativeVelocity));
 
     int acceptedSteps = 0;
     while (distance < config.getPipeLength() && remainingFraction > config.getCompletionFraction()
         && acceptedSteps < config.getMaximumNumberOfSteps()) {
       state.init(3);
+      setLiquidPhaseType(state, configuredLiquidPhaseType);
       state.initPhysicalProperties();
-      double liquidVolumeRatio = phaseVolumeFlow(state, 1) / initialLiquidVolumeFlow;
-      double characteristicSize = characteristicSize(liquidVolumeRatio);
-      LocalClosure closure = calculateLocalClosure(state, characteristicSize, trackedLiquidMoles);
+      double dispersedVolumeRatio = phaseVolumeFlow(state, trackedPhase) / initialDispersedVolumeFlow;
+      double characteristicSize = characteristicSize(dispersedVolumeRatio);
+      LocalHydrodynamics hydrodynamics = calculateLocalHydrodynamics(state, characteristicSize);
+      LocalClosure closure = calculateLocalClosure(state, characteristicSize, trackedMolesByPhase[1], hydrodynamics);
       validateClosure(closure);
       if (closure.usedHeatFluxFallback) {
         addWarningOnce(warnings, "The coupled boundary returned a non-finite heat flux near phase depletion; "
             + "a bounded two-film enthalpy closure was used for that axial state.");
       }
 
-      double areaPerLength = interfacialAreaPerLength(liquidVolumeRatio, initialLiquidVolumeFlow);
+      double areaPerLength = interfacialAreaPerLength(dispersedVolumeRatio, initialDispersedVolumeFlow,
+          hydrodynamics.dispersedPhaseVelocity(gasDissolution));
       double candidateStep = Math.min(stepLength, config.getPipeLength() - distance);
       StepEstimate estimate = estimateStep(state, closure, areaPerLength, candidateStep);
 
@@ -127,11 +148,10 @@ public class PipelineEvaporationStudy {
       double previousFraction = remainingFraction;
       double enthalpyBefore = totalEnthalpy(state);
       double[] transfer = new double[componentCount];
-      double[] liquidInventoryBefore = new double[componentCount];
       for (int i = 0; i < componentCount; i++) {
-        liquidInventoryBefore[i] = state.getPhase(1).getComponent(i).getNumberOfMolesInPhase();
         transfer[i] = closure.componentMolarFluxes[i] * effectiveArea;
         int donorPhase = transfer[i] >= 0.0 ? 0 : 1;
+        int receiverPhase = 1 - donorPhase;
         double donorInventory = state.getPhase(donorPhase).getComponent(i).getNumberOfMolesInPhase();
         double maximumTransfer = 0.999 * Math.max(0.0, donorInventory);
         if (Math.abs(transfer[i]) > maximumTransfer) {
@@ -139,13 +159,14 @@ public class PipelineEvaporationStudy {
           addWarningOnce(warnings, "A closure flux pointed out of a depleted component inventory; "
               + "a conservative component limiter was applied.");
         }
+        if (donorInventory > MINIMUM_INVENTORY) {
+          double trackedShare = Math.min(1.0, trackedMolesByPhase[donorPhase][i] / donorInventory);
+          double trackedTransfer = Math.abs(transfer[i]) * trackedShare;
+          trackedMolesByPhase[donorPhase][i] = Math.max(0.0, trackedMolesByPhase[donorPhase][i] - trackedTransfer);
+          trackedMolesByPhase[receiverPhase][i] += trackedTransfer;
+        }
         state.getPhase(0).addMoles(i, -transfer[i]);
         state.getPhase(1).addMoles(i, transfer[i]);
-
-        if (transfer[i] < 0.0 && liquidInventoryBefore[i] > MINIMUM_INVENTORY) {
-          double trackedShare = Math.min(1.0, trackedLiquidMoles[i] / liquidInventoryBefore[i]);
-          trackedLiquidMoles[i] = Math.max(0.0, trackedLiquidMoles[i] + transfer[i] * trackedShare);
-        }
       }
 
       double gasTemperature = state.getPhase(0).getTemperature();
@@ -153,10 +174,11 @@ public class PipelineEvaporationStudy {
       state.initBeta();
       state.init_x_y();
       state.init(3);
+      setLiquidPhaseType(state, configuredLiquidPhaseType);
 
       double wallHeat = wallHeat(candidateStep, gasTemperature, liquidTemperature);
-      double gasWallHeat = config.getLiquidDistribution() == LiquidDistribution.DROPLETS ? wallHeat : 0.0;
-      double liquidWallHeat = config.getLiquidDistribution() == LiquidDistribution.WALL_FILM ? wallHeat : 0.0;
+      double gasWallHeat = wallHeatReceivingPhase() == 0 ? wallHeat : 0.0;
+      double liquidWallHeat = wallHeatReceivingPhase() == 1 ? wallHeat : 0.0;
       double gasTargetEnthalpy = state.getPhase(0).getEnthalpy("J") + closure.interphaseHeatFluxes[0] * effectiveArea
           + gasWallHeat;
       double liquidTargetEnthalpy = state.getPhase(1).getEnthalpy("J") + closure.interphaseHeatFluxes[1] * effectiveArea
@@ -166,6 +188,7 @@ public class PipelineEvaporationStudy {
       solvePhaseTemperature(state, 1, liquidTargetEnthalpy, liquidTemperature);
       solveTotalEnergy(state, enthalpyBefore + wallHeat);
       state.init(3);
+      setLiquidPhaseType(state, configuredLiquidPhaseType);
       state.initPhysicalProperties();
 
       double stepEnergyResidual = totalEnthalpy(state) - enthalpyBefore - wallHeat;
@@ -178,7 +201,7 @@ public class PipelineEvaporationStudy {
       distance += candidateStep;
       cumulativeWallHeat += wallHeat;
       acceptedSteps++;
-      remainingFraction = trackedMass(state, trackedLiquidMoles) / initialTrackedMass;
+      remainingFraction = trackedMass(state, trackedMolesByPhase[trackedPhase], trackedPhase) / initialTrackedMass;
       remainingFraction = Math.max(0.0, Math.min(1.0, remainingFraction));
 
       double totalFlux = 0.0;
@@ -187,10 +210,16 @@ public class PipelineEvaporationStudy {
         appliedFluxes[i] = transfer[i] / effectiveArea;
         totalFlux += appliedFluxes[i];
       }
-      double outletLiquidVolumeRatio = phaseVolumeFlow(state, 1) / initialLiquidVolumeFlow;
-      profile.add(new EvaporationProfilePoint(distance, remainingFraction, characteristicSize(outletLiquidVolumeRatio),
-          state.getPhase(0).getTemperature(), state.getPhase(1).getTemperature(),
-          interfacialAreaPerLength(outletLiquidVolumeRatio, initialLiquidVolumeFlow), totalFlux, appliedFluxes));
+      double outletDispersedVolumeRatio = phaseVolumeFlow(state, trackedPhase) / initialDispersedVolumeFlow;
+      double outletCharacteristicSize = characteristicSize(outletDispersedVolumeRatio);
+      LocalHydrodynamics outletHydrodynamics = calculateLocalHydrodynamics(state, outletCharacteristicSize);
+      profile.add(new EvaporationProfilePoint(distance, remainingFraction,
+          characteristicSize(outletDispersedVolumeRatio), state.getPhase(0).getTemperature(),
+          state.getPhase(1).getTemperature(),
+          interfacialAreaPerLength(outletDispersedVolumeRatio, initialDispersedVolumeFlow,
+              outletHydrodynamics.dispersedPhaseVelocity(gasDissolution)),
+          totalFlux, appliedFluxes, outletHydrodynamics.gasVelocity, outletHydrodynamics.liquidVelocity,
+          outletHydrodynamics.relativeVelocity));
 
       if (remainingFraction <= config.getCompletionFraction()) {
         double denominator = previousFraction - remainingFraction;
@@ -213,15 +242,18 @@ public class PipelineEvaporationStudy {
       addWarningOnce(warnings, "The maximum number of axial steps was reached before completion.");
     }
     if (!complete && remainingFraction > config.getCompletionFraction()) {
-      addWarningOnce(warnings, "The injected liquid did not reach the completion criterion within the pipe length.");
+      addWarningOnce(warnings,
+          gasDissolution ? "The injected gas did not reach the dissolution criterion within the pipe length."
+              : "The injected liquid did not reach the evaporation criterion within the pipe length.");
     }
 
     double maxComponentBalanceError = maximumComponentBalanceError(state, initialComponentTotals);
+    setLiquidPhaseType(state, configuredLiquidPhaseType);
     double finalEnthalpy = totalEnthalpy(state);
     double energyScale = Math.max(1.0, Math.abs(initialEnthalpy) + Math.abs(cumulativeWallHeat));
     double relativeEnergyError = Math.abs(finalEnthalpy - initialEnthalpy - cumulativeWallHeat) / energyScale;
     return new PipelineEvaporationResult(profile, complete, completionDistance, maxComponentBalanceError,
-        relativeEnergyError, warnings, state);
+        relativeEnergyError, warnings, state, gasDissolution);
   }
 
   private void validateSystem(SystemInterface system) {
@@ -232,8 +264,8 @@ public class PipelineEvaporationStudy {
       throw new IllegalArgumentException("phase 0 must be gas");
     }
     PhaseType liquidType = system.getPhase(1).getType();
-    if (liquidType != PhaseType.OIL && liquidType != PhaseType.LIQUID) {
-      throw new IllegalArgumentException("phase 1 must be a hydrocarbon liquid or oil phase");
+    if (liquidType != PhaseType.OIL && liquidType != PhaseType.LIQUID && liquidType != PhaseType.AQUEOUS) {
+      throw new IllegalArgumentException("phase 1 must be an oil, liquid, or aqueous phase");
     }
     if (system.getPhase(0).getNumberOfComponents() < 2) {
       throw new IllegalArgumentException("Maxwell-Stefan transfer requires at least two components");
@@ -241,19 +273,25 @@ public class PipelineEvaporationStudy {
   }
 
   private LocalClosure calculateLocalClosure(SystemInterface state, double characteristicSize,
-      double[] trackedLiquidMoles) {
+      double[] trackedLiquidMoles, LocalHydrodynamics hydrodynamics) {
     PipeData pipe = new PipeData(config.getPipeDiameter(), config.getPipeRoughness());
     SystemInterface localSystem = state.clone();
     TwoPhaseFlowNode node;
-    if (config.getLiquidDistribution() == LiquidDistribution.DROPLETS) {
+    if (gasDissolution) {
+      BubbleFlowNode bubbleNode = new BubbleFlowNode(localSystem, pipe);
+      bubbleNode.setAverageBubbleDiameter(characteristicSize);
+      bubbleNode.setSpecifiedDispersedPhaseRelativeVelocity(hydrodynamics.relativeVelocity);
+      node = bubbleNode;
+    } else if (config.getLiquidDistribution() == LiquidDistribution.DROPLETS) {
       DropletFlowNode dropletNode = new DropletFlowNode(localSystem, pipe);
       dropletNode.setAverageDropletDiameter(characteristicSize);
+      dropletNode.setSpecifiedDispersedPhaseRelativeVelocity(hydrodynamics.relativeVelocity);
       node = dropletNode;
     } else {
       node = new AnnularFlow(localSystem, pipe);
     }
 
-    setLocalHydrodynamics(node, localSystem, pipe);
+    setLocalHydrodynamics(node, localSystem, pipe, hydrodynamics);
     node.setLengthOfNode(1.0);
     node.getFluidBoundary().setMassTransferCalc(true);
     node.getFluidBoundary().setHeatTransferCalc(true);
@@ -300,7 +338,8 @@ public class PipelineEvaporationStudy {
             : (phase == 0 ? 0.02 : 0.10);
         double characteristicLength = node instanceof DropletFlowNode
             ? ((DropletFlowNode) node).getAverageDropletDiameter()
-            : 0.01 * node.getGeometry().getDiameter();
+            : node instanceof BubbleFlowNode ? ((BubbleFlowNode) node).getAverageBubbleDiameter()
+                : 0.01 * node.getGeometry().getDiameter();
         double stagnantNusseltNumber = node instanceof DropletFlowNode && phase == 1 ? 17.66 : 2.0;
         heatTransferCoefficients[phase] = stagnantNusseltNumber * safeConductivity
             / Math.max(1.0e-8, characteristicLength);
@@ -336,19 +375,42 @@ public class PipelineEvaporationStudy {
         -heatTransferCoefficients[1] * (node.getBulkSystem().getPhase(1).getTemperature() - interfaceTemperature) };
   }
 
-  private void setLocalHydrodynamics(TwoPhaseFlowNode node, SystemInterface system, PipeData pipe) {
+  private void setLocalHydrodynamics(TwoPhaseFlowNode node, SystemInterface system, PipeData pipe,
+      LocalHydrodynamics hydrodynamics) {
     double gasVolumeFlow = phaseVolumeFlow(system, 0);
     double liquidVolumeFlow = phaseVolumeFlow(system, 1);
-    double gasAreaDemand = gasVolumeFlow / config.getGasVelocity();
-    double liquidAreaDemand = liquidVolumeFlow / config.getLiquidVelocity();
+    double gasAreaDemand = gasVolumeFlow / hydrodynamics.gasVelocity;
+    double liquidAreaDemand = liquidVolumeFlow / hydrodynamics.liquidVelocity;
     double totalAreaDemand = gasAreaDemand + liquidAreaDemand;
     double gasFraction = totalAreaDemand > 0.0 ? gasAreaDemand / totalAreaDemand : 0.999;
     gasFraction = Math.max(1.0e-6, Math.min(1.0 - 1.0e-6, gasFraction));
     node.setPhaseFraction(0, gasFraction);
     node.setPhaseFraction(1, 1.0 - gasFraction);
-    node.setVelocity(0, config.getGasVelocity());
-    node.setVelocity(1, config.getLiquidVelocity());
+    node.setVelocity(0, hydrodynamics.gasVelocity);
+    node.setVelocity(1, hydrodynamics.liquidVelocity);
     pipe.setNodeLength(1.0);
+  }
+
+  private LocalHydrodynamics calculateLocalHydrodynamics(SystemInterface system, double characteristicSize) {
+    if (config.getSlipModel() == DispersedPhaseSlipModel.USER_SPECIFIED
+        || config.getLiquidDistribution() == LiquidDistribution.WALL_FILM && !gasDissolution) {
+      return new LocalHydrodynamics(config.getGasVelocity(), config.getLiquidVelocity(),
+          Math.abs(config.getGasVelocity() - config.getLiquidVelocity()));
+    }
+
+    int dispersedPhase = gasDissolution ? 0 : 1;
+    int continuousPhase = 1 - dispersedPhase;
+    double continuousDensity = system.getPhase(continuousPhase).getPhysicalProperties().getDensity();
+    double dispersedDensity = system.getPhase(dispersedPhase).getPhysicalProperties().getDensity();
+    double continuousViscosity = system.getPhase(continuousPhase).getPhysicalProperties().getViscosity();
+    double relativeVelocity = DispersedPhaseSlipCalculator.terminalVelocityMagnitude(characteristicSize,
+        continuousDensity, dispersedDensity, continuousViscosity);
+    double axialSlip = -Math.signum(dispersedDensity - continuousDensity) * relativeVelocity
+        * Math.sin(config.getPipeInclinationAngle());
+    double continuousVelocity = gasDissolution ? config.getLiquidVelocity() : config.getGasVelocity();
+    double dispersedVelocity = Math.max(1.0e-6, continuousVelocity + axialSlip);
+    return gasDissolution ? new LocalHydrodynamics(dispersedVelocity, continuousVelocity, relativeVelocity)
+        : new LocalHydrodynamics(continuousVelocity, dispersedVelocity, relativeVelocity);
   }
 
   private double calculateSpaldingMassTransferNumber(TwoPhaseFlowNode node, double[] trackedLiquidMoles) {
@@ -397,8 +459,8 @@ public class PipelineEvaporationStudy {
     }
 
     double wallHeat = wallHeat(stepLength, state.getPhase(0).getTemperature(), state.getPhase(1).getTemperature());
-    double gasWallHeat = config.getLiquidDistribution() == LiquidDistribution.DROPLETS ? wallHeat : 0.0;
-    double liquidWallHeat = config.getLiquidDistribution() == LiquidDistribution.WALL_FILM ? wallHeat : 0.0;
+    double gasWallHeat = wallHeatReceivingPhase() == 0 ? wallHeat : 0.0;
+    double liquidWallHeat = wallHeatReceivingPhase() == 1 ? wallHeat : 0.0;
     double gasCp = safeHeatCapacity(state.getPhase(0).getCp());
     double liquidCp = safeHeatCapacity(state.getPhase(1).getCp());
     double gasChange = Math.abs(closure.interphaseHeatFluxes[0] * area + gasWallHeat) / gasCp;
@@ -407,10 +469,21 @@ public class PipelineEvaporationStudy {
   }
 
   private double interfacialAreaPerLength(double liquidVolumeRatio, double initialLiquidVolumeFlow) {
+    return interfacialAreaPerLength(liquidVolumeRatio, initialLiquidVolumeFlow,
+        gasDissolution ? config.getGasVelocity() : config.getLiquidVelocity());
+  }
+
+  private double interfacialAreaPerLength(double liquidVolumeRatio, double initialLiquidVolumeFlow,
+      double dispersedPhaseVelocity) {
+    if (gasDissolution) {
+      double diameter = characteristicSize(liquidVolumeRatio);
+      double currentVolumeFlow = initialLiquidVolumeFlow * Math.max(0.0, liquidVolumeRatio);
+      return bubbleAreaPerLength(currentVolumeFlow, dispersedPhaseVelocity, diameter);
+    }
     if (config.getLiquidDistribution() == LiquidDistribution.DROPLETS) {
       double diameter = characteristicSize(liquidVolumeRatio);
       double currentVolumeFlow = initialLiquidVolumeFlow * Math.max(0.0, liquidVolumeRatio);
-      return dropletAreaPerLength(currentVolumeFlow, config.getLiquidVelocity(), diameter);
+      return dropletAreaPerLength(currentVolumeFlow, dispersedPhaseVelocity, diameter);
     }
     double filmThickness = characteristicSize(liquidVolumeRatio);
     return filmAreaPerLength(config.getPipeDiameter(), filmThickness, config.getWettedPerimeterFraction());
@@ -432,6 +505,18 @@ public class PipelineEvaporationStudy {
   }
 
   /**
+   * Calculate the surface area of a spherical-bubble population per axial length.
+   *
+   * @param gasVolumeFlow dispersed gas volume flow in m3/s
+   * @param gasVelocity bubble velocity in m/s
+   * @param sauterMeanDiameter Sauter mean diameter in m
+   * @return interfacial area per length in m2/m
+   */
+  static double bubbleAreaPerLength(double gasVolumeFlow, double gasVelocity, double sauterMeanDiameter) {
+    return dropletAreaPerLength(gasVolumeFlow, gasVelocity, sauterMeanDiameter);
+  }
+
+  /**
    * Calculate wall-film interfacial area per axial length.
    *
    * @param pipeDiameter pipe inside diameter in m
@@ -446,6 +531,9 @@ public class PipelineEvaporationStudy {
 
   private double characteristicSize(double liquidVolumeRatio) {
     double boundedRatio = Math.max(0.0, liquidVolumeRatio);
+    if (gasDissolution) {
+      return config.getInitialBubbleDiameter() * Math.cbrt(boundedRatio);
+    }
     if (config.getLiquidDistribution() == LiquidDistribution.DROPLETS) {
       return config.getInitialDropletDiameter() * Math.cbrt(boundedRatio);
     }
@@ -453,16 +541,24 @@ public class PipelineEvaporationStudy {
   }
 
   private double wallHeat(double stepLength, double gasTemperature, double liquidTemperature) {
-    double receivingTemperature = config.getLiquidDistribution() == LiquidDistribution.DROPLETS ? gasTemperature
-        : liquidTemperature;
+    double receivingTemperature = wallHeatReceivingPhase() == 0 ? gasTemperature : liquidTemperature;
     return config.getOverallWallHeatTransferCoefficient() * Math.PI * config.getPipeDiameter() * stepLength
         * (config.getAmbientTemperature() - receivingTemperature);
+  }
+
+  private int wallHeatReceivingPhase() {
+    return !gasDissolution && config.getLiquidDistribution() == LiquidDistribution.DROPLETS ? 0 : 1;
   }
 
   private static double phaseVolumeFlow(SystemInterface system, int phase) {
     double massFlow = system.getPhase(phase).getNumberOfMolesInPhase() * system.getPhase(phase).getMolarMass();
     double density = system.getPhase(phase).getPhysicalProperties().getDensity();
     return density > 0.0 ? massFlow / density : 0.0;
+  }
+
+  private static void setLiquidPhaseType(SystemInterface system, PhaseType phaseType) {
+    system.setPhaseType(1, phaseType);
+    system.getPhase(1).setType(phaseType);
   }
 
   private static void solvePhaseTemperature(SystemInterface state, int phaseNumber, double targetEnthalpy,
@@ -540,10 +636,10 @@ public class PipelineEvaporationStudy {
     return maximumError;
   }
 
-  private static double trackedMass(SystemInterface system, double[] trackedMoles) {
+  private static double trackedMass(SystemInterface system, double[] trackedMoles, int trackedPhase) {
     double mass = 0.0;
     for (int i = 0; i < trackedMoles.length; i++) {
-      mass += trackedMoles[i] * system.getPhase(1).getComponent(i).getMolarMass();
+      mass += trackedMoles[i] * system.getPhase(trackedPhase).getComponent(i).getMolarMass();
     }
     return mass;
   }
@@ -593,6 +689,22 @@ public class PipelineEvaporationStudy {
       this.componentMolarFluxes = componentMolarFluxes;
       this.interphaseHeatFluxes = interphaseHeatFluxes;
       this.usedHeatFluxFallback = usedHeatFluxFallback;
+    }
+  }
+
+  private static final class LocalHydrodynamics {
+    private final double gasVelocity;
+    private final double liquidVelocity;
+    private final double relativeVelocity;
+
+    private LocalHydrodynamics(double gasVelocity, double liquidVelocity, double relativeVelocity) {
+      this.gasVelocity = gasVelocity;
+      this.liquidVelocity = liquidVelocity;
+      this.relativeVelocity = relativeVelocity;
+    }
+
+    private double dispersedPhaseVelocity(boolean gasIsDispersed) {
+      return gasIsDispersed ? gasVelocity : liquidVelocity;
     }
   }
 

--- a/src/test/java/neqsim/fluidmechanics/flownode/fluidboundary/interphasetransportcoefficient/interphasetwophase/interphasepipeflow/InterphaseDropletFlowCorrelationTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flownode/fluidboundary/interphasetransportcoefficient/interphasetwophase/interphasepipeflow/InterphaseDropletFlowCorrelationTest.java
@@ -1,0 +1,34 @@
+package neqsim.fluidmechanics.flownode.fluidboundary.interphasetransportcoefficient.interphasetwophase.interphasepipeflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+/** Fast equation-level checks for the droplet transfer correlations. */
+public class InterphaseDropletFlowCorrelationTest {
+  @Test
+  void testRanzMarshallSherwoodReferenceValue() {
+    InterphaseDropletFlow model = new InterphaseDropletFlow();
+    double reynoldsNumber = 100.0;
+    double schmidtNumber = 0.70;
+    double expected = 2.0 + 0.6 * Math.sqrt(reynoldsNumber) * Math.pow(schmidtNumber, 0.33);
+    assertEquals(expected, model.calcSherwoodNumber(0, reynoldsNumber, schmidtNumber, null), 1.0e-12);
+  }
+
+  @Test
+  void testRanzMarshallNusseltReferenceValue() {
+    InterphaseDropletFlow model = new InterphaseDropletFlow();
+    double reynoldsNumber = 40.0;
+    double prandtlNumber = 0.72;
+    double expected = 2.0 + 0.6 * Math.sqrt(reynoldsNumber) * Math.pow(prandtlNumber, 0.33);
+    assertEquals(expected, model.calcNusseltNumber(0, reynoldsNumber, prandtlNumber, null), 1.0e-12);
+  }
+
+  @Test
+  void testAbramzonSirignanoReferenceAndLimit() {
+    InterphaseDropletFlow model = new InterphaseDropletFlow();
+    assertEquals(1.0, model.calcAbramzonSirignanoF(0.0), 0.0);
+    assertEquals(Math.pow(2.0, 0.7) * Math.log(2.0), model.calcAbramzonSirignanoF(1.0), 1.0e-12);
+    assertTrue(model.calcAbramzonSirignanoF(5.0) > model.calcAbramzonSirignanoF(1.0));
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationStudyTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationStudyTest.java
@@ -1,0 +1,158 @@
+package neqsim.process.equipment.pipeline.evaporation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests for the conservative axial pipeline evaporation model. */
+public class PipelineEvaporationStudyTest {
+  @Test
+  void testDropletAreaPerLengthUsesSauterMeanDiameter() {
+    double area = PipelineEvaporationStudy.dropletAreaPerLength(2.0e-5, 0.5, 200.0e-6);
+    assertEquals(1.2, area, 1.0e-12);
+    assertEquals(0.0, PipelineEvaporationStudy.dropletAreaPerLength(0.0, 0.5, 200.0e-6), 0.0);
+  }
+
+  @Test
+  void testFilmAreaPerLengthUsesInterfaceDiameter() {
+    double area = PipelineEvaporationStudy.filmAreaPerLength(0.20, 0.50e-3, 0.75);
+    assertEquals(0.75 * Math.PI * 0.199, area, 1.0e-12);
+  }
+
+  @Test
+  void testConfigurationRejectsUnresolvedStepRange() {
+    PipelineEvaporationConfig config = new PipelineEvaporationConfig();
+    config.setMinimumStepLength(1.0);
+    config.setInitialStepLength(0.5);
+    assertThrows(IllegalArgumentException.class, config::validate);
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void testShortDropletMarchConservesComponents() {
+    SystemInterface inlet = createTwoPhaseHydrocarbonSystem();
+    double initialLiquidHeptane = inlet.getPhase(1).getComponent("n-heptane").getNumberOfMolesInPhase();
+
+    PipelineEvaporationConfig config = new PipelineEvaporationConfig();
+    config.setPipeLength(1.0e-3);
+    config.setMinimumStepLength(1.0e-3);
+    config.setInitialStepLength(1.0e-3);
+    config.setMaximumStepLength(1.0e-3);
+    config.setPipeDiameter(0.10);
+    config.setGasVelocity(5.0);
+    config.setLiquidVelocity(0.5);
+    config.setInitialDropletDiameter(200.0e-6);
+    config.setMaximumDonorFractionPerStep(0.5);
+    config.setMaximumTemperatureChangePerStep(20.0);
+    config.setUseAbramzonSirignano(false);
+
+    PipelineEvaporationResult result = new PipelineEvaporationStudy(inlet, config).run();
+
+    List<EvaporationProfilePoint> profile = result.getProfile();
+    assertEquals(2, profile.size());
+    assertEquals(1.0e-3, profile.get(1).getDistance(), 1.0e-15);
+    assertTrue(profile.get(1).getRemainingInjectedLiquidFraction() >= 0.0);
+    assertTrue(profile.get(1).getRemainingInjectedLiquidFraction() <= 1.0);
+    assertTrue(Double.isFinite(profile.get(1).getGasTemperature()));
+    assertTrue(Double.isFinite(profile.get(1).getLiquidTemperature()));
+    assertTrue(result.getMaximumComponentMolarBalanceError() < 1.0e-10);
+    assertTrue(result.getRelativeEnergyBalanceError() < 1.0e-6);
+    assertFalse(result.isCompleteEvaporation());
+
+    assertEquals(initialLiquidHeptane, inlet.getPhase(1).getComponent("n-heptane").getNumberOfMolesInPhase(), 0.0,
+        "the study must not mutate its inlet system");
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void testShortWallFilmMarchConservesComponents() {
+    SystemInterface inlet = createTwoPhaseHydrocarbonSystem();
+    PipelineEvaporationConfig config = new PipelineEvaporationConfig();
+    config.setLiquidDistribution(LiquidDistribution.WALL_FILM);
+    config.setPipeLength(1.0e-3);
+    config.setMinimumStepLength(1.0e-3);
+    config.setInitialStepLength(1.0e-3);
+    config.setMaximumStepLength(1.0e-3);
+    config.setPipeDiameter(0.10);
+    config.setGasVelocity(5.0);
+    config.setLiquidVelocity(0.5);
+    config.setInitialFilmThickness(0.50e-3);
+    config.setWettedPerimeterFraction(0.75);
+    config.setMaximumDonorFractionPerStep(0.5);
+    config.setMaximumTemperatureChangePerStep(20.0);
+
+    PipelineEvaporationResult result = new PipelineEvaporationStudy(inlet, config).run();
+    EvaporationProfilePoint outlet = result.getProfile().get(result.getProfile().size() - 1);
+
+    assertEquals(2, result.getProfile().size());
+    assertTrue(outlet.getRemainingInjectedLiquidFraction() >= 0.0);
+    assertTrue(outlet.getRemainingInjectedLiquidFraction() <= 1.0);
+    assertTrue(outlet.getInterfacialAreaPerLength() > 0.0);
+    assertTrue(result.getMaximumComponentMolarBalanceError() < 1.0e-10);
+    assertTrue(result.getRelativeEnergyBalanceError() < 1.0e-6);
+  }
+
+  @Test
+  @Tag("slow")
+  @Timeout(value = 120, unit = TimeUnit.SECONDS)
+  void testHotDropletCaseReachesMassBasedCompletion() {
+    SystemInterface inlet = createTwoPhaseHydrocarbonSystem();
+    inlet.setPressure(1.5);
+    inlet.getPhase(0).setTemperature(400.15);
+    inlet.getPhase(1).setTemperature(330.15);
+    inlet.init(3);
+    inlet.initPhysicalProperties();
+
+    PipelineEvaporationConfig config = new PipelineEvaporationConfig();
+    config.setPipeLength(1.0);
+    config.setPipeDiameter(0.10);
+    config.setGasVelocity(5.0);
+    config.setLiquidVelocity(0.5);
+    config.setMinimumStepLength(1.0e-8);
+    config.setInitialStepLength(1.0e-3);
+    config.setMaximumStepLength(0.01);
+    config.setMaximumDonorFractionPerStep(0.2);
+    config.setMaximumTemperatureChangePerStep(20.0);
+    config.setCompletionFraction(0.01);
+    config.setAmbientTemperature(400.15);
+    config.setOverallWallHeatTransferCoefficient(100.0);
+
+    PipelineEvaporationResult result = new PipelineEvaporationStudy(inlet, config).run();
+    EvaporationProfilePoint outlet = result.getProfile().get(result.getProfile().size() - 1);
+
+    assertTrue(result.isCompleteEvaporation());
+    assertTrue(result.getCompleteEvaporationDistance() > 0.0);
+    assertTrue(result.getCompleteEvaporationDistance() < config.getPipeLength());
+    assertTrue(outlet.getRemainingInjectedLiquidFraction() <= config.getCompletionFraction());
+    assertTrue(result.getMaximumComponentMolarBalanceError() < 1.0e-10);
+    assertTrue(result.getRelativeEnergyBalanceError() < 1.0e-5);
+  }
+
+  private static SystemInterface createTwoPhaseHydrocarbonSystem() {
+    SystemInterface system = new SystemSrkEos(335.15, 10.0);
+    system.addComponent("methane", 5.0, 0);
+    system.addComponent("ethane", 0.5, 0);
+    system.addComponent("n-heptane", 0.01, 1);
+    system.addComponent("nC10", 0.01, 1);
+    system.createDatabase(true);
+    system.setMixingRule(2);
+    system.setPhaseType(0, PhaseType.GAS);
+    system.setPhaseType(1, PhaseType.OIL);
+    system.getPhase(0).setTemperature(335.15);
+    system.getPhase(1).setTemperature(295.15);
+    system.initBeta();
+    system.init_x_y();
+    system.init(3);
+    system.initPhysicalProperties();
+    return system;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationStudyTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/evaporation/PipelineEvaporationStudyTest.java
@@ -9,8 +9,10 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import neqsim.fluidmechanics.flownode.DispersedPhaseSlipCalculator;
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.thermo.system.SystemSrkEos;
 
 /** Tests for the conservative axial pipeline evaporation model. */
@@ -26,6 +28,15 @@ public class PipelineEvaporationStudyTest {
   void testFilmAreaPerLengthUsesInterfaceDiameter() {
     double area = PipelineEvaporationStudy.filmAreaPerLength(0.20, 0.50e-3, 0.75);
     assertEquals(0.75 * Math.PI * 0.199, area, 1.0e-12);
+  }
+
+  @Test
+  void testBubbleAreaAndTerminalSlipClosures() {
+    assertEquals(1.2, PipelineEvaporationStudy.bubbleAreaPerLength(2.0e-4, 5.0, 200.0e-6), 1.0e-12);
+    double smallBubble = DispersedPhaseSlipCalculator.terminalVelocityMagnitude(0.50e-3, 800.0, 30.0, 5.0e-3);
+    double largeBubble = DispersedPhaseSlipCalculator.terminalVelocityMagnitude(1.00e-3, 800.0, 30.0, 5.0e-3);
+    assertTrue(smallBubble > 0.0);
+    assertTrue(largeBubble > smallBubble);
   }
 
   @Test
@@ -102,6 +113,77 @@ public class PipelineEvaporationStudyTest {
   }
 
   @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void testShortBubbleDissolutionIntoOilTracksInjectedGasAndSlip() {
+    SystemInterface inlet = createGasBubbleInOilSystem();
+    double initialGasMethane = inlet.getPhase(0).getComponent("methane").getNumberOfMolesInPhase();
+
+    PipelineEvaporationConfig config = oneStepDissolutionConfig();
+    config.setSlipModel(DispersedPhaseSlipModel.TERMINAL_VELOCITY);
+    config.setPipeInclinationAngle(Math.PI / 6.0);
+
+    PipelineDissolutionResult result = new PipelineDissolutionStudy(inlet, config).run();
+    EvaporationProfilePoint outlet = result.getProfile().get(1);
+
+    assertEquals(2, result.getProfile().size());
+    assertTrue(result.isGasDissolutionStudy());
+    assertFalse(result.isCompleteDissolution());
+    assertTrue(Double.isNaN(result.getCompleteDissolutionDistance()));
+    assertTrue(outlet.getRemainingTrackedPhaseFraction() >= 0.0);
+    assertTrue(outlet.getRemainingTrackedPhaseFraction() <= 1.0);
+    assertTrue(outlet.getGasVelocity() > outlet.getLiquidVelocity(), "bubbles should drift forward in an uphill pipe");
+    assertTrue(outlet.getDispersedPhaseRelativeVelocity() > 0.0);
+    assertTrue(result.getMaximumComponentMolarBalanceError() < 1.0e-10);
+    assertTrue(result.getRelativeEnergyBalanceError() < 1.0e-6);
+    assertEquals(config.getPipeLength(), outlet.getDistance(), 1.0e-15);
+    assertTrue(result.getWarnings().stream().anyMatch(warning -> warning.contains("did not reach")));
+    assertEquals(initialGasMethane, inlet.getPhase(0).getComponent("methane").getNumberOfMolesInPhase(), 0.0,
+        "the dissolution study must not mutate its inlet system");
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void testShortBubbleDissolutionAcceptsAqueousContinuousPhase() {
+    SystemInterface inlet = createGasBubbleInWaterSystem();
+    PipelineEvaporationConfig config = oneStepDissolutionConfig();
+    config.setInitialBubbleDiameter(0.50e-3);
+
+    PipelineDissolutionResult result = new PipelineDissolutionStudy(inlet, config).run();
+    EvaporationProfilePoint outlet = result.getProfile().get(1);
+
+    assertEquals(PhaseType.AQUEOUS, result.getOutletSystem().getPhase(1).getType());
+    assertTrue(outlet.getRemainingTrackedPhaseFraction() >= 0.0);
+    assertTrue(outlet.getRemainingTrackedPhaseFraction() < 1.0);
+    assertTrue(result.getMaximumComponentMolarBalanceError() < 1.0e-10);
+    assertTrue(result.getRelativeEnergyBalanceError() < 1.0e-6);
+  }
+
+  @Test
+  @Tag("slow")
+  @Timeout(value = 120, unit = TimeUnit.SECONDS)
+  void testGasBubbleCaseReachesMassBasedDissolutionCriterion() {
+    SystemInterface inlet = createGasBubbleInOilSystem();
+    PipelineEvaporationConfig config = oneStepDissolutionConfig();
+    config.setPipeLength(0.10);
+    config.setMinimumStepLength(1.0e-8);
+    config.setMaximumStepLength(0.01);
+    config.setMaximumDonorFractionPerStep(0.20);
+    config.setCompletionFraction(0.01);
+    config.setSlipModel(DispersedPhaseSlipModel.TERMINAL_VELOCITY);
+    config.setPipeInclinationAngle(Math.PI / 6.0);
+
+    PipelineDissolutionResult result = new PipelineDissolutionStudy(inlet, config).run();
+    EvaporationProfilePoint outlet = result.getProfile().get(result.getProfile().size() - 1);
+
+    assertTrue(result.isCompleteDissolution());
+    assertTrue(result.getCompleteDissolutionDistance() > 0.0);
+    assertTrue(result.getCompleteDissolutionDistance() < config.getPipeLength());
+    assertTrue(outlet.getRemainingTrackedPhaseFraction() <= config.getCompletionFraction());
+    assertTrue(result.getMaximumComponentMolarBalanceError() < 1.0e-10);
+    assertTrue(result.getRelativeEnergyBalanceError() < 1.0e-5);
+  }
+
+  @Test
   @Tag("slow")
   @Timeout(value = 120, unit = TimeUnit.SECONDS)
   void testHotDropletCaseReachesMassBasedCompletion() {
@@ -153,6 +235,53 @@ public class PipelineEvaporationStudyTest {
     system.init_x_y();
     system.init(3);
     system.initPhysicalProperties();
+    return system;
+  }
+
+  private static PipelineEvaporationConfig oneStepDissolutionConfig() {
+    PipelineEvaporationConfig config = new PipelineEvaporationConfig();
+    config.setPipeLength(1.0e-3);
+    config.setMinimumStepLength(1.0e-3);
+    config.setInitialStepLength(1.0e-3);
+    config.setMaximumStepLength(1.0e-3);
+    config.setPipeDiameter(0.10);
+    config.setGasVelocity(0.50);
+    config.setLiquidVelocity(0.30);
+    config.setInitialBubbleDiameter(1.0e-3);
+    config.setMaximumDonorFractionPerStep(0.5);
+    config.setMaximumTemperatureChangePerStep(20.0);
+    return config;
+  }
+
+  private static SystemInterface createGasBubbleInOilSystem() {
+    SystemInterface system = new SystemSrkEos(305.15, 120.0);
+    system.addComponent("methane", 0.01, 0);
+    system.addComponent("nC10", 5.0, 1);
+    system.createDatabase(true);
+    system.setMixingRule(2);
+    system.setPhaseType(0, PhaseType.GAS);
+    system.setPhaseType(1, PhaseType.OIL);
+    system.initBeta();
+    system.init_x_y();
+    system.init(3);
+    system.initPhysicalProperties();
+    return system;
+  }
+
+  private static SystemInterface createGasBubbleInWaterSystem() {
+    SystemInterface system = new SystemSrkCPAstatoil(295.15, 50.0);
+    system.addComponent("CO2", 0.10, 0);
+    system.addComponent("water", 20.0, 1);
+    system.createDatabase(true);
+    system.setMixingRule(10);
+    system.setPhaseType(0, PhaseType.GAS);
+    system.setPhaseType(1, PhaseType.AQUEOUS);
+    system.initBeta();
+    system.init_x_y();
+    system.init(3);
+    system.initPhysicalProperties();
+    system.setPhaseType(1, PhaseType.AQUEOUS);
+    system.getPhase(1).setType(PhaseType.AQUEOUS);
     return system;
   }
 }


### PR DESCRIPTION
## Summary

- add conservative finite-rate completion-distance studies for injected liquid evaporation and injected gas dissolution
- support liquid droplets, wall films, and gas bubbles in oil or aqueous continuous phases
- reuse NeqSim's Krishna non-equilibrium boundary for fugacity-equilibrated multicomponent Maxwell-Stefan transport, with thermodynamic and finite-flux corrections
- couple component transfer to separate phase enthalpy updates, optional wall heat, adaptive axial stepping, inventory limits, and conservation diagnostics
- track provenance in both phases, including reverse transfer, instead of inferring transfer from hydrodynamic holdup
- return a complete axial profile, remaining tracked fraction, warnings, and `NaN` completion distance when the phase does not disappear or the criterion is not reached

## Geometry and slip

- evolving Sauter mean diameter for droplets and bubbles using dispersed-phase volume
- evolving wall-film thickness and wetted perimeter
- backward-compatible user-specified gas and liquid actual velocities
- optional local Schiller-Naumann terminal-velocity closure
- separate total particle-relative speed for Ranz-Marshall transfer and gravity-projected axial slip for residence time
- local gas velocity, liquid velocity, and relative speed in every profile point
- corrected droplet-node interfacial area to use dispersed liquid velocity

## Numerical safeguards

- equal-and-opposite component inventory updates
- two-phase provenance transport under proportional mixing
- adaptive limits on donor depletion and temperature change
- bounded component transfer at depleted inventories
- bounded two-film heat-flux fallback near phase disappearance
- exact overall enthalpy correction and reported mass/energy residuals
- interpolated completion distance at a configurable remaining-mass threshold
- no equilibrium flash between axial steps and no forced phase removal

## Validation

- fast equation-level checks for Ranz-Marshall, Abramzon-Sirignano, bubble area, and Schiller-Naumann slip trends
- droplet, wall-film, oil-bubble, and aqueous CPA regression sources compile
- local production sources and focused tests compile against the installed NeqSim 3.16.0 distribution
- executed oil-bubble completion case: 1% criterion reached; maximum component residual `2.7e-15 mol/s`; relative energy residual `3.4e-9`
- executed aqueous CPA CO2 case: finite dissolution with gas remaining at the short-pipe outlet; maximum component residual `3.6e-15 mol/s`; relative energy residual `1.6e-15`
- re-executed droplet and wall-film smoke cases after the bidirectional provenance/slip changes

The full Maven build could not be run in this sandbox because Maven Central is unavailable and no writable populated Maven cache is provided. GitHub CI remains the repository-native build gate.

## Accuracy boundary

This PR does not claim absolute experimental completion-distance accuracy. Dominant project uncertainties remain inlet `d32`/film coverage, breakup/coalescence/entrainment, bubble swarm and surfactant effects, hydraulic pressure/velocity profiles, binary diffusivity, and EOS/BIP quality. For water/polar systems, use CPA or electrolyte CPA and validate equilibrium gas solubility first. The documentation defines a validation ladder and identifies the published Daïf et al. forced-convection multicomponent droplet case as an external target.