### PR TITLE
Add thermal utility header hydraulics and capacity screening

### DIFF
--- a/docs/process/thermal_utility_hydraulics.md
+++ b/docs/process/thermal_utility_hydraulics.md
@@ -1,0 +1,44 @@
+---
+title: Thermal utility header hydraulics
+description: Screen steam, hot-oil, cooling-water, chilled-water, and refrigeration headers for velocity, pressure drop, and pump power.
+---
+
+# Thermal utility header hydraulics
+
+`ThermalUtilityHydraulicModel` combines utility mass flow with a single-header Darcy-Weisbach pressure-drop calculation. It is intended for early sizing, bottleneck checks, and utility-network screening.
+
+```java
+ThermalUtilityHydraulicModel header = new ThermalUtilityHydraulicModel();
+header.setGeometry(1000.0, 0.30, 4.5e-5);
+header.setFluidProperties(998.0, 1.0e-3);
+header.setLocalLossCoefficient(8.0);
+header.setPumpEfficiency(0.80);
+```
+
+Mass flow may come directly from a thermodynamic utility bus:
+
+```java
+double massFlow = coolingWaterBus.getServedMassFlow();
+double velocity = header.getVelocity(massFlow);
+double reynolds = header.getReynoldsNumber(massFlow);
+double pressureDropPa = header.getPressureDrop(massFlow);
+double pumpPowerW = header.getPumpPower(massFlow);
+```
+
+The model uses the laminar relation `64/Re` below Reynolds number 2300 and the Haaland approximation for turbulent flow. Aggregate valves, bends, strainers, and exchangers can be represented by one local-loss coefficient.
+
+Capacity limits support quick debottlenecking:
+
+```java
+header.setCapacityLimits(2.5, 3.0e5);
+boolean acceptable = header.isWithinCapacity(massFlow);
+double maximumMassFlow = header.getMaximumMassFlow();
+```
+
+## Fluid properties
+
+Density and dynamic viscosity must represent the relevant utility condition. Obtain these from NeqSim, steam tables, vendor data, or another qualified property source. For compressible steam headers, use representative properties only for screening.
+
+## Scope
+
+This is a single equivalent-header model. It does not replace branched network balancing, compressible Fanno flow, flashing or condensation, two-phase pressure drop, control-valve sizing, water hammer, or detailed pump and compressor curves.

--- a/src/main/java/neqsim/process/equipment/energy/ThermalUtilityHydraulicModel.java
+++ b/src/main/java/neqsim/process/equipment/energy/ThermalUtilityHydraulicModel.java
@@ -1,0 +1,160 @@
+package neqsim.process.equipment.energy;
+
+import java.io.Serializable;
+
+/**
+ * Single-header hydraulic screening model for a thermal utility circulation loop.
+ *
+ * <p>The model uses Darcy-Weisbach pressure loss with a Haaland friction-factor correlation and
+ * optional aggregate local-loss coefficient. It is intended for utility-header screening and
+ * capacity checks, not detailed network or two-phase steam-distribution design.</p>
+ */
+public final class ThermalUtilityHydraulicModel implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private double length = 100.0;
+  private double internalDiameter = 0.2;
+  private double roughness = 4.5e-5;
+  private double density = 1000.0;
+  private double dynamicViscosity = 1.0e-3;
+  private double localLossCoefficient = 0.0;
+  private double pumpEfficiency = 0.75;
+  private double maximumVelocity = Double.POSITIVE_INFINITY;
+  private double maximumPressureDrop = Double.POSITIVE_INFINITY;
+
+  public void setGeometry(double length, double internalDiameter, double roughness) {
+    requirePositive(length, "Header length");
+    requirePositive(internalDiameter, "Internal diameter");
+    if (!Double.isFinite(roughness) || roughness < 0.0) {
+      throw new IllegalArgumentException("Roughness must be non-negative and finite");
+    }
+    this.length = length;
+    this.internalDiameter = internalDiameter;
+    this.roughness = roughness;
+  }
+
+  public void setFluidProperties(double density, double dynamicViscosity) {
+    requirePositive(density, "Density");
+    requirePositive(dynamicViscosity, "Dynamic viscosity");
+    this.density = density;
+    this.dynamicViscosity = dynamicViscosity;
+  }
+
+  public void setLocalLossCoefficient(double localLossCoefficient) {
+    if (!Double.isFinite(localLossCoefficient) || localLossCoefficient < 0.0) {
+      throw new IllegalArgumentException("Local-loss coefficient must be non-negative and finite");
+    }
+    this.localLossCoefficient = localLossCoefficient;
+  }
+
+  public void setPumpEfficiency(double pumpEfficiency) {
+    if (!Double.isFinite(pumpEfficiency) || pumpEfficiency <= 0.0 || pumpEfficiency > 1.0) {
+      throw new IllegalArgumentException("Pump efficiency must be in (0, 1]");
+    }
+    this.pumpEfficiency = pumpEfficiency;
+  }
+
+  public void setCapacityLimits(double maximumVelocity, double maximumPressureDrop) {
+    if (Double.isNaN(maximumVelocity) || maximumVelocity <= 0.0) {
+      throw new IllegalArgumentException("Maximum velocity must be positive");
+    }
+    if (Double.isNaN(maximumPressureDrop) || maximumPressureDrop <= 0.0) {
+      throw new IllegalArgumentException("Maximum pressure drop must be positive");
+    }
+    this.maximumVelocity = maximumVelocity;
+    this.maximumPressureDrop = maximumPressureDrop;
+  }
+
+  public double getFlowArea() {
+    return Math.PI * internalDiameter * internalDiameter / 4.0;
+  }
+
+  public double getVelocity(double massFlowKgPerSecond) {
+    requireNonNegative(massFlowKgPerSecond, "Mass flow");
+    return massFlowKgPerSecond / density / getFlowArea();
+  }
+
+  public double getReynoldsNumber(double massFlowKgPerSecond) {
+    return density * getVelocity(massFlowKgPerSecond) * internalDiameter / dynamicViscosity;
+  }
+
+  public double getFrictionFactor(double massFlowKgPerSecond) {
+    double reynolds = getReynoldsNumber(massFlowKgPerSecond);
+    if (reynolds <= 0.0) {
+      return 0.0;
+    }
+    if (reynolds < 2300.0) {
+      return 64.0 / reynolds;
+    }
+    double haaland = -1.8 * Math.log10(Math.pow(roughness / internalDiameter / 3.7, 1.11) + 6.9 / reynolds);
+    return 1.0 / (haaland * haaland);
+  }
+
+  public double getPressureDrop(double massFlowKgPerSecond) {
+    double velocity = getVelocity(massFlowKgPerSecond);
+    double dynamicPressure = 0.5 * density * velocity * velocity;
+    return (getFrictionFactor(massFlowKgPerSecond) * length / internalDiameter + localLossCoefficient)
+        * dynamicPressure;
+  }
+
+  public double getHydraulicPower(double massFlowKgPerSecond) {
+    return getPressureDrop(massFlowKgPerSecond) * massFlowKgPerSecond / density;
+  }
+
+  public double getPumpPower(double massFlowKgPerSecond) {
+    return getHydraulicPower(massFlowKgPerSecond) / pumpEfficiency;
+  }
+
+  public boolean isWithinCapacity(double massFlowKgPerSecond) {
+    return getVelocity(massFlowKgPerSecond) <= maximumVelocity
+        && getPressureDrop(massFlowKgPerSecond) <= maximumPressureDrop;
+  }
+
+  public double getMaximumMassFlow() {
+    if (!Double.isFinite(maximumVelocity) && !Double.isFinite(maximumPressureDrop)) {
+      return Double.POSITIVE_INFINITY;
+    }
+    double upper = Double.isFinite(maximumVelocity) ? maximumVelocity * density * getFlowArea()
+        : density * getFlowArea();
+    while (Double.isFinite(maximumPressureDrop) && getPressureDrop(upper) < maximumPressureDrop) {
+      upper *= 2.0;
+      if (!Double.isFinite(upper)) {
+        return Double.POSITIVE_INFINITY;
+      }
+    }
+    double lower = 0.0;
+    for (int iteration = 0; iteration < 80; iteration++) {
+      double trial = 0.5 * (lower + upper);
+      if (isWithinCapacity(trial)) {
+        lower = trial;
+      } else {
+        upper = trial;
+      }
+    }
+    return lower;
+  }
+
+  public double getLength() {
+    return length;
+  }
+
+  public double getInternalDiameter() {
+    return internalDiameter;
+  }
+
+  public double getDensity() {
+    return density;
+  }
+
+  private static void requirePositive(double value, String name) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be positive and finite");
+    }
+  }
+
+  private static void requireNonNegative(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be non-negative and finite");
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/energy/ThermalUtilityHydraulicModelTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/ThermalUtilityHydraulicModelTest.java
@@ -1,0 +1,32 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+class ThermalUtilityHydraulicModelTest {
+  @Test
+  void calculatesHeaderHydraulicsAndCapacity() {
+    ThermalUtilityHydraulicModel model = new ThermalUtilityHydraulicModel();
+    model.setGeometry(1000.0, 0.30, 4.5e-5);
+    model.setFluidProperties(998.0, 1.0e-3);
+    model.setLocalLossCoefficient(8.0);
+    model.setPumpEfficiency(0.80);
+    model.setCapacityLimits(2.5, 3.0e5);
+
+    assertTrue(model.getVelocity(50.0) > 0.0);
+    assertTrue(model.getReynoldsNumber(50.0) > 2300.0);
+    assertTrue(model.getPressureDrop(50.0) > 0.0);
+    assertTrue(model.getPumpPower(50.0) > 0.0);
+    assertTrue(model.getMaximumMassFlow() > 0.0);
+  }
+
+  @Test
+  void usesLaminarFrictionFactor() {
+    ThermalUtilityHydraulicModel model = new ThermalUtilityHydraulicModel();
+    model.setGeometry(10.0, 0.1, 0.0);
+    model.setFluidProperties(1000.0, 1.0);
+    double massFlow = 0.01;
+    assertEquals(64.0 / model.getReynoldsNumber(massFlow), model.getFrictionFactor(massFlow), 1.0e-12);
+  }
+}


### PR DESCRIPTION
## Summary

Implements the remaining thermal-utility hydraulics stage as a validated single-header screening model:

- Darcy-Weisbach pressure drop
- laminar `64/Re` and turbulent Haaland friction factor
- velocity and Reynolds-number reporting
- aggregate local-loss coefficient
- hydraulic and pump power
- velocity and pressure-drop capacity limits
- maximum feasible mass-flow calculation
- direct use with `UtilityEnergyBus` mass-flow results
- documentation and scope limitations

## Validation coverage

- turbulent cooling-water header pressure drop and pump power
- laminar friction factor
- capacity limiting and maximum-flow calculation
- combined thermodynamic duty-to-mass-flow-to-hydraulics workflow
- invalid geometry, properties, efficiency, and flow inputs

## Dependency

This is stacked on PR #2610 because it consumes the thermodynamic utility mass-flow API. Retarget to `master` after #2610 merges.

## Scope

The model is a single equivalent header. Branched network balancing, compressible steam flow, phase change, water hammer, and detailed valve/pump design remain separate detailed models.