### PR TITLE
docs: repair risk framework quick start

### DIFF
--- a/docs/risk/index.md
+++ b/docs/risk/index.md
@@ -5,7 +5,6 @@ nav_order: 7
 description: "NeqSim risk and reliability simulation framework. Covers equipment failure modeling, Monte Carlo simulation, bow-tie analysis, SIS integration, risk matrix, and production impact analysis."
 ---
 
-
 This documentation covers NeqSim's comprehensive **Operational Risk Simulation Framework** for equipment failure analysis, production impact assessment, and process topology analysis.
 
 ---
@@ -32,7 +31,7 @@ This documentation covers NeqSim's comprehensive **Operational Risk Simulation F
 
 | Section | Description |
 |---------|-------------|
-| [**Advanced Framework Overview**](./ | Overview of all 7 priority packages |
+| [Advanced Framework Overview](overview.md#framework-capabilities) | Overview of the implemented risk-analysis packages |
 | [P1: Dynamic Simulation](dynamic-simulation) | Monte Carlo with transient modeling |
 | [P2: SIS/SIF Integration](sis-integration) | IEC 61508/61511, LOPA, SIL verification |
 | [P4: Bow-Tie Analysis](bowtie-analysis) | Barrier analysis, threat/consequence visualization |
@@ -40,87 +39,75 @@ This documentation covers NeqSim's comprehensive **Operational Risk Simulation F
 
 ---
 
-## 🚀 Quick Start
+## Quick start: a traceable LOPA calculation
 
-### Java
+The example below is a complete Java 8 program. It applies a BPCS protection layer and a SIL 2 safety instrumented
+function (SIF) to an initiating-event frequency. The numerical result is transparent:
+
+$$
+f_{\mathrm{mitigated}}
+= f_{\mathrm{IE}}\,\mathrm{PFD}_{\mathrm{BPCS}}\,\mathrm{PFD}_{\mathrm{SIF}}
+= 0.1 \times 0.1 \times 0.005
+= 5.0 \times 10^{-5}\ \mathrm{yr}^{-1}
+$$
 
 ```java
-import neqsim.process.safety.risk.*;
-import neqsim.process.util.topology.*;
-import neqsim.process.equipment.failure.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.safety.risk.RiskEvent;
+import neqsim.process.safety.risk.sis.LOPAResult;
+import neqsim.process.safety.risk.sis.SISIntegratedRiskModel;
+import neqsim.process.safety.risk.sis.SafetyInstrumentedFunction;
 
-// Create process system
-ProcessSystem process = new ProcessSystem();
-// ... add equipment ...
+public final class RiskFrameworkQuickStart {
+  private static final Logger logger = LogManager.getLogger(RiskFrameworkQuickStart.class);
 
-// Risk analysis
-RiskMatrix matrix = new RiskMatrix(process);
-matrix.buildRiskMatrix();
-System.out.println(matrix.toVisualization());
+  private RiskFrameworkQuickStart() {}
 
-// Monte Carlo simulation
-OperationalRiskSimulator simulator = new OperationalRiskSimulator(process);
-simulator.addEquipmentReliability("Compressor A", 0.5, 24.0);
-OperationalRiskResult result = simulator.runSimulation(10000, 365);
-System.out.println("Availability: " + result.getAvailability() + "%");
+  public static void main(String[] args) {
+    String eventName = "HP vessel overpressure";
 
-// Topology analysis
-ProcessTopologyAnalyzer topology = new ProcessTopologyAnalyzer(process);
-topology.buildTopology();
-topology.setFunctionalLocation("Compressor A", "1775-KA-23011A");
+    SISIntegratedRiskModel model = new SISIntegratedRiskModel("HP vessel LOPA");
+    model.addInitiatingEvent(eventName, 0.1, RiskEvent.ConsequenceCategory.MAJOR);
+
+    SISIntegratedRiskModel.IndependentProtectionLayer bpcs =
+        new SISIntegratedRiskModel.IndependentProtectionLayer(
+            "BPCS pressure control",
+            0.1,
+            SISIntegratedRiskModel.IndependentProtectionLayer.IPLType.BPCS);
+    bpcs.addApplicableEvent(eventName);
+    model.addIPL(bpcs);
+
+    SafetyInstrumentedFunction esd = SafetyInstrumentedFunction.builder()
+        .id("SIF-001")
+        .name("High-pressure ESD")
+        .description("Isolate the HP vessel on confirmed high pressure")
+        .sil(2)
+        .pfd(0.005)
+        .initiatingEvent(eventName)
+        .addProtectedEquipment("HP vessel")
+        .safeState("Isolated")
+        .build();
+    model.addSIF(esd);
+
+    LOPAResult result = model.performLOPA(eventName);
+    double expectedFrequency = 0.1 * 0.1 * 0.005;
+    if (Math.abs(result.getMitigatedFrequency() - expectedFrequency) > 1.0e-12) {
+      throw new IllegalStateException("LOPA layer multiplication did not close");
+    }
+
+    logger.info("Mitigated frequency: {} per year", result.getMitigatedFrequency());
+    logger.info("Total risk-reduction factor: {}", result.getTotalRRF());
+  }
+}
 ```
 
-### Advanced Risk Framework (Python)
-
-```python
-# Dynamic simulation with transients
-from neqsim.process.safety.risk.dynamic import DynamicRiskSimulator
-
-sim = DynamicRiskSimulator("Platform Risk")
-sim.setBaseProductionRate(100.0)
-sim.addEquipment("Compressor", 8760, 72, 1.0)
-sim.setShutdownProfile(DynamicRiskSimulator.RampProfile.S_CURVE)
-result = sim.runSimulation()
-print(f"Transient losses: {result.getTransientLoss().getTotalTransientLoss()}")
-
-# SIS/LOPA Analysis
-from neqsim.process.safety.risk.sis import SISIntegratedRiskModel, SafetyInstrumentedFunction
-
-model = SISIntegratedRiskModel("Overpressure Protection")
-model.setInitiatingEventFrequency(0.1)
-model.addIPL("BPCS Alarm", 10)
-model.addIPL("Operator", 10)
-sif = SafetyInstrumentedFunction("SIF-001", "PAHH")
-sif.setSILTarget(2)
-model.addSIF(sif)
-lopa = model.performLOPA()
-print(f"LOPA: {'PASS' if lopa.isAcceptable() else 'FAIL'}")
-```
-
-### Python (neqsim-python)
-
-```python
-import jpype
-import neqsim
-
-from neqsim.process.safety.risk import RiskMatrix, OperationalRiskSimulator
-from neqsim.process.util.topology import ProcessTopologyAnalyzer, FunctionalLocation
-
-# Build topology
-topology = ProcessTopologyAnalyzer(process)
-topology.buildTopology()
-
-# STID tagging
-topology.setFunctionalLocation("Compressor A", "1775-KA-23011A")
-
-# Risk matrix
-matrix = RiskMatrix()
-matrix.addRiskItem("Compressor Trip",
-    RiskMatrix.ProbabilityCategory.POSSIBLE,
-    RiskMatrix.ConsequenceCategory.MAJOR,
-    500000.0)
-print(matrix.toVisualization())
-```
+This calculation demonstrates software behavior, not approval of an initiating-event frequency, IPL independence,
+SIL target, test interval, or safe state. Those inputs require a traceable hazard study and accountable review. For a
+process-coupled study, continue with [Monte Carlo simulation](monte-carlo.md), [dynamic risk](dynamic-simulation.md),
+[SIS integration](sis-integration.md), and [process topology](topology.md). Python users should access these Java
+classes through the supported `from neqsim import jneqsim` gateway; see the
+[advanced risk notebook](../examples/AdvancedRiskFramework_Tutorial.ipynb) for the complete setup.
 
 ---
 

--- a/src/test/java/neqsim/process/safety/risk/RiskDocumentationTest.java
+++ b/src/test/java/neqsim/process/safety/risk/RiskDocumentationTest.java
@@ -1,0 +1,44 @@
+package neqsim.process.safety.risk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.Test;
+import neqsim.process.safety.risk.sis.LOPAResult;
+import neqsim.process.safety.risk.sis.SISIntegratedRiskModel;
+import neqsim.process.safety.risk.sis.SafetyInstrumentedFunction;
+
+/** Verifies the executable LOPA example in {@code docs/risk/index.md}. */
+class RiskDocumentationTest {
+
+  @Test
+  void testRiskFrameworkQuickStart() {
+    String eventName = "HP vessel overpressure";
+
+    SISIntegratedRiskModel model = new SISIntegratedRiskModel("HP vessel LOPA");
+    model.addInitiatingEvent(eventName, 0.1, RiskEvent.ConsequenceCategory.MAJOR);
+
+    SISIntegratedRiskModel.IndependentProtectionLayer bpcs =
+        new SISIntegratedRiskModel.IndependentProtectionLayer(
+            "BPCS pressure control", 0.1,
+            SISIntegratedRiskModel.IndependentProtectionLayer.IPLType.BPCS);
+    bpcs.addApplicableEvent(eventName);
+    model.addIPL(bpcs);
+
+    SafetyInstrumentedFunction esd =
+        SafetyInstrumentedFunction.builder().id("SIF-001").name("High-pressure ESD")
+            .description("Isolate the HP vessel on confirmed high pressure").sil(2).pfd(0.005)
+            .initiatingEvent(eventName).addProtectedEquipment("HP vessel").safeState("Isolated").build();
+    model.addSIF(esd);
+
+    LOPAResult result = model.performLOPA(eventName);
+
+    assertEquals(5.0e-5, result.getMitigatedFrequency(), 1.0e-12);
+    assertEquals(2000.0, result.getTotalRRF(), 1.0e-9);
+    assertEquals(2, result.getLayers().size());
+    assertEquals("SIF-001", esd.getId());
+    assertEquals(2, esd.getSil());
+    assertEquals(0.005, esd.getPfdAvg(), 1.0e-12);
+    assertEquals("Isolated", esd.getSafeState());
+    assertFalse(esd.getProtectedEquipment().isEmpty());
+  }
+}


### PR DESCRIPTION
## Campaign

Relates to #2499.

## Scan scope

D006 — engineering design and safety rotation, frozen to:

- `docs/risk/index.md`
- current `RiskEvent`, `SISIntegratedRiskModel`, `IndependentProtectionLayer`, `SafetyInstrumentedFunction`, and `LOPAResult` APIs
- focused executable coverage in `RiskDocumentationTest`

Base: `00200d037fb55f52ec4a98d52e5411744443cda2`. No other open PR existed when the scope was frozen.

## Confirmed defect groups

1. **High — malformed navigation:** the Advanced Framework Overview table link was missing its closing parenthesis and target.
2. **High — incomplete Java program:** the landing-page example constructed an empty `ProcessSystem`, omitted required imports and equipment, and then attempted process-dependent analysis.
3. **High — nonexistent RiskMatrix API:** the examples used a default constructor, `addRiskItem`, `ProbabilityCategory.POSSIBLE`, and `toVisualization`; none exists on the current class.
4. **High — nonexistent dynamic-risk API:** `setBaseProductionRate`, `addEquipment`, zero-argument `runSimulation`, and `getTransientLoss` do not exist on `DynamicRiskSimulator`.
5. **High — invalid SIS construction:** `SafetyInstrumentedFunction(String, String)` and `setSILTarget` do not exist.
6. **High — invalid LOPA calls:** the page used string-based `addIPL`, zero-argument `performLOPA`, and `isAcceptable`; current APIs require an `IndependentProtectionLayer`, event name, and `isTargetMet`.
7. **High — unsupported Python imports:** the snippets imported Java packages as Python modules instead of using the supported `from neqsim import jneqsim` gateway.
8. **High — undefined state:** the Python topology example referenced an undefined `process`.
9. **Medium — repository policy:** the Java example used wildcard imports and `System.out.println`.

## Fixes

- Repaired the overview link to the existing `overview.md#framework-capabilities` anchor.
- Replaced three misleading snippets with one complete Java 8 LOPA program using explicit imports and Log4j2.
- Added the independently checkable protection-layer equation and its expected `5.0e-5 yr^-1` result.
- Added a clear boundary between software demonstration and accountable hazard-study inputs.
- Directed process-coupled and Python users to verified detailed pages and the supported `jneqsim` gateway.
- Added `RiskDocumentationTest`, exercising every API call shown and asserting frequency, total RRF, layer count, SIF identity, SIL, PFD, safe state, and protected equipment.

## Validation

Passed locally:

- Source-file execution against NeqSim 3.16.0: mitigated frequency `5.0e-5 yr^-1`; total RRF `2000`.
- Front matter, balanced code/math delimiters, supported KaTeX syntax, no duplicate H1, no wildcard import, and no `System.out`.
- One complete Java fence and 25 internal targets; corrected anchor exists.
- Documentation search audit: 619 Markdown pages and one standalone HTML page.
- ISO 14224 and Standards Norway links resolved.
- OREDA root-page direct open was transiently rejected by the web fetcher; an immediate search retry found the current official OREDA root and publications pages, so no link was replaced.

Local Maven/Spotless execution is unavailable because the environment cannot resolve uncached Maven artifacts. Hosted Spotless, focused/full Java tests, Jekyll/search, Javadoc, pre-commit, and CodeQL are therefore pending and remain the authoritative gates.

## Rendering

The source contains one display equation using standalone `$$` delimiters and supported KaTeX commands. Hosted Jekyll rendering is pending; no screenshot or visual-render success is claimed yet.

## Compatibility and impact

Documentation and tests only. No production API, model, parameter, default, or runtime behavior changes.

## Exclusions and next scope

This batch does not repair the deeper risk sub-pages or the separate engineering/safety/field-development landing-page title issues found during screening. Those remain candidates after D006 is merged.