### PR TITLE
docs: repair tutorial and cookbook navigation

### DIFF
--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -10,11 +10,11 @@ Quick, copy-paste recipes for common tasks. Each recipe is self-contained and re
 
 | Category | Description |
 |----------|-------------|
-| [Thermodynamics Recipes](thermodynamics-recipes) | Fluids, flash, properties, phase envelopes |
-| [Process Recipes](process-recipes) | Equipment, flowsheets, streams |
-| [Adsorption Recipes](adsorption-recipes) | Isotherm evaluation, PSA/TSA cycles, breakthrough curves |
-| [Pipeline Recipes](pipeline-recipes) | Pressure drop, multiphase flow, slugging |
-| [Unit Conversion](unit-conversion-recipes) | Working with units in NeqSim |
+| [Thermodynamics Recipes](thermodynamics-recipes.md) | Fluids, flash, properties, phase envelopes |
+| [Process Recipes](process-recipes.md) | Equipment, flowsheets, streams |
+| [Adsorption Recipes](adsorption-recipes.md) | Isotherm evaluation, PSA/TSA cycles, breakthrough curves |
+| [Pipeline Recipes](pipeline-recipes.md) | Pressure drop, multiphase flow, slugging |
+| [Unit Conversion](unit-conversion-recipes.md) | Working with units in NeqSim |
 
 ## Most Popular Recipes
 
@@ -22,16 +22,16 @@ Quick, copy-paste recipes for common tasks. Each recipe is self-contained and re
 
 | Task | Recipe |
 |------|--------|
-| Create a natural gas fluid | [thermodynamics-recipes.md#create-natural-gas](thermodynamics-recipes#create-natural-gas) |
-| Run a flash calculation | [thermodynamics-recipes.md#run-tp-flash](thermodynamics-recipes#run-tp-flash) |
-| Get density (correct way) | [thermodynamics-recipes.md#get-density-correctly](thermodynamics-recipes#get-density-correctly) |
-| Calculate phase envelope | [thermodynamics-recipes.md#calculate-phase-envelope](thermodynamics-recipes#phase-envelope) |
-| Simple separator | [process-recipes.md#two-phase-separator](process-recipes#two-phase-separator) |
-| Compressor with efficiency | [process-recipes.md#compressor-with-efficiency](process-recipes#compressor-with-efficiency) |
-| Pipeline pressure drop | [pipeline-recipes.md#simple-pressure-drop](pipeline-recipes#simple-pressure-drop) |
-| Export to JSON | [thermodynamics-recipes.md#export-to-json](thermodynamics-recipes#export-to-json) |
-| Set up recycle | [process-recipes.md#recycle-stream](process-recipes#recycle-stream) |
-| Which EoS to use? | [thermodynamics-recipes.md#which-eos-should-i-use](thermodynamics-recipes#which-eos-should-i-use) |
+| Create a natural gas fluid | [thermodynamics-recipes.md#create-natural-gas](thermodynamics-recipes.md#create-natural-gas) |
+| Run a flash calculation | [thermodynamics-recipes.md#flash-calculations](thermodynamics-recipes.md#flash-calculations) |
+| Get density (correct way) | [thermodynamics-recipes.md#reading-properties](thermodynamics-recipes.md#reading-properties) |
+| Calculate phase envelope | [thermodynamics-recipes.md#phase-envelopes](thermodynamics-recipes.md#phase-envelopes) |
+| Simple separator | [process-recipes.md#two-phase-separator](process-recipes.md#two-phase-separator) |
+| Compressor with efficiency | [process-recipes.md#compressor-with-efficiency](process-recipes.md#compressor-with-efficiency) |
+| Pipeline pressure drop | [pipeline-recipes.md#simple-pressure-drop](pipeline-recipes.md#simple-pressure-drop) |
+| Export to JSON | [thermodynamics-recipes.md#export-parse-and-clone](thermodynamics-recipes.md#export-parse-and-clone) |
+| Set up recycle | [process-recipes.md#recycle-stream](process-recipes.md#recycle-stream) |
+| Which EoS to use? | [thermodynamics-recipes.md#which-eos-should-i-use](thermodynamics-recipes.md#which-eos-should-i-use) |
 
 ## Recipe Format
 
@@ -45,4 +45,4 @@ Each recipe includes:
 
 For complete API documentation, see:
 - **[JavaDoc API](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html)** - All classes and methods
-- **[Reference Manual](../REFERENCE_MANUAL_INDEX)** - Comprehensive guides
+- **[Reference Manual](../REFERENCE_MANUAL_INDEX.md)** - Comprehensive guides

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -12,10 +12,10 @@ Curated sequences of tutorials based on your role:
 
 | Path | Description | Time |
 |------|-------------|------|
-| **[Learning Paths Overview](learning-paths)** | Choose your learning track | - |
-| [PVT Engineer Track](learning-paths#pvt-engineer-path) | Fluids, flash, characterization | 4-6 hours |
-| [Process Engineer Track](learning-paths#process-engineer-path) | Equipment, flowsheets, optimization | 6-8 hours |
-| [Developer Track](learning-paths#developer-path) | API, architecture, extensions | 8-10 hours |
+| **[Learning Paths Overview](learning-paths.md)** | Choose your learning track | - |
+| [PVT Engineer Track](learning-paths.md#pvt-engineer-path) | Fluids, flash, characterization | 4-6 hours |
+| [Process Engineer Track](learning-paths.md#process-engineer-path) | Equipment, flowsheets, optimization | 6-8 hours |
+| [Developer Track](learning-paths.md#developer-path) | API, architecture, extensions | 8-10 hours |
 
 ## Quick Start Guides
 
@@ -23,11 +23,11 @@ Get up and running fast:
 
 | Guide | Time | Platform |
 |-------|------|----------|
-| **[Solve an Engineering Task](solve-engineering-task)** | **15-60 min** | **Any (VS Code, Codex, manual)** |
-| **[Introduction to Agentic Engineering](../integration/ai_agentic_programming_intro)** | **20 min** | **VS Code + Copilot** |
-| [Java Quickstart](../quickstart/java-quickstart) | 10 min | Java/Maven |
-| [Python Quickstart](../quickstart/python-quickstart) | 5 min | Python/pip |
-| [Colab Quickstart](../quickstart/colab-quickstart) | 1 min | Browser |
+| **[Solve an Engineering Task](solve-engineering-task.md)** | **15-60 min** | **Any (VS Code, Codex, manual)** |
+| **[Introduction to Agentic Engineering](../integration/ai_agentic_programming_intro.md)** | **20 min** | **VS Code + Copilot** |
+| [Java Quickstart](../quickstart/java-quickstart.md) | 10 min | Java/Maven |
+| [Python Quickstart](../quickstart/python-quickstart.md) | 5 min | Python/pip |
+| [Colab Quickstart](../quickstart/colab-quickstart.md) | 1 min | Browser |
 
 ## Process Tutorials
 
@@ -35,11 +35,11 @@ Complete walkthroughs for common applications:
 
 | Tutorial | Description | Level |
 |----------|-------------|-------|
-| **[TEG Gas Dehydration](teg_dehydration_tutorial)** | Complete TEG loop with contactor and regeneration | Intermediate |
-| **[Gas-Oil Separation Plant (GOSP)](gosp_tutorial)** | Multi-stage separation with compression | Intermediate |
-| **[PVT Lab Test Simulations](../pvtsimulation/pvt_lab_tests)** | CCE, CVD, DL, separator tests | Intermediate |
-| **[Flow Assurance Overview](../pvtsimulation/flow_assurance_overview)** | Hydrates, wax, asphaltenes screening | Intermediate |
-| **[UniSim/HYSYS to NeqSim Conversion](../process/unisim-to-neqsim-conversion)** | Convert UniSim `.usc` models to NeqSim | Intermediate |
+| **[TEG Gas Dehydration](teg_dehydration_tutorial.md)** | Complete TEG loop with contactor and regeneration | Intermediate |
+| **[Gas-Oil Separation Plant (GOSP)](gosp_tutorial.md)** | Multi-stage separation with compression | Intermediate |
+| **[PVT Lab Test Simulations](../pvtsimulation/pvt_lab_tests.md)** | CCE, CVD, DL, separator tests | Intermediate |
+| **[Flow Assurance Overview](../pvtsimulation/flow_assurance_overview.md)** | Hydrates, wax, asphaltenes screening | Intermediate |
+| **[UniSim/HYSYS to NeqSim Conversion](../process/unisim-to-neqsim-conversion.md)** | Convert UniSim `.usc` models to NeqSim | Intermediate |
 
 ## Video Tutorials
 
@@ -47,7 +47,7 @@ Coming soon! For now, see the [NeqSim Colab notebooks](https://github.com/EvenSo
 
 ## Next Steps
 
-- **[Cookbook](../cookbook/index)** - Quick recipes for specific tasks
-- **[Examples](../examples/index)** - Jupyter notebooks and code samples
-- **[Troubleshooting](../troubleshooting/index)** - Common issues and solutions
+- **[Cookbook](../cookbook/index.md)** - Quick recipes for specific tasks
+- **[Examples](../examples/index.md)** - Jupyter notebooks and code samples
+- **[Troubleshooting](../troubleshooting/index.md)** - Common issues and solutions
 - **[JavaDoc API](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html)** - Complete API reference


### PR DESCRIPTION
## Summary

Repairs tutorial and cookbook source navigation as D033 of #2499.

### Frozen scan scope

- `docs/tutorials/index.md`
- `docs/cookbook/index.md`
- `docs/troubleshooting/index.md`

The troubleshooting guide passed the batch scan unchanged. The patch is limited to the tutorial and cookbook landing pages.

### Confirmed defects and severity

- **Medium — 33 nonconforming internal links:** 17 tutorial and 16 cookbook links used extensionless repository source targets. NeqSim's Jekyll source convention requires explicit `.md` targets; `jekyll-relative-links` converts them to published `.html`/clean URLs.
- **Medium — four broken cookbook fragments:** links advertised TP flash, density, phase-envelope, and JSON recipes but targeted nonexistent anchors. The actual section anchors are `flash-calculations`, `reading-properties`, `phase-envelopes`, and `export-parse-and-clone`.

### Fix

- Added `.md` to all 33 affected source links.
- Corrected the four fragment destinations and their displayed path labels.
- Preserved all link labels, learning-path content, recipe content, tables, and external URLs otherwise unchanged.

### Validation

- All 39 internal links across the frozen three-page batch resolve to 21 repository files.
- All 13 fragment links resolve to headings in their target files.
- Zero extensionless internal file targets remain in the batch.
- Front matter contains non-empty `title` and `description` on all three pages.
- No duplicate H1 occurs after front matter.
- Table continuity is preserved: 20 tutorial rows, 19 cookbook rows, and 7 troubleshooting rows.
- Code fences remain balanced: 0/0/8 delimiters on tutorial/cookbook/troubleshooting pages.
- There are no display equations or mixed `<div>`/Markdown constructs in the batch.
- External NeqSim-Colab and JavaDoc destinations returned successfully on 2026-07-27.
- Branch is two commits ahead, zero behind current `master`; full diff is exactly two Markdown files with no open-PR overlap.
- No Java/Python API, code example, notebook, production code, or test changed, so runtime/API regression coverage is not applicable to this link-only repair.
- Hosted build/test/Javadoc, pre-commit, Spotless, documentation search coverage, and CodeQL all passed.
- Final-head Copilot reviewed 2/2 changed files and produced no comments, suggested-change blocks, or review threads; no Copilot-authored or suggestion commit exists.

### Rendering

Repository source and destination structure were validated. No rendered-site artifact is available yet, so browser visual inspection is not claimed.

### D032 reconciliation

PR #2624 merged externally as commit `6b34838f1d3506316fd22b8ba04698554d592e62`. Its merge is exactly the previously validated one-file metadata patch, and final Copilot review contained no inline findings or unresolved threads.

### Deliberate exclusions

Content pages reached from these landing pages are destination/fragment targets only; their code examples and prose are outside this bounded index-navigation batch. The unchanged troubleshooting examples retain the D023 runtime evidence.

### Next scan

D034: JavaDoc-facing examples, Python snippets, notebooks, images, and external links after D033 is merged or closed.