### PR TITLE
perf: avoid duplicate ProcessSystem run preparation

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -1444,7 +1444,10 @@ public class ProcessSystem extends SimulationBaseClass {
   public void runOptimized(UUID id) {
     enterRunScope();
     try {
-      resetActiveStates();
+      // The concrete method selected below applies flowsheet-wide settings and
+      // performs the active-state reset when runOptimized() is called directly.
+      // When run() delegates here, its outer run scope already performed the
+      // active-state reset, so repeating preparation in this dispatcher is wasteful.
       if (hasAdjusters()) {
         // Adjusters create implicit feedback loops via signal connections and
         // iterate on a target variable. The graph partitioner cannot represent
@@ -2744,8 +2747,12 @@ public class ProcessSystem extends SimulationBaseClass {
     boolean runThrew = false;
     try {
       resetExecutionProfile();
-      resetActiveStates();
-      applyFlowsheetWideSettings();
+      // runOptimized() establishes an inner run scope before selecting a concrete
+      // execution method. Reset active states here while this scope is outermost;
+      // the legacy sequential path performs its own reset at the same run depth.
+      if (useOptimizedExecution) {
+        resetActiveStates();
+      }
       long wallStart = System.nanoTime();
       boolean prevWarmStart = neqsim.thermo.ThermodynamicModelSettings.isUseWarmStartKValues();
       if (useFlashWarmStart) {

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemExecutionPreparationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemExecutionPreparationTest.java
@@ -1,0 +1,132 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Verifies that public process dispatchers prepare a flowsheet once before concrete execution.
+ */
+class ProcessSystemExecutionPreparationTest {
+  /**
+   * Stream that records how often a flowsheet-wide property setting is applied.
+   */
+  private static final class CountingStream extends Stream {
+    private static final long serialVersionUID = 1000L;
+    private int propertyInitLevelApplications;
+
+    /**
+     * Creates a stream that counts property-initialization setting applications.
+     *
+     * @param name stream name
+     * @param fluid stream fluid
+     */
+    CountingStream(String name, SystemInterface fluid) {
+      super(name, fluid);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setPropertyInitLevel(PropertyInitLevel level) {
+      super.setPropertyInitLevel(level);
+      propertyInitLevelApplications++;
+    }
+
+    /**
+     * Returns the number of property-initialization setting applications.
+     *
+     * @return application count
+     */
+    int getPropertyInitLevelApplications() {
+      return propertyInitLevelApplications;
+    }
+
+    /**
+     * Resets the application count.
+     */
+    void resetPropertyInitLevelApplications() {
+      propertyInitLevelApplications = 0;
+    }
+  }
+
+  /**
+   * Creates a representative feed stream.
+   *
+   * @return feed stream
+   */
+  private CountingStream createFeed() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+    CountingStream feed = new CountingStream("feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    return feed;
+  }
+
+  /**
+   * Runs the process through the selected dispatcher and verifies a single preparation pass.
+   *
+   * @param optimizedExecution whether {@link ProcessSystem#run()} uses optimized dispatch
+   */
+  private void assertSinglePreparation(boolean optimizedExecution) {
+    CountingStream feed = createFeed();
+    ProcessSystem process = new ProcessSystem("preparation");
+    process.setUseOptimizedExecution(optimizedExecution);
+    process.add(feed);
+    process.setPropertyInitLevel(Stream.PropertyInitLevel.DENSITY_ONLY);
+    feed.resetPropertyInitLevelApplications();
+
+    process.run();
+
+    assertEquals(1, feed.getPropertyInitLevelApplications(),
+        "run() must apply flowsheet settings once before concrete execution");
+    assertEquals(Stream.PropertyInitLevel.DENSITY_ONLY, feed.getPropertyInitLevel());
+    assertTrue(process.getRunStatus().isSuccess());
+  }
+
+  /**
+   * Verifies optimized dispatch prepares the flowsheet once.
+   */
+  @Test
+  void optimizedDispatcherPreparesFlowsheetOnce() {
+    assertSinglePreparation(true);
+  }
+
+  /**
+   * Verifies sequential dispatch prepares the flowsheet once.
+   */
+  @Test
+  void sequentialDispatcherPreparesFlowsheetOnce() {
+    assertSinglePreparation(false);
+  }
+
+  /**
+   * Verifies the retained outer active-state reset reactivates an auto-bypassed unit after its feed changes.
+   */
+  @Test
+  void optimizedDispatcherReactivatesAutoBypassedUnitAfterFeedChange() {
+    CountingStream feed = createFeed();
+    feed.setFlowRate(0.0, "kg/hr");
+    Heater heater = new Heater("heater", feed);
+    heater.setOutletTemperature(310.0);
+    heater.setMinimumFlow(1.0);
+    ProcessSystem process = new ProcessSystem("low-flow-reactivation");
+    process.add(feed);
+    process.add(heater);
+
+    process.run();
+    assertFalse(heater.isActive());
+
+    feed.setFlowRate(1000.0, "kg/hr");
+    process.run();
+
+    assertTrue(heater.isActive());
+    assertTrue(heater.getOutletStream().getFlowRate("kg/hr") > 1.0);
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemExecutionPreparationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemExecutionPreparationTest.java
@@ -117,6 +117,7 @@ class ProcessSystemExecutionPreparationTest {
     heater.setOutletTemperature(310.0);
     heater.setMinimumFlow(1.0);
     ProcessSystem process = new ProcessSystem("low-flow-reactivation");
+    process.setUseOptimizedExecution(true);
     process.add(feed);
     process.add(heater);
 


### PR DESCRIPTION
## Summary

`ProcessSystem.run(UUID)` and `runOptimized(UUID)` repeated flowsheet preparation before delegating to concrete execution methods that must prepare themselves because they are also public entry points. On warm, wide flowsheets this caused avoidable full unit/stream scans and repeated propagation of flowsheet-wide settings on every run.

This change:
- removes preparation from the optimized dispatcher;
- lets legacy sequential dispatch prepare only in `runSequential(UUID)`;
- retains the optimized wrapper's one effective outer-depth active-state reset, preserving low-flow reactivation semantics;
- leaves the concrete execution methods responsible for flowsheet-wide settings and direct-call preparation.

There is no public API, serialization, convergence, caching, or shared-state change.

## Duplicate/conflict check

The benchmark baseline is `3bb63211f95ae5a66c1da05484331714d8a45f7f`. Current `master` was rechecked at `d546283a4d687a6a42a72167d46d871cea77df56` on 2026-07-30; the `ProcessSystem.java`, `ProcessModel.java`, and `Stream.java` blobs are unchanged from the benchmark baseline. Open performance issue #2110 and PRs #1754, #2686, and #2689 were inspected. None implements this dispatcher-preparation deduplication. PR #2686 changes separate transient-execution regions of `ProcessSystem.java`; #2689 changes TPflash endpoint refinement. Both are logically non-overlapping.

## Reproducible benchmark

Method:
- 24 warm-up runs;
- 20 measured batches per workload;
- three fresh JVM forks for `master` and this branch;
- reported value is the median of the three per-fork p50 values;
- OpenJDK 17, `-XX:-UsePerfData -Xms512m -Xmx2g`;
- current source compiled to a Java 8 target with Eclipse ECJ;
- profiling disabled during measured batches.

| Workload | Runs/batch | master p50 | branch p50 | Gain |
| --- | ---: | ---: | ---: | ---: |
| Optimized `ProcessSystem`, 192 independent streams | 500 | 0.079744 ms | 0.060830 ms | 23.7% |
| Optimized `ProcessSystem`, eight independent six-unit separation/compression trains | 500 | 0.575526 ms | 0.373901 ms | 35.0% |
| `ProcessModel`, four independent areas × 48 streams | 1000 | 0.082100 ms | 0.061053 ms | 25.6% |

Checksums, run status, and unit counts were identical for every fork. A thermodynamics-dominated legacy sequential stream case showed no reliable change, so no speedup is claimed for that path.

## Accuracy and robustness

A separate baseline-versus-branch harness exercised three nearby operating points:
- 293/298/303 K;
- 75/80/85 bara;
- 18,000/20,000/22,000 kg/h.

Each point ran twice. The complete output matched bit-for-bit between `master` and this branch for every unit's temperature, pressure, phase count, total moles, and enthalpy. All six runs reported success and zero mass-balance failures. Repeated-run behavior and the retained low-flow active-state reset are covered explicitly.

## Tests

- New `ProcessSystemExecutionPreparationTest`: 3/3 pass on the branch.
  - On unmodified `master`, both preparation-count assertions fail as expected: two setting applications instead of one.
  - The low-flow reactivation test passes on both and guards the lifecycle behavior retained by this patch.
- `ProcessModelExecutionOptimizationTest`: 11/11 pass.
- `ProcessSystemMultiPhaseCheckTest`: 7/7 pass.
- `ProcessSystemLowFlowBypassTest`: 4/4 pass.
- Total focused/relevant tests: 25/25 pass.
- Java 8-target compilation: pass.
- `git diff --check`: pass.

Local `./mvnw spotless:check` and the full Maven suite could not resolve Maven Central in this execution environment, even through the available proxy. Hosted CI is therefore authoritative for Spotless and the broader matrix; no check is claimed locally.

## Compatibility and risk

- Public API compatibility: unchanged.
- Determinism and thermodynamic results: bit-for-bit validation above.
- Thread safety: unchanged; `run(UUID)` remains synchronized and no mutable shared state or cache was added.
- Accuracy, mass/energy behavior, phase behavior, and convergence logic: untouched.
- Direct concrete execution methods still perform their established preparation.
- Optimized dispatch retains the outer-depth active reset needed to reactivate changed low-flow equipment.

## Documentation impact

Documentation impact: none. This is an internal removal of redundant dispatcher work and does not change APIs, inputs, outputs, units, defaults, accuracy, execution-strategy selection, or recommended usage. The adjacent `ProcessSystem`, `ProcessModel`, graph-execution, physical-property initialization, and performance-tuning documentation was reviewed and remains accurate.

## Limitations

The benchmark emphasizes warm repeated execution, where dispatcher overhead is visible; gains depend on flowsheet width and the amount of flowsheet-wide setting propagation. The local environment could not run Maven, so the benchmark used exact current source over packaged NeqSim 3.16.0 dependencies and hosted CI must validate the repository's full dependency matrix.