### PR TITLE
docs: update Colab quickstart JavaDoc link

### DIFF
--- a/docs/quickstart/colab-quickstart.md
+++ b/docs/quickstart/colab-quickstart.md
@@ -187,7 +187,7 @@ plt.show()
 
 ## Next Steps
 
-- **[Python Quickstart](python-quickstart)** - Local Python installation
-- **[Examples](../examples/index)** - More notebook tutorials
-- **[Cookbook](../cookbook/index)** - Quick recipes
-- **[JavaDoc API](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html)** - Complete API reference
+- **[Python Quickstart](python-quickstart.md)** - Local Python installation
+- **[Examples](../examples/index.md)** - More notebook tutorials
+- **[Cookbook](../cookbook/index.md)** - Quick recipes
+- **[JavaDoc API](https://equinor.github.io/neqsim/javadoc/index.html)** - Complete API reference


### PR DESCRIPTION
## Documentation campaign

Continues #2499 as scan batch **D042** (rotation scope 7: JavaDoc-facing examples, Python snippets, notebooks, images, and external links).

### Frozen changed path

- `docs/quickstart/colab-quickstart.md`

No Java, notebook, image, thermodynamic, or process-model files are changed.

## Confirmed defect and root cause

- **Medium — external-reference accuracy:** the Colab quickstart labels the legacy `neqsimhome` JavaDoc as the complete API reference, but that endpoint currently identifies itself as **NeqSim 3.9.1 API**.
- The repository's `.github/workflows/publish_javadoc.yml` publishes release JavaDoc to `javadoc/index.html` on the dedicated `javadoc` branch. Its current overview identifies **NeqSim 3.16.0 API**.
- **Low — source-link conformance:** the three internal next-step links omitted their `.md` source extensions.

## Fix

- Point the quickstart to `https://equinor.github.io/neqsim/javadoc/index.html`, the destination produced by the repository's release workflow.
- Add `.md` to the Python quickstart, examples index, and cookbook index destinations.
- Preserve every Colab notebook, badge, Python snippet, numerical value, and figure unchanged because they validated cleanly.

## Validation completed before publication

Mandatory fresh environment:

- Resolution: `online-new-snapshot`
- NeqSim 3.16.0
- Python 3.12.13
- OpenJDK 17.0.19
- 49 public-PyPI wheels with inventory, size, and SHA-256 verification

Executed Python workflows:

- First flash: one phase, 43.42 kg/m³, Z = 0.8778.
- Process example: 7,588.310 kg/h gas, 2,411.690 kg/h liquid, 202.162 kW compression.
- Product mass flow closes to the 10,000 kg/h feed within `1e-3 kg/h`.
- Phase envelope: 34 dew points and 41 bubble points.
- The generated phase-envelope figure was visually inspected; axes, units, curves, legend, and grid are legible.

Link and structure checks:

- All four repository notebook blobs and the NeqSim-Colab catalog notebook exist.
- Some Colab frontend probes returned tool-internal errors while other Colab pages loaded. These were treated as transient and no notebook link was replaced from a single failed probe.
- The new JavaDoc target is backed by `javadoc/javadoc/index.html` on the repository's `javadoc` branch and identifies NeqSim 3.16.0.
- All three internal destinations exist at the exact branch head.
- Jekyll front matter, Markdown-only headings outside code fences, six balanced code-fence pairs, tables, images, and HTML/Markdown interactions were checked.
- No equations are present.
- Exact diff: one file, 4 additions and 4 deletions.

## Exact-head hosted validation

Validated head: `8c96f25c4b103176b0ede6697fa5643dce27125e`.

- Documentation build and generated-search coverage passed.
- Javadoc/build, pre-commit, Spotless, CodeQL, agent-reference, and changed-file checks passed.
- The PR is one commit ahead and zero behind `master`, mergeable, with exactly one changed file and 4 additions/4 deletions.
- Copilot reviewed 1/1 changed file and generated no inline comments, suggested-change blocks, or unresolved threads.
- No accepted suggestion remains unvalidated.

## Exclusions and next scope

- The broader repository-wide legacy JavaDoc-link inventory is not changed opportunistically in this bounded batch; this PR establishes and validates the correct destination for follow-up batches.
- D042 remains incomplete while this PR is open.
- Next rotation after D042 completes: scope 8, recent merged code versus documentation coverage.
