### PR TITLE
Add part-load efficiency curves to generators, transformers, and prime movers

### DIFF
--- a/docs/process/converter_load_efficiency_curves.md
+++ b/docs/process/converter_load_efficiency_curves.md
@@ -1,0 +1,45 @@
+---
+title: Converter load-efficiency curves
+description: Add part-load performance to generators, transformers, and prime movers.
+---
+
+# Converter load-efficiency curves
+
+`Generator`, `Transformer`, and `PrimeMover` support optional piecewise-linear efficiency versus useful-output load. Their existing constant-efficiency behavior remains the default.
+
+```java
+LoadEfficiencyCurve curve = new LoadEfficiencyCurve(
+    new double[] {0.25, 0.50, 0.75, 1.00},
+    new double[] {0.80, 0.90, 0.94, 0.96});
+
+Generator generator = new Generator("main generator");
+generator.setRatedOutputPower(20.0e6);
+generator.setLoadEfficiencyCurve(curve);
+```
+
+The curve is evaluated from useful output divided by rated useful output. Endpoints are clamped, intermediate points are linearly interpolated, and output above the rating is rejected.
+
+```java
+double inputRequired = generator.getRequiredInputPowerForOutput(10.0e6);
+double efficiency = generator.getEfficiencyAtOutputPower(10.0e6);
+```
+
+Forward conversion uses bounded iteration so the input, useful output, and heat loss remain consistent even when efficiency changes with load.
+
+The same API is available for transformers and fuel-fired prime movers:
+
+```java
+Transformer transformer = new Transformer("export transformer");
+transformer.setRatedOutputPower(25.0e6);
+transformer.setLoadEfficiencyCurve(transformerCurve);
+
+PrimeMover turbine = new PrimeMover("gas turbine driver");
+turbine.setRatedOutputPower(15.0e6);
+turbine.setLoadEfficiencyCurve(turbineCurve);
+```
+
+Call `clearLoadEfficiencyCurve()` to restore nominal constant efficiency.
+
+## Scope
+
+The curve represents steady load-dependent conversion efficiency. Startup fuel, minimum uptime, ambient derating, degradation, maintenance state, and dynamic thermal limits should be represented by higher-level equipment or commitment models.

--- a/src/main/java/neqsim/process/equipment/energy/ElectricMotor.java
+++ b/src/main/java/neqsim/process/equipment/energy/ElectricMotor.java
@@ -1,15 +1,30 @@
 package neqsim.process.equipment.energy;
 
+import java.util.Objects;
+import neqsim.process.equipment.compressor.driver.ElectricMotorDriver;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyStream;
 import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
+import neqsim.util.validation.ValidationResult;
 
 /**
  * Electric motor converting electrical power to shaft work.
  *
+ * <p>
+ * The default model uses constant efficiency. An optional {@link ElectricMotorDriver} adds rated power, fixed-speed or
+ * VFD capability, part-load efficiency, and ambient/altitude derating using the same driver model already used by
+ * NeqSim compressor studies.
+ * </p>
+ *
  * @author NeqSim
- * @version 1.0
+ * @version 2.0
  */
 public class ElectricMotor extends EnergyConverter {
   private static final long serialVersionUID = 1000L;
+
+  private ElectricMotorDriver performanceModel;
+  private double configuredOperatingSpeed = Double.NaN;
 
   /**
    * Creates an electric motor with 95 percent efficiency.
@@ -30,5 +45,200 @@ public class ElectricMotor extends EnergyConverter {
   public ElectricMotor(String name, double efficiency) {
     this(name);
     setEfficiency(efficiency);
+  }
+
+  /**
+   * Attaches a detailed electric-motor performance model.
+   *
+   * @param performanceModel rated motor/VFD performance model
+   */
+  public void setPerformanceModel(ElectricMotorDriver performanceModel) {
+    ElectricMotorDriver model = Objects.requireNonNull(performanceModel, "performanceModel cannot be null");
+    if (!Double.isFinite(model.getRatedPower()) || model.getRatedPower() <= 0.0) {
+      throw new IllegalArgumentException("Motor performance model must have positive finite rated power");
+    }
+    if (!Double.isFinite(model.getRatedSpeed()) || model.getRatedSpeed() <= 0.0) {
+      throw new IllegalArgumentException("Motor performance model must have positive finite rated speed");
+    }
+    this.performanceModel = model;
+  }
+
+  /** Removes the detailed performance model and restores constant-efficiency behavior. */
+  public void clearPerformanceModel() {
+    performanceModel = null;
+  }
+
+  /**
+   * Gets the attached performance model.
+   *
+   * @return performance model, or {@code null} when constant efficiency is active
+   */
+  public ElectricMotorDriver getPerformanceModel() {
+    return performanceModel;
+  }
+
+  /**
+   * Checks whether detailed motor performance is active.
+   *
+   * @return {@code true} when a driver model is attached
+   */
+  public boolean hasPerformanceModel() {
+    return performanceModel != null;
+  }
+
+  /**
+   * Sets operating speed used when no positive-speed {@link MechanicalShaft} is connected.
+   *
+   * @param speed operating speed in rpm
+   */
+  public void setOperatingSpeed(double speed) {
+    if (!Double.isFinite(speed) || speed <= 0.0) {
+      throw new IllegalArgumentException("Motor operating speed must be positive and finite");
+    }
+    configuredOperatingSpeed = speed;
+  }
+
+  /** Clears explicit speed so a connected shaft or the rated speed is used. */
+  public void clearOperatingSpeed() {
+    configuredOperatingSpeed = Double.NaN;
+  }
+
+  /**
+   * Gets the resolved operating speed.
+   *
+   * @return connected shaft speed, configured speed, rated speed, or NaN without a detailed model
+   */
+  public double getOperatingSpeed() {
+    EnergyPort outputPort = getEnergyPort(OUTPUT_PORT);
+    if (outputPort.isConnected()) {
+      EnergyStream outputStream = outputPort.getEnergyStream();
+      if (outputStream instanceof MechanicalShaft && ((MechanicalShaft) outputStream).getSpeed() > 0.0) {
+        return ((MechanicalShaft) outputStream).getSpeed();
+      }
+    }
+    if (Double.isFinite(configuredOperatingSpeed)) {
+      return configuredOperatingSpeed;
+    }
+    return performanceModel == null ? Double.NaN : performanceModel.getRatedSpeed();
+  }
+
+  /**
+   * Gets currently available mechanical output capacity.
+   *
+   * @return available shaft power in W, or positive infinity for the constant-efficiency model
+   */
+  public double getAvailableShaftPower() {
+    if (performanceModel == null) {
+      return Double.POSITIVE_INFINITY;
+    }
+    return getAvailableShaftPower(getOperatingSpeed());
+  }
+
+  /**
+   * Gets motor efficiency at a requested shaft output.
+   *
+   * @param outputPower requested shaft output in W
+   * @return performance-model efficiency, or nominal constant efficiency
+   */
+  public double getEfficiencyAtOutputPower(double outputPower) {
+    if (!Double.isFinite(outputPower) || outputPower < 0.0) {
+      throw new IllegalArgumentException("Motor output power must be non-negative and finite");
+    }
+    if (performanceModel == null) {
+      return getEfficiency();
+    }
+    if (outputPower == 0.0) {
+      return 0.0;
+    }
+    double speed = getOperatingSpeed();
+    double ratedAvailablePower = performanceModel.getAvailablePower(speed) * 1000.0;
+    if (ratedAvailablePower <= 0.0) {
+      return 0.0;
+    }
+    double loadFraction = Math.min(1.2, outputPower / ratedAvailablePower);
+    return performanceModel.getEfficiency(speed, loadFraction);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected double calculateTargetOutput(double input) {
+    if (performanceModel == null) {
+      return super.calculateTargetOutput(input);
+    }
+    if (isTripped() || input <= getIdleLoss()) {
+      return 0.0;
+    }
+
+    double availableOutput = getAvailableShaftPower();
+    if (!Double.isFinite(availableOutput) || availableOutput <= 0.0) {
+      return 0.0;
+    }
+    if (calculateRequiredInputForOutput(availableOutput) <= input) {
+      return availableOutput;
+    }
+
+    double lowerOutput = 0.0;
+    double upperOutput = availableOutput;
+    for (int iteration = 0; iteration < 60; iteration++) {
+      double trialOutput = 0.5 * (lowerOutput + upperOutput);
+      if (calculateRequiredInputForOutput(trialOutput) <= input) {
+        lowerOutput = trialOutput;
+      } else {
+        upperOutput = trialOutput;
+      }
+    }
+    return lowerOutput;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected double calculateRequiredInputForOutput(double output) {
+    if (performanceModel == null) {
+      return super.calculateRequiredInputForOutput(output);
+    }
+    if (output <= 0.0) {
+      return 0.0;
+    }
+
+    double speed = getOperatingSpeed();
+    double availableOutput = getAvailableShaftPower(speed);
+    if (output > availableOutput + Math.max(1.0e-6, availableOutput * 1.0e-10)) {
+      throw new IllegalArgumentException("Requested shaft power exceeds motor capability at the operating speed");
+    }
+    double efficiency = getEfficiencyAtOutputPower(output);
+    if (!Double.isFinite(efficiency) || efficiency <= 0.0 || efficiency > 1.0) {
+      throw new IllegalStateException("Motor performance model returned invalid efficiency at the requested load");
+    }
+    return output / efficiency + getIdleLoss();
+  }
+
+  /** Gets derated shaft capability at one speed. */
+  private double getAvailableShaftPower(double speed) {
+    if (!Double.isFinite(speed) || speed <= 0.0) {
+      return 0.0;
+    }
+    double availablePower = performanceModel.getAvailablePower(speed) * 1000.0;
+    double derating = performanceModel.getAmbientDeratingFactor();
+    if (!Double.isFinite(availablePower) || !Double.isFinite(derating)) {
+      throw new IllegalStateException("Motor performance model returned non-finite capability");
+    }
+    return Math.max(0.0, availablePower * Math.max(0.0, Math.min(1.0, derating)));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ValidationResult validateSetup() {
+    ValidationResult result = super.validateSetup();
+    if (performanceModel != null) {
+      double speed = getOperatingSpeed();
+      if (!Double.isFinite(speed) || speed <= 0.0) {
+        result.addError("energy", "Motor operating speed is not available",
+            "Set shaft speed, call setOperatingSpeed(rpm), or configure a rated motor speed");
+      } else if (performanceModel.getAvailablePower(speed) <= 0.0) {
+        result.addError("energy", "Motor cannot operate at the configured shaft speed",
+            "Select a valid fixed-speed point or configure the VFD speed range");
+      }
+    }
+    return result;
   }
 }

--- a/src/main/java/neqsim/process/equipment/energy/ElectricMotor.java
+++ b/src/main/java/neqsim/process/equipment/energy/ElectricMotor.java
@@ -218,11 +218,29 @@ public class ElectricMotor extends EnergyConverter {
       return 0.0;
     }
     double availablePower = performanceModel.getAvailablePower(speed) * 1000.0;
-    double derating = performanceModel.getAmbientDeratingFactor();
+    double derating = getCombinedEnvironmentalDeratingFactor();
     if (!Double.isFinite(availablePower) || !Double.isFinite(derating)) {
       throw new IllegalStateException("Motor performance model returned non-finite capability");
     }
-    return Math.max(0.0, availablePower * Math.max(0.0, Math.min(1.0, derating)));
+    return Math.max(0.0, availablePower * derating);
+  }
+
+  /**
+   * Gets combined ambient-temperature and altitude derating.
+   *
+   * <p>
+   * The legacy driver returns early below 40 degrees Celsius, which omits altitude derating. The energy-network motor
+   * preserves that driver behavior for temperature while applying the missing altitude factor whenever the early return
+   * is active.
+   * </p>
+   */
+  private double getCombinedEnvironmentalDeratingFactor() {
+    double derating = performanceModel.getAmbientDeratingFactor();
+    if (performanceModel.getAmbientTemperature() <= 40.0 && performanceModel.getAltitude() > 1000.0) {
+      double altitudeDerating = 1.0 - 0.01 * (performanceModel.getAltitude() - 1000.0) / 100.0;
+      derating *= altitudeDerating;
+    }
+    return Math.max(0.5, Math.min(1.0, derating));
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
@@ -17,11 +17,12 @@ import neqsim.util.validation.ValidationResult;
  * <p>
  * The input is a specification port, the useful output is a calculated port, and conversion losses are available as a
  * calculated heat port. This common implementation is used by motors, generators, gearboxes, inverters, and
- * transformers.
+ * transformers. Subclasses can override the protected conversion methods to provide load-dependent performance while
+ * retaining common network, ramp, trip, and conservation behavior.
  * </p>
  *
  * @author NeqSim
- * @version 1.0
+ * @version 1.1
  */
 public class EnergyConverter extends ProcessEquipmentBaseClass {
   private static final long serialVersionUID = 1000L;
@@ -82,16 +83,21 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   }
 
   /**
-   * Gets conversion efficiency.
+   * Gets nominal conversion efficiency.
    *
-   * @return efficiency from zero to one
+   * <p>
+   * Subclasses with performance maps may use a different operating efficiency at the current load. Use
+   * {@link #getOperatingEfficiency()} for the efficiency realized by the latest calculation.
+   * </p>
+   *
+   * @return nominal efficiency from zero to one
    */
   public double getEfficiency() {
     return efficiency;
   }
 
   /**
-   * Sets conversion efficiency.
+   * Sets nominal conversion efficiency.
    *
    * @param efficiency efficiency greater than zero and at most one
    */
@@ -176,7 +182,7 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   }
 
   /**
-   * Gets the current allocated input power.
+   * Gets the current realized input power.
    *
    * @return input power in W
    */
@@ -203,6 +209,42 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   }
 
   /**
+   * Gets realized total conversion efficiency from the latest calculation.
+   *
+   * @return output divided by realized input, or zero when no input is consumed
+   */
+  public double getOperatingEfficiency() {
+    return currentInputPower > 0.0 ? currentOutputPower / currentInputPower : 0.0;
+  }
+
+  /**
+   * Calculates input power required for a requested useful output.
+   *
+   * <p>
+   * The default implementation uses nominal efficiency and idle loss. Subclasses may override the protected inverse
+   * conversion method to apply load-, speed-, or ambient-dependent performance maps.
+   * </p>
+   *
+   * @param outputPower requested useful output in W
+   * @return required input in W
+   * @throws IllegalArgumentException when the output is invalid or exceeds configured capability
+   */
+  public double getRequiredInputPowerForOutput(double outputPower) {
+    if (!Double.isFinite(outputPower) || outputPower < 0.0) {
+      throw new IllegalArgumentException("Requested output power must be non-negative and finite");
+    }
+    double requiredInput = calculateRequiredInputForOutput(outputPower);
+    if (!Double.isFinite(requiredInput) || requiredInput < 0.0) {
+      throw new IllegalStateException("Converter performance model returned invalid required input power");
+    }
+    if (Double.isFinite(maximumInputPower)
+        && requiredInput > maximumInputPower + Math.max(1.0e-9, maximumInputPower * 1.0e-12)) {
+      throw new IllegalArgumentException("Requested output exceeds the converter input-power capability");
+    }
+    return requiredInput;
+  }
+
+  /**
    * Checks whether the converter is tripped.
    *
    * @return {@code true} when tripped
@@ -226,8 +268,9 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
-    double input = readAvailableInput();
-    publish(input, calculateTargetOutput(input));
+    double availableInput = readAvailableInput();
+    double output = calculateTargetOutput(availableInput);
+    publish(calculateRealizedInput(availableInput, output), output);
     setCalculationIdentifier(id);
   }
 
@@ -238,8 +281,8 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
       throw new IllegalArgumentException("Converter timestep must be non-negative and finite");
     }
 
-    double input = readAvailableInput();
-    double targetOutput = calculateTargetOutput(input);
+    double availableInput = readAvailableInput();
+    double targetOutput = calculateTargetOutput(availableInput);
     double maximumChange = rampRate * dt;
     double rampedOutput = targetOutput;
     if (Double.isFinite(maximumChange) && Math.abs(targetOutput - currentOutputPower) > maximumChange) {
@@ -250,11 +293,40 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
     // Ramp limits therefore constrain increases, while a loss of input immediately caps output at the
     // thermodynamically available target.
     double output = Math.min(targetOutput, Math.max(0.0, rampedOutput));
-    double effectiveInput = output > 0.0 ? output / efficiency + idleLoss : 0.0;
-    effectiveInput = Math.min(input, effectiveInput);
-    publish(effectiveInput, output);
+    publish(calculateRealizedInput(availableInput, output), output);
     increaseTime(dt);
     setCalculationIdentifier(id);
+  }
+
+  /**
+   * Calculates useful steady-state output from available input.
+   *
+   * <p>
+   * Subclasses can override this method to apply performance maps. Implementations must return a finite non-negative
+   * output that can be supported by the supplied input.
+   * </p>
+   *
+   * @param input available input power in W
+   * @return useful output in W
+   */
+  protected double calculateTargetOutput(double input) {
+    if (tripped || input <= idleLoss) {
+      return 0.0;
+    }
+    return (input - idleLoss) * efficiency;
+  }
+
+  /**
+   * Calculates required input for useful output.
+   *
+   * @param output useful output power in W
+   * @return required input power in W
+   */
+  protected double calculateRequiredInputForOutput(double output) {
+    if (output <= 0.0) {
+      return 0.0;
+    }
+    return output / efficiency + idleLoss;
   }
 
   /**
@@ -269,29 +341,30 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
     return Math.min(maximumInputPower, getEnergyPort(INPUT_PORT).getPowerMagnitude());
   }
 
-  /**
-   * Calculates useful steady-state output.
-   *
-   * @param input input power in W
-   * @return useful output in W
-   */
-  private double calculateTargetOutput(double input) {
-    if (tripped || input <= idleLoss) {
-      return 0.0;
+  /** Calculates input actually consumed by the realized output. */
+  private double calculateRealizedInput(double availableInput, double output) {
+    if (output > 0.0) {
+      return Math.min(availableInput, getRequiredInputPowerForOutput(output));
     }
-    return (input - idleLoss) * efficiency;
+    if (availableInput > 0.0 && availableInput <= idleLoss) {
+      return availableInput;
+    }
+    return 0.0;
   }
 
   /**
    * Publishes converter results to connected output and loss ports.
    *
-   * @param input input power in W
+   * @param input realized input power in W
    * @param output useful output power in W
    */
   private void publish(double input, double output) {
-    currentInputPower = Math.max(0.0, input);
-    currentOutputPower = Math.max(0.0, output);
-    heatLoss = Math.max(0.0, currentInputPower - currentOutputPower);
+    if (!Double.isFinite(input) || input < 0.0 || !Double.isFinite(output) || output < 0.0 || output > input) {
+      throw new IllegalStateException("Energy converter result violates finite non-negative energy conservation");
+    }
+    currentInputPower = input;
+    currentOutputPower = output;
+    heatLoss = currentInputPower - currentOutputPower;
 
     EnergyPort outputPort = getEnergyPort(OUTPUT_PORT);
     outputPort.setConversionLoss(heatLoss);
@@ -332,7 +405,8 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
     result.put("inputPowerW", currentInputPower);
     result.put("outputPowerW", currentOutputPower);
     result.put("heatLossW", heatLoss);
-    result.put("efficiency", efficiency);
+    result.put("nominalEfficiency", efficiency);
+    result.put("operatingEfficiency", getOperatingEfficiency());
     result.put("tripped", tripped);
     return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(result);
   }

--- a/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
@@ -234,14 +234,24 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public void runTransient(double dt, UUID id) {
+    if (!Double.isFinite(dt) || dt < 0.0) {
+      throw new IllegalArgumentException("Converter timestep must be non-negative and finite");
+    }
+
     double input = readAvailableInput();
     double targetOutput = calculateTargetOutput(input);
-    double maximumChange = rampRate * Math.max(0.0, dt);
-    double output = targetOutput;
+    double maximumChange = rampRate * dt;
+    double rampedOutput = targetOutput;
     if (Double.isFinite(maximumChange) && Math.abs(targetOutput - currentOutputPower) > maximumChange) {
-      output = currentOutputPower + Math.copySign(maximumChange, targetOutput - currentOutputPower);
+      rampedOutput = currentOutputPower + Math.copySign(maximumChange, targetOutput - currentOutputPower);
     }
-    double effectiveInput = output > 0.0 ? Math.min(input, output / efficiency + idleLoss) : 0.0;
+
+    // A memoryless converter cannot sustain a ramp-limited output using energy that is no longer available.
+    // Ramp limits therefore constrain increases, while a loss of input immediately caps output at the
+    // thermodynamically available target.
+    double output = Math.min(targetOutput, Math.max(0.0, rampedOutput));
+    double effectiveInput = output > 0.0 ? output / efficiency + idleLoss : 0.0;
+    effectiveInput = Math.min(input, effectiveInput);
     publish(effectiveInput, output);
     increaseTime(dt);
     setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/energy/Generator.java
+++ b/src/main/java/neqsim/process/equipment/energy/Generator.java
@@ -5,28 +5,22 @@ import neqsim.process.equipment.stream.EnergyType;
 /**
  * Generator converting shaft work to electrical power.
  *
+ * <p>An optional rated output and {@link LoadEfficiencyCurve} provide part-load performance while
+ * the default remains constant 97 percent efficiency.</p>
+ *
  * @author NeqSim
- * @version 1.0
+ * @version 2.0
  */
-public class Generator extends EnergyConverter {
+public class Generator extends LoadMappedEnergyConverter {
   private static final long serialVersionUID = 1000L;
 
-  /**
-   * Creates a generator with 97 percent efficiency.
-   *
-   * @param name equipment name
-   */
+  /** Creates a generator with 97 percent efficiency. */
   public Generator(String name) {
     super(name, EnergyType.SHAFT_WORK, EnergyType.ELECTRICAL);
     setEfficiency(0.97);
   }
 
-  /**
-   * Creates a generator.
-   *
-   * @param name equipment name
-   * @param efficiency shaft-to-electrical efficiency
-   */
+  /** Creates a generator with specified nominal efficiency. */
   public Generator(String name, double efficiency) {
     this(name);
     setEfficiency(efficiency);

--- a/src/main/java/neqsim/process/equipment/energy/Inverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/Inverter.java
@@ -39,9 +39,12 @@ public class Inverter extends EnergyConverter {
    * @param frequency output frequency in Hz
    */
   public void setOutputElectricalQuality(double voltage, double frequency) {
-    EnergyQuality validation = new EnergyQuality();
-    validation.setVoltage(voltage);
-    validation.setFrequency(frequency);
+    if (!Double.isFinite(voltage) || voltage <= 0.0) {
+      throw new IllegalArgumentException("Output voltage must be positive and finite");
+    }
+    if (!Double.isFinite(frequency) || frequency <= 0.0) {
+      throw new IllegalArgumentException("Output frequency must be positive and finite");
+    }
     outputVoltage = voltage;
     outputFrequency = frequency;
     publishOutputElectricalQuality();

--- a/src/main/java/neqsim/process/equipment/energy/Inverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/Inverter.java
@@ -31,8 +31,8 @@ public class Inverter extends EnergyConverter {
    * Sets output electrical quality.
    *
    * <p>
-   * Voltage and frequency are updated on the existing output quality object so temperature, pressure, utility level, and
-   * future metadata are preserved.
+   * Voltage and frequency are updated on the existing output quality object so temperature, pressure, utility level,
+   * and future metadata are preserved.
    * </p>
    *
    * @param voltage output voltage in V

--- a/src/main/java/neqsim/process/equipment/energy/Inverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/Inverter.java
@@ -1,5 +1,6 @@
 package neqsim.process.equipment.energy;
 
+import java.util.UUID;
 import neqsim.process.equipment.stream.EnergyPort;
 import neqsim.process.equipment.stream.EnergyQuality;
 import neqsim.process.equipment.stream.EnergyType;
@@ -29,18 +30,53 @@ public class Inverter extends EnergyConverter {
   /**
    * Sets output electrical quality.
    *
+   * <p>
+   * Voltage and frequency are updated on the existing output quality object so temperature, pressure, utility level, and
+   * future metadata are preserved.
+   * </p>
+   *
    * @param voltage output voltage in V
    * @param frequency output frequency in Hz
    */
   public void setOutputElectricalQuality(double voltage, double frequency) {
-    EnergyQuality quality = new EnergyQuality();
-    quality.setVoltage(voltage);
-    quality.setFrequency(frequency);
+    EnergyQuality validation = new EnergyQuality();
+    validation.setVoltage(voltage);
+    validation.setFrequency(frequency);
     outputVoltage = voltage;
     outputFrequency = frequency;
+    publishOutputElectricalQuality();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run(UUID id) {
+    super.run(id);
+    publishOutputElectricalQuality();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void runTransient(double dt, UUID id) {
+    super.runTransient(dt, id);
+    publishOutputElectricalQuality();
+  }
+
+  /** Publishes configured voltage and frequency without replacing other output quality metadata. */
+  private void publishOutputElectricalQuality() {
     EnergyPort output = getEnergyPort(OUTPUT_PORT);
-    if (output.isConnected()) {
+    if (!output.isConnected()) {
+      return;
+    }
+    EnergyQuality quality = output.getEnergyStream().getQuality();
+    if (quality == null) {
+      quality = new EnergyQuality();
       output.getEnergyStream().setQuality(quality);
+    }
+    if (Double.isFinite(outputVoltage)) {
+      quality.setVoltage(outputVoltage);
+    }
+    if (Double.isFinite(outputFrequency)) {
+      quality.setFrequency(outputFrequency);
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/energy/LoadEfficiencyCurve.java
+++ b/src/main/java/neqsim/process/equipment/energy/LoadEfficiencyCurve.java
@@ -1,0 +1,73 @@
+package neqsim.process.equipment.energy;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/** Immutable piecewise-linear efficiency curve versus fractional useful output load. */
+public final class LoadEfficiencyCurve implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final double[] loadFractions;
+  private final double[] efficiencies;
+
+  /**
+   * Creates a validated curve.
+   *
+   * @param loadFractions strictly increasing fractions, beginning above zero
+   * @param efficiencies efficiencies in (0, 1]
+   */
+  public LoadEfficiencyCurve(double[] loadFractions, double[] efficiencies) {
+    if (loadFractions == null || efficiencies == null || loadFractions.length != efficiencies.length
+        || loadFractions.length < 2) {
+      throw new IllegalArgumentException("Load and efficiency arrays must have equal length of at least two");
+    }
+    this.loadFractions = loadFractions.clone();
+    this.efficiencies = efficiencies.clone();
+    double previous = 0.0;
+    for (int index = 0; index < this.loadFractions.length; index++) {
+      double load = this.loadFractions[index];
+      double efficiency = this.efficiencies[index];
+      if (!Double.isFinite(load) || load <= previous) {
+        throw new IllegalArgumentException("Load fractions must be positive, finite, and strictly increasing");
+      }
+      if (!Double.isFinite(efficiency) || efficiency <= 0.0 || efficiency > 1.0) {
+        throw new IllegalArgumentException("Curve efficiencies must be in (0, 1]");
+      }
+      previous = load;
+    }
+  }
+
+  /** Evaluates with endpoint clamping. */
+  public double getEfficiency(double loadFraction) {
+    if (!Double.isFinite(loadFraction) || loadFraction < 0.0) {
+      throw new IllegalArgumentException("Load fraction must be non-negative and finite");
+    }
+    if (loadFraction <= loadFractions[0]) {
+      return efficiencies[0];
+    }
+    int last = loadFractions.length - 1;
+    if (loadFraction >= loadFractions[last]) {
+      return efficiencies[last];
+    }
+    for (int index = 1; index < loadFractions.length; index++) {
+      if (loadFraction <= loadFractions[index]) {
+        double fraction = (loadFraction - loadFractions[index - 1])
+            / (loadFractions[index] - loadFractions[index - 1]);
+        return efficiencies[index - 1] + fraction * (efficiencies[index] - efficiencies[index - 1]);
+      }
+    }
+    return efficiencies[last];
+  }
+
+  public double[] getLoadFractions() {
+    return loadFractions.clone();
+  }
+
+  public double[] getEfficiencies() {
+    return efficiencies.clone();
+  }
+
+  @Override
+  public String toString() {
+    return "LoadEfficiencyCurve" + Arrays.toString(loadFractions);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/LoadMappedEnergyConverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/LoadMappedEnergyConverter.java
@@ -1,0 +1,112 @@
+package neqsim.process.equipment.energy;
+
+import neqsim.process.equipment.stream.EnergyType;
+
+/**
+ * Energy converter with optional rated output and piecewise-linear load-efficiency curve.
+ *
+ * <p>Without a curve, the inherited constant-efficiency behavior is unchanged. With a curve,
+ * efficiency is evaluated from useful output divided by rated useful output, and forward conversion
+ * is solved by bounded bisection to preserve energy conservation.</p>
+ */
+public class LoadMappedEnergyConverter extends EnergyConverter {
+  private static final long serialVersionUID = 1000L;
+  private double ratedOutputPower = Double.POSITIVE_INFINITY;
+  private LoadEfficiencyCurve loadEfficiencyCurve;
+
+  protected LoadMappedEnergyConverter(String name, EnergyType inputType, EnergyType outputType) {
+    super(name, inputType, outputType);
+  }
+
+  /** Sets rated useful output in W. */
+  public void setRatedOutputPower(double ratedOutputPower) {
+    if (!Double.isFinite(ratedOutputPower) || ratedOutputPower <= 0.0) {
+      throw new IllegalArgumentException("Rated output power must be positive and finite");
+    }
+    this.ratedOutputPower = ratedOutputPower;
+  }
+
+  /** @return rated useful output in W, or positive infinity when unspecified */
+  public double getRatedOutputPower() {
+    return ratedOutputPower;
+  }
+
+  /** Attaches a load-efficiency curve. Rated output must also be configured before use. */
+  public void setLoadEfficiencyCurve(LoadEfficiencyCurve curve) {
+    if (curve == null) {
+      throw new IllegalArgumentException("Load-efficiency curve is required");
+    }
+    loadEfficiencyCurve = curve;
+  }
+
+  /** Removes the curve and restores nominal constant efficiency. */
+  public void clearLoadEfficiencyCurve() {
+    loadEfficiencyCurve = null;
+  }
+
+  public LoadEfficiencyCurve getLoadEfficiencyCurve() {
+    return loadEfficiencyCurve;
+  }
+
+  public boolean hasLoadEfficiencyCurve() {
+    return loadEfficiencyCurve != null;
+  }
+
+  /** Gets operating efficiency at one requested useful output. */
+  public double getEfficiencyAtOutputPower(double outputPower) {
+    if (!Double.isFinite(outputPower) || outputPower < 0.0) {
+      throw new IllegalArgumentException("Output power must be non-negative and finite");
+    }
+    if (loadEfficiencyCurve == null) {
+      return getEfficiency();
+    }
+    requireRatedOutput();
+    if (outputPower > ratedOutputPower + Math.max(1.0e-6, ratedOutputPower * 1.0e-10)) {
+      throw new IllegalArgumentException("Requested output exceeds rated converter output");
+    }
+    return loadEfficiencyCurve.getEfficiency(outputPower / ratedOutputPower);
+  }
+
+  @Override
+  protected double calculateRequiredInputForOutput(double output) {
+    if (loadEfficiencyCurve == null) {
+      return super.calculateRequiredInputForOutput(output);
+    }
+    if (output <= 0.0) {
+      return 0.0;
+    }
+    double efficiency = getEfficiencyAtOutputPower(output);
+    return output / efficiency + getIdleLoss();
+  }
+
+  @Override
+  protected double calculateTargetOutput(double input) {
+    if (loadEfficiencyCurve == null) {
+      return super.calculateTargetOutput(input);
+    }
+    if (isTripped() || input <= getIdleLoss()) {
+      return 0.0;
+    }
+    requireRatedOutput();
+    if (calculateRequiredInputForOutput(ratedOutputPower) <= input) {
+      return ratedOutputPower;
+    }
+    double lower = 0.0;
+    double upper = ratedOutputPower;
+    for (int iteration = 0; iteration < 60; iteration++) {
+      double trial = 0.5 * (lower + upper);
+      if (calculateRequiredInputForOutput(trial) <= input) {
+        lower = trial;
+      } else {
+        upper = trial;
+      }
+    }
+    return lower;
+  }
+
+  private void requireRatedOutput() {
+    if (!Double.isFinite(ratedOutputPower) || ratedOutputPower <= 0.0) {
+      throw new IllegalStateException("Configure rated output power before using a load-efficiency curve");
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/energy/MotorAssistedDriveTrain.java
+++ b/src/main/java/neqsim/process/equipment/energy/MotorAssistedDriveTrain.java
@@ -106,6 +106,10 @@ public class MotorAssistedDriveTrain implements Serializable {
       result.addError("energy", "Assist motor is not connected to the electrical bus",
           "Reconnect motor energyInput to the electrical bus");
     }
+    if (assistMotor.getEnergyPort(EnergyConverter.OUTPUT_PORT).getEnergyStream() != shaft) {
+      result.addError("energy", "Assist motor is not connected to the common shaft",
+          "Reconnect motor energyOutput to the common shaft");
+    }
     return result;
   }
 }

--- a/src/main/java/neqsim/process/equipment/energy/MotorAssistedDriveTrain.java
+++ b/src/main/java/neqsim/process/equipment/energy/MotorAssistedDriveTrain.java
@@ -66,7 +66,7 @@ public class MotorAssistedDriveTrain implements Serializable {
       throw new IllegalArgumentException("Drive-train power targets must be non-negative and finite");
     }
     compressor.getEnergyPort("shaftPower").setRequestedPower(compressorPower);
-    assistMotor.setRequestedInputPower(motorAssistPower / assistMotor.getEfficiency() + assistMotor.getIdleLoss());
+    assistMotor.setRequestedInputPower(assistMotor.getRequiredInputPowerForOutput(motorAssistPower));
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/energy/MotorDriveTrain.java
+++ b/src/main/java/neqsim/process/equipment/energy/MotorDriveTrain.java
@@ -113,6 +113,10 @@ public class MotorDriveTrain implements Serializable {
       result.addError("energy", "Motor is not connected to the configured electrical bus",
           "Reconnect motor energyInput to the electrical bus");
     }
+    if (motor.getEnergyPort(EnergyConverter.OUTPUT_PORT).getEnergyStream() != shaft) {
+      result.addError("energy", "Motor is not connected to the configured shaft",
+          "Reconnect motor energyOutput to the mechanical shaft");
+    }
     if (drivenEquipment.getEnergyPort("shaftPower").getEnergyStream() != shaft) {
       result.addError("energy", "Driven equipment is not connected to the configured shaft",
           "Reconnect shaftPower to the mechanical shaft");

--- a/src/main/java/neqsim/process/equipment/energy/MotorDriveTrain.java
+++ b/src/main/java/neqsim/process/equipment/energy/MotorDriveTrain.java
@@ -63,7 +63,7 @@ public class MotorDriveTrain implements Serializable {
       throw new IllegalArgumentException("Requested shaft power must be non-negative and finite");
     }
     drivenEquipment.getEnergyPort("shaftPower").setRequestedPower(shaftPower);
-    motor.setRequestedInputPower(shaftPower / motor.getEfficiency() + motor.getIdleLoss());
+    motor.setRequestedInputPower(motor.getRequiredInputPowerForOutput(shaftPower));
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/energy/PrimeMover.java
+++ b/src/main/java/neqsim/process/equipment/energy/PrimeMover.java
@@ -2,36 +2,15 @@ package neqsim.process.equipment.energy;
 
 import neqsim.process.equipment.stream.EnergyType;
 
-/**
- * Generic fuel-fired prime mover converting chemical energy to shaft work.
- *
- * <p>
- * The input power is the fuel lower- or higher-heating-value rate chosen by the model author. Cost and emissions can be
- * assigned to the chemical-energy producer port and are included in the upstream bus report.
- * </p>
- *
- * @author NeqSim
- * @version 1.0
- */
-public class PrimeMover extends EnergyConverter {
+/** Generic fuel-fired prime mover with optional part-load efficiency curve. */
+public class PrimeMover extends LoadMappedEnergyConverter {
   private static final long serialVersionUID = 1000L;
 
-  /**
-   * Creates a prime mover with 35 percent efficiency.
-   *
-   * @param name equipment name
-   */
   public PrimeMover(String name) {
     super(name, EnergyType.CHEMICAL, EnergyType.SHAFT_WORK);
     setEfficiency(0.35);
   }
 
-  /**
-   * Creates a prime mover.
-   *
-   * @param name equipment name
-   * @param efficiency fuel-to-shaft efficiency
-   */
   public PrimeMover(String name, double efficiency) {
     this(name);
     setEfficiency(efficiency);

--- a/src/main/java/neqsim/process/equipment/energy/Transformer.java
+++ b/src/main/java/neqsim/process/equipment/energy/Transformer.java
@@ -4,41 +4,20 @@ import neqsim.process.equipment.stream.EnergyPort;
 import neqsim.process.equipment.stream.EnergyQuality;
 import neqsim.process.equipment.stream.EnergyType;
 
-/**
- * Electrical transformer with power efficiency and voltage ratio.
- *
- * @author NeqSim
- * @version 1.0
- */
-public class Transformer extends EnergyConverter {
+/** Electrical transformer with voltage ratio and optional part-load efficiency curve. */
+public class Transformer extends LoadMappedEnergyConverter {
   private static final long serialVersionUID = 1000L;
-
   private double voltageRatio = 1.0;
 
-  /**
-   * Creates a transformer with 99 percent efficiency.
-   *
-   * @param name equipment name
-   */
   public Transformer(String name) {
     super(name, EnergyType.ELECTRICAL, EnergyType.ELECTRICAL);
     setEfficiency(0.99);
   }
 
-  /**
-   * Gets secondary-to-primary voltage ratio.
-   *
-   * @return voltage ratio
-   */
   public double getVoltageRatio() {
     return voltageRatio;
   }
 
-  /**
-   * Sets secondary-to-primary voltage ratio and updates connected output quality.
-   *
-   * @param voltageRatio positive voltage ratio
-   */
   public void setVoltageRatio(double voltageRatio) {
     if (!Double.isFinite(voltageRatio) || voltageRatio <= 0.0) {
       throw new IllegalArgumentException("Voltage ratio must be positive and finite");
@@ -47,7 +26,6 @@ public class Transformer extends EnergyConverter {
     updateOutputQuality();
   }
 
-  /** Updates connected output voltage and preserves input frequency. */
   private void updateOutputQuality() {
     EnergyPort input = getEnergyPort(INPUT_PORT);
     EnergyPort output = getEnergyPort(OUTPUT_PORT);

--- a/src/main/java/neqsim/process/equipment/energy/UtilityEnergyBus.java
+++ b/src/main/java/neqsim/process/equipment/energy/UtilityEnergyBus.java
@@ -23,6 +23,9 @@ public class UtilityEnergyBus extends EnergyBus {
    */
   public UtilityEnergyBus(String name, UtilityLevel utilityLevel) {
     super(name, EnergyType.HEAT);
+    if (utilityLevel == null || utilityLevel == UtilityLevel.UNSPECIFIED) {
+      throw new IllegalArgumentException("A specified utility level is required");
+    }
     getQuality().setUtilityLevel(utilityLevel);
   }
 
@@ -36,7 +39,7 @@ public class UtilityEnergyBus extends EnergyBus {
    */
   public UtilityEnergyBus(String name, UtilityLevel utilityLevel, double supplyTemperature, double returnTemperature) {
     this(name, utilityLevel);
-    getQuality().setTemperature(supplyTemperature);
+    setSupplyTemperature(supplyTemperature);
     setReturnTemperature(returnTemperature);
   }
 

--- a/src/test/java/neqsim/process/equipment/energy/ElectricMotorPerformanceIntegrationTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/ElectricMotorPerformanceIntegrationTest.java
@@ -1,0 +1,131 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.compressor.driver.ElectricMotorDriver;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
+
+class ElectricMotorPerformanceIntegrationTest {
+
+  @Test
+  void testPartLoadEfficiencyIsUsedForInverseElectricalSizing() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    ElectricMotor motor = new ElectricMotor("part-load motor");
+    motor.setPerformanceModel(performance);
+    motor.setOperatingSpeed(3000.0);
+
+    double expectedEfficiency = 0.96 * 0.85;
+    double requiredInput = motor.getRequiredInputPowerForOutput(250.0e3);
+
+    assertEquals(expectedEfficiency, motor.getEfficiencyAtOutputPower(250.0e3), 1.0e-12);
+    assertEquals(250.0e3 / expectedEfficiency, requiredInput, 1.0e-9);
+  }
+
+  @Test
+  void testMotorDriveTrainUsesPerformanceModelForRequestedInput() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    ElectricMotor motor = new ElectricMotor("drive motor");
+    motor.setPerformanceModel(performance);
+
+    Compressor compressor = new Compressor("compressor");
+    EnergyBus electricalBus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("compressor shaft");
+    shaft.setSpeed(3000.0);
+    MotorDriveTrain driveTrain = new MotorDriveTrain(motor, compressor, electricalBus, shaft);
+
+    driveTrain.setRequestedShaftPower(250.0e3);
+
+    assertEquals(motor.getRequiredInputPowerForOutput(250.0e3),
+        motor.getEnergyPort(EnergyConverter.INPUT_PORT).getRequestedPower(), 1.0e-9);
+    assertEquals(250.0e3, compressor.getEnergyPort("shaftPower").getRequestedPower(), 1.0e-9);
+  }
+
+  @Test
+  void testAmbientDeratingCapsRealizedMotorOutputAndPreservesConservation() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    performance.setAmbientTemperature(50.0);
+
+    EnergyBus electricalBus = new EnergyBus("derated electrical bus", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("derated motor shaft");
+    shaft.setSpeed(3000.0);
+    EnergyPort source = port("grid", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, electricalBus);
+
+    ElectricMotor motor = new ElectricMotor("derated motor");
+    motor.setPerformanceModel(performance);
+    motor.connectEnergyStream(EnergyConverter.INPUT_PORT, electricalBus, EnergyPortMode.SPECIFICATION);
+    motor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, shaft, EnergyPortMode.CALCULATED);
+    motor.setRequestedInputPower(2.0e6);
+    source.setDuty(2.0e6);
+
+    electricalBus.solveBalance();
+    motor.run(UUID.randomUUID());
+
+    assertEquals(800.0e3, motor.getAvailableShaftPower(), 1.0e-9);
+    assertEquals(800.0e3, motor.getOutputPower(), 1.0e-6);
+    assertEquals(motor.getRequiredInputPowerForOutput(800.0e3), motor.getInputPower(), 1.0e-6);
+    assertTrue(motor.getInputPower() < 2.0e6);
+    assertEquals(motor.getInputPower(), motor.getOutputPower() + motor.getHeatLoss(), 1.0e-9);
+    assertEquals(motor.getOutputPower() / motor.getInputPower(), motor.getOperatingEfficiency(), 1.0e-12);
+  }
+
+  @Test
+  void testFixedSpeedViolationBecomesValidWhenVfdRangeIsEnabled() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    EnergyBus electricalBus = new EnergyBus("vfd electrical bus", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("variable speed shaft");
+    shaft.setSpeed(1500.0);
+
+    ElectricMotor motor = new ElectricMotor("VFD motor");
+    motor.setPerformanceModel(performance);
+    motor.connectEnergyStream(EnergyConverter.INPUT_PORT, electricalBus, EnergyPortMode.SPECIFICATION);
+    motor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, shaft, EnergyPortMode.CALCULATED);
+
+    assertFalse(motor.validateSetup().isValid());
+    assertEquals(0.0, motor.getAvailableShaftPower(), 1.0e-12);
+
+    performance.setMinSpeedRatio(0.3);
+    performance.setMaxSpeedRatio(1.2);
+    performance.setHasVFD(true);
+
+    assertTrue(motor.validateSetup().isValid());
+    assertEquals(500.0e3, motor.getAvailableShaftPower(), 1.0e-9);
+  }
+
+  @Test
+  void testRequestedOutputAboveDeratedCapabilityIsRejected() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    performance.setAmbientTemperature(50.0);
+    ElectricMotor motor = new ElectricMotor("capacity-limited motor");
+    motor.setPerformanceModel(performance);
+    motor.setOperatingSpeed(3000.0);
+
+    assertThrows(IllegalArgumentException.class, () -> motor.getRequiredInputPowerForOutput(800.1e3));
+  }
+
+  @Test
+  void testClearingPerformanceModelRestoresConstantEfficiency() {
+    ElectricMotor motor = new ElectricMotor("fallback motor", 0.95);
+    motor.setPerformanceModel(new ElectricMotorDriver(1000.0, 3000.0, 0.96));
+    motor.clearPerformanceModel();
+
+    assertFalse(motor.hasPerformanceModel());
+    assertEquals(100.0e3 / 0.95, motor.getRequiredInputPowerForOutput(100.0e3), 1.0e-9);
+  }
+
+  private static EnergyPort port(String owner, EnergyPortDirection direction, EnergyPortMode mode, EnergyBus bus) {
+    EnergyPort port = new EnergyPort("power", EnergyType.ELECTRICAL, direction, mode);
+    port.setOwnerName(owner);
+    port.connect(bus);
+    return port;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/energy/ElectricMotorPerformanceIntegrationTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/ElectricMotorPerformanceIntegrationTest.java
@@ -79,6 +79,20 @@ class ElectricMotorPerformanceIntegrationTest {
   }
 
   @Test
+  void testAltitudeDeratingIsAppliedAtStandardAmbientTemperature() {
+    ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
+    performance.setAmbientTemperature(15.0);
+    performance.setAltitude(2000.0);
+
+    ElectricMotor motor = new ElectricMotor("high-altitude motor");
+    motor.setPerformanceModel(performance);
+    motor.setOperatingSpeed(3000.0);
+
+    assertEquals(900.0e3, motor.getAvailableShaftPower(), 1.0e-9);
+    assertThrows(IllegalArgumentException.class, () -> motor.getRequiredInputPowerForOutput(900.1e3));
+  }
+
+  @Test
   void testFixedSpeedViolationBecomesValidWhenVfdRangeIsEnabled() {
     ElectricMotorDriver performance = new ElectricMotorDriver(1000.0, 3000.0, 0.96);
     EnergyBus electricalBus = new EnergyBus("vfd electrical bus", EnergyType.ELECTRICAL);

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
@@ -1,0 +1,138 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.expander.Expander;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.equipment.stream.MechanicalShaft;
+import neqsim.process.equipment.stream.UtilityLevel;
+
+class EnergyNetworkProfessionalHardeningTest {
+
+  @Test
+  void testTransientConverterOutputIsLimitedByAvailableInput() {
+    EnergyBus inputBus = new EnergyBus("input bus", EnergyType.ELECTRICAL);
+    EnergyBus outputBus = new EnergyBus("output bus", EnergyType.ELECTRICAL);
+    EnergyPort source = port("source", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED, inputBus);
+
+    Inverter inverter = new Inverter("inverter");
+    inverter.setEfficiency(0.95);
+    inverter.setIdleLoss(10.0);
+    inverter.setRampRate(10.0);
+    inverter.connectEnergyStream(EnergyConverter.INPUT_PORT, inputBus, EnergyPortMode.SPECIFICATION);
+    inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, outputBus, EnergyPortMode.CALCULATED);
+    inverter.setRequestedInputPower(1000.0);
+
+    source.setDuty(1000.0);
+    inputBus.solveBalance();
+    inverter.run(UUID.randomUUID());
+    assertEquals(940.5, inverter.getOutputPower(), 1.0e-12);
+
+    source.setDuty(100.0);
+    inputBus.solveBalance();
+    inverter.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(100.0, inverter.getInputPower(), 1.0e-12);
+    assertEquals(85.5, inverter.getOutputPower(), 1.0e-12);
+    assertEquals(14.5, inverter.getHeatLoss(), 1.0e-12);
+    assertEquals(inverter.getInputPower(), inverter.getOutputPower() + inverter.getHeatLoss(), 1.0e-12);
+    assertThrows(IllegalArgumentException.class, () -> inverter.runTransient(-1.0, UUID.randomUUID()));
+  }
+
+  @Test
+  void testInverterQualityUpdatePreservesExistingMetadata() {
+    EnergyBus outputBus = new EnergyBus("quality bus", EnergyType.ELECTRICAL);
+    outputBus.getQuality().setTemperature(320.0);
+    outputBus.getQuality().setPressure(2.0e5);
+
+    Inverter inverter = new Inverter("quality inverter");
+    inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, outputBus, EnergyPortMode.CALCULATED);
+    inverter.setOutputElectricalQuality(690.0, 50.0);
+
+    assertEquals(690.0, outputBus.getQuality().getVoltage(), 1.0e-12);
+    assertEquals(50.0, outputBus.getQuality().getFrequency(), 1.0e-12);
+    assertEquals(320.0, outputBus.getQuality().getTemperature(), 1.0e-12);
+    assertEquals(2.0e5, outputBus.getQuality().getPressure(), 1.0e-12);
+  }
+
+  @Test
+  void testInverterPublishesQualityWhenConfiguredBeforeConnection() {
+    Inverter inverter = new Inverter("late-connected inverter");
+    inverter.setOutputElectricalQuality(400.0, 60.0);
+
+    EnergyBus outputBus = new EnergyBus("late output", EnergyType.ELECTRICAL);
+    outputBus.getQuality().setTemperature(315.0);
+    inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, outputBus, EnergyPortMode.CALCULATED);
+    inverter.run(UUID.randomUUID());
+
+    assertEquals(400.0, outputBus.getQuality().getVoltage(), 1.0e-12);
+    assertEquals(60.0, outputBus.getQuality().getFrequency(), 1.0e-12);
+    assertEquals(315.0, outputBus.getQuality().getTemperature(), 1.0e-12);
+  }
+
+  @Test
+  void testMotorDriveTrainDetectsMotorOutputRewiring() {
+    ElectricMotor motor = new ElectricMotor("motor");
+    Compressor compressor = new Compressor("compressor");
+    EnergyBus electricalBus = new EnergyBus("electrical bus", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("configured shaft");
+    MotorDriveTrain driveTrain = new MotorDriveTrain(motor, compressor, electricalBus, shaft);
+
+    assertTrue(driveTrain.validateSetup().isValid());
+
+    MechanicalShaft wrongShaft = new MechanicalShaft("wrong shaft");
+    motor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, wrongShaft, EnergyPortMode.CALCULATED);
+
+    assertFalse(driveTrain.validateSetup().isValid());
+    assertTrue(driveTrain.validateSetup().getReport().contains("Motor is not connected to the configured shaft"));
+  }
+
+  @Test
+  void testMotorAssistedDriveTrainDetectsAssistMotorOutputRewiring() {
+    Expander expander = new Expander("expander");
+    Compressor compressor = new Compressor("compressor");
+    ElectricMotor assistMotor = new ElectricMotor("assist motor");
+    EnergyBus electricalBus = new EnergyBus("assist electrical bus", EnergyType.ELECTRICAL);
+    MechanicalShaft shaft = new MechanicalShaft("common shaft");
+    MotorAssistedDriveTrain driveTrain =
+        new MotorAssistedDriveTrain(expander, compressor, assistMotor, electricalBus, shaft);
+
+    assertTrue(driveTrain.validateSetup().isValid());
+
+    MechanicalShaft wrongShaft = new MechanicalShaft("wrong assist shaft");
+    assistMotor.connectEnergyStream(EnergyConverter.OUTPUT_PORT, wrongShaft, EnergyPortMode.CALCULATED);
+
+    assertFalse(driveTrain.validateSetup().isValid());
+    assertTrue(driveTrain.validateSetup().getReport().contains("Assist motor is not connected to the common shaft"));
+  }
+
+  @Test
+  void testUtilityEnergyBusRequiresSpecifiedGrade() {
+    assertThrows(IllegalArgumentException.class, () -> new UtilityEnergyBus("null utility", null));
+    assertThrows(IllegalArgumentException.class,
+        () -> new UtilityEnergyBus("unspecified utility", UtilityLevel.UNSPECIFIED));
+
+    UtilityEnergyBus steam = new UtilityEnergyBus("LP steam", UtilityLevel.LOW_PRESSURE_STEAM, 425.0, 383.0);
+    assertEquals(UtilityLevel.LOW_PRESSURE_STEAM, steam.getUtilityLevel());
+    assertEquals(425.0, steam.getSupplyTemperature(), 1.0e-12);
+    assertEquals(383.0, steam.getReturnTemperature(), 1.0e-12);
+  }
+
+  private static EnergyPort port(String owner, EnergyType type, EnergyPortDirection direction, EnergyPortMode mode,
+      EnergyBus bus) {
+    EnergyPort port = new EnergyPort("power", type, direction, mode);
+    port.setOwnerName(owner);
+    port.connect(bus);
+    return port;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
@@ -72,8 +72,7 @@ class EnergyNetworkProfessionalHardeningTest {
     inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, outputBus, EnergyPortMode.CALCULATED);
     inverter.setOutputElectricalQuality(690.0, 50.0);
 
-    assertThrows(IllegalArgumentException.class,
-        () -> inverter.setOutputElectricalQuality(Double.NaN, 50.0));
+    assertThrows(IllegalArgumentException.class, () -> inverter.setOutputElectricalQuality(Double.NaN, 50.0));
     assertThrows(IllegalArgumentException.class, () -> inverter.setOutputElectricalQuality(690.0, 0.0));
     assertEquals(690.0, inverter.getOutputVoltage(), 1.0e-12);
     assertEquals(50.0, inverter.getOutputFrequency(), 1.0e-12);

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
@@ -47,6 +47,9 @@ class EnergyNetworkProfessionalHardeningTest {
     assertEquals(14.5, inverter.getHeatLoss(), 1.0e-12);
     assertEquals(inverter.getInputPower(), inverter.getOutputPower() + inverter.getHeatLoss(), 1.0e-12);
     assertThrows(IllegalArgumentException.class, () -> inverter.runTransient(-1.0, UUID.randomUUID()));
+    assertThrows(IllegalArgumentException.class, () -> inverter.runTransient(Double.NaN, UUID.randomUUID()));
+    assertThrows(IllegalArgumentException.class,
+        () -> inverter.runTransient(Double.POSITIVE_INFINITY, UUID.randomUUID()));
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
@@ -22,8 +22,8 @@ class EnergyNetworkProfessionalHardeningTest {
   void testTransientConverterOutputIsLimitedByAvailableInput() {
     EnergyBus inputBus = new EnergyBus("input bus", EnergyType.ELECTRICAL);
     EnergyBus outputBus = new EnergyBus("output bus", EnergyType.ELECTRICAL);
-    EnergyPort source = port("source", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT,
-        EnergyPortMode.CALCULATED, inputBus);
+    EnergyPort source = port("source", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED,
+        inputBus);
 
     Inverter inverter = new Inverter("inverter");
     inverter.setEfficiency(0.95);
@@ -104,8 +104,8 @@ class EnergyNetworkProfessionalHardeningTest {
     ElectricMotor assistMotor = new ElectricMotor("assist motor");
     EnergyBus electricalBus = new EnergyBus("assist electrical bus", EnergyType.ELECTRICAL);
     MechanicalShaft shaft = new MechanicalShaft("common shaft");
-    MotorAssistedDriveTrain driveTrain =
-        new MotorAssistedDriveTrain(expander, compressor, assistMotor, electricalBus, shaft);
+    MotorAssistedDriveTrain driveTrain = new MotorAssistedDriveTrain(expander, compressor, assistMotor, electricalBus,
+        shaft);
 
     assertTrue(driveTrain.validateSetup().isValid());
 

--- a/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyNetworkProfessionalHardeningTest.java
@@ -66,6 +66,22 @@ class EnergyNetworkProfessionalHardeningTest {
   }
 
   @Test
+  void testInverterRejectsInvalidSetpointsWithoutChangingConfiguredQuality() {
+    EnergyBus outputBus = new EnergyBus("validated quality bus", EnergyType.ELECTRICAL);
+    Inverter inverter = new Inverter("validated inverter");
+    inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, outputBus, EnergyPortMode.CALCULATED);
+    inverter.setOutputElectricalQuality(690.0, 50.0);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> inverter.setOutputElectricalQuality(Double.NaN, 50.0));
+    assertThrows(IllegalArgumentException.class, () -> inverter.setOutputElectricalQuality(690.0, 0.0));
+    assertEquals(690.0, inverter.getOutputVoltage(), 1.0e-12);
+    assertEquals(50.0, inverter.getOutputFrequency(), 1.0e-12);
+    assertEquals(690.0, outputBus.getQuality().getVoltage(), 1.0e-12);
+    assertEquals(50.0, outputBus.getQuality().getFrequency(), 1.0e-12);
+  }
+
+  @Test
   void testInverterPublishesQualityWhenConfiguredBeforeConnection() {
     Inverter inverter = new Inverter("late-connected inverter");
     inverter.setOutputElectricalQuality(400.0, 60.0);

--- a/src/test/java/neqsim/process/equipment/energy/LoadMappedEnergyConverterTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/LoadMappedEnergyConverterTest.java
@@ -1,0 +1,83 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+
+class LoadMappedEnergyConverterTest {
+
+  private static final LoadEfficiencyCurve CURVE =
+      new LoadEfficiencyCurve(new double[] {0.25, 0.5, 1.0}, new double[] {0.80, 0.90, 0.96});
+
+  @Test
+  void testCurveInterpolationAndValidation() {
+    assertEquals(0.80, CURVE.getEfficiency(0.1), 1.0e-12);
+    assertEquals(0.85, CURVE.getEfficiency(0.375), 1.0e-12);
+    assertEquals(0.96, CURVE.getEfficiency(1.2), 1.0e-12);
+    assertThrows(IllegalArgumentException.class,
+        () -> new LoadEfficiencyCurve(new double[] {0.5, 0.5}, new double[] {0.9, 0.95}));
+  }
+
+  @Test
+  void testGeneratorInverseSizingAndForwardConversion() {
+    Generator generator = new Generator("generator");
+    generator.setRatedOutputPower(1.0e6);
+    generator.setLoadEfficiencyCurve(CURVE);
+
+    assertEquals(500.0e3 / 0.90, generator.getRequiredInputPowerForOutput(500.0e3), 1.0e-9);
+
+    EnergyBus shaft = new EnergyBus("shaft", EnergyType.SHAFT_WORK);
+    EnergyBus grid = new EnergyBus("grid", EnergyType.ELECTRICAL);
+    EnergyPort source = source("source", shaft);
+    generator.connectEnergyStream(EnergyConverter.INPUT_PORT, shaft, EnergyPortMode.SPECIFICATION);
+    generator.connectEnergyStream(EnergyConverter.OUTPUT_PORT, grid, EnergyPortMode.CALCULATED);
+    generator.setRequestedInputPower(500.0e3 / 0.90);
+    source.setDuty(500.0e3 / 0.90);
+    shaft.solveBalance();
+    generator.run(UUID.randomUUID());
+
+    assertEquals(500.0e3, generator.getOutputPower(), 1.0e-5);
+    assertEquals(generator.getInputPower(), generator.getOutputPower() + generator.getHeatLoss(), 1.0e-9);
+  }
+
+  @Test
+  void testTransformerAndPrimeMoverUseSameCurveContract() {
+    Transformer transformer = new Transformer("transformer");
+    transformer.setRatedOutputPower(10.0e6);
+    transformer.setLoadEfficiencyCurve(CURVE);
+    assertEquals(2.5e6 / 0.80, transformer.getRequiredInputPowerForOutput(2.5e6), 1.0e-9);
+
+    PrimeMover primeMover = new PrimeMover("prime mover");
+    primeMover.setRatedOutputPower(5.0e6);
+    primeMover.setLoadEfficiencyCurve(CURVE);
+    assertEquals(5.0e6 / 0.96, primeMover.getRequiredInputPowerForOutput(5.0e6), 1.0e-9);
+    assertThrows(IllegalArgumentException.class,
+        () -> primeMover.getRequiredInputPowerForOutput(5.1e6));
+  }
+
+  @Test
+  void testCurveRequiresRatingAndCanBeCleared() {
+    Generator generator = new Generator("fallback", 0.97);
+    generator.setLoadEfficiencyCurve(CURVE);
+    assertThrows(IllegalStateException.class,
+        () -> generator.getRequiredInputPowerForOutput(100.0e3));
+    generator.clearLoadEfficiencyCurve();
+    assertFalse(generator.hasLoadEfficiencyCurve());
+    assertEquals(100.0e3 / 0.97, generator.getRequiredInputPowerForOutput(100.0e3), 1.0e-9);
+  }
+
+  private static EnergyPort source(String owner, EnergyBus bus) {
+    EnergyPort port = new EnergyPort("power", bus.getEnergyType(), EnergyPortDirection.OUTPUT,
+        EnergyPortMode.CALCULATED);
+    port.setOwnerName(owner);
+    port.connect(bus);
+    return port;
+  }
+}


### PR DESCRIPTION
## Summary

Completes the remaining converter capability-map stage:

- reusable immutable `LoadEfficiencyCurve`
- shared `LoadMappedEnergyConverter` implementation
- optional part-load performance for `Generator`, `Transformer`, and `PrimeMover`
- rated useful-output capacity
- endpoint clamping and linear interpolation
- inverse input sizing from requested useful output
- bounded forward conversion with energy conservation
- explicit rejection above rated output
- constant-efficiency fallback remains unchanged
- professional-use documentation

## Validation coverage

- interpolation, endpoint clamping, and invalid curve definitions
- generator inverse sizing and forward conversion
- input = useful output + heat loss
- transformer and prime-mover use of the same curve contract
- rated-output enforcement
- missing rating and curve-clearing behavior

## Dependency

This is stacked on PR #2609 because it reuses the extensible converter hooks introduced for detailed electric-motor performance. Retarget to `master` after #2609 merges.