### PR TITLE
test: diagnose missing pump JSON type field

### DIFF
--- a/src/test/java/neqsim/process/mechanicaldesign/pump/PumpDocumentationTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/pump/PumpDocumentationTest.java
@@ -75,6 +75,7 @@ public class PumpDocumentationTest {
     assertTrue(assessment.getRequiredCasingPressureBara() <= 25.0);
     assertFalse(assessment.getChecks().isEmpty());
     assertTrue(responseObject.has("api610Screening"));
+    assertTrue(responseObject.has("api610TypeCode"));
     assertEquals("OH2", responseObject.get("api610TypeCode").getAsString());
   }
 }


### PR DESCRIPTION
## Campaign batch

D012 post-merge review follow-up for #2499 and #2543. This addresses the only actionable Copilot comment left after #2543 merged; it does not begin D013.

## Confirmed defect and severity

- **Low — missing JSON fields could produce a null dereference instead of a diagnostic assertion failure.**
- Copilot noted that `responseObject.get("api610TypeCode")` returns null when the field is absent.
- The subsequent `.getAsString()` would then throw `NullPointerException`, obscuring which required documentation-response field is missing.

## Fix

- Add an explicit `responseObject.has("api610TypeCode")` assertion before reading the value.
- Retain the structural `OH2` value assertion.
- No production code, documentation text, equations, links, navigation, or public API changed.

## Frozen path

- `src/test/java/neqsim/process/mechanicaldesign/pump/PumpDocumentationTest.java`

## Validation evidence

- Branch is based on `master` commit `6b507441c78b25070c48985ce5c1ee45ff39cf65`, remains mergeable, and changes one file by +1/−0.
- Pre-commit, Spotless, Javadoc, CodeQL, Java/XML change detection, and agent-skill cross-reference checks passed.
- Ubuntu Java 21 stopped during test compilation before any tests ran:
  - `FreezingPointTemperatureFlashTest.java:24`
  - ambiguous `assertDoesNotThrow(operations::freezingPointTemperatureFlash)` overload
- Windows Java 21 was canceled after the Ubuntu failure; Java 8 matrices were skipped.
- The failure is present on the unchanged `master` file introduced by #2545 and is unrelated to the sole pump-test assertion changed here. Open PR #2549 independently records the same baseline compiler failure.
- The focused `PumpDocumentationTest` therefore has not executed on this branch, and no JUnit pass is claimed.
- A local Maven run is not available because this workspace does not contain a complete NeqSim checkout.

## Rendering, links, and exclusions

- No Markdown, Jekyll page, equation, image, notebook, internal link, or external link changed; no rendering or link result is claimed or required.
- The unrelated freezing-test compile repair is deliberately excluded from this one-file D012 PR.
- D013 remains excluded until D012 can be verified.
- No direct `master` push, merge, auto-merge, production change, or test weakening is included.

## Before/after

- Before: absence of `api610TypeCode` can surface as an indirect null dereference.
- After: the test reports a direct failed presence assertion before validating the field value.
