### PR TITLE
Fix mixed-refrigerant exchanger energy-balance convergence

### DIFF
--- a/src/main/java/neqsim/process/lng/LNGProcessBuilder.java
+++ b/src/main/java/neqsim/process/lng/LNGProcessBuilder.java
@@ -355,16 +355,17 @@ public class LNGProcessBuilder {
 
     CompressionTrain mrTrain = addTwoStageCompression(context, name + " MR", mrSuction, 30.0, compressorEfficiency);
 
-    double mrOutletTemperatureC = targetLiquefactionTemperatureC - 5.0;
+    double mrExpansionInletSeedTemperatureC = targetLiquefactionTemperatureC - 5.0;
     LNGHeatExchanger mche = createExchanger(name + " main cryogenic exchanger");
     mche.addInStreamMSHE(context.feed, "hot", targetLiquefactionTemperatureC);
-    mche.addInStreamMSHE(mrTrain.outlet, "hot", mrOutletTemperatureC);
+    mche.addInStreamMSHE(mrTrain.outlet, "hot", null);
 
     ThrottlingValve mrValve = new ThrottlingValve(name + " MR JT valve", mche.getOutStream(1));
     mrValve.setOutletPressure(3.0, "bara");
-    initializeExpansionInlet(mche.getOutStream(1), mrOutletTemperatureC, 30.0);
+    initializeExpansionInlet(mche.getOutStream(1), mrExpansionInletSeedTemperatureC, 30.0);
     mrValve.run();
-    initializeColdSideWarmStart(mrValve.getOutletStream(), mrOutletTemperatureC, mrValve.getOutletPressure());
+    initializeColdSideWarmStart(mrValve.getOutletStream(), mrExpansionInletSeedTemperatureC,
+        mrValve.getOutletPressure());
     mche.addInStreamMSHE(mrValve.getOutletStream(), "cold", null);
     context.exchangers.add(mche);
 
@@ -407,16 +408,17 @@ public class LNGProcessBuilder {
     context.process.add(precooler);
     addRecycle(context, name + " propane recycle", precooler.getOutStream(2), propaneSuction);
 
-    double mrOutletTemperatureC = targetLiquefactionTemperatureC - 5.0;
+    double mrExpansionInletSeedTemperatureC = targetLiquefactionTemperatureC - 5.0;
     LNGHeatExchanger mche = createExchanger(name + " main cryogenic exchanger");
     mche.addInStreamMSHE(precooler.getOutStream(0), "hot", targetLiquefactionTemperatureC);
-    mche.addInStreamMSHE(precooler.getOutStream(1), "hot", mrOutletTemperatureC);
+    mche.addInStreamMSHE(precooler.getOutStream(1), "hot", null);
 
     ThrottlingValve mrValve = new ThrottlingValve(name + " MR JT valve", mche.getOutStream(1));
     mrValve.setOutletPressure(4.0, "bara");
-    initializeExpansionInlet(mche.getOutStream(1), mrOutletTemperatureC, 45.0);
+    initializeExpansionInlet(mche.getOutStream(1), mrExpansionInletSeedTemperatureC, 45.0);
     mrValve.run();
-    initializeColdSideWarmStart(mrValve.getOutletStream(), mrOutletTemperatureC, mrValve.getOutletPressure());
+    initializeColdSideWarmStart(mrValve.getOutletStream(), mrExpansionInletSeedTemperatureC,
+        mrValve.getOutletPressure());
     mche.addInStreamMSHE(mrValve.getOutletStream(), "cold", null);
     context.exchangers.add(mche);
     context.process.add(mche);
@@ -461,16 +463,17 @@ public class LNGProcessBuilder {
     context.process.add(precooler);
     addRecycle(context, name + " warm MR recycle", precooler.getOutStream(2), warmMrSuction);
 
-    double coldMrOutletTemperatureC = targetLiquefactionTemperatureC - 5.0;
+    double coldMrExpansionInletSeedTemperatureC = targetLiquefactionTemperatureC - 5.0;
     LNGHeatExchanger mche = createExchanger(name + " main cryogenic exchanger");
     mche.addInStreamMSHE(precooler.getOutStream(0), "hot", targetLiquefactionTemperatureC);
-    mche.addInStreamMSHE(precooler.getOutStream(1), "hot", coldMrOutletTemperatureC);
+    mche.addInStreamMSHE(precooler.getOutStream(1), "hot", null);
 
     ThrottlingValve coldValve = new ThrottlingValve(name + " cold MR JT valve", mche.getOutStream(1));
     coldValve.setOutletPressure(3.0, "bara");
-    initializeExpansionInlet(mche.getOutStream(1), coldMrOutletTemperatureC, 38.0);
+    initializeExpansionInlet(mche.getOutStream(1), coldMrExpansionInletSeedTemperatureC, 38.0);
     coldValve.run();
-    initializeColdSideWarmStart(coldValve.getOutletStream(), coldMrOutletTemperatureC, coldValve.getOutletPressure());
+    initializeColdSideWarmStart(coldValve.getOutletStream(), coldMrExpansionInletSeedTemperatureC,
+        coldValve.getOutletPressure());
     mche.addInStreamMSHE(coldValve.getOutletStream(), "cold", null);
     context.exchangers.add(mche);
     context.process.add(mche);
@@ -673,7 +676,7 @@ public class LNGProcessBuilder {
    * </p>
    *
    * @param highPressureStream exchanger outlet feeding the expansion device
-   * @param temperatureC specified exchanger outlet temperature in Celsius
+   * @param temperatureC cold-end initialization temperature in Celsius
    * @param pressureBara high-side pressure in bara
    */
   private void initializeExpansionInlet(StreamInterface highPressureStream, double temperatureC, double pressureBara) {
@@ -683,7 +686,7 @@ public class LNGProcessBuilder {
   }
 
   /**
-   * Seeds a recycle cold-side inlet below the coldest specified hot-stream outlet.
+   * Seeds a recycle cold-side inlet below the high-pressure cold-end initialization temperature.
    *
    * <p>
    * The expansion device first establishes an isenthalpic outlet. For the initial exchanger iteration only, the recycle
@@ -692,12 +695,12 @@ public class LNGProcessBuilder {
    * </p>
    *
    * @param coldSideStream expansion-device outlet used as the exchanger cold-side inlet
-   * @param coldestHotOutletTemperatureC coldest specified hot-stream outlet temperature in Celsius
+   * @param coldEndSeedTemperatureC high-pressure cold-end initialization temperature in Celsius
    * @param pressureBara cold-side pressure in bara
    */
-  private void initializeColdSideWarmStart(StreamInterface coldSideStream, double coldestHotOutletTemperatureC,
+  private void initializeColdSideWarmStart(StreamInterface coldSideStream, double coldEndSeedTemperatureC,
       double pressureBara) {
-    double seedTemperatureC = Math.min(coldSideStream.getTemperature("C"), coldestHotOutletTemperatureC - 5.0);
+    double seedTemperatureC = Math.min(coldSideStream.getTemperature("C"), coldEndSeedTemperatureC - 5.0);
     initializeExpansionInlet(coldSideStream, seedTemperatureC, pressureBara);
   }
 

--- a/src/test/java/neqsim/process/lng/LNGProcessBuilderTest.java
+++ b/src/test/java/neqsim/process/lng/LNGProcessBuilderTest.java
@@ -48,9 +48,9 @@ class LNGProcessBuilderTest {
     LNGHeatExchanger mainExchanger = model.getCryogenicHeatExchangers()
         .get(model.getCryogenicHeatExchangers().size() - 1);
     double coldSideInletC = mainExchanger.getInStream(2).getTemperature("C");
-    double coldestHotOutletC = Math.min(mainExchanger.getOutTemperature(0), mainExchanger.getOutTemperature(1));
-    assertTrue(coldSideInletC < coldestHotOutletC,
-        cycle + " cold-side warm start must be colder than the specified hot-stream outlets");
+    double specifiedFeedOutletC = mainExchanger.getOutTemperature(0);
+    assertTrue(coldSideInletC < specifiedFeedOutletC,
+        cycle + " cold-side warm start must be colder than the specified feed outlet");
 
     if (cycle == LNGProcessCycle.NITROGEN_EXPANDER) {
       assertEquals(1, model.getExpanders().size());


### PR DESCRIPTION
## Summary

- keep the natural-gas liquefaction outlet temperature specified in the SMR, C3MR, and DMR main cryogenic exchangers
- solve the high-pressure refrigerant outlet together with the low-pressure return outlet
- retain explicit cold-end stream seeds only as first-iteration states for the downstream JT valves
- update the construction regression to check the cold-side seed against the one specified hot outlet

## Root cause

The mixed-refrigerant MCHEs specified both hot-side outlet temperatures and left only the low-pressure refrigerant return temperature unknown. That over-constrained the exchanger: the solver could not satisfy the prescribed feed cooling, prescribed high-pressure MR cooling, and energy balance with one degree of freedom. The Ubuntu Java 21 JaCoCo suite failed the SMR smoke test in `MultiStreamHeatExchanger2.resetOfExtremesAndStalls` with a hot/cold duty ratio of 2.574 after 1000 attempts.

The corrected formulation specifies the LNG feed target and lets the existing two-unknown solver determine the two refrigerant outlet temperatures from energy balance and the minimum approach constraint. The JT valve and recycle remain explicit and update the tear-stream states during process convergence.

## Validation

- exact failing Ubuntu Actions log inspected; nested cause confirmed as `resetOfExtremes: gave up after 1000 attempts - last issues: energy ratio = 2.574`
- source and test formatting inspected against the repository style
- focused local Maven execution was attempted, but this workspace cannot reach Maven Central and has no cached plugin repository
- Spotless format patch: passed
- Pre-commit checks: passed
- PaperLab replication gate: passed
- CodeQL security analysis: passed
- Java 21 Javadoc: passed
- Ubuntu Java 21 complete JaCoCo suite: running
- Windows Java 21 fast suite: running