### PR TITLE
fix: limit DLE monotonicity QC to saturated region

### DIFF
--- a/src/main/java/neqsim/pvtsimulation/simulation/DifferentialLiberation.java
+++ b/src/main/java/neqsim/pvtsimulation/simulation/DifferentialLiberation.java
@@ -316,8 +316,11 @@ public class DifferentialLiberation extends BasePVTsimulation {
     }
 
     for (int i = 1; i < Bo.length; i++) {
-      // Bo should decrease as pressure decreases (pressures array is typically decreasing)
-      if (pressures[i] < pressures[i - 1] && Bo[i] > Bo[i - 1]) {
+      boolean bothPointsBelowSaturation = pressures[i] <= saturationPressure
+          && pressures[i - 1] <= saturationPressure;
+      // Bo should decrease as pressure decreases below saturation.
+      if (bothPointsBelowSaturation && pressures[i] < pressures[i - 1]
+          && Bo[i] > Bo[i - 1]) {
         return false;
       }
     }
@@ -388,8 +391,11 @@ public class DifferentialLiberation extends BasePVTsimulation {
     }
 
     for (int i = 1; i < oilDensity.length; i++) {
-      // Density should increase as pressure decreases (gas liberates)
-      if (pressures[i] < pressures[i - 1] && oilDensity[i] < oilDensity[i - 1]) {
+      boolean bothPointsBelowSaturation = pressures[i] <= saturationPressure
+          && pressures[i - 1] <= saturationPressure;
+      // Density should increase as pressure decreases below saturation.
+      if (bothPointsBelowSaturation && pressures[i] < pressures[i - 1]
+          && oilDensity[i] < oilDensity[i - 1]) {
         return false;
       }
     }

--- a/src/main/java/neqsim/pvtsimulation/simulation/DifferentialLiberation.java
+++ b/src/main/java/neqsim/pvtsimulation/simulation/DifferentialLiberation.java
@@ -316,11 +316,9 @@ public class DifferentialLiberation extends BasePVTsimulation {
     }
 
     for (int i = 1; i < Bo.length; i++) {
-      boolean bothPointsBelowSaturation = pressures[i] <= saturationPressure
-          && pressures[i - 1] <= saturationPressure;
+      boolean bothPointsBelowSaturation = pressures[i] <= saturationPressure && pressures[i - 1] <= saturationPressure;
       // Bo should decrease as pressure decreases below saturation.
-      if (bothPointsBelowSaturation && pressures[i] < pressures[i - 1]
-          && Bo[i] > Bo[i - 1]) {
+      if (bothPointsBelowSaturation && pressures[i] < pressures[i - 1] && Bo[i] > Bo[i - 1]) {
         return false;
       }
     }
@@ -391,11 +389,9 @@ public class DifferentialLiberation extends BasePVTsimulation {
     }
 
     for (int i = 1; i < oilDensity.length; i++) {
-      boolean bothPointsBelowSaturation = pressures[i] <= saturationPressure
-          && pressures[i - 1] <= saturationPressure;
+      boolean bothPointsBelowSaturation = pressures[i] <= saturationPressure && pressures[i - 1] <= saturationPressure;
       // Density should increase as pressure decreases below saturation.
-      if (bothPointsBelowSaturation && pressures[i] < pressures[i - 1]
-          && oilDensity[i] < oilDensity[i - 1]) {
+      if (bothPointsBelowSaturation && pressures[i] < pressures[i - 1] && oilDensity[i] < oilDensity[i - 1]) {
         return false;
       }
     }

--- a/src/test/java/neqsim/pvtsimulation/simulation/DifferentialLiberationTest.java
+++ b/src/test/java/neqsim/pvtsimulation/simulation/DifferentialLiberationTest.java
@@ -1,6 +1,7 @@
 package neqsim.pvtsimulation.simulation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -60,5 +61,8 @@ public class DifferentialLiberationTest {
     assertEquals(1.0533007759, differentialLiberation.getBo()[pressures.length - 1], 0.001);
     assertEquals(0.0, differentialLiberation.getRs()[pressures.length - 1], 0.001);
     assertEquals(805.6468027140055, differentialLiberation.getOilDensity()[pressures.length - 1], 0.001);
+    assertTrue(differentialLiberation.validateBoMonotonicity());
+    assertTrue(differentialLiberation.validateRsMonotonicity());
+    assertTrue(differentialLiberation.validateOilDensityMonotonicity());
   }
 }


### PR DESCRIPTION
## Summary

- restrict oil formation-volume-factor monotonicity checks to pairs at or below saturation
- restrict oil-density monotonicity checks to the same saturated-oil region
- add regression assertions to the existing differential-liberation fixture

## Problem

The QC methods document below-saturation behavior but currently evaluate the full pressure schedule. For the existing reservoir-oil fixture, physically correct undersaturated expansion causes $B_o$ to rise and oil density to fall as pressure declines toward the bubble point. The current methods therefore return false even though the below-bubble trends are correct.

## Reproduction

Using the existing `DifferentialLiberationTest` composition at 97.5 °C with pressures from 351.4 to 1 bara:

- saturation pressure: 193.19 bara in the DLE driver
- `validateBoMonotonicity()`: false before this change
- `validateOilDensityMonotonicity()`: false before this change
- `validateRsMonotonicity()`: true

The changed methods now evaluate only adjacent points where both pressures are at or below saturation.

## Validation

- reproduced against public PyPI NeqSim 3.16.0 with the repository regression fixture
- the patched Java source is syntactically focused and the existing test now asserts all three relevant QC methods
- hosted Java and formatting checks are requested through this draft PR

A local Maven execution could not download the newly bumped Maven Enforcer plugin because Maven Central DNS was unavailable in the sandbox; no test result is claimed locally.