### PR TITLE
Add structured system design failure propagation

### DIFF
--- a/docs/process/mechanical_design.md
+++ b/docs/process/mechanical_design.md
@@ -186,8 +186,16 @@ SystemMechanicalDesign sysMecDesign = new SystemMechanicalDesign(process);
 // Set company standards for all equipment
 sysMecDesign.setCompanySpecificDesignStandards("Equinor");
 
-// Run design calculations for all equipment
-sysMecDesign.runDesignCalculation();
+// Prefer the structured API so partial system totals cannot be mistaken for complete results
+SystemMechanicalDesignResult calculation =
+    sysMecDesign.calculate(SystemDesignExecutionMode.BEST_EFFORT);
+if (!calculation.isComplete()) {
+  for (EquipmentDesignOutcome outcome : calculation.getEquipmentOutcomes()) {
+    if (outcome.getStatus() == EquipmentDesignOutcome.Status.FAILED) {
+      logger.error("Design failed for {}: {}", outcome.getEquipmentName(), outcome.getMessage());
+    }
+  }
+}
 
 // The aggregate is cached on the ProcessSystem and survives copy/serialization
 boolean calculated = sysMecDesign.hasRunDesignCalculation();
@@ -216,6 +224,15 @@ replace the aggregate totals instead of accumulating them and increment the calc
 The system-level result is serialized with `ProcessSystem`, including its equipment summaries and
 breakdowns. Collection getters return defensive snapshots, so modifying a returned summary does not
 alter the stored design state.
+
+`calculate(BEST_EFFORT)` continues with independent equipment after a calculation error and returns
+an immutable outcome for every item. Aggregate weights, dimensions, and utilities then contain only
+successfully calculated equipment, and `isComplete()` is false. `calculate(FAIL_FAST)` stops on the
+first failure and throws `SystemMechanicalDesignException`; `getPartialResult()` preserves the
+calculated, failed, and skipped outcomes. Exception class and message are included in the serialized
+result, while stack traces remain in the application log. The legacy `runDesignCalculation()` method
+retains best-effort behavior for source compatibility; inspect `getLastCalculationResult()` before
+using its aggregates.
 
 ## JSON Export
 

--- a/src/main/java/neqsim/process/mechanicaldesign/EquipmentDesignOutcome.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/EquipmentDesignOutcome.java
@@ -6,8 +6,8 @@ import java.io.Serializable;
  * Immutable outcome for one equipment item in a system mechanical design calculation.
  *
  * <p>
- * Failure details deliberately contain only the exception type and message. Stack traces remain in the application
- * log and are not copied into serialized engineering results.
+ * Failure details deliberately contain only the exception type and message. Stack traces remain in the application log
+ * and are not copied into serialized engineering results.
  * </p>
  *
  * @author NeqSim Development Team
@@ -67,8 +67,8 @@ public final class EquipmentDesignOutcome implements Serializable {
     if (failureMessage == null || failureMessage.trim().isEmpty()) {
       failureMessage = "No error message was provided";
     }
-    return new EquipmentDesignOutcome(equipmentName, equipmentType, Status.FAILED,
-        exception.getClass().getName(), failureMessage);
+    return new EquipmentDesignOutcome(equipmentName, equipmentType, Status.FAILED, exception.getClass().getName(),
+        failureMessage);
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/EquipmentDesignOutcome.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/EquipmentDesignOutcome.java
@@ -1,0 +1,114 @@
+package neqsim.process.mechanicaldesign;
+
+import java.io.Serializable;
+
+/**
+ * Immutable outcome for one equipment item in a system mechanical design calculation.
+ *
+ * <p>
+ * Failure details deliberately contain only the exception type and message. Stack traces remain in the application
+ * log and are not copied into serialized engineering results.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public final class EquipmentDesignOutcome implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Status of an equipment design attempt. */
+  public enum Status {
+    /** The equipment design calculation completed and was included in system totals. */
+    CALCULATED,
+
+    /** The equipment design calculation failed and was excluded from system totals. */
+    FAILED,
+
+    /** The equipment was not attempted because fail-fast execution had stopped. */
+    SKIPPED
+  }
+
+  private final String equipmentName;
+  private final String equipmentType;
+  private final Status status;
+  private final String errorType;
+  private final String message;
+
+  private EquipmentDesignOutcome(String equipmentName, String equipmentType, Status status, String errorType,
+      String message) {
+    this.equipmentName = equipmentName;
+    this.equipmentType = equipmentType;
+    this.status = status;
+    this.errorType = errorType;
+    this.message = message;
+  }
+
+  /**
+   * Create a successful outcome.
+   *
+   * @param equipmentName equipment name
+   * @param equipmentType equipment Java type
+   * @return calculated outcome
+   */
+  public static EquipmentDesignOutcome calculated(String equipmentName, String equipmentType) {
+    return new EquipmentDesignOutcome(equipmentName, equipmentType, Status.CALCULATED, null, null);
+  }
+
+  /**
+   * Create a failed outcome.
+   *
+   * @param equipmentName equipment name
+   * @param equipmentType equipment Java type, or an empty string when the equipment could not be resolved
+   * @param exception calculation exception
+   * @return failed outcome
+   */
+  public static EquipmentDesignOutcome failed(String equipmentName, String equipmentType, Exception exception) {
+    String failureMessage = exception.getMessage();
+    if (failureMessage == null || failureMessage.trim().isEmpty()) {
+      failureMessage = "No error message was provided";
+    }
+    return new EquipmentDesignOutcome(equipmentName, equipmentType, Status.FAILED,
+        exception.getClass().getName(), failureMessage);
+  }
+
+  /**
+   * Create a skipped outcome.
+   *
+   * @param equipmentName equipment name
+   * @return skipped outcome
+   */
+  public static EquipmentDesignOutcome skipped(String equipmentName) {
+    return new EquipmentDesignOutcome(equipmentName, "", Status.SKIPPED, null,
+        "Not attempted because fail-fast execution stopped after an earlier failure");
+  }
+
+  /** @return equipment name */
+  public String getEquipmentName() {
+    return equipmentName;
+  }
+
+  /** @return equipment Java type, or an empty string when unavailable */
+  public String getEquipmentType() {
+    return equipmentType;
+  }
+
+  /** @return outcome status */
+  public Status getStatus() {
+    return status;
+  }
+
+  /** @return exception class name for a failed outcome, otherwise {@code null} */
+  public String getErrorType() {
+    return errorType;
+  }
+
+  /** @return failure or skip message, otherwise {@code null} */
+  public String getMessage() {
+    return message;
+  }
+
+  /** @return {@code true} only when the calculation completed successfully */
+  public boolean isCalculated() {
+    return status == Status.CALCULATED;
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/SystemDesignExecutionMode.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/SystemDesignExecutionMode.java
@@ -1,0 +1,15 @@
+package neqsim.process.mechanicaldesign;
+
+/**
+ * Controls how a whole-process mechanical design calculation handles equipment failures.
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public enum SystemDesignExecutionMode {
+  /** Continue with independent equipment and return a structured partial result. */
+  BEST_EFFORT,
+
+  /** Stop after the first failed equipment calculation and throw an exception with the partial result. */
+  FAIL_FAST
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesign.java
@@ -479,10 +479,9 @@ public class SystemMechanicalDesign implements java.io.Serializable {
           }
           designCalculationRevision++;
           designCalculationRun = false;
-          lastCalculationResult = new SystemMechanicalDesignResult(designCalculationRevision, executionMode,
-              outcomes);
-          throw new SystemMechanicalDesignException(
-              "Mechanical design failed for equipment " + names.get(i), ex, lastCalculationResult);
+          lastCalculationResult = new SystemMechanicalDesignResult(designCalculationRevision, executionMode, outcomes);
+          throw new SystemMechanicalDesignException("Mechanical design failed for equipment " + names.get(i), ex,
+              lastCalculationResult);
         }
       }
     }

--- a/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesign.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.ProcessEquipmentInterface;
@@ -115,8 +116,11 @@ public class SystemMechanicalDesign implements java.io.Serializable {
   /** Whether at least one complete system design calculation has been run. */
   private boolean designCalculationRun = false;
 
-  /** Monotonic revision number incremented after every complete system design calculation. */
+  /** Monotonic revision number incremented after every system design calculation attempt. */
   private long designCalculationRevision = 0L;
+
+  /** Structured outcome from the most recent calculation attempt. */
+  private SystemMechanicalDesignResult lastCalculationResult;
 
   // ============================================================================
   // Equipment Design Summary Inner Class
@@ -397,16 +401,38 @@ public class SystemMechanicalDesign implements java.io.Serializable {
    * sizing inputs are not discarded. After calling this method, all getters will return updated values.
    * </p>
    */
-  public void runDesignCalculation() {
+  public synchronized void runDesignCalculation() {
+    calculate(SystemDesignExecutionMode.BEST_EFFORT);
+  }
+
+  /**
+   * Run system mechanical design with explicit failure handling.
+   *
+   * <p>
+   * In {@link SystemDesignExecutionMode#BEST_EFFORT} mode, independent equipment continues after a failure and the
+   * returned result identifies partial aggregates. In {@link SystemDesignExecutionMode#FAIL_FAST} mode, the first
+   * failure throws {@link SystemMechanicalDesignException}; its partial result identifies the failed item and every
+   * item not attempted. Aggregate fields contain only successfully calculated equipment in either mode.
+   * </p>
+   *
+   * @param executionMode failure handling mode
+   * @return structured calculation result
+   * @throws NullPointerException if executionMode is null
+   * @throws SystemMechanicalDesignException on the first failure in fail-fast mode
+   */
+  public synchronized SystemMechanicalDesignResult calculate(SystemDesignExecutionMode executionMode) {
+    Objects.requireNonNull(executionMode, "executionMode");
     // Reset all accumulators
     resetAccumulators();
 
     ArrayList<String> names = this.processSystem.getAllUnitNames();
+    List<EquipmentDesignOutcome> outcomes = new ArrayList<EquipmentDesignOutcome>();
     for (int i = 0; i < names.size(); i++) {
+      ProcessEquipmentInterface equipment = null;
       try {
-        ProcessEquipmentInterface equipment = this.processSystem.getUnit(names.get(i));
+        equipment = this.processSystem.getUnit(names.get(i));
         if (equipment == null) {
-          continue;
+          throw new IllegalStateException("Process equipment could not be resolved");
         }
 
         MechanicalDesign mecDesign = getOrInitializeMechanicalDesign(equipment);
@@ -441,13 +467,30 @@ public class SystemMechanicalDesign implements java.io.Serializable {
         EquipmentDesignSummary summary = createEquipmentSummary(equipment, mecDesign);
         equipmentList.add(summary);
 
+        outcomes.add(EquipmentDesignOutcome.calculated(equipment.getName(), equipment.getClass().getName()));
+
       } catch (Exception ex) {
-        logger.error("Error processing equipment " + names.get(i) + ": " + ex.getMessage(), ex);
+        String equipmentType = equipment == null ? "" : equipment.getClass().getName();
+        outcomes.add(EquipmentDesignOutcome.failed(names.get(i), equipmentType, ex));
+        logger.error("Mechanical design failed for equipment " + names.get(i) + ": " + ex.getMessage(), ex);
+        if (executionMode == SystemDesignExecutionMode.FAIL_FAST) {
+          for (int j = i + 1; j < names.size(); j++) {
+            outcomes.add(EquipmentDesignOutcome.skipped(names.get(j)));
+          }
+          designCalculationRevision++;
+          designCalculationRun = false;
+          lastCalculationResult = new SystemMechanicalDesignResult(designCalculationRevision, executionMode,
+              outcomes);
+          throw new SystemMechanicalDesignException(
+              "Mechanical design failed for equipment " + names.get(i), ex, lastCalculationResult);
+        }
       }
     }
 
-    designCalculationRun = true;
     designCalculationRevision++;
+    lastCalculationResult = new SystemMechanicalDesignResult(designCalculationRevision, executionMode, outcomes);
+    designCalculationRun = lastCalculationResult.isComplete();
+    return lastCalculationResult;
   }
 
   /**
@@ -756,10 +799,19 @@ public class SystemMechanicalDesign implements java.io.Serializable {
   /**
    * Get the persistent calculation revision.
    *
-   * @return number of completed calls to {@link #runDesignCalculation()}
+   * @return number of completed calculation attempts, including structured partial results
    */
   public long getDesignCalculationRevision() {
     return designCalculationRevision;
+  }
+
+  /**
+   * Get the structured outcome from the most recent system design attempt.
+   *
+   * @return immutable result, or an empty optional before the first attempt
+   */
+  public synchronized Optional<SystemMechanicalDesignResult> getLastCalculationResult() {
+    return Optional.ofNullable(lastCalculationResult);
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignException.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignException.java
@@ -18,8 +18,7 @@ public class SystemMechanicalDesignException extends RuntimeException {
    * @param cause original equipment calculation exception
    * @param partialResult structured result including calculated, failed, and skipped equipment
    */
-  public SystemMechanicalDesignException(String message, Throwable cause,
-      SystemMechanicalDesignResult partialResult) {
+  public SystemMechanicalDesignException(String message, Throwable cause, SystemMechanicalDesignResult partialResult) {
     super(message, cause);
     this.partialResult = partialResult;
   }

--- a/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignException.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignException.java
@@ -1,0 +1,31 @@
+package neqsim.process.mechanicaldesign;
+
+/**
+ * Signals a fail-fast system mechanical design failure while preserving the structured partial result.
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class SystemMechanicalDesignException extends RuntimeException {
+  private static final long serialVersionUID = 1000L;
+
+  private final SystemMechanicalDesignResult partialResult;
+
+  /**
+   * Create a system design exception.
+   *
+   * @param message failure description
+   * @param cause original equipment calculation exception
+   * @param partialResult structured result including calculated, failed, and skipped equipment
+   */
+  public SystemMechanicalDesignException(String message, Throwable cause,
+      SystemMechanicalDesignResult partialResult) {
+    super(message, cause);
+    this.partialResult = partialResult;
+  }
+
+  /** @return structured result available when fail-fast execution stopped */
+  public SystemMechanicalDesignResult getPartialResult() {
+    return partialResult;
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignResult.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignResult.java
@@ -37,8 +37,7 @@ public final class SystemMechanicalDesignResult implements Serializable {
       List<EquipmentDesignOutcome> equipmentOutcomes) {
     this.revision = revision;
     this.executionMode = executionMode;
-    this.equipmentOutcomes = Collections
-        .unmodifiableList(new ArrayList<EquipmentDesignOutcome>(equipmentOutcomes));
+    this.equipmentOutcomes = Collections.unmodifiableList(new ArrayList<EquipmentDesignOutcome>(equipmentOutcomes));
 
     int successful = 0;
     int failed = 0;

--- a/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignResult.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignResult.java
@@ -1,0 +1,103 @@
+package neqsim.process.mechanicaldesign;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable structured result from a whole-process mechanical design calculation.
+ *
+ * <p>
+ * Aggregate getters on {@link SystemMechanicalDesign} contain only successfully calculated equipment. Call
+ * {@link #isComplete()} before treating those aggregates as whole-system values.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public final class SystemMechanicalDesignResult implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final long revision;
+  private final SystemDesignExecutionMode executionMode;
+  private final List<EquipmentDesignOutcome> equipmentOutcomes;
+  private final int calculatedCount;
+  private final int failedCount;
+  private final int skippedCount;
+
+  /**
+   * Create an immutable system result.
+   *
+   * @param revision persistent calculation-attempt revision
+   * @param executionMode requested failure handling mode
+   * @param equipmentOutcomes outcomes in process order
+   */
+  public SystemMechanicalDesignResult(long revision, SystemDesignExecutionMode executionMode,
+      List<EquipmentDesignOutcome> equipmentOutcomes) {
+    this.revision = revision;
+    this.executionMode = executionMode;
+    this.equipmentOutcomes = Collections
+        .unmodifiableList(new ArrayList<EquipmentDesignOutcome>(equipmentOutcomes));
+
+    int successful = 0;
+    int failed = 0;
+    int skipped = 0;
+    for (EquipmentDesignOutcome outcome : equipmentOutcomes) {
+      if (outcome.getStatus() == EquipmentDesignOutcome.Status.CALCULATED) {
+        successful++;
+      } else if (outcome.getStatus() == EquipmentDesignOutcome.Status.FAILED) {
+        failed++;
+      } else if (outcome.getStatus() == EquipmentDesignOutcome.Status.SKIPPED) {
+        skipped++;
+      }
+    }
+    this.calculatedCount = successful;
+    this.failedCount = failed;
+    this.skippedCount = skipped;
+  }
+
+  /** @return persistent calculation-attempt revision */
+  public long getRevision() {
+    return revision;
+  }
+
+  /** @return requested execution mode */
+  public SystemDesignExecutionMode getExecutionMode() {
+    return executionMode;
+  }
+
+  /** @return immutable outcomes in process order */
+  public List<EquipmentDesignOutcome> getEquipmentOutcomes() {
+    return equipmentOutcomes;
+  }
+
+  /** @return number of successfully calculated equipment items */
+  public int getCalculatedCount() {
+    return calculatedCount;
+  }
+
+  /** @return number of failed equipment items */
+  public int getFailedCount() {
+    return failedCount;
+  }
+
+  /** @return number of equipment items skipped by fail-fast execution */
+  public int getSkippedCount() {
+    return skippedCount;
+  }
+
+  /**
+   * Check whether every process item was successfully calculated.
+   *
+   * @return {@code true} when there are no failures or skipped items
+   */
+  public boolean isComplete() {
+    return failedCount == 0 && skippedCount == 0;
+  }
+
+  /** @return {@code true} when at least one equipment calculation failed */
+  public boolean hasFailures() {
+    return failedCount > 0;
+  }
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignTest.java
@@ -291,18 +291,16 @@ public class SystemMechanicalDesignTest {
     assertEquals(1, result.getFailedCount());
     assertEquals(0, result.getSkippedCount());
     assertEquals(3, result.getEquipmentOutcomes().size());
-    assertEquals(EquipmentDesignOutcome.Status.FAILED,
-        result.getEquipmentOutcomes().get(1).getStatus());
-    assertEquals(IllegalStateException.class.getName(),
-        result.getEquipmentOutcomes().get(1).getErrorType());
+    assertEquals(EquipmentDesignOutcome.Status.FAILED, result.getEquipmentOutcomes().get(1).getStatus());
+    assertEquals(IllegalStateException.class.getName(), result.getEquipmentOutcomes().get(1).getErrorType());
     assertEquals("Deliberate design failure", result.getEquipmentOutcomes().get(1).getMessage());
     assertFalse(systemDesign.hasRunDesignCalculation());
     assertSame(result, systemDesign.getLastCalculationResult().get());
     assertEquals(240.0, systemDesign.getTotalWeight(), 1.0e-12);
 
     neqsim.process.processmodel.ProcessSystem restoredProcess = process.copy();
-    SystemMechanicalDesignResult restoredResult = restoredProcess.getSystemMechanicalDesign()
-        .getLastCalculationResult().get();
+    SystemMechanicalDesignResult restoredResult = restoredProcess.getSystemMechanicalDesign().getLastCalculationResult()
+        .get();
     assertEquals(1, restoredResult.getFailedCount());
     assertEquals("failed equipment", restoredResult.getEquipmentOutcomes().get(1).getEquipmentName());
   }
@@ -324,8 +322,7 @@ public class SystemMechanicalDesignTest {
     assertEquals(1, result.getCalculatedCount());
     assertEquals(1, result.getFailedCount());
     assertEquals(1, result.getSkippedCount());
-    assertEquals(EquipmentDesignOutcome.Status.SKIPPED,
-        result.getEquipmentOutcomes().get(2).getStatus());
+    assertEquals(EquipmentDesignOutcome.Status.SKIPPED, result.getEquipmentOutcomes().get(2).getStatus());
     assertEquals(120.0, systemDesign.getTotalWeight(), 1.0e-12);
     assertEquals(1L, systemDesign.getDesignCalculationRevision());
     assertSame(result, systemDesign.getLastCalculationResult().get());

--- a/src/test/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/SystemMechanicalDesignTest.java
@@ -1,7 +1,9 @@
 package neqsim.process.mechanicaldesign;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
@@ -82,6 +84,33 @@ public class SystemMechanicalDesignTest {
 
     private int getCalculationCount() {
       return calculationCount;
+    }
+  }
+
+  private static final class FailingTestEquipment extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private final MechanicalDesign mechanicalDesign;
+
+    private FailingTestEquipment(String name) {
+      super(name);
+      mechanicalDesign = new MechanicalDesign(this) {
+        private static final long serialVersionUID = 1000L;
+
+        @Override
+        public void calcDesign() {
+          throw new IllegalStateException("Deliberate design failure");
+        }
+      };
+    }
+
+    @Override
+    public MechanicalDesign getMechanicalDesign() {
+      return mechanicalDesign;
+    }
+
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
     }
   }
 
@@ -244,6 +273,62 @@ public class SystemMechanicalDesignTest {
     assertEquals(2L, restoredDesign.getDesignCalculationRevision());
     assertEquals(120.0, restoredDesign.getTotalWeight(), 1.0e-12);
     assertEquals(654.0, restoredEquipment.getMechanicalDesign().getPower(), 1.0e-12);
+  }
+
+  @Test
+  void bestEffortCalculationReturnsStructuredPartialResult() {
+    neqsim.process.processmodel.ProcessSystem process = new neqsim.process.processmodel.ProcessSystem();
+    process.add(new PersistentTestEquipment("first calculated"));
+    process.add(new FailingTestEquipment("failed equipment"));
+    process.add(new PersistentTestEquipment("second calculated"));
+    SystemMechanicalDesign systemDesign = process.getSystemMechanicalDesign();
+
+    SystemMechanicalDesignResult result = systemDesign.calculate(SystemDesignExecutionMode.BEST_EFFORT);
+
+    assertFalse(result.isComplete());
+    assertTrue(result.hasFailures());
+    assertEquals(2, result.getCalculatedCount());
+    assertEquals(1, result.getFailedCount());
+    assertEquals(0, result.getSkippedCount());
+    assertEquals(3, result.getEquipmentOutcomes().size());
+    assertEquals(EquipmentDesignOutcome.Status.FAILED,
+        result.getEquipmentOutcomes().get(1).getStatus());
+    assertEquals(IllegalStateException.class.getName(),
+        result.getEquipmentOutcomes().get(1).getErrorType());
+    assertEquals("Deliberate design failure", result.getEquipmentOutcomes().get(1).getMessage());
+    assertFalse(systemDesign.hasRunDesignCalculation());
+    assertSame(result, systemDesign.getLastCalculationResult().get());
+    assertEquals(240.0, systemDesign.getTotalWeight(), 1.0e-12);
+
+    neqsim.process.processmodel.ProcessSystem restoredProcess = process.copy();
+    SystemMechanicalDesignResult restoredResult = restoredProcess.getSystemMechanicalDesign()
+        .getLastCalculationResult().get();
+    assertEquals(1, restoredResult.getFailedCount());
+    assertEquals("failed equipment", restoredResult.getEquipmentOutcomes().get(1).getEquipmentName());
+  }
+
+  @Test
+  void failFastCalculationThrowsWithPartialResultAndSkippedEquipment() {
+    neqsim.process.processmodel.ProcessSystem process = new neqsim.process.processmodel.ProcessSystem();
+    process.add(new PersistentTestEquipment("calculated"));
+    process.add(new FailingTestEquipment("failed equipment"));
+    process.add(new PersistentTestEquipment("not attempted"));
+    SystemMechanicalDesign systemDesign = process.getSystemMechanicalDesign();
+
+    SystemMechanicalDesignException exception = assertThrows(SystemMechanicalDesignException.class,
+        () -> systemDesign.calculate(SystemDesignExecutionMode.FAIL_FAST));
+    SystemMechanicalDesignResult result = exception.getPartialResult();
+
+    assertFalse(result.isComplete());
+    assertEquals(SystemDesignExecutionMode.FAIL_FAST, result.getExecutionMode());
+    assertEquals(1, result.getCalculatedCount());
+    assertEquals(1, result.getFailedCount());
+    assertEquals(1, result.getSkippedCount());
+    assertEquals(EquipmentDesignOutcome.Status.SKIPPED,
+        result.getEquipmentOutcomes().get(2).getStatus());
+    assertEquals(120.0, systemDesign.getTotalWeight(), 1.0e-12);
+    assertEquals(1L, systemDesign.getDesignCalculationRevision());
+    assertSame(result, systemDesign.getLastCalculationResult().get());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add immutable, serializable per-equipment outcomes and whole-system calculation results
- add explicit `BEST_EFFORT` and `FAIL_FAST` execution modes
- preserve partial results in `SystemMechanicalDesignException` and on the cached system design
- keep the legacy `runDesignCalculation()` entry point source-compatible while making partial aggregates inspectable
- document that aggregate values include only successfully calculated equipment

## Correctness and compatibility
- complete results are marked complete only when every equipment item is calculated
- fail-fast results identify all not-attempted equipment as `SKIPPED`
- serialized failures retain exception type and message, not stack traces
- calculation revisions count every attempt; `hasRunDesignCalculation()` remains true only for complete aggregate results

## Validation
- Java 8 production compilation passed in the repository compiler harness
- behavior harness passed complete, best-effort, fail-fast, partial aggregation, defensive-state, and serialization checks
- focused JUnit coverage added for best-effort and fail-fast behavior
- full Maven and Spotless validation delegated to hosted CI because this environment cannot download Maven dependencies

## Scope and maturity
This PR improves result integrity and diagnostics. It does not certify any equipment design calculation or expand a standard's implementation status.