### PR TITLE
docs: repair thermodynamics landing navigation (D028)

### DIFF
--- a/docs/thermo/README.md
+++ b/docs/thermo/README.md
@@ -3,8 +3,6 @@ title: "Thermodynamic Documentation Set"
 description: "This folder collects topic-specific documentation for using NeqSim's thermodynamic, PVT, and physical property capabilities. Each page is intended to be self-contained while pointing to related guides..."
 ---
 
-# Thermodynamic Documentation Set
-
 This folder collects topic-specific documentation for using NeqSim's thermodynamic, PVT, and physical property capabilities. Each page is intended to be self-contained while pointing to related guides so you can jump directly to the workflows you need.
 
 ---
@@ -38,44 +36,44 @@ thermo/
 
 ### Core Guides
 
-- [Thermodynamic Models Guide](thermodynamic_models): **Comprehensive overview** of all thermodynamic models in NeqSim, including equations of state, CPA, reference equations (GERG-2008, EOS-CG), activity coefficient models, electrolyte models, and the auto-select feature. Covers theory, usage, and model selection guidelines.
-- [Mercury Thermodynamics](mercury_thermodynamics): **Mercury-focused workflow** for SRK-TwuCoon-Statoil-EOS, TPflash setup, INTER-table usage, and thesis-linked correlation guidance.
-- [Søreide-Whitson Model](SoreideWhitsonModel): **Gas solubility in brine** - Modified Peng-Robinson EoS with salinity-dependent alpha function for water. Essential for produced water emission calculations and used in **NeqSimLive**. Includes mathematical formulation, salt type coefficients, validation data, and literature references.
-- [Fluid Creation Guide](fluid_creation_guide): **Comprehensive guide** to creating fluids in NeqSim, including all available equations of state, mixing rules, and model selection guidelines.
-- [Mixing Rules Guide](mixing_rules_guide): **Detailed documentation** on mixing rules, including mathematical formulations, binary interaction parameters, and usage examples for different applications.
-- [Flash Calculations Guide](flash_calculations_guide): **Comprehensive documentation** of flash calculations available via ThermodynamicOperations, including TP, PH, PS, VU flashes, saturation calculations, and hydrate equilibria.
-- [Reactive Flash](reactive_flash): **Simultaneous chemical and phase equilibrium** using the Modified RAND method. Covers reactive TP and PH flash for systems with gas-phase reactions, ionic equilibria, and multiphase reactive systems.
-- [Hydrate Models Guide](hydrate_models): **Comprehensive documentation** of gas hydrate thermodynamic models, including van der Waals-Platteeuw theory, Structure I/II hydrates, CPA and PVTsim implementations, and inhibitor modeling.
-- [Electrolyte CPA Model](ElectrolyteCPAModel): **Detailed documentation** of the electrolyte CPA model, including Fürst electrostatic contributions, validation data, and usage examples.
+- [Thermodynamic Models Guide](thermodynamic_models.md): **Comprehensive overview** of all thermodynamic models in NeqSim, including equations of state, CPA, reference equations (GERG-2008, EOS-CG), activity coefficient models, electrolyte models, and the auto-select feature. Covers theory, usage, and model selection guidelines.
+- [Mercury Thermodynamics](mercury_thermodynamics.md): **Mercury-focused workflow** for SRK-TwuCoon-Statoil-EOS, TPflash setup, INTER-table usage, and thesis-linked correlation guidance.
+- [Søreide-Whitson Model](SoreideWhitsonModel.md): **Gas solubility in brine** - Modified Peng-Robinson EoS with salinity-dependent alpha function for water. Essential for produced water emission calculations and used in **NeqSimLive**. Includes mathematical formulation, salt type coefficients, validation data, and literature references.
+- [Fluid Creation Guide](fluid_creation_guide.md): **Comprehensive guide** to creating fluids in NeqSim, including all available equations of state, mixing rules, and model selection guidelines.
+- [Mixing Rules Guide](mixing_rules_guide.md): **Detailed documentation** on mixing rules, including mathematical formulations, binary interaction parameters, and usage examples for different applications.
+- [Flash Calculations Guide](flash_calculations_guide.md): **Comprehensive documentation** of flash calculations available via ThermodynamicOperations, including TP, PH, PS, VU flashes, saturation calculations, and hydrate equilibria.
+- [Reactive Flash](reactive_flash.md): **Simultaneous chemical and phase equilibrium** using the Modified RAND method. Covers reactive TP and PH flash for systems with gas-phase reactions, ionic equilibria, and multiphase reactive systems.
+- [Hydrate Models Guide](hydrate_models.md): **Comprehensive documentation** of gas hydrate thermodynamic models, including van der Waals-Platteeuw theory, Structure I/II hydrates, CPA and PVTsim implementations, and inhibitor modeling.
+- [Electrolyte CPA Model](ElectrolyteCPAModel.md): **Detailed documentation** of the electrolyte CPA model, including Fürst electrostatic contributions, validation data, and usage examples.
 
 ### Database Documentation
 
-- [Component Database Guide](component_database_guide): **Detailed documentation** of the COMP pure component parameters database, including parameter descriptions, units, and links to thermodynamic models.
-- [INTER Table Guide](inter_table_guide): **Detailed documentation** of the INTER binary interaction parameters database, including column reference for all EoS, CPA, Huron-Vidal, Wong-Sandler, and NRTL parameters.
+- [Component Database Guide](component_database_guide.md): **Detailed documentation** of the COMP pure component parameters database, including parameter descriptions, units, and links to thermodynamic models.
+- [INTER Table Guide](inter_table_guide.md): **Detailed documentation** of the INTER binary interaction parameters database, including column reference for all EoS, CPA, Huron-Vidal, Wong-Sandler, and NRTL parameters.
 
 ### Reference Documentation
 
-- [Mathematical Models](mathematical_models): Equations of state, activity-coefficient formulations, and transport correlations available in NeqSim.
-- [GERG-2008 and EOS-CG](gerg2008_eoscg): Detailed guide to the reference equations of state for natural gas and CCS applications.
+- [Mathematical Models](mathematical_models.md): Equations of state, activity-coefficient formulations, and transport correlations available in NeqSim.
+- [GERG-2008 and EOS-CG](gerg2008_eoscg.md): Detailed guide to the reference equations of state for natural gas and CCS applications.
 
 ### Acid Gas and Sour Fluid Modeling
 
-- [H2S Distribution Guide](H2S_distribution_guide): **H2S phase distribution modeling** between gas, oil, and water using SRK, PR, CPA, and Electrolyte-CPA equations of state. Covers acid-base chemistry, pH effects, and salinity impacts.
-- [H2S Distribution Modeling (Detailed)](H2S_DISTRIBUTION_MODELING): **Comprehensive H2S modeling** including chemical reactions, model selection guidance, and validation examples.
-- [Amine CO2 Solubility (Kent-Eisenberg)](amine_co2_solubility): **Screening-level CO2 solubility** in aqueous MEA / DEA / MDEA / activated-MDEA solvents using the Kent-Eisenberg apparent-equilibrium-constant model. Covers the validated screening API, validation status, equations, and usage examples.
+- [H2S Distribution Guide](H2S_distribution_guide.md): **H2S phase distribution modeling** between gas, oil, and water using SRK, PR, CPA, and Electrolyte-CPA equations of state. Covers acid-base chemistry, pH effects, and salinity impacts.
+- [H2S Distribution Modeling (Detailed)](H2S_DISTRIBUTION_MODELING.md): **Comprehensive H2S modeling** including chemical reactions, model selection guidance, and validation examples.
+- [Amine CO2 Solubility (Kent-Eisenberg)](amine_co2_solubility.md): **Screening-level CO2 solubility** in aqueous MEA / DEA / MDEA / activated-MDEA solvents using the Kent-Eisenberg apparent-equilibrium-constant model. Covers the validated screening API, validation status, equations, and usage examples.
 
 ### Application Guides
 
-- [Thermodynamic Workflows](thermodynamic_workflows): How to set up systems, select models, and perform common equilibrium calculations.
-- [Adsorption Isotherm Models](adsorption_isotherms): **Complete reference** for all adsorption isotherm models — Langmuir, Extended Langmuir, BET, Freundlich, Sips, DRA potential theory, capillary condensation, and the parameter database.
-- [PVT and Fluid Characterization](pvt_fluid_characterization): Building realistic fluid descriptions, including heavy-end handling and lab-data reconciliation.
-- [Thermodynamic Operations](thermodynamic_operations): Flash calculations, phase envelopes, and other process-centric operations.
-- [Physical Properties](physical_properties): Density, viscosity, surface tension, and transport-property calculations.
-- [Attainable Metastability — Volume Balancing Method](attainable_metastability): **Superheat / pressure-undershoot limit of a rapidly depressurising liquid** (Log, 2025). Rarefaction-outflow vs. Plesset-Zwick bubble-growth balance, the `n_bub` tuning parameter, and a CO₂ blowdown example.
+- [Thermodynamic Workflows](thermodynamic_workflows.md): How to set up systems, select models, and perform common equilibrium calculations.
+- [Adsorption Isotherm Models](adsorption_isotherms.md): **Complete reference** for all adsorption isotherm models — Langmuir, Extended Langmuir, BET, Freundlich, Sips, DRA potential theory, capillary condensation, and the parameter database.
+- [PVT and Fluid Characterization](pvt_fluid_characterization.md): Building realistic fluid descriptions, including heavy-end handling and lab-data reconciliation.
+- [Thermodynamic Operations](thermodynamic_operations.md): Flash calculations, phase envelopes, and other process-centric operations.
+- [Physical Properties](physical_properties.md): Density, viscosity, surface tension, and transport-property calculations.
+- [Attainable Metastability — Volume Balancing Method](attainable_metastability.md): **Superheat / pressure-undershoot limit of a rapidly depressurising liquid** (Log, 2025). Rarefaction-outflow vs. Plesset-Zwick bubble-growth balance, the `n_bub` tuning parameter, and a CO₂ blowdown example.
 
 ---
 
 Examples are written for the Java API unless a page says otherwise. Python uses the
 NeqSim gateway and different import conventions; follow the
-[Python quickstart](../quickstart/python-quickstart) rather than translating Java
+[Python quickstart](../quickstart/python-quickstart.md) rather than translating Java
 syntax literally.


### PR DESCRIPTION
## D028 — Thermodynamics landing-page navigation

Linked to #2499.

### Frozen scope

- `docs/thermo/README.md`

All Java source, tests, notebooks, thermodynamic models, equations, images, external links, other landing pages, and open-PR paths are excluded. The changed path has zero overlap with all 28 other open pull requests.

### Confirmed defects and fixes

1. **Medium — duplicate page title.** Removed the Markdown H1 that duplicated the Jekyll front-matter title.
2. **Medium — 23 nonconforming internal file links.** Added the repository-required `.md` suffix to every verified file destination. The five directory links remain directory links.

All 24 confirmed defects are repaired.

### Validation performed

- exact `master` base and current merge base: `de28ff7f772a6f8b00865b9aedd3fd78705cd444`
- overlap check: all 28 other open PR changed-path sets inspected; zero touch `docs/thermo/README.md`
- Jekyll front matter: present and retained
- duplicate Markdown H1 count: 0
- internal links: 28 occurrences
- destinations: all 28 resolve (23 files plus 5 directory README targets)
- extensionless file targets: 0 after repair
- code fences: one balanced tree fence
- equations, images, HTML interactions, and external links: none
- branch readback matches the validated content byte-for-byte
- final scope: one commit, one file, 23 additions and 25 deletions
- branch is current with `master`: one commit ahead, zero behind, mergeable
- build/test/Javadoc workflow: passed
- pre-commit: passed
- Spotless: passed
- documentation search coverage: passed
- CodeQL: passed
- Copilot reviewed the final one-file diff with no inline findings or suggested changes; no review threads or Copilot-authored commits exist

No executable code example or API claim changed, so no new Java or Python regression is warranted. The resilient Python bootstrap was not invoked because this batch contains no Python, notebook, or NeqSim runtime execution.

### Rendering

No rendered-site artifact is currently available; browser visual inspection is not claimed.

### Next scan

After D028 is merged and recorded, D029 advances to process equipment and process simulation.
