### PR TITLE
feat: expose TwoFluidPipe closure diagnostic profiles

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -37,10 +37,15 @@ simulator exports or field data.
 `severe_slugging_number`, `water_wetting_flag`, `water_dropout_risk_flag`, and
 `severe_slug_potential_flag`.
 
+Continuous benchmark profiles use linear interpolation. Variables ending in `_flag` and intervals
+with non-finite diagnostic sentinels use nearest-neighbour sampling, preserving binary flags and
+avoiding interpolation-generated `NaN` values.
+
 ### Tests
 
 `TwoFluidPipeReportTest` verifies profile shape, physical bounds, and report columns.
-`TwoFluidBenchmarkHarnessTest` verifies capture and comparison of the new benchmark variables.
+`TwoFluidBenchmarkHarnessTest` verifies capture, continuous interpolation, discrete flag sampling,
+non-finite sentinel handling, and comparison of the new benchmark variables.
 
 ---
 

--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,41 @@
 
 ---
 
+## 2026-07-30 — TwoFluidPipe closure diagnostics exposed as profiles
+
+### Summary
+
+`TwoFluidPipe` now exposes the closure diagnostics already calculated for each
+`TwoFluidSection`. The steady-state and transient report CSVs include the new profiles, and the
+benchmark harness captures their numeric values and risk flags for comparison with public
+simulator exports or field data.
+
+### New API
+
+| API | What it does |
+|---|---|
+| `getOilWaterFlowRegimeProfile()` | Reports the oil-water flow configuration by section |
+| `getWaterWettingProfile()` | Reports water-wetting flags for corrosion screening |
+| `getWaterDropoutRiskProfile()` | Reports water dropout or accumulation flags |
+| `getEntrainmentFractionProfile()` | Reports estimated liquid entrainment fractions |
+| `getEntrainedDropletDiameterProfile()` | Reports characteristic entrained droplet diameters |
+| `getSevereSluggingNumberProfile()` | Reports the riser-base severe-slugging stability number |
+| `getSevereSlugPotentialProfile()` | Reports severe-slugging risk flags |
+
+### Reporting and validation
+
+`TwoFluidPipeReport` appends the closure profiles to its steady-state and transient CSV exports.
+`TwoFluidBenchmarkHarness` adds `entrainment_fraction`, `entrained_droplet_diameter_m`,
+`severe_slugging_number`, `water_wetting_flag`, `water_dropout_risk_flag`, and
+`severe_slug_potential_flag`.
+
+### Tests
+
+`TwoFluidPipeReportTest` verifies profile shape, physical bounds, and report columns.
+`TwoFluidBenchmarkHarnessTest` verifies capture and comparison of the new benchmark variables.
+
+---
+
 ## 2026-07-28 — Dynamic VU flashes preserve nearby CPA state
 
 ### Summary

--- a/docs/wiki/two_fluid_reporting_and_validation.md
+++ b/docs/wiki/two_fluid_reporting_and_validation.md
@@ -43,6 +43,13 @@ After `pipe.run()`, the following methods provide one value per pipe section:
 | `getWaterVelocityProfile()` | m/s | Water velocity when oil-water slip is active |
 | `getOilWaterSlipProfile()` | m/s | Oil velocity minus water velocity |
 | `getFlowRegimeProfile()` | enum | Gas-liquid flow regime by section |
+| `getOilWaterFlowRegimeProfile()` | enum | Oil-water flow configuration by section |
+| `getWaterWettingProfile()` | boolean | Water-wetting indicator for corrosion screening |
+| `getWaterDropoutRiskProfile()` | boolean | Water dropout / accumulation risk |
+| `getEntrainmentFractionProfile()` | fraction | Estimated liquid entrainment in annular/mist flow |
+| `getEntrainedDropletDiameterProfile()` | m | Characteristic entrained droplet diameter |
+| `getSevereSluggingNumberProfile()` | dimensionless | Riser-base stability indicator |
+| `getSevereSlugPotentialProfile()` | boolean | Severe-slugging risk flag |
 | `getHeatTransferProfile()` | W/(m2 K) | Heat-transfer coefficient profile, when configured |
 | `getSurfaceTemperatureProfile()` | K | Ambient/surface temperature profile, when configured |
 
@@ -59,6 +66,9 @@ double[] waterCut = pipe.getWaterCutProfile();
 double[] gasVelocity = pipe.getGasVelocityProfile();
 double[] liquidVelocity = pipe.getLiquidVelocityProfile();
 PipeSection.FlowRegime[] regimes = pipe.getFlowRegimeProfile();
+double[] entrainment = pipe.getEntrainmentFractionProfile();
+double[] severeSluggingNumber = pipe.getSevereSluggingNumberProfile();
+boolean[] waterWetting = pipe.getWaterWettingProfile();
 
 for (int i = 0; i < x.length; i++) {
   double pBara = pressureBara[i] * 1.0e-5;
@@ -106,7 +116,9 @@ Recommended transient CSV columns:
 ```text
 time_s,position_m,pressure_bara,temperature_C,liquid_holdup,water_cut,
 gas_velocity_m_s,liquid_velocity_m_s,oil_velocity_m_s,water_velocity_m_s,
-flow_regime
+flow_regime,oil_water_flow_regime,water_wetting,water_dropout_risk,
+entrainment_fraction,entrained_droplet_diameter_m,severe_slugging_number,
+severe_slug_potential
 ```
 
 ## Summary metrics
@@ -133,21 +145,22 @@ Use these methods for an executive summary or design report:
 
 ## Closure diagnostics
 
-The two-fluid closure pass updates additional section-level diagnostics that are useful for model
-review and validation:
+The two-fluid closure pass updates additional diagnostics that are useful for model review and
+validation. Each value is available both on `TwoFluidSection` and as a top-level
+`TwoFluidPipe` profile:
 
-| Section API | Description |
-|-------------|-------------|
-| `getOilWaterFlowRegime()` | Oil-water flow configuration |
-| `isWaterWetting()` | Water-wetting indicator for corrosion screening |
-| `isWaterDropoutRisk()` | Water dropout / accumulation risk |
-| `getEntrainmentFraction()` | Estimated liquid entrainment fraction in annular/mist flow |
-| `getEntrainedDropletDiameter()` | Characteristic entrained droplet diameter |
-| `getSevereSluggingNumber()` | Riser-base stability indicator |
-| `isSevereSlugPotential()` | Severe slugging risk flag |
+| Section API | Pipe profile API | Description |
+|-------------|------------------|-------------|
+| `getOilWaterFlowRegime()` | `getOilWaterFlowRegimeProfile()` | Oil-water flow configuration |
+| `isWaterWetting()` | `getWaterWettingProfile()` | Water-wetting indicator for corrosion screening |
+| `isWaterDropoutRisk()` | `getWaterDropoutRiskProfile()` | Water dropout / accumulation risk |
+| `getEntrainmentFraction()` | `getEntrainmentFractionProfile()` | Estimated liquid entrainment fraction |
+| `getEntrainedDropletDiameter()` | `getEntrainedDropletDiameterProfile()` | Entrained droplet diameter |
+| `getSevereSluggingNumber()` | `getSevereSluggingNumberProfile()` | Riser-base stability indicator |
+| `isSevereSlugPotential()` | `getSevereSlugPotentialProfile()` | Severe-slugging risk flag |
 
-These values are stored on `TwoFluidSection` objects. They are not yet exposed as top-level
-`TwoFluidPipe` profile arrays, so a future report exporter should add profile accessors for them.
+The steady-state and transient profile CSV exporters include these diagnostics. Boolean values are
+written as `true` or `false`; a missing oil-water regime is written as an empty field.
 
 ## Benchmark comparison format
 
@@ -171,6 +184,12 @@ gas_velocity_m_s
 liquid_velocity_m_s
 oil_velocity_m_s
 water_velocity_m_s
+entrainment_fraction
+entrained_droplet_diameter_m
+severe_slugging_number
+water_wetting_flag
+water_dropout_risk_flag
+severe_slug_potential_flag
 ```
 
 Example use:
@@ -205,7 +224,8 @@ For long oil and gas flowlines, report at least:
 - Boundary conditions: inlet stream, flow rate, outlet pressure, transient changes.
 - Thermodynamics: fluid model, flash interval, mass-transfer relaxation time, heat-transfer setup.
 - Pressure and temperature profiles.
-- Liquid holdup, water cut, phase velocity, and flow-regime profiles.
+- Liquid holdup, water cut, phase velocity, flow-regime, entrainment, wetting, and severe-slugging
+  profiles.
 - Slug statistics and terrain low-point liquid accumulation.
 - Hydrate/wax/thermal risk sections if thresholds are configured.
 - Erosional velocity margin and maximum mixture velocity.
@@ -216,7 +236,5 @@ For long oil and gas flowlines, report at least:
 The current API is adequate for engineering studies and benchmark development. A polished
 industrial report workflow should still add:
 
-- Top-level profile accessors for closure diagnostics such as entrainment fraction, water wetting,
-  and severe slugging number.
 - Plot templates for pressure, temperature, holdup, water cut, flow regime, and slug events.
 - Direct import of OLGA/LedaFlow export formats where licensing allows it.

--- a/docs/wiki/two_fluid_reporting_and_validation.md
+++ b/docs/wiki/two_fluid_reporting_and_validation.md
@@ -59,7 +59,7 @@ Example Java extraction:
 pipe.run();
 
 double[] x = pipe.getPositionProfile();
-double[] pressureBara = pipe.getPressureProfile();
+double[] pressurePa = pipe.getPressureProfile();
 double[] temperatureC = pipe.getTemperatureProfile("C");
 double[] liquidHoldup = pipe.getLiquidHoldupProfile();
 double[] waterCut = pipe.getWaterCutProfile();
@@ -71,7 +71,7 @@ double[] severeSluggingNumber = pipe.getSevereSluggingNumberProfile();
 boolean[] waterWetting = pipe.getWaterWettingProfile();
 
 for (int i = 0; i < x.length; i++) {
-  double pBara = pressureBara[i] * 1.0e-5;
+  double pBara = pressurePa[i] * 1.0e-5;
   System.out.printf("%8.1f,%10.4f,%8.3f,%8.5f,%8.5f,%8.3f,%8.3f,%s%n",
       x[i], pBara, temperatureC[i], liquidHoldup[i], waterCut[i],
       gasVelocity[i], liquidVelocity[i], regimes[i]);

--- a/docs/wiki/two_fluid_reporting_and_validation.md
+++ b/docs/wiki/two_fluid_reporting_and_validation.md
@@ -208,8 +208,11 @@ if (!comparison.isPassed()) {
 }
 ```
 
-For transient comparisons, capture and pass a list of snapshots. The harness interpolates in both
-time and position. Comparison results can be exported as CSV:
+For transient comparisons, capture and pass a list of snapshots. The harness uses linear
+interpolation in time and position for continuous profiles. Variables ending in `_flag` use
+nearest-neighbour sampling so boolean diagnostics remain `0.0` or `1.0`. Intervals containing a
+non-finite diagnostic sentinel also use the nearest endpoint instead of producing `NaN`.
+Comparison results can be exported as CSV:
 
 ```java
 String comparisonCsv = TwoFluidPipeReport.toComparisonCsv(comparison);

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -11,6 +11,7 @@ import neqsim.process.equipment.pipeline.twophasepipe.SlugTracker;
 import neqsim.process.equipment.pipeline.twophasepipe.ThermodynamicCoupling;
 import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidConservationEquations;
 import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidSection;
+import neqsim.process.equipment.pipeline.twophasepipe.closure.OilWaterFlowRegimeDetector.OilWaterFlowRegime;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.ConservativeStateLimiter;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.TimeIntegrator;
 import neqsim.process.equipment.stream.StreamInterface;
@@ -4743,6 +4744,123 @@ public class TwoFluidPipe extends Pipeline {
       regimes[i] = sections[i].getFlowRegime();
     }
     return regimes;
+  }
+
+  /**
+   * Get oil-water flow regime at each section.
+   *
+   * @return oil-water flow regime profile; an entry is {@code null} when the closure has not been evaluated
+   */
+  public OilWaterFlowRegime[] getOilWaterFlowRegimeProfile() {
+    if (sections == null) {
+      return new OilWaterFlowRegime[0];
+    }
+    OilWaterFlowRegime[] regimes = new OilWaterFlowRegime[numberOfSections];
+    for (int i = 0; i < numberOfSections; i++) {
+      regimes[i] = sections[i].getOilWaterFlowRegime();
+    }
+    return regimes;
+  }
+
+  /**
+   * Get the water-wetting diagnostic at each section.
+   *
+   * @return water-wetting flags for corrosion screening
+   */
+  public boolean[] getWaterWettingProfile() {
+    if (sections == null) {
+      return new boolean[0];
+    }
+    boolean[] profile = new boolean[numberOfSections];
+    for (int i = 0; i < numberOfSections; i++) {
+      profile[i] = sections[i].isWaterWetting();
+    }
+    return profile;
+  }
+
+  /**
+   * Get the water-dropout diagnostic at each section.
+   *
+   * @return water-dropout risk flags
+   */
+  public boolean[] getWaterDropoutRiskProfile() {
+    if (sections == null) {
+      return new boolean[0];
+    }
+    boolean[] profile = new boolean[numberOfSections];
+    for (int i = 0; i < numberOfSections; i++) {
+      profile[i] = sections[i].isWaterDropoutRisk();
+    }
+    return profile;
+  }
+
+  /**
+   * Get estimated liquid entrainment fraction at each section.
+   *
+   * @return entrainment fraction profile, bounded from 0 to 1
+   */
+  public double[] getEntrainmentFractionProfile() {
+    if (sections == null) {
+      return new double[0];
+    }
+    double[] profile = new double[numberOfSections];
+    for (int i = 0; i < numberOfSections; i++) {
+      profile[i] = sections[i].getEntrainmentFraction();
+    }
+    return profile;
+  }
+
+  /**
+   * Get characteristic entrained droplet diameter at each section.
+   *
+   * @return entrained droplet diameter profile in metres
+   */
+  public double[] getEntrainedDropletDiameterProfile() {
+    if (sections == null) {
+      return new double[0];
+    }
+    double[] profile = new double[numberOfSections];
+    for (int i = 0; i < numberOfSections; i++) {
+      profile[i] = sections[i].getEntrainedDropletDiameter();
+    }
+    return profile;
+  }
+
+  /**
+   * Get the severe-slugging stability number at each section.
+   *
+   * <p>
+   * Values below 1 indicate elevated severe-slugging risk. Sections where the diagnostic is not applicable retain
+   * {@link Double#POSITIVE_INFINITY}.
+   * </p>
+   *
+   * @return severe-slugging stability-number profile
+   */
+  public double[] getSevereSluggingNumberProfile() {
+    if (sections == null) {
+      return new double[0];
+    }
+    double[] profile = new double[numberOfSections];
+    for (int i = 0; i < numberOfSections; i++) {
+      profile[i] = sections[i].getSevereSluggingNumber();
+    }
+    return profile;
+  }
+
+  /**
+   * Get the severe-slugging risk flag at each section.
+   *
+   * @return severe-slugging potential flags
+   */
+  public boolean[] getSevereSlugPotentialProfile() {
+    if (sections == null) {
+      return new boolean[0];
+    }
+    boolean[] profile = new boolean[numberOfSections];
+    for (int i = 0; i < numberOfSections; i++) {
+      profile[i] = sections[i].isSevereSlugPotential();
+    }
+    return profile;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReport.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReport.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import com.google.gson.GsonBuilder;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
 import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
+import neqsim.process.equipment.pipeline.twophasepipe.closure.OilWaterFlowRegimeDetector.OilWaterFlowRegime;
 import neqsim.process.equipment.pipeline.twophasepipe.validation.TwoFluidBenchmarkHarness;
 
 /**
@@ -38,6 +39,13 @@ public final class TwoFluidPipeReport {
     private final double[] oilVelocity;
     private final double[] waterVelocity;
     private final FlowRegime[] flowRegime;
+    private final OilWaterFlowRegime[] oilWaterFlowRegime;
+    private final boolean[] waterWetting;
+    private final boolean[] waterDropoutRisk;
+    private final double[] entrainmentFraction;
+    private final double[] entrainedDropletDiameter;
+    private final double[] severeSluggingNumber;
+    private final boolean[] severeSlugPotential;
 
     private ProfileSnapshot(TwoFluidPipe pipe) {
       this.timeSeconds = pipe.getSimulationTime();
@@ -53,6 +61,13 @@ public final class TwoFluidPipeReport {
       this.oilVelocity = pipe.getOilVelocityProfile();
       this.waterVelocity = pipe.getWaterVelocityProfile();
       this.flowRegime = pipe.getFlowRegimeProfile();
+      this.oilWaterFlowRegime = pipe.getOilWaterFlowRegimeProfile();
+      this.waterWetting = pipe.getWaterWettingProfile();
+      this.waterDropoutRisk = pipe.getWaterDropoutRiskProfile();
+      this.entrainmentFraction = pipe.getEntrainmentFractionProfile();
+      this.entrainedDropletDiameter = pipe.getEntrainedDropletDiameterProfile();
+      this.severeSluggingNumber = pipe.getSevereSluggingNumberProfile();
+      this.severeSlugPotential = pipe.getSevereSlugPotentialProfile();
     }
 
     public double getTimeSeconds() {
@@ -235,7 +250,9 @@ public final class TwoFluidPipeReport {
     }
     csv.append("position_m,pressure_bara,temperature_C,liquid_holdup,water_cut,oil_holdup,")
         .append("water_holdup,gas_velocity_m_s,liquid_velocity_m_s,oil_velocity_m_s,")
-        .append("water_velocity_m_s,flow_regime\n");
+        .append("water_velocity_m_s,flow_regime,oil_water_flow_regime,water_wetting,")
+        .append("water_dropout_risk,entrainment_fraction,entrained_droplet_diameter_m,")
+        .append("severe_slugging_number,severe_slug_potential\n");
 
     for (int i = 0; i < snapshot.positionMeters.length; i++) {
       if (includeTime) {
@@ -250,7 +267,16 @@ public final class TwoFluidPipeReport {
           .append(format(valueAt(snapshot.oilVelocity, i))).append(',')
           .append(format(valueAt(snapshot.waterVelocity, i))).append(',')
           .append(snapshot.flowRegime.length > i && snapshot.flowRegime[i] != null ? snapshot.flowRegime[i].name() : "")
-          .append('\n');
+          .append(',')
+          .append(snapshot.oilWaterFlowRegime.length > i && snapshot.oilWaterFlowRegime[i] != null
+              ? snapshot.oilWaterFlowRegime[i].name()
+              : "")
+          .append(',').append(valueAt(snapshot.waterWetting, i)).append(',')
+          .append(valueAt(snapshot.waterDropoutRisk, i)).append(',')
+          .append(format(valueAt(snapshot.entrainmentFraction, i))).append(',')
+          .append(format(valueAt(snapshot.entrainedDropletDiameter, i))).append(',')
+          .append(format(valueAt(snapshot.severeSluggingNumber, i))).append(',')
+          .append(valueAt(snapshot.severeSlugPotential, i)).append('\n');
     }
     return csv.toString();
   }
@@ -264,6 +290,10 @@ public final class TwoFluidPipeReport {
 
   private static double valueAt(double[] values, int index) {
     return values.length > index ? values[index] : Double.NaN;
+  }
+
+  private static boolean valueAt(boolean[] values, int index) {
+    return values.length > index && values[index];
   }
 
   private static String csvRow(String type, Object position, double value, String unit, String description) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
@@ -78,6 +78,12 @@ public final class TwoFluidBenchmarkHarness {
     variables.put("liquid_velocity_m_s", pipe.getLiquidVelocityProfile());
     variables.put("oil_velocity_m_s", pipe.getOilVelocityProfile());
     variables.put("water_velocity_m_s", pipe.getWaterVelocityProfile());
+    variables.put("entrainment_fraction", pipe.getEntrainmentFractionProfile());
+    variables.put("entrained_droplet_diameter_m", pipe.getEntrainedDropletDiameterProfile());
+    variables.put("severe_slugging_number", pipe.getSevereSluggingNumberProfile());
+    variables.put("water_wetting_flag", toDouble(pipe.getWaterWettingProfile()));
+    variables.put("water_dropout_risk_flag", toDouble(pipe.getWaterDropoutRiskProfile()));
+    variables.put("severe_slug_potential_flag", toDouble(pipe.getSevereSlugPotentialProfile()));
     return new Snapshot(pipe.getSimulationTime(), pipe.getPositionProfile(), variables);
   }
 
@@ -179,6 +185,14 @@ public final class TwoFluidBenchmarkHarness {
       scaled[i] = values[i] * factor;
     }
     return scaled;
+  }
+
+  private static double[] toDouble(boolean[] values) {
+    double[] numeric = new double[values.length];
+    for (int i = 0; i < values.length; i++) {
+      numeric[i] = values[i] ? 1.0 : 0.0;
+    }
+    return numeric;
   }
 
   /** One reference sample from an external simulator or field data set. */

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
@@ -99,7 +99,13 @@ public final class TwoFluidBenchmarkHarness {
   }
 
   /**
-   * Compare transient snapshots against benchmark points using linear interpolation in time and position.
+   * Compare transient snapshots against benchmark points.
+   *
+   * <p>
+   * Continuous profiles use linear interpolation in time and position. Variables ending in {@code _flag} use
+   * nearest-neighbour sampling so boolean indicators remain binary. Intervals with a non-finite endpoint also use
+   * nearest-neighbour sampling to preserve diagnostic sentinels without producing {@link Double#NaN}.
+   * </p>
    *
    * @param snapshots model snapshots
    * @param referencePoints reference points
@@ -147,7 +153,24 @@ public final class TwoFluidBenchmarkHarness {
 
     double fraction = (point.getTimeSeconds() - lower.getTimeSeconds()) / dt;
     fraction = Math.max(0.0, Math.min(1.0, fraction));
+    return interpolateValues(lowerValue, upperValue, fraction, isDiscreteVariable(point.getVariable()));
+  }
+
+  private static double interpolateValues(double lowerValue, double upperValue, double fraction, boolean discrete) {
+    if (fraction <= 0.0) {
+      return lowerValue;
+    }
+    if (fraction >= 1.0) {
+      return upperValue;
+    }
+    if (discrete || !Double.isFinite(lowerValue) || !Double.isFinite(upperValue)) {
+      return fraction < 0.5 ? lowerValue : upperValue;
+    }
     return lowerValue + fraction * (upperValue - lowerValue);
+  }
+
+  private static boolean isDiscreteVariable(String variable) {
+    return normalize(variable).endsWith("_flag");
   }
 
   private static Map<String, Integer> parseHeader(String line) {
@@ -285,7 +308,8 @@ public final class TwoFluidBenchmarkHarness {
     }
 
     public double valueAt(String variable, double positionMeters) {
-      double[] values = variables.get(normalize(variable));
+      String normalizedVariable = normalize(variable);
+      double[] values = variables.get(normalizedVariable);
       if (values == null || values.length == 0) {
         throw new IllegalArgumentException("No model profile for variable: " + variable);
       }
@@ -293,10 +317,10 @@ public final class TwoFluidBenchmarkHarness {
         throw new IllegalArgumentException("Position and value profile lengths differ for " + variable + ": "
             + positionsMeters.length + " vs " + values.length);
       }
-      return interpolatePosition(positionMeters, positionsMeters, values);
+      return interpolatePosition(positionMeters, positionsMeters, values, isDiscreteVariable(normalizedVariable));
     }
 
-    private double interpolatePosition(double x, double[] positions, double[] values) {
+    private double interpolatePosition(double x, double[] positions, double[] values, boolean discrete) {
       if (x <= positions[0]) {
         return values[0];
       }
@@ -311,7 +335,7 @@ public final class TwoFluidBenchmarkHarness {
             return values[i];
           }
           double fraction = (x - positions[i]) / dx;
-          return values[i] + fraction * (values[i + 1] - values[i]);
+          return interpolateValues(values[i], values[i + 1], fraction, discrete);
         }
       }
       return values[last];

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReportTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReportTest.java
@@ -28,7 +28,20 @@ class TwoFluidPipeReportTest {
     String steadyCsv = TwoFluidPipeReport.toSteadyStateProfileCsv(pipe);
     assertTrue(steadyCsv.startsWith("position_m,pressure_bara,temperature_C"));
     assertTrue(steadyCsv.contains("flow_regime"));
+    assertTrue(steadyCsv.contains("entrainment_fraction"));
+    assertTrue(steadyCsv.contains("severe_slugging_number"));
     assertEquals(pipe.getPositionProfile().length + 1, steadyCsv.split("\\R").length);
+
+    int sectionCount = pipe.getPositionProfile().length;
+    assertEquals(sectionCount, pipe.getOilWaterFlowRegimeProfile().length);
+    assertEquals(sectionCount, pipe.getWaterWettingProfile().length);
+    assertEquals(sectionCount, pipe.getWaterDropoutRiskProfile().length);
+    assertEquals(sectionCount, pipe.getEntrainmentFractionProfile().length);
+    assertEquals(sectionCount, pipe.getEntrainedDropletDiameterProfile().length);
+    assertEquals(sectionCount, pipe.getSevereSluggingNumberProfile().length);
+    assertEquals(sectionCount, pipe.getSevereSlugPotentialProfile().length);
+    assertTrue(Arrays.stream(pipe.getEntrainmentFractionProfile()).allMatch(value -> value >= 0.0 && value <= 1.0));
+    assertTrue(Arrays.stream(pipe.getEntrainedDropletDiameterProfile()).allMatch(value -> value >= 0.0));
 
     List<TwoFluidPipeReport.ProfileSnapshot> snapshots = TwoFluidPipeReport.newSnapshotList();
     snapshots.add(TwoFluidPipeReport.capture(pipe));

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarnessTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarnessTest.java
@@ -76,6 +76,52 @@ class TwoFluidBenchmarkHarnessTest {
     assertTrue(comparison.isPassed(), comparison.failureSummary());
   }
 
+  @Test
+  void testKeepsFlagInterpolationBinary() {
+    Snapshot t0 = new Snapshot(0.0, new double[] { 0.0, 100.0 },
+        java.util.Collections.singletonMap("water_wetting_flag", new double[] { 0.0, 1.0 }));
+    Snapshot t10 = new Snapshot(10.0, new double[] { 0.0, 100.0 },
+        java.util.Collections.singletonMap("water_wetting_flag", new double[] { 1.0, 0.0 }));
+    List<BenchmarkPoint> points = Arrays.asList(
+        new BenchmarkPoint("early", 2.0, 75.0, "water_wetting_flag", 1.0, 0.0, 0.0, "unit"),
+        new BenchmarkPoint("late", 8.0, 75.0, "water_wetting_flag", 0.0, 0.0, 0.0, "unit"));
+
+    Comparison comparison = TwoFluidBenchmarkHarness.compare(Arrays.asList(t10, t0), points);
+
+    assertTrue(comparison.isPassed(), comparison.failureSummary());
+    assertEquals(1.0, comparison.getRows().get(0).getModelValue(), 0.0);
+    assertEquals(0.0, comparison.getRows().get(1).getModelValue(), 0.0);
+  }
+
+  @Test
+  void testPreservesNonFiniteSentinelsDuringInterpolation() {
+    Snapshot spatial = new Snapshot(0.0, new double[] { 0.0, 100.0 },
+        java.util.Collections.singletonMap("severe_slugging_number",
+            new double[] { Double.POSITIVE_INFINITY, 2.0 }));
+
+    assertTrue(Double.isInfinite(spatial.valueAt("severe_slugging_number", 25.0)));
+    assertEquals(2.0, spatial.valueAt("severe_slugging_number", 75.0), 0.0);
+
+    Snapshot t0 = new Snapshot(0.0, new double[] { 0.0 },
+        java.util.Collections.singletonMap("severe_slugging_number",
+            new double[] { Double.POSITIVE_INFINITY }));
+    Snapshot t10 = new Snapshot(10.0, new double[] { 0.0 },
+        java.util.Collections.singletonMap("severe_slugging_number", new double[] { 2.0 }));
+    BenchmarkPoint earlyPoint =
+        new BenchmarkPoint("early", 2.0, 0.0, "severe_slugging_number", 0.0, 0.0, 0.0, "unit");
+    BenchmarkPoint latePoint =
+        new BenchmarkPoint("late", 8.0, 0.0, "severe_slugging_number", 2.0, 0.0, 0.0, "unit");
+
+    Comparison early =
+        TwoFluidBenchmarkHarness.compare(Arrays.asList(t0, t10), java.util.Collections.singletonList(earlyPoint));
+    Comparison late =
+        TwoFluidBenchmarkHarness.compare(Arrays.asList(t0, t10), java.util.Collections.singletonList(latePoint));
+
+    assertTrue(Double.isInfinite(early.getRows().get(0).getModelValue()));
+    assertTrue(late.isPassed(), late.failureSummary());
+    assertEquals(2.0, late.getRows().get(0).getModelValue(), 0.0);
+  }
+
   private TwoFluidPipe createSolvedWetGasPipe() {
     SystemInterface fluid = new SystemSrkEos(273.15 + 35.0, 60.0);
     fluid.addComponent("methane", 0.92);

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarnessTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarnessTest.java
@@ -96,26 +96,22 @@ class TwoFluidBenchmarkHarnessTest {
   @Test
   void testPreservesNonFiniteSentinelsDuringInterpolation() {
     Snapshot spatial = new Snapshot(0.0, new double[] { 0.0, 100.0 },
-        java.util.Collections.singletonMap("severe_slugging_number",
-            new double[] { Double.POSITIVE_INFINITY, 2.0 }));
+        java.util.Collections.singletonMap("severe_slugging_number", new double[] { Double.POSITIVE_INFINITY, 2.0 }));
 
     assertTrue(Double.isInfinite(spatial.valueAt("severe_slugging_number", 25.0)));
     assertEquals(2.0, spatial.valueAt("severe_slugging_number", 75.0), 0.0);
 
     Snapshot t0 = new Snapshot(0.0, new double[] { 0.0 },
-        java.util.Collections.singletonMap("severe_slugging_number",
-            new double[] { Double.POSITIVE_INFINITY }));
+        java.util.Collections.singletonMap("severe_slugging_number", new double[] { Double.POSITIVE_INFINITY }));
     Snapshot t10 = new Snapshot(10.0, new double[] { 0.0 },
         java.util.Collections.singletonMap("severe_slugging_number", new double[] { 2.0 }));
-    BenchmarkPoint earlyPoint =
-        new BenchmarkPoint("early", 2.0, 0.0, "severe_slugging_number", 0.0, 0.0, 0.0, "unit");
-    BenchmarkPoint latePoint =
-        new BenchmarkPoint("late", 8.0, 0.0, "severe_slugging_number", 2.0, 0.0, 0.0, "unit");
+    BenchmarkPoint earlyPoint = new BenchmarkPoint("early", 2.0, 0.0, "severe_slugging_number", 0.0, 0.0, 0.0, "unit");
+    BenchmarkPoint latePoint = new BenchmarkPoint("late", 8.0, 0.0, "severe_slugging_number", 2.0, 0.0, 0.0, "unit");
 
-    Comparison early =
-        TwoFluidBenchmarkHarness.compare(Arrays.asList(t0, t10), java.util.Collections.singletonList(earlyPoint));
-    Comparison late =
-        TwoFluidBenchmarkHarness.compare(Arrays.asList(t0, t10), java.util.Collections.singletonList(latePoint));
+    Comparison early = TwoFluidBenchmarkHarness.compare(Arrays.asList(t0, t10),
+        java.util.Collections.singletonList(earlyPoint));
+    Comparison late = TwoFluidBenchmarkHarness.compare(Arrays.asList(t0, t10),
+        java.util.Collections.singletonList(latePoint));
 
     assertTrue(Double.isInfinite(early.getRows().get(0).getModelValue()));
     assertTrue(late.isPassed(), late.failureSummary());

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarnessTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarnessTest.java
@@ -36,6 +36,13 @@ class TwoFluidBenchmarkHarnessTest {
     TwoFluidPipe pipe = createSolvedWetGasPipe();
     Snapshot snapshot = TwoFluidBenchmarkHarness.capture(pipe);
 
+    assertTrue(snapshot.getAvailableVariables().contains("entrainment_fraction"));
+    assertTrue(snapshot.getAvailableVariables().contains("entrained_droplet_diameter_m"));
+    assertTrue(snapshot.getAvailableVariables().contains("severe_slugging_number"));
+    assertTrue(snapshot.getAvailableVariables().contains("water_wetting_flag"));
+    assertTrue(snapshot.getAvailableVariables().contains("water_dropout_risk_flag"));
+    assertTrue(snapshot.getAvailableVariables().contains("severe_slug_potential_flag"));
+
     double inletPressure = pipe.getPressureProfile()[0] * 1e-5;
     double outletPressure = pipe.getPressureProfile()[pipe.getPressureProfile().length - 1] * 1e-5;
     double averageHoldup = Arrays.stream(pipe.getLiquidHoldupProfile()).average()
@@ -45,7 +52,9 @@ class TwoFluidBenchmarkHarnessTest {
             "generated"),
         new BenchmarkPoint("fixture", 0.0, pipe.getPositionProfile()[pipe.getPositionProfile().length - 1],
             "pressure_bara", outletPressure, 0.05, 0.001, "generated"),
-        new BenchmarkPoint("fixture", 0.0, 500.0, "liquid_holdup", averageHoldup, 0.20, 1.0, "generated"));
+        new BenchmarkPoint("fixture", 0.0, 500.0, "liquid_holdup", averageHoldup, 0.20, 1.0, "generated"),
+        new BenchmarkPoint("fixture", 0.0, pipe.getPositionProfile()[0], "entrainment_fraction",
+            pipe.getEntrainmentFractionProfile()[0], 1.0e-12, 0.0, "generated"));
 
     Comparison comparison = TwoFluidBenchmarkHarness.compare(snapshot, reference);
 


### PR DESCRIPTION
## Summary

- expose oil-water regime, water-wetting/dropout, entrainment, droplet-size, and severe-slugging profiles directly from `TwoFluidPipe`
- append the diagnostics to steady-state and transient `TwoFluidPipeReport` CSV exports
- capture numeric closure diagnostics and risk flags in `TwoFluidBenchmarkHarness`
- keep `*_flag` comparisons binary and preserve non-finite diagnostic sentinels during interpolation
- document the API and add focused report/benchmark coverage

## API additions

- `getOilWaterFlowRegimeProfile()`
- `getWaterWettingProfile()`
- `getWaterDropoutRiskProfile()`
- `getEntrainmentFractionProfile()`
- `getEntrainedDropletDiameterProfile()`
- `getSevereSluggingNumberProfile()`
- `getSevereSlugPotentialProfile()`

## Benchmark variable additions

- `entrainment_fraction`
- `entrained_droplet_diameter_m`
- `severe_slugging_number`
- `water_wetting_flag`
- `water_dropout_risk_flag`
- `severe_slug_potential_flag`

Boolean benchmark profiles use 1.0/0.0 and nearest-neighbour sampling in position and time. Continuous finite profiles retain linear interpolation. Intervals containing a non-finite diagnostic sentinel use the nearest endpoint rather than generating `NaN`. The categorical oil-water regime is exported in report CSV but intentionally is not encoded as an unstable numeric enum ordinal.

## Compatibility

The Java API changes are additive. Existing steady-state and transient CSV columns keep their order, with the new diagnostic columns appended. Existing continuous benchmark interpolation is unchanged.

## Documentation impact

Updated `docs/wiki/two_fluid_reporting_and_validation.md` and `CHANGELOG_AGENT_NOTES.md` with the new APIs, report variables, and interpolation semantics.

## Validation

- [x] `git diff --check` on the original implementation
- [x] focused JUnit coverage added for profile dimensions, physical bounds, CSV columns, benchmark capture, continuous interpolation, binary flag sampling, and non-finite sentinel handling
- [x] changed Java sources parsed successfully and deterministic interpolation smoke checks passed locally
- [x] hosted Maven tests, Spotless, Javadocs, CodeQL, documentation, pre-commit, PaperLab, and the full Java 8/21 Linux/Windows matrix passed on head `ccfb6694`
