### PR TITLE
fix: guard full side-draw Naphtali boundary

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -205,7 +205,10 @@ Side draws withdraw a fraction of tray vapor or liquid traffic. They are true ex
 streams: `getOutletStreams()` includes them, and `getMassBalance(unit)` subtracts them from the
 feed-product balance. The sequential tray solvers and `NAPHTALI_SANDHOLM` both remove the withdrawn
 phase from inter-tray material and energy traffic; the Naphtali-Sandholm solver also fingerprints the
-configured split so a changed draw cannot reuse an incompatible warm state.
+configured split so a changed draw cannot reuse an incompatible warm state. An exact liquid
+side-draw fraction of `1.0` leaves zero internal downflow across that stage, so NeqSim routes an
+explicit or reused `NAPHTALI_SANDHOLM` selection to `MESH_RESIDUAL`. Fractions below `1.0`
+retain positive internal traffic and remain eligible for the simultaneous solver.
 
 ```java
 column.setGasSideDrawFraction(6, 0.05);

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1779,6 +1779,27 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
+   * Check whether a liquid side draw removes all liquid traffic from any stage.
+   *
+   * <p>
+   * Naphtali-Sandholm initialization propagates liquid traffic by dividing by the fraction that remains for the tray
+   * below. The exact full-withdrawal boundary has a zero divisor and must use a solver that does not rely on that
+   * initialization. Fractions below one retain positive internal traffic and remain supported by the simultaneous
+   * solver.
+   * </p>
+   *
+   * @return {@code true} when at least one liquid side-draw fraction is exactly one
+   */
+  private boolean hasFullyWithdrawnLiquidStage() {
+    for (int trayIndex = 0; trayIndex < numberOfTrays; trayIndex++) {
+      if (trays.get(trayIndex).getLiquidSideDrawFraction() >= 1.0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Select the solver to use for the current run after guarded default heuristics are applied.
    *
    * @return solver strategy to execute for this run
@@ -1803,6 +1824,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     // equation system.
     if (effectiveSolverType == SolverType.NAPHTALI_SANDHOLM && !pumparounds.isEmpty()) {
       logger.debug("Using MESH_RESIDUAL for column {} because active pumparounds require outer return-stream coupling",
+          getName());
+      return SolverType.MESH_RESIDUAL;
+    }
+    if (effectiveSolverType == SolverType.NAPHTALI_SANDHOLM && hasFullyWithdrawnLiquidStage()) {
+      logger.debug("Using MESH_RESIDUAL for column {} because a full liquid side draw leaves zero internal downflow",
           getName());
       return SolverType.MESH_RESIDUAL;
     }

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolverTuningTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnSolverTuningTest.java
@@ -3,6 +3,7 @@ package neqsim.process.equipment.distillation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import neqsim.process.equipment.stream.Stream;
@@ -173,4 +174,29 @@ public class DistillationColumnSolverTuningTest {
       }
     });
   }
+
+  /**
+   * Exactly 100 percent liquid withdrawal disconnects the internal downflow and must avoid the Naphtali-Sandholm
+   * initialization divisions by the remaining liquid fraction. A nearby supported fraction must retain the requested
+   * simultaneous solver rather than introducing an arbitrary broad cutoff.
+   *
+   * @throws Exception if the guarded solver selector cannot be inspected
+   */
+  @Test
+  public void fullLiquidWithdrawalUsesResidualFallbackAtExactBoundary() throws Exception {
+    DistillationColumn column = buildColumn(6);
+    column.setSolverType(DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    int drawTrayNumber = 3;
+    Method selector = DistillationColumn.class.getDeclaredMethod("getEffectiveSolverTypeForRun");
+    selector.setAccessible(true);
+
+    column.setLiquidSideDrawFraction(drawTrayNumber, 1.0);
+    assertEquals(DistillationColumn.SolverType.MESH_RESIDUAL, selector.invoke(column),
+        "100 percent liquid withdrawal must avoid singular Naphtali-Sandholm initialization");
+
+    column.setLiquidSideDrawFraction(drawTrayNumber, 0.99);
+    assertEquals(DistillationColumn.SolverType.NAPHTALI_SANDHOLM, selector.invoke(column),
+        "a nearby positive internal-flow fraction should remain on the simultaneous solver");
+  }
+
 }


### PR DESCRIPTION
## Problem and root cause

`SimpleTray` permits an exact liquid side-draw fraction of `1.0`. Naphtali–Sandholm initialization reconstructs liquid traffic by dividing by the fraction that remains for the tray below; at `1.0` withdrawal that internal fraction is zero. The existing `1e-12` denominator floor avoids an exception but can seed numerically meaningless liquid flow instead of representing zero downflow.

This is the dedicated follow-up to the 100%-withdrawal review on #2674.

## Baseline evidence

The pre-fix `master` source had no liquid-side-draw feasibility guard in `getEffectiveSolverTypeForRun()`, so an explicitly requested or AUTO-reused `NAPHTALI_SANDHOLM` solver remained selected at `1.0`. Copilot independently identified the same missing production guard on the test-only commit.

The deterministic selector regression records both sides of the boundary without running a flash:

- before the fix, exact `1.0` selected `NAPHTALI_SANDHOLM` and violated the expected fallback;
- nearby `0.99` selected `NAPHTALI_SANDHOLM` and provides the positive-internal-traffic control case.

The test-only hosted run was superseded before it reached the assertion, so no completed red CI run is claimed.

## Algorithmic change

`getEffectiveSolverTypeForRun()` detects a tray whose liquid side-draw fraction reaches the validated full-withdrawal boundary and routes an explicit or AUTO warm-reused `NAPHTALI_SANDHOLM` choice to `MESH_RESIDUAL`.

The guard is deliberately narrow:

- `1.0` liquid withdrawal -> `MESH_RESIDUAL`;
- `0.99` and every lower validated fraction -> remains eligible for `NAPHTALI_SANDHOLM`;
- no convergence tolerance, thermodynamic state, product stream, or public API changes;
- the existing pumparound fallback and ordinary no-side-draw behavior are unchanged.

## Measured result

Exact refreshed head `ef10aad` passed 10,908 tests with zero failures/errors and 212 skipped on Java 8 and Java 21, Ubuntu and Windows. All three Java 21 slow shards also passed. This is a correctness/robustness boundary fix; no speed claim is made.

The change was merged externally on July 30, 2026 as `602ae3a`.

## Engineering validation

Completed on exact refreshed head `ef10aad`:

- Java 8 Ubuntu/Windows: 10,908 tests per platform, zero failures/errors;
- Java 21 Ubuntu/Windows: 10,908 tests per platform, zero failures/errors;
- all three Java 21 slow-test shards;
- JavaDoc;
- Spotless and pre-commit;
- PaperLab replication gate;
- documentation search coverage;
- CodeQL.

## Documentation impact

Updated `docs/process/equipment/distillation.md` to document the exact full-withdrawal fallback while preserving simultaneous-solver eligibility below `1.0`.

## Copilot dispositions

- Accepted the missing production guard/documentation finding and implemented it with the focused regression above.
- Rejected the suppressed suggestion to change `>= 1.0` to `== 1.0`, and its later JavaDoc-wording variant: the public setter validation limits fractions to `[0, 1]`, so the predicate represents exactly the supported full-withdrawal boundary. Keeping `>=` is defensive against invalid internal state and does not broaden fallback below 100%; any future relaxation above 1.0 would require its own feasibility and contract review.

## Compatibility and remaining limitations

The change is private solver orchestration only and is backward compatible for all fractions below `1.0`. It does not make the current Naphtali initializer support a zero-internal-liquid stage; it explicitly selects the established residual-monitored path instead. Vapor full-withdrawal feasibility and more general zero-traffic equation reduction remain separate targets.