### PR TITLE
Fix sequential column warm-start compatibility

### DIFF
--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -630,6 +630,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    */
   private transient long trayStateThermodynamicIdentitySignature = Long.MIN_VALUE;
   /**
+   * Fingerprint of fixed column inputs used to build the current sequential tray initialization.
+   *
+   * <p>
+   * Feed operating conditions are intentionally excluded so nearby feed cases retain their warm start.
+   * </p>
+   */
+  private transient long lastSequentialInitializationSignature = Long.MIN_VALUE;
+  /**
    * Whether the current tray state was produced by {@link NaphtaliSandholmSolver} on this column instance.
    *
    * <p>
@@ -1112,6 +1120,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     // identity they describe. Any later solve that sees a different identity must initialize again
     // instead of reusing or warm-starting from a tray network built for other components.
     trayStateThermodynamicIdentitySignature = calculateThermodynamicIdentitySignature();
+    lastSequentialInitializationSignature = calculateSequentialInitializationSignature();
     naphtaliSandholmStateOwned = false;
     hasNaphtaliSandholmWarmState = false;
 
@@ -2403,6 +2412,21 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
+   * Calculate a deterministic fingerprint of fixed inputs that define a sequential initialization.
+   *
+   * <p>
+   * Feed flow, temperature, pressure, and composition are excluded because ordinary nearby feed changes are the main
+   * benefit of a sequential warm start. Thermodynamic model and component identity are checked separately.
+   * </p>
+   *
+   * @return fixed column-configuration fingerprint
+   */
+  private long calculateSequentialInitializationSignature() {
+    long signature = 1125899906842597L;
+    return updateColumnConfigurationSignature(signature);
+  }
+
+  /**
    * Calculate a deterministic fingerprint of inputs that affect a Naphtali-Sandholm solve.
    *
    * @return input and specification fingerprint
@@ -2911,6 +2935,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     // acceptNaphtaliWarmStartCandidate and commitNaphtaliSandholmWarmState recomputes the
     // fingerprint from the inputs that are actually in force.
     this.trayStateThermodynamicIdentitySignature = candidate.trayStateThermodynamicIdentitySignature;
+    this.lastSequentialInitializationSignature = candidate.lastSequentialInitializationSignature;
     this.naphtaliSandholmStateOwned = false;
     this.hasNaphtaliSandholmWarmState = false;
     this.lastNaphtaliSandholmInputSignature = Long.MIN_VALUE;
@@ -5116,6 +5141,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     terminalGasProductDrawStream = null;
     terminalLiquidProductDrawStream = null;
     trayStateThermodynamicIdentitySignature = Long.MIN_VALUE;
+    lastSequentialInitializationSignature = Long.MIN_VALUE;
     err = 1.0e10;
     resetLastSolveMetrics();
 
@@ -5306,6 +5332,18 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     if (numberOfTrays == 1) {
       solveSingleTray(id);
       return;
+    }
+
+    long currentThermodynamicIdentitySignature = calculateThermodynamicIdentitySignature();
+    long currentSequentialInitializationSignature = calculateSequentialInitializationSignature();
+    boolean thermodynamicIdentityChanged = currentThermodynamicIdentitySignature != trayStateThermodynamicIdentitySignature;
+    boolean columnConfigurationChanged = currentSequentialInitializationSignature != lastSequentialInitializationSignature;
+    if (hasBeenSolvedBefore && !isDoInitializion()
+        && (thermodynamicIdentityChanged || (!hasAdjustableSpecifications() && columnConfigurationChanged))) {
+      logger.info("Sequential warm start is incompatible with current inputs for column {}; "
+          + "rebuilding tray initialization.", getName());
+      hasBeenSolvedBefore = false;
+      setDoInitializion(true);
     }
 
     if (isDoInitializion()) {
@@ -11677,6 +11715,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     naphtaliSandholmStateOwned = false;
     lastNaphtaliSandholmInputSignature = Long.MIN_VALUE;
     lastNaphtaliSandholmWarmStateReused = false;
+    lastSequentialInitializationSignature = Long.MIN_VALUE;
     resetInsideOutTelemetry();
     resetNaphtaliTelemetry();
     terminalGasProductDrawStream = null;

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1222,6 +1222,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     trays.get(0).replaceStream(streamNumb, trays.get(1).getLiquidOutStream());
     trays.get(0).init();
     trays.get(0).run();
+
+    // Tray profile construction intentionally seeds internal feed clones at local tray
+    // temperatures. Restore the caller-owned feed thermodynamic states before the actual
+    // column solver starts so the solved mass and energy balances use the requested feeds.
+    refreshInternalExternalFeedSystems();
   }
 
   /**
@@ -2261,7 +2266,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @return {@code true} when the Naphtali-Sandholm solver accepted its direct result
    */
   boolean solveNaphtaliSandholm(UUID id) {
-    if (feedStreams.isEmpty()) {
+    captureDirectExternalTrayFeeds();
+    if (feedStreams.isEmpty() && directExternalFeedStreams.isEmpty()) {
       resetLastSolveMetrics();
       return false;
     }
@@ -2296,15 +2302,17 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
 
     Map<Integer, List<SystemInterface>> originalFeedSystems = new java.util.HashMap<>();
     Map<Integer, List<Double>> originalFeedFlowRates = new java.util.HashMap<>();
-    for (Map.Entry<Integer, List<StreamInterface>> entry : feedStreams.entrySet()) {
+    Set<Integer> externalFeedTrayNumberSet = new HashSet<Integer>(feedStreams.keySet());
+    externalFeedTrayNumberSet.addAll(directExternalFeedStreams.keySet());
+    for (Integer trayNumber : externalFeedTrayNumberSet) {
       List<SystemInterface> clones = new java.util.ArrayList<>();
       List<Double> flowRates = new java.util.ArrayList<>();
-      for (StreamInterface feed : entry.getValue()) {
+      for (StreamInterface feed : getExternalFeedStreams(trayNumber.intValue())) {
         clones.add(feed.getThermoSystem().clone());
         flowRates.add(feed.getFlowRate("mol/hr"));
       }
-      originalFeedSystems.put(entry.getKey(), clones);
-      originalFeedFlowRates.put(entry.getKey(), flowRates);
+      originalFeedSystems.put(trayNumber, clones);
+      originalFeedFlowRates.put(trayNumber, flowRates);
     }
 
     boolean initialized = isDoInitializion();
@@ -2388,7 +2396,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * running the solver
    */
   boolean willReuseNaphtaliSandholmWarmState() {
-    if (feedStreams.isEmpty() || numberOfTrays == 1 || isDoInitializion()) {
+    captureDirectExternalTrayFeeds();
+    if ((feedStreams.isEmpty() && directExternalFeedStreams.isEmpty()) || numberOfTrays == 1
+        || isDoInitializion()) {
       return false;
     }
     if (calculateThermodynamicIdentitySignature() != trayStateThermodynamicIdentitySignature) {
@@ -2438,12 +2448,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    */
   private long calculateNaphtaliSandholmInputSignature() {
     long signature = 1125899906842597L;
-    List<Integer> feedTrayNumbers = new ArrayList<Integer>(feedStreams.keySet());
-    Collections.sort(feedTrayNumbers);
-    signature = updateNaphtaliSandholmInputSignature(signature, feedTrayNumbers.size());
-    for (Integer trayNumber : feedTrayNumbers) {
+    Set<Integer> externalFeedTrayNumberSet = new HashSet<Integer>(feedStreams.keySet());
+    externalFeedTrayNumberSet.addAll(directExternalFeedStreams.keySet());
+    List<Integer> externalFeedTrayNumbers = new ArrayList<Integer>(externalFeedTrayNumberSet);
+    Collections.sort(externalFeedTrayNumbers);
+    signature = updateNaphtaliSandholmInputSignature(signature, externalFeedTrayNumbers.size());
+    for (Integer trayNumber : externalFeedTrayNumbers) {
       signature = updateNaphtaliSandholmInputSignature(signature, trayNumber.longValue());
-      List<StreamInterface> trayFeeds = feedStreams.get(trayNumber);
+      List<StreamInterface> trayFeeds = getExternalFeedStreams(trayNumber.intValue());
       signature = updateNaphtaliSandholmInputSignature(signature, trayFeeds.size());
       for (StreamInterface feed : trayFeeds) {
         SystemInterface system = feed.getThermoSystem();
@@ -5329,7 +5341,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param initialRelaxation relaxation factor applied to the first iteration
    */
   private void solveSequential(UUID id, double initialRelaxation) {
-    if (feedStreams.isEmpty()) {
+    captureDirectExternalTrayFeeds();
+    if (feedStreams.isEmpty() && directExternalFeedStreams.isEmpty()) {
       resetLastSolveMetrics();
       return;
     }
@@ -5819,13 +5832,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       trays.get(i).setPressure(bottomTrayPressure - i * dp);
     }
 
-    for (int trayIndex = 0; trayIndex < numberOfTrays; trayIndex++) {
-      List<StreamInterface> externalFeeds = getExternalFeedStreams(trayIndex);
-      for (int streamIndex = 0; streamIndex < externalFeeds.size(); streamIndex++) {
-        SystemInterface cloned = externalFeeds.get(streamIndex).getThermoSystem().clone();
-        trays.get(trayIndex).getStream(streamIndex).setThermoSystem(cloned);
-      }
-    }
+    refreshInternalExternalFeedSystems();
 
     return firstFeedTrayNumber;
   }
@@ -9726,6 +9733,26 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       List<StreamInterface> externalFeeds = getExternalFeedStreams(trayIndex);
       for (int streamIndex = 0; streamIndex < externalFeeds.size(); streamIndex++) {
         trays.get(trayIndex).replaceStream(streamIndex, externalFeeds.get(streamIndex).clone());
+      }
+    }
+  }
+
+  /**
+   * Refresh internal feed clones from their caller-owned source streams.
+   *
+   * <p>
+   * The external feeds occupy the leading tray-input positions after initialization.
+   * Replacing only their thermodynamic systems preserves the internal stream objects and
+   * inter-tray wiring while applying current flow, temperature, pressure, composition, EOS,
+   * and mixing-rule state.
+   * </p>
+   */
+  private void refreshInternalExternalFeedSystems() {
+    for (int trayIndex = 0; trayIndex < numberOfTrays; trayIndex++) {
+      List<StreamInterface> externalFeeds = getExternalFeedStreams(trayIndex);
+      for (int streamIndex = 0; streamIndex < externalFeeds.size(); streamIndex++) {
+        SystemInterface cloned = externalFeeds.get(streamIndex).getThermoSystem().clone();
+        trays.get(trayIndex).getStream(streamIndex).setThermoSystem(cloned);
       }
     }
   }

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2509,12 +2509,13 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     signature = updateSequentialStreamStateSignature(signature, liquidOutStream);
     signature = updateNaphtaliSandholmInputSignature(signature, trays.size());
     for (SimpleTray tray : trays) {
-      if (tray == null || tray.getThermoSystem() == null) {
+      StreamInterface trayOutlet = tray == null ? null : tray.getOutletStream();
+      if (trayOutlet == null || trayOutlet.getThermoSystem() == null) {
         signature = updateNaphtaliSandholmInputSignature(signature, -1L);
         continue;
       }
       signature = updateNaphtaliSandholmInputSignature(signature, tray.getTemperature());
-      signature = updateSequentialSystemStateSignature(signature, tray.getThermoSystem());
+      signature = updateSequentialSystemStateSignature(signature, trayOutlet.getThermoSystem());
     }
     return signature;
   }
@@ -5476,12 +5477,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       return;
     }
 
-    long currentSequentialInputSignature = calculateSequentialExactReuseSignature();
-    if (canReuseSequentialWarmState(currentSequentialInputSignature)) {
-      reuseSequentialWarmState(id, invocationStartTime);
-      return;
+    if (hasSequentialExactReuseState) {
+      long currentSequentialInputSignature = calculateSequentialExactReuseSignature();
+      if (canReuseSequentialWarmState(currentSequentialInputSignature)) {
+        reuseSequentialWarmState(id, invocationStartTime);
+        return;
+      }
+      hasSequentialExactReuseState = false;
     }
-    hasSequentialExactReuseState = false;
 
     int firstFeedTrayNumber = prepareColumnForSolve();
 

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1202,21 +1202,43 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     // Link upward
     for (int i = 1; i < numberOfTrays; i++) {
       trays.get(i).addStream(trays.get(i - 1).getGasOutStream());
-      trays.get(i).init();
+      initializeInternalTrayInputTemperatures(i);
       trays.get(i).run();
     }
 
     // Link downward
     for (int i = numberOfTrays - 2; i >= 1; i--) {
       trays.get(i).addStream(trays.get(i + 1).getLiquidOutStream());
-      trays.get(i).init();
+      initializeInternalTrayInputTemperatures(i);
       trays.get(i).run();
     }
 
     int streamNumb = (trays.get(0)).getNumberOfInputStreams() - 1;
     trays.get(0).replaceStream(streamNumb, trays.get(1).getLiquidOutStream());
-    trays.get(0).init();
+    initializeInternalTrayInputTemperatures(0);
     trays.get(0).run();
+  }
+
+  /**
+   * Seed generated inter-tray streams at the receiving tray temperature without modifying caller-owned feeds.
+   *
+   * <p>
+   * {@link SimpleTray#init()} applies its temperature to every inlet. During column relinking that can include an
+   * external feed, silently changing the feed temperature and enthalpy used by later solves. Only generated internal
+   * traffic needs the profile seed; registered and directly connected external feeds must retain their inlet state.
+   * </p>
+   *
+   * @param trayIndex tray whose generated inlet streams should be seeded
+   */
+  private void initializeInternalTrayInputTemperatures(int trayIndex) {
+    SimpleTray tray = trays.get(trayIndex);
+    List<StreamInterface> externalFeeds = getExternalFeedStreams(trayIndex);
+    for (int streamIndex = 0; streamIndex < tray.getNumberOfInputStreams(); streamIndex++) {
+      StreamInterface inputStream = tray.getStream(streamIndex);
+      if (!containsStreamByIdentity(externalFeeds, inputStream) && inputStream.getThermoSystem() != null) {
+        inputStream.getThermoSystem().setTemperature(tray.getTemperature());
+      }
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2418,7 +2418,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     hasSequentialExactReuseState = hasBeenSolvedBefore && acceptedStatus && !isDoInitializion()
         && !hasAdjustableSpecifications() && !hasActiveColumnTearVariables();
     if (hasSequentialExactReuseState) {
-      lastSequentialInputSignature = calculateNaphtaliSandholmInputSignature();
+      lastSequentialInputSignature = calculateSequentialExactReuseSignature();
     }
   }
 
@@ -2490,6 +2490,67 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     }
     setCalculationIdentifier(id);
     lastSolveStatusReason = "Reused unchanged Naphtali-Sandholm solution";
+  }
+
+  /**
+   * Calculate a deterministic fingerprint for exact sequential-state reuse.
+   *
+   * <p>
+   * The external-input fingerprint alone is insufficient because advanced callers and solver tests can deliberately
+   * perturb tray states between invocations. Include the accepted tray and exposed product states so such edits trigger
+   * a real solve instead of being hidden by the exact-reuse path.
+   * </p>
+   *
+   * @return fingerprint of external inputs, tray states, and public products
+   */
+  private long calculateSequentialExactReuseSignature() {
+    long signature = calculateNaphtaliSandholmInputSignature();
+    signature = updateSequentialStreamStateSignature(signature, gasOutStream);
+    signature = updateSequentialStreamStateSignature(signature, liquidOutStream);
+    signature = updateNaphtaliSandholmInputSignature(signature, trays.size());
+    for (SimpleTray tray : trays) {
+      if (tray == null || tray.getThermoSystem() == null) {
+        signature = updateNaphtaliSandholmInputSignature(signature, -1L);
+        continue;
+      }
+      signature = updateNaphtaliSandholmInputSignature(signature, tray.getTemperature());
+      signature = updateSequentialSystemStateSignature(signature, tray.getThermoSystem());
+    }
+    return signature;
+  }
+
+  /**
+   * Add a stream thermodynamic state to the exact sequential-reuse fingerprint.
+   *
+   * @param signature fingerprint accumulated so far
+   * @param stream stream to fingerprint
+   * @return updated fingerprint
+   */
+  private long updateSequentialStreamStateSignature(long signature, StreamInterface stream) {
+    if (stream == null || stream.getThermoSystem() == null) {
+      return updateNaphtaliSandholmInputSignature(signature, -1L);
+    }
+    return updateSequentialSystemStateSignature(signature, stream.getThermoSystem());
+  }
+
+  /**
+   * Add a complete thermodynamic system state to the exact sequential-reuse fingerprint.
+   *
+   * @param signature fingerprint accumulated so far
+   * @param system thermodynamic system to fingerprint
+   * @return updated fingerprint
+   */
+  private long updateSequentialSystemStateSignature(long signature, SystemInterface system) {
+    long updatedSignature = updateNaphtaliSandholmThermodynamicModelSignature(signature, system);
+    updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, system.getTemperature());
+    updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, system.getPressure());
+    updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, system.getTotalNumberOfMoles());
+    double[] composition = system.getMolarComposition();
+    updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, composition.length);
+    for (double moleFraction : composition) {
+      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, moleFraction);
+    }
+    return updatedSignature;
   }
 
   /**
@@ -5415,7 +5476,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       return;
     }
 
-    long currentSequentialInputSignature = calculateNaphtaliSandholmInputSignature();
+    long currentSequentialInputSignature = calculateSequentialExactReuseSignature();
     if (canReuseSequentialWarmState(currentSequentialInputSignature)) {
       reuseSequentialWarmState(id, invocationStartTime);
       return;

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2397,8 +2397,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    */
   boolean willReuseNaphtaliSandholmWarmState() {
     captureDirectExternalTrayFeeds();
-    if ((feedStreams.isEmpty() && directExternalFeedStreams.isEmpty()) || numberOfTrays == 1
-        || isDoInitializion()) {
+    if ((feedStreams.isEmpty() && directExternalFeedStreams.isEmpty()) || numberOfTrays == 1 || isDoInitializion()) {
       return false;
     }
     if (calculateThermodynamicIdentitySignature() != trayStateThermodynamicIdentitySignature) {
@@ -9741,10 +9740,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * Refresh internal feed clones from their caller-owned source streams.
    *
    * <p>
-   * The external feeds occupy the leading tray-input positions after initialization.
-   * Replacing only their thermodynamic systems preserves the internal stream objects and
-   * inter-tray wiring while applying current flow, temperature, pressure, composition, EOS,
-   * and mixing-rule state.
+   * The external feeds occupy the leading tray-input positions after initialization. Replacing only their thermodynamic
+   * systems preserves the internal stream objects and inter-tray wiring while applying current flow, temperature,
+   * pressure, composition, EOS, and mixing-rule state.
    * </p>
    */
   private void refreshInternalExternalFeedSystems() {

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -637,6 +637,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * </p>
    */
   private transient long lastSequentialInitializationSignature = Long.MIN_VALUE;
+  /** Whether an accepted sequential solution is eligible for exact unchanged-input reuse. */
+  private transient boolean hasSequentialExactReuseState = false;
+  /** Full input fingerprint associated with the accepted sequential solution. */
+  private transient long lastSequentialInputSignature = Long.MIN_VALUE;
+  /** Whether the latest sequential invocation reused an exact accepted state. */
+  private transient boolean lastSequentialWarmStateReused = false;
   /**
    * Whether the current tray state was produced by {@link NaphtaliSandholmSolver} on this column instance.
    *
@@ -1128,6 +1134,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     lastSequentialInitializationSignature = calculateSequentialInitializationSignature();
     naphtaliSandholmStateOwned = false;
     hasNaphtaliSandholmWarmState = false;
+    hasSequentialExactReuseState = false;
 
     resetTrayInputsToExternalFeeds();
     cloneExternalTrayInputsForInitialization();
@@ -2381,6 +2388,66 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    */
   boolean wasNaphtaliSandholmWarmStateReused() {
     return lastNaphtaliSandholmWarmStateReused;
+  }
+
+  /**
+   * Decide whether an accepted sequential solution can be reused for identical inputs.
+   *
+   * <p>
+   * Exact reuse is deliberately disabled for adjustable specifications and active outer tear variables. Those
+   * calculations can change targets or internal return streams outside the fixed sequential input fingerprint.
+   * </p>
+   *
+   * @param inputSignature full current input fingerprint
+   * @return {@code true} when no new sequential iterations are required
+   */
+  private boolean canReuseSequentialWarmState(long inputSignature) {
+    boolean acceptedStatus = lastSolveStatus == SolveStatus.RIGOROUS_CONVERGED
+        || lastSolveStatus == SolveStatus.RECONCILED_PRODUCTS;
+    return hasSequentialExactReuseState && hasBeenSolvedBefore && acceptedStatus && !isDoInitializion()
+        && !hasAdjustableSpecifications() && !hasActiveColumnTearVariables()
+        && inputSignature == lastSequentialInputSignature;
+  }
+
+  /**
+   * Record an accepted sequential solution for exact unchanged-input reuse.
+   */
+  private void commitSequentialWarmState() {
+    boolean acceptedStatus = lastSolveStatus == SolveStatus.RIGOROUS_CONVERGED
+        || lastSolveStatus == SolveStatus.RECONCILED_PRODUCTS;
+    hasSequentialExactReuseState = hasBeenSolvedBefore && acceptedStatus && !isDoInitializion()
+        && !hasAdjustableSpecifications() && !hasActiveColumnTearVariables();
+    if (hasSequentialExactReuseState) {
+      lastSequentialInputSignature = calculateNaphtaliSandholmInputSignature();
+    }
+  }
+
+  /**
+   * Reuse the accepted sequential products and tray state for identical inputs.
+   *
+   * @param id calculation identifier for the requested invocation
+   * @param startTime nano time when this invocation started
+   */
+  private void reuseSequentialWarmState(UUID id, long startTime) {
+    lastIterationCount = 0;
+    lastSequentialWarmStateReused = true;
+    lastSolveTimeSeconds = (System.nanoTime() - startTime) / 1.0e9;
+    gasOutStream.setCalculationIdentifier(id);
+    liquidOutStream.setCalculationIdentifier(id);
+    for (int trayIndex = 0; trayIndex < numberOfTrays; trayIndex++) {
+      trays.get(trayIndex).setCalculationIdentifier(id);
+    }
+    setCalculationIdentifier(id);
+    lastSolveStatusReason = "Reused unchanged sequential solution";
+  }
+
+  /**
+   * Check whether the latest sequential invocation reused an exact accepted state.
+   *
+   * @return {@code true} when no initializer or tray iteration was required
+   */
+  boolean wasSequentialWarmStateReused() {
+    return lastSequentialWarmStateReused;
   }
 
   /**
@@ -5340,11 +5407,20 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param initialRelaxation relaxation factor applied to the first iteration
    */
   private void solveSequential(UUID id, double initialRelaxation) {
+    long invocationStartTime = System.nanoTime();
+    lastSequentialWarmStateReused = false;
     captureDirectExternalTrayFeeds();
     if (feedStreams.isEmpty() && directExternalFeedStreams.isEmpty()) {
       resetLastSolveMetrics();
       return;
     }
+
+    long currentSequentialInputSignature = calculateNaphtaliSandholmInputSignature();
+    if (canReuseSequentialWarmState(currentSequentialInputSignature)) {
+      reuseSequentialWarmState(id, invocationStartTime);
+      return;
+    }
+    hasSequentialExactReuseState = false;
 
     int firstFeedTrayNumber = prepareColumnForSolve();
 
@@ -5662,6 +5738,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     }
 
     finalizeSolve(id, iter, err, massErr, energyErr, startTime);
+    commitSequentialWarmState();
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1116,6 +1116,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     }
     setDoInitializion(false);
 
+    // Capture legacy direct feeds before recording the identity of the tray network. Otherwise the
+    // first initialized state omits those feeds from the fingerprint and appears incompatible on
+    // the next unchanged solve.
+    captureDirectExternalTrayFeeds();
+
     // The tray fluids are about to be rebuilt from the current feeds, so record which thermodynamic
     // identity they describe. Any later solve that sees a different identity must initialize again
     // instead of reusing or warm-starting from a tray network built for other components.
@@ -1124,7 +1129,6 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     naphtaliSandholmStateOwned = false;
     hasNaphtaliSandholmWarmState = false;
 
-    captureDirectExternalTrayFeeds();
     resetTrayInputsToExternalFeeds();
     cloneExternalTrayInputsForInitialization();
 
@@ -2504,12 +2508,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    */
   private long calculateThermodynamicIdentitySignature() {
     long signature = 1125899906842597L;
-    List<Integer> feedTrayNumbers = new ArrayList<Integer>(feedStreams.keySet());
-    Collections.sort(feedTrayNumbers);
-    signature = updateNaphtaliSandholmInputSignature(signature, feedTrayNumbers.size());
-    for (Integer trayNumber : feedTrayNumbers) {
+    Set<Integer> externalFeedTrayNumberSet = new HashSet<Integer>(feedStreams.keySet());
+    externalFeedTrayNumberSet.addAll(directExternalFeedStreams.keySet());
+    List<Integer> externalFeedTrayNumbers = new ArrayList<Integer>(externalFeedTrayNumberSet);
+    Collections.sort(externalFeedTrayNumbers);
+    signature = updateNaphtaliSandholmInputSignature(signature, externalFeedTrayNumbers.size());
+    for (Integer trayNumber : externalFeedTrayNumbers) {
       signature = updateNaphtaliSandholmInputSignature(signature, trayNumber.longValue());
-      List<StreamInterface> trayFeeds = feedStreams.get(trayNumber);
+      List<StreamInterface> trayFeeds = getExternalFeedStreams(trayNumber.intValue());
       signature = updateNaphtaliSandholmInputSignature(signature, trayFeeds.size());
       for (StreamInterface feed : trayFeeds) {
         signature = updateThermodynamicIdentitySignature(signature, feed.getThermoSystem());

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -11911,6 +11911,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     lastNaphtaliSandholmInputSignature = Long.MIN_VALUE;
     lastNaphtaliSandholmWarmStateReused = false;
     lastSequentialInitializationSignature = Long.MIN_VALUE;
+    hasSequentialExactReuseState = false;
+    lastSequentialInputSignature = Long.MIN_VALUE;
+    lastSequentialWarmStateReused = false;
     resetInsideOutTelemetry();
     resetNaphtaliTelemetry();
     terminalGasProductDrawStream = null;

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -5802,7 +5802,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @return index of the lowest feed tray in the column
    */
   private int prepareColumnForSolve() {
-    int firstFeedTrayNumber = feedStreams.keySet().stream().min(Integer::compareTo).get();
+    int firstFeedTrayNumber = getFirstExternalFeedTrayNumber();
 
     if (bottomTrayPressure < 0) {
       bottomTrayPressure = getTray(firstFeedTrayNumber).getStream(0).getPressure();

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -9746,7 +9746,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * </p>
    */
   private void refreshInternalExternalFeedSystems() {
-    for (int trayIndex = 0; trayIndex < numberOfTrays; trayIndex++) {
+    for (int trayIndex = 0; trayIndex < trays.size(); trayIndex++) {
       List<StreamInterface> externalFeeds = getExternalFeedStreams(trayIndex);
       for (int streamIndex = 0; streamIndex < externalFeeds.size(); streamIndex++) {
         SystemInterface cloned = externalFeeds.get(streamIndex).getThermoSystem().clone();

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -5972,7 +5972,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       trays.get(i).setPressure(bottomTrayPressure - i * dp);
     }
 
-    refreshInternalExternalFeedSystems();
+    // Before initialization, tray inputs can still be caller-owned feeds in attachment order.
+    // init() establishes a deterministic external-feed order, creates internal clones, and
+    // refreshes those clones after profile seeding. Refresh only an existing initialized network.
+    if (!isDoInitializion()) {
+      refreshInternalExternalFeedSystems();
+    }
 
     return firstFeedTrayNumber;
   }

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1126,6 +1126,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
 
     captureDirectExternalTrayFeeds();
     resetTrayInputsToExternalFeeds();
+    cloneExternalTrayInputsForInitialization();
 
     // If feed streams are empty, nothing to do
     if (feedStreams.isEmpty() && directExternalFeedStreams.isEmpty()) {
@@ -1202,43 +1203,21 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     // Link upward
     for (int i = 1; i < numberOfTrays; i++) {
       trays.get(i).addStream(trays.get(i - 1).getGasOutStream());
-      initializeInternalTrayInputTemperatures(i);
+      trays.get(i).init();
       trays.get(i).run();
     }
 
     // Link downward
     for (int i = numberOfTrays - 2; i >= 1; i--) {
       trays.get(i).addStream(trays.get(i + 1).getLiquidOutStream());
-      initializeInternalTrayInputTemperatures(i);
+      trays.get(i).init();
       trays.get(i).run();
     }
 
     int streamNumb = (trays.get(0)).getNumberOfInputStreams() - 1;
     trays.get(0).replaceStream(streamNumb, trays.get(1).getLiquidOutStream());
-    initializeInternalTrayInputTemperatures(0);
+    trays.get(0).init();
     trays.get(0).run();
-  }
-
-  /**
-   * Seed generated inter-tray streams at the receiving tray temperature without modifying caller-owned feeds.
-   *
-   * <p>
-   * {@link SimpleTray#init()} applies its temperature to every inlet. During column relinking that can include an
-   * external feed, silently changing the feed temperature and enthalpy used by later solves. Only generated internal
-   * traffic needs the profile seed; registered and directly connected external feeds must retain their inlet state.
-   * </p>
-   *
-   * @param trayIndex tray whose generated inlet streams should be seeded
-   */
-  private void initializeInternalTrayInputTemperatures(int trayIndex) {
-    SimpleTray tray = trays.get(trayIndex);
-    List<StreamInterface> externalFeeds = getExternalFeedStreams(trayIndex);
-    for (int streamIndex = 0; streamIndex < tray.getNumberOfInputStreams(); streamIndex++) {
-      StreamInterface inputStream = tray.getStream(streamIndex);
-      if (!containsStreamByIdentity(externalFeeds, inputStream) && inputStream.getThermoSystem() != null) {
-        inputStream.getThermoSystem().setTemperature(tray.getTemperature());
-      }
-    }
   }
 
   /**
@@ -5834,14 +5813,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       trays.get(i).setPressure(bottomTrayPressure - i * dp);
     }
 
-    int[] numeroffeeds = new int[numberOfTrays];
-    for (Entry<Integer, List<StreamInterface>> entry : feedStreams.entrySet()) {
-      int feedTrayNumber = entry.getKey();
-      List<StreamInterface> trayFeeds = entry.getValue();
-      for (StreamInterface feedStream : trayFeeds) {
-        numeroffeeds[feedTrayNumber]++;
-        SystemInterface cloned = feedStream.getThermoSystem().clone();
-        trays.get(feedTrayNumber).getStream(numeroffeeds[feedTrayNumber] - 1).setThermoSystem(cloned);
+    for (int trayIndex = 0; trayIndex < numberOfTrays; trayIndex++) {
+      List<StreamInterface> externalFeeds = getExternalFeedStreams(trayIndex);
+      for (int streamIndex = 0; streamIndex < externalFeeds.size(); streamIndex++) {
+        SystemInterface cloned = externalFeeds.get(streamIndex).getThermoSystem().clone();
+        trays.get(trayIndex).getStream(streamIndex).setThermoSystem(cloned);
       }
     }
 
@@ -9731,6 +9707,24 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
+   * Replace caller-owned external tray feeds with internal stream clones before profile seeding.
+   *
+   * <p>
+   * {@link SimpleTray#init()} intentionally seeds all tray inlets at the tray temperature. Keeping an internal clone
+   * preserves that established numerical initialization while preventing the column from changing the temperature or
+   * enthalpy state of streams owned by its caller.
+   * </p>
+   */
+  private void cloneExternalTrayInputsForInitialization() {
+    for (int trayIndex = 0; trayIndex < trays.size(); trayIndex++) {
+      List<StreamInterface> externalFeeds = getExternalFeedStreams(trayIndex);
+      for (int streamIndex = 0; streamIndex < externalFeeds.size(); streamIndex++) {
+        trays.get(trayIndex).replaceStream(streamIndex, externalFeeds.get(streamIndex).clone());
+      }
+    }
+  }
+
+  /**
    * Get the lowest tray index containing an external feed stream.
    *
    * @return first external feed tray index
@@ -9790,6 +9784,13 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     String streamName = stream.getName();
     if (streamName == null || streamName.trim().isEmpty()) {
       return false;
+    }
+    for (StreamInterface knownExternalFeed : knownExternalFeeds) {
+      if (knownExternalFeed != null && streamName.equals(knownExternalFeed.getName())) {
+        // Initialization uses internal clones so caller-owned feeds are not mutated. A same-name
+        // tray input is that clone, not a newly connected legacy side feed.
+        return false;
+      }
     }
     if (registeredFeedNames.contains(streamName)) {
       // A tray input that shares a registered feed name but a different identity is a clone left by

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -3076,13 +3076,16 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     this.hasBeenSolvedBefore = candidate.hasBeenSolvedBefore;
     this.lastTotalFeedFlow = candidate.lastTotalFeedFlow;
     this.doInitializion = candidate.doInitializion;
-    // The tray network now belongs to the candidate, so every cached fingerprint that described the
-    // replaced trays is void. The warm state is dropped rather than carried over; when the adopted
-    // state is a legitimate accepted answer the caller re-arms it through
-    // acceptNaphtaliWarmStartCandidate and commitNaphtaliSandholmWarmState recomputes the
-    // fingerprint from the inputs that are actually in force.
+    // The tray network now belongs to the candidate, so cache ownership must follow the adopted
+    // state explicitly. An accepted sequential candidate carries the full input fingerprint needed
+    // for safe unchanged-input reuse; invocation telemetry must describe the next live invocation.
+    // Naphtali-Sandholm ownership is dropped unless the caller explicitly re-arms it through
+    // acceptNaphtaliWarmStartCandidate and commitNaphtaliSandholmWarmState.
     this.trayStateThermodynamicIdentitySignature = candidate.trayStateThermodynamicIdentitySignature;
     this.lastSequentialInitializationSignature = candidate.lastSequentialInitializationSignature;
+    this.hasSequentialExactReuseState = candidate.hasSequentialExactReuseState;
+    this.lastSequentialInputSignature = candidate.lastSequentialInputSignature;
+    this.lastSequentialWarmStateReused = false;
     this.naphtaliSandholmStateOwned = false;
     this.hasNaphtaliSandholmWarmState = false;
     this.lastNaphtaliSandholmInputSignature = Long.MIN_VALUE;

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -496,8 +496,7 @@ public class DistillationColumnWarmStateCacheTest {
    */
   @Test
   public void directTrayFeedIdentityChangeForcesColdInitialization() {
-    DirectFeedColumnCase mutated =
-        buildDirectFeedColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    DirectFeedColumnCase mutated = buildDirectFeedColumnCase(createIdentityTestFluid(false, "n-butane", 2));
     mutated.column.run();
     assertTrue(mutated.column.solved(), mutated.column.getConvergenceDiagnostics());
     int initialInitializationCount = mutated.column.getInitializationCount();
@@ -513,8 +512,7 @@ public class DistillationColumnWarmStateCacheTest {
     assertEquals(30.0, mutated.directFeed.getTemperature("C"), 1.0e-9,
         "direct-feed handling must not mutate the direct caller-owned feed");
 
-    DirectFeedColumnCase coldReference =
-        buildDirectFeedColumnCase(createIdentityTestFluid(false, "i-butane", 2));
+    DirectFeedColumnCase coldReference = buildDirectFeedColumnCase(createIdentityTestFluid(false, "i-butane", 2));
     coldReference.column.run();
     assertTrue(coldReference.column.solved(), coldReference.column.getConvergenceDiagnostics());
     assertColdReferenceEquivalent(coldReference.column, mutated.column);

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -630,6 +630,41 @@ public class DistillationColumnWarmStateCacheTest {
   }
 
   /**
+   * An accepted damped candidate must retain ownership of its exact sequential reuse fingerprint.
+   */
+  @Test
+  public void acceptedSequentialCandidateRetainsExactReuseState() {
+    ColumnCase live = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    configureDampedSubstitution(live.column);
+    ColumnCase candidate = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    configureDampedSubstitution(candidate.column);
+
+    candidate.column.run();
+
+    assertTrue(candidate.column.solved(), candidate.column.getConvergenceDiagnostics());
+    double acceptedGasFlow = candidate.column.getGasOutStream().getFlowRate("mol/hr");
+    double acceptedLiquidFlow = candidate.column.getLiquidOutStream().getFlowRate("mol/hr");
+    live.column.acceptDampedFallbackCandidate(candidate.column, "accepted sequential candidate");
+
+    live.column.run();
+
+    assertTrue(live.column.solved(), live.column.getConvergenceDiagnostics());
+    assertTrue(live.column.wasSequentialWarmStateReused(),
+        "an adopted accepted sequential candidate must remain exactly reusable");
+    assertEquals(0, live.column.getLastIterationCount(),
+        "exact reuse of an adopted candidate must require no new tray iterations");
+    assertEquals(acceptedGasFlow, live.column.getGasOutStream().getFlowRate("mol/hr"),
+        Math.max(1.0e-9, Math.abs(acceptedGasFlow) * 1.0e-5),
+        "adopted exact reuse must preserve overhead flow");
+    assertEquals(acceptedLiquidFlow, live.column.getLiquidOutStream().getFlowRate("mol/hr"),
+        Math.max(1.0e-9, Math.abs(acceptedLiquidFlow) * 1.0e-5),
+        "adopted exact reuse must preserve bottoms flow");
+    assertEquals(20.0, live.feed.getTemperature("C"), 1.0e-9,
+        "candidate adoption and exact reuse must preserve the caller-owned feed");
+    assertPhysicalAndBalanced(live);
+  }
+
+  /**
    * Sequential warm starts must be invalidated when a fixed reboiler temperature changes.
    *
    * <p>

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -493,21 +493,19 @@ public class DistillationColumnWarmStateCacheTest {
   }
 
   /**
-   * Cold initialization must preserve caller-owned feeds when direct and registered feeds were attached in reverse order.
+   * Cold initialization must preserve caller-owned feeds when direct and registered feeds were attached in reverse
+   * order.
    */
   @Test
   public void coldInitializationPreservesReverseAttachedFeedIdentity() {
-    Stream directFeed =
-        new Stream("reverse-order direct feed", createIdentityTestFluid(false, "n-butane", 2));
+    Stream directFeed = new Stream("reverse-order direct feed", createIdentityTestFluid(false, "n-butane", 2));
     configureDirectFeed(directFeed);
-    Stream registeredFeed =
-        new Stream("reverse-order registered feed", createIdentityTestFluid(false, "n-butane", 2));
+    Stream registeredFeed = new Stream("reverse-order registered feed", createIdentityTestFluid(false, "n-butane", 2));
     configureIdentityFeed(registeredFeed);
     SystemInterface directFeedSystem = directFeed.getThermoSystem();
     SystemInterface registeredFeedSystem = registeredFeed.getThermoSystem();
 
-    TrackingDistillationColumn column =
-        new TrackingDistillationColumn("reverse-order feed column", 6, true, false);
+    TrackingDistillationColumn column = new TrackingDistillationColumn("reverse-order feed column", 6, true, false);
     column.getTray(2).addStream(directFeed);
     column.addFeedStream(registeredFeed, 2);
     column.setTopPressure(10.0);
@@ -527,8 +525,7 @@ public class DistillationColumnWarmStateCacheTest {
     assertEquals(20.0, registeredFeed.getTemperature("C"), 1.0e-9,
         "cold preparation must preserve the registered-feed temperature");
 
-    double totalFeedFlow =
-        directFeed.getFlowRate("mol/hr") + registeredFeed.getFlowRate("mol/hr");
+    double totalFeedFlow = directFeed.getFlowRate("mol/hr") + registeredFeed.getFlowRate("mol/hr");
     double totalProductFlow = column.getGasOutStream().getFlowRate("mol/hr")
         + column.getLiquidOutStream().getFlowRate("mol/hr");
     assertEquals(totalFeedFlow, totalProductFlow, 5.0e-3 * totalFeedFlow,

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -214,7 +214,7 @@ public class DistillationColumnWarmStateCacheTest {
     ColumnCase registeredCase = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
     Stream directFeed = new Stream("legacy direct side feed", directFluid);
     configureDirectFeed(directFeed);
-    registeredCase.column.getTray(4).addStream(directFeed);
+    registeredCase.column.getTray(2).addStream(directFeed);
     configureDampedSubstitution(registeredCase.column);
     return new DirectFeedColumnCase(registeredCase.feed, directFeed, registeredCase.column);
   }

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -149,6 +149,19 @@ public class DistillationColumnWarmStateCacheTest {
     }
   }
 
+  /** Registered feed, legacy direct side feed, and column used by direct-feed compatibility tests. */
+  private static final class DirectFeedColumnCase {
+    private final Stream registeredFeed;
+    private final Stream directFeed;
+    private final TrackingDistillationColumn column;
+
+    private DirectFeedColumnCase(Stream registeredFeed, Stream directFeed, TrackingDistillationColumn column) {
+      this.registeredFeed = registeredFeed;
+      this.directFeed = directFeed;
+      this.column = column;
+    }
+  }
+
   /**
    * Build a hydrocarbon fluid whose numeric composition can remain unchanged while identity changes.
    *
@@ -192,6 +205,21 @@ public class DistillationColumnWarmStateCacheTest {
   }
 
   /**
+   * Build a column with one registered feed and one legacy side feed connected directly to a tray.
+   *
+   * @param directFluid thermodynamic system for the direct side feed
+   * @return direct-feed column case
+   */
+  private static DirectFeedColumnCase buildDirectFeedColumnCase(SystemInterface directFluid) {
+    ColumnCase registeredCase = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    Stream directFeed = new Stream("legacy direct side feed", directFluid);
+    configureDirectFeed(directFeed);
+    registeredCase.column.getTray(4).addStream(directFeed);
+    configureDampedSubstitution(registeredCase.column);
+    return new DirectFeedColumnCase(registeredCase.feed, directFeed, registeredCase.column);
+  }
+
+  /**
    * Apply conditions that deliberately keep every legacy numeric fingerprint input unchanged.
    *
    * @param feed feed to configure
@@ -199,6 +227,18 @@ public class DistillationColumnWarmStateCacheTest {
   private static void configureIdentityFeed(Stream feed) {
     feed.setFlowRate(IDENTITY_TEST_FLOW_MOL_PER_HOUR, "mol/hr");
     feed.setTemperature(20.0, "C");
+    feed.setPressure(10.0, "bara");
+    feed.run();
+  }
+
+  /**
+   * Apply fixed operating conditions to a legacy direct side feed.
+   *
+   * @param feed direct side feed to configure
+   */
+  private static void configureDirectFeed(Stream feed) {
+    feed.setFlowRate(0.2 * IDENTITY_TEST_FLOW_MOL_PER_HOUR, "mol/hr");
+    feed.setTemperature(30.0, "C");
     feed.setPressure(10.0, "bara");
     feed.run();
   }
@@ -212,6 +252,17 @@ public class DistillationColumnWarmStateCacheTest {
   private static void replaceFeedFluid(ColumnCase columnCase, SystemInterface replacementFluid) {
     columnCase.feed.setThermoSystem(replacementFluid);
     configureIdentityFeed(columnCase.feed);
+  }
+
+  /**
+   * Replace the direct side feed at unchanged numeric operating conditions.
+   *
+   * @param columnCase direct-feed case to mutate
+   * @param replacementFluid replacement thermodynamic system
+   */
+  private static void replaceDirectFeedFluid(DirectFeedColumnCase columnCase, SystemInterface replacementFluid) {
+    columnCase.directFeed.setThermoSystem(replacementFluid);
+    configureDirectFeed(columnCase.directFeed);
   }
 
   /**
@@ -438,6 +489,37 @@ public class DistillationColumnWarmStateCacheTest {
     assertColdReferenceEquivalent(coldReference.column, mutated.column);
     assertPhysicalAndBalanced(mutated);
     assertNextRunReusesExactly(mutated);
+  }
+
+  /**
+   * A legacy direct tray feed participates in the same thermodynamic-identity gate as registered feeds.
+   */
+  @Test
+  public void directTrayFeedIdentityChangeForcesColdInitialization() {
+    DirectFeedColumnCase mutated =
+        buildDirectFeedColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    mutated.column.run();
+    assertTrue(mutated.column.solved(), mutated.column.getConvergenceDiagnostics());
+    int initialInitializationCount = mutated.column.getInitializationCount();
+
+    replaceDirectFeedFluid(mutated, createIdentityTestFluid(false, "i-butane", 2));
+    mutated.column.run();
+
+    assertTrue(mutated.column.solved(), mutated.column.getConvergenceDiagnostics());
+    assertEquals(initialInitializationCount + 1, mutated.column.getInitializationCount(),
+        "a direct side-feed identity change must rebuild the sequential initialization exactly once");
+    assertEquals(20.0, mutated.registeredFeed.getTemperature("C"), 1.0e-9,
+        "direct-feed handling must not mutate the registered caller-owned feed");
+    assertEquals(30.0, mutated.directFeed.getTemperature("C"), 1.0e-9,
+        "direct-feed handling must not mutate the direct caller-owned feed");
+
+    DirectFeedColumnCase coldReference =
+        buildDirectFeedColumnCase(createIdentityTestFluid(false, "i-butane", 2));
+    coldReference.column.run();
+    assertTrue(coldReference.column.solved(), coldReference.column.getConvergenceDiagnostics());
+    assertColdReferenceEquivalent(coldReference.column, mutated.column);
+    assertPhysicalStream(mutated.column.getGasOutStream());
+    assertPhysicalStream(mutated.column.getLiquidOutStream());
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -495,19 +495,17 @@ public class DistillationColumnWarmStateCacheTest {
    * A direct-feed-only sequential column must scale its divergence guard from the physical feed flow.
    *
    * <p>
-   * Legacy direct tray feeds are valid external feeds. Ignoring them when setting the internal-traffic
-   * threshold leaves the threshold at the 1000 kg/h floor and rejects this otherwise ordinary
-   * multicomponent stripper before it can converge.
+   * Legacy direct tray feeds are valid external feeds. Ignoring them when setting the internal-traffic threshold leaves
+   * the threshold at the 1000 kg/h floor and rejects this otherwise ordinary multicomponent stripper before it can
+   * converge.
    * </p>
    */
   @Test
   public void directOnlySequentialColumnUsesExternalFeedScaleForDivergenceGuard() {
-    Stream directFeed =
-        new Stream("direct-only feed", createIdentityTestFluid(false, "n-butane", 2));
+    Stream directFeed = new Stream("direct-only feed", createIdentityTestFluid(false, "n-butane", 2));
     configureIdentityFeed(directFeed);
 
-    TrackingDistillationColumn column =
-        new TrackingDistillationColumn("direct-only sequential column", 6, true, false);
+    TrackingDistillationColumn column = new TrackingDistillationColumn("direct-only sequential column", 6, true, false);
     column.getTray(3).addStream(directFeed);
     column.setTopPressure(10.0);
     column.setBottomPressure(10.5);

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -616,6 +616,10 @@ public class DistillationColumnWarmStateCacheTest {
     warmCase.column.run();
 
     assertTrue(warmCase.column.solved(), warmCase.column.getConvergenceDiagnostics());
+    assertTrue(warmCase.column.wasSequentialWarmStateReused(),
+        "an unchanged accepted sequential case must use exact input reuse");
+    assertEquals(0, warmCase.column.getLastIterationCount(),
+        "exact sequential reuse must require no new tray iterations");
     assertEquals(acceptedInitializationCount, warmCase.column.getInitializationCount(),
         "an unchanged re-run must retain the accepted sequential warm state");
     assertEquals(gasFlow, warmCase.column.getGasOutStream().getFlowRate("mol/hr"),

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
@@ -489,6 +490,51 @@ public class DistillationColumnWarmStateCacheTest {
     assertColdReferenceEquivalent(coldReference.column, mutated.column);
     assertPhysicalAndBalanced(mutated);
     assertNextRunReusesExactly(mutated);
+  }
+
+  /**
+   * Cold initialization must preserve caller-owned feeds when direct and registered feeds were attached in reverse order.
+   */
+  @Test
+  public void coldInitializationPreservesReverseAttachedFeedIdentity() {
+    Stream directFeed =
+        new Stream("reverse-order direct feed", createIdentityTestFluid(false, "n-butane", 2));
+    configureDirectFeed(directFeed);
+    Stream registeredFeed =
+        new Stream("reverse-order registered feed", createIdentityTestFluid(false, "n-butane", 2));
+    configureIdentityFeed(registeredFeed);
+    SystemInterface directFeedSystem = directFeed.getThermoSystem();
+    SystemInterface registeredFeedSystem = registeredFeed.getThermoSystem();
+
+    TrackingDistillationColumn column =
+        new TrackingDistillationColumn("reverse-order feed column", 6, true, false);
+    column.getTray(2).addStream(directFeed);
+    column.addFeedStream(registeredFeed, 2);
+    column.setTopPressure(10.0);
+    column.setBottomPressure(10.5);
+    column.getReboiler().setOutTemperature(273.15 + 80.0);
+    configureDampedSubstitution(column);
+
+    column.run();
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertSame(directFeedSystem, directFeed.getThermoSystem(),
+        "cold preparation must not replace the caller-owned direct-feed system");
+    assertSame(registeredFeedSystem, registeredFeed.getThermoSystem(),
+        "cold preparation must not replace the caller-owned registered-feed system");
+    assertEquals(30.0, directFeed.getTemperature("C"), 1.0e-9,
+        "cold preparation must preserve the direct-feed temperature");
+    assertEquals(20.0, registeredFeed.getTemperature("C"), 1.0e-9,
+        "cold preparation must preserve the registered-feed temperature");
+
+    double totalFeedFlow =
+        directFeed.getFlowRate("mol/hr") + registeredFeed.getFlowRate("mol/hr");
+    double totalProductFlow = column.getGasOutStream().getFlowRate("mol/hr")
+        + column.getLiquidOutStream().getFlowRate("mol/hr");
+    assertEquals(totalFeedFlow, totalProductFlow, 5.0e-3 * totalFeedFlow,
+        "reverse-order registered and direct feeds must close the total molar balance");
+    assertPhysicalStream(column.getGasOutStream());
+    assertPhysicalStream(column.getLiquidOutStream());
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -13,7 +13,7 @@ import neqsim.thermo.system.SystemPrEos;
 import neqsim.thermo.system.SystemSrkEos;
 
 /**
- * Regression tests for the Naphtali-Sandholm warm-state cache introduced with the warm-solve speed-up.
+ * Regression tests for column warm-state compatibility and cache invalidation.
  *
  * <p>
  * The cache reuses an accepted tray solution when a fingerprint of the solver inputs is unchanged. The fingerprint
@@ -438,6 +438,86 @@ public class DistillationColumnWarmStateCacheTest {
     assertColdReferenceEquivalent(coldReference.column, mutated.column);
     assertPhysicalAndBalanced(mutated);
     assertNextRunReusesExactly(mutated);
+  }
+
+  /**
+   * Sequential warm starts must be invalidated when a fixed reboiler temperature changes.
+   *
+   * <p>
+   * The 90 C case previously converged to a path-dependent product split, while the 100 C case reached the internal
+   * traffic guard. Both targets are feasible from a cold initialization. After the configuration change is detected,
+   * the sequential solver must rebuild once, agree with the cold reference, and retain the new state on an unchanged
+   * re-run.
+   * </p>
+   */
+  @Test
+  public void sequentialSpecificationChangeMatchesColdReferenceAndIsRepeatable() {
+    assertSequentialSpecificationChange(90.0);
+    assertSequentialSpecificationChange(100.0);
+  }
+
+  /**
+   * Verify one changed fixed-temperature target against a cold reference and an unchanged re-run.
+   *
+   * @param targetTemperatureC changed reboiler temperature in degrees Celsius
+   */
+  private static void assertSequentialSpecificationChange(double targetTemperatureC) {
+    ColumnCase warmCase = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    configureDampedSubstitution(warmCase.column);
+    warmCase.column.run();
+    assertTrue(warmCase.column.solved(), warmCase.column.getConvergenceDiagnostics());
+    int baselineInitializationCount = warmCase.column.getInitializationCount();
+
+    warmCase.column.getReboiler().setOutTemperature(273.15 + targetTemperatureC);
+    warmCase.column.run();
+
+    assertTrue(warmCase.column.solved(), warmCase.column.getConvergenceDiagnostics());
+    assertEquals(baselineInitializationCount + 1, warmCase.column.getInitializationCount(),
+        "a changed fixed reboiler temperature must rebuild the sequential initialization exactly once");
+    assertTrue(warmCase.column.getLastIterationCount() <= 30,
+        "the rebuilt solve should remain within the established cold-reference iteration budget");
+    assertPhysicalAndBalanced(warmCase);
+
+    ColumnCase coldReference = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    configureDampedSubstitution(coldReference.column);
+    coldReference.column.getReboiler().setOutTemperature(273.15 + targetTemperatureC);
+    coldReference.column.run();
+
+    assertTrue(coldReference.column.solved(), coldReference.column.getConvergenceDiagnostics());
+    assertColdReferenceEquivalent(coldReference.column, warmCase.column);
+    assertPhysicalAndBalanced(coldReference);
+
+    int acceptedInitializationCount = warmCase.column.getInitializationCount();
+    double gasFlow = warmCase.column.getGasOutStream().getFlowRate("mol/hr");
+    double liquidFlow = warmCase.column.getLiquidOutStream().getFlowRate("mol/hr");
+    double[] gasComposition = warmCase.column.getGasOutStream().getThermoSystem().getMolarComposition().clone();
+    double[] liquidComposition = warmCase.column.getLiquidOutStream().getThermoSystem().getMolarComposition().clone();
+
+    warmCase.column.run();
+
+    assertTrue(warmCase.column.solved(), warmCase.column.getConvergenceDiagnostics());
+    assertEquals(acceptedInitializationCount, warmCase.column.getInitializationCount(),
+        "an unchanged re-run must retain the accepted sequential warm state");
+    assertEquals(gasFlow, warmCase.column.getGasOutStream().getFlowRate("mol/hr"),
+        Math.max(1.0e-9, Math.abs(gasFlow) * 1.0e-5), "an unchanged re-run must reproduce overhead flow");
+    assertEquals(liquidFlow, warmCase.column.getLiquidOutStream().getFlowRate("mol/hr"),
+        Math.max(1.0e-9, Math.abs(liquidFlow) * 1.0e-5), "an unchanged re-run must reproduce bottoms flow");
+    assertArrayEquals(gasComposition, warmCase.column.getGasOutStream().getThermoSystem().getMolarComposition(), 1.0e-7,
+        "an unchanged re-run must reproduce overhead composition");
+    assertArrayEquals(liquidComposition, warmCase.column.getLiquidOutStream().getThermoSystem().getMolarComposition(),
+        1.0e-7, "an unchanged re-run must reproduce bottoms composition");
+    assertPhysicalAndBalanced(warmCase);
+  }
+
+  /**
+   * Configure the deterministic low-relaxation sequential regression solver.
+   *
+   * @param column column to configure
+   */
+  private static void configureDampedSubstitution(DistillationColumn column) {
+    column.setSolverType(DistillationColumn.SolverType.DAMPED_SUBSTITUTION);
+    column.setRelaxationFactor(0.2);
+    column.setMaxNumberOfIterations(120, true);
   }
 
 }

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -654,11 +654,9 @@ public class DistillationColumnWarmStateCacheTest {
     assertEquals(0, live.column.getLastIterationCount(),
         "exact reuse of an adopted candidate must require no new tray iterations");
     assertEquals(acceptedGasFlow, live.column.getGasOutStream().getFlowRate("mol/hr"),
-        Math.max(1.0e-9, Math.abs(acceptedGasFlow) * 1.0e-5),
-        "adopted exact reuse must preserve overhead flow");
+        Math.max(1.0e-9, Math.abs(acceptedGasFlow) * 1.0e-5), "adopted exact reuse must preserve overhead flow");
     assertEquals(acceptedLiquidFlow, live.column.getLiquidOutStream().getFlowRate("mol/hr"),
-        Math.max(1.0e-9, Math.abs(acceptedLiquidFlow) * 1.0e-5),
-        "adopted exact reuse must preserve bottoms flow");
+        Math.max(1.0e-9, Math.abs(acceptedLiquidFlow) * 1.0e-5), "adopted exact reuse must preserve bottoms flow");
     assertEquals(20.0, live.feed.getTemperature("C"), 1.0e-9,
         "candidate adoption and exact reuse must preserve the caller-owned feed");
     assertPhysicalAndBalanced(live);

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -464,14 +464,19 @@ public class DistillationColumnWarmStateCacheTest {
   private static void assertSequentialSpecificationChange(double targetTemperatureC) {
     ColumnCase warmCase = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
     configureDampedSubstitution(warmCase.column);
+    double inletTemperature = warmCase.feed.getTemperature("K");
     warmCase.column.run();
     assertTrue(warmCase.column.solved(), warmCase.column.getConvergenceDiagnostics());
+    assertEquals(inletTemperature, warmCase.feed.getTemperature("K"), 1.0e-9,
+        "column initialization must not change the caller-owned feed temperature");
     int baselineInitializationCount = warmCase.column.getInitializationCount();
 
     warmCase.column.getReboiler().setOutTemperature(273.15 + targetTemperatureC);
     warmCase.column.run();
 
     assertTrue(warmCase.column.solved(), warmCase.column.getConvergenceDiagnostics());
+    assertEquals(inletTemperature, warmCase.feed.getTemperature("K"), 1.0e-9,
+        "column reinitialization must not change the caller-owned feed temperature");
     assertEquals(baselineInitializationCount + 1, warmCase.column.getInitializationCount(),
         "a changed fixed reboiler temperature must rebuild the sequential initialization exactly once");
     assertTrue(warmCase.column.getLastIterationCount() <= 30,

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -521,6 +521,41 @@ public class DistillationColumnWarmStateCacheTest {
   }
 
   /**
+   * A direct side-feed operating-point change must invalidate exact Naphtali-Sandholm reuse.
+   */
+  @Test
+  public void directTrayFeedOperatingPointChangeInvalidatesNaphtaliReuse() {
+    DirectFeedColumnCase mutated = buildDirectFeedColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    mutated.column.setSolverType(DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    mutated.column.run();
+    assertTrue(mutated.column.solved(), mutated.column.getConvergenceDiagnostics());
+
+    mutated.column.run();
+    assertTrue(mutated.column.wasNaphtaliSandholmWarmStateReused(),
+        "an unchanged direct-feed case must reuse the accepted simultaneous solution");
+    double originalOverheadFlow = mutated.column.getGasOutStream().getFlowRate("mol/hr");
+
+    mutated.directFeed.setFlowRate(0.22 * IDENTITY_TEST_FLOW_MOL_PER_HOUR, "mol/hr");
+    mutated.directFeed.run();
+
+    assertFalse(mutated.column.willReuseNaphtaliSandholmWarmState(),
+        "a direct side-feed flow change must invalidate exact simultaneous-solver reuse");
+    mutated.column.run();
+
+    assertTrue(mutated.column.solved(), mutated.column.getConvergenceDiagnostics());
+    assertFalse(mutated.column.wasNaphtaliSandholmWarmStateReused(),
+        "the changed direct feed must be solved rather than answered from the old cache");
+    assertNotEquals(originalOverheadFlow, mutated.column.getGasOutStream().getFlowRate("mol/hr"), 1.0,
+        "a 10 percent direct-feed flow change must alter the product flow");
+    assertEquals(20.0, mutated.registeredFeed.getTemperature("C"), 1.0e-9,
+        "direct-feed cache checks must not mutate the registered caller-owned feed");
+    assertEquals(30.0, mutated.directFeed.getTemperature("C"), 1.0e-9,
+        "direct-feed cache checks must not mutate the direct caller-owned feed");
+    assertPhysicalStream(mutated.column.getGasOutStream());
+    assertPhysicalStream(mutated.column.getLiquidOutStream());
+  }
+
+  /**
    * Sequential warm starts must be invalidated when a fixed reboiler temperature changes.
    *
    * <p>

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -492,6 +492,39 @@ public class DistillationColumnWarmStateCacheTest {
   }
 
   /**
+   * A direct-feed-only sequential column must scale its divergence guard from the physical feed flow.
+   *
+   * <p>
+   * Legacy direct tray feeds are valid external feeds. Ignoring them when setting the internal-traffic
+   * threshold leaves the threshold at the 1000 kg/h floor and rejects this otherwise ordinary
+   * multicomponent stripper before it can converge.
+   * </p>
+   */
+  @Test
+  public void directOnlySequentialColumnUsesExternalFeedScaleForDivergenceGuard() {
+    Stream directFeed =
+        new Stream("direct-only feed", createIdentityTestFluid(false, "n-butane", 2));
+    configureIdentityFeed(directFeed);
+
+    TrackingDistillationColumn column =
+        new TrackingDistillationColumn("direct-only sequential column", 6, true, false);
+    column.getTray(3).addStream(directFeed);
+    column.setTopPressure(10.0);
+    column.setBottomPressure(10.5);
+    column.getReboiler().setOutTemperature(273.15 + 80.0);
+    configureDampedSubstitution(column);
+
+    column.run();
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertTrue(column.getLastIterationCount() <= 120,
+        "the direct-feed-only solve must remain inside the deterministic hard cap");
+    assertEquals(20.0, directFeed.getTemperature("C"), 1.0e-9,
+        "direct-feed handling must preserve the caller-owned feed temperature");
+    assertPhysicalAndBalanced(new ColumnCase(directFeed, column));
+  }
+
+  /**
    * A legacy direct tray feed participates in the same thermodynamic-identity gate as registered feeds.
    */
   @Test


### PR DESCRIPTION
## Problem

Sequential distillation solves reuse converged tray gas/liquid traffic whenever `hasBeenSolvedBefore` is true. That warm state was not checked against fixed column configuration or thermodynamic identity. A direct reboiler-temperature change could therefore seed the next damped-substitution solve from a tray profile that belongs to the old specification.

## Reproduction on current master

A deterministic six-tray SRK propane / n-butane / n-pentane stripper was solved at 80 °C, then re-solved with relaxation 0.2:

| New reboiler target | Fresh cold solve | Existing warm re-solve |
|---|---:|---:|
| 90 °C | solved in 26 iterations; 47,960 mol/h overhead | solved in 28 iterations; 48,974 mol/h overhead |
| 100 °C | solved in 4 iterations; 64,852 mol/h overhead | internal-traffic guard reached |

The 90 °C result is path-dependent and the 100 °C target is demonstrably feasible from a cold initialization.

## Root cause

Two independent warm-state defects were reproduced:

1. `solveSequential` decided whether to reuse tray traffic solely from `hasBeenSolvedBefore` and the explicit initialization flag. It did not verify that the tray initialization still described the fixed endpoint temperatures, pressure profile, reflux configuration, EOS, mixing rule, or ordered component identities.
2. The first compatibility fix correctly forced one `init()`, but Windows CI still found a 0.2323% overhead-flow difference from a fresh 90 °C cold reference (36,860.1193 versus 36,945.9556 mol/h). Tracing the rebuild showed that `DistillationColumn.init()` called `SimpleTray.init()` after relinking. On feed trays with two inputs, that method set the temperature of every inlet, including the caller-owned external feed. A preceding solve could therefore silently change the feed temperature/enthalpy used by the next rebuild.

## Change

- Record a transient fingerprint of fixed column inputs whenever `init()` rebuilds the tray state.
- Before a sequential warm start, compare both the fixed-configuration fingerprint and the existing thermodynamic-identity fingerprint.
- Rebuild initialization only when those inputs are incompatible.
- Keep feed flow, temperature, pressure, and composition outside the fixed-configuration fingerprint so ordinary nearby feed cases retain their warm start.
- Avoid repeated cold starts inside adjustable-specification outer iterations.
- Preserve/reset the new fingerprint with accepted candidates and structural rebuilds.
- During tray relinking, use internal clones of registered and directly connected feeds. The clones retain the established tray-temperature initialization, while caller-owned feed temperature and enthalpy remain unchanged.
- Refresh every registered/direct internal feed clone from its caller-owned source before each initialized solve and immediately after tray-profile construction, so initialization seeding cannot become the physical feed state.
- Do not refresh pre-initialization tray inputs: `init()` first establishes deterministic registered/direct-feed ordering and internal clone ownership, preventing reverse attachment order from swapping systems or mutating caller-owned feeds.
- Include direct tray feeds in the deterministic thermodynamic-identity fingerprint, after capturing them and in sorted tray order.
- Use the lowest registered or direct external feed tray consistently when preparing pressure defaults and the first tray solve.
- Include direct-feed flow, temperature, pressure, composition, EOS, and mixing rule in the exact Naphtali–Sandholm cache fingerprint and preserved solver inputs.
- Scale sequential internal-traffic divergence detection from the complete registered/direct external-feed inventory, including direct-feed-only columns.
- Transfer exact sequential reuse ownership and its verified input fingerprint when an accepted AUTO/fallback candidate replaces the live tray state, while resetting per-invocation reuse telemetry.

## Regression coverage

The enabled regression exercises both 90 °C and 100 °C targets and checks:

- rigorous solved status;
- cold-reference product equivalence;
- component and total molar balance;
- physical temperature, pressure, flow, and composition bounds;
- no more than the established 30-iteration cold-reference budget;
- exactly one required reinitialization after the specification change;
- preservation of the caller-owned external feed temperature through initialization and reinitialization;
- repeatability of an unchanged re-run without another initialization;
- direct side-feed component-identity invalidation, exactly one rebuild, cold-reference agreement, physical products, and preservation of both caller-owned feed temperatures;
- direct side-feed operating-point invalidation of exact Naphtali–Sandholm reuse;
- a direct-feed-only six-tray stripper that must converge inside the hard iteration cap, preserve its caller-owned feed state, and close component/total balances;
- cold initialization with a direct feed attached before a registered feed on the same tray, verifying exact caller `SystemInterface` identity, feed temperatures, convergence, total balance, and physical products;
- accepted damped-candidate adoption followed by an unchanged zero-iteration exact reuse, with product-flow equality, balance, physical bounds, and caller-feed preservation.

No tolerance was loosened, no failure was hidden, and the unrelated diagnostic change from the former branch history was removed.

## Compatibility and risk

The added fields are transient and do not change serialized column data. Fixed-configuration invalidation is confined to sequential damped substitution; direct-feed identity and operating-state coverage is shared with the exact Naphtali–Sandholm cache. Nearby operating-point warm starts are preserved. Adjustable column specifications retain their intended inner-loop continuation behavior.

## Validation

Exact head: `28155ed9e969dcb5a322f7159c3f5b25313aa85d`

The original compatibility head passed Spotless, pre-commit, PaperLab, Javadoc, CodeQL, cross-reference checks, and all three slow-test shards. Its Windows Java 21 fast suite ran 10,850 tests and exposed the remaining 90 °C cold-reference mismatch described above; no tolerance was changed. A first attempt that skipped external-feed temperature seeding was rejected after the slow suite exposed an inside-out telemetry fallback.

A later exact head ran 10,853 fast tests on both Ubuntu/JaCoCo and Windows and exposed three failures: the direct-feed regression entered guarded fallback, the unchanged 90 °C re-run changed overhead flow from 36,945.96 to 47,377.09 mol/h, and the TEG regeneration energy residual reached 3.631%. These failures showed that internal clones retained tray-seeded temperatures after profile construction. The current design keeps seeded clones for initialization only, then restores the physical caller-owned feed systems before solving.

Running on the corrected exact head:

- focused warm-state regression at both 90 °C and 100 °C, hard-capped at 120 iterations;
- affected and broader Java 21 fast-test suites on Ubuntu and Windows;
- three bounded Java 21 slow-test shards;
- Spotless, pre-commit, PaperLab, CodeQL, Javadoc, and reference checks.

On the exact head, `DistillationColumnWarmStateCacheTest` passed 12/12. The complete Java 21 fast suite passed 10,858 tests with 0 failures/errors and 212 skipped on both Ubuntu/JaCoCo and Windows. All three bounded slow-test shards passed (74, 44, and 96 tests). Spotless, pre-commit, PaperLab, CodeQL, Javadoc, and reference checks are green. The complete Java 8 suite also passed 10,858 tests with 0 failures/errors and 212 skipped on both Windows (35:35) and Ubuntu (47:07). Commit `47dd7ff` applied the repository-generated formatting patch for the reverse-feed regression without changing behavior or assertions.

The prior Copilot hard-cap and exact-one-rebuild suggestions are implemented. Further technically valid Copilot findings were accepted: direct tray feeds participate in both identity and exact-cache fingerprints, newly attached direct feeds are captured before compatibility checks, the lower external feed determines preparation, feed refresh uses the actual tray inventory, solve-metric reset clears the new sequential exact-reuse state, direct-feed-only columns use their physical feed flow for the divergence guard, cold preparation waits for deterministic initialization before refreshing internal feed clones, and accepted sequential candidates explicitly transfer exact-reuse ownership while clearing invocation telemetry. Both accepted inline threads were answered with exact-head validation evidence and resolved; no inline review thread remains open. Full simultaneous-solver processing of legacy direct feeds is a broader API/capability gap and is deferred to a separate bounded change. The outdated diagnostic thread was answered and resolved because that unchanged master behavior is outside this focused diff. The branch is now current with `master` commit `22fb6418`; the merge is non-conflicting and the PR diff remains exactly the two intended column files. Copilot reviewed exact head `28155ed9` across both changed files and generated no new comments. The PR is ready for human review and remains open and unmerged.
