### PR TITLE
Consolidate equipment design behind typed kernels

### DIFF
--- a/docs/process/mechanical_design_standards.md
+++ b/docs/process/mechanical_design_standards.md
@@ -40,7 +40,7 @@ the source catalog diverge.
 | ASME-B31.4 | 2022 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
 | ASME-B31.8 | 2022 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
 | API-617 | 8th Ed | compressor design codes | CompressorDesignStandard | CompressorDesignStandard | SCREENING | Preliminary compressor-factor screening only; package and vendor requirements are not implemented. |
-| API-610 | 12th Ed | pump design codes | DesignStandard | PumpApi610DesignCalculator | SCREENING | API 610 screening is available through PumpMechanicalDesign but is not selected by StandardRegistry. |
+| API-610 | 13th Ed | pump design codes | DesignStandard | PumpApi610DesignKernel | SCREENING | API 610 screening is connected through a pure engineering-workflow adapter; purchased-standard, project, and vendor verification remain required. |
 | API-650 | 13th Ed | pressure vessel design code | PressureVesselDesignStandard | None | CATALOGUED | The registry maps this tank standard to a separator-oriented pressure-vessel class; no tank-code calculation is implemented. |
 | API-620 | 13th Ed | pressure vessel design code | PressureVesselDesignStandard | None | CATALOGUED | The registry maps this tank standard to a separator-oriented pressure-vessel class; no tank-code calculation is implemented. |
 | API-660 | 9th Ed | heat exchanger design codes | DesignStandard | None | CATALOGUED | No standard-specific heat-exchanger mechanical calculation is connected. |
@@ -84,6 +84,19 @@ the same applicability decision without creating a standard.
 retaining the permissive factory behavior. It may create a metadata-only `DesignStandard`; it does
 not add calculation support.
 
+## Consolidated design kernels
+
+`EquipmentDesignKernel<I, O>` extends the existing typed engineering-calculation contract with the
+implemented standard, audited maturity, and structured applicability. Kernels must not mutate their
+input or a `ProcessSystem`. Compatibility adapters defensively copy legacy mutable calculators.
+
+`StandardRegistry.getDesignKernel(...)` returns an explicit lookup status. API 610 is the first
+connected adapter and returns `IMPLEMENTED`; standards that have not been adapted return
+`NOT_IMPLEMENTED`, never an empty or implied success. The API 610 kernel returns an immutable
+assessment snapshot and always requires engineering and vendor review because its maturity remains
+`SCREENING`. The current kernel explicitly supports 13th edition; a different edition fails closed
+as `EDITION_NOT_IMPLEMENTED` until separately implemented and validated.
+
 ## How to interpret the registry
 
 `StandardRegistry.createStandard(...)` remains backward compatible. The factory class shown in the
@@ -91,10 +104,10 @@ matrix records what it currently creates; it does not prove that the resulting c
 selected edition. `StandardRegistry.getMappedImplementationClass(...)` allows applications and
 audits to inspect that mapping without constructing equipment or accessing the design database.
 
-The API 610 pump screen is a deliberate special case. It is implemented by
-`PumpApi610DesignCalculator` through `PumpMechanicalDesign`, while the generic registry currently
-creates only a base `DesignStandard`. A later consolidation will connect equipment-specific
-calculators through one typed standards interface.
+The API 610 pump screen remains available through `PumpMechanicalDesign`. The consolidated
+`PumpApi610DesignKernel` is a pure adapter over the same calculator, so existing callers are not
+removed or redirected. The generic legacy factory still creates a base `DesignStandard`; executable
+kernel support is exposed explicitly through `StandardRegistry.getDesignKernel(...)`.
 
 ## Engineering boundary
 

--- a/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernel.java
+++ b/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernel.java
@@ -1,0 +1,42 @@
+package neqsim.process.engineering.calculation;
+
+import java.io.Serializable;
+import neqsim.process.mechanicaldesign.designstandards.StandardApplicability;
+import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
+import neqsim.process.mechanicaldesign.designstandards.StandardSupportLevel;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+
+/**
+ * Pure, typed adapter contract for an equipment design calculation associated with a standard.
+ *
+ * <p>
+ * Implementations must not mutate the supplied input or a {@code ProcessSystem}. Legacy mutable
+ * calculators are connected through adapters that copy their configuration before execution.
+ * </p>
+ *
+ * @param <I> immutable or defensively copied calculation input
+ * @param <O> typed calculation output
+ */
+public interface EquipmentDesignKernel<I, O> extends EngineeringCalculationModule<I, O>, Serializable {
+  /** @return catalogued standard implemented by this kernel */
+  StandardType standard();
+
+  /** @return audited implementation maturity */
+  StandardSupportLevel maturity();
+
+  /**
+   * Check whether this kernel implements the requested edition and amendment basis.
+   *
+   * @param edition explicit standard edition
+   * @return {@code true} when the kernel can execute that edition basis
+   */
+  boolean supports(StandardEdition edition);
+
+  /**
+   * Assess whether the kernel's standard applies to the supplied equipment input.
+   *
+   * @param input calculation input
+   * @return structured applicability decision
+   */
+  StandardApplicability applicability(I input);
+}

--- a/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernel.java
+++ b/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernel.java
@@ -10,8 +10,8 @@ import neqsim.process.mechanicaldesign.designstandards.StandardType;
  * Pure, typed adapter contract for an equipment design calculation associated with a standard.
  *
  * <p>
- * Implementations must not mutate the supplied input or a {@code ProcessSystem}. Legacy mutable
- * calculators are connected through adapters that copy their configuration before execution.
+ * Implementations must not mutate the supplied input or a {@code ProcessSystem}. Legacy mutable calculators are
+ * connected through adapters that copy their configuration before execution.
  * </p>
  *
  * @param <I> immutable or defensively copied calculation input

--- a/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernelRegistry.java
+++ b/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernelRegistry.java
@@ -1,0 +1,115 @@
+package neqsim.process.engineering.calculation;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
+import neqsim.process.mechanicaldesign.designstandards.StandardSupportLevel;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+
+/** Registry of standard-specific kernels exposed through the public engineering workflow. */
+public final class EquipmentDesignKernelRegistry {
+  /** Explicit implementation lookup status. */
+  public enum Status {
+    /** An executable kernel is registered. */
+    IMPLEMENTED,
+    /** No kernel has been adapted to the common API. */
+    NOT_IMPLEMENTED
+  }
+
+  /** Immutable registry lookup that never represents missing support as an empty success. */
+  public static final class Lookup {
+    private final StandardType standardType;
+    private final Status status;
+    private final EquipmentDesignKernel<?, ?> kernel;
+
+    private Lookup(StandardType standardType, Status status, EquipmentDesignKernel<?, ?> kernel) {
+      this.standardType = standardType;
+      this.status = status;
+      this.kernel = kernel;
+    }
+
+    /** @return requested standard */
+    public StandardType getStandardType() {
+      return standardType;
+    }
+
+    /** @return explicit implementation status */
+    public Status getStatus() {
+      return status;
+    }
+
+    /** @return whether an executable kernel is registered */
+    public boolean isImplemented() {
+      return status == Status.IMPLEMENTED;
+    }
+
+    /**
+     * Require the registered kernel.
+     *
+     * @return registered kernel
+     * @throws IllegalStateException if the standard has no common kernel
+     */
+    public EquipmentDesignKernel<?, ?> requireKernel() {
+      if (kernel == null) {
+        throw new IllegalStateException("No equipment design kernel is implemented for " + standardType.getCode());
+      }
+      return kernel;
+    }
+
+    /** @return implementation class name, or {@code None} when not implemented */
+    public String getImplementationClassName() {
+      return kernel == null ? "None" : kernel.getClass().getSimpleName();
+    }
+
+    /** @return registered maturity, or {@link StandardSupportLevel#CATALOGUED} when absent */
+    public StandardSupportLevel getMaturity() {
+      return kernel == null ? StandardSupportLevel.CATALOGUED : kernel.maturity();
+    }
+
+    /**
+     * Check whether the registered kernel implements an explicit edition basis.
+     *
+     * @param edition requested edition
+     * @return {@code true} only when a kernel exists and supports the edition
+     */
+    public boolean supports(StandardEdition edition) {
+      return kernel != null && kernel.supports(edition);
+    }
+  }
+
+  private static final Map<StandardType, EquipmentDesignKernel<?, ?>> KERNELS;
+
+  static {
+    Map<StandardType, EquipmentDesignKernel<?, ?>> kernels =
+        new EnumMap<StandardType, EquipmentDesignKernel<?, ?>>(StandardType.class);
+    register(kernels, new PumpApi610DesignKernel());
+    KERNELS = Collections.unmodifiableMap(kernels);
+  }
+
+  private EquipmentDesignKernelRegistry() {
+    // Utility class.
+  }
+
+  /**
+   * Look up a standard-specific kernel.
+   *
+   * @param standardType standard to inspect
+   * @return explicit implemented or not-implemented result
+   */
+  public static Lookup lookup(StandardType standardType) {
+    if (standardType == null) {
+      throw new IllegalArgumentException("standardType cannot be null");
+    }
+    EquipmentDesignKernel<?, ?> kernel = KERNELS.get(standardType);
+    return new Lookup(standardType, kernel == null ? Status.NOT_IMPLEMENTED : Status.IMPLEMENTED, kernel);
+  }
+
+  private static void register(Map<StandardType, EquipmentDesignKernel<?, ?>> kernels,
+      EquipmentDesignKernel<?, ?> kernel) {
+    EquipmentDesignKernel<?, ?> previous = kernels.put(kernel.standard(), kernel);
+    if (previous != null) {
+      throw new IllegalStateException("Duplicate equipment design kernel for " + kernel.standard().getCode());
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernelRegistry.java
+++ b/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernelRegistry.java
@@ -81,8 +81,8 @@ public final class EquipmentDesignKernelRegistry {
   private static final Map<StandardType, EquipmentDesignKernel<?, ?>> KERNELS;
 
   static {
-    Map<StandardType, EquipmentDesignKernel<?, ?>> kernels =
-        new EnumMap<StandardType, EquipmentDesignKernel<?, ?>>(StandardType.class);
+    Map<StandardType, EquipmentDesignKernel<?, ?>> kernels = new EnumMap<StandardType, EquipmentDesignKernel<?, ?>>(
+        StandardType.class);
     register(kernels, new PumpApi610DesignKernel());
     KERNELS = Collections.unmodifiableMap(kernels);
   }

--- a/src/main/java/neqsim/process/engineering/calculation/PumpApi610DesignAssessment.java
+++ b/src/main/java/neqsim/process/engineering/calculation/PumpApi610DesignAssessment.java
@@ -1,0 +1,229 @@
+package neqsim.process.engineering.calculation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.AssessmentStatus;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.CheckStatus;
+
+/** Immutable engineering-workflow snapshot of an API 610 screening calculation. */
+public final class PumpApi610DesignAssessment implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Immutable snapshot of one legacy calculator check. */
+  public static final class CheckResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String id;
+    private final String requirement;
+    private final CheckStatus status;
+    private final double actualValue;
+    private final double limitValue;
+    private final String unit;
+    private final String message;
+
+    private CheckResult(PumpApi610DesignCalculator.Check check) {
+      id = check.getId();
+      requirement = check.getRequirement();
+      status = check.getStatus();
+      actualValue = check.getActualValue();
+      limitValue = check.getLimitValue();
+      unit = check.getUnit();
+      message = check.getMessage();
+    }
+
+    /** @return stable check identifier */
+    public String getId() {
+      return id;
+    }
+
+    /** @return requirement description */
+    public String getRequirement() {
+      return requirement;
+    }
+
+    /** @return check status */
+    public CheckStatus getStatus() {
+      return status;
+    }
+
+    /** @return calculated or supplied value */
+    public double getActualValue() {
+      return actualValue;
+    }
+
+    /** @return configured limiting value */
+    public double getLimitValue() {
+      return limitValue;
+    }
+
+    /** @return engineering unit */
+    public String getUnit() {
+      return unit;
+    }
+
+    /** @return check explanation */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return serializable check representation */
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("id", id);
+      result.put("requirement", requirement);
+      result.put("status", status.name());
+      result.put("actualValue", Double.valueOf(actualValue));
+      result.put("limitValue", Double.valueOf(limitValue));
+      result.put("unit", unit);
+      result.put("message", message);
+      return result;
+    }
+  }
+
+  private final String standardEdition;
+  private final AssessmentStatus assessmentStatus;
+  private final String operatingRegion;
+  private final double operatingFlowRatio;
+  private final double npshMarginM;
+  private final double npshMarginRatio;
+  private final double governingShutoffHeadM;
+  private final double requiredCasingPressureBara;
+  private final double preliminaryHydrostaticTestPressureBara;
+  private final double headRiseToShutoffFraction;
+  private final double requiredDriverPowerKw;
+  private final double selectedDriverPowerKw;
+  private final double bearingL10LifeHours;
+  private final double criticalSpeedRatio;
+  private final List<CheckResult> checks;
+
+  private PumpApi610DesignAssessment(PumpApi610DesignCalculator calculator) {
+    standardEdition = calculator.getStandardEdition();
+    assessmentStatus = calculator.getAssessmentStatus();
+    operatingRegion = calculator.getOperatingRegion();
+    operatingFlowRatio = calculator.getOperatingFlowRatio();
+    npshMarginM = calculator.getNpshMarginM();
+    npshMarginRatio = calculator.getNpshMarginRatio();
+    governingShutoffHeadM = calculator.getGoverningShutoffHeadM();
+    requiredCasingPressureBara = calculator.getRequiredCasingPressureBara();
+    preliminaryHydrostaticTestPressureBara = calculator.getPreliminaryHydrostaticTestPressureBara();
+    headRiseToShutoffFraction = calculator.getHeadRiseToShutoffFraction();
+    requiredDriverPowerKw = calculator.getRequiredDriverPowerKw();
+    selectedDriverPowerKw = calculator.getSelectedDriverPowerKw();
+    bearingL10LifeHours = calculator.getBearingL10LifeHours();
+    criticalSpeedRatio = calculator.getCriticalSpeedRatio();
+    List<CheckResult> checkResults = new ArrayList<CheckResult>();
+    for (PumpApi610DesignCalculator.Check check : calculator.getChecks()) {
+      checkResults.add(new CheckResult(check));
+    }
+    checks = Collections.unmodifiableList(checkResults);
+  }
+
+  static PumpApi610DesignAssessment from(PumpApi610DesignCalculator calculator) {
+    return new PumpApi610DesignAssessment(calculator);
+  }
+
+  /** @return explicit edition evaluated by the legacy calculator */
+  public String getStandardEdition() {
+    return standardEdition;
+  }
+
+  /** @return overall API 610 screening status */
+  public AssessmentStatus getAssessmentStatus() {
+    return assessmentStatus;
+  }
+
+  /** @return operating-region label */
+  public String getOperatingRegion() {
+    return operatingRegion;
+  }
+
+  /** @return operating flow divided by BEP flow */
+  public double getOperatingFlowRatio() {
+    return operatingFlowRatio;
+  }
+
+  /** @return NPSH head margin in metres */
+  public double getNpshMarginM() {
+    return npshMarginM;
+  }
+
+  /** @return NPSHa divided by NPSHr */
+  public double getNpshMarginRatio() {
+    return npshMarginRatio;
+  }
+
+  /** @return governing shutoff head in metres */
+  public double getGoverningShutoffHeadM() {
+    return governingShutoffHeadM;
+  }
+
+  /** @return required casing pressure in bara */
+  public double getRequiredCasingPressureBara() {
+    return requiredCasingPressureBara;
+  }
+
+  /** @return preliminary hydrostatic test pressure in bara */
+  public double getPreliminaryHydrostaticTestPressureBara() {
+    return preliminaryHydrostaticTestPressureBara;
+  }
+
+  /** @return fractional head rise from rated point to shutoff */
+  public double getHeadRiseToShutoffFraction() {
+    return headRiseToShutoffFraction;
+  }
+
+  /** @return required driver power in kW */
+  public double getRequiredDriverPowerKw() {
+    return requiredDriverPowerKw;
+  }
+
+  /** @return selected driver rating in kW */
+  public double getSelectedDriverPowerKw() {
+    return selectedDriverPowerKw;
+  }
+
+  /** @return calculated L10 bearing life in hours */
+  public double getBearingL10LifeHours() {
+    return bearingL10LifeHours;
+  }
+
+  /** @return first-critical-speed separation ratio */
+  public double getCriticalSpeedRatio() {
+    return criticalSpeedRatio;
+  }
+
+  /** @return immutable check snapshots */
+  public List<CheckResult> getChecks() {
+    return checks;
+  }
+
+  /** @return serializable assessment representation */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("standardEdition", standardEdition);
+    result.put("assessmentStatus", assessmentStatus.name());
+    result.put("operatingRegion", operatingRegion);
+    result.put("operatingFlowRatio", Double.valueOf(operatingFlowRatio));
+    result.put("npshMarginM", Double.valueOf(npshMarginM));
+    result.put("npshMarginRatio", Double.valueOf(npshMarginRatio));
+    result.put("governingShutoffHeadM", Double.valueOf(governingShutoffHeadM));
+    result.put("requiredCasingPressureBara", Double.valueOf(requiredCasingPressureBara));
+    result.put("preliminaryHydrostaticTestPressureBara", Double.valueOf(preliminaryHydrostaticTestPressureBara));
+    result.put("headRiseToShutoffFraction", Double.valueOf(headRiseToShutoffFraction));
+    result.put("requiredDriverPowerKw", Double.valueOf(requiredDriverPowerKw));
+    result.put("selectedDriverPowerKw", Double.valueOf(selectedDriverPowerKw));
+    result.put("bearingL10LifeHours", Double.valueOf(bearingL10LifeHours));
+    result.put("criticalSpeedRatio", Double.valueOf(criticalSpeedRatio));
+    List<Map<String, Object>> checkMaps = new ArrayList<Map<String, Object>>();
+    for (CheckResult check : checks) {
+      checkMaps.add(check.toMap());
+    }
+    result.put("checks", checkMaps);
+    result.put("engineeringApprovalRequired", Boolean.TRUE);
+    return result;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/calculation/PumpApi610DesignKernel.java
+++ b/src/main/java/neqsim/process/engineering/calculation/PumpApi610DesignKernel.java
@@ -106,8 +106,7 @@ public final class PumpApi610DesignKernel
 
     StandardApplicability decision = applicability(input);
     if (!decision.isApplicable()) {
-      readiness.addBlocker("API610_NOT_APPLICABLE", decision.getReason(),
-          "Use API 610 only for a Pump equipment type");
+      readiness.addBlocker("API610_NOT_APPLICABLE", decision.getReason(), "Use API 610 only for a Pump equipment type");
     }
     if (!supports(input.getEdition())) {
       readiness.addBlocker("API610_EDITION_NOT_IMPLEMENTED",
@@ -124,13 +123,12 @@ public final class PumpApi610DesignKernel
   @Override
   public EngineeringCalculationResult<PumpApi610DesignAssessment> calculate(Input input,
       EngineeringCalculationContext context) {
-    EngineeringCalculationContext effectiveContext =
-        context == null ? EngineeringCalculationContext.builder().build() : context;
+    EngineeringCalculationContext effectiveContext = context == null ? EngineeringCalculationContext.builder().build()
+        : context;
     CalculationReadiness readiness = assess(input, effectiveContext);
-    EngineeringCalculationResult.Builder<PumpApi610DesignAssessment> result =
-        EngineeringCalculationResult.<PumpApi610DesignAssessment>builder("api-610-pump-screening", getMethod(),
-            getMethodVersion())
-            .context(effectiveContext).readiness(readiness);
+    EngineeringCalculationResult.Builder<PumpApi610DesignAssessment> result = EngineeringCalculationResult
+        .<PumpApi610DesignAssessment>builder("api-610-pump-screening", getMethod(), getMethodVersion())
+        .context(effectiveContext).readiness(readiness);
 
     if (input == null || !readiness.isReady()) {
       return result.status(EngineeringCalculationResult.Status.BLOCKED)

--- a/src/main/java/neqsim/process/engineering/calculation/PumpApi610DesignKernel.java
+++ b/src/main/java/neqsim/process/engineering/calculation/PumpApi610DesignKernel.java
@@ -1,0 +1,149 @@
+package neqsim.process.engineering.calculation;
+
+import java.io.Serializable;
+import neqsim.process.mechanicaldesign.designstandards.StandardApplicability;
+import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
+import neqsim.process.mechanicaldesign.designstandards.StandardSupportLevel;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator;
+
+/** Pure engineering-workflow adapter for the legacy API 610 screening calculator. */
+public final class PumpApi610DesignKernel
+    implements EquipmentDesignKernel<PumpApi610DesignKernel.Input, PumpApi610DesignAssessment> {
+  private static final long serialVersionUID = 1000L;
+  private static final String IMPLEMENTED_EDITION = "13th Ed";
+
+  /** Immutable, defensively copied kernel input. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final StandardEdition edition;
+    private final String equipmentType;
+    private final PumpApi610DesignCalculator configuration;
+
+    /**
+     * Create a kernel input from a legacy calculator configuration.
+     *
+     * @param edition explicit API 610 edition
+     * @param equipmentType simple equipment class name
+     * @param configuration configured, unexecuted legacy calculator
+     */
+    public Input(StandardEdition edition, String equipmentType, PumpApi610DesignCalculator configuration) {
+      if (edition == null || edition.getStandardType() != StandardType.API_610) {
+        throw new IllegalArgumentException("edition must identify API-610");
+      }
+      if (equipmentType == null || equipmentType.trim().isEmpty()) {
+        throw new IllegalArgumentException("equipmentType cannot be null or blank");
+      }
+      if (configuration == null) {
+        throw new IllegalArgumentException("configuration cannot be null");
+      }
+      this.edition = edition;
+      this.equipmentType = equipmentType.trim();
+      this.configuration = configuration.copyConfiguration();
+    }
+
+    /** @return explicit API 610 edition */
+    public StandardEdition getEdition() {
+      return edition;
+    }
+
+    /** @return simple equipment class name */
+    public String getEquipmentType() {
+      return equipmentType;
+    }
+
+    /** @return independent copy of the legacy calculator configuration */
+    public PumpApi610DesignCalculator getConfiguration() {
+      return configuration.copyConfiguration();
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public StandardType standard() {
+    return StandardType.API_610;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public StandardSupportLevel maturity() {
+    return StandardSupportLevel.SCREENING;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean supports(StandardEdition edition) {
+    return edition != null && edition.getStandardType() == standard()
+        && IMPLEMENTED_EDITION.equalsIgnoreCase(edition.getEdition());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public StandardApplicability applicability(Input input) {
+    return StandardApplicability.assess(standard(), input == null ? null : input.getEquipmentType());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getMethod() {
+    return "api-610-pump-screening";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getMethodVersion() {
+    return "1.0.0";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public CalculationReadiness assess(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness.Builder readiness = CalculationReadiness.builder();
+    if (input == null) {
+      return readiness.addBlocker("API610_INPUT_MISSING", "API 610 kernel input is required",
+          "Provide an explicit edition, equipment type, and calculator configuration").build();
+    }
+
+    StandardApplicability decision = applicability(input);
+    if (!decision.isApplicable()) {
+      readiness.addBlocker("API610_NOT_APPLICABLE", decision.getReason(),
+          "Use API 610 only for a Pump equipment type");
+    }
+    if (!supports(input.getEdition())) {
+      readiness.addBlocker("API610_EDITION_NOT_IMPLEMENTED",
+          "The API 610 kernel implements " + IMPLEMENTED_EDITION + ", not " + input.getEdition().getEdition(),
+          "Select the implemented edition or add separately validated edition logic");
+    }
+    readiness.addWarning("API610_SCREENING_ONLY",
+        "The API 610 kernel provides preliminary screening, not conformity assessment",
+        "Verify the purchased edition, project requirements, and vendor documentation");
+    return readiness.build();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public EngineeringCalculationResult<PumpApi610DesignAssessment> calculate(Input input,
+      EngineeringCalculationContext context) {
+    EngineeringCalculationContext effectiveContext =
+        context == null ? EngineeringCalculationContext.builder().build() : context;
+    CalculationReadiness readiness = assess(input, effectiveContext);
+    EngineeringCalculationResult.Builder<PumpApi610DesignAssessment> result =
+        EngineeringCalculationResult.<PumpApi610DesignAssessment>builder("api-610-pump-screening", getMethod(),
+            getMethodVersion())
+            .context(effectiveContext).readiness(readiness);
+
+    if (input == null || !readiness.isReady()) {
+      return result.status(EngineeringCalculationResult.Status.BLOCKED)
+          .message("API 610 screening is blocked until the readiness findings are resolved").build();
+    }
+
+    PumpApi610DesignCalculator calculator = input.getConfiguration();
+    calculator.setStandardEdition(input.getEdition().getEdition());
+    calculator.calculate();
+    PumpApi610DesignAssessment assessment = PumpApi610DesignAssessment.from(calculator);
+    return result.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED).value(assessment)
+        .input("standard", input.getEdition().getDisplayName()).input("equipmentType", input.getEquipmentType())
+        .warning("API 610 screening does not certify code or vendor compliance")
+        .message("API 610 screening completed; engineering and vendor review remain required").build();
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardApplicability.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardApplicability.java
@@ -29,6 +29,25 @@ public final class StandardApplicability implements Serializable {
     this.reason = reason == null ? "" : reason;
   }
 
+  /**
+   * Assess a standard against a simple equipment class name.
+   *
+   * @param standardType standard to assess
+   * @param equipmentType simple equipment class name
+   * @return structured applicability decision
+   */
+  public static StandardApplicability assess(StandardType standardType, String equipmentType) {
+    if (standardType == null) {
+      throw new IllegalArgumentException("standardType cannot be null");
+    }
+    if (equipmentType == null || equipmentType.trim().isEmpty()) {
+      return unknown(standardType, "An equipment type is required to assess applicability.");
+    }
+    String normalizedEquipmentType = equipmentType.trim();
+    return standardType.appliesTo(normalizedEquipmentType) ? applicable(standardType, normalizedEquipmentType)
+        : notApplicable(standardType, normalizedEquipmentType);
+  }
+
   static StandardApplicability applicable(StandardType standardType, String equipmentType) {
     return new StandardApplicability(standardType, equipmentType, Status.APPLICABLE,
         standardType.getCode() + " lists " + equipmentType + " as applicable equipment.");

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistry.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistry.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import neqsim.process.engineering.calculation.EquipmentDesignKernelRegistry;
 import neqsim.process.mechanicaldesign.MechanicalDesign;
 
 /**
@@ -115,6 +116,11 @@ public final class StandardRegistry {
         throw new StandardSelectionException(StandardSelectionException.Reason.NOT_REGISTRY_CONNECTED, standardType,
             null, support.getLimitation());
       }
+      EquipmentDesignKernelRegistry.Lookup kernel = getDesignKernel(standardType);
+      if (kernel.isImplemented() && !kernel.supports(selection.getEdition())) {
+        throw new StandardSelectionException(StandardSelectionException.Reason.EDITION_NOT_IMPLEMENTED, standardType,
+            null, "No registered kernel implements " + selection.getEdition().getDisplayName());
+      }
 
       StandardApplicability applicability = assessApplicability(standardType, equipment);
       if (applicability.getStatus() == StandardApplicability.Status.UNKNOWN) {
@@ -148,10 +154,17 @@ public final class StandardRegistry {
     }
 
     String equipmentType = equipment.getProcessEquipment().getClass().getSimpleName();
-    if (standardType.appliesTo(equipmentType)) {
-      return StandardApplicability.applicable(standardType, equipmentType);
-    }
-    return StandardApplicability.notApplicable(standardType, equipmentType);
+    return StandardApplicability.assess(standardType, equipmentType);
+  }
+
+  /**
+   * Look up the standard-specific design kernel exposed through the engineering workflow.
+   *
+   * @param standardType standard to inspect
+   * @return explicit implemented or not-implemented lookup
+   */
+  public static EquipmentDesignKernelRegistry.Lookup getDesignKernel(StandardType standardType) {
+    return EquipmentDesignKernelRegistry.lookup(standardType);
   }
 
   private static DesignStandard instantiateStandard(StandardType standardType, String standardName,

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionException.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionException.java
@@ -14,6 +14,8 @@ public final class StandardSelectionException extends IllegalArgumentException {
     CATALOG_ONLY,
     /** A calculation exists elsewhere but is not connected to the registry. */
     NOT_REGISTRY_CONNECTED,
+    /** A kernel exists, but not for the requested edition basis. */
+    EDITION_NOT_IMPLEMENTED,
     /** The standard does not apply to the supplied equipment type. */
     NOT_APPLICABLE
   }

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
@@ -3,6 +3,7 @@ package neqsim.process.mechanicaldesign.designstandards;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import neqsim.process.engineering.calculation.EquipmentDesignKernelRegistry;
 
 /**
  * Produces an auditable view of the calculations behind standards catalogued by NeqSim.
@@ -35,9 +36,11 @@ public final class StandardSupportAudit {
 
     switch (standardType) {
     case API_610:
-      return new StandardSupport(standardType, StandardSupportLevel.SCREENING, false, registryImplementation,
-          "PumpApi610DesignCalculator",
-          "API 610 screening is available through PumpMechanicalDesign but is not selected by StandardRegistry.");
+      EquipmentDesignKernelRegistry.Lookup pumpImplementation = StandardRegistry.getDesignKernel(standardType);
+      return new StandardSupport(standardType, StandardSupportLevel.SCREENING, pumpImplementation.isImplemented(),
+          registryImplementation, pumpImplementation.getImplementationClassName(),
+          "API 610 screening is connected through a pure engineering-workflow adapter; purchased-standard, project, "
+              + "and vendor verification remain required.");
     case API_650:
     case API_620:
       return new StandardSupport(standardType, StandardSupportLevel.CATALOGUED, false, registryImplementation,

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardType.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardType.java
@@ -59,7 +59,7 @@ public enum StandardType {
   // API Standards (American Petroleum Institute)
   API_617("API-617", "Axial and Centrifugal Compressors", "8th Ed", new String[] { "Compressor" },
       "compressor design codes"),
-  API_610("API-610", "Centrifugal Pumps", "12th Ed", new String[] { "Pump" }, "pump design codes"),
+  API_610("API-610", "Centrifugal Pumps", "13th Ed", new String[] { "Pump" }, "pump design codes"),
   API_650("API-650", "Welded Tanks for Oil Storage", "13th Ed", new String[] { "Tank", "SimpleTankFiller" },
       "pressure vessel design code"),
   API_620("API-620", "Large Welded Low-Pressure Storage Tanks", "13th Ed", new String[] { "Tank", "SimpleTankFiller" },

--- a/src/main/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculator.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculator.java
@@ -246,8 +246,8 @@ public class PumpApi610DesignCalculator implements Serializable {
    * Copy all input data and screening criteria without copying calculated results.
    *
    * <p>
-   * The engineering-workflow adapter uses this method to execute the legacy mutable calculator
-   * without mutating caller-owned state.
+   * The engineering-workflow adapter uses this method to execute the legacy mutable calculator without mutating
+   * caller-owned state.
    * </p>
    *
    * @return independent calculator configuration

--- a/src/main/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculator.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/pump/PumpApi610DesignCalculator.java
@@ -242,6 +242,68 @@ public class PumpApi610DesignCalculator implements Serializable {
   private AssessmentStatus assessmentStatus = AssessmentStatus.NOT_EVALUATED;
   private final List<Check> checks = new ArrayList<Check>();
 
+  /**
+   * Copy all input data and screening criteria without copying calculated results.
+   *
+   * <p>
+   * The engineering-workflow adapter uses this method to execute the legacy mutable calculator
+   * without mutating caller-owned state.
+   * </p>
+   *
+   * @return independent calculator configuration
+   */
+  public PumpApi610DesignCalculator copyConfiguration() {
+    PumpApi610DesignCalculator copy = new PumpApi610DesignCalculator();
+    copy.standardEdition = standardEdition;
+    copy.assessmentBasis = assessmentBasis;
+    copy.pumpType = pumpType;
+    copy.pumpTypeSource = pumpTypeSource;
+    copy.dutyPointSource = dutyPointSource;
+    copy.bepSource = bepSource;
+    copy.npshrSource = npshrSource;
+    copy.shutoffHeadSource = shutoffHeadSource;
+    copy.operatingFlowM3h = operatingFlowM3h;
+    copy.ratedHeadM = ratedHeadM;
+    copy.ratedSpeedRpm = ratedSpeedRpm;
+    copy.fluidDensityKgM3 = fluidDensityKgM3;
+    copy.absorbedPowerKw = absorbedPowerKw;
+    copy.bepFlowM3h = bepFlowM3h;
+    copy.bepHeadM = bepHeadM;
+    copy.npshAvailableM = npshAvailableM;
+    copy.npshRequiredM = npshRequiredM;
+    copy.maximumSuctionPressureBara = maximumSuctionPressureBara;
+    copy.furnishedMawpBara = furnishedMawpBara;
+    copy.shutoffHeadM = shutoffHeadM;
+    copy.hydrostaticTestPressureBara = hydrostaticTestPressureBara;
+    copy.porLowFraction = porLowFraction;
+    copy.porHighFraction = porHighFraction;
+    copy.ratedPointLowFraction = ratedPointLowFraction;
+    copy.ratedPointHighFraction = ratedPointHighFraction;
+    copy.aorLowFraction = aorLowFraction;
+    copy.aorHighFraction = aorHighFraction;
+    copy.npshMarginFactor = npshMarginFactor;
+    copy.minimumNpshMarginM = minimumNpshMarginM;
+    copy.assumedShutoffHeadFactor = assumedShutoffHeadFactor;
+    copy.minimumHeadRiseToShutoffFraction = minimumHeadRiseToShutoffFraction;
+    copy.hydrostaticTestPressureFactor = hydrostaticTestPressureFactor;
+    copy.driverMarginFactor = driverMarginFactor;
+    copy.minimumBearingLifeHours = minimumBearingLifeHours;
+    copy.maximumShaftDeflectionMm = maximumShaftDeflectionMm;
+    copy.minimumCriticalSpeedRatio = minimumCriticalSpeedRatio;
+    copy.maximumNozzleLoadUtilization = maximumNozzleLoadUtilization;
+    copy.maximumVibrationVelocityMmS = maximumVibrationVelocityMmS;
+    copy.bearingType = bearingType;
+    copy.bearingDynamicLoadRatingKn = bearingDynamicLoadRatingKn;
+    copy.bearingEquivalentDynamicLoadKn = bearingEquivalentDynamicLoadKn;
+    copy.shaftDeflectionMm = shaftDeflectionMm;
+    copy.firstCriticalSpeedRpm = firstCriticalSpeedRpm;
+    copy.nozzleLoadUtilization = nozzleLoadUtilization;
+    copy.vibrationVelocityMmS = vibrationVelocityMmS;
+    copy.seallessPump = seallessPump;
+    copy.driverCandidateRatingsKw = driverCandidateRatingsKw.clone();
+    return copy;
+  }
+
   /** Evaluates all configured checks and replaces any previous result. */
   public void calculate() {
     checks.clear();

--- a/src/test/java/neqsim/process/engineering/calculation/PumpApi610DesignKernelTest.java
+++ b/src/test/java/neqsim/process/engineering/calculation/PumpApi610DesignKernelTest.java
@@ -1,0 +1,95 @@
+package neqsim.process.engineering.calculation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import neqsim.process.mechanicaldesign.designstandards.StandardApplicability;
+import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
+import neqsim.process.mechanicaldesign.designstandards.StandardSupportLevel;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.Api610PumpType;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.AssessmentStatus;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.BearingType;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.DataSource;
+
+/** Tests the common engineering-kernel adapter for API 610 screening. */
+class PumpApi610DesignKernelTest {
+  @Test
+  void registryReturnsExplicitImplementationStatus() {
+    EquipmentDesignKernelRegistry.Lookup implemented =
+        EquipmentDesignKernelRegistry.lookup(StandardType.API_610);
+    EquipmentDesignKernelRegistry.Lookup absent = EquipmentDesignKernelRegistry.lookup(StandardType.API_660);
+
+    assertEquals(EquipmentDesignKernelRegistry.Status.IMPLEMENTED, implemented.getStatus());
+    assertEquals("PumpApi610DesignKernel", implemented.getImplementationClassName());
+    assertEquals(StandardSupportLevel.SCREENING, implemented.getMaturity());
+    assertTrue(implemented.supports(StandardEdition.defaultEdition(StandardType.API_610)));
+    assertTrue(implemented.requireKernel() instanceof PumpApi610DesignKernel);
+    assertEquals(EquipmentDesignKernelRegistry.Status.NOT_IMPLEMENTED, absent.getStatus());
+    assertEquals("None", absent.getImplementationClassName());
+    assertThrows(IllegalStateException.class, absent::requireKernel);
+  }
+
+  @Test
+  void calculatesWithoutMutatingLegacyConfiguration() {
+    PumpApi610DesignCalculator legacyConfiguration = passingConfiguration();
+    StandardEdition edition = StandardEdition.of(StandardType.API_610, "13th Ed",
+        Collections.singletonList("Project amendment A"));
+    PumpApi610DesignKernel.Input input =
+        new PumpApi610DesignKernel.Input(edition, "Pump", legacyConfiguration);
+    PumpApi610DesignKernel kernel = new PumpApi610DesignKernel();
+    EngineeringCalculationContext context = EngineeringCalculationContext.builder().designCaseId("rated")
+        .addStandardReference(edition.getDisplayName()).build();
+
+    EngineeringCalculationResult<PumpApi610DesignAssessment> result = kernel.calculate(input, context);
+
+    assertEquals(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED, result.getStatus());
+    assertEquals(AssessmentStatus.PASS, result.getValue().getAssessmentStatus());
+    assertEquals("13th Ed", result.getValue().getStandardEdition());
+    assertEquals(30.0, result.getValue().getSelectedDriverPowerKw(), 1.0e-12);
+    assertTrue(result.getValue().toMap().containsKey("checks"));
+    assertThrows(UnsupportedOperationException.class, () -> result.getValue().getChecks().clear());
+    assertEquals(AssessmentStatus.NOT_EVALUATED, legacyConfiguration.getAssessmentStatus());
+    assertTrue(legacyConfiguration.getChecks().isEmpty());
+    assertEquals(StandardType.API_610, kernel.standard());
+    assertEquals(StandardSupportLevel.SCREENING, kernel.maturity());
+    assertEquals(StandardApplicability.Status.APPLICABLE, kernel.applicability(input).getStatus());
+  }
+
+  @Test
+  void blocksInapplicableEquipmentAndRejectsWrongStandard() {
+    PumpApi610DesignKernel kernel = new PumpApi610DesignKernel();
+    PumpApi610DesignKernel.Input separatorInput = new PumpApi610DesignKernel.Input(
+        StandardEdition.defaultEdition(StandardType.API_610), "Separator", passingConfiguration());
+
+    EngineeringCalculationResult<PumpApi610DesignAssessment> result =
+        kernel.calculate(separatorInput, EngineeringCalculationContext.builder().build());
+
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED, result.getStatus());
+    assertEquals(StandardApplicability.Status.NOT_APPLICABLE, kernel.applicability(separatorInput).getStatus());
+    PumpApi610DesignKernel.Input oldEditionInput = new PumpApi610DesignKernel.Input(
+        StandardEdition.of(StandardType.API_610, "12th Ed"), "Pump", passingConfiguration());
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED,
+        kernel.calculate(oldEditionInput, EngineeringCalculationContext.builder().build()).getStatus());
+    assertThrows(IllegalArgumentException.class,
+        () -> new PumpApi610DesignKernel.Input(StandardEdition.defaultEdition(StandardType.API_617), "Pump",
+            passingConfiguration()));
+  }
+
+  private static PumpApi610DesignCalculator passingConfiguration() {
+    PumpApi610DesignCalculator calculator = new PumpApi610DesignCalculator();
+    calculator.setPumpType(Api610PumpType.OH2);
+    calculator.setDutyPoint(100.0, 80.0, 3000.0, 850.0, 25.0);
+    calculator.setBepPoint(100.0, 80.0, DataSource.VENDOR_CURVE);
+    calculator.setNpsh(6.0, 4.0, DataSource.VENDOR_CURVE);
+    calculator.setPressureBasis(5.0, 20.0, 90.0, DataSource.VENDOR_CURVE);
+    calculator.setHydrostaticTestPressureBara(30.0);
+    calculator.setDriverCriteria(1.10, new double[] { 22.0, 30.0, 37.0 });
+    calculator.setBearingData(BearingType.BALL, 100.0, 5.0);
+    calculator.setMechanicalEvidence(0.03, 4000.0, 0.8, 2.5);
+    return calculator;
+  }
+}

--- a/src/test/java/neqsim/process/engineering/calculation/PumpApi610DesignKernelTest.java
+++ b/src/test/java/neqsim/process/engineering/calculation/PumpApi610DesignKernelTest.java
@@ -19,8 +19,7 @@ import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.DataSourc
 class PumpApi610DesignKernelTest {
   @Test
   void registryReturnsExplicitImplementationStatus() {
-    EquipmentDesignKernelRegistry.Lookup implemented =
-        EquipmentDesignKernelRegistry.lookup(StandardType.API_610);
+    EquipmentDesignKernelRegistry.Lookup implemented = EquipmentDesignKernelRegistry.lookup(StandardType.API_610);
     EquipmentDesignKernelRegistry.Lookup absent = EquipmentDesignKernelRegistry.lookup(StandardType.API_660);
 
     assertEquals(EquipmentDesignKernelRegistry.Status.IMPLEMENTED, implemented.getStatus());
@@ -38,8 +37,7 @@ class PumpApi610DesignKernelTest {
     PumpApi610DesignCalculator legacyConfiguration = passingConfiguration();
     StandardEdition edition = StandardEdition.of(StandardType.API_610, "13th Ed",
         Collections.singletonList("Project amendment A"));
-    PumpApi610DesignKernel.Input input =
-        new PumpApi610DesignKernel.Input(edition, "Pump", legacyConfiguration);
+    PumpApi610DesignKernel.Input input = new PumpApi610DesignKernel.Input(edition, "Pump", legacyConfiguration);
     PumpApi610DesignKernel kernel = new PumpApi610DesignKernel();
     EngineeringCalculationContext context = EngineeringCalculationContext.builder().designCaseId("rated")
         .addStandardReference(edition.getDisplayName()).build();
@@ -65,8 +63,8 @@ class PumpApi610DesignKernelTest {
     PumpApi610DesignKernel.Input separatorInput = new PumpApi610DesignKernel.Input(
         StandardEdition.defaultEdition(StandardType.API_610), "Separator", passingConfiguration());
 
-    EngineeringCalculationResult<PumpApi610DesignAssessment> result =
-        kernel.calculate(separatorInput, EngineeringCalculationContext.builder().build());
+    EngineeringCalculationResult<PumpApi610DesignAssessment> result = kernel.calculate(separatorInput,
+        EngineeringCalculationContext.builder().build());
 
     assertEquals(EngineeringCalculationResult.Status.BLOCKED, result.getStatus());
     assertEquals(StandardApplicability.Status.NOT_APPLICABLE, kernel.applicability(separatorInput).getStatus());

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistryTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardRegistryTest.java
@@ -46,7 +46,8 @@ class StandardRegistryTest {
 
   @Test
   void testCreateStandardThrowsOnNull() {
-    assertThrows(IllegalArgumentException.class, () -> StandardRegistry.createStandard(null, mechanicalDesign));
+    assertThrows(IllegalArgumentException.class,
+        () -> StandardRegistry.createStandard((StandardType) null, mechanicalDesign));
   }
 
   @Test

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionTest.java
@@ -95,16 +95,15 @@ class StandardSelectionTest {
   void testStrictSelectionUsesConsolidatedApi610Kernel() {
     MechanicalDesign pumpDesign = new Pump("Test Pump").getMechanicalDesign();
 
-    DesignStandard standard =
-        StandardRegistry.createStandard(StandardSelection.strict(StandardType.API_610), pumpDesign);
+    DesignStandard standard = StandardRegistry.createStandard(StandardSelection.strict(StandardType.API_610),
+        pumpDesign);
 
     assertEquals("API-610 13th Ed", standard.getStandardName());
     assertEquals(EquipmentDesignKernelRegistry.Status.IMPLEMENTED,
         StandardRegistry.getDesignKernel(StandardType.API_610).getStatus());
 
-    StandardSelectionException oldEdition = assertThrows(StandardSelectionException.class,
-        () -> StandardRegistry.createStandard(
-            StandardSelection.strict(StandardEdition.of(StandardType.API_610, "12th Ed")), pumpDesign));
+    StandardSelectionException oldEdition = assertThrows(StandardSelectionException.class, () -> StandardRegistry
+        .createStandard(StandardSelection.strict(StandardEdition.of(StandardType.API_610, "12th Ed")), pumpDesign));
     assertEquals(StandardSelectionException.Reason.EDITION_NOT_IMPLEMENTED, oldEdition.getReason());
   }
 

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionTest.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import neqsim.process.engineering.calculation.EquipmentDesignKernelRegistry;
+import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.mechanicaldesign.MechanicalDesign;
 
@@ -90,11 +92,20 @@ class StandardSelectionTest {
   }
 
   @Test
-  void testStrictSelectionRejectsDisconnectedCalculation() {
-    StandardSelectionException exception = assertThrows(StandardSelectionException.class,
-        () -> StandardRegistry.createStandard(StandardSelection.strict(StandardType.API_610), mechanicalDesign));
+  void testStrictSelectionUsesConsolidatedApi610Kernel() {
+    MechanicalDesign pumpDesign = new Pump("Test Pump").getMechanicalDesign();
 
-    assertEquals(StandardSelectionException.Reason.NOT_REGISTRY_CONNECTED, exception.getReason());
+    DesignStandard standard =
+        StandardRegistry.createStandard(StandardSelection.strict(StandardType.API_610), pumpDesign);
+
+    assertEquals("API-610 13th Ed", standard.getStandardName());
+    assertEquals(EquipmentDesignKernelRegistry.Status.IMPLEMENTED,
+        StandardRegistry.getDesignKernel(StandardType.API_610).getStatus());
+
+    StandardSelectionException oldEdition = assertThrows(StandardSelectionException.class,
+        () -> StandardRegistry.createStandard(
+            StandardSelection.strict(StandardEdition.of(StandardType.API_610, "12th Ed")), pumpDesign));
+    assertEquals(StandardSelectionException.Reason.EDITION_NOT_IMPLEMENTED, oldEdition.getReason());
   }
 
   @Test

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
@@ -32,8 +32,8 @@ class StandardSupportAuditTest {
     StandardSupport pumpSupport = StandardSupportAudit.getSupport(StandardType.API_610);
     assertEquals(StandardSupportLevel.SCREENING, pumpSupport.getSupportLevel());
     assertEquals("DesignStandard", pumpSupport.getRegistryImplementation());
-    assertEquals("PumpApi610DesignCalculator", pumpSupport.getCalculationImplementation());
-    assertFalse(pumpSupport.isRegistryConnected());
+    assertEquals("PumpApi610DesignKernel", pumpSupport.getCalculationImplementation());
+    assertTrue(pumpSupport.isRegistryConnected());
 
     assertEquals(StandardSupportLevel.CATALOGUED,
         StandardSupportAudit.getSupport(StandardType.API_660).getSupportLevel());


### PR DESCRIPTION
## Summary

- introduce `EquipmentDesignKernel<I, O>` as the standards-aware extension of the existing typed engineering calculation API
- add a registry that returns explicit `IMPLEMENTED` / `NOT_IMPLEMENTED` status instead of implying support
- adapt the legacy mutable API 610 calculator through a pure kernel that defensively copies its configuration
- return an immutable API 610 assessment snapshot with calculation provenance and review-gated status
- expose kernel lookup through `StandardRegistry` while preserving all existing `MechanicalDesign` and calculator entry points
- make API 610 edition support fail closed and align the catalog with the implemented 13th-edition screening basis

## Engineering boundary

The API 610 implementation remains `SCREENING`. It does not certify conformity and always requires purchased-standard, project, engineering, and vendor review. The kernel currently accepts only 13th edition; other editions are rejected as `EDITION_NOT_IMPLEMENTED`.

## Compatibility

The adapter does not mutate a caller-owned calculator or `ProcessSystem`. Legacy API 610 usage through `PumpMechanicalDesign` is unchanged. No API 610 numerical criteria or equations are changed in this PR.

## Stacking

This draft is intentionally based on `agent/typed-design-standard-selection` (PR #2547), which is based on PR #2542. It should be rebased and retargeted as the earlier stages merge.

## Validation

- changed core sources compile with the JDK compiler harness
- smoke test executes a complete passing API 610 assessment and verifies the legacy input remains unmodified
- focused test source compiles against the changed core API
- generated standards matrix matches the published documentation exactly
- GitHub Actions provides the authoritative Spotless and repository-level validation
## CI baseline note

- `Spotless format patch`, `PaperLab Replication Gate`, and `Execute complete offshore engineering notebook` pass on the final head.
- The process-to-engineering notebook workflow compiles all production and test sources past this branch's changes, then stops at the unchanged `master` method reference in `FreezingPointTemperatureFlashTest`, where JUnit reports an ambiguous `assertDoesNotThrow` overload.
- The branch-caused null-overload ambiguity in `StandardRegistryTest` was fixed on both stacked branches.