### PR TITLE
Make DesignOptimizer fail closed and run real searches

### DIFF
--- a/docs/process/DESIGN_FRAMEWORK.md
+++ b/docs/process/DESIGN_FRAMEWORK.md
@@ -100,12 +100,13 @@ process.run();
 DesignOptimizer optimizer = DesignOptimizer.fromTemplate(template, basis)
     .autoSizeEquipment(1.2)
     .applyDefaultConstraints()
+    .configureFeedRateOptimization("Feed", 25000.0, 80000.0, "kg/hr")
     .setObjective(DesignOptimizer.ObjectiveType.MAXIMIZE_PRODUCTION);
 
 DesignResult result = optimizer.optimize();
 
-if (result.isConverged()) {
-    System.out.println(result.getSummary());
+if (result.getExecutionStatus() == DesignResult.ExecutionStatus.OPTIMIZED) {
+    logger.info(result.getSummary());
 }
 ```
 
@@ -260,18 +261,21 @@ DesignOptimizer optimizer = DesignOptimizer.fromTemplate(template, basis);
 optimizer
     .autoSizeEquipment(1.2)       // Auto-size all AutoSizeable equipment
     .applyDefaultConstraints()     // Apply registry constraints
+    .configureFeedRateOptimization("Feed", 25000.0, 80000.0, "kg/hr")
     .setObjective(ObjectiveType.MAXIMIZE_PRODUCTION);
 
 // Run
 DesignResult result = optimizer.validate();  // Just validate
-DesignResult result = optimizer.optimize();  // Full optimization
+DesignResult result = optimizer.optimize();  // Bounded search only when explicitly configured
 ```
 
 **ProcessModule Support:**
 - Use `forProcess(ProcessModule)` for modular process structures
 - Check mode with `optimizer.isModuleMode()`
 - Access the module with `optimizer.getModule()`
-- All child ProcessSystems are automatically evaluated for constraints
+- Baseline validation, constraint reporting, and auto-sizing cover all child `ProcessSystem` objects
+- Bounded search through `DesignOptimizer` currently requires one `ProcessSystem`; use the whole-plant
+  `ProductionOptimizer`/`ProcessModelOptimizationView` APIs for multi-system optimization
 
 **Objective Types:**
 - `MAXIMIZE_PRODUCTION` - Maximize total hydrocarbon production
@@ -280,6 +284,11 @@ DesignResult result = optimizer.optimize();  // Full optimization
 - `MINIMIZE_ENERGY` - Minimize energy consumption
 - `CUSTOM` - Custom objective function
 
+Optimization is fail-closed. Without `configureFeedRateOptimization(...)`, `optimize()` runs only the
+baseline, optional auto-sizing, and validation; the result status is `VALIDATED` or `AUTO_SIZED`,
+`isConverged()` is false, and no optimized flow is reported. Oil and gas objectives additionally
+require `setProductStream(...)`. A custom objective requires `setCustomObjective(...)`.
+
 ### DesignResult
 
 Container for design and optimization results.
@@ -287,8 +296,11 @@ Container for design and optimization results.
 ```java
 DesignResult result = optimizer.optimize();
 
-// Check convergence
-if (result.isConverged()) {
+// First distinguish validation/sizing from a real bounded search
+if (result.getExecutionStatus() == DesignResult.ExecutionStatus.OPTIMIZED) {
+    // isConverged() means the configured interval search can reach its decision-variable tolerance
+    boolean toleranceReached = result.isConverged();
+
     // Get metrics
     int iterations = result.getIterations();
     double objective = result.getObjectiveValue();
@@ -503,6 +515,7 @@ The design framework integrates with existing NeqSim capabilities:
 DesignOptimizer designOpt = DesignOptimizer.forProcess(process)
     .autoSizeEquipment()
     .applyDefaultConstraints()
+    .configureFeedRateOptimization("Feed", 25000.0, 80000.0, "kg/hr")
     .setObjective(ObjectiveType.MAXIMIZE_PRODUCTION);
 
 // The underlying ProductionOptimizer handles the mathematical optimization
@@ -814,5 +827,4 @@ Export Pipeline:
 4. **Optimization** finds the maximum flow rate that respects ALL constraints across ALL equipment
 5. The **Active Constraint** is the specific limit currently preventing higher production
 6. The **Bottleneck** is the equipment where that active constraint exists
-
 

--- a/docs/process/processmodel/process_module.md
+++ b/docs/process/processmodel/process_module.md
@@ -467,16 +467,18 @@ if (optimizer.isModuleMode()) {
     System.out.println("Optimizing module: " + optimizer.getModule().getName());
 }
 
-// Configure and run
+// Configure validation and auto-sizing across the module
 optimizer
     .autoSizeEquipment(1.2)
-    .applyDefaultConstraints()
-    .setObjective(ObjectiveType.MAXIMIZE_PRODUCTION);
+    .applyDefaultConstraints();
 
 DesignResult result = optimizer.optimize();
 ```
 
-Constraints are evaluated across **all nested ProcessSystems** in the module hierarchy.
+Constraints are evaluated across **all nested ProcessSystems** in the module hierarchy. The result
+status is `AUTO_SIZED`, not `OPTIMIZED`, because no search was performed. Configured bounded search
+through `DesignOptimizer` currently requires a single `ProcessSystem`; use
+`ProductionOptimizer` with `ProcessModelOptimizationView` for whole-module optimization.
 
 ---
 

--- a/src/main/java/neqsim/process/design/DesignOptimizer.java
+++ b/src/main/java/neqsim/process/design/DesignOptimizer.java
@@ -1,15 +1,23 @@
 package neqsim.process.design;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.ToDoubleFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.capacity.CapacityConstrainedEquipment;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.processmodel.ProcessModule;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.util.optimizer.ProductionOptimizer;
 
 /**
  * Integrated design-to-optimization workflow manager.
@@ -31,6 +39,7 @@ import neqsim.process.processmodel.ProcessSystem;
  *
  * <pre>
  * DesignResult result = DesignOptimizer.forProcess(process).autoSizeEquipment(1.2).applyDefaultConstraints()
+ *     .configureFeedRateOptimization("feed", 50000.0, 200000.0, "kg/hr")
  *     .setObjective(ObjectiveType.MAXIMIZE_PRODUCTION).optimize();
  * </pre>
  *
@@ -48,6 +57,18 @@ public class DesignOptimizer {
   private boolean autoSizeEnabled = false;
   private ObjectiveType objective = ObjectiveType.MAXIMIZE_PRODUCTION;
   private List<String> excludedEquipment = new ArrayList<>();
+  private boolean defaultConstraintsEnabled = false;
+  private String optimizationFeedStreamName;
+  private String productStreamName;
+  private double optimizationLowerBound;
+  private double optimizationUpperBound;
+  private String optimizationRateUnit = "kg/hr";
+  private double optimizationTolerance = 1.0e-3;
+  private int optimizationMaxIterations = 30;
+  private ProductionOptimizer.SearchMode searchMode = ProductionOptimizer.SearchMode.BINARY_FEASIBILITY;
+  private boolean searchModeExplicitlySet = false;
+  private ProductionOptimizer.OptimizationObjective customObjective;
+  private List<ProductionOptimizer.OptimizationConstraint> optimizationConstraints = new ArrayList<>();
 
   /**
    * Objective types for optimization.
@@ -130,6 +151,9 @@ public class DesignOptimizer {
    * @return this optimizer for chaining
    */
   public DesignOptimizer autoSizeEquipment(double safetyFactor) {
+    if (Double.isNaN(safetyFactor) || Double.isInfinite(safetyFactor) || safetyFactor < 1.0) {
+      throw new IllegalArgumentException("Safety factor must be finite and at least 1.0");
+    }
     this.safetyFactor = safetyFactor;
     this.autoSizeEnabled = true;
     return this;
@@ -150,7 +174,7 @@ public class DesignOptimizer {
    * @return this optimizer for chaining
    */
   public DesignOptimizer applyDefaultConstraints() {
-    // Constraints are applied during optimization based on equipment types
+    defaultConstraintsEnabled = true;
     return this;
   }
 
@@ -161,7 +185,113 @@ public class DesignOptimizer {
    * @return this optimizer for chaining
    */
   public DesignOptimizer setObjective(ObjectiveType objective) {
-    this.objective = objective;
+    this.objective = Objects.requireNonNull(objective, "Objective type is required");
+    return this;
+  }
+
+  /**
+   * Configure a bounded feed-rate search.
+   *
+   * <p>
+   * Calling {@link #optimize()} without this configuration performs validation and optional auto-sizing only; it does
+   * not claim that an optimization search ran.
+   * </p>
+   *
+   * @param feedStreamName manipulated feed stream name
+   * @param lowerBound lower feed-rate bound
+   * @param upperBound upper feed-rate bound
+   * @param rateUnit feed-rate unit
+   * @return this optimizer for chaining
+   */
+  public DesignOptimizer configureFeedRateOptimization(String feedStreamName, double lowerBound, double upperBound,
+      String rateUnit) {
+    if (feedStreamName == null || feedStreamName.trim().isEmpty()) {
+      throw new IllegalArgumentException("Feed stream name is required");
+    }
+    if (Double.isNaN(lowerBound) || Double.isInfinite(lowerBound) || lowerBound < 0.0
+        || Double.isNaN(upperBound) || Double.isInfinite(upperBound) || upperBound <= lowerBound) {
+      throw new IllegalArgumentException("Optimization bounds must be finite with 0 <= lower < upper");
+    }
+    if (rateUnit == null || rateUnit.trim().isEmpty()) {
+      throw new IllegalArgumentException("Rate unit is required");
+    }
+    this.optimizationFeedStreamName = feedStreamName;
+    this.optimizationLowerBound = lowerBound;
+    this.optimizationUpperBound = upperBound;
+    this.optimizationRateUnit = rateUnit;
+    return this;
+  }
+
+  /**
+   * Select the product stream used by oil- or gas-production objectives.
+   *
+   * @param productStreamName product stream name
+   * @return this optimizer for chaining
+   */
+  public DesignOptimizer setProductStream(String productStreamName) {
+    if (productStreamName == null || productStreamName.trim().isEmpty()) {
+      throw new IllegalArgumentException("Product stream name is required");
+    }
+    this.productStreamName = productStreamName;
+    return this;
+  }
+
+  /**
+   * Set search convergence controls.
+   *
+   * @param tolerance decision-variable tolerance in the configured rate unit
+   * @param maxIterations maximum search iterations
+   * @return this optimizer for chaining
+   */
+  public DesignOptimizer setSearchConvergence(double tolerance, int maxIterations) {
+    if (Double.isNaN(tolerance) || Double.isInfinite(tolerance) || tolerance <= 0.0) {
+      throw new IllegalArgumentException("Search tolerance must be finite and positive");
+    }
+    if (maxIterations <= 0) {
+      throw new IllegalArgumentException("Maximum iterations must be positive");
+    }
+    this.optimizationTolerance = tolerance;
+    this.optimizationMaxIterations = maxIterations;
+    return this;
+  }
+
+  /**
+   * Select the search algorithm used by the production optimizer.
+   *
+   * @param searchMode search algorithm
+   * @return this optimizer for chaining
+   */
+  public DesignOptimizer setSearchMode(ProductionOptimizer.SearchMode searchMode) {
+    this.searchMode = Objects.requireNonNull(searchMode, "Search mode is required");
+    this.searchModeExplicitlySet = true;
+    return this;
+  }
+
+  /**
+   * Configure the evaluator used when {@link ObjectiveType#CUSTOM} is selected.
+   *
+   * @param name objective name
+   * @param evaluator process objective evaluator
+   * @param maximize {@code true} to maximize, {@code false} to minimize
+   * @return this optimizer for chaining
+   */
+  public DesignOptimizer setCustomObjective(String name, ToDoubleFunction<ProcessSystem> evaluator,
+      boolean maximize) {
+    ProductionOptimizer.ObjectiveType direction = maximize ? ProductionOptimizer.ObjectiveType.MAXIMIZE
+        : ProductionOptimizer.ObjectiveType.MINIMIZE;
+    customObjective = new ProductionOptimizer.OptimizationObjective(name, evaluator, 1.0, direction);
+    objective = ObjectiveType.CUSTOM;
+    return this;
+  }
+
+  /**
+   * Add an explicit process constraint to the bounded search.
+   *
+   * @param constraint optimization constraint
+   * @return this optimizer for chaining
+   */
+  public DesignOptimizer addOptimizationConstraint(ProductionOptimizer.OptimizationConstraint constraint) {
+    optimizationConstraints.add(Objects.requireNonNull(constraint, "Optimization constraint is required"));
     return this;
   }
 
@@ -189,41 +319,40 @@ public class DesignOptimizer {
     DesignResult result = new DesignResult(process != null ? process : getFirstProcessSystem());
 
     try {
-      // Step 1: Run baseline
       logger.info("Running baseline simulation...");
       runSimulation();
 
-      // Step 2: Auto-size equipment if enabled
       if (autoSizeEnabled) {
         logger.info("Auto-sizing equipment with safety factor: " + safetyFactor);
         autoSizeAllEquipment();
-        runSimulation(); // Re-run after sizing
+        runSimulation();
       }
 
-      // Step 3: Record results (simplified - full optimization will be added later)
-      result.setConverged(true);
-      result.setIterations(1);
-
-      // Record flow rate
-      StreamInterface productStream = findProductStream();
-      if (productStream != null) {
-        result.addOptimizedFlowRate(productStream.getName(), productStream.getFlowRate("kg/hr"));
-        result.setObjectiveValue(productStream.getFlowRate("kg/hr"));
+      if (defaultConstraintsEnabled) {
+        initializeDefaultConstraints(result);
       }
 
-      // Record equipment sizes
+      if (optimizationFeedStreamName == null) {
+        result.setExecutionStatus(
+            autoSizeEnabled ? DesignResult.ExecutionStatus.AUTO_SIZED : DesignResult.ExecutionStatus.VALIDATED);
+        result.setConverged(false);
+        result.setIterations(0);
+        result.addWarning("No optimization search was performed. Configure explicit feed-rate bounds with "
+            + "configureFeedRateOptimization(...) before calling optimize().");
+      } else {
+        runConfiguredOptimization(result);
+      }
+
       recordEquipmentSizes(result);
-
-      // Record constraint status
       recordConstraintStatus(result);
-
-      // Check for violations
       checkViolations(result);
 
-      logger.info("Design complete. Violations: " + result.hasViolations());
+      logger.info("Design workflow complete. Status: " + result.getExecutionStatus() + ", violations: "
+          + result.hasViolations());
 
     } catch (Exception e) {
       logger.error("Design failed: " + e.getMessage(), e);
+      result.setExecutionStatus(DesignResult.ExecutionStatus.FAILED);
       result.setConverged(false);
       result.addViolation("Design failed: " + e.getMessage());
     }
@@ -249,8 +378,21 @@ public class DesignOptimizer {
    */
   public DesignResult validate() {
     DesignResult result = new DesignResult(process != null ? process : getFirstProcessSystem());
-    runSimulation();
-    checkViolations(result);
+    try {
+      runSimulation();
+      if (defaultConstraintsEnabled) {
+        initializeDefaultConstraints(result);
+      }
+      recordEquipmentSizes(result);
+      recordConstraintStatus(result);
+      checkViolations(result);
+      result.setExecutionStatus(DesignResult.ExecutionStatus.VALIDATED);
+      result.setConverged(false);
+    } catch (Exception e) {
+      logger.error("Design validation failed: " + e.getMessage(), e);
+      result.setExecutionStatus(DesignResult.ExecutionStatus.FAILED);
+      result.addViolation("Design validation failed: " + e.getMessage());
+    }
     return result;
   }
 
@@ -265,6 +407,173 @@ public class DesignOptimizer {
     } else if (module != null) {
       module.run();
     }
+  }
+
+  /**
+   * Delegate an explicitly configured bounded search to the production optimizer.
+   *
+   * @param result design result to populate
+   */
+  private void runConfiguredOptimization(DesignResult result) {
+    if (process == null) {
+      throw new IllegalStateException("Configured optimization currently requires a ProcessSystem, not a module");
+    }
+    StreamInterface feedStream = requireStream(optimizationFeedStreamName, "optimization feed");
+    ProductionOptimizer.SearchMode effectiveSearchMode = effectiveSearchMode();
+    ProductionOptimizer.OptimizationConfig config = new ProductionOptimizer.OptimizationConfig(
+        optimizationLowerBound, optimizationUpperBound).rateUnit(optimizationRateUnit)
+            .tolerance(optimizationTolerance).maxIterations(optimizationMaxIterations)
+            .searchMode(effectiveSearchMode);
+    ProductionOptimizer.OptimizationObjective configuredObjective = createObjective(feedStream);
+    ProductionOptimizer engine = new ProductionOptimizer();
+    ProductionOptimizer.OptimizationResult optimizationResult = engine.optimize(process, feedStream, config,
+        Collections.singletonList(configuredObjective), new ArrayList<>(optimizationConstraints));
+
+    // The search engine evaluates many mutable process states. Restore and run the selected point so the process and
+    // the returned result describe the same operating condition.
+    feedStream.setFlowRate(optimizationResult.getOptimalRate(), optimizationRateUnit);
+    runSimulation();
+
+    result.setIterations(optimizationResult.getIterationHistory().size());
+    result.setConverged(isToleranceConverged(effectiveSearchMode));
+    if (!result.isConverged()) {
+      result.addWarning("The selected search mode did not demonstrate decision-variable tolerance convergence "
+          + "within the configured iteration limit.");
+    }
+    for (Map.Entry<String, Double> entry : optimizationResult.getDecisionVariables().entrySet()) {
+      result.addDecisionVariable(entry.getKey(), entry.getValue());
+    }
+    result.addOptimizedFlowRate(feedStream.getName(), optimizationResult.getOptimalRate());
+    Double objectiveValue = optimizationResult.getObjectiveValues().get(configuredObjective.getName());
+    result.setObjectiveValue(objectiveValue == null ? optimizationResult.getScore() : objectiveValue.doubleValue());
+
+    for (ProductionOptimizer.ConstraintStatus status : optimizationResult.getConstraintStatuses()) {
+      if (status.violated()) {
+        result.addViolation("Optimization constraint " + status.getName() + " violated with margin "
+            + status.getMargin());
+      }
+    }
+    if (optimizationResult.isFeasible()) {
+      result.setExecutionStatus(DesignResult.ExecutionStatus.OPTIMIZED);
+    } else {
+      result.setExecutionStatus(DesignResult.ExecutionStatus.INFEASIBLE);
+      result.setConverged(false);
+      result.addViolation(optimizationResult.getInfeasibilityDiagnosis());
+    }
+  }
+
+  /**
+   * Create the selected objective with explicit phase and stream semantics.
+   *
+   * @param feedStream manipulated feed stream
+   * @return production optimizer objective
+   */
+  private ProductionOptimizer.OptimizationObjective createObjective(final StreamInterface feedStream) {
+    if (objective == ObjectiveType.CUSTOM) {
+      if (customObjective == null) {
+        throw new IllegalStateException("CUSTOM objective requires setCustomObjective(...)");
+      }
+      return customObjective;
+    }
+    if (objective == ObjectiveType.MAXIMIZE_PRODUCTION) {
+      return new ProductionOptimizer.OptimizationObjective("total production",
+          proc -> feedStream.getFlowRate(optimizationRateUnit), 1.0, ProductionOptimizer.ObjectiveType.MAXIMIZE);
+    }
+    if (objective == ObjectiveType.MAXIMIZE_OIL) {
+      final StreamInterface product = requireConfiguredProductStream();
+      return new ProductionOptimizer.OptimizationObjective("oil production",
+          proc -> phaseFlow(product, "oil", optimizationRateUnit), 1.0,
+          ProductionOptimizer.ObjectiveType.MAXIMIZE);
+    }
+    if (objective == ObjectiveType.MAXIMIZE_GAS) {
+      final StreamInterface product = requireConfiguredProductStream();
+      return new ProductionOptimizer.OptimizationObjective("gas production",
+          proc -> phaseFlow(product, "gas", optimizationRateUnit), 1.0,
+          ProductionOptimizer.ObjectiveType.MAXIMIZE);
+    }
+    return new ProductionOptimizer.OptimizationObjective("total energy", proc -> totalEnergyRequirement(), 1.0,
+        ProductionOptimizer.ObjectiveType.MINIMIZE);
+  }
+
+  /**
+   * Use feasibility search for throughput and a score search for all other objectives unless explicitly selected.
+   *
+   * @return effective search mode
+   */
+  private ProductionOptimizer.SearchMode effectiveSearchMode() {
+    if (!searchModeExplicitlySet && objective != ObjectiveType.MAXIMIZE_PRODUCTION) {
+      return ProductionOptimizer.SearchMode.GOLDEN_SECTION_SCORE;
+    }
+    return searchMode;
+  }
+
+  /**
+   * Check whether interval-reduction algorithms can reach the configured tolerance before their iteration cap.
+   *
+   * @param effectiveSearchMode selected search mode
+   * @return true when tolerance convergence is guaranteed by the configured interval and iteration count
+   */
+  private boolean isToleranceConverged(ProductionOptimizer.SearchMode effectiveSearchMode) {
+    double span = optimizationUpperBound - optimizationLowerBound;
+    if (span <= optimizationTolerance) {
+      return true;
+    }
+    if (effectiveSearchMode == ProductionOptimizer.SearchMode.BINARY_FEASIBILITY) {
+      double required = Math.ceil(Math.log(span / optimizationTolerance) / Math.log(2.0));
+      return optimizationMaxIterations >= required;
+    }
+    if (effectiveSearchMode == ProductionOptimizer.SearchMode.GOLDEN_SECTION_SCORE) {
+      double phi = 0.5 * (Math.sqrt(5.0) - 1.0);
+      double required = Math.ceil(Math.log(optimizationTolerance / span) / Math.log(phi));
+      return optimizationMaxIterations >= required;
+    }
+    return false;
+  }
+
+  /** @return explicitly configured product stream */
+  private StreamInterface requireConfiguredProductStream() {
+    if (productStreamName == null) {
+      throw new IllegalStateException(objective + " requires setProductStream(...)");
+    }
+    return requireStream(productStreamName, "product");
+  }
+
+  /**
+   * Resolve and type-check a named stream.
+   *
+   * @param name equipment name
+   * @param role diagnostic role
+   * @return stream
+   */
+  private StreamInterface requireStream(String name, String role) {
+    ProcessEquipmentInterface equipment = process.getUnit(name);
+    if (!(equipment instanceof StreamInterface)) {
+      throw new IllegalArgumentException("Configured " + role + " '" + name + "' is not a process stream");
+    }
+    return (StreamInterface) equipment;
+  }
+
+  /** @return phase flow, or zero when the requested phase is absent */
+  private double phaseFlow(StreamInterface stream, String phaseType, String unit) {
+    if (!stream.getFluid().hasPhaseType(phaseType)) {
+      return 0.0;
+    }
+    return stream.getFluid().getPhase(phaseType).getFlowRate(unit);
+  }
+
+  /** @return total compressor, pump, and absolute heater duty in kW */
+  private double totalEnergyRequirement() {
+    double total = 0.0;
+    for (ProcessEquipmentInterface equipment : getAllUnitOperations()) {
+      if (equipment instanceof Compressor) {
+        total += Math.abs(((Compressor) equipment).getPower("kW"));
+      } else if (equipment instanceof Pump) {
+        total += Math.abs(((Pump) equipment).getPower("kW"));
+      } else if (equipment instanceof Heater) {
+        total += Math.abs(((Heater) equipment).getDuty()) / 1000.0;
+      }
+    }
+    return total;
   }
 
   /**
@@ -315,16 +624,20 @@ public class DesignOptimizer {
     }
   }
 
-  private StreamInterface findProductStream() {
-    // Find the last stream in the process as the product
-    List<ProcessEquipmentInterface> units = getAllUnitOperations();
-    for (int i = units.size() - 1; i >= 0; i--) {
-      ProcessEquipmentInterface equipment = units.get(i);
-      if (equipment instanceof StreamInterface) {
-        return (StreamInterface) equipment;
+  /**
+   * Materialize lazy equipment constraints and report equipment that has no executable defaults.
+   *
+   * @param result design result receiving applicability warnings
+   */
+  private void initializeDefaultConstraints(DesignResult result) {
+    for (ProcessEquipmentInterface equipment : getAllUnitOperations()) {
+      if (equipment instanceof CapacityConstrainedEquipment && !excludedEquipment.contains(equipment.getName())) {
+        CapacityConstrainedEquipment constrained = (CapacityConstrainedEquipment) equipment;
+        if (constrained.isCapacityAnalysisEnabled() && constrained.getCapacityConstraints().isEmpty()) {
+          result.addWarning(equipment.getName() + " has no executable default capacity constraints");
+        }
       }
     }
-    return null;
   }
 
   private void recordEquipmentSizes(DesignResult result) {
@@ -345,9 +658,12 @@ public class DesignOptimizer {
         CapacityConstrainedEquipment constrained = (CapacityConstrainedEquipment) equipment;
         for (neqsim.process.equipment.capacity.CapacityConstraint constraint : constrained.getCapacityConstraints()
             .values()) {
-          double utilized = constraint.getCurrentValue() / constraint.getMaxValue();
+          if (!constraint.isEnabled()) {
+            continue;
+          }
+          double utilized = constraint.getUtilization();
           result.addConstraintStatus(equipment.getName(), constraint.getName(), constraint.getCurrentValue(),
-              constraint.getMaxValue(), utilized);
+              constraint.getDisplayDesignValue(), utilized);
         }
       }
     }
@@ -359,7 +675,10 @@ public class DesignOptimizer {
         CapacityConstrainedEquipment constrained = (CapacityConstrainedEquipment) equipment;
         for (neqsim.process.equipment.capacity.CapacityConstraint constraint : constrained.getCapacityConstraints()
             .values()) {
-          double utilized = constraint.getCurrentValue() / constraint.getMaxValue();
+          if (!constraint.isEnabled()) {
+            continue;
+          }
+          double utilized = constraint.getUtilization();
           if (utilized > 1.0) {
             result.addViolation(equipment.getName() + ": " + constraint.getName() + " exceeded ("
                 + String.format("%.1f%% utilization", utilized * 100) + ")");

--- a/src/main/java/neqsim/process/design/DesignOptimizer.java
+++ b/src/main/java/neqsim/process/design/DesignOptimizer.java
@@ -208,8 +208,8 @@ public class DesignOptimizer {
     if (feedStreamName == null || feedStreamName.trim().isEmpty()) {
       throw new IllegalArgumentException("Feed stream name is required");
     }
-    if (Double.isNaN(lowerBound) || Double.isInfinite(lowerBound) || lowerBound < 0.0
-        || Double.isNaN(upperBound) || Double.isInfinite(upperBound) || upperBound <= lowerBound) {
+    if (Double.isNaN(lowerBound) || Double.isInfinite(lowerBound) || lowerBound < 0.0 || Double.isNaN(upperBound)
+        || Double.isInfinite(upperBound) || upperBound <= lowerBound) {
       throw new IllegalArgumentException("Optimization bounds must be finite with 0 <= lower < upper");
     }
     if (rateUnit == null || rateUnit.trim().isEmpty()) {
@@ -275,8 +275,7 @@ public class DesignOptimizer {
    * @param maximize {@code true} to maximize, {@code false} to minimize
    * @return this optimizer for chaining
    */
-  public DesignOptimizer setCustomObjective(String name, ToDoubleFunction<ProcessSystem> evaluator,
-      boolean maximize) {
+  public DesignOptimizer setCustomObjective(String name, ToDoubleFunction<ProcessSystem> evaluator, boolean maximize) {
     ProductionOptimizer.ObjectiveType direction = maximize ? ProductionOptimizer.ObjectiveType.MAXIMIZE
         : ProductionOptimizer.ObjectiveType.MINIMIZE;
     customObjective = new ProductionOptimizer.OptimizationObjective(name, evaluator, 1.0, direction);
@@ -420,10 +419,9 @@ public class DesignOptimizer {
     }
     StreamInterface feedStream = requireStream(optimizationFeedStreamName, "optimization feed");
     ProductionOptimizer.SearchMode effectiveSearchMode = effectiveSearchMode();
-    ProductionOptimizer.OptimizationConfig config = new ProductionOptimizer.OptimizationConfig(
-        optimizationLowerBound, optimizationUpperBound).rateUnit(optimizationRateUnit)
-            .tolerance(optimizationTolerance).maxIterations(optimizationMaxIterations)
-            .searchMode(effectiveSearchMode);
+    ProductionOptimizer.OptimizationConfig config = new ProductionOptimizer.OptimizationConfig(optimizationLowerBound,
+        optimizationUpperBound).rateUnit(optimizationRateUnit).tolerance(optimizationTolerance)
+        .maxIterations(optimizationMaxIterations).searchMode(effectiveSearchMode);
     ProductionOptimizer.OptimizationObjective configuredObjective = createObjective(feedStream);
     ProductionOptimizer engine = new ProductionOptimizer();
     ProductionOptimizer.OptimizationResult optimizationResult = engine.optimize(process, feedStream, config,
@@ -449,8 +447,8 @@ public class DesignOptimizer {
 
     for (ProductionOptimizer.ConstraintStatus status : optimizationResult.getConstraintStatuses()) {
       if (status.violated()) {
-        result.addViolation("Optimization constraint " + status.getName() + " violated with margin "
-            + status.getMargin());
+        result.addViolation(
+            "Optimization constraint " + status.getName() + " violated with margin " + status.getMargin());
       }
     }
     if (optimizationResult.isFeasible()) {
@@ -482,14 +480,12 @@ public class DesignOptimizer {
     if (objective == ObjectiveType.MAXIMIZE_OIL) {
       final StreamInterface product = requireConfiguredProductStream();
       return new ProductionOptimizer.OptimizationObjective("oil production",
-          proc -> phaseFlow(product, "oil", optimizationRateUnit), 1.0,
-          ProductionOptimizer.ObjectiveType.MAXIMIZE);
+          proc -> phaseFlow(product, "oil", optimizationRateUnit), 1.0, ProductionOptimizer.ObjectiveType.MAXIMIZE);
     }
     if (objective == ObjectiveType.MAXIMIZE_GAS) {
       final StreamInterface product = requireConfiguredProductStream();
       return new ProductionOptimizer.OptimizationObjective("gas production",
-          proc -> phaseFlow(product, "gas", optimizationRateUnit), 1.0,
-          ProductionOptimizer.ObjectiveType.MAXIMIZE);
+          proc -> phaseFlow(product, "gas", optimizationRateUnit), 1.0, ProductionOptimizer.ObjectiveType.MAXIMIZE);
     }
     return new ProductionOptimizer.OptimizationObjective("total energy", proc -> totalEnergyRequirement(), 1.0,
         ProductionOptimizer.ObjectiveType.MINIMIZE);

--- a/src/main/java/neqsim/process/design/DesignResult.java
+++ b/src/main/java/neqsim/process/design/DesignResult.java
@@ -20,12 +20,30 @@ import neqsim.process.processmodel.ProcessSystem;
  */
 public class DesignResult {
 
+  /** Describes what work produced this result without conflating validation with optimization. */
+  public enum ExecutionStatus {
+    /** No workflow has run. */
+    NOT_RUN,
+    /** A baseline simulation and constraint validation ran, but no search ran. */
+    VALIDATED,
+    /** Equipment auto-sizing and validation ran, but no search ran. */
+    AUTO_SIZED,
+    /** A configured optimization search returned a feasible operating point. */
+    OPTIMIZED,
+    /** A configured search completed without finding a feasible operating point. */
+    INFEASIBLE,
+    /** The workflow failed before it could return an engineering result. */
+    FAILED
+  }
+
   private ProcessSystem process;
+  private ExecutionStatus executionStatus = ExecutionStatus.NOT_RUN;
   private boolean converged;
   private int iterations;
   private double objectiveValue;
 
   private Map<String, Double> optimizedFlowRates = new HashMap<>();
+  private Map<String, Double> decisionVariables = new HashMap<>();
   private Map<String, Map<String, Double>> equipmentSizes = new HashMap<>();
   private Map<String, ConstraintStatus> constraintStatus = new HashMap<>();
   private List<String> warnings = new ArrayList<>();
@@ -47,6 +65,24 @@ public class DesignResult {
    */
   public ProcessSystem getProcess() {
     return process;
+  }
+
+  /**
+   * Get the workflow status.
+   *
+   * @return status distinguishing validation, sizing, optimization, infeasibility, and failure
+   */
+  public ExecutionStatus getExecutionStatus() {
+    return executionStatus;
+  }
+
+  /**
+   * Set the workflow status.
+   *
+   * @param executionStatus workflow status
+   */
+  public void setExecutionStatus(ExecutionStatus executionStatus) {
+    this.executionStatus = executionStatus;
   }
 
   /**
@@ -123,6 +159,25 @@ public class DesignResult {
   }
 
   /**
+   * Record a decision-variable value returned by an actual optimizer search.
+   *
+   * @param name decision-variable name
+   * @param value selected value
+   */
+  public void addDecisionVariable(String name, double value) {
+    decisionVariables.put(name, value);
+  }
+
+  /**
+   * Get the decision variables returned by an optimizer search.
+   *
+   * @return defensive map of decision-variable names and selected values
+   */
+  public Map<String, Double> getDecisionVariables() {
+    return new HashMap<>(decisionVariables);
+  }
+
+  /**
    * Record equipment size.
    *
    * @param equipmentName equipment name
@@ -140,7 +195,8 @@ public class DesignResult {
    * @return map of size name to value
    */
   public Map<String, Double> getEquipmentSizes(String equipmentName) {
-    return equipmentSizes.getOrDefault(equipmentName, new HashMap<>());
+    Map<String, Double> sizes = equipmentSizes.get(equipmentName);
+    return sizes == null ? new HashMap<String, Double>() : new HashMap<String, Double>(sizes);
   }
 
   /**
@@ -229,7 +285,7 @@ public class DesignResult {
    * @return the equipment
    */
   public ProcessEquipmentInterface getEquipment(String name) {
-    return process.getUnit(name);
+    return process == null ? null : process.getUnit(name);
   }
 
   /**
@@ -249,7 +305,8 @@ public class DesignResult {
    */
   public String getSummary() {
     StringBuilder sb = new StringBuilder();
-    sb.append("=== Design Optimization Result ===\n");
+    sb.append("=== Design Result ===\n");
+    sb.append("Status: ").append(executionStatus).append("\n");
     sb.append("Converged: ").append(converged).append("\n");
     sb.append("Iterations: ").append(iterations).append("\n");
     sb.append("Objective: ").append(String.format("%.4f", objectiveValue)).append("\n\n");

--- a/src/main/java/neqsim/process/design/package-info.java
+++ b/src/main/java/neqsim/process/design/package-info.java
@@ -23,11 +23,11 @@
  *
  * // 2. Run integrated design-optimization
  * DesignResult result = DesignOptimizer.forProcess(process).autoSizeEquipment(1.2).applyDefaultConstraints()
- *     .configureFeedRateOptimization("Feed", 25000.0, 80000.0, "kg/hr")
- *     .setObjective(ObjectiveType.MAXIMIZE_PRODUCTION).optimize();
+ *     .configureFeedRateOptimization("Feed", 25000.0, 80000.0, "kg/hr").setObjective(ObjectiveType.MAXIMIZE_PRODUCTION)
+ *     .optimize();
  *
  * // 3. Check results
- * System.out.println(result.getSummary());
+ * logger.info(result.getSummary());
  * </pre>
  *
  * @author NeqSim Development Team

--- a/src/main/java/neqsim/process/design/package-info.java
+++ b/src/main/java/neqsim/process/design/package-info.java
@@ -23,6 +23,7 @@
  *
  * // 2. Run integrated design-optimization
  * DesignResult result = DesignOptimizer.forProcess(process).autoSizeEquipment(1.2).applyDefaultConstraints()
+ *     .configureFeedRateOptimization("Feed", 25000.0, 80000.0, "kg/hr")
  *     .setObjective(ObjectiveType.MAXIMIZE_PRODUCTION).optimize();
  *
  * // 3. Check results

--- a/src/test/java/neqsim/process/design/DesignFrameworkTest.java
+++ b/src/test/java/neqsim/process/design/DesignFrameworkTest.java
@@ -474,6 +474,51 @@ class DesignFrameworkTest {
 
     // Verify result
     assertNotNull(result);
+    assertEquals(DesignResult.ExecutionStatus.AUTO_SIZED, result.getExecutionStatus());
+    assertFalse(result.isConverged());
+    assertTrue(result.getWarnings().get(0).contains("No optimization search was performed"));
+  }
+
+  @Test
+  void configuredDesignOptimizerRunsBoundedSearchAndRestoresSelectedPoint() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 20.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+
+    ProcessSystem process = new ProcessSystem();
+    Stream feed = new Stream("Optimization feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    process.add(feed);
+
+    DesignResult result = DesignOptimizer.forProcess(process)
+        .configureFeedRateOptimization("Optimization feed", 1000.0, 2000.0, "kg/hr")
+        .setSearchConvergence(1.0, 20).setObjective(DesignOptimizer.ObjectiveType.MAXIMIZE_PRODUCTION).optimize();
+
+    assertEquals(DesignResult.ExecutionStatus.OPTIMIZED, result.getExecutionStatus());
     assertTrue(result.isConverged());
+    assertTrue(result.getIterations() > 1);
+    assertTrue(result.getOptimizedFlowRate("Optimization feed") > 1998.0);
+    assertEquals(result.getOptimizedFlowRate("Optimization feed"), feed.getFlowRate("kg/hr"), 1.0e-9);
+    assertTrue(result.getDecisionVariables().containsKey("Optimization feed"));
+  }
+
+  @Test
+  void phaseObjectiveFailsClosedWithoutExplicitProductStream() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 20.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+
+    ProcessSystem process = new ProcessSystem();
+    Stream feed = new Stream("Feed without product", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    process.add(feed);
+
+    DesignResult result = DesignOptimizer.forProcess(process)
+        .configureFeedRateOptimization("Feed without product", 500.0, 1500.0, "kg/hr")
+        .setObjective(DesignOptimizer.ObjectiveType.MAXIMIZE_GAS).optimize();
+
+    assertEquals(DesignResult.ExecutionStatus.FAILED, result.getExecutionStatus());
+    assertFalse(result.isConverged());
+    assertTrue(result.getViolations().get(0).contains("setProductStream"));
   }
 }

--- a/src/test/java/neqsim/process/design/DesignFrameworkTest.java
+++ b/src/test/java/neqsim/process/design/DesignFrameworkTest.java
@@ -491,8 +491,8 @@ class DesignFrameworkTest {
     process.add(feed);
 
     DesignResult result = DesignOptimizer.forProcess(process)
-        .configureFeedRateOptimization("Optimization feed", 1000.0, 2000.0, "kg/hr")
-        .setSearchConvergence(1.0, 20).setObjective(DesignOptimizer.ObjectiveType.MAXIMIZE_PRODUCTION).optimize();
+        .configureFeedRateOptimization("Optimization feed", 1000.0, 2000.0, "kg/hr").setSearchConvergence(1.0, 20)
+        .setObjective(DesignOptimizer.ObjectiveType.MAXIMIZE_PRODUCTION).optimize();
 
     assertEquals(DesignResult.ExecutionStatus.OPTIMIZED, result.getExecutionStatus());
     assertTrue(result.isConverged());


### PR DESCRIPTION
## Summary
- stop reporting validation or auto-sizing as a converged optimization
- require explicit feed stream, bounds, units, tolerance, and iteration controls for a search
- delegate configured searches to the executable `ProductionOptimizer`
- honor throughput, oil, gas, energy, and custom objective direction; phase objectives require an explicit product stream
- restore and rerun the selected optimum so the mutable `ProcessSystem` matches the returned result
- distinguish `VALIDATED`, `AUTO_SIZED`, `OPTIMIZED`, `INFEASIBLE`, and `FAILED` outcomes
- use each `CapacityConstraint`'s real utilization/design basis, including minimum constraints and disabled constraints
- return defensive equipment-size and decision-variable maps

## Compatibility
Existing fluent calls still compile. Calls without `configureFeedRateOptimization(...)` now return an explicit validation/auto-sizing result with `isConverged() == false` instead of falsely claiming an optimization ran. Configured module-wide searches fail closed; validation and sizing across module children remain supported, while whole-plant searches use the existing `ProductionOptimizer`/`ProcessModelOptimizationView` APIs.

## Validation
- Java 8 compilation passed with a focused dependency harness
- behavior harness passed unconfigured validation, bounded throughput search, selected-state restoration, objective reporting, and phase-objective fail-closed checks
- focused JUnit regression tests and documentation updated
- full Maven/Spotless validation delegated to hosted CI because Maven dependencies cannot be downloaded in this environment

## Scope and maturity
This is an optimizer correctness and API-integrity change. It does not claim engineering certification, global optimality for non-convex searches, or tolerance convergence for fixed-budget stochastic algorithms.