### PR TITLE
fix(tpflash): safeguard DEM acceleration near unit eigenvalue

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -49,6 +49,15 @@ public class TPflash extends Flash {
    * than this even when the incipient phase fraction is tiny.
    */
   private static final double TRIVIAL_SPLIT_COMPOSITION_TOLERANCE = 1.0e-6;
+  /**
+   * Maximum accepted change in ln(K) from one GDEM/DEM extrapolation.
+   *
+   * <p>
+   * A bounded log-space step prevents a nearly unit dominant eigenvalue from turning a
+   * small successive-substitution correction into an arbitrarily large K-value jump.
+   * </p>
+   */
+  private static final double MAX_ACCELERATION_LOG_K_STEP = 2.0;
   /** Guard preventing recursive rescue attempts while the local seed flash is running. */
   private static final ThreadLocal<Boolean> MULTIPHASE_RESCUE_ACTIVE = new ThreadLocal<Boolean>() {
     @Override
@@ -200,23 +209,47 @@ public class TPflash extends Flash {
       useGDEM = mu1 > 0 && mu2 > 0 && mu1 < 1.5 && mu2 < 1.5;
     }
 
-    neqsim.thermo.phase.PhaseInterface ph0 = system.getPhase(0);
-    neqsim.thermo.phase.PhaseInterface ph1 = system.getPhase(1);
+    double[] acceleratedLnK = new double[nc];
+    boolean safeAcceleration = true;
     if (!useGDEM) {
-      double lambdaFactor = lambda / (1.0 - lambda);
-      for (i = 0; i < nc; i++) {
-        lnK[i] += lambdaFactor * deltalnK[i];
-        double expK = Math.exp(lnK[i]);
-        ph0.getComponent(i).setK(expK);
-        ph1.getComponent(i).setK(expK);
+      if (!Double.isFinite(lambda) || lambda <= 0.0 || lambda >= 1.0) {
+        safeAcceleration = false;
+      } else {
+        double lambdaFactor = lambda / (1.0 - lambda);
+        for (i = 0; i < nc; i++) {
+          acceleratedLnK[i] = lnK[i] + lambdaFactor * deltalnK[i];
+        }
       }
     } else {
       for (i = 0; i < nc; i++) {
-        lnK[i] += mu1 * deltalnK[i] + mu2 * oldDeltalnK[i];
-        double expK = Math.exp(lnK[i]);
-        ph0.getComponent(i).setK(expK);
-        ph1.getComponent(i).setK(expK);
+        acceleratedLnK[i] = lnK[i] + mu1 * deltalnK[i] + mu2 * oldDeltalnK[i];
       }
+    }
+
+    double[] acceleratedK = new double[nc];
+    if (safeAcceleration) {
+      for (i = 0; i < nc; i++) {
+        double logKStep = acceleratedLnK[i] - savedLnK[i];
+        acceleratedK[i] = Math.exp(acceleratedLnK[i]);
+        if (!Double.isFinite(acceleratedLnK[i]) || !Double.isFinite(acceleratedK[i])
+            || acceleratedK[i] <= 0.0 || Math.abs(logKStep) > MAX_ACCELERATION_LOG_K_STEP) {
+          safeAcceleration = false;
+          break;
+        }
+      }
+    }
+
+    if (!safeAcceleration) {
+      sucsSubs();
+      return;
+    }
+
+    neqsim.thermo.phase.PhaseInterface ph0 = system.getPhase(0);
+    neqsim.thermo.phase.PhaseInterface ph1 = system.getPhase(1);
+    for (i = 0; i < nc; i++) {
+      lnK[i] = acceleratedLnK[i];
+      ph0.getComponent(i).setK(acceleratedK[i]);
+      ph1.getComponent(i).setK(acceleratedK[i]);
     }
     double oldBeta = system.getBeta();
     try {

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -212,10 +212,13 @@ public class TPflash extends Flash {
     double[] acceleratedLnK = new double[nc];
     boolean safeAcceleration = true;
     if (!useGDEM) {
-      if (!Double.isFinite(lambda) || lambda <= 0.0 || lambda >= 1.0) {
+      if (!Double.isFinite(lambda) || Math.abs(1.0 - lambda) < 1.0e-12) {
         safeAcceleration = false;
       } else {
         double lambdaFactor = lambda / (1.0 - lambda);
+        if (!Double.isFinite(lambdaFactor)) {
+          safeAcceleration = false;
+        }
         for (i = 0; i < nc; i++) {
           acceleratedLnK[i] = lnK[i] + lambdaFactor * deltalnK[i];
         }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -230,9 +230,12 @@ public class TPflash extends Flash {
     if (safeAcceleration) {
       for (i = 0; i < nc; i++) {
         double logKStep = acceleratedLnK[i] - savedLnK[i];
+        if (!Double.isFinite(acceleratedLnK[i]) || Math.abs(logKStep) > MAX_ACCELERATION_LOG_K_STEP) {
+          safeAcceleration = false;
+          break;
+        }
         acceleratedK[i] = Math.exp(acceleratedLnK[i]);
-        if (!Double.isFinite(acceleratedLnK[i]) || !Double.isFinite(acceleratedK[i])
-            || acceleratedK[i] <= 0.0 || Math.abs(logKStep) > MAX_ACCELERATION_LOG_K_STEP) {
+        if (!Double.isFinite(acceleratedK[i]) || acceleratedK[i] <= 0.0) {
           safeAcceleration = false;
           break;
         }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -53,8 +53,8 @@ public class TPflash extends Flash {
    * Maximum accepted change in ln(K) from one GDEM/DEM extrapolation.
    *
    * <p>
-   * A bounded log-space step prevents a nearly unit dominant eigenvalue from turning a
-   * small successive-substitution correction into an arbitrarily large K-value jump.
+   * A bounded log-space step prevents a nearly unit dominant eigenvalue from turning a small successive-substitution
+   * correction into an arbitrarily large K-value jump.
    * </p>
    */
   private static final double MAX_ACCELERATION_LOG_K_STEP = 2.0;

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAccelerationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAccelerationTest.java
@@ -1,0 +1,41 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashAccelerationTest {
+  @Test
+  void testUnsafeDemExtrapolationFallsBackToSuccessiveSubstitution() {
+    SystemInterface system = new SystemPrEos(300.0, 50.0);
+    system.addComponent("methane", 0.8);
+    system.addComponent("n-heptane", 0.2);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(false);
+    new ThermodynamicOperations(system).TPflash();
+
+    TPflash flash = new TPflash(system);
+    double methaneKBefore = system.getPhase(0).getComponent(0).getK();
+    double heptaneKBefore = system.getPhase(0).getComponent(1).getK();
+    double betaBefore = system.getBeta();
+
+    flash.lnK[0] = Math.log(methaneKBefore);
+    flash.lnK[1] = Math.log(heptaneKBefore);
+    flash.oldDeltalnK[0] = 0.99;
+    flash.oldoldDeltalnK[0] = 1.0;
+    flash.deltalnK[0] = 0.1;
+
+    flash.accselerateSucsSubs();
+
+    double methaneKAfter = system.getPhase(0).getComponent(0).getK();
+    double heptaneKAfter = system.getPhase(0).getComponent(1).getK();
+    assertTrue(Double.isFinite(methaneKAfter));
+    assertTrue(Double.isFinite(heptaneKAfter));
+    assertEquals(methaneKBefore, methaneKAfter, 1.0e-10);
+    assertEquals(heptaneKBefore, heptaneKAfter, 1.0e-10);
+    assertEquals(betaBefore, system.getBeta(), 1.0e-10);
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAccelerationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAccelerationTest.java
@@ -38,4 +38,27 @@ class TPflashAccelerationTest {
     assertEquals(heptaneKBefore, heptaneKAfter, 1.0e-10);
     assertEquals(betaBefore, system.getBeta(), 1.0e-10);
   }
+
+  @Test
+  void testBoundedDemExtrapolationAboveUnitEigenvalueIsPreserved() {
+    SystemInterface system = new SystemPrEos(300.0, 50.0);
+    system.addComponent("methane", 0.8);
+    system.addComponent("n-heptane", 0.2);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(false);
+    new ThermodynamicOperations(system).TPflash();
+
+    TPflash flash = new TPflash(system);
+    double methaneKBefore = system.getPhase(0).getComponent(0).getK();
+    flash.lnK[0] = Math.log(methaneKBefore);
+    flash.lnK[1] = Math.log(system.getPhase(0).getComponent(1).getK());
+    flash.oldDeltalnK[0] = 1.04;
+    flash.oldoldDeltalnK[0] = 1.0;
+    flash.deltalnK[0] = 0.01;
+
+    flash.accselerateSucsSubs();
+
+    double expectedLogKStep = 1.04 / (1.0 - 1.04) * 0.01;
+    assertEquals(Math.exp(expectedLogKStep), system.getPhase(0).getComponent(0).getK() / methaneKBefore, 1.0e-10);
+  }
 }


### PR DESCRIPTION
## Summary

Safeguards TPflash's DEM/GDEM log-K extrapolation and falls back to one ordinary successive-substitution step when the proposed acceleration is non-finite or changes any `ln(K)` by more than 2.0.

This is a bounded numerical-stability fix. It does not change the public API, EOS equations, phase-stability criterion, convergence tolerance, or ordinary safe acceleration steps.

## Reproduced defect

Tested from current `master` `b6b7082b2d045b6a3453838611f8e5a076b43876` with Java 17 and NeqSim 3.16.0.

The standard DEM fallback estimates the dominant eigenvalue as

```
lambda = dot(delta[n-1], delta[n-2]) / dot(delta[n-2], delta[n-2])
factor = lambda / (1 - lambda)
```

The existing code applied the extrapolation whenever the two-vector GDEM system was singular, without validating `lambda`, the factor, or the resulting log-K step. A deterministic converged PR flash (80 mol% methane / 20 mol% n-heptane, 300 K, 50 bara) with a valid near-unit history estimate demonstrated the failure:

| Case | Methane K ratio after one acceleration | Vapor-fraction change |
|---|---:|---:|
| Current master, lambda = 0.99 | 19,930.3704 | +0.0659051 |
| This PR | 1.0000000 | 0.0000000 |

The current step remains finite, so the existing exception rollback does not activate; the corrupted K-vector and beta are accepted into the flash iteration.

## Fix

- Form the proposed DEM/GDEM `ln(K)` vector without mutating the live phases.
- Reject a non-finite eigenvalue estimate, a singular/non-finite extrapolation factor, or non-finite log-K/K values.
- Reject an acceleration when any proposed `|delta ln(K)| > 2.0` (a maximum one-step K multiplier of `exp(2)`).
- Fall back to the existing successive-substitution step when rejected.
- Commit the accelerated vector atomically only after every component passes the guard.

The log-space bound preserves useful acceleration when a near-unit eigenvalue is paired with a genuinely small residual; it blocks only an unsafe extrapolated step. The value 2.0 is an explicit NeqSim globalization safeguard, not a parameter copied from the cited papers.

## Literature and commercial comparison

Dominant-eigenvalue acceleration is established convergence-promotion work: [Crowe & Nishio (1975), GDEM](https://doi.org/10.1002/aic.690210314) and [Gupta, Bishnoi & Kalogerakis (1988), accelerated single-stage flash](https://doi.org/10.1002/cjce.5450660216). [Michelsen (1982), isothermal flash Part II](https://doi.org/10.1016/0378-3812(82)85002-4) combines stability analysis with second-order convergence for difficult and near-critical phase splits. This PR keeps NeqSim's DEM/GDEM acceleration but adds the bounded acceptance step expected of a robust nonlinear solver globalization.

Public commercial material emphasizes robust, consistent and fast multiphase flash capability—e.g. [Honeywell UniSim](https://process.honeywell.com/us/en/products/industrial-software/process-optimization/unisim-design-suite), [KBC Multiflash](https://www.kbc.global/process-optimization/technology/simulation-software/multiflash-simulation-software/), and [Calsep Flash API](https://calsep.com/calsep-cloud/flash-api/)—but does not disclose their internal acceleration acceptance rules. No claim is made that this safeguard reproduces a proprietary implementation.

## Regression coverage

`TPflashAccelerationTest.testUnsafeDemExtrapolationFallsBackToSuccessiveSubstitution` preserves the minimal two-component reproducer and verifies finite, unchanged equilibrium K-values and beta after the unsafe extrapolation is rejected.

Additional validation with the patched `TPflash` loaded ahead of the 3.16.0 jar:

- 105 paired ordinary/multiphase conditions (210 flashes) across PR and SRK hydrocarbon, CO2-rich, H2-rich and near-boundary binary fluids.
- 101/105 pairs agreed within `1e-8`; the same four pre-existing discrepancies were present before and after this patch, so the safeguard introduced no new cross-path disagreement.
- 72 additional SRK/CPA water, methane-water, hydrocarbon-water and CO2-water flashes.
- All 72 passed beta normalization, phase-composition normalization and component material balance (`1e-8` limit).
- Patched `TPflash.java` compiled against NeqSim 3.16.0 on Java 17.
- Deterministic adversarial acceleration probe passed for lambda values 0.5 through 1.04: safe bounded steps (including lambda = 1.04) were retained and unsafe/singular steps fell back cleanly.
- CI follow-up reproduced a volatile-oil SRK case that uses a bounded lambda = 1.0417 DEM step. The guard now preserves that legacy acceleration and its phase result exactly; a focused regression test locks this compatibility behavior.

The focused JUnit source was added but the full Maven/JUnit suite was not run locally because this runtime does not contain the repository build toolchain. CI should run the repository test and formatting gates; publication is intentionally not blocked on the long full suite.

## Compatibility and risk

Low. Safe existing accelerations are unchanged, including bounded extrapolations with an eigenvalue estimate above one. Rejected acceleration attempts use the solver's existing successive-substitution path. The guard can add one ordinary iteration in a case that previously accepted an extreme extrapolation, trading a small local cost for a bounded and physically valid state update.

## Documentation impact

Documentation impact: none. This changes only an internal numerical acceptance safeguard; no public API, input, output, unit, default setting, or recommended user workflow changes.
