### PR TITLE
[AI-Assisted] Use undamped residual for damped column convergence

### DIFF
--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -697,6 +697,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   private int lastIterationCount = 0;
   /** Last recorded average temperature residual in Kelvin. */
   private double lastTemperatureResidual = 0.0;
+  /** Last average tray-temperature step applied by the sequential solver in Kelvin. */
+  private double lastAppliedTemperatureStepResidual = Double.NaN;
   /** Last recorded relative mass balance residual. */
   private double lastMassResidual = 0.0;
   /** Last recorded relative enthalpy residual. */
@@ -1223,6 +1225,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   @Override
   public void run(UUID id) {
     long runStartTime = System.nanoTime();
+    lastAppliedTemperatureStepResidual = Double.NaN;
     lastInternalTrafficGuardReached = false;
     internalTrafficCapActive = false;
     lastSpecificationHomotopyStepCount = 0;
@@ -2868,6 +2871,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     this.err = candidate.err;
     this.lastIterationCount = candidate.lastIterationCount;
     this.lastTemperatureResidual = candidate.lastTemperatureResidual;
+    this.lastAppliedTemperatureStepResidual = candidate.lastAppliedTemperatureStepResidual;
     this.lastMassResidual = candidate.lastMassResidual;
     this.lastEnergyResidual = candidate.lastEnergyResidual;
     this.lastTopSpecificationResidual = candidate.lastTopSpecificationResidual;
@@ -5441,6 +5445,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       }
 
       double temperatureResidual = 0.0;
+      double appliedTemperatureStepResidual = 0.0;
       double effectiveRelaxation = Math.max(minTemperatureRelaxation, Math.min(1.0, relaxation));
       for (int i = 0; i < numberOfTrays; i++) {
         double updated = trays.get(i).getThermoSystem().getTemperature();
@@ -5449,9 +5454,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
         }
         double newTemp = oldtemps[i] + effectiveRelaxation * (updated - oldtemps[i]);
         trays.get(i).setTemperature(newTemp);
+        appliedTemperatureStepResidual += Math.abs(newTemp - oldtemps[i]);
         temperatureResidual += Math.abs(newTemp - oldtemps[i]);
       }
       temperatureResidual /= Math.max(1, numberOfTrays);
+      appliedTemperatureStepResidual /= Math.max(1, numberOfTrays);
+      lastAppliedTemperatureStepResidual = appliedTemperatureStepResidual;
       err = temperatureResidual;
 
       boolean evaluateBalances = shouldEvaluateBalances(iter, iterationLimit, polishing, err, baseTempTolerance,
@@ -8125,6 +8133,16 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
+   * Retrieve the average tray-temperature step applied by the latest sequential-solver iteration.
+   *
+   * @return average applied temperature step in Kelvin, or {@link Double#NaN} when the latest run did not execute the
+   * sequential solver
+   */
+  public double getLastAppliedTemperatureStepResidual() {
+    return lastAppliedTemperatureStepResidual;
+  }
+
+  /**
    * Retrieve the latest relative mass residual.
    *
    * @return relative mass balance residual
@@ -8560,6 +8578,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     diagnostics.append("  Residuals:\n");
     diagnostics.append("    temperature: ").append(lastTemperatureResidual).append(" K (tolerance ")
         .append(getEffectiveTemperatureTolerance()).append(")\n");
+    diagnostics.append("    applied temperature step: ").append(lastAppliedTemperatureStepResidual).append(" K\n");
     diagnostics.append("    mass: ").append(lastMassResidual).append(" (tolerance ")
         .append(getEffectiveMassBalanceTolerance()).append(")\n");
     diagnostics.append("    energy: ").append(lastEnergyResidual).append(" (tolerance ")
@@ -11634,6 +11653,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     err = 1.0e10;
     lastIterationCount = 0;
     lastTemperatureResidual = 0.0;
+    lastAppliedTemperatureStepResidual = Double.NaN;
     lastMassResidual = 0.0;
     lastEnergyResidual = 0.0;
     lastSolveTimeSeconds = 0.0;

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -5470,7 +5470,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
         massEnergyEvaluated = true;
       }
 
-      double tempScaled = err / baseTempTolerance;
+      // Keep adaptive damping calibrated to the step actually applied; convergence uses the
+      // undamped fixed-point residual in err.
+      double tempScaled = appliedTemperatureStepResidual / baseTempTolerance;
       double massScaled = massErr / baseMassTolerance;
       double energyScaled = energyErr / baseEnergyTolerance;
       double combinedResidual = Math.max(tempScaled, massScaled);

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -5455,7 +5455,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
         double newTemp = oldtemps[i] + effectiveRelaxation * (updated - oldtemps[i]);
         trays.get(i).setTemperature(newTemp);
         appliedTemperatureStepResidual += Math.abs(newTemp - oldtemps[i]);
-        temperatureResidual += Math.abs(newTemp - oldtemps[i]);
+        temperatureResidual += Math.abs(updated - oldtemps[i]);
       }
       temperatureResidual /= Math.max(1, numberOfTrays);
       appliedTemperatureStepResidual /= Math.max(1, numberOfTrays);

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolverTuningTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolverTuningTest.java
@@ -80,8 +80,7 @@ public class DistillationColumnSolverTuningTest {
     double fixedPointResidual = column.getLastTemperatureResidual();
     assertTrue(appliedStep > 0.0, "the perturbed state must produce an applied temperature step");
     assertTrue(fixedPointResidual > 0.0, "the perturbed state must produce a fixed-point residual");
-    assertEquals(0.2 * fixedPointResidual, appliedStep,
-        Math.max(1.0e-10, 1.0e-8 * fixedPointResidual),
+    assertEquals(0.2 * fixedPointResidual, appliedStep, Math.max(1.0e-10, 1.0e-8 * fixedPointResidual),
         "relaxation must scale only the applied step, not the convergence residual");
   }
 

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolverTuningTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolverTuningTest.java
@@ -61,6 +61,31 @@ public class DistillationColumnSolverTuningTest {
   }
 
   /**
+   * Damping must reduce the applied update without reducing the fixed-point residual used for convergence.
+   */
+  @Test
+  public void reportedResidualIsUndampedFixedPointMismatch() {
+    DistillationColumn column = buildColumn(6);
+    column.getReboiler().setOutTemperature(273.15 + 80.0);
+    column.setSolverType(DistillationColumn.SolverType.DAMPED_SUBSTITUTION);
+    column.run();
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+
+    column.setRelaxationFactor(0.2);
+    column.getTray(2).setTemperature(column.getTray(2).getTemperature() + 1.0);
+    column.setMaxNumberOfIterations(1, true);
+    column.run();
+
+    double appliedStep = column.getLastAppliedTemperatureStepResidual();
+    double fixedPointResidual = column.getLastTemperatureResidual();
+    assertTrue(appliedStep > 0.0, "the perturbed state must produce an applied temperature step");
+    assertTrue(fixedPointResidual > 0.0, "the perturbed state must produce a fixed-point residual");
+    assertEquals(0.2 * fixedPointResidual, appliedStep,
+        Math.max(1.0e-10, 1.0e-8 * fixedPointResidual),
+        "relaxation must scale only the applied step, not the convergence residual");
+  }
+
+  /**
    * A relaxation factor above the floor must leave the floor untouched.
    */
   @Test


### PR DESCRIPTION
## Problem

The sequential/damped-substitution column solver reports the average **applied damped temperature step** as its convergence residual. At relaxation 0.2, this makes the reported residual five times smaller than the undamped fixed-point mismatch and can permit premature convergence.

## Bounded scope

This PR was rebuilt cleanly from current `master` and is limited to:

- one diagnostic for the final sequential-solver applied temperature step;
- one deterministic, hard-capped hydrocarbon-column regression;
- one residual-formula correction in `solveSequential`.

Earlier speculative fallback-state changes and the path-dependent warm/cold-reference test were removed. No fallback, cache, specification, tolerance, product-reconciliation, or thermodynamic-model behavior is changed.

## Reproduction on the uncorrected formula

Baseline head `738f5e2b848ed9532b950c019b93baff8080cda3` converged a propane/n-butane/n-pentane stripper, applied a controlled 1 K tray perturbation, then performed exactly one hard-capped sweep at relaxation 0.2.

Windows/Java 21 ran 10,858 tests and produced exactly the intended failure:

- expected applied step: `4.106355444686675e-4 K` (`0.2 * fixed-point mismatch`)
- actual applied step: `2.0531777223433373e-3 K`
- ratio: exactly `5.0`
- total failures: 1; errors: 0; skipped: 212

This proves that the old `getLastTemperatureResidual()` value was the damped step rather than the undamped convergence mismatch.

## Algorithmic change

`solveSequential` now keeps two distinct quantities:

- `lastAppliedTemperatureStepResidual`: average `abs(newTemp - oldTemp)` for diagnostics;
- `lastTemperatureResidual`: average `abs(updated - oldTemp)` for convergence;
- adaptive relaxation remains scaled by `lastAppliedTemperatureStepResidual`, preserving its prior controller calibration while the stopping gate uses the undamped residual.

The change adds no flash calls and no allocations inside the iteration loop. It also avoids coupling the convergence metric correction to the adaptive step-size trajectory.

## Regression

`reportedResidualIsUndampedFixedPointMismatch` uses a converged six-tray hydrocarbon stripper, a controlled nearby perturbation, relaxation 0.2, and a one-iteration hard cap. It requires:

```
applied step = 0.2 * undamped fixed-point residual
```

The internal diagnostic avoids contamination from public-run synchronization and finalization effects.

## Compatibility and risk

The new diagnostic is reset at every public run, copied when an automatic-solver candidate is adopted, included in convergence diagnostics, and returns `NaN` when no sequential sweep ran. Serialization identity is unchanged. The implementation does not change direct-substitution arithmetic because its effective relaxation is 1.0.

## Validation status

Current head `05f71c7` validates the adaptive-controller correction on Windows/Java 21:

- 10,858 tests passed;
- 0 failures and 0 errors; 212 skipped;
- the existing SRK→PR cold-reference contract now passes;
- the hard-capped fixed-point/applied-step regression passes;
- Spotless, pre-commit, PaperLab, agent/skill reference checks, Java 21 Javadoc, and CodeQL pass.

The preceding head `6275eb4` differed from the SRK→PR cold reference by `1.5220951124770286e-4` against the unchanged `1.0e-4` bound. Restoring the applied-step norm only for adaptive damping removes that regression while retaining the undamped convergence gate. No tolerance was loosened and no test was disabled.

Ubuntu/Java 21 with JaCoCo is still running. During validation, `master` advanced by one unrelated documentation commit (`bdd7eac`); after the solver suite completes, this two-file change must be replayed on that base and revalidated. The PR is not ready and will not be merged automatically.

## Copilot review

Every current thread on the clean diff has been inspected after the latest push.

- The current metadata-consistency suggestion was accepted: the description now separates the baseline and fixed heads with exact evidence. The thread was replied to and resolved.
- Outdated soft-cap and fallback-state threads were replied to and resolved because the referenced code/tests were removed by the clean branch rebuild; the retained regression uses an explicit one-iteration hard cap.
- The directly relevant suggestion—to measure the applied step inside `solveSequential` instead of inferring it from public tray temperatures—was implemented, validated by the passing hard-capped regression in the 10,858-test Windows run, replied to, and resolved.
- The broader unchanged-run repeatability suggestion remains open because the earlier proposed warm/cold case was demonstrably path-dependent; no invalid regression or tolerance loosening is retained.