### PR TITLE
Fix catalytic reformer Gibbs convergence

### DIFF
--- a/src/main/java/neqsim/process/equipment/reactor/HydrogenProductionUtils.java
+++ b/src/main/java/neqsim/process/equipment/reactor/HydrogenProductionUtils.java
@@ -30,6 +30,12 @@ final class HydrogenProductionUtils {
   /** Small positive mole amount used to seed products for Gibbs calculations. */
   private static final double TRACE_MOLES = 1.0e-20;
 
+  /** Composition damping used by syngas Gibbs screening reactors. */
+  private static final double SYNGAS_GIBBS_DAMPING = 1.0e-2;
+
+  /** Convergence tolerance used by syngas Gibbs screening reactors. */
+  private static final double SYNGAS_GIBBS_TOLERANCE = 1.0e-5;
+
   /** Common syngas species required by the equilibrium and reporting models. */
   private static final String[] SYNGAS_COMPONENTS = { "methane", "water", "oxygen", "hydrogen", "CO", "CO2",
       "nitrogen" };
@@ -78,9 +84,9 @@ final class HydrogenProductionUtils {
       GibbsReactor.EnergyMode energyMode) {
     GibbsReactor reactor = new GibbsReactor(name, inletStream);
     reactor.setUseAllDatabaseSpecies(false);
-    reactor.setDampingComposition(1.0e-4);
+    reactor.setDampingComposition(SYNGAS_GIBBS_DAMPING);
     reactor.setMaxIterations(6000);
-    reactor.setConvergenceTolerance(1.0e-6);
+    reactor.setConvergenceTolerance(SYNGAS_GIBBS_TOLERANCE);
     reactor.setEnergyMode(energyMode);
     if (inletStream.getThermoSystem().hasComponent("nitrogen")) {
       reactor.setComponentAsInert("nitrogen");

--- a/src/test/java/neqsim/process/equipment/reactor/CatalyticTubeReformerTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/CatalyticTubeReformerTest.java
@@ -1,0 +1,38 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests for {@link CatalyticTubeReformer}.
+ */
+public class CatalyticTubeReformerTest extends neqsim.NeqSimTest {
+  @Test
+  void testSteamMethaneReformingConversion() {
+    SystemInterface feedFluid = new SystemSrkEos(650.0, 25.0);
+    feedFluid.addComponent("methane", 1.0);
+    feedFluid.addComponent("water", 3.0);
+    feedFluid.setMixingRule("classic");
+
+    Stream feed = new Stream("reformer feed", feedFluid);
+    feed.setFlowRate(100.0, "kmol/hr");
+    feed.run();
+
+    CatalyticTubeReformer reformer = new CatalyticTubeReformer("primary reformer", feed);
+    reformer.setReformingTemperature(1123.15, "K");
+    reformer.setPressureDrop(2.0);
+    reformer.run();
+
+    assertTrue(reformer.getMethaneConversion() > 0.75,
+        "Hot steam-methane reforming should not remain trapped near the inlet composition");
+    assertTrue(reformer.getMethaneConversion() < 0.90,
+        "The equilibrium conversion should remain within the expected screening range");
+    assertTrue(reformer.getHeatDuty("kW") > 0.0,
+        "Steam-methane reforming and feed heating should require positive duty");
+    assertEquals(3.0, reformer.getSteamToCarbonRatio(), 1.0e-8);
+  }
+}


### PR DESCRIPTION
## Summary

- increase syngas Gibbs composition damping from `1e-4` to `1e-2`
- use a screening-appropriate `1e-5` convergence tolerance
- add a regression test for hot steam-methane reforming conversion and duty

## Reproduction

With NeqSim 3.16.0, a 3:1 steam-to-carbon feed at 1123.15 K and 23 bara stalls after 6000 iterations with the current helper settings and returns about 0.04% methane conversion. The same declared-species Gibbs problem with the proposed damping converges at a final error below `1e-5` and gives about 80.96% conversion.

This was detected while completing the NeqSim-Colab blue-ammonia tutorial. The notebook uses an explicitly configured public `GibbsReactor` until this dedicated-unit correction is released.

## Validation

- PyPI NeqSim 3.16.0 reproduction: passed
- independent public-API Gibbs calculation: 80.963% conversion
- focused Java regression test: added; awaiting hosted CI
- no API signature or serialized-field changes
