### PR TITLE
fix: respect transient dependency levels

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -27,10 +27,14 @@ historian tag mapping, and event schedule before running `runTransient`.
 
 NeqSim dynamic simulation uses the `runTransient(double dt)` method on `ProcessSystem`.
 Each timestep:
-1. All measurement devices read current values
-2. All controllers calculate new outputs
-3. All equipment updates for the timestep
-4. Flash calculations update thermodynamic state
+1. Flowsheet-wide settings and setter units are applied.
+2. Simulation time advances, then due events and field inputs are applied.
+3. Equipment updates, including its thermodynamic calculations, run in insertion
+   order or dependency-aware graph levels when parallel transient execution is
+   enabled.
+4. Standalone controllers run; equipment-embedded controllers retain their
+   equipment-specific execution timing for compatibility.
+5. Measurement devices are sampled, alarms are evaluated, and history is stored.
 
 ## Basic Dynamic Setup
 
@@ -384,12 +388,15 @@ For large flowsheets with independent branches, enable
 `process.setParallelTransientEnabled(true)` and set the maximum worker count
 with `process.setTransientThreadPoolSize(n)`. The per-process worker pool is
 created lazily and reused across timesteps; changing the worker count or
-disabling the option retires it. If the caller is interrupted while waiting,
-NeqSim restores the interrupt status, cancels queued work without interrupting
-equipment already updating state, and aborts the remaining timestep phases.
-Treat that timestep as incomplete. Keep parallel execution off for tightly
-coupled sequential equipment or recycle loops unless their transient
-dependencies have been verified.
+disabling the option retires it. Execution follows cached process-graph levels,
+so upstream groups complete before downstream equipment is submitted while
+independent groups within a level remain parallel. If the caller is interrupted
+while waiting, NeqSim restores the interrupt status, cancels queued work without
+interrupting equipment already updating state, does not submit downstream
+levels, and aborts the remaining timestep phases. Treat that timestep as
+incomplete. Graph ordering does not define transient recycle convergence or
+rollback, so keep parallel execution off for recycle loops and other implicit
+couplings until their transient contract is explicitly supported.
 
 ## Python Dynamic Simulation
 

--- a/docs/development/TASK_LOG.md
+++ b/docs/development/TASK_LOG.md
@@ -36,12 +36,6 @@ requirement`, or `confidential compressor route`.
 
 <!-- Add new entries at the top. Most recent first. -->
 
-### 2026-07-30 — Reuse parallel transient workers across timesteps
-**Type:** E (Feature)
-**Keywords:** dynamic simulation, runTransient, ProcessSystem, parallel transient, executor reuse, thread pool, scalability
-**Solution:** `ProcessSystem` now owns a lazy reusable transient executor; regression coverage is in `ProcessSystemParallelTransientTest`, with behavior documented in `docs/process/dynamic-simulation-enhancements.md`.
-**Notes:** The prior implementation created and destroyed a fixed thread pool on every transient step. An isolated 8-unit, 200-step orchestration baseline with two configured workers completed all 1600 unit executions but created 400 distinct worker threads; the reusable executor reduced that stable scheduling metric to 2. The pool is transient model runtime state, uses daemon workers with a 60-second idle timeout, and is retired when parallel execution is disabled or its size changes. Parallel transient execution remains opt-in and suitable only when equipment dependencies permit concurrent execution.
-
 ### 2026-07-16 — Historical FeS wall inventory to elemental-sulfur compressor deposition
 **Type:** E (Feature) / B (Process)
 **Keywords:** iron sulfide, FeS, mackinawite, pyrrhotite, siderite, FeCO3, carbon steel, seawater, oxygen ingress, nitrogen purge, elemental sulfur, S8, wall inventory, compressor deposit, entrained condensate, warm shaft

--- a/docs/development/TASK_LOG.md
+++ b/docs/development/TASK_LOG.md
@@ -36,6 +36,12 @@ requirement`, or `confidential compressor route`.
 
 <!-- Add new entries at the top. Most recent first. -->
 
+### 2026-07-30 — Reuse parallel transient workers across timesteps
+**Type:** E (Feature)
+**Keywords:** dynamic simulation, runTransient, ProcessSystem, parallel transient, executor reuse, thread pool, scalability
+**Solution:** `ProcessSystem` now owns a lazy reusable transient executor; regression coverage is in `ProcessSystemParallelTransientTest`, with behavior documented in `docs/process/dynamic-simulation-enhancements.md`.
+**Notes:** The prior implementation created and destroyed a fixed thread pool on every transient step. An isolated 8-unit, 200-step orchestration baseline with two configured workers completed all 1600 unit executions but created 400 distinct worker threads; the reusable executor reduced that stable scheduling metric to 2. The pool is transient model runtime state, uses daemon workers with a 60-second idle timeout, and is retired when parallel execution is disabled or its size changes. Parallel transient execution remains opt-in and suitable only when equipment dependencies permit concurrent execution.
+
 ### 2026-07-16 — Historical FeS wall inventory to elemental-sulfur compressor deposition
 **Type:** E (Feature) / B (Process)
 **Keywords:** iron sulfide, FeS, mackinawite, pyrrhotite, siderite, FeCO3, carbon steel, seawater, oxygen ingress, nitrogen purge, elemental sulfur, S8, wall inventory, compressor deposit, entrained condensate, warm shaft

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -542,19 +542,30 @@ allows idle daemon workers to time out after 60 seconds. Changing
 retires the existing pool. This avoids creating and destroying a complete
 thread pool for every timestep in long dynamic studies.
 
+Parallel transient execution uses the same cached process graph as steady-state
+parallel execution. Equipment is partitioned into topological levels: all
+upstream groups in one level finish before downstream equipment is submitted,
+while independent groups in the same level can use separate workers. Groups
+that must share mutable inlet state execute sequentially within one worker.
+This prevents a downstream unit from observing a partially updated upstream
+stream merely because both units were submitted in the same timestep.
+
 If the thread calling `runTransient(...)` is interrupted while waiting for
 parallel equipment, NeqSim restores the caller's interrupt status and stops
-waiting. Later parallel passes in the same timestep observe that status and do
-not submit additional equipment work. Queued futures are cancelled without
-interrupting equipment already updating state. Because those running updates
-are not transactionally interruptible, NeqSim aborts the remaining controller,
-measurement, result-storage, and event-publication phases for that timestep.
-Callers should still treat an interrupted timestep as incomplete rather than as
-an atomic rollback.
+waiting. No downstream level is submitted. Later parallel passes in the same
+timestep observe that status and do not submit additional equipment work.
+Queued futures are cancelled without interrupting equipment already updating
+state. Because those running updates are not transactionally interruptible,
+NeqSim aborts the remaining controller, measurement, result-storage, and
+event-publication phases for that timestep. Callers should still treat an
+interrupted timestep as incomplete rather than as an atomic rollback.
 
 **Note:** Parallel execution is beneficial for flowsheets with many independent
-equipment units. For small flowsheets or tightly coupled equipment (recycles),
-the overhead may outweigh the benefit.
+branches. Topological ordering covers feed-forward stream dependencies, but it
+does not define iteration or rollback for recycle loops and other implicit
+couplings. Keep the option disabled for those cases until their transient
+convergence contract is explicitly supported. For small flowsheets, the
+scheduling overhead may also outweigh the benefit.
 
 ### 5.3 Integration Methods
 
@@ -576,13 +587,15 @@ process.setIntegrationMethod(IntegrationMethod.RUNGE_KUTTA_4);    // Higher-orde
 
 ## 6. Test Coverage
 
-All features are covered by three test classes with 59 total tests:
+The features in this guide are covered by four focused test classes with 67
+total tests:
 
 | Test Class | Tests | Coverage |
 |-----------|-------|----------|
 | `DynamicImprovementsTest` | 17 | Controller modes, 2-DOF PID, SFC, control structures, gain scheduling, event logging, performance metrics |
 | `DynamicImprovementsPhase2Test` | 26 | Sensor faults, valve nonlinearities, adaptive timestep, parallel transient, integration methods, JSON process builder |
 | `DynamicImprovementsPhase3Test` | 16 | Transmitter filter, alarm shelving, separator internals, HX thermal model, distillation MESH dynamics |
+| `ProcessSystemParallelTransientTest` | 8 | Worker reuse, copy lifecycle, dependency ordering, independent-level concurrency, and interruption behavior |
 
 Run all tests:
 

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -587,20 +587,20 @@ process.setIntegrationMethod(IntegrationMethod.RUNGE_KUTTA_4);    // Higher-orde
 
 ## 6. Test Coverage
 
-The features in this guide are covered by four focused test classes with 68
+The features in this guide are covered by four focused test classes with 69
 total tests:
 
 | Test Class | Tests | Coverage |
 |-----------|-------|----------|
 | `DynamicImprovementsTest` | 17 | Controller modes, 2-DOF PID, SFC, control structures, gain scheduling, event logging, performance metrics |
-| `DynamicImprovementsPhase2Test` | 26 | Sensor faults, valve nonlinearities, adaptive timestep, parallel transient, integration methods, JSON process builder |
+| `DynamicImprovementsPhase2Test` | 27 | Sensor faults, valve nonlinearities, adaptive timestep, parallel transient, integration methods, JSON process builder |
 | `DynamicImprovementsPhase3Test` | 16 | Transmitter filter, alarm shelving, separator internals, HX thermal model, distillation MESH dynamics |
 | `ProcessSystemParallelTransientTest` | 9 | Worker reuse, copy lifecycle, dependency ordering, independent-level concurrency, and interruption behavior at waits and level boundaries |
 
 Run all tests:
 
 ```bash
-./mvnw test -Dtest=DynamicImprovementsTest,DynamicImprovementsPhase2Test,DynamicImprovementsPhase3Test
+./mvnw test -Dtest=DynamicImprovementsTest,DynamicImprovementsPhase2Test,DynamicImprovementsPhase3Test,ProcessSystemParallelTransientTest
 ```
 
 ---

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -587,7 +587,7 @@ process.setIntegrationMethod(IntegrationMethod.RUNGE_KUTTA_4);    // Higher-orde
 
 ## 6. Test Coverage
 
-The features in this guide are covered by four focused test classes with 67
+The features in this guide are covered by four focused test classes with 68
 total tests:
 
 | Test Class | Tests | Coverage |
@@ -595,7 +595,7 @@ total tests:
 | `DynamicImprovementsTest` | 17 | Controller modes, 2-DOF PID, SFC, control structures, gain scheduling, event logging, performance metrics |
 | `DynamicImprovementsPhase2Test` | 26 | Sensor faults, valve nonlinearities, adaptive timestep, parallel transient, integration methods, JSON process builder |
 | `DynamicImprovementsPhase3Test` | 16 | Transmitter filter, alarm shelving, separator internals, HX thermal model, distillation MESH dynamics |
-| `ProcessSystemParallelTransientTest` | 8 | Worker reuse, copy lifecycle, dependency ordering, independent-level concurrency, and interruption behavior |
+| `ProcessSystemParallelTransientTest` | 9 | Worker reuse, copy lifecycle, dependency ordering, independent-level concurrency, and interruption behavior at waits and level boundaries |
 
 Run all tests:
 

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -11,6 +11,7 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -27,6 +28,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1739,7 +1741,14 @@ public class ProcessSystem extends SimulationBaseClass {
           singleGroup.add(level);
           plan.add(singleGroup);
         } else {
-          plan.add(groupNodesBySharedInputStreams(level));
+          List<List<ProcessNode>> groups = groupNodesBySharedInputStreams(level);
+          Collections.sort(groups, new Comparator<List<ProcessNode>>() {
+            @Override
+            public int compare(List<ProcessNode> left, List<ProcessNode> right) {
+              return Integer.compare(left.get(0).getIndex(), right.get(0).getIndex());
+            }
+          });
+          plan.add(groups);
         }
       }
       cachedParallelPlan = plan;
@@ -4167,11 +4176,11 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Runs all equipment transient calculations in parallel using an ExecutorService. Each equipment unit is submitted as
-   * an independent task. This is suitable when equipment units are loosely coupled (no data dependencies within a
-   * single timestep). If the caller is interrupted while waiting, its interrupt status is restored and the wait loop
-   * stops. A subsequent pass observes that status and returns without submitting more tasks. Already submitted
-   * equipment that is queued is cancelled without interrupting tasks already updating state.
+   * Runs transient calculations in dependency order using the cached process-graph levels. Independent groups within a
+   * level execute in parallel; a downstream level is not submitted until every upstream group has completed. If the
+   * caller is interrupted while waiting, its interrupt status is restored and the wait loop stops. A subsequent pass
+   * observes that status and returns without submitting more tasks. Already submitted equipment that is queued is
+   * cancelled without interrupting tasks already updating state.
    *
    * @param dt time step in seconds
    * @param id calculation identifier
@@ -4183,32 +4192,45 @@ public class ProcessSystem extends SimulationBaseClass {
       return false;
     }
     ExecutorService executor = getParallelTransientExecutor();
-    List<Future<?>> futures = new ArrayList<Future<?>>(unitOperations.size());
-    for (int i = 0; i < unitOperations.size(); i++) {
-      final ProcessEquipmentInterface unit = unitOperations.get(i);
-      final double stepSize = dt;
-      final UUID calcId = id;
-      futures.add(executor.submit(new Runnable() {
-        @Override
-        public void run() {
-          runUnitTransientSkippingInactive(unit, stepSize, calcId);
+    final AtomicBoolean stopRequested = new AtomicBoolean(false);
+    for (List<List<ProcessNode>> levelGroups : getCachedParallelPlan()) {
+      List<Future<?>> futures = new ArrayList<Future<?>>(levelGroups.size());
+      for (List<ProcessNode> group : levelGroups) {
+        final List<ProcessNode> groupToRun = group;
+        final double stepSize = dt;
+        final UUID calcId = id;
+        futures.add(executor.submit(new Runnable() {
+          @Override
+          public void run() {
+            for (ProcessNode node : groupToRun) {
+              if (stopRequested.get()) {
+                return;
+              }
+              try {
+                runUnitTransientSkippingInactive(node.getEquipment(), stepSize, calcId);
+              } catch (Exception ex) {
+                logger.error("Parallel transient equipment execution failed for {}", node.getName(), ex);
+              }
+            }
+          }
+        }));
+      }
+      for (int i = 0; i < futures.size(); i++) {
+        Future<?> f = futures.get(i);
+        try {
+          f.get();
+        } catch (InterruptedException ex) {
+          stopRequested.set(true);
+          Thread.currentThread().interrupt();
+          for (int pendingIndex = i; pendingIndex < futures.size(); pendingIndex++) {
+            futures.get(pendingIndex).cancel(false);
+          }
+          logger.warn("Parallel transient execution interrupted; caller interrupt status restored");
+          return false;
+        } catch (ExecutionException ex) {
+          Throwable cause = ex.getCause();
+          logger.error("Parallel transient equipment execution failed", cause == null ? ex : cause);
         }
-      }));
-    }
-    for (int i = 0; i < futures.size(); i++) {
-      Future<?> f = futures.get(i);
-      try {
-        f.get();
-      } catch (InterruptedException ex) {
-        Thread.currentThread().interrupt();
-        for (int pendingIndex = i; pendingIndex < futures.size(); pendingIndex++) {
-          futures.get(pendingIndex).cancel(false);
-        }
-        logger.warn("Parallel transient execution interrupted; caller interrupt status restored");
-        return false;
-      } catch (ExecutionException ex) {
-        Throwable cause = ex.getCause();
-        logger.error("Parallel transient equipment execution failed", cause == null ? ex : cause);
       }
     }
     return true;
@@ -4627,8 +4649,10 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
-   * Enables or disables multi-threaded equipment execution during transient steps. Disabling the feature retires any
-   * reusable transient worker pool owned by this process system.
+   * Enables or disables multi-threaded equipment execution during transient steps. Stream dependencies are respected
+   * through process-graph level barriers, while independent groups in the same level may execute concurrently. Recycle
+   * and other iterative transient couplings still require separate convergence semantics. Disabling the feature retires
+   * any reusable transient worker pool owned by this process system.
    *
    * @param enabled true to enable parallel execution
    */

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4178,9 +4178,10 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Runs transient calculations in dependency order using the cached process-graph levels. Independent groups within a
    * level execute in parallel; a downstream level is not submitted until every upstream group has completed. If the
-   * caller is interrupted while waiting, its interrupt status is restored and the wait loop stops. A subsequent pass
-   * observes that status and returns without submitting more tasks. Already submitted equipment that is queued is
-   * cancelled without interrupting tasks already updating state.
+   * caller is interrupted while waiting, its interrupt status is restored and the wait loop stops. Each dependency
+   * level checks that status before submitting work, so an interrupt at a level boundary does not enqueue downstream
+   * equipment. Already submitted equipment that is queued is cancelled without interrupting tasks already updating
+   * state.
    *
    * @param dt time step in seconds
    * @param id calculation identifier
@@ -4194,6 +4195,11 @@ public class ProcessSystem extends SimulationBaseClass {
     ExecutorService executor = getParallelTransientExecutor();
     final AtomicBoolean stopRequested = new AtomicBoolean(false);
     for (List<List<ProcessNode>> levelGroups : getCachedParallelPlan()) {
+      if (Thread.currentThread().isInterrupted()) {
+        stopRequested.set(true);
+        logger.warn("Parallel transient execution stopped before submitting the next dependency level");
+        return false;
+      }
       List<Future<?>> futures = new ArrayList<Future<?>>(levelGroups.size());
       for (List<ProcessNode> group : levelGroups) {
         final List<ProcessNode> groupToRun = group;

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
@@ -11,8 +11,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -199,6 +201,58 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
       executionCount.incrementAndGet();
       started.countDown();
       setCalculationIdentifier(id);
+    }
+  }
+
+  /**
+   * Direct executor that interrupts the submitting thread after completing its first task. This creates a deterministic
+   * interruption at the barrier between two dependency levels.
+   */
+  private static final class InterruptAfterFirstTaskExecutor extends AbstractExecutorService {
+    private final AtomicBoolean interruptAfterNextTask = new AtomicBoolean(true);
+    private volatile boolean shutdown;
+
+    /** {@inheritDoc} */
+    @Override
+    public void shutdown() {
+      shutdown = true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public java.util.List<Runnable> shutdownNow() {
+      shutdown = true;
+      return Collections.emptyList();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isShutdown() {
+      return shutdown;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isTerminated() {
+      return shutdown;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return shutdown;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void execute(Runnable command) {
+      if (shutdown) {
+        throw new RejectedExecutionException("executor is shut down");
+      }
+      command.run();
+      if (interruptAfterNextTask.compareAndSet(true, false)) {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 
@@ -442,6 +496,42 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
   }
 
   /**
+   * An interrupt observed after one dependency level completes must prevent submission of downstream equipment.
+   *
+   * @throws Exception if the deterministic executor cannot be installed
+   */
+  @Test
+  public void interruptBetweenDependencyLevelsDoesNotSubmitDownstreamEquipment() throws Exception {
+    CountDownLatch upstreamStarted = new CountDownLatch(1);
+    CountDownLatch releaseUpstream = new CountDownLatch(0);
+    CountDownLatch downstreamStarted = new CountDownLatch(1);
+    AtomicBoolean upstreamCompleted = new AtomicBoolean();
+    AtomicBoolean downstreamObservedIncompleteUpstream = new AtomicBoolean();
+
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 20.0);
+    fluid.addComponent("methane", 1.0);
+    Stream feed = new Stream("feed", fluid);
+    BlockingHeater upstream = new BlockingHeater("upstream", feed, upstreamStarted, releaseUpstream, upstreamCompleted);
+    DependencyRecordingHeater downstream = new DependencyRecordingHeater("downstream", upstream.getOutletStream(),
+        upstreamCompleted, downstreamObservedIncompleteUpstream, downstreamStarted);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(upstream);
+    process.add(downstream);
+    process.setParallelTransientEnabled(true);
+    process.setTransientThreadPoolSize(1);
+    setParallelTransientExecutor(process, new InterruptAfterFirstTaskExecutor(), 1);
+
+    try {
+      process.runTransient(1.0, UUID.randomUUID());
+      assertTrue(Thread.currentThread().isInterrupted(), "Boundary interrupt status was not preserved");
+      assertEquals(1L, downstreamStarted.getCount(), "Downstream equipment was submitted after a boundary interrupt");
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  /**
    * Runtime worker pools must not participate in process serialization or copying.
    */
   @Test
@@ -645,5 +735,23 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
     Field field = ProcessSystem.class.getDeclaredField("parallelTransientExecutor");
     field.setAccessible(true);
     return (ExecutorService) field.get(process);
+  }
+
+  /**
+   * Installs a deterministic executor for level-boundary interruption testing.
+   *
+   * @param process process system to configure
+   * @param executor executor to install
+   * @param size configured executor size
+   * @throws Exception if reflection cannot access the private runtime fields
+   */
+  private static void setParallelTransientExecutor(ProcessSystem process, ExecutorService executor, int size)
+      throws Exception {
+    Field executorField = ProcessSystem.class.getDeclaredField("parallelTransientExecutor");
+    executorField.setAccessible(true);
+    executorField.set(process, executor);
+    Field sizeField = ProcessSystem.class.getDeclaredField("parallelTransientExecutorSize");
+    sizeField.setAccessible(true);
+    sizeField.setInt(process, size);
   }
 }

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
@@ -374,10 +374,9 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
     SystemSrkEos fluid = new SystemSrkEos(298.15, 20.0);
     fluid.addComponent("methane", 1.0);
     Stream feed = new Stream("feed", fluid);
-    BlockingHeater upstream = new BlockingHeater("upstream", feed, upstreamStarted, releaseUpstream,
-        upstreamCompleted);
-    DependencyRecordingHeater downstream = new DependencyRecordingHeater("downstream",
-        upstream.getOutletStream(), upstreamCompleted, downstreamObservedIncompleteUpstream, downstreamStarted);
+    BlockingHeater upstream = new BlockingHeater("upstream", feed, upstreamStarted, releaseUpstream, upstreamCompleted);
+    DependencyRecordingHeater downstream = new DependencyRecordingHeater("downstream", upstream.getOutletStream(),
+        upstreamCompleted, downstreamObservedIncompleteUpstream, downstreamStarted);
 
     ProcessSystem process = new ProcessSystem();
     process.add(upstream);

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
@@ -19,7 +19,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.measurementdevice.MeasurementDeviceBaseClass;
+import neqsim.thermo.system.SystemSrkEos;
 
 /**
  * Regression tests for parallel transient execution in {@link ProcessSystem}.
@@ -80,7 +84,18 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
      * @param release latch controlling when execution may finish
      */
     private BlockingTransientUnit(CountDownLatch started, CountDownLatch release) {
-      super("blocking-unit");
+      this("blocking-unit", started, release);
+    }
+
+    /**
+     * Creates a named blocking unit.
+     *
+     * @param name unit name
+     * @param started latch signalled when execution starts
+     * @param release latch controlling when execution may finish
+     */
+    private BlockingTransientUnit(String name, CountDownLatch started, CountDownLatch release) {
+      super(name);
       this.started = started;
       this.release = release;
     }
@@ -188,6 +203,83 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
   }
 
   /**
+   * Two-port unit that blocks while representing an upstream dynamic calculation.
+   */
+  private static final class BlockingHeater extends Heater {
+    private static final long serialVersionUID = 1000L;
+    private final transient CountDownLatch started;
+    private final transient CountDownLatch release;
+    private final AtomicBoolean completed;
+
+    /**
+     * Creates a blocking upstream heater.
+     *
+     * @param name unit name
+     * @param inletStream inlet stream
+     * @param started latch signalled when execution starts
+     * @param release latch controlling when execution may finish
+     * @param completed flag set after the upstream state update completes
+     */
+    private BlockingHeater(String name, StreamInterface inletStream, CountDownLatch started, CountDownLatch release,
+        AtomicBoolean completed) {
+      super(name, inletStream);
+      this.started = started;
+      this.release = release;
+      this.completed = completed;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void runTransient(double dt, UUID id) {
+      started.countDown();
+      try {
+        release.await();
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+      }
+      completed.set(true);
+      setCalculationIdentifier(id);
+    }
+  }
+
+  /**
+   * Downstream two-port unit that records whether it started before its upstream dependency completed.
+   */
+  private static final class DependencyRecordingHeater extends Heater {
+    private static final long serialVersionUID = 1000L;
+    private final AtomicBoolean upstreamCompleted;
+    private final AtomicBoolean observedIncompleteUpstream;
+    private final transient CountDownLatch started;
+
+    /**
+     * Creates a downstream dependency observer.
+     *
+     * @param name unit name
+     * @param inletStream upstream outlet stream
+     * @param upstreamCompleted upstream completion flag
+     * @param observedIncompleteUpstream flag set if this unit starts too early
+     * @param started latch signalled when this unit starts
+     */
+    private DependencyRecordingHeater(String name, StreamInterface inletStream, AtomicBoolean upstreamCompleted,
+        AtomicBoolean observedIncompleteUpstream, CountDownLatch started) {
+      super(name, inletStream);
+      this.upstreamCompleted = upstreamCompleted;
+      this.observedIncompleteUpstream = observedIncompleteUpstream;
+      this.started = started;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void runTransient(double dt, UUID id) {
+      if (!upstreamCompleted.get()) {
+        observedIncompleteUpstream.set(true);
+      }
+      started.countDown();
+      setCalculationIdentifier(id);
+    }
+  }
+
+  /**
    * Standalone controller that records transient scan execution.
    */
   private static final class CountingController extends ControllerDeviceBaseClass {
@@ -264,6 +356,90 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
     assertTrue(workerNames.size() <= numberOfWorkers,
         "Expected at most " + numberOfWorkers + " reused workers, but observed " + workerNames);
     assertEquals(numberOfSteps, process.getTime(), 1.0e-12);
+  }
+
+  /**
+   * Connected equipment must respect stream-dependency order even when transient parallelism is enabled.
+   *
+   * @throws Exception if the test thread cannot coordinate with the process runner
+   */
+  @Test
+  public void connectedEquipmentWaitsForUpstreamTransientCompletion() throws Exception {
+    CountDownLatch upstreamStarted = new CountDownLatch(1);
+    CountDownLatch releaseUpstream = new CountDownLatch(1);
+    CountDownLatch downstreamStarted = new CountDownLatch(1);
+    AtomicBoolean upstreamCompleted = new AtomicBoolean();
+    AtomicBoolean downstreamObservedIncompleteUpstream = new AtomicBoolean();
+
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 20.0);
+    fluid.addComponent("methane", 1.0);
+    Stream feed = new Stream("feed", fluid);
+    BlockingHeater upstream = new BlockingHeater("upstream", feed, upstreamStarted, releaseUpstream,
+        upstreamCompleted);
+    DependencyRecordingHeater downstream = new DependencyRecordingHeater("downstream",
+        upstream.getOutletStream(), upstreamCompleted, downstreamObservedIncompleteUpstream, downstreamStarted);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(upstream);
+    process.add(downstream);
+    process.setParallelTransientEnabled(true);
+    process.setTransientThreadPoolSize(2);
+
+    Thread processRunner = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        process.runTransient(1.0, UUID.randomUUID());
+      }
+    });
+
+    try {
+      processRunner.start();
+      assertTrue(upstreamStarted.await(5L, TimeUnit.SECONDS), "Upstream equipment did not start");
+      downstreamStarted.await(500L, TimeUnit.MILLISECONDS);
+      releaseUpstream.countDown();
+      processRunner.join(5000L);
+
+      assertFalse(processRunner.isAlive(), "Transient process did not finish after releasing upstream equipment");
+      assertTrue(downstreamStarted.getCount() == 0L, "Downstream equipment did not execute");
+      assertFalse(downstreamObservedIncompleteUpstream.get(),
+          "Downstream equipment started before its stream-producing dependency completed");
+    } finally {
+      releaseUpstream.countDown();
+      processRunner.join(2000L);
+    }
+  }
+
+  /**
+   * Units in the same dependency level must retain parallel execution after introducing level barriers.
+   *
+   * @throws Exception if the test thread cannot coordinate with the process runner
+   */
+  @Test
+  public void independentEquipmentWithinLevelStillRunsConcurrently() throws Exception {
+    CountDownLatch bothStarted = new CountDownLatch(2);
+    CountDownLatch release = new CountDownLatch(1);
+    ProcessSystem process = new ProcessSystem();
+    process.add(new BlockingTransientUnit("independent-a", bothStarted, release));
+    process.add(new BlockingTransientUnit("independent-b", bothStarted, release));
+    process.setParallelTransientEnabled(true);
+    process.setTransientThreadPoolSize(2);
+
+    Thread processRunner = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        process.runTransient(1.0, UUID.randomUUID());
+      }
+    });
+
+    try {
+      processRunner.start();
+      assertTrue(bothStarted.await(5L, TimeUnit.SECONDS),
+          "Independent equipment in the same dependency level did not execute concurrently");
+    } finally {
+      release.countDown();
+      processRunner.join(5000L);
+    }
+    assertFalse(processRunner.isAlive(), "Parallel transient process did not finish after releasing both units");
   }
 
   /**

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemParallelTransientTest.java
@@ -444,6 +444,8 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
         process.runTransient(1.0, UUID.randomUUID());
       }
     });
+    processRunner.setDaemon(true);
+    processRunner.setName("NeqSim-Test-Connected-Transient");
 
     try {
       processRunner.start();
@@ -483,6 +485,8 @@ public class ProcessSystemParallelTransientTest extends neqsim.NeqSimTest {
         process.runTransient(1.0, UUID.randomUUID());
       }
     });
+    processRunner.setDaemon(true);
+    processRunner.setName("NeqSim-Test-Independent-Transient");
 
     try {
       processRunner.start();


### PR DESCRIPTION
## Root cause

At merged `master` commit `df4fb3ea`, `ProcessSystem.runEquipmentTransientParallel(...)` submitted every unit operation in one batch. The steady-state parallel path already had a cached process-graph plan with topological levels, but transient execution ignored it. Connected upstream and downstream equipment could therefore execute concurrently and the downstream unit could read state while its producer was still updating it.

## Scope

- execute parallel transient equipment through the existing cached graph levels
- wait for each upstream level before submitting the next downstream level
- retain concurrency among dependency-independent groups in the same level
- execute shared-input groups sequentially inside one worker
- order cached groups by process-node index for deterministic submission
- preserve the reusable bounded per-`ProcessSystem` executor from #2686
- preserve interruption semantics: stop group work between units, cancel queued futures without interrupting running equipment, check interruption at every level boundary, and never submit downstream levels after caller interruption
- preserve public APIs and the opt-in default

`ProcessModel.runTransient(...)` remains insertion-ordered across process areas; each child `ProcessSystem` benefits from the corrected internal ordering.

## Reproduction and evidence

A deterministic two-heater regression blocks the upstream unit while the downstream unit records whether it starts before upstream completion.

| Metric | `df4fb3ea` | This branch |
|---|---:|---:|
| Graph dependency levels | 2 | 2 |
| Downstream started before upstream release | true | false |
| Downstream observed incomplete upstream state | true | false |

The test fails on merged `master` with:

```
Downstream equipment started before its stream-producing dependency completed
```

and passes after the level barriers are applied.

A realistic synthetic feed → heater → separator comparison produced three dependency levels. After one 0.5 s transient step, parallel and sequential execution agreed exactly in the checked results:

- gas outlet flow difference: 0.0 kg/h
- liquid outlet flow difference: 0.0 kg/h

The existing orchestration harness still completed 1,600/1,600 unit executions for 8 independent units × 200 timesteps using 2 reused workers. Wall-clock measurements were variable in this shared environment and are not used as acceptance criteria.

## Tests run

Local runtime: OpenJDK 17 with Eclipse ECJ 3.40.0 compiling changed current source to Java 8 source/target against the packaged NeqSim 3.16.0 dependency set.

- `ProcessSystemParallelTransientTest`: 9/9 passed
  - connected producer/consumer ordering
  - independent same-level concurrency
  - worker reuse and copy lifecycle
  - five interruption/cancellation regressions, including deterministic level-boundary interruption
- `ProcessSystemResetTest`: 3/3 passed, including 12,500 repeated transient steps
- `RunTransientEventSchedulerTest`: 4/4 passed, including two-area `ProcessModel.runTransient(...)`
- total focused suite: 16/16 passed
- realistic feed/heater/separator sequential-vs-parallel comparison: passed
- 1,600-execution worker-reuse harness: passed with 2 workers
- `python devtools/verify_skills_agents.py`: 0 errors, 0 warnings
- agent-skill map regeneration produced no diff
- `git diff --check`: passed

Local Maven tests and Spotless could not start because the sandbox could not resolve the newly required `maven-enforcer-plugin:3.6.3` from Maven Central. No Maven or Spotless result is claimed; hosted checks are authoritative.

## Engineering behavior

The process graph is cached and invalidated by the existing topology lifecycle, so repeated timesteps do not rebuild the graph. Level barriers enforce feed-forward stream dependencies. Within a level, independent groups still use the configured worker pool, and groups that share mutable inlet state are serialized. An interruption cancels queued groups and sets a shared stop flag so a running group does not advance to another unit after its current update completes. Every dependency-level boundary checks the caller status before submitting the next level.

## Compatibility and risk

- no public Java or Python API changes
- parallel transient execution remains disabled by default
- sequential transient behavior is unchanged
- timestep advancement, events, field inputs, controller phase, measurements, calculation identifiers, and integration selection are unchanged
- thermodynamic models, tolerances, mass/energy equations, and phase behavior are unchanged
- existing copy/serialization exclusion and executor resizing/retirement behavior are unchanged
- topology construction now determines execution order when transient parallelism is enabled; missing or implicit graph edges therefore remain a risk for equipment that does not report its ports
- graph levels do not define transient recycle iteration or transactional rollback; parallel transient execution remains unsupported for those implicit couplings

## Documentation impact

Updated:

- `ProcessSystem` Javadocs for dependency-aware parallel transient execution
- `docs/process/dynamic-simulation-enhancements.md` with level ordering, cancellation behavior, limits, accurate test counts, complete test command, and test coverage
- `.github/skills/neqsim-dynamic-simulation/SKILL.md` with the actual timestep phase order and graph-level execution contract

## Hosted validation

On synchronized head `a7fc5064`, six non-build workflows pass: Spotless, pre-commit, CodeQL, documentation search, skills lint, and PaperLab. Within the build workflow, Java 21 fast tests pass on Ubuntu and Windows, all three Java 21 slow-test shards pass on Ubuntu, Javadoc passes, agent-skill cross-reference validation passes, and Java 8 tests pass on Ubuntu.

The first Java 8 Windows attempt ran 10,910 tests and failed two unrelated tests outside this PR's four-file diff: `DynamicCompressorNotebookRegressionTest.compressorSpeedUpDrawsDownSuctionInventory` and `MultiStreamHeatExchangerTest.testRun2`. The same merge commit passed Java 8 on Ubuntu and Java 21 on both platforms. A targeted rerun of only the failed Windows job is in progress to distinguish platform flakiness from a repeatable incompatibility; no Java 8 Windows pass is claimed yet and no source or tolerance change has been made for these failures.

## Review disposition

Copilot identified a valid interrupt race at the boundary between completed and not-yet-submitted dependency levels. The race was reproduced deterministically: before the repair, downstream equipment was submitted after the caller became interrupted; after the repair, downstream execution remains unsubmitted and the caller interrupt flag is preserved. The inline thread was answered and resolved. A later review generated no new inline comments; its suppressed notes were checked against source, and the valid documentation counts/command and the two newly added helper-thread lifecycles were corrected. The 16-test focused suite remained green after those changes. After synchronizing with current `master` (`25d210b9`), GitHub briefly exposed the inherited TPflash commit during review; refreshing the unchanged `master` base restored the intended four-file dynamic diff. The resulting suppressed TPflash observations concern already-merged `master` code and are outside this PR, so no thermodynamic code or tolerances were changed here.

## Next dependency

Define explicit transient convergence semantics for recycle/controller/implicit signal couplings, then specify incomplete-step state ownership or rollback before expanding parallel execution to those models.