### PR TITLE
fix(tpflash): accept stable water-rich gas-oil endpoints

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -195,7 +195,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │                                                                                 │
 │  IF ordinary flash, water feed ≥ 0.01, and no aqueous phase:                    │
 │     → Evaluate a cloned TPmultiflash candidate                                  │
-│     → Accept only a two-phase aqueous candidate with lower Gibbs energy,        │
+│     → Accept any two-phase candidate with lower Gibbs energy,                   │
 │       bounded/normalized phase fractions, and distinct phase compositions       │
 │                                                                                 │
 │  IF chemical system:                                                            │
@@ -215,7 +215,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | `maxNumberOfIterations` | 50 | Maximum iterations per convergence loop |
 | Convergence tolerance | 1e-10 | Deviation threshold for K-value convergence |
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
-| Ordinary aqueous-refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; the cloned candidate remains subject to Gibbs and phase-quality acceptance checks |
+| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; accept an already-computed two-phase candidate only through Gibbs and phase-quality checks, independent of its phase labels |
 
 ### 1.1 Problem Formulation
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -902,8 +902,7 @@ public class TPflash extends Flash {
     try {
       candidate.setMultiPhaseCheck(true);
       new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
-      if (candidate.getNumberOfPhases() == 2
-          && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
+      if (candidate.getNumberOfPhases() == 2 && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
         copyFlashStateFrom(candidate);
       }
     } catch (Exception ex) {

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -44,8 +44,8 @@ public class TPflash extends Flash {
   private static final double LIQUID_LIQUID_ACTIVE_COMPONENT_LIMIT = 1.0e-6;
   /** Minimum critical-temperature span (K) for liquid-liquid refinement. */
   private static final double LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN = 150.0;
-  /** Minimum water feed fraction for ordinary aqueous endpoint refinement. */
-  private static final double AQUEOUS_REFINEMENT_WATER_FRACTION_LIMIT = 0.01;
+  /** Minimum water feed fraction for ordinary water-rich endpoint refinement. */
+  private static final double WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT = 0.01;
   /**
    * Minimum extensive Gibbs-energy reduction (J) required for the spurious-multiphase rescue to collapse a two-phase
    * result to a single phase. Avoids false triggers from numerical noise.
@@ -596,7 +596,7 @@ public class TPflash extends Flash {
         // applied on this path, as it can discard a genuine split the stability test overlooked.
         collapseTrivialMultiphaseSplit();
         rescueLiquidLiquidEndpoint();
-        rescueAqueousEndpoint();
+        rescueWaterRichEndpoint();
         return;
       }
     }
@@ -782,7 +782,7 @@ public class TPflash extends Flash {
     collapseTrivialMultiphaseSplit();
     normalizeActivePhaseFractions();
     rescueLiquidLiquidEndpoint();
-    rescueAqueousEndpoint();
+    rescueWaterRichEndpoint();
 
     // Final chemical equilibrium call after all phase reordering
     // This ensures chemical equilibrium is solved on the final phase configuration
@@ -868,13 +868,15 @@ public class TPflash extends Flash {
    *
    * <p>
    * The ordinary flash searches only the cubic gas/oil roots and can therefore leave a substantial water fraction
-   * dissolved in a hydrocarbon-labelled phase even when a lower-Gibbs aqueous split exists. The one-mol-percent feed
-   * guard keeps trace-water process flashes on the existing fast path. A cloned multiphase candidate replaces the
-   * ordinary state only through the same strict phase-fraction, distinct-composition, and Gibbs-energy checks used by
-   * the liquid-liquid rescue.
+   * dissolved in hydrocarbon-labelled phases, or miss a lower-Gibbs gas-oil split when water makes the generic
+   * hydrocarbon endpoint screen inapplicable. The one-mol-percent feed guard keeps trace-water process flashes on the
+   * existing fast path. A cloned multiphase candidate replaces the ordinary state only when it contains exactly two
+   * phases and passes the same strict phase-fraction, distinct-composition, and Gibbs-energy checks used by the
+   * liquid-liquid rescue. The candidate need not contain an aqueous-labelled phase: phase stability and Gibbs energy,
+   * rather than the expected phase label, decide whether the already-computed candidate is accepted.
    * </p>
    */
-  private void rescueAqueousEndpoint() {
+  private void rescueWaterRichEndpoint() {
     if (system.doMultiPhaseCheck() || system.isChemicalSystem() || system.hasIons() || solidCheck
         || system.isMultiphaseWaxCheck() || system.getNumberOfPhases() > 2) {
       return;
@@ -891,7 +893,7 @@ public class TPflash extends Flash {
         break;
       }
     }
-    if (waterFeedFraction < AQUEOUS_REFINEMENT_WATER_FRACTION_LIMIT) {
+    if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
       return;
     }
 
@@ -900,12 +902,12 @@ public class TPflash extends Flash {
     try {
       candidate.setMultiPhaseCheck(true);
       new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
-      if (candidate.getNumberOfPhases() == 2 && candidate.hasPhaseType(PhaseType.AQUEOUS)
+      if (candidate.getNumberOfPhases() == 2
           && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
         copyFlashStateFrom(candidate);
       }
     } catch (Exception ex) {
-      logger.debug("Aqueous endpoint refinement failed: {}", ex.getMessage());
+      logger.debug("Water-rich endpoint refinement failed: {}", ex.getMessage());
     }
   }
 

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichEndpointTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichEndpointTest.java
@@ -9,8 +9,7 @@ import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 class TPflashWaterRichEndpointTest {
-  private static final String[] COMPONENTS =
-      { "nitrogen", "methane", "ethane", "propane", "nC10", "water" };
+  private static final String[] COMPONENTS = { "nitrogen", "methane", "ethane", "propane", "nC10", "water" };
   private static final double[] FEED = { 0.01, 0.75, 0.08, 0.04, 0.02, 0.10 };
 
   @Test
@@ -25,23 +24,19 @@ class TPflashWaterRichEndpointTest {
     assertEquals(multiphase.getGibbsEnergy(), ordinary.getGibbsEnergy(), 1.0e-8);
     assertEquals(multiphase.getEnthalpy(), ordinary.getEnthalpy(), 1.0e-8);
     double firstOrdinaryGibbsEnergy = ordinary.getGibbsEnergy();
-    double firstOrdinaryOilBeta = ordinary.getPhase(0).getType() == PhaseType.OIL
-        ? ordinary.getBeta(0)
+    double firstOrdinaryOilBeta = ordinary.getPhase(0).getType() == PhaseType.OIL ? ordinary.getBeta(0)
         : ordinary.getBeta(1);
     new ThermodynamicOperations(ordinary).TPflash();
     ordinary.initProperties();
     assertEquals(firstOrdinaryGibbsEnergy, ordinary.getGibbsEnergy(), 1.0e-8);
-    double repeatedOrdinaryOilBeta = ordinary.getPhase(0).getType() == PhaseType.OIL
-        ? ordinary.getBeta(0)
+    double repeatedOrdinaryOilBeta = ordinary.getPhase(0).getType() == PhaseType.OIL ? ordinary.getBeta(0)
         : ordinary.getBeta(1);
     assertEquals(firstOrdinaryOilBeta, repeatedOrdinaryOilBeta, 1.0e-12);
 
     for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
-      assertEquals(multiphase.getPhase(phaseIndex).getType(),
-          ordinary.getPhase(phaseIndex).getType());
+      assertEquals(multiphase.getPhase(phaseIndex).getType(), ordinary.getPhase(phaseIndex).getType());
       assertEquals(multiphase.getBeta(phaseIndex), ordinary.getBeta(phaseIndex), 1.0e-12);
-      assertEquals(multiphase.getPhase(phaseIndex).getDensity(),
-          ordinary.getPhase(phaseIndex).getDensity(), 1.0e-8);
+      assertEquals(multiphase.getPhase(phaseIndex).getDensity(), ordinary.getPhase(phaseIndex).getDensity(), 1.0e-8);
       for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
         assertEquals(multiphase.getPhase(phaseIndex).getComponent(componentIndex).getx(),
             ordinary.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
@@ -70,26 +65,19 @@ class TPflashWaterRichEndpointTest {
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
-        recoveredFeed += system.getBeta(phaseIndex)
-            * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
       assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-12);
 
-      double firstPhaseLogFugacity =
-          Math.log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(),
-              Double.MIN_NORMAL))
-              + Math.log(system.getPhase(0).getComponent(componentIndex)
-                  .getFugacityCoefficient());
-      double secondPhaseLogFugacity =
-          Math.log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(),
-              Double.MIN_NORMAL))
-              + Math.log(system.getPhase(1).getComponent(componentIndex)
-                  .getFugacityCoefficient());
-      maximumLogFugacityResidual =
-          Math.max(maximumLogFugacityResidual,
-              Math.abs(firstPhaseLogFugacity - secondPhaseLogFugacity));
+      double firstPhaseLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondPhaseLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      maximumLogFugacityResidual = Math.max(maximumLogFugacityResidual,
+          Math.abs(firstPhaseLogFugacity - secondPhaseLogFugacity));
     }
-    assertTrue(maximumLogFugacityResidual < 1.0e-8,
-        "maximum log fugacity residual was " + maximumLogFugacityResidual);
+    assertTrue(maximumLogFugacityResidual < 1.0e-8, "maximum log fugacity residual was " + maximumLogFugacityResidual);
   }
 }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichEndpointTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichEndpointTest.java
@@ -1,0 +1,95 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashWaterRichEndpointTest {
+  private static final String[] COMPONENTS =
+      { "nitrogen", "methane", "ethane", "propane", "nC10", "water" };
+  private static final double[] FEED = { 0.01, 0.75, 0.08, 0.04, 0.02, 0.10 };
+
+  @Test
+  void ordinaryAndMultiphaseFlashSelectSameGasOilEquilibrium() {
+    SystemInterface ordinary = createAndFlash(false);
+    SystemInterface multiphase = createAndFlash(true);
+
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquals(2, multiphase.getNumberOfPhases());
+    assertTrue(ordinary.hasPhaseType(PhaseType.GAS));
+    assertTrue(ordinary.hasPhaseType(PhaseType.OIL));
+    assertEquals(multiphase.getGibbsEnergy(), ordinary.getGibbsEnergy(), 1.0e-8);
+    assertEquals(multiphase.getEnthalpy(), ordinary.getEnthalpy(), 1.0e-8);
+    double firstOrdinaryGibbsEnergy = ordinary.getGibbsEnergy();
+    double firstOrdinaryOilBeta = ordinary.getPhase(0).getType() == PhaseType.OIL
+        ? ordinary.getBeta(0)
+        : ordinary.getBeta(1);
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.initProperties();
+    assertEquals(firstOrdinaryGibbsEnergy, ordinary.getGibbsEnergy(), 1.0e-8);
+    double repeatedOrdinaryOilBeta = ordinary.getPhase(0).getType() == PhaseType.OIL
+        ? ordinary.getBeta(0)
+        : ordinary.getBeta(1);
+    assertEquals(firstOrdinaryOilBeta, repeatedOrdinaryOilBeta, 1.0e-12);
+
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      assertEquals(multiphase.getPhase(phaseIndex).getType(),
+          ordinary.getPhase(phaseIndex).getType());
+      assertEquals(multiphase.getBeta(phaseIndex), ordinary.getBeta(phaseIndex), 1.0e-12);
+      assertEquals(multiphase.getPhase(phaseIndex).getDensity(),
+          ordinary.getPhase(phaseIndex).getDensity(), 1.0e-8);
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        assertEquals(multiphase.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            ordinary.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
+      }
+    }
+
+    assertFlashClosure(ordinary);
+    assertFlashClosure(multiphase);
+  }
+
+  private SystemInterface createAndFlash(boolean multiphaseCheck) {
+    SystemInterface system = new SystemSrkCPAstatoil(323.15, 1.0);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], FEED[componentIndex]);
+    }
+    system.setMixingRule(10);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.initProperties();
+    return system;
+  }
+
+  private void assertFlashClosure(SystemInterface system) {
+    assertEquals(1.0, system.getBeta(0) + system.getBeta(1), 1.0e-12);
+    double maximumLogFugacityResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex)
+            * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-12);
+
+      double firstPhaseLogFugacity =
+          Math.log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(),
+              Double.MIN_NORMAL))
+              + Math.log(system.getPhase(0).getComponent(componentIndex)
+                  .getFugacityCoefficient());
+      double secondPhaseLogFugacity =
+          Math.log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(),
+              Double.MIN_NORMAL))
+              + Math.log(system.getPhase(1).getComponent(componentIndex)
+                  .getFugacityCoefficient());
+      maximumLogFugacityResidual =
+          Math.max(maximumLogFugacityResidual,
+              Math.abs(firstPhaseLogFugacity - secondPhaseLogFugacity));
+    }
+    assertTrue(maximumLogFugacityResidual < 1.0e-8,
+        "maximum log fugacity residual was " + maximumLogFugacityResidual);
+  }
+}


### PR DESCRIPTION
## Problem

The ordinary water-rich endpoint refinement introduced by #2689 already evaluates a cloned multiphase candidate, but accepts it only when that candidate contains an `AQUEOUS` phase. That phase-label assumption hides a stable `GAS + OIL` endpoint for water-rich CPA mixtures.

Minimal deterministic reproduction (SRK-CPA Statoil, mixing rule 10; z = N2 0.01 / methane 0.75 / ethane 0.08 / propane 0.04 / nC10 0.02 / water 0.10):

- 323.15 K, 1 bar: ordinary TPflash returned one `GAS` phase, G = -2645.3424 J.
- TPmultiflash returned `GAS + OIL`, G = -2659.0919 J, beta(oil) = 0.0112750756.
- The multiphase result has maximum material residual 4.51e-17 and maximum log-fugacity residual 8.56e-13.
- A second case at 373.15 K, 10 bar showed the same defect: G = 3557.4563 J versus stable G = 3549.3674 J, beta(oil) = 0.0091694939.

No open flash PR or issue was found that implements this correction. #2693 changes process flow-rate initialization and does not overlap this solver path.

## Root cause and change

`rescueAqueousEndpoint()` runs the expensive cloned TPmultiflash whenever water feed is at least 0.01 and the ordinary result has no aqueous phase. It then rejects an otherwise valid candidate solely through:

```java
candidate.hasPhaseType(PhaseType.AQUEOUS)
```

The refinement is renamed to describe its actual feed-based guard, and the phase-label restriction is removed. Acceptance remains safeguarded by the existing requirements:

- exactly two candidate phases;
- finite, normalized, bounded phase fractions;
- distinct phase compositions;
- a meaningful reduction in extensive Gibbs energy;
- no chemical, ionic, solid, or wax system.

This adds no trial flash or stability calculation: the candidate was already computed. It only permits the already-authoritative two-phase result to be copied when phase quality and Gibbs energy justify it.

## Method basis

The candidate uses NeqSim's existing Michelsen tangent-plane stability analysis and multiphase phase-split calculation:

- Michelsen (1982), [Part I: Stability](https://doi.org/10.1016/0378-3812(82)85001-2)
- Michelsen (1982), [Part II: Phase-split calculation](https://doi.org/10.1016/0378-3812(82)85002-4)

Evidence: the accepted candidate satisfies equilibrium and material closure and has lower Gibbs energy. Inference: requiring a particular phase label after those numerical checks is not a thermodynamic acceptance criterion. No claim is made about proprietary commercial-simulator implementations.

## Validation

A deterministic 450-state ordinary/multiphase matrix covered SRK, PR, and SRK-CPA; classic and CPA mixing rules; methane/water, wet gas, oil/water, CO2/water, and hydrogen/water; 230-373.15 K; and 1-300 bar.

| Signal | master | this branch |
|---|---:|---:|
| Successful flashes | 450/450 | 450/450 |
| Structural disagreements where multiphase has <=2 phases | 2 | 0 |
| Other numerical disagreements | 8 | 8 |
| Maximum beta-sum residual | 2.22e-16 | 2.22e-16 |
| Maximum phase-normalization residual | 5.77e-15 | 5.77e-15 |

The eight remaining numerical discrepancies are unchanged, separately reproducible defects; this PR does not mask them or loosen any tolerance.

For the two corrected states, ordinary and multiphase results now agree exactly in phase state, beta, compositions, density, Gibbs energy, and enthalpy. Repeating the corrected ordinary flash returns identical Gibbs energy and beta.

The focused Java regression checks:

- ordinary/multiphase phase selection and exact cross-algorithm agreement at 1e-12 for beta/composition;
- thermodynamic properties;
- repeated execution;
- component and total material closure;
- maximum log-fugacity residual < 1e-8.

Local validation run:

- production `TPflash.java` compiled with Java 17;
- focused test source compiled against NeqSim APIs (local JUnit API stubs because the workspace contains the packaged NeqSim jar, not the Maven test dependencies);
- deterministic 450-state executable matrix passed;
- focused repeatability reproduction passed.

Not run locally: Maven/Spotless, the complete JUnit suite, Javadocs, or Java 8. GitHub CI is expected to provide those repository-level checks.

## Performance

Three alternating forked-JVM runs, 150 construction+flash samples per fork:

| Case | master median-of-medians | branch median-of-medians |
|---|---:|---:|
| 323.15 K / 1 bar corrected endpoint | 21.60 ms | 17.42 ms |
| 373.15 K / 10 bar corrected endpoint | 12.60 ms | 12.17 ms |
| dry CPA fast path | 2.99 ms | 2.86 ms |

Run-to-run variance is material, so these data support only "no measurable regression," not a speedup claim. The 450-state single-pass ordinary median was 0.906 ms on master and 0.902 ms on this branch. The dry and trace-water gates are unchanged.

## Numerical tolerances and compatibility risk

- Cross-algorithm beta/composition comparison: 1e-12.
- Gibbs/enthalpy comparison: 1e-8 J in the focused regression.
- Equilibrium diagnostic: maximum log-fugacity residual < 1e-8.
- No public API or serialization change.
- Behavior changes only for neutral, nonchemical, water-rich ordinary endpoints where an already-computed exactly-two-phase candidate passes the existing lower-Gibbs and phase-quality checks.
- Three-phase candidates remain rejected.

Compatibility risk is low and intentionally thermodynamic: affected callers may now receive the stable two-phase `GAS + OIL` state instead of a metastable one-phase gas.

## Documentation impact

Updated `TPflash_algorithm.md` and method Javadocs to document phase-label-neutral water-rich refinement and its unchanged 0.01 water-feed guard.