### PR TITLE
Add fail-closed engineering design dependencies

### DIFF
--- a/docs/engineering/design-cases-and-envelopes.md
+++ b/docs/engineering/design-cases-and-envelopes.md
@@ -135,6 +135,11 @@ The process-to-engineering simulator repeatedly:
 If a selected pipe diameter, separator geometry, valve Cv, or exchanger area changes the process hydraulics, the old
 envelope is stale. The rerun is what closes the engineering loop.
 
+Within each iteration, declared module dependencies are evaluated as topological levels. A downstream
+module sees upstream selections from that same iteration. Conflicting proposals for one state key are
+rejected unless every proposer declares the same governing maximum or minimum rule; the loop never
+uses module list order as an implicit engineering-selection rule.
+
 ## Case-coverage review
 
 Use a case matrix to review equipment and metric coverage:

--- a/docs/engineering/guide.md
+++ b/docs/engineering/guide.md
@@ -92,6 +92,18 @@ Use `EngineeringDesignLoop` through explicit discipline modules, or use an
 Typical loop variables include separator diameter and length, pipe inside diameter, valve Cv, driver rating,
 exchanger area, instrument range, pressure rating, and preliminary relief or blowdown targets.
 
+Discipline modules declare upstream module IDs through `EngineeringDesignModule.getDependencies()`.
+`EngineeringDesignDependencyGraph` validates missing IDs, duplicate IDs, self-dependencies, and cycles,
+then evaluates deterministic topological levels. Updates from one level are selected and applied before
+the next level is evaluated, so downstream modules consume current-iteration design state rather than
+an accidentally alphabetical or one-iteration-old value.
+
+Two modules may not silently overwrite the same design-variable key. The default
+`REQUIRE_UNIQUE` policy throws `EngineeringDesignConflictException` with the module IDs, units, and
+proposed values. A genuinely shared upper- or lower-governing variable must declare the same explicit
+`GOVERNING_MAXIMUM` or `GOVERNING_MINIMUM` rule on every proposal. Unit or rule disagreement still
+fails closed, and the selected state's `sourceModule` retains the governing owner.
+
 Gate check:
 
 - all cases converged after the final design update;
@@ -99,6 +111,7 @@ Gate check:
 - every declared constraint passes;
 - no hidden screening default was used;
 - all selected values retain method, units, governing case, and input evidence; and
+- the module dependency graph is valid and every shared-variable selection has an explicit governing rule;
 - the source process model remains unchanged.
 
 See [Process-to-Engineering Simulator](../integration/process-to-engineering-simulator) for configuration patterns,

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignConflictException.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignConflictException.java
@@ -1,0 +1,29 @@
+package neqsim.process.engineering.design;
+
+/**
+ * Signals incompatible module proposals for one engineering design variable.
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class EngineeringDesignConflictException extends IllegalStateException {
+  private static final long serialVersionUID = 1000L;
+
+  private final String designVariableKey;
+
+  /**
+   * Create a design-update conflict.
+   *
+   * @param designVariableKey conflicting design variable
+   * @param message diagnostic containing module owners and proposed values
+   */
+  public EngineeringDesignConflictException(String designVariableKey, String message) {
+    super(message);
+    this.designVariableKey = designVariableKey;
+  }
+
+  /** @return conflicting design-variable key */
+  public String getDesignVariableKey() {
+    return designVariableKey;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignDependencyException.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignDependencyException.java
@@ -1,0 +1,20 @@
+package neqsim.process.engineering.design;
+
+/**
+ * Signals an invalid engineering design-module dependency graph.
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class EngineeringDesignDependencyException extends IllegalArgumentException {
+  private static final long serialVersionUID = 1000L;
+
+  /**
+   * Create a dependency-configuration exception.
+   *
+   * @param message diagnostic containing the invalid module IDs
+   */
+  public EngineeringDesignDependencyException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignDependencyGraph.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignDependencyGraph.java
@@ -29,8 +29,8 @@ public final class EngineeringDesignDependencyGraph implements Serializable {
   private final List<List<EngineeringDesignModule>> orderedLevels;
 
   private EngineeringDesignDependencyGraph(List<EngineeringDesignModule> configuredModules) {
-    List<EngineeringDesignModule> modules = configuredModules == null
-        ? new ArrayList<EngineeringDesignModule>() : new ArrayList<EngineeringDesignModule>(configuredModules);
+    List<EngineeringDesignModule> modules = configuredModules == null ? new ArrayList<EngineeringDesignModule>()
+        : new ArrayList<EngineeringDesignModule>(configuredModules);
     Collections.sort(modules, new Comparator<EngineeringDesignModule>() {
       @Override
       public int compare(EngineeringDesignModule first, EngineeringDesignModule second) {
@@ -108,8 +108,8 @@ public final class EngineeringDesignDependencyGraph implements Serializable {
     return orderedLevels;
   }
 
-  private static List<List<EngineeringDesignModule>> buildOrderedLevels(
-      Map<String, EngineeringDesignModule> modules, Map<String, List<String>> dependencies) {
+  private static List<List<EngineeringDesignModule>> buildOrderedLevels(Map<String, EngineeringDesignModule> modules,
+      Map<String, List<String>> dependencies) {
     Set<String> remaining = new LinkedHashSet<String>(modules.keySet());
     Set<String> completed = new LinkedHashSet<String>();
     List<List<EngineeringDesignModule>> levels = new ArrayList<List<EngineeringDesignModule>>();
@@ -122,8 +122,7 @@ public final class EngineeringDesignDependencyGraph implements Serializable {
       }
       Collections.sort(ready);
       if (ready.isEmpty()) {
-        throw new EngineeringDesignDependencyException(
-            "Cycle detected among engineering design modules " + remaining);
+        throw new EngineeringDesignDependencyException("Cycle detected among engineering design modules " + remaining);
       }
       List<EngineeringDesignModule> level = new ArrayList<EngineeringDesignModule>();
       for (String id : ready) {

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignDependencyGraph.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignDependencyGraph.java
@@ -1,0 +1,163 @@
+package neqsim.process.engineering.design;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Immutable, validated dependency graph for engineering design modules.
+ *
+ * <p>
+ * Modules in the same level are independent. Their proposals are resolved together before the next level is evaluated,
+ * so a dependent module sees its dependencies' selected state in the same design iteration.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public final class EngineeringDesignDependencyGraph implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final Map<String, EngineeringDesignModule> modulesById;
+  private final Map<String, List<String>> dependenciesById;
+  private final List<List<EngineeringDesignModule>> orderedLevels;
+
+  private EngineeringDesignDependencyGraph(List<EngineeringDesignModule> configuredModules) {
+    List<EngineeringDesignModule> modules = configuredModules == null
+        ? new ArrayList<EngineeringDesignModule>() : new ArrayList<EngineeringDesignModule>(configuredModules);
+    Collections.sort(modules, new Comparator<EngineeringDesignModule>() {
+      @Override
+      public int compare(EngineeringDesignModule first, EngineeringDesignModule second) {
+        return requireId(first).compareTo(requireId(second));
+      }
+    });
+
+    Map<String, EngineeringDesignModule> moduleMap = new LinkedHashMap<String, EngineeringDesignModule>();
+    for (EngineeringDesignModule module : modules) {
+      String id = requireId(module);
+      if (moduleMap.put(id, module) != null) {
+        throw new EngineeringDesignDependencyException("Duplicate engineering design module ID " + id);
+      }
+    }
+
+    Map<String, List<String>> dependencyMap = new LinkedHashMap<String, List<String>>();
+    for (EngineeringDesignModule module : modules) {
+      String id = requireId(module);
+      List<String> dependencies = normalizedDependencies(module.getDependencies(), id);
+      for (String dependency : dependencies) {
+        if (!moduleMap.containsKey(dependency)) {
+          throw new EngineeringDesignDependencyException(
+              "Engineering design module " + id + " depends on missing module " + dependency);
+        }
+        if (id.equals(dependency)) {
+          throw new EngineeringDesignDependencyException("Engineering design module " + id + " depends on itself");
+        }
+      }
+      dependencyMap.put(id, Collections.unmodifiableList(dependencies));
+    }
+
+    modulesById = Collections.unmodifiableMap(moduleMap);
+    dependenciesById = Collections.unmodifiableMap(dependencyMap);
+    orderedLevels = buildOrderedLevels(moduleMap, dependencyMap);
+  }
+
+  /**
+   * Build and validate a dependency graph.
+   *
+   * @param configuredModules design modules
+   * @return immutable dependency graph
+   */
+  public static EngineeringDesignDependencyGraph of(List<EngineeringDesignModule> configuredModules) {
+    return new EngineeringDesignDependencyGraph(configuredModules);
+  }
+
+  /** @return module IDs in deterministic topological order */
+  public List<String> getOrderedModuleIds() {
+    List<String> result = new ArrayList<String>();
+    for (List<EngineeringDesignModule> level : orderedLevels) {
+      for (EngineeringDesignModule module : level) {
+        result.add(module.getId());
+      }
+    }
+    return Collections.unmodifiableList(result);
+  }
+
+  /** @return defensive dependency map keyed by module ID */
+  public Map<String, List<String>> getDependenciesById() {
+    return dependenciesById;
+  }
+
+  /**
+   * Get a configured module by ID.
+   *
+   * @param moduleId module ID
+   * @return module, or {@code null} when absent
+   */
+  public EngineeringDesignModule getModule(String moduleId) {
+    return modulesById.get(moduleId);
+  }
+
+  /** @return immutable topological levels */
+  List<List<EngineeringDesignModule>> getOrderedLevels() {
+    return orderedLevels;
+  }
+
+  private static List<List<EngineeringDesignModule>> buildOrderedLevels(
+      Map<String, EngineeringDesignModule> modules, Map<String, List<String>> dependencies) {
+    Set<String> remaining = new LinkedHashSet<String>(modules.keySet());
+    Set<String> completed = new LinkedHashSet<String>();
+    List<List<EngineeringDesignModule>> levels = new ArrayList<List<EngineeringDesignModule>>();
+    while (!remaining.isEmpty()) {
+      List<String> ready = new ArrayList<String>();
+      for (String id : remaining) {
+        if (completed.containsAll(dependencies.get(id))) {
+          ready.add(id);
+        }
+      }
+      Collections.sort(ready);
+      if (ready.isEmpty()) {
+        throw new EngineeringDesignDependencyException(
+            "Cycle detected among engineering design modules " + remaining);
+      }
+      List<EngineeringDesignModule> level = new ArrayList<EngineeringDesignModule>();
+      for (String id : ready) {
+        level.add(modules.get(id));
+        remaining.remove(id);
+        completed.add(id);
+      }
+      levels.add(Collections.unmodifiableList(level));
+    }
+    return Collections.unmodifiableList(levels);
+  }
+
+  private static List<String> normalizedDependencies(List<String> configured, String moduleId) {
+    if (configured == null) {
+      throw new EngineeringDesignDependencyException(
+          "Engineering design module " + moduleId + " returned null dependencies");
+    }
+    Set<String> unique = new LinkedHashSet<String>();
+    for (String dependency : configured) {
+      if (dependency == null || dependency.trim().isEmpty()) {
+        throw new EngineeringDesignDependencyException(
+            "Engineering design module " + moduleId + " has a blank dependency ID");
+      }
+      unique.add(dependency.trim());
+    }
+    List<String> result = new ArrayList<String>(unique);
+    Collections.sort(result);
+    return result;
+  }
+
+  private static String requireId(EngineeringDesignModule module) {
+    if (module == null || module.getId() == null || module.getId().trim().isEmpty()) {
+      throw new EngineeringDesignDependencyException("Engineering design modules must have non-blank IDs");
+    }
+    return module.getId().trim();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignLoop.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignLoop.java
@@ -137,7 +137,8 @@ public final class EngineeringDesignLoop {
       OwnedUpdate candidate = proposals.get(index);
       double candidateValue = candidate.update.selectedValue();
       boolean governing = resolution == EngineeringDesignUpdate.ConflictResolution.GOVERNING_MAXIMUM
-          ? candidateValue > selectedValue : candidateValue < selectedValue;
+          ? candidateValue > selectedValue
+          : candidateValue < selectedValue;
       if (governing || (candidateValue == selectedValue && candidate.moduleId.compareTo(selected.moduleId) < 0)) {
         selected = candidate;
         selectedValue = candidateValue;
@@ -146,10 +147,9 @@ public final class EngineeringDesignLoop {
     return selected;
   }
 
-  private static EngineeringDesignConflictException conflict(String key, List<OwnedUpdate> proposals,
-      String reason) {
-    StringBuilder diagnostic = new StringBuilder("Conflicting engineering design updates for ").append(key)
-        .append(": ").append(reason).append("; proposals=");
+  private static EngineeringDesignConflictException conflict(String key, List<OwnedUpdate> proposals, String reason) {
+    StringBuilder diagnostic = new StringBuilder("Conflicting engineering design updates for ").append(key).append(": ")
+        .append(reason).append("; proposals=");
     for (int index = 0; index < proposals.size(); index++) {
       OwnedUpdate proposal = proposals.get(index);
       if (index > 0) {

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignLoop.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignLoop.java
@@ -1,10 +1,11 @@
 package neqsim.process.engineering.design;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import neqsim.process.engineering.calculation.EngineeringCalculationContext;
 import neqsim.process.engineering.designcase.EngineeringCaseRunOptions;
 import neqsim.process.engineering.designcase.EngineeringCaseRunReport;
@@ -24,7 +25,7 @@ public final class EngineeringDesignLoop {
     }
     EngineeringDesignLoopOptions options = configuredOptions == null ? EngineeringDesignLoopOptions.builder().build()
         : configuredOptions;
-    List<EngineeringDesignModule> modules = orderedModules(configuredModules);
+    EngineeringDesignDependencyGraph dependencyGraph = EngineeringDesignDependencyGraph.of(configuredModules);
     ProcessSystem working = baseProcess.copy();
     EngineeringDesignState state = new EngineeringDesignState();
     List<EngineeringDesignIteration> iterations = new ArrayList<EngineeringDesignIteration>();
@@ -38,35 +39,48 @@ public final class EngineeringDesignLoop {
           .simulationFingerprint(caseReport.getResultFingerprint())
           .attribute("designIteration", Integer.toString(number)).build();
       List<EngineeringDesignModuleResult> moduleResults = new ArrayList<EngineeringDesignModuleResult>();
-      for (EngineeringDesignModule module : modules) {
-        moduleResults.add(module.evaluate(working, caseReport, state, context));
-      }
-
       int appliedUpdates = 0;
       double maximumChange = 0.0;
-      List<EngineeringDesignVariable> designVariables = new ArrayList<EngineeringDesignVariable>();
-      Map<String, EngineeringDesignUpdate> selectedUpdates = new java.util.LinkedHashMap<String, EngineeringDesignUpdate>();
-      Map<String, String> updateOwners = new java.util.LinkedHashMap<String, String>();
-      for (EngineeringDesignModuleResult moduleResult : moduleResults) {
-        for (EngineeringDesignUpdate update : moduleResult.getUpdates()) {
-          selectedUpdates.put(update.getKey(), update);
-          updateOwners.put(update.getKey(), moduleResult.getModuleId());
+      Map<String, EngineeringDesignVariable> designVariablesByKey = new LinkedHashMap<String, EngineeringDesignVariable>();
+      Map<String, List<OwnedUpdate>> proposalsByKey = new LinkedHashMap<String, List<OwnedUpdate>>();
+      for (List<EngineeringDesignModule> level : dependencyGraph.getOrderedLevels()) {
+        Set<String> levelUpdateKeys = new LinkedHashSet<String>();
+        for (EngineeringDesignModule module : level) {
+          EngineeringDesignModuleResult moduleResult = module.evaluate(working, caseReport, state, context);
+          if (moduleResult == null || !module.getId().trim().equals(moduleResult.getModuleId())) {
+            throw new EngineeringDesignDependencyException("Engineering design module " + module.getId()
+                + " returned a result for " + (moduleResult == null ? "null" : moduleResult.getModuleId()));
+          }
+          moduleResults.add(moduleResult);
+          for (EngineeringDesignUpdate update : moduleResult.getUpdates()) {
+            List<OwnedUpdate> proposals = proposalsByKey.get(update.getKey());
+            if (proposals == null) {
+              proposals = new ArrayList<OwnedUpdate>();
+              proposalsByKey.put(update.getKey(), proposals);
+            }
+            proposals.add(new OwnedUpdate(moduleResult.getModuleId(), update));
+            levelUpdateKeys.add(update.getKey());
+          }
+        }
+        for (String key : levelUpdateKeys) {
+          OwnedUpdate selectedUpdate = resolveUpdate(key, proposalsByKey.get(key));
+          EngineeringDesignUpdate update = selectedUpdate.update;
+          double selected = update.selectedValue();
+          EngineeringDesignValue previous = state.get(update.getKey());
+          double change = relativeChange(previous, selected);
+          maximumChange = Math.max(maximumChange, change);
+          boolean applied = previous == null || change > update.getRelativeTolerance();
+          designVariablesByKey.put(key, new EngineeringDesignVariable(update, previous, selected, change, applied));
+          if (applied) {
+            update.apply(working, selected);
+            state.put(new EngineeringDesignValue(update.getKey(), selected, update.getUnit(), selectedUpdate.moduleId,
+                update.getGoverningCaseId(), number));
+            appliedUpdates++;
+          }
         }
       }
-      for (EngineeringDesignUpdate update : selectedUpdates.values()) {
-        double selected = update.selectedValue();
-        EngineeringDesignValue previous = state.get(update.getKey());
-        double change = relativeChange(previous, selected);
-        maximumChange = Math.max(maximumChange, change);
-        boolean applied = previous == null || change > update.getRelativeTolerance();
-        designVariables.add(new EngineeringDesignVariable(update, previous, selected, change, applied));
-        if (applied) {
-          update.apply(working, selected);
-          state.put(new EngineeringDesignValue(update.getKey(), selected, update.getUnit(),
-              updateOwners.get(update.getKey()), update.getGoverningCaseId(), number));
-          appliedUpdates++;
-        }
-      }
+      List<EngineeringDesignVariable> designVariables = new ArrayList<EngineeringDesignVariable>(
+          designVariablesByKey.values());
 
       List<EngineeringConstraintResult> constraintResults = evaluateConstraints(moduleResults, state);
       Map<String, Double> processValues = flattenProcessValues(caseReport);
@@ -99,16 +113,62 @@ public final class EngineeringDesignLoop {
     return new EngineeringDesignLoopResult(false, "MAXIMUM_ITERATIONS_REACHED", state, iterations, working);
   }
 
-  private static List<EngineeringDesignModule> orderedModules(List<EngineeringDesignModule> configured) {
-    List<EngineeringDesignModule> result = configured == null ? new ArrayList<EngineeringDesignModule>()
-        : new ArrayList<EngineeringDesignModule>(configured);
-    Collections.sort(result, new Comparator<EngineeringDesignModule>() {
-      @Override
-      public int compare(EngineeringDesignModule first, EngineeringDesignModule second) {
-        return first.getId().compareTo(second.getId());
+  private static OwnedUpdate resolveUpdate(String key, List<OwnedUpdate> proposals) {
+    if (proposals.size() == 1) {
+      return proposals.get(0);
+    }
+    EngineeringDesignUpdate.ConflictResolution resolution = proposals.get(0).update.getConflictResolution();
+    String unit = proposals.get(0).update.getUnit();
+    for (OwnedUpdate proposal : proposals) {
+      if (!unit.equals(proposal.update.getUnit())) {
+        throw conflict(key, proposals, "incompatible units");
       }
-    });
-    return result;
+      if (resolution != proposal.update.getConflictResolution()) {
+        throw conflict(key, proposals, "incompatible conflict-resolution rules");
+      }
+    }
+    if (resolution == EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE) {
+      throw conflict(key, proposals, "no governing rule was declared");
+    }
+
+    OwnedUpdate selected = proposals.get(0);
+    double selectedValue = selected.update.selectedValue();
+    for (int index = 1; index < proposals.size(); index++) {
+      OwnedUpdate candidate = proposals.get(index);
+      double candidateValue = candidate.update.selectedValue();
+      boolean governing = resolution == EngineeringDesignUpdate.ConflictResolution.GOVERNING_MAXIMUM
+          ? candidateValue > selectedValue : candidateValue < selectedValue;
+      if (governing || (candidateValue == selectedValue && candidate.moduleId.compareTo(selected.moduleId) < 0)) {
+        selected = candidate;
+        selectedValue = candidateValue;
+      }
+    }
+    return selected;
+  }
+
+  private static EngineeringDesignConflictException conflict(String key, List<OwnedUpdate> proposals,
+      String reason) {
+    StringBuilder diagnostic = new StringBuilder("Conflicting engineering design updates for ").append(key)
+        .append(": ").append(reason).append("; proposals=");
+    for (int index = 0; index < proposals.size(); index++) {
+      OwnedUpdate proposal = proposals.get(index);
+      if (index > 0) {
+        diagnostic.append(", ");
+      }
+      diagnostic.append(proposal.moduleId).append("=").append(proposal.update.selectedValue()).append(" ")
+          .append(proposal.update.getUnit()).append(" [").append(proposal.update.getConflictResolution()).append("]");
+    }
+    return new EngineeringDesignConflictException(key, diagnostic.toString());
+  }
+
+  private static final class OwnedUpdate {
+    private final String moduleId;
+    private final EngineeringDesignUpdate update;
+
+    private OwnedUpdate(String moduleId, EngineeringDesignUpdate update) {
+      this.moduleId = moduleId;
+      this.update = update;
+    }
   }
 
   private static List<EngineeringConstraintResult> evaluateConstraints(

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignModule.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignModule.java
@@ -1,6 +1,8 @@
 package neqsim.process.engineering.design;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
 import neqsim.process.engineering.calculation.EngineeringCalculationContext;
 import neqsim.process.engineering.designcase.EngineeringCaseRunReport;
 import neqsim.process.processmodel.ProcessSystem;
@@ -8,6 +10,15 @@ import neqsim.process.processmodel.ProcessSystem;
 /** One discipline calculation participating in the iterative engineering design loop. */
 public interface EngineeringDesignModule extends Serializable {
   String getId();
+
+  /**
+   * Module IDs whose selected updates must be available before this module is evaluated in an iteration.
+   *
+   * @return dependency IDs; empty by default
+   */
+  default List<String> getDependencies() {
+    return Collections.emptyList();
+  }
 
   EngineeringDesignModuleResult evaluate(ProcessSystem process, EngineeringCaseRunReport caseReport,
       EngineeringDesignState state, EngineeringCalculationContext context);

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignUpdate.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignUpdate.java
@@ -13,6 +13,16 @@ public final class EngineeringDesignUpdate implements Serializable {
     void apply(ProcessSystem process, double value);
   }
 
+  /** Defines how proposals from more than one module may govern a shared design variable. */
+  public enum ConflictResolution {
+    /** More than one module proposing the key is a configuration error. */
+    REQUIRE_UNIQUE,
+    /** Select the largest proposed value after confirming identical units and rules. */
+    GOVERNING_MAXIMUM,
+    /** Select the smallest proposed value after confirming identical units and rules. */
+    GOVERNING_MINIMUM
+  }
+
   private final String key;
   private final double requiredValue;
   private final String unit;
@@ -21,6 +31,7 @@ public final class EngineeringDesignUpdate implements Serializable {
   private final double[] candidates;
   private final DesignCandidate[] designCandidates;
   private final Applier applier;
+  private final ConflictResolution conflictResolution;
 
   private EngineeringDesignUpdate(Builder builder) {
     key = requireText(builder.key, "key");
@@ -51,6 +62,7 @@ public final class EngineeringDesignUpdate implements Serializable {
       }
     }
     applier = builder.applier;
+    conflictResolution = builder.conflictResolution;
   }
 
   public static Builder builder(String key, double requiredValue, String unit) {
@@ -75,6 +87,11 @@ public final class EngineeringDesignUpdate implements Serializable {
 
   public double getRelativeTolerance() {
     return relativeTolerance;
+  }
+
+  /** @return declared shared-variable conflict resolution */
+  public ConflictResolution getConflictResolution() {
+    return conflictResolution;
   }
 
   public double selectedValue() {
@@ -130,6 +147,7 @@ public final class EngineeringDesignUpdate implements Serializable {
     private double[] candidates;
     private DesignCandidate[] designCandidates;
     private Applier applier;
+    private ConflictResolution conflictResolution = ConflictResolution.REQUIRE_UNIQUE;
 
     private Builder(String key, double requiredValue, String unit) {
       this.key = key;
@@ -162,6 +180,20 @@ public final class EngineeringDesignUpdate implements Serializable {
 
     public Builder applier(Applier value) {
       applier = value;
+      return this;
+    }
+
+    /**
+     * Declare how this update may be combined with proposals for the same key from other modules.
+     *
+     * @param value explicit governing rule
+     * @return this builder
+     */
+    public Builder conflictResolution(ConflictResolution value) {
+      if (value == null) {
+        throw new IllegalArgumentException("conflictResolution must not be null");
+      }
+      conflictResolution = value;
       return this;
     }
 

--- a/src/main/java/neqsim/process/engineering/design/EngineeringDesignValue.java
+++ b/src/main/java/neqsim/process/engineering/design/EngineeringDesignValue.java
@@ -39,6 +39,21 @@ public final class EngineeringDesignValue implements Serializable {
     return unit;
   }
 
+  /** @return module that supplied the selected governing proposal */
+  public String getSourceModule() {
+    return sourceModule;
+  }
+
+  /** @return governing design case ID, or an empty string when not case-specific */
+  public String getGoverningCaseId() {
+    return governingCaseId;
+  }
+
+  /** @return design-loop iteration in which this value was selected */
+  public int getIteration() {
+    return iteration;
+  }
+
   public Map<String, Object> toMap() {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("key", key);

--- a/src/test/java/neqsim/process/engineering/design/EngineeringDesignLoopTest.java
+++ b/src/test/java/neqsim/process/engineering/design/EngineeringDesignLoopTest.java
@@ -84,10 +84,10 @@ class EngineeringDesignLoopTest {
 
   @Test
   void dependencyGraphOrdersModulesAndMakesUpstreamStateAvailableInSameIteration() {
-    DependencyModule downstream = new DependencyModule("a-downstream", Arrays.asList("z-upstream"),
-        "design.downstream", 2.0, "design.upstream", EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
-    DependencyModule upstream = new DependencyModule("z-upstream", Collections.<String>emptyList(),
-        "design.upstream", 1.0, null, EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+    DependencyModule downstream = new DependencyModule("a-downstream", Arrays.asList("z-upstream"), "design.downstream",
+        2.0, "design.upstream", EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+    DependencyModule upstream = new DependencyModule("z-upstream", Collections.<String>emptyList(), "design.upstream",
+        1.0, null, EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
 
     EngineeringDesignDependencyGraph graph = EngineeringDesignDependencyGraph
         .of(Arrays.<EngineeringDesignModule>asList(downstream, upstream));
@@ -103,8 +103,8 @@ class EngineeringDesignLoopTest {
 
   @Test
   void dependencyGraphRejectsMissingDependenciesAndCycles() {
-    DependencyModule missing = new DependencyModule("missing-user", Arrays.asList("not-configured"), null, 0.0,
-        null, EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+    DependencyModule missing = new DependencyModule("missing-user", Arrays.asList("not-configured"), null, 0.0, null,
+        EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
     EngineeringDesignDependencyException missingException = assertThrows(EngineeringDesignDependencyException.class,
         () -> EngineeringDesignDependencyGraph.of(Arrays.<EngineeringDesignModule>asList(missing)));
     assertTrue(missingException.getMessage().contains("not-configured"));
@@ -122,8 +122,8 @@ class EngineeringDesignLoopTest {
   void duplicateUpdatesFailClosedWithoutGoverningRule() {
     DependencyModule first = new DependencyModule("first", Collections.<String>emptyList(), "shared.pressure", 60.0,
         null, EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
-    DependencyModule second = new DependencyModule("second", Collections.<String>emptyList(), "shared.pressure",
-        70.0, null, EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+    DependencyModule second = new DependencyModule("second", Collections.<String>emptyList(), "shared.pressure", 70.0,
+        null, EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
 
     EngineeringDesignConflictException exception = assertThrows(EngineeringDesignConflictException.class,
         () -> EngineeringDesignLoop.run(process(), cases("conflict"),
@@ -139,8 +139,8 @@ class EngineeringDesignLoopTest {
   void explicitGoverningMaximumSelectsTraceableProposal() {
     DependencyModule low = new DependencyModule("low-case", Collections.<String>emptyList(), "shared.pressure", 60.0,
         null, EngineeringDesignUpdate.ConflictResolution.GOVERNING_MAXIMUM);
-    DependencyModule high = new DependencyModule("high-case", Collections.<String>emptyList(), "shared.pressure",
-        70.0, null, EngineeringDesignUpdate.ConflictResolution.GOVERNING_MAXIMUM);
+    DependencyModule high = new DependencyModule("high-case", Collections.<String>emptyList(), "shared.pressure", 70.0,
+        null, EngineeringDesignUpdate.ConflictResolution.GOVERNING_MAXIMUM);
 
     EngineeringDesignLoopResult result = EngineeringDesignLoop.run(process(), cases("governing-maximum"),
         Arrays.<EngineeringDesignModule>asList(low, high),
@@ -267,8 +267,8 @@ class EngineeringDesignLoopTest {
       EngineeringDesignModuleResult.Builder builder = EngineeringDesignModuleResult.builder(id, "dependency test",
           "1.0");
       if (updateKey != null) {
-        builder.addUpdate(EngineeringDesignUpdate.builder(updateKey, value, "bara")
-            .conflictResolution(conflictResolution).build());
+        builder.addUpdate(
+            EngineeringDesignUpdate.builder(updateKey, value, "bara").conflictResolution(conflictResolution).build());
       }
       return builder.build();
     }

--- a/src/test/java/neqsim/process/engineering/design/EngineeringDesignLoopTest.java
+++ b/src/test/java/neqsim/process/engineering/design/EngineeringDesignLoopTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import neqsim.process.engineering.calculation.EngineeringCalculationContext;
 import neqsim.process.engineering.designcase.EngineeringCaseRunReport;
 import neqsim.process.engineering.designcase.EngineeringCaseSet;
@@ -80,6 +82,87 @@ class EngineeringDesignLoopTest {
     assertEquals(3, result.getIterations().size());
   }
 
+  @Test
+  void dependencyGraphOrdersModulesAndMakesUpstreamStateAvailableInSameIteration() {
+    DependencyModule downstream = new DependencyModule("a-downstream", Arrays.asList("z-upstream"),
+        "design.downstream", 2.0, "design.upstream", EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+    DependencyModule upstream = new DependencyModule("z-upstream", Collections.<String>emptyList(),
+        "design.upstream", 1.0, null, EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+
+    EngineeringDesignDependencyGraph graph = EngineeringDesignDependencyGraph
+        .of(Arrays.<EngineeringDesignModule>asList(downstream, upstream));
+    EngineeringDesignLoopResult result = EngineeringDesignLoop.run(process(), cases("dependency-order"),
+        Arrays.<EngineeringDesignModule>asList(downstream, upstream),
+        EngineeringDesignLoopOptions.builder().maximumIterations(4).build());
+
+    assertEquals(Arrays.asList("z-upstream", "a-downstream"), graph.getOrderedModuleIds());
+    assertTrue(result.isConverged());
+    assertEquals(1.0, result.getState().requireValue("design.upstream"), 1.0e-12);
+    assertEquals(2.0, result.getState().requireValue("design.downstream"), 1.0e-12);
+  }
+
+  @Test
+  void dependencyGraphRejectsMissingDependenciesAndCycles() {
+    DependencyModule missing = new DependencyModule("missing-user", Arrays.asList("not-configured"), null, 0.0,
+        null, EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+    EngineeringDesignDependencyException missingException = assertThrows(EngineeringDesignDependencyException.class,
+        () -> EngineeringDesignDependencyGraph.of(Arrays.<EngineeringDesignModule>asList(missing)));
+    assertTrue(missingException.getMessage().contains("not-configured"));
+
+    DependencyModule first = new DependencyModule("first", Arrays.asList("second"), null, 0.0, null,
+        EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+    DependencyModule second = new DependencyModule("second", Arrays.asList("first"), null, 0.0, null,
+        EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+    EngineeringDesignDependencyException cycleException = assertThrows(EngineeringDesignDependencyException.class,
+        () -> EngineeringDesignDependencyGraph.of(Arrays.<EngineeringDesignModule>asList(first, second)));
+    assertTrue(cycleException.getMessage().contains("Cycle detected"));
+  }
+
+  @Test
+  void duplicateUpdatesFailClosedWithoutGoverningRule() {
+    DependencyModule first = new DependencyModule("first", Collections.<String>emptyList(), "shared.pressure", 60.0,
+        null, EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+    DependencyModule second = new DependencyModule("second", Collections.<String>emptyList(), "shared.pressure",
+        70.0, null, EngineeringDesignUpdate.ConflictResolution.REQUIRE_UNIQUE);
+
+    EngineeringDesignConflictException exception = assertThrows(EngineeringDesignConflictException.class,
+        () -> EngineeringDesignLoop.run(process(), cases("conflict"),
+            Arrays.<EngineeringDesignModule>asList(first, second),
+            EngineeringDesignLoopOptions.builder().maximumIterations(3).build()));
+
+    assertEquals("shared.pressure", exception.getDesignVariableKey());
+    assertTrue(exception.getMessage().contains("first=60.0 bara"));
+    assertTrue(exception.getMessage().contains("second=70.0 bara"));
+  }
+
+  @Test
+  void explicitGoverningMaximumSelectsTraceableProposal() {
+    DependencyModule low = new DependencyModule("low-case", Collections.<String>emptyList(), "shared.pressure", 60.0,
+        null, EngineeringDesignUpdate.ConflictResolution.GOVERNING_MAXIMUM);
+    DependencyModule high = new DependencyModule("high-case", Collections.<String>emptyList(), "shared.pressure",
+        70.0, null, EngineeringDesignUpdate.ConflictResolution.GOVERNING_MAXIMUM);
+
+    EngineeringDesignLoopResult result = EngineeringDesignLoop.run(process(), cases("governing-maximum"),
+        Arrays.<EngineeringDesignModule>asList(low, high),
+        EngineeringDesignLoopOptions.builder().maximumIterations(3).build());
+
+    assertTrue(result.isConverged());
+    assertEquals(70.0, result.getState().requireValue("shared.pressure"), 1.0e-12);
+    assertEquals("high-case", result.getState().get("shared.pressure").getSourceModule());
+  }
+
+  private EngineeringCaseSet cases(String id) {
+    return new EngineeringCaseSet(id).addCase(new EngineeringDesignCase("normal", "Normal",
+        EngineeringDesignCase.Type.NORMAL, new EngineeringDesignCase.Configurator() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public void configure(ProcessSystem process) {
+            // The dependency and conflict tests use the unchanged normal case.
+          }
+        })).addMetric(EngineeringMetric.equipmentPressure("FEED"));
+  }
+
   private ProcessSystem process() {
     SystemInterface fluid = new SystemSrkEos(300.0, 50.0);
     fluid.addComponent("methane", 1.0);
@@ -143,6 +226,51 @@ class EngineeringDesignLoopTest {
                 }
               }).build())
           .build();
+    }
+  }
+
+  private static final class DependencyModule implements EngineeringDesignModule {
+    private static final long serialVersionUID = 1000L;
+    private final String id;
+    private final List<String> dependencies;
+    private final String updateKey;
+    private final double value;
+    private final String requiredStateKey;
+    private final EngineeringDesignUpdate.ConflictResolution conflictResolution;
+
+    private DependencyModule(String id, List<String> dependencies, String updateKey, double value,
+        String requiredStateKey, EngineeringDesignUpdate.ConflictResolution conflictResolution) {
+      this.id = id;
+      this.dependencies = dependencies;
+      this.updateKey = updateKey;
+      this.value = value;
+      this.requiredStateKey = requiredStateKey;
+      this.conflictResolution = conflictResolution;
+    }
+
+    @Override
+    public String getId() {
+      return id;
+    }
+
+    @Override
+    public List<String> getDependencies() {
+      return dependencies;
+    }
+
+    @Override
+    public EngineeringDesignModuleResult evaluate(ProcessSystem process, EngineeringCaseRunReport caseReport,
+        EngineeringDesignState state, EngineeringCalculationContext context) {
+      if (requiredStateKey != null && !state.contains(requiredStateKey)) {
+        throw new IllegalStateException("Required upstream state was not available: " + requiredStateKey);
+      }
+      EngineeringDesignModuleResult.Builder builder = EngineeringDesignModuleResult.builder(id, "dependency test",
+          "1.0");
+      if (updateKey != null) {
+        builder.addUpdate(EngineeringDesignUpdate.builder(updateKey, value, "bara")
+            .conflictResolution(conflictResolution).build());
+      }
+      return builder.build();
     }
   }
 }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/FreezingPointTemperatureFlashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/FreezingPointTemperatureFlashTest.java
@@ -21,7 +21,9 @@ class FreezingPointTemperatureFlashTest {
     system.setSolidPhaseCheck("CO2");
 
     ThermodynamicOperations operations = new ThermodynamicOperations(system);
-    assertDoesNotThrow(operations::freezingPointTemperatureFlash);
+    assertDoesNotThrow(() -> {
+      operations.freezingPointTemperatureFlash();
+    });
 
     double freezingTemperature = system.getTemperature();
     assertTrue(Double.isFinite(freezingTemperature));


### PR DESCRIPTION
## Summary
- add an immutable `EngineeringDesignDependencyGraph` with deterministic topological levels
- validate duplicate IDs, blank IDs/dependencies, missing dependencies, self-dependencies, and cycles before design starts
- let modules declare dependencies through a Java 8-compatible default method
- apply upstream selections before evaluating the next level in the same design iteration
- replace silent last-writer-wins updates with typed `EngineeringDesignConflictException`
- require explicit `GOVERNING_MAXIMUM` or `GOVERNING_MINIMUM` rules for intentionally shared variables
- reject unit or governing-rule disagreement and retain the selected source module in design state
- expose governing case/source/iteration provenance getters

## Compatibility
Modules with no declared dependencies remain independent and deterministic. Existing single-owner design variables behave unchanged. Previously ambiguous duplicate update keys now fail closed unless their engineering governing rule is explicit.

## Validation
- Java 8 production compilation passed with a focused dependency harness
- behavior harness passed topological ordering, same-iteration upstream state, missing dependencies, conflicts, and governing selection
- JUnit regression coverage added for missing/cyclic graphs, conflict diagnostics, and traceable maximum selection
- documentation gates updated
- full Maven/Spotless validation delegated to hosted CI because dependencies cannot be downloaded in this environment

## Scope and maturity
The graph coordinates calculation order and scalar governing selection. It does not replace discipline review or make screening modules construction-qualified; engineering approval remains required.