### PR TITLE
docs: repair energy stream navigation (D026)

### DIFF
--- a/docs/REFERENCE_MANUAL_INDEX.md
+++ b/docs/REFERENCE_MANUAL_INDEX.md
@@ -238,6 +238,7 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 | Document             | Path                                                                                           | Description                               |
 | -------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------- |
 | Process Overview     | [docs/process/README.md](process/)                                                             | Process simulation module                 |
+| Energy Streams & Equipment Ports | [docs/process/energy_streams.md](process/energy_streams.md)                  | Typed heat, shaft-work, and electrical connections, unit-aware duties, buses, and shafts |
 | NeqSim Studio (Python) | [docs/process/neqsim-studio.md](process/neqsim-studio)                                        | Newcomer-friendly Python process builder (natural language, templates, wizard, edit-by-chat, gallery) |
 | Process Guide        | [docs/wiki/process_simulation.md](wiki/process_simulation)                                     | Process simulation guide                  |
 | Advanced Process     | [docs/wiki/advanced_process_simulation.md](wiki/advanced_process_simulation)                   | Advanced techniques                       |
@@ -1221,7 +1222,7 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 | ---------------------- | ------- |
 | Wiki/Tutorials         | 60      |
 | Thermodynamics         | 26      |
-| Process Simulation     | 48      |
+| Process Simulation     | 49      |
 | Safety Systems         | 18      |
 | **Risk Simulation**    | **13**  |
 | Field Development      | 11      |

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -3,8 +3,6 @@ title: Process Simulation Package
 description: The `process` package provides process equipment, unit operations, controllers, and process system management for building complete flowsheets.
 ---
 
-# Process Simulation Package
-
 The `process` package provides process equipment, unit operations, controllers, and process system management for building complete flowsheets.
 
 For controlled design cases, equipment and discipline sizing, safety verification, engineering deliverables, and
@@ -48,7 +46,7 @@ This documentation is organized into the following sections:
 | [bioprocessing.md](bioprocessing) | **Bio-processing** — reactors, fermenters, solid-liquid separators, LLE, evaporators, dryers, crystallizers |
 | [neqsim-studio.md](neqsim-studio) | **NeqSim Studio (Python)** — newcomer-friendly process builder: natural language, templates, guided wizard, edit-by-chat, recipe gallery |
 | [processmodel/](processmodel/) | ProcessSystem and flowsheet management |
-| [energy_streams.md](energy_streams) | **Energy streams** — typed heat, shaft-work, and electrical ports, unit-aware duties, graph ordering, and energy-driven equipment |
+| [energy_streams.md](energy_streams.md) | **Energy streams** — typed heat, shaft-work, and electrical ports, unit-aware duties, graph ordering, and energy-driven equipment |
 | [process_json_export_and_e300_fluids.md](process_json_export_and_e300_fluids) | **Process JSON export** — self-contained ProcessSystem/ProcessModel JSON for MCP, including E300-equivalent component properties and volume correction |
 | [simulation-hooks-and-events.md](simulation-hooks-and-events) | **Lifecycle hooks, event bus, auto-validation** for ProcessSystem and ProcessModel |
 | [model-change-events.md](model-change-events) | **Governed model revisions** — versioned change events, idempotent publication, fingerprints, and durable replay |

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -3,8 +3,6 @@ title: Energy streams and equipment ports
 description: Connect heat, shaft-work, and electrical duties between NeqSim unit operations.
 ---
 
-# Energy streams and equipment ports
-
 `EnergyStream` carries a power rate between process equipment. Its canonical unit is watt (W), while unit-aware APIs accept `W`, `kW`, `MW`, `hp`, and `BTU/hr`.
 
 Typed `EnergyPort` metadata separates three concepts:


### PR DESCRIPTION
## D026 — Energy-stream documentation navigation

Closes no issue; linked to #2499.

### Frozen scope

- `docs/process/energy_streams.md`
- `docs/process/README.md`
- `docs/REFERENCE_MANUAL_INDEX.md`

Production code, tests, notebooks, and unrelated legacy links are excluded.

### Confirmed defects and fixes

1. **Medium — duplicate H1 on the energy-stream page.** The page repeated its front-matter title as a Markdown H1. Removed the redundant H1 so the Jekyll title is the sole page heading.
2. **Medium — duplicate H1 on the process package page.** Removed the redundant H1 for the same repository conformance rule.
3. **Medium — malformed internal navigation.** The newly added energy-stream entry linked to `energy_streams`; changed it to the required same-directory target `energy_streams.md`.
4. **Medium — missing reference-manual discovery.** Added the energy-stream guide to Part III, Chapter 11.
5. **Low — stale manual count.** Incremented the Process Simulation document total from 48 to 49 after indexing the new page.

### API/source evidence

Every Java API shown on the energy-stream page is already exercised by focused executable coverage on current `master`:

- `DocExamplesCompilationTest.testEnergyDrivenPumpDocumentationExample`
- `DocExamplesCompilationTest.testEnergyBusDocumentationExamples`
- `EnergyBusTest`
- `PumpTest`

The examples match current `EnergyStream`, `EnergyBus`, `MechanicalShaft`, `EnergyPortMode`, and pump APIs. No regression-test change is required for this navigation-only repair.

### Validation performed before opening

- Jekyll front matter retained on both pages
- duplicate-H1 count: 0 on both changed process pages
- energy-stream Java fences: 3 paired blocks / 6 delimiters
- no equations, images, external links, notebooks, or HTML/Markdown interactions in the energy-stream page
- corrected README target exists
- new Reference Manual Index target exists
- Process Simulation index total updated to 49
- full branch scope reviewed: exactly the three frozen documentation files

### Final-head validation

- hosted build/test/Javadoc workflow: passed
- pre-commit: passed
- Spotless: passed
- documentation search coverage: passed
- CodeQL: passed
- source/test parity: all documented energy-stream APIs retain focused executable coverage
- front matter, heading structure, three paired Java fences, and both changed internal destinations: passed
- final remote diff: 3 files, 3 additions, 6 deletions; no production/test/notebook changes
- Copilot reviewed all 3/3 changed files and generated no comments or suggested changes; no review threads or Copilot-authored commits exist

No equations, images, external links, notebooks, or rendered-site artifact are in scope, so browser visual inspection is not claimed.

### Next scan

D027 returns to the next non-overlapping landing-page/navigation batch after D026 is merged and recorded.
