### PR TITLE
docs: repair DEXPI engineering guide

### DIFF
--- a/docs/engineering/dexpi-guide.md
+++ b/docs/engineering/dexpi-guide.md
@@ -66,8 +66,9 @@ file; it is a different official information model.
 
 ## Native DEXPI 2.0 export
 
-The following complete example builds and runs a small process, exports the Plant and Process profiles separately,
-checks both reports, and writes each report beside the exact XML it assessed:
+Save the following complete Java 8 program as `Dexpi20ExportExample.java`. It builds and runs a small process,
+exports the Plant and Process profiles separately, checks both reports, and writes each report beside the exact XML
+it assessed:
 
 ```java
 import java.io.File;
@@ -83,47 +84,55 @@ import neqsim.process.processmodel.dexpi.Dexpi20ProcessModelWriter;
 import neqsim.process.processmodel.dexpi.Dexpi20XmlWriter;
 import neqsim.thermo.system.SystemSrkEos;
 
-SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
-fluid.addComponent("methane", 0.8);
-fluid.addComponent("n-heptane", 0.2);
-fluid.setMixingRule("classic");
 
-Stream feed = new Stream("10-FEED-001", fluid);
-feed.setFlowRate(1000.0, "kg/hr");
-Separator separator = new Separator("10-VA-001", feed);
-Compressor compressor =
-    new Compressor("10-KA-001", separator.getGasOutStream());
-compressor.setOutletPressure(80.0);
+public final class Dexpi20ExportExample {
+  private Dexpi20ExportExample() {
+  }
 
-ProcessSystem process = new ProcessSystem();
-process.setName("DEXPI 2.0 example");
-process.add(feed);
-process.add(separator);
-process.add(compressor);
-process.run();
+  public static void main(String[] args) throws Exception {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-heptane", 0.2);
+    fluid.setMixingRule("classic");
 
-Path outputDirectory = new File("dexpi-output").toPath();
-Files.createDirectories(outputDirectory);
-Path plantXml = outputDirectory.resolve("plant.dexpi.xml");
-Path processXml = outputDirectory.resolve("process.dexpi.xml");
+    Stream feed = new Stream("10-FEED-001", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    Separator separator = new Separator("10-VA-001", feed);
+    Compressor compressor =
+        new Compressor("10-KA-001", separator.getGasOutStream());
+    compressor.setOutletPressure(80.0);
 
-Dexpi20ConformanceAssessment.Report plantReport =
-    Dexpi20XmlWriter.writeAndAssess(process, plantXml.toFile());
-Dexpi20ConformanceAssessment.Report processReport =
-    Dexpi20ProcessModelWriter.writeAndAssess(process, processXml.toFile());
+    ProcessSystem process = new ProcessSystem();
+    process.setName("DEXPI 2.0 example");
+    process.add(feed);
+    process.add(separator);
+    process.add(compressor);
+    process.run();
 
-if (!plantReport.isSchemaAndProfileConformant()
-    || !processReport.isSchemaAndProfileConformant()) {
-  throw new IllegalStateException(
-      "DEXPI 2.0 schema or supported-profile validation failed");
+    Path outputDirectory = new File("dexpi-output").toPath();
+    Files.createDirectories(outputDirectory);
+    Path plantXml = outputDirectory.resolve("plant.dexpi.xml");
+    Path processXml = outputDirectory.resolve("process.dexpi.xml");
+
+    Dexpi20ConformanceAssessment.Report plantReport =
+        Dexpi20XmlWriter.writeAndAssess(process, plantXml.toFile());
+    Dexpi20ConformanceAssessment.Report processReport =
+        Dexpi20ProcessModelWriter.writeAndAssess(process, processXml.toFile());
+
+    if (!plantReport.isSchemaAndProfileConformant()
+        || !processReport.isSchemaAndProfileConformant()) {
+      throw new IllegalStateException(
+          "DEXPI 2.0 schema or supported-profile validation failed");
+    }
+
+    Files.write(
+        outputDirectory.resolve("plant.dexpi.conformance.json"),
+        plantReport.toJson().getBytes(StandardCharsets.UTF_8));
+    Files.write(
+        outputDirectory.resolve("process.dexpi.conformance.json"),
+        processReport.toJson().getBytes(StandardCharsets.UTF_8));
+  }
 }
-
-Files.write(
-    outputDirectory.resolve("plant.dexpi.conformance.json"),
-    plantReport.toJson().getBytes(StandardCharsets.UTF_8));
-Files.write(
-    outputDirectory.resolve("process.dexpi.conformance.json"),
-    processReport.toJson().getBytes(StandardCharsets.UTF_8));
 ```
 
 The explicit `Files.write(...)` calls create the JSON sidecars; `writeAndAssess(...)` returns a report but does not

--- a/docs/engineering/dexpi-guide.md
+++ b/docs/engineering/dexpi-guide.md
@@ -4,8 +4,6 @@ description: "Practical guide to selecting, generating, validating, qualifying, 
 keywords: "DEXPI, DEXPI 2.0, Proteus, P&ID, PFD, BFD, pyDEXPI, engineering graph, conformance, round trip"
 ---
 
-# DEXPI Engineering Guide
-
 This guide helps you choose the correct NeqSim DEXPI workflow. DEXPI is an engineering information-exchange format:
 it can preserve process, plant, connectivity, instrumentation, and diagram information, but it is not itself a process
 simulation, an approved P&ID, or a construction release.
@@ -14,13 +12,13 @@ simulation, an approved P&ID, or a construction release.
 
 | Need | NeqSim entry point | Detailed documentation |
 | --- | --- | --- |
-| Import an existing Proteus-compatible P&ID and build a process scaffold | `DexpiXmlReader`, `DexpiSimulationBuilder` | [DEXPI import, export, and visualization](../integration/dexpi-reader) |
-| Export a quick Proteus-compatible P&ID | `DexpiXmlWriter.write(...)` | [DEXPI import, export, and visualization](../integration/dexpi-reader#exporting-to-dexpi-xml) |
-| Render through pyDEXPI | `DexpiXmlWriter.writeForPyDexpi(...)` or `DexpiDiagramBridge.exportForPyDexpi(...)` | [pyDEXPI-friendly export](../integration/dexpi-reader#pydexpi-friendly-export-namespace-omitted) |
-| Export a native DEXPI 2.0 P&ID Plant model | `Dexpi20XmlWriter.writeAndAssess(...)` | [DEXPI 2.0 conformance](../integration/dexpi-20-conformance) |
-| Export a native DEXPI 2.0 PFD/BFD Process model | `Dexpi20ProcessModelWriter.writeAndAssess(...)` | [DEXPI 2.0 conformance](../integration/dexpi-20-conformance#process-model-export) |
-| Generate a governed engineering package with DEXPI, registers, cases, and evidence | `EngineeringDeliverableCompiler` | [Standards-based DEXPI engineering generation](../integration/dexpi-engineering-generation) |
-| Generate a review-required P&ID proposal | `PidDesignSynthesizer`, `PidEngineeringPackageExporter` | [Governed P&ID design synthesis](../pid-design-synthesis) |
+| Import an existing Proteus-compatible P&ID and build a process scaffold | `DexpiXmlReader`, `DexpiSimulationBuilder` | [DEXPI import, export, and visualization](../integration/dexpi-reader.md) |
+| Export a quick Proteus-compatible P&ID | `DexpiXmlWriter.write(...)` | [DEXPI import, export, and visualization](../integration/dexpi-reader.md#exporting-to-dexpi-xml) |
+| Render through pyDEXPI | `DexpiXmlWriter.writeForPyDexpi(...)` or `DexpiDiagramBridge.exportForPyDexpi(...)` | [pyDEXPI-friendly export](../integration/dexpi-reader.md#pydexpi-friendly-export-namespace-omitted) |
+| Export a native DEXPI 2.0 P&ID Plant model | `Dexpi20XmlWriter.writeAndAssess(...)` | [DEXPI 2.0 conformance](../integration/dexpi-20-conformance.md) |
+| Export a native DEXPI 2.0 PFD/BFD Process model | `Dexpi20ProcessModelWriter.writeAndAssess(...)` | [DEXPI 2.0 conformance](../integration/dexpi-20-conformance.md#process-model-export) |
+| Generate a governed engineering package with DEXPI, registers, cases, and evidence | `EngineeringDeliverableCompiler` | [Standards-based DEXPI engineering generation](../integration/dexpi-engineering-generation.md) |
+| Generate a review-required P&ID proposal | `PidDesignSynthesizer`, `PidEngineeringPackageExporter` | [Governed P&ID design synthesis](../pid-design-synthesis.md) |
 
 ## Understand the exchange profiles
 
@@ -68,23 +66,69 @@ file; it is a different official information model.
 
 ## Native DEXPI 2.0 export
 
-Export and assess the Plant and Process models separately:
+The following complete example builds and runs a small process, exports the Plant and Process profiles separately,
+checks both reports, and writes each report beside the exact XML it assessed:
 
 ```java
-Dexpi20ConformanceAssessment.Report plantReport =
-    Dexpi20XmlWriter.writeAndAssess(process, new File("plant.dexpi.xml"));
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.processmodel.dexpi.Dexpi20ConformanceAssessment;
+import neqsim.process.processmodel.dexpi.Dexpi20ProcessModelWriter;
+import neqsim.process.processmodel.dexpi.Dexpi20XmlWriter;
+import neqsim.thermo.system.SystemSrkEos;
 
+SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+fluid.addComponent("methane", 0.8);
+fluid.addComponent("n-heptane", 0.2);
+fluid.setMixingRule("classic");
+
+Stream feed = new Stream("10-FEED-001", fluid);
+feed.setFlowRate(1000.0, "kg/hr");
+Separator separator = new Separator("10-VA-001", feed);
+Compressor compressor =
+    new Compressor("10-KA-001", separator.getGasOutStream());
+compressor.setOutletPressure(80.0);
+
+ProcessSystem process = new ProcessSystem();
+process.setName("DEXPI 2.0 example");
+process.add(feed);
+process.add(separator);
+process.add(compressor);
+process.run();
+
+Path outputDirectory = new File("dexpi-output").toPath();
+Files.createDirectories(outputDirectory);
+Path plantXml = outputDirectory.resolve("plant.dexpi.xml");
+Path processXml = outputDirectory.resolve("process.dexpi.xml");
+
+Dexpi20ConformanceAssessment.Report plantReport =
+    Dexpi20XmlWriter.writeAndAssess(process, plantXml.toFile());
 Dexpi20ConformanceAssessment.Report processReport =
-    Dexpi20ProcessModelWriter.writeAndAssess(process, new File("process.dexpi.xml"));
+    Dexpi20ProcessModelWriter.writeAndAssess(process, processXml.toFile());
 
 if (!plantReport.isSchemaAndProfileConformant()
     || !processReport.isSchemaAndProfileConformant()) {
-  throw new IllegalStateException("DEXPI 2.0 schema or supported-profile validation failed");
+  throw new IllegalStateException(
+      "DEXPI 2.0 schema or supported-profile validation failed");
 }
+
+Files.write(
+    outputDirectory.resolve("plant.dexpi.conformance.json"),
+    plantReport.toJson().getBytes(StandardCharsets.UTF_8));
+Files.write(
+    outputDirectory.resolve("process.dexpi.conformance.json"),
+    processReport.toJson().getBytes(StandardCharsets.UTF_8));
 ```
 
-Keep each conformance JSON beside the exact assessed XML. The report pins the official schema fingerprint, imported
-model versions, supported semantic profile, file digest, object counts, references, and findings.
+The explicit `Files.write(...)` calls create the JSON sidecars; `writeAndAssess(...)` returns a report but does not
+write that report to disk. Each report pins the official schema fingerprint, imported model versions, supported
+semantic profile, assessed-file digest, object counts, references, and findings.
 
 ## Validation and qualification ladder
 
@@ -110,7 +154,7 @@ engineering graph, calculation dependencies, connectivity, validation findings, 
 The canonical graph is the source of identity and provenance. DEXPI is an exchange representation of selected graph
 content; it is not the only engineering database.
 
-See [Engineering Deliverables and Handover](deliverables-and-handover) for the package layers and issue workflow.
+See [Engineering Deliverables and Handover](deliverables-and-handover.md) for the package layers and issue workflow.
 
 ## Importing a P&ID into simulation
 
@@ -165,8 +209,8 @@ classification, target-system loading, or final information acceptance.
 
 ## Related documentation
 
-- [DEXPI import, export, and visualization](../integration/dexpi-reader)
-- [DEXPI 2.0 native exchange and conformance](../integration/dexpi-20-conformance)
-- [Standards-based DEXPI engineering generation](../integration/dexpi-engineering-generation)
-- [Governed P&ID design synthesis](../pid-design-synthesis)
-- [Engineering Deliverables and Handover](deliverables-and-handover)
+- [DEXPI import, export, and visualization](../integration/dexpi-reader.md)
+- [DEXPI 2.0 native exchange and conformance](../integration/dexpi-20-conformance.md)
+- [Standards-based DEXPI engineering generation](../integration/dexpi-engineering-generation.md)
+- [Governed P&ID design synthesis](../pid-design-synthesis.md)
+- [Engineering Deliverables and Handover](deliverables-and-handover.md)

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
@@ -39,6 +39,35 @@ class Dexpi20ProcessModelWriterTest {
   }
 
   @Test
+  void documentationExampleWritesAssessedPlantAndProcessExchanges() throws Exception {
+    ProcessSystem process = documentationProcess();
+    process.run();
+
+    Path outputDirectory = temporaryDirectory.resolve("dexpi-output");
+    Files.createDirectories(outputDirectory);
+    Path plantXml = outputDirectory.resolve("plant.dexpi.xml");
+    Path processXml = outputDirectory.resolve("process.dexpi.xml");
+
+    Dexpi20ConformanceAssessment.Report plantReport =
+        Dexpi20XmlWriter.writeAndAssess(process, plantXml.toFile());
+    Dexpi20ConformanceAssessment.Report processReport =
+        Dexpi20ProcessModelWriter.writeAndAssess(process, processXml.toFile());
+
+    assertTrue(plantReport.isSchemaAndProfileConformant(), plantReport.getErrors().toString());
+    assertTrue(processReport.isSchemaAndProfileConformant(), processReport.getErrors().toString());
+
+    Path plantReportFile = outputDirectory.resolve("plant.dexpi.conformance.json");
+    Path processReportFile = outputDirectory.resolve("process.dexpi.conformance.json");
+    Files.write(plantReportFile, plantReport.toJson().getBytes(StandardCharsets.UTF_8));
+    Files.write(processReportFile, processReport.toJson().getBytes(StandardCharsets.UTF_8));
+
+    assertTrue(Files.size(plantXml) > 0L);
+    assertTrue(Files.size(processXml) > 0L);
+    assertTrue(Files.size(plantReportFile) > 0L);
+    assertTrue(Files.size(processReportFile) > 0L);
+  }
+
+  @Test
   void plantAndProcessAssessmentsCannotBeInterchanged() throws Exception {
     Path plant = temporaryDirectory.resolve("plant.dexpi.xml");
     Dexpi20XmlWriter.write(process(), plant.toFile());
@@ -76,6 +105,26 @@ class Dexpi20ProcessModelWriterTest {
     assertTrue(report.getErrors().toString().contains("NominalDirection"));
     assertTrue(report.getErrors().toString().contains("ConnectorReference"));
     assertTrue(report.getErrors().toString().contains("Source reference"));
+  }
+
+  private ProcessSystem documentationProcess() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-heptane", 0.2);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("10-FEED-001", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    Separator separator = new Separator("10-VA-001", feed);
+    Compressor compressor = new Compressor("10-KA-001", separator.getGasOutStream());
+    compressor.setOutletPressure(80.0);
+
+    ProcessSystem process = new ProcessSystem();
+    process.setName("DEXPI 2.0 example");
+    process.add(feed);
+    process.add(separator);
+    process.add(compressor);
+    return process;
   }
 
   private ProcessSystem process() {

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
@@ -48,10 +48,9 @@ class Dexpi20ProcessModelWriterTest {
     Path plantXml = outputDirectory.resolve("plant.dexpi.xml");
     Path processXml = outputDirectory.resolve("process.dexpi.xml");
 
-    Dexpi20ConformanceAssessment.Report plantReport =
-        Dexpi20XmlWriter.writeAndAssess(process, plantXml.toFile());
-    Dexpi20ConformanceAssessment.Report processReport =
-        Dexpi20ProcessModelWriter.writeAndAssess(process, processXml.toFile());
+    Dexpi20ConformanceAssessment.Report plantReport = Dexpi20XmlWriter.writeAndAssess(process, plantXml.toFile());
+    Dexpi20ConformanceAssessment.Report processReport = Dexpi20ProcessModelWriter.writeAndAssess(process,
+        processXml.toFile());
 
     assertTrue(plantReport.isSchemaAndProfileConformant(), plantReport.getErrors().toString());
     assertTrue(processReport.isSchemaAndProfileConformant(), processReport.getErrors().toString());


### PR DESCRIPTION
## Documentation campaign batch D039

Links #2499.

### Frozen scope

- `docs/engineering/dexpi-guide.md`
- `src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java` only for executable documentation coverage

This batch does not overlap open PRs #2647, #2650, or #2632.

### Confirmed defects and root cause

- **Medium — Jekyll title duplication:** front matter already supplies the page title, but the source repeated it as an H1.
- **Medium — source-link conformance:** 13 internal-link occurrences (covering 7 documentation targets and 2 fragment targets) omitted the required `.md` suffix.
- **High — non-executable and misleading native-export example:** the snippet omitted imports and process construction/execution, and the prose told readers to retain conformance JSON without showing that `writeAndAssess(...)` only returns a report. The writers do not persist JSON sidecars automatically.

### Repairs

- Removed the duplicate source H1.
- Normalized every internal documentation link to an existing `.md` source target while retaining validated fragments.
- Replaced the partial snippet with a directly runnable Java 8 program (`Dexpi20ExportExample.java`) that:
  - creates and converges a small SRK separator/compressor process;
  - exports and assesses native DEXPI 2.0 Plant and Process models separately;
  - checks both supported-profile results; and
  - explicitly writes both report JSON sidecars beside the assessed XML.
- Added a focused regression that executes every documented API call and asserts all four output files are non-empty.

### Validation performed before PR

- Compared every documented API call with current `Dexpi20XmlWriter`, `Dexpi20ProcessModelWriter`, and `Dexpi20ConformanceAssessment` source at `3955bde`.
- Confirmed the Plant/Process report semantics against the existing DEXPI tests.
- Verified all 13 internal link occurrences, both target fragments, and all four linked notebooks.
- Confirmed front matter, zero duplicate H1s, balanced code fences, no equations/images/raw HTML, and a two-file-only diff.
- Confirmed the guide remains indexed exactly once in both `docs/engineering/index.md` and `docs/REFERENCE_MANUAL_INDEX.md`.

### Final validation at exact head `0e7fa0b`

Passed:

- `Dexpi20ProcessModelWriterTest`: 4/4 on Ubuntu and Windows with Java 8 and Java 21
- fast suites: 10,851 tests on each of Ubuntu/Windows Java 21 and Ubuntu/Windows Java 8, with zero failures or errors
- Ubuntu Java 21 slow shards: 96, 74, and 44 tests, with zero failures or errors
- Spotless and pre-commit
- Javadoc and agent-reference validation
- documentation search coverage
- CodeQL
- process-to-engineering workflow
- exact-head Copilot review of 2/2 files, with no new comments or review threads

Copilot's one suppressed observation was technically accepted: the example is a named class with
`main(...) throws Exception`. The accepted change is validated across all four Java/platform matrices.

No rendered-site artifact is currently available, so visual browser inspection is not claimed. No external links were changed. No notebooks, production code, equations, images, or public APIs are changed.

### Next rotation scope

After D039 is merged and recorded, continue the engineering-design/safety/DEXPI/field-development rotation with a fresh non-overlapping bounded scan.