### PR TITLE
fix: apply transient setters once

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-dynamic-simulation
 description: "Dynamic simulation guidance for NeqSim. USE WHEN: running transient simulations, modeling startup/shutdown, tuning PID controllers, analyzing pressure/level dynamics, performing blowdown/depressurization, or setting up measurement devices and control loops. Covers runTransient, DynamicProcessHelper, controller tuning, and dynamic equipment configuration."
-last_verified: "2026-07-10"
+last_verified: "2026-07-30"
 ---
 
 # Dynamic Simulation Guidance
@@ -27,11 +27,13 @@ historian tag mapping, and event schedule before running `runTransient`.
 
 NeqSim dynamic simulation uses the `runTransient(double dt)` method on `ProcessSystem`.
 Each timestep:
-1. Flowsheet-wide settings and setter units are applied.
+1. Flowsheet-wide settings are applied. Each setter unit receives exactly one
+   transient call, applying its specification and advancing its own clock once.
 2. Simulation time advances, then due events and field inputs are applied.
 3. Equipment updates, including its thermodynamic calculations, run in insertion
    order or dependency-aware graph levels when parallel transient execution is
-   enabled.
+   enabled. Setter units are excluded from these explicit, semi-implicit, and
+   parallel equipment passes.
 4. Standalone controllers run; equipment-embedded controllers retain their
    equipment-specific execution timing for compatibility.
 5. Measurement devices are sampled, alarms are evaluated, and history is stored.

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -522,6 +522,12 @@ double actualDt = process.runTransientAdaptive(1.0, id);
 The adaptive algorithm compares state changes between the full step and two
 half-steps, reducing or increasing $\Delta t$ based on the relative error.
 
+Setter units form a dedicated pre-step specification phase. Each setter receives
+exactly one `runTransient(dt, id)` call per process timestep, so its specification
+is applied once and its own clock advances by the same $\Delta t$ as the process.
+Setters are excluded from the later explicit, semi-implicit, and parallel
+equipment passes.
+
 ### 5.2 Parallel Transient Execution
 
 For large flowsheets, equipment-level transient calculations can be run in
@@ -587,7 +593,7 @@ process.setIntegrationMethod(IntegrationMethod.RUNGE_KUTTA_4);    // Higher-orde
 
 ## 6. Test Coverage
 
-The features in this guide are covered by four focused test classes with 69
+The features in this guide are covered by five focused test classes with 72
 total tests:
 
 | Test Class | Tests | Coverage |
@@ -596,11 +602,12 @@ total tests:
 | `DynamicImprovementsPhase2Test` | 27 | Sensor faults, valve nonlinearities, adaptive timestep, parallel transient, integration methods, JSON process builder |
 | `DynamicImprovementsPhase3Test` | 16 | Transmitter filter, alarm shelving, separator internals, HX thermal model, distillation MESH dynamics |
 | `ProcessSystemParallelTransientTest` | 9 | Worker reuse, copy lifecycle, dependency ordering, independent-level concurrency, and interruption behavior at waits and level boundaries |
+| `ProcessSystemTransientSetterTest` | 3 | Single setter application, repeated-step clock advancement, and explicit, semi-implicit, and parallel execution |
 
 Run all tests:
 
 ```bash
-./mvnw test -Dtest=DynamicImprovementsTest,DynamicImprovementsPhase2Test,DynamicImprovementsPhase3Test,ProcessSystemParallelTransientTest
+./mvnw test -Dtest=DynamicImprovementsTest,DynamicImprovementsPhase2Test,DynamicImprovementsPhase3Test,ProcessSystemParallelTransientTest,ProcessSystemTransientSetterTest
 ```
 
 ---

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -3258,6 +3258,13 @@ public class ProcessSystem extends SimulationBaseClass {
    * @param id the calculation identifier for this timestep
    */
   private void runUnitTransientSkippingInactive(ProcessEquipmentInterface unit, double dt, UUID id) {
+    // Setters are a dedicated pre-step specification phase. They have already
+    // received one runTransient(dt, id) call, including their single clock
+    // advance, and must not be integrated again in explicit, semi-implicit, or
+    // parallel equipment passes.
+    if (unit instanceof Setter) {
+      return;
+    }
     // Honor only the explicit user lock during dynamic stepping. Units that were
     // auto-bypassed by the low-flow heuristic on a previous (possibly steady-state)
     // pass must be given a chance to re-evaluate each timestep: they may hold dynamic
@@ -4064,7 +4071,18 @@ public class ProcessSystem extends SimulationBaseClass {
     runTransient(getTimeStep(), UUID.randomUUID());
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Advances one transient process timestep.
+   *
+   * <p>
+   * Setter units execute once as a dedicated pre-step specification phase through their transient contract. They are
+   * excluded from subsequent equipment integration passes so explicit, semi-implicit, and parallel stepping apply each
+   * setter once and advance its clock by exactly {@code dt}.
+   * </p>
+   *
+   * @param dt timestep in seconds
+   * @param id calculation identifier shared by the timestep
+   */
   @Override
   public synchronized void runTransient(double dt, UUID id) {
     ensureInitialStateSnapshot();
@@ -4079,7 +4097,7 @@ public class ProcessSystem extends SimulationBaseClass {
     for (int i = 0; i < unitOperations.size(); i++) {
       ProcessEquipmentInterface unit = unitOperations.get(i);
       if (unit instanceof Setter) {
-        unit.run(id);
+        unit.runTransient(dt, id);
       }
     }
 

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientSetterTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientSetterTest.java
@@ -1,0 +1,101 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.util.Setter;
+
+/**
+ * Regression tests for setter execution during transient process steps.
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public class ProcessSystemTransientSetterTest extends neqsim.NeqSimTest {
+  /**
+   * Setter that records how often its specification phase is applied.
+   */
+  private static final class CountingSetter extends Setter {
+    private static final long serialVersionUID = 1000L;
+    private final AtomicInteger executionCount = new AtomicInteger();
+
+    /**
+     * Creates a counting setter.
+     *
+     * @param name setter name
+     */
+    private CountingSetter(String name) {
+      super(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void run(UUID id) {
+      executionCount.incrementAndGet();
+      setCalculationIdentifier(id);
+    }
+
+    /**
+     * Returns the number of applied specification phases.
+     *
+     * @return execution count
+     */
+    private int getExecutionCount() {
+      return executionCount.get();
+    }
+  }
+
+  /**
+   * A setter is a pre-step specification phase and must execute exactly once per explicit transient timestep.
+   */
+  @Test
+  public void explicitTransientAppliesSetterOnce() {
+    ProcessSystem process = new ProcessSystem("explicit-setter-step");
+    CountingSetter setter = new CountingSetter("setter");
+    process.add(setter);
+
+    process.runTransient(2.0, UUID.randomUUID());
+    process.runTransient(2.0, UUID.randomUUID());
+
+    assertEquals(2, setter.getExecutionCount());
+    assertEquals(4.0, setter.getTime(), 1.0e-12);
+  }
+
+  /**
+   * The semi-implicit second equipment pass must not reapply timestep setters.
+   */
+  @Test
+  public void semiImplicitTransientAppliesSetterOnce() {
+    ProcessSystem process = new ProcessSystem("semi-implicit-setter-step");
+    process.setIntegrationMethod(ProcessSystem.IntegrationMethod.SEMI_IMPLICIT);
+    CountingSetter setter = new CountingSetter("setter");
+    process.add(setter);
+
+    process.runTransient(2.0, UUID.randomUUID());
+
+    assertEquals(1, setter.getExecutionCount());
+    assertEquals(2.0, setter.getTime(), 1.0e-12);
+  }
+
+  /**
+   * Parallel equipment scheduling must not reapply setters, including the semi-implicit second pass.
+   */
+  @Test
+  public void parallelSemiImplicitTransientAppliesEachSetterOnce() {
+    ProcessSystem process = new ProcessSystem("parallel-semi-implicit-setter-step");
+    process.setParallelTransientEnabled(true);
+    process.setIntegrationMethod(ProcessSystem.IntegrationMethod.SEMI_IMPLICIT);
+    CountingSetter firstSetter = new CountingSetter("first setter");
+    CountingSetter secondSetter = new CountingSetter("second setter");
+    process.add(firstSetter);
+    process.add(secondSetter);
+
+    process.runTransient(2.0, UUID.randomUUID());
+
+    assertEquals(1, firstSetter.getExecutionCount());
+    assertEquals(1, secondSetter.getExecutionCount());
+    assertEquals(2.0, firstSetter.getTime(), 1.0e-12);
+    assertEquals(2.0, secondSetter.getTime(), 1.0e-12);
+  }
+}


### PR DESCRIPTION
## Root cause

`ProcessSystem.runTransient(dt, id)` applied every `Setter` once through `run(id)` before the timestep and then included it again in the ordinary equipment transient pass. Because `Setter` inherits the default `runTransient(...)` contract, that second call reapplied the specification and advanced the setter clock. `SEMI_IMPLICIT` added a third application and a second clock advance. The parallel path had the same behavior because setters were included in graph groups.

Steady-state execution already treats setters as a dedicated specification phase and excludes them from the later equipment pass.

## Scope

- execute each setter exactly once through `runTransient(dt, id)` in the pre-step specification phase
- exclude setters from explicit, semi-implicit, and parallel equipment integration passes
- preserve one setter clock advance by exactly `dt` per process timestep
- add focused explicit, repeated-step, semi-implicit, and parallel regression coverage
- document the phase contract in the `ProcessSystem` Javadoc, dynamic guide, and dynamic-simulation skill

No public API is added or removed.

## Baseline and before/after evidence

A deterministic counting-setter harness with `dt = 2.0 s` produced:

| Case | Before applications / setter time | After applications / setter time |
|---|---:|---:|
| Explicit Euler | 2 / 2.0 s | 1 / 2.0 s |
| Semi-implicit | 3 / 4.0 s | 1 / 2.0 s |
| Parallel semi-implicit, each of two setters | 3 / 4.0 s | 1 / 2.0 s |

The baseline ran against the packaged NeqSim 3.16.0 dependency set. Current `master` contained the same deterministic pre-step plus equipment-pass call sequence; the focused regression therefore fails before this patch. The patched current `ProcessSystem` and its current `Stream` dependency were compiled at Java 8 source/target and produced the corrected results above.

## Tests and validation

Local runtime: OpenJDK 17, compiling changed current source with the Java 8 compiler tools and `-source 8 -target 8` against the packaged NeqSim 3.16.0 dependency set.

- deterministic explicit, semi-implicit, and parallel semi-implicit harness: passed
- repeated-step behavior is covered by `ProcessSystemTransientSetterTest`
- focused test source compiled at Java 8 source/target
- `python devtools/verify_skills_agents.py`: 0 errors, 0 warnings
- agent-skill map regeneration produced no diff
- `git diff --check`: passed

Local Maven/JUnit and Spotless could not start because the sandbox could not resolve `maven-enforcer-plugin:3.6.3` from Maven Central. No local Maven, JUnit, or Spotless result is claimed; hosted checks are the verification gate.

## Hosted validation

On head `fb6c6bde`, Spotless, pre-commit, skills/agents lint, and PaperLab pass. The build/Javadoc matrix, CodeQL, and documentation search are still in progress; no result is claimed for them yet. The PR is mergeable and current with `master`, with only the four intended files changed. No review comments or unresolved threads are present.

## Engineering behavior

Setters remain first in the timestep phase order and still receive the shared calculation identifier. Calling their transient contract once preserves specification application and advances their own simulation clock exactly once. Events, field inputs, equipment state integration, controllers, measurements, alarms, history, and process time advancement retain their existing order. Regular unit-operation calls, thermodynamic models, tolerances, mass and energy balances, and phase behavior are unchanged.

## Compatibility and risk

- no Java or Python API changes
- explicit, semi-implicit, sequential, and parallel paths share the corrected contract
- repeated execution remains deterministic: one setter application and one clock advance per timestep
- a custom `Setter` subclass that overrides `runTransient(...)` now receives that dynamic call once in the intended pre-step phase instead of receiving `run(...)` first and another transient call later
- setter specifications remain applied before scheduled events and field inputs, matching the existing pre-step ordering
- interruption and incomplete-step behavior are unchanged

## Documentation impact

Updated:

- `ProcessSystem.runTransient(...)` Javadoc
- `docs/process/dynamic-simulation-enhancements.md`
- `.github/skills/neqsim-dynamic-simulation/SKILL.md`

## Next dependency

Define explicit transient convergence semantics for recycle/controller and other implicit signal couplings, then specify incomplete-step state ownership or rollback.