### PR TITLE
fix: include reaction heat in reactive PH flashes

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphasePHflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphasePHflash.java
@@ -16,10 +16,10 @@ import neqsim.thermodynamicoperations.BaseOperation;
  * </p>
  *
  * <p>
- * The outer loop solves: Q(T) = [H(T,P,n(T)) - H_spec] / |H_spec| = 0, where n(T) is the equilibrium composition from
- * the reactive TP flash at temperature T. The Newton update uses: dQ/d(1/T) = -T^2 * Cp_total / |H_spec|, where
- * Cp_total = (dH/dT)_P includes both sensible heat and reaction heat effects (since the equilibrium composition shifts
- * with temperature, the system Cp implicitly captures reaction enthalpy contributions via Le Chatelier's principle).
+ * The outer loop solves a thermochemical enthalpy balance. NeqSim's process-stream enthalpy uses a sensible-enthalpy
+ * reference and intentionally excludes ideal-gas formation enthalpies. A reactive flash must therefore add the species
+ * formation-enthalpy inventory to both the supplied feed enthalpy and each trial equilibrium state. The secant updates
+ * capture composition-dependent reaction heat while the first heat-capacity step supplies a robust initial estimate.
  * </p>
  *
  * <p>
@@ -90,6 +90,9 @@ public class ReactiveMultiphasePHflash extends BaseOperation {
   /** Specified enthalpy (J). */
   private double enthalpySpec;
 
+  /** Specified thermochemical enthalpy including ideal-gas formation enthalpies (J). */
+  private double thermochemicalEnthalpySpec;
+
   /** Specified entropy (J/K). If non-zero, overrides enthalpy mode. */
   private double entropySpec = 0.0;
 
@@ -129,6 +132,7 @@ public class ReactiveMultiphasePHflash extends BaseOperation {
   public ReactiveMultiphasePHflash(SystemInterface system, double enthalpySpec) {
     this.system = system;
     this.enthalpySpec = enthalpySpec;
+    this.thermochemicalEnthalpySpec = enthalpySpec + getFormationEnthalpyInventory();
     this.converged = false;
     this.outerIterations = 0;
     this.totalInnerIterations = 0;
@@ -225,7 +229,7 @@ public class ReactiveMultiphasePHflash extends BaseOperation {
    * </p>
    */
   private void solveEnthalpySpec() {
-    double absHspec = Math.abs(enthalpySpec);
+    double absHspec = Math.abs(thermochemicalEnthalpySpec);
     if (absHspec < 1.0e-10) {
       absHspec = 1.0; // Prevent division by zero for near-zero enthalpy
     }
@@ -271,7 +275,7 @@ public class ReactiveMultiphasePHflash extends BaseOperation {
         if (Math.abs(Cp) < 1.0e-20) {
           Cp = 100.0;
         }
-        Tnew = T - (system.getEnthalpy() - enthalpySpec) / Cp;
+        Tnew = T - (getThermochemicalEnthalpy() - thermochemicalEnthalpySpec) / Cp;
       } else {
         // Secant method: interpolate using two successive (T, error) pairs.
         // This naturally captures the effective dH/dT including reaction enthalpy
@@ -284,7 +288,7 @@ public class ReactiveMultiphasePHflash extends BaseOperation {
           if (Math.abs(Cp) < 1.0e-20) {
             Cp = 100.0;
           }
-          Tnew = T - (system.getEnthalpy() - enthalpySpec) / Cp;
+          Tnew = T - (getThermochemicalEnthalpy() - thermochemicalEnthalpySpec) / Cp;
         }
       }
 
@@ -329,9 +333,10 @@ public class ReactiveMultiphasePHflash extends BaseOperation {
       }
 
       logger.debug(
-          "PH iter=" + iter + " T=" + String.format("%.4f", T) + " H=" + String.format("%.4e", system.getEnthalpy())
-              + " Hspec=" + String.format("%.4e", enthalpySpec) + " err=" + String.format("%.3e", error) + " bracket=["
-              + String.format("%.2f", tLow) + "," + String.format("%.2f", tHigh) + "]");
+          "PH iter=" + iter + " T=" + String.format("%.4f", T) + " H_therm="
+              + String.format("%.4e", getThermochemicalEnthalpy()) + " Hspec_therm="
+              + String.format("%.4e", thermochemicalEnthalpySpec) + " err=" + String.format("%.3e", error)
+              + " bracket=[" + String.format("%.2f", tLow) + "," + String.format("%.2f", tHigh) + "]");
 
       // Check convergence
       if (Math.abs(error) < TOL) {
@@ -513,7 +518,36 @@ public class ReactiveMultiphasePHflash extends BaseOperation {
    * @return (H_system - H_spec) / |H_spec|
    */
   private double computeEnthalpyResidual(double absHspec) {
-    return (system.getEnthalpy() - enthalpySpec) / absHspec;
+    return (getThermochemicalEnthalpy() - thermochemicalEnthalpySpec) / absHspec;
+  }
+
+  /**
+   * Calculate the current species formation-enthalpy inventory.
+   *
+   * @return sum of n_i times the ideal-gas formation enthalpy of species i, in J
+   */
+  private double getFormationEnthalpyInventory() {
+    double formationEnthalpy = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      for (int componentIndex = 0; componentIndex < system.getPhase(phaseIndex)
+          .getNumberOfComponents(); componentIndex++) {
+        double numberOfMoles = system.getPhase(phaseIndex).getComponent(componentIndex)
+            .getNumberOfMolesInPhase();
+        double formationEnthalpyPerMole = system.getPhase(phaseIndex).getComponent(componentIndex)
+            .getIdealGasEnthalpyOfFormation();
+        formationEnthalpy += numberOfMoles * formationEnthalpyPerMole;
+      }
+    }
+    return formationEnthalpy;
+  }
+
+  /**
+   * Get sensible plus formation enthalpy for the current reactive state.
+   *
+   * @return thermochemical enthalpy in J
+   */
+  private double getThermochemicalEnthalpy() {
+    return system.getEnthalpy() + getFormationEnthalpyInventory();
   }
 
   /**
@@ -524,10 +558,8 @@ public class ReactiveMultiphasePHflash extends BaseOperation {
    * </p>
    *
    * <p>
-   * The system Cp includes both sensible heat and implicit reaction heat effects: as T changes, the reactive TP flash
-   * produces a different equilibrium composition, and the resulting Cp from init(2) reflects the full derivative dH/dT
-   * at fixed P and feed composition. For strongly exothermic/endothermic reactions (e.g., WGS, SMR), this correctly
-   * captures the coupling between equilibrium shift and enthalpy.
+   * The system Cp supplies only the initial sensible-enthalpy slope. Subsequent secant steps use complete
+   * thermochemical residuals and therefore capture equilibrium-composition shifts and reaction heat.
    * </p>
    *
    * @param absHspec absolute value of H_spec for normalization
@@ -647,8 +679,9 @@ public class ReactiveMultiphasePHflash extends BaseOperation {
     sb.append("  Inner iters:    ").append(totalInnerIterations).append("\n");
     sb.append("  Phases:         ").append(system.getNumberOfPhases()).append("\n");
     if (converged) {
-      sb.append("  H_spec:         ").append(String.format("%.4e J", enthalpySpec)).append("\n");
-      sb.append("  H_actual:       ").append(String.format("%.4e J", system.getEnthalpy())).append("\n");
+      sb.append("  H_process_spec: ").append(String.format("%.4e J", enthalpySpec)).append("\n");
+      sb.append("  H_therm_spec:   ").append(String.format("%.4e J", thermochemicalEnthalpySpec)).append("\n");
+      sb.append("  H_therm_actual: ").append(String.format("%.4e J", getThermochemicalEnthalpy())).append("\n");
     }
     return sb.toString();
   }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphaseTPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphaseTPflash.java
@@ -214,8 +214,11 @@ public class ReactiveMultiphaseTPflash extends BaseOperation {
       // Enforce effectiveMaxPhases: electrolyte CPA init may have created extra phases
       if (effectiveMaxPhases == 1 && system.getNumberOfPhases() > 1) {
         system.setNumberOfPhases(1);
-        system.setMaxNumberOfPhases(1);
         system.init(0);
+        // init(0) may restore the implementation default. Re-apply the user's
+        // one-phase limit after initialization so stability analysis cannot add
+        // a duplicate trial phase.
+        system.setMaxNumberOfPhases(1);
       }
 
       // Step 2.5: Reactive stability analysis

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphasePHflashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphasePHflashTest.java
@@ -383,4 +383,65 @@ public class ReactiveMultiphasePHflashTest {
     assertEquals(xCO2_tp, xCO2_verify, 0.02, "CO2 from PH flash temperature should match original TP flash");
     assertEquals(Hspec, H_verify, Math.abs(Hspec) * 0.01, "Enthalpy at PH flash T should match specification");
   }
+
+  /**
+   * Verify an adiabatic WGS flash from an unreacted feed.
+   *
+   * <p>
+   * The forward water-gas shift reaction is exothermic. A correct thermochemical enthalpy balance therefore raises the
+   * equilibrium temperature above the 700 K feed temperature. This regression also verifies the balance independently
+   * by adding the species formation-enthalpy inventory to NeqSim's process-stream enthalpy.
+   * </p>
+   */
+  @Test
+  public void testAdiabaticWGSIncludesFormationEnthalpy() {
+    SystemInterface system = new SystemSrkEos(700.0, 10.0);
+    system.addComponent("CO", 0.40);
+    system.addComponent("water", 0.40);
+    system.addComponent("CO2", 0.10);
+    system.addComponent("hydrogen", 0.10);
+    system.setMixingRule("classic");
+    system.setMaxNumberOfPhases(1);
+    system.setNumberOfPhases(1);
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.TPflash();
+    system.init(2);
+
+    double processEnthalpySpec = system.getEnthalpy();
+    double thermochemicalEnthalpySpec = processEnthalpySpec + getFormationEnthalpyInventory(system);
+    double feedCO2Moles = system.getPhase(0).getComponent("CO2").getNumberOfMolesInPhase();
+
+    system.setTemperature(800.0);
+    operations.reactivePHflash(processEnthalpySpec, 0);
+    system.init(2);
+
+    ReactiveMultiphasePHflash flash = (ReactiveMultiphasePHflash) operations.getOperation();
+    double thermochemicalEnthalpy = system.getEnthalpy() + getFormationEnthalpyInventory(system);
+    double equilibriumCO2Moles = system.getPhase(0).getComponent("CO2").getNumberOfMolesInPhase();
+
+    assertTrue(flash.isConverged(), "Reactive PH flash should converge");
+    assertEquals(1, system.getNumberOfPhases(), "The gas-only phase limit must be preserved");
+    assertTrue(system.getTemperature() > 700.0, "Exothermic forward reaction should heat the adiabatic outlet");
+    assertEquals(898.1, system.getTemperature(), 2.0, "Adiabatic WGS temperature should match the independent root");
+    assertTrue(equilibriumCO2Moles > feedCO2Moles, "The forward WGS reaction should form CO2");
+    assertEquals(thermochemicalEnthalpySpec, thermochemicalEnthalpy,
+        Math.abs(thermochemicalEnthalpySpec) * 1.0e-7, "Thermochemical enthalpy should close");
+  }
+
+  /** Return the species formation-enthalpy inventory in J. */
+  private double getFormationEnthalpyInventory(SystemInterface system) {
+    double formationEnthalpy = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      for (int componentIndex = 0; componentIndex < system.getPhase(phaseIndex)
+          .getNumberOfComponents(); componentIndex++) {
+        double numberOfMoles = system.getPhase(phaseIndex).getComponent(componentIndex)
+            .getNumberOfMolesInPhase();
+        double formationEnthalpyPerMole = system.getPhase(phaseIndex).getComponent(componentIndex)
+            .getIdealGasEnthalpyOfFormation();
+        formationEnthalpy += numberOfMoles * formationEnthalpyPerMole;
+      }
+    }
+    return formationEnthalpy;
+  }
 }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphaseTPflashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphaseTPflashTest.java
@@ -433,4 +433,25 @@ public class ReactiveMultiphaseTPflashTest {
       assertTrue(Gfinal <= G0 + 1e-6, "Gibbs energy should decrease: G_initial=" + G0 + ", G_final=" + Gfinal);
     }
   }
+
+  /** Verify that the public convenience API preserves an explicit one-phase limit. */
+  @Test
+  void testConvenienceMethodPreservesSinglePhaseLimit() {
+    SystemInterface system = new SystemSrkEos(700.0, 10.0);
+    system.addComponent("CO", 0.40);
+    system.addComponent("water", 0.40);
+    system.addComponent("CO2", 0.10);
+    system.addComponent("hydrogen", 0.10);
+    system.setMixingRule("classic");
+    system.setMaxNumberOfPhases(1);
+    system.setNumberOfPhases(1);
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.reactiveTPflash();
+
+    ReactiveMultiphaseTPflash flash = (ReactiveMultiphaseTPflash) operations.getOperation();
+    assertTrue(flash.isConverged(), "Reactive TP flash should converge");
+    assertEquals(1, system.getNumberOfPhases(), "The explicit one-phase limit must be preserved");
+    assertEquals(1, system.getMaxNumberOfPhases(), "Initialization must not reset the phase limit");
+  }
 }


### PR DESCRIPTION
## Summary

- preserve an explicit one-phase limit after `init(0)` in reactive TP flashes
- include species ideal-gas formation enthalpies in reactive PH energy balances
- add public-API regressions for phase-limit preservation and adiabatic water-gas shift heating

## Defects reproduced with public NeqSim 3.16.0

For a 700 K, 10 bara WGS feed containing 0.40 mol CO, 0.40 mol water, 0.10 mol CO2, and 0.10 mol hydrogen:

1. `setMaxNumberOfPhases(1)` is reset during reactive initialization. The public `ThermodynamicOperations.reactiveTPflash()` returns two phases, each with beta 1 and 1 mol, so extensive properties are doubled.
2. `reactivePHflash()` balances NeqSim's process-stream enthalpy, whose component implementation intentionally excludes ideal-gas formation enthalpy. An unreacted adiabatic feed therefore cools to about 674.47 K even though forward WGS is exothermic.

An independent thermochemical balance,

`H_therm = H_process + sum(n_i * DeltaHf_i)`,

gives an adiabatic equilibrium temperature of 898.086 K and a residual below 0.01 J when the one-phase state is enforced.

## Implementation

Ordinary process-stream enthalpy conventions are unchanged. The formation-enthalpy inventory is added only inside reactive PH residuals. The original feed inventory is captured with the supplied process enthalpy, and every trial equilibrium state is evaluated on the same thermochemical basis. Existing entropy mode and non-reactive delegation remain unchanged.

## Validation

- Added `testConvenienceMethodPreservesSinglePhaseLimit`
- Added `testAdiabaticWGSIncludesFormationEnthalpy`
- Public 3.16.0 reproduction and independent Python bisection passed
- Source and tests satisfy the repository line-length/style shape
- Local Maven execution was unavailable because this runner could not resolve Maven Central and has no `javac`; hosted CI is required before review readiness

This PR is intentionally draft until Java, Spotless, Javadoc, and CodeQL checks complete.