### PR TITLE
docs: repair filter equipment guide examples

### DIFF
--- a/docs/process/equipment/filters.md
+++ b/docs/process/equipment/filters.md
@@ -1,451 +1,294 @@
 ---
 title: Filter Equipment
-description: Oil and gas filter simulation with type presets, beta-ratio efficiency, hydraulic curves, Ergun pressure drop, dynamic loading, bypass, and mechanical design.
+description: Oil and gas filter simulation with type presets, beta-ratio efficiency, hydraulic curves, Ergun pressure drop, dynamic loading, bypass, and preliminary mechanical design.
 ---
 
-# Filter Equipment
+NeqSim's filter equipment represents particulate filters, coalescers, strainers,
+and granular-media beds as two-port process units. The default is a fixed clean
+differential pressure. Optional models add flow-dependent hydraulics,
+particle-size efficiency, loading and breakthrough, bypass, backwash or
+regeneration, and preliminary vessel design.
 
-Documentation for filter equipment in NeqSim process simulation.
+## Contents
 
-## Table of Contents
-- [Overview](#overview)
-- [Filter Class](#filter-class)
-- [Filter Types](#filter-types)
-- [Particle and Droplet Capture](#particle-and-droplet-capture)
-- [Pressure-Drop Models](#pressure-drop-models)
-- [CharCoalFilter Class](#charcoalfilter-class)
-- [Dynamic Filter Loading](#dynamic-filter-loading)
-- [Differential-Pressure Bypass](#differential-pressure-bypass)
-- [Mechanical Design](#mechanical-design)
-- [Standards Basis](#standards-basis)
-- [Sulfur Filter](#sulfur-filter)
-- [Usage Examples](#usage-examples)
+- [Classes and scope](#classes-and-scope)
+- [Verified quick start](#verified-quick-start)
+- [Filter types](#filter-types)
+- [Particle and droplet capture](#particle-and-droplet-capture)
+- [Pressure-drop models](#pressure-drop-models)
+- [Dynamic loading and maintenance](#dynamic-loading-and-maintenance)
+- [Differential-pressure bypass](#differential-pressure-bypass)
+- [Mechanical design](#mechanical-design)
+- [Specialized filters](#specialized-filters)
+- [Standards basis](#standards-basis)
+- [Related documentation](#related-documentation)
 
----
+## Classes and scope
 
-## Overview
+The main classes are in `neqsim.process.equipment.filter`.
 
-**Location:** `neqsim.process.equipment.filter`
-
-**Classes:**
-| Class | Description |
-|-------|-------------|
-| `Filter` | Generic particulate, strainer, coalescer, and media-filter unit operation |
-| `CharCoalFilter` | Activated charcoal filter; inherits dynamic loading and regeneration behaviour |
-| `SulfurFilter` | Captures solid elemental sulfur (`S8`) and feeds captured mass into dynamic loading |
-| `FilterPerformanceCurve` | Particle-size versus beta-ratio performance data |
+| Class | Purpose |
+| --- | --- |
+| `Filter` | Generic particulate, coalescer, strainer, or media-filter unit |
+| `CharCoalFilter` | Compatibility class that selects activated-carbon media defaults |
+| `SulfurFilter` | Detects and captures a configurable fraction of solid elemental sulfur (`S8`) |
+| `FilterPerformanceCurve` | Particle size versus beta-ratio test data |
 | `FilterPressureDropCurve` | Actual volumetric flow versus clean differential-pressure data |
 
-Applications include:
+The generic concentration model is an external solids or aerosol inventory. It
+reports contaminant capture but does not remove a thermodynamic component from
+the outlet fluid. Use contaminant-specific equipment when molecular removal must
+be included in the stream material balance.
 
-- Particulate removal
-- Gas and liquid coalescing
-- Temporary and permanent strainers
-- Bag and cartridge filtration
-- Sand, nutshell, and backwashable media beds
-- Activated-carbon guard media hydraulics and loading
-- Sulfur compound and solid sulfur removal
+## Verified quick start
 
----
-
-## Filter Class
-
-### Basic Usage
+This complete Java 8 example creates a gas stream, configures a cartridge
+filter from beta-ratio data, calculates steady-state performance and preliminary
+mechanical design, and then advances the dynamic loading state.
 
 ```java
+import java.util.List;
+import java.util.UUID;
 import neqsim.process.equipment.filter.Filter;
+import neqsim.process.equipment.filter.FilterPerformanceCurve;
+import neqsim.process.equipment.filter.FilterType;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.mechanicaldesign.filter.FilterMechanicalDesign;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
 
-// Create filter on gas stream
-Filter filter = new Filter("Particulate Filter", gasStream);
-filter.setFilterServiceType(FilterType.CARTRIDGE);
-filter.run();
+public final class FilterQuickStart {
+  private FilterQuickStart() {}
 
-// Get outlet stream
-StreamInterface cleanGas = filter.getOutletStream();
+  public static void main(String[] args) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 20.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("filter feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    feed.run();
+
+    FilterPerformanceCurve curve = new FilterPerformanceCurve(
+        new double[] {5.0, 10.0, 20.0},
+        new double[] {2.0, 100.0, 1000.0});
+    curve.setTestStandard("ISO 16889:2022");
+
+    Filter filter = new Filter("inlet cartridge filter", feed);
+    filter.setFilterServiceType(FilterType.CARTRIDGE);
+    filter.setDeltaP(0.10); // bar
+    filter.setPerformanceCurve(curve);
+    filter.setParticleSize(10.0); // micrometres
+    filter.setInletParticleConcentration(100.0); // mg/kg
+    filter.setTerminalDeltaP(1.0); // bar
+    filter.setElementCollapsePressure(5.0); // bar
+    filter.setElementIntegrityVerified(true);
+    filter.run();
+
+    StreamInterface cleanGas = filter.getOutletStream();
+    double efficiency = filter.getCurrentRemovalEfficiency();
+    double outletConcentration = filter.getOutletParticleConcentration(); // mg/kg
+    double capturedRate = filter.getCalculatedCapturedRate(); // kg/hr
+
+    FilterMechanicalDesign design =
+        (FilterMechanicalDesign) filter.getMechanicalDesign();
+    design.setMaxOperationPressure(70.0); // bara
+    design.setMaxOperationTemperature(333.15); // K
+    design.calcDesign();
+
+    int elements = design.getRequiredElements();
+    double vesselId = design.getInnerDiameter(); // m
+    List<String> warnings = design.getDesignWarnings();
+
+    filter.setLoadingCapacity(2.0); // kg
+    filter.setPressureDropIncreaseAtCapacity(0.5); // bar
+    filter.setCalculateSteadyState(false);
+    filter.runTransient(3600.0, UUID.randomUUID());
+
+    System.out.printf(
+        "Pout=%.3f bara, efficiency=%.4f, Cout=%.3f mg/kg, "
+            + "captured=%.6f kg/hr, elements=%d, ID=%.3f m, "
+            + "loading=%.6f kg, warnings=%d%n",
+        cleanGas.getPressure("bara"), efficiency, outletConcentration,
+        capturedRate, elements, vesselId, filter.getSolidsLoading(),
+        warnings.size());
+  }
+}
 ```
 
-The original fixed differential-pressure behavior remains the default. Select a
-filter type or pressure-drop model only when the required input data are
-available.
+At the stated beta ratio, the nominal removal efficiency is 0.99 and the
+reported outlet concentration is 1 mg/kg. The first transient hour adds the
+calculated captured mass to `solidsLoading`. The component composition and
+enthalpy of `cleanGas` are unchanged apart from the pressure-flash response.
 
-## Filter Types
+## Filter types
 
-`FilterType` provides construction-specific starting points. Calling
-`setFilterServiceType(...)` selects the associated pressure-drop model, flow
-exponent, face velocity, element geometry, and mechanical-design behavior.
+`setFilterServiceType(...)` selects construction-specific hydraulic and design
+defaults. Replace these screening defaults with project or vendor data.
 
-| Type | Typical service | Default hydraulic model |
-|---|---|---|
+| `FilterType` | Typical service | Default clean-pressure-drop model |
+| --- | --- | --- |
 | `CARTRIDGE` | Gas or liquid particulate removal | Flow-scaled |
 | `BAG` | Produced water and liquid filtration | Flow-scaled |
-| `Y_STRAINER` | Temporary or compact coarse protection | Flow-scaled, quadratic |
-| `BASKET_STRAINER` | Coarse liquid protection with larger dirt capacity | Flow-scaled, quadratic |
+| `Y_STRAINER` | Compact coarse protection | Flow-scaled, quadratic |
+| `BASKET_STRAINER` | Coarse liquid protection | Flow-scaled, quadratic |
 | `COALESCER` | Aerosol or dispersed-droplet capture | Flow-scaled, quadratic |
 | `GRANULAR_MEDIA` | Sand, nutshell, or guard media | Ergun |
-| `BACKWASHABLE_MEDIA` | Regenerable produced-water media filters | Ergun |
-| `ACTIVATED_CARBON` | Sorbent guard-bed hydraulics and loading | Ergun |
+| `BACKWASHABLE_MEDIA` | Regenerable produced-water media | Ergun |
+| `ACTIVATED_CARBON` | Activated-carbon guard bed | Ergun |
 
-The defaults are screening values. Replace face velocities, element areas,
-media geometry, ratings, and curves with project/vendor data.
+## Particle and droplet capture
 
-## Particle and Droplet Capture
-
-The size-dependent performance model uses the filtration beta ratio:
+For particles at or above size $x$, the beta ratio and fractional efficiency
+are
 
 $$
-\beta_x = \frac{N_{\mathrm{upstream},x}}{N_{\mathrm{downstream},x}}
+\beta_x = \frac{N_{\mathrm{upstream},x}}
+                 {N_{\mathrm{downstream},x}}
 $$
 
 $$
-\eta_x = 1 - \frac{1}{\beta_x}
+\eta_x = 1 - \frac{1}{\beta_x}.
 $$
 
-where $x$ is the minimum particle or droplet size in micrometres. NeqSim uses
-log-linear interpolation between supplied beta-ratio points and clamps outside
-the tested size range.
+`FilterPerformanceCurve` uses log-linear interpolation between supplied beta
+ratios and clamps to the nearest endpoint outside the tested particle-size
+range. `setParticleSize(...)` takes micrometres.
+`setInletParticleConcentration(...)` takes mg/kg of process fluid. After
+`run()`, `getOutletParticleConcentration()` reports mg/kg and
+`getCalculatedCapturedRate()` reports kg/hr.
 
-```java
-FilterPerformanceCurve efficiencyCurve = new FilterPerformanceCurve(
-    new double[] {5.0, 10.0, 20.0},
-    new double[] {2.0, 100.0, 1000.0});
-efficiencyCurve.setTestStandard("ISO 16889:2022");
+Loading is accumulated only by `runTransient(...)` when steady-state mode is
+disabled. A steady-state `run()` calculates the capture rate but does not change
+the accumulated loading state.
 
-Filter filter = new Filter("10 micron liquid filter", feed);
-filter.setPerformanceCurve(efficiencyCurve);
-filter.setParticleSize(10.0);
-filter.setInletParticleConcentration(100.0); // mg/kg
-filter.run();
+## Pressure-drop models
 
-double efficiency = filter.getCurrentRemovalEfficiency();
-double outletConcentration = filter.getOutletParticleConcentration(); // mg/kg
-double capturedRate = filter.getCalculatedCapturedRate(); // kg/hr
-```
+Actual volumetric flow is evaluated at the filter inlet.
 
-The generic concentration is an external solids/aerosol inventory and is not a
-thermodynamic component. It changes reported contaminant concentration and
-dynamic filter loading, but it does not change the outlet stream composition or
-enthalpy. Use a contaminant-specific unit such as `SulfurFilter`,
-`MercuryRemovalBed`, or `AdsorptionBed` when molecular material removal must be
-included in the stream material balance.
-
-## Pressure-Drop Models
-
-`FilterPressureDropModel` supports four approaches:
-
-| Model | Calculation | Required inputs |
-|---|---|---|
+| Model | Relation | Required data |
+| --- | --- | --- |
 | `FIXED` | Constant clean differential pressure | `setDeltaP(...)` |
-| `FLOW_SCALED` | $\Delta P=\Delta P_{ref}(Q/Q_{ref})^n$ | Clean ΔP, reference actual flow, exponent |
-| `TABULATED` | Linear interpolation/extrapolation of test points | `FilterPressureDropCurve` |
-| `ERGUN` | Viscous and inertial packed-bed terms | Area, bed depth, media size, void fraction |
+| `FLOW_SCALED` | $\Delta P=\Delta P_{ref}(Q/Q_{ref})^n$ | Clean differential pressure, reference actual flow, exponent |
+| `TABULATED` | Linear interpolation; defined endpoint extrapolation | `FilterPressureDropCurve` |
+| `ERGUN` | Viscous and inertial packed-bed terms | Area, depth, media diameter, void fraction |
 
-Actual volumetric flow is evaluated at inlet conditions. The Ergun model uses
-NeqSim density and viscosity, so gas compression, temperature, and liquid
-viscosity affect differential pressure.
+Use `setReferenceFlowRate(...)` in actual m3/hr for the flow-scaled model.
+Installing a `FilterPressureDropCurve` selects the tabulated model. Use
+`setMediaGeometry(areaM2, bedDepthM, particleDiameterM, voidFraction)` for the
+Ergun model. NeqSim obtains density and viscosity from the inlet thermodynamic
+state, so phase, pressure, and temperature affect the result.
 
-```java
-Filter strainer = new Filter("basket strainer", liquidFeed);
-strainer.setFilterServiceType(FilterType.BASKET_STRAINER);
-strainer.setDeltaP(0.15); // bar at reference flow
-strainer.setReferenceFlowRate(120.0); // actual m3/hr
+The Ergun implementation is a homogeneous packed-bed screening model. It does
+not represent channeling, distributor maldistribution, non-spherical-particle
+corrections, bed compaction, or multiphase flow through the media.
 
-FilterPressureDropCurve testedCurve = new FilterPressureDropCurve(
-    new double[] {50.0, 100.0, 150.0},
-    new double[] {0.05, 0.18, 0.40});
-testedCurve.setTestStandard("ISO 3968:2017");
-strainer.setPressureDropCurve(testedCurve);
-```
+## Dynamic loading and maintenance
 
----
+Dynamic operation requires `setCalculateSteadyState(false)` followed by
+`runTransient(dtSeconds, calculationId)`. The generic state includes:
 
-## CharCoalFilter Class
+- `solidsLoading` and `loadingCapacity` in kg;
+- captured, backwash, and regeneration rates in kg/hr;
+- a clean differential pressure plus a configured increase at one capacity;
+- breakthrough beginning at a configured capacity fraction; and
+- optional holdup volume in m3 and calculated residence time in seconds.
 
-`CharCoalFilter` is the compatibility class for an activated-carbon media
-filter. It automatically selects `ACTIVATED_CARBON`, including Ergun hydraulics,
-dynamic contaminant loading, and regeneration. It does not currently remove a
-named thermodynamic component.
+`setSolidsLoadingRate(...)` supplies a measured captured rate and disables the
+concentration-based rate. Alternatively, particle concentration and removal
+efficiency determine the captured rate automatically. `startBackwash()` and
+`startRegeneration()` activate their configured removal rates during transient
+steps. Stop them explicitly, or call `resetDynamicState()` after element
+replacement or completed maintenance.
 
-### Basic Usage
-
-```java
-import neqsim.process.equipment.filter.CharCoalFilter;
-
-CharCoalFilter charFilter = new CharCoalFilter("carbon guard filter", gasStream);
-charFilter.setMediaGeometry(2.0, 3.0, 0.003, 0.40);
-charFilter.setNominalRemovalEfficiency(0.99);
-charFilter.setInletParticleConcentration(1.0); // external contaminant, mg/kg
-charFilter.run();
-
-// Get treated stream
-StreamInterface treatedGas = charFilter.getOutletStream();
-```
-
-Use `MercuryRemovalBed` for mercury chemisorption, `AdsorptionBed` for
-component adsorption, or `H2SScavenger` for reactive H2S removal.
-
----
-
-## Dynamic Filter Loading
-
-`Filter` can be used as a steady-state pressure-drop element or as a dynamic
-filter that accumulates captured solids or contaminant loading during transient
-simulation. Dynamic mode is enabled by setting `setCalculateSteadyState(false)`
-and calling `runTransient(dt, id)`.
-
-The generic loading model tracks:
-
-- `solidsLoading` in kg
-- `solidsLoadingRate` in kg/hr
-- finite `loadingCapacity` in kg
-- `loadingFraction = solidsLoading / loadingCapacity`
-- pressure-drop buildup from clean `deltaP` plus `pressureDropIncreaseAtCapacity`
-- breakthrough after `breakthroughStartFraction`
-- backwash and regeneration removal rates
-- holdup volume and calculated residence time
-
-Loading is added to the selected clean-filter hydraulic model:
+The loading pressure contribution is
 
 $$
-\Delta P = \Delta P_\mathrm{clean} + \Delta P_\mathrm{capacity}\,f_\mathrm{loading}
+\Delta P = \Delta P_{\mathrm{clean}}
+         + \Delta P_{\mathrm{capacity}} f_{\mathrm{loading}}.
 $$
 
-where $f_\mathrm{loading}$ is the fraction of the configured loading capacity
-used. Breakthrough remains zero below the configured start fraction and then
-ramps linearly to one at full capacity.
+Breakthrough is zero up to `breakthroughStartFraction` and increases linearly to
+one at a loading fraction of one. Loading may exceed the nominal capacity; use
+`isReplacementRequired()` as an operating signal rather than assuming the state
+is capped.
 
-When inlet concentration and a beta ratio/efficiency are configured, the
-captured rate is calculated automatically. `setSolidsLoadingRate(...)` remains
-available as a manual captured-rate input when measured loading is known.
+## Differential-pressure bypass
 
-```java
-Filter filter = new Filter("dynamic filter", feed);
-filter.setDeltaP(0.10);
-filter.setHoldupVolume(1.0);
-filter.setSolidsLoadingRate(5.0);
-filter.setLoadingCapacity(10.0);
-filter.setPressureDropIncreaseAtCapacity(1.0);
-filter.setBreakthroughStartFraction(0.5);
-filter.setCalculateSteadyState(false);
+`setBypassCrackingDeltaP(...)` enables a parallel-path screening calculation.
+When unrestricted differential pressure exceeds the cracking setting, the
+applied pressure drop is capped and `getBypassFraction()` reports the estimated
+unfiltered fraction. Bypassed flow reduces the current removal efficiency.
 
-filter.runTransient(3600.0, UUID.randomUUID());
+The model assumes a quadratic parallel bypass path. Use explicit splitter,
+valve, recycle, and control equipment when the bypass network or valve
+characteristic matters.
 
-double loading = filter.getSolidsLoading();
-double loadingFraction = filter.getLoadingFraction();
-double pressureDrop = filter.getDeltaP();
-double breakthrough = filter.getBreakthroughFraction();
-```
+## Mechanical design
 
-Backwash and regeneration remove accumulated loading during transient steps:
+`Filter` constructs a `FilterMechanicalDesign` with the equipment. After the
+process calculation, `calcDesign()` performs preliminary:
 
-```java
-filter.setBackwashRemovalRate(4.0);
-filter.setRegenerationRemovalRate(2.0);
-filter.startBackwash();
-filter.startRegeneration();
-filter.runTransient(1800.0, UUID.randomUUID());
-```
-
-Use `resetDynamicState()` after replacement, clean-out, or completed
-regeneration to clear loading, breakthrough, and active maintenance flags.
-
-## Differential-Pressure Bypass
-
-A filter bypass or relief path can be represented by a cracking differential
-pressure. When unrestricted filter differential pressure exceeds the setting,
-the applied differential pressure is capped and an approximate bypass fraction
-is reported. Bypassed flow receives no filtration, so capture efficiency falls.
-
-```java
-filter.setBypassCrackingDeltaP(1.5); // bar
-filter.run();
-
-double unrestrictedDeltaP = filter.getUnrestrictedDeltaP();
-double appliedDeltaP = filter.getDeltaP();
-double bypassFraction = filter.getBypassFraction();
-```
-
-The bypass split assumes a quadratic parallel bypass path and is a screening
-model. Use a splitter, valve, recycle path, and controller for a detailed
-hydraulic network.
-
-## Mechanical Design
-
-Every `Filter` owns a `FilterMechanicalDesign`. `calcDesign()` performs:
-
-- type-specific element area or media-bed cross-section sizing;
-- element count and actual face-velocity calculation;
+- type-specific element or media-area sizing;
+- element count and face-velocity checks;
 - vessel diameter and tangent-length screening;
-- shell and 2:1 ellipsoidal-head thickness screening;
-- inlet/outlet nozzle velocity sizing and preliminary nominal diameter;
-- terminal differential-pressure and element collapse/burst checks;
-- element integrity evidence tracking;
-- weight, bill of materials, CAPEX, maintenance, and lifecycle-cost estimates.
+- shell and 2:1 ellipsoidal-head membrane-thickness screening;
+- inlet/outlet nozzle velocity sizing;
+- terminal and collapse differential-pressure checks; and
+- weight, bill of materials, purchase-cost, maintenance, and lifecycle estimates.
 
-```java
-filter.setTerminalDeltaP(1.0);          // normal replacement/backwash point, bar
-filter.setElementCollapsePressure(5.0); // supplier rating, bar
-filter.setElementIntegrityVerified(true);
-filter.run();
+Maximum operating pressure is in bara and maximum operating temperature is in
+kelvin. The design class applies configurable pressure and temperature margins.
+The result is screening-level evidence, not a certified pressure-vessel or
+filter-element design.
 
-FilterMechanicalDesign design =
-    (FilterMechanicalDesign) filter.getMechanicalDesign();
-design.setMaxOperationPressure(70.0);    // bara
-design.setMaxOperationTemperature(333.15); // K
-design.calcDesign();
+Final design requires the governing code edition, project design rules,
+certified material allowables, weld efficiency, corrosion and erosion
+allowances, external loads, nozzle reinforcement, closure and support design,
+fatigue, fire and relief cases, materials compatibility, inspection strategy,
+and vendor review.
 
-int elements = design.getRequiredElements();
-double vesselId = design.getInnerDiameter();
-double shellThickness = design.getShellThickness();
-double nozzleSize = design.getSelectedNozzleDiameterMm();
-List<String> warnings = design.getDesignWarnings();
-```
+## Specialized filters
 
-The pressure-boundary calculation is preliminary. Certified design still needs
-the governing code edition, project pressure/temperature rules, certified
-allowable stresses, weld efficiency, corrosion/erosion allowance, external
-loads, nozzle reinforcement, closure design, supports, fatigue, fire case,
-relief protection, materials compatibility, inspection, and vendor review.
+`CharCoalFilter` selects `ACTIVATED_CARBON` defaults and inherits the generic
+Ergun, loading, and regeneration models. It does not remove a named molecular
+component. Use an [adsorption bed](adsorption_bed.md) for component adsorption.
 
-## Standards Basis
+`SulfurFilter` performs a solid-aware flash when `S8` is present and captures the
+configured fraction of solid-phase S8. It removes that captured amount from the
+outlet thermodynamic inventory and adds the captured rate to dynamic loading
+during `runTransient(...)`. The sulfur element capacity and installed element
+count define the inherited loading capacity. See the
+[reactor guide](reactors.md#sulfur-oxidation-reactor) for a complete
+`SulfurOxidationReactor` to `SulfurFilter` example.
 
-NeqSim implements open, user-configurable representations of standard test
-results; it does not reproduce protected acceptance tables or claim equipment
-certification.
+For molecular removal, use the dedicated
+[mercury guard-bed model](../mercury_removal.md),
+[adsorption-bed model](adsorption_bed.md), or
+[H2S scavenger](../H2S_scavenger_guide.md), as applicable.
 
-| Reference | Implemented use |
-|---|---|
-| [ISO 16889:2022](https://www.iso.org/standard/77245.html) | Store and interpolate beta-ratio, contaminant-capacity, and differential-pressure performance supplied by a test laboratory/vendor |
-| [ISO 3968:2017](https://www.iso.org/standard/64104.html) | Store and interpolate measured clean differential-pressure versus actual-flow data |
-| [ISO 2942:2018](https://www.iso.org/standard/68005.html) | Record that element fabrication integrity was verified; bubble point is not converted into efficiency |
-| [ISO 2941:2009](https://www.iso.org/standard/41062.html) | Check operating differential pressure against a user-supplied element collapse/burst rating |
-| [ASME Section VIII Division 1](https://www.asme.org/codes-standards/find-codes-standards/bpvc-viii-1-bpvc-section-viii-rules-construction-pressure-vessels-division-1) | Screening shell/head membrane-thickness equations with configurable material allowable stress, joint efficiency, and corrosion allowance |
+## Standards basis
 
-The ISO references above are primarily hydraulic-fluid filter test methods.
-Their data structures are also useful for oil and gas liquid filters, while gas
-coalescers and special media should use the applicable vendor test method and
-record it in the curve metadata.
+NeqSim stores user-supplied laboratory or vendor results and applies open,
+configurable calculations. It does not embed protected acceptance tables,
+certify equipment, or establish project compliance.
 
-ISO and ASME publish the scope and status pages openly, while the normative
-documents remain copyrighted. Consequently, NeqSim stores user-supplied test
-results and configurable design inputs rather than embedding protected tables.
+| Reference | Use in NeqSim |
+| --- | --- |
+| [ISO 16889:2022](https://www.iso.org/standard/77245.html) | Record and interpolate supplied beta-ratio data |
+| [ISO 3968:2017](https://www.iso.org/standard/64104.html) | Record and interpolate supplied clean differential-pressure data |
+| [ISO 2942:2018](https://www.iso.org/standard/68005.html) | Record project or supplier evidence of element fabrication integrity |
+| [ISO 2941:2009](https://www.iso.org/standard/41062.html) | Compare calculated differential pressure with a user-supplied collapse or burst rating |
+| [ASME BPVC Section VIII, Division 1](https://www.asme.org/codes-standards/find-codes-standards/bpvc-viii-1-bpvc-section-viii-rules-construction-pressure-vessels-division-1) | Basis for preliminary shell and head membrane-thickness equations |
 
----
+Confirm that a cited edition and method apply to the fluid, element, and project.
+The ISO references above are primarily hydraulic-fluid filter test methods; gas
+coalescers and special media may require different vendor or project methods.
 
-## Sulfur Filter
+## Related documentation
 
-`SulfurFilter` extends `Filter` for gas streams containing solid elemental
-sulfur as `S8`. During `run()` it performs a TP-solid flash when `S8` is present,
-detects the solid sulfur phase, removes the captured fraction from the outlet,
-and reports the captured sulfur rate in kg/hr.
-
-During `runTransient(...)`, captured `S8` is added to the inherited dynamic
-filter loading state. That means a sulfur filter can represent operational
-pressure buildup from sulfur deposition and eventual breakthrough as the element
-capacity is consumed.
-
-```java
-SulfurFilter filter = new SulfurFilter("sulfur filter", sulfurBearingGas);
-filter.setRemovalEfficiency(1.0);
-filter.setDeltaP(0.10);
-filter.setFilterElementCapacity(1000.0);
-filter.setNumberOfElements(1);
-filter.setPressureDropIncreaseAtCapacity(1.0);
-filter.setBreakthroughStartFraction(0.9);
-filter.setCalculateSteadyState(false);
-
-filter.runTransient(3600.0, UUID.randomUUID());
-
-boolean detected = filter.isSolidS8Detected();
-double capturedRate = filter.getSolidSulfurRemovalRate();
-double sulfurLoading = filter.getSolidsLoading();
-double builtPressureDrop = filter.getDeltaP();
-```
-
-The finite dynamic capacity is synchronized from
-`filterElementCapacity * numberOfElements`, so sulfur-filter sizing and dynamic
-loading use the same capacity basis.
-
----
-
-## Usage Examples
-
-### Inlet Gas Conditioning
-
-```java
-ProcessSystem process = new ProcessSystem();
-
-// Raw gas feed
-Stream rawGas = new Stream("Raw Gas", gasFluid);
-rawGas.setFlowRate(100000.0, "Sm3/day");
-process.add(rawGas);
-
-// Particulate filter
-Filter particleFilter = new Filter("Inlet Filter", rawGas);
-process.add(particleFilter);
-
-// Molecular mercury removal uses a chemisorption bed
-MercuryRemovalBed hgFilter = new MercuryRemovalBed("Hg Guard Bed",
-    particleFilter.getOutletStream());
-process.add(hgFilter);
-
-// Run
-process.run();
-```
-
-### Sulfur Formation and Filtration
-
-Pair `SulfurOxidationReactor` with `SulfurFilter` when sour methane contains
-oxygen and elemental sulfur formation should be represented explicitly. The
-reactor creates `S8`; the filter captures solid `S8` and builds pressure drop
-dynamically.
-
-```java
-SystemInterface gas = new SystemSrkEos(283.15, 20.0);
-gas.addComponent("methane", 80.0);
-gas.addComponent("H2S", 80.0);
-gas.addComponent("oxygen", 40.0);
-gas.addComponent("water", 1.0e-12);
-gas.addComponent("S8", 1.0e-12);
-gas.setMixingRule("classic");
-gas.setMultiPhaseCheck(true);
-gas.setSolidPhaseCheck("S8");
-
-Stream feed = new Stream("sour methane feed", gas);
-feed.setFlowRate(1000.0, "kg/hr");
-feed.run();
-
-SulfurOxidationReactor reactor = new SulfurOxidationReactor("sulfur reactor", feed);
-reactor.setH2SConversionTarget(1.0);
-reactor.run();
-
-SulfurFilter filter = new SulfurFilter("sulfur filter", reactor.getOutletStream());
-filter.setRemovalEfficiency(1.0);
-filter.setDeltaP(0.10);
-filter.setFilterElementCapacity(1000.0);
-filter.setNumberOfElements(1);
-filter.setPressureDropIncreaseAtCapacity(1.0);
-filter.setCalculateSteadyState(false);
-filter.runTransient(3600.0, UUID.randomUUID());
-```
-
-This example is covered by `SulfurOxidationReactorTest` and `FilterTest`.
-
-### LNG Mercury Removal
-
-```java
-// Upstream of cryogenic section
-MercuryRemovalBed mercuryRemoval = new MercuryRemovalBed("Mercury Removal", feed);
-mercuryRemoval.run();
-
-double outletMercury = mercuryRemoval.getOutletStream()
-    .getFluid().getComponent("mercury").getFlowRate("g/hr");
-```
-
----
-
-## Related Documentation
-
-- [Separators](separators) - Phase separation
-- [Absorbers](absorbers) - Absorption processes
-- [Reactors](reactors) - Sulfur oxidation and other reactor models
-- [Streams](streams) - Stream handling
+- [Separators](separators.md) - phase separation and entrainment
+- [Absorbers](absorbers.md) - mass-transfer columns
+- [Reactors](reactors.md) - sulfur oxidation and other reactor models
+- [Streams](streams.md) - stream construction and handling

--- a/docs/process/equipment/filters.md
+++ b/docs/process/equipment/filters.md
@@ -71,8 +71,8 @@ public final class FilterQuickStart {
     feed.run();
 
     FilterPerformanceCurve curve = new FilterPerformanceCurve(
-        new double[] {5.0, 10.0, 20.0},
-        new double[] {2.0, 100.0, 1000.0});
+        new double[] { 5.0, 10.0, 20.0 },
+        new double[] { 2.0, 100.0, 1000.0 });
     curve.setTestStandard("ISO 16889:2022");
 
     Filter filter = new Filter("inlet cartridge filter", feed);

--- a/src/test/java/neqsim/process/equipment/filter/FilterDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/filter/FilterDocumentationTest.java
@@ -62,12 +62,10 @@ public class FilterDocumentationTest extends neqsim.NeqSimTest {
     int elements = design.getRequiredElements();
     double vesselId = design.getInnerDiameter();
     List<String> warnings = design.getDesignWarnings();
-    int warningCount = warnings.size();
 
     assertTrue(elements > 0);
     assertTrue(vesselId > 0.0);
     assertNotNull(warnings);
-    assertTrue(warningCount >= 0);
     assertTrue(design.getShellThickness() > 0.0);
     assertTrue(design.getSelectedNozzleDiameterMm() > 0.0);
     assertTrue(design.isDifferentialPressureDesignAcceptable());

--- a/src/test/java/neqsim/process/equipment/filter/FilterDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/filter/FilterDocumentationTest.java
@@ -1,0 +1,84 @@
+package neqsim.process.equipment.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.mechanicaldesign.filter.FilterMechanicalDesign;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Executable regression coverage for {@code docs/process/equipment/filters.md}. */
+public class FilterDocumentationTest extends neqsim.NeqSimTest {
+
+  /** Verifies every API call in the filter-guide quick start. */
+  @Test
+  public void testFilterGuideQuickStart() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 20.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("filter feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    feed.run();
+
+    FilterPerformanceCurve curve = new FilterPerformanceCurve(
+        new double[] {5.0, 10.0, 20.0}, new double[] {2.0, 100.0, 1000.0});
+    curve.setTestStandard("ISO 16889:2022");
+
+    Filter filter = new Filter("inlet cartridge filter", feed);
+    filter.setFilterServiceType(FilterType.CARTRIDGE);
+    filter.setDeltaP(0.10);
+    filter.setPerformanceCurve(curve);
+    filter.setParticleSize(10.0);
+    filter.setInletParticleConcentration(100.0);
+    filter.setTerminalDeltaP(1.0);
+    filter.setElementCollapsePressure(5.0);
+    filter.setElementIntegrityVerified(true);
+    filter.run();
+
+    StreamInterface cleanGas = filter.getOutletStream();
+    double efficiency = filter.getCurrentRemovalEfficiency();
+    double outletConcentration = filter.getOutletParticleConcentration();
+    double capturedRate = filter.getCalculatedCapturedRate();
+
+    assertNotNull(cleanGas);
+    assertEquals(19.9, cleanGas.getPressure("bara"), 1.0e-8);
+    assertEquals(0.99, efficiency, 1.0e-12);
+    assertEquals(1.0, outletConcentration, 1.0e-12);
+    assertEquals(0.099, capturedRate, 1.0e-12);
+
+    FilterMechanicalDesign design =
+        (FilterMechanicalDesign) filter.getMechanicalDesign();
+    design.setMaxOperationPressure(70.0);
+    design.setMaxOperationTemperature(333.15);
+    design.calcDesign();
+
+    int elements = design.getRequiredElements();
+    double vesselId = design.getInnerDiameter();
+    List<String> warnings = design.getDesignWarnings();
+    int warningCount = warnings.size();
+
+    assertTrue(elements > 0);
+    assertTrue(vesselId > 0.0);
+    assertNotNull(warnings);
+    assertTrue(warningCount >= 0);
+    assertTrue(design.getShellThickness() > 0.0);
+    assertTrue(design.getSelectedNozzleDiameterMm() > 0.0);
+    assertTrue(design.isDifferentialPressureDesignAcceptable());
+
+    filter.setLoadingCapacity(2.0);
+    filter.setPressureDropIncreaseAtCapacity(0.5);
+    filter.setCalculateSteadyState(false);
+    filter.runTransient(3600.0, UUID.randomUUID());
+
+    assertEquals(capturedRate, filter.getSolidsLoading(), 1.0e-12);
+    assertTrue(filter.getDeltaP() > filter.getCleanDeltaP());
+    assertFalse(filter.isReplacementRequired());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/filter/FilterDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/filter/FilterDocumentationTest.java
@@ -27,8 +27,8 @@ public class FilterDocumentationTest extends neqsim.NeqSimTest {
     feed.setFlowRate(1000.0, "kg/hr");
     feed.run();
 
-    FilterPerformanceCurve curve = new FilterPerformanceCurve(
-        new double[] {5.0, 10.0, 20.0}, new double[] {2.0, 100.0, 1000.0});
+    FilterPerformanceCurve curve = new FilterPerformanceCurve(new double[] { 5.0, 10.0, 20.0 },
+        new double[] { 2.0, 100.0, 1000.0 });
     curve.setTestStandard("ISO 16889:2022");
 
     Filter filter = new Filter("inlet cartridge filter", feed);
@@ -53,8 +53,7 @@ public class FilterDocumentationTest extends neqsim.NeqSimTest {
     assertEquals(1.0, outletConcentration, 1.0e-12);
     assertEquals(0.099, capturedRate, 1.0e-12);
 
-    FilterMechanicalDesign design =
-        (FilterMechanicalDesign) filter.getMechanicalDesign();
+    FilterMechanicalDesign design = (FilterMechanicalDesign) filter.getMechanicalDesign();
     design.setMaxOperationPressure(70.0);
     design.setMaxOperationTemperature(333.15);
     design.calcDesign();


### PR DESCRIPTION
## Campaign

D011 in the documentation-quality campaign tracked by #2499.

## Frozen scope

- `docs/process/equipment/filters.md`
- `src/test/java/neqsim/process/equipment/filter/FilterDocumentationTest.java`

No production code, index, notebook, or unrelated documentation is changed.

## Confirmed defects and root cause

| Severity | Defect | Evidence/root cause |
| --- | --- | --- |
| High | The guide's Java examples were not compilable as presented. | Missing imports and undefined `gasStream`, `feed`, `FilterType`, `UUID`, `List`, and equipment classes meant users could not run the examples. |
| Medium | The generic concentration model was described as changing dynamic loading during a normal `run()`. | Current `Filter` only integrates captured mass in `runTransient(...)` when steady-state mode is disabled. |
| Medium | The sulfur section said the filter removes solid S8 without stating that removal is efficiency-limited. | `SulfurFilter.run(...)` multiplies detected solid S8 by `getCurrentRemovalEfficiency()`. |
| Medium | Specialized molecular-removal examples were incomplete and duplicated dedicated equipment guides. | Generic `Filter`/activated-carbon hydraulics do not remove named thermodynamic components. |
| Low | Front matter title was repeated as an H1. | This violates the repository documentation agent and renders a duplicate page title. |
| Low | The ASME external link used a dead product-page slug. | The old URL failed on retry; the current official ASME BPVC.VIII.1 page resolves. |
| Low | Related documentation links omitted the required `.md` suffix. | Repository documentation-agent link rules require explicit existing targets. |

## Fix

- Replaced the fragments with one complete Java 8 quick start.
- Clarified steady-state capture-rate calculation versus transient mass accumulation.
- Documented units, model boundaries, bypass assumptions, loading behavior, and preliminary-design limitations.
- Corrected the sulfur and activated-carbon scope and linked dedicated molecular-removal guides.
- Removed the duplicate H1 and corrected all internal-link targets.
- Replaced the dead ASME URL after retry and official-site lookup.
- Added `FilterDocumentationTest`, which exercises every NeqSim API call in the quick start and asserts pressure drop, beta-ratio capture, mechanical-design outputs, and transient loading.

## Validation plan and current evidence

Completed before publication:

- Compared every documented call and engineering claim with current `Filter`, curve, sulfur-filter, mechanical-design, and existing regression sources.
- Confirmed the seven internal target files and the sulfur-reactor anchor exist on current `master`.
- Checked front matter, heading hierarchy, balanced code fences, Markdown tables, KaTeX delimiters, and absence of mixed HTML/Markdown.
- ISO 16889, ISO 3968, ISO 2942, and ISO 2941 official pages responded successfully.
- The old ASME slug failed; the replacement official ASME product page was found and verified.
- Java source is Java 8 compatible and has no lines over 120 characters.
- On final head `9785e07`, pre-commit, Spotless, Jekyll/search, Javadoc, and agent-skill checks pass.
- The first pre-commit attempt exposed only a formatter delta in the new test; the exact hosted Spotless patch was applied and the final pre-commit run passed.

CodeQL passed. The Windows Java 21 matrix completed successfully: `FilterDocumentationTest` ran 1 test with 0 failures/errors, and the full suite ran 10,553 tests with 0 failures/errors and 212 skips. The Ubuntu matrix was still running when this evidence was reconciled. PR #2538 was merged externally as `aad968e`; no merge action was taken by this campaign run. No local Maven runner or current repository checkout was available in this execution environment, and no browser rendering surface was available for a screenshot.

## Compatibility and risk

Documentation and regression-test only. No runtime behavior, public API, default, serialization, or performance change.

## Exclusions

- No changes to the newly merged filter implementation.
- No edits to other pages that independently repeat their front-matter titles.
- No attempt to resolve unrelated repository-wide CI failures.

## Next rotation scope

After D011 is merged and its complete validation is clean, select the next bounded process-equipment/process-simulation page from the #2499 ledger.