### PR TITLE
Avoid CPA K-value warm starts in PS flashes

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/PSFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/PSFlash.java
@@ -134,19 +134,36 @@ public class PSFlash extends QfuncFlash {
   public void onPhaseSolve() {
   }
 
+  /**
+   * Check whether K-value warm starts are suitable for the inner TP flashes.
+   *
+   * <p>
+   * CPA association-site fractions can change strongly with temperature. Reusing K-values while the PS solver moves
+   * through temperature space may therefore increase TP-flash work or bias the iteration path. Cubic EOS models retain
+   * the established warm-start acceleration.
+   * </p>
+   *
+   * @return {@code true} when inner TP flashes may reuse K-values
+   */
+  protected boolean isInnerTpFlashWarmStartSafe() {
+    String modelName = system == null || system.getModelName() == null ? "" : system.getModelName();
+    return !modelName.toUpperCase(java.util.Locale.ROOT).contains("CPA");
+  }
+
   /** {@inheritDoc} */
   @Override
   public void run() {
     // First TPflash runs COLD (Wilson initial K) so that stale K from a
     // previous unrelated flash (at different P/T) does not bias the solution.
-    // Then enable K-value warm-start only for subsequent TPflash iterations
-    // within this outer PS-flash loop — safe because the outer loop converges
-    // on T, absorbing inner SS-path differences. Typical speedup: 3-5x.
+    // Then enable K-value warm-start for subsequent TPflash iterations only when
+    // the thermodynamic model is suitable. CPA association terms can make K-values
+    // stale as temperature changes, increasing work in glycol/water calculations.
     boolean prevWarm = neqsim.thermo.ThermodynamicModelSettings.isUseWarmStartKValues();
+    boolean useInnerWarmStart = isInnerTpFlashWarmStartSafe();
     try {
       neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(false);
       tpFlash.run();
-      neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(true);
+      neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(useInnerWarmStart);
 
       if (type == 0) {
         solveQ();

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/PSFlashWarmStartPolicyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/PSFlashWarmStartPolicyTest.java
@@ -66,7 +66,7 @@ public class PSFlashWarmStartPolicyTest {
    */
   @Test
   public void richTegCpaFlashConvergesRepeatablyAtNearbyPressures() {
-    double[] dischargePressuresBara = new double[] {1.35, 1.50};
+    double[] dischargePressuresBara = new double[] { 1.35, 1.50 };
 
     for (double dischargePressureBara : dischargePressuresBara) {
       SystemInterface system = createRichTegFluid();

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/PSFlashWarmStartPolicyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/PSFlashWarmStartPolicyTest.java
@@ -1,0 +1,159 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.ThermodynamicModelSettings;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Tests model-aware K-value warm starts and representative CPA robustness in {@link PSFlash}. */
+public class PSFlashWarmStartPolicyTest {
+
+  /** CPA PS flashes keep inner TP flashes cold and restore the caller's setting. */
+  @Test
+  public void cpaDisablesInnerWarmStart() {
+    SystemInterface system = new SystemSrkCPAstatoil(373.15, 1.2);
+    RecordingPSFlash flash = new RecordingPSFlash(system);
+    RecordingTPflash innerFlash = new RecordingTPflash(system);
+    flash.setInnerFlash(innerFlash);
+
+    boolean previousWarmStart = ThermodynamicModelSettings.isUseWarmStartKValues();
+    try {
+      ThermodynamicModelSettings.setUseWarmStartKValues(true);
+      flash.run();
+
+      assertEquals(1, innerFlash.getRunCount());
+      assertFalse(innerFlash.wasWarmStartEnabled(), "The first TP flash must use a cold start");
+      assertFalse(flash.wasWarmStartEnabledDuringSolve(),
+          "CPA PS iterations must not reuse K-values across temperatures");
+      assertTrue(ThermodynamicModelSettings.isUseWarmStartKValues(),
+          "PSFlash must restore the caller's warm-start setting");
+    } finally {
+      ThermodynamicModelSettings.setUseWarmStartKValues(previousWarmStart);
+    }
+  }
+
+  /** Cubic-EOS PS flashes retain the established inner warm-start acceleration. */
+  @Test
+  public void cubicEosRetainsInnerWarmStart() {
+    SystemInterface system = new SystemSrkEos(300.15, 20.0);
+    RecordingPSFlash flash = new RecordingPSFlash(system);
+    RecordingTPflash innerFlash = new RecordingTPflash(system);
+    flash.setInnerFlash(innerFlash);
+
+    boolean previousWarmStart = ThermodynamicModelSettings.isUseWarmStartKValues();
+    try {
+      ThermodynamicModelSettings.setUseWarmStartKValues(false);
+      flash.run();
+
+      assertEquals(1, innerFlash.getRunCount());
+      assertFalse(innerFlash.wasWarmStartEnabled(), "The first TP flash must use a cold start");
+      assertTrue(flash.wasWarmStartEnabledDuringSolve(),
+          "Cubic-EOS PS iterations should reuse K-values after the first TP flash");
+      assertFalse(ThermodynamicModelSettings.isUseWarmStartKValues(),
+          "PSFlash must restore the caller's warm-start setting");
+    } finally {
+      ThermodynamicModelSettings.setUseWarmStartKValues(previousWarmStart);
+    }
+  }
+
+  /**
+   * A representative rich-TEG CPA fluid must solve repeatably at two nearby discharge pressures.
+   */
+  @Test
+  public void richTegCpaFlashConvergesRepeatablyAtNearbyPressures() {
+    double[] dischargePressuresBara = new double[] {1.35, 1.50};
+
+    for (double dischargePressureBara : dischargePressuresBara) {
+      SystemInterface system = createRichTegFluid();
+      ThermodynamicOperations operations = new ThermodynamicOperations(system);
+      operations.TPflash();
+      system.initProperties();
+      double targetEntropy = system.getEntropy();
+
+      system.setPressure(dischargePressureBara);
+      system.setTemperature(433.15);
+      operations.PSflash(targetEntropy);
+      system.initProperties();
+
+      double firstTemperature = system.getTemperature();
+      assertEquals(targetEntropy, system.getEntropy(), 1.0e-3,
+          "CPA PS flash must satisfy entropy at " + dischargePressureBara + " bara");
+      assertEquals(dischargePressureBara, system.getPressure("bara"), 1.0e-10,
+          "PS flash must preserve specified pressure");
+      assertTrue(Double.isFinite(firstTemperature) && firstTemperature > 350.0 && firstTemperature < 500.0,
+          "CPA PS flash temperature must remain physical");
+
+      system.setTemperature(firstTemperature + 5.0);
+      operations.PSflash(targetEntropy);
+      system.initProperties();
+
+      assertEquals(targetEntropy, system.getEntropy(), 1.0e-3,
+          "Repeated CPA PS flash must satisfy entropy at " + dischargePressureBara + " bara");
+      assertEquals(firstTemperature, system.getTemperature(), 0.05,
+          "Repeated CPA PS flash must return the same physical state");
+    }
+  }
+
+  /** Create the rich TEG/water CPA fluid used by the regenerator engineering regression. */
+  private SystemInterface createRichTegFluid() {
+    SystemInterface system = new SystemSrkCPAstatoil(418.15, 1.21325);
+    system.addComponent("nitrogen", 0.00005);
+    system.addComponent("water", 0.19995);
+    system.addComponent("TEG", 0.8);
+    system.setMixingRule(10);
+    system.setMultiPhaseCheck(true);
+    return system;
+  }
+
+  /** PS flash with a deterministic outer solve used to observe the warm-start policy. */
+  private static final class RecordingPSFlash extends PSFlash {
+    private boolean warmStartEnabledDuringSolve;
+
+    RecordingPSFlash(SystemInterface system) {
+      super(system, 0.0, 0);
+    }
+
+    void setInnerFlash(Flash innerFlash) {
+      tpFlash = innerFlash;
+    }
+
+    boolean wasWarmStartEnabledDuringSolve() {
+      return warmStartEnabledDuringSolve;
+    }
+
+    @Override
+    public double solveQ() {
+      warmStartEnabledDuringSolve = ThermodynamicModelSettings.isUseWarmStartKValues();
+      return system.getTemperature();
+    }
+  }
+
+  /** TP flash test double that records the policy used for its invocation. */
+  private static final class RecordingTPflash extends TPflash {
+    private int runCount;
+    private boolean warmStartEnabled;
+
+    RecordingTPflash(SystemInterface system) {
+      super(system);
+    }
+
+    int getRunCount() {
+      return runCount;
+    }
+
+    boolean wasWarmStartEnabled() {
+      return warmStartEnabled;
+    }
+
+    @Override
+    public void run() {
+      runCount++;
+      warmStartEnabled = ThermodynamicModelSettings.isUseWarmStartKValues();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Makes the PS-flash inner TP-flash warm-start policy model-aware, following the validated PH-flash policy merged in #2631:

- the first TP flash remains cold for every model;
- subsequent inner TP flashes retain K-value warm starts for cubic EOS models;
- CPA models keep cold K initialization while the outer PS solve changes temperature;
- the caller's thread-local warm-start setting is restored in every path.

This is a focused improvement to entropy-flash robustness and efficiency for associating systems used in column calculations, compressors, expanders, and other isentropic process steps.

## Problem and root cause

Issue #2110 identifies automatic K-value reuse in iterative PS/PH/TV/PV/PU/PVF/PHsolid/VU/Q-function flashes as a CPA regression source. In its representative TEG-regeneration case, cubic SRK improved from 34.4 s to 30.4 s (-12%), while CPA regressed from 55.9 s to 104.8 s (+87%).

Current `PSFlash.run()` unconditionally enables K-value reuse after its first TP flash. For CPA, association-site fractions for water and glycols can change strongly as the outer entropy solve changes temperature. A reused K vector can therefore be a worse TP-flash seed than cold initialization and add work or destabilize the iteration. Historical compressor fix #2130 also documents PS-flash divergence around associating fluids and uses a more expensive fixed-pressure TP/Newton fallback.

## Algorithmic change

`PSFlash` now evaluates the thermodynamic model once per run:

- model name containing `CPA`: keep inner TP flashes cold;
- other models: preserve the existing warm-start acceleration;
- first inner TP flash remains cold for every model;
- no tolerance, residual, derivative, damping, convergence acceptance, or flash equation changes.

## Tests and engineering cases

Added `PSFlashWarmStartPolicyTest`:

1. deterministic CPA regression: first and subsequent inner TP flashes stay cold;
2. deterministic SRK regression: first TP flash is cold and later iterations retain warm start;
3. caller thread-local settings are restored for initially enabled and disabled states;
4. representative rich-TEG CPA mixture (N2/water/TEG = 0.00005/0.19995/0.8, CPA rule 10) solves isentropically at nearby 1.35 and 1.50 bara discharge pressures;
5. each engineering point checks entropy specification, fixed pressure, physical finite temperature, and repeatability from a perturbed temperature.

Before this change, the deterministic CPA test observes warm start enabled during the outer PS solve and fails.

## Performance evidence

No wall-clock assertion is added. Deterministic policy coverage prevents the known CPA-hostile path, while the two nearby engineering points verify repeatability and specification satisfaction. Issue #2110 remains the motivating process benchmark; a stable benchmark environment should rerun its complete TEG flowsheet for end-to-end timing.

## Compatibility and risk

- no public API change;
- no changed tolerances or convergence acceptance;
- cubic EOS behavior is unchanged;
- only model names containing `CPA` change policy;
- cold K initialization is the established robust fallback;
- a specific CPA state that benefited from warm reuse may take more inner work, but avoids the documented general regression and instability.

## Post-publication validation (2026-07-27)

The PR was merged externally while its full matrix was still running.

- Spotless, pre-commit, PaperLab, CodeQL, and Java 21 Javadoc passed.
- On Windows/Java 21, all three `PSFlashWarmStartPolicyTest` cases passed, including both rich-TEG operating points and repeatability.
- The full suite reached 10,806 tests and failed on three unrelated tests: `CompressorTest.testRunWithEnergyStreamInput`, `GasTurbineTest.testSetInletStream`, and `ProcessSystemTest.testCopy`.
- PR #2635, already present in this PR's base through merge commit `e9d102b`, had failed earlier with the exact same three tests and exact same observed values. Its change log records the Expander step-count change that explains the compressor numeric baseline; its process identity changes explain the equality assertions.
- Ubuntu/Java 21 was cancelled after the Windows failure, and Java 8 jobs were skipped. Therefore this PR does not claim a fully green broad matrix. No PSFlash-specific regression was observed.

## Remaining limitations

This PR intentionally covers `PSFlash` only. The remaining iterative flash variants from #2110 should be handled one by one with their own representative cases and regression evidence.