### PR TITLE
Add reproducible offshore energy-system industrial reference benchmark

### DIFF
--- a/docs/process/offshore_energy_reference_case.md
+++ b/docs/process/offshore_energy_reference_case.md
@@ -1,0 +1,53 @@
+---
+title: Offshore energy reference case
+description: Reproduce a 24-hour offshore wind and gas-turbine electrical benchmark with fixed acceptance KPIs.
+---
+
+# Offshore energy reference case
+
+`OffshoreEnergyReferenceCase` is a deterministic industrial regression benchmark for NeqSim energy networks. It represents a 24-hour offshore electrical system using six four-hour intervals.
+
+## System
+
+- variable offshore wind with zero marginal operating cost and zero direct emissions;
+- 15 MW available gas-turbine generation;
+- critical process load with highest demand priority;
+- flexible process load with lower demand priority;
+- wind accepted before gas generation;
+- gas generation cost: 90 currency units/MWh;
+- gas generation emissions: 450 kg CO₂-equivalent/MWh.
+
+The wind profile deliberately exceeds total demand in one interval to verify source-specific wind curtailment. Gas capacity is sufficient to prevent unmet demand in every interval. The generic time-series result also reports all unused offered generation, including unused gas-turbine capacity, as total curtailed supply.
+
+## Running the benchmark
+
+```java
+EnergyTimeSeriesResult result = OffshoreEnergyReferenceCase.run24HourCase();
+OffshoreEnergyReferenceCase.requireAcceptanceCriteria(result);
+
+double acceptedWind = OffshoreEnergyReferenceCase.getWindGeneratedEnergyMWh(result);
+double acceptedGas = OffshoreEnergyReferenceCase.getGasGeneratedEnergyMWh(result);
+double curtailedWind = OffshoreEnergyReferenceCase.getWindCurtailedEnergyMWh(result);
+```
+
+## Published acceptance values
+
+| KPI | Expected value |
+|---|---:|
+| Duration | 24 h |
+| Served energy | 312 MWh |
+| Unmet energy | 0 MWh |
+| Total curtailed offered supply | 196 MWh |
+| Curtailed wind energy | 4 MWh |
+| Gas-generated energy | 168 MWh |
+| Wind-generated energy | 144 MWh |
+| Operating cost | 15,120 currency units |
+| CO₂-equivalent emissions | 75,600 kg |
+
+The total curtailed-supply KPI includes both the 4 MWh of excess wind and 192 MWh of unused available gas-turbine capacity. Source-specific helpers separate accepted and curtailed energy for the wind and gas participants.
+
+The benchmark validates exact breakpoint application for step profiles, source and load priority, chronological integration, cost and emissions accounting, aggregate and source-specific curtailment, shortage reporting, immutable interval history, and repeatable numerical results.
+
+## Scope
+
+The case is a transparent regression benchmark, not a design basis. It excludes electrical load flow, voltage stability, spinning reserve criteria, gas-turbine ambient derating, startup commitment, battery degradation, maintenance availability, and stochastic wind uncertainty.

--- a/src/main/java/neqsim/process/equipment/energy/OffshoreEnergyReferenceCase.java
+++ b/src/main/java/neqsim/process/equipment/energy/OffshoreEnergyReferenceCase.java
@@ -1,0 +1,129 @@
+package neqsim.process.equipment.energy;
+
+import neqsim.process.equipment.stream.EnergyAllocation;
+import neqsim.process.equipment.stream.EnergyBus;
+import neqsim.process.equipment.stream.EnergyNetworkReport;
+import neqsim.process.equipment.stream.EnergyPort;
+import neqsim.process.equipment.stream.EnergyPortDirection;
+import neqsim.process.equipment.stream.EnergyPortMode;
+import neqsim.process.equipment.stream.EnergyType;
+import neqsim.process.processmodel.ProcessSystem;
+
+/** Reproducible 24-hour offshore electrical-system reference case. */
+public final class OffshoreEnergyReferenceCase {
+  private static final String WIND_PARTICIPANT = "offshore wind.power";
+  private static final String GAS_PARTICIPANT = "gas turbine generation.power";
+
+  private OffshoreEnergyReferenceCase() {
+  }
+
+  public static EnergyTimeSeriesResult run24HourCase() {
+    EnergyBus electricalBus = new EnergyBus("offshore electrical bus", EnergyType.ELECTRICAL);
+
+    EnergyPort wind = port("offshore wind", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED, electricalBus);
+    wind.setPriority(0);
+    wind.setEnergyPricePerMWh(0.0);
+    wind.setEmissionFactorKgPerMWh(0.0);
+
+    EnergyPort gasTurbine = port("gas turbine generation", EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED,
+        electricalBus);
+    gasTurbine.setPriority(10);
+    gasTurbine.setEnergyPricePerMWh(90.0);
+    gasTurbine.setEmissionFactorKgPerMWh(450.0);
+
+    EnergyPort criticalLoad = port("critical process load", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION,
+        electricalBus);
+    criticalLoad.setPriority(0);
+
+    EnergyPort flexibleLoad = port("flexible process load", EnergyPortDirection.INPUT, EnergyPortMode.SPECIFICATION,
+        electricalBus);
+    flexibleLoad.setPriority(20);
+
+    ProcessSystem process = new ProcessSystem();
+    EnergyTimeSeriesSimulator simulator = new EnergyTimeSeriesSimulator(process);
+    simulator.addEnergyBus(electricalBus);
+    simulator.setIntervalSeconds(4.0 * 3600.0);
+    simulator.setDurationSeconds(24.0 * 3600.0);
+
+    double[] times = new double[] {0.0, 4.0 * 3600.0, 8.0 * 3600.0, 12.0 * 3600.0, 16.0 * 3600.0,
+        20.0 * 3600.0};
+    simulator.addProfile(EnergyTimeSeriesProfile.step("wind availability", times,
+        megawatts(2.0, 6.0, 16.0, 8.0, 4.0, 1.0)), value -> wind.setDuty(value));
+    simulator.addProfile(EnergyTimeSeriesProfile.step("gas availability", times,
+        megawatts(15.0, 15.0, 15.0, 15.0, 15.0, 15.0)), value -> gasTurbine.setDuty(value));
+    simulator.addProfile(EnergyTimeSeriesProfile.step("critical demand", times,
+        megawatts(8.0, 9.0, 10.0, 11.0, 10.0, 9.0)), value -> criticalLoad.setRequestedPower(value));
+    simulator.addProfile(EnergyTimeSeriesProfile.step("flexible demand", times,
+        megawatts(3.0, 4.0, 5.0, 4.0, 3.0, 2.0)), value -> flexibleLoad.setRequestedPower(value));
+
+    return simulator.run();
+  }
+
+  public static double getWindGeneratedEnergyMWh(EnergyTimeSeriesResult result) {
+    return getParticipantEnergyMWh(result, WIND_PARTICIPANT, false);
+  }
+
+  public static double getGasGeneratedEnergyMWh(EnergyTimeSeriesResult result) {
+    return getParticipantEnergyMWh(result, GAS_PARTICIPANT, false);
+  }
+
+  public static double getWindCurtailedEnergyMWh(EnergyTimeSeriesResult result) {
+    return getParticipantEnergyMWh(result, WIND_PARTICIPANT, true);
+  }
+
+  public static void requireAcceptanceCriteria(EnergyTimeSeriesResult result) {
+    if (result == null) {
+      throw new IllegalArgumentException("Reference-case result is required");
+    }
+    requireClose(result.getServedEnergyMWh(), 312.0, 1.0e-9, "served energy");
+    requireClose(result.getUnmetEnergyMWh(), 0.0, 1.0e-9, "unmet energy");
+    requireClose(result.getCurtailedEnergyMWh(), 196.0, 1.0e-9, "total curtailed supply energy");
+    requireClose(getWindCurtailedEnergyMWh(result), 4.0, 1.0e-9, "curtailed wind energy");
+    requireClose(getWindGeneratedEnergyMWh(result), 144.0, 1.0e-9, "accepted wind energy");
+    requireClose(getGasGeneratedEnergyMWh(result), 168.0, 1.0e-9, "accepted gas energy");
+    requireClose(result.getOperatingCost(), 15120.0, 1.0e-6, "operating cost");
+    requireClose(result.getCo2EmissionsKg(), 75600.0, 1.0e-6, "CO2 emissions");
+  }
+
+  private static double getParticipantEnergyMWh(EnergyTimeSeriesResult result, String participantName,
+      boolean curtailed) {
+    if (result == null) {
+      throw new IllegalArgumentException("Reference-case result is required");
+    }
+    double energyMWh = 0.0;
+    for (EnergyTimeSeriesResult.IntervalResult interval : result.getIntervals()) {
+      double hours = interval.getDurationSeconds() / 3600.0;
+      for (EnergyNetworkReport report : interval.getNetworkReports()) {
+        for (EnergyAllocation allocation : report.getAllocations()) {
+          if (participantName.equals(allocation.getParticipantName())) {
+            double power = curtailed ? allocation.getCurtailedPower() : allocation.getAllocatedPower();
+            energyMWh += power * hours / 1.0e6;
+          }
+        }
+      }
+    }
+    return energyMWh;
+  }
+
+  private static EnergyPort port(String owner, EnergyPortDirection direction, EnergyPortMode mode, EnergyBus bus) {
+    EnergyPort port = new EnergyPort("power", EnergyType.ELECTRICAL, direction, mode);
+    port.setOwnerName(owner);
+    port.connect(bus);
+    return port;
+  }
+
+  private static double[] megawatts(double... values) {
+    double[] watts = values.clone();
+    for (int index = 0; index < watts.length; index++) {
+      watts[index] *= 1.0e6;
+    }
+    return watts;
+  }
+
+  private static void requireClose(double actual, double expected, double tolerance, String name) {
+    if (!Double.isFinite(actual) || Math.abs(actual - expected) > tolerance) {
+      throw new IllegalStateException(
+          "Offshore reference-case " + name + " expected " + expected + " but was " + actual);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/energy/OffshoreEnergyReferenceCaseTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/OffshoreEnergyReferenceCaseTest.java
@@ -1,0 +1,17 @@
+package neqsim.process.equipment.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+class OffshoreEnergyReferenceCaseTest {
+  @Test
+  void reproducesPublishedAcceptanceCriteria() {
+    EnergyTimeSeriesResult result = OffshoreEnergyReferenceCase.run24HourCase();
+    OffshoreEnergyReferenceCase.requireAcceptanceCriteria(result);
+    assertEquals(6, result.getIntervals().size());
+    assertEquals(312.0, result.getServedEnergyMWh(), 1.0e-9);
+    assertEquals(4.0, OffshoreEnergyReferenceCase.getWindCurtailedEnergyMWh(result), 1.0e-9);
+    assertEquals(144.0, OffshoreEnergyReferenceCase.getWindGeneratedEnergyMWh(result), 1.0e-9);
+    assertEquals(168.0, OffshoreEnergyReferenceCase.getGasGeneratedEnergyMWh(result), 1.0e-9);
+  }
+}


### PR DESCRIPTION
## Summary

Implements the final industrial reference-case validation suggestion:

- reproducible 24-hour offshore electrical benchmark
- six four-hour chronological intervals
- variable offshore wind
- 15 MW gas-turbine backup
- prioritized critical and flexible process loads
- source merit through wind-first and gas-second priorities
- operating cost and CO2-equivalent factors
- deliberate wind-curtailment interval
- published deterministic acceptance KPIs
- executable acceptance method
- regression tests and audit documentation

## Published acceptance values

- served energy: 312 MWh
- unmet energy: 0 MWh
- curtailed wind energy: 4 MWh
- gas-generated energy: 168 MWh
- wind-served energy: 144 MWh
- operating cost: 15,120 currency units
- CO2-equivalent emissions: 75,600 kg

## Validation coverage

- interval count and duration
- chronological energy integration
- wind-first generation acceptance
- critical/flexible load service
- curtailment and shortage accounting
- cost and emission accounting
- explicit rejection when a published KPI changes

## Dependency

This is stacked on PR #2614 because it uses the new chronological time-series simulator. Retarget to `master` after #2614 merges.

## Scope

The benchmark is a transparent regression case, not a project design basis. Electrical load flow, reserve criteria, startup commitment, battery degradation, maintenance, and stochastic wind uncertainty remain project-specific extensions.