### PR TITLE
fix: preserve no-side-draw Naphtali status contract

### DIFF
--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2912,11 +2912,13 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       updateMeshResiduals();
     }
     boolean hasActiveSideDraw = hasActiveSideDrawFractions();
-    if (accepted && (!hasActiveSideDraw || residualConvergenceSatisfied())) {
+    if (accepted && hasActiveSideDraw && residualConvergenceSatisfied()) {
       lastSolveStatus = SolveStatus.RIGOROUS_CONVERGED;
-      lastSolveStatusReason = hasActiveSideDraw
-          ? "Naphtali-Sandholm side-draw products satisfy the active rigorous convergence gates"
-          : "Naphtali-Sandholm solver accepted its direct tray products";
+      lastSolveStatusReason =
+          "Naphtali-Sandholm side-draw products satisfy the active rigorous convergence gates";
+    } else if (accepted && !hasActiveSideDraw) {
+      lastSolveStatus = SolveStatus.RECONCILED_PRODUCTS;
+      lastSolveStatusReason = "Naphtali-Sandholm direct products were applied";
     } else {
       lastSolveStatus = SolveStatus.FAILED;
       lastSolveStatusReason = accepted ? "Applied Naphtali-Sandholm side-draw state failed the active convergence gates"

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2914,8 +2914,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     boolean hasActiveSideDraw = hasActiveSideDrawFractions();
     if (accepted && hasActiveSideDraw && residualConvergenceSatisfied()) {
       lastSolveStatus = SolveStatus.RIGOROUS_CONVERGED;
-      lastSolveStatusReason =
-          "Naphtali-Sandholm side-draw products satisfy the active rigorous convergence gates";
+      lastSolveStatusReason = "Naphtali-Sandholm side-draw products satisfy the active rigorous convergence gates";
     } else if (accepted && !hasActiveSideDraw) {
       lastSolveStatus = SolveStatus.RECONCILED_PRODUCTS;
       lastSolveStatusReason = "Naphtali-Sandholm direct products were applied";

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -117,6 +117,8 @@ public class ColumnStudyRegressionTest {
     column.run();
 
     assertTrue(column.solved(), "Column-study case should converge with Naphtali-Sandholm");
+    assertEquals(DistillationColumn.SolveStatus.RECONCILED_PRODUCTS, column.getLastSolveStatus(),
+        "a no-side-draw direct result should preserve the established reconciled-product status");
     assertEquals(17, column.getLastIterationCount(), "Newton iteration count guards against premature SR acceptance");
     assertTrayTemperatureProfile(column);
     assertTrayPressureProfile(column);


### PR DESCRIPTION
## Problem

Merged PR #2674 correctly made applied-state rigorous gates authoritative for active side-draw columns, but its finalizer also changed the established no-side-draw status contract.

Before #2674, an accepted direct Naphtali–Sandholm result without side draws was classified as `RECONCILED_PRODUCTS`. Current `master` assigned `RIGOROUS_CONVERGED` solely from the solver's internal acceptance, even when `residualConvergenceSatisfied()` was false. This could make `getLastSolveStatus()` claim rigorous convergence while `solved()` disagreed.

The defect was identified in Copilot's final suppressed review after #2674 had already been merged externally. The technical disposition is recorded on #2674.

## Preserved baseline

The first commit added one deterministic assertion to the existing realistic 10-stage, 24-component no-side-draw column-study regression. It did not add another expensive column solve.

Against current-master commit `3bb63211f95ae5a66c1da05484331714d8a45f7f`, Windows Java 21 ran 10,895 tests and failed exactly that assertion:

- expected: `RECONCILED_PRODUCTS`
- observed: `RIGOROUS_CONVERGED`
- failures: 1
- errors: 0
- skipped: 212

The three Java 21 slow-test shards, JavaDoc, CodeQL, Spotless, and pre-commit all passed on the regression-only head, isolating the defect to terminal status classification.

## Root cause and fix

`finalizeNaphtaliSolve()` used one branch for both active-side-draw and ordinary columns. For accepted ordinary columns it therefore promoted the historical reconciled-product result to `RIGOROUS_CONVERGED` without evaluating the applied-state residual gate.

The implementation now maps terminal states explicitly:

- side draw + accepted + applied rigorous gates: `RIGOROUS_CONVERGED`
- side draw + rejected or failed applied gates: `FAILED`
- no side draw + accepted: `RECONCILED_PRODUCTS`
- no side draw + rejected: `FAILED`

No solver tolerance, iteration path, thermodynamic result, product stream, or public API changes.

## Validation

Exact head `7d3a9afa791a2e4a4d989ae0f81c34ae3e655a11`:

- Java 21 Ubuntu: 10,895 tests, 0 failures, 0 errors, 212 skipped
- Java 21 Windows: 10,895 tests, 0 failures, 0 errors, 212 skipped
- `ColumnStudyRegressionTest`: 6 tests passed on both platforms
- all three Java 21 slow-test shards passed
- JavaDoc, CodeQL, PaperLab, Spotless, pre-commit, documentation search, and agent-skill reference checks passed
- Copilot reviewed 2/2 changed files after the latest push with no findings or unresolved threads
- Java 8 Ubuntu and Windows are running

The pull request remains draft until the Java 8 matrix and final review recheck complete.

Documentation impact: none. This restores the established diagnostic status contract; column operation, public APIs, inputs, outputs, units, defaults, and recommended usage are unchanged.