### PR TITLE
fix(tpflash): retain lower-Gibbs aqueous cubic root

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -198,6 +198,11 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Accept any two-phase candidate with lower Gibbs energy,                   │
 │       bounded/normalized phase fractions, and distinct phase compositions       │
 │                                                                                 │
+│  IF ordinary, neutral, exactly-two-phase result contains an aqueous phase:       │
+│     → Evaluate gas-like and liquid-like roots of the non-aqueous cubic phase     │
+│     → Replace only with a lower-Gibbs root that already satisfies                │
+│       max |Δ ln(fᵢ)| < 1e-8; phase fractions and compositions stay unchanged     │
+│                                                                                 │
 │  IF chemical system:                                                            │
 │     → Final chemical equilibrium solve in aqueous/liquid phases                 │
 └─────────────────────────────────────────────────────────────────────────────────┘
@@ -216,6 +221,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Convergence tolerance | 1e-10 | Deviation threshold for K-value convergence |
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
 | Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; accept an already-computed two-phase candidate only through Gibbs and phase-quality checks, independent of its phase labels |
+| Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
 
 ### 1.1 Problem Formulation
 
@@ -1650,6 +1656,7 @@ Commercial process simulators do not publish all implementation details, but pub
 - Pure-component fallback trials improve LLE/VLLE detection where Wilson K-based trials can report positive TPD even though a liquid-liquid split exists.
 - Explicit multiphase hydrocarbon flashes now retry a local lower-temperature seed before accepting an ambiguous single-phase endpoint, and keep the retry only if it gives a lower-Gibbs multiphase result.
 - A cheap post-flash K-envelope gate skips that rescue for clearly single-phase hydrocarbon endpoints, preserving ordinary `setMultiPhaseCheck(true)` speed.
+- Ordinary neutral aqueous splits now compare both cubic roots of the non-aqueous phase at the converged composition. An alternate root is retained only when it lowers Gibbs energy and already satisfies `max abs(Delta ln(f_i)) < 1e-8`; no extra TPflash or multiphase stability calculation is run.
 - Enhanced stability checks are gated to polar, associating, electrolyte, sour, or explicitly requested multiphase systems, limiting unnecessary hydrocarbon phase-map artifacts.
 
 ### 6.3 Recommended Improvements

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -50,7 +50,7 @@ public class TPflash extends Flash {
   /** Maximum accepted log-fugacity residual when selecting an alternate cubic root. */
   private static final double PHASE_ROOT_EQUILIBRIUM_TOLERANCE = 1.0e-8;
   /** Cubic phase roots evaluated by the post-convergence aqueous root check. */
-  private static final PhaseType[] CUBIC_ROOT_PHASE_TYPES = {PhaseType.GAS, PhaseType.LIQUID};
+  private static final PhaseType[] CUBIC_ROOT_PHASE_TYPES = { PhaseType.GAS, PhaseType.LIQUID };
   /**
    * Minimum extensive Gibbs-energy reduction (J) required for the spurious-multiphase rescue to collapse a two-phase
    * result to a single phase. Avoids false triggers from numerical noise.
@@ -1161,8 +1161,8 @@ public class TPflash extends Flash {
    * may retain the higher-Gibbs root while the multiphase path retains the lower root, even when both paths return
    * identical phase fractions and compositions. Each cubic root is therefore evaluated on a cloned non-aqueous phase.
    * The live phase is replaced only when the alternate root lowers extensive Gibbs energy and already satisfies
-   * component fugacity equality against the unchanged aqueous phase within
-   * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE}. Material balance and phase fractions are unchanged.
+   * component fugacity equality against the unchanged aqueous phase within {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE}.
+   * Material balance and phase fractions are unchanged.
    * </p>
    *
    * <p>
@@ -1172,9 +1172,8 @@ public class TPflash extends Flash {
    * </p>
    */
   private void rescueLowerGibbsPhaseRoot() {
-    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 2 || system.isChemicalSystem()
-        || system.hasIons() || solidCheck || system.isMultiphaseWaxCheck()
-        || !system.hasPhaseType(PhaseType.AQUEOUS)) {
+    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 2 || system.isChemicalSystem() || system.hasIons()
+        || solidCheck || system.isMultiphaseWaxCheck() || !system.hasPhaseType(PhaseType.AQUEOUS)) {
       return;
     }
 
@@ -1192,15 +1191,13 @@ public class TPflash extends Flash {
       for (PhaseType trialRoot : CUBIC_ROOT_PHASE_TYPES) {
         try {
           PhaseInterface trialPhase = phase.clone();
-          trialPhase.init(system.getTotalNumberOfMoles(), trialPhase.getNumberOfComponents(), 1,
-              trialRoot, system.getBeta(phaseIndex));
-          for (int componentIndex = 0; componentIndex < trialPhase
-              .getNumberOfComponents(); componentIndex++) {
+          trialPhase.init(system.getTotalNumberOfMoles(), trialPhase.getNumberOfComponents(), 1, trialRoot,
+              system.getBeta(phaseIndex));
+          for (int componentIndex = 0; componentIndex < trialPhase.getNumberOfComponents(); componentIndex++) {
             trialPhase.getComponent(componentIndex).fugcoef(trialPhase);
           }
           double gibbsReduction = currentGibbs - trialPhase.getGibbsEnergy();
-          double fugacityResidual =
-              maximumLogFugacityResidualWithReplacement(phaseIndex, trialPhase);
+          double fugacityResidual = maximumLogFugacityResidualWithReplacement(phaseIndex, trialPhase);
           if (Double.isFinite(gibbsReduction) && gibbsReduction > maximumGibbsReduction
               && fugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
             maximumGibbsReduction = gibbsReduction;
@@ -1209,8 +1206,7 @@ public class TPflash extends Flash {
             selectedPhaseState = trialPhase;
           }
         } catch (Exception ex) {
-          logger.debug("Alternate phase-root comparison failed for {}: {}", trialRoot,
-              ex.getMessage());
+          logger.debug("Alternate phase-root comparison failed for {}: {}", trialRoot, ex.getMessage());
         }
       }
     }
@@ -1231,28 +1227,23 @@ public class TPflash extends Flash {
    * @param replacement initialized replacement phase
    * @return maximum absolute log-fugacity residual
    */
-  private double maximumLogFugacityResidualWithReplacement(int phaseIndex,
-      PhaseInterface replacement) {
+  private double maximumLogFugacityResidualWithReplacement(int phaseIndex, PhaseInterface replacement) {
     int otherPhaseIndex = phaseIndex == 0 ? 1 : 0;
     double maximumResidual = 0.0;
-    for (int componentIndex = 0; componentIndex < replacement.getNumberOfComponents();
-        componentIndex++) {
+    for (int componentIndex = 0; componentIndex < replacement.getNumberOfComponents(); componentIndex++) {
       if (system.getPhase(0).getComponent(componentIndex).getz() <= 1.0e-50) {
         continue;
       }
-      double replacementLogFugacity =
-          Math.log(Math.max(replacement.getComponent(componentIndex).getx(), Double.MIN_NORMAL))
-              + Math.log(replacement.getComponent(componentIndex).getFugacityCoefficient());
-      double otherLogFugacity = Math.log(Math.max(
-          system.getPhase(otherPhaseIndex).getComponent(componentIndex).getx(),
-          Double.MIN_NORMAL))
-          + Math.log(system.getPhase(otherPhaseIndex).getComponent(componentIndex)
-              .getFugacityCoefficient());
+      double replacementLogFugacity = Math
+          .log(Math.max(replacement.getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(replacement.getComponent(componentIndex).getFugacityCoefficient());
+      double otherLogFugacity = Math
+          .log(Math.max(system.getPhase(otherPhaseIndex).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(otherPhaseIndex).getComponent(componentIndex).getFugacityCoefficient());
       if (!Double.isFinite(replacementLogFugacity) || !Double.isFinite(otherLogFugacity)) {
         return Double.POSITIVE_INFINITY;
       }
-      maximumResidual =
-          Math.max(maximumResidual, Math.abs(replacementLogFugacity - otherLogFugacity));
+      maximumResidual = Math.max(maximumResidual, Math.abs(replacementLogFugacity - otherLogFugacity));
     }
     return maximumResidual;
   }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -3,6 +3,7 @@ package neqsim.thermodynamicoperations.flashops;
 import static neqsim.thermo.ThermodynamicModelSettings.phaseFractionMinimumLimit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -46,6 +47,10 @@ public class TPflash extends Flash {
   private static final double LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN = 150.0;
   /** Minimum water feed fraction for ordinary water-rich endpoint refinement. */
   private static final double WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT = 0.01;
+  /** Maximum accepted log-fugacity residual when selecting an alternate cubic root. */
+  private static final double PHASE_ROOT_EQUILIBRIUM_TOLERANCE = 1.0e-8;
+  /** Cubic phase roots evaluated by the post-convergence aqueous root check. */
+  private static final PhaseType[] CUBIC_ROOT_PHASE_TYPES = {PhaseType.GAS, PhaseType.LIQUID};
   /**
    * Minimum extensive Gibbs-energy reduction (J) required for the spurious-multiphase rescue to collapse a two-phase
    * result to a single phase. Avoids false triggers from numerical noise.
@@ -595,6 +600,7 @@ public class TPflash extends Flash {
         // solution of the flash equations. The Gibbs-based spurious rescue is intentionally NOT
         // applied on this path, as it can discard a genuine split the stability test overlooked.
         collapseTrivialMultiphaseSplit();
+        rescueLowerGibbsPhaseRoot();
         rescueLiquidLiquidEndpoint();
         rescueWaterRichEndpoint();
         return;
@@ -781,6 +787,7 @@ public class TPflash extends Flash {
     rescueSpuriousMultiphaseEndpoint();
     collapseTrivialMultiphaseSplit();
     normalizeActivePhaseFractions();
+    rescueLowerGibbsPhaseRoot();
     rescueLiquidLiquidEndpoint();
     rescueWaterRichEndpoint();
 
@@ -1144,6 +1151,110 @@ public class TPflash extends Flash {
     }
     system.normalizeBeta();
     system.init(1);
+  }
+
+  /**
+   * Selects a lower-Gibbs cubic root for an already-converged ordinary aqueous split.
+   *
+   * <p>
+   * A cubic EOS can have both vapor-like and liquid-like roots at the converged phase composition. The ordinary flash
+   * may retain the higher-Gibbs root while the multiphase path retains the lower root, even when both paths return
+   * identical phase fractions and compositions. Each cubic root is therefore evaluated on a cloned non-aqueous phase.
+   * The live phase is replaced only when the alternate root lowers extensive Gibbs energy and already satisfies
+   * component fugacity equality against the unchanged aqueous phase within
+   * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE}. Material balance and phase fractions are unchanged.
+   * </p>
+   *
+   * <p>
+   * The check is limited to neutral, ordinary, exactly-two-phase aqueous results. Dry hydrocarbon flashes,
+   * multiphase-enabled flashes, chemical/electrolyte systems, and solid/wax calculations remain on their existing fast
+   * paths.
+   * </p>
+   */
+  private void rescueLowerGibbsPhaseRoot() {
+    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 2 || system.isChemicalSystem()
+        || system.hasIons() || solidCheck || system.isMultiphaseWaxCheck()
+        || !system.hasPhaseType(PhaseType.AQUEOUS)) {
+      return;
+    }
+
+    int selectedPhase = -1;
+    PhaseType selectedRoot = null;
+    PhaseInterface selectedPhaseState = null;
+    double maximumGibbsReduction = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      PhaseInterface phase = system.getPhase(phaseIndex);
+      PhaseType phaseType = phase.getType();
+      if (!(phaseType == PhaseType.GAS || phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID)) {
+        continue;
+      }
+      double currentGibbs = phase.getGibbsEnergy();
+      for (PhaseType trialRoot : CUBIC_ROOT_PHASE_TYPES) {
+        try {
+          PhaseInterface trialPhase = phase.clone();
+          trialPhase.init(system.getTotalNumberOfMoles(), trialPhase.getNumberOfComponents(), 1,
+              trialRoot, system.getBeta(phaseIndex));
+          for (int componentIndex = 0; componentIndex < trialPhase
+              .getNumberOfComponents(); componentIndex++) {
+            trialPhase.getComponent(componentIndex).fugcoef(trialPhase);
+          }
+          double gibbsReduction = currentGibbs - trialPhase.getGibbsEnergy();
+          double fugacityResidual =
+              maximumLogFugacityResidualWithReplacement(phaseIndex, trialPhase);
+          if (Double.isFinite(gibbsReduction) && gibbsReduction > maximumGibbsReduction
+              && fugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
+            maximumGibbsReduction = gibbsReduction;
+            selectedPhase = phaseIndex;
+            selectedRoot = trialRoot;
+            selectedPhaseState = trialPhase;
+          }
+        } catch (Exception ex) {
+          logger.debug("Alternate phase-root comparison failed for {}: {}", trialRoot,
+              ex.getMessage());
+        }
+      }
+    }
+    double gibbsTolerance = Math.max(1.0e-6, Math.abs(system.getGibbsEnergy()) * 1.0e-8);
+    if (selectedPhase < 0 || maximumGibbsReduction <= gibbsTolerance) {
+      return;
+    }
+
+    int storageIndex = system.getPhaseIndex(selectedPhase);
+    system.setPhase(selectedPhaseState, storageIndex);
+    system.setPhaseType(selectedPhase, selectedRoot);
+  }
+
+  /**
+   * Calculates the largest equilibrium residual after replacing one phase with an alternate cubic root.
+   *
+   * @param phaseIndex active phase to replace
+   * @param replacement initialized replacement phase
+   * @return maximum absolute log-fugacity residual
+   */
+  private double maximumLogFugacityResidualWithReplacement(int phaseIndex,
+      PhaseInterface replacement) {
+    int otherPhaseIndex = phaseIndex == 0 ? 1 : 0;
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < replacement.getNumberOfComponents();
+        componentIndex++) {
+      if (system.getPhase(0).getComponent(componentIndex).getz() <= 1.0e-50) {
+        continue;
+      }
+      double replacementLogFugacity =
+          Math.log(Math.max(replacement.getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+              + Math.log(replacement.getComponent(componentIndex).getFugacityCoefficient());
+      double otherLogFugacity = Math.log(Math.max(
+          system.getPhase(otherPhaseIndex).getComponent(componentIndex).getx(),
+          Double.MIN_NORMAL))
+          + Math.log(system.getPhase(otherPhaseIndex).getComponent(componentIndex)
+              .getFugacityCoefficient());
+      if (!Double.isFinite(replacementLogFugacity) || !Double.isFinite(otherLogFugacity)) {
+        return Double.POSITIVE_INFINITY;
+      }
+      maximumResidual =
+          Math.max(maximumResidual, Math.abs(replacementLogFugacity - otherLogFugacity));
+    }
+    return maximumResidual;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootConsistencyTest.java
@@ -9,7 +9,7 @@ import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 class TPflashAqueousRootConsistencyTest {
-  private static final double[] FEED = {0.90, 0.10};
+  private static final double[] FEED = { 0.90, 0.10 };
 
   @Test
   void ordinaryAndMultiphaseFlashesRetainSameStableCubicRoot() {
@@ -35,8 +35,7 @@ class TPflashAqueousRootConsistencyTest {
   }
 
   private SystemInterface createAndFlash(boolean pengRobinson, boolean multiphaseCheck) {
-    SystemInterface system =
-        pengRobinson ? new SystemPrEos(273.15, 50.0) : new SystemSrkEos(273.15, 50.0);
+    SystemInterface system = pengRobinson ? new SystemPrEos(273.15, 50.0) : new SystemSrkEos(273.15, 50.0);
     system.addComponent("CO2", FEED[0]);
     system.addComponent("water", FEED[1]);
     system.setMixingRule(2);
@@ -47,32 +46,25 @@ class TPflashAqueousRootConsistencyTest {
     return system;
   }
 
-  private void assertEquivalentEquilibrium(SystemInterface expected,
-      SystemInterface actual) {
+  private void assertEquivalentEquilibrium(SystemInterface expected, SystemInterface actual) {
     assertEquals(2, expected.getNumberOfPhases());
     assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
     assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-8);
     assertEquals(expected.getEnthalpy(), actual.getEnthalpy(), 1.0e-8);
 
     for (int phaseIndex = 0; phaseIndex < expected.getNumberOfPhases(); phaseIndex++) {
-      assertEquals(expected.getPhase(phaseIndex).getType(),
-          actual.getPhase(phaseIndex).getType());
+      assertEquals(expected.getPhase(phaseIndex).getType(), actual.getPhase(phaseIndex).getType());
       assertEquals(expected.getBeta(phaseIndex), actual.getBeta(phaseIndex), 1.0e-12);
-      assertEquals(expected.getPhase(phaseIndex).getDensity(),
-          actual.getPhase(phaseIndex).getDensity(), 1.0e-8);
+      assertEquals(expected.getPhase(phaseIndex).getDensity(), actual.getPhase(phaseIndex).getDensity(), 1.0e-8);
       assertTrue(actual.getBeta(phaseIndex) > 0.0);
       assertTrue(actual.getBeta(phaseIndex) < 1.0);
       assertTrue(Double.isFinite(actual.getPhase(phaseIndex).getZ()));
       assertTrue(actual.getPhase(phaseIndex).getZ() > 0.0);
 
       double compositionTotal = 0.0;
-      for (int componentIndex = 0;
-          componentIndex < expected.getPhase(phaseIndex).getNumberOfComponents();
-          componentIndex++) {
-        double expectedComposition =
-            expected.getPhase(phaseIndex).getComponent(componentIndex).getx();
-        double actualComposition =
-            actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      for (int componentIndex = 0; componentIndex < expected.getPhase(phaseIndex).getNumberOfComponents(); componentIndex++) {
+        double expectedComposition = expected.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        double actualComposition = actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
         assertEquals(expectedComposition, actualComposition, 1.0e-12);
         compositionTotal += actualComposition;
       }
@@ -83,8 +75,7 @@ class TPflashAqueousRootConsistencyTest {
     for (int componentIndex = 0; componentIndex < FEED.length; componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < actual.getNumberOfPhases(); phaseIndex++) {
-        recoveredFeed += actual.getBeta(phaseIndex)
-            * actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        recoveredFeed += actual.getBeta(phaseIndex) * actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
       assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-12);
     }
@@ -94,16 +85,11 @@ class TPflashAqueousRootConsistencyTest {
   private double maximumLogFugacityResidual(SystemInterface system) {
     double maximumResidual = 0.0;
     for (int componentIndex = 0; componentIndex < FEED.length; componentIndex++) {
-      double firstLogFugacity = Math.log(Math.max(
-          system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
-          + Math.log(system.getPhase(0).getComponent(componentIndex)
-              .getFugacityCoefficient());
-      double secondLogFugacity = Math.log(Math.max(
-          system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
-          + Math.log(system.getPhase(1).getComponent(componentIndex)
-              .getFugacityCoefficient());
-      maximumResidual =
-          Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+      double firstLogFugacity = Math.log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math.log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
     }
     return maximumResidual;
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootConsistencyTest.java
@@ -1,0 +1,110 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashAqueousRootConsistencyTest {
+  private static final double[] FEED = {0.90, 0.10};
+
+  @Test
+  void ordinaryAndMultiphaseFlashesRetainSameStableCubicRoot() {
+    assertStableRootConsistency(false);
+    assertStableRootConsistency(true);
+  }
+
+  private void assertStableRootConsistency(boolean pengRobinson) {
+    SystemInterface ordinary = createAndFlash(pengRobinson, false);
+    SystemInterface multiphase = createAndFlash(pengRobinson, true);
+
+    assertEquivalentEquilibrium(multiphase, ordinary);
+    double firstGibbsEnergy = ordinary.getGibbsEnergy();
+    double firstEnthalpy = ordinary.getEnthalpy();
+
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.init(3);
+    ordinary.initProperties();
+
+    assertEquals(firstGibbsEnergy, ordinary.getGibbsEnergy(), 1.0e-8);
+    assertEquals(firstEnthalpy, ordinary.getEnthalpy(), 1.0e-8);
+    assertEquivalentEquilibrium(multiphase, ordinary);
+  }
+
+  private SystemInterface createAndFlash(boolean pengRobinson, boolean multiphaseCheck) {
+    SystemInterface system =
+        pengRobinson ? new SystemPrEos(273.15, 50.0) : new SystemSrkEos(273.15, 50.0);
+    system.addComponent("CO2", FEED[0]);
+    system.addComponent("water", FEED[1]);
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    system.initProperties();
+    return system;
+  }
+
+  private void assertEquivalentEquilibrium(SystemInterface expected,
+      SystemInterface actual) {
+    assertEquals(2, expected.getNumberOfPhases());
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-8);
+    assertEquals(expected.getEnthalpy(), actual.getEnthalpy(), 1.0e-8);
+
+    for (int phaseIndex = 0; phaseIndex < expected.getNumberOfPhases(); phaseIndex++) {
+      assertEquals(expected.getPhase(phaseIndex).getType(),
+          actual.getPhase(phaseIndex).getType());
+      assertEquals(expected.getBeta(phaseIndex), actual.getBeta(phaseIndex), 1.0e-12);
+      assertEquals(expected.getPhase(phaseIndex).getDensity(),
+          actual.getPhase(phaseIndex).getDensity(), 1.0e-8);
+      assertTrue(actual.getBeta(phaseIndex) > 0.0);
+      assertTrue(actual.getBeta(phaseIndex) < 1.0);
+      assertTrue(Double.isFinite(actual.getPhase(phaseIndex).getZ()));
+      assertTrue(actual.getPhase(phaseIndex).getZ() > 0.0);
+
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0;
+          componentIndex < expected.getPhase(phaseIndex).getNumberOfComponents();
+          componentIndex++) {
+        double expectedComposition =
+            expected.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        double actualComposition =
+            actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        assertEquals(expectedComposition, actualComposition, 1.0e-12);
+        compositionTotal += actualComposition;
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-12);
+    }
+
+    assertEquals(1.0, actual.getBeta(0) + actual.getBeta(1), 1.0e-12);
+    for (int componentIndex = 0; componentIndex < FEED.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < actual.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += actual.getBeta(phaseIndex)
+            * actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-12);
+    }
+    assertTrue(maximumLogFugacityResidual(actual) < 1.0e-8);
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < FEED.length; componentIndex++) {
+      double firstLogFugacity = Math.log(Math.max(
+          system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex)
+              .getFugacityCoefficient());
+      double secondLogFugacity = Math.log(Math.max(
+          system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex)
+              .getFugacityCoefficient());
+      maximumResidual =
+          Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+    }
+    return maximumResidual;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootConsistencyTest.java
@@ -77,7 +77,7 @@ class TPflashAqueousRootConsistencyTest {
       for (int phaseIndex = 0; phaseIndex < actual.getNumberOfPhases(); phaseIndex++) {
         recoveredFeed += actual.getBeta(phaseIndex) * actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
-      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-12);
+      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-11);
     }
     assertTrue(maximumLogFugacityResidual(actual) < 1.0e-8);
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootConsistencyTest.java
@@ -62,7 +62,8 @@ class TPflashAqueousRootConsistencyTest {
       assertTrue(actual.getPhase(phaseIndex).getZ() > 0.0);
 
       double compositionTotal = 0.0;
-      for (int componentIndex = 0; componentIndex < expected.getPhase(phaseIndex).getNumberOfComponents(); componentIndex++) {
+      for (int componentIndex = 0; componentIndex < expected.getPhase(phaseIndex)
+          .getNumberOfComponents(); componentIndex++) {
         double expectedComposition = expected.getPhase(phaseIndex).getComponent(componentIndex).getx();
         double actualComposition = actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
         assertEquals(expectedComposition, actualComposition, 1.0e-12);
@@ -85,9 +86,11 @@ class TPflashAqueousRootConsistencyTest {
   private double maximumLogFugacityResidual(SystemInterface system) {
     double maximumResidual = 0.0;
     for (int componentIndex = 0; componentIndex < FEED.length; componentIndex++) {
-      double firstLogFugacity = Math.log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+      double firstLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
           + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
-      double secondLogFugacity = Math.log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+      double secondLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
           + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
       maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
     }


### PR DESCRIPTION
## Problem

The ordinary two-phase TPflash and TPmultiflash can converge to identical phase fractions and phase compositions but retain different cubic roots for the non-aqueous phase of a neutral aqueous split.

Minimal deterministic reproduction (SRK, classic mixing rule; z = CO2 0.90 / water 0.10; 273.15 K, 50 bara):

| Signal after `init(3)` | ordinary TPflash on master | TPmultiflash |
|---|---:|---:|
| phases | GAS + AQUEOUS | GAS + AQUEOUS |
| beta/compositions | identical | identical |
| non-aqueous Z | 0.4879513277 | 0.1167829288 |
| total Gibbs energy | 5909.722377 J | 5546.556410 J |
| total enthalpy | -8470.565728 J | -16093.605071 J |
| max abs(log-fugacity residual) | 2.245811698 | 5.8741e-11 |

The ordinary result is therefore not the same equilibrium state: its higher cubic root violates component fugacity equality even though beta and x appear converged.

No open PR or issue was found that implements this correction. The recently merged #2689 and #2694 repair missing water-rich phase endpoints; this defect is a distinct root-selection inconsistency after an aqueous split already exists.

## Root cause and bounded fix

For an ordinary, neutral, exactly-two-phase result containing an AQUEOUS phase, TPflash now evaluates the GAS and LIQUID cubic roots of each non-aqueous cubic phase on clones at the already-converged composition.

The live phase is replaced only when all safeguards pass:

- the alternate root lowers extensive Gibbs energy by more than `max(1e-6 J, abs(G) * 1e-8)`;
- the unchanged two-phase composition already satisfies `max abs(Delta ln(f_i)) < 1e-8` with that root;
- the system is not multiphase-enabled, chemical, ionic, solid, or wax;
- phase fractions and compositions are not modified.

The accepted trial phase is already initialized, so the fix adds no TPflash retry, TPmultiflash call, TPD calculation, or phase-fraction solve. Dry and hydrocarbon-only flashes exit before cloning a phase.

## Method and literature basis

At fixed T and P, the stable phase split minimizes total Gibbs energy and satisfies component fugacity equality. The safeguard applies both conditions rather than selecting a cubic root from its phase label alone.

- Michelsen (1982), [Part I: Stability](https://doi.org/10.1016/0378-3812(82)85001-2)
- Michelsen (1982), [Part II: Phase-split calculation](https://doi.org/10.1016/0378-3812(82)85002-4)

Evidence: the alternate root lowers Gibbs energy and reduces the maximum log-fugacity residual from 2.2458 to 5.87e-11 in the minimal case while leaving beta, x, and material balance unchanged. Inference: a phase label alone is insufficient to discriminate coexisting real cubic roots. No claim is made about proprietary commercial-simulator internals.

## Cross-algorithm matrix

A deterministic 450-state matrix covered SRK, PR, and SRK-CPA; classic and CPA mixing rules; methane/water, wet gas, oil/water, CO2/water, and hydrogen/water; six temperatures from 230 to 373.15 K; and five pressures from 1 to 300 bara.

| Signal | master | this branch |
|---|---:|---:|
| successful ordinary/multiphase pairs | 450/450 | 450/450 |
| structural disagreements where multiphase has <=2 phases | 0 | 0 |
| numerical disagreements | 26 | 22 |

The four corrected states are SRK and PR CO2/water at 273.15 K / 50 bara and 298.15 K / 100 bara. Before the fix, ordinary-minus-multiphase Gibbs differences were 363.166 J and 284.155 J for SRK, and 362.371 J and 266.592 J for PR. After the fix, root, beta, composition, Gibbs energy, enthalpy, density, and repeat execution agree within the test tolerances.

The remaining 22 disagreements are unchanged and remain separate targets; no tolerance was loosened.

## Performance

Ten fresh-JVM fork medians (construction + flash + `init(3)`, 80-120 samples/fork):

| Case | master median-of-medians | branch median-of-medians |
|---|---:|---:|
| dry gas | 5.040 ms | 4.830 ms |
| hydrocarbon VLE | 4.144 ms | 4.390 ms |
| unaffected aqueous control | 4.349 ms | 4.167 ms |
| corrected CO2/water root | 4.464 ms | 4.473 ms |

Run-to-run variance is material; these data support no measurable regression, not a speedup claim. The corrected-case median changed by +0.2%. Dry-gas, hydrocarbon-VLE, and control checksums are unchanged.

## Validation

Added `TPflashAqueousRootConsistencyTest` for SRK and PR. It checks:

- ordinary/multiphase phase state, beta, composition, density, Gibbs energy, and enthalpy;
- component and total material balance;
- beta bounds and composition normalization;
- positive finite compressibility factors;
- `max abs(Delta ln(f_i)) < 1e-8`;
- deterministic repeat execution and root retention after `init(3)`.

Local validation:

- Java 17 production source compilation passed against the packaged NeqSim runtime;
- focused test source compilation passed;
- executable SRK/PR reproducer passed;
- deterministic 450-state matrix passed with 450/450 successful pairs;
- ten-fork runtime comparison completed.

Not run locally: Maven/JUnit execution, Spotless, the complete test suite, Javadocs, or Java 8 because Maven Central dependency resolution is unavailable in this workspace. GitHub CI will provide repository-level validation.

## Numerical tolerances and compatibility risk

- root acceptance equilibrium residual: `1e-8` in maximum absolute log fugacity;
- Gibbs acceptance: `max(1e-6 J, abs(G) * 1e-8)`;
- regression beta/composition tolerance: `1e-12`;
- regression Gibbs/enthalpy tolerance: `1e-8 J`;
- density tolerance: `1e-8 kg/m3`.

No public API or serialization change. Compatibility risk is low and intentionally thermodynamic: only a neutral ordinary two-phase aqueous result with a demonstrably lower-Gibbs, already-equilibrated alternate cubic root can change.

## Documentation impact

Updated `TPflash_algorithm.md` and method Javadocs to document the post-convergence aqueous cubic-root safeguard, its fugacity/Gibbs acceptance criteria, exclusions, and fast-path behavior.