### PR TITLE
[AI-Assisted] Bound Java 21 Ubuntu tests to 60 minutes

### DIFF
--- a/.github/workflows/verify_build.yml
+++ b/.github/workflows/verify_build.yml
@@ -62,6 +62,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.os }}
     needs: test_javadoc
+    timeout-minutes: 60
     strategy:
       fail-fast: true
       matrix:
@@ -84,9 +85,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'maven'
-      - name: Run tests and generate JaCoCo report
+      - name: Run fast tests and generate JaCoCo report
         if: matrix.verify_jacoco
-        run: mvn -B test -ntp -DexcludedTestGroups= "-Daether.connector.basic.retries=5"
+        run: mvn -B test -ntp -DskipITs "-Daether.connector.basic.retries=5"
       - name: Run fast tests, do not generate JaCoCo report
         if: ${{ !matrix.verify_jacoco }}
         run: mvn -B test -ntp -DskipITs "-Daether.connector.basic.retries=5" "-Djacoco.skip=true"
@@ -112,6 +113,56 @@ jobs:
           name: codecov
           use_oidc: true
           fail_ci_if_error: true
+
+  test_java_slow:
+    name: Assert slow tests (${{ matrix.label }}) with Java 21 on Ubuntu
+    runs-on: ubuntu-latest
+    needs: test_javadoc
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: 0
+            label: 1/3
+          - shard: 1
+            label: 2/3
+          - shard: 2
+            label: 3/3
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          token: ${{ github.token }}
+          fetch-depth: 1
+      - name: Set up Java 21 environment
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      - name: Run slow-test shard without JaCoCo
+        shell: bash
+        run: |
+          mapfile -t slow_files < <(
+            grep -rl --include='*Test.java' '@Tag("slow")' src/test/java | sort
+          )
+          selected=()
+          for index in "${!slow_files[@]}"; do
+            if ((index % 3 == ${{ matrix.shard }})); then
+              class_name="${slow_files[$index]#src/test/java/}"
+              class_name="${class_name%.java}"
+              selected+=("${class_name//\//.}")
+            fi
+          done
+          if ((${#selected[@]} == 0)); then
+            echo "No slow tests discovered for shard ${{ matrix.shard }}"
+            exit 1
+          fi
+          test_pattern=$(IFS=,; echo "${selected[*]}")
+          mvn -B test -ntp -Dtest="$test_pattern" -Dgroups=slow \
+            "-DexcludedTestGroups=" "-Daether.connector.basic.retries=5" \
+            "-Djacoco.skip=true"
 
   test_java_8:
     name: Assert tests with Java 8 on Ubuntu

--- a/.github/workflows/verify_build.yml
+++ b/.github/workflows/verify_build.yml
@@ -145,7 +145,7 @@ jobs:
         shell: bash
         run: |
           mapfile -t slow_files < <(
-            grep -rl --include='*Test.java' '@Tag("slow")' src/test/java | sort
+            grep -rl --include='*.java' '@Tag("slow")' src/test/java | sort
           )
           selected=()
           for index in "${!slow_files[@]}"; do

--- a/src/test/java/neqsim/physicalproperties/interfaceproperties/surfacetension/CDFTCriticalCorrectionCalibrationTest.java
+++ b/src/test/java/neqsim/physicalproperties/interfaceproperties/surfacetension/CDFTCriticalCorrectionCalibrationTest.java
@@ -3,6 +3,7 @@ package neqsim.physicalproperties.interfaceproperties.surfacetension;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPrEos;
@@ -22,6 +23,7 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @author Agent
  * @version 1.0
  */
+@Tag("slow")
 class CDFTCriticalCorrectionCalibrationTest {
   private static final Logger logger = LogManager.getLogger(CDFTCriticalCorrectionCalibrationTest.class);
 

--- a/src/test/java/neqsim/process/equipment/separator/ThreePhaseGasScrubberTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/ThreePhaseGasScrubberTest.java
@@ -10,6 +10,7 @@ import neqsim.process.measurementdevice.PressureTransmitter;
 import neqsim.process.measurementdevice.WaterLevelTransmitter;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
 
 /**
  * Tests for {@link ThreePhaseGasScrubber} and vertical-orientation behaviour of {@link ThreePhaseSeparator}, covering
@@ -22,11 +23,31 @@ import neqsim.thermo.system.SystemSrkCPAstatoil;
 class ThreePhaseGasScrubberTest {
 
   /**
-   * Builds a gas + oil + water three-phase fluid.
+   * Builds a computationally light gas + oil + water fluid for the dynamic controller tests.
+   *
+   * <p>
+   * These tests exercise separator inventory and control behavior over hundreds of transient steps, not association
+   * thermodynamics. The focused CPA transient test below retains coverage of the associating-fluid VU-flash path.
+   * </p>
    *
    * @return a three-phase thermodynamic system
    */
   private static SystemInterface makeThreePhaseFluid() {
+    SystemInterface fluid = new SystemSrkEos(273.15 + 50.0, 15.0);
+    fluid.addComponent("methane", 85.0);
+    fluid.addComponent("n-heptane", 15.0);
+    fluid.addComponent("water", 50.0);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  /**
+   * Builds the associating three-phase fluid used by the focused CPA transient smoke test.
+   *
+   * @return a three-phase CPA thermodynamic system
+   */
+  private static SystemInterface makeCpaThreePhaseFluid() {
     SystemInterface fluid = new SystemSrkCPAstatoil(273.15 + 50.0, 15.0);
     fluid.addComponent("methane", 85.0);
     fluid.addComponent("ethane", 5.0);
@@ -47,7 +68,18 @@ class ThreePhaseGasScrubberTest {
    * @return a solved {@link ThreePhaseGasScrubber}
    */
   private static ThreePhaseGasScrubber makeScrubber(String name) {
-    Stream feed = new Stream("feed", makeThreePhaseFluid());
+    return makeScrubber(name, makeThreePhaseFluid());
+  }
+
+  /**
+   * Builds a vertical three-phase scrubber from the supplied fluid and runs the initial steady-state solution.
+   *
+   * @param name equipment name
+   * @param fluid feed fluid
+   * @return a solved {@link ThreePhaseGasScrubber}
+   */
+  private static ThreePhaseGasScrubber makeScrubber(String name, SystemInterface fluid) {
+    Stream feed = new Stream("feed", fluid);
     feed.setTemperature(50.0, "C");
     feed.setPressure(15.0, "bara");
     feed.setFlowRate(5000.0, "kg/hr");
@@ -151,6 +183,27 @@ class ThreePhaseGasScrubberTest {
     Assertions.assertTrue(sep.getWaterLevel() >= 0.0);
     Assertions.assertTrue(sep.getOilLevel() >= sep.getWaterLevel() - 1e-9,
         "oil level (water+oil) must be >= water level");
+  }
+
+  /**
+   * One transient step with the full CPA fluid must retain a finite physical vessel state. This keeps the associating
+   * VU-flash path covered without repeating the same expensive flash for every controller-integration time step.
+   */
+  @Test
+  void testCpaTransientFlashRemainsPhysical() {
+    ThreePhaseGasScrubber scrubber = makeScrubber("CPA transient", makeCpaThreePhaseFluid());
+    scrubber.setCalculateSteadyState(false);
+    scrubber.runTransient(3.0, UUID.randomUUID());
+
+    Assertions.assertTrue(Double.isFinite(scrubber.getWaterLevel()), "CPA water level must be finite");
+    Assertions.assertTrue(Double.isFinite(scrubber.getOilLevel()), "CPA oil level must be finite");
+    Assertions.assertTrue(scrubber.getWaterLevel() >= 0.0, "CPA water level must be non-negative");
+    Assertions.assertTrue(scrubber.getOilLevel() >= scrubber.getWaterLevel() - 1e-6,
+        "CPA oil level must remain above the water level");
+    Assertions.assertTrue(Double.isFinite(scrubber.getThermoSystem().getPressure("bara")),
+        "CPA vessel pressure must be finite");
+    Assertions.assertTrue(scrubber.getThermoSystem().getPressure("bara") > 0.0,
+        "CPA vessel pressure must remain positive");
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltSaturationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltSaturationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
 import neqsim.thermo.system.SystemInterface;
@@ -16,6 +17,7 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @author ESOL
  * @version $Id$
  */
+@Tag("slow")
 class SaltSaturationTest {
   private static final double SATURATION_RATIO_TOLERANCE = 1.0e-3;
   private static final double PLUMMER_BUSENBERG_CALCITE_KSP_TOLERANCE = 1.0e-8;


### PR DESCRIPTION
## Problem

The Java 21 Ubuntu test job was unbounded and deliberately cleared the repository's default `slow` exclusion. On completed workflow run `30308454790`:

- Maven test time was **5 h 15 min** for 11,060 tests.
- `ThreePhaseGasScrubberTest` alone took **13,097 s (3 h 38 min)**.
- Slow-tagged tests consumed about **4 h 25 min** inside the JaCoCo job.

## Change

- Restore the default exclusion of `@Tag("slow")` in the Java 21 Ubuntu JaCoCo job.
- Add a hard `timeout-minutes: 60` to every Java 21 fast and slow job.
- Discover every slow-tagged Java test source, including nonstandard class names, and distribute them deterministically across three parallel Ubuntu/Java 21 shards.
- Run slow shards without JaCoCo so they remain behavioral gates without dominating coverage instrumentation time.
- Classify `SaltSaturationTest` and `CDFTCriticalCorrectionCalibrationTest` as slow.
- Keep the scrubber's complete controller horizons and disturbances, but use a light SRK methane/n-heptane/water fluid for the hundreds of controller-integration VU flashes.
- Retain a focused CPA transient smoke test so the associating-fluid VU-flash path remains covered.

## Acceptance criteria

- Every Java 21 test job has a hard 60-minute ceiling.
- Fast and all slow-tagged tests execute.
- The scrubber dynamic-control assertions and disturbance horizons are preserved.
- A CPA transient VU flash remains covered.
- No production API or numerical implementation changes.

## Validation

Final head `14f5860a6966279fdd077a830f268b282a023d21`, workflow run `30341584075`:

- **Ubuntu Java 21 fast + JaCoCo:** 10,849 tests, **34m34s**, green.
- **Windows Java 21 fast:** 10,849 tests, **23m25s**, green.
- **Ubuntu Java 21 slow shards:** 74 tests in **30m56s**, 96 tests in **14m00s**, and 44 tests in **10m35s**; all green.
- Longest Java 21 test job / parallel stage: **34m34s**, leaving **25m26s** below the hard limit.
- `ThreePhaseGasScrubberTest`: 8 tests in **5.03s**, down from 3h38m.
- Previously missed `SolverSpeedBenchmark`: selected and passed in **805.9s**.
- Spotless, pre-commit, CodeQL, Javadoc, and agent-skill reference checks: green.

The unchanged downstream Java 8 jobs continue independently and are outside this Java 21 runtime change.