### PR TITLE
docs: repair PVT simulation overview (D013)

### DIFF
--- a/docs/pvtsimulation/README.md
+++ b/docs/pvtsimulation/README.md
@@ -1,454 +1,116 @@
 ---
 title: PVT Simulation Package
-description: The `pvtsimulation` package provides tools for simulating standard PVT laboratory experiments used in reservoir fluid characterization.
+description: Simulate standard PVT laboratory experiments and reservoir-fluid behaviour with NeqSim.
 ---
 
-# PVT Simulation Package
+The `neqsim.pvtsimulation` package contains compositional simulations for
+reservoir-fluid characterization, laboratory-test reconstruction, and PVT quality
+control. Build and characterize the thermodynamic system first, then give each
+experiment its own clone so that one pressure path does not affect another.
 
-The `pvtsimulation` package provides tools for simulating standard PVT laboratory experiments used in reservoir fluid characterization.
+## Choose a simulation
 
-## Table of Contents
-- [Overview](#overview)
-- [Package Structure](#package-structure)
-- [PVT Experiments](#pvt-experiments)
-- [Usage Examples](#usage-examples)
-- [Integration with Characterization](#integration-with-characterization)
+| Engineering task | Main class | Typical results |
+| --- | --- | --- |
+| Bubble-point or dew-point pressure | `SaturationPressure` | Saturation pressure |
+| Constant-composition expansion (CCE) | `ConstantMassExpansion` | Relative volume, Y-factor, density, and compressibility |
+| Constant-volume depletion (CVD) | `ConstantVolumeDepletion` | Liquid dropout, depletion, Z-factor, and material-balance checks |
+| Differential liberation (DL) | `DifferentialLiberation` | Oil FVF, solution GOR, gas FVF, and oil density |
+| Surface-separation study | `SeparatorTest`, `MultiStageSeparatorTest` | Stage and total GOR, oil FVF, stock-tank density, and API gravity |
+| Injection-gas swelling | `SwellingTest` | Saturation pressure and relative oil volume versus injected gas |
+| Minimum miscibility pressure | `MMPCalculator` | MMP, recovery curve, and interpreted miscibility mechanism |
+| Viscosity pressure sweep | `ViscositySim` | Gas, oil, and aqueous viscosities |
 
----
+The CCE, CVD, DL, single-stage separator, swelling, and viscosity classes use
+`runCalc()`. `SaturationPressure`, `MultiStageSeparatorTest`, and `MMPCalculator`
+use `run()`.
 
-## Overview
+## Runnable multi-stage separator example
 
-**Location:** `neqsim.pvtsimulation`
-
-**Purpose:**
-- Simulate standard PVT laboratory experiments
-- Support fluid characterization workflows
-- Model tuning and regression against lab data
-- Generate PVT reports
-
----
-
-## Package Structure
-
-```
-pvtsimulation/
-├── simulation/                      # PVT experiment simulations
-│   ├── BasePVTsimulation.java       # Base class
-│   ├── SimulationInterface.java     # Interface
-│   │
-│   ├── SaturationPressure.java      # Bubble/dew point
-│   ├── SaturationTemperature.java   # Saturation temperature
-│   │
-│   ├── ConstantMassExpansion.java   # CME experiment
-│   ├── ConstantVolumeDepletion.java # CVD experiment
-│   ├── DifferentialLiberation.java  # DL experiment
-│   │
-│   ├── SeparatorTest.java           # Single separator
-│   ├── MultiStageSeparatorTest.java # Multi-stage separation
-│   │
-│   ├── SwellingTest.java            # Gas injection swelling
-│   ├── SlimTubeSim.java             # Slim tube MMP
-│   ├── MMPCalculator.java           # Minimum miscibility pressure
-│   │
-│   ├── ViscositySim.java            # Viscosity vs pressure
-│   ├── ViscosityWaxOilSim.java      # Wax oil viscosity
-│   ├── DensitySim.java              # Density vs pressure
-│   ├── WaxFractionSim.java          # Wax precipitation
-│   └── GOR.java                     # Gas-oil ratio
-│
-├── regression/                      # Parameter fitting
-│   └── PVTRegression.java
-│
-├── modeltuning/                     # Model tuning
-│   └── ModelTuning.java
-│
-├── reservoirproperties/             # Reservoir calculations
-│   ├── ReservoirProperties.java
-│   ├── materialbalance/             # Inverse material balance & aquifer influx
-│   │   ├── GasMaterialBalance.java      # P/Z line (OGIP), Cole plot, Havlena-Odeh
-│   │   ├── OilMaterialBalance.java      # Havlena-Odeh (OOIP, gas cap, drive indices)
-│   │   └── VanEverdingenHurstAquifer.java # Aquifer influx, Carter-Tracy, AQUTAB
-│   └── relpermeability/             # Relative permeability tables
-│       ├── RelativePermeabilityGenerator.java
-│       ├── RelPermModelFamily.java  # Corey / LET
-│       └── RelPermTableType.java    # SWOF, SGOF, SOF3, SLGOF
-│
-├── util/                            # Utilities
-│   ├── parameterfitting/            # Parameter fitting utilities
-│   │   ├── AsphalteneOnsetFunction.java
-│   │   └── AsphalteneOnsetFitting.java
-│   ├── DeclineCurveAnalysis.java    # Arps + Duong decline; forward + history matching
-│   ├── GasPseudoPressure.java       # Real gas pseudopressure integral
-│   ├── GasPseudoCriticalProperties.java # Pseudocritical Tpc/Ppc correlations
-│   └── PVTUtil.java
-│
-└── flowassurance/                   # Flow assurance analysis
-    ├── AsphalteneStabilityAnalyzer.java
-    ├── DeBoerAsphalteneScreening.java
-    └── AsphalteneMethodComparison.java
-```
-
-### Sub-packages
-
-| Package                               | Documentation                                                                | Description                                                                                                          |
-| ------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `flowassurance`                       | [flowassurance/](flowassurance/)                                             | Asphaltene stability, De Boer screening, CPA onset calculations                                                      |
-| `reservoirproperties.materialbalance` | [reservoir_material_balance.md](reservoir_material_balance.md)               | Gas/oil material balance (OGIP/OOIP, drive indices), Van Everdingen-Hurst / Carter-Tracy aquifer influx, decline history matching |
-| `reservoirproperties.relpermeability` | [relative_permeability.md](relative_permeability.md)                         | Corey and LET relative permeability curve generation, Eclipse table export                                           |
-| `util`                                | [gas_pseudopressure_pseudocritical.md](gas_pseudopressure_pseudocritical.md) | Gas pseudopressure integral, pseudocritical correlations (Standing, Sutton, Piper), Wichert-Aziz acid gas correction |
-
----
-
-## PVT Experiments
-
-### Saturation Pressure
-
-Calculate bubble point or dew point pressure.
+This complete example uses kelvin and bara in the thermodynamic-system
+constructor. `setReservoirConditions` and `addSeparatorStage` use degrees Celsius
+and bara.
 
 ```java
-import neqsim.pvtsimulation.simulation.SaturationPressure;
-
-SystemInterface oil = new SystemSrkEos(373.15, 200.0);
-oil.addComponent("nitrogen", 0.5);
-oil.addComponent("CO2", 2.0);
-oil.addComponent("methane", 40.0);
-oil.addComponent("ethane", 8.0);
-oil.addComponent("propane", 5.0);
-oil.addComponent("n-pentane", 3.0);
-oil.addComponent("n-heptane", 20.0);
-oil.addComponent("n-C10", 21.5);
-oil.setMixingRule("classic");
-
-SaturationPressure satPres = new SaturationPressure(oil);
-satPres.setTemperature(373.15, "K");
-satPres.run();
-
-System.out.println("Saturation pressure: " + satPres.getSaturationPressure() + " bar");
-```
-
-### Constant Mass Expansion (CME)
-
-Simulates isothermal expansion of reservoir fluid, measuring relative volume.
-
-```java
-import neqsim.pvtsimulation.simulation.ConstantMassExpansion;
-
-ConstantMassExpansion cme = new ConstantMassExpansion(oil);
-cme.setTemperature(373.15, "K");
-
-// Set pressure steps
-double[] pressures = {300, 250, 200, 180, 160, 140, 120, 100, 80, 60, 40};
-cme.setPressures(pressures, "bara");
-
-cme.run();
-
-// Get results
-double[] relativeVolumes = cme.getRelativeVolume();
-double[] liquidVolumes = cme.getLiquidRelativeVolume();
-double[] Yvalues = cme.getYfactor();
-double[] densities = cme.getDensity();
-double[] Zfactors = cme.getZfactor();
-
-// Print results
-System.out.println("P (bar)\tVrel\tVliq\tY\tDensity\tZ");
-for (int i = 0; i < pressures.length; i++) {
-    System.out.printf("%.1f\t%.4f\t%.4f\t%.4f\t%.2f\t%.4f%n",
-        pressures[i], relativeVolumes[i], liquidVolumes[i],
-        Yvalues[i], densities[i], Zfactors[i]);
-}
-```
-
-**CME Output Properties:**
-- Relative volume (V/Vsat)
-- Liquid relative volume
-- Y-factor
-- Density
-- Compressibility factor (Z)
-
-### Constant Volume Depletion (CVD)
-
-Simulates gas condensate depletion at constant volume.
-
-```java
-import neqsim.pvtsimulation.simulation.ConstantVolumeDepletion;
-
-SystemInterface condensate = new SystemPrEos(373.15, 400.0);
-// Add components...
-
-ConstantVolumeDepletion cvd = new ConstantVolumeDepletion(condensate);
-cvd.setTemperature(373.15, "K");
-
-double[] pressures = {400, 350, 300, 250, 200, 150, 100, 50};
-cvd.setPressures(pressures, "bara");
-
-cvd.run();
-
-// Results
-double[] liquidDropout = cvd.getLiquidVolumeFraction();
-double[] cumulativeGasProduced = cvd.getCumulativeGasProduced();
-double[] Zfactors = cvd.getZfactor();
-double[] Bg = cvd.getBg();
-```
-
-**CVD Output Properties:**
-- Liquid dropout (volume fraction)
-- Cumulative gas produced
-- Two-phase Z-factor
-- Gas formation volume factor (Bg)
-- Produced gas composition (each step)
-
-### Differential Liberation (DL)
-
-Black oil experiment - gas released at each pressure step.
-
-```java
-import neqsim.pvtsimulation.simulation.DifferentialLiberation;
-
-DifferentialLiberation dl = new DifferentialLiberation(oil);
-dl.setTemperature(373.15, "K");
-
-double[] pressures = {300, 250, 200, 150, 100, 50, 1.01325};
-dl.setPressures(pressures, "bara");
-
-dl.run();
-
-// Results
-double[] Rs = dl.getRs();           // Solution GOR
-double[] Bo = dl.getBo();           // Oil FVF
-double[] oilDensity = dl.getOilDensity();
-double[] oilViscosity = dl.getOilViscosity();
-double[] gasDensity = dl.getGasDensity();
-double[] gasGravity = dl.getGasGravity();
-double[] Bg = dl.getBg();
-
-System.out.println("P (bar)\tRs (Sm3/Sm3)\tBo\tρ_oil (kg/m3)");
-for (int i = 0; i < pressures.length; i++) {
-    System.out.printf("%.1f\t%.2f\t\t%.4f\t%.2f%n",
-        pressures[i], Rs[i], Bo[i], oilDensity[i]);
-}
-```
-
-**DL Output Properties:**
-- Solution GOR (Rs)
-- Oil formation volume factor (Bo)
-- Oil density
-- Oil viscosity
-- Gas gravity
-- Gas formation volume factor (Bg)
-
-### Separator Test
-
-Model surface separation conditions.
-
-```java
-import neqsim.pvtsimulation.simulation.SeparatorTest;
-
-SeparatorTest sepTest = new SeparatorTest(oil);
-
-// Define separator stages
-double[] temperatures = {323.15, 288.15};  // K
-double[] pressures = {50.0, 1.01325};       // bar
-
-sepTest.setSeparatorConditions(temperatures, pressures);
-sepTest.run();
-
-// Results
-double GOR = sepTest.getGOR();
-double Bo = sepTest.getBo();
-double oilDensity = sepTest.getOilDensity();
-double oilMW = sepTest.getOilMolarMass();
-
-System.out.println("GOR: " + GOR + " Sm3/Sm3");
-System.out.println("Bo: " + Bo);
-System.out.println("Stock tank oil density: " + oilDensity + " kg/m3");
-```
-
-### Multi-Stage Separator Test
-
-```java
+import java.util.List;
 import neqsim.pvtsimulation.simulation.MultiStageSeparatorTest;
+import neqsim.pvtsimulation.simulation.MultiStageSeparatorTest.SeparatorStageResult;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
 
-MultiStageSeparatorTest mst = new MultiStageSeparatorTest(oil);
+public final class PvtSeparatorQuickStart {
+  private PvtSeparatorQuickStart() {}
 
-// Configure stages
-mst.addSeparator(50.0, 323.15);   // HP separator
-mst.addSeparator(10.0, 308.15);   // LP separator
-mst.addSeparator(1.01325, 288.15); // Stock tank
+  public static void main(String[] args) {
+    SystemInterface reservoirFluid = new SystemSrkEos(373.15, 300.0);
+    reservoirFluid.addComponent("nitrogen", 0.5);
+    reservoirFluid.addComponent("CO2", 2.0);
+    reservoirFluid.addComponent("methane", 45.0);
+    reservoirFluid.addComponent("ethane", 8.0);
+    reservoirFluid.addComponent("propane", 5.0);
+    reservoirFluid.addComponent("i-butane", 1.5);
+    reservoirFluid.addComponent("n-butane", 2.5);
+    reservoirFluid.addComponent("i-pentane", 1.0);
+    reservoirFluid.addComponent("n-pentane", 1.5);
+    reservoirFluid.addComponent("n-hexane", 3.0);
+    reservoirFluid.addComponent("n-heptane", 30.0);
+    reservoirFluid.setMixingRule("classic");
+    reservoirFluid.setMultiPhaseCheck(true);
 
-mst.run();
+    MultiStageSeparatorTest separatorTest =
+        new MultiStageSeparatorTest(reservoirFluid);
+    separatorTest.setReservoirConditions(300.0, 100.0);
+    separatorTest.addSeparatorStage(50.0, 40.0, "HP separator");
+    separatorTest.addSeparatorStage(10.0, 30.0, "LP separator");
+    separatorTest.addStockTankStage();
+    separatorTest.run();
 
-double[] stageGORs = mst.getStageGOR();
-double totalGOR = mst.getTotalGOR();
+    List<SeparatorStageResult> stages = separatorTest.getStageResults();
+    for (SeparatorStageResult stage : stages) {
+      System.out.printf(
+          "%s: %.3f bara, %.2f C, cumulative GOR %.3f Sm3/Sm3%n",
+          stage.getStageName(), stage.getPressure(), stage.getTemperature(),
+          stage.getCumulativeGOR());
+    }
+
+    System.out.printf("Total GOR: %.3f Sm3/Sm3%n", separatorTest.getTotalGOR());
+    System.out.printf("Oil FVF: %.5f m3/Sm3%n", separatorTest.getBo());
+    System.out.printf(
+        "Stock-tank density: %.2f kg/m3%n",
+        separatorTest.getStockTankOilDensity());
+  }
+}
 ```
 
-### Swelling Test
+The repository test
+`neqsim.pvtsimulation.PvtSimulationDocumentationTest` compiles and executes this
+same workflow. The result magnitudes depend on the fluid characterization and
+equation of state; do not use the example composition as calibrated field data.
 
-Gas injection swelling experiment.
+## Working with laboratory data
 
-```java
-import neqsim.pvtsimulation.simulation.SwellingTest;
+1. Reproduce the laboratory composition, plus-fraction characterization, equation
+   of state, mixing rule, and volume-shift choices.
+2. Use the measured temperature and pressure schedule without silently changing
+   gauge, absolute, standard, or reservoir units.
+3. Run each experiment from a separate clone of the characterized base fluid.
+4. Compare primary observables and material balance before tuning model
+   parameters.
+5. Record the NeqSim version, input composition, characterization settings, and
+   fitted parameters with the result.
 
-SystemInterface injectionGas = new SystemSrkEos(373.15, 200.0);
-injectionGas.addComponent("CO2", 1.0);
-injectionGas.setMixingRule("classic");
+Several simulations expose experimental-data and quality-control methods. Their
+calibration interfaces are experiment-specific; verify the current Java source and
+Javadocs before building an automated regression workflow.
 
-SwellingTest swelling = new SwellingTest(oil);
-swelling.setInjectionGas(injectionGas);
-swelling.setTemperature(373.15, "K");
+## Related documentation
 
-// Injection amounts (moles per mole original oil)
-double[] injectionAmounts = {0.0, 0.1, 0.2, 0.3, 0.4, 0.5};
-swelling.setInjectionAmounts(injectionAmounts);
-
-swelling.run();
-
-double[] saturationPressures = swelling.getSaturationPressures();
-double[] swellingFactors = swelling.getSwellingFactors();
-double[] oilDensities = swelling.getOilDensities();
-```
-
-### MMP Calculation
-
-Minimum miscibility pressure via slim tube simulation.
-
-```java
-import neqsim.pvtsimulation.simulation.MMPCalculator;
-
-MMPCalculator mmp = new MMPCalculator(oil, injectionGas);
-mmp.setTemperature(373.15, "K");
-mmp.run();
-
-double minimumMiscibilityPressure = mmp.getMMP();
-System.out.println("MMP: " + minimumMiscibilityPressure + " bar");
-```
-
----
-
-## Viscosity Simulation
-
-```java
-import neqsim.pvtsimulation.simulation.ViscositySim;
-
-ViscositySim viscSim = new ViscositySim(oil);
-viscSim.setTemperature(373.15, "K");
-
-double[] pressures = {400, 300, 200, 150, 100, 50};
-viscSim.setPressures(pressures, "bara");
-
-viscSim.run();
-
-double[] oilViscosities = viscSim.getOilViscosity();
-double[] gasViscosities = viscSim.getGasViscosity();
-```
-
----
-
-## Integration with Characterization
-
-### Tuning to Lab Data
-
-```java
-import neqsim.pvtsimulation.regression.PVTRegression;
-
-// Set up experiment with measured data
-ConstantMassExpansion cme = new ConstantMassExpansion(oil);
-cme.setExperimentalData(measuredPressures, measuredRelativeVolumes);
-
-// Create regression
-PVTRegression regression = new PVTRegression(oil);
-regression.addExperiment(cme);
-
-// Select parameters to tune
-regression.tuneParameter("C7+", "Tc", 0.95, 1.05);  // ±5%
-regression.tuneParameter("C7+", "Pc", 0.95, 1.05);
-regression.tuneParameter("C7+", "acf", 0.90, 1.10);
-
-// Run regression
-regression.run();
-
-// Get tuned fluid
-SystemInterface tunedOil = regression.getTunedSystem();
-```
-
----
-
-## Complete PVT Study Example
-
-```java
-// Create reservoir oil
-SystemInterface oil = new SystemSrkEos(373.15, 300.0);
-oil.addComponent("nitrogen", 0.5);
-oil.addComponent("CO2", 2.1);
-oil.addComponent("methane", 35.2);
-oil.addComponent("ethane", 7.8);
-oil.addComponent("propane", 5.4);
-oil.addComponent("i-butane", 1.2);
-oil.addComponent("n-butane", 3.1);
-oil.addComponent("i-pentane", 1.5);
-oil.addComponent("n-pentane", 2.1);
-oil.addComponent("n-hexane", 3.5);
-oil.addTBPfraction("C7", 8.2, 96.0 / 1000.0, 0.738);
-oil.addTBPfraction("C10", 12.4, 134.0 / 1000.0, 0.785);
-oil.addTBPfraction("C15", 8.5, 206.0 / 1000.0, 0.835);
-oil.addTBPfraction("C20+", 8.5, 450.0 / 1000.0, 0.920);
-oil.setMixingRule("classic");
-oil.useVolumeCorrection(true);
-
-double reservoirTemp = 373.15;  // K
-
-// 1. Saturation Pressure
-SaturationPressure sat = new SaturationPressure(oil);
-sat.setTemperature(reservoirTemp, "K");
-sat.run();
-double Psat = sat.getSaturationPressure();
-System.out.println("Bubble point: " + Psat + " bar");
-
-// 2. CME
-ConstantMassExpansion cme = new ConstantMassExpansion(oil.clone());
-cme.setTemperature(reservoirTemp, "K");
-double[] cmePressures = generatePressureRange(Psat + 50, 50, 15);
-cme.setPressures(cmePressures, "bara");
-cme.run();
-
-// 3. Differential Liberation
-DifferentialLiberation dl = new DifferentialLiberation(oil.clone());
-dl.setTemperature(reservoirTemp, "K");
-double[] dlPressures = generatePressureRange(Psat, 1.01325, 10);
-dl.setPressures(dlPressures, "bara");
-dl.run();
-
-// 4. Separator Test
-SeparatorTest sep = new SeparatorTest(oil.clone());
-sep.setSeparatorConditions(
-    new double[]{323.15, 288.15},  // Temperatures
-    new double[]{30.0, 1.01325}    // Pressures
-);
-sep.run();
-
-// Print summary
-System.out.println("\n=== PVT Summary ===");
-System.out.println("Bubble point: " + Psat + " bar");
-System.out.println("GOR: " + sep.getGOR() + " Sm3/Sm3");
-System.out.println("Bo at Psat: " + dl.getBo()[0]);
-System.out.println("Oil density at STC: " + sep.getOilDensity() + " kg/m3");
-```
-
----
-
-## Best Practices
-
-1. **Clone fluids** before running multiple experiments
-2. **Use appropriate EoS** for fluid type (CPA for polar, PR for heavy oils)
-3. **Match temperature units** carefully (K vs °C)
-4. **Validate against lab data** before using for field predictions
-5. **Document characterization** for reproducibility
-
----
-
-## Related Documentation
-
-- [PVT Workflow](pvt_workflow) - End-to-end PVT workflow
-- [Fluid Characterization](../thermo/pvt_fluid_characterization) - Heavy end characterization
-- [Black Oil Package](../blackoil/) - Black oil model export
-- [Eclipse E300 Fluid Import](eclipse_e300_fluid_import) - Reading/writing Eclipse E300 fluid files
-- [JSON Fluid Format](json_fluid_format) - JSON-based fluid file format with full EOS fidelity
+- [PVT laboratory-test guide](pvt_lab_tests.md)
+- [Phase-envelope guide](phase_envelope_guide.md)
+- [PVT and fluid characterization](../thermo/pvt_fluid_characterization.md)
+- [Eclipse E300 fluid import](eclipse_e300_fluid_import.md)
+- [NeqSim JSON fluid format](json_fluid_format.md)
+- [Black-oil package](../blackoil/README.md)
+- [Reservoir material balance](reservoir_material_balance.md)
+- [Relative-permeability tables](relative_permeability.md)
+- [Flow-assurance screening](flowassurance/README.md)

--- a/src/test/java/neqsim/pvtsimulation/PvtSimulationDocumentationTest.java
+++ b/src/test/java/neqsim/pvtsimulation/PvtSimulationDocumentationTest.java
@@ -1,0 +1,52 @@
+package neqsim.pvtsimulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.pvtsimulation.simulation.MultiStageSeparatorTest;
+import neqsim.pvtsimulation.simulation.MultiStageSeparatorTest.SeparatorStageResult;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Verifies the executable PVT landing-page example. */
+class PvtSimulationDocumentationTest extends NeqSimTest {
+  @Test
+  void testMultiStageSeparatorQuickStart() {
+    SystemInterface reservoirFluid = new SystemSrkEos(373.15, 300.0);
+    reservoirFluid.addComponent("nitrogen", 0.5);
+    reservoirFluid.addComponent("CO2", 2.0);
+    reservoirFluid.addComponent("methane", 45.0);
+    reservoirFluid.addComponent("ethane", 8.0);
+    reservoirFluid.addComponent("propane", 5.0);
+    reservoirFluid.addComponent("i-butane", 1.5);
+    reservoirFluid.addComponent("n-butane", 2.5);
+    reservoirFluid.addComponent("i-pentane", 1.0);
+    reservoirFluid.addComponent("n-pentane", 1.5);
+    reservoirFluid.addComponent("n-hexane", 3.0);
+    reservoirFluid.addComponent("n-heptane", 30.0);
+    reservoirFluid.setMixingRule("classic");
+    reservoirFluid.setMultiPhaseCheck(true);
+
+    MultiStageSeparatorTest separatorTest = new MultiStageSeparatorTest(reservoirFluid);
+    separatorTest.setReservoirConditions(300.0, 100.0);
+    separatorTest.addSeparatorStage(50.0, 40.0, "HP separator");
+    separatorTest.addSeparatorStage(10.0, 30.0, "LP separator");
+    separatorTest.addStockTankStage();
+    separatorTest.run();
+
+    List<SeparatorStageResult> stages = separatorTest.getStageResults();
+    assertEquals(3, stages.size());
+    assertEquals("HP separator", stages.get(0).getStageName());
+    assertEquals(50.0, stages.get(0).getPressure(), 1.0e-12);
+    assertEquals(40.0, stages.get(0).getTemperature(), 1.0e-12);
+    assertEquals(separatorTest.getTotalGOR(), stages.get(2).getCumulativeGOR(), 0.1);
+    assertTrue(Double.isFinite(separatorTest.getTotalGOR()));
+    assertTrue(separatorTest.getTotalGOR() > 0.0);
+    assertTrue(Double.isFinite(separatorTest.getBo()));
+    assertTrue(separatorTest.getBo() > 1.0);
+    assertTrue(separatorTest.getStockTankOilDensity() > 500.0);
+    assertTrue(separatorTest.getStockTankOilDensity() < 1200.0);
+  }
+}


### PR DESCRIPTION
Closes part of #2499 (D013).

## Frozen scan batch

- `docs/pvtsimulation/README.md`
- `src/test/java/neqsim/pvtsimulation/PvtSimulationDocumentationTest.java`

Excluded: the broader `pvt_workflow.md` and `pvt_lab_tests.md` guides (future bounded batches), notebooks, production code, and files touched by open PR #2566.

## Confirmed defects

| Severity | Evidence and root cause | Fix |
| --- | --- | --- |
| High | Nine Java fragments named missing or renamed methods such as `getZfactor()`, `getCumulativeGasProduced()`, `addSeparator()`, `setInjectionAmounts()`, and undefined `generatePressureRange()`; several also omitted required imports. The page had drifted independently of the current simulation classes. | Replaced the fragments with one complete multi-stage separator program using source-verified APIs. |
| High | The tuning example described a `PVTRegression` orchestration API that does not match current source. | Removed the unsupported workflow and documented experiment-specific calibration boundaries. |
| Medium | CCE, CVD, DL, separator, swelling, and viscosity examples called `run()` although their current entry point is `runCalc()`. | Added an explicit source-verified execution-method map. |
| Medium | Separator temperatures mixed kelvin values with an API documented and implemented in degrees Celsius. | States the constructor and separator-method units explicitly and uses Celsius correctly. |
| Medium | Jekyll front matter was followed by a duplicate H1, which renders twice when `index.md` includes the README. | Removed the duplicate H1 and made the page include-safe. |
| Low | The hand-maintained source tree and marketing-style output lists were stale. | Replaced them with a concise capability table and operational guidance. |

## Regression coverage

`PvtSimulationDocumentationTest` mirrors every API call in the retained Java fence and asserts stage configuration, cumulative/total GOR consistency, finite positive GOR and oil FVF, and a physical stock-tank density range.

## Validation

Completed before publication:

- Current Java source and existing tests inspected for every named simulation class.
- Front matter, headings, Markdown table, code fence, and HTML interaction check: clean.
- Nine internal documentation targets resolved on current `master`.
- Equations: none in this batch; no KaTeX delimiters to validate.
- Images: none.
- External links: none.
- Notebook/Python checks: not applicable.
- Branch comparison: exactly two files, 102/440 documentation lines and one 52-line focused test; branch is a two-commit fast-forward from `fe2d31d`.

Hosted status:

- Windows Java 21 passed the focused `PvtSimulationDocumentationTest` (1 test, 0 failures/errors) and the complete 10,630-test suite (0 failures/errors, 212 skipped).
- Ubuntu Java 21 also passed `PvtSimulationDocumentationTest` (1 test, 0 failures/errors). Its 10,830-test coverage suite had no failures and one unrelated error in `LNGProcessBuilderTest.testSmrRouteRunsAndReportsPerformance`; the D013 test completed before that suite summary.
- Passed: dedicated Spotless workflow, Javadoc, CodeQL, agent-reference verification, Jekyll build, search-source and generated-index coverage, and search JavaScript syntax.
- Mandatory Copilot gate rechecked after the latest head (`e295095`, committed before the review): Copilot reviewed both changed files, produced no inline comments or suggested-change blocks, and no commit applies a Copilot suggestion. No acceptance, rejection, or additional validation action is outstanding.
- The pre-commit run on the original base failed only on `src/test/java/neqsim/process/mechanicaldesign/designstandards/StandardSelectionTest.java`, outside this PR. Current `master` changed that file in merged PR #2566; this branch is one commit behind, remains mergeable, and its diff still contains only the two frozen D013 files.
- The documentation workflow produced no rendered-site artifact or preview. Visual browser inspection is therefore unavailable and is not claimed.

## Before / after

Before: the landing page presents non-compiling snippets and incorrect units/entry points.

After: one complete Java 8 quick start is executable and backed by a focused regression; remaining capability descriptions are tied to current class names without invented calls.

## Next scan scope

D014 should audit `docs/pvtsimulation/pvt_lab_tests.md` as its own bounded batch; it contains separate detailed examples and is intentionally excluded here.