### PR TITLE
fix: refresh AGA3 standard-condition density

### DIFF
--- a/src/main/java/neqsim/standards/gasquality/Standard_AGA3.java
+++ b/src/main/java/neqsim/standards/gasquality/Standard_AGA3.java
@@ -175,6 +175,7 @@ public class Standard_AGA3 extends neqsim.standards.Standard {
       stdSystem.init(1);
       ops = new ThermodynamicOperations(stdSystem);
       ops.TPflash();
+      stdSystem.initPhysicalProperties();
       standardDensity = stdSystem.getPhase(0).getDensity("kg/m3");
 
       // Step 1: Initial estimate of discharge coefficient (Cd) using RG equation

--- a/src/test/java/neqsim/standards/gasquality/Standard_AGA3Test.java
+++ b/src/test/java/neqsim/standards/gasquality/Standard_AGA3Test.java
@@ -1,5 +1,6 @@
 package neqsim.standards.gasquality;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -91,8 +92,18 @@ class Standard_AGA3Test extends neqsim.NeqSimTest {
     double massFlow = standard.getValue("massFlowRate");
     // Mass flow should definitely be positive
     assertTrue(massFlow > 0, "Mass flow should be positive");
-    // Standard volume flow should be non-negative (zero if std density calc fails)
-    assertTrue(svf >= 0.0, "Standard volume flow should be non-negative");
+
+    SystemInterface standardSystem = testSystem.clone();
+    standardSystem.setTemperature(288.15);
+    standardSystem.setPressure(1.01325);
+    ThermodynamicOperations standardOps = new ThermodynamicOperations(standardSystem);
+    standardOps.TPflash();
+    standardSystem.initPhysicalProperties();
+
+    double standardDensity = standardSystem.getPhase(0).getDensity("kg/m3");
+    double expectedStandardVolumeFlow = massFlow / standardDensity * 3600.0;
+    assertEquals(expectedStandardVolumeFlow, svf, expectedStandardVolumeFlow * 1.0e-10,
+        "Standard volume flow must use density refreshed at standard conditions");
   }
 
   /**


### PR DESCRIPTION
## Summary

- refresh physical properties after the AGA3 standard-condition TP flash
- prevent the flowing-density cache from being reused for standard-volume conversion
- strengthen `Standard_AGA3Test` with an independent standard-density conversion check

## Reproduction

With NeqSim 3.16.0, a 7.2925 kg/s natural-gas case at 50 bara and 20 °C reports
625.55 Sm³/h because the 41.97 kg/m³ flowing density is reused after the standard-condition flash.
Refreshing physical properties gives 0.7703 kg/m³ at 15 °C and 1.01325 bara, or about 34,081 Sm³/h.

## Validation

- reproduced through the public Python/JPype interface using PyPI NeqSim 3.16.0
- regression compares `standardVolumeFlowRate` with `massFlow / refreshedStandardDensity * 3600`
- no production behavior outside `Standard_AGA3` is changed

The PR is intentionally draft while hosted checks and Copilot review run.