### PR TITLE
docs: fix pump guide operating-point regression

### DIFF
--- a/docs/process/equipment/pumps.md
+++ b/docs/process/equipment/pumps.md
@@ -130,8 +130,10 @@ purchased standard edition, project specification, and vendor documentation for 
 
 ## Complete Java example
 
-This Java 8 example runs a water pump with a vendor curve, checks NPSH, performs the API 610
-screen, and exports the structured mechanical-design response.
+This Java 8 example runs a single-phase liquid pump with a vendor curve, checks NPSH, performs
+the API 610 screen, and exports the structured mechanical-design response. The inlet uses
+n-hexane so the actual-volume flow conversion is based on one stable liquid phase at the stated
+temperature and pressure.
 
 ```java
 import org.apache.logging.log4j.LogManager;
@@ -150,7 +152,7 @@ public final class PumpDesignExample {
 
   public static void main(String[] args) {
     SystemInterface fluid = new SystemSrkEos(298.15, 5.0);
-    fluid.addComponent("water", 1.0);
+    fluid.addComponent("n-hexane", 1.0);
     fluid.setMixingRule("classic");
 
     Stream feed = new Stream("pump feed", fluid);
@@ -201,7 +203,7 @@ public final class PumpDesignExample {
 | `pump.getPower("kW")` | Absorbed shaft power calculated by the process model |
 | `pump.getPumpChart().getHead(flow, speed)` | Vendor-curve head in the configured head unit |
 | `pump.getNPSHAvailable()` | Process-side NPSHa in metres, or `NaN` if unavailable |
-| `pump.getNPSHRequired()` | Vendor curve value or coarse fallback estimate in metres |
+| `pump.getNPSHRequired()` | Fitted vendor-curve value or coarse fallback estimate in metres |
 | `assessment.getOperatingRegion()` | Rated-point classification relative to vendor BEP |
 | `assessment.getSelectedDriverPowerKw()` | First configured rating meeting the required driver power |
 | `assessment.getRequiredCasingPressureBara()` | Screening casing-pressure requirement in bara |
@@ -212,6 +214,10 @@ public final class PumpDesignExample {
 - The process model is a one-dimensional steady-state equipment calculation; it does not resolve
   internal impeller or volute CFD.
 - Vendor curves govern realistic head, efficiency, NPSHr, runout, and shutoff behaviour.
+- Set actual-volume flow only for a fluid with an established phase state. A multiphase or
+  unflashed fluid can change density after the flow conversion and move the operating point.
+- `setCurves` and `setNPSHCurve` fit reduced polynomial curves; evaluated values can differ
+  slightly from individual tabulated points.
 - The fallback NPSHr correlation is only a preliminary screen.
 - The mechanical-design calculation provides screening dimensions and evidence status, not a
   certificate of conformity or accountable design approval.

--- a/src/test/java/neqsim/process/mechanicaldesign/pump/PumpDocumentationTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/pump/PumpDocumentationTest.java
@@ -18,7 +18,7 @@ public class PumpDocumentationTest {
   @Test
   public void testPumpAndApi610GuideExample() {
     SystemInterface fluid = new SystemSrkEos(298.15, 5.0);
-    fluid.addComponent("water", 1.0);
+    fluid.addComponent("n-hexane", 1.0);
     fluid.setMixingRule("classic");
 
     Stream feed = new Stream("pump feed", fluid);
@@ -46,10 +46,11 @@ public class PumpDocumentationTest {
     double npshRequiredM = pump.getNPSHRequired();
 
     assertTrue(powerKw > 0.0);
+    assertEquals(100.0, feed.getFlowRate("m3/hr"), 1.0e-9);
     assertEquals(105.0, vendorHeadM, 1.0e-9);
     assertTrue(Double.isFinite(npshAvailableM));
     assertTrue(npshAvailableM > npshRequiredM);
-    assertEquals(3.0, npshRequiredM, 1.0e-9);
+    assertEquals(3.0, npshRequiredM, 0.02);
     assertFalse(pump.isCavitating());
 
     PumpMechanicalDesign design = pump.getMechanicalDesign();


### PR DESCRIPTION
## Campaign batch

D012 follow-up for #2499. This repairs the executable regression introduced by merged PR #2540; it does not begin D013.

## Confirmed defect and root cause

- **High — documented operating point did not execute as stated.** The Java matrix evaluated the vendor head as `120.00000000000001 m` instead of `105.0 m`.
- The example used pure water with `SystemSrkEos` and set `100 m3/hr` before a stable single-liquid phase was established. After TP flash, the actual inlet rate was `0.395471527 m3/hr`, below the 50 m3/hr curve minimum, so `PumpChart.getHead` correctly clamped to the minimum curve point.
- The next exact assertion was also too strict: `setNPSHCurve` fits a reduced polynomial, yielding `3.008571429 m` at 100 m3/hr rather than reproducing the tabulated `3.0 m` bit-for-bit.

## Fix

- Use single-phase n-hexane at 298.15 K and 5 bara so the actual-volume flow conversion remains at the intended `100 m3/hr` operating point.
- Add a regression assertion for the actual inlet volumetric flow.
- Apply an engineering tolerance of `0.02 m` to the fitted NPSHr result.
- Document the stable-phase requirement for actual-volume flow conversion and that performance/NPSH curves are reduced polynomial fits.

## Evidence and validation

- Reproduced the merged failure with NeqSim 3.16.0: flow `0.395471527 m3/hr`, head `120.00000000000001 m`.
- Executed the corrected pump path with NeqSim 3.16.0: flow `100.0 m3/hr`, head `105.00000000000001 m`, NPSHa `73.624707221 m`, NPSHr `3.008571429 m`, shaft power `23.524117649 kW`, cavitation `false`.
- Re-audited `Stream.setFlowRate`, `SystemThermo.setTotalFlowRate/getFlowRate`, `Pump.run`, `PumpChart.getHead`, density correction, and existing pump-chart tests on current master.
- Markdown front matter, structure, existing internal links, equations, tables, and code fences are unchanged or locally inspected. No external link, notebook, image, or rendering change is in scope.
- Java 8 syntax was reviewed. Local Java compilation was unavailable because the execution image has no `javac`; the complete `PumpDocumentationTest` must pass the hosted Java matrix before D012 can be marked complete.
- Hosted pre-commit, Spotless, Javadoc, documentation search/Jekyll, CodeQL, and agent-skill checks pass on head `e929e7c`; Ubuntu and Windows Java matrices remain in progress.

## Scope and exclusions

Two files only: the pump guide and its focused documentation regression. No production API, numerical model, global default, index, notebook, performance, compatibility, or standards-interpretation change.

## Next step

Keep D012 as `validating` until hosted Ubuntu and Windows Java jobs pass. Then reconcile D012 as complete and select D013 from the #2499 rotation.