### PR TITLE
Preserve system mechanical design state

### DIFF
--- a/docs/process/mechanical_design.md
+++ b/docs/process/mechanical_design.md
@@ -161,6 +161,10 @@ sysMecDesign.setCompanySpecificDesignStandards("Equinor");
 // Run design calculations for all equipment
 sysMecDesign.runDesignCalculation();
 
+// The aggregate is cached on the ProcessSystem and survives copy/serialization
+boolean calculated = sysMecDesign.hasRunDesignCalculation();
+long revision = sysMecDesign.getDesignCalculationRevision();
+
 // Access aggregated results
 double totalWeight = sysMecDesign.getTotalWeight();           // kg
 double totalVolume = sysMecDesign.getTotalVolume();           // m³
@@ -177,6 +181,13 @@ Map<String, Integer> countByType = sysMecDesign.getEquipmentCountByType();
 // Print summary report
 System.out.println(sysMecDesign.generateSummaryReport());
 ```
+
+System-wide calculation reuses each equipment's current `MechanicalDesign` object. Standards,
+limits, and sizing inputs configured before the call are therefore preserved. Repeated calls
+replace the aggregate totals instead of accumulating them and increment the calculation revision.
+The system-level result is serialized with `ProcessSystem`, including its equipment summaries and
+breakdowns. Collection getters return defensive snapshots, so modifying a returned summary does not
+alter the stored design state.
 
 ## JSON Export
 

--- a/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesign.java
@@ -381,8 +381,7 @@ public class SystemMechanicalDesign implements java.io.Serializable {
    */
   public void setCompanySpecificDesignStandards(String name) {
     for (int i = 0; i < this.processSystem.getUnitOperations().size(); i++) {
-      MechanicalDesign mechanicalDesign = getOrInitializeMechanicalDesign(
-          this.getProcess().getUnitOperations().get(i));
+      MechanicalDesign mechanicalDesign = getOrInitializeMechanicalDesign(this.getProcess().getUnitOperations().get(i));
       if (mechanicalDesign != null) {
         mechanicalDesign.setCompanySpecificDesignStandards(name);
       }

--- a/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesign.java
@@ -112,6 +112,12 @@ public class SystemMechanicalDesign implements java.io.Serializable {
   /** Maximum equipment height [m]. */
   private double maxEquipmentHeight = 0.0;
 
+  /** Whether at least one complete system design calculation has been run. */
+  private boolean designCalculationRun = false;
+
+  /** Monotonic revision number incremented after every complete system design calculation. */
+  private long designCalculationRevision = 0L;
+
   // ============================================================================
   // Equipment Design Summary Inner Class
   // ============================================================================
@@ -143,6 +149,25 @@ public class SystemMechanicalDesign implements java.io.Serializable {
     public EquipmentDesignSummary(String name, String type) {
       this.name = name;
       this.type = type;
+    }
+
+    /**
+     * Copy constructor used when exposing a defensive result snapshot.
+     *
+     * @param source summary to copy
+     */
+    private EquipmentDesignSummary(EquipmentDesignSummary source) {
+      this.name = source.name;
+      this.type = source.type;
+      this.weight = source.weight;
+      this.designPressure = source.designPressure;
+      this.designTemperature = source.designTemperature;
+      this.power = source.power;
+      this.duty = source.duty;
+      this.dimensions = source.dimensions;
+      this.length = source.length;
+      this.width = source.width;
+      this.height = source.height;
     }
 
     /**
@@ -356,7 +381,11 @@ public class SystemMechanicalDesign implements java.io.Serializable {
    */
   public void setCompanySpecificDesignStandards(String name) {
     for (int i = 0; i < this.processSystem.getUnitOperations().size(); i++) {
-      this.getProcess().getUnitOperations().get(i).getMechanicalDesign().setCompanySpecificDesignStandards(name);
+      MechanicalDesign mechanicalDesign = getOrInitializeMechanicalDesign(
+          this.getProcess().getUnitOperations().get(i));
+      if (mechanicalDesign != null) {
+        mechanicalDesign.setCompanySpecificDesignStandards(name);
+      }
     }
   }
 
@@ -364,8 +393,9 @@ public class SystemMechanicalDesign implements java.io.Serializable {
    * Run design calculations for all equipment in the process system.
    *
    * <p>
-   * This method iterates through all unit operations, initializes their mechanical design, runs calculations, and
-   * aggregates the results. After calling this method, all getters will return updated values.
+   * This method iterates through all unit operations, initializes missing mechanical designs, runs calculations, and
+   * aggregates the results. Existing mechanical design objects are retained so caller-supplied standards, limits, and
+   * sizing inputs are not discarded. After calling this method, all getters will return updated values.
    * </p>
    */
   public void runDesignCalculation() {
@@ -380,12 +410,14 @@ public class SystemMechanicalDesign implements java.io.Serializable {
           continue;
         }
 
-        equipment.initMechanicalDesign();
-        MechanicalDesign mecDesign = equipment.getMechanicalDesign();
+        MechanicalDesign mecDesign = getOrInitializeMechanicalDesign(equipment);
+        if (mecDesign == null) {
+          throw new IllegalStateException("Mechanical design is not available for " + equipment.getName());
+        }
         mecDesign.calcDesign();
 
         // Accumulate totals
-        double plotSpace = mecDesign.getModuleHeight() * mecDesign.getModuleLength();
+        double plotSpace = mecDesign.getModuleWidth() * mecDesign.getModuleLength();
         totalPlotSpace += plotSpace;
         totalVolume += mecDesign.getVolumeTotal();
         totalWeight += mecDesign.getWeightTotal();
@@ -414,6 +446,27 @@ public class SystemMechanicalDesign implements java.io.Serializable {
         logger.error("Error processing equipment " + names.get(i) + ": " + ex.getMessage(), ex);
       }
     }
+
+    designCalculationRun = true;
+    designCalculationRevision++;
+  }
+
+  /**
+   * Return the current mechanical design, initializing it only when the equipment has no design yet.
+   *
+   * @param equipment process equipment
+   * @return persistent mechanical design, or {@code null} when the equipment provides none
+   */
+  private MechanicalDesign getOrInitializeMechanicalDesign(ProcessEquipmentInterface equipment) {
+    if (equipment == null) {
+      return null;
+    }
+    MechanicalDesign mechanicalDesign = equipment.getMechanicalDesign();
+    if (mechanicalDesign == null) {
+      equipment.initMechanicalDesign();
+      mechanicalDesign = equipment.getMechanicalDesign();
+    }
+    return mechanicalDesign;
   }
 
   /**
@@ -592,6 +645,9 @@ public class SystemMechanicalDesign implements java.io.Serializable {
     String dims = String.format("%.1fm x %.1fm x %.1fm", mecDesign.getModuleLength(), mecDesign.getModuleWidth(),
         mecDesign.getModuleHeight());
     summary.setDimensions(dims);
+    summary.setLength(mecDesign.getModuleLength());
+    summary.setWidth(mecDesign.getModuleWidth());
+    summary.setHeight(mecDesign.getModuleHeight());
 
     return summary;
   }
@@ -601,7 +657,11 @@ public class SystemMechanicalDesign implements java.io.Serializable {
    */
   public void setDesign() {
     for (int i = 0; i < this.processSystem.getUnitOperations().size(); i++) {
-      this.processSystem.getUnitOperations().get(i).getMechanicalDesign().setDesign();
+      MechanicalDesign mechanicalDesign = getOrInitializeMechanicalDesign(
+          this.processSystem.getUnitOperations().get(i));
+      if (mechanicalDesign != null) {
+        mechanicalDesign.setDesign();
+      }
     }
   }
 
@@ -678,7 +738,29 @@ public class SystemMechanicalDesign implements java.io.Serializable {
    * @return list of equipment design summaries
    */
   public List<EquipmentDesignSummary> getEquipmentList() {
-    return new ArrayList<EquipmentDesignSummary>(equipmentList);
+    List<EquipmentDesignSummary> result = new ArrayList<EquipmentDesignSummary>();
+    for (EquipmentDesignSummary summary : equipmentList) {
+      result.add(new EquipmentDesignSummary(summary));
+    }
+    return result;
+  }
+
+  /**
+   * Check whether this object contains a completed aggregate calculation.
+   *
+   * @return {@code true} after {@link #runDesignCalculation()} completes
+   */
+  public boolean hasRunDesignCalculation() {
+    return designCalculationRun;
+  }
+
+  /**
+   * Get the persistent calculation revision.
+   *
+   * @return number of completed calls to {@link #runDesignCalculation()}
+   */
+  public long getDesignCalculationRevision() {
+    return designCalculationRevision;
   }
 
   /**
@@ -963,10 +1045,14 @@ public class SystemMechanicalDesign implements java.io.Serializable {
   public double getMechanicalWeight(String unit) {
     double weight = 0.0;
     for (int i = 0; i < processSystem.getUnitOperations().size(); i++) {
-      processSystem.getUnitOperations().get(i).getMechanicalDesign().calcDesign();
-      System.out.println("Name " + processSystem.getUnitOperations().get(i).getName() + "  weight "
-          + processSystem.getUnitOperations().get(i).getMechanicalDesign().getWeightTotal());
-      weight += processSystem.getUnitOperations().get(i).getMechanicalDesign().getWeightTotal();
+      ProcessEquipmentInterface equipment = processSystem.getUnitOperations().get(i);
+      MechanicalDesign mechanicalDesign = getOrInitializeMechanicalDesign(equipment);
+      if (mechanicalDesign == null) {
+        continue;
+      }
+      mechanicalDesign.calcDesign();
+      logger.debug("Equipment {} mechanical weight {} kg", equipment.getName(), mechanicalDesign.getWeightTotal());
+      weight += mechanicalDesign.getWeightTotal();
     }
     return weight;
   }
@@ -1067,7 +1153,7 @@ public class SystemMechanicalDesign implements java.io.Serializable {
   @Override
   public int hashCode() {
     return Objects.hash(numberOfModules, processSystem, totalPlotSpace, totalVolume, totalWeight, totalPowerRequired,
-        totalPowerRecovered, totalHeatingDuty, totalCoolingDuty);
+        totalPowerRecovered, totalHeatingDuty, totalCoolingDuty, designCalculationRun, designCalculationRevision);
   }
 
   /** {@inheritDoc} */
@@ -1088,6 +1174,10 @@ public class SystemMechanicalDesign implements java.io.Serializable {
         && Double.doubleToLongBits(totalVolume) == Double.doubleToLongBits(other.totalVolume)
         && Double.doubleToLongBits(totalWeight) == Double.doubleToLongBits(other.totalWeight)
         && Double.doubleToLongBits(totalPowerRequired) == Double.doubleToLongBits(other.totalPowerRequired)
-        && Double.doubleToLongBits(totalPowerRecovered) == Double.doubleToLongBits(other.totalPowerRecovered);
+        && Double.doubleToLongBits(totalPowerRecovered) == Double.doubleToLongBits(other.totalPowerRecovered)
+        && Double.doubleToLongBits(totalHeatingDuty) == Double.doubleToLongBits(other.totalHeatingDuty)
+        && Double.doubleToLongBits(totalCoolingDuty) == Double.doubleToLongBits(other.totalCoolingDuty)
+        && designCalculationRun == other.designCalculationRun
+        && designCalculationRevision == other.designCalculationRevision;
   }
 }

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -7947,8 +7947,8 @@ public class ProcessSystem extends SimulationBaseClass {
   // Mechanical Design and Cost Estimation API
   // ============================================================================
 
-  /** System-level mechanical design (lazy initialized). */
-  private transient neqsim.process.mechanicaldesign.SystemMechanicalDesign systemMechanicalDesign;
+  /** System-level mechanical design (lazy initialized and persisted with the process). */
+  private neqsim.process.mechanicaldesign.SystemMechanicalDesign systemMechanicalDesign;
 
   /** Process-level cost estimate (lazy initialized). */
   private transient neqsim.process.costestimation.ProcessCostEstimate processCostEstimate;
@@ -7957,8 +7957,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * Initialize mechanical design for all equipment in the process.
    *
    * <p>
-   * This method calls initMechanicalDesign() on each equipment item, preparing them for mechanical design calculations.
-   * Should be called after process simulation has run.
+   * This method initializes equipment that does not yet have a mechanical design. Existing design objects are retained
+   * so configured standards, limits, and sizing inputs remain part of the process design state. It should be called
+   * after process simulation has run.
    * </p>
    *
    * <p>
@@ -7968,7 +7969,7 @@ public class ProcessSystem extends SimulationBaseClass {
   public void initAllMechanicalDesigns() {
     for (ProcessEquipmentInterface equipment : unitOperations) {
       if (equipment != null) {
-        equipment.initMechanicalDesign();
+        getOrInitializeMechanicalDesign(equipment);
       }
     }
   }
@@ -7988,14 +7989,28 @@ public class ProcessSystem extends SimulationBaseClass {
   public void runAllMechanicalDesigns() {
     for (ProcessEquipmentInterface equipment : unitOperations) {
       if (equipment != null) {
-        // Ensure mechanical design is initialized
-        equipment.initMechanicalDesign();
-        neqsim.process.mechanicaldesign.MechanicalDesign mecDesign = equipment.getMechanicalDesign();
+        neqsim.process.mechanicaldesign.MechanicalDesign mecDesign = getOrInitializeMechanicalDesign(equipment);
         if (mecDesign != null) {
           mecDesign.calcDesign();
         }
       }
     }
+  }
+
+  /**
+   * Return the current mechanical design, initializing it only when it is absent.
+   *
+   * @param equipment process equipment
+   * @return persistent mechanical design, or {@code null} when the equipment provides none
+   */
+  private neqsim.process.mechanicaldesign.MechanicalDesign getOrInitializeMechanicalDesign(
+      ProcessEquipmentInterface equipment) {
+    neqsim.process.mechanicaldesign.MechanicalDesign mechanicalDesign = equipment.getMechanicalDesign();
+    if (mechanicalDesign == null) {
+      equipment.initMechanicalDesign();
+      mechanicalDesign = equipment.getMechanicalDesign();
+    }
+    return mechanicalDesign;
   }
 
   /**
@@ -8201,8 +8216,7 @@ public class ProcessSystem extends SimulationBaseClass {
     if (equipment == null) {
       return null;
     }
-    equipment.initMechanicalDesign();
-    neqsim.process.mechanicaldesign.MechanicalDesign mecDesign = equipment.getMechanicalDesign();
+    neqsim.process.mechanicaldesign.MechanicalDesign mecDesign = getOrInitializeMechanicalDesign(equipment);
     if (mecDesign != null) {
       mecDesign.calcDesign();
     }

--- a/src/test/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignTest.java
@@ -1,10 +1,15 @@
 package neqsim.process.mechanicaldesign;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import neqsim.process.costestimation.CostEstimateBaseClass;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.pipeline.AdiabaticPipe;
 import neqsim.process.equipment.pump.Pump;
@@ -23,6 +28,62 @@ import neqsim.thermo.system.SystemSrkEos;
 
 public class SystemMechanicalDesignTest {
   private static final Logger logger = LogManager.getLogger(SystemMechanicalDesignTest.class);
+
+  private static final class PersistentTestEquipment extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private CountingMechanicalDesign mechanicalDesign;
+    private int initializationCount;
+
+    private PersistentTestEquipment(String name) {
+      super(name);
+      mechanicalDesign = new CountingMechanicalDesign(this);
+    }
+
+    @Override
+    public MechanicalDesign getMechanicalDesign() {
+      return mechanicalDesign;
+    }
+
+    @Override
+    public void initMechanicalDesign() {
+      initializationCount++;
+      mechanicalDesign = new CountingMechanicalDesign(this);
+    }
+
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+
+    private int getInitializationCount() {
+      return initializationCount;
+    }
+  }
+
+  private static final class CountingMechanicalDesign extends MechanicalDesign {
+    private static final long serialVersionUID = 1000L;
+    private int calculationCount;
+
+    private CountingMechanicalDesign(PersistentTestEquipment equipment) {
+      super(equipment);
+    }
+
+    @Override
+    public void calcDesign() {
+      calculationCount++;
+      setWeightTotal(120.0);
+      setVolumeTotal(12.0);
+      setModuleLength(4.0);
+      setModuleWidth(3.0);
+      setModuleHeight(2.0);
+      setMaxOperationPressure(50.0);
+      setMaxOperationTemperature(60.0);
+    }
+
+    private int getCalculationCount() {
+      return calculationCount;
+    }
+  }
 
   static neqsim.process.processmodel.ProcessSystem operations;
 
@@ -124,6 +185,63 @@ public class SystemMechanicalDesignTest {
     operations.add(recycle1);
 
     operations.run();
+  }
+
+  @Test
+  void processHelpersPreserveConfiguredMechanicalDesign() {
+    neqsim.process.processmodel.ProcessSystem process = new neqsim.process.processmodel.ProcessSystem();
+    PersistentTestEquipment equipment = new PersistentTestEquipment("configured equipment");
+    process.add(equipment);
+    CountingMechanicalDesign configuredDesign = (CountingMechanicalDesign) equipment.getMechanicalDesign();
+    configuredDesign.setMaxDesignPower(321.0);
+
+    process.initAllMechanicalDesigns();
+    process.runAllMechanicalDesigns();
+    MechanicalDesign selectedDesign = process.getEquipmentMechanicalDesign(equipment.getName());
+
+    assertSame(configuredDesign, selectedDesign);
+    assertSame(configuredDesign, equipment.getMechanicalDesign());
+    assertEquals(0, equipment.getInitializationCount());
+    assertEquals(2, configuredDesign.getCalculationCount());
+    assertEquals(321.0, configuredDesign.getPower(), 1.0e-12);
+  }
+
+  @Test
+  void aggregateStateIsRepeatableDefensiveAndPersistent() {
+    neqsim.process.processmodel.ProcessSystem process = new neqsim.process.processmodel.ProcessSystem();
+    PersistentTestEquipment equipment = new PersistentTestEquipment("persistent equipment");
+    process.add(equipment);
+    CountingMechanicalDesign configuredDesign = (CountingMechanicalDesign) equipment.getMechanicalDesign();
+    configuredDesign.setMaxDesignPower(654.0);
+    SystemMechanicalDesign systemDesign = process.getSystemMechanicalDesign();
+
+    systemDesign.runDesignCalculation();
+    systemDesign.runDesignCalculation();
+
+    assertSame(configuredDesign, equipment.getMechanicalDesign());
+    assertEquals(0, equipment.getInitializationCount());
+    assertEquals(2, configuredDesign.getCalculationCount());
+    assertTrue(systemDesign.hasRunDesignCalculation());
+    assertEquals(2L, systemDesign.getDesignCalculationRevision());
+    assertEquals(120.0, systemDesign.getTotalWeight(), 1.0e-12);
+    assertEquals(12.0, systemDesign.getTotalVolume(), 1.0e-12);
+    assertEquals(12.0, systemDesign.getTotalPlotSpace(), 1.0e-12);
+    assertEquals(1, systemDesign.getEquipmentList().size());
+    assertEquals(4.0, systemDesign.getEquipmentList().get(0).getLength(), 1.0e-12);
+
+    systemDesign.getEquipmentList().get(0).setWeight(999.0);
+    assertEquals(120.0, systemDesign.getEquipmentList().get(0).getWeight(), 1.0e-12);
+
+    neqsim.process.processmodel.ProcessSystem restoredProcess = process.copy();
+    SystemMechanicalDesign restoredDesign = restoredProcess.getSystemMechanicalDesign();
+    PersistentTestEquipment restoredEquipment = (PersistentTestEquipment) restoredProcess
+        .getUnit("persistent equipment");
+
+    assertSame(restoredProcess, restoredDesign.getProcess());
+    assertTrue(restoredDesign.hasRunDesignCalculation());
+    assertEquals(2L, restoredDesign.getDesignCalculationRevision());
+    assertEquals(120.0, restoredDesign.getTotalWeight(), 1.0e-12);
+    assertEquals(654.0, restoredEquipment.getMechanicalDesign().getPower(), 1.0e-12);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- preserve configured equipment `MechanicalDesign` instances during system-wide initialization, execution, and equipment-specific access
- persist the cached `SystemMechanicalDesign` with `ProcessSystem` copies and Java serialization
- expose whether aggregation has run and a monotonic calculation revision
- return deep defensive equipment-summary snapshots and retain numeric dimensions
- correct total plot space from module height × length to module width × length
- remove direct console output from mechanical-weight aggregation

## Correctness boundary

This PR intentionally preserves the existing per-equipment exception handling in `SystemMechanicalDesign`. Structured failure propagation is the next correctness slice. It does not change any equipment sizing equations or standards implementation.

## Compatibility

Existing public entry points remain available. `initAllMechanicalDesigns()` is now idempotent for already initialized equipment, so caller-configured standards, limits, and sizing inputs are retained. Older serialized `ProcessSystem` objects remain compatible because the added persisted aggregate field defaults to `null` and is lazily recreated.

## Stacking

This draft is intentionally based on `agent/design-kernel-api-consolidation` (PR #2549), which is based on PR #2547 and PR #2542. It should be rebased and retargeted as the earlier stages merge.

## Validation

- Java 8 compiler harness compiles the changed `SystemMechanicalDesign` against minimal dependency stubs
- behavioral smoke test covers repeat execution, configured-object identity, stable totals, corrected footprint, defensive summaries, Java serialization, and restored process back-reference
- repository parse reached dependency resolution without syntax errors; the local environment cannot download Maven dependencies
- GitHub Actions is the authoritative Spotless and repository-level validation