### PR TITLE
Fix spec-aware sequential column warm-state invalidation

### DIFF
--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2717,10 +2717,10 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * Add configuration inputs that require rebuilding sequential tray initialization.
    *
    * <p>
-   * An adjustable top or bottom product specification changes the corresponding condenser or
-   * reboiler temperature inside its outer solve. Those manipulated temperatures are deliberately
-   * excluded here so the specification solver can retain nearby tray states between trial points.
-   * Every independent fixed configuration input remains fingerprinted.
+   * An adjustable top or bottom product specification changes the corresponding condenser or reboiler temperature
+   * inside its outer solve. Those manipulated temperatures are deliberately excluded here so the specification solver
+   * can retain nearby tray states between trial points. Every independent fixed configuration input remains
+   * fingerprinted.
    * </p>
    *
    * @param signature fingerprint accumulated so far
@@ -2734,12 +2734,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * Add column configuration inputs to a fingerprint.
    *
    * @param signature fingerprint accumulated so far
-   * @param ignoreSpecificationManipulatedTemperatures whether to omit endpoint temperatures
-   *        adjusted by active product specifications
+   * @param ignoreSpecificationManipulatedTemperatures whether to omit endpoint temperatures adjusted by active product
+   * specifications
    * @return updated fingerprint
    */
-  private long updateColumnConfigurationSignature(long signature,
-      boolean ignoreSpecificationManipulatedTemperatures) {
+  private long updateColumnConfigurationSignature(long signature, boolean ignoreSpecificationManipulatedTemperatures) {
     long updatedSignature = updateNaphtaliSandholmInputSignature(signature, numberOfTrays);
     updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, topTrayPressure);
     updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, bottomTrayPressure);
@@ -2779,13 +2778,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * Check whether an active outer specification owns a tray endpoint temperature.
    *
    * @param trayIndex zero-based tray index
-   * @return {@code true} for a condenser/reboiler temperature manipulated by an active
-   *         specification
+   * @return {@code true} for a condenser/reboiler temperature manipulated by an active specification
    */
   private boolean isSpecificationManipulatedTemperature(int trayIndex) {
     boolean bottomTemperature = trayIndex == 0 && hasReboiler && needsAdjustment(bottomSpecification);
-    boolean topTemperature = trayIndex == numberOfTrays - 1 && hasCondenser
-        && needsAdjustment(topSpecification);
+    boolean topTemperature = trayIndex == numberOfTrays - 1 && hasCondenser && needsAdjustment(topSpecification);
     return bottomTemperature || topTemperature;
   }
 
@@ -5550,8 +5547,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     long currentSequentialInitializationSignature = calculateSequentialInitializationSignature();
     boolean thermodynamicIdentityChanged = currentThermodynamicIdentitySignature != trayStateThermodynamicIdentitySignature;
     boolean columnConfigurationChanged = currentSequentialInitializationSignature != lastSequentialInitializationSignature;
-    if (hasBeenSolvedBefore && !isDoInitializion()
-        && (thermodynamicIdentityChanged || columnConfigurationChanged)) {
+    if (hasBeenSolvedBefore && !isDoInitializion() && (thermodynamicIdentityChanged || columnConfigurationChanged)) {
       logger.info("Sequential warm start is incompatible with current inputs for column {}; "
           + "rebuilding tray initialization.", getName());
       hasBeenSolvedBefore = false;

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2566,7 +2566,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    */
   private long calculateSequentialInitializationSignature() {
     long signature = 1125899906842597L;
-    return updateColumnConfigurationSignature(signature);
+    return updateSequentialInitializationConfigurationSignature(signature);
   }
 
   /**
@@ -2710,6 +2710,36 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @return updated fingerprint
    */
   private long updateColumnConfigurationSignature(long signature) {
+    return updateColumnConfigurationSignature(signature, false);
+  }
+
+  /**
+   * Add configuration inputs that require rebuilding sequential tray initialization.
+   *
+   * <p>
+   * An adjustable top or bottom product specification changes the corresponding condenser or
+   * reboiler temperature inside its outer solve. Those manipulated temperatures are deliberately
+   * excluded here so the specification solver can retain nearby tray states between trial points.
+   * Every independent fixed configuration input remains fingerprinted.
+   * </p>
+   *
+   * @param signature fingerprint accumulated so far
+   * @return updated fingerprint
+   */
+  private long updateSequentialInitializationConfigurationSignature(long signature) {
+    return updateColumnConfigurationSignature(signature, true);
+  }
+
+  /**
+   * Add column configuration inputs to a fingerprint.
+   *
+   * @param signature fingerprint accumulated so far
+   * @param ignoreSpecificationManipulatedTemperatures whether to omit endpoint temperatures
+   *        adjusted by active product specifications
+   * @return updated fingerprint
+   */
+  private long updateColumnConfigurationSignature(long signature,
+      boolean ignoreSpecificationManipulatedTemperatures) {
     long updatedSignature = updateNaphtaliSandholmInputSignature(signature, numberOfTrays);
     updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, topTrayPressure);
     updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, bottomTrayPressure);
@@ -2720,10 +2750,16 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
         updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, -1L);
         continue;
       }
-      boolean temperatureSpecified = tray.isSetOutTemperature();
-      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, temperatureSpecified ? 1L : 0L);
-      if (temperatureSpecified) {
-        updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, tray.getOutTemperature());
+      boolean specificationManipulatedTemperature = ignoreSpecificationManipulatedTemperatures
+          && isSpecificationManipulatedTemperature(trayIndex);
+      if (specificationManipulatedTemperature) {
+        updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, 2L);
+      } else {
+        boolean temperatureSpecified = tray.isSetOutTemperature();
+        updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, temperatureSpecified ? 1L : 0L);
+        if (temperatureSpecified) {
+          updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, tray.getOutTemperature());
+        }
       }
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature,
           getEffectiveMurphreeEfficiency(trayIndex));
@@ -2737,6 +2773,20 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
           getCondenser().isTotalCondenser() ? 1L : 0L);
     }
     return updatedSignature;
+  }
+
+  /**
+   * Check whether an active outer specification owns a tray endpoint temperature.
+   *
+   * @param trayIndex zero-based tray index
+   * @return {@code true} for a condenser/reboiler temperature manipulated by an active
+   *         specification
+   */
+  private boolean isSpecificationManipulatedTemperature(int trayIndex) {
+    boolean bottomTemperature = trayIndex == 0 && hasReboiler && needsAdjustment(bottomSpecification);
+    boolean topTemperature = trayIndex == numberOfTrays - 1 && hasCondenser
+        && needsAdjustment(topSpecification);
+    return bottomTemperature || topTemperature;
   }
 
   /**
@@ -5501,7 +5551,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     boolean thermodynamicIdentityChanged = currentThermodynamicIdentitySignature != trayStateThermodynamicIdentitySignature;
     boolean columnConfigurationChanged = currentSequentialInitializationSignature != lastSequentialInitializationSignature;
     if (hasBeenSolvedBefore && !isDoInitializion()
-        && (thermodynamicIdentityChanged || (!hasAdjustableSpecifications() && columnConfigurationChanged))) {
+        && (thermodynamicIdentityChanged || columnConfigurationChanged)) {
       logger.info("Sequential warm start is incompatible with current inputs for column {}; "
           + "rebuilding tray initialization.", getName());
       hasBeenSolvedBefore = false;

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -675,6 +675,8 @@ public class DistillationColumnWarmStateCacheTest {
   public void adjustableSpecificationStillInvalidatesFixedPressureChange() {
     ColumnCase calibration = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
     configureDampedSubstitution(calibration.column);
+    calibration.column.setTopPressure(9.0);
+    calibration.column.setBottomPressure(9.5);
     calibration.column.run();
     assertTrue(calibration.column.solved(), calibration.column.getConvergenceDiagnostics());
     double targetRecovery = getBottomComponentRecovery(calibration, "n-pentane");
@@ -682,13 +684,13 @@ public class DistillationColumnWarmStateCacheTest {
 
     ColumnCase warmCase = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
     configureDampedSubstitution(warmCase.column);
-    configureBottomPentaneRecoverySpecification(warmCase.column, targetRecovery);
     warmCase.column.run();
     assertTrue(warmCase.column.solved(), warmCase.column.getConvergenceDiagnostics());
-    assertEquals(0.0, warmCase.column.getLastBottomSpecificationResidual(),
-        warmCase.column.getBottomSpecification().getTolerance(), "initial bottom recovery specification must converge");
+    assertNotEquals(targetRecovery, getBottomComponentRecovery(warmCase, "n-pentane"), 1.0e-3,
+        "the nearby pressure point must exercise a distinct recovery state");
     int baselineInitializationCount = warmCase.column.getInitializationCount();
 
+    configureBottomPentaneRecoverySpecification(warmCase.column, targetRecovery);
     warmCase.column.setTopPressure(9.0);
     warmCase.column.setBottomPressure(9.5);
     warmCase.column.run();

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -663,6 +663,85 @@ public class DistillationColumnWarmStateCacheTest {
   }
 
   /**
+   * An adjustable product specification must not suppress invalidation of other fixed column inputs.
+   *
+   * <p>
+   * The bottom recovery target manipulates the reboiler temperature internally. A nearby pressure change is independent
+   * of that manipulated degree of freedom and must rebuild the sequential tray initialization before solving the same
+   * recovery target. The rebuilt solution must agree with a fresh column at the changed pressure.
+   * </p>
+   */
+  @Test
+  public void adjustableSpecificationStillInvalidatesFixedPressureChange() {
+    ColumnCase calibration = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    configureDampedSubstitution(calibration.column);
+    calibration.column.run();
+    assertTrue(calibration.column.solved(), calibration.column.getConvergenceDiagnostics());
+    double targetRecovery = getBottomComponentRecovery(calibration, "n-pentane");
+    assertTrue(targetRecovery > 0.0 && targetRecovery < 1.0, "calibrated recovery must be physical");
+
+    ColumnCase warmCase = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    configureDampedSubstitution(warmCase.column);
+    configureBottomRecoverySpecification(warmCase.column, targetRecovery);
+    warmCase.column.run();
+    assertTrue(warmCase.column.solved(), warmCase.column.getConvergenceDiagnostics());
+    assertEquals(0.0, warmCase.column.getLastBottomSpecificationResidual(),
+        warmCase.column.getBottomSpecification().getTolerance(), "initial bottom recovery specification must converge");
+    int baselineInitializationCount = warmCase.column.getInitializationCount();
+
+    warmCase.column.setTopPressure(9.0);
+    warmCase.column.setBottomPressure(9.5);
+    warmCase.column.run();
+
+    assertTrue(warmCase.column.solved(), warmCase.column.getConvergenceDiagnostics());
+    assertEquals(baselineInitializationCount + 1, warmCase.column.getInitializationCount(),
+        "a fixed pressure change must rebuild even while bottom recovery adjusts reboiler temperature");
+    assertEquals(0.0, warmCase.column.getLastBottomSpecificationResidual(),
+        warmCase.column.getBottomSpecification().getTolerance(), "changed-pressure recovery specification must converge");
+    assertPhysicalAndBalanced(warmCase);
+
+    ColumnCase coldReference = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
+    configureDampedSubstitution(coldReference.column);
+    configureBottomRecoverySpecification(coldReference.column, targetRecovery);
+    coldReference.column.setTopPressure(9.0);
+    coldReference.column.setBottomPressure(9.5);
+    coldReference.column.run();
+
+    assertTrue(coldReference.column.solved(), coldReference.column.getConvergenceDiagnostics());
+    assertEquals(0.0, coldReference.column.getLastBottomSpecificationResidual(),
+        coldReference.column.getBottomSpecification().getTolerance(), "cold-reference recovery specification must converge");
+    assertColdReferenceEquivalent(coldReference.column, warmCase.column);
+    assertPhysicalAndBalanced(coldReference);
+  }
+
+  /**
+   * Calculate component recovery in the bottom product.
+   *
+   * @param columnCase solved column case
+   * @param componentName component to evaluate
+   * @return bottom recovery fraction
+   */
+  private static double getBottomComponentRecovery(ColumnCase columnCase, String componentName) {
+    double feedComponentFlow = columnCase.feed.getFlowRate("mol/hr")
+        * columnCase.feed.getThermoSystem().getComponent(componentName).getz();
+    double bottomComponentFlow = columnCase.column.getLiquidOutStream().getFlowRate("mol/hr")
+        * columnCase.column.getLiquidOutStream().getThermoSystem().getComponent(componentName).getz();
+    return bottomComponentFlow / feedComponentFlow;
+  }
+
+  /**
+   * Configure an adjustable bottom component-recovery specification.
+   *
+   * @param column column to configure
+   * @param targetRecovery target bottom recovery fraction
+   */
+  private static void configureBottomRecoverySpecification(DistillationColumn column, double targetRecovery) {
+    column.setBottomComponentRecovery("n-pentane", targetRecovery);
+    column.getBottomSpecification().setTolerance(5.0e-3);
+    column.getBottomSpecification().setMaxIterations(15);
+  }
+
+  /**
    * Sequential warm starts must be invalidated when a fixed reboiler temperature changes.
    *
    * <p>

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -697,7 +697,8 @@ public class DistillationColumnWarmStateCacheTest {
     assertEquals(baselineInitializationCount + 1, warmCase.column.getInitializationCount(),
         "a fixed pressure change must rebuild even while bottom recovery adjusts reboiler temperature");
     assertEquals(0.0, warmCase.column.getLastBottomSpecificationResidual(),
-        warmCase.column.getBottomSpecification().getTolerance(), "changed-pressure recovery specification must converge");
+        warmCase.column.getBottomSpecification().getTolerance(),
+        "changed-pressure recovery specification must converge");
     assertPhysicalAndBalanced(warmCase);
 
     ColumnCase coldReference = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
@@ -709,7 +710,8 @@ public class DistillationColumnWarmStateCacheTest {
 
     assertTrue(coldReference.column.solved(), coldReference.column.getConvergenceDiagnostics());
     assertEquals(0.0, coldReference.column.getLastBottomSpecificationResidual(),
-        coldReference.column.getBottomSpecification().getTolerance(), "cold-reference recovery specification must converge");
+        coldReference.column.getBottomSpecification().getTolerance(),
+        "cold-reference recovery specification must converge");
     assertColdReferenceEquivalent(coldReference.column, warmCase.column);
     assertPhysicalAndBalanced(coldReference);
   }

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -682,7 +682,7 @@ public class DistillationColumnWarmStateCacheTest {
 
     ColumnCase warmCase = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
     configureDampedSubstitution(warmCase.column);
-    configureBottomRecoverySpecification(warmCase.column, targetRecovery);
+    configureBottomPentaneRecoverySpecification(warmCase.column, targetRecovery);
     warmCase.column.run();
     assertTrue(warmCase.column.solved(), warmCase.column.getConvergenceDiagnostics());
     assertEquals(0.0, warmCase.column.getLastBottomSpecificationResidual(),
@@ -703,7 +703,7 @@ public class DistillationColumnWarmStateCacheTest {
 
     ColumnCase coldReference = buildIdentityColumnCase(createIdentityTestFluid(false, "n-butane", 2));
     configureDampedSubstitution(coldReference.column);
-    configureBottomRecoverySpecification(coldReference.column, targetRecovery);
+    configureBottomPentaneRecoverySpecification(coldReference.column, targetRecovery);
     coldReference.column.setTopPressure(9.0);
     coldReference.column.setBottomPressure(9.5);
     coldReference.column.run();
@@ -732,12 +732,12 @@ public class DistillationColumnWarmStateCacheTest {
   }
 
   /**
-   * Configure an adjustable bottom component-recovery specification.
+   * Configure an adjustable n-pentane bottom-recovery specification.
    *
    * @param column column to configure
    * @param targetRecovery target bottom recovery fraction
    */
-  private static void configureBottomRecoverySpecification(DistillationColumn column, double targetRecovery) {
+  private static void configureBottomPentaneRecoverySpecification(DistillationColumn column, double targetRecovery) {
     column.setBottomComponentRecovery("n-pentane", targetRecovery);
     column.getBottomSpecification().setTolerance(5.0e-3);
     column.getBottomSpecification().setMaxIterations(15);


### PR DESCRIPTION
## Problem and root cause

Sequential substitution and its coordinated AUTO/fallback paths used this compatibility gate:

`thermodynamicIdentityChanged || (!hasAdjustableSpecifications() && columnConfigurationChanged)`.

The adjustable-specification guard was intended to let the outer secant/homotopy loop move its condenser or reboiler temperature without rebuilding on every trial. It instead masked the **entire** fixed-configuration fingerprint, including pressure, independently fixed tray temperatures, Murphree efficiency, reflux settings, and condenser mode.

A solved product-specified column could therefore continue from an incompatible tray profile after an independent operating change and converge to a path-dependent result.

## Baseline evidence

A deterministic six-stage SRK propane/n-butane/n-pentane stripper was calibrated at the nearby changed-pressure point, 9.0/9.5 bara. A separate warm column was first solved at 10.0/10.5 bara, then the calibrated n-pentane bottoms-recovery specification was activated while pressure was changed to 9.0/9.5 bara.

With the pre-fix NeqSim 3.16.0 behavior, both the warm and fresh cold-reference cases reported rigorous convergence and satisfied the 0.005 recovery tolerance, but they reached different states:

- target/cold recovery: **0.912591304**;
- warm recovery: **0.911044569**;
- warm specification residual: **-0.001546734**; cold residual: **0.0**;
- warm versus cold overhead flow differed by **+0.5746%**;
- warm versus cold bottoms flow differed by **-0.4174%**.

The source-level cause is independently observable: the active recovery specification suppresses the complete configuration comparison. The regression therefore also requires exactly one initialization rebuild on the fixed pressure change.

## Algorithmic change

The sequential initialization fingerprint is now specification-aware instead of specification-blind:

- adjustable top product/purity/recovery/flow specifications omit only the condenser temperature they manipulate;
- adjustable bottom specifications omit only the reboiler temperature they manipulate;
- all independent fixed column inputs remain fingerprinted and can invalidate an incompatible sequential tray state;
- the full Naphtali–Sandholm input fingerprint still includes the current manipulated endpoint temperature, so trial points cannot be mistaken for exact-input reuse;
- no tolerance, iteration budget, thermodynamic equation, public API, serialization contract, or solver default changed.

Affected paths are sequential substitution, damped substitution, Wegstein, and AUTO/fallback candidates that use the shared sequential initialization.

## Regression and engineering validation

`DistillationColumnWarmStateCacheTest.adjustableSpecificationStillInvalidatesFixedPressureChange` checks:

- realistic multicomponent hydrocarbon separation;
- active component-recovery degree of freedom;
- a distinct nearby pressure operating point;
- rigorous convergence before and after the change;
- exactly one initialization rebuild;
- cold-reference product flow and composition agreement;
- specification residual;
- total and component molar closure;
- positive finite product flows and pressures;
- bounded normalized compositions and physical temperatures.

The first draft fixture activated the recovery specification on an unsolved column and CI correctly rejected that setup because it entered guarded fallback before exercising the target invalidation. The revised regression calibrates the target at the changed pressure and activates it only after a rigorous base-pressure solve; no production tolerance or convergence gate was loosened.

## Checks

Exact head `5d5dbc90`; GitHub merge ref `57f686f6` includes current `master` commit `44663622`:

- focused `DistillationColumnWarmStateCacheTest`: **13/13 passed** on Java 21 Windows/Ubuntu and Java 8 Windows/Ubuntu;
- full Java 21 fast suites: **10,861 passed, 0 failures/errors, 212 skipped** on each platform;
- full Java 8 suites: **10,861 passed, 0 failures/errors, 212 skipped** on each platform;
- Java 8 duration: **45:33 Windows**, **36:57 Ubuntu**;
- all three Java 21 slow-test shards passed;
- Spotless, pre-commit, PaperLab, CodeQL, Javadoc, agent-reference and change-detection checks passed;
- final diff against current `master` contains only `DistillationColumn` and its focused warm-state regression test.

## Compatibility and risk

The change only rejects warm states whose **independent fixed configuration** changed. Nearby trial temperatures owned by an active outer specification remain warm-started. The principal risk is a false invalidation (extra initialization, not a wrong accepted result); the regression protects against missed invalidation and cold-reference divergence.

## Documentation impact

None. `docs/process/equipment/distillation.md` documents public specification behavior and diagnostics but does not promise the internal cache fingerprint or initialization count. `CHANGELOG_AGENT_NOTES.md` is reserved for API and migration-relevant behavior. This fix changes no public API or user workflow.

## Remaining limitations

This PR does not add direct legacy tray-feed injection to the Naphtali–Sandholm equations and does not redesign the outer secant/homotopy algorithm. Those remain separate bounded targets.

Ready for human review. Do not merge automatically.