### PR TITLE
Fix direct tray feeds in Naphtali-Sandholm equations

### DIFF
--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -836,10 +836,11 @@ public class NaphtaliSandholmSolver {
     hasReboiler = column.hasReboiler();
     hasCondenser = column.hasCondenser();
 
-    // Get number of components from the first feed
-    Map<Integer, List<StreamInterface>> feedMap = column.getFeedStreams();
+    // Get number of components from the first external feed. This includes legacy
+    // side feeds connected directly to a tray as well as registered column feeds.
     StreamInterface firstFeed = null;
-    for (List<StreamInterface> feeds : feedMap.values()) {
+    for (int trayIndex = 0; trayIndex < N; trayIndex++) {
+      List<StreamInterface> feeds = column.getExternalFeedStreams(trayIndex);
       if (!feeds.isEmpty()) {
         firstFeed = feeds.get(0);
         break;
@@ -908,14 +909,14 @@ public class NaphtaliSandholmSolver {
       }
     }
 
-    // Process feed streams
+    // Process every external feed in the same deterministic tray/stream order used
+    // when DistillationColumn captured originalFeedSystems and flow rates.
     // Use originalFeedSystems (cloned before init() corrupted them) if available.
-    for (Map.Entry<Integer, List<StreamInterface>> entry : feedMap.entrySet()) {
-      int trayIdx = entry.getKey();
-      if (trayIdx < 0 || trayIdx >= N) {
+    for (int trayIdx = 0; trayIdx < N; trayIdx++) {
+      List<StreamInterface> feeds = column.getExternalFeedStreams(trayIdx);
+      if (feeds.isEmpty()) {
         continue;
       }
-      List<StreamInterface> feeds = entry.getValue();
       List<SystemInterface> origSystems = (originalFeedSystems != null) ? originalFeedSystems.get(trayIdx) : null;
 
       for (int fi = 0; fi < feeds.size(); fi++) {
@@ -1242,10 +1243,11 @@ public class NaphtaliSandholmSolver {
     // initial T-profile.
     double feedTemp = 0;
     double feedTempWeight = 0;
-    Map<Integer, List<StreamInterface>> feedMap = column.getFeedStreams();
-    for (Map.Entry<Integer, List<StreamInterface>> entry : feedMap.entrySet()) {
-      int trayIdx = entry.getKey();
-      List<StreamInterface> feeds = entry.getValue();
+    for (int trayIdx = 0; trayIdx < N; trayIdx++) {
+      List<StreamInterface> feeds = column.getExternalFeedStreams(trayIdx);
+      if (feeds.isEmpty()) {
+        continue;
+      }
       List<SystemInterface> origSystems = (originalFeedSystems != null) ? originalFeedSystems.get(trayIdx) : null;
       for (int fi = 0; fi < feeds.size(); fi++) {
         StreamInterface feed = feeds.get(fi);

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -125,6 +125,70 @@ public class ColumnStudyRegressionTest {
   }
 
   /**
+   * Verify that a legacy top feed connected directly to a tray participates in the simultaneous MESH equations.
+   *
+   * <p>
+   * The public column API registers feeds in the column feed map, while legacy workflows connect side feeds and
+   * stripping gas through {@code getTray(index).addStream(stream)}. Both connections describe the same physical inlet
+   * and must therefore produce the same Naphtali-Sandholm solution. The nearby operating point guards against a
+   * coincidental match at one flow rate.
+   * </p>
+   */
+  @Test
+  public void legacyDirectTopFeedParticipatesInNaphtaliSandholmEquations() {
+    double[] topFeedFactors = { 1.0, 1.1 };
+    for (int caseIndex = 0; caseIndex < topFeedFactors.length; caseIndex++) {
+      double topFeedFactor = topFeedFactors[caseIndex];
+      SystemInterface baseFluid = createBaseFluid();
+      StreamInterface registeredMainFeed = createStream("registered_main_feed_" + caseIndex, baseFluid,
+          MAIN_FEED_COMPOSITION, MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
+      StreamInterface registeredTopFeed = createStream("registered_top_feed_" + caseIndex, baseFluid,
+          TOP_FEED_COMPOSITION, TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA,
+          TOP_FEED_MASS_FLOW_KG_HR * topFeedFactor);
+      DistillationColumn registeredColumn = createColumn(registeredMainFeed, registeredTopFeed, false);
+      registeredColumn.run();
+      assertColumnSolveIsValid(registeredColumn, registeredMainFeed, registeredTopFeed,
+          "registered-feed reference at factor " + topFeedFactor);
+      assertEquals(DistillationColumn.SolverType.NAPHTALI_SANDHOLM, registeredColumn.getLastSolverTypeUsed(),
+          "registered-feed reference should be accepted by the simultaneous solver");
+
+      StreamInterface directMainFeed = createStream("direct_main_feed_" + caseIndex, baseFluid,
+          MAIN_FEED_COMPOSITION, MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
+      StreamInterface directTopFeed = createStream("legacy_direct_top_feed_" + caseIndex, baseFluid,
+          TOP_FEED_COMPOSITION, TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA,
+          TOP_FEED_MASS_FLOW_KG_HR * topFeedFactor);
+      DistillationColumn directColumn = createColumn(directMainFeed, directTopFeed, true);
+      directColumn.run();
+      assertColumnSolveIsValid(directColumn, directMainFeed, directTopFeed,
+          "legacy direct-feed case at factor " + topFeedFactor);
+      assertEquals(DistillationColumn.SolverType.NAPHTALI_SANDHOLM, directColumn.getLastSolverTypeUsed(),
+          "a direct tray feed must participate in Naphtali-Sandholm rather than force a fallback");
+
+      ColumnProductSummary registeredProducts = getProductSummary(registeredColumn);
+      ColumnProductSummary directProducts = getProductSummary(directColumn);
+      assertProductSummaryWithinRelativeTolerance(registeredProducts, directProducts, 1.0e-5,
+          "registered and direct connections should describe the same physical column");
+      assertComponentMassBalances(directMainFeed, directTopFeed, directColumn);
+      assertTrue(Double.isFinite(directColumn.getLastMeshMaterialResidualNorm()),
+          "direct-feed material residual should be finite");
+      assertTrue(Double.isFinite(directColumn.getLastMeshEnergyResidualNorm()),
+          "direct-feed energy residual should be finite");
+      assertWithinRelativeTolerance(registeredColumn.getLastMeshMaterialResidualNorm(),
+          directColumn.getLastMeshMaterialResidualNorm(), 1.0e-4,
+          "direct-feed material residual should match the registered reference");
+      assertWithinRelativeTolerance(registeredColumn.getLastMeshEnergyResidualNorm(),
+          directColumn.getLastMeshEnergyResidualNorm(), 1.0e-4,
+          "direct-feed energy residual should match the registered reference");
+      assertEquals(REBOILER_TEMPERATURE_C, directColumn.getReboiler().getTemperature() - 273.15, 1.0e-6,
+          "the fixed reboiler-temperature specification should be satisfied");
+      assertPhysicalProduct(directColumn.getGasOutStream(), "overhead");
+      assertPhysicalProduct(directColumn.getLiquidOutStream(), "bottoms");
+      assertTrue(directColumn.getLastIterationCount() <= 300,
+          "direct-feed simultaneous solve should remain inside the configured iteration budget");
+    }
+  }
+
+  /**
    * Reports cold, unchanged warm, and 10-percent-increased inlet solve times for the column-study case.
    *
    * <p>
@@ -271,6 +335,28 @@ public class ColumnStudyRegressionTest {
   }
 
   /**
+   * Assert finite, positive flow, temperature, and normalized composition for a terminal product.
+   *
+   * @param product terminal product stream
+   * @param label product label used in assertion messages
+   */
+  private void assertPhysicalProduct(StreamInterface product, String label) {
+    assertTrue(Double.isFinite(product.getFlowRate("kg/hr")) && product.getFlowRate("kg/hr") > 0.0,
+        label + " flow should be finite and positive");
+    assertTrue(Double.isFinite(product.getTemperature()) && product.getTemperature() > 0.0,
+        label + " temperature should be finite and positive");
+    double compositionSum = 0.0;
+    double[] composition = product.getThermoSystem().getMolarComposition();
+    for (int componentIndex = 0; componentIndex < composition.length; componentIndex++) {
+      assertTrue(Double.isFinite(composition[componentIndex]) && composition[componentIndex] >= 0.0
+          && composition[componentIndex] <= 1.0, label + " composition should remain physical at component "
+              + componentIndex);
+      compositionSum += composition[componentIndex];
+    }
+    assertEquals(1.0, compositionSum, 1.0e-8, label + " composition should remain normalized");
+  }
+
+  /**
    * Assert that a completed column solve converged and preserves the external mass balance.
    *
    * @param column solved column
@@ -371,9 +457,26 @@ public class ColumnStudyRegressionTest {
    * @return configured column ready to run
    */
   private DistillationColumn createColumn(StreamInterface feedStream, StreamInterface topFeedStream) {
+    return createColumn(feedStream, topFeedStream, false);
+  }
+
+  /**
+   * Create and configure the column-study distillation column with a selected top-feed connection style.
+   *
+   * @param feedStream main column feed
+   * @param topFeedStream external top reflux feed
+   * @param directTopFeed whether to connect the top feed directly to its tray for legacy compatibility testing
+   * @return configured column ready to run
+   */
+  private DistillationColumn createColumn(StreamInterface feedStream, StreamInterface topFeedStream,
+      boolean directTopFeed) {
     DistillationColumn column = new DistillationColumn("20VE105_205_standalone", NUMBER_OF_TRAYS, true, false);
     column.addFeedStream(feedStream, answerTrayToNeqSimStage(5));
-    column.addFeedStream(topFeedStream, answerTrayToNeqSimStage(1));
+    if (directTopFeed) {
+      column.getTray(answerTrayToNeqSimStage(1)).addStream(topFeedStream);
+    } else {
+      column.addFeedStream(topFeedStream, answerTrayToNeqSimStage(1));
+    }
     column.setTopPressure(TOP_PRESSURE_BARA);
     column.setBottomPressure(getCompensatedBottomPressure());
     column.getReboiler().setOutletTemperature(273.15 + REBOILER_TEMPERATURE_C);

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -152,8 +152,8 @@ public class ColumnStudyRegressionTest {
       assertEquals(DistillationColumn.SolverType.NAPHTALI_SANDHOLM, registeredColumn.getLastSolverTypeUsed(),
           "registered-feed reference should be accepted by the simultaneous solver");
 
-      StreamInterface directMainFeed = createStream("direct_main_feed_" + caseIndex, baseFluid,
-          MAIN_FEED_COMPOSITION, MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
+      StreamInterface directMainFeed = createStream("direct_main_feed_" + caseIndex, baseFluid, MAIN_FEED_COMPOSITION,
+          MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
       StreamInterface directTopFeed = createStream("legacy_direct_top_feed_" + caseIndex, baseFluid,
           TOP_FEED_COMPOSITION, TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA,
           TOP_FEED_MASS_FLOW_KG_HR * topFeedFactor);
@@ -348,9 +348,10 @@ public class ColumnStudyRegressionTest {
     double compositionSum = 0.0;
     double[] composition = product.getThermoSystem().getMolarComposition();
     for (int componentIndex = 0; componentIndex < composition.length; componentIndex++) {
-      assertTrue(Double.isFinite(composition[componentIndex]) && composition[componentIndex] >= 0.0
-          && composition[componentIndex] <= 1.0, label + " composition should remain physical at component "
-              + componentIndex);
+      assertTrue(
+          Double.isFinite(composition[componentIndex]) && composition[componentIndex] >= 0.0
+              && composition[componentIndex] <= 1.0,
+          label + " composition should remain physical at component " + componentIndex);
       compositionSum += composition[componentIndex];
     }
     assertEquals(1.0, compositionSum, 1.0e-8, label + " composition should remain normalized");


### PR DESCRIPTION
## Problem

Legacy column workflows may connect side feeds or stripping gas with `column.getTray(index).addStream(stream)`. `DistillationColumn` already includes those streams when it preserves feed state, fingerprints warm-state compatibility, and evaluates column MESH and mass-balance diagnostics. `NaphtaliSandholmSolver.initialize()`, however, assembled its component feed terms, phase enthalpy terms, and feed-temperature initialization only from `column.getFeedStreams()`, which contains registered feeds only.

The result was an internally inconsistent simultaneous solve: a direct tray feed existed at the process boundary and in the diagnostics but was absent from the Naphtali–Sandholm equations. A direct-only column could report no feed, while mixed registered/direct cases could reject the simultaneous candidate, fall back, or disagree with the physically equivalent registered-feed case.

## Reproduction and baseline evidence

Commit `84b427ad` adds the regression before the production change. It uses the existing 10-stage multicomponent column-study case and compares:

- the documented registered connection through `addFeedStream`;
- the physically equivalent legacy direct tray connection;
- the published top-feed rate; and
- a nearby +10% top-feed rate.

On the pre-fix source path, all three Naphtali feed-assembly loops iterate `column.getFeedStreams()`; direct tray feeds are therefore deterministically omitted even though `DistillationColumn.getExternalFeedStreams(tray)` and the column diagnostics include them. The initial test-only CI attempts were cancelled by later pushes before producing a numeric assertion report, so this PR does not claim a completed pre-fix timing or residual measurement.

## Root cause

The column had two valid internal feed representations, but the simultaneous solver consumed only the registered map. This violated the solver’s own original-feed snapshot ordering and made equation assembly disagree with the process boundary used by validation and fallback logic.

## Algorithmic change

`NaphtaliSandholmSolver` now walks trays in deterministic order and uses the column’s existing package-private unified external-feed view for:

1. selecting the reference feed and component count;
2. assembling all feed component/material terms;
3. assembling phase enthalpy/energy feed terms; and
4. forming the feed-temperature initialization anchor.

The solver uses the same tray/stream order as the column’s original-system and flow snapshots. No tolerance, thermodynamic model, line search, residual acceptance criterion, or fallback policy is changed.

## Regression and engineering validation

`legacyDirectTopFeedParticipatesInNaphtaliSandholmEquations()` requires both connection styles and both operating points to:

- be accepted by `NAPHTALI_SANDHOLM`, not a fallback;
- agree in overhead and bottoms products within relative tolerance;
- close total and component mass balances;
- produce finite material and energy residuals that agree with the registered reference;
- maintain positive finite product flow and temperature;
- maintain bounded, normalized compositions;
- satisfy the fixed reboiler-temperature specification; and
- remain within the configured 300-iteration budget.

This is a correctness and applicability fix; no wall-clock speed claim is made.

## Validation status

Completed on exact head `819c871c`:

- focused `ColumnStudyRegressionTest`: 3/3 passed on Java 21 Windows (49.65 s), Java 21 Ubuntu (53.84 s), Java 8 Windows (68.79 s), and Java 8 Ubuntu (120.9 s);
- full Java 21 Windows and Ubuntu suites: 10,853 tests passed on each platform, 0 failures/errors, 212 skipped;
- full Java 8 Windows and Ubuntu suites: 10,853 tests passed on each platform, 0 failures/errors, 212 skipped;
- all three Java 21 slow-test shards;
- Spotless, pre-commit, PaperLab, CodeQL, Javadoc, and reference checks;
- Copilot review of both changed files with no findings; and
- no unresolved review threads.

The exact two-file implementation was merged into `master` as `62f657df` on 29 July 2026. A post-merge rerun of the preserved test-only commit `84b427ad` is in progress solely to capture the pre-fix assertion evidence; it cannot alter the merged implementation.

## Compatibility and risk

- No public API, serialized field, cloning contract, thread-local state, or calculation identity changes.
- Registered feeds retain their existing order and behavior.
- Direct tray feeds already recognized by the column are now recognized consistently by the simultaneous solver.
- Main residual risk is interaction with unusual multi-feed tray ordering; deterministic tray-order and two-rate equivalence coverage reduce that risk.

## Documentation impact

Documentation impact: none. The public `addFeedStream` API and its documentation remain unchanged. This repair aligns the internal legacy tray-connection path with existing column behavior and does not introduce a new user-facing API or configuration.

## Remaining limitations

This PR does not add a new public side-feed API, change fallback selection, or extend side-draw modeling. Those are independent follow-up scopes.