### PR TITLE
docs: align WellFlow IPR examples with current API

### DIFF
--- a/docs/simulation/well_simulation_guide.md
+++ b/docs/simulation/well_simulation_guide.md
@@ -66,7 +66,7 @@ q/q_max = 1 - 0.2(P_wf/P_res) - 0.8(P_wf/P_res)²
 
 ```java
 // From well test data: 500 Sm³/day at 120 bara, reservoir at 200 bara
-well.setVogelIPR(500.0, 120.0, 200.0);
+well.setVogelParameters(500.0, 120.0, 200.0);
 well.setOutletPressure(100.0, "bara");
 well.solveFlowFromOutletPressure(true);
 well.run();
@@ -81,7 +81,7 @@ q = C × (P_res² - P_wf²)^n
 ```
 
 ```java
-well.setFetkovichIPR(0.012, 0.85);  // C and n coefficients
+well.setFetkovichParameters(0.012, 0.85, 200.0);  // C, n, and reservoir pressure (bara)
 ```
 
 #### 4. Backpressure Equation
@@ -95,7 +95,7 @@ P_res² - P_wf² = A×q + B×q²
 Where A is the Darcy term and B is the non-Darcy (rate-dependent) term.
 
 ```java
-well.setBackpressureIPR(0.5, 0.001);  // A and B coefficients
+well.setBackpressureParameters(0.5, 0.001, 200.0);  // A, B, and reservoir pressure (bara)
 ```
 
 #### 5. Table-Driven IPR
@@ -105,7 +105,7 @@ For measured IPR curves from well tests:
 ```java
 double[] pressures = {50, 80, 100, 120, 150, 180};  // bara
 double[] rates = {2.5, 2.0, 1.6, 1.2, 0.7, 0.2};    // MSm³/day
-well.setTableIPR(pressures, rates);
+well.setTableInflow(pressures, rates);
 ```
 
 #### 6. Loading IPR from CSV File
@@ -658,10 +658,10 @@ System.out.println("Zone C: " + zoneFlows[2] + " MSm³/day");
 | Method                                | Description                  |
 | ------------------------------------- | ---------------------------- |
 | `setWellProductionIndex(pi)`        | Set productivity index       |
-| `setVogelIPR(qTest, pwfTest, pRes)` | Configure Vogel IPR          |
-| `setFetkovichIPR(c, n)`             | Configure Fetkovich IPR      |
-| `setBackpressureIPR(a, b)`          | Configure Backpressure IPR   |
-| `setTableIPR(pwf[], rate[])`        | Set table-driven IPR         |
+| `setVogelParameters(qTest, pwfTest, pRes)` | Configure Vogel IPR       |
+| `setFetkovichParameters(c, n, pRes)`       | Configure Fetkovich IPR   |
+| `setBackpressureParameters(a, b, pRes)`    | Configure Backpressure IPR |
+| `setTableInflow(pwf[], rate[])`            | Set table-driven IPR      |
 | `addLayer(name, stream, pRes, pi)`  | Add reservoir layer          |
 | `getLayerFlowRates(unit)`           | Get layer flow contributions |
 

--- a/docs/simulation/well_simulation_guide.md
+++ b/docs/simulation/well_simulation_guide.md
@@ -81,7 +81,8 @@ q = C × (P_res² - P_wf²)^n
 ```
 
 ```java
-well.setFetkovichParameters(0.012, 0.85, 200.0);  // C, n, and reservoir pressure (bara)
+// C, n, and reservoir pressure (bara)
+well.setFetkovichParameters(0.012, 0.85, 200.0);
 ```
 
 #### 4. Backpressure Equation
@@ -95,7 +96,8 @@ P_res² - P_wf² = A×q + B×q²
 Where A is the Darcy term and B is the non-Darcy (rate-dependent) term.
 
 ```java
-well.setBackpressureParameters(0.5, 0.001, 200.0);  // A, B, and reservoir pressure (bara)
+// A, B, and reservoir pressure (bara)
+well.setBackpressureParameters(0.5, 0.001, 200.0);
 ```
 
 #### 5. Table-Driven IPR


### PR DESCRIPTION
## Summary

- replace four legacy `WellFlow` IPR setter names in the well simulation guide
- supply the required reservoir-pressure argument for Fetkovich and backpressure models
- update the `WellFlow` API summary table to the current method signatures

## Why

The NeqSim-Colab `wellcalcs.ipynb` modernization exposed that the guide calls `setVogelIPR`, `setFetkovichIPR`, `setBackpressureIPR`, and `setTableIPR`, while current `WellFlow` provides `setVogelParameters`, `setFetkovichParameters`, `setBackpressureParameters`, and `setTableInflow`. Copying the published snippets therefore fails at compile time.

## Validation

- compared every corrected signature with current `WellFlow.java` on `master`
- verified the branch is based on current `master`
- docs only: one Markdown file, no production or test code