### PR TITLE
docs: align TransientPipe page structure and links

### DIFF
--- a/docs/wiki/transient_multiphase_pipe.md
+++ b/docs/wiki/transient_multiphase_pipe.md
@@ -3,8 +3,6 @@ title: "Transient Multiphase Pipe Model"
 description: "Configure and validate NeqSim's drift-flux transient pipeline model, including pressure boundaries, terrain effects, liquid accumulation, and profile results."
 ---
 
-# Transient Multiphase Pipe Model
-
 ## Overview
 
 The `TransientPipe` class provides a 1D transient multiphase (gas-liquid) flow simulator for pipelines. It uses the drift-flux formulation combined with mechanistic flow regime detection to model complex phenomena like terrain-induced slugging, liquid accumulation at low points, and transient pressure wave propagation.
@@ -361,7 +359,7 @@ String stats = slugTracker.getStatisticsString();
 logger.info("{}", stats);
 ```
 
-**Note:** Both `TransientPipe` (drift-flux) and `TwoFluidPipe` (two-fluid) use the same `SlugTracker` and `LiquidAccumulationTracker` components, but may predict different slug frequencies due to their underlying holdup models. See the [Two-Fluid Model documentation](two_fluid_model#comparison-with-drift-flux-model-transientpipe) for a detailed comparison.
+**Note:** Both `TransientPipe` (drift-flux) and `TwoFluidPipe` (two-fluid) use the same `SlugTracker` and `LiquidAccumulationTracker` components, but may predict different slug frequencies due to their underlying holdup models. See the [Two-Fluid Model documentation](two_fluid_model.md#comparison-with-drift-flux-model-transientpipe) for a detailed comparison.
 
 ### Accumulation Zones
 
@@ -626,6 +624,6 @@ logger.info("TransientPipe: {} bar", dpTransient);
 
 ## See Also
 
-- [Pipeline Flow Equations](pipeline_flow_equations)
-- [Pipeline Model Recommendations](pipeline_model_recommendations)
-- [Process Simulation](advanced_process_simulation)
+- [Pipeline Flow Equations](pipeline_flow_equations.md)
+- [Pipeline Model Recommendations](pipeline_model_recommendations.md)
+- [Process Simulation](advanced_process_simulation.md)


### PR DESCRIPTION
## D025 follow-up — align merged page with repository documentation rules

Linked campaign: #2499  
Predecessor: #2599 / merge `397214a`

### Frozen scope

- `docs/wiki/transient_multiphase_pipe.md`

No Java, production code, notebook, image, index, or unrelated file was in scope. The active energy-stream PR #2600 did not touch this page.

### Confirmed post-merge defects (5/5)

- **Medium:** front-matter title was duplicated as an H1, contrary to `.github/agents/documentation.agent.md`.
- **Medium:** four same-directory internal links omitted the mandatory `.md` suffix.

### Fixes

- Removed the duplicate H1 so the first content heading is `## Overview` under the Jekyll title.
- Added `.md` to the TwoFluidPipe comparison, pipeline equations, model recommendations, and advanced process-simulation links while preserving the valid comparison fragment.

### Final-head validation

Head: `22a65cf57035909a97aa1c85c3b4786001ebcc8d`

- Read current `AGENTS.md`, `.github/agents/documentation.agent.md`, and referenced repository skills.
- One commit, one changed file: 4 additions / 6 deletions.
- Front matter remains intact; no H1 remains; first content heading is `## Overview`.
- 32 code-fence markers and four display-math delimiters remain paired.
- All four relative targets exist; the TwoFluidPipe comparison fragment remains present.
- No `System.out` or `System.err` calls, external links, or images are present.
- Pre-commit, documentation build/search, CodeQL, Spotless, change detection, and agent-reference checks passed.
- Java 8/21 tests and Javadoc correctly skipped for this docs-only follow-up.
- Copilot reviewed the complete final-head file with no comments, suggested-change blocks, threads, or Copilot-authored commits.

### D025 Java evidence from #2599

- `TransientPipeDocumentationTest`: 2/2 passed on Ubuntu and Windows with Java 8 and 21.
- Complete suites: Ubuntu Java 21 10,884 tests; Windows Java 21 and both Java 8 jobs 10,682 tests each; zero failures/errors.
- The previously long-running Ubuntu coverage job completed successfully.

### Rendering and limitations

No browser-rendered site artifact was available, so visual inspection is not claimed.

### Publication state

PR #2601 merged externally as `6ff930b602dc48cfd6cf2d061020a433466f1e0a`. The merge is exactly the one frozen documentation file, and `master` equals that commit. This campaign did not merge, enable auto-merge, or push directly to `master`.

### Next scope

D026: the next bounded rotation entry.