### PR TITLE
docs: make D014 plus-fraction example executable

### DIFF
--- a/docs/pvtsimulation/pvt_lab_tests.md
+++ b/docs/pvtsimulation/pvt_lab_tests.md
@@ -25,9 +25,10 @@ explicitly:
 | `ViscositySim.setTemperaturesAndPressures` temperature array | K |
 | `ViscositySim` viscosity outputs | Pa·s; multiply by 1000 for cP |
 
-Pseudo-component names may contain `+`. `addTBPfraction` and `addPlusFraction` preserve it
-when they append the internal `_PC` suffix. For example, `addPlusFraction("C20+", ...)`
-creates `C20+_PC` before characterization.
+`addTBPfraction` and `addPlusFraction` preserve `+` in a pseudo-component label when
+they append the internal `_PC` suffix, for example `C20+_PC`. However, the default Pedersen
+plus-fraction characterization parses a terminal carbon number from that label. Use a numeric
+label such as `C20`, not `C20+`, before calling `characterisePlusFraction()`.
 
 ## Supported experiments
 
@@ -87,7 +88,7 @@ public final class ConstantMassExpansionExample {
     fluid.addTBPfraction("C17", 0.99, 236.0 / 1000.0, 0.840);
     fluid.addTBPfraction("C18", 0.92, 245.0 / 1000.0, 0.846);
     fluid.addTBPfraction("C19", 0.60, 265.0 / 1000.0, 0.857);
-    fluid.addPlusFraction("C20+", 6.64, 453.0 / 1000.0, 0.918);
+    fluid.addPlusFraction("C20", 6.64, 453.0 / 1000.0, 0.918);
     fluid.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12);
     fluid.getCharacterization().characterisePlusFraction();
     fluid.setMixingRule("classic");

--- a/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
+++ b/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
@@ -8,8 +8,16 @@ import neqsim.pvtsimulation.simulation.ConstantMassExpansion;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
-/** Verifies the executable constant-mass-expansion documentation example. */
+/** Verifies the executable constant-mass-expansion example and plus-fraction naming guidance. */
 class PvtLabTestsDocumentationTest extends NeqSimTest {
+  @Test
+  void testPlusSignIsPreservedBeforeCharacterization() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 1.01325);
+    fluid.addPlusFraction("C20+", 1.0, 0.453, 0.918);
+
+    assertTrue(fluid.hasComponent("C20+_PC"));
+  }
+
   @Test
   void testConstantMassExpansionQuickStart() {
     SystemInterface fluid = new SystemSrkEos(370.65, 350.0);
@@ -36,8 +44,8 @@ class PvtLabTestsDocumentationTest extends NeqSimTest {
     fluid.addTBPfraction("C17", 0.99, 236.0 / 1000.0, 0.840);
     fluid.addTBPfraction("C18", 0.92, 245.0 / 1000.0, 0.846);
     fluid.addTBPfraction("C19", 0.60, 265.0 / 1000.0, 0.857);
-    fluid.addPlusFraction("C20+", 6.64, 453.0 / 1000.0, 0.918);
-    assertTrue(fluid.hasComponent("C20+_PC"));
+    fluid.addPlusFraction("C20", 6.64, 453.0 / 1000.0, 0.918);
+    assertTrue(fluid.hasComponent("C20_PC"));
     fluid.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12);
     fluid.getCharacterization().characterisePlusFraction();
     fluid.setMixingRule("classic");


### PR DESCRIPTION
## Summary

Second D014 follow-up for #2499 after merged #2574 exposed an execution failure.

The final Windows Java 21 matrix for #2574 ran 10,646 tests and failed only `PvtLabTestsDocumentationTest`: `C20+` is accepted by `addPlusFraction` and stored as `C20+_PC`, but `PedersenPlusModel.characterizePlusFraction` parses a terminal carbon number and throws `ArrayIndexOutOfBoundsException` for that label.

## Frozen scope

- `docs/pvtsimulation/pvt_lab_tests.md`
- `src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java`

## Fix

- Distinguish stored-label support from the stricter default Pedersen characterization contract.
- Restore the executable CCE quick start to the characterization-safe `C20` label.
- Keep a separate focused test proving `C20+` is stored as `C20+_PC` before characterization.
- Assert the CCE workflow creates `C20_PC` before running characterization.

## Evidence and root cause

- #2574 Windows Java 21: 10,646 tests, 0 failures, 1 error, 212 skipped.
- Error: `PvtLabTestsDocumentationTest.testConstantMassExpansionQuickStart:42`.
- Stack: `PlusFractionModel$PedersenPlusModel.characterizePlusFraction` → `Characterise.characterisePlusFraction`.
- Current parser reads fixed substrings from the pseudo-component name; the `+` changes that branch and produces an invalid first-fraction index.

## Exact-head validation

Passed on `8eae792`:

- pre-commit;
- Spotless;
- Javadoc on Ubuntu Java 21;
- Jekyll build and complete search-index verification;
- CodeQL;
- agent-skill cross-reference verification;
- complete diff/history review: one commit, two frozen files, no unintended changes.

Java 21 matrix evidence:

- Windows executed both `PvtLabTestsDocumentationTest` methods: 2 tests, 0 failures/errors.
- Windows executed 10,650 tests overall: the sole failure was unrelated `DesignFrameworkDocExampleTest.docExampleAutoSizeAndReadResult`, added by current `master` commit `d7221cf`; the D014 test, PVT simulation tests, and LNG tests passed.
- Ubuntu was cancelled after the Windows failure, so no Ubuntu test-pass claim is made.

## Copilot gate

Copilot reviewed both changed files after the latest push and raised one suggestion: assert the current exception for `C20+` characterization. This was technically assessed and deferred because an `assertThrows` would freeze the incidental `ArrayIndexOutOfBoundsException` parser defect as a supported API contract. The regression instead verifies the stable `C20+_PC` storage behavior and executes the supported numeric-label characterization path. The thread is resolved, and no Copilot-authored or Copilot-applied commit exists.

No production parser change is proposed: this documentation campaign should describe current behavior rather than expand production API semantics. No equations, links, images, or notebooks changed, and no visual browser inspection is claimed without a rendered artifact.