### PR TITLE
fix(tpflash): refine liquid-liquid endpoints

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -810,8 +810,8 @@ public class TPflash extends Flash {
    * </p>
    *
    * <p>
-   * The guard deliberately excludes multi-liquid endpoints, any endpoint containing a gas or aqueous phase, chemical and
-   * electrolyte systems, and solid/wax calculations. Thus ordinary gas, gas-liquid, and established liquid-liquid
+   * The guard deliberately excludes multi-liquid endpoints, any endpoint containing a gas or aqueous phase, chemical
+   * and electrolyte systems, and solid/wax calculations. Thus ordinary gas, gas-liquid, and established liquid-liquid
    * process flashes remain on the existing fast path without an additional flash or property initialization.
    * </p>
    */

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -38,6 +38,12 @@ public class TPflash extends Flash {
   private static final double MULTIPHASE_RESCUE_LIQUID_SUM_Z_OVER_K_LIMIT = 5.0;
   /** Minimum log K spread for liquid endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_LIQUID_LOG_K_SPREAD_LIMIT = 3.0;
+  /** Minimum feed fraction of non-hydrocarbon components for liquid-liquid refinement. */
+  private static final double LIQUID_LIQUID_NON_HYDROCARBON_FRACTION_LIMIT = 0.20;
+  /** Minimum active feed fraction used when screening components for liquid-liquid refinement. */
+  private static final double LIQUID_LIQUID_ACTIVE_COMPONENT_LIMIT = 1.0e-6;
+  /** Minimum critical-temperature span (K) for liquid-liquid refinement. */
+  private static final double LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN = 150.0;
   /**
    * Minimum extensive Gibbs-energy reduction (J) required for the spurious-multiphase rescue to collapse a two-phase
    * result to a single phase. Avoids false triggers from numerical noise.
@@ -587,6 +593,7 @@ public class TPflash extends Flash {
         // solution of the flash equations. The Gibbs-based spurious rescue is intentionally NOT
         // applied on this path, as it can discard a genuine split the stability test overlooked.
         collapseTrivialMultiphaseSplit();
+        rescueLiquidLiquidEndpoint();
         return;
       }
     }
@@ -771,6 +778,7 @@ public class TPflash extends Flash {
     rescueSpuriousMultiphaseEndpoint();
     collapseTrivialMultiphaseSplit();
     normalizeActivePhaseFractions();
+    rescueLiquidLiquidEndpoint();
 
     // Final chemical equilibrium call after all phase reordering
     // This ensures chemical equilibrium is solved on the final phase configuration
@@ -788,6 +796,116 @@ public class TPflash extends Flash {
         logger.warn("Final chemical eq init failed: " + ex.getMessage());
       }
     }
+  }
+
+  /**
+   * Refines an ordinary liquid-only endpoint with the multiphase stability solver.
+   *
+   * <p>
+   * The ordinary two-phase flash primarily searches for a vapor-liquid split. For a liquid-only
+   * endpoint it can therefore converge to a local single-liquid state or to a metastable
+   * liquid-liquid split even though Michelsen tangent-plane stability analysis finds a lower-Gibbs
+   * liquid-liquid equilibrium. A cloned candidate is evaluated with multiphase checking enabled
+   * and replaces the ordinary result only when the existing strict phase-fraction,
+   * distinct-composition, and Gibbs-energy acceptance checks pass.
+   * </p>
+   *
+   * <p>
+   * The guard deliberately excludes any endpoint containing a gas or aqueous phase, chemical and
+   * electrolyte systems, and solid/wax calculations. Thus ordinary gas and gas-liquid process
+   * flashes remain on the existing fast path without an additional flash or property
+   * initialization.
+   * </p>
+   */
+  private void rescueLiquidLiquidEndpoint() {
+    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() < 1 || system.getNumberOfPhases() > 2
+        || system.isChemicalSystem() || system.hasIons() || solidCheck || system.isMultiphaseWaxCheck()) {
+      return;
+    }
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      PhaseType phaseType = system.getPhase(phaseIndex).getType();
+      if (!(phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID)) {
+        return;
+      }
+    }
+
+    if (!hasPotentialLiquidLiquidInstability()) {
+      return;
+    }
+
+    double referenceGibbsEnergy = system.getGibbsEnergy();
+    SystemInterface candidate = system.clone();
+    try {
+      candidate.setMultiPhaseCheck(true);
+      candidate.setNumberOfPhases(2);
+      candidate.setPhaseIndex(0, 0);
+      candidate.setPhaseIndex(1, 1);
+      candidate.setPhaseType(0, PhaseType.GAS);
+      candidate.setPhaseType(1, PhaseType.OIL);
+      candidate.setBeta(0, 0.5);
+      candidate.setBeta(1, 0.5);
+      for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+        for (int componentIndex = 0; componentIndex < candidate.getPhase(phaseIndex)
+            .getNumberOfComponents(); componentIndex++) {
+          candidate.getPhase(phaseIndex).getComponent(componentIndex)
+              .setx(candidate.getPhase(phaseIndex).getComponent(componentIndex).getz());
+        }
+        candidate.getPhase(phaseIndex).normalize();
+      }
+      candidate.init(0);
+      candidate.init(1);
+      new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+      if (isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
+        copyFlashStateFrom(candidate);
+      }
+    } catch (Exception ex) {
+      logger.debug("Liquid-liquid endpoint refinement failed: {}", ex.getMessage());
+    }
+  }
+
+  /**
+   * Screens for a non-aqueous, non-hydrocarbon-rich, high-volatility-contrast liquid mixture.
+   *
+   * <p>
+   * Liquid-liquid demixing in non-aqueous cubic-EOS process mixtures is most relevant when a substantial
+   * polar/inert/non-hydrocarbon fraction coexists with a much less volatile hydrocarbon. The screen uses only feed
+   * composition and immutable component critical data; it performs no property initialization or trial-phase
+   * calculation. The subsequent tangent-plane stability calculation remains the authoritative decision.
+   * </p>
+   *
+   * @return true when the cheap composition screen justifies multiphase stability refinement
+   */
+  private boolean hasPotentialLiquidLiquidInstability() {
+    double nonHydrocarbonFraction = 0.0;
+    double minimumCriticalTemperature = Double.POSITIVE_INFINITY;
+    double maximumCriticalTemperature = Double.NEGATIVE_INFINITY;
+    boolean hasHeavyHydrocarbon = false;
+    int numberOfComponents = system.getPhase(0).getNumberOfComponents();
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component =
+          system.getPhase(0).getComponent(componentIndex);
+      double feedFraction = component.getz();
+      if (feedFraction <= LIQUID_LIQUID_ACTIVE_COMPONENT_LIMIT) {
+        continue;
+      }
+      if ("water".equalsIgnoreCase(component.getComponentName())) {
+        return false;
+      }
+      double criticalTemperature = component.getTC();
+      minimumCriticalTemperature = Math.min(minimumCriticalTemperature, criticalTemperature);
+      maximumCriticalTemperature = Math.max(maximumCriticalTemperature, criticalTemperature);
+      if (component.isHydrocarbon()) {
+        if (criticalTemperature > system.getTemperature() + LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN) {
+          hasHeavyHydrocarbon = true;
+        }
+      } else {
+        nonHydrocarbonFraction += feedFraction;
+      }
+    }
+    return nonHydrocarbonFraction >= LIQUID_LIQUID_NON_HYDROCARBON_FRACTION_LIMIT
+        && hasHeavyHydrocarbon
+        && maximumCriticalTemperature - minimumCriticalTemperature
+            >= LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN;
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -802,24 +802,22 @@ public class TPflash extends Flash {
    * Refines an ordinary liquid-only endpoint with the multiphase stability solver.
    *
    * <p>
-   * The ordinary two-phase flash primarily searches for a vapor-liquid split. For a liquid-only
-   * endpoint it can therefore converge to a local single-liquid state or to a metastable
-   * liquid-liquid split even though Michelsen tangent-plane stability analysis finds a lower-Gibbs
-   * liquid-liquid equilibrium. A cloned candidate is evaluated with multiphase checking enabled
-   * and replaces the ordinary result only when the existing strict phase-fraction,
+   * The ordinary two-phase flash primarily searches for a vapor-liquid split. For a liquid-only endpoint it can
+   * therefore converge to a local single-liquid state or to a metastable liquid-liquid split even though Michelsen
+   * tangent-plane stability analysis finds a lower-Gibbs liquid-liquid equilibrium. A cloned candidate is evaluated
+   * with multiphase checking enabled and replaces the ordinary result only when the existing strict phase-fraction,
    * distinct-composition, and Gibbs-energy acceptance checks pass.
    * </p>
    *
    * <p>
-   * The guard deliberately excludes any endpoint containing a gas or aqueous phase, chemical and
-   * electrolyte systems, and solid/wax calculations. Thus ordinary gas and gas-liquid process
-   * flashes remain on the existing fast path without an additional flash or property
-   * initialization.
+   * The guard deliberately excludes multi-liquid endpoints, any endpoint containing a gas or aqueous phase, chemical and
+   * electrolyte systems, and solid/wax calculations. Thus ordinary gas, gas-liquid, and established liquid-liquid
+   * process flashes remain on the existing fast path without an additional flash or property initialization.
    * </p>
    */
   private void rescueLiquidLiquidEndpoint() {
-    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() < 1 || system.getNumberOfPhases() > 2
-        || system.isChemicalSystem() || system.hasIons() || solidCheck || system.isMultiphaseWaxCheck()) {
+    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 1 || system.isChemicalSystem() || system.hasIons()
+        || solidCheck || system.isMultiphaseWaxCheck()) {
       return;
     }
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
@@ -852,8 +850,6 @@ public class TPflash extends Flash {
         }
         candidate.getPhase(phaseIndex).normalize();
       }
-      candidate.init(0);
-      candidate.init(1);
       new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
       if (isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
         copyFlashStateFrom(candidate);
@@ -882,8 +878,7 @@ public class TPflash extends Flash {
     boolean hasHeavyHydrocarbon = false;
     int numberOfComponents = system.getPhase(0).getNumberOfComponents();
     for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
-      neqsim.thermo.component.ComponentInterface component =
-          system.getPhase(0).getComponent(componentIndex);
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
       double feedFraction = component.getz();
       if (feedFraction <= LIQUID_LIQUID_ACTIVE_COMPONENT_LIMIT) {
         continue;
@@ -902,10 +897,8 @@ public class TPflash extends Flash {
         nonHydrocarbonFraction += feedFraction;
       }
     }
-    return nonHydrocarbonFraction >= LIQUID_LIQUID_NON_HYDROCARBON_FRACTION_LIMIT
-        && hasHeavyHydrocarbon
-        && maximumCriticalTemperature - minimumCriticalTemperature
-            >= LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN;
+    return nonHydrocarbonFraction >= LIQUID_LIQUID_NON_HYDROCARBON_FRACTION_LIMIT && hasHeavyHydrocarbon
+        && maximumCriticalTemperature - minimumCriticalTemperature >= LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashLiquidLiquidConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashLiquidLiquidConsistencyTest.java
@@ -72,12 +72,14 @@ class TPflashLiquidLiquidConsistencyTest {
       }
       assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-10);
 
-      double firstPhaseFugacity = system.getPhase(0).getComponent(componentIndex).getx()
-          * system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient();
-      double secondPhaseFugacity = system.getPhase(1).getComponent(componentIndex).getx()
-          * system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient();
+      double firstPhaseLogFugacity = Math.log(Math.max(
+          system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondPhaseLogFugacity = Math.log(Math.max(
+          system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
       maximumLogFugacityResidual = Math.max(maximumLogFugacityResidual,
-          Math.abs(Math.log(firstPhaseFugacity / secondPhaseFugacity)));
+          Math.abs(firstPhaseLogFugacity - secondPhaseLogFugacity));
     }
     assertTrue(maximumLogFugacityResidual < 1.0e-8, "maximum log fugacity residual was " + maximumLogFugacityResidual);
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashLiquidLiquidConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashLiquidLiquidConsistencyTest.java
@@ -72,11 +72,11 @@ class TPflashLiquidLiquidConsistencyTest {
       }
       assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-10);
 
-      double firstPhaseLogFugacity = Math.log(Math.max(
-          system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+      double firstPhaseLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
           + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
-      double secondPhaseLogFugacity = Math.log(Math.max(
-          system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+      double secondPhaseLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
           + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
       maximumLogFugacityResidual = Math.max(maximumLogFugacityResidual,
           Math.abs(firstPhaseLogFugacity - secondPhaseLogFugacity));

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashLiquidLiquidConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashLiquidLiquidConsistencyTest.java
@@ -1,0 +1,84 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashLiquidLiquidConsistencyTest {
+  private static final String[] COMPONENTS = { "methane", "CO2", "n-heptane" };
+  private static final double[] FEED = { 0.15, 0.65, 0.20 };
+
+  @Test
+  void ordinaryFlashRefinesLowerGibbsLiquidLiquidEndpoint() {
+    SystemInterface ordinary = createAndFlash(false);
+    SystemInterface multiphase = createAndFlash(true);
+
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquals(2, multiphase.getNumberOfPhases());
+    assertEquals(multiphase.getGibbsEnergy(), ordinary.getGibbsEnergy(), 1.0e-8);
+
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      assertEquals(multiphase.getBeta(phaseIndex), ordinary.getBeta(phaseIndex), 1.0e-8);
+      assertEquals(multiphase.getPhase(phaseIndex).getDensity(), ordinary.getPhase(phaseIndex).getDensity(), 1.0e-6);
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        assertEquals(multiphase.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            ordinary.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-8);
+      }
+    }
+
+    assertFlashClosure(ordinary);
+    assertFlashClosure(multiphase);
+  }
+
+  @Test
+  void ordinaryHydrocarbonLiquidRemainsOnSinglePhasePath() {
+    SystemInterface system = new SystemPrEos(298.15, 50.0);
+    system.addComponent("n-heptane", 0.70);
+    system.addComponent("nC10", 0.30);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(false);
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.TPflash();
+    double firstGibbsEnergy = system.getGibbsEnergy();
+    operations.TPflash();
+
+    assertEquals(1, system.getNumberOfPhases());
+    assertEquals(firstGibbsEnergy, system.getGibbsEnergy(), 1.0e-8);
+  }
+
+  private SystemInterface createAndFlash(boolean multiphaseCheck) {
+    SystemInterface system = new SystemPrEos(215.0, 50.0);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], FEED[componentIndex]);
+    }
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private void assertFlashClosure(SystemInterface system) {
+    assertEquals(1.0, system.getBeta(0) + system.getBeta(1), 1.0e-12);
+    double maximumLogFugacityResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-10);
+
+      double firstPhaseFugacity = system.getPhase(0).getComponent(componentIndex).getx()
+          * system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient();
+      double secondPhaseFugacity = system.getPhase(1).getComponent(componentIndex).getx()
+          * system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient();
+      maximumLogFugacityResidual = Math.max(maximumLogFugacityResidual,
+          Math.abs(Math.log(firstPhaseFugacity / secondPhaseFugacity)));
+    }
+    assertTrue(maximumLogFugacityResidual < 1.0e-8, "maximum log fugacity residual was " + maximumLogFugacityResidual);
+  }
+}


### PR DESCRIPTION
## Problem

The ordinary TPflash path can declare a liquid-only endpoint stable after its vapor-liquid-oriented trials even when the multiphase path finds a lower-Gibbs liquid-liquid equilibrium. This violates the expected ordinary/multiphase consistency for stable one- and two-phase results.

Minimal PR-EOS reproduction at 215 K and 50 bara, z(methane/CO2/n-heptane) = 0.15/0.65/0.20:

| Path | Result | Gibbs energy (J) |
| --- | --- | ---: |
| master ordinary TPflash | one OIL phase | -1302.808092616 |
| master multiphase TPflash | two OIL phases, beta = 0.893459476 / 0.106540524 | -1303.222382406 |
| patched ordinary TPflash | same two OIL phases as multiphase | -1303.222382406 |

The missed state lowers Gibbs energy by 0.414289791 J. Its maximum log-fugacity residual is 6.64e-13 and maximum component material residual is 8.88e-16.

## Root cause

The ordinary two-phase solver primarily searches the vapor-liquid manifold. A liquid-only endpoint can therefore bypass the liquid-like tangent-plane trials in `TPmultiflash` and remain at a local single-liquid or metastable liquid-liquid state.

## Change

After an ordinary liquid-only result, TPflash now:

1. applies a cheap, property-free screen for a non-aqueous, non-hydrocarbon-rich mixture with a large critical-temperature span and a heavy hydrocarbon;
2. cold-starts a cloned candidate at the feed composition with multiphase checking enabled;
3. runs the existing multiphase stability/phase-split implementation; and
4. copies the candidate only if the existing strict beta-sum, nontrivial-composition, and lower-Gibbs acceptance checks pass.

The guard excludes gas/gas-liquid endpoints, already split multi-liquid endpoints, aqueous systems, chemical/electrolyte systems, and solid/wax flashes. It also avoids duplicate EOS initialization before the cloned TPflash. The screen is only a cost gate; the tangent-plane stability calculation and Gibbs acceptance remain authoritative.

## Literature basis

This follows Michelsen's tangent-plane stability and phase-split workflow:

- M. L. Michelsen, *The isothermal flash problem. Part I. Stability*, Fluid Phase Equilibria 9 (1982), https://doi.org/10.1016/0378-3812(82)85001-2
- M. L. Michelsen, *The isothermal flash problem. Part II. Phase-split calculation*, Fluid Phase Equilibria 9 (1982), https://doi.org/10.1016/0378-3812(82)85002-4

Evidence: these papers explicitly prescribe tangent-plane stability analysis and use stable trial phases to initialize the split calculation, including critical-region safeguards. Inference: selectively invoking that existing analysis behind a cheap composition/critical-property gate is a NeqSim performance policy, not a claim from the papers.

Public PVTsim documentation advertises robust/fast two-phase and multiphase PT flashes (up to five phases) and repeated-flash APIs, but does not disclose proprietary phase-stability gates: https://calsep.com/pvtsim-nova/find-a-pvtsim-package/full-package/ and https://calsep.com/calsep-cloud/flash-api/. No proprietary algorithm is inferred.

## Validation

### Deterministic numerical screens

- 540 PR-EOS CO2/methane/n-heptane states: lower-Gibbs liquid-only ordinary/multiphase defects **98 -> 0**.
- Raw differences across that screen: **176 -> 79**; the remaining differences are three-phase states or rejected invalid/higher-Gibbs multiphase endpoints, not lower-Gibbs one/two-liquid candidates.
- 105-case SRK/PR/CPA matrix covering gas, oil, water, hydrocarbon-water, CO2-rich, H2-rich, and near-boundary fluids: one/two-phase consistency differences **10 -> 6**; all four CO2-rich differences were removed. The six remaining cases and one low-temperature hydrocarbon-water validation failure are present on master and are outside this non-aqueous change.
- Focused regression: beta sum tolerance 1e-12, material closure 1e-10, maximum log-fugacity residual 1e-8, ordinary/multiphase beta and composition agreement 1e-8, density agreement 1e-6.
- Deterministic repeat flash for a stable n-heptane/nC10 liquid remains one phase with unchanged Gibbs energy.

### Runtime

Five fresh-JVM repetitions, each with 200 warmups and 2000 repeated flashes; median per-flash time:

| Case | master | patched | Interpretation |
| --- | ---: | ---: | --- |
| gas | 138.5 us | 145.0 us | no extra solver; fork-to-fork noise |
| gas-oil | 61.3 us | 61.4 us | unchanged fast path |
| stable hydrocarbon oil | 66.6 us | 53.0 us | no extra solver; fork-to-fork noise |
| reproduced CO2 LLE | 170.8 us | 2069.5 us | +1.90 ms only where stability refinement corrects the state |

An unguarded liquid-only refinement was also tested and rejected because it slowed the stable hydrocarbon oil case by about 16x. The committed gate reduces the ordinary fast-path work to phase/type checks plus a component metadata scan; no EOS/property calculation or cloned flash occurs unless the screen passes.

### Commands and limits

- Java 8 source/target compilation of the modified production class: passed.
- Focused regression source compiled and its two test methods executed in a standalone assertion harness: passed.
- Deterministic 540-state and 105-state harnesses: passed with the results above.
- `git diff --check`: passed.
- Maven/Spotless and the repository JUnit suite were not runnable locally because Maven Central DNS resolution was unavailable in the execution environment. Hosted Spotless, pre-commit, PaperLab, Javadocs, CodeQL, Java 8 and Java 21 tests on Ubuntu and Windows, and all three Java 21 slow-test shards pass on the final head. No tolerance was loosened to mask a defect.

## Compatibility and risk

- No public API or serialization change.
- Existing multiphase behavior is reused; the ordinary result changes only when a screened candidate is demonstrably valid, distinct, and lower in Gibbs energy.
- Aqueous, ionic, chemical, solid, and wax paths are deliberately excluded to avoid expanding this bounded fix.
- The 20 mol% non-hydrocarbon screen and 150 K critical-temperature span are performance gates, not equilibrium criteria. Lower-concentration LLE outside the screen remains a future robustness target.

## Documentation impact

Numerical-method Javadocs were added beside the implementation, including the guard scope, tangent-plane role, and fast-path behavior. No user-guide or API documentation changes are required because the public API and workflow are unchanged.