### PR TITLE
perf: reuse parallel transient workers

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -384,9 +384,11 @@ For large flowsheets with independent branches, enable
 `process.setParallelTransientEnabled(true)` and set the maximum worker count
 with `process.setTransientThreadPoolSize(n)`. The per-process worker pool is
 created lazily and reused across timesteps; changing the worker count or
-disabling the option retires it. Keep parallel execution off for tightly
-coupled sequential equipment or recycle loops unless their transient
-dependencies have been verified.
+disabling the option retires it. If the caller is interrupted while waiting,
+NeqSim restores the interrupt status but does not forcibly cancel equipment
+already updating state, so treat that timestep as incomplete. Keep parallel
+execution off for tightly coupled sequential equipment or recycle loops unless
+their transient dependencies have been verified.
 
 ## Python Dynamic Simulation
 

--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -380,6 +380,14 @@ for (int i = 0; i < nSteps; i++) {
 }
 ```
 
+For large flowsheets with independent branches, enable
+`process.setParallelTransientEnabled(true)` and set the maximum worker count
+with `process.setTransientThreadPoolSize(n)`. The per-process worker pool is
+created lazily and reused across timesteps; changing the worker count or
+disabling the option retires it. Keep parallel execution off for tightly
+coupled sequential equipment or recycle loops unless their transient
+dependencies have been verified.
+
 ## Python Dynamic Simulation
 
 ```python

--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -386,10 +386,10 @@ with `process.setTransientThreadPoolSize(n)`. The per-process worker pool is
 created lazily and reused across timesteps; changing the worker count or
 disabling the option retires it. If the caller is interrupted while waiting,
 NeqSim restores the interrupt status, cancels queued work without interrupting
-equipment already updating state, and skips later task submission. Treat that
-timestep as incomplete. Keep parallel execution off for tightly coupled
-sequential equipment or recycle loops unless their transient dependencies have
-been verified.
+equipment already updating state, and aborts the remaining timestep phases.
+Treat that timestep as incomplete. Keep parallel execution off for tightly
+coupled sequential equipment or recycle loops unless their transient
+dependencies have been verified.
 
 ## Python Dynamic Simulation
 

--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -385,8 +385,8 @@ For large flowsheets with independent branches, enable
 with `process.setTransientThreadPoolSize(n)`. The per-process worker pool is
 created lazily and reused across timesteps; changing the worker count or
 disabling the option retires it. If the caller is interrupted while waiting,
-NeqSim restores the interrupt status and later passes skip task submission, but
-does not forcibly cancel equipment already updating state, so treat that
+NeqSim restores the interrupt status, cancels queued work without interrupting
+equipment already updating state, and skips later task submission. Treat that
 timestep as incomplete. Keep parallel execution off for tightly coupled
 sequential equipment or recycle loops unless their transient dependencies have
 been verified.

--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -385,10 +385,11 @@ For large flowsheets with independent branches, enable
 with `process.setTransientThreadPoolSize(n)`. The per-process worker pool is
 created lazily and reused across timesteps; changing the worker count or
 disabling the option retires it. If the caller is interrupted while waiting,
-NeqSim restores the interrupt status but does not forcibly cancel equipment
-already updating state, so treat that timestep as incomplete. Keep parallel
-execution off for tightly coupled sequential equipment or recycle loops unless
-their transient dependencies have been verified.
+NeqSim restores the interrupt status and later passes skip task submission, but
+does not forcibly cancel equipment already updating state, so treat that
+timestep as incomplete. Keep parallel execution off for tightly coupled
+sequential equipment or recycle loops unless their transient dependencies have
+been verified.
 
 ## Python Dynamic Simulation
 

--- a/docs/development/TASK_LOG.md
+++ b/docs/development/TASK_LOG.md
@@ -36,6 +36,12 @@ requirement`, or `confidential compressor route`.
 
 <!-- Add new entries at the top. Most recent first. -->
 
+### 2026-07-30 — Reuse parallel transient workers across timesteps
+**Type:** E (Feature)
+**Keywords:** dynamic simulation, runTransient, ProcessSystem, parallel transient, executor reuse, thread pool, scalability
+**Solution:** `ProcessSystem` now owns a lazy reusable transient executor; regression coverage is in `ProcessSystemParallelTransientTest`, with behavior documented in `docs/process/dynamic-simulation-enhancements.md`.
+**Notes:** The prior implementation created and destroyed a fixed thread pool on every transient step. An isolated 8-unit, 200-step orchestration baseline with two configured workers completed all 1600 unit executions but created 400 distinct worker threads; the reusable executor reduced that stable scheduling metric to 2. The pool is transient model runtime state, uses daemon workers with a 60-second idle timeout, and is retired when parallel execution is disabled or its size changes. Parallel transient execution remains opt-in and suitable only when equipment dependencies permit concurrent execution.
+
 ### 2026-07-16 — Historical FeS wall inventory to elemental-sulfur compressor deposition
 **Type:** E (Feature) / B (Process)
 **Keywords:** iron sulfide, FeS, mackinawite, pyrrhotite, siderite, FeCO3, carbon steel, seawater, oxygen ingress, nitrogen purge, elemental sulfur, S8, wall inventory, compressor deposit, entrained condensate, warm shaft

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -544,10 +544,11 @@ thread pool for every timestep in long dynamic studies.
 
 If the thread calling `runTransient(...)` is interrupted while waiting for
 parallel equipment, NeqSim restores the caller's interrupt status and stops
-waiting. Already submitted equipment tasks are not forcibly cancelled because
-unit-operation state updates are not transactionally interruptible. Callers
-should therefore treat an interrupted timestep as incomplete rather than as an
-atomic rollback.
+waiting. Later parallel passes in the same timestep observe that status and do
+not submit additional equipment work. Already submitted equipment tasks are
+not forcibly cancelled because unit-operation state updates are not
+transactionally interruptible. Callers should therefore treat an interrupted
+timestep as incomplete rather than as an atomic rollback.
 
 **Note:** Parallel execution is beneficial for flowsheets with many independent
 equipment units. For small flowsheets or tightly coupled equipment (recycles),

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -547,8 +547,10 @@ parallel equipment, NeqSim restores the caller's interrupt status and stops
 waiting. Later parallel passes in the same timestep observe that status and do
 not submit additional equipment work. Queued futures are cancelled without
 interrupting equipment already updating state. Because those running updates
-are not transactionally interruptible, callers should still treat an
-interrupted timestep as incomplete rather than as an atomic rollback.
+are not transactionally interruptible, NeqSim aborts the remaining controller,
+measurement, result-storage, and event-publication phases for that timestep.
+Callers should still treat an interrupted timestep as incomplete rather than as
+an atomic rollback.
 
 **Note:** Parallel execution is beneficial for flowsheets with many independent
 equipment units. For small flowsheets or tightly coupled equipment (recycles),

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -545,10 +545,10 @@ thread pool for every timestep in long dynamic studies.
 If the thread calling `runTransient(...)` is interrupted while waiting for
 parallel equipment, NeqSim restores the caller's interrupt status and stops
 waiting. Later parallel passes in the same timestep observe that status and do
-not submit additional equipment work. Already submitted equipment tasks are
-not forcibly cancelled because unit-operation state updates are not
-transactionally interruptible. Callers should therefore treat an interrupted
-timestep as incomplete rather than as an atomic rollback.
+not submit additional equipment work. Queued futures are cancelled without
+interrupting equipment already updating state. Because those running updates
+are not transactionally interruptible, callers should still treat an
+interrupted timestep as incomplete rather than as an atomic rollback.
 
 **Note:** Parallel execution is beneficial for flowsheets with many independent
 equipment units. For small flowsheets or tightly coupled equipment (recycles),

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -542,6 +542,13 @@ allows idle daemon workers to time out after 60 seconds. Changing
 retires the existing pool. This avoids creating and destroying a complete
 thread pool for every timestep in long dynamic studies.
 
+If the thread calling `runTransient(...)` is interrupted while waiting for
+parallel equipment, NeqSim restores the caller's interrupt status and stops
+waiting. Already submitted equipment tasks are not forcibly cancelled because
+unit-operation state updates are not transactionally interruptible. Callers
+should therefore treat an interrupted timestep as incomplete rather than as an
+atomic rollback.
+
 **Note:** Parallel execution is beneficial for flowsheets with many independent
 equipment units. For small flowsheets or tightly coupled equipment (recycles),
 the overhead may outweigh the benefit.

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -535,6 +535,13 @@ process.setTransientThreadPoolSize(4); // Number of worker threads
 process.runTransient();
 ```
 
+The configured workers are reused across timesteps. NeqSim creates the executor
+lazily for each `ProcessSystem`, keeps it out of serialized model state, and
+allows idle daemon workers to time out after 60 seconds. Changing
+`setTransientThreadPoolSize(...)` or disabling parallel transient execution
+retires the existing pool. This avoids creating and destroying a complete
+thread pool for every timestep in long dynamic studies.
+
 **Note:** Parallel execution is beneficial for flowsheets with many independent
 equipment units. For small flowsheets or tightly coupled equipment (recycles),
 the overhead may outweigh the benefit.

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4159,13 +4159,17 @@ public class ProcessSystem extends SimulationBaseClass {
    * Runs all equipment transient calculations in parallel using an ExecutorService. Each equipment unit is submitted as
    * an independent task. This is suitable when equipment units are loosely coupled (no data dependencies within a
    * single timestep). If the caller is interrupted while waiting, its interrupt status is restored and the wait loop
-   * stops. Already submitted equipment tasks are not cancelled because interrupting state mutation inside equipment is
-   * not guaranteed to be safe.
+   * stops. A subsequent pass observes that status and returns without submitting more tasks. Already submitted equipment
+   * tasks are not cancelled because interrupting state mutation inside equipment is not guaranteed to be safe.
    *
    * @param dt time step in seconds
    * @param id calculation identifier
    */
   private void runEquipmentTransientParallel(double dt, UUID id) {
+    if (Thread.currentThread().isInterrupted()) {
+      logger.warn("Parallel transient execution skipped because the caller is interrupted");
+      return;
+    }
     ExecutorService executor = getParallelTransientExecutor();
     List<Future<?>> futures = new ArrayList<Future<?>>(unitOperations.size());
     for (int i = 0; i < unitOperations.size(); i++) {

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -168,8 +168,7 @@ public class ProcessSystem extends SimulationBaseClass {
   /** Worker count used to create {@link #parallelTransientExecutor}. */
   private transient int parallelTransientExecutorSize;
   /** Counter used to give reusable transient workers stable diagnostic names. */
-  private static final java.util.concurrent.atomic.AtomicInteger TRANSIENT_WORKER_COUNTER =
-      new java.util.concurrent.atomic.AtomicInteger();
+  private static final java.util.concurrent.atomic.AtomicInteger TRANSIENT_WORKER_COUNTER = new java.util.concurrent.atomic.AtomicInteger();
 
   /**
    * Pluggable integration strategy advertised to equipment during {@code runTransient}. Defaults to
@@ -4201,9 +4200,8 @@ public class ProcessSystem extends SimulationBaseClass {
         return worker;
       }
     };
-    java.util.concurrent.ThreadPoolExecutor executor =
-        (java.util.concurrent.ThreadPoolExecutor) java.util.concurrent.Executors
-            .newFixedThreadPool(transientThreadPoolSize, daemonFactory);
+    java.util.concurrent.ThreadPoolExecutor executor = (java.util.concurrent.ThreadPoolExecutor) java.util.concurrent.Executors
+        .newFixedThreadPool(transientThreadPoolSize, daemonFactory);
     executor.setKeepAliveTime(60L, java.util.concurrent.TimeUnit.SECONDS);
     executor.allowCoreThreadTimeOut(true);
     parallelTransientExecutor = executor;

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4160,8 +4160,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * an independent task. This is suitable when equipment units are loosely coupled (no data dependencies within a
    * single timestep). If the caller is interrupted while waiting, its interrupt status is restored and the wait loop
    * stops. A subsequent pass observes that status and returns without submitting more tasks. Already submitted
-   * equipment tasks are not cancelled because interrupting state mutation inside equipment is not guaranteed to be
-   * safe.
+   * equipment that is queued is cancelled without interrupting tasks already updating state.
    *
    * @param dt time step in seconds
    * @param id calculation identifier
@@ -4184,11 +4183,15 @@ public class ProcessSystem extends SimulationBaseClass {
         }
       }));
     }
-    for (Future<?> f : futures) {
+    for (int i = 0; i < futures.size(); i++) {
+      Future<?> f = futures.get(i);
       try {
         f.get();
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
+        for (int pendingIndex = i; pendingIndex < futures.size(); pendingIndex++) {
+          futures.get(pendingIndex).cancel(false);
+        }
         logger.warn("Parallel transient execution interrupted; caller interrupt status restored");
         break;
       } catch (ExecutionException ex) {

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -160,6 +160,16 @@ public class ProcessSystem extends SimulationBaseClass {
   private boolean parallelTransientEnabled = false;
   /** Thread pool size for parallel transient execution. */
   private int transientThreadPoolSize = Runtime.getRuntime().availableProcessors();
+  /**
+   * Reusable worker pool for parallel transient execution. The executor is transient because threads and executor
+   * services are runtime resources rather than process-model state.
+   */
+  private transient java.util.concurrent.ExecutorService parallelTransientExecutor;
+  /** Worker count used to create {@link #parallelTransientExecutor}. */
+  private transient int parallelTransientExecutorSize;
+  /** Counter used to give reusable transient workers stable diagnostic names. */
+  private static final java.util.concurrent.atomic.AtomicInteger TRANSIENT_WORKER_COUNTER =
+      new java.util.concurrent.atomic.AtomicInteger();
 
   /**
    * Pluggable integration strategy advertised to equipment during {@code runTransient}. Defaults to
@@ -4146,8 +4156,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * @param id calculation identifier
    */
   private void runEquipmentTransientParallel(double dt, UUID id) {
-    java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors
-        .newFixedThreadPool(transientThreadPoolSize);
+    java.util.concurrent.ExecutorService executor = getParallelTransientExecutor();
     List<java.util.concurrent.Future<?>> futures = new ArrayList<java.util.concurrent.Future<?>>(unitOperations.size());
     for (int i = 0; i < unitOperations.size(); i++) {
       final ProcessEquipmentInterface unit = unitOperations.get(i);
@@ -4167,7 +4176,50 @@ public class ProcessSystem extends SimulationBaseClass {
         logger.error("Parallel transient execution failed: " + ex.getMessage(), ex);
       }
     }
-    executor.shutdown();
+  }
+
+  /**
+   * Returns the reusable executor for parallel transient steps, creating it lazily for the configured worker count.
+   * Core workers are allowed to time out after one minute of inactivity so discarded process models do not retain idle
+   * threads indefinitely.
+   *
+   * @return reusable executor sized by {@link #getTransientThreadPoolSize()}
+   */
+  private synchronized java.util.concurrent.ExecutorService getParallelTransientExecutor() {
+    if (parallelTransientExecutor != null && !parallelTransientExecutor.isShutdown()
+        && parallelTransientExecutorSize == transientThreadPoolSize) {
+      return parallelTransientExecutor;
+    }
+    shutdownParallelTransientExecutor();
+    final java.util.concurrent.ThreadFactory defaultFactory = java.util.concurrent.Executors.defaultThreadFactory();
+    java.util.concurrent.ThreadFactory daemonFactory = new java.util.concurrent.ThreadFactory() {
+      @Override
+      public Thread newThread(Runnable task) {
+        Thread worker = defaultFactory.newThread(task);
+        worker.setDaemon(true);
+        worker.setName("NeqSim-Transient-Worker-" + TRANSIENT_WORKER_COUNTER.getAndIncrement());
+        return worker;
+      }
+    };
+    java.util.concurrent.ThreadPoolExecutor executor =
+        (java.util.concurrent.ThreadPoolExecutor) java.util.concurrent.Executors
+            .newFixedThreadPool(transientThreadPoolSize, daemonFactory);
+    executor.setKeepAliveTime(60L, java.util.concurrent.TimeUnit.SECONDS);
+    executor.allowCoreThreadTimeOut(true);
+    parallelTransientExecutor = executor;
+    parallelTransientExecutorSize = transientThreadPoolSize;
+    return parallelTransientExecutor;
+  }
+
+  /**
+   * Retires the reusable parallel transient executor, if one has been created.
+   */
+  private synchronized void shutdownParallelTransientExecutor() {
+    if (parallelTransientExecutor != null) {
+      parallelTransientExecutor.shutdown();
+      parallelTransientExecutor = null;
+      parallelTransientExecutorSize = 0;
+    }
   }
 
   /**
@@ -4541,12 +4593,16 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Enables or disables multi-threaded equipment execution during transient steps.
+   * Enables or disables multi-threaded equipment execution during transient steps. Disabling the feature retires any
+   * reusable transient worker pool owned by this process system.
    *
    * @param enabled true to enable parallel execution
    */
-  public void setParallelTransientEnabled(boolean enabled) {
+  public synchronized void setParallelTransientEnabled(boolean enabled) {
     this.parallelTransientEnabled = enabled;
+    if (!enabled) {
+      shutdownParallelTransientExecutor();
+    }
   }
 
   /**
@@ -4559,12 +4615,17 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Sets the thread pool size for parallel transient execution.
+   * Sets the thread pool size for parallel transient execution. Changing the size retires the existing reusable worker
+   * pool; a replacement is created lazily on the next parallel transient step.
    *
    * @param poolSize number of threads
    */
-  public void setTransientThreadPoolSize(int poolSize) {
-    this.transientThreadPoolSize = Math.max(1, poolSize);
+  public synchronized void setTransientThreadPoolSize(int poolSize) {
+    int normalizedPoolSize = Math.max(1, poolSize);
+    if (normalizedPoolSize != transientThreadPoolSize) {
+      transientThreadPoolSize = normalizedPoolSize;
+      shutdownParallelTransientExecutor();
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4159,8 +4159,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * Runs all equipment transient calculations in parallel using an ExecutorService. Each equipment unit is submitted as
    * an independent task. This is suitable when equipment units are loosely coupled (no data dependencies within a
    * single timestep). If the caller is interrupted while waiting, its interrupt status is restored and the wait loop
-   * stops. A subsequent pass observes that status and returns without submitting more tasks. Already submitted equipment
-   * tasks are not cancelled because interrupting state mutation inside equipment is not guaranteed to be safe.
+   * stops. A subsequent pass observes that status and returns without submitting more tasks. Already submitted
+   * equipment tasks are not cancelled because interrupting state mutation inside equipment is not guaranteed to be
+   * safe.
    *
    * @param dt time step in seconds
    * @param id calculation identifier

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -4157,7 +4158,9 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Runs all equipment transient calculations in parallel using an ExecutorService. Each equipment unit is submitted as
    * an independent task. This is suitable when equipment units are loosely coupled (no data dependencies within a
-   * single timestep).
+   * single timestep). If the caller is interrupted while waiting, its interrupt status is restored and the wait loop
+   * stops. Already submitted equipment tasks are not cancelled because interrupting state mutation inside equipment is
+   * not guaranteed to be safe.
    *
    * @param dt time step in seconds
    * @param id calculation identifier
@@ -4179,8 +4182,13 @@ public class ProcessSystem extends SimulationBaseClass {
     for (Future<?> f : futures) {
       try {
         f.get();
-      } catch (Exception ex) {
-        logger.error("Parallel transient execution failed: " + ex.getMessage(), ex);
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        logger.warn("Parallel transient execution interrupted; caller interrupt status restored");
+        break;
+      } catch (ExecutionException ex) {
+        Throwable cause = ex.getCause();
+        logger.error("Parallel transient equipment execution failed", cause == null ? ex : cause);
       }
     }
   }

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4102,7 +4102,9 @@ public class ProcessSystem extends SimulationBaseClass {
     // by low-flow bypass keeps its current state during the timestep — same skip gate as
     // the steady run() path (runUnitProfiled). See docs/process/processmodel/low_flow_bypass.md.
     if (parallelTransientEnabled && unitOperations.size() > 1) {
-      runEquipmentTransientParallel(dt, id);
+      if (!runEquipmentTransientParallel(dt, id)) {
+        return;
+      }
     } else {
       for (int i = 0; i < unitOperations.size(); i++) {
         runUnitTransientSkippingInactive(unitOperations.get(i), dt, id);
@@ -4112,7 +4114,9 @@ public class ProcessSystem extends SimulationBaseClass {
     // Semi-implicit: run a second pass for improved stability
     if (integrationMethod == IntegrationMethod.SEMI_IMPLICIT) {
       if (parallelTransientEnabled && unitOperations.size() > 1) {
-        runEquipmentTransientParallel(dt, id);
+        if (!runEquipmentTransientParallel(dt, id)) {
+          return;
+        }
       } else {
         for (int i = 0; i < unitOperations.size(); i++) {
           runUnitTransientSkippingInactive(unitOperations.get(i), dt, id);
@@ -4164,11 +4168,12 @@ public class ProcessSystem extends SimulationBaseClass {
    *
    * @param dt time step in seconds
    * @param id calculation identifier
+   * @return {@code true} if the equipment pass completed, or {@code false} if the caller was interrupted
    */
-  private void runEquipmentTransientParallel(double dt, UUID id) {
+  private boolean runEquipmentTransientParallel(double dt, UUID id) {
     if (Thread.currentThread().isInterrupted()) {
       logger.warn("Parallel transient execution skipped because the caller is interrupted");
-      return;
+      return false;
     }
     ExecutorService executor = getParallelTransientExecutor();
     List<Future<?>> futures = new ArrayList<Future<?>>(unitOperations.size());
@@ -4193,12 +4198,13 @@ public class ProcessSystem extends SimulationBaseClass {
           futures.get(pendingIndex).cancel(false);
         }
         logger.warn("Parallel transient execution interrupted; caller interrupt status restored");
-        break;
+        return false;
       } catch (ExecutionException ex) {
         Throwable cause = ex.getCause();
         logger.error("Parallel transient equipment execution failed", cause == null ? ex : cause);
       }
     }
+    return true;
   }
 
   /**

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -19,6 +19,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.ProcessElementInterface;
@@ -164,11 +172,11 @@ public class ProcessSystem extends SimulationBaseClass {
    * Reusable worker pool for parallel transient execution. The executor is transient because threads and executor
    * services are runtime resources rather than process-model state.
    */
-  private transient java.util.concurrent.ExecutorService parallelTransientExecutor;
+  private transient ExecutorService parallelTransientExecutor;
   /** Worker count used to create {@link #parallelTransientExecutor}. */
   private transient int parallelTransientExecutorSize;
   /** Counter used to give reusable transient workers stable diagnostic names. */
-  private static final java.util.concurrent.atomic.AtomicInteger TRANSIENT_WORKER_COUNTER = new java.util.concurrent.atomic.AtomicInteger();
+  private static final AtomicInteger TRANSIENT_WORKER_COUNTER = new AtomicInteger();
 
   /**
    * Pluggable integration strategy advertised to equipment during {@code runTransient}. Defaults to
@@ -4155,8 +4163,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * @param id calculation identifier
    */
   private void runEquipmentTransientParallel(double dt, UUID id) {
-    java.util.concurrent.ExecutorService executor = getParallelTransientExecutor();
-    List<java.util.concurrent.Future<?>> futures = new ArrayList<java.util.concurrent.Future<?>>(unitOperations.size());
+    ExecutorService executor = getParallelTransientExecutor();
+    List<Future<?>> futures = new ArrayList<Future<?>>(unitOperations.size());
     for (int i = 0; i < unitOperations.size(); i++) {
       final ProcessEquipmentInterface unit = unitOperations.get(i);
       final double stepSize = dt;
@@ -4168,7 +4176,7 @@ public class ProcessSystem extends SimulationBaseClass {
         }
       }));
     }
-    for (java.util.concurrent.Future<?> f : futures) {
+    for (Future<?> f : futures) {
       try {
         f.get();
       } catch (Exception ex) {
@@ -4184,14 +4192,14 @@ public class ProcessSystem extends SimulationBaseClass {
    *
    * @return reusable executor sized by {@link #getTransientThreadPoolSize()}
    */
-  private synchronized java.util.concurrent.ExecutorService getParallelTransientExecutor() {
+  private synchronized ExecutorService getParallelTransientExecutor() {
     if (parallelTransientExecutor != null && !parallelTransientExecutor.isShutdown()
         && parallelTransientExecutorSize == transientThreadPoolSize) {
       return parallelTransientExecutor;
     }
     shutdownParallelTransientExecutor();
-    final java.util.concurrent.ThreadFactory defaultFactory = java.util.concurrent.Executors.defaultThreadFactory();
-    java.util.concurrent.ThreadFactory daemonFactory = new java.util.concurrent.ThreadFactory() {
+    final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
+    ThreadFactory daemonFactory = new ThreadFactory() {
       @Override
       public Thread newThread(Runnable task) {
         Thread worker = defaultFactory.newThread(task);
@@ -4200,9 +4208,8 @@ public class ProcessSystem extends SimulationBaseClass {
         return worker;
       }
     };
-    java.util.concurrent.ThreadPoolExecutor executor = (java.util.concurrent.ThreadPoolExecutor) java.util.concurrent.Executors
-        .newFixedThreadPool(transientThreadPoolSize, daemonFactory);
-    executor.setKeepAliveTime(60L, java.util.concurrent.TimeUnit.SECONDS);
+    ThreadPoolExecutor executor = new ThreadPoolExecutor(transientThreadPoolSize, transientThreadPoolSize, 60L,
+        TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(), daemonFactory);
     executor.allowCoreThreadTimeOut(true);
     parallelTransientExecutor = executor;
     parallelTransientExecutorSize = transientThreadPoolSize;

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
@@ -1,11 +1,20 @@
 package neqsim.process.processmodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
@@ -55,6 +64,45 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
   }
 
   /**
+   * Transient unit that blocks until released so the process runner can be interrupted while waiting on its future.
+   */
+  private static final class BlockingTransientUnit extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private final transient CountDownLatch started;
+    private final transient CountDownLatch release;
+
+    /**
+     * Creates a blocking unit.
+     *
+     * @param started latch signalled when execution starts
+     * @param release latch controlling when execution may finish
+     */
+    private BlockingTransientUnit(CountDownLatch started, CountDownLatch release) {
+      super("blocking-unit");
+      this.started = started;
+      this.release = release;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void runTransient(double dt, UUID id) {
+      started.countDown();
+      try {
+        release.await();
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+      }
+      setCalculationIdentifier(id);
+    }
+  }
+
+  /**
    * Repeated transient steps must reuse the configured bounded worker set instead of creating a new executor for every
    * step.
    */
@@ -88,7 +136,7 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
    * Runtime worker pools must not participate in process serialization or copying.
    */
   @Test
-  public void parallelTransientExecutorIsExcludedFromCopies() {
+  public void parallelTransientExecutorIsExcludedFromCopies() throws Exception {
     Set<String> workerNames = Collections.synchronizedSet(new HashSet<String>());
     AtomicInteger executionCount = new AtomicInteger();
     ProcessSystem process = new ProcessSystem();
@@ -97,11 +145,71 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
     process.setParallelTransientEnabled(true);
     process.setTransientThreadPoolSize(2);
     process.runTransient(1.0, UUID.randomUUID());
+    ExecutorService originalExecutor = getParallelTransientExecutor(process);
+    assertNotNull(originalExecutor, "Original process must create its configured transient executor");
 
     ProcessSystem copiedProcess = process.copy();
+    assertNull(getParallelTransientExecutor(copiedProcess),
+        "A copied process must not contain the original executor runtime resource");
     copiedProcess.runTransient(1.0, UUID.randomUUID());
+    ExecutorService copiedExecutor = getParallelTransientExecutor(copiedProcess);
+    assertNotNull(copiedExecutor, "Copied process must lazily create a replacement executor");
 
     assertEquals(1.0, process.getTime(), 1.0e-12);
     assertEquals(2.0, copiedProcess.getTime(), 1.0e-12);
+    assertNotSame(originalExecutor, copiedExecutor, "The copied process must create its own transient executor");
+  }
+
+  /**
+   * Interrupting the caller while it waits for parallel transient equipment must preserve the caller's interrupt flag
+   * and allow it to return promptly.
+   *
+   * @throws Exception if the test thread cannot coordinate with the process runner
+   */
+  @Test
+  public void preservesCallerInterruptStatusWhileWaitingForEquipment() throws Exception {
+    CountDownLatch started = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    Set<String> workerNames = Collections.synchronizedSet(new HashSet<String>());
+    AtomicInteger executionCount = new AtomicInteger();
+    AtomicBoolean interruptStatusAfterRun = new AtomicBoolean();
+    ProcessSystem process = new ProcessSystem();
+    process.add(new BlockingTransientUnit(started, release));
+    process.add(new ThreadRecordingUnit("recording-unit", workerNames, executionCount));
+    process.setParallelTransientEnabled(true);
+    process.setTransientThreadPoolSize(2);
+
+    Thread processRunner = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        process.runTransient(1.0, UUID.randomUUID());
+        interruptStatusAfterRun.set(Thread.currentThread().isInterrupted());
+      }
+    });
+
+    try {
+      processRunner.start();
+      assertTrue(started.await(5L, TimeUnit.SECONDS), "Blocking unit did not start");
+      processRunner.interrupt();
+      processRunner.join(2000L);
+      assertFalse(processRunner.isAlive(), "Interrupted process runner did not return promptly");
+      assertTrue(interruptStatusAfterRun.get(), "Parallel transient execution cleared the caller's interrupt status");
+    } finally {
+      release.countDown();
+      processRunner.join(2000L);
+    }
+  }
+
+  /**
+   * Reads the executor runtime field for copy-lifecycle regression assertions.
+   *
+   * @param process process system to inspect
+   * @return current transient executor, or {@code null} when none has been created
+   * @throws Exception if reflection cannot access the private field
+   */
+  private static ExecutorService getParallelTransientExecutor(ProcessSystem process) throws Exception {
+    Field field = ProcessSystem.class.getDeclaredField("parallelTransientExecutor");
+    field.setAccessible(true);
+    return (ExecutorService) field.get(process);
   }
 }

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
@@ -17,7 +17,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.measurementdevice.MeasurementDeviceBaseClass;
 
 /**
  * Regression tests for parallel transient execution in {@link ProcessSystem}.
@@ -182,6 +184,55 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
       executionCount.incrementAndGet();
       started.countDown();
       setCalculationIdentifier(id);
+    }
+  }
+
+  /**
+   * Standalone controller that records transient scan execution.
+   */
+  private static final class CountingController extends ControllerDeviceBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private final AtomicInteger executionCount;
+
+    /**
+     * Creates a counting controller.
+     *
+     * @param executionCount shared execution counter
+     */
+    private CountingController(AtomicInteger executionCount) {
+      super("counting-controller");
+      this.executionCount = executionCount;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void runTransient(double initResponse, double dt, UUID id) {
+      executionCount.incrementAndGet();
+    }
+  }
+
+  /**
+   * Measurement device that records each value scan.
+   */
+  private static final class CountingMeasurement extends MeasurementDeviceBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private final AtomicInteger executionCount;
+
+    /**
+     * Creates a counting measurement.
+     *
+     * @param executionCount shared execution counter
+     */
+    private CountingMeasurement(AtomicInteger executionCount) {
+      super("counting-measurement", "-");
+      this.executionCount = executionCount;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double getMeasuredValue(String unit) {
+      executionCount.incrementAndGet();
+      return 0.0;
     }
   }
 
@@ -359,6 +410,49 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
       assertFalse(queuedStarted.await(500L, TimeUnit.MILLISECONDS),
           "Queued equipment continued executing after runTransient returned");
       assertEquals(0, queuedExecutionCount.get(), "Queued equipment mutated state after runTransient returned");
+    } finally {
+      releaseBlocking.countDown();
+      processRunner.join(2000L);
+    }
+  }
+
+  /**
+   * An interrupted parallel equipment pass must abort controller and measurement phases that could otherwise race with
+   * equipment still updating state.
+   *
+   * @throws Exception if the test thread cannot coordinate with the process runner
+   */
+  @Test
+  public void interruptAbortsRemainingTransientStepPhases() throws Exception {
+    CountDownLatch blockingStarted = new CountDownLatch(1);
+    CountDownLatch releaseBlocking = new CountDownLatch(1);
+    Set<String> workerNames = Collections.synchronizedSet(new HashSet<String>());
+    AtomicInteger equipmentExecutionCount = new AtomicInteger();
+    AtomicInteger controllerExecutionCount = new AtomicInteger();
+    AtomicInteger measurementExecutionCount = new AtomicInteger();
+    ProcessSystem process = new ProcessSystem();
+    process.add(new BlockingTransientUnit(blockingStarted, releaseBlocking));
+    process.add(new ThreadRecordingUnit("recording-unit", workerNames, equipmentExecutionCount));
+    process.add(new CountingController(controllerExecutionCount));
+    process.add(new CountingMeasurement(measurementExecutionCount));
+    process.setParallelTransientEnabled(true);
+    process.setTransientThreadPoolSize(2);
+
+    Thread processRunner = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        process.runTransient(1.0, UUID.randomUUID());
+      }
+    });
+
+    try {
+      processRunner.start();
+      assertTrue(blockingStarted.await(5L, TimeUnit.SECONDS), "Blocking equipment did not start");
+      processRunner.interrupt();
+      processRunner.join(2000L);
+      assertFalse(processRunner.isAlive(), "Interrupted process runner did not return promptly");
+      assertEquals(0, controllerExecutionCount.get(), "Controller scan ran after equipment interruption");
+      assertEquals(0, measurementExecutionCount.get(), "Measurement scan ran after equipment interruption");
     } finally {
       releaseBlocking.countDown();
       processRunner.join(2000L);

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
@@ -1,0 +1,107 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+
+/**
+ * Regression tests for parallel transient execution in {@link ProcessSystem}.
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
+  /**
+   * Minimal transient unit that records the worker thread used for each step.
+   */
+  private static final class ThreadRecordingUnit extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private final Set<String> workerNames;
+    private final AtomicInteger executionCount;
+
+    /**
+     * Creates a recording unit.
+     *
+     * @param name unit name
+     * @param workerNames shared set receiving worker-thread names
+     * @param executionCount shared execution counter
+     */
+    private ThreadRecordingUnit(String name, Set<String> workerNames, AtomicInteger executionCount) {
+      super(name);
+      this.workerNames = workerNames;
+      this.executionCount = executionCount;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void runTransient(double dt, UUID id) {
+      workerNames.add(Thread.currentThread().getName());
+      executionCount.incrementAndGet();
+      increaseTime(dt);
+      setCalculationIdentifier(id);
+    }
+  }
+
+  /**
+   * Repeated transient steps must reuse the configured bounded worker set instead of creating a new executor for every
+   * step.
+   */
+  @Test
+  public void reusesConfiguredWorkersAcrossTransientSteps() {
+    int numberOfUnits = 8;
+    int numberOfSteps = 20;
+    int numberOfWorkers = 2;
+    Set<String> workerNames = Collections.synchronizedSet(new HashSet<String>());
+    AtomicInteger executionCount = new AtomicInteger();
+
+    ProcessSystem process = new ProcessSystem();
+    for (int i = 0; i < numberOfUnits; i++) {
+      process.add(new ThreadRecordingUnit("unit-" + i, workerNames, executionCount));
+    }
+    process.setParallelTransientEnabled(true);
+    process.setTransientThreadPoolSize(numberOfWorkers);
+
+    UUID id = UUID.randomUUID();
+    for (int i = 0; i < numberOfSteps; i++) {
+      process.runTransient(1.0, id);
+    }
+
+    assertEquals(numberOfUnits * numberOfSteps, executionCount.get());
+    assertTrue(workerNames.size() <= numberOfWorkers,
+        "Expected at most " + numberOfWorkers + " reused workers, but observed " + workerNames);
+    assertEquals(numberOfSteps, process.getTime(), 1.0e-12);
+  }
+
+  /**
+   * Runtime worker pools must not participate in process serialization or copying.
+   */
+  @Test
+  public void parallelTransientExecutorIsExcludedFromCopies() {
+    Set<String> workerNames = Collections.synchronizedSet(new HashSet<String>());
+    AtomicInteger executionCount = new AtomicInteger();
+    ProcessSystem process = new ProcessSystem();
+    process.add(new ThreadRecordingUnit("unit", workerNames, executionCount));
+    process.add(new ThreadRecordingUnit("unit-2", workerNames, executionCount));
+    process.setParallelTransientEnabled(true);
+    process.setTransientThreadPoolSize(2);
+    process.runTransient(1.0, UUID.randomUUID());
+
+    ProcessSystem copiedProcess = process.copy();
+    copiedProcess.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(1.0, process.getTime(), 1.0e-12);
+    assertEquals(2.0, copiedProcess.getTime(), 1.0e-12);
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
@@ -103,6 +103,54 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
   }
 
   /**
+   * Transient unit that detects overlapping invocations while the first invocation is blocked.
+   */
+  private static final class ReentrantBlockingTransientUnit extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private final transient CountDownLatch firstStarted;
+    private final transient CountDownLatch secondStarted;
+    private final transient CountDownLatch release;
+    private final AtomicInteger executionCount = new AtomicInteger();
+
+    /**
+     * Creates a blocking unit that reports its first and second invocations.
+     *
+     * @param firstStarted latch signalled when the first invocation starts
+     * @param secondStarted latch signalled if a second invocation starts before release
+     * @param release latch controlling when invocations may finish
+     */
+    private ReentrantBlockingTransientUnit(CountDownLatch firstStarted, CountDownLatch secondStarted,
+        CountDownLatch release) {
+      super("reentrant-blocking-unit");
+      this.firstStarted = firstStarted;
+      this.secondStarted = secondStarted;
+      this.release = release;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void runTransient(double dt, UUID id) {
+      if (executionCount.incrementAndGet() == 1) {
+        firstStarted.countDown();
+      } else {
+        secondStarted.countDown();
+      }
+      try {
+        release.await();
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+      }
+      setCalculationIdentifier(id);
+    }
+  }
+
+  /**
    * Repeated transient steps must reuse the configured bounded worker set instead of creating a new executor for every
    * step.
    */
@@ -194,6 +242,45 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
       processRunner.join(2000L);
       assertFalse(processRunner.isAlive(), "Interrupted process runner did not return promptly");
       assertTrue(interruptStatusAfterRun.get(), "Parallel transient execution cleared the caller's interrupt status");
+    } finally {
+      release.countDown();
+      processRunner.join(2000L);
+    }
+  }
+
+  /**
+   * An interrupted semi-implicit step must not submit its second parallel equipment pass while the first pass can still
+   * be mutating equipment state.
+   *
+   * @throws Exception if the test thread cannot coordinate with the process runner
+   */
+  @Test
+  public void interruptedSemiImplicitStepDoesNotSubmitSecondParallelPass() throws Exception {
+    CountDownLatch firstStarted = new CountDownLatch(1);
+    CountDownLatch secondStarted = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    Set<String> workerNames = Collections.synchronizedSet(new HashSet<String>());
+    AtomicInteger executionCount = new AtomicInteger();
+    ProcessSystem process = new ProcessSystem();
+    process.add(new ReentrantBlockingTransientUnit(firstStarted, secondStarted, release));
+    process.add(new ThreadRecordingUnit("recording-unit", workerNames, executionCount));
+    process.setParallelTransientEnabled(true);
+    process.setTransientThreadPoolSize(4);
+    process.setIntegrationMethod(ProcessSystem.IntegrationMethod.SEMI_IMPLICIT);
+
+    Thread processRunner = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        process.runTransient(1.0, UUID.randomUUID());
+      }
+    });
+
+    try {
+      processRunner.start();
+      assertTrue(firstStarted.await(5L, TimeUnit.SECONDS), "First semi-implicit equipment pass did not start");
+      processRunner.interrupt();
+      assertFalse(secondStarted.await(500L, TimeUnit.MILLISECONDS),
+          "Interrupted semi-implicit step submitted a second parallel equipment pass");
     } finally {
       release.countDown();
       processRunner.join(2000L);

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
@@ -151,6 +151,41 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
   }
 
   /**
+   * Transient unit that signals when execution starts.
+   */
+  private static final class SignallingTransientUnit extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private final transient CountDownLatch started;
+    private final AtomicInteger executionCount;
+
+    /**
+     * Creates a signalling unit.
+     *
+     * @param started latch signalled when execution starts
+     * @param executionCount shared execution counter
+     */
+    private SignallingTransientUnit(CountDownLatch started, AtomicInteger executionCount) {
+      super("signalling-unit");
+      this.started = started;
+      this.executionCount = executionCount;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void runTransient(double dt, UUID id) {
+      executionCount.incrementAndGet();
+      started.countDown();
+      setCalculationIdentifier(id);
+    }
+  }
+
+  /**
    * Repeated transient steps must reuse the configured bounded worker set instead of creating a new executor for every
    * step.
    */
@@ -283,6 +318,49 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
           "Interrupted semi-implicit step submitted a second parallel equipment pass");
     } finally {
       release.countDown();
+      processRunner.join(2000L);
+    }
+  }
+
+  /**
+   * Interrupting a parallel transient wait must cancel queued equipment work without interrupting a unit already
+   * updating its state.
+   *
+   * @throws Exception if the test thread cannot coordinate with the process runner
+   */
+  @Test
+  public void interruptCancelsQueuedEquipmentWithoutInterruptingRunningTask() throws Exception {
+    CountDownLatch blockingStarted = new CountDownLatch(1);
+    CountDownLatch releaseBlocking = new CountDownLatch(1);
+    CountDownLatch queuedStarted = new CountDownLatch(1);
+    AtomicInteger queuedExecutionCount = new AtomicInteger();
+    ProcessSystem process = new ProcessSystem();
+    process.add(new BlockingTransientUnit(blockingStarted, releaseBlocking));
+    process.add(new SignallingTransientUnit(queuedStarted, queuedExecutionCount));
+    process.setParallelTransientEnabled(true);
+    process.setTransientThreadPoolSize(1);
+
+    Thread processRunner = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        process.runTransient(1.0, UUID.randomUUID());
+      }
+    });
+
+    try {
+      processRunner.start();
+      assertTrue(blockingStarted.await(5L, TimeUnit.SECONDS), "Blocking equipment did not start");
+      processRunner.interrupt();
+      processRunner.join(2000L);
+      assertFalse(processRunner.isAlive(), "Interrupted process runner did not return promptly");
+      assertEquals(0, queuedExecutionCount.get(), "Queued equipment ran before the blocking unit was released");
+
+      releaseBlocking.countDown();
+      assertFalse(queuedStarted.await(500L, TimeUnit.MILLISECONDS),
+          "Queued equipment continued executing after runTransient returned");
+      assertEquals(0, queuedExecutionCount.get(), "Queued equipment mutated state after runTransient returned");
+    } finally {
+      releaseBlocking.countDown();
       processRunner.join(2000L);
     }
   }


### PR DESCRIPTION
## Root cause

`ProcessSystem.runEquipmentTransientParallel(...)` created and shut down a new fixed thread pool on every transient timestep. Long simulations therefore paid executor construction and worker-thread startup costs once per step, even when the configured worker count and flowsheet were unchanged. The same wait loop also caught generic `Exception`, which cleared a caller interrupt without restoring it. After that status was restored, a semi-implicit second pass still submitted another full equipment batch while first-pass tasks could remain active, and already-queued first-pass work could continue after `runTransient(...)` returned.

## Scope

- lazily create one bounded parallel-transient executor per `ProcessSystem`
- reuse it across transient timesteps
- keep the executor out of copied/serialized process state with a `transient` field
- use named daemon workers and allow idle core workers to time out after 60 seconds
- retire the pool when parallel execution is disabled or its configured size changes
- restore caller interruption and distinguish `ExecutionException` from `InterruptedException`
- skip later parallel-pass task submission when the caller is already interrupted
- cancel queued futures without interrupting equipment already running
- abort later timestep phases after an interrupted parallel pass
- preserve the existing opt-in default and public API

Equipment ordering, normal task submission, calculation identifiers, simulation time advancement, integration, thermodynamic calls, convergence tolerances, and `ProcessModel.runTransient(...)` orchestration are unchanged. Only a later parallel pass in an already-interrupted timestep skips submission. `ProcessModel` benefits through each child `ProcessSystem`.

## Evidence and benchmark method

The performance baseline is an isolated orchestration microbenchmark, not a thermodynamic throughput benchmark. It uses 8 transient units, 2 configured workers, 200 timesteps, and verifies all 1,600 unit executions plus process time advancement.

| Metric | Current behavior | This branch |
|---|---:|---:|
| Unit executions | 1,600 | 1,600 |
| Distinct worker threads | 400 | 2 |
| Median elapsed time, 3 runs | 148.93 ms | 83.11 ms |

The stable regression metric is worker creation (400 -> 2). The observed ~44% elapsed-time reduction only characterizes this local orchestration harness and is not asserted in CI.

A deterministic interruption regression starts a blocking transient unit, interrupts the process caller while it waits in `Future.get()`, and records the caller interrupt flag after `runTransient(...)` returns:

- before `545deac`: failed; interrupt status was `false`
- after `545deac`: passed; interrupt status is restored and the caller returns promptly

A second deterministic regression blocks a semi-implicit first pass, interrupts its caller, and detects whether the same equipment is invoked concurrently by the second pass:

- before `93bfda1`: failed; the second invocation started
- after `93bfda1`: passed; the interrupted second pass submits no equipment tasks

A third deterministic regression uses one worker, blocks the running unit, interrupts the caller, and releases it after `runTransient(...)` returns:

- before `1f1b519`: failed; the queued unit executed and mutated state after return
- after `1f1b519`: passed; queued work is cancelled without interrupting the running unit

A fourth deterministic regression holds equipment active during caller interruption and records standalone controller and measurement scans:

- before `97f397e`: failed; the controller scan ran while equipment was still active
- after `97f397e`: passed; the interrupted equipment pass aborts all remaining timestep phases

Already-running equipment is deliberately not forcibly interrupted because unit-operation state mutation is not transactionally interruptible. An interrupted timestep must be treated as incomplete, not rolled back.

## Tests run

Local runtime: OpenJDK 17.0.19 with Eclipse ECJ 3.40.0 compiling to a Java 8 source/target against the packaged NeqSim 3.16.0 dependency set plus the changed current source.

- `ProcessSystemParallelTransientTest`: 6/6 passed
  - repeated steps reuse no more than the configured workers
  - copied systems start with no executor and lazily create a distinct executor
  - interrupted parallel waits preserve caller interrupt status and return promptly
  - interrupted semi-implicit steps do not submit a second overlapping parallel pass
  - interruption cancels queued equipment without interrupting the running unit
  - controller and measurement phases do not run after an interrupted equipment pass
- `ProcessSystemResetTest` + `RunTransientEventSchedulerTest`: 7/7 passed, including a two-area `ProcessModel.runTransient(...)` event case and 12,500 repeated transient steps
- orchestration harness after the latest change: 1,600/1,600 executions, 2 worker threads, copied model time advanced from 200 s to 201 s
- `git diff --check`: passed

Local Maven formatting could not run in the execution sandbox: the wrapper could not create its required `/root/.m2` directory, and an earlier attempt could not resolve the Spotless plugin from Maven Central. The changed Java lines were checked manually against the 120-column format and `git diff --check`; hosted Spotless remains authoritative. No unrun local check is claimed.

## Hosted validation at `2831567`

All latest-head workflows completed successfully:

- Spotless format patch
- pre-commit checks
- CodeQL security analysis
- documentation search coverage
- skills and agents lint
- PaperLab replication gate
- full build, tests, and Javadoc
  - Javadoc on Java 21/Ubuntu
  - fast tests with JaCoCo on Java 21/Ubuntu
  - fast tests on Java 21/Windows
  - all three slow-test shards on Java 21/Ubuntu
  - tests on Java 8/Ubuntu
  - tests on Java 8/Windows

## Current `master` inspection

After this head was validated, `master` advanced to `1e352322` through #2687. That merged patch changes steady-state `run()`/`runOptimized()` preparation near lines 1444 and 2747 plus its focused test; this PR changes the parallel transient path near line 4200. The scopes and hunks are independent, and GitHub reports this draft mergeable. No branch rewrite was made solely to rerun the fully green matrix against an unrelated one-commit advance.

## Review disposition

- Direct-executor thread: accepted and resolved. The implementation constructs `ThreadPoolExecutor` directly with fixed-size/unbounded-queue semantics.
- Suppressed interrupt-status note: accepted in `545deac`; reproduced before editing, fixed with explicit exception handling, and covered by a deterministic regression.
- Suppressed copy-lifecycle note: accepted in `545deac`; the test now directly verifies a null executor in the copy before use and a distinct lazily-created executor afterward.
- Suppressed semi-implicit resubmission note: accepted in `93bfda1`; reproduced as a concurrent second invocation, fixed with an early interrupted-status guard, and covered by a deterministic regression.
- Queued-work review thread: accepted and resolved in `1f1b519`; reproduced as post-return state mutation, fixed with non-interrupting future cancellation, and covered by a one-worker regression.
- Suppressed remaining-phase race: accepted in `97f397e`; reproduced as a concurrent controller scan, fixed by propagating private pass completion to `runTransient(...)`, and covered through controller and measurement counters.

## Compatibility and risk

- parallel transient execution remains disabled by default
- no public signature or Java/Python call pattern changes
- numerical and thermodynamic behavior is unchanged
- executor access and configuration are synchronized with the already-synchronized transient step
- daemon workers avoid holding the JVM open; idle timeout limits retained workers for abandoned models
- caller interruption is now observable as required by Java interruption conventions
- later parallel passes do not submit new work after interruption
- queued futures are cancelled without interrupting running equipment
- remaining controller, measurement, result-storage, and post-controller event phases abort after interruption
- running equipment is not forcibly interrupted; callers must regard an interrupted step as incomplete
- tightly coupled sequential equipment and recycle loops still require verified dependency safety before enabling parallel transient execution

## Documentation impact

Updated the affected Javadocs, `docs/process/dynamic-simulation-enhancements.md`, and the repository dynamic-simulation skill. The earlier task-log-only delta was dropped when updating onto current `master`; rewriting the full append-only log through the connector was rejected because it contains unrelated operational history.

## Limitations / next dependency

This removes per-step worker churn, restores caller interruption, cancels queued work, and aborts later timestep phases after interruption. It does not introduce transactional rollback or dependency-aware transient scheduling. A later, separate iteration should establish execution-order and dependency semantics for parallel `ProcessSystem`/`ProcessModel` areas before broadening parallel execution to recycles, controllers, or connected stateful equipment.