### PR TITLE
Audit mechanical-design standard support

### DIFF
--- a/docs/process/mechanical_design_standards.md
+++ b/docs/process/mechanical_design_standards.md
@@ -1,212 +1,87 @@
 ---
 title: Mechanical Design Standards in NeqSim
-description: NeqSim provides comprehensive support for international design standards used in process equipment mechanical design. The framework enables engineers to apply company-specific and international standa...
+description: Audited catalog of mechanical-design standards, implementation maturity, calculation paths, and engineering limitations in NeqSim.
 ---
 
-# Mechanical Design Standards in NeqSim
+NeqSim catalogs standards that may be relevant to process-equipment design. Catalog inclusion is
+not a statement that every requirement or calculation in a published standard has been implemented.
+The matrix below reports the calculation evidence that currently exists in NeqSim.
 
-## Overview
+## Maturity definitions
 
-NeqSim provides comprehensive support for international design standards used in process equipment mechanical design. The framework enables engineers to apply company-specific and international standards consistently across all equipment in a process simulation.
+| Maturity | Meaning |
+| --- | --- |
+| `CATALOGUED` | Standard identity, edition metadata, category, and equipment applicability are available, but no standard calculation is exposed. |
+| `SCREENING` | A preliminary engineering calculation is available with the boundary stated in the matrix. It is not a conformity assessment. |
+| `VALIDATED` | The stated calculation range has independent numerical validation and controlled regression evidence. |
+| `QUALIFIED` | A controlled implementation and evidence package has been released for a stated use. Accountable engineering approval is still required. |
 
-## Supported Design Standards
+No current entry is classified as `VALIDATED` or `QUALIFIED`. Existing calculations remain useful
+for preliminary screening, but project criteria, purchased standards, vendor data, and engineering
+review remain governing.
 
-### StandardType Enumeration
+## Current support matrix
 
-The `StandardType` enum catalogs 30+ international design standards organized by category:
+The table between the generated markers is produced by
+`StandardSupportAudit.generateMarkdownTable()`. A regression test fails if the published table and
+the source catalog diverge.
 
-| Category | Standards |
-|----------|-----------|
-| **Pressure Vessel Codes** | ASME Section VIII Div.1/2, EN 13445, PD 5500, DNV-OS-F101 |
-| **Piping Codes** | ASME B31.3, ASME B31.4, ASME B31.8, EN 13480, NORSOK L-002 |
-| **Process Design** | NORSOK P-001, NORSOK P-002, API RP 14E, API RP 521 |
-| **Material Standards** | ASTM A516, ASTM A106, EN 10028, NORSOK M-001 |
-| **Safety Standards** | API RP 520, API RP 521, ISO 23251 |
+<!-- BEGIN GENERATED STANDARD SUPPORT MATRIX -->
+| Standard | Edition metadata | Category | Registry factory | Calculation path | Maturity | Boundary |
+| --- | --- | --- | --- | --- | --- | --- |
+| NORSOK-L-001 | Rev 6 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
+| NORSOK-P-001 | Rev 5 | separator process design | SeparatorDesignStandard | SeparatorDesignStandard | SCREENING | Preliminary K-factor and sizing inputs only; standard-specific requirements are not independently validated. |
+| NORSOK-P-002 | Rev 5 | separator process design | SeparatorDesignStandard | SeparatorDesignStandard | SCREENING | Preliminary K-factor and sizing inputs only; standard-specific requirements are not independently validated. |
+| NORSOK-M-001 | Rev 6 | material plate design codes | MaterialPlateDesignStandard | MaterialPlateDesignStandard | SCREENING | Material-property lookup only; material selection, qualification, and code acceptance are not implemented. |
+| NORSOK-M-630 | Rev 7 | material pipe design codes | MaterialPipeDesignStandard | MaterialPipeDesignStandard | SCREENING | Material-property lookup only; material selection, qualification, and code acceptance are not implemented. |
+| ASME-VIII-Div1 | 2021 | pressure vessel design code | PressureVesselDesignStandard | PressureVesselDesignStandard | SCREENING | Generic thin-wall separator screening only; edition-specific clauses and complete vessel checks are not implemented. |
+| ASME-VIII-Div2 | 2021 | pressure vessel design code | PressureVesselDesignStandard | PressureVesselDesignStandard | SCREENING | Generic thin-wall separator screening only; edition-specific clauses and complete vessel checks are not implemented. |
+| ASME-B31.3 | 2022 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
+| ASME-B31.4 | 2022 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
+| ASME-B31.8 | 2022 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
+| API-617 | 8th Ed | compressor design codes | CompressorDesignStandard | CompressorDesignStandard | SCREENING | Preliminary compressor-factor screening only; package and vendor requirements are not implemented. |
+| API-610 | 12th Ed | pump design codes | DesignStandard | PumpApi610DesignCalculator | SCREENING | API 610 screening is available through PumpMechanicalDesign but is not selected by StandardRegistry. |
+| API-650 | 13th Ed | pressure vessel design code | PressureVesselDesignStandard | None | CATALOGUED | The registry maps this tank standard to a separator-oriented pressure-vessel class; no tank-code calculation is implemented. |
+| API-620 | 13th Ed | pressure vessel design code | PressureVesselDesignStandard | None | CATALOGUED | The registry maps this tank standard to a separator-oriented pressure-vessel class; no tank-code calculation is implemented. |
+| API-660 | 9th Ed | heat exchanger design codes | DesignStandard | None | CATALOGUED | No standard-specific heat-exchanger mechanical calculation is connected. |
+| API-661 | 7th Ed | heat exchanger design codes | DesignStandard | None | CATALOGUED | No standard-specific heat-exchanger mechanical calculation is connected. |
+| API-521 | 7th Ed | valve design codes | ValveDesignStandard | None | CATALOGUED | The mapped valve class does not implement relief-system or relief-valve standard calculations. |
+| API-526 | 7th Ed | valve design codes | ValveDesignStandard | None | CATALOGUED | The mapped valve class does not implement relief-system or relief-valve standard calculations. |
+| API-5L | 46th Ed | material pipe design codes | MaterialPipeDesignStandard | MaterialPipeDesignStandard | SCREENING | Material-property lookup only; material selection, qualification, and code acceptance are not implemented. |
+| API-12J | 8th Ed | separator process design | SeparatorDesignStandard | SeparatorDesignStandard | SCREENING | Preliminary K-factor and sizing inputs only; standard-specific requirements are not independently validated. |
+| DNV-ST-F101 | 2021 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
+| DNV-OS-F101 | 2013 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
+| DNV-RP-F105 | 2021 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
+| ISO-13623 | 2017 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
+| ISO-15649 | 2001 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
+| ISO-16812 | 2019 | heat exchanger design codes | DesignStandard | None | CATALOGUED | No standard-specific heat-exchanger mechanical calculation is connected. |
+| ASTM-A106 | 2022 | material pipe design codes | MaterialPipeDesignStandard | MaterialPipeDesignStandard | SCREENING | Material-property lookup only; material selection, qualification, and code acceptance are not implemented. |
+| ASTM-A516 | 2022 | material plate design codes | MaterialPlateDesignStandard | MaterialPlateDesignStandard | SCREENING | Material-property lookup only; material selection, qualification, and code acceptance are not implemented. |
+| ASTM-A333 | 2022 | material pipe design codes | MaterialPipeDesignStandard | MaterialPipeDesignStandard | SCREENING | Material-property lookup only; material selection, qualification, and code acceptance are not implemented. |
+| EN-13480 | 2017 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
+| EN-13445 | 2021 | pressure vessel design code | PressureVesselDesignStandard | PressureVesselDesignStandard | SCREENING | Generic thin-wall separator screening only; edition-specific clauses and complete vessel checks are not implemented. |
+| PD-5500 | 2021 | pressure vessel design code | PressureVesselDesignStandard | PressureVesselDesignStandard | SCREENING | Generic thin-wall separator screening only; edition-specific clauses and complete vessel checks are not implemented. |
+<!-- END GENERATED STANDARD SUPPORT MATRIX -->
 
-### Using StandardType
+## How to interpret the registry
 
-```java
-import neqsim.process.mechanicaldesign.designstandards.StandardType;
+`StandardRegistry.createStandard(...)` remains backward compatible. The factory class shown in the
+matrix records what it currently creates; it does not prove that the resulting class implements the
+selected edition. `StandardRegistry.getMappedImplementationClass(...)` allows applications and
+audits to inspect that mapping without constructing equipment or accessing the design database.
 
-// Get standard by code
-StandardType standard = StandardType.fromCode("ASME-VIII-1");
+The API 610 pump screen is a deliberate special case. It is implemented by
+`PumpApi610DesignCalculator` through `PumpMechanicalDesign`, while the generic registry currently
+creates only a base `DesignStandard`. A later consolidation will connect equipment-specific
+calculators through one typed standards interface.
 
-// Get standard properties
-String code = standard.getCode();           // "ASME-VIII-1"
-String name = standard.getName();           // "ASME Section VIII Division 1"
-String version = standard.getDefaultVersion(); // "2023"
-String category = standard.getDesignStandardCategory(); // "pressure vessel design code"
+## Engineering boundary
 
-// Check equipment applicability
-boolean applies = standard.appliesTo("separator"); // true
-boolean applies2 = standard.appliesTo("pump");     // false
+- Treat `CATALOGUED` entries as discovery metadata only.
+- Treat `SCREENING` results as preliminary design information with the stated boundary.
+- Do not infer certification, code compliance, vendor acceptance, or construction readiness.
+- Record the purchased edition, project amendments, input provenance, and accountable approval
+  outside the current legacy registry.
 
-// Get all standards for an equipment type
-List<StandardType> applicable = StandardType.getApplicableStandards("compressor");
-```
-
-## Standard Categories
-
-NeqSim uses category-based standard assignment to ensure appropriate standards are applied to each equipment type:
-
-| Category Key | Description | Example Standards |
-|--------------|-------------|-------------------|
-| `pressure vessel design code` | Pressure containment design | ASME VIII, EN 13445 |
-| `separator process design` | Separator sizing rules | NORSOK P-002, API 12J |
-| `compressor design` | Compressor design requirements | API 617, API 618 |
-| `pipeline design codes` | Pipeline design | DNV-OS-F101, ASME B31.4 |
-| `valve design` | Valve sizing and selection | API 6D, EN ISO 10497 |
-| `material plate design` | Plate material selection | ASTM A516, EN 10028 |
-| `material pipe design` | Pipe material selection | ASTM A106, API 5L |
-
-## StandardRegistry
-
-The `StandardRegistry` class provides factory methods for creating `DesignStandard` instances:
-
-```java
-import neqsim.process.mechanicaldesign.designstandards.StandardRegistry;
-import neqsim.process.mechanicaldesign.designstandards.DesignStandard;
-
-// Create a design standard from StandardType
-DesignStandard standard = StandardRegistry.createStandard(StandardType.ASME_VIII_DIV1);
-
-// Create with specific version
-DesignStandard standard2 = StandardRegistry.createStandard(StandardType.NORSOK_P002, "Rev 3");
-
-// Get recommended standards for equipment
-List<StandardType> recommended = StandardRegistry.getRecommendedStandards("separator", "Equinor");
-```
-
-## Applying Standards to Equipment
-
-### Single Equipment
-
-```java
-import neqsim.process.equipment.separator.Separator;
-import neqsim.process.mechanicaldesign.MechanicalDesign;
-import neqsim.process.mechanicaldesign.designstandards.StandardType;
-
-// Create equipment
-Separator separator = new Separator("HP Separator", feedStream);
-
-// Get mechanical design
-MechanicalDesign mechDesign = separator.getMechanicalDesign();
-
-// Apply single standard
-mechDesign.setDesignStandard(StandardType.ASME_VIII_DIV1);
-
-// Apply standard with version
-mechDesign.setDesignStandard(StandardType.NORSOK_P002, "Rev 3");
-
-// Apply multiple standards
-List<StandardType> standards = Arrays.asList(
-    StandardType.ASME_VIII_DIV1,
-    StandardType.NORSOK_P002,
-    StandardType.ASTM_A516
-);
-mechDesign.setDesignStandards(standards);
-```
-
-### System-Wide Standards
-
-```java
-import neqsim.process.mechanicaldesign.SystemMechanicalDesign;
-import neqsim.process.processmodel.ProcessSystem;
-
-// Create process system
-ProcessSystem process = new ProcessSystem();
-process.add(separator);
-process.add(compressor);
-process.add(heatExchanger);
-
-// Apply company standards to all equipment
-SystemMechanicalDesign sysMechDesign = new SystemMechanicalDesign(process);
-sysMechDesign.setCompanySpecificDesignStandards("Equinor");
-
-// Run design calculations
-sysMechDesign.runDesignCalculation();
-```
-
-## Design Standard Hierarchy
-
-Standards are applied hierarchically based on specificity:
-
-```
-1. Equipment-specific standard (highest priority)
-   ↓
-2. TORG project standards
-   ↓
-3. Company default standards
-   ↓
-4. NeqSim default standards (lowest priority)
-```
-
-## Available Design Standard Classes
-
-NeqSim includes specialized design standard implementations:
-
-| Class | Purpose |
-|-------|---------|
-| `PressureVesselDesignStandard` | ASME/EN pressure vessel calculations |
-| `SeparatorDesignStandard` | Separator sizing per NORSOK/API |
-| `CompressorDesignStandard` | Compressor design per API 617/618 |
-| `PipelineDesignStandard` | Pipeline wall thickness per DNV/ASME |
-| `MaterialPlateDesignStandard` | Plate material properties |
-| `MaterialPipeDesignStandard` | Pipe material properties |
-| `JointEfficiencyPlateStandard` | Weld joint efficiency factors |
-| `GasScrubberDesignStandard` | Gas scrubber sizing rules |
-| `AdsorptionDehydrationDesignStandard` | Dehydration unit design |
-
-## Example: Complete Standard Application
-
-```java
-import neqsim.process.equipment.separator.Separator;
-import neqsim.process.equipment.compressor.Compressor;
-import neqsim.process.mechanicaldesign.SystemMechanicalDesign;
-import neqsim.process.mechanicaldesign.designstandards.StandardType;
-import neqsim.process.processmodel.ProcessSystem;
-import neqsim.thermo.system.SystemSrkEos;
-
-// Create fluid
-SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
-fluid.addComponent("methane", 0.85);
-fluid.addComponent("ethane", 0.10);
-fluid.addComponent("propane", 0.05);
-fluid.setMixingRule("classic");
-
-// Create feed stream
-Stream feed = new Stream("Feed", fluid);
-feed.setFlowRate(10000, "kg/hr");
-feed.setTemperature(25, "C");
-feed.setPressure(50, "bara");
-
-// Create equipment with standards
-Separator separator = new Separator("HP Separator", feed);
-separator.getMechanicalDesign().setDesignStandard(StandardType.ASME_VIII_DIV1);
-separator.getMechanicalDesign().setDesignStandard(StandardType.NORSOK_P002);
-
-Compressor compressor = new Compressor("Export Compressor", separator.getGasOutStream());
-compressor.setOutletPressure(150, "bara");
-compressor.getMechanicalDesign().setDesignStandard(StandardType.API_617);
-
-// Build process
-ProcessSystem process = new ProcessSystem();
-process.add(feed);
-process.add(separator);
-process.add(compressor);
-process.run();
-
-// Run mechanical design
-SystemMechanicalDesign sysMechDesign = new SystemMechanicalDesign(process);
-sysMechDesign.runDesignCalculation();
-
-// Get results
-System.out.println("Total Weight: " + sysMechDesign.getTotalWeight() + " kg");
-System.out.println("Total Volume: " + sysMechDesign.getTotalVolume() + " m³");
-```
-
-## See Also
-
-- [Mechanical Design Database](mechanical_design_database) - Data sources for design parameters
-- [TORG Document Integration](torg_integration) - Technical Requirements Documents
-- [Field Development Orchestration](field_development_orchestration) - Complete design workflows
+See the [engineering capability statement](../engineering/current-capabilities.md) for the broader
+process-to-engineering workflow and its qualification boundary.

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistry.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistry.java
@@ -107,9 +107,9 @@ public final class StandardRegistry {
    * Get the class selected by the category-based standards factory.
    *
    * <p>
-   * A mapping to {@link DesignStandard} means that the registry only creates a metadata holder; it
-   * does not imply that the named standard has an executable calculation. Use
-   * {@link StandardSupportAudit#getSupport(StandardType)} to inspect the implementation evidence.
+   * A mapping to {@link DesignStandard} means that the registry only creates a metadata holder; it does not imply that
+   * the named standard has an executable calculation. Use {@link StandardSupportAudit#getSupport(StandardType)} to
+   * inspect the implementation evidence.
    * </p>
    *
    * @param standardType standard to inspect

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistry.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistry.java
@@ -81,37 +81,66 @@ public final class StandardRegistry {
     String effectiveVersion = version != null ? version : getEffectiveVersion(standardType);
     String standardName = standardType.getCode() + " " + effectiveVersion;
 
-    String category = standardType.getDesignStandardCategory();
+    Class<? extends DesignStandard> implementationClass = getMappedImplementationClass(standardType);
 
-    // Create appropriate standard based on category
+    if (implementationClass == PressureVesselDesignStandard.class) {
+      return new PressureVesselDesignStandard(standardName, equipment);
+    } else if (implementationClass == SeparatorDesignStandard.class) {
+      return new SeparatorDesignStandard(standardName, equipment);
+    } else if (implementationClass == GasScrubberDesignStandard.class) {
+      return new GasScrubberDesignStandard(standardName, equipment);
+    } else if (implementationClass == PipelineDesignStandard.class) {
+      return new PipelineDesignStandard(standardName, equipment);
+    } else if (implementationClass == CompressorDesignStandard.class) {
+      return new CompressorDesignStandard(standardName, equipment);
+    } else if (implementationClass == MaterialPlateDesignStandard.class) {
+      return new MaterialPlateDesignStandard(standardName, equipment);
+    } else if (implementationClass == MaterialPipeDesignStandard.class) {
+      return new MaterialPipeDesignStandard(standardName, equipment);
+    } else if (implementationClass == ValveDesignStandard.class) {
+      return new ValveDesignStandard(standardName, equipment);
+    }
+    return new DesignStandard(standardName, equipment);
+  }
+
+  /**
+   * Get the class selected by the category-based standards factory.
+   *
+   * <p>
+   * A mapping to {@link DesignStandard} means that the registry only creates a metadata holder; it
+   * does not imply that the named standard has an executable calculation. Use
+   * {@link StandardSupportAudit#getSupport(StandardType)} to inspect the implementation evidence.
+   * </p>
+   *
+   * @param standardType standard to inspect
+   * @return class selected by {@link #createStandard(StandardType, MechanicalDesign)}
+   * @throws IllegalArgumentException if {@code standardType} is null
+   */
+  public static Class<? extends DesignStandard> getMappedImplementationClass(StandardType standardType) {
+    if (standardType == null) {
+      throw new IllegalArgumentException("standardType cannot be null");
+    }
+
+    String category = standardType.getDesignStandardCategory();
     switch (category) {
     case "pressure vessel design code":
-      return new PressureVesselDesignStandard(standardName, equipment);
-
+      return PressureVesselDesignStandard.class;
     case "separator process design":
-      return new SeparatorDesignStandard(standardName, equipment);
-
+      return SeparatorDesignStandard.class;
     case "gas scrubber process design":
-      return new GasScrubberDesignStandard(standardName, equipment);
-
+      return GasScrubberDesignStandard.class;
     case "pipeline design codes":
-      return new PipelineDesignStandard(standardName, equipment);
-
+      return PipelineDesignStandard.class;
     case "compressor design codes":
-      return new CompressorDesignStandard(standardName, equipment);
-
+      return CompressorDesignStandard.class;
     case "material plate design codes":
-      return new MaterialPlateDesignStandard(standardName, equipment);
-
+      return MaterialPlateDesignStandard.class;
     case "material pipe design codes":
-      return new MaterialPipeDesignStandard(standardName, equipment);
-
+      return MaterialPipeDesignStandard.class;
     case "valve design codes":
-      return new ValveDesignStandard(standardName, equipment);
-
+      return ValveDesignStandard.class;
     default:
-      // Return base DesignStandard for unknown categories
-      return new DesignStandard(standardName, equipment);
+      return DesignStandard.class;
     }
   }
 

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupport.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupport.java
@@ -1,0 +1,75 @@
+package neqsim.process.mechanicaldesign.designstandards;
+
+/**
+ * Immutable description of NeqSim's implementation support for one {@link StandardType}.
+ */
+public final class StandardSupport {
+  private final StandardType standardType;
+  private final StandardSupportLevel supportLevel;
+  private final String registryImplementation;
+  private final String calculationImplementation;
+  private final String limitation;
+
+  /**
+   * Create a standards-support description.
+   *
+   * @param standardType catalogued standard
+   * @param supportLevel implementation evidence level
+   * @param registryImplementation class selected by {@link StandardRegistry}
+   * @param calculationImplementation calculation path that provides the stated support
+   * @param limitation concise implementation boundary
+   */
+  StandardSupport(StandardType standardType, StandardSupportLevel supportLevel,
+      String registryImplementation, String calculationImplementation, String limitation) {
+    this.standardType = standardType;
+    this.supportLevel = supportLevel;
+    this.registryImplementation = registryImplementation;
+    this.calculationImplementation = calculationImplementation;
+    this.limitation = limitation;
+  }
+
+  /**
+   * Get the catalogued standard.
+   *
+   * @return standard type
+   */
+  public StandardType getStandardType() {
+    return standardType;
+  }
+
+  /**
+   * Get the implementation evidence level.
+   *
+   * @return support level
+   */
+  public StandardSupportLevel getSupportLevel() {
+    return supportLevel;
+  }
+
+  /**
+   * Get the class selected by the generic standards factory.
+   *
+   * @return simple class name
+   */
+  public String getRegistryImplementation() {
+    return registryImplementation;
+  }
+
+  /**
+   * Get the calculation path that provides the stated support.
+   *
+   * @return implementation name, or {@code None} when only metadata is available
+   */
+  public String getCalculationImplementation() {
+    return calculationImplementation;
+  }
+
+  /**
+   * Get the concise implementation boundary.
+   *
+   * @return limitation text
+   */
+  public String getLimitation() {
+    return limitation;
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupport.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupport.java
@@ -19,8 +19,8 @@ public final class StandardSupport {
    * @param calculationImplementation calculation path that provides the stated support
    * @param limitation concise implementation boundary
    */
-  StandardSupport(StandardType standardType, StandardSupportLevel supportLevel,
-      String registryImplementation, String calculationImplementation, String limitation) {
+  StandardSupport(StandardType standardType, StandardSupportLevel supportLevel, String registryImplementation,
+      String calculationImplementation, String limitation) {
     this.standardType = standardType;
     this.supportLevel = supportLevel;
     this.registryImplementation = registryImplementation;

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
@@ -1,0 +1,141 @@
+package neqsim.process.mechanicaldesign.designstandards;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Produces an auditable view of the calculations behind standards catalogued by NeqSim.
+ *
+ * <p>
+ * This class reports current implementation evidence only. It does not assess or reproduce the
+ * contents of the published standards.
+ * </p>
+ */
+public final class StandardSupportAudit {
+  private static final String NO_CALCULATION = "None";
+
+  private StandardSupportAudit() {
+    // Utility class.
+  }
+
+  /**
+   * Get implementation support for one standard.
+   *
+   * @param standardType standard to inspect
+   * @return support description
+   * @throws IllegalArgumentException if {@code standardType} is null
+   */
+  public static StandardSupport getSupport(StandardType standardType) {
+    if (standardType == null) {
+      throw new IllegalArgumentException("standardType cannot be null");
+    }
+
+    String registryImplementation = StandardRegistry.getMappedImplementationClass(standardType).getSimpleName();
+
+    switch (standardType) {
+    case API_610:
+      return new StandardSupport(standardType, StandardSupportLevel.SCREENING, registryImplementation,
+          "PumpApi610DesignCalculator",
+          "API 610 screening is available through PumpMechanicalDesign but is not selected by StandardRegistry.");
+    case API_650:
+    case API_620:
+      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation,
+          NO_CALCULATION,
+          "The registry maps this tank standard to a separator-oriented pressure-vessel class; "
+              + "no tank-code calculation is implemented.");
+    case API_660:
+    case API_661:
+    case ISO_16812:
+      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation,
+          NO_CALCULATION, "No standard-specific heat-exchanger mechanical calculation is connected.");
+    case API_521:
+    case API_526:
+      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation,
+          NO_CALCULATION,
+          "The mapped valve class does not implement relief-system or relief-valve standard calculations.");
+    default:
+      return getCategorySupport(standardType, registryImplementation);
+    }
+  }
+
+  /**
+   * Get support descriptions for every catalogued standard.
+   *
+   * @return immutable list in {@link StandardType} declaration order
+   */
+  public static List<StandardSupport> getAllSupport() {
+    List<StandardSupport> result = new ArrayList<StandardSupport>();
+    for (StandardType standardType : StandardType.values()) {
+      result.add(getSupport(standardType));
+    }
+    return Collections.unmodifiableList(result);
+  }
+
+  /**
+   * Generate the Markdown table published in the mechanical-design standards guide.
+   *
+   * @return generated Markdown table
+   */
+  public static String generateMarkdownTable() {
+    StringBuilder table = new StringBuilder();
+    table.append("| Standard | Edition metadata | Category | Registry factory | Calculation path "
+        + "| Maturity | Boundary |\n");
+    table.append("| --- | --- | --- | --- | --- | --- | --- |\n");
+
+    for (StandardSupport support : getAllSupport()) {
+      StandardType standardType = support.getStandardType();
+      table.append("| ").append(escapeMarkdown(standardType.getCode())).append(" | ")
+          .append(escapeMarkdown(standardType.getDefaultVersion())).append(" | ")
+          .append(escapeMarkdown(standardType.getDesignStandardCategory())).append(" | ")
+          .append(escapeMarkdown(support.getRegistryImplementation())).append(" | ")
+          .append(escapeMarkdown(support.getCalculationImplementation())).append(" | ")
+          .append(support.getSupportLevel().name()).append(" | ")
+          .append(escapeMarkdown(support.getLimitation())).append(" |\n");
+    }
+    return table.toString();
+  }
+
+  private static StandardSupport getCategorySupport(StandardType standardType,
+      String registryImplementation) {
+    String category = standardType.getDesignStandardCategory();
+
+    if ("pressure vessel design code".equals(category)) {
+      return screening(standardType, registryImplementation,
+          "Generic thin-wall separator screening only; edition-specific clauses and complete "
+              + "vessel checks are not implemented.");
+    }
+    if ("separator process design".equals(category)) {
+      return screening(standardType, registryImplementation,
+          "Preliminary K-factor and sizing inputs only; standard-specific requirements are not "
+              + "independently validated.");
+    }
+    if ("pipeline design codes".equals(category)) {
+      return screening(standardType, registryImplementation,
+          "Preliminary category screening with fixed fallback values; not a complete "
+              + "edition-specific wall-thickness calculation.");
+    }
+    if ("compressor design codes".equals(category)) {
+      return screening(standardType, registryImplementation,
+          "Preliminary compressor-factor screening only; package and vendor requirements are not implemented.");
+    }
+    if ("material plate design codes".equals(category)
+        || "material pipe design codes".equals(category)) {
+      return screening(standardType, registryImplementation,
+          "Material-property lookup only; material selection, qualification, and code acceptance are not implemented.");
+    }
+
+    return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation,
+        NO_CALCULATION, "No category-specific calculation is connected.");
+  }
+
+  private static StandardSupport screening(StandardType standardType, String implementation,
+      String limitation) {
+    return new StandardSupport(standardType, StandardSupportLevel.SCREENING, implementation,
+        implementation, limitation);
+  }
+
+  private static String escapeMarkdown(String value) {
+    return value == null ? "" : value.replace("|", "\\|").replace("\n", " ");
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
@@ -8,8 +8,8 @@ import java.util.List;
  * Produces an auditable view of the calculations behind standards catalogued by NeqSim.
  *
  * <p>
- * This class reports current implementation evidence only. It does not assess or reproduce the
- * contents of the published standards.
+ * This class reports current implementation evidence only. It does not assess or reproduce the contents of the
+ * published standards.
  * </p>
  */
 public final class StandardSupportAudit {
@@ -40,19 +40,17 @@ public final class StandardSupportAudit {
           "API 610 screening is available through PumpMechanicalDesign but is not selected by StandardRegistry.");
     case API_650:
     case API_620:
-      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation,
-          NO_CALCULATION,
+      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation, NO_CALCULATION,
           "The registry maps this tank standard to a separator-oriented pressure-vessel class; "
               + "no tank-code calculation is implemented.");
     case API_660:
     case API_661:
     case ISO_16812:
-      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation,
-          NO_CALCULATION, "No standard-specific heat-exchanger mechanical calculation is connected.");
+      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation, NO_CALCULATION,
+          "No standard-specific heat-exchanger mechanical calculation is connected.");
     case API_521:
     case API_526:
-      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation,
-          NO_CALCULATION,
+      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation, NO_CALCULATION,
           "The mapped valve class does not implement relief-system or relief-valve standard calculations.");
     default:
       return getCategorySupport(standardType, registryImplementation);
@@ -90,14 +88,13 @@ public final class StandardSupportAudit {
           .append(escapeMarkdown(standardType.getDesignStandardCategory())).append(" | ")
           .append(escapeMarkdown(support.getRegistryImplementation())).append(" | ")
           .append(escapeMarkdown(support.getCalculationImplementation())).append(" | ")
-          .append(support.getSupportLevel().name()).append(" | ")
-          .append(escapeMarkdown(support.getLimitation())).append(" |\n");
+          .append(support.getSupportLevel().name()).append(" | ").append(escapeMarkdown(support.getLimitation()))
+          .append(" |\n");
     }
     return table.toString();
   }
 
-  private static StandardSupport getCategorySupport(StandardType standardType,
-      String registryImplementation) {
+  private static StandardSupport getCategorySupport(StandardType standardType, String registryImplementation) {
     String category = standardType.getDesignStandardCategory();
 
     if ("pressure vessel design code".equals(category)) {
@@ -119,20 +116,18 @@ public final class StandardSupportAudit {
       return screening(standardType, registryImplementation,
           "Preliminary compressor-factor screening only; package and vendor requirements are not implemented.");
     }
-    if ("material plate design codes".equals(category)
-        || "material pipe design codes".equals(category)) {
+    if ("material plate design codes".equals(category) || "material pipe design codes".equals(category)) {
       return screening(standardType, registryImplementation,
           "Material-property lookup only; material selection, qualification, and code acceptance are not implemented.");
     }
 
-    return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation,
-        NO_CALCULATION, "No category-specific calculation is connected.");
+    return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation, NO_CALCULATION,
+        "No category-specific calculation is connected.");
   }
 
-  private static StandardSupport screening(StandardType standardType, String implementation,
-      String limitation) {
-    return new StandardSupport(standardType, StandardSupportLevel.SCREENING, implementation,
-        implementation, limitation);
+  private static StandardSupport screening(StandardType standardType, String implementation, String limitation) {
+    return new StandardSupport(standardType, StandardSupportLevel.SCREENING, implementation, implementation,
+        limitation);
   }
 
   private static String escapeMarkdown(String value) {

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportLevel.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportLevel.java
@@ -4,8 +4,8 @@ package neqsim.process.mechanicaldesign.designstandards;
  * Evidence level for a standard listed by the NeqSim mechanical-design framework.
  *
  * <p>
- * The level describes NeqSim's implementation evidence. It does not describe the authority of the
- * published standard and must not be interpreted as design certification.
+ * The level describes NeqSim's implementation evidence. It does not describe the authority of the published standard
+ * and must not be interpreted as design certification.
  * </p>
  */
 public enum StandardSupportLevel {

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportLevel.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportLevel.java
@@ -1,0 +1,23 @@
+package neqsim.process.mechanicaldesign.designstandards;
+
+/**
+ * Evidence level for a standard listed by the NeqSim mechanical-design framework.
+ *
+ * <p>
+ * The level describes NeqSim's implementation evidence. It does not describe the authority of the
+ * published standard and must not be interpreted as design certification.
+ * </p>
+ */
+public enum StandardSupportLevel {
+  /** Metadata and equipment applicability are catalogued, but no standard calculation is exposed. */
+  CATALOGUED,
+
+  /** A preliminary engineering calculation is available with stated limitations. */
+  SCREENING,
+
+  /** The stated calculation range has independent numerical validation. */
+  VALIDATED,
+
+  /** A controlled implementation and evidence package has been released for a stated use. */
+  QUALIFIED
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
@@ -1,0 +1,89 @@
+package neqsim.process.mechanicaldesign.designstandards;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Tests the published implementation evidence for catalogued design standards. */
+class StandardSupportAuditTest {
+  private static final String MATRIX_BEGIN = "<!-- BEGIN GENERATED STANDARD SUPPORT MATRIX -->";
+  private static final String MATRIX_END = "<!-- END GENERATED STANDARD SUPPORT MATRIX -->";
+
+  @Test
+  void testEveryStandardHasSupportInformation() {
+    List<StandardSupport> support = StandardSupportAudit.getAllSupport();
+
+    assertEquals(StandardType.values().length, support.size());
+    for (int index = 0; index < StandardType.values().length; index++) {
+      assertEquals(StandardType.values()[index], support.get(index).getStandardType());
+    }
+  }
+
+  @Test
+  void testEvidenceLevelsExposeCurrentImplementationBoundary() {
+    StandardSupport pumpSupport = StandardSupportAudit.getSupport(StandardType.API_610);
+    assertEquals(StandardSupportLevel.SCREENING, pumpSupport.getSupportLevel());
+    assertEquals("DesignStandard", pumpSupport.getRegistryImplementation());
+    assertEquals("PumpApi610DesignCalculator", pumpSupport.getCalculationImplementation());
+
+    assertEquals(StandardSupportLevel.CATALOGUED,
+        StandardSupportAudit.getSupport(StandardType.API_660).getSupportLevel());
+    assertEquals(StandardSupportLevel.CATALOGUED,
+        StandardSupportAudit.getSupport(StandardType.API_650).getSupportLevel());
+    assertEquals(StandardSupportLevel.CATALOGUED,
+        StandardSupportAudit.getSupport(StandardType.API_521).getSupportLevel());
+    assertEquals(StandardSupportLevel.SCREENING,
+        StandardSupportAudit.getSupport(StandardType.ASME_VIII_DIV1).getSupportLevel());
+    assertEquals(StandardSupportLevel.SCREENING,
+        StandardSupportAudit.getSupport(StandardType.API_12J).getSupportLevel());
+  }
+
+  @Test
+  void testFactoryMappingCanBeInspectedWithoutCreatingStandard() {
+    assertEquals(PressureVesselDesignStandard.class,
+        StandardRegistry.getMappedImplementationClass(StandardType.ASME_VIII_DIV1));
+    assertEquals(SeparatorDesignStandard.class,
+        StandardRegistry.getMappedImplementationClass(StandardType.API_12J));
+    assertEquals(DesignStandard.class,
+        StandardRegistry.getMappedImplementationClass(StandardType.API_610));
+    assertEquals(DesignStandard.class,
+        StandardRegistry.getMappedImplementationClass(StandardType.API_660));
+    assertThrows(IllegalArgumentException.class,
+        () -> StandardRegistry.getMappedImplementationClass(null));
+  }
+
+  @Test
+  void testNullStandardIsRejected() {
+    assertThrows(IllegalArgumentException.class, () -> StandardSupportAudit.getSupport(null));
+  }
+
+  @Test
+  void testGeneratedMatrixContainsEveryStandard() {
+    String table = StandardSupportAudit.generateMarkdownTable();
+
+    for (StandardType standardType : StandardType.values()) {
+      assertTrue(table.contains("| " + standardType.getCode() + " |"));
+    }
+  }
+
+  @Test
+  void testPublishedMatrixMatchesGeneratedAudit() throws IOException {
+    Path documentation = Paths.get("docs", "process", "mechanical_design_standards.md");
+    String contents = new String(Files.readAllBytes(documentation), StandardCharsets.UTF_8);
+    int begin = contents.indexOf(MATRIX_BEGIN);
+    int end = contents.indexOf(MATRIX_END);
+
+    assertTrue(begin >= 0, "Generated matrix start marker is missing");
+    assertTrue(end > begin, "Generated matrix end marker is missing");
+
+    String published = contents.substring(begin + MATRIX_BEGIN.length(), end).trim();
+    assertEquals(StandardSupportAudit.generateMarkdownTable().trim(), published);
+  }
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
@@ -70,6 +70,11 @@ class StandardSupportAuditTest {
   }
 
   @Test
+  void testLineEndingNormalization() {
+    assertEquals("header\nrow\n", normalizeLineEndings("header\r\nrow\r"));
+  }
+
+  @Test
   void testPublishedMatrixMatchesGeneratedAudit() throws IOException {
     Path documentation = Paths.get("docs", "process", "mechanical_design_standards.md");
     String contents = new String(Files.readAllBytes(documentation), StandardCharsets.UTF_8);
@@ -79,7 +84,12 @@ class StandardSupportAuditTest {
     assertTrue(begin >= 0, "Generated matrix start marker is missing");
     assertTrue(end > begin, "Generated matrix end marker is missing");
 
-    String published = contents.substring(begin + MATRIX_BEGIN.length(), end).trim();
-    assertEquals(StandardSupportAudit.generateMarkdownTable().trim(), published);
+    String published = normalizeLineEndings(contents.substring(begin + MATRIX_BEGIN.length(), end)).trim();
+    String generated = normalizeLineEndings(StandardSupportAudit.generateMarkdownTable()).trim();
+    assertEquals(generated, published);
+  }
+
+  private static String normalizeLineEndings(String value) {
+    return value.replace("\r\n", "\n").replace('\r', '\n');
   }
 }

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
@@ -49,14 +49,10 @@ class StandardSupportAuditTest {
   void testFactoryMappingCanBeInspectedWithoutCreatingStandard() {
     assertEquals(PressureVesselDesignStandard.class,
         StandardRegistry.getMappedImplementationClass(StandardType.ASME_VIII_DIV1));
-    assertEquals(SeparatorDesignStandard.class,
-        StandardRegistry.getMappedImplementationClass(StandardType.API_12J));
-    assertEquals(DesignStandard.class,
-        StandardRegistry.getMappedImplementationClass(StandardType.API_610));
-    assertEquals(DesignStandard.class,
-        StandardRegistry.getMappedImplementationClass(StandardType.API_660));
-    assertThrows(IllegalArgumentException.class,
-        () -> StandardRegistry.getMappedImplementationClass(null));
+    assertEquals(SeparatorDesignStandard.class, StandardRegistry.getMappedImplementationClass(StandardType.API_12J));
+    assertEquals(DesignStandard.class, StandardRegistry.getMappedImplementationClass(StandardType.API_610));
+    assertEquals(DesignStandard.class, StandardRegistry.getMappedImplementationClass(StandardType.API_660));
+    assertThrows(IllegalArgumentException.class, () -> StandardRegistry.getMappedImplementationClass(null));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- add `StandardSupportLevel`, `StandardSupport`, and `StandardSupportAudit` to distinguish catalog metadata from executable engineering calculations
- expose the class selected by `StandardRegistry` without constructing equipment or reading the design database
- classify all 32 current `StandardType` entries: 25 preliminary screening entries and 7 catalog-only entries; none are presented as validated or qualified
- publish a generated support matrix covering edition metadata, category, registry mapping, calculation path, maturity, and the current engineering boundary
- add regression coverage that requires every standard to be represented and keeps the published matrix identical to the generated source

## Why

The existing catalog and guide used “supported” for both standard metadata and numerical implementations. Several catalog entries map only to the base `DesignStandard`, while others map to generic category calculators that do not implement an edition-specific conformity assessment. The previous guide also contained stale or nonexistent API examples.

This change makes the current evidence explicit before later PRs introduce typed editions, fail-closed selection, and qualified equipment kernels.

## Important findings made explicit

- API 610 screening exists through `PumpApi610DesignCalculator`, but `StandardRegistry` currently selects only the base `DesignStandard`.
- API 650/620 are catalogued but map to a separator-oriented pressure-vessel class; no tank-code calculation is claimed.
- API 660/661 and ISO 16812 have no connected standard-specific exchanger calculation.
- API 521/526 map to `ValveDesignStandard`, which does not implement the named relief calculations.
- existing vessel, piping, separator, compressor, and material paths are identified as preliminary screening with their limitations.

## Compatibility and numerical behavior

- the existing `createStandard(...)` behavior and returned classes are preserved
- no equipment sizing equation, default, serialization field, or process-simulation result is changed
- unsupported selections do not fail yet; that behavior belongs in the follow-up typed-standards PR
- the matrix describes NeqSim implementation evidence and does not reproduce standards content or claim certification

## Validation

Completed locally:

- Java 8 production-source compilation for the changed registry and audit model using the JDK compiler module and isolated dependency stubs
- Java 8 test-source compilation for `StandardSupportAuditTest`
- executable generation of the 32-row Markdown matrix
- byte-for-byte comparison of the generated matrix with the published documentation block
- verified the existing documentation index already references the updated page and the new internal engineering link exists

Hosted evidence:

- the repository Spotless workflow produced an exact formatter patch, which was applied mechanically to all reported files
- documentation search and PaperLab passed on the initial head
- the complete hosted validation matrix is rerunning on the formatted head

The local environment cannot resolve Maven plugins from Maven Central, so no local Maven, Javadoc, or full-suite pass is claimed.

## Next programme step

After this truth layer passes CI and review, the next PR will introduce typed standard identity/edition/applicability metadata and fail-closed selection for catalog-only entries while retaining a legacy compatibility mode.