### PR TITLE
Fix black-oil converter phase detection and viscosities

### DIFF
--- a/src/main/java/neqsim/blackoil/BlackOilConverter.java
+++ b/src/main/java/neqsim/blackoil/BlackOilConverter.java
@@ -208,6 +208,7 @@ public class BlackOilConverter {
         SystemInterface oilComp = phaseAsStandaloneSystem(base, oil, Tref, p);
         ThermodynamicOperations oilResOps = new ThermodynamicOperations(oilComp);
         oilResOps.TPflash();
+        oilComp.initPhysicalProperties();
         PhaseInterface oilRes = findOilPhase(oilComp);
         double V_res_liq = (oilRes != null) ? phaseVolume(oilRes) : totalVolume(oilComp);
         double mu_o = (oilRes != null) ? oilRes.getViscosity() : Double.NaN;
@@ -241,6 +242,7 @@ public class BlackOilConverter {
 
         ThermodynamicOperations gasResOps = new ThermodynamicOperations(gasComp);
         gasResOps.TPflash();
+        gasComp.initPhysicalProperties();
         PhaseInterface gasRes = findGasPhase(gasComp);
         double V_res_gas = (gasRes != null) ? phaseVolume(gasRes) : totalVolume(gasComp);
         double mu_g = (gasRes != null) ? gasRes.getViscosity() : Double.NaN;
@@ -271,6 +273,7 @@ public class BlackOilConverter {
         SystemInterface wRes = phaseAsStandaloneSystem(base, wat, Tref, p);
         ThermodynamicOperations wOps = new ThermodynamicOperations(wRes);
         wOps.TPflash();
+        wRes.initPhysicalProperties();
         PhaseInterface wPhase = findWaterPhase(wRes);
         double rho_w_res = (wPhase != null) ? wPhase.getDensity() : Double.NaN;
         double mu_w = (wPhase != null) ? wPhase.getViscosity() : Double.NaN;
@@ -321,7 +324,8 @@ public class BlackOilConverter {
     for (int i = 0; i < s.getNumberOfPhases(); i++) {
       PhaseInterface p = s.getPhase(i);
       String type = safeTypeName(p);
-      if (type.contains("liquid") && hydrocarbonFraction(p) > 1e-6 && !isMostlyWater(p)) {
+      if ((type.contains("liquid") || type.contains("oil")) && hydrocarbonFraction(p) > 1e-6
+          && !isMostlyWater(p)) {
         return p;
       }
     }

--- a/src/main/java/neqsim/blackoil/BlackOilConverter.java
+++ b/src/main/java/neqsim/blackoil/BlackOilConverter.java
@@ -324,7 +324,8 @@ public class BlackOilConverter {
     for (int i = 0; i < s.getNumberOfPhases(); i++) {
       PhaseInterface p = s.getPhase(i);
       String type = safeTypeName(p);
-      if ((type.contains("liquid") || type.contains("oil")) && hydrocarbonFraction(p) > 1e-6 && !isMostlyWater(p)) {
+      if ((type.contains("liquid") || type.equals("oil")) && hydrocarbonFraction(p) > 1e-6
+          && !isMostlyWater(p)) {
         return p;
       }
     }

--- a/src/main/java/neqsim/blackoil/BlackOilConverter.java
+++ b/src/main/java/neqsim/blackoil/BlackOilConverter.java
@@ -208,7 +208,7 @@ public class BlackOilConverter {
         SystemInterface oilComp = phaseAsStandaloneSystem(base, oil, Tref, p);
         ThermodynamicOperations oilResOps = new ThermodynamicOperations(oilComp);
         oilResOps.TPflash();
-        oilComp.initPhysicalProperties();
+        oilComp.initProperties();
         PhaseInterface oilRes = findOilPhase(oilComp);
         double V_res_liq = (oilRes != null) ? phaseVolume(oilRes) : totalVolume(oilComp);
         double mu_o = (oilRes != null) ? oilRes.getViscosity() : Double.NaN;
@@ -242,7 +242,7 @@ public class BlackOilConverter {
 
         ThermodynamicOperations gasResOps = new ThermodynamicOperations(gasComp);
         gasResOps.TPflash();
-        gasComp.initPhysicalProperties();
+        gasComp.initProperties();
         PhaseInterface gasRes = findGasPhase(gasComp);
         double V_res_gas = (gasRes != null) ? phaseVolume(gasRes) : totalVolume(gasComp);
         double mu_g = (gasRes != null) ? gasRes.getViscosity() : Double.NaN;
@@ -273,7 +273,7 @@ public class BlackOilConverter {
         SystemInterface wRes = phaseAsStandaloneSystem(base, wat, Tref, p);
         ThermodynamicOperations wOps = new ThermodynamicOperations(wRes);
         wOps.TPflash();
-        wRes.initPhysicalProperties();
+        wRes.initProperties();
         PhaseInterface wPhase = findWaterPhase(wRes);
         double rho_w_res = (wPhase != null) ? wPhase.getDensity() : Double.NaN;
         double mu_w = (wPhase != null) ? wPhase.getViscosity() : Double.NaN;

--- a/src/main/java/neqsim/blackoil/BlackOilConverter.java
+++ b/src/main/java/neqsim/blackoil/BlackOilConverter.java
@@ -324,8 +324,7 @@ public class BlackOilConverter {
     for (int i = 0; i < s.getNumberOfPhases(); i++) {
       PhaseInterface p = s.getPhase(i);
       String type = safeTypeName(p);
-      if ((type.contains("liquid") || type.contains("oil")) && hydrocarbonFraction(p) > 1e-6
-          && !isMostlyWater(p)) {
+      if ((type.contains("liquid") || type.contains("oil")) && hydrocarbonFraction(p) > 1e-6 && !isMostlyWater(p)) {
         return p;
       }
     }

--- a/src/main/java/neqsim/blackoil/BlackOilConverter.java
+++ b/src/main/java/neqsim/blackoil/BlackOilConverter.java
@@ -324,8 +324,7 @@ public class BlackOilConverter {
     for (int i = 0; i < s.getNumberOfPhases(); i++) {
       PhaseInterface p = s.getPhase(i);
       String type = safeTypeName(p);
-      if ((type.contains("liquid") || type.equals("oil")) && hydrocarbonFraction(p) > 1e-6
-          && !isMostlyWater(p)) {
+      if ((type.contains("liquid") || type.equals("oil")) && hydrocarbonFraction(p) > 1e-6 && !isMostlyWater(p)) {
         return p;
       }
     }

--- a/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
+++ b/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
@@ -65,8 +65,7 @@ class BlackOilConverterTest {
     wetOil.setMultiPhaseCheck(true);
 
     double[] pressures = { 50.0, 100.0, 150.0, 200.0 };
-    BlackOilConverter.Result result =
-        BlackOilConverter.convert(wetOil, 353.15, pressures, 1.01325, 288.15);
+    BlackOilConverter.Result result = BlackOilConverter.convert(wetOil, 353.15, pressures, 1.01325, 288.15);
 
     assertTrue(Double.isFinite(result.rho_w_sc));
     assertTrue(result.rho_w_sc > 0.0);

--- a/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
+++ b/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
@@ -1,0 +1,56 @@
+package neqsim.blackoil;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+
+class BlackOilConverterTest {
+  @Test
+  void testConvertOilProducesFinitePvtProperties() {
+    SystemInterface oil = new SystemPrEos(373.15, 300.0);
+    oil.addComponent("nitrogen", 0.005);
+    oil.addComponent("CO2", 0.010);
+    oil.addComponent("methane", 0.350);
+    oil.addComponent("ethane", 0.070);
+    oil.addComponent("propane", 0.065);
+    oil.addComponent("i-butane", 0.025);
+    oil.addComponent("n-butane", 0.040);
+    oil.addComponent("i-pentane", 0.020);
+    oil.addComponent("n-pentane", 0.025);
+    oil.addComponent("n-hexane", 0.050);
+    oil.addComponent("n-heptane", 0.080);
+    oil.addComponent("n-octane", 0.080);
+    oil.addComponent("n-nonane", 0.060);
+    oil.addComponent("nC10", 0.120);
+    oil.setMixingRule("classic");
+    oil.useVolumeCorrection(true);
+    oil.setMultiPhaseCheck(true);
+
+    double[] pressures = { 25.0, 50.0, 100.0, 150.0, 200.0, 250.0, 300.0 };
+    BlackOilConverter.Result result =
+        BlackOilConverter.convert(oil, 373.15, pressures, 1.01325, 288.15);
+
+    assertNotNull(result);
+    assertNotNull(result.pvt);
+    assertTrue(Double.isFinite(result.rho_o_sc));
+    assertTrue(result.rho_o_sc > 0.0);
+    assertTrue(Double.isFinite(result.rho_g_sc));
+    assertTrue(result.rho_g_sc > 0.0);
+    assertTrue(result.pvt.Rs(100.0) > 0.0);
+
+    for (double pressure : pressures) {
+      assertTrue(Double.isFinite(result.pvt.Bo(pressure)));
+      assertTrue(result.pvt.Bo(pressure) > 0.0);
+      assertTrue(Double.isFinite(result.pvt.Rs(pressure)));
+      assertTrue(result.pvt.Rs(pressure) >= 0.0);
+      assertTrue(Double.isFinite(result.pvt.mu_o(pressure)));
+      assertTrue(result.pvt.mu_o(pressure) > 0.0);
+      assertTrue(Double.isFinite(result.pvt.Bg(pressure)));
+      assertTrue(result.pvt.Bg(pressure) > 0.0);
+      assertTrue(Double.isFinite(result.pvt.mu_g(pressure)));
+      assertTrue(result.pvt.mu_g(pressure) > 0.0);
+    }
+  }
+}

--- a/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
+++ b/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
@@ -29,8 +29,7 @@ class BlackOilConverterTest {
     oil.setMultiPhaseCheck(true);
 
     double[] pressures = { 25.0, 50.0, 100.0, 150.0, 200.0, 250.0, 300.0 };
-    BlackOilConverter.Result result =
-        BlackOilConverter.convert(oil, 373.15, pressures, 1.01325, 288.15);
+    BlackOilConverter.Result result = BlackOilConverter.convert(oil, 373.15, pressures, 1.01325, 288.15);
 
     assertNotNull(result);
     assertNotNull(result.pvt);

--- a/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
+++ b/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
@@ -67,6 +67,8 @@ class BlackOilConverterTest {
     double[] pressures = { 50.0, 100.0, 150.0, 200.0 };
     BlackOilConverter.Result result = BlackOilConverter.convert(wetOil, 353.15, pressures, 1.01325, 288.15);
 
+    assertNotNull(result);
+    assertNotNull(result.pvt);
     assertTrue(Double.isFinite(result.rho_w_sc));
     assertTrue(result.rho_w_sc > 0.0);
     for (double pressure : pressures) {

--- a/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
+++ b/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
 
 class BlackOilConverterTest {
   @Test
@@ -50,6 +51,30 @@ class BlackOilConverterTest {
       assertTrue(result.pvt.Bg(pressure) > 0.0);
       assertTrue(Double.isFinite(result.pvt.mu_g(pressure)));
       assertTrue(result.pvt.mu_g(pressure) > 0.0);
+    }
+  }
+
+  @Test
+  void testConvertWetOilProducesFiniteWaterProperties() {
+    SystemInterface wetOil = new SystemSrkCPAstatoil(353.15, 200.0);
+    wetOil.addComponent("methane", 0.35);
+    wetOil.addComponent("n-heptane", 0.25);
+    wetOil.addComponent("nC10", 0.20);
+    wetOil.addComponent("water", 0.20);
+    wetOil.setMixingRule(10);
+    wetOil.setMultiPhaseCheck(true);
+
+    double[] pressures = { 50.0, 100.0, 150.0, 200.0 };
+    BlackOilConverter.Result result =
+        BlackOilConverter.convert(wetOil, 353.15, pressures, 1.01325, 288.15);
+
+    assertTrue(Double.isFinite(result.rho_w_sc));
+    assertTrue(result.rho_w_sc > 0.0);
+    for (double pressure : pressures) {
+      assertTrue(Double.isFinite(result.pvt.Bw(pressure)));
+      assertTrue(result.pvt.Bw(pressure) > 0.0);
+      assertTrue(Double.isFinite(result.pvt.mu_w(pressure)));
+      assertTrue(result.pvt.mu_w(pressure) > 0.0);
     }
   }
 }


### PR DESCRIPTION
## Summary

- recognize NeqSim's `oil` phase type in `BlackOilConverter`
- initialize physical properties before reading oil, gas, and water viscosities
- add a regression requiring finite positive converted oil and gas PVT properties

## Reproduction

With the public NeqSim 3.16.0 wheel, converting a valid synthetic oil produced an `oil` phase in the EOS flash but returned `rho_o_sc = NaN`, `Rs = 0`, and non-finite or zero oil viscosity. `findOilPhase` only accepted names containing `liquid`, while NeqSim reports the hydrocarbon liquid phase as `oil`. In addition, TP flash alone does not initialize transport models, so viscosity reads remained zero after phase recognition.

## Validation

- reproduced against the public 3.16.0 Python package with OpenJDK 17
- confirmed the EOS phase names are `oil` and `gas` for the regression fluid
- confirmed `initPhysicalProperties()` changes the oil viscosity from zero to a finite positive value
- added `BlackOilConverterTest` covering finite positive surface densities, `Bo`, `Rs`, `Bg`, and phase viscosities across seven pressures
- hosted Spotless patch and PaperLab checks pass for the formatted follow-up commit
- pre-commit now reports only the unrelated existing `StandardSelectionTest.java` formatting drift on `master`; neither changed file is listed
- hosted Java/Javadoc and CodeQL checks are still pending

The automation image contains a JRE but no `javac`; hosted Java and formatting checks are therefore the compilation authority for this draft.