### PR TITLE
test: cover Unicode notebook metadata

### DIFF
--- a/docs/test_convert_notebooks.py
+++ b/docs/test_convert_notebooks.py
@@ -12,7 +12,7 @@ def write_notebook(path: Path, title: str, documentation_metadata=None) -> None:
             {
                 "cell_type": "markdown",
                 "metadata": {},
-                "source": [f"# {title}\\n"],
+                "source": [f"# {title}\n"],
             }
         ],
         "metadata": {
@@ -31,7 +31,7 @@ class ConvertNotebooksTest(unittest.TestCase):
             examples_dir = Path(temp_dir)
             notebook_path = examples_dir / "Curated.ipynb"
             markdown_path = examples_dir / "Curated.md"
-            curated_title = 'Curated "quoted" \\ tutorial'
+            curated_title = 'Curated "quoted" \\ tutorial – Å'
             curated_description = "Curated engineering description\nwith detail"
             write_notebook(
                 notebook_path,
@@ -47,11 +47,11 @@ class ConvertNotebooksTest(unittest.TestCase):
 
             generated_content = markdown_path.read_text(encoding="utf-8")
             self.assertIn(
-                f"title: {json.dumps(curated_title)}",
+                f"title: {json.dumps(curated_title, ensure_ascii=False)}",
                 generated_content,
             )
             self.assertIn(
-                f"description: {json.dumps(curated_description)}",
+                f"description: {json.dumps(curated_description, ensure_ascii=False)}",
                 generated_content,
             )
             self.assertNotIn(f"# {curated_title}", generated_content)

--- a/docs/test_convert_notebooks.py
+++ b/docs/test_convert_notebooks.py
@@ -12,7 +12,7 @@ def write_notebook(path: Path, title: str, documentation_metadata=None) -> None:
             {
                 "cell_type": "markdown",
                 "metadata": {},
-                "source": [f"# {title}\n"],
+                "source": [f"# {title}\\n"],
             }
         ],
         "metadata": {


### PR DESCRIPTION
Follow-up to #2592 and part of #2499 (D021).

## Frozen scope

- `docs/test_convert_notebooks.py`

No converter implementation, notebook, generated Markdown, Java source/test, production code, equation, image, link, or workflow file changes.

## Confirmed final-review gap

A Copilot review comment arrived after #2592 was merged externally. Production emits notebook-owned page metadata with `json.dumps(..., ensure_ascii=False)`, but two regression assertions used `json.dumps(...)` with the default `ensure_ascii=True`. The existing ASCII-only fixture therefore passed without proving literal Unicode output.

## Fix

- add non-ASCII characters (`– Å`) to the curated-title fixture;
- make both expected YAML scalar assertions use `ensure_ascii=False`, exactly matching production.

## Validation

- `python docs/test_convert_notebooks.py`: 3/3 passed;
- `python -m py_compile docs/convert_notebooks.py docs/test_convert_notebooks.py`: passed;
- remote comparison with `master`: one file, 3 additions/3 deletions, two commits, 0 behind;
- no equations, links, images, notebooks, generated pages, or executable NeqSim API examples changed;
- no browser rendering is needed or claimed for this test-only diff.

The earlier #2588/#2592 notebook, Java 8/21, documentation/search, CodeQL, and rendering evidence remains unaffected.

## Final-head hosted and review gates

Head `a2125de` passes:

- pre-commit;
- Spotless format patch;
- documentation build and complete search-index verification;
- CodeQL;
- agent-skill cross-reference and Java/XML change detection.

Java 8/21 and Javadoc correctly skipped because this one-file test-only diff changes no Java/XML source. Copilot reviewed the complete changed file on the final head and produced no comments or suggested changes; there are no review threads or Copilot-authored commits. The final comparison is mergeable, one file, 3 additions/3 deletions, and 0 commits behind `master`.

The PR is ready for maintainer review and intentionally remains draft. No merge, auto-merge, or direct `master` change is requested.