### PR TITLE
docs: make thermodynamics cookbook executable (D015)

### DIFF
--- a/docs/cookbook/thermodynamics-recipes.md
+++ b/docs/cookbook/thermodynamics-recipes.md
@@ -1,11 +1,10 @@
 ---
 title: Thermodynamics Recipes
-description: Quick recipes for thermodynamic calculations in NeqSim - fluids, flash, properties, phase envelopes, and more.
+description: Copy-paste NeqSim recipes for fluids, flash calculations, properties, phase envelopes, model selection, and JSON export.
 ---
 
-# Thermodynamics Recipes
-
-Copy-paste solutions for common thermodynamic tasks.
+Copy-paste solutions for common thermodynamic tasks. Every code block defines its own fluid and
+can run independently in Python after `pip install neqsim`.
 
 ## Table of Contents
 
@@ -14,9 +13,7 @@ Copy-paste solutions for common thermodynamic tasks.
 - [Reading Properties](#reading-properties)
 - [Phase Envelopes](#phase-envelopes)
 - [Choosing an EoS](#which-eos-should-i-use)
-- [Export and Import](#export-and-import)
-
----
+- [Export, Parse, and Clone](#export-parse-and-clone)
 
 ## Creating Fluids
 
@@ -25,8 +22,7 @@ Copy-paste solutions for common thermodynamic tasks.
 ```python
 from neqsim import jneqsim
 
-# Create at 25°C (298.15 K) and 50 bara
-fluid = jneqsim.thermo.system.SystemSrkEos(273.15 + 25, 50.0)
+fluid = jneqsim.thermo.system.SystemSrkEos(298.15, 50.0)
 fluid.addComponent("nitrogen", 0.02)
 fluid.addComponent("CO2", 0.01)
 fluid.addComponent("methane", 0.85)
@@ -37,14 +33,15 @@ fluid.addComponent("n-pentane", 0.01)
 fluid.setMixingRule("classic")
 ```
 
-**Gotcha**: Always call `setMixingRule()` after adding all components!
+The constructor uses kelvin and bara. Component amounts are relative mole amounts; they do not
+need to sum to one. Set the mixing rule after all components are added.
 
-### Create Oil with Plus Fraction
+### Create Oil with a Characterized Plus Fraction
 
 ```python
 from neqsim import jneqsim
 
-fluid = jneqsim.thermo.system.SystemPrEos(273.15 + 60, 200.0)
+fluid = jneqsim.thermo.system.SystemPrEos(333.15, 200.0)
 fluid.addComponent("nitrogen", 0.5)
 fluid.addComponent("CO2", 2.0)
 fluid.addComponent("methane", 45.0)
@@ -54,268 +51,264 @@ fluid.addComponent("n-butane", 3.0)
 fluid.addComponent("n-pentane", 2.0)
 fluid.addComponent("n-hexane", 2.0)
 
-# Add C7+ as pseudo-component
-fluid.addTBPfraction("C7+", 32.5, 0.220, 0.82)  # mole%, MW, SG
-
+# Arguments: relative mole amount, molar mass (kg/mol), density (g/cm3).
+# Use a terminal numeric label before default Pedersen characterization.
+fluid.addPlusFraction("C7", 32.5, 0.220, 0.82)
+fluid.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12)
+fluid.getCharacterization().characterisePlusFraction()
 fluid.setMixingRule("classic")
 fluid.setMultiPhaseCheck(True)
 ```
 
-### Create CO₂-Rich Fluid (CPA)
+`addTBPfraction(...)` creates one specified pseudo-component. Use `addPlusFraction(...)` followed
+by `characterisePlusFraction()` when a residual fraction is to be split and lumped. The current
+default Pedersen parser expects a numeric terminal carbon label such as `C7`, not `C7+`.
+
+### Create a CO₂-Water Fluid with CPA
 
 ```python
 from neqsim import jneqsim
 
-# Use CPA for CO2 with water
-fluid = jneqsim.thermo.system.SystemSrkCPAstatoil(273.15 + 25, 100.0)
+fluid = jneqsim.thermo.system.SystemSrkCPAstatoil(298.15, 100.0)
 fluid.addComponent("CO2", 0.95)
 fluid.addComponent("methane", 0.03)
 fluid.addComponent("water", 0.02)
-fluid.setMixingRule(10)  # CPA mixing rule
+fluid.setMixingRule(10)
 ```
 
----
+CPA is useful when association, especially water, matters. Validate the selected model and binary
+interaction parameters against data for the composition and conditions of interest.
 
 ## Flash Calculations
 
-### Run TP Flash
+This complete example runs TP, constant-enthalpy PH, and constant-entropy PS flashes from the same
+initial natural-gas state. Enthalpy and entropy passed to `PHflash` and `PSflash` are total-system
+values in J and J/K.
 
 ```python
 from neqsim import jneqsim
 
-# After creating fluid...
-ops = jneqsim.thermodynamicoperations.ThermodynamicOperations(fluid)
-ops.TPflash()
+def make_fluid():
+    gas = jneqsim.thermo.system.SystemSrkEos(298.15, 50.0)
+    gas.addComponent("nitrogen", 0.02)
+    gas.addComponent("CO2", 0.01)
+    gas.addComponent("methane", 0.85)
+    gas.addComponent("ethane", 0.06)
+    gas.addComponent("propane", 0.03)
+    gas.addComponent("n-butane", 0.02)
+    gas.addComponent("n-pentane", 0.01)
+    gas.setMixingRule("classic")
+    return gas
 
-# IMPORTANT: Initialize properties after flash
-fluid.initProperties()
+tp_fluid = make_fluid()
+tp_ops = jneqsim.thermodynamicoperations.ThermodynamicOperations(tp_fluid)
+tp_ops.TPflash()
+tp_fluid.initProperties()
+print(f"TP phases: {tp_fluid.getNumberOfPhases()}")
 
-print(f"Phases: {fluid.getNumberOfPhases()}")
+ph_fluid = make_fluid()
+ph_ops = jneqsim.thermodynamicoperations.ThermodynamicOperations(ph_fluid)
+ph_ops.TPflash()
+ph_fluid.initProperties()
+initial_enthalpy_j = ph_fluid.getEnthalpy("J")
+ph_fluid.setPressure(30.0, "bara")
+ph_ops.PHflash(initial_enthalpy_j)
+print(f"PH temperature: {ph_fluid.getTemperature() - 273.15:.2f} °C")
+
+ps_fluid = make_fluid()
+ps_ops = jneqsim.thermodynamicoperations.ThermodynamicOperations(ps_fluid)
+ps_ops.TPflash()
+ps_fluid.initProperties()
+initial_entropy_j_per_k = ps_fluid.getEntropy("J/K")
+ps_fluid.setPressure(20.0, "bara")
+ps_ops.PSflash(initial_entropy_j_per_k)
+print(f"PS temperature: {ps_fluid.getTemperature() - 273.15:.2f} °C")
 ```
-
-### Run PH Flash (Given Pressure and Enthalpy)
-
-```python
-# First, get enthalpy at known conditions
-fluid.initProperties()
-H_initial = fluid.getEnthalpy("J")
-
-# Set new pressure, then flash at constant enthalpy
-fluid.setPressure(30.0, "bara")
-ops.PHflash(H_initial)
-
-print(f"New temperature: {fluid.getTemperature() - 273.15:.2f} °C")
-```
-
-### Run PS Flash (Isentropic)
-
-```python
-# Get entropy at initial conditions
-fluid.initProperties()
-S_initial = fluid.getEntropy("J/K")
-
-# Set new pressure, then flash at constant entropy
-fluid.setPressure(20.0, "bara")
-ops.PSflash(S_initial)
-
-print(f"New temperature: {fluid.getTemperature() - 273.15:.2f} °C")
-```
-
----
 
 ## Reading Properties
 
-### Get Density (Correctly!)
+Run a flash and `initProperties()` before reading physical properties. The no-argument
+`getDensity()` is based on the EoS phase volumes without Peneloux correction.
+`getDensity("kg/m3")` uses initialized physical-property densities and corrected volume fractions.
 
 ```python
-# WRONG - Returns EoS density WITHOUT Peneloux correction
-density_wrong = fluid.getDensity()
+from neqsim import jneqsim
 
-# CORRECT - Returns density WITH Peneloux volume correction
-density_correct = fluid.getDensity("kg/m3")
+fluid = jneqsim.thermo.system.SystemSrkEos(298.15, 50.0)
+fluid.addComponent("nitrogen", 0.02)
+fluid.addComponent("CO2", 0.01)
+fluid.addComponent("methane", 0.85)
+fluid.addComponent("ethane", 0.06)
+fluid.addComponent("propane", 0.03)
+fluid.addComponent("n-butane", 0.02)
+fluid.addComponent("n-pentane", 0.01)
+fluid.setMixingRule("classic")
 
-print(f"Without correction: {density_wrong:.2f} kg/m³")
-print(f"With correction: {density_correct:.2f} kg/m³")
-```
-
-**Gotcha**: Always pass a unit string to `getDensity()` to get the corrected value!
-
-### Get All Common Properties
-
-```python
-# Make sure to initialize first
+ops = jneqsim.thermodynamicoperations.ThermodynamicOperations(fluid)
+ops.TPflash()
 fluid.initProperties()
 
-# Bulk properties
 print(f"Temperature: {fluid.getTemperature() - 273.15:.2f} °C")
 print(f"Pressure: {fluid.getPressure():.2f} bara")
-print(f"Density: {fluid.getDensity('kg/m3'):.2f} kg/m³")
-print(f"Molar mass: {fluid.getMolarMass('kg/mol') * 1000:.2f} g/mol")
+print(f"EoS density: {fluid.getDensity():.2f} kg/m³")
+print(f"Corrected density: {fluid.getDensity('kg/m3'):.2f} kg/m³")
+print(f"Molar mass: {fluid.getMolarMass('g/mol'):.2f} g/mol")
 print(f"Z-factor: {fluid.getZ():.4f}")
 print(f"Enthalpy: {fluid.getEnthalpy('kJ/kg'):.2f} kJ/kg")
-print(f"Entropy: {fluid.getEntropy('J/kgK'):.2f} J/kgK")
-print(f"Cp: {fluid.getCp('kJ/kgK'):.4f} kJ/kgK")
-print(f"Cv: {fluid.getCv('kJ/kgK'):.4f} kJ/kgK")
-print(f"Speed of sound: {fluid.getSoundSpeed('m/s'):.2f} m/s")
-
-# Transport properties
+print(f"Entropy: {fluid.getEntropy('J/kgK'):.2f} J/(kg·K)")
+print(f"Cp: {fluid.getCp('kJ/kgK'):.4f} kJ/(kg·K)")
+print(f"Cv: {fluid.getCv('kJ/kgK'):.4f} kJ/(kg·K)")
+print(f"Sound speed: {fluid.getSoundSpeed('m/s'):.2f} m/s")
 print(f"Viscosity: {fluid.getViscosity('cP'):.4f} cP")
-print(f"Thermal cond: {fluid.getThermalConductivity('W/mK'):.4f} W/mK")
-```
+print(
+    "Thermal conductivity: "
+    f"{fluid.getThermalConductivity('W/mK'):.4f} W/(m·K)"
+)
 
-### Get Phase-Specific Properties
-
-```python
-# Check available phases
 if fluid.hasPhaseType("gas"):
     gas = fluid.getPhase("gas")
     print(f"Gas density: {gas.getDensity('kg/m3'):.2f} kg/m³")
     print(f"Gas viscosity: {gas.getViscosity('cP'):.4f} cP")
-    print(f"Gas fraction: {gas.getBeta():.4f} (mole)")
+    print(f"Gas mole fraction: {gas.getBeta():.4f}")
 
-if fluid.hasPhaseType("oil"):
-    oil = fluid.getPhase("oil")
-    print(f"Oil density: {oil.getDensity('kg/m3'):.2f} kg/m³")
-    print(f"Oil viscosity: {oil.getViscosity('cP'):.4f} cP")
+for component_index in range(fluid.getNumberOfComponents()):
+    component = fluid.getComponent(component_index)
+    name = str(component.getComponentName())
+    print(
+        f"{name}: z={component.getz():.4f}, "
+        f"Tc={component.getTC():.1f} K, "
+        f"Pc={component.getPC():.1f} bara"
+    )
 ```
 
-### Get Component Properties
-
-```python
-for i in range(fluid.getNumberOfComponents()):
-    comp = fluid.getComponent(i)
-    name = str(comp.getComponentName())
-    z = comp.getz()  # Overall mole fraction
-
-    print(f"{name}: z={z:.4f}, Tc={comp.getTC():.1f} K, Pc={comp.getPC():.1f} bara")
-```
-
----
+Bulk properties of a multiphase system are mixture-level quantities. Read the named phase when a
+phase-specific value is required.
 
 ## Phase Envelopes
 
-### Calculate Phase Envelope
+The named arrays contain temperature in K and pressure in bara. The cricondenbar and
+cricondentherm arrays are ordered `[temperature, pressure, ...]`.
 
 ```python
 from neqsim import jneqsim
 import matplotlib.pyplot as plt
 
-# Create fluid
-fluid = jneqsim.thermo.system.SystemSrkEos(273.15 + 25, 50.0)
+fluid = jneqsim.thermo.system.SystemSrkEos(298.15, 50.0)
 fluid.addComponent("methane", 0.80)
 fluid.addComponent("ethane", 0.10)
 fluid.addComponent("propane", 0.05)
 fluid.addComponent("n-butane", 0.05)
 fluid.setMixingRule("classic")
 
-# Calculate envelope
 ops = jneqsim.thermodynamicoperations.ThermodynamicOperations(fluid)
 ops.calcPTphaseEnvelope()
 
-# Extract points
-dew_T = [t - 273.15 for t in list(ops.get("dewT"))]
-dew_P = list(ops.get("dewP"))
-bub_T = [t - 273.15 for t in list(ops.get("bubT"))]
-bub_P = list(ops.get("bubP"))
+dew_temperature_c = [value - 273.15 for value in list(ops.get("dewT"))]
+dew_pressure_bara = list(ops.get("dewP"))
+bubble_temperature_c = [value - 273.15 for value in list(ops.get("bubT"))]
+bubble_pressure_bara = list(ops.get("bubP"))
 
-# Plot
-plt.figure(figsize=(10, 6))
-plt.plot(dew_T, dew_P, 'b-', label='Dew line', linewidth=2)
-plt.plot(bub_T, bub_P, 'r-', label='Bubble line', linewidth=2)
-plt.xlabel('Temperature (°C)')
-plt.ylabel('Pressure (bara)')
-plt.title('Phase Envelope')
-plt.legend()
+cricondenbar = list(ops.get("cricondenbar"))
+cricondentherm = list(ops.get("cricondentherm"))
+print(
+    f"Cricondenbar: {cricondenbar[1]:.2f} bara at "
+    f"{cricondenbar[0] - 273.15:.2f} °C"
+)
+print(
+    f"Cricondentherm: {cricondentherm[0] - 273.15:.2f} °C at "
+    f"{cricondentherm[1]:.2f} bara"
+)
+
+plt.figure(figsize=(9, 5))
+plt.plot(dew_temperature_c, dew_pressure_bara, label="Dew line")
+plt.plot(bubble_temperature_c, bubble_pressure_bara, label="Bubble line")
+plt.xlabel("Temperature (°C)")
+plt.ylabel("Pressure (bara)")
+plt.title("Pressure-temperature phase envelope")
 plt.grid(True)
+plt.legend()
 plt.show()
 ```
 
-### Get Cricondenbar and Cricondentherm
-
-```python
-ops.calcPTphaseEnvelope()
-
-cricondenbar_P = ops.get("cricondenbar")[1]  # Pressure
-cricondenbar_T = ops.get("cricondenbar")[0] - 273.15  # Temperature in °C
-
-cricondentherm_P = ops.get("cricondentherm")[1]
-cricondentherm_T = ops.get("cricondentherm")[0] - 273.15
-
-print(f"Cricondenbar: {cricondenbar_P:.2f} bara at {cricondenbar_T:.2f} °C")
-print(f"Cricondentherm: {cricondentherm_T:.2f} °C at {cricondentherm_P:.2f} bara")
-```
-
----
+Near critical points and for strongly associating or highly asymmetric mixtures, check convergence
+and compare with a validated fluid model or laboratory data.
 
 ## Which EoS Should I Use?
 
-| Fluid Type | Recommended EoS | NeqSim Class |
-|------------|-----------------|--------------|
-| **Dry gas** | SRK or PR | `SystemSrkEos`, `SystemPrEos` |
-| **Gas condensate** | PR with Peneloux | `SystemPrEos` |
-| **Black oil** | PR or SRK | `SystemPrEos`, `SystemSrkEos` |
-| **Heavy oil** | PR or CPA | `SystemPrEos`, `SystemSrkCPAstatoil` |
-| **CO₂ systems** | CPA | `SystemSrkCPAstatoil` |
-| **CO₂ + water** | CPA or Electrolyte-CPA | `SystemSrkCPAstatoil` |
-| **Natural gas (custody)** | GERG-2008 | `SystemGERG2008Eos` |
-| **LNG** | GERG-2008 or PR | `SystemGERG2008Eos`, `SystemPrEos` |
-| **Aqueous systems** | CPA | `SystemSrkCPAstatoil` |
-| **Electrolytes** | Electrolyte-CPA | See electrolyte guide |
+| Fluid or task | Starting model | Important qualification |
+|---|---|---|
+| Dry natural gas | SRK or PR | Validate density and calorific properties for the composition |
+| Gas condensate | PR or SRK | Tune heavy-end characterization to PVT data |
+| Black or volatile oil | PR or SRK | Characterize and tune C7+ before process studies |
+| Dry CO₂-rich fluid | PR, SRK, or a validated multiparameter model | Check impurities and phase-boundary range |
+| CO₂ with water | CPA | Validate water content, mutual solubility, and BIPs |
+| Natural-gas reference properties | GERG-2008 | Use only supported components and validity ranges |
+| LNG | GERG-2008 or PR | Validate cryogenic liquid density and phase equilibrium |
+| Electrolytes and brines | Electrolyte-CPA | Define ions, salinity basis, and precipitation scope |
 
-### Quick Selection Code
+Selection depends on fluid chemistry, properties of interest, conditions, available tuning data, and
+required uncertainty—not only the fluid label.
 
 ```python
 from neqsim import jneqsim
 
-# For dry gas / gas condensate
-fluid = jneqsim.thermo.system.SystemSrkEos(T, P)
+temperature_k = 288.15
+pressure_bara = 70.0
 
-# For black oil
-fluid = jneqsim.thermo.system.SystemPrEos(T, P)
-
-# For CO2/water systems
-fluid = jneqsim.thermo.system.SystemSrkCPAstatoil(T, P)
-
-# For custody transfer (natural gas)
-fluid = jneqsim.thermo.system.SystemGERG2008Eos(T, P)
+srk_fluid = jneqsim.thermo.system.SystemSrkEos(
+    temperature_k,
+    pressure_bara,
+)
+pr_fluid = jneqsim.thermo.system.SystemPrEos(
+    temperature_k,
+    pressure_bara,
+)
+cpa_fluid = jneqsim.thermo.system.SystemSrkCPAstatoil(
+    temperature_k,
+    pressure_bara,
+)
+gerg_fluid = jneqsim.thermo.system.SystemGERG2008Eos(
+    temperature_k,
+    pressure_bara,
+)
 ```
 
----
+## Export, Parse, and Clone
 
-## Export and Import
-
-### Export to JSON
-
-```python
-# Full fluid state as JSON
-json_str = fluid.toJson()
-print(json_str)
-```
-
-### Export to Python Dictionary
+`toJson()` returns a nested response with `conditions`, `properties`, and `composition`. Values are
+serialized as objects containing `value` and `unit`; convert numeric strings explicitly.
 
 ```python
 import json
+from neqsim import jneqsim
 
-# Parse JSON to dict
-data = json.loads(fluid.toJson())
-print(f"Temperature: {data['temperature']['value']} {data['temperature']['unit']}")
-```
+fluid = jneqsim.thermo.system.SystemSrkEos(298.15, 50.0)
+fluid.addComponent("methane", 0.90)
+fluid.addComponent("ethane", 0.07)
+fluid.addComponent("propane", 0.03)
+fluid.setMixingRule("classic")
 
-### Clone a Fluid
+ops = jneqsim.thermodynamicoperations.ThermodynamicOperations(fluid)
+ops.TPflash()
+fluid.initProperties()
 
-```python
-# Create a copy (independent of original)
+json_text = str(fluid.toJson())
+data = json.loads(json_text)
+temperature = data["conditions"]["overall"]["temperature"]
+print(f"Temperature: {float(temperature['value']):.2f} {temperature['unit']}")
+
 fluid_copy = fluid.clone()
-
-# Modify copy without affecting original
 fluid_copy.setTemperature(300.0)
+print(f"Original: {fluid.getTemperature():.2f} K")
+print(f"Copy: {fluid_copy.getTemperature():.2f} K")
 ```
 
----
+The clone is independent of the original, but recalculate its equilibrium and properties after
+changing temperature, pressure, composition, or model settings.
 
 ## See Also
 
-- **[Reading Fluid Properties Guide](../thermo/reading_fluid_properties)** - Comprehensive property access
-- **[Thermodynamic Models](../thermo/thermodynamic_models)** - All EoS details
+- **[Reading Fluid Properties Guide](../thermo/reading_fluid_properties)** - Property access and initialization
+- **[Thermodynamic Models](../thermo/thermodynamic_models)** - Model theory and selection
+- **[Phase Envelope Guide](../pvtsimulation/phase_envelope_guide)** - Algorithms, results, and troubleshooting
 - **[JavaDoc: SystemInterface](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/thermo/system/SystemInterface.html)** - Complete API

--- a/src/test/java/neqsim/thermo/system/ThermodynamicsCookbookDocumentationTest.java
+++ b/src/test/java/neqsim/thermo/system/ThermodynamicsCookbookDocumentationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.gson.Gson;
 import java.util.Map;
@@ -137,7 +138,13 @@ class ThermodynamicsCookbookDocumentationTest extends NeQSimTest {
     Map<String, Object> conditions = (Map<String, Object>) root.get("conditions");
     Map<String, Object> overall = (Map<String, Object>) conditions.get("overall");
     Map<String, Object> temperatureValue = (Map<String, Object>) overall.get("temperature");
-    assertTrue(Double.isFinite(Double.parseDouble((String) temperatureValue.get("value"))));
+    String temperatureStringValue = (String) temperatureValue.get("value");
+    try {
+      double parsedTemperature = Double.parseDouble(temperatureStringValue);
+      assertTrue(Double.isFinite(parsedTemperature));
+    } catch (NumberFormatException ex) {
+      fail("Temperature value is not a valid number: " + temperatureStringValue);
+    }
     assertFalse(((String) temperatureValue.get("unit")).isEmpty());
 
     SystemInterface copy = fluid.clone();

--- a/src/test/java/neqsim/thermo/system/ThermodynamicsCookbookDocumentationTest.java
+++ b/src/test/java/neqsim/thermo/system/ThermodynamicsCookbookDocumentationTest.java
@@ -1,0 +1,150 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.Gson;
+import java.util.Map;
+import neqsim.NeQSimTest;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import org.junit.jupiter.api.Test;
+
+/** Executes the API families illustrated by the thermodynamics cookbook recipes. */
+class ThermodynamicsCookbookDocumentationTest extends NeQSimTest {
+  private SystemInterface createNaturalGas() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("nitrogen", 0.02);
+    fluid.addComponent("CO2", 0.01);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.06);
+    fluid.addComponent("propane", 0.03);
+    fluid.addComponent("n-butane", 0.02);
+    fluid.addComponent("n-pentane", 0.01);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  @Test
+  void testFluidCreationRecipes() {
+    assertEquals(7, createNaturalGas().getNumberOfComponents());
+
+    SystemInterface oil = new SystemPrEos(333.15, 200.0);
+    oil.addComponent("nitrogen", 0.5);
+    oil.addComponent("CO2", 2.0);
+    oil.addComponent("methane", 45.0);
+    oil.addComponent("ethane", 8.0);
+    oil.addComponent("propane", 5.0);
+    oil.addComponent("n-butane", 3.0);
+    oil.addComponent("n-pentane", 2.0);
+    oil.addComponent("n-hexane", 2.0);
+    oil.addPlusFraction("C7", 32.5, 0.220, 0.82);
+    oil.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12);
+    oil.getCharacterization().characterisePlusFraction();
+    oil.setMixingRule("classic");
+    oil.setMultiPhaseCheck(true);
+    assertTrue(oil.getNumberOfComponents() > 9);
+
+    SystemInterface cpaFluid = new SystemSrkCPAstatoil(298.15, 100.0);
+    cpaFluid.addComponent("CO2", 0.95);
+    cpaFluid.addComponent("methane", 0.03);
+    cpaFluid.addComponent("water", 0.02);
+    cpaFluid.setMixingRule(10);
+    assertEquals(3, cpaFluid.getNumberOfComponents());
+  }
+
+  @Test
+  void testFlashAndPropertyRecipes() {
+    SystemInterface tpFluid = createNaturalGas();
+    ThermodynamicOperations tpOps = new ThermodynamicOperations(tpFluid);
+    tpOps.TPflash();
+    tpFluid.initProperties();
+    assertTrue(tpFluid.getNumberOfPhases() >= 1);
+
+    SystemInterface phFluid = createNaturalGas();
+    ThermodynamicOperations phOps = new ThermodynamicOperations(phFluid);
+    phOps.TPflash();
+    phFluid.initProperties();
+    double initialEnthalpy = phFluid.getEnthalpy("J");
+    phFluid.setPressure(30.0, "bara");
+    phOps.PHflash(initialEnthalpy);
+    assertTrue(Double.isFinite(phFluid.getTemperature()));
+
+    SystemInterface psFluid = createNaturalGas();
+    ThermodynamicOperations psOps = new ThermodynamicOperations(psFluid);
+    psOps.TPflash();
+    psFluid.initProperties();
+    double initialEntropy = psFluid.getEntropy("J/K");
+    psFluid.setPressure(20.0, "bara");
+    psOps.PSflash(initialEntropy);
+    assertTrue(Double.isFinite(psFluid.getTemperature()));
+
+    assertTrue(tpFluid.getDensity() > 0.0);
+    assertTrue(tpFluid.getDensity("kg/m3") > 0.0);
+    assertTrue(tpFluid.getMolarMass("g/mol") > 0.0);
+    assertTrue(Double.isFinite(tpFluid.getZ()));
+    assertTrue(Double.isFinite(tpFluid.getEnthalpy("kJ/kg")));
+    assertTrue(Double.isFinite(tpFluid.getEntropy("J/kgK")));
+    assertTrue(tpFluid.getCp("kJ/kgK") > 0.0);
+    assertTrue(tpFluid.getCv("kJ/kgK") > 0.0);
+    assertTrue(tpFluid.getSoundSpeed("m/s") > 0.0);
+    assertTrue(tpFluid.getViscosity("cP") > 0.0);
+    assertTrue(tpFluid.getThermalConductivity("W/mK") > 0.0);
+    assertTrue(tpFluid.hasPhaseType("gas"));
+    assertTrue(tpFluid.getPhase("gas").getDensity("kg/m3") > 0.0);
+    assertTrue(tpFluid.getPhase("gas").getViscosity("cP") > 0.0);
+    assertTrue(tpFluid.getPhase("gas").getBeta() > 0.0);
+    assertTrue(tpFluid.getComponent(0).getTC() > 0.0);
+    assertTrue(tpFluid.getComponent(0).getPC() > 0.0);
+  }
+
+  @Test
+  void testPhaseEnvelopeRecipe() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.05);
+    fluid.addComponent("n-butane", 0.05);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
+    ops.calcPTphaseEnvelope();
+
+    assertEquals(ops.get("dewT").length, ops.get("dewP").length);
+    assertEquals(ops.get("bubT").length, ops.get("bubP").length);
+    assertTrue(ops.get("dewT").length > 2);
+    assertTrue(ops.get("bubT").length > 2);
+    assertTrue(ops.get("cricondenbar")[1] > 0.0);
+    assertTrue(ops.get("cricondentherm")[0] > 0.0);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testModelSelectionJsonAndCloneRecipes() {
+    double temperature = 288.15;
+    double pressure = 70.0;
+    assertEquals("SRK-EOS", new SystemSrkEos(temperature, pressure).getModelName());
+    assertEquals("PR-EOS", new SystemPrEos(temperature, pressure).getModelName());
+    assertFalse(new SystemSrkCPAstatoil(temperature, pressure).getModelName().isEmpty());
+    assertEquals("GERG2008-EOS", new SystemGERG2008Eos(temperature, pressure).getModelName());
+
+    SystemInterface fluid = createNaturalGas();
+    new ThermodynamicOperations(fluid).TPflash();
+    fluid.initProperties();
+
+    Map<String, Object> root = new Gson().fromJson(fluid.toJson(), Map.class);
+    Map<String, Object> conditions = (Map<String, Object>) root.get("conditions");
+    Map<String, Object> overall = (Map<String, Object>) conditions.get("overall");
+    Map<String, Object> temperatureValue = (Map<String, Object>) overall.get("temperature");
+    assertTrue(Double.isFinite(Double.parseDouble((String) temperatureValue.get("value"))));
+    assertFalse(((String) temperatureValue.get("unit")).isEmpty());
+
+    SystemInterface copy = fluid.clone();
+    assertNotSame(fluid, copy);
+    double originalTemperature = fluid.getTemperature();
+    copy.setTemperature(300.0);
+    assertEquals(300.0, copy.getTemperature(), 1.0e-12);
+    assertEquals(originalTemperature, fluid.getTemperature(), 1.0e-12);
+  }
+}


### PR DESCRIPTION
## D015 — thermodynamics cookbook

Links #2499.

### Frozen scope

- `docs/cookbook/thermodynamics-recipes.md`
- `src/test/java/neqsim/thermo/system/ThermodynamicsCookbookDocumentationTest.java`

The batch excludes the TEG files changed by open PR #2576 and makes no production-code changes.

### Confirmed defects and root causes

1. **High — non-running recipes:** flash, property, and export snippets relied on hidden `fluid`, `ops`, `T`, or `P` state despite claiming copy-paste readiness.
2. **High — incorrect JSON schema:** the guide read `data["temperature"]`, while `SystemThermo.toJson()` serializes `FluidResponse` under `conditions.overall.temperature`.
3. **High — ambiguous plus-fraction recipe:** `addTBPfraction("C7+", ...)` did not perform the stated plus-fraction characterization and mislabeled molar-mass/density units.
4. **Medium — overbroad model guidance:** blanket model recommendations omitted composition, validity-range, binary-parameter, and calibration qualifications.
5. **Low — malformed page structure:** the body repeated the front-matter title as a second H1.

### Fixes

- Made all eight Python blocks independent and executable.
- Corrected JSON traversal and explicit numeric-string conversion.
- Replaced the heavy-end recipe with `addPlusFraction("C7", ...)`, explicit kg/mol and g/cm³ units, lumping, and Pedersen characterization.
- Added guarded model-selection guidance and clear density/initialization semantics.
- Removed the duplicate H1 while preserving existing anchors and navigation.
- Added four focused Java tests covering every documented API family: fluid creation, TP/PH/PS flashes and properties, phase envelopes, model selection, JSON, and cloning.

### Validation evidence

- NeqSim 3.16.0 clean Python environment: **8/8 independent Markdown Python blocks passed**.
- Representative results: PH 13.87 °C; PS −23.33 °C; corrected density 45.31 kg/m³; cricondenbar 102.00 bara at −5.40 °C; JSON temperature 25.00 °C.
- Front matter, Markdown structure, anchors, and 16 balanced fence markers passed.
- All three internal related-document links resolve on current `master`.
- The official NeqSim site exposes the referenced JavaDoc destination; the direct safe-open check returned a connector/tooling error, not an HTTP failure, so no permanent-link claim is made.
- Local Maven execution was blocked before compilation because the clean `/tmp` repository could not resolve Maven Central DNS. Hosted Java CI is therefore required and this PR remains draft.
- This page contains no equations, notebooks, or images. No rendered-site artifact was available, so visual browser inspection is not claimed.

### Remaining gates

- Hosted focused Java regression and full matrix.
- Jekyll/search, Spotless, Javadoc, CodeQL, and agent-reference checks.
- Mandatory final-head Copilot review/comments/suggested-change/commit assessment.

### Next rotation scope

After D015 is completed: JavaDoc, Python/notebook documentation, images, and retried external links.