### PR TITLE
docs: correct ISO 6976 regression evidence

### DIFF
--- a/docs/wiki/gas_quality_standards_from_tests.md
+++ b/docs/wiki/gas_quality_standards_from_tests.md
@@ -16,19 +16,21 @@ rule, and performs a TP flash. `testCalculate` then configures
 `Standard_ISO6976` with a 0 °C volume reference, a 15.55 °C combustion-energy
 reference, a real-gas reference state, and a volume basis.
 
-`getValue(...)` reports energy properties in kJ per cubic metre on the configured
-reference basis. The table converts those assertions to MJ/m³ for readability.
-`testCalculate` asserts GCV and WI. `testCalculate2` uses a separately initialized
-SRK system with the same four component amounts and asserts relative density.
+`getUnit(...)` labels energy properties as `KJ/Nm3`. In this API, the cubic metre
+is evaluated at the configured volume-reference temperature; it is not an
+unqualified geometric m³. The table converts the kJ/Nm³ assertions to MJ/Nm³ for
+readability. `testCalculate` asserts GCV and WI. `testCalculate2` uses a
+separately initialized SRK system with the same four component amounts and
+asserts relative density.
 
 | Property | Regression value | Unit |
 | --- | ---: | --- |
-| Superior calorific value (`GCV`) | 39.61457 | MJ/m³ |
-| Superior Wobbe index (`WI`) | 51.70101 | MJ/m³ |
+| Superior calorific value (`GCV`) | 39.61457 | MJ/Nm³ |
+| Superior Wobbe index (`WI`) | 51.70101 | MJ/Nm³ |
 | Relative density | 0.5870995 | dimensionless |
 
-The exact energy assertions before conversion are 39614.56783352743 kJ/m³ for
-GCV and 51701.01275822569 kJ/m³ for WI.
+The exact energy assertions before conversion are 39614.56783352743 kJ/Nm³ for
+GCV and 51701.01275822569 kJ/Nm³ for WI.
 
 The superior Wobbe index is related to the superior calorific value by
 
@@ -46,9 +48,9 @@ basis with every result.
 `testCalculate` verifies that `WI` and `WobbeIndex` both resolve to
 `SuperiorWobbeIndex`. The separate `testWIAliasVariesWithComposition` regression
 prevents the alias from returning a composition-independent value: its lean
-98 mol% methane / 2 mol% ethane test target is approximately 53860 kJ/m³
-(53.86 MJ/m³), while its richer methane/ethane/propane target is approximately
-58380 kJ/m³ (58.38 MJ/m³).
+98 mol% methane / 2 mol% ethane test target is approximately 53860 kJ/Nm³
+(53.86 MJ/Nm³), while its richer methane/ethane/propane target is approximately
+58380 kJ/Nm³ (58.38 MJ/Nm³).
 
 These values are software regression anchors for the specified fixtures and
 reference conditions. They are not universal sales-gas limits.
@@ -59,18 +61,18 @@ reference conditions. They are not universal sales-gas limits.
 temperatures. When a value is requested, `checkReferenceCondition()` changes an
 unsupported combustion-energy reference to 25 °C and an unsupported volume
 reference to 15 °C, and logs both corrections. The test asserts
-37499.35392575905 kJ/m³ (37.49935 MJ/m³) for the resulting GCV.
+37499.35392575905 kJ/Nm³ (37.49935 MJ/Nm³) for the resulting GCV.
 
 This fallback keeps the calculation running, but it also changes the requested
 basis. Validate reference temperatures before calculation instead of treating
-the fallback as input validation. For the 1995 implementation, use the volume
-reference temperatures with implemented corrections—0, 15, 15.55, or 20 °C—as
-explained in the primary guide.
+the fallback as input validation. Although `checkReferenceCondition()` accepts 25 °C as a volume reference,
+explicit volume-dependent corrections are implemented only for 0, 15, 15.55,
+and 20 °C. Use one of those four values, as explained in the primary guide.
 
 ## Pseudo-components and unsupported species
 
 `testCalculateWithPSeudo` adds a `C10` TBP fraction and asserts a resulting GCV
-of 42377.76099372482 kJ/m³ (42.37776 MJ/m³). This proves that the current fallback
+of 42377.76099372482 kJ/Nm³ (42.37776 MJ/Nm³). This proves that the current fallback
 route remains numerically stable for that fixture; it does not prove explicit
 ISO 6976 coverage for the pseudo-component.
 

--- a/docs/wiki/gas_quality_standards_from_tests.md
+++ b/docs/wiki/gas_quality_standards_from_tests.md
@@ -18,8 +18,8 @@ reference, a real-gas reference state, and a volume basis.
 
 `getValue(...)` reports energy properties in kJ per cubic metre on the configured
 reference basis. The table converts those assertions to MJ/m³ for readability.
-`testCalculate` asserts GCV and WI; `testCalculate2` asserts relative density for
-the same composition and reference conditions.
+`testCalculate` asserts GCV and WI. `testCalculate2` uses a separately initialized
+SRK system with the same four component amounts and asserts relative density.
 
 | Property | Regression value | Unit |
 | --- | ---: | --- |
@@ -82,10 +82,11 @@ approximation before using the result for design, fiscal, or contractual work.
 
 ## Full-property and stream coverage
 
-`testCalculate2` checks the 0/15.55 °C fixture across superior and inferior
-calorific values, superior and inferior Wobbe indices, relative density,
-compression factor, and molar mass. `testCalculate3` uses a different gas at
-15/15 °C and verifies the same property family. It also confirms that
+`testCalculate2` creates a separate SRK system, loads the component database,
+uses mixing rule 2, and configures the standard at 0/15.55 °C. It checks
+superior and inferior calorific values, superior and inferior Wobbe indices,
+relative density, compression factor, and molar mass. `testCalculate3` uses a
+different gas at 15/15 °C and verifies the same property family. It also confirms that
 `Stream.getGCV(...)` and `Stream.getWI(...)` agree with the standard calculation
 after the stream has run.
 

--- a/docs/wiki/gas_quality_standards_from_tests.md
+++ b/docs/wiki/gas_quality_standards_from_tests.md
@@ -1,38 +1,99 @@
 ---
-title: "Gas quality standards validated by ISO 6976 tests"
-description: "The ISO 6976 calorific value and Wobbe index calculations are verified in `Standard_ISO6976Test`. This page summarizes the tested configurations and equations so you can align custom gas-quality runs ..."
+title: "ISO 6976 regression evidence"
+description: "Trace the current ISO 6976 gas-quality regression coverage for calorific value, Wobbe index, reference conditions, aliases, and unsupported components."
 ---
 
-# Gas quality standards validated by ISO 6976 tests
+This page explains the numerical evidence in
+[`Standard_ISO6976Test`](../../src/test/java/neqsim/standards/gasquality/Standard_ISO6976Test.java).
+Use it with the [ISO 6976 calculation guide](../standards/iso6976_calorific_values.md),
+which documents the API, editions, units, and engineering boundaries.
 
-The ISO 6976 calorific value and Wobbe index calculations are verified in `Standard_ISO6976Test`. This page summarizes the tested configurations and equations so you can align custom gas-quality runs with the regression suite.
+## Reference fixture and expected values
 
-## Base ISO 6976 calculation
+`testCalculate` builds an SRK gas at 20 °C and 1.0 bara, adds methane, ethane,
+nitrogen, and carbon dioxide, applies the classic mixing rule, and performs a
+TP flash. It then configures `Standard_ISO6976` with a 0 °C volume reference, a
+15.55 °C combustion-energy reference, a real-gas reference state, and a volume
+basis.
 
-`testCalculate` initializes a dry natural gas at 20 °C and 1 bar with a classic mixing rule and executes `Standard_ISO6976.calculate()` using volume-based reference conditions (0 °C volume base, 15.55 °C energy base).【F:src/test/java/neqsim/standards/gasquality/Standard_ISO6976Test.java†L23-L47】 The test confirms the gross calorific value (GCV) of 39,614.57 kJ/Sm³ and Wobbe index (WI) of 44.61 MJ/Sm³.
+The current assertions are:
 
-The Wobbe index relation checked in the test is
+| Property | Regression value | Unit |
+| --- | ---: | --- |
+| Superior calorific value (`GCV`) | 39.61457 | MJ/m³ |
+| Superior Wobbe index (`WI`) | 51.70101 | MJ/m³ |
+| Relative density | 0.5870995 | dimensionless |
 
-$
-WI = \frac{GCV}{\sqrt{\rho_r}}\ ,
-$
+The superior Wobbe index is related to the superior calorific value by
 
-where $\rho_r$ is the relative density. Matching the test values indicates both combustion energy and density normalization are consistent with ISO 6976.
+$$
+W_s = \frac{H_s}{\sqrt{d}}
+$$
 
-## Handling reference condition overrides
+where $H_s$ is the superior calorific value on the selected basis and $d$ is
+the relative density on the same reference basis. Report both reference
+temperatures, the real or ideal reference state, and the volume, mass, or molar
+basis with every result.
 
-`testCalculateWithWrongReferenceState` shows that if non-standard reference temperatures are provided, the standard falls back to defined bases (15 °C for energy, 0 °C for volume) while still computing GCV and WI.【F:src/test/java/neqsim/standards/gasquality/Standard_ISO6976Test.java†L49-L73】 Use this behavior to guard against user input errors without failing calculations.
+## Aliases and composition sensitivity
 
-## Including pseudo-components
+`testCalculate` verifies that `WI` and `WobbeIndex` both resolve to
+`SuperiorWobbeIndex`. The separate `testWIAliasVariesWithComposition` regression
+prevents the alias from returning a composition-independent value: its lean
+98 mol% methane / 2 mol% ethane gas gives approximately 53.86 MJ/m³, while its
+richer methane/ethane/propane gas gives approximately 58.38 MJ/m³.
 
-`testCalculateWithPSeudo` adds a TBP pseudo-fraction to the gas and re-runs the calculation to verify heavier fractions contribute to higher heating value (GCV ≈ 42,378 kJ/Sm³).【F:src/test/java/neqsim/standards/gasquality/Standard_ISO6976Test.java†L75-L96】 The setup demonstrates that ISO 6976 evaluation tolerates lumped heavy ends when a classic mixing rule and full flash initialization are applied.
+These values are software regression anchors for the specified fixtures and
+reference conditions. They are not universal sales-gas limits.
 
-## Full-property audit
+## Invalid reference temperatures
 
-`testCalculate2` and `testCalculate3` sweep alternative temperatures and reference pairs to assert a complete property set: compression factor, superior/inferior calorific values, Wobbe indices, relative density, and molar mass.【F:src/test/java/neqsim/standards/gasquality/Standard_ISO6976Test.java†L98-L200】 The tests also run a process `Stream` to ensure downstream WI reporting matches the standard calculation.
+`testCalculateWithWrongReferenceState` deliberately sets unsupported reference
+temperatures. When a value is requested, `checkReferenceCondition()` changes an
+unsupported combustion-energy reference to 25 °C and an unsupported volume
+reference to 15 °C, and logs both corrections. The resulting GCV assertion is
+37.49935 MJ/m³.
 
-When configuring your own gas-quality evaluations:
+This fallback keeps the calculation running, but it also changes the requested
+basis. Validate reference temperatures before calculation instead of treating
+the fallback as input validation. For the 1995 implementation, use the volume
+reference temperatures with implemented corrections—0, 15, 15.55, or 20 °C—as
+explained in the primary guide.
 
-- Always initialize the thermodynamic system (`init(0)`) before calling the standard.
-- Select reference temperatures explicitly; unexpected inputs will be corrected but should be avoided for traceability.
-- Validate both GCV and Wobbe index against expected tolerances to confirm combustion properties are consistent.
+## Pseudo-components and unsupported species
+
+`testCalculateWithPSeudo` adds a `C10` TBP fraction and asserts a resulting GCV
+of 42.37776 MJ/m³. This proves that the current fallback route remains
+numerically stable for that fixture; it does not prove explicit ISO 6976
+coverage for the pseudo-component.
+
+For hydrocarbon, TBP, and plus fractions not found in the ISO data table,
+`Standard_ISO6976` substitutes n-heptane data and records the original component
+name in `getComponentsNotDefinedByStandard()`. Other unsupported component types
+use different fallback mappings. Always inspect that list and disclose any
+approximation before using the result for design, fiscal, or contractual work.
+
+## Full-property and stream coverage
+
+`testCalculate2` checks the 0/15.55 °C fixture across superior and inferior
+calorific values, superior and inferior Wobbe indices, relative density,
+compression factor, and molar mass. `testCalculate3` uses a different gas at
+15/15 °C and verifies the same property family. It also confirms that
+`Stream.getGCV(...)` and `Stream.getWI(...)` agree with the standard calculation
+after the stream has run.
+
+Initialize or flash the thermodynamic system so that its composition and state
+are current before constructing the standard. Use the same preparation,
+reference conditions, and basis when comparing a custom calculation with a
+regression value.
+
+## Interpretation boundary
+
+The tests establish repeatable NeqSim results for defined inputs and catch
+software regressions in aliases, reference handling, composition response, and
+stream integration. They do not establish sampling quality, measurement
+uncertainty, laboratory conformity, contractual compliance, or certification to
+a particular ISO 6976 edition.
+
+See the [standards package overview](../standards/README.md) for the broader
+measurement and reporting checks.

--- a/docs/wiki/gas_quality_standards_from_tests.md
+++ b/docs/wiki/gas_quality_standards_from_tests.md
@@ -10,11 +10,11 @@ which documents the API, editions, units, and engineering boundaries.
 
 ## Reference fixture and expected values
 
-`testCalculate` builds an SRK gas at 20 °C and 1.0 bara, adds methane, ethane,
-nitrogen, and carbon dioxide, applies the classic mixing rule, and performs a
-TP flash. It then configures `Standard_ISO6976` with a 0 °C volume reference, a
-15.55 °C combustion-energy reference, a real-gas reference state, and a volume
-basis.
+The shared `setUpBeforeClass` fixture builds an SRK gas at 20 °C and 1.0 bara,
+adds methane, ethane, nitrogen, and carbon dioxide, applies the classic mixing
+rule, and performs a TP flash. `testCalculate` then configures
+`Standard_ISO6976` with a 0 °C volume reference, a 15.55 °C combustion-energy
+reference, a real-gas reference state, and a volume basis.
 
 `getValue(...)` reports energy properties in kJ per cubic metre on the configured
 reference basis. The table converts those assertions to MJ/m³ for readability.

--- a/docs/wiki/gas_quality_standards_from_tests.md
+++ b/docs/wiki/gas_quality_standards_from_tests.md
@@ -4,7 +4,7 @@ description: "Trace the current ISO 6976 gas-quality regression coverage for cal
 ---
 
 This page explains the numerical evidence in
-[`Standard_ISO6976Test`](../../src/test/java/neqsim/standards/gasquality/Standard_ISO6976Test.java).
+[`Standard_ISO6976Test`](https://github.com/equinor/neqsim/blob/master/src/test/java/neqsim/standards/gasquality/Standard_ISO6976Test.java).
 Use it with the [ISO 6976 calculation guide](../standards/iso6976_calorific_values.md),
 which documents the API, editions, units, and engineering boundaries.
 

--- a/docs/wiki/gas_quality_standards_from_tests.md
+++ b/docs/wiki/gas_quality_standards_from_tests.md
@@ -16,13 +16,19 @@ TP flash. It then configures `Standard_ISO6976` with a 0 °C volume reference, a
 15.55 °C combustion-energy reference, a real-gas reference state, and a volume
 basis.
 
-The current assertions are:
+`getValue(...)` reports energy properties in kJ per cubic metre on the configured
+reference basis. The table converts those assertions to MJ/m³ for readability.
+`testCalculate` asserts GCV and WI; `testCalculate2` asserts relative density for
+the same composition and reference conditions.
 
 | Property | Regression value | Unit |
 | --- | ---: | --- |
 | Superior calorific value (`GCV`) | 39.61457 | MJ/m³ |
 | Superior Wobbe index (`WI`) | 51.70101 | MJ/m³ |
 | Relative density | 0.5870995 | dimensionless |
+
+The exact energy assertions before conversion are 39614.56783352743 kJ/m³ for
+GCV and 51701.01275822569 kJ/m³ for WI.
 
 The superior Wobbe index is related to the superior calorific value by
 
@@ -40,8 +46,9 @@ basis with every result.
 `testCalculate` verifies that `WI` and `WobbeIndex` both resolve to
 `SuperiorWobbeIndex`. The separate `testWIAliasVariesWithComposition` regression
 prevents the alias from returning a composition-independent value: its lean
-98 mol% methane / 2 mol% ethane gas gives approximately 53.86 MJ/m³, while its
-richer methane/ethane/propane gas gives approximately 58.38 MJ/m³.
+98 mol% methane / 2 mol% ethane test target is approximately 53860 kJ/m³
+(53.86 MJ/m³), while its richer methane/ethane/propane target is approximately
+58380 kJ/m³ (58.38 MJ/m³).
 
 These values are software regression anchors for the specified fixtures and
 reference conditions. They are not universal sales-gas limits.
@@ -51,8 +58,8 @@ reference conditions. They are not universal sales-gas limits.
 `testCalculateWithWrongReferenceState` deliberately sets unsupported reference
 temperatures. When a value is requested, `checkReferenceCondition()` changes an
 unsupported combustion-energy reference to 25 °C and an unsupported volume
-reference to 15 °C, and logs both corrections. The resulting GCV assertion is
-37.49935 MJ/m³.
+reference to 15 °C, and logs both corrections. The test asserts
+37499.35392575905 kJ/m³ (37.49935 MJ/m³) for the resulting GCV.
 
 This fallback keeps the calculation running, but it also changes the requested
 basis. Validate reference temperatures before calculation instead of treating
@@ -63,9 +70,9 @@ explained in the primary guide.
 ## Pseudo-components and unsupported species
 
 `testCalculateWithPSeudo` adds a `C10` TBP fraction and asserts a resulting GCV
-of 42.37776 MJ/m³. This proves that the current fallback route remains
-numerically stable for that fixture; it does not prove explicit ISO 6976
-coverage for the pseudo-component.
+of 42377.76099372482 kJ/m³ (42.37776 MJ/m³). This proves that the current fallback
+route remains numerically stable for that fixture; it does not prove explicit
+ISO 6976 coverage for the pseudo-component.
 
 For hydrocarbon, TBP, and plus fractions not found in the ISO data table,
 `Standard_ISO6976` substitutes n-heptane data and records the original component


### PR DESCRIPTION
## Documentation campaign

Part of #2499. Batch **D040** advances the rotation to scope 5: PVT, flow assurance, standards, and gas/oil quality.

### Frozen scope

- `docs/wiki/gas_quality_standards_from_tests.md`
- Evidence reviewed, but not changed:
  - `src/test/java/neqsim/standards/gasquality/Standard_ISO6976Test.java`
  - `src/main/java/neqsim/standards/gasquality/Standard_ISO6976.java`
  - `docs/standards/iso6976_calorific_values.md`
  - `docs/standards/README.md`

The benchmark/index files touched by open PR #2632, DEXPI files in #2654, and column files in #2647 are excluded.

## Confirmed defects and root causes

| Severity | Defect | Evidence/root cause |
| --- | --- | --- |
| High | Base-fixture Wobbe index documented as 44.61 MJ/Nm³ | Current regression asserts `WI == SuperiorWobbeIndex == 51.701012758... MJ/Nm³`; 44.6 was the old broken alias result. |
| High | Invalid-reference fallback documented as 15 °C energy / 0 °C volume | `checkReferenceCondition()` actually mutates unsupported inputs to 25 °C energy / 15 °C volume. |
| High | Fallback described as safe input guarding | The implementation logs and changes the requested basis; it is not traceable input validation. |
| High | TBP test described as ISO support for lumped heavy ends | Unsupported HC/TBP/plus components use fallback data and are recorded by `getComponentsNotDefinedByStandard()`. |
| Medium | Four repository-internal citation artifacts rendered as prose | Generated `【F:...】` markers were never valid Jekyll links. |
| Medium | Display equation used unsupported single-dollar block delimiters | Repository documentation requires standalone `$$` display delimiters. |
| Medium | Test coverage and fixture ownership were inaccurate | Shared `@BeforeAll`, `testCalculate2`, and `testCalculate3` use distinct setup paths. |
| Medium | Fixture pressure stated only as “1 bar” | Constructor input is 1.0 bara. |
| Medium | Source-test relative link escaped the Jekyll source tree | `src/` is not published under the documentation site; the rendered link would fail. |
| Low | Front matter title was duplicated as a Markdown H1 | Jekyll renders the front-matter title. |
| Low | Compliance and measurement boundaries were absent | Numerical regression evidence was presented too broadly for fiscal/contractual use. |

## Fix

- Replace stale values and fallback behavior with the current source/test contract.
- State exact kJ/Nm³ assertions and explicit MJ/Nm³ conversions.
- Explain the API's `KJ/Nm3` label and configured volume-reference basis.
- Explain the Wobbe equation and aliases on that explicit basis.
- Distinguish pseudo-component numerical fallback from ISO component coverage.
- Attribute the shared fixture and separate full-property fixtures precisely.
- Describe the exact full-property and `Stream` regressions.
- Link the focused Java test through GitHub so it remains reachable from the rendered site.
- Add valid relative links to the primary ISO 6976 guide and standards overview.
- Add explicit interpretation boundaries for sampling, uncertainty, contractual compliance, and edition certification.
- Remove the duplicate H1, invalid citation artifacts, and malformed display math.

## Exact-head validation

Validated at commit `90a52b848a07f99820d82a52b465afe6f306f947`, page blob `8b53db5f1399fa3f80c0f4d84c8f500a8cd51155`:

- Jekyll front matter: one title; no duplicate Markdown H1.
- Markdown structure: clean headings and table syntax.
- Math: one balanced standalone `$$` block; no `\(...\)`, `\[...\]`, or single-dollar display block.
- Links: both documentation-relative targets resolve; the GitHub source target was fetched successfully; no link escapes the generated site.
- Source/API audit: exact aliases, numeric assertions, unit label, reference fallback, volume-correction basis, unsupported-component tracking, and stream methods checked against current Java source and tests.
- Exact values present: GCV `39614.56783352743`, WI `51701.01275822569`, invalid-reference GCV `37499.35392575905`, and TBP-fallback GCV `42377.76099372482` kJ/Nm³.
- `Standard_ISO6976Test.java` is byte-identical on the branch and current `master` (blob `fd78142190e9d59b290b569bdd91610de5f94d12`). The current-master full matrix in #2650 passed 10,850 fast tests on Java 8/21 and Ubuntu/Windows plus all three Java 21 slow shards. Exact-branch Java matrices correctly skipped because this PR changes documentation only.
- Exact-head GitHub Actions:
  - Documentation search coverage: Jekyll build, source contracts, generated search index, and JavaScript syntax passed.
  - Pre-commit passed.
  - Spotless passed with no patch required.
  - CodeQL passed.
  - Build/test workflow change detection and agent-skill cross-reference verification passed.
- Diff: one intended page, six bounded documentation commits, current with `master`, mergeable, no index or source changes.

No standalone executable example was added or changed. A focused Java regression is linked as evidence. No rendered-site screenshot artifact was available, so browser visual inspection is not claimed.

## Copilot disposition

- Accepted the unit/assertion-ownership thread; added exact kJ values and assigned relative density to `testCalculate2`; replied with validation evidence and resolved the thread.
- Evaluated and implemented technically valid suppressed observations about fixture ownership, separate `testCalculate2` setup, API unit label, 25 °C validation versus explicit volume corrections, and the source link outside the Jekyll tree.
- Final exact-head review covered 1/1 changed files and generated no new comments.
- No unresolved review threads or unvalidated accepted changes remain.

## Exclusions and next scope

No Java behavior, test tolerance, standard data, reference-manual index, or unrelated documentation is changed. D040 remains open and is not recorded as completed until merged. After completion, the next batch should advance to scope 6 from the #2499 rotation.