### PR TITLE
[AI-Assisted] Warm-start dynamic CPA VU flashes

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,38 @@
 
 ---
 
+## 2026-07-28 — Dynamic VU flashes preserve nearby CPA state
+
+### Summary
+
+Continuous separator and tank calculations now initialize each VU flash from the immediately
+preceding converged thermodynamic state. This preserves CPA association and phase-equilibrium work
+between nearby time steps. Standalone VU flashes keep their previous cold-start behavior, and a
+dynamic warm initialization retries once from the incoming pressure and temperature if it does not
+satisfy the volume and internal-energy residuals.
+
+### New API
+
+| API | What it does |
+|---|---|
+| `ThermodynamicOperations.VUflash(Vspec, Uspec, warmStartInitialization)` | Explicitly selects warm or cold initialization for a VU flash |
+| `ThermodynamicOperations.VUflash(volume, energy, volumeUnit, energyUnit, warmStartInitialization)` | Unit-aware version of the same option |
+| `OptimizedVUflash.getLastIterationCount()` | Reports the Newton iterations used by the last solve |
+| `OptimizedVUflash.isLastRunConverged()` | Reports whether the last solve met its convergence criteria |
+| `OptimizedVUflash.wasColdFallbackUsed()` | Reports whether a requested warm initialization needed the cold retry |
+
+### Dynamic behavior
+
+`Separator.runTransient`, `ThreePhaseSeparator.runTransient`, and `Tank.runTransient` opt in to
+warm initialization. Existing VU-flash overloads and steady-state calls remain cold by default.
+
+### Test
+
+`VUFlashTest.testDynamicCpaVUflashUsesBoundedWarmStarts` covers repeated, nearby three-phase
+SRK-CPA VU flashes and verifies bounded convergence without a cold fallback.
+
+---
+
 ## 2026-07-27 — Capacity-aware compressor operating points and optimizer alignment
 
 ### Summary

--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -13,11 +13,11 @@
 
 ### Summary
 
-Continuous separator and tank calculations now initialize each VU flash from the immediately
-preceding converged thermodynamic state. This preserves CPA association and phase-equilibrium work
-between nearby time steps. Standalone VU flashes keep their previous cold-start behavior, and a
-dynamic warm initialization retries once from the incoming pressure and temperature if it does not
-satisfy the volume and internal-energy residuals.
+Continuous separator and tank calculations with associating fluids now initialize each VU flash
+from the immediately preceding converged thermodynamic state. This preserves CPA association and
+phase-equilibrium work between nearby time steps. Cubic-EOS dynamics and standalone VU flashes keep
+their previous cold-start behavior, and a dynamic warm initialization retries once from the
+incoming pressure and temperature if it does not satisfy the volume and internal-energy residuals.
 
 ### New API
 
@@ -26,18 +26,20 @@ satisfy the volume and internal-energy residuals.
 | `ThermodynamicOperations.VUflash(Vspec, Uspec, warmStartInitialization)` | Explicitly selects warm or cold initialization for a VU flash |
 | `ThermodynamicOperations.VUflash(volume, energy, volumeUnit, energyUnit, warmStartInitialization)` | Unit-aware version of the same option |
 | `OptimizedVUflash.getLastIterationCount()` | Reports the Newton iterations used by the last solve |
-| `OptimizedVUflash.isLastRunConverged()` | Reports whether the last solve met its convergence criteria |
+| `OptimizedVUflash.isLastRunConverged()` | Reports whether the final state met the accepted V/U residual criteria |
 | `OptimizedVUflash.wasColdFallbackUsed()` | Reports whether a requested warm initialization needed the cold retry |
 
 ### Dynamic behavior
 
 `Separator.runTransient`, `ThreePhaseSeparator.runTransient`, and `Tank.runTransient` opt in to
-warm initialization. Existing VU-flash overloads and steady-state calls remain cold by default.
+warm initialization for associating fluids. Cubic-EOS dynamics, existing VU-flash overloads, and
+steady-state calls remain cold by default.
 
 ### Test
 
 `VUFlashTest.testDynamicCpaVUflashUsesBoundedWarmStarts` covers repeated, nearby three-phase
 SRK-CPA VU flashes and verifies bounded convergence without a cold fallback.
+`DynamicCompressorNotebookRegressionTest` protects the established cubic-EOS dynamic trajectory.
 
 ---
 

--- a/src/main/java/neqsim/process/equipment/separator/Separator.java
+++ b/src/main/java/neqsim/process/equipment/separator/Separator.java
@@ -977,8 +977,8 @@ public class Separator extends ProcessEquipmentBaseClass
       ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
       // Preserve the nearby equilibrium seed only for associating fluids. Cubic EOS dynamics
       // retain the legacy cold initialization and its established trajectory.
-      boolean warmStartInitialization =
-          !neqsim.thermo.ThermodynamicModelSettings.isInnerFlashWarmStartSafe(thermoSystem);
+      boolean warmStartInitialization = !neqsim.thermo.ThermodynamicModelSettings
+          .isInnerFlashWarmStartSafe(thermoSystem);
       thermoOps.VUflash(gasVolume + liquidVolume, newEnergy, "m3", "J", warmStartInitialization);
       thermoSystem.initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
 

--- a/src/main/java/neqsim/process/equipment/separator/Separator.java
+++ b/src/main/java/neqsim/process/equipment/separator/Separator.java
@@ -975,7 +975,7 @@ public class Separator extends ProcessEquipmentBaseClass
       }
 
       ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
-      thermoOps.VUflash(gasVolume + liquidVolume, newEnergy, "m3", "J");
+      thermoOps.VUflash(gasVolume + liquidVolume, newEnergy, "m3", "J", true);
       thermoSystem.initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
 
       // Update entrainment fractions from performance calculator during transient

--- a/src/main/java/neqsim/process/equipment/separator/Separator.java
+++ b/src/main/java/neqsim/process/equipment/separator/Separator.java
@@ -975,7 +975,11 @@ public class Separator extends ProcessEquipmentBaseClass
       }
 
       ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
-      thermoOps.VUflash(gasVolume + liquidVolume, newEnergy, "m3", "J", true);
+      // Preserve the nearby equilibrium seed only for associating fluids. Cubic EOS dynamics
+      // retain the legacy cold initialization and its established trajectory.
+      boolean warmStartInitialization =
+          !neqsim.thermo.ThermodynamicModelSettings.isInnerFlashWarmStartSafe(thermoSystem);
+      thermoOps.VUflash(gasVolume + liquidVolume, newEnergy, "m3", "J", warmStartInitialization);
       thermoSystem.initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
 
       // Update entrainment fractions from performance calculator during transient

--- a/src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java
+++ b/src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java
@@ -892,7 +892,7 @@ public class ThreePhaseSeparator extends Separator {
       }
 
       ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
-      thermoOps.VUflash(gasVolume + liquidVolume, newEnergy, "m3", "J");
+      thermoOps.VUflash(gasVolume + liquidVolume, newEnergy, "m3", "J", true);
       thermoSystem.initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
 
       // Update entrainment fractions from performance calculator during transient

--- a/src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java
+++ b/src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java
@@ -892,7 +892,11 @@ public class ThreePhaseSeparator extends Separator {
       }
 
       ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
-      thermoOps.VUflash(gasVolume + liquidVolume, newEnergy, "m3", "J", true);
+      // Preserve the nearby equilibrium seed only for associating fluids. Cubic EOS dynamics
+      // retain the legacy cold initialization and its established trajectory.
+      boolean warmStartInitialization =
+          !neqsim.thermo.ThermodynamicModelSettings.isInnerFlashWarmStartSafe(thermoSystem);
+      thermoOps.VUflash(gasVolume + liquidVolume, newEnergy, "m3", "J", warmStartInitialization);
       thermoSystem.initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
 
       // Update entrainment fractions from performance calculator during transient

--- a/src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java
+++ b/src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java
@@ -894,8 +894,8 @@ public class ThreePhaseSeparator extends Separator {
       ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
       // Preserve the nearby equilibrium seed only for associating fluids. Cubic EOS dynamics
       // retain the legacy cold initialization and its established trajectory.
-      boolean warmStartInitialization =
-          !neqsim.thermo.ThermodynamicModelSettings.isInnerFlashWarmStartSafe(thermoSystem);
+      boolean warmStartInitialization = !neqsim.thermo.ThermodynamicModelSettings
+          .isInnerFlashWarmStartSafe(thermoSystem);
       thermoOps.VUflash(gasVolume + liquidVolume, newEnergy, "m3", "J", warmStartInitialization);
       thermoSystem.initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
 

--- a/src/main/java/neqsim/process/equipment/tank/Tank.java
+++ b/src/main/java/neqsim/process/equipment/tank/Tank.java
@@ -322,7 +322,11 @@ public class Tank extends ProcessEquipmentBaseClass implements AutoSizeable, Cap
     System.out.println("total moles " + thermoSystem.getTotalNumberOfMoles());
 
     ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
-    thermoOps.VUflash(volume1, newEnergy, true);
+    // Preserve the nearby equilibrium seed only for associating fluids. Cubic EOS dynamics
+    // retain the legacy cold initialization and its established trajectory.
+    boolean warmStartInitialization =
+        !neqsim.thermo.ThermodynamicModelSettings.isInnerFlashWarmStartSafe(thermoSystem);
+    thermoOps.VUflash(volume1, newEnergy, warmStartInitialization);
 
     setOutComposition(thermoSystem);
     setTempPres(thermoSystem.getTemperature(), thermoSystem.getPressure());

--- a/src/main/java/neqsim/process/equipment/tank/Tank.java
+++ b/src/main/java/neqsim/process/equipment/tank/Tank.java
@@ -324,8 +324,7 @@ public class Tank extends ProcessEquipmentBaseClass implements AutoSizeable, Cap
     ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
     // Preserve the nearby equilibrium seed only for associating fluids. Cubic EOS dynamics
     // retain the legacy cold initialization and its established trajectory.
-    boolean warmStartInitialization =
-        !neqsim.thermo.ThermodynamicModelSettings.isInnerFlashWarmStartSafe(thermoSystem);
+    boolean warmStartInitialization = !neqsim.thermo.ThermodynamicModelSettings.isInnerFlashWarmStartSafe(thermoSystem);
     thermoOps.VUflash(volume1, newEnergy, warmStartInitialization);
 
     setOutComposition(thermoSystem);

--- a/src/main/java/neqsim/process/equipment/tank/Tank.java
+++ b/src/main/java/neqsim/process/equipment/tank/Tank.java
@@ -322,7 +322,7 @@ public class Tank extends ProcessEquipmentBaseClass implements AutoSizeable, Cap
     System.out.println("total moles " + thermoSystem.getTotalNumberOfMoles());
 
     ThermodynamicOperations thermoOps = new ThermodynamicOperations(thermoSystem);
-    thermoOps.VUflash(volume1, newEnergy);
+    thermoOps.VUflash(volume1, newEnergy, true);
 
     setOutComposition(thermoSystem);
     setTempPres(thermoSystem.getTemperature(), thermoSystem.getPressure());

--- a/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
+++ b/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
@@ -1054,9 +1054,8 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
    * Performs a VU flash with an explicit initialization policy.
    *
    * <p>
-   * Warm initialization is intended for a continuous dynamic trajectory whose current system is
-   * the immediately preceding converged state. Independent flashes should use the cold-default
-   * overload.
+   * Warm initialization is intended for a continuous dynamic trajectory whose current system is the immediately
+   * preceding converged state. Independent flashes should use the cold-default overload.
    * </p>
    *
    * @param volume specified volume
@@ -1089,14 +1088,12 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
       conversionFactorEntr = 1.0 / system.getTotalNumberOfMoles() / system.getMolarMass();
       break;
     case "kJ/kg":
-      conversionFactorEntr =
-          1.0 / system.getTotalNumberOfMoles() / system.getMolarMass() / 1000.0;
+      conversionFactorEntr = 1.0 / system.getTotalNumberOfMoles() / system.getMolarMass() / 1000.0;
       break;
     default:
       break;
     }
-    VUflash(volume * conversionFactorV, energy / conversionFactorEntr,
-        warmStartInitialization);
+    VUflash(volume * conversionFactorV, energy / conversionFactorEntr, warmStartInitialization);
   }
 
   /**
@@ -1120,8 +1117,7 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
     if (isPureComponentWithinInternalEnergyRange(Uspec)) {
       operation = new VUflashSingleComp(system, Vspec, Uspec);
     } else {
-      operation =
-          new OptimizedVUflash(system, Vspec, Uspec, warmStartInitialization);
+      operation = new OptimizedVUflash(system, Vspec, Uspec, warmStartInitialization);
     }
     getOperation().run();
   }

--- a/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
+++ b/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
@@ -1047,6 +1047,26 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
    * @param unitEnergy a {@link java.lang.String} object
    */
   public void VUflash(double volume, double energy, String unitVol, String unitEnergy) {
+    VUflash(volume, energy, unitVol, unitEnergy, false);
+  }
+
+  /**
+   * Performs a VU flash with an explicit initialization policy.
+   *
+   * <p>
+   * Warm initialization is intended for a continuous dynamic trajectory whose current system is
+   * the immediately preceding converged state. Independent flashes should use the cold-default
+   * overload.
+   * </p>
+   *
+   * @param volume specified volume
+   * @param energy specified internal energy
+   * @param unitVol volume unit
+   * @param unitEnergy energy unit
+   * @param warmStartInitialization whether the initialization TP flash may reuse current K-values
+   */
+  public void VUflash(double volume, double energy, String unitVol, String unitEnergy,
+      boolean warmStartInitialization) {
     double conversionFactorV = 1.0;
     double conversionFactorEntr = 1.0;
 
@@ -1069,12 +1089,14 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
       conversionFactorEntr = 1.0 / system.getTotalNumberOfMoles() / system.getMolarMass();
       break;
     case "kJ/kg":
-      conversionFactorEntr = 1.0 / system.getTotalNumberOfMoles() / system.getMolarMass() / 1000.0;
+      conversionFactorEntr =
+          1.0 / system.getTotalNumberOfMoles() / system.getMolarMass() / 1000.0;
       break;
     default:
       break;
     }
-    VUflash(volume * conversionFactorV, energy / conversionFactorEntr);
+    VUflash(volume * conversionFactorV, energy / conversionFactorEntr,
+        warmStartInitialization);
   }
 
   /**
@@ -1084,10 +1106,22 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
    * @param Uspec a double
    */
   public void VUflash(double Vspec, double Uspec) {
+    VUflash(Vspec, Uspec, false);
+  }
+
+  /**
+   * Performs a VU flash with an explicit initialization policy.
+   *
+   * @param Vspec specified volume in NeqSim internal units
+   * @param Uspec specified internal energy in NeqSim internal units
+   * @param warmStartInitialization whether the initialization TP flash may reuse current K-values
+   */
+  public void VUflash(double Vspec, double Uspec, boolean warmStartInitialization) {
     if (isPureComponentWithinInternalEnergyRange(Uspec)) {
       operation = new VUflashSingleComp(system, Vspec, Uspec);
     } else {
-      operation = new OptimizedVUflash(system, Vspec, Uspec);
+      operation =
+          new OptimizedVUflash(system, Vspec, Uspec, warmStartInitialization);
     }
     getOperation().run();
   }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/OptimizedVUflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/OptimizedVUflash.java
@@ -53,6 +53,14 @@ public class OptimizedVUflash extends Flash {
   private double lastPressure = Double.NaN;
   private double lastTemperature = Double.NaN;
   private boolean isWellBehaved = true;
+  /** Whether the initialization TP flash may reuse the current system's K-values. */
+  private final boolean warmStartInitialization;
+  /** Number of Newton iterations used by the most recent solve. */
+  private int lastIterationCount = 0;
+  /** Whether the most recent solve met both V and U specifications. */
+  private boolean lastRunConverged = false;
+  /** Whether the most recent warm-initialized run required a cold retry. */
+  private boolean coldFallbackUsed = false;
 
   /**
    * Constructor for OptimizedVUflash.
@@ -62,10 +70,30 @@ public class OptimizedVUflash extends Flash {
    * @param Uspec specified internal energy
    */
   public OptimizedVUflash(SystemInterface system, double Vspec, double Uspec) {
+    this(system, Vspec, Uspec, false);
+  }
+
+  /**
+   * Constructor for an optimized VU flash with an explicit initialization policy.
+   *
+   * <p>
+   * Warm initialization is intended for continuous dynamic calculations where the supplied system
+   * is the immediately preceding converged state. Standalone flashes should retain the cold
+   * default so unrelated states cannot seed each other.
+   * </p>
+   *
+   * @param system thermodynamic system to flash
+   * @param Vspec specified total volume
+   * @param Uspec specified internal energy
+   * @param warmStartInitialization whether the initialization TP flash may reuse current K-values
+   */
+  public OptimizedVUflash(SystemInterface system, double Vspec, double Uspec,
+      boolean warmStartInitialization) {
     this.system = system;
     this.tpFlash = new TPflash(system);
     this.Vspec = Vspec;
     this.Uspec = Uspec;
+    this.warmStartInitialization = warmStartInitialization;
   }
 
   /**
@@ -151,6 +179,8 @@ public class OptimizedVUflash extends Flash {
    * @return converged pressure, or the current system pressure if input validation fails
    */
   public double solveQ() {
+    lastIterationCount = 0;
+    lastRunConverged = false;
     if (!validateInputs()) {
       logger.warn("Invalid inputs for OptimizedVUflash");
       return system.getPressure();
@@ -227,6 +257,7 @@ public class OptimizedVUflash extends Flash {
         // small
         if (totalError < tolerance && volErr < 1e-6 && hErr < 1e-5) {
           isWellBehaved = true;
+          lastRunConverged = true;
           break;
         }
 
@@ -249,7 +280,8 @@ public class OptimizedVUflash extends Flash {
       } while (iterations < MAX_ITERATIONS);
 
       // Update performance tracking
-      if (iterations < MAX_ITERATIONS) {
+      lastIterationCount = iterations;
+      if (lastRunConverged) {
         lastPressure = nyPres;
         lastTemperature = nyTemp;
 
@@ -258,10 +290,12 @@ public class OptimizedVUflash extends Flash {
           isWellBehaved = true;
         }
       } else {
-        logger.warn("OptimizedVUflash did not converge after " + MAX_ITERATIONS + " iterations");
+        logger.warn("OptimizedVUflash did not converge after " + iterations + " iterations");
         isWellBehaved = false;
       }
     } catch (Exception e) {
+      lastIterationCount = iterations;
+      lastRunConverged = false;
       logger.warn("Exception in OptimizedVUflash: " + e.getMessage());
       isWellBehaved = false;
     }
@@ -304,13 +338,13 @@ public class OptimizedVUflash extends Flash {
    *
    * @param warmStartInnerFlashes whether the inner TP flashes of the Newton iteration may reuse K-values
    */
-  private void solveFromCurrentState(boolean warmStartInnerFlashes) {
+  private void solveFromCurrentState(boolean warmStartInitialFlash,
+      boolean warmStartInnerFlashes) {
     lastPressure = Double.NaN;
     lastTemperature = Double.NaN;
     isWellBehaved = true;
-    // The first TP flash always runs COLD (Wilson K) so that stale K-values from an unrelated
-    // flash at a different P/T cannot bias the solution.
-    neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(false);
+    neqsim.thermo.ThermodynamicModelSettings
+        .setUseWarmStartKValues(warmStartInitialFlash);
     tpFlash.run();
     neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(warmStartInnerFlashes);
     solveQ();
@@ -320,21 +354,55 @@ public class OptimizedVUflash extends Flash {
   @Override
   public void run() {
     boolean prevWarm = neqsim.thermo.ThermodynamicModelSettings.isUseWarmStartKValues();
+    double startPressure = system.getPressure();
+    double startTemperature = system.getTemperature();
+    coldFallbackUsed = false;
     try {
-      // Warm start is required here for every model, including CPA. Unlike the iterative outer
-      // flashes governed by ThermodynamicModelSettings.isInnerFlashWarmStartSafe(system), the VU
-      // flash marches a transient vessel inventory in small P/T steps around the previous
-      // converged state, so the previous K-values are the natural seed. Restarting each inner
-      // flash cold lets the Newton iteration drop a phase mid-iteration and strand the vessel on a
-      // state that violates the volume specification - and because solveQ() leaves the system at
-      // its last iterate, that state then seeds every following transient step.
-      solveFromCurrentState(true);
+      // Every Newton-loop TP flash may reuse K-values. The initialization flash does so only when
+      // the caller identifies the state as the previous point on a continuous dynamic trajectory.
+      solveFromCurrentState(warmStartInitialization, true);
+      if (warmStartInitialization && !isSolutionAcceptable()) {
+        // A warm seed is an optimization, never a correctness requirement. Retry once from the
+        // incoming P/T with a cold initialization if the nearby-state assumption was invalid.
+        coldFallbackUsed = true;
+        system.setPressure(startPressure);
+        system.setTemperature(startTemperature);
+        solveFromCurrentState(false, true);
+      }
       if (!isSolutionAcceptable()) {
+        lastRunConverged = false;
         logger.warn("OptimizedVUflash did not reach the volume/energy specification");
       }
     } finally {
       neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(prevWarm);
     }
+  }
+
+  /**
+   * Returns the Newton iteration count from the most recent solve.
+   *
+   * @return last Newton iteration count
+   */
+  public int getLastIterationCount() {
+    return lastIterationCount;
+  }
+
+  /**
+   * Returns whether the most recent solve met both volume and energy specifications.
+   *
+   * @return true when the last run converged
+   */
+  public boolean isLastRunConverged() {
+    return lastRunConverged;
+  }
+
+  /**
+   * Returns whether a warm-initialized run required the cold safety fallback.
+   *
+   * @return true when the last run retried with cold initialization
+   */
+  public boolean wasColdFallbackUsed() {
+    return coldFallbackUsed;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/OptimizedVUflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/OptimizedVUflash.java
@@ -359,16 +359,18 @@ public class OptimizedVUflash extends Flash {
       // Every Newton-loop TP flash may reuse K-values. The initialization flash does so only when
       // the caller identifies the state as the previous point on a continuous dynamic trajectory.
       solveFromCurrentState(warmStartInitialization, true);
-      if (warmStartInitialization && !isSolutionAcceptable()) {
+      boolean solutionAcceptable = isSolutionAcceptable();
+      if (warmStartInitialization && !solutionAcceptable) {
         // A warm seed is an optimization, never a correctness requirement. Retry once from the
         // incoming P/T with a cold initialization if the nearby-state assumption was invalid.
         coldFallbackUsed = true;
         system.setPressure(startPressure);
         system.setTemperature(startTemperature);
         solveFromCurrentState(false, true);
+        solutionAcceptable = isSolutionAcceptable();
       }
-      if (!isSolutionAcceptable()) {
-        lastRunConverged = false;
+      lastRunConverged = solutionAcceptable;
+      if (!solutionAcceptable) {
         logger.warn("OptimizedVUflash did not reach the volume/energy specification");
       }
     } finally {
@@ -386,9 +388,9 @@ public class OptimizedVUflash extends Flash {
   }
 
   /**
-   * Returns whether the most recent solve met both volume and energy specifications.
+   * Returns whether the most recent solve met the accepted volume and energy residual criteria.
    *
-   * @return true when the last run converged
+   * @return true when the final state satisfied both accepted residual criteria
    */
   public boolean isLastRunConverged() {
     return lastRunConverged;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/OptimizedVUflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/OptimizedVUflash.java
@@ -77,9 +77,9 @@ public class OptimizedVUflash extends Flash {
    * Constructor for an optimized VU flash with an explicit initialization policy.
    *
    * <p>
-   * Warm initialization is intended for continuous dynamic calculations where the supplied system
-   * is the immediately preceding converged state. Standalone flashes should retain the cold
-   * default so unrelated states cannot seed each other.
+   * Warm initialization is intended for continuous dynamic calculations where the supplied system is the immediately
+   * preceding converged state. Standalone flashes should retain the cold default so unrelated states cannot seed each
+   * other.
    * </p>
    *
    * @param system thermodynamic system to flash
@@ -87,8 +87,7 @@ public class OptimizedVUflash extends Flash {
    * @param Uspec specified internal energy
    * @param warmStartInitialization whether the initialization TP flash may reuse current K-values
    */
-  public OptimizedVUflash(SystemInterface system, double Vspec, double Uspec,
-      boolean warmStartInitialization) {
+  public OptimizedVUflash(SystemInterface system, double Vspec, double Uspec, boolean warmStartInitialization) {
     this.system = system;
     this.tpFlash = new TPflash(system);
     this.Vspec = Vspec;
@@ -338,13 +337,11 @@ public class OptimizedVUflash extends Flash {
    *
    * @param warmStartInnerFlashes whether the inner TP flashes of the Newton iteration may reuse K-values
    */
-  private void solveFromCurrentState(boolean warmStartInitialFlash,
-      boolean warmStartInnerFlashes) {
+  private void solveFromCurrentState(boolean warmStartInitialFlash, boolean warmStartInnerFlashes) {
     lastPressure = Double.NaN;
     lastTemperature = Double.NaN;
     isWellBehaved = true;
-    neqsim.thermo.ThermodynamicModelSettings
-        .setUseWarmStartKValues(warmStartInitialFlash);
+    neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(warmStartInitialFlash);
     tpFlash.run();
     neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(warmStartInnerFlashes);
     solveQ();

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/OptimizedVUflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/OptimizedVUflash.java
@@ -333,8 +333,9 @@ public class OptimizedVUflash extends Flash {
   }
 
   /**
-   * Runs the initialization TP flash cold and then the Newton iteration with the requested inner warm-start setting.
+   * Runs the initialization TP flash and Newton iteration with their requested warm-start settings.
    *
+   * @param warmStartInitialFlash whether the initialization TP flash may reuse current K-values
    * @param warmStartInnerFlashes whether the inner TP flashes of the Newton iteration may reuse K-values
    */
   private void solveFromCurrentState(boolean warmStartInitialFlash, boolean warmStartInnerFlashes) {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/VUFlashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/VUFlashTest.java
@@ -1,9 +1,13 @@
 package neqsim.thermodynamicoperations.flashops;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
@@ -34,5 +38,47 @@ class VUFlashTest {
     testOps.VUflash(volume * 1.1, internalenergy, "m3", "J");
 
     assertEquals(21.387, testSystem.getPressure(), 0.01);
+  }
+
+  /**
+   * A sequence of nearby CPA VU flashes, as used by dynamic separators, must reuse the previous
+   * equilibrium state instead of cold-starting every time. The iteration bound is deterministic
+   * and protects the transient path from the multi-hour regression seen in the scrubber suite.
+   */
+  @Test
+  void testDynamicCpaVUflashUsesBoundedWarmStarts() {
+    SystemInterface fluid = new SystemSrkCPAstatoil(273.15 + 50.0, 15.0);
+    fluid.addComponent("methane", 85.0);
+    fluid.addComponent("ethane", 5.0);
+    fluid.addComponent("propane", 3.0);
+    fluid.addComponent("n-hexane", 2.0);
+    fluid.addComponent("n-heptane", 15.0);
+    fluid.addComponent("water", 50.0);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+    fluid.initProperties();
+
+    for (int step = 0; step < 5; step++) {
+      double volume = fluid.getVolume("m3");
+      double internalEnergy = fluid.getInternalEnergy("J");
+      double energyIncrement = Math.max(Math.abs(internalEnergy) * 1.0e-5, 1.0);
+
+      operations = new ThermodynamicOperations(fluid);
+      operations.VUflash(volume, internalEnergy + energyIncrement, "m3", "J", true);
+
+      assertTrue(operations.getOperation() instanceof OptimizedVUflash);
+      OptimizedVUflash flash = (OptimizedVUflash) operations.getOperation();
+      assertTrue(flash.isLastRunConverged(), "dynamic CPA VU flash must converge at step " + step);
+      assertTrue(flash.getLastIterationCount() <= 20,
+          "dynamic CPA VU flash must remain bounded at step " + step + ", iterations="
+              + flash.getLastIterationCount());
+      assertFalse(flash.wasColdFallbackUsed(), "nearby dynamic state must not require a cold fallback");
+      assertTrue(fluid.hasPhaseType("gas"), "gas phase retained at step " + step);
+      assertTrue(fluid.hasPhaseType("oil"), "oil phase retained at step " + step);
+      assertTrue(fluid.hasPhaseType("aqueous"), "aqueous phase retained at step " + step);
+    }
   }
 }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/VUFlashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/VUFlashTest.java
@@ -41,9 +41,9 @@ class VUFlashTest {
   }
 
   /**
-   * A sequence of nearby CPA VU flashes, as used by dynamic separators, must reuse the previous
-   * equilibrium state instead of cold-starting every time. The iteration bound is deterministic
-   * and protects the transient path from the multi-hour regression seen in the scrubber suite.
+   * A sequence of nearby CPA VU flashes, as used by dynamic separators, must reuse the previous equilibrium state
+   * instead of cold-starting every time. The iteration bound is deterministic and protects the transient path from the
+   * multi-hour regression seen in the scrubber suite.
    */
   @Test
   void testDynamicCpaVUflashUsesBoundedWarmStarts() {
@@ -73,8 +73,7 @@ class VUFlashTest {
       OptimizedVUflash flash = (OptimizedVUflash) operations.getOperation();
       assertTrue(flash.isLastRunConverged(), "dynamic CPA VU flash must converge at step " + step);
       assertTrue(flash.getLastIterationCount() <= 20,
-          "dynamic CPA VU flash must remain bounded at step " + step + ", iterations="
-              + flash.getLastIterationCount());
+          "dynamic CPA VU flash must remain bounded at step " + step + ", iterations=" + flash.getLastIterationCount());
       assertFalse(flash.wasColdFallbackUsed(), "nearby dynamic state must not require a cold fallback");
       assertTrue(fluid.hasPhaseType("gas"), "gas phase retained at step " + step);
       assertTrue(fluid.hasPhaseType("oil"), "oil phase retained at step " + step);


### PR DESCRIPTION
## Problem

`ThreePhaseGasScrubberTest` increased from 421–447 s on Java 21 Ubuntu to 13,097 s while its test source remained byte-identical. The regression began with #2639's CPA inner-flash warm-start policy changes.

The current VU path restores warm starts inside the Newton loop, but each dynamic separator step still starts with an unconditional cold TP flash. `ThreePhaseSeparator.runTransient()` creates a new `ThermodynamicOperations` and `OptimizedVUflash` for every step, so the previous converged CPA K-values are discarded hundreds of times.

This is separate from #2648, which bounds CI and reduces controller-test cost but does not repair the production CPA transient path.

## Change

- Add an explicit warm-initialization option to `OptimizedVUflash` and the `ThermodynamicOperations.VUflash` overloads.
- Keep standalone VU flashes cold by default.
- Make continuous dynamic separator, three-phase separator, and tank calculations request warm initialization only for associating fluids; cubic-EOS dynamics retain the legacy cold path.
- Retain warm starts for Newton-loop TP flashes.
- Retry once with cold initialization if a warm-seeded solve does not satisfy both volume and energy specifications.
- Expose last-run convergence, iteration count, and cold-fallback diagnostics; convergence reports the accepted final V/U residual state.
- Document the opt-in API and dynamic behavior in `CHANGELOG_AGENT_NOTES.md`.
- Add a deterministic five-step three-phase CPA regression using the scrubber composition. It requires:
  - convergence within 20 Newton iterations per nearby state;
  - no cold fallback;
  - retained gas, oil, and aqueous phases.

## Engineering rationale

A dynamic inventory calculation advances from the immediately preceding converged state, so its K-values are the physically relevant seed. A cold default remains appropriate for independent VU flashes where the supplied state may be unrelated.

## Validation

Historical reproduction:

- Before #2639: 421–447 s, pass.
- #2639: 692.6 s and pressure-control failure.
- After the follow-up correctness changes: 13,097 s, pass.
- The scrubber test blob was identical before and after the 30.9× regression.

Static branch validation:

- Based on PR base `master` at `20cadfc`.
- Only the intended six Java files and the API changelog differ.
- Balanced source structure and no newly introduced lines over 120 characters.

CI follow-up:

- The first full matrix exposed a related cubic-EOS dynamic regression on Windows: warm-initializing every separator VU flash changed the compressor inventory trajectory.
- Dynamic warm initialization is now scoped to associating fluids, preserving the legacy cubic-EOS path while retaining the CPA optimization.
- Corrected final head `5bf2c00` passes the complete GitHub Actions matrix.
- `ThreePhaseGasScrubberTest`: 8 tests passed in 5.426 s on Ubuntu/Java 21 (previous regression: 13,097 s).
- `DynamicCompressorNotebookRegressionTest`: 3 tests passed in 5.893 s on Windows/Java 21.
- Java 21 fast suites: 10,850 tests, 0 failures, 0 errors on both Ubuntu and Windows.
- Java 21 slow shards: 96 + 74 + 44 tests, 0 failures and 0 errors.
- Java 8 fast suites: 10,850 tests, 0 failures, 0 errors on both Ubuntu and Windows.
- Javadoc, Spotless, pre-commit, CodeQL, PaperLab, and agent-skill cross-reference checks passed.