### PR TITLE
docs: document physical property type aliases

### DIFF
--- a/docs/physical_properties/README.md
+++ b/docs/physical_properties/README.md
@@ -88,7 +88,8 @@ Select the model set before initializing the properties. For example, call
 The string overload of `initPhysicalProperties` selects a
 `PhysicalPropertyType` such as `DYNAMIC_VISCOSITY`; it does not select a
 `PhysicalPropertyModel`. Therefore, `initPhysicalProperties("GLYCOL")` is not a model-set
-selection call.
+selection call. For compatibility, the legacy keys `DENSITY`, `VISCOSITY`, and `CONDUCTIVITY`
+map to `MASS_DENSITY`, `DYNAMIC_VISCOSITY`, and `THERMAL_CONDUCTIVITY`, respectively.
 
 ## Overriding individual phase models
 

--- a/src/test/java/neqsim/physicalproperties/PhysicalPropertiesPackageDocumentationTest.java
+++ b/src/test/java/neqsim/physicalproperties/PhysicalPropertiesPackageDocumentationTest.java
@@ -38,8 +38,12 @@ class PhysicalPropertiesPackageDocumentationTest {
     fluid.initPhysicalProperties();
 
     assertPositiveFinite(fluid.getPhase("gas").getViscosity("kg/msec"));
+    fluid.initPhysicalProperties("DENSITY");
+    assertPositiveFinite(fluid.getPhase("gas").getDensity("kg/m3"));
     fluid.initPhysicalProperties("VISCOSITY");
     assertPositiveFinite(fluid.getPhase("gas").getViscosity("kg/msec"));
+    fluid.initPhysicalProperties("CONDUCTIVITY");
+    assertPositiveFinite(fluid.getPhase("gas").getThermalConductivity("W/mK"));
     assertThrows(RuntimeException.class, () -> fluid.initPhysicalProperties("GLYCOL"));
   }
 


### PR DESCRIPTION
Follow-up to D037 in #2499 and merged PR #2640.

## Frozen scope

- `docs/physical_properties/README.md`
- `src/test/java/neqsim/physicalproperties/PhysicalPropertiesPackageDocumentationTest.java`

No other open PR changes either scoped path. The current branch is based on `master` commit `85043e74b8b08b944d2e5e0ae0f532c8895a3ddd`.

## Confirmed defect

**Severity: medium — incomplete API compatibility guidance.**

The D037 page documents the canonical `PhysicalPropertyType` names but omits the three compatibility aliases accepted by `PhysicalPropertyType.byName`. A late Copilot review on #2640 correctly identified the omission after that PR was merged.

Source evidence in `src/main/java/neqsim/physicalproperties/PhysicalPropertyType.java` confirms these exact mappings:

- `DENSITY` → `MASS_DENSITY`
- `VISCOSITY` → `DYNAMIC_VISCOSITY`
- `CONDUCTIVITY` → `THERMAL_CONDUCTIVITY`

## Fix

- Document all three exact compatibility mappings beside the canonical type guidance.
- Execute each alias through `initPhysicalProperties(String)` in the focused documentation regression and assert a positive, finite result.
- Retain the negative `GLYCOL` assertion so property-type aliases remain distinct from `PhysicalPropertyModel` selection.

## Validation evidence

Completed on head `acf36c3f84aff1cf2d2d2620c0c58a417066fa05`:

- Source/API audit: exact alias mappings match `PhysicalPropertyType.byName`.
- Markdown/Jekyll structure: required title and description front matter present; no duplicate H1; six balanced code fences; no raw HTML.
- Links/navigation: all 11 internal links resolve to eight unique repository targets; no raw-space destinations.
- Equations/rendering: no equations or math delimiters are present in the changed page; no equation render claim is needed.
- External links/images/notebooks/Python: none in scope.
- Windows Java 21: `PhysicalPropertiesPackageDocumentationTest` passed 4/4.
- Windows Java 21 full suite: 10,857 tests, 0 failures, 0 errors, 212 skipped.
- Passed: Spotless format patch, pre-commit checks, documentation search coverage, CodeQL, Javadoc, agent-skill cross-reference verification, and Java/XML change detection.
- Copilot reviewed 2/2 changed files after the latest push and produced no inline comments or suggested-change blocks; no review threads exist.

Remaining validation:

- Ubuntu Java 21 completed successfully after the long JaCoCo run: `PhysicalPropertiesPackageDocumentationTest` passed 4/4 and the full suite passed 11,060 tests with 0 failures, 0 errors, and 215 skipped.
- Windows Java 21 previously passed 10,857 tests with 0 failures and 0 errors.
- The workflow has advanced to Java 8 tests on Ubuntu and Windows; both are currently running.
- The PR remains draft until both Java 8 jobs reach terminal results and the final-head Copilot/thread/diff review is repeated.

## Render and before/after note

Before: users were shown only canonical `PhysicalPropertyType` names and could not discover the accepted legacy keys.

After: the page states all three legacy-to-canonical mappings and the regression test executes every mapping.

No rendered-site artifact is currently available, so browser visual inspection is not claimed. The change is plain prose beside an existing paragraph and does not alter layout structures.

## Deliberate exclusions

- No production-code change: the implementation is already correct.
- No index change: this updates an already indexed page.
- No unrelated physical-property, thermodynamic, or documentation cleanup.
- No campaign ledger completion while the PR is open.

## Next campaign scope

After this PR is merged and D037 follow-up evidence is recorded, continue with the next uncompleted rotation scope from #2499.