### PR TITLE
Fix SimpleTEGAbsorber water and mass conservation

### DIFF
--- a/docs/tutorials/teg_dehydration_tutorial.md
+++ b/docs/tutorials/teg_dehydration_tutorial.md
@@ -316,12 +316,17 @@ requires pressure letdown, flash-gas handling, lean/rich heat exchange,
 reboiling and stripping, cooling, pumping, makeup, and recycle convergence.
 
 NeqSim does not currently provide the `GlycolDehydrationModule` API previously
-shown on this page. Do not copy that obsolete example. The existing
-`SimpleTEGAbsorber` also has an open component-balance defect tracked in
-[issue #2659](https://github.com/equinor/neqsim/issues/2659). Until that defect
-is fixed and regression-tested, use a conservative equilibrium contact for
-screening and do not interpret `SimpleTEGAbsorber` results as a complete material
-balance.
+shown on this page. Do not copy that obsolete example. `SimpleTEGAbsorber` is
+available for stage-efficiency screening and now conserves the complete gas and
+solvent inventories even when the two feeds start with different component
+lists. Its gas and rich-TEG outlets close both the water-component and total
+mass balances; this behavior is protected by the regression for
+[issue #2659](https://github.com/equinor/neqsim/issues/2659).
+
+The conservative outlet behavior does not turn `SimpleTEGAbsorber` into a
+rate-based equipment model. Continue to apply the packing, hydraulics,
+mass-transfer, regeneration, and operating-envelope limitations described
+above, and verify component and total balances for every engineering case.
 
 ## Sensitivity studies
 

--- a/src/main/java/neqsim/process/equipment/absorber/SimpleTEGAbsorber.java
+++ b/src/main/java/neqsim/process/equipment/absorber/SimpleTEGAbsorber.java
@@ -21,6 +21,11 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
 /**
  * SimpleTEGAbsorber class.
  *
+ * <p>
+ * The gas and solvent feeds may have different component slates. The absorber combines their complete component
+ * inventories before flashing and preserves the transferred water in its phase-specific outlet streams.
+ * </p>
+ *
  * @author Even Solbraa
  * @version $Id: $Id
  */
@@ -113,34 +118,8 @@ public class SimpleTEGAbsorber extends SimpleAbsorber {
    * mixStream.
    */
   public void mixStream() {
-    String compName = new String();
-
     for (int k = 1; k < streams.size(); k++) {
-      for (int i = 0; i < streams.get(k).getThermoSystem().getPhases()[0].getNumberOfComponents(); i++) {
-        boolean gotComponent = false;
-        String componentName = streams.get(k).getThermoSystem().getPhases()[0].getComponent(i).getName();
-        // System.out.println("adding: " + componentName);
-
-        double moles = streams.get(k).getThermoSystem().getPhases()[0].getComponent(i).getNumberOfmoles();
-        // System.out.println("moles: " + moles + " " +
-        // mixedStream.getThermoSystem().getPhases()[0].getNumberOfComponents());
-        for (int p = 0; p < mixedStream.getThermoSystem().getPhases()[0].getNumberOfComponents(); p++) {
-          if (mixedStream.getThermoSystem().getPhases()[0].getComponent(p).getName().equals(componentName)) {
-            gotComponent = true;
-            compName = streams.get(0).getThermoSystem().getPhases()[0].getComponent(p).getComponentName();
-          }
-        }
-
-        if (gotComponent) {
-          // System.out.println("adding moles starting....");
-          mixedStream.getThermoSystem().addComponent(compName, moles);
-          // mixedStream.getThermoSystem().init_x_y();
-          // System.out.println("adding moles finished");
-        } else {
-          // System.out.println("ikke gaa hit");
-          mixedStream.getThermoSystem().addComponent(compName, moles);
-        }
-      }
+      mixedStream.getThermoSystem().addFluid(streams.get(k).getThermoSystem());
     }
     mixedStream.getThermoSystem().init_x_y();
     mixedStream.getThermoSystem().initBeta();

--- a/src/test/java/neqsim/process/equipment/absorber/SimpleTEGAbsorberTest.java
+++ b/src/test/java/neqsim/process/equipment/absorber/SimpleTEGAbsorberTest.java
@@ -45,8 +45,8 @@ class SimpleTEGAbsorberTest extends NeqSimTest {
     Set<String> componentNames = new LinkedHashSet<String>();
     for (StreamInterface stream : streams) {
       for (int phaseNumber = 0; phaseNumber < stream.getFluid().getNumberOfPhases(); phaseNumber++) {
-        for (int componentNumber = 0;
-            componentNumber < stream.getFluid().getPhase(phaseNumber).getNumberOfComponents(); componentNumber++) {
+        for (int componentNumber = 0; componentNumber < stream.getFluid().getPhase(phaseNumber)
+            .getNumberOfComponents(); componentNumber++) {
           componentNames.add(stream.getFluid().getPhase(phaseNumber).getComponent(componentNumber).getName());
         }
       }
@@ -117,8 +117,8 @@ class SimpleTEGAbsorberTest extends NeqSimTest {
         dryGas.getFlowRate("kg/hr") + richTeg.getFlowRate("kg/hr"), BALANCE_TOLERANCE_KG_PER_HOUR,
         "The absorber total mass balance must close");
     for (String componentName : componentNames(absorberCase.wetGas, absorberCase.leanTeg)) {
-      double inletComponentFlow =
-          componentFlow(absorberCase.wetGas, componentName) + componentFlow(absorberCase.leanTeg, componentName);
+      double inletComponentFlow = componentFlow(absorberCase.wetGas, componentName)
+          + componentFlow(absorberCase.leanTeg, componentName);
       double outletComponentFlow = componentFlow(dryGas, componentName) + componentFlow(richTeg, componentName);
       assertEquals(inletComponentFlow, outletComponentFlow, BALANCE_TOLERANCE_KG_PER_HOUR,
           "The absorber component balance must close for " + componentName);

--- a/src/test/java/neqsim/process/equipment/absorber/SimpleTEGAbsorberTest.java
+++ b/src/test/java/neqsim/process/equipment/absorber/SimpleTEGAbsorberTest.java
@@ -1,0 +1,151 @@
+package neqsim.process.equipment.absorber;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.util.StreamSaturatorUtil;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+
+class SimpleTEGAbsorberTest extends NeqSimTest {
+  private static final double BALANCE_TOLERANCE_KG_PER_HOUR = 1.0e-6;
+
+  private static final class AbsorberCase {
+    private final StreamInterface wetGas;
+    private final StreamInterface leanTeg;
+    private final SimpleTEGAbsorber absorber;
+
+    private AbsorberCase(StreamInterface wetGas, StreamInterface leanTeg, SimpleTEGAbsorber absorber) {
+      this.wetGas = wetGas;
+      this.leanTeg = leanTeg;
+      this.absorber = absorber;
+    }
+  }
+
+  private static double componentFlow(StreamInterface stream, String componentName) {
+    double flow = 0.0;
+    for (int phaseNumber = 0; phaseNumber < stream.getFluid().getNumberOfPhases(); phaseNumber++) {
+      ComponentInterface component = stream.getFluid().getPhase(phaseNumber).getComponent(componentName);
+      if (component != null) {
+        flow += component.getFlowRate("kg/hr");
+      }
+    }
+    return flow;
+  }
+
+  private static Set<String> componentNames(StreamInterface... streams) {
+    Set<String> componentNames = new LinkedHashSet<String>();
+    for (StreamInterface stream : streams) {
+      for (int phaseNumber = 0; phaseNumber < stream.getFluid().getNumberOfPhases(); phaseNumber++) {
+        for (int componentNumber = 0;
+            componentNumber < stream.getFluid().getPhase(phaseNumber).getNumberOfComponents(); componentNumber++) {
+          componentNames.add(stream.getFluid().getPhase(phaseNumber).getComponent(componentNumber).getName());
+        }
+      }
+    }
+    return componentNames;
+  }
+
+  private static AbsorberCase runAbsorberCase(boolean setTargetWater) {
+    SystemSrkCPAstatoil gasFluid = new SystemSrkCPAstatoil(303.15, 70.0);
+    gasFluid.addComponent("methane", 0.90);
+    gasFluid.addComponent("ethane", 0.05);
+    gasFluid.addComponent("propane", 0.02);
+    gasFluid.addComponent("CO2", 0.02);
+    gasFluid.addComponent("nitrogen", 0.01);
+    gasFluid.setMixingRule(10);
+
+    Stream gasFeed = new Stream("gas basis", gasFluid);
+    gasFeed.setFlowRate(1.0, "MSm3/day");
+    gasFeed.setTemperature(30.0, "C");
+    gasFeed.setPressure(70.0, "bara");
+    StreamSaturatorUtil saturator = new StreamSaturatorUtil("water saturator", gasFeed);
+
+    SystemSrkCPAstatoil tegFluid = new SystemSrkCPAstatoil(308.15, 70.0);
+    tegFluid.addComponent("TEG", 0.995);
+    tegFluid.addComponent("water", 0.005);
+    tegFluid.setMixingRule(10);
+
+    Stream leanTeg = new Stream("lean TEG", tegFluid);
+    leanTeg.setFlowRate(100.0, "kg/hr");
+
+    SimpleTEGAbsorber absorber = new SimpleTEGAbsorber("TEG contactor");
+    absorber.addGasInStream(saturator.getOutletStream());
+    absorber.addSolventInStream(leanTeg);
+    absorber.setNumberOfStages(6);
+    absorber.setStageEfficiency(0.25);
+    absorber.setInternalDiameter(2.0);
+    if (setTargetWater) {
+      absorber.setWaterInDryGas(30.0e-6);
+    }
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(gasFeed);
+    process.add(saturator);
+    process.add(leanTeg);
+    process.add(absorber);
+    process.run();
+
+    return new AbsorberCase(saturator.getOutletStream(), leanTeg, absorber);
+  }
+
+  private static void assertConservativeOutlets(AbsorberCase absorberCase) {
+    StreamInterface dryGas = absorberCase.absorber.getGasOutStream();
+    StreamInterface richTeg = absorberCase.absorber.getLiquidOutStream();
+
+    double wetWaterFlow = componentFlow(absorberCase.wetGas, "water");
+    double leanWaterFlow = componentFlow(absorberCase.leanTeg, "water");
+    double dryWaterFlow = componentFlow(dryGas, "water");
+    double richWaterFlow = componentFlow(richTeg, "water");
+    double gasWaterTransfer = wetWaterFlow - dryWaterFlow;
+    double solventWaterPickup = richWaterFlow - leanWaterFlow;
+
+    assertTrue(gasWaterTransfer > 0.0, "The absorber must remove water from the gas");
+    assertEquals(gasWaterTransfer, solventWaterPickup, BALANCE_TOLERANCE_KG_PER_HOUR,
+        "Water removed from the gas must appear in the rich TEG");
+    assertEquals(wetWaterFlow + leanWaterFlow, dryWaterFlow + richWaterFlow, BALANCE_TOLERANCE_KG_PER_HOUR,
+        "The absorber water-component balance must close");
+    assertEquals(absorberCase.wetGas.getFlowRate("kg/hr") + absorberCase.leanTeg.getFlowRate("kg/hr"),
+        dryGas.getFlowRate("kg/hr") + richTeg.getFlowRate("kg/hr"), BALANCE_TOLERANCE_KG_PER_HOUR,
+        "The absorber total mass balance must close");
+    for (String componentName : componentNames(absorberCase.wetGas, absorberCase.leanTeg)) {
+      double inletComponentFlow =
+          componentFlow(absorberCase.wetGas, componentName) + componentFlow(absorberCase.leanTeg, componentName);
+      double outletComponentFlow = componentFlow(dryGas, componentName) + componentFlow(richTeg, componentName);
+      assertEquals(inletComponentFlow, outletComponentFlow, BALANCE_TOLERANCE_KG_PER_HOUR,
+          "The absorber component balance must close for " + componentName);
+    }
+    assertEquals(1, dryGas.getFluid().getNumberOfPhases(), "The gas outlet must contain one phase");
+    assertEquals(PhaseType.GAS, dryGas.getFluid().getPhase(0).getType());
+    assertEquals(1, richTeg.getFluid().getNumberOfPhases(), "The rich-TEG outlet must contain one phase");
+    assertTrue(richTeg.getFluid().getPhase(0).getType() == PhaseType.AQUEOUS
+        || richTeg.getFluid().getPhase(0).getType() == PhaseType.LIQUID);
+  }
+
+  @Test
+  void transfersWaterToRichTegWhenFeedsHaveDifferentComponentSlates() {
+    AbsorberCase absorberCase = runAbsorberCase(false);
+
+    assertConservativeOutlets(absorberCase);
+    assertEquals(1.5, absorberCase.absorber.getNumberOfTheoreticalStages(), 1.0e-12);
+    assertTrue(absorberCase.absorber.getFsFactor() > 0.0);
+    assertTrue(absorberCase.absorber.getMinimumDiameterForFsLimit() > 0.0);
+  }
+
+  @Test
+  void targetWaterModePreservesWaterAndTotalMass() {
+    AbsorberCase absorberCase = runAbsorberCase(true);
+
+    assertConservativeOutlets(absorberCase);
+    double dryGasWater = absorberCase.absorber.getGasOutStream().getFluid().getPhase(0).getComponent("water").getx();
+    assertEquals(30.0e-6, dryGasWater, 2.0e-8);
+  }
+}


### PR DESCRIPTION
## Summary

- replace the custom `SimpleTEGAbsorber.mixStream()` component loop with NeqSim's conservative `SystemInterface.addFluid(...)` path
- add focused regression coverage for disjoint gas/solvent component slates, water and total mass conservation, every component balance, outlet phase inventories, stage efficiency, sizing helpers, and target-water mode
- update the TEG tutorial to describe the corrected conservative outlet behavior and retain the equipment-model limitations

## Root cause

When TEG existed only in the solvent inlet, the old loop did not find it in the gas-derived mixed system and called `addComponent` with an empty component name. `run(UUID)` caught the resulting exception, leaving the pre-run gas and solvent clones exposed as outlets. The dry-gas clone therefore appeared to lose inlet water while the rich-TEG clone remained equal to the lean solvent.

`addFluid(...)` unions the component inventories by identity and refreshes component and mixing-rule state when a new component is introduced. The existing phase-to-system extraction then preserves the manually transferred water in the single rich-liquid outlet.

## Validation

Baseline reproduction on NeqSim 3.16.0, Python 3.12.13, and OpenJDK 17 reproduced:

`InvalidInputException: ... Input componentName with value  not found in database`

An independent execution of the corrected inventory/transfer sequence through the public NeqSim API produced:

| Mode | Dry-gas water | Rich-TEG water | Water residual | Total mass residual |
| --- | ---: | ---: | ---: | ---: |
| 6 stages × 0.25 efficiency | 8.848234 kg/h | 15.958971 kg/h | -1.79e-10 kg/h | -1.19e-9 kg/h |
| 30 mol-ppm target | 30.0099 mol-ppm | 23.854503 kg/h | -1.79e-10 kg/h | -1.19e-9 kg/h |

Additional local checks:

- Java source and regression test parse successfully
- `git diff --check` passes
- remote branch blob SHAs match the reviewed local files

The focused Maven test and Spotless commands could not execute locally because this environment cannot resolve `repo1.maven.org` and has no populated Maven dependency cache. GitHub CI should run the repository Java/format gates.

No existing golden result was changed: existing covered workflows pre-seed a common component slate and do not exercise the failing branch. The new regression uses conservation invariants and narrow target behavior instead of solver-specific golden outlet flows.

## Documentation impact

Updated `docs/tutorials/teg_dehydration_tutorial.md` to remove the obsolete open-defect warning, document conservative handling of different feed component lists, and preserve the stage-efficiency/rate-based-design limitations.

Closes #2659