### PR TITLE
Energy Networks v3: deterministic allocation, converters, utilities and dynamics

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,35 @@
 
 ---
 
+## 2026-07-25 — New: Energy Networks v3
+
+### Summary
+
+Typed energy streams now support deterministic multi-party dispatch rather than relying only on sequential net-duty
+updates. The implementation adds explicit requests, allocations, priorities, balancing, shortages, curtailment,
+persistent participant IDs, energy-quality metadata, conversion equipment, utility levels, transient storage/shaft
+behavior, and auditable cost/emissions reporting.
+
+### New capability
+
+- `EnergyBus.solveBalance()` and `EnergyNetworkSolver`: priority/proportional dispatch with real `BALANCE` mode.
+- `EnergyNetworkReport`: supply, demand, unmet load, curtailment, balancing, loss, efficiency, cost, and CO2.
+- `EnergyQuality` and `UtilityLevel`: voltage/frequency, thermal grade, pressure, temperature, and shaft speed.
+- `ElectricMotor`, `Generator`, `Gearbox`, `Inverter`, and `Transformer`: explicit conversion and heat loss.
+- `MotorDriveTrain` and `MotorAssistedDriveTrain`: pump/compressor electrical drives and expander motor assist.
+- `UtilityEnergyBus`, `ThermalUtilitySource`, and `ThermalUtilityConsumer`: typed steam, hot-oil, water, and
+  refrigeration networks.
+- `MechanicalShaft.advanceTransient(dt)` and dynamic `BatteryStorage`: inertia/SOC, ramp limits, and trips.
+- Two-stream, multi-stream, and LNG heat exchangers publish calculated recoverable heat.
+
+### Compatibility
+
+Legacy sequential buses and owner-name/port-name contribution lookup remain supported. Internal network bookkeeping
+uses stable serialized participant IDs, so equipment renaming no longer changes allocation identity.
+
+---
+
+
 ---
 
 ## 2026-07-15 — New: `CompressorChartIGV` (vendor IGV-position chart family, Phase 2)

--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -15,7 +15,7 @@
 
 Typed energy streams now support deterministic multi-party dispatch rather than relying only on sequential net-duty
 updates. The implementation adds explicit requests, allocations, priorities, balancing, shortages, curtailment,
-persistent participant IDs, energy-quality metadata, conversion equipment, utility levels, transient storage/shaft
+persistent participant IDs, energy-quality metadata, conversion equipment, utility levels, fuel-energy reporting, transient storage/shaft
 behavior, and auditable cost/emissions reporting.
 
 ### New capability
@@ -23,7 +23,7 @@ behavior, and auditable cost/emissions reporting.
 - `EnergyBus.solveBalance()` and `EnergyNetworkSolver`: priority/proportional dispatch with real `BALANCE` mode.
 - `EnergyNetworkReport`: supply, demand, unmet load, curtailment, balancing, loss, efficiency, cost, and CO2.
 - `EnergyQuality` and `UtilityLevel`: voltage/frequency, thermal grade, pressure, temperature, and shaft speed.
-- `ElectricMotor`, `Generator`, `Gearbox`, `Inverter`, and `Transformer`: explicit conversion and heat loss.
+- `ElectricMotor`, `Generator`, `Gearbox`, `Inverter`, `Transformer`, and `PrimeMover`: explicit conversion and heat loss.
 - `MotorDriveTrain` and `MotorAssistedDriveTrain`: pump/compressor electrical drives and expander motor assist.
 - `UtilityEnergyBus`, `ThermalUtilitySource`, and `ThermalUtilityConsumer`: typed steam, hot-oil, water, and
   refrigeration networks.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,10 @@ src/main/java/neqsim/
   physicalproperties/    Density, viscosity, conductivity, surface tension
   process/equipment/     33 equipment packages:
     stream/ separator/ compressor/ pump/ valve/ heatexchanger/
+    energy/              EnergyNetworkSolver, EnergyConverter, motors/generators,
+                         gearboxes/inverters/transformers, typed utility buses
+    stream/               EnergyBus deterministic allocation, EnergyQuality,
+                         EnergyNetworkReport, transient MechanicalShaft
     pipeline/ distillation/ mixer/ splitter/ expander/ reactor/
     pipeline/routing/     PipingRouteBuilder — STID/E3D line-list route
                           hydraulics to serial PipeBeggsAndBrills models

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -107,7 +107,7 @@ flexibleLoad.connect(allocatedGrid);
 EnergyNetworkReport allocation = allocatedGrid.solveBalance();
 double essentialAllocation = essentialLoad.getPowerMagnitude("kW"); // 80 kW
 double flexibleAllocation = flexibleLoad.getPowerMagnitude("kW");   // 20 kW
-double unmetDemand = allocation.getUnmetDemand();                   // 60 kW
+double unmetDemand = allocation.getUnmetDemand();                   // 60000 W
 ```
 
 A `BALANCE` port can inject power during shortage and absorb power during surplus. Configure its generation and consumption limits with `setBalanceLimits`. `BatteryStorage.enableAutomaticBalancing` provides this behavior with state-of-charge, charge/discharge efficiency, power limits, ramp response, and trip handling.

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -131,7 +131,8 @@ The `neqsim.process.equipment.energy` package provides process units with explic
 | `Generator` | shaft work → electrical |
 | `Gearbox` | shaft work → shaft work, with speed ratio |
 | `Inverter` | electrical → electrical, with voltage/frequency quality |
-| `Transformer` | electrical → electrical, with voltage ratio |\n| `PrimeMover` | chemical/fuel energy → shaft work |
+| `Transformer` | electrical → electrical, with voltage ratio |
+| `PrimeMover` | chemical/fuel energy → shaft work |
 
 `MotorDriveTrain` connects an electric motor to any pump, compressor, or other unit exposing `shaftPower`. `MotorAssistedDriveTrain` connects an expander, an assist motor, and a compressor to the same `MechanicalShaft`. The two network solvers then dispatch electrical supply to the motor and combined shaft supply to the compressor.
 
@@ -172,7 +173,9 @@ Every solved bus returns an `EnergyNetworkReport` containing offered and accepte
 | Electrolyzer | `electricalPower` input | Feed-calculated demand or connected power-driven specification |
 | CO2Electrolyzer, BioFeedstockPreparation | `electricalPower` input | Calculated demand |
 | AmmoniaSynthesisReactor | `reactionHeat` output | Calculated reaction heat |
-| StirredTankReactor | `heatDuty` bidirectional; `agitatorPower` input | Calculated or specified heat duty and calculated electrical demand |\n| HeatExchanger, MultiStreamHeatExchanger, LNGHeatExchanger | `heatDuty` bidirectional | Calculated recoverable heat |\n| Energy converters | `energyInput`, `energyOutput`, `heatLoss` | Specified input, calculated useful output and loss |
+| StirredTankReactor | `heatDuty` bidirectional; `agitatorPower` input | Calculated or specified heat duty and calculated electrical demand |
+| HeatExchanger, MultiStreamHeatExchanger, LNGHeatExchanger | `heatDuty` bidirectional | Calculated recoverable heat |
+| Energy converters | `energyInput`, `energyOutput`, `heatLoss` | Specified input, calculated useful output and loss |
 
 ## Reboiler duty reporting
 

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -77,6 +77,84 @@ The process graph orders calculated producers before specification consumers. Th
 
 These connections remain stable when the flowsheet is executed repeatedly, and Java serialization preserves shared bus identity, port metadata, and named contributions.
 
+## Deterministic allocation and balancing
+
+For a state-of-art multi-party network, ports publish offers or requests and the bus solves one deterministic allocation. Lower priority numbers are served first; equal-priority participants share available power proportionally.
+
+```java
+EnergyBus allocatedGrid = new EnergyBus("allocated grid", EnergyType.ELECTRICAL);
+
+EnergyPort generator = new EnergyPort("power", EnergyType.ELECTRICAL,
+    EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
+generator.setOwnerName("generator");
+generator.connect(allocatedGrid);
+generator.setDuty(100.0, "kW");
+
+EnergyPort essentialLoad = new EnergyPort("power", EnergyType.ELECTRICAL,
+    EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION);
+essentialLoad.setOwnerName("essential load");
+essentialLoad.setPriority(10);
+essentialLoad.setRequestedPower(80.0, "kW");
+essentialLoad.connect(allocatedGrid);
+
+EnergyPort flexibleLoad = new EnergyPort("power", EnergyType.ELECTRICAL,
+    EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION);
+flexibleLoad.setOwnerName("flexible load");
+flexibleLoad.setPriority(20);
+flexibleLoad.setRequestedPower(80.0, "kW");
+flexibleLoad.connect(allocatedGrid);
+
+EnergyNetworkReport allocation = allocatedGrid.solveBalance();
+double essentialAllocation = essentialLoad.getPowerMagnitude("kW"); // 80 kW
+double flexibleAllocation = flexibleLoad.getPowerMagnitude("kW");   // 20 kW
+double unmetDemand = allocation.getUnmetDemand();                   // 60 kW
+```
+
+A `BALANCE` port can inject power during shortage and absorb power during surplus. Configure its generation and consumption limits with `setBalanceLimits`. `BatteryStorage.enableAutomaticBalancing` provides this behavior with state-of-charge, charge/discharge efficiency, power limits, ramp response, and trip handling.
+
+When a bus is part of a graph-executed process, add an `EnergyNetworkSolver` to make allocation an explicit scheduling node:
+
+```java
+EnergyNetworkSolver network = new EnergyNetworkSolver("electrical allocation", allocatedGrid);
+process.add(network);
+```
+
+The graph schedules calculated participants before the solver and specification or balance participants after it.
+
+## Conversion equipment and rotating drives
+
+The `neqsim.process.equipment.energy` package provides process units with explicit input, useful-output, and heat-loss ports:
+
+| Equipment | Conversion |
+|---|---|
+| `ElectricMotor` | electrical → shaft work |
+| `Generator` | shaft work → electrical |
+| `Gearbox` | shaft work → shaft work, with speed ratio |
+| `Inverter` | electrical → electrical, with voltage/frequency quality |
+| `Transformer` | electrical → electrical, with voltage ratio |
+
+`MotorDriveTrain` connects an electric motor to any pump, compressor, or other unit exposing `shaftPower`. `MotorAssistedDriveTrain` connects an expander, an assist motor, and a compressor to the same `MechanicalShaft`. The two network solvers then dispatch electrical supply to the motor and combined shaft supply to the compressor.
+
+## Energy quality and utility levels
+
+`EnergyQuality` adds voltage, frequency, temperature, pressure, and shaft-speed metadata. Ports may declare required quality, and incompatible specified qualities are rejected during connection.
+
+`UtilityEnergyBus` represents typed thermal utilities:
+
+- high-, medium-, and low-pressure steam
+- hot oil
+- cooling and chilled water
+- refrigeration
+- ambient cooling
+
+`ThermalUtilitySource` and `ThermalUtilityConsumer` participate in the same allocation, shortage, cost, and emissions reporting as electrical and shaft networks. Heaters, coolers, condensers, reboilers, two-stream heat exchangers, multi-stream exchangers, and `LNGHeatExchanger` publish or consume typed heat duties.
+
+## Dynamics and reporting
+
+`MechanicalShaft.advanceTransient(dt)` integrates rotational kinetic energy from the solved net shaft power. Moment of inertia, friction loss, maximum speed, acceleration/deceleration limits, and trip coastdown are configurable.
+
+Every solved bus returns an `EnergyNetworkReport` containing offered and accepted supply, requested and served demand, balancing generation/consumption, unmet demand, curtailment, conversion loss, delivery efficiency, operating cost, and CO2-equivalent rate. Set marginal price and emission factor on producer ports with `setEnergyPricePerMWh` and `setEmissionFactorKgPerMWh`.
+
 ## Equipment coverage
 
 | Equipment group | Typed port | Supported role |
@@ -90,11 +168,11 @@ These connections remain stable when the flowsheet is executed repeatedly, and J
 | Condenser | `heatDuty` output | Calculated heat removal |
 | Reboiler | `heatDuty` input | Calculated duty or legacy external duty specification |
 | SolarPanel, WindTurbine, WindFarm, FuelCell | `electricalPower` output | Calculated generation |
-| BatteryStorage | `electricalPower` bidirectional | Calculated charge/discharge |
+| BatteryStorage | `electricalPower` bidirectional | Calculated charge/discharge or automatic balance |
 | Electrolyzer | `electricalPower` input | Feed-calculated demand or connected power-driven specification |
 | CO2Electrolyzer, BioFeedstockPreparation | `electricalPower` input | Calculated demand |
 | AmmoniaSynthesisReactor | `reactionHeat` output | Calculated reaction heat |
-| StirredTankReactor | `heatDuty` bidirectional; `agitatorPower` input | Calculated or specified heat duty and calculated electrical demand |
+| StirredTankReactor | `heatDuty` bidirectional; `agitatorPower` input | Calculated or specified heat duty and calculated electrical demand |\n| HeatExchanger, MultiStreamHeatExchanger, LNGHeatExchanger | `heatDuty` bidirectional | Calculated recoverable heat |\n| Energy converters | `energyInput`, `energyOutput`, `heatLoss` | Specified input, calculated useful output and loss |
 
 ## Reboiler duty reporting
 

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -7,7 +7,7 @@ description: Connect heat, shaft-work, and electrical duties between NeqSim unit
 
 Typed `EnergyPort` metadata separates three concepts:
 
-- `EnergyType`: `HEAT`, `SHAFT_WORK`, `ELECTRICAL`, or legacy `UNSPECIFIED`.
+- `EnergyType`: `HEAT`, `SHAFT_WORK`, `ELECTRICAL`, `CHEMICAL`, or legacy `UNSPECIFIED`.
 - `EnergyPortDirection`: physical flow relative to the equipment boundary.
 - `EnergyPortMode`: whether the equipment calculates the duty, reads it as a specification, or leaves it to a balance solver.
 
@@ -131,7 +131,7 @@ The `neqsim.process.equipment.energy` package provides process units with explic
 | `Generator` | shaft work → electrical |
 | `Gearbox` | shaft work → shaft work, with speed ratio |
 | `Inverter` | electrical → electrical, with voltage/frequency quality |
-| `Transformer` | electrical → electrical, with voltage ratio |
+| `Transformer` | electrical → electrical, with voltage ratio |\n| `PrimeMover` | chemical/fuel energy → shaft work |
 
 `MotorDriveTrain` connects an electric motor to any pump, compressor, or other unit exposing `shaftPower`. `MotorAssistedDriveTrain` connects an expander, an assist motor, and a compressor to the same `MechanicalShaft`. The two network solvers then dispatch electrical supply to the motor and combined shaft supply to the compressor.
 
@@ -153,7 +153,7 @@ The `neqsim.process.equipment.energy` package provides process units with explic
 
 `MechanicalShaft.advanceTransient(dt)` integrates rotational kinetic energy from the solved net shaft power. Moment of inertia, friction loss, maximum speed, acceleration/deceleration limits, and trip coastdown are configurable.
 
-Every solved bus returns an `EnergyNetworkReport` containing offered and accepted supply, requested and served demand, balancing generation/consumption, unmet demand, curtailment, conversion loss, delivery efficiency, operating cost, and CO2-equivalent rate. Set marginal price and emission factor on producer ports with `setEnergyPricePerMWh` and `setEmissionFactorKgPerMWh`.
+Every solved bus returns an `EnergyNetworkReport` containing offered and accepted supply, requested and served demand, balancing generation/consumption, unmet demand, curtailment, conversion loss, delivery efficiency, fuel-energy rate, operating cost, and CO2-equivalent rate. Set marginal price and emission factor on producer ports with `setEnergyPricePerMWh` and `setEmissionFactorKgPerMWh`.
 
 ## Equipment coverage
 

--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -79,7 +79,7 @@ These connections remain stable when the flowsheet is executed repeatedly, and J
 
 ## Deterministic allocation and balancing
 
-For a state-of-art multi-party network, ports publish offers or requests and the bus solves one deterministic allocation. Lower priority numbers are served first; equal-priority participants share available power proportionally.
+For a state-of-the-art multi-party network, ports publish offers or requests and the bus solves one deterministic allocation. Lower priority numbers are served first; equal-priority participants share available power proportionally.
 
 ```java
 EnergyBus allocatedGrid = new EnergyBus("allocated grid", EnergyType.ELECTRICAL);

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -12,8 +12,8 @@ import neqsim.util.validation.ValidationResult;
  * Battery storage with state of charge, efficiencies, power limits, ramp response, trip behavior, and bus balancing.
  *
  * <p>
- * Stored capacity and state of charge use Wh for compatibility with the original charge/discharge API. Positive
- * battery power is discharge to the electrical bus and negative power is charging from the bus.
+ * Stored capacity and state of charge use Wh for compatibility with the original charge/discharge API. Positive battery
+ * power is discharge to the electrical bus and negative power is charging from the bus.
  * </p>
  *
  * @author esol

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -12,8 +12,9 @@ import neqsim.util.validation.ValidationResult;
  * Battery storage with state of charge, efficiencies, power limits, ramp response, trip behavior, and bus balancing.
  *
  * <p>
- * Stored capacity and state of charge use Wh for compatibility with the original charge/discharge API. Positive battery
- * power is discharge to the electrical bus and negative power is charging from the bus.
+ * Stored capacity and state of charge use Wh for compatibility with the original charge/discharge API. On an
+ * {@link EnergyBus}, positive battery power is discharge to the bus and negative power is charging. Legacy point-to-point
+ * streams retain their historical opposite sign convention.
  * </p>
  *
  * @author esol

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -174,16 +174,14 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
    * @param maximumDischargePower maximum discharging power in W
    */
   public void setPowerLimits(double maximumChargePower, double maximumDischargePower) {
-    if (Double.isNaN(maximumChargePower) || maximumChargePower < 0.0 || Double.isNaN(maximumDischargePower)
-        || maximumDischargePower < 0.0) {
-      throw new IllegalArgumentException("Battery power limits must be non-negative");
+    if (!Double.isFinite(maximumChargePower) || maximumChargePower < 0.0
+        || !Double.isFinite(maximumDischargePower) || maximumDischargePower < 0.0) {
+      throw new IllegalArgumentException("Battery power limits must be non-negative and finite");
     }
     this.maximumChargePower = maximumChargePower;
     this.maximumDischargePower = maximumDischargePower;
-    if (Double.isFinite(maximumChargePower) && Double.isFinite(maximumDischargePower)) {
-      getEnergyPort(ELECTRICAL_PORT).setBalanceLimits(tripped ? 0.0 : maximumDischargePower,
-          tripped ? 0.0 : maximumChargePower);
-    }
+    getEnergyPort(ELECTRICAL_PORT).setBalanceLimits(tripped ? 0.0 : maximumDischargePower,
+        tripped ? 0.0 : maximumChargePower);
   }
 
   /**
@@ -261,7 +259,7 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
-    publishPower();
+    publishPower(false);
     setCalculationIdentifier(id);
   }
 
@@ -272,11 +270,17 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
       throw new IllegalArgumentException("Battery timestep must be non-negative and finite");
     }
     double requestedPower = tripped ? 0.0 : targetPower;
-    if (!tripped && getEnergyPort(ELECTRICAL_PORT).isConnected()
+    if (getEnergyPort(ELECTRICAL_PORT).isConnected()
         && getEnergyPort(ELECTRICAL_PORT).getMode() == EnergyPortMode.BALANCE
-        && getEnergyPort(ELECTRICAL_PORT).getEnergyStream() instanceof EnergyBus
-        && ((EnergyBus) getEnergyPort(ELECTRICAL_PORT).getEnergyStream()).hasSolution()) {
-      requestedPower = getEnergyPort(ELECTRICAL_PORT).getDuty();
+        && getEnergyPort(ELECTRICAL_PORT).getEnergyStream() instanceof EnergyBus) {
+      EnergyBus energyBus = (EnergyBus) getEnergyPort(ELECTRICAL_PORT).getEnergyStream();
+      getEnergyPort(ELECTRICAL_PORT).clearRealizedBalancePower();
+      if (!energyBus.hasSolution()) {
+        energyBus.solveBalance();
+      }
+      if (!tripped) {
+        requestedPower = getEnergyPort(ELECTRICAL_PORT).getDuty();
+      }
     }
     requestedPower = Math.max(-maximumChargePower, Math.min(maximumDischargePower, requestedPower));
 
@@ -305,18 +309,25 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
       stateOfCharge += storedEnergy;
     }
 
-    publishPower();
+    publishPower(true);
     increaseTime(dt);
     setCalculationIdentifier(id);
   }
 
-  /** Publishes current battery power without overwriting a solved balance contribution. */
-  private void publishPower() {
+  /**
+   * Publishes current battery power.
+   *
+   * @param reconcileBalance whether transient balance power should be reconciled with the bus allocation
+   */
+  private void publishPower(boolean reconcileBalance) {
     if (!getEnergyPort(ELECTRICAL_PORT).isConnected()) {
       return;
     }
     if (getEnergyPort(ELECTRICAL_PORT).getMode() == EnergyPortMode.BALANCE
         && getEnergyPort(ELECTRICAL_PORT).getEnergyStream() instanceof EnergyBus) {
+      if (reconcileBalance) {
+        getEnergyPort(ELECTRICAL_PORT).reportRealizedBalancePower(currentPower);
+      }
       return;
     }
     if (getEnergyPort(ELECTRICAL_PORT).getEnergyStream() instanceof EnergyBus) {

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -1,148 +1,359 @@
 package neqsim.process.equipment.battery;
 
 import java.util.UUID;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.process.equipment.stream.EnergyBus;
 import neqsim.process.equipment.stream.EnergyPortDirection;
 import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyType;
-import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.util.validation.ValidationResult;
 
 /**
- * Simple battery storage unit maintaining a state of charge.
+ * Battery storage with state of charge, efficiencies, power limits, ramp response, trip behavior, and bus balancing.
  *
  * <p>
- * The unit can be charged or discharged by supplying a power level and a duration. The state of charge is updated
- * accordingly and the energy stream of the unit reflects the power usage (positive duty while charging and negative
- * when discharging).
+ * Stored capacity and state of charge use Wh for compatibility with the original charge/discharge API. Positive
+ * battery power is discharge to the electrical bus and negative power is charging from the bus.
  * </p>
  *
  * @author esol
+ * @version 2.0
  */
 public class BatteryStorage extends ProcessEquipmentBaseClass {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000L;
 
-  private double capacity; // [J]
-  private double stateOfCharge; // [J]
+  /** Electrical bidirectional port name. */
+  public static final String ELECTRICAL_PORT = "electricalPower";
+
+  private double capacity;
+  private double stateOfCharge;
   private double chargeEfficiency = 0.95;
   private double dischargeEfficiency = 0.95;
-  private double currentPower = 0.0; // [W]
+  private double currentPower = 0.0;
+  private double targetPower = 0.0;
+  private double maximumChargePower = Double.POSITIVE_INFINITY;
+  private double maximumDischargePower = Double.POSITIVE_INFINITY;
+  private double powerRampRate = Double.POSITIVE_INFINITY;
+  private boolean tripped = false;
 
   /**
-   * Construct a battery with the given name and capacity.
+   * Constructs a battery.
    *
-   * @param name name of the unit
-   * @param capacity maximum energy capacity [J]
+   * @param name unit name
+   * @param capacity maximum stored energy in Wh
    */
   public BatteryStorage(String name, double capacity) {
     super(name);
-    registerEnergyPort("electricalPower", EnergyType.ELECTRICAL, EnergyPortDirection.BIDIRECTIONAL,
+    registerEnergyPort(ELECTRICAL_PORT, EnergyType.ELECTRICAL, EnergyPortDirection.BIDIRECTIONAL,
         EnergyPortMode.CALCULATED);
-    this.capacity = capacity;
-    this.stateOfCharge = 0.0;
+    setCapacity(capacity);
+    stateOfCharge = 0.0;
   }
 
-  /**
-   * Default constructor with zero capacity.
-   */
+  /** Default constructor with zero capacity. */
   public BatteryStorage() {
     this("BatteryStorage", 0.0);
   }
 
   /**
-   * Construct a battery with a given name and zero capacity.
+   * Constructs a battery with zero capacity.
    *
-   * @param name name of the unit
+   * @param name unit name
    */
   public BatteryStorage(String name) {
     this(name, 0.0);
   }
 
   /**
-   * Charge the battery.
+   * Charges the battery immediately over a specified duration.
    *
-   * @param power charging power [W]
-   * @param hours duration of charging [h]
+   * @param power charging power in W
+   * @param hours charging duration in h
    */
   public void charge(double power, double hours) {
-    double energyIn = power * hours * chargeEfficiency;
+    validatePowerAndDuration(power, hours);
+    double actualPower = Math.min(power, maximumChargePower);
+    double energyIn = actualPower * hours * chargeEfficiency;
     stateOfCharge = Math.min(capacity, stateOfCharge + energyIn);
-    currentPower = -power;
+    currentPower = -actualPower;
+    targetPower = currentPower;
   }
 
   /**
-   * Discharge the battery.
+   * Discharges the battery immediately over a specified duration.
    *
-   * @param power requested power [W]
-   * @param hours duration of discharge [h]
-   * @return actual delivered power [W]
+   * @param power requested discharge power in W
+   * @param hours discharge duration in h
+   * @return actual delivered power in W
    */
   public double discharge(double power, double hours) {
-    double energyNeeded = power * hours / dischargeEfficiency;
-    double actualPower = power;
+    validatePowerAndDuration(power, hours);
+    double actualPower = Math.min(power, maximumDischargePower);
+    double energyNeeded = actualPower * hours / dischargeEfficiency;
     if (energyNeeded > stateOfCharge && hours > 0.0) {
       actualPower = stateOfCharge * dischargeEfficiency / hours;
       energyNeeded = stateOfCharge;
     }
     stateOfCharge = Math.max(0.0, stateOfCharge - energyNeeded);
     currentPower = actualPower;
+    targetPower = currentPower;
     return actualPower;
   }
 
   /**
-   * Get state of charge [J].
+   * Gets state of charge.
    *
-   * @return current stored energy
+   * @return stored energy in Wh
    */
   public double getStateOfCharge() {
     return stateOfCharge;
   }
 
   /**
-   * Set state of charge [J].
+   * Sets state of charge.
    *
-   * @param soc stored energy
+   * @param stateOfCharge stored energy in Wh
    */
-  public void setStateOfCharge(double soc) {
-    stateOfCharge = Math.max(0.0, Math.min(capacity, soc));
+  public void setStateOfCharge(double stateOfCharge) {
+    if (!Double.isFinite(stateOfCharge)) {
+      throw new IllegalArgumentException("State of charge must be finite");
+    }
+    this.stateOfCharge = Math.max(0.0, Math.min(capacity, stateOfCharge));
   }
 
   /**
-   * Get capacity [J].
+   * Gets capacity.
    *
-   * @return maximum storage capacity
+   * @return maximum stored energy in Wh
    */
   public double getCapacity() {
     return capacity;
   }
 
   /**
-   * Set capacity [J].
+   * Sets capacity.
    *
-   * @param capacity maximum storage capacity
+   * @param capacity maximum stored energy in Wh
    */
   public void setCapacity(double capacity) {
+    if (!Double.isFinite(capacity) || capacity < 0.0) {
+      throw new IllegalArgumentException("Battery capacity must be non-negative and finite");
+    }
     this.capacity = capacity;
     stateOfCharge = Math.min(stateOfCharge, capacity);
   }
 
   /**
-   * Get state of charge as a fraction of capacity.
+   * Gets state of charge as a fraction of capacity.
    *
-   * @return state of charge [0-1]
+   * @return state-of-charge fraction from zero to one
    */
   public double getStateOfChargeFraction() {
     return capacity > 0.0 ? stateOfCharge / capacity : 0.0;
   }
 
+  /**
+   * Sets charge and discharge efficiencies.
+   *
+   * @param chargeEfficiency charging efficiency in (0, 1]
+   * @param dischargeEfficiency discharging efficiency in (0, 1]
+   */
+  public void setEfficiencies(double chargeEfficiency, double dischargeEfficiency) {
+    validateEfficiency(chargeEfficiency, "Charge efficiency");
+    validateEfficiency(dischargeEfficiency, "Discharge efficiency");
+    this.chargeEfficiency = chargeEfficiency;
+    this.dischargeEfficiency = dischargeEfficiency;
+  }
+
+  /**
+   * Sets charge and discharge power limits.
+   *
+   * @param maximumChargePower maximum charging power in W
+   * @param maximumDischargePower maximum discharging power in W
+   */
+  public void setPowerLimits(double maximumChargePower, double maximumDischargePower) {
+    if (Double.isNaN(maximumChargePower) || maximumChargePower < 0.0 || Double.isNaN(maximumDischargePower)
+        || maximumDischargePower < 0.0) {
+      throw new IllegalArgumentException("Battery power limits must be non-negative");
+    }
+    this.maximumChargePower = maximumChargePower;
+    this.maximumDischargePower = maximumDischargePower;
+    if (Double.isFinite(maximumChargePower) && Double.isFinite(maximumDischargePower)) {
+      getEnergyPort(ELECTRICAL_PORT).setBalanceLimits(maximumDischargePower, maximumChargePower);
+    }
+  }
+
+  /**
+   * Sets battery power ramp rate.
+   *
+   * @param powerRampRate maximum power change in W/s
+   */
+  public void setPowerRampRate(double powerRampRate) {
+    if (Double.isNaN(powerRampRate) || powerRampRate <= 0.0) {
+      throw new IllegalArgumentException("Battery ramp rate must be positive");
+    }
+    this.powerRampRate = powerRampRate;
+  }
+
+  /**
+   * Sets target power for transient operation.
+   *
+   * @param targetPower positive discharge or negative charge power in W
+   */
+  public void setTargetPower(double targetPower) {
+    if (!Double.isFinite(targetPower)) {
+      throw new IllegalArgumentException("Battery target power must be finite");
+    }
+    this.targetPower = Math.max(-maximumChargePower, Math.min(maximumDischargePower, targetPower));
+  }
+
+  /**
+   * Gets current battery power.
+   *
+   * @return positive discharge or negative charge power in W
+   */
+  public double getCurrentPower() {
+    return currentPower;
+  }
+
+  /**
+   * Enables deterministic automatic bus balancing.
+   *
+   * @param maximumChargePower maximum surplus absorption in W
+   * @param maximumDischargePower maximum shortage generation in W
+   * @param priority balancing priority
+   */
+  public void enableAutomaticBalancing(double maximumChargePower, double maximumDischargePower, int priority) {
+    setPowerLimits(maximumChargePower, maximumDischargePower);
+    getEnergyPort(ELECTRICAL_PORT).setPriority(priority);
+    getEnergyPort(ELECTRICAL_PORT).setMode(EnergyPortMode.BALANCE);
+  }
+
+  /**
+   * Trips or resets the battery converter.
+   *
+   * @param tripped trip state
+   */
+  public void setTripped(boolean tripped) {
+    this.tripped = tripped;
+    if (tripped) {
+      targetPower = 0.0;
+    }
+  }
+
+  /**
+   * Checks trip state.
+   *
+   * @return {@code true} when tripped
+   */
+  public boolean isTripped() {
+    return tripped;
+  }
+
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
-    if (getEnergyPort("electricalPower").getEnergyStream() instanceof EnergyBus) {
-      getEnergyPort("electricalPower").setDuty(currentPower);
-    } else {
-      getEnergyPort("electricalPower").setDuty(-currentPower);
-    }
+    publishPower();
     setCalculationIdentifier(id);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void runTransient(double dt, UUID id) {
+    if (!Double.isFinite(dt) || dt < 0.0) {
+      throw new IllegalArgumentException("Battery timestep must be non-negative and finite");
+    }
+    double requestedPower = tripped ? 0.0 : targetPower;
+    if (getEnergyPort(ELECTRICAL_PORT).isConnected()
+        && getEnergyPort(ELECTRICAL_PORT).getMode() == EnergyPortMode.BALANCE
+        && getEnergyPort(ELECTRICAL_PORT).getEnergyStream() instanceof EnergyBus
+        && ((EnergyBus) getEnergyPort(ELECTRICAL_PORT).getEnergyStream()).hasSolution()) {
+      requestedPower = getEnergyPort(ELECTRICAL_PORT).getDuty();
+    }
+    requestedPower = Math.max(-maximumChargePower, Math.min(maximumDischargePower, requestedPower));
+
+    double maximumChange = powerRampRate * dt;
+    if (Double.isFinite(maximumChange) && Math.abs(requestedPower - currentPower) > maximumChange) {
+      currentPower += Math.copySign(maximumChange, requestedPower - currentPower);
+    } else {
+      currentPower = requestedPower;
+    }
+
+    double hours = dt / 3600.0;
+    if (currentPower > 0.0 && hours > 0.0) {
+      double requiredEnergy = currentPower * hours / dischargeEfficiency;
+      if (requiredEnergy > stateOfCharge) {
+        currentPower = stateOfCharge * dischargeEfficiency / hours;
+        requiredEnergy = stateOfCharge;
+      }
+      stateOfCharge -= requiredEnergy;
+    } else if (currentPower < 0.0 && hours > 0.0) {
+      double availableCapacity = capacity - stateOfCharge;
+      double storedEnergy = -currentPower * hours * chargeEfficiency;
+      if (storedEnergy > availableCapacity) {
+        currentPower = -availableCapacity / (hours * chargeEfficiency);
+        storedEnergy = availableCapacity;
+      }
+      stateOfCharge += storedEnergy;
+    }
+
+    publishPower();
+    increaseTime(dt);
+    setCalculationIdentifier(id);
+  }
+
+  /** Publishes current battery power without overwriting a solved balance contribution. */
+  private void publishPower() {
+    if (!getEnergyPort(ELECTRICAL_PORT).isConnected()) {
+      return;
+    }
+    if (getEnergyPort(ELECTRICAL_PORT).getMode() == EnergyPortMode.BALANCE
+        && getEnergyPort(ELECTRICAL_PORT).getEnergyStream() instanceof EnergyBus) {
+      return;
+    }
+    if (getEnergyPort(ELECTRICAL_PORT).getEnergyStream() instanceof EnergyBus) {
+      getEnergyPort(ELECTRICAL_PORT).setDuty(currentPower);
+    } else {
+      getEnergyPort(ELECTRICAL_PORT).setDuty(-currentPower);
+    }
+  }
+
+  /**
+   * Validates power and duration arguments.
+   *
+   * @param power power in W
+   * @param hours duration in h
+   */
+  private static void validatePowerAndDuration(double power, double hours) {
+    if (!Double.isFinite(power) || power < 0.0 || !Double.isFinite(hours) || hours < 0.0) {
+      throw new IllegalArgumentException("Power and duration must be non-negative and finite");
+    }
+  }
+
+  /**
+   * Validates an efficiency.
+   *
+   * @param efficiency efficiency value
+   * @param name property name
+   */
+  private static void validateEfficiency(double efficiency, String name) {
+    if (!Double.isFinite(efficiency) || efficiency <= 0.0 || efficiency > 1.0) {
+      throw new IllegalArgumentException(name + " must be in (0, 1]");
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ValidationResult validateSetup() {
+    ValidationResult result = new ValidationResult(getName());
+    if (capacity <= 0.0) {
+      result.addError("energy", "Battery capacity is not positive", "Call setCapacity(capacityWh)");
+    }
+    if (!getEnergyPort(ELECTRICAL_PORT).isConnected()) {
+      result.addWarning("energy", "Battery electrical port is not connected",
+          "Connect electricalPower to an electrical EnergyBus");
+    }
+    return result;
   }
 }

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -180,7 +180,8 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
     this.maximumChargePower = maximumChargePower;
     this.maximumDischargePower = maximumDischargePower;
     if (Double.isFinite(maximumChargePower) && Double.isFinite(maximumDischargePower)) {
-      getEnergyPort(ELECTRICAL_PORT).setBalanceLimits(maximumDischargePower, maximumChargePower);
+      getEnergyPort(ELECTRICAL_PORT).setBalanceLimits(tripped ? 0.0 : maximumDischargePower,
+          tripped ? 0.0 : maximumChargePower);
     }
   }
 
@@ -240,6 +241,11 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
     if (tripped) {
       targetPower = 0.0;
     }
+    if (getEnergyPort(ELECTRICAL_PORT).getMode() == EnergyPortMode.BALANCE
+        && Double.isFinite(maximumChargePower) && Double.isFinite(maximumDischargePower)) {
+      getEnergyPort(ELECTRICAL_PORT).setBalanceLimits(tripped ? 0.0 : maximumDischargePower,
+          tripped ? 0.0 : maximumChargePower);
+    }
   }
 
   /**
@@ -265,7 +271,7 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
       throw new IllegalArgumentException("Battery timestep must be non-negative and finite");
     }
     double requestedPower = tripped ? 0.0 : targetPower;
-    if (getEnergyPort(ELECTRICAL_PORT).isConnected()
+    if (!tripped && getEnergyPort(ELECTRICAL_PORT).isConnected()
         && getEnergyPort(ELECTRICAL_PORT).getMode() == EnergyPortMode.BALANCE
         && getEnergyPort(ELECTRICAL_PORT).getEnergyStream() instanceof EnergyBus
         && ((EnergyBus) getEnergyPort(ELECTRICAL_PORT).getEnergyStream()).hasSolution()) {

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -241,8 +241,8 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
     if (tripped) {
       targetPower = 0.0;
     }
-    if (getEnergyPort(ELECTRICAL_PORT).getMode() == EnergyPortMode.BALANCE
-        && Double.isFinite(maximumChargePower) && Double.isFinite(maximumDischargePower)) {
+    if (getEnergyPort(ELECTRICAL_PORT).getMode() == EnergyPortMode.BALANCE && Double.isFinite(maximumChargePower)
+        && Double.isFinite(maximumDischargePower)) {
       getEnergyPort(ELECTRICAL_PORT).setBalanceLimits(tripped ? 0.0 : maximumDischargePower,
           tripped ? 0.0 : maximumChargePower);
     }

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -13,8 +13,8 @@ import neqsim.util.validation.ValidationResult;
  *
  * <p>
  * Stored capacity and state of charge use Wh for compatibility with the original charge/discharge API. On an
- * {@link EnergyBus}, positive battery power is discharge to the bus and negative power is charging. Legacy point-to-point
- * streams retain their historical opposite sign convention.
+ * {@link EnergyBus}, positive battery power is discharge to the bus and negative power is charging. Legacy
+ * point-to-point streams retain their historical opposite sign convention.
  * </p>
  *
  * @author esol

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -174,8 +174,8 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
    * @param maximumDischargePower maximum discharging power in W
    */
   public void setPowerLimits(double maximumChargePower, double maximumDischargePower) {
-    if (!Double.isFinite(maximumChargePower) || maximumChargePower < 0.0
-        || !Double.isFinite(maximumDischargePower) || maximumDischargePower < 0.0) {
+    if (!Double.isFinite(maximumChargePower) || maximumChargePower < 0.0 || !Double.isFinite(maximumDischargePower)
+        || maximumDischargePower < 0.0) {
       throw new IllegalArgumentException("Battery power limits must be non-negative and finite");
     }
     this.maximumChargePower = maximumChargePower;

--- a/src/main/java/neqsim/process/equipment/energy/ElectricMotor.java
+++ b/src/main/java/neqsim/process/equipment/energy/ElectricMotor.java
@@ -1,0 +1,34 @@
+package neqsim.process.equipment.energy;
+
+import neqsim.process.equipment.stream.EnergyType;
+
+/**
+ * Electric motor converting electrical power to shaft work.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class ElectricMotor extends EnergyConverter {
+  private static final long serialVersionUID = 1000L;
+
+  /**
+   * Creates an electric motor with 95 percent efficiency.
+   *
+   * @param name equipment name
+   */
+  public ElectricMotor(String name) {
+    super(name, EnergyType.ELECTRICAL, EnergyType.SHAFT_WORK);
+    setEfficiency(0.95);
+  }
+
+  /**
+   * Creates an electric motor.
+   *
+   * @param name equipment name
+   * @param efficiency electrical-to-shaft efficiency
+   */
+  public ElectricMotor(String name, double efficiency) {
+    this(name);
+    setEfficiency(efficiency);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
@@ -1,0 +1,329 @@
+package neqsim.process.equipment.energy;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import com.google.gson.GsonBuilder;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.util.validation.ValidationResult;
+
+/**
+ * Generic two-domain energy conversion equipment with efficiency, capacity, ramp, loss, and trip behavior.
+ *
+ * <p>
+ * The input is a specification port, the useful output is a calculated port, and conversion losses are available as a
+ * calculated heat port. This common implementation is used by motors, generators, gearboxes, inverters, and
+ * transformers.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class EnergyConverter extends ProcessEquipmentBaseClass {
+  private static final long serialVersionUID = 1000L;
+
+  /** Input port name. */
+  public static final String INPUT_PORT = "energyInput";
+  /** Useful output port name. */
+  public static final String OUTPUT_PORT = "energyOutput";
+  /** Loss heat port name. */
+  public static final String LOSS_PORT = "heatLoss";
+
+  private final EnergyType inputType;
+  private final EnergyType outputType;
+  private double efficiency = 1.0;
+  private double maximumInputPower = Double.POSITIVE_INFINITY;
+  private double idleLoss = 0.0;
+  private double rampRate = Double.POSITIVE_INFINITY;
+  private double currentInputPower = 0.0;
+  private double currentOutputPower = 0.0;
+  private double heatLoss = 0.0;
+  private boolean tripped = false;
+
+  /**
+   * Creates an energy converter.
+   *
+   * @param name equipment name
+   * @param inputType input energy domain
+   * @param outputType output energy domain
+   */
+  public EnergyConverter(String name, EnergyType inputType, EnergyType outputType) {
+    super(name);
+    if (inputType == null || outputType == null) {
+      throw new IllegalArgumentException("Input and output energy types are required");
+    }
+    this.inputType = inputType;
+    this.outputType = outputType;
+    registerEnergyPort(INPUT_PORT, inputType, EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION);
+    registerEnergyPort(OUTPUT_PORT, outputType, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
+    registerEnergyPort(LOSS_PORT, EnergyType.HEAT, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
+  }
+
+  /**
+   * Gets the input energy domain.
+   *
+   * @return input energy type
+   */
+  public EnergyType getInputType() {
+    return inputType;
+  }
+
+  /**
+   * Gets the output energy domain.
+   *
+   * @return output energy type
+   */
+  public EnergyType getOutputType() {
+    return outputType;
+  }
+
+  /**
+   * Gets conversion efficiency.
+   *
+   * @return efficiency from zero to one
+   */
+  public double getEfficiency() {
+    return efficiency;
+  }
+
+  /**
+   * Sets conversion efficiency.
+   *
+   * @param efficiency efficiency greater than zero and at most one
+   */
+  public void setEfficiency(double efficiency) {
+    if (!Double.isFinite(efficiency) || efficiency <= 0.0 || efficiency > 1.0) {
+      throw new IllegalArgumentException("Efficiency must be greater than zero and at most one");
+    }
+    this.efficiency = efficiency;
+  }
+
+  /**
+   * Gets maximum input power.
+   *
+   * @return maximum input in W
+   */
+  public double getMaximumInputPower() {
+    return maximumInputPower;
+  }
+
+  /**
+   * Sets maximum input power.
+   *
+   * @param maximumInputPower maximum input in W
+   */
+  public void setMaximumInputPower(double maximumInputPower) {
+    if (Double.isNaN(maximumInputPower) || maximumInputPower <= 0.0) {
+      throw new IllegalArgumentException("Maximum input power must be positive");
+    }
+    this.maximumInputPower = maximumInputPower;
+    getEnergyPort(INPUT_PORT).setPowerLimits(0.0, maximumInputPower);
+  }
+
+  /**
+   * Gets fixed idle loss.
+   *
+   * @return idle loss in W
+   */
+  public double getIdleLoss() {
+    return idleLoss;
+  }
+
+  /**
+   * Sets fixed idle loss.
+   *
+   * @param idleLoss idle loss in W
+   */
+  public void setIdleLoss(double idleLoss) {
+    if (!Double.isFinite(idleLoss) || idleLoss < 0.0) {
+      throw new IllegalArgumentException("Idle loss must be non-negative and finite");
+    }
+    this.idleLoss = idleLoss;
+  }
+
+  /**
+   * Gets output ramp rate.
+   *
+   * @return ramp rate in W/s
+   */
+  public double getRampRate() {
+    return rampRate;
+  }
+
+  /**
+   * Sets output ramp rate.
+   *
+   * @param rampRate ramp rate in W/s; positive infinity disables the limit
+   */
+  public void setRampRate(double rampRate) {
+    if (Double.isNaN(rampRate) || rampRate <= 0.0) {
+      throw new IllegalArgumentException("Ramp rate must be positive");
+    }
+    this.rampRate = rampRate;
+  }
+
+  /**
+   * Sets requested input power for the upstream network solver.
+   *
+   * @param power requested input in W
+   */
+  public void setRequestedInputPower(double power) {
+    getEnergyPort(INPUT_PORT).setRequestedPower(power);
+  }
+
+  /**
+   * Gets the current allocated input power.
+   *
+   * @return input power in W
+   */
+  public double getInputPower() {
+    return currentInputPower;
+  }
+
+  /**
+   * Gets useful output power.
+   *
+   * @return output power in W
+   */
+  public double getOutputPower() {
+    return currentOutputPower;
+  }
+
+  /**
+   * Gets conversion heat loss.
+   *
+   * @return loss in W
+   */
+  public double getHeatLoss() {
+    return heatLoss;
+  }
+
+  /**
+   * Checks whether the converter is tripped.
+   *
+   * @return {@code true} when tripped
+   */
+  public boolean isTripped() {
+    return tripped;
+  }
+
+  /**
+   * Trips or resets the converter.
+   *
+   * @param tripped trip state
+   */
+  public void setTripped(boolean tripped) {
+    this.tripped = tripped;
+    if (tripped) {
+      getEnergyPort(INPUT_PORT).setRequestedPower(0.0);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run(UUID id) {
+    double input = readAvailableInput();
+    publish(input, calculateTargetOutput(input));
+    setCalculationIdentifier(id);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void runTransient(double dt, UUID id) {
+    double input = readAvailableInput();
+    double targetOutput = calculateTargetOutput(input);
+    double maximumChange = rampRate * Math.max(0.0, dt);
+    double output = targetOutput;
+    if (Double.isFinite(maximumChange) && Math.abs(targetOutput - currentOutputPower) > maximumChange) {
+      output = currentOutputPower + Math.copySign(maximumChange, targetOutput - currentOutputPower);
+    }
+    double effectiveInput = output > 0.0 ? Math.min(input, output / efficiency + idleLoss) : 0.0;
+    publish(effectiveInput, output);
+    increaseTime(dt);
+    setCalculationIdentifier(id);
+  }
+
+  /**
+   * Reads bounded allocated input power.
+   *
+   * @return available input in W
+   */
+  private double readAvailableInput() {
+    if (tripped || !getEnergyPort(INPUT_PORT).isConnected()) {
+      return 0.0;
+    }
+    return Math.min(maximumInputPower, getEnergyPort(INPUT_PORT).getPowerMagnitude());
+  }
+
+  /**
+   * Calculates useful steady-state output.
+   *
+   * @param input input power in W
+   * @return useful output in W
+   */
+  private double calculateTargetOutput(double input) {
+    if (tripped || input <= idleLoss) {
+      return 0.0;
+    }
+    return (input - idleLoss) * efficiency;
+  }
+
+  /**
+   * Publishes converter results to connected output and loss ports.
+   *
+   * @param input input power in W
+   * @param output useful output power in W
+   */
+  private void publish(double input, double output) {
+    currentInputPower = Math.max(0.0, input);
+    currentOutputPower = Math.max(0.0, output);
+    heatLoss = Math.max(0.0, currentInputPower - currentOutputPower);
+
+    EnergyPort outputPort = getEnergyPort(OUTPUT_PORT);
+    outputPort.setConversionLoss(heatLoss);
+    if (outputPort.isConnected()) {
+      outputPort.setDuty(currentOutputPower);
+    }
+    EnergyPort lossPort = getEnergyPort(LOSS_PORT);
+    if (lossPort.isConnected()) {
+      lossPort.setDuty(heatLoss);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ValidationResult validateSetup() {
+    ValidationResult result = new ValidationResult(getName());
+    if (getName() == null || getName().trim().isEmpty()) {
+      result.addError("equipment", "Energy converter has no name", "Set a name in the constructor");
+    }
+    if (!getEnergyPort(INPUT_PORT).isConnected()) {
+      result.addError("energy", "Input energy port is not connected",
+          "Connect an " + inputType + " stream to " + INPUT_PORT);
+    }
+    if (!getEnergyPort(OUTPUT_PORT).isConnected()) {
+      result.addWarning("energy", "Output energy port is not connected",
+          "Connect an " + outputType + " stream to " + OUTPUT_PORT);
+    }
+    return result;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toJson() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("name", getName());
+    result.put("inputType", inputType);
+    result.put("outputType", outputType);
+    result.put("inputPowerW", currentInputPower);
+    result.put("outputPowerW", currentOutputPower);
+    result.put("heatLossW", heatLoss);
+    result.put("efficiency", efficiency);
+    result.put("tripped", tripped);
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(result);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/EnergyNetworkSolver.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyNetworkSolver.java
@@ -79,7 +79,13 @@ public class EnergyNetworkSolver extends ProcessEquipmentBaseClass {
    * @return immutable report list
    */
   public List<EnergyNetworkReport> getReports() {
-    return Collections.unmodifiableList(reports);
+    List<EnergyNetworkReport> currentReports = new ArrayList<EnergyNetworkReport>();
+    for (EnergyBus energyBus : energyBuses) {
+      if (energyBus.getLastReport() != null) {
+        currentReports.add(energyBus.getLastReport());
+      }
+    }
+    return Collections.unmodifiableList(currentReports);
   }
 
   /** {@inheritDoc} */
@@ -95,6 +101,9 @@ public class EnergyNetworkSolver extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public void runTransient(double dt, UUID id) {
+    for (EnergyBus energyBus : energyBuses) {
+      energyBus.clearRealizedBalancePowers();
+    }
     run(id);
     increaseTime(dt);
   }
@@ -121,6 +130,6 @@ public class EnergyNetworkSolver extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public String toJson() {
-    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(reports);
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(getReports());
   }
 }

--- a/src/main/java/neqsim/process/equipment/energy/EnergyNetworkSolver.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyNetworkSolver.java
@@ -1,0 +1,126 @@
+package neqsim.process.equipment.energy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import com.google.gson.GsonBuilder;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyNetworkReport;
+import neqsim.util.validation.ValidationResult;
+
+/**
+ * Process equipment that solves one or more {@link EnergyBus} objects between energy producers and consumers.
+ *
+ * <p>
+ * Adding this unit to a {@code ProcessSystem} makes allocation an explicit calculation step. The process graph orders
+ * calculated producers before this solver and specification or balance consumers after it.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class EnergyNetworkSolver extends ProcessEquipmentBaseClass {
+  private static final long serialVersionUID = 1000L;
+
+  private final List<EnergyBus> energyBuses = new ArrayList<EnergyBus>();
+  private final List<EnergyNetworkReport> reports = new ArrayList<EnergyNetworkReport>();
+
+  /**
+   * Creates an empty network solver.
+   *
+   * @param name equipment name
+   */
+  public EnergyNetworkSolver(String name) {
+    super(name);
+  }
+
+  /**
+   * Creates a network solver for one bus.
+   *
+   * @param name equipment name
+   * @param energyBus energy bus to solve
+   */
+  public EnergyNetworkSolver(String name, EnergyBus energyBus) {
+    this(name);
+    addEnergyBus(energyBus);
+  }
+
+  /**
+   * Adds an energy bus.
+   *
+   * @param energyBus energy bus to solve
+   */
+  public void addEnergyBus(EnergyBus energyBus) {
+    if (energyBus == null) {
+      throw new IllegalArgumentException("Energy bus cannot be null");
+    }
+    for (EnergyBus existing : energyBuses) {
+      if (existing == energyBus) {
+        return;
+      }
+    }
+    energyBuses.add(energyBus);
+  }
+
+  /**
+   * Gets configured energy buses.
+   *
+   * @return immutable energy-bus list
+   */
+  public List<EnergyBus> getEnergyBuses() {
+    return Collections.unmodifiableList(energyBuses);
+  }
+
+  /**
+   * Gets reports from the most recent run.
+   *
+   * @return immutable report list
+   */
+  public List<EnergyNetworkReport> getReports() {
+    return Collections.unmodifiableList(reports);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run(UUID id) {
+    reports.clear();
+    for (EnergyBus energyBus : energyBuses) {
+      reports.add(energyBus.solveBalance());
+    }
+    setCalculationIdentifier(id);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void runTransient(double dt, UUID id) {
+    run(id);
+    increaseTime(dt);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ValidationResult validateSetup() {
+    ValidationResult result = new ValidationResult(getName());
+    if (getName() == null || getName().trim().isEmpty()) {
+      result.addError("equipment", "Energy network solver has no name", "Set a name in the constructor");
+    }
+    if (energyBuses.isEmpty()) {
+      result.addError("energy", "No energy buses are configured", "Call addEnergyBus(bus)");
+    }
+    for (EnergyBus energyBus : energyBuses) {
+      if (energyBus.getRegisteredPorts().isEmpty()) {
+        result.addWarning("energy", "Energy bus " + energyBus.getName() + " has no connected ports",
+            "Connect producer and consumer energy ports to the bus");
+      }
+    }
+    return result;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toJson() {
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(reports);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/Gearbox.java
+++ b/src/main/java/neqsim/process/equipment/energy/Gearbox.java
@@ -1,0 +1,63 @@
+package neqsim.process.equipment.energy;
+
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyQuality;
+import neqsim.process.equipment.stream.EnergyType;
+
+/**
+ * Mechanical gearbox connecting shaft-work networks with an efficiency and speed ratio.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class Gearbox extends EnergyConverter {
+  private static final long serialVersionUID = 1000L;
+
+  private double speedRatio = 1.0;
+
+  /**
+   * Creates a gearbox with 98 percent efficiency.
+   *
+   * @param name equipment name
+   */
+  public Gearbox(String name) {
+    super(name, EnergyType.SHAFT_WORK, EnergyType.SHAFT_WORK);
+    setEfficiency(0.98);
+  }
+
+  /**
+   * Gets output-to-input speed ratio.
+   *
+   * @return speed ratio
+   */
+  public double getSpeedRatio() {
+    return speedRatio;
+  }
+
+  /**
+   * Sets output-to-input speed ratio and updates connected output quality.
+   *
+   * @param speedRatio positive speed ratio
+   */
+  public void setSpeedRatio(double speedRatio) {
+    if (!Double.isFinite(speedRatio) || speedRatio <= 0.0) {
+      throw new IllegalArgumentException("Speed ratio must be positive and finite");
+    }
+    this.speedRatio = speedRatio;
+    updateOutputSpeedQuality();
+  }
+
+  /** Updates output shaft-speed quality when both stream qualities are available. */
+  private void updateOutputSpeedQuality() {
+    EnergyPort input = getEnergyPort(INPUT_PORT);
+    EnergyPort output = getEnergyPort(OUTPUT_PORT);
+    if (!input.isConnected() || !output.isConnected()) {
+      return;
+    }
+    double inputSpeed = input.getEnergyStream().getQuality().getShaftSpeed();
+    if (Double.isFinite(inputSpeed)) {
+      EnergyQuality quality = output.getEnergyStream().getQuality();
+      quality.setShaftSpeed(inputSpeed * speedRatio);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/Generator.java
+++ b/src/main/java/neqsim/process/equipment/energy/Generator.java
@@ -1,0 +1,34 @@
+package neqsim.process.equipment.energy;
+
+import neqsim.process.equipment.stream.EnergyType;
+
+/**
+ * Generator converting shaft work to electrical power.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class Generator extends EnergyConverter {
+  private static final long serialVersionUID = 1000L;
+
+  /**
+   * Creates a generator with 97 percent efficiency.
+   *
+   * @param name equipment name
+   */
+  public Generator(String name) {
+    super(name, EnergyType.SHAFT_WORK, EnergyType.ELECTRICAL);
+    setEfficiency(0.97);
+  }
+
+  /**
+   * Creates a generator.
+   *
+   * @param name equipment name
+   * @param efficiency shaft-to-electrical efficiency
+   */
+  public Generator(String name, double efficiency) {
+    this(name);
+    setEfficiency(efficiency);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/Inverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/Inverter.java
@@ -1,0 +1,64 @@
+package neqsim.process.equipment.energy;
+
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyQuality;
+import neqsim.process.equipment.stream.EnergyType;
+
+/**
+ * Electrical inverter or variable-frequency converter.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class Inverter extends EnergyConverter {
+  private static final long serialVersionUID = 1000L;
+
+  private double outputVoltage = Double.NaN;
+  private double outputFrequency = Double.NaN;
+
+  /**
+   * Creates an inverter with 97 percent efficiency.
+   *
+   * @param name equipment name
+   */
+  public Inverter(String name) {
+    super(name, EnergyType.ELECTRICAL, EnergyType.ELECTRICAL);
+    setEfficiency(0.97);
+  }
+
+  /**
+   * Sets output electrical quality.
+   *
+   * @param voltage output voltage in V
+   * @param frequency output frequency in Hz
+   */
+  public void setOutputElectricalQuality(double voltage, double frequency) {
+    EnergyQuality quality = new EnergyQuality();
+    quality.setVoltage(voltage);
+    quality.setFrequency(frequency);
+    outputVoltage = voltage;
+    outputFrequency = frequency;
+    EnergyPort output = getEnergyPort(OUTPUT_PORT);
+    if (output.isConnected()) {
+      output.getEnergyStream().setQuality(quality);
+    }
+  }
+
+  /**
+   * Gets configured output voltage.
+   *
+   * @return voltage in V
+   */
+  public double getOutputVoltage() {
+    return outputVoltage;
+  }
+
+  /**
+   * Gets configured output frequency.
+   *
+   * @return frequency in Hz
+   */
+  public double getOutputFrequency() {
+    return outputFrequency;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/MotorAssistedDriveTrain.java
+++ b/src/main/java/neqsim/process/equipment/energy/MotorAssistedDriveTrain.java
@@ -1,0 +1,111 @@
+package neqsim.process.equipment.energy;
+
+import java.io.Serializable;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.expander.Expander;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.MechanicalShaft;
+import neqsim.util.validation.ValidationResult;
+
+/**
+ * Expander-driven compressor train with supplemental electric-motor power on a common shaft.
+ *
+ * <p>
+ * The expander and motor publish calculated shaft power while the compressor receives a deterministic shaft-power
+ * allocation. When recovered expander power is insufficient, the motor contribution supplies the configured assist.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class MotorAssistedDriveTrain implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final Expander expander;
+  private final Compressor compressor;
+  private final ElectricMotor assistMotor;
+  private final EnergyBus electricalBus;
+  private final MechanicalShaft shaft;
+
+  /**
+   * Creates and connects a motor-assisted expander/compressor train.
+   *
+   * @param expander shaft-power producer
+   * @param compressor shaft-power consumer
+   * @param assistMotor supplemental electric motor
+   * @param electricalBus motor supply bus
+   * @param shaft common shaft bus
+   */
+  public MotorAssistedDriveTrain(Expander expander, Compressor compressor, ElectricMotor assistMotor,
+      EnergyBus electricalBus, MechanicalShaft shaft) {
+    if (expander == null || compressor == null || assistMotor == null || electricalBus == null || shaft == null) {
+      throw new IllegalArgumentException("Expander, compressor, assist motor, electrical bus, and shaft are required");
+    }
+    this.expander = expander;
+    this.compressor = compressor;
+    this.assistMotor = assistMotor;
+    this.electricalBus = electricalBus;
+    this.shaft = shaft;
+
+    expander.connectEnergyStream("shaftPower", shaft, EnergyPortMode.CALCULATED);
+    assistMotor.connectEnergyStream(EnergyConverter.INPUT_PORT, electricalBus, EnergyPortMode.SPECIFICATION);
+    assistMotor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, shaft, EnergyPortMode.CALCULATED);
+    compressor.connectEnergyStream("shaftPower", shaft, EnergyPortMode.SPECIFICATION);
+  }
+
+  /**
+   * Sets compressor demand and maximum planned motor assist.
+   *
+   * @param compressorPower requested compressor shaft power in W
+   * @param motorAssistPower planned supplemental shaft power in W
+   */
+  public void setPowerTargets(double compressorPower, double motorAssistPower) {
+    if (!Double.isFinite(compressorPower) || compressorPower < 0.0 || !Double.isFinite(motorAssistPower)
+        || motorAssistPower < 0.0) {
+      throw new IllegalArgumentException("Drive-train power targets must be non-negative and finite");
+    }
+    compressor.getEnergyPort("shaftPower").setRequestedPower(compressorPower);
+    assistMotor.setRequestedInputPower(motorAssistPower / assistMotor.getEfficiency() + assistMotor.getIdleLoss());
+  }
+
+  /**
+   * Gets common shaft.
+   *
+   * @return shaft bus
+   */
+  public MechanicalShaft getShaft() {
+    return shaft;
+  }
+
+  /**
+   * Gets assist motor.
+   *
+   * @return assist motor
+   */
+  public ElectricMotor getAssistMotor() {
+    return assistMotor;
+  }
+
+  /**
+   * Validates the connected train.
+   *
+   * @return validation result
+   */
+  public ValidationResult validateSetup() {
+    ValidationResult result = new ValidationResult(compressor.getName() + " assisted drive");
+    if (expander.getEnergyPort("shaftPower").getEnergyStream() != shaft) {
+      result.addError("energy", "Expander is not connected to the common shaft",
+          "Reconnect expander shaftPower to the common shaft");
+    }
+    if (compressor.getEnergyPort("shaftPower").getEnergyStream() != shaft) {
+      result.addError("energy", "Compressor is not connected to the common shaft",
+          "Reconnect compressor shaftPower to the common shaft");
+    }
+    if (assistMotor.getEnergyPort(EnergyConverter.INPUT_PORT).getEnergyStream() != electricalBus) {
+      result.addError("energy", "Assist motor is not connected to the electrical bus",
+          "Reconnect motor energyInput to the electrical bus");
+    }
+    return result;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/MotorDriveTrain.java
+++ b/src/main/java/neqsim/process/equipment/energy/MotorDriveTrain.java
@@ -1,0 +1,122 @@
+package neqsim.process.equipment.energy;
+
+import java.io.Serializable;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.MechanicalShaft;
+import neqsim.util.validation.ValidationResult;
+
+/**
+ * Convenience coupling for an electrically driven compressor, pump, or other unit exposing a {@code shaftPower} port.
+ *
+ * <p>
+ * The class connects an electrical bus to an {@link ElectricMotor}, the motor to a mechanical shaft, and that shaft to
+ * the driven equipment. The motor and driven equipment remain ordinary process units and should both be added to the
+ * process system.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class MotorDriveTrain implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final ElectricMotor motor;
+  private final ProcessEquipmentBaseClass drivenEquipment;
+  private final EnergyBus electricalBus;
+  private final MechanicalShaft shaft;
+
+  /**
+   * Creates and connects a motor drive train.
+   *
+   * @param motor electric motor process unit
+   * @param drivenEquipment equipment exposing a shaftPower energy port
+   * @param electricalBus electrical supply bus
+   * @param shaft mechanical shaft bus
+   */
+  public MotorDriveTrain(ElectricMotor motor, ProcessEquipmentBaseClass drivenEquipment, EnergyBus electricalBus,
+      MechanicalShaft shaft) {
+    if (motor == null || drivenEquipment == null || electricalBus == null || shaft == null) {
+      throw new IllegalArgumentException("Motor, driven equipment, electrical bus, and shaft are required");
+    }
+    if (drivenEquipment.getEnergyPort("shaftPower") == null) {
+      throw new IllegalArgumentException("Driven equipment must expose a shaftPower energy port");
+    }
+    this.motor = motor;
+    this.drivenEquipment = drivenEquipment;
+    this.electricalBus = electricalBus;
+    this.shaft = shaft;
+
+    motor.connectEnergyStream(EnergyConverter.INPUT_PORT, electricalBus, EnergyPortMode.SPECIFICATION);
+    motor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, shaft, EnergyPortMode.CALCULATED);
+    drivenEquipment.connectEnergyStream("shaftPower", shaft, EnergyPortMode.SPECIFICATION);
+  }
+
+  /**
+   * Sets requested useful shaft power and calculates the motor electrical request.
+   *
+   * @param shaftPower requested shaft power in W
+   */
+  public void setRequestedShaftPower(double shaftPower) {
+    if (!Double.isFinite(shaftPower) || shaftPower < 0.0) {
+      throw new IllegalArgumentException("Requested shaft power must be non-negative and finite");
+    }
+    drivenEquipment.getEnergyPort("shaftPower").setRequestedPower(shaftPower);
+    motor.setRequestedInputPower(shaftPower / motor.getEfficiency() + motor.getIdleLoss());
+  }
+
+  /**
+   * Gets the motor.
+   *
+   * @return motor process unit
+   */
+  public ElectricMotor getMotor() {
+    return motor;
+  }
+
+  /**
+   * Gets driven equipment.
+   *
+   * @return driven equipment
+   */
+  public ProcessEquipmentBaseClass getDrivenEquipment() {
+    return drivenEquipment;
+  }
+
+  /**
+   * Gets electrical bus.
+   *
+   * @return electrical bus
+   */
+  public EnergyBus getElectricalBus() {
+    return electricalBus;
+  }
+
+  /**
+   * Gets mechanical shaft.
+   *
+   * @return shaft bus
+   */
+  public MechanicalShaft getShaft() {
+    return shaft;
+  }
+
+  /**
+   * Validates the connected drive train.
+   *
+   * @return validation result with actionable diagnostics
+   */
+  public ValidationResult validateSetup() {
+    ValidationResult result = new ValidationResult(drivenEquipment.getName() + " motor drive");
+    if (motor.getEnergyPort(EnergyConverter.INPUT_PORT).getEnergyStream() != electricalBus) {
+      result.addError("energy", "Motor is not connected to the configured electrical bus",
+          "Reconnect motor energyInput to the electrical bus");
+    }
+    if (drivenEquipment.getEnergyPort("shaftPower").getEnergyStream() != shaft) {
+      result.addError("energy", "Driven equipment is not connected to the configured shaft",
+          "Reconnect shaftPower to the mechanical shaft");
+    }
+    return result;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/PrimeMover.java
+++ b/src/main/java/neqsim/process/equipment/energy/PrimeMover.java
@@ -1,0 +1,39 @@
+package neqsim.process.equipment.energy;
+
+import neqsim.process.equipment.stream.EnergyType;
+
+/**
+ * Generic fuel-fired prime mover converting chemical energy to shaft work.
+ *
+ * <p>
+ * The input power is the fuel lower- or higher-heating-value rate chosen by the model author. Cost and emissions can be
+ * assigned to the chemical-energy producer port and are included in the upstream bus report.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class PrimeMover extends EnergyConverter {
+  private static final long serialVersionUID = 1000L;
+
+  /**
+   * Creates a prime mover with 35 percent efficiency.
+   *
+   * @param name equipment name
+   */
+  public PrimeMover(String name) {
+    super(name, EnergyType.CHEMICAL, EnergyType.SHAFT_WORK);
+    setEfficiency(0.35);
+  }
+
+  /**
+   * Creates a prime mover.
+   *
+   * @param name equipment name
+   * @param efficiency fuel-to-shaft efficiency
+   */
+  public PrimeMover(String name, double efficiency) {
+    this(name);
+    setEfficiency(efficiency);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/ThermalUtilityConsumer.java
+++ b/src/main/java/neqsim/process/equipment/energy/ThermalUtilityConsumer.java
@@ -33,7 +33,7 @@ public class ThermalUtilityConsumer extends ProcessEquipmentBaseClass {
   public ThermalUtilityConsumer(String name, UtilityLevel utilityLevel) {
     super(name);
     if (utilityLevel == null || utilityLevel == UtilityLevel.UNSPECIFIED) {
-      throw new IllegalArgumentException("A required thermal utility level is required");
+      throw new IllegalArgumentException("A thermal utility level is required");
     }
     this.utilityLevel = utilityLevel;
     registerEnergyPort(INPUT_PORT, EnergyType.HEAT, EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION);
@@ -80,6 +80,12 @@ public class ThermalUtilityConsumer extends ProcessEquipmentBaseClass {
     ValidationResult result = new ValidationResult(getName());
     if (!getEnergyPort(INPUT_PORT).isConnected()) {
       result.addError("energy", "Thermal utility input is not connected",
+          "Connect " + INPUT_PORT + " to a " + utilityLevel + " UtilityEnergyBus");
+    } else if (!(getEnergyPort(INPUT_PORT).getEnergyStream() instanceof UtilityEnergyBus)) {
+      result.addError("energy", "Thermal utility input is not connected to a typed UtilityEnergyBus",
+          "Connect " + INPUT_PORT + " to a " + utilityLevel + " UtilityEnergyBus");
+    } else if (((UtilityEnergyBus) getEnergyPort(INPUT_PORT).getEnergyStream()).getUtilityLevel() != utilityLevel) {
+      result.addError("energy", "Connected utility level does not satisfy the consumer requirement",
           "Connect " + INPUT_PORT + " to a " + utilityLevel + " UtilityEnergyBus");
     }
     return result;

--- a/src/main/java/neqsim/process/equipment/energy/ThermalUtilityConsumer.java
+++ b/src/main/java/neqsim/process/equipment/energy/ThermalUtilityConsumer.java
@@ -1,0 +1,88 @@
+package neqsim.process.equipment.energy;
+
+import java.util.UUID;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyQuality;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.UtilityLevel;
+import neqsim.util.validation.ValidationResult;
+
+/**
+ * Thermal utility consumer with a requested duty and explicit utility-grade requirement.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class ThermalUtilityConsumer extends ProcessEquipmentBaseClass {
+  private static final long serialVersionUID = 1000L;
+
+  /** Thermal input port name. */
+  public static final String INPUT_PORT = "utilityInput";
+
+  private final UtilityLevel utilityLevel;
+  private double allocatedPower = 0.0;
+
+  /**
+   * Creates a thermal utility consumer.
+   *
+   * @param name equipment name
+   * @param utilityLevel required utility grade
+   */
+  public ThermalUtilityConsumer(String name, UtilityLevel utilityLevel) {
+    super(name);
+    if (utilityLevel == null || utilityLevel == UtilityLevel.UNSPECIFIED) {
+      throw new IllegalArgumentException("A required thermal utility level is required");
+    }
+    this.utilityLevel = utilityLevel;
+    registerEnergyPort(INPUT_PORT, EnergyType.HEAT, EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION);
+    getEnergyPort(INPUT_PORT).setRequiredQuality(new EnergyQuality(utilityLevel));
+  }
+
+  /**
+   * Sets requested thermal duty.
+   *
+   * @param requestedPower requested duty in W
+   */
+  public void setRequestedPower(double requestedPower) {
+    getEnergyPort(INPUT_PORT).setRequestedPower(requestedPower);
+  }
+
+  /**
+   * Gets allocated thermal duty.
+   *
+   * @return allocated duty in W
+   */
+  public double getAllocatedPower() {
+    return allocatedPower;
+  }
+
+  /**
+   * Gets required utility grade.
+   *
+   * @return utility grade
+   */
+  public UtilityLevel getUtilityLevel() {
+    return utilityLevel;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run(UUID id) {
+    allocatedPower =
+        getEnergyPort(INPUT_PORT).isConnected() ? getEnergyPort(INPUT_PORT).getPowerMagnitude() : 0.0;
+    setCalculationIdentifier(id);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ValidationResult validateSetup() {
+    ValidationResult result = new ValidationResult(getName());
+    if (!getEnergyPort(INPUT_PORT).isConnected()) {
+      result.addError("energy", "Thermal utility input is not connected",
+          "Connect " + INPUT_PORT + " to a " + utilityLevel + " UtilityEnergyBus");
+    }
+    return result;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/ThermalUtilityConsumer.java
+++ b/src/main/java/neqsim/process/equipment/energy/ThermalUtilityConsumer.java
@@ -70,8 +70,7 @@ public class ThermalUtilityConsumer extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
-    allocatedPower =
-        getEnergyPort(INPUT_PORT).isConnected() ? getEnergyPort(INPUT_PORT).getPowerMagnitude() : 0.0;
+    allocatedPower = getEnergyPort(INPUT_PORT).isConnected() ? getEnergyPort(INPUT_PORT).getPowerMagnitude() : 0.0;
     setCalculationIdentifier(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/energy/ThermalUtilitySource.java
+++ b/src/main/java/neqsim/process/equipment/energy/ThermalUtilitySource.java
@@ -1,0 +1,96 @@
+package neqsim.process.equipment.energy;
+
+import java.util.UUID;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.UtilityLevel;
+import neqsim.util.validation.ValidationResult;
+
+/**
+ * Dispatchable source of a standard thermal utility such as steam, hot oil, cooling water, or refrigeration.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class ThermalUtilitySource extends ProcessEquipmentBaseClass {
+  private static final long serialVersionUID = 1000L;
+
+  /** Thermal output port name. */
+  public static final String OUTPUT_PORT = "utilityOutput";
+
+  private final UtilityLevel utilityLevel;
+  private double availablePower = 0.0;
+
+  /**
+   * Creates a thermal utility source.
+   *
+   * @param name equipment name
+   * @param utilityLevel utility grade
+   */
+  public ThermalUtilitySource(String name, UtilityLevel utilityLevel) {
+    super(name);
+    if (utilityLevel == null || utilityLevel == UtilityLevel.UNSPECIFIED) {
+      throw new IllegalArgumentException("A thermal utility level is required");
+    }
+    this.utilityLevel = utilityLevel;
+    registerEnergyPort(OUTPUT_PORT, EnergyType.HEAT, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
+  }
+
+  /**
+   * Gets utility grade.
+   *
+   * @return utility grade
+   */
+  public UtilityLevel getUtilityLevel() {
+    return utilityLevel;
+  }
+
+  /**
+   * Gets available utility power.
+   *
+   * @return available power in W
+   */
+  public double getAvailablePower() {
+    return availablePower;
+  }
+
+  /**
+   * Sets available utility power.
+   *
+   * @param availablePower available power in W
+   */
+  public void setAvailablePower(double availablePower) {
+    if (!Double.isFinite(availablePower) || availablePower < 0.0) {
+      throw new IllegalArgumentException("Available power must be non-negative and finite");
+    }
+    this.availablePower = availablePower;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run(UUID id) {
+    if (getEnergyPort(OUTPUT_PORT).isConnected()) {
+      getEnergyPort(OUTPUT_PORT).setDuty(availablePower);
+    }
+    setCalculationIdentifier(id);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ValidationResult validateSetup() {
+    ValidationResult result = new ValidationResult(getName());
+    if (!getEnergyPort(OUTPUT_PORT).isConnected()) {
+      result.addError("energy", "Thermal utility output is not connected",
+          "Connect " + OUTPUT_PORT + " to a UtilityEnergyBus");
+    } else if (getEnergyPort(OUTPUT_PORT).getEnergyStream() instanceof UtilityEnergyBus) {
+      UtilityEnergyBus bus = (UtilityEnergyBus) getEnergyPort(OUTPUT_PORT).getEnergyStream();
+      if (bus.getUtilityLevel() != utilityLevel) {
+        result.addError("energy", "Utility level does not match connected bus",
+            "Connect the source to a " + utilityLevel + " bus");
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/ThermalUtilitySource.java
+++ b/src/main/java/neqsim/process/equipment/energy/ThermalUtilitySource.java
@@ -84,6 +84,9 @@ public class ThermalUtilitySource extends ProcessEquipmentBaseClass {
     if (!getEnergyPort(OUTPUT_PORT).isConnected()) {
       result.addError("energy", "Thermal utility output is not connected",
           "Connect " + OUTPUT_PORT + " to a UtilityEnergyBus");
+    } else if (!(getEnergyPort(OUTPUT_PORT).getEnergyStream() instanceof UtilityEnergyBus)) {
+      result.addError("energy", "Thermal utility output is not connected to a typed UtilityEnergyBus",
+          "Connect " + OUTPUT_PORT + " to a " + utilityLevel + " UtilityEnergyBus");
     } else if (getEnergyPort(OUTPUT_PORT).getEnergyStream() instanceof UtilityEnergyBus) {
       UtilityEnergyBus bus = (UtilityEnergyBus) getEnergyPort(OUTPUT_PORT).getEnergyStream();
       if (bus.getUtilityLevel() != utilityLevel) {

--- a/src/main/java/neqsim/process/equipment/energy/Transformer.java
+++ b/src/main/java/neqsim/process/equipment/energy/Transformer.java
@@ -1,0 +1,66 @@
+package neqsim.process.equipment.energy;
+
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyQuality;
+import neqsim.process.equipment.stream.EnergyType;
+
+/**
+ * Electrical transformer with power efficiency and voltage ratio.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class Transformer extends EnergyConverter {
+  private static final long serialVersionUID = 1000L;
+
+  private double voltageRatio = 1.0;
+
+  /**
+   * Creates a transformer with 99 percent efficiency.
+   *
+   * @param name equipment name
+   */
+  public Transformer(String name) {
+    super(name, EnergyType.ELECTRICAL, EnergyType.ELECTRICAL);
+    setEfficiency(0.99);
+  }
+
+  /**
+   * Gets secondary-to-primary voltage ratio.
+   *
+   * @return voltage ratio
+   */
+  public double getVoltageRatio() {
+    return voltageRatio;
+  }
+
+  /**
+   * Sets secondary-to-primary voltage ratio and updates connected output quality.
+   *
+   * @param voltageRatio positive voltage ratio
+   */
+  public void setVoltageRatio(double voltageRatio) {
+    if (!Double.isFinite(voltageRatio) || voltageRatio <= 0.0) {
+      throw new IllegalArgumentException("Voltage ratio must be positive and finite");
+    }
+    this.voltageRatio = voltageRatio;
+    updateOutputQuality();
+  }
+
+  /** Updates connected output voltage and preserves input frequency. */
+  private void updateOutputQuality() {
+    EnergyPort input = getEnergyPort(INPUT_PORT);
+    EnergyPort output = getEnergyPort(OUTPUT_PORT);
+    if (!input.isConnected() || !output.isConnected()) {
+      return;
+    }
+    EnergyQuality inputQuality = input.getEnergyStream().getQuality();
+    EnergyQuality outputQuality = output.getEnergyStream().getQuality();
+    if (Double.isFinite(inputQuality.getVoltage())) {
+      outputQuality.setVoltage(inputQuality.getVoltage() * voltageRatio);
+    }
+    if (Double.isFinite(inputQuality.getFrequency())) {
+      outputQuality.setFrequency(inputQuality.getFrequency());
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/UtilityEnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/energy/UtilityEnergyBus.java
@@ -1,0 +1,90 @@
+package neqsim.process.equipment.energy;
+
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.UtilityLevel;
+
+/**
+ * Thermal {@link EnergyBus} carrying a standard utility grade and supply/return temperatures.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class UtilityEnergyBus extends EnergyBus {
+  private static final long serialVersionUID = 1000L;
+
+  private double returnTemperature = Double.NaN;
+
+  /**
+   * Creates a utility bus.
+   *
+   * @param name bus name
+   * @param utilityLevel utility grade
+   */
+  public UtilityEnergyBus(String name, UtilityLevel utilityLevel) {
+    super(name, EnergyType.HEAT);
+    getQuality().setUtilityLevel(utilityLevel);
+  }
+
+  /**
+   * Creates a utility bus with explicit supply and return temperatures.
+   *
+   * @param name bus name
+   * @param utilityLevel utility grade
+   * @param supplyTemperature supply temperature in K
+   * @param returnTemperature return temperature in K
+   */
+  public UtilityEnergyBus(String name, UtilityLevel utilityLevel, double supplyTemperature, double returnTemperature) {
+    this(name, utilityLevel);
+    getQuality().setTemperature(supplyTemperature);
+    setReturnTemperature(returnTemperature);
+  }
+
+  /**
+   * Gets supply temperature.
+   *
+   * @return temperature in K, or {@link Double#NaN} when unspecified
+   */
+  public double getSupplyTemperature() {
+    return getQuality().getTemperature();
+  }
+
+  /**
+   * Sets supply temperature.
+   *
+   * @param supplyTemperature temperature in K
+   */
+  public void setSupplyTemperature(double supplyTemperature) {
+    getQuality().setTemperature(supplyTemperature);
+  }
+
+  /**
+   * Gets return temperature.
+   *
+   * @return temperature in K, or {@link Double#NaN} when unspecified
+   */
+  public double getReturnTemperature() {
+    return returnTemperature;
+  }
+
+  /**
+   * Sets return temperature.
+   *
+   * @param returnTemperature temperature in K
+   */
+  public void setReturnTemperature(double returnTemperature) {
+    if (!Double.isFinite(returnTemperature) || returnTemperature <= 0.0) {
+      throw new IllegalArgumentException("Return temperature must be positive and finite");
+    }
+    this.returnTemperature = returnTemperature;
+  }
+
+  /**
+   * Gets utility grade.
+   *
+   * @return utility grade
+   */
+  public UtilityLevel getUtilityLevel() {
+    return getQuality().getUtilityLevel();
+  }
+}

--- a/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
@@ -564,6 +564,7 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface, Sta
   public void run(UUID id) {
     if (useDeltaT) {
       runDeltaT(id);
+      publishHeatDuty();
       updateLastState();
       return;
     }
@@ -685,8 +686,19 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface, Sta
        */
     }
 
+    publishHeatDuty();
     updateLastState();
     setCalculationIdentifier(id);
+  }
+
+  /**
+   * Publishes recoverable exchanger duty to the inherited calculated heat port.
+   */
+  private void publishHeatDuty() {
+    if (getEnergyPort("heatDuty").isConnected()
+        && getEnergyPort("heatDuty").getMode() == neqsim.process.equipment.stream.EnergyPortMode.CALCULATED) {
+      getEnergyPort("heatDuty").setDuty(Math.abs(duty));
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchanger.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchanger.java
@@ -676,8 +676,19 @@ public class MultiStreamHeatExchanger extends Heater implements MultiStreamHeatE
       logger.info("iterations: " + iterations);
       iterations = 0;
     }
+    publishHeatDuty();
     setCalculationIdentifier(id);
     firstTime = true;
+  }
+
+  /**
+   * Publishes recoverable exchanger duty to the inherited calculated heat port.
+   */
+  private void publishHeatDuty() {
+    if (getEnergyPort("heatDuty").isConnected()
+        && getEnergyPort("heatDuty").getMode() == neqsim.process.equipment.stream.EnergyPortMode.CALCULATED) {
+      getEnergyPort("heatDuty").setDuty(Math.abs(duty));
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchanger2.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchanger2.java
@@ -195,6 +195,19 @@ public class MultiStreamHeatExchanger2 extends Heater implements MultiStreamHeat
       logger.debug("Outlet temps before solving: " + outletTemps);
       logger.debug("Unknown flags: " + unknownOutlets);
     }
+    energyDiff();
+    publishHeatDuty();
+    setCalculationIdentifier(id);
+  }
+
+  /**
+   * Publishes recoverable exchanger duty to the inherited calculated heat port.
+   */
+  private void publishHeatDuty() {
+    if (getEnergyPort("heatDuty").isConnected()
+        && getEnergyPort("heatDuty").getMode() == neqsim.process.equipment.stream.EnergyPortMode.CALCULATED) {
+      getEnergyPort("heatDuty").setDuty(getDuty());
+    }
   }
 
   // ================================================================
@@ -1376,7 +1389,7 @@ public class MultiStreamHeatExchanger2 extends Heater implements MultiStreamHeat
   /** {@inheritDoc} */
   @Override
   public double getDuty() {
-    return 0.0;
+    return Math.max(Math.abs(hotLoad), Math.abs(coldLoad)) * 1000.0;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/stream/EnergyAllocation.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyAllocation.java
@@ -1,0 +1,131 @@
+package neqsim.process.equipment.stream;
+
+import java.io.Serializable;
+
+/**
+ * Immutable allocation result for one energy-network participant.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class EnergyAllocation implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String participantId;
+  private final String participantName;
+  private final EnergyPortMode mode;
+  private final EnergyPortDirection direction;
+  private final int priority;
+  private final double requestedPower;
+  private final double allocatedPower;
+  private final double unmetPower;
+  private final double curtailedPower;
+
+  /**
+   * Creates an allocation result.
+   *
+   * @param participantId stable participant identifier
+   * @param participantName display name
+   * @param mode calculation mode
+   * @param direction physical direction
+   * @param priority dispatch priority
+   * @param requestedPower requested or offered power in W
+   * @param allocatedPower allocated power in W
+   * @param unmetPower unmet demand in W
+   * @param curtailedPower curtailed supply in W
+   */
+  public EnergyAllocation(String participantId, String participantName, EnergyPortMode mode,
+      EnergyPortDirection direction, int priority, double requestedPower, double allocatedPower, double unmetPower,
+      double curtailedPower) {
+    this.participantId = participantId;
+    this.participantName = participantName;
+    this.mode = mode;
+    this.direction = direction;
+    this.priority = priority;
+    this.requestedPower = requestedPower;
+    this.allocatedPower = allocatedPower;
+    this.unmetPower = unmetPower;
+    this.curtailedPower = curtailedPower;
+  }
+
+  /**
+   * Gets the stable participant identifier.
+   *
+   * @return participant identifier
+   */
+  public String getParticipantId() {
+    return participantId;
+  }
+
+  /**
+   * Gets the participant display name.
+   *
+   * @return display name
+   */
+  public String getParticipantName() {
+    return participantName;
+  }
+
+  /**
+   * Gets the calculation mode.
+   *
+   * @return calculation mode
+   */
+  public EnergyPortMode getMode() {
+    return mode;
+  }
+
+  /**
+   * Gets the physical direction.
+   *
+   * @return direction
+   */
+  public EnergyPortDirection getDirection() {
+    return direction;
+  }
+
+  /**
+   * Gets the dispatch priority.
+   *
+   * @return priority, where a lower value is served first
+   */
+  public int getPriority() {
+    return priority;
+  }
+
+  /**
+   * Gets requested or offered power.
+   *
+   * @return power in W
+   */
+  public double getRequestedPower() {
+    return requestedPower;
+  }
+
+  /**
+   * Gets allocated power.
+   *
+   * @return power in W
+   */
+  public double getAllocatedPower() {
+    return allocatedPower;
+  }
+
+  /**
+   * Gets unmet demand.
+   *
+   * @return power in W
+   */
+  public double getUnmetPower() {
+    return unmetPower;
+  }
+
+  /**
+   * Gets curtailed supply.
+   *
+   * @return power in W
+   */
+  public double getCurtailedPower() {
+    return curtailedPower;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -242,11 +242,8 @@ public class EnergyBus extends EnergyStream {
 
     double externalSupply = Math.max(0.0, super.getDuty());
     double externalDemand = Math.max(0.0, -super.getDuty());
-    double registeredContribution = 0.0;
-
     for (EnergyPort port : registeredPorts.values()) {
       double contribution = getContribution(port.getParticipantId());
-      registeredContribution += contribution;
       if (port.getMode() == EnergyPortMode.CALCULATED) {
         if (contribution > 0.0) {
           producers.add(new DispatchEntry(port, contribution));

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -29,6 +29,7 @@ public class EnergyBus extends EnergyStream {
   private Map<String, Double> contributions = new LinkedHashMap<String, Double>();
   private Map<String, Double> allocations = new LinkedHashMap<String, Double>();
   private Map<String, EnergyPort> registeredPorts = new LinkedHashMap<String, EnergyPort>();
+  private Map<String, Double> realizedBalancePowers = new LinkedHashMap<String, Double>();
   private boolean solutionValid = false;
   private EnergyNetworkReport lastReport = null;
 
@@ -74,6 +75,9 @@ public class EnergyBus extends EnergyStream {
     if (registeredPorts == null) {
       registeredPorts = new LinkedHashMap<String, EnergyPort>();
     }
+    if (realizedBalancePowers == null) {
+      realizedBalancePowers = new LinkedHashMap<String, Double>();
+    }
   }
 
   /** {@inheritDoc} */
@@ -83,6 +87,7 @@ public class EnergyBus extends EnergyStream {
     clonedBus.contributions = new LinkedHashMap<String, Double>(contributions);
     clonedBus.allocations = new LinkedHashMap<String, Double>();
     clonedBus.registeredPorts = new LinkedHashMap<String, EnergyPort>();
+    clonedBus.realizedBalancePowers = new LinkedHashMap<String, Double>();
     clonedBus.solutionValid = false;
     clonedBus.lastReport = null;
     return clonedBus;
@@ -113,6 +118,7 @@ public class EnergyBus extends EnergyStream {
     registeredPorts.remove(port.getParticipantId());
     contributions.remove(port.getParticipantId());
     allocations.remove(port.getParticipantId());
+    realizedBalancePowers.remove(port.getParticipantId());
     invalidateSolution();
   }
 
@@ -211,7 +217,60 @@ public class EnergyBus extends EnergyStream {
   public void clearContributions() {
     contributions.clear();
     allocations.clear();
+    realizedBalancePowers.clear();
     invalidateSolution();
+  }
+
+  /**
+   * Clears realized powers reported by balance equipment before a new transient dispatch.
+   */
+  public void clearRealizedBalancePowers() {
+    if (!realizedBalancePowers.isEmpty()) {
+      realizedBalancePowers.clear();
+      invalidateSolution();
+    }
+  }
+
+  /**
+   * Clears one balance participant's previously realized power.
+   *
+   * @param participantId stable participant identifier
+   */
+  void clearRealizedBalancePower(String participantId) {
+    if (realizedBalancePowers.remove(participantId) != null) {
+      invalidateSolution();
+    }
+  }
+
+  /**
+   * Records a balance participant's physically realized power and redispatches the remaining network.
+   *
+   * <p>
+   * This keeps transient ramp, trip, and stored-energy constraints consistent with allocations and network
+   * shortfall/curtailment reporting. The realized participant is treated as fixed until it is cleared for the next
+   * transient dispatch.
+   * </p>
+   *
+   * @param port reporting balance port
+   * @param actualPower positive generation or negative consumption in W
+   * @return updated network report
+   */
+  EnergyNetworkReport reportRealizedBalancePower(EnergyPort port, double actualPower) {
+    if (port.getMode() != EnergyPortMode.BALANCE || registeredPorts.get(port.getParticipantId()) != port) {
+      throw new IllegalArgumentException("Realized power can only be reported by a registered balance port");
+    }
+    if (!Double.isFinite(actualPower)) {
+      throw new IllegalArgumentException("Realized balance power must be finite");
+    }
+    if (port.getDirection() == EnergyPortDirection.INPUT && actualPower > 0.0) {
+      throw new IllegalArgumentException("An input balance port cannot report generated power");
+    }
+    if (port.getDirection() == EnergyPortDirection.OUTPUT && actualPower < 0.0) {
+      throw new IllegalArgumentException("An output balance port cannot report consumed power");
+    }
+    realizedBalancePowers.put(port.getParticipantId(), actualPower);
+    invalidateSolution();
+    return solveBalance();
   }
 
   /** {@inheritDoc} */
@@ -266,6 +325,9 @@ public class EnergyBus extends EnergyStream {
     List<DispatchEntry> demands = new ArrayList<DispatchEntry>();
     List<DispatchEntry> balancingGenerators = new ArrayList<DispatchEntry>();
     List<DispatchEntry> balancingConsumers = new ArrayList<DispatchEntry>();
+    List<DispatchEntry> realizedBalancingGenerators = new ArrayList<DispatchEntry>();
+    List<DispatchEntry> realizedBalancingConsumers = new ArrayList<DispatchEntry>();
+    double offeredBalancingGeneration = 0.0;
 
     double externalSupply = Math.max(0.0, super.getDuty());
     double externalDemand = Math.max(0.0, -super.getDuty());
@@ -285,6 +347,16 @@ public class EnergyBus extends EnergyStream {
           demands.add(new DispatchEntry(port, request));
         }
       } else if (port.getMode() == EnergyPortMode.BALANCE) {
+        offeredBalancingGeneration += port.getMaximumBalanceGeneration();
+        Double realizedPower = realizedBalancePowers.get(port.getParticipantId());
+        if (realizedPower != null) {
+          if (realizedPower.doubleValue() > 0.0) {
+            realizedBalancingGenerators.add(new DispatchEntry(port, realizedPower.doubleValue()));
+          } else if (realizedPower.doubleValue() < 0.0) {
+            realizedBalancingConsumers.add(new DispatchEntry(port, -realizedPower.doubleValue()));
+          }
+          continue;
+        }
         if (port.getDirection() != EnergyPortDirection.INPUT && port.getMaximumBalanceGeneration() > 0.0) {
           balancingGenerators.add(new DispatchEntry(port, port.getMaximumBalanceGeneration()));
         }
@@ -308,8 +380,11 @@ public class EnergyBus extends EnergyStream {
     double normalSupply = externalSupply + sumRequested(producers);
     double requestedDemand = externalDemand + sumRequested(demands);
     double availableBalancingGeneration = sumRequested(balancingGenerators);
-    double totalAvailableSupply = normalSupply + availableBalancingGeneration;
-    double demandAllocationLimit = Math.min(requestedDemand, totalAvailableSupply);
+    double realizedBalancingGeneration = sumRequested(realizedBalancingGenerators);
+    double realizedBalancingConsumption = sumRequested(realizedBalancingConsumers);
+    double totalAvailableSupply = normalSupply + realizedBalancingGeneration + availableBalancingGeneration;
+    double demandAllocationLimit =
+        Math.min(requestedDemand, Math.max(0.0, totalAvailableSupply - realizedBalancingConsumption));
 
     double participantDemandLimit = Math.max(0.0, demandAllocationLimit - externalDemand);
     allocateByPriority(demands, participantDemandLimit);
@@ -318,28 +393,34 @@ public class EnergyBus extends EnergyStream {
     double servedDemand = servedParticipantDemand + servedExternalDemand;
 
     double availableBalancingConsumption = sumRequested(balancingConsumers);
-    double balancingConsumptionTarget = Math.min(Math.max(0.0, normalSupply - servedDemand),
-        availableBalancingConsumption);
-    double normalGenerationTarget = Math.min(normalSupply, servedDemand + balancingConsumptionTarget);
+    double balancingConsumptionTarget =
+        Math.min(Math.max(0.0, normalSupply + realizedBalancingGeneration - servedDemand
+            - realizedBalancingConsumption), availableBalancingConsumption);
+    double normalGenerationTarget = Math.min(normalSupply, Math.max(0.0,
+        servedDemand + realizedBalancingConsumption + balancingConsumptionTarget - realizedBalancingGeneration));
     double participantGenerationTarget = Math.max(0.0, normalGenerationTarget - externalSupply);
     allocateByPriority(producers, participantGenerationTarget);
     double acceptedParticipantSupply = sumAllocated(producers);
     double acceptedExternalSupply = Math.min(externalSupply, normalGenerationTarget);
     double acceptedNormalSupply = acceptedParticipantSupply + acceptedExternalSupply;
 
-    double balancingGenerationTarget = Math.max(0.0, servedDemand - acceptedNormalSupply);
+    double balancingGenerationTarget = Math.max(0.0, servedDemand + realizedBalancingConsumption
+        + balancingConsumptionTarget - acceptedNormalSupply - realizedBalancingGeneration);
     allocateByPriority(balancingGenerators, balancingGenerationTarget);
-    double balancingGeneration = sumAllocated(balancingGenerators);
+    double balancingGeneration = realizedBalancingGeneration + sumAllocated(balancingGenerators);
 
-    double actualSurplus = Math.max(0.0, acceptedNormalSupply + balancingGeneration - servedDemand);
+    double actualSurplus = Math.max(0.0,
+        acceptedNormalSupply + balancingGeneration - servedDemand - realizedBalancingConsumption);
     allocateByPriority(balancingConsumers, actualSurplus);
-    double balancingConsumption = sumAllocated(balancingConsumers);
+    double balancingConsumption = realizedBalancingConsumption + sumAllocated(balancingConsumers);
 
     allocations.clear();
     updatePortNetworkState(producers, true);
     updatePortNetworkState(demands, false);
     updatePortNetworkState(balancingGenerators, true);
     updatePortNetworkState(balancingConsumers, false);
+    updatePortNetworkState(realizedBalancingGenerators, true);
+    updatePortNetworkState(realizedBalancingConsumers, false);
     for (EnergyPort port : registeredPorts.values()) {
       if (port.getMode() != EnergyPortMode.CALCULATED) {
         contributions.put(port.getParticipantId(), getAllocation(port.getParticipantId()));
@@ -347,7 +428,7 @@ public class EnergyBus extends EnergyStream {
     }
 
     double acceptedSupply = acceptedNormalSupply + balancingGeneration;
-    double offeredSupply = normalSupply + availableBalancingGeneration;
+    double offeredSupply = normalSupply + offeredBalancingGeneration;
     double unmetDemand = Math.max(0.0, requestedDemand - servedDemand);
     double curtailedSupply = Math.max(0.0, normalSupply - acceptedNormalSupply);
 

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -347,7 +347,7 @@ public class EnergyBus extends EnergyStream {
     }
 
     double acceptedSupply = acceptedNormalSupply + balancingGeneration;
-    double offeredSupply = normalSupply + balancingGeneration;
+    double offeredSupply = normalSupply + availableBalancingGeneration;
     double unmetDemand = Math.max(0.0, requestedDemand - servedDemand);
     double curtailedSupply = Math.max(0.0, normalSupply - acceptedNormalSupply);
 

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -74,7 +74,9 @@ public class EnergyBus extends EnergyStream {
   void registerPort(EnergyPort port) {
     EnergyPort previous = registeredPorts.get(port.getParticipantId());
     if (previous != null && previous != port) {
-      throw new IllegalArgumentException("Duplicate energy-bus participant identifier: " + port.getParticipantId());
+      do {
+        port.regenerateParticipantId();
+      } while (registeredPorts.containsKey(port.getParticipantId()));
     }
     registeredPorts.put(port.getParticipantId(), port);
     invalidateSolution();

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -217,6 +217,9 @@ public class EnergyBus extends EnergyStream {
   /** {@inheritDoc} */
   @Override
   public void setDuty(double duty) {
+    if (!Double.isFinite(duty)) {
+      throw new IllegalArgumentException("Energy-bus duty must be finite");
+    }
     super.setDuty(duty);
     invalidateSolution();
   }
@@ -337,6 +340,11 @@ public class EnergyBus extends EnergyStream {
     updatePortNetworkState(demands, false);
     updatePortNetworkState(balancingGenerators, true);
     updatePortNetworkState(balancingConsumers, false);
+    for (EnergyPort port : registeredPorts.values()) {
+      if (port.getMode() != EnergyPortMode.CALCULATED) {
+        contributions.put(port.getParticipantId(), getAllocation(port.getParticipantId()));
+      }
+    }
 
     double acceptedSupply = acceptedNormalSupply + balancingGeneration;
     double offeredSupply = normalSupply + balancingGeneration;
@@ -536,10 +544,9 @@ public class EnergyBus extends EnergyStream {
   private void updatePortNetworkState(List<DispatchEntry> entries, boolean generation) {
     for (DispatchEntry entry : entries) {
       double signedAllocation = generation ? entry.allocated : -entry.allocated;
-      allocations.put(entry.port.getParticipantId(), signedAllocation);
-      if (entry.port.getMode() != EnergyPortMode.CALCULATED) {
-        contributions.put(entry.port.getParticipantId(), signedAllocation);
-      }
+      Double previousAllocation = allocations.get(entry.port.getParticipantId());
+      allocations.put(entry.port.getParticipantId(),
+          (previousAllocation == null ? 0.0 : previousAllocation.doubleValue()) + signedAllocation);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -1,5 +1,7 @@
 package neqsim.process.equipment.stream;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -52,6 +54,26 @@ public class EnergyBus extends EnergyStream {
    */
   public EnergyBus(String name, EnergyType energyType) {
     super(name, energyType);
+  }
+
+  /**
+   * Restores collection defaults for energy buses serialized before allocation support was introduced.
+   *
+   * @param input serialized object input
+   * @throws IOException if the stream cannot be read
+   * @throws ClassNotFoundException if a serialized class cannot be resolved
+   */
+  private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
+    input.defaultReadObject();
+    if (contributions == null) {
+      contributions = new LinkedHashMap<String, Double>();
+    }
+    if (allocations == null) {
+      allocations = new LinkedHashMap<String, Double>();
+    }
+    if (registeredPorts == null) {
+      registeredPorts = new LinkedHashMap<String, EnergyPort>();
+    }
   }
 
   /** {@inheritDoc} */
@@ -362,7 +384,8 @@ public class EnergyBus extends EnergyStream {
    * Gets the net unsatisfied bus duty in watts.
    *
    * <p>
-   * A positive result is surplus generation and a negative result is shortage. The value uses published calculated
+   * A positive result is unallocated published generation. A negative value can represent unsolved demand, while solved
+   * shortages are reported by {@link EnergyNetworkReport#getUnmetDemand()}. The value uses published calculated
    * contributions and solved specification/balance contributions, so it remains a useful convergence residual.
    * </p>
    *

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -1,25 +1,34 @@
 package neqsim.process.equipment.stream;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import neqsim.util.unit.PowerUnit;
 
 /**
- * Multi-party energy connection that aggregates named power contributions.
+ * Multi-party energy connection with deterministic allocation and balancing.
  *
  * <p>
- * Unlike the point-to-point {@link EnergyStream}, an energy bus can connect several calculated and specification ports.
- * Positive and negative contribution signs represent injection and withdrawal from the bus. The inherited duty is
- * retained as an optional external or balancing contribution.
+ * Positive contributions inject power and negative contributions withdraw power. Calculated ports publish fixed
+ * offers or demands, specification ports publish dispatchable requests, and balance ports absorb a surplus or cover a
+ * shortage within configured limits. Lower priority numbers are dispatched first; participants with equal priority
+ * are allocated proportionally and ordered by persistent participant identifier.
+ * </p>
  *
  * @author NeqSim
- * @version 1.0
+ * @version 2.0
  */
 public class EnergyBus extends EnergyStream {
   private static final long serialVersionUID = 1000L;
 
   private Map<String, Double> contributions = new LinkedHashMap<String, Double>();
+  private Map<String, Double> allocations = new LinkedHashMap<String, Double>();
+  private Map<String, EnergyPort> registeredPorts = new LinkedHashMap<String, EnergyPort>();
+  private boolean solutionValid = false;
+  private EnergyNetworkReport lastReport = null;
 
   /** Creates an unnamed bus with an unspecified energy domain. */
   public EnergyBus() {
@@ -50,29 +59,67 @@ public class EnergyBus extends EnergyStream {
   public EnergyBus clone() {
     EnergyBus clonedBus = (EnergyBus) super.clone();
     clonedBus.contributions = new LinkedHashMap<String, Double>(contributions);
+    clonedBus.allocations = new LinkedHashMap<String, Double>();
+    clonedBus.registeredPorts = new LinkedHashMap<String, EnergyPort>();
+    clonedBus.solutionValid = false;
+    clonedBus.lastReport = null;
     return clonedBus;
+  }
+
+  /**
+   * Registers a connected port using its stable participant identifier.
+   *
+   * @param port connected port
+   */
+  void registerPort(EnergyPort port) {
+    EnergyPort previous = registeredPorts.get(port.getParticipantId());
+    if (previous != null && previous != port) {
+      throw new IllegalArgumentException("Duplicate energy-bus participant identifier: " + port.getParticipantId());
+    }
+    registeredPorts.put(port.getParticipantId(), port);
+    invalidateSolution();
+  }
+
+  /**
+   * Unregisters a disconnected port and removes its network state.
+   *
+   * @param port disconnected port
+   */
+  void unregisterPort(EnergyPort port) {
+    registeredPorts.remove(port.getParticipantId());
+    contributions.remove(port.getParticipantId());
+    allocations.remove(port.getParticipantId());
+    invalidateSolution();
+  }
+
+  /**
+   * Gets registered ports keyed by persistent identifier.
+   *
+   * @return immutable registered-port map
+   */
+  public Map<String, EnergyPort> getRegisteredPorts() {
+    return Collections.unmodifiableMap(registeredPorts);
   }
 
   /**
    * Sets a named power contribution in watts.
    *
-   * @param participant unique participant or port name
+   * @param participant unique participant identifier or legacy participant name
    * @param power signed power contribution in W
    */
   public void setContribution(String participant, double power) {
-    if (participant == null || participant.trim().isEmpty()) {
-      throw new IllegalArgumentException("Energy bus participant cannot be null or empty");
-    }
+    validateParticipant(participant);
     if (!Double.isFinite(power)) {
       throw new IllegalArgumentException("Energy bus contribution must be finite");
     }
     contributions.put(participant, power);
+    invalidateSolution();
   }
 
   /**
    * Sets a named power contribution in a specified unit.
    *
-   * @param participant unique participant or port name
+   * @param participant unique participant identifier or legacy participant name
    * @param power signed power contribution
    * @param unit power unit
    */
@@ -83,7 +130,7 @@ public class EnergyBus extends EnergyStream {
   /**
    * Gets a participant contribution in watts.
    *
-   * @param participant participant or port name
+   * @param participant participant identifier or legacy name
    * @return signed contribution in W, or zero when absent
    */
   public double getContribution(String participant) {
@@ -94,7 +141,7 @@ public class EnergyBus extends EnergyStream {
   /**
    * Gets a participant contribution in a requested unit.
    *
-   * @param participant participant or port name
+   * @param participant participant identifier or legacy name
    * @param unit requested power unit
    * @return signed contribution in the requested unit
    */
@@ -103,17 +150,43 @@ public class EnergyBus extends EnergyStream {
   }
 
   /**
+   * Gets a participant's most recent signed allocation.
+   *
+   * @param participant stable participant identifier
+   * @return positive injection, negative withdrawal, or zero when not allocated
+   */
+  public double getAllocation(String participant) {
+    Double allocation = allocations.get(participant);
+    return allocation == null ? 0.0 : allocation.doubleValue();
+  }
+
+  /**
+   * Gets a participant allocation in a requested unit.
+   *
+   * @param participant stable participant identifier
+   * @param unit requested power unit
+   * @return signed allocation in the requested unit
+   */
+  public double getAllocation(String participant, String unit) {
+    return new PowerUnit(getAllocation(participant), "W").getValue(unit);
+  }
+
+  /**
    * Removes a participant contribution.
    *
-   * @param participant participant or port name
+   * @param participant participant identifier or legacy name
    */
   public void removeContribution(String participant) {
     contributions.remove(participant);
+    allocations.remove(participant);
+    invalidateSolution();
   }
 
-  /** Removes all named contributions while preserving the inherited balancing duty. */
+  /** Removes all contributions and allocations while preserving the inherited external duty. */
   public void clearContributions() {
     contributions.clear();
+    allocations.clear();
+    invalidateSolution();
   }
 
   /**
@@ -126,9 +199,169 @@ public class EnergyBus extends EnergyStream {
   }
 
   /**
-   * Gets the net bus duty in watts.
+   * Gets an immutable view of signed allocations in watts.
    *
-   * @return inherited balancing duty plus all named contributions in W
+   * @return allocations keyed by stable participant identifier
+   */
+  public Map<String, Double> getAllocations() {
+    return Collections.unmodifiableMap(allocations);
+  }
+
+  /**
+   * Checks whether the current offers and requests have been solved.
+   *
+   * @return {@code true} when allocation results are current
+   */
+  public boolean hasSolution() {
+    return solutionValid;
+  }
+
+  /** Marks allocation results stale without removing the previous report. */
+  public void invalidateSolution() {
+    solutionValid = false;
+  }
+
+  /**
+   * Solves generation, demand, balancing, curtailment, and shortage deterministically.
+   *
+   * @return auditable network report
+   */
+  public EnergyNetworkReport solveBalance() {
+    List<DispatchEntry> producers = new ArrayList<DispatchEntry>();
+    List<DispatchEntry> demands = new ArrayList<DispatchEntry>();
+    List<DispatchEntry> balancingGenerators = new ArrayList<DispatchEntry>();
+    List<DispatchEntry> balancingConsumers = new ArrayList<DispatchEntry>();
+
+    double externalSupply = Math.max(0.0, super.getDuty());
+    double externalDemand = Math.max(0.0, -super.getDuty());
+    double registeredContribution = 0.0;
+
+    for (EnergyPort port : registeredPorts.values()) {
+      double contribution = getContribution(port.getParticipantId());
+      registeredContribution += contribution;
+      if (port.getMode() == EnergyPortMode.CALCULATED) {
+        if (contribution > 0.0) {
+          producers.add(new DispatchEntry(port, contribution));
+        } else if (contribution < 0.0) {
+          demands.add(new DispatchEntry(port, -contribution));
+        }
+      } else if (port.getMode() == EnergyPortMode.SPECIFICATION) {
+        double request = boundedRequest(port);
+        if (port.getDirection() == EnergyPortDirection.OUTPUT) {
+          producers.add(new DispatchEntry(port, request));
+        } else {
+          demands.add(new DispatchEntry(port, request));
+        }
+      } else if (port.getMode() == EnergyPortMode.BALANCE) {
+        if (port.getDirection() != EnergyPortDirection.INPUT && port.getMaximumBalanceGeneration() > 0.0) {
+          balancingGenerators.add(new DispatchEntry(port, port.getMaximumBalanceGeneration()));
+        }
+        if (port.getDirection() != EnergyPortDirection.OUTPUT && port.getMaximumBalanceConsumption() > 0.0) {
+          balancingConsumers.add(new DispatchEntry(port, port.getMaximumBalanceConsumption()));
+        }
+      }
+    }
+
+    for (Map.Entry<String, Double> entry : contributions.entrySet()) {
+      if (registeredPorts.containsKey(entry.getKey())) {
+        continue;
+      }
+      if (entry.getValue().doubleValue() > 0.0) {
+        externalSupply += entry.getValue().doubleValue();
+      } else {
+        externalDemand -= entry.getValue().doubleValue();
+      }
+    }
+
+    double normalSupply = externalSupply + sumRequested(producers);
+    double requestedDemand = externalDemand + sumRequested(demands);
+    double availableBalancingGeneration = sumRequested(balancingGenerators);
+    double totalAvailableSupply = normalSupply + availableBalancingGeneration;
+    double demandAllocationLimit = Math.min(requestedDemand, totalAvailableSupply);
+
+    double participantDemandLimit = Math.max(0.0, demandAllocationLimit - externalDemand);
+    allocateByPriority(demands, participantDemandLimit);
+    double servedParticipantDemand = sumAllocated(demands);
+    double servedExternalDemand = Math.min(externalDemand, demandAllocationLimit);
+    double servedDemand = servedParticipantDemand + servedExternalDemand;
+
+    double availableBalancingConsumption = sumRequested(balancingConsumers);
+    double balancingConsumptionTarget =
+        Math.min(Math.max(0.0, normalSupply - servedDemand), availableBalancingConsumption);
+    double normalGenerationTarget = Math.min(normalSupply, servedDemand + balancingConsumptionTarget);
+    double participantGenerationTarget = Math.max(0.0, normalGenerationTarget - externalSupply);
+    allocateByPriority(producers, participantGenerationTarget);
+    double acceptedParticipantSupply = sumAllocated(producers);
+    double acceptedExternalSupply = Math.min(externalSupply, normalGenerationTarget);
+    double acceptedNormalSupply = acceptedParticipantSupply + acceptedExternalSupply;
+
+    double balancingGenerationTarget = Math.max(0.0, servedDemand - acceptedNormalSupply);
+    allocateByPriority(balancingGenerators, balancingGenerationTarget);
+    double balancingGeneration = sumAllocated(balancingGenerators);
+
+    double actualSurplus = Math.max(0.0, acceptedNormalSupply + balancingGeneration - servedDemand);
+    allocateByPriority(balancingConsumers, actualSurplus);
+    double balancingConsumption = sumAllocated(balancingConsumers);
+
+    allocations.clear();
+    updatePortNetworkState(producers, true);
+    updatePortNetworkState(demands, false);
+    updatePortNetworkState(balancingGenerators, true);
+    updatePortNetworkState(balancingConsumers, false);
+
+    double acceptedSupply = acceptedNormalSupply + balancingGeneration;
+    double offeredSupply = normalSupply + availableBalancingGeneration;
+    double unmetDemand = Math.max(0.0, requestedDemand - servedDemand);
+    double curtailedSupply =
+        Math.max(0.0, normalSupply - acceptedNormalSupply) + Math.max(0.0, availableBalancingGeneration
+            - balancingGeneration);
+
+    List<EnergyAllocation> allocationResults = createAllocationResults();
+    double conversionLoss = 0.0;
+    double operatingCostPerHour = 0.0;
+    double co2EmissionRate = 0.0;
+    for (EnergyPort port : registeredPorts.values()) {
+      conversionLoss += port.getConversionLoss();
+      double allocatedGeneration = Math.max(0.0, getAllocation(port.getParticipantId()));
+      double allocatedMWhPerHour = allocatedGeneration / 1.0e6;
+      operatingCostPerHour += allocatedMWhPerHour * port.getEnergyPricePerMWh();
+      co2EmissionRate += allocatedMWhPerHour * port.getEmissionFactorKgPerMWh();
+    }
+
+    lastReport = new EnergyNetworkReport(getName(), allocationResults, offeredSupply, acceptedSupply, requestedDemand,
+        servedDemand, unmetDemand, curtailedSupply, balancingGeneration, balancingConsumption, conversionLoss,
+        operatingCostPerHour, co2EmissionRate);
+    solutionValid = true;
+    return lastReport;
+  }
+
+  /**
+   * Alias for {@link #solveBalance()}.
+   *
+   * @return auditable network report
+   */
+  public EnergyNetworkReport solve() {
+    return solveBalance();
+  }
+
+  /**
+   * Gets the most recent network report.
+   *
+   * @return report, or {@code null} before the first solution
+   */
+  public EnergyNetworkReport getLastReport() {
+    return lastReport;
+  }
+
+  /**
+   * Gets the net unsatisfied bus duty in watts.
+   *
+   * <p>
+   * A positive result is surplus generation and a negative result is shortage. The value uses published calculated
+   * contributions and solved specification/balance contributions, so it remains a useful convergence residual.
+   * </p>
+   *
+   * @return net residual power in W
    */
   @Override
   public double getDuty() {
@@ -140,7 +373,7 @@ public class EnergyBus extends EnergyStream {
   }
 
   /**
-   * Alias for {@link #getDuty()} emphasizing the bus balance.
+   * Alias for {@link #getDuty()} emphasizing the bus residual.
    *
    * @return net bus power in W
    */
@@ -149,14 +382,9 @@ public class EnergyBus extends EnergyStream {
   }
 
   /**
-   * Gets the net bus power while excluding one participant's previous contribution.
+   * Gets the net bus power while excluding one participant's contribution.
    *
-   * <p>
-   * Specification consumers use this value when a process is run repeatedly. Excluding the consumer's own previous
-   * withdrawal prevents self-feedback from reducing its available power on every run.
-   * </p>
-   *
-   * @param participant participant or port contribution key to exclude
+   * @param participant participant identifier or legacy name to exclude
    * @return net power excluding that contribution in W
    */
   public double getNetPowerExcluding(String participant) {
@@ -172,7 +400,7 @@ public class EnergyBus extends EnergyStream {
   /**
    * Gets net bus power excluding one participant in a requested unit.
    *
-   * @param participant participant or port contribution key to exclude
+   * @param participant participant identifier or legacy name to exclude
    * @param unit requested power unit
    * @return net power excluding that contribution in the requested unit
    */
@@ -188,5 +416,160 @@ public class EnergyBus extends EnergyStream {
    */
   public double getNetPower(String unit) {
     return getDuty(unit);
+  }
+
+  /**
+   * Applies port minimum and maximum limits to a request.
+   *
+   * @param port requesting port
+   * @return bounded request in W
+   */
+  private static double boundedRequest(EnergyPort port) {
+    double request = Math.min(port.getRequestedPower(), port.getMaximumPower());
+    if (request > 0.0) {
+      request = Math.max(request, port.getMinimumPower());
+    }
+    return request;
+  }
+
+  /**
+   * Allocates a capacity across entries by priority and proportionally within an equal-priority group.
+   *
+   * @param entries dispatch entries
+   * @param available available power in W
+   */
+  private static void allocateByPriority(List<DispatchEntry> entries, double available) {
+    Collections.sort(entries, new Comparator<DispatchEntry>() {
+      /** {@inheritDoc} */
+      @Override
+      public int compare(DispatchEntry first, DispatchEntry second) {
+        int priorityComparison = Integer.compare(first.port.getPriority(), second.port.getPriority());
+        if (priorityComparison != 0) {
+          return priorityComparison;
+        }
+        return first.port.getParticipantId().compareTo(second.port.getParticipantId());
+      }
+    });
+    double remaining = Math.max(0.0, available);
+    int start = 0;
+    while (start < entries.size()) {
+      int end = start + 1;
+      int priority = entries.get(start).port.getPriority();
+      double groupRequest = entries.get(start).requested;
+      while (end < entries.size() && entries.get(end).port.getPriority() == priority) {
+        groupRequest += entries.get(end).requested;
+        end++;
+      }
+      double groupAllocation = Math.min(remaining, groupRequest);
+      for (int index = start; index < end; index++) {
+        DispatchEntry entry = entries.get(index);
+        entry.allocated = groupRequest > 0.0 ? groupAllocation * entry.requested / groupRequest : 0.0;
+      }
+      remaining -= groupAllocation;
+      start = end;
+    }
+  }
+
+  /**
+   * Sums requested power.
+   *
+   * @param entries dispatch entries
+   * @return requested power in W
+   */
+  private static double sumRequested(List<DispatchEntry> entries) {
+    double total = 0.0;
+    for (DispatchEntry entry : entries) {
+      total += entry.requested;
+    }
+    return total;
+  }
+
+  /**
+   * Sums allocated power.
+   *
+   * @param entries dispatch entries
+   * @return allocated power in W
+   */
+  private static double sumAllocated(List<DispatchEntry> entries) {
+    double total = 0.0;
+    for (DispatchEntry entry : entries) {
+      total += entry.allocated;
+    }
+    return total;
+  }
+
+  /**
+   * Stores signed allocation and solved contributions for dispatchable participants.
+   *
+   * @param entries dispatch entries
+   * @param generation {@code true} for generation, {@code false} for consumption
+   */
+  private void updatePortNetworkState(List<DispatchEntry> entries, boolean generation) {
+    for (DispatchEntry entry : entries) {
+      double signedAllocation = generation ? entry.allocated : -entry.allocated;
+      allocations.put(entry.port.getParticipantId(), signedAllocation);
+      if (entry.port.getMode() != EnergyPortMode.CALCULATED) {
+        contributions.put(entry.port.getParticipantId(), signedAllocation);
+      }
+    }
+  }
+
+  /**
+   * Creates immutable results for every registered participant.
+   *
+   * @return allocation results
+   */
+  private List<EnergyAllocation> createAllocationResults() {
+    List<EnergyAllocation> results = new ArrayList<EnergyAllocation>();
+    for (EnergyPort port : registeredPorts.values()) {
+      double requested;
+      double contribution = getContribution(port.getParticipantId());
+      if (port.getMode() == EnergyPortMode.CALCULATED) {
+        requested = Math.abs(contribution);
+      } else if (port.getMode() == EnergyPortMode.BALANCE) {
+        requested = getAllocation(port.getParticipantId()) >= 0.0 ? port.getMaximumBalanceGeneration()
+            : port.getMaximumBalanceConsumption();
+      } else {
+        requested = boundedRequest(port);
+      }
+      double allocated = Math.abs(getAllocation(port.getParticipantId()));
+      double unmet = port.getDirection() == EnergyPortDirection.INPUT ? Math.max(0.0, requested - allocated) : 0.0;
+      double curtailed =
+          port.getDirection() == EnergyPortDirection.OUTPUT ? Math.max(0.0, requested - allocated) : 0.0;
+      results.add(new EnergyAllocation(port.getParticipantId(), port.getParticipantName(), port.getMode(),
+          port.getDirection(), port.getPriority(), requested, allocated, unmet, curtailed));
+    }
+    return results;
+  }
+
+  /**
+   * Validates a participant key.
+   *
+   * @param participant participant key
+   */
+  private static void validateParticipant(String participant) {
+    if (participant == null || participant.trim().isEmpty()) {
+      throw new IllegalArgumentException("Energy bus participant cannot be null or empty");
+    }
+  }
+
+  /**
+   * Mutable working state used during one deterministic dispatch.
+   */
+  private static final class DispatchEntry {
+    private final EnergyPort port;
+    private final double requested;
+    private double allocated = 0.0;
+
+    /**
+     * Creates a dispatch entry.
+     *
+     * @param port participant port
+     * @param requested requested or offered power in W
+     */
+    private DispatchEntry(EnergyPort port, double requested) {
+      this.port = port;
+      this.requested = Math.max(0.0, requested);
+    }
   }
 }

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -536,7 +536,7 @@ public class EnergyBus extends EnergyStream {
   }
 
   /**
-   * Stores signed allocation and solved contributions for dispatchable participants.
+   * Accumulates signed allocations for one dispatch leg.
    *
    * @param entries dispatch entries
    * @param generation {@code true} for generation, {@code false} for consumption

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -351,9 +351,9 @@ public class EnergyBus extends EnergyStream {
         Double realizedPower = realizedBalancePowers.get(port.getParticipantId());
         if (realizedPower != null) {
           if (realizedPower.doubleValue() > 0.0) {
-            realizedBalancingGenerators.add(new DispatchEntry(port, realizedPower.doubleValue()));
+            realizedBalancingGenerators.add(new DispatchEntry(port, realizedPower.doubleValue(), true));
           } else if (realizedPower.doubleValue() < 0.0) {
-            realizedBalancingConsumers.add(new DispatchEntry(port, -realizedPower.doubleValue()));
+            realizedBalancingConsumers.add(new DispatchEntry(port, -realizedPower.doubleValue(), true));
           }
           continue;
         }
@@ -704,6 +704,20 @@ public class EnergyBus extends EnergyStream {
     private DispatchEntry(EnergyPort port, double requested) {
       this.port = port;
       this.requested = Math.max(0.0, requested);
+    }
+
+    /**
+     * Creates a dispatch entry with optional fixed full allocation.
+     *
+     * @param port participant port
+     * @param requested requested or offered power in W
+     * @param fixedAllocation whether allocated power is fixed at the requested value
+     */
+    private DispatchEntry(EnergyPort port, double requested, boolean fixedAllocation) {
+      this(port, requested);
+      if (fixedAllocation) {
+        allocated = this.requested;
+      }
     }
   }
 }

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -112,7 +112,7 @@ public class EnergyBus extends EnergyStream {
     if (!Double.isFinite(power)) {
       throw new IllegalArgumentException("Energy bus contribution must be finite");
     }
-    contributions.put(participant, power);
+    contributions.put(resolveParticipantId(participant), power);
     invalidateSolution();
   }
 
@@ -134,7 +134,7 @@ public class EnergyBus extends EnergyStream {
    * @return signed contribution in W, or zero when absent
    */
   public double getContribution(String participant) {
-    Double contribution = contributions.get(participant);
+    Double contribution = contributions.get(resolveParticipantId(participant));
     return contribution == null ? 0.0 : contribution.doubleValue();
   }
 
@@ -156,7 +156,7 @@ public class EnergyBus extends EnergyStream {
    * @return positive injection, negative withdrawal, or zero when not allocated
    */
   public double getAllocation(String participant) {
-    Double allocation = allocations.get(participant);
+    Double allocation = allocations.get(resolveParticipantId(participant));
     return allocation == null ? 0.0 : allocation.doubleValue();
   }
 
@@ -177,8 +177,9 @@ public class EnergyBus extends EnergyStream {
    * @param participant participant identifier or legacy name
    */
   public void removeContribution(String participant) {
-    contributions.remove(participant);
-    allocations.remove(participant);
+    String participantId = resolveParticipantId(participant);
+    contributions.remove(participantId);
+    allocations.remove(participantId);
     invalidateSolution();
   }
 
@@ -186,6 +187,13 @@ public class EnergyBus extends EnergyStream {
   public void clearContributions() {
     contributions.clear();
     allocations.clear();
+    invalidateSolution();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setDuty(double duty) {
+    super.setDuty(duty);
     invalidateSolution();
   }
 
@@ -388,9 +396,10 @@ public class EnergyBus extends EnergyStream {
    * @return net power excluding that contribution in W
    */
   public double getNetPowerExcluding(String participant) {
+    String participantId = resolveParticipantId(participant);
     double netPower = super.getDuty();
     for (Map.Entry<String, Double> entry : contributions.entrySet()) {
-      if (!entry.getKey().equals(participant)) {
+      if (!entry.getKey().equals(participantId)) {
         netPower += entry.getValue().doubleValue();
       }
     }
@@ -551,6 +560,24 @@ public class EnergyBus extends EnergyStream {
     if (participant == null || participant.trim().isEmpty()) {
       throw new IllegalArgumentException("Energy bus participant cannot be null or empty");
     }
+  }
+
+  /**
+   * Resolves a legacy owner-name and port-name key to a stable participant identifier.
+   *
+   * @param participant stable identifier or legacy display key
+   * @return stable identifier when a registered display key matches, otherwise the supplied key
+   */
+  private String resolveParticipantId(String participant) {
+    if (registeredPorts.containsKey(participant)) {
+      return participant;
+    }
+    for (EnergyPort port : registeredPorts.values()) {
+      if (port.getParticipantName().equals(participant)) {
+        return port.getParticipantId();
+      }
+    }
+    return participant;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -336,7 +336,7 @@ public class EnergyBus extends EnergyStream {
 
     lastReport = new EnergyNetworkReport(getName(), allocationResults, offeredSupply, acceptedSupply, requestedDemand,
         servedDemand, unmetDemand, curtailedSupply, balancingGeneration, balancingConsumption, conversionLoss,
-        operatingCostPerHour, co2EmissionRate);
+        getEnergyType() == EnergyType.CHEMICAL ? acceptedSupply : 0.0, operatingCostPerHour, co2EmissionRate);
     solutionValid = true;
     return lastReport;
   }

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -318,11 +318,9 @@ public class EnergyBus extends EnergyStream {
     updatePortNetworkState(balancingConsumers, false);
 
     double acceptedSupply = acceptedNormalSupply + balancingGeneration;
-    double offeredSupply = normalSupply + availableBalancingGeneration;
+    double offeredSupply = normalSupply + balancingGeneration;
     double unmetDemand = Math.max(0.0, requestedDemand - servedDemand);
-    double curtailedSupply =
-        Math.max(0.0, normalSupply - acceptedNormalSupply) + Math.max(0.0, availableBalancingGeneration
-            - balancingGeneration);
+    double curtailedSupply = Math.max(0.0, normalSupply - acceptedNormalSupply);
 
     List<EnergyAllocation> allocationResults = createAllocationResults();
     double conversionLoss = 0.0;

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -383,8 +383,8 @@ public class EnergyBus extends EnergyStream {
     double realizedBalancingGeneration = sumRequested(realizedBalancingGenerators);
     double realizedBalancingConsumption = sumRequested(realizedBalancingConsumers);
     double totalAvailableSupply = normalSupply + realizedBalancingGeneration + availableBalancingGeneration;
-    double demandAllocationLimit =
-        Math.min(requestedDemand, Math.max(0.0, totalAvailableSupply - realizedBalancingConsumption));
+    double demandAllocationLimit = Math.min(requestedDemand,
+        Math.max(0.0, totalAvailableSupply - realizedBalancingConsumption));
 
     double participantDemandLimit = Math.max(0.0, demandAllocationLimit - externalDemand);
     allocateByPriority(demands, participantDemandLimit);
@@ -393,9 +393,9 @@ public class EnergyBus extends EnergyStream {
     double servedDemand = servedParticipantDemand + servedExternalDemand;
 
     double availableBalancingConsumption = sumRequested(balancingConsumers);
-    double balancingConsumptionTarget =
-        Math.min(Math.max(0.0, normalSupply + realizedBalancingGeneration - servedDemand
-            - realizedBalancingConsumption), availableBalancingConsumption);
+    double balancingConsumptionTarget = Math.min(
+        Math.max(0.0, normalSupply + realizedBalancingGeneration - servedDemand - realizedBalancingConsumption),
+        availableBalancingConsumption);
     double normalGenerationTarget = Math.min(normalSupply, Math.max(0.0,
         servedDemand + realizedBalancingConsumption + balancingConsumptionTarget - realizedBalancingGeneration));
     double participantGenerationTarget = Math.max(0.0, normalGenerationTarget - externalSupply);

--- a/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyBus.java
@@ -12,10 +12,10 @@ import neqsim.util.unit.PowerUnit;
  * Multi-party energy connection with deterministic allocation and balancing.
  *
  * <p>
- * Positive contributions inject power and negative contributions withdraw power. Calculated ports publish fixed
- * offers or demands, specification ports publish dispatchable requests, and balance ports absorb a surplus or cover a
- * shortage within configured limits. Lower priority numbers are dispatched first; participants with equal priority
- * are allocated proportionally and ordered by persistent participant identifier.
+ * Positive contributions inject power and negative contributions withdraw power. Calculated ports publish fixed offers
+ * or demands, specification ports publish dispatchable requests, and balance ports absorb a surplus or cover a shortage
+ * within configured limits. Lower priority numbers are dispatched first; participants with equal priority are allocated
+ * proportionally and ordered by persistent participant identifier.
  * </p>
  *
  * @author NeqSim
@@ -291,8 +291,8 @@ public class EnergyBus extends EnergyStream {
     double servedDemand = servedParticipantDemand + servedExternalDemand;
 
     double availableBalancingConsumption = sumRequested(balancingConsumers);
-    double balancingConsumptionTarget =
-        Math.min(Math.max(0.0, normalSupply - servedDemand), availableBalancingConsumption);
+    double balancingConsumptionTarget = Math.min(Math.max(0.0, normalSupply - servedDemand),
+        availableBalancingConsumption);
     double normalGenerationTarget = Math.min(normalSupply, servedDemand + balancingConsumptionTarget);
     double participantGenerationTarget = Math.max(0.0, normalGenerationTarget - externalSupply);
     allocateByPriority(producers, participantGenerationTarget);
@@ -538,8 +538,7 @@ public class EnergyBus extends EnergyStream {
       }
       double allocated = Math.abs(getAllocation(port.getParticipantId()));
       double unmet = port.getDirection() == EnergyPortDirection.INPUT ? Math.max(0.0, requested - allocated) : 0.0;
-      double curtailed =
-          port.getDirection() == EnergyPortDirection.OUTPUT ? Math.max(0.0, requested - allocated) : 0.0;
+      double curtailed = port.getDirection() == EnergyPortDirection.OUTPUT ? Math.max(0.0, requested - allocated) : 0.0;
       results.add(new EnergyAllocation(port.getParticipantId(), port.getParticipantName(), port.getMode(),
           port.getDirection(), port.getPriority(), requested, allocated, unmet, curtailed));
     }

--- a/src/main/java/neqsim/process/equipment/stream/EnergyNetworkReport.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyNetworkReport.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import com.google.gson.GsonBuilder;
+import neqsim.util.unit.PowerUnit;
 
 /**
  * Auditable result of an {@link EnergyBus} balance calculation.
@@ -26,6 +27,7 @@ public final class EnergyNetworkReport implements Serializable {
   private final double balancingGeneration;
   private final double balancingConsumption;
   private final double conversionLoss;
+  private final double fuelEnergyRate;
   private final double operatingCostPerHour;
   private final double co2EmissionRate;
 
@@ -43,13 +45,14 @@ public final class EnergyNetworkReport implements Serializable {
    * @param balancingGeneration balancing generation in W
    * @param balancingConsumption balancing consumption in W
    * @param conversionLoss conversion loss in W
+   * @param fuelEnergyRate accepted chemical or fuel energy rate in W
    * @param operatingCostPerHour operating cost per hour
    * @param co2EmissionRate CO2-equivalent emission rate in kg/h
    */
   public EnergyNetworkReport(String busName, List<EnergyAllocation> allocations, double offeredSupply,
       double acceptedSupply, double requestedDemand, double servedDemand, double unmetDemand, double curtailedSupply,
-      double balancingGeneration, double balancingConsumption, double conversionLoss, double operatingCostPerHour,
-      double co2EmissionRate) {
+      double balancingGeneration, double balancingConsumption, double conversionLoss, double fuelEnergyRate,
+      double operatingCostPerHour, double co2EmissionRate) {
     this.busName = busName;
     this.allocations = new ArrayList<EnergyAllocation>(allocations);
     this.offeredSupply = offeredSupply;
@@ -61,6 +64,7 @@ public final class EnergyNetworkReport implements Serializable {
     this.balancingGeneration = balancingGeneration;
     this.balancingConsumption = balancingConsumption;
     this.conversionLoss = conversionLoss;
+    this.fuelEnergyRate = fuelEnergyRate;
     this.operatingCostPerHour = operatingCostPerHour;
     this.co2EmissionRate = co2EmissionRate;
   }
@@ -162,6 +166,25 @@ public final class EnergyNetworkReport implements Serializable {
    */
   public double getConversionLoss() {
     return conversionLoss;
+  }
+
+  /**
+   * Gets accepted chemical or fuel energy rate.
+   *
+   * @return fuel energy rate in W
+   */
+  public double getFuelEnergyRate() {
+    return fuelEnergyRate;
+  }
+
+  /**
+   * Gets accepted chemical or fuel energy rate in a requested power unit.
+   *
+   * @param unit requested power unit
+   * @return fuel energy rate in the requested unit
+   */
+  public double getFuelEnergyRate(String unit) {
+    return new PowerUnit(fuelEnergyRate, "W").getValue(unit);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/stream/EnergyNetworkReport.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyNetworkReport.java
@@ -1,0 +1,205 @@
+package neqsim.process.equipment.stream;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Auditable result of an {@link EnergyBus} balance calculation.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class EnergyNetworkReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String busName;
+  private final List<EnergyAllocation> allocations;
+  private final double offeredSupply;
+  private final double acceptedSupply;
+  private final double requestedDemand;
+  private final double servedDemand;
+  private final double unmetDemand;
+  private final double curtailedSupply;
+  private final double balancingGeneration;
+  private final double balancingConsumption;
+  private final double conversionLoss;
+  private final double operatingCostPerHour;
+  private final double co2EmissionRate;
+
+  /**
+   * Creates a network report.
+   *
+   * @param busName bus name
+   * @param allocations participant allocations
+   * @param offeredSupply offered supply in W
+   * @param acceptedSupply accepted supply in W
+   * @param requestedDemand requested demand in W
+   * @param servedDemand served demand in W
+   * @param unmetDemand unmet demand in W
+   * @param curtailedSupply curtailed supply in W
+   * @param balancingGeneration balancing generation in W
+   * @param balancingConsumption balancing consumption in W
+   * @param conversionLoss conversion loss in W
+   * @param operatingCostPerHour operating cost per hour
+   * @param co2EmissionRate CO2-equivalent emission rate in kg/h
+   */
+  public EnergyNetworkReport(String busName, List<EnergyAllocation> allocations, double offeredSupply,
+      double acceptedSupply, double requestedDemand, double servedDemand, double unmetDemand, double curtailedSupply,
+      double balancingGeneration, double balancingConsumption, double conversionLoss, double operatingCostPerHour,
+      double co2EmissionRate) {
+    this.busName = busName;
+    this.allocations = new ArrayList<EnergyAllocation>(allocations);
+    this.offeredSupply = offeredSupply;
+    this.acceptedSupply = acceptedSupply;
+    this.requestedDemand = requestedDemand;
+    this.servedDemand = servedDemand;
+    this.unmetDemand = unmetDemand;
+    this.curtailedSupply = curtailedSupply;
+    this.balancingGeneration = balancingGeneration;
+    this.balancingConsumption = balancingConsumption;
+    this.conversionLoss = conversionLoss;
+    this.operatingCostPerHour = operatingCostPerHour;
+    this.co2EmissionRate = co2EmissionRate;
+  }
+
+  /**
+   * Gets the bus name.
+   *
+   * @return bus name
+   */
+  public String getBusName() {
+    return busName;
+  }
+
+  /**
+   * Gets immutable participant results.
+   *
+   * @return allocation results
+   */
+  public List<EnergyAllocation> getAllocations() {
+    return Collections.unmodifiableList(allocations);
+  }
+
+  /**
+   * Gets offered supply.
+   *
+   * @return offered supply in W
+   */
+  public double getOfferedSupply() {
+    return offeredSupply;
+  }
+
+  /**
+   * Gets accepted supply.
+   *
+   * @return accepted supply in W
+   */
+  public double getAcceptedSupply() {
+    return acceptedSupply;
+  }
+
+  /**
+   * Gets requested demand.
+   *
+   * @return requested demand in W
+   */
+  public double getRequestedDemand() {
+    return requestedDemand;
+  }
+
+  /**
+   * Gets served demand.
+   *
+   * @return served demand in W
+   */
+  public double getServedDemand() {
+    return servedDemand;
+  }
+
+  /**
+   * Gets unmet demand.
+   *
+   * @return unmet demand in W
+   */
+  public double getUnmetDemand() {
+    return unmetDemand;
+  }
+
+  /**
+   * Gets curtailed supply.
+   *
+   * @return curtailed supply in W
+   */
+  public double getCurtailedSupply() {
+    return curtailedSupply;
+  }
+
+  /**
+   * Gets balancing generation.
+   *
+   * @return balancing generation in W
+   */
+  public double getBalancingGeneration() {
+    return balancingGeneration;
+  }
+
+  /**
+   * Gets balancing consumption.
+   *
+   * @return balancing consumption in W
+   */
+  public double getBalancingConsumption() {
+    return balancingConsumption;
+  }
+
+  /**
+   * Gets conversion losses reported by connected ports.
+   *
+   * @return conversion loss in W
+   */
+  public double getConversionLoss() {
+    return conversionLoss;
+  }
+
+  /**
+   * Gets the hourly operating cost at the current load.
+   *
+   * @return cost per hour
+   */
+  public double getOperatingCostPerHour() {
+    return operatingCostPerHour;
+  }
+
+  /**
+   * Gets the current CO2-equivalent emission rate.
+   *
+   * @return emission rate in kg/h
+   */
+  public double getCo2EmissionRate() {
+    return co2EmissionRate;
+  }
+
+  /**
+   * Gets network delivery efficiency.
+   *
+   * @return served demand divided by accepted supply, or one when both are zero
+   */
+  public double getEfficiency() {
+    if (acceptedSupply <= 0.0) {
+      return servedDemand <= 0.0 ? 1.0 : 0.0;
+    }
+    return Math.max(0.0, Math.min(1.0, servedDemand / acceptedSupply));
+  }
+
+  /**
+   * Serializes the report as JSON.
+   *
+   * @return JSON report
+   */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create().toJson(this);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -546,10 +546,38 @@ public class EnergyPort implements Serializable {
     setDuty(new PowerUnit(duty, unit).getValue("W"));
   }
 
+  /**
+   * Reports power physically realized by balance equipment after transient constraints are applied.
+   *
+   * @param actualPower positive generation or negative consumption in W
+   * @return updated energy-network report
+   * @throws IllegalStateException if this is not a connected energy-bus balance port
+   */
+  public EnergyNetworkReport reportRealizedBalancePower(double actualPower) {
+    EnergyStream stream = requireConnectedStream();
+    if (!(stream instanceof EnergyBus) || mode != EnergyPortMode.BALANCE) {
+      throw new IllegalStateException("Realized balance power requires an energy-bus balance port");
+    }
+    return ((EnergyBus) stream).reportRealizedBalancePower(this, actualPower);
+  }
+
+  /**
+   * Clears previously realized balance power before a new transient dispatch.
+   */
+  public void clearRealizedBalancePower() {
+    EnergyStream stream = requireConnectedStream();
+    if (!(stream instanceof EnergyBus) || mode != EnergyPortMode.BALANCE) {
+      throw new IllegalStateException("Realized balance power requires an energy-bus balance port");
+    }
+    ((EnergyBus) stream).clearRealizedBalancePower(participantId);
+  }
+
   /** Invalidates the connected bus solution after a port setting changes. */
   private void invalidateBusSolution() {
     if (energyStream instanceof EnergyBus) {
-      ((EnergyBus) energyStream).invalidateSolution();
+      EnergyBus energyBus = (EnergyBus) energyStream;
+      energyBus.clearRealizedBalancePower(participantId);
+      energyBus.invalidateSolution();
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -477,7 +477,12 @@ public class EnergyPort implements Serializable {
     if (stream instanceof EnergyBus) {
       EnergyBus bus = (EnergyBus) stream;
       if (mode == EnergyPortMode.SPECIFICATION) {
+        boolean hadSolution = bus.hasSolution();
         setRequestedPower(Math.abs(duty));
+        if (!hadSolution) {
+          double contribution = direction == EnergyPortDirection.OUTPUT ? Math.abs(duty) : -Math.abs(duty);
+          bus.setContribution(participantId, contribution);
+        }
         return;
       }
       if (mode == EnergyPortMode.BALANCE) {

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -477,12 +477,12 @@ public class EnergyPort implements Serializable {
     if (stream instanceof EnergyBus) {
       EnergyBus bus = (EnergyBus) stream;
       if (mode == EnergyPortMode.SPECIFICATION) {
-        boolean hadSolution = bus.hasSolution();
-        setRequestedPower(Math.abs(duty));
-        if (!hadSolution) {
-          double contribution = direction == EnergyPortDirection.OUTPUT ? Math.abs(duty) : -Math.abs(duty);
-          bus.setContribution(participantId, contribution);
+        if (bus.hasSolution()) {
+          return;
         }
+        setRequestedPower(Math.abs(duty));
+        double contribution = direction == EnergyPortDirection.OUTPUT ? Math.abs(duty) : -Math.abs(duty);
+        bus.setContribution(participantId, contribution);
         return;
       }
       if (mode == EnergyPortMode.BALANCE) {

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -20,7 +20,7 @@ import neqsim.util.unit.PowerUnit;
 public class EnergyPort implements Serializable {
   private static final long serialVersionUID = 1000L;
 
-  private final String participantId = UUID.randomUUID().toString();
+  private String participantId = UUID.randomUUID().toString();
   private final String name;
   private final EnergyType energyType;
   private final EnergyPortDirection direction;
@@ -63,6 +63,19 @@ public class EnergyPort implements Serializable {
    */
   public String getParticipantId() {
     return participantId;
+  }
+
+  /**
+   * Assigns a new participant identifier after a deserialized equipment copy collides with an existing bus participant.
+   *
+   * <p>
+   * Normal serialization preserves participant identity. Regeneration is only performed by
+   * {@link EnergyBus#registerPort(EnergyPort)} when two distinct port objects with the same serialized identifier are
+   * connected to one bus.
+   * </p>
+   */
+  void regenerateParticipantId() {
+    participantId = UUID.randomUUID().toString();
   }
 
   /**
@@ -478,6 +491,7 @@ public class EnergyPort implements Serializable {
       EnergyBus bus = (EnergyBus) stream;
       if (mode == EnergyPortMode.SPECIFICATION) {
         if (bus.hasSolution()) {
+          requestedPower = Math.abs(duty);
           return;
         }
         setRequestedPower(Math.abs(duty));

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -2,27 +2,41 @@ package neqsim.process.equipment.stream;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.UUID;
+import neqsim.util.unit.PowerUnit;
 
 /**
  * Named, typed connection point between process equipment and an {@link EnergyStream}.
  *
  * <p>
- * An energy port separates three concerns that were previously implicit in the sign of a duty: the physical energy
- * domain, the physical transfer direction, and the calculation role. This lets graph-based schedulers order an energy
- * producer before a consumer without changing the legacy {@code EnergyStream} duty convention.
+ * An energy port separates the physical domain, transfer direction, calculation role, requested power, and allocated
+ * power. Each port owns a persistent participant identifier so an energy network remains valid when equipment is
+ * renamed.
+ * </p>
  *
  * @author NeqSim
- * @version 1.0
+ * @version 2.0
  */
 public class EnergyPort implements Serializable {
   private static final long serialVersionUID = 1000L;
 
+  private final String participantId = UUID.randomUUID().toString();
   private final String name;
   private final EnergyType energyType;
   private final EnergyPortDirection direction;
   private EnergyPortMode mode;
   private String ownerName = "";
   private EnergyStream energyStream;
+  private int priority = 100;
+  private double requestedPower = 0.0;
+  private double minimumPower = 0.0;
+  private double maximumPower = Double.POSITIVE_INFINITY;
+  private double maximumBalanceGeneration = 0.0;
+  private double maximumBalanceConsumption = 0.0;
+  private double energyPricePerMWh = 0.0;
+  private double emissionFactorKgPerMWh = 0.0;
+  private double conversionLoss = 0.0;
+  private EnergyQuality requiredQuality = new EnergyQuality();
 
   /**
    * Creates an unconnected energy port.
@@ -43,6 +57,15 @@ public class EnergyPort implements Serializable {
   }
 
   /**
+   * Gets the persistent network-participant identifier.
+   *
+   * @return participant identifier
+   */
+  public String getParticipantId() {
+    return participantId;
+  }
+
+  /**
    * Gets the port name.
    *
    * @return port name
@@ -52,7 +75,7 @@ public class EnergyPort implements Serializable {
   }
 
   /**
-   * Gets the owning equipment name used for energy-bus contribution keys.
+   * Gets the owning equipment name used for display and reporting.
    *
    * @return owner name, or an empty string when the port is standalone
    */
@@ -61,12 +84,21 @@ public class EnergyPort implements Serializable {
   }
 
   /**
-   * Sets the owning equipment name used for energy-bus contribution keys.
+   * Sets the owning equipment display name.
    *
    * @param ownerName equipment name
    */
   public void setOwnerName(String ownerName) {
     this.ownerName = Objects.requireNonNull(ownerName, "ownerName cannot be null");
+  }
+
+  /**
+   * Gets a human-readable participant name.
+   *
+   * @return owner and port name
+   */
+  public String getParticipantName() {
+    return ownerName.isEmpty() ? name : ownerName + "." + name;
   }
 
   /**
@@ -103,6 +135,219 @@ public class EnergyPort implements Serializable {
    */
   public void setMode(EnergyPortMode mode) {
     this.mode = Objects.requireNonNull(mode, "mode cannot be null");
+    invalidateBusSolution();
+  }
+
+  /**
+   * Gets dispatch priority.
+   *
+   * @return priority, where lower values are dispatched first
+   */
+  public int getPriority() {
+    return priority;
+  }
+
+  /**
+   * Sets dispatch priority.
+   *
+   * @param priority priority, where lower values are dispatched first
+   */
+  public void setPriority(int priority) {
+    this.priority = priority;
+    invalidateBusSolution();
+  }
+
+  /**
+   * Gets requested power.
+   *
+   * @return non-negative request in W
+   */
+  public double getRequestedPower() {
+    return requestedPower;
+  }
+
+  /**
+   * Gets requested power in a requested unit.
+   *
+   * @param unit power unit
+   * @return request in the requested unit
+   */
+  public double getRequestedPower(String unit) {
+    return new PowerUnit(requestedPower, "W").getValue(unit);
+  }
+
+  /**
+   * Sets requested power for a specification port.
+   *
+   * @param requestedPower non-negative request in W
+   */
+  public void setRequestedPower(double requestedPower) {
+    if (!Double.isFinite(requestedPower) || requestedPower < 0.0) {
+      throw new IllegalArgumentException("Requested power must be non-negative and finite");
+    }
+    this.requestedPower = requestedPower;
+    invalidateBusSolution();
+  }
+
+  /**
+   * Sets requested power in a specified unit.
+   *
+   * @param requestedPower non-negative request
+   * @param unit power unit
+   */
+  public void setRequestedPower(double requestedPower, String unit) {
+    setRequestedPower(new PowerUnit(requestedPower, unit).getValue("W"));
+  }
+
+  /**
+   * Sets normal operating limits.
+   *
+   * @param minimumPower minimum dispatched power in W
+   * @param maximumPower maximum dispatched power in W
+   */
+  public void setPowerLimits(double minimumPower, double maximumPower) {
+    if (!Double.isFinite(minimumPower) || minimumPower < 0.0) {
+      throw new IllegalArgumentException("Minimum power must be non-negative and finite");
+    }
+    if (Double.isNaN(maximumPower) || maximumPower < minimumPower) {
+      throw new IllegalArgumentException("Maximum power must be at least the minimum power");
+    }
+    this.minimumPower = minimumPower;
+    this.maximumPower = maximumPower;
+    invalidateBusSolution();
+  }
+
+  /**
+   * Gets minimum operating power.
+   *
+   * @return minimum power in W
+   */
+  public double getMinimumPower() {
+    return minimumPower;
+  }
+
+  /**
+   * Gets maximum operating power.
+   *
+   * @return maximum power in W
+   */
+  public double getMaximumPower() {
+    return maximumPower;
+  }
+
+  /**
+   * Sets available balancing limits.
+   *
+   * @param generationLimit maximum power injected into the bus in W
+   * @param consumptionLimit maximum power absorbed from the bus in W
+   */
+  public void setBalanceLimits(double generationLimit, double consumptionLimit) {
+    if (!Double.isFinite(generationLimit) || generationLimit < 0.0 || !Double.isFinite(consumptionLimit)
+        || consumptionLimit < 0.0) {
+      throw new IllegalArgumentException("Balance limits must be non-negative and finite");
+    }
+    maximumBalanceGeneration = generationLimit;
+    maximumBalanceConsumption = consumptionLimit;
+    invalidateBusSolution();
+  }
+
+  /**
+   * Gets maximum balancing generation.
+   *
+   * @return generation limit in W
+   */
+  public double getMaximumBalanceGeneration() {
+    return maximumBalanceGeneration;
+  }
+
+  /**
+   * Gets maximum balancing consumption.
+   *
+   * @return consumption limit in W
+   */
+  public double getMaximumBalanceConsumption() {
+    return maximumBalanceConsumption;
+  }
+
+  /**
+   * Sets marginal energy price used by network reports.
+   *
+   * @param price price per MWh
+   */
+  public void setEnergyPricePerMWh(double price) {
+    if (!Double.isFinite(price)) {
+      throw new IllegalArgumentException("Energy price must be finite");
+    }
+    energyPricePerMWh = price;
+  }
+
+  /**
+   * Gets marginal energy price.
+   *
+   * @return price per MWh
+   */
+  public double getEnergyPricePerMWh() {
+    return energyPricePerMWh;
+  }
+
+  /**
+   * Sets the emission factor used by network reports.
+   *
+   * @param factor CO2-equivalent factor in kg/MWh
+   */
+  public void setEmissionFactorKgPerMWh(double factor) {
+    if (!Double.isFinite(factor) || factor < 0.0) {
+      throw new IllegalArgumentException("Emission factor must be non-negative and finite");
+    }
+    emissionFactorKgPerMWh = factor;
+  }
+
+  /**
+   * Gets the emission factor.
+   *
+   * @return CO2-equivalent factor in kg/MWh
+   */
+  public double getEmissionFactorKgPerMWh() {
+    return emissionFactorKgPerMWh;
+  }
+
+  /**
+   * Sets conversion loss reported by the connected conversion equipment.
+   *
+   * @param conversionLoss loss in W
+   */
+  public void setConversionLoss(double conversionLoss) {
+    if (!Double.isFinite(conversionLoss) || conversionLoss < 0.0) {
+      throw new IllegalArgumentException("Conversion loss must be non-negative and finite");
+    }
+    this.conversionLoss = conversionLoss;
+  }
+
+  /**
+   * Gets reported conversion loss.
+   *
+   * @return loss in W
+   */
+  public double getConversionLoss() {
+    return conversionLoss;
+  }
+
+  /**
+   * Gets required quality metadata.
+   *
+   * @return required quality
+   */
+  public EnergyQuality getRequiredQuality() {
+    return requiredQuality;
+  }
+
+  /**
+   * Sets required quality metadata.
+   *
+   * @param requiredQuality required quality
+   */
+  public void setRequiredQuality(EnergyQuality requiredQuality) {
+    this.requiredQuality = Objects.requireNonNull(requiredQuality, "requiredQuality cannot be null");
   }
 
   /**
@@ -111,9 +356,10 @@ public class EnergyPort implements Serializable {
    * <p>
    * A legacy stream with type {@link EnergyType#UNSPECIFIED} adopts the port type. A typed stream can only be connected
    * to a port of the same type or to an unspecified port.
+   * </p>
    *
    * @param stream energy stream to connect
-   * @throws IllegalArgumentException if the stream and port energy types conflict
+   * @throws IllegalArgumentException if stream type or specified quality conflicts with this port
    */
   public void connect(EnergyStream stream) {
     Objects.requireNonNull(stream, "stream cannot be null");
@@ -125,16 +371,22 @@ public class EnergyPort implements Serializable {
     if (streamType == EnergyType.UNSPECIFIED && energyType != EnergyType.UNSPECIFIED) {
       stream.setEnergyType(energyType);
     }
+    if (!stream.getQuality().satisfies(requiredQuality)) {
+      throw new IllegalArgumentException("Energy quality is incompatible with port " + getParticipantName());
+    }
     if (energyStream instanceof EnergyBus && energyStream != stream) {
-      ((EnergyBus) energyStream).removeContribution(getContributionKey());
+      ((EnergyBus) energyStream).unregisterPort(this);
     }
     energyStream = stream;
+    if (stream instanceof EnergyBus) {
+      ((EnergyBus) stream).registerPort(this);
+    }
   }
 
   /** Disconnects the current energy stream, if any. */
   public void disconnect() {
     if (energyStream instanceof EnergyBus) {
-      ((EnergyBus) energyStream).removeContribution(getContributionKey());
+      ((EnergyBus) energyStream).unregisterPort(this);
     }
     energyStream = null;
   }
@@ -168,9 +420,13 @@ public class EnergyPort implements Serializable {
     if (stream instanceof EnergyBus) {
       EnergyBus bus = (EnergyBus) stream;
       if (mode == EnergyPortMode.CALCULATED) {
-        return bus.getContribution(getContributionKey());
+        return bus.getContribution(participantId);
       }
-      return bus.getNetPowerExcluding(getContributionKey());
+      if (bus.hasSolution()) {
+        double allocation = bus.getAllocation(participantId);
+        return direction == EnergyPortDirection.BIDIRECTIONAL ? allocation : Math.abs(allocation);
+      }
+      return bus.getNetPowerExcluding(participantId);
     }
     return stream.getDuty();
   }
@@ -178,24 +434,11 @@ public class EnergyPort implements Serializable {
   /**
    * Gets the non-negative transferred-power magnitude in watts.
    *
-   * <p>
-   * This is the preferred accessor for typed ports because physical direction is represented by {@link #getDirection()}
-   * rather than by a legacy duty sign.
-   *
    * @return absolute duty in W
    * @throws IllegalStateException if no stream is connected
    */
   public double getPowerMagnitude() {
-    double duty = getDuty();
-    if (energyStream instanceof EnergyBus && mode != EnergyPortMode.CALCULATED) {
-      if (direction == EnergyPortDirection.INPUT) {
-        return Math.max(0.0, duty);
-      }
-      if (direction == EnergyPortDirection.OUTPUT) {
-        return Math.max(0.0, -duty);
-      }
-    }
-    return Math.abs(duty);
+    return Math.abs(getDuty());
   }
 
   /**
@@ -206,7 +449,7 @@ public class EnergyPort implements Serializable {
    * @throws IllegalStateException if no stream is connected
    */
   public double getPowerMagnitude(String unit) {
-    return new neqsim.util.unit.PowerUnit(getPowerMagnitude(), "W").getValue(unit);
+    return new PowerUnit(getPowerMagnitude(), "W").getValue(unit);
   }
 
   /**
@@ -217,27 +460,37 @@ public class EnergyPort implements Serializable {
    * @throws IllegalStateException if no stream is connected
    */
   public double getDuty(String unit) {
-    return new neqsim.util.unit.PowerUnit(getDuty(), "W").getValue(unit);
+    return new PowerUnit(getDuty(), "W").getValue(unit);
   }
 
   /**
-   * Sets the connected stream duty in watts.
+   * Sets calculated power or a specification request in watts.
    *
    * @param duty duty in W
    * @throws IllegalStateException if no stream is connected
    */
   public void setDuty(double duty) {
+    if (!Double.isFinite(duty)) {
+      throw new IllegalArgumentException("Energy-port duty must be finite");
+    }
     EnergyStream stream = requireConnectedStream();
     if (stream instanceof EnergyBus) {
+      EnergyBus bus = (EnergyBus) stream;
+      if (mode == EnergyPortMode.SPECIFICATION) {
+        setRequestedPower(Math.abs(duty));
+        return;
+      }
+      if (mode == EnergyPortMode.BALANCE) {
+        setRequestedPower(Math.abs(duty));
+        return;
+      }
       double contribution = duty;
       if (direction == EnergyPortDirection.INPUT) {
         contribution = -Math.abs(duty);
       } else if (direction == EnergyPortDirection.OUTPUT) {
         contribution = Math.abs(duty);
-      } else if (mode == EnergyPortMode.SPECIFICATION) {
-        contribution = -duty;
       }
-      ((EnergyBus) stream).setContribution(getContributionKey(), contribution);
+      bus.setContribution(participantId, contribution);
     } else {
       stream.setDuty(duty);
     }
@@ -251,13 +504,21 @@ public class EnergyPort implements Serializable {
    * @throws IllegalStateException if no stream is connected
    */
   public void setDuty(double duty, String unit) {
-    setDuty(new neqsim.util.unit.PowerUnit(duty, unit).getValue("W"));
+    setDuty(new PowerUnit(duty, unit).getValue("W"));
   }
 
-  private String getContributionKey() {
-    return ownerName.isEmpty() ? name : ownerName + "." + name;
+  /** Invalidates the connected bus solution after a port setting changes. */
+  private void invalidateBusSolution() {
+    if (energyStream instanceof EnergyBus) {
+      ((EnergyBus) energyStream).invalidateSolution();
+    }
   }
 
+  /**
+   * Gets the connected stream or raises a configuration error.
+   *
+   * @return connected stream
+   */
   private EnergyStream requireConnectedStream() {
     if (energyStream == null) {
       throw new IllegalStateException("Energy port " + name + " is not connected");

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -1,5 +1,7 @@
 package neqsim.process.equipment.stream;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
@@ -54,6 +56,25 @@ public class EnergyPort implements Serializable {
     this.energyType = Objects.requireNonNull(energyType, "energyType cannot be null");
     this.direction = Objects.requireNonNull(direction, "direction cannot be null");
     this.mode = Objects.requireNonNull(mode, "mode cannot be null");
+  }
+
+  /**
+   * Restores defaults introduced after the original serialized energy-port format.
+   *
+   * @param input serialized object input
+   * @throws IOException if the stream cannot be read
+   * @throws ClassNotFoundException if a serialized class cannot be resolved
+   */
+  private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
+    input.defaultReadObject();
+    if (participantId == null) {
+      participantId = UUID.randomUUID().toString();
+      priority = 100;
+      maximumPower = Double.POSITIVE_INFINITY;
+    }
+    if (requiredQuality == null) {
+      requiredQuality = new EnergyQuality();
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyPort.java
@@ -457,8 +457,7 @@ public class EnergyPort implements Serializable {
         return bus.getContribution(participantId);
       }
       if (bus.hasSolution()) {
-        double allocation = bus.getAllocation(participantId);
-        return direction == EnergyPortDirection.BIDIRECTIONAL ? allocation : Math.abs(allocation);
+        return bus.getAllocation(participantId);
       }
       return bus.getNetPowerExcluding(participantId);
     }
@@ -504,11 +503,11 @@ public class EnergyPort implements Serializable {
    * @throws IllegalStateException if no stream is connected
    */
   public void setDuty(double duty) {
-    if (!Double.isFinite(duty)) {
-      throw new IllegalArgumentException("Energy-port duty must be finite");
-    }
     EnergyStream stream = requireConnectedStream();
     if (stream instanceof EnergyBus) {
+      if (!Double.isFinite(duty)) {
+        throw new IllegalArgumentException("Energy-port duty must be finite on an energy bus");
+      }
       EnergyBus bus = (EnergyBus) stream;
       if (mode == EnergyPortMode.SPECIFICATION) {
         if (bus.hasSolution()) {

--- a/src/main/java/neqsim/process/equipment/stream/EnergyQuality.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyQuality.java
@@ -1,0 +1,214 @@
+package neqsim.process.equipment.stream;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Quality metadata carried by an {@link EnergyStream}.
+ *
+ * <p>
+ * Power alone is not sufficient to determine whether two energy connections are compatible. Electrical systems also
+ * require voltage and frequency, thermal utilities require a temperature grade, and rotating equipment requires a
+ * compatible shaft speed. Unspecified values remain backward compatible and act as wildcards.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class EnergyQuality implements Serializable, Cloneable {
+  private static final long serialVersionUID = 1000L;
+
+  private UtilityLevel utilityLevel = UtilityLevel.UNSPECIFIED;
+  private double voltage = Double.NaN;
+  private double frequency = Double.NaN;
+  private double temperature = Double.NaN;
+  private double pressure = Double.NaN;
+  private double shaftSpeed = Double.NaN;
+
+  /** Creates unspecified energy quality metadata. */
+  public EnergyQuality() {
+  }
+
+  /**
+   * Creates quality metadata for a standard utility grade.
+   *
+   * @param utilityLevel standard utility grade
+   */
+  public EnergyQuality(UtilityLevel utilityLevel) {
+    setUtilityLevel(utilityLevel);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public EnergyQuality clone() {
+    try {
+      return (EnergyQuality) super.clone();
+    } catch (CloneNotSupportedException ex) {
+      throw new IllegalStateException("Energy quality could not be cloned", ex);
+    }
+  }
+
+  /**
+   * Checks whether this supplied quality can satisfy a requirement.
+   *
+   * <p>
+   * Unspecified supplied or required values are treated as compatible. Specified electrical values use a five-percent
+   * voltage tolerance and a two-percent frequency tolerance. A specified utility level must match exactly.
+   * </p>
+   *
+   * @param required required quality metadata
+   * @return {@code true} when the supplied quality is compatible
+   */
+  public boolean satisfies(EnergyQuality required) {
+    if (required == null) {
+      return true;
+    }
+    if (required.utilityLevel != UtilityLevel.UNSPECIFIED && utilityLevel != UtilityLevel.UNSPECIFIED
+        && required.utilityLevel != utilityLevel) {
+      return false;
+    }
+    return matchesWithinTolerance(voltage, required.voltage, 0.05)
+        && matchesWithinTolerance(frequency, required.frequency, 0.02)
+        && matchesWithinTolerance(shaftSpeed, required.shaftSpeed, 0.05);
+  }
+
+  /**
+   * Compares a supplied and required value using a relative tolerance.
+   *
+   * @param supplied supplied value
+   * @param required required value
+   * @param tolerance relative tolerance
+   * @return {@code true} when compatible
+   */
+  private static boolean matchesWithinTolerance(double supplied, double required, double tolerance) {
+    if (!Double.isFinite(supplied) || !Double.isFinite(required)) {
+      return true;
+    }
+    return Math.abs(supplied - required) <= Math.max(1.0, Math.abs(required)) * tolerance;
+  }
+
+  /**
+   * Gets the utility grade.
+   *
+   * @return utility grade
+   */
+  public UtilityLevel getUtilityLevel() {
+    return utilityLevel;
+  }
+
+  /**
+   * Sets the utility grade.
+   *
+   * @param utilityLevel utility grade
+   */
+  public void setUtilityLevel(UtilityLevel utilityLevel) {
+    this.utilityLevel = Objects.requireNonNull(utilityLevel, "utilityLevel cannot be null");
+  }
+
+  /**
+   * Gets electrical voltage.
+   *
+   * @return voltage in V, or {@link Double#NaN} when unspecified
+   */
+  public double getVoltage() {
+    return voltage;
+  }
+
+  /**
+   * Sets electrical voltage.
+   *
+   * @param voltage voltage in V
+   */
+  public void setVoltage(double voltage) {
+    this.voltage = requirePositiveOrNaN(voltage, "voltage");
+  }
+
+  /**
+   * Gets electrical frequency.
+   *
+   * @return frequency in Hz, or {@link Double#NaN} when unspecified
+   */
+  public double getFrequency() {
+    return frequency;
+  }
+
+  /**
+   * Sets electrical frequency.
+   *
+   * @param frequency frequency in Hz
+   */
+  public void setFrequency(double frequency) {
+    this.frequency = requirePositiveOrNaN(frequency, "frequency");
+  }
+
+  /**
+   * Gets thermal temperature.
+   *
+   * @return temperature in K, or {@link Double#NaN} when unspecified
+   */
+  public double getTemperature() {
+    return temperature;
+  }
+
+  /**
+   * Sets thermal temperature.
+   *
+   * @param temperature temperature in K
+   */
+  public void setTemperature(double temperature) {
+    this.temperature = requirePositiveOrNaN(temperature, "temperature");
+  }
+
+  /**
+   * Gets utility pressure.
+   *
+   * @return pressure in Pa, or {@link Double#NaN} when unspecified
+   */
+  public double getPressure() {
+    return pressure;
+  }
+
+  /**
+   * Sets utility pressure.
+   *
+   * @param pressure pressure in Pa
+   */
+  public void setPressure(double pressure) {
+    this.pressure = requirePositiveOrNaN(pressure, "pressure");
+  }
+
+  /**
+   * Gets shaft speed.
+   *
+   * @return speed in rpm, or {@link Double#NaN} when unspecified
+   */
+  public double getShaftSpeed() {
+    return shaftSpeed;
+  }
+
+  /**
+   * Sets shaft speed.
+   *
+   * @param shaftSpeed speed in rpm
+   */
+  public void setShaftSpeed(double shaftSpeed) {
+    this.shaftSpeed = requirePositiveOrNaN(shaftSpeed, "shaftSpeed");
+  }
+
+  /**
+   * Validates a positive optional value.
+   *
+   * @param value candidate value
+   * @param property property name
+   * @return validated value
+   */
+  private static double requirePositiveOrNaN(double value, String property) {
+    if (Double.isNaN(value)) {
+      return value;
+    }
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(property + " must be positive and finite, or NaN when unspecified");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/stream/EnergyQuality.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyQuality.java
@@ -69,6 +69,8 @@ public class EnergyQuality implements Serializable, Cloneable {
     }
     return matchesWithinTolerance(voltage, required.voltage, 0.05)
         && matchesWithinTolerance(frequency, required.frequency, 0.02)
+        && matchesWithinTolerance(temperature, required.temperature, 0.02)
+        && matchesWithinTolerance(pressure, required.pressure, 0.05)
         && matchesWithinTolerance(shaftSpeed, required.shaftSpeed, 0.05);
   }
 

--- a/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
@@ -109,9 +109,9 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
    * Sets the duty in watts.
    *
    * <p>
-   * Legacy point-to-point streams retain support for non-finite intermediate values used by existing equipment
-   * fallback calculations. Multi-party {@link EnergyBus} connections reject non-finite duties because allocation
-   * requires finite inputs.
+   * Legacy point-to-point streams retain support for non-finite intermediate values used by existing equipment fallback
+   * calculations. Multi-party {@link EnergyBus} connections reject non-finite duties because allocation requires finite
+   * inputs.
    * </p>
    *
    * @param duty duty in W

--- a/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
@@ -108,12 +108,15 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
   /**
    * Sets the duty in watts.
    *
+   * <p>
+   * Legacy point-to-point streams retain support for non-finite intermediate values used by existing equipment
+   * fallback calculations. Multi-party {@link EnergyBus} connections reject non-finite duties because allocation
+   * requires finite inputs.
+   * </p>
+   *
    * @param duty duty in W
    */
   public void setDuty(double duty) {
-    if (!Double.isFinite(duty)) {
-      throw new IllegalArgumentException("Energy-stream duty must be finite");
-    }
     this.duty = duty;
   }
 

--- a/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
@@ -1,5 +1,7 @@
 package neqsim.process.equipment.stream;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,6 +54,23 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
   public EnergyStream(String name, EnergyType energyType) {
     this.name = name;
     this.energyType = Objects.requireNonNull(energyType, "energyType cannot be null");
+  }
+
+  /**
+   * Restores defaults introduced after the original serialized energy-stream format.
+   *
+   * @param input serialized object input
+   * @throws IOException if the stream cannot be read
+   * @throws ClassNotFoundException if a serialized class cannot be resolved
+   */
+  private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
+    input.defaultReadObject();
+    if (energyType == null) {
+      energyType = EnergyType.UNSPECIFIED;
+    }
+    if (quality == null) {
+      quality = new EnergyQuality();
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyStream.java
@@ -13,6 +13,7 @@ import neqsim.util.unit.PowerUnit;
  * The canonical stored value is duty in watts. Positive and negative values remain supported for compatibility with
  * existing models; new equipment should use {@link EnergyPort} metadata to express physical direction instead of
  * encoding direction only in the duty sign.
+ * </p>
  *
  * @author asmund
  * @version $Id: $Id
@@ -27,6 +28,7 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
   private String tagNumber = "";
   protected double duty = 0.0;
   private EnergyType energyType = EnergyType.UNSPECIFIED;
+  private EnergyQuality quality = new EnergyQuality();
 
   /** Creates an unnamed, unspecified energy stream with zero duty. */
   public EnergyStream() {
@@ -58,6 +60,7 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
     EnergyStream clonedStream = null;
     try {
       clonedStream = (EnergyStream) super.clone();
+      clonedStream.quality = quality.clone();
     } catch (Exception ex) {
       logger.error(ex.getMessage());
     }
@@ -89,6 +92,9 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
    * @param duty duty in W
    */
   public void setDuty(double duty) {
+    if (!Double.isFinite(duty)) {
+      throw new IllegalArgumentException("Energy-stream duty must be finite");
+    }
     this.duty = duty;
   }
 
@@ -194,6 +200,24 @@ public class EnergyStream implements ProcessElementInterface, Cloneable {
    */
   public void setEnergyType(EnergyType energyType) {
     this.energyType = Objects.requireNonNull(energyType, "energyType cannot be null");
+  }
+
+  /**
+   * Gets mutable energy-quality metadata.
+   *
+   * @return quality metadata
+   */
+  public EnergyQuality getQuality() {
+    return quality;
+  }
+
+  /**
+   * Replaces energy-quality metadata.
+   *
+   * @param quality quality metadata
+   */
+  public void setQuality(EnergyQuality quality) {
+    this.quality = Objects.requireNonNull(quality, "quality cannot be null");
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/stream/EnergyType.java
+++ b/src/main/java/neqsim/process/equipment/stream/EnergyType.java
@@ -7,9 +7,10 @@ package neqsim.process.equipment.stream;
  * The type is metadata used to prevent accidental connections such as wiring an electrical generator directly to a
  * heat-duty port. {@link #UNSPECIFIED} preserves compatibility with legacy energy streams that did not declare a
  * domain.
+ * </p>
  *
  * @author NeqSim
- * @version 1.0
+ * @version 2.0
  */
 public enum EnergyType {
   /** Legacy or otherwise unspecified energy domain. */
@@ -19,5 +20,7 @@ public enum EnergyType {
   /** Mechanical shaft work transferred between rotating equipment. */
   SHAFT_WORK,
   /** Electrical power transferred between electrical equipment and loads. */
-  ELECTRICAL
+  ELECTRICAL,
+  /** Chemical or fuel energy rate based on a declared heating-value convention. */
+  CHEMICAL
 }

--- a/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
+++ b/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
@@ -157,7 +157,7 @@ public class MechanicalShaft extends EnergyBus {
       throw new IllegalArgumentException("Maximum shaft speed must be positive");
     }
     this.maximumSpeed = maximumSpeed;
-    speed = Math.min(speed, maximumSpeed);
+    setSpeed(Math.min(speed, maximumSpeed));
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
+++ b/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
@@ -79,6 +79,8 @@ public class MechanicalShaft extends EnergyBus {
     this.speed = Math.min(speed, maximumSpeed);
     if (this.speed > 0.0) {
       getQuality().setShaftSpeed(this.speed);
+    } else {
+      getQuality().setShaftSpeed(Double.NaN);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
+++ b/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
@@ -273,7 +273,13 @@ public class MechanicalShaft extends EnergyBus {
    * @return effective net power in W
    */
   private double getEffectiveNetPower() {
-    double netPower = getNetPower();
-    return tripped ? Math.min(0.0, netPower) : netPower;
+    if (!tripped) {
+      return getNetPower();
+    }
+    double loadPower = Math.min(0.0, duty);
+    for (Double contribution : getContributions().values()) {
+      loadPower += Math.min(0.0, contribution.doubleValue());
+    }
+    return loadPower;
   }
 }

--- a/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
+++ b/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
@@ -4,12 +4,13 @@ package neqsim.process.equipment.stream;
  * Shared rotating shaft that balances mechanical power producers and loads.
  *
  * <p>
- * Producers add positive contributions with {@link #setGeneratedPower(String, double)}, while compressors, pumps, and
- * other loads add positive demands with {@link #setConsumedPower(String, double)}. The inherited net bus power is
- * positive when generation exceeds demand and negative when the shaft is under-powered.
+ * In steady state the inherited bus residual is positive when generation exceeds demand and negative when the shaft is
+ * under-powered. In transient mode {@link #advanceTransient(double)} integrates rotational kinetic energy,
+ * {@code d(0.5 J omega^2)/dt = Pnet}, with optional friction, speed, acceleration, and trip limits.
+ * </p>
  *
  * @author NeqSim
- * @version 1.0
+ * @version 2.0
  */
 public class MechanicalShaft extends EnergyBus {
   private static final long serialVersionUID = 1000L;
@@ -17,6 +18,11 @@ public class MechanicalShaft extends EnergyBus {
   private double speed = 0.0;
   private double momentOfInertia = 0.0;
   private double mechanicalEfficiency = 1.0;
+  private double frictionLoss = 0.0;
+  private double maximumSpeed = Double.POSITIVE_INFINITY;
+  private double maximumAcceleration = Double.POSITIVE_INFINITY;
+  private double maximumDeceleration = Double.POSITIVE_INFINITY;
+  private boolean tripped = false;
 
   /** Creates an unnamed shaft. */
   public MechanicalShaft() {
@@ -70,7 +76,10 @@ public class MechanicalShaft extends EnergyBus {
     if (!Double.isFinite(speed) || speed < 0.0) {
       throw new IllegalArgumentException("Shaft speed must be finite and non-negative");
     }
-    this.speed = speed;
+    this.speed = Math.min(speed, maximumSpeed);
+    if (this.speed > 0.0) {
+      getQuality().setShaftSpeed(this.speed);
+    }
   }
 
   /**
@@ -113,5 +122,158 @@ public class MechanicalShaft extends EnergyBus {
       throw new IllegalArgumentException("Shaft efficiency must be in (0, 1]");
     }
     this.mechanicalEfficiency = mechanicalEfficiency;
+  }
+
+  /**
+   * Gets speed-dependent aggregate friction loss.
+   *
+   * @return friction loss in W
+   */
+  public double getFrictionLoss() {
+    return frictionLoss;
+  }
+
+  /**
+   * Sets aggregate friction loss.
+   *
+   * @param frictionLoss friction loss in W
+   */
+  public void setFrictionLoss(double frictionLoss) {
+    if (!Double.isFinite(frictionLoss) || frictionLoss < 0.0) {
+      throw new IllegalArgumentException("Shaft friction loss must be non-negative and finite");
+    }
+    this.frictionLoss = frictionLoss;
+  }
+
+  /**
+   * Sets maximum shaft speed.
+   *
+   * @param maximumSpeed maximum speed in rpm
+   */
+  public void setMaximumSpeed(double maximumSpeed) {
+    if (Double.isNaN(maximumSpeed) || maximumSpeed <= 0.0) {
+      throw new IllegalArgumentException("Maximum shaft speed must be positive");
+    }
+    this.maximumSpeed = maximumSpeed;
+    speed = Math.min(speed, maximumSpeed);
+  }
+
+  /**
+   * Gets maximum shaft speed.
+   *
+   * @return maximum speed in rpm
+   */
+  public double getMaximumSpeed() {
+    return maximumSpeed;
+  }
+
+  /**
+   * Sets shaft acceleration and deceleration limits.
+   *
+   * @param maximumAcceleration maximum speed increase in rpm/s
+   * @param maximumDeceleration maximum speed decrease in rpm/s
+   */
+  public void setAccelerationLimits(double maximumAcceleration, double maximumDeceleration) {
+    if (Double.isNaN(maximumAcceleration) || maximumAcceleration <= 0.0 || Double.isNaN(maximumDeceleration)
+        || maximumDeceleration <= 0.0) {
+      throw new IllegalArgumentException("Shaft acceleration limits must be positive");
+    }
+    this.maximumAcceleration = maximumAcceleration;
+    this.maximumDeceleration = maximumDeceleration;
+  }
+
+  /**
+   * Trips or resets shaft generation.
+   *
+   * <p>
+   * While tripped, positive net power is ignored and the shaft can only coast down through load and friction.
+   * </p>
+   *
+   * @param tripped trip state
+   */
+  public void setTripped(boolean tripped) {
+    this.tripped = tripped;
+  }
+
+  /**
+   * Checks shaft trip state.
+   *
+   * @return {@code true} when tripped
+   */
+  public boolean isTripped() {
+    return tripped;
+  }
+
+  /**
+   * Gets current net shaft torque.
+   *
+   * @return torque in N m, or zero at standstill
+   */
+  public double getNetTorque() {
+    double angularSpeed = speed * 2.0 * Math.PI / 60.0;
+    if (angularSpeed <= 0.0) {
+      return 0.0;
+    }
+    return (getEffectiveNetPower() - frictionLoss) / angularSpeed;
+  }
+
+  /**
+   * Advances shaft speed from the current energy-network imbalance.
+   *
+   * @param dt timestep in seconds
+   * @return updated speed in rpm
+   */
+  public double advanceTransient(double dt) {
+    if (!Double.isFinite(dt) || dt < 0.0) {
+      throw new IllegalArgumentException("Transient shaft timestep must be non-negative and finite");
+    }
+    if (dt == 0.0) {
+      return speed;
+    }
+    if (momentOfInertia <= 0.0) {
+      throw new IllegalStateException("A positive shaft moment of inertia is required for transient integration");
+    }
+
+    double oldSpeed = speed;
+    double oldAngularSpeed = oldSpeed * 2.0 * Math.PI / 60.0;
+    double netPower = getEffectiveNetPower();
+    if (oldSpeed > 0.0 || netPower > 0.0) {
+      netPower -= frictionLoss;
+    }
+    double angularSpeedSquared =
+        Math.max(0.0, oldAngularSpeed * oldAngularSpeed + 2.0 * netPower * dt / momentOfInertia);
+    double targetSpeed = Math.sqrt(angularSpeedSquared) * 60.0 / (2.0 * Math.PI);
+    targetSpeed = Math.min(targetSpeed, maximumSpeed);
+
+    double delta = targetSpeed - oldSpeed;
+    double allowedIncrease = maximumAcceleration * dt;
+    double allowedDecrease = maximumDeceleration * dt;
+    if (delta > allowedIncrease) {
+      targetSpeed = oldSpeed + allowedIncrease;
+    } else if (-delta > allowedDecrease) {
+      targetSpeed = Math.max(0.0, oldSpeed - allowedDecrease);
+    }
+    setSpeed(targetSpeed);
+    return speed;
+  }
+
+  /**
+   * Alias for {@link #advanceTransient(double)}.
+   *
+   * @param dt timestep in seconds
+   * @return updated speed in rpm
+   */
+  public double runTransient(double dt) {
+    return advanceTransient(dt);
+  }
+
+  /**
+   * Gets net power after applying trip logic.
+   *
+   * @return effective net power in W
+   */
+  private double getEffectiveNetPower() {
+    double netPower = getNetPower();
+    return tripped ? Math.min(0.0, netPower) : netPower;
   }
 }

--- a/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
+++ b/src/main/java/neqsim/process/equipment/stream/MechanicalShaft.java
@@ -240,8 +240,8 @@ public class MechanicalShaft extends EnergyBus {
     if (oldSpeed > 0.0 || netPower > 0.0) {
       netPower -= frictionLoss;
     }
-    double angularSpeedSquared =
-        Math.max(0.0, oldAngularSpeed * oldAngularSpeed + 2.0 * netPower * dt / momentOfInertia);
+    double angularSpeedSquared = Math.max(0.0,
+        oldAngularSpeed * oldAngularSpeed + 2.0 * netPower * dt / momentOfInertia);
     double targetSpeed = Math.sqrt(angularSpeedSquared) * 60.0 / (2.0 * Math.PI);
     targetSpeed = Math.min(targetSpeed, maximumSpeed);
 

--- a/src/main/java/neqsim/process/equipment/stream/UtilityLevel.java
+++ b/src/main/java/neqsim/process/equipment/stream/UtilityLevel.java
@@ -1,0 +1,28 @@
+package neqsim.process.equipment.stream;
+
+/**
+ * Standard utility grades used to describe the quality of a thermal energy stream.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public enum UtilityLevel {
+  /** No utility grade has been specified. */
+  UNSPECIFIED,
+  /** High-pressure steam. */
+  HIGH_PRESSURE_STEAM,
+  /** Medium-pressure steam. */
+  MEDIUM_PRESSURE_STEAM,
+  /** Low-pressure steam. */
+  LOW_PRESSURE_STEAM,
+  /** Hot-oil utility. */
+  HOT_OIL,
+  /** Cooling-water utility. */
+  COOLING_WATER,
+  /** Chilled-water utility. */
+  CHILLED_WATER,
+  /** Refrigeration utility. */
+  REFRIGERATION,
+  /** Ambient or air-cooling utility. */
+  AMBIENT_COOLING
+}

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -525,12 +525,9 @@ public final class ProcessGraphBuilder {
     // physical direction, determines scheduling order. A point-to-point
     // EnergyStream permits one producer and one consumer; EnergyBus supports
     // multi-party generation, demand, and balancing.
-    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToProducers =
-        new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
-    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToConsumers =
-        new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
-    Map<EnergyStream, EnergyNetworkSolver> energyToSolver =
-        new IdentityHashMap<EnergyStream, EnergyNetworkSolver>();
+    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToProducers = new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
+    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToConsumers = new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
+    Map<EnergyStream, EnergyNetworkSolver> energyToSolver = new IdentityHashMap<EnergyStream, EnergyNetworkSolver>();
 
     for (ProcessEquipmentInterface unit : units) {
       if (unit instanceof EnergyNetworkSolver) {
@@ -553,8 +550,7 @@ public final class ProcessGraphBuilder {
         if (port.getMode() == EnergyPortMode.CALCULATED) {
           targetMap = energyToProducers;
           role = "calculation producers";
-        } else if (port.getMode() == EnergyPortMode.SPECIFICATION
-            || port.getMode() == EnergyPortMode.BALANCE) {
+        } else if (port.getMode() == EnergyPortMode.SPECIFICATION || port.getMode() == EnergyPortMode.BALANCE) {
           targetMap = energyToConsumers;
           role = "specification or balance consumers";
         }

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.TwoPortInterface;
 import neqsim.process.equipment.ejector.Ejector;
+import neqsim.process.equipment.energy.EnergyNetworkSolver;
 import neqsim.process.equipment.expander.TurboExpanderCompressor;
 import neqsim.process.equipment.flare.FlareStack;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
@@ -524,10 +525,24 @@ public final class ProcessGraphBuilder {
     // physical direction, determines scheduling order. A point-to-point
     // EnergyStream permits one producer and one consumer; EnergyBus supports
     // multi-party generation, demand, and balancing.
-    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToProducers = new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
-    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToConsumers = new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
+    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToProducers =
+        new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
+    Map<EnergyStream, List<ProcessEquipmentInterface>> energyToConsumers =
+        new IdentityHashMap<EnergyStream, List<ProcessEquipmentInterface>>();
+    Map<EnergyStream, EnergyNetworkSolver> energyToSolver =
+        new IdentityHashMap<EnergyStream, EnergyNetworkSolver>();
 
     for (ProcessEquipmentInterface unit : units) {
+      if (unit instanceof EnergyNetworkSolver) {
+        EnergyNetworkSolver solver = (EnergyNetworkSolver) unit;
+        for (EnergyBus bus : solver.getEnergyBuses()) {
+          EnergyNetworkSolver previous = energyToSolver.put(bus, solver);
+          if (previous != null && previous != solver) {
+            throw new IllegalStateException("Energy bus " + bus.getName() + " is assigned to multiple solvers: "
+                + previous.getName() + " and " + solver.getName());
+          }
+        }
+      }
       for (EnergyPort port : unit.getEnergyPorts().values()) {
         if (!port.isConnected()) {
           continue;
@@ -538,9 +553,10 @@ public final class ProcessGraphBuilder {
         if (port.getMode() == EnergyPortMode.CALCULATED) {
           targetMap = energyToProducers;
           role = "calculation producers";
-        } else if (port.getMode() == EnergyPortMode.SPECIFICATION) {
+        } else if (port.getMode() == EnergyPortMode.SPECIFICATION
+            || port.getMode() == EnergyPortMode.BALANCE) {
           targetMap = energyToConsumers;
-          role = "specification consumers";
+          role = "specification or balance consumers";
         }
         if (targetMap == null) {
           continue;
@@ -562,14 +578,41 @@ public final class ProcessGraphBuilder {
 
     for (Map.Entry<EnergyStream, List<ProcessEquipmentInterface>> entry : energyToProducers.entrySet()) {
       List<ProcessEquipmentInterface> consumers = energyToConsumers.get(entry.getKey());
-      if (consumers == null) {
+      EnergyNetworkSolver solver = energyToSolver.get(entry.getKey());
+      if (solver != null) {
+        for (ProcessEquipmentInterface producer : entry.getValue()) {
+          if (producer != solver) {
+            addEnergyEdgeIfAbsent(graph, producer, solver, entry.getKey());
+          }
+        }
+        if (consumers != null) {
+          for (ProcessEquipmentInterface consumer : consumers) {
+            if (consumer != solver) {
+              addEnergyEdgeIfAbsent(graph, solver, consumer, entry.getKey());
+            }
+          }
+        }
+      } else if (consumers != null) {
+        for (ProcessEquipmentInterface producer : entry.getValue()) {
+          for (ProcessEquipmentInterface consumer : consumers) {
+            if (producer != consumer) {
+              addEnergyEdgeIfAbsent(graph, producer, consumer, entry.getKey());
+            }
+          }
+        }
+      }
+    }
+
+    // A bus can contain only specification/balance participants and a solver
+    // (for example a grid connection or pre-populated external contribution).
+    for (Map.Entry<EnergyStream, List<ProcessEquipmentInterface>> entry : energyToConsumers.entrySet()) {
+      EnergyNetworkSolver solver = energyToSolver.get(entry.getKey());
+      if (solver == null || energyToProducers.containsKey(entry.getKey())) {
         continue;
       }
-      for (ProcessEquipmentInterface producer : entry.getValue()) {
-        for (ProcessEquipmentInterface consumer : consumers) {
-          if (producer != consumer) {
-            addEnergyEdgeIfAbsent(graph, producer, consumer, entry.getKey());
-          }
+      for (ProcessEquipmentInterface consumer : entry.getValue()) {
+        if (consumer != solver) {
+          addEnergyEdgeIfAbsent(graph, solver, consumer, entry.getKey());
         }
       }
     }

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -24,7 +24,11 @@ import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFrictio
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction.InterfacialFrictionResult;
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.EnergyAllocation;
 import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyNetworkReport;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
 import neqsim.process.equipment.stream.EnergyPortMode;
 import neqsim.process.equipment.stream.EnergyStream;
 import neqsim.process.equipment.stream.EnergyType;
@@ -1618,4 +1622,42 @@ public class DocExamplesCompilationTest {
     assertEquals(1.8, sparePower, 1.0e-12);
   }
 
+  /**
+   * Deterministic allocation example from docs/process/energy_streams.md.
+   */
+  @Test
+  public void testEnergyNetworkAllocationDocumentationExample() {
+    EnergyBus allocatedGrid = new EnergyBus("allocated grid", EnergyType.ELECTRICAL);
+
+    EnergyPort generator = new EnergyPort("power", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+    generator.setOwnerName("generator");
+    generator.connect(allocatedGrid);
+    generator.setDuty(100.0, "kW");
+
+    EnergyPort essentialLoad = new EnergyPort("power", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
+        EnergyPortMode.SPECIFICATION);
+    essentialLoad.setOwnerName("essential load");
+    essentialLoad.setPriority(10);
+    essentialLoad.setRequestedPower(80.0, "kW");
+    essentialLoad.connect(allocatedGrid);
+
+    EnergyPort flexibleLoad = new EnergyPort("power", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
+        EnergyPortMode.SPECIFICATION);
+    flexibleLoad.setOwnerName("flexible load");
+    flexibleLoad.setPriority(20);
+    flexibleLoad.setRequestedPower(80.0, "kW");
+    flexibleLoad.connect(allocatedGrid);
+
+    EnergyNetworkReport allocation = allocatedGrid.solveBalance();
+    double essentialAllocation = essentialLoad.getPowerMagnitude("kW");
+    double flexibleAllocation = flexibleLoad.getPowerMagnitude("kW");
+    double unmetDemand = allocation.getUnmetDemand();
+
+    assertEquals(80.0, essentialAllocation, 1.0e-12);
+    assertEquals(20.0, flexibleAllocation, 1.0e-12);
+    assertEquals(60.0, unmetDemand / 1000.0, 1.0e-12);
+  }
+
 }
+

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -24,7 +24,6 @@ import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFrictio
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction.InterfacialFrictionResult;
 import neqsim.process.equipment.separator.Separator;
-import neqsim.process.equipment.stream.EnergyAllocation;
 import neqsim.process.equipment.stream.EnergyBus;
 import neqsim.process.equipment.stream.EnergyNetworkReport;
 import neqsim.process.equipment.stream.EnergyPort;

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -17,6 +17,7 @@ import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.distillation.ColumnSpecification;
 import neqsim.process.equipment.distillation.DistillationColumn;
 import neqsim.process.equipment.distillation.RateBasedPackedColumn;
+import neqsim.process.equipment.energy.EnergyNetworkSolver;
 import neqsim.process.equipment.distillation.internals.ColumnInternalsDesigner;
 import neqsim.process.equipment.heatexchanger.CoolingWaterSystem;
 import neqsim.process.equipment.heatexchanger.FiredHeater;
@@ -1653,6 +1654,11 @@ public class DocExamplesCompilationTest {
     double flexibleAllocation = flexibleLoad.getPowerMagnitude("kW");
     double unmetDemand = allocation.getUnmetDemand();
 
+    EnergyNetworkSolver network = new EnergyNetworkSolver("electrical allocation", allocatedGrid);
+    ProcessSystem process = new ProcessSystem();
+    process.add(network);
+
+    assertEquals(1, network.getEnergyBuses().size());
     assertEquals(80.0, essentialAllocation, 1.0e-12);
     assertEquals(20.0, flexibleAllocation, 1.0e-12);
     assertEquals(60.0, unmetDemand / 1000.0, 1.0e-12);

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -1659,4 +1659,3 @@ public class DocExamplesCompilationTest {
   }
 
 }
-

--- a/src/test/java/neqsim/process/equipment/energy/EnergyConverterTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyConverterTest.java
@@ -1,0 +1,71 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
+
+class EnergyConverterTest {
+
+  @Test
+  void testMotorConvertsAllocatedElectricalPowerToShaftWork() {
+    EnergyBus electricalBus = new EnergyBus("electrical", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("shaft");
+    EnergyPort grid = port("grid", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED,
+        electricalBus);
+    EnergyPort load =
+        port("load", EnergyType.SHAFT_WORK, EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, shaft);
+    ElectricMotor motor = new ElectricMotor("motor", 0.95);
+    motor.connectEnergyStream(EnergyConverter.INPUT_PORT, electricalBus, EnergyPortMode.SPECIFICATION);
+    motor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, shaft, EnergyPortMode.CALCULATED);
+    motor.setRequestedInputPower(100000.0);
+    load.setRequestedPower(95000.0);
+    grid.setDuty(100000.0);
+
+    electricalBus.solveBalance();
+    motor.run();
+    shaft.solveBalance();
+
+    assertEquals(100000.0, motor.getInputPower(), 1.0e-9);
+    assertEquals(95000.0, motor.getOutputPower(), 1.0e-9);
+    assertEquals(5000.0, motor.getHeatLoss(), 1.0e-9);
+    assertEquals(-95000.0, shaft.getAllocation(load.getParticipantId()), 1.0e-9);
+    assertEquals(5000.0, shaft.getLastReport().getConversionLoss(), 1.0e-9);
+  }
+
+  @Test
+  void testConverterTransientRampAndTrip() {
+    EnergyBus input = new EnergyBus("input", EnergyType.ELECTRICAL);
+    EnergyBus output = new EnergyBus("output", EnergyType.ELECTRICAL);
+    EnergyPort source =
+        port("source", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, input);
+    Inverter inverter = new Inverter("inverter");
+    inverter.connectEnergyStream(EnergyConverter.INPUT_PORT, input, EnergyPortMode.SPECIFICATION);
+    inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, output, EnergyPortMode.CALCULATED);
+    inverter.setRequestedInputPower(1000.0);
+    inverter.setRampRate(100.0);
+    source.setDuty(1000.0);
+    input.solveBalance();
+
+    inverter.runTransient(2.0);
+
+    assertEquals(200.0, inverter.getOutputPower(), 1.0e-12);
+    inverter.setTripped(true);
+    inverter.runTransient(2.0);
+    assertEquals(0.0, inverter.getOutputPower(), 1.0e-12);
+    assertTrue(inverter.isTripped());
+  }
+
+  private static EnergyPort port(String owner, EnergyType type, EnergyPortDirection direction, EnergyPortMode mode,
+      EnergyBus bus) {
+    EnergyPort port = new EnergyPort("power", type, direction, mode);
+    port.setOwnerName(owner);
+    port.connect(bus);
+    return port;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/energy/EnergyConverterTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyConverterTest.java
@@ -18,8 +18,8 @@ class EnergyConverterTest {
     MechanicalShaft shaft = new MechanicalShaft("shaft");
     EnergyPort grid = port("grid", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED,
         electricalBus);
-    EnergyPort load =
-        port("load", EnergyType.SHAFT_WORK, EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, shaft);
+    EnergyPort load = port("load", EnergyType.SHAFT_WORK, EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION,
+        shaft);
     ElectricMotor motor = new ElectricMotor("motor", 0.95);
     motor.connectEnergyStream(EnergyConverter.INPUT_PORT, electricalBus, EnergyPortMode.SPECIFICATION);
     motor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, shaft, EnergyPortMode.CALCULATED);
@@ -42,8 +42,8 @@ class EnergyConverterTest {
   void testConverterTransientRampAndTrip() {
     EnergyBus input = new EnergyBus("input", EnergyType.ELECTRICAL);
     EnergyBus output = new EnergyBus("output", EnergyType.ELECTRICAL);
-    EnergyPort source =
-        port("source", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, input);
+    EnergyPort source = port("source", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED,
+        input);
     Inverter inverter = new Inverter("inverter");
     inverter.connectEnergyStream(EnergyConverter.INPUT_PORT, input, EnergyPortMode.SPECIFICATION);
     inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, output, EnergyPortMode.CALCULATED);

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkDynamicsTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkDynamicsTest.java
@@ -1,0 +1,52 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.battery.BatteryStorage;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
+
+class EnergyNetworkDynamicsTest {
+
+  @Test
+  void testShaftInertiaIntegratesPowerImbalanceAndTripCoastdown() {
+    MechanicalShaft shaft = new MechanicalShaft("dynamic shaft");
+    shaft.setMomentOfInertia(10.0);
+    shaft.setSpeed(1000.0);
+    shaft.setGeneratedPower("driver", 120000.0);
+    shaft.setConsumedPower("load", 100000.0);
+
+    double acceleratedSpeed = shaft.advanceTransient(1.0);
+
+    assertTrue(acceleratedSpeed > 1000.0);
+    shaft.setTripped(true);
+    double coastedSpeed = shaft.advanceTransient(1.0);
+    assertTrue(coastedSpeed < acceleratedSpeed);
+  }
+
+  @Test
+  void testBatteryBalanceAllocationUpdatesStateOfCharge() {
+    EnergyBus bus = new EnergyBus("battery bus", EnergyType.ELECTRICAL);
+    EnergyPort load = new EnergyPort("power", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
+        EnergyPortMode.SPECIFICATION);
+    load.setOwnerName("load");
+    load.connect(bus);
+    load.setRequestedPower(100.0);
+
+    BatteryStorage battery = new BatteryStorage("battery", 1000.0);
+    battery.setStateOfCharge(500.0);
+    battery.enableAutomaticBalancing(100.0, 100.0, 10);
+    battery.connectEnergyStream(BatteryStorage.ELECTRICAL_PORT, bus, EnergyPortMode.BALANCE);
+
+    bus.solveBalance();
+    battery.runTransient(3600.0);
+
+    assertEquals(500.0 - 100.0 / 0.95, battery.getStateOfCharge(), 1.0e-9);
+    assertEquals(100.0, battery.getCurrentPower(), 1.0e-9);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkDynamicsTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkDynamicsTest.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.energy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.battery.BatteryStorage;
@@ -57,5 +58,42 @@ class EnergyNetworkDynamicsTest {
     battery.runTransient(3600.0);
     assertEquals(0.0, battery.getCurrentPower(), 1.0e-9);
     assertEquals(stateBeforeTrip, battery.getStateOfCharge(), 1.0e-9);
+  }
+
+  @Test
+  void testBatteryReconcilesRampLimitedBalancePower() {
+    EnergyBus bus = new EnergyBus("ramp-limited battery bus", EnergyType.ELECTRICAL);
+    EnergyPort load = new EnergyPort("power", EnergyType.ELECTRICAL, EnergyPortDirection.INPUT,
+        EnergyPortMode.SPECIFICATION);
+    load.setOwnerName("load");
+    load.connect(bus);
+    load.setRequestedPower(100.0);
+
+    BatteryStorage battery = new BatteryStorage("battery", 1000.0);
+    battery.setStateOfCharge(500.0);
+    battery.enableAutomaticBalancing(100.0, 100.0, 10);
+    battery.setPowerRampRate(10.0);
+    battery.connectEnergyStream(BatteryStorage.ELECTRICAL_PORT, bus, EnergyPortMode.BALANCE);
+
+    bus.solveBalance();
+    battery.runTransient(1.0);
+
+    assertEquals(10.0, battery.getCurrentPower(), 1.0e-9);
+    assertEquals(10.0, bus.getAllocation(
+        battery.getEnergyPort(BatteryStorage.ELECTRICAL_PORT).getParticipantId()), 1.0e-9);
+    assertEquals(-10.0, bus.getAllocation(load.getParticipantId()), 1.0e-9);
+    assertEquals(10.0, bus.getLastReport().getServedDemand(), 1.0e-9);
+    assertEquals(90.0, bus.getLastReport().getUnmetDemand(), 1.0e-9);
+    assertEquals(10.0, bus.getLastReport().getBalancingGeneration(), 1.0e-9);
+  }
+
+  @Test
+  void testBatteryRejectsNonFinitePowerLimits() {
+    BatteryStorage battery = new BatteryStorage("battery", 1000.0);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> battery.setPowerLimits(Double.POSITIVE_INFINITY, 100.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> battery.setPowerLimits(100.0, Double.POSITIVE_INFINITY));
   }
 }

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkDynamicsTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkDynamicsTest.java
@@ -27,6 +27,8 @@ class EnergyNetworkDynamicsTest {
     shaft.setTripped(true);
     double coastedSpeed = shaft.advanceTransient(1.0);
     assertTrue(coastedSpeed < acceleratedSpeed);
+    shaft.setSpeed(0.0);
+    assertTrue(Double.isNaN(shaft.getQuality().getShaftSpeed()));
   }
 
   @Test
@@ -48,5 +50,12 @@ class EnergyNetworkDynamicsTest {
 
     assertEquals(500.0 - 100.0 / 0.95, battery.getStateOfCharge(), 1.0e-9);
     assertEquals(100.0, battery.getCurrentPower(), 1.0e-9);
+
+    double stateBeforeTrip = battery.getStateOfCharge();
+    battery.setTripped(true);
+    assertEquals(100.0, bus.solveBalance().getUnmetDemand(), 1.0e-9);
+    battery.runTransient(3600.0);
+    assertEquals(0.0, battery.getCurrentPower(), 1.0e-9);
+    assertEquals(stateBeforeTrip, battery.getStateOfCharge(), 1.0e-9);
   }
 }

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkDynamicsTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkDynamicsTest.java
@@ -79,8 +79,8 @@ class EnergyNetworkDynamicsTest {
     battery.runTransient(1.0);
 
     assertEquals(10.0, battery.getCurrentPower(), 1.0e-9);
-    assertEquals(10.0, bus.getAllocation(
-        battery.getEnergyPort(BatteryStorage.ELECTRICAL_PORT).getParticipantId()), 1.0e-9);
+    assertEquals(10.0, bus.getAllocation(battery.getEnergyPort(BatteryStorage.ELECTRICAL_PORT).getParticipantId()),
+        1.0e-9);
     assertEquals(-10.0, bus.getAllocation(load.getParticipantId()), 1.0e-9);
     assertEquals(10.0, bus.getLastReport().getServedDemand(), 1.0e-9);
     assertEquals(90.0, bus.getLastReport().getUnmetDemand(), 1.0e-9);
@@ -91,9 +91,7 @@ class EnergyNetworkDynamicsTest {
   void testBatteryRejectsNonFinitePowerLimits() {
     BatteryStorage battery = new BatteryStorage("battery", 1000.0);
 
-    assertThrows(IllegalArgumentException.class,
-        () -> battery.setPowerLimits(Double.POSITIVE_INFINITY, 100.0));
-    assertThrows(IllegalArgumentException.class,
-        () -> battery.setPowerLimits(100.0, Double.POSITIVE_INFINITY));
+    assertThrows(IllegalArgumentException.class, () -> battery.setPowerLimits(Double.POSITIVE_INFINITY, 100.0));
+    assertThrows(IllegalArgumentException.class, () -> battery.setPowerLimits(100.0, Double.POSITIVE_INFINITY));
   }
 }

--- a/src/test/java/neqsim/process/equipment/energy/UtilityEnergyNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/UtilityEnergyNetworkTest.java
@@ -1,0 +1,28 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.UtilityLevel;
+
+class UtilityEnergyNetworkTest {
+
+  @Test
+  void testTypedSteamUtilityAllocation() {
+    UtilityEnergyBus steam = new UtilityEnergyBus("LP steam", UtilityLevel.LOW_PRESSURE_STEAM, 425.0, 383.0);
+    ThermalUtilitySource source = new ThermalUtilitySource("boiler", UtilityLevel.LOW_PRESSURE_STEAM);
+    ThermalUtilityConsumer consumer = new ThermalUtilityConsumer("reboiler", UtilityLevel.LOW_PRESSURE_STEAM);
+    source.connectEnergyStream(ThermalUtilitySource.OUTPUT_PORT, steam, EnergyPortMode.CALCULATED);
+    consumer.connectEnergyStream(ThermalUtilityConsumer.INPUT_PORT, steam, EnergyPortMode.SPECIFICATION);
+    source.setAvailablePower(2.0e6);
+    consumer.setRequestedPower(1.5e6);
+
+    source.run();
+    steam.solveBalance();
+    consumer.run();
+
+    assertEquals(1.5e6, consumer.getAllocatedPower(), 1.0e-9);
+    assertEquals(0.5e6, steam.getLastReport().getCurtailedSupply(), 1.0e-9);
+    assertEquals(UtilityLevel.LOW_PRESSURE_STEAM, steam.getUtilityLevel());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
@@ -104,6 +104,19 @@ class EnergyBusAllocationTest {
   }
 
   @Test
+  void testChemicalBusReportsFuelEnergyRate() {
+    EnergyBus fuelBus = new EnergyBus("fuel gas energy", EnergyType.CHEMICAL);
+    EnergyPort fuelSupply = port("fuel supply", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, fuelBus);
+    EnergyPort primeMover = port("prime mover", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, fuelBus);
+    fuelSupply.setDuty(10.0e6);
+    primeMover.setRequestedPower(8.0e6);
+
+    EnergyNetworkReport report = fuelBus.solveBalance();
+
+    assertEquals(8.0, report.getFuelEnergyRate("MW"), 1.0e-12);
+  }
+
+  @Test
   void testIncompatibleUtilityQualityIsRejected() {
     EnergyBus steam = new EnergyBus("steam", EnergyType.HEAT);
     steam.getQuality().setUtilityLevel(UtilityLevel.LOW_PRESSURE_STEAM);

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
@@ -26,6 +26,8 @@ class EnergyBusAllocationTest {
 
     assertEquals(-100.0 * 2.0 / 3.0, bus.getAllocation(first.getParticipantId()), 1.0e-12);
     assertEquals(-100.0 / 3.0, bus.getAllocation(second.getParticipantId()), 1.0e-12);
+    assertEquals(-100.0 * 2.0 / 3.0, first.getDuty(), 1.0e-12);
+    assertEquals(100.0 * 2.0 / 3.0, first.getPowerMagnitude(), 1.0e-12);
     assertEquals(50.0, report.getUnmetDemand(), 1.0e-12);
     assertEquals(100.0, report.getServedDemand(), 1.0e-12);
 
@@ -87,6 +89,7 @@ class EnergyBusAllocationTest {
     EnergyNetworkReport shortage = bus.solveBalance();
 
     assertEquals(50.0, bus.getAllocation(storage.getParticipantId()), 1.0e-12);
+    assertEquals(50.0, storage.getDuty(), 1.0e-12);
     assertEquals(0.0, shortage.getUnmetDemand(), 1.0e-12);
 
     producer.setDuty(150.0);

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
@@ -90,6 +90,7 @@ class EnergyBusAllocationTest {
 
     assertEquals(50.0, bus.getAllocation(storage.getParticipantId()), 1.0e-12);
     assertEquals(50.0, storage.getDuty(), 1.0e-12);
+    assertEquals(110.0, shortage.getOfferedSupply(), 1.0e-12);
     assertEquals(0.0, shortage.getUnmetDemand(), 1.0e-12);
 
     producer.setDuty(150.0);

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
@@ -1,0 +1,118 @@
+package neqsim.process.equipment.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+
+class EnergyBusAllocationTest {
+
+  @Test
+  void testEqualPriorityShortageIsAllocatedProportionally() {
+    EnergyBus bus = new EnergyBus("power bus", EnergyType.ELECTRICAL);
+    EnergyPort producer = port("producer", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
+    EnergyPort first = port("first", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    EnergyPort second = port("second", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    producer.setDuty(100.0);
+    first.setRequestedPower(100.0);
+    second.setRequestedPower(50.0);
+
+    EnergyNetworkReport report = bus.solveBalance();
+
+    assertEquals(-100.0 * 2.0 / 3.0, bus.getAllocation(first.getParticipantId()), 1.0e-12);
+    assertEquals(-100.0 / 3.0, bus.getAllocation(second.getParticipantId()), 1.0e-12);
+    assertEquals(50.0, report.getUnmetDemand(), 1.0e-12);
+    assertEquals(100.0, report.getServedDemand(), 1.0e-12);
+  }
+
+  @Test
+  void testPriorityDispatchAndStableIdentity() throws Exception {
+    EnergyBus bus = new EnergyBus("priority bus", EnergyType.ELECTRICAL);
+    EnergyPort producer = port("producer", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
+    EnergyPort essential = port("essential", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    EnergyPort flexible = port("flexible", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    essential.setPriority(10);
+    flexible.setPriority(20);
+    essential.setRequestedPower(80.0);
+    flexible.setRequestedPower(80.0);
+    producer.setDuty(100.0);
+
+    bus.solveBalance();
+
+    assertEquals(-80.0, bus.getAllocation(essential.getParticipantId()), 1.0e-12);
+    assertEquals(-20.0, bus.getAllocation(flexible.getParticipantId()), 1.0e-12);
+    String participantId = flexible.getParticipantId();
+    flexible.setOwnerName("renamed equipment");
+    assertEquals(-20.0, bus.getAllocation(participantId), 1.0e-12);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(flexible);
+    }
+    EnergyPort restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (EnergyPort) input.readObject();
+    }
+    assertEquals(participantId, restored.getParticipantId());
+  }
+
+  @Test
+  void testBalancePortCoversShortageAndAbsorbsSurplus() {
+    EnergyBus bus = new EnergyBus("balanced bus", EnergyType.ELECTRICAL);
+    EnergyPort producer = port("producer", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
+    EnergyPort consumer = port("consumer", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    EnergyPort storage = port("storage", EnergyPortDirection.BIDIRECTIONAL, EnergyPortMode.BALANCE, bus);
+    storage.setBalanceLimits(60.0, 30.0);
+    consumer.setRequestedPower(100.0);
+    producer.setDuty(50.0);
+
+    EnergyNetworkReport shortage = bus.solveBalance();
+
+    assertEquals(50.0, bus.getAllocation(storage.getParticipantId()), 1.0e-12);
+    assertEquals(0.0, shortage.getUnmetDemand(), 1.0e-12);
+
+    producer.setDuty(150.0);
+    EnergyNetworkReport surplus = bus.solveBalance();
+
+    assertEquals(-30.0, bus.getAllocation(storage.getParticipantId()), 1.0e-12);
+    assertEquals(20.0, surplus.getCurtailedSupply(), 1.0e-12);
+  }
+
+  @Test
+  void testCostEmissionAndEfficiencyReporting() {
+    EnergyBus bus = new EnergyBus("report bus", EnergyType.ELECTRICAL);
+    EnergyPort producer = port("grid", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
+    EnergyPort consumer = port("load", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    producer.setEnergyPricePerMWh(100.0);
+    producer.setEmissionFactorKgPerMWh(400.0);
+    producer.setDuty(1.0e6);
+    consumer.setRequestedPower(1.0e6);
+
+    EnergyNetworkReport report = bus.solveBalance();
+
+    assertEquals(100.0, report.getOperatingCostPerHour(), 1.0e-12);
+    assertEquals(400.0, report.getCo2EmissionRate(), 1.0e-12);
+    assertEquals(1.0, report.getEfficiency(), 1.0e-12);
+  }
+
+  @Test
+  void testIncompatibleUtilityQualityIsRejected() {
+    EnergyBus steam = new EnergyBus("steam", EnergyType.HEAT);
+    steam.getQuality().setUtilityLevel(UtilityLevel.LOW_PRESSURE_STEAM);
+    EnergyPort consumer =
+        new EnergyPort("heat", EnergyType.HEAT, EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION);
+    consumer.setRequiredQuality(new EnergyQuality(UtilityLevel.HIGH_PRESSURE_STEAM));
+
+    assertThrows(IllegalArgumentException.class, () -> consumer.connect(steam));
+  }
+
+  private static EnergyPort port(String owner, EnergyPortDirection direction, EnergyPortMode mode, EnergyBus bus) {
+    EnergyPort port = new EnergyPort("power", bus.getEnergyType(), direction, mode);
+    port.setOwnerName(owner);
+    port.connect(bus);
+    return port;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
@@ -2,6 +2,7 @@ package neqsim.process.equipment.stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -26,6 +27,10 @@ class EnergyBusAllocationTest {
     assertEquals(-100.0 / 3.0, bus.getAllocation(second.getParticipantId()), 1.0e-12);
     assertEquals(50.0, report.getUnmetDemand(), 1.0e-12);
     assertEquals(100.0, report.getServedDemand(), 1.0e-12);
+
+    first.setDuty(first.getPowerMagnitude());
+    assertEquals(100.0 / 3.0, second.getPowerMagnitude(), 1.0e-12);
+    assertTrue(bus.hasSolution());
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
@@ -120,8 +120,8 @@ class EnergyBusAllocationTest {
   void testIncompatibleUtilityQualityIsRejected() {
     EnergyBus steam = new EnergyBus("steam", EnergyType.HEAT);
     steam.getQuality().setUtilityLevel(UtilityLevel.LOW_PRESSURE_STEAM);
-    EnergyPort consumer =
-        new EnergyPort("heat", EnergyType.HEAT, EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION);
+    EnergyPort consumer = new EnergyPort("heat", EnergyType.HEAT, EnergyPortDirection.INPUT,
+        EnergyPortMode.SPECIFICATION);
     consumer.setRequiredQuality(new EnergyQuality(UtilityLevel.HIGH_PRESSURE_STEAM));
 
     assertThrows(IllegalArgumentException.class, () -> consumer.connect(steam));

--- a/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyBusAllocationTest.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
@@ -28,9 +29,14 @@ class EnergyBusAllocationTest {
     assertEquals(50.0, report.getUnmetDemand(), 1.0e-12);
     assertEquals(100.0, report.getServedDemand(), 1.0e-12);
 
-    first.setDuty(first.getPowerMagnitude());
+    first.setDuty(50.0);
     assertEquals(100.0 / 3.0, second.getPowerMagnitude(), 1.0e-12);
     assertTrue(bus.hasSolution());
+
+    EnergyNetworkReport updated = bus.solveBalance();
+    assertEquals(-50.0, bus.getAllocation(first.getParticipantId()), 1.0e-12);
+    assertEquals(-50.0, bus.getAllocation(second.getParticipantId()), 1.0e-12);
+    assertEquals(0.0, updated.getUnmetDemand(), 1.0e-12);
   }
 
   @Test
@@ -62,6 +68,10 @@ class EnergyBusAllocationTest {
       restored = (EnergyPort) input.readObject();
     }
     assertEquals(participantId, restored.getParticipantId());
+
+    restored.connect(bus);
+    assertNotEquals(participantId, restored.getParticipantId());
+    assertTrue(bus.getRegisteredPorts().containsKey(restored.getParticipantId()));
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/stream/EnergyNetworkIntegrationTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/EnergyNetworkIntegrationTest.java
@@ -10,6 +10,7 @@ import neqsim.process.equipment.electrolyzer.Electrolyzer;
 import neqsim.process.equipment.electrolyzer.ElectrolyzerIVCharacteristic;
 import neqsim.process.equipment.electrolyzer.ElectrolyzerTechnology;
 import neqsim.process.equipment.expander.Expander;
+import neqsim.process.equipment.heatexchanger.HeatExchanger;
 import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.powergeneration.SolarPanel;
 import neqsim.process.processmodel.ProcessSystem;
@@ -86,6 +87,34 @@ class EnergyNetworkIntegrationTest extends neqsim.NeqSimTest {
     assertEquals(firstStackPower, electrolyzer.getStackPower(), Math.max(1.0, firstStackPower * 1.0e-10));
     assertEquals(-firstStackPower, bus.getContribution("electrolyzer.electricalPower"),
         Math.max(1.0, firstStackPower * 1.0e-10));
+  }
+
+  @Test
+  void testTwoStreamHeatExchangerPublishesCalculatedRecoveryDuty() {
+    SystemInterface hotFluid = new SystemSrkEos(373.15, 20.0);
+    hotFluid.addComponent("methane", 1.0);
+    hotFluid.setMixingRule("classic");
+    Stream hot = new Stream("hot feed", hotFluid);
+    hot.setFlowRate(0.2, "MSm3/day");
+    hot.run();
+
+    SystemInterface coldFluid = new SystemSrkEos(273.15, 20.0);
+    coldFluid.addComponent("methane", 1.0);
+    coldFluid.setMixingRule("classic");
+    Stream cold = new Stream("cold feed", coldFluid);
+    cold.setFlowRate(0.2, "MSm3/day");
+    cold.run();
+
+    EnergyBus recovery = new EnergyBus("exchanger recovery", EnergyType.HEAT);
+    HeatExchanger exchanger = new HeatExchanger("feed exchanger", hot, cold);
+    exchanger.setUAvalue(10000.0);
+    exchanger.connectEnergyStream("heatDuty", recovery, EnergyPortMode.CALCULATED);
+
+    exchanger.run();
+
+    assertTrue(exchanger.getDuty() > 0.0);
+    assertEquals(exchanger.getDuty(), recovery.getContribution("feed exchanger.heatDuty"),
+        Math.max(1.0, exchanger.getDuty() * 1.0e-10));
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/graph/EnergyNetworkSolverGraphTest.java
+++ b/src/test/java/neqsim/process/processmodel/graph/EnergyNetworkSolverGraphTest.java
@@ -1,0 +1,58 @@
+package neqsim.process.processmodel.graph;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.energy.EnergyNetworkSolver;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.processmodel.ProcessSystem;
+
+class EnergyNetworkSolverGraphTest {
+
+  @Test
+  void testSolverIsOrderedBetweenProducerAndSpecificationConsumer() {
+    EnergyBus bus = new EnergyBus("bus", EnergyType.ELECTRICAL);
+    EnergyUnit producer = new EnergyUnit("producer", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, bus);
+    EnergyUnit consumer = new EnergyUnit("consumer", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, bus);
+    EnergyNetworkSolver solver = new EnergyNetworkSolver("network solver", bus);
+    ProcessSystem process = new ProcessSystem();
+    process.add(consumer);
+    process.add(solver);
+    process.add(producer);
+
+    List<ProcessEquipmentInterface> order = ProcessGraphBuilder.buildGraph(process).getCalculationOrder();
+
+    assertTrue(order.indexOf(producer) < order.indexOf(solver));
+    assertTrue(order.indexOf(solver) < order.indexOf(consumer));
+  }
+
+  private static final class EnergyUnit extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+
+    /**
+     * Creates a graph-test energy unit.
+     *
+     * @param name unit name
+     * @param direction port direction
+     * @param mode port mode
+     * @param bus connected bus
+     */
+    private EnergyUnit(String name, EnergyPortDirection direction, EnergyPortMode mode, EnergyBus bus) {
+      super(name);
+      registerEnergyPort("power", EnergyType.ELECTRICAL, direction, mode);
+      connectEnergyStream("power", bus, mode);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/graph/EnergyNetworkSolverGraphTest.java
+++ b/src/test/java/neqsim/process/processmodel/graph/EnergyNetworkSolverGraphTest.java
@@ -28,6 +28,9 @@ class EnergyNetworkSolverGraphTest {
 
     List<ProcessEquipmentInterface> order = ProcessGraphBuilder.buildGraph(process).getCalculationOrder();
 
+    assertTrue(order.contains(producer));
+    assertTrue(order.contains(solver));
+    assertTrue(order.contains(consumer));
     assertTrue(order.indexOf(producer) < order.indexOf(solver));
     assertTrue(order.indexOf(solver) < order.indexOf(consumer));
   }


### PR DESCRIPTION
## Summary

Implements the Energy Networks v3 recommendations discussed after the typed energy-stream review:

- deterministic multi-producer/multi-consumer allocation with proportional equal-priority dispatch
- real BALANCE participants, shortage, surplus, unmet-demand and curtailment accounting
- stable serialized participant identities with legacy name lookup
- electrical/mechanical conversion equipment (motor, generator, gearbox, inverter, transformer)
- motor-driven rotating-equipment and motor-assisted expander/compressor coupling
- typed thermal utility levels and quality metadata
- recoverable duties from two-stream, multi-stream and LNG heat exchangers
- transient shaft inertia plus battery ramp, state-of-charge and trip behavior
- cost, efficiency, conversion-loss and CO2 reporting
- graph scheduling through an explicit EnergyNetworkSolver
- regression and integration coverage

## Compatibility

Legacy point-to-point and sequential EnergyBus behavior remains supported. Existing owner-name/port-name contribution lookups are retained while internal allocation uses persistent IDs.

## Validation

All Java 8/21 tests pass on Ubuntu and Windows. Spotless, pre-commit, JavaDoc, CodeQL, documentation search, and PaperLab checks are green.