### PR TITLE
fix(tpflash): refine aqueous two-phase endpoints

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -193,6 +193,11 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │  Order phases by density                                                        │
 │  Final system.init(1)                                                           │
 │                                                                                 │
+│  IF ordinary flash, water feed ≥ 0.01, and no aqueous phase:                    │
+│     → Evaluate a cloned TPmultiflash candidate                                  │
+│     → Accept only a two-phase aqueous candidate with lower Gibbs energy,        │
+│       bounded phase fractions, normalized material balance, and distinct phases │
+│                                                                                 │
 │  IF chemical system:                                                            │
 │     → Final chemical equilibrium solve in aqueous/liquid phases                 │
 └─────────────────────────────────────────────────────────────────────────────────┘
@@ -210,6 +215,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | `maxNumberOfIterations` | 50 | Maximum iterations per convergence loop |
 | Convergence tolerance | 1e-10 | Deviation threshold for K-value convergence |
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
+| Ordinary aqueous-refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; the cloned candidate remains subject to Gibbs and phase-quality acceptance checks |
 
 ### 1.1 Problem Formulation
 

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -196,7 +196,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │  IF ordinary flash, water feed ≥ 0.01, and no aqueous phase:                    │
 │     → Evaluate a cloned TPmultiflash candidate                                  │
 │     → Accept only a two-phase aqueous candidate with lower Gibbs energy,        │
-│       bounded phase fractions, normalized material balance, and distinct phases │
+│       bounded/normalized phase fractions, and distinct phase compositions       │
 │                                                                                 │
 │  IF chemical system:                                                            │
 │     → Final chemical equilibrium solve in aqueous/liquid phases                 │

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -867,11 +867,11 @@ public class TPflash extends Flash {
    * Refines an ordinary water-rich endpoint with the multiphase stability solver.
    *
    * <p>
-   * The ordinary flash searches only the cubic gas/oil roots and can therefore leave a substantial
-   * water fraction dissolved in a hydrocarbon-labelled phase even when a lower-Gibbs aqueous split
-   * exists. The one-mol-percent feed guard keeps trace-water process flashes on the existing fast
-   * path. A cloned multiphase candidate replaces the ordinary state only through the same strict
-   * phase-fraction, distinct-composition, and Gibbs-energy checks used by the liquid-liquid rescue.
+   * The ordinary flash searches only the cubic gas/oil roots and can therefore leave a substantial water fraction
+   * dissolved in a hydrocarbon-labelled phase even when a lower-Gibbs aqueous split exists. The one-mol-percent feed
+   * guard keeps trace-water process flashes on the existing fast path. A cloned multiphase candidate replaces the
+   * ordinary state only through the same strict phase-fraction, distinct-composition, and Gibbs-energy checks used by
+   * the liquid-liquid rescue.
    * </p>
    */
   private void rescueAqueousEndpoint() {
@@ -881,15 +881,11 @@ public class TPflash extends Flash {
     }
 
     double waterFeedFraction = 0.0;
-    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
-      if (system.getPhase(phaseIndex).getType() == PhaseType.AQUEOUS) {
-        return;
-      }
+    if (system.hasPhaseType(PhaseType.AQUEOUS)) {
+      return;
     }
-    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents();
-        componentIndex++) {
-      neqsim.thermo.component.ComponentInterface component =
-          system.getPhase(0).getComponent(componentIndex);
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
       if ("water".equalsIgnoreCase(component.getComponentName())) {
         waterFeedFraction = component.getz();
         break;
@@ -904,7 +900,7 @@ public class TPflash extends Flash {
     try {
       candidate.setMultiPhaseCheck(true);
       new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
-      if (candidate.getNumberOfPhases() == 2 && containsAqueousPhase(candidate)
+      if (candidate.getNumberOfPhases() == 2 && candidate.hasPhaseType(PhaseType.AQUEOUS)
           && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
         copyFlashStateFrom(candidate);
       }
@@ -913,20 +909,6 @@ public class TPflash extends Flash {
     }
   }
 
-  /**
-   * Checks whether a candidate contains an aqueous phase.
-   *
-   * @param candidate candidate system to inspect
-   * @return true when one candidate phase is aqueous
-   */
-  private boolean containsAqueousPhase(SystemInterface candidate) {
-    for (int phaseIndex = 0; phaseIndex < candidate.getNumberOfPhases(); phaseIndex++) {
-      if (candidate.getPhase(phaseIndex).getType() == PhaseType.AQUEOUS) {
-        return true;
-      }
-    }
-    return false;
-  }
 
   /**
    * Screens for a non-aqueous, non-hydrocarbon-rich, high-volatility-contrast liquid mixture.

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -594,6 +594,7 @@ public class TPflash extends Flash {
         // applied on this path, as it can discard a genuine split the stability test overlooked.
         collapseTrivialMultiphaseSplit();
         rescueLiquidLiquidEndpoint();
+        rescueAqueousEndpoint();
         return;
       }
     }
@@ -779,6 +780,7 @@ public class TPflash extends Flash {
     collapseTrivialMultiphaseSplit();
     normalizeActivePhaseFractions();
     rescueLiquidLiquidEndpoint();
+    rescueAqueousEndpoint();
 
     // Final chemical equilibrium call after all phase reordering
     // This ensures chemical equilibrium is solved on the final phase configuration
@@ -857,6 +859,71 @@ public class TPflash extends Flash {
     } catch (Exception ex) {
       logger.debug("Liquid-liquid endpoint refinement failed: {}", ex.getMessage());
     }
+  }
+
+  /**
+   * Refines an ordinary water-rich endpoint with the multiphase stability solver.
+   *
+   * <p>
+   * The ordinary flash searches only the cubic gas/oil roots and can therefore leave a substantial
+   * water fraction dissolved in a hydrocarbon-labelled phase even when a lower-Gibbs aqueous split
+   * exists. The one-mol-percent feed guard keeps trace-water process flashes on the existing fast
+   * path. A cloned multiphase candidate replaces the ordinary state only through the same strict
+   * phase-fraction, distinct-composition, and Gibbs-energy checks used by the liquid-liquid rescue.
+   * </p>
+   */
+  private void rescueAqueousEndpoint() {
+    if (system.doMultiPhaseCheck() || system.isChemicalSystem() || system.hasIons() || solidCheck
+        || system.isMultiphaseWaxCheck() || system.getNumberOfPhases() > 2) {
+      return;
+    }
+
+    double waterFeedFraction = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex).getType() == PhaseType.AQUEOUS) {
+        return;
+      }
+    }
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents();
+        componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component =
+          system.getPhase(0).getComponent(componentIndex);
+      if ("water".equalsIgnoreCase(component.getComponentName())) {
+        waterFeedFraction = component.getz();
+        break;
+      }
+    }
+    if (waterFeedFraction < 0.01) {
+      return;
+    }
+
+    double referenceGibbsEnergy = system.getGibbsEnergy();
+    SystemInterface candidate = system.clone();
+    try {
+      candidate.setMultiPhaseCheck(true);
+      new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+      if (candidate.getNumberOfPhases() == 2 && containsAqueousPhase(candidate)
+          && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
+        copyFlashStateFrom(candidate);
+      }
+    } catch (Exception ex) {
+      logger.debug("Aqueous endpoint refinement failed: {}", ex.getMessage());
+    }
+  }
+
+  /**
+   * Checks whether a candidate contains an aqueous phase.
+   *
+   * @param candidate candidate system to inspect
+   * @return true when one candidate phase is aqueous
+   */
+  private boolean containsAqueousPhase(SystemInterface candidate) {
+    for (int phaseIndex = 0; phaseIndex < candidate.getNumberOfPhases(); phaseIndex++) {
+      if (candidate.getPhase(phaseIndex).getType() == PhaseType.AQUEOUS) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -44,6 +44,8 @@ public class TPflash extends Flash {
   private static final double LIQUID_LIQUID_ACTIVE_COMPONENT_LIMIT = 1.0e-6;
   /** Minimum critical-temperature span (K) for liquid-liquid refinement. */
   private static final double LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN = 150.0;
+  /** Minimum water feed fraction for ordinary aqueous endpoint refinement. */
+  private static final double AQUEOUS_REFINEMENT_WATER_FRACTION_LIMIT = 0.01;
   /**
    * Minimum extensive Gibbs-energy reduction (J) required for the spurious-multiphase rescue to collapse a two-phase
    * result to a single phase. Avoids false triggers from numerical noise.
@@ -893,7 +895,7 @@ public class TPflash extends Flash {
         break;
       }
     }
-    if (waterFeedFraction < 0.01) {
+    if (waterFeedFraction < AQUEOUS_REFINEMENT_WATER_FRACTION_LIMIT) {
       return;
     }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -909,7 +909,6 @@ public class TPflash extends Flash {
     }
   }
 
-
   /**
    * Screens for a non-aqueous, non-hydrocarbon-rich, high-volatility-contrast liquid mixture.
    *

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPFlashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPFlashTest.java
@@ -89,7 +89,8 @@ class TPFlashTest {
     testOps = new ThermodynamicOperations(testSystem);
     testOps.TPflash();
     testSystem.initProperties();
-    double expected = -552559.256480;
+    // The stable ordinary endpoint now matches the existing multiphase reference in testRun4.
+    double expected = -936973.1969586421;
     double deviation = Math.abs((testSystem.getEnthalpy() - expected) / expected * 100);
     assertEquals(0.0, deviation, 0.5);
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousEndpointTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousEndpointTest.java
@@ -1,0 +1,72 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashAqueousEndpointTest {
+  private static final String[] COMPONENTS = { "methane", "water" };
+  private static final double[] FEED = { 0.85, 0.15 };
+
+  @Test
+  void ordinaryAndMultiphaseFlashSelectSameAqueousEquilibrium() {
+    SystemInterface ordinary = createAndFlash(false);
+    SystemInterface multiphase = createAndFlash(true);
+
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquals(2, multiphase.getNumberOfPhases());
+    assertTrue(ordinary.hasPhaseType("aqueous"));
+    assertTrue(ordinary.hasPhaseType("gas"));
+    assertEquals(multiphase.getGibbsEnergy(), ordinary.getGibbsEnergy(), 1.0e-8);
+    assertEquals(multiphase.getEnthalpy(), ordinary.getEnthalpy(), 1.0e-8);
+
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      assertEquals(multiphase.getPhase(phaseIndex).getType(), ordinary.getPhase(phaseIndex).getType());
+      assertEquals(multiphase.getBeta(phaseIndex), ordinary.getBeta(phaseIndex), 1.0e-12);
+      assertEquals(multiphase.getPhase(phaseIndex).getDensity(), ordinary.getPhase(phaseIndex).getDensity(), 1.0e-8);
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        assertEquals(multiphase.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            ordinary.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
+      }
+    }
+
+    assertFlashClosure(ordinary);
+    assertFlashClosure(multiphase);
+  }
+
+  private SystemInterface createAndFlash(boolean multiphaseCheck) {
+    SystemInterface system = new SystemSrkEos(273.15, 300.0);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], FEED[componentIndex]);
+    }
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private void assertFlashClosure(SystemInterface system) {
+    assertEquals(1.0, system.getBeta(0) + system.getBeta(1), 1.0e-12);
+    double maximumLogFugacityResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-12);
+
+      double firstPhaseFugacity = system.getPhase(0).getComponent(componentIndex).getx()
+          * system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient();
+      double secondPhaseFugacity = system.getPhase(1).getComponent(componentIndex).getx()
+          * system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient();
+      maximumLogFugacityResidual = Math.max(maximumLogFugacityResidual,
+          Math.abs(Math.log(firstPhaseFugacity / secondPhaseFugacity)));
+    }
+    assertTrue(maximumLogFugacityResidual < 1.0e-8,
+        "maximum log fugacity residual was " + maximumLogFugacityResidual);
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousEndpointTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousEndpointTest.java
@@ -59,12 +59,14 @@ class TPflashAqueousEndpointTest {
       }
       assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-12);
 
-      double firstPhaseFugacity = system.getPhase(0).getComponent(componentIndex).getx()
-          * system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient();
-      double secondPhaseFugacity = system.getPhase(1).getComponent(componentIndex).getx()
-          * system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient();
+      double firstPhaseLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondPhaseLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
       maximumLogFugacityResidual = Math.max(maximumLogFugacityResidual,
-          Math.abs(Math.log(firstPhaseFugacity / secondPhaseFugacity)));
+          Math.abs(firstPhaseLogFugacity - secondPhaseLogFugacity));
     }
     assertTrue(maximumLogFugacityResidual < 1.0e-8, "maximum log fugacity residual was " + maximumLogFugacityResidual);
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousEndpointTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousEndpointTest.java
@@ -45,7 +45,7 @@ class TPflashAqueousEndpointTest {
     system.setMixingRule("classic");
     system.setMultiPhaseCheck(multiphaseCheck);
     new ThermodynamicOperations(system).TPflash();
-    system.init(3);
+    system.initProperties();
     return system;
   }
 
@@ -66,7 +66,6 @@ class TPflashAqueousEndpointTest {
       maximumLogFugacityResidual = Math.max(maximumLogFugacityResidual,
           Math.abs(Math.log(firstPhaseFugacity / secondPhaseFugacity)));
     }
-    assertTrue(maximumLogFugacityResidual < 1.0e-8,
-        "maximum log fugacity residual was " + maximumLogFugacityResidual);
+    assertTrue(maximumLogFugacityResidual < 1.0e-8, "maximum log fugacity residual was " + maximumLogFugacityResidual);
   }
 }


### PR DESCRIPTION
## Problem

The ordinary two-phase TP flash can converge to cubic gas/oil roots even when the stable equilibrium has exactly two phases and one is aqueous. A deterministic SRK regression at 273.15 K and 300 bara with (z_mathrm{methane}=0.85), (z_mathrm{water}=0.15) reproduced:

| path | phases | Gibbs energy |
|---|---|---:|
| ordinary TPflash | GAS + OIL | 10458.8035 J |
| multiphase TPflash | GAS + AQUEOUS | 8367.8302 J |

This violates cross-algorithm consistency and leaves the ordinary result 2090.9733 J above the stable state.

## Root cause

The ordinary path searches the cubic gas/oil roots. Aqueous trial-phase seeding and comprehensive tangent-plane stability analysis live in `TPmultiflash`, so an ordinary endpoint with no phase labelled `AQUEOUS` has no opportunity to discover that split.

## Change

After an ordinary endpoint, a cloned multiphase candidate is evaluated only when all cheap guards pass:

- neutral, non-chemical system without ions, solids, or wax;
- at most two current phases and no existing aqueous phase;
- water feed fraction at least 0.01.

The original state is replaced only when the candidate:

- has exactly two phases, including an aqueous phase;
- passes the existing phase-fraction and distinct-composition checks;
- has lower Gibbs energy by the existing numerical acceptance margin.

Restricting acceptance to exactly two phases keeps this change bounded: ordinary TPflash does not begin returning newly discovered three-phase states.

## Method and literature basis

The candidate reuses NeqSim's existing Michelsen tangent-plane stability and multiphase split implementation. The stability criterion follows:

- Michelsen, “The isothermal flash problem. Part I. Stability,” [Fluid Phase Equilibria 9 (1982) 1–19](https://doi.org/10.1016/0378-3812(82)85001-2).
- Michelsen, “The isothermal flash problem. Part II. Phase-split calculation,” [Fluid Phase Equilibria 9 (1982) 21–40](https://doi.org/10.1016/0378-3812(82)85002-4).

Evidence: the lower-Gibbs candidate satisfies material balance, normalized compositions, phase-fraction bounds, and equal component fugacities. The 0.01 water gate is a performance guard, not a thermodynamic stability criterion; the TPD/multiphase calculation remains authoritative after the gate activates. No inference is made about proprietary commercial-simulator internals.

## Results

Focused regression after the change:

- ordinary and multiphase phase types, phase fractions, and compositions agree within (10^{-12});
- Gibbs and enthalpy agree within (10^{-8}) J;
- maximum log-fugacity residual: (1.31	imes10^{-13});
- maximum component material residual: (1.67	imes10^{-14});
- beta-sum and composition-normalization residuals: zero;
- 10 repeated executions were bitwise deterministic in the local harness.

A deterministic 450-state SRK/PR/CPA water matrix (methane-water, wet gas, oil-water, CO2-water, and H2-water; 230–373.15 K; 1–300 bara) changed ordinary/multiphase discrepancies from **142 to 105**. All **37 structural disagreements whose multiphase reference had at most two phases were removed**. The remaining set consists of 92 three-phase phase-count differences intentionally outside this patch and 13 pre-existing numerical two-phase differences for separate isolation.

No flash threw an exception in the final 450-state matrix. Iteration counts were not benchmarked: the ordinary and nested `TPmultiflash` iteration totals are not exposed through the public operations API, and adding production instrumentation was outside this bounded correctness change.

## Performance

Median wall time per flash, including system construction and JPype overhead:

| case | baseline | change |
|---|---:|---:|
| dry five-component gas/oil, 1000 runs | 3.76 ms | 3.57 ms |
| 0.1 mol% water (below gate), 1000 runs | 4.64 ms | 4.64 ms |
| active 15 mol% water regression, 300 runs | 2.90 ms | 6.88 ms |

The dry and trace-water fast paths are unchanged within benchmark noise. The approximately 3.98 ms cost is paid only when the aqueous-refinement gate activates.

## Tests

- New `TPflashAqueousEndpointTest`: fails against the master baseline and passes with this change.
- Production source compiled with Java 17 against the available NeqSim 3.16.0 dependency classes.
- Focused test passed with JUnit Platform standalone.
- The 450-state comparison matrix and focused residual/determinism harness passed as described above.

Not run locally: Maven test suites, Spotless, pre-commit, Javadocs, and the full build. Maven dependency resolution was unavailable because Maven Central DNS resolution failed in the execution environment.

Review and CI hardening on head `9b2bab44`:

- initializes physical properties before density assertions;
- reuses `SystemInterface.hasPhaseType(PhaseType)` for aqueous checks;
- computes fugacity closure in zero-safe log space;
- updates `TPFlashTest.testRun3` from the metastable ordinary enthalpy (-552559.256480 J) to -936973.1969586421 J, which is the pre-existing multiphase reference in `testRun4`. The failed Windows run observed the new value before the stale expectation was updated.

Final GitHub CI passed Java 8 and Java 21 tests on Ubuntu and Windows, all three Java 21 slow-test shards, Javadocs, CodeQL, documentation coverage, pre-commit, Spotless, and PaperLab. All review threads were resolved before merge.

## Compatibility and risk

- No public API changes.
- Chemical/electrolyte, solid, and wax systems are excluded.
- Trace-water feeds below 1 mol% remain on the existing fast path.
- A candidate with three phases is never copied.
- The original result is retained on any exception or failed acceptance check.

## Documentation impact

Updated `TPflash_algorithm.md` and method Javadocs to document the guard, the candidate acceptance criteria, and the performance trade-off.
