### PR TITLE
test: fix pump documentation JSON regression

### DIFF
--- a/src/test/java/neqsim/process/mechanicaldesign/pump/PumpDocumentationTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/pump/PumpDocumentationTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
 
 import neqsim.process.equipment.pump.Pump;
@@ -62,6 +64,7 @@ public class PumpDocumentationTest {
     PumpApi610DesignCalculator assessment = design.getApi610Assessment();
     PumpApi610DesignCalculator.AssessmentStatus status = assessment.getAssessmentStatus();
     String responseJson = design.getResponse().toJson();
+    JsonObject responseObject = JsonParser.parseString(responseJson).getAsJsonObject();
 
     assertNotNull(status);
     assertEquals(DataSource.VENDOR_CURVE, assessment.getBepSource());
@@ -71,7 +74,7 @@ public class PumpDocumentationTest {
     assertTrue(assessment.getSelectedDriverPowerKw() > powerKw);
     assertTrue(assessment.getRequiredCasingPressureBara() <= 25.0);
     assertFalse(assessment.getChecks().isEmpty());
-    assertTrue(responseJson.contains("\"api610Screening\""));
-    assertTrue(responseJson.contains("\"api610TypeCode\":\"OH2\""));
+    assertTrue(responseObject.has("api610Screening"));
+    assertEquals("OH2", responseObject.get("api610TypeCode").getAsString());
   }
 }


### PR DESCRIPTION
## Campaign batch

D012 follow-up for #2499. This repairs the final regression exposed after merged PR #2541; it does not begin D013.

## Confirmed defect and severity

- **Medium — executable documentation regression was coupled to JSON whitespace.**
- The Windows Java 21 matrix for #2541 ran 10,554 tests with one failure at `PumpDocumentationTest.java:75`.
- Every preceding operating-point, vendor-head, NPSH, cavitation, API 610, and structured-screening assertion passed. The failing assertion expected the compact substring `"api610TypeCode":"OH2"`.
- `MechanicalDesignResponse.toJson()` deliberately calls Gson `setPrettyPrinting()`, so the valid response contains formatting whitespace. This made the regression depend on presentation rather than JSON structure.

## Fix

- Parse the response with the repository's existing Gson `JsonParser.parseString` API.
- Assert that the `api610Screening` field exists.
- Assert the `api610TypeCode` value structurally as `OH2`.
- No production code, documentation text, equations, links, navigation, or public API changed.

## Frozen paths

- `src/test/java/neqsim/process/mechanicaldesign/pump/PumpDocumentationTest.java`

## Validation evidence

- Current `master` base: `1ef59b9b0a2f0842054bf6569c55387cafb409a7`.
- Serializer audit: `MechanicalDesignResponse.toJson()` uses pretty-printing.
- Schema audit: `PumpMechanicalDesignResponse` exposes top-level `api610TypeCode` and `api610Screening`.
- Compatibility audit: current source already uses `JsonParser.parseString`.
- Prior hosted execution reached the failed line only after all engineering assertions and the `api610Screening` assertion passed.
- Local review was static because this workspace contains the isolated D012 artifact rather than a complete Maven checkout; no local JUnit pass is claimed.
- Hosted pre-commit, Spotless, Javadoc, CodeQL, Java-change detection, and agent-reference checks pass. Windows Java 21 completed 10,554 tests with 0 failures, 0 errors, and 212 skipped; `PumpDocumentationTest` passed 1/1. Ubuntu completed 10,754 tests with one unrelated existing `LNGProcessBuilderTest.testSmrRouteRunsAndReportsPerformance` cryogenic-exchanger error.

## Rendering, links, and exclusions

- No documentation, Markdown, Jekyll, equations, images, notebooks, internal/external links, or rendered pages changed; no render or link result is claimed or required for this one-file regression repair.
- D013 remains excluded until D012's hosted checks are clean and merged.
- No production change, direct `master` push, merge, auto-merge, or test weakening is included.

## Expected before/after

- Before: valid pretty-printed response fails a compact-whitespace substring assertion.
- After: the regression validates the JSON field and value independently of presentation formatting.
