### PR TITLE
feat: couple pumparounds into Naphtali MESH equations

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -17,7 +17,7 @@ column model for absorption and stripping. The main implementation lives in
 | Solvers | `SolverType` | Direct, damped, inside-out, adaptive matrix inside-out, Wegstein, sum-rates, Newton temperature correction, Naphtali-Sandholm, MESH residual, and `AUTO` with candidate tracing. |
 | Formal specifications | `ColumnSpecification`, convenience setters | Product purity, component recovery, reflux ratio, product flow rate, duty specifications, and staged specification homotopy for difficult product targets. |
 | Side products | `setGasSideDrawFraction`, `setLiquidSideDrawFraction`, `addSideDrawFlowSpecification` | Side draws are external product streams and are included in outlet stream and mass-balance reporting. |
-| Pumparounds | `addLiquidPumparound` | Internal liquid draw/return circuits solved as column tear variables. |
+| Pumparounds | `addLiquidPumparound` | Internal liquid draw/return circuits; Naphtali-Sandholm couples their mass and energy terms directly, while sequential solvers use column tear variables. |
 | Hardware modes | `CondenserMode`, `ReboilerMode` | Partial or total condenser, fixed liquid reflux split, equilibrium reboiler, and vapor boilup ratio mode. |
 | Hydraulics and sizing | `calcColumnInternals`, `enableHydraulicPressureDropCoupling` | Rates tray or packing hydraulics and can couple total pressure drop back into the pressure profile. |
 | Efficiency | `setMurphreeEfficiency`, `setMurphreeEfficiencies` | Column-wide and per-stage Murphree vapor efficiency correction. |
@@ -183,7 +183,7 @@ required.
 | `WEGSTEIN` | Accelerated successive substitution after warm-up. | Well-conditioned fixed-point problems. |
 | `SUM_RATES` | Flow-corrected tearing method. | Absorbers, strippers, and flow-sensitive columns. |
 | `NEWTON` | Tray-temperature Newton accelerator. | Difficult temperature convergence. It is not full simultaneous MESH Newton. |
-| `NAPHTALI_SANDHOLM` | Guarded simultaneous correction of MESH blocks after inside-out warm start. | Residual-driven hydrocarbon fractionators. |
+| `NAPHTALI_SANDHOLM` | Guarded simultaneous correction of MESH equations, including nonlocal pumparound draw/return terms. | Residual-driven hydrocarbon fractionators. |
 | `MESH_RESIDUAL` | Inside-out initialization plus full residual auditing. | Material, equilibrium, summation, energy, product-draw, and spec residual checks. |
 | `AUTO` | Runs a feasibility pre-screen, initializes a copied candidate, solves a relaxed damped base case, probes candidate strategies on column copies, and accepts the first solved non-fallback candidate or the best valid fallback. | Agent workflows and uncertain cases where robust automatic selection and diagnostics are useful. |
 
@@ -239,7 +239,12 @@ traffic and the latest tear-variable diagnostics report non-convergence.
 ## Pumparounds
 
 Liquid pumparounds are internal draw/return circuits. They are not external products and do not
-appear in `getOutletStreams()`.
+appear in `getOutletStreams()`. With `NAPHTALI_SANDHOLM`, the configured draw fraction is removed
+from the draw tray and returned to the configured tray in the same MESH equation system. The return
+preserves component flow and uses the draw composition at `drawTemperature - temperatureDrop` for
+its enthalpy. Because this link can connect non-adjacent trays, the solver uses a dense numerical
+Jacobian only for active pumparound cases; ordinary columns retain the block-tridiagonal path.
+Sequential solvers retain the established outer tear-stream iteration.
 
 ```java
 DistillationColumn.ColumnPumparound pumparound = column.addLiquidPumparound("PA-1", 4, 6,
@@ -253,7 +258,9 @@ double latestChange = column.getLastPumparoundRelativeChange();
 ```
 
 The `temperatureDrop` argument is in Kelvin. Positive values cool the returned liquid; negative
-values heat it. A non-finite or below-zero-K return temperature fails explicitly.
+values heat it. A non-finite or below-zero-K return temperature fails explicitly. For a direct
+Naphtali-Sandholm solve, `getLastPumparoundRelativeChange()` is zero because the stream object is
+materialized from the simultaneous solution rather than converged as an outer tear variable.
 
 ## Hydraulics and Pressure-Drop Coupling
 

--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -259,8 +259,9 @@ double latestChange = column.getLastPumparoundRelativeChange();
 
 The `temperatureDrop` argument is in Kelvin. Positive values cool the returned liquid; negative
 values heat it. A non-finite or below-zero-K return temperature fails explicitly. For a direct
-Naphtali-Sandholm solve, `getLastPumparoundRelativeChange()` is zero because the stream object is
-materialized from the simultaneous solution rather than converged as an outer tear variable.
+Naphtali-Sandholm solve, `getLastPumparoundRelativeChange()` reports the stream-materialization
+change for diagnostics, but that change does not trigger a second column solve because the circuit
+already participates in the simultaneous equations.
 
 ## Hydraulics and Pressure-Drop Coupling
 

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2780,8 +2780,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
           getEffectiveMurphreeEfficiency(trayIndex));
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, tray.getGasSideDrawFraction());
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, tray.getLiquidSideDrawFraction());
-      updatedSignature =
-          updateNaphtaliSandholmInputSignature(updatedSignature, tray.getLiquidPumparoundDrawFraction());
+      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, tray.getLiquidPumparoundDrawFraction());
     }
     updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, pumparounds.size());
     for (ColumnPumparound pumparound : pumparounds) {

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1433,7 +1433,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     // stream update above only materializes that accepted state, so it is not an outer
     // tear variable and must not trigger a second identical column solve.
     if (lastSolverTypeUsed == SolverType.NAPHTALI_SANDHOLM) {
-      lastPumparoundRelativeChange = 0.0;
+      lastPumparoundRelativeChange = maxRelativeChange;
       return 0.0;
     }
     lastPumparoundRelativeChange = maxRelativeChange;

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2786,7 +2786,6 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     for (ColumnPumparound pumparound : pumparounds) {
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, pumparound.getDrawTrayNumber());
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, pumparound.getReturnTrayNumber());
-      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, pumparound.getDrawFraction());
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, pumparound.getTemperatureDrop());
     }
     if (hasReboiler && getReboiler() != null) {

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1429,6 +1429,13 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       StreamInterface drawStream = getTray(pumparound.getDrawTrayNumber()).getLiquidPumparoundDrawStream();
       maxRelativeChange = Math.max(maxRelativeChange, pumparound.updateReturnStream(drawStream, id));
     }
+    // Naphtali-Sandholm includes the draw and cooled return in one equation system. The
+    // stream update above only materializes that accepted state, so it is not an outer
+    // tear variable and must not trigger a second identical column solve.
+    if (lastSolverTypeUsed == SolverType.NAPHTALI_SANDHOLM) {
+      lastPumparoundRelativeChange = 0.0;
+      return 0.0;
+    }
     lastPumparoundRelativeChange = maxRelativeChange;
     if (maxRelativeChange > 1.0e-12) {
       columnTearVariablesChanged = true;
@@ -1796,15 +1803,6 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     if (solverType == SolverType.AUTO && hasBeenSolvedBefore && autoWarmStartSolver != null
         && autoWarmStartSolver != SolverType.AUTO && !hasAdjustableSpecifications()) {
       effectiveSolverType = autoWarmStartSolver;
-    }
-    // Pumparound returns are converged by the outer tear loop and are not yet assembled as
-    // Naphtali-Sandholm feed terms. Keep that coordinated configuration on the established
-    // residual-monitored solver until both withdrawal and return participate in one simultaneous
-    // equation system.
-    if (effectiveSolverType == SolverType.NAPHTALI_SANDHOLM && !pumparounds.isEmpty()) {
-      logger.debug("Using MESH_RESIDUAL for column {} because active pumparounds require outer return-stream coupling",
-          getName());
-      return SolverType.MESH_RESIDUAL;
     }
     return effectiveSolverType;
   }
@@ -2782,6 +2780,15 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
           getEffectiveMurphreeEfficiency(trayIndex));
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, tray.getGasSideDrawFraction());
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, tray.getLiquidSideDrawFraction());
+      updatedSignature =
+          updateNaphtaliSandholmInputSignature(updatedSignature, tray.getLiquidPumparoundDrawFraction());
+    }
+    updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, pumparounds.size());
+    for (ColumnPumparound pumparound : pumparounds) {
+      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, pumparound.getDrawTrayNumber());
+      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, pumparound.getReturnTrayNumber());
+      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, pumparound.getDrawFraction());
+      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, pumparound.getTemperatureDrop());
     }
     if (hasReboiler && getReboiler() != null) {
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, getReboiler().getRefluxRatio());

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -2985,15 +2985,23 @@ public class NaphtaliSandholmSolver {
     return sum;
   }
 
-  /** Return whether at least one liquid pumparound is active. */
+  /** Return whether at least one liquid pumparound has a positive draw fraction. */
   private boolean hasActivePumparounds() {
-    return pumparounds != null && !pumparounds.isEmpty();
+    if (pumparounds == null) {
+      return false;
+    }
+    for (DistillationColumn.ColumnPumparound pumparound : pumparounds) {
+      if (pumparound.getDrawFraction() > 0.0) {
+        return true;
+      }
+    }
+    return false;
   }
 
-  /** Return whether a tray supplies a configured pumparound draw. */
+  /** Return whether a tray supplies a positive-flow configured pumparound draw. */
   private boolean isPumparoundDrawTray(int tray) {
     for (DistillationColumn.ColumnPumparound pumparound : pumparounds) {
-      if (pumparound.getDrawTrayNumber() == tray) {
+      if (pumparound.getDrawFraction() > 0.0 && pumparound.getDrawTrayNumber() == tray) {
         return true;
       }
     }
@@ -3157,9 +3165,10 @@ public class NaphtaliSandholmSolver {
    * Compute the Jacobian matrix numerically using finite differences.
    *
    * <p>
-   * The Jacobian has block-tridiagonal structure. Only entries in the tri-diagonal bands are computed. For variable k
-   * on tray jj, we compute d(residual_j)/d(var_{jj,k}) for j in {jj-1, jj, jj+1}. After perturbing a variable on tray
-   * jj, only tray jj's thermo is re-evaluated (K-values, enthalpies depend only on local T and x).
+   * Ordinary columns retain the block-tridiagonal structure: for a variable on tray jj, only residuals on trays
+   * jj-1, jj, and jj+1 are differentiated. An active pumparound can connect non-adjacent trays, so that opt-in path
+   * differentiates every residual row and is solved as a dense system. Only tray jj thermodynamics are re-evaluated;
+   * pumparound return enthalpy is refreshed when jj supplies a changed draw composition or temperature.
    * </p>
    *
    * @param F0 current residual vector

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -2991,7 +2991,8 @@ public class NaphtaliSandholmSolver {
       return false;
     }
     for (DistillationColumn.ColumnPumparound pumparound : pumparounds) {
-      if (pumparound.getDrawFraction() > 0.0) {
+      int drawTray = pumparound.getDrawTrayNumber();
+      if (liquidPumparoundFraction[drawTray] > 0.0) {
         return true;
       }
     }
@@ -3001,7 +3002,8 @@ public class NaphtaliSandholmSolver {
   /** Return whether a tray supplies a positive-flow configured pumparound draw. */
   private boolean isPumparoundDrawTray(int tray) {
     for (DistillationColumn.ColumnPumparound pumparound : pumparounds) {
-      if (pumparound.getDrawFraction() > 0.0 && pumparound.getDrawTrayNumber() == tray) {
+      int drawTray = pumparound.getDrawTrayNumber();
+      if (liquidPumparoundFraction[drawTray] > 0.0 && drawTray == tray) {
         return true;
       }
     }
@@ -3043,7 +3045,8 @@ public class NaphtaliSandholmSolver {
     double returnedFlow = 0.0;
     for (DistillationColumn.ColumnPumparound pumparound : pumparounds) {
       if (pumparound.getReturnTrayNumber() == tray) {
-        returnedFlow += pumparound.getDrawFraction() * liq[pumparound.getDrawTrayNumber()][component];
+        int drawTray = pumparound.getDrawTrayNumber();
+        returnedFlow += liquidPumparoundFraction[drawTray] * liq[drawTray][component];
       }
     }
     return returnedFlow;
@@ -3056,7 +3059,8 @@ public class NaphtaliSandholmSolver {
       DistillationColumn.ColumnPumparound pumparound = pumparounds.get(circuitIndex);
       if (pumparound.getReturnTrayNumber() == tray) {
         int drawTray = pumparound.getDrawTrayNumber();
-        returnedEnergy += pumparound.getDrawFraction() * L[drawTray] * pumparoundReturnEnthalpy[circuitIndex];
+        returnedEnergy +=
+            liquidPumparoundFraction[drawTray] * L[drawTray] * pumparoundReturnEnthalpy[circuitIndex];
       }
     }
     return returnedEnergy;

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -2990,6 +2990,16 @@ public class NaphtaliSandholmSolver {
     return pumparounds != null && !pumparounds.isEmpty();
   }
 
+  /** Return whether a tray supplies a configured pumparound draw. */
+  private boolean isPumparoundDrawTray(int tray) {
+    for (DistillationColumn.ColumnPumparound pumparound : pumparounds) {
+      if (pumparound.getDrawTrayNumber() == tray) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Refresh return enthalpies from each draw tray's current liquid composition and temperature.
    *
@@ -3169,7 +3179,11 @@ public class NaphtaliSandholmSolver {
         double h = Math.max(Math.abs(origVal) * pertSize, minPert);
         setVariable(jj, k, origVal + h);
         evaluateThermoForTray(jj);
-        refreshPumparoundReturnEnthalpies();
+        boolean returnPropertiesChanged =
+            densePumparoundJacobian && isPumparoundDrawTray(jj) && k <= C;
+        if (returnPropertiesChanged) {
+          refreshPumparoundReturnEnthalpies();
+        }
 
         if (densePumparoundJacobian) {
           double[] Fpert = computeResidual();
@@ -3190,7 +3204,9 @@ public class NaphtaliSandholmSolver {
 
         setVariable(jj, k, origVal);
         evaluateThermoForTray(jj);
-        refreshPumparoundReturnEnthalpies();
+        if (returnPropertiesChanged) {
+          refreshPumparoundReturnEnthalpies();
+        }
       }
     }
 

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -3059,8 +3059,7 @@ public class NaphtaliSandholmSolver {
       DistillationColumn.ColumnPumparound pumparound = pumparounds.get(circuitIndex);
       if (pumparound.getReturnTrayNumber() == tray) {
         int drawTray = pumparound.getDrawTrayNumber();
-        returnedEnergy +=
-            liquidPumparoundFraction[drawTray] * L[drawTray] * pumparoundReturnEnthalpy[circuitIndex];
+        returnedEnergy += liquidPumparoundFraction[drawTray] * L[drawTray] * pumparoundReturnEnthalpy[circuitIndex];
       }
     }
     return returnedEnergy;

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -763,8 +763,8 @@ public class NaphtaliSandholmSolver {
 
         // A pumparound couples non-adjacent draw and return trays, so its Jacobian is
         // not block tridiagonal. Ordinary columns retain the fast block solve.
-        double[] dx =
-            hasActivePumparounds() ? solveDenseLU(jacobian, residual) : solveBlockTridiagonal(jacobian, residual);
+        double[] dx = hasActivePumparounds() ? solveDenseLU(jacobian, residual)
+            : solveBlockTridiagonal(jacobian, residual);
         if (dx == null) {
           // Fall back to full LU solve for an ordinary column whose block factorization failed.
           dx = hasActivePumparounds() ? null : solveDenseLU(jacobian, residual);
@@ -2994,9 +2994,9 @@ public class NaphtaliSandholmSolver {
    * Refresh return enthalpies from each draw tray's current liquid composition and temperature.
    *
    * <p>
-   * The circuit preserves draw-tray pressure, matching {@link DistillationColumn.ColumnPumparound}
-   * stream materialization. A positive temperature drop therefore represents heat removed by the
-   * pumparound cooler without adding an external material feed.
+   * The circuit preserves draw-tray pressure, matching {@link DistillationColumn.ColumnPumparound} stream
+   * materialization. A positive temperature drop therefore represents heat removed by the pumparound cooler without
+   * adding an external material feed.
    * </p>
    */
   private void refreshPumparoundReturnEnthalpies() {
@@ -3015,8 +3015,8 @@ public class NaphtaliSandholmSolver {
       if (!Double.isFinite(returnTemperature) || returnTemperature <= 0.0) {
         throw new IllegalStateException("Pumparound return temperature must be finite and above 0 K");
       }
-      pumparoundReturnEnthalpy[circuitIndex] =
-          computeSinglePhaseEnthalpy(composition, returnTemperature, P[drawTray] / 1.0e5, false);
+      pumparoundReturnEnthalpy[circuitIndex] = computeSinglePhaseEnthalpy(composition, returnTemperature,
+          P[drawTray] / 1.0e5, false);
     }
   }
 
@@ -3025,8 +3025,7 @@ public class NaphtaliSandholmSolver {
     double returnedFlow = 0.0;
     for (DistillationColumn.ColumnPumparound pumparound : pumparounds) {
       if (pumparound.getReturnTrayNumber() == tray) {
-        returnedFlow +=
-            pumparound.getDrawFraction() * liq[pumparound.getDrawTrayNumber()][component];
+        returnedFlow += pumparound.getDrawFraction() * liq[pumparound.getDrawTrayNumber()][component];
       }
     }
     return returnedFlow;
@@ -4845,15 +4844,15 @@ public class NaphtaliSandholmSolver {
         tray.setCachedLiquidOutStream(new neqsim.process.equipment.stream.Stream("liq_" + j, liqSystem));
 
         if (liquidSideDrawFraction[j] > 0.0) {
-          SystemInterface liquidSideSystem =
-              createAppliedPhaseSystem(j, liq[j], liquidSideDrawFraction[j], PhaseType.LIQUID);
+          SystemInterface liquidSideSystem = createAppliedPhaseSystem(j, liq[j], liquidSideDrawFraction[j],
+              PhaseType.LIQUID);
           tray.setCachedLiquidSideDrawStream(
               new neqsim.process.equipment.stream.Stream("liq_side_" + j, liquidSideSystem));
         }
 
         if (liquidPumparoundFraction[j] > 0.0) {
-          SystemInterface pumparoundDrawSystem =
-              createAppliedPhaseSystem(j, liq[j], liquidPumparoundFraction[j], PhaseType.LIQUID);
+          SystemInterface pumparoundDrawSystem = createAppliedPhaseSystem(j, liq[j], liquidPumparoundFraction[j],
+              PhaseType.LIQUID);
           tray.setCachedLiquidPumparoundDrawStream(
               new neqsim.process.equipment.stream.Stream("liq_pumparound_" + j, pumparoundDrawSystem));
         }

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -548,7 +548,7 @@ public class NaphtaliSandholmSolver {
    */
   private boolean hasActiveSideDraws() {
     for (int j = 0; j < N; j++) {
-      if (internalLiquidFraction[j] < 1.0 || internalVaporFraction[j] < 1.0) {
+      if (liquidSideDrawFraction[j] > 0.0 || internalVaporFraction[j] < 1.0) {
         return true;
       }
     }
@@ -3820,7 +3820,7 @@ public class NaphtaliSandholmSolver {
       if (useOverallQreb) {
         qRebOverall = internalLiquidFraction[0] * L[0] * hL[0] + internalVaporFraction[N - 1] * V[N - 1] * hV[N - 1];
         for (int jj = 0; jj < N; jj++) {
-          qRebOverall += (1.0 - internalLiquidFraction[jj]) * L[jj] * hL[jj];
+          qRebOverall += liquidSideDrawFraction[jj] * L[jj] * hL[jj];
           qRebOverall += (1.0 - internalVaporFraction[jj]) * V[jj] * hV[jj];
           qRebOverall -= feedLTotal[jj] * feedHL[jj];
           qRebOverall -= feedVTotal[jj] * feedHV[jj];
@@ -3953,7 +3953,7 @@ public class NaphtaliSandholmSolver {
         for (int j = 0; j < N; j++) {
           nonBottomProducts += (1.0 - internalVaporFraction[j]) * V[j];
           if (j > 0) {
-            nonBottomProducts += (1.0 - internalLiquidFraction[j]) * L[j];
+            nonBottomProducts += liquidSideDrawFraction[j] * L[j];
           }
         }
         L[0] = Math.max(totalFeedMolesField - nonBottomProducts, totalFeedMolesField * 0.001);

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -135,8 +135,20 @@ public class NaphtaliSandholmSolver {
   /** Fraction of total tray vapor that continues upward after a side draw. */
   private double[] internalVaporFraction;
 
-  /** Fraction of total tray liquid that continues downward after a side draw. */
+  /** Fraction of total tray liquid that continues downward after all local liquid withdrawals. */
   private double[] internalLiquidFraction;
+
+  /** Fraction of total tray liquid withdrawn as an external side product. */
+  private double[] liquidSideDrawFraction;
+
+  /** Fraction of total tray liquid withdrawn into a pumparound circuit. */
+  private double[] liquidPumparoundFraction;
+
+  /** Configured liquid pumparound circuits. */
+  private List<DistillationColumn.ColumnPumparound> pumparounds;
+
+  /** Cooled/heated pumparound return enthalpy in J/mol, indexed by circuit. */
+  private double[] pumparoundReturnEnthalpy;
 
   /** Heat input Q_j in J/hr on the solver flow basis for tray j. */
   private double[] Q;
@@ -595,6 +607,10 @@ public class NaphtaliSandholmSolver {
       if (warmStartFromColumn) {
         logger.info("NS: using converged tray MESH state as a direct Newton warm start");
         bpConverged = true;
+      } else if (hasActivePumparounds()) {
+        logger.info("NS: entering Newton directly because pumparound returns add nonlocal MESH coupling");
+        seedSolutionForDirectNewton();
+        bpConverged = true;
       } else if (useOverallMBClosure) {
         logger.info("NS: bypassing BP/SR (useOverallMBClosure active) — direct Newton");
         seedSolutionForDirectNewton();
@@ -652,7 +668,7 @@ public class NaphtaliSandholmSolver {
         applyResultsToColumn(id, 0, norm, startTime);
         return true;
       }
-      if (!warmStartFromColumn && mbErrorBP < 0.005 && energyErrorBP >= 0.01) {
+      if (!warmStartFromColumn && !hasActivePumparounds() && mbErrorBP < 0.005 && energyErrorBP >= 0.01) {
         // Mass balance OK but energy not — use Sum-Rates method to correct T
         // The BP method determines T from bubble-point (sum Kx = 1), which
         // fails for wide-boiling / absorber columns. SR determines T from
@@ -745,11 +761,13 @@ public class NaphtaliSandholmSolver {
         // Compute Jacobian analytically
         double[][] jacobian = computeJacobian(residual);
 
-        // Solve J * dx = F using block-tridiagonal solver
-        double[] dx = solveBlockTridiagonal(jacobian, residual);
+        // A pumparound couples non-adjacent draw and return trays, so its Jacobian is
+        // not block tridiagonal. Ordinary columns retain the fast block solve.
+        double[] dx =
+            hasActivePumparounds() ? solveDenseLU(jacobian, residual) : solveBlockTridiagonal(jacobian, residual);
         if (dx == null) {
-          // Fall back to full LU solve
-          dx = solveDenseLU(jacobian, residual);
+          // Fall back to full LU solve for an ordinary column whose block factorization failed.
+          dx = hasActivePumparounds() ? null : solveDenseLU(jacobian, residual);
           if (dx == null) {
             logger.error("Naphtali-Sandholm: linear solver failed at iteration {}", iter);
             // Restore best state and try to continue with smaller steps
@@ -961,6 +979,10 @@ public class NaphtaliSandholmSolver {
     feedVTotal = new double[N];
     internalVaporFraction = new double[N];
     internalLiquidFraction = new double[N];
+    liquidSideDrawFraction = new double[N];
+    liquidPumparoundFraction = new double[N];
+    pumparounds = column.getPumparounds();
+    pumparoundReturnEnthalpy = new double[pumparounds.size()];
     Q = new double[N];
     fixedTemperature = new double[N];
     Arrays.fill(fixedTemperature, Double.NaN);
@@ -978,7 +1000,9 @@ public class NaphtaliSandholmSolver {
         P[j] = fallbackPressure;
       }
       internalVaporFraction[j] = 1.0 - tray.getGasSideDrawFraction();
-      internalLiquidFraction[j] = 1.0 - tray.getLiquidSideDrawFraction();
+      liquidSideDrawFraction[j] = tray.getLiquidSideDrawFraction();
+      liquidPumparoundFraction[j] = tray.getLiquidPumparoundDrawFraction();
+      internalLiquidFraction[j] = 1.0 - liquidSideDrawFraction[j] - liquidPumparoundFraction[j];
     }
 
     // Process every external feed in the same deterministic tray/stream order used
@@ -1490,6 +1514,7 @@ public class NaphtaliSandholmSolver {
     for (int j = 0; j < N; j++) {
       evaluateThermoForTray(j);
     }
+    refreshPumparoundReturnEnthalpies();
   }
 
   /**
@@ -1841,7 +1866,7 @@ public class NaphtaliSandholmSolver {
       double out = internalVaporFraction[N - 1] * vap[N - 1][i] + internalLiquidFraction[0] * liq[0][i];
       for (int j = 0; j < N; j++) {
         out += (1.0 - internalVaporFraction[j]) * vap[j][i];
-        out += (1.0 - internalLiquidFraction[j]) * liq[j][i];
+        out += liquidSideDrawFraction[j] * liq[j][i];
       }
       double err = Math.abs(out - Fi[i]) / Math.max(Fi[i], 1e-20);
       if (err > maxCompMBerr) {
@@ -2799,6 +2824,7 @@ public class NaphtaliSandholmSolver {
       if (j < N - 1) {
         hIn += Math.abs(internalLiquidFraction[j + 1] * L[j + 1] * hL[j + 1]);
       }
+      hIn += Math.abs(getPumparoundEnergyReturn(j));
       double scale = Math.max(hOut, hIn);
       if (scale > 1e-10) {
         double relErr = Math.abs(eErr[j]) / scale;
@@ -2837,6 +2863,7 @@ public class NaphtaliSandholmSolver {
       if (feedMolesJ > 1e-10) {
         hIn += feedLTotal[j] * feedHL[j] + feedVTotal[j] * feedHV[j];
       }
+      hIn += getPumparoundEnergyReturn(j);
       eErr[j] = hOut - hIn;
     }
     return eErr;
@@ -2958,6 +2985,66 @@ public class NaphtaliSandholmSolver {
     return sum;
   }
 
+  /** Return whether at least one liquid pumparound is active. */
+  private boolean hasActivePumparounds() {
+    return pumparounds != null && !pumparounds.isEmpty();
+  }
+
+  /**
+   * Refresh return enthalpies from each draw tray's current liquid composition and temperature.
+   *
+   * <p>
+   * The circuit preserves draw-tray pressure, matching {@link DistillationColumn.ColumnPumparound}
+   * stream materialization. A positive temperature drop therefore represents heat removed by the
+   * pumparound cooler without adding an external material feed.
+   * </p>
+   */
+  private void refreshPumparoundReturnEnthalpies() {
+    if (!hasActivePumparounds()) {
+      return;
+    }
+    for (int circuitIndex = 0; circuitIndex < pumparounds.size(); circuitIndex++) {
+      DistillationColumn.ColumnPumparound pumparound = pumparounds.get(circuitIndex);
+      int drawTray = pumparound.getDrawTrayNumber();
+      double drawLiquid = Math.max(L[drawTray], 1.0e-20);
+      double[] composition = new double[C];
+      for (int i = 0; i < C; i++) {
+        composition[i] = liq[drawTray][i] / drawLiquid;
+      }
+      double returnTemperature = T[drawTray] - pumparound.getTemperatureDrop();
+      if (!Double.isFinite(returnTemperature) || returnTemperature <= 0.0) {
+        throw new IllegalStateException("Pumparound return temperature must be finite and above 0 K");
+      }
+      pumparoundReturnEnthalpy[circuitIndex] =
+          computeSinglePhaseEnthalpy(composition, returnTemperature, P[drawTray] / 1.0e5, false);
+    }
+  }
+
+  /** Get the component flow returned by all pumparounds entering one tray, in mol/hr. */
+  private double getPumparoundComponentReturn(int tray, int component) {
+    double returnedFlow = 0.0;
+    for (DistillationColumn.ColumnPumparound pumparound : pumparounds) {
+      if (pumparound.getReturnTrayNumber() == tray) {
+        returnedFlow +=
+            pumparound.getDrawFraction() * liq[pumparound.getDrawTrayNumber()][component];
+      }
+    }
+    return returnedFlow;
+  }
+
+  /** Get the enthalpy rate returned by all pumparounds entering one tray, in J/hr. */
+  private double getPumparoundEnergyReturn(int tray) {
+    double returnedEnergy = 0.0;
+    for (int circuitIndex = 0; circuitIndex < pumparounds.size(); circuitIndex++) {
+      DistillationColumn.ColumnPumparound pumparound = pumparounds.get(circuitIndex);
+      if (pumparound.getReturnTrayNumber() == tray) {
+        int drawTray = pumparound.getDrawTrayNumber();
+        returnedEnergy += pumparound.getDrawFraction() * L[drawTray] * pumparoundReturnEnthalpy[circuitIndex];
+      }
+    }
+    return returnedEnergy;
+  }
+
   /**
    * Compute the MESH residual vector.
    *
@@ -3008,8 +3095,9 @@ public class NaphtaliSandholmSolver {
           Mij -= internalVaporFraction[j - 1] * vap[j - 1][i];
         }
 
-        // Feed
+        // External feed and internal pumparound return
         Mij -= feedLiq[j][i] + feedVap[j][i];
+        Mij -= getPumparoundComponentReturn(j, i);
 
         F[base + i] = Mij / flowScale;
       }
@@ -3028,8 +3116,9 @@ public class NaphtaliSandholmSolver {
           Hj -= internalVaporFraction[j - 1] * V[j - 1] * hV[j - 1];
         }
 
-        // Feed enthalpies
+        // External-feed and internal pumparound-return enthalpies
         Hj -= feedLTotal[j] * feedHL[j] + feedVTotal[j] * feedHV[j];
+        Hj -= getPumparoundEnergyReturn(j);
 
         // Heat duty
         Hj -= Q[j];
@@ -3072,35 +3161,37 @@ public class NaphtaliSandholmSolver {
     double[][] J = new double[totalVars][totalVars];
     double pertSize = 1e-4;
     double minPert = 1e-8;
+    boolean densePumparoundJacobian = hasActivePumparounds();
 
     for (int jj = 0; jj < N; jj++) {
       for (int k = 0; k < varsPerTray; k++) {
         int varIdx = jj * varsPerTray + k;
-
-        // Save original value
         double origVal = getVariable(jj, k);
         double h = Math.max(Math.abs(origVal) * pertSize, minPert);
-
-        // Perturb
         setVariable(jj, k, origVal + h);
-
-        // Re-evaluate thermo ONLY for the tray whose variable changed
         evaluateThermoForTray(jj);
+        refreshPumparoundReturnEnthalpies();
 
-        // Compute perturbed residuals for affected trays (j-1, j, j+1)
-        int jStart = Math.max(0, jj - 1);
-        int jEnd = Math.min(N - 1, jj + 1);
-        for (int j = jStart; j <= jEnd; j++) {
-          double[] Fpert = computeResidualForTray(j);
-          int rowBase = j * varsPerTray;
-          for (int eq = 0; eq < varsPerTray; eq++) {
-            J[rowBase + eq][varIdx] = (Fpert[eq] - F0[rowBase + eq]) / h;
+        if (densePumparoundJacobian) {
+          double[] Fpert = computeResidual();
+          for (int row = 0; row < totalVars; row++) {
+            J[row][varIdx] = (Fpert[row] - F0[row]) / h;
+          }
+        } else {
+          int jStart = Math.max(0, jj - 1);
+          int jEnd = Math.min(N - 1, jj + 1);
+          for (int j = jStart; j <= jEnd; j++) {
+            double[] Fpert = computeResidualForTray(j);
+            int rowBase = j * varsPerTray;
+            for (int eq = 0; eq < varsPerTray; eq++) {
+              J[rowBase + eq][varIdx] = (Fpert[eq] - F0[rowBase + eq]) / h;
+            }
           }
         }
 
-        // Restore
         setVariable(jj, k, origVal);
         evaluateThermoForTray(jj);
+        refreshPumparoundReturnEnthalpies();
       }
     }
 
@@ -3132,6 +3223,7 @@ public class NaphtaliSandholmSolver {
         Mij -= internalVaporFraction[j - 1] * vap[j - 1][i];
       }
       Mij -= feedLiq[j][i] + feedVap[j][i];
+      Mij -= getPumparoundComponentReturn(j, i);
 
       Fj[i] = Mij / flowScale;
     }
@@ -3148,6 +3240,7 @@ public class NaphtaliSandholmSolver {
         Hj -= internalVaporFraction[j - 1] * V[j - 1] * hV[j - 1];
       }
       Hj -= feedLTotal[j] * feedHL[j] + feedVTotal[j] * feedHV[j];
+      Hj -= getPumparoundEnergyReturn(j);
       Hj -= Q[j];
 
       double trayFlow = Math.max(Lj + V[j], flowScale);
@@ -3362,6 +3455,11 @@ public class NaphtaliSandholmSolver {
    * </p>
    */
   private void runBostonSullivanRefinement() {
+    // The classic block-tridiagonal refinement cannot represent a nonlocal
+    // draw-to-return circuit. The full Newton residual below owns that coupling.
+    if (hasActivePumparounds()) {
+      return;
+    }
     if (!enableBostonSullivan) {
       return;
     }
@@ -4082,7 +4180,7 @@ public class NaphtaliSandholmSolver {
     double productFlow = internalVaporFraction[N - 1] * V[N - 1] + internalLiquidFraction[0] * L[0];
     for (int j = 0; j < N; j++) {
       productFlow += (1.0 - internalVaporFraction[j]) * V[j];
-      productFlow += (1.0 - internalLiquidFraction[j]) * L[j];
+      productFlow += liquidSideDrawFraction[j] * L[j];
     }
     return Math.abs(productFlow - totalFeedFlow) / Math.max(totalFeedFlow, 1e-20);
   }
@@ -4119,6 +4217,7 @@ public class NaphtaliSandholmSolver {
           mij -= internalVaporFraction[j - 1] * vap[j - 1][i];
         }
         mij -= feedLiq[j][i] + feedVap[j][i];
+        mij -= getPumparoundComponentReturn(j, i);
         double rel = Math.abs(mij) / denom;
         if (rel > worst) {
           worst = rel;
@@ -4659,10 +4758,10 @@ public class NaphtaliSandholmSolver {
    * @param startTime start time in nanoseconds
    */
   private void applyResultsToColumn(UUID id, int iterations, double finalNorm, long startTime) {
-    boolean hasActiveSideDraw = false;
+    boolean hasActivePhaseSplit = false;
     for (int j = 0; j < N; j++) {
       if (internalVaporFraction[j] < 1.0 || internalLiquidFraction[j] < 1.0) {
-        hasActiveSideDraw = true;
+        hasActivePhaseSplit = true;
         break;
       }
     }
@@ -4729,7 +4828,7 @@ public class NaphtaliSandholmSolver {
       // Build gas and liquid output streams from the flashed tray system
       tray.invalidateOutStreamCache();
 
-      if (hasActiveSideDraw) {
+      if (hasActivePhaseSplit) {
         // Materialize each split from the solver's component flow vector. Setting
         // composition and total flow separately allows normalization and phase
         // reinitialization to drift from the accepted species inventory.
@@ -4745,11 +4844,18 @@ public class NaphtaliSandholmSolver {
         SystemInterface liqSystem = createAppliedPhaseSystem(j, liq[j], internalLiquidFraction[j], PhaseType.LIQUID);
         tray.setCachedLiquidOutStream(new neqsim.process.equipment.stream.Stream("liq_" + j, liqSystem));
 
-        if (internalLiquidFraction[j] < 1.0) {
-          SystemInterface liquidSideSystem = createAppliedPhaseSystem(j, liq[j], 1.0 - internalLiquidFraction[j],
-              PhaseType.LIQUID);
+        if (liquidSideDrawFraction[j] > 0.0) {
+          SystemInterface liquidSideSystem =
+              createAppliedPhaseSystem(j, liq[j], liquidSideDrawFraction[j], PhaseType.LIQUID);
           tray.setCachedLiquidSideDrawStream(
               new neqsim.process.equipment.stream.Stream("liq_side_" + j, liquidSideSystem));
+        }
+
+        if (liquidPumparoundFraction[j] > 0.0) {
+          SystemInterface pumparoundDrawSystem =
+              createAppliedPhaseSystem(j, liq[j], liquidPumparoundFraction[j], PhaseType.LIQUID);
+          tray.setCachedLiquidPumparoundDrawStream(
+              new neqsim.process.equipment.stream.Stream("liq_pumparound_" + j, pumparoundDrawSystem));
         }
       } else {
         SystemInterface gasSystem = referenceSystem.clone();
@@ -4786,7 +4892,7 @@ public class NaphtaliSandholmSolver {
     double productFlow = topFlow + botFlow;
     for (int j = 0; j < N; j++) {
       productFlow += (1.0 - internalVaporFraction[j]) * V[j];
-      productFlow += (1.0 - internalLiquidFraction[j]) * L[j];
+      productFlow += liquidSideDrawFraction[j] * L[j];
     }
     double massBalErr = Math.abs(productFlow - totalFeedFlow) / Math.max(totalFeedFlow, 1e-20);
 

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -3179,8 +3179,7 @@ public class NaphtaliSandholmSolver {
         double h = Math.max(Math.abs(origVal) * pertSize, minPert);
         setVariable(jj, k, origVal + h);
         evaluateThermoForTray(jj);
-        boolean returnPropertiesChanged =
-            densePumparoundJacobian && isPumparoundDrawTray(jj) && k <= C;
+        boolean returnPropertiesChanged = densePumparoundJacobian && isPumparoundDrawTray(jj) && k <= C;
         if (returnPropertiesChanged) {
           refreshPumparoundReturnEnthalpies();
         }

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -758,7 +758,7 @@ public class NaphtaliSandholmSolver {
           return true;
         }
 
-        // Compute Jacobian analytically
+        // Compute the finite-difference Jacobian
         double[][] jacobian = computeJacobian(residual);
 
         // A pumparound couples non-adjacent draw and return trays, so its Jacobian is
@@ -1629,8 +1629,9 @@ public class NaphtaliSandholmSolver {
    * Seed a mass-balanced initial guess for direct Newton entry.
    *
    * <p>
-   * Used when {@code useOverallMBClosure} is active (T-spec'd reboiler with no boilup specification). Bypasses the
-   * BP-Wilson V-cascade — which is unstable for wide-boiling stripper topologies — and replaces it with a sweep that:
+   * Used when {@code useOverallMBClosure} is active (T-spec'd reboiler with no boilup specification), and when
+   * nonlocal pumparound returns require direct Newton entry. Bypasses the BP-Wilson V-cascade — which is unstable for
+   * wide-boiling stripper topologies — and replaces it with a sweep that:
    * </p>
    * <ol>
    * <li>Anchors V[N-1] (top vapor leaving column) to total feed minus a sensible bottoms estimate, so the overall MB

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -3165,8 +3165,8 @@ public class NaphtaliSandholmSolver {
    * Compute the Jacobian matrix numerically using finite differences.
    *
    * <p>
-   * Ordinary columns retain the block-tridiagonal structure: for a variable on tray jj, only residuals on trays
-   * jj-1, jj, and jj+1 are differentiated. An active pumparound can connect non-adjacent trays, so that opt-in path
+   * Ordinary columns retain the block-tridiagonal structure: for a variable on tray jj, only residuals on trays jj-1,
+   * jj, and jj+1 are differentiated. An active pumparound can connect non-adjacent trays, so that opt-in path
    * differentiates every residual row and is solved as a dense system. Only tray jj thermodynamics are re-evaluated;
    * pumparound return enthalpy is refreshed when jj supplies a changed draw composition or temperature.
    * </p>

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -1584,11 +1584,9 @@ public class NaphtaliSandholmSolver {
           for (int i = 0; i < C; i++) {
             double feedComponent = feedLiq[j][i] + feedVap[j][i];
             double vaporFromBelow = j > 0 ? internalVaporFraction[j - 1] * previousVapor[i] : 0.0;
-            double pumparoundReturn = activePumparound
-                ? getSeedPumparoundComponentReturn(j, i, previousLiquid)
-                : 0.0;
-            double requiredLiquidFromAbove = seedVapor[j][i] + seedLiquid[j][i] - vaporFromBelow
-                - feedComponent - pumparoundReturn;
+            double pumparoundReturn = activePumparound ? getSeedPumparoundComponentReturn(j, i, previousLiquid) : 0.0;
+            double requiredLiquidFromAbove = seedVapor[j][i] + seedLiquid[j][i] - vaporFromBelow - feedComponent
+                - pumparoundReturn;
             double nextLiquid = requiredLiquidFromAbove / Math.max(internalLiquidFraction[j + 1], 1.0e-12);
             seedLiquid[j + 1][i] = Math.max(nextLiquid, 1.0e-15);
           }
@@ -1601,11 +1599,9 @@ public class NaphtaliSandholmSolver {
         seedVapor[N - 1][i] = overheadComponent[i];
         double feedComponent = feedLiq[N - 1][i] + feedVap[N - 1][i];
         double vaporFromBelow = N >= 2 ? internalVaporFraction[N - 2] * seedVapor[N - 2][i] : 0.0;
-        double pumparoundReturn = activePumparound
-            ? getSeedPumparoundComponentReturn(N - 1, i, previousLiquid)
-            : 0.0;
-        seedLiquid[N - 1][i] = Math.max(
-            vaporFromBelow + feedComponent + pumparoundReturn - seedVapor[N - 1][i], 1.0e-15);
+        double pumparoundReturn = activePumparound ? getSeedPumparoundComponentReturn(N - 1, i, previousLiquid) : 0.0;
+        seedLiquid[N - 1][i] = Math.max(vaporFromBelow + feedComponent + pumparoundReturn - seedVapor[N - 1][i],
+            1.0e-15);
       }
 
       if (!activePumparound) {
@@ -1615,8 +1611,7 @@ public class NaphtaliSandholmSolver {
       for (int j = 0; j < N; j++) {
         for (int i = 0; i < C; i++) {
           double scale = Math.max(Math.abs(seedLiquid[j][i]), 1.0e-12 * flowScale);
-          maxRelativeChange = Math.max(maxRelativeChange,
-              Math.abs(seedLiquid[j][i] - previousLiquid[j][i]) / scale);
+          maxRelativeChange = Math.max(maxRelativeChange, Math.abs(seedLiquid[j][i] - previousLiquid[j][i]) / scale);
         }
       }
       if (maxRelativeChange < 1.0e-8) {
@@ -1629,8 +1624,8 @@ public class NaphtaliSandholmSolver {
    * Seed a mass-balanced initial guess for direct Newton entry.
    *
    * <p>
-   * Used when {@code useOverallMBClosure} is active (T-spec'd reboiler with no boilup specification), and when
-   * nonlocal pumparound returns require direct Newton entry. Bypasses the BP-Wilson V-cascade — which is unstable for
+   * Used when {@code useOverallMBClosure} is active (T-spec'd reboiler with no boilup specification), and when nonlocal
+   * pumparound returns require direct Newton entry. Bypasses the BP-Wilson V-cascade — which is unstable for
    * wide-boiling stripper topologies — and replaces it with a sweep that:
    * </p>
    * <ol>
@@ -1756,14 +1751,11 @@ public class NaphtaliSandholmSolver {
         for (int j = 0; j < N - 1; j++) {
           double vaporFromBelow = j > 0 ? internalVaporFraction[j - 1] * V[j - 1] : 0.0;
           double pumparoundReturn = getSeedPumparoundTotalReturn(j, previousLiquidTotals);
-          double requiredLiquidFromAbove = V[j] + L[j] - vaporFromBelow - feedTotalPerTray[j]
-              - pumparoundReturn;
-          L[j + 1] = Math.max(
-              requiredLiquidFromAbove / Math.max(internalLiquidFraction[j + 1], 1.0e-12),
+          double requiredLiquidFromAbove = V[j] + L[j] - vaporFromBelow - feedTotalPerTray[j] - pumparoundReturn;
+          L[j + 1] = Math.max(requiredLiquidFromAbove / Math.max(internalLiquidFraction[j + 1], 1.0e-12),
               1.0e-6 * totalFeed);
           double scale = Math.max(Math.abs(L[j + 1]), 1.0e-12 * totalFeed);
-          maxRelativeChange = Math.max(maxRelativeChange,
-              Math.abs(L[j + 1] - previousLiquidTotals[j + 1]) / scale);
+          maxRelativeChange = Math.max(maxRelativeChange, Math.abs(L[j + 1] - previousLiquidTotals[j + 1]) / scale);
         }
         if (maxRelativeChange < 1.0e-8) {
           break;

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -1517,6 +1517,114 @@ public class NaphtaliSandholmSolver {
     refreshPumparoundReturnEnthalpies();
   }
 
+  /** Get a lagged total pumparound return for a direct-Newton seed sweep, in mol/hr. */
+  private double getSeedPumparoundTotalReturn(int tray, double[] seedLiquidTotals) {
+    double returnedFlow = 0.0;
+    for (DistillationColumn.ColumnPumparound pumparound : pumparounds) {
+      if (pumparound.getReturnTrayNumber() == tray) {
+        int drawTray = pumparound.getDrawTrayNumber();
+        returnedFlow += liquidPumparoundFraction[drawTray] * seedLiquidTotals[drawTray];
+      }
+    }
+    return returnedFlow;
+  }
+
+  /** Get a lagged component pumparound return for a direct-Newton seed sweep, in mol/hr. */
+  private double getSeedPumparoundComponentReturn(int tray, int component, double[][] seedLiquid) {
+    double returnedFlow = 0.0;
+    for (DistillationColumn.ColumnPumparound pumparound : pumparounds) {
+      if (pumparound.getReturnTrayNumber() == tray) {
+        int drawTray = pumparound.getDrawTrayNumber();
+        returnedFlow += liquidPumparoundFraction[drawTray] * seedLiquid[drawTray][component];
+      }
+    }
+    return returnedFlow;
+  }
+
+  /**
+   * Forward-shoot component flows for the direct-Newton seed.
+   *
+   * <p>
+   * Pumparound returns are nonlocal: a return tray can be visited before its draw tray in the forward sweep. A bounded
+   * fixed-point iteration therefore lags the draw inventory by one sweep. This only constructs the initial guess; the
+   * subsequent Newton solve still enforces the fully simultaneous return terms.
+   * </p>
+   *
+   * @param seedLiquid liquid component-flow seed by tray, in mol/hr
+   * @param seedVapor vapor component-flow seed by tray, in mol/hr
+   * @param seedK Wilson K-value seed by tray
+   * @param bottomsComponent component bottoms-flow anchors, in mol/hr
+   * @param overheadComponent component overhead-flow anchors, in mol/hr
+   */
+  private void shootDirectNewtonSeedComponentFlows(double[][] seedLiquid, double[][] seedVapor, double[][] seedK,
+      double[] bottomsComponent, double[] overheadComponent) {
+    boolean activePumparound = hasActivePumparounds();
+    int maxSeedSweeps = activePumparound ? 12 : 1;
+    double[][] previousLiquid = new double[N][C];
+
+    for (int sweep = 0; sweep < maxSeedSweeps; sweep++) {
+      for (int j = 0; j < N; j++) {
+        System.arraycopy(seedLiquid[j], 0, previousLiquid[j], 0, C);
+      }
+      System.arraycopy(bottomsComponent, 0, seedLiquid[0], 0, C);
+      double[] previousVapor = new double[C];
+
+      for (int j = 0; j < N; j++) {
+        double sumKx = 0.0;
+        for (int i = 0; i < C; i++) {
+          sumKx += seedK[j][i] * seedLiquid[j][i] / Math.max(L[j], 1.0e-20);
+        }
+        double normalization = Math.max(sumKx, 1.0e-20);
+        for (int i = 0; i < C; i++) {
+          double yi = (seedK[j][i] * seedLiquid[j][i] / Math.max(L[j], 1.0e-20)) / normalization;
+          seedVapor[j][i] = yi * V[j];
+        }
+
+        if (j < N - 1) {
+          for (int i = 0; i < C; i++) {
+            double feedComponent = feedLiq[j][i] + feedVap[j][i];
+            double vaporFromBelow = j > 0 ? internalVaporFraction[j - 1] * previousVapor[i] : 0.0;
+            double pumparoundReturn = activePumparound
+                ? getSeedPumparoundComponentReturn(j, i, previousLiquid)
+                : 0.0;
+            double requiredLiquidFromAbove = seedVapor[j][i] + seedLiquid[j][i] - vaporFromBelow
+                - feedComponent - pumparoundReturn;
+            double nextLiquid = requiredLiquidFromAbove / Math.max(internalLiquidFraction[j + 1], 1.0e-12);
+            seedLiquid[j + 1][i] = Math.max(nextLiquid, 1.0e-15);
+          }
+          System.arraycopy(seedVapor[j], 0, previousVapor, 0, C);
+        }
+      }
+
+      // Preserve the estimated overhead split while satisfying the top-tray component balance.
+      for (int i = 0; i < C; i++) {
+        seedVapor[N - 1][i] = overheadComponent[i];
+        double feedComponent = feedLiq[N - 1][i] + feedVap[N - 1][i];
+        double vaporFromBelow = N >= 2 ? internalVaporFraction[N - 2] * seedVapor[N - 2][i] : 0.0;
+        double pumparoundReturn = activePumparound
+            ? getSeedPumparoundComponentReturn(N - 1, i, previousLiquid)
+            : 0.0;
+        seedLiquid[N - 1][i] = Math.max(
+            vaporFromBelow + feedComponent + pumparoundReturn - seedVapor[N - 1][i], 1.0e-15);
+      }
+
+      if (!activePumparound) {
+        break;
+      }
+      double maxRelativeChange = 0.0;
+      for (int j = 0; j < N; j++) {
+        for (int i = 0; i < C; i++) {
+          double scale = Math.max(Math.abs(seedLiquid[j][i]), 1.0e-12 * flowScale);
+          maxRelativeChange = Math.max(maxRelativeChange,
+              Math.abs(seedLiquid[j][i] - previousLiquid[j][i]) / scale);
+        }
+      }
+      if (maxRelativeChange < 1.0e-8) {
+        break;
+      }
+    }
+  }
+
   /**
    * Seed a mass-balanced initial guess for direct Newton entry.
    *
@@ -1637,6 +1745,31 @@ public class NaphtaliSandholmSolver {
       L[j + 1] = Math.max(L[j + 1], 1e-6 * totalFeed);
     }
 
+    // Reconcile the nonlocal pumparound return into the seed traffic. The return is lagged by
+    // one sweep because its draw tray may occur later in this bottom-up traversal.
+    if (hasActivePumparounds()) {
+      for (int sweep = 0; sweep < 12; sweep++) {
+        double[] previousLiquidTotals = L.clone();
+        L[0] = bottomsTotal;
+        double maxRelativeChange = 0.0;
+        for (int j = 0; j < N - 1; j++) {
+          double vaporFromBelow = j > 0 ? internalVaporFraction[j - 1] * V[j - 1] : 0.0;
+          double pumparoundReturn = getSeedPumparoundTotalReturn(j, previousLiquidTotals);
+          double requiredLiquidFromAbove = V[j] + L[j] - vaporFromBelow - feedTotalPerTray[j]
+              - pumparoundReturn;
+          L[j + 1] = Math.max(
+              requiredLiquidFromAbove / Math.max(internalLiquidFraction[j + 1], 1.0e-12),
+              1.0e-6 * totalFeed);
+          double scale = Math.max(Math.abs(L[j + 1]), 1.0e-12 * totalFeed);
+          maxRelativeChange = Math.max(maxRelativeChange,
+              Math.abs(L[j + 1] - previousLiquidTotals[j + 1]) / scale);
+        }
+        if (maxRelativeChange < 1.0e-8) {
+          break;
+        }
+      }
+    }
+
     // ----- 5. Per-component flows via forward shooting from reboiler -----
     // Boundary at j=0: L_i[0] = bottoms_i.
     // At each tray j, vapor leaving uses Wilson-K equilibrium with x[j]:
@@ -1644,7 +1777,6 @@ public class NaphtaliSandholmSolver {
     // Then component MB to advance: L_i[j+1] = V_i[j] + L_i[j] - V_i[j-1] - F_i[j]
     double[][] Liloc = new double[N][C];
     double[][] Viloc = new double[N][C];
-    double[] VimPrev = new double[C]; // V_i[-1] = 0
     for (int i = 0; i < C; i++) {
       Liloc[0][i] = bottoms_i[i];
     }
@@ -1660,49 +1792,7 @@ public class NaphtaliSandholmSolver {
       }
     }
 
-    for (int j = 0; j < N; j++) {
-      // y_i ∝ K_ij × x_i[j]; renormalize to sum=1; then V_i[j] = y_i × V[j].
-      double sumKx = 0;
-      for (int i = 0; i < C; i++) {
-        sumKx += Kseed[j][i] * Liloc[j][i] / Math.max(L[j], 1e-20);
-      }
-      double norm = Math.max(sumKx, 1e-20);
-      for (int i = 0; i < C; i++) {
-        double yi = (Kseed[j][i] * Liloc[j][i] / Math.max(L[j], 1e-20)) / norm;
-        Viloc[j][i] = yi * V[j];
-      }
-
-      if (j < N - 1) {
-        // Component MB on tray j (steady state): V_i[j-1] + L_i[j+1] + F_i[j] = V_i[j]
-        // + L_i[j]
-        for (int i = 0; i < C; i++) {
-          double Fij = feedLiq[j][i] + feedVap[j][i];
-          double vaporFromBelow = j > 0 ? internalVaporFraction[j - 1] * VimPrev[i] : 0.0;
-          double liquidToTrayBelow = Viloc[j][i] + Liloc[j][i] - vaporFromBelow - Fij;
-          double Lnext = liquidToTrayBelow / Math.max(internalLiquidFraction[j + 1], 1e-12);
-          Liloc[j + 1][i] = Math.max(Lnext, 1e-15);
-        }
-        System.arraycopy(Viloc[j], 0, VimPrev, 0, C);
-      }
-    }
-
-    // ----- 6. Enforce overhead boundary condition: V_i[N-1] = overhead_i -----
-    // The shoot generally over/undershoots the per-component overhead because
-    // the seed K-values are not at equilibrium. Project the top vapor onto
-    // the Kremser-derived split (it is what we want to honour for component
-    // MB at the column outlet).
-    for (int i = 0; i < C; i++) {
-      Viloc[N - 1][i] = overhead_i[i];
-    }
-    // Recompute L_i[N-1] from top-tray MB so per-tray MB still holds at top:
-    // V_i[N-2] + L_i[N] (=0) + F_i[N-1] = V_i[N-1] + L_i[N-1]
-    // ⇒ L_i[N-1] = V_i[N-2] + F_i[N-1] - V_i[N-1]
-    for (int i = 0; i < C; i++) {
-      double Fij = feedLiq[N - 1][i] + feedVap[N - 1][i];
-      double VimN2 = (N >= 2) ? Viloc[N - 2][i] : 0.0;
-      double Lnew = internalVaporFraction[N - 2] * VimN2 + Fij - Viloc[N - 1][i];
-      Liloc[N - 1][i] = Math.max(Lnew, 1e-15);
-    }
+    shootDirectNewtonSeedComponentFlows(Liloc, Viloc, Kseed, bottoms_i, overhead_i);
 
     // ----- 6.5. Iterative tray-by-tray bubble-point T refinement -----
     // The default T-seed is a linear ramp between reboiler and top, which
@@ -1778,39 +1868,8 @@ public class NaphtaliSandholmSolver {
         }
       }
 
-      // Re-shoot per-component flows with updated K-values.
-      for (int i = 0; i < C; i++) {
-        VimPrev[i] = 0.0;
-      }
-      for (int j = 0; j < N; j++) {
-        double sumKxJ = 0;
-        for (int i = 0; i < C; i++) {
-          sumKxJ += Kseed[j][i] * Liloc[j][i] / Math.max(L[j], 1e-20);
-        }
-        double normJ = Math.max(sumKxJ, 1e-20);
-        for (int i = 0; i < C; i++) {
-          double yi = (Kseed[j][i] * Liloc[j][i] / Math.max(L[j], 1e-20)) / normJ;
-          Viloc[j][i] = yi * V[j];
-        }
-        if (j < N - 1) {
-          for (int i = 0; i < C; i++) {
-            double Fij = feedLiq[j][i] + feedVap[j][i];
-            double vaporFromBelow = j > 0 ? internalVaporFraction[j - 1] * VimPrev[i] : 0.0;
-            double liquidToTrayBelow = Viloc[j][i] + Liloc[j][i] - vaporFromBelow - Fij;
-            double Lnext = liquidToTrayBelow / Math.max(internalLiquidFraction[j + 1], 1e-12);
-            Liloc[j + 1][i] = Math.max(Lnext, 1e-15);
-          }
-          System.arraycopy(Viloc[j], 0, VimPrev, 0, C);
-        }
-      }
-      // Re-enforce overhead boundary.
-      for (int i = 0; i < C; i++) {
-        Viloc[N - 1][i] = overhead_i[i];
-        double Fij = feedLiq[N - 1][i] + feedVap[N - 1][i];
-        double VimN2 = (N >= 2) ? Viloc[N - 2][i] : 0.0;
-        double Lnew = internalVaporFraction[N - 2] * VimN2 + Fij - Viloc[N - 1][i];
-        Liloc[N - 1][i] = Math.max(Lnew, 1e-15);
-      }
+      // Re-shoot per-component flows with updated K-values and the lagged nonlocal return seed.
+      shootDirectNewtonSeedComponentFlows(Liloc, Viloc, Kseed, bottoms_i, overhead_i);
       // Refresh L[j] totals from new component flows (V[j] is held; it carries
       // the boilup / overhead anchor).
       for (int j = 0; j < N; j++) {

--- a/src/main/java/neqsim/process/equipment/distillation/SimpleTray.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SimpleTray.java
@@ -375,6 +375,16 @@ public class SimpleTray extends neqsim.process.equipment.mixer.Mixer implements 
   }
 
   /**
+   * Set a pre-built liquid pumparound draw stream to be returned by
+   * {@link #getLiquidPumparoundDrawStream()}.
+   *
+   * @param stream liquid pumparound draw stream
+   */
+  void setCachedLiquidPumparoundDrawStream(StreamInterface stream) {
+    this.cachedLiquidPumparoundDrawStream = stream;
+  }
+
+  /**
    * getGasOutStream.
    *
    * @return a {@link neqsim.process.equipment.stream.Stream} object

--- a/src/main/java/neqsim/process/equipment/distillation/SimpleTray.java
+++ b/src/main/java/neqsim/process/equipment/distillation/SimpleTray.java
@@ -375,8 +375,7 @@ public class SimpleTray extends neqsim.process.equipment.mixer.Mixer implements 
   }
 
   /**
-   * Set a pre-built liquid pumparound draw stream to be returned by
-   * {@link #getLiquidPumparoundDrawStream()}.
+   * Set a pre-built liquid pumparound draw stream to be returned by {@link #getLiquidPumparoundDrawStream()}.
    *
    * @param stream liquid pumparound draw stream
    */

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -312,35 +312,73 @@ public class ColumnStudyRegressionTest {
   }
 
   /**
-   * Verify that a configured pumparound uses the coordinated residual-monitored fallback.
+   * Verify that a liquid pumparound participates directly in the simultaneous material and energy balances.
    *
    * <p>
-   * Pumparound returns are outer tear streams and are not yet feed terms in the Naphtali-Sandholm equation system.
-   * Routing this configuration through MESH_RESIDUAL prevents the simultaneous solver from applying a liquid split that
-   * omits the return stream.
+   * The draw is an internal recycle rather than a product: the configured fraction must leave the draw tray, return
+   * with the same component inventory at the specified lower temperature, and disappear from the external column
+   * balance. Two nearby draw fractions guard against a coincidental result at one operating point.
    * </p>
    */
   @Test
-  public void naphtaliSandholmDefersPumparoundToCoupledFallback() {
-    SystemInterface baseFluid = createBaseFluid();
-    StreamInterface feedStream = createStream("pumparound_main_feed", baseFluid, MAIN_FEED_COMPOSITION,
-        MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
-    StreamInterface topFeedStream = createStream("pumparound_top_feed", baseFluid, TOP_FEED_COMPOSITION,
-        TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA, TOP_FEED_MASS_FLOW_KG_HR);
-    DistillationColumn column = createColumn(feedStream, topFeedStream);
-    column.addLiquidPumparound("column-study pumparound", answerTrayToNeqSimStage(7), answerTrayToNeqSimStage(5), 0.03,
-        5.0);
+  public void naphtaliSandholmPumparoundParticipatesInMeshBalances() {
+    double[] drawFractions = { 0.03, 0.05 };
+    double previousDrawFlow = 0.0;
+    for (int caseIndex = 0; caseIndex < drawFractions.length; caseIndex++) {
+      double drawFraction = drawFractions[caseIndex];
+      SystemInterface baseFluid = createBaseFluid();
+      StreamInterface feedStream = createStream("pumparound_main_feed_" + caseIndex, baseFluid,
+          MAIN_FEED_COMPOSITION, MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
+      StreamInterface topFeedStream = createStream("pumparound_top_feed_" + caseIndex, baseFluid,
+          TOP_FEED_COMPOSITION, TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA, TOP_FEED_MASS_FLOW_KG_HR);
+      DistillationColumn column = createColumn(feedStream, topFeedStream);
+      int drawTrayNumber = answerTrayToNeqSimStage(7);
+      DistillationColumn.ColumnPumparound pumparound = column.addLiquidPumparound(
+          "column-study pumparound " + caseIndex, drawTrayNumber, answerTrayToNeqSimStage(5), drawFraction, 5.0);
 
-    column.run();
+      column.run();
 
-    assertEquals(DistillationColumn.SolverType.MESH_RESIDUAL, column.getLastSolverTypeUsed(),
-        "an active pumparound should avoid the incomplete simultaneous return-stream formulation");
-    assertTrue(column.solved(), "pumparound fallback should satisfy the active convergence gates");
-    assertTrue(column.isLastColumnTearConverged(), "pumparound return-stream tear should converge");
-    // This regression owns solver coordination. Detailed pumparound product accounting is a
-    // separate outer-tear concern and must not be used to validate the Naphtali side-draw equations.
-    assertPhysicalProduct(column.getGasOutStream(), "pumparound overhead");
-    assertPhysicalProduct(column.getLiquidOutStream(), "pumparound bottoms");
+      assertEquals(DistillationColumn.SolverType.NAPHTALI_SANDHOLM, column.getLastSolverTypeUsed(),
+          () -> "pumparound case should be accepted by the simultaneous solver\n"
+              + column.getConvergenceDiagnostics());
+      assertEquals(DistillationColumn.SolveStatus.RIGOROUS_CONVERGED, column.getLastSolveStatus(),
+          "pumparound case should close without terminal-product reconciliation");
+      assertTrue(column.solved(), "pumparound case should satisfy the active convergence gates");
+      assertTrue(column.isLastColumnTearConverged(), "pumparound stream materialization should complete");
+      assertTrue(column.getLastColumnTearIterationCount() <= 2,
+          "direct pumparound coupling should not require a repeated column tear solve");
+
+      StreamInterface internalLiquid = column.getTray(drawTrayNumber).getLiquidOutStream();
+      StreamInterface drawStream = pumparound.getDrawStream();
+      StreamInterface returnStream = pumparound.getReturnStream();
+      double internalMolarFlow = internalLiquid.getFlowRate("mol/hr");
+      double drawMolarFlow = drawStream.getFlowRate("mol/hr");
+      double actualDrawFraction = drawMolarFlow / (internalMolarFlow + drawMolarFlow);
+      assertEquals(drawFraction, actualDrawFraction, 1.0e-6,
+          "the applied tray streams must preserve the configured pumparound split");
+      assertEquals(drawMolarFlow, returnStream.getFlowRate("mol/hr"), Math.max(1.0e-6, 1.0e-8 * drawMolarFlow),
+          "pumparound draw and return molar flows should match");
+      assertEquals(drawStream.getTemperature() - 5.0, returnStream.getTemperature(), 1.0e-6,
+          "pumparound return temperature should preserve the specified drop");
+      assertTrue(drawStream.getFlowRate("kg/hr") > previousDrawFlow,
+          "pumparound flow should increase at the nearby higher draw fraction");
+      previousDrawFlow = drawStream.getFlowRate("kg/hr");
+
+      assertOverallMassBalance(feedStream, topFeedStream, column);
+      assertComponentMassBalances(feedStream, topFeedStream, column);
+      assertTrue(Double.isFinite(column.getLastMeshMaterialResidualNorm()),
+          "pumparound material residual should be finite");
+      assertTrue(Double.isFinite(column.getLastMeshEnergyResidualNorm()),
+          "pumparound energy residual should be finite");
+      assertEquals(REBOILER_TEMPERATURE_C, column.getReboiler().getTemperature() - 273.15, 1.0e-6,
+          "the fixed reboiler-temperature specification should be satisfied");
+      assertPhysicalProduct(column.getGasOutStream(), "pumparound overhead");
+      assertPhysicalProduct(column.getLiquidOutStream(), "pumparound bottoms");
+      assertPhysicalProduct(drawStream, "pumparound draw");
+      assertPhysicalProduct(returnStream, "pumparound return");
+      assertTrue(column.getLastIterationCount() <= 300,
+          "pumparound simultaneous solve should remain inside the configured iteration budget");
+    }
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -334,9 +334,9 @@ public class ColumnStudyRegressionTest {
           TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA, TOP_FEED_MASS_FLOW_KG_HR);
       DistillationColumn column = createColumn(feedStream, topFeedStream);
       int drawTrayNumber = answerTrayToNeqSimStage(7);
-      DistillationColumn.ColumnPumparound pumparound =
-          column.addLiquidPumparound("column-study pumparound " + caseIndex, drawTrayNumber,
-              answerTrayToNeqSimStage(5), initialCircuitDrawFraction, 5.0);
+      DistillationColumn.ColumnPumparound pumparound = column.addLiquidPumparound(
+          "column-study pumparound " + caseIndex, drawTrayNumber, answerTrayToNeqSimStage(5),
+          initialCircuitDrawFraction, 5.0);
       // The tray setter is public and is also used by operating-point studies. Withdrawal and
       // return terms must use this same applied fraction after configuration.
       column.getTray(drawTrayNumber).setLiquidPumparoundDrawFraction(drawFraction);

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -357,7 +357,7 @@ public class ColumnStudyRegressionTest {
           "the applied tray streams must preserve the configured pumparound split");
       assertEquals(drawMolarFlow, returnStream.getFlowRate("mol/hr"), Math.max(1.0e-6, 1.0e-8 * drawMolarFlow),
           "pumparound draw and return molar flows should match");
-      assertEquals(drawStream.getTemperature() - 5.0, returnStream.getTemperature(), 1.0e-6,
+      assertEquals(drawStream.getTemperature() - pumparound.getTemperatureDrop(), returnStream.getTemperature(), 1.0e-6,
           "pumparound return temperature should preserve the specified drop");
       assertTrue(drawStream.getFlowRate("kg/hr") > previousDrawFlow,
           "pumparound flow should increase at the nearby higher draw fraction");

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -205,7 +205,6 @@ public class ColumnStudyRegressionTest {
     double previousSideDrawFlow = 0.0;
     for (int caseIndex = 0; caseIndex < drawFractions.length; caseIndex++) {
       double drawFraction = drawFractions[caseIndex];
-      double initialCircuitDrawFraction = caseIndex == 0 ? drawFraction : drawFractions[0];
       SystemInterface baseFluid = createBaseFluid();
       StreamInterface feedStream = createStream("side_draw_main_feed_" + caseIndex, baseFluid, MAIN_FEED_COMPOSITION,
           MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
@@ -327,6 +326,7 @@ public class ColumnStudyRegressionTest {
     double previousDrawFlow = 0.0;
     for (int caseIndex = 0; caseIndex < drawFractions.length; caseIndex++) {
       double drawFraction = drawFractions[caseIndex];
+      double initialCircuitDrawFraction = caseIndex == 0 ? drawFraction : drawFractions[0];
       SystemInterface baseFluid = createBaseFluid();
       StreamInterface feedStream = createStream("pumparound_main_feed_" + caseIndex, baseFluid, MAIN_FEED_COMPOSITION,
           MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -327,10 +327,10 @@ public class ColumnStudyRegressionTest {
     for (int caseIndex = 0; caseIndex < drawFractions.length; caseIndex++) {
       double drawFraction = drawFractions[caseIndex];
       SystemInterface baseFluid = createBaseFluid();
-      StreamInterface feedStream = createStream("pumparound_main_feed_" + caseIndex, baseFluid,
-          MAIN_FEED_COMPOSITION, MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
-      StreamInterface topFeedStream = createStream("pumparound_top_feed_" + caseIndex, baseFluid,
-          TOP_FEED_COMPOSITION, TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA, TOP_FEED_MASS_FLOW_KG_HR);
+      StreamInterface feedStream = createStream("pumparound_main_feed_" + caseIndex, baseFluid, MAIN_FEED_COMPOSITION,
+          MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
+      StreamInterface topFeedStream = createStream("pumparound_top_feed_" + caseIndex, baseFluid, TOP_FEED_COMPOSITION,
+          TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA, TOP_FEED_MASS_FLOW_KG_HR);
       DistillationColumn column = createColumn(feedStream, topFeedStream);
       int drawTrayNumber = answerTrayToNeqSimStage(7);
       DistillationColumn.ColumnPumparound pumparound = column.addLiquidPumparound(
@@ -339,8 +339,7 @@ public class ColumnStudyRegressionTest {
       column.run();
 
       assertEquals(DistillationColumn.SolverType.NAPHTALI_SANDHOLM, column.getLastSolverTypeUsed(),
-          () -> "pumparound case should be accepted by the simultaneous solver\n"
-              + column.getConvergenceDiagnostics());
+          () -> "pumparound case should be accepted by the simultaneous solver\n" + column.getConvergenceDiagnostics());
       assertEquals(DistillationColumn.SolveStatus.RIGOROUS_CONVERGED, column.getLastSolveStatus(),
           "pumparound case should close without terminal-product reconciliation");
       assertTrue(column.solved(), "pumparound case should satisfy the active convergence gates");

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -205,6 +205,7 @@ public class ColumnStudyRegressionTest {
     double previousSideDrawFlow = 0.0;
     for (int caseIndex = 0; caseIndex < drawFractions.length; caseIndex++) {
       double drawFraction = drawFractions[caseIndex];
+      double initialCircuitDrawFraction = caseIndex == 0 ? drawFraction : drawFractions[0];
       SystemInterface baseFluid = createBaseFluid();
       StreamInterface feedStream = createStream("side_draw_main_feed_" + caseIndex, baseFluid, MAIN_FEED_COMPOSITION,
           MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
@@ -333,8 +334,12 @@ public class ColumnStudyRegressionTest {
           TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA, TOP_FEED_MASS_FLOW_KG_HR);
       DistillationColumn column = createColumn(feedStream, topFeedStream);
       int drawTrayNumber = answerTrayToNeqSimStage(7);
-      DistillationColumn.ColumnPumparound pumparound = column.addLiquidPumparound(
-          "column-study pumparound " + caseIndex, drawTrayNumber, answerTrayToNeqSimStage(5), drawFraction, 5.0);
+      DistillationColumn.ColumnPumparound pumparound =
+          column.addLiquidPumparound("column-study pumparound " + caseIndex, drawTrayNumber,
+              answerTrayToNeqSimStage(5), initialCircuitDrawFraction, 5.0);
+      // The tray setter is public and is also used by operating-point studies. Withdrawal and
+      // return terms must use this same applied fraction after configuration.
+      column.getTray(drawTrayNumber).setLiquidPumparoundDrawFraction(drawFraction);
 
       column.run();
 


### PR DESCRIPTION
## Outcome

Closed without merge. Exact-head validation disproved the proposed direct Naphtali–Sandholm pumparound capability, so this implementation is not suitable for publication.

## Problem investigated

Naphtali–Sandholm previously routed active liquid pumparounds to a residual-based fallback. This draft attempted to couple nonlocal pumparound material and energy returns directly into the simultaneous MESH equations for the realistic 24-component column regression.

## Attempted change

- separated external liquid side draws from internal pumparound circulation;
- added nonlocal component and cooled-return enthalpy terms;
- added recycle-consistent total/component initialization sweeps;
- used a dense finite-difference Jacobian for the nonlocal equations;
- corrected applied-fraction fingerprinting and external mass/energy accounting;
- added deterministic 3% and nearby 5% circulation coverage, including public tray-fraction mutation.

## Exact-head evidence (`b11d58b`)

The same capability regression failed on both Java 21 platforms:

- Ubuntu: 2,283 s for the pumparound test; expected `NAPHTALI_SANDHOLM`, actual `DAMPED_SUBSTITUTION`.
- Windows: 1,850 s; same result.
- Both runs performed 20 dense Newton solves, 5,720 semi-analytic Jacobian columns, 5,720 finite-difference columns, and 13,684 thermodynamic evaluations before fallback.
- Final fallback state reported 76 iterations, mass residual about `9.53e-14`, but MESH infinity norm `1.0`; the direct solver did not converge.

The preceding implementation required 2,697 s and also fell back. The wall-clock difference is not a defensible speed improvement: stable solver metrics and the selected fallback path were unchanged.

## Gates

Passed on the exact head: Spotless, pre-commit, PaperLab, JavaDoc, documentation search, CodeQL, and all three slow-test shards. The full Ubuntu and Windows suites reached the same functional failure and then exceeded the workflow time ceiling.

## Copilot disposition

All current Copilot findings were assessed. The external-product accounting concern was technically correct and addressed in the draft, but the functional regression failed before that behavior could be accepted as a complete validated change. The direct-solver assertion also remains unvalidated. Both formal threads were replied to and intentionally left unresolved. Later suggestions on per-component assertions, exception context, and return-tray lookup caching were not pursued because they cannot repair the demonstrated convergence failure and would expand an abandoned implementation.

## Conclusion and next work

No code from this draft should merge. The next investigation should isolate the 20-step Newton stagnation in a focused harness and evaluate continuation from zero circulation (with stable iteration/evaluation metrics) before another direct-coupling PR. If continuation cannot establish a rigorous applied-state solution, retain the fallback and address its excessive cost separately.