### PR TITLE
style: format risk documentation test

### DIFF
--- a/src/test/java/neqsim/process/safety/risk/RiskDocumentationTest.java
+++ b/src/test/java/neqsim/process/safety/risk/RiskDocumentationTest.java
@@ -17,17 +17,14 @@ class RiskDocumentationTest {
     SISIntegratedRiskModel model = new SISIntegratedRiskModel("HP vessel LOPA");
     model.addInitiatingEvent(eventName, 0.1, RiskEvent.ConsequenceCategory.MAJOR);
 
-    SISIntegratedRiskModel.IndependentProtectionLayer bpcs =
-        new SISIntegratedRiskModel.IndependentProtectionLayer(
-            "BPCS pressure control", 0.1,
-            SISIntegratedRiskModel.IndependentProtectionLayer.IPLType.BPCS);
+    SISIntegratedRiskModel.IndependentProtectionLayer bpcs = new SISIntegratedRiskModel.IndependentProtectionLayer(
+        "BPCS pressure control", 0.1, SISIntegratedRiskModel.IndependentProtectionLayer.IPLType.BPCS);
     bpcs.addApplicableEvent(eventName);
     model.addIPL(bpcs);
 
-    SafetyInstrumentedFunction esd =
-        SafetyInstrumentedFunction.builder().id("SIF-001").name("High-pressure ESD")
-            .description("Isolate the HP vessel on confirmed high pressure").sil(2).pfd(0.005)
-            .initiatingEvent(eventName).addProtectedEquipment("HP vessel").safeState("Isolated").build();
+    SafetyInstrumentedFunction esd = SafetyInstrumentedFunction.builder().id("SIF-001").name("High-pressure ESD")
+        .description("Isolate the HP vessel on confirmed high pressure").sil(2).pfd(0.005).initiatingEvent(eventName)
+        .addProtectedEquipment("HP vessel").safeState("Isolated").build();
     model.addSIF(esd);
 
     LOPAResult result = model.performLOPA(eventName);


### PR DESCRIPTION
## Campaign follow-up

Relates to #2499 and repairs the hosted validation defect left by merged documentation PR #2521.

## Scope

One file only:

- `src/test/java/neqsim/process/safety/risk/RiskDocumentationTest.java`

## Evidence and root cause

PR #2521 was merged while its hosted checks were still running. The pre-commit workflow then reported that the new test did not match the repository Spotless format. The successful `Spotless format patch` workflow produced a one-file patch with no semantic changes.

## Fix

Applied that exact hosted formatter patch:

- wrap `IndependentProtectionLayer` construction according to repository style;
- reflow the `SafetyInstrumentedFunction` builder chain;
- preserve every assertion and API call unchanged.

## Validation

Passed:

- Patch blob matches the original formatter artifact's expected blob `13c8089`.
- The replacement Spotless artifact contains changes only for two unrelated field-lifecycle files inherited from current `master`; `RiskDocumentationTest.java` is absent, confirming the D006 test is clean.
- Documentation search audit passed: 621 Markdown pages and one standalone HTML page.
- Hosted Javadoc and agent/skill cross-reference checks passed.
- D006's documentation-search/Jekyll workflow and CodeQL passed on merged #2521.
- Replacement CodeQL passed on #2522.
- D006's local NeqSim 3.16.0 runtime result remains unchanged: mitigated frequency `5.0e-5 yr^-1`, total RRF `2000`.

Pending:

- Ubuntu and Windows Java test jobs.

Blocked outside this PR:

- Repository-wide pre-commit reports only `FieldLifecycleSimulator.java` and `NorwegianOilFieldLifecycleTest.java`, both already present on `master` and neither changed here.

## Impact and exclusions

No production code, documentation text, model, parameter, default, runtime behavior, or test assertion changes. This PR does not advance to a new scan batch; it closes D006's formatter regression before the campaign rotates onward.