### PR TITLE
Fix TransientPipe explicit outlet pressure initialization

### DIFF
--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipe.java
@@ -496,8 +496,10 @@ public class TransientPipe extends TwoPortEquipment implements PipeLineInterface
     double f = (Re > 2300) ? 0.316 * Math.pow(Re, -0.25) : 64.0 / Math.max(Re, 1);
     double frictionDrop = f * rho_m * U_M * U_M * length / (2 * diameter);
 
-    outletPressureValue = inletPressureValue - hydrostaticDrop - frictionDrop;
-    outletPressureValue = Math.max(outletPressureValue, 1e5); // Minimum 1 bar
+    if (!outletPressureExplicitlySet) {
+      outletPressureValue = inletPressureValue - hydrostaticDrop - frictionDrop;
+      outletPressureValue = Math.max(outletPressureValue, 1e5); // Minimum 1 bar
+    }
 
     // Initialize sections with linear pressure profile
     for (int i = 0; i < numberOfSections; i++) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipe.java
@@ -498,8 +498,8 @@ public class TransientPipe extends TwoPortEquipment implements PipeLineInterface
 
     if (!outletPressureExplicitlySet) {
       outletPressureValue = inletPressureValue - hydrostaticDrop - frictionDrop;
-      outletPressureValue = Math.max(outletPressureValue, 1e5); // Minimum 1 bar
     }
+    outletPressureValue = Math.max(outletPressureValue, 1e5); // Minimum 1 bar
 
     // Initialize sections with linear pressure profile
     for (int i = 0; i < numberOfSections; i++) {

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeTest.java
@@ -94,6 +94,35 @@ class TransientPipeTest {
     // No exceptions should be thrown
   }
 
+  @Test
+  void testExplicitOutletPressureSurvivesInitialization() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 80.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-pentane", 0.2);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream inlet = new Stream("explicit outlet inlet", fluid);
+    inlet.setFlowRate(5.0, "kg/sec");
+    inlet.run();
+
+    TransientPipe pipe = new TransientPipe("explicit outlet pipe", inlet);
+    pipe.setLength(200.0);
+    pipe.setDiameter(0.15);
+    pipe.setNumberOfSections(10);
+    pipe.setOutletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+
+    double specifiedOutletPressure = 42.0;
+    pipe.setOutletPressure(specifiedOutletPressure);
+    pipe.runTransient(0.0, java.util.UUID.randomUUID());
+
+    double[] pressureProfile = pipe.getPressureProfile();
+    assertNotNull(pressureProfile);
+    double initializedOutletPressure = pressureProfile[pressureProfile.length - 1] / 1.0e5;
+    assertEquals(specifiedOutletPressure, initializedOutletPressure, 1.0e-9,
+        "Initialization must preserve an explicitly specified outlet pressure");
+  }
+
   @Disabled("Integration test - requires thermodynamic calculations")
   @Test
   void testSimulationWithGasCondensate() {


### PR DESCRIPTION
## Summary

- preserve an outlet pressure supplied through `setOutletPressure()` when `TransientPipe` initializes its sections
- retain the existing hydrostatic/friction estimate when no outlet pressure was explicitly supplied
- add a regression test that initializes an 80 bara two-phase inlet with a 42 bara outlet boundary and checks the final mesh node

## Problem

`initializeFromStream()` currently calculates and assigns `outletPressureValue` unconditionally. That overwrites the public setter value even though `outletPressureExplicitlySet` is already tracked. In a 200 m riser probe, requesting 60 bara initialized the outlet near 78.13 bara instead.

## Validation

The regression uses `runTransient(0.0, UUID)` to isolate initialization from time integration. It fails on current `master` because the final pressure node does not equal the explicit boundary and passes with the guard in this PR.

This change deliberately does not add physical-property initialization or alter automatic outlet-pressure estimation.