### PR TITLE
docs: repair process simulation navigation (D029)

### DIFF
--- a/docs/simulation/README.md
+++ b/docs/simulation/README.md
@@ -3,8 +3,6 @@ title: "Process Simulation Guides"
 description: "Advanced guides for process simulation features in NeqSim."
 ---
 
-# Process Simulation Guides
-
 Advanced guides for process simulation features in NeqSim.
 
 ---
@@ -21,54 +19,54 @@ This folder contains guides for advanced process simulation topics including pro
 
 | Document | Description |
 |----------|-------------|
-| [process_logic_framework.md](process_logic_framework) | Process logic framework architecture |
-| [advanced_process_logic.md](advanced_process_logic) | Advanced logic patterns |
-| [ProcessLogicEnhancements.md](ProcessLogicEnhancements) | Logic enhancements |
-| [process_logic_implementation_summary.md](process_logic_implementation_summary) | Implementation summary |
-| [RuntimeLogicFlexibility.md](RuntimeLogicFlexibility) | Runtime logic flexibility |
-| [process_calculator.md](process_calculator) | Process calculators |
+| [process_logic_framework.md](process_logic_framework.md) | Process logic framework architecture |
+| [advanced_process_logic.md](advanced_process_logic.md) | Advanced logic patterns |
+| [ProcessLogicEnhancements.md](ProcessLogicEnhancements.md) | Logic enhancements |
+| [process_logic_implementation_summary.md](process_logic_implementation_summary.md) | Implementation summary |
+| [RuntimeLogicFlexibility.md](RuntimeLogicFlexibility.md) | Runtime logic flexibility |
+| [process_calculator.md](process_calculator.md) | Process calculators |
 
 ### Dynamic & Transient Simulation
 
 | Document | Description |
 |----------|-------------|
-| [dynamic_simulation_guide.md](dynamic_simulation_guide) | **Comprehensive dynamic/transient simulation guide** |
-| [derivatives_and_gradients.md](derivatives_and_gradients) | Derivatives and gradients for dynamic systems |
+| [dynamic_simulation_guide.md](dynamic_simulation_guide.md) | **Comprehensive dynamic/transient simulation guide** |
+| [derivatives_and_gradients.md](derivatives_and_gradients.md) | Derivatives and gradients for dynamic systems |
 
 ### Simulation Techniques
 
 | Document | Description |
 |----------|-------------|
-| [process_serialization.md](process_serialization) | **Saving and loading process models** |
-| [parallel_process_simulation.md](parallel_process_simulation) | Parallel and multi-threaded simulation |
-| [graph_based_process_simulation.md](graph_based_process_simulation) | Graph-based process simulation |
-| [recycle_acceleration_guide.md](recycle_acceleration_guide) | Recycle convergence acceleration |
-| [differentiable_thermodynamics.md](differentiable_thermodynamics) | Auto-differentiation for optimization |
-| [INTEGRATED_WORKFLOW_GUIDE.md](INTEGRATED_WORKFLOW_GUIDE) | Integrated workflow guide |
+| [process_serialization.md](process_serialization.md) | **Saving and loading process models** |
+| [parallel_process_simulation.md](parallel_process_simulation.md) | Parallel and multi-threaded simulation |
+| [graph_based_process_simulation.md](graph_based_process_simulation.md) | Graph-based process simulation |
+| [recycle_acceleration_guide.md](recycle_acceleration_guide.md) | Recycle convergence acceleration |
+| [differentiable_thermodynamics.md](differentiable_thermodynamics.md) | Auto-differentiation for optimization |
+| [INTEGRATED_WORKFLOW_GUIDE.md](INTEGRATED_WORKFLOW_GUIDE.md) | Integrated workflow guide |
 
 
 ### Process Automation Deep Dives
 
 | Document | Description |
 |----------|-------------|
-| [automation/automation_foundations.md](automation/automation_foundations) | Addressing, variable catalogs, unit handling, and safe accessor schema |
-| [automation/automation_integrations.md](automation/automation_integrations) | Multi-area patterns plus optimizer and digital-twin integration |
-| [automation/automation_operations.md](automation/automation_operations) | Diagnostics, bounds validation, and troubleshooting playbook |
+| [automation/automation_foundations.md](automation/automation_foundations.md) | Addressing, variable catalogs, unit handling, and safe accessor schema |
+| [automation/automation_integrations.md](automation/automation_integrations.md) | Multi-area patterns plus optimizer and digital-twin integration |
+| [automation/automation_operations.md](automation/automation_operations.md) | Diagnostics, bounds validation, and troubleshooting playbook |
 
 ### Equipment Modeling
 
 | Document | Description |
 |----------|-------------|
-| [turboexpander_compressor_model.md](turboexpander_compressor_model) | Turboexpander and compressor modeling |
-| [equipment_factory.md](equipment_factory) | Equipment factory patterns |
+| [turboexpander_compressor_model.md](turboexpander_compressor_model.md) | Turboexpander and compressor modeling |
+| [equipment_factory.md](equipment_factory.md) | Equipment factory patterns |
 
 ### Well and Reservoir
 
 | Document | Description |
 |----------|-------------|
-| [well_simulation_guide.md](well_simulation_guide) | Well simulation guide |
-| [well_and_choke_simulation.md](well_and_choke_simulation) | Choke valve simulation |
-| [field_development_engine.md](field_development_engine) | Field development engine |
+| [well_simulation_guide.md](well_simulation_guide.md) | Well simulation guide |
+| [well_and_choke_simulation.md](well_and_choke_simulation.md) | Choke valve simulation |
+| [field_development_engine.md](field_development_engine.md) | Field development engine |
 
 ---
 


### PR DESCRIPTION
## D029 — Process-simulation landing-page navigation

Linked to #2499.

### Frozen scope

- `docs/simulation/README.md`

All Java source, tests, notebooks, process-equipment implementations, equations, images, external links, other landing pages, and open-PR paths are excluded. The changed path has zero overlap with all 28 other open pull requests.

### Confirmed defects and fixes

1. **Medium — duplicate page title.** Removed the Markdown H1 that duplicated the Jekyll front-matter title.
2. **Medium — 22 nonconforming internal file links.** Added the repository-required `.md` suffix to every verified file destination. The three directory links remain directory links.

All 23 confirmed defects are repaired.

### Validation performed

- exact `master` base and current merge base: `c0d8d5d21849e8e5f259a349d25899fb155e7b54`
- overlap check: all 28 other open PR changed-path sets inspected; zero touch `docs/simulation/README.md`
- Jekyll front matter: present and retained
- duplicate Markdown H1 count: 0
- internal links: 25 occurrences
- destinations: all 25 resolve (22 files plus 3 directory README targets)
- extensionless file targets: 0 after repair
- Markdown tables: six separators and their rows remain continuous
- code fences, equations, images, HTML interactions, and external links: none
- branch readback matches the validated content byte-for-byte
- final scope: one commit, one file, 22 additions and 24 deletions
- branch is current with `master`: one commit ahead, zero behind, mergeable
- build/test/Javadoc workflow: passed
- pre-commit: passed
- Spotless: passed
- documentation search coverage: passed
- CodeQL: passed
- Copilot reviewed the final one-file diff with no inline findings or suggested changes; no review threads or Copilot-authored commits exist

No executable code example or API claim changed, so no Java or Python regression is warranted. The resilient Python bootstrap was not invoked because this batch contains no Python, notebook, or NeqSim runtime execution.

### Rendering

No rendered-site artifact is currently available; browser visual inspection is not claimed.

### Next scan

After D029 is merged and recorded, D030 advances to engineering design, safety, DEXPI, and field-development documentation.
