### PR TITLE
fix: scale LNG layer flash inventory before composition

### DIFF
--- a/src/main/java/neqsim/process/equipment/lng/LNGTankLayeredModel.java
+++ b/src/main/java/neqsim/process/equipment/lng/LNGTankLayeredModel.java
@@ -346,7 +346,6 @@ public class LNGTankLayeredModel implements Serializable {
     }
     system.setTotalNumberOfMoles(layer.getTotalMoles());
     system.setMolarComposition(molarComposition);
-    system.init(0);
     return system;
   }
 

--- a/src/main/java/neqsim/process/equipment/lng/LNGTankLayeredModel.java
+++ b/src/main/java/neqsim/process/equipment/lng/LNGTankLayeredModel.java
@@ -332,20 +332,21 @@ public class LNGTankLayeredModel implements Serializable {
     system.setPressure(tankPressure);
     system.setTemperature(layer.getTemperature());
 
-    // Set composition from layer
+    // Scale the cloned reference system to the layer inventory and composition.
+    // The reference system can contain an arbitrary number of moles (for example,
+    // a Stream flow basis), so component deltas must not be calculated from mole
+    // fractions alone.
     system.init(0);
-    double currentMoles = system.getTotalNumberOfMoles();
     Map<String, Double> comp = layer.getComposition();
+    double[] molarComposition = new double[system.getPhase(0).getNumberOfComponents()];
 
     for (int i = 0; i < system.getPhase(0).getNumberOfComponents(); i++) {
       String name = system.getPhase(0).getComponent(i).getComponentName();
-      double targetFrac = comp.containsKey(name) ? comp.get(name) : 0.0;
-      double currentFrac = system.getPhase(0).getComponent(i).getz();
-      double molesNeeded = (targetFrac - currentFrac) * layer.getTotalMoles();
-      if (Math.abs(molesNeeded) > 1e-20) {
-        system.addComponent(name, molesNeeded);
-      }
+      molarComposition[i] = comp.containsKey(name) ? comp.get(name) : 0.0;
     }
+    system.setTotalNumberOfMoles(layer.getTotalMoles());
+    system.setMolarComposition(molarComposition);
+    system.init(0);
     return system;
   }
 

--- a/src/test/java/neqsim/process/equipment/lng/LNGAgeingTest.java
+++ b/src/test/java/neqsim/process/equipment/lng/LNGAgeingTest.java
@@ -131,7 +131,12 @@ public class LNGAgeingTest {
 
     assertNotNull(result);
     assertTrue(result.getTemperature() > 0, "Temperature should be positive");
-    assertTrue(result.getDensity() > 0, "Density should be positive");
+    assertTrue(result.getDensity() > 400.0 && result.getDensity() < 500.0,
+        "Density should remain in the physical LNG range, got " + result.getDensity());
+    assertTrue(result.getGcvVolumetric() > 35.0 && result.getGcvVolumetric() < 50.0,
+        "Volumetric GCV should remain in the LNG range, got " + result.getGcvVolumetric());
+    assertTrue(result.getWobbeIndex() > 45.0 && result.getWobbeIndex() < 65.0,
+        "Wobbe index should remain in the LNG range, got " + result.getWobbeIndex());
     assertTrue(result.getBogMassFlowRate() >= 0, "BOG rate should be non-negative");
 
     assertTrue(model.getTotalLiquidMoles() <= initialMoles, "Moles should not increase after boil-off");


### PR DESCRIPTION
## Summary

- scale a cloned LNG reference system to the layer's total mole inventory before applying the layer molar composition
- remove dependence on the arbitrary `Stream`/reference-fluid mole basis in `buildFlashSystem`
- add physical LNG-range regression bounds for density, volumetric GCV, and Wobbe index after one ageing step

## Problem reproduced

Using the public PyPI NeqSim 3.16.0 `LNGAgeingScenario` with the documented lean-LNG feed pattern produced an initial ISO 6578 density of 452.082 kg/m3, but after ageing returned 752.797 kg/m3, 151.718 MJ/Sm3 GCV, and 98.260 MJ/Sm3 Wobbe index. The cause is that `buildFlashSystem` adds mole-fraction deltas multiplied by the layer inventory to a clone that still has its arbitrary reference inventory.

## Validation

A release-JAR probe of the corrected operation order (`setTotalNumberOfMoles`, then `setMolarComposition`, then bubble-point flash) produced 452.082 kg/m3, 41.667 MJ/Sm3 GCV, 53.839 MJ/Sm3 Wobbe index, and a liquid composition sum of 1.0. The added JUnit bounds encode those physical expectations.

The local automation image contains Java 17 but not `javac`/Maven, so this PR is opened as a draft for repository CI rather than being claimed ready for merge.