### PR TITLE
[AI-Assisted] Integrate capacity-aware compressor results with optimization

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,39 @@
 
 ---
 
+## 2026-07-27 — Capacity-aware compressor operating points and optimizer alignment
+
+### Summary
+
+Compressor reporting, bottleneck detection, and pressure-boundary optimization now use the same
+capacity-constraint semantics. A typed immutable result provides a stable handoff to field-life,
+energy, emissions, and external calculation tools without replacing the existing map/JSON API.
+
+### New API
+
+| API | What it does |
+|---|---|
+| `Compressor.getOperatingPointResult()` | Returns physical performance, map status, recycle losses, pressure-target status, limiting constraint, and detached capacity snapshots |
+| `Compressor.getOperatingPointResult(tolerance)` | Uses a caller-defined relative discharge-pressure tolerance |
+| `CompressorOperatingPointResult.toJson()` | Exports the typed result as schema-versioned JSON |
+
+### Capacity and optimization behavior
+
+- Surge and stonewall are now true minimum-good constraints: their current values are physical
+  margin percentages, and configured minima are 10 % and 5 % by default.
+- Hard minimum constraints now report `isHardLimitExceeded() == true` below their minimum.
+- `PressureBoundaryOptimizer` consumes every enabled, non-design, non-advisory compressor
+  `CapacityConstraint`. Custom power and speed settings remain explicit additional overrides.
+
+> **Behavior change:** a compressor below its required surge or stonewall margin is now infeasible
+> to bottleneck and optimization APIs. Previously the already-normalized margin supplier prevented
+> the minimum value from becoming a violation.
+
+### Tests
+
+`CompressorOperatingPointResultTest`, `CapacityConstraintMinimumLimitTest`, and
+`PressureBoundaryCapacityIntegrationTest`.
+
 ## 2026-07-27 — Column convergence gate corrected, solver runtime knobs reachable, ProcessModel per-boundary-stream diagnostics
 
 ### Summary

--- a/docs/process/equipment/compressors.md
+++ b/docs/process/equipment/compressors.md
@@ -212,7 +212,7 @@ The map / JSON contains the following fields:
 
 | Field | Unit | Description |
 |-------|------|-------------|
-| `schemaVersion` | — | JSON schema version (`"1.0"`) |
+| `schemaVersion` | — | JSON schema version (`"1.1"`) |
 | `name` | — | Compressor name |
 | `flow_m3hr` | m³/hr | Inlet actual volumetric flow rate |
 | `head_kJkg` | kJ/kg | Polytropic fluid head |
@@ -231,6 +231,30 @@ The map / JSON contains the following fields:
 
 When no chart is active, `withinChart` is `true` and `limitingConstraint` is `no_chart`.
 Values that cannot be computed are returned as `NaN`.
+
+### Capacity-aware typed result
+
+For optimization, bottleneck analysis, field-life studies, or exchange with tools such as eCalc,
+use the immutable typed result. It adds the calculated-versus-requested discharge pressure,
+pressure-target status, anti-surge recycle and cooler losses, maximum capacity utilization, the
+limiting constraint, and detached snapshots of every compressor constraint.
+
+```java
+CompressorOperatingPointResult result = compressor.getOperatingPointResult(0.02);
+boolean feasible = result.isFeasible();
+String limitingConstraint = result.getLimitingConstraint();
+double recycleLossKW = result.getRecyclePowerLossKW();
+List<CompressorOperatingPointResult.ConstraintSnapshot> constraints =
+    result.getConstraints();
+String resultJson = result.toJson();
+```
+
+The result reuses the same `CapacityConstraint` objects as
+`ProcessSystem.findBottleneck()` and `CapacityConstraintAdapter`.
+`PressureBoundaryOptimizer` also consumes these constraints, so surge, stonewall, speed,
+driver power, discharge temperature, and custom vendor limits have identical semantics in
+reporting and optimization. Explicit optimizer power and speed settings remain additional
+overrides.
 
 ---
 

--- a/docs/process/equipment/compressors.md
+++ b/docs/process/equipment/compressors.md
@@ -249,8 +249,8 @@ List<CompressorOperatingPointResult.ConstraintSnapshot> constraints =
 String resultJson = result.toJson();
 ```
 
-The result reuses the same `CapacityConstraint` objects as
-`ProcessSystem.findBottleneck()` and `CapacityConstraintAdapter`.
+The result evaluates the same `CapacityConstraint` definitions used by
+`ProcessSystem.findBottleneck()` and `CapacityConstraintAdapter`, but returns detached snapshots for safe exchange.
 `PressureBoundaryOptimizer` also consumes these constraints, so surge, stonewall, speed,
 driver power, discharge temperature, and custom vendor limits have identical semantics in
 reporting and optimization. Explicit optimizer power and speed settings remain additional

--- a/src/main/java/neqsim/process/equipment/capacity/CapacityConstraint.java
+++ b/src/main/java/neqsim/process/equipment/capacity/CapacityConstraint.java
@@ -393,9 +393,9 @@ public class CapacityConstraint implements Serializable {
   }
 
   /**
-   * Checks if this constraint exceeds the absolute maximum (for HARD constraints).
+   * Checks whether this HARD constraint exceeds its absolute limit.
    *
-   * @return true if current value exceeds max value
+   * @return true if a maximum constraint is above its maximum or a minimum constraint is below its minimum
    */
   public boolean isHardLimitExceeded() {
     if (type != ConstraintType.HARD) {

--- a/src/main/java/neqsim/process/equipment/capacity/CapacityConstraint.java
+++ b/src/main/java/neqsim/process/equipment/capacity/CapacityConstraint.java
@@ -398,7 +398,13 @@ public class CapacityConstraint implements Serializable {
    * @return true if current value exceeds max value
    */
   public boolean isHardLimitExceeded() {
-    if (type != ConstraintType.HARD || maxValue == Double.MAX_VALUE) {
+    if (type != ConstraintType.HARD) {
+      return false;
+    }
+    if (isMinimumConstraint()) {
+      return getCurrentValue() < minValue;
+    }
+    if (maxValue == Double.MAX_VALUE) {
       return false;
     }
     return getCurrentValue() > maxValue;

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -5213,7 +5213,7 @@ public class Compressor extends TwoPortEquipment
         .setDesignValue(Double.MAX_VALUE).setMinValue(10.0).setWarningThreshold(0.85).setValueSupplier(() -> {
           double marginRatio = this.getDistanceToSurge();
           if (Double.isNaN(marginRatio) || Double.isInfinite(marginRatio)) {
-            return Double.MAX_VALUE;
+            return 0.0;
           }
           return marginRatio * 100.0;
         }).setEnabled(chartActive));
@@ -5224,7 +5224,7 @@ public class Compressor extends TwoPortEquipment
         .setDesignValue(Double.MAX_VALUE).setMinValue(5.0).setWarningThreshold(0.90).setValueSupplier(() -> {
           double marginRatio = this.getDistanceToStoneWall();
           if (Double.isNaN(marginRatio) || Double.isInfinite(marginRatio)) {
-            return Double.MAX_VALUE;
+            return 0.0;
           }
           return marginRatio * 100.0;
         }).setEnabled(chartActive));

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -3038,8 +3038,8 @@ public class Compressor extends TwoPortEquipment
    * Returns an immutable, capacity-aware operating-point result.
    *
    * <p>
-   * The result adds pressure-target classification, anti-surge recycle losses, and detached
-   * capacity-constraint snapshots to the legacy {@link #getOperatingPoint()} map.
+   * The result adds pressure-target classification, anti-surge recycle losses, and detached capacity-constraint
+   * snapshots to the legacy {@link #getOperatingPoint()} map.
    * </p>
    *
    * @return typed compressor operating-point result
@@ -3054,8 +3054,7 @@ public class Compressor extends TwoPortEquipment
    * @param pressureToleranceFraction non-negative relative discharge-pressure tolerance
    * @return typed compressor operating-point result
    */
-  public CompressorOperatingPointResult getOperatingPointResult(
-      double pressureToleranceFraction) {
+  public CompressorOperatingPointResult getOperatingPointResult(double pressureToleranceFraction) {
     return CompressorOperatingPointResult.from(this, pressureToleranceFraction);
   }
 
@@ -5211,8 +5210,7 @@ public class Compressor extends TwoPortEquipment
     // represents a minimum-good constraint with designValue = Double.MAX_VALUE.
     // getDistanceToSurge() returns (currentFlow / surgeFlow) - 1.
     addCapacityConstraint(StandardConstraintType.COMPRESSOR_SURGE_MARGIN.createConstraint()
-        .setDesignValue(Double.MAX_VALUE).setMinValue(10.0).setWarningThreshold(0.85)
-        .setValueSupplier(() -> {
+        .setDesignValue(Double.MAX_VALUE).setMinValue(10.0).setWarningThreshold(0.85).setValueSupplier(() -> {
           double marginRatio = this.getDistanceToSurge();
           if (Double.isNaN(marginRatio) || Double.isInfinite(marginRatio)) {
             return Double.MAX_VALUE;
@@ -5223,8 +5221,7 @@ public class Compressor extends TwoPortEquipment
     // Stonewall margin constraint
     // getDistanceToStoneWall() returns (stoneWallFlow / currentFlow) - 1.
     addCapacityConstraint(StandardConstraintType.COMPRESSOR_STONEWALL_MARGIN.createConstraint()
-        .setDesignValue(Double.MAX_VALUE).setMinValue(5.0).setWarningThreshold(0.90)
-        .setValueSupplier(() -> {
+        .setDesignValue(Double.MAX_VALUE).setMinValue(5.0).setWarningThreshold(0.90).setValueSupplier(() -> {
           double marginRatio = this.getDistanceToStoneWall();
           if (Double.isNaN(marginRatio) || Double.isInfinite(marginRatio)) {
             return Double.MAX_VALUE;

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -3035,6 +3035,31 @@ public class Compressor extends TwoPortEquipment
   }
 
   /**
+   * Returns an immutable, capacity-aware operating-point result.
+   *
+   * <p>
+   * The result adds pressure-target classification, anti-surge recycle losses, and detached
+   * capacity-constraint snapshots to the legacy {@link #getOperatingPoint()} map.
+   * </p>
+   *
+   * @return typed compressor operating-point result
+   */
+  public CompressorOperatingPointResult getOperatingPointResult() {
+    return CompressorOperatingPointResult.from(this);
+  }
+
+  /**
+   * Returns an immutable operating-point result with a caller-defined pressure tolerance.
+   *
+   * @param pressureToleranceFraction non-negative relative discharge-pressure tolerance
+   * @return typed compressor operating-point result
+   */
+  public CompressorOperatingPointResult getOperatingPointResult(
+      double pressureToleranceFraction) {
+    return CompressorOperatingPointResult.from(this, pressureToleranceFraction);
+  }
+
+  /**
    * Setter for the field <code>antiSurge</code>.
    *
    * @param antiSurge a {@link neqsim.process.equipment.compressor.AntiSurge} object
@@ -5182,44 +5207,30 @@ public class Compressor extends TwoPortEquipment
         }));
 
     // Surge margin constraint
-    // getDistanceToSurge() returns a ratio: (currentFlow / surgeFlow) - 1
-    // e.g., 0.5 means current flow is 50% above surge flow
-    // For utilization: 0 margin = 100% utilized (at surge), large margin = low
-    // utilization
-    addCapacityConstraint(
-        StandardConstraintType.COMPRESSOR_SURGE_MARGIN.createConstraint().setDesignValue(100.0).setMinValue(10.0) // Minimum
-            // 10%
-            // surge
-            // margin
-            // required
-            .setWarningThreshold(0.85) // Warning at 85% utilization (15% margin)
-            .setValueSupplier(() -> {
-              double marginRatio = this.getDistanceToSurge();
-              if (marginRatio <= 0 || Double.isNaN(marginRatio) || Double.isInfinite(marginRatio)) {
-                return 100.0; // At or below surge = 100% utilized
-              }
-              // Convert ratio to utilization: utilization = 1 / (1 + marginRatio)
-              // e.g., margin=0.5 -> utilization = 1/1.5 = 66.7%
-              return 100.0 / (1.0 + marginRatio);
-            }).setEnabled(chartActive));
+    // The capacity abstraction expects the raw physical margin as current value and
+    // represents a minimum-good constraint with designValue = Double.MAX_VALUE.
+    // getDistanceToSurge() returns (currentFlow / surgeFlow) - 1.
+    addCapacityConstraint(StandardConstraintType.COMPRESSOR_SURGE_MARGIN.createConstraint()
+        .setDesignValue(Double.MAX_VALUE).setMinValue(10.0).setWarningThreshold(0.85)
+        .setValueSupplier(() -> {
+          double marginRatio = this.getDistanceToSurge();
+          if (Double.isNaN(marginRatio) || Double.isInfinite(marginRatio)) {
+            return Double.MAX_VALUE;
+          }
+          return marginRatio * 100.0;
+        }).setEnabled(chartActive));
 
     // Stonewall margin constraint
-    // getDistanceToStoneWall() returns a ratio: (stoneWallFlow / currentFlow) - 1
-    // e.g., 0.5 means stonewall is 50% above current flow
-    addCapacityConstraint(
-        StandardConstraintType.COMPRESSOR_STONEWALL_MARGIN.createConstraint().setDesignValue(100.0).setMinValue(5.0) // Minimum
-            // 5%
-            // stonewall
-            // margin
-            .setWarningThreshold(0.90) // Warning at 90% utilization (10% margin)
-            .setValueSupplier(() -> {
-              double marginRatio = this.getDistanceToStoneWall();
-              if (marginRatio <= 0 || Double.isNaN(marginRatio) || Double.isInfinite(marginRatio)) {
-                return 100.0; // At or above stonewall = 100% utilized
-              }
-              // Convert ratio to utilization: utilization = 1 / (1 + marginRatio)
-              return 100.0 / (1.0 + marginRatio);
-            }).setEnabled(chartActive));
+    // getDistanceToStoneWall() returns (stoneWallFlow / currentFlow) - 1.
+    addCapacityConstraint(StandardConstraintType.COMPRESSOR_STONEWALL_MARGIN.createConstraint()
+        .setDesignValue(Double.MAX_VALUE).setMinValue(5.0).setWarningThreshold(0.90)
+        .setValueSupplier(() -> {
+          double marginRatio = this.getDistanceToStoneWall();
+          if (Double.isNaN(marginRatio) || Double.isInfinite(marginRatio)) {
+            return Double.MAX_VALUE;
+          }
+          return marginRatio * 100.0;
+        }).setEnabled(chartActive));
 
     // Discharge temperature constraint
     // Track actual discharge temperature vs maximum allowable

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorOperatingPointResult.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorOperatingPointResult.java
@@ -1,0 +1,761 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
+import com.google.gson.GsonBuilder;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.stream.StreamInterface;
+
+/**
+ * Immutable, capacity-aware snapshot of one compressor operating point.
+ *
+ * <p>
+ * The result combines thermodynamic performance, compressor-map position, anti-surge recycle
+ * screening, pressure-target status, and the universal NeqSim capacity constraints. It is intended
+ * for production optimization, bottleneck analysis, field-life studies, and exchange with external
+ * energy and emissions tools.
+ * </p>
+ *
+ * <p>
+ * All physical values use fixed units stated in the getter names and JavaDoc. Values that cannot be
+ * evaluated are represented by {@link Double#NaN}. The result does not retain references to the
+ * compressor or its mutable constraints.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class CompressorOperatingPointResult implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Default relative tolerance for discharge-pressure target evaluation. */
+  public static final double DEFAULT_PRESSURE_TOLERANCE_FRACTION = 0.02;
+
+  /** Overall feasibility status for the operating point. */
+  public enum OperatingStatus {
+    /** All evaluated physical, map, capacity, and pressure-target checks pass. */
+    VALID,
+    /** Essential physical values are missing or non-finite. */
+    INVALID,
+    /** The operating point is on the unstable side of the surge line. */
+    SURGE,
+    /** The operating point is beyond the stonewall or choke boundary. */
+    STONEWALL,
+    /** At least one equipment capacity constraint is exceeded. */
+    CAPACITY_LIMIT,
+    /** The calculated discharge pressure is outside the configured target tolerance. */
+    PRESSURE_TARGET_NOT_MET
+  }
+
+  /** Status of calculated discharge pressure relative to the compressor target. */
+  public enum PressureTargetStatus {
+    /** A target comparison could not be evaluated. */
+    NOT_EVALUATED,
+    /** Calculated pressure is within the configured relative tolerance. */
+    ON_TARGET,
+    /** Calculated pressure is below the target minus tolerance. */
+    BELOW_TARGET,
+    /** Calculated pressure is above the target plus tolerance. */
+    ABOVE_TARGET
+  }
+
+  /** Immutable snapshot of one {@link CapacityConstraint}. */
+  public static final class ConstraintSnapshot implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String name;
+    private final String unit;
+    private final CapacityConstraint.ConstraintType type;
+    private final CapacityConstraint.ConstraintSeverity severity;
+    private final double currentValue;
+    private final double designValue;
+    private final double minimumValue;
+    private final double maximumValue;
+    private final double utilization;
+    private final double margin;
+    private final boolean enabled;
+    private final boolean violated;
+    private final String dataSource;
+    private final String description;
+
+    /**
+     * Creates a detached snapshot of a mutable capacity constraint.
+     *
+     * @param constraint capacity constraint to read
+     */
+    private ConstraintSnapshot(CapacityConstraint constraint) {
+      name = constraint.getName();
+      unit = constraint.getUnit();
+      type = constraint.getType();
+      severity = constraint.getSeverity();
+      currentValue = safeDouble(constraint::getCurrentValue);
+      designValue = constraint.getDisplayDesignValue();
+      minimumValue = constraint.getMinValue();
+      maximumValue = constraint.getMaxValue();
+      utilization = safeDouble(constraint::getUtilization);
+      margin = safeDouble(constraint::getMargin);
+      enabled = constraint.isEnabled();
+      violated = safeBoolean(constraint::isViolated);
+      dataSource = constraint.getDataSource();
+      description = constraint.getDescription();
+    }
+
+    /**
+     * Gets the constraint name.
+     *
+     * @return constraint name
+     */
+    public String getName() {
+      return name;
+    }
+
+    /**
+     * Gets the engineering unit.
+     *
+     * @return unit string
+     */
+    public String getUnit() {
+      return unit;
+    }
+
+    /**
+     * Gets the capacity constraint type.
+     *
+     * @return constraint type
+     */
+    public CapacityConstraint.ConstraintType getType() {
+      return type;
+    }
+
+    /**
+     * Gets the optimization severity.
+     *
+     * @return constraint severity
+     */
+    public CapacityConstraint.ConstraintSeverity getSeverity() {
+      return severity;
+    }
+
+    /**
+     * Gets the evaluated current value.
+     *
+     * @return current value in {@link #getUnit()}
+     */
+    public double getCurrentValue() {
+      return currentValue;
+    }
+
+    /**
+     * Gets the design value used for reporting.
+     *
+     * @return design value in {@link #getUnit()}
+     */
+    public double getDesignValue() {
+      return designValue;
+    }
+
+    /**
+     * Gets the required minimum value.
+     *
+     * @return minimum value in {@link #getUnit()}
+     */
+    public double getMinimumValue() {
+      return minimumValue;
+    }
+
+    /**
+     * Gets the absolute maximum value.
+     *
+     * @return maximum value in {@link #getUnit()}
+     */
+    public double getMaximumValue() {
+      return maximumValue;
+    }
+
+    /**
+     * Gets capacity utilization.
+     *
+     * @return utilization fraction, where 1.0 is the limit
+     */
+    public double getUtilization() {
+      return utilization;
+    }
+
+    /**
+     * Gets remaining capacity margin.
+     *
+     * @return margin fraction, where positive is feasible
+     */
+    public double getMargin() {
+      return margin;
+    }
+
+    /**
+     * Checks whether the constraint participates in capacity analysis.
+     *
+     * @return true when enabled
+     */
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    /**
+     * Checks whether the constraint is violated.
+     *
+     * @return true when utilization exceeds 1.0
+     */
+    public boolean isViolated() {
+      return violated;
+    }
+
+    /**
+     * Gets the provenance of the design value.
+     *
+     * @return data-source label
+     */
+    public String getDataSource() {
+      return dataSource;
+    }
+
+    /**
+     * Gets the engineering description.
+     *
+     * @return constraint description
+     */
+    public String getDescription() {
+      return description;
+    }
+  }
+
+  private final String schemaVersion = "1.0";
+  private final String compressorName;
+  private final double flowM3PerHour;
+  private final double polytropicHeadKJPerKg;
+  private final double speedRpm;
+  private final double polytropicEfficiency;
+  private final double powerKW;
+  private final double inletPressureBara;
+  private final double requestedDischargePressureBara;
+  private final double actualDischargePressureBara;
+  private final double dischargePressureErrorFraction;
+  private final double dischargeTemperatureC;
+  private final double pressureToleranceFraction;
+  private final PressureTargetStatus pressureTargetStatus;
+  private final boolean chartActive;
+  private final boolean withinChart;
+  private final boolean inSurge;
+  private final boolean inStonewall;
+  private final double distanceToSurge;
+  private final double distanceToStonewall;
+  private final double surgeFlowM3PerHour;
+  private final double surgeControlLineFlowM3PerHour;
+  private final double requiredRecycleFraction;
+  private final double recyclePowerLossKW;
+  private final double recycleCoolerDutyKW;
+  private final double maximumCapacityUtilization;
+  private final String limitingConstraint;
+  private final boolean capacityExceeded;
+  private final boolean hardLimitExceeded;
+  private final OperatingStatus operatingStatus;
+  private final List<ConstraintSnapshot> constraints;
+
+  /**
+   * Creates an immutable snapshot from a solved compressor.
+   *
+   * @param compressor compressor to evaluate
+   * @param pressureToleranceFraction relative discharge-pressure tolerance
+   */
+  private CompressorOperatingPointResult(Compressor compressor, double pressureToleranceFraction) {
+    compressorName = compressor.getName();
+    this.pressureToleranceFraction = pressureToleranceFraction;
+
+    StreamInterface inlet = compressor.getInletStream();
+    StreamInterface outlet = compressor.getOutletStream();
+    flowM3PerHour = inlet == null ? Double.NaN : safeDouble(() -> inlet.getFlowRate("m3/hr"));
+    polytropicHeadKJPerKg = safeDouble(compressor::getPolytropicFluidHead);
+    speedRpm = safeDouble(compressor::getSpeed);
+    polytropicEfficiency = safeDouble(compressor::getPolytropicEfficiency);
+    powerKW = safeDouble(() -> compressor.getPower("kW"));
+    inletPressureBara = inlet == null ? Double.NaN : safeDouble(() -> inlet.getPressure("bara"));
+    requestedDischargePressureBara = safeDouble(compressor::getOutletPressure);
+    actualDischargePressureBara =
+        outlet == null ? Double.NaN : safeDouble(() -> outlet.getPressure("bara"));
+    dischargeTemperatureC =
+        outlet == null ? Double.NaN : safeDouble(() -> outlet.getTemperature("C"));
+
+    dischargePressureErrorFraction =
+        calculateRelativeError(actualDischargePressureBara, requestedDischargePressureBara);
+    pressureTargetStatus =
+        determinePressureTargetStatus(dischargePressureErrorFraction, pressureToleranceFraction);
+
+    chartActive = safeBoolean(() -> compressor.getCompressorChart() != null
+        && compressor.getCompressorChart().isUseCompressorChart());
+    inSurge = chartActive && safeBoolean(compressor::isSurge);
+    inStonewall = chartActive && safeBoolean(compressor::isStoneWall);
+    withinChart = !chartActive || (!inSurge && !inStonewall);
+    distanceToSurge = chartActive ? safeDouble(compressor::getDistanceToSurge) : Double.NaN;
+    distanceToStonewall =
+        chartActive ? safeDouble(compressor::getDistanceToStoneWall) : Double.NaN;
+    surgeFlowM3PerHour = chartActive ? safeDouble(compressor::getSurgeFlowRate) : Double.NaN;
+    surgeControlLineFlowM3PerHour =
+        chartActive ? safeDouble(compressor::getControlLineFlow) : Double.NaN;
+    requiredRecycleFraction =
+        chartActive ? clampFraction(safeDouble(compressor::getRequiredRecycleFractionToControlLine))
+            : 0.0;
+    recyclePowerLossKW = chartActive
+        ? safeDouble(() -> compressor.getAntiSurgeRecyclePower(requiredRecycleFraction, "kW"))
+        : 0.0;
+    recycleCoolerDutyKW = chartActive
+        ? safeDouble(() -> compressor.getAntiSurgeRecycleHeatDuty(requiredRecycleFraction, "kW"))
+        : 0.0;
+
+    constraints = snapshotConstraints(compressor);
+    maximumCapacityUtilization = safeDouble(compressor::getMaxUtilization);
+    CapacityConstraint bottleneck = safeBottleneck(compressor);
+    limitingConstraint = determineLimitingConstraint(bottleneck, inSurge, inStonewall);
+    capacityExceeded = safeBoolean(compressor::isCapacityExceeded);
+    hardLimitExceeded = safeBoolean(compressor::isHardLimitExceeded);
+    operatingStatus = determineOperatingStatus();
+  }
+
+  /**
+   * Creates a result using the default two-percent pressure-target tolerance.
+   *
+   * @param compressor compressor to evaluate
+   * @return immutable operating-point result
+   * @throws IllegalArgumentException if compressor is null
+   */
+  public static CompressorOperatingPointResult from(Compressor compressor) {
+    return from(compressor, DEFAULT_PRESSURE_TOLERANCE_FRACTION);
+  }
+
+  /**
+   * Creates a result using a caller-defined pressure-target tolerance.
+   *
+   * @param compressor compressor to evaluate
+   * @param pressureToleranceFraction non-negative relative tolerance
+   * @return immutable operating-point result
+   * @throws IllegalArgumentException if compressor is null or tolerance is invalid
+   */
+  public static CompressorOperatingPointResult from(Compressor compressor,
+      double pressureToleranceFraction) {
+    if (compressor == null) {
+      throw new IllegalArgumentException("compressor must not be null");
+    }
+    if (!isFinite(pressureToleranceFraction) || pressureToleranceFraction < 0.0) {
+      throw new IllegalArgumentException("pressureToleranceFraction must be finite and non-negative");
+    }
+    return new CompressorOperatingPointResult(compressor, pressureToleranceFraction);
+  }
+
+  private static List<ConstraintSnapshot> snapshotConstraints(Compressor compressor) {
+    List<ConstraintSnapshot> result = new ArrayList<ConstraintSnapshot>();
+    try {
+      for (Map.Entry<String, CapacityConstraint> entry : compressor.getCapacityConstraints().entrySet()) {
+        if (entry.getValue() != null) {
+          result.add(new ConstraintSnapshot(entry.getValue()));
+        }
+      }
+    } catch (Exception ex) {
+      return Collections.emptyList();
+    }
+    return Collections.unmodifiableList(result);
+  }
+
+  private static CapacityConstraint safeBottleneck(Compressor compressor) {
+    try {
+      return compressor.getBottleneckConstraint();
+    } catch (Exception ex) {
+      return null;
+    }
+  }
+
+  private static String determineLimitingConstraint(CapacityConstraint bottleneck,
+      boolean inSurge, boolean inStonewall) {
+    if (bottleneck != null) {
+      return bottleneck.getName();
+    }
+    if (inSurge) {
+      return "surgeMargin";
+    }
+    if (inStonewall) {
+      return "stonewallMargin";
+    }
+    return "none";
+  }
+
+  private static double calculateRelativeError(double actual, double target) {
+    if (!isFinite(actual) || !isFinite(target) || target <= 0.0) {
+      return Double.NaN;
+    }
+    return (actual - target) / Math.abs(target);
+  }
+
+  private static PressureTargetStatus determinePressureTargetStatus(double relativeError,
+      double tolerance) {
+    if (!isFinite(relativeError)) {
+      return PressureTargetStatus.NOT_EVALUATED;
+    }
+    if (relativeError < -tolerance) {
+      return PressureTargetStatus.BELOW_TARGET;
+    }
+    if (relativeError > tolerance) {
+      return PressureTargetStatus.ABOVE_TARGET;
+    }
+    return PressureTargetStatus.ON_TARGET;
+  }
+
+  private OperatingStatus determineOperatingStatus() {
+    if (!isFiniteNonNegative(flowM3PerHour) || !isFiniteNonNegative(powerKW)
+        || !isFinite(actualDischargePressureBara)) {
+      return OperatingStatus.INVALID;
+    }
+    if (inSurge) {
+      return OperatingStatus.SURGE;
+    }
+    if (inStonewall) {
+      return OperatingStatus.STONEWALL;
+    }
+    if (capacityExceeded || hardLimitExceeded) {
+      return OperatingStatus.CAPACITY_LIMIT;
+    }
+    if (pressureTargetStatus == PressureTargetStatus.BELOW_TARGET
+        || pressureTargetStatus == PressureTargetStatus.ABOVE_TARGET) {
+      return OperatingStatus.PRESSURE_TARGET_NOT_MET;
+    }
+    return OperatingStatus.VALID;
+  }
+
+  private static boolean isFiniteNonNegative(double value) {
+    return isFinite(value) && value >= 0.0;
+  }
+
+  private static double clampFraction(double value) {
+    if (!isFinite(value)) {
+      return Double.NaN;
+    }
+    return Math.max(0.0, Math.min(1.0, value));
+  }
+
+  private static double safeDouble(DoubleSupplier supplier) {
+    try {
+      return supplier.getAsDouble();
+    } catch (Exception | StackOverflowError ex) {
+      return Double.NaN;
+    }
+  }
+
+  private static boolean isFinite(double value) {
+    return !Double.isNaN(value) && !Double.isInfinite(value);
+  }
+
+  private static boolean safeBoolean(BooleanSupplier supplier) {
+    try {
+      return supplier.getAsBoolean();
+    } catch (Exception | StackOverflowError ex) {
+      return false;
+    }
+  }
+
+  /**
+   * Gets the result schema version.
+   *
+   * @return schema version
+   */
+  public String getSchemaVersion() {
+    return schemaVersion;
+  }
+
+  /**
+   * Gets the compressor name.
+   *
+   * @return compressor name
+   */
+  public String getCompressorName() {
+    return compressorName;
+  }
+
+  /**
+   * Gets actual inlet volumetric flow.
+   *
+   * @return flow in m3/hr
+   */
+  public double getFlowM3PerHour() {
+    return flowM3PerHour;
+  }
+
+  /**
+   * Gets polytropic fluid head.
+   *
+   * @return head in kJ/kg
+   */
+  public double getPolytropicHeadKJPerKg() {
+    return polytropicHeadKJPerKg;
+  }
+
+  /**
+   * Gets shaft speed.
+   *
+   * @return speed in rpm
+   */
+  public double getSpeedRpm() {
+    return speedRpm;
+  }
+
+  /**
+   * Gets polytropic efficiency.
+   *
+   * @return efficiency fraction
+   */
+  public double getPolytropicEfficiency() {
+    return polytropicEfficiency;
+  }
+
+  /**
+   * Gets shaft power.
+   *
+   * @return power in kW
+   */
+  public double getPowerKW() {
+    return powerKW;
+  }
+
+  /**
+   * Gets compressor inlet pressure.
+   *
+   * @return inlet pressure in bara
+   */
+  public double getInletPressureBara() {
+    return inletPressureBara;
+  }
+
+  /**
+   * Gets requested discharge pressure.
+   *
+   * @return requested pressure in bara
+   */
+  public double getRequestedDischargePressureBara() {
+    return requestedDischargePressureBara;
+  }
+
+  /**
+   * Gets calculated discharge pressure.
+   *
+   * @return actual pressure in bara
+   */
+  public double getActualDischargePressureBara() {
+    return actualDischargePressureBara;
+  }
+
+  /**
+   * Gets signed relative discharge-pressure error.
+   *
+   * @return {@code (actual - target) / abs(target)}
+   */
+  public double getDischargePressureErrorFraction() {
+    return dischargePressureErrorFraction;
+  }
+
+  /**
+   * Gets calculated discharge temperature.
+   *
+   * @return temperature in degrees Celsius
+   */
+  public double getDischargeTemperatureC() {
+    return dischargeTemperatureC;
+  }
+
+  /**
+   * Gets the relative pressure tolerance used for classification.
+   *
+   * @return pressure tolerance fraction
+   */
+  public double getPressureToleranceFraction() {
+    return pressureToleranceFraction;
+  }
+
+  /**
+   * Gets discharge-pressure target status.
+   *
+   * @return pressure-target status
+   */
+  public PressureTargetStatus getPressureTargetStatus() {
+    return pressureTargetStatus;
+  }
+
+  /**
+   * Checks whether a compressor performance chart is active.
+   *
+   * @return true when a chart is active
+   */
+  public boolean isChartActive() {
+    return chartActive;
+  }
+
+  /**
+   * Checks whether the point is between surge and stonewall.
+   *
+   * @return true when inside the map, or when no map is active
+   */
+  public boolean isWithinChart() {
+    return withinChart;
+  }
+
+  /**
+   * Checks whether the point is in surge.
+   *
+   * @return true when in surge
+   */
+  public boolean isInSurge() {
+    return inSurge;
+  }
+
+  /**
+   * Checks whether the point is beyond stonewall.
+   *
+   * @return true when beyond stonewall
+   */
+  public boolean isInStonewall() {
+    return inStonewall;
+  }
+
+  /**
+   * Gets fractional distance to surge.
+   *
+   * @return {@code flow / surgeFlow - 1}
+   */
+  public double getDistanceToSurge() {
+    return distanceToSurge;
+  }
+
+  /**
+   * Gets fractional distance to stonewall.
+   *
+   * @return {@code stonewallFlow / flow - 1}
+   */
+  public double getDistanceToStonewall() {
+    return distanceToStonewall;
+  }
+
+  /**
+   * Gets surge-line flow at the current head.
+   *
+   * @return flow in m3/hr
+   */
+  public double getSurgeFlowM3PerHour() {
+    return surgeFlowM3PerHour;
+  }
+
+  /**
+   * Gets anti-surge control-line flow at the current head.
+   *
+   * @return flow in m3/hr
+   */
+  public double getSurgeControlLineFlowM3PerHour() {
+    return surgeControlLineFlowM3PerHour;
+  }
+
+  /**
+   * Gets screening recycle fraction required to reach the anti-surge control line.
+   *
+   * @return recycle fraction from 0 to 1
+   */
+  public double getRequiredRecycleFraction() {
+    return requiredRecycleFraction;
+  }
+
+  /**
+   * Gets screening shaft-power loss due to recycle.
+   *
+   * @return recycle power loss in kW
+   */
+  public double getRecyclePowerLossKW() {
+    return recyclePowerLossKW;
+  }
+
+  /**
+   * Gets screening recycle-cooler duty.
+   *
+   * @return cooler duty in kW
+   */
+  public double getRecycleCoolerDutyKW() {
+    return recycleCoolerDutyKW;
+  }
+
+  /**
+   * Gets maximum utilization across enabled compressor constraints.
+   *
+   * @return utilization fraction, where 1.0 is the limit
+   */
+  public double getMaximumCapacityUtilization() {
+    return maximumCapacityUtilization;
+  }
+
+  /**
+   * Gets the limiting capacity constraint.
+   *
+   * @return constraint name, or {@code "none"}
+   */
+  public String getLimitingConstraint() {
+    return limitingConstraint;
+  }
+
+  /**
+   * Checks whether any capacity constraint is exceeded.
+   *
+   * @return true when capacity is exceeded
+   */
+  public boolean isCapacityExceeded() {
+    return capacityExceeded;
+  }
+
+  /**
+   * Checks whether any hard capacity limit is exceeded.
+   *
+   * @return true when a hard limit is exceeded
+   */
+  public boolean isHardLimitExceeded() {
+    return hardLimitExceeded;
+  }
+
+  /**
+   * Gets the overall operating status.
+   *
+   * @return operating status
+   */
+  public OperatingStatus getOperatingStatus() {
+    return operatingStatus;
+  }
+
+  /**
+   * Checks aggregate operating-point feasibility.
+   *
+   * @return true when {@link #getOperatingStatus()} is {@link OperatingStatus#VALID}
+   */
+  public boolean isFeasible() {
+    return operatingStatus == OperatingStatus.VALID;
+  }
+
+  /**
+   * Gets immutable snapshots of all compressor constraints.
+   *
+   * @return unmodifiable constraint list
+   */
+  public List<ConstraintSnapshot> getConstraints() {
+    return constraints;
+  }
+
+  /**
+   * Serializes this result to schema-versioned JSON.
+   *
+   * @return JSON representation
+   */
+  public String toJson() {
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(this);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorOperatingPointResult.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorOperatingPointResult.java
@@ -403,7 +403,7 @@ public final class CompressorOperatingPointResult implements Serializable {
   }
 
   private OperatingStatus determineOperatingStatus() {
-    if (!isFiniteNonNegative(flowM3PerHour) || !isFiniteNonNegative(powerKW)
+    if (!isFiniteNonNegative(flowM3PerHour) || !isFinite(powerKW)
         || !isFinite(actualDischargePressureBara)) {
       return OperatingStatus.INVALID;
     }

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorOperatingPointResult.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorOperatingPointResult.java
@@ -348,15 +348,25 @@ public final class CompressorOperatingPointResult implements Serializable {
 
   private static List<ConstraintSnapshot> snapshotConstraints(Compressor compressor) {
     List<ConstraintSnapshot> result = new ArrayList<ConstraintSnapshot>();
+    Map<String, CapacityConstraint> constraints;
     try {
-      for (Map.Entry<String, CapacityConstraint> entry : compressor.getCapacityConstraints().entrySet()) {
-        if (entry.getValue() != null) {
-          result.add(new ConstraintSnapshot(entry.getValue()));
-        }
-      }
+      constraints = compressor.getCapacityConstraints();
     } catch (Exception ex) {
       return Collections.emptyList();
     }
+
+    for (Map.Entry<String, CapacityConstraint> entry : constraints.entrySet()) {
+      CapacityConstraint constraint = entry.getValue();
+      if (constraint == null) {
+        continue;
+      }
+      try {
+        result.add(new ConstraintSnapshot(constraint));
+      } catch (Exception ex) {
+        // Ignore individual constraint failures to preserve partial snapshots.
+      }
+    }
+
     return Collections.unmodifiableList(result);
   }
 

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorOperatingPointResult.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorOperatingPointResult.java
@@ -403,8 +403,7 @@ public final class CompressorOperatingPointResult implements Serializable {
   }
 
   private OperatingStatus determineOperatingStatus() {
-    if (!isFiniteNonNegative(flowM3PerHour) || !isFinite(powerKW)
-        || !isFinite(actualDischargePressureBara)) {
+    if (!isFiniteNonNegative(flowM3PerHour) || !isFinite(powerKW) || !isFinite(actualDischargePressureBara)) {
       return OperatingStatus.INVALID;
     }
     if (inSurge) {

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorOperatingPointResult.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorOperatingPointResult.java
@@ -15,16 +15,15 @@ import neqsim.process.equipment.stream.StreamInterface;
  * Immutable, capacity-aware snapshot of one compressor operating point.
  *
  * <p>
- * The result combines thermodynamic performance, compressor-map position, anti-surge recycle
- * screening, pressure-target status, and the universal NeqSim capacity constraints. It is intended
- * for production optimization, bottleneck analysis, field-life studies, and exchange with external
- * energy and emissions tools.
+ * The result combines thermodynamic performance, compressor-map position, anti-surge recycle screening, pressure-target
+ * status, and the universal NeqSim capacity constraints. It is intended for production optimization, bottleneck
+ * analysis, field-life studies, and exchange with external energy and emissions tools.
  * </p>
  *
  * <p>
- * All physical values use fixed units stated in the getter names and JavaDoc. Values that cannot be
- * evaluated are represented by {@link Double#NaN}. The result does not retain references to the
- * compressor or its mutable constraints.
+ * All physical values use fixed units stated in the getter names and JavaDoc. Values that cannot be evaluated are
+ * represented by {@link Double#NaN}. The result does not retain references to the compressor or its mutable
+ * constraints.
  * </p>
  *
  * @author NeqSim
@@ -283,30 +282,25 @@ public final class CompressorOperatingPointResult implements Serializable {
     powerKW = safeDouble(() -> compressor.getPower("kW"));
     inletPressureBara = inlet == null ? Double.NaN : safeDouble(() -> inlet.getPressure("bara"));
     requestedDischargePressureBara = safeDouble(compressor::getOutletPressure);
-    actualDischargePressureBara =
-        outlet == null ? Double.NaN : safeDouble(() -> outlet.getPressure("bara"));
-    dischargeTemperatureC =
-        outlet == null ? Double.NaN : safeDouble(() -> outlet.getTemperature("C"));
+    actualDischargePressureBara = outlet == null ? Double.NaN : safeDouble(() -> outlet.getPressure("bara"));
+    dischargeTemperatureC = outlet == null ? Double.NaN : safeDouble(() -> outlet.getTemperature("C"));
 
-    dischargePressureErrorFraction =
-        calculateRelativeError(actualDischargePressureBara, requestedDischargePressureBara);
-    pressureTargetStatus =
-        determinePressureTargetStatus(dischargePressureErrorFraction, pressureToleranceFraction);
+    dischargePressureErrorFraction = calculateRelativeError(actualDischargePressureBara,
+        requestedDischargePressureBara);
+    pressureTargetStatus = determinePressureTargetStatus(dischargePressureErrorFraction, pressureToleranceFraction);
 
-    chartActive = safeBoolean(() -> compressor.getCompressorChart() != null
-        && compressor.getCompressorChart().isUseCompressorChart());
+    chartActive = safeBoolean(
+        () -> compressor.getCompressorChart() != null && compressor.getCompressorChart().isUseCompressorChart());
     inSurge = chartActive && safeBoolean(compressor::isSurge);
     inStonewall = chartActive && safeBoolean(compressor::isStoneWall);
     withinChart = !chartActive || (!inSurge && !inStonewall);
     distanceToSurge = chartActive ? safeDouble(compressor::getDistanceToSurge) : Double.NaN;
-    distanceToStonewall =
-        chartActive ? safeDouble(compressor::getDistanceToStoneWall) : Double.NaN;
+    distanceToStonewall = chartActive ? safeDouble(compressor::getDistanceToStoneWall) : Double.NaN;
     surgeFlowM3PerHour = chartActive ? safeDouble(compressor::getSurgeFlowRate) : Double.NaN;
-    surgeControlLineFlowM3PerHour =
-        chartActive ? safeDouble(compressor::getControlLineFlow) : Double.NaN;
-    requiredRecycleFraction =
-        chartActive ? clampFraction(safeDouble(compressor::getRequiredRecycleFractionToControlLine))
-            : 0.0;
+    surgeControlLineFlowM3PerHour = chartActive ? safeDouble(compressor::getControlLineFlow) : Double.NaN;
+    requiredRecycleFraction = chartActive
+        ? clampFraction(safeDouble(compressor::getRequiredRecycleFractionToControlLine))
+        : 0.0;
     recyclePowerLossKW = chartActive
         ? safeDouble(() -> compressor.getAntiSurgeRecyclePower(requiredRecycleFraction, "kW"))
         : 0.0;
@@ -342,8 +336,7 @@ public final class CompressorOperatingPointResult implements Serializable {
    * @return immutable operating-point result
    * @throws IllegalArgumentException if compressor is null or tolerance is invalid
    */
-  public static CompressorOperatingPointResult from(Compressor compressor,
-      double pressureToleranceFraction) {
+  public static CompressorOperatingPointResult from(Compressor compressor, double pressureToleranceFraction) {
     if (compressor == null) {
       throw new IllegalArgumentException("compressor must not be null");
     }
@@ -375,8 +368,8 @@ public final class CompressorOperatingPointResult implements Serializable {
     }
   }
 
-  private static String determineLimitingConstraint(CapacityConstraint bottleneck,
-      boolean inSurge, boolean inStonewall) {
+  private static String determineLimitingConstraint(CapacityConstraint bottleneck, boolean inSurge,
+      boolean inStonewall) {
     if (bottleneck != null) {
       return bottleneck.getName();
     }
@@ -396,8 +389,7 @@ public final class CompressorOperatingPointResult implements Serializable {
     return (actual - target) / Math.abs(target);
   }
 
-  private static PressureTargetStatus determinePressureTargetStatus(double relativeError,
-      double tolerance) {
+  private static PressureTargetStatus determinePressureTargetStatus(double relativeError, double tolerance) {
     if (!isFinite(relativeError)) {
       return PressureTargetStatus.NOT_EVALUATED;
     }

--- a/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
+++ b/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.compressor.CompressorChartGenerator;
 import neqsim.process.equipment.stream.StreamInterface;
@@ -554,27 +555,55 @@ public class PressureBoundaryOptimizer implements Serializable {
     List<OptimizationConstraint> constraints = new ArrayList<OptimizationConstraint>();
 
     for (final Compressor comp : compressors) {
-      // Surge margin constraint
-      constraints.add(new OptimizationConstraint(comp.getName() + "_surgeMargin", proc -> comp.getDistanceToSurge(),
-          minSurgeMargin, ConstraintDirection.GREATER_THAN, ConstraintSeverity.HARD, 10.0,
-          "Compressor " + comp.getName() + " must maintain surge margin > " + minSurgeMargin));
+      Map<String, CapacityConstraint> equipmentConstraints = comp.getCapacityConstraints();
 
-      // Power limit constraint
-      if (maxPowerLimit < Double.MAX_VALUE) {
-        constraints.add(new OptimizationConstraint(comp.getName() + "_power", proc -> comp.getPower("kW"),
-            maxPowerLimit, ConstraintDirection.LESS_THAN, ConstraintSeverity.HARD, 5.0,
-            "Compressor " + comp.getName() + " power must be < " + maxPowerLimit + " kW"));
+      // Preserve the public optimizer setting by applying it to the same physical
+      // minimum-margin constraint used by bottleneck detection and external optimizers.
+      CapacityConstraint surgeMargin = equipmentConstraints.get("surgeMargin");
+      if (surgeMargin != null && surgeMargin.isMinimumConstraint()) {
+        surgeMargin.setMinValue(minSurgeMargin * 100.0);
       }
 
-      // Speed limits
+      // Reuse all enabled equipment constraints. This keeps pressure-boundary
+      // optimization aligned with ProcessSystem.findBottleneck(), capacity reports,
+      // and CapacityConstraintAdapter instead of maintaining a second constraint list.
+      for (final CapacityConstraint equipmentConstraint : equipmentConstraints.values()) {
+        if (!equipmentConstraint.isEnabled()
+            || equipmentConstraint.getType() == CapacityConstraint.ConstraintType.DESIGN
+            || equipmentConstraint.getSeverity()
+                == CapacityConstraint.ConstraintSeverity.ADVISORY) {
+          continue;
+        }
+        ConstraintSeverity severity =
+            equipmentConstraint.getSeverity() == CapacityConstraint.ConstraintSeverity.SOFT
+                ? ConstraintSeverity.SOFT
+                : ConstraintSeverity.HARD;
+        double penaltyWeight = severity == ConstraintSeverity.HARD ? 10.0 : 1.0;
+        constraints.add(new OptimizationConstraint(
+            comp.getName() + "_" + equipmentConstraint.getName(),
+            proc -> equipmentConstraint.getUtilization(), 1.0,
+            ConstraintDirection.LESS_THAN, severity, penaltyWeight,
+            equipmentConstraint.getDescription()));
+      }
+
+      // Explicit caller limits remain additional overrides when they are tighter
+      // than, or independent of, the equipment design constraints.
+      if (maxPowerLimit < Double.MAX_VALUE) {
+        constraints.add(new OptimizationConstraint(comp.getName() + "_configuredPowerLimit",
+            proc -> comp.getPower("kW"), maxPowerLimit, ConstraintDirection.LESS_THAN,
+            ConstraintSeverity.HARD, 5.0,
+            "Compressor " + comp.getName() + " power must be < " + maxPowerLimit + " kW"));
+      }
       if (maxSpeedLimit < Double.MAX_VALUE) {
-        constraints.add(new OptimizationConstraint(comp.getName() + "_maxSpeed", proc -> comp.getSpeed(), maxSpeedLimit,
-            ConstraintDirection.LESS_THAN, ConstraintSeverity.HARD, 5.0,
+        constraints.add(new OptimizationConstraint(comp.getName() + "_configuredMaxSpeed",
+            proc -> comp.getSpeed(), maxSpeedLimit, ConstraintDirection.LESS_THAN,
+            ConstraintSeverity.HARD, 5.0,
             "Compressor " + comp.getName() + " speed must be < " + maxSpeedLimit + " RPM"));
       }
       if (minSpeedLimit > 0) {
-        constraints.add(new OptimizationConstraint(comp.getName() + "_minSpeed", proc -> comp.getSpeed(), minSpeedLimit,
-            ConstraintDirection.GREATER_THAN, ConstraintSeverity.HARD, 5.0,
+        constraints.add(new OptimizationConstraint(comp.getName() + "_configuredMinSpeed",
+            proc -> comp.getSpeed(), minSpeedLimit, ConstraintDirection.GREATER_THAN,
+            ConstraintSeverity.HARD, 5.0,
             "Compressor " + comp.getName() + " speed must be > " + minSpeedLimit + " RPM"));
       }
     }

--- a/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
+++ b/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
@@ -570,10 +570,9 @@ public class PressureBoundaryOptimizer implements Serializable {
     for (final Compressor comp : compressors) {
       Map<String, CapacityConstraint> equipmentConstraints = comp.getCapacityConstraints();
 
-      // Preserve the public optimizer setting by applying it to the same physical
-      // minimum-margin constraint used by bottleneck detection and external optimizers.
       CapacityConstraint surgeMargin = equipmentConstraints.get("surgeMargin");
-      if (surgeMargin != null && surgeMargin.isMinimumConstraint()) {
+      if (surgeMargin != null && surgeMargin.isMinimumConstraint() && minSurgeMargin > 0.0
+          && !Double.isNaN(minSurgeMargin) && !Double.isInfinite(minSurgeMargin)) {
         surgeMargin.setMinValue(minSurgeMargin * 100.0);
       }
 

--- a/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
+++ b/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
@@ -570,19 +570,15 @@ public class PressureBoundaryOptimizer implements Serializable {
       for (final CapacityConstraint equipmentConstraint : equipmentConstraints.values()) {
         if (!equipmentConstraint.isEnabled()
             || equipmentConstraint.getType() == CapacityConstraint.ConstraintType.DESIGN
-            || equipmentConstraint.getSeverity()
-                == CapacityConstraint.ConstraintSeverity.ADVISORY) {
+            || equipmentConstraint.getSeverity() == CapacityConstraint.ConstraintSeverity.ADVISORY) {
           continue;
         }
-        ConstraintSeverity severity =
-            equipmentConstraint.getSeverity() == CapacityConstraint.ConstraintSeverity.SOFT
-                ? ConstraintSeverity.SOFT
-                : ConstraintSeverity.HARD;
+        ConstraintSeverity severity = equipmentConstraint.getSeverity() == CapacityConstraint.ConstraintSeverity.SOFT
+            ? ConstraintSeverity.SOFT
+            : ConstraintSeverity.HARD;
         double penaltyWeight = severity == ConstraintSeverity.HARD ? 10.0 : 1.0;
-        constraints.add(new OptimizationConstraint(
-            comp.getName() + "_" + equipmentConstraint.getName(),
-            proc -> equipmentConstraint.getUtilization(), 1.0,
-            ConstraintDirection.LESS_THAN, severity, penaltyWeight,
+        constraints.add(new OptimizationConstraint(comp.getName() + "_" + equipmentConstraint.getName(),
+            proc -> equipmentConstraint.getUtilization(), 1.0, ConstraintDirection.LESS_THAN, severity, penaltyWeight,
             equipmentConstraint.getDescription()));
       }
 
@@ -590,20 +586,17 @@ public class PressureBoundaryOptimizer implements Serializable {
       // than, or independent of, the equipment design constraints.
       if (maxPowerLimit < Double.MAX_VALUE) {
         constraints.add(new OptimizationConstraint(comp.getName() + "_configuredPowerLimit",
-            proc -> comp.getPower("kW"), maxPowerLimit, ConstraintDirection.LESS_THAN,
-            ConstraintSeverity.HARD, 5.0,
+            proc -> comp.getPower("kW"), maxPowerLimit, ConstraintDirection.LESS_THAN, ConstraintSeverity.HARD, 5.0,
             "Compressor " + comp.getName() + " power must be < " + maxPowerLimit + " kW"));
       }
       if (maxSpeedLimit < Double.MAX_VALUE) {
-        constraints.add(new OptimizationConstraint(comp.getName() + "_configuredMaxSpeed",
-            proc -> comp.getSpeed(), maxSpeedLimit, ConstraintDirection.LESS_THAN,
-            ConstraintSeverity.HARD, 5.0,
+        constraints.add(new OptimizationConstraint(comp.getName() + "_configuredMaxSpeed", proc -> comp.getSpeed(),
+            maxSpeedLimit, ConstraintDirection.LESS_THAN, ConstraintSeverity.HARD, 5.0,
             "Compressor " + comp.getName() + " speed must be < " + maxSpeedLimit + " RPM"));
       }
       if (minSpeedLimit > 0) {
-        constraints.add(new OptimizationConstraint(comp.getName() + "_configuredMinSpeed",
-            proc -> comp.getSpeed(), minSpeedLimit, ConstraintDirection.GREATER_THAN,
-            ConstraintSeverity.HARD, 5.0,
+        constraints.add(new OptimizationConstraint(comp.getName() + "_configuredMinSpeed", proc -> comp.getSpeed(),
+            minSpeedLimit, ConstraintDirection.GREATER_THAN, ConstraintSeverity.HARD, 5.0,
             "Compressor " + comp.getName() + " speed must be > " + minSpeedLimit + " RPM"));
       }
     }

--- a/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
+++ b/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
@@ -817,9 +817,13 @@ public class PressureBoundaryOptimizer implements Serializable {
   /**
    * Sets the minimum surge margin for compressors.
    *
-   * @param minSurgeMargin the minimum surge margin (e.g., 0.10 for 10%)
+   * @param minSurgeMargin finite, positive minimum surge margin (e.g., 0.10 for 10%)
+   * @throws IllegalArgumentException if {@code minSurgeMargin} is not finite and positive
    */
   public void setMinSurgeMargin(double minSurgeMargin) {
+    if (Double.isNaN(minSurgeMargin) || Double.isInfinite(minSurgeMargin) || minSurgeMargin <= 0.0) {
+      throw new IllegalArgumentException("minSurgeMargin must be finite and greater than zero");
+    }
     this.minSurgeMargin = minSurgeMargin;
   }
 

--- a/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
+++ b/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
@@ -443,6 +443,9 @@ public class PressureBoundaryOptimizer implements Serializable {
 
     for (Compressor comp : compressors) {
       if (comp.getCompressorChart() == null || !comp.getCompressorChart().isUseCompressorChart()) {
+        Map<String, CapacityConstraint> retainedConstraints =
+            new LinkedHashMap<String, CapacityConstraint>(comp.getCapacityConstraints());
+
         // Run to establish baseline
         process.run();
 
@@ -454,6 +457,16 @@ public class PressureBoundaryOptimizer implements Serializable {
         comp.setUsePolytropicCalc(true);
         comp.setSolveSpeed(true);
         comp.getCompressorChart().setUseCompressorChart(true);
+
+        // Default map constraints were initialized before the chart existed and are
+        // therefore disabled. Recreate those defaults now, while retaining caller-added
+        // constraints that are not part of the standard compressor constraint set.
+        comp.reinitializeCapacityConstraints();
+        for (Map.Entry<String, CapacityConstraint> entry : retainedConstraints.entrySet()) {
+          if (!comp.getCapacityConstraints().containsKey(entry.getKey())) {
+            comp.addCapacityConstraint(entry.getValue());
+          }
+        }
 
         logger.info("Configured compressor chart for: {}", comp.getName());
       }

--- a/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
+++ b/src/main/java/neqsim/process/util/optimizer/PressureBoundaryOptimizer.java
@@ -443,8 +443,8 @@ public class PressureBoundaryOptimizer implements Serializable {
 
     for (Compressor comp : compressors) {
       if (comp.getCompressorChart() == null || !comp.getCompressorChart().isUseCompressorChart()) {
-        Map<String, CapacityConstraint> retainedConstraints =
-            new LinkedHashMap<String, CapacityConstraint>(comp.getCapacityConstraints());
+        Map<String, CapacityConstraint> retainedConstraints = new LinkedHashMap<String, CapacityConstraint>(
+            comp.getCapacityConstraints());
 
         // Run to establish baseline
         process.run();

--- a/src/test/java/neqsim/process/equipment/capacity/CapacityConstraintMinimumLimitTest.java
+++ b/src/test/java/neqsim/process/equipment/capacity/CapacityConstraintMinimumLimitTest.java
@@ -1,0 +1,46 @@
+package neqsim.process.equipment.capacity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for minimum-value capacity constraints.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class CapacityConstraintMinimumLimitTest {
+
+  /** Verifies utilization and hard-limit behavior on both sides of a minimum. */
+  @Test
+  public void testHardMinimumConstraint() {
+    CapacityConstraint margin =
+        new CapacityConstraint("surgeMargin", "%", CapacityConstraint.ConstraintType.HARD)
+            .setDesignValue(Double.MAX_VALUE).setMinValue(10.0).setCurrentValue(15.0);
+
+    assertTrue(margin.isMinimumConstraint());
+    assertEquals(10.0 / 15.0, margin.getUtilization(), 1.0e-12);
+    assertFalse(margin.isViolated());
+    assertFalse(margin.isHardLimitExceeded());
+
+    margin.setCurrentValue(5.0);
+
+    assertEquals(2.0, margin.getUtilization(), 1.0e-12);
+    assertTrue(margin.isViolated());
+    assertTrue(margin.isHardLimitExceeded());
+  }
+
+  /** Verifies that equality with the minimum remains feasible. */
+  @Test
+  public void testMinimumBoundaryIsFeasible() {
+    CapacityConstraint margin =
+        new CapacityConstraint("stonewallMargin", "%", CapacityConstraint.ConstraintType.HARD)
+            .setDesignValue(Double.MAX_VALUE).setMinValue(5.0).setCurrentValue(5.0);
+
+    assertEquals(1.0, margin.getUtilization(), 0.0);
+    assertFalse(margin.isViolated());
+    assertFalse(margin.isHardLimitExceeded());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/capacity/CapacityConstraintMinimumLimitTest.java
+++ b/src/test/java/neqsim/process/equipment/capacity/CapacityConstraintMinimumLimitTest.java
@@ -16,9 +16,8 @@ public class CapacityConstraintMinimumLimitTest {
   /** Verifies utilization and hard-limit behavior on both sides of a minimum. */
   @Test
   public void testHardMinimumConstraint() {
-    CapacityConstraint margin =
-        new CapacityConstraint("surgeMargin", "%", CapacityConstraint.ConstraintType.HARD)
-            .setDesignValue(Double.MAX_VALUE).setMinValue(10.0).setCurrentValue(15.0);
+    CapacityConstraint margin = new CapacityConstraint("surgeMargin", "%", CapacityConstraint.ConstraintType.HARD)
+        .setDesignValue(Double.MAX_VALUE).setMinValue(10.0).setCurrentValue(15.0);
 
     assertTrue(margin.isMinimumConstraint());
     assertEquals(10.0 / 15.0, margin.getUtilization(), 1.0e-12);
@@ -35,9 +34,8 @@ public class CapacityConstraintMinimumLimitTest {
   /** Verifies that equality with the minimum remains feasible. */
   @Test
   public void testMinimumBoundaryIsFeasible() {
-    CapacityConstraint margin =
-        new CapacityConstraint("stonewallMargin", "%", CapacityConstraint.ConstraintType.HARD)
-            .setDesignValue(Double.MAX_VALUE).setMinValue(5.0).setCurrentValue(5.0);
+    CapacityConstraint margin = new CapacityConstraint("stonewallMargin", "%", CapacityConstraint.ConstraintType.HARD)
+        .setDesignValue(Double.MAX_VALUE).setMinValue(5.0).setCurrentValue(5.0);
 
     assertEquals(1.0, margin.getUtilization(), 0.0);
     assertFalse(margin.isViolated());

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorOperatingPointResultTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorOperatingPointResultTest.java
@@ -12,6 +12,7 @@ import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.expander.Expander;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -141,6 +142,61 @@ public class CompressorOperatingPointResultTest {
     assertTrue(json.contains("\"operatingStatus\""));
     assertTrue(json.contains("\"pressureTargetStatus\""));
     assertTrue(json.contains("\"constraints\""));
+  }
+
+  /** Verifies that undefined map margins fail closed as violated minimum constraints. */
+  @Test
+  public void testUndefinedMapMarginsViolateMinimumConstraints() {
+    Compressor undefinedMargins = new Compressor("undefined margins", compressor.getInletStream()) {
+      private static final long serialVersionUID = 1000L;
+
+      @Override
+      public double getDistanceToSurge() {
+        return Double.NaN;
+      }
+
+      @Override
+      public double getDistanceToStoneWall() {
+        return Double.POSITIVE_INFINITY;
+      }
+    };
+    undefinedMargins.setOutletPressure(100.0, "bara");
+    undefinedMargins.setUsePolytropicCalc(true);
+    undefinedMargins.setPolytropicEfficiency(0.75);
+    undefinedMargins.run();
+
+    CompressorChartGenerator generator = new CompressorChartGenerator(undefinedMargins);
+    generator.setChartType("interpolate and extrapolate");
+    undefinedMargins.setCompressorChart(generator.generateCompressorChart("normal curves"));
+    undefinedMargins.reinitializeCapacityConstraints();
+
+    CapacityConstraint surge = undefinedMargins.getCapacityConstraints().get("surgeMargin");
+    CapacityConstraint stonewall = undefinedMargins.getCapacityConstraints().get("stonewallMargin");
+    assertNotNull(surge);
+    assertNotNull(stonewall);
+    assertEquals(0.0, surge.getCurrentValue(), 0.0);
+    assertEquals(0.0, stonewall.getCurrentValue(), 0.0);
+    assertTrue(surge.isViolated());
+    assertTrue(stonewall.isViolated());
+
+    CompressorOperatingPointResult result = undefinedMargins.getOperatingPointResult();
+    assertEquals(CompressorOperatingPointResult.OperatingStatus.CAPACITY_LIMIT, result.getOperatingStatus());
+    assertFalse(result.isFeasible());
+  }
+
+  /** Verifies that signed recovered power does not invalidate an inherited expander result. */
+  @Test
+  public void testExpanderRecoveredPowerIsValid() {
+    Expander expander = new Expander("turboexpander", compressor.getInletStream());
+    expander.setOutletPressure(20.0, "bara");
+    expander.setIsentropicEfficiency(0.80);
+    expander.run();
+
+    CompressorOperatingPointResult result = expander.getOperatingPointResult();
+
+    assertTrue(result.getPowerKW() < 0.0);
+    assertEquals(CompressorOperatingPointResult.OperatingStatus.VALID, result.getOperatingStatus());
+    assertTrue(result.isFeasible());
   }
 
   /** Verifies that the detached result survives Java serialization. */

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorOperatingPointResultTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorOperatingPointResultTest.java
@@ -1,0 +1,174 @@
+package neqsim.process.equipment.compressor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests the immutable, capacity-aware compressor operating-point result.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class CompressorOperatingPointResultTest {
+  private Compressor compressor;
+
+  /** Creates and solves a chartless compressor case. */
+  @BeforeEach
+  public void setUp() {
+    SystemInterface gas = new SystemSrkEos(298.15, 50.0);
+    gas.addComponent("methane", 0.90);
+    gas.addComponent("ethane", 0.07);
+    gas.addComponent("propane", 0.03);
+    gas.setMixingRule("classic");
+    gas.setMultiPhaseCheck(false);
+
+    Stream inlet = new Stream("inlet", gas);
+    inlet.setFlowRate(10000.0, "kg/hr");
+    inlet.setTemperature(25.0, "C");
+    inlet.setPressure(50.0, "bara");
+    inlet.run();
+
+    compressor = new Compressor("export compressor", inlet);
+    compressor.setOutletPressure(100.0, "bara");
+    compressor.setUsePolytropicCalc(true);
+    compressor.setPolytropicEfficiency(0.75);
+    compressor.run();
+  }
+
+  /** Verifies physical values, pressure status, and chartless feasibility. */
+  @Test
+  public void testChartlessResultIsPhysicalAndFeasible() {
+    CompressorOperatingPointResult result = compressor.getOperatingPointResult();
+
+    assertEquals("1.0", result.getSchemaVersion());
+    assertEquals("export compressor", result.getCompressorName());
+    assertTrue(result.getFlowM3PerHour() > 0.0);
+    assertTrue(result.getPolytropicHeadKJPerKg() > 0.0);
+    assertTrue(result.getPowerKW() > 0.0);
+    assertEquals(50.0, result.getInletPressureBara(), 1.0e-8);
+    assertEquals(100.0, result.getRequestedDischargePressureBara(), 1.0e-8);
+    assertEquals(100.0, result.getActualDischargePressureBara(), 1.0e-6);
+    assertEquals(CompressorOperatingPointResult.PressureTargetStatus.ON_TARGET,
+        result.getPressureTargetStatus());
+    assertFalse(result.isChartActive());
+    assertTrue(result.isWithinChart());
+    assertEquals(0.0, result.getRequiredRecycleFraction(), 0.0);
+    assertEquals(0.0, result.getRecyclePowerLossKW(), 0.0);
+    assertEquals(CompressorOperatingPointResult.OperatingStatus.VALID,
+        result.getOperatingStatus());
+    assertTrue(result.isFeasible());
+    assertNotNull(result.getConstraints());
+  }
+
+  /** Verifies signed pressure-target classification with a caller-defined tolerance. */
+  @Test
+  public void testPressureTargetStatusUsesActualOutletPressure() {
+    compressor.getOutletStream().setPressure(95.0, "bara");
+
+    CompressorOperatingPointResult result = compressor.getOperatingPointResult(0.02);
+
+    assertEquals(CompressorOperatingPointResult.PressureTargetStatus.BELOW_TARGET,
+        result.getPressureTargetStatus());
+    assertEquals(-0.05, result.getDischargePressureErrorFraction(), 1.0e-12);
+    assertEquals(CompressorOperatingPointResult.OperatingStatus.PRESSURE_TARGET_NOT_MET,
+        result.getOperatingStatus());
+    assertFalse(result.isFeasible());
+  }
+
+  /** Verifies that the result reuses the universal capacity and bottleneck API. */
+  @Test
+  public void testCapacityBottleneckIsPropagated() {
+    CapacityConstraint customLimit =
+        new CapacityConstraint("vendorPowerLimit", "kW", CapacityConstraint.ConstraintType.HARD)
+            .setDesignValue(1000.0).setMaxValue(1000.0).setCurrentValue(1200.0)
+            .setSeverity(CapacityConstraint.ConstraintSeverity.HARD);
+    compressor.addCapacityConstraint(customLimit);
+
+    CompressorOperatingPointResult result = compressor.getOperatingPointResult();
+
+    assertTrue(result.isCapacityExceeded());
+    assertTrue(result.isHardLimitExceeded());
+    assertEquals("vendorPowerLimit", result.getLimitingConstraint());
+    assertEquals(1.2, result.getMaximumCapacityUtilization(), 1.0e-12);
+    assertEquals(CompressorOperatingPointResult.OperatingStatus.CAPACITY_LIMIT,
+        result.getOperatingStatus());
+    CompressorOperatingPointResult.ConstraintSnapshot snapshot = result.getConstraints().stream()
+        .filter(value -> value.getName().equals("vendorPowerLimit")).findFirst().orElse(null);
+    assertNotNull(snapshot);
+    assertTrue(snapshot.isEnabled());
+    assertTrue(snapshot.isViolated());
+    assertEquals(1.2, snapshot.getUtilization(), 1.0e-12);
+    assertEquals(-0.2, snapshot.getMargin(), 1.0e-12);
+  }
+
+  /** Verifies map margins, recycle screening, JSON, and corrected minimum constraints. */
+  @Test
+  public void testChartResultIncludesRecycleAndMinimumMargins() {
+    CompressorChartGenerator generator = new CompressorChartGenerator(compressor);
+    generator.setChartType("interpolate and extrapolate");
+    CompressorChartInterface chart = generator.generateCompressorChart("normal curves");
+    compressor.setCompressorChart(chart);
+    compressor.reinitializeCapacityConstraints();
+    compressor.run();
+
+    CompressorOperatingPointResult result = compressor.getOperatingPointResult();
+
+    assertTrue(result.isChartActive());
+    assertFalse(Double.isNaN(result.getDistanceToSurge()));
+    assertFalse(Double.isNaN(result.getDistanceToStonewall()));
+    assertTrue(result.getRequiredRecycleFraction() >= 0.0);
+    assertTrue(result.getRequiredRecycleFraction() <= 1.0);
+    assertEquals(result.getPowerKW() * result.getRequiredRecycleFraction(),
+        result.getRecyclePowerLossKW(), 1.0e-8);
+    assertEquals(result.getRecyclePowerLossKW(), result.getRecycleCoolerDutyKW(), 1.0e-8);
+
+    CapacityConstraint surge = compressor.getCapacityConstraints().get("surgeMargin");
+    CapacityConstraint stonewall = compressor.getCapacityConstraints().get("stonewallMargin");
+    assertNotNull(surge);
+    assertNotNull(stonewall);
+    assertTrue(surge.isMinimumConstraint());
+    assertTrue(stonewall.isMinimumConstraint());
+    assertEquals(compressor.getDistanceToSurge() * 100.0, surge.getCurrentValue(), 1.0e-8);
+    assertEquals(compressor.getDistanceToStoneWall() * 100.0, stonewall.getCurrentValue(),
+        1.0e-8);
+
+    String json = result.toJson();
+    assertTrue(json.contains("\"operatingStatus\""));
+    assertTrue(json.contains("\"pressureTargetStatus\""));
+    assertTrue(json.contains("\"constraints\""));
+  }
+
+  /** Verifies that the detached result survives Java serialization. */
+  @Test
+  public void testResultIsSerializable() throws Exception {
+    CompressorOperatingPointResult original = compressor.getOperatingPointResult();
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(buffer)) {
+      output.writeObject(original);
+    }
+
+    CompressorOperatingPointResult restored;
+    try (ObjectInputStream input =
+        new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
+      restored = (CompressorOperatingPointResult) input.readObject();
+    }
+
+    assertNotNull(restored);
+    assertEquals(original.getCompressorName(), restored.getCompressorName());
+    assertEquals(original.getPowerKW(), restored.getPowerKW(), 0.0);
+    assertSame(original.getOperatingStatus(), restored.getOperatingStatus());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorOperatingPointResultTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorOperatingPointResultTest.java
@@ -61,14 +61,12 @@ public class CompressorOperatingPointResultTest {
     assertEquals(50.0, result.getInletPressureBara(), 1.0e-8);
     assertEquals(100.0, result.getRequestedDischargePressureBara(), 1.0e-8);
     assertEquals(100.0, result.getActualDischargePressureBara(), 1.0e-6);
-    assertEquals(CompressorOperatingPointResult.PressureTargetStatus.ON_TARGET,
-        result.getPressureTargetStatus());
+    assertEquals(CompressorOperatingPointResult.PressureTargetStatus.ON_TARGET, result.getPressureTargetStatus());
     assertFalse(result.isChartActive());
     assertTrue(result.isWithinChart());
     assertEquals(0.0, result.getRequiredRecycleFraction(), 0.0);
     assertEquals(0.0, result.getRecyclePowerLossKW(), 0.0);
-    assertEquals(CompressorOperatingPointResult.OperatingStatus.VALID,
-        result.getOperatingStatus());
+    assertEquals(CompressorOperatingPointResult.OperatingStatus.VALID, result.getOperatingStatus());
     assertTrue(result.isFeasible());
     assertNotNull(result.getConstraints());
   }
@@ -80,21 +78,18 @@ public class CompressorOperatingPointResultTest {
 
     CompressorOperatingPointResult result = compressor.getOperatingPointResult(0.02);
 
-    assertEquals(CompressorOperatingPointResult.PressureTargetStatus.BELOW_TARGET,
-        result.getPressureTargetStatus());
+    assertEquals(CompressorOperatingPointResult.PressureTargetStatus.BELOW_TARGET, result.getPressureTargetStatus());
     assertEquals(-0.05, result.getDischargePressureErrorFraction(), 1.0e-12);
-    assertEquals(CompressorOperatingPointResult.OperatingStatus.PRESSURE_TARGET_NOT_MET,
-        result.getOperatingStatus());
+    assertEquals(CompressorOperatingPointResult.OperatingStatus.PRESSURE_TARGET_NOT_MET, result.getOperatingStatus());
     assertFalse(result.isFeasible());
   }
 
   /** Verifies that the result reuses the universal capacity and bottleneck API. */
   @Test
   public void testCapacityBottleneckIsPropagated() {
-    CapacityConstraint customLimit =
-        new CapacityConstraint("vendorPowerLimit", "kW", CapacityConstraint.ConstraintType.HARD)
-            .setDesignValue(1000.0).setMaxValue(1000.0).setCurrentValue(1200.0)
-            .setSeverity(CapacityConstraint.ConstraintSeverity.HARD);
+    CapacityConstraint customLimit = new CapacityConstraint("vendorPowerLimit", "kW",
+        CapacityConstraint.ConstraintType.HARD).setDesignValue(1000.0).setMaxValue(1000.0).setCurrentValue(1200.0)
+        .setSeverity(CapacityConstraint.ConstraintSeverity.HARD);
     compressor.addCapacityConstraint(customLimit);
 
     CompressorOperatingPointResult result = compressor.getOperatingPointResult();
@@ -103,8 +98,7 @@ public class CompressorOperatingPointResultTest {
     assertTrue(result.isHardLimitExceeded());
     assertEquals("vendorPowerLimit", result.getLimitingConstraint());
     assertEquals(1.2, result.getMaximumCapacityUtilization(), 1.0e-12);
-    assertEquals(CompressorOperatingPointResult.OperatingStatus.CAPACITY_LIMIT,
-        result.getOperatingStatus());
+    assertEquals(CompressorOperatingPointResult.OperatingStatus.CAPACITY_LIMIT, result.getOperatingStatus());
     CompressorOperatingPointResult.ConstraintSnapshot snapshot = result.getConstraints().stream()
         .filter(value -> value.getName().equals("vendorPowerLimit")).findFirst().orElse(null);
     assertNotNull(snapshot);
@@ -131,8 +125,7 @@ public class CompressorOperatingPointResultTest {
     assertFalse(Double.isNaN(result.getDistanceToStonewall()));
     assertTrue(result.getRequiredRecycleFraction() >= 0.0);
     assertTrue(result.getRequiredRecycleFraction() <= 1.0);
-    assertEquals(result.getPowerKW() * result.getRequiredRecycleFraction(),
-        result.getRecyclePowerLossKW(), 1.0e-8);
+    assertEquals(result.getPowerKW() * result.getRequiredRecycleFraction(), result.getRecyclePowerLossKW(), 1.0e-8);
     assertEquals(result.getRecyclePowerLossKW(), result.getRecycleCoolerDutyKW(), 1.0e-8);
 
     CapacityConstraint surge = compressor.getCapacityConstraints().get("surgeMargin");
@@ -142,8 +135,7 @@ public class CompressorOperatingPointResultTest {
     assertTrue(surge.isMinimumConstraint());
     assertTrue(stonewall.isMinimumConstraint());
     assertEquals(compressor.getDistanceToSurge() * 100.0, surge.getCurrentValue(), 1.0e-8);
-    assertEquals(compressor.getDistanceToStoneWall() * 100.0, stonewall.getCurrentValue(),
-        1.0e-8);
+    assertEquals(compressor.getDistanceToStoneWall() * 100.0, stonewall.getCurrentValue(), 1.0e-8);
 
     String json = result.toJson();
     assertTrue(json.contains("\"operatingStatus\""));
@@ -161,8 +153,7 @@ public class CompressorOperatingPointResultTest {
     }
 
     CompressorOperatingPointResult restored;
-    try (ObjectInputStream input =
-        new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
       restored = (CompressorOperatingPointResult) input.readObject();
     }
 

--- a/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
@@ -51,9 +51,9 @@ public class PressureBoundaryCapacityIntegrationTest {
 
     PressureBoundaryOptimizer optimizer = new PressureBoundaryOptimizer(process, feed, export);
     optimizer.setMinSurgeMargin(0.15);
-    optimizer.configureCompressorCharts();
     compressor.addCapacityConstraint(new CapacityConstraint("vendorLimit", "-", CapacityConstraint.ConstraintType.SOFT)
         .setDesignValue(1.0).setCurrentValue(0.8).setSeverity(CapacityConstraint.ConstraintSeverity.SOFT));
+    optimizer.configureCompressorCharts();
 
     Method factory = PressureBoundaryOptimizer.class.getDeclaredMethod("createCompressorConstraints");
     factory.setAccessible(true);

--- a/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
@@ -3,6 +3,7 @@ package neqsim.process.util.optimizer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -50,6 +51,13 @@ public class PressureBoundaryCapacityIntegrationTest {
     process.run();
 
     PressureBoundaryOptimizer optimizer = new PressureBoundaryOptimizer(process, feed, export);
+    assertThrows(IllegalArgumentException.class, () -> optimizer.setMinSurgeMargin(0.0));
+    assertThrows(IllegalArgumentException.class, () -> optimizer.setMinSurgeMargin(-0.10));
+    assertThrows(IllegalArgumentException.class, () -> optimizer.setMinSurgeMargin(Double.NaN));
+    assertThrows(IllegalArgumentException.class,
+        () -> optimizer.setMinSurgeMargin(Double.POSITIVE_INFINITY));
+    assertThrows(IllegalArgumentException.class,
+        () -> optimizer.setMinSurgeMargin(Double.NEGATIVE_INFINITY));
     optimizer.setMinSurgeMargin(0.15);
     compressor.addCapacityConstraint(new CapacityConstraint("vendorLimit", "-", CapacityConstraint.ConstraintType.SOFT)
         .setDesignValue(1.0).setCurrentValue(0.8).setSeverity(CapacityConstraint.ConstraintSeverity.SOFT));

--- a/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
@@ -52,15 +52,12 @@ public class PressureBoundaryCapacityIntegrationTest {
     PressureBoundaryOptimizer optimizer = new PressureBoundaryOptimizer(process, feed, export);
     optimizer.setMinSurgeMargin(0.15);
     optimizer.configureCompressorCharts();
-    compressor.addCapacityConstraint(
-        new CapacityConstraint("vendorLimit", "-", CapacityConstraint.ConstraintType.SOFT)
-            .setDesignValue(1.0).setCurrentValue(0.8)
-            .setSeverity(CapacityConstraint.ConstraintSeverity.SOFT));
+    compressor.addCapacityConstraint(new CapacityConstraint("vendorLimit", "-", CapacityConstraint.ConstraintType.SOFT)
+        .setDesignValue(1.0).setCurrentValue(0.8).setSeverity(CapacityConstraint.ConstraintSeverity.SOFT));
 
     Method factory = PressureBoundaryOptimizer.class.getDeclaredMethod("createCompressorConstraints");
     factory.setAccessible(true);
-    List<OptimizationConstraint> constraints =
-        (List<OptimizationConstraint>) factory.invoke(optimizer);
+    List<OptimizationConstraint> constraints = (List<OptimizationConstraint>) factory.invoke(optimizer);
 
     assertConstraintPresent(constraints, "ExportCompressor_speed");
     assertConstraintPresent(constraints, "ExportCompressor_power");
@@ -73,13 +70,11 @@ public class PressureBoundaryCapacityIntegrationTest {
     CapacityConstraint surge = compressor.getCapacityConstraints().get("surgeMargin");
     assertNotNull(surge);
     assertEquals(15.0, surge.getMinValue(), 0.0);
-    OptimizationConstraint surgeOptimization =
-        getConstraint(constraints, "ExportCompressor_surgeMargin");
+    OptimizationConstraint surgeOptimization = getConstraint(constraints, "ExportCompressor_surgeMargin");
     assertEquals(1.0 - surge.getUtilization(), surgeOptimization.margin(process), 1.0e-12);
   }
 
-  private static void assertConstraintPresent(List<OptimizationConstraint> constraints,
-      String name) {
+  private static void assertConstraintPresent(List<OptimizationConstraint> constraints, String name) {
     assertTrue(hasConstraint(constraints, name), "Expected optimizer constraint " + name);
   }
 
@@ -87,8 +82,7 @@ public class PressureBoundaryCapacityIntegrationTest {
     return getConstraint(constraints, name) != null;
   }
 
-  private static OptimizationConstraint getConstraint(List<OptimizationConstraint> constraints,
-      String name) {
+  private static OptimizationConstraint getConstraint(List<OptimizationConstraint> constraints, String name) {
     for (OptimizationConstraint constraint : constraints) {
       if (name.equals(constraint.getName())) {
         return constraint;

--- a/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
@@ -75,7 +75,7 @@ public class PressureBoundaryCapacityIntegrationTest {
 
     CapacityConstraint surge = compressor.getCapacityConstraints().get("surgeMargin");
     assertNotNull(surge);
-    assertEquals(15.0, surge.getMinValue(), 0.0);
+    assertEquals(15.0, surge.getMinValue(), 1.0e-12);
     OptimizationConstraint surgeOptimization = getConstraint(constraints, "ExportCompressor_surgeMargin");
     assertEquals(1.0 - surge.getUtilization(), surgeOptimization.margin(process), 1.0e-12);
   }

--- a/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
@@ -1,0 +1,99 @@
+package neqsim.process.util.optimizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.util.optimizer.ProductionOptimizer.OptimizationConstraint;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Verifies that pressure-boundary optimization consumes compressor capacity constraints.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class PressureBoundaryCapacityIntegrationTest {
+
+  /** Verifies reuse of map, driver, temperature, and custom capacity constraints. */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testOptimizerUsesEnabledCompressorCapacityConstraints() throws Exception {
+    SystemInterface gas = new SystemSrkEos(288.15, 50.0);
+    gas.addComponent("methane", 0.90);
+    gas.addComponent("ethane", 0.07);
+    gas.addComponent("propane", 0.03);
+    gas.setMixingRule("classic");
+
+    Stream feed = new Stream("Feed", gas);
+    feed.setFlowRate(30000.0, "kg/hr");
+    feed.run();
+
+    Compressor compressor = new Compressor("ExportCompressor", feed);
+    compressor.setOutletPressure(100.0, "bara");
+    compressor.setUsePolytropicCalc(true);
+    compressor.setPolytropicEfficiency(0.75);
+    Stream export = new Stream("Export", compressor.getOutletStream());
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(compressor);
+    process.add(export);
+    process.run();
+
+    PressureBoundaryOptimizer optimizer = new PressureBoundaryOptimizer(process, feed, export);
+    optimizer.setMinSurgeMargin(0.15);
+    optimizer.configureCompressorCharts();
+    compressor.addCapacityConstraint(
+        new CapacityConstraint("vendorLimit", "-", CapacityConstraint.ConstraintType.SOFT)
+            .setDesignValue(1.0).setCurrentValue(0.8)
+            .setSeverity(CapacityConstraint.ConstraintSeverity.SOFT));
+
+    Method factory = PressureBoundaryOptimizer.class.getDeclaredMethod("createCompressorConstraints");
+    factory.setAccessible(true);
+    List<OptimizationConstraint> constraints =
+        (List<OptimizationConstraint>) factory.invoke(optimizer);
+
+    assertConstraintPresent(constraints, "ExportCompressor_speed");
+    assertConstraintPresent(constraints, "ExportCompressor_power");
+    assertConstraintPresent(constraints, "ExportCompressor_surgeMargin");
+    assertConstraintPresent(constraints, "ExportCompressor_stonewallMargin");
+    assertConstraintPresent(constraints, "ExportCompressor_vendorLimit");
+    assertFalse(hasConstraint(constraints, "ExportCompressor_ratedPower"),
+        "DESIGN constraints should remain reporting-only");
+
+    CapacityConstraint surge = compressor.getCapacityConstraints().get("surgeMargin");
+    assertNotNull(surge);
+    assertEquals(15.0, surge.getMinValue(), 0.0);
+    OptimizationConstraint surgeOptimization =
+        getConstraint(constraints, "ExportCompressor_surgeMargin");
+    assertEquals(1.0 - surge.getUtilization(), surgeOptimization.margin(process), 1.0e-12);
+  }
+
+  private static void assertConstraintPresent(List<OptimizationConstraint> constraints,
+      String name) {
+    assertTrue(hasConstraint(constraints, name), "Expected optimizer constraint " + name);
+  }
+
+  private static boolean hasConstraint(List<OptimizationConstraint> constraints, String name) {
+    return getConstraint(constraints, name) != null;
+  }
+
+  private static OptimizationConstraint getConstraint(List<OptimizationConstraint> constraints,
+      String name) {
+    for (OptimizationConstraint constraint : constraints) {
+      if (name.equals(constraint.getName())) {
+        return constraint;
+      }
+    }
+    return null;
+  }
+}

--- a/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PressureBoundaryCapacityIntegrationTest.java
@@ -54,10 +54,8 @@ public class PressureBoundaryCapacityIntegrationTest {
     assertThrows(IllegalArgumentException.class, () -> optimizer.setMinSurgeMargin(0.0));
     assertThrows(IllegalArgumentException.class, () -> optimizer.setMinSurgeMargin(-0.10));
     assertThrows(IllegalArgumentException.class, () -> optimizer.setMinSurgeMargin(Double.NaN));
-    assertThrows(IllegalArgumentException.class,
-        () -> optimizer.setMinSurgeMargin(Double.POSITIVE_INFINITY));
-    assertThrows(IllegalArgumentException.class,
-        () -> optimizer.setMinSurgeMargin(Double.NEGATIVE_INFINITY));
+    assertThrows(IllegalArgumentException.class, () -> optimizer.setMinSurgeMargin(Double.POSITIVE_INFINITY));
+    assertThrows(IllegalArgumentException.class, () -> optimizer.setMinSurgeMargin(Double.NEGATIVE_INFINITY));
     optimizer.setMinSurgeMargin(0.15);
     compressor.addCapacityConstraint(new CapacityConstraint("vendorLimit", "-", CapacityConstraint.ConstraintType.SOFT)
         .setDesignValue(1.0).setCurrentValue(0.8).setSeverity(CapacityConstraint.ConstraintSeverity.SOFT));


### PR DESCRIPTION
## Summary

Adds a NeqSim-native, typed compressor operating-point result and aligns compressor reporting, bottleneck detection, and pressure-boundary optimization around the existing `CapacityConstraint` framework.

## What changed

- adds immutable `CompressorOperatingPointResult` with:
  - physical flow, head, speed, efficiency, power, pressure, and temperature
  - surge and stonewall state and margins
  - anti-surge control-line flow, required recycle fraction, recycle power loss, and recycle-cooler duty
  - requested-versus-calculated discharge-pressure status
  - maximum capacity utilization, limiting constraint, feasibility status, and detached constraint snapshots
  - schema-versioned JSON serialization
- exposes the result through `Compressor.getOperatingPointResult()` while preserving the existing map/JSON API
- corrects compressor surge and stonewall constraints to use physical margin percentages as true minimum-good limits
- corrects `CapacityConstraint.isHardLimitExceeded()` for hard minimum constraints
- makes `PressureBoundaryOptimizer` reuse every enabled, non-design, non-advisory compressor capacity constraint
- keeps caller-specified power and speed limits as additional optimizer overrides
- documents the API and behavior change

## Why this belongs in NeqSim

eCalc-style energy and emissions workflows need explicit, stable equipment status rather than reconstructing feasibility from many mutable getters. Compressor physics, capacity, bottleneck analysis, and pressure-boundary optimization are NeqSim responsibilities; this change connects those existing layers instead of adding a parallel solver. Time-series aggregation, installation modeling, fuel/emissions accounting, and reporting remain in eCalc.

It also fixes a correctness issue: surge and stonewall suppliers returned an already-normalized utilization while declaring a minimum margin. As a result, operation below the configured minimum did not become a capacity violation.

## Compatibility

- existing `getOperatingPoint()` and `getOperatingPointJson()` remain unchanged
- a chartless compressor remains a valid thermodynamic operating point
- behavior changes only where a compressor is below a configured surge/stonewall minimum: bottleneck and optimization APIs now correctly report it as infeasible
- implementation is clean-room NeqSim code; no LGPL eCalc source was copied into the Apache-2.0 repository

## Example notebook

A companion source-pinned Colab is included in [EvenSol/NeqSim-Colab#62](https://github.com/EvenSol/NeqSim-Colab/pull/62). It generates all speed/head/efficiency curves and surge/stonewall boundaries, then exercises the same constraints through the typed result, `ProcessSystem.findBottleneck()`, and `PressureBoundaryOptimizer.findMaxFlowRate()`. It also evaluates driver debottlenecking and field-life inlet-pressure reduction.

## Validation

- new production class compiled with Java 8 source/target compatibility against NeqSim 3.16.0
- focused tests added:
  - `CompressorOperatingPointResultTest`
  - `CapacityConstraintMinimumLimitTest`
  - `PressureBoundaryCapacityIntegrationTest`
- GitHub Actions currently green for Spotless, pre-commit, documentation search coverage, PaperLab, CodeQL, and Java 21 Javadoc
- Java 21 Ubuntu and Windows test jobs are still running

## Engineering interpretation

The same constraint definition now drives:

1. compressor operating-point reporting,
2. `ProcessSystem.findBottleneck()`,
3. `CapacityConstraintAdapter`, and
4. `PressureBoundaryOptimizer` field-life/capacity searches.

This provides a stable equipment-level contract for eCalc handoff and later generator fuel, emissions, and life-of-field time-series integration.

I understand the implementation and why the change is appropriate: it preserves the existing physical models and optimization algorithms while removing duplicated constraint semantics at their integration boundary.
