### PR TITLE
fix: allow TEG absorber rename before streams are initialized

### DIFF
--- a/src/main/java/neqsim/process/equipment/absorber/SimpleAbsorber.java
+++ b/src/main/java/neqsim/process/equipment/absorber/SimpleAbsorber.java
@@ -75,8 +75,12 @@ public class SimpleAbsorber extends Separator implements AbsorberInterface {
   @Override
   public void setName(String name) {
     super.setName(name);
-    outStream[0].setName(name + "_Sout1");
-    outStream[1].setName(name + "_Sout2");
+    if (outStream[0] != null) {
+      outStream[0].setName(name + "_Sout1");
+    }
+    if (outStream[1] != null) {
+      outStream[1].setName(name + "_Sout2");
+    }
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/absorber/SimpleAbsorberTest.java
+++ b/src/test/java/neqsim/process/equipment/absorber/SimpleAbsorberTest.java
@@ -1,5 +1,8 @@
 package neqsim.process.equipment.absorber;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -33,5 +36,13 @@ public class SimpleAbsorberTest extends neqsim.NeqSimTest {
      * operations.run();
      */
     // operations.displayResult();
+  }
+
+  @Test
+  void testSetNameBeforeStreamsAreInitialized() {
+    SimpleTEGAbsorber absorber = new SimpleTEGAbsorber("TEG absorber");
+
+    assertDoesNotThrow(() -> absorber.setName("renamed absorber"));
+    assertEquals("renamed absorber", absorber.getName());
   }
 }


### PR DESCRIPTION
## Summary

- guard `SimpleAbsorber.setName` when outlet streams have not been initialized
- preserve outlet renaming after either stream exists
- add a regression for the name-only `SimpleTEGAbsorber` construction path

## Defect

The current Python helper constructs `SimpleTEGAbsorber(name)` and then calls `setName(name)`. The name-only Java constructor has not populated `outStream[0]` or `outStream[1]`, so the existing setter throws a `NullPointerException` before users can add gas and solvent streams.

Reproduced against the public PyPI NeqSim 3.16.0 package while modernizing the TEG-dehydration Colab notebook.

## Validation

- focused regression asserts that a name-only TEG absorber can be renamed before streams are supplied
- full diff is limited to the null guards and the focused test
- CI and Copilot review are intentionally awaited before this draft is marked ready

## Review state

- Copilot reviewed both changed files at head `065a0553` and produced no inline comments or suggested-change blocks.
- The full two-commit diff contains only the null guards and focused regression test.
- Pre-commit, Spotless, and PaperLab checks pass.
- Java build/test/Javadoc and CodeQL remain in progress, so this PR remains draft.