### PR TITLE
Add chronological unit-commitment constraints for energy generation

### DIFF
--- a/docs/process/energy_unit_commitment.md
+++ b/docs/process/energy_unit_commitment.md
@@ -1,0 +1,51 @@
+---
+title: Energy unit commitment constraints
+description: Model startup, minimum load, ramps, minimum up/down time, startup cost, and startup emissions.
+---
+
+# Energy unit commitment constraints
+
+`CommittedEnergyGenerator` represents a dispatchable electrical, shaft-work, heat, or other typed generation unit whose output cannot change freely between chronological intervals.
+
+```java
+CommittedEnergyGenerator turbine = new CommittedEnergyGenerator(
+    "gas turbine generator", EnergyType.ELECTRICAL);
+
+turbine.setPowerLimits(5.0e6, 25.0e6);
+turbine.setRampRates(1.0e6, 2.0e6);
+turbine.setMinimumUpDownTimes(4.0 * 3600.0, 2.0 * 3600.0);
+turbine.setStartupPenalty(150000.0, 5000.0);
+turbine.connectEnergyStream(
+    CommittedEnergyGenerator.OUTPUT_PORT,
+    electricalBus,
+    EnergyPortMode.CALCULATED);
+```
+
+Initialize the chronological state before a study:
+
+```java
+turbine.initializeCommitment(false, 3.0 * 3600.0, 0.0);
+```
+
+A positive requested power is an on-command; zero is an off-command:
+
+```java
+turbine.setRequestedPower(20.0e6);
+turbine.runTransient(900.0, calculationId);
+```
+
+The latest immutable `StepResult` reports whether the unit started, stopped, or was blocked by minimum up/down time. The unit also tracks cumulative startup count, cost, and CO2-equivalent emissions.
+
+```java
+CommittedEnergyGenerator.StepResult step = turbine.getLastStepResult();
+double output = step.getGeneratedPower();
+int starts = turbine.getStartupCount();
+double startupCost = turbine.getCumulativeStartupCost();
+double startupEmissions = turbine.getCumulativeStartupEmissionsKg();
+```
+
+During an enforced minimum-up period, an off-command retains at least the minimum stable target. During minimum-down time, an on-command remains blocked. Ramp limits apply between chronological steps.
+
+## Scope
+
+This class enforces one unit's chronological constraints. It does not choose the globally optimal on/off schedule. Combine it with time-series profiles, merit-order dispatch, or a higher-level mixed-integer optimizer for multi-unit commitment studies. Startup trajectories below minimum stable load and detailed thermal-state startup models require equipment-specific dynamic models.

--- a/src/main/java/neqsim/process/equipment/energy/CommittedEnergyGenerator.java
+++ b/src/main/java/neqsim/process/equipment/energy/CommittedEnergyGenerator.java
@@ -1,0 +1,282 @@
+package neqsim.process.equipment.energy;
+
+import java.io.Serializable;
+import java.util.UUID;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.util.validation.ValidationResult;
+
+/**
+ * Dispatchable generation unit with startup, minimum-load, ramp, and minimum up/down constraints.
+ *
+ * <p>The unit publishes calculated generation through {@value #OUTPUT_PORT}. A positive requested
+ * power is an on-command; zero is an off-command. Transient execution applies chronological
+ * commitment constraints and records cumulative startup cost and startup emissions.</p>
+ */
+public class CommittedEnergyGenerator extends ProcessEquipmentBaseClass {
+  private static final long serialVersionUID = 1000L;
+  public static final String OUTPUT_PORT = "energyOutput";
+
+  /** Immutable diagnostic for the latest commitment step. */
+  public static final class StepResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final boolean committed;
+    private final boolean started;
+    private final boolean stopped;
+    private final boolean startBlocked;
+    private final boolean stopBlocked;
+    private final double requestedPower;
+    private final double generatedPower;
+
+    private StepResult(boolean committed, boolean started, boolean stopped, boolean startBlocked,
+        boolean stopBlocked, double requestedPower, double generatedPower) {
+      this.committed = committed;
+      this.started = started;
+      this.stopped = stopped;
+      this.startBlocked = startBlocked;
+      this.stopBlocked = stopBlocked;
+      this.requestedPower = requestedPower;
+      this.generatedPower = generatedPower;
+    }
+
+    public boolean isCommitted() {
+      return committed;
+    }
+
+    public boolean isStarted() {
+      return started;
+    }
+
+    public boolean isStopped() {
+      return stopped;
+    }
+
+    public boolean isStartBlocked() {
+      return startBlocked;
+    }
+
+    public boolean isStopBlocked() {
+      return stopBlocked;
+    }
+
+    public double getRequestedPower() {
+      return requestedPower;
+    }
+
+    public double getGeneratedPower() {
+      return generatedPower;
+    }
+  }
+
+  private final EnergyType outputType;
+  private double requestedPower = 0.0;
+  private double currentPower = 0.0;
+  private double minimumStablePower = 0.0;
+  private double maximumPower = Double.POSITIVE_INFINITY;
+  private double rampUpRate = Double.POSITIVE_INFINITY;
+  private double rampDownRate = Double.POSITIVE_INFINITY;
+  private double minimumUpTime = 0.0;
+  private double minimumDownTime = 0.0;
+  private double timeInState = 0.0;
+  private boolean committed = false;
+  private double startupCost = 0.0;
+  private double startupEmissionsKg = 0.0;
+  private double cumulativeStartupCost = 0.0;
+  private double cumulativeStartupEmissionsKg = 0.0;
+  private int startupCount = 0;
+  private StepResult lastStepResult = new StepResult(false, false, false, false, false, 0.0, 0.0);
+
+  public CommittedEnergyGenerator(String name, EnergyType outputType) {
+    super(name);
+    if (outputType == null || outputType == EnergyType.UNSPECIFIED) {
+      throw new IllegalArgumentException("A specified output energy type is required");
+    }
+    this.outputType = outputType;
+    registerEnergyPort(OUTPUT_PORT, outputType, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED);
+  }
+
+  public void setPowerLimits(double minimumStablePower, double maximumPower) {
+    if (!Double.isFinite(minimumStablePower) || minimumStablePower < 0.0
+        || !Double.isFinite(maximumPower) || maximumPower <= 0.0
+        || minimumStablePower > maximumPower) {
+      throw new IllegalArgumentException("Power limits must be finite and satisfy 0 <= minimum <= maximum");
+    }
+    this.minimumStablePower = minimumStablePower;
+    this.maximumPower = maximumPower;
+  }
+
+  public void setRampRates(double rampUpRate, double rampDownRate) {
+    requirePositiveOrInfinity(rampUpRate, "Ramp-up rate");
+    requirePositiveOrInfinity(rampDownRate, "Ramp-down rate");
+    this.rampUpRate = rampUpRate;
+    this.rampDownRate = rampDownRate;
+  }
+
+  public void setMinimumUpDownTimes(double minimumUpTime, double minimumDownTime) {
+    requireNonNegative(minimumUpTime, "Minimum up time");
+    requireNonNegative(minimumDownTime, "Minimum down time");
+    this.minimumUpTime = minimumUpTime;
+    this.minimumDownTime = minimumDownTime;
+  }
+
+  public void setStartupPenalty(double startupCost, double startupEmissionsKg) {
+    requireNonNegative(startupCost, "Startup cost");
+    requireNonNegative(startupEmissionsKg, "Startup emissions");
+    this.startupCost = startupCost;
+    this.startupEmissionsKg = startupEmissionsKg;
+  }
+
+  public void setRequestedPower(double requestedPower) {
+    if (!Double.isFinite(requestedPower) || requestedPower < 0.0) {
+      throw new IllegalArgumentException("Requested power must be non-negative and finite");
+    }
+    this.requestedPower = requestedPower;
+  }
+
+  public double getRequestedPower() {
+    return requestedPower;
+  }
+
+  public double getCurrentPower() {
+    return currentPower;
+  }
+
+  public boolean isCommitted() {
+    return committed;
+  }
+
+  public double getTimeInState() {
+    return timeInState;
+  }
+
+  public int getStartupCount() {
+    return startupCount;
+  }
+
+  public double getCumulativeStartupCost() {
+    return cumulativeStartupCost;
+  }
+
+  public double getCumulativeStartupEmissionsKg() {
+    return cumulativeStartupEmissionsKg;
+  }
+
+  public StepResult getLastStepResult() {
+    return lastStepResult;
+  }
+
+  /** Initializes chronological state before a study. */
+  public void initializeCommitment(boolean committed, double timeInState, double initialPower) {
+    requireNonNegative(timeInState, "Time in state");
+    requireNonNegative(initialPower, "Initial power");
+    if (!committed && initialPower > 0.0) {
+      throw new IllegalArgumentException("An offline unit cannot have positive initial power");
+    }
+    if (committed && (initialPower < minimumStablePower || initialPower > maximumPower)) {
+      throw new IllegalArgumentException("Initial online power must be within configured power limits");
+    }
+    this.committed = committed;
+    this.timeInState = timeInState;
+    this.currentPower = initialPower;
+    publish();
+  }
+
+  @Override
+  public void run(UUID id) {
+    runTransient(0.0, id);
+  }
+
+  @Override
+  public void runTransient(double dt, UUID id) {
+    requireNonNegative(dt, "Commitment timestep");
+    boolean wantsOn = requestedPower > 0.0;
+    boolean started = false;
+    boolean stopped = false;
+    boolean startBlocked = false;
+    boolean stopBlocked = false;
+
+    if (wantsOn && !committed) {
+      if (timeInState >= minimumDownTime) {
+        committed = true;
+        timeInState = 0.0;
+        started = true;
+        startupCount++;
+        cumulativeStartupCost += startupCost;
+        cumulativeStartupEmissionsKg += startupEmissionsKg;
+      } else {
+        startBlocked = true;
+      }
+    } else if (!wantsOn && committed) {
+      if (timeInState >= minimumUpTime) {
+        committed = false;
+        timeInState = 0.0;
+        stopped = true;
+      } else {
+        stopBlocked = true;
+      }
+    }
+
+    double target = 0.0;
+    if (committed) {
+      target = wantsOn ? Math.max(minimumStablePower, Math.min(maximumPower, requestedPower))
+          : minimumStablePower;
+    }
+    double maximumIncrease = rampUpRate * dt;
+    double maximumDecrease = rampDownRate * dt;
+    if (target > currentPower && Double.isFinite(maximumIncrease)) {
+      currentPower = Math.min(target, currentPower + maximumIncrease);
+    } else if (target < currentPower && Double.isFinite(maximumDecrease)) {
+      currentPower = Math.max(target, currentPower - maximumDecrease);
+    } else {
+      currentPower = target;
+    }
+    if (!committed && currentPower <= Math.max(1.0e-9, maximumPower * 1.0e-12)) {
+      currentPower = 0.0;
+    }
+
+    timeInState += dt;
+    publish();
+    lastStepResult = new StepResult(committed, started, stopped, startBlocked, stopBlocked,
+        requestedPower, currentPower);
+    increaseTime(dt);
+    setCalculationIdentifier(id);
+  }
+
+  private void publish() {
+    if (getEnergyPort(OUTPUT_PORT).isConnected()) {
+      getEnergyPort(OUTPUT_PORT).setDuty(currentPower);
+    }
+  }
+
+  @Override
+  public ValidationResult validateSetup() {
+    ValidationResult result = new ValidationResult(getName());
+    if (!Double.isFinite(maximumPower)) {
+      result.addError("energy", "Maximum committed-unit power is not configured",
+          "Call setPowerLimits(minimumStablePower, maximumPower)");
+    }
+    if (!getEnergyPort(OUTPUT_PORT).isConnected()) {
+      result.addWarning("energy", "Committed generation output is not connected",
+          "Connect energyOutput to an EnergyBus");
+    }
+    return result;
+  }
+
+  public EnergyType getOutputType() {
+    return outputType;
+  }
+
+  private static void requireNonNegative(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be non-negative and finite");
+    }
+  }
+
+  private static void requirePositiveOrInfinity(double value, String name) {
+    if (Double.isNaN(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be positive");
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/energy/CommittedEnergyGeneratorTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/CommittedEnergyGeneratorTest.java
@@ -1,0 +1,102 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+
+class CommittedEnergyGeneratorTest {
+
+  @Test
+  void testMinimumDownTimeBlocksStartThenStartupPenaltyIsRecorded() {
+    CommittedEnergyGenerator unit = configuredUnit();
+    unit.initializeCommitment(false, 300.0, 0.0);
+    unit.setRequestedPower(8.0e6);
+
+    unit.runTransient(300.0, UUID.randomUUID());
+    assertFalse(unit.isCommitted());
+    assertTrue(unit.getLastStepResult().isStartBlocked());
+    assertEquals(0.0, unit.getCurrentPower(), 1.0e-12);
+
+    unit.runTransient(1.0, UUID.randomUUID());
+    assertTrue(unit.isCommitted());
+    assertTrue(unit.getLastStepResult().isStarted());
+    assertEquals(1, unit.getStartupCount());
+    assertEquals(50000.0, unit.getCumulativeStartupCost(), 1.0e-12);
+    assertEquals(1000.0, unit.getCumulativeStartupEmissionsKg(), 1.0e-12);
+  }
+
+  @Test
+  void testRampAndMinimumStableLoad() {
+    CommittedEnergyGenerator unit = configuredUnit();
+    unit.initializeCommitment(false, 601.0, 0.0);
+    unit.setRequestedPower(8.0e6);
+
+    unit.runTransient(10.0, UUID.randomUUID());
+    assertEquals(1.0e6, unit.getCurrentPower(), 1.0e-9);
+    unit.runTransient(10.0, UUID.randomUUID());
+    assertEquals(2.0e6, unit.getCurrentPower(), 1.0e-9);
+
+    unit.setRequestedPower(0.5e6);
+    unit.runTransient(10.0, UUID.randomUUID());
+    assertEquals(2.0e6, unit.getCurrentPower(), 1.0e-9);
+  }
+
+  @Test
+  void testMinimumUpTimeBlocksShutdown() {
+    CommittedEnergyGenerator unit = configuredUnit();
+    unit.initializeCommitment(true, 100.0, 4.0e6);
+    unit.setRequestedPower(0.0);
+
+    unit.runTransient(100.0, UUID.randomUUID());
+    assertTrue(unit.isCommitted());
+    assertTrue(unit.getLastStepResult().isStopBlocked());
+    assertTrue(unit.getCurrentPower() >= 2.0e6);
+
+    unit.runTransient(700.0, UUID.randomUUID());
+    unit.runTransient(1.0, UUID.randomUUID());
+    assertFalse(unit.isCommitted());
+    assertTrue(unit.getLastStepResult().isStopped());
+  }
+
+  @Test
+  void testGenerationIsPublishedToBus() {
+    CommittedEnergyGenerator unit = configuredUnit();
+    EnergyBus grid = new EnergyBus("grid", EnergyType.ELECTRICAL);
+    unit.connectEnergyStream(CommittedEnergyGenerator.OUTPUT_PORT, grid, EnergyPortMode.CALCULATED);
+    unit.initializeCommitment(false, 601.0, 0.0);
+    unit.setRequestedPower(5.0e6);
+
+    unit.runTransient(100.0, UUID.randomUUID());
+    grid.solveBalance();
+
+    assertEquals(unit.getCurrentPower(),
+        grid.getContribution(unit.getEnergyPort(CommittedEnergyGenerator.OUTPUT_PORT).getParticipantId()), 1.0e-9);
+  }
+
+  @Test
+  void testInvalidConfigurationAndInitialization() {
+    CommittedEnergyGenerator unit = new CommittedEnergyGenerator("unit", EnergyType.ELECTRICAL);
+    assertFalse(unit.validateSetup().isValid());
+    assertThrows(IllegalArgumentException.class, () -> unit.setPowerLimits(2.0, 1.0));
+    assertThrows(IllegalArgumentException.class, () -> unit.setRampRates(0.0, 1.0));
+    assertThrows(IllegalArgumentException.class, () -> unit.setRequestedPower(-1.0));
+    unit.setPowerLimits(2.0e6, 10.0e6);
+    assertThrows(IllegalArgumentException.class, () -> unit.initializeCommitment(false, 0.0, 1.0));
+    assertThrows(IllegalArgumentException.class, () -> unit.runTransient(Double.NaN, UUID.randomUUID()));
+  }
+
+  private static CommittedEnergyGenerator configuredUnit() {
+    CommittedEnergyGenerator unit = new CommittedEnergyGenerator("gas turbine", EnergyType.ELECTRICAL);
+    unit.setPowerLimits(2.0e6, 10.0e6);
+    unit.setRampRates(0.1e6, 0.2e6);
+    unit.setMinimumUpDownTimes(900.0, 600.0);
+    unit.setStartupPenalty(50000.0, 1000.0);
+    return unit;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the remaining startup and commitment-constraint stage:

- typed `CommittedEnergyGenerator` process equipment
- on/off commitment state
- minimum stable load and maximum power
- ramp-up and ramp-down limits
- minimum up and minimum down time
- blocked-start and blocked-stop diagnostics
- startup count, startup cost, and startup CO2-equivalent emissions
- explicit chronological state initialization
- calculated generation published to an `EnergyBus`
- immutable latest-step result
- setup validation and documentation

## Validation coverage

- minimum-down start blocking and later successful startup
- startup cost/emissions accounting
- ramping and minimum-load behavior
- minimum-up shutdown blocking
- bus publication
- invalid limits, requests, initialization, and timesteps

## Scope

This PR enforces one unit's chronological constraints but does not solve global mixed-integer unit commitment. Multi-unit optimal scheduling remains a higher-level optimizer using these constraints.