### PR TITLE
Fix ammonia reference EOS dense-phase properties

### DIFF
--- a/src/main/java/neqsim/thermo/util/referenceequations/Ammonia2023.java
+++ b/src/main/java/neqsim/thermo/util/referenceequations/Ammonia2023.java
@@ -56,6 +56,10 @@ public class Ammonia2023 {
   private static final double[] GAOB_EPS = { 0.4478, 0.44689 };
   private static final double[] GAOB_B = { 1.244, 0.6826 };
 
+  // Saturated-liquid density ancillary used only to select the dense EOS root.
+  private static final double[] SAT_LIQ_N = { 2.447, 5.8341, -25.944, 53.383, -54.411, 22.771 };
+  private static final double[] SAT_LIQ_T = { 0.384, 1.65, 2.2, 2.75, 3.35, 4.0 };
+
   // --- Simple viscosity correlation coefficients ----------------------------
   // Fitted to CoolProp viscosity data at 293.15 K
 
@@ -96,7 +100,7 @@ public class Ammonia2023 {
   private double solveDensity(double T, double p) {
     boolean liquidGuess = phase != null && (phase.getType() == PhaseType.LIQUID || phase.getType() == PhaseType.OIL);
 
-    double rho = liquidGuess ? RHO_CRIT * 2.0 : p / (R * T);
+    double rho = liquidGuess ? saturatedLiquidDensityGuess(T) : p / (R * T);
 
     // Newton iteration using the initial guess
     for (int i = 0; i < 100; i++) {
@@ -146,6 +150,19 @@ public class Ammonia2023 {
       }
     }
     return rho;
+  }
+
+  private static double saturatedLiquidDensityGuess(double temperature) {
+    if (temperature >= T_CRIT) {
+      return RHO_CRIT;
+    }
+
+    double theta = 1.0 - temperature / T_CRIT;
+    double reducedDensity = 1.0;
+    for (int i = 0; i < SAT_LIQ_N.length; i++) {
+      reducedDensity += SAT_LIQ_N[i] * Math.pow(theta, SAT_LIQ_T[i]);
+    }
+    return RHO_CRIT * reducedDensity;
   }
 
   private double pressureFromDensity(double rho, double T) {
@@ -289,16 +306,17 @@ public class Ammonia2023 {
       double tauPow = Math.pow(tau, GAOB_T[i]);
       double a = delta - GAOB_EPS[i];
       double Y = GAOB_BETA[i] * Math.pow(tau - GAOB_GAMMA[i], 2.0) + GAOB_B[i];
-      double expo = Math.exp(GAOB_ETA[i] * a * a - 1.0 / Y);
+      double expo = Math.exp(GAOB_ETA[i] * a * a + 1.0 / Y);
       double term = GAOB_N[i] * delPow * tauPow * expo;
       double Bdelta = GAOB_D[i] / delta + 2.0 * GAOB_ETA[i] * a;
-      double Bt = GAOB_T[i] / tau + (2.0 * GAOB_BETA[i] * (tau - GAOB_GAMMA[i])) / (Y * Y);
+      double Bt = GAOB_T[i] / tau - (2.0 * GAOB_BETA[i] * (tau - GAOB_GAMMA[i])) / (Y * Y);
       r.alpha += term;
       r.dalpha_dDelta += term * Bdelta;
       r.d2alpha_dDelta2 += term * (Bdelta * Bdelta - GAOB_D[i] / (delta * delta) + 2.0 * GAOB_ETA[i]);
       r.dalpha_dTau += term * Bt;
-      r.d2alpha_dTau2 += term * (Bt * Bt - GAOB_T[i] / (tau * tau)
-          + 2.0 * GAOB_BETA[i] * ((Y - 2.0 * GAOB_BETA[i] * Math.pow(tau - GAOB_GAMMA[i], 2.0)) / (Y * Y * Y)));
+      double tauOffset = tau - GAOB_GAMMA[i];
+      r.d2alpha_dTau2 += term * (Bt * Bt - GAOB_T[i] / (tau * tau) - 2.0 * GAOB_BETA[i] / (Y * Y)
+          + 8.0 * GAOB_BETA[i] * GAOB_BETA[i] * tauOffset * tauOffset / (Y * Y * Y));
       r.d2alpha_dDelta_dTau += term * Bdelta * Bt;
     }
 
@@ -351,7 +369,7 @@ public class Ammonia2023 {
 
     double cv = -R * tau * tau * (id.d2alpha_dTau2 + r.d2alpha_dTau2);
     double numer = 1.0 + delta * r.dalpha_dDelta - delta * tau * r.d2alpha_dDelta_dTau;
-    double denom = 1.0 - delta * delta * r.d2alpha_dDelta2;
+    double denom = 1.0 + 2.0 * delta * r.dalpha_dDelta + delta * delta * r.d2alpha_dDelta2;
     double cp = cv + R * numer * numer / denom;
 
     double u = R * T * tau * (id.dalpha_dTau + r.dalpha_dTau);

--- a/src/test/java/neqsim/thermo/phase/PhaseAmmoniaEosTest.java
+++ b/src/test/java/neqsim/thermo/phase/PhaseAmmoniaEosTest.java
@@ -67,11 +67,28 @@ class PhaseAmmoniaEosTest {
     system.init(3);
 
     PhaseInterface liq = system.getPhase(0);
-    assertEquals(415.24155674578753, liq.getDensity(), 4.2e-4);
-    assertEquals(92.846, liq.getCp(), 0.1);
-    assertEquals(87.457, liq.getCv(), 0.1);
-    assertEquals(0.0, liq.getSoundSpeed(), 1.0e-6);
-    assertEquals(0.23094, liq.getThermalConductivity(), 1.0e-3);
-    assertEquals(6.55e-5, liq.getViscosity(), 1.0e-7);
+    // Reference values from the Gao et al. (2020) EOS as implemented in CoolProp 8.0.0.
+    assertEquals(610.5159719028246, liq.getDensity(), 1.0e-3);
+    assertEquals(80.67821299666132, liq.getCp(), 1.0e-3);
+    assertEquals(47.49260694762637, liq.getCv(), 1.0e-3);
+    assertEquals(1374.6068258903206, liq.getSoundSpeed(), 1.0e-2);
+    assertEquals(0.5004989173082783, liq.getThermalConductivity(), 1.0e-4);
+    assertEquals(1.3860846498812973e-4, liq.getViscosity(), 1.0e-6);
+    assertTrue(liq.getCp() > liq.getCv());
+  }
+
+  @Test
+  void testBubblePointPressureAgainstReferenceEquation() {
+    double[] temperatures = {260.0, 280.0, 300.0, 320.0};
+    double[] expectedPressures = {
+        2.552457115844972, 5.507043744582428, 10.611215021486935, 18.71755110160696};
+
+    for (int i = 0; i < temperatures.length; i++) {
+      SystemInterface system = new SystemAmmoniaEos(temperatures[i], expectedPressures[i]);
+      ThermodynamicOperations operations = new ThermodynamicOperations(system);
+      operations.bubblePointPressureFlash(false);
+
+      assertEquals(expectedPressures[i], system.getPressure(), 1.0e-4);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- select the physically dense ammonia root using the Gao et al. saturated-liquid density ancillary
- correct the sign and temperature derivatives of the Gao-B residual Helmholtz terms
- correct the constant-pressure heat-capacity denominator
- replace the former metastable-liquid expectations with published reference-EOS values
- add saturation-pressure regressions from 260 K to 320 K

## Diagnosis

`SystemAmmoniaEos` in NeqSim 3.16.0 selected an intermediate density root for forced liquid ammonia. It therefore returned 415.24 kg/m³ at 293.15 K and 10 bara instead of 610.516 kg/m³. The same state produced inconsistent caloric properties. Bubble-pressure flashes also deviated severely or jumped to an unphysical root because the Gao-B exponential used `-1/Y` while the Gao et al. formulation uses `+1/Y`.

## Validation

A locally compiled override was exercised through the public NeqSim Python/JVM API against NeqSim 3.16.0:

- liquid density at 293.15 K, 10 bara: 610.5159716 kg/m³ (CoolProp 8.0.0: 610.5159719 kg/m³)
- molar Cp: 80.6782404 J/(mol K) (reference: 80.6782130)
- molar Cv: 47.4926230 J/(mol K) (reference: 47.4926069)
- sound speed: 1374.6071 m/s (reference: 1374.6068)
- saturation pressures at 260, 280, 300, and 320 K agree within 6.4e-6 bara of the Gao et al. EOS reference values

The reference values are from the Gao et al. ammonia EOS distributed by CoolProp 8.0.0. The patch is limited to `Ammonia2023` and its focused regression test.