### PR TITLE
docs: repair fluid creation units and model guidance (D019)

### DIFF
--- a/docs/thermo/README.md
+++ b/docs/thermo/README.md
@@ -13,11 +13,11 @@ This folder collects topic-specific documentation for using NeqSim's thermodynam
 
 ```
 thermo/
-├── system/       # Fluid system implementations (58 EoS classes)
-├── phase/        # Phase types and calculations (62 classes)
-├── component/    # Component properties (65 classes)
-├── mixingrule/   # Mixing rules for EoS
-└── characterization/  # Plus fraction characterization
+├── system/            # Fluid-system and equation-of-state implementations
+├── phase/             # Phase models and calculations
+├── component/         # Pure-component and mixture-component properties
+├── mixingrule/        # Equation-of-state mixing rules
+└── characterization/  # TBP and plus-fraction characterization
 ```
 
 ---
@@ -75,4 +75,7 @@ thermo/
 
 ---
 
-Each document favors short, reproducible code snippets using the Java API so the same ideas transfer to other supported languages (Python/Matlab) with minor syntax changes.
+Examples are written for the Java API unless a page says otherwise. Python uses the
+NeqSim gateway and different import conventions; follow the
+[Python quickstart](../quickstart/python-quickstart) rather than translating Java
+syntax literally.

--- a/docs/thermo/fluid_creation_guide.md
+++ b/docs/thermo/fluid_creation_guide.md
@@ -31,6 +31,7 @@ Creating a fluid in NeqSim follows a consistent pattern:
 ```java
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 // 1. Create the fluid with initial temperature (K) and pressure (bara)
 SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
@@ -43,19 +44,24 @@ fluid.addComponent("propane", 0.05);
 // 3. Set up the mixing rule
 fluid.setMixingRule("classic");
 
-// 4. Initialize the fluid
-fluid.init(0);
+// 4. Calculate equilibrium, then initialize physical properties
+ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+operations.TPflash();
+fluid.initProperties();
 ```
 
 ### Constructor Parameters
 
-All fluid system classes accept these constructor signatures:
+Most equation-of-state system classes provide a temperature/pressure constructor:
 
 | Constructor | Description |
 |-------------|-------------|
-| `SystemXXX()` | Default: 298.15 K, 1.0 bara |
-| `SystemXXX(T, P)` | Temperature (K), Pressure (bara) |
-| `SystemXXX(T, P, checkForSolids)` | With solid phase checking enabled |
+| `SystemXXX(T, P)` | Temperature in K and absolute pressure in bara |
+| `SystemXXX()` | Model-specific defaults; do not assume one common state |
+| `SystemXXX(T, P, checkForSolids)` | Available on many, but not all, system classes |
+
+Use the explicit `(T, P)` form in reproducible examples. Check the selected
+class's JavaDoc before using a default or solid-checking overload.
 
 ---
 
@@ -221,9 +227,14 @@ $$
 
 ### 5.1 GERG-2008
 
-The ISO 20765-2 standard for natural gas. Highest accuracy for custody transfer and fiscal metering.
+NeqSim includes a GERG-2008 implementation for the ISO 20765-2 natural-gas
+reference equation. The current `SystemGERG2008Eos` source explicitly marks
+parts of the implementation unfinished. Treat it as a calculation and
+validation tool, not as sole evidence for custody-transfer or fiscal acceptance.
 
-**Supported components (21):** Methane, Nitrogen, CO2, Ethane, Propane, n-Butane, i-Butane, n-Pentane, i-Pentane, n-Hexane, n-Heptane, n-Octane, n-Nonane, n-Decane, Hydrogen, Oxygen, CO, Water, Helium, Argon.
+**Mapped GERG-2008 components (21):** Methane, Nitrogen, CO2, Ethane, Propane,
+n-Butane, i-Butane, n-Pentane, i-Pentane, n-Hexane, n-Heptane, n-Octane,
+n-Nonane, n-Decane, Hydrogen, Oxygen, CO, Water, H2S, Helium, Argon.
 
 ```java
 import neqsim.thermo.system.SystemGERG2008Eos;
@@ -235,7 +246,7 @@ fluid.addComponent("propane", 0.03);
 fluid.addComponent("nitrogen", 0.02);
 fluid.createDatabase(true);
 
-// Access GERG-specific properties
+// Access the GERG-specific density for comparison with validated references
 double density = fluid.getPhase(0).getDensity_GERG2008();
 ```
 
@@ -261,7 +272,7 @@ fluid.addComponent("oxygen", 0.02);
 | `SystemSpanWagnerEos` | Span-Wagner equation for CO2 |
 | `SystemLeachmanEos` | Leachman equation for hydrogen |
 | `SystemBWRSEos` | Benedict-Webb-Rubin-Starling |
-| `SystemBnsEos` | BNS equation of state |
+| `SystemBnsEos` | Burgoyne-Nielsen-Stanko Peng-Robinson correlation |
 
 ---
 
@@ -332,7 +343,7 @@ fluid.addComponent("methane", 0.7);
 fluid.addComponent("CO2", 0.15);
 fluid.addComponent("H2S", 0.05);
 fluid.addComponent("water", 0.1);
-fluid.addSalinity(2.0, "mole/sec");  // Add salinity
+fluid.addSalinity(2.0, "mole/sec");  // Salt-equivalent molar flow, not concentration
 fluid.setMixingRule(11);  // Soreide-Whitson mixing rule
 ```
 
@@ -421,7 +432,8 @@ For `addComponent(name, value, unit)`:
 
 ### 9.3 Common Component Names
 
-NeqSim's database includes hundreds of components. Common names:
+NeqSim uses a database-backed component catalog. Verify exact names in the
+[component list](component_list); common examples include:
 
 **Hydrocarbons:**
 `methane`, `ethane`, `propane`, `i-butane`, `n-butane`, `i-pentane`, `n-pentane`, `n-hexane`, `n-heptane`, `n-octane`, `n-nonane`, `n-decane`
@@ -445,13 +457,12 @@ For petroleum fluids, NeqSim supports TBP (True Boiling Point) and plus-fraction
 
 ```java
 SystemInterface oil = new SystemSrkEos(350.0, 100.0);
-oil.createDatabase(true);  // Required before adding TBP fractions
 
-// addTBPfraction(name, moles, molarMass [g/mol], density [g/cm3])
-oil.addTBPfraction("C7", 0.05, 96.0, 0.738);
-oil.addTBPfraction("C8", 0.04, 107.0, 0.765);
-oil.addTBPfraction("C9", 0.03, 121.0, 0.781);
-oil.addTBPfraction("C10", 0.02, 134.0, 0.792);
+// addTBPfraction(name, molarFlow, molarMass [kg/mol], specificGravity)
+oil.addTBPfraction("C7", 0.05, 0.096, 0.738);
+oil.addTBPfraction("C8", 0.04, 0.107, 0.765);
+oil.addTBPfraction("C9", 0.03, 0.121, 0.781);
+oil.addTBPfraction("C10", 0.02, 0.134, 0.792);
 
 oil.setMixingRule("classic");
 ```
@@ -459,8 +470,9 @@ oil.setMixingRule("classic");
 ### 10.2 Plus Fractions
 
 ```java
-// addPlusFraction(name, moles, molarMass [g/mol], density [g/cm3])
-oil.addPlusFraction("C20+", 0.10, 350.0, 0.88);
+// Use a numeric label; NeqSim stores the pseudo-component with a _PC suffix.
+// addPlusFraction(name, molarFlow, molarMass [kg/mol], specificGravity)
+oil.addPlusFraction("C20", 0.10, 0.350, 0.88);
 ```
 
 ### 10.3 TBP Characterization Models
@@ -547,16 +559,16 @@ public class WaterHydrocarbonExample {
 }
 ```
 
-### 11.3 High-Accuracy Fiscal Metering (GERG-2008)
+### 11.3 GERG-2008 Density Comparison
 
 ```java
 import neqsim.thermo.system.SystemGERG2008Eos;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
-public class FiscalMeteringExample {
+public class GergDensityComparisonExample {
     public static void main(String[] args) {
-        // GERG-2008 for custody transfer accuracy
+        // Compare NeqSim's GERG-2008 result with an approved reference
         SystemInterface gas = new SystemGERG2008Eos(288.15, 40.0);
 
         gas.addComponent("methane", 0.92);
@@ -587,7 +599,6 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
 public class OilCharacterizationExample {
     public static void main(String[] args) {
         SystemInterface oil = new SystemPrEos(350.0, 150.0);
-        oil.createDatabase(true);
 
         // Light ends
         oil.addComponent("nitrogen", 0.005);
@@ -601,14 +612,14 @@ public class OilCharacterizationExample {
         oil.addComponent("n-pentane", 0.02);
         oil.addComponent("n-hexane", 0.03);
 
-        // TBP fractions (moles, MW g/mol, density g/cm3)
-        oil.addTBPfraction("C7", 0.05, 96.0, 0.738);
-        oil.addTBPfraction("C8", 0.04, 107.0, 0.765);
-        oil.addTBPfraction("C9", 0.03, 121.0, 0.781);
-        oil.addTBPfraction("C10", 0.02, 134.0, 0.792);
+        // TBP fractions (molar flow, molar mass kg/mol, specific gravity)
+        oil.addTBPfraction("C7", 0.05, 0.096, 0.738);
+        oil.addTBPfraction("C8", 0.04, 0.107, 0.765);
+        oil.addTBPfraction("C9", 0.03, 0.121, 0.781);
+        oil.addTBPfraction("C10", 0.02, 0.134, 0.792);
 
-        // Plus fraction
-        oil.addPlusFraction("C11+", 0.18, 250.0, 0.85);
+        // Use a numeric label; NeqSim stores this as C11_PC.
+        oil.addPlusFraction("C11", 0.18, 0.250, 0.85);
 
         oil.setMixingRule("classic");
 
@@ -635,28 +646,32 @@ public class OilCharacterizationExample {
 | Water-hydrocarbon | `SystemSrkCPAstatoil` | `CLASSIC_TX_CPA` (10) |
 | Glycol dehydration | `SystemSrkCPAstatoil` | `CPA_MIX` (7) |
 | Sour gas / brine | `SystemSoreideWhitson` | `SOREIDE_WHITSON` (11) |
-| Fiscal metering | `SystemGERG2008Eos` | N/A |
+| Natural-gas reference-property comparison | `SystemGERG2008Eos` | N/A |
 | CCS / CO2 transport | `SystemEOSCGEos` | N/A |
 | Electrolyte solutions | `SystemElectrolyteCPAstatoil` | N/A |
 | Polar organics | `SystemUNIFAC` or `SystemNRTL` | N/A |
 
 ### Decision Flow
 
-1. **Is high accuracy required for custody transfer?** → Use GERG-2008
-2. **Does the system contain water, glycols, or alcohols?** → Use CPA models
+1. **Is a validated natural-gas reference calculation required?** → Evaluate
+   GERG-2008 against the applicable composition range and an approved reference
+2. **Does the system contain water, glycols, or alcohols?** → Evaluate CPA models
 3. **Is it a sour gas system with brine?** → Use Søreide-Whitson
 4. **Is it a standard hydrocarbon system?** → Use SRK or PR
 5. **Does it contain electrolytes?** → Use Electrolyte-CPA or Pitzer
 6. **Is it a non-ideal organic mixture?** → Use UNIFAC or NRTL
 
-### Performance vs. Accuracy Trade-offs
+### Model-Coverage Trade-offs
 
-| Model Type | Speed | Accuracy | Best For |
-|------------|-------|----------|----------|
-| Cubic (SRK/PR) | Fast | Good | General process simulation |
-| CPA | Medium | Very Good | Polar/associating systems |
-| GERG-2008 | Slow | Excellent | Fiscal metering, calibration |
-| UNIFAC | Medium | Good | Chemical process design |
+Accuracy depends on composition, state, parameters, and validation data; the
+labels below describe model scope rather than guaranteed error.
+
+| Model Type | Typical Cost | Intended Scope |
+|------------|--------------|----------------|
+| Cubic (SRK/PR) | Low | General hydrocarbon process calculations |
+| CPA | Moderate | Associating mixtures within a validated parameter set |
+| GERG-2008 | Higher | Natural-gas reference-property comparisons |
+| UNIFAC | Moderate | Screening non-ideal liquid mixtures with available groups |
 
 ---
 

--- a/src/test/java/neqsim/thermo/system/FluidCreationGuideDocumentationTest.java
+++ b/src/test/java/neqsim/thermo/system/FluidCreationGuideDocumentationTest.java
@@ -1,0 +1,96 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import neqsim.NeqSimTest;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import org.junit.jupiter.api.Test;
+
+/** Executes the complete workflows and corrected heavy-end units in the fluid creation guide. */
+class FluidCreationGuideDocumentationTest extends NeqSimTest {
+  @Test
+  void testNaturalGasWorkflow() {
+    SystemInterface gas = new SystemSrkEos(283.15, 70.0);
+    gas.addComponent("nitrogen", 0.02);
+    gas.addComponent("CO2", 0.01);
+    gas.addComponent("methane", 0.85);
+    gas.addComponent("ethane", 0.06);
+    gas.addComponent("propane", 0.03);
+    gas.addComponent("i-butane", 0.01);
+    gas.addComponent("n-butane", 0.01);
+    gas.addComponent("i-pentane", 0.005);
+    gas.addComponent("n-pentane", 0.005);
+    gas.setMixingRule("classic");
+
+    new ThermodynamicOperations(gas).TPflash();
+    gas.initProperties();
+
+    assertTrue(gas.getDensity("kg/m3") > 0.0);
+    assertTrue(Double.isFinite(gas.getZ()));
+    assertTrue(gas.getMolarMass() > 0.0);
+  }
+
+  @Test
+  void testWaterHydrocarbonWorkflow() {
+    SystemInterface fluid = new SystemSrkCPAstatoil(323.15, 50.0);
+    fluid.addComponent("methane", 0.70);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.05);
+    fluid.addComponent("water", 0.10);
+    fluid.addComponent("MEG", 0.05);
+    fluid.setMixingRule(10);
+
+    new ThermodynamicOperations(fluid).TPflash();
+
+    assertEquals(5, fluid.getNumberOfComponents());
+    assertTrue(fluid.getNumberOfPhases() >= 1);
+  }
+
+  @Test
+  void testGergDensityComparisonWorkflow() {
+    SystemInterface gas = new SystemGERG2008Eos(288.15, 40.0);
+    gas.addComponent("methane", 0.92);
+    gas.addComponent("ethane", 0.04);
+    gas.addComponent("propane", 0.02);
+    gas.addComponent("nitrogen", 0.01);
+    gas.addComponent("CO2", 0.01);
+    gas.createDatabase(true);
+
+    new ThermodynamicOperations(gas).TPflash();
+
+    double density = gas.getPhase(0).getDensity_GERG2008();
+    assertTrue(Double.isFinite(density));
+    assertTrue(density > 0.0);
+  }
+
+  @Test
+  void testOilCharacterizationUsesKilogramsPerMole() {
+    SystemInterface oil = new SystemPrEos(350.0, 150.0);
+    oil.addComponent("nitrogen", 0.005);
+    oil.addComponent("CO2", 0.02);
+    oil.addComponent("methane", 0.35);
+    oil.addComponent("ethane", 0.08);
+    oil.addComponent("propane", 0.06);
+    oil.addComponent("i-butane", 0.02);
+    oil.addComponent("n-butane", 0.03);
+    oil.addComponent("i-pentane", 0.02);
+    oil.addComponent("n-pentane", 0.02);
+    oil.addComponent("n-hexane", 0.03);
+    oil.addTBPfraction("C7", 0.05, 0.096, 0.738);
+    oil.addTBPfraction("C8", 0.04, 0.107, 0.765);
+    oil.addTBPfraction("C9", 0.03, 0.121, 0.781);
+    oil.addTBPfraction("C10", 0.02, 0.134, 0.792);
+    oil.addPlusFraction("C11", 0.18, 0.250, 0.85);
+
+    assertEquals(0.096, oil.getPhase(0).getComponent("C7_PC").getMolarMass(), 1.0e-12);
+    assertEquals(0.250, oil.getPhase(0).getComponent("C11_PC").getMolarMass(), 1.0e-12);
+
+    oil.setMixingRule("classic");
+    new ThermodynamicOperations(oil).TPflash();
+    oil.initProperties();
+
+    assertTrue(oil.getNumberOfPhases() >= 1);
+    assertTrue(oil.getDensity("kg/m3") > 0.0);
+  }
+}


### PR DESCRIPTION
## Summary

Repairs D019 of #2499: thermodynamics overview and fluid-creation guidance.

### Frozen scan scope

- `docs/thermo/README.md`
- `docs/thermo/fluid_creation_guide.md`
- focused regression coverage in `FluidCreationGuideDocumentationTest`

This deliberately excludes EOS production code and documentation under active Span-Wagner, Vega, fundamental-EOS, electrolyte-CPA, GERG-extension, delumping, and phase-envelope work.

### Confirmed defects and fixes

1. **High — heavy-end molar masses were 1,000× too large.** The guide labelled `addTBPfraction` and `addPlusFraction` input as g/mol and supplied 96–350. Current `SystemInterface` and `SystemThermo` consume kg/mol and internally convert to g/mol for correlations. All examples now use 0.096–0.350 kg/mol.
2. **High — GERG was presented as an unquestioned fiscal/custody-transfer choice.** Current `SystemGERG2008Eos` source explicitly marks parts unfinished. The guide now frames it as a reference-comparison and validation tool, not sole fiscal evidence.
3. **Medium — the 21-component GERG list omitted H2S.** The mapped implementation has 21 slots including H2S; the list now includes it.
4. **Medium — plus-fraction labels used embedded `+` suffixes.** Numeric labels now follow the current characterization convention; NeqSim adds `_PC`.
5. **Medium — `init(0)` was described as equilibrium initialization.** The basic workflow now runs `TPflash()` and `initProperties()`.
6. **Medium — every system class was claimed to share identical defaults and constructors.** The guide now states that defaults and the solids overload are model-specific.
7. **Low/medium — salinity flow was ambiguous as concentration.** The Søreide-Whitson example now identifies the argument as salt-equivalent molar flow.
8. **Low/medium — fragile class counts and literal Java-to-Python translation guidance were stale.** The overview now avoids volatile counts and points readers to gateway-specific Python setup.

### Verification performed

- Current-source audit against `SystemInterface`, `SystemThermo`, `SystemSoreideWhitson`, `SystemGERG2008Eos`, `GERG2008`, and `EosMixingRuleType`.
- All 34 relative destinations across the two pages resolve on current `master`.
- Front matter, table-of-contents anchors, balanced code fences, and both display-math blocks were statically checked.
- Added four focused executable tests for the natural-gas, CPA water/hydrocarbon, GERG-density, and characterized-oil workflows. The oil test asserts the stored C7 and C11 pseudo-component molar masses before flashing.

Hosted documentation build/search, pre-commit, Spotless, Javadoc, agent-reference, and CodeQL checks pass. `FluidCreationGuideDocumentationTest` passes 4/4 on Ubuntu and Windows with Java 8 and 21. Complete suites pass with zero failures or errors: Ubuntu Java 21 ran 10,866 tests (215 skipped); Windows Java 21 and both Java 8 jobs ran 10,664 tests each (212 skipped). Final-head Copilot reviewed all 3 changed files and generated no comments or suggested-change blocks; there are no review threads and no commits applying Copilot suggestions. The complete three-commit diff remains limited to the frozen three files. No rendered-site artifact is available, so browser inspection is not claimed.

### Deliberate exclusions

- No production code, notebooks, images, or equations changed.
- No direct `master` update, merge, or auto-merge.
- Next rotation scope after D019: process equipment and process simulation.
