### PR TITLE
docs: finish D015 cookbook validation

### DIFF
--- a/docs/cookbook/thermodynamics-recipes.md
+++ b/docs/cookbook/thermodynamics-recipes.md
@@ -4,7 +4,8 @@ description: Copy-paste NeqSim recipes for fluids, flash calculations, propertie
 ---
 
 Copy-paste solutions for common thermodynamic tasks. Every code block defines its own fluid and
-can run independently in Python after `pip install neqsim`.
+can run independently in Python after `pip install neqsim`. The phase-envelope plotting block
+also requires `matplotlib`.
 
 ## Table of Contents
 
@@ -54,15 +55,17 @@ fluid.addComponent("n-hexane", 2.0)
 # Arguments: relative mole amount, molar mass (kg/mol), density (g/cm3).
 # Use a terminal numeric label before default Pedersen characterization.
 fluid.addPlusFraction("C7", 32.5, 0.220, 0.82)
+fluid.setMixingRule("classic")
 fluid.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12)
 fluid.getCharacterization().characterisePlusFraction()
-fluid.setMixingRule("classic")
 fluid.setMultiPhaseCheck(True)
 ```
 
 `addTBPfraction(...)` creates one specified pseudo-component. Use `addPlusFraction(...)` followed
-by `characterisePlusFraction()` when a residual fraction is to be split and lumped. The current
-default Pedersen parser expects a numeric terminal carbon label such as `C7`, not `C7+`.
+by `characterisePlusFraction()` when a residual fraction is to be split and lumped. Although
+`addPlusFraction(...)` accepts a name containing `+`, the current default Pedersen
+characterization parser does not safely parse that name. Use a numeric terminal carbon label such
+as `C7` when calling `characterisePlusFraction()`.
 
 ### Create a CO₂-Water Fluid with CPA
 

--- a/src/test/java/neqsim/thermo/system/ThermodynamicsCookbookDocumentationTest.java
+++ b/src/test/java/neqsim/thermo/system/ThermodynamicsCookbookDocumentationTest.java
@@ -8,12 +8,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.gson.Gson;
 import java.util.Map;
-import neqsim.NeQSimTest;
+import neqsim.NeqSimTest;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import org.junit.jupiter.api.Test;
 
 /** Executes the API families illustrated by the thermodynamics cookbook recipes. */
-class ThermodynamicsCookbookDocumentationTest extends NeQSimTest {
+class ThermodynamicsCookbookDocumentationTest extends NeqSimTest {
   private SystemInterface createNaturalGas() {
     SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
     fluid.addComponent("nitrogen", 0.02);
@@ -41,9 +41,9 @@ class ThermodynamicsCookbookDocumentationTest extends NeQSimTest {
     oil.addComponent("n-pentane", 2.0);
     oil.addComponent("n-hexane", 2.0);
     oil.addPlusFraction("C7", 32.5, 0.220, 0.82);
+    oil.setMixingRule("classic");
     oil.getCharacterization().getLumpingModel().setNumberOfPseudoComponents(12);
     oil.getCharacterization().characterisePlusFraction();
-    oil.setMixingRule("classic");
     oil.setMultiPhaseCheck(true);
     assertTrue(oil.getNumberOfComponents() > 9);
 


### PR DESCRIPTION
Fixes the post-merge D015 validation defects from #2578 and continues #2499.

## Frozen scope

- `docs/cookbook/thermodynamics-recipes.md`
- `src/test/java/neqsim/thermo/system/ThermodynamicsCookbookDocumentationTest.java`

No production code, equations, images, notebooks, navigation, or unrelated documentation is changed.

## Confirmed defects and fixes

1. **High – Java regression test did not compile.** #2578 imported and extended `NeQSimTest`, but the repository class is case-sensitive `neqsim.NeqSimTest`. This caused the hosted Java 21 compilation failure. The import and superclass are corrected.
2. **Medium – plus-fraction setup order contradicted the current builder contract.** Both the Python recipe and focused Java test now set the mixing rule before `characterisePlusFraction()`.
3. **Medium – undeclared plotting dependency.** The introduction now states that the phase-envelope block additionally requires `matplotlib`.
4. **Clarity – terminal plus-fraction label.** The note now distinguishes storage from characterization: `addPlusFraction` can accept a name containing `+`, while the current default Pedersen characterization parser does not safely parse that name. The executable recipe therefore retains `C7`.

## Mandatory Copilot assessment

- Accepted the mixing-rule ordering findings and applied them to both the documented recipe and regression test.
- Accepted the missing-`matplotlib` finding and declared the dependency.
- Rejected the suggestion that the `C7` warning is inaccurate. D014 independently demonstrated that `addPlusFraction("C20+")` stores `C20+_PC`, but current default Pedersen characterization then misparses the terminal plus label. The new wording makes that distinction explicit instead of claiming storage is unsupported.
- Preserved the Copilot Autofix commit from #2578 that catches `NumberFormatException` and fails with contextual test output. It does not alter numerical behavior and remains part of the focused test.

## Validation

- Clean Python execution with NeqSim 3.16.0: all 8 independent code blocks passed.
- TP, PH, PS, initialized properties, phase envelope, model construction, JSON traversal, and clone independence executed.
- Front matter, balanced fences, preserved anchors, and the existing three internal links remain unchanged from the validated D015 page.
- Local Maven reached dependency resolution but was blocked by a transient Maven Central DNS failure for `maven-enforcer-plugin:3.6.3`; no local Java pass is claimed.
- Hosted Java compilation/test, Jekyll/search, Spotless, CodeQL, agent-reference checks, and final-head Copilot review are required before this draft is ready.
- No rendered-site artifact is available and no visual inspection is claimed.

## Exclusions and next scope

This follow-up only repairs D015. The next new scan remains rotation scope 7 after D015 is clean and merged.