### PR TITLE
docs: repair safety landing navigation (D027)

### DIFF
--- a/docs/safety/README.md
+++ b/docs/safety/README.md
@@ -3,8 +3,6 @@ title: Safety Systems Documentation
 description: Documentation for safety-related features and systems in NeqSim.
 ---
 
-# Safety Systems Documentation
-
 Documentation for safety-related features and systems in NeqSim.
 
 ---
@@ -22,26 +20,26 @@ This folder contains guides for implementing safety systems in process simulatio
 | Document | Description |
 |----------|-------------|
 | [ESD Dynamic Testing Workflow](esd_testing_workflow.md) | Dynamic ESD testing with process logic, OperationalTagMap/tagreader evidence, and JSON criteria reports |
-| [ESD_BLOWDOWN_SYSTEM.md](ESD_BLOWDOWN_SYSTEM) | Complete ESD and blowdown system guide |
-| [PRESSURE_MONITORING_ESD.md](PRESSURE_MONITORING_ESD) | Pressure monitoring for ESD |
+| [ESD_BLOWDOWN_SYSTEM.md](ESD_BLOWDOWN_SYSTEM.md) | Complete ESD and blowdown system guide |
+| [PRESSURE_MONITORING_ESD.md](PRESSURE_MONITORING_ESD.md) | Pressure monitoring for ESD |
 
 ### HIPPS (High Integrity Pressure Protection)
 
 | Document | Description |
 |----------|-------------|
-| [HIPPS_SUMMARY.md](HIPPS_SUMMARY) | HIPPS overview and summary |
-| [hipps_implementation.md](hipps_implementation) | HIPPS implementation details |
-| [hipps_safety_logic.md](hipps_safety_logic) | HIPPS safety logic programming |
+| [HIPPS_SUMMARY.md](HIPPS_SUMMARY.md) | HIPPS overview and summary |
+| [hipps_implementation.md](hipps_implementation.md) | HIPPS implementation details |
+| [hipps_safety_logic.md](hipps_safety_logic.md) | HIPPS safety logic programming |
 
 ### Safety Architecture
 
 | Document | Description |
 |----------|-------------|
-| [INTEGRATED_SAFETY_SYSTEMS.md](INTEGRATED_SAFETY_SYSTEMS) | Integrated safety systems overview |
-| [layered_safety_architecture.md](layered_safety_architecture) | Layered safety architecture (defense in depth) |
-| [sis_logic_implementation.md](sis_logic_implementation) | Safety Instrumented Systems (SIS) logic |
-| [integration_safety_chain_tests.md](integration_safety_chain_tests) | Safety chain integration testing |
-| [SAFETY_SIMULATION_ROADMAP.md](SAFETY_SIMULATION_ROADMAP) | Safety simulation development roadmap |
+| [INTEGRATED_SAFETY_SYSTEMS.md](INTEGRATED_SAFETY_SYSTEMS.md) | Integrated safety systems overview |
+| [layered_safety_architecture.md](layered_safety_architecture.md) | Layered safety architecture (defense in depth) |
+| [sis_logic_implementation.md](sis_logic_implementation.md) | Safety Instrumented Systems (SIS) logic |
+| [integration_safety_chain_tests.md](integration_safety_chain_tests.md) | Safety chain integration testing |
+| [SAFETY_SIMULATION_ROADMAP.md](SAFETY_SIMULATION_ROADMAP.md) | Safety simulation development roadmap |
 
 ### Standards Compliance and Hazard Screening
 
@@ -54,15 +52,14 @@ This folder contains guides for implementing safety systems in process simulatio
 | [Automated HAZOP from STID and Simulation](automated_hazop_from_stid.md) | End-to-end STID/P&ID, plant data, NeqSim simulation, HAZOP, barrier, and report workflow |
 | [AI-HAZOP Input Data Format](ai_hazop_input_format.md) | Required input-data format for a P&ID Safety Analyser / AI-HAZOP front-end: process model JSON, per-deviation `runHazopScenario` request, DEXPI design-conditions, limit-basis policy, and blocked-outlet overpressure screening |
 | [Open Drain Review with NeqSim Evidence](open_drain_review.md) | NORSOK S-001 Clause 9 review using NeqSim-calculated liquid leak rate, firewater load, density, pressure, and drain capacity plus STID/tagreader evidence |
-
 | [Barrier Management and SCE Traceability](barrier_management.md) | Evidence-linked PSFs, SCEs, performance standards, and safety-analysis handoffs |
 
 ### Fire and Thermal Protection
 
 | Document | Description |
 |----------|-------------|
-| [fire_blowdown_capabilities.md](fire_blowdown_capabilities) | Fire case blowdown simulation |
-| [fire_heat_transfer_enhancements.md](fire_heat_transfer_enhancements) | Fire heat transfer modeling |
+| [fire_blowdown_capabilities.md](fire_blowdown_capabilities.md) | Fire case blowdown simulation |
+| [fire_heat_transfer_enhancements.md](fire_heat_transfer_enhancements.md) | Fire heat transfer modeling |
 | [Vessel Thermomechanical Safety](vessel_thermomechanical_safety.md) | Transient non-equilibrium blowdown, fast filling, cryogenic boil-off, composite-wall conduction, and fire/blowdown wall rupture |
 | [Trapped Liquid Fire Rupture](trapped_liquid_fire_rupture.md) | Blocked-in liquid segment fire rupture screening with material, flange, PFP, and source-term handoff |
 | [Blocked-In Liquid Thermal Expansion](blocked_in_liquid_thermal_expansion.md) | Isochoric pressure-rise screening (API 521 §4.4.12) for blocked-in liquid segments, independent of fire exposure |
@@ -74,16 +71,16 @@ This folder contains guides for implementing safety systems in process simulatio
 | [Trapped Inventory Calculator](trapped_inventory_calculator.md) | Evidence-linked trapped inventory for isolation, blowdown, flare-load, and MDMT screening |
 | [Trapped Liquid Fire Rupture](trapped_liquid_fire_rupture.md) | Fire exposure, thermal expansion, pipe/flange failure screening, PFP demand, and source-term handoff |
 | [Blocked-In Liquid Thermal Expansion](blocked_in_liquid_thermal_expansion.md) | Isochoric pressure-rise screening and simplified beta/kappa relation for blocked-in liquid thermal relief screening |
-| [psv_dynamic_sizing_example.md](psv_dynamic_sizing_example) | Pressure Safety Valve dynamic sizing |
+| [psv_dynamic_sizing_example.md](psv_dynamic_sizing_example.md) | Pressure Safety Valve dynamic sizing |
 | [Vessel Thermomechanical Safety](vessel_thermomechanical_safety.md) | Dynamic PSV sizing vs steady-state API 521 conservatism, plus blowdown, filling, boil-off, and rupture models |
-| [rupture_disk_dynamic_behavior.md](rupture_disk_dynamic_behavior) | Rupture disk dynamic behavior |
+| [rupture_disk_dynamic_behavior.md](rupture_disk_dynamic_behavior.md) | Rupture disk dynamic behavior |
 
 ### Alarms
 
 | Document | Description |
 |----------|-------------|
-| [alarm_system_guide.md](alarm_system_guide) | Alarm system implementation guide |
-| [alarm_triggered_logic_example.md](alarm_triggered_logic_example) | Alarm-triggered logic examples |
+| [alarm_system_guide.md](alarm_system_guide.md) | Alarm system implementation guide |
+| [alarm_triggered_logic_example.md](alarm_triggered_logic_example.md) | Alarm-triggered logic examples |
 
 ---
 
@@ -91,5 +88,5 @@ This folder contains guides for implementing safety systems in process simulatio
 
 - [Process Package](../process/) - Process simulation overview
 - [Process Safety](../process/safety/) - Safety equipment classes
-- [Controllers](../process/controllers) - Controller devices
+- [Controllers](../process/controllers.md) - Controller devices
 


### PR DESCRIPTION
## D027 — Safety landing-page navigation

Linked to #2499.

### Frozen scope

- `docs/safety/README.md`

All Java source, tests, notebooks, equations, images, external links, other landing pages, and Energy Networks v3 files are excluded. No open pull request changes this path.

### Confirmed defects and fixes

1. **Medium — duplicate page title.** Removed the Markdown H1 that duplicated the Jekyll front-matter title.
2. **Medium — 17 nonconforming internal file links.** Added the repository-required `.md` suffix to each verified file destination, including the related controller guide.
3. **Medium — broken Markdown table.** Removed the blank line that detached “Barrier Management and SCE Traceability” from the Standards Compliance and Hazard Screening table.

All 19 confirmed defects are repaired.

### Validation performed before opening

- current `master` base: `3870edc913201ea2bf1d9c6ad4904761d3638937`
- overlap check: all 28 open PR changed-path sets inspected; zero touch `docs/safety/README.md`
- Jekyll front matter: present and retained
- duplicate Markdown H1 count: 0
- internal links: 35 occurrences, 32 unique destinations
- file destinations: all 30 unique files resolve on current `master`
- directory destinations: both resolve as repository directories
- extensionless file targets: 0 after repair
- Markdown table continuity: repaired and rechecked
- code fences, equations, images, and HTML interactions: none
- remote branch readback matches the validated content exactly
- branch scope: one commit, one file, 17 additions and 20 deletions

No executable code example changed, so no new Java regression is warranted.

### Final-head hosted validation

- build/test/Javadoc workflow: passed
- pre-commit: passed
- Spotless: passed
- documentation search coverage: passed
- CodeQL: passed
- final remote diff: one file, 17 additions and 20 deletions
- Copilot reviewed and approved the complete 1/1 changed file with zero comments; no review threads, suggested changes, or Copilot-authored commits exist

### Rendering

No rendered-site artifact is currently available; browser visual inspection is not claimed.

### Next scan

After D027 is merged and recorded, D028 advances to thermodynamics, fluids, phase equilibrium, and physical-properties documentation.
