### PR TITLE
Preserve SIS and HIPPS semantics in DEXPI export

### DIFF
--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -55,6 +55,7 @@ import neqsim.process.equipment.splitter.Splitter;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.equipment.tank.Tank;
+import neqsim.process.equipment.valve.HIPPSValve;
 import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.measurementdevice.LevelTransmitter;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
@@ -83,6 +84,8 @@ public final class DexpiXmlWriter {
   private static final org.apache.logging.log4j.Logger logger = org.apache.logging.log4j.LogManager
       .getLogger(DexpiXmlWriter.class);
   private static final Pattern NON_IDENTIFIER = Pattern.compile("[^A-Za-z0-9_-]");
+  private static final Pattern COMMON_SAFETY_TRIP_TAG =
+      Pattern.compile("^(?:[PLTF](?:S|A)(?:HH|LL)|FSL)$");
   private static final transient ThreadLocal<DecimalFormat> DECIMAL_FORMAT = ThreadLocal.withInitial(() -> {
     DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(Locale.ROOT);
     DecimalFormat format = new DecimalFormat("0.############", symbols);
@@ -1310,6 +1313,9 @@ public final class DexpiXmlWriter {
     if (genericAttributes.hasChildNodes()) {
       element.appendChild(genericAttributes);
     }
+    if (unit instanceof HIPPSValve) {
+      appendHippsSafetyMetadata(document, element, (HIPPSValve) unit, null);
+    }
 
     return element;
   }
@@ -1874,6 +1880,7 @@ public final class DexpiXmlWriter {
     for (Map.Entry<String, MeasurementDeviceInterface> entry : transmitters.entrySet()) {
       String tag = entry.getKey();
       MeasurementDeviceInterface device = entry.getValue();
+      HIPPSValve hippsFunction = findHippsForTransmitter(device, processSystem);
 
       String[] parsed = parseIsaTag(tag);
       String category = parsed[0];
@@ -1941,6 +1948,9 @@ public final class DexpiXmlWriter {
         appendGenericAttribute(document, pifAttrs, "TagConformanceWarning", tagCheck.getMessage());
       }
       pif.appendChild(pifAttrs);
+      if (hippsFunction != null) {
+        appendHippsSafetyMetadata(document, pif, hippsFunction, tag);
+      }
 
       // ConnectionPoints (5 signal nodes)
       if (hasPosition) {
@@ -2019,7 +2029,7 @@ public final class DexpiXmlWriter {
       pif.appendChild(psgf);
 
       // System assignment (DCS by default; SIS for safety tags)
-      String systemAssignment = detectSafetySystem(tag) ? "SIS" : "DCS";
+      String systemAssignment = hippsFunction != null || detectSafetySystem(tag) ? "SIS" : "DCS";
       Element sysAttrs = document.createElement("GenericAttributes");
       sysAttrs.setAttribute("Set", "SystemAssignment");
       appendGenericAttribute(document, sysAttrs, "ControlSystem", systemAssignment);
@@ -2027,7 +2037,8 @@ public final class DexpiXmlWriter {
 
       // SIL marking for safety-instrumented functions (NORSOK Z-003 / IEC 61511)
       if ("SIS".equals(systemAssignment) && hasPosition) {
-        DexpiLayoutEngine.appendSilMarker(document, pif, 1, cx, cy);
+        int silRating = hippsFunction == null ? 1 : hippsFunction.getSILRating();
+        DexpiLayoutEngine.appendSilMarker(document, pif, silRating, cx, cy);
       }
 
       // Look for matching controller (e.g. PT-xxx -> PC-xxx)
@@ -2783,6 +2794,9 @@ public final class DexpiXmlWriter {
    * @return the DEXPI ComponentClass (GlobeValve, GateValve, BallValve, CheckValve, ButterflyValve)
    */
   private static String reverseMapValveClass(ProcessEquipmentInterface unit) {
+    if (unit instanceof HIPPSValve) {
+      return "GateValve";
+    }
     String name = unit.getName();
     if (name != null) {
       String upper = name.toUpperCase(Locale.ROOT);
@@ -2818,7 +2832,64 @@ public final class DexpiXmlWriter {
     String prefix = dashIndex > 0 ? tag.substring(0, dashIndex) : tag;
     String upper = prefix.toUpperCase(Locale.ROOT);
     return upper.startsWith("XV") || upper.startsWith("SD") || upper.startsWith("ZS") || upper.startsWith("SV")
-        || upper.contains("ESD") || upper.contains("HIPPS");
+        || upper.contains("ESD") || upper.contains("HIPPS") || COMMON_SAFETY_TRIP_TAG.matcher(upper).matches();
+  }
+
+  /**
+   * Finds the HIPPS final element that uses a measurement device as one of its trip sensors.
+   *
+   * @param device measurement device to locate
+   * @param processSystem process model containing the HIPPS valve
+   * @return associated HIPPS valve, or {@code null} when the device is not part of a HIPPS function
+   */
+  private static HIPPSValve findHippsForTransmitter(MeasurementDeviceInterface device, ProcessSystem processSystem) {
+    for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
+      if (unit instanceof HIPPSValve) {
+        HIPPSValve hipps = (HIPPSValve) unit;
+        for (MeasurementDeviceInterface configuredDevice : hipps.getPressureTransmitters()) {
+          if (configuredDevice == device) {
+            return hipps;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Appends explicit IEC 61511 metadata for a HIPPS sensor or final element.
+   *
+   * @param document XML document
+   * @param parent element receiving the metadata
+   * @param hipps HIPPS final element
+   * @param sensorTag sensor tag, or {@code null} when describing the final element
+   */
+  private static void appendHippsSafetyMetadata(Document document, Element parent, HIPPSValve hipps,
+      String sensorTag) {
+    Element safetyAttributes = document.createElement("GenericAttributes");
+    safetyAttributes.setAttribute("Set", "SafetyInstrumentedFunction");
+    appendGenericAttribute(document, safetyAttributes, "SafetyFunctionType", "HIPPS");
+    appendGenericAttribute(document, safetyAttributes, "SafetyFunctionTag", hipps.getName());
+    appendGenericAttribute(document, safetyAttributes, "FunctionalRole", sensorTag == null ? "FinalElement" : "Sensor");
+    appendGenericAttribute(document, safetyAttributes, "SensorTag", sensorTag);
+
+    List<String> sensorTags = new ArrayList<>();
+    for (MeasurementDeviceInterface sensor : hipps.getPressureTransmitters()) {
+      if (!isBlank(sensor.getName())) {
+        sensorTags.add(sensor.getName());
+      }
+    }
+    appendGenericAttribute(document, safetyAttributes, "SensorTags", String.join(",", sensorTags));
+    appendGenericAttribute(document, safetyAttributes, "FinalElementTag", hipps.getName());
+    appendGenericAttribute(document, safetyAttributes, "SafetyIntegrityLevel", String.valueOf(hipps.getSILRating()));
+    if (hipps.getVotingLogic() != null) {
+      appendGenericAttribute(document, safetyAttributes, "VotingArchitecture", hipps.getVotingLogic().getNotation());
+    }
+    appendGenericAttribute(document, safetyAttributes, "SafeState", "Closed");
+    appendNumericAttribute(document, safetyAttributes, "ProofTestInterval", hipps.getProofTestInterval(), "h");
+    appendNumericAttribute(document, safetyAttributes, "ClosureTime", hipps.getClosureTime(), "s");
+    appendGenericAttribute(document, safetyAttributes, "ControlSystem", "SIS");
+    parent.appendChild(safetyAttributes);
   }
 
   /**

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -84,8 +84,7 @@ public final class DexpiXmlWriter {
   private static final org.apache.logging.log4j.Logger logger = org.apache.logging.log4j.LogManager
       .getLogger(DexpiXmlWriter.class);
   private static final Pattern NON_IDENTIFIER = Pattern.compile("[^A-Za-z0-9_-]");
-  private static final Pattern COMMON_SAFETY_TRIP_TAG =
-      Pattern.compile("^(?:[PLTF](?:S|A)(?:HH|LL)|FSL)$");
+  private static final Pattern COMMON_SAFETY_TRIP_TAG = Pattern.compile("^(?:[PLTF](?:S|A)(?:HH|LL)|FSL)$");
   private static final transient ThreadLocal<DecimalFormat> DECIMAL_FORMAT = ThreadLocal.withInitial(() -> {
     DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(Locale.ROOT);
     DecimalFormat format = new DecimalFormat("0.############", symbols);
@@ -2864,8 +2863,7 @@ public final class DexpiXmlWriter {
    * @param hipps HIPPS final element
    * @param sensorTag sensor tag, or {@code null} when describing the final element
    */
-  private static void appendHippsSafetyMetadata(Document document, Element parent, HIPPSValve hipps,
-      String sensorTag) {
+  private static void appendHippsSafetyMetadata(Document document, Element parent, HIPPSValve hipps, String sensorTag) {
     Element safetyAttributes = document.createElement("GenericAttributes");
     safetyAttributes.setAttribute("Set", "SafetyInstrumentedFunction");
     appendGenericAttribute(document, safetyAttributes, "SafetyFunctionType", "HIPPS");

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.processmodel.dexpi;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -17,7 +18,9 @@ import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.separator.ThreePhaseSeparator;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.tank.Tank;
+import neqsim.process.equipment.valve.HIPPSValve;
 import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.measurementdevice.PressureTransmitter;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -626,6 +629,92 @@ public class DexpiXmlWriterTest extends NeqSimTest {
     String resetXml = resetOut.toString(StandardCharsets.UTF_8.name());
     assertTrue(resetXml.contains("SchemaVersion=\"4.1.1\""),
         "Resetting to PROTEUS_4_1_1 should restore the 4.1.1 schema version");
+  }
+
+  /**
+   * Tests that common high-high, low-low, and low-flow trip tags are exported as SIS instruments while an ordinary
+   * process transmitter remains assigned to the DCS.
+   *
+   * @throws IOException if writing fails
+   */
+  @Test
+  public void testCommonSafetyTripTagsUseSisAssignment() throws IOException {
+    Stream feed = createFeedStream();
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+
+    String[] safetyTags = { "PSHH-101", "PAHH-102", "LSHH-103", "TSHH-104", "FSL-105" };
+    for (String tag : safetyTags) {
+      process.add(new PressureTransmitter(tag, feed));
+    }
+    process.add(new PressureTransmitter("PT-106", feed));
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.writeDexpi20(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    for (String tag : safetyTags) {
+      assertTrue(xml.contains("Name=\"TagNameAssignmentClass\" Value=\"" + tag + "\""),
+          tag + " should be present in the export");
+    }
+    assertEquals(safetyTags.length, countOccurrences(xml, "Name=\"ControlSystem\" Value=\"SIS\""),
+        "Every safety-trip instrument should be assigned to SIS");
+    assertEquals(1, countOccurrences(xml, "Name=\"ControlSystem\" Value=\"DCS\""),
+        "The ordinary process transmitter should remain assigned to DCS");
+  }
+
+  /**
+   * Tests that a HIPPS loop retains its final-element class, SIL rating, voting architecture, and sensor membership.
+   *
+   * @throws IOException if writing fails
+   */
+  @Test
+  public void testHippsSafetySemanticsExport() throws IOException {
+    Stream feed = createFeedStream();
+    HIPPSValve hipps = new HIPPSValve("HIPPS-XV-101", feed);
+    hipps.setOutletPressure(45.0);
+    hipps.setSILRating(3);
+    hipps.setVotingLogic(HIPPSValve.VotingLogic.TWO_OUT_OF_THREE);
+    hipps.setProofTestInterval(8760.0);
+    hipps.setClosureTime(6.0);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(hipps);
+    String[] sensorTags = { "PSHH-101A", "PSHH-101B", "PSHH-101C" };
+    for (String tag : sensorTags) {
+      PressureTransmitter transmitter = new PressureTransmitter(tag, feed);
+      hipps.addPressureTransmitter(transmitter);
+      process.add(transmitter);
+    }
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.writeDexpi20(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    int hippsId = xml.indexOf("ID=\"HIPPS-XV-101\"");
+    assertTrue(hippsId >= 0, "HIPPS final element should be present");
+    int componentStart = xml.lastIndexOf("<PipingComponent", hippsId);
+    int componentEnd = xml.indexOf("</PipingComponent>", hippsId);
+    assertTrue(componentStart >= 0 && componentEnd > hippsId, "HIPPS should export as a piping component");
+    String hippsComponent = xml.substring(componentStart, componentEnd);
+    assertTrue(hippsComponent.contains("ComponentClass=\"GateValve\""),
+        "HIPPS final element should not be reduced to a generic control globe valve");
+    assertFalse(hippsComponent.contains("ComponentClass=\"GlobeValve\""),
+        "HIPPS final element must preserve its shutdown-valve identity");
+
+    assertTrue(xml.contains("Name=\"SafetyFunctionTag\" Value=\"HIPPS-XV-101\""));
+    assertTrue(xml.contains("Name=\"SafetyIntegrityLevel\" Value=\"3\""));
+    assertTrue(xml.contains("Name=\"VotingArchitecture\" Value=\"2oo3\""));
+    assertTrue(xml.contains("Name=\"FinalElementTag\" Value=\"HIPPS-XV-101\""));
+    assertTrue(xml.contains("Name=\"SensorTags\" Value=\"PSHH-101A,PSHH-101B,PSHH-101C\""));
+    assertTrue(xml.contains("Name=\"SafeState\" Value=\"Closed\""));
+    assertTrue(xml.contains("Name=\"ProofTestInterval\" Unit=\"h\" Value=\"8760\""));
+    assertTrue(xml.contains("Name=\"ClosureTime\" Unit=\"s\" Value=\"6\""));
+    assertEquals(3, countOccurrences(xml, "Name=\"FunctionalRole\" Value=\"Sensor\""));
+    assertEquals(1, countOccurrences(xml, "Name=\"FunctionalRole\" Value=\"FinalElement\""));
+    assertEquals(4, countOccurrences(xml, "Name=\"SafetyIntegrityLevel\" Value=\"3\""),
+        "SIL 3 should be available on the final element and each of the three trip sensors");
   }
 
   /**


### PR DESCRIPTION
## Summary

- classify common safety-trip transmitter tags such as PSHH, PAHH, LSHH, TSHH, and FSL as SIS rather than DCS
- preserve HIPPS final-element semantics by exporting `HIPPSValve` as a shutdown-style gate valve
- export explicit HIPPS safety-function metadata, including SIL, voting architecture, sensor membership, safe state, proof-test interval, and closure time
- use the configured HIPPS SIL rating for diagram markers instead of hard-coding SIL 1
- add DEXPI 2.0 regression coverage for safety-trip tags and a SIL 3, 2oo3 HIPPS loop

## Validation

- compiled the modified exporter against NeqSim 3.16.0
- compiled the updated test source against the NeqSim 3.16.0 API
- ran a focused standalone regression covering the `writeDexpi20` path; SIS classification and HIPPS metadata checks passed
- verified the branch is two commits ahead of current `master`, with changes limited to the exporter and its test

Closes #2653