### PR TITLE
Add typed API 617 and API 12J design screens

### DIFF
--- a/docs/process/DESIGN_FRAMEWORK.md
+++ b/docs/process/DESIGN_FRAMEWORK.md
@@ -32,10 +32,11 @@ The design framework consists of several integrated components:
 | `EquipmentDesignKernel` | Readiness-gated, standard-specific calculation adapter |
 
 Standard-specific equipment calculations are registered explicitly. The current registry exposes
-screening kernels for API 610 pump checks, API 521 relief-scenario evaluation, and API 526
-standard-orifice selection. Unsupported editions, inapplicable equipment types, and incomplete
-inputs return blocked results. All three remain preliminary engineering screens and do not claim
-certification or construction readiness.
+screening kernels for API 617 compressor-casing checks, API 610 pump checks, API 521 relief-scenario
+evaluation, API 526 standard-orifice selection, and API 12J separator-performance checks.
+Unsupported editions, inapplicable equipment types, and incomplete inputs return blocked results.
+All remain preliminary engineering screens and do not claim certification or construction
+readiness.
 
 ## Quick Start
 

--- a/docs/process/mechanical_design_standards.md
+++ b/docs/process/mechanical_design_standards.md
@@ -39,7 +39,7 @@ the source catalog diverge.
 | ASME-B31.3 | 2022 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
 | ASME-B31.4 | 2022 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
 | ASME-B31.8 | 2022 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
-| API-617 | 8th Ed | compressor design codes | CompressorDesignStandard | CompressorDesignStandard | SCREENING | Preliminary compressor-factor screening only; package and vendor requirements are not implemented. |
+| API-617 | 8th Ed | compressor design codes | CompressorDesignStandard | Api617CompressorDesignKernel | SCREENING | Compressor-casing pressure containment, flange, nozzle-load allowance, and thermal-growth screening only; rotor dynamics, package integration, and vendor conformity are not evaluated. |
 | API-610 | 13th Ed | pump design codes | DesignStandard | PumpApi610DesignKernel | SCREENING | API 610 screening is connected through a pure engineering-workflow adapter; purchased-standard, project, and vendor verification remain required. |
 | API-650 | 13th Ed | pressure vessel design code | PressureVesselDesignStandard | None | CATALOGUED | The registry maps this tank standard to a separator-oriented pressure-vessel class; no tank-code calculation is implemented. |
 | API-620 | 13th Ed | pressure vessel design code | PressureVesselDesignStandard | None | CATALOGUED | The registry maps this tank standard to a separator-oriented pressure-vessel class; no tank-code calculation is implemented. |
@@ -48,7 +48,7 @@ the source catalog diverge.
 | API-521 | 7th Ed | relief system design codes | ValveDesignStandard | Api521ReliefDesignKernel | SCREENING | Scenario aggregation, governing-case selection, relief-area sizing, and accumulated-pressure screening only; scenario completeness, installation, and conformity require independent review. |
 | API-526 | 7th Ed | relief valve design codes | ValveDesignStandard | Api526OrificeSelectionKernel | SCREENING | Standard-orifice area selection only; valve pressure class, dimensions, materials, installation, and vendor certification are not evaluated. |
 | API-5L | 46th Ed | material pipe design codes | MaterialPipeDesignStandard | MaterialPipeDesignStandard | SCREENING | Material-property lookup only; material selection, qualification, and code acceptance are not implemented. |
-| API-12J | 8th Ed | separator process design | SeparatorDesignStandard | SeparatorDesignStandard | SCREENING | Preliminary K-factor and sizing inputs only; standard-specific requirements are not independently validated. |
+| API-12J | 8th Ed | separator process design | SeparatorDesignStandard | Api12JSeparatorDesignKernel | SCREENING | Gravity cut-diameter, K-factor, and liquid residence-time screening only; service applicability, vessel construction, internals, and performance guarantees require independent review. |
 | DNV-ST-F101 | 2021 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
 | DNV-OS-F101 | 2013 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
 | DNV-RP-F105 | 2021 | pipeline design codes | PipelineDesignStandard | PipelineDesignStandard | SCREENING | Preliminary category screening with fixed fallback values; not a complete edition-specific wall-thickness calculation. |
@@ -90,12 +90,12 @@ not add calculation support.
 implemented standard, audited maturity, and structured applicability. Kernels must not mutate their
 input or a `ProcessSystem`. Compatibility adapters defensively copy legacy mutable calculators.
 
-`StandardRegistry.getDesignKernel(...)` returns an explicit lookup status. API 610, API 521, and API
-526 have connected adapters and return `IMPLEMENTED`; standards that have not been adapted return
-`NOT_IMPLEMENTED`, never an empty or implied success. Each kernel returns an immutable assessment
-snapshot and always requires engineering review because its maturity remains `SCREENING`.
-Unsupported editions fail closed as `EDITION_NOT_IMPLEMENTED` until separately implemented and
-validated.
+`StandardRegistry.getDesignKernel(...)` returns an explicit lookup status. API 617, API 610, API
+521, API 526, and API 12J have connected adapters and return `IMPLEMENTED`; standards that have not
+been adapted return `NOT_IMPLEMENTED`, never an empty or implied success. Each kernel returns an
+immutable assessment snapshot and always requires engineering review because its maturity remains
+`SCREENING`. Unsupported editions fail closed as `EDITION_NOT_IMPLEMENTED` until separately
+implemented and validated.
 
 The API 521 adapter defensively copies the mutable protected-item basis, requires at least one
 complete credible scenario, selects the governing rate, and records the sizing and accumulated
@@ -103,6 +103,11 @@ pressure checks. The API 526 adapter accepts an explicitly unit-tagged required 
 inadequate result when a single standard orifice cannot cover it. These adapters do not establish
 scenario completeness or qualify valve construction, installation, reaction loads, flare-network
 effects, or vendor certification.
+
+The API 617 adapter defensively copies a compressor-casing configuration before evaluating pressure
+containment, hydrotest, flange-rating, nozzle-load allowance, and thermal-growth screens. The API
+12J adapter uses explicitly unit-tagged cut diameter together with K-factor and liquid residence
+time. Passing either result is not a package, vessel, or performance certification.
 
 ## How to interpret the registry
 

--- a/src/main/java/neqsim/process/engineering/calculation/Api12JSeparatorAssessment.java
+++ b/src/main/java/neqsim/process/engineering/calculation/Api12JSeparatorAssessment.java
@@ -1,0 +1,86 @@
+package neqsim.process.engineering.calculation;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import neqsim.process.equipment.separator.entrainment.DropletSettlingCalculator;
+
+/** Immutable snapshot of an API 12J separator performance screening check. */
+public final class Api12JSeparatorAssessment implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String standardEdition;
+  private final boolean gasLiquidSectionPasses;
+  private final boolean liquidSectionPasses;
+  private final boolean allScreeningCriteriaPass;
+  private final double gravityCutDiameterMicrometre;
+  private final double kFactorUtilization;
+  private final String gasLiquidFinding;
+  private final String liquidFinding;
+
+  Api12JSeparatorAssessment(String standardEdition, DropletSettlingCalculator.ApiComplianceResult result) {
+    this.standardEdition = standardEdition;
+    gasLiquidSectionPasses = result.gasLiquidSectionCompliant;
+    liquidSectionPasses = result.liquidSectionCompliant;
+    allScreeningCriteriaPass = result.isFullyCompliant();
+    gravityCutDiameterMicrometre = result.gravityCutDiameter_um;
+    kFactorUtilization = result.kFactorUtilization;
+    gasLiquidFinding = result.gasLiquidComment;
+    liquidFinding = result.liquidComment;
+  }
+
+  /** @return explicit API 12J edition */
+  public String getStandardEdition() {
+    return standardEdition;
+  }
+
+  /** @return whether gas-section screening criteria pass */
+  public boolean isGasLiquidSectionPassing() {
+    return gasLiquidSectionPasses;
+  }
+
+  /** @return whether liquid residence-time screening criteria pass */
+  public boolean isLiquidSectionPassing() {
+    return liquidSectionPasses;
+  }
+
+  /** @return whether every implemented screening criterion passes */
+  public boolean areAllScreeningCriteriaPassing() {
+    return allScreeningCriteriaPass;
+  }
+
+  /** @return gravity cut diameter in micrometres */
+  public double getGravityCutDiameterMicrometre() {
+    return gravityCutDiameterMicrometre;
+  }
+
+  /** @return operating K-factor divided by the implemented screening limit */
+  public double getKFactorUtilization() {
+    return kFactorUtilization;
+  }
+
+  /** @return gas-section finding */
+  public String getGasLiquidFinding() {
+    return gasLiquidFinding;
+  }
+
+  /** @return liquid-section finding */
+  public String getLiquidFinding() {
+    return liquidFinding;
+  }
+
+  /** @return serializable assessment representation */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("standardEdition", standardEdition);
+    result.put("gasLiquidSectionPasses", Boolean.valueOf(gasLiquidSectionPasses));
+    result.put("liquidSectionPasses", Boolean.valueOf(liquidSectionPasses));
+    result.put("allScreeningCriteriaPass", Boolean.valueOf(allScreeningCriteriaPass));
+    result.put("gravityCutDiameterMicrometre", Double.valueOf(gravityCutDiameterMicrometre));
+    result.put("kFactorUtilization", Double.valueOf(kFactorUtilization));
+    result.put("gasLiquidFinding", gasLiquidFinding);
+    result.put("liquidFinding", liquidFinding);
+    result.put("engineeringApprovalRequired", Boolean.TRUE);
+    return result;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/calculation/Api12JSeparatorDesignKernel.java
+++ b/src/main/java/neqsim/process/engineering/calculation/Api12JSeparatorDesignKernel.java
@@ -1,0 +1,232 @@
+package neqsim.process.engineering.calculation;
+
+import java.io.Serializable;
+import neqsim.process.equipment.separator.entrainment.DropletSettlingCalculator;
+import neqsim.process.mechanicaldesign.designstandards.StandardApplicability;
+import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
+import neqsim.process.mechanicaldesign.designstandards.StandardSupportLevel;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+
+/** Pure API 12J gas-section and liquid-residence-time screening adapter. */
+public final class Api12JSeparatorDesignKernel
+    implements EquipmentDesignKernel<Api12JSeparatorDesignKernel.Input, Api12JSeparatorAssessment> {
+  private static final long serialVersionUID = 1000L;
+  private static final String IMPLEMENTED_EDITION = "8th Ed";
+
+  /** Unit used to supply the gravity cut diameter. */
+  public enum DiameterUnit {
+    /** Metres. */
+    METRE,
+    /** Micrometres. */
+    MICROMETRE
+  }
+
+  /** Separator orientation used by the implemented K-factor screen. */
+  public enum Orientation {
+    /** Horizontal vessel. */
+    HORIZONTAL,
+    /** Vertical vessel. */
+    VERTICAL
+  }
+
+  /** Immutable, unit-aware screening input. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final StandardEdition edition;
+    private final String equipmentType;
+    private final double gravityCutDiameterM;
+    private final double kFactorMPerS;
+    private final boolean mistEliminatorPresent;
+    private final double liquidResidenceTimeS;
+    private final Orientation orientation;
+    private final boolean threePhase;
+
+    /**
+     * Create an API 12J screening input.
+     *
+     * @param edition explicit API 12J edition
+     * @param equipmentType simple separator equipment class name
+     * @param gravityCutDiameter gravity-section cut diameter
+     * @param diameterUnit unit of {@code gravityCutDiameter}
+     * @param kFactorMPerS operating Souders-Brown K-factor in m/s
+     * @param mistEliminatorPresent whether a mist eliminator is installed
+     * @param liquidResidenceTimeS liquid residence time in seconds
+     * @param orientation separator orientation
+     * @param threePhase whether the separator handles gas, oil, and water
+     */
+    public Input(StandardEdition edition, String equipmentType, double gravityCutDiameter, DiameterUnit diameterUnit,
+        double kFactorMPerS, boolean mistEliminatorPresent, double liquidResidenceTimeS, Orientation orientation,
+        boolean threePhase) {
+      if (edition == null || edition.getStandardType() != StandardType.API_12J) {
+        throw new IllegalArgumentException("edition must identify API-12J");
+      }
+      if (equipmentType == null || equipmentType.trim().isEmpty()) {
+        throw new IllegalArgumentException("equipmentType cannot be null or blank");
+      }
+      if (diameterUnit == null || orientation == null) {
+        throw new IllegalArgumentException("diameterUnit and orientation cannot be null");
+      }
+      this.edition = edition;
+      this.equipmentType = equipmentType.trim();
+      this.gravityCutDiameterM = diameterUnit == DiameterUnit.METRE ? gravityCutDiameter
+          : gravityCutDiameter * 1.0e-6;
+      this.kFactorMPerS = kFactorMPerS;
+      this.mistEliminatorPresent = mistEliminatorPresent;
+      this.liquidResidenceTimeS = liquidResidenceTimeS;
+      this.orientation = orientation;
+      this.threePhase = threePhase;
+    }
+
+    /** @return explicit edition */
+    public StandardEdition getEdition() {
+      return edition;
+    }
+
+    /** @return simple separator equipment class name */
+    public String getEquipmentType() {
+      return equipmentType;
+    }
+
+    /** @return gravity cut diameter in metres */
+    public double getGravityCutDiameterM() {
+      return gravityCutDiameterM;
+    }
+
+    /** @return operating K-factor in m/s */
+    public double getKFactorMPerS() {
+      return kFactorMPerS;
+    }
+
+    /** @return whether a mist eliminator is present */
+    public boolean hasMistEliminator() {
+      return mistEliminatorPresent;
+    }
+
+    /** @return liquid residence time in seconds */
+    public double getLiquidResidenceTimeS() {
+      return liquidResidenceTimeS;
+    }
+
+    /** @return separator orientation */
+    public Orientation getOrientation() {
+      return orientation;
+    }
+
+    /** @return whether the service is three-phase */
+    public boolean isThreePhase() {
+      return threePhase;
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public StandardType standard() {
+    return StandardType.API_12J;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public StandardSupportLevel maturity() {
+    return StandardSupportLevel.SCREENING;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean supports(StandardEdition edition) {
+    return edition != null && edition.getStandardType() == standard()
+        && IMPLEMENTED_EDITION.equalsIgnoreCase(edition.getEdition());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public StandardApplicability applicability(Input input) {
+    return StandardApplicability.assess(standard(), input == null ? null : input.getEquipmentType());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getMethod() {
+    return "api-12j-separator-performance-screening";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getMethodVersion() {
+    return "1.0.0";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public CalculationReadiness assess(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness.Builder readiness = CalculationReadiness.builder();
+    if (input == null) {
+      return readiness.addBlocker("API12J_INPUT_MISSING", "API 12J screening input is required",
+          "Provide an edition, equipment type, cut diameter, K-factor, and residence time").build();
+    }
+    StandardApplicability decision = applicability(input);
+    if (!decision.isApplicable()) {
+      readiness.addBlocker("API12J_NOT_APPLICABLE", decision.getReason(),
+          "Use a Separator, ThreePhaseSeparator, or GasScrubber equipment type");
+    }
+    if (!supports(input.getEdition())) {
+      readiness.addBlocker("API12J_EDITION_NOT_IMPLEMENTED",
+          "The API 12J kernel implements " + IMPLEMENTED_EDITION + ", not " + input.getEdition().getEdition(),
+          "Select the implemented edition or add separately validated edition criteria");
+    }
+    if (!positive(input.getGravityCutDiameterM())) {
+      readiness.addBlocker("API12J_CUT_DIAMETER_INVALID", "Gravity cut diameter must be finite and positive",
+          "Supply a calculated cut diameter with an explicit unit");
+    }
+    if (!Double.isFinite(input.getKFactorMPerS()) || input.getKFactorMPerS() < 0.0) {
+      readiness.addBlocker("API12J_K_FACTOR_INVALID", "K-factor must be finite and non-negative",
+          "Supply the operating Souders-Brown K-factor in m/s");
+    }
+    if (!positive(input.getLiquidResidenceTimeS())) {
+      readiness.addBlocker("API12J_RESIDENCE_TIME_INVALID", "Liquid residence time must be finite and positive",
+          "Supply the governing-case liquid residence time in seconds");
+    }
+    readiness.addWarning("API12J_SCREENING_ONLY",
+        "The implemented checks cover cut diameter, K-factor, and liquid residence time only",
+        "Verify the purchased edition, service applicability, vessel construction, internals, and project criteria");
+    return readiness.build();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public EngineeringCalculationResult<Api12JSeparatorAssessment> calculate(Input input,
+      EngineeringCalculationContext context) {
+    EngineeringCalculationContext effectiveContext = context == null ? EngineeringCalculationContext.builder().build()
+        : context;
+    CalculationReadiness readiness = assess(input, effectiveContext);
+    EngineeringCalculationResult.Builder<Api12JSeparatorAssessment> result = EngineeringCalculationResult
+        .<Api12JSeparatorAssessment>builder("api-12j-separator-performance-screening", getMethod(),
+            getMethodVersion())
+        .context(effectiveContext).readiness(readiness);
+    if (input == null || !readiness.isReady()) {
+      return result.status(EngineeringCalculationResult.Status.BLOCKED)
+          .message("API 12J screening is blocked until the readiness findings are resolved").build();
+    }
+
+    DropletSettlingCalculator.ApiComplianceResult legacy = DropletSettlingCalculator.checkApi12JCompliance(
+        input.getGravityCutDiameterM(), input.getKFactorMPerS(), input.hasMistEliminator(),
+        input.getLiquidResidenceTimeS(), input.getOrientation().name().toLowerCase(), input.isThreePhase());
+    Api12JSeparatorAssessment assessment = new Api12JSeparatorAssessment(input.getEdition().getDisplayName(), legacy);
+    result.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED).value(assessment)
+        .input("standard", input.getEdition().getDisplayName()).input("equipmentType", input.getEquipmentType())
+        .input("gravityCutDiameterM", Double.valueOf(input.getGravityCutDiameterM()))
+        .input("kFactorMPerS", Double.valueOf(input.getKFactorMPerS()))
+        .input("liquidResidenceTimeS", Double.valueOf(input.getLiquidResidenceTimeS()))
+        .warning("API 12J screening does not certify separator design or performance");
+    if (!assessment.areAllScreeningCriteriaPassing()) {
+      result.warning("One or more implemented API 12J screening criteria do not pass")
+          .message("API 12J screening completed with findings requiring design revision and engineering review");
+    } else {
+      result.message("API 12J screening criteria pass; independent design review remains required");
+    }
+    return result.build();
+  }
+
+  private static boolean positive(double value) {
+    return Double.isFinite(value) && value > 0.0;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/calculation/Api12JSeparatorDesignKernel.java
+++ b/src/main/java/neqsim/process/engineering/calculation/Api12JSeparatorDesignKernel.java
@@ -68,8 +68,7 @@ public final class Api12JSeparatorDesignKernel
       }
       this.edition = edition;
       this.equipmentType = equipmentType.trim();
-      this.gravityCutDiameterM = diameterUnit == DiameterUnit.METRE ? gravityCutDiameter
-          : gravityCutDiameter * 1.0e-6;
+      this.gravityCutDiameterM = diameterUnit == DiameterUnit.METRE ? gravityCutDiameter : gravityCutDiameter * 1.0e-6;
       this.kFactorMPerS = kFactorMPerS;
       this.mistEliminatorPresent = mistEliminatorPresent;
       this.liquidResidenceTimeS = liquidResidenceTimeS;
@@ -199,8 +198,7 @@ public final class Api12JSeparatorDesignKernel
         : context;
     CalculationReadiness readiness = assess(input, effectiveContext);
     EngineeringCalculationResult.Builder<Api12JSeparatorAssessment> result = EngineeringCalculationResult
-        .<Api12JSeparatorAssessment>builder("api-12j-separator-performance-screening", getMethod(),
-            getMethodVersion())
+        .<Api12JSeparatorAssessment>builder("api-12j-separator-performance-screening", getMethod(), getMethodVersion())
         .context(effectiveContext).readiness(readiness);
     if (input == null || !readiness.isReady()) {
       return result.status(EngineeringCalculationResult.Status.BLOCKED)

--- a/src/main/java/neqsim/process/engineering/calculation/Api617CompressorAssessment.java
+++ b/src/main/java/neqsim/process/engineering/calculation/Api617CompressorAssessment.java
@@ -1,0 +1,196 @@
+package neqsim.process.engineering.calculation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.mechanicaldesign.compressor.CompressorCasingDesignCalculator;
+
+/** Immutable engineering-workflow snapshot of an API 617 compressor-casing screening calculation. */
+public final class Api617CompressorAssessment implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String standardEdition;
+  private final String materialGrade;
+  private final double requiredWallThicknessMm;
+  private final double minimumWallThicknessMm;
+  private final double selectedWallThicknessMm;
+  private final double mawpMPa;
+  private final double stressRatio;
+  private final double hydroTestPressureMPa;
+  private final boolean hydroTestPasses;
+  private final int flangeClass;
+  private final double flangeRatingBarg;
+  private final boolean flangeRatingPasses;
+  private final double suctionNozzleAllowableForceN;
+  private final double dischargeNozzleAllowableForceN;
+  private final double differentialExpansionMm;
+  private final boolean thermalGrowthPasses;
+  private final boolean splitLineBoltsPass;
+  private final String naceStatus;
+  private final List<String> appliedStandards;
+  private final List<String> designIssues;
+
+  private Api617CompressorAssessment(String standardEdition, CompressorCasingDesignCalculator calculator) {
+    this.standardEdition = standardEdition;
+    materialGrade = calculator.getMaterialGrade();
+    requiredWallThicknessMm = calculator.getRequiredWallThicknessMm();
+    minimumWallThicknessMm = calculator.getMinimumWallThicknessMm();
+    selectedWallThicknessMm = calculator.getSelectedWallThicknessMm();
+    mawpMPa = calculator.getMawpMPa();
+    stressRatio = calculator.getStressRatio();
+    hydroTestPressureMPa = calculator.getHydroTestPressureMPa();
+    hydroTestPasses = calculator.isHydroTestAcceptable();
+    flangeClass = calculator.getFlangeClass();
+    flangeRatingBarg = calculator.getFlangeRatingBarg();
+    flangeRatingPasses = calculator.isFlangeRatingAdequate();
+    suctionNozzleAllowableForceN = calculator.getSuctionNozzleAllowableForceN();
+    dischargeNozzleAllowableForceN = calculator.getDischargeNozzleAllowableForceN();
+    differentialExpansionMm = calculator.getDifferentialExpansionMm();
+    thermalGrowthPasses = calculator.isThermalGrowthAcceptable();
+    splitLineBoltsPass = calculator.isSplitLineBoltsAdequate();
+    naceStatus = calculator.getNaceComplianceStatus();
+    appliedStandards = Collections.unmodifiableList(new ArrayList<String>(calculator.getAppliedStandards()));
+    designIssues = Collections.unmodifiableList(new ArrayList<String>(calculator.getDesignIssues()));
+  }
+
+  static Api617CompressorAssessment from(String edition, CompressorCasingDesignCalculator calculator) {
+    return new Api617CompressorAssessment(edition, calculator);
+  }
+
+  /** @return explicit API 617 edition */
+  public String getStandardEdition() {
+    return standardEdition;
+  }
+
+  /** @return selected material grade */
+  public String getMaterialGrade() {
+    return materialGrade;
+  }
+
+  /** @return pressure-only required wall thickness in millimetres */
+  public double getRequiredWallThicknessMm() {
+    return requiredWallThicknessMm;
+  }
+
+  /** @return minimum wall thickness including corrosion allowance in millimetres */
+  public double getMinimumWallThicknessMm() {
+    return minimumWallThicknessMm;
+  }
+
+  /** @return selected nominal wall thickness in millimetres */
+  public double getSelectedWallThicknessMm() {
+    return selectedWallThicknessMm;
+  }
+
+  /** @return calculated maximum allowable working pressure in MPa */
+  public double getMawpMPa() {
+    return mawpMPa;
+  }
+
+  /** @return hoop stress divided by allowable stress */
+  public double getStressRatio() {
+    return stressRatio;
+  }
+
+  /** @return hydrostatic test pressure in MPa */
+  public double getHydroTestPressureMPa() {
+    return hydroTestPressureMPa;
+  }
+
+  /** @return whether the implemented hydrostatic stress screen passes */
+  public boolean isHydroTestPassing() {
+    return hydroTestPasses;
+  }
+
+  /** @return selected flange pressure class */
+  public int getFlangeClass() {
+    return flangeClass;
+  }
+
+  /** @return selected flange pressure rating in barg */
+  public double getFlangeRatingBarg() {
+    return flangeRatingBarg;
+  }
+
+  /** @return whether the selected flange rating screen passes */
+  public boolean isFlangeRatingPassing() {
+    return flangeRatingPasses;
+  }
+
+  /** @return API 617 suction-nozzle allowable force in newtons */
+  public double getSuctionNozzleAllowableForceN() {
+    return suctionNozzleAllowableForceN;
+  }
+
+  /** @return API 617 discharge-nozzle allowable force in newtons */
+  public double getDischargeNozzleAllowableForceN() {
+    return dischargeNozzleAllowableForceN;
+  }
+
+  /** @return casing-to-rotor differential expansion in millimetres */
+  public double getDifferentialExpansionMm() {
+    return differentialExpansionMm;
+  }
+
+  /** @return whether the implemented differential-expansion screen passes */
+  public boolean isThermalGrowthPassing() {
+    return thermalGrowthPasses;
+  }
+
+  /** @return whether the implemented split-line-bolt screen passes */
+  public boolean areSplitLineBoltsPassing() {
+    return splitLineBoltsPass;
+  }
+
+  /** @return NACE material-screen status */
+  public String getNaceStatus() {
+    return naceStatus;
+  }
+
+  /** @return immutable standards claimed by the legacy calculation */
+  public List<String> getAppliedStandards() {
+    return appliedStandards;
+  }
+
+  /** @return immutable calculation findings */
+  public List<String> getDesignIssues() {
+    return designIssues;
+  }
+
+  /** @return whether every implemented mechanical screen passes */
+  public boolean areAllScreeningChecksPassing() {
+    return hydroTestPasses && flangeRatingPasses && thermalGrowthPasses && splitLineBoltsPass
+        && designIssues.isEmpty();
+  }
+
+  /** @return serializable assessment representation */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("standardEdition", standardEdition);
+    result.put("materialGrade", materialGrade);
+    result.put("requiredWallThicknessMm", Double.valueOf(requiredWallThicknessMm));
+    result.put("minimumWallThicknessMm", Double.valueOf(minimumWallThicknessMm));
+    result.put("selectedWallThicknessMm", Double.valueOf(selectedWallThicknessMm));
+    result.put("mawpMPa", Double.valueOf(mawpMPa));
+    result.put("stressRatio", Double.valueOf(stressRatio));
+    result.put("hydroTestPressureMPa", Double.valueOf(hydroTestPressureMPa));
+    result.put("hydroTestPasses", Boolean.valueOf(hydroTestPasses));
+    result.put("flangeClass", Integer.valueOf(flangeClass));
+    result.put("flangeRatingBarg", Double.valueOf(flangeRatingBarg));
+    result.put("flangeRatingPasses", Boolean.valueOf(flangeRatingPasses));
+    result.put("suctionNozzleAllowableForceN", Double.valueOf(suctionNozzleAllowableForceN));
+    result.put("dischargeNozzleAllowableForceN", Double.valueOf(dischargeNozzleAllowableForceN));
+    result.put("differentialExpansionMm", Double.valueOf(differentialExpansionMm));
+    result.put("thermalGrowthPasses", Boolean.valueOf(thermalGrowthPasses));
+    result.put("splitLineBoltsPass", Boolean.valueOf(splitLineBoltsPass));
+    result.put("naceStatus", naceStatus);
+    result.put("appliedStandards", new ArrayList<String>(appliedStandards));
+    result.put("designIssues", new ArrayList<String>(designIssues));
+    result.put("allScreeningChecksPass", Boolean.valueOf(areAllScreeningChecksPassing()));
+    result.put("engineeringApprovalRequired", Boolean.TRUE);
+    return result;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/calculation/Api617CompressorAssessment.java
+++ b/src/main/java/neqsim/process/engineering/calculation/Api617CompressorAssessment.java
@@ -162,8 +162,7 @@ public final class Api617CompressorAssessment implements Serializable {
 
   /** @return whether every implemented mechanical screen passes */
   public boolean areAllScreeningChecksPassing() {
-    return hydroTestPasses && flangeRatingPasses && thermalGrowthPasses && splitLineBoltsPass
-        && designIssues.isEmpty();
+    return hydroTestPasses && flangeRatingPasses && thermalGrowthPasses && splitLineBoltsPass && designIssues.isEmpty();
   }
 
   /** @return serializable assessment representation */

--- a/src/main/java/neqsim/process/engineering/calculation/Api617CompressorDesignKernel.java
+++ b/src/main/java/neqsim/process/engineering/calculation/Api617CompressorDesignKernel.java
@@ -1,0 +1,258 @@
+package neqsim.process.engineering.calculation;
+
+import java.io.Serializable;
+import neqsim.process.mechanicaldesign.compressor.CompressorCasingDesignCalculator;
+import neqsim.process.mechanicaldesign.compressor.CompressorMechanicalDesign;
+import neqsim.process.mechanicaldesign.designstandards.StandardApplicability;
+import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
+import neqsim.process.mechanicaldesign.designstandards.StandardSupportLevel;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+
+/** Pure engineering-workflow adapter for the legacy API 617 compressor-casing screening calculator. */
+public final class Api617CompressorDesignKernel
+    implements EquipmentDesignKernel<Api617CompressorDesignKernel.Input, Api617CompressorAssessment> {
+  private static final long serialVersionUID = 1000L;
+  private static final String IMPLEMENTED_EDITION = "8th Ed";
+
+  /** Immutable, defensively copied kernel input. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final StandardEdition edition;
+    private final String equipmentType;
+    private final double designPressureMPa;
+    private final double designTemperatureC;
+    private final double maxOperatingPressureMPa;
+    private final double maxOperatingTemperatureC;
+    private final double minOperatingTemperatureC;
+    private final double casingInnerDiameterMm;
+    private final double casingLengthMm;
+    private final String materialGrade;
+    private final double corrosionAllowanceMm;
+    private final double jointEfficiency;
+    private final CompressorMechanicalDesign.CasingType casingType;
+    private final boolean sourService;
+    private final double h2sPartialPressureKPa;
+    private final double suctionNozzleSizeMm;
+    private final double dischargeNozzleSizeMm;
+
+    /**
+     * Create an API 617 kernel input from a legacy calculator configuration.
+     *
+     * @param edition explicit API 617 edition
+     * @param equipmentType simple compressor equipment class name
+     * @param configuration configured, unexecuted legacy calculator
+     */
+    public Input(StandardEdition edition, String equipmentType, CompressorCasingDesignCalculator configuration) {
+      if (edition == null || edition.getStandardType() != StandardType.API_617) {
+        throw new IllegalArgumentException("edition must identify API-617");
+      }
+      if (equipmentType == null || equipmentType.trim().isEmpty()) {
+        throw new IllegalArgumentException("equipmentType cannot be null or blank");
+      }
+      if (configuration == null) {
+        throw new IllegalArgumentException("configuration cannot be null");
+      }
+      this.edition = edition;
+      this.equipmentType = equipmentType.trim();
+      designPressureMPa = configuration.getDesignPressureMPa();
+      designTemperatureC = configuration.getDesignTemperatureC();
+      maxOperatingPressureMPa = configuration.getMaxOperatingPressureMPa();
+      maxOperatingTemperatureC = configuration.getMaxOperatingTemperatureC();
+      minOperatingTemperatureC = configuration.getMinOperatingTemperatureC();
+      casingInnerDiameterMm = configuration.getCasingInnerDiameterMm();
+      casingLengthMm = configuration.getCasingLengthMm();
+      materialGrade = configuration.getMaterialGrade();
+      corrosionAllowanceMm = configuration.getCorrosionAllowanceMm();
+      jointEfficiency = configuration.getJointEfficiency();
+      casingType = configuration.getCasingType();
+      sourService = configuration.isSourService();
+      h2sPartialPressureKPa = configuration.getH2sPartialPressureKPa();
+      suctionNozzleSizeMm = configuration.getSuctionNozzleSizeMm();
+      dischargeNozzleSizeMm = configuration.getDischargeNozzleSizeMm();
+    }
+
+    /** @return explicit API 617 edition */
+    public StandardEdition getEdition() {
+      return edition;
+    }
+
+    /** @return simple compressor equipment class name */
+    public String getEquipmentType() {
+      return equipmentType;
+    }
+
+    /** @return independent copy of the legacy calculator configuration */
+    public CompressorCasingDesignCalculator getConfiguration() {
+      CompressorCasingDesignCalculator configuration = new CompressorCasingDesignCalculator();
+      configuration.setDesignPressureMPa(designPressureMPa);
+      configuration.setDesignTemperatureC(designTemperatureC);
+      configuration.setMaxOperatingPressureMPa(maxOperatingPressureMPa);
+      configuration.setMaxOperatingTemperatureC(maxOperatingTemperatureC);
+      configuration.setMinOperatingTemperatureC(minOperatingTemperatureC);
+      configuration.setCasingInnerDiameterMm(casingInnerDiameterMm);
+      configuration.setCasingLengthMm(casingLengthMm);
+      configuration.setMaterialGrade(materialGrade);
+      configuration.setCorrosionAllowanceMm(corrosionAllowanceMm);
+      configuration.setJointEfficiency(jointEfficiency);
+      configuration.setCasingType(casingType);
+      configuration.setSourService(sourService);
+      configuration.setH2sPartialPressureKPa(h2sPartialPressureKPa);
+      configuration.setSuctionNozzleSizeMm(suctionNozzleSizeMm);
+      configuration.setDischargeNozzleSizeMm(dischargeNozzleSizeMm);
+      return configuration;
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public StandardType standard() {
+    return StandardType.API_617;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public StandardSupportLevel maturity() {
+    return StandardSupportLevel.SCREENING;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean supports(StandardEdition edition) {
+    return edition != null && edition.getStandardType() == standard()
+        && IMPLEMENTED_EDITION.equalsIgnoreCase(edition.getEdition());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public StandardApplicability applicability(Input input) {
+    return StandardApplicability.assess(standard(), input == null ? null : input.getEquipmentType());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getMethod() {
+    return "api-617-compressor-casing-screening";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getMethodVersion() {
+    return "1.0.0";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public CalculationReadiness assess(Input input, EngineeringCalculationContext context) {
+    CalculationReadiness.Builder readiness = CalculationReadiness.builder();
+    if (input == null) {
+      return readiness.addBlocker("API617_INPUT_MISSING", "API 617 compressor-casing input is required",
+          "Provide an edition, compressor equipment type, and calculator configuration").build();
+    }
+    StandardApplicability decision = applicability(input);
+    if (!decision.isApplicable()) {
+      readiness.addBlocker("API617_NOT_APPLICABLE", decision.getReason(),
+          "Use API 617 only for Compressor equipment");
+    }
+    if (!supports(input.getEdition())) {
+      readiness.addBlocker("API617_EDITION_NOT_IMPLEMENTED",
+          "The API 617 kernel implements " + IMPLEMENTED_EDITION + ", not " + input.getEdition().getEdition(),
+          "Select the implemented edition or add separately validated edition logic");
+    }
+    assessConfiguration(input.getConfiguration(), readiness);
+    readiness.addWarning("API617_SCREENING_ONLY",
+        "The compressor-casing calculator provides preliminary mechanical screening, not package conformity",
+        "Verify the purchased edition, rotor dynamics, vendor design, materials, auxiliaries, and project requirements");
+    return readiness.build();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public EngineeringCalculationResult<Api617CompressorAssessment> calculate(Input input,
+      EngineeringCalculationContext context) {
+    EngineeringCalculationContext effectiveContext = context == null ? EngineeringCalculationContext.builder().build()
+        : context;
+    CalculationReadiness readiness = assess(input, effectiveContext);
+    EngineeringCalculationResult.Builder<Api617CompressorAssessment> result = EngineeringCalculationResult
+        .<Api617CompressorAssessment>builder("api-617-compressor-casing-screening", getMethod(), getMethodVersion())
+        .context(effectiveContext).readiness(readiness);
+    if (input == null || !readiness.isReady()) {
+      return result.status(EngineeringCalculationResult.Status.BLOCKED)
+          .message("API 617 screening is blocked until the readiness findings are resolved").build();
+    }
+
+    CompressorCasingDesignCalculator calculator = input.getConfiguration();
+    try {
+      calculator.calculate();
+      Api617CompressorAssessment assessment = Api617CompressorAssessment.from(input.getEdition().getDisplayName(),
+          calculator);
+      result.status(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED).value(assessment)
+          .input("standard", input.getEdition().getDisplayName()).input("equipmentType", input.getEquipmentType())
+          .input("designPressureMPa", Double.valueOf(calculator.getDesignPressureMPa()))
+          .input("designTemperatureC", Double.valueOf(calculator.getDesignTemperatureC()))
+          .warning("API 617 screening does not certify compressor package or casing compliance");
+      if (!assessment.areAllScreeningChecksPassing()) {
+        result.warning("One or more implemented compressor-casing screening checks do not pass")
+            .message("API 617 screening completed with findings requiring design revision and vendor review");
+      } else {
+        result.message("API 617 compressor-casing screening completed; vendor review remains required");
+      }
+      return result.build();
+    } catch (RuntimeException exception) {
+      return result.status(EngineeringCalculationResult.Status.FAILED)
+          .message("API 617 screening failed: " + exception.getMessage()).build();
+    }
+  }
+
+  private static void assessConfiguration(CompressorCasingDesignCalculator calculator,
+      CalculationReadiness.Builder readiness) {
+    if (!positive(calculator.getDesignPressureMPa())) {
+      readiness.addBlocker("API617_DESIGN_PRESSURE_INVALID", "Design pressure must be finite and positive",
+          "Supply the compressor-casing design pressure in MPa");
+    }
+    if (!positive(calculator.getMaxOperatingPressureMPa())
+        || calculator.getMaxOperatingPressureMPa() > calculator.getDesignPressureMPa()) {
+      readiness.addBlocker("API617_OPERATING_PRESSURE_INVALID",
+          "Maximum operating pressure must be positive and no greater than design pressure",
+          "Correct the governing pressure basis");
+    }
+    if (!Double.isFinite(calculator.getDesignTemperatureC())
+        || !Double.isFinite(calculator.getMaxOperatingTemperatureC())
+        || !Double.isFinite(calculator.getMinOperatingTemperatureC())
+        || calculator.getMinOperatingTemperatureC() > calculator.getMaxOperatingTemperatureC()
+        || calculator.getMaxOperatingTemperatureC() > calculator.getDesignTemperatureC()) {
+      readiness.addBlocker("API617_TEMPERATURE_BASIS_INVALID",
+          "Operating temperature range must be finite, ordered, and within design temperature",
+          "Correct the compressor-casing temperature basis");
+    }
+    if (!positive(calculator.getCasingInnerDiameterMm()) || !positive(calculator.getCasingLengthMm())) {
+      readiness.addBlocker("API617_CASING_GEOMETRY_INVALID", "Casing diameter and length must be positive",
+          "Supply preliminary casing geometry in millimetres");
+    }
+    if (calculator.getMaterialGrade() == null || calculator.getMaterialGrade().trim().isEmpty()) {
+      readiness.addBlocker("API617_MATERIAL_MISSING", "A traceable material grade is required",
+          "Select a supported casing material grade");
+    }
+    if (!Double.isFinite(calculator.getCorrosionAllowanceMm()) || calculator.getCorrosionAllowanceMm() < 0.0) {
+      readiness.addBlocker("API617_CORROSION_ALLOWANCE_INVALID",
+          "Corrosion allowance must be finite and non-negative", "Supply the project corrosion allowance");
+    }
+    if (!Double.isFinite(calculator.getJointEfficiency()) || calculator.getJointEfficiency() <= 0.0
+        || calculator.getJointEfficiency() > 1.0) {
+      readiness.addBlocker("API617_JOINT_EFFICIENCY_INVALID", "Joint efficiency must be above zero and at most one",
+          "Supply the verified fabrication joint efficiency");
+    }
+    if (!positive(calculator.getSuctionNozzleSizeMm()) || !positive(calculator.getDischargeNozzleSizeMm())) {
+      readiness.addBlocker("API617_NOZZLE_SIZE_INVALID", "Suction and discharge nozzle sizes must be positive",
+          "Supply preliminary nozzle sizes in millimetres");
+    }
+    if (calculator.isSourService()
+        && (!Double.isFinite(calculator.getH2sPartialPressureKPa()) || calculator.getH2sPartialPressureKPa() < 0.0)) {
+      readiness.addBlocker("API617_H2S_BASIS_INVALID", "Sour-service H2S partial pressure must be non-negative",
+          "Supply the governing H2S partial pressure in kPa");
+    }
+  }
+
+  private static boolean positive(double value) {
+    return Double.isFinite(value) && value > 0.0;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/calculation/Api617CompressorDesignKernel.java
+++ b/src/main/java/neqsim/process/engineering/calculation/Api617CompressorDesignKernel.java
@@ -150,8 +150,7 @@ public final class Api617CompressorDesignKernel
     }
     StandardApplicability decision = applicability(input);
     if (!decision.isApplicable()) {
-      readiness.addBlocker("API617_NOT_APPLICABLE", decision.getReason(),
-          "Use API 617 only for Compressor equipment");
+      readiness.addBlocker("API617_NOT_APPLICABLE", decision.getReason(), "Use API 617 only for Compressor equipment");
     }
     if (!supports(input.getEdition())) {
       readiness.addBlocker("API617_EDITION_NOT_IMPLEMENTED",
@@ -233,8 +232,8 @@ public final class Api617CompressorDesignKernel
           "Select a supported casing material grade");
     }
     if (!Double.isFinite(calculator.getCorrosionAllowanceMm()) || calculator.getCorrosionAllowanceMm() < 0.0) {
-      readiness.addBlocker("API617_CORROSION_ALLOWANCE_INVALID",
-          "Corrosion allowance must be finite and non-negative", "Supply the project corrosion allowance");
+      readiness.addBlocker("API617_CORROSION_ALLOWANCE_INVALID", "Corrosion allowance must be finite and non-negative",
+          "Supply the project corrosion allowance");
     }
     if (!Double.isFinite(calculator.getJointEfficiency()) || calculator.getJointEfficiency() <= 0.0
         || calculator.getJointEfficiency() > 1.0) {

--- a/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernelRegistry.java
+++ b/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernelRegistry.java
@@ -83,9 +83,11 @@ public final class EquipmentDesignKernelRegistry {
   static {
     Map<StandardType, EquipmentDesignKernel<?, ?>> kernels = new EnumMap<StandardType, EquipmentDesignKernel<?, ?>>(
         StandardType.class);
+    register(kernels, new Api617CompressorDesignKernel());
     register(kernels, new PumpApi610DesignKernel());
     register(kernels, new Api521ReliefDesignKernel());
     register(kernels, new Api526OrificeSelectionKernel());
+    register(kernels, new Api12JSeparatorDesignKernel());
     KERNELS = Collections.unmodifiableMap(kernels);
   }
 

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
@@ -37,9 +37,8 @@ public final class StandardSupportAudit {
     switch (standardType) {
     case API_617:
       EquipmentDesignKernelRegistry.Lookup compressorImplementation = StandardRegistry.getDesignKernel(standardType);
-      return new StandardSupport(standardType, StandardSupportLevel.SCREENING,
-          compressorImplementation.isImplemented(), registryImplementation,
-          compressorImplementation.getImplementationClassName(),
+      return new StandardSupport(standardType, StandardSupportLevel.SCREENING, compressorImplementation.isImplemented(),
+          registryImplementation, compressorImplementation.getImplementationClassName(),
           "Compressor-casing pressure containment, flange, nozzle-load allowance, and thermal-growth screening only; "
               + "rotor dynamics, package integration, and vendor conformity are not evaluated.");
     case API_610:
@@ -72,9 +71,8 @@ public final class StandardSupportAudit {
               + "certification are not evaluated.");
     case API_12J:
       EquipmentDesignKernelRegistry.Lookup separatorImplementation = StandardRegistry.getDesignKernel(standardType);
-      return new StandardSupport(standardType, StandardSupportLevel.SCREENING,
-          separatorImplementation.isImplemented(), registryImplementation,
-          separatorImplementation.getImplementationClassName(),
+      return new StandardSupport(standardType, StandardSupportLevel.SCREENING, separatorImplementation.isImplemented(),
+          registryImplementation, separatorImplementation.getImplementationClassName(),
           "Gravity cut-diameter, K-factor, and liquid residence-time screening only; service applicability, vessel "
               + "construction, internals, and performance guarantees require independent review.");
     default:

--- a/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAudit.java
@@ -35,6 +35,13 @@ public final class StandardSupportAudit {
     String registryImplementation = StandardRegistry.getMappedImplementationClass(standardType).getSimpleName();
 
     switch (standardType) {
+    case API_617:
+      EquipmentDesignKernelRegistry.Lookup compressorImplementation = StandardRegistry.getDesignKernel(standardType);
+      return new StandardSupport(standardType, StandardSupportLevel.SCREENING,
+          compressorImplementation.isImplemented(), registryImplementation,
+          compressorImplementation.getImplementationClassName(),
+          "Compressor-casing pressure containment, flange, nozzle-load allowance, and thermal-growth screening only; "
+              + "rotor dynamics, package integration, and vendor conformity are not evaluated.");
     case API_610:
       EquipmentDesignKernelRegistry.Lookup pumpImplementation = StandardRegistry.getDesignKernel(standardType);
       return new StandardSupport(standardType, StandardSupportLevel.SCREENING, pumpImplementation.isImplemented(),
@@ -63,6 +70,13 @@ public final class StandardSupportAudit {
           registryImplementation, orificeImplementation.getImplementationClassName(),
           "Standard-orifice area selection only; valve pressure class, dimensions, materials, installation, and vendor "
               + "certification are not evaluated.");
+    case API_12J:
+      EquipmentDesignKernelRegistry.Lookup separatorImplementation = StandardRegistry.getDesignKernel(standardType);
+      return new StandardSupport(standardType, StandardSupportLevel.SCREENING,
+          separatorImplementation.isImplemented(), registryImplementation,
+          separatorImplementation.getImplementationClassName(),
+          "Gravity cut-diameter, K-factor, and liquid residence-time screening only; service applicability, vessel "
+              + "construction, internals, and performance guarantees require independent review.");
     default:
       return getCategorySupport(standardType, registryImplementation);
     }

--- a/src/test/java/neqsim/process/engineering/calculation/Api12JSeparatorDesignKernelTest.java
+++ b/src/test/java/neqsim/process/engineering/calculation/Api12JSeparatorDesignKernelTest.java
@@ -1,0 +1,75 @@
+package neqsim.process.engineering.calculation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.mechanicaldesign.designstandards.StandardApplicability;
+import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+
+/** Tests unit-aware, fail-closed API 12J separator screening. */
+class Api12JSeparatorDesignKernelTest {
+  @Test
+  void passingSiAndMicrometreInputsAreEquivalent() {
+    Api12JSeparatorDesignKernel kernel = new Api12JSeparatorDesignKernel();
+    StandardEdition edition = StandardEdition.defaultEdition(StandardType.API_12J);
+    Api12JSeparatorDesignKernel.Input micrometre = new Api12JSeparatorDesignKernel.Input(edition, "Separator", 80.0,
+        Api12JSeparatorDesignKernel.DiameterUnit.MICROMETRE, 0.08, false, 240.0,
+        Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false);
+    Api12JSeparatorDesignKernel.Input si = new Api12JSeparatorDesignKernel.Input(edition, "Separator", 80.0e-6,
+        Api12JSeparatorDesignKernel.DiameterUnit.METRE, 0.08, false, 240.0,
+        Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false);
+
+    Api12JSeparatorAssessment first = kernel.calculate(micrometre, null).getValue();
+    Api12JSeparatorAssessment second = kernel.calculate(si, null).getValue();
+
+    assertTrue(first.areAllScreeningCriteriaPassing());
+    assertEquals(first.getGravityCutDiameterMicrometre(), second.getGravityCutDiameterMicrometre(), 1.0e-12);
+    assertEquals(first.getKFactorUtilization(), second.getKFactorUtilization(), 1.0e-12);
+    assertTrue(first.toMap().containsKey("engineeringApprovalRequired"));
+  }
+
+  @Test
+  void nonPassingCriteriaRemainCalculatedFindings() {
+    Api12JSeparatorDesignKernel.Input input = new Api12JSeparatorDesignKernel.Input(
+        StandardEdition.defaultEdition(StandardType.API_12J), "ThreePhaseSeparator", 150.0,
+        Api12JSeparatorDesignKernel.DiameterUnit.MICROMETRE, 0.30, false, 200.0,
+        Api12JSeparatorDesignKernel.Orientation.VERTICAL, true);
+
+    EngineeringCalculationResult<Api12JSeparatorAssessment> result = new Api12JSeparatorDesignKernel().calculate(input,
+        null);
+
+    assertEquals(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED, result.getStatus());
+    assertFalse(result.getValue().areAllScreeningCriteriaPassing());
+    assertFalse(result.getValue().isGasLiquidSectionPassing());
+    assertFalse(result.getValue().isLiquidSectionPassing());
+  }
+
+  @Test
+  void blocksUnsupportedEditionEquipmentAndInvalidInputs() {
+    Api12JSeparatorDesignKernel kernel = new Api12JSeparatorDesignKernel();
+    Api12JSeparatorDesignKernel.Input oldEdition = new Api12JSeparatorDesignKernel.Input(
+        StandardEdition.of(StandardType.API_12J, "7th Ed"), "Separator", 80.0,
+        Api12JSeparatorDesignKernel.DiameterUnit.MICROMETRE, 0.08, false, 240.0,
+        Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false);
+    Api12JSeparatorDesignKernel.Input wrongEquipment = new Api12JSeparatorDesignKernel.Input(
+        StandardEdition.defaultEdition(StandardType.API_12J), "Pump", 80.0,
+        Api12JSeparatorDesignKernel.DiameterUnit.MICROMETRE, 0.08, false, 240.0,
+        Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false);
+    Api12JSeparatorDesignKernel.Input invalid = new Api12JSeparatorDesignKernel.Input(
+        StandardEdition.defaultEdition(StandardType.API_12J), "Separator", Double.NaN,
+        Api12JSeparatorDesignKernel.DiameterUnit.METRE, -1.0, false, 0.0,
+        Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false);
+
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED, kernel.calculate(oldEdition, null).getStatus());
+    assertEquals(StandardApplicability.Status.NOT_APPLICABLE, kernel.applicability(wrongEquipment).getStatus());
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED, kernel.calculate(wrongEquipment, null).getStatus());
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED, kernel.calculate(invalid, null).getStatus());
+    assertThrows(IllegalArgumentException.class,
+        () -> new Api12JSeparatorDesignKernel.Input(StandardEdition.defaultEdition(StandardType.API_610), "Separator",
+            80.0, Api12JSeparatorDesignKernel.DiameterUnit.MICROMETRE, 0.08, false, 240.0,
+            Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false));
+  }
+}

--- a/src/test/java/neqsim/process/engineering/calculation/Api617CompressorDesignKernelTest.java
+++ b/src/test/java/neqsim/process/engineering/calculation/Api617CompressorDesignKernelTest.java
@@ -51,8 +51,8 @@ class Api617CompressorDesignKernelTest {
     assertEquals(EngineeringCalculationResult.Status.BLOCKED, kernel.calculate(invalid, null).getStatus());
     assertFalse(kernel.assess(invalid, null).isReady());
     assertThrows(IllegalArgumentException.class,
-        () -> new Api617CompressorDesignKernel.Input(StandardEdition.defaultEdition(StandardType.API_610),
-            "Compressor", passingConfiguration()));
+        () -> new Api617CompressorDesignKernel.Input(StandardEdition.defaultEdition(StandardType.API_610), "Compressor",
+            passingConfiguration()));
   }
 
   private static CompressorCasingDesignCalculator passingConfiguration() {

--- a/src/test/java/neqsim/process/engineering/calculation/Api617CompressorDesignKernelTest.java
+++ b/src/test/java/neqsim/process/engineering/calculation/Api617CompressorDesignKernelTest.java
@@ -1,0 +1,74 @@
+package neqsim.process.engineering.calculation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.mechanicaldesign.compressor.CompressorCasingDesignCalculator;
+import neqsim.process.mechanicaldesign.designstandards.StandardApplicability;
+import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+
+/** Tests the fail-closed common engineering adapter for API 617 casing screening. */
+class Api617CompressorDesignKernelTest {
+  @Test
+  void calculatesFromDefensiveConfigurationCopy() {
+    CompressorCasingDesignCalculator configuration = passingConfiguration();
+    Api617CompressorDesignKernel.Input input = new Api617CompressorDesignKernel.Input(
+        StandardEdition.defaultEdition(StandardType.API_617), "Compressor", configuration);
+    configuration.setDesignPressureMPa(50.0);
+
+    EngineeringCalculationResult<Api617CompressorAssessment> result = new Api617CompressorDesignKernel()
+        .calculate(input, EngineeringCalculationContext.builder().designCaseId("rated").build());
+
+    assertEquals(EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED, result.getStatus());
+    assertTrue(result.getValue().getRequiredWallThicknessMm() > 0.0);
+    assertTrue(result.getValue().getSelectedWallThicknessMm() >= result.getValue().getMinimumWallThicknessMm());
+    assertEquals("SA-516-70", result.getValue().getMaterialGrade());
+    assertTrue(result.getValue().getAppliedStandards().get(0).contains("API 617 8th Ed"));
+    assertThrows(UnsupportedOperationException.class, () -> result.getValue().getAppliedStandards().clear());
+    assertEquals(5.0, input.getConfiguration().getDesignPressureMPa(), 1.0e-12);
+    input.getConfiguration().setDesignPressureMPa(1.0);
+    assertEquals(5.0, input.getConfiguration().getDesignPressureMPa(), 1.0e-12);
+  }
+
+  @Test
+  void blocksUnsupportedEditionEquipmentAndInvalidPressureBasis() {
+    Api617CompressorDesignKernel kernel = new Api617CompressorDesignKernel();
+    Api617CompressorDesignKernel.Input oldEdition = new Api617CompressorDesignKernel.Input(
+        StandardEdition.of(StandardType.API_617, "7th Ed"), "Compressor", passingConfiguration());
+    Api617CompressorDesignKernel.Input wrongEquipment = new Api617CompressorDesignKernel.Input(
+        StandardEdition.defaultEdition(StandardType.API_617), "Pump", passingConfiguration());
+    CompressorCasingDesignCalculator invalidConfiguration = passingConfiguration();
+    invalidConfiguration.setMaxOperatingPressureMPa(6.0);
+    Api617CompressorDesignKernel.Input invalid = new Api617CompressorDesignKernel.Input(
+        StandardEdition.defaultEdition(StandardType.API_617), "Compressor", invalidConfiguration);
+
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED, kernel.calculate(oldEdition, null).getStatus());
+    assertEquals(StandardApplicability.Status.NOT_APPLICABLE, kernel.applicability(wrongEquipment).getStatus());
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED, kernel.calculate(wrongEquipment, null).getStatus());
+    assertEquals(EngineeringCalculationResult.Status.BLOCKED, kernel.calculate(invalid, null).getStatus());
+    assertFalse(kernel.assess(invalid, null).isReady());
+    assertThrows(IllegalArgumentException.class,
+        () -> new Api617CompressorDesignKernel.Input(StandardEdition.defaultEdition(StandardType.API_610),
+            "Compressor", passingConfiguration()));
+  }
+
+  private static CompressorCasingDesignCalculator passingConfiguration() {
+    CompressorCasingDesignCalculator calculator = new CompressorCasingDesignCalculator();
+    calculator.setDesignPressureMPa(5.0);
+    calculator.setMaxOperatingPressureMPa(4.0);
+    calculator.setDesignTemperatureC(150.0);
+    calculator.setMaxOperatingTemperatureC(100.0);
+    calculator.setMinOperatingTemperatureC(-20.0);
+    calculator.setCasingInnerDiameterMm(500.0);
+    calculator.setCasingLengthMm(1500.0);
+    calculator.setMaterialGrade("SA-516-70");
+    calculator.setCorrosionAllowanceMm(1.5);
+    calculator.setJointEfficiency(0.85);
+    calculator.setSuctionNozzleSizeMm(200.0);
+    calculator.setDischargeNozzleSizeMm(150.0);
+    return calculator;
+  }
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSupportAuditTest.java
@@ -51,6 +51,10 @@ class StandardSupportAuditTest {
         StandardSupportAudit.getSupport(StandardType.ASME_VIII_DIV1).getSupportLevel());
     assertEquals(StandardSupportLevel.SCREENING,
         StandardSupportAudit.getSupport(StandardType.API_12J).getSupportLevel());
+    assertEquals("Api617CompressorDesignKernel",
+        StandardSupportAudit.getSupport(StandardType.API_617).getCalculationImplementation());
+    assertEquals("Api12JSeparatorDesignKernel",
+        StandardSupportAudit.getSupport(StandardType.API_12J).getCalculationImplementation());
     assertTrue(StandardSupportAudit.getSupport(StandardType.API_12J).isRegistryConnected());
     assertFalse(StandardSupportAudit.getSupport(StandardType.API_660).isRegistryConnected());
   }


### PR DESCRIPTION
## Summary
- add a pure API 617 adapter over the existing compressor-casing calculator
- snapshot the required scalar configuration through public getters and reconstruct a fresh calculator at execution
- return immutable pressure-containment, hydrotest, flange, nozzle-load allowance, thermal-growth, NACE, and issue findings
- add a pure API 12J adapter for cut-diameter, K-factor, and liquid residence-time screening
- make cut-diameter input explicitly unit-aware and keep non-passing criteria as calculated findings
- register both kernels and connect the standards audit to their executable calculation paths

## Compatibility
No legacy compressor or separator calculator is modified. Existing callers remain unchanged. The adapters add defensive common-workflow inputs and immutable result snapshots.

## Validation
- Java 8 production compilation passed with focused dependency stubs
- behavior harness passed API 12J passing/failing cases, metre/micrometre equivalence, API 617 defensive copying, serialization, and invalid pressure-basis blocking
- JUnit regression coverage added for editions, applicability, readiness, unit equivalence, immutability, and non-passing findings
- generated standards matrix and design framework documentation updated
- full Maven and Spotless validation delegated to hosted CI because dependency downloads are unavailable locally

## Scope and maturity
Both kernels remain **SCREENING**. API 617 does not cover complete package design, rotor dynamics, auxiliaries, vendor guarantees, or conformity. API 12J covers only the implemented gas-section and residence-time criteria; vessel construction, internals, service applicability, and performance guarantees require independent engineering review.