### PR TITLE
Improve API 610 pump mechanical design screening

### DIFF
--- a/docs/process/equipment/pumps.md
+++ b/docs/process/equipment/pumps.md
@@ -13,6 +13,7 @@ Documentation for liquid pumping equipment in NeqSim.
 - [Pump Performance](#pump-performance)
 - [Head and Efficiency Curves](#head-and-efficiency-curves)
 - [NPSH Calculations](#npsh-calculations)
+- [API 610 Mechanical Design Screening](#api-610-mechanical-design-screening)
 - [Examples](#examples)
 
 ---
@@ -177,6 +178,45 @@ if (margin < 1.0) {
 ### NPSH Available Calculation
 
 $$NPSH_A = \frac{P_{suction}}{\rho g} + \frac{v^2}{2g} - \frac{P_{vapor}}{\rho g}$$
+
+---
+
+## API 610 Mechanical Design Screening
+
+`PumpMechanicalDesign` combines the simulated duty point with purchaser and vendor data to produce an auditable
+API 610 13th-edition screening result. It distinguishes a calculated pass or failure from missing evidence using
+`PASS`, `WARNING`, `FAIL`, and `NOT_EVALUATED` check statuses.
+
+```java
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator;
+import neqsim.process.mechanicaldesign.pump.PumpMechanicalDesign;
+
+PumpMechanicalDesign design = pump.getMechanicalDesign();
+design.setApi610PumpType(PumpApi610DesignCalculator.Api610PumpType.OH2);
+design.setMaximumSuctionPressure(8.0); // bara
+design.setFurnishedCasingMawp(25.0);  // bara
+design.calcDesign();
+
+PumpApi610DesignCalculator assessment = design.getApi610Assessment();
+PumpApi610DesignCalculator.AssessmentStatus status = assessment.getAssessmentStatus();
+String json = design.getResponse().toJson();
+```
+
+The screen calculates or checks:
+
+- Rated flow against vendor BEP, rated-point region, POR, and AOR
+- NPSHa/NPSHr head and ratio margins
+- Maximum suction pressure plus shutoff head, furnished casing MAWP, and preliminary hydrotest pressure
+- Absorbed shaft power, driver margin, and the next configured driver rating
+- Head rise to shutoff when a vendor curve or purchaser value is available
+- ISO 281 bearing L10 life from vendor `C` and `P` loads
+- Optional shaft-deflection, critical-speed, nozzle-load, and vibration evidence
+- Exact OH1-OH6, BB1-BB5, or VS1-VS7 construction type and sealless-pump scope warning
+
+Use `assessment.setBearingData(...)` and `assessment.setMechanicalEvidence(...)` before the next
+`design.calcDesign()` call to add vendor mechanical evidence. Unavailable values remain `NOT_EVALUATED`; NeqSim does
+not infer detailed casing, rotor, nozzle, seal, baseplate, material, inspection, or test compliance. Final verification
+must use the purchased edition, project specification, and vendor documentation.
 
 ---
 

--- a/docs/process/mechanical_design.md
+++ b/docs/process/mechanical_design.md
@@ -484,8 +484,8 @@ separator.getMechanicalDesign().loadProcessDesignParameters();  // Loads from Te
 |-----------|--------|------|---------------|-------------|
 | NPSH margin factor | `getNpshMarginFactor()` | - | 1.1-1.3 | NPSHa / NPSHr requirement |
 | Hydraulic power margin | `getHydraulicPowerMargin()` | - | 1.05-1.15 | Driver sizing margin |
-| POR low fraction | `getPorLowFraction()` | - | 0.70-0.80 | Preferred Operating Region low limit (of BEP) |
-| POR high fraction | `getPorHighFraction()` | - | 1.10-1.15 | Preferred Operating Region high limit (of BEP) |
+| POR low fraction | `getPorLowFraction()` | - | 0.70 | Preferred Operating Region low limit (of BEP) |
+| POR high fraction | `getPorHighFraction()` | - | 1.20 | Preferred Operating Region high limit (of BEP) |
 | AOR low fraction | `getAorLowFraction()` | - | 0.60-0.70 | Allowable Operating Region low limit |
 | AOR high fraction | `getAorHighFraction()` | - | 1.20-1.30 | Allowable Operating Region high limit |
 | Maximum suction specific speed | `getMaxSuctionSpecificSpeed()` | - | 8000-13000 | Nss limit for stable operation |
@@ -696,6 +696,10 @@ Design calculations include:
 ```java
 PumpMechanicalDesign pumpDesign =
     (PumpMechanicalDesign) pump.getMechanicalDesign();
+pumpDesign.setApi610PumpType(PumpApi610DesignCalculator.Api610PumpType.OH2);
+pumpDesign.setMaximumSuctionPressure(8.0); // bara, purchaser maximum
+pumpDesign.setFurnishedCasingMawp(25.0);  // bara, vendor value
+pumpDesign.calcDesign();
 
 // Key parameters
 double specificSpeed = pumpDesign.getSpecificSpeed();
@@ -711,16 +715,27 @@ double aorLow = pumpDesign.getAorLowFraction();   // Allowable Operating Region
 double aorHigh = pumpDesign.getAorHighFraction();
 double maxNss = pumpDesign.getMaxSuctionSpecificSpeed();
 double headMargin = pumpDesign.getHeadMarginFactor();
+
+// Structured API 610 screening result
+PumpApi610DesignCalculator api610 = pumpDesign.getApi610Assessment();
+PumpApi610DesignCalculator.AssessmentStatus status = api610.getAssessmentStatus();
+List<PumpApi610DesignCalculator.Check> checks = api610.getChecks();
 ```
 
 Design calculations include:
-- Pump type selection (OH, BB, VS) based on application
+- Exact API 610 construction type (OH1-OH6, BB1-BB5 or VS1-VS7), supplied by the purchaser or preliminarily recommended
 - Impeller sizing from affinity laws
-- NPSH margin verification against requirements
-- Driver margin per API 610 (10-25%)
-- Seal type selection
-- Operating region validation (POR/AOR vs BEP)
-- Suction specific speed verification
+- Speed-aware vendor BEP, shutoff-head and NPSHr ingestion
+- Rated-point, POR and AOR screening relative to vendor BEP
+- NPSH head and ratio margin verification
+- Maximum-discharge-pressure, furnished MAWP and preliminary hydrotest-pressure screening
+- Driver selection without double-counting pump efficiency
+- ISO 281 rolling-element bearing life when vendor bearing load data are supplied
+- Vendor-evidence checks for shaft deflection, critical speed, nozzle loads and vibration
+
+The result is an API 610 13th-edition engineering screen, not a certificate of conformity. Checks that require vendor
+geometry, loads, analysis or test data return `NOT_EVALUATED` until those data are provided. Project criteria and the
+purchased standard remain governing.
 
 ### Valves (IEC 60534)
 

--- a/src/main/java/neqsim/process/engineering/design/modules/PumpPackageDesignModule.java
+++ b/src/main/java/neqsim/process/engineering/design/modules/PumpPackageDesignModule.java
@@ -8,6 +8,7 @@ import neqsim.process.engineering.design.EngineeringDesignState;
 import neqsim.process.engineering.design.EngineeringDesignUpdate;
 import neqsim.process.engineering.designcase.EngineeringCaseRunReport;
 import neqsim.process.engineering.designcase.EngineeringDesignEnvelope;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator;
 import neqsim.process.processmodel.ProcessSystem;
 
 /** Selects pump driver rating and verifies the minimum simulated NPSH margin. */
@@ -41,7 +42,10 @@ public final class PumpPackageDesignModule implements EngineeringDesignModule {
     EngineeringDesignEnvelope.GoverningValue power = DesignModuleSupport.requireMetric(caseReport, powerMetricId);
     EngineeringDesignEnvelope.GoverningValue npsh = DesignModuleSupport.requireMetric(caseReport, npshMarginMetricId);
     double requiredPower = power.getValue() * (1.0 + driverMarginFraction);
-    double selectedPower = select(requiredPower);
+    double selectedPower = PumpApi610DesignCalculator.selectDriverRating(requiredPower, driverCandidatesKw);
+    if (!Double.isFinite(selectedPower)) {
+      throw new IllegalStateException("No pump driver candidate satisfies " + requiredPower + " kW");
+    }
     String powerKey = pumpTag + ".driverRatedPower";
     String utilizationKey = pumpTag + ".driverUtilization";
     String npshKey = pumpTag + ".minimumNpshMargin";
@@ -58,18 +62,5 @@ public final class PumpPackageDesignModule implements EngineeringDesignModule {
             minimumNpshMarginM, "m", EngineeringDesignConstraint.Comparison.MINIMUM))
         .warning("Vendor curve, minimum continuous stable flow, seal system, start-up and runout require review")
         .build();
-  }
-
-  private double select(double required) {
-    double selected = Double.POSITIVE_INFINITY;
-    for (double candidate : driverCandidatesKw) {
-      if (candidate >= required) {
-        selected = Math.min(selected, candidate);
-      }
-    }
-    if (!Double.isFinite(selected)) {
-      throw new IllegalStateException("No pump driver candidate satisfies " + required + " kW");
-    }
-    return selected;
   }
 }

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -1189,11 +1189,9 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
       try {
         thermoOps.bubblePointPressureFlash(false);
       } catch (Exception e) {
-        // If bubble point flash fails, fluid might be in supercritical state or single
-        // phase
-        // Use a conservative estimate or return high value
-        logger.warn("Could not calculate vapor pressure for NPSH calculation: " + e.getMessage());
-        return 1000.0; // Return large value to indicate no cavitation risk
+        // Missing vapour-pressure evidence must not be interpreted as a safe NPSH margin.
+        logger.warn("Could not calculate vapor pressure for NPSH calculation: {}", e.getMessage());
+        return Double.NaN;
       }
       double pressureVapor = tempSystem.getPressure("Pa");
 
@@ -1210,8 +1208,8 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
 
       return npsha;
     } catch (Exception e) {
-      logger.error("Error calculating NPSH available: " + e.getMessage());
-      return 0.0;
+      logger.error("Error calculating NPSH available: {}", e.getMessage());
+      return Double.NaN;
     }
   }
 
@@ -1268,6 +1266,10 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
     }
     double npsha = getNPSHAvailable();
     double npshr = getNPSHRequired();
+    if (!Double.isFinite(npsha) || !Double.isFinite(npshr) || npshr <= 0.0) {
+      logger.warn("Pump {} NPSH status is unknown because NPSHa or NPSHr is unavailable", getName());
+      return true;
+    }
     boolean cavitating = npsha < (npshMargin * npshr);
     if (cavitating) {
       logger.warn("Pump " + getName() + " cavitation risk: NPSHa=" + String.format("%.2f", npsha) + " m < "

--- a/src/main/java/neqsim/process/equipment/pump/PumpChart.java
+++ b/src/main/java/neqsim/process/equipment/pump/PumpChart.java
@@ -507,6 +507,15 @@ public class PumpChart implements PumpChartInterface, java.io.Serializable {
    */
   @Override
   public double getBestEfficiencyFlowRate() {
+    return getBestEfficiencyFlowRate(referenceSpeed);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getBestEfficiencyFlowRate(double speed) {
+    if (speed <= 0.0 || reducedEfficiencyFunc == null) {
+      return 0.0;
+    }
     // Find maximum efficiency by searching through reduced flow range
     double bestFlow = 0.0;
     double bestEff = 0.0;
@@ -516,7 +525,7 @@ public class PumpChart implements PumpChartInterface, java.io.Serializable {
       double eff = reducedEfficiencyFunc.value(rFlow);
       if (eff > bestEff) {
         bestEff = eff;
-        bestFlow = rFlow * referenceSpeed;
+        bestFlow = rFlow * speed;
       }
     }
     return bestFlow;

--- a/src/main/java/neqsim/process/equipment/pump/PumpChartAlternativeMapLookupExtrapolate.java
+++ b/src/main/java/neqsim/process/equipment/pump/PumpChartAlternativeMapLookupExtrapolate.java
@@ -112,6 +112,16 @@ public class PumpChartAlternativeMapLookupExtrapolate extends CompressorChartAlt
 
   /** {@inheritDoc} */
   @Override
+  public double getBestEfficiencyFlowRate(double speed) {
+    double[] speeds = getSpeeds();
+    if (speeds == null || speeds.length == 0 || speeds[0] <= 0.0 || speed <= 0.0) {
+      return 0.0;
+    }
+    return getBestEfficiencyFlowRate() * speed / speeds[0];
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public double getSpecificSpeed() {
     double flowBEP = getBestEfficiencyFlowRate();
     if (flowBEP <= 0) {

--- a/src/main/java/neqsim/process/equipment/pump/PumpChartInterface.java
+++ b/src/main/java/neqsim/process/equipment/pump/PumpChartInterface.java
@@ -120,6 +120,21 @@ public interface PumpChartInterface extends Cloneable {
   public double getBestEfficiencyFlowRate();
 
   /**
+   * Get the flow rate at best efficiency point (BEP) at a specified speed.
+   *
+   * <p>
+   * Implementations with reduced performance curves should scale BEP flow with speed according to the affinity laws.
+   * The default preserves compatibility with chart implementations that only expose a reference-speed BEP.
+   * </p>
+   *
+   * @param speed pump speed in rpm
+   * @return flow rate at BEP in m3/hr at the specified speed
+   */
+  public default double getBestEfficiencyFlowRate(double speed) {
+    return getBestEfficiencyFlowRate();
+  }
+
+  /**
    * Calculate pump specific speed at BEP.
    *
    * @return specific speed (dimensionless)

--- a/src/main/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculator.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculator.java
@@ -9,9 +9,9 @@ import java.util.List;
  * Value-only calculator for API 610 pump design screening.
  *
  * <p>
- * The calculator evaluates process and purchaser data that can be checked without detailed vendor geometry. It does
- * not certify API 610 conformity. Final casing, rotor, bearing, nozzle-load, seal, baseplate and test compliance must
- * be verified against the purchased standard, project specification and vendor documentation.
+ * The calculator evaluates process and purchaser data that can be checked without detailed vendor geometry. It does not
+ * certify API 610 conformity. Final casing, rotor, bearing, nozzle-load, seal, baseplate and test compliance must be
+ * verified against the purchased standard, project specification and vendor documentation.
  * </p>
  *
  * <p>
@@ -224,10 +224,9 @@ public class PumpApi610DesignCalculator implements Serializable {
   private boolean seallessPump;
 
   // Candidate driver ratings and calculated results.
-  private double[] driverCandidateRatingsKw = new double[] { 0.75, 1.1, 1.5, 2.2, 3.0, 4.0, 5.5, 7.5, 11.0, 15.0,
-      18.5, 22.0, 30.0, 37.0, 45.0, 55.0, 75.0, 90.0, 110.0, 132.0, 160.0, 200.0, 250.0, 315.0, 400.0,
-      500.0, 630.0, 800.0, 1000.0, 1250.0, 1600.0, 2000.0, 2500.0, 3150.0, 4000.0, 5000.0, 6300.0,
-      8000.0, 10000.0 };
+  private double[] driverCandidateRatingsKw = new double[] { 0.75, 1.1, 1.5, 2.2, 3.0, 4.0, 5.5, 7.5, 11.0, 15.0, 18.5,
+      22.0, 30.0, 37.0, 45.0, 55.0, 75.0, 90.0, 110.0, 132.0, 160.0, 200.0, 250.0, 315.0, 400.0, 500.0, 630.0, 800.0,
+      1000.0, 1250.0, 1600.0, 2000.0, 2500.0, 3150.0, 4000.0, 5000.0, 6300.0, 8000.0, 10000.0 };
   private double operatingFlowRatio = Double.NaN;
   private String operatingRegion = "NOT_EVALUATED";
   private double npshMarginM = Double.NaN;
@@ -303,8 +302,8 @@ public class PumpApi610DesignCalculator implements Serializable {
     boolean ratioPass = npshMarginRatio >= npshMarginFactor;
     boolean headPass = npshMarginM >= minimumNpshMarginM;
     CheckStatus status = ratioPass && headPass ? CheckStatus.PASS : CheckStatus.FAIL;
-    addCheck("npsh-margin", "NPSHa shall exceed NPSHr by configured head and ratio margins", status,
-        npshMarginM, minimumNpshMarginM, "m",
+    addCheck("npsh-margin", "NPSHa shall exceed NPSHr by configured head and ratio margins", status, npshMarginM,
+        minimumNpshMarginM, "m",
         "NPSH margin ratio=" + format(npshMarginRatio) + ", required ratio=" + format(npshMarginFactor));
   }
 
@@ -629,8 +628,7 @@ public class PumpApi610DesignCalculator implements Serializable {
     this.shutoffHeadSource = shutoffHeadSource;
   }
 
-  public void setDutyPoint(double flowM3h, double headM, double speedRpm, double densityKgM3,
-      double absorbedPowerKw) {
+  public void setDutyPoint(double flowM3h, double headM, double speedRpm, double densityKgM3, double absorbedPowerKw) {
     this.operatingFlowM3h = flowM3h;
     this.ratedHeadM = headM;
     this.ratedSpeedRpm = speedRpm;

--- a/src/main/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculator.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculator.java
@@ -1,0 +1,833 @@
+package neqsim.process.mechanicaldesign.pump;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Value-only calculator for API 610 pump design screening.
+ *
+ * <p>
+ * The calculator evaluates process and purchaser data that can be checked without detailed vendor geometry. It does
+ * not certify API 610 conformity. Final casing, rotor, bearing, nozzle-load, seal, baseplate and test compliance must
+ * be verified against the purchased standard, project specification and vendor documentation.
+ * </p>
+ *
+ * <p>
+ * Unknown vendor inputs are represented by {@link Double#NaN} and produce {@link CheckStatus#NOT_EVALUATED}, never a
+ * silent pass.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class PumpApi610DesignCalculator implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Standard gravitational acceleration [m/s2]. */
+  private static final double GRAVITY = 9.80665;
+
+  /** Exact API 610 centrifugal-pump construction types. */
+  public enum Api610PumpType {
+    /** Type is not yet selected by purchaser or vendor. */
+    UNSPECIFIED,
+    /** Foot-mounted overhung pump. */
+    OH1,
+    /** Centreline-mounted overhung pump. */
+    OH2,
+    /** Vertical in-line pump with separate bearing bracket. */
+    OH3,
+    /** Rigidly coupled vertical in-line pump. */
+    OH4,
+    /** Close-coupled vertical in-line pump. */
+    OH5,
+    /** High-speed integrally geared overhung pump. */
+    OH6,
+    /** Axially split one- or two-stage between-bearings pump. */
+    BB1,
+    /** Radially split one- or two-stage between-bearings pump. */
+    BB2,
+    /** Axially split multistage between-bearings pump. */
+    BB3,
+    /** Radially split single-casing multistage pump. */
+    BB4,
+    /** Radially split double-casing multistage pump. */
+    BB5,
+    /** Wet-pit diffuser vertical pump. */
+    VS1,
+    /** Wet-pit volute vertical pump. */
+    VS2,
+    /** Wet-pit axial-flow vertical pump. */
+    VS3,
+    /** Vertical sump pump with line shaft. */
+    VS4,
+    /** Vertical cantilever sump pump. */
+    VS5,
+    /** Double-casing diffuser vertical pump. */
+    VS6,
+    /** Double-casing volute vertical pump. */
+    VS7
+  }
+
+  /** Provenance of a design input. */
+  public enum DataSource {
+    /** Value obtained from the current process simulation. */
+    PROCESS_MODEL,
+    /** Value explicitly supplied by the purchaser or project. */
+    PURCHASER_INPUT,
+    /** Value obtained from a manufacturer performance curve. */
+    VENDOR_CURVE,
+    /** Value produced by a preliminary screening correlation or assumption. */
+    SCREENING_ESTIMATE,
+    /** Required data are not available. */
+    NOT_AVAILABLE
+  }
+
+  /** Result of one screening check. */
+  public enum CheckStatus {
+    /** Requirement is met for the supplied data. */
+    PASS,
+    /** Point remains operable but needs engineering review. */
+    WARNING,
+    /** Supplied data do not meet the configured screening criterion. */
+    FAIL,
+    /** Required purchaser or vendor data were not supplied. */
+    NOT_EVALUATED
+  }
+
+  /** Overall screening result. */
+  public enum AssessmentStatus {
+    /** All evaluated checks pass and there are no data gaps. */
+    PASS,
+    /** No evaluated check fails, but warnings or data gaps remain. */
+    PASS_WITH_WARNINGS,
+    /** At least one evaluated check fails. */
+    FAIL,
+    /** No check could be evaluated. */
+    NOT_EVALUATED
+  }
+
+  /** Bearing rolling-element type for the ISO 281 basic rating-life exponent. */
+  public enum BearingType {
+    /** Ball bearing, life exponent p = 3. */
+    BALL,
+    /** Roller bearing, life exponent p = 10/3. */
+    ROLLER,
+    /** Sleeve or hydrodynamic bearing; ISO 281 L10 is not applicable. */
+    SLEEVE
+  }
+
+  /** One auditable screening check. */
+  public static class Check implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String id;
+    private final String requirement;
+    private final CheckStatus status;
+    private final double actualValue;
+    private final double limitValue;
+    private final String unit;
+    private final String message;
+
+    Check(String id, String requirement, CheckStatus status, double actualValue, double limitValue, String unit,
+        String message) {
+      this.id = id;
+      this.requirement = requirement;
+      this.status = status;
+      this.actualValue = actualValue;
+      this.limitValue = limitValue;
+      this.unit = unit;
+      this.message = message;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getRequirement() {
+      return requirement;
+    }
+
+    public CheckStatus getStatus() {
+      return status;
+    }
+
+    public double getActualValue() {
+      return actualValue;
+    }
+
+    public double getLimitValue() {
+      return limitValue;
+    }
+
+    public String getUnit() {
+      return unit;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+  }
+
+  // Identification and provenance.
+  private String standardEdition = "13th";
+  private String assessmentBasis = "API 610 screening; vendor and purchaser verification required";
+  private Api610PumpType pumpType = Api610PumpType.UNSPECIFIED;
+  private DataSource pumpTypeSource = DataSource.NOT_AVAILABLE;
+  private DataSource dutyPointSource = DataSource.PROCESS_MODEL;
+  private DataSource bepSource = DataSource.NOT_AVAILABLE;
+  private DataSource npshrSource = DataSource.NOT_AVAILABLE;
+  private DataSource shutoffHeadSource = DataSource.NOT_AVAILABLE;
+
+  // Duty and vendor inputs.
+  private double operatingFlowM3h = Double.NaN;
+  private double ratedHeadM = Double.NaN;
+  private double ratedSpeedRpm = Double.NaN;
+  private double fluidDensityKgM3 = Double.NaN;
+  private double absorbedPowerKw = Double.NaN;
+  private double bepFlowM3h = Double.NaN;
+  private double bepHeadM = Double.NaN;
+  private double npshAvailableM = Double.NaN;
+  private double npshRequiredM = Double.NaN;
+  private double maximumSuctionPressureBara = Double.NaN;
+  private double furnishedMawpBara = Double.NaN;
+  private double shutoffHeadM = Double.NaN;
+  private double hydrostaticTestPressureBara = Double.NaN;
+
+  // Configurable screening criteria.
+  private double porLowFraction = 0.70;
+  private double porHighFraction = 1.20;
+  private double ratedPointLowFraction = 0.80;
+  private double ratedPointHighFraction = 1.10;
+  private double aorLowFraction = 0.60;
+  private double aorHighFraction = 1.30;
+  private double npshMarginFactor = 1.15;
+  private double minimumNpshMarginM = 1.0;
+  private double assumedShutoffHeadFactor = 1.10;
+  private double minimumHeadRiseToShutoffFraction = 0.10;
+  private double hydrostaticTestPressureFactor = 1.50;
+  private double driverMarginFactor = 1.10;
+  private double minimumBearingLifeHours = 25000.0;
+  private double maximumShaftDeflectionMm = 0.05;
+  private double minimumCriticalSpeedRatio = 1.20;
+  private double maximumNozzleLoadUtilization = 1.0;
+  private double maximumVibrationVelocityMmS = 3.0;
+
+  // Optional mechanical evidence.
+  private BearingType bearingType = BearingType.BALL;
+  private double bearingDynamicLoadRatingKn = Double.NaN;
+  private double bearingEquivalentDynamicLoadKn = Double.NaN;
+  private double shaftDeflectionMm = Double.NaN;
+  private double firstCriticalSpeedRpm = Double.NaN;
+  private double nozzleLoadUtilization = Double.NaN;
+  private double vibrationVelocityMmS = Double.NaN;
+  private boolean seallessPump;
+
+  // Candidate driver ratings and calculated results.
+  private double[] driverCandidateRatingsKw = new double[] { 0.75, 1.1, 1.5, 2.2, 3.0, 4.0, 5.5, 7.5, 11.0, 15.0,
+      18.5, 22.0, 30.0, 37.0, 45.0, 55.0, 75.0, 90.0, 110.0, 132.0, 160.0, 200.0, 250.0, 315.0, 400.0,
+      500.0, 630.0, 800.0, 1000.0, 1250.0, 1600.0, 2000.0, 2500.0, 3150.0, 4000.0, 5000.0, 6300.0,
+      8000.0, 10000.0 };
+  private double operatingFlowRatio = Double.NaN;
+  private String operatingRegion = "NOT_EVALUATED";
+  private double npshMarginM = Double.NaN;
+  private double npshMarginRatio = Double.NaN;
+  private double governingShutoffHeadM = Double.NaN;
+  private double requiredCasingPressureBara = Double.NaN;
+  private double preliminaryHydrostaticTestPressureBara = Double.NaN;
+  private double headRiseToShutoffFraction = Double.NaN;
+  private double requiredDriverPowerKw = Double.NaN;
+  private double selectedDriverPowerKw = Double.NaN;
+  private double bearingL10LifeHours = Double.NaN;
+  private double criticalSpeedRatio = Double.NaN;
+  private AssessmentStatus assessmentStatus = AssessmentStatus.NOT_EVALUATED;
+  private final List<Check> checks = new ArrayList<Check>();
+
+  /** Evaluates all configured checks and replaces any previous result. */
+  public void calculate() {
+    checks.clear();
+    evaluateOperatingRegion();
+    evaluateNpsh();
+    evaluatePressureCasing();
+    evaluateHydrostaticTest();
+    evaluateHeadCurve();
+    evaluateDriver();
+    evaluateBearingLife();
+    evaluateOptionalMechanicalEvidence();
+    evaluateScope();
+    updateAssessmentStatus();
+  }
+
+  private void evaluateOperatingRegion() {
+    if (!isPositiveFinite(operatingFlowM3h) || !isPositiveFinite(bepFlowM3h)) {
+      operatingFlowRatio = Double.NaN;
+      operatingRegion = "NOT_EVALUATED";
+      addNotEvaluated("operating-region", "Rated flow shall be evaluated relative to vendor BEP",
+          "Vendor BEP flow is not available");
+      return;
+    }
+    operatingFlowRatio = operatingFlowM3h / bepFlowM3h;
+    if (operatingFlowRatio >= ratedPointLowFraction && operatingFlowRatio <= ratedPointHighFraction) {
+      operatingRegion = "POR";
+      addCheck("operating-region", "Rated flow within configured rated-point region", CheckStatus.PASS,
+          operatingFlowRatio, ratedPointHighFraction, "Q/Qbep", "Rated point is within the configured rated region");
+    } else if (operatingFlowRatio >= porLowFraction && operatingFlowRatio <= porHighFraction) {
+      operatingRegion = "POR";
+      addCheck("operating-region", "Rated flow within configured rated-point region", CheckStatus.WARNING,
+          operatingFlowRatio,
+          operatingFlowRatio < ratedPointLowFraction ? ratedPointLowFraction : ratedPointHighFraction, "Q/Qbep",
+          "Duty is inside POR but outside the configured rated-point region");
+    } else if (operatingFlowRatio >= aorLowFraction && operatingFlowRatio <= aorHighFraction) {
+      operatingRegion = "AOR";
+      addCheck("operating-region", "Rated flow within configured allowable operating region", CheckStatus.WARNING,
+          operatingFlowRatio, operatingFlowRatio < porLowFraction ? porLowFraction : porHighFraction, "Q/Qbep",
+          "Rated point is outside POR but remains inside AOR");
+    } else {
+      operatingRegion = "OUTSIDE_AOR";
+      addCheck("operating-region", "Rated flow within configured allowable operating region", CheckStatus.FAIL,
+          operatingFlowRatio, operatingFlowRatio < aorLowFraction ? aorLowFraction : aorHighFraction, "Q/Qbep",
+          "Rated point is outside the configured allowable operating region");
+    }
+  }
+
+  private void evaluateNpsh() {
+    if (!isFinite(npshAvailableM) || !isPositiveFinite(npshRequiredM)) {
+      npshMarginM = Double.NaN;
+      npshMarginRatio = Double.NaN;
+      addNotEvaluated("npsh-margin", "NPSHa shall exceed NPSHr by the configured head and ratio margins",
+          "Reliable NPSHa or vendor NPSHr is not available");
+      return;
+    }
+    npshMarginM = npshAvailableM - npshRequiredM;
+    npshMarginRatio = npshAvailableM / npshRequiredM;
+    boolean ratioPass = npshMarginRatio >= npshMarginFactor;
+    boolean headPass = npshMarginM >= minimumNpshMarginM;
+    CheckStatus status = ratioPass && headPass ? CheckStatus.PASS : CheckStatus.FAIL;
+    addCheck("npsh-margin", "NPSHa shall exceed NPSHr by configured head and ratio margins", status,
+        npshMarginM, minimumNpshMarginM, "m",
+        "NPSH margin ratio=" + format(npshMarginRatio) + ", required ratio=" + format(npshMarginFactor));
+  }
+
+  private void evaluatePressureCasing() {
+    if (!isPositiveFinite(maximumSuctionPressureBara) || !isPositiveFinite(ratedHeadM)
+        || !isPositiveFinite(fluidDensityKgM3)) {
+      governingShutoffHeadM = Double.NaN;
+      requiredCasingPressureBara = Double.NaN;
+      preliminaryHydrostaticTestPressureBara = Double.NaN;
+      addNotEvaluated("pressure-casing", "Pressure casing MAWP shall cover maximum suction plus shutoff head",
+          "Maximum suction pressure, rated head or liquid density is not available");
+      return;
+    }
+    if (isPositiveFinite(shutoffHeadM)) {
+      governingShutoffHeadM = shutoffHeadM;
+    } else {
+      governingShutoffHeadM = ratedHeadM * assumedShutoffHeadFactor;
+      shutoffHeadSource = DataSource.SCREENING_ESTIMATE;
+    }
+    requiredCasingPressureBara = maximumSuctionPressureBara
+        + fluidDensityKgM3 * GRAVITY * governingShutoffHeadM / 1.0e5;
+    double hydrotestBasis = isPositiveFinite(furnishedMawpBara) ? furnishedMawpBara : requiredCasingPressureBara;
+    preliminaryHydrostaticTestPressureBara = hydrotestBasis * hydrostaticTestPressureFactor;
+    if (!isPositiveFinite(furnishedMawpBara)) {
+      addNotEvaluated("pressure-casing", "Furnished casing MAWP shall cover the required casing pressure",
+          "Required pressure calculated; furnished casing MAWP is not available");
+      return;
+    }
+    CheckStatus status = furnishedMawpBara >= requiredCasingPressureBara ? CheckStatus.PASS : CheckStatus.FAIL;
+    addCheck("pressure-casing", "Furnished casing MAWP shall cover maximum suction plus shutoff head", status,
+        furnishedMawpBara, requiredCasingPressureBara, "bara",
+        "Required casing pressure uses shutoff-head source " + shutoffHeadSource);
+  }
+
+  private void evaluateHeadCurve() {
+    if (shutoffHeadSource != DataSource.VENDOR_CURVE && shutoffHeadSource != DataSource.PURCHASER_INPUT) {
+      headRiseToShutoffFraction = Double.NaN;
+      addNotEvaluated("head-rise", "Head rise from rated flow to shutoff shall meet the configured minimum",
+          "A vendor or purchaser shutoff head is not available");
+      return;
+    }
+    if (!isPositiveFinite(shutoffHeadM) || !isPositiveFinite(ratedHeadM)) {
+      headRiseToShutoffFraction = Double.NaN;
+      addNotEvaluated("head-rise", "Head rise from rated flow to shutoff shall meet the configured minimum",
+          "Rated or shutoff head is not available");
+      return;
+    }
+    headRiseToShutoffFraction = shutoffHeadM / ratedHeadM - 1.0;
+    CheckStatus status = headRiseToShutoffFraction >= minimumHeadRiseToShutoffFraction ? CheckStatus.PASS
+        : CheckStatus.FAIL;
+    addCheck("head-rise", "Head rise from rated flow to shutoff shall meet the configured minimum", status,
+        headRiseToShutoffFraction, minimumHeadRiseToShutoffFraction, "fraction",
+        "Endpoint screening does not replace verification of a continuously rising H-Q curve");
+  }
+
+  private void evaluateHydrostaticTest() {
+    if (!isPositiveFinite(preliminaryHydrostaticTestPressureBara)) {
+      addNotEvaluated("hydrostatic-test", "Casing hydrostatic test pressure shall meet the configured pressure factor",
+          "Casing pressure basis is not available");
+      return;
+    }
+    if (!isPositiveFinite(hydrostaticTestPressureBara)) {
+      addNotEvaluated("hydrostatic-test", "Casing hydrostatic test pressure shall meet the configured pressure factor",
+          "Required test pressure calculated; vendor test pressure is not available");
+      return;
+    }
+    CheckStatus status = hydrostaticTestPressureBara >= preliminaryHydrostaticTestPressureBara ? CheckStatus.PASS
+        : CheckStatus.FAIL;
+    addCheck("hydrostatic-test", "Casing hydrostatic test pressure shall meet the configured pressure factor", status,
+        hydrostaticTestPressureBara, preliminaryHydrostaticTestPressureBara, "bara", "Vendor test-pressure evidence");
+  }
+
+  private void evaluateDriver() {
+    if (!isPositiveFinite(absorbedPowerKw)) {
+      requiredDriverPowerKw = Double.NaN;
+      selectedDriverPowerKw = Double.NaN;
+      addNotEvaluated("driver-rating", "Driver rating shall cover absorbed power with configured margin",
+          "Maximum absorbed power is not available");
+      return;
+    }
+    requiredDriverPowerKw = absorbedPowerKw * driverMarginFactor;
+    selectedDriverPowerKw = selectDriverRating(requiredDriverPowerKw, driverCandidateRatingsKw);
+    if (!isPositiveFinite(selectedDriverPowerKw)) {
+      addCheck("driver-rating", "Driver rating shall cover absorbed power with configured margin", CheckStatus.FAIL,
+          requiredDriverPowerKw, maximum(driverCandidateRatingsKw), "kW",
+          "No configured driver candidate covers the required power");
+      return;
+    }
+    addCheck("driver-rating", "Driver rating shall cover absorbed power with configured margin", CheckStatus.PASS,
+        selectedDriverPowerKw, requiredDriverPowerKw, "kW", "Selected next configured driver rating");
+  }
+
+  private void evaluateBearingLife() {
+    if (bearingType == BearingType.SLEEVE) {
+      bearingL10LifeHours = Double.NaN;
+      addNotEvaluated("bearing-life", "Bearing life shall be verified for the governing radial and axial loads",
+          "ISO 281 rolling-element L10 calculation is not applicable to sleeve bearings");
+      return;
+    }
+    bearingL10LifeHours = calculateBearingL10LifeHours(bearingDynamicLoadRatingKn, bearingEquivalentDynamicLoadKn,
+        ratedSpeedRpm, bearingType);
+    if (!isPositiveFinite(bearingL10LifeHours)) {
+      addNotEvaluated("bearing-life", "Bearing L10 life shall meet the configured minimum",
+          "Bearing dynamic rating, equivalent load or rated speed is not available");
+      return;
+    }
+    CheckStatus status = bearingL10LifeHours >= minimumBearingLifeHours ? CheckStatus.PASS : CheckStatus.FAIL;
+    addCheck("bearing-life", "Bearing L10 life shall meet the configured minimum", status, bearingL10LifeHours,
+        minimumBearingLifeHours, "h", "ISO 281 basic rating-life screening calculation");
+  }
+
+  private void evaluateOptionalMechanicalEvidence() {
+    evaluateMaximum("shaft-deflection", "Shaft deflection at the seal shall not exceed the configured limit",
+        shaftDeflectionMm, maximumShaftDeflectionMm, "mm", "Vendor shaft analysis is not available");
+
+    if (isPositiveFinite(firstCriticalSpeedRpm) && isPositiveFinite(ratedSpeedRpm)) {
+      criticalSpeedRatio = firstCriticalSpeedRpm / ratedSpeedRpm;
+      CheckStatus status = criticalSpeedRatio >= minimumCriticalSpeedRatio ? CheckStatus.PASS : CheckStatus.FAIL;
+      addCheck("critical-speed", "First critical speed shall meet the configured separation ratio", status,
+          criticalSpeedRatio, minimumCriticalSpeedRatio, "ratio", "Dry critical-speed screening");
+    } else {
+      criticalSpeedRatio = Double.NaN;
+      addNotEvaluated("critical-speed", "Critical-speed separation shall be verified",
+          "Vendor rotor-dynamic analysis is not available");
+    }
+
+    evaluateMaximum("nozzle-loads", "Combined nozzle-load utilization shall not exceed unity", nozzleLoadUtilization,
+        maximumNozzleLoadUtilization, "fraction", "Nozzle loads or allowables are not available");
+    evaluateMaximum("vibration", "Vibration velocity shall not exceed the configured limit", vibrationVelocityMmS,
+        maximumVibrationVelocityMmS, "mm/s", "Vendor or measured vibration data are not available");
+  }
+
+  private void evaluateScope() {
+    if (pumpType == Api610PumpType.UNSPECIFIED) {
+      addNotEvaluated("pump-type", "Exact API 610 construction type shall be selected",
+          "Only a preliminary pump family recommendation is available");
+    } else if (pumpTypeSource == DataSource.SCREENING_ESTIMATE) {
+      addCheck("pump-type", "Exact API 610 construction type shall be selected", CheckStatus.WARNING, Double.NaN,
+          Double.NaN, "", "Preliminary recommended construction type " + pumpType + " requires purchaser selection");
+    } else {
+      addCheck("pump-type", "Exact API 610 construction type shall be selected", CheckStatus.PASS, Double.NaN,
+          Double.NaN, "", "Selected construction type " + pumpType);
+    }
+    if (seallessPump) {
+      addCheck("standard-scope", "Sealless pump construction requires the applicable sealless-pump standard",
+          CheckStatus.WARNING, Double.NaN, Double.NaN, "",
+          "Magnetic-drive and canned-motor pumps are outside API 610 scope");
+    }
+  }
+
+  private void evaluateMaximum(String id, String requirement, double actual, double limit, String unit,
+      String missingMessage) {
+    if (!isFinite(actual)) {
+      addNotEvaluated(id, requirement, missingMessage);
+      return;
+    }
+    CheckStatus status = actual <= limit ? CheckStatus.PASS : CheckStatus.FAIL;
+    addCheck(id, requirement, status, actual, limit, unit,
+        status == CheckStatus.PASS ? "Criterion met" : "Criterion exceeded");
+  }
+
+  private void updateAssessmentStatus() {
+    if (checks.isEmpty()) {
+      assessmentStatus = AssessmentStatus.NOT_EVALUATED;
+      return;
+    }
+    boolean evaluated = false;
+    boolean warningOrGap = false;
+    for (Check check : checks) {
+      if (check.getStatus() == CheckStatus.FAIL) {
+        assessmentStatus = AssessmentStatus.FAIL;
+        return;
+      }
+      if (check.getStatus() == CheckStatus.WARNING || check.getStatus() == CheckStatus.NOT_EVALUATED) {
+        warningOrGap = true;
+      } else {
+        evaluated = true;
+      }
+    }
+    if (!evaluated) {
+      assessmentStatus = AssessmentStatus.NOT_EVALUATED;
+    } else if (warningOrGap) {
+      assessmentStatus = AssessmentStatus.PASS_WITH_WARNINGS;
+    } else {
+      assessmentStatus = AssessmentStatus.PASS;
+    }
+  }
+
+  private void addNotEvaluated(String id, String requirement, String message) {
+    addCheck(id, requirement, CheckStatus.NOT_EVALUATED, Double.NaN, Double.NaN, "", message);
+  }
+
+  private void addCheck(String id, String requirement, CheckStatus status, double actual, double limit, String unit,
+      String message) {
+    checks.add(new Check(id, requirement, status, actual, limit, unit, message));
+  }
+
+  private static boolean isFinite(double value) {
+    return !Double.isNaN(value) && !Double.isInfinite(value);
+  }
+
+  private static boolean isPositiveFinite(double value) {
+    return isFinite(value) && value > 0.0;
+  }
+
+  private static String format(double value) {
+    return isFinite(value) ? String.format("%.3f", value) : "not available";
+  }
+
+  private static double maximum(double[] values) {
+    double result = Double.NaN;
+    if (values == null) {
+      return result;
+    }
+    for (double value : values) {
+      if (isFinite(value) && (Double.isNaN(result) || value > result)) {
+        result = value;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Selects the smallest configured driver rating that covers the required power.
+   *
+   * @param requiredPowerKw required driver power in kW
+   * @param candidatesKw available ratings in kW; ordering is not significant
+   * @return selected rating in kW, or NaN if none is suitable
+   */
+  public static double selectDriverRating(double requiredPowerKw, double[] candidatesKw) {
+    if (!isPositiveFinite(requiredPowerKw) || candidatesKw == null) {
+      return Double.NaN;
+    }
+    double selected = Double.POSITIVE_INFINITY;
+    for (double candidate : candidatesKw) {
+      if (isPositiveFinite(candidate) && candidate >= requiredPowerKw && candidate < selected) {
+        selected = candidate;
+      }
+    }
+    return Double.isInfinite(selected) ? Double.NaN : selected;
+  }
+
+  /**
+   * Calculates ISO 281 basic rating life for a rolling-element bearing.
+   *
+   * @param dynamicLoadRatingKn basic dynamic load rating C in kN
+   * @param equivalentDynamicLoadKn equivalent dynamic bearing load P in kN
+   * @param speedRpm bearing speed in rpm
+   * @param type rolling-element bearing type
+   * @return L10 life in hours, or NaN for incomplete or inapplicable input
+   */
+  public static double calculateBearingL10LifeHours(double dynamicLoadRatingKn, double equivalentDynamicLoadKn,
+      double speedRpm, BearingType type) {
+    if (!isPositiveFinite(dynamicLoadRatingKn) || !isPositiveFinite(equivalentDynamicLoadKn)
+        || !isPositiveFinite(speedRpm) || type == null || type == BearingType.SLEEVE) {
+      return Double.NaN;
+    }
+    double exponent = type == BearingType.BALL ? 3.0 : 10.0 / 3.0;
+    double lifeMillionRevolutions = Math.pow(dynamicLoadRatingKn / equivalentDynamicLoadKn, exponent);
+    return lifeMillionRevolutions * 1.0e6 / (60.0 * speedRpm);
+  }
+
+  public String getStandardEdition() {
+    return standardEdition;
+  }
+
+  public void setStandardEdition(String standardEdition) {
+    this.standardEdition = standardEdition;
+  }
+
+  public String getAssessmentBasis() {
+    return assessmentBasis;
+  }
+
+  public Api610PumpType getPumpType() {
+    return pumpType;
+  }
+
+  public void setPumpType(Api610PumpType pumpType) {
+    setPumpType(pumpType, DataSource.PURCHASER_INPUT);
+  }
+
+  public void setPumpType(Api610PumpType pumpType, DataSource source) {
+    this.pumpType = pumpType == null ? Api610PumpType.UNSPECIFIED : pumpType;
+    this.pumpTypeSource = this.pumpType == Api610PumpType.UNSPECIFIED ? DataSource.NOT_AVAILABLE
+        : source == null ? DataSource.NOT_AVAILABLE : source;
+  }
+
+  public DataSource getPumpTypeSource() {
+    return pumpTypeSource;
+  }
+
+  public DataSource getDutyPointSource() {
+    return dutyPointSource;
+  }
+
+  public void setDutyPointSource(DataSource dutyPointSource) {
+    this.dutyPointSource = dutyPointSource;
+  }
+
+  public DataSource getBepSource() {
+    return bepSource;
+  }
+
+  public void setBepSource(DataSource bepSource) {
+    this.bepSource = bepSource;
+  }
+
+  public DataSource getNpshrSource() {
+    return npshrSource;
+  }
+
+  public void setNpshrSource(DataSource npshrSource) {
+    this.npshrSource = npshrSource;
+  }
+
+  public DataSource getShutoffHeadSource() {
+    return shutoffHeadSource;
+  }
+
+  public void setShutoffHeadSource(DataSource shutoffHeadSource) {
+    this.shutoffHeadSource = shutoffHeadSource;
+  }
+
+  public void setDutyPoint(double flowM3h, double headM, double speedRpm, double densityKgM3,
+      double absorbedPowerKw) {
+    this.operatingFlowM3h = flowM3h;
+    this.ratedHeadM = headM;
+    this.ratedSpeedRpm = speedRpm;
+    this.fluidDensityKgM3 = densityKgM3;
+    this.absorbedPowerKw = absorbedPowerKw;
+  }
+
+  public void setBepPoint(double flowM3h, double headM, DataSource source) {
+    this.bepFlowM3h = flowM3h;
+    this.bepHeadM = headM;
+    this.bepSource = source == null ? DataSource.NOT_AVAILABLE : source;
+  }
+
+  public void setNpsh(double availableM, double requiredM, DataSource requiredSource) {
+    this.npshAvailableM = availableM;
+    this.npshRequiredM = requiredM;
+    this.npshrSource = requiredSource == null ? DataSource.NOT_AVAILABLE : requiredSource;
+  }
+
+  public void setPressureBasis(double maximumSuctionPressureBara, double furnishedMawpBara, double shutoffHeadM,
+      DataSource shutoffSource) {
+    this.maximumSuctionPressureBara = maximumSuctionPressureBara;
+    this.furnishedMawpBara = furnishedMawpBara;
+    this.shutoffHeadM = shutoffHeadM;
+    this.shutoffHeadSource = shutoffSource == null ? DataSource.NOT_AVAILABLE : shutoffSource;
+  }
+
+  public void setHydrostaticTestPressureBara(double hydrostaticTestPressureBara) {
+    this.hydrostaticTestPressureBara = hydrostaticTestPressureBara;
+  }
+
+  public void setOperatingRegions(double porLow, double porHigh, double aorLow, double aorHigh) {
+    this.porLowFraction = porLow;
+    this.porHighFraction = porHigh;
+    this.aorLowFraction = aorLow;
+    this.aorHighFraction = aorHigh;
+  }
+
+  public void setRatedPointRegion(double ratedLow, double ratedHigh) {
+    this.ratedPointLowFraction = ratedLow;
+    this.ratedPointHighFraction = ratedHigh;
+  }
+
+  public void setNpshCriteria(double marginFactor, double minimumMarginM) {
+    this.npshMarginFactor = marginFactor;
+    this.minimumNpshMarginM = minimumMarginM;
+  }
+
+  public void setPressureCriteria(double assumedShutoffHeadFactor, double hydrostaticTestPressureFactor) {
+    this.assumedShutoffHeadFactor = assumedShutoffHeadFactor;
+    this.hydrostaticTestPressureFactor = hydrostaticTestPressureFactor;
+  }
+
+  public void setMinimumHeadRiseToShutoffFraction(double minimumHeadRiseToShutoffFraction) {
+    this.minimumHeadRiseToShutoffFraction = minimumHeadRiseToShutoffFraction;
+  }
+
+  public void setDriverCriteria(double marginFactor, double[] candidateRatingsKw) {
+    this.driverMarginFactor = marginFactor;
+    if (candidateRatingsKw != null) {
+      this.driverCandidateRatingsKw = candidateRatingsKw.clone();
+    }
+  }
+
+  public void setBearingData(BearingType type, double dynamicLoadRatingKn, double equivalentDynamicLoadKn) {
+    this.bearingType = type == null ? BearingType.BALL : type;
+    this.bearingDynamicLoadRatingKn = dynamicLoadRatingKn;
+    this.bearingEquivalentDynamicLoadKn = equivalentDynamicLoadKn;
+  }
+
+  public void setMechanicalEvidence(double shaftDeflectionMm, double firstCriticalSpeedRpm,
+      double nozzleLoadUtilization, double vibrationVelocityMmS) {
+    this.shaftDeflectionMm = shaftDeflectionMm;
+    this.firstCriticalSpeedRpm = firstCriticalSpeedRpm;
+    this.nozzleLoadUtilization = nozzleLoadUtilization;
+    this.vibrationVelocityMmS = vibrationVelocityMmS;
+  }
+
+  public void setMechanicalCriteria(double minimumBearingLifeHours, double maximumShaftDeflectionMm,
+      double minimumCriticalSpeedRatio, double maximumNozzleLoadUtilization, double maximumVibrationVelocityMmS) {
+    this.minimumBearingLifeHours = minimumBearingLifeHours;
+    this.maximumShaftDeflectionMm = maximumShaftDeflectionMm;
+    this.minimumCriticalSpeedRatio = minimumCriticalSpeedRatio;
+    this.maximumNozzleLoadUtilization = maximumNozzleLoadUtilization;
+    this.maximumVibrationVelocityMmS = maximumVibrationVelocityMmS;
+  }
+
+  public void setSeallessPump(boolean seallessPump) {
+    this.seallessPump = seallessPump;
+  }
+
+  public double getOperatingFlowM3h() {
+    return operatingFlowM3h;
+  }
+
+  public double getRatedHeadM() {
+    return ratedHeadM;
+  }
+
+  public double getRatedSpeedRpm() {
+    return ratedSpeedRpm;
+  }
+
+  public double getFluidDensityKgM3() {
+    return fluidDensityKgM3;
+  }
+
+  public double getAbsorbedPowerKw() {
+    return absorbedPowerKw;
+  }
+
+  public double getBepFlowM3h() {
+    return bepFlowM3h;
+  }
+
+  public double getBepHeadM() {
+    return bepHeadM;
+  }
+
+  public double getNpshAvailableM() {
+    return npshAvailableM;
+  }
+
+  public double getNpshRequiredM() {
+    return npshRequiredM;
+  }
+
+  public double getFurnishedMawpBara() {
+    return furnishedMawpBara;
+  }
+
+  public double getOperatingFlowRatio() {
+    return operatingFlowRatio;
+  }
+
+  public String getOperatingRegion() {
+    return operatingRegion;
+  }
+
+  public double getNpshMarginM() {
+    return npshMarginM;
+  }
+
+  public double getNpshMarginRatio() {
+    return npshMarginRatio;
+  }
+
+  public double getGoverningShutoffHeadM() {
+    return governingShutoffHeadM;
+  }
+
+  public double getRequiredCasingPressureBara() {
+    return requiredCasingPressureBara;
+  }
+
+  public double getPreliminaryHydrostaticTestPressureBara() {
+    return preliminaryHydrostaticTestPressureBara;
+  }
+
+  public double getHydrostaticTestPressureBara() {
+    return hydrostaticTestPressureBara;
+  }
+
+  public double getHeadRiseToShutoffFraction() {
+    return headRiseToShutoffFraction;
+  }
+
+  public double getRequiredDriverPowerKw() {
+    return requiredDriverPowerKw;
+  }
+
+  public double getSelectedDriverPowerKw() {
+    return selectedDriverPowerKw;
+  }
+
+  public double getBearingL10LifeHours() {
+    return bearingL10LifeHours;
+  }
+
+  public double getCriticalSpeedRatio() {
+    return criticalSpeedRatio;
+  }
+
+  public AssessmentStatus getAssessmentStatus() {
+    return assessmentStatus;
+  }
+
+  public List<Check> getChecks() {
+    return Collections.unmodifiableList(checks);
+  }
+
+  public Check getCheck(String id) {
+    for (Check check : checks) {
+      if (check.getId().equals(id)) {
+        return check;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesign.java
@@ -359,8 +359,7 @@ public class PumpMechanicalDesign extends MechanicalDesign {
 
     npshRequired = pump.getNPSHRequired();
     npshAvailable = pump.getNPSHAvailable();
-    if (pump.getPumpChart() != null && pump.getPumpChart().isUsePumpChart()
-        && pump.getPumpChart().hasNPSHCurve()) {
+    if (pump.getPumpChart() != null && pump.getPumpChart().isUsePumpChart() && pump.getPumpChart().hasNPSHCurve()) {
       npshrDataSource = DataSource.VENDOR_CURVE;
     } else if (npshRequired > 0.0) {
       npshrDataSource = DataSource.SCREENING_ESTIMATE;
@@ -480,8 +479,8 @@ public class PumpMechanicalDesign extends MechanicalDesign {
       }
     }
     if (!shutoffHeadUserSpecified) {
-      double chartShutoffHead =
-          convertChartHeadToMeters(chart.getHead(0.0, speedRpm), chart.getHeadUnit(), densityKgM3);
+      double chartShutoffHead = convertChartHeadToMeters(chart.getHead(0.0, speedRpm), chart.getHeadUnit(),
+          densityKgM3);
       if (chartShutoffHead > 0.0) {
         shutoffHead = chartShutoffHead;
         shutoffHeadDataSource = DataSource.VENDOR_CURVE;
@@ -517,8 +516,8 @@ public class PumpMechanicalDesign extends MechanicalDesign {
     api610Assessment.setNpshCriteria(npshMarginFactor, minimumNpshMarginM);
     api610Assessment.setDriverCriteria(driverMargin, null);
     api610Assessment.setPressureBasis(
-        Double.isFinite(maximumSuctionPressure) ? maximumSuctionPressure : suctionPressureBara,
-        furnishedCasingMawp, shutoffHead, shutoffHeadDataSource);
+        Double.isFinite(maximumSuctionPressure) ? maximumSuctionPressure : suctionPressureBara, furnishedCasingMawp,
+        shutoffHead, shutoffHeadDataSource);
     api610Assessment.setSeallessPump(sealType == SealType.MAGNETIC_DRIVE || sealType == SealType.CANNED_MOTOR);
     api610Assessment.calculate();
     double selectedDriver = api610Assessment.getSelectedDriverPowerKw();
@@ -1179,8 +1178,7 @@ public class PumpMechanicalDesign extends MechanicalDesign {
   public void setShutoffHead(double headM) {
     this.shutoffHead = headM;
     this.shutoffHeadUserSpecified = Double.isFinite(headM) && headM > 0.0;
-    this.shutoffHeadDataSource =
-        this.shutoffHeadUserSpecified ? DataSource.PURCHASER_INPUT : DataSource.NOT_AVAILABLE;
+    this.shutoffHeadDataSource = this.shutoffHeadUserSpecified ? DataSource.PURCHASER_INPUT : DataSource.NOT_AVAILABLE;
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesign.java
@@ -8,7 +8,10 @@ import javax.swing.JTable;
 import neqsim.process.costestimation.pump.PumpCostEstimate;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.pump.PumpChartInterface;
 import neqsim.process.mechanicaldesign.MechanicalDesign;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.Api610PumpType;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.DataSource;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
 /**
@@ -61,9 +64,6 @@ public class PumpMechanicalDesign extends MechanicalDesign {
 
   /** Driver sizing margin for large pumps (&gt; 55 kW) per API 610. */
   private static final double DRIVER_MARGIN_LARGE = 1.10;
-
-  /** Design pressure margin factor. */
-  private static final double DESIGN_PRESSURE_MARGIN = 1.10;
 
   /** Design temperature margin [C]. */
   private static final double DESIGN_TEMPERATURE_MARGIN = 30.0;
@@ -226,10 +226,16 @@ public class PumpMechanicalDesign extends MechanicalDesign {
   private double maxContinuousFlowFraction = 1.20;
 
   /** Preferred operating region - low limit as fraction of BEP. */
-  private double porLowFraction = 0.80;
+  private double porLowFraction = 0.70;
 
   /** Preferred operating region - high limit as fraction of BEP. */
-  private double porHighFraction = 1.10;
+  private double porHighFraction = 1.20;
+
+  /** Rated-point region - low limit as fraction of furnished BEP. */
+  private double ratedPointLowFraction = 0.80;
+
+  /** Rated-point region - high limit as fraction of furnished BEP. */
+  private double ratedPointHighFraction = 1.10;
 
   /** Allowable operating region - low limit as fraction of BEP. */
   private double aorLowFraction = 0.60;
@@ -242,6 +248,54 @@ public class PumpMechanicalDesign extends MechanicalDesign {
 
   /** Head margin factor. */
   private double headMarginFactor = 1.05;
+
+  /** Minimum absolute NPSH margin [m] used by the API 610 screening profile. */
+  private double minimumNpshMarginM = 1.0;
+
+  /** Exact API 610 construction type selected or recommended. */
+  private Api610PumpType api610PumpType = Api610PumpType.UNSPECIFIED;
+
+  /** True when the exact API 610 type was supplied rather than estimated. */
+  private boolean api610PumpTypeUserSpecified = false;
+
+  /** Current rated/duty flow [m3/h]. */
+  private double ratedFlow = Double.NaN;
+
+  /** Current rated/duty head [m]. */
+  private double ratedHead = Double.NaN;
+
+  /** Absorbed shaft power from the process pump [kW]. */
+  private double absorbedPower = Double.NaN;
+
+  /** Hydraulic liquid power at the duty point [kW]. */
+  private double hydraulicPower = Double.NaN;
+
+  /** Maximum suction pressure used for casing screening [bara]. */
+  private double maximumSuctionPressure = Double.NaN;
+
+  /** True when maximum suction pressure was explicitly supplied by the purchaser. */
+  private boolean maximumSuctionPressureUserSpecified = false;
+
+  /** Furnished casing MAWP supplied by purchaser or vendor [bara]. */
+  private double furnishedCasingMawp = Double.NaN;
+
+  /** Shutoff head from a vendor curve or purchaser input [m]. */
+  private double shutoffHead = Double.NaN;
+
+  /** True when shutoff head was explicitly supplied by the purchaser. */
+  private boolean shutoffHeadUserSpecified = false;
+
+  /** Source of the BEP values. */
+  private DataSource bepDataSource = DataSource.NOT_AVAILABLE;
+
+  /** Source of the NPSHr value. */
+  private DataSource npshrDataSource = DataSource.NOT_AVAILABLE;
+
+  /** Source of the shutoff head value. */
+  private DataSource shutoffHeadDataSource = DataSource.NOT_AVAILABLE;
+
+  /** API 610 screening calculator and auditable result. */
+  private final PumpApi610DesignCalculator api610Assessment = new PumpApi610DesignCalculator();
 
   /**
    * Constructor for PumpMechanicalDesign.
@@ -261,7 +315,8 @@ public class PumpMechanicalDesign extends MechanicalDesign {
     Pump pump = (Pump) getProcessEquipment();
 
     // Ensure pump has been run
-    if (pump.getInletStream() == null || pump.getInletStream().getThermoSystem() == null) {
+    if (pump.getInletStream() == null || pump.getOutletStream() == null
+        || pump.getInletStream().getThermoSystem() == null) {
       return;
     }
 
@@ -270,48 +325,79 @@ public class PumpMechanicalDesign extends MechanicalDesign {
     double dischargePressure = pump.getOutletStream().getPressure("bara");
     double suctionTemperature = pump.getInletStream().getTemperature("C");
     double dischargeTemperature = pump.getOutletStream().getTemperature("C");
-    double massFlowRate = pump.getInletStream().getFlowRate("kg/hr");
     double volumeFlowRate = pump.getInletStream().getFlowRate("m3/hr");
     double density = pump.getInletStream().getThermoSystem().getDensity("kg/m3");
-    double hydraulicPowerKW = pump.getPower("kW");
+    absorbedPower = pump.getPower("kW");
 
     // Calculate differential pressure and head
     double differentialPressure = dischargePressure - suctionPressure;
-    double pumpHead = (differentialPressure * 1e5) / (density * GRAVITY); // meters
+    double pumpHead = density > 0.0 ? (differentialPressure * 1e5) / (density * GRAVITY) : Double.NaN;
+    ratedFlow = volumeFlowRate;
+    ratedHead = pumpHead;
+    hydraulicPower = density > 0.0 && volumeFlowRate > 0.0 && pumpHead > 0.0
+        ? density * GRAVITY * volumeFlowRate / 3600.0 * pumpHead / 1000.0
+        : Double.NaN;
 
     // Get or estimate pump efficiency
-    pumpEfficiency = pump.getIsentropicEfficiency();
+    pumpEfficiency = normalizeEfficiency(pump.getIsentropicEfficiency());
     if (pumpEfficiency <= 0 || pumpEfficiency > 1.0) {
       pumpEfficiency = DEFAULT_PUMP_EFFICIENCY;
     }
 
-    // Calculate design conditions with margins
-    designPressure = dischargePressure * DESIGN_PRESSURE_MARGIN;
-    designTemperature = Math.max(suctionTemperature, dischargeTemperature) + DESIGN_TEMPERATURE_MARGIN;
-
-    // Calculate specific speeds
-    if (volumeFlowRate > 0 && pumpHead > 0) {
-      ratedSpeed = estimateOptimalSpeed(volumeFlowRate, pumpHead);
-      calculateSpecificSpeeds(volumeFlowRate, pumpHead, ratedSpeed);
+    if (!(absorbedPower > 0.0) && hydraulicPower > 0.0) {
+      absorbedPower = hydraulicPower / pumpEfficiency;
     }
 
-    // Select pump type based on specific speed
-    selectPumpType();
+    // Preserve the process-model shaft speed. Estimate only if it is unavailable.
+    ratedSpeed = pump.getSpeed();
+    if (!(ratedSpeed > 0.0) && volumeFlowRate > 0.0 && pumpHead > 0.0) {
+      ratedSpeed = estimateOptimalSpeed(volumeFlowRate, pumpHead);
+    }
+
+    // Prefer vendor performance data for BEP, shutoff head and NPSHr.
+    populateVendorCurveData(pump, ratedSpeed, density);
+
+    npshRequired = pump.getNPSHRequired();
+    npshAvailable = pump.getNPSHAvailable();
+    if (pump.getPumpChart() != null && pump.getPumpChart().isUsePumpChart()
+        && pump.getPumpChart().hasNPSHCurve()) {
+      npshrDataSource = DataSource.VENDOR_CURVE;
+    } else if (npshRequired > 0.0) {
+      npshrDataSource = DataSource.SCREENING_ESTIMATE;
+    } else {
+      npshrDataSource = DataSource.NOT_AVAILABLE;
+    }
+    npshMargin = Double.isFinite(npshAvailable) && npshRequired > 0.0 ? npshAvailable - npshRequired : Double.NaN;
+
+    // Calculate specific speeds on explicit SI and customary suction-specific-speed bases.
+    double specificSpeedFlow = bepFlow > 0.0 ? bepFlow : volumeFlowRate;
+    double specificSpeedHead = bepHead > 0.0 ? bepHead : pumpHead;
+    if (specificSpeedFlow > 0.0 && specificSpeedHead > 0.0 && ratedSpeed > 0.0) {
+      calculateSpecificSpeeds(specificSpeedFlow, specificSpeedHead, ratedSpeed);
+    }
+
+    // Select a preliminary construction type only when the purchaser has not fixed one.
+    selectPumpType(pumpHead);
+
+    if (!maximumSuctionPressureUserSpecified) {
+      maximumSuctionPressure = suctionPressure;
+    }
+    double governingShutoffHead = shutoffHead > 0.0 ? shutoffHead : pumpHead * 1.10;
+    designPressure = maximumSuctionPressure + density * GRAVITY * governingShutoffHead / 1.0e5;
+    designPressure = Math.max(designPressure, dischargePressure);
+    designTemperature = Math.max(suctionTemperature, dischargeTemperature) + DESIGN_TEMPERATURE_MARGIN;
 
     // Calculate impeller sizing
     calculateImpellerSizing(volumeFlowRate, pumpHead, ratedSpeed);
 
     // Calculate shaft sizing
-    calculateShaftSizing(hydraulicPowerKW, ratedSpeed, pumpEfficiency);
+    calculateShaftSizing(absorbedPower, ratedSpeed);
 
     // Calculate casing design
     calculateCasingDesign(designPressure, designTemperature);
 
     // Calculate driver sizing
-    calculateDriverSizing(hydraulicPowerKW, pumpEfficiency);
-
-    // Estimate NPSH required
-    estimateNpshRequired(volumeFlowRate, ratedSpeed);
+    calculateDriverSizing(absorbedPower);
 
     // Calculate nozzle sizes
     calculateNozzleSizes(volumeFlowRate);
@@ -322,11 +408,14 @@ public class PumpMechanicalDesign extends MechanicalDesign {
     // Calculate module dimensions
     calculateModuleDimensions();
 
-    // Set operating range
-    bepFlow = volumeFlowRate;
-    bepHead = pumpHead;
-    minimumFlow = volumeFlowRate * 0.3; // Typical minimum stable flow
-    maximumFlow = volumeFlowRate * 1.2; // Typical maximum flow
+    // Set operating range. Vendor BEP is preferred; current duty is only a preliminary fallback.
+    double operatingRangeBasis = bepFlow > 0.0 ? bepFlow : volumeFlowRate;
+    minimumFlow = operatingRangeBasis * minContinuousFlowFraction;
+    maximumFlow = operatingRangeBasis * maxContinuousFlowFraction;
+    maxDesignVolumeFlow = maximumFlow;
+    maxDesignPower = driverPower;
+
+    configureAndRunApi610Assessment(suctionPressure, density);
   }
 
   /**
@@ -361,6 +450,84 @@ public class PumpMechanicalDesign extends MechanicalDesign {
     return closestSpeed;
   }
 
+  private double normalizeEfficiency(double efficiency) {
+    if (efficiency > 1.0 && efficiency <= 100.0) {
+      return efficiency / 100.0;
+    }
+    return efficiency;
+  }
+
+  private void populateVendorCurveData(Pump pump, double speedRpm, double densityKgM3) {
+    bepFlow = Double.NaN;
+    bepHead = Double.NaN;
+    bepDataSource = DataSource.NOT_AVAILABLE;
+    if (!shutoffHeadUserSpecified) {
+      shutoffHead = Double.NaN;
+      shutoffHeadDataSource = DataSource.NOT_AVAILABLE;
+    }
+    PumpChartInterface chart = pump.getPumpChart();
+    if (chart == null || !chart.isUsePumpChart() || !(speedRpm > 0.0)) {
+      return;
+    }
+    double chartBepFlow = chart.getBestEfficiencyFlowRate(speedRpm);
+    if (chartBepFlow > 0.0) {
+      double chartBepHead = convertChartHeadToMeters(chart.getHead(chartBepFlow, speedRpm), chart.getHeadUnit(),
+          densityKgM3);
+      if (chartBepHead > 0.0) {
+        bepFlow = chartBepFlow;
+        bepHead = chartBepHead;
+        bepDataSource = DataSource.VENDOR_CURVE;
+      }
+    }
+    if (!shutoffHeadUserSpecified) {
+      double chartShutoffHead =
+          convertChartHeadToMeters(chart.getHead(0.0, speedRpm), chart.getHeadUnit(), densityKgM3);
+      if (chartShutoffHead > 0.0) {
+        shutoffHead = chartShutoffHead;
+        shutoffHeadDataSource = DataSource.VENDOR_CURVE;
+      }
+    }
+  }
+
+  private double convertChartHeadToMeters(double chartHead, String unit, double densityKgM3) {
+    if (!(chartHead > 0.0) || unit == null) {
+      return Double.NaN;
+    }
+    if (unit.equals("meter") || unit.equals("m")) {
+      return chartHead;
+    }
+    if (unit.equals("kJ/kg")) {
+      return chartHead * 1000.0 / GRAVITY;
+    }
+    if (unit.equals("bar") && densityKgM3 > 0.0) {
+      return chartHead * 1.0e5 / (densityKgM3 * GRAVITY);
+    }
+    return Double.NaN;
+  }
+
+  private void configureAndRunApi610Assessment(double suctionPressureBara, double densityKgM3) {
+    api610Assessment.setPumpType(api610PumpType,
+        api610PumpTypeUserSpecified ? DataSource.PURCHASER_INPUT : DataSource.SCREENING_ESTIMATE);
+    api610Assessment.setDutyPoint(ratedFlow, ratedHead, ratedSpeed, densityKgM3, absorbedPower);
+    api610Assessment.setDutyPointSource(DataSource.PROCESS_MODEL);
+    api610Assessment.setBepPoint(bepFlow, bepHead, bepDataSource);
+    api610Assessment.setNpsh(npshAvailable, npshRequired, npshrDataSource);
+    api610Assessment.setOperatingRegions(porLowFraction, porHighFraction, aorLowFraction, aorHighFraction);
+    api610Assessment.setRatedPointRegion(ratedPointLowFraction, ratedPointHighFraction);
+    api610Assessment.setNpshCriteria(npshMarginFactor, minimumNpshMarginM);
+    api610Assessment.setDriverCriteria(driverMargin, null);
+    api610Assessment.setPressureBasis(
+        Double.isFinite(maximumSuctionPressure) ? maximumSuctionPressure : suctionPressureBara,
+        furnishedCasingMawp, shutoffHead, shutoffHeadDataSource);
+    api610Assessment.setSeallessPump(sealType == SealType.MAGNETIC_DRIVE || sealType == SealType.CANNED_MOTOR);
+    api610Assessment.calculate();
+    double selectedDriver = api610Assessment.getSelectedDriverPowerKw();
+    if (selectedDriver > 0.0) {
+      driverPower = selectedDriver;
+      maxDesignPower = selectedDriver;
+    }
+  }
+
   /**
    * Calculate specific speeds for pump classification.
    *
@@ -369,34 +536,56 @@ public class PumpMechanicalDesign extends MechanicalDesign {
    * @param speedRpm pump speed in rpm
    */
   private void calculateSpecificSpeeds(double flowM3h, double headM, double speedRpm) {
-    double flowM3min = flowM3h / 60.0;
+    double flowM3s = flowM3h / 3600.0;
 
-    // Specific speed: Ns = N * sqrt(Q) / H^0.75
-    specificSpeed = speedRpm * Math.sqrt(flowM3min) / Math.pow(headM, 0.75);
+    // SI specific speed: N * sqrt(Q[m3/s]) / H[m]^0.75.
+    specificSpeed = speedRpm * Math.sqrt(flowM3s) / Math.pow(headM, 0.75);
 
-    // Suction specific speed: Nss = N * sqrt(Q) / NPSHr^0.75
-    // Estimate NPSHr first, then calculate
-    double estimatedNpshr = 3.0 + 0.001 * speedRpm * Math.sqrt(flowM3min);
-    suctionSpecificSpeed = speedRpm * Math.sqrt(flowM3min) / Math.pow(estimatedNpshr, 0.75);
+    // Conventional US suction specific speed, compatible with common API purchaser limits.
+    if (npshRequired > 0.0) {
+      double flowPerEyeGpm = flowM3h * 4.402867;
+      if (api610PumpType == Api610PumpType.BB1) {
+        flowPerEyeGpm /= 2.0;
+      }
+      double npshFeet = npshRequired * 3.28084;
+      suctionSpecificSpeed = speedRpm * Math.sqrt(flowPerEyeGpm) / Math.pow(npshFeet, 0.75);
+    } else {
+      suctionSpecificSpeed = Double.NaN;
+    }
   }
 
   /**
    * Select pump type based on specific speed and application.
    */
-  private void selectPumpType() {
-    // General guidelines for pump type selection
-    if (specificSpeed < 50) {
-      // Low flow, high head - multistage
+  private void selectPumpType(double totalHeadM) {
+    if (api610PumpTypeUserSpecified) {
+      mapApi610TypeToLegacyFamily();
+      return;
+    }
+    if (totalHeadM > 250.0) {
       pumpType = PumpType.BETWEEN_BEARINGS;
-      numberOfStages = (int) Math.ceil(300.0 / specificSpeed);
-    } else if (specificSpeed < 300) {
-      // Normal range - single stage overhung
-      pumpType = PumpType.OVERHUNG;
-      numberOfStages = 1;
+      numberOfStages = Math.max(2, (int) Math.ceil(totalHeadM / 200.0));
+      api610PumpType = numberOfStages > 2 ? Api610PumpType.BB3 : Api610PumpType.BB2;
     } else {
-      // High flow, low head - mixed/axial flow
       pumpType = PumpType.OVERHUNG;
       numberOfStages = 1;
+      api610PumpType = Api610PumpType.OH2;
+    }
+  }
+
+  private void mapApi610TypeToLegacyFamily() {
+    String code = api610PumpType.name();
+    if (code.startsWith("OH")) {
+      pumpType = PumpType.OVERHUNG;
+      numberOfStages = 1;
+    } else if (code.startsWith("BB")) {
+      pumpType = PumpType.BETWEEN_BEARINGS;
+      if (api610PumpType == Api610PumpType.BB3 || api610PumpType == Api610PumpType.BB4
+          || api610PumpType == Api610PumpType.BB5) {
+        numberOfStages = Math.max(2, numberOfStages);
+      }
+    } else if (code.startsWith("VS")) {
+      pumpType = PumpType.VERTICALLY_SUSPENDED;
     }
   }
 
@@ -444,19 +633,15 @@ public class PumpMechanicalDesign extends MechanicalDesign {
    *
    * @param powerKW shaft power in kW
    * @param speedRpm shaft speed in rpm
-   * @param efficiency pump efficiency
    */
-  private void calculateShaftSizing(double powerKW, double speedRpm, double efficiency) {
+  private void calculateShaftSizing(double powerKW, double speedRpm) {
     if (speedRpm <= 0) {
       shaftDiameter = 40.0; // Default
       return;
     }
 
-    // Shaft power considering efficiency
-    double shaftPowerKW = powerKW / efficiency;
-
     // Calculate torque: T = P * 60 / (2 * pi * N) [kNm]
-    double torqueKNm = (shaftPowerKW * 60.0) / (2.0 * Math.PI * speedRpm);
+    double torqueKNm = (powerKW * 60.0) / (2.0 * Math.PI * speedRpm);
     double torqueNm = torqueKNm * 1000.0;
 
     // Shaft diameter from shear stress: d = (16*T / (pi*tau))^(1/3)
@@ -510,34 +695,28 @@ public class PumpMechanicalDesign extends MechanicalDesign {
   /**
    * Calculate driver sizing with appropriate margins per API 610.
    *
-   * @param hydraulicPowerKW hydraulic power in kW
-   * @param efficiency pump efficiency
+   * @param absorbedPowerKW absorbed shaft power in kW
    */
-  private void calculateDriverSizing(double hydraulicPowerKW, double efficiency) {
-    // Shaft power = hydraulic power / efficiency
-    double shaftPowerKW = hydraulicPowerKW / efficiency;
-
+  private void calculateDriverSizing(double absorbedPowerKW) {
     // Select margin based on power range per API 610
-    if (shaftPowerKW < 22.0) {
+    if (absorbedPowerKW < 22.0) {
       driverMargin = DRIVER_MARGIN_SMALL;
-    } else if (shaftPowerKW < 55.0) {
+    } else if (absorbedPowerKW <= 55.0) {
       driverMargin = DRIVER_MARGIN_MEDIUM;
     } else {
       driverMargin = DRIVER_MARGIN_LARGE;
     }
 
     // Driver power with margin
-    driverPower = shaftPowerKW * driverMargin;
+    driverPower = absorbedPowerKW * driverMargin;
 
     // Round up to standard motor sizes (IEC frame sizes)
     double[] standardPowers = { 0.75, 1.1, 1.5, 2.2, 3.0, 4.0, 5.5, 7.5, 11.0, 15.0, 18.5, 22.0, 30.0, 37.0, 45.0, 55.0,
         75.0, 90.0, 110.0, 132.0, 160.0, 200.0, 250.0, 315.0, 400.0 };
 
-    for (double standardPower : standardPowers) {
-      if (standardPower >= driverPower) {
-        driverPower = standardPower;
-        break;
-      }
+    double selectedPower = PumpApi610DesignCalculator.selectDriverRating(driverPower, standardPowers);
+    if (selectedPower > 0.0) {
+      driverPower = selectedPower;
     }
   }
 
@@ -682,9 +861,9 @@ public class PumpMechanicalDesign extends MechanicalDesign {
     moduleHeight = Math.max(0.5, impellerDiameter / 1000.0 + 0.3);
 
     // Set outer diameter for reporting
-    outerDiameter = impellerDiameter * 1.15 + 2.0 * casingWallThickness;
-    innerDiameter = impellerDiameter * 1.15;
-    tantanLength = impellerWidth * numberOfStages;
+    outerDiameter = (impellerDiameter * 1.15 + 2.0 * casingWallThickness) / 1000.0;
+    innerDiameter = impellerDiameter * 1.15 / 1000.0;
+    tantanLength = impellerWidth * numberOfStages / 1000.0;
     this.wallThickness = casingWallThickness;
   }
 
@@ -708,6 +887,13 @@ public class PumpMechanicalDesign extends MechanicalDesign {
    */
   public void setPumpType(PumpType pumpType) {
     this.pumpType = pumpType;
+    if (pumpType == PumpType.OVERHUNG) {
+      setApi610PumpType(Api610PumpType.OH2);
+    } else if (pumpType == PumpType.BETWEEN_BEARINGS) {
+      setApi610PumpType(Api610PumpType.BB3);
+    } else if (pumpType == PumpType.VERTICALLY_SUSPENDED) {
+      setApi610PumpType(Api610PumpType.VS1);
+    }
   }
 
   /**
@@ -738,6 +924,15 @@ public class PumpMechanicalDesign extends MechanicalDesign {
   }
 
   /**
+   * Get the estimated impeller outlet width.
+   *
+   * @return impeller width in mm
+   */
+  public double getImpellerWidth() {
+    return impellerWidth;
+  }
+
+  /**
    * Get the shaft diameter.
    *
    * @return shaft diameter in mm
@@ -753,6 +948,15 @@ public class PumpMechanicalDesign extends MechanicalDesign {
    */
   public double getDriverPower() {
     return driverPower;
+  }
+
+  /**
+   * Get the driver sizing multiplier applied to absorbed power.
+   *
+   * @return driver margin factor
+   */
+  public double getDriverMargin() {
+    return driverMargin;
   }
 
   /**
@@ -816,6 +1020,181 @@ public class PumpMechanicalDesign extends MechanicalDesign {
    */
   public double getNpshRequired() {
     return npshRequired;
+  }
+
+  /**
+   * Get NPSH available from the process suction state.
+   *
+   * @return NPSHa in m, or NaN when unavailable
+   */
+  public double getNpshAvailable() {
+    return npshAvailable;
+  }
+
+  /**
+   * Get absolute NPSH margin.
+   *
+   * @return NPSHa minus NPSHr in m, or NaN when unavailable
+   */
+  public double getNpshMargin() {
+    return npshMargin;
+  }
+
+  /**
+   * Get NPSH ratio.
+   *
+   * @return NPSHa divided by NPSHr, or NaN when unavailable
+   */
+  public double getNpshMarginRatio() {
+    return npshRequired > 0.0 && Double.isFinite(npshAvailable) ? npshAvailable / npshRequired : Double.NaN;
+  }
+
+  /**
+   * Get casing wall thickness from the preliminary pressure-boundary estimate.
+   *
+   * @return casing wall thickness in mm
+   */
+  public double getCasingWallThickness() {
+    return casingWallThickness;
+  }
+
+  /**
+   * Get preliminary calculated casing MAWP.
+   *
+   * @return estimated MAWP in bara
+   */
+  public double getMaxAllowableWorkingPressure() {
+    return maxAllowableWorkingPressure;
+  }
+
+  /**
+   * Get rated process flow.
+   *
+   * @return rated flow in m3/h
+   */
+  public double getRatedFlow() {
+    return ratedFlow;
+  }
+
+  /**
+   * Get rated process head.
+   *
+   * @return rated head in m
+   */
+  public double getRatedHead() {
+    return ratedHead;
+  }
+
+  /**
+   * Get vendor BEP flow.
+   *
+   * @return BEP flow in m3/h, or NaN when a vendor curve is unavailable
+   */
+  public double getBepFlow() {
+    return bepFlow;
+  }
+
+  /**
+   * Get vendor BEP head.
+   *
+   * @return BEP head in m, or NaN when a vendor curve is unavailable
+   */
+  public double getBepHead() {
+    return bepHead;
+  }
+
+  /**
+   * Get normalized pump efficiency.
+   *
+   * @return efficiency as a fraction
+   */
+  public double getPumpEfficiency() {
+    return pumpEfficiency;
+  }
+
+  /**
+   * Get absorbed shaft power.
+   *
+   * @return absorbed power in kW
+   */
+  public double getAbsorbedPower() {
+    return absorbedPower;
+  }
+
+  /**
+   * Get hydraulic liquid power.
+   *
+   * @return hydraulic power in kW
+   */
+  public double getHydraulicPower() {
+    return hydraulicPower;
+  }
+
+  /**
+   * Get exact API 610 construction type.
+   *
+   * @return selected or recommended construction type
+   */
+  public Api610PumpType getApi610PumpType() {
+    return api610PumpType;
+  }
+
+  /**
+   * Set exact API 610 construction type from purchaser or vendor data.
+   *
+   * @param type exact API 610 construction type
+   */
+  public void setApi610PumpType(Api610PumpType type) {
+    this.api610PumpType = type == null ? Api610PumpType.UNSPECIFIED : type;
+    this.api610PumpTypeUserSpecified = this.api610PumpType != Api610PumpType.UNSPECIFIED;
+    if (this.api610PumpTypeUserSpecified) {
+      mapApi610TypeToLegacyFamily();
+    }
+  }
+
+  /**
+   * Set maximum suction pressure used for maximum-discharge-pressure screening.
+   *
+   * @param pressureBara maximum suction pressure in bara
+   */
+  public void setMaximumSuctionPressure(double pressureBara) {
+    this.maximumSuctionPressure = pressureBara;
+    this.maximumSuctionPressureUserSpecified = Double.isFinite(pressureBara) && pressureBara > 0.0;
+  }
+
+  /**
+   * Set furnished casing MAWP for verification.
+   *
+   * @param mawpBara furnished casing MAWP in bara
+   */
+  public void setFurnishedCasingMawp(double mawpBara) {
+    this.furnishedCasingMawp = mawpBara;
+  }
+
+  /**
+   * Set purchaser or vendor shutoff head.
+   *
+   * @param headM shutoff head in m
+   */
+  public void setShutoffHead(double headM) {
+    this.shutoffHead = headM;
+    this.shutoffHeadUserSpecified = Double.isFinite(headM) && headM > 0.0;
+    this.shutoffHeadDataSource =
+        this.shutoffHeadUserSpecified ? DataSource.PURCHASER_INPUT : DataSource.NOT_AVAILABLE;
+  }
+
+  /**
+   * Get the auditable API 610 design screening calculator and latest result.
+   *
+   * <p>
+   * Optional vendor evidence such as bearing ratings, shaft deflection, critical speed, nozzle-load utilization and
+   * vibration may be configured directly on this value-only object before the next {@link #calcDesign()} call.
+   * </p>
+   *
+   * @return API 610 screening calculator
+   */
+  public PumpApi610DesignCalculator getApi610Assessment() {
+    return api610Assessment;
   }
 
   /**
@@ -956,6 +1335,24 @@ public class PumpMechanicalDesign extends MechanicalDesign {
    */
   public void setNpshMarginFactor(double factor) {
     this.npshMarginFactor = factor;
+  }
+
+  /**
+   * Gets the minimum absolute NPSH margin.
+   *
+   * @return minimum NPSHa minus NPSHr in m
+   */
+  public double getMinimumNpshMarginM() {
+    return minimumNpshMarginM;
+  }
+
+  /**
+   * Sets the minimum absolute NPSH margin.
+   *
+   * @param minimumMarginM minimum NPSHa minus NPSHr in m
+   */
+  public void setMinimumNpshMarginM(double minimumMarginM) {
+    this.minimumNpshMarginM = minimumMarginM;
   }
 
   /**
@@ -1159,9 +1556,8 @@ public class PumpMechanicalDesign extends MechanicalDesign {
     }
 
     // Validate operating point vs BEP
-    if (bepFlow > 0) {
-      double operatingFlow = bepFlow; // Assuming design point = BEP
-      if (!validateOperatingInPOR(operatingFlow, bepFlow)) {
+    if (bepFlow > 0 && ratedFlow > 0) {
+      if (!validateOperatingInPOR(ratedFlow, bepFlow)) {
         result.addIssue("Operating point outside Preferred Operating Region (POR)");
       }
     }
@@ -1175,6 +1571,13 @@ public class PumpMechanicalDesign extends MechanicalDesign {
     // Validate design margins
     if (driverMargin < 1.05) {
       result.addIssue("Driver power margin " + String.format("%.2f", driverMargin) + " below recommended 1.05");
+    }
+
+    for (PumpApi610DesignCalculator.Check check : api610Assessment.getChecks()) {
+      if (check.getStatus() == PumpApi610DesignCalculator.CheckStatus.FAIL
+          || check.getStatus() == PumpApi610DesignCalculator.CheckStatus.WARNING) {
+        result.addIssue(check.getId() + " [" + check.getStatus() + "]: " + check.getMessage());
+      }
     }
 
     result.setValid(result.getIssues().isEmpty());
@@ -1204,16 +1607,23 @@ public class PumpMechanicalDesign extends MechanicalDesign {
           this.hydraulicPowerMargin = value;
           break;
         case "PreferredOperatingRegionLow":
-          this.porLowFraction = value;
+          // Legacy data rows contain the 80-110% rated-point band, not the wider POR.
+          this.ratedPointLowFraction = value;
           break;
         case "PreferredOperatingRegionHigh":
-          this.porHighFraction = value;
+          this.ratedPointHighFraction = value;
           break;
         case "AllowableOperatingRegionLow":
           this.aorLowFraction = value;
           break;
         case "AllowableOperatingRegionHigh":
           this.aorHighFraction = value;
+          break;
+        case "MinContinuousFlow":
+          this.minContinuousFlowFraction = value;
+          break;
+        case "MaxContinuousFlow":
+          this.maxContinuousFlowFraction = value;
           break;
         case "SuctionSpecificSpeedMax":
           this.maxSuctionSpecificSpeed = value;
@@ -1226,6 +1636,12 @@ public class PumpMechanicalDesign extends MechanicalDesign {
     } catch (Exception ex) {
       // Use default values if database lookup fails
     }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void readDesignSpecifications() {
+    loadProcessDesignParameters();
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesignResponse.java
@@ -1,5 +1,6 @@
 package neqsim.process.mechanicaldesign.pump;
 
+import neqsim.process.equipment.pump.Pump;
 import neqsim.process.mechanicaldesign.MechanicalDesignResponse;
 
 /**
@@ -81,6 +82,15 @@ public class PumpMechanicalDesignResponse extends MechanicalDesignResponse {
   /** NPSH margin [m]. */
   private double npshMargin;
 
+  /** NPSH margin ratio [NPSHa/NPSHr]. */
+  private double npshMarginRatio;
+
+  /** Absorbed pump shaft power [kW]. */
+  private double absorbedPower;
+
+  /** Hydraulic liquid power [kW]. */
+  private double hydraulicPower;
+
   /** Casing wall thickness [mm]. */
   private double casingWallThickness;
 
@@ -139,6 +149,9 @@ public class PumpMechanicalDesignResponse extends MechanicalDesignResponse {
   /** Head margin factor. */
   private double headMarginFactor;
 
+  /** Structured API 610 screening result with pass/fail/data-gap checks. */
+  private PumpApi610DesignCalculator api610Screening;
+
   // ============================================================================
   // Constructors
   // ============================================================================
@@ -148,7 +161,7 @@ public class PumpMechanicalDesignResponse extends MechanicalDesignResponse {
    */
   public PumpMechanicalDesignResponse() {
     setEquipmentType("Pump");
-    setDesignStandard("API 610");
+    setDesignStandard("API 610, 13th edition screening");
   }
 
   /**
@@ -159,7 +172,7 @@ public class PumpMechanicalDesignResponse extends MechanicalDesignResponse {
   public PumpMechanicalDesignResponse(PumpMechanicalDesign mecDesign) {
     super(mecDesign);
     setEquipmentType("Pump");
-    setDesignStandard("API 610");
+    setDesignStandard("API 610, 13th edition screening");
     populateFromPumpDesign(mecDesign);
   }
 
@@ -173,21 +186,36 @@ public class PumpMechanicalDesignResponse extends MechanicalDesignResponse {
       return;
     }
 
-    // Use only methods that exist in PumpMechanicalDesign
     this.numberOfStages = mecDesign.getNumberOfStages();
     this.impellerDiameter = mecDesign.getImpellerDiameter();
+    this.impellerWidth = mecDesign.getImpellerWidth();
     this.shaftDiameter = mecDesign.getShaftDiameter();
     this.ratedSpeed = mecDesign.getRatedSpeed();
     this.specificSpeed = mecDesign.getSpecificSpeed();
     this.suctionSpecificSpeed = mecDesign.getSuctionSpecificSpeed();
     this.driverPower = mecDesign.getDriverPower();
+    this.driverMargin = mecDesign.getDriverMargin();
+    this.ratedFlow = mecDesign.getRatedFlow();
+    this.ratedHead = mecDesign.getRatedHead();
+    this.bepFlow = mecDesign.getBepFlow();
+    this.bepHead = mecDesign.getBepHead();
+    this.efficiency = mecDesign.getPumpEfficiency();
     this.npshr = mecDesign.getNpshRequired();
+    this.npsha = mecDesign.getNpshAvailable();
+    this.npshMargin = mecDesign.getNpshMargin();
+    this.npshMarginRatio = mecDesign.getNpshMarginRatio();
+    this.absorbedPower = mecDesign.getAbsorbedPower();
+    this.hydraulicPower = mecDesign.getHydraulicPower();
+    this.casingWallThickness = mecDesign.getCasingWallThickness();
     this.suctionNozzleSize = mecDesign.getSuctionNozzleSize();
     this.dischargeNozzleSize = mecDesign.getDischargeNozzleSize();
     this.minimumContinuousFlow = mecDesign.getMinimumFlow();
 
     if (mecDesign.getPumpType() != null) {
       this.pumpType = mecDesign.getPumpType().name();
+    }
+    if (mecDesign.getApi610PumpType() != null) {
+      this.api610TypeCode = mecDesign.getApi610PumpType().name();
     }
     if (mecDesign.getSealType() != null) {
       this.sealType = mecDesign.getSealType().name();
@@ -202,6 +230,23 @@ public class PumpMechanicalDesignResponse extends MechanicalDesignResponse {
     this.aorHighFraction = mecDesign.getAorHighFraction();
     this.maxSuctionSpecificSpeed = mecDesign.getMaxSuctionSpecificSpeed();
     this.headMarginFactor = mecDesign.getHeadMarginFactor();
+    this.api610Screening = mecDesign.getApi610Assessment();
+
+    if (mecDesign.getProcessEquipment() instanceof Pump) {
+      Pump pump = (Pump) mecDesign.getProcessEquipment();
+      if (pump.getInletStream() != null && pump.getOutletStream() != null) {
+        this.suctionPressure = pump.getInletStream().getPressure("bara");
+        this.dischargePressure = pump.getOutletStream().getPressure("bara");
+        this.differentialPressure = dischargePressure - suctionPressure;
+        this.fluidTemperature = pump.getInletStream().getTemperature("C");
+        this.fluidDensity = pump.getInletStream().getThermoSystem().getDensity("kg/m3");
+        try {
+          this.fluidViscosity = pump.getInletStream().getThermoSystem().getViscosity("cP");
+        } catch (Exception ex) {
+          this.fluidViscosity = Double.NaN;
+        }
+      }
+    }
   }
 
   // ============================================================================
@@ -368,6 +413,30 @@ public class PumpMechanicalDesignResponse extends MechanicalDesignResponse {
     this.npshMargin = npshMargin;
   }
 
+  public double getNpshMarginRatio() {
+    return npshMarginRatio;
+  }
+
+  public void setNpshMarginRatio(double npshMarginRatio) {
+    this.npshMarginRatio = npshMarginRatio;
+  }
+
+  public double getAbsorbedPower() {
+    return absorbedPower;
+  }
+
+  public void setAbsorbedPower(double absorbedPower) {
+    this.absorbedPower = absorbedPower;
+  }
+
+  public double getHydraulicPower() {
+    return hydraulicPower;
+  }
+
+  public void setHydraulicPower(double hydraulicPower) {
+    this.hydraulicPower = hydraulicPower;
+  }
+
   public double getCasingWallThickness() {
     return casingWallThickness;
   }
@@ -514,5 +583,13 @@ public class PumpMechanicalDesignResponse extends MechanicalDesignResponse {
 
   public void setHeadMarginFactor(double headMarginFactor) {
     this.headMarginFactor = headMarginFactor;
+  }
+
+  public PumpApi610DesignCalculator getApi610Screening() {
+    return api610Screening;
+  }
+
+  public void setApi610Screening(PumpApi610DesignCalculator api610Screening) {
+    this.api610Screening = api610Screening;
   }
 }

--- a/src/test/java/neqsim/process/equipment/pump/PumpAffinityLawTest.java
+++ b/src/test/java/neqsim/process/equipment/pump/PumpAffinityLawTest.java
@@ -153,6 +153,15 @@ public class PumpAffinityLawTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  void testBestEfficiencyPointScalesWithRequestedSpeed() {
+    double bepAtReferenceSpeed = pump.getPumpChart().getBestEfficiencyFlowRate(1000.0);
+    double bepAtHigherSpeed = pump.getPumpChart().getBestEfficiencyFlowRate(1500.0);
+
+    Assertions.assertEquals(1.5, bepAtHigherSpeed / bepAtReferenceSpeed, 0.01,
+        "BEP flow should scale linearly with speed");
+  }
+
+  @Test
   void testSpecificSpeed() {
     // Calculate specific speed (should be consistent with centrifugal pump)
     double ns = pump.getPumpChart().getSpecificSpeed();

--- a/src/test/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculatorTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculatorTest.java
@@ -1,0 +1,105 @@
+package neqsim.process.mechanicaldesign.pump;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.Api610PumpType;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.AssessmentStatus;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.BearingType;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.CheckStatus;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.DataSource;
+
+/** Tests for the value-only API 610 mechanical design screening calculator. */
+class PumpApi610DesignCalculatorTest {
+  @Test
+  void completePassingAssessmentIsAuditable() {
+    PumpApi610DesignCalculator calculator = new PumpApi610DesignCalculator();
+    calculator.setPumpType(Api610PumpType.OH2);
+    calculator.setDutyPoint(100.0, 80.0, 3000.0, 850.0, 25.0);
+    calculator.setBepPoint(100.0, 80.0, DataSource.VENDOR_CURVE);
+    calculator.setNpsh(6.0, 4.0, DataSource.VENDOR_CURVE);
+    calculator.setPressureBasis(5.0, 20.0, 90.0, DataSource.VENDOR_CURVE);
+    calculator.setHydrostaticTestPressureBara(30.0);
+    calculator.setDriverCriteria(1.10, new double[] { 22.0, 30.0, 37.0 });
+    calculator.setBearingData(BearingType.BALL, 100.0, 5.0);
+    calculator.setMechanicalEvidence(0.03, 4000.0, 0.8, 2.5);
+
+    calculator.calculate();
+
+    assertEquals(AssessmentStatus.PASS, calculator.getAssessmentStatus());
+    assertEquals("POR", calculator.getOperatingRegion());
+    assertEquals(30.0, calculator.getSelectedDriverPowerKw(), 1.0e-12);
+    assertEquals(13.0, calculator.getRequiredCasingPressureBara(), 0.6);
+    assertEquals(30.0, calculator.getPreliminaryHydrostaticTestPressureBara(), 1.0e-12);
+    assertTrue(calculator.getBearingL10LifeHours() > 25000.0);
+    assertEquals(CheckStatus.PASS, calculator.getCheck("head-rise").getStatus());
+  }
+
+  @Test
+  void suppliedNonCompliantEvidenceFailsAssessment() {
+    PumpApi610DesignCalculator calculator = new PumpApi610DesignCalculator();
+    calculator.setPumpType(Api610PumpType.OH2);
+    calculator.setDutyPoint(50.0, 80.0, 3000.0, 850.0, 25.0);
+    calculator.setBepPoint(100.0, 80.0, DataSource.VENDOR_CURVE);
+    calculator.setNpsh(4.0, 4.0, DataSource.VENDOR_CURVE);
+    calculator.setPressureBasis(5.0, 8.0, 84.0, DataSource.PURCHASER_INPUT);
+    calculator.setHydrostaticTestPressureBara(10.0);
+    calculator.setBearingData(BearingType.BALL, 5.0, 5.0);
+    calculator.setMechanicalEvidence(0.08, 3300.0, 1.2, 4.0);
+
+    calculator.calculate();
+
+    assertEquals(AssessmentStatus.FAIL, calculator.getAssessmentStatus());
+    assertEquals(CheckStatus.FAIL, calculator.getCheck("operating-region").getStatus());
+    assertEquals(CheckStatus.FAIL, calculator.getCheck("npsh-margin").getStatus());
+    assertEquals(CheckStatus.FAIL, calculator.getCheck("pressure-casing").getStatus());
+    assertEquals(CheckStatus.FAIL, calculator.getCheck("hydrostatic-test").getStatus());
+    assertEquals(CheckStatus.FAIL, calculator.getCheck("head-rise").getStatus());
+    assertEquals(CheckStatus.FAIL, calculator.getCheck("bearing-life").getStatus());
+    assertEquals(CheckStatus.FAIL, calculator.getCheck("shaft-deflection").getStatus());
+    assertEquals(CheckStatus.FAIL, calculator.getCheck("critical-speed").getStatus());
+    assertEquals(CheckStatus.FAIL, calculator.getCheck("nozzle-loads").getStatus());
+    assertEquals(CheckStatus.FAIL, calculator.getCheck("vibration").getStatus());
+  }
+
+  @Test
+  void missingVendorDataIsNeverTreatedAsPassing() {
+    PumpApi610DesignCalculator calculator = new PumpApi610DesignCalculator();
+
+    calculator.calculate();
+
+    assertEquals(AssessmentStatus.NOT_EVALUATED, calculator.getAssessmentStatus());
+    assertEquals(CheckStatus.NOT_EVALUATED, calculator.getCheck("operating-region").getStatus());
+    assertEquals(CheckStatus.NOT_EVALUATED, calculator.getCheck("pressure-casing").getStatus());
+    assertEquals(CheckStatus.NOT_EVALUATED, calculator.getCheck("bearing-life").getStatus());
+    assertTrue(calculator.getChecks().stream()
+        .allMatch(check -> check.getStatus() == CheckStatus.NOT_EVALUATED));
+  }
+
+  @Test
+  void bearingLifeAndDriverSelectionUseEngineeringUnits() {
+    assertEquals(44444.444, PumpApi610DesignCalculator.calculateBearingL10LifeHours(100.0, 5.0,
+        3000.0, BearingType.BALL), 0.01);
+    assertTrue(Double.isNaN(PumpApi610DesignCalculator.calculateBearingL10LifeHours(100.0, 5.0,
+        3000.0, BearingType.SLEEVE)));
+    assertEquals(30.0,
+        PumpApi610DesignCalculator.selectDriverRating(27.5, new double[] { 37.0, 22.0, 30.0 }), 1.0e-12);
+    assertTrue(Double.isNaN(
+        PumpApi610DesignCalculator.selectDriverRating(40.0, new double[] { 22.0, 30.0, 37.0 })));
+  }
+
+  @Test
+  void seallessConstructionProducesScopeWarning() {
+    PumpApi610DesignCalculator calculator = new PumpApi610DesignCalculator();
+    calculator.setPumpType(Api610PumpType.OH2);
+    calculator.setDutyPoint(100.0, 80.0, 3000.0, 850.0, 25.0);
+    calculator.setSeallessPump(true);
+
+    calculator.calculate();
+
+    assertEquals(AssessmentStatus.PASS_WITH_WARNINGS, calculator.getAssessmentStatus());
+    assertNotNull(calculator.getCheck("standard-scope"));
+    assertEquals(CheckStatus.WARNING, calculator.getCheck("standard-scope").getStatus());
+  }
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculatorTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculatorTest.java
@@ -73,20 +73,17 @@ class PumpApi610DesignCalculatorTest {
     assertEquals(CheckStatus.NOT_EVALUATED, calculator.getCheck("operating-region").getStatus());
     assertEquals(CheckStatus.NOT_EVALUATED, calculator.getCheck("pressure-casing").getStatus());
     assertEquals(CheckStatus.NOT_EVALUATED, calculator.getCheck("bearing-life").getStatus());
-    assertTrue(calculator.getChecks().stream()
-        .allMatch(check -> check.getStatus() == CheckStatus.NOT_EVALUATED));
+    assertTrue(calculator.getChecks().stream().allMatch(check -> check.getStatus() == CheckStatus.NOT_EVALUATED));
   }
 
   @Test
   void bearingLifeAndDriverSelectionUseEngineeringUnits() {
-    assertEquals(44444.444, PumpApi610DesignCalculator.calculateBearingL10LifeHours(100.0, 5.0,
-        3000.0, BearingType.BALL), 0.01);
-    assertTrue(Double.isNaN(PumpApi610DesignCalculator.calculateBearingL10LifeHours(100.0, 5.0,
-        3000.0, BearingType.SLEEVE)));
-    assertEquals(30.0,
-        PumpApi610DesignCalculator.selectDriverRating(27.5, new double[] { 37.0, 22.0, 30.0 }), 1.0e-12);
-    assertTrue(Double.isNaN(
-        PumpApi610DesignCalculator.selectDriverRating(40.0, new double[] { 22.0, 30.0, 37.0 })));
+    assertEquals(44444.444,
+        PumpApi610DesignCalculator.calculateBearingL10LifeHours(100.0, 5.0, 3000.0, BearingType.BALL), 0.01);
+    assertTrue(
+        Double.isNaN(PumpApi610DesignCalculator.calculateBearingL10LifeHours(100.0, 5.0, 3000.0, BearingType.SLEEVE)));
+    assertEquals(30.0, PumpApi610DesignCalculator.selectDriverRating(27.5, new double[] { 37.0, 22.0, 30.0 }), 1.0e-12);
+    assertTrue(Double.isNaN(PumpApi610DesignCalculator.selectDriverRating(40.0, new double[] { 22.0, 30.0, 37.0 })));
   }
 
   @Test

--- a/src/test/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesignTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.mechanicaldesign.pump;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.logging.log4j.LogManager;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.DataSource;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
@@ -83,6 +85,16 @@ public class PumpMechanicalDesignTest {
     double hydraulicPower = pump.getPower() / 1000.0; // Convert to kW
     assertTrue(driverPower >= hydraulicPower, "Driver power should be >= hydraulic power");
     logger.info("Driver power: " + driverPower + " kW");
+  }
+
+  @Test
+  public void testAbsorbedPowerIsNotEfficiencyCorrectedTwice() {
+    double absorbedPower = pump.getPower("kW");
+
+    assertEquals(absorbedPower, mechDesign.getAbsorbedPower(), Math.max(1.0e-9, absorbedPower * 1.0e-9));
+    assertEquals(absorbedPower * mechDesign.getDriverMargin(),
+        mechDesign.getApi610Assessment().getRequiredDriverPowerKw(),
+        Math.max(1.0e-9, absorbedPower * 1.0e-9));
   }
 
   @Test
@@ -259,5 +271,65 @@ public class PumpMechanicalDesignTest {
         logger.info("  Issue: " + issue);
       }
     }
+  }
+
+  @Test
+  public void testVendorCurveDrivesBepSpeedAndNpshInputs() {
+    double[] speed = new double[] { 1000.0 };
+    double[][] flow = new double[][] { { 10.0, 20.0, 30.0, 40.0, 50.0, 60.0 } };
+    double[][] head = new double[][] { { 120.0, 118.0, 115.0, 110.0, 103.0, 94.0 } };
+    double[][] efficiency = new double[][] { { 60.0, 70.0, 78.0, 82.0, 81.0, 76.0 } };
+    double[][] npsh = new double[][] { { 2.0, 2.2, 2.5, 3.0, 3.8, 4.8 } };
+    pump.getPumpChart().setCurves(new double[] {}, speed, flow, head, efficiency);
+    pump.getPumpChart().setHeadUnit("meter");
+    pump.getPumpChart().setNPSHCurve(npsh);
+    pump.setSpeed(1000.0);
+    pump.getInletStream().setFlowRate(40000.0, "kg/hr");
+    pump.getInletStream().run();
+    pump.run();
+
+    mechDesign.calcDesign();
+
+    assertEquals(1000.0, mechDesign.getRatedSpeed(), 1.0e-12);
+    assertTrue(mechDesign.getBepFlow() > 30.0 && mechDesign.getBepFlow() < 60.0);
+    assertEquals(DataSource.VENDOR_CURVE, mechDesign.getApi610Assessment().getBepSource());
+    assertEquals(DataSource.VENDOR_CURVE, mechDesign.getApi610Assessment().getNpshrSource());
+    assertTrue(mechDesign.getNpshRequired() > 2.0 && mechDesign.getNpshRequired() < 5.0);
+  }
+
+  @Test
+  public void testPurchaserPressureInputsSurviveRepeatedCalculation() {
+    mechDesign.setMaximumSuctionPressure(7.0);
+    mechDesign.setShutoffHead(123.0);
+
+    mechDesign.calcDesign();
+    mechDesign.calcDesign();
+
+    assertEquals(123.0, mechDesign.getApi610Assessment().getGoverningShutoffHeadM(), 1.0e-12);
+    assertEquals(DataSource.PURCHASER_INPUT,
+        mechDesign.getApi610Assessment().getShutoffHeadSource());
+    assertTrue(mechDesign.getApi610Assessment().getRequiredCasingPressureBara() > 7.0);
+  }
+
+  @Test
+  public void testRecommendedAndPurchaserSelectedTypeAreDistinguished() {
+    assertEquals(DataSource.SCREENING_ESTIMATE, mechDesign.getApi610Assessment().getPumpTypeSource());
+
+    mechDesign.setApi610PumpType(PumpApi610DesignCalculator.Api610PumpType.OH2);
+    mechDesign.calcDesign();
+
+    assertEquals(DataSource.PURCHASER_INPUT, mechDesign.getApi610Assessment().getPumpTypeSource());
+  }
+
+  @Test
+  public void testPumpResponseIncludesApi610ScreeningAndCalculatedFields() {
+    PumpMechanicalDesignResponse response = mechDesign.getResponse();
+    String json = response.toJson();
+
+    assertNotNull(response.getApi610Screening());
+    assertEquals(mechDesign.getAbsorbedPower(), response.getAbsorbedPower(), 1.0e-12);
+    assertEquals(mechDesign.getHydraulicPower(), response.getHydraulicPower(), 1.0e-12);
+    assertTrue(json.contains("\"api610Screening\""));
+    assertTrue(json.contains("\"api610TypeCode\""));
   }
 }

--- a/src/test/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/pump/PumpMechanicalDesignTest.java
@@ -93,8 +93,7 @@ public class PumpMechanicalDesignTest {
 
     assertEquals(absorbedPower, mechDesign.getAbsorbedPower(), Math.max(1.0e-9, absorbedPower * 1.0e-9));
     assertEquals(absorbedPower * mechDesign.getDriverMargin(),
-        mechDesign.getApi610Assessment().getRequiredDriverPowerKw(),
-        Math.max(1.0e-9, absorbedPower * 1.0e-9));
+        mechDesign.getApi610Assessment().getRequiredDriverPowerKw(), Math.max(1.0e-9, absorbedPower * 1.0e-9));
   }
 
   @Test
@@ -306,8 +305,7 @@ public class PumpMechanicalDesignTest {
     mechDesign.calcDesign();
 
     assertEquals(123.0, mechDesign.getApi610Assessment().getGoverningShutoffHeadM(), 1.0e-12);
-    assertEquals(DataSource.PURCHASER_INPUT,
-        mechDesign.getApi610Assessment().getShutoffHeadSource());
+    assertEquals(DataSource.PURCHASER_INPUT, mechDesign.getApi610Assessment().getShutoffHeadSource());
     assertTrue(mechDesign.getApi610Assessment().getRequiredCasingPressureBara() > 7.0);
   }
 


### PR DESCRIPTION
## Summary

- add a reusable, value-only API 610 13th-edition pump mechanical-design screening calculator
- distinguish process, purchaser, vendor-curve, screening-estimate, and unavailable input provenance
- report PASS, WARNING, FAIL, and NOT_EVALUATED checks instead of treating missing vendor data as compliance
- add exact OH1-OH6, BB1-BB5, and VS1-VS7 type codes
- integrate rated-point/POR/AOR, NPSH, casing MAWP and hydrotest, head-rise, driver, ISO 281 bearing-life, shaft-deflection, critical-speed, nozzle-load, vibration, and scope screening
- make vendor BEP flow speed-aware and consume vendor BEP, shutoff-head, and NPSHr data in mechanical design
- correct absorbed-power handling so shaft and driver sizing do not divide by pump efficiency twice
- return unknown NPSHa as NaN rather than a false-safe 1000 m value
- populate the pump mechanical-design JSON response and reuse driver rating selection in the package design module
- document the screening/certification boundary and required purchaser/vendor evidence

## Standards boundary

This is an auditable engineering screen, not an API 610 certificate of conformity. Project criteria, the purchased standard, and vendor geometry/analysis/test documentation remain governing. Missing vendor evidence is explicitly NOT_EVALUATED.

## Validation

- Java 8 compilation and executable harness passed for `PumpApi610DesignCalculator`
- static parse of the modified Java source found no syntax or API-signature errors (external Maven dependencies are unavailable locally)
- upstream blob SHAs were verified against current `master` before creating the commit
- full Maven tests and Spotless are delegated to GitHub Actions because the local environment cannot resolve Maven plugins from Central
