### PR TITLE
Fix LoopedPipeNetwork Beggs-Brill dispatch and roughness

### DIFF
--- a/docs/process/equipment/production_well_networks.md
+++ b/docs/process/equipment/production_well_networks.md
@@ -259,12 +259,22 @@ friction and gravity based on bulk fluid properties.
 **Convenience method:**
 
 ```java
-network.addMultiphasePipe("mp1", "manifold", "platform",
+network.addMultiphasePipe("manifold", "platform", "mp1",
     15000.0,         // length [m]
-    0.3,             // ID [m]
-    0.0,             // inclination [degrees]
-    20);             // number of segments
+    0.3);            // ID [m]
 ```
+
+To use Beggs–Brill for ordinary pipes added afterwards, configure the
+network-wide default before calling `addPipe`:
+
+```java
+network.setPipeModelType(LoopedPipeNetwork.PipeModelType.BEGGS_BRILL);
+network.addPipe("manifold", "platform", "mp1", 15000.0, 0.3);
+```
+
+The setting applies only to later `addPipe` calls. It does not change existing
+pipes or elements created with specialized methods such as `addChoke` and
+`addTubing`. `addMultiphasePipe` always selects Beggs–Brill explicitly.
 
 ---
 
@@ -836,6 +846,13 @@ pressure residuals.
 ### Convenience Methods on LoopedPipeNetwork
 
 ```java
+// Default model for ordinary pipes added afterwards
+void setPipeModelType(PipeModelType type)
+
+// Ordinary pipe using the configured default model
+NetworkPipe addPipe(String fromNode, String toNode, String pipeName,
+    double length_m, double diameter_m)
+
 // Well IPR (oil or gas PI model)
 void addWellIPR(String name, String fromNode, String toNode,
     double reservoirPressure_bara, double pi, boolean gasIPR)
@@ -857,10 +874,9 @@ void addTubing(String name, String fromNode, String toNode,
     double length_m, double diameter_m,
     double inclination_deg, int segments)
 
-// Multiphase pipe (segmented horizontal/inclined)
-void addMultiphasePipe(String name, String fromNode, String toNode,
-    double length_m, double diameter_m,
-    double inclination_deg, int segments)
+// Multiphase pipe using Beggs-Brill explicitly
+NetworkPipe addMultiphasePipe(String fromNode, String toNode,
+    String elementName, double length_m, double diameter_m)
 
 // Fixed-pressure sink (separator, platform)
 void addFixedPressureSinkNode(String name, double pressure_bara)

--- a/docs/process/equipment/production_well_networks.md
+++ b/docs/process/equipment/production_well_networks.md
@@ -264,6 +264,10 @@ network.addMultiphasePipe("manifold", "platform", "mp1",
     0.3);            // ID [m]
 ```
 
+Pipe roughness is specified in metres throughout the network and
+`PipeBeggsAndBrills` APIs. For example, commercial-steel roughness can be set
+with `network.getPipe("mp1").setRoughness(4.5e-5)`.
+
 To use Beggs–Brill for ordinary pipes added afterwards, configure the
 network-wide default before calling `addPipe`:
 

--- a/src/main/java/neqsim/process/equipment/network/LoopedPipeNetwork.java
+++ b/src/main/java/neqsim/process/equipment/network/LoopedPipeNetwork.java
@@ -1840,8 +1840,7 @@ public class LoopedPipeNetwork extends ProcessEquipmentBaseClass {
    * Existing pipes and elements created by the specialized factory methods are not changed.
    * </p>
    *
-   * @param type pipe model type ({@link PipeModelType#DARCY_WEISBACH} or
-   *        {@link PipeModelType#BEGGS_BRILL})
+   * @param type pipe model type ({@link PipeModelType#DARCY_WEISBACH} or {@link PipeModelType#BEGGS_BRILL})
    */
   public void setPipeModelType(PipeModelType type) {
     this.pipeModelType = type;

--- a/src/main/java/neqsim/process/equipment/network/LoopedPipeNetwork.java
+++ b/src/main/java/neqsim/process/equipment/network/LoopedPipeNetwork.java
@@ -1834,9 +1834,14 @@ public class LoopedPipeNetwork extends ProcessEquipmentBaseClass {
   }
 
   /**
-   * Set the pipe flow model type.
+   * Set the flow model used by pipes created by subsequent calls to {@link #addPipe}.
    *
-   * @param type pipe model type (DARCY_WEISBACH or BEGGS_BRILL)
+   * <p>
+   * Existing pipes and elements created by the specialized factory methods are not changed.
+   * </p>
+   *
+   * @param type pipe model type ({@link PipeModelType#DARCY_WEISBACH} or
+   *        {@link PipeModelType#BEGGS_BRILL})
    */
   public void setPipeModelType(PipeModelType type) {
     this.pipeModelType = type;
@@ -1960,6 +1965,11 @@ public class LoopedPipeNetwork extends ProcessEquipmentBaseClass {
   /**
    * Add a pipe connecting two nodes.
    *
+   * <p>
+   * The pipe uses the model selected by {@link #setPipeModelType(PipeModelType)}. The default is
+   * {@link PipeModelType#DARCY_WEISBACH}.
+   * </p>
+   *
    * @param fromNode source node name
    * @param toNode target node name
    * @param pipeName pipe name
@@ -1985,6 +1995,9 @@ public class LoopedPipeNetwork extends ProcessEquipmentBaseClass {
     NetworkPipe pipe = new NetworkPipe(pipeName, fromNode, toNode);
     pipe.setLength(lengthM);
     pipe.setDiameter(diameterM);
+    if (pipeModelType == PipeModelType.BEGGS_BRILL) {
+      pipe.setElementType(NetworkElementType.MULTIPHASE_PIPE);
+    }
     pipes.put(pipeName, pipe);
     pipeNames.add(pipeName);
 

--- a/src/main/java/neqsim/process/equipment/network/LoopedPipeNetwork.java
+++ b/src/main/java/neqsim/process/equipment/network/LoopedPipeNetwork.java
@@ -3858,7 +3858,7 @@ public class LoopedPipeNetwork extends ProcessEquipmentBaseClass {
         inletStream.run();
 
         bbPipe = new PipeBeggsAndBrills(pipe.getName() + "_bb", inletStream);
-        bbPipe.setPipeWallRoughness(pipe.getRoughness() * 1000.0); // m -> mm
+        bbPipe.setPipeWallRoughness(pipe.getRoughness());
         bbPipe.setLength(pipe.getLength());
         bbPipe.setDiameter(pipe.getDiameter());
         bbPipe.setNumberOfIncrements(pipe.getMultiphaseSegments());

--- a/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
@@ -743,7 +743,7 @@ public class PipeBeggsAndBrills extends Pipeline implements neqsim.process.desig
   /**
    * Setter for the field <code>pipeWallRoughness</code>.
    *
-   * @param pipeWallRoughness the pipeWallRoughness to set
+   * @param pipeWallRoughness pipe wall roughness in meters
    */
   @Override
   public void setPipeWallRoughness(double pipeWallRoughness) {

--- a/src/test/java/neqsim/process/equipment/network/LoopedPipeNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/LoopedPipeNetworkTest.java
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
 import neqsim.process.equipment.reservoir.SimpleReservoir;
+import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -1738,6 +1740,58 @@ class LoopedPipeNetworkTest {
     assertNotNull(flowline);
     assertEquals(LoopedPipeNetwork.NetworkElementType.MULTIPHASE_PIPE, flowline.getElementType());
     assertTrue(Math.abs(flowline.getFlowRate()) > 0, "Flowline should have non-zero flow");
+  }
+
+  /**
+   * Test that network and standalone Beggs-Brill models use the same metre-based roughness.
+   */
+  @Test
+  void testMultiphasePipeRoughnessMatchesStandaloneBeggsBrill() {
+    double inletPressureBar = 80.0;
+    double inletTemperatureK = 288.15;
+    double lengthM = 15000.0;
+    double diameterM = 0.2;
+    double roughnessM = 4.5e-5;
+    int segments = 20;
+
+    LoopedPipeNetwork network = new LoopedPipeNetwork("RoughnessParityNet");
+    network.setFluidTemplate(testGas);
+    network.setSolverType(LoopedPipeNetwork.SolverType.NEWTON_RAPHSON);
+    network.setMaxIterations(200);
+    network.setTolerance(100.0);
+    network.addSourceNode("wellhead", inletPressureBar, 0.0);
+    network.getNode("wellhead").setTemperature(inletTemperatureK);
+    network.addFixedPressureSinkNode("platform", 40.0);
+
+    LoopedPipeNetwork.NetworkPipe networkPipe =
+        network.addMultiphasePipe("wellhead", "platform", "flowline", lengthM, diameterM);
+    networkPipe.setRoughness(roughnessM);
+    networkPipe.setMultiphaseSegments(segments);
+    network.run();
+
+    assertTrue(network.isConverged(), "Multiphase pipe network should converge");
+    assertEquals("BB-Multiphase", networkPipe.getFlowRegime());
+
+    double flowRateKgHr = Math.abs(networkPipe.getFlowRate()) * 3600.0;
+    SystemInterface standaloneFluid = testGas.clone();
+    standaloneFluid.setPressure(inletPressureBar, "bara");
+    standaloneFluid.setTemperature(inletTemperatureK, "K");
+    Stream standaloneInlet = new Stream("standalone inlet", standaloneFluid);
+    standaloneInlet.setFlowRate(flowRateKgHr, "kg/hr");
+    standaloneInlet.run();
+
+    PipeBeggsAndBrills standalonePipe =
+        new PipeBeggsAndBrills("standalone Beggs-Brill", standaloneInlet);
+    standalonePipe.setLength(lengthM);
+    standalonePipe.setDiameter(diameterM);
+    standalonePipe.setPipeWallRoughness(roughnessM);
+    standalonePipe.setNumberOfIncrements(segments);
+    standalonePipe.run();
+
+    PipeBeggsAndBrills networkModel = networkPipe.getBBModel();
+    assertNotNull(networkModel);
+    assertEquals(roughnessM, networkModel.getPipeWallRoughness(), 1e-12);
+    assertEquals(standalonePipe.getPressureDrop(), networkModel.getPressureDrop(), 1e-8);
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/network/LoopedPipeNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/LoopedPipeNetworkTest.java
@@ -1741,6 +1741,30 @@ class LoopedPipeNetworkTest {
   }
 
   /**
+   * Test that the configured pipe model applies to ordinary pipes added afterwards.
+   */
+  @Test
+  void testConfiguredBeggsBrillAppliesToAddedPipe() {
+    LoopedPipeNetwork network = new LoopedPipeNetwork("ConfiguredMultiphaseNet");
+    network.setFluidTemplate(testGas);
+    network.setSolverType(LoopedPipeNetwork.SolverType.NEWTON_RAPHSON);
+    network.setMaxIterations(200);
+    network.setTolerance(100.0);
+    network.setPipeModelType(LoopedPipeNetwork.PipeModelType.BEGGS_BRILL);
+
+    network.addSourceNode("wellhead", 80.0, 0.0);
+    network.addFixedPressureSinkNode("platform", 40.0);
+    LoopedPipeNetwork.NetworkPipe flowline =
+        network.addPipe("wellhead", "platform", "flowline", 15000.0, 0.2);
+
+    network.run();
+
+    assertTrue(network.isConverged(), "Configured multiphase pipe network should converge");
+    assertEquals(LoopedPipeNetwork.NetworkElementType.MULTIPHASE_PIPE, flowline.getElementType());
+    assertEquals("BB-Multiphase", flowline.getFlowRegime());
+  }
+
+  /**
    * Test VFP table export (Improvement #8).
    */
   @Test

--- a/src/test/java/neqsim/process/equipment/network/LoopedPipeNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/LoopedPipeNetworkTest.java
@@ -1790,7 +1790,9 @@ class LoopedPipeNetworkTest {
     PipeBeggsAndBrills networkModel = networkPipe.getBBModel();
     assertNotNull(networkModel);
     assertEquals(roughnessM, networkModel.getPipeWallRoughness(), 1e-12);
-    assertEquals(standalonePipe.getPressureDrop(), networkModel.getPressureDrop(), 1e-8);
+    double standalonePressureDropBar = standalonePipe.getPressureDrop();
+    double pressureDropToleranceBar = Math.max(1e-6, Math.abs(standalonePressureDropBar) * 1e-6);
+    assertEquals(standalonePressureDropBar, networkModel.getPressureDrop(), pressureDropToleranceBar);
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/network/LoopedPipeNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/LoopedPipeNetworkTest.java
@@ -1763,8 +1763,8 @@ class LoopedPipeNetworkTest {
     network.getNode("wellhead").setTemperature(inletTemperatureK);
     network.addFixedPressureSinkNode("platform", 40.0);
 
-    LoopedPipeNetwork.NetworkPipe networkPipe =
-        network.addMultiphasePipe("wellhead", "platform", "flowline", lengthM, diameterM);
+    LoopedPipeNetwork.NetworkPipe networkPipe = network.addMultiphasePipe("wellhead", "platform", "flowline", lengthM,
+        diameterM);
     networkPipe.setRoughness(roughnessM);
     networkPipe.setMultiphaseSegments(segments);
     network.run();
@@ -1780,8 +1780,7 @@ class LoopedPipeNetworkTest {
     standaloneInlet.setFlowRate(flowRateKgHr, "kg/hr");
     standaloneInlet.run();
 
-    PipeBeggsAndBrills standalonePipe =
-        new PipeBeggsAndBrills("standalone Beggs-Brill", standaloneInlet);
+    PipeBeggsAndBrills standalonePipe = new PipeBeggsAndBrills("standalone Beggs-Brill", standaloneInlet);
     standalonePipe.setLength(lengthM);
     standalonePipe.setDiameter(diameterM);
     standalonePipe.setPipeWallRoughness(roughnessM);
@@ -1808,8 +1807,7 @@ class LoopedPipeNetworkTest {
 
     network.addSourceNode("wellhead", 80.0, 0.0);
     network.addFixedPressureSinkNode("platform", 40.0);
-    LoopedPipeNetwork.NetworkPipe flowline =
-        network.addPipe("wellhead", "platform", "flowline", 15000.0, 0.2);
+    LoopedPipeNetwork.NetworkPipe flowline = network.addPipe("wellhead", "platform", "flowline", 15000.0, 0.2);
 
     network.run();
 


### PR DESCRIPTION
## Summary

- apply `setPipeModelType(BEGGS_BRILL)` to ordinary pipes created by subsequent `addPipe(...)` calls
- preserve the default Darcy-Weisbach behavior and leave existing or explicitly typed elements unchanged
- pass `NetworkPipe` roughness directly to `PipeBeggsAndBrills` in metres instead of multiplying it by 1000
- add regression coverage for configured model dispatch and pressure-drop parity with a standalone Beggs-Brill pipe
- document model-selection semantics, metre-based roughness, and the current `addMultiphasePipe(...)` signature

## Root cause

`pipeModelType` was stored but never applied when `addPipe(...)` created a `PIPE`, so the head-loss dispatcher always chose Darcy-Weisbach. Separately, `calculateHeadLossMultiphase(...)` treated the metre-based network roughness as if the Beggs-Brill setter expected millimetres, although that setter also expects metres.

## Compatibility

The default remains `DARCY_WEISBACH`. Calling `setPipeModelType(...)` affects only later ordinary `addPipe(...)` calls. Existing pipes and specialized elements such as chokes and tubing retain their explicit element types.

## Validation

- `git diff --check` passes
- remote branch blobs were verified against the reviewed local files
- Pre-commit checks: passed
- Spotless format patch: passed with no remaining formatting diff
- Java 21 Javadoc: passed
- PaperLab replication gate: passed
- Java 21 fast and slow test jobs: running on the latest commit at the time of this update
- local focused Maven execution could not start because Maven Central was unavailable in the execution environment (`repo1.maven.org: Temporary failure in name resolution`)

The Copilot review suggestion was incorporated by replacing the absolute `1e-8` bar pressure-drop tolerance with a small relative tolerance plus an absolute floor.

## Documentation impact

Updated the public Javadocs for pipe model selection and Beggs-Brill roughness units, plus `docs/process/equipment/production_well_networks.md` with model-selection behavior, metre-based roughness, and corrected method signatures.

Closes #2656
Closes #2657