### PR TITLE
Add thermodynamic mass-flow reporting to utility energy networks

### DIFF
--- a/docs/process/energy_streams.md
+++ b/docs/process/energy_streams.md
@@ -150,6 +150,43 @@ The `neqsim.process.equipment.energy` package provides process units with explic
 
 `ThermalUtilitySource` and `ThermalUtilityConsumer` participate in the same allocation, shortage, cost, and emissions reporting as electrical and shaft networks. Heaters, coolers, condensers, reboilers, two-stream heat exchangers, multi-stream exchangers, and `LNGHeatExchanger` publish or consume typed heat duties.
 
+### Thermodynamic utility mass flow
+
+Configure explicit supply and return states when the utility network must report physical circulation rather than only thermal power. Specific enthalpy is supplied in J/kg, allowing the values to come from NeqSim, vendor data, or another qualified property package.
+
+```java
+ThermalUtilityState steamSupply =
+    new ThermalUtilityState(425.0, 4.0e5, 2.8e6);
+ThermalUtilityState condensateReturn =
+    new ThermalUtilityState(383.0, 4.0e5, 0.6e6);
+
+UtilityEnergyBus lpSteam = new UtilityEnergyBus(
+    "LP steam", UtilityLevel.LOW_PRESSURE_STEAM,
+    steamSupply, condensateReturn);
+
+ThermalUtilitySource boiler =
+    new ThermalUtilitySource("boiler", UtilityLevel.LOW_PRESSURE_STEAM);
+ThermalUtilityConsumer reboiler =
+    new ThermalUtilityConsumer("reboiler", UtilityLevel.LOW_PRESSURE_STEAM);
+boiler.connectEnergyStream(ThermalUtilitySource.OUTPUT_PORT,
+    lpSteam, EnergyPortMode.CALCULATED);
+reboiler.connectEnergyStream(ThermalUtilityConsumer.INPUT_PORT,
+    lpSteam, EnergyPortMode.SPECIFICATION);
+boiler.setAvailablePower(2.0e6);
+reboiler.setRequestedPower(1.5e6);
+
+boiler.run();
+lpSteam.solveBalance();
+reboiler.run();
+
+double servedSteamKgPerSecond = lpSteam.getServedMassFlow();
+double curtailedSteamKgPerSecond = lpSteam.getCurtailedMassFlow();
+double servedSteamTonPerHour = lpSteam.getMassFlowForDuty(
+    lpSteam.getLastReport().getServedDemand(), "W", "ton/hr");
+```
+
+Heating utilities require supply enthalpy above return enthalpy. Cooling-water, chilled-water, refrigeration, and ambient-cooling utilities require return enthalpy above supply enthalpy because they absorb process heat. The solved bus exposes requested, served, offered, accepted, unmet, and curtailed mass-flow equivalents.
+
 ## Dynamics and reporting
 
 `MechanicalShaft.advanceTransient(dt)` integrates rotational kinetic energy from the solved net shaft power. Moment of inertia, friction loss, maximum speed, acceleration/deceleration limits, and trip coastdown are configurable.

--- a/src/main/java/neqsim/process/equipment/energy/ThermalUtilityState.java
+++ b/src/main/java/neqsim/process/equipment/energy/ThermalUtilityState.java
@@ -1,0 +1,82 @@
+package neqsim.process.equipment.energy;
+
+import java.io.Serializable;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Immutable thermodynamic state used to convert a thermal-utility duty into mass flow.
+ *
+ * <p>
+ * The state deliberately stores specific enthalpy explicitly rather than embedding an approximate steam or water
+ * correlation. Callers can therefore obtain properties from NeqSim, vendor data, or another qualified property package
+ * and still use one consistent utility-network balance.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class ThermalUtilityState implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final double temperature;
+  private final double pressure;
+  private final double specificEnthalpy;
+
+  /**
+   * Creates one utility state.
+   *
+   * @param temperature temperature in K
+   * @param pressure pressure in Pa
+   * @param specificEnthalpy specific enthalpy in J/kg
+   */
+  public ThermalUtilityState(double temperature, double pressure, double specificEnthalpy) {
+    if (!Double.isFinite(temperature) || temperature <= 0.0) {
+      throw new IllegalArgumentException("Utility-state temperature must be positive and finite");
+    }
+    if (!Double.isFinite(pressure) || pressure <= 0.0) {
+      throw new IllegalArgumentException("Utility-state pressure must be positive and finite");
+    }
+    if (!Double.isFinite(specificEnthalpy)) {
+      throw new IllegalArgumentException("Utility-state specific enthalpy must be finite");
+    }
+    this.temperature = temperature;
+    this.pressure = pressure;
+    this.specificEnthalpy = specificEnthalpy;
+  }
+
+  /**
+   * Gets temperature.
+   *
+   * @return temperature in K
+   */
+  public double getTemperature() {
+    return temperature;
+  }
+
+  /**
+   * Gets pressure.
+   *
+   * @return pressure in Pa
+   */
+  public double getPressure() {
+    return pressure;
+  }
+
+  /**
+   * Gets specific enthalpy.
+   *
+   * @return specific enthalpy in J/kg
+   */
+  public double getSpecificEnthalpy() {
+    return specificEnthalpy;
+  }
+
+  /**
+   * Serializes the state as JSON.
+   *
+   * @return JSON state
+   */
+  public String toJson() {
+    return new GsonBuilder().create().toJson(this);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/UtilityEnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/energy/UtilityEnergyBus.java
@@ -1,19 +1,30 @@
 package neqsim.process.equipment.energy;
 
+import java.util.Objects;
 import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyNetworkReport;
 import neqsim.process.equipment.stream.EnergyType;
 import neqsim.process.equipment.stream.UtilityLevel;
+import neqsim.util.unit.PowerUnit;
 
 /**
- * Thermal {@link EnergyBus} carrying a standard utility grade and supply/return temperatures.
+ * Thermal {@link EnergyBus} carrying a standard utility grade and optional supply/return thermodynamic states.
+ *
+ * <p>
+ * A solved energy duty can be converted to physical utility mass flow when supply and return specific enthalpies are
+ * configured. Heating utilities must lose enthalpy from supply to return; cooling and refrigeration utilities must gain
+ * enthalpy while absorbing process heat.
+ * </p>
  *
  * @author NeqSim
- * @version 1.0
+ * @version 2.0
  */
 public class UtilityEnergyBus extends EnergyBus {
   private static final long serialVersionUID = 1000L;
 
   private double returnTemperature = Double.NaN;
+  private ThermalUtilityState supplyState;
+  private ThermalUtilityState returnState;
 
   /**
    * Creates a utility bus.
@@ -44,6 +55,168 @@ public class UtilityEnergyBus extends EnergyBus {
   }
 
   /**
+   * Creates a utility bus with complete thermodynamic states.
+   *
+   * @param name bus name
+   * @param utilityLevel utility grade
+   * @param supplyState supply state
+   * @param returnState return state
+   */
+  public UtilityEnergyBus(String name, UtilityLevel utilityLevel, ThermalUtilityState supplyState,
+      ThermalUtilityState returnState) {
+    this(name, utilityLevel);
+    setThermodynamicStates(supplyState, returnState);
+  }
+
+  /**
+   * Sets supply and return thermodynamic states used for mass-flow conversion.
+   *
+   * @param supplyState supply state
+   * @param returnState return state
+   */
+  public void setThermodynamicStates(ThermalUtilityState supplyState, ThermalUtilityState returnState) {
+    ThermalUtilityState supply = Objects.requireNonNull(supplyState, "supplyState cannot be null");
+    ThermalUtilityState returns = Objects.requireNonNull(returnState, "returnState cannot be null");
+    double enthalpyChange = supply.getSpecificEnthalpy() - returns.getSpecificEnthalpy();
+    if (isHeatingUtility()) {
+      if (enthalpyChange <= 0.0) {
+        throw new IllegalArgumentException("Heating-utility supply enthalpy must exceed return enthalpy");
+      }
+    } else if (enthalpyChange >= 0.0) {
+      throw new IllegalArgumentException("Cooling-utility return enthalpy must exceed supply enthalpy");
+    }
+
+    this.supplyState = supply;
+    this.returnState = returns;
+    getQuality().setTemperature(supply.getTemperature());
+    getQuality().setPressure(supply.getPressure());
+    returnTemperature = returns.getTemperature();
+  }
+
+  /** Removes thermodynamic states while retaining utility grade and temperature metadata. */
+  public void clearThermodynamicStates() {
+    supplyState = null;
+    returnState = null;
+  }
+
+  /**
+   * Checks whether specific-enthalpy states are available.
+   *
+   * @return {@code true} when both supply and return states are configured
+   */
+  public boolean hasThermodynamicStates() {
+    return supplyState != null && returnState != null;
+  }
+
+  /**
+   * Gets supply thermodynamic state.
+   *
+   * @return supply state, or {@code null} when not configured
+   */
+  public ThermalUtilityState getSupplyState() {
+    return supplyState;
+  }
+
+  /**
+   * Gets return thermodynamic state.
+   *
+   * @return return state, or {@code null} when not configured
+   */
+  public ThermalUtilityState getReturnState() {
+    return returnState;
+  }
+
+  /**
+   * Gets useful thermal duty per unit mass circulated.
+   *
+   * @return absolute supply-return enthalpy difference in J/kg
+   */
+  public double getSpecificDuty() {
+    requireThermodynamicStates();
+    return Math.abs(supplyState.getSpecificEnthalpy() - returnState.getSpecificEnthalpy());
+  }
+
+  /**
+   * Converts thermal duty to required utility mass flow.
+   *
+   * @param duty absolute thermal duty in W
+   * @return mass flow in kg/s
+   */
+  public double getMassFlowForDuty(double duty) {
+    if (!Double.isFinite(duty) || duty < 0.0) {
+      throw new IllegalArgumentException("Utility duty must be non-negative and finite");
+    }
+    return duty / getSpecificDuty();
+  }
+
+  /**
+   * Converts thermal duty to required utility mass flow.
+   *
+   * @param duty thermal duty
+   * @param powerUnit duty unit supported by {@link PowerUnit}
+   * @param massFlowUnit requested mass-flow unit: kg/sec, kg/hr, or ton/hr
+   * @return utility mass flow in the requested unit
+   */
+  public double getMassFlowForDuty(double duty, String powerUnit, String massFlowUnit) {
+    double dutyInW = new PowerUnit(duty, powerUnit).getValue("W");
+    return convertMassFlow(getMassFlowForDuty(dutyInW), massFlowUnit);
+  }
+
+  /**
+   * Gets mass flow corresponding to requested network demand.
+   *
+   * @return requested mass flow in kg/s
+   */
+  public double getRequestedMassFlow() {
+    return getMassFlowForDuty(requireLastReport().getRequestedDemand());
+  }
+
+  /**
+   * Gets mass flow corresponding to served network demand.
+   *
+   * @return served mass flow in kg/s
+   */
+  public double getServedMassFlow() {
+    return getMassFlowForDuty(requireLastReport().getServedDemand());
+  }
+
+  /**
+   * Gets mass flow corresponding to offered utility supply.
+   *
+   * @return offered mass flow in kg/s
+   */
+  public double getOfferedMassFlow() {
+    return getMassFlowForDuty(requireLastReport().getOfferedSupply());
+  }
+
+  /**
+   * Gets mass flow corresponding to accepted utility supply.
+   *
+   * @return accepted mass flow in kg/s
+   */
+  public double getAcceptedMassFlow() {
+    return getMassFlowForDuty(requireLastReport().getAcceptedSupply());
+  }
+
+  /**
+   * Gets mass flow equivalent of unmet utility demand.
+   *
+   * @return unmet-demand mass flow in kg/s
+   */
+  public double getUnmetMassFlow() {
+    return getMassFlowForDuty(requireLastReport().getUnmetDemand());
+  }
+
+  /**
+   * Gets mass flow equivalent of curtailed utility supply.
+   *
+   * @return curtailed-supply mass flow in kg/s
+   */
+  public double getCurtailedMassFlow() {
+    return getMassFlowForDuty(requireLastReport().getCurtailedSupply());
+  }
+
+  /**
    * Gets supply temperature.
    *
    * @return temperature in K, or {@link Double#NaN} when unspecified
@@ -59,6 +232,32 @@ public class UtilityEnergyBus extends EnergyBus {
    */
   public void setSupplyTemperature(double supplyTemperature) {
     getQuality().setTemperature(supplyTemperature);
+    if (supplyState != null) {
+      supplyState = new ThermalUtilityState(supplyTemperature, supplyState.getPressure(),
+          supplyState.getSpecificEnthalpy());
+    }
+  }
+
+  /**
+   * Gets supply pressure.
+   *
+   * @return pressure in Pa, or {@link Double#NaN} when unspecified
+   */
+  public double getSupplyPressure() {
+    return getQuality().getPressure();
+  }
+
+  /**
+   * Sets supply pressure.
+   *
+   * @param supplyPressure pressure in Pa
+   */
+  public void setSupplyPressure(double supplyPressure) {
+    getQuality().setPressure(supplyPressure);
+    if (supplyState != null) {
+      supplyState = new ThermalUtilityState(supplyState.getTemperature(), supplyPressure,
+          supplyState.getSpecificEnthalpy());
+    }
   }
 
   /**
@@ -80,6 +279,10 @@ public class UtilityEnergyBus extends EnergyBus {
       throw new IllegalArgumentException("Return temperature must be positive and finite");
     }
     this.returnTemperature = returnTemperature;
+    if (returnState != null) {
+      returnState = new ThermalUtilityState(returnTemperature, returnState.getPressure(),
+          returnState.getSpecificEnthalpy());
+    }
   }
 
   /**
@@ -89,5 +292,42 @@ public class UtilityEnergyBus extends EnergyBus {
    */
   public UtilityLevel getUtilityLevel() {
     return getQuality().getUtilityLevel();
+  }
+
+  /** Returns whether this utility delivers heat rather than absorbing it. */
+  private boolean isHeatingUtility() {
+    UtilityLevel level = getUtilityLevel();
+    return level == UtilityLevel.HIGH_PRESSURE_STEAM || level == UtilityLevel.MEDIUM_PRESSURE_STEAM
+        || level == UtilityLevel.LOW_PRESSURE_STEAM || level == UtilityLevel.HOT_OIL;
+  }
+
+  /** Requires supply and return states for a mass-flow calculation. */
+  private void requireThermodynamicStates() {
+    if (!hasThermodynamicStates()) {
+      throw new IllegalStateException("Configure supply and return thermodynamic states before calculating mass flow");
+    }
+  }
+
+  /** Requires a completed energy-network solve. */
+  private EnergyNetworkReport requireLastReport() {
+    EnergyNetworkReport report = getLastReport();
+    if (report == null) {
+      throw new IllegalStateException("Solve the utility energy bus before requesting report mass flows");
+    }
+    return report;
+  }
+
+  /** Converts kg/s to one supported reporting unit. */
+  private static double convertMassFlow(double massFlowKgPerSecond, String unit) {
+    if ("kg/sec".equals(unit) || "kg/s".equals(unit)) {
+      return massFlowKgPerSecond;
+    }
+    if ("kg/hr".equals(unit)) {
+      return massFlowKgPerSecond * 3600.0;
+    }
+    if ("ton/hr".equals(unit) || "t/hr".equals(unit)) {
+      return massFlowKgPerSecond * 3.6;
+    }
+    throw new IllegalArgumentException("Unsupported utility mass-flow unit: " + unit);
   }
 }

--- a/src/test/java/neqsim/process/equipment/energy/ThermalUtilityMassFlowTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/ThermalUtilityMassFlowTest.java
@@ -1,0 +1,99 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.UtilityLevel;
+
+class ThermalUtilityMassFlowTest {
+
+  @Test
+  void testSteamNetworkReportsPhysicalMassFlows() {
+    ThermalUtilityState steamSupply = new ThermalUtilityState(425.0, 4.0e5, 2.8e6);
+    ThermalUtilityState condensateReturn = new ThermalUtilityState(383.0, 4.0e5, 0.6e6);
+    UtilityEnergyBus steam = new UtilityEnergyBus("LP steam", UtilityLevel.LOW_PRESSURE_STEAM, steamSupply,
+        condensateReturn);
+
+    ThermalUtilitySource source = new ThermalUtilitySource("boiler", UtilityLevel.LOW_PRESSURE_STEAM);
+    ThermalUtilityConsumer consumer = new ThermalUtilityConsumer("reboiler", UtilityLevel.LOW_PRESSURE_STEAM);
+    source.connectEnergyStream(ThermalUtilitySource.OUTPUT_PORT, steam, EnergyPortMode.CALCULATED);
+    consumer.connectEnergyStream(ThermalUtilityConsumer.INPUT_PORT, steam, EnergyPortMode.SPECIFICATION);
+    source.setAvailablePower(2.0e6);
+    consumer.setRequestedPower(1.5e6);
+
+    source.run();
+    steam.solveBalance();
+    consumer.run();
+
+    assertTrue(steam.hasThermodynamicStates());
+    assertEquals(2.2e6, steam.getSpecificDuty(), 1.0e-9);
+    assertEquals(2.0e6 / 2.2e6, steam.getOfferedMassFlow(), 1.0e-12);
+    assertEquals(1.5e6 / 2.2e6, steam.getAcceptedMassFlow(), 1.0e-12);
+    assertEquals(1.5e6 / 2.2e6, steam.getRequestedMassFlow(), 1.0e-12);
+    assertEquals(1.5e6 / 2.2e6, steam.getServedMassFlow(), 1.0e-12);
+    assertEquals(0.0, steam.getUnmetMassFlow(), 1.0e-12);
+    assertEquals(0.5e6 / 2.2e6, steam.getCurtailedMassFlow(), 1.0e-12);
+    assertEquals(425.0, steam.getSupplyTemperature(), 1.0e-12);
+    assertEquals(4.0e5, steam.getSupplyPressure(), 1.0e-12);
+    assertEquals(383.0, steam.getReturnTemperature(), 1.0e-12);
+  }
+
+  @Test
+  void testCoolingWaterDutyUsesReturnMinusSupplyEnthalpy() {
+    ThermalUtilityState coolingWaterSupply = new ThermalUtilityState(293.15, 3.0e5, 84.0e3);
+    ThermalUtilityState coolingWaterReturn = new ThermalUtilityState(313.15, 2.5e5, 168.0e3);
+    UtilityEnergyBus coolingWater = new UtilityEnergyBus("cooling water", UtilityLevel.COOLING_WATER,
+        coolingWaterSupply, coolingWaterReturn);
+
+    assertEquals(84.0e3, coolingWater.getSpecificDuty(), 1.0e-12);
+    assertEquals(50.0, coolingWater.getMassFlowForDuty(4.2e6), 1.0e-12);
+    assertEquals(3600.0, coolingWater.getMassFlowForDuty(84.0, "kW", "kg/hr"), 1.0e-12);
+    assertEquals(3.6, coolingWater.getMassFlowForDuty(84.0, "kW", "ton/hr"), 1.0e-12);
+  }
+
+  @Test
+  void testUtilityEnthalpyDirectionIsValidatedByGrade() {
+    ThermalUtilityState highEnthalpy = new ThermalUtilityState(425.0, 4.0e5, 2.8e6);
+    ThermalUtilityState lowEnthalpy = new ThermalUtilityState(383.0, 4.0e5, 0.6e6);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> new UtilityEnergyBus("invalid steam", UtilityLevel.LOW_PRESSURE_STEAM, lowEnthalpy, highEnthalpy));
+    assertThrows(IllegalArgumentException.class,
+        () -> new UtilityEnergyBus("invalid cooling", UtilityLevel.COOLING_WATER, highEnthalpy, lowEnthalpy));
+    assertThrows(IllegalArgumentException.class,
+        () -> new UtilityEnergyBus("zero duty", UtilityLevel.HOT_OIL, highEnthalpy, highEnthalpy));
+  }
+
+  @Test
+  void testThermalUtilityStateAndMassFlowPreconditionsAreValidated() {
+    assertThrows(IllegalArgumentException.class, () -> new ThermalUtilityState(0.0, 1.0e5, 0.0));
+    assertThrows(IllegalArgumentException.class, () -> new ThermalUtilityState(300.0, 0.0, 0.0));
+    assertThrows(IllegalArgumentException.class, () -> new ThermalUtilityState(300.0, 1.0e5, Double.NaN));
+
+    UtilityEnergyBus steam = new UtilityEnergyBus("unconfigured steam", UtilityLevel.LOW_PRESSURE_STEAM);
+    assertThrows(IllegalStateException.class, steam::getSpecificDuty);
+    assertThrows(IllegalStateException.class, steam::getServedMassFlow);
+
+    steam.setThermodynamicStates(new ThermalUtilityState(425.0, 4.0e5, 2.8e6),
+        new ThermalUtilityState(383.0, 4.0e5, 0.6e6));
+    assertThrows(IllegalArgumentException.class, () -> steam.getMassFlowForDuty(-1.0));
+    assertThrows(IllegalArgumentException.class, () -> steam.getMassFlowForDuty(1.0, "MW", "lb/hr"));
+  }
+
+  @Test
+  void testTemperatureAndPressureUpdatesKeepExplicitStateCoherent() {
+    UtilityEnergyBus hotOil = new UtilityEnergyBus("hot oil", UtilityLevel.HOT_OIL,
+        new ThermalUtilityState(500.0, 5.0e5, 1.0e6), new ThermalUtilityState(400.0, 4.5e5, 0.5e6));
+
+    hotOil.setSupplyTemperature(510.0);
+    hotOil.setSupplyPressure(5.5e5);
+    hotOil.setReturnTemperature(405.0);
+
+    assertEquals(510.0, hotOil.getSupplyState().getTemperature(), 1.0e-12);
+    assertEquals(5.5e5, hotOil.getSupplyState().getPressure(), 1.0e-12);
+    assertEquals(405.0, hotOil.getReturnState().getTemperature(), 1.0e-12);
+    assertEquals(0.5e6, hotOil.getSpecificDuty(), 1.0e-12);
+  }
+}


### PR DESCRIPTION
## Summary

Adds physical utility-flow reporting on top of typed thermal energy buses:

- immutable `ThermalUtilityState` with temperature, pressure, and specific enthalpy
- supply/return thermodynamic states on `UtilityEnergyBus`
- heating-utility and cooling-utility enthalpy-direction validation
- useful specific duty in J/kg
- duty-to-mass-flow conversion in kg/s, kg/hr, or ton/hr
- requested, served, offered, accepted, unmet, and curtailed mass-flow KPIs from `EnergyNetworkReport`
- supply temperature/pressure metadata synchronized with the configured supply state
- temperature/pressure updates preserve explicit state consistency
- documented steam-network example

## Validation coverage

- LP-steam dispatch converts 2.0 MW offered and 1.5 MW served into physical steam/condensate flow
- cooling-water duty uses return-minus-supply enthalpy and converts 4.2 MW to 50 kg/s
- invalid heating/cooling enthalpy directions are rejected
- invalid thermodynamic states, missing states, missing reports, negative duty, and unsupported flow units fail explicitly
- later supply/return temperature and pressure updates keep the immutable states coherent

## Compatibility

Existing temperature-only `UtilityEnergyBus` constructors and power-based dispatch remain supported. Mass-flow methods require explicit supply and return specific enthalpies.

## Dependency

This is a stacked PR based on `feature/energy-network-professional-hardening` / PR #2608. It should be retargeted to `master` after #2608 is merged.
