### PR TITLE
Fix Codecov upload authentication on protected master

### DIFF
--- a/.github/workflows/verify_build.yml
+++ b/.github/workflows/verify_build.yml
@@ -57,6 +57,9 @@ jobs:
 
   test_java_matrix:
     name: Assert tests with Java 21 on ${{ matrix.platform }}
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ${{ matrix.os }}
     needs: test_javadoc
     strategy:
@@ -107,7 +110,7 @@ jobs:
         with:
           files: target/site/jacoco/jacoco.xml
           name: codecov
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           fail_ci_if_error: true
 
   test_java_8:


### PR DESCRIPTION
## Summary

- authenticate Codecov v7 uploads with GitHub OIDC instead of the absent `CODECOV_TOKEN` secret
- grant `id-token: write` only to the Java matrix job that performs the upload
- keep coverage upload restricted to Ubuntu pushes on protected `master`
- retain `fail_ci_if_error: true`

## Root cause

The Codecov wrapper reports `Token length: 0`, then rejects the queued upload because `master` is protected. The workflow references `secrets.CODECOV_TOKEN`, but no value reaches the job.

## Validation

- inspected the updated workflow on the branch
- confirmed `codecov/codecov-action@v7` documents `use_oidc: true` with `id-token: write`
- the upload itself can only be exercised after merge because the step intentionally runs only on a push to `master`
