### PR TITLE
Add typed fail-closed design-standard selection

### DIFF
--- a/docs/process/mechanical_design_standards.md
+++ b/docs/process/mechanical_design_standards.md
@@ -63,6 +63,27 @@ the source catalog diverge.
 | PD-5500 | 2021 | pressure vessel design code | PressureVesselDesignStandard | PressureVesselDesignStandard | SCREENING | Generic thin-wall separator screening only; edition-specific clauses and complete vessel checks are not implemented. |
 <!-- END GENERATED STANDARD SUPPORT MATRIX -->
 
+## Typed standard selection
+
+New code can select an explicit edition and any project amendments without depending on the
+registry's process-wide version overrides:
+
+```java
+StandardEdition edition = StandardEdition.of(StandardType.API_12J, "8th Ed",
+    Arrays.asList("Project amendment A", "Corrigendum 1"));
+mechanicalDesign.setDesignStandard(StandardSelection.strict(edition));
+```
+
+Strict selection fails closed with a `StandardSelectionException` when the entry is catalog-only,
+its calculation is not connected to the registry, the equipment context is missing, or the
+standard is not listed for that equipment type. The exception exposes a machine-readable reason so
+applications do not need to parse its message. `StandardRegistry.assessApplicability(...)` provides
+the same applicability decision without creating a standard.
+
+`StandardSelection.legacy(...)` is available for migrations that need an explicit edition while
+retaining the permissive factory behavior. It may create a metadata-only `DesignStandard`; it does
+not add calculation support.
+
 ## How to interpret the registry
 
 `StandardRegistry.createStandard(...)` remains backward compatible. The factory class shown in the

--- a/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesign.java
@@ -33,6 +33,7 @@ import neqsim.process.mechanicaldesign.designstandards.PipelineDesignStandard;
 import neqsim.process.mechanicaldesign.designstandards.PressureVesselDesignStandard;
 import neqsim.process.mechanicaldesign.designstandards.SeparatorDesignStandard;
 import neqsim.process.mechanicaldesign.designstandards.StandardRegistry;
+import neqsim.process.mechanicaldesign.designstandards.StandardSelection;
 import neqsim.process.mechanicaldesign.designstandards.StandardType;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -1097,6 +1098,25 @@ public class MechanicalDesign implements java.io.Serializable {
     }
     DesignStandard standard = StandardRegistry.createStandard(standardType, version, this);
     String category = standardType.getDesignStandardCategory();
+    getDesignStandard().put(category, standard);
+    hasSetCompanySpecificDesignStandards = true;
+  }
+
+  /**
+   * Set a design standard from an explicit typed selection.
+   *
+   * <p>
+   * Use {@link StandardSelection#strict(StandardType)} for fail-closed selection. The existing
+   * {@link #setDesignStandard(StandardType)} overload remains legacy compatible.
+   * </p>
+   *
+   * @param selection typed edition and selection behavior
+   * @throws neqsim.process.mechanicaldesign.designstandards.StandardSelectionException if a strict
+   *         selection cannot be honored
+   */
+  public void setDesignStandard(StandardSelection selection) {
+    DesignStandard standard = StandardRegistry.createStandard(selection, this);
+    String category = selection.getStandardType().getDesignStandardCategory();
     getDesignStandard().put(category, standard);
     hasSetCompanySpecificDesignStandards = true;
   }

--- a/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesign.java
@@ -1111,8 +1111,8 @@ public class MechanicalDesign implements java.io.Serializable {
    * </p>
    *
    * @param selection typed edition and selection behavior
-   * @throws neqsim.process.mechanicaldesign.designstandards.StandardSelectionException if a strict
-   *         selection cannot be honored
+   * @throws neqsim.process.mechanicaldesign.designstandards.StandardSelectionException if a strict selection cannot be
+   * honored
    */
   public void setDesignStandard(StandardSelection selection) {
     DesignStandard standard = StandardRegistry.createStandard(selection, this);

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardApplicability.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardApplicability.java
@@ -1,0 +1,90 @@
+package neqsim.process.mechanicaldesign.designstandards;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Immutable result of evaluating whether a standard applies to equipment. */
+public final class StandardApplicability implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Applicability result. */
+  public enum Status {
+    /** The equipment type is listed for the standard. */
+    APPLICABLE,
+    /** The equipment type is known but is not listed for the standard. */
+    NOT_APPLICABLE,
+    /** Applicability cannot be determined from the available equipment context. */
+    UNKNOWN
+  }
+
+  private final StandardType standardType;
+  private final String equipmentType;
+  private final Status status;
+  private final String reason;
+
+  private StandardApplicability(StandardType standardType, String equipmentType, Status status, String reason) {
+    this.standardType = Objects.requireNonNull(standardType, "standardType");
+    this.equipmentType = equipmentType;
+    this.status = Objects.requireNonNull(status, "status");
+    this.reason = reason == null ? "" : reason;
+  }
+
+  static StandardApplicability applicable(StandardType standardType, String equipmentType) {
+    return new StandardApplicability(standardType, equipmentType, Status.APPLICABLE,
+        standardType.getCode() + " lists " + equipmentType + " as applicable equipment.");
+  }
+
+  static StandardApplicability notApplicable(StandardType standardType, String equipmentType) {
+    return new StandardApplicability(standardType, equipmentType, Status.NOT_APPLICABLE,
+        standardType.getCode() + " does not list " + equipmentType + " as applicable equipment.");
+  }
+
+  static StandardApplicability unknown(StandardType standardType, String reason) {
+    return new StandardApplicability(standardType, null, Status.UNKNOWN, reason);
+  }
+
+  /** @return standard type */
+  public StandardType getStandardType() {
+    return standardType;
+  }
+
+  /** @return simple equipment class name, or {@code null} when unavailable */
+  public String getEquipmentType() {
+    return equipmentType;
+  }
+
+  /** @return applicability status */
+  public Status getStatus() {
+    return status;
+  }
+
+  /** @return human-readable reason */
+  public String getReason() {
+    return reason;
+  }
+
+  /** @return whether the standard is explicitly applicable */
+  public boolean isApplicable() {
+    return status == Status.APPLICABLE;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (!(object instanceof StandardApplicability)) {
+      return false;
+    }
+    StandardApplicability other = (StandardApplicability) object;
+    return standardType == other.standardType && Objects.equals(equipmentType, other.equipmentType)
+        && status == other.status && reason.equals(other.reason);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(standardType, equipmentType, status, reason);
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardEdition.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardEdition.java
@@ -10,8 +10,8 @@ import java.util.Objects;
  * Immutable, explicit edition of a catalogued design standard.
  *
  * <p>
- * Unlike the legacy global version override, an edition travels with a selection and can therefore
- * be reproduced independently of process-wide mutable state.
+ * Unlike the legacy global version override, an edition travels with a selection and can therefore be reproduced
+ * independently of process-wide mutable state.
  * </p>
  */
 public final class StandardEdition implements Serializable {
@@ -118,8 +118,7 @@ public final class StandardEdition implements Serializable {
       return false;
     }
     StandardEdition other = (StandardEdition) object;
-    return standardType == other.standardType && edition.equals(other.edition)
-        && amendments.equals(other.amendments);
+    return standardType == other.standardType && edition.equals(other.edition) && amendments.equals(other.amendments);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardEdition.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardEdition.java
@@ -1,0 +1,143 @@
+package neqsim.process.mechanicaldesign.designstandards;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable, explicit edition of a catalogued design standard.
+ *
+ * <p>
+ * Unlike the legacy global version override, an edition travels with a selection and can therefore
+ * be reproduced independently of process-wide mutable state.
+ * </p>
+ */
+public final class StandardEdition implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final StandardType standardType;
+  private final String edition;
+  private final List<String> amendments;
+
+  private StandardEdition(StandardType standardType, String edition, List<String> amendments) {
+    if (standardType == null) {
+      throw new IllegalArgumentException("standardType cannot be null");
+    }
+    this.standardType = standardType;
+    this.edition = requireText(edition, "edition");
+
+    List<String> amendmentCopy = new ArrayList<String>();
+    if (amendments != null) {
+      for (String amendment : amendments) {
+        amendmentCopy.add(requireText(amendment, "amendment"));
+      }
+    }
+    this.amendments = Collections.unmodifiableList(amendmentCopy);
+  }
+
+  /**
+   * Use the catalogued default edition for a standard.
+   *
+   * @param standardType standard type
+   * @return explicit standard edition
+   */
+  public static StandardEdition defaultEdition(StandardType standardType) {
+    if (standardType == null) {
+      throw new IllegalArgumentException("standardType cannot be null");
+    }
+    return of(standardType, standardType.getDefaultVersion());
+  }
+
+  /**
+   * Create an explicit standard edition without project amendments.
+   *
+   * @param standardType standard type
+   * @param edition edition or revision identifier
+   * @return explicit standard edition
+   */
+  public static StandardEdition of(StandardType standardType, String edition) {
+    return new StandardEdition(standardType, edition, Collections.<String>emptyList());
+  }
+
+  /**
+   * Create an explicit standard edition with project amendments.
+   *
+   * @param standardType standard type
+   * @param edition edition or revision identifier
+   * @param amendments project amendments, corrigenda, or supplements
+   * @return explicit standard edition
+   */
+  public static StandardEdition of(StandardType standardType, String edition, List<String> amendments) {
+    return new StandardEdition(standardType, edition, amendments);
+  }
+
+  /** @return standard type */
+  public StandardType getStandardType() {
+    return standardType;
+  }
+
+  /** @return edition or revision identifier */
+  public String getEdition() {
+    return edition;
+  }
+
+  /** @return immutable list of project amendments */
+  public List<String> getAmendments() {
+    return amendments;
+  }
+
+  /**
+   * Get a traceable name suitable for the legacy {@link DesignStandard} object.
+   *
+   * @return standard code, edition, and amendments
+   */
+  public String getDisplayName() {
+    StringBuilder name = new StringBuilder(standardType.getCode()).append(' ').append(edition);
+    if (!amendments.isEmpty()) {
+      name.append(" [amendments: ");
+      for (int index = 0; index < amendments.size(); index++) {
+        if (index > 0) {
+          name.append("; ");
+        }
+        name.append(amendments.get(index));
+      }
+      name.append(']');
+    }
+    return name.toString();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (!(object instanceof StandardEdition)) {
+      return false;
+    }
+    StandardEdition other = (StandardEdition) object;
+    return standardType == other.standardType && edition.equals(other.edition)
+        && amendments.equals(other.amendments);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(standardType, edition, amendments);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return getDisplayName();
+  }
+
+  private static String requireText(String value, String fieldName) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(fieldName + " cannot be null or blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistry.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistry.java
@@ -88,10 +88,9 @@ public final class StandardRegistry {
    * Create a standard from a typed edition selection.
    *
    * <p>
-   * Strict selections fail closed when the standard is catalog-only, its calculation is not
-   * connected to this registry, the equipment context is missing, or the standard is not listed
-   * for the equipment type. Legacy-compatible selections preserve the permissive factory behavior
-   * while still using an explicit, reproducible edition.
+   * Strict selections fail closed when the standard is catalog-only, its calculation is not connected to this registry,
+   * the equipment context is missing, or the standard is not listed for the equipment type. Legacy-compatible
+   * selections preserve the permissive factory behavior while still using an explicit, reproducible edition.
    * </p>
    *
    * @param selection typed standard selection

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistry.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistry.java
@@ -81,6 +81,83 @@ public final class StandardRegistry {
     String effectiveVersion = version != null ? version : getEffectiveVersion(standardType);
     String standardName = standardType.getCode() + " " + effectiveVersion;
 
+    return instantiateStandard(standardType, standardName, equipment);
+  }
+
+  /**
+   * Create a standard from a typed edition selection.
+   *
+   * <p>
+   * Strict selections fail closed when the standard is catalog-only, its calculation is not
+   * connected to this registry, the equipment context is missing, or the standard is not listed
+   * for the equipment type. Legacy-compatible selections preserve the permissive factory behavior
+   * while still using an explicit, reproducible edition.
+   * </p>
+   *
+   * @param selection typed standard selection
+   * @param equipment mechanical design equipment context
+   * @return a new DesignStandard instance
+   * @throws StandardSelectionException if a strict selection cannot be honored
+   */
+  public static DesignStandard createStandard(StandardSelection selection, MechanicalDesign equipment) {
+    if (selection == null) {
+      throw new StandardSelectionException(StandardSelectionException.Reason.MISSING_SELECTION, null, null,
+          "selection cannot be null");
+    }
+
+    StandardType standardType = selection.getStandardType();
+    if (selection.getMode() == StandardSelection.Mode.STRICT) {
+      StandardSupport support = StandardSupportAudit.getSupport(standardType);
+      if (support.getSupportLevel() == StandardSupportLevel.CATALOGUED) {
+        throw new StandardSelectionException(StandardSelectionException.Reason.CATALOG_ONLY, standardType, null,
+            support.getLimitation());
+      }
+      if (!support.isRegistryConnected()) {
+        throw new StandardSelectionException(StandardSelectionException.Reason.NOT_REGISTRY_CONNECTED, standardType,
+            null, support.getLimitation());
+      }
+
+      StandardApplicability applicability = assessApplicability(standardType, equipment);
+      if (applicability.getStatus() == StandardApplicability.Status.UNKNOWN) {
+        throw new StandardSelectionException(StandardSelectionException.Reason.MISSING_EQUIPMENT, standardType, null,
+            applicability.getReason());
+      }
+      if (applicability.getStatus() == StandardApplicability.Status.NOT_APPLICABLE) {
+        throw new StandardSelectionException(StandardSelectionException.Reason.NOT_APPLICABLE, standardType,
+            applicability.getEquipmentType(), applicability.getReason());
+      }
+    }
+
+    return instantiateStandard(standardType, selection.getEdition().getDisplayName(), equipment);
+  }
+
+  /**
+   * Assess applicability using the process equipment represented by a mechanical design.
+   *
+   * @param standardType standard to assess
+   * @param equipment mechanical design equipment context
+   * @return structured applicability result
+   * @throws IllegalArgumentException if {@code standardType} is null
+   */
+  public static StandardApplicability assessApplicability(StandardType standardType, MechanicalDesign equipment) {
+    if (standardType == null) {
+      throw new IllegalArgumentException("standardType cannot be null");
+    }
+    if (equipment == null || equipment.getProcessEquipment() == null) {
+      return StandardApplicability.unknown(standardType,
+          "A mechanical design with process equipment is required to assess applicability.");
+    }
+
+    String equipmentType = equipment.getProcessEquipment().getClass().getSimpleName();
+    if (standardType.appliesTo(equipmentType)) {
+      return StandardApplicability.applicable(standardType, equipmentType);
+    }
+    return StandardApplicability.notApplicable(standardType, equipmentType);
+  }
+
+  private static DesignStandard instantiateStandard(StandardType standardType, String standardName,
+      MechanicalDesign equipment) {
+
     Class<? extends DesignStandard> implementationClass = getMappedImplementationClass(standardType);
 
     if (implementationClass == PressureVesselDesignStandard.class) {

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSelection.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSelection.java
@@ -1,0 +1,111 @@
+package neqsim.process.mechanicaldesign.designstandards;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Immutable request to select a specific design-standard edition. */
+public final class StandardSelection implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Selection behavior. */
+  public enum Mode {
+    /** Preserve the permissive behavior of the legacy registry. */
+    LEGACY_COMPATIBLE,
+    /** Reject unsupported, disconnected, or inapplicable selections. */
+    STRICT
+  }
+
+  private final StandardEdition edition;
+  private final Mode mode;
+
+  private StandardSelection(StandardEdition edition, Mode mode) {
+    if (edition == null) {
+      throw new IllegalArgumentException("edition cannot be null");
+    }
+    if (mode == null) {
+      throw new IllegalArgumentException("mode cannot be null");
+    }
+    this.edition = edition;
+    this.mode = mode;
+  }
+
+  /**
+   * Select the catalogued default edition with strict checks.
+   *
+   * @param standardType standard type
+   * @return strict selection
+   */
+  public static StandardSelection strict(StandardType standardType) {
+    return strict(StandardEdition.defaultEdition(standardType));
+  }
+
+  /**
+   * Select an explicit edition with strict checks.
+   *
+   * @param edition explicit edition
+   * @return strict selection
+   */
+  public static StandardSelection strict(StandardEdition edition) {
+    return new StandardSelection(edition, Mode.STRICT);
+  }
+
+  /**
+   * Select the catalogued default edition with legacy-compatible behavior.
+   *
+   * @param standardType standard type
+   * @return legacy-compatible selection
+   */
+  public static StandardSelection legacy(StandardType standardType) {
+    return legacy(StandardEdition.defaultEdition(standardType));
+  }
+
+  /**
+   * Select an explicit edition with legacy-compatible behavior.
+   *
+   * @param edition explicit edition
+   * @return legacy-compatible selection
+   */
+  public static StandardSelection legacy(StandardEdition edition) {
+    return new StandardSelection(edition, Mode.LEGACY_COMPATIBLE);
+  }
+
+  /** @return explicit edition */
+  public StandardEdition getEdition() {
+    return edition;
+  }
+
+  /** @return selected standard type */
+  public StandardType getStandardType() {
+    return edition.getStandardType();
+  }
+
+  /** @return selection behavior */
+  public Mode getMode() {
+    return mode;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (!(object instanceof StandardSelection)) {
+      return false;
+    }
+    StandardSelection other = (StandardSelection) object;
+    return edition.equals(other.edition) && mode == other.mode;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(edition, mode);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return mode + ": " + edition;
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionException.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionException.java
@@ -1,0 +1,60 @@
+package neqsim.process.mechanicaldesign.designstandards;
+
+/** Exception raised when a strict standard selection cannot be honored. */
+public final class StandardSelectionException extends IllegalArgumentException {
+  private static final long serialVersionUID = 1000L;
+
+  /** Machine-readable rejection reason. */
+  public enum Reason {
+    /** No selection was supplied. */
+    MISSING_SELECTION,
+    /** No equipment context was supplied. */
+    MISSING_EQUIPMENT,
+    /** The standard is discovery metadata without an implemented calculation. */
+    CATALOG_ONLY,
+    /** A calculation exists elsewhere but is not connected to the registry. */
+    NOT_REGISTRY_CONNECTED,
+    /** The standard does not apply to the supplied equipment type. */
+    NOT_APPLICABLE
+  }
+
+  private final Reason reason;
+  private final StandardType standardType;
+  private final String equipmentType;
+
+  StandardSelectionException(Reason reason, StandardType standardType, String equipmentType, String detail) {
+    super(buildMessage(reason, standardType, equipmentType, detail));
+    this.reason = reason;
+    this.standardType = standardType;
+    this.equipmentType = equipmentType;
+  }
+
+  /** @return machine-readable rejection reason */
+  public Reason getReason() {
+    return reason;
+  }
+
+  /** @return rejected standard type, or {@code null} if no selection was supplied */
+  public StandardType getStandardType() {
+    return standardType;
+  }
+
+  /** @return equipment type, or {@code null} if unavailable */
+  public String getEquipmentType() {
+    return equipmentType;
+  }
+
+  private static String buildMessage(Reason reason, StandardType standardType, String equipmentType, String detail) {
+    StringBuilder message = new StringBuilder("Standard selection rejected: ").append(reason);
+    if (standardType != null) {
+      message.append(" (standard=").append(standardType.getCode()).append(')');
+    }
+    if (equipmentType != null) {
+      message.append(" (equipment=").append(equipmentType).append(')');
+    }
+    if (detail != null && !detail.isEmpty()) {
+      message.append(". ").append(detail);
+    }
+    return message.toString();
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupport.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupport.java
@@ -6,6 +6,7 @@ package neqsim.process.mechanicaldesign.designstandards;
 public final class StandardSupport {
   private final StandardType standardType;
   private final StandardSupportLevel supportLevel;
+  private final boolean registryConnected;
   private final String registryImplementation;
   private final String calculationImplementation;
   private final String limitation;
@@ -15,14 +16,16 @@ public final class StandardSupport {
    *
    * @param standardType catalogued standard
    * @param supportLevel implementation evidence level
+   * @param registryConnected whether the stated calculation is selected by the registry
    * @param registryImplementation class selected by {@link StandardRegistry}
    * @param calculationImplementation calculation path that provides the stated support
    * @param limitation concise implementation boundary
    */
-  StandardSupport(StandardType standardType, StandardSupportLevel supportLevel, String registryImplementation,
-      String calculationImplementation, String limitation) {
+  StandardSupport(StandardType standardType, StandardSupportLevel supportLevel, boolean registryConnected,
+      String registryImplementation, String calculationImplementation, String limitation) {
     this.standardType = standardType;
     this.supportLevel = supportLevel;
+    this.registryConnected = registryConnected;
     this.registryImplementation = registryImplementation;
     this.calculationImplementation = calculationImplementation;
     this.limitation = limitation;
@@ -44,6 +47,15 @@ public final class StandardSupport {
    */
   public StandardSupportLevel getSupportLevel() {
     return supportLevel;
+  }
+
+  /**
+   * Check whether the calculation path is selected by {@link StandardRegistry}.
+   *
+   * @return {@code true} when strict registry selection can reach the calculation
+   */
+  public boolean isRegistryConnected() {
+    return registryConnected;
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
@@ -35,22 +35,23 @@ public final class StandardSupportAudit {
 
     switch (standardType) {
     case API_610:
-      return new StandardSupport(standardType, StandardSupportLevel.SCREENING, registryImplementation,
+      return new StandardSupport(standardType, StandardSupportLevel.SCREENING, false, registryImplementation,
           "PumpApi610DesignCalculator",
           "API 610 screening is available through PumpMechanicalDesign but is not selected by StandardRegistry.");
     case API_650:
     case API_620:
-      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation, NO_CALCULATION,
-          "The registry maps this tank standard to a separator-oriented pressure-vessel class; "
+      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, false, registryImplementation,
+          NO_CALCULATION, "The registry maps this tank standard to a separator-oriented pressure-vessel class; "
               + "no tank-code calculation is implemented.");
     case API_660:
     case API_661:
     case ISO_16812:
-      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation, NO_CALCULATION,
-          "No standard-specific heat-exchanger mechanical calculation is connected.");
+      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, false, registryImplementation,
+          NO_CALCULATION, "No standard-specific heat-exchanger mechanical calculation is connected.");
     case API_521:
     case API_526:
-      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation, NO_CALCULATION,
+      return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, false, registryImplementation,
+          NO_CALCULATION,
           "The mapped valve class does not implement relief-system or relief-valve standard calculations.");
     default:
       return getCategorySupport(standardType, registryImplementation);
@@ -121,12 +122,12 @@ public final class StandardSupportAudit {
           "Material-property lookup only; material selection, qualification, and code acceptance are not implemented.");
     }
 
-    return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, registryImplementation, NO_CALCULATION,
-        "No category-specific calculation is connected.");
+    return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, false, registryImplementation,
+        NO_CALCULATION, "No category-specific calculation is connected.");
   }
 
   private static StandardSupport screening(StandardType standardType, String implementation, String limitation) {
-    return new StandardSupport(standardType, StandardSupportLevel.SCREENING, implementation, implementation,
+    return new StandardSupport(standardType, StandardSupportLevel.SCREENING, true, implementation, implementation,
         limitation);
   }
 

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistryTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistryTest.java
@@ -46,7 +46,8 @@ class StandardRegistryTest {
 
   @Test
   void testCreateStandardThrowsOnNull() {
-    assertThrows(IllegalArgumentException.class, () -> StandardRegistry.createStandard(null, mechanicalDesign));
+    assertThrows(IllegalArgumentException.class,
+        () -> StandardRegistry.createStandard((StandardType) null, mechanicalDesign));
   }
 
   @Test

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionTest.java
@@ -35,8 +35,8 @@ class StandardSelectionTest {
     assertEquals("8th Ed", edition.getEdition());
     assertEquals(Collections.singletonList("Project amendment A"), edition.getAmendments());
     assertThrows(UnsupportedOperationException.class, () -> edition.getAmendments().add("Mutation"));
-    assertEquals(StandardEdition.of(StandardType.API_12J, "8th Ed",
-        Collections.singletonList("Project amendment A")), edition);
+    assertEquals(StandardEdition.of(StandardType.API_12J, "8th Ed", Collections.singletonList("Project amendment A")),
+        edition);
     assertNotEquals(StandardEdition.of(StandardType.API_12J, "9th Ed"), edition);
 
     assertThrows(IllegalArgumentException.class, () -> StandardEdition.of(null, "8th Ed"));
@@ -53,8 +53,7 @@ class StandardSelectionTest {
     mechanicalDesign.setDesignStandard(StandardSelection.strict(edition));
 
     DesignStandard standard = mechanicalDesign.getDesignStandard().get("separator process design");
-    assertEquals("API-12J 8th Ed [amendments: Project amendment A; Corrigendum 1]",
-        standard.getStandardName());
+    assertEquals("API-12J 8th Ed [amendments: Project amendment A; Corrigendum 1]", standard.getStandardName());
   }
 
   @Test
@@ -69,10 +68,8 @@ class StandardSelectionTest {
 
   @Test
   void testApplicabilityIsStructured() {
-    StandardApplicability applicable =
-        StandardRegistry.assessApplicability(StandardType.API_12J, mechanicalDesign);
-    StandardApplicability notApplicable =
-        StandardRegistry.assessApplicability(StandardType.API_617, mechanicalDesign);
+    StandardApplicability applicable = StandardRegistry.assessApplicability(StandardType.API_12J, mechanicalDesign);
+    StandardApplicability notApplicable = StandardRegistry.assessApplicability(StandardType.API_617, mechanicalDesign);
     StandardApplicability unknown = StandardRegistry.assessApplicability(StandardType.API_12J, null);
 
     assertEquals(StandardApplicability.Status.APPLICABLE, applicable.getStatus());
@@ -122,8 +119,8 @@ class StandardSelectionTest {
 
   @Test
   void testLegacyCompatibleSelectionPreservesPermissiveFactory() {
-    DesignStandard standard =
-        StandardRegistry.createStandard(StandardSelection.legacy(StandardType.API_660), mechanicalDesign);
+    DesignStandard standard = StandardRegistry.createStandard(StandardSelection.legacy(StandardType.API_660),
+        mechanicalDesign);
 
     assertEquals(DesignStandard.class, standard.getClass());
     assertEquals("API-660 9th Ed", standard.getStandardName());

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionTest.java
@@ -1,0 +1,131 @@
+package neqsim.process.mechanicaldesign.designstandards;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.mechanicaldesign.MechanicalDesign;
+
+/** Tests typed, reproducible, fail-closed standard selection. */
+class StandardSelectionTest {
+  private MechanicalDesign mechanicalDesign;
+
+  @BeforeEach
+  void setUp() {
+    mechanicalDesign = new Separator("Test Separator").getMechanicalDesign();
+    StandardRegistry.clearVersionOverrides();
+  }
+
+  @Test
+  void testEditionIsValidatedAndImmutable() {
+    List<String> amendments = new ArrayList<String>();
+    amendments.add("Project amendment A");
+
+    StandardEdition edition = StandardEdition.of(StandardType.API_12J, " 8th Ed ", amendments);
+    amendments.add("Late mutation");
+
+    assertEquals("8th Ed", edition.getEdition());
+    assertEquals(Collections.singletonList("Project amendment A"), edition.getAmendments());
+    assertThrows(UnsupportedOperationException.class, () -> edition.getAmendments().add("Mutation"));
+    assertEquals(StandardEdition.of(StandardType.API_12J, "8th Ed",
+        Collections.singletonList("Project amendment A")), edition);
+    assertNotEquals(StandardEdition.of(StandardType.API_12J, "9th Ed"), edition);
+
+    assertThrows(IllegalArgumentException.class, () -> StandardEdition.of(null, "8th Ed"));
+    assertThrows(IllegalArgumentException.class, () -> StandardEdition.of(StandardType.API_12J, " "));
+    assertThrows(IllegalArgumentException.class,
+        () -> StandardEdition.of(StandardType.API_12J, "8th Ed", Arrays.asList("valid", " ")));
+  }
+
+  @Test
+  void testStrictSelectionStoresExplicitEditionAndAmendments() {
+    StandardEdition edition = StandardEdition.of(StandardType.API_12J, "8th Ed",
+        Arrays.asList("Project amendment A", "Corrigendum 1"));
+
+    mechanicalDesign.setDesignStandard(StandardSelection.strict(edition));
+
+    DesignStandard standard = mechanicalDesign.getDesignStandard().get("separator process design");
+    assertEquals("API-12J 8th Ed [amendments: Project amendment A; Corrigendum 1]",
+        standard.getStandardName());
+  }
+
+  @Test
+  void testExplicitEditionDoesNotUseGlobalOverride() {
+    StandardRegistry.setVersionOverride(StandardType.API_12J, "global override");
+
+    DesignStandard standard = StandardRegistry.createStandard(
+        StandardSelection.strict(StandardEdition.of(StandardType.API_12J, "project edition")), mechanicalDesign);
+
+    assertEquals("API-12J project edition", standard.getStandardName());
+  }
+
+  @Test
+  void testApplicabilityIsStructured() {
+    StandardApplicability applicable =
+        StandardRegistry.assessApplicability(StandardType.API_12J, mechanicalDesign);
+    StandardApplicability notApplicable =
+        StandardRegistry.assessApplicability(StandardType.API_617, mechanicalDesign);
+    StandardApplicability unknown = StandardRegistry.assessApplicability(StandardType.API_12J, null);
+
+    assertEquals(StandardApplicability.Status.APPLICABLE, applicable.getStatus());
+    assertTrue(applicable.isApplicable());
+    assertEquals("Separator", applicable.getEquipmentType());
+    assertEquals(StandardApplicability.Status.NOT_APPLICABLE, notApplicable.getStatus());
+    assertFalse(notApplicable.isApplicable());
+    assertEquals(StandardApplicability.Status.UNKNOWN, unknown.getStatus());
+  }
+
+  @Test
+  void testStrictSelectionRejectsCatalogOnlyStandard() {
+    StandardSelectionException exception = assertThrows(StandardSelectionException.class,
+        () -> StandardRegistry.createStandard(StandardSelection.strict(StandardType.API_660), mechanicalDesign));
+
+    assertEquals(StandardSelectionException.Reason.CATALOG_ONLY, exception.getReason());
+    assertEquals(StandardType.API_660, exception.getStandardType());
+  }
+
+  @Test
+  void testStrictSelectionRejectsDisconnectedCalculation() {
+    StandardSelectionException exception = assertThrows(StandardSelectionException.class,
+        () -> StandardRegistry.createStandard(StandardSelection.strict(StandardType.API_610), mechanicalDesign));
+
+    assertEquals(StandardSelectionException.Reason.NOT_REGISTRY_CONNECTED, exception.getReason());
+  }
+
+  @Test
+  void testStrictSelectionRejectsInapplicableEquipment() {
+    StandardSelectionException exception = assertThrows(StandardSelectionException.class,
+        () -> StandardRegistry.createStandard(StandardSelection.strict(StandardType.API_617), mechanicalDesign));
+
+    assertEquals(StandardSelectionException.Reason.NOT_APPLICABLE, exception.getReason());
+    assertEquals("Separator", exception.getEquipmentType());
+  }
+
+  @Test
+  void testStrictSelectionRejectsMissingContext() {
+    StandardSelectionException missingEquipment = assertThrows(StandardSelectionException.class,
+        () -> StandardRegistry.createStandard(StandardSelection.strict(StandardType.API_12J), null));
+    StandardSelectionException missingSelection = assertThrows(StandardSelectionException.class,
+        () -> StandardRegistry.createStandard((StandardSelection) null, mechanicalDesign));
+
+    assertEquals(StandardSelectionException.Reason.MISSING_EQUIPMENT, missingEquipment.getReason());
+    assertEquals(StandardSelectionException.Reason.MISSING_SELECTION, missingSelection.getReason());
+  }
+
+  @Test
+  void testLegacyCompatibleSelectionPreservesPermissiveFactory() {
+    DesignStandard standard =
+        StandardRegistry.createStandard(StandardSelection.legacy(StandardType.API_660), mechanicalDesign);
+
+    assertEquals(DesignStandard.class, standard.getClass());
+    assertEquals("API-660 9th Ed", standard.getStandardName());
+  }
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
@@ -1,6 +1,7 @@
 package neqsim.process.mechanicaldesign.designstandards;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
@@ -32,6 +33,7 @@ class StandardSupportAuditTest {
     assertEquals(StandardSupportLevel.SCREENING, pumpSupport.getSupportLevel());
     assertEquals("DesignStandard", pumpSupport.getRegistryImplementation());
     assertEquals("PumpApi610DesignCalculator", pumpSupport.getCalculationImplementation());
+    assertFalse(pumpSupport.isRegistryConnected());
 
     assertEquals(StandardSupportLevel.CATALOGUED,
         StandardSupportAudit.getSupport(StandardType.API_660).getSupportLevel());
@@ -43,6 +45,8 @@ class StandardSupportAuditTest {
         StandardSupportAudit.getSupport(StandardType.ASME_VIII_DIV1).getSupportLevel());
     assertEquals(StandardSupportLevel.SCREENING,
         StandardSupportAudit.getSupport(StandardType.API_12J).getSupportLevel());
+    assertTrue(StandardSupportAudit.getSupport(StandardType.API_12J).isRegistryConnected());
+    assertFalse(StandardSupportAudit.getSupport(StandardType.API_660).isRegistryConnected());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- add immutable `StandardEdition` and `StandardSelection` APIs for explicit editions and project amendments
- add structured `StandardApplicability` results and machine-readable `StandardSelectionException` reasons
- make strict registry selection fail closed for catalog-only, disconnected, missing-context, and inapplicable standards
- preserve the existing permissive `StandardType` factory overloads and provide an explicit legacy-compatible migration mode
- record whether audited calculations are actually reachable through `StandardRegistry`
- document the strict/legacy boundary and add focused regression coverage

## Compatibility

This stage is additive. Existing `StandardRegistry.createStandard(StandardType, ...)` and `MechanicalDesign.setDesignStandard(StandardType, ...)` behavior is unchanged. No numerical design equations are changed.

## Stacking

This draft is intentionally based on `agent/audit-design-standard-support` (PR #2542). After that PR merges, this branch can be rebased and the PR retargeted to `master`.

## Validation

- focused tests cover immutable edition data, amendments, explicit-edition reproducibility, structured applicability, each strict rejection class, mechanical-design integration, and legacy-compatible fallback
- local Maven execution is unavailable in the sandbox because dependencies cannot be downloaded; full build, tests, Javadoc, Spotless, and pre-commit validation are delegated to GitHub Actions