### PR TITLE
Add chronological energy time-series simulation and integrated KPIs

### DIFF
--- a/docs/process/energy_time_series.md
+++ b/docs/process/energy_time_series.md
@@ -1,0 +1,67 @@
+---
+title: Energy time-series simulation
+description: Run energy networks with renewable, load, price, and emissions profiles and integrate operational KPIs.
+---
+
+# Energy time-series simulation
+
+`EnergyTimeSeriesSimulator` executes a `ProcessSystem` and one or more `EnergyBus` objects over fixed-duration intervals. It supports repeated steady-state studies and transient execution for storage, rotating shafts, trips, ramp limits, and other dynamic equipment.
+
+Profiles may be stepwise or linearly interpolated:
+
+```java
+EnergyTimeSeriesProfile wind = EnergyTimeSeriesProfile.linear(
+    "wind generation",
+    new double[] {0.0, 3600.0, 7200.0},
+    new double[] {1.0e6, 2.5e6, 0.5e6});
+
+EnergyTimeSeriesProfile demand = EnergyTimeSeriesProfile.step(
+    "process demand",
+    new double[] {0.0, 3600.0, 7200.0},
+    new double[] {1.5e6, 2.0e6, 1.0e6});
+```
+
+Bind each profile to the relevant setter:
+
+```java
+EnergyTimeSeriesSimulator study = new EnergyTimeSeriesSimulator(process);
+study.addEnergyBus(electricalBus);
+study.setIntervalSeconds(900.0);
+study.setDurationSeconds(24.0 * 3600.0);
+
+study.addProfile(wind, value -> windPort.setDuty(value));
+study.addProfile(demand, value -> loadPort.setRequestedPower(value));
+```
+
+For transient studies:
+
+```java
+study.setExecutionMode(EnergyTimeSeriesSimulator.ExecutionMode.TRANSIENT);
+```
+
+The result stores every interval and integrates the network report rates:
+
+```java
+EnergyTimeSeriesResult result = study.run();
+
+double servedMWh = result.getServedEnergyMWh();
+double unmetMWh = result.getUnmetEnergyMWh();
+double curtailedMWh = result.getCurtailedEnergyMWh();
+double operatingCost = result.getOperatingCost();
+double co2Kg = result.getCo2EmissionsKg();
+```
+
+The last interval is shortened automatically when the study duration is not an integer multiple of the interval length. Every interval retains immutable `EnergyNetworkReport` snapshots for audit, plotting, and downstream optimization.
+
+## Recommended uses
+
+- offshore electrical balance with wind, gas turbines, batteries, and process loads;
+- variable electricity price and grid-carbon intensity studies;
+- renewable curtailment and unmet-demand analysis;
+- battery state-of-charge and ramp studies in transient mode;
+- utility demand profiles and operating-cost estimates;
+- lifecycle or seasonal operating scenarios.
+
+## Scope
+
+The runner performs chronological simulation and KPI integration. It does not itself solve unit commitment, market bidding, or stochastic optimization. Dispatch within each interval follows the configured `EnergyBus` policy.

--- a/src/main/java/neqsim/process/equipment/energy/EnergyTimeSeriesProfile.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyTimeSeriesProfile.java
@@ -1,0 +1,182 @@
+package neqsim.process.equipment.energy;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable scalar time series with stepwise or linear interpolation.
+ *
+ * <p>
+ * Times are expressed in seconds from the start of a study. Values may represent power, price, emission intensity,
+ * setpoints, or any other scalar input consumed by an {@link EnergyTimeSeriesSimulator.ProfileTarget}.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class EnergyTimeSeriesProfile implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Interpolation used between profile points. */
+  public enum Interpolation {
+    /** Hold the previous point until the next timestamp. */
+    STEP,
+    /** Linearly interpolate between adjacent points. */
+    LINEAR
+  }
+
+  /** Immutable point in one profile. */
+  public static final class Point implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double timeSeconds;
+    private final double value;
+
+    /**
+     * Creates a profile point.
+     *
+     * @param timeSeconds non-negative time from study start
+     * @param value finite scalar value
+     */
+    public Point(double timeSeconds, double value) {
+      if (!Double.isFinite(timeSeconds) || timeSeconds < 0.0) {
+        throw new IllegalArgumentException("Profile time must be non-negative and finite");
+      }
+      if (!Double.isFinite(value)) {
+        throw new IllegalArgumentException("Profile value must be finite");
+      }
+      this.timeSeconds = timeSeconds;
+      this.value = value;
+    }
+
+    /** @return time from study start in seconds */
+    public double getTimeSeconds() {
+      return timeSeconds;
+    }
+
+    /** @return scalar profile value */
+    public double getValue() {
+      return value;
+    }
+  }
+
+  private final String name;
+  private final Interpolation interpolation;
+  private final List<Point> points;
+
+  /**
+   * Creates an immutable profile.
+   *
+   * @param name profile name
+   * @param interpolation interpolation rule
+   * @param points strictly increasing profile points
+   */
+  public EnergyTimeSeriesProfile(String name, Interpolation interpolation, List<Point> points) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("Profile name is required");
+    }
+    if (interpolation == null) {
+      throw new IllegalArgumentException("Profile interpolation is required");
+    }
+    if (points == null || points.isEmpty()) {
+      throw new IllegalArgumentException("At least one profile point is required");
+    }
+    List<Point> copy = new ArrayList<Point>(points.size());
+    double previousTime = -1.0;
+    for (Point point : points) {
+      if (point == null) {
+        throw new IllegalArgumentException("Profile points cannot contain null");
+      }
+      if (point.getTimeSeconds() <= previousTime) {
+        throw new IllegalArgumentException("Profile times must be strictly increasing");
+      }
+      copy.add(point);
+      previousTime = point.getTimeSeconds();
+    }
+    this.name = name;
+    this.interpolation = interpolation;
+    this.points = Collections.unmodifiableList(copy);
+  }
+
+  /** Convenience factory for a stepwise profile. */
+  public static EnergyTimeSeriesProfile step(String name, double[] timesSeconds, double[] values) {
+    return fromArrays(name, Interpolation.STEP, timesSeconds, values);
+  }
+
+  /** Convenience factory for a linearly interpolated profile. */
+  public static EnergyTimeSeriesProfile linear(String name, double[] timesSeconds, double[] values) {
+    return fromArrays(name, Interpolation.LINEAR, timesSeconds, values);
+  }
+
+  private static EnergyTimeSeriesProfile fromArrays(String name, Interpolation interpolation, double[] timesSeconds,
+      double[] values) {
+    if (timesSeconds == null || values == null || timesSeconds.length != values.length || timesSeconds.length == 0) {
+      throw new IllegalArgumentException("Profile time and value arrays must have equal positive length");
+    }
+    List<Point> points = new ArrayList<Point>(timesSeconds.length);
+    for (int index = 0; index < timesSeconds.length; index++) {
+      points.add(new Point(timesSeconds[index], values[index]));
+    }
+    return new EnergyTimeSeriesProfile(name, interpolation, points);
+  }
+
+  /** @return profile name */
+  public String getName() {
+    return name;
+  }
+
+  /** @return interpolation rule */
+  public Interpolation getInterpolation() {
+    return interpolation;
+  }
+
+  /** @return immutable profile points */
+  public List<Point> getPoints() {
+    return points;
+  }
+
+  /** @return final profile timestamp in seconds */
+  public double getEndTimeSeconds() {
+    return points.get(points.size() - 1).getTimeSeconds();
+  }
+
+  /**
+   * Evaluates the profile. Values are clamped to the first and last point outside the profile range.
+   *
+   * <p>
+   * Step profiles are right-continuous: the value attached to a timestamp becomes active exactly at that timestamp.
+   * </p>
+   *
+   * @param timeSeconds study time
+   * @return interpolated value
+   */
+  public double getValue(double timeSeconds) {
+    if (!Double.isFinite(timeSeconds) || timeSeconds < 0.0) {
+      throw new IllegalArgumentException("Profile evaluation time must be non-negative and finite");
+    }
+    if (timeSeconds <= points.get(0).getTimeSeconds()) {
+      return points.get(0).getValue();
+    }
+    int lastIndex = points.size() - 1;
+    if (timeSeconds >= points.get(lastIndex).getTimeSeconds()) {
+      return points.get(lastIndex).getValue();
+    }
+    for (int index = 1; index < points.size(); index++) {
+      Point upper = points.get(index);
+      Point lower = points.get(index - 1);
+      if (interpolation == Interpolation.STEP) {
+        if (timeSeconds < upper.getTimeSeconds()) {
+          return lower.getValue();
+        }
+        if (timeSeconds == upper.getTimeSeconds()) {
+          return upper.getValue();
+        }
+      } else if (timeSeconds <= upper.getTimeSeconds()) {
+        double fraction = (timeSeconds - lower.getTimeSeconds()) / (upper.getTimeSeconds() - lower.getTimeSeconds());
+        return lower.getValue() + fraction * (upper.getValue() - lower.getValue());
+      }
+    }
+    return points.get(lastIndex).getValue();
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/EnergyTimeSeriesResult.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyTimeSeriesResult.java
@@ -1,0 +1,97 @@
+package neqsim.process.equipment.energy;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import com.google.gson.GsonBuilder;
+import neqsim.process.equipment.stream.EnergyNetworkReport;
+
+/** Immutable result from an {@link EnergyTimeSeriesSimulator} study. */
+public final class EnergyTimeSeriesResult implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Immutable result for one simulation interval. */
+  public static final class IntervalResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final int intervalIndex;
+    private final double startTimeSeconds;
+    private final double durationSeconds;
+    private final List<EnergyNetworkReport> networkReports;
+
+    IntervalResult(int intervalIndex, double startTimeSeconds, double durationSeconds,
+        List<EnergyNetworkReport> networkReports) {
+      this.intervalIndex = intervalIndex;
+      this.startTimeSeconds = startTimeSeconds;
+      this.durationSeconds = durationSeconds;
+      this.networkReports = Collections.unmodifiableList(new ArrayList<EnergyNetworkReport>(networkReports));
+    }
+
+    public int getIntervalIndex() {
+      return intervalIndex;
+    }
+
+    public double getStartTimeSeconds() {
+      return startTimeSeconds;
+    }
+
+    public double getDurationSeconds() {
+      return durationSeconds;
+    }
+
+    public List<EnergyNetworkReport> getNetworkReports() {
+      return networkReports;
+    }
+  }
+
+  private final List<IntervalResult> intervals;
+  private final double totalDurationSeconds;
+  private final double servedEnergyMWh;
+  private final double unmetEnergyMWh;
+  private final double curtailedEnergyMWh;
+  private final double operatingCost;
+  private final double co2EmissionsKg;
+
+  EnergyTimeSeriesResult(List<IntervalResult> intervals, double totalDurationSeconds, double servedEnergyMWh,
+      double unmetEnergyMWh, double curtailedEnergyMWh, double operatingCost, double co2EmissionsKg) {
+    this.intervals = Collections.unmodifiableList(new ArrayList<IntervalResult>(intervals));
+    this.totalDurationSeconds = totalDurationSeconds;
+    this.servedEnergyMWh = servedEnergyMWh;
+    this.unmetEnergyMWh = unmetEnergyMWh;
+    this.curtailedEnergyMWh = curtailedEnergyMWh;
+    this.operatingCost = operatingCost;
+    this.co2EmissionsKg = co2EmissionsKg;
+  }
+
+  public List<IntervalResult> getIntervals() {
+    return intervals;
+  }
+
+  public double getTotalDurationSeconds() {
+    return totalDurationSeconds;
+  }
+
+  public double getServedEnergyMWh() {
+    return servedEnergyMWh;
+  }
+
+  public double getUnmetEnergyMWh() {
+    return unmetEnergyMWh;
+  }
+
+  public double getCurtailedEnergyMWh() {
+    return curtailedEnergyMWh;
+  }
+
+  public double getOperatingCost() {
+    return operatingCost;
+  }
+
+  public double getCo2EmissionsKg() {
+    return co2EmissionsKg;
+  }
+
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create().toJson(this);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/EnergyTimeSeriesSimulator.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyTimeSeriesSimulator.java
@@ -1,0 +1,189 @@
+package neqsim.process.equipment.energy;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyNetworkReport;
+import neqsim.process.processmodel.ProcessSystem;
+
+/**
+ * Runs a process and its energy buses over a sequence of fixed-duration intervals.
+ *
+ * <p>
+ * Profiles are evaluated at the start of each interval. The process can be executed either as a repeated steady-state
+ * model or through {@link ProcessSystem#runTransient(double, UUID)}. Each interval stores immutable energy-network
+ * reports and contributes to integrated energy, cost, and emission KPIs.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class EnergyTimeSeriesSimulator implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Simulation execution mode. */
+  public enum ExecutionMode {
+    /** Re-run the complete steady-state process for every interval. */
+    STEADY_STATE,
+    /** Advance equipment dynamics using the interval duration. */
+    TRANSIENT
+  }
+
+  /** Target that receives one evaluated profile value. */
+  public interface ProfileTarget {
+    /** Applies a scalar input value before one interval is executed. */
+    void apply(double value);
+  }
+
+  /** Immutable profile-to-target binding. */
+  public static final class ProfileBinding {
+    private final EnergyTimeSeriesProfile profile;
+    private final ProfileTarget target;
+
+    public ProfileBinding(EnergyTimeSeriesProfile profile, ProfileTarget target) {
+      if (profile == null || target == null) {
+        throw new IllegalArgumentException("Profile and target are required");
+      }
+      this.profile = profile;
+      this.target = target;
+    }
+
+    public EnergyTimeSeriesProfile getProfile() {
+      return profile;
+    }
+
+    void apply(double timeSeconds) {
+      target.apply(profile.getValue(timeSeconds));
+    }
+  }
+
+  private final ProcessSystem process;
+  private final List<EnergyBus> energyBuses = new ArrayList<EnergyBus>();
+  private final List<ProfileBinding> profileBindings = new ArrayList<ProfileBinding>();
+  private ExecutionMode executionMode = ExecutionMode.STEADY_STATE;
+  private double intervalSeconds = 3600.0;
+  private double durationSeconds = 86400.0;
+
+  public EnergyTimeSeriesSimulator(ProcessSystem process) {
+    if (process == null) {
+      throw new IllegalArgumentException("Process system is required");
+    }
+    this.process = process;
+  }
+
+  public ProcessSystem getProcess() {
+    return process;
+  }
+
+  public void addEnergyBus(EnergyBus energyBus) {
+    if (energyBus == null) {
+      throw new IllegalArgumentException("Energy bus cannot be null");
+    }
+    for (EnergyBus existing : energyBuses) {
+      if (existing == energyBus) {
+        return;
+      }
+    }
+    energyBuses.add(energyBus);
+  }
+
+  public List<EnergyBus> getEnergyBuses() {
+    return Collections.unmodifiableList(energyBuses);
+  }
+
+  public void addProfile(EnergyTimeSeriesProfile profile, ProfileTarget target) {
+    profileBindings.add(new ProfileBinding(profile, target));
+  }
+
+  public List<ProfileBinding> getProfileBindings() {
+    return Collections.unmodifiableList(profileBindings);
+  }
+
+  public ExecutionMode getExecutionMode() {
+    return executionMode;
+  }
+
+  public void setExecutionMode(ExecutionMode executionMode) {
+    if (executionMode == null) {
+      throw new IllegalArgumentException("Execution mode is required");
+    }
+    this.executionMode = executionMode;
+  }
+
+  public double getIntervalSeconds() {
+    return intervalSeconds;
+  }
+
+  public void setIntervalSeconds(double intervalSeconds) {
+    if (!Double.isFinite(intervalSeconds) || intervalSeconds <= 0.0) {
+      throw new IllegalArgumentException("Time-series interval must be positive and finite");
+    }
+    this.intervalSeconds = intervalSeconds;
+  }
+
+  public double getDurationSeconds() {
+    return durationSeconds;
+  }
+
+  public void setDurationSeconds(double durationSeconds) {
+    if (!Double.isFinite(durationSeconds) || durationSeconds <= 0.0) {
+      throw new IllegalArgumentException("Time-series duration must be positive and finite");
+    }
+    this.durationSeconds = durationSeconds;
+  }
+
+  /** Runs the configured study. */
+  public EnergyTimeSeriesResult run() {
+    if (energyBuses.isEmpty()) {
+      throw new IllegalStateException("Add at least one energy bus before running a time-series study");
+    }
+
+    List<EnergyTimeSeriesResult.IntervalResult> intervals = new ArrayList<EnergyTimeSeriesResult.IntervalResult>();
+    double servedEnergyMWh = 0.0;
+    double unmetEnergyMWh = 0.0;
+    double curtailedEnergyMWh = 0.0;
+    double operatingCost = 0.0;
+    double co2EmissionsKg = 0.0;
+
+    double timeSeconds = 0.0;
+    int intervalIndex = 0;
+    while (timeSeconds < durationSeconds) {
+      double stepSeconds = Math.min(intervalSeconds, durationSeconds - timeSeconds);
+      for (ProfileBinding binding : profileBindings) {
+        binding.apply(timeSeconds);
+      }
+
+      UUID calculationId = UUID.randomUUID();
+      if (executionMode == ExecutionMode.TRANSIENT) {
+        process.runTransient(stepSeconds, calculationId);
+      } else {
+        process.run(calculationId);
+      }
+
+      List<EnergyNetworkReport> reports = new ArrayList<EnergyNetworkReport>(energyBuses.size());
+      double hours = stepSeconds / 3600.0;
+      for (EnergyBus energyBus : energyBuses) {
+        EnergyNetworkReport report = energyBus.hasSolution() ? energyBus.getLastReport() : energyBus.solveBalance();
+        if (report == null) {
+          report = energyBus.solveBalance();
+        }
+        reports.add(report);
+        servedEnergyMWh += report.getServedDemand() * hours / 1.0e6;
+        unmetEnergyMWh += report.getUnmetDemand() * hours / 1.0e6;
+        curtailedEnergyMWh += report.getCurtailedSupply() * hours / 1.0e6;
+        operatingCost += report.getOperatingCostPerHour() * hours;
+        co2EmissionsKg += report.getCo2EmissionRate() * hours;
+      }
+
+      intervals.add(new EnergyTimeSeriesResult.IntervalResult(intervalIndex, timeSeconds, stepSeconds, reports));
+      timeSeconds += stepSeconds;
+      intervalIndex++;
+    }
+
+    return new EnergyTimeSeriesResult(intervals, durationSeconds, servedEnergyMWh, unmetEnergyMWh, curtailedEnergyMWh,
+        operatingCost, co2EmissionsKg);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/energy/EnergyTimeSeriesSimulatorTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyTimeSeriesSimulatorTest.java
@@ -1,0 +1,109 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.processmodel.ProcessSystem;
+
+class EnergyTimeSeriesSimulatorTest {
+
+  @Test
+  void testProfileInterpolationAndValidation() {
+    EnergyTimeSeriesProfile step = EnergyTimeSeriesProfile.step("step", new double[] { 0.0, 10.0, 20.0 },
+        new double[] { 1.0, 2.0, 4.0 });
+    EnergyTimeSeriesProfile linear = EnergyTimeSeriesProfile.linear("linear", new double[] { 0.0, 10.0 },
+        new double[] { 0.0, 100.0 });
+
+    assertEquals(1.0, step.getValue(9.0), 1.0e-12);
+    assertEquals(1.0, step.getValue(Math.nextDown(10.0)), 1.0e-12);
+    assertEquals(2.0, step.getValue(10.0), 1.0e-12);
+    assertEquals(2.0, step.getValue(Math.nextUp(10.0)), 1.0e-12);
+    assertEquals(4.0, step.getValue(100.0), 1.0e-12);
+    assertEquals(50.0, linear.getValue(5.0), 1.0e-12);
+    assertEquals(0.0, linear.getValue(0.0), 1.0e-12);
+    assertEquals(100.0, linear.getValue(20.0), 1.0e-12);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> EnergyTimeSeriesProfile.step("bad", new double[] { 0.0, 0.0 }, new double[] { 1.0, 2.0 }));
+    assertThrows(IllegalArgumentException.class, () -> new EnergyTimeSeriesProfile.Point(Double.NaN, 1.0));
+    assertThrows(IllegalArgumentException.class, () -> step.getValue(-1.0));
+  }
+
+  @Test
+  void testIntegratedEnergyCostEmissionsAndPartialFinalInterval() {
+    EnergyBus grid = new EnergyBus("grid", EnergyType.ELECTRICAL);
+    EnergyPort generator = port("generator", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, grid);
+    EnergyPort load = port("load", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION, grid);
+    generator.setEnergyPricePerMWh(100.0);
+    generator.setEmissionFactorKgPerMWh(200.0);
+
+    EnergyTimeSeriesSimulator simulator = new EnergyTimeSeriesSimulator(new ProcessSystem());
+    simulator.addEnergyBus(grid);
+    simulator.setIntervalSeconds(3600.0);
+    simulator.setDurationSeconds(9000.0);
+    simulator.addProfile(
+        EnergyTimeSeriesProfile.step("generation", new double[] { 0.0, 7200.0 }, new double[] { 2.0e6, 1.0e6 }),
+        value -> generator.setDuty(value));
+    simulator.addProfile(
+        EnergyTimeSeriesProfile.step("load", new double[] { 0.0, 3600.0 }, new double[] { 1.0e6, 1.5e6 }),
+        value -> load.setRequestedPower(value));
+
+    EnergyTimeSeriesResult result = simulator.run();
+
+    assertEquals(3, result.getIntervals().size());
+    assertEquals(3600.0, result.getIntervals().get(0).getDurationSeconds(), 1.0e-12);
+    assertEquals(1800.0, result.getIntervals().get(2).getDurationSeconds(), 1.0e-12);
+    assertEquals(3.0, result.getServedEnergyMWh(), 1.0e-12);
+    assertEquals(0.25, result.getUnmetEnergyMWh(), 1.0e-12);
+    assertEquals(1.5, result.getCurtailedEnergyMWh(), 1.0e-12);
+    assertEquals(300.0, result.getOperatingCost(), 1.0e-12);
+    assertEquals(600.0, result.getCo2EmissionsKg(), 1.0e-12);
+    assertThrows(UnsupportedOperationException.class, () -> result.getIntervals().clear());
+    assertThrows(UnsupportedOperationException.class, () -> result.getIntervals().get(0).getNetworkReports().clear());
+  }
+
+  @Test
+  void testMultipleBusesAndJsonResult() {
+    EnergyBus electrical = new EnergyBus("electrical", EnergyType.ELECTRICAL);
+    EnergyBus heat = new EnergyBus("heat", EnergyType.HEAT);
+    electrical.setContribution("source", 1.0e6);
+    electrical.setContribution("load", -0.5e6);
+    heat.setContribution("source", 2.0e6);
+    heat.setContribution("load", -1.0e6);
+
+    EnergyTimeSeriesSimulator simulator = new EnergyTimeSeriesSimulator(new ProcessSystem());
+    simulator.addEnergyBus(electrical);
+    simulator.addEnergyBus(heat);
+    simulator.setDurationSeconds(3600.0);
+
+    EnergyTimeSeriesResult result = simulator.run();
+
+    assertEquals(2, result.getIntervals().get(0).getNetworkReports().size());
+    assertEquals(1.5, result.getServedEnergyMWh(), 1.0e-12);
+    org.junit.jupiter.api.Assertions.assertTrue(result.toJson().contains("servedEnergyMWh"));
+  }
+
+  @Test
+  void testSimulatorPreconditions() {
+    EnergyTimeSeriesSimulator simulator = new EnergyTimeSeriesSimulator(new ProcessSystem());
+    assertThrows(IllegalStateException.class, simulator::run);
+    assertThrows(IllegalArgumentException.class, () -> simulator.setIntervalSeconds(0.0));
+    assertThrows(IllegalArgumentException.class, () -> simulator.setDurationSeconds(Double.NaN));
+    assertThrows(IllegalArgumentException.class, () -> simulator.setExecutionMode(null));
+    assertThrows(IllegalArgumentException.class, () -> new EnergyTimeSeriesProfile("empty",
+        EnergyTimeSeriesProfile.Interpolation.STEP, Arrays.<EnergyTimeSeriesProfile.Point>asList()));
+  }
+
+  private static EnergyPort port(String owner, EnergyPortDirection direction, EnergyPortMode mode, EnergyBus bus) {
+    EnergyPort port = new EnergyPort("power", bus.getEnergyType(), direction, mode);
+    port.setOwnerName(owner);
+    port.connect(bus);
+    return port;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the remaining chronological-operation stage for Energy Networks v3:

- immutable stepwise and linearly interpolated scalar profiles
- explicit profile-to-setter bindings for generation, load, price, emissions, and equipment setpoints
- repeated steady-state or transient `ProcessSystem` execution
- one or more explicitly tracked `EnergyBus` networks
- automatic partial final interval
- immutable interval report history
- integrated served energy, unmet energy, curtailment, operating cost, and CO2-equivalent emissions
- JSON result output
- professional-use documentation

## Validation coverage

- step and linear interpolation, clamping, and invalid profile definitions
- exact rate-times-duration accounting including a half-length final interval
- multi-bus aggregation
- immutable result collections
- missing bus, invalid interval, invalid duration, and null execution mode preconditions

## Compatibility

The simulator is additive and does not change existing steady-state or transient process execution. Profile targets use ordinary setters, so existing equipment classes require no modification.

## Scope

This PR provides chronological simulation and KPI integration. Dispatch within each interval follows the configured bus policy. Unit commitment, startup decisions, stochastic optimization, and market settlement remain separate optimization layers.