### PR TITLE
docs: require minimal thermodynamic initialization levels

### DIFF
--- a/.github/instructions/thermodynamic-initialization.instructions.md
+++ b/.github/instructions/thermodynamic-initialization.instructions.md
@@ -1,0 +1,21 @@
+---
+applyTo: "src/**/*.java,src/test/**/*.java,.github/skills/**/*.md,docs/**/*.md"
+---
+
+# Minimal thermodynamic initialization level
+
+Use the lowest NeqSim thermodynamic initialization level that is sufficient for the quantities being evaluated. Do not raise an initialization level defensively or because a higher level is available.
+
+## Required rule
+
+- Use `init(0)` only for composition and phase-amount bookkeeping that does not require EOS state.
+- Use `init(1)` for fixed-temperature/fixed-pressure phase-equilibrium work: cubic-root selection, molar volume and compressibility factor, fugacity coefficients, chemical potentials, tangent-plane or Gibbs-equilibrium comparisons, phase stability, and TP-flash iteration state.
+- Use `init(2)` only when first temperature derivatives or caloric properties are actually required, such as enthalpy, entropy, heat capacity, Joule-Thomson coefficients, or temperature derivatives of residual Helmholtz/Gibbs terms.
+- Use `init(3)` only when second composition derivatives, full derivative matrices, or another explicitly documented level-3 quantity is required.
+- Use `initProperties()` only when physical/transport properties are required. Do not substitute `init(3)` for physical-property initialization.
+
+Before adding or increasing an initialization level, identify the exact downstream getter or derivative that requires it and verify that requirement in the relevant phase/component implementation. If the code only evaluates cubic roots, fugacity equality, fixed-T/P Gibbs equilibrium, phase fractions, or compositions, `init(1)` is normally sufficient.
+
+Higher initialization levels add avoidable calculations in flash and process-simulation hot paths. A change from `init(1)` to `init(2)` or `init(3)` therefore requires a correctness-based justification and focused validation; it must not be accepted solely from an automated review suggestion.
+
+When reducing an existing initialization level, add focused tests showing unchanged requested results and benchmark stable metrics where the path is performance-sensitive.

--- a/.github/skills/neqsim-thermodynamic-initialization/SKILL.md
+++ b/.github/skills/neqsim-thermodynamic-initialization/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: neqsim-thermodynamic-initialization
+description: Select and audit NeqSim thermodynamic initialization levels for correctness and performance.
+---
+
+# NeqSim thermodynamic initialization
+
+Use this skill whenever implementing or reviewing flashes, phase stability, EOS root selection, process-equipment thermodynamics, property access, or performance changes involving `init(...)` or `initProperties()`.
+
+## Core rule
+
+Always use the lowest initialization level required by the quantities actually consumed:
+
+| Level | Use for |
+|---|---|
+| `init(0)` | Composition, phase amounts, and basic bookkeeping without EOS properties |
+| `init(1)` | Fixed-T/P EOS state, cubic roots, molar volume, Z, fugacity coefficients, chemical potentials, phase-equilibrium Gibbs comparisons, TPD/stability calculations, and TP-flash iterations |
+| `init(2)` | Caloric properties and first temperature derivatives: enthalpy, entropy, Cp/Cv, Joule-Thomson coefficient, and related temperature derivatives |
+| `init(3)` | Second composition derivatives, derivative matrices, and other explicitly verified level-3 quantities |
+| `initProperties()` | Density models and transport/interfacial properties when those properties are requested |
+
+Do not call `init(2)` or `init(3)` merely to be safe. Before increasing a level, trace the exact downstream getter and confirm its dependency in `Phase`, `PhaseEos`, the component implementation, or the relevant property model.
+
+For fixed-T/P cubic-root selection and fugacity/Gibbs equilibrium checks, prefer `init(1)`. Temperature derivative caches such as `loc_AT` and `loc_ATT` support caloric properties; they are not by themselves evidence that a fixed-T/P flash-Gibbs comparison requires `init(2)`.
+
+## Review checklist
+
+1. Identify every property read after the initialization call.
+2. Map each property to the minimum required level from source code, not assumption.
+3. Reject automated suggestions that raise the level without a demonstrated dependency.
+4. For a proposed reduction, add focused tests proving unchanged requested quantities and convergence.
+5. For hot paths, report iterations, flash calls, allocations, or benchmark results; avoid flaky wall-clock CI assertions.
+6. Keep `initProperties()` separate from thermodynamic derivative levels.
+
+## Audit guidance
+
+Search production code for `init(2)` and `init(3)`. Prioritize calls inside iterative flashes, recycle loops, tray/column iteration, transient flow cells, and frequently executed unit operations. Do not bulk-replace them. Handle one bounded call path at a time, prove that downstream consumers need only a lower level, add regression coverage, and measure the benefit before opening a PR.


### PR DESCRIPTION
## Summary

Adds a repository-wide engineering rule and dedicated skill requiring NeqSim code and reviews to use the lowest thermodynamic initialization level needed by the quantities actually consumed.

## Rule added

- `init(1)` for fixed-T/P EOS state, cubic roots, fugacity coefficients, chemical potentials, TP-flash/stability work, and phase-equilibrium Gibbs comparisons.
- `init(2)` only for caloric properties and first temperature derivatives.
- `init(3)` only for explicitly required second composition derivatives or full derivative matrices.
- `initProperties()` only for requested physical/transport properties.

Automated review suggestions must not increase an initialization level without tracing a concrete downstream dependency in the relevant phase/component/property implementation.

## Files

- `.github/instructions/thermodynamic-initialization.instructions.md` applies the rule to Java, tests, skills, and documentation.
- `.github/skills/neqsim-thermodynamic-initialization/SKILL.md` provides a reusable review and audit workflow.

## Existing-code audit

Opened #2698 to inspect existing `init(2)`/`init(3)` call sites one bounded path at a time. The issue explicitly forbids bulk replacement and requires focused regression and performance evidence.

## Validation

Documentation/agent-guidance only; no Java behavior or public API changes. Reviewed against current `PhaseEos.init` level semantics and existing TPflash usage.

Documentation impact: this PR is the documentation and skill update.