### PR TITLE
Integrate electric-motor part-load and VFD performance into energy networks

### DIFF
--- a/src/main/java/neqsim/process/equipment/energy/ElectricMotor.java
+++ b/src/main/java/neqsim/process/equipment/energy/ElectricMotor.java
@@ -1,15 +1,30 @@
 package neqsim.process.equipment.energy;
 
+import java.util.Objects;
+import neqsim.process.equipment.compressor.driver.ElectricMotorDriver;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyStream;
 import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
+import neqsim.util.validation.ValidationResult;
 
 /**
  * Electric motor converting electrical power to shaft work.
  *
+ * <p>
+ * The default model uses constant efficiency. An optional {@link ElectricMotorDriver} adds rated power, fixed-speed or
+ * VFD capability, part-load efficiency, and ambient/altitude derating using the same driver model already used by
+ * NeqSim compressor studies.
+ * </p>
+ *
  * @author NeqSim
- * @version 1.0
+ * @version 2.0
  */
 public class ElectricMotor extends EnergyConverter {
   private static final long serialVersionUID = 1000L;
+
+  private ElectricMotorDriver performanceModel;
+  private double configuredOperatingSpeed = Double.NaN;
 
   /**
    * Creates an electric motor with 95 percent efficiency.
@@ -30,5 +45,218 @@ public class ElectricMotor extends EnergyConverter {
   public ElectricMotor(String name, double efficiency) {
     this(name);
     setEfficiency(efficiency);
+  }
+
+  /**
+   * Attaches a detailed electric-motor performance model.
+   *
+   * @param performanceModel rated motor/VFD performance model
+   */
+  public void setPerformanceModel(ElectricMotorDriver performanceModel) {
+    ElectricMotorDriver model = Objects.requireNonNull(performanceModel, "performanceModel cannot be null");
+    if (!Double.isFinite(model.getRatedPower()) || model.getRatedPower() <= 0.0) {
+      throw new IllegalArgumentException("Motor performance model must have positive finite rated power");
+    }
+    if (!Double.isFinite(model.getRatedSpeed()) || model.getRatedSpeed() <= 0.0) {
+      throw new IllegalArgumentException("Motor performance model must have positive finite rated speed");
+    }
+    this.performanceModel = model;
+  }
+
+  /** Removes the detailed performance model and restores constant-efficiency behavior. */
+  public void clearPerformanceModel() {
+    performanceModel = null;
+  }
+
+  /**
+   * Gets the attached performance model.
+   *
+   * @return performance model, or {@code null} when constant efficiency is active
+   */
+  public ElectricMotorDriver getPerformanceModel() {
+    return performanceModel;
+  }
+
+  /**
+   * Checks whether detailed motor performance is active.
+   *
+   * @return {@code true} when a driver model is attached
+   */
+  public boolean hasPerformanceModel() {
+    return performanceModel != null;
+  }
+
+  /**
+   * Sets operating speed used when no positive-speed {@link MechanicalShaft} is connected.
+   *
+   * @param speed operating speed in rpm
+   */
+  public void setOperatingSpeed(double speed) {
+    if (!Double.isFinite(speed) || speed <= 0.0) {
+      throw new IllegalArgumentException("Motor operating speed must be positive and finite");
+    }
+    configuredOperatingSpeed = speed;
+  }
+
+  /** Clears explicit speed so a connected shaft or the rated speed is used. */
+  public void clearOperatingSpeed() {
+    configuredOperatingSpeed = Double.NaN;
+  }
+
+  /**
+   * Gets the resolved operating speed.
+   *
+   * @return connected shaft speed, configured speed, rated speed, or NaN without a detailed model
+   */
+  public double getOperatingSpeed() {
+    EnergyPort outputPort = getEnergyPort(OUTPUT_PORT);
+    if (outputPort.isConnected()) {
+      EnergyStream outputStream = outputPort.getEnergyStream();
+      if (outputStream instanceof MechanicalShaft && ((MechanicalShaft) outputStream).getSpeed() > 0.0) {
+        return ((MechanicalShaft) outputStream).getSpeed();
+      }
+    }
+    if (Double.isFinite(configuredOperatingSpeed)) {
+      return configuredOperatingSpeed;
+    }
+    return performanceModel == null ? Double.NaN : performanceModel.getRatedSpeed();
+  }
+
+  /**
+   * Gets currently available mechanical output capacity.
+   *
+   * @return available shaft power in W, or positive infinity for the constant-efficiency model
+   */
+  public double getAvailableShaftPower() {
+    if (performanceModel == null) {
+      return Double.POSITIVE_INFINITY;
+    }
+    return getAvailableShaftPower(getOperatingSpeed());
+  }
+
+  /**
+   * Gets motor efficiency at a requested shaft output.
+   *
+   * @param outputPower requested shaft output in W
+   * @return performance-model efficiency, or nominal constant efficiency
+   */
+  public double getEfficiencyAtOutputPower(double outputPower) {
+    if (!Double.isFinite(outputPower) || outputPower < 0.0) {
+      throw new IllegalArgumentException("Motor output power must be non-negative and finite");
+    }
+    if (performanceModel == null) {
+      return getEfficiency();
+    }
+    if (outputPower == 0.0) {
+      return 0.0;
+    }
+    double speed = getOperatingSpeed();
+    double ratedAvailablePower = performanceModel.getAvailablePower(speed) * 1000.0;
+    if (ratedAvailablePower <= 0.0) {
+      return 0.0;
+    }
+    double loadFraction = Math.min(1.2, outputPower / ratedAvailablePower);
+    return performanceModel.getEfficiency(speed, loadFraction);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected double calculateTargetOutput(double input) {
+    if (performanceModel == null) {
+      return super.calculateTargetOutput(input);
+    }
+    if (isTripped() || input <= getIdleLoss()) {
+      return 0.0;
+    }
+
+    double availableOutput = getAvailableShaftPower();
+    if (!Double.isFinite(availableOutput) || availableOutput <= 0.0) {
+      return 0.0;
+    }
+    if (calculateRequiredInputForOutput(availableOutput) <= input) {
+      return availableOutput;
+    }
+
+    double lowerOutput = 0.0;
+    double upperOutput = availableOutput;
+    for (int iteration = 0; iteration < 60; iteration++) {
+      double trialOutput = 0.5 * (lowerOutput + upperOutput);
+      if (calculateRequiredInputForOutput(trialOutput) <= input) {
+        lowerOutput = trialOutput;
+      } else {
+        upperOutput = trialOutput;
+      }
+    }
+    return lowerOutput;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected double calculateRequiredInputForOutput(double output) {
+    if (performanceModel == null) {
+      return super.calculateRequiredInputForOutput(output);
+    }
+    if (output <= 0.0) {
+      return 0.0;
+    }
+
+    double speed = getOperatingSpeed();
+    double availableOutput = getAvailableShaftPower(speed);
+    if (output > availableOutput + Math.max(1.0e-6, availableOutput * 1.0e-10)) {
+      throw new IllegalArgumentException("Requested shaft power exceeds motor capability at the operating speed");
+    }
+    double efficiency = getEfficiencyAtOutputPower(output);
+    if (!Double.isFinite(efficiency) || efficiency <= 0.0 || efficiency > 1.0) {
+      throw new IllegalStateException("Motor performance model returned invalid efficiency at the requested load");
+    }
+    return output / efficiency + getIdleLoss();
+  }
+
+  /** Gets derated shaft capability at one speed. */
+  private double getAvailableShaftPower(double speed) {
+    if (!Double.isFinite(speed) || speed <= 0.0) {
+      return 0.0;
+    }
+    double availablePower = performanceModel.getAvailablePower(speed) * 1000.0;
+    double derating = getCombinedEnvironmentalDeratingFactor();
+    if (!Double.isFinite(availablePower) || !Double.isFinite(derating)) {
+      throw new IllegalStateException("Motor performance model returned non-finite capability");
+    }
+    return Math.max(0.0, availablePower * derating);
+  }
+
+  /**
+   * Gets combined ambient-temperature and altitude derating.
+   *
+   * <p>
+   * The legacy driver returns early below 40 degrees Celsius, which omits altitude derating. The energy-network motor
+   * preserves that driver behavior for temperature while applying the missing altitude factor whenever the early return
+   * is active.
+   * </p>
+   */
+  private double getCombinedEnvironmentalDeratingFactor() {
+    double derating = performanceModel.getAmbientDeratingFactor();
+    if (performanceModel.getAmbientTemperature() <= 40.0 && performanceModel.getAltitude() > 1000.0) {
+      double altitudeDerating = 1.0 - 0.01 * (performanceModel.getAltitude() - 1000.0) / 100.0;
+      derating *= altitudeDerating;
+    }
+    return Math.max(0.5, Math.min(1.0, derating));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ValidationResult validateSetup() {
+    ValidationResult result = super.validateSetup();
+    if (performanceModel != null) {
+      double speed = getOperatingSpeed();
+      if (!Double.isFinite(speed) || speed <= 0.0) {
+        result.addError("energy", "Motor operating speed is not available",
+            "Set shaft speed, call setOperatingSpeed(rpm), or configure a rated motor speed");
+      } else if (performanceModel.getAvailablePower(speed) <= 0.0) {
+        result.addError("energy", "Motor cannot operate at the configured shaft speed",
+            "Select a valid fixed-speed point or configure the VFD speed range");
+      }
+    }
+    return result;
   }
 }

--- a/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
@@ -17,11 +17,12 @@ import neqsim.util.validation.ValidationResult;
  * <p>
  * The input is a specification port, the useful output is a calculated port, and conversion losses are available as a
  * calculated heat port. This common implementation is used by motors, generators, gearboxes, inverters, and
- * transformers.
+ * transformers. Subclasses can override the protected conversion methods to provide load-dependent performance while
+ * retaining common network, ramp, trip, and conservation behavior.
  * </p>
  *
  * @author NeqSim
- * @version 1.0
+ * @version 1.1
  */
 public class EnergyConverter extends ProcessEquipmentBaseClass {
   private static final long serialVersionUID = 1000L;
@@ -82,16 +83,21 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   }
 
   /**
-   * Gets conversion efficiency.
+   * Gets nominal conversion efficiency.
    *
-   * @return efficiency from zero to one
+   * <p>
+   * Subclasses with performance maps may use a different operating efficiency at the current load. Use
+   * {@link #getOperatingEfficiency()} for the efficiency realized by the latest calculation.
+   * </p>
+   *
+   * @return nominal efficiency from zero to one
    */
   public double getEfficiency() {
     return efficiency;
   }
 
   /**
-   * Sets conversion efficiency.
+   * Sets nominal conversion efficiency.
    *
    * @param efficiency efficiency greater than zero and at most one
    */
@@ -176,7 +182,7 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   }
 
   /**
-   * Gets the current allocated input power.
+   * Gets the current realized input power.
    *
    * @return input power in W
    */
@@ -203,6 +209,42 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   }
 
   /**
+   * Gets realized total conversion efficiency from the latest calculation.
+   *
+   * @return output divided by realized input, or zero when no input is consumed
+   */
+  public double getOperatingEfficiency() {
+    return currentInputPower > 0.0 ? currentOutputPower / currentInputPower : 0.0;
+  }
+
+  /**
+   * Calculates input power required for a requested useful output.
+   *
+   * <p>
+   * The default implementation uses nominal efficiency and idle loss. Subclasses may override the protected inverse
+   * conversion method to apply load-, speed-, or ambient-dependent performance maps.
+   * </p>
+   *
+   * @param outputPower requested useful output in W
+   * @return required input in W
+   * @throws IllegalArgumentException when the output is invalid or exceeds configured capability
+   */
+  public double getRequiredInputPowerForOutput(double outputPower) {
+    if (!Double.isFinite(outputPower) || outputPower < 0.0) {
+      throw new IllegalArgumentException("Requested output power must be non-negative and finite");
+    }
+    double requiredInput = calculateRequiredInputForOutput(outputPower);
+    if (!Double.isFinite(requiredInput) || requiredInput < 0.0) {
+      throw new IllegalStateException("Converter performance model returned invalid required input power");
+    }
+    if (Double.isFinite(maximumInputPower)
+        && requiredInput > maximumInputPower + Math.max(1.0e-9, maximumInputPower * 1.0e-12)) {
+      throw new IllegalArgumentException("Requested output exceeds the converter input-power capability");
+    }
+    return requiredInput;
+  }
+
+  /**
    * Checks whether the converter is tripped.
    *
    * @return {@code true} when tripped
@@ -226,8 +268,9 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
-    double input = readAvailableInput();
-    publish(input, calculateTargetOutput(input));
+    double availableInput = readAvailableInput();
+    double output = calculateTargetOutput(availableInput);
+    publish(calculateRealizedInput(availableInput, output), output);
     setCalculationIdentifier(id);
   }
 
@@ -238,8 +281,8 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
       throw new IllegalArgumentException("Converter timestep must be non-negative and finite");
     }
 
-    double input = readAvailableInput();
-    double targetOutput = calculateTargetOutput(input);
+    double availableInput = readAvailableInput();
+    double targetOutput = calculateTargetOutput(availableInput);
     double maximumChange = rampRate * dt;
     double rampedOutput = targetOutput;
     if (Double.isFinite(maximumChange) && Math.abs(targetOutput - currentOutputPower) > maximumChange) {
@@ -250,11 +293,40 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
     // Ramp limits therefore constrain increases, while a loss of input immediately caps output at the
     // thermodynamically available target.
     double output = Math.min(targetOutput, Math.max(0.0, rampedOutput));
-    double effectiveInput = output > 0.0 ? output / efficiency + idleLoss : 0.0;
-    effectiveInput = Math.min(input, effectiveInput);
-    publish(effectiveInput, output);
+    publish(calculateRealizedInput(availableInput, output), output);
     increaseTime(dt);
     setCalculationIdentifier(id);
+  }
+
+  /**
+   * Calculates useful steady-state output from available input.
+   *
+   * <p>
+   * Subclasses can override this method to apply performance maps. Implementations must return a finite non-negative
+   * output that can be supported by the supplied input.
+   * </p>
+   *
+   * @param input available input power in W
+   * @return useful output in W
+   */
+  protected double calculateTargetOutput(double input) {
+    if (tripped || input <= idleLoss) {
+      return 0.0;
+    }
+    return (input - idleLoss) * efficiency;
+  }
+
+  /**
+   * Calculates required input for useful output.
+   *
+   * @param output useful output power in W
+   * @return required input power in W
+   */
+  protected double calculateRequiredInputForOutput(double output) {
+    if (output <= 0.0) {
+      return 0.0;
+    }
+    return output / efficiency + idleLoss;
   }
 
   /**
@@ -269,29 +341,30 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
     return Math.min(maximumInputPower, getEnergyPort(INPUT_PORT).getPowerMagnitude());
   }
 
-  /**
-   * Calculates useful steady-state output.
-   *
-   * @param input input power in W
-   * @return useful output in W
-   */
-  private double calculateTargetOutput(double input) {
-    if (tripped || input <= idleLoss) {
-      return 0.0;
+  /** Calculates input actually consumed by the realized output. */
+  private double calculateRealizedInput(double availableInput, double output) {
+    if (output > 0.0) {
+      return Math.min(availableInput, getRequiredInputPowerForOutput(output));
     }
-    return (input - idleLoss) * efficiency;
+    if (availableInput > 0.0 && availableInput <= idleLoss) {
+      return availableInput;
+    }
+    return 0.0;
   }
 
   /**
    * Publishes converter results to connected output and loss ports.
    *
-   * @param input input power in W
+   * @param input realized input power in W
    * @param output useful output power in W
    */
   private void publish(double input, double output) {
-    currentInputPower = Math.max(0.0, input);
-    currentOutputPower = Math.max(0.0, output);
-    heatLoss = Math.max(0.0, currentInputPower - currentOutputPower);
+    if (!Double.isFinite(input) || input < 0.0 || !Double.isFinite(output) || output < 0.0 || output > input) {
+      throw new IllegalStateException("Energy converter result violates finite non-negative energy conservation");
+    }
+    currentInputPower = input;
+    currentOutputPower = output;
+    heatLoss = currentInputPower - currentOutputPower;
 
     EnergyPort outputPort = getEnergyPort(OUTPUT_PORT);
     outputPort.setConversionLoss(heatLoss);
@@ -332,7 +405,8 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
     result.put("inputPowerW", currentInputPower);
     result.put("outputPowerW", currentOutputPower);
     result.put("heatLossW", heatLoss);
-    result.put("efficiency", efficiency);
+    result.put("nominalEfficiency", efficiency);
+    result.put("operatingEfficiency", getOperatingEfficiency());
     result.put("tripped", tripped);
     return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(result);
   }

--- a/src/main/java/neqsim/process/equipment/energy/MotorAssistedDriveTrain.java
+++ b/src/main/java/neqsim/process/equipment/energy/MotorAssistedDriveTrain.java
@@ -66,7 +66,7 @@ public class MotorAssistedDriveTrain implements Serializable {
       throw new IllegalArgumentException("Drive-train power targets must be non-negative and finite");
     }
     compressor.getEnergyPort("shaftPower").setRequestedPower(compressorPower);
-    assistMotor.setRequestedInputPower(motorAssistPower / assistMotor.getEfficiency() + assistMotor.getIdleLoss());
+    assistMotor.setRequestedInputPower(assistMotor.getRequiredInputPowerForOutput(motorAssistPower));
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/energy/MotorDriveTrain.java
+++ b/src/main/java/neqsim/process/equipment/energy/MotorDriveTrain.java
@@ -63,7 +63,7 @@ public class MotorDriveTrain implements Serializable {
       throw new IllegalArgumentException("Requested shaft power must be non-negative and finite");
     }
     drivenEquipment.getEnergyPort("shaftPower").setRequestedPower(shaftPower);
-    motor.setRequestedInputPower(shaftPower / motor.getEfficiency() + motor.getIdleLoss());
+    motor.setRequestedInputPower(motor.getRequiredInputPowerForOutput(shaftPower));
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/energy/ElectricMotorPerformanceIntegrationTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/ElectricMotorPerformanceIntegrationTest.java
@@ -1,0 +1,145 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.compressor.driver.ElectricMotorDriver;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
+
+class ElectricMotorPerformanceIntegrationTest {
+
+  @Test
+  void testPartLoadEfficiencyIsUsedForInverseElectricalSizing() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    ElectricMotor motor = new ElectricMotor("part-load motor");
+    motor.setPerformanceModel(performance);
+    motor.setOperatingSpeed(3000.0);
+
+    double expectedEfficiency = 0.96 * 0.85;
+    double requiredInput = motor.getRequiredInputPowerForOutput(250.0e3);
+
+    assertEquals(expectedEfficiency, motor.getEfficiencyAtOutputPower(250.0e3), 1.0e-12);
+    assertEquals(250.0e3 / expectedEfficiency, requiredInput, 1.0e-9);
+  }
+
+  @Test
+  void testMotorDriveTrainUsesPerformanceModelForRequestedInput() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    ElectricMotor motor = new ElectricMotor("drive motor");
+    motor.setPerformanceModel(performance);
+
+    Compressor compressor = new Compressor("compressor");
+    EnergyBus electricalBus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("compressor shaft");
+    shaft.setSpeed(3000.0);
+    MotorDriveTrain driveTrain = new MotorDriveTrain(motor, compressor, electricalBus, shaft);
+
+    driveTrain.setRequestedShaftPower(250.0e3);
+
+    assertEquals(motor.getRequiredInputPowerForOutput(250.0e3),
+        motor.getEnergyPort(EnergyConverter.INPUT_PORT).getRequestedPower(), 1.0e-9);
+    assertEquals(250.0e3, compressor.getEnergyPort("shaftPower").getRequestedPower(), 1.0e-9);
+  }
+
+  @Test
+  void testAmbientDeratingCapsRealizedMotorOutputAndPreservesConservation() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    performance.setAmbientTemperature(50.0);
+
+    EnergyBus electricalBus = new EnergyBus("derated electrical bus", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("derated motor shaft");
+    shaft.setSpeed(3000.0);
+    EnergyPort source = port("grid", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, electricalBus);
+
+    ElectricMotor motor = new ElectricMotor("derated motor");
+    motor.setPerformanceModel(performance);
+    motor.connectEnergyStream(EnergyConverter.INPUT_PORT, electricalBus, EnergyPortMode.SPECIFICATION);
+    motor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, shaft, EnergyPortMode.CALCULATED);
+    motor.setRequestedInputPower(2.0e6);
+    source.setDuty(2.0e6);
+
+    electricalBus.solveBalance();
+    motor.run(UUID.randomUUID());
+
+    assertEquals(800.0e3, motor.getAvailableShaftPower(), 1.0e-9);
+    assertEquals(800.0e3, motor.getOutputPower(), 1.0e-6);
+    assertEquals(motor.getRequiredInputPowerForOutput(800.0e3), motor.getInputPower(), 1.0e-6);
+    assertTrue(motor.getInputPower() < 2.0e6);
+    assertEquals(motor.getInputPower(), motor.getOutputPower() + motor.getHeatLoss(), 1.0e-9);
+    assertEquals(motor.getOutputPower() / motor.getInputPower(), motor.getOperatingEfficiency(), 1.0e-12);
+  }
+
+  @Test
+  void testAltitudeDeratingIsAppliedAtStandardAmbientTemperature() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    performance.setAmbientTemperature(15.0);
+    performance.setAltitude(2000.0);
+
+    ElectricMotor motor = new ElectricMotor("high-altitude motor");
+    motor.setPerformanceModel(performance);
+    motor.setOperatingSpeed(3000.0);
+
+    assertEquals(900.0e3, motor.getAvailableShaftPower(), 1.0e-9);
+    assertThrows(IllegalArgumentException.class, () -> motor.getRequiredInputPowerForOutput(900.1e3));
+  }
+
+  @Test
+  void testFixedSpeedViolationBecomesValidWhenVfdRangeIsEnabled() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    EnergyBus electricalBus = new EnergyBus("vfd electrical bus", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("variable speed shaft");
+    shaft.setSpeed(1500.0);
+
+    ElectricMotor motor = new ElectricMotor("VFD motor");
+    motor.setPerformanceModel(performance);
+    motor.connectEnergyStream(EnergyConverter.INPUT_PORT, electricalBus, EnergyPortMode.SPECIFICATION);
+    motor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, shaft, EnergyPortMode.CALCULATED);
+
+    assertFalse(motor.validateSetup().isValid());
+    assertEquals(0.0, motor.getAvailableShaftPower(), 1.0e-12);
+
+    performance.setMinSpeedRatio(0.3);
+    performance.setMaxSpeedRatio(1.2);
+    performance.setHasVFD(true);
+
+    assertTrue(motor.validateSetup().isValid());
+    assertEquals(500.0e3, motor.getAvailableShaftPower(), 1.0e-9);
+  }
+
+  @Test
+  void testRequestedOutputAboveDeratedCapabilityIsRejected() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    performance.setAmbientTemperature(50.0);
+    ElectricMotor motor = new ElectricMotor("capacity-limited motor");
+    motor.setPerformanceModel(performance);
+    motor.setOperatingSpeed(3000.0);
+
+    assertThrows(IllegalArgumentException.class, () -> motor.getRequiredInputPowerForOutput(800.1e3));
+  }
+
+  @Test
+  void testClearingPerformanceModelRestoresConstantEfficiency() {
+    ElectricMotor motor = new ElectricMotor("fallback motor", 0.95);
+    motor.setPerformanceModel(new ElectricMotorDriver(1000.0, 3000.0, 0.96));
+    motor.clearPerformanceModel();
+
+    assertFalse(motor.hasPerformanceModel());
+    assertEquals(100.0e3 / 0.95, motor.getRequiredInputPowerForOutput(100.0e3), 1.0e-9);
+  }
+
+  private static EnergyPort port(String owner, EnergyPortDirection direction, EnergyPortMode mode, EnergyBus bus) {
+    EnergyPort port = new EnergyPort("power", EnergyType.ELECTRICAL, direction, mode);
+    port.setOwnerName(owner);
+    port.connect(bus);
+    return port;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the first equipment-capability stage for Energy Networks v3 by integrating the existing `ElectricMotorDriver` model with `ElectricMotor`:

- optional rated motor/VFD performance model on `ElectricMotor`
- automatic operating-speed readback from a connected `MechanicalShaft`
- explicit speed fallback and rated-speed fallback
- fixed-speed and VFD speed-range capability enforcement
- part-load efficiency for electrical-to-shaft conversion
- ambient/altitude derating through the existing driver model
- derated shaft-power capacity reporting
- inverse electrical-input sizing for requested shaft output
- common extensible forward/inverse conversion hooks in `EnergyConverter`
- realized rather than merely allocated converter input reporting
- `MotorDriveTrain` and `MotorAssistedDriveTrain` use inverse performance sizing

## Validation coverage

- 25% motor load uses the existing part-load efficiency characteristic
- drive-train electrical request matches inverse performance sizing
- ambient and altitude derating cap realized shaft output while conserving energy
- invalid fixed-speed operation is detected
- enabling the configured VFD range makes the same speed valid
- shaft request above derated motor capability is rejected
- clearing the detailed model restores legacy constant-efficiency behavior

## Compatibility

`ElectricMotor` retains constant-efficiency behavior unless a performance model is explicitly attached. Existing constructors and APIs remain valid.

## Dependency

PR #2608 is merged. This branch has been rebuilt directly on the merged `master` head and now contains only the motor-performance integration.