### PR TITLE
Fix DistillationColumn.solved() contradicting the reported solve status

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,81 @@
 
 ---
 
+## 2026-07-27 — Fix: `DistillationColumn.solved()` no longer contradicts the reported solve status
+
+### Summary
+
+`DistillationColumn.solved()` could return `false` for a column whose
+`getLastSolveStatus()` was `RIGOROUS_CONVERGED` and whose residuals — as reported by
+`getLastTemperatureResidual()` and `getConvergenceDiagnostics()` — were all inside their
+tolerances. Observed on a TEG regeneration column: reported temperature residual
+`0.0168 K` against a `0.05 K` tolerance, while the internal gate saw `0.270`.
+
+Cause: the convergence gate tested the private working field `err` instead of
+`lastTemperatureResidual`. `err` is the live iteration variable of every inner solver loop —
+reset to `1e10` or `0.0` on solver entry and accumulated tray by tray — so any solver pass
+that exits before `finalizeSolve()` leaves it holding a partial value.
+
+Impact: enclosing `Recycle`, `ProcessSystem`, and `ProcessModel` loops never saw the column
+as converged and kept iterating until an iteration cap or wall-clock timeout, then returned a
+partially converged state. Downstream consumers saw very long run times and results that
+drifted between runs.
+
+### What changed
+
+- `residualConvergenceSatisfied()` now gates on `lastTemperatureResidual`, the same value
+  reported by `getLastTemperatureResidual()` and `getConvergenceDiagnostics()`. Both it and
+  `lastSolveStatus` are written by `finalizeSolve()` and cleared by `resetLastSolveMetrics()`,
+  so they stay consistent.
+- `internalTrafficSatisfied()` now compares against `MAX_SOLVED_INTERNAL_TRAFFIC_TO_FEED_RATIO`
+  (100) instead of the relaxed-update limit `MAX_RELAXED_INTERNAL_TRAFFIC_TO_FEED_RATIO` (1e5).
+- Guarded fallback products now log a warning. When the tray solution is rejected,
+  `updateProductsFromOverallFeedFlash()` replaces the public products with a **single
+  equilibrium flash of the mixed feeds**. The residual getters are computed against those
+  fallback products and therefore look converged. Check `getLastSolveStatus()` —
+  `FALLBACK_PRODUCTS` means product flows and duties are not a rigorous column result.
+- A non-finite reboiler or condenser duty after a solve is now logged instead of being
+  silently returned by `getDuty()`.
+- `massBalanceCheck()` and `componentMassBalanceCheck()` use `logger.debug` instead of
+  `System.out.println`.
+
+### Migration
+
+No API change. Callers that worked around the old behaviour by ignoring `solved()` can now
+rely on it. When reading column results programmatically, always check
+`getLastSolveStatus()` in addition to the residual getters.
+
+Regression test: `src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolvedConsistencyTest.java`.
+
+---
+
+## 2026-05-14 — Breaking: `Condenser.setRefluxRatio()` now means L/D, not a split fraction
+
+### Summary
+
+Before PR #2156 the value passed to `Condenser.setRefluxRatio(r)` was used directly as the
+split fraction of the condensed liquid returned as reflux:
+
+```java
+mixedStreamSplitter.setSplitFactors(new double[] {r, 1.0 - r});
+```
+
+It is now interpreted as a true reflux ratio `R = L/D` and converted internally:
+
+```java
+double refluxFraction = r <= 0.0 ? 0.0 : r / (1.0 + r);
+mixedStreamSplitter.setSplitFactors(new double[] {refluxFraction, 1.0 - refluxFraction});
+```
+
+### Migration
+
+Any model calibrated against the old meaning runs at a different reflux and must be re-tuned.
+To reproduce the old split fraction `f`, pass `R = f / (1 - f)`.
+
+Affected: TEG regeneration and other columns that call `getCondenser().setRefluxRatio(...)`.
+
+---
+
 ## 2026-07-25 — New: Energy Networks v3
 
 ### Summary

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -7462,7 +7462,15 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * satisfied
    */
   private boolean residualConvergenceSatisfied() {
-    boolean temperatureSolved = err < getEffectiveTemperatureTolerance();
+    // Gate on lastTemperatureResidual, not on the working field err. err is the live iteration
+    // variable of every inner solver loop: it is reset to 1e10 or 0.0 on solver entry and
+    // accumulated tray by tray, so any solver pass that exits before finalizeSolve() leaves it
+    // holding a partial value. That made solved() report false while getLastSolveStatus() said
+    // RIGOROUS_CONVERGED and every residual printed by getConvergenceDiagnostics() was inside
+    // tolerance, which kept enclosing Recycle/ProcessSystem loops iterating to their timeout.
+    // lastTemperatureResidual and lastSolveStatus are both written by finalizeSolve() and both
+    // cleared by resetLastSolveMetrics(), so they stay consistent with each other.
+    boolean temperatureSolved = lastTemperatureResidual < getEffectiveTemperatureTolerance();
     boolean massSolved = lastMassResidual <= getEffectiveMassBalanceTolerance();
     boolean energySolved = !enforceEnergyBalanceTolerance
         || lastEnergyResidual <= getEffectiveEnthalpyBalanceTolerance();
@@ -7476,8 +7484,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @return {@code true} if the latest maximum internal traffic ratio is acceptable
    */
   private boolean internalTrafficSatisfied() {
+    // The solved-state guard must use the solved-state limit. Comparing against the relaxed
+    // update limit (1e5) let a column that circulates orders of magnitude more internal traffic
+    // than it is fed still report solved().
     return Double.isFinite(lastInternalTrafficRatio) && !lastInternalTrafficGuardReached
-        && lastInternalTrafficRatio <= MAX_RELAXED_INTERNAL_TRAFFIC_TO_FEED_RATIO;
+        && lastInternalTrafficRatio <= MAX_SOLVED_INTERNAL_TRAFFIC_TO_FEED_RATIO;
   }
 
   /**
@@ -9464,8 +9475,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       massOutput[i] = trays.get(i).getThermoSystem().getFlowRate("kg/hr");
       massBalance[i] = massInput[i] - massOutput[i];
 
-      System.out.println("Tray " + i + ": #in=" + numberOfInputStreams + ", massIn=" + massInput[i] + ", massOut="
-          + massOutput[i] + ", balance=" + massBalance[i]);
+      logger.debug("Tray {}: #in={}, massIn={}, massOut={}, balance={}", Integer.valueOf(i),
+          Integer.valueOf(numberOfInputStreams), Double.valueOf(massInput[i]), Double.valueOf(massOutput[i]),
+          Double.valueOf(massBalance[i]));
     }
     double massError = 0.0;
     for (int i = 0; i < numberOfTrays; i++) {
@@ -9504,8 +9516,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       }
 
       massBalance[i] = massInput[i] - massOutput[i];
-      System.out.println("Tray " + i + ", comp=" + componentName + ", #in=" + numberOfInputStreams + ", massIn="
-          + massInput[i] + ", massOut=" + massOutput[i] + ", balance=" + massBalance[i]);
+      logger.debug("Tray {}, comp={}, #in={}, massIn={}, massOut={}, balance={}", Integer.valueOf(i), componentName,
+          Integer.valueOf(numberOfInputStreams), Double.valueOf(massInput[i]), Double.valueOf(massOutput[i]),
+          Double.valueOf(massBalance[i]));
     }
 
     double massError = 0.0;
@@ -9978,7 +9991,27 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       updateMeshResiduals();
     }
     updateLastSolveStatus(productReconciled, fallbackProductsApplied);
+    warnOnNonFiniteColumnEndDuty();
     setCalculationIdentifier(id);
+  }
+
+  /**
+   * Warn when the reboiler or condenser duty is not a finite number after a solve.
+   *
+   * <p>
+   * A non-finite duty means the column-end energy balance could not be evaluated. It is silently propagated to callers
+   * through {@code getDuty()}, so it must at least be reported.
+   * </p>
+   */
+  private void warnOnNonFiniteColumnEndDuty() {
+    if (hasReboiler && getReboiler() != null && !Double.isFinite(getReboiler().getDuty())) {
+      logger.warn("Column {} finished with a non-finite reboiler duty ({}); the column-end energy balance "
+          + "could not be evaluated", getName(), Double.valueOf(getReboiler().getDuty()));
+    }
+    if (hasCondenser && getCondenser() != null && !Double.isFinite(getCondenser().getDuty())) {
+      logger.warn("Column {} finished with a non-finite condenser duty ({}); the column-end energy balance "
+          + "could not be evaluated", getName(), Double.valueOf(getCondenser().getDuty()));
+    }
   }
 
   /**
@@ -10042,6 +10075,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     if (fallbackProductsApplied) {
       setLastSolveStatus(SolveStatus.FALLBACK_PRODUCTS,
           "Public products were generated from guarded fallback flash products");
+      // The public products are now a single equilibrium flash of the mixed feeds, not the tray
+      // solution. The residual getters are computed against those fallback products and therefore
+      // look converged, so this warning is the only signal a caller gets. Callers must check
+      // getLastSolveStatus() and not the residuals alone.
+      logger.warn("Column {} returned guarded fallback products from an overall feed flash; "
+          + "tray solution was rejected and product flows/duties are not a rigorous column result", getName());
       return;
     }
     if (lastInternalTrafficGuardReached) {
@@ -10949,8 +10988,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
-   * Prints a simple energy balance for each tray to the console. The method calculates the total enthalpy of all inlet
-   * streams and compares it with the outlet enthalpy in order to highlight any discrepancies in the column setup.
+   * Logs a simple energy balance for each tray. The method calculates the total enthalpy of all inlet streams and
+   * compares it with the outlet enthalpy in order to highlight any discrepancies in the column setup.
    */
   public void energyBalanceCheck() {
     double[] energyInput = new double[numberOfTrays];
@@ -10965,8 +11004,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       energyOutput[i] += trays.get(i).getLiquidOutStream().getFluid().getEnthalpy();
       energyBalance[i] = energyInput[i] - energyOutput[i];
 
-      System.out.println("Tray " + i + ", #in=" + numberOfInputStreams + ", eIn=" + energyInput[i] + ", eOut="
-          + energyOutput[i] + ", balance=" + energyBalance[i]);
+      logger.debug("Tray {}, #in={}, eIn={}, eOut={}, balance={}", Integer.valueOf(i),
+          Integer.valueOf(numberOfInputStreams), Double.valueOf(energyInput[i]), Double.valueOf(energyOutput[i]),
+          Double.valueOf(energyBalance[i]));
     }
   }
 
@@ -11019,9 +11059,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
 
     // Display
     column.displayResult();
-    System.out.println("Gas out:");
+    logger.info("Gas out:");
     column.getGasOutStream().getThermoSystem().display();
-    System.out.println("Liquid out:");
+    logger.info("Liquid out:");
     column.getLiquidOutStream().getThermoSystem().display();
   }
 

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolvedConsistencyTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolvedConsistencyTest.java
@@ -90,9 +90,25 @@ public class DistillationColumnSolvedConsistencyTest extends neqsim.NeqSimTest {
     process.run();
 
     DistillationColumn column = (DistillationColumn) process.getUnit("TEG regeneration column");
+
+    boolean convergedStatus = column.getLastSolveStatus() == DistillationColumn.SolveStatus.RIGOROUS_CONVERGED
+        || column.getLastSolveStatus() == DistillationColumn.SolveStatus.RECONCILED_PRODUCTS;
+    Assertions.assertTrue(convergedStatus,
+        "Column did not converge on the first run, cannot check solved() stability. Status was "
+            + column.getLastSolveStatus() + ": " + column.getLastSolveStatusReason());
+
     boolean firstSolved = column.solved();
+    Assertions.assertTrue(firstSolved,
+        "Column should be solved() on the first run when status/residuals indicate convergence. Diagnostics:\n"
+            + column.getConvergenceDiagnostics());
 
     process.run();
+
+    convergedStatus = column.getLastSolveStatus() == DistillationColumn.SolveStatus.RIGOROUS_CONVERGED
+        || column.getLastSolveStatus() == DistillationColumn.SolveStatus.RECONCILED_PRODUCTS;
+    Assertions.assertTrue(convergedStatus,
+        "Column did not converge on the second run, cannot check solved() stability. Status was "
+            + column.getLastSolveStatus() + ": " + column.getLastSolveStatusReason());
 
     Assertions.assertEquals(firstSolved, column.solved(),
         "solved() flipped on a warm re-solve of an unchanged column. Diagnostics:\n"

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolvedConsistencyTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolvedConsistencyTest.java
@@ -1,0 +1,116 @@
+package neqsim.process.equipment.distillation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+
+/**
+ * Regression tests guarding the consistency of {@link DistillationColumn#solved()} with the solve status and the
+ * residuals reported by the public getters.
+ *
+ * <p>
+ * A column that reports {@code RIGOROUS_CONVERGED} and residuals inside their tolerances must also report
+ * {@code solved() == true}. When that contract was broken, enclosing recycle and process loops kept iterating a
+ * converged column until they hit an iteration cap or a wall-clock timeout and then returned a partially converged
+ * state.
+ * </p>
+ *
+ * @author NeqSim
+ * @version $Id: $Id
+ */
+public class DistillationColumnSolvedConsistencyTest extends neqsim.NeqSimTest {
+  /**
+   * Build a small TEG regeneration column with a reboiler and a condenser.
+   *
+   * @return a runnable process system whose single column unit is named "TEG regeneration column"
+   */
+  private ProcessSystem createTegRegenerationProcess() {
+    SystemInterface richTeg = new SystemSrkCPAstatoil(273.15 + 100.0, 1.05);
+    richTeg.addComponent("methane", 0.001);
+    richTeg.addComponent("water", 0.05);
+    richTeg.addComponent("TEG", 0.949);
+    richTeg.setMixingRule(10);
+    richTeg.setMultiPhaseCheck(false);
+
+    Stream richTegFeed = new Stream("rich TEG feed", richTeg);
+    richTegFeed.setFlowRate(5000.0, "kg/hr");
+    richTegFeed.setTemperature(100.0, "C");
+    richTegFeed.setPressure(1.05, "bara");
+
+    DistillationColumn column = new DistillationColumn("TEG regeneration column", 1, true, true);
+    column.addFeedStream(richTegFeed, 1);
+    column.getReboiler().setOutTemperature(273.15 + 202.0);
+    column.getCondenser().setOutTemperature(273.15 + 95.0);
+    column.setTopPressure(1.05);
+    column.setBottomPressure(1.05);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(richTegFeed);
+    process.add(column);
+    return process;
+  }
+
+  /**
+   * A column that reports a converged solve status with residuals inside tolerance must also report
+   * {@code solved() == true}.
+   */
+  @Test
+  public void solvedAgreesWithReportedStatusAndResiduals() {
+    ProcessSystem process = createTegRegenerationProcess();
+    process.run();
+
+    DistillationColumn column = (DistillationColumn) process.getUnit("TEG regeneration column");
+
+    boolean convergedStatus = column.getLastSolveStatus() == DistillationColumn.SolveStatus.RIGOROUS_CONVERGED
+        || column.getLastSolveStatus() == DistillationColumn.SolveStatus.RECONCILED_PRODUCTS;
+    Assertions.assertTrue(convergedStatus,
+        "Column did not converge, cannot check the solved()/status contract. Status was " + column.getLastSolveStatus()
+            + ": " + column.getLastSolveStatusReason());
+
+    Assertions.assertTrue(column.getLastTemperatureResidual() < column.getTemperatureTolerance(),
+        "Reported temperature residual should be inside tolerance for a converged column");
+    Assertions.assertTrue(column.getLastMassResidual() <= column.getMassBalanceTolerance(),
+        "Reported mass residual should be inside tolerance for a converged column");
+
+    Assertions.assertTrue(column.solved(),
+        "solved() must agree with the reported solve status and residuals. Diagnostics:\n"
+            + column.getConvergenceDiagnostics());
+  }
+
+  /**
+   * Running a converged column a second time must not flip it back to an unsolved state. Recycle loops re-run the
+   * column on every outer iteration and rely on this.
+   */
+  @Test
+  public void solvedIsStableAcrossRepeatedRuns() {
+    ProcessSystem process = createTegRegenerationProcess();
+    process.run();
+
+    DistillationColumn column = (DistillationColumn) process.getUnit("TEG regeneration column");
+    boolean firstSolved = column.solved();
+
+    process.run();
+
+    Assertions.assertEquals(firstSolved, column.solved(),
+        "solved() flipped on a warm re-solve of an unchanged column. Diagnostics:\n"
+            + column.getConvergenceDiagnostics());
+  }
+
+  /**
+   * The reboiler and condenser duties of a converged column must be finite numbers.
+   */
+  @Test
+  public void columnEndDutiesAreFinite() {
+    ProcessSystem process = createTegRegenerationProcess();
+    process.run();
+
+    DistillationColumn column = (DistillationColumn) process.getUnit("TEG regeneration column");
+    Assertions.assertTrue(Double.isFinite(column.getReboiler().getDuty()),
+        "Reboiler duty must be finite, was " + column.getReboiler().getDuty());
+    Assertions.assertTrue(Double.isFinite(column.getCondenser().getDuty()),
+        "Condenser duty must be finite, was " + column.getCondenser().getDuty());
+  }
+}


### PR DESCRIPTION
## Summary

`DistillationColumn.solved()` could return `false` for a column whose `getLastSolveStatus()` was `RIGOROUS_CONVERGED` and whose residuals — as reported by `getLastTemperatureResidual()` and `getConvergenceDiagnostics()` — were all inside their tolerances.

Because `Recycle`, `ProcessSystem` and `ProcessModel` use `solved()` to decide when to stop iterating, a converged column was re-solved until an iteration cap or a wall-clock timeout was hit, and the partially converged state at that moment was returned. Downstream consumers saw very long run times and results that drifted between runs.

## How it was found

While diagnosing the `equinor/NeqSimAPI` Dependabot PR that bumps `jneqsim` 3.1.5 → 3.16.0. Its integration suite reported `15 failed, 35 passed, 2 skipped in 13081 s (3 h 38 m)`, with the failures clustered almost entirely on TEG/glycol models that contain a `DistillationColumn`. The TEG loops settled 40–50 % above their user-specified circulation, e.g. `lean_TEG_flow_kg_hr` = 7579.5 against an input setpoint of 5040.0 kg/hr.

## Root cause

The convergence gate tested the private working field `err` instead of `lastTemperatureResidual`:

```java
boolean temperatureSolved = err < getEffectiveTemperatureTolerance();
```

`err` is the live iteration variable of every inner solver loop. It is reset to `1e10` or `0.0` on solver entry and accumulated tray by tray (`err += Math.abs(newTemp - oldtemps[i])`, `err = Math.max(err, latestInnerTempResidual)`, …). Any solver pass that exits before `finalizeSolve()` leaves it holding a partial value, while `lastTemperatureResidual` still carries the last finalized result.

Measured on the TEG regeneration column in `GlycolModulesTest` (private state read by reflection, same run):

```
getLastSolveStatus()          = RIGOROUS_CONVERGED
                                "Tray solution satisfies active rigorous convergence gates"
getLastTemperatureResidual()  = 0.0168 K      (tolerance 0.05 K)
getLastMassResidual()         = 1.5e-15       (tolerance 0.2)
private field err             = 0.26998       -> temperature gate FALSE
solved()                      = false
```

`getConvergenceDiagnostics()` printed `Solved: false` directly under a residual block in which every entry was inside tolerance.

## Changes

**`residualConvergenceSatisfied()` gates on `lastTemperatureResidual`.**
Both `lastTemperatureResidual` and `lastSolveStatus` are written by `finalizeSolve()` and both cleared by `resetLastSolveMetrics()` (which sets `lastSolveStatus = NOT_RUN`), so the two stay consistent and a stale-good residual cannot make `solved()` return `true`. `err` remains the solvers' internal working variable.

**`internalTrafficSatisfied()` uses the solved-state limit.**
It compared against `MAX_RELAXED_INTERNAL_TRAFFIC_TO_FEED_RATIO` (`1e5`, the bound used during relaxed tear-stream updates) rather than `MAX_SOLVED_INTERNAL_TRAFFIC_TO_FEED_RATIO` (`100`), which is the constant named for exactly this check and was otherwise almost unused.

**Guarded fallback products are no longer silent.**
When the tray solution is rejected, `updateProductsFromOverallFeedFlash()` replaces the public products with a *single equilibrium flash of the mixed feeds*. The residual getters are then computed against those fallback products and look perfect, so nothing in the numbers reveals what happened. Observed on the same TEG regenerator:

```
getLastSolveStatus()   = FALLBACK_PRODUCTS
reboiler liquid out    = 12870 kg/hr   (9154 kg/hr on the converged run, +40 %)
Reboiler.getDuty()     = NaN
getLastMassResidual()  = 6.6e-16
```

`updateLastSolveStatus()` now logs a warning stating that product flows and duties are not a rigorous column result and that callers must check `getLastSolveStatus()` rather than the residuals alone.

**Non-finite column-end duties are reported.**
New `warnOnNonFiniteColumnEndDuty()` logs a warning when the reboiler or condenser duty is `NaN`/infinite after a solve, instead of letting `getDuty()` propagate it silently.

**Logging rule.**
`massBalanceCheck()`, `componentMassBalanceCheck()`, `energyBalanceCheck()` and `main()` used `System.out.println`; they now use the class logger with parameterised messages.

## New test

`src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolvedConsistencyTest.java` builds a small TEG regeneration column (1 tray + reboiler + condenser, both ends temperature-specified) and asserts:

1. `solvedAgreesWithReportedStatusAndResiduals` — when the status is converged and the reported temperature and mass residuals are inside `getTemperatureTolerance()` / `getMassBalanceTolerance()`, `solved()` is `true`. The failure message embeds `getConvergenceDiagnostics()`.
2. `solvedIsStableAcrossRepeatedRuns` — a warm re-solve of an unchanged column does not flip `solved()`. Recycle loops depend on this.
3. `columnEndDutiesAreFinite` — reboiler and condenser duties are finite numbers.

Test 1 fails on `master` and passes with this change.

## Verification

Before / after on the `GlycolModulesTest` TEG regenerator:

| | before | after |
|---|---|---|
| `solved()` | `false` | `true` |
| `getLastSolveStatus()` | `RIGOROUS_CONVERGED` | `RIGOROUS_CONVERGED` |
| `getLastTemperatureResidual()` | 3.6e-4 (tol 0.05) | 3.6e-4 (tol 0.05) |
| private `err` | 1.0E10 | 1.0E10 (no longer consulted) |

Test runs on this branch:

- `DistillationColumnSolvedConsistencyTest`, `GlycolRigTest`, `GlycolModulesTest`, `TegRegenerationEnergyBalanceTest` — 9 tests, 0 failures
- whole `neqsim.process.equipment.distillation` package — 101 tests, 0 failures, 1 skipped
- `neqsim.process.processmodel.**` + `neqsim.process.equipment.absorber` + `neqsim.process.equipment.util` — 830 tests, 0 failures, 3 skipped
- `mvnw spotless:apply` then `spotless:check` — clean
- `mvnw javadoc:javadoc` — clean

## Compatibility

No API change. Callers that worked around the old behaviour by ignoring `solved()` can now rely on it. `getLastSolveStatus()` remains the authoritative signal, and it is now the only way to detect the `FALLBACK_PRODUCTS` case — the residual getters cannot reveal it.

The tightened internal-traffic gate can, in principle, turn a previously "solved" column into an unsolved one if it circulates more than 100× its external feed. That is not physical for a real column, and no test in the suite regressed.

## Documentation

`CHANGELOG_AGENT_NOTES.md` gains two entries:

1. This fix, with the migration note that callers should check `getLastSolveStatus()` in addition to the residual getters.
2. A previously undocumented **breaking** change from PR #2156 (2026-05-14): `Condenser.setRefluxRatio(r)` used to be applied directly as the split fraction of condensed liquid returned as reflux; it is now interpreted as a true reflux ratio `R = L/D` and converted internally to `R / (1 + R)`. Models calibrated against the old meaning run at a different reflux; to reproduce an old split fraction `f`, pass `R = f / (1 - f)`.

## Known issues found in the same investigation, not addressed here

- `RuntimeException: Phase with phase type AQUEOUS not found.` from a `PipeBeggsAndBrills` outlet in a MEG/water model. `SystemThermo.getPhase(PhaseType)` is unchanged since v3.1.5 — the fluid genuinely no longer has an aqueous phase. Prime suspect is the duplicate-phase merge/removal rewrite in `TPmultiflash` (PR #2273). Needs its own reproduction and regression test.
- `src/test/java/neqsim/process/util/example/TEGdehydrationProcessDistillation.java` `main()` throws on startup: duplicate unit name `lean TEG to absorber`.
