### PR TITLE
docs: document catalytic tube reformer convergence

### DIFF
--- a/docs/process/hydrogen_production.md
+++ b/docs/process/hydrogen_production.md
@@ -3,8 +3,6 @@ title: Hydrogen Production with NeqSim
 description: Modeling guide for hydrogen production routes — SMR fired reformers, ATR and POX syngas generators, blue-H2 WGS/capture/compression chains, pressure-swing adsorption (PSA), and water electrolysis. Covers ReformerFurnace, CatalyticTubeReformer, WaterGasShiftReactor, AutothermalReformer, PartialOxidationReactor, PSACascade, BlueHydrogenPlantBuilder, Electrolyzer, CAPEX estimation, para/ortho hydrogen corrections, and catalyst deactivation screening.
 ---
 
-# Hydrogen Production with NeqSim
-
 NeqSim covers thermochemical and electrochemical hydrogen production routes natively:
 
 1. **Grey / blue H₂** — steam methane reforming (SMR), autothermal reforming
@@ -70,6 +68,51 @@ capture, or vendor reactor design data.
 | Steam methane reforming (SMR) | `ReformerFurnace` + `CatalyticTubeReformer` + `FurnaceBurner` | 4/5 | Detailed radiant-box view factors, burner CFD, tube metallurgy/vendor rating |
 | Autothermal reforming (ATR) | `AutothermalReformer` with `SyngasBurnerZone` + catalytic `GibbsReactor` | 4/5 | Burner aerodynamics, oxygen-mixing CFD, rate-based catalyst bed calibration |
 | Partial oxidation (POX) | `PartialOxidationReactor` + `SyngasBurnerZone` + `QuenchSection` | 3/5 | Fast-quench kinetics, refractory thermal model, soot/coke kinetics |
+
+### Direct catalytic tube reformer
+
+Use `CatalyticTubeReformer` when the tube-side methane/steam feed already exists
+as a NeqSim stream and a fired-furnace heat balance is not required. Temperatures
+are Kelvin, pressures are absolute bar, and `setPressureDrop()` takes bar.
+
+```java
+import neqsim.process.equipment.reactor.CatalyticTubeReformer;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+SystemInterface feedFluid = new SystemSrkEos(650.0, 25.0);
+feedFluid.addComponent("methane", 1.0);
+feedFluid.addComponent("water", 3.0);
+feedFluid.setMixingRule("classic");
+
+Stream feed = new Stream("reformer feed", feedFluid);
+feed.setFlowRate(100.0, "kmol/hr");
+feed.run();
+
+CatalyticTubeReformer reformer =
+    new CatalyticTubeReformer("primary reformer", feed);
+reformer.setReformingTemperature(1123.15, "K");
+reformer.setPressureDrop(2.0);
+reformer.run();
+
+double methaneConversion = reformer.getMethaneConversion();
+double heatDutyKW = reformer.getHeatDuty("kW");
+double steamToCarbon = reformer.getSteamToCarbonRatio();
+double outletPressureBara = reformer.getOutletStream().getPressure("bara");
+boolean tubeWallAcceptable = reformer.isTubeWallTemperatureAcceptable();
+```
+
+For this 3:1 steam-to-methane feed, the current SRK equilibrium calculation
+converges to about 81% methane conversion. The regression requires conversion
+between 75% and 90%, positive heat duty, a steam-to-carbon ratio of 3.0, and an
+outlet pressure of 23 bara. The duty includes feed heating from 650 K to the
+specified reforming temperature as well as the equilibrium reaction enthalpy.
+
+The class is a screening equilibrium model. It does not represent reaction-rate
+limits, axial profiles, burner CFD, detailed radiation, catalyst-pellet transport,
+or vendor tube metallurgy. Use `ReformerFurnace` when fuel, air, flue gas, and
+available radiant heat must be included in the process heat balance.
 
 ### SMR fired reformer builder
 
@@ -233,6 +276,10 @@ H2 product rate, and carbon-intensity metrics remain in physically credible
 screening ranges. These tests are deliberately range-based so improved EOS or
 reactor solvers can move the answer without breaking validation, while large
 model regressions are still caught.
+
+`CatalyticTubeReformerTest` separately locks the direct SMR quick start at
+1123.15 K and 23 bara. It checks conversion, heat duty, steam-to-carbon ratio,
+outlet pressure, syngas-product creation, and the tube-wall screening result.
 
 ## Green H₂ — water electrolysis
 
@@ -421,6 +468,7 @@ the result for guaranteed catalyst run length.
 
 | Test class | Coverage |
 |---|---|
+| `CatalyticTubeReformerTest` | Direct SMR quick start, conversion, duty, S/C ratio, pressure drop, product species, and tube-wall screening |
 | `PressureSwingAdsorptionBedTest` | Defaults, recovery cap, mass balance, composition, sorbent switch |
 | `ElectrolyzerTechnologyTest` | Per-tech default consistency |
 | `ElectrolyzerIVCharacteristicTest` | $E_{rev}$ vs $T$, Tafel monotonicity, technology ordering |

--- a/src/test/java/neqsim/process/equipment/reactor/CatalyticTubeReformerTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/CatalyticTubeReformerTest.java
@@ -34,5 +34,8 @@ public class CatalyticTubeReformerTest extends neqsim.NeqSimTest {
     assertTrue(reformer.getHeatDuty("kW") > 0.0,
         "Steam-methane reforming and feed heating should require positive duty");
     assertEquals(3.0, reformer.getSteamToCarbonRatio(), 1.0e-8);
+    assertEquals(23.0, reformer.getOutletStream().getPressure("bara"), 1.0e-8);
+    assertTrue(reformer.getOutletStream().getThermoSystem().hasComponent("hydrogen"));
+    assertTrue(reformer.isTubeWallTemperatureAcceptable());
   }
 }


### PR DESCRIPTION
Closes no issue; advances documentation campaign #2499 (D008).

## Scan scope

Rotation scope 8: recent merged code versus documentation coverage.

Frozen paths:

- `docs/process/hydrogen_production.md`
- `src/test/java/neqsim/process/equipment/reactor/CatalyticTubeReformerTest.java`

The scan reviewed the public catalytic-reformer functionality and convergence correction merged in #2526. It deliberately excludes production-code changes and all files touched by open dependency PRs.

## Confirmed defects

1. **Medium — missing executable coverage for recently repaired public functionality.** The hydrogen guide named `CatalyticTubeReformer` but provided no complete direct-use example, expected result, convergence evidence, unit contract, or model boundary.
2. **Low — duplicate rendered page title.** The page used Jekyll `title` front matter and an additional Markdown H1, contrary to the repository documentation-agent rule.

## Fix

- Add a complete methane/steam direct-reformer example with explicit K, bara, bar, kmol/h, and kW units.
- Record the observed SRK result and a stable regression envelope.
- Explain what the reported heat duty contains and distinguish the equilibrium screening model from kinetic, axial, CFD, pellet-transport, and vendor-design models.
- Extend the existing focused test to cover the documented outlet pressure, hydrogen product, and tube-wall acceptance API.
- Remove the duplicate H1. Existing section and reference-manual indexes already link the page, so no navigation file changes are needed.

## Evidence and validation

- Complete example compiled with OpenJDK 17 using the current `CatalyticTubeReformer` and #2526 syngas helper sources against the NeqSim 3.16.0 dependency bundle.
- Example executed successfully:
  - methane conversion: `0.809603989`
  - heat duty: `759.640995 kW`
  - steam/carbon ratio: `3.000000`
  - outlet pressure: `23.000000 bara`
  - tube-wall screening: acceptable
- `python3 devtools/check_documentation_search.py`: passed; 618 Markdown pages and one standalone HTML page indexed.
- `python3 devtools/test_engineering_documentation.py`: passed.
- Focused static audit: passed for front matter, duplicate-H1 rule, 11 balanced code fences, internal link targets, section/reference indexes, and every direct-example API call.
- No external link, image, notebook, or equation was changed; no transient link failure was observed.

## Blockers / checks not claimed

This remains a draft because the execution environment has no Ruby/Jekyll installation and Maven cannot resolve uncached plugins/dependencies from Maven Central. Therefore:

- no Jekyll render or visual inspection is claimed;
- no focused JUnit or full Maven suite result is claimed;
- hosted CI must supply the site, formatting, focused-test, and broader regression evidence.

## Compatibility and risk

Documentation and tests only. No production behavior or public API changes. The numerical assertions retain the existing 75–90% conversion envelope so future physically justified solver improvements are not pinned to one exact value.

## Next scope

After D008 is merged and fully validated, wrap the rotation to scope 1: landing pages, navigation, indexes, and internal links.
