### PR TITLE
docs: repair thermodynamic operations overview

### DIFF
--- a/docs/thermo/thermodynamic_operations.md
+++ b/docs/thermo/thermodynamic_operations.md
@@ -50,7 +50,7 @@ public final class ThermodynamicOperationsQuickStart {
     operations.PHflash(inletEnthalpy);
     fluid.initProperties();
 
-    logger.info("Gas fraction: {} mol/mol", vaporFraction);
+    logger.info("Inlet gas fraction: {} mol/mol", vaporFraction);
     logger.info("Inlet density: {} kg/m3", inletDensity);
     logger.info("Outlet temperature: {} C", fluid.getTemperature("C"));
     logger.info("Enthalpy residual: {} J", fluid.getEnthalpy() - inletEnthalpy);
@@ -71,12 +71,12 @@ portable exact output values.
 | `PHflash(H)` | pressure and total enthalpy | temperature and phase equilibrium | valve, heater, or heat exchanger |
 | `PSflash(S)` | pressure and total entropy | temperature and phase equilibrium | ideal compressor or expander reference |
 | `TVflash(V, "m3")` | temperature and total volume | pressure and phase equilibrium | fixed-volume screening |
-| `VUflash(V, U, "m3", "J")` | total volume and internal energy | temperature, pressure, and phases | dynamic vessel calculations |
+| `VUflash(V, u, "m3", "J/kg")` | total volume and specific internal energy | temperature, pressure, and phases | dynamic vessel calculations |
 
 The no-unit `PHflash` and `PSflash` overloads use total system enthalpy and entropy in NeqSim's
-internal SI representation. Prefer the overloads with explicit unit strings when values originate
-outside NeqSim. Volume and energy specifications are extensive quantities, so preserve the
-system's material amount when copying a specification between fluids.
+internal SI representation. Prefer supported explicit unit strings when values originate outside
+NeqSim. A total-volume specification belongs to the fluid inventory from which it was calculated,
+so preserve the system's material amount when copying it between states.
 
 ## Property initialization boundary
 

--- a/docs/thermo/thermodynamic_operations.md
+++ b/docs/thermo/thermodynamic_operations.md
@@ -67,8 +67,8 @@ portable exact output values.
 | `TPflash()` | temperature and pressure | phase amounts and compositions | separator or pipeline state |
 | `PHflash(H)` | pressure and total enthalpy | temperature and phase equilibrium | valve, heater, or heat exchanger |
 | `PSflash(S)` | pressure and total entropy | temperature and phase equilibrium | ideal compressor or expander reference |
-| `TVflash(V)` | temperature and total volume | pressure and phase equilibrium | fixed-volume screening |
-| `VUflash(V, U)` | total volume and internal energy | temperature, pressure, and phases | dynamic vessel calculations |
+| `TVflash(V, "m3")` | temperature and total volume | pressure and phase equilibrium | fixed-volume screening |
+| `VUflash(V, U, "m3", "J")` | total volume and internal energy | temperature, pressure, and phases | dynamic vessel calculations |
 
 The no-unit `PHflash` and `PSflash` overloads use total system enthalpy and entropy in NeqSim's
 internal SI representation. Prefer the overloads with explicit unit strings when values originate

--- a/docs/thermo/thermodynamic_operations.md
+++ b/docs/thermo/thermodynamic_operations.md
@@ -19,11 +19,16 @@ This Java 8 program performs a TP flash at 25 °C and 50 bara, initializes prope
 calculates the state after an isenthalpic pressure reduction to 30 bara.
 
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 public final class ThermodynamicOperationsQuickStart {
+  private static final Logger logger =
+      LogManager.getLogger(ThermodynamicOperationsQuickStart.class);
+
   private ThermodynamicOperationsQuickStart() {}
 
   public static void main(String[] args) {
@@ -45,12 +50,10 @@ public final class ThermodynamicOperationsQuickStart {
     operations.PHflash(inletEnthalpy);
     fluid.initProperties();
 
-    System.out.printf("Gas fraction: %.6f mol/mol%n", vaporFraction);
-    System.out.printf("Inlet density: %.3f kg/m3%n", inletDensity);
-    System.out.printf("Outlet temperature: %.3f C%n", fluid.getTemperature("C"));
-    System.out.printf(
-        "Enthalpy residual: %.6g J%n",
-        fluid.getEnthalpy() - inletEnthalpy);
+    logger.info("Gas fraction: {} mol/mol", vaporFraction);
+    logger.info("Inlet density: {} kg/m3", inletDensity);
+    logger.info("Outlet temperature: {} C", fluid.getTemperature("C"));
+    logger.info("Enthalpy residual: {} J", fluid.getEnthalpy() - inletEnthalpy);
   }
 }
 ```

--- a/docs/thermo/thermodynamic_operations.md
+++ b/docs/thermo/thermodynamic_operations.md
@@ -1,40 +1,120 @@
 ---
 title: "Thermodynamic Operations"
-description: "Thermodynamic operations execute equilibrium and property tasks using a configured fluid. Most workflows create a `ThermodynamicOperations` object once and reuse it for multiple calls."
+description: "Run NeqSim flash calculations safely, initialize thermodynamic and transport properties, and select the dedicated workflow for phase envelopes, hydrates, solids, electrolytes, and reactive systems."
+keywords: "NeqSim, ThermodynamicOperations, TPflash, PHflash, PSflash, phase equilibrium, flash calculation, thermodynamic properties"
 ---
 
-# Thermodynamic Operations
+`ThermodynamicOperations` solves equilibrium and state-function specifications for a configured
+`SystemInterface`. A reliable workflow is:
 
-Thermodynamic operations execute equilibrium and property tasks using a configured fluid. Most workflows create a `ThermodynamicOperations` object once and reuse it for multiple calls.
+1. define the fluid and mixing rule;
+2. set the known state variables;
+3. run the appropriate flash;
+4. call `initProperties()` before reading density or transport properties; and
+5. check that the resulting phases and engineering values are physical.
 
-## Flash Calculations
-- **`TPflash()`**: Calculates phase split at specified temperature and pressure. Run `initProperties()` afterward for density/viscosity.
-- **`PHflash(H)` and `PSflash(S)`**: Solve for temperature/phase split given enthalpy or entropy targets—useful for compressors and turbines. Set the pressure on the fluid with `setPressure()` before calling these.
-- **`TVflash(V)`**: Volume-constrained flash—finds pressure at fixed temperature and total volume.
-- **`VUflash(V, U)`**: Volume- and internal-energy-constrained flash for transient simulations.
+## Complete Java quick start
+
+This Java 8 program performs a TP flash at 25 °C and 50 bara, initializes properties, and then
+calculates the state after an isenthalpic pressure reduction to 30 bara.
 
 ```java
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.TPflash();
-double vaporFraction = fluid.getBeta();
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+public final class ThermodynamicOperationsQuickStart {
+  private ThermodynamicOperationsQuickStart() {}
+
+  public static void main(String[] args) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.90);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.03);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+    fluid.initProperties();
+
+    double vaporFraction = fluid.getPhaseFraction("gas", "mole");
+    double inletDensity = fluid.getDensity("kg/m3");
+    double inletEnthalpy = fluid.getEnthalpy();
+
+    fluid.setPressure(30.0, "bara");
+    operations.PHflash(inletEnthalpy);
+    fluid.initProperties();
+
+    System.out.printf("Gas fraction: %.6f mol/mol%n", vaporFraction);
+    System.out.printf("Inlet density: %.3f kg/m3%n", inletDensity);
+    System.out.printf("Outlet temperature: %.3f C%n", fluid.getTemperature("C"));
+    System.out.printf(
+        "Enthalpy residual: %.6g J%n",
+        fluid.getEnthalpy() - inletEnthalpy);
+  }
+}
 ```
 
-## Phase Envelopes
-- **PT envelope**: `ops.calcPTphaseEnvelope()` fills critical point, cricondenbar, cricondentherm, and two-phase boundary.
-- **Hydrate curves**: Enable `hydrateCheck(true)` before calling `ops.hydrateFormationTemperature(pressure)`.
-- **Wax/solid envelopes**: Use a solid-enabled system and call `ops.calcSolidFormationTemperature()`.
+For this lean-gas case, the focused documentation regression requires a gas fraction above
+0.999 mol/mol, an inlet density between 35 and 50 kg/m³, a finite outlet temperature, and
+isenthalpic closure within 0.001 J. These are deliberately bounded engineering checks rather than
+portable exact output values.
 
-## Property Routines
-After flashes, properties are available on each phase:
-- `getDensity()` or `getNumberOfMoles()` for molar/volume properties.
-- `getEnthalpy()`, `getEntropy()`, and `getCp()` for energy balances.
-- `getViscosity()`, `getThermalConductivity()`, and `getInterfacialTension()` for transport analyses.
+## Choose the flash from the specification
 
-## Electrolytes and Reactions
-- **Electrolytes**: Build systems such as `SystemFurstElectrolyteEos` or `SystemElectrolyteCPAstatoil`, add salts/acids, and enable charge balance. Use `ops.electrolyteFlash()` for salt precipitation studies.
-- **Chemical reactions**: Define reactions with stoichiometry and equilibrium constants, then call `ops.calcChemicalEquilibrium()` to couple them into flashes.
+| Operation | Known state | Solved state | Typical use |
+|---|---|---|---|
+| `TPflash()` | temperature and pressure | phase amounts and compositions | separator or pipeline state |
+| `PHflash(H)` | pressure and total enthalpy | temperature and phase equilibrium | valve, heater, or heat exchanger |
+| `PSflash(S)` | pressure and total entropy | temperature and phase equilibrium | ideal compressor or expander reference |
+| `TVflash(V)` | temperature and total volume | pressure and phase equilibrium | fixed-volume screening |
+| `VUflash(V, U)` | total volume and internal energy | temperature, pressure, and phases | dynamic vessel calculations |
 
-## Best Practices
-- Always reinitialize (`fluid.init(3)`) after changing temperature, pressure, or composition significantly.
-- Reuse the same `ThermodynamicOperations` instance when sweeping conditions to avoid rebuilding internal caches.
-- For performance-sensitive loops, pre-allocate fluids and avoid repeated parsing of the component database.
+The no-unit `PHflash` and `PSflash` overloads use total system enthalpy and entropy in NeqSim's
+internal SI representation. Prefer the overloads with explicit unit strings when values originate
+outside NeqSim. Volume and energy specifications are extensive quantities, so preserve the
+system's material amount when copying a specification between fluids.
+
+## Property initialization boundary
+
+A flash establishes the equilibrium state. It does not guarantee that all transport-property
+models have been evaluated. Call `initProperties()` after the flash before retrieving density,
+viscosity, thermal conductivity, or interfacial tension.
+
+Use bulk getters such as `fluid.getDensity("kg/m3")` only when a bulk value is meaningful. For
+multiphase systems, check phase existence and retrieve a named phase explicitly, for example
+`fluid.getPhase("gas").getDensity("kg/m3")`.
+
+Do not use `init(3)` as a replacement for a flash after changing temperature, pressure, or
+composition. The flash operation establishes the new equilibrium; `initProperties()` then
+initializes thermodynamic and physical properties for the accepted state.
+
+## Specialized equilibrium workflows
+
+The compact quick start above covers state flashes. Use the dedicated guides for operations that
+need additional phase configuration, model selection, or result extraction:
+
+- [Flash calculations](flash_calculations_guide.md) — saturation, phase-envelope, critical-point,
+  hydrate, and solid operations;
+- [Reactive flash](reactive_flash.md) — simultaneous chemical and phase equilibrium;
+- [Electrolyte CPA](ElectrolyteCPAModel.md) — electrolyte-system construction and applicability;
+- [Hydrate models](hydrate_models.md) — hydrate structures, inhibitors, and formation conditions;
+- [Physical properties](physical_properties.md) — density and transport-property models.
+
+There is no generic `electrolyteFlash()`, `calcChemicalEquilibrium()`, or
+`calcSolidFormationTemperature()` method on `ThermodynamicOperations`. Select the documented
+operation for the physical problem instead of relying on those legacy names.
+
+## Reuse and independent calculations
+
+Reuse one `ThermodynamicOperations` instance while changing the state of the same fluid. Clone the
+fluid and construct a separate operations object when two calculations must remain independent.
+Always validate phase existence, conservation, units, and convergence before using a result in an
+engineering decision.
+
+## Related documentation
+
+- [Fluid creation](fluid_creation_guide.md)
+- [Mixing rules](mixing_rules_guide.md)
+- [Thermodynamic workflows](thermodynamic_workflows.md)
+- [Thermodynamic models](thermodynamic_models.md)

--- a/docs/thermo/thermodynamic_operations.md
+++ b/docs/thermo/thermodynamic_operations.md
@@ -42,6 +42,9 @@ public final class ThermodynamicOperationsQuickStart {
     operations.TPflash();
     fluid.initProperties();
 
+    if (!fluid.hasPhaseType("gas")) {
+      throw new IllegalStateException("Expected a gas phase after the TP flash");
+    }
     double vaporFraction = fluid.getPhaseFraction("gas", "mole");
     double inletDensity = fluid.getDensity("kg/m3");
     double inletEnthalpy = fluid.getEnthalpy();

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -1664,4 +1664,35 @@ public class DocExamplesCompilationTest {
     assertEquals(60.0, unmetDemand / 1000.0, 1.0e-12);
   }
 
+
+  /**
+   * Complete Java quick start from docs/thermo/thermodynamic_operations.md.
+   */
+  @Test
+  public void testThermodynamicOperationsOverviewQuickStart() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.90);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.03);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+    fluid.initProperties();
+
+    double vaporFraction = fluid.getPhaseFraction("gas", "mole");
+    double inletDensity = fluid.getDensity("kg/m3");
+    double inletEnthalpy = fluid.getEnthalpy();
+
+    fluid.setPressure(30.0, "bara");
+    operations.PHflash(inletEnthalpy);
+    fluid.initProperties();
+
+    assertTrue(vaporFraction > 0.999);
+    assertTrue(inletDensity > 35.0);
+    assertTrue(inletDensity < 50.0);
+    assertTrue(Double.isFinite(fluid.getTemperature("C")));
+    assertEquals(inletEnthalpy, fluid.getEnthalpy(), 1.0e-3);
+  }
+
 }

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -1664,7 +1664,6 @@ public class DocExamplesCompilationTest {
     assertEquals(60.0, unmetDemand / 1000.0, 1.0e-12);
   }
 
-
   /**
    * Complete Java quick start and operation table from docs/thermo/thermodynamic_operations.md.
    */

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -1679,6 +1679,7 @@ public class DocExamplesCompilationTest {
     operations.TPflash();
     fluid.initProperties();
 
+    assertTrue(fluid.hasPhaseType("gas"));
     double vaporFraction = fluid.getPhaseFraction("gas", "mole");
     double inletDensity = fluid.getDensity("kg/m3");
     double inletEnthalpy = fluid.getEnthalpy();
@@ -1688,7 +1689,6 @@ public class DocExamplesCompilationTest {
     double inletSpecificInternalEnergy = fluid.getInternalEnergy("J/kg");
     SystemInterface initialState = fluid.clone();
 
-    assertTrue(fluid.hasPhaseType("gas"));
     double gasDensity = fluid.getPhase("gas").getDensity("kg/m3");
     assertTrue(gasDensity > 35.0);
     assertTrue(gasDensity < 50.0);

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -1685,10 +1685,13 @@ public class DocExamplesCompilationTest {
     double inletEntropy = fluid.getEntropy();
     double inletVolume = fluid.getVolume("m3");
     double inletInternalEnergy = fluid.getInternalEnergy();
+    double inletSpecificInternalEnergy = fluid.getInternalEnergy("J/kg");
     SystemInterface initialState = fluid.clone();
 
     assertTrue(fluid.hasPhaseType("gas"));
-    assertEquals(inletDensity, fluid.getPhase("gas").getDensity("kg/m3"), 1.0e-9);
+    double gasDensity = fluid.getPhase("gas").getDensity("kg/m3");
+    assertTrue(gasDensity > 35.0);
+    assertTrue(gasDensity < 50.0);
 
     fluid.setPressure(30.0, "bara");
     operations.PHflash(inletEnthalpy);
@@ -1710,7 +1713,7 @@ public class DocExamplesCompilationTest {
     vuFluid.setTemperature(310.0, "K");
     vuFluid.setPressure(35.0, "bara");
     ThermodynamicOperations vuOperations = new ThermodynamicOperations(vuFluid);
-    vuOperations.VUflash(inletVolume, inletInternalEnergy, "m3", "J");
+    vuOperations.VUflash(inletVolume, inletSpecificInternalEnergy, "m3", "J/kg");
     vuFluid.initProperties();
 
     assertTrue(vaporFraction > 0.999);

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -1722,7 +1722,7 @@ public class DocExamplesCompilationTest {
     assertEquals(inletVolume, tvFluid.getVolume("m3"), 1.0e-9);
     assertTrue(tvFluid.getPressure("bara") > 0.0);
     assertEquals(inletVolume, vuFluid.getVolume("m3"), 1.0e-9);
-    assertEquals(inletInternalEnergy, vuFluid.getInternalEnergy(), 1.0e-3);
+    assertEquals(inletInternalEnergy, vuFluid.getInternalEnergy(), 1.0e-2);
     assertTrue(Double.isFinite(vuFluid.getTemperature("K")));
     assertTrue(vuFluid.getPressure("bara") > 0.0);
   }

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -1664,7 +1664,6 @@ public class DocExamplesCompilationTest {
     assertEquals(60.0, unmetDemand / 1000.0, 1.0e-12);
   }
 
-
   /**
    * Complete Java quick start from docs/thermo/thermodynamic_operations.md.
    */

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -1664,8 +1664,9 @@ public class DocExamplesCompilationTest {
     assertEquals(60.0, unmetDemand / 1000.0, 1.0e-12);
   }
 
+
   /**
-   * Complete Java quick start from docs/thermo/thermodynamic_operations.md.
+   * Complete Java quick start and operation table from docs/thermo/thermodynamic_operations.md.
    */
   @Test
   public void testThermodynamicOperationsOverviewQuickStart() {
@@ -1682,16 +1683,49 @@ public class DocExamplesCompilationTest {
     double vaporFraction = fluid.getPhaseFraction("gas", "mole");
     double inletDensity = fluid.getDensity("kg/m3");
     double inletEnthalpy = fluid.getEnthalpy();
+    double inletEntropy = fluid.getEntropy();
+    double inletVolume = fluid.getVolume("m3");
+    double inletInternalEnergy = fluid.getInternalEnergy();
+    SystemInterface initialState = fluid.clone();
+
+    assertTrue(fluid.hasPhaseType("gas"));
+    assertEquals(inletDensity, fluid.getPhase("gas").getDensity("kg/m3"), 1.0e-9);
 
     fluid.setPressure(30.0, "bara");
     operations.PHflash(inletEnthalpy);
     fluid.initProperties();
+
+    SystemInterface psFluid = initialState.clone();
+    psFluid.setPressure(70.0, "bara");
+    ThermodynamicOperations psOperations = new ThermodynamicOperations(psFluid);
+    psOperations.PSflash(inletEntropy);
+    psFluid.initProperties();
+
+    SystemInterface tvFluid = initialState.clone();
+    tvFluid.setPressure(25.0, "bara");
+    ThermodynamicOperations tvOperations = new ThermodynamicOperations(tvFluid);
+    tvOperations.TVflash(inletVolume, "m3");
+    tvFluid.initProperties();
+
+    SystemInterface vuFluid = initialState.clone();
+    vuFluid.setTemperature(310.0, "K");
+    vuFluid.setPressure(35.0, "bara");
+    ThermodynamicOperations vuOperations = new ThermodynamicOperations(vuFluid);
+    vuOperations.VUflash(inletVolume, inletInternalEnergy, "m3", "J");
+    vuFluid.initProperties();
 
     assertTrue(vaporFraction > 0.999);
     assertTrue(inletDensity > 35.0);
     assertTrue(inletDensity < 50.0);
     assertTrue(Double.isFinite(fluid.getTemperature("C")));
     assertEquals(inletEnthalpy, fluid.getEnthalpy(), 1.0e-3);
+    assertEquals(inletEntropy, psFluid.getEntropy(), 1.0e-6);
+    assertEquals(inletVolume, tvFluid.getVolume("m3"), 1.0e-9);
+    assertTrue(tvFluid.getPressure("bara") > 0.0);
+    assertEquals(inletVolume, vuFluid.getVolume("m3"), 1.0e-9);
+    assertEquals(inletInternalEnergy, vuFluid.getInternalEnergy(), 1.0e-3);
+    assertTrue(Double.isFinite(vuFluid.getTemperature("K")));
+    assertTrue(vuFluid.getPressure("bara") > 0.0);
   }
 
 }


### PR DESCRIPTION
## Summary

D045 of #2499 repairs the compact thermodynamic-operations overview and adds an executable documentation contract.

### Frozen scope

- `docs/thermo/thermodynamic_operations.md`
- `src/test/java/neqsim/DocExamplesCompilationTest.java`

### Confirmed defects and root cause

- **High:** nonexistent `electrolyteFlash()`, `calcChemicalEquilibrium()`, and `calcSolidFormationTemperature()` methods were presented as current `ThermodynamicOperations` API.
- **Medium:** hydrate guidance named nonexistent `hydrateCheck(true)` and described the `hydrateFormationTemperature(double)` argument as pressure although source treats it as an initial temperature guess.
- **Medium:** the only Java fragment was incomplete and lacked units, property-initialization boundaries, phase guards, expected behavior, and an executable contract.
- **Medium:** the page implied that `init(3)` can replace equilibrium recalculation and omitted the required `initProperties()` boundary for transport properties.
- **Low:** duplicate H1 and inconsistent Markdown structure weakened Jekyll rendering and navigation.

The page had accumulated shorthand API names without current-source verification.

### Repair

- complete Java 8 TP/PH program with explicit state and property units;
- Log4j2 output and an unambiguous inlet-gas-fraction label;
- explicit gas-phase guard before phase-specific access;
- clear equilibrium-versus-property-initialization boundary;
- bulk-versus-phase property guidance;
- current TP, PH, PS, TV, and VU signatures, with supported `m3` and `J/kg` selectors for VU;
- links to dedicated phase-envelope, hydrate, solid, electrolyte, reactive, and physical-property guides;
- explicit retirement of the three nonexistent operation names;
- focused JUnit coverage for every NeqSim call shown, including state-function and volume closure.

### Regression contract

`testThermodynamicOperationsOverviewQuickStart()` checks:

- gas-phase existence before reading its fraction or density;
- gas fraction > 0.999 mol/mol;
- bulk and gas-phase density in independent 35–50 kg/m³ engineering envelopes;
- finite PH/VU temperatures and positive TV/VU pressures;
- PH total-enthalpy closure within 0.001 J;
- PS total-entropy closure within 1e-6 J/K;
- TV/VU volume closure within 1e-9 m³;
- VU total-internal-energy closure within 0.01 J.

The VU tolerance is based on observed cross-platform solver closure: 0.00164 J residual on approximately 2338 J. The earlier 0.001 J assertion was narrower than the numerical residual and failed Windows despite a physically correct result.

### Exact-head validation

Validated head: `66691b096c046391c95b555db61020f3df1513b6`.

Source and documentation checks:

- exact current `ThermodynamicOperations` and `SystemInterface` signature/unit audit;
- valid front matter, zero source H1s, and balanced Java fences;
- all nine internal documentation targets resolve;
- documentation build and generated search coverage passed;
- Javadoc, pre-commit, CodeQL, and agent-skill reference checks passed;
- Spotless workflow passed and its uploaded patch was inspected: 0 bytes;
- no equations, HTML interactions, images, notebooks, Python, or external links are present in the page, so those execution/link/render classes are not applicable;
- no rendered-site artifact was produced, so browser visual inspection is not claimed.

Executable checks:

- Java 21 Ubuntu: `DocExamplesCompilationTest` 44/44; full suite 10,884 tests, 0 failures, 0 errors, 212 skipped;
- Java 21 Windows: `DocExamplesCompilationTest` 44/44; full suite 10,884 tests, 0 failures, 0 errors, 212 skipped;
- Java 8 Ubuntu: `DocExamplesCompilationTest` 44/44; full suite 10,884 tests, 0 failures, 0 errors, 212 skipped;
- Java 8 Windows: `DocExamplesCompilationTest` 44/44; full suite 10,884 tests, 0 failures, 0 errors, 212 skipped;
- all three Java 21 slow shards passed.

A previous-head Windows run exposed the corrected VU tolerance and an unrelated timing-flaky `ProcessGraphTest.testGraphConstructionOverhead`; neither failure remains on the exact head.

### Copilot disposition

All inline and suppressed suggestions were evaluated against current source, units, numerical behavior, `AGENTS.md`, and repository conventions.

Accepted and validated:

- replace `System.out` with class-level Log4j2 logging;
- clarify that the logged fraction belongs to the inlet TP state;
- remove a brittle bulk-density/phase-density equality;
- replace unsupported VU `"J"` with supported `"J/kg"`;
- guard gas-phase existence before phase-specific access.

Copilot reviewed both files after the final push and raised no new findings. The accepted inline thread contains exact-head evidence and is resolved; no review threads remain open.

### Final scope and exclusions

- final diff: exactly the two frozen files;
- branch is 12 commits ahead and 0 behind current `master`;
- no overlap with open #2632 or #2676;
- excluded: those PRs' thermodynamic/reference/notebook paths, all other thermo pages, production code, notebooks, and Python.

The draft PR is mergeable and remains unmerged. An open PR is not a completed D045 ledger entry. Next rotation after merge: D046, process equipment and process simulation.