### PR TITLE
Enforce thermal utility temperature quality and report exergy

### DIFF
--- a/docs/process/thermal_utility_quality.md
+++ b/docs/process/thermal_utility_quality.md
@@ -1,0 +1,87 @@
+---
+title: Thermal utility quality and exergy
+description: Screen heating, cooling, and refrigeration duties for temperature feasibility and reversible-work quality.
+---
+
+# Thermal utility quality and exergy
+
+Thermal power is not interchangeable across temperature levels. A 1 MW heat source at 70 °C cannot supply a process duty that requires 150 °C, and 1 MW of refrigeration has a different thermodynamic value from 1 MW of cooling water.
+
+`ThermalUtilityQualityAnalysis` adds two screening calculations to a typed `UtilityEnergyBus`:
+
+1. **Temperature-grade feasibility** using a process temperature and minimum approach.
+2. **Minimum reversible exergy rate** using a logarithmic-mean utility temperature and a reference environment.
+
+## Temperature feasibility
+
+For a heating utility:
+
+\[
+T_{supply} \ge T_{process} + \Delta T_{min}
+\]
+
+For cooling water, chilled water, refrigeration, or ambient cooling:
+
+\[
+T_{supply} \le T_{process} - \Delta T_{min}
+\]
+
+```java
+UtilityEnergyBus lpSteam = new UtilityEnergyBus(
+    "LP steam", UtilityLevel.LOW_PRESSURE_STEAM,
+    425.0, 383.0);
+
+boolean feasible = ThermalUtilityQualityAnalysis.canServeProcessTemperature(
+    lpSteam, 400.0, 10.0);
+```
+
+A `ThermalUtilityConsumer` can enforce the same rule during validation and execution:
+
+```java
+ThermalUtilityConsumer reboiler = new ThermalUtilityConsumer(
+    "reboiler", UtilityLevel.LOW_PRESSURE_STEAM);
+reboiler.connectEnergyStream(
+    ThermalUtilityConsumer.INPUT_PORT,
+    lpSteam,
+    EnergyPortMode.SPECIFICATION);
+reboiler.setProcessTemperatureRequirement(400.0, 10.0);
+```
+
+If the connected utility grade cannot satisfy the requirement, `validateSetup()` reports an actionable error and `run()` rejects the physically infeasible allocation.
+
+## Reversible exergy screening
+
+The effective utility temperature is calculated as the logarithmic mean of supply and return temperatures:
+
+\[
+T_{lm} = \frac{T_s - T_r}{\ln(T_s/T_r)}
+\]
+
+The reversible-work quality factor relative to environment temperature \(T_0\) is:
+
+\[
+\phi = \left|1 - \frac{T_0}{T_{lm}}\right|
+\]
+
+and the exergy-rate screening metric is:
+
+\[
+\dot E_x = \dot Q\,\phi
+\]
+
+```java
+double exergyFactor = ThermalUtilityQualityAnalysis.getExergyFactor(
+    lpSteam, 298.15);
+
+double servedExergy = ThermalUtilityQualityAnalysis.getServedExergyRate(
+    lpSteam, 298.15);
+
+double curtailedExergy = ThermalUtilityQualityAnalysis.getCurtailedExergyRate(
+    lpSteam, 298.15);
+```
+
+The absolute Carnot factor provides a positive screening metric for both hot utilities and refrigeration below the reference temperature. It is useful for comparing utility grades, heat-recovery opportunities, and curtailment quality.
+
+## Scope
+
+This is a process-integration screening model. It does not replace a full entropy balance, pinch analysis, exchanger area calculation, steam-header hydraulic model, or refrigeration-cycle simulation. Use qualified thermodynamic states and detailed equipment models for design decisions.

--- a/src/main/java/neqsim/process/equipment/energy/ThermalUtilityConsumer.java
+++ b/src/main/java/neqsim/process/equipment/energy/ThermalUtilityConsumer.java
@@ -10,10 +10,10 @@ import neqsim.process.equipment.stream.UtilityLevel;
 import neqsim.util.validation.ValidationResult;
 
 /**
- * Thermal utility consumer with a requested duty and explicit utility-grade requirement.
+ * Thermal utility consumer with a requested duty, utility-grade requirement, and optional temperature feasibility rule.
  *
  * @author NeqSim
- * @version 1.0
+ * @version 2.0
  */
 public class ThermalUtilityConsumer extends ProcessEquipmentBaseClass {
   private static final long serialVersionUID = 1000L;
@@ -23,6 +23,8 @@ public class ThermalUtilityConsumer extends ProcessEquipmentBaseClass {
 
   private final UtilityLevel utilityLevel;
   private double allocatedPower = 0.0;
+  private double requiredProcessTemperature = Double.NaN;
+  private double minimumApproachTemperature = 0.0;
 
   /**
    * Creates a thermal utility consumer.
@@ -67,9 +69,73 @@ public class ThermalUtilityConsumer extends ProcessEquipmentBaseClass {
     return utilityLevel;
   }
 
+  /**
+   * Sets the process temperature and minimum utility approach that must be feasible.
+   *
+   * <p>
+   * A heating utility must have supply temperature at least {@code processTemperature + minimumApproachTemperature}.
+   * A cooling utility must have supply temperature at most
+   * {@code processTemperature - minimumApproachTemperature}.
+   * </p>
+   *
+   * @param processTemperature process-side target temperature in K
+   * @param minimumApproachTemperature minimum approach temperature in K
+   */
+  public void setProcessTemperatureRequirement(double processTemperature, double minimumApproachTemperature) {
+    if (!Double.isFinite(processTemperature) || processTemperature <= 0.0) {
+      throw new IllegalArgumentException("Process temperature must be positive and finite");
+    }
+    if (!Double.isFinite(minimumApproachTemperature) || minimumApproachTemperature < 0.0) {
+      throw new IllegalArgumentException("Minimum approach temperature must be non-negative and finite");
+    }
+    requiredProcessTemperature = processTemperature;
+    this.minimumApproachTemperature = minimumApproachTemperature;
+  }
+
+  /** Clears the process-temperature feasibility requirement. */
+  public void clearProcessTemperatureRequirement() {
+    requiredProcessTemperature = Double.NaN;
+    minimumApproachTemperature = 0.0;
+  }
+
+  /**
+   * Checks whether a process-temperature requirement is configured.
+   *
+   * @return {@code true} when configured
+   */
+  public boolean hasProcessTemperatureRequirement() {
+    return Double.isFinite(requiredProcessTemperature);
+  }
+
+  /**
+   * Gets required process temperature.
+   *
+   * @return temperature in K, or NaN when unspecified
+   */
+  public double getRequiredProcessTemperature() {
+    return requiredProcessTemperature;
+  }
+
+  /**
+   * Gets minimum utility approach temperature.
+   *
+   * @return approach in K
+   */
+  public double getMinimumApproachTemperature() {
+    return minimumApproachTemperature;
+  }
+
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
+    if (hasProcessTemperatureRequirement() && getEnergyPort(INPUT_PORT).isConnected()) {
+      if (!(getEnergyPort(INPUT_PORT).getEnergyStream() instanceof UtilityEnergyBus)) {
+        throw new IllegalStateException("Temperature-constrained utility consumers require a UtilityEnergyBus");
+      }
+      ThermalUtilityQualityAnalysis.requireFeasibleProcessTemperature(
+          (UtilityEnergyBus) getEnergyPort(INPUT_PORT).getEnergyStream(), requiredProcessTemperature,
+          minimumApproachTemperature);
+    }
     allocatedPower = getEnergyPort(INPUT_PORT).isConnected() ? getEnergyPort(INPUT_PORT).getPowerMagnitude() : 0.0;
     setCalculationIdentifier(id);
   }
@@ -84,9 +150,17 @@ public class ThermalUtilityConsumer extends ProcessEquipmentBaseClass {
     } else if (!(getEnergyPort(INPUT_PORT).getEnergyStream() instanceof UtilityEnergyBus)) {
       result.addError("energy", "Thermal utility input is not connected to a typed UtilityEnergyBus",
           "Connect " + INPUT_PORT + " to a " + utilityLevel + " UtilityEnergyBus");
-    } else if (((UtilityEnergyBus) getEnergyPort(INPUT_PORT).getEnergyStream()).getUtilityLevel() != utilityLevel) {
-      result.addError("energy", "Connected utility level does not satisfy the consumer requirement",
-          "Connect " + INPUT_PORT + " to a " + utilityLevel + " UtilityEnergyBus");
+    } else {
+      UtilityEnergyBus utilityBus = (UtilityEnergyBus) getEnergyPort(INPUT_PORT).getEnergyStream();
+      if (utilityBus.getUtilityLevel() != utilityLevel) {
+        result.addError("energy", "Connected utility level does not satisfy the consumer requirement",
+            "Connect " + INPUT_PORT + " to a " + utilityLevel + " UtilityEnergyBus");
+      } else if (hasProcessTemperatureRequirement()
+          && !ThermalUtilityQualityAnalysis.canServeProcessTemperature(utilityBus, requiredProcessTemperature,
+              minimumApproachTemperature)) {
+        result.addError("energy", "Connected utility temperature grade cannot satisfy the process requirement",
+            "Select a hotter heating utility, a colder cooling utility, or reduce the minimum approach temperature");
+      }
     }
     return result;
   }

--- a/src/main/java/neqsim/process/equipment/energy/ThermalUtilityQualityAnalysis.java
+++ b/src/main/java/neqsim/process/equipment/energy/ThermalUtilityQualityAnalysis.java
@@ -1,0 +1,131 @@
+package neqsim.process.equipment.energy;
+
+import neqsim.process.equipment.stream.EnergyNetworkReport;
+import neqsim.process.equipment.stream.UtilityLevel;
+
+/**
+ * Thermodynamic feasibility and reversible-exergy analysis for a {@link UtilityEnergyBus}.
+ *
+ * <p>
+ * Thermal power alone does not determine whether a utility can serve a process duty. Heating utilities must be hot
+ * enough above the process temperature, while cooling utilities must be cold enough below it. The exergy methods use
+ * the logarithmic-mean utility temperature and the Carnot quality factor to report the minimum reversible work
+ * associated with a thermal duty. They are screening metrics, not replacements for a full entropy balance.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class ThermalUtilityQualityAnalysis {
+  private ThermalUtilityQualityAnalysis() {
+  }
+
+  public static boolean canServeProcessTemperature(UtilityEnergyBus utilityBus, double processTemperature,
+      double minimumApproachTemperature) {
+    UtilityEnergyBus bus = requireBus(utilityBus);
+    validateTemperature(processTemperature, "Process temperature");
+    validateApproach(minimumApproachTemperature);
+    double supplyTemperature = bus.getSupplyTemperature();
+    if (!Double.isFinite(supplyTemperature) || supplyTemperature <= 0.0) {
+      return false;
+    }
+    if (isHeatingUtility(bus.getUtilityLevel())) {
+      return supplyTemperature >= processTemperature + minimumApproachTemperature;
+    }
+    return supplyTemperature <= processTemperature - minimumApproachTemperature;
+  }
+
+  public static void requireFeasibleProcessTemperature(UtilityEnergyBus utilityBus, double processTemperature,
+      double minimumApproachTemperature) {
+    if (!canServeProcessTemperature(utilityBus, processTemperature, minimumApproachTemperature)) {
+      UtilityEnergyBus bus = requireBus(utilityBus);
+      String direction = isHeatingUtility(bus.getUtilityLevel()) ? "above" : "below";
+      throw new IllegalStateException("Utility " + bus.getName() + " supply temperature must be at least "
+          + minimumApproachTemperature + " K " + direction + " the process temperature");
+    }
+  }
+
+  public static double getEffectiveTemperature(UtilityEnergyBus utilityBus) {
+    UtilityEnergyBus bus = requireBus(utilityBus);
+    double supplyTemperature = bus.getSupplyTemperature();
+    double returnTemperature = bus.getReturnTemperature();
+    if (!Double.isFinite(supplyTemperature) || supplyTemperature <= 0.0 || !Double.isFinite(returnTemperature)
+        || returnTemperature <= 0.0) {
+      throw new IllegalStateException(
+          "Configure positive finite utility supply and return temperatures before exergy analysis");
+    }
+    if (Math.abs(supplyTemperature - returnTemperature)
+        <= Math.max(supplyTemperature, returnTemperature) * 1.0e-12) {
+      return 0.5 * (supplyTemperature + returnTemperature);
+    }
+    double logarithmicMean = (supplyTemperature - returnTemperature)
+        / Math.log(supplyTemperature / returnTemperature);
+    if (!Double.isFinite(logarithmicMean) || logarithmicMean <= 0.0) {
+      throw new IllegalStateException("Utility temperatures do not define a finite logarithmic-mean temperature");
+    }
+    return logarithmicMean;
+  }
+
+  public static double getExergyFactor(UtilityEnergyBus utilityBus, double referenceTemperature) {
+    validateTemperature(referenceTemperature, "Reference temperature");
+    return Math.abs(1.0 - referenceTemperature / getEffectiveTemperature(utilityBus));
+  }
+
+  public static double getExergyRateForDuty(UtilityEnergyBus utilityBus, double thermalDuty,
+      double referenceTemperature) {
+    if (!Double.isFinite(thermalDuty) || thermalDuty < 0.0) {
+      throw new IllegalArgumentException("Thermal duty must be non-negative and finite");
+    }
+    return thermalDuty * getExergyFactor(utilityBus, referenceTemperature);
+  }
+
+  public static double getServedExergyRate(UtilityEnergyBus utilityBus, double referenceTemperature) {
+    UtilityEnergyBus bus = requireBus(utilityBus);
+    return getExergyRateForDuty(bus, requireReport(bus).getServedDemand(), referenceTemperature);
+  }
+
+  public static double getUnmetExergyRate(UtilityEnergyBus utilityBus, double referenceTemperature) {
+    UtilityEnergyBus bus = requireBus(utilityBus);
+    return getExergyRateForDuty(bus, requireReport(bus).getUnmetDemand(), referenceTemperature);
+  }
+
+  public static double getCurtailedExergyRate(UtilityEnergyBus utilityBus, double referenceTemperature) {
+    UtilityEnergyBus bus = requireBus(utilityBus);
+    return getExergyRateForDuty(bus, requireReport(bus).getCurtailedSupply(), referenceTemperature);
+  }
+
+  public static boolean isHeatingUtility(UtilityLevel utilityLevel) {
+    if (utilityLevel == null || utilityLevel == UtilityLevel.UNSPECIFIED) {
+      throw new IllegalArgumentException("A specified utility level is required");
+    }
+    return utilityLevel == UtilityLevel.HIGH_PRESSURE_STEAM || utilityLevel == UtilityLevel.MEDIUM_PRESSURE_STEAM
+        || utilityLevel == UtilityLevel.LOW_PRESSURE_STEAM || utilityLevel == UtilityLevel.HOT_OIL;
+  }
+
+  private static UtilityEnergyBus requireBus(UtilityEnergyBus utilityBus) {
+    if (utilityBus == null) {
+      throw new IllegalArgumentException("Utility bus is required");
+    }
+    return utilityBus;
+  }
+
+  private static EnergyNetworkReport requireReport(UtilityEnergyBus utilityBus) {
+    EnergyNetworkReport report = utilityBus.getLastReport();
+    if (report == null) {
+      throw new IllegalStateException("Solve the utility energy bus before requesting exergy KPIs");
+    }
+    return report;
+  }
+
+  private static void validateTemperature(double temperature, String name) {
+    if (!Double.isFinite(temperature) || temperature <= 0.0) {
+      throw new IllegalArgumentException(name + " must be positive and finite");
+    }
+  }
+
+  private static void validateApproach(double approach) {
+    if (!Double.isFinite(approach) || approach < 0.0) {
+      throw new IllegalArgumentException("Minimum approach temperature must be non-negative and finite");
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/energy/ThermalUtilityQualityAnalysisTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/ThermalUtilityQualityAnalysisTest.java
@@ -1,0 +1,27 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.UtilityLevel;
+
+class ThermalUtilityQualityAnalysisTest {
+  @Test
+  void screensHeatingAndCoolingTemperatureGrades() {
+    UtilityEnergyBus steam = new UtilityEnergyBus("LP steam", UtilityLevel.LOW_PRESSURE_STEAM, 425.0, 383.0);
+    assertTrue(ThermalUtilityQualityAnalysis.canServeProcessTemperature(steam, 400.0, 10.0));
+    assertFalse(ThermalUtilityQualityAnalysis.canServeProcessTemperature(steam, 420.0, 10.0));
+
+    UtilityEnergyBus coolingWater =
+        new UtilityEnergyBus("cooling water", UtilityLevel.COOLING_WATER, 293.0, 313.0);
+    assertTrue(ThermalUtilityQualityAnalysis.canServeProcessTemperature(coolingWater, 310.0, 10.0));
+    assertFalse(ThermalUtilityQualityAnalysis.canServeProcessTemperature(coolingWater, 300.0, 10.0));
+  }
+
+  @Test
+  void reportsPositiveExergyFactor() {
+    UtilityEnergyBus steam = new UtilityEnergyBus("LP steam", UtilityLevel.LOW_PRESSURE_STEAM, 425.0, 383.0);
+    assertTrue(ThermalUtilityQualityAnalysis.getEffectiveTemperature(steam) > 383.0);
+    assertTrue(ThermalUtilityQualityAnalysis.getExergyFactor(steam, 298.15) > 0.0);
+  }
+}


### PR DESCRIPTION
## Summary

Adds temperature-grade feasibility and reversible-exergy screening to typed thermal utility networks:

- `ThermalUtilityQualityAnalysis` for heating/cooling feasibility
- heating utilities require supply temperature above process temperature plus minimum approach
- cooling and refrigeration utilities require supply temperature below process temperature minus minimum approach
- `ThermalUtilityConsumer` can configure and enforce a process-temperature requirement
- infeasible utility grades are reported by `validateSetup()` and rejected during `run()`
- logarithmic-mean utility temperature
- positive reversible-work quality factor for hot utilities and refrigeration
- served, unmet, and curtailed exergy-rate KPIs from solved utility networks
- dedicated documentation with equations, code examples, and scope limitations

## Validation coverage

- feasible and infeasible LP-steam temperature grades
- feasible and infeasible cooling-water temperature grades
- runtime rejection and actionable setup validation for an underspecified hot-oil utility
- logarithmic-mean steam temperature and served/curtailed exergy
- positive refrigeration reversible-work metric below ambient temperature
- invalid process temperature, approach, reference temperature, duty, missing utility temperatures, and unsolved reports fail explicitly

## Scope

The exergy result is a reversible screening metric based on the logarithmic-mean utility temperature. It does not replace a full entropy balance, pinch analysis, exchanger design, steam hydraulics, or refrigeration-cycle simulation.

## Dependency

This is a stacked PR based on `feature/thermal-utility-mass-flow` / PR #2610. It should be retargeted to `master` after #2610 is merged.
