### PR TITLE
Fix ammonia EOS test compilation

### DIFF
--- a/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
+++ b/src/main/java/neqsim/process/fielddevelopment/lifecycle/FieldLifecycleSimulator.java
@@ -178,8 +178,7 @@ public class FieldLifecycleSimulator {
         operation = operateSharedFacility(model, config, strategy, fieldAgeYears, allocation, facilityDesign,
             potential.oilRecoveryFactor);
       } catch (IllegalStateException ex) {
-        logger.warn("Facility/process model for {} reached its operating limit: {}", model.getName(),
-            ex.getMessage());
+        logger.warn("Facility/process model for {} reached its operating limit: {}", model.getName(), ex.getMessage());
         stopReason = "facility/process operating limit reached";
         break;
       }

--- a/src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/lifecycle/NorwegianOilFieldLifecycleTest.java
@@ -57,8 +57,7 @@ class NorwegianOilFieldLifecycleTest extends neqsim.NeqSimTest {
 
   @Test
   void facilityOperatingLimitEndsLifecycleGracefully() {
-    FieldLifecycleConcept concept =
-        NorwegianOilFieldCase.createCase("operating-limit regression", 0.85, 5.0e6, 13.0);
+    FieldLifecycleConcept concept = NorwegianOilFieldCase.createCase("operating-limit regression", 0.85, 5.0e6, 13.0);
 
     FieldLifecycleResult result = new FieldLifecycleEvaluator().evaluate(concept);
 

--- a/src/test/java/neqsim/thermo/phase/PhaseAmmoniaEosTest.java
+++ b/src/test/java/neqsim/thermo/phase/PhaseAmmoniaEosTest.java
@@ -7,6 +7,7 @@ import neqsim.thermo.ThermodynamicConstantsInterface;
 import neqsim.thermo.system.SystemAmmoniaEos;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.util.exception.IsNaNException;
 
 /**
  * Simple sanity check for the {@link PhaseAmmoniaEos} implementation.
@@ -78,7 +79,7 @@ class PhaseAmmoniaEosTest {
   }
 
   @Test
-  void testBubblePointPressureAgainstReferenceEquation() {
+  void testBubblePointPressureAgainstReferenceEquation() throws IsNaNException {
     double[] temperatures = {260.0, 280.0, 300.0, 320.0};
     double[] expectedPressures = {
         2.552457115844972, 5.507043744582428, 10.611215021486935, 18.71755110160696};

--- a/src/test/java/neqsim/thermo/phase/PhaseAmmoniaEosTest.java
+++ b/src/test/java/neqsim/thermo/phase/PhaseAmmoniaEosTest.java
@@ -81,8 +81,7 @@ class PhaseAmmoniaEosTest {
   @Test
   void testBubblePointPressureAgainstReferenceEquation() throws IsNaNException {
     double[] temperatures = { 260.0, 280.0, 300.0, 320.0 };
-    double[] expectedPressures = { 2.552457115844972, 5.507043744582428,
-        10.611215021486935, 18.71755110160696 };
+    double[] expectedPressures = { 2.552457115844972, 5.507043744582428, 10.611215021486935, 18.71755110160696 };
 
     for (int i = 0; i < temperatures.length; i++) {
       SystemInterface system = new SystemAmmoniaEos(temperatures[i], expectedPressures[i]);

--- a/src/test/java/neqsim/thermo/phase/PhaseAmmoniaEosTest.java
+++ b/src/test/java/neqsim/thermo/phase/PhaseAmmoniaEosTest.java
@@ -80,9 +80,9 @@ class PhaseAmmoniaEosTest {
 
   @Test
   void testBubblePointPressureAgainstReferenceEquation() throws IsNaNException {
-    double[] temperatures = {260.0, 280.0, 300.0, 320.0};
-    double[] expectedPressures = {
-        2.552457115844972, 5.507043744582428, 10.611215021486935, 18.71755110160696};
+    double[] temperatures = { 260.0, 280.0, 300.0, 320.0 };
+    double[] expectedPressures = { 2.552457115844972, 5.507043744582428,
+        10.611215021486935, 18.71755110160696 };
 
     for (int i = 0; i < temperatures.length; i++) {
       SystemInterface system = new SystemAmmoniaEos(temperatures[i], expectedPressures[i]);


### PR DESCRIPTION
## Summary

- declare the checked `IsNaNException` thrown by `bubblePointPressureFlash(false)`
- restore test compilation after #2523
- apply the exact Spotless formatting required for the new ammonia regression arrays
- repair two pre-existing, mechanical Spotless violations from the field-lifecycle change already on `master`

## Root cause

The bubble-point regression added in #2523 called `ThermodynamicOperations.bubblePointPressureFlash(boolean)`, which declares `IsNaNException`, from a test method that neither caught nor declared the exception. Maven therefore failed during `testCompile`, including the CodeQL autobuild path.

The first PR run also exposed two unrelated repository-wide formatting violations already present on `master`. Those lines are included here as formatter-only changes so the required pre-commit check can pass.

## Validation

Passed:

- CodeQL `Build with Maven (no tests)` — confirms the original test-compilation failure is fixed
- pre-commit checks
- Spotless format workflow
- PaperLab replication gate
- Java 21 Javadoc generation
- agent-skill cross-reference verification

Still running:

- complete Ubuntu Java 21 test suite with JaCoCo
- Windows Java 21 fast test suite
- final CodeQL analysis

No thermodynamic or field-lifecycle behavior is changed.