### PR TITLE
docs: repair documentation landing page quick starts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ description: Comprehensive Java library for thermodynamic, physical property, an
 ## Quick Start
 
 ```java
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,6 +116,7 @@ description: "Industrial Agentic Engineering with NeqSim — AI Agents for Engin
 ## ⚡ Quick Start Example
 
 ```java
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
@@ -139,7 +140,7 @@ System.out.println("Compressibility: " + gas.getZ());
 
 <hr class="section-divider" style="border: none; height: 2px; background: linear-gradient(to right, transparent, #159957, transparent); margin: 2rem 0;">
 
-## � New: Quickstart & Learning Resources
+## 🆕 Quickstart & Learning Resources
 
 <div class="nav-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin: 2rem 0;">
 
@@ -188,7 +189,7 @@ System.out.println("Compressibility: " + gas.getZ());
 
 <hr class="section-divider" style="border: none; height: 2px; background: linear-gradient(to right, transparent, #159957, transparent); margin: 2rem 0;">
 
-## �📖 Documentation Sections
+## 📖 Documentation Sections
 
 <div style="overflow-x: auto; margin: 1.5rem 0;">
 <table style="width: 100%; border-collapse: separate; border-spacing: 0; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);">

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -60,6 +60,7 @@ import neqsim.thermo.system.FluidBuilder;
 import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPitzer;
+import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
@@ -70,6 +71,28 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @version 1.0
  */
 public class DocExamplesCompilationTest {
+
+  /**
+   * Quick-start example shared by docs/index.md and docs/README.md.
+   */
+  @Test
+  public void testDocumentationLandingPageQuickStart() {
+    SystemInterface gas = new SystemSrkEos(298.15, 50.0);
+    gas.addComponent("methane", 0.90);
+    gas.addComponent("ethane", 0.05);
+    gas.addComponent("propane", 0.03);
+    gas.addComponent("CO2", 0.02);
+    gas.setMixingRule("classic");
+
+    ThermodynamicOperations ops = new ThermodynamicOperations(gas);
+    ops.TPflash();
+    gas.initProperties();
+
+    assertTrue(gas.getDensity("kg/m3") > 35.0);
+    assertTrue(gas.getDensity("kg/m3") < 50.0);
+    assertTrue(gas.getZ() > 0.8);
+    assertTrue(gas.getZ() < 1.0);
+  }
 
   /**
    * FluidBuilder fluent API example from docs/util/engineering_utilities.md.


### PR DESCRIPTION
## D009 — landing pages, navigation, and internal-link integrity

Linked campaign: #2499

### Frozen scope

Rotation scope 1 is limited to:

- `docs/index.md`
- `docs/README.md`
- `src/test/java/neqsim/DocExamplesCompilationTest.java`

No production code, equations, images, notebooks, section indexes, or unrelated documentation are changed.

### Confirmed defects and evidence

| Severity | Defect | Evidence / root cause |
|---|---|---|
| High | The complete Java quick start on both landing pages did not compile | Both snippets declare `SystemInterface gas` but omitted the `SystemInterface` import. The example had been duplicated without executable coverage. |
| Medium | Two landing-page section headings contained Unicode replacement characters | `docs/index.md` contained U+FFFD in the quickstart and documentation-section headings, indicating an earlier encoding loss and producing visibly broken navigation text. |
| Medium | Landing-page Java APIs lacked regression coverage | The shared natural-gas TP-flash example was not represented in `DocExamplesCompilationTest`, allowing its imports and calls to drift. |

### Fixes

- Add the missing `neqsim.thermo.system.SystemInterface` import to both Java snippets.
- Replace the corrupted headings with stable Unicode headings: “🆕 Quickstart & Learning Resources” and “📖 Documentation Sections”.
- Add `testDocumentationLandingPageQuickStart()`, exercising the exact model, composition, mixing rule, TP flash, initialization, density, and compressibility calls with physical bounds.

### Validation performed

- Remote diff against current `master` (`9f2f121`): exactly 3 intended files, 27 additions, 2 deletions; branch is 3 commits ahead and 0 behind.
- Remote content audit: one required `SystemInterface` import per landing page, zero U+FFFD characters, valid front matter on both pages, one regression method, and all four physical assertions present.
- Internal navigation: 104 unique internal paths resolve in the documentation tree; 6 fragment anchors resolve.
- Java quick start compiled and executed against NeqSim 3.16.0 / Java 17: density `40.895367 kg/m3`, `Z = 0.896884626`.
- Python landing-page quick start executed against NeqSim 3.16.0: density `39.181336 kg/m3`, `Z = 0.899847913`.
- Repository documentation audits passed locally: `python3 devtools/check_documentation_search.py` (618 Markdown pages and 1 standalone HTML page) and `python3 devtools/test_engineering_documentation.py`.
- External-link audit: NTNU, Maven Central, Apache-2.0, the NeqSim repository, and the public `equinor/neqsim-python` repository resolve. The hosted Javadoc endpoint resolves, but still identifies itself as NeqSim 3.9.1; this is recorded as a separate publication-freshness risk because no authoritative replacement endpoint was found. Two Shields SVG requests failed in the browsing tool, so they are treated as transient/tool-specific and are not replaced.
- No equations changed; no equation-rendering claim is made. No images or notebooks changed. The source-level fixes do not require a visual before/after screenshot.

### Hosted validation

GitHub-hosted pre-commit, Spotless, Javadoc, and agent-skill cross-reference checks have passed. Jekyll/search coverage, CodeQL, and the Ubuntu/Windows Java matrices were still running when the PR was merged externally. D009 remains in ledger validation until that evidence is reconciled; a full local Maven/Jekyll run was not available in this environment, so no unperformed result is claimed.

### Regression value and compatibility

The new test prevents the duplicated landing-page example from silently becoming non-compiling or physically implausible. There is no public API, production behavior, dependency, schema, or performance change.

### Deliberate exclusions / next scope

The stale hosted Javadoc publication is not changed without a verified current destination. D009 scope 2, after this batch is merged, should continue the rotation through root indexes and linked quickstart pages, including deployed-site rendering and Javadoc publication freshness.
