### PR TITLE
docs: repair flow assurance index

### DIFF
--- a/docs/pvtsimulation/flowassurance/README.md
+++ b/docs/pvtsimulation/flowassurance/README.md
@@ -1,173 +1,106 @@
 ---
 title: Flow Assurance in NeqSim
-description: Flow assurance is the discipline ensuring that hydrocarbon fluids can be produced, transported, and processed safely and economically throughout the life of a field. NeqSim provides comprehensive tool...
+description: "Guide to NeqSim flow-assurance screening for hydrates, wax, asphaltenes, scale, corrosion, erosion, emulsions, and pipeline cooldown."
 ---
 
-# Flow Assurance in NeqSim
+Flow assurance keeps hydrocarbon fluids transportable during production, shutdown,
+and restart. NeqSim combines thermodynamic models with screening calculators for
+identifying risks and comparing mitigation options. Treat screening results as input
+to an engineering assessment, not as design certification.
 
-Flow assurance is the discipline ensuring that hydrocarbon fluids can be produced, transported, and processed safely and economically throughout the life of a field. NeqSim provides comprehensive tools for predicting and managing flow assurance challenges.
+## Choose a workflow
 
-## Overview
+| Topic | Start here |
+| --- | --- |
+| Integrated overview | [Flow-assurance overview](../flow_assurance_overview.md) |
+| Hydrates | [Hydrate models](../../thermo/hydrate_models.md) |
+| Wax | [Wax characterization](../../thermo/characterization/wax_characterization.md) |
+| Asphaltenes | [Asphaltene modeling](asphaltene_modeling.md) |
+| Pipeline cooldown, corrosion, scale, and wax curves | [Screening tools](flow_assurance_screening_tools.md) |
+| Sand erosion | [Erosion prediction](erosion_prediction.md) |
+| Emulsions | [Emulsion viscosity](emulsion_viscosity_calculator.md) |
+| High-salinity scale and chemical treatment | [Mineral-scale and chemical-treatment validation](../mineral_scale_chemical_treatment_validation.md) |
 
-Flow assurance encompasses the prevention and remediation of:
+## Screening classes
 
-- **Hydrate formation** - Ice-like structures that can block pipelines
-- **Wax deposition** - Paraffin precipitation at low temperatures
-- **Asphaltene precipitation** - Heavy organic precipitation during pressure/temperature changes
-- **Scale formation** - Mineral deposits from produced water
-- **Corrosion** - Material degradation from H₂S, CO₂, and water
-- **Slugging** - Unstable multiphase flow regimes
+The following classes are in `neqsim.pvtsimulation.flowassurance`.
 
-## Documentation Structure
+| Class | Purpose |
+| --- | --- |
+| `PipelineCooldownCalculator` | Lumped-parameter pipeline shutdown cooldown |
+| `DeWaardMilliamsCorrosion` | Screening-level CO2 corrosion rate |
+| `ScalePredictionCalculator` | Saturation indices for common mineral scales |
+| `PitzerScaleActivityModel` | Activity coefficients for high-salinity brines |
+| `MultiMineralScaleEquilibrium` | Coupled, shared-ion mineral precipitation |
+| `WaxCurveCalculator` | Wax fraction curves with monotonicity enforcement |
+| `ErosionPredictionCalculator` | API RP 14E velocity and DNV RP O501 erosion screening |
+| `EmulsionViscosityCalculator` | Effective viscosity and phase-inversion screening |
 
-| Topic | Description |
-|-------|-------------|
-| [Asphaltene Modeling](asphaltene_modeling) | Overview of asphaltene stability analysis |
-| [CPA-Based Asphaltene Calculations](asphaltene_cpa_calculations) | Thermodynamic onset pressure/temperature |
-| [De Boer Asphaltene Screening](asphaltene_deboer_screening) | Empirical screening correlation |
-| [Asphaltene Parameter Fitting](asphaltene_parameter_fitting) | Tuning CPA parameters to experimental data |
-| [Asphaltene Method Comparison](asphaltene_method_comparison) | Comparing CPA vs De Boer approaches |
-| [Asphaltene Model Validation](asphaltene_validation) | Validation against SPE-24987 field data |
-| [Flow Assurance Screening Tools](flow_assurance_screening_tools) | Pipeline cooldown, CO2 corrosion, scale prediction, wax curve monotonicity |
-| [High-salinity scale and chemical treatment](../mineral_scale_chemical_treatment_validation) | Pitzer validation, pH/H2S dosing and RCA |
+For the fuller NORSOK M-506 and M-001 workflows in
+`neqsim.process.corrosion`, see the
+[corrosion analysis module](../../process/corrosion/index.md).
 
-## Key Classes
+## Quick start: De Boer asphaltene screening
 
-### Flow Assurance Screening Tools
-
-| Class | Package | Purpose |
-|-------|---------|---------|
-| `PipelineCooldownCalculator` | `neqsim.pvtsimulation.flowassurance` | Lumped-parameter pipeline shutdown cooldown |
-| `DeWaardMilliamsCorrosion` | `neqsim.pvtsimulation.flowassurance` | CO2 corrosion rate (de Waard-Milliams 1991) |
-
-> **Full NORSOK standard models:** For production-grade corrosion analysis per NORSOK M-506 and
-> material selection per NORSOK M-001, see the **[Corrosion Analysis Module](../../process/corrosion/)**
-> in `neqsim.process.corrosion`. These integrate directly with pipeline mechanical design.
-| `ScalePredictionCalculator` | `neqsim.pvtsimulation.flowassurance` | Saturation index for CaCO3, BaSO4, SrSO4, CaSO4, FeCO3 |
-| `PitzerScaleActivityModel` | `neqsim.pvtsimulation.flowassurance` | Validated high-salinity activity coefficients for NaCl-dominated brines |
-| `MultiMineralScaleEquilibrium` | `neqsim.pvtsimulation.flowassurance` | Coupled shared-ion precipitation for five minerals |
-| `WaxCurveCalculator` | `neqsim.pvtsimulation.flowassurance` | Wax fraction curves with monotonicity enforcement |
-
-### Asphaltene Analysis
-
-| Class | Package | Purpose |
-|-------|---------|---------|
-| `AsphalteneCharacterization` | `neqsim.thermo.characterization` | SARA-based characterization |
-| `AsphalteneStabilityAnalyzer` | `neqsim.pvtsimulation.flowassurance` | High-level CPA analysis API |
-| `DeBoerAsphalteneScreening` | `neqsim.pvtsimulation.flowassurance` | Empirical De Boer screening (quadratic boundaries) |
-| `FloryHugginsAsphalteneModel` | `neqsim.pvtsimulation.flowassurance` | Flory-Huggins regular solution model with physics-based calibration and API gravity configuration |
-| `RefractiveIndexAsphalteneScreening` | `neqsim.pvtsimulation.flowassurance` | Refractive index stability screening (Buckley et al.) |
-| `AsphalteneMultiMethodBenchmark` | `neqsim.pvtsimulation.flowassurance` | Unified 6-method comparison framework with literature cases |
-| `PedersenAsphalteneCharacterization` | `neqsim.thermo.characterization` | Pedersen cubic EOS asphaltene characterization with kij tuning |
-| `AsphalteneMethodComparison` | `neqsim.pvtsimulation.flowassurance` | Compare multiple methods |
-| `AsphalteneOnsetPressureFlash` | `neqsim.thermodynamicoperations` | Onset pressure calculation |
-| `AsphalteneOnsetTemperatureFlash` | `neqsim.thermodynamicoperations` | Onset temperature calculation |
-| `AsphalteneOnsetFitting` | `neqsim.pvtsimulation.util.parameterfitting` | Fit CPA parameters to experimental onset data |
-| `AsphalteneOnsetFunction` | `neqsim.pvtsimulation.util.parameterfitting` | Levenberg-Marquardt function for fitting |
-
-## Quick Start
-
-### Simple Screening (De Boer Method)
+The De Boer method is a fast empirical screen based on reservoir
+undersaturation and in-situ oil density. Pressures in this example are absolute
+bar and density is in kg/m3.
 
 ```java
 import neqsim.pvtsimulation.flowassurance.DeBoerAsphalteneScreening;
+import neqsim.pvtsimulation.flowassurance.DeBoerAsphalteneScreening.DeBoerRisk;
 
-// Create screening for specific conditions
-DeBoerAsphalteneScreening screening = new DeBoerAsphalteneScreening(
-    350.0,  // Reservoir pressure [bar]
-    150.0,  // Bubble point pressure [bar]
-    750.0   // In-situ oil density [kg/m³]
-);
+DeBoerAsphalteneScreening screening =
+    new DeBoerAsphalteneScreening(350.0, 150.0, 750.0);
 
-// Get risk assessment
-String risk = screening.evaluateRisk();
+DeBoerRisk risk = screening.evaluateRisk();
 double riskIndex = screening.calculateRiskIndex();
 
-System.out.println("Asphaltene Risk: " + risk);
-System.out.println("Risk Index: " + riskIndex);
+System.out.println("Risk category: " + risk);
+System.out.println("Risk index: " + riskIndex);
 ```
 
-### Thermodynamic Analysis (CPA Method)
+For these inputs, the current correlation returns `MODERATE_PROBLEM` and a risk
+index of `1.6`. This classification is a screening result; confirm a flagged fluid
+with laboratory data and a fitted thermodynamic model.
 
-```java
-import neqsim.thermo.system.SystemSrkCPAstatoil;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
+## Select an asphaltene method
 
-// Create CPA fluid with asphaltene
-SystemSrkCPAstatoil fluid = new SystemSrkCPAstatoil(373.15, 200.0);
-fluid.addComponent("methane", 0.5);
-fluid.addComponent("n-heptane", 0.45);
-fluid.addComponent("asphaltene", 0.05);
-fluid.setMixingRule("classic");
+| Need | Class or guide | Notes |
+| --- | --- | --- |
+| Fast empirical screen | `DeBoerAsphalteneScreening` | Requires reservoir pressure, saturation pressure, and in-situ density |
+| CPA stability analysis | `AsphalteneStabilityAnalyzer` | See [CPA calculations](asphaltene_cpa_calculations.md) |
+| Compare available methods | `AsphalteneMethodComparison` or `AsphalteneMultiMethodBenchmark` | See [method comparison](asphaltene_method_comparison.md) |
+| Regular-solution model | `FloryHugginsAsphalteneModel` | Configure and calibrate for the fluid being studied |
+| Refractive-index screen | `RefractiveIndexAsphalteneScreening` | Requires measured or estimated refractive-index inputs |
+| Cubic-EOS characterization | `PedersenAsphalteneCharacterization` | Adds characterized pseudo-components and supports binary-interaction tuning |
+| CPA parameter fitting | `AsphalteneOnsetFitting` | See [parameter fitting](asphaltene_parameter_fitting.md) |
+| Pressure-onset flash | `neqsim.thermodynamicoperations.flashops.saturationops.AsphalteneOnsetPressureFlash` | Run the flash object and read `getOnsetPressure()` |
+| Temperature-onset flash | `neqsim.thermodynamicoperations.flashops.saturationops.AsphalteneOnsetTemperatureFlash` | Run the flash object and read its onset result |
 
-// Calculate onset pressure
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.asphalteneOnsetPressure();
+The `PhaseType` enum includes `ASPHALTENE` for a solid asphaltene-rich phase and
+`LIQUID_ASPHALTENE` for the liquid-liquid Pedersen approach. Phase appearance and
+type depend on the selected model, enabled phase checks, composition, and flash
+conditions; do not assume that adding an asphaltene component alone guarantees a
+precipitated phase.
 
-double onsetPressure = fluid.getPressure();
-System.out.println("Onset Pressure: " + onsetPressure + " bar");
-```
+NeqSim includes an `asphaltene` database component for CPA workflows. Its default
+parameters are generic starting values. For cubic-EOS workflows,
+`PedersenAsphalteneCharacterization` creates case-specific pseudo-components.
+Tune either approach to measured onset or precipitation data before using it for
+design decisions.
 
-### Parameter Fitting (Tuning to Lab Data)
+## Asphaltene documentation
 
-```java
-import neqsim.pvtsimulation.util.parameterfitting.AsphalteneOnsetFitting;
+- [De Boer screening](asphaltene_deboer_screening.md)
+- [CPA calculations](asphaltene_cpa_calculations.md)
+- [Parameter fitting](asphaltene_parameter_fitting.md)
+- [Method comparison](asphaltene_method_comparison.md)
+- [Validation cases](asphaltene_validation.md)
 
-// Create fitter with your fluid system
-AsphalteneOnsetFitting fitter = new AsphalteneOnsetFitting(fluid);
+## Related documentation
 
-// Add experimental onset points (T in Kelvin, P in bar)
-fitter.addOnsetPoint(353.15, 350.0);  // 80°C
-fitter.addOnsetPoint(373.15, 320.0);  // 100°C
-fitter.addOnsetPoint(393.15, 280.0);  // 120°C
+- [PVT simulation](../README.md)
+- [Thermodynamic models](../../thermo/README.md)
+- [Process simulation](../../process/README.md)
 
-// Set initial parameter guesses and run fitting
-fitter.setInitialGuess(3500.0, 0.005);  // epsilon/R, kappa
-fitter.solve();
-
-// Get fitted CPA parameters
-double epsilonR = fitter.getFittedAssociationEnergy();
-double kappa = fitter.getFittedAssociationVolume();
-```
-
-## Asphaltene Component in NeqSim Database
-
-NeqSim includes a pre-defined asphaltene pseudo-component with CPA parameters suitable for typical asphaltene modeling:
-
-| Property | Value | Unit |
-|----------|-------|------|
-| Molecular Weight | 750 | g/mol |
-| Critical Temperature | 1049.85 | K |
-| Critical Pressure | 8.0 | bar |
-| Acentric Factor | 1.5 | - |
-| Association Energy (ε/R) | 3500 | K |
-| Association Volume (κ) | 0.005 | - |
-
-These parameters can be tuned to match specific experimental data using the `AsphalteneOnsetFitting` class.
-
-## PhaseType.ASPHALTENE
-
-When asphaltene precipitates, NeqSim identifies it using the dedicated `PhaseType.ASPHALTENE` enum value. This enables:
-
-- **Accurate phase identification** - Distinguish asphaltene from wax or hydrate
-- **Correct physical properties** - Asphaltene-specific density (~1150 kg/m³), viscosity (~10,000 Pa·s), thermal conductivity (~0.20 W/mK)
-- **Easy API access** - Use `fluid.hasPhaseType("asphaltene")` to detect precipitation
-
-```java
-import neqsim.thermo.phase.PhaseType;
-
-// After flash calculation
-if (fluid.hasPhaseType(PhaseType.ASPHALTENE)) {
-    PhaseInterface asphaltene = fluid.getPhaseOfType("asphaltene");
-    System.out.println("Asphaltene density: " + asphaltene.getDensity("kg/m3") + " kg/m³");
-    System.out.println("Asphaltene fraction: " + (asphaltene.getBeta() * 100) + "%");
-}
-```
-
-See [Asphaltene Modeling](asphaltene_modeling) for more details on `PhaseType.ASPHALTENE`.
-
-## Related Topics
-
-- [Thermodynamic Models](../../thermo/) - Equation of state fundamentals
-- [PVT Simulation](../) - Fluid characterization
-- [Process Equipment](../../process/) - Separator and pipeline modeling

--- a/src/test/java/neqsim/pvtsimulation/flowassurance/FlowAssuranceDocumentationTest.java
+++ b/src/test/java/neqsim/pvtsimulation/flowassurance/FlowAssuranceDocumentationTest.java
@@ -1,0 +1,22 @@
+package neqsim.pvtsimulation.flowassurance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.Test;
+import neqsim.pvtsimulation.flowassurance.DeBoerAsphalteneScreening.DeBoerRisk;
+
+/** Verifies the executable quick start in the flow-assurance documentation index. */
+class FlowAssuranceDocumentationTest {
+
+  @Test
+  void testDeBoerQuickStart() {
+    DeBoerAsphalteneScreening screening = new DeBoerAsphalteneScreening(350.0, 150.0, 750.0);
+
+    DeBoerRisk risk = screening.evaluateRisk();
+    double riskIndex = screening.calculateRiskIndex();
+
+    assertEquals(DeBoerRisk.MODERATE_PROBLEM, risk);
+    assertEquals(1.6, riskIndex, 1.0e-12);
+    assertFalse(risk.getDescription().trim().isEmpty());
+  }
+}


### PR DESCRIPTION
Closes part of #2499 (D007).

## Frozen scan batch

- `docs/pvtsimulation/flowassurance/README.md`
- `src/test/java/neqsim/pvtsimulation/flowassurance/FlowAssuranceDocumentationTest.java`

This batch deliberately excludes `docs/pvtsimulation/fluid_characterization_mathematics.md` because open PR #2337 changes that page, and it does not overlap other open NeqSim PRs found during the scan.

## Confirmed defects

| Severity | Defect | Evidence / root cause |
| --- | --- | --- |
| High | De Boer quick start did not compile | `evaluateRisk()` returns `DeBoerRisk`, not `String` |
| High | CPA onset example called a nonexistent API | `ThermodynamicOperations.asphalteneOnsetPressure()` does not exist; onset is implemented by `AsphalteneOnsetPressureFlash` |
| Medium | Corrosion navigation was broken | The page linked to nonexistent `docs/process/corrosion/README.md`; the section entry point is `index.md` |
| Medium | Screening-class table rendered incorrectly | A blockquote split the table before the scale and wax rows |
| Medium | Phase guidance overpromised behavior | Adding an asphaltene component does not by itself guarantee a precipitated phase or phase label |
| Medium | Onset classes were assigned to the wrong package | Both onset flashes live in `neqsim.thermodynamicoperations.flashops.saturationops` |
| Low | Jekyll title was duplicated | The front-matter title was repeated as an H1 contrary to the documentation agent rules |
| Low | Front-matter description was truncated | It ended in an ellipsis and omitted useful search terms |

## Fixes

- Reworked the page as a concise navigation and method-selection guide.
- Repaired the Markdown table and all internal targets in the frozen page.
- Replaced the broken quick start with the actual nested enum return type and documented deterministic output.
- Removed the nonexistent onset-operation call and pointed to the real flash classes and result API.
- Replaced unsupported fixed asphaltene-property claims with model- and calibration-aware guidance.
- Added explicit units, screening limitations, and links for hydrate, wax, erosion, emulsion, corrosion, scale, and asphaltene workflows.
- Added `FlowAssuranceDocumentationTest` to execute every API call in the remaining Java example.

## Validation

Passed:

- Read current Java sources for all 14 classes named in the revised page.
- Confirmed all 17 relative documentation targets exist on current `master`.
- Confirmed the branch is exactly two files, two commits ahead of `master`, and not behind.
- Static Markdown checks: valid front matter, no duplicate H1, no `\\(...\\)` / `\\[...\\]` math delimiters, no HTML/Markdown mixing, balanced code fence.
- Runtime-smoked the complete quick start with NeqSim 3.16.0: `MODERATE_PROBLEM`, risk index `1.6`.
- Hosted documentation build, source contracts, generated search coverage, and search JavaScript syntax.
- Hosted Javadoc, CodeQL, and agent-skill cross-reference checks.
- Scoped Spotless: the formatter reported no violation in `FlowAssuranceDocumentationTest`.
- Equation check: no equations remain in this landing page.
- External-link check: not applicable; the revised page contains no external links.
- Notebook check: not applicable; this batch contains no notebook.

Pending or blocked:

- The focused D007 JUnit has not executed on the hosted PR branch, so no JUnit pass is claimed. Repository-wide test compilation still stops first because `PhaseAmmoniaEosTest.java:89` on current `master` neither catches nor declares `IsNaNException`; this is outside the two-file D007 diff.
- PR #2524 proposes the exact checked-exception and formatter-only repairs without overlapping D007. On its head, pre-commit, Spotless, Javadoc, CodeQL, and agent-skill checks pass, proving the original compile/format gates are repaired.
- PR #2524's Windows matrix then executed 10,526 tests and reported nine unrelated failures in RCA, field-lifecycle, LNG, and ammonia tests; the Ubuntu matrix was canceled after the Windows failure. D007 does not change those systems and will not absorb their fixes.
- A local focused-Maven attempt was not completed because the runner had no dependency cache and external Maven artifact access was unavailable; it is not counted as validation evidence.
- The page has not been visually inspected in a browser. Hosted Jekyll build and search rendering gates passed, but no screenshot is claimed.

## Expected regression result

The quick-start inputs `P_res = 350 bara`, `P_sat = 150 bara`, and `rho = 750 kg/m3` should return:

- `DeBoerRisk.MODERATE_PROBLEM`
- risk index `1.6`

The focused JUnit test locks both values.

## Next D007 step

Keep this PR draft. After #2524 or an equivalent repair lands on `master`, rerun the focused D007 JUnit and full matrix; distinguish any remaining repository-wide failures from the two-file documentation batch. No production code is changed.