### PR TITLE
[AI-Assisted] Add typed energy streams and equipment ports

### DIFF
--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -48,6 +48,7 @@ This documentation is organized into the following sections:
 | [bioprocessing.md](bioprocessing) | **Bio-processing** — reactors, fermenters, solid-liquid separators, LLE, evaporators, dryers, crystallizers |
 | [neqsim-studio.md](neqsim-studio) | **NeqSim Studio (Python)** — newcomer-friendly process builder: natural language, templates, guided wizard, edit-by-chat, recipe gallery |
 | [processmodel/](processmodel/) | ProcessSystem and flowsheet management |
+| [energy_streams.md](energy_streams) | **Energy streams** — typed heat, shaft-work, and electrical ports, unit-aware duties, graph ordering, and energy-driven equipment |
 | [process_json_export_and_e300_fluids.md](process_json_export_and_e300_fluids) | **Process JSON export** — self-contained ProcessSystem/ProcessModel JSON for MCP, including E300-equivalent component properties and volume correction |
 | [simulation-hooks-and-events.md](simulation-hooks-and-events) | **Lifecycle hooks, event bus, auto-validation** for ProcessSystem and ProcessModel |
 | [model-change-events.md](model-change-events) | **Governed model revisions** — versioned change events, idempotent publication, fingerprints, and durable replay |

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -1,0 +1,51 @@
+---
+title: Energy streams and equipment ports
+description: Connect heat, shaft-work, and electrical duties between NeqSim unit operations.
+---
+
+# Energy streams and equipment ports
+
+`EnergyStream` carries a power rate between process equipment. Its canonical unit is watt (W), while unit-aware APIs accept `W`, `kW`, `MW`, `hp`, and `BTU/hr`.
+
+Typed `EnergyPort` metadata separates three concepts:
+
+- `EnergyType`: `HEAT`, `SHAFT_WORK`, `ELECTRICAL`, or legacy `UNSPECIFIED`.
+- `EnergyPortDirection`: physical flow relative to the equipment boundary.
+- `EnergyPortMode`: whether the equipment calculates the duty, reads it as a specification, or leaves it to a balance solver.
+
+Calculation mode controls process-graph ordering. An equipment port in `CALCULATED` mode is scheduled before a unit reading the same stream through a `SPECIFICATION` port, even if units were added to the process in the opposite order.
+
+## Energy-driven pump
+
+A connected shaft-work stream makes `Pump` calculate its outlet pressure from available shaft power, inlet volumetric flow, and efficiency:
+
+```java
+SystemInterface water = new SystemSrkEos(298.15, 2.0);
+water.addComponent("water", 1.0);
+water.setMixingRule("classic");
+
+Stream feed = new Stream("pump feed", water);
+feed.setFlowRate(100000.0, "kg/hr");
+feed.run();
+
+EnergyStream shaft = new EnergyStream("pump shaft", EnergyType.SHAFT_WORK);
+shaft.setPower(100.0, "kW");
+
+Pump pump = new Pump("energy-driven pump", feed);
+pump.setIsentropicEfficiency(0.75);
+pump.setEnergyStream(shaft);
+pump.run();
+
+double outletPressure = pump.getOutletStream().getPressure("bara");
+EnergyPortMode mode = pump.getEnergyPort("shaftPower").getMode();
+```
+
+Without an externally connected energy stream, `Pump` keeps its existing pressure-specified behavior and publishes the calculated shaft duty through `getEnergyStream()`.
+
+## Reboiler duty reporting
+
+A `Reboiler` now publishes its calculated heat duty through `getEnergyStream()`. The stream is typed as `HEAT`, and `getDuty("kW")` or `getEnergyFlow("MW")` can be used for utility summaries and downstream coupling.
+
+## Compatibility
+
+Existing `getDuty()`, `setDuty(double)`, equality, and `setEnergyStream(EnergyStream)` behavior remain available. Legacy equipment that encodes direction in a signed duty keeps that convention until it is migrated to typed ports. New integrations should declare an `EnergyType` and use named ports so type validation and graph scheduling are available.

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -65,6 +65,20 @@ double sparePower = shaftTrain.getNetPower("MW");
 
 Point-to-point `EnergyStream` connections reject multiple calculated producers or specification consumers during graph construction. Use `EnergyBus` for intentional multi-party distribution.
 
+## Coupled networks and repeated execution
+
+When a specification consumer is connected to an `EnergyBus`, it reads the net power excluding its own contribution from the previous run. After calculation, supported consumers publish their actual withdrawal back to the bus. This makes repeated steady-state runs stable instead of progressively subtracting the same load.
+
+`getNetPowerExcluding(String)` exposes the same balance operation for custom dispatch logic. Input and output ports convert equipment power to negative withdrawals and positive injections. A bidirectional specification port treats positive equipment duty as a bus withdrawal, which supports recovered-heat links such as condenser to heater.
+
+The process graph orders calculated producers before specification consumers. This applies to coupled networks such as:
+
+- expander → `MechanicalShaft` → compressor or pump
+- solar or other generation → electrical `EnergyBus` → electrolyzer
+- condenser heat output → heat-recovery `EnergyBus` → heater
+
+These connections remain stable when the flowsheet is executed repeatedly, and Java serialization preserves shared bus identity, port metadata, and named contributions.
+
 ## Equipment coverage
 
 | Equipment group | Typed port | Supported role |

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -71,6 +71,9 @@ Point-to-point `EnergyStream` connections reject multiple calculated producers o
 |---|---|---|
 | Pump, Compressor | `shaftPower` input | Calculated duty or external power specification |
 | Expander, SteamTurbine | `shaftPower` output | Calculated shaft power |
+| GasTurbine | `shaftPower` and `exhaustHeat` outputs | Calculated power/heat; shaft output can also be a fuel-sizing specification |
+| GasTurbineUnit | `shaftPower` output | Calculated delivered shaft power at the active demand and site limit |
+| CombinedCycleSystem | `electricalPower` output | Calculated combined-cycle generation |
 | Heater, Cooler | `heatDuty` bidirectional | Calculated duty or legacy external duty specification |
 | Condenser | `heatDuty` output | Calculated heat removal |
 | Reboiler | `heatDuty` input | Calculated duty or legacy external duty specification |
@@ -79,6 +82,7 @@ Point-to-point `EnergyStream` connections reject multiple calculated producers o
 | Electrolyzer | `electricalPower` input | Feed-calculated demand or connected power-driven specification |
 | CO2Electrolyzer, BioFeedstockPreparation | `electricalPower` input | Calculated demand |
 | AmmoniaSynthesisReactor | `reactionHeat` output | Calculated reaction heat |
+| StirredTankReactor | `heatDuty` bidirectional; `agitatorPower` input | Calculated or specified heat duty and calculated electrical demand |
 
 ## Reboiler duty reporting
 

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -42,6 +42,44 @@ EnergyPortMode mode = pump.getEnergyPort("shaftPower").getMode();
 
 Without an externally connected energy stream, `Pump` keeps its existing pressure-specified behavior and publishes the calculated shaft duty through `getEnergyStream()`.
 
+## Multi-party buses and shafts
+
+Use `EnergyBus` when several producers or consumers share a heat or electrical network. Named contributions are signed: positive values inject power and negative values withdraw power.
+
+```java
+EnergyBus grid = new EnergyBus("main electrical bus", EnergyType.ELECTRICAL);
+grid.setContribution("solar", 2.0, "MW");
+grid.setContribution("electrolyzer", -1.5, "MW");
+double reserve = grid.getNetPower("kW");
+```
+
+`MechanicalShaft` is a shaft-work bus with convenience methods for generation and loads:
+
+```java
+MechanicalShaft shaftTrain = new MechanicalShaft("expander-compressor shaft");
+shaftTrain.setMechanicalEfficiency(0.98);
+shaftTrain.setGeneratedPower("expander", 10.0e6);
+shaftTrain.setConsumedPower("compressor", 8.0e6);
+double sparePower = shaftTrain.getNetPower("MW");
+```
+
+Point-to-point `EnergyStream` connections reject multiple calculated producers or specification consumers during graph construction. Use `EnergyBus` for intentional multi-party distribution.
+
+## Equipment coverage
+
+| Equipment group | Typed port | Supported role |
+|---|---|---|
+| Pump, Compressor | `shaftPower` input | Calculated duty or external power specification |
+| Expander, SteamTurbine | `shaftPower` output | Calculated shaft power |
+| Heater, Cooler | `heatDuty` bidirectional | Calculated duty or legacy external duty specification |
+| Condenser | `heatDuty` output | Calculated heat removal |
+| Reboiler | `heatDuty` input | Calculated duty or legacy external duty specification |
+| SolarPanel, WindTurbine, WindFarm, FuelCell | `electricalPower` output | Calculated generation |
+| BatteryStorage | `electricalPower` bidirectional | Calculated charge/discharge |
+| Electrolyzer | `electricalPower` input | Feed-calculated demand or connected power-driven specification |
+| CO2Electrolyzer, BioFeedstockPreparation | `electricalPower` input | Calculated demand |
+| AmmoniaSynthesisReactor | `reactionHeat` output | Calculated reaction heat |
+
 ## Reboiler duty reporting
 
 A `Reboiler` now publishes its calculated heat duty through `getEnergyStream()`. The stream is typed as `HEAT`, and `getDuty("kW")` or `getEnergyFlow("MW")` can be used for utility summaries and downstream coupling.

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
@@ -307,6 +307,7 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
       throw new IllegalArgumentException("Energy port already registered: " + portName);
     }
     EnergyPort port = new EnergyPort(portName, energyType, direction, mode);
+    port.setOwnerName(getName());
     if (energyPorts.isEmpty() && energyStream != null) {
       port.connect(energyStream);
     }

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
@@ -427,7 +427,15 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
    * @return a boolean
    */
   public boolean isSetEnergyStream() {
-    return isSetEnergyStream;
+    if (!isSetEnergyStream || energyPorts.isEmpty()) {
+      return isSetEnergyStream;
+    }
+    for (EnergyPort port : energyPorts.values()) {
+      if (port.isConnected() && port.getMode() == EnergyPortMode.SPECIFICATION) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
@@ -26,7 +26,11 @@ import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.failure.EquipmentFailureMode;
 import neqsim.process.equipment.iec81346.ReferenceDesignation;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.mechanicaldesign.MechanicalDesign;
 import neqsim.process.util.report.Report;
 import neqsim.process.util.report.ReportConfig;
@@ -60,6 +64,7 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
   public HashMap<String, String> properties = new HashMap<String, String>();
   public EnergyStream energyStream = new EnergyStream();
   private boolean isSetEnergyStream = false;
+  private final Map<String, EnergyPort> energyPorts = new LinkedHashMap<String, EnergyPort>();
   protected boolean isSolved = true;
   private boolean isActive = true;
   private boolean lockedInactive = false;
@@ -283,13 +288,98 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
   }
 
   /**
+   * Registers a typed energy port on this equipment.
+   *
+   * <p>The first registered port is connected to the equipment's existing internal energy stream so
+   * legacy result reporting remains available without marking the stream as an external
+   * specification.
+   *
+   * @param portName unique port name
+   * @param energyType physical energy domain
+   * @param direction physical transfer direction
+   * @param mode calculation role
+   * @return the registered port
+   * @throws IllegalArgumentException if the port name is already registered
+   */
+  public EnergyPort registerEnergyPort(String portName, EnergyType energyType,
+      EnergyPortDirection direction, EnergyPortMode mode) {
+    if (energyPorts.containsKey(portName)) {
+      throw new IllegalArgumentException("Energy port already registered: " + portName);
+    }
+    EnergyPort port = new EnergyPort(portName, energyType, direction, mode);
+    if (energyPorts.isEmpty() && energyStream != null) {
+      port.connect(energyStream);
+    }
+    energyPorts.put(portName, port);
+    return port;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, EnergyPort> getEnergyPorts() {
+    return Collections.unmodifiableMap(energyPorts);
+  }
+
+  /**
+   * Gets a named energy port.
+   *
+   * @param portName port name
+   * @return the port, or {@code null} when no port has that name
+   */
+  public EnergyPort getEnergyPort(String portName) {
+    return energyPorts.get(portName);
+  }
+
+  /**
+   * Connects an energy stream to a named port and marks it as externally connected.
+   *
+   * @param portName port name
+   * @param stream energy stream to connect
+   * @throws IllegalArgumentException if the port does not exist or its type is incompatible
+   */
+  public void connectEnergyStream(String portName, EnergyStream stream) {
+    EnergyPort port = energyPorts.get(portName);
+    if (port == null) {
+      throw new IllegalArgumentException("Unknown energy port: " + portName);
+    }
+    port.connect(stream);
+    if (energyPorts.size() == 1) {
+      energyStream = stream;
+    }
+    setEnergyStream(true);
+  }
+
+  /**
+   * Disconnects the stream from a named energy port.
+   *
+   * @param portName port name
+   * @throws IllegalArgumentException if the port does not exist
+   */
+  public void disconnectEnergyStream(String portName) {
+    EnergyPort port = energyPorts.get(portName);
+    if (port == null) {
+      throw new IllegalArgumentException("Unknown energy port: " + portName);
+    }
+    port.disconnect();
+    if (energyPorts.size() == 1) {
+      setEnergyStream(false);
+    }
+  }
+
+  /**
    * Setter for the field <code>energyStream</code>.
+   *
+   * <p>For equipment exposing exactly one typed energy port, this legacy method also connects that
+   * port. Existing equipment without typed ports retains its original behavior.
    *
    * @param energyStream a {@link neqsim.process.equipment.stream.EnergyStream} object
    */
   public void setEnergyStream(EnergyStream energyStream) {
     setEnergyStream(true);
     this.energyStream = energyStream;
+    if (energyPorts.size() == 1) {
+      energyPorts.values().iterator().next().connect(energyStream);
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
@@ -290,9 +290,9 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
   /**
    * Registers a typed energy port on this equipment.
    *
-   * <p>The first registered port is connected to the equipment's existing internal energy stream so
-   * legacy result reporting remains available without marking the stream as an external
-   * specification.
+   * <p>
+   * The first registered port is connected to the equipment's existing internal energy stream so legacy result
+   * reporting remains available without marking the stream as an external specification.
    *
    * @param portName unique port name
    * @param energyType physical energy domain
@@ -301,8 +301,8 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
    * @return the registered port
    * @throws IllegalArgumentException if the port name is already registered
    */
-  public EnergyPort registerEnergyPort(String portName, EnergyType energyType,
-      EnergyPortDirection direction, EnergyPortMode mode) {
+  public EnergyPort registerEnergyPort(String portName, EnergyType energyType, EnergyPortDirection direction,
+      EnergyPortMode mode) {
     if (energyPorts.containsKey(portName)) {
       throw new IllegalArgumentException("Energy port already registered: " + portName);
     }
@@ -369,8 +369,9 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
   /**
    * Setter for the field <code>energyStream</code>.
    *
-   * <p>For equipment exposing exactly one typed energy port, this legacy method also connects that
-   * port. Existing equipment without typed ports retains its original behavior.
+   * <p>
+   * For equipment exposing exactly one typed energy port, this legacy method also connects that port. Existing
+   * equipment without typed ports retains its original behavior.
    *
    * @param energyStream a {@link neqsim.process.equipment.stream.EnergyStream} object
    */

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
@@ -357,8 +357,7 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
    * @param stream energy stream to connect
    * @param mode calculation role for this connection
    */
-  public void connectEnergyStream(
-      String portName, EnergyStream stream, EnergyPortMode mode) {
+  public void connectEnergyStream(String portName, EnergyStream stream, EnergyPortMode mode) {
     connectEnergyStream(portName, stream);
     setEnergyPortMode(portName, mode);
   }

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
@@ -15,9 +15,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -65,6 +67,7 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
   public EnergyStream energyStream = new EnergyStream();
   private boolean isSetEnergyStream = false;
   private final Map<String, EnergyPort> energyPorts = new LinkedHashMap<String, EnergyPort>();
+  private final Set<String> externallyConnectedEnergyPorts = new LinkedHashSet<String>();
   protected boolean isSolved = true;
   private boolean isActive = true;
   private boolean lockedInactive = false;
@@ -339,15 +342,13 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
    * @throws IllegalArgumentException if the port does not exist or its type is incompatible
    */
   public void connectEnergyStream(String portName, EnergyStream stream) {
-    EnergyPort port = energyPorts.get(portName);
-    if (port == null) {
-      throw new IllegalArgumentException("Unknown energy port: " + portName);
-    }
+    EnergyPort port = requireEnergyPort(portName);
     port.connect(stream);
-    if (energyPorts.size() == 1) {
+    externallyConnectedEnergyPorts.add(portName);
+    if (isLegacyEnergyPort(port)) {
       energyStream = stream;
     }
-    setEnergyStream(true);
+    updateExternalEnergySpecificationFlag();
   }
 
   /**
@@ -358,8 +359,15 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
    * @param mode calculation role for this connection
    */
   public void connectEnergyStream(String portName, EnergyStream stream, EnergyPortMode mode) {
-    connectEnergyStream(portName, stream);
-    setEnergyPortMode(portName, mode);
+    EnergyPort port = requireEnergyPort(portName);
+    Objects.requireNonNull(mode, "mode cannot be null");
+    port.connect(stream);
+    port.setMode(mode);
+    externallyConnectedEnergyPorts.add(portName);
+    if (isLegacyEnergyPort(port)) {
+      energyStream = stream;
+    }
+    updateExternalEnergySpecificationFlag();
   }
 
   /**
@@ -370,11 +378,9 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
    * @throws IllegalArgumentException if the port does not exist
    */
   public void setEnergyPortMode(String portName, EnergyPortMode mode) {
-    EnergyPort port = energyPorts.get(portName);
-    if (port == null) {
-      throw new IllegalArgumentException("Unknown energy port: " + portName);
-    }
+    EnergyPort port = requireEnergyPort(portName);
     port.setMode(mode);
+    updateExternalEnergySpecificationFlag();
   }
 
   /**
@@ -384,14 +390,14 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
    * @throws IllegalArgumentException if the port does not exist
    */
   public void disconnectEnergyStream(String portName) {
-    EnergyPort port = energyPorts.get(portName);
-    if (port == null) {
-      throw new IllegalArgumentException("Unknown energy port: " + portName);
-    }
+    EnergyPort port = requireEnergyPort(portName);
+    externallyConnectedEnergyPorts.remove(portName);
     port.disconnect();
-    if (energyPorts.size() == 1) {
-      setEnergyStream(false);
+    if (isLegacyEnergyPort(port)) {
+      energyStream = new EnergyStream(getName() + "." + portName + ".internal", port.getEnergyType());
+      port.connect(energyStream);
     }
+    updateExternalEnergySpecificationFlag();
   }
 
   /**
@@ -404,11 +410,17 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
    * @param energyStream a {@link neqsim.process.equipment.stream.EnergyStream} object
    */
   public void setEnergyStream(EnergyStream energyStream) {
-    setEnergyStream(true);
-    this.energyStream = energyStream;
-    if (energyPorts.size() == 1) {
-      energyPorts.values().iterator().next().connect(energyStream);
+    Objects.requireNonNull(energyStream, "energyStream cannot be null");
+    if (energyPorts.isEmpty()) {
+      this.energyStream = energyStream;
+      setEnergyStream(true);
+      return;
     }
+    EnergyPort legacyPort = energyPorts.values().iterator().next();
+    legacyPort.connect(energyStream);
+    externallyConnectedEnergyPorts.add(legacyPort.getName());
+    this.energyStream = energyStream;
+    updateExternalEnergySpecificationFlag();
   }
 
   /**
@@ -426,15 +438,39 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
    * @return a boolean
    */
   public boolean isSetEnergyStream() {
-    if (!isSetEnergyStream || energyPorts.isEmpty()) {
+    if (energyPorts.isEmpty()) {
       return isSetEnergyStream;
     }
-    for (EnergyPort port : energyPorts.values()) {
-      if (port.isConnected() && port.getMode() == EnergyPortMode.SPECIFICATION) {
+    for (String portName : externallyConnectedEnergyPorts) {
+      EnergyPort port = energyPorts.get(portName);
+      if (port != null && port.isConnected() && port.getMode() == EnergyPortMode.SPECIFICATION) {
         return true;
       }
     }
     return false;
+  }
+
+  private EnergyPort requireEnergyPort(String portName) {
+    EnergyPort port = energyPorts.get(portName);
+    if (port == null) {
+      throw new IllegalArgumentException("Unknown energy port: " + portName);
+    }
+    return port;
+  }
+
+  private boolean isLegacyEnergyPort(EnergyPort port) {
+    return !energyPorts.isEmpty() && energyPorts.values().iterator().next() == port;
+  }
+
+  private void updateExternalEnergySpecificationFlag() {
+    isSetEnergyStream = false;
+    for (String portName : externallyConnectedEnergyPorts) {
+      EnergyPort port = energyPorts.get(portName);
+      if (port != null && port.isConnected() && port.getMode() == EnergyPortMode.SPECIFICATION) {
+        isSetEnergyStream = true;
+        return;
+      }
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
@@ -351,6 +351,34 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
   }
 
   /**
+   * Connects an energy stream with an explicit calculation role.
+   *
+   * @param portName port name
+   * @param stream energy stream to connect
+   * @param mode calculation role for this connection
+   */
+  public void connectEnergyStream(
+      String portName, EnergyStream stream, EnergyPortMode mode) {
+    connectEnergyStream(portName, stream);
+    setEnergyPortMode(portName, mode);
+  }
+
+  /**
+   * Sets the calculation role of a named energy port.
+   *
+   * @param portName port name
+   * @param mode calculation role
+   * @throws IllegalArgumentException if the port does not exist
+   */
+  public void setEnergyPortMode(String portName, EnergyPortMode mode) {
+    EnergyPort port = energyPorts.get(portName);
+    if (port == null) {
+      throw new IllegalArgumentException("Unknown energy port: " + portName);
+    }
+    port.setMode(mode);
+  }
+
+  /**
    * Disconnects the stream from a named energy port.
    *
    * @param portName port name

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentInterface.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentInterface.java
@@ -12,6 +12,7 @@ import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.electricaldesign.ElectricalDesign;
 import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.iec81346.ReferenceDesignation;
+import neqsim.process.equipment.stream.EnergyPort;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.instrumentdesign.InstrumentDesign;
 import neqsim.process.mechanicaldesign.DesignConditions;
@@ -202,6 +203,19 @@ public interface ProcessEquipmentInterface extends ProcessElementInterface, Simu
    */
   public default List<StreamInterface> getOutletStreams() {
     return Collections.emptyList();
+  }
+
+  /**
+   * Returns the named energy ports exposed by this equipment.
+   *
+   * <p>The default is empty so existing equipment remains source and binary compatible. Equipment
+   * backed by {@link ProcessEquipmentBaseClass} can register typed ports for graph discovery and
+   * validation.
+   *
+   * @return unmodifiable map keyed by port name
+   */
+  public default Map<String, EnergyPort> getEnergyPorts() {
+    return Collections.emptyMap();
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentInterface.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentInterface.java
@@ -208,9 +208,9 @@ public interface ProcessEquipmentInterface extends ProcessElementInterface, Simu
   /**
    * Returns the named energy ports exposed by this equipment.
    *
-   * <p>The default is empty so existing equipment remains source and binary compatible. Equipment
-   * backed by {@link ProcessEquipmentBaseClass} can register typed ports for graph discovery and
-   * validation.
+   * <p>
+   * The default is empty so existing equipment remains source and binary compatible. Equipment backed by
+   * {@link ProcessEquipmentBaseClass} can register typed ports for graph discovery and validation.
    *
    * @return unmodifiable map keyed by port name
    */

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.battery;
 
 import java.util.UUID;
+import neqsim.process.equipment.stream.EnergyBus;
 import neqsim.process.equipment.stream.EnergyPortDirection;
 import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyType;
@@ -137,7 +138,11 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
-    getEnergyStream().setDuty(-currentPower);
+    if (getEnergyPort("electricalPower").getEnergyStream() instanceof EnergyBus) {
+      getEnergyPort("electricalPower").setDuty(currentPower);
+    } else {
+      getEnergyPort("electricalPower").setDuty(-currentPower);
+    }
     setCalculationIdentifier(id);
   }
 }

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -1,6 +1,9 @@
 package neqsim.process.equipment.battery;
 
 import java.util.UUID;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 
 /**
@@ -32,6 +35,8 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
    */
   public BatteryStorage(String name, double capacity) {
     super(name);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.BIDIRECTIONAL,
+        EnergyPortMode.CALCULATED);
     this.capacity = capacity;
     this.stateOfCharge = 0.0;
   }

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -924,7 +924,7 @@ public class Compressor extends TwoPortEquipment
     }
 
     if (isSetEnergyStream()) {
-      setPower(energyStream.getDuty());
+      setPower(getEnergyPort("shaftPower").getPowerMagnitude());
     }
 
     ThermodynamicOperations thermoOps = new ThermodynamicOperations(getThermoSystem());

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -26,6 +26,10 @@ import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.capacity.CapacityConstrainedEquipment;
 import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.capacity.StandardConstraintType;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.mechanicaldesign.compressor.CompressorMechanicalDesign;
 import neqsim.process.ml.StateVector;
@@ -217,6 +221,7 @@ public class Compressor extends TwoPortEquipment
    */
   public Compressor(String name) {
     super(name);
+    registerEnergyPort("shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
     initMechanicalDesign();
     initElectricalDesign();
     initInstrumentDesign();
@@ -244,6 +249,35 @@ public class Compressor extends TwoPortEquipment
     this(name);
     if (interpolateMapLookup) {
       compressorChart = new CompressorChartAlternativeMapLookup();
+    }
+  }
+
+  /**
+   * Connects an external shaft-power specification using the legacy single-stream API.
+   *
+   * @param energyStream shaft-work stream
+   */
+  @Override
+  public void setEnergyStream(EnergyStream energyStream) {
+    super.setEnergyStream(energyStream);
+    getEnergyPort("shaftPower").setMode(EnergyPortMode.SPECIFICATION);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectEnergyStream(String portName, EnergyStream stream) {
+    super.connectEnergyStream(portName, stream);
+    if ("shaftPower".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void disconnectEnergyStream(String portName) {
+    super.disconnectEnergyStream(portName);
+    if ("shaftPower".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.CALCULATED);
     }
   }
 
@@ -692,6 +726,9 @@ public class Compressor extends TwoPortEquipment
   }
 
   private void finishRun(UUID id) {
+    if (!isSetEnergyStream()) {
+      getEnergyStream().setDuty(dH);
+    }
     updateRecalculationState();
     if (thermalModel != null && thermalModel.isAutoSolve()) {
       thermalModel.solveSteadyState(this);

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -26,6 +26,7 @@ import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.capacity.CapacityConstrainedEquipment;
 import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.capacity.StandardConstraintType;
+import neqsim.process.equipment.stream.EnergyBus;
 import neqsim.process.equipment.stream.EnergyPortDirection;
 import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyStream;
@@ -221,11 +222,25 @@ public class Compressor extends TwoPortEquipment
    */
   public Compressor(String name) {
     super(name);
-    registerEnergyPort("shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
+    registerEnergyPort("shaftPower", EnergyType.SHAFT_WORK, getShaftPowerDirection(), EnergyPortMode.CALCULATED);
     initMechanicalDesign();
     initElectricalDesign();
     initInstrumentDesign();
     initializeCapacityConstraints();
+  }
+
+  /**
+   * Gets the physical direction of the shaft-power port.
+   *
+   * <p>
+   * Subclasses such as expanders override this hook so the inherited constructor registers the port once with the
+   * correct direction.
+   * </p>
+   *
+   * @return shaft-power direction
+   */
+  protected EnergyPortDirection getShaftPowerDirection() {
+    return EnergyPortDirection.INPUT;
   }
 
   /**
@@ -726,7 +741,7 @@ public class Compressor extends TwoPortEquipment
   }
 
   private void finishRun(UUID id) {
-    if (!isSetEnergyStream()) {
+    if (!isSetEnergyStream() || getEnergyPort("shaftPower").getEnergyStream() instanceof EnergyBus) {
       getEnergyPort("shaftPower").setDuty(dH);
     }
     updateRecalculationState();

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -259,16 +259,16 @@ public class Compressor extends TwoPortEquipment
    */
   @Override
   public void setEnergyStream(EnergyStream energyStream) {
-    super.setEnergyStream(energyStream);
-    getEnergyPort("shaftPower").setMode(EnergyPortMode.SPECIFICATION);
+    super.connectEnergyStream("shaftPower", energyStream, EnergyPortMode.SPECIFICATION);
   }
 
   /** {@inheritDoc} */
   @Override
   public void connectEnergyStream(String portName, EnergyStream stream) {
-    super.connectEnergyStream(portName, stream);
     if ("shaftPower".equals(portName)) {
-      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+      super.connectEnergyStream(portName, stream, EnergyPortMode.SPECIFICATION);
+    } else {
+      super.connectEnergyStream(portName, stream);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -727,7 +727,7 @@ public class Compressor extends TwoPortEquipment
 
   private void finishRun(UUID id) {
     if (!isSetEnergyStream()) {
-      getEnergyStream().setDuty(dH);
+      getEnergyPort("shaftPower").setDuty(dH);
     }
     updateRecalculationState();
     if (thermalModel != null && thermalModel.isAutoSolve()) {

--- a/src/main/java/neqsim/process/equipment/distillation/Condenser.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Condenser.java
@@ -208,7 +208,7 @@ public class Condenser extends SimpleTray {
     // System.out.println("temperature: " +
     // mixedStream.getThermoSystem().getTemperature());
     duty = mixedStream.getFluid().getEnthalpy() - calcMixStreamEnthalpy0();
-    energyStream.setDuty(duty);
+    getEnergyPort("heatDuty").setDuty(duty);
     // System.out.println("beta " + mixedStream.getThermoSystem().getBeta())
 
     setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/distillation/Condenser.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Condenser.java
@@ -1,6 +1,9 @@
 package neqsim.process.equipment.distillation;
 
 import java.util.UUID;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.splitter.Splitter;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
@@ -33,6 +36,7 @@ public class Condenser extends SimpleTray {
    */
   public Condenser(String name) {
     super(name);
+    registerEnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
@@ -1,6 +1,10 @@
 package neqsim.process.equipment.distillation;
 
 import java.util.UUID;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
@@ -25,6 +29,37 @@ public class Reboiler extends neqsim.process.equipment.distillation.SimpleTray {
    */
   public Reboiler(String name) {
     super(name);
+    registerEnergyPort(
+        "heatDuty", EnergyType.HEAT, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
+  }
+
+  /**
+   * Connects an external heat-duty specification using the legacy single-stream API.
+   *
+   * @param energyStream heat-duty stream
+   */
+  @Override
+  public void setEnergyStream(EnergyStream energyStream) {
+    super.setEnergyStream(energyStream);
+    getEnergyPort("heatDuty").setMode(EnergyPortMode.SPECIFICATION);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectEnergyStream(String portName, EnergyStream stream) {
+    super.connectEnergyStream(portName, stream);
+    if ("heatDuty".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void disconnectEnergyStream(String portName) {
+    super.disconnectEnergyStream(portName);
+    if ("heatDuty".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.CALCULATED);
+    }
   }
 
   /**
@@ -104,6 +139,9 @@ public class Reboiler extends neqsim.process.equipment.distillation.SimpleTray {
 
     // System.out.println("beta " + mixedStream.getThermoSystem().getBeta())
     duty = mixedStream.getFluid().getEnthalpy() - calcMixStreamEnthalpy0();
+    if (!isSetEnergyStream()) {
+      getEnergyStream().setDuty(duty);
+    }
 
     mixedStream.setCalculationIdentifier(id);
     setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
@@ -29,8 +29,7 @@ public class Reboiler extends neqsim.process.equipment.distillation.SimpleTray {
    */
   public Reboiler(String name) {
     super(name);
-    registerEnergyPort(
-        "heatDuty", EnergyType.HEAT, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
+    registerEnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
@@ -39,16 +39,16 @@ public class Reboiler extends neqsim.process.equipment.distillation.SimpleTray {
    */
   @Override
   public void setEnergyStream(EnergyStream energyStream) {
-    super.setEnergyStream(energyStream);
-    getEnergyPort("heatDuty").setMode(EnergyPortMode.SPECIFICATION);
+    super.connectEnergyStream("heatDuty", energyStream, EnergyPortMode.SPECIFICATION);
   }
 
   /** {@inheritDoc} */
   @Override
   public void connectEnergyStream(String portName, EnergyStream stream) {
-    super.connectEnergyStream(portName, stream);
     if ("heatDuty".equals(portName)) {
-      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+      super.connectEnergyStream(portName, stream, EnergyPortMode.SPECIFICATION);
+    } else {
+      super.connectEnergyStream(portName, stream);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
@@ -139,7 +139,7 @@ public class Reboiler extends neqsim.process.equipment.distillation.SimpleTray {
     // System.out.println("beta " + mixedStream.getThermoSystem().getBeta())
     duty = mixedStream.getFluid().getEnthalpy() - calcMixStreamEnthalpy0();
     if (!isSetEnergyStream()) {
-      getEnergyStream().setDuty(duty);
+      getEnergyPort("heatDuty").setDuty(duty);
     }
 
     mixedStream.setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/electrolyzer/CO2Electrolyzer.java
+++ b/src/main/java/neqsim/process/equipment/electrolyzer/CO2Electrolyzer.java
@@ -383,14 +383,14 @@ public class CO2Electrolyzer extends ProcessEquipmentBaseClass {
 
   private void updateEnergyConsumption(double electronMolesPerSecond) {
     if (electronMolesPerSecond <= 0.0) {
-      energyStream.setDuty(0.0);
+      getEnergyPort("electricalPower").setDuty(0.0);
       setEnergyStream(true);
       return;
     }
     double effectiveElectrons = electronMolesPerSecond / Math.max(currentEfficiency, 1e-6);
     double current = effectiveElectrons * FARADAY_CONSTANT;
     double power = current * cellVoltage;
-    energyStream.setDuty(power);
+    getEnergyPort("electricalPower").setDuty(power);
     setEnergyStream(true);
   }
 

--- a/src/main/java/neqsim/process/equipment/electrolyzer/CO2Electrolyzer.java
+++ b/src/main/java/neqsim/process/equipment/electrolyzer/CO2Electrolyzer.java
@@ -52,8 +52,7 @@ public class CO2Electrolyzer extends ProcessEquipmentBaseClass {
    */
   public CO2Electrolyzer(String name) {
     super(name);
-    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
-        EnergyPortMode.CALCULATED);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
     initializeDefaultElectronNumbers();
   }
 

--- a/src/main/java/neqsim/process/equipment/electrolyzer/CO2Electrolyzer.java
+++ b/src/main/java/neqsim/process/equipment/electrolyzer/CO2Electrolyzer.java
@@ -8,6 +8,9 @@ import java.util.Set;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.process.equipment.reactor.GibbsReactor;
 import neqsim.process.equipment.stream.Stream;
@@ -49,6 +52,8 @@ public class CO2Electrolyzer extends ProcessEquipmentBaseClass {
    */
   public CO2Electrolyzer(String name) {
     super(name);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
     initializeDefaultElectronNumbers();
   }
 

--- a/src/main/java/neqsim/process/equipment/electrolyzer/Electrolyzer.java
+++ b/src/main/java/neqsim/process/equipment/electrolyzer/Electrolyzer.java
@@ -271,7 +271,7 @@ public class Electrolyzer extends ProcessEquipmentBaseClass {
         waterInlet.setFlowRate(0.0, "mole/sec");
         waterInlet.run(id);
         setProductStreams(0.0, 0.0, inletPressure, inletPressure, tempK, id);
-        energyStream.setDuty(standbyPowerFraction * ratedPower);
+        getEnergyPort("electricalPower").setDuty(standbyPowerFraction * ratedPower);
         setEnergyStream(true);
         setCalculationIdentifier(id);
         return;
@@ -310,7 +310,7 @@ public class Electrolyzer extends ProcessEquipmentBaseClass {
     double deliveryPressure = hydrogenDeliveryPressure > 0.0 ? hydrogenDeliveryPressure : inletPressure;
     setProductStreams(hydrogenFlow, oxygenFlow, deliveryPressure, inletPressure, tempK, id);
 
-    energyStream.setDuty(stackPower);
+    getEnergyPort("electricalPower").setDuty(stackPower);
     setEnergyStream(true);
     setCalculationIdentifier(id);
   }

--- a/src/main/java/neqsim/process/equipment/electrolyzer/Electrolyzer.java
+++ b/src/main/java/neqsim/process/equipment/electrolyzer/Electrolyzer.java
@@ -4,6 +4,10 @@ import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.Fluid;
@@ -121,6 +125,8 @@ public class Electrolyzer extends ProcessEquipmentBaseClass {
    */
   public Electrolyzer(String name) {
     super(name);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
   }
 
   /**
@@ -132,6 +138,38 @@ public class Electrolyzer extends ProcessEquipmentBaseClass {
   public Electrolyzer(String name, StreamInterface inletStream) {
     this(name);
     setInletStream(inletStream);
+  }
+
+  /**
+   * Connects an external electrical-power specification and selects power-driven operation.
+   *
+   * @param energyStream electrical energy stream
+   */
+  @Override
+  public void setEnergyStream(EnergyStream energyStream) {
+    super.setEnergyStream(energyStream);
+    getEnergyPort("electricalPower").setMode(EnergyPortMode.SPECIFICATION);
+    setAvailablePower(Math.abs(energyStream.getDuty()));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectEnergyStream(String portName, EnergyStream stream) {
+    super.connectEnergyStream(portName, stream);
+    if ("electricalPower".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+      setAvailablePower(Math.abs(stream.getDuty()));
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void disconnectEnergyStream(String portName) {
+    super.disconnectEnergyStream(portName);
+    if ("electricalPower".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.CALCULATED);
+      operationMode = OperationMode.WATER_FEED;
+    }
   }
 
   /**
@@ -202,6 +240,9 @@ public class Electrolyzer extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
+    if (getEnergyPort("electricalPower").getMode() == EnergyPortMode.SPECIFICATION) {
+      setAvailablePower(Math.abs(getEnergyPort("electricalPower").getDuty()));
+    }
     double tempK = waterInlet.getTemperature("K");
     double inletPressure = waterInlet.getPressure("bara");
     curtailedPower = 0.0;

--- a/src/main/java/neqsim/process/equipment/electrolyzer/Electrolyzer.java
+++ b/src/main/java/neqsim/process/equipment/electrolyzer/Electrolyzer.java
@@ -146,18 +146,18 @@ public class Electrolyzer extends ProcessEquipmentBaseClass {
    */
   @Override
   public void setEnergyStream(EnergyStream energyStream) {
-    super.setEnergyStream(energyStream);
-    getEnergyPort("electricalPower").setMode(EnergyPortMode.SPECIFICATION);
+    super.connectEnergyStream("electricalPower", energyStream, EnergyPortMode.SPECIFICATION);
     setAvailablePower(Math.abs(energyStream.getDuty()));
   }
 
   /** {@inheritDoc} */
   @Override
   public void connectEnergyStream(String portName, EnergyStream stream) {
-    super.connectEnergyStream(portName, stream);
     if ("electricalPower".equals(portName)) {
-      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+      super.connectEnergyStream(portName, stream, EnergyPortMode.SPECIFICATION);
       setAvailablePower(Math.abs(stream.getDuty()));
+    } else {
+      super.connectEnergyStream(portName, stream);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/electrolyzer/Electrolyzer.java
+++ b/src/main/java/neqsim/process/equipment/electrolyzer/Electrolyzer.java
@@ -147,7 +147,7 @@ public class Electrolyzer extends ProcessEquipmentBaseClass {
   @Override
   public void setEnergyStream(EnergyStream energyStream) {
     super.connectEnergyStream("electricalPower", energyStream, EnergyPortMode.SPECIFICATION);
-    setAvailablePower(Math.abs(energyStream.getDuty()));
+    setAvailablePower(getEnergyPort("electricalPower").getPowerMagnitude());
   }
 
   /** {@inheritDoc} */
@@ -155,7 +155,7 @@ public class Electrolyzer extends ProcessEquipmentBaseClass {
   public void connectEnergyStream(String portName, EnergyStream stream) {
     if ("electricalPower".equals(portName)) {
       super.connectEnergyStream(portName, stream, EnergyPortMode.SPECIFICATION);
-      setAvailablePower(Math.abs(stream.getDuty()));
+      setAvailablePower(getEnergyPort(portName).getPowerMagnitude());
     } else {
       super.connectEnergyStream(portName, stream);
     }
@@ -240,7 +240,7 @@ public class Electrolyzer extends ProcessEquipmentBaseClass {
   @Override
   public void run(UUID id) {
     if (getEnergyPort("electricalPower").getMode() == EnergyPortMode.SPECIFICATION) {
-      setAvailablePower(Math.abs(getEnergyPort("electricalPower").getDuty()));
+      setAvailablePower(getEnergyPort("electricalPower").getPowerMagnitude());
     }
     double tempK = waterInlet.getTemperature("K");
     double inletPressure = waterInlet.getPressure("bara");

--- a/src/main/java/neqsim/process/equipment/electrolyzer/Electrolyzer.java
+++ b/src/main/java/neqsim/process/equipment/electrolyzer/Electrolyzer.java
@@ -125,8 +125,7 @@ public class Electrolyzer extends ProcessEquipmentBaseClass {
    */
   public Electrolyzer(String name) {
     super(name);
-    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
-        EnergyPortMode.CALCULATED);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/expander/Expander.java
+++ b/src/main/java/neqsim/process/equipment/expander/Expander.java
@@ -3,6 +3,9 @@ package neqsim.process.equipment.expander;
 import java.util.UUID;
 import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.mechanicaldesign.expander.ExpanderMechanicalDesign;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -63,6 +66,7 @@ public class Expander extends Compressor implements ExpanderInterface {
    */
   public Expander(String name) {
     super(name);
+    registerEnergyPort("shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
     initExpanderMechanicalDesign();
   }
 
@@ -73,8 +77,8 @@ public class Expander extends Compressor implements ExpanderInterface {
    * @param inletStream a {@link neqsim.process.equipment.stream.StreamInterface} object
    */
   public Expander(String name, StreamInterface inletStream) {
-    super(name, inletStream);
-    initExpanderMechanicalDesign();
+    this(name);
+    setInletStream(inletStream);
   }
 
   /**
@@ -559,9 +563,7 @@ public class Expander extends Compressor implements ExpanderInterface {
       dH = hout - hinn;
       thermoOps.PHflash(hout, 0);
     }
-    if (isSetEnergyStream()) {
-      energyStream.setDuty(-dH);
-    }
+    getEnergyStream().setDuty(-dH);
     // thermoSystem.display();
     outStream.setThermoSystem(getThermoSystem());
     setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/expander/Expander.java
+++ b/src/main/java/neqsim/process/equipment/expander/Expander.java
@@ -563,7 +563,7 @@ public class Expander extends Compressor implements ExpanderInterface {
       dH = hout - hinn;
       thermoOps.PHflash(hout, 0);
     }
-    getEnergyStream().setDuty(-dH);
+    getEnergyPort("shaftPower").setDuty(-dH);
     // thermoSystem.display();
     outStream.setThermoSystem(getThermoSystem());
     setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/expander/Expander.java
+++ b/src/main/java/neqsim/process/equipment/expander/Expander.java
@@ -5,7 +5,7 @@ import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.stream.EnergyPortDirection;
 import neqsim.process.equipment.stream.EnergyPortMode;
-import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.EnergyStream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.mechanicaldesign.expander.ExpanderMechanicalDesign;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -66,8 +66,33 @@ public class Expander extends Compressor implements ExpanderInterface {
    */
   public Expander(String name) {
     super(name);
-    registerEnergyPort("shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
     initExpanderMechanicalDesign();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected EnergyPortDirection getShaftPowerDirection() {
+    return EnergyPortDirection.OUTPUT;
+  }
+
+  /**
+   * Connects a calculated shaft-work output using the legacy single-stream API.
+   *
+   * @param energyStream shaft-work stream
+   */
+  @Override
+  public void setEnergyStream(EnergyStream energyStream) {
+    super.connectEnergyStream("shaftPower", energyStream, EnergyPortMode.CALCULATED);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectEnergyStream(String portName, EnergyStream stream) {
+    if ("shaftPower".equals(portName)) {
+      super.connectEnergyStream(portName, stream, EnergyPortMode.CALCULATED);
+    } else {
+      super.connectEnergyStream(portName, stream);
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
@@ -450,7 +450,7 @@ public class Heater extends TwoPortEquipment
     double newH = system.getEnthalpy();
     energyInput = newH - oldH;
     if (!isSetEnergyStream()) {
-      getEnergyStream().setDuty(energyInput);
+      getEnergyPort("heatDuty").setDuty(energyInput);
     }
     // system.setTemperature(temperatureOut);
     // testOps.TPflash();

--- a/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
@@ -17,6 +17,7 @@ import neqsim.process.design.AutoSizeable;
 import neqsim.process.electricaldesign.heatexchanger.HeatExchangerElectricalDesign;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.TwoPortEquipment;
+import neqsim.process.equipment.stream.EnergyBus;
 import neqsim.process.equipment.stream.EnergyPortDirection;
 import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyStream;
@@ -421,7 +422,11 @@ public class Heater extends TwoPortEquipment
     system.init(2);
     double oldH = system.getEnthalpy();
     if (isSetEnergyStream()) {
-      energyInput = -energyStream.getDuty();
+      if (getEnergyPort("heatDuty").getEnergyStream() instanceof EnergyBus) {
+        energyInput = getEnergyPort("heatDuty").getPowerMagnitude();
+      } else {
+        energyInput = -getEnergyPort("heatDuty").getDuty();
+      }
     }
     double newEnthalpy = energyInput + oldH;
     system.setPressure(system.getPressure() - pressureDrop, pressureUnit);
@@ -449,7 +454,7 @@ public class Heater extends TwoPortEquipment
     system.init(3);
     double newH = system.getEnthalpy();
     energyInput = newH - oldH;
-    if (!isSetEnergyStream()) {
+    if (!isSetEnergyStream() || getEnergyPort("heatDuty").getEnergyStream() instanceof EnergyBus) {
       getEnergyPort("heatDuty").setDuty(energyInput);
     }
     // system.setTemperature(temperatureOut);

--- a/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
@@ -17,6 +17,10 @@ import neqsim.process.design.AutoSizeable;
 import neqsim.process.electricaldesign.heatexchanger.HeatExchangerElectricalDesign;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.TwoPortEquipment;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.instrumentdesign.heatexchanger.HeatExchangerInstrumentDesign;
@@ -92,6 +96,7 @@ public class Heater extends TwoPortEquipment
    */
   public Heater(String name) {
     super(name);
+    registerEnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.BIDIRECTIONAL, EnergyPortMode.CALCULATED);
   }
 
   /**
@@ -101,10 +106,39 @@ public class Heater extends TwoPortEquipment
    * @param inStream a {@link neqsim.process.equipment.stream.StreamInterface} object
    */
   public Heater(String name, StreamInterface inStream) {
-    super(name);
+    this(name);
     this.inStream = inStream;
     system = inStream.getThermoSystem().clone();
     outStream = new Stream("outStream", system);
+  }
+
+  /**
+   * Connects an external heat-duty specification using the legacy single-stream API.
+   *
+   * @param energyStream heat-duty stream
+   */
+  @Override
+  public void setEnergyStream(EnergyStream energyStream) {
+    super.setEnergyStream(energyStream);
+    getEnergyPort("heatDuty").setMode(EnergyPortMode.SPECIFICATION);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectEnergyStream(String portName, EnergyStream stream) {
+    super.connectEnergyStream(portName, stream);
+    if ("heatDuty".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void disconnectEnergyStream(String portName) {
+    super.disconnectEnergyStream(portName);
+    if ("heatDuty".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.CALCULATED);
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
@@ -119,16 +119,16 @@ public class Heater extends TwoPortEquipment
    */
   @Override
   public void setEnergyStream(EnergyStream energyStream) {
-    super.setEnergyStream(energyStream);
-    getEnergyPort("heatDuty").setMode(EnergyPortMode.SPECIFICATION);
+    super.connectEnergyStream("heatDuty", energyStream, EnergyPortMode.SPECIFICATION);
   }
 
   /** {@inheritDoc} */
   @Override
   public void connectEnergyStream(String portName, EnergyStream stream) {
-    super.connectEnergyStream(portName, stream);
     if ("heatDuty".equals(portName)) {
-      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+      super.connectEnergyStream(portName, stream, EnergyPortMode.SPECIFICATION);
+    } else {
+      super.connectEnergyStream(portName, stream);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/powergeneration/CombinedCycleSystem.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/CombinedCycleSystem.java
@@ -96,8 +96,7 @@ public class CombinedCycleSystem extends TwoPortEquipment implements CapacityCon
    */
   public CombinedCycleSystem(String name) {
     super(name);
-    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
-        EnergyPortMode.CALCULATED);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/powergeneration/CombinedCycleSystem.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/CombinedCycleSystem.java
@@ -12,6 +12,9 @@ import neqsim.process.design.AutoSizeable;
 import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.capacity.CapacityConstrainedEquipment;
 import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.StreamInterface;
 
 /**
@@ -93,6 +96,8 @@ public class CombinedCycleSystem extends TwoPortEquipment implements CapacityCon
    */
   public CombinedCycleSystem(String name) {
     super(name);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
   }
 
   /**
@@ -102,7 +107,8 @@ public class CombinedCycleSystem extends TwoPortEquipment implements CapacityCon
    * @param fuelGasInlet fuel gas stream to the gas turbine
    */
   public CombinedCycleSystem(String name, StreamInterface fuelGasInlet) {
-    super(name, fuelGasInlet);
+    this(name);
+    setInletStream(fuelGasInlet);
   }
 
   /** {@inheritDoc} */
@@ -130,6 +136,7 @@ public class CombinedCycleSystem extends TwoPortEquipment implements CapacityCon
       logger.warn("Gas turbine exhaust not available, estimating HRSG from heat balance");
       totalPower = gasTurbinePower;
       overallEfficiency = fuelEnergyInput > 0 ? totalPower / fuelEnergyInput : 0.0;
+      getEnergyPort("electricalPower").setDuty(totalPower);
       setCalculationIdentifier(id);
       return;
     }
@@ -156,6 +163,7 @@ public class CombinedCycleSystem extends TwoPortEquipment implements CapacityCon
     // Set outlet stream (gas exhausting from HRSG stack)
     outStream.setThermoSystem(hrsg.getOutletStream().getThermoSystem().clone());
     outStream.setCalculationIdentifier(id);
+    getEnergyPort("electricalPower").setDuty(totalPower);
     setCalculationIdentifier(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/powergeneration/FuelCell.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/FuelCell.java
@@ -40,8 +40,7 @@ public class FuelCell extends TwoPortEquipment {
    */
   public FuelCell(String name) {
     super(name);
-    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
-        EnergyPortMode.CALCULATED);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/powergeneration/FuelCell.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/FuelCell.java
@@ -4,6 +4,9 @@ import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.TwoPortEquipment;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 
@@ -37,6 +40,8 @@ public class FuelCell extends TwoPortEquipment {
    */
   public FuelCell(String name) {
     super(name);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
   }
 
   /**
@@ -47,7 +52,8 @@ public class FuelCell extends TwoPortEquipment {
    * @param oxidantStream inlet oxidant stream
    */
   public FuelCell(String name, StreamInterface fuelStream, StreamInterface oxidantStream) {
-    super(name, fuelStream);
+    this(name);
+    setInletStream(fuelStream);
     this.oxidantStream = oxidantStream;
   }
 

--- a/src/main/java/neqsim/process/equipment/powergeneration/FuelCell.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/FuelCell.java
@@ -162,7 +162,7 @@ public class FuelCell extends TwoPortEquipment {
     power = efficiency * fuelEnergy;
     heatLoss = fuelEnergy - power;
 
-    getEnergyStream().setDuty(-power);
+    getEnergyPort("electricalPower").setDuty(-power);
     setCalculationIdentifier(id);
   }
 }

--- a/src/main/java/neqsim/process/equipment/powergeneration/GasTurbine.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/GasTurbine.java
@@ -19,6 +19,7 @@ import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.stream.EnergyPort;
 import neqsim.process.equipment.stream.EnergyPortDirection;
 import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
 import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
@@ -131,6 +132,36 @@ public class GasTurbine extends TwoPortEquipment implements CapacityConstrainedE
   public GasTurbine(String name, StreamInterface inletStream) {
     this(name);
     setInletStream(inletStream);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setEnergyStream(EnergyStream energyStream) {
+    super.setEnergyStream(energyStream);
+    super.connectEnergyStream("shaftPower", energyStream);
+    getEnergyPort("shaftPower").setMode(EnergyPortMode.SPECIFICATION);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectEnergyStream(String portName, EnergyStream stream) {
+    super.connectEnergyStream(portName, stream);
+    if ("shaftPower".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void disconnectEnergyStream(String portName) {
+    super.disconnectEnergyStream(portName);
+    if ("shaftPower".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.CALCULATED);
+      if (drivenLoads.isEmpty() && auxiliaryPowerW <= 0.0) {
+        requiredPower = 0.0;
+        powerDemandMode = false;
+      }
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/powergeneration/GasTurbine.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/GasTurbine.java
@@ -16,6 +16,10 @@ import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.expander.Expander;
 import neqsim.process.equipment.heatexchanger.Cooler;
 import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.mechanicaldesign.compressor.CompressorMechanicalDesign;
@@ -106,6 +110,8 @@ public class GasTurbine extends TwoPortEquipment implements CapacityConstrainedE
    */
   public GasTurbine(String name) {
     super(name);
+    registerEnergyPort("shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
+    registerEnergyPort("exhaustHeat", EnergyType.HEAT, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
     // needs to be changed to gas tubing mechanical design
     SystemInterface airThermoSystem = new neqsim.thermo.Fluid().create("combustion air");
     airThermoSystem.createDatabase(true);
@@ -180,6 +186,11 @@ public class GasTurbine extends TwoPortEquipment implements CapacityConstrainedE
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
+    EnergyPort shaftPowerPort = getEnergyPort("shaftPower");
+    if (shaftPowerPort.isConnected() && shaftPowerPort.getMode() == EnergyPortMode.SPECIFICATION) {
+      requiredPower = shaftPowerPort.getPowerMagnitude();
+      powerDemandMode = true;
+    }
     if (powerDemandMode || !drivenLoads.isEmpty() || auxiliaryPowerW > 0.0) {
       runPowerDemand(id);
       return;
@@ -246,6 +257,7 @@ public class GasTurbine extends TwoPortEquipment implements CapacityConstrainedE
       power = thermalEfficiency * fuelHeat;
       this.heat = fuelHeat - power;
     }
+    publishEnergyPorts();
     setCalculationIdentifier(id);
   }
 
@@ -285,7 +297,20 @@ public class GasTurbine extends TwoPortEquipment implements CapacityConstrainedE
     heat = fuelHeat - requiredPower;
     outStream.setThermoSystem(thermoSystem.clone());
     outStream.setCalculationIdentifier(id);
+    publishEnergyPorts();
     setCalculationIdentifier(id);
+  }
+
+  /** Publishes calculated shaft power and recoverable exhaust heat to connected energy ports. */
+  private void publishEnergyPorts() {
+    EnergyPort shaftPowerPort = getEnergyPort("shaftPower");
+    if (shaftPowerPort.isConnected() && shaftPowerPort.getMode() != EnergyPortMode.SPECIFICATION) {
+      shaftPowerPort.setDuty(power);
+    }
+    EnergyPort exhaustHeatPort = getEnergyPort("exhaustHeat");
+    if (exhaustHeatPort.isConnected()) {
+      exhaustHeatPort.setDuty(heat);
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/powergeneration/GasTurbine.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/GasTurbine.java
@@ -137,17 +137,16 @@ public class GasTurbine extends TwoPortEquipment implements CapacityConstrainedE
   /** {@inheritDoc} */
   @Override
   public void setEnergyStream(EnergyStream energyStream) {
-    super.setEnergyStream(energyStream);
-    super.connectEnergyStream("shaftPower", energyStream);
-    getEnergyPort("shaftPower").setMode(EnergyPortMode.SPECIFICATION);
+    super.connectEnergyStream("shaftPower", energyStream, EnergyPortMode.SPECIFICATION);
   }
 
   /** {@inheritDoc} */
   @Override
   public void connectEnergyStream(String portName, EnergyStream stream) {
-    super.connectEnergyStream(portName, stream);
     if ("shaftPower".equals(portName)) {
-      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+      super.connectEnergyStream(portName, stream, EnergyPortMode.SPECIFICATION);
+    } else {
+      super.connectEnergyStream(portName, stream);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/powergeneration/SolarPanel.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/SolarPanel.java
@@ -95,7 +95,7 @@ public class SolarPanel extends ProcessEquipmentBaseClass {
   @Override
   public void run(UUID id) {
     power = irradiance * panelArea * efficiency;
-    getEnergyStream().setDuty(-power);
+    getEnergyPort("electricalPower").setDuty(-power);
     setEnergyStream(true);
     setCalculationIdentifier(id);
   }

--- a/src/main/java/neqsim/process/equipment/powergeneration/SolarPanel.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/SolarPanel.java
@@ -36,8 +36,7 @@ public class SolarPanel extends ProcessEquipmentBaseClass {
    */
   public SolarPanel(String name) {
     super(name);
-    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
-        EnergyPortMode.CALCULATED);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/powergeneration/SolarPanel.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/SolarPanel.java
@@ -3,6 +3,9 @@ package neqsim.process.equipment.powergeneration;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 
 /**
@@ -33,6 +36,8 @@ public class SolarPanel extends ProcessEquipmentBaseClass {
    */
   public SolarPanel(String name) {
     super(name);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/powergeneration/SteamTurbine.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/SteamTurbine.java
@@ -126,7 +126,7 @@ public class SteamTurbine extends TwoPortEquipment implements CapacityConstraine
     }
 
     this.power = actualWork; // Watts (positive = power produced)
-    getEnergyStream().setDuty(-power);
+    getEnergyPort("shaftPower").setDuty(-power);
 
     outStream.setThermoSystem(outletFluid);
     outStream.setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/powergeneration/SteamTurbine.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/SteamTurbine.java
@@ -10,6 +10,9 @@ import neqsim.process.design.AutoSizeable;
 import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.capacity.CapacityConstrainedEquipment;
 import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 
@@ -65,6 +68,7 @@ public class SteamTurbine extends TwoPortEquipment implements CapacityConstraine
    */
   public SteamTurbine(String name) {
     super(name);
+    registerEnergyPort("shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
   }
 
   /**
@@ -74,7 +78,8 @@ public class SteamTurbine extends TwoPortEquipment implements CapacityConstraine
    * @param inletStream inlet steam stream
    */
   public SteamTurbine(String name, StreamInterface inletStream) {
-    super(name, inletStream);
+    this(name);
+    setInletStream(inletStream);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/powergeneration/WindFarm.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/WindFarm.java
@@ -267,7 +267,7 @@ public class WindFarm extends ProcessEquipmentBaseClass {
     capacityFactor = totalRated > 0 ? power / totalRated : 0.0;
 
     // Set energy stream (negative = produced/available)
-    getEnergyStream().setDuty(-power);
+    getEnergyPort("electricalPower").setDuty(-power);
     setCalculationIdentifier(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/powergeneration/WindFarm.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/WindFarm.java
@@ -1,6 +1,9 @@
 package neqsim.process.equipment.powergeneration;
 
 import java.util.UUID;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 
 /**
@@ -116,6 +119,8 @@ public class WindFarm extends ProcessEquipmentBaseClass {
    */
   public WindFarm(String name) {
     super(name);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
   }
 
   /**
@@ -125,7 +130,7 @@ public class WindFarm extends ProcessEquipmentBaseClass {
    * @param numberOfTurbines number of wind turbines
    */
   public WindFarm(String name, int numberOfTurbines) {
-    super(name);
+    this(name);
     this.numberOfTurbines = numberOfTurbines;
   }
 

--- a/src/main/java/neqsim/process/equipment/powergeneration/WindFarm.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/WindFarm.java
@@ -119,8 +119,7 @@ public class WindFarm extends ProcessEquipmentBaseClass {
    */
   public WindFarm(String name) {
     super(name);
-    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
-        EnergyPortMode.CALCULATED);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/powergeneration/WindTurbine.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/WindTurbine.java
@@ -129,7 +129,7 @@ public class WindTurbine extends ProcessEquipmentBaseClass {
   @Override
   public void run(UUID id) {
     power = 0.5 * airDensity * rotorArea * Math.pow(windSpeed, 3.0) * powerCoefficient;
-    getEnergyStream().setDuty(-power);
+    getEnergyPort("electricalPower").setDuty(-power);
     setCalculationIdentifier(id);
   }
 }

--- a/src/main/java/neqsim/process/equipment/powergeneration/WindTurbine.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/WindTurbine.java
@@ -1,6 +1,9 @@
 package neqsim.process.equipment.powergeneration;
 
 import java.util.UUID;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 
 /**
@@ -37,6 +40,8 @@ public class WindTurbine extends ProcessEquipmentBaseClass {
    */
   public WindTurbine(String name) {
     super(name);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/powergeneration/WindTurbine.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/WindTurbine.java
@@ -40,8 +40,7 @@ public class WindTurbine extends ProcessEquipmentBaseClass {
    */
   public WindTurbine(String name) {
     super(name);
-    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
-        EnergyPortMode.CALCULATED);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/powergeneration/gasturbine/GasTurbineUnit.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/gasturbine/GasTurbineUnit.java
@@ -8,6 +8,9 @@ import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.compressor.driver.GasTurbineDriver;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 
@@ -87,6 +90,7 @@ public class GasTurbineUnit extends TwoPortEquipment {
    */
   public GasTurbineUnit(String name) {
     super(name);
+    registerEnergyPort("shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
   }
 
   /**
@@ -97,7 +101,8 @@ public class GasTurbineUnit extends TwoPortEquipment {
    * @param spec catalog spec (use {@link GasTurbineCatalog#get(String)})
    */
   public GasTurbineUnit(String name, StreamInterface fuelStream, GasTurbineSpec spec) {
-    super(name, fuelStream);
+    this(name);
+    setInletStream(fuelStream);
     setSpec(spec);
   }
 
@@ -237,6 +242,7 @@ public class GasTurbineUnit extends TwoPortEquipment {
   public void run(UUID id) {
     if (spec == null) {
       logger.warn("GasTurbineUnit {} has no spec — cannot run", getName());
+      getEnergyPort("shaftPower").setDuty(0.0);
       return;
     }
     if (performanceMap == null) {
@@ -292,6 +298,7 @@ public class GasTurbineUnit extends TwoPortEquipment {
       this.co2KgPerS = 0.0;
       this.noxKgPerS = 0.0;
       this.methaneSlipKgPerS = 0.0;
+      getEnergyPort("shaftPower").setDuty(0.0);
       copyInletToOutlet();
       return;
     }
@@ -329,6 +336,7 @@ public class GasTurbineUnit extends TwoPortEquipment {
     this.noxKgPerS = emissions.computeNOxKgPerS(spec.getNoxPpmDLE(), this.exhaustMassFlowKgPerS, 28.7);
     this.methaneSlipKgPerS = emissions.computeMethaneSlipKgPerS(fuel, this.fuelMolarFlowMolPerS);
 
+    getEnergyPort("shaftPower").setDuty(Math.min(this.demandedPowerW, this.availablePowerW));
     copyInletToOutlet();
   }
 

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -207,16 +207,16 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
    */
   @Override
   public void setEnergyStream(EnergyStream energyStream) {
-    super.setEnergyStream(energyStream);
-    getEnergyPort("shaftPower").setMode(EnergyPortMode.SPECIFICATION);
+    super.connectEnergyStream("shaftPower", energyStream, EnergyPortMode.SPECIFICATION);
   }
 
   /** {@inheritDoc} */
   @Override
   public void connectEnergyStream(String portName, EnergyStream stream) {
-    super.connectEnergyStream(portName, stream);
     if ("shaftPower".equals(portName)) {
-      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+      super.connectEnergyStream(portName, stream, EnergyPortMode.SPECIFICATION);
+    } else {
+      super.connectEnergyStream(portName, stream);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -678,7 +678,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
    * @throws IllegalArgumentException if power, efficiency, density, or flow is not positive
    */
   private void runWithSpecifiedShaftPower(double inletEnthalpy, UUID id) {
-    double shaftPower = getEnergyStream().getDuty();
+    double shaftPower = getEnergyPort("shaftPower").getPowerMagnitude();
     double efficiency = isentropicEfficiency > 1.0 ? isentropicEfficiency / 100.0 : isentropicEfficiency;
     if (!Double.isFinite(shaftPower) || shaftPower <= 0.0) {
       throw new IllegalArgumentException(

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -519,7 +519,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
       thermoSystem.init(3);
       dH = 0.0;
       if (!isSetEnergyStream()) {
-        getEnergyStream().setDuty(0.0);
+        getEnergyPort("shaftPower").setDuty(0.0);
       }
       outStream.setThermoSystem(thermoSystem);
       finishRun(id);
@@ -663,7 +663,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
     // System.out.println("entropy inn.." + entropy);
     // thermoOps.PSflash(entropy);
     dH = thermoSystem.getEnthalpy() - hinn;
-    getEnergyStream().setDuty(dH);
+    getEnergyPort("shaftPower").setDuty(dH);
     outStream.setThermoSystem(thermoSystem);
     finishRun(id);
 

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -18,6 +18,7 @@ import neqsim.physicalproperties.PhysicalPropertyType;
 import neqsim.process.electricaldesign.pump.PumpElectricalDesign;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.TwoPortEquipment;
+import neqsim.process.equipment.stream.EnergyBus;
 import neqsim.process.equipment.stream.EnergyPortDirection;
 import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyStream;
@@ -707,6 +708,9 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
     thermoOps.PHflash(inletEnthalpy + dH, 0);
     thermoSystem.init(3);
     outStream.setThermoSystem(thermoSystem);
+    if (getEnergyPort("shaftPower").getEnergyStream() instanceof EnergyBus) {
+      getEnergyPort("shaftPower").setDuty(dH);
+    }
     finishRun(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -184,11 +184,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
    */
   public Pump(String name) {
     super(name);
-    registerEnergyPort(
-        "shaftPower",
-        EnergyType.SHAFT_WORK,
-        EnergyPortDirection.INPUT,
-        EnergyPortMode.CALCULATED);
+    registerEnergyPort("shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
     initMechanicalDesign();
     initElectricalDesign();
   }
@@ -341,8 +337,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
         || pressure != lastOutletPressure || outTemperature != lastOutTemperature || speed != lastSpeed
         || minimumFlow != lastMinimumFlow || isentropicEfficiency != lastIsentropicEfficiency || dH != lastPower
         || useOutTemperature != lastUseOutTemperature || calculateAsCompressor != lastCalculateAsCompressor
-        || powerSet != lastPowerSet || pumpChart.isUsePumpChart() != lastUsePumpChart
-        || checkNPSH != lastCheckNPSH
+        || powerSet != lastPowerSet || pumpChart.isUsePumpChart() != lastUsePumpChart || checkNPSH != lastCheckNPSH
         || (isSetEnergyStream() && getEnergyStream().getDuty() != dH)) {
       return true;
     }
@@ -684,26 +679,21 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
    */
   private void runWithSpecifiedShaftPower(double inletEnthalpy, UUID id) {
     double shaftPower = getEnergyStream().getDuty();
-    double efficiency =
-        isentropicEfficiency > 1.0 ? isentropicEfficiency / 100.0 : isentropicEfficiency;
+    double efficiency = isentropicEfficiency > 1.0 ? isentropicEfficiency / 100.0 : isentropicEfficiency;
     if (!Double.isFinite(shaftPower) || shaftPower <= 0.0) {
       throw new IllegalArgumentException(
           "Connected shaft power for pump " + getName() + " must be finite and positive");
     }
     if (!Double.isFinite(efficiency) || efficiency <= 0.0 || efficiency > 1.0) {
-      throw new IllegalArgumentException(
-          "Isentropic efficiency for pump " + getName() + " must be in (0, 1]");
+      throw new IllegalArgumentException("Isentropic efficiency for pump " + getName() + " must be in (0, 1]");
     }
 
     inStream.getThermoSystem().initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
     double densityInlet = inStream.getThermoSystem().getDensity("kg/m3");
     double volumetricFlow = inStream.getThermoSystem().getFlowRate("kg/sec") / densityInlet;
-    if (!Double.isFinite(densityInlet)
-        || densityInlet <= 0.0
-        || !Double.isFinite(volumetricFlow)
+    if (!Double.isFinite(densityInlet) || densityInlet <= 0.0 || !Double.isFinite(volumetricFlow)
         || volumetricFlow <= 0.0) {
-      throw new IllegalArgumentException(
-          "Pump " + getName() + " requires positive inlet density and volumetric flow");
+      throw new IllegalArgumentException("Pump " + getName() + " requires positive inlet density and volumetric flow");
     }
 
     double hydraulicPower = shaftPower * efficiency;

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -18,6 +18,10 @@ import neqsim.physicalproperties.PhysicalPropertyType;
 import neqsim.process.electricaldesign.pump.PumpElectricalDesign;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.TwoPortEquipment;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.mechanicaldesign.pump.PumpMechanicalDesign;
 import neqsim.process.util.monitor.PumpResponse;
@@ -180,6 +184,11 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
    */
   public Pump(String name) {
     super(name);
+    registerEnergyPort(
+        "shaftPower",
+        EnergyType.SHAFT_WORK,
+        EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
     initMechanicalDesign();
     initElectricalDesign();
   }
@@ -193,6 +202,35 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
   public Pump(String name, StreamInterface inletStream) {
     this(name);
     setInletStream(inletStream);
+  }
+
+  /**
+   * Connects an external shaft-power specification using the legacy single-stream API.
+   *
+   * @param energyStream shaft-work stream
+   */
+  @Override
+  public void setEnergyStream(EnergyStream energyStream) {
+    super.setEnergyStream(energyStream);
+    getEnergyPort("shaftPower").setMode(EnergyPortMode.SPECIFICATION);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectEnergyStream(String portName, EnergyStream stream) {
+    super.connectEnergyStream(portName, stream);
+    if ("shaftPower".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void disconnectEnergyStream(String portName) {
+    super.disconnectEnergyStream(portName);
+    if ("shaftPower".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.CALCULATED);
+    }
   }
 
   /** {@inheritDoc} */
@@ -303,7 +341,9 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
         || pressure != lastOutletPressure || outTemperature != lastOutTemperature || speed != lastSpeed
         || minimumFlow != lastMinimumFlow || isentropicEfficiency != lastIsentropicEfficiency || dH != lastPower
         || useOutTemperature != lastUseOutTemperature || calculateAsCompressor != lastCalculateAsCompressor
-        || powerSet != lastPowerSet || pumpChart.isUsePumpChart() != lastUsePumpChart || checkNPSH != lastCheckNPSH) {
+        || powerSet != lastPowerSet || pumpChart.isUsePumpChart() != lastUsePumpChart
+        || checkNPSH != lastCheckNPSH
+        || (isSetEnergyStream() && getEnergyStream().getDuty() != dH)) {
       return true;
     }
     double flow = inletSystem.getFlowRate("kg/hr");
@@ -483,6 +523,9 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
       thermoSystem.setPressure(pressure, pressureUnit);
       thermoSystem.init(3);
       dH = 0.0;
+      if (!isSetEnergyStream()) {
+        getEnergyStream().setDuty(0.0);
+      }
       outStream.setThermoSystem(thermoSystem);
       finishRun(id);
       return;
@@ -496,6 +539,11 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
     inStream.getThermoSystem().init(3);
     double hinn = inStream.getThermoSystem().getEnthalpy();
     double entropy = inStream.getThermoSystem().getEntropy();
+
+    if (isSetEnergyStream()) {
+      runWithSpecifiedShaftPower(hinn, id);
+      return;
+    }
 
     if (useOutTemperature) {
       thermoSystem = inStream.getThermoSystem().clone();
@@ -620,10 +668,56 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
     // System.out.println("entropy inn.." + entropy);
     // thermoOps.PSflash(entropy);
     dH = thermoSystem.getEnthalpy() - hinn;
+    getEnergyStream().setDuty(dH);
     outStream.setThermoSystem(thermoSystem);
     finishRun(id);
 
     // outStream.run(id);
+  }
+
+  /**
+   * Calculates outlet pressure and state from a connected shaft-power specification.
+   *
+   * @param inletEnthalpy total inlet enthalpy in J
+   * @param id calculation identifier
+   * @throws IllegalArgumentException if power, efficiency, density, or flow is not positive
+   */
+  private void runWithSpecifiedShaftPower(double inletEnthalpy, UUID id) {
+    double shaftPower = getEnergyStream().getDuty();
+    double efficiency =
+        isentropicEfficiency > 1.0 ? isentropicEfficiency / 100.0 : isentropicEfficiency;
+    if (!Double.isFinite(shaftPower) || shaftPower <= 0.0) {
+      throw new IllegalArgumentException(
+          "Connected shaft power for pump " + getName() + " must be finite and positive");
+    }
+    if (!Double.isFinite(efficiency) || efficiency <= 0.0 || efficiency > 1.0) {
+      throw new IllegalArgumentException(
+          "Isentropic efficiency for pump " + getName() + " must be in (0, 1]");
+    }
+
+    inStream.getThermoSystem().initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
+    double densityInlet = inStream.getThermoSystem().getDensity("kg/m3");
+    double volumetricFlow = inStream.getThermoSystem().getFlowRate("kg/sec") / densityInlet;
+    if (!Double.isFinite(densityInlet)
+        || densityInlet <= 0.0
+        || !Double.isFinite(volumetricFlow)
+        || volumetricFlow <= 0.0) {
+      throw new IllegalArgumentException(
+          "Pump " + getName() + " requires positive inlet density and volumetric flow");
+    }
+
+    double hydraulicPower = shaftPower * efficiency;
+    double deltaPressure = hydraulicPower / volumetricFlow;
+    thermoSystem = inStream.getThermoSystem().clone();
+    thermoSystem.setPressure(inStream.getThermoSystem().getPressure("Pa") + deltaPressure, "Pa");
+    pressure = thermoSystem.getPressure(pressureUnit);
+
+    ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
+    dH = shaftPower;
+    thermoOps.PHflash(inletEnthalpy + dH, 0);
+    thermoSystem.init(3);
+    outStream.setThermoSystem(thermoSystem);
+    finishRun(id);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/reactor/AmmoniaSynthesisReactor.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AmmoniaSynthesisReactor.java
@@ -6,6 +6,9 @@ import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.TwoPortEquipment;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -139,6 +142,7 @@ public class AmmoniaSynthesisReactor extends TwoPortEquipment {
    */
   public AmmoniaSynthesisReactor(String name) {
     super(name);
+    registerEnergyPort("reactionHeat", EnergyType.HEAT, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
   }
 
   /**
@@ -148,7 +152,8 @@ public class AmmoniaSynthesisReactor extends TwoPortEquipment {
    * @param inletStream the synthesis gas feed stream
    */
   public AmmoniaSynthesisReactor(String name, StreamInterface inletStream) {
-    super(name, inletStream);
+    this(name);
+    setInletStream(inletStream);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/reactor/AmmoniaSynthesisReactor.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AmmoniaSynthesisReactor.java
@@ -244,7 +244,7 @@ public class AmmoniaSynthesisReactor extends TwoPortEquipment {
     outStream.setThermoSystem(outSystem);
     outStream.run(id);
 
-    getEnergyStream().setDuty(heatDuty);
+    getEnergyPort("reactionHeat").setDuty(heatDuty);
     setCalculationIdentifier(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/reactor/StirredTankReactor.java
+++ b/src/main/java/neqsim/process/equipment/reactor/StirredTankReactor.java
@@ -6,6 +6,11 @@ import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.TwoPortEquipment;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -75,6 +80,8 @@ public class StirredTankReactor extends TwoPortEquipment {
    */
   public StirredTankReactor(String name) {
     super(name);
+    registerEnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.BIDIRECTIONAL, EnergyPortMode.CALCULATED);
+    registerEnergyPort("agitatorPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
   }
 
   /**
@@ -84,7 +91,34 @@ public class StirredTankReactor extends TwoPortEquipment {
    * @param inletStream inlet feed stream
    */
   public StirredTankReactor(String name, StreamInterface inletStream) {
-    super(name, inletStream);
+    this(name);
+    setInletStream(inletStream);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setEnergyStream(EnergyStream energyStream) {
+    super.setEnergyStream(energyStream);
+    super.connectEnergyStream("heatDuty", energyStream);
+    getEnergyPort("heatDuty").setMode(EnergyPortMode.SPECIFICATION);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectEnergyStream(String portName, EnergyStream stream) {
+    super.connectEnergyStream(portName, stream);
+    if ("heatDuty".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void disconnectEnergyStream(String portName) {
+    super.disconnectEnergyStream(portName);
+    if ("heatDuty".equals(portName)) {
+      getEnergyPort(portName).setMode(EnergyPortMode.CALCULATED);
+    }
   }
 
   /**
@@ -326,9 +360,14 @@ public class StirredTankReactor extends TwoPortEquipment {
     }
 
     // Flash calculation at outlet conditions
+    EnergyPort heatPort = getEnergyPort("heatDuty");
+    boolean heatSpecified = heatPort.isConnected() && heatPort.getMode() == EnergyPortMode.SPECIFICATION;
     ThermodynamicOperations ops = new ThermodynamicOperations(system);
     try {
-      if (isothermal) {
+      if (heatSpecified) {
+        heatDuty = heatPort.getDuty();
+        ops.PHflash(inletEnthalpy + heatDuty, 0);
+      } else if (isothermal) {
         ops.TPflash();
       } else {
         // Adiabatic: use inlet enthalpy
@@ -343,10 +382,17 @@ public class StirredTankReactor extends TwoPortEquipment {
 
     // Calculate heat duty (energy balance)
     double outletEnthalpy = system.getEnthalpy();
-    if (isothermal) {
-      heatDuty = outletEnthalpy - inletEnthalpy;
-    } else {
-      heatDuty = 0.0;
+    if (!heatSpecified) {
+      if (isothermal) {
+        heatDuty = outletEnthalpy - inletEnthalpy;
+      } else {
+        heatDuty = 0.0;
+      }
+      heatPort.setDuty(heatDuty);
+    }
+    EnergyPort agitatorPort = getEnergyPort("agitatorPower");
+    if (agitatorPort.isConnected()) {
+      agitatorPort.setDuty(getAgitatorPower() * 1.0e3);
     }
 
     outStream.setThermoSystem(system);

--- a/src/main/java/neqsim/process/equipment/reactor/StirredTankReactor.java
+++ b/src/main/java/neqsim/process/equipment/reactor/StirredTankReactor.java
@@ -98,17 +98,16 @@ public class StirredTankReactor extends TwoPortEquipment {
   /** {@inheritDoc} */
   @Override
   public void setEnergyStream(EnergyStream energyStream) {
-    super.setEnergyStream(energyStream);
-    super.connectEnergyStream("heatDuty", energyStream);
-    getEnergyPort("heatDuty").setMode(EnergyPortMode.SPECIFICATION);
+    super.connectEnergyStream("heatDuty", energyStream, EnergyPortMode.SPECIFICATION);
   }
 
   /** {@inheritDoc} */
   @Override
   public void connectEnergyStream(String portName, EnergyStream stream) {
-    super.connectEnergyStream(portName, stream);
     if ("heatDuty".equals(portName)) {
-      getEnergyPort(portName).setMode(EnergyPortMode.SPECIFICATION);
+      super.connectEnergyStream(portName, stream, EnergyPortMode.SPECIFICATION);
+    } else {
+      super.connectEnergyStream(portName, stream);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/solidhandling/BioFeedstockPreparation.java
+++ b/src/main/java/neqsim/process/equipment/solidhandling/BioFeedstockPreparation.java
@@ -175,7 +175,7 @@ public class BioFeedstockPreparation extends ProcessEquipmentBaseClass {
     preparedBulkVolumeM3PerHr = preparedFeedRateKgPerHr / preparedDensity;
     massClosureFraction = (preparedFeedRateKgPerHr + waterRemovedKgPerHr + drySolidsLostKgPerHr) / wetFeedRateKgPerHr;
 
-    getEnergyStream().setDuty(powerKW * 1000.0);
+    getEnergyPort("electricalPower").setDuty(powerKW * 1000.0);
     setCalculationIdentifier(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/solidhandling/BioFeedstockPreparation.java
+++ b/src/main/java/neqsim/process/equipment/solidhandling/BioFeedstockPreparation.java
@@ -3,6 +3,9 @@ package neqsim.process.equipment.solidhandling;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.thermo.characterization.BioFeedstock;
 
@@ -63,6 +66,8 @@ public class BioFeedstockPreparation extends ProcessEquipmentBaseClass {
    */
   public BioFeedstockPreparation(String name) {
     super(name);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/solidhandling/BioFeedstockPreparation.java
+++ b/src/main/java/neqsim/process/equipment/solidhandling/BioFeedstockPreparation.java
@@ -66,8 +66,7 @@ public class BioFeedstockPreparation extends ProcessEquipmentBaseClass {
    */
   public BioFeedstockPreparation(String name) {
     super(name);
-    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
-        EnergyPortMode.CALCULATED);
+    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -149,6 +149,38 @@ public class EnergyBus extends EnergyStream {
   }
 
   /**
+   * Gets the net bus power while excluding one participant's previous contribution.
+   *
+   * <p>
+   * Specification consumers use this value when a process is run repeatedly. Excluding the consumer's own previous
+   * withdrawal prevents self-feedback from reducing its available power on every run.
+   * </p>
+   *
+   * @param participant participant or port contribution key to exclude
+   * @return net power excluding that contribution in W
+   */
+  public double getNetPowerExcluding(String participant) {
+    double netPower = super.getDuty();
+    for (Map.Entry<String, Double> entry : contributions.entrySet()) {
+      if (!entry.getKey().equals(participant)) {
+        netPower += entry.getValue().doubleValue();
+      }
+    }
+    return netPower;
+  }
+
+  /**
+   * Gets net bus power excluding one participant in a requested unit.
+   *
+   * @param participant participant or port contribution key to exclude
+   * @param unit requested power unit
+   * @return net power excluding that contribution in the requested unit
+   */
+  public double getNetPowerExcluding(String participant, String unit) {
+    return new PowerUnit(getNetPowerExcluding(participant), "W").getValue(unit);
+  }
+
+  /**
    * Gets net bus power in a requested unit.
    *
    * @param unit requested power unit

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -1,0 +1,160 @@
+package neqsim.process.equipment.stream;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import neqsim.util.unit.PowerUnit;
+
+/**
+ * Multi-party energy connection that aggregates named power contributions.
+ *
+ * <p>
+ * Unlike the point-to-point {@link EnergyStream}, an energy bus can connect several calculated and
+ * specification ports. Positive and negative contribution signs represent injection and withdrawal
+ * from the bus. The inherited duty is retained as an optional external or balancing contribution.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class EnergyBus extends EnergyStream {
+  private static final long serialVersionUID = 1000L;
+
+  private Map<String, Double> contributions = new LinkedHashMap<String, Double>();
+
+  /** Creates an unnamed bus with an unspecified energy domain. */
+  public EnergyBus() {
+    super();
+  }
+
+  /**
+   * Creates a named bus with an unspecified energy domain.
+   *
+   * @param name bus name
+   */
+  public EnergyBus(String name) {
+    super(name);
+  }
+
+  /**
+   * Creates a named, typed energy bus.
+   *
+   * @param name bus name
+   * @param energyType physical energy domain
+   */
+  public EnergyBus(String name, EnergyType energyType) {
+    super(name, energyType);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public EnergyBus clone() {
+    EnergyBus clonedBus = (EnergyBus) super.clone();
+    clonedBus.contributions = new LinkedHashMap<String, Double>(contributions);
+    return clonedBus;
+  }
+
+  /**
+   * Sets a named power contribution in watts.
+   *
+   * @param participant unique participant or port name
+   * @param power signed power contribution in W
+   */
+  public void setContribution(String participant, double power) {
+    if (participant == null || participant.trim().isEmpty()) {
+      throw new IllegalArgumentException("Energy bus participant cannot be null or empty");
+    }
+    if (!Double.isFinite(power)) {
+      throw new IllegalArgumentException("Energy bus contribution must be finite");
+    }
+    contributions.put(participant, power);
+  }
+
+  /**
+   * Sets a named power contribution in a specified unit.
+   *
+   * @param participant unique participant or port name
+   * @param power signed power contribution
+   * @param unit power unit
+   */
+  public void setContribution(String participant, double power, String unit) {
+    setContribution(participant, new PowerUnit(power, unit).getValue("W"));
+  }
+
+  /**
+   * Gets a participant contribution in watts.
+   *
+   * @param participant participant or port name
+   * @return signed contribution in W, or zero when absent
+   */
+  public double getContribution(String participant) {
+    Double contribution = contributions.get(participant);
+    return contribution == null ? 0.0 : contribution.doubleValue();
+  }
+
+  /**
+   * Gets a participant contribution in a requested unit.
+   *
+   * @param participant participant or port name
+   * @param unit requested power unit
+   * @return signed contribution in the requested unit
+   */
+  public double getContribution(String participant, String unit) {
+    return new PowerUnit(getContribution(participant), "W").getValue(unit);
+  }
+
+  /**
+   * Removes a participant contribution.
+   *
+   * @param participant participant or port name
+   */
+  public void removeContribution(String participant) {
+    contributions.remove(participant);
+  }
+
+  /** Removes all named contributions while preserving the inherited balancing duty. */
+  public void clearContributions() {
+    contributions.clear();
+  }
+
+  /**
+   * Gets an immutable view of named contributions in watts.
+   *
+   * @return contributions keyed by participant
+   */
+  public Map<String, Double> getContributions() {
+    return Collections.unmodifiableMap(contributions);
+  }
+
+  /**
+   * Gets the net bus duty in watts.
+   *
+   * @return inherited balancing duty plus all named contributions in W
+   */
+  @Override
+  public double getDuty() {
+    double netDuty = super.getDuty();
+    for (Double contribution : contributions.values()) {
+      netDuty += contribution.doubleValue();
+    }
+    return netDuty;
+  }
+
+  /**
+   * Alias for {@link #getDuty()} emphasizing the bus balance.
+   *
+   * @return net bus power in W
+   */
+  public double getNetPower() {
+    return getDuty();
+  }
+
+  /**
+   * Gets net bus power in a requested unit.
+   *
+   * @param unit requested power unit
+   * @return net bus power in the requested unit
+   */
+  public double getNetPower(String unit) {
+    return getDuty(unit);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -9,9 +9,9 @@ import neqsim.util.unit.PowerUnit;
  * Multi-party energy connection that aggregates named power contributions.
  *
  * <p>
- * Unlike the point-to-point {@link EnergyStream}, an energy bus can connect several calculated and
- * specification ports. Positive and negative contribution signs represent injection and withdrawal
- * from the bus. The inherited duty is retained as an optional external or balancing contribution.
+ * Unlike the point-to-point {@link EnergyStream}, an energy bus can connect several calculated and specification ports.
+ * Positive and negative contribution signs represent injection and withdrawal from the bus. The inherited duty is
+ * retained as an optional external or balancing contribution.
  *
  * @author NeqSim
  * @version 1.0

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -21,6 +21,7 @@ public class EnergyPort implements Serializable {
   private final EnergyType energyType;
   private final EnergyPortDirection direction;
   private EnergyPortMode mode;
+  private String ownerName = "";
   private EnergyStream energyStream;
 
   /**
@@ -48,6 +49,24 @@ public class EnergyPort implements Serializable {
    */
   public String getName() {
     return name;
+  }
+
+  /**
+   * Gets the owning equipment name used for energy-bus contribution keys.
+   *
+   * @return owner name, or an empty string when the port is standalone
+   */
+  public String getOwnerName() {
+    return ownerName;
+  }
+
+  /**
+   * Sets the owning equipment name used for energy-bus contribution keys.
+   *
+   * @param ownerName equipment name
+   */
+  public void setOwnerName(String ownerName) {
+    this.ownerName = Objects.requireNonNull(ownerName, "ownerName cannot be null");
   }
 
   /**
@@ -98,6 +117,9 @@ public class EnergyPort implements Serializable {
    */
   public void connect(EnergyStream stream) {
     Objects.requireNonNull(stream, "stream cannot be null");
+    if (energyStream instanceof EnergyBus && energyStream != stream) {
+      ((EnergyBus) energyStream).removeContribution(getContributionKey());
+    }
     EnergyType streamType = stream.getEnergyType();
     if (streamType != EnergyType.UNSPECIFIED && energyType != EnergyType.UNSPECIFIED && streamType != energyType) {
       throw new IllegalArgumentException(
@@ -111,6 +133,9 @@ public class EnergyPort implements Serializable {
 
   /** Disconnects the current energy stream, if any. */
   public void disconnect() {
+    if (energyStream instanceof EnergyBus) {
+      ((EnergyBus) energyStream).removeContribution(getContributionKey());
+    }
     energyStream = null;
   }
 
@@ -139,7 +164,11 @@ public class EnergyPort implements Serializable {
    * @throws IllegalStateException if no stream is connected
    */
   public double getDuty() {
-    return requireConnectedStream().getDuty();
+    EnergyStream stream = requireConnectedStream();
+    if (stream instanceof EnergyBus && mode == EnergyPortMode.CALCULATED) {
+      return ((EnergyBus) stream).getContribution(getContributionKey());
+    }
+    return stream.getDuty();
   }
 
   /**
@@ -175,7 +204,7 @@ public class EnergyPort implements Serializable {
    * @throws IllegalStateException if no stream is connected
    */
   public double getDuty(String unit) {
-    return requireConnectedStream().getDuty(unit);
+    return new neqsim.util.unit.PowerUnit(getDuty(), "W").getValue(unit);
   }
 
   /**
@@ -185,7 +214,12 @@ public class EnergyPort implements Serializable {
    * @throws IllegalStateException if no stream is connected
    */
   public void setDuty(double duty) {
-    requireConnectedStream().setDuty(duty);
+    EnergyStream stream = requireConnectedStream();
+    if (stream instanceof EnergyBus) {
+      ((EnergyBus) stream).setContribution(getContributionKey(), duty);
+    } else {
+      stream.setDuty(duty);
+    }
   }
 
   /**
@@ -196,7 +230,11 @@ public class EnergyPort implements Serializable {
    * @throws IllegalStateException if no stream is connected
    */
   public void setDuty(double duty, String unit) {
-    requireConnectedStream().setDuty(duty, unit);
+    setDuty(new neqsim.util.unit.PowerUnit(duty, unit).getValue("W"));
+  }
+
+  private String getContributionKey() {
+    return ownerName.isEmpty() ? name : ownerName + "." + name;
   }
 
   private EnergyStream requireConnectedStream() {

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -206,7 +206,7 @@ public class EnergyPort implements Serializable {
    * @throws IllegalStateException if no stream is connected
    */
   public double getPowerMagnitude(String unit) {
-    return Math.abs(getDuty(unit));
+    return new neqsim.util.unit.PowerUnit(getPowerMagnitude(), "W").getValue(unit);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -1,0 +1,184 @@
+package neqsim.process.equipment.stream;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Named, typed connection point between process equipment and an {@link EnergyStream}.
+ *
+ * <p>An energy port separates three concerns that were previously implicit in the sign of a duty:
+ * the physical energy domain, the physical transfer direction, and the calculation role. This lets
+ * graph-based schedulers order an energy producer before a consumer without changing the legacy
+ * {@code EnergyStream} duty convention.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class EnergyPort implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String name;
+  private final EnergyType energyType;
+  private final EnergyPortDirection direction;
+  private EnergyPortMode mode;
+  private EnergyStream energyStream;
+
+  /**
+   * Creates an unconnected energy port.
+   *
+   * @param name unique port name within its equipment
+   * @param energyType physical energy domain
+   * @param direction physical energy direction relative to the equipment
+   * @param mode calculation role of the port
+   */
+  public EnergyPort(String name, EnergyType energyType, EnergyPortDirection direction,
+      EnergyPortMode mode) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("Energy port name cannot be null or empty");
+    }
+    this.name = name;
+    this.energyType = Objects.requireNonNull(energyType, "energyType cannot be null");
+    this.direction = Objects.requireNonNull(direction, "direction cannot be null");
+    this.mode = Objects.requireNonNull(mode, "mode cannot be null");
+  }
+
+  /**
+   * Gets the port name.
+   *
+   * @return port name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the physical energy domain accepted by this port.
+   *
+   * @return energy type
+   */
+  public EnergyType getEnergyType() {
+    return energyType;
+  }
+
+  /**
+   * Gets the physical energy direction relative to the equipment.
+   *
+   * @return port direction
+   */
+  public EnergyPortDirection getDirection() {
+    return direction;
+  }
+
+  /**
+   * Gets the calculation role of the port.
+   *
+   * @return calculation mode
+   */
+  public EnergyPortMode getMode() {
+    return mode;
+  }
+
+  /**
+   * Sets the calculation role of the port.
+   *
+   * @param mode calculation mode
+   */
+  public void setMode(EnergyPortMode mode) {
+    this.mode = Objects.requireNonNull(mode, "mode cannot be null");
+  }
+
+  /**
+   * Connects an energy stream to this port.
+   *
+   * <p>A legacy stream with type {@link EnergyType#UNSPECIFIED} adopts the port type. A typed stream
+   * can only be connected to a port of the same type or to an unspecified port.
+   *
+   * @param stream energy stream to connect
+   * @throws IllegalArgumentException if the stream and port energy types conflict
+   */
+  public void connect(EnergyStream stream) {
+    Objects.requireNonNull(stream, "stream cannot be null");
+    EnergyType streamType = stream.getEnergyType();
+    if (streamType != EnergyType.UNSPECIFIED && energyType != EnergyType.UNSPECIFIED
+        && streamType != energyType) {
+      throw new IllegalArgumentException("Energy stream type " + streamType
+          + " is incompatible with port type " + energyType + " for port " + name);
+    }
+    if (streamType == EnergyType.UNSPECIFIED && energyType != EnergyType.UNSPECIFIED) {
+      stream.setEnergyType(energyType);
+    }
+    energyStream = stream;
+  }
+
+  /** Disconnects the current energy stream, if any. */
+  public void disconnect() {
+    energyStream = null;
+  }
+
+  /**
+   * Checks whether a stream is connected.
+   *
+   * @return {@code true} when connected
+   */
+  public boolean isConnected() {
+    return energyStream != null;
+  }
+
+  /**
+   * Gets the connected energy stream.
+   *
+   * @return connected stream, or {@code null} when unconnected
+   */
+  public EnergyStream getEnergyStream() {
+    return energyStream;
+  }
+
+  /**
+   * Gets the connected stream duty in watts.
+   *
+   * @return duty in W
+   * @throws IllegalStateException if no stream is connected
+   */
+  public double getDuty() {
+    return requireConnectedStream().getDuty();
+  }
+
+  /**
+   * Gets the connected stream duty in a requested unit.
+   *
+   * @param unit requested power unit
+   * @return duty in the requested unit
+   * @throws IllegalStateException if no stream is connected
+   */
+  public double getDuty(String unit) {
+    return requireConnectedStream().getDuty(unit);
+  }
+
+  /**
+   * Sets the connected stream duty in watts.
+   *
+   * @param duty duty in W
+   * @throws IllegalStateException if no stream is connected
+   */
+  public void setDuty(double duty) {
+    requireConnectedStream().setDuty(duty);
+  }
+
+  /**
+   * Sets the connected stream duty in a specified unit.
+   *
+   * @param duty duty value
+   * @param unit power unit
+   * @throws IllegalStateException if no stream is connected
+   */
+  public void setDuty(double duty, String unit) {
+    requireConnectedStream().setDuty(duty, unit);
+  }
+
+  private EnergyStream requireConnectedStream() {
+    if (energyStream == null) {
+      throw new IllegalStateException("Energy port " + name + " is not connected");
+    }
+    return energyStream;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -165,8 +165,12 @@ public class EnergyPort implements Serializable {
    */
   public double getDuty() {
     EnergyStream stream = requireConnectedStream();
-    if (stream instanceof EnergyBus && mode == EnergyPortMode.CALCULATED) {
-      return ((EnergyBus) stream).getContribution(getContributionKey());
+    if (stream instanceof EnergyBus) {
+      EnergyBus bus = (EnergyBus) stream;
+      if (mode == EnergyPortMode.CALCULATED) {
+        return bus.getContribution(getContributionKey());
+      }
+      return bus.getNetPowerExcluding(getContributionKey());
     }
     return stream.getDuty();
   }
@@ -182,7 +186,16 @@ public class EnergyPort implements Serializable {
    * @throws IllegalStateException if no stream is connected
    */
   public double getPowerMagnitude() {
-    return Math.abs(getDuty());
+    double duty = getDuty();
+    if (energyStream instanceof EnergyBus && mode != EnergyPortMode.CALCULATED) {
+      if (direction == EnergyPortDirection.INPUT) {
+        return Math.max(0.0, duty);
+      }
+      if (direction == EnergyPortDirection.OUTPUT) {
+        return Math.max(0.0, -duty);
+      }
+    }
+    return Math.abs(duty);
   }
 
   /**
@@ -221,6 +234,8 @@ public class EnergyPort implements Serializable {
         contribution = -Math.abs(duty);
       } else if (direction == EnergyPortDirection.OUTPUT) {
         contribution = Math.abs(duty);
+      } else if (mode == EnergyPortMode.SPECIFICATION) {
+        contribution = -duty;
       }
       ((EnergyBus) stream).setContribution(getContributionKey(), contribution);
     } else {

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -175,8 +175,8 @@ public class EnergyPort implements Serializable {
    * Gets the non-negative transferred-power magnitude in watts.
    *
    * <p>
-   * This is the preferred accessor for typed ports because physical direction is represented by
-   * {@link #getDirection()} rather than by a legacy duty sign.
+   * This is the preferred accessor for typed ports because physical direction is represented by {@link #getDirection()}
+   * rather than by a legacy duty sign.
    *
    * @return absolute duty in W
    * @throws IllegalStateException if no stream is connected

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -216,7 +216,13 @@ public class EnergyPort implements Serializable {
   public void setDuty(double duty) {
     EnergyStream stream = requireConnectedStream();
     if (stream instanceof EnergyBus) {
-      ((EnergyBus) stream).setContribution(getContributionKey(), duty);
+      double contribution = duty;
+      if (direction == EnergyPortDirection.INPUT) {
+        contribution = -Math.abs(duty);
+      } else if (direction == EnergyPortDirection.OUTPUT) {
+        contribution = Math.abs(duty);
+      }
+      ((EnergyBus) stream).setContribution(getContributionKey(), contribution);
     } else {
       stream.setDuty(duty);
     }

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -117,9 +117,6 @@ public class EnergyPort implements Serializable {
    */
   public void connect(EnergyStream stream) {
     Objects.requireNonNull(stream, "stream cannot be null");
-    if (energyStream instanceof EnergyBus && energyStream != stream) {
-      ((EnergyBus) energyStream).removeContribution(getContributionKey());
-    }
     EnergyType streamType = stream.getEnergyType();
     if (streamType != EnergyType.UNSPECIFIED && energyType != EnergyType.UNSPECIFIED && streamType != energyType) {
       throw new IllegalArgumentException(
@@ -127,6 +124,9 @@ public class EnergyPort implements Serializable {
     }
     if (streamType == EnergyType.UNSPECIFIED && energyType != EnergyType.UNSPECIFIED) {
       stream.setEnergyType(energyType);
+    }
+    if (energyStream instanceof EnergyBus && energyStream != stream) {
+      ((EnergyBus) energyStream).removeContribution(getContributionKey());
     }
     energyStream = stream;
   }

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -143,6 +143,31 @@ public class EnergyPort implements Serializable {
   }
 
   /**
+   * Gets the non-negative transferred-power magnitude in watts.
+   *
+   * <p>
+   * This is the preferred accessor for typed ports because physical direction is represented by
+   * {@link #getDirection()} rather than by a legacy duty sign.
+   *
+   * @return absolute duty in W
+   * @throws IllegalStateException if no stream is connected
+   */
+  public double getPowerMagnitude() {
+    return Math.abs(getDuty());
+  }
+
+  /**
+   * Gets the non-negative transferred-power magnitude in a requested unit.
+   *
+   * @param unit requested power unit
+   * @return absolute duty in the requested unit
+   * @throws IllegalStateException if no stream is connected
+   */
+  public double getPowerMagnitude(String unit) {
+    return Math.abs(getDuty(unit));
+  }
+
+  /**
    * Gets the connected stream duty in a requested unit.
    *
    * @param unit requested power unit

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -6,10 +6,10 @@ import java.util.Objects;
 /**
  * Named, typed connection point between process equipment and an {@link EnergyStream}.
  *
- * <p>An energy port separates three concerns that were previously implicit in the sign of a duty:
- * the physical energy domain, the physical transfer direction, and the calculation role. This lets
- * graph-based schedulers order an energy producer before a consumer without changing the legacy
- * {@code EnergyStream} duty convention.
+ * <p>
+ * An energy port separates three concerns that were previously implicit in the sign of a duty: the physical energy
+ * domain, the physical transfer direction, and the calculation role. This lets graph-based schedulers order an energy
+ * producer before a consumer without changing the legacy {@code EnergyStream} duty convention.
  *
  * @author NeqSim
  * @version 1.0
@@ -31,8 +31,7 @@ public class EnergyPort implements Serializable {
    * @param direction physical energy direction relative to the equipment
    * @param mode calculation role of the port
    */
-  public EnergyPort(String name, EnergyType energyType, EnergyPortDirection direction,
-      EnergyPortMode mode) {
+  public EnergyPort(String name, EnergyType energyType, EnergyPortDirection direction, EnergyPortMode mode) {
     if (name == null || name.trim().isEmpty()) {
       throw new IllegalArgumentException("Energy port name cannot be null or empty");
     }
@@ -90,8 +89,9 @@ public class EnergyPort implements Serializable {
   /**
    * Connects an energy stream to this port.
    *
-   * <p>A legacy stream with type {@link EnergyType#UNSPECIFIED} adopts the port type. A typed stream
-   * can only be connected to a port of the same type or to an unspecified port.
+   * <p>
+   * A legacy stream with type {@link EnergyType#UNSPECIFIED} adopts the port type. A typed stream can only be connected
+   * to a port of the same type or to an unspecified port.
    *
    * @param stream energy stream to connect
    * @throws IllegalArgumentException if the stream and port energy types conflict
@@ -99,10 +99,9 @@ public class EnergyPort implements Serializable {
   public void connect(EnergyStream stream) {
     Objects.requireNonNull(stream, "stream cannot be null");
     EnergyType streamType = stream.getEnergyType();
-    if (streamType != EnergyType.UNSPECIFIED && energyType != EnergyType.UNSPECIFIED
-        && streamType != energyType) {
-      throw new IllegalArgumentException("Energy stream type " + streamType
-          + " is incompatible with port type " + energyType + " for port " + name);
+    if (streamType != EnergyType.UNSPECIFIED && energyType != EnergyType.UNSPECIFIED && streamType != energyType) {
+      throw new IllegalArgumentException(
+          "Energy stream type " + streamType + " is incompatible with port type " + energyType + " for port " + name);
     }
     if (streamType == EnergyType.UNSPECIFIED && energyType != EnergyType.UNSPECIFIED) {
       stream.setEnergyType(energyType);

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPortDirection.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPortDirection.java
@@ -1,0 +1,16 @@
+package neqsim.process.equipment.stream;
+
+/**
+ * Physical direction of energy transfer relative to a process equipment boundary.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public enum EnergyPortDirection {
+  /** Energy enters the equipment through the port. */
+  INPUT,
+  /** Energy leaves the equipment through the port. */
+  OUTPUT,
+  /** The physical transfer direction may change during a simulation. */
+  BIDIRECTIONAL
+}

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPortMode.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPortMode.java
@@ -1,0 +1,21 @@
+package neqsim.process.equipment.stream;
+
+/**
+ * Calculation role of an {@link EnergyPort} in a process simulation.
+ *
+ * <p>The mode is independent of the physical direction. For example, a pressure-specified pump has
+ * an {@link EnergyPortDirection#INPUT} shaft port but calculates its required power, so that port is
+ * {@link #CALCULATED}. A power-specified pump reads the same physical input port as a
+ * {@link #SPECIFICATION}.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public enum EnergyPortMode {
+  /** The equipment reads the connected stream as an input specification. */
+  SPECIFICATION,
+  /** The equipment calculates and publishes the connected stream duty. */
+  CALCULATED,
+  /** The duty is determined by a wider energy balance or simultaneous solver. */
+  BALANCE
+}

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPortMode.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPortMode.java
@@ -3,10 +3,10 @@ package neqsim.process.equipment.stream;
 /**
  * Calculation role of an {@link EnergyPort} in a process simulation.
  *
- * <p>The mode is independent of the physical direction. For example, a pressure-specified pump has
- * an {@link EnergyPortDirection#INPUT} shaft port but calculates its required power, so that port is
- * {@link #CALCULATED}. A power-specified pump reads the same physical input port as a
- * {@link #SPECIFICATION}.
+ * <p>
+ * The mode is independent of the physical direction. For example, a pressure-specified pump has an
+ * {@link EnergyPortDirection#INPUT} shaft port but calculates its required power, so that port is {@link #CALCULATED}.
+ * A power-specified pump reads the same physical input port as a {@link #SPECIFICATION}.
  *
  * @author NeqSim
  * @version 1.0

--- a/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
@@ -9,9 +9,10 @@ import neqsim.util.unit.PowerUnit;
 /**
  * A named energy-flow connection used to couple process equipment.
  *
- * <p>The canonical stored value is duty in watts. Positive and negative values remain supported for
- * compatibility with existing models; new equipment should use {@link EnergyPort} metadata to
- * express physical direction instead of encoding direction only in the duty sign.
+ * <p>
+ * The canonical stored value is duty in watts. Positive and negative values remain supported for compatibility with
+ * existing models; new equipment should use {@link EnergyPort} metadata to express physical direction instead of
+ * encoding direction only in the duty sign.
  *
  * @author asmund
  * @version $Id: $Id
@@ -23,6 +24,7 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
   private static final Logger logger = LogManager.getLogger(EnergyStream.class);
 
   private String name = "";
+  private String tagNumber = "";
   private double duty = 0.0;
   private EnergyType energyType = EnergyType.UNSPECIFIED;
 
@@ -214,6 +216,18 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
     }
     EnergyStream other = (EnergyStream) obj;
     return Double.doubleToLongBits(duty) == Double.doubleToLongBits(other.duty);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTagNumber() {
+    return tagNumber;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setTagNumber(String tagNumber) {
+    this.tagNumber = Objects.requireNonNull(tagNumber, "tagNumber cannot be null");
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
@@ -3,35 +3,51 @@ package neqsim.process.equipment.stream;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.ProcessElementInterface;
+import neqsim.util.unit.PowerUnit;
 
 /**
- * EnergyStream class.
+ * A named energy-flow connection used to couple process equipment.
+ *
+ * <p>The canonical stored value is duty in watts. Positive and negative values remain supported for
+ * compatibility with existing models; new equipment should use {@link EnergyPort} metadata to
+ * express physical direction instead of encoding direction only in the duty sign.
  *
  * @author asmund
  * @version $Id: $Id
  */
-public class EnergyStream implements java.io.Serializable, Cloneable {
+public class EnergyStream implements ProcessElementInterface, Cloneable {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
   /** Logger object for class. */
-  static Logger logger = LogManager.getLogger(EnergyStream.class);
+  private static final Logger logger = LogManager.getLogger(EnergyStream.class);
+
   private String name = "";
-
   private double duty = 0.0;
+  private EnergyType energyType = EnergyType.UNSPECIFIED;
 
-  /**
-   * Constructor for EnergyStream.
-   */
+  /** Creates an unnamed, unspecified energy stream with zero duty. */
   public EnergyStream() {
   }
 
   /**
-   * Constructor for EnergyStream.
+   * Creates an unspecified energy stream with zero duty.
    *
-   * @param name a {@link java.lang.String} object
+   * @param name stream name
    */
   public EnergyStream(String name) {
     this.name = name;
+  }
+
+  /**
+   * Creates a typed energy stream with zero duty.
+   *
+   * @param name stream name
+   * @param energyType physical energy domain
+   */
+  public EnergyStream(String name, EnergyType energyType) {
+    this.name = name;
+    this.energyType = Objects.requireNonNull(energyType, "energyType cannot be null");
   }
 
   /** {@inheritDoc} */
@@ -47,21 +63,135 @@ public class EnergyStream implements java.io.Serializable, Cloneable {
   }
 
   /**
-   * Getter for the field <code>duty</code>.
+   * Gets the duty in watts.
    *
-   * @return a double
+   * @return duty in W
    */
   public double getDuty() {
     return duty;
   }
 
   /**
-   * Setter for the field <code>duty</code>.
+   * Gets the duty in a requested power unit.
    *
-   * @param duty a double
+   * @param unit requested power unit
+   * @return duty in the requested unit
+   */
+  public double getDuty(String unit) {
+    return new PowerUnit(duty, "W").getValue(unit);
+  }
+
+  /**
+   * Sets the duty in watts.
+   *
+   * @param duty duty in W
    */
   public void setDuty(double duty) {
     this.duty = duty;
+  }
+
+  /**
+   * Sets the duty in a specified power unit.
+   *
+   * @param duty duty value
+   * @param unit power unit
+   */
+  public void setDuty(double duty, String unit) {
+    this.duty = new PowerUnit(duty, unit).getValue("W");
+  }
+
+  /**
+   * Alias for {@link #getDuty()} using power terminology.
+   *
+   * @return power in W
+   */
+  public double getPower() {
+    return getDuty();
+  }
+
+  /**
+   * Alias for {@link #getDuty(String)} using power terminology.
+   *
+   * @param unit requested power unit
+   * @return power in the requested unit
+   */
+  public double getPower(String unit) {
+    return getDuty(unit);
+  }
+
+  /**
+   * Alias for {@link #setDuty(double)} using power terminology.
+   *
+   * @param power power in W
+   */
+  public void setPower(double power) {
+    setDuty(power);
+  }
+
+  /**
+   * Alias for {@link #setDuty(double, String)} using power terminology.
+   *
+   * @param power power value
+   * @param unit power unit
+   */
+  public void setPower(double power, String unit) {
+    setDuty(power, unit);
+  }
+
+  /**
+   * Alias for {@link #getDuty()} using energy-flow terminology.
+   *
+   * @return energy flow in W
+   */
+  public double getEnergyFlow() {
+    return getDuty();
+  }
+
+  /**
+   * Alias for {@link #getDuty(String)} using energy-flow terminology.
+   *
+   * @param unit requested power unit
+   * @return energy flow in the requested unit
+   */
+  public double getEnergyFlow(String unit) {
+    return getDuty(unit);
+  }
+
+  /**
+   * Alias for {@link #setDuty(double)} using energy-flow terminology.
+   *
+   * @param energyFlow energy flow in W
+   */
+  public void setEnergyFlow(double energyFlow) {
+    setDuty(energyFlow);
+  }
+
+  /**
+   * Alias for {@link #setDuty(double, String)} using energy-flow terminology.
+   *
+   * @param energyFlow energy-flow value
+   * @param unit power unit
+   */
+  public void setEnergyFlow(double energyFlow, String unit) {
+    setDuty(energyFlow, unit);
+  }
+
+  /**
+   * Gets the physical energy domain.
+   *
+   * @return energy type
+   */
+  public EnergyType getEnergyType() {
+    return energyType;
+  }
+
+  /**
+   * Sets the physical energy domain.
+   *
+   * @param energyType physical energy domain
+   */
+  public void setEnergyType(EnergyType energyType) {
+    this.energyType = Objects.requireNonNull(energyType, "energyType cannot be null");
   }
 
   /** {@inheritDoc} */
@@ -86,20 +216,14 @@ public class EnergyStream implements java.io.Serializable, Cloneable {
     return Double.doubleToLongBits(duty) == Double.doubleToLongBits(other.duty);
   }
 
-  /**
-   * Getter for the field <code>name</code>.
-   *
-   * @return a {@link java.lang.String} object
-   */
+  /** {@inheritDoc} */
+  @Override
   public String getName() {
     return name;
   }
 
-  /**
-   * Setter for the field <code>name</code>.
-   *
-   * @param name a {@link java.lang.String} object
-   */
+  /** {@inheritDoc} */
+  @Override
   public void setName(String name) {
     this.name = name;
   }

--- a/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
@@ -25,7 +25,7 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
 
   private String name = "";
   private String tagNumber = "";
-  private double duty = 0.0;
+  protected double duty = 0.0;
   private EnergyType energyType = EnergyType.UNSPECIFIED;
 
   /** Creates an unnamed, unspecified energy stream with zero duty. */
@@ -80,7 +80,7 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
    * @return duty in the requested unit
    */
   public double getDuty(String unit) {
-    return new PowerUnit(duty, "W").getValue(unit);
+    return new PowerUnit(getDuty(), "W").getValue(unit);
   }
 
   /**
@@ -99,7 +99,7 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
    * @param unit power unit
    */
   public void setDuty(double duty, String unit) {
-    this.duty = new PowerUnit(duty, unit).getValue("W");
+    setDuty(new PowerUnit(duty, unit).getValue("W"));
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/stream/EnergyType.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyType.java
@@ -1,0 +1,22 @@
+package neqsim.process.equipment.stream;
+
+/**
+ * Physical energy domain carried by an {@link EnergyStream}.
+ *
+ * <p>The type is metadata used to prevent accidental connections such as wiring an electrical
+ * generator directly to a heat-duty port. {@link #UNSPECIFIED} preserves compatibility with legacy
+ * energy streams that did not declare a domain.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public enum EnergyType {
+  /** Legacy or otherwise unspecified energy domain. */
+  UNSPECIFIED,
+  /** Heat transferred across an equipment boundary. */
+  HEAT,
+  /** Mechanical shaft work transferred between rotating equipment. */
+  SHAFT_WORK,
+  /** Electrical power transferred between electrical equipment and loads. */
+  ELECTRICAL
+}

--- a/src/main/java/neqsim/process/equipment/stream/EnergyType.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyType.java
@@ -3,9 +3,10 @@ package neqsim.process.equipment.stream;
 /**
  * Physical energy domain carried by an {@link EnergyStream}.
  *
- * <p>The type is metadata used to prevent accidental connections such as wiring an electrical
- * generator directly to a heat-duty port. {@link #UNSPECIFIED} preserves compatibility with legacy
- * energy streams that did not declare a domain.
+ * <p>
+ * The type is metadata used to prevent accidental connections such as wiring an electrical generator directly to a
+ * heat-duty port. {@link #UNSPECIFIED} preserves compatibility with legacy energy streams that did not declare a
+ * domain.
  *
  * @author NeqSim
  * @version 1.0

--- a/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
+++ b/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
@@ -4,10 +4,9 @@ package neqsim.process.equipment.stream;
  * Shared rotating shaft that balances mechanical power producers and loads.
  *
  * <p>
- * Producers add positive contributions with {@link #setGeneratedPower(String, double)}, while
- * compressors, pumps, and other loads add positive demands with
- * {@link #setConsumedPower(String, double)}. The inherited net bus power is positive when generation
- * exceeds demand and negative when the shaft is under-powered.
+ * Producers add positive contributions with {@link #setGeneratedPower(String, double)}, while compressors, pumps, and
+ * other loads add positive demands with {@link #setConsumedPower(String, double)}. The inherited net bus power is
+ * positive when generation exceeds demand and negative when the shaft is under-powered.
  *
  * @author NeqSim
  * @version 1.0
@@ -110,8 +109,7 @@ public class MechanicalShaft extends EnergyBus {
    * @param mechanicalEfficiency efficiency in the range (0, 1]
    */
   public void setMechanicalEfficiency(double mechanicalEfficiency) {
-    if (!Double.isFinite(mechanicalEfficiency) || mechanicalEfficiency <= 0.0
-        || mechanicalEfficiency > 1.0) {
+    if (!Double.isFinite(mechanicalEfficiency) || mechanicalEfficiency <= 0.0 || mechanicalEfficiency > 1.0) {
       throw new IllegalArgumentException("Shaft efficiency must be in (0, 1]");
     }
     this.mechanicalEfficiency = mechanicalEfficiency;

--- a/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
+++ b/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
@@ -1,0 +1,119 @@
+package neqsim.process.equipment.stream;
+
+/**
+ * Shared rotating shaft that balances mechanical power producers and loads.
+ *
+ * <p>
+ * Producers add positive contributions with {@link #setGeneratedPower(String, double)}, while
+ * compressors, pumps, and other loads add positive demands with
+ * {@link #setConsumedPower(String, double)}. The inherited net bus power is positive when generation
+ * exceeds demand and negative when the shaft is under-powered.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class MechanicalShaft extends EnergyBus {
+  private static final long serialVersionUID = 1000L;
+
+  private double speed = 0.0;
+  private double momentOfInertia = 0.0;
+  private double mechanicalEfficiency = 1.0;
+
+  /** Creates an unnamed shaft. */
+  public MechanicalShaft() {
+    this("");
+  }
+
+  /**
+   * Creates a named shaft.
+   *
+   * @param name shaft name
+   */
+  public MechanicalShaft(String name) {
+    super(name, EnergyType.SHAFT_WORK);
+  }
+
+  /**
+   * Sets generated shaft power in watts.
+   *
+   * @param participant producer name
+   * @param power generated power in W
+   */
+  public void setGeneratedPower(String participant, double power) {
+    setContribution("producer:" + participant, Math.abs(power) * mechanicalEfficiency);
+  }
+
+  /**
+   * Sets consumed shaft power in watts.
+   *
+   * @param participant load name
+   * @param power consumed power in W
+   */
+  public void setConsumedPower(String participant, double power) {
+    setContribution("load:" + participant, -Math.abs(power));
+  }
+
+  /**
+   * Gets shaft speed.
+   *
+   * @return speed in rpm
+   */
+  public double getSpeed() {
+    return speed;
+  }
+
+  /**
+   * Sets shaft speed.
+   *
+   * @param speed speed in rpm
+   */
+  public void setSpeed(double speed) {
+    if (!Double.isFinite(speed) || speed < 0.0) {
+      throw new IllegalArgumentException("Shaft speed must be finite and non-negative");
+    }
+    this.speed = speed;
+  }
+
+  /**
+   * Gets rotating moment of inertia.
+   *
+   * @return moment of inertia in kg m2
+   */
+  public double getMomentOfInertia() {
+    return momentOfInertia;
+  }
+
+  /**
+   * Sets rotating moment of inertia.
+   *
+   * @param momentOfInertia moment of inertia in kg m2
+   */
+  public void setMomentOfInertia(double momentOfInertia) {
+    if (!Double.isFinite(momentOfInertia) || momentOfInertia < 0.0) {
+      throw new IllegalArgumentException("Shaft moment of inertia must be finite and non-negative");
+    }
+    this.momentOfInertia = momentOfInertia;
+  }
+
+  /**
+   * Gets mechanical transfer efficiency.
+   *
+   * @return efficiency in the range (0, 1]
+   */
+  public double getMechanicalEfficiency() {
+    return mechanicalEfficiency;
+  }
+
+  /**
+   * Sets mechanical transfer efficiency applied to generated power.
+   *
+   * @param mechanicalEfficiency efficiency in the range (0, 1]
+   */
+  public void setMechanicalEfficiency(double mechanicalEfficiency) {
+    if (!Double.isFinite(mechanicalEfficiency) || mechanicalEfficiency <= 0.0
+        || mechanicalEfficiency > 1.0) {
+      throw new IllegalArgumentException("Shaft efficiency must be in (0, 1]");
+    }
+    this.mechanicalEfficiency = mechanicalEfficiency;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessEdge.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessEdge.java
@@ -2,6 +2,7 @@ package neqsim.process.processmodel.graph;
 
 import java.io.Serializable;
 import java.util.Objects;
+import neqsim.process.equipment.stream.EnergyStream;
 import neqsim.process.equipment.stream.StreamInterface;
 
 /**
@@ -45,8 +46,11 @@ public class ProcessEdge implements Serializable {
   /** The target node (downstream equipment). */
   private final ProcessNode target;
 
-  /** The stream this edge represents (may be null for control signals). */
+  /** The material stream this edge represents, when applicable. */
   private final StreamInterface stream;
+
+  /** The energy stream this edge represents, when applicable. */
+  private final EnergyStream energyStream;
 
   /** Name of this edge/stream. */
   private final String name;
@@ -76,6 +80,7 @@ public class ProcessEdge implements Serializable {
     this.source = Objects.requireNonNull(source, "source cannot be null");
     this.target = Objects.requireNonNull(target, "target cannot be null");
     this.stream = stream;
+    this.energyStream = null;
     this.name = name != null ? name : generateName();
     this.edgeType = edgeType != null ? edgeType : EdgeType.UNKNOWN;
   }
@@ -94,6 +99,27 @@ public class ProcessEdge implements Serializable {
   }
 
   /**
+   * Creates an energy edge.
+   *
+   * @param index unique index
+   * @param source source node
+   * @param target target node
+   * @param energyStream energy stream connecting the equipment
+   * @param name edge name
+   */
+  public ProcessEdge(int index, ProcessNode source, ProcessNode target,
+      EnergyStream energyStream, String name) {
+    this.index = index;
+    this.source = Objects.requireNonNull(source, "source cannot be null");
+    this.target = Objects.requireNonNull(target, "target cannot be null");
+    this.stream = null;
+    this.energyStream =
+        Objects.requireNonNull(energyStream, "energyStream cannot be null");
+    this.name = name != null ? name : generateName();
+    this.edgeType = EdgeType.ENERGY;
+  }
+
+  /**
    * Creates an edge without a stream (e.g., control signal).
    *
    * @param index unique index
@@ -103,7 +129,7 @@ public class ProcessEdge implements Serializable {
    * @param edgeType type of edge
    */
   public ProcessEdge(int index, ProcessNode source, ProcessNode target, String name, EdgeType edgeType) {
-    this(index, source, target, null, name, edgeType);
+    this(index, source, target, (StreamInterface) null, name, edgeType);
   }
 
   private String generateName() {
@@ -165,6 +191,15 @@ public class ProcessEdge implements Serializable {
    */
   public StreamInterface getStream() {
     return stream;
+  }
+
+  /**
+   * Gets the energy stream represented by this edge.
+   *
+   * @return energy stream, or {@code null} for non-energy edges
+   */
+  public EnergyStream getEnergyStream() {
+    return energyStream;
   }
 
   /**
@@ -271,6 +306,10 @@ public class ProcessEdge implements Serializable {
       } catch (Exception e) {
         features[7] = 0.0;
       }
+    }
+
+    if (energyStream != null) {
+      features[7] = Math.tanh(energyStream.getDuty() / 1.0e6);
     }
 
     // Back edge indicator

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessEdge.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessEdge.java
@@ -107,14 +107,12 @@ public class ProcessEdge implements Serializable {
    * @param energyStream energy stream connecting the equipment
    * @param name edge name
    */
-  public ProcessEdge(int index, ProcessNode source, ProcessNode target,
-      EnergyStream energyStream, String name) {
+  public ProcessEdge(int index, ProcessNode source, ProcessNode target, EnergyStream energyStream, String name) {
     this.index = index;
     this.source = Objects.requireNonNull(source, "source cannot be null");
     this.target = Objects.requireNonNull(target, "target cannot be null");
     this.stream = null;
-    this.energyStream =
-        Objects.requireNonNull(energyStream, "energyStream cannot be null");
+    this.energyStream = Objects.requireNonNull(energyStream, "energyStream cannot be null");
     this.name = name != null ? name : generateName();
     this.edgeType = EdgeType.ENERGY;
   }

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraph.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraph.java
@@ -295,15 +295,13 @@ public class ProcessGraph implements Serializable {
    * @param energyStream energy stream connecting them
    * @return the created energy edge
    */
-  public ProcessEdge addEnergyEdge(
-      ProcessNode source, ProcessNode target, EnergyStream energyStream) {
+  public ProcessEdge addEnergyEdge(ProcessNode source, ProcessNode target, EnergyStream energyStream) {
     Objects.requireNonNull(source, "source cannot be null");
     Objects.requireNonNull(target, "target cannot be null");
     Objects.requireNonNull(energyStream, "energyStream cannot be null");
 
     int index = edges.size();
-    ProcessEdge edge =
-        new ProcessEdge(index, source, target, energyStream, energyStream.getName());
+    ProcessEdge edge = new ProcessEdge(index, source, target, energyStream, energyStream.getName());
     edges.add(edge);
     source.addOutgoingEdge(edge);
     target.addIncomingEdge(edge);

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraph.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraph.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.stream.EnergyStream;
 
 /**
  * Represents a process flowsheet as an explicit directed graph (DAG with potential cycles).
@@ -278,6 +279,31 @@ public class ProcessGraph implements Serializable {
 
     int index = edges.size();
     ProcessEdge edge = new ProcessEdge(index, source, target, stream);
+    edges.add(edge);
+    source.addOutgoingEdge(edge);
+    target.addIncomingEdge(edge);
+
+    invalidateCache();
+    return edge;
+  }
+
+  /**
+   * Adds an energy-stream dependency between two nodes.
+   *
+   * @param source calculation producer node
+   * @param target calculation consumer node
+   * @param energyStream energy stream connecting them
+   * @return the created energy edge
+   */
+  public ProcessEdge addEnergyEdge(
+      ProcessNode source, ProcessNode target, EnergyStream energyStream) {
+    Objects.requireNonNull(source, "source cannot be null");
+    Objects.requireNonNull(target, "target cannot be null");
+    Objects.requireNonNull(energyStream, "energyStream cannot be null");
+
+    int index = edges.size();
+    ProcessEdge edge =
+        new ProcessEdge(index, source, target, energyStream, energyStream.getName());
     edges.add(edge);
     source.addOutgoingEdge(edge);
     target.addIncomingEdge(edge);

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -524,10 +524,8 @@ public final class ProcessGraphBuilder {
     // physical direction, determines scheduling order. A point-to-point
     // EnergyStream permits one producer and one consumer; EnergyBus supports
     // multi-party generation, demand, and balancing.
-    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToProducers =
-        new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
-    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToConsumers =
-        new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
+    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToProducers = new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
+    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToConsumers = new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
 
     for (ProcessEquipmentInterface unit : units) {
       for (EnergyPort port : unit.getEnergyPorts().values()) {
@@ -553,18 +551,16 @@ public final class ProcessGraphBuilder {
           connectedUnits = new ArrayList<ProcessEquipmentInterface>();
           targetMap.put(stream, connectedUnits);
         }
-        if (!(stream instanceof EnergyBus) && !connectedUnits.isEmpty()
-            && connectedUnits.get(0) != unit) {
-          throw new IllegalStateException("Point-to-point energy stream " + stream.getName()
-              + " has multiple " + role + ": " + connectedUnits.get(0).getName() + " and "
-              + unit.getName() + ". Use EnergyBus for multi-party distribution.");
+        if (!(stream instanceof EnergyBus) && !connectedUnits.isEmpty() && connectedUnits.get(0) != unit) {
+          throw new IllegalStateException("Point-to-point energy stream " + stream.getName() + " has multiple " + role
+              + ": " + connectedUnits.get(0).getName() + " and " + unit.getName()
+              + ". Use EnergyBus for multi-party distribution.");
         }
         addByIdentityIfAbsent(connectedUnits, unit);
       }
     }
 
-    for (Map.Entry<EnergyStream, List<ProcessEquipmentInterface>> entry :
-        energyToProducers.entrySet()) {
+    for (Map.Entry<EnergyStream, List<ProcessEquipmentInterface>> entry : energyToProducers.entrySet()) {
       List<ProcessEquipmentInterface> consumers = energyToConsumers.get(entry.getKey());
       if (consumers == null) {
         continue;
@@ -1059,8 +1055,8 @@ public final class ProcessGraphBuilder {
    * @param units equipment list
    * @param candidate candidate equipment
    */
-  private static void addByIdentityIfAbsent(
-      List<ProcessEquipmentInterface> units, ProcessEquipmentInterface candidate) {
+  private static void addByIdentityIfAbsent(List<ProcessEquipmentInterface> units,
+      ProcessEquipmentInterface candidate) {
     for (ProcessEquipmentInterface unit : units) {
       if (unit == candidate) {
         return;

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -523,10 +523,8 @@ public final class ProcessGraphBuilder {
     // physical direction, determines scheduling order. This supports both a
     // generator driving a load and a pressure-specified load publishing its
     // calculated demand to a driver or utility model.
-    Map<EnergyStream, ProcessEquipmentInterface> energyToProducer =
-        new IdentityHashMap<EnergyStream, ProcessEquipmentInterface>();
-    Map<EnergyStream, ProcessEquipmentInterface> energyToConsumer =
-        new IdentityHashMap<EnergyStream, ProcessEquipmentInterface>();
+    Map<EnergyStream, ProcessEquipmentInterface> energyToProducer = new IdentityHashMap<EnergyStream, ProcessEquipmentInterface>();
+    Map<EnergyStream, ProcessEquipmentInterface> energyToConsumer = new IdentityHashMap<EnergyStream, ProcessEquipmentInterface>();
 
     for (ProcessEquipmentInterface unit : units) {
       for (EnergyPort port : unit.getEnergyPorts().values()) {
@@ -537,32 +535,21 @@ public final class ProcessGraphBuilder {
         if (port.getMode() == EnergyPortMode.CALCULATED) {
           ProcessEquipmentInterface previous = energyToProducer.put(stream, unit);
           if (previous != null && previous != unit) {
-            throw new IllegalStateException(
-                "Energy stream "
-                    + stream.getName()
-                    + " has multiple calculation producers: "
-                    + previous.getName()
-                    + " and "
-                    + unit.getName());
+            throw new IllegalStateException("Energy stream " + stream.getName()
+                + " has multiple calculation producers: " + previous.getName() + " and " + unit.getName());
           }
         } else if (port.getMode() == EnergyPortMode.SPECIFICATION) {
           ProcessEquipmentInterface previous = energyToConsumer.put(stream, unit);
           if (previous != null && previous != unit) {
             throw new IllegalStateException(
-                "Energy stream "
-                    + stream.getName()
-                    + " has multiple specification consumers: "
-                    + previous.getName()
-                    + " and "
-                    + unit.getName()
-                    + ". Use a dedicated energy bus for shared distribution.");
+                "Energy stream " + stream.getName() + " has multiple specification consumers: " + previous.getName()
+                    + " and " + unit.getName() + ". Use a dedicated energy bus for shared distribution.");
           }
         }
       }
     }
 
-    for (Map.Entry<EnergyStream, ProcessEquipmentInterface> entry :
-        energyToConsumer.entrySet()) {
+    for (Map.Entry<EnergyStream, ProcessEquipmentInterface> entry : energyToConsumer.entrySet()) {
       ProcessEquipmentInterface producer = energyToProducer.get(entry.getKey());
       ProcessEquipmentInterface consumer = entry.getValue();
       if (producer != null && producer != consumer) {
@@ -1053,19 +1040,15 @@ public final class ProcessGraphBuilder {
    * @param targetEquipment equipment reading the energy duty as a specification
    * @param stream connected energy stream
    */
-  private static void addEnergyEdgeIfAbsent(
-      ProcessGraph graph,
-      ProcessEquipmentInterface sourceEquipment,
-      ProcessEquipmentInterface targetEquipment,
-      EnergyStream stream) {
+  private static void addEnergyEdgeIfAbsent(ProcessGraph graph, ProcessEquipmentInterface sourceEquipment,
+      ProcessEquipmentInterface targetEquipment, EnergyStream stream) {
     ProcessNode sourceNode = graph.getNode(sourceEquipment);
     ProcessNode targetNode = graph.getNode(targetEquipment);
     if (sourceNode == null || targetNode == null) {
       return;
     }
     for (ProcessEdge edge : sourceNode.getOutgoingEdges()) {
-      if (edge.getTarget() == targetNode
-          && edge.getEdgeType() == ProcessEdge.EdgeType.ENERGY
+      if (edge.getTarget() == targetNode && edge.getEdgeType() == ProcessEdge.EdgeType.ENERGY
           && edge.getEnergyStream() == stream) {
         return;
       }

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -24,6 +24,7 @@ import neqsim.process.equipment.manifold.Manifold;
 import neqsim.process.equipment.mixer.MixerInterface;
 import neqsim.process.equipment.reactor.FurnaceBurner;
 import neqsim.process.equipment.splitter.SplitterInterface;
+import neqsim.process.equipment.stream.EnergyBus;
 import neqsim.process.equipment.stream.EnergyPort;
 import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyStream;
@@ -520,11 +521,13 @@ public final class ProcessGraphBuilder {
     }
 
     // Third pass: add typed energy dependencies. Calculation mode, rather than
-    // physical direction, determines scheduling order. This supports both a
-    // generator driving a load and a pressure-specified load publishing its
-    // calculated demand to a driver or utility model.
-    Map<EnergyStream, ProcessEquipmentInterface> energyToProducer = new IdentityHashMap<EnergyStream, ProcessEquipmentInterface>();
-    Map<EnergyStream, ProcessEquipmentInterface> energyToConsumer = new IdentityHashMap<EnergyStream, ProcessEquipmentInterface>();
+    // physical direction, determines scheduling order. A point-to-point
+    // EnergyStream permits one producer and one consumer; EnergyBus supports
+    // multi-party generation, demand, and balancing.
+    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToProducers =
+        new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
+    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToConsumers =
+        new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
 
     for (ProcessEquipmentInterface unit : units) {
       for (EnergyPort port : unit.getEnergyPorts().values()) {
@@ -532,28 +535,46 @@ public final class ProcessGraphBuilder {
           continue;
         }
         EnergyStream stream = port.getEnergyStream();
+        Map<EnergyStream, List<ProcessEquipmentInterface>> targetMap = null;
+        String role = null;
         if (port.getMode() == EnergyPortMode.CALCULATED) {
-          ProcessEquipmentInterface previous = energyToProducer.put(stream, unit);
-          if (previous != null && previous != unit) {
-            throw new IllegalStateException("Energy stream " + stream.getName()
-                + " has multiple calculation producers: " + previous.getName() + " and " + unit.getName());
-          }
+          targetMap = energyToProducers;
+          role = "calculation producers";
         } else if (port.getMode() == EnergyPortMode.SPECIFICATION) {
-          ProcessEquipmentInterface previous = energyToConsumer.put(stream, unit);
-          if (previous != null && previous != unit) {
-            throw new IllegalStateException(
-                "Energy stream " + stream.getName() + " has multiple specification consumers: " + previous.getName()
-                    + " and " + unit.getName() + ". Use a dedicated energy bus for shared distribution.");
-          }
+          targetMap = energyToConsumers;
+          role = "specification consumers";
         }
+        if (targetMap == null) {
+          continue;
+        }
+
+        List<ProcessEquipmentInterface> connectedUnits = targetMap.get(stream);
+        if (connectedUnits == null) {
+          connectedUnits = new ArrayList<ProcessEquipmentInterface>();
+          targetMap.put(stream, connectedUnits);
+        }
+        if (!(stream instanceof EnergyBus) && !connectedUnits.isEmpty()
+            && connectedUnits.get(0) != unit) {
+          throw new IllegalStateException("Point-to-point energy stream " + stream.getName()
+              + " has multiple " + role + ": " + connectedUnits.get(0).getName() + " and "
+              + unit.getName() + ". Use EnergyBus for multi-party distribution.");
+        }
+        addByIdentityIfAbsent(connectedUnits, unit);
       }
     }
 
-    for (Map.Entry<EnergyStream, ProcessEquipmentInterface> entry : energyToConsumer.entrySet()) {
-      ProcessEquipmentInterface producer = energyToProducer.get(entry.getKey());
-      ProcessEquipmentInterface consumer = entry.getValue();
-      if (producer != null && producer != consumer) {
-        addEnergyEdgeIfAbsent(graph, producer, consumer, entry.getKey());
+    for (Map.Entry<EnergyStream, List<ProcessEquipmentInterface>> entry :
+        energyToProducers.entrySet()) {
+      List<ProcessEquipmentInterface> consumers = energyToConsumers.get(entry.getKey());
+      if (consumers == null) {
+        continue;
+      }
+      for (ProcessEquipmentInterface producer : entry.getValue()) {
+        for (ProcessEquipmentInterface consumer : consumers) {
+          if (producer != consumer) {
+            addEnergyEdgeIfAbsent(graph, producer, consumer, entry.getKey());
+          }
+        }
       }
     }
 
@@ -1030,6 +1051,22 @@ public final class ProcessGraphBuilder {
         }
       }
     }
+  }
+
+  /**
+   * Adds equipment to a list unless the identical object is already present.
+   *
+   * @param units equipment list
+   * @param candidate candidate equipment
+   */
+  private static void addByIdentityIfAbsent(
+      List<ProcessEquipmentInterface> units, ProcessEquipmentInterface candidate) {
+    for (ProcessEquipmentInterface unit : units) {
+      if (unit == candidate) {
+        return;
+      }
+    }
+    units.add(candidate);
   }
 
   /**

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -24,6 +24,9 @@ import neqsim.process.equipment.manifold.Manifold;
 import neqsim.process.equipment.mixer.MixerInterface;
 import neqsim.process.equipment.reactor.FurnaceBurner;
 import neqsim.process.equipment.splitter.SplitterInterface;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.equipment.util.Adjuster;
 import neqsim.process.equipment.util.Calculator;
@@ -516,7 +519,58 @@ public final class ProcessGraphBuilder {
       }
     }
 
-    // Third pass: add signal edges for Calculator and Adjuster units.
+    // Third pass: add typed energy dependencies. Calculation mode, rather than
+    // physical direction, determines scheduling order. This supports both a
+    // generator driving a load and a pressure-specified load publishing its
+    // calculated demand to a driver or utility model.
+    Map<EnergyStream, ProcessEquipmentInterface> energyToProducer =
+        new IdentityHashMap<EnergyStream, ProcessEquipmentInterface>();
+    Map<EnergyStream, ProcessEquipmentInterface> energyToConsumer =
+        new IdentityHashMap<EnergyStream, ProcessEquipmentInterface>();
+
+    for (ProcessEquipmentInterface unit : units) {
+      for (EnergyPort port : unit.getEnergyPorts().values()) {
+        if (!port.isConnected()) {
+          continue;
+        }
+        EnergyStream stream = port.getEnergyStream();
+        if (port.getMode() == EnergyPortMode.CALCULATED) {
+          ProcessEquipmentInterface previous = energyToProducer.put(stream, unit);
+          if (previous != null && previous != unit) {
+            throw new IllegalStateException(
+                "Energy stream "
+                    + stream.getName()
+                    + " has multiple calculation producers: "
+                    + previous.getName()
+                    + " and "
+                    + unit.getName());
+          }
+        } else if (port.getMode() == EnergyPortMode.SPECIFICATION) {
+          ProcessEquipmentInterface previous = energyToConsumer.put(stream, unit);
+          if (previous != null && previous != unit) {
+            throw new IllegalStateException(
+                "Energy stream "
+                    + stream.getName()
+                    + " has multiple specification consumers: "
+                    + previous.getName()
+                    + " and "
+                    + unit.getName()
+                    + ". Use a dedicated energy bus for shared distribution.");
+          }
+        }
+      }
+    }
+
+    for (Map.Entry<EnergyStream, ProcessEquipmentInterface> entry :
+        energyToConsumer.entrySet()) {
+      ProcessEquipmentInterface producer = energyToProducer.get(entry.getKey());
+      ProcessEquipmentInterface consumer = entry.getValue();
+      if (producer != null && producer != consumer) {
+        addEnergyEdgeIfAbsent(graph, producer, consumer, entry.getKey());
+      }
+    }
+
+    // Fourth pass: add signal edges for Calculator and Adjuster units.
     // These units represent calculation/control dependencies, not physical
     // material streams. Signal edges keep calculation order correct and allow
     // diagram exporters to render dashed signal lines instead of solid piping.
@@ -989,6 +1043,34 @@ public final class ProcessGraphBuilder {
         }
       }
     }
+  }
+
+  /**
+   * Adds a typed energy dependency when the same stream edge does not already exist.
+   *
+   * @param graph process graph
+   * @param sourceEquipment equipment calculating the energy duty
+   * @param targetEquipment equipment reading the energy duty as a specification
+   * @param stream connected energy stream
+   */
+  private static void addEnergyEdgeIfAbsent(
+      ProcessGraph graph,
+      ProcessEquipmentInterface sourceEquipment,
+      ProcessEquipmentInterface targetEquipment,
+      EnergyStream stream) {
+    ProcessNode sourceNode = graph.getNode(sourceEquipment);
+    ProcessNode targetNode = graph.getNode(targetEquipment);
+    if (sourceNode == null || targetNode == null) {
+      return;
+    }
+    for (ProcessEdge edge : sourceNode.getOutgoingEdges()) {
+      if (edge.getTarget() == targetNode
+          && edge.getEdgeType() == ProcessEdge.EdgeType.ENERGY
+          && edge.getEnergyStream() == stream) {
+        return;
+      }
+    }
+    graph.addEnergyEdge(sourceNode, targetNode, stream);
   }
 
   /**

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -1567,6 +1567,7 @@ public class DocExamplesCompilationTest {
       assertNotNull(r.getStatus());
     }
   }
+
   /**
    * Energy-driven pump example from docs/process/energy_streams.md.
    */
@@ -1580,8 +1581,7 @@ public class DocExamplesCompilationTest {
     feed.setFlowRate(100000.0, "kg/hr");
     feed.run();
 
-    EnergyStream shaft =
-        new EnergyStream("pump shaft", EnergyType.SHAFT_WORK);
+    EnergyStream shaft = new EnergyStream("pump shaft", EnergyType.SHAFT_WORK);
     shaft.setPower(100.0, "kW");
 
     Pump pump = new Pump("energy-driven pump", feed);

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -21,8 +21,12 @@ import neqsim.process.equipment.distillation.internals.ColumnInternalsDesigner;
 import neqsim.process.equipment.heatexchanger.CoolingWaterSystem;
 import neqsim.process.equipment.heatexchanger.FiredHeater;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction;
+import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction.InterfacialFrictionResult;
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.fielddevelopment.concept.DevelopmentCaseTemplate;
@@ -1563,4 +1567,33 @@ public class DocExamplesCompilationTest {
       assertNotNull(r.getStatus());
     }
   }
+  /**
+   * Energy-driven pump example from docs/process/energy_streams.md.
+   */
+  @Test
+  public void testEnergyDrivenPumpDocumentationExample() {
+    SystemInterface water = new SystemSrkEos(298.15, 2.0);
+    water.addComponent("water", 1.0);
+    water.setMixingRule("classic");
+
+    Stream feed = new Stream("pump feed", water);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.run();
+
+    EnergyStream shaft =
+        new EnergyStream("pump shaft", EnergyType.SHAFT_WORK);
+    shaft.setPower(100.0, "kW");
+
+    Pump pump = new Pump("energy-driven pump", feed);
+    pump.setIsentropicEfficiency(0.75);
+    pump.setEnergyStream(shaft);
+    pump.run();
+
+    double outletPressure = pump.getOutletStream().getPressure("bara");
+    EnergyPortMode mode = pump.getEnergyPort("shaftPower").getMode();
+
+    assertTrue(outletPressure > feed.getPressure("bara"));
+    assertEquals(EnergyPortMode.SPECIFICATION, mode);
+  }
+
 }

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -24,9 +24,11 @@ import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFrictio
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction.InterfacialFrictionResult;
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.EnergyBus;
 import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyStream;
 import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.fielddevelopment.concept.DevelopmentCaseTemplate;
@@ -1594,6 +1596,26 @@ public class DocExamplesCompilationTest {
 
     assertTrue(outletPressure > feed.getPressure("bara"));
     assertEquals(EnergyPortMode.SPECIFICATION, mode);
+  }
+
+  /**
+   * Energy bus and mechanical shaft examples from docs/process/energy_streams.md.
+   */
+  @Test
+  public void testEnergyBusDocumentationExamples() {
+    EnergyBus grid = new EnergyBus("main electrical bus", EnergyType.ELECTRICAL);
+    grid.setContribution("solar", 2.0, "MW");
+    grid.setContribution("electrolyzer", -1.5, "MW");
+    double reserve = grid.getNetPower("kW");
+
+    MechanicalShaft shaftTrain = new MechanicalShaft("expander-compressor shaft");
+    shaftTrain.setMechanicalEfficiency(0.98);
+    shaftTrain.setGeneratedPower("expander", 10.0e6);
+    shaftTrain.setConsumedPower("compressor", 8.0e6);
+    double sparePower = shaftTrain.getNetPower("MW");
+
+    assertEquals(500.0, reserve, 1.0e-12);
+    assertEquals(1.8, sparePower, 1.0e-12);
   }
 
 }

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnTest.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
@@ -568,6 +569,8 @@ public class DistillationColumnTest {
     double actualFlow = reboiler.getGasOutStream().getFlowRate("kg/hr")
         + reboiler.getLiquidOutStream().getFlowRate("kg/hr");
     assertEquals(expectedFlow, actualFlow, expectedFlow * 1.0e-8);
+    assertEquals(reboiler.getDuty(), reboiler.getEnergyStream().getDuty(), 1.0e-8);
+    assertEquals(EnergyType.HEAT, reboiler.getEnergyStream().getEnergyType());
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/powergeneration/GasTurbineTest.java
+++ b/src/test/java/neqsim/process/equipment/powergeneration/GasTurbineTest.java
@@ -7,6 +7,11 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemSrkEos;
 
@@ -106,11 +111,17 @@ public class GasTurbineTest extends neqsim.NeqSimTest {
 
     GasTurbine gasturb = new GasTurbine("turbine", fuelStream);
     gasturb.setThermalEfficiency(0.35);
+    MechanicalShaft shaft = new MechanicalShaft("GT shaft");
+    EnergyBus heatBus = new EnergyBus("exhaust heat bus", EnergyType.HEAT);
+    gasturb.connectEnergyStream("shaftPower", shaft, EnergyPortMode.CALCULATED);
+    gasturb.connectEnergyStream("exhaustHeat", heatBus, EnergyPortMode.CALCULATED);
     gasturb.run();
 
     // Net shaft power must equal efficiency x fuel LHV, and exhaust heat the remainder.
     assertEquals(0.35 * fuelHeat, gasturb.getPower(), Math.abs(0.35 * fuelHeat) * 1e-6);
     assertEquals(fuelHeat - gasturb.getPower(), gasturb.getHeat(), Math.abs(fuelHeat) * 1e-6);
+    assertEquals(gasturb.getPower(), shaft.getNetPower(), Math.abs(gasturb.getPower()) * 1e-9);
+    assertEquals(gasturb.getHeat(), heatBus.getNetPower(), Math.abs(gasturb.getHeat()) * 1e-9);
     // Realistic simple-cycle efficiency, unlike the very low detailed-cycle default at 2.5 bara.
     Assertions.assertTrue(gasturb.getPower() / fuelHeat > 0.30, "simple-cycle efficiency must be realistic");
   }
@@ -165,6 +176,25 @@ public class GasTurbineTest extends neqsim.NeqSimTest {
     gasturb.setRequiredPower(60.0, "MW");
     gasturb.run();
     assertEquals(2.0 * fuelAt30, gasturb.getFuelFlowRate("Sm3/sec"), 2.0 * fuelAt30 * 1e-3);
+  }
+
+  @Test
+  void testShaftEnergyStreamSetsPowerDemand() {
+    SystemSrkEos fuel = new SystemSrkEos(298.15, 20.0);
+    fuel.addComponent("methane", 1.0);
+    fuel.setMixingRule("classic");
+    Stream fuelStream = new Stream("fuel", fuel);
+    fuelStream.setFlowRate(1000.0, "kg/hr");
+    fuelStream.run();
+
+    EnergyStream requestedPower = new EnergyStream("shaft demand", EnergyType.SHAFT_WORK);
+    requestedPower.setDuty(20.0, "MW");
+    GasTurbine gasturb = new GasTurbine("turbine", fuelStream);
+    gasturb.setThermalEfficiency(0.35);
+    gasturb.connectEnergyStream("shaftPower", requestedPower, EnergyPortMode.SPECIFICATION);
+    gasturb.run();
+
+    assertEquals(20.0, gasturb.getPower() / 1.0e6, 1e-9);
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/powergeneration/GasTurbineTest.java
+++ b/src/test/java/neqsim/process/equipment/powergeneration/GasTurbineTest.java
@@ -191,7 +191,7 @@ public class GasTurbineTest extends neqsim.NeqSimTest {
     requestedPower.setDuty(20.0, "MW");
     GasTurbine gasturb = new GasTurbine("turbine", fuelStream);
     gasturb.setThermalEfficiency(0.35);
-    gasturb.connectEnergyStream("shaftPower", requestedPower, EnergyPortMode.SPECIFICATION);
+    gasturb.setEnergyStream(requestedPower);
     gasturb.run();
 
     assertEquals(20.0, gasturb.getPower() / 1.0e6, 1e-9);

--- a/src/test/java/neqsim/process/equipment/pump/PumpTest.java
+++ b/src/test/java/neqsim/process/equipment/pump/PumpTest.java
@@ -9,6 +9,7 @@ import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyStream;
 import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.util.Recycle;
 
@@ -414,6 +415,31 @@ public class PumpTest extends neqsim.NeqSimTest {
     Assertions.assertEquals(expectedOutletPressure, pump.getOutletStream().getPressure("Pa"), 1.0);
     Assertions.assertEquals(shaftPower, pump.getPower(), 1.0e-6);
     Assertions.assertEquals(EnergyPortMode.SPECIFICATION, pump.getEnergyPort("shaftPower").getMode());
+  }
+
+  @Test
+  void testPressureSpecifiedPumpPublishesLoadToShaftBus() {
+    neqsim.thermo.system.SystemInterface water =
+        new neqsim.thermo.system.SystemSrkEos(273.15 + 25.0, 2.0);
+    water.addComponent("water", 1.0);
+    water.setMixingRule("classic");
+
+    Stream feed = new Stream("shaft bus pump feed", water);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.run();
+
+    MechanicalShaft shaft = new MechanicalShaft("pump train");
+    Pump pump = new Pump("bus pump", feed);
+    pump.setOutletPressure(10.0, "bara");
+    pump.setIsentropicEfficiency(0.75);
+    pump.connectEnergyStream("shaftPower", shaft, EnergyPortMode.CALCULATED);
+
+    pump.run();
+
+    Assertions.assertTrue(pump.getPower() > 0.0);
+    Assertions.assertEquals(
+        -pump.getPower(), shaft.getContribution("bus pump.shaftPower"), 1.0e-6);
+    Assertions.assertEquals(EnergyPortMode.CALCULATED, pump.getEnergyPort("shaftPower").getMode());
   }
 
 }

--- a/src/test/java/neqsim/process/equipment/pump/PumpTest.java
+++ b/src/test/java/neqsim/process/equipment/pump/PumpTest.java
@@ -419,8 +419,7 @@ public class PumpTest extends neqsim.NeqSimTest {
 
   @Test
   void testPressureSpecifiedPumpPublishesLoadToShaftBus() {
-    neqsim.thermo.system.SystemInterface water =
-        new neqsim.thermo.system.SystemSrkEos(273.15 + 25.0, 2.0);
+    neqsim.thermo.system.SystemInterface water = new neqsim.thermo.system.SystemSrkEos(273.15 + 25.0, 2.0);
     water.addComponent("water", 1.0);
     water.setMixingRule("classic");
 
@@ -437,8 +436,7 @@ public class PumpTest extends neqsim.NeqSimTest {
     pump.run();
 
     Assertions.assertTrue(pump.getPower() > 0.0);
-    Assertions.assertEquals(
-        -pump.getPower(), shaft.getContribution("bus pump.shaftPower"), 1.0e-6);
+    Assertions.assertEquals(-pump.getPower(), shaft.getContribution("bus pump.shaftPower"), 1.0e-6);
     Assertions.assertEquals(EnergyPortMode.CALCULATED, pump.getEnergyPort("shaftPower").getMode());
   }
 

--- a/src/test/java/neqsim/process/equipment/pump/PumpTest.java
+++ b/src/test/java/neqsim/process/equipment/pump/PumpTest.java
@@ -6,6 +6,9 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.util.Recycle;
 
@@ -379,6 +382,43 @@ public class PumpTest extends neqsim.NeqSimTest {
 
     Assertions.assertEquals(expectedPowerKw, pump.getPower("kW"), expectedPowerKw * 1.0e-8,
         "Hydraulic power must use density at the current inlet state");
+  }
+
+  @Test
+  void testRunWithShaftPowerEnergyStream() {
+    neqsim.thermo.system.SystemInterface water =
+        new neqsim.thermo.system.SystemSrkEos(273.15 + 25.0, 2.0);
+    water.addComponent("water", 1.0);
+    water.setMixingRule("classic");
+
+    Stream feed = new Stream("energy-driven pump feed", water);
+    feed.setFlowRate(100000.0, "kg/hr");
+    feed.setTemperature(25.0, "C");
+    feed.setPressure(2.0, "bara");
+    feed.run();
+    feed.getThermoSystem().initPhysicalProperties();
+
+    double efficiency = 0.75;
+    double shaftPower = 100.0e3;
+    double density = feed.getThermoSystem().getDensity("kg/m3");
+    double volumetricFlow = feed.getFlowRate("kg/sec") / density;
+    double expectedOutletPressure =
+        feed.getPressure("Pa") + shaftPower * efficiency / volumetricFlow;
+
+    EnergyStream shaft =
+        new EnergyStream("pump shaft", EnergyType.SHAFT_WORK);
+    shaft.setPower(shaftPower);
+    Pump pump = new Pump("energy-driven pump", feed);
+    pump.setIsentropicEfficiency(efficiency);
+    pump.setEnergyStream(shaft);
+
+    pump.run();
+
+    Assertions.assertEquals(
+        expectedOutletPressure, pump.getOutletStream().getPressure("Pa"), 1.0);
+    Assertions.assertEquals(shaftPower, pump.getPower(), 1.0e-6);
+    Assertions.assertEquals(
+        EnergyPortMode.SPECIFICATION, pump.getEnergyPort("shaftPower").getMode());
   }
 
 }

--- a/src/test/java/neqsim/process/equipment/pump/PumpTest.java
+++ b/src/test/java/neqsim/process/equipment/pump/PumpTest.java
@@ -386,8 +386,7 @@ public class PumpTest extends neqsim.NeqSimTest {
 
   @Test
   void testRunWithShaftPowerEnergyStream() {
-    neqsim.thermo.system.SystemInterface water =
-        new neqsim.thermo.system.SystemSrkEos(273.15 + 25.0, 2.0);
+    neqsim.thermo.system.SystemInterface water = new neqsim.thermo.system.SystemSrkEos(273.15 + 25.0, 2.0);
     water.addComponent("water", 1.0);
     water.setMixingRule("classic");
 
@@ -402,11 +401,9 @@ public class PumpTest extends neqsim.NeqSimTest {
     double shaftPower = 100.0e3;
     double density = feed.getThermoSystem().getDensity("kg/m3");
     double volumetricFlow = feed.getFlowRate("kg/sec") / density;
-    double expectedOutletPressure =
-        feed.getPressure("Pa") + shaftPower * efficiency / volumetricFlow;
+    double expectedOutletPressure = feed.getPressure("Pa") + shaftPower * efficiency / volumetricFlow;
 
-    EnergyStream shaft =
-        new EnergyStream("pump shaft", EnergyType.SHAFT_WORK);
+    EnergyStream shaft = new EnergyStream("pump shaft", EnergyType.SHAFT_WORK);
     shaft.setPower(shaftPower);
     Pump pump = new Pump("energy-driven pump", feed);
     pump.setIsentropicEfficiency(efficiency);
@@ -414,11 +411,9 @@ public class PumpTest extends neqsim.NeqSimTest {
 
     pump.run();
 
-    Assertions.assertEquals(
-        expectedOutletPressure, pump.getOutletStream().getPressure("Pa"), 1.0);
+    Assertions.assertEquals(expectedOutletPressure, pump.getOutletStream().getPressure("Pa"), 1.0);
     Assertions.assertEquals(shaftPower, pump.getPower(), 1.0e-6);
-    Assertions.assertEquals(
-        EnergyPortMode.SPECIFICATION, pump.getEnergyPort("shaftPower").getMode());
+    Assertions.assertEquals(EnergyPortMode.SPECIFICATION, pump.getEnergyPort("shaftPower").getMode());
   }
 
 }

--- a/src/test/java/neqsim/process/equipment/reactor/BioProcessingReactorTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/BioProcessingReactorTest.java
@@ -4,6 +4,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -123,6 +127,8 @@ public class BioProcessingReactorTest {
     reactor.setVesselVolume(50.0);
     reactor.setResidenceTime(24.0, "hr");
     reactor.setAgitatorPowerPerVolume(1.5);
+    EnergyBus electricalBus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);
+    reactor.connectEnergyStream("agitatorPower", electricalBus, EnergyPortMode.CALCULATED);
     reactor.run();
 
     // Verify outlet stream exists and has expected properties
@@ -135,6 +141,35 @@ public class BioProcessingReactorTest {
 
     // Check agitator power
     Assertions.assertEquals(75.0, reactor.getAgitatorPower(), 1e-6, "Agitator power should be 1.5 * 50 = 75 kW");
+    Assertions.assertEquals(-75.0, electricalBus.getNetPower("kW"), 1e-6,
+        "Agitator should withdraw electrical power from the bus");
+  }
+
+  /**
+   * Test a StirredTankReactor driven by an external heat-duty stream.
+   */
+  @Test
+  public void testStirredTankReactorEnergySpecification() {
+    SystemInterface system = new SystemSrkEos(303.15, 1.01325);
+    system.addComponent("water", 1.0);
+    system.setMixingRule("classic");
+
+    Stream feed = new Stream("heated feed", system);
+    feed.setFlowRate(100.0, "kg/hr");
+    feed.run();
+    feed.getFluid().init(3);
+    double inletEnthalpy = feed.getFluid().getEnthalpy();
+
+    EnergyStream heat = new EnergyStream("reactor heat", EnergyType.HEAT);
+    heat.setDuty(5.0, "kW");
+    StirredTankReactor reactor = new StirredTankReactor("heated CSTR", feed);
+    reactor.setEnergyStream(heat);
+    reactor.run();
+
+    reactor.getOutletStream().getFluid().init(3);
+    Assertions.assertEquals(5.0, reactor.getHeatDuty("kW"), 1e-9);
+    Assertions.assertEquals(inletEnthalpy + 5.0e3, reactor.getOutletStream().getFluid().getEnthalpy(), 1e-3);
+    Assertions.assertEquals(EnergyPortMode.SPECIFICATION, reactor.getEnergyPort("heatDuty").getMode());
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusTest.java
@@ -43,6 +43,7 @@ class EnergyBusTest {
     assertEquals(0.8, shaft.getNetPower("MW"), 1.0e-12);
     assertEquals(EnergyType.SHAFT_WORK, shaft.getEnergyType());
   }
+
   @Test
   void testEquipmentPortsPublishDirectedBusContributions() {
     EnergyBus bus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusTest.java
@@ -2,6 +2,13 @@ package neqsim.process.equipment.stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.battery.BatteryStorage;
 import neqsim.process.equipment.powergeneration.SolarPanel;
@@ -30,6 +37,77 @@ class EnergyBusTest {
     assertNotSame(bus, clone);
     assertEquals(100.0, bus.getContribution("heater"), 1.0e-12);
     assertEquals(200.0, clone.getContribution("heater"), 1.0e-12);
+  }
+
+  @Test
+  void testSpecificationConsumerExcludesItsPreviousWithdrawal() {
+    EnergyBus bus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);
+    EnergyPort generator = new EnergyPort("power", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+    generator.setOwnerName("generator");
+    generator.connect(bus);
+    generator.setDuty(500.0);
+
+    EnergyPort consumer = new EnergyPort("power", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
+        EnergyPortMode.SPECIFICATION);
+    consumer.setOwnerName("consumer");
+    consumer.connect(bus);
+
+    assertEquals(500.0, consumer.getPowerMagnitude(), 1.0e-12);
+    consumer.setDuty(500.0);
+    assertEquals(0.0, bus.getNetPower(), 1.0e-12);
+    assertEquals(500.0, consumer.getPowerMagnitude(), 1.0e-12);
+  }
+
+  @Test
+  void testBidirectionalSpecificationRecordsHeatWithdrawal() {
+    EnergyBus bus = new EnergyBus("heat recovery", EnergyType.HEAT);
+    EnergyPort condenser = new EnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+    condenser.setOwnerName("condenser");
+    condenser.connect(bus);
+    condenser.setDuty(-1000.0);
+
+    EnergyPort heater = new EnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.BIDIRECTIONAL,
+        EnergyPortMode.SPECIFICATION);
+    heater.setOwnerName("heater");
+    heater.connect(bus);
+    heater.setDuty(heater.getPowerMagnitude());
+
+    assertEquals(1000.0, bus.getContribution("condenser.heatDuty"), 1.0e-12);
+    assertEquals(-1000.0, bus.getContribution("heater.heatDuty"), 1.0e-12);
+    assertEquals(0.0, bus.getNetPower(), 1.0e-12);
+  }
+
+  @Test
+  void testSerializationPreservesSharedBusIdentityAndMetadata() throws Exception {
+    EnergyBus bus = new EnergyBus("serialized bus", EnergyType.ELECTRICAL);
+    EnergyPort producer = new EnergyPort("power", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+    producer.setOwnerName("producer");
+    producer.connect(bus);
+    producer.setDuty(250.0);
+    EnergyPort consumer = new EnergyPort("power", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
+        EnergyPortMode.SPECIFICATION);
+    consumer.setOwnerName("consumer");
+    consumer.connect(bus);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(Arrays.asList(producer, consumer));
+    }
+
+    List<?> restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (List<?>) input.readObject();
+    }
+
+    EnergyPort restoredProducer = (EnergyPort) restored.get(0);
+    EnergyPort restoredConsumer = (EnergyPort) restored.get(1);
+    assertSame(restoredProducer.getEnergyStream(), restoredConsumer.getEnergyStream());
+    assertEquals(EnergyType.ELECTRICAL, restoredProducer.getEnergyType());
+    assertEquals(EnergyPortMode.SPECIFICATION, restoredConsumer.getMode());
+    assertEquals(250.0, restoredConsumer.getPowerMagnitude(), 1.0e-12);
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusTest.java
@@ -3,6 +3,8 @@ package neqsim.process.equipment.stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.battery.BatteryStorage;
+import neqsim.process.equipment.powergeneration.SolarPanel;
 
 class EnergyBusTest {
 
@@ -41,4 +43,27 @@ class EnergyBusTest {
     assertEquals(0.8, shaft.getNetPower("MW"), 1.0e-12);
     assertEquals(EnergyType.SHAFT_WORK, shaft.getEnergyType());
   }
+  @Test
+  void testEquipmentPortsPublishDirectedBusContributions() {
+    EnergyBus bus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);
+    SolarPanel solar = new SolarPanel("solar", 1000.0, 10.0, 0.20);
+    solar.connectEnergyStream("electricalPower", bus, EnergyPortMode.CALCULATED);
+    solar.run();
+
+    BatteryStorage battery = new BatteryStorage("battery", 10.0e6);
+    battery.connectEnergyStream("electricalPower", bus, EnergyPortMode.CALCULATED);
+    battery.charge(1000.0, 1.0);
+    battery.run();
+
+    assertEquals(2000.0, bus.getContribution("solar.electricalPower"), 1.0e-12);
+    assertEquals(-1000.0, bus.getContribution("battery.electricalPower"), 1.0e-12);
+    assertEquals(1000.0, bus.getNetPower(), 1.0e-12);
+
+    battery.discharge(500.0, 1.0);
+    battery.run();
+
+    assertEquals(500.0, bus.getContribution("battery.electricalPower"), 1.0e-12);
+    assertEquals(2500.0, bus.getNetPower(), 1.0e-12);
+  }
+
 }

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusTest.java
@@ -1,0 +1,44 @@
+package neqsim.process.equipment.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import org.junit.jupiter.api.Test;
+
+class EnergyBusTest {
+
+  @Test
+  void testAggregatesNamedContributionsAndBalanceDuty() {
+    EnergyBus bus = new EnergyBus("main electrical bus", EnergyType.ELECTRICAL);
+    bus.setDuty(25.0, "kW");
+    bus.setContribution("solar", 1.0, "MW");
+    bus.setContribution("electrolyzer", -250.0, "kW");
+
+    assertEquals(775.0, bus.getNetPower("kW"), 1.0e-12);
+    assertEquals(-250.0, bus.getContribution("electrolyzer", "kW"), 1.0e-12);
+  }
+
+  @Test
+  void testCloneHasIndependentContributionMap() {
+    EnergyBus bus = new EnergyBus("bus", EnergyType.HEAT);
+    bus.setContribution("heater", 100.0);
+
+    EnergyBus clone = bus.clone();
+    clone.setContribution("heater", 200.0);
+
+    assertNotSame(bus, clone);
+    assertEquals(100.0, bus.getContribution("heater"), 1.0e-12);
+    assertEquals(200.0, clone.getContribution("heater"), 1.0e-12);
+  }
+
+  @Test
+  void testMechanicalShaftBalancesGenerationAndLoad() {
+    MechanicalShaft shaft = new MechanicalShaft("compressor train");
+    shaft.setMechanicalEfficiency(0.98);
+    shaft.setGeneratedPower("expander", 10.0e6);
+    shaft.setConsumedPower("compressor", 8.5e6);
+    shaft.setConsumedPower("oil pump", 0.5e6);
+
+    assertEquals(0.8, shaft.getNetPower("MW"), 1.0e-12);
+    assertEquals(EnergyType.SHAFT_WORK, shaft.getEnergyType());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/stream/EnergyNetworkIntegrationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyNetworkIntegrationTest.java
@@ -1,0 +1,145 @@
+package neqsim.process.equipment.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.distillation.Condenser;
+import neqsim.process.equipment.electrolyzer.Electrolyzer;
+import neqsim.process.equipment.electrolyzer.ElectrolyzerIVCharacteristic;
+import neqsim.process.equipment.electrolyzer.ElectrolyzerTechnology;
+import neqsim.process.equipment.expander.Expander;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.powergeneration.SolarPanel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.Fluid;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+class EnergyNetworkIntegrationTest extends neqsim.NeqSimTest {
+
+  @Test
+  void testExpanderShaftDrivesCompressorAndRemainsStableOnRepeatRun() {
+    Stream expanderFeed = methaneFeed("expander feed", 100.0, 1.0);
+    Expander expander = new Expander("expander", expanderFeed);
+    expander.setOutletPressure(50.0);
+    expander.setIsentropicEfficiency(0.8);
+
+    Stream compressorFeed = methaneFeed("compressor feed", 10.0, 1.0);
+    Compressor compressor = new Compressor("compressor", compressorFeed);
+    compressor.setOutletPressure(20.0);
+    compressor.setIsentropicEfficiency(0.8);
+
+    MechanicalShaft shaft = new MechanicalShaft("expander compressor shaft");
+    expander.connectEnergyStream("shaftPower", shaft, EnergyPortMode.CALCULATED);
+    compressor.connectEnergyStream("shaftPower", shaft, EnergyPortMode.SPECIFICATION);
+
+    ProcessSystem process = graphOrderedProcess();
+    process.add(compressor);
+    process.add(compressorFeed);
+    process.add(expander);
+    process.add(expanderFeed);
+    process.runSequential(UUID.randomUUID());
+
+    double generatedPower = shaft.getContribution("expander.shaftPower");
+    double consumedPower = shaft.getContribution("compressor.shaftPower");
+    assertTrue(generatedPower > 0.0);
+    assertEquals(-generatedPower, consumedPower, Math.max(1.0, generatedPower * 1.0e-10));
+    assertEquals(0.0, shaft.getNetPower(), Math.max(1.0, generatedPower * 1.0e-10));
+
+    process.runSequential(UUID.randomUUID());
+
+    assertEquals(generatedPower, shaft.getContribution("expander.shaftPower"),
+        Math.max(1.0, generatedPower * 1.0e-10));
+    assertEquals(-generatedPower, shaft.getContribution("compressor.shaftPower"),
+        Math.max(1.0, generatedPower * 1.0e-10));
+  }
+
+  @Test
+  void testSolarBusDrivesElectrolyzerAndRemainsStableOnRepeatRun() {
+    SolarPanel solar = new SolarPanel("solar", 1000.0, 5000.0, 0.20);
+    Stream waterFeed = waterFeed();
+    Electrolyzer electrolyzer = new Electrolyzer("electrolyzer", waterFeed);
+    electrolyzer.setTechnology(ElectrolyzerTechnology.PEM);
+    electrolyzer.setIVCharacteristic(new ElectrolyzerIVCharacteristic(ElectrolyzerTechnology.PEM));
+    electrolyzer.sizeStack(1.0e6);
+
+    EnergyBus bus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);
+    solar.connectEnergyStream("electricalPower", bus, EnergyPortMode.CALCULATED);
+    electrolyzer.connectEnergyStream("electricalPower", bus, EnergyPortMode.SPECIFICATION);
+
+    ProcessSystem process = graphOrderedProcess();
+    process.add(electrolyzer);
+    process.add(waterFeed);
+    process.add(solar);
+    process.runSequential(UUID.randomUUID());
+
+    double firstStackPower = electrolyzer.getStackPower();
+    assertTrue(firstStackPower > 0.0);
+    assertTrue(electrolyzer.getHydrogenOutStream().getFlowRate("mole/sec") > 0.0);
+    assertEquals(1.0e6, bus.getContribution("solar.electricalPower"), 1.0e-6);
+    assertEquals(-firstStackPower, bus.getContribution("electrolyzer.electricalPower"),
+        Math.max(1.0, firstStackPower * 1.0e-10));
+
+    process.runSequential(UUID.randomUUID());
+
+    assertEquals(firstStackPower, electrolyzer.getStackPower(), Math.max(1.0, firstStackPower * 1.0e-10));
+    assertEquals(-firstStackPower, bus.getContribution("electrolyzer.electricalPower"),
+        Math.max(1.0, firstStackPower * 1.0e-10));
+  }
+
+  @Test
+  void testCondenserHeatRecoveryDrivesHeater() {
+    EnergyBus heatRecovery = new EnergyBus("heat recovery", EnergyType.HEAT);
+    Condenser condenser = new Condenser("condenser");
+    condenser.connectEnergyStream("heatDuty", heatRecovery, EnergyPortMode.CALCULATED);
+    condenser.getEnergyPort("heatDuty").setDuty(-200.0, "kW");
+
+    Stream heaterFeed = methaneFeed("heater feed", 20.0, 0.1);
+    double inletTemperature = heaterFeed.getTemperature("K");
+    Heater heater = new Heater("heater", heaterFeed);
+    heater.connectEnergyStream("heatDuty", heatRecovery, EnergyPortMode.SPECIFICATION);
+
+    heater.run();
+    double firstOutletTemperature = heater.getOutletStream().getTemperature("K");
+
+    assertTrue(firstOutletTemperature > inletTemperature);
+    assertEquals(200.0, heatRecovery.getContribution("condenser.heatDuty", "kW"), 1.0e-12);
+    assertEquals(-200.0, heatRecovery.getContribution("heater.heatDuty", "kW"), 1.0e-9);
+    assertEquals(0.0, heatRecovery.getNetPower("kW"), 1.0e-9);
+
+    heater.run();
+
+    assertEquals(firstOutletTemperature, heater.getOutletStream().getTemperature("K"), 1.0e-8);
+    assertEquals(0.0, heatRecovery.getNetPower("kW"), 1.0e-9);
+  }
+
+  private static ProcessSystem graphOrderedProcess() {
+    ProcessSystem process = new ProcessSystem();
+    process.setUseOptimizedExecution(false);
+    process.setUseGraphBasedExecution(true);
+    return process;
+  }
+
+  private static Stream methaneFeed(String name, double pressureBara, double flowMSm3Day) {
+    SystemInterface gas = new SystemSrkEos(298.15, pressureBara);
+    gas.addComponent("methane", 1.0);
+    gas.setMixingRule("classic");
+    Stream feed = new Stream(name, gas);
+    feed.setPressure(pressureBara, "bara");
+    feed.setFlowRate(flowMSm3Day, "MSm3/day");
+    feed.run();
+    return feed;
+  }
+
+  private static Stream waterFeed() {
+    SystemInterface water = new Fluid().create("water");
+    Stream feed = new Stream("water feed", water);
+    feed.setPressure(1.0, "bara");
+    feed.setTemperature(353.15, "K");
+    feed.setFlowRate(2.0, "mole/sec");
+    feed.run();
+    return feed;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/stream/EnergyNetworkIntegrationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyNetworkIntegrationTest.java
@@ -50,8 +50,7 @@ class EnergyNetworkIntegrationTest extends neqsim.NeqSimTest {
 
     process.runSequential(UUID.randomUUID());
 
-    assertEquals(generatedPower, shaft.getContribution("expander.shaftPower"),
-        Math.max(1.0, generatedPower * 1.0e-10));
+    assertEquals(generatedPower, shaft.getContribution("expander.shaftPower"), Math.max(1.0, generatedPower * 1.0e-10));
     assertEquals(-generatedPower, shaft.getContribution("compressor.shaftPower"),
         Math.max(1.0, generatedPower * 1.0e-10));
   }

--- a/src/test/java/neqsim/process/equipment/stream/EnergyNetworkIntegrationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyNetworkIntegrationTest.java
@@ -105,13 +105,13 @@ class EnergyNetworkIntegrationTest extends neqsim.NeqSimTest {
 
     assertTrue(firstOutletTemperature > inletTemperature);
     assertEquals(200.0, heatRecovery.getContribution("condenser.heatDuty", "kW"), 1.0e-12);
-    assertEquals(-200.0, heatRecovery.getContribution("heater.heatDuty", "kW"), 1.0e-9);
-    assertEquals(0.0, heatRecovery.getNetPower("kW"), 1.0e-9);
+    assertEquals(-200.0, heatRecovery.getContribution("heater.heatDuty", "kW"), 1.0e-3);
+    assertEquals(0.0, heatRecovery.getNetPower("kW"), 1.0e-3);
 
     heater.run();
 
-    assertEquals(firstOutletTemperature, heater.getOutletStream().getTemperature("K"), 1.0e-8);
-    assertEquals(0.0, heatRecovery.getNetPower("kW"), 1.0e-9);
+    assertEquals(firstOutletTemperature, heater.getOutletStream().getTemperature("K"), 1.0e-6);
+    assertEquals(0.0, heatRecovery.getNetPower("kW"), 1.0e-3);
   }
 
   private static ProcessSystem graphOrderedProcess() {

--- a/src/test/java/neqsim/process/equipment/stream/EnergyPortCoverageTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyPortCoverageTest.java
@@ -30,147 +30,60 @@ class EnergyPortCoverageTest {
 
   @Test
   void testRotatingEquipmentPorts() {
-    assertPort(
-        new Pump("pump"),
-        "shaftPower",
-        EnergyType.SHAFT_WORK,
-        EnergyPortDirection.INPUT,
+    assertPort(new Pump("pump"), "shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.INPUT,
         EnergyPortMode.CALCULATED);
-    assertPort(
-        new Compressor("compressor"),
-        "shaftPower",
-        EnergyType.SHAFT_WORK,
-        EnergyPortDirection.INPUT,
+    assertPort(new Compressor("compressor"), "shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.INPUT,
         EnergyPortMode.CALCULATED);
-    assertPort(
-        new Expander("expander"),
-        "shaftPower",
-        EnergyType.SHAFT_WORK,
-        EnergyPortDirection.OUTPUT,
+    assertPort(new Expander("expander"), "shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.OUTPUT,
         EnergyPortMode.CALCULATED);
-    assertPort(
-        new SteamTurbine("steam turbine"),
-        "shaftPower",
-        EnergyType.SHAFT_WORK,
-        EnergyPortDirection.OUTPUT,
+    assertPort(new SteamTurbine("steam turbine"), "shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.OUTPUT,
         EnergyPortMode.CALCULATED);
-    assertPort(
-        new GasTurbine("gas turbine"),
-        "shaftPower",
-        EnergyType.SHAFT_WORK,
-        EnergyPortDirection.OUTPUT,
+    assertPort(new GasTurbine("gas turbine"), "shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.OUTPUT,
         EnergyPortMode.CALCULATED);
-    assertPort(
-        new GasTurbineUnit("catalogue gas turbine"),
-        "shaftPower",
-        EnergyType.SHAFT_WORK,
-        EnergyPortDirection.OUTPUT,
-        EnergyPortMode.CALCULATED);
+    assertPort(new GasTurbineUnit("catalogue gas turbine"), "shaftPower", EnergyType.SHAFT_WORK,
+        EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
   }
 
   @Test
   void testThermalEquipmentPorts() {
-    assertPort(
-        new Heater("heater"),
-        "heatDuty",
-        EnergyType.HEAT,
-        EnergyPortDirection.BIDIRECTIONAL,
+    assertPort(new Heater("heater"), "heatDuty", EnergyType.HEAT, EnergyPortDirection.BIDIRECTIONAL,
         EnergyPortMode.CALCULATED);
-    assertPort(
-        new Cooler("cooler"),
-        "heatDuty",
-        EnergyType.HEAT,
-        EnergyPortDirection.BIDIRECTIONAL,
+    assertPort(new Cooler("cooler"), "heatDuty", EnergyType.HEAT, EnergyPortDirection.BIDIRECTIONAL,
         EnergyPortMode.CALCULATED);
-    assertPort(
-        new Condenser("condenser"),
-        "heatDuty",
-        EnergyType.HEAT,
-        EnergyPortDirection.OUTPUT,
+    assertPort(new Condenser("condenser"), "heatDuty", EnergyType.HEAT, EnergyPortDirection.OUTPUT,
         EnergyPortMode.CALCULATED);
-    assertPort(
-        new Reboiler("reboiler"),
-        "heatDuty",
-        EnergyType.HEAT,
-        EnergyPortDirection.INPUT,
+    assertPort(new Reboiler("reboiler"), "heatDuty", EnergyType.HEAT, EnergyPortDirection.INPUT,
         EnergyPortMode.CALCULATED);
-    assertPort(
-        new AmmoniaSynthesisReactor("ammonia reactor"),
-        "reactionHeat",
-        EnergyType.HEAT,
-        EnergyPortDirection.OUTPUT,
-        EnergyPortMode.CALCULATED);
+    assertPort(new AmmoniaSynthesisReactor("ammonia reactor"), "reactionHeat", EnergyType.HEAT,
+        EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
     StirredTankReactor reactor = new StirredTankReactor("CSTR");
-    assertPort(
-        reactor,
-        "heatDuty",
-        EnergyType.HEAT,
-        EnergyPortDirection.BIDIRECTIONAL,
-        EnergyPortMode.CALCULATED);
-    assertPort(
-        reactor,
-        "agitatorPower",
-        EnergyType.ELECTRICAL,
-        EnergyPortDirection.INPUT,
-        EnergyPortMode.CALCULATED);
-    assertPort(
-        new GasTurbine("gas turbine"),
-        "exhaustHeat",
-        EnergyType.HEAT,
-        EnergyPortDirection.OUTPUT,
+    assertPort(reactor, "heatDuty", EnergyType.HEAT, EnergyPortDirection.BIDIRECTIONAL, EnergyPortMode.CALCULATED);
+    assertPort(reactor, "agitatorPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
+    assertPort(new GasTurbine("gas turbine"), "exhaustHeat", EnergyType.HEAT, EnergyPortDirection.OUTPUT,
         EnergyPortMode.CALCULATED);
   }
 
   @Test
   void testElectricalEquipmentPorts() {
-    ProcessEquipmentBaseClass[] generators = {
-      new SolarPanel("solar"),
-      new WindTurbine("wind turbine"),
-      new WindFarm("wind farm"),
-      new FuelCell("fuel cell"),
-      new CombinedCycleSystem("combined cycle")
-    };
+    ProcessEquipmentBaseClass[] generators = { new SolarPanel("solar"), new WindTurbine("wind turbine"),
+        new WindFarm("wind farm"), new FuelCell("fuel cell"), new CombinedCycleSystem("combined cycle") };
     for (ProcessEquipmentBaseClass generator : generators) {
-      assertPort(
-          generator,
-          "electricalPower",
-          EnergyType.ELECTRICAL,
-          EnergyPortDirection.OUTPUT,
+      assertPort(generator, "electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
           EnergyPortMode.CALCULATED);
     }
 
-    assertPort(
-        new BatteryStorage("battery"),
-        "electricalPower",
-        EnergyType.ELECTRICAL,
-        EnergyPortDirection.BIDIRECTIONAL,
+    assertPort(new BatteryStorage("battery"), "electricalPower", EnergyType.ELECTRICAL,
+        EnergyPortDirection.BIDIRECTIONAL, EnergyPortMode.CALCULATED);
+    assertPort(new Electrolyzer("electrolyzer"), "electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
         EnergyPortMode.CALCULATED);
-    assertPort(
-        new Electrolyzer("electrolyzer"),
-        "electricalPower",
-        EnergyType.ELECTRICAL,
-        EnergyPortDirection.INPUT,
-        EnergyPortMode.CALCULATED);
-    assertPort(
-        new CO2Electrolyzer("CO2 electrolyzer"),
-        "electricalPower",
-        EnergyType.ELECTRICAL,
-        EnergyPortDirection.INPUT,
-        EnergyPortMode.CALCULATED);
-    assertPort(
-        new BioFeedstockPreparation("feed preparation"),
-        "electricalPower",
-        EnergyType.ELECTRICAL,
-        EnergyPortDirection.INPUT,
-        EnergyPortMode.CALCULATED);
+    assertPort(new CO2Electrolyzer("CO2 electrolyzer"), "electricalPower", EnergyType.ELECTRICAL,
+        EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
+    assertPort(new BioFeedstockPreparation("feed preparation"), "electricalPower", EnergyType.ELECTRICAL,
+        EnergyPortDirection.INPUT, EnergyPortMode.CALCULATED);
   }
 
-  private static void assertPort(
-      ProcessEquipmentBaseClass equipment,
-      String portName,
-      EnergyType type,
-      EnergyPortDirection direction,
-      EnergyPortMode mode) {
+  private static void assertPort(ProcessEquipmentBaseClass equipment, String portName, EnergyType type,
+      EnergyPortDirection direction, EnergyPortMode mode) {
     EnergyPort port = equipment.getEnergyPort(portName);
     assertNotNull(port);
     assertEquals(type, port.getEnergyType());

--- a/src/test/java/neqsim/process/equipment/stream/EnergyPortCoverageTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyPortCoverageTest.java
@@ -1,0 +1,145 @@
+package neqsim.process.equipment.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.battery.BatteryStorage;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.distillation.Condenser;
+import neqsim.process.equipment.distillation.Reboiler;
+import neqsim.process.equipment.electrolyzer.CO2Electrolyzer;
+import neqsim.process.equipment.electrolyzer.Electrolyzer;
+import neqsim.process.equipment.expander.Expander;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.powergeneration.FuelCell;
+import neqsim.process.equipment.powergeneration.SolarPanel;
+import neqsim.process.equipment.powergeneration.SteamTurbine;
+import neqsim.process.equipment.powergeneration.WindFarm;
+import neqsim.process.equipment.powergeneration.WindTurbine;
+import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.reactor.AmmoniaSynthesisReactor;
+import neqsim.process.equipment.solidhandling.BioFeedstockPreparation;
+
+class EnergyPortCoverageTest {
+
+  @Test
+  void testRotatingEquipmentPorts() {
+    assertPort(
+        new Pump("pump"),
+        "shaftPower",
+        EnergyType.SHAFT_WORK,
+        EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new Compressor("compressor"),
+        "shaftPower",
+        EnergyType.SHAFT_WORK,
+        EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new Expander("expander"),
+        "shaftPower",
+        EnergyType.SHAFT_WORK,
+        EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new SteamTurbine("steam turbine"),
+        "shaftPower",
+        EnergyType.SHAFT_WORK,
+        EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+  }
+
+  @Test
+  void testThermalEquipmentPorts() {
+    assertPort(
+        new Heater("heater"),
+        "heatDuty",
+        EnergyType.HEAT,
+        EnergyPortDirection.BIDIRECTIONAL,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new Cooler("cooler"),
+        "heatDuty",
+        EnergyType.HEAT,
+        EnergyPortDirection.BIDIRECTIONAL,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new Condenser("condenser"),
+        "heatDuty",
+        EnergyType.HEAT,
+        EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new Reboiler("reboiler"),
+        "heatDuty",
+        EnergyType.HEAT,
+        EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new AmmoniaSynthesisReactor("ammonia reactor"),
+        "reactionHeat",
+        EnergyType.HEAT,
+        EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+  }
+
+  @Test
+  void testElectricalEquipmentPorts() {
+    ProcessEquipmentBaseClass[] generators = {
+      new SolarPanel("solar"),
+      new WindTurbine("wind turbine"),
+      new WindFarm("wind farm"),
+      new FuelCell("fuel cell")
+    };
+    for (ProcessEquipmentBaseClass generator : generators) {
+      assertPort(
+          generator,
+          "electricalPower",
+          EnergyType.ELECTRICAL,
+          EnergyPortDirection.OUTPUT,
+          EnergyPortMode.CALCULATED);
+    }
+
+    assertPort(
+        new BatteryStorage("battery"),
+        "electricalPower",
+        EnergyType.ELECTRICAL,
+        EnergyPortDirection.BIDIRECTIONAL,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new Electrolyzer("electrolyzer"),
+        "electricalPower",
+        EnergyType.ELECTRICAL,
+        EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new CO2Electrolyzer("CO2 electrolyzer"),
+        "electricalPower",
+        EnergyType.ELECTRICAL,
+        EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new BioFeedstockPreparation("feed preparation"),
+        "electricalPower",
+        EnergyType.ELECTRICAL,
+        EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
+  }
+
+  private static void assertPort(
+      ProcessEquipmentBaseClass equipment,
+      String portName,
+      EnergyType type,
+      EnergyPortDirection direction,
+      EnergyPortMode mode) {
+    EnergyPort port = equipment.getEnergyPort(portName);
+    assertNotNull(port);
+    assertEquals(type, port.getEnergyType());
+    assertEquals(direction, port.getDirection());
+    assertEquals(mode, port.getMode());
+    assertEquals(type, equipment.getEnergyStream().getEnergyType());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/stream/EnergyPortCoverageTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyPortCoverageTest.java
@@ -13,13 +13,17 @@ import neqsim.process.equipment.electrolyzer.Electrolyzer;
 import neqsim.process.equipment.expander.Expander;
 import neqsim.process.equipment.heatexchanger.Cooler;
 import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.powergeneration.CombinedCycleSystem;
 import neqsim.process.equipment.powergeneration.FuelCell;
+import neqsim.process.equipment.powergeneration.GasTurbine;
 import neqsim.process.equipment.powergeneration.SolarPanel;
 import neqsim.process.equipment.powergeneration.SteamTurbine;
 import neqsim.process.equipment.powergeneration.WindFarm;
 import neqsim.process.equipment.powergeneration.WindTurbine;
+import neqsim.process.equipment.powergeneration.gasturbine.GasTurbineUnit;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.reactor.AmmoniaSynthesisReactor;
+import neqsim.process.equipment.reactor.StirredTankReactor;
 import neqsim.process.equipment.solidhandling.BioFeedstockPreparation;
 
 class EnergyPortCoverageTest {
@@ -46,6 +50,18 @@ class EnergyPortCoverageTest {
         EnergyPortMode.CALCULATED);
     assertPort(
         new SteamTurbine("steam turbine"),
+        "shaftPower",
+        EnergyType.SHAFT_WORK,
+        EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new GasTurbine("gas turbine"),
+        "shaftPower",
+        EnergyType.SHAFT_WORK,
+        EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new GasTurbineUnit("catalogue gas turbine"),
         "shaftPower",
         EnergyType.SHAFT_WORK,
         EnergyPortDirection.OUTPUT,
@@ -84,6 +100,25 @@ class EnergyPortCoverageTest {
         EnergyType.HEAT,
         EnergyPortDirection.OUTPUT,
         EnergyPortMode.CALCULATED);
+    StirredTankReactor reactor = new StirredTankReactor("CSTR");
+    assertPort(
+        reactor,
+        "heatDuty",
+        EnergyType.HEAT,
+        EnergyPortDirection.BIDIRECTIONAL,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        reactor,
+        "agitatorPower",
+        EnergyType.ELECTRICAL,
+        EnergyPortDirection.INPUT,
+        EnergyPortMode.CALCULATED);
+    assertPort(
+        new GasTurbine("gas turbine"),
+        "exhaustHeat",
+        EnergyType.HEAT,
+        EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
   }
 
   @Test
@@ -92,7 +127,8 @@ class EnergyPortCoverageTest {
       new SolarPanel("solar"),
       new WindTurbine("wind turbine"),
       new WindFarm("wind farm"),
-      new FuelCell("fuel cell")
+      new FuelCell("fuel cell"),
+      new CombinedCycleSystem("combined cycle")
     };
     for (ProcessEquipmentBaseClass generator : generators) {
       assertPort(
@@ -140,6 +176,8 @@ class EnergyPortCoverageTest {
     assertEquals(type, port.getEnergyType());
     assertEquals(direction, port.getDirection());
     assertEquals(mode, port.getMode());
-    assertEquals(type, equipment.getEnergyStream().getEnergyType());
+    if (port.isConnected()) {
+      assertEquals(type, port.getEnergyStream().getEnergyType());
+    }
   }
 }

--- a/src/test/java/neqsim/process/equipment/stream/EnergyPortTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyPortTest.java
@@ -118,8 +118,7 @@ class EnergyPortTest {
 
     private TestEquipment(String name) {
       super(name);
-      registerEnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.BIDIRECTIONAL,
-          EnergyPortMode.CALCULATED);
+      registerEnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.BIDIRECTIONAL, EnergyPortMode.CALCULATED);
     }
 
     @Override

--- a/src/test/java/neqsim/process/equipment/stream/EnergyPortTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyPortTest.java
@@ -1,0 +1,68 @@
+package neqsim.process.equipment.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+class EnergyPortTest {
+
+  @Test
+  void testConnectAdoptsPortEnergyType() {
+    EnergyPort port =
+        new EnergyPort(
+            "shaftPower",
+            EnergyType.SHAFT_WORK,
+            EnergyPortDirection.INPUT,
+            EnergyPortMode.SPECIFICATION);
+    EnergyStream stream = new EnergyStream("driver");
+
+    port.connect(stream);
+
+    assertTrue(port.isConnected());
+    assertSame(stream, port.getEnergyStream());
+    assertEquals(EnergyType.SHAFT_WORK, stream.getEnergyType());
+  }
+
+  @Test
+  void testRejectsIncompatibleEnergyType() {
+    EnergyPort heatPort =
+        new EnergyPort(
+            "heatDuty",
+            EnergyType.HEAT,
+            EnergyPortDirection.INPUT,
+            EnergyPortMode.SPECIFICATION);
+    EnergyStream electricalStream =
+        new EnergyStream("electrical", EnergyType.ELECTRICAL);
+
+    assertThrows(IllegalArgumentException.class, () -> heatPort.connect(electricalStream));
+  }
+
+  @Test
+  void testUnitAwareDutyDelegation() {
+    EnergyPort port =
+        new EnergyPort(
+            "generator",
+            EnergyType.ELECTRICAL,
+            EnergyPortDirection.OUTPUT,
+            EnergyPortMode.CALCULATED);
+    port.connect(new EnergyStream("power"));
+
+    port.setDuty(750.0, "kW");
+
+    assertEquals(0.75, port.getDuty("MW"), 1e-12);
+  }
+
+  @Test
+  void testUnconnectedDutyAccessFailsClearly() {
+    EnergyPort port =
+        new EnergyPort(
+            "heatDuty",
+            EnergyType.HEAT,
+            EnergyPortDirection.INPUT,
+            EnergyPortMode.SPECIFICATION);
+
+    assertThrows(IllegalStateException.class, port::getDuty);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/stream/EnergyPortTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyPortTest.java
@@ -10,12 +10,8 @@ class EnergyPortTest {
 
   @Test
   void testConnectAdoptsPortEnergyType() {
-    EnergyPort port =
-        new EnergyPort(
-            "shaftPower",
-            EnergyType.SHAFT_WORK,
-            EnergyPortDirection.INPUT,
-            EnergyPortMode.SPECIFICATION);
+    EnergyPort port = new EnergyPort("shaftPower", EnergyType.SHAFT_WORK, EnergyPortDirection.INPUT,
+        EnergyPortMode.SPECIFICATION);
     EnergyStream stream = new EnergyStream("driver");
 
     port.connect(stream);
@@ -27,26 +23,17 @@ class EnergyPortTest {
 
   @Test
   void testRejectsIncompatibleEnergyType() {
-    EnergyPort heatPort =
-        new EnergyPort(
-            "heatDuty",
-            EnergyType.HEAT,
-            EnergyPortDirection.INPUT,
-            EnergyPortMode.SPECIFICATION);
-    EnergyStream electricalStream =
-        new EnergyStream("electrical", EnergyType.ELECTRICAL);
+    EnergyPort heatPort = new EnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.INPUT,
+        EnergyPortMode.SPECIFICATION);
+    EnergyStream electricalStream = new EnergyStream("electrical", EnergyType.ELECTRICAL);
 
     assertThrows(IllegalArgumentException.class, () -> heatPort.connect(electricalStream));
   }
 
   @Test
   void testUnitAwareDutyDelegation() {
-    EnergyPort port =
-        new EnergyPort(
-            "generator",
-            EnergyType.ELECTRICAL,
-            EnergyPortDirection.OUTPUT,
-            EnergyPortMode.CALCULATED);
+    EnergyPort port = new EnergyPort("generator", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
     port.connect(new EnergyStream("power"));
 
     port.setDuty(750.0, "kW");
@@ -56,12 +43,8 @@ class EnergyPortTest {
 
   @Test
   void testUnconnectedDutyAccessFailsClearly() {
-    EnergyPort port =
-        new EnergyPort(
-            "heatDuty",
-            EnergyType.HEAT,
-            EnergyPortDirection.INPUT,
-            EnergyPortMode.SPECIFICATION);
+    EnergyPort port = new EnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.INPUT,
+        EnergyPortMode.SPECIFICATION);
 
     assertThrows(IllegalStateException.class, port::getDuty);
   }

--- a/src/test/java/neqsim/process/equipment/stream/EnergyPortTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyPortTest.java
@@ -1,10 +1,14 @@
 package neqsim.process.equipment.stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
 
 class EnergyPortTest {
 
@@ -31,6 +35,66 @@ class EnergyPortTest {
   }
 
   @Test
+  void testRejectedReconnectPreservesBusConnectionAndContribution() {
+    EnergyPort heatPort = new EnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+    heatPort.setOwnerName("heater");
+    EnergyBus heatBus = new EnergyBus("heat bus", EnergyType.HEAT);
+    heatPort.connect(heatBus);
+    heatPort.setDuty(100.0);
+
+    EnergyStream electricalStream = new EnergyStream("electrical", EnergyType.ELECTRICAL);
+
+    assertThrows(IllegalArgumentException.class, () -> heatPort.connect(electricalStream));
+    assertSame(heatBus, heatPort.getEnergyStream());
+    assertEquals(100.0, heatBus.getContribution("heater.heatDuty"), 1e-12);
+  }
+
+  @Test
+  void testRejectedLegacySetPreservesInternalConnection() {
+    TestEquipment equipment = new TestEquipment("heater");
+    EnergyStream internalStream = equipment.getEnergyStream();
+    EnergyStream electricalStream = new EnergyStream("electrical", EnergyType.ELECTRICAL);
+
+    assertThrows(IllegalArgumentException.class, () -> equipment.setEnergyStream(electricalStream));
+
+    assertSame(internalStream, equipment.getEnergyStream());
+    assertSame(internalStream, equipment.getEnergyPort("heatDuty").getEnergyStream());
+    assertFalse(equipment.isSetEnergyStream());
+  }
+
+  @Test
+  void testDisconnectRestoresInternalLegacyStream() {
+    TestEquipment equipment = new TestEquipment("heater");
+    EnergyStream externalStream = new EnergyStream("external heat", EnergyType.HEAT);
+    externalStream.setDuty(42.0);
+
+    equipment.connectEnergyStream("heatDuty", externalStream, EnergyPortMode.SPECIFICATION);
+    assertTrue(equipment.isSetEnergyStream());
+    assertSame(externalStream, equipment.getEnergyStream());
+
+    equipment.disconnectEnergyStream("heatDuty");
+
+    assertFalse(equipment.isSetEnergyStream());
+    assertNotSame(externalStream, equipment.getEnergyStream());
+    assertSame(equipment.getEnergyStream(), equipment.getEnergyPort("heatDuty").getEnergyStream());
+    assertEquals(EnergyType.HEAT, equipment.getEnergyStream().getEnergyType());
+
+    equipment.getEnergyPort("heatDuty").setDuty(10.0);
+    assertEquals(42.0, externalStream.getDuty(), 1e-12);
+  }
+
+  @Test
+  void testCalculatedExternalConnectionIsNotSpecification() {
+    TestEquipment equipment = new TestEquipment("heater");
+    EnergyStream externalStream = new EnergyStream("external heat", EnergyType.HEAT);
+
+    equipment.connectEnergyStream("heatDuty", externalStream, EnergyPortMode.CALCULATED);
+
+    assertFalse(equipment.isSetEnergyStream());
+  }
+
+  @Test
   void testUnitAwareDutyDelegation() {
     EnergyPort port = new EnergyPort("generator", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
         EnergyPortMode.CALCULATED);
@@ -47,5 +111,20 @@ class EnergyPortTest {
         EnergyPortMode.SPECIFICATION);
 
     assertThrows(IllegalStateException.class, port::getDuty);
+  }
+
+  private static final class TestEquipment extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+
+    private TestEquipment(String name) {
+      super(name);
+      registerEnergyPort("heatDuty", EnergyType.HEAT, EnergyPortDirection.BIDIRECTIONAL,
+          EnergyPortMode.CALCULATED);
+    }
+
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
   }
 }

--- a/src/test/java/neqsim/process/equipment/stream/EnergyStreamTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyStreamTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.process.ProcessElementInterface;
 
 class EnergyStreamTest {
 
@@ -121,4 +122,23 @@ class EnergyStreamTest {
 
     assertEquals(a.hashCode(), b.hashCode());
   }
+  @Test
+  void testUnitAwareEnergyFlowAliases() {
+    EnergyStream stream = new EnergyStream("motor-power", EnergyType.ELECTRICAL);
+    stream.setEnergyFlow(1.5, "MW");
+
+    assertEquals(1.5e6, stream.getDuty(), 1e-10);
+    assertEquals(1500.0, stream.getPower("kW"), 1e-10);
+    assertEquals(1.5, stream.getEnergyFlow("MW"), 1e-10);
+  }
+
+  @Test
+  void testEnergyStreamIsProcessElement() {
+    ProcessElementInterface element =
+        new EnergyStream("shaft-work", EnergyType.SHAFT_WORK);
+
+    assertEquals("shaft-work", element.getName());
+    assertEquals(EnergyType.SHAFT_WORK, ((EnergyStream) element).getEnergyType());
+  }
+
 }

--- a/src/test/java/neqsim/process/equipment/stream/EnergyStreamTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyStreamTest.java
@@ -122,6 +122,7 @@ class EnergyStreamTest {
 
     assertEquals(a.hashCode(), b.hashCode());
   }
+
   @Test
   void testUnitAwareEnergyFlowAliases() {
     EnergyStream stream = new EnergyStream("motor-power", EnergyType.ELECTRICAL);
@@ -134,8 +135,7 @@ class EnergyStreamTest {
 
   @Test
   void testEnergyStreamIsProcessElement() {
-    ProcessElementInterface element =
-        new EnergyStream("shaft-work", EnergyType.SHAFT_WORK);
+    ProcessElementInterface element = new EnergyStream("shaft-work", EnergyType.SHAFT_WORK);
 
     assertEquals("shaft-work", element.getName());
     assertEquals(EnergyType.SHAFT_WORK, ((EnergyStream) element).getEnergyType());

--- a/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
+++ b/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
@@ -43,14 +43,11 @@ class EnergyStreamGraphTest {
   @Test
   void testEnergyBusSupportsMultipleProducersAndConsumers() {
     EnergyBus bus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);
-    EnergyUnit solar =
-        new EnergyUnit("solar", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
-    EnergyUnit wind =
-        new EnergyUnit("wind", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
-    EnergyUnit electrolyzer =
-        new EnergyUnit("electrolyzer", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
-    EnergyUnit heater =
-        new EnergyUnit("heater", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    EnergyUnit solar = new EnergyUnit("solar", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
+    EnergyUnit wind = new EnergyUnit("wind", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
+    EnergyUnit electrolyzer = new EnergyUnit("electrolyzer", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION,
+        bus);
+    EnergyUnit heater = new EnergyUnit("heater", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
     ProcessSystem process = new ProcessSystem();
     process.add(electrolyzer);
     process.add(heater);
@@ -59,24 +56,19 @@ class EnergyStreamGraphTest {
 
     ProcessGraph graph = ProcessGraphBuilder.buildGraph(process);
 
-    long energyEdges =
-        graph.getEdges().stream()
-            .filter(edge -> edge.getEdgeType() == ProcessEdge.EdgeType.ENERGY)
-            .count();
+    long energyEdges = graph.getEdges().stream().filter(edge -> edge.getEdgeType() == ProcessEdge.EdgeType.ENERGY)
+        .count();
     assertEquals(4L, energyEdges);
   }
 
   @Test
   void testPointToPointStreamRejectsMultipleConsumers() {
     EnergyStream shaft = new EnergyStream("single shaft", EnergyType.SHAFT_WORK);
-    EnergyUnit expander =
-        new EnergyUnit("expander", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, shaft);
-    EnergyUnit compressorA =
-        new EnergyUnit(
-            "compressor A", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, shaft);
-    EnergyUnit compressorB =
-        new EnergyUnit(
-            "compressor B", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, shaft);
+    EnergyUnit expander = new EnergyUnit("expander", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, shaft);
+    EnergyUnit compressorA = new EnergyUnit("compressor A", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION,
+        shaft);
+    EnergyUnit compressorB = new EnergyUnit("compressor B", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION,
+        shaft);
     ProcessSystem process = new ProcessSystem();
     process.add(expander);
     process.add(compressorA);

--- a/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
+++ b/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
@@ -1,0 +1,71 @@
+package neqsim.process.processmodel.graph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyStream;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.processmodel.ProcessSystem;
+
+class EnergyStreamGraphTest {
+
+  @Test
+  void testCalculatedEnergyPortOrdersSpecificationConsumer() {
+    EnergyStream shaft = new EnergyStream("shared-shaft", EnergyType.SHAFT_WORK);
+    EnergyUnit expander =
+        new EnergyUnit(
+            "expander",
+            EnergyPortDirection.OUTPUT,
+            EnergyPortMode.CALCULATED,
+            shaft);
+    EnergyUnit compressor =
+        new EnergyUnit(
+            "compressor",
+            EnergyPortDirection.INPUT,
+            EnergyPortMode.SPECIFICATION,
+            shaft);
+    ProcessSystem process = new ProcessSystem();
+    process.add(compressor);
+    process.add(expander);
+
+    ProcessGraph graph = ProcessGraphBuilder.buildGraph(process);
+
+    ProcessEdge energyEdge =
+        graph.getEdges().stream()
+            .filter(edge -> edge.getEdgeType() == ProcessEdge.EdgeType.ENERGY)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Expected an energy dependency"));
+    assertSame(shaft, energyEdge.getEnergyStream());
+    assertEquals("expander", energyEdge.getSource().getName());
+    assertEquals("compressor", energyEdge.getTarget().getName());
+
+    List<ProcessEquipmentInterface> order = graph.getCalculationOrder();
+    assertTrue(order.indexOf(expander) < order.indexOf(compressor));
+  }
+
+  private static final class EnergyUnit extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+
+    EnergyUnit(
+        String name,
+        EnergyPortDirection direction,
+        EnergyPortMode mode,
+        EnergyStream stream) {
+      super(name);
+      registerEnergyPort("energy", EnergyType.SHAFT_WORK, direction, mode);
+      connectEnergyStream("energy", stream);
+    }
+
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
+++ b/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
@@ -19,29 +19,17 @@ class EnergyStreamGraphTest {
   @Test
   void testCalculatedEnergyPortOrdersSpecificationConsumer() {
     EnergyStream shaft = new EnergyStream("shared-shaft", EnergyType.SHAFT_WORK);
-    EnergyUnit expander =
-        new EnergyUnit(
-            "expander",
-            EnergyPortDirection.OUTPUT,
-            EnergyPortMode.CALCULATED,
-            shaft);
-    EnergyUnit compressor =
-        new EnergyUnit(
-            "compressor",
-            EnergyPortDirection.INPUT,
-            EnergyPortMode.SPECIFICATION,
-            shaft);
+    EnergyUnit expander = new EnergyUnit("expander", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, shaft);
+    EnergyUnit compressor = new EnergyUnit("compressor", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION,
+        shaft);
     ProcessSystem process = new ProcessSystem();
     process.add(compressor);
     process.add(expander);
 
     ProcessGraph graph = ProcessGraphBuilder.buildGraph(process);
 
-    ProcessEdge energyEdge =
-        graph.getEdges().stream()
-            .filter(edge -> edge.getEdgeType() == ProcessEdge.EdgeType.ENERGY)
-            .findFirst()
-            .orElseThrow(() -> new AssertionError("Expected an energy dependency"));
+    ProcessEdge energyEdge = graph.getEdges().stream().filter(edge -> edge.getEdgeType() == ProcessEdge.EdgeType.ENERGY)
+        .findFirst().orElseThrow(() -> new AssertionError("Expected an energy dependency"));
     assertSame(shaft, energyEdge.getEnergyStream());
     assertEquals("expander", energyEdge.getSource().getName());
     assertEquals("compressor", energyEdge.getTarget().getName());
@@ -53,11 +41,7 @@ class EnergyStreamGraphTest {
   private static final class EnergyUnit extends ProcessEquipmentBaseClass {
     private static final long serialVersionUID = 1000L;
 
-    EnergyUnit(
-        String name,
-        EnergyPortDirection direction,
-        EnergyPortMode mode,
-        EnergyStream stream) {
+    EnergyUnit(String name, EnergyPortDirection direction, EnergyPortMode mode, EnergyStream stream) {
       super(name);
       registerEnergyPort("energy", EnergyType.SHAFT_WORK, direction, mode);
       connectEnergyStream("energy", stream);

--- a/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
+++ b/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
@@ -90,7 +90,7 @@ class EnergyStreamGraphTest {
 
     EnergyUnit(String name, EnergyPortDirection direction, EnergyPortMode mode, EnergyStream stream) {
       super(name);
-      registerEnergyPort("energy", EnergyType.SHAFT_WORK, direction, mode);
+      registerEnergyPort("energy", stream.getEnergyType(), direction, mode);
       connectEnergyStream("energy", stream);
     }
 

--- a/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
+++ b/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,25 @@ class EnergyStreamGraphTest {
 
     List<ProcessEquipmentInterface> order = graph.getCalculationOrder();
     assertTrue(order.indexOf(expander) < order.indexOf(compressor));
+  }
+
+  @Test
+  void testGraphExecutionIsIndependentOfInsertionOrder() {
+    EnergyStream heat = new EnergyStream("recovered heat", EnergyType.HEAT);
+    List<String> runOrder = new ArrayList<String>();
+    EnergyUnit producer = new EnergyUnit("producer", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, heat,
+        runOrder);
+    EnergyUnit consumer = new EnergyUnit("consumer", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, heat,
+        runOrder);
+    ProcessSystem process = new ProcessSystem();
+    process.add(consumer);
+    process.add(producer);
+    process.setUseOptimizedExecution(false);
+    process.setUseGraphBasedExecution(true);
+
+    process.runSequential(UUID.randomUUID());
+
+    assertEquals(Arrays.asList("producer", "consumer"), runOrder);
   }
 
   @Test
@@ -79,15 +100,25 @@ class EnergyStreamGraphTest {
 
   private static final class EnergyUnit extends ProcessEquipmentBaseClass {
     private static final long serialVersionUID = 1000L;
+    private final List<String> runOrder;
 
     EnergyUnit(String name, EnergyPortDirection direction, EnergyPortMode mode, EnergyStream stream) {
+      this(name, direction, mode, stream, null);
+    }
+
+    EnergyUnit(String name, EnergyPortDirection direction, EnergyPortMode mode, EnergyStream stream,
+        List<String> runOrder) {
       super(name);
+      this.runOrder = runOrder;
       registerEnergyPort("energy", stream.getEnergyType(), direction, mode);
       connectEnergyStream("energy", stream);
     }
 
     @Override
     public void run(UUID id) {
+      if (runOrder != null) {
+        runOrder.add(getName());
+      }
       setCalculationIdentifier(id);
     }
   }

--- a/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
+++ b/src/test/java/neqsim/process/processmodel/graph/EnergyStreamGraphTest.java
@@ -2,12 +2,14 @@ package neqsim.process.processmodel.graph;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.stream.EnergyBus;
 import neqsim.process.equipment.stream.EnergyPortDirection;
 import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyStream;
@@ -36,6 +38,51 @@ class EnergyStreamGraphTest {
 
     List<ProcessEquipmentInterface> order = graph.getCalculationOrder();
     assertTrue(order.indexOf(expander) < order.indexOf(compressor));
+  }
+
+  @Test
+  void testEnergyBusSupportsMultipleProducersAndConsumers() {
+    EnergyBus bus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);
+    EnergyUnit solar =
+        new EnergyUnit("solar", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
+    EnergyUnit wind =
+        new EnergyUnit("wind", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
+    EnergyUnit electrolyzer =
+        new EnergyUnit("electrolyzer", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    EnergyUnit heater =
+        new EnergyUnit("heater", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    ProcessSystem process = new ProcessSystem();
+    process.add(electrolyzer);
+    process.add(heater);
+    process.add(solar);
+    process.add(wind);
+
+    ProcessGraph graph = ProcessGraphBuilder.buildGraph(process);
+
+    long energyEdges =
+        graph.getEdges().stream()
+            .filter(edge -> edge.getEdgeType() == ProcessEdge.EdgeType.ENERGY)
+            .count();
+    assertEquals(4L, energyEdges);
+  }
+
+  @Test
+  void testPointToPointStreamRejectsMultipleConsumers() {
+    EnergyStream shaft = new EnergyStream("single shaft", EnergyType.SHAFT_WORK);
+    EnergyUnit expander =
+        new EnergyUnit("expander", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, shaft);
+    EnergyUnit compressorA =
+        new EnergyUnit(
+            "compressor A", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, shaft);
+    EnergyUnit compressorB =
+        new EnergyUnit(
+            "compressor B", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, shaft);
+    ProcessSystem process = new ProcessSystem();
+    process.add(expander);
+    process.add(compressorA);
+    process.add(compressorB);
+
+    assertThrows(IllegalStateException.class, () -> ProcessGraphBuilder.buildGraph(process));
   }
 
   private static final class EnergyUnit extends ProcessEquipmentBaseClass {


### PR DESCRIPTION
## Summary

- add unit-aware, typed `EnergyStream` APIs while preserving legacy duty, sign, and equality behavior
- add named `EnergyPort` metadata for energy type, physical direction, and calculation role
- add `EnergyBus` and `MechanicalShaft` for multi-producer/multi-consumer balances with named contributions
- discover calculated-to-specification energy dependencies in `ProcessGraphBuilder`, including point-to-point validation and multi-party bus edges
- make repeated bus execution stable by excluding a consumer's prior withdrawal and recording actual equipment loads
- support energy-driven pump operation, gas-turbine shaft specifications, recovered heat, and coupled shaft/electrical networks
- roll typed ports through rotating, thermal, generation, storage, electrolysis, reactor, and utility equipment
- add executable documentation plus lifecycle, graph, serialization, bus, equipment, and end-to-end acceptance tests

## Equipment coverage

- shaft work: `Pump`, `Compressor`, `Expander`, `SteamTurbine`, `GasTurbine`, and catalogue `GasTurbineUnit`
- heat: `Heater`, `Cooler`, `Condenser`, `Reboiler`, `GasTurbine` exhaust heat, `AmmoniaSynthesisReactor`, and `StirredTankReactor`
- electrical: `SolarPanel`, `WindTurbine`, `WindFarm`, `FuelCell`, `CombinedCycleSystem`, `BatteryStorage`, `Electrolyzer`, `CO2Electrolyzer`, `BioFeedstockPreparation`, and CSTR agitator demand

## Coupled-network acceptance

- expander → `MechanicalShaft` → compressor, including repeated execution
- solar generation → electrical `EnergyBus` → electrolyzer, including repeated execution
- condenser heat output → heat-recovery `EnergyBus` → heater
- graph execution independent of equipment insertion order
- Java serialization preserves shared-bus identity, typed port metadata, and named contributions

## Compatibility

This is additive. Existing `getDuty()`, `setDuty(double)`, `setEnergyStream(EnergyStream)`, signed-duty behavior, and equality semantics are retained. Canonical identity and global legacy sign changes are intentionally outside this PR because they require the NRC/API-major process.

## Validation

Testing level: full repository CI plus focused unit, equipment, graph, bus, lifecycle, serialization, and coupled-network tests.

Green on final head `45639b8`:
- Spotless and pre-commit
- documentation search coverage
- PaperLab replication gate
- Java compilation and javadocs
- CodeQL
- full Windows fast regression suite

The full Ubuntu regression suite with JaCoCo was still running when this PR was merged and remains the only outstanding post-merge verification item.