### PR TITLE
Add executable standard-kernel regression verification

### DIFF
--- a/docs/integration/industrial-method-qualification.md
+++ b/docs/integration/industrial-method-qualification.md
@@ -20,6 +20,13 @@ The result is machine-readable and can report `QUALIFIED_FOR_SERVICE`, `UNREGIST
 `INCOMPLETE_QUALIFICATION`, `MISSING_INDEPENDENT_BENCHMARK`, `USE_NOT_QUALIFIED`,
 `INSUFFICIENT_SERVICE_CONTEXT` or `OUTSIDE_QUALIFIED_ENVELOPE`.
 
+Numeric regression health is intentionally reported separately from qualification. An
+`EngineeringBenchmarkSuite.Report` exposes `areAllBenchmarksPassed()` and
+`getFailedBenchmarkIds()` for executable baseline checks, while `isPassed()` continues to require a
+passing independently reviewed, non-regression benchmark for every required exact method version.
+This prevents a green internal regression suite from being presented as independent engineering
+qualification.
+
 ## Define and assess a method
 
 ```java

--- a/docs/process/DESIGN_FRAMEWORK.md
+++ b/docs/process/DESIGN_FRAMEWORK.md
@@ -38,6 +38,19 @@ Unsupported editions, inapplicable equipment types, and incomplete inputs return
 All remain preliminary engineering screens and do not claim certification or construction
 readiness.
 
+The executable `StandardDesignKernelVerificationSuite.evaluateRegression()` runs every registered
+kernel against deterministic numeric baselines. It includes SI/customary equivalence at the API 526
+orifice boundary and metre/micrometre equivalence for API 12J. Inspect
+`report.areAllBenchmarksPassed()` for regression health and `report.getFailedBenchmarkIds()` for
+diagnosis. The records are deliberately classified as `REGRESSION_BASELINE`; therefore
+`report.isPassed()` remains false until separately controlled, independently reviewed evidence is
+provided for the exact method versions.
+
+`EquipmentDesignKernelRegistry.getRegisteredStandards()` provides an immutable, deterministic
+registry snapshot for API and serialization regression checks. A registered kernel must identify the
+same standard as its lookup key, support the catalogued default edition, expose a unique
+`method@version`, use a maturity above `CATALOGUED`, and remain serializable.
+
 ## Quick Start
 
 ### Basic Auto-Sizing Example

--- a/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernelRegistry.java
+++ b/src/main/java/neqsim/process/engineering/calculation/EquipmentDesignKernelRegistry.java
@@ -2,6 +2,8 @@ package neqsim.process.engineering.calculation;
 
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.Map;
 import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
 import neqsim.process.mechanicaldesign.designstandards.StandardSupportLevel;
@@ -107,6 +109,15 @@ public final class EquipmentDesignKernelRegistry {
     }
     EquipmentDesignKernel<?, ?> kernel = KERNELS.get(standardType);
     return new Lookup(standardType, kernel == null ? Status.NOT_IMPLEMENTED : Status.IMPLEMENTED, kernel);
+  }
+
+  /**
+   * List standards with an executable common design kernel.
+   *
+   * @return deterministic immutable standard set
+   */
+  public static Set<StandardType> getRegisteredStandards() {
+    return Collections.unmodifiableSet(EnumSet.copyOf(KERNELS.keySet()));
   }
 
   private static void register(Map<StandardType, EquipmentDesignKernel<?, ?>> kernels,

--- a/src/main/java/neqsim/process/engineering/calculation/StandardDesignKernelVerificationSuite.java
+++ b/src/main/java/neqsim/process/engineering/calculation/StandardDesignKernelVerificationSuite.java
@@ -1,0 +1,209 @@
+package neqsim.process.engineering.calculation;
+
+import java.util.Arrays;
+import neqsim.process.engineering.production.EngineeringBenchmarkSuite;
+import neqsim.process.engineering.production.EngineeringValidationBenchmark;
+import neqsim.process.engineering.production.EngineeringValidationBenchmark.SourceClass;
+import neqsim.process.mechanicaldesign.compressor.CompressorCasingDesignCalculator;
+import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.Api610PumpType;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.AssessmentStatus;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.BearingType;
+import neqsim.process.mechanicaldesign.pump.PumpApi610DesignCalculator.DataSource;
+import neqsim.process.safety.overpressure.ProtectedItem;
+import neqsim.process.safety.overpressure.ReliefCause;
+import neqsim.process.safety.overpressure.ReliefPhase;
+import neqsim.process.safety.overpressure.ReliefScenario;
+
+/** Executable non-qualification regression suite for the common standard design kernels. */
+public final class StandardDesignKernelVerificationSuite {
+  private static final String SUITE_ID = "standard-design-kernel-regression";
+  private static final String REVISION = "1";
+  private static final String SOURCE_REFERENCE = "NEQSIM-STANDARD-KERNEL-REGRESSION";
+  private static final double FAILURE_SENTINEL = 1.0e100;
+  private static final double SQUARE_METRES_PER_SQUARE_INCH = 6.4516e-4;
+
+  private StandardDesignKernelVerificationSuite() {
+    // Utility class.
+  }
+
+  /**
+   * Execute deterministic regression and unit-equivalence cases for every registered standard kernel.
+   *
+   * <p>
+   * The returned cases use {@link SourceClass#REGRESSION_BASELINE}. Consequently
+   * {@link EngineeringBenchmarkSuite.Report#areAllBenchmarksPassed()} may be true while
+   * {@link EngineeringBenchmarkSuite.Report#isPassed()} remains false. Independent controlled evidence is still
+   * required for method qualification.
+   * </p>
+   *
+   * @return evaluated numeric regression report
+   */
+  public static EngineeringBenchmarkSuite.Report evaluateRegression() {
+    PumpApi610DesignKernel pumpKernel = new PumpApi610DesignKernel();
+    Api521ReliefDesignKernel reliefKernel = new Api521ReliefDesignKernel();
+    Api526OrificeSelectionKernel orificeKernel = new Api526OrificeSelectionKernel();
+    Api617CompressorDesignKernel compressorKernel = new Api617CompressorDesignKernel();
+    Api12JSeparatorDesignKernel separatorKernel = new Api12JSeparatorDesignKernel();
+
+    EngineeringBenchmarkSuite suite = new EngineeringBenchmarkSuite(SUITE_ID, REVISION)
+        .requireMethod(methodKey(pumpKernel)).requireMethod(methodKey(reliefKernel)).requireMethod(methodKey(orificeKernel))
+        .requireMethod(methodKey(compressorKernel)).requireMethod(methodKey(separatorKernel));
+    suite.add(pumpBenchmark(pumpKernel));
+    suite.add(reliefBenchmark(reliefKernel));
+    suite.add(orificeBenchmark(orificeKernel));
+    suite.add(compressorBenchmark(compressorKernel));
+    suite.add(separatorBenchmark(separatorKernel));
+    return suite.evaluate();
+  }
+
+  private static EngineeringValidationBenchmark pumpBenchmark(PumpApi610DesignKernel kernel) {
+    PumpApi610DesignKernel.Input input = new PumpApi610DesignKernel.Input(
+        StandardEdition.defaultEdition(StandardType.API_610), "Pump", pumpConfiguration());
+    EngineeringCalculationResult<PumpApi610DesignAssessment> result = kernel.calculate(input, null);
+    PumpApi610DesignAssessment value = result.getValue();
+    return baseline("api-610-rated-duty", kernel)
+        .check("calculatedReviewRequired", 1.0, calculated(result), "flag", 0.0, 0.0)
+        .check("selectedDriverPower", 30.0, value == null ? FAILURE_SENTINEL : value.getSelectedDriverPowerKw(), "kW",
+            1.0e-12, 1.0e-12)
+        .check("screeningPass", 1.0,
+            value != null && value.getAssessmentStatus() == AssessmentStatus.PASS ? 1.0 : 0.0, "flag", 0.0, 0.0)
+        .build();
+  }
+
+  private static EngineeringValidationBenchmark reliefBenchmark(Api521ReliefDesignKernel kernel) {
+    ProtectedItem item = new ProtectedItem("V-100", 100.0).setReliefSetPressureBara(100.0).setBackPressureBara(1.0);
+    Api521ReliefDesignKernel.Input input = new Api521ReliefDesignKernel.Input(
+        StandardEdition.defaultEdition(StandardType.API_521), "ProtectedItem", item,
+        Arrays.asList(vapourScenario("blocked outlet", ReliefCause.BLOCKED_OUTLET, 1.0),
+            vapourScenario("pool fire", ReliefCause.FIRE, 2.0)),
+        false);
+    EngineeringCalculationResult<Api521ReliefAssessment> result = kernel.calculate(input, null);
+    Api521ReliefAssessment value = result.getValue();
+    return baseline("api-521-governing-scenario", kernel)
+        .check("calculatedReviewRequired", 1.0, calculated(result), "flag", 0.0, 0.0)
+        .check("governingReliefRate", 2.0, value == null ? FAILURE_SENTINEL : value.getGoverningReliefRateKgPerS(),
+            "kg/s", 1.0e-12, 1.0e-12)
+        .check("capacityAdequate", 1.0, value != null && value.isCapacityAdequate() ? 1.0 : 0.0, "flag", 0.0, 0.0)
+        .check("accumulatedPressureAccepted", 1.0,
+            value != null && value.isAccumulatedPressureAccepted() ? 1.0 : 0.0, "flag", 0.0, 0.0)
+        .build();
+  }
+
+  private static EngineeringValidationBenchmark orificeBenchmark(Api526OrificeSelectionKernel kernel) {
+    StandardEdition edition = StandardEdition.defaultEdition(StandardType.API_526);
+    Api526OrificeSelectionAssessment customary = kernel
+        .calculate(new Api526OrificeSelectionKernel.Input(edition, "SafetyValve", 0.503,
+            Api526OrificeSelectionKernel.AreaUnit.SQUARE_INCH), null)
+        .getValue();
+    Api526OrificeSelectionAssessment si = kernel
+        .calculate(new Api526OrificeSelectionKernel.Input(edition, "SafetyReliefValve",
+            0.503 * SQUARE_METRES_PER_SQUARE_INCH, Api526OrificeSelectionKernel.AreaUnit.SQUARE_METRE), null)
+        .getValue();
+    return baseline("api-526-boundary-and-unit-equivalence", kernel)
+        .check("selectedStandardArea", 0.503,
+            customary == null ? FAILURE_SENTINEL : customary.getSelectedAreaIn2(), "in2", 1.0e-12, 1.0e-12)
+        .check("requiredAreaSiConversion", 0.503, si == null ? FAILURE_SENTINEL : si.getRequiredAreaIn2(), "in2",
+            1.0e-12, 1.0e-12)
+        .check("unitEquivalentRequiredArea", 0.0,
+            customary == null || si == null ? FAILURE_SENTINEL
+                : Math.abs(customary.getRequiredAreaIn2() - si.getRequiredAreaIn2()),
+            "in2", 1.0e-12, 0.0)
+        .check("adequate", 1.0, customary != null && customary.isAdequate() ? 1.0 : 0.0, "flag", 0.0, 0.0)
+        .build();
+  }
+
+  private static EngineeringValidationBenchmark compressorBenchmark(Api617CompressorDesignKernel kernel) {
+    Api617CompressorDesignKernel.Input input = new Api617CompressorDesignKernel.Input(
+        StandardEdition.defaultEdition(StandardType.API_617), "Compressor", compressorConfiguration());
+    EngineeringCalculationResult<Api617CompressorAssessment> result = kernel.calculate(input, null);
+    Api617CompressorAssessment value = result.getValue();
+    return baseline("api-617-pressure-containment", kernel)
+        .check("calculatedReviewRequired", 1.0, calculated(result), "flag", 0.0, 0.0)
+        .check("selectedWallThickness", 12.7,
+            value == null ? FAILURE_SENTINEL : value.getSelectedWallThicknessMm(), "mm", 1.0e-12, 1.0e-12)
+        .check("hydroTestPressure", 7.5, value == null ? FAILURE_SENTINEL : value.getHydroTestPressureMPa(), "MPa",
+            1.0e-12, 1.0e-12)
+        .build();
+  }
+
+  private static EngineeringValidationBenchmark separatorBenchmark(Api12JSeparatorDesignKernel kernel) {
+    StandardEdition edition = StandardEdition.defaultEdition(StandardType.API_12J);
+    Api12JSeparatorAssessment micrometre = kernel
+        .calculate(new Api12JSeparatorDesignKernel.Input(edition, "Separator", 80.0,
+            Api12JSeparatorDesignKernel.DiameterUnit.MICROMETRE, 0.08, false, 240.0,
+            Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false), null)
+        .getValue();
+    Api12JSeparatorAssessment si = kernel
+        .calculate(new Api12JSeparatorDesignKernel.Input(edition, "Separator", 80.0e-6,
+            Api12JSeparatorDesignKernel.DiameterUnit.METRE, 0.08, false, 240.0,
+            Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false), null)
+        .getValue();
+    return baseline("api-12j-screen-and-unit-equivalence", kernel)
+        .check("gravityCutDiameter", 80.0,
+            micrometre == null ? FAILURE_SENTINEL : micrometre.getGravityCutDiameterMicrometre(), "micrometre",
+            1.0e-12, 1.0e-12)
+        .check("kFactorUtilization", 2.0 / 3.0,
+            micrometre == null ? FAILURE_SENTINEL : micrometre.getKFactorUtilization(), "fraction", 1.0e-12,
+            1.0e-12)
+        .check("unitEquivalentCutDiameter", 0.0,
+            micrometre == null || si == null ? FAILURE_SENTINEL
+                : Math.abs(micrometre.getGravityCutDiameterMicrometre() - si.getGravityCutDiameterMicrometre()),
+            "micrometre", 1.0e-12, 0.0)
+        .check("screeningPass", 1.0,
+            micrometre != null && micrometre.areAllScreeningCriteriaPassing() ? 1.0 : 0.0, "flag", 0.0, 0.0)
+        .build();
+  }
+
+  private static EngineeringValidationBenchmark.Builder baseline(String id, EquipmentDesignKernel<?, ?> kernel) {
+    return EngineeringValidationBenchmark.builder(id, kernel.getMethod(), kernel.getMethodVersion())
+        .source(SourceClass.REGRESSION_BASELINE, SOURCE_REFERENCE, REVISION);
+  }
+
+  private static String methodKey(EquipmentDesignKernel<?, ?> kernel) {
+    return kernel.getMethod() + "@" + kernel.getMethodVersion();
+  }
+
+  private static double calculated(EngineeringCalculationResult<?> result) {
+    return result.getStatus() == EngineeringCalculationResult.Status.CALCULATED_REVIEW_REQUIRED ? 1.0 : 0.0;
+  }
+
+  private static ReliefScenario vapourScenario(String name, ReliefCause cause, double rateKgPerS) {
+    return new ReliefScenario.Builder(name, cause).phase(ReliefPhase.VAPOUR).reliefRateKgPerS(rateKgPerS)
+        .reliefTemperatureK(320.0).molarMassKgPerMol(0.020).compressibility(0.95).specificHeatRatio(1.25)
+        .addAssumption("regression property basis").build();
+  }
+
+  private static PumpApi610DesignCalculator pumpConfiguration() {
+    PumpApi610DesignCalculator calculator = new PumpApi610DesignCalculator();
+    calculator.setPumpType(Api610PumpType.OH2);
+    calculator.setDutyPoint(100.0, 80.0, 3000.0, 850.0, 25.0);
+    calculator.setBepPoint(100.0, 80.0, DataSource.VENDOR_CURVE);
+    calculator.setNpsh(6.0, 4.0, DataSource.VENDOR_CURVE);
+    calculator.setPressureBasis(5.0, 20.0, 90.0, DataSource.VENDOR_CURVE);
+    calculator.setHydrostaticTestPressureBara(30.0);
+    calculator.setDriverCriteria(1.10, new double[] {22.0, 30.0, 37.0});
+    calculator.setBearingData(BearingType.BALL, 100.0, 5.0);
+    calculator.setMechanicalEvidence(0.03, 4000.0, 0.8, 2.5);
+    return calculator;
+  }
+
+  private static CompressorCasingDesignCalculator compressorConfiguration() {
+    CompressorCasingDesignCalculator calculator = new CompressorCasingDesignCalculator();
+    calculator.setDesignPressureMPa(5.0);
+    calculator.setMaxOperatingPressureMPa(4.0);
+    calculator.setDesignTemperatureC(150.0);
+    calculator.setMaxOperatingTemperatureC(100.0);
+    calculator.setMinOperatingTemperatureC(-20.0);
+    calculator.setCasingInnerDiameterMm(500.0);
+    calculator.setCasingLengthMm(1500.0);
+    calculator.setMaterialGrade("SA-516-70");
+    calculator.setCorrosionAllowanceMm(1.5);
+    calculator.setJointEfficiency(0.85);
+    calculator.setSuctionNozzleSizeMm(200.0);
+    calculator.setDischargeNozzleSizeMm(150.0);
+    return calculator;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/calculation/StandardDesignKernelVerificationSuite.java
+++ b/src/main/java/neqsim/process/engineering/calculation/StandardDesignKernelVerificationSuite.java
@@ -49,8 +49,9 @@ public final class StandardDesignKernelVerificationSuite {
     Api12JSeparatorDesignKernel separatorKernel = new Api12JSeparatorDesignKernel();
 
     EngineeringBenchmarkSuite suite = new EngineeringBenchmarkSuite(SUITE_ID, REVISION)
-        .requireMethod(methodKey(pumpKernel)).requireMethod(methodKey(reliefKernel)).requireMethod(methodKey(orificeKernel))
-        .requireMethod(methodKey(compressorKernel)).requireMethod(methodKey(separatorKernel));
+        .requireMethod(methodKey(pumpKernel)).requireMethod(methodKey(reliefKernel))
+        .requireMethod(methodKey(orificeKernel)).requireMethod(methodKey(compressorKernel))
+        .requireMethod(methodKey(separatorKernel));
     suite.add(pumpBenchmark(pumpKernel));
     suite.add(reliefBenchmark(reliefKernel));
     suite.add(orificeBenchmark(orificeKernel));
@@ -68,8 +69,8 @@ public final class StandardDesignKernelVerificationSuite {
         .check("calculatedReviewRequired", 1.0, calculated(result), "flag", 0.0, 0.0)
         .check("selectedDriverPower", 30.0, value == null ? FAILURE_SENTINEL : value.getSelectedDriverPowerKw(), "kW",
             1.0e-12, 1.0e-12)
-        .check("screeningPass", 1.0,
-            value != null && value.getAssessmentStatus() == AssessmentStatus.PASS ? 1.0 : 0.0, "flag", 0.0, 0.0)
+        .check("screeningPass", 1.0, value != null && value.getAssessmentStatus() == AssessmentStatus.PASS ? 1.0 : 0.0,
+            "flag", 0.0, 0.0)
         .build();
   }
 
@@ -87,32 +88,29 @@ public final class StandardDesignKernelVerificationSuite {
         .check("governingReliefRate", 2.0, value == null ? FAILURE_SENTINEL : value.getGoverningReliefRateKgPerS(),
             "kg/s", 1.0e-12, 1.0e-12)
         .check("capacityAdequate", 1.0, value != null && value.isCapacityAdequate() ? 1.0 : 0.0, "flag", 0.0, 0.0)
-        .check("accumulatedPressureAccepted", 1.0,
-            value != null && value.isAccumulatedPressureAccepted() ? 1.0 : 0.0, "flag", 0.0, 0.0)
+        .check("accumulatedPressureAccepted", 1.0, value != null && value.isAccumulatedPressureAccepted() ? 1.0 : 0.0,
+            "flag", 0.0, 0.0)
         .build();
   }
 
   private static EngineeringValidationBenchmark orificeBenchmark(Api526OrificeSelectionKernel kernel) {
     StandardEdition edition = StandardEdition.defaultEdition(StandardType.API_526);
-    Api526OrificeSelectionAssessment customary = kernel
-        .calculate(new Api526OrificeSelectionKernel.Input(edition, "SafetyValve", 0.503,
-            Api526OrificeSelectionKernel.AreaUnit.SQUARE_INCH), null)
-        .getValue();
+    Api526OrificeSelectionAssessment customary = kernel.calculate(new Api526OrificeSelectionKernel.Input(edition,
+        "SafetyValve", 0.503, Api526OrificeSelectionKernel.AreaUnit.SQUARE_INCH), null).getValue();
     Api526OrificeSelectionAssessment si = kernel
         .calculate(new Api526OrificeSelectionKernel.Input(edition, "SafetyReliefValve",
             0.503 * SQUARE_METRES_PER_SQUARE_INCH, Api526OrificeSelectionKernel.AreaUnit.SQUARE_METRE), null)
         .getValue();
     return baseline("api-526-boundary-and-unit-equivalence", kernel)
-        .check("selectedStandardArea", 0.503,
-            customary == null ? FAILURE_SENTINEL : customary.getSelectedAreaIn2(), "in2", 1.0e-12, 1.0e-12)
+        .check("selectedStandardArea", 0.503, customary == null ? FAILURE_SENTINEL : customary.getSelectedAreaIn2(),
+            "in2", 1.0e-12, 1.0e-12)
         .check("requiredAreaSiConversion", 0.503, si == null ? FAILURE_SENTINEL : si.getRequiredAreaIn2(), "in2",
             1.0e-12, 1.0e-12)
         .check("unitEquivalentRequiredArea", 0.0,
             customary == null || si == null ? FAILURE_SENTINEL
                 : Math.abs(customary.getRequiredAreaIn2() - si.getRequiredAreaIn2()),
             "in2", 1.0e-12, 0.0)
-        .check("adequate", 1.0, customary != null && customary.isAdequate() ? 1.0 : 0.0, "flag", 0.0, 0.0)
-        .build();
+        .check("adequate", 1.0, customary != null && customary.isAdequate() ? 1.0 : 0.0, "flag", 0.0, 0.0).build();
   }
 
   private static EngineeringValidationBenchmark compressorBenchmark(Api617CompressorDesignKernel kernel) {
@@ -122,8 +120,8 @@ public final class StandardDesignKernelVerificationSuite {
     Api617CompressorAssessment value = result.getValue();
     return baseline("api-617-pressure-containment", kernel)
         .check("calculatedReviewRequired", 1.0, calculated(result), "flag", 0.0, 0.0)
-        .check("selectedWallThickness", 12.7,
-            value == null ? FAILURE_SENTINEL : value.getSelectedWallThicknessMm(), "mm", 1.0e-12, 1.0e-12)
+        .check("selectedWallThickness", 12.7, value == null ? FAILURE_SENTINEL : value.getSelectedWallThicknessMm(),
+            "mm", 1.0e-12, 1.0e-12)
         .check("hydroTestPressure", 7.5, value == null ? FAILURE_SENTINEL : value.getHydroTestPressureMPa(), "MPa",
             1.0e-12, 1.0e-12)
         .build();
@@ -131,29 +129,24 @@ public final class StandardDesignKernelVerificationSuite {
 
   private static EngineeringValidationBenchmark separatorBenchmark(Api12JSeparatorDesignKernel kernel) {
     StandardEdition edition = StandardEdition.defaultEdition(StandardType.API_12J);
-    Api12JSeparatorAssessment micrometre = kernel
-        .calculate(new Api12JSeparatorDesignKernel.Input(edition, "Separator", 80.0,
-            Api12JSeparatorDesignKernel.DiameterUnit.MICROMETRE, 0.08, false, 240.0,
-            Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false), null)
-        .getValue();
-    Api12JSeparatorAssessment si = kernel
-        .calculate(new Api12JSeparatorDesignKernel.Input(edition, "Separator", 80.0e-6,
-            Api12JSeparatorDesignKernel.DiameterUnit.METRE, 0.08, false, 240.0,
-            Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false), null)
-        .getValue();
+    Api12JSeparatorAssessment micrometre = kernel.calculate(new Api12JSeparatorDesignKernel.Input(edition, "Separator",
+        80.0, Api12JSeparatorDesignKernel.DiameterUnit.MICROMETRE, 0.08, false, 240.0,
+        Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false), null).getValue();
+    Api12JSeparatorAssessment si = kernel.calculate(new Api12JSeparatorDesignKernel.Input(edition, "Separator", 80.0e-6,
+        Api12JSeparatorDesignKernel.DiameterUnit.METRE, 0.08, false, 240.0,
+        Api12JSeparatorDesignKernel.Orientation.HORIZONTAL, false), null).getValue();
     return baseline("api-12j-screen-and-unit-equivalence", kernel)
         .check("gravityCutDiameter", 80.0,
-            micrometre == null ? FAILURE_SENTINEL : micrometre.getGravityCutDiameterMicrometre(), "micrometre",
-            1.0e-12, 1.0e-12)
-        .check("kFactorUtilization", 2.0 / 3.0,
-            micrometre == null ? FAILURE_SENTINEL : micrometre.getKFactorUtilization(), "fraction", 1.0e-12,
+            micrometre == null ? FAILURE_SENTINEL : micrometre.getGravityCutDiameterMicrometre(), "micrometre", 1.0e-12,
             1.0e-12)
+        .check("kFactorUtilization", 2.0 / 3.0,
+            micrometre == null ? FAILURE_SENTINEL : micrometre.getKFactorUtilization(), "fraction", 1.0e-12, 1.0e-12)
         .check("unitEquivalentCutDiameter", 0.0,
             micrometre == null || si == null ? FAILURE_SENTINEL
                 : Math.abs(micrometre.getGravityCutDiameterMicrometre() - si.getGravityCutDiameterMicrometre()),
             "micrometre", 1.0e-12, 0.0)
-        .check("screeningPass", 1.0,
-            micrometre != null && micrometre.areAllScreeningCriteriaPassing() ? 1.0 : 0.0, "flag", 0.0, 0.0)
+        .check("screeningPass", 1.0, micrometre != null && micrometre.areAllScreeningCriteriaPassing() ? 1.0 : 0.0,
+            "flag", 0.0, 0.0)
         .build();
   }
 
@@ -184,7 +177,7 @@ public final class StandardDesignKernelVerificationSuite {
     calculator.setNpsh(6.0, 4.0, DataSource.VENDOR_CURVE);
     calculator.setPressureBasis(5.0, 20.0, 90.0, DataSource.VENDOR_CURVE);
     calculator.setHydrostaticTestPressureBara(30.0);
-    calculator.setDriverCriteria(1.10, new double[] {22.0, 30.0, 37.0});
+    calculator.setDriverCriteria(1.10, new double[] { 22.0, 30.0, 37.0 });
     calculator.setBearingData(BearingType.BALL, 100.0, 5.0);
     calculator.setMechanicalEvidence(0.03, 4000.0, 0.8, 2.5);
     return calculator;

--- a/src/main/java/neqsim/process/engineering/production/EngineeringBenchmarkSuite.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringBenchmarkSuite.java
@@ -72,6 +72,44 @@ public final class EngineeringBenchmarkSuite implements Serializable {
       return !requiredMethods.isEmpty() && qualifyingMethods.containsAll(requiredMethods);
     }
 
+    /**
+     * Check numeric regression tolerances independently of evidence qualification.
+     *
+     * <p>
+     * A passing regression baseline protects implementation behavior but does not qualify a method. Use
+     * {@link #isPassed()} for the independently reviewed production-readiness gate.
+     * </p>
+     *
+     * @return true when the report contains at least one benchmark and every numeric check passes
+     */
+    public boolean areAllBenchmarksPassed() {
+      if (benchmarks.isEmpty()) {
+        return false;
+      }
+      for (EngineeringValidationBenchmark benchmark : benchmarks) {
+        if (!benchmark.isPassed()) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /** @return immutable IDs of benchmark cases outside their numeric tolerances */
+    public List<String> getFailedBenchmarkIds() {
+      List<String> failed = new ArrayList<String>();
+      for (EngineeringValidationBenchmark benchmark : benchmarks) {
+        if (!benchmark.isPassed()) {
+          failed.add(benchmark.getId());
+        }
+      }
+      return Collections.unmodifiableList(failed);
+    }
+
+    /** @return immutable benchmark records evaluated by this report */
+    public List<EngineeringValidationBenchmark> getBenchmarks() {
+      return benchmarks;
+    }
+
     public Set<String> getMissingQualifyingMethods() {
       Set<String> missing = new LinkedHashSet<String>(requiredMethods);
       missing.removeAll(qualifyingMethods);
@@ -88,6 +126,7 @@ public final class EngineeringBenchmarkSuite implements Serializable {
 
     public Map<String, Object> toMap() {
       Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", "engineering_benchmark_suite.v1");
       result.put("suiteId", id);
       result.put("revision", revision);
       result.put("requiredMethods", new ArrayList<String>(requiredMethods));
@@ -98,6 +137,8 @@ public final class EngineeringBenchmarkSuite implements Serializable {
         rows.add(benchmark.toMap());
       }
       result.put("benchmarks", rows);
+      result.put("allBenchmarksPassed", Boolean.valueOf(areAllBenchmarksPassed()));
+      result.put("failedBenchmarkIds", new ArrayList<String>(getFailedBenchmarkIds()));
       result.put("passed", Boolean.valueOf(isPassed()));
       result.put("engineeringApprovalRequired", Boolean.TRUE);
       return result;

--- a/src/main/java/neqsim/process/engineering/production/EngineeringValidationBenchmark.java
+++ b/src/main/java/neqsim/process/engineering/production/EngineeringValidationBenchmark.java
@@ -98,6 +98,11 @@ public final class EngineeringValidationBenchmark implements Serializable {
     return new Builder(id, methodId, methodVersion);
   }
 
+  /** @return stable benchmark case identifier */
+  public String getId() {
+    return id;
+  }
+
   public String getMethodId() {
     return methodId;
   }

--- a/src/test/java/neqsim/process/engineering/calculation/StandardDesignKernelVerificationSuiteTest.java
+++ b/src/test/java/neqsim/process/engineering/calculation/StandardDesignKernelVerificationSuiteTest.java
@@ -1,0 +1,71 @@
+package neqsim.process.engineering.calculation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+import neqsim.process.engineering.production.EngineeringBenchmarkSuite;
+import neqsim.process.mechanicaldesign.designstandards.StandardEdition;
+import neqsim.process.mechanicaldesign.designstandards.StandardSupportLevel;
+import neqsim.process.mechanicaldesign.designstandards.StandardType;
+import org.junit.jupiter.api.Test;
+
+/** Regression, unit-equivalence, registry-integrity, and serialization checks for standard kernels. */
+class StandardDesignKernelVerificationSuiteTest {
+  @Test
+  void executesEveryRegisteredKernelWithoutClaimingIndependentQualification() throws Exception {
+    EngineeringBenchmarkSuite.Report report = StandardDesignKernelVerificationSuite.evaluateRegression();
+
+    assertEquals(5, report.getBenchmarks().size());
+    assertTrue(report.areAllBenchmarksPassed(), report.toMap().toString());
+    assertTrue(report.getFailedBenchmarkIds().isEmpty());
+    assertFalse(report.isPassed(), "Regression baselines must not qualify the methods");
+    assertEquals(5, report.getMissingQualifyingMethods().size());
+    assertEquals("engineering_benchmark_suite.v1", report.toMap().get("schemaVersion"));
+    EngineeringBenchmarkSuite.Report restored = roundTrip(report);
+    assertTrue(restored.areAllBenchmarksPassed());
+    assertEquals(report.getRequiredMethods(), restored.getRequiredMethods());
+  }
+
+  @Test
+  void registrySnapshotIsDeterministicImmutableAndInternallyConsistent() throws Exception {
+    Set<StandardType> expected = EnumSet.of(StandardType.API_12J, StandardType.API_521, StandardType.API_526,
+        StandardType.API_610, StandardType.API_617);
+
+    assertEquals(expected, EquipmentDesignKernelRegistry.getRegisteredStandards());
+    assertThrows(UnsupportedOperationException.class,
+        () -> EquipmentDesignKernelRegistry.getRegisteredStandards().clear());
+
+    Set<String> methodKeys = new HashSet<String>();
+    for (StandardType standard : EquipmentDesignKernelRegistry.getRegisteredStandards()) {
+      EquipmentDesignKernelRegistry.Lookup lookup = EquipmentDesignKernelRegistry.lookup(standard);
+      EquipmentDesignKernel<?, ?> kernel = lookup.requireKernel();
+      assertTrue(lookup.isImplemented());
+      assertEquals(standard, kernel.standard());
+      assertTrue(kernel.maturity() != StandardSupportLevel.CATALOGUED);
+      assertTrue(kernel.supports(StandardEdition.defaultEdition(standard)));
+      assertTrue(methodKeys.add(kernel.getMethod() + "@" + kernel.getMethodVersion()), "Duplicate method key");
+      assertNotNull(roundTrip(kernel));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    output.writeObject(value);
+    output.close();
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    T copy = (T) input.readObject();
+    input.close();
+    return copy;
+  }
+}


### PR DESCRIPTION
## Summary
- execute deterministic numeric regression cases for all five registered API design kernels
- verify API 526 SI/customary and API 12J metre/micrometre unit equivalence
- expose immutable registry snapshots and stable benchmark report schema/accessors
- separate numeric regression health from independently reviewed method qualification
- cover registry integrity, method-key uniqueness, default editions, serialization, and API snapshot behavior

## Qualification boundary
Every built-in case is explicitly `REGRESSION_BASELINE`. `areAllBenchmarksPassed()` reports implementation health, while `isPassed()` remains false until independently reviewed non-regression evidence covers every exact `method@version`.

## Verification
- focused Java 8 compilation of the suite, registry, and benchmark infrastructure
- executable smoke run across all five kernels
- numeric baselines, unit equivalence, registry invariants, and Java serialization passed
- repository diff whitespace check

Stacked on #2559.