### PR TITLE
docs: repair TransientPipe boundary guidance

### DIFF
--- a/docs/wiki/transient_multiphase_pipe.md
+++ b/docs/wiki/transient_multiphase_pipe.md
@@ -278,15 +278,17 @@ System.out.println("Pipeline pressure drop: " + deltaPBar + " bar");
 ### Boundary Conditions
 
 The default inlet boundary is `CONSTANT_FLOW`, and the default outlet boundary is
-`CONSTANT_PRESSURE`. Set a receiving pressure explicitly before the first
-`run()` or `runTransient()` call when the downstream pressure is known:
+`CONSTANT_PRESSURE`. The connected inlet stream supplies the mass flow during
+initialization and is re-read by each `runTransient()` call, so set the initial
+flow with `inlet.setFlowRate(...)` as shown in the quick start. Set a receiving
+pressure explicitly before the first `run()` or `runTransient()` call when the
+downstream pressure is known:
 
 ```java
 import java.util.UUID;
 import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe.BoundaryCondition;
 
 pipe.setInletBoundaryCondition(BoundaryCondition.CONSTANT_FLOW);
-pipe.setInletMassFlow(5.0); // kg/s
 
 pipe.setOutletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
 double specifiedOutletPressure = 30.0; // bara

--- a/docs/wiki/transient_multiphase_pipe.md
+++ b/docs/wiki/transient_multiphase_pipe.md
@@ -306,7 +306,7 @@ pipe.runTransient(0.0, UUID.randomUUID());
 double[] initialPressure = pipe.getPressureProfile(); // Pa
 double initializedOutletPressure =
     initialPressure[initialPressure.length - 1] / 1.0e5;
-if (Math.abs(initializedOutletPressure - specifiedOutletPressure) > 1.0e-9) {
+if (Math.abs(initializedOutletPressure - specifiedOutletPressure) > 1.0e-6) {
     throw new IllegalStateException("Outlet pressure boundary was not preserved");
 }
 ```

--- a/docs/wiki/transient_multiphase_pipe.md
+++ b/docs/wiki/transient_multiphase_pipe.md
@@ -130,11 +130,17 @@ U = [ρ_G·α_G, ρ_L·α_L, ρ_m·u, ρ_m·e]
 ### Basic Horizontal Pipeline
 
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.pipeline.twophasepipe.LiquidAccumulationTracker;
 import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
+
+// Define this as a class field in the enclosing example class.
+private static final Logger logger =
+    LogManager.getLogger(TransientPipeExample.class);
 
 // Create two-phase fluid
 SystemInterface fluid = new SystemSrkEos(300, 50); // 300 K, 50 bar
@@ -197,8 +203,8 @@ pipe.run();
 LiquidAccumulationTracker accumulationTracker = pipe.getAccumulationTracker();
 for (LiquidAccumulationTracker.AccumulationZone zone
         : accumulationTracker.getAccumulationZones()) {
-    System.out.println("Zone starts at: " + zone.startPosition + " m");
-    System.out.println("Accumulated volume: " + zone.liquidVolume + " m³");
+    logger.info("Zone starts at: {} m", zone.startPosition);
+    logger.info("Accumulated volume: {} m³", zone.liquidVolume);
 }
 ```
 
@@ -251,7 +257,7 @@ pipe.run();
 // when both oil and aqueous phases are present.
 double[] pressure = pipe.getPressureProfile(); // Pa
 double deltaPBar = (pressure[0] - pressure[pressure.length - 1]) / 1.0e5;
-System.out.println("Pipeline pressure drop: " + deltaPBar + " bar");
+logger.info("Pipeline pressure drop: {} bar", deltaPBar);
 ```
 
 ## Configuration Options
@@ -352,7 +358,7 @@ double frequency = slugTracker.getSlugFrequency();
 
 // Detailed statistics
 String stats = slugTracker.getStatisticsString();
-System.out.println(stats);
+logger.info("{}", stats);
 ```
 
 **Note:** Both `TransientPipe` (drift-flux) and `TwoFluidPipe` (two-fluid) use the same `SlugTracker` and `LiquidAccumulationTracker` components, but may predict different slug frequencies due to their underlying holdup models. See the [Two-Fluid Model documentation](two_fluid_model#comparison-with-drift-flux-model-transientpipe) for a detailed comparison.
@@ -364,11 +370,11 @@ LiquidAccumulationTracker tracker = pipe.getAccumulationTracker();
 
 for (LiquidAccumulationTracker.AccumulationZone zone
         : tracker.getAccumulationZones()) {
-    System.out.println("Zone start: " + zone.startPosition + " m");
-    System.out.println("Zone end: " + zone.endPosition + " m");
-    System.out.println("Accumulated volume: " + zone.liquidVolume + " m³");
-    System.out.println("Maximum volume: " + zone.maxVolume + " m³");
-    System.out.println("Is overflowing: " + zone.isOverflowing);
+    logger.info("Zone start: {} m", zone.startPosition);
+    logger.info("Zone end: {} m", zone.endPosition);
+    logger.info("Accumulated volume: {} m³", zone.liquidVolume);
+    logger.info("Maximum volume: {} m³", zone.maxVolume);
+    logger.info("Is overflowing: {}", zone.isOverflowing);
 }
 ```
 
@@ -382,8 +388,7 @@ FlowRegimeDetector detector = new FlowRegimeDetector();
 
 for (PipeSection section : sections) {
     FlowRegime regime = detector.detectFlowRegime(section);
-    System.out.println("Position " + section.getPosition() + 
-                       ": " + regime);
+    logger.info("Position {}: {}", section.getPosition(), regime);
 }
 ```
 
@@ -395,10 +400,10 @@ DriftFluxModel model = new DriftFluxModel();
 for (PipeSection section : sections) {
     DriftFluxParameters params = model.calculateDriftFlux(section);
     
-    System.out.println("C0 = " + params.C0);
-    System.out.println("Drift velocity = " + params.driftVelocity + " m/s");
-    System.out.println("Void fraction = " + params.voidFraction);
-    System.out.println("Slip ratio = " + params.slipRatio);
+    logger.info("C0 = {}", params.C0);
+    logger.info("Drift velocity = {} m/s", params.driftVelocity);
+    logger.info("Void fraction = {}", params.voidFraction);
+    logger.info("Slip ratio = {}", params.slipRatio);
 }
 ```
 
@@ -410,14 +415,14 @@ PipeSection[] sections = pipe.getSections();
 for (int i = 0; i < sections.length; i++) {
     PipeSection s = sections[i];
     
-    System.out.printf("Section %d (x=%.1f m):%n", i, s.getPosition());
-    System.out.printf("  Pressure: %.2f bar%n", s.getPressure()/1e5);
-    System.out.printf("  Temperature: %.1f K%n", s.getTemperature());
-    System.out.printf("  Liquid holdup: %.3f%n", s.getLiquidHoldup());
-    System.out.printf("  Gas velocity: %.2f m/s%n", s.getGasVelocity());
-    System.out.printf("  Liquid velocity: %.2f m/s%n", s.getLiquidVelocity());
-    System.out.printf("  Flow regime: %s%n", s.getFlowRegime());
-    System.out.printf("  Is low point: %b%n", s.isLowPoint());
+    logger.info("Section {} (x={} m)", i, s.getPosition());
+    logger.info("Pressure: {} bar", s.getPressure() / 1.0e5);
+    logger.info("Temperature: {} K", s.getTemperature());
+    logger.info("Liquid holdup: {}", s.getLiquidHoldup());
+    logger.info("Gas velocity: {} m/s", s.getGasVelocity());
+    logger.info("Liquid velocity: {} m/s", s.getLiquidVelocity());
+    logger.info("Flow regime: {}", s.getFlowRegime());
+    logger.info("Is low point: {}", s.isLowPoint());
 }
 ```
 
@@ -609,8 +614,8 @@ tp.run();
 double[] pressures = tp.getPressureProfile();
 double dpTransient = (pressures[0] - pressures[pressures.length - 1]) / 1e5;
 
-System.out.println("Beggs & Brill: " + dpBeggsBrill + " bar");
-System.out.println("TransientPipe: " + dpTransient + " bar");
+logger.info("Beggs & Brill: {} bar", dpBeggsBrill);
+logger.info("TransientPipe: {} bar", dpTransient);
 ```
 
 ### References for Model Comparison

--- a/docs/wiki/transient_multiphase_pipe.md
+++ b/docs/wiki/transient_multiphase_pipe.md
@@ -140,7 +140,7 @@ import neqsim.thermo.system.SystemSrkEos;
 
 // Define this as a class field in the enclosing example class.
 private static final Logger logger =
-    LogManager.getLogger(TransientPipeExample.class);
+    LogManager.getLogger("TransientPipeExample");
 
 // Create two-phase fluid
 SystemInterface fluid = new SystemSrkEos(300, 50); // 300 K, 50 bar

--- a/docs/wiki/transient_multiphase_pipe.md
+++ b/docs/wiki/transient_multiphase_pipe.md
@@ -130,6 +130,7 @@ U = [ρ_G·α_G, ρ_L·α_L, ρ_m·u, ρ_m·e]
 ### Basic Horizontal Pipeline
 
 ```java
+import neqsim.process.equipment.pipeline.twophasepipe.LiquidAccumulationTracker;
 import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;

--- a/docs/wiki/transient_multiphase_pipe.md
+++ b/docs/wiki/transient_multiphase_pipe.md
@@ -1,6 +1,6 @@
 ---
 title: "Transient Multiphase Pipe Model"
-description: "The `TransientPipe` class provides a 1D transient multiphase (gas-liquid) flow simulator for pipelines. It uses the drift-flux formulation combined with mechanistic flow regime detection to model comp..."
+description: "Configure and validate NeqSim's drift-flux transient pipeline model, including pressure boundaries, terrain effects, liquid accumulation, and profile results."
 ---
 
 # Transient Multiphase Pipe Model
@@ -28,9 +28,9 @@ The model supports:
 
 The core model uses the Zuber-Findlay drift-flux formulation:
 
-```
-v_G = C₀ · v_m + v_d
-```
+$$
+v_G = C_0 v_m + v_d
+$$
 
 Where:
 - `v_G` = gas velocity (m/s)
@@ -49,14 +49,21 @@ The distribution coefficient `C₀` and drift velocity `v_d` depend on the flow 
 
 ### Three-Phase Flow Handling
 
-When both oil and aqueous (water) liquid phases are present, the model calculates volume-weighted average liquid properties:
+When both oil and aqueous (water) liquid phases are present, the model calculates
+volume-weighted average liquid properties:
 
-```
-ρ_L,avg = (V_oil / V_total) × ρ_oil + (V_water / V_total) × ρ_water
-μ_L,avg = (V_oil / V_total) × μ_oil + (V_water / V_total) × μ_water
-H_L,avg = (V_oil / V_total) × H_oil + (V_water / V_total) × H_water
-c_L,avg = (V_oil / V_total) × c_oil + (V_water / V_total) × c_water
-```
+$$
+\begin{aligned}
+\rho_{L,\mathrm{avg}} &= \frac{V_{\mathrm{oil}}}{V_{\mathrm{total}}}\rho_{\mathrm{oil}}
++ \frac{V_{\mathrm{water}}}{V_{\mathrm{total}}}\rho_{\mathrm{water}}, \\
+\mu_{L,\mathrm{avg}} &= \frac{V_{\mathrm{oil}}}{V_{\mathrm{total}}}\mu_{\mathrm{oil}}
++ \frac{V_{\mathrm{water}}}{V_{\mathrm{total}}}\mu_{\mathrm{water}}, \\
+H_{L,\mathrm{avg}} &= \frac{V_{\mathrm{oil}}}{V_{\mathrm{total}}}H_{\mathrm{oil}}
++ \frac{V_{\mathrm{water}}}{V_{\mathrm{total}}}H_{\mathrm{water}}, \\
+c_{L,\mathrm{avg}} &= \frac{V_{\mathrm{oil}}}{V_{\mathrm{total}}}c_{\mathrm{oil}}
++ \frac{V_{\mathrm{water}}}{V_{\mathrm{total}}}c_{\mathrm{water}}.
+\end{aligned}
+$$
 
 Where:
 - `V_oil`, `V_water` = volume of oil and water phases from thermodynamic flash
@@ -125,6 +132,7 @@ U = [ρ_G·α_G, ρ_L·α_L, ρ_m·u, ρ_m·e]
 ```java
 import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
 // Create two-phase fluid
@@ -185,10 +193,11 @@ pipe.setElevationProfile(elevations);
 pipe.run();
 
 // Check for liquid accumulation
-AccumulationTracker accumTracker = pipe.getAccumulationTracker();
-for (AccumulationZone zone : accumTracker.getAccumulationZones()) {
-    System.out.println("Accumulation at position: " + zone.getPosition());
-    System.out.println("Accumulated volume: " + zone.getAccumulatedVolume() + " m³");
+LiquidAccumulationTracker accumulationTracker = pipe.getAccumulationTracker();
+for (LiquidAccumulationTracker.AccumulationZone zone
+        : accumulationTracker.getAccumulationZones()) {
+    System.out.println("Zone starts at: " + zone.startPosition + " m");
+    System.out.println("Accumulated volume: " + zone.liquidVolume + " m³");
 }
 ```
 
@@ -238,9 +247,10 @@ pipe.setNumberOfSections(50);
 pipe.run();
 
 // The model automatically uses volume-weighted averaging for liquid properties
-// when both oil and aqueous phases are present
-double deltaP = P[0] - P[39];
-System.out.println("Riser pressure drop: " + deltaP/1e5 + " bar");
+// when both oil and aqueous phases are present.
+double[] pressure = pipe.getPressureProfile(); // Pa
+double deltaPBar = (pressure[0] - pressure[pressure.length - 1]) / 1.0e5;
+System.out.println("Pipeline pressure drop: " + deltaPBar + " bar");
 ```
 
 ## Configuration Options
@@ -267,15 +277,37 @@ System.out.println("Riser pressure drop: " + deltaP/1e5 + " bar");
 
 ### Boundary Conditions
 
-```java
-// Available boundary condition types
-pipe.setInletBoundaryCondition(BoundaryCondition.CONSTANT_FLOW);
-pipe.setOutletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+The default inlet boundary is `CONSTANT_FLOW`, and the default outlet boundary is
+`CONSTANT_PRESSURE`. Set a receiving pressure explicitly before the first
+`run()` or `runTransient()` call when the downstream pressure is known:
 
-// Set boundary values
-pipe.setInletMassFlow(5.0);           // kg/s
-pipe.setOutletPressure(30.0);         // bara
+```java
+import java.util.UUID;
+import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe.BoundaryCondition;
+
+pipe.setInletBoundaryCondition(BoundaryCondition.CONSTANT_FLOW);
+pipe.setInletMassFlow(5.0); // kg/s
+
+pipe.setOutletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+double specifiedOutletPressure = 30.0; // bara
+pipe.setOutletPressure(specifiedOutletPressure);
+
+// A zero-duration first call initializes the profiles without advancing time.
+pipe.runTransient(0.0, UUID.randomUUID());
+double[] initialPressure = pipe.getPressureProfile(); // Pa
+double initializedOutletPressure =
+    initialPressure[initialPressure.length - 1] / 1.0e5;
+if (Math.abs(initializedOutletPressure - specifiedOutletPressure) > 1.0e-9) {
+    throw new IllegalStateException("Outlet pressure boundary was not preserved");
+}
 ```
+
+`setOutletPressure(double)` accepts absolute pressure in bara. An explicit value
+is retained while the pipe is initialized and is imposed at the final
+computational section for a `CONSTANT_PRESSURE` outlet. If the setter is not
+called, initialization estimates the outlet pressure from inlet pressure,
+elevation, and friction and applies a lower bound of 1 bara. This estimate is an
+initial condition, not a substitute for a known receiving-system pressure.
 
 | Type | Description |
 |------|-------------|
@@ -327,11 +359,13 @@ System.out.println(stats);
 ```java
 LiquidAccumulationTracker tracker = pipe.getAccumulationTracker();
 
-for (AccumulationZone zone : tracker.getAccumulationZones()) {
-    System.out.println("Zone position: " + zone.getPosition() + " m");
-    System.out.println("Accumulated volume: " + zone.getAccumulatedVolume() + " m³");
-    System.out.println("Current holdup: " + zone.getCurrentHoldup());
-    System.out.println("Is overflowing: " + zone.isOverflowing());
+for (LiquidAccumulationTracker.AccumulationZone zone
+        : tracker.getAccumulationZones()) {
+    System.out.println("Zone start: " + zone.startPosition + " m");
+    System.out.println("Zone end: " + zone.endPosition + " m");
+    System.out.println("Accumulated volume: " + zone.liquidVolume + " m³");
+    System.out.println("Maximum volume: " + zone.maxVolume + " m³");
+    System.out.println("Is overflowing: " + zone.isOverflowing);
 }
 ```
 
@@ -502,15 +536,13 @@ The `TransientPipe` model uses a different approach than empirical correlations 
 
 ### Expected Differences
 
-Comparison tests show significant differences between the models, which is expected given their fundamentally different approaches:
-
-| Flow Condition | Typical Difference | Explanation |
-|----------------|-------------------|-------------|
-| Single-phase gas, horizontal | 50-80% | Different friction correlations |
-| Multiphase horizontal | 100-300% | Different holdup/slip models |
-| Uphill flow (+10°) | 40-60% | Hydrostatic term treatment |
-| Downhill flow (-10°) | 40-60% | Liquid drainage models differ |
-| High velocity gas | 50-100% | Compressibility effects |
+The models can differ materially because they use different conservation,
+holdup, slip, and flow-regime treatments. Do not use a fixed percentage as an
+acceptance tolerance: the difference depends on fluid, geometry, boundary
+conditions, discretization, and whether the transient solution has reached the
+intended comparison state. Compare like-for-like pressure, temperature, flow,
+and elevation boundaries and report the complete configuration with each
+benchmark result.
 
 ### When to Use Each Model
 
@@ -533,7 +565,7 @@ For critical applications, it is recommended to:
 
 1. **Benchmark both models** against field data or detailed CFD simulations
 2. **Understand model assumptions** - TransientPipe uses mechanistic closure relations that may need tuning for specific fluids
-3. **Consider uncertainty bands** - differences of 50-100% between models indicate the inherent uncertainty in multiphase flow predictions
+3. **Quantify uncertainty for the case** - derive uncertainty from relevant measurements, parameter sensitivity, and model-form comparisons rather than a generic percentage
 4. **Use multiple models** - consensus from different approaches increases confidence
 
 ### Comparison Test Examples

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeDocumentationTest.java
@@ -49,7 +49,7 @@ class TransientPipeDocumentationTest {
     pipe.setLength(900.0);
     pipe.setDiameter(0.20);
     pipe.setNumberOfSections(9);
-    pipe.setElevationProfile(new double[] {0.0, -2.0, -4.0, -6.0, -4.0, -2.0, 0.0, 0.0, 0.0});
+    pipe.setElevationProfile(new double[] { 0.0, -2.0, -4.0, -6.0, -4.0, -2.0, 0.0, 0.0, 0.0 });
     pipe.initializePipe();
 
     LiquidAccumulationTracker tracker = pipe.getAccumulationTracker();

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeDocumentationTest.java
@@ -31,7 +31,6 @@ class TransientPipeDocumentationTest {
     pipe.setDiameter(0.15);
     pipe.setNumberOfSections(10);
     pipe.setInletBoundaryCondition(BoundaryCondition.CONSTANT_FLOW);
-    pipe.setInletMassFlow(5.0);
     pipe.setOutletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
 
     double specifiedOutletPressure = 30.0;

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeDocumentationTest.java
@@ -1,0 +1,65 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe.BoundaryCondition;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Regression coverage for executable examples in transient_multiphase_pipe.md.
+ */
+class TransientPipeDocumentationTest {
+  @Test
+  void explicitOutletPressureExamplePreservesReceivingPressure() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 80.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-pentane", 0.2);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream inlet = new Stream("documented inlet", fluid);
+    inlet.setFlowRate(5.0, "kg/sec");
+    inlet.run();
+
+    TransientPipe pipe = new TransientPipe("documented pipe", inlet);
+    pipe.setLength(200.0);
+    pipe.setDiameter(0.15);
+    pipe.setNumberOfSections(10);
+    pipe.setInletBoundaryCondition(BoundaryCondition.CONSTANT_FLOW);
+    pipe.setInletMassFlow(5.0);
+    pipe.setOutletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+
+    double specifiedOutletPressure = 30.0;
+    pipe.setOutletPressure(specifiedOutletPressure);
+    pipe.runTransient(0.0, UUID.randomUUID());
+
+    double[] pressure = pipe.getPressureProfile();
+    double initializedOutletPressure = pressure[pressure.length - 1] / 1.0e5;
+    assertEquals(specifiedOutletPressure, initializedOutletPressure, 1.0e-9);
+  }
+
+  @Test
+  void accumulationZoneExampleUsesCurrentPublicFields() {
+    TransientPipe pipe = new TransientPipe("documented terrain pipe");
+    pipe.setLength(900.0);
+    pipe.setDiameter(0.20);
+    pipe.setNumberOfSections(9);
+    pipe.setElevationProfile(new double[] {0.0, -2.0, -4.0, -6.0, -4.0, -2.0, 0.0, 0.0, 0.0});
+    pipe.initializePipe();
+
+    LiquidAccumulationTracker tracker = pipe.getAccumulationTracker();
+    assertFalse(tracker.getAccumulationZones().isEmpty());
+
+    LiquidAccumulationTracker.AccumulationZone zone = tracker.getAccumulationZones().get(0);
+    assertTrue(zone.startPosition >= 0.0);
+    assertTrue(zone.endPosition > zone.startPosition);
+    assertTrue(zone.maxVolume > 0.0);
+    assertEquals(0.0, zone.liquidVolume, 1.0e-12);
+    assertFalse(zone.isOverflowing);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeDocumentationTest.java
@@ -39,7 +39,7 @@ class TransientPipeDocumentationTest {
 
     double[] pressure = pipe.getPressureProfile();
     double initializedOutletPressure = pressure[pressure.length - 1] / 1.0e5;
-    assertEquals(specifiedOutletPressure, initializedOutletPressure, 1.0e-9);
+    assertEquals(specifiedOutletPressure, initializedOutletPressure, 1.0e-6);
   }
 
   @Test


### PR DESCRIPTION
## D025 — recent merged code versus documentation coverage

Linked campaign: #2499

### Frozen scope

- `docs/wiki/transient_multiphase_pipe.md`
- `src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientPipeDocumentationTest.java`

Production code was intentionally excluded. This batch documents the user-visible boundary contract fixed by merged commit `983775e` / PR #2596.

### Confirmed defects repaired (13/13)

1. **High:** explicit receiving pressure set with `setOutletPressure()` was not documented as being preserved through initialization.
2. **High:** accumulation examples used the nonexistent `AccumulationTracker` type.
3. **High:** accumulation examples used nonexistent `AccumulationZone` getters instead of current public fields.
4. **Medium:** the three-phase example read an undefined `P` array.
5. **Medium:** that example hard-coded section 39 despite configuring 50 sections.
6. **Medium:** the quick-start imports omitted `SystemInterface`.
7. **Medium:** the shared imports omitted `LiquidAccumulationTracker`.
8. **Medium:** the boundary example presented `setInletMassFlow()` as the authoritative first-run input although initialization re-reads the connected stream.
9. **Medium:** unsupported generic model-difference percentages were presented as reusable tolerances.
10. **Medium:** 24 `System.out`/`System.err` calls violated the repository's mandatory Log4j2 rule.
11. **Low:** both display-equation groups used code fences rather than renderable math delimiters.
12. **Low:** front-matter description was visibly truncated.
13. **Low:** the outlet-pressure regression tolerance was unnecessarily strict; guide and test now use `1.0e-6` bara (0.1 Pa).

### Exact fixes

- Document default and explicit pressure boundaries, bara/Pa units, setter order, fallback estimate, 1 bara floor, connected-stream inlet-flow behavior, and zero-duration initialization.
- Assert that a 30 bara receiving pressure survives `runTransient(0.0, UUID)`.
- Use `LiquidAccumulationTracker.AccumulationZone` and its current fields.
- Calculate pressure drop from the example's own profile and array length.
- Replace all console output with parameterized Log4j2 examples.
- Convert both equation groups to `$$` display math.
- Replace generic percentage tolerances with case-specific validation guidance.
- Add two focused Java 8-compatible regression methods covering the corrected boundary and accumulation APIs.

### Validation evidence

Final branch head: `437896a17638751ae4e710bf39efb07605dce04c`.

- Current source/API audit: `TransientPipe`, `LiquidAccumulationTracker`, merged #2596 source/tests.
- Focused regression on Windows Java 21: **2/2 passed**.
- Complete Windows Java 21 suite: **10,682 tests**, zero failures/errors, 212 skipped; build successful.
- Pre-commit, Spotless, Javadoc, documentation build/search, CodeQL, change detection, and agent-reference checks: passed.
- Markdown: valid front matter, one H1, 16 paired fences, two paired display-math blocks.
- Navigation: all four relative targets and the TwoFluidPipe fragment resolve.
- Changed page: no images or external links.
- Java 8 source compatibility: static syntax/API audit passed; this PR workflow exposed hosted Java 21 jobs only.
- Ubuntu Java 21 coverage-enabled suite is still running; D025 remains `validating` until it completes.

### Copilot gate

All four actionable threads were assessed and resolved:

- added the missing tracker import;
- replaced every console-output call across the page with Log4j2;
- aligned the guide and regression test to a robust 1e-6 bara tolerance.

Two final-head Copilot reviews inspected both files and reported no new comments. No Copilot-authored commit exists.

### Final diff and exclusions

The merge is one commit and exactly two frozen files: 160 additions / 56 deletions. No production code, notebook, image, or unrelated file changed. Browser-rendered site inspection was unavailable and is not claimed.

### Publication state

PR #2599 was merged externally as `397214a1dbe74ccc34f0bd7e6b3d614a870de4cb` while the Ubuntu suite was still running. The merge commit is the current `master` head. This campaign did not merge, enable auto-merge, or push directly to `master`.

### Next scope

D026: next bounded rotation entry after D025 validation is complete.