### PR TITLE
docs: clarify vessel pressure validation

### DIFF
--- a/docs/process/equipment/vessel_depressurization.md
+++ b/docs/process/equipment/vessel_depressurization.md
@@ -697,9 +697,10 @@ List<String> warnings = vessel.validateWithWarnings();  // returns errors and wa
 ```
 
 `validate()` rejects configurations that cannot produce a meaningful simulation, including a
-back pressure greater than or equal to the initial pressure. For `CALCULATED` or `TRANSIENT_WALL`
-heat transfer, it also rejects a non-positive vessel length or diameter; the default dimensions are
-positive. It logs non-critical configuration warnings.
+back pressure greater than or equal to the initial pressure. When the calculation type is
+`ENERGY_BALANCE` and heat transfer is `CALCULATED` or `TRANSIENT_WALL`, it also rejects a
+non-positive vessel length or diameter; the default dimensions are positive. It logs non-critical
+configuration warnings.
 
 `validateWithWarnings()` does not throw configuration errors. It returns them with an `ERROR:`
 prefix together with non-critical warnings. Initial pressures above 700 bar produce a non-critical

--- a/docs/process/equipment/vessel_depressurization.md
+++ b/docs/process/equipment/vessel_depressurization.md
@@ -702,7 +702,7 @@ vessel geometry. It logs non-critical configuration warnings.
 
 `validateWithWarnings()` does not throw configuration errors. It returns them with an `ERROR:`
 prefix together with non-critical warnings. Initial pressures above 700 bar produce an
-Equation-of-State validity warning, not an error. For example, an 80 bara initial state with 1.2
+`equation-of-state` validity warning, not an error. For example, an 80 bara initial state with 1.2
 bara back pressure is valid, while a 750 bara initial state with the same back pressure remains
 valid but produces the high-pressure warning.
 

--- a/docs/process/equipment/vessel_depressurization.md
+++ b/docs/process/equipment/vessel_depressurization.md
@@ -701,10 +701,10 @@ back pressure greater than or equal to the initial pressure and calculated heat 
 vessel geometry. It logs non-critical configuration warnings.
 
 `validateWithWarnings()` does not throw configuration errors. It returns them with an `ERROR:`
-prefix together with non-critical warnings. Initial pressures above 700 bar produce an
-`equation-of-state` validity warning, not an error. For example, an 80 bara initial state with 1.2
-bara back pressure is valid, while a 750 bara initial state with the same back pressure remains
-valid but produces the high-pressure warning.
+prefix together with non-critical warnings. Initial pressures above 700 bar produce a non-critical
+warning to confirm that the equation of state is valid for the pressure range. For example, an 80
+bara initial state with 1.2 bara back pressure is valid, while a 750 bara initial state with the same
+back pressure remains valid but produces the high-pressure warning.
 
 ### Orifice Sizing (API 521)
 

--- a/docs/process/equipment/vessel_depressurization.md
+++ b/docs/process/equipment/vessel_depressurization.md
@@ -697,8 +697,9 @@ List<String> warnings = vessel.validateWithWarnings();  // returns errors and wa
 ```
 
 `validate()` rejects configurations that cannot produce a meaningful simulation, including a
-back pressure greater than or equal to the initial pressure and calculated heat transfer without
-vessel geometry. It logs non-critical configuration warnings.
+back pressure greater than or equal to the initial pressure. For `CALCULATED` or `TRANSIENT_WALL`
+heat transfer, it also rejects a non-positive vessel length or diameter; the default dimensions are
+positive. It logs non-critical configuration warnings.
 
 `validateWithWarnings()` does not throw configuration errors. It returns them with an `ERROR:`
 prefix together with non-critical warnings. Initial pressures above 700 bar produce a non-critical

--- a/docs/process/equipment/vessel_depressurization.md
+++ b/docs/process/equipment/vessel_depressurization.md
@@ -701,10 +701,10 @@ back pressure greater than or equal to the initial pressure and calculated heat 
 vessel geometry. It logs non-critical configuration warnings.
 
 `validateWithWarnings()` does not throw configuration errors. It returns them with an `ERROR:`
-prefix together with non-critical warnings. Initial pressures above 700 bar produce an equation-of-
-state validity warning, not an error. For example, an 80 bara initial state with 1.2 bara back
-pressure is valid, while a 750 bara initial state with the same back pressure remains valid but
-produces the high-pressure warning.
+prefix together with non-critical warnings. Initial pressures above 700 bar produce an
+Equation-of-State validity warning, not an error. For example, an 80 bara initial state with 1.2
+bara back pressure is valid, while a 750 bara initial state with the same back pressure remains
+valid but produces the high-pressure warning.
 
 ### Orifice Sizing (API 521)
 

--- a/docs/process/equipment/vessel_depressurization.md
+++ b/docs/process/equipment/vessel_depressurization.md
@@ -3,8 +3,6 @@ title: "Vessel Depressurization and Filling"
 description: "Dynamic modeling of pressure vessel filling, depressurization, and blowdown using VesselDepressurization. Covers thermodynamic modes, heat transfer models (real-gas beta, momentum-based mixed convection, Biot correction, Rohsenow boiling), fire cases, composite vessels, flow assurance, CNG tank scenarios, and Python/Java API reference."
 ---
 
-# Vessel Depressurization and Filling
-
 Dynamic modeling of pressure vessel filling, depressurization, and blowdown using the `VesselDepressurization` class.
 
 ## Table of Contents
@@ -219,12 +217,16 @@ vessel.setFlowDirection(FlowDirection.FILLING);     // pressurization
 
 ```java
 vessel.setBackPressure(1.0);                // downstream pressure [bara]
-vessel.setTargetPressure(20.0);             // stop condition [bar]
+vessel.setTargetPressure(20.0);             // stop condition [bara]
 vessel.setAmbientTemperature(288.15);       // ambient [K]
 vessel.setInletTemperature(288.15);         // filling gas supply T [K]
 vessel.setInletTemperature(15.0, "C");      // or with unit string
 vessel.setValveOpeningTime(5.0);            // ESD ramp time [s] (0 = instant)
 ```
+
+Pressure setters use absolute bar at the public API boundary. `setBackPressure()` and
+`setTargetPressure()` convert their inputs to pascals internally; do not pre-convert these values.
+The initial fluid-system pressure returned by `SystemInterface.getPressure()` is also in bar.
 
 ### Initial Liquid Level
 
@@ -686,10 +688,23 @@ Map<String, String> risks = vessel.assessFlowAssuranceRisks();
 
 ### Validation
 
+Run validation after the initial vessel state and boundary conditions are configured and before
+starting the transient simulation.
+
 ```java
-vessel.validate();                               // throws on errors
-List<String> warnings = vessel.validateWithWarnings();  // non-throwing
+vessel.validate();                                      // throws on configuration errors
+List<String> warnings = vessel.validateWithWarnings();  // returns errors and warnings
 ```
+
+`validate()` rejects configurations that cannot produce a meaningful simulation, including a
+back pressure greater than or equal to the initial pressure and calculated heat transfer without
+vessel geometry. It logs non-critical configuration warnings.
+
+`validateWithWarnings()` does not throw configuration errors. It returns them with an `ERROR:`
+prefix together with non-critical warnings. Initial pressures above 700 bar produce an equation-of-
+state validity warning, not an error. For example, an 80 bara initial state with 1.2 bara back
+pressure is valid, while a 750 bara initial state with the same back pressure remains valid but
+produces the high-pressure warning.
 
 ### Orifice Sizing (API 521)
 


### PR DESCRIPTION
## Summary

D035 (rotation scope 8: recent merged implementation versus documentation coverage) follows merged vessel-validation fix #2623.

Contributes to #2499.

### Frozen scope

- Changed: `docs/process/equipment/vessel_depressurization.md`
- Source evidence: `src/main/java/neqsim/process/equipment/tank/VesselDepressurization.java`
- Regression evidence: `src/test/java/neqsim/process/equipment/tank/VesselDepressurizationTest.java`
- Excluded: distillation documentation and implementation because active distillation work overlapped during the scan; separator entropy documentation because #2626 already has current exergy guidance and focused regression coverage.

## Confirmed defects and root cause

1. **Low — Jekyll title duplication:** the page repeated its front-matter title as a source H1.
2. **Medium — technical/unit guidance:** after #2623 corrected mixed pressure-unit validation, the page still omitted the absolute-bar public API boundary, internal Pa conversion, exact error/warning semantics, and >700 bar equation-of-state warning behavior.

## Fixes

- Removed the duplicate source H1.
- Clarified that `setBackPressure()` and `setTargetPressure()` accept absolute bar and convert internally to Pa; `SystemInterface.getPressure()` already returns bar.
- Documented when to call `validate()`, which invalid configurations it rejects, and how `validateWithWarnings()` reports errors and non-critical warnings.
- Documented the exact geometry condition: only `ENERGY_BALANCE` with `CALCULATED` or `TRANSIENT_WALL` heat transfer rejects non-positive length or diameter; defaults are positive.
- Added the focused-test behavior: 80/1.2 bara is valid, while 750/1.2 bara remains valid but produces a high-pressure EOS-validity warning.

## Validation

Final head: `8b0b7bbcbb3e29cc8e6d7c312192447b728e79e8`

- Compared every technical claim with current source and `testValidationPressureUnits`, `testValidateMethod`, and `testValidateWithWarningsMethod`.
- Diff: one documentation file, +22/-5; branch is zero commits behind `master` and mergeable.
- Front matter present; zero source H1 headings after repair.
- 70 code-fence markers balanced; no new APIs or executable examples.
- All table lines retained.
- 12 display and 76 inline dollar delimiters balanced; no legacy `\(...\)` or `\[...\]` delimiters.
- All table-of-contents anchors resolve.
- All four relative targets resolve: HTC comparison notebook, QRA integration guide, fire heat-transfer guide, and tank guide.
- Hosted checks passed on the reconciled final head: build/test/Javadoc, pre-commit, Spotless, documentation search coverage, and CodeQL.
- Copilot: two actionable inline findings were technically valid, applied, validated, replied to, and resolved. One suppressed low-confidence observation correctly identified the missing `ENERGY_BALANCE` condition and was also applied. The final-head review covered 1/1 files and generated no new comments; no unresolved review threads remain.

No external Markdown links, changed equations, images, notebooks, production code, or new executable examples are in scope. No rendered-site artifact was available, so browser inspection is not claimed. No merge or direct `master` change was performed.