### PR TITLE
docs: repair mixer and splitter workflows (D020)

### DIFF
--- a/docs/process/equipment/mixers_splitters.md
+++ b/docs/process/equipment/mixers_splitters.md
@@ -135,6 +135,7 @@ The following splitter snippets continue from `mixedGas`, which is created in th
 example above.
 
 ```java
+// Continue from the complete mixer example above.
 Splitter splitter = new Splitter("SP-100", mixedGas, 2);
 splitter.setSplitFactors(new double[] {7.0, 3.0});
 splitter.run();
@@ -152,6 +153,7 @@ Use `setFlowRates` when one or more outlet flow rates are known. `Splitter.REMAI
 `-1.0`) marks an outlet that receives material left after the fixed demands:
 
 ```java
+// Continue from the complete mixer example above.
 Splitter distributor = new Splitter("distribution splitter", mixedGas, 2);
 distributor.setFlowRates(
     new double[] {2500.0, Splitter.REMAINDER},
@@ -173,6 +175,7 @@ clamped to zero.
 implementation. This snippet reuses `richGas` and `leanGas` from the complete mixer example:
 
 ```java
+// Continue from the complete mixer example above.
 StaticMixer staticMixer = new StaticMixer("MX-101");
 staticMixer.addStream(richGas);
 staticMixer.addStream(leanGas);

--- a/docs/process/equipment/mixers_splitters.md
+++ b/docs/process/equipment/mixers_splitters.md
@@ -128,7 +128,8 @@ $$
 
 ### Relative split factors
 
-`setSplitFactors` accepts nonnegative relative weights and normalizes them. The values do not have
+`setSplitFactors` treats its values as relative weights. It clamps negative values to zero and
+normalizes the remaining weights, so at least one value must be positive. The values do not have
 to sum to one. For example, `{7.0, 3.0}` becomes `{0.7, 0.3}`.
 
 The following splitter snippets continue from `mixedGas`, which is created in the complete mixer
@@ -143,9 +144,6 @@ splitter.run();
 StreamInterface product = splitter.getSplitStream(0);
 StreamInterface recycle = splitter.getSplitStream(1);
 ```
-
-Negative factor weights are clamped to zero before normalization. Supply at least one positive
-weight.
 
 ### Specified flows and remainder outlets
 

--- a/docs/process/equipment/mixers_splitters.md
+++ b/docs/process/equipment/mixers_splitters.md
@@ -131,10 +131,10 @@ $$
 `setSplitFactors` accepts nonnegative relative weights and normalizes them. The values do not have
 to sum to one. For example, `{7.0, 3.0}` becomes `{0.7, 0.3}`.
 
-```java
-import neqsim.process.equipment.splitter.Splitter;
-import neqsim.process.equipment.stream.StreamInterface;
+The following splitter snippets continue from `mixedGas`, which is created in the complete mixer
+example above.
 
+```java
 Splitter splitter = new Splitter("SP-100", mixedGas, 2);
 splitter.setSplitFactors(new double[] {7.0, 3.0});
 splitter.run();
@@ -170,12 +170,9 @@ clamped to zero.
 ## Static mixer
 
 `StaticMixer` supports the same multi-inlet connection pattern but uses its own mixing
-implementation:
+implementation. This snippet reuses `richGas` and `leanGas` from the complete mixer example:
 
 ```java
-import neqsim.process.equipment.mixer.StaticMixer;
-import neqsim.process.equipment.stream.StreamInterface;
-
 StaticMixer staticMixer = new StaticMixer("MX-101");
 staticMixer.addStream(richGas);
 staticMixer.addStream(leanGas);

--- a/docs/process/equipment/mixers_splitters.md
+++ b/docs/process/equipment/mixers_splitters.md
@@ -1,278 +1,206 @@
 ---
 title: Mixers and Splitters
-description: Documentation for stream mixing and splitting equipment in NeqSim.
+description: Combine and divide NeqSim process streams with mass, component, and energy checks.
 ---
 
-# Mixers and Splitters
+Mixers combine material streams, while splitters divide one stream without changing its
+thermodynamic state or composition. The public classes are in
+`neqsim.process.equipment.mixer` and `neqsim.process.equipment.splitter`.
 
-Documentation for stream mixing and splitting equipment in NeqSim.
+## Capabilities
 
-## Table of Contents
-- [Overview](#overview)
-- [Mixer](#mixer)
-- [Splitter](#splitter)
-- [Static Mixer](#static-mixer)
-- [Examples](#examples)
+| Class | Use |
+| --- | --- |
+| `Mixer` | Combine two or more streams and calculate an outlet state |
+| `StaticMixer` | Use the alternative static-mixing implementation |
+| `Splitter` | Divide one stream by relative factors or specified outlet flow rates |
 
----
-
-## Overview
-
-**Location:** `neqsim.process.equipment.mixer`, `neqsim.process.equipment.splitter`
-
-**Classes:**
-| Class               | Description                 |
-| ------------------- | --------------------------- |
-| `Mixer`             | Combine multiple streams    |
-| `MixerInterface`    | Mixer interface             |
-| `Splitter`          | Split stream into fractions |
-| `SplitterInterface` | Splitter interface          |
-| `StaticMixer`       | Static mixing element       |
-
----
+The stream accessors return `StreamInterface`. Keep that interface type unless a downstream API
+specifically requires the concrete `Stream` class.
 
 ## Mixer
 
-Combine multiple streams into one outlet stream.
+In its default mode, `Mixer` applies total mass and component balances and calculates the outlet
+temperature from an enthalpy balance:
 
-### Basic Usage
+$$
+\dot{m}_{\mathrm{out}}=\sum_i \dot{m}_i
+$$
+
+$$
+\dot{H}_{\mathrm{out}}=\sum_i \dot{H}_i
+$$
+
+For component $j$, the outlet mole fraction is molar-flow weighted:
+
+$$
+x_{j,\mathrm{out}}=
+\frac{\sum_i \dot{n}_i x_{j,i}}{\sum_i \dot{n}_i}
+$$
+
+Here, $\dot{m}$ is mass flow, $\dot{n}$ is molar flow, $\dot{H}$ is enthalpy
+flow, and $x_j$ is mole fraction.
+
+### Complete mixer example
 
 ```java
 import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+SystemSrkEos richFluid = new SystemSrkEos(300.0, 30.0);
+richFluid.addComponent("methane", 0.80);
+richFluid.addComponent("ethane", 0.15);
+richFluid.addComponent("propane", 0.05);
+richFluid.setMixingRule("classic");
+
+Stream richGas = new Stream("rich gas", richFluid);
+richGas.setFlowRate(5000.0, "kg/hr");
+richGas.run();
+
+SystemSrkEos leanFluid = new SystemSrkEos(310.0, 32.0);
+leanFluid.addComponent("methane", 0.95);
+leanFluid.addComponent("ethane", 0.04);
+leanFluid.addComponent("propane", 0.01);
+leanFluid.setMixingRule("classic");
+
+Stream leanGas = new Stream("lean gas", leanFluid);
+leanGas.setFlowRate(3000.0, "kg/hr");
+leanGas.run();
 
 Mixer mixer = new Mixer("M-100");
-mixer.addStream(stream1);
-mixer.addStream(stream2);
-mixer.addStream(stream3);
+mixer.addStream(richGas);
+mixer.addStream(leanGas);
 mixer.run();
 
-Stream mixed = mixer.getOutletStream();
+StreamInterface mixedGas = mixer.getOutletStream();
+double mixedFlowKgPerHour = mixedGas.getFlowRate("kg/hr");
+double mixedTemperatureC = mixedGas.getTemperature("C");
 ```
 
-### Mixing Calculation
+The example produces $8000\ \mathrm{kg/h}$. A focused documentation test verifies the flow,
+enthalpy closure, component result, and pressure diagnostics.
 
-The mixer performs mass and energy balance:
+### Pressure behavior and diagnostics
 
-$$\dot{m}_{out} = \sum_i \dot{m}_i$$
-
-$$\dot{m}_{out} \cdot h_{out} = \sum_i \dot{m}_i \cdot h_i$$
-
-$$x_{j,out} = \frac{\sum_i \dot{m}_i \cdot x_{j,i}}{\sum_i \dot{m}_i}$$
-
-> **Note:** The outlet temperature of a mixer is **calculated** from the energy balance of the inlet streams — there is no `setOutletTemperature()` method for the mixer. If you need to control the temperature after mixing, use a downstream `Heater` or `Cooler`.
-
-### Pressure Handling
+`Mixer` sets the outlet pressure to the lowest active inlet pressure. It does not provide an
+independent `setOutletPressure` specification. If active inlet pressures differ by more than the
+configured tolerance, the calculation continues at the lowest pressure and records a diagnostic:
 
 ```java
-// Default: outlet pressure = minimum inlet pressure
+mixer.setPressureMismatchTolerance(0.5);
 mixer.run();
 
-// Or specify outlet pressure
-mixer.setOutletPressure(20.0, "bara");
+boolean pressureMismatch = mixer.isPressureMismatch();
+double pressureSpreadBar = mixer.getInletPressureSpread();
+double minimumInletPressureBara = mixer.getMinInletPressure();
+double maximumInletPressureBara = mixer.getMaxInletPressure();
+```
+
+A material mixer is not a hydraulic pressure-drop model. Use an upstream valve, compressor, pump,
+or pipeline model when pressure equalization or pressure loss must be represented explicitly.
+
+### Specified outlet temperature
+
+`setOutletTemperature(double)` is available and expects kelvin. It changes the calculation from
+the default enthalpy-balanced mode to a specified-temperature TP flash:
+
+```java
+mixer.setOutletTemperature(305.15);
 mixer.run();
 ```
 
----
+Use this mode only when the outlet temperature is an imposed boundary condition. For an auditable
+heating or cooling duty, retain the energy-balanced mixer and add a downstream `Heater` or
+`Cooler`.
 
 ## Splitter
 
-Split a stream into multiple fractions.
+`Splitter` clones the inlet thermodynamic state and composition into each outlet and changes only
+the amount of material. For normalized split factors $f_k$:
 
-### Basic Usage
+$$
+\dot{m}_k=f_k\dot{m}_{\mathrm{in}},
+\qquad
+\sum_k f_k=1
+$$
+
+### Relative split factors
+
+`setSplitFactors` accepts nonnegative relative weights and normalizes them. The values do not have
+to sum to one. For example, `{7.0, 3.0}` becomes `{0.7, 0.3}`.
 
 ```java
 import neqsim.process.equipment.splitter.Splitter;
+import neqsim.process.equipment.stream.StreamInterface;
 
-// Split into 2 streams
-Splitter splitter = new Splitter("SP-100", inletStream, 2);
-splitter.setSplitFactors(new double[]{0.7, 0.3});  // 70% and 30%
+Splitter splitter = new Splitter("SP-100", mixedGas, 2);
+splitter.setSplitFactors(new double[] {7.0, 3.0});
 splitter.run();
 
-Stream split1 = splitter.getSplitStream(0);  // 70%
-Stream split2 = splitter.getSplitStream(1);  // 30%
+StreamInterface product = splitter.getSplitStream(0);
+StreamInterface recycle = splitter.getSplitStream(1);
 ```
 
-### Split Factor Specification
+Negative factor weights are clamped to zero before normalization. Supply at least one positive
+weight.
+
+### Specified flows and remainder outlets
+
+Use `setFlowRates` when one or more outlet flow rates are known. `Splitter.REMAINDER` (equal to
+`-1.0`) marks an outlet that receives material left after the fixed demands:
 
 ```java
-// By mass fractions (must sum to 1.0)
-splitter.setSplitFactors(new double[]{0.5, 0.3, 0.2});
+Splitter distributor = new Splitter("distribution splitter", mixedGas, 2);
+distributor.setFlowRates(
+    new double[] {2500.0, Splitter.REMAINDER},
+    "kg/hr");
+distributor.run();
 
-// By flow rates
-splitter.setFlowRates(new double[]{100.0, 60.0, 40.0}, "kg/hr");
+StreamInterface fixedDemand = distributor.getSplitStream(0);
+StreamInterface remainingFlow = distributor.getSplitStream(1);
 ```
 
-### Properties
+If several outlets use `Splitter.REMAINDER`, they share the leftover flow equally. If fixed
+positive demands exceed the inlet flow, NeqSim scales them proportionally to the available flow
+and assigns zero to remainder outlets. Other negative fixed-flow values are invalid and are
+clamped to zero.
 
-All split streams have identical:
-- Temperature
-- Pressure
-- Composition (mole fractions)
+## Static mixer
 
-Only flow rate differs.
-
----
-
-## Static Mixer
-
-For inline mixing with pressure drop.
-
-### Usage
+`StaticMixer` supports the same multi-inlet connection pattern but uses its own mixing
+implementation:
 
 ```java
 import neqsim.process.equipment.mixer.StaticMixer;
+import neqsim.process.equipment.stream.StreamInterface;
 
-StaticMixer staticMixer = new StaticMixer("Static Mixer");
-staticMixer.addStream(stream1);
-staticMixer.addStream(stream2);
-staticMixer.setPressureDrop(0.5, "bara");
+StaticMixer staticMixer = new StaticMixer("MX-101");
+staticMixer.addStream(richGas);
+staticMixer.addStream(leanGas);
 staticMixer.run();
+
+StreamInterface staticMixerOutlet = staticMixer.getOutletStream();
 ```
 
----
+`StaticMixer` does not expose a `setPressureDrop` method. Add a valve or pipe model when the
+pressure loss through a physical mixing element is part of the engineering question.
 
-## Examples
+## Validation checklist
 
-### Example 1: Simple Stream Mixing
+- Run every inlet stream before running a stand-alone mixer or splitter.
+- Check mixer mass and enthalpy closure in the default energy-balanced mode.
+- Inspect mixer pressure-mismatch diagnostics; do not silently mix materially different
+  pressures.
+- Check that splitter outlet flows sum to the inlet flow.
+- Use `StreamInterface` for mixer and splitter outlet accessors.
+- Add equipment to a `ProcessSystem` in upstream-to-downstream order for integrated simulations.
 
-```java
-import neqsim.thermo.system.SystemSrkEos;
-import neqsim.process.equipment.stream.Stream;
-import neqsim.process.equipment.mixer.Mixer;
+## Related documentation
 
-// Stream 1: Rich gas
-SystemSrkEos gas1 = new SystemSrkEos(300.0, 50.0);
-gas1.addComponent("methane", 0.80);
-gas1.addComponent("ethane", 0.15);
-gas1.addComponent("propane", 0.05);
-gas1.setMixingRule("classic");
-
-Stream stream1 = new Stream("Rich Gas", gas1);
-stream1.setFlowRate(5000.0, "kg/hr");
-stream1.run();
-
-// Stream 2: Lean gas
-SystemSrkEos gas2 = new SystemSrkEos(310.0, 50.0);
-gas2.addComponent("methane", 0.95);
-gas2.addComponent("ethane", 0.04);
-gas2.addComponent("propane", 0.01);
-gas2.setMixingRule("classic");
-
-Stream stream2 = new Stream("Lean Gas", gas2);
-stream2.setFlowRate(3000.0, "kg/hr");
-stream2.run();
-
-// Mix streams
-Mixer mixer = new Mixer("M-100");
-mixer.addStream(stream1);
-mixer.addStream(stream2);
-mixer.run();
-
-// Results
-Stream mixed = mixer.getOutletStream();
-System.out.println("Mixed flow: " + mixed.getFlowRate("kg/hr") + " kg/hr");
-System.out.println("Mixed temp: " + mixed.getTemperature("C") + " C");
-System.out.println("Methane: " + mixed.getFluid().getMoleFraction("methane"));
-```
-
-### Example 2: Recycle Split
-
-```java
-// Main process stream
-Stream processStream = new Stream("Process", processFluid);
-processStream.setFlowRate(10000.0, "kg/hr");
-processStream.run();
-
-// Split: 90% product, 10% recycle
-Splitter splitter = new Splitter("Recycle Splitter", processStream, 2);
-splitter.setSplitFactors(new double[]{0.90, 0.10});
-splitter.run();
-
-Stream product = splitter.getSplitStream(0);
-Stream recycle = splitter.getSplitStream(1);
-
-System.out.println("Product: " + product.getFlowRate("kg/hr") + " kg/hr");
-System.out.println("Recycle: " + recycle.getFlowRate("kg/hr") + " kg/hr");
-```
-
-### Example 3: Multiple Stream Manifold
-
-```java
-// Create manifold mixer for 4 wells
-Mixer manifold = new Mixer("Production Manifold");
-
-for (int i = 1; i <= 4; i++) {
-    SystemSrkEos wellFluid = new SystemSrkEos(350.0, 100.0 - i * 5);
-    wellFluid.addComponent("methane", 0.85);
-    wellFluid.addComponent("ethane", 0.08);
-    wellFluid.addComponent("propane", 0.05);
-    wellFluid.addComponent("water", 0.02);
-    wellFluid.setMixingRule("classic");
-
-    Stream wellStream = new Stream("Well " + i, wellFluid);
-    wellStream.setFlowRate(1000.0 + i * 200, "Sm3/day");
-    wellStream.run();
-
-    manifold.addStream(wellStream);
-}
-
-manifold.run();
-
-System.out.println("Total production: " + manifold.getOutletStream().getFlowRate("Sm3/day") + " Sm3/day");
-System.out.println("Manifold pressure: " + manifold.getOutletStream().getPressure("bara") + " bara");
-```
-
-### Example 4: Product Distribution
-
-```java
-// Gas from separator
-Stream gasProduct = separator.getGasOutStream();
-
-// Distribute to 3 customers
-Splitter distributor = new Splitter("Gas Distribution", gasProduct, 3);
-
-// Set by flow rates
-double[] rates = {5000.0, 3000.0, 2000.0};  // Sm3/hr
-distributor.setFlowRates(rates, "Sm3/hr");
-distributor.run();
-
-for (int i = 0; i < 3; i++) {
-    Stream customerStream = distributor.getSplitStream(i);
-    System.out.println("Customer " + (i+1) + ": " + customerStream.getFlowRate("Sm3/hr") + " Sm3/hr");
-}
-```
-
-### Example 5: Bypass Configuration
-
-```java
-// Main stream
-Stream mainStream = new Stream("Main", fluid);
-mainStream.setFlowRate(1000.0, "kg/hr");
-mainStream.run();
-
-// Split: 80% through heater, 20% bypass
-Splitter bypass = new Splitter("Bypass", mainStream, 2);
-bypass.setSplitFactors(new double[]{0.80, 0.20});
-bypass.run();
-
-// Heat 80%
-Heater heater = new Heater("E-100", bypass.getSplitStream(0));
-heater.setOutletTemperature(400.0, "K");
-heater.run();
-
-// Remix
-Mixer remix = new Mixer("M-100");
-remix.addStream(heater.getOutletStream());
-remix.addStream(bypass.getSplitStream(1));
-remix.run();
-
-System.out.println("Bypass temp control: " + remix.getOutletStream().getTemperature("K") + " K");
-```
-
----
-
-## Related Documentation
-
-- [Equipment Index](index.md) - All equipment
-- [Streams](streams) - Stream handling
-- [Controllers](../controllers) - Adjusters and recycles
+- [Equipment index](README.md)
+- [Streams](streams)
+- [Heat exchangers](heat_exchangers)
+- [Valves](valves)
+- [Controllers and recycles](../controllers)

--- a/docs/process/equipment/mixers_splitters.md
+++ b/docs/process/equipment/mixers_splitters.md
@@ -199,7 +199,7 @@ pressure loss through a physical mixing element is part of the engineering quest
 
 ## Related documentation
 
-- [Equipment index](README.md)
+- [Equipment index](index.md)
 - [Streams](streams)
 - [Heat exchangers](heat_exchangers)
 - [Valves](valves)

--- a/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
@@ -35,6 +35,13 @@ class MixerSplitterDocumentationTest {
     Stream richGas = createGasStream("rich gas", 300.0, 30.0, 5000.0, new double[] { 0.80, 0.15, 0.05 });
     Stream leanGas = createGasStream("lean gas", 310.0, 32.0, 3000.0, new double[] { 0.95, 0.04, 0.01 });
     double inletEnthalpyJ = richGas.getFluid().getEnthalpy("J") + leanGas.getFluid().getEnthalpy("J");
+    double richMolarFlow = richGas.getFlowRate("mole/sec");
+    double leanMolarFlow = leanGas.getFlowRate("mole/sec");
+    double expectedMethaneFraction =
+        (richMolarFlow * richGas.getFluid().getMolarComposition()[0]
+            + leanMolarFlow * leanGas.getFluid().getMolarComposition()[0])
+            / (richMolarFlow + leanMolarFlow);
+    double enthalpyToleranceJ = Math.max(1.0e-3, Math.abs(inletEnthalpyJ) * 1.0e-8);
 
     Mixer mixer = new Mixer("M-100");
     mixer.addStream(richGas);
@@ -44,7 +51,8 @@ class MixerSplitterDocumentationTest {
 
     StreamInterface mixedGas = mixer.getOutletStream();
     assertEquals(8000.0, mixedGas.getFlowRate("kg/hr"), 1.0e-6);
-    assertEquals(inletEnthalpyJ, mixedGas.getFluid().getEnthalpy("J"), 1.0e-3);
+    assertEquals(inletEnthalpyJ, mixedGas.getFluid().getEnthalpy("J"), enthalpyToleranceJ);
+    assertEquals(expectedMethaneFraction, mixedGas.getFluid().getMolarComposition()[0], 1.0e-10);
     assertEquals(30.0, mixedGas.getPressure("bara"), 1.0e-6);
     assertTrue(mixer.isPressureMismatch());
     assertEquals(2.0, mixer.getInletPressureSpread(), 1.0e-6);

--- a/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
@@ -81,6 +81,7 @@ class MixerSplitterDocumentationTest {
   @Test
   void splitterExamplesNormalizeFactorsAndConserveSpecifiedFlows() {
     Stream inlet = createGasStream("splitter inlet", 305.0, 30.0, 8000.0, new double[] { 0.90, 0.08, 0.02 });
+    double inletMethaneFraction = inlet.getFluid().getMolarComposition()[0];
 
     Splitter ratioSplitter = new Splitter("SP-100", inlet, 2);
     ratioSplitter.setSplitFactors(new double[] { 7.0, 3.0 });
@@ -90,6 +91,8 @@ class MixerSplitterDocumentationTest {
     StreamInterface recycle = ratioSplitter.getSplitStream(1);
     assertEquals(5600.0, product.getFlowRate("kg/hr"), 1.0e-3);
     assertEquals(2400.0, recycle.getFlowRate("kg/hr"), 1.0e-3);
+    assertEquals(inletMethaneFraction, product.getFluid().getMolarComposition()[0], 1.0e-10);
+    assertEquals(inletMethaneFraction, recycle.getFluid().getMolarComposition()[0], 1.0e-10);
     assertEquals(0.0, ratioSplitter.getMassBalance("kg/hr"), 1.0e-3);
 
     Splitter flowSplitter = new Splitter("distribution splitter", inlet, 2);
@@ -100,6 +103,8 @@ class MixerSplitterDocumentationTest {
     StreamInterface remainingFlow = flowSplitter.getSplitStream(1);
     assertEquals(2500.0, fixedDemand.getFlowRate("kg/hr"), 1.0e-3);
     assertEquals(5500.0, remainingFlow.getFlowRate("kg/hr"), 1.0e-3);
+    assertEquals(inletMethaneFraction, fixedDemand.getFluid().getMolarComposition()[0], 1.0e-10);
+    assertEquals(inletMethaneFraction, remainingFlow.getFluid().getMolarComposition()[0], 1.0e-10);
     assertEquals(0.0, flowSplitter.getMassBalance("kg/hr"), 1.0e-3);
   }
 }

--- a/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
@@ -37,10 +37,8 @@ class MixerSplitterDocumentationTest {
     double inletEnthalpyJ = richGas.getFluid().getEnthalpy("J") + leanGas.getFluid().getEnthalpy("J");
     double richMolarFlow = richGas.getFlowRate("mole/sec");
     double leanMolarFlow = leanGas.getFlowRate("mole/sec");
-    double expectedMethaneFraction =
-        (richMolarFlow * richGas.getFluid().getMolarComposition()[0]
-            + leanMolarFlow * leanGas.getFluid().getMolarComposition()[0])
-            / (richMolarFlow + leanMolarFlow);
+    double expectedMethaneFraction = (richMolarFlow * richGas.getFluid().getMolarComposition()[0]
+        + leanMolarFlow * leanGas.getFluid().getMolarComposition()[0]) / (richMolarFlow + leanMolarFlow);
     double enthalpyToleranceJ = Math.max(1.0e-3, Math.abs(inletEnthalpyJ) * 1.0e-8);
 
     Mixer mixer = new Mixer("M-100");

--- a/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
@@ -1,0 +1,107 @@
+package neqsim.process.equipment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.mixer.StaticMixer;
+import neqsim.process.equipment.splitter.Splitter;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Executable regression coverage for the mixers and splitters documentation.
+ */
+class MixerSplitterDocumentationTest {
+  private static Stream createGasStream(String name, double temperatureK, double pressureBara,
+      double flowKgPerHour, double[] composition) {
+    SystemSrkEos fluid = new SystemSrkEos(temperatureK, pressureBara);
+    fluid.addComponent("methane", composition[0]);
+    fluid.addComponent("ethane", composition[1]);
+    fluid.addComponent("propane", composition[2]);
+    fluid.setMixingRule("classic");
+
+    Stream stream = new Stream(name, fluid);
+    stream.setFlowRate(flowKgPerHour, "kg/hr");
+    stream.run();
+    return stream;
+  }
+
+  @Test
+  void mixerExampleClosesBalancesAndReportsPressureMismatch() {
+    Stream richGas =
+        createGasStream("rich gas", 300.0, 30.0, 5000.0, new double[] {0.80, 0.15, 0.05});
+    Stream leanGas =
+        createGasStream("lean gas", 310.0, 32.0, 3000.0, new double[] {0.95, 0.04, 0.01});
+    double inletEnthalpyJ =
+        richGas.getFluid().getEnthalpy("J") + leanGas.getFluid().getEnthalpy("J");
+
+    Mixer mixer = new Mixer("M-100");
+    mixer.addStream(richGas);
+    mixer.addStream(leanGas);
+    mixer.setPressureMismatchTolerance(0.5);
+    mixer.run();
+
+    StreamInterface mixedGas = mixer.getOutletStream();
+    assertEquals(8000.0, mixedGas.getFlowRate("kg/hr"), 1.0e-6);
+    assertEquals(inletEnthalpyJ, mixedGas.getFluid().getEnthalpy("J"), 1.0e-3);
+    assertEquals(30.0, mixedGas.getPressure("bara"), 1.0e-6);
+    assertTrue(mixer.isPressureMismatch());
+    assertEquals(2.0, mixer.getInletPressureSpread(), 1.0e-6);
+    assertEquals(30.0, mixer.getMinInletPressure(), 1.0e-6);
+    assertEquals(32.0, mixer.getMaxInletPressure(), 1.0e-6);
+  }
+
+  @Test
+  void specifiedTemperatureAndStaticMixerExamplesUseCurrentApis() {
+    Stream richGas =
+        createGasStream("rich gas", 300.0, 30.0, 5000.0, new double[] {0.80, 0.15, 0.05});
+    Stream leanGas =
+        createGasStream("lean gas", 310.0, 30.0, 3000.0, new double[] {0.95, 0.04, 0.01});
+
+    Mixer specifiedTemperatureMixer = new Mixer("specified-temperature mixer");
+    specifiedTemperatureMixer.addStream(richGas);
+    specifiedTemperatureMixer.addStream(leanGas);
+    specifiedTemperatureMixer.setOutletTemperature(305.15);
+    specifiedTemperatureMixer.run();
+    assertEquals(305.15, specifiedTemperatureMixer.getOutletStream().getTemperature("K"), 1.0e-6);
+
+    StaticMixer staticMixer = new StaticMixer("MX-101");
+    staticMixer.addStream(richGas);
+    staticMixer.addStream(leanGas);
+    staticMixer.run();
+    StreamInterface staticMixerOutlet = staticMixer.getOutletStream();
+    assertEquals(8000.0, staticMixerOutlet.getFlowRate("kg/hr"), 1.0e-6);
+  }
+
+  @Test
+  void splitterExamplesNormalizeFactorsAndConserveSpecifiedFlows() {
+    Stream inlet =
+        createGasStream("splitter inlet", 305.0, 30.0, 8000.0, new double[] {0.90, 0.08, 0.02});
+
+    Splitter ratioSplitter = new Splitter("SP-100", inlet, 2);
+    ratioSplitter.setSplitFactors(new double[] {7.0, 3.0});
+    ratioSplitter.run();
+
+    StreamInterface product = ratioSplitter.getSplitStream(0);
+    StreamInterface recycle = ratioSplitter.getSplitStream(1);
+    assertEquals(5600.0, product.getFlowRate("kg/hr"), 1.0e-3);
+    assertEquals(2400.0, recycle.getFlowRate("kg/hr"), 1.0e-3);
+    assertEquals(0.0, ratioSplitter.getMassBalance("kg/hr"), 1.0e-3);
+
+    Splitter flowSplitter = new Splitter("distribution splitter", inlet, 2);
+    flowSplitter.setFlowRates(
+        new double[] {2500.0, Splitter.REMAINDER},
+        "kg/hr");
+    flowSplitter.run();
+
+    StreamInterface fixedDemand = flowSplitter.getSplitStream(0);
+    StreamInterface remainingFlow = flowSplitter.getSplitStream(1);
+    assertEquals(2500.0, fixedDemand.getFlowRate("kg/hr"), 1.0e-3);
+    assertEquals(5500.0, remainingFlow.getFlowRate("kg/hr"), 1.0e-3);
+    assertEquals(0.0, flowSplitter.getMassBalance("kg/hr"), 1.0e-3);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
@@ -16,8 +16,8 @@ import neqsim.thermo.system.SystemSrkEos;
  * Executable regression coverage for the mixers and splitters documentation.
  */
 class MixerSplitterDocumentationTest {
-  private static Stream createGasStream(String name, double temperatureK, double pressureBara,
-      double flowKgPerHour, double[] composition) {
+  private static Stream createGasStream(String name, double temperatureK, double pressureBara, double flowKgPerHour,
+      double[] composition) {
     SystemSrkEos fluid = new SystemSrkEos(temperatureK, pressureBara);
     fluid.addComponent("methane", composition[0]);
     fluid.addComponent("ethane", composition[1]);
@@ -32,12 +32,9 @@ class MixerSplitterDocumentationTest {
 
   @Test
   void mixerExampleClosesBalancesAndReportsPressureMismatch() {
-    Stream richGas =
-        createGasStream("rich gas", 300.0, 30.0, 5000.0, new double[] {0.80, 0.15, 0.05});
-    Stream leanGas =
-        createGasStream("lean gas", 310.0, 32.0, 3000.0, new double[] {0.95, 0.04, 0.01});
-    double inletEnthalpyJ =
-        richGas.getFluid().getEnthalpy("J") + leanGas.getFluid().getEnthalpy("J");
+    Stream richGas = createGasStream("rich gas", 300.0, 30.0, 5000.0, new double[] { 0.80, 0.15, 0.05 });
+    Stream leanGas = createGasStream("lean gas", 310.0, 32.0, 3000.0, new double[] { 0.95, 0.04, 0.01 });
+    double inletEnthalpyJ = richGas.getFluid().getEnthalpy("J") + leanGas.getFluid().getEnthalpy("J");
 
     Mixer mixer = new Mixer("M-100");
     mixer.addStream(richGas);
@@ -57,10 +54,8 @@ class MixerSplitterDocumentationTest {
 
   @Test
   void specifiedTemperatureAndStaticMixerExamplesUseCurrentApis() {
-    Stream richGas =
-        createGasStream("rich gas", 300.0, 30.0, 5000.0, new double[] {0.80, 0.15, 0.05});
-    Stream leanGas =
-        createGasStream("lean gas", 310.0, 30.0, 3000.0, new double[] {0.95, 0.04, 0.01});
+    Stream richGas = createGasStream("rich gas", 300.0, 30.0, 5000.0, new double[] { 0.80, 0.15, 0.05 });
+    Stream leanGas = createGasStream("lean gas", 310.0, 30.0, 3000.0, new double[] { 0.95, 0.04, 0.01 });
 
     Mixer specifiedTemperatureMixer = new Mixer("specified-temperature mixer");
     specifiedTemperatureMixer.addStream(richGas);
@@ -79,11 +74,10 @@ class MixerSplitterDocumentationTest {
 
   @Test
   void splitterExamplesNormalizeFactorsAndConserveSpecifiedFlows() {
-    Stream inlet =
-        createGasStream("splitter inlet", 305.0, 30.0, 8000.0, new double[] {0.90, 0.08, 0.02});
+    Stream inlet = createGasStream("splitter inlet", 305.0, 30.0, 8000.0, new double[] { 0.90, 0.08, 0.02 });
 
     Splitter ratioSplitter = new Splitter("SP-100", inlet, 2);
-    ratioSplitter.setSplitFactors(new double[] {7.0, 3.0});
+    ratioSplitter.setSplitFactors(new double[] { 7.0, 3.0 });
     ratioSplitter.run();
 
     StreamInterface product = ratioSplitter.getSplitStream(0);
@@ -93,9 +87,7 @@ class MixerSplitterDocumentationTest {
     assertEquals(0.0, ratioSplitter.getMassBalance("kg/hr"), 1.0e-3);
 
     Splitter flowSplitter = new Splitter("distribution splitter", inlet, 2);
-    flowSplitter.setFlowRates(
-        new double[] {2500.0, Splitter.REMAINDER},
-        "kg/hr");
+    flowSplitter.setFlowRates(new double[] { 2500.0, Splitter.REMAINDER }, "kg/hr");
     flowSplitter.run();
 
     StreamInterface fixedDemand = flowSplitter.getSplitStream(0);

--- a/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java
@@ -82,6 +82,8 @@ class MixerSplitterDocumentationTest {
   void splitterExamplesNormalizeFactorsAndConserveSpecifiedFlows() {
     Stream inlet = createGasStream("splitter inlet", 305.0, 30.0, 8000.0, new double[] { 0.90, 0.08, 0.02 });
     double inletMethaneFraction = inlet.getFluid().getMolarComposition()[0];
+    double inletTemperatureK = inlet.getTemperature("K");
+    double inletPressureBara = inlet.getPressure("bara");
 
     Splitter ratioSplitter = new Splitter("SP-100", inlet, 2);
     ratioSplitter.setSplitFactors(new double[] { 7.0, 3.0 });
@@ -93,6 +95,10 @@ class MixerSplitterDocumentationTest {
     assertEquals(2400.0, recycle.getFlowRate("kg/hr"), 1.0e-3);
     assertEquals(inletMethaneFraction, product.getFluid().getMolarComposition()[0], 1.0e-10);
     assertEquals(inletMethaneFraction, recycle.getFluid().getMolarComposition()[0], 1.0e-10);
+    assertEquals(inletTemperatureK, product.getTemperature("K"), 1.0e-10);
+    assertEquals(inletTemperatureK, recycle.getTemperature("K"), 1.0e-10);
+    assertEquals(inletPressureBara, product.getPressure("bara"), 1.0e-10);
+    assertEquals(inletPressureBara, recycle.getPressure("bara"), 1.0e-10);
     assertEquals(0.0, ratioSplitter.getMassBalance("kg/hr"), 1.0e-3);
 
     Splitter flowSplitter = new Splitter("distribution splitter", inlet, 2);
@@ -105,6 +111,10 @@ class MixerSplitterDocumentationTest {
     assertEquals(5500.0, remainingFlow.getFlowRate("kg/hr"), 1.0e-3);
     assertEquals(inletMethaneFraction, fixedDemand.getFluid().getMolarComposition()[0], 1.0e-10);
     assertEquals(inletMethaneFraction, remainingFlow.getFluid().getMolarComposition()[0], 1.0e-10);
+    assertEquals(inletTemperatureK, fixedDemand.getTemperature("K"), 1.0e-10);
+    assertEquals(inletTemperatureK, remainingFlow.getTemperature("K"), 1.0e-10);
+    assertEquals(inletPressureBara, fixedDemand.getPressure("bara"), 1.0e-10);
+    assertEquals(inletPressureBara, remainingFlow.getPressure("bara"), 1.0e-10);
     assertEquals(0.0, flowSplitter.getMassBalance("kg/hr"), 1.0e-3);
   }
 }


### PR DESCRIPTION
## D020 — mixers and splitters

Campaign: #2499

### Frozen scope

- `docs/process/equipment/mixers_splitters.md`
- `src/test/java/neqsim/process/equipment/MixerSplitterDocumentationTest.java`

Rotation scope: process equipment and process simulation. Separator documentation and every file touched by other open PRs were deliberately excluded.

### Confirmed defects and evidence

1. **High — non-compiling outlet types:** `Mixer.getOutletStream()` and `Splitter.getSplitStream(int)` return `StreamInterface`, but the page assigned them to `Stream`.
2. **High — nonexistent mixer pressure API:** the page called `Mixer.setOutletPressure(...)`; the current mixer instead selects the lowest active inlet pressure and exposes mismatch diagnostics.
3. **High — nonexistent static-mixer API:** the page called `StaticMixer.setPressureDrop(...)`, which does not exist.
4. **High — incomplete examples presented as runnable:** several blocks depended on undeclared `fluid`, `processFluid`, or `separator` variables.
5. **Medium — incorrect component equation:** outlet mole fraction was mass-flow weighted; it must be molar-flow weighted.
6. **Medium — false temperature claim:** the page said `Mixer.setOutletTemperature` did not exist. It exists, accepts kelvin, and switches the mixer to a specified-temperature TP flash.
7. **Medium — incomplete pressure guidance:** lowest-inlet behavior, tolerance, and `isPressureMismatch` diagnostics were omitted.
8. **Medium — stale splitter semantics:** factor weights are normalized; `Splitter.REMAINDER`, multiple remainder outlets, oversubscribed fixed demands, and invalid negative demands were undocumented.
9. **Medium — repository/style/rendering defects:** duplicate H1, non-standalone equation delimiters, and `System.out`-based examples conflicted with repository documentation conventions.

### Fix

- Replaced stale API usage with current `Mixer`, `StaticMixer`, `Splitter`, and `StreamInterface` workflows.
- Corrected mass, enthalpy, molar component, and split equations.
- Documented energy-balanced versus specified-temperature mixer behavior.
- Documented lowest-active-inlet pressure behavior and public pressure diagnostics.
- Documented exact split-factor clamping/normalization and fixed-flow/remainder semantics.
- Made every continuation-snippet boundary explicit in prose and inside its code fence.
- Added three focused executable tests covering mass, energy, pressure, temperature, composition, outlet-state preservation, normalization, and remainder behavior.

### Validation evidence

Completed on exact head `44e628b` and merge base `5ceeeca`:

- Complete 11-commit comparison reviewed: exactly the two frozen files; no production code.
- Current implementations, interfaces, and repository tests audited.
- Jekyll front matter and Markdown structure statically valid; duplicate H1 removed.
- Six Java fences and four display equations are balanced; display delimiters are standalone.
- Five relative targets resolve: equipment index, streams, heat exchangers, valves, and controllers.
- No external links, images, notebooks, HTML interactions, or orphan/index changes are in scope.
- No `System.out`, fictitious `setOutletPressure`, or fictitious `setPressureDrop` call remains.
- Documentation lines remain below 100 characters; all changed lines remain below 120 characters.
- Hosted Spotless, pre-commit, Javadoc, agent-reference, documentation build/search, and CodeQL checks pass.
- `MixerSplitterDocumentationTest` passes 3/3 on Ubuntu and Windows with Java 8 and 21.
- Complete suites pass with zero failures/errors:
  - Ubuntu Java 21: 10,869 tests, 215 skipped.
  - Windows Java 21: 10,667 tests, 212 skipped.
  - Ubuntu Java 8: 10,667 tests, 212 skipped.
  - Windows Java 8: 10,667 tests, 212 skipped.
- Copilot gate: seven inline threads and seven suppressed observations across prior heads were technically assessed. Valid findings were applied or adapted; duplicate/outdated observations were documented. All threads are resolved. Two final-head Copilot reviews covered both files and generated no new comments. No Copilot-authored or automatically applied commit exists.

No browser-rendered site artifact is available, so visual page inspection is not claimed. D020 is ready for maintainer review and the PR intentionally remains draft.

### Next scope

After D020 is merged, D021 will rotate to engineering design, safety, DEXPI, and field development.