### PR TITLE
docs: correct D014 plus-fraction naming

### DIFF
--- a/docs/pvtsimulation/pvt_lab_tests.md
+++ b/docs/pvtsimulation/pvt_lab_tests.md
@@ -25,8 +25,9 @@ explicitly:
 | `ViscositySim.setTemperaturesAndPressures` temperature array | K |
 | `ViscositySim` viscosity outputs | Pa·s; multiply by 1000 for cP |
 
-Pseudo-component names must not contain `+`. For example, represent a C20-plus fraction as
-`"C20"`, not `"C20+"`.
+Pseudo-component names may contain `+`. `addTBPfraction` and `addPlusFraction` preserve it
+when they append the internal `_PC` suffix. For example, `addPlusFraction("C20+", ...)`
+creates `C20+_PC` before characterization.
 
 ## Supported experiments
 
@@ -86,7 +87,7 @@ public final class ConstantMassExpansionExample {
     fluid.addTBPfraction("C17", 0.99, 236.0 / 1000.0, 0.840);
     fluid.addTBPfraction("C18", 0.92, 245.0 / 1000.0, 0.846);
     fluid.addTBPfraction("C19", 0.60, 265.0 / 1000.0, 0.857);
-    fluid.addPlusFraction("C20", 6.64, 453.0 / 1000.0, 0.918);
+    fluid.addPlusFraction("C20+", 6.64, 453.0 / 1000.0, 0.918);
     fluid.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12);
     fluid.getCharacterization().characterisePlusFraction();
     fluid.setMixingRule("classic");

--- a/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
+++ b/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
@@ -36,7 +36,8 @@ class PvtLabTestsDocumentationTest extends NeqSimTest {
     fluid.addTBPfraction("C17", 0.99, 236.0 / 1000.0, 0.840);
     fluid.addTBPfraction("C18", 0.92, 245.0 / 1000.0, 0.846);
     fluid.addTBPfraction("C19", 0.60, 265.0 / 1000.0, 0.857);
-    fluid.addPlusFraction("C20", 6.64, 453.0 / 1000.0, 0.918);
+    fluid.addPlusFraction("C20+", 6.64, 453.0 / 1000.0, 0.918);
+    assertTrue(fluid.hasComponent("C20+_PC"));
     fluid.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12);
     fluid.getCharacterization().characterisePlusFraction();
     fluid.setMixingRule("classic");


### PR DESCRIPTION
## Summary

Follow-up to merged D014 (#2572) in #2499.

A final-head GitHub Copilot review arrived after #2572 merged and correctly identified one remaining technical error: the guide prohibited `+` in pseudo-component names even though current `SystemThermo.addPlusFraction` delegates to `addTBPfraction`, preserves `+`, and appends the internal `_PC` suffix.

## Frozen scope

- `docs/pvtsimulation/pvt_lab_tests.md`
- `src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java`

## Fix

- Document that names such as `C20+` are supported and become `C20+_PC` before characterization.
- Use `C20+` in the published CCE quick start.
- Extend the focused regression to assert that `C20+_PC` is created.

## Validation

Exact head `bae8250`:

- Pre-commit: passed.
- Spotless: passed.
- Javadoc: passed.
- Agent-reference verification: passed.
- Jekyll build, generated search coverage, and search JavaScript: passed.
- CodeQL: passed.
- Copilot reviewed both changed files after the push and produced no comments or suggested-change blocks.
- Full diff and one-commit history reviewed: only the two frozen D014 files changed; no Copilot-authored/applied commit is present.
- Ubuntu and Windows Java 21 matrices are still running; the focused regression is not yet claimed as passed.

No equations, external links, images, or notebooks changed. No rendered-site artifact is available, so visual browser inspection is not claimed.

No production code, direct `master` update, merge, or auto-merge is included.