### PR TITLE
Fix solid-phase lookup in freezing-point flash

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/FreezingPointTemperatureFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/FreezingPointTemperatureFlash.java
@@ -6,6 +6,7 @@ import java.io.PrintWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.thermo.ThermodynamicConstantsInterface;
+import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -49,12 +50,33 @@ public class FreezingPointTemperatureFlash extends ConstantDutyTemperatureFlash
   }
 
   /**
+   * Returns the configured solid phase, including inactive phases retained in the system phase array.
+   *
+   * <p>A fluid-only TP flash reduces {@code getNumberOfPhases()}, but the configured solid phase
+   * remains available in {@code getPhases()}. Searching only active phases therefore fails during a
+   * freezing-point iteration.
+   *
+   * @return configured solid phase
+   * @throws IllegalStateException if solid-phase checking has not been enabled
+   */
+  private PhaseInterface getConfiguredSolidPhase() {
+    for (PhaseInterface phase : system.getPhases()) {
+      if (phase != null && phase.getType() == PhaseType.SOLID) {
+        return phase;
+      }
+    }
+    throw new IllegalStateException(
+        "Solid phase is not configured. Call setSolidPhaseCheck before the freezing-point flash.");
+  }
+
+  /**
    * calcFunc.
    *
    * @return a double
    */
   public double calcFunc() {
     ThermodynamicOperations ops = new ThermodynamicOperations(system);
+    PhaseInterface solidPhase = getConfiguredSolidPhase();
     // double deriv = 0, funkOld = 0;
     double funk = 0;
     double SolidFugCoeff = 0.0;
@@ -64,7 +86,7 @@ public class FreezingPointTemperatureFlash extends ConstantDutyTemperatureFlash
       // logger.info("Checking all the components " + k);
       if (system.getPhase(0).getComponent(k).doSolidCheck()) {
         ops.TPflash(false);
-        SolidFugCoeff = system.getPhase(PhaseType.SOLID).getComponent(k).fugcoef(system.getPhase(PhaseType.SOLID));
+        SolidFugCoeff = solidPhase.getComponent(k).fugcoef(solidPhase);
         funk = system.getPhase(0).getComponent(k).getz();
         for (int i = 0; i < system.getNumberOfPhases(); i++) {
           funk -= system.getPhase(i).getBeta() * SolidFugCoeff
@@ -79,6 +101,7 @@ public class FreezingPointTemperatureFlash extends ConstantDutyTemperatureFlash
   @Override
   public void run() {
     ThermodynamicOperations ops = new ThermodynamicOperations(system);
+    PhaseInterface solidPhase = getConfiguredSolidPhase();
     int iterations = 0;
     int maxNumberOfIterations = 100;
     double deriv = 0;
@@ -114,7 +137,7 @@ public class FreezingPointTemperatureFlash extends ConstantDutyTemperatureFlash
           iterations++;
           // oldPhaseType = system.getPhase(0).getType();
           ops.TPflash(false);
-          SolidFugCoeff = system.getPhase(PhaseType.SOLID).getComponent(k).fugcoef(system.getPhase(PhaseType.SOLID));
+          SolidFugCoeff = solidPhase.getComponent(k).fugcoef(solidPhase);
           funk = system.getPhase(0).getComponent(k).getz();
           for (int i = 0; i < system.getNumberOfPhases(); i++) {
             funk -= system.getPhase(i).getBeta() * SolidFugCoeff

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/FreezingPointTemperatureFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/FreezingPointTemperatureFlash.java
@@ -52,9 +52,9 @@ public class FreezingPointTemperatureFlash extends ConstantDutyTemperatureFlash
   /**
    * Returns the configured solid phase, including inactive phases retained in the system phase array.
    *
-   * <p>A fluid-only TP flash reduces {@code getNumberOfPhases()}, but the configured solid phase
-   * remains available in {@code getPhases()}. Searching only active phases therefore fails during a
-   * freezing-point iteration.
+   * <p>
+   * A fluid-only TP flash reduces {@code getNumberOfPhases()}, but the configured solid phase remains available in
+   * {@code getPhases()}. Searching only active phases therefore fails during a freezing-point iteration.
    *
    * @return configured solid phase
    * @throws IllegalStateException if solid-phase checking has not been enabled

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/FreezingPointTemperatureFlashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/FreezingPointTemperatureFlashTest.java
@@ -1,0 +1,34 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class FreezingPointTemperatureFlashTest {
+  @Test
+  void testLNGFreezingPointFlashAfterFluidOnlyTPFlash() {
+    SystemInterface system = new SystemSrkEos(120.35, 5.0);
+    system.addComponent("CO2", 0.17);
+    system.addComponent("nitrogen", 1.1011731548);
+    system.addComponent("methane", 0.324);
+    system.addComponent("ethane", 0.274);
+    system.addComponent("propane", 0.0306);
+    system.setMixingRule(2);
+    system.setSolidPhaseCheck("CO2");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    assertDoesNotThrow(operations::freezingPointTemperatureFlash);
+
+    double freezingTemperature = system.getTemperature();
+    assertTrue(Double.isFinite(freezingTemperature));
+    assertTrue(freezingTemperature > 90.0 && freezingTemperature < 220.0);
+
+    FreezingPointTemperatureFlash flash = new FreezingPointTemperatureFlash(system);
+    double residual = assertDoesNotThrow(flash::calcFunc);
+    assertTrue(Math.abs(residual) < 1.0e-8);
+  }
+}


### PR DESCRIPTION
## Summary

- retain the configured solid phase across internal fluid-only TP flashes
- avoid `Phase with phase type SOLID not found` in `freezingPointTemperatureFlash()`
- add an LNG regression covering convergence, a finite physical temperature, and the equilibrium residual

## Root cause

`FreezingPointTemperatureFlash` called `TPflash(false)`, which reduces the active phase count to the fluid phases. It then looked up `PhaseType.SOLID` only among active phases, even though `setSolidPhaseCheck("CO2")` correctly retained the solid phase in the system phase array.

## Validation

The defect was reproduced with the existing LNG example on the public NeqSim 3.16.0 PyPI package. The added focused JUnit covers that exact configuration.

- Pre-commit checks: passed
- Spotless format patch: passed
- PaperLab replication gate: passed
- Java build, tests, and Javadoc: in progress
- CodeQL: in progress

Local Maven execution was attempted, but dependency resolution was blocked by a transient Maven Central DNS failure; hosted CI is the compilation and regression gate.