### PR TITLE
perf: avoid unnecessary fugacity init when setting flow (withdrawn)

### DIFF
--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -5474,10 +5474,9 @@ public abstract class SystemThermo implements SystemInterface {
   public void setTotalFlowRate(double flowRate, String flowunit) {
     init(0);
     double density = 0.0;
-    boolean requiresActualDensity =
-        flowunit.equals("Am3/hr") || flowunit.equals("Am3/min") || flowunit.equals("gallons/min")
-            || flowunit.equals("Am3/sec") || flowunit.equals("m3/hr") || flowunit.equals("m3/min")
-            || flowunit.equals("m3/sec") || flowunit.equals("m3/day");
+    boolean requiresActualDensity = flowunit.equals("Am3/hr") || flowunit.equals("Am3/min")
+        || flowunit.equals("gallons/min") || flowunit.equals("Am3/sec") || flowunit.equals("m3/hr")
+        || flowunit.equals("m3/min") || flowunit.equals("m3/sec") || flowunit.equals("m3/day");
     if (requiresActualDensity) {
       try {
         init(1);

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -5473,19 +5473,20 @@ public abstract class SystemThermo implements SystemInterface {
   @Override
   public void setTotalFlowRate(double flowRate, String flowunit) {
     init(0);
-    try {
-      init(1);
-    } catch (Exception ex) {
-      logger.error(ex.getMessage());
-    }
     double density = 0.0;
-    if (flowunit.equals("Am3/hr") || flowunit.equals("Am3/min") || flowunit.equals("gallons/min")
-        || flowunit.equals("Am3/sec") || flowunit.equals("m3/hr") || flowunit.equals("m3/min")
-        || flowunit.equals("m3/sec") || flowunit.equals("m3/day")) {
+    boolean requiresActualDensity =
+        flowunit.equals("Am3/hr") || flowunit.equals("Am3/min") || flowunit.equals("gallons/min")
+            || flowunit.equals("Am3/sec") || flowunit.equals("m3/hr") || flowunit.equals("m3/min")
+            || flowunit.equals("m3/sec") || flowunit.equals("m3/day");
+    if (requiresActualDensity) {
+      try {
+        init(1);
+      } catch (Exception ex) {
+        logger.error(ex.getMessage());
+      }
       initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
+      density = getPhase(0).getDensity("kg/m3");
     }
-
-    density = getPhase(0).getDensity("kg/m3");
     if (flowunit.equals("idSm3/hr") || flowunit.equals("idSm3/min") || flowunit.equals("idSm3/sec")
         || flowunit.equals("gallons/min")) {
       density = getIdealLiquidDensity("kg/m3");

--- a/src/test/java/neqsim/thermo/system/SystemThermoSetMolarCompositionTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoSetMolarCompositionTest.java
@@ -15,6 +15,31 @@ public class SystemThermoSetMolarCompositionTest extends neqsim.NeqSimTest {
 
   SystemInterface sys;
 
+  private static final class CountingSystemSrkEos extends SystemSrkEos {
+    private static final long serialVersionUID = 1L;
+    private int fugacityInitCount;
+
+    CountingSystemSrkEos(double temperature, double pressure) {
+      super(temperature, pressure);
+    }
+
+    @Override
+    public void init(int initType) {
+      if (initType == 1) {
+        fugacityInitCount++;
+      }
+      super.init(initType);
+    }
+
+    void resetFugacityInitCount() {
+      fugacityInitCount = 0;
+    }
+
+    int getFugacityInitCount() {
+      return fugacityInitCount;
+    }
+  }
+
   @BeforeEach
   void setup() {
     sys = new SystemSrkEos(298.0, 300.0);
@@ -103,6 +128,40 @@ public class SystemThermoSetMolarCompositionTest extends neqsim.NeqSimTest {
     double flowRate = sys.getFlowRate("kg/hr");
 
     assertEquals(876223.6458342039, flowRate, 1e-3);
+  }
+
+  @Test
+  void setFlowRateSkipsFugacityInitializationForDensityIndependentUnits() {
+    String[] units = { "kg/hr", "mole/hr", "MSm3/day", "idSm3/hr" };
+    double[] rates = { 50000.0, 3600.0, 1.0, 1000.0 };
+
+    for (int i = 0; i < units.length; i++) {
+      CountingSystemSrkEos fluid = new CountingSystemSrkEos(298.0, 10.0);
+      fluid.addComponent("methane", 0.8);
+      fluid.addComponent("ethane", 0.2);
+      fluid.setMixingRule("classic");
+      fluid.init(0);
+      fluid.resetFugacityInitCount();
+
+      fluid.setTotalFlowRate(rates[i], units[i]);
+
+      assertEquals(0, fluid.getFugacityInitCount(), units[i] + " does not require EOS fugacity initialization");
+    }
+  }
+
+  @Test
+  void setActualVolumeFlowRateRetainsFugacityInitialization() {
+    CountingSystemSrkEos fluid = new CountingSystemSrkEos(298.0, 10.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("ethane", 0.2);
+    fluid.setMixingRule("classic");
+    fluid.init(0);
+    fluid.resetFugacityInitCount();
+
+    fluid.setTotalFlowRate(1000.0, "m3/hr");
+
+    assertEquals(1, fluid.getFugacityInitCount(), "actual-volume conversion requires an EOS density");
+    assertEquals(1000.0, fluid.getFlowRate("m3/hr"), 1e-6);
   }
 
   @Test


### PR DESCRIPTION
## Withdrawn

This draft is closed and must not be merged. Full-suite and focused reproduction showed that skipping `init(1)` violates the immediate state contract of `setTotalFlowRate(...)`.

## Blocking evidence

- Java 21 Ubuntu reached 10,909 tests and failed:
  - `ValveSizingMethodComparisonTest.verifyGasKvFormula`
  - `EclipseFluidReadWriteTest.testFluidWater_os_sep_test`
- Baseline versus PR reproduction:
  - methane `Z`: 1.84367281971 → 2.0
  - methane `gamma`: 1.13687998674 → NaN
  - flashed Eclipse fluid `hasPhaseType("oil")`: true → false
- Review found another correctness gap: supported `Am3/day` was omitted from the density-required unit list.
- A safer alternative retaining `init(1)` improved setter timings by 63–70%, but changed active phase behavior and did not show a reliable representative wet-CPA `ProcessModel` gain. A baseline-like shortcut reintroduced the oil-phase failure.

The evidence and acceptance criteria for any future attempt are recorded on #170.

## Documentation impact

Documentation impact: none. The implementation was withdrawn and no user-facing behavior should change.