### PR TITLE
Fix separator entropy-production flow screening

### DIFF
--- a/src/main/java/neqsim/process/equipment/separator/Separator.java
+++ b/src/main/java/neqsim/process/equipment/separator/Separator.java
@@ -2739,7 +2739,8 @@ public class Separator extends ProcessEquipmentBaseClass
   public double getEntropyProduction(String unit) {
     double entrop = 0.0;
     for (int i = 0; i < numberOfInputStreams; i++) {
-      if (inletStreamMixer.getStream(i).getFlowRate(unit) > 1e-10) {
+      // The method argument is an entropy unit, so use an explicit flow unit for screening.
+      if (inletStreamMixer.getStream(i).getFlowRate("kg/sec") > 1e-10) {
         inletStreamMixer.getStream(i).getFluid().init(3);
         entrop += inletStreamMixer.getStream(i).getFluid().getEntropy();
       }

--- a/src/test/java/neqsim/process/equipment/separator/SeparatorTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/SeparatorTest.java
@@ -63,10 +63,8 @@ class SeparatorTest extends neqsim.NeqSimTest {
     ((StreamInterface) processOps.getUnit("inlet stream")).setFlowRate(1.0, "MSm3/day");
     processOps.run();
 
-    double separatorEntropyProduction =
-        Assertions.assertDoesNotThrow(() -> sep.getEntropyProduction("J/K"));
-    double processEntropyProduction =
-        Assertions.assertDoesNotThrow(() -> processOps.getEntropyProduction("J/K"));
+    double separatorEntropyProduction = Assertions.assertDoesNotThrow(() -> sep.getEntropyProduction("J/K"));
+    double processEntropyProduction = Assertions.assertDoesNotThrow(() -> processOps.getEntropyProduction("J/K"));
 
     Assertions.assertTrue(Double.isFinite(separatorEntropyProduction));
     Assertions.assertTrue(Double.isFinite(processEntropyProduction));

--- a/src/test/java/neqsim/process/equipment/separator/SeparatorTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/SeparatorTest.java
@@ -59,6 +59,21 @@ class SeparatorTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  void testEntropyProductionUsesEntropyUnitOnlyForResult() {
+    ((StreamInterface) processOps.getUnit("inlet stream")).setFlowRate(1.0, "MSm3/day");
+    processOps.run();
+
+    double separatorEntropyProduction =
+        Assertions.assertDoesNotThrow(() -> sep.getEntropyProduction("J/K"));
+    double processEntropyProduction =
+        Assertions.assertDoesNotThrow(() -> processOps.getEntropyProduction("J/K"));
+
+    Assertions.assertTrue(Double.isFinite(separatorEntropyProduction));
+    Assertions.assertTrue(Double.isFinite(processEntropyProduction));
+    Assertions.assertEquals(separatorEntropyProduction, processEntropyProduction, 1e-12);
+  }
+
+  @Test
   public void testOnePhase() {
     ((StreamInterface) processOps.getUnit("inlet stream")).setFlowRate(1.0, "MSm3/day");
     ((StreamInterface) processOps.getUnit("inlet stream")).getFluid()


### PR DESCRIPTION
## Summary

- use an explicit mass-flow unit when screening separator inlet streams in `getEntropyProduction`
- keep the method argument reserved for the entropy result contract
- add a regression test covering both separator-level and `ProcessSystem` entropy-production calls

## Reproduction

With NeqSim 3.16.0, `Separator.getEntropyProduction("J/K")` calls `getFlowRate("J/K")` and throws an unsupported flow-unit exception. This also makes `ProcessSystem.getEntropyProduction("J/K")` fail for any flowsheet containing a separator.

## Validation

The regression test runs the existing multiphase separator fixture, verifies both calls complete, checks finite results, and confirms the process total equals the separator contribution in the two-unit fixture.

This defect was reproduced while validating the NeqSim-Colab oil-process exergy notebook.