### PR TITLE
Fix SimpleReservoir dynamic simulation example

### DIFF
--- a/docs/simulation/dynamic_simulation_guide.md
+++ b/docs/simulation/dynamic_simulation_guide.md
@@ -288,14 +288,18 @@ comp.runTransient(dt, id);
 
 ```java
 SimpleReservoir reservoir = new SimpleReservoir("Field");
-reservoir.setReservoirFluid(fluid);
-reservoir.setGasVolume(1e9, "Sm3");
+
+// Initial phase volumes are in-situ m³: gas, oil, and water.
+reservoir.setReservoirFluid(fluid, 20.0e6, 0.0, 0.0);
 
 StreamInterface producer = reservoir.addGasProducer("GP-1");
 producer.setFlowRate(5.0, "MSm3/day");
 
-// Run for one day
-reservoir.runTransient(86400, id);
+// Initialize the well stream before the first transient step.
+reservoir.run();
+
+UUID id = UUID.randomUUID();
+reservoir.runTransient(86400.0, id);
 double remainingGas = reservoir.getGasInPlace("Sm3");
 ```
 

--- a/docs/simulation/dynamic_simulation_guide.md
+++ b/docs/simulation/dynamic_simulation_guide.md
@@ -295,10 +295,10 @@ reservoir.setReservoirFluid(fluid, 20.0e6, 0.0, 0.0);
 StreamInterface producer = reservoir.addGasProducer("GP-1");
 producer.setFlowRate(5.0, "MSm3/day");
 
-// Initialize the well stream before the first transient step.
-reservoir.run();
-
 UUID id = UUID.randomUUID();
+
+// Use the same calculation identifier for initialization and the transient step.
+reservoir.run(id);
 reservoir.runTransient(86400.0, id);
 double remainingGas = reservoir.getGasInPlace("Sm3");
 ```


### PR DESCRIPTION
## Summary
- replace obsolete `setReservoirFluid(fluid)` and nonexistent `setGasVolume(...)` calls
- use the current four-volume `setReservoirFluid(...)` API with explicit in-situ m³ units
- initialize the producer stream before the first transient step
- retain the one-day depletion example with an explicit calculation identifier

## Validation
The corrected workflow was exercised through the published NeqSim-Colab reservoir-depletion tutorial against NeqSim 3.16.0, Python 3.12.13, and OpenJDK 17.0.19. The notebook completed sequentially with zero errors and passed material-balance, monotonic-depletion, reinjection, and independent p/z checks.

## Scope
Documentation-only change to `docs/simulation/dynamic_simulation_guide.md`.