### PR TITLE
fix: preserve three-fluid stratified geometry across diameters

### DIFF
--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -712,6 +712,17 @@ For gas-oil-water systems, `ThreeFluidSection` and `ThreeFluidConservationEquati
         └─────────────────┘
 ```
 
+`ThreeFluidSection` obtains the water and combined-liquid levels by inverting the
+circular-segment area:
+
+$$A(h)=\frac{r^2}{2}\left(\theta-\sin\theta\right),\qquad\theta=2\cos^{-1}\left(1-\frac{2h}{D}\right)$$
+
+The Newton iteration uses the exact derivative
+$$\frac{\mathrm{d}A}{\mathrm{d}h}=2\sqrt{h(D-h)}$$
+so the recovered levels, wetted perimeters, and interfacial widths remain geometrically
+similar across pipe diameters. The regression test checks both the water layer and the
+combined oil-water layer from 0.05 m to 2.0 m diameter.
+
 ## Simulation Modes: Steady-State vs Transient
 
 The `TwoFluidPipe` supports two simulation modes: steady-state initialization via `run()` and incremental transient simulation via `runTransient()`.

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSection.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSection.java
@@ -294,9 +294,11 @@ public class ThreeFluidSection extends TwoFluidSection {
       double theta = 2.0 * Math.acos(arg);
       double area = r * r * (theta - Math.sin(theta)) / 2.0;
 
-      // Derivative: dA/dh = 2*r*sqrt(h*(d-h))
+      // Exact circular-segment derivative: dA/dh = 2*sqrt(h*(d-h)).
+      // It has units of length; multiplying by radius would make the Newton step
+      // depend on pipe diameter and violate geometric similarity.
       double sqrtTerm = Math.sqrt(Math.max(0.0, h * (d - h)));
-      double dArea_dh = 2.0 * r * sqrtTerm;
+      double dArea_dh = 2.0 * sqrtTerm;
 
       double error = area - targetArea;
       if (Math.abs(error) < 1e-12 * totalArea) {

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSectionTest.java
@@ -135,9 +135,8 @@ class ThreeFluidSectionTest {
 
   @Test
   void testThreeLayerGeometryConservesSegmentAreaAcrossPipeDiameters() {
-    double[] diameters = {0.05, 0.10, 0.30, 1.0, 2.0};
-    double[][] holdupSets = {{0.94, 0.05, 0.01}, {0.80, 0.15, 0.05}, {0.50, 0.30, 0.20},
-        {0.10, 0.45, 0.45}};
+    double[] diameters = { 0.05, 0.10, 0.30, 1.0, 2.0 };
+    double[][] holdupSets = { { 0.94, 0.05, 0.01 }, { 0.80, 0.15, 0.05 }, { 0.50, 0.30, 0.20 }, { 0.10, 0.45, 0.45 } };
 
     for (double diameter : diameters) {
       for (double[] holdups : holdupSets) {
@@ -159,8 +158,17 @@ class ThreeFluidSectionTest {
   }
 
   private static double circularSegmentArea(double level, double diameter) {
+    if (level <= 0.0) {
+      return 0.0;
+    }
+    if (level >= diameter) {
+      return Math.PI * diameter * diameter / 4.0;
+    }
+
     double radius = diameter / 2.0;
-    double theta = 2.0 * Math.acos(1.0 - 2.0 * level / diameter);
+    double cosineArgument = 1.0 - 2.0 * level / diameter;
+    cosineArgument = Math.max(-1.0, Math.min(1.0, cosineArgument));
+    double theta = 2.0 * Math.acos(cosineArgument);
     return radius * radius * (theta - Math.sin(theta)) / 2.0;
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSectionTest.java
@@ -136,8 +136,7 @@ class ThreeFluidSectionTest {
   @Test
   void testThreeLayerGeometryConservesSegmentAreaAcrossPipeDiameters() {
     double[] diameters = { 0.05, 0.10, 0.30, 1.0, 2.0 };
-    double[][] holdupSets = {
-        { 0.94, 0.05, 0.01 }, // Near-single-gas
+    double[][] holdupSets = { { 0.94, 0.05, 0.01 }, // Near-single-gas
         { 0.80, 0.15, 0.05 }, // Gas-rich
         { 0.50, 0.30, 0.20 }, // Mixed holdup
         { 0.10, 0.45, 0.45 }, // Liquid-rich

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSectionTest.java
@@ -136,7 +136,9 @@ class ThreeFluidSectionTest {
   @Test
   void testThreeLayerGeometryConservesSegmentAreaAcrossPipeDiameters() {
     double[] diameters = { 0.05, 0.10, 0.30, 1.0, 2.0 };
-    double[][] holdupSets = { { 0.94, 0.05, 0.01 }, { 0.80, 0.15, 0.05 }, { 0.50, 0.30, 0.20 }, { 0.10, 0.45, 0.45 } };
+    double[][] holdupSets = {
+        { 0.94, 0.05, 0.01 }, { 0.80, 0.15, 0.05 }, { 0.50, 0.30, 0.20 },
+        { 0.10, 0.45, 0.45 } };
 
     for (double diameter : diameters) {
       for (double[] holdups : holdupSets) {

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSectionTest.java
@@ -134,6 +134,37 @@ class ThreeFluidSectionTest {
   }
 
   @Test
+  void testThreeLayerGeometryConservesSegmentAreaAcrossPipeDiameters() {
+    double[] diameters = {0.05, 0.10, 0.30, 1.0, 2.0};
+    double[][] holdupSets = {{0.94, 0.05, 0.01}, {0.80, 0.15, 0.05}, {0.50, 0.30, 0.20},
+        {0.10, 0.45, 0.45}};
+
+    for (double diameter : diameters) {
+      for (double[] holdups : holdupSets) {
+        ThreeFluidSection testSection = new ThreeFluidSection(0.0, 10.0, diameter, 0.0);
+        testSection.setHoldups(holdups[0], holdups[1], holdups[2]);
+        testSection.updateThreeLayerGeometry();
+
+        double waterAreaFromLevel = circularSegmentArea(testSection.getWaterLevel(), diameter);
+        double combinedLiquidLevel = testSection.getWaterLevel() + testSection.getOilLevel();
+        double combinedLiquidAreaFromLevel = circularSegmentArea(combinedLiquidLevel, diameter);
+        double totalArea = testSection.getArea();
+
+        assertEquals(testSection.getWaterArea(), waterAreaFromLevel, 1e-12 * totalArea,
+            "Water level must reproduce water holdup area for D=" + diameter + " m");
+        assertEquals(testSection.getWaterArea() + testSection.getOilArea(), combinedLiquidAreaFromLevel,
+            1e-12 * totalArea, "Combined liquid level must reproduce liquid holdup area for D=" + diameter + " m");
+      }
+    }
+  }
+
+  private static double circularSegmentArea(double level, double diameter) {
+    double radius = diameter / 2.0;
+    double theta = 2.0 * Math.acos(1.0 - 2.0 * level / diameter);
+    return radius * radius * (theta - Math.sin(theta)) / 2.0;
+  }
+
+  @Test
   void testWettedPerimetersArePositive() {
     section.setHoldups(0.5, 0.3, 0.2);
     section.updateThreeLayerGeometry();

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThreeFluidSectionTest.java
@@ -137,8 +137,11 @@ class ThreeFluidSectionTest {
   void testThreeLayerGeometryConservesSegmentAreaAcrossPipeDiameters() {
     double[] diameters = { 0.05, 0.10, 0.30, 1.0, 2.0 };
     double[][] holdupSets = {
-        { 0.94, 0.05, 0.01 }, { 0.80, 0.15, 0.05 }, { 0.50, 0.30, 0.20 },
-        { 0.10, 0.45, 0.45 } };
+        { 0.94, 0.05, 0.01 }, // Near-single-gas
+        { 0.80, 0.15, 0.05 }, // Gas-rich
+        { 0.50, 0.30, 0.20 }, // Mixed holdup
+        { 0.10, 0.45, 0.45 }, // Liquid-rich
+    };
 
     for (double diameter : diameters) {
       for (double[] holdups : holdupSets) {


### PR DESCRIPTION
## Summary

- correct the Newton derivative used to invert circular-segment area in `ThreeFluidSection`
- add a Java 8 regression that verifies water and combined oil-water areas across five pipe diameters and four phase-holdup sets
- document the three-layer geometry equations and scale-invariance requirement

## Root cause and impact

The circular-segment area is

`A(h) = r²(θ - sin θ)/2`, with `θ = 2 acos(1 - 2h/D)`.

Its exact derivative is `dA/dh = 2 sqrt(h(D-h))`. The implementation multiplied that derivative by an extra radius, giving it units of area instead of length. The resulting Newton step depended on absolute pipe diameter and frequently exhausted all 50 iterations for ordinary pipeline diameters.

On the baseline implementation, the new regression's 0.05 m diameter / 5% water case requested `9.817477042468105e-5 m²` but the returned level reproduced only `1.0062305874050833e-15 m²`. This propagates into water/oil levels, wetted perimeters, gas-oil and oil-water interfacial widths, and therefore the wall/interfacial shear forces used by the three-fluid momentum equations.

The change removes the spurious radius multiplier. It does not alter a public API or tune an empirical correlation.

## Validation

- reproduced the defect first with a failing focused JUnit test on current `master` (`3ae4a463`)
- compiled the affected production classes and test with Temurin 17 `javac --release 8`
- ran all `ThreeFluidSectionTest` tests: **18 passed, 0 failed**
- regression covers diameters `0.05, 0.10, 0.30, 1.0, 2.0 m`
- regression covers gas/oil/water holdups from near-single-gas `0.94/0.05/0.01` through liquid-rich `0.10/0.45/0.45`
- both the water level and combined oil-water level must reproduce the exact analytical segment area within `1e-12` of total pipe area
- `git diff --check` passed

The validation target is the exact circular-segment identity, which is stronger and more direct for this numerical defect than fitting to experimental pressure-drop data. Published three-layer gas-oil-water models depend on consistent phase geometry, while OLGA's published two-fluid formulation validates pressure drop, holdup, and regime behavior against laboratory/field data:

- Bendiksen et al. (1991), *The Dynamic Two-Fluid Model OLGA: Theory and Application*, [doi:10.2118/19451-PA](https://doi.org/10.2118/19451-PA)
- Amooey et al. (2014), *Transition Model of Stratified Oil-water Flow in a Horizontal Pipe*, [doi:10.1080/10916466.2011.606551](https://doi.org/10.1080/10916466.2011.606551)

### Local validation limitation

The repository-wide Maven/Spotless gates could not be executed locally because the sandboxed Maven process could not resolve Maven Central through the available network proxy. The focused source and tests were compiled independently with Java 8 bytecode targeting; hosted CI should run Maven, Spotless, Javadocs, and the broader matrix.

## Compatibility

- public API: unchanged
- serialization fields: unchanged
- thermodynamic model and phase equilibrium: unchanged
- numerical behavior: corrected only for three-layer stratified geometry inversion
- overlapping work: none found; open PR #2691 changes diagnostic/reporting APIs rather than this geometry solver

## Documentation impact

Updated `docs/wiki/two_fluid_model.md` with the circular-segment area, exact derivative, affected geometry quantities, and tested diameter range.