### PR TITLE
Add typed unit-aware design conditions

### DIFF
--- a/docs/process/mechanical_design.md
+++ b/docs/process/mechanical_design.md
@@ -125,6 +125,10 @@ MechanicalDesign mecDesign = separator.getMechanicalDesign();
 // Set design standards (optional - uses defaults if not specified)
 mecDesign.setCompanySpecificDesignStandards("Equinor");
 
+// Prefer explicit units for operating conditions; canonical storage is bara and K
+mecDesign.setMaxOperationPressure(1450.38, "psia");
+mecDesign.setMaxOperationTemperature(250.0, "F");
+
 // Calculate design
 mecDesign.calcDesign();
 
@@ -138,6 +142,30 @@ double designPressure = mecDesign.getMaxDesignPressure(); // bara
 // Display results in GUI
 mecDesign.displayResults();
 ```
+
+### Declared design conditions and units
+
+`DesignConditions` stores data-sheet declarations separately from calculated sizing results. Legacy
+single-argument setters retain their documented canonical units: pressure in `bara`, temperature in
+degrees Celsius, and corrosion allowance in `mm`. Unit-aware overloads should be preferred for new
+code:
+
+```java
+DesignConditions conditions = separator.getDesignConditions();
+conditions.setDesignPressure(1450.38, "psia");
+conditions.setMaxDesignTemperature(250.0, "F");
+conditions.setMinDesignTemperature(-50.0, "C");
+conditions.setReliefSetPressure(100.0, "barg");
+conditions.setCorrosionAllowance(0.125, "in");
+
+double designPressureBara = conditions.getDesignPressure("bara");
+double maximumTemperatureC = conditions.getMaxDesignTemperature("C");
+```
+
+`DesignConditionValue` adds an immutable typed representation for pressure, temperature, and length
+conditions. `DesignConditions.getCondition(type)` and `getConditions()` expose typed defensive
+snapshots. Values are converted to the condition's canonical unit on creation, invalid units fail
+closed, and physically impossible pressure, temperature, or corrosion values are rejected.
 
 ### System-Wide Mechanical Design
 

--- a/src/main/java/neqsim/process/mechanicaldesign/DesignConditionValue.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/DesignConditionValue.java
@@ -1,0 +1,157 @@
+package neqsim.process.mechanicaldesign;
+
+import java.io.Serializable;
+import java.util.Objects;
+import neqsim.util.unit.LengthUnit;
+import neqsim.util.unit.PressureUnit;
+import neqsim.util.unit.TemperatureUnit;
+
+/** Immutable, typed engineering value for one declared equipment design condition. */
+public final class DesignConditionValue implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private enum Dimension {
+    PRESSURE,
+    TEMPERATURE,
+    LENGTH
+  }
+
+  /** Supported declared design-condition quantities and their canonical storage units. */
+  public enum Type {
+    /** Maximum allowable working pressure, stored in bara. */
+    DESIGN_PRESSURE(Dimension.PRESSURE, "bara"),
+    /** Maximum design temperature, stored in degrees Celsius. */
+    MAX_DESIGN_TEMPERATURE(Dimension.TEMPERATURE, "C"),
+    /** Minimum design metal temperature, stored in degrees Celsius. */
+    MIN_DESIGN_TEMPERATURE(Dimension.TEMPERATURE, "C"),
+    /** Protecting relief-device set pressure, stored in bara. */
+    RELIEF_SET_PRESSURE(Dimension.PRESSURE, "bara"),
+    /** Corrosion allowance, stored in millimetres. */
+    CORROSION_ALLOWANCE(Dimension.LENGTH, "mm");
+
+    private final Dimension dimension;
+    private final String canonicalUnit;
+
+    Type(Dimension dimension, String canonicalUnit) {
+      this.dimension = dimension;
+      this.canonicalUnit = canonicalUnit;
+    }
+
+    /** @return canonical storage unit */
+    public String getCanonicalUnit() {
+      return canonicalUnit;
+    }
+  }
+
+  private final Type type;
+  private final double canonicalValue;
+
+  private DesignConditionValue(Type type, double canonicalValue) {
+    this.type = type;
+    this.canonicalValue = canonicalValue;
+  }
+
+  /**
+   * Create a typed condition and convert it to the quantity's canonical unit.
+   *
+   * @param type declared condition type
+   * @param value numeric value
+   * @param unit engineering unit
+   * @return immutable typed value
+   */
+  public static DesignConditionValue of(Type type, double value, String unit) {
+    if (type == null) {
+      throw new IllegalArgumentException("type cannot be null");
+    }
+    if (unit == null || unit.trim().isEmpty()) {
+      throw new IllegalArgumentException("unit cannot be blank");
+    }
+    if (Double.isNaN(value) || Double.isInfinite(value)) {
+      throw new IllegalArgumentException("value must be finite");
+    }
+
+    double converted = convert(value, unit.trim(), type.getCanonicalUnit(), type.dimension);
+    validatePhysicalRange(type, converted);
+    return new DesignConditionValue(type, converted);
+  }
+
+  /** @return declared condition type */
+  public Type getType() {
+    return type;
+  }
+
+  /** @return value in the canonical unit returned by {@link Type#getCanonicalUnit()} */
+  public double getCanonicalValue() {
+    return canonicalValue;
+  }
+
+  /** @return canonical storage unit */
+  public String getCanonicalUnit() {
+    return type.getCanonicalUnit();
+  }
+
+  /**
+   * Convert this condition to another compatible engineering unit.
+   *
+   * @param unit requested unit
+   * @return converted value
+   */
+  public double getValue(String unit) {
+    if (unit == null || unit.trim().isEmpty()) {
+      throw new IllegalArgumentException("unit cannot be blank");
+    }
+    return convert(canonicalValue, type.getCanonicalUnit(), unit.trim(), type.dimension);
+  }
+
+  private static double convert(double value, String fromUnit, String toUnit, Dimension dimension) {
+    switch (dimension) {
+    case PRESSURE:
+      return new PressureUnit(value, fromUnit).getValue(toUnit);
+    case TEMPERATURE:
+      return new TemperatureUnit(value, fromUnit).getValue(toUnit);
+    case LENGTH:
+      return new LengthUnit(value, fromUnit).getValue(toUnit);
+    default:
+      throw new IllegalStateException("Unsupported condition dimension " + dimension);
+    }
+  }
+
+  private static void validatePhysicalRange(Type type, double canonicalValue) {
+    if ((type == Type.DESIGN_PRESSURE || type == Type.RELIEF_SET_PRESSURE) && canonicalValue < 0.0) {
+      throw new IllegalArgumentException(type + " cannot be below absolute vacuum");
+    }
+    if (type == Type.CORROSION_ALLOWANCE && canonicalValue < 0.0) {
+      throw new IllegalArgumentException("CORROSION_ALLOWANCE cannot be negative");
+    }
+    if ((type == Type.MAX_DESIGN_TEMPERATURE || type == Type.MIN_DESIGN_TEMPERATURE)
+        && new TemperatureUnit(canonicalValue, "C").getValue("K") < 0.0) {
+      throw new IllegalArgumentException(type + " cannot be below absolute zero");
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, Double.valueOf(canonicalValue));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof DesignConditionValue)) {
+      return false;
+    }
+    DesignConditionValue other = (DesignConditionValue) obj;
+    return type == other.type
+        && Double.doubleToLongBits(canonicalValue) == Double.doubleToLongBits(other.canonicalValue);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return type + "=" + canonicalValue + " " + type.getCanonicalUnit();
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/DesignConditionValue.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/DesignConditionValue.java
@@ -11,9 +11,7 @@ public final class DesignConditionValue implements Serializable {
   private static final long serialVersionUID = 1000L;
 
   private enum Dimension {
-    PRESSURE,
-    TEMPERATURE,
-    LENGTH
+    PRESSURE, TEMPERATURE, LENGTH
   }
 
   /** Supported declared design-condition quantities and their canonical storage units. */

--- a/src/main/java/neqsim/process/mechanicaldesign/DesignConditions.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/DesignConditions.java
@@ -1,7 +1,12 @@
 package neqsim.process.mechanicaldesign;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
 import com.google.gson.GsonBuilder;
+import neqsim.process.mechanicaldesign.DesignConditionValue.Type;
 
 /**
  * Lightweight holder for the explicit nameplate design conditions of a piece of process equipment.
@@ -76,12 +81,33 @@ public final class DesignConditions implements Serializable {
   }
 
   /**
+   * Sets the design pressure using an explicit absolute or gauge pressure unit.
+   *
+   * @param value design pressure
+   * @param unit pressure unit supported by {@code PressureUnit}
+   * @return this holder for chaining
+   */
+  public DesignConditions setDesignPressure(double value, String unit) {
+    return setCondition(DesignConditionValue.of(Type.DESIGN_PRESSURE, value, unit));
+  }
+
+  /**
    * Gets the design pressure (maximum allowable working pressure, MAWP).
    *
    * @return design pressure in bara, or {@link Double#NaN} if not set
    */
   public double getDesignPressure() {
     return designPressureBara;
+  }
+
+  /**
+   * Gets the design pressure in an explicit pressure unit.
+   *
+   * @param unit requested pressure unit
+   * @return converted pressure, or {@link Double#NaN} if not set
+   */
+  public double getDesignPressure(String unit) {
+    return convertIfSet(Type.DESIGN_PRESSURE, designPressureBara, unit);
   }
 
   /**
@@ -105,12 +131,33 @@ public final class DesignConditions implements Serializable {
   }
 
   /**
+   * Sets the maximum design temperature using an explicit temperature unit.
+   *
+   * @param value maximum design temperature
+   * @param unit temperature unit supported by {@code TemperatureUnit}
+   * @return this holder for chaining
+   */
+  public DesignConditions setMaxDesignTemperature(double value, String unit) {
+    return setCondition(DesignConditionValue.of(Type.MAX_DESIGN_TEMPERATURE, value, unit));
+  }
+
+  /**
    * Gets the maximum design temperature.
    *
    * @return maximum design temperature in degrees Celsius, or {@link Double#NaN} if not set
    */
   public double getMaxDesignTemperature() {
     return maxDesignTemperatureC;
+  }
+
+  /**
+   * Gets the maximum design temperature in an explicit unit.
+   *
+   * @param unit requested temperature unit
+   * @return converted temperature, or {@link Double#NaN} if not set
+   */
+  public double getMaxDesignTemperature(String unit) {
+    return convertIfSet(Type.MAX_DESIGN_TEMPERATURE, maxDesignTemperatureC, unit);
   }
 
   /**
@@ -134,12 +181,33 @@ public final class DesignConditions implements Serializable {
   }
 
   /**
+   * Sets the minimum design metal temperature using an explicit temperature unit.
+   *
+   * @param value minimum design metal temperature
+   * @param unit temperature unit supported by {@code TemperatureUnit}
+   * @return this holder for chaining
+   */
+  public DesignConditions setMinDesignTemperature(double value, String unit) {
+    return setCondition(DesignConditionValue.of(Type.MIN_DESIGN_TEMPERATURE, value, unit));
+  }
+
+  /**
    * Gets the minimum design metal temperature (MDMT).
    *
    * @return minimum design metal temperature in degrees Celsius, or {@link Double#NaN} if not set
    */
   public double getMinDesignTemperature() {
     return minDesignTemperatureC;
+  }
+
+  /**
+   * Gets the minimum design metal temperature in an explicit unit.
+   *
+   * @param unit requested temperature unit
+   * @return converted temperature, or {@link Double#NaN} if not set
+   */
+  public double getMinDesignTemperature(String unit) {
+    return convertIfSet(Type.MIN_DESIGN_TEMPERATURE, minDesignTemperatureC, unit);
   }
 
   /**
@@ -163,12 +231,33 @@ public final class DesignConditions implements Serializable {
   }
 
   /**
+   * Sets the relief set pressure using an explicit absolute or gauge pressure unit.
+   *
+   * @param value relief set pressure
+   * @param unit pressure unit supported by {@code PressureUnit}
+   * @return this holder for chaining
+   */
+  public DesignConditions setReliefSetPressure(double value, String unit) {
+    return setCondition(DesignConditionValue.of(Type.RELIEF_SET_PRESSURE, value, unit));
+  }
+
+  /**
    * Gets the relief (PSV) set pressure protecting the equipment.
    *
    * @return relief set pressure in bara, or {@link Double#NaN} if not set
    */
   public double getReliefSetPressure() {
     return reliefSetPressureBara;
+  }
+
+  /**
+   * Gets the relief set pressure in an explicit pressure unit.
+   *
+   * @param unit requested pressure unit
+   * @return converted pressure, or {@link Double#NaN} if not set
+   */
+  public double getReliefSetPressure(String unit) {
+    return convertIfSet(Type.RELIEF_SET_PRESSURE, reliefSetPressureBara, unit);
   }
 
   /**
@@ -192,12 +281,33 @@ public final class DesignConditions implements Serializable {
   }
 
   /**
+   * Sets the corrosion allowance using an explicit length unit.
+   *
+   * @param value corrosion allowance
+   * @param unit length unit supported by {@code LengthUnit}
+   * @return this holder for chaining
+   */
+  public DesignConditions setCorrosionAllowance(double value, String unit) {
+    return setCondition(DesignConditionValue.of(Type.CORROSION_ALLOWANCE, value, unit));
+  }
+
+  /**
    * Gets the corrosion allowance.
    *
    * @return corrosion allowance in mm, or {@link Double#NaN} if not set
    */
   public double getCorrosionAllowance() {
     return corrosionAllowanceMm;
+  }
+
+  /**
+   * Gets the corrosion allowance in an explicit length unit.
+   *
+   * @param unit requested length unit
+   * @return converted allowance, or {@link Double#NaN} if not set
+   */
+  public double getCorrosionAllowance(String unit) {
+    return convertIfSet(Type.CORROSION_ALLOWANCE, corrosionAllowanceMm, unit);
   }
 
   /**
@@ -265,6 +375,88 @@ public final class DesignConditions implements Serializable {
    */
   public boolean isFailureActionSet() {
     return failureAction != null && failureAction != FailureAction.NOT_SPECIFIED;
+  }
+
+  /**
+   * Set one immutable typed design condition.
+   *
+   * @param condition typed value to store
+   * @return this holder for chaining
+   */
+  public DesignConditions setCondition(DesignConditionValue condition) {
+    if (condition == null) {
+      throw new IllegalArgumentException("condition cannot be null");
+    }
+    switch (condition.getType()) {
+    case DESIGN_PRESSURE:
+      return setDesignPressure(condition.getCanonicalValue());
+    case MAX_DESIGN_TEMPERATURE:
+      return setMaxDesignTemperature(condition.getCanonicalValue());
+    case MIN_DESIGN_TEMPERATURE:
+      return setMinDesignTemperature(condition.getCanonicalValue());
+    case RELIEF_SET_PRESSURE:
+      return setReliefSetPressure(condition.getCanonicalValue());
+    case CORROSION_ALLOWANCE:
+      return setCorrosionAllowance(condition.getCanonicalValue());
+    default:
+      throw new IllegalStateException("Unsupported design condition " + condition.getType());
+    }
+  }
+
+  /**
+   * Get one typed condition when it has been declared.
+   *
+   * @param type condition type
+   * @return typed value, or empty when the condition is unset
+   */
+  public Optional<DesignConditionValue> getCondition(Type type) {
+    if (type == null) {
+      throw new IllegalArgumentException("type cannot be null");
+    }
+    switch (type) {
+    case DESIGN_PRESSURE:
+      return conditionIfSet(type, designPressureBara);
+    case MAX_DESIGN_TEMPERATURE:
+      return conditionIfSet(type, maxDesignTemperatureC);
+    case MIN_DESIGN_TEMPERATURE:
+      return conditionIfSet(type, minDesignTemperatureC);
+    case RELIEF_SET_PRESSURE:
+      return conditionIfSet(type, reliefSetPressureBara);
+    case CORROSION_ALLOWANCE:
+      return conditionIfSet(type, corrosionAllowanceMm);
+    default:
+      throw new IllegalStateException("Unsupported design condition " + type);
+    }
+  }
+
+  /**
+   * Get an immutable snapshot of all declared typed numeric conditions.
+   *
+   * @return map keyed by condition type
+   */
+  public Map<Type, DesignConditionValue> getConditions() {
+    Map<Type, DesignConditionValue> result = new EnumMap<Type, DesignConditionValue>(Type.class);
+    for (Type type : Type.values()) {
+      Optional<DesignConditionValue> condition = getCondition(type);
+      if (condition.isPresent()) {
+        result.put(type, condition.get());
+      }
+    }
+    return Collections.unmodifiableMap(result);
+  }
+
+  private Optional<DesignConditionValue> conditionIfSet(Type type, double canonicalValue) {
+    if (Double.isNaN(canonicalValue)) {
+      return Optional.empty();
+    }
+    return Optional.of(DesignConditionValue.of(type, canonicalValue, type.getCanonicalUnit()));
+  }
+
+  private double convertIfSet(Type type, double canonicalValue, String unit) {
+    if (Double.isNaN(canonicalValue)) {
+      return Double.NaN;
+    }
+    return DesignConditionValue.of(type, canonicalValue, type.getCanonicalUnit()).getValue(unit);
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/DesignLimitData.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/DesignLimitData.java
@@ -12,10 +12,15 @@ public final class DesignLimitData implements Serializable {
   /** Empty data set with undefined limits. */
   public static final DesignLimitData EMPTY = DesignLimitData.builder().build();
 
+  /** Maximum pressure limit in bara. */
   private final double maxPressure;
+  /** Minimum pressure limit in bara. */
   private final double minPressure;
+  /** Maximum temperature limit in kelvin. */
   private final double maxTemperature;
+  /** Minimum temperature limit in kelvin. */
   private final double minTemperature;
+  /** Corrosion allowance in millimetres. */
   private final double corrosionAllowance;
   private final double jointEfficiency;
 

--- a/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesign.java
@@ -36,6 +36,8 @@ import neqsim.process.mechanicaldesign.designstandards.StandardRegistry;
 import neqsim.process.mechanicaldesign.designstandards.StandardSelection;
 import neqsim.process.mechanicaldesign.designstandards.StandardType;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
+import neqsim.util.unit.PressureUnit;
+import neqsim.util.unit.TemperatureUnit;
 
 /**
  * MechanicalDesign class.
@@ -686,16 +688,56 @@ public class MechanicalDesign implements java.io.Serializable {
     return designLimitData.getMaxPressure();
   }
 
+  /**
+   * Gets the maximum pressure limit in an explicit pressure unit.
+   *
+   * @param unit requested pressure unit
+   * @return converted maximum pressure limit
+   */
+  public double getDesignMaxPressureLimit(String unit) {
+    return new PressureUnit(getDesignMaxPressureLimit(), "bara").getValue(unit);
+  }
+
   public double getDesignMinPressureLimit() {
     return designLimitData.getMinPressure();
+  }
+
+  /**
+   * Gets the minimum pressure limit in an explicit pressure unit.
+   *
+   * @param unit requested pressure unit
+   * @return converted minimum pressure limit
+   */
+  public double getDesignMinPressureLimit(String unit) {
+    return new PressureUnit(getDesignMinPressureLimit(), "bara").getValue(unit);
   }
 
   public double getDesignMaxTemperatureLimit() {
     return designLimitData.getMaxTemperature();
   }
 
+  /**
+   * Gets the maximum temperature limit in an explicit temperature unit.
+   *
+   * @param unit requested temperature unit
+   * @return converted maximum temperature limit
+   */
+  public double getDesignMaxTemperatureLimit(String unit) {
+    return new TemperatureUnit(getDesignMaxTemperatureLimit(), "K").getValue(unit);
+  }
+
   public double getDesignMinTemperatureLimit() {
     return designLimitData.getMinTemperature();
+  }
+
+  /**
+   * Gets the minimum temperature limit in an explicit temperature unit.
+   *
+   * @param unit requested temperature unit
+   * @return converted minimum temperature limit
+   */
+  public double getDesignMinTemperatureLimit(String unit) {
+    return new TemperatureUnit(getDesignMinTemperatureLimit(), "K").getValue(unit);
   }
 
   public double getDesignCorrosionAllowance() {
@@ -763,10 +805,20 @@ public class MechanicalDesign implements java.io.Serializable {
   /**
    * Getter for the field <code>maxOperationPressure</code>.
    *
-   * @return the maxPressure
+   * @return maximum operating pressure in bara
    */
   public double getMaxOperationPressure() {
     return maxOperationPressure;
+  }
+
+  /**
+   * Gets the maximum operating pressure in an explicit pressure unit.
+   *
+   * @param unit requested pressure unit
+   * @return converted maximum operating pressure
+   */
+  public double getMaxOperationPressure(String unit) {
+    return new PressureUnit(maxOperationPressure, "bara").getValue(unit);
   }
 
   /**
@@ -779,12 +831,32 @@ public class MechanicalDesign implements java.io.Serializable {
   }
 
   /**
+   * Gets the maximum design pressure in an explicit pressure unit.
+   *
+   * @param unit requested pressure unit
+   * @return converted maximum design pressure
+   */
+  public double getMaxDesignPressure(String unit) {
+    return new PressureUnit(getMaxDesignPressure(), "bara").getValue(unit);
+  }
+
+  /**
    * getMinDesignPressure.
    *
    * @return a double
    */
   public double getMinDesignPressure() {
     return getMinOperationPressure() * (1.0 - pressureMarginFactor);
+  }
+
+  /**
+   * Gets the minimum design pressure in an explicit pressure unit.
+   *
+   * @param unit requested pressure unit
+   * @return converted minimum design pressure
+   */
+  public double getMinDesignPressure(String unit) {
+    return new PressureUnit(getMinDesignPressure(), "bara").getValue(unit);
   }
 
   /**
@@ -796,64 +868,134 @@ public class MechanicalDesign implements java.io.Serializable {
   /**
    * Setter for the field <code>maxOperationPressure</code>.
    *
-   * @param maxPressure the maxPressure to set
+   * @param maxPressure maximum operating pressure in bara
    */
   public void setMaxOperationPressure(double maxPressure) {
     this.maxOperationPressure = maxPressure;
   }
 
   /**
+   * Sets the maximum operating pressure using an explicit absolute or gauge pressure unit.
+   *
+   * @param maxPressure maximum operating pressure
+   * @param unit pressure unit supported by {@link PressureUnit}
+   */
+  public void setMaxOperationPressure(double maxPressure, String unit) {
+    this.maxOperationPressure = new PressureUnit(maxPressure, unit).getValue("bara");
+  }
+
+  /**
    * Getter for the field <code>minOperationPressure</code>.
    *
-   * @return the minPressure
+   * @return minimum operating pressure in bara
    */
   public double getMinOperationPressure() {
     return minOperationPressure;
   }
 
   /**
+   * Gets the minimum operating pressure in an explicit pressure unit.
+   *
+   * @param unit requested pressure unit
+   * @return converted minimum operating pressure
+   */
+  public double getMinOperationPressure(String unit) {
+    return new PressureUnit(minOperationPressure, "bara").getValue(unit);
+  }
+
+  /**
    * Setter for the field <code>minOperationPressure</code>.
    *
-   * @param minPressure the minPressure to set
+   * @param minPressure minimum operating pressure in bara
    */
   public void setMinOperationPressure(double minPressure) {
     this.minOperationPressure = minPressure;
   }
 
   /**
+   * Sets the minimum operating pressure using an explicit absolute or gauge pressure unit.
+   *
+   * @param minPressure minimum operating pressure
+   * @param unit pressure unit supported by {@link PressureUnit}
+   */
+  public void setMinOperationPressure(double minPressure, String unit) {
+    this.minOperationPressure = new PressureUnit(minPressure, unit).getValue("bara");
+  }
+
+  /**
    * Getter for the field <code>maxOperationTemperature</code>.
    *
-   * @return the maxTemperature
+   * @return maximum operating temperature in kelvin
    */
   public double getMaxOperationTemperature() {
     return maxOperationTemperature;
   }
 
   /**
+   * Gets the maximum operating temperature in an explicit temperature unit.
+   *
+   * @param unit requested temperature unit
+   * @return converted maximum operating temperature
+   */
+  public double getMaxOperationTemperature(String unit) {
+    return new TemperatureUnit(maxOperationTemperature, "K").getValue(unit);
+  }
+
+  /**
    * Setter for the field <code>maxOperationTemperature</code>.
    *
-   * @param maxTemperature the maxTemperature to set
+   * @param maxTemperature maximum operating temperature in kelvin
    */
   public void setMaxOperationTemperature(double maxTemperature) {
     this.maxOperationTemperature = maxTemperature;
   }
 
   /**
+   * Sets the maximum operating temperature using an explicit temperature unit.
+   *
+   * @param maxTemperature maximum operating temperature
+   * @param unit temperature unit supported by {@link TemperatureUnit}
+   */
+  public void setMaxOperationTemperature(double maxTemperature, String unit) {
+    this.maxOperationTemperature = new TemperatureUnit(maxTemperature, unit).getValue("K");
+  }
+
+  /**
    * Getter for the field <code>minOperationTemperature</code>.
    *
-   * @return the minTemperature
+   * @return minimum operating temperature in kelvin
    */
   public double getMinOperationTemperature() {
     return minOperationTemperature;
   }
 
   /**
+   * Gets the minimum operating temperature in an explicit temperature unit.
+   *
+   * @param unit requested temperature unit
+   * @return converted minimum operating temperature
+   */
+  public double getMinOperationTemperature(String unit) {
+    return new TemperatureUnit(minOperationTemperature, "K").getValue(unit);
+  }
+
+  /**
    * Setter for the field <code>minOperationTemperature</code>.
    *
-   * @param minTemperature the minTemperature to set
+   * @param minTemperature minimum operating temperature in kelvin
    */
   public void setMinOperationTemperature(double minTemperature) {
     this.minOperationTemperature = minTemperature;
+  }
+
+  /**
+   * Sets the minimum operating temperature using an explicit temperature unit.
+   *
+   * @param minTemperature minimum operating temperature
+   * @param unit temperature unit supported by {@link TemperatureUnit}
+   */
+  public void setMinOperationTemperature(double minTemperature, String unit) {
+    this.minOperationTemperature = new TemperatureUnit(minTemperature, unit).getValue("K");
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/MechanicalDesignResponse.java
@@ -379,10 +379,10 @@ public class MechanicalDesignResponse implements java.io.Serializable {
 
     // Design conditions
     this.maxDesignPressure = mecDesign.getMaxDesignPressure();
-    this.maxDesignTemperature = mecDesign.getDesignMaxTemperatureLimit();
-    this.minDesignTemperature = mecDesign.getDesignMinTemperatureLimit();
+    this.maxDesignTemperature = mecDesign.getDesignMaxTemperatureLimit("C");
+    this.minDesignTemperature = mecDesign.getDesignMinTemperatureLimit("C");
     this.maxOperatingPressure = mecDesign.getMaxOperationPressure();
-    this.maxOperatingTemperature = mecDesign.getMaxOperationTemperature();
+    this.maxOperatingTemperature = mecDesign.getMaxOperationTemperature("C");
 
     // Dimensions
     this.innerDiameter = mecDesign.getInnerDiameter();

--- a/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesign.java
@@ -622,8 +622,8 @@ public class SystemMechanicalDesign implements java.io.Serializable {
     String type = classifyEquipment(equipment);
     EquipmentDesignSummary summary = new EquipmentDesignSummary(equipment.getName(), type);
     summary.setWeight(mecDesign.getWeightTotal());
-    summary.setDesignPressure(mecDesign.getMaxOperationPressure() * 1.1);
-    summary.setDesignTemperature(mecDesign.getMaxOperationTemperature() + 30);
+    summary.setDesignPressure(mecDesign.getMaxDesignPressure());
+    summary.setDesignTemperature(mecDesign.getMaxOperationTemperature("C") + 30.0);
 
     // Set power/duty based on equipment type
     try {

--- a/src/test/java/neqsim/process/mechanicaldesign/DesignConditionValueTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/DesignConditionValueTest.java
@@ -1,0 +1,103 @@
+package neqsim.process.mechanicaldesign;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.mechanicaldesign.DesignConditionValue.Type;
+
+/** Tests typed design conditions and explicit SI/field-unit equivalence. */
+class DesignConditionValueTest {
+  @Test
+  void typedValuesConvertToCanonicalUnits() {
+    DesignConditionValue pressure = DesignConditionValue.of(Type.DESIGN_PRESSURE, 145.03773773020922, "psia");
+    DesignConditionValue maxTemperature = DesignConditionValue.of(Type.MAX_DESIGN_TEMPERATURE, 212.0, "F");
+    DesignConditionValue corrosion = DesignConditionValue.of(Type.CORROSION_ALLOWANCE, 0.125, "in");
+
+    assertEquals(10.0, pressure.getCanonicalValue(), 1.0e-10);
+    assertEquals(100.0, maxTemperature.getCanonicalValue(), 1.0e-10);
+    assertEquals(3.175, corrosion.getCanonicalValue(), 1.0e-12);
+    assertEquals(1.25, corrosion.getValue("cm"), 1.0e-12);
+    assertEquals("bara", pressure.getCanonicalUnit());
+    assertEquals("C", maxTemperature.getCanonicalUnit());
+  }
+
+  @Test
+  void designConditionsExposeTypedDefensiveSnapshot() {
+    DesignConditions conditions = new DesignConditions().setDesignPressure(145.03773773020922, "psia")
+        .setMaxDesignTemperature(373.15, "K").setMinDesignTemperature(-50.0, "C")
+        .setReliefSetPressure(10.0, "barg").setCorrosionAllowance(0.125, "in");
+
+    assertEquals(10.0, conditions.getDesignPressure(), 1.0e-10);
+    assertEquals(145.03773773020922, conditions.getDesignPressure("psia"), 1.0e-8);
+    assertEquals(100.0, conditions.getMaxDesignTemperature(), 1.0e-10);
+    assertEquals(212.0, conditions.getMaxDesignTemperature("F"), 1.0e-10);
+    assertEquals(11.01325, conditions.getReliefSetPressure(), 1.0e-10);
+    assertEquals(3.175, conditions.getCorrosionAllowance(), 1.0e-12);
+
+    Map<Type, DesignConditionValue> snapshot = conditions.getConditions();
+    assertEquals(5, snapshot.size());
+    assertEquals(Type.MIN_DESIGN_TEMPERATURE,
+        conditions.getCondition(Type.MIN_DESIGN_TEMPERATURE).get().getType());
+    assertThrows(UnsupportedOperationException.class, snapshot::clear);
+    assertFalse(new DesignConditions().getCondition(Type.DESIGN_PRESSURE).isPresent());
+  }
+
+  @Test
+  void rejectsInvalidUnitsAndPhysicalValues() {
+    assertThrows(IllegalArgumentException.class,
+        () -> DesignConditionValue.of(Type.MAX_DESIGN_TEMPERATURE, -1.0, "K"));
+    assertThrows(IllegalArgumentException.class,
+        () -> DesignConditionValue.of(Type.CORROSION_ALLOWANCE, -1.0, "mm"));
+    assertThrows(RuntimeException.class, () -> DesignConditionValue.of(Type.DESIGN_PRESSURE, 10.0, "unknown"));
+    assertThrows(IllegalArgumentException.class, () -> new DesignConditions().setCondition(null));
+  }
+
+  @Test
+  void mechanicalDesignUsesExplicitCanonicalUnits() {
+    MechanicalDesign design = new MechanicalDesign(new Separator("unit test separator"));
+
+    design.setMaxOperationPressure(145.03773773020922, "psia");
+    design.setMinOperationPressure(0.0, "barg");
+    design.setMaxOperationTemperature(212.0, "F");
+    design.setMinOperationTemperature(32.0, "F");
+
+    assertEquals(10.0, design.getMaxOperationPressure(), 1.0e-10);
+    assertEquals(145.03773773020922, design.getMaxOperationPressure("psia"), 1.0e-8);
+    assertEquals(1.01325, design.getMinOperationPressure(), 1.0e-10);
+    assertEquals(373.15, design.getMaxOperationTemperature(), 1.0e-10);
+    assertEquals(100.0, design.getMaxOperationTemperature("C"), 1.0e-10);
+    assertEquals(273.15, design.getMinOperationTemperature(), 1.0e-10);
+    assertEquals(11.0, design.getMaxDesignPressure(), 1.0e-10);
+
+    MechanicalDesignResponse response = new MechanicalDesignResponse(design);
+    assertEquals(100.0, response.getMaxOperatingTemperature(), 1.0e-10);
+  }
+
+  @Test
+  void typedConditionSurvivesJavaSerialization() throws Exception {
+    DesignConditions conditions = new DesignConditions().setDesignPressure(100.0, "barg")
+        .setMaxDesignTemperature(350.0, "F").setCorrosionAllowance(0.125, "in");
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(conditions);
+    }
+
+    DesignConditions restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (DesignConditions) input.readObject();
+    }
+
+    assertEquals(101.01325, restored.getDesignPressure(), 1.0e-10);
+    assertEquals(176.66666666666666, restored.getMaxDesignTemperature(), 1.0e-10);
+    assertEquals(3.175, restored.getCondition(Type.CORROSION_ALLOWANCE).get().getCanonicalValue(), 1.0e-12);
+    assertTrue(restored.getConditions().containsKey(Type.DESIGN_PRESSURE));
+  }
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/DesignConditionValueTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/DesignConditionValueTest.java
@@ -32,8 +32,8 @@ class DesignConditionValueTest {
   @Test
   void designConditionsExposeTypedDefensiveSnapshot() {
     DesignConditions conditions = new DesignConditions().setDesignPressure(145.03773773020922, "psia")
-        .setMaxDesignTemperature(373.15, "K").setMinDesignTemperature(-50.0, "C")
-        .setReliefSetPressure(10.0, "barg").setCorrosionAllowance(0.125, "in");
+        .setMaxDesignTemperature(373.15, "K").setMinDesignTemperature(-50.0, "C").setReliefSetPressure(10.0, "barg")
+        .setCorrosionAllowance(0.125, "in");
 
     assertEquals(10.0, conditions.getDesignPressure(), 1.0e-10);
     assertEquals(145.03773773020922, conditions.getDesignPressure("psia"), 1.0e-8);
@@ -44,18 +44,15 @@ class DesignConditionValueTest {
 
     Map<Type, DesignConditionValue> snapshot = conditions.getConditions();
     assertEquals(5, snapshot.size());
-    assertEquals(Type.MIN_DESIGN_TEMPERATURE,
-        conditions.getCondition(Type.MIN_DESIGN_TEMPERATURE).get().getType());
+    assertEquals(Type.MIN_DESIGN_TEMPERATURE, conditions.getCondition(Type.MIN_DESIGN_TEMPERATURE).get().getType());
     assertThrows(UnsupportedOperationException.class, snapshot::clear);
     assertFalse(new DesignConditions().getCondition(Type.DESIGN_PRESSURE).isPresent());
   }
 
   @Test
   void rejectsInvalidUnitsAndPhysicalValues() {
-    assertThrows(IllegalArgumentException.class,
-        () -> DesignConditionValue.of(Type.MAX_DESIGN_TEMPERATURE, -1.0, "K"));
-    assertThrows(IllegalArgumentException.class,
-        () -> DesignConditionValue.of(Type.CORROSION_ALLOWANCE, -1.0, "mm"));
+    assertThrows(IllegalArgumentException.class, () -> DesignConditionValue.of(Type.MAX_DESIGN_TEMPERATURE, -1.0, "K"));
+    assertThrows(IllegalArgumentException.class, () -> DesignConditionValue.of(Type.CORROSION_ALLOWANCE, -1.0, "mm"));
     assertThrows(RuntimeException.class, () -> DesignConditionValue.of(Type.DESIGN_PRESSURE, 10.0, "unknown"));
     assertThrows(IllegalArgumentException.class, () -> new DesignConditions().setCondition(null));
   }

--- a/src/test/java/neqsim/process/mechanicaldesign/MechanicalDesignDataSourceTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/MechanicalDesignDataSourceTest.java
@@ -39,6 +39,8 @@ class MechanicalDesignDataSourceTest {
     assertEquals(10.0, design.getDesignMinPressureLimit(), 1e-8);
     assertEquals(410.0, design.getDesignMaxTemperatureLimit(), 1e-8);
     assertEquals(250.0, design.getDesignMinTemperatureLimit(), 1e-8);
+    assertEquals(136.85, design.getDesignMaxTemperatureLimit("C"), 1e-8);
+    assertEquals(-23.15, design.getDesignMinTemperatureLimit("C"), 1e-8);
     assertEquals(3.0, design.getDesignCorrosionAllowance(), 1e-8);
     assertEquals(0.95, design.getDesignJointEfficiency(), 1e-8);
 

--- a/src/test/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignTest.java
@@ -77,7 +77,7 @@ public class SystemMechanicalDesignTest {
       setModuleWidth(3.0);
       setModuleHeight(2.0);
       setMaxOperationPressure(50.0);
-      setMaxOperationTemperature(60.0);
+      setMaxOperationTemperature(60.0, "C");
     }
 
     private int getCalculationCount() {
@@ -228,6 +228,8 @@ public class SystemMechanicalDesignTest {
     assertEquals(12.0, systemDesign.getTotalPlotSpace(), 1.0e-12);
     assertEquals(1, systemDesign.getEquipmentList().size());
     assertEquals(4.0, systemDesign.getEquipmentList().get(0).getLength(), 1.0e-12);
+    assertEquals(55.0, systemDesign.getEquipmentList().get(0).getDesignPressure(), 1.0e-12);
+    assertEquals(90.0, systemDesign.getEquipmentList().get(0).getDesignTemperature(), 1.0e-12);
 
     systemDesign.getEquipmentList().get(0).setWeight(999.0);
     assertEquals(120.0, systemDesign.getEquipmentList().get(0).getWeight(), 1.0e-12);


### PR DESCRIPTION
## Summary

- add immutable `DesignConditionValue` quantities so declared pressure, temperature, and corrosion values retain their engineering type
- add explicit-unit setters/getters to `DesignConditions` and `MechanicalDesign` while preserving legacy canonical-unit methods
- expose defensive typed condition snapshots and Java-serialization-safe values
- document canonical design-limit units
- correct response temperature fields to emit documented degrees Celsius instead of raw kelvin
- make system summaries use the configured pressure margin and convert operating temperature from kelvin before adding the existing 30 °C design margin

## Canonical units and compatibility

Legacy single-argument methods are unchanged:

- `MechanicalDesign`: pressure in bara and temperature in K
- `DesignConditions`: pressure in bara, temperature in °C, corrosion allowance in mm
- `DesignLimitData`: pressure in bara, temperature in K, corrosion allowance in mm

New overloads use NeqSim's existing `PressureUnit`, `TemperatureUnit`, and `LengthUnit` converters. Typed values reject missing/invalid units, non-finite values, pressure below absolute vacuum, temperature below absolute zero, and negative corrosion allowance.

## Stacking

This draft is intentionally based on `agent/system-mechanical-design-state` (PR #2551). It should be rebased and retargeted as the earlier correctness and standards stages merge.

## Validation

- Java 8 compiler harness compiles the typed condition implementation with the real NeqSim unit converters
- conversion/serialization smoke test covers psia↔bara, barg↔bara, °F↔°C, inches↔mm, defensive maps, and Java round-trip
- system-design harness compiles and executes the corrected summary path
- focused JUnit coverage adds SI/field-unit equivalence, invalid-unit/physical-boundary, serialization, response-unit, design-limit, and system-summary regressions
- GitHub Actions provides authoritative Spotless and repository-level validation