### PR TITLE
Avoid CPA K-value warm starts in PH flashes

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/PHflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/PHflash.java
@@ -190,19 +190,36 @@ public class PHflash extends Flash {
     return 1.0 / nyTemp;
   }
 
+  /**
+   * Check whether K-value warm starts are suitable for the inner TP flashes.
+   *
+   * <p>
+   * CPA association-site fractions can change strongly with temperature. Reusing K-values while the PH solver moves
+   * through temperature space may therefore increase TP-flash work or bias the iteration path. Cubic EOS models retain
+   * the established warm-start acceleration.
+   * </p>
+   *
+   * @return {@code true} when inner TP flashes may reuse K-values
+   */
+  protected boolean isInnerTpFlashWarmStartSafe() {
+    String modelName = system == null || system.getModelName() == null ? "" : system.getModelName();
+    return !modelName.toUpperCase(java.util.Locale.ROOT).contains("CPA");
+  }
+
   /** {@inheritDoc} */
   @Override
   public void run() {
     // First TPflash runs COLD (Wilson initial K) so that stale K from a
     // previous unrelated flash (at different P/T) does not bias the solution.
-    // Then enable K-value warm-start only for subsequent TPflash iterations
-    // within this outer PH-flash loop — safe because the outer loop converges
-    // on T via enthalpy residual. Typical speedup: 3-5x.
+    // Then enable K-value warm-start for subsequent TPflash iterations only when
+    // the thermodynamic model is suitable. CPA association terms can make K-values
+    // stale as temperature changes, increasing work in glycol/water columns.
     boolean prevWarm = neqsim.thermo.ThermodynamicModelSettings.isUseWarmStartKValues();
+    boolean useInnerWarmStart = isInnerTpFlashWarmStartSafe();
     try {
       neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(false);
       tpFlash.run();
-      neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(true);
+      neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(useInnerWarmStart);
       // System.out.println("enthalpy start: " + system.getEnthalpy());
       if (type == 0) {
         solveQ();

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/PHflashWarmStartPolicyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/PHflashWarmStartPolicyTest.java
@@ -1,0 +1,109 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.ThermodynamicModelSettings;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests model-aware K-value warm starts in {@link PHflash}. */
+public class PHflashWarmStartPolicyTest {
+
+  /** CPA PH flashes keep inner TP flashes cold and restore the caller's setting. */
+  @Test
+  public void cpaDisablesInnerWarmStart() {
+    SystemInterface system = new SystemSrkCPAstatoil(373.15, 1.2);
+    RecordingPHflash flash = new RecordingPHflash(system);
+    RecordingTPflash innerFlash = new RecordingTPflash(system);
+    flash.setInnerFlash(innerFlash);
+
+    boolean previousWarmStart = ThermodynamicModelSettings.isUseWarmStartKValues();
+    try {
+      ThermodynamicModelSettings.setUseWarmStartKValues(true);
+      flash.run();
+
+      assertEquals(1, innerFlash.getRunCount());
+      assertFalse(innerFlash.wasWarmStartEnabled(), "The first TP flash must use a cold start");
+      assertFalse(flash.wasWarmStartEnabledDuringSolve(),
+          "CPA PH iterations must not reuse K-values across temperatures");
+      assertTrue(ThermodynamicModelSettings.isUseWarmStartKValues(),
+          "PHflash must restore the caller's warm-start setting");
+    } finally {
+      ThermodynamicModelSettings.setUseWarmStartKValues(previousWarmStart);
+    }
+  }
+
+  /** Cubic-EOS PH flashes retain the established inner warm-start acceleration. */
+  @Test
+  public void cubicEosRetainsInnerWarmStart() {
+    SystemInterface system = new SystemSrkEos(300.15, 20.0);
+    RecordingPHflash flash = new RecordingPHflash(system);
+    RecordingTPflash innerFlash = new RecordingTPflash(system);
+    flash.setInnerFlash(innerFlash);
+
+    boolean previousWarmStart = ThermodynamicModelSettings.isUseWarmStartKValues();
+    try {
+      ThermodynamicModelSettings.setUseWarmStartKValues(false);
+      flash.run();
+
+      assertEquals(1, innerFlash.getRunCount());
+      assertFalse(innerFlash.wasWarmStartEnabled(), "The first TP flash must use a cold start");
+      assertTrue(flash.wasWarmStartEnabledDuringSolve(),
+          "Cubic-EOS PH iterations should reuse K-values after the first TP flash");
+      assertFalse(ThermodynamicModelSettings.isUseWarmStartKValues(),
+          "PHflash must restore the caller's warm-start setting");
+    } finally {
+      ThermodynamicModelSettings.setUseWarmStartKValues(previousWarmStart);
+    }
+  }
+
+  /** PH flash with a deterministic outer solve used to observe the warm-start policy. */
+  private static final class RecordingPHflash extends PHflash {
+    private boolean warmStartEnabledDuringSolve;
+
+    RecordingPHflash(SystemInterface system) {
+      super(system, 0.0, 0);
+    }
+
+    void setInnerFlash(Flash innerFlash) {
+      tpFlash = innerFlash;
+    }
+
+    boolean wasWarmStartEnabledDuringSolve() {
+      return warmStartEnabledDuringSolve;
+    }
+
+    @Override
+    public double solveQ() {
+      warmStartEnabledDuringSolve = ThermodynamicModelSettings.isUseWarmStartKValues();
+      return system.getTemperature();
+    }
+  }
+
+  /** TP flash test double that records the policy used for its invocation. */
+  private static final class RecordingTPflash extends TPflash {
+    private int runCount;
+    private boolean warmStartEnabled;
+
+    RecordingTPflash(SystemInterface system) {
+      super(system);
+    }
+
+    int getRunCount() {
+      return runCount;
+    }
+
+    boolean wasWarmStartEnabled() {
+      return warmStartEnabled;
+    }
+
+    @Override
+    public void run() {
+      runCount++;
+      warmStartEnabled = ThermodynamicModelSettings.isUseWarmStartKValues();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Makes the PH-flash inner TP-flash warm-start policy model-aware:

- the first TP flash remains cold for every model;
- subsequent inner TP flashes retain K-value warm starts for cubic EOS models;
- CPA models keep cold K initialization while the outer PH solve changes temperature;
- the caller's thread-local warm-start setting is restored in every path.

This is a focused first improvement to distillation-column robustness and speed for associating systems, especially TEG/water regeneration columns where PH flashes are repeated across tray sweeps.

## Problem and root cause

Issue #2110 records a representative TEG-regeneration regression with unchanged engineering results but CPA runtime increasing from 55.9 s to 104.8 s (+87%), while the equivalent SRK case improved from 34.4 s to 30.4 s. The current `PHflash` always enables K-value reuse after its first TP flash. For CPA, association-site fractions change strongly as the outer PH iteration changes temperature, so the reused K vector can be a worse seed than a cold initialization and add inner TP-flash work.

The policy is deliberately limited to CPA model names. It does not change tolerances, convergence acceptance, flash equations, or cubic-EOS behavior.

## Solvers and coordinated behavior

This changes the PH-flash path used repeatedly by column tray energy calculations. It is complementary to #2589, which improves warm-state reuse inside `DistillationColumn` and the Naphtali-Sandholm solver. The branch was rebuilt as one commit directly on master commit `58404ade`, so CI validates both improvements together without duplicating #2589.

## Tests

Added `PHflashWarmStartPolicyTest` with deterministic test doubles to verify:

1. CPA: first TP flash is cold and later PH iterations keep warm start disabled.
2. SRK: first TP flash is cold and later PH iterations retain the existing acceleration.
3. The thread-local caller setting is restored for both enabled and disabled initial states.

The full Java matrix also exercises existing process and column tests, including `TegRegenerationEnergyBalanceTest` for CPA column duty and energy conservation.

## Before/after evidence

| Case | Before policy | After policy |
|---|---|---|
| CPA PH inner iterations | Cold first TP flash, then forced warm K reuse | Cold first TP flash, then cold K initialization throughout |
| Cubic-EOS PH inner iterations | Cold first TP flash, then warm K reuse | Unchanged |
| Caller thread-local flag | Restored in `finally` | Unchanged and explicitly regression-tested |

No wall-clock assertion is added to CI. The issue #2110 timing is retained as the motivating benchmark; deterministic policy coverage prevents the known CPA-hostile path from returning.

## Compatibility and risk

- No public API change.
- No changed convergence tolerance or acceptance criterion.
- Change affects only model names containing `CPA`.
- Main risk is that an individual CPA case may have benefited from warm K reuse; cold initialization is the established reproducible fallback and favors robustness.
- PS flashes are intentionally unchanged and remain the next separately benchmarked target.
- The original #2110 wall-clock case should be rerun in a stable benchmark environment; CI verifies deterministic policy and engineering regressions instead of flaky timing thresholds.

## Validation status

Draft remains open while the clean post-#2589 CI matrix completes. On the current head:

- Spotless format patch: passed
- Pre-commit checks: passed
- PaperLab replication gate: passed
- Agent-skill reference checks: passed
- Java 21 Javadoc, Java 21 tests, CodeQL, and Java 8 tests: running or queued

Mark ready for review only after the complete Java 8/21 matrix succeeds.