### PR TITLE
Stop field lifecycle cleanly at facility operating limits

### DIFF
--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
@@ -173,8 +173,16 @@ public class FieldLifecycleSimulator {
           suppliedPotential.getGasSm3PerDay() > 0.0 ? suppliedPotential.getGasSm3PerDay() : potential.gasRateSm3PerDay,
           potential.waterRateSm3PerDay);
       AllocationResult allocation = allocator.allocate(strategy, calendarYear, satellitePotential);
-      FacilityOperatingResult operation = operateSharedFacility(model, config, strategy, fieldAgeYears, allocation,
-          facilityDesign, potential.oilRecoveryFactor);
+      FacilityOperatingResult operation;
+      try {
+        operation = operateSharedFacility(model, config, strategy, fieldAgeYears, allocation, facilityDesign,
+            potential.oilRecoveryFactor);
+      } catch (IllegalStateException ex) {
+        logger.warn("Facility/process model for {} reached its operating limit: {}", model.getName(),
+            ex.getMessage());
+        stopReason = "facility/process operating limit reached";
+        break;
+      }
       ProductSpecificationResult productQuality = evaluateProductQuality(model, config);
 
       double operatingDays = dtDays * config.getAvailability();

--- a/src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java
@@ -56,6 +56,18 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  void facilityOperatingLimitEndsLifecycleGracefully() {
+    FieldLifecycleConcept concept =
+        NorwegianOilFieldCase.createCase("operating-limit regression", 0.85, 5.0e6, 13.0);
+
+    FieldLifecycleResult result = new FieldLifecycleEvaluator().evaluate(concept);
+
+    assertFalse(result.getAnnualResults().isEmpty());
+    assertEquals("facility/process operating limit reached", result.getStopReason());
+    assertTrue(Double.isFinite(result.getNpvMusd()));
+  }
+
+  @Test
   void naturalDepletionDoesNotInjectGas() {
     FieldLifecycleResult result = new FieldLifecycleEvaluator()
         .evaluate(NorwegianOilFieldCase.createCase("short depletion", 0.0, 0.0, 2.0));


### PR DESCRIPTION
## Summary

- convert an exhausted shared-facility/process solve into an explicit lifecycle stop
- retain all valid annual production, quality, energy and economic results accumulated before the operating limit
- add a regression covering the 13-year Norwegian gas-injection reference case

## Why

Running the complete NeqSim-Colab field-development notebook against current `master` exposed a late-life standalone case where the wells/SURF potential solve remained feasible but the gas-injection/process facility could no longer find a physically valid operating point after rate reduction. The lifecycle previously aborted with `Could not solve shared facility after rate reduction`, so the portfolio could not be evaluated.

The simulator now reports `facility/process operating limit reached`, consistent with the existing controlled stop for a wells/SURF hydraulic limit.

## Verification

- exact `master` lifecycle sources compiled against the NeqSim 3.16.0 runtime
- full 321-cell / 151-code-cell educational field-and-area-development notebook executed with zero cell errors
- all notebook engineering and lifecycle validation gates passed
- standalone case: 12 annual results, finite NPV, controlled facility/process operating-limit stop

The PR remains draft for normal CI and maintainer review.