### PR TITLE
docs: preserve curated notebook pages

### DIFF
--- a/docs/convert_notebooks.py
+++ b/docs/convert_notebooks.py
@@ -65,20 +65,31 @@ def notebook_to_markdown(notebook_path):
         nb = json.load(f)
 
     notebook_name = Path(notebook_path).stem
-    title = notebook_name.replace('_', ' ').replace('-', ' ')
+    documentation_metadata = nb.get('metadata', {}).get('neqsim_docs', {})
+    title = documentation_metadata.get(
+        'title',
+        notebook_name.replace('_', ' ').replace('-', ' '),
+    )
+    description = documentation_metadata.get(
+        'description',
+        'Jupyter notebook tutorial for NeqSim',
+    )
+    generated_title = (
+        f"# {title}\n\n"
+        if documentation_metadata.get('show_generated_title', True)
+        else ''
+    )
 
     # Jekyll front matter
     front_matter = f"""---
 layout: default
 title: "{title}"
-description: "Jupyter notebook tutorial for NeqSim"
+description: "{description}"
 parent: Examples
 nav_order: 1
 ---
 
-# {title}
-
-> **Note:** This is an auto-generated Markdown version of the Jupyter notebook
+{generated_title}> **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`{notebook_name}.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/{notebook_name}.ipynb).
 > You can also [view it on nbviewer](https://nbviewer.org/github/equinor/neqsim/blob/master/docs/examples/{notebook_name}.ipynb)
 > or [open in Google Colab](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/{notebook_name}.ipynb).
@@ -159,26 +170,6 @@ nav_order: 1
     return full_content
 
 
-def should_preserve_markdown(markdown_path):
-    """Return whether an existing generated page is explicitly curated."""
-    if not markdown_path.exists():
-        return False
-
-    content = markdown_path.read_text(encoding="utf-8")
-    if not content.startswith("---\n"):
-        return False
-
-    try:
-        front_matter = content.split("---\n", 2)[1]
-    except IndexError:
-        return False
-
-    return any(
-        line.strip().lower() == "notebook_conversion: preserve"
-        for line in front_matter.splitlines()
-    )
-
-
 def convert_all_notebooks(examples_dir):
     """
     Convert all notebooks in the examples directory to Markdown.
@@ -203,10 +194,6 @@ def convert_all_notebooks(examples_dir):
     for nb_path in notebooks:
         md_filename = nb_path.stem + '.md'
         md_path = examples_path / md_filename
-
-        if should_preserve_markdown(md_path):
-            print(f"  Preserving curated page: {md_filename}")
-            continue
 
         print(f"  Converting: {nb_path.name} -> {md_filename}")
 

--- a/docs/convert_notebooks.py
+++ b/docs/convert_notebooks.py
@@ -159,6 +159,26 @@ nav_order: 1
     return full_content
 
 
+def should_preserve_markdown(markdown_path):
+    """Return whether an existing generated page is explicitly curated."""
+    if not markdown_path.exists():
+        return False
+
+    content = markdown_path.read_text(encoding="utf-8")
+    if not content.startswith("---\n"):
+        return False
+
+    try:
+        front_matter = content.split("---\n", 2)[1]
+    except IndexError:
+        return False
+
+    return any(
+        line.strip().lower() == "notebook_conversion: preserve"
+        for line in front_matter.splitlines()
+    )
+
+
 def convert_all_notebooks(examples_dir):
     """
     Convert all notebooks in the examples directory to Markdown.
@@ -183,6 +203,10 @@ def convert_all_notebooks(examples_dir):
     for nb_path in notebooks:
         md_filename = nb_path.stem + '.md'
         md_path = examples_path / md_filename
+
+        if should_preserve_markdown(md_path):
+            print(f"  Preserving curated page: {md_filename}")
+            continue
 
         print(f"  Converting: {nb_path.name} -> {md_filename}")
 

--- a/docs/convert_notebooks.py
+++ b/docs/convert_notebooks.py
@@ -66,6 +66,8 @@ def notebook_to_markdown(notebook_path):
 
     notebook_name = Path(notebook_path).stem
     documentation_metadata = nb.get('metadata', {}).get('neqsim_docs', {})
+    if not isinstance(documentation_metadata, dict):
+        documentation_metadata = {}
     title = documentation_metadata.get(
         'title',
         notebook_name.replace('_', ' ').replace('-', ' '),
@@ -79,12 +81,14 @@ def notebook_to_markdown(notebook_path):
         if documentation_metadata.get('show_generated_title', True)
         else ''
     )
+    title_yaml = json.dumps(str(title), ensure_ascii=False)
+    description_yaml = json.dumps(str(description), ensure_ascii=False)
 
     # Jekyll front matter
     front_matter = f"""---
 layout: default
-title: "{title}"
-description: "{description}"
+title: {title_yaml}
+description: {description_yaml}
 parent: Examples
 nav_order: 1
 ---

--- a/docs/examples/FieldDevelopmentWorkflow.ipynb
+++ b/docs/examples/FieldDevelopmentWorkflow.ipynb
@@ -349,6 +349,11 @@
   "language_info": {
    "name": "python",
    "version": "3.12"
+  },
+  "neqsim_docs": {
+   "description": "Executable NeqSim tutorial for unit-safe gas-production profiles, after-tax cash flow, and bounded sensitivities.",
+   "show_generated_title": false,
+   "title": "Transparent field-development screening"
   }
  },
  "nbformat": 4,

--- a/docs/examples/FieldDevelopmentWorkflow.md
+++ b/docs/examples/FieldDevelopmentWorkflow.md
@@ -4,26 +4,26 @@ title: "Transparent field-development screening"
 description: "Executable NeqSim tutorial for unit-safe gas-production profiles, after-tax cash flow, and bounded sensitivities."
 parent: Examples
 nav_order: 1
-notebook_conversion: preserve
 ---
 
-> **Notebook:** This page mirrors
+# FieldDevelopmentWorkflow
+
+> **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`FieldDevelopmentWorkflow.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/FieldDevelopmentWorkflow.ipynb).
 > You can also [view it on nbviewer](https://nbviewer.org/github/equinor/neqsim/blob/master/docs/examples/FieldDevelopmentWorkflow.ipynb)
-> or [open it in Google Colab](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/FieldDevelopmentWorkflow.ipynb).
+> or [open in Google Colab](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/FieldDevelopmentWorkflow.ipynb).
 
-This tutorial builds an auditable gas-production forecast and after-tax cash flow from current NeqSim APIs. It
-deliberately uses the lower-level production-profile and economics classes so every unit conversion and assumption is
-visible.
+---
 
-> **Engineering boundary:** this is a deterministic screening example, not a reserves estimate, concept approval,
-> FEED model, or investment recommendation. Replace the synthetic rates, costs, prices, fiscal basis, and decline
-> assumptions with traceable project data and qualified engineering models.
+# Transparent field-development screening with NeqSim
+
+This tutorial builds an auditable gas-production forecast and after-tax cash flow from current NeqSim APIs. It deliberately uses the lower-level production-profile and economics classes so every unit conversion and assumption is visible.
+
+> **Engineering boundary:** this is a deterministic screening example, not a reserves estimate, concept approval, FEED model, or investment recommendation. Replace the synthetic rates, costs, prices, fiscal basis, and decline assumptions with traceable project data and qualified engineering models.
 
 ## 1. Runtime setup
 
-The setup installs the current public `neqsim` package only when it is missing. Restart the runtime after changing the
-installed NeqSim version.
+The setup installs the current public `neqsim` package only when it is missing. Restart the runtime after changing the installed NeqSim version.
 
 ```python
 import importlib.util
@@ -53,11 +53,7 @@ DAYS_PER_YEAR = 365.25
 
 ## 2. Define the screening basis
 
-The example represents a synthetic four-well gas development. Throughout this tutorial, Sm³ uses a 15 °C and
-1.01325 bara accounting basis. `ProductionProfileGenerator` treats the supplied volumes numerically; it does not
-perform a standard-condition conversion. Rates are standard cubic metres per day, and yearly profile values are
-standard cubic metres per year. Monetary inputs and outputs are million US dollars unless the API label states
-otherwise. The synthetic costs are teaching inputs, not an AACE-classified estimate.
+The example represents a synthetic four-well gas development. Throughout this tutorial, Sm³ uses a 15 °C and 1.01325 bara accounting basis. `ProductionProfileGenerator` treats the supplied volumes numerically; it does not perform a standard-condition conversion. Rates are standard cubic metres per day, and yearly profile values are standard cubic metres per year. Monetary inputs and outputs are million US dollars unless the API label states otherwise. The synthetic costs are teaching inputs, not an AACE-classified estimate.
 
 | Assumption | Value |
 |---|---:|
@@ -71,9 +67,7 @@ otherwise. The synthetic costs are teaching inputs, not an AACE-classified estim
 | Discount rate | 8% |
 | Fiscal model | `CashFlowEngine("NO")` |
 
-The `ProductionProfileGenerator.generateFullProfile` input is a **daily rate**, but each returned map value is an
-**annual volume**. Passing the annual value directly to `addAnnualProduction` avoids a second, erroneous
-multiplication by days per year.
+The `ProductionProfileGenerator.generateFullProfile` input is a **daily rate**, but each returned map value is an **annual volume**. Passing the annual value directly to `addAnnualProduction` avoids a second, erroneous multiplication by days per year.
 
 ```python
 def build_gas_case(
@@ -136,6 +130,16 @@ assert math.isclose(first_daily_rate_msm3, 8.0, rel_tol=0.0, abs_tol=1e-12)
 assert cumulative_gsm3 > 0.0
 ```
 
+<details>
+<summary>Output</summary>
+
+```
+First-year average rate: 8.000000 MSm³/d
+Twenty-year cumulative gas: 36.178855 GSm³
+```
+
+</details>
+
 ```python
 years = list(base_profile)
 daily_rates = [
@@ -169,11 +173,9 @@ plt.show()
 
 ## 4. Inspect the after-tax screening economics
 
-The first figure shows the imposed plateau followed by exponential decline. It verifies the intended rate/volume
-conversion but does not establish reservoir deliverability.
+The first figure shows the imposed plateau followed by exponential decline. It verifies the intended rate/volume conversion but does not establish reservoir deliverability.
 
-The model is intentionally deterministic. Its NPV, IRR, payback, and break-even price depend entirely on the synthetic
-assumptions above and the selected `NO` fiscal implementation.
+The model is intentionally deterministic. Its NPV, IRR, payback, and break-even price depend entirely on the synthetic assumptions above and the selected `NO` fiscal implementation.
 
 ```python
 cash_result = base_case["result"]
@@ -188,10 +190,27 @@ assert cash_result.getTotalCapex() > 0.0
 assert 0.0 < break_even_gas_price < 2.0
 ```
 
+<details>
+<summary>Output</summary>
+
+```
+=== Cash Flow Summary ===
+Project period: 2026 - 2047 (22 years)
+Total CAPEX: 1384.5 MUSD
+Total Revenue: 10853.7 MUSD
+Total Tax: 5700.7 MUSD
+NPV @ 8.0%: 652.3 MUSD
+IRR: 18.6%
+Payback: 5.0 years
+
+Break-even gas price: 0.155762 USD/Sm³
+```
+
+</details>
+
 ## 5. Compare bounded sensitivities
 
-A small deterministic sensitivity is more transparent than attaching unsupported P10/P50/P90 labels. Probabilistic
-labels require distributions, correlations, sampling evidence, and a documented percentile convention.
+A small deterministic sensitivity is more transparent than attaching unsupported P10/P50/P90 labels. Probabilistic labels require distributions, correlations, sampling evidence, and a documented percentile convention.
 
 ```python
 sensitivity_cases = [
@@ -229,14 +248,24 @@ fig.tight_layout()
 plt.show()
 ```
 
+<details>
+<summary>Output</summary>
+
+```
+| Case | NPV (MUSD) | IRR (%) | Payback (years) |
+|---|---:|---:|---:|
+| Lower rate | 355.5 | 14.1 | 6.0 |
+| Base case | 652.3 | 18.6 | 5.0 |
+| Higher CAPEX | 533.0 | 15.4 | 5.0 |
+```
+
+</details>
+
 ## 6. Interpretation and next fidelity step
 
-The second figure confirms the expected directional response: lower gas rate and higher CAPEX both reduce NPV. These
-bounded cases are engineering checks, not probabilistic percentiles.
+The second figure confirms the expected directional response: lower gas rate and higher CAPEX both reduce NPV. These bounded cases are engineering checks, not probabilistic percentiles.
 
-This notebook verifies the mechanics of an annual production profile and cash-flow screen. It does **not** model
-GIIP/STOIIP depletion, well deliverability, host capacity, multiphase hydraulics, product specifications, flow
-assurance, schedule uncertainty, or process equipment.
+This notebook verifies the mechanics of an annual production profile and cash-flow screen. It does **not** model GIIP/STOIIP depletion, well deliverability, host capacity, multiphase hydraulics, product specifications, flow assurance, schedule uncertainty, or process equipment.
 
 Before concept selection:
 
@@ -247,6 +276,5 @@ Before concept selection:
 5. Add documented uncertainty distributions and correlations before reporting percentiles.
 6. Obtain discipline review of the technical, fiscal, cost, schedule, and safety basis.
 
-For the physically coupled main-branch workflow, see
-[Integrated Field Lifecycle Simulation](../fielddevelopment/FIELD_LIFECYCLE_SIMULATION.md). That API may be newer than
-the latest public Python package, so use a repository build when reproducing main-branch examples.
+For the physically coupled main-branch workflow, see [Integrated Field Lifecycle Simulation](../fielddevelopment/FIELD_LIFECYCLE_SIMULATION.md). That API may be newer than the latest public Python package, so use a repository build when reproducing main-branch examples.
+

--- a/docs/examples/FieldDevelopmentWorkflow.md
+++ b/docs/examples/FieldDevelopmentWorkflow.md
@@ -1,29 +1,29 @@
 ---
 layout: default
-title: "FieldDevelopmentWorkflow"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Transparent field-development screening"
+description: "Executable NeqSim tutorial for unit-safe gas-production profiles, after-tax cash flow, and bounded sensitivities."
 parent: Examples
 nav_order: 1
+notebook_conversion: preserve
 ---
 
-# FieldDevelopmentWorkflow
-
-> **Note:** This is an auto-generated Markdown version of the Jupyter notebook
+> **Notebook:** This page mirrors
 > [`FieldDevelopmentWorkflow.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/FieldDevelopmentWorkflow.ipynb).
 > You can also [view it on nbviewer](https://nbviewer.org/github/equinor/neqsim/blob/master/docs/examples/FieldDevelopmentWorkflow.ipynb)
-> or [open in Google Colab](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/FieldDevelopmentWorkflow.ipynb).
+> or [open it in Google Colab](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/FieldDevelopmentWorkflow.ipynb).
 
----
+This tutorial builds an auditable gas-production forecast and after-tax cash flow from current NeqSim APIs. It
+deliberately uses the lower-level production-profile and economics classes so every unit conversion and assumption is
+visible.
 
-# Transparent field-development screening with NeqSim
-
-This tutorial builds an auditable gas-production forecast and after-tax cash flow from current NeqSim APIs. It deliberately uses the lower-level production-profile and economics classes so every unit conversion and assumption is visible.
-
-> **Engineering boundary:** this is a deterministic screening example, not a reserves estimate, concept approval, FEED model, or investment recommendation. Replace the synthetic rates, costs, prices, fiscal basis, and decline assumptions with traceable project data and qualified engineering models.
+> **Engineering boundary:** this is a deterministic screening example, not a reserves estimate, concept approval,
+> FEED model, or investment recommendation. Replace the synthetic rates, costs, prices, fiscal basis, and decline
+> assumptions with traceable project data and qualified engineering models.
 
 ## 1. Runtime setup
 
-The setup installs the current public `neqsim` package only when it is missing. Restart the runtime after changing the installed NeqSim version.
+The setup installs the current public `neqsim` package only when it is missing. Restart the runtime after changing the
+installed NeqSim version.
 
 ```python
 import importlib.util
@@ -53,7 +53,11 @@ DAYS_PER_YEAR = 365.25
 
 ## 2. Define the screening basis
 
-The example represents a synthetic four-well gas development. Throughout this tutorial, Sm³ uses a 15 °C and 1.01325 bara accounting basis. `ProductionProfileGenerator` treats the supplied volumes numerically; it does not perform a standard-condition conversion. Rates are standard cubic metres per day, and yearly profile values are standard cubic metres per year. Monetary inputs and outputs are million US dollars unless the API label states otherwise. The synthetic costs are teaching inputs, not an AACE-classified estimate.
+The example represents a synthetic four-well gas development. Throughout this tutorial, Sm³ uses a 15 °C and
+1.01325 bara accounting basis. `ProductionProfileGenerator` treats the supplied volumes numerically; it does not
+perform a standard-condition conversion. Rates are standard cubic metres per day, and yearly profile values are
+standard cubic metres per year. Monetary inputs and outputs are million US dollars unless the API label states
+otherwise. The synthetic costs are teaching inputs, not an AACE-classified estimate.
 
 | Assumption | Value |
 |---|---:|
@@ -67,7 +71,9 @@ The example represents a synthetic four-well gas development. Throughout this tu
 | Discount rate | 8% |
 | Fiscal model | `CashFlowEngine("NO")` |
 
-The `ProductionProfileGenerator.generateFullProfile` input is a **daily rate**, but each returned map value is an **annual volume**. Passing the annual value directly to `addAnnualProduction` avoids a second, erroneous multiplication by days per year.
+The `ProductionProfileGenerator.generateFullProfile` input is a **daily rate**, but each returned map value is an
+**annual volume**. Passing the annual value directly to `addAnnualProduction` avoids a second, erroneous
+multiplication by days per year.
 
 ```python
 def build_gas_case(
@@ -130,16 +136,6 @@ assert math.isclose(first_daily_rate_msm3, 8.0, rel_tol=0.0, abs_tol=1e-12)
 assert cumulative_gsm3 > 0.0
 ```
 
-<details>
-<summary>Output</summary>
-
-```
-First-year average rate: 8.000000 MSm³/d
-Twenty-year cumulative gas: 36.178855 GSm³
-```
-
-</details>
-
 ```python
 years = list(base_profile)
 daily_rates = [
@@ -173,9 +169,11 @@ plt.show()
 
 ## 4. Inspect the after-tax screening economics
 
-The first figure shows the imposed plateau followed by exponential decline. It verifies the intended rate/volume conversion but does not establish reservoir deliverability.
+The first figure shows the imposed plateau followed by exponential decline. It verifies the intended rate/volume
+conversion but does not establish reservoir deliverability.
 
-The model is intentionally deterministic. Its NPV, IRR, payback, and break-even price depend entirely on the synthetic assumptions above and the selected `NO` fiscal implementation.
+The model is intentionally deterministic. Its NPV, IRR, payback, and break-even price depend entirely on the synthetic
+assumptions above and the selected `NO` fiscal implementation.
 
 ```python
 cash_result = base_case["result"]
@@ -190,27 +188,10 @@ assert cash_result.getTotalCapex() > 0.0
 assert 0.0 < break_even_gas_price < 2.0
 ```
 
-<details>
-<summary>Output</summary>
-
-```
-=== Cash Flow Summary ===
-Project period: 2026 - 2047 (22 years)
-Total CAPEX: 1384.5 MUSD
-Total Revenue: 10853.7 MUSD
-Total Tax: 5700.7 MUSD
-NPV @ 8.0%: 652.3 MUSD
-IRR: 18.6%
-Payback: 5.0 years
-
-Break-even gas price: 0.155762 USD/Sm³
-```
-
-</details>
-
 ## 5. Compare bounded sensitivities
 
-A small deterministic sensitivity is more transparent than attaching unsupported P10/P50/P90 labels. Probabilistic labels require distributions, correlations, sampling evidence, and a documented percentile convention.
+A small deterministic sensitivity is more transparent than attaching unsupported P10/P50/P90 labels. Probabilistic
+labels require distributions, correlations, sampling evidence, and a documented percentile convention.
 
 ```python
 sensitivity_cases = [
@@ -248,24 +229,14 @@ fig.tight_layout()
 plt.show()
 ```
 
-<details>
-<summary>Output</summary>
-
-```
-| Case | NPV (MUSD) | IRR (%) | Payback (years) |
-|---|---:|---:|---:|
-| Lower rate | 355.5 | 14.1 | 6.0 |
-| Base case | 652.3 | 18.6 | 5.0 |
-| Higher CAPEX | 533.0 | 15.4 | 5.0 |
-```
-
-</details>
-
 ## 6. Interpretation and next fidelity step
 
-The second figure confirms the expected directional response: lower gas rate and higher CAPEX both reduce NPV. These bounded cases are engineering checks, not probabilistic percentiles.
+The second figure confirms the expected directional response: lower gas rate and higher CAPEX both reduce NPV. These
+bounded cases are engineering checks, not probabilistic percentiles.
 
-This notebook verifies the mechanics of an annual production profile and cash-flow screen. It does **not** model GIIP/STOIIP depletion, well deliverability, host capacity, multiphase hydraulics, product specifications, flow assurance, schedule uncertainty, or process equipment.
+This notebook verifies the mechanics of an annual production profile and cash-flow screen. It does **not** model
+GIIP/STOIIP depletion, well deliverability, host capacity, multiphase hydraulics, product specifications, flow
+assurance, schedule uncertainty, or process equipment.
 
 Before concept selection:
 
@@ -276,5 +247,6 @@ Before concept selection:
 5. Add documented uncertainty distributions and correlations before reporting percentiles.
 6. Obtain discipline review of the technical, fiscal, cost, schedule, and safety basis.
 
-For the physically coupled main-branch workflow, see [Integrated Field Lifecycle Simulation](../fielddevelopment/FIELD_LIFECYCLE_SIMULATION.md). That API may be newer than the latest public Python package, so use a repository build when reproducing main-branch examples.
-
+For the physically coupled main-branch workflow, see
+[Integrated Field Lifecycle Simulation](../fielddevelopment/FIELD_LIFECYCLE_SIMULATION.md). That API may be newer than
+the latest public Python package, so use a repository build when reproducing main-branch examples.

--- a/docs/examples/FieldDevelopmentWorkflow.md
+++ b/docs/examples/FieldDevelopmentWorkflow.md
@@ -6,8 +6,6 @@ parent: Examples
 nav_order: 1
 ---
 
-# FieldDevelopmentWorkflow
-
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`FieldDevelopmentWorkflow.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/FieldDevelopmentWorkflow.ipynb).
 > You can also [view it on nbviewer](https://nbviewer.org/github/equinor/neqsim/blob/master/docs/examples/FieldDevelopmentWorkflow.ipynb)

--- a/docs/test_convert_notebooks.py
+++ b/docs/test_convert_notebooks.py
@@ -3,10 +3,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from convert_notebooks import convert_all_notebooks, should_preserve_markdown
+from convert_notebooks import convert_all_notebooks
 
 
-def write_notebook(path: Path, title: str) -> None:
+def write_notebook(path: Path, title: str, documentation_metadata=None) -> None:
     notebook = {
         "cells": [
             {
@@ -15,7 +15,10 @@ def write_notebook(path: Path, title: str) -> None:
                 "source": [f"# {title}\\n"],
             }
         ],
-        "metadata": {"language_info": {"name": "python"}},
+        "metadata": {
+            "language_info": {"name": "python"},
+            "neqsim_docs": documentation_metadata or {},
+        },
         "nbformat": 4,
         "nbformat_minor": 5,
     }
@@ -23,46 +26,45 @@ def write_notebook(path: Path, title: str) -> None:
 
 
 class ConvertNotebooksTest(unittest.TestCase):
-    def test_converter_preserves_explicitly_curated_markdown(self):
+    def test_converter_uses_curated_page_metadata(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             examples_dir = Path(temp_dir)
             notebook_path = examples_dir / "Curated.ipynb"
             markdown_path = examples_dir / "Curated.md"
-            curated_content = """---
-title: "Curated tutorial"
-notebook_conversion: preserve
----
-
-Curated engineering content.
-"""
-            write_notebook(notebook_path, "Notebook title")
-            markdown_path.write_text(curated_content, encoding="utf-8")
-
-            self.assertTrue(should_preserve_markdown(markdown_path))
+            write_notebook(
+                notebook_path,
+                "Notebook title",
+                {
+                    "title": "Curated tutorial",
+                    "description": "Curated engineering description",
+                    "show_generated_title": False,
+                },
+            )
 
             convert_all_notebooks(examples_dir)
 
-            self.assertEqual(
-                markdown_path.read_text(encoding="utf-8"),
-                curated_content,
+            generated_content = markdown_path.read_text(encoding="utf-8")
+            self.assertIn('title: "Curated tutorial"', generated_content)
+            self.assertIn(
+                'description: "Curated engineering description"',
+                generated_content,
             )
+            self.assertEqual(generated_content.count("# Curated tutorial"), 0)
+            self.assertEqual(generated_content.count("# Notebook title"), 1)
 
-    def test_converter_still_updates_unmarked_markdown(self):
+    def test_converter_keeps_default_metadata_behavior(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             examples_dir = Path(temp_dir)
             notebook_path = examples_dir / "Generated.ipynb"
             markdown_path = examples_dir / "Generated.md"
             write_notebook(notebook_path, "Current notebook title")
-            markdown_path.write_text("stale content\\n", encoding="utf-8")
-
-            self.assertFalse(should_preserve_markdown(markdown_path))
 
             convert_all_notebooks(examples_dir)
 
             generated_content = markdown_path.read_text(encoding="utf-8")
             self.assertIn('title: "Generated"', generated_content)
+            self.assertIn("# Generated", generated_content)
             self.assertIn("# Current notebook title", generated_content)
-            self.assertNotIn("stale content", generated_content)
 
 
 if __name__ == "__main__":

--- a/docs/test_convert_notebooks.py
+++ b/docs/test_convert_notebooks.py
@@ -1,0 +1,69 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from convert_notebooks import convert_all_notebooks, should_preserve_markdown
+
+
+def write_notebook(path: Path, title: str) -> None:
+    notebook = {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [f"# {title}\\n"],
+            }
+        ],
+        "metadata": {"language_info": {"name": "python"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(notebook), encoding="utf-8")
+
+
+class ConvertNotebooksTest(unittest.TestCase):
+    def test_converter_preserves_explicitly_curated_markdown(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            examples_dir = Path(temp_dir)
+            notebook_path = examples_dir / "Curated.ipynb"
+            markdown_path = examples_dir / "Curated.md"
+            curated_content = """---
+title: "Curated tutorial"
+notebook_conversion: preserve
+---
+
+Curated engineering content.
+"""
+            write_notebook(notebook_path, "Notebook title")
+            markdown_path.write_text(curated_content, encoding="utf-8")
+
+            self.assertTrue(should_preserve_markdown(markdown_path))
+
+            convert_all_notebooks(examples_dir)
+
+            self.assertEqual(
+                markdown_path.read_text(encoding="utf-8"),
+                curated_content,
+            )
+
+    def test_converter_still_updates_unmarked_markdown(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            examples_dir = Path(temp_dir)
+            notebook_path = examples_dir / "Generated.ipynb"
+            markdown_path = examples_dir / "Generated.md"
+            write_notebook(notebook_path, "Current notebook title")
+            markdown_path.write_text("stale content\\n", encoding="utf-8")
+
+            self.assertFalse(should_preserve_markdown(markdown_path))
+
+            convert_all_notebooks(examples_dir)
+
+            generated_content = markdown_path.read_text(encoding="utf-8")
+            self.assertIn('title: "Generated"', generated_content)
+            self.assertIn("# Current notebook title", generated_content)
+            self.assertNotIn("stale content", generated_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/test_convert_notebooks.py
+++ b/docs/test_convert_notebooks.py
@@ -31,12 +31,14 @@ class ConvertNotebooksTest(unittest.TestCase):
             examples_dir = Path(temp_dir)
             notebook_path = examples_dir / "Curated.ipynb"
             markdown_path = examples_dir / "Curated.md"
+            curated_title = 'Curated "quoted" \\ tutorial'
+            curated_description = "Curated engineering description\nwith detail"
             write_notebook(
                 notebook_path,
                 "Notebook title",
                 {
-                    "title": "Curated tutorial",
-                    "description": "Curated engineering description",
+                    "title": curated_title,
+                    "description": curated_description,
                     "show_generated_title": False,
                 },
             )
@@ -44,12 +46,15 @@ class ConvertNotebooksTest(unittest.TestCase):
             convert_all_notebooks(examples_dir)
 
             generated_content = markdown_path.read_text(encoding="utf-8")
-            self.assertIn('title: "Curated tutorial"', generated_content)
             self.assertIn(
-                'description: "Curated engineering description"',
+                f"title: {json.dumps(curated_title)}",
                 generated_content,
             )
-            self.assertEqual(generated_content.count("# Curated tutorial"), 0)
+            self.assertIn(
+                f"description: {json.dumps(curated_description)}",
+                generated_content,
+            )
+            self.assertNotIn(f"# {curated_title}", generated_content)
             self.assertEqual(generated_content.count("# Notebook title"), 1)
 
     def test_converter_keeps_default_metadata_behavior(self):
@@ -65,6 +70,26 @@ class ConvertNotebooksTest(unittest.TestCase):
             self.assertIn('title: "Generated"', generated_content)
             self.assertIn("# Generated", generated_content)
             self.assertIn("# Current notebook title", generated_content)
+
+    def test_converter_ignores_non_mapping_documentation_metadata(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            examples_dir = Path(temp_dir)
+            notebook_path = examples_dir / "InvalidMetadata.ipynb"
+            markdown_path = examples_dir / "InvalidMetadata.md"
+            write_notebook(
+                notebook_path,
+                "Notebook title",
+                "invalid metadata",
+            )
+
+            convert_all_notebooks(examples_dir)
+
+            generated_content = markdown_path.read_text(encoding="utf-8")
+            self.assertIn('title: "InvalidMetadata"', generated_content)
+            self.assertIn(
+                'description: "Jupyter notebook tutorial for NeqSim"',
+                generated_content,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #2588 and part of #2499 (D021).

## Frozen scope

- `docs/convert_notebooks.py`
- `docs/examples/FieldDevelopmentWorkflow.ipynb` — documentation metadata only
- `docs/examples/FieldDevelopmentWorkflow.md`
- `docs/test_convert_notebooks.py`

No notebook cell, execution count, stored output, Java source/test, production code, equation, image, or workflow file is changed.

## Confirmed post-merge regression

Three minutes after #2588 merged externally as `8705229`, automatic notebook conversion merged as `3f1c465` and regenerated `FieldDevelopmentWorkflow.md`.

Severity: **medium documentation regression**.

Evidence and root cause:

- the converter derived every page title and description only from the filename;
- it emitted a generated H1 before the notebook's existing H1;
- D021 therefore lost its curated engineering metadata and gained two page-level headings;
- the validated notebook cells and outputs remained unchanged.

## Fix

- define optional `metadata.neqsim_docs` fields in the notebook for the page title, description, and generated-title behavior;
- make the converter use those fields while retaining its existing defaults for every notebook without the metadata;
- set D021's curated title/description and suppress only the redundant generated H1;
- regenerate the page so it still contains all current code and three stored text-output sections;
- add standard-library regression tests for the curated-metadata path, unchanged default path, and non-mapping metadata fallback.

This keeps the Markdown synchronized with future notebook changes; it does not permanently opt the page out of conversion.

## Validation performed

- `python docs/test_convert_notebooks.py`: 3/3 tests passed;
- `python -m py_compile docs/convert_notebooks.py docs/test_convert_notebooks.py`: passed;
- `python docs/convert_notebooks.py` on the D021 notebook: passed;
- notebook/Markdown parity: all 7 Python code blocks exactly match all 7 notebook code cells;
- stored text outputs retained: production round trip, cash-flow summary/break-even, and sensitivity table (3/3);
- page structure: curated front matter occurs once, exactly one body H1 remains, and code fences are balanced;
- notebook readback: only five documentation-metadata lines differ from `master`;
- math gate: no equations are present in this scope;
- final remote diff: exactly the four frozen files, 0 commits behind `master`.

The previously validated NeqSim 3.16.0 notebook execution, two stored figures, and four Java 8/21 Ubuntu/Windows suites from #2588 are unaffected. Existing external links are unchanged and were not reclassified. No browser-rendered site inspection is claimed.

## Final-head hosted validation

Head `3d9841b` passes:

- pre-commit;
- Spotless format patch;
- documentation build and complete search-index verification;
- CodeQL;
- agent-skill cross-reference verification;
- Java/XML change detection.

The Java 8/21 and Javadoc jobs correctly skipped because the final diff changes no Java/XML source. The earlier #2588 Java matrices remain the regression evidence for the unchanged documented APIs.

## Copilot gate

Copilot reviewed all four files on the final head. Across the PR:

- one valid YAML-safety finding was implemented with JSON/YAML-safe quoting, a non-mapping fallback, and expanded tests;
- marker-contract, duplicate-H1, and scope findings based on superseded implementation or stale PR text were rejected with exact final-head evidence;
- the final review's sole comment was already covered by the quote/backslash/newline and non-mapping tests;
- all review threads are resolved;
- no Copilot-authored commit exists.

The complete final diff was reread and remains limited to the four frozen files. The PR was merged externally as `fd9ee26259cf365a284a2022d79595e9d9312f9a`; this campaign run did not merge it, enable auto-merge, or push directly to `master`. D021 is complete, and D022 may take the next bounded rotation scope.