### PR TITLE
Make engineering-case completeness and acceptance explicit

### DIFF
--- a/docs/engineering/design-cases-and-envelopes.md
+++ b/docs/engineering/design-cases-and-envelopes.md
@@ -91,8 +91,11 @@ not describe all design limits.
 ## Execute isolated cases
 
 `EngineeringCaseRunner` executes enabled cases on independent process copies. `EngineeringCaseRunOptions` controls
-parallelism and whether convergence is required. The report retains definition and result fingerprints so a case-set
-change can be distinguished from a result change.
+parallelism, whether convergence is required, and incomplete-result propagation. The default
+`RETURN_PARTIAL` policy retains all available evidence. `THROW_WITH_PARTIAL_RESULT` raises an
+`EngineeringCaseExecutionException`; its `getPartialReport()` preserves the same auditable case and
+metric findings. The report retains definition and result fingerprints so a case-set change can be
+distinguished from a result change.
 
 Case status remains explicit:
 
@@ -104,8 +107,9 @@ Case status remains explicit:
 | `FAILED` | Case configuration or simulation failed |
 | `SKIPPED` | Case was disabled or intentionally excluded |
 
-Partial and failed cases are not silently promoted into the governing envelope. They remain visible as readiness
-findings and must be resolved or accepted with a controlled scope decision.
+Successful metrics from a partial case may still identify a candidate governing value, but the
+envelope remains explicitly incomplete. Failed/non-converged cases and metrics with no governing
+value remain visible and must be resolved before a complete report can be required.
 
 ## Interpret the governing envelope
 
@@ -120,6 +124,12 @@ direction and retains:
 
 The envelope is a selection result, not an approval. Review it for physical discontinuities, phase changes,
 extrapolation, unexpected governing cases, and missing coverage.
+
+`isComplete()` means every configured metric has a governing value and no case is failed or partial.
+It does not mean limits pass. `isAccepted()` is deliberately stricter: the envelope must be complete,
+every governing metric must have at least one configured acceptance limit, and no evaluated case may
+violate a limit. Therefore an otherwise successful envelope with unconfigured limits remains
+review-required rather than reporting a false acceptance.
 
 ## Connect cases to the closed design loop
 
@@ -149,8 +159,9 @@ Use a case matrix to review equipment and metric coverage:
 | Are all required cases present? | Case IDs, types, required/enabled state, and controlled basis |
 | Did every required case converge? | Per-case process and unit run status |
 | Did every metric evaluate? | Per-case metric status and units |
+| Is the envelope complete? | No failed/partial case and no missing governing metric ID |
 | Is the governing direction correct? | Engineering rationale for maximum/minimum/absolute selection |
-| Are limits explicit? | Lower/upper limits, units, source, and margin |
+| Are limits explicit and accepted? | Lower/upper limits, units, source, margin, and `isAccepted()` state |
 | Are accidental cases modeled with adequate physics? | Dynamic/safety method, initial conditions, sequence, and credibility reference |
 | Is the envelope still current? | Definition fingerprint, result fingerprint, process revision, and design-loop iteration |
 

--- a/docs/engineering/guide.md
+++ b/docs/engineering/guide.md
@@ -61,6 +61,12 @@ approved hazard-review basis.
 
 Gate check: every design variable and calculated load can be traced to the case that governs it.
 
+Require `EngineeringCaseRunReport.isComplete()` before using the envelope as a closed design basis.
+Completeness and acceptance are separate: `isAccepted()` additionally requires configured limits and
+no violations. Workflows that must stop on incomplete coverage can select
+`EngineeringCaseFailurePolicy.THROW_WITH_PARTIAL_RESULT`; the thrown exception retains the partial
+report for diagnosis and audit.
+
 ## Gate 3: Run isolated cases and create governing envelopes
 
 Run cases on independent copies. This prevents one case or design update from contaminating another and preserves the

--- a/src/main/java/neqsim/process/engineering/designcase/DesignCaseEngine.java
+++ b/src/main/java/neqsim/process/engineering/designcase/DesignCaseEngine.java
@@ -30,7 +30,8 @@ public final class DesignCaseEngine {
     Collections.sort(orderedCases, new Comparator<EngineeringDesignCase>() {
       @Override
       public int compare(EngineeringDesignCase first, EngineeringDesignCase second) {
-        return Integer.compare(first.getPriority(), second.getPriority());
+        int priorityComparison = Integer.compare(first.getPriority(), second.getPriority());
+        return priorityComparison != 0 ? priorityComparison : first.getId().compareTo(second.getId());
       }
     });
     for (EngineeringDesignCase designCase : orderedCases) {
@@ -63,7 +64,7 @@ public final class DesignCaseEngine {
       }
       results.add(result);
     }
-    return new EngineeringDesignEnvelope(results, governing);
+    return new EngineeringDesignEnvelope(metrics, results, governing);
   }
 
   /** Executes the enhanced isolated case runner and returns fingerprints and convergence evidence. */

--- a/src/main/java/neqsim/process/engineering/designcase/EngineeringCaseExecutionException.java
+++ b/src/main/java/neqsim/process/engineering/designcase/EngineeringCaseExecutionException.java
@@ -1,0 +1,26 @@
+package neqsim.process.engineering.designcase;
+
+/** Signals an incomplete multi-case run while retaining its auditable partial report. */
+public final class EngineeringCaseExecutionException extends IllegalStateException {
+  private static final long serialVersionUID = 1000L;
+  private final EngineeringCaseRunReport partialReport;
+
+  /**
+   * Create an incomplete-case-run exception.
+   *
+   * @param message failure summary
+   * @param partialReport report containing every completed case and finding
+   */
+  public EngineeringCaseExecutionException(String message, EngineeringCaseRunReport partialReport) {
+    super(message);
+    if (partialReport == null) {
+      throw new IllegalArgumentException("partialReport cannot be null");
+    }
+    this.partialReport = partialReport;
+  }
+
+  /** @return auditable partial report */
+  public EngineeringCaseRunReport getPartialReport() {
+    return partialReport;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/designcase/EngineeringCaseFailurePolicy.java
+++ b/src/main/java/neqsim/process/engineering/designcase/EngineeringCaseFailurePolicy.java
@@ -1,0 +1,9 @@
+package neqsim.process.engineering.designcase;
+
+/** Controls propagation of incomplete multi-case engineering results. */
+public enum EngineeringCaseFailurePolicy {
+  /** Return the partial report for explicit inspection. */
+  RETURN_PARTIAL,
+  /** Throw an exception that retains the partial report. */
+  THROW_WITH_PARTIAL_RESULT
+}

--- a/src/main/java/neqsim/process/engineering/designcase/EngineeringCaseRunOptions.java
+++ b/src/main/java/neqsim/process/engineering/designcase/EngineeringCaseRunOptions.java
@@ -9,11 +9,13 @@ public final class EngineeringCaseRunOptions implements Serializable {
   private final int parallelism;
   private final boolean requireConvergence;
   private final EngineeringNumericalHealthCriteria numericalHealthCriteria;
+  private final EngineeringCaseFailurePolicy failurePolicy;
 
   private EngineeringCaseRunOptions(Builder builder) {
     parallelism = builder.parallelism;
     requireConvergence = builder.requireConvergence;
     numericalHealthCriteria = builder.numericalHealthCriteria;
+    failurePolicy = builder.failurePolicy;
   }
 
   public static Builder builder() {
@@ -36,11 +38,17 @@ public final class EngineeringCaseRunOptions implements Serializable {
     return numericalHealthCriteria;
   }
 
+  /** @return incomplete-result propagation policy */
+  public EngineeringCaseFailurePolicy getFailurePolicy() {
+    return failurePolicy;
+  }
+
   /** Builder for case execution options. */
   public static final class Builder {
     private int parallelism = 1;
     private boolean requireConvergence = true;
     private EngineeringNumericalHealthCriteria numericalHealthCriteria;
+    private EngineeringCaseFailurePolicy failurePolicy = EngineeringCaseFailurePolicy.RETURN_PARTIAL;
 
     public Builder parallelism(int value) {
       if (value < 1) {
@@ -61,6 +69,20 @@ public final class EngineeringCaseRunOptions implements Serializable {
         throw new IllegalArgumentException("numericalHealthCriteria must not be null");
       }
       numericalHealthCriteria = value;
+      return this;
+    }
+
+    /**
+     * Configure how incomplete runs are propagated.
+     *
+     * @param value explicit failure policy
+     * @return this builder
+     */
+    public Builder failurePolicy(EngineeringCaseFailurePolicy value) {
+      if (value == null) {
+        throw new IllegalArgumentException("failurePolicy must not be null");
+      }
+      failurePolicy = value;
       return this;
     }
 

--- a/src/main/java/neqsim/process/engineering/designcase/EngineeringCaseRunReport.java
+++ b/src/main/java/neqsim/process/engineering/designcase/EngineeringCaseRunReport.java
@@ -37,6 +37,30 @@ public final class EngineeringCaseRunReport implements Serializable {
     return envelope;
   }
 
+  /** @return whether every configured metric has a governing value and no case failed */
+  public boolean isComplete() {
+    return envelope.isComplete();
+  }
+
+  /** @return whether the complete envelope is assessed and within every configured limit */
+  public boolean isAccepted() {
+    return envelope.isAccepted();
+  }
+
+  /**
+   * Require a complete governing envelope.
+   *
+   * @return this report when complete
+   * @throws EngineeringCaseExecutionException when incomplete; the exception retains this report
+   */
+  public EngineeringCaseRunReport requireComplete() {
+    if (!isComplete()) {
+      throw new EngineeringCaseExecutionException(
+          "Engineering case set " + caseSetId + " did not produce a complete governing envelope", this);
+    }
+    return this;
+  }
+
   public Map<String, Object> toMap() {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("schemaVersion", "engineering_case_run.v1");
@@ -44,6 +68,8 @@ public final class EngineeringCaseRunReport implements Serializable {
     result.put("definitionFingerprint", definitionFingerprint);
     result.put("resultFingerprint", resultFingerprint);
     result.put("envelope", envelope.toMap());
+    result.put("complete", Boolean.valueOf(isComplete()));
+    result.put("accepted", Boolean.valueOf(isAccepted()));
     result.put("isolatedProcessCopies", Boolean.TRUE);
     result.put("engineeringApprovalRequired", Boolean.TRUE);
     return result;

--- a/src/main/java/neqsim/process/engineering/designcase/EngineeringCaseRunner.java
+++ b/src/main/java/neqsim/process/engineering/designcase/EngineeringCaseRunner.java
@@ -32,10 +32,17 @@ public final class EngineeringCaseRunner {
     EngineeringCaseRunOptions effectiveOptions = options == null ? EngineeringCaseRunOptions.sequential() : options;
     List<DesignCaseResult> results = execute(baseProcess, caseSet, effectiveOptions);
     Map<String, EngineeringDesignEnvelope.GoverningValue> governing = governing(caseSet.getMetrics(), results);
-    EngineeringDesignEnvelope envelope = new EngineeringDesignEnvelope(results, governing);
+    EngineeringDesignEnvelope envelope = new EngineeringDesignEnvelope(caseSet.getMetrics(), results, governing);
     String definitionFingerprint = fingerprint(caseSet.toMap());
     String resultFingerprint = fingerprint(envelope.toMap());
-    return new EngineeringCaseRunReport(caseSet.getId(), definitionFingerprint, resultFingerprint, envelope);
+    EngineeringCaseRunReport report = new EngineeringCaseRunReport(caseSet.getId(), definitionFingerprint,
+        resultFingerprint, envelope);
+    if (!report.isComplete()
+        && effectiveOptions.getFailurePolicy() == EngineeringCaseFailurePolicy.THROW_WITH_PARTIAL_RESULT) {
+      throw new EngineeringCaseExecutionException(
+          "Engineering case set " + caseSet.getId() + " did not produce a complete governing envelope", report);
+    }
+    return report;
   }
 
   private static List<DesignCaseResult> execute(ProcessSystem baseProcess, EngineeringCaseSet caseSet,

--- a/src/main/java/neqsim/process/engineering/designcase/EngineeringDesignEnvelope.java
+++ b/src/main/java/neqsim/process/engineering/designcase/EngineeringDesignEnvelope.java
@@ -68,8 +68,7 @@ public final class EngineeringDesignEnvelope implements Serializable {
 
   EngineeringDesignEnvelope(List<EngineeringMetric> configuredMetrics, List<DesignCaseResult> caseResults,
       Map<String, GoverningValue> governingValues) {
-    this.configuredMetrics = Collections
-        .unmodifiableList(new ArrayList<EngineeringMetric>(configuredMetrics));
+    this.configuredMetrics = Collections.unmodifiableList(new ArrayList<EngineeringMetric>(configuredMetrics));
     this.caseResults = new ArrayList<DesignCaseResult>(caseResults);
     this.governingValues = new LinkedHashMap<String, GoverningValue>(governingValues);
   }

--- a/src/main/java/neqsim/process/engineering/designcase/EngineeringDesignEnvelope.java
+++ b/src/main/java/neqsim/process/engineering/designcase/EngineeringDesignEnvelope.java
@@ -62,12 +62,21 @@ public final class EngineeringDesignEnvelope implements Serializable {
     }
   }
 
+  private final List<EngineeringMetric> configuredMetrics;
   private final List<DesignCaseResult> caseResults;
   private final Map<String, GoverningValue> governingValues;
 
-  EngineeringDesignEnvelope(List<DesignCaseResult> caseResults, Map<String, GoverningValue> governingValues) {
+  EngineeringDesignEnvelope(List<EngineeringMetric> configuredMetrics, List<DesignCaseResult> caseResults,
+      Map<String, GoverningValue> governingValues) {
+    this.configuredMetrics = Collections
+        .unmodifiableList(new ArrayList<EngineeringMetric>(configuredMetrics));
     this.caseResults = new ArrayList<DesignCaseResult>(caseResults);
     this.governingValues = new LinkedHashMap<String, GoverningValue>(governingValues);
+  }
+
+  /** @return immutable metrics configured for every executable case */
+  public List<EngineeringMetric> getConfiguredMetrics() {
+    return configuredMetrics;
   }
 
   public List<DesignCaseResult> getCaseResults() {
@@ -117,6 +126,47 @@ public final class EngineeringDesignEnvelope implements Serializable {
     return getPartialCaseCount() > 0 || getFailedCaseCount() > 0;
   }
 
+  /** @return configured metric IDs for which no converged case produced a governing value */
+  public List<String> getMissingGoverningMetricIds() {
+    List<String> missing = new ArrayList<String>();
+    for (EngineeringMetric metric : configuredMetrics) {
+      if (!governingValues.containsKey(metric.getId())) {
+        missing.add(metric.getId());
+      }
+    }
+    return Collections.unmodifiableList(missing);
+  }
+
+  /** @return governing metric IDs without any configured acceptance limit */
+  public List<String> getUnassessedGoverningMetricIds() {
+    List<String> unassessed = new ArrayList<String>();
+    for (GoverningValue governing : governingValues.values()) {
+      EngineeringMetric metric = governing.getMetric();
+      if (metric.getLowerAcceptanceLimit() == null && metric.getUpperAcceptanceLimit() == null) {
+        unassessed.add(metric.getId());
+      }
+    }
+    return Collections.unmodifiableList(unassessed);
+  }
+
+  /** @return whether every configured metric has a governing value and no case failed or was partial */
+  public boolean isComplete() {
+    return !hasCaseFailures() && getMissingGoverningMetricIds().isEmpty();
+  }
+
+  /**
+   * Determine whether a complete envelope is within every configured acceptance limit.
+   *
+   * <p>
+   * A complete envelope with unconfigured limits remains review-required and is not reported as accepted.
+   * </p>
+   *
+   * @return true only when complete, fully assessed, and without limit violations
+   */
+  public boolean isAccepted() {
+    return isComplete() && getUnassessedGoverningMetricIds().isEmpty() && getLimitViolationCount() == 0;
+  }
+
   public List<EngineeringCalculation> toCalculations() {
     List<EngineeringCalculation> result = new ArrayList<EngineeringCalculation>();
     for (GoverningValue governing : governingValues.values()) {
@@ -133,6 +183,11 @@ public final class EngineeringDesignEnvelope implements Serializable {
 
   public Map<String, Object> toMap() {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
+    List<Map<String, Object>> metricDefinitions = new ArrayList<Map<String, Object>>();
+    for (EngineeringMetric metric : configuredMetrics) {
+      metricDefinitions.add(metric.toMap());
+    }
+    result.put("configuredMetrics", metricDefinitions);
     List<Map<String, Object>> cases = new ArrayList<Map<String, Object>>();
     for (DesignCaseResult caseResult : caseResults) {
       cases.add(caseResult.toMap());
@@ -150,6 +205,10 @@ public final class EngineeringDesignEnvelope implements Serializable {
     summary.put("failedCaseCount", Integer.valueOf(getFailedCaseCount()));
     summary.put("skippedCaseCount", Integer.valueOf(getSkippedCaseCount()));
     summary.put("limitViolationCount", Integer.valueOf(getLimitViolationCount()));
+    summary.put("missingGoverningMetricIds", new ArrayList<String>(getMissingGoverningMetricIds()));
+    summary.put("unassessedGoverningMetricIds", new ArrayList<String>(getUnassessedGoverningMetricIds()));
+    summary.put("complete", Boolean.valueOf(isComplete()));
+    summary.put("accepted", Boolean.valueOf(isAccepted()));
     result.put("summary", summary);
     return result;
   }

--- a/src/test/java/neqsim/process/engineering/designcase/EngineeringCaseRunnerTest.java
+++ b/src/test/java/neqsim/process/engineering/designcase/EngineeringCaseRunnerTest.java
@@ -1,7 +1,10 @@
 package neqsim.process.engineering.designcase;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.engineering.numerics.EngineeringNumericalHealthCriteria;
@@ -30,6 +33,9 @@ class EngineeringCaseRunnerTest {
     assertEquals(80.0, sequential.getEnvelope().getGoverningValues().get("FEED.pressure").getValue(), 1.0e-10);
     assertEquals(basePressure, ((Stream) process.getUnit("FEED")).getPressure("bara"), 1.0e-10);
     assertEquals(2, sequential.getEnvelope().getSuccessfulCaseCount());
+    assertTrue(sequential.isComplete());
+    assertFalse(sequential.isAccepted());
+    assertEquals(1, sequential.getEnvelope().getUnassessedGoverningMetricIds().size());
     assertTrue(sequential.toJson().contains("isolatedProcessCopies"));
     assertNotEquals(sequential.getDefinitionFingerprint(), sequential.getResultFingerprint());
   }
@@ -45,6 +51,59 @@ class EngineeringCaseRunnerTest {
 
     assertTrue(report.toJson().contains("numericalHealth"));
     assertEquals("HEALTHY", report.getEnvelope().getCaseResults().get(0).getNumericalHealthReport().getStatus().name());
+  }
+
+  @Test
+  void incompleteEnvelopeCanReturnOrThrowWithTheSamePartialEvidence() {
+    ProcessSystem process = process();
+    EngineeringMetric nonFinite = new EngineeringMetric("FEED.invalid", "FEED", "Invalid metric", "fraction",
+        EngineeringMetric.GoverningDirection.MAXIMUM, new EngineeringMetric.Extractor() {
+          private static final long serialVersionUID = 1000L;
+
+          @Override
+          public double extract(ProcessSystem ignored) {
+            return Double.NaN;
+          }
+        });
+    EngineeringCaseSet cases = new EngineeringCaseSet("incomplete").addCase(caseAtPressure("normal", 50.0, 10))
+        .addMetric(nonFinite);
+
+    EngineeringCaseRunReport partial = EngineeringCaseRunner.run(process, cases,
+        EngineeringCaseRunOptions.sequential());
+
+    assertFalse(partial.isComplete());
+    assertEquals("FEED.invalid", partial.getEnvelope().getMissingGoverningMetricIds().get(0));
+    EngineeringCaseExecutionException requireException = assertThrows(EngineeringCaseExecutionException.class,
+        partial::requireComplete);
+    assertSame(partial, requireException.getPartialReport());
+
+    EngineeringCaseExecutionException executionException = assertThrows(EngineeringCaseExecutionException.class,
+        () -> EngineeringCaseRunner.run(process, cases,
+            EngineeringCaseRunOptions.builder()
+                .failurePolicy(EngineeringCaseFailurePolicy.THROW_WITH_PARTIAL_RESULT).build()));
+    assertFalse(executionException.getPartialReport().isComplete());
+  }
+
+  @Test
+  void acceptanceRequiresConfiguredLimitsAndNoViolation() {
+    ProcessSystem process = process();
+    EngineeringCaseSet passing = new EngineeringCaseSet("passing-limits")
+        .addCase(caseAtPressure("normal", 50.0, 10)).addCase(caseAtPressure("maximum", 80.0, 20))
+        .addMetric(EngineeringMetric.equipmentPressure("FEED").setAcceptanceRange(null, Double.valueOf(90.0)));
+    EngineeringCaseSet failing = new EngineeringCaseSet("failing-limits")
+        .addCase(caseAtPressure("normal", 50.0, 10)).addCase(caseAtPressure("maximum", 80.0, 20))
+        .addMetric(EngineeringMetric.equipmentPressure("FEED").setAcceptanceRange(null, Double.valueOf(70.0)));
+
+    EngineeringCaseRunReport accepted = EngineeringCaseRunner.run(process, passing,
+        EngineeringCaseRunOptions.sequential());
+    EngineeringCaseRunReport violated = EngineeringCaseRunner.run(process, failing,
+        EngineeringCaseRunOptions.sequential());
+
+    assertTrue(accepted.isComplete());
+    assertTrue(accepted.isAccepted());
+    assertTrue(violated.isComplete());
+    assertFalse(violated.isAccepted());
+    assertEquals(1, violated.getEnvelope().getLimitViolationCount());
   }
 
   private EngineeringDesignCase caseAtPressure(String id, final double pressureBara, int priority) {

--- a/src/test/java/neqsim/process/engineering/designcase/EngineeringCaseRunnerTest.java
+++ b/src/test/java/neqsim/process/engineering/designcase/EngineeringCaseRunnerTest.java
@@ -78,20 +78,19 @@ class EngineeringCaseRunnerTest {
     assertSame(partial, requireException.getPartialReport());
 
     EngineeringCaseExecutionException executionException = assertThrows(EngineeringCaseExecutionException.class,
-        () -> EngineeringCaseRunner.run(process, cases,
-            EngineeringCaseRunOptions.builder()
-                .failurePolicy(EngineeringCaseFailurePolicy.THROW_WITH_PARTIAL_RESULT).build()));
+        () -> EngineeringCaseRunner.run(process, cases, EngineeringCaseRunOptions.builder()
+            .failurePolicy(EngineeringCaseFailurePolicy.THROW_WITH_PARTIAL_RESULT).build()));
     assertFalse(executionException.getPartialReport().isComplete());
   }
 
   @Test
   void acceptanceRequiresConfiguredLimitsAndNoViolation() {
     ProcessSystem process = process();
-    EngineeringCaseSet passing = new EngineeringCaseSet("passing-limits")
-        .addCase(caseAtPressure("normal", 50.0, 10)).addCase(caseAtPressure("maximum", 80.0, 20))
+    EngineeringCaseSet passing = new EngineeringCaseSet("passing-limits").addCase(caseAtPressure("normal", 50.0, 10))
+        .addCase(caseAtPressure("maximum", 80.0, 20))
         .addMetric(EngineeringMetric.equipmentPressure("FEED").setAcceptanceRange(null, Double.valueOf(90.0)));
-    EngineeringCaseSet failing = new EngineeringCaseSet("failing-limits")
-        .addCase(caseAtPressure("normal", 50.0, 10)).addCase(caseAtPressure("maximum", 80.0, 20))
+    EngineeringCaseSet failing = new EngineeringCaseSet("failing-limits").addCase(caseAtPressure("normal", 50.0, 10))
+        .addCase(caseAtPressure("maximum", 80.0, 20))
         .addMetric(EngineeringMetric.equipmentPressure("FEED").setAcceptanceRange(null, Double.valueOf(70.0)));
 
     EngineeringCaseRunReport accepted = EngineeringCaseRunner.run(process, passing,


### PR DESCRIPTION
## Summary
- distinguish a complete governing envelope from an accepted, limit-checked envelope
- retain configured metrics and report missing/unassessed governing metric IDs
- add configurable partial-result propagation with exceptions that preserve the full report
- make equal-priority legacy case execution deterministic and document fail-closed workflow gates

## Safety boundary
`isAccepted()` is deliberately fail-closed: a complete envelope without configured acceptance limits remains review-required. Partial metrics may remain visible as evidence, but any failed or partial case makes the report incomplete.

## Verification
- focused Java 8 compilation of the changed production classes and legacy engine
- behavior smoke checks for completeness, limit acceptance, missing metrics, both partial-result policies, report identity, and Java serialization
- repository diff whitespace check

Stacked on #2558.