### PR TITLE
docs: repair PVT laboratory-test guide (D014)

### DIFF
--- a/docs/pvtsimulation/pvt_lab_tests.md
+++ b/docs/pvtsimulation/pvt_lab_tests.md
@@ -18,7 +18,7 @@ explicitly:
 | EOS constructor temperature | K |
 | EOS constructor pressure | bara |
 | `addTBPfraction` and `addPlusFraction` molar mass | kg/mol |
-| TBP/plus-fraction density | kg/m³ |
+| TBP/plus-fraction density | Specific gravity (numerically g/cm³); kg/m³ inputs are auto-detected and converted |
 | `BasePVTsimulation.setTemperature(value, unit)` | Use `"C"` or `"K"` explicitly |
 | Pressure arrays | bara |
 | `SeparatorTest.setSeparatorConditions` temperature array | K |
@@ -32,7 +32,7 @@ Pseudo-component names must not contain `+`. For example, represent a C20-plus f
 
 | Experiment | Class | Main results |
 | --- | --- | --- |
-| Constant mass expansion (CCE/CME) | `ConstantMassExpansion` | Relative volume, liquid relative volume, gas Z-factor, Y-function |
+| Constant mass expansion (CCE/CME) | `ConstantMassExpansion` | Relative volume, liquid volume as percent of saturation volume, gas Z-factor, Y-function |
 | Constant volume depletion (CVD) | `ConstantVolumeDepletion` | Saturation pressure, relative volume, liquid dropout, cumulative mole-percent depletion |
 | Differential liberation (DL) | `DifferentialLiberation` | Saturation pressure, Bo, Bg, Rs, oil density, gas Z-factor |
 | Legacy separator test | `SeparatorTest` | Per-stage GOR and oil formation-volume factor arrays |
@@ -49,11 +49,16 @@ This complete Java example uses SI molar masses for every characterized fraction
 pressure schedule and returned arrays share the same index.
 
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.pvtsimulation.simulation.ConstantMassExpansion;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
 public final class ConstantMassExpansionExample {
+  private static final Logger logger =
+      LogManager.getLogger(ConstantMassExpansionExample.class);
+
   private ConstantMassExpansionExample() {}
 
   public static void main(String[] args) {
@@ -102,12 +107,10 @@ public final class ConstantMassExpansionExample {
     double[] yFunction = cce.getYfactor();
 
     for (int i = 0; i < pressuresBara.length; i++) {
-      System.out.printf(
-          "%7.1f bara  Vrel=%8.5f  Vliq,rel=%8.5f  Zgas=%8.5f  Y=%8.5f%n",
-          pressuresBara[i], relativeVolume[i], liquidRelativeVolume[i], gasZ[i],
-          yFunction[i]);
+      logger.info("{} bara: Vrel={}, Vliq={} %, Zgas={}, Y={}", pressuresBara[i],
+          relativeVolume[i], liquidRelativeVolume[i], gasZ[i], yFunction[i]);
     }
-    System.out.printf("Saturation pressure: %.3f bara%n", cce.getSaturationPressure());
+    logger.info("Saturation pressure: {} bara", cce.getSaturationPressure());
   }
 }
 ```
@@ -171,4 +174,3 @@ depend on the fluid, available measurements, and intended prediction range.
 - [Fluid characterization](../thermo/pvt_fluid_characterization.md)
 - [Thermodynamic models](../thermo/thermodynamic_models.md)
 - [Phase-envelope guide](phase_envelope_guide.md)
-

--- a/docs/pvtsimulation/pvt_lab_tests.md
+++ b/docs/pvtsimulation/pvt_lab_tests.md
@@ -1,455 +1,174 @@
 ---
-title: PVT Lab Test Simulations
-description: Guide to simulating standard PVT laboratory experiments in NeqSim including CCE, CVD, differential liberation, separator tests, swelling tests, and viscosity measurements.
+title: PVT Laboratory-Test Simulations
+description: Current NeqSim APIs, units, and an executable constant-mass-expansion example
 ---
 
-# PVT Lab Test Simulations
+NeqSim can reproduce common pressure-volume-temperature (PVT) laboratory experiments with
+an equation-of-state fluid. Use measured composition and characterized heavy fractions as
+the starting point, then compare simulated and measured values at the same temperature and
+pressure schedule.
 
-This guide demonstrates how to simulate standard PVT laboratory experiments using NeqSim. These simulations are essential for validating EoS parameters against lab data and characterizing reservoir fluids.
+## Units and naming
 
-## Overview
+The simulation classes do not all use the same setter signatures. Apply these conventions
+explicitly:
 
-| Test | Abbreviation | Fluid Type | Purpose |
-|------|--------------|------------|---------|
-| Constant Composition Expansion | CCE | Oil, Gas, Condensate | Saturation pressure, compressibility |
-| Constant Volume Depletion | CVD | Gas Condensate | Liquid dropout, gas composition |
-| Differential Liberation | DL | Black Oil | Bo, Rs, GOR vs pressure |
-| Separator Test | SEP | All | GOR, FVF at separator conditions |
-| Swelling Test | SWT | Oil + Gas | MMP, oil swelling with gas injection |
-| Viscosity vs Pressure | VIS | All | μo, μg behavior |
+| Quantity | Convention |
+| --- | --- |
+| EOS constructor temperature | K |
+| EOS constructor pressure | bara |
+| `addTBPfraction` and `addPlusFraction` molar mass | kg/mol |
+| TBP/plus-fraction density | kg/m³ |
+| `BasePVTsimulation.setTemperature(value, unit)` | Use `"C"` or `"K"` explicitly |
+| Pressure arrays | bara |
+| `SeparatorTest.setSeparatorConditions` temperature array | K |
+| `ViscositySim.setTemperaturesAndPressures` temperature array | K |
+| `ViscositySim` viscosity outputs | Pa·s; multiply by 1000 for cP |
 
----
+Pseudo-component names must not contain `+`. For example, represent a C20-plus fraction as
+`"C20"`, not `"C20+"`.
 
-## Constant Composition Expansion (CCE)
+## Supported experiments
 
-CCE measures fluid behavior above and below the saturation pressure at constant temperature.
+| Experiment | Class | Main results |
+| --- | --- | --- |
+| Constant mass expansion (CCE/CME) | `ConstantMassExpansion` | Relative volume, liquid relative volume, gas Z-factor, Y-function |
+| Constant volume depletion (CVD) | `ConstantVolumeDepletion` | Saturation pressure, relative volume, liquid dropout, cumulative mole-percent depletion |
+| Differential liberation (DL) | `DifferentialLiberation` | Saturation pressure, Bo, Bg, Rs, oil density, gas Z-factor |
+| Legacy separator test | `SeparatorTest` | Per-stage GOR and oil formation-volume factor arrays |
+| Swelling test | `SwellingTest` | Pressure and relative-oil-volume arrays |
+| Pressure/temperature viscosity grid | `ViscositySim` | Gas, oil, and aqueous viscosity arrays in Pa·s |
 
-### What CCE Measures
+`SwellingTest` does not calculate minimum miscibility pressure (MMP). Determine MMP with a
+dedicated slim-tube or multi-contact workflow; do not infer it from the swelling-factor
+curve alone.
 
-- Bubble point or dew point pressure
-- Relative volume vs pressure
-- Liquid compressibility above Pb
-- Two-phase compressibility below Pb
+## Executable constant-mass-expansion example
 
-### Java Implementation
+This complete Java example uses SI molar masses for every characterized fraction. The
+pressure schedule and returned arrays share the same index.
 
 ```java
 import neqsim.pvtsimulation.simulation.ConstantMassExpansion;
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
-// Create reservoir fluid
-SystemSrkEos fluid = new SystemSrkEos(373.15, 300.0);  // Reservoir T, high P
-fluid.addComponent("nitrogen", 0.005);
-fluid.addComponent("CO2", 0.015);
-fluid.addComponent("methane", 0.45);
-fluid.addComponent("ethane", 0.08);
-fluid.addComponent("propane", 0.05);
-fluid.addComponent("i-butane", 0.02);
-fluid.addComponent("n-butane", 0.03);
-fluid.addComponent("i-pentane", 0.015);
-fluid.addComponent("n-pentane", 0.02);
-fluid.addComponent("n-hexane", 0.025);
-fluid.addTBPfraction("C7", 0.05, 95.0, 0.72);
-fluid.addTBPfraction("C10", 0.08, 135.0, 0.78);
-fluid.addTBPfraction("C15", 0.06, 200.0, 0.82);
-fluid.addTBPfraction("C20+", 0.10, 350.0, 0.88);
-fluid.setMixingRule("classic");
-fluid.setMultiPhaseCheck(true);
-
-// Set up CCE test
-ConstantMassExpansion cce = new ConstantMassExpansion(fluid);
-cce.setTemperature(100.0, "C");  // Test temperature
-
-// Define pressure steps
-double[] pressures = {400, 350, 300, 280, 260, 240, 220, 200, 180, 160, 140, 120, 100};
-cce.setPressures(pressures, "bara");
-
-// Run CCE
-cce.runCalc();
-
-// Get results
-System.out.println("=== CCE Results at 100°C ===");
-System.out.println("Pressure (bara) | Rel. Volume | Liquid Vol%");
-System.out.println("----------------|-------------|------------");
-
-double[] relVol = cce.getRelativeVolume();
-double[] liquidVol = cce.getLiquidVolume();
-double saturationP = cce.getSaturationPressure();
-
-for (int i = 0; i < pressures.length; i++) {
-    System.out.printf("%15.1f | %11.4f | %10.2f%n",
-        pressures[i], relVol[i], liquidVol[i] * 100);
-}
-
-System.out.printf("%nSaturation Pressure: %.1f bara%n", saturationP);
-```
-
-### Python Implementation
-
-```python
-from neqsim import jneqsim
-
-SystemSrkEos = jneqsim.thermo.system.SystemSrkEos
-ConstantMassExpansion = jneqsim.pvtsimulation.simulation.ConstantMassExpansion
-
-# Create fluid
-fluid = SystemSrkEos(273.15 + 100.0, 300.0)
-fluid.addComponent("methane", 0.50)
-fluid.addComponent("ethane", 0.10)
-fluid.addComponent("propane", 0.08)
-fluid.addComponent("n-butane", 0.05)
-fluid.addComponent("n-pentane", 0.04)
-fluid.addTBPfraction("C7+", 0.23, 150.0, 0.80)
-fluid.setMixingRule("classic")
-
-# Run CCE
-cce = ConstantMassExpansion(fluid)
-cce.setTemperature(100.0, "C")
-
-pressures = [350.0, 300.0, 250.0, 200.0, 180.0, 160.0, 140.0, 120.0, 100.0]
-cce.setPressures(pressures, "bara")
-cce.runCalc()
-
-print(f"Saturation pressure: {cce.getSaturationPressure():.1f} bara")
-```
-
----
-
-## Constant Volume Depletion (CVD)
-
-CVD simulates gas condensate reservoir depletion by removing gas at constant volume.
-
-### What CVD Measures
-
-- Liquid dropout curve (retrograde condensation)
-- Gas production rate vs pressure
-- Produced gas composition changes
-- Cumulative recovery
-
-### Java Implementation
-
-```java
-import neqsim.pvtsimulation.simulation.ConstantVolumeDepletion;
-import neqsim.thermo.system.SystemSrkEos;
-
-// Rich gas condensate
-SystemSrkEos fluid = new SystemSrkEos(373.15, 400.0);
-fluid.addComponent("nitrogen", 0.02);
-fluid.addComponent("CO2", 0.03);
-fluid.addComponent("methane", 0.70);
-fluid.addComponent("ethane", 0.08);
-fluid.addComponent("propane", 0.05);
-fluid.addComponent("i-butane", 0.015);
-fluid.addComponent("n-butane", 0.025);
-fluid.addComponent("i-pentane", 0.01);
-fluid.addComponent("n-pentane", 0.015);
-fluid.addTBPfraction("C7+", 0.055, 120.0, 0.76);
-fluid.setMixingRule("classic");
-
-// CVD test
-ConstantVolumeDepletion cvd = new ConstantVolumeDepletion(fluid);
-cvd.setTemperature(100.0, "C");
-
-double[] pressures = {400, 350, 300, 250, 200, 150, 100, 50};
-cvd.setPressures(pressures, "bara");
-
-cvd.runCalc();
-
-// Results
-System.out.println("=== CVD Results ===");
-System.out.println("Pressure | Liquid Dropout | Z-factor | Gas Produced");
-System.out.println("(bara)   | (vol%)         |          | (mol%)");
-System.out.println("---------------------------------------------------------");
-
-double[] liquidDropout = cvd.getLiquidVolume();  // Liquid volume %
-double[] zFactor = cvd.getZfactor();
-double[] gasProduced = cvd.getCumulativeGasProduced();
-
-for (int i = 0; i < pressures.length; i++) {
-    System.out.printf("%8.0f | %14.2f | %8.4f | %11.2f%n",
-        pressures[i], liquidDropout[i], zFactor[i], gasProduced[i] * 100);
-}
-
-System.out.printf("%nDew Point Pressure: %.1f bara%n", cvd.getDewPointPressure());
-System.out.printf("Maximum Liquid Dropout: %.2f%% at %.0f bara%n",
-    cvd.getMaxLiquidVolume(), cvd.getPressureAtMaxLiquid());
-```
-
----
-
-## Differential Liberation (DL)
-
-DL simulates oil reservoir depletion by removing all gas at each pressure step.
-
-### What DL Measures
-
-- Oil formation volume factor (Bo)
-- Solution gas-oil ratio (Rs)
-- Gas formation volume factor (Bg)
-- Oil and gas density vs pressure
-
-### Java Implementation
-
-```java
-import neqsim.pvtsimulation.simulation.DifferentialLiberation;
-import neqsim.thermo.system.SystemSrkEos;
-
-// Black oil
-SystemSrkEos fluid = new SystemSrkEos(373.15, 300.0);
-fluid.addComponent("nitrogen", 0.002);
-fluid.addComponent("CO2", 0.008);
-fluid.addComponent("methane", 0.30);
-fluid.addComponent("ethane", 0.06);
-fluid.addComponent("propane", 0.04);
-fluid.addComponent("i-butane", 0.015);
-fluid.addComponent("n-butane", 0.025);
-fluid.addComponent("i-pentane", 0.01);
-fluid.addComponent("n-pentane", 0.015);
-fluid.addComponent("n-hexane", 0.02);
-fluid.addTBPfraction("C7", 0.08, 100.0, 0.74);
-fluid.addTBPfraction("C10", 0.10, 140.0, 0.78);
-fluid.addTBPfraction("C15", 0.10, 210.0, 0.83);
-fluid.addTBPfraction("C25+", 0.22, 400.0, 0.90);
-fluid.setMixingRule("classic");
-
-// DL test
-DifferentialLiberation dl = new DifferentialLiberation(fluid);
-dl.setTemperature(100.0, "C");
-
-double[] pressures = {300, 250, 200, 180, 160, 140, 120, 100, 80, 60, 40, 20, 1};
-dl.setPressures(pressures, "bara");
-
-dl.runCalc();
-
-// Results
-System.out.println("=== Differential Liberation Results at 100°C ===");
-System.out.println("Pressure | Bo      | Rs        | Bg        | Oil ρ    | Gas ρ");
-System.out.println("(bara)   | (m3/m3) | (Sm3/Sm3) | (m3/Sm3)  | (kg/m3)  | (kg/m3)");
-System.out.println("--------------------------------------------------------------");
-
-double[] Bo = dl.getBo();
-double[] Rs = dl.getRs();
-double[] Bg = dl.getBg();
-double[] oilDensity = dl.getOilDensity("kg/m3");
-double[] gasDensity = dl.getGasDensity("kg/m3");
-
-for (int i = 0; i < pressures.length; i++) {
-    System.out.printf("%8.0f | %7.4f | %9.1f | %9.5f | %8.1f | %7.2f%n",
-        pressures[i], Bo[i], Rs[i], Bg[i], oilDensity[i], gasDensity[i]);
-}
-
-System.out.printf("%nBubble Point: %.1f bara%n", dl.getBubblePointPressure());
-System.out.printf("Bo at Pb: %.4f m3/m3%n", dl.getBoAtBubblePoint());
-System.out.printf("Rs at Pb: %.1f Sm3/Sm3%n", dl.getRsAtBubblePoint());
-```
-
----
-
-## Separator Test
-
-Separator tests simulate field separation to determine GOR and FVF at specific conditions.
-
-### Java Implementation
-
-```java
-import neqsim.pvtsimulation.simulation.SeparatorTest;
-import neqsim.thermo.system.SystemSrkEos;
-
-// Reservoir fluid at bubble point
-SystemSrkEos fluid = new SystemSrkEos(373.15, 250.0);
-fluid.addComponent("methane", 0.40);
-fluid.addComponent("ethane", 0.08);
-fluid.addComponent("propane", 0.06);
-fluid.addComponent("n-butane", 0.04);
-fluid.addComponent("n-pentane", 0.03);
-fluid.addComponent("n-hexane", 0.03);
-fluid.addTBPfraction("C7+", 0.36, 180.0, 0.82);
-fluid.setMixingRule("classic");
-
-// 2-stage separator test
-SeparatorTest sepTest = new SeparatorTest(fluid);
-
-// Stage 1: HP separator
-sepTest.setSeparatorTemperature(0, 60.0, "C");
-sepTest.setSeparatorPressure(0, 40.0, "bara");
-
-// Stage 2: LP separator (stock tank)
-sepTest.setSeparatorTemperature(1, 15.0, "C");
-sepTest.setSeparatorPressure(1, 1.01325, "bara");
-
-sepTest.runCalc();
-
-// Results
-System.out.println("=== Separator Test Results ===");
-System.out.printf("Stage 1: P=40 bara, T=60°C%n");
-System.out.printf("  GOR: %.0f Sm3/Sm3%n", sepTest.getGOR(0));
-
-System.out.printf("Stage 2: P=1.01 bara, T=15°C%n");
-System.out.printf("  GOR: %.0f Sm3/Sm3%n", sepTest.getGOR(1));
-
-System.out.printf("%nTotal GOR: %.0f Sm3/Sm3%n", sepTest.getTotalGOR());
-System.out.printf("Oil FVF (Bo): %.4f Rm3/Sm3%n", sepTest.getBo());
-System.out.printf("Stock tank oil density: %.1f kg/m3%n", sepTest.getOilDensity("kg/m3"));
-System.out.printf("Stock tank API gravity: %.1f°%n", sepTest.getAPIgravity());
-```
-
----
-
-## Swelling Test
-
-Swelling tests measure oil volume change when gas is injected (used for EOR evaluation).
-
-### Java Implementation
-
-```java
-import neqsim.pvtsimulation.simulation.SwellingTest;
-import neqsim.thermo.system.SystemPrEos;
-
-// Reservoir oil
-SystemPrEos oil = new SystemPrEos(373.15, 200.0);
-oil.addComponent("methane", 0.25);
-oil.addComponent("ethane", 0.05);
-oil.addComponent("propane", 0.04);
-oil.addComponent("n-butane", 0.03);
-oil.addComponent("n-pentane", 0.03);
-oil.addTBPfraction("C7+", 0.60, 220.0, 0.84);
-oil.setMixingRule("classic");
-
-// Injection gas (CO2 for EOR)
-SystemPrEos gas = new SystemPrEos(373.15, 200.0);
-gas.addComponent("CO2", 1.0);
-gas.setMixingRule("classic");
-
-// Swelling test
-SwellingTest swelling = new SwellingTest(oil);
-swelling.setInjectionGas(gas);
-swelling.setTemperature(100.0, "C");
-
-// Injection amounts (mol% of original oil)
-double[] injectionMol = {0, 5, 10, 15, 20, 25, 30, 35, 40};
-swelling.setInjectedMoles(injectionMol);
-
-swelling.runCalc();
-
-// Results
-System.out.println("=== Swelling Test (CO2 Injection) ===");
-System.out.println("CO2 Added | Swelling Factor | Sat. Pressure");
-System.out.println("(mol%)    | (vol/vol)       | (bara)");
-System.out.println("------------------------------------------");
-
-double[] swellingFactor = swelling.getSwellingFactor();
-double[] satPressure = swelling.getSaturationPressure();
-
-for (int i = 0; i < injectionMol.length; i++) {
-    System.out.printf("%9.0f | %15.4f | %12.1f%n",
-        injectionMol[i], swellingFactor[i], satPressure[i]);
-}
-
-System.out.printf("%nMMP (est): %.1f bara%n", swelling.getMMP());
-```
-
----
-
-## Viscosity Measurements
-
-### Dead Oil Viscosity vs Temperature
-
-```java
-import neqsim.pvtsimulation.simulation.ViscositySimulation;
-import neqsim.thermo.system.SystemSrkEos;
-
-// Dead oil (no dissolved gas)
-SystemSrkEos deadOil = new SystemSrkEos(298.15, 1.0);
-deadOil.addComponent("n-hexane", 0.05);
-deadOil.addTBPfraction("C7", 0.10, 100.0, 0.74);
-deadOil.addTBPfraction("C10", 0.20, 140.0, 0.78);
-deadOil.addTBPfraction("C15", 0.25, 210.0, 0.83);
-deadOil.addTBPfraction("C25+", 0.40, 400.0, 0.90);
-deadOil.setMixingRule("classic");
-
-// Viscosity vs temperature
-ViscositySimulation visSim = new ViscositySimulation(deadOil);
-visSim.setPressure(1.0, "bara");
-
-double[] temperatures = {20, 40, 60, 80, 100, 120, 140};
-visSim.setTemperatures(temperatures, "C");
-
-visSim.runCalc();
-
-System.out.println("=== Dead Oil Viscosity vs Temperature ===");
-System.out.println("Temperature | Viscosity");
-System.out.println("(°C)        | (cP)");
-System.out.println("-------------------------");
-
-double[] viscosity = visSim.getViscosity("cP");
-for (int i = 0; i < temperatures.length; i++) {
-    System.out.printf("%11.0f | %9.2f%n", temperatures[i], viscosity[i]);
+public final class ConstantMassExpansionExample {
+  private ConstantMassExpansionExample() {}
+
+  public static void main(String[] args) {
+    SystemInterface fluid = new SystemSrkEos(370.65, 350.0);
+    fluid.addComponent("nitrogen", 0.39);
+    fluid.addComponent("CO2", 0.30);
+    fluid.addComponent("methane", 40.20);
+    fluid.addComponent("ethane", 7.61);
+    fluid.addComponent("propane", 7.95);
+    fluid.addComponent("i-butane", 1.19);
+    fluid.addComponent("n-butane", 4.08);
+    fluid.addComponent("i-pentane", 1.39);
+    fluid.addComponent("n-pentane", 2.15);
+    fluid.addComponent("n-hexane", 2.79);
+    fluid.addTBPfraction("C7", 4.28, 95.0 / 1000.0, 0.729);
+    fluid.addTBPfraction("C8", 4.31, 106.0 / 1000.0, 0.749);
+    fluid.addTBPfraction("C9", 3.08, 121.0 / 1000.0, 0.770);
+    fluid.addTBPfraction("C10", 2.47, 135.0 / 1000.0, 0.786);
+    fluid.addTBPfraction("C11", 1.91, 148.0 / 1000.0, 0.792);
+    fluid.addTBPfraction("C12", 1.69, 161.0 / 1000.0, 0.804);
+    fluid.addTBPfraction("C13", 1.59, 175.0 / 1000.0, 0.819);
+    fluid.addTBPfraction("C14", 1.22, 196.0 / 1000.0, 0.833);
+    fluid.addTBPfraction("C15", 1.25, 206.0 / 1000.0, 0.836);
+    fluid.addTBPfraction("C16", 1.00, 225.0 / 1000.0, 0.843);
+    fluid.addTBPfraction("C17", 0.99, 236.0 / 1000.0, 0.840);
+    fluid.addTBPfraction("C18", 0.92, 245.0 / 1000.0, 0.846);
+    fluid.addTBPfraction("C19", 0.60, 265.0 / 1000.0, 0.857);
+    fluid.addPlusFraction("C20", 6.64, 453.0 / 1000.0, 0.918);
+    fluid.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12);
+    fluid.getCharacterization().characterisePlusFraction();
+    fluid.setMixingRule("classic");
+
+    double[] pressuresBara = {
+      351.4, 323.2, 301.5, 275.9, 250.1, 226.1, 205.9, 197.3,
+      189.3, 183.3, 165.0, 131.2, 108.3, 85.3, 55.6
+    };
+
+    ConstantMassExpansion cce = new ConstantMassExpansion(fluid);
+    cce.setTemperature(97.5, "C");
+    cce.setPressures(pressuresBara);
+    cce.runCalc();
+
+    double[] relativeVolume = cce.getRelativeVolume();
+    double[] liquidRelativeVolume = cce.getLiquidRelativeVolume();
+    double[] gasZ = cce.getZgas();
+    double[] yFunction = cce.getYfactor();
+
+    for (int i = 0; i < pressuresBara.length; i++) {
+      System.out.printf(
+          "%7.1f bara  Vrel=%8.5f  Vliq,rel=%8.5f  Zgas=%8.5f  Y=%8.5f%n",
+          pressuresBara[i], relativeVolume[i], liquidRelativeVolume[i], gasZ[i],
+          yFunction[i]);
+    }
+    System.out.printf("Saturation pressure: %.3f bara%n", cce.getSaturationPressure());
+  }
 }
 ```
 
-### Live Oil Viscosity vs Pressure
+The focused documentation regression executes this example and checks representative
+finite values and array lengths. Treat calculated values as model results, not laboratory
+measurements.
 
-```java
-// Live oil viscosity below bubble point
-ViscositySimulation visSim = new ViscositySimulation(liveOil);
-visSim.setTemperature(100.0, "C");
+## Current API map
 
-double[] pressures = {250, 200, 180, 160, 140, 120, 100, 80, 60, 40, 20};
-visSim.setPressures(pressures, "bara");
+### Constant volume depletion
 
-visSim.runCalc();
+Configure `ConstantVolumeDepletion` with `setTemperature`, `setPressures`, and `runCalc`.
+Read `getSaturationPressure`, `getRelativeVolume`, `getLiquidRelativeVolume`,
+`getCummulativeMolePercDepleted`, `getZmix`, and `getZgas`. The spelling
+`getCummulativeMolePercDepleted` is the current compatibility API.
 
-System.out.println("=== Live Oil Viscosity vs Pressure at 100°C ===");
-System.out.println("Pressure | Oil μ   | Gas μ");
-System.out.println("(bara)   | (cP)    | (cP)");
-System.out.println("----------------------------");
+### Differential liberation
 
-double[] oilVis = visSim.getOilViscosity("cP");
-double[] gasVis = visSim.getGasViscosity("cP");
+Configure `DifferentialLiberation` with `setTemperature`, `setPressures`, and `runCalc`.
+Read `getSaturationPressure`, `getBo`, `getBg`, `getRs`, `getOilDensity`, `getZgas`, and
+`getRelGasGravity`. Result arrays align with the pressure schedule.
 
-for (int i = 0; i < pressures.length; i++) {
-    System.out.printf("%8.0f | %7.3f | %6.4f%n", pressures[i], oilVis[i], gasVis[i]);
-}
-```
+### Separator tests
 
----
+The legacy `SeparatorTest` accepts all stages in one call:
+`setSeparatorConditions(temperaturesK, pressuresBara)`. After `runCalc`, read the per-stage
+arrays from `getGOR` and `getBofactor`. For named stages, reservoir-condition handling,
+stock-tank results, and cumulative GOR, prefer `MultiStageSeparatorTest`; see the
+[PVT simulation overview](README.md).
 
-## Tuning EoS to Lab Data
+### Swelling tests
 
-When simulation results don't match lab data:
+Set the injection fluid with `setInjectionGas`, supply cumulative injected-gas mole
+percentages with `setCummulativeMolePercentGasInjected`, and call `runCalc`. Read the
+pressure and relative-oil-volume arrays from `getPressures` and `getRelativeOilVolume`.
 
-### Volume Translation
+### Viscosity grids
 
-```java
-// Adjust volume translation to match liquid density
-fluid.getComponent("C7+").setVolumeCorrectionT(0.02);  // Peneloux correction
-```
+`ViscositySim.setTemperaturesAndPressures(temperaturesK, pressuresBara)` defines paired
+states. After `runCalc`, use `getGasViscosity`, `getOilViscosity`, and
+`getAqueousViscosity`. These arrays are in Pa·s.
 
-### Binary Interaction Parameters
+## Calibration workflow
 
-```java
-// Adjust kij for CO2-hydrocarbon interactions
-fluid.setMixingRule(2);  // Classic with tuned kij
-fluid.getPhase(0).setKij(
-    fluid.getComponent("CO2").getComponentNumber(),
-    fluid.getComponent("methane").getComponentNumber(),
-    0.12  // Tuned kij value
-);
-```
+Calibrate a fluid only against traceable measurements and keep a separate validation set.
+A practical sequence is:
 
-### Plus Fraction Characterization
+1. Verify composition, component names, molar-mass units, densities, and test conditions.
+2. Characterize the plus fraction and freeze the chosen lumping scheme.
+3. Compare untuned saturation pressure and volumetric trends with measurements.
+4. Adjust only physically justified characterization or interaction parameters.
+5. Re-run every experiment and report residuals, parameter bounds, and validation results.
 
-```java
-// Split C7+ into more pseudo-components
-CharacterisationTBP char = new CharacterisationTBP(fluid);
-char.setNumberOfPseudocomponents(10);
-char.characterisePlusFraction();
-```
+There is no universal one-call tuning recipe for all PVT experiments. Regression choices
+depend on the fluid, available measurements, and intended prediction range.
 
----
+## See also
 
-## See Also
+- [PVT simulation overview](README.md)
+- [Fluid characterization](../thermo/pvt_fluid_characterization.md)
+- [Thermodynamic models](../thermo/thermodynamic_models.md)
+- [Phase-envelope guide](phase_envelope_guide.md)
 
-- [Fluid Characterization](../wiki/fluid_characterization) - Plus fraction characterization
-- [Thermodynamic Models](../thermo/thermodynamic_models) - EoS selection
-- [Phase Envelope Guide](../pvtsimulation/phase_envelope_guide) - PT diagrams

--- a/docs/pvtsimulation/pvt_lab_tests.md
+++ b/docs/pvtsimulation/pvt_lab_tests.md
@@ -33,7 +33,7 @@ Pseudo-component names must not contain `+`. For example, represent a C20-plus f
 | Experiment | Class | Main results |
 | --- | --- | --- |
 | Constant mass expansion (CCE/CME) | `ConstantMassExpansion` | Relative volume, liquid volume as percent of saturation volume, gas Z-factor, Y-function |
-| Constant volume depletion (CVD) | `ConstantVolumeDepletion` | Saturation pressure, relative volume, liquid dropout, cumulative mole-percent depletion |
+| Constant volume depletion (CVD) | `ConstantVolumeDepletion` | Saturation pressure, relative volume, liquid volume as percent of saturation volume, cumulative mole-percent depletion |
 | Differential liberation (DL) | `DifferentialLiberation` | Saturation pressure, Bo, Bg, Rs, oil density, gas Z-factor |
 | Legacy separator test | `SeparatorTest` | Per-stage GOR and oil formation-volume factor arrays |
 | Swelling test | `SwellingTest` | Pressure and relative-oil-volume arrays |
@@ -127,6 +127,7 @@ Configure `ConstantVolumeDepletion` with `setTemperature`, `setPressures`, and `
 Read `getSaturationPressure`, `getRelativeVolume`, `getLiquidRelativeVolume`,
 `getCummulativeMolePercDepleted`, `getZmix`, and `getZgas`. The spelling
 `getCummulativeMolePercDepleted` is the current compatibility API.
+`getLiquidRelativeVolume` returns percent of saturation volume, not a unitless fraction.
 
 ### Differential liberation
 

--- a/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
+++ b/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
@@ -41,10 +41,8 @@ class PvtLabTestsDocumentationTest extends NeqSimTest {
     fluid.getCharacterization().characterisePlusFraction();
     fluid.setMixingRule("classic");
 
-    double[] pressuresBara = {
-      351.4, 323.2, 301.5, 275.9, 250.1, 226.1, 205.9, 197.3,
-      189.3, 183.3, 165.0, 131.2, 108.3, 85.3, 55.6
-    };
+    double[] pressuresBara = { 351.4, 323.2, 301.5, 275.9, 250.1, 226.1, 205.9, 197.3, 189.3, 183.3, 165.0, 131.2,
+        108.3, 85.3, 55.6 };
 
     ConstantMassExpansion cce = new ConstantMassExpansion(fluid);
     cce.setTemperature(97.5, "C");

--- a/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
+++ b/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
@@ -61,6 +61,9 @@ class PvtLabTestsDocumentationTest extends NeqSimTest {
     assertEquals(0.95756922523, relativeVolume[0], 0.001);
     assertEquals(1.35726592522, relativeVolume[12], 0.001);
     assertEquals(2.18937648076, yFunction[12], 0.001);
+    assertTrue(Double.isFinite(liquidRelativeVolume[12]));
+    assertTrue(liquidRelativeVolume[12] >= 0.0);
+    assertTrue(liquidRelativeVolume[12] <= 100.0);
     assertTrue(Double.isFinite(cce.getSaturationPressure()));
     assertTrue(cce.getSaturationPressure() > 0.0);
   }

--- a/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
+++ b/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
@@ -1,0 +1,69 @@
+package neqsim.pvtsimulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.pvtsimulation.simulation.ConstantMassExpansion;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Verifies the executable constant-mass-expansion documentation example. */
+class PvtLabTestsDocumentationTest extends NeqSimTest {
+  @Test
+  void testConstantMassExpansionQuickStart() {
+    SystemInterface fluid = new SystemSrkEos(370.65, 350.0);
+    fluid.addComponent("nitrogen", 0.39);
+    fluid.addComponent("CO2", 0.30);
+    fluid.addComponent("methane", 40.20);
+    fluid.addComponent("ethane", 7.61);
+    fluid.addComponent("propane", 7.95);
+    fluid.addComponent("i-butane", 1.19);
+    fluid.addComponent("n-butane", 4.08);
+    fluid.addComponent("i-pentane", 1.39);
+    fluid.addComponent("n-pentane", 2.15);
+    fluid.addComponent("n-hexane", 2.79);
+    fluid.addTBPfraction("C7", 4.28, 95.0 / 1000.0, 0.729);
+    fluid.addTBPfraction("C8", 4.31, 106.0 / 1000.0, 0.749);
+    fluid.addTBPfraction("C9", 3.08, 121.0 / 1000.0, 0.770);
+    fluid.addTBPfraction("C10", 2.47, 135.0 / 1000.0, 0.786);
+    fluid.addTBPfraction("C11", 1.91, 148.0 / 1000.0, 0.792);
+    fluid.addTBPfraction("C12", 1.69, 161.0 / 1000.0, 0.804);
+    fluid.addTBPfraction("C13", 1.59, 175.0 / 1000.0, 0.819);
+    fluid.addTBPfraction("C14", 1.22, 196.0 / 1000.0, 0.833);
+    fluid.addTBPfraction("C15", 1.25, 206.0 / 1000.0, 0.836);
+    fluid.addTBPfraction("C16", 1.00, 225.0 / 1000.0, 0.843);
+    fluid.addTBPfraction("C17", 0.99, 236.0 / 1000.0, 0.840);
+    fluid.addTBPfraction("C18", 0.92, 245.0 / 1000.0, 0.846);
+    fluid.addTBPfraction("C19", 0.60, 265.0 / 1000.0, 0.857);
+    fluid.addPlusFraction("C20", 6.64, 453.0 / 1000.0, 0.918);
+    fluid.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12);
+    fluid.getCharacterization().characterisePlusFraction();
+    fluid.setMixingRule("classic");
+
+    double[] pressuresBara = {
+      351.4, 323.2, 301.5, 275.9, 250.1, 226.1, 205.9, 197.3,
+      189.3, 183.3, 165.0, 131.2, 108.3, 85.3, 55.6
+    };
+
+    ConstantMassExpansion cce = new ConstantMassExpansion(fluid);
+    cce.setTemperature(97.5, "C");
+    cce.setPressures(pressuresBara);
+    cce.runCalc();
+
+    double[] relativeVolume = cce.getRelativeVolume();
+    double[] liquidRelativeVolume = cce.getLiquidRelativeVolume();
+    double[] gasZ = cce.getZgas();
+    double[] yFunction = cce.getYfactor();
+
+    assertEquals(pressuresBara.length, relativeVolume.length);
+    assertEquals(pressuresBara.length, liquidRelativeVolume.length);
+    assertEquals(pressuresBara.length, gasZ.length);
+    assertEquals(pressuresBara.length, yFunction.length);
+    assertEquals(0.95756922523, relativeVolume[0], 0.001);
+    assertEquals(1.35726592522, relativeVolume[12], 0.001);
+    assertEquals(2.18937648076, yFunction[12], 0.001);
+    assertTrue(Double.isFinite(cce.getSaturationPressure()));
+    assertTrue(cce.getSaturationPressure() > 0.0);
+  }
+}


### PR DESCRIPTION
Part of #2499 — documentation campaign batch D014.

## Frozen scope

- `docs/pvtsimulation/pvt_lab_tests.md`
- `src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java`

No production code is changed.

## Confirmed defects and root cause

The legacy guide had six groups of stale examples that no longer matched the current simulation classes:

1. Heavy-fraction molar masses were passed as values such as `95.0` instead of `0.095 kg/mol` (1,000× too large), and one plus fraction used an unsupported `+` in its component name.
2. CCE/CME used nonexistent `getLiquidVolume` output.
3. CVD and differential-liberation examples used obsolete or nonexistent result methods.
4. The separator example used nonexistent per-stage setter/getter methods and labeled the raw temperature array as °C even though `SeparatorTest.setSeparatorConditions` consumes K.
5. The swelling example used nonexistent injection/result methods and claimed that `SwellingTest` calculates MMP; the implementation exposes pressure and relative-oil-volume arrays, not MMP.
6. The viscosity example referenced nonexistent `ViscositySimulation` APIs and labeled SI Pa·s output as cP.

The generic tuning example also referenced unsupported characterization and interaction-parameter calls.

## Fix

- Replaced broken snippets with a current units/naming contract and source-verified API map.
- Added one complete constant-mass-expansion quick start using kg/mol heavy-fraction inputs and current getters.
- Clarified that swelling results do not constitute an MMP calculation.
- Documented separator K/bara inputs and viscosity Pa·s output explicitly.
- Replaced unsupported generic tuning code with a bounded calibration workflow.
- Corrected all internal links and removed the duplicate rendered H1.
- Added a focused JUnit regression that mirrors and executes every API call in the published quick start.

## Validation evidence

Completed locally:

- front matter present and balanced
- Markdown code fences balanced
- no duplicate H1
- changed-page internal targets verified on current `master`
- obsolete/nonexistent method names removed
- no math delimiters or equations are present in the changed page
- Markdown line length checked; the Java test now uses the exact layout emitted by Spotless
- current source/tests compared for `ConstantMassExpansion`, `ConstantVolumeDepletion`, `DifferentialLiberation`, `SeparatorTest`, `SwellingTest`, and `ViscositySim`

Hosted validation on final head `1170420`:

- Passed: pre-commit, dedicated Spotless, Javadoc, and agent-reference verification.
- The first pre-commit run identified only the new test's pressure-array layout; commit `076c2cc` applied the exact Spotless format and every later rerun passed.
- Pending: `PvtLabTestsDocumentationTest` within the Ubuntu/Windows Java matrices, documentation source/search and Jekyll checks, and CodeQL. The immediately preceding head passed documentation/Jekyll/search and CodeQL, but those superseded results are not claimed for the final head.

No visual browser inspection is claimed yet; no rendered-site artifact is available locally.

## Copilot gate

Copilot reviewed both changed files and raised three valid inline findings: heavy-fraction density semantics, CCE liquid-relative-volume percent units, and the repository's Log4j2-only output rule. All were independently confirmed against `SystemThermo`, `ConstantMassExpansion`, and `AGENTS.md`, adapted in `0bef5a6`/`da8c155`, explained in their threads, and resolved. A later review contained two suppressed CVD percent-unit clarifications; current `ConstantVolumeDepletion` source confirmed both, so commit `1170420` applied them. The final-head Copilot recheck is pending, and the PR will not be reported ready until it completes. No commit is attributed to or blindly applies a Copilot suggestion. The full diff and history remain limited to the two frozen D014 files.

## Exclusions

- No production solver or thermodynamic-model changes.
- No neighboring PVT pages beyond the frozen D014 path.
- No external-link replacement; the changed page uses repository-internal links only.

Next rotation scope after D014: D015, as recorded in #2499.