### PR TITLE
docs: repair Colab quickstart examples (D016)

### DIFF
--- a/docs/quickstart/colab-quickstart.md
+++ b/docs/quickstart/colab-quickstart.md
@@ -3,9 +3,8 @@ title: Google Colab Quickstart
 description: Try NeqSim instantly in Google Colab with no installation. One-click notebooks for thermodynamic and process calculations.
 ---
 
-# Google Colab Quickstart
-
-Try NeqSim instantly - no installation required!
+Try NeqSim in a clean Google Colab runtime. The setup cell installs the current
+PyPI release; the examples below then run without a local Java or Python setup.
 
 ## One-Click Start
 
@@ -21,9 +20,11 @@ If starting from a blank notebook, run this cell first:
 # Install NeqSim (takes ~30 seconds)
 !pip install neqsim -q
 
-# Import NeqSim
+# Import NeqSim and report the installed version
+from importlib.metadata import version
 from neqsim import jneqsim
-print("NeqSim ready!")
+
+print(f"NeqSim {version('neqsim')} ready!")
 ```
 
 ## Your First Calculation
@@ -51,12 +52,16 @@ print(f"Z-factor: {fluid.getZ():.4f}")
 
 ## Example Notebooks
 
+The repository notebooks below do not repeat the installation command. In a
+fresh Colab runtime, run the **Quick Setup Cell** above as the first cell before
+running their NeqSim imports.
+
 | Notebook | Description | Open |
 |----------|-------------|------|
 | **Introduction** | Getting started examples | [![Open](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/examples_of_NeqSim_in_Colab.ipynb) |
 | **Reading Properties** | Init levels, density, units | [![Open](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/ReadingFluidProperties.ipynb) |
 | **PVT Simulation** | Fluid characterization, tuning | [![Open](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/PVT_Simulation_and_Tuning.ipynb) |
-| **Process Simulation** | Separators, compressors | [![Open](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/NetworkSolverTutorial.ipynb) |
+| **Gathering Network Solver** | Multi-well pressure-flow allocation | [![Open](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/NetworkSolverTutorial.ipynb) |
 | **ESP Pump** | Electric submersible pump | [![Open](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/ESP_Pump_Tutorial.ipynb) |
 
 ## Quick Process Example
@@ -71,26 +76,30 @@ Stream = jneqsim.process.equipment.stream.Stream
 Separator = jneqsim.process.equipment.separator.Separator
 Compressor = jneqsim.process.equipment.compressor.Compressor
 
-# Create fluid
+# Create a two-phase feed at 30°C and 50 bara
 fluid = SystemSrkEos(273.15 + 30, 50.0)
-fluid.addComponent("methane", 0.80)
+fluid.addComponent("methane", 0.70)
 fluid.addComponent("ethane", 0.10)
-fluid.addComponent("propane", 0.05)
+fluid.addComponent("propane", 0.10)
 fluid.addComponent("n-butane", 0.05)
+fluid.addComponent("n-pentane", 0.05)
 fluid.setMixingRule("classic")
 
 # Build process
 process = ProcessSystem()
 
 feed = Stream("Feed", fluid)
-feed.setFlowRate(5000, "kg/hr")
+feed.setFlowRate(10000.0, "kg/hr")
+feed.setTemperature(30.0, "C")
+feed.setPressure(50.0, "bara")
 process.add(feed)
 
 sep = Separator("Separator", feed)
 process.add(sep)
 
 comp = Compressor("Compressor", sep.getGasOutStream())
-comp.setOutletPressure(100.0)
+comp.setOutletPressure(100.0, "bara")
+comp.setIsentropicEfficiency(0.75)
 process.add(comp)
 
 # Run
@@ -101,6 +110,11 @@ print(f"Gas rate: {sep.getGasOutStream().getFlowRate('kg/hr'):.0f} kg/hr")
 print(f"Liquid rate: {sep.getLiquidOutStream().getFlowRate('kg/hr'):.0f} kg/hr")
 print(f"Compressor power: {comp.getPower('kW'):.1f} kW")
 ```
+
+With NeqSim 3.16.0, this case gives approximately 7,588 kg/h gas,
+2,412 kg/h liquid, and 202.2 kW compressor power. Small differences can occur
+between releases, but both separator products and the compressor power must be
+positive and the two product mass flows must close to the 10,000 kg/h feed.
 
 ## Visualization in Colab
 
@@ -128,11 +142,23 @@ bub_press = list(ops.get("bubP"))
 
 # Plot
 plt.figure(figsize=(10, 6))
-plt.plot([t - 273.15 for t in dew_temps], dew_press, 'b-', label='Dew line', linewidth=2)
-plt.plot([t - 273.15 for t in bub_temps], bub_press, 'r-', label='Bubble line', linewidth=2)
-plt.xlabel('Temperature (°C)')
-plt.ylabel('Pressure (bara)')
-plt.title('Phase Envelope')
+plt.plot(
+    [temperature - 273.15 for temperature in dew_temps],
+    dew_press,
+    "b-",
+    label="Dew line",
+    linewidth=2,
+)
+plt.plot(
+    [temperature - 273.15 for temperature in bub_temps],
+    bub_press,
+    "r-",
+    label="Bubble line",
+    linewidth=2,
+)
+plt.xlabel("Temperature (°C)")
+plt.ylabel("Pressure (bara)")
+plt.title("Phase envelope")
 plt.legend()
 plt.grid(True, alpha=0.3)
 plt.show()
@@ -142,10 +168,14 @@ plt.show()
 
 1. **Runtime disconnects**: Colab may disconnect after idle time. Re-run the install cell if needed.
 
-2. **Suppress warnings**:
+2. **Review warnings**: Do not hide warnings from flashes or process equipment;
+   they can indicate convergence or validity problems. To reduce only Python
+   gateway logging, use:
+
    ```python
-   import warnings
-   warnings.filterwarnings('ignore')
+   import logging
+
+   logging.getLogger("jpype").setLevel(logging.WARNING)
    ```
 
 3. **Save results**: Download results to your Google Drive:

--- a/docs/quickstart/colab-quickstart.md
+++ b/docs/quickstart/colab-quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Google Colab Quickstart
-description: Try NeqSim instantly in Google Colab with no installation. One-click notebooks for thermodynamic and process calculations.
+description: Try NeqSim in Google Colab with a one-cell install and no local setup. One-click thermodynamic and process examples.
 ---
 
 Try NeqSim in a clean Google Colab runtime. The setup cell installs the current

--- a/src/test/java/neqsim/quickstart/ColabQuickstartDocumentationTest.java
+++ b/src/test/java/neqsim/quickstart/ColabQuickstartDocumentationTest.java
@@ -71,9 +71,9 @@ public class ColabQuickstartDocumentationTest extends NeqSimTest {
 
     double gasFlow = separator.getGasOutStream().getFlowRate("kg/hr");
     double liquidFlow = separator.getLiquidOutStream().getFlowRate("kg/hr");
-    assertTrue(gasFlow > 0.0);
-    assertTrue(liquidFlow > 0.0);
-    assertEquals(10000.0, gasFlow + liquidFlow, 1.0e-6);
+    assertTrue(gasFlow > 100.0);
+    assertTrue(liquidFlow > 100.0);
+    assertEquals(10000.0, gasFlow + liquidFlow, 1.0e-3);
     assertTrue(compressor.getPower("kW") > 0.0);
   }
 

--- a/src/test/java/neqsim/quickstart/ColabQuickstartDocumentationTest.java
+++ b/src/test/java/neqsim/quickstart/ColabQuickstartDocumentationTest.java
@@ -1,0 +1,105 @@
+package neqsim.quickstart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import neqsim.NeqSimTest;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Executes the NeqSim API calls shown in the Google Colab quickstart.
+ *
+ * @author esol
+ * @version 1.0
+ */
+public class ColabQuickstartDocumentationTest extends NeqSimTest {
+  /**
+   * Verifies the first thermodynamic calculation shown in the quickstart.
+   */
+  @Test
+  void firstCalculationProducesInitializedGasProperties() {
+    SystemSrkEos fluid = new SystemSrkEos(273.15 + 25.0, 50.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.05);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+    fluid.initProperties();
+
+    assertTrue(fluid.getNumberOfPhases() > 0);
+    assertTrue(fluid.getDensity("kg/m3") > 0.0);
+    assertTrue(fluid.getZ() > 0.0);
+  }
+
+  /**
+   * Verifies that the process example separates both products and compresses the gas.
+   */
+  @Test
+  void processExampleSeparatesTwoPhasesAndClosesMassBalance() {
+    SystemSrkEos fluid = new SystemSrkEos(273.15 + 30.0, 50.0);
+    fluid.addComponent("methane", 0.70);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.10);
+    fluid.addComponent("n-butane", 0.05);
+    fluid.addComponent("n-pentane", 0.05);
+    fluid.setMixingRule("classic");
+
+    ProcessSystem process = new ProcessSystem();
+    Stream feed = new Stream("Feed", fluid);
+    feed.setFlowRate(10000.0, "kg/hr");
+    feed.setTemperature(30.0, "C");
+    feed.setPressure(50.0, "bara");
+    process.add(feed);
+
+    Separator separator = new Separator("Separator", feed);
+    process.add(separator);
+
+    Compressor compressor = new Compressor("Compressor", separator.getGasOutStream());
+    compressor.setOutletPressure(100.0, "bara");
+    compressor.setIsentropicEfficiency(0.75);
+    process.add(compressor);
+
+    process.run();
+
+    double gasFlow = separator.getGasOutStream().getFlowRate("kg/hr");
+    double liquidFlow = separator.getLiquidOutStream().getFlowRate("kg/hr");
+    assertTrue(gasFlow > 0.0);
+    assertTrue(liquidFlow > 0.0);
+    assertEquals(10000.0, gasFlow + liquidFlow, 1.0e-6);
+    assertTrue(compressor.getPower("kW") > 0.0);
+  }
+
+  /**
+   * Verifies the phase-envelope data keys used by the plotting example.
+   */
+  @Test
+  void phaseEnvelopeExampleProvidesDewAndBubbleCurves() {
+    SystemSrkEos fluid = new SystemSrkEos(273.15 + 25.0, 50.0);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.05);
+    fluid.addComponent("n-butane", 0.05);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.calcPTphaseEnvelope();
+
+    double[] dewTemperatures = operations.get("dewT");
+    double[] dewPressures = operations.get("dewP");
+    double[] bubbleTemperatures = operations.get("bubT");
+    double[] bubblePressures = operations.get("bubP");
+
+    assertTrue(dewTemperatures.length > 0);
+    assertEquals(dewTemperatures.length, dewPressures.length);
+    assertTrue(bubbleTemperatures.length > 0);
+    assertEquals(bubbleTemperatures.length, bubblePressures.length);
+  }
+}


### PR DESCRIPTION
## Campaign

D016 in #2499 — rotation scope 7 (JavaDoc-facing examples, Python snippets, notebooks, images, and external links).

## Frozen scope

- `docs/quickstart/colab-quickstart.md`
- `src/test/java/neqsim/quickstart/ColabQuickstartDocumentationTest.java`

No production code, notebooks, equations, images, or indexes are changed.

## Confirmed defects

1. **Misleading process result (high):** the documented 30 °C / 50 bara feed remained single-phase; the separator liquid stream was about `1e-26 kg/h`, so it did not demonstrate separation.
2. **Deprecated/ambiguous API (medium):** `Compressor.setOutletPressure(100.0)` omitted the pressure unit.
3. **Missing clean-runtime boundary (medium):** the linked repository notebooks import NeqSim without installing it, while the page implied direct clean-runtime execution.
4. **Incorrect notebook description (medium):** `NetworkSolverTutorial.ipynb` was described as a separator/compressor process example; it is a multi-well gathering-network solver.
5. **Unsafe troubleshooting guidance (medium):** blanket `warnings.filterwarnings("ignore")` could hide convergence or validity warnings.
6. **Jekyll structure (low):** a duplicate H1 followed front matter whose title already supplies the page heading.

## Repairs and evidence

- Replaced the process feed with a two-phase C1–C5 case and explicit feed temperature, feed pressure, compressor pressure unit, and efficiency.
- Added expected NeqSim 3.16.0 behavior and engineering assertions: positive gas/liquid products, mass closure, and positive compressor power.
- Added a focused Java 8-compatible regression executing every documented NeqSim API family: the first flash/properties calculation, the complete process example, and the four phase-envelope data keys.
- Added an explicit clean-Colab setup boundary and installed-version output.
- Corrected the network notebook description.
- Replaced blanket warning suppression with targeted JPype logger guidance and an instruction to review engineering warnings.
- Removed the duplicate H1.

## Validation performed

- NeqSim 3.16.0 / Python 3.12.13 / OpenJDK 17.0.19: all three executable Python examples ran in order with zero exceptions.
  - First calculation: density `43.42 kg/m³`, `Z = 0.8778`.
  - Process: `7,588 kg/h` gas, `2,412 kg/h` liquid, `202.2 kW`; product flows close to the `10,000 kg/h` feed.
  - Phase envelope: dew and bubble arrays populated and plotted.
- Front matter, balanced fences, duplicate-H1 scan, and all three relative links passed.
- All four repository notebook targets exist; full notebook execution is deliberately excluded from this frozen batch.
- Colab destination and JavaDoc endpoint opened successfully on 2026-07-23. The SVG badge fetch produced a parser-only `400 OK` artifact and is treated as transient, not a permanent link failure.
- Current Java source confirms `setOutletPressure(double, String)`, `calcPTphaseEnvelope()`, and `get(String)` returning `double[]`.
- No equations or images are present, so equation/image rendering is not applicable.
- Local Maven was retried with network access but Maven Central DNS resolution remained transiently unavailable; hosted CI is therefore the definitive Java compile/test and Spotless gate.

## Review gates

Final head `ab79a82` passes pre-commit, Spotless (4,470 files already clean; zero formatter changes), Javadoc, documentation build/search, CodeQL, and agent-reference checks. The Ubuntu and Windows Java 21 test matrices are still running, so the PR remains draft.

Copilot reviewed both files on the final head and generated no new comments. Its two earlier findings were accepted and adapted: material split thresholds now prevent the original near-zero liquid result from passing, and the front-matter description matches the one-cell install boundary. Copilot's suppressed low-confidence concern about the `1e-3 kg/h` closure tolerance is deliberately retained pending the hosted cross-platform result: this deterministic mass split closes several orders of magnitude tighter, and the tolerance is already only `1e-7` relative.

## Exclusions and next scope

Linked notebooks are target-checked but not edited or claimed clean. The next rotation scope is recent merged public functionality versus documentation coverage.