### PR TITLE
Harden energy converters, drive trains, and typed utilities

### DIFF
--- a/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
@@ -234,14 +234,24 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public void runTransient(double dt, UUID id) {
+    if (!Double.isFinite(dt) || dt < 0.0) {
+      throw new IllegalArgumentException("Converter timestep must be non-negative and finite");
+    }
+
     double input = readAvailableInput();
     double targetOutput = calculateTargetOutput(input);
-    double maximumChange = rampRate * Math.max(0.0, dt);
-    double output = targetOutput;
+    double maximumChange = rampRate * dt;
+    double rampedOutput = targetOutput;
     if (Double.isFinite(maximumChange) && Math.abs(targetOutput - currentOutputPower) > maximumChange) {
-      output = currentOutputPower + Math.copySign(maximumChange, targetOutput - currentOutputPower);
+      rampedOutput = currentOutputPower + Math.copySign(maximumChange, targetOutput - currentOutputPower);
     }
-    double effectiveInput = output > 0.0 ? Math.min(input, output / efficiency + idleLoss) : 0.0;
+
+    // A memoryless converter cannot sustain a ramp-limited output using energy that is no longer available.
+    // Ramp limits therefore constrain increases, while a loss of input immediately caps output at the
+    // thermodynamically available target.
+    double output = Math.min(targetOutput, Math.max(0.0, rampedOutput));
+    double effectiveInput = output > 0.0 ? output / efficiency + idleLoss : 0.0;
+    effectiveInput = Math.min(input, effectiveInput);
     publish(effectiveInput, output);
     increaseTime(dt);
     setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/energy/Inverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/Inverter.java
@@ -39,9 +39,12 @@ public class Inverter extends EnergyConverter {
    * @param frequency output frequency in Hz
    */
   public void setOutputElectricalQuality(double voltage, double frequency) {
-    EnergyQuality validation = new EnergyQuality();
-    validation.setVoltage(voltage);
-    validation.setFrequency(frequency);
+    if (!Double.isFinite(voltage) || voltage <= 0.0) {
+      throw new IllegalArgumentException("Output voltage must be positive and finite");
+    }
+    if (!Double.isFinite(frequency) || frequency <= 0.0) {
+      throw new IllegalArgumentException("Output frequency must be positive and finite");
+    }
     outputVoltage = voltage;
     outputFrequency = frequency;
     publishOutputElectricalQuality();

--- a/src/main/java/neqsim/process/equipment/energy/Inverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/Inverter.java
@@ -31,8 +31,8 @@ public class Inverter extends EnergyConverter {
    * Sets output electrical quality.
    *
    * <p>
-   * Voltage and frequency are updated on the existing output quality object so temperature, pressure, utility level, and
-   * future metadata are preserved.
+   * Voltage and frequency are updated on the existing output quality object so temperature, pressure, utility level,
+   * and future metadata are preserved.
    * </p>
    *
    * @param voltage output voltage in V

--- a/src/main/java/neqsim/process/equipment/energy/Inverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/Inverter.java
@@ -1,5 +1,6 @@
 package neqsim.process.equipment.energy;
 
+import java.util.UUID;
 import neqsim.process.equipment.stream.EnergyPort;
 import neqsim.process.equipment.stream.EnergyQuality;
 import neqsim.process.equipment.stream.EnergyType;
@@ -29,18 +30,53 @@ public class Inverter extends EnergyConverter {
   /**
    * Sets output electrical quality.
    *
+   * <p>
+   * Voltage and frequency are updated on the existing output quality object so temperature, pressure, utility level, and
+   * future metadata are preserved.
+   * </p>
+   *
    * @param voltage output voltage in V
    * @param frequency output frequency in Hz
    */
   public void setOutputElectricalQuality(double voltage, double frequency) {
-    EnergyQuality quality = new EnergyQuality();
-    quality.setVoltage(voltage);
-    quality.setFrequency(frequency);
+    EnergyQuality validation = new EnergyQuality();
+    validation.setVoltage(voltage);
+    validation.setFrequency(frequency);
     outputVoltage = voltage;
     outputFrequency = frequency;
+    publishOutputElectricalQuality();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run(UUID id) {
+    super.run(id);
+    publishOutputElectricalQuality();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void runTransient(double dt, UUID id) {
+    super.runTransient(dt, id);
+    publishOutputElectricalQuality();
+  }
+
+  /** Publishes configured voltage and frequency without replacing other output quality metadata. */
+  private void publishOutputElectricalQuality() {
     EnergyPort output = getEnergyPort(OUTPUT_PORT);
-    if (output.isConnected()) {
+    if (!output.isConnected()) {
+      return;
+    }
+    EnergyQuality quality = output.getEnergyStream().getQuality();
+    if (quality == null) {
+      quality = new EnergyQuality();
       output.getEnergyStream().setQuality(quality);
+    }
+    if (Double.isFinite(outputVoltage)) {
+      quality.setVoltage(outputVoltage);
+    }
+    if (Double.isFinite(outputFrequency)) {
+      quality.setFrequency(outputFrequency);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/energy/MotorAssistedDriveTrain.java
+++ b/src/main/java/neqsim/process/equipment/energy/MotorAssistedDriveTrain.java
@@ -106,6 +106,10 @@ public class MotorAssistedDriveTrain implements Serializable {
       result.addError("energy", "Assist motor is not connected to the electrical bus",
           "Reconnect motor energyInput to the electrical bus");
     }
+    if (assistMotor.getEnergyPort(EnergyConverter.OUTPUT_PORT).getEnergyStream() != shaft) {
+      result.addError("energy", "Assist motor is not connected to the common shaft",
+          "Reconnect motor energyOutput to the common shaft");
+    }
     return result;
   }
 }

--- a/src/main/java/neqsim/process/equipment/energy/MotorDriveTrain.java
+++ b/src/main/java/neqsim/process/equipment/energy/MotorDriveTrain.java
@@ -113,6 +113,10 @@ public class MotorDriveTrain implements Serializable {
       result.addError("energy", "Motor is not connected to the configured electrical bus",
           "Reconnect motor energyInput to the electrical bus");
     }
+    if (motor.getEnergyPort(EnergyConverter.OUTPUT_PORT).getEnergyStream() != shaft) {
+      result.addError("energy", "Motor is not connected to the configured shaft",
+          "Reconnect motor energyOutput to the mechanical shaft");
+    }
     if (drivenEquipment.getEnergyPort("shaftPower").getEnergyStream() != shaft) {
       result.addError("energy", "Driven equipment is not connected to the configured shaft",
           "Reconnect shaftPower to the mechanical shaft");

--- a/src/main/java/neqsim/process/equipment/energy/UtilityEnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/energy/UtilityEnergyBus.java
@@ -23,6 +23,9 @@ public class UtilityEnergyBus extends EnergyBus {
    */
   public UtilityEnergyBus(String name, UtilityLevel utilityLevel) {
     super(name, EnergyType.HEAT);
+    if (utilityLevel == null || utilityLevel == UtilityLevel.UNSPECIFIED) {
+      throw new IllegalArgumentException("A specified utility level is required");
+    }
     getQuality().setUtilityLevel(utilityLevel);
   }
 
@@ -36,7 +39,7 @@ public class UtilityEnergyBus extends EnergyBus {
    */
   public UtilityEnergyBus(String name, UtilityLevel utilityLevel, double supplyTemperature, double returnTemperature) {
     this(name, utilityLevel);
-    getQuality().setTemperature(supplyTemperature);
+    setSupplyTemperature(supplyTemperature);
     setReturnTemperature(returnTemperature);
   }
 

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
@@ -1,0 +1,138 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.expander.Expander;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
+import neqsim.process.equipment.stream.UtilityLevel;
+
+class EnergyNetworkProfessionalHardeningTest {
+
+  @Test
+  void testTransientConverterOutputIsLimitedByAvailableInput() {
+    EnergyBus inputBus = new EnergyBus("input bus", EnergyType.ELECTRICAL);
+    EnergyBus outputBus = new EnergyBus("output bus", EnergyType.ELECTRICAL);
+    EnergyPort source = port("source", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED, inputBus);
+
+    Inverter inverter = new Inverter("inverter");
+    inverter.setEfficiency(0.95);
+    inverter.setIdleLoss(10.0);
+    inverter.setRampRate(10.0);
+    inverter.connectEnergyStream(EnergyConverter.INPUT_PORT, inputBus, EnergyPortMode.SPECIFICATION);
+    inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, outputBus, EnergyPortMode.CALCULATED);
+    inverter.setRequestedInputPower(1000.0);
+
+    source.setDuty(1000.0);
+    inputBus.solveBalance();
+    inverter.run(UUID.randomUUID());
+    assertEquals(940.5, inverter.getOutputPower(), 1.0e-12);
+
+    source.setDuty(100.0);
+    inputBus.solveBalance();
+    inverter.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(100.0, inverter.getInputPower(), 1.0e-12);
+    assertEquals(85.5, inverter.getOutputPower(), 1.0e-12);
+    assertEquals(14.5, inverter.getHeatLoss(), 1.0e-12);
+    assertEquals(inverter.getInputPower(), inverter.getOutputPower() + inverter.getHeatLoss(), 1.0e-12);
+    assertThrows(IllegalArgumentException.class, () -> inverter.runTransient(-1.0, UUID.randomUUID()));
+  }
+
+  @Test
+  void testInverterQualityUpdatePreservesExistingMetadata() {
+    EnergyBus outputBus = new EnergyBus("quality bus", EnergyType.ELECTRICAL);
+    outputBus.getQuality().setTemperature(320.0);
+    outputBus.getQuality().setPressure(2.0e5);
+
+    Inverter inverter = new Inverter("quality inverter");
+    inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, outputBus, EnergyPortMode.CALCULATED);
+    inverter.setOutputElectricalQuality(690.0, 50.0);
+
+    assertEquals(690.0, outputBus.getQuality().getVoltage(), 1.0e-12);
+    assertEquals(50.0, outputBus.getQuality().getFrequency(), 1.0e-12);
+    assertEquals(320.0, outputBus.getQuality().getTemperature(), 1.0e-12);
+    assertEquals(2.0e5, outputBus.getQuality().getPressure(), 1.0e-12);
+  }
+
+  @Test
+  void testInverterPublishesQualityWhenConfiguredBeforeConnection() {
+    Inverter inverter = new Inverter("late-connected inverter");
+    inverter.setOutputElectricalQuality(400.0, 60.0);
+
+    EnergyBus outputBus = new EnergyBus("late output", EnergyType.ELECTRICAL);
+    outputBus.getQuality().setTemperature(315.0);
+    inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, outputBus, EnergyPortMode.CALCULATED);
+    inverter.run(UUID.randomUUID());
+
+    assertEquals(400.0, outputBus.getQuality().getVoltage(), 1.0e-12);
+    assertEquals(60.0, outputBus.getQuality().getFrequency(), 1.0e-12);
+    assertEquals(315.0, outputBus.getQuality().getTemperature(), 1.0e-12);
+  }
+
+  @Test
+  void testMotorDriveTrainDetectsMotorOutputRewiring() {
+    ElectricMotor motor = new ElectricMotor("motor");
+    Compressor compressor = new Compressor("compressor");
+    EnergyBus electricalBus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("configured shaft");
+    MotorDriveTrain driveTrain = new MotorDriveTrain(motor, compressor, electricalBus, shaft);
+
+    assertTrue(driveTrain.validateSetup().isValid());
+
+    MechanicalShaft wrongShaft = new MechanicalShaft("wrong shaft");
+    motor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, wrongShaft, EnergyPortMode.CALCULATED);
+
+    assertFalse(driveTrain.validateSetup().isValid());
+    assertTrue(driveTrain.validateSetup().getReport().contains("Motor is not connected to the configured shaft"));
+  }
+
+  @Test
+  void testMotorAssistedDriveTrainDetectsAssistMotorOutputRewiring() {
+    Expander expander = new Expander("expander");
+    Compressor compressor = new Compressor("compressor");
+    ElectricMotor assistMotor = new ElectricMotor("assist motor");
+    EnergyBus electricalBus = new EnergyBus("assist electrical bus", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("common shaft");
+    MotorAssistedDriveTrain driveTrain =
+        new MotorAssistedDriveTrain(expander, compressor, assistMotor, electricalBus, shaft);
+
+    assertTrue(driveTrain.validateSetup().isValid());
+
+    MechanicalShaft wrongShaft = new MechanicalShaft("wrong assist shaft");
+    assistMotor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, wrongShaft, EnergyPortMode.CALCULATED);
+
+    assertFalse(driveTrain.validateSetup().isValid());
+    assertTrue(driveTrain.validateSetup().getReport().contains("Assist motor is not connected to the common shaft"));
+  }
+
+  @Test
+  void testUtilityEnergyBusRequiresSpecifiedGrade() {
+    assertThrows(IllegalArgumentException.class, () -> new UtilityEnergyBus("null utility", null));
+    assertThrows(IllegalArgumentException.class,
+        () -> new UtilityEnergyBus("unspecified utility", UtilityLevel.UNSPECIFIED));
+
+    UtilityEnergyBus steam = new UtilityEnergyBus("LP steam", UtilityLevel.LOW_PRESSURE_STEAM, 425.0, 383.0);
+    assertEquals(UtilityLevel.LOW_PRESSURE_STEAM, steam.getUtilityLevel());
+    assertEquals(425.0, steam.getSupplyTemperature(), 1.0e-12);
+    assertEquals(383.0, steam.getReturnTemperature(), 1.0e-12);
+  }
+
+  private static EnergyPort port(String owner, EnergyType type, EnergyPortDirection direction, EnergyPortMode mode,
+      EnergyBus bus) {
+    EnergyPort port = new EnergyPort("power", type, direction, mode);
+    port.setOwnerName(owner);
+    port.connect(bus);
+    return port;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
@@ -72,8 +72,7 @@ class EnergyNetworkProfessionalHardeningTest {
     inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, outputBus, EnergyPortMode.CALCULATED);
     inverter.setOutputElectricalQuality(690.0, 50.0);
 
-    assertThrows(IllegalArgumentException.class,
-        () -> inverter.setOutputElectricalQuality(Double.NaN, 50.0));
+    assertThrows(IllegalArgumentException.class, () -> inverter.setOutputElectricalQuality(Double.NaN, 50.0));
     assertThrows(IllegalArgumentException.class, () -> inverter.setOutputElectricalQuality(690.0, 0.0));
     assertEquals(690.0, inverter.getOutputVoltage(), 1.0e-12);
     assertEquals(50.0, inverter.getOutputFrequency(), 1.0e-12);

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
@@ -47,6 +47,9 @@ class EnergyNetworkProfessionalHardeningTest {
     assertEquals(14.5, inverter.getHeatLoss(), 1.0e-12);
     assertEquals(inverter.getInputPower(), inverter.getOutputPower() + inverter.getHeatLoss(), 1.0e-12);
     assertThrows(IllegalArgumentException.class, () -> inverter.runTransient(-1.0, UUID.randomUUID()));
+    assertThrows(IllegalArgumentException.class, () -> inverter.runTransient(Double.NaN, UUID.randomUUID()));
+    assertThrows(IllegalArgumentException.class,
+        () -> inverter.runTransient(Double.POSITIVE_INFINITY, UUID.randomUUID()));
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
@@ -22,8 +22,8 @@ class EnergyNetworkProfessionalHardeningTest {
   void testTransientConverterOutputIsLimitedByAvailableInput() {
     EnergyBus inputBus = new EnergyBus("input bus", EnergyType.ELECTRICAL);
     EnergyBus outputBus = new EnergyBus("output bus", EnergyType.ELECTRICAL);
-    EnergyPort source = port("source", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
-        EnergyPortMode.CALCULATED, inputBus);
+    EnergyPort source = port("source", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED,
+        inputBus);
 
     Inverter inverter = new Inverter("inverter");
     inverter.setEfficiency(0.95);
@@ -104,8 +104,8 @@ class EnergyNetworkProfessionalHardeningTest {
     ElectricMotor assistMotor = new ElectricMotor("assist motor");
     EnergyBus electricalBus = new EnergyBus("assist electrical bus", EnergyType.ELECTRICAL);
     MechanicalShaft shaft = new MechanicalShaft("common shaft");
-    MotorAssistedDriveTrain driveTrain =
-        new MotorAssistedDriveTrain(expander, compressor, assistMotor, electricalBus, shaft);
+    MotorAssistedDriveTrain driveTrain = new MotorAssistedDriveTrain(expander, compressor, assistMotor, electricalBus,
+        shaft);
 
     assertTrue(driveTrain.validateSetup().isValid());
 

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
@@ -66,6 +66,22 @@ class EnergyNetworkProfessionalHardeningTest {
   }
 
   @Test
+  void testInverterRejectsInvalidSetpointsWithoutChangingConfiguredQuality() {
+    EnergyBus outputBus = new EnergyBus("validated quality bus", EnergyType.ELECTRICAL);
+    Inverter inverter = new Inverter("validated inverter");
+    inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, outputBus, EnergyPortMode.CALCULATED);
+    inverter.setOutputElectricalQuality(690.0, 50.0);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> inverter.setOutputElectricalQuality(Double.NaN, 50.0));
+    assertThrows(IllegalArgumentException.class, () -> inverter.setOutputElectricalQuality(690.0, 0.0));
+    assertEquals(690.0, inverter.getOutputVoltage(), 1.0e-12);
+    assertEquals(50.0, inverter.getOutputFrequency(), 1.0e-12);
+    assertEquals(690.0, outputBus.getQuality().getVoltage(), 1.0e-12);
+    assertEquals(50.0, outputBus.getQuality().getFrequency(), 1.0e-12);
+  }
+
+  @Test
   void testInverterPublishesQualityWhenConfiguredBeforeConnection() {
     Inverter inverter = new Inverter("late-connected inverter");
     inverter.setOutputElectricalQuality(400.0, 60.0);


### PR DESCRIPTION
## Summary

Professional hardening follow-up for Energy Networks v3:

- enforce transient energy conservation in memoryless `EnergyConverter` units
- reject negative or non-finite converter timesteps
- preserve existing `EnergyQuality` metadata when an inverter sets voltage/frequency
- republish inverter quality after late stream connection and during steady/transient runs
- validate motor output wiring in `MotorDriveTrain`
- validate assist-motor output wiring in `MotorAssistedDriveTrain`
- reject null or unspecified grades in `UtilityEnergyBus`

## Validation coverage

- sudden input-power collapse cannot leave converter output above the physically supported target
- converter input equals useful output plus reported heat loss
- invalid transient timestep is rejected
- inverter voltage/frequency updates preserve temperature and pressure metadata
- inverter quality configured before connection is published after execution
- both compound drive-train validators detect motor output rewiring
- typed utility buses reject null/unspecified levels and accept a valid LP-steam definition

## Scope

This PR is intentionally limited to conservation and setup validation. Coupled process-energy convergence remains in PR #2607; load-dependent equipment maps and thermodynamic utility-flow models remain later stages.
