### PR TITLE
docs: repair executable PVT and design examples

### DIFF
--- a/docs/process/DESIGN_FRAMEWORK.md
+++ b/docs/process/DESIGN_FRAMEWORK.md
@@ -147,11 +147,14 @@ if (result.getExecutionStatus() == DesignResult.ExecutionStatus.OPTIMIZED) {
 
 `optimize()` (and `validate()`) return a `DesignResult` you can inspect programmatically —
 convergence status, per-equipment sizes, constraint utilisation, warnings, and hard violations.
+A converged optimization requires an explicit manipulated feed and finite search bounds; without
+`configureFeedRateOptimization(...)`, `optimize()` performs validation and optional auto-sizing only.
 
 ```java
 DesignResult result = DesignOptimizer.forProcess(process)
     .autoSizeEquipment(1.2)
     .applyDefaultConstraints()
+    .configureFeedRateOptimization("Feed", 5000.0, 15000.0, "kg/hr")
     .setObjective(DesignOptimizer.ObjectiveType.MAXIMIZE_PRODUCTION)
     .optimize();
 

--- a/docs/process/DESIGN_FRAMEWORK.md
+++ b/docs/process/DESIGN_FRAMEWORK.md
@@ -149,6 +149,7 @@ if (result.getExecutionStatus() == DesignResult.ExecutionStatus.OPTIMIZED) {
 convergence status, per-equipment sizes, constraint utilisation, warnings, and hard violations.
 A converged optimization requires an explicit manipulated feed and finite search bounds; without
 `configureFeedRateOptimization(...)`, `optimize()` performs validation and optional auto-sizing only.
+The example bounds bracket its 10,000 kg/hr baseline; use case-specific engineering limits in production studies.
 
 ```java
 DesignResult result = DesignOptimizer.forProcess(process)

--- a/docs/pvtsimulation/pvt_lab_tests.md
+++ b/docs/pvtsimulation/pvt_lab_tests.md
@@ -25,9 +25,10 @@ explicitly:
 | `ViscositySim.setTemperaturesAndPressures` temperature array | K |
 | `ViscositySim` viscosity outputs | Pa·s; multiply by 1000 for cP |
 
-Pseudo-component names may contain `+`. `addTBPfraction` and `addPlusFraction` preserve it
-when they append the internal `_PC` suffix. For example, `addPlusFraction("C20+", ...)`
-creates `C20+_PC` before characterization.
+`addTBPfraction` and `addPlusFraction` preserve `+` in a pseudo-component label when
+they append the internal `_PC` suffix, for example `C20+_PC`. However, the default Pedersen
+plus-fraction characterization parses a terminal carbon number from that label. Use a numeric
+label such as `C20`, not `C20+`, before calling `characterisePlusFraction()`.
 
 ## Supported experiments
 
@@ -87,7 +88,7 @@ public final class ConstantMassExpansionExample {
     fluid.addTBPfraction("C17", 0.99, 236.0 / 1000.0, 0.840);
     fluid.addTBPfraction("C18", 0.92, 245.0 / 1000.0, 0.846);
     fluid.addTBPfraction("C19", 0.60, 265.0 / 1000.0, 0.857);
-    fluid.addPlusFraction("C20+", 6.64, 453.0 / 1000.0, 0.918);
+    fluid.addPlusFraction("C20", 6.64, 453.0 / 1000.0, 0.918);
     fluid.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12);
     fluid.getCharacterization().characterisePlusFraction();
     fluid.setMixingRule("classic");

--- a/src/test/java/neqsim/process/design/DesignFrameworkDocExampleTest.java
+++ b/src/test/java/neqsim/process/design/DesignFrameworkDocExampleTest.java
@@ -73,8 +73,10 @@ class DesignFrameworkDocExampleTest {
     // Explicit bounds cause optimize() to run a converged search rather than autosizing only.
     assertEquals(DesignResult.ExecutionStatus.OPTIMIZED, result.getExecutionStatus());
     assertTrue(result.isConverged());
-    // Objective value was recorded.
-    assertTrue(result.getObjectiveValue() >= 0.0);
+    // The selected objective is a finite feed rate inside the configured search interval.
+    assertTrue(Double.isFinite(result.getObjectiveValue()));
+    assertTrue(result.getObjectiveValue() >= 5000.0);
+    assertTrue(result.getObjectiveValue() <= 15000.0);
     // Equipment sizes were recorded for the separator.
     assertNotNull(result.getEquipmentSizes("HP-Separator"));
     assertTrue(result.getEquipmentSizes("HP-Separator").containsKey("diameter"));

--- a/src/test/java/neqsim/process/design/DesignFrameworkDocExampleTest.java
+++ b/src/test/java/neqsim/process/design/DesignFrameworkDocExampleTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.design;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -66,9 +67,11 @@ class DesignFrameworkDocExampleTest {
     ProcessSystem process = buildProcess();
 
     DesignResult result = DesignOptimizer.forProcess(process).autoSizeEquipment(1.2).applyDefaultConstraints()
+        .configureFeedRateOptimization("Feed", 5000.0, 15000.0, "kg/hr")
         .setObjective(DesignOptimizer.ObjectiveType.MAXIMIZE_PRODUCTION).optimize();
 
-    // The workflow ran to completion (no exception path).
+    // Explicit bounds cause optimize() to run a converged search rather than autosizing only.
+    assertEquals(DesignResult.ExecutionStatus.OPTIMIZED, result.getExecutionStatus());
     assertTrue(result.isConverged());
     // Objective value was recorded.
     assertTrue(result.getObjectiveValue() >= 0.0);

--- a/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
+++ b/src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java
@@ -8,8 +8,16 @@ import neqsim.pvtsimulation.simulation.ConstantMassExpansion;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
-/** Verifies the executable constant-mass-expansion documentation example. */
+/** Verifies the executable constant-mass-expansion example and plus-fraction naming guidance. */
 class PvtLabTestsDocumentationTest extends NeqSimTest {
+  @Test
+  void testPlusSignIsPreservedBeforeCharacterization() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 1.01325);
+    fluid.addPlusFraction("C20+", 1.0, 0.453, 0.918);
+
+    assertTrue(fluid.hasComponent("C20+_PC"));
+  }
+
   @Test
   void testConstantMassExpansionQuickStart() {
     SystemInterface fluid = new SystemSrkEos(370.65, 350.0);
@@ -36,8 +44,8 @@ class PvtLabTestsDocumentationTest extends NeqSimTest {
     fluid.addTBPfraction("C17", 0.99, 236.0 / 1000.0, 0.840);
     fluid.addTBPfraction("C18", 0.92, 245.0 / 1000.0, 0.846);
     fluid.addTBPfraction("C19", 0.60, 265.0 / 1000.0, 0.857);
-    fluid.addPlusFraction("C20+", 6.64, 453.0 / 1000.0, 0.918);
-    assertTrue(fluid.hasComponent("C20+_PC"));
+    fluid.addPlusFraction("C20", 6.64, 453.0 / 1000.0, 0.918);
+    assertTrue(fluid.hasComponent("C20_PC"));
     fluid.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12);
     fluid.getCharacterization().characterisePlusFraction();
     fluid.setMixingRule("classic");


### PR DESCRIPTION
## Summary

Repairs both documentation regressions reported by the Windows Java 21 matrix:

- make the constant-mass-expansion quick start use the characterization-safe numeric plus-fraction label `C20` / `C20_PC`
- preserve a separate assertion that `addPlusFraction("C20+", ...)` stores `C20+_PC` before characterization
- configure explicit feed-rate bounds in the executable `DesignResult` example
- assert a real bounded design search returns `OPTIMIZED`, converges, and reports a finite objective inside 5,000–15,000 kg/hr

## Root causes

1. `PedersenPlusModel.characterizePlusFraction` parses a terminal carbon number from the pseudo-component label. The stored name `C20+_PC` is valid before characterization, but the `+` changes the parser branch and produces an invalid first-fraction index. The executable example now uses the supported numeric label rather than encoding the incidental `ArrayIndexOutOfBoundsException` as expected behavior.
2. The design example selected `MAXIMIZE_PRODUCTION` without defining a manipulated feed or finite search bounds. `DesignOptimizer.optimize()` correctly performed auto-sizing/validation only, returned `AUTO_SIZED`, and set `isConverged()` to false. The example now requests the bounded search it claims to demonstrate.

## Scope

- `docs/pvtsimulation/pvt_lab_tests.md`
- `src/test/java/neqsim/pvtsimulation/PvtLabTestsDocumentationTest.java`
- `docs/process/DESIGN_FRAMEWORK.md`
- `src/test/java/neqsim/process/design/DesignFrameworkDocExampleTest.java`

No production parser, optimizer algorithm, convergence tolerance, or thermodynamic code changes.

## Relationship to #2575

The two PVT files are identical to focused PR #2575 and are included here so the complete Java matrix validates both independent fixes together against `master`. If #2575 merges first, those identical files will drop from this PR's diff automatically.

## Exact-head validation (`8774b3b`)

- `DesignFrameworkDocExampleTest`: 3 tests, 0 failures/errors on Java 21 and Java 8, Windows and Ubuntu
- `PvtLabTestsDocumentationTest`: 2 tests, 0 failures/errors on Java 21 and Java 8, Windows and Ubuntu
- Windows Java 21: 10,650 tests, 0 failures, 0 errors, 212 skipped — `BUILD SUCCESS`
- Ubuntu Java 21 + JaCoCo: 10,852 tests, 0 failures, 0 errors, 215 skipped; 4,671 classes analyzed — `BUILD SUCCESS`
- Windows Java 8: 10,650 tests, 0 failures, 0 errors, 212 skipped — `BUILD SUCCESS`
- Ubuntu Java 8: 10,650 tests, 0 failures, 0 errors, 212 skipped — `BUILD SUCCESS`
- pre-commit, Spotless, Java 21 Javadoc, documentation search coverage, CodeQL, and agent-skill cross-reference checks passed
- Copilot reviewed all 4 changed files on the combined PR and generated no new comments

Full workflow `Run build, test and javadoc` run 7502 completed successfully.