### PR TITLE
fix: run each controller once per transient step

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -34,11 +34,13 @@ Each timestep:
    order or dependency-aware graph levels when parallel transient execution is
    enabled. Setter units are excluded from these explicit, semi-implicit, and
    parallel equipment passes.
-4. Standalone controllers run; equipment-embedded controllers retain their
-   equipment-specific execution timing for compatibility. Controller ownership
-   is identity-based: registering an embedded controller separately, or adding
-   one standalone controller instance repeatedly, does not update its PID state
-   more than once per timestep.
+4. Standalone controllers run; controllers actually executed inside equipment
+   retain their equipment-specific timing for compatibility. Execution is
+   coalesced by object identity and the timestep calculation identifier. Merely
+   attaching a controller to equipment that does not execute it must not suppress
+   the standalone update; repeated standalone registration runs once per step.
+   Custom controllers integrated by equipment must report the completed identifier
+   through `hasRunTransient(UUID)`.
 5. Measurement devices are sampled, alarms are evaluated, and history is stored.
 
 ## Basic Dynamic Setup

--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -35,7 +35,10 @@ Each timestep:
    enabled. Setter units are excluded from these explicit, semi-implicit, and
    parallel equipment passes.
 4. Standalone controllers run; equipment-embedded controllers retain their
-   equipment-specific execution timing for compatibility.
+   equipment-specific execution timing for compatibility. Controller ownership
+   is identity-based: registering an embedded controller separately, or adding
+   one standalone controller instance repeatedly, does not update its PID state
+   more than once per timestep.
 5. Measurement devices are sampled, alarms are evaluated, and history is stored.
 
 ## Basic Dynamic Setup

--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -39,8 +39,10 @@ Each timestep:
    coalesced by object identity and the timestep calculation identifier. Merely
    attaching a controller to equipment that does not execute it must not suppress
    the standalone update; repeated standalone registration runs once per step.
-   Custom controllers integrated by equipment must report the completed identifier
-   through `hasRunTransient(UUID)`.
+   `ControllerDeviceBaseClass` also makes repeated calls with one identifier
+   idempotent, including semi-implicit equipment passes. Custom controllers
+   integrated by equipment must implement the same identifier contract through
+   `hasRunTransient(UUID)`.
 5. Measurement devices are sampled, alarms are evaluated, and history is stored.
 
 ## Basic Dynamic Setup

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -528,12 +528,17 @@ is applied once and its own clock advances by the same $\Delta t$ as the process
 Setters are excluded from the later explicit, semi-implicit, and parallel
 equipment passes.
 
-Controller execution is identity-based. A controller attached to equipment runs
-inside that equipment's transient update. Registering the same object separately
-with `process.add(controller)` keeps it discoverable but does not run its time,
-integral, derivative, or event-log state twice. Repeated standalone registration
-is also coalesced to one update per timestep; distinct controller objects remain
-independent even if they share a name.
+Controller execution is coalesced by object identity and timestep calculation
+identifier. Equipment that actually integrates a controller passes the same
+calculation identifier to the controller; registering that object separately with
+`process.add(controller)` therefore keeps it discoverable without advancing its
+time, integral, derivative, or event-log state twice. Merely attaching a controller
+to equipment that does not execute it does not suppress the standalone update.
+Repeated standalone registration is also coalesced to one update per timestep;
+distinct controller objects remain independent even if they share a name.
+`ControllerDeviceBaseClass` tracks the identifier automatically; custom controller
+implementations that integrate inside equipment should implement
+`hasRunTransient(UUID)`.
 
 ### 5.2 Parallel Transient Execution
 
@@ -600,7 +605,7 @@ process.setIntegrationMethod(IntegrationMethod.RUNGE_KUTTA_4);    // Higher-orde
 
 ## 6. Test Coverage
 
-The features in this guide are covered by six focused test classes with 75
+The features in this guide are covered by six focused test classes with 76
 total tests:
 
 | Test Class | Tests | Coverage |
@@ -610,7 +615,7 @@ total tests:
 | `DynamicImprovementsPhase3Test` | 16 | Transmitter filter, alarm shelving, separator internals, HX thermal model, distillation MESH dynamics |
 | `ProcessSystemParallelTransientTest` | 9 | Worker reuse, copy lifecycle, dependency ordering, independent-level concurrency, and interruption behavior at waits and level boundaries |
 | `ProcessSystemTransientSetterTest` | 3 | Single setter application, repeated-step clock advancement, and explicit, semi-implicit, and parallel execution |
-| `ProcessSystemTransientControllerTest` | 3 | Equipment ownership, duplicate standalone registration, identity semantics, and repeated timesteps |
+| `ProcessSystemTransientControllerTest` | 4 | Equipment execution, attachment-only fallback, duplicate standalone registration, identity semantics, and repeated timesteps |
 
 Run all tests:
 

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -536,9 +536,10 @@ time, integral, derivative, or event-log state twice. Merely attaching a control
 to equipment that does not execute it does not suppress the standalone update.
 Repeated standalone registration is also coalesced to one update per timestep;
 distinct controller objects remain independent even if they share a name.
-`ControllerDeviceBaseClass` tracks the identifier automatically; custom controller
-implementations that integrate inside equipment should implement
-`hasRunTransient(UUID)`.
+`ControllerDeviceBaseClass` tracks the identifier automatically and makes
+repeated calls with one identifier idempotent, including semi-implicit equipment
+passes. Custom controller implementations that integrate inside equipment should
+implement `hasRunTransient(UUID)` and the same one-update-per-identifier contract.
 
 ### 5.2 Parallel Transient Execution
 
@@ -605,7 +606,7 @@ process.setIntegrationMethod(IntegrationMethod.RUNGE_KUTTA_4);    // Higher-orde
 
 ## 6. Test Coverage
 
-The features in this guide are covered by six focused test classes with 76
+The features in this guide are covered by six focused test classes with 77
 total tests:
 
 | Test Class | Tests | Coverage |
@@ -615,7 +616,7 @@ total tests:
 | `DynamicImprovementsPhase3Test` | 16 | Transmitter filter, alarm shelving, separator internals, HX thermal model, distillation MESH dynamics |
 | `ProcessSystemParallelTransientTest` | 9 | Worker reuse, copy lifecycle, dependency ordering, independent-level concurrency, and interruption behavior at waits and level boundaries |
 | `ProcessSystemTransientSetterTest` | 3 | Single setter application, repeated-step clock advancement, and explicit, semi-implicit, and parallel execution |
-| `ProcessSystemTransientControllerTest` | 4 | Equipment execution, attachment-only fallback, duplicate standalone registration, identity semantics, and repeated timesteps |
+| `ProcessSystemTransientControllerTest` | 5 | Equipment execution, semi-implicit passes, attachment-only fallback, duplicate standalone registration, identity semantics, and repeated timesteps |
 
 Run all tests:
 

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -528,6 +528,13 @@ is applied once and its own clock advances by the same $\Delta t$ as the process
 Setters are excluded from the later explicit, semi-implicit, and parallel
 equipment passes.
 
+Controller execution is identity-based. A controller attached to equipment runs
+inside that equipment's transient update. Registering the same object separately
+with `process.add(controller)` keeps it discoverable but does not run its time,
+integral, derivative, or event-log state twice. Repeated standalone registration
+is also coalesced to one update per timestep; distinct controller objects remain
+independent even if they share a name.
+
 ### 5.2 Parallel Transient Execution
 
 For large flowsheets, equipment-level transient calculations can be run in
@@ -593,7 +600,7 @@ process.setIntegrationMethod(IntegrationMethod.RUNGE_KUTTA_4);    // Higher-orde
 
 ## 6. Test Coverage
 
-The features in this guide are covered by five focused test classes with 72
+The features in this guide are covered by six focused test classes with 75
 total tests:
 
 | Test Class | Tests | Coverage |
@@ -603,11 +610,12 @@ total tests:
 | `DynamicImprovementsPhase3Test` | 16 | Transmitter filter, alarm shelving, separator internals, HX thermal model, distillation MESH dynamics |
 | `ProcessSystemParallelTransientTest` | 9 | Worker reuse, copy lifecycle, dependency ordering, independent-level concurrency, and interruption behavior at waits and level boundaries |
 | `ProcessSystemTransientSetterTest` | 3 | Single setter application, repeated-step clock advancement, and explicit, semi-implicit, and parallel execution |
+| `ProcessSystemTransientControllerTest` | 3 | Equipment ownership, duplicate standalone registration, identity semantics, and repeated timesteps |
 
 Run all tests:
 
 ```bash
-./mvnw test -Dtest=DynamicImprovementsTest,DynamicImprovementsPhase2Test,DynamicImprovementsPhase3Test,ProcessSystemParallelTransientTest,ProcessSystemTransientSetterTest
+./mvnw test -Dtest=DynamicImprovementsTest,DynamicImprovementsPhase2Test,DynamicImprovementsPhase3Test,ProcessSystemParallelTransientTest,ProcessSystemTransientSetterTest,ProcessSystemTransientControllerTest
 ```
 
 ---

--- a/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
+++ b/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
@@ -268,6 +268,12 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
 
   /** {@inheritDoc} */
   @Override
+  public boolean hasRunTransient(UUID id) {
+    return id != null && id.equals(calcIdentifier);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public void setControllerSetPoint(double signal) {
     this.controllerSetPoint = signal;
   }

--- a/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
+++ b/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
@@ -136,6 +136,9 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
    */
   @Override
   public void runTransient(double initResponse, double dt, UUID id) {
+    if (hasRunTransient(id)) {
+      return;
+    }
     if (!isActive) {
       totalTime += dt;
       response = initResponse;

--- a/src/main/java/neqsim/process/controllerdevice/ControllerDeviceInterface.java
+++ b/src/main/java/neqsim/process/controllerdevice/ControllerDeviceInterface.java
@@ -98,6 +98,23 @@ public interface ControllerDeviceInterface extends ProcessElementInterface {
   public void runTransient(double initResponse, double dt, UUID id);
 
   /**
+   * Reports whether this controller has already completed the transient update identified by {@code id}.
+   *
+   * <p>
+   * Equipment that integrates a controller inside its own {@code runTransient} implementation passes through the
+   * process timestep identifier. The process-level standalone controller phase uses this method to avoid advancing the
+   * same controller state twice. Implementations that do not track calculation identifiers retain the conservative
+   * default and are executed by the standalone phase.
+   * </p>
+   *
+   * @param id calculation identifier for the current process timestep
+   * @return {@code true} only when this controller completed a transient update with the same identifier
+   */
+  public default boolean hasRunTransient(UUID id) {
+    return false;
+  }
+
+  /**
    * getResponse.
    *
    * @return a double

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -612,9 +612,10 @@ public class ProcessSystem extends SimulationBaseClass {
 
   /**
    * Add a standalone controller device to the process system. Controllers added here participate in the explicit
-   * controller scan during {@code runTransient}. A controller instance that is also attached to equipment remains
-   * discoverable in this list but is executed only through its equipment owner. Repeated standalone registration of the
-   * same instance likewise schedules one controller update per timestep.
+   * controller scan during {@code runTransient}. Each controller identity is scheduled at most once in that scan. A
+   * controller that already reports the current timestep calculation identifier, for example after equipment-owned
+   * execution, is not advanced again. Merely attaching a controller to equipment that does not execute it does not
+   * suppress its standalone update.
    *
    * @param controllerDevice a {@link neqsim.process.controllerdevice.ControllerDeviceInterface} object
    */
@@ -4161,18 +4162,15 @@ public class ProcessSystem extends SimulationBaseClass {
     }
 
     // Explicit controller scan phase: run standalone controllers registered via
-    // add(ControllerDeviceInterface). Reserve equipment-owned controller identities
-    // because those controllers already ran inside equipment runTransient(). Reusing
-    // the same identity in the standalone list must not integrate controller state
-    // (time, integral, derivative, event log) a second time.
+    // add(ControllerDeviceInterface). Identity coalescing prevents repeated standalone
+    // registration from integrating mutable state more than once. The calculation
+    // identifier distinguishes a controller actually executed inside equipment from one
+    // merely attached to equipment for association or discovery.
     java.util.Set<ControllerDeviceInterface> scheduledControllers = java.util.Collections
         .newSetFromMap(new IdentityHashMap<ControllerDeviceInterface, Boolean>());
-    for (int i = 0; i < unitOperations.size(); i++) {
-      scheduledControllers.addAll(unitOperations.get(i).getControllers());
-    }
     for (int i = 0; i < controllerDevices.size(); i++) {
       ControllerDeviceInterface ctrl = controllerDevices.get(i);
-      if (scheduledControllers.add(ctrl) && ctrl.isActive()) {
+      if (scheduledControllers.add(ctrl) && ctrl.isActive() && !ctrl.hasRunTransient(id)) {
         ctrl.runTransient(ctrl.getResponse(), dt, id);
       }
     }

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -612,7 +612,9 @@ public class ProcessSystem extends SimulationBaseClass {
 
   /**
    * Add a standalone controller device to the process system. Controllers added here participate in the explicit
-   * controller scan during {@code runTransient}.
+   * controller scan during {@code runTransient}. A controller instance that is also attached to equipment remains
+   * discoverable in this list but is executed only through its equipment owner. Repeated standalone registration of the
+   * same instance likewise schedules one controller update per timestep.
    *
    * @param controllerDevice a {@link neqsim.process.controllerdevice.ControllerDeviceInterface} object
    */
@@ -4159,12 +4161,18 @@ public class ProcessSystem extends SimulationBaseClass {
     }
 
     // Explicit controller scan phase: run standalone controllers registered via
-    // add(ControllerDeviceInterface). Equipment-embedded controllers already ran
-    // above
-    // inside each equipment's runTransient() for backward compatibility.
+    // add(ControllerDeviceInterface). Reserve equipment-owned controller identities
+    // because those controllers already ran inside equipment runTransient(). Reusing
+    // the same identity in the standalone list must not integrate controller state
+    // (time, integral, derivative, event log) a second time.
+    java.util.Set<ControllerDeviceInterface> scheduledControllers = java.util.Collections
+        .newSetFromMap(new IdentityHashMap<ControllerDeviceInterface, Boolean>());
+    for (int i = 0; i < unitOperations.size(); i++) {
+      scheduledControllers.addAll(unitOperations.get(i).getControllers());
+    }
     for (int i = 0; i < controllerDevices.size(); i++) {
       ControllerDeviceInterface ctrl = controllerDevices.get(i);
-      if (ctrl.isActive()) {
+      if (scheduledControllers.add(ctrl) && ctrl.isActive()) {
         ctrl.runTransient(ctrl.getResponse(), dt, id);
       }
     }

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientControllerTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientControllerTest.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
+import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.thermo.system.SystemSrkEos;
@@ -22,6 +23,7 @@ public class ProcessSystemTransientControllerTest extends neqsim.NeqSimTest {
   private static final class CountingController extends ControllerDeviceBaseClass {
     private static final long serialVersionUID = 1000L;
     private final AtomicInteger executionCount = new AtomicInteger();
+    private UUID lastTransientIdentifier;
 
     /**
      * Creates an active counting controller.
@@ -37,6 +39,13 @@ public class ProcessSystemTransientControllerTest extends neqsim.NeqSimTest {
     @Override
     public void runTransient(double initResponse, double dt, UUID id) {
       executionCount.incrementAndGet();
+      lastTransientIdentifier = id;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean hasRunTransient(UUID id) {
+      return id != null && id.equals(lastTransientIdentifier);
     }
 
     /**
@@ -69,6 +78,32 @@ public class ProcessSystemTransientControllerTest extends neqsim.NeqSimTest {
     ProcessSystem process = new ProcessSystem("controller ownership");
     process.add(feed);
     process.add(valve);
+    process.add(controller);
+    process.run();
+
+    process.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(1, controller.getExecutionCount());
+  }
+
+  /**
+   * Attachment alone must not suppress the standalone phase when equipment does not execute its controller.
+   */
+  @Test
+  public void attachedButNotEquipmentExecutedControllerRunsStandalone() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 20.0);
+    fluid.addComponent("methane", 1.0);
+
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    Heater heater = new Heater("heater", feed);
+
+    CountingController controller = new CountingController("temperature controller");
+    heater.setController(controller);
+
+    ProcessSystem process = new ProcessSystem("controller attachment");
+    process.add(feed);
+    process.add(heater);
     process.add(controller);
     process.run();
 

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientControllerTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientControllerTest.java
@@ -23,7 +23,6 @@ public class ProcessSystemTransientControllerTest extends neqsim.NeqSimTest {
   private static final class CountingController extends ControllerDeviceBaseClass {
     private static final long serialVersionUID = 1000L;
     private final AtomicInteger executionCount = new AtomicInteger();
-    private UUID lastTransientIdentifier;
 
     /**
      * Creates an active counting controller.
@@ -33,19 +32,29 @@ public class ProcessSystemTransientControllerTest extends neqsim.NeqSimTest {
     private CountingController(String name) {
       super(name);
       setActive(true);
+      setUnit("bara");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double getMeasuredValue() {
+      return 0.0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double getMeasuredValue(String unit) {
+      return 0.0;
     }
 
     /** {@inheritDoc} */
     @Override
     public void runTransient(double initResponse, double dt, UUID id) {
-      executionCount.incrementAndGet();
-      lastTransientIdentifier = id;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean hasRunTransient(UUID id) {
-      return id != null && id.equals(lastTransientIdentifier);
+      boolean alreadyCompleted = hasRunTransient(id);
+      super.runTransient(initResponse, dt, id);
+      if (!alreadyCompleted) {
+        executionCount.incrementAndGet();
+      }
     }
 
     /**
@@ -79,6 +88,35 @@ public class ProcessSystemTransientControllerTest extends neqsim.NeqSimTest {
     process.add(feed);
     process.add(valve);
     process.add(controller);
+    process.run();
+
+    process.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(1, controller.getExecutionCount());
+  }
+
+  /**
+   * Semi-implicit equipment passes share one timestep identifier and must integrate controller state once.
+   */
+  @Test
+  public void semiImplicitEquipmentPassesRunControllerOnce() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 20.0);
+    fluid.addComponent("methane", 1.0);
+
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    ThrottlingValve valve = new ThrottlingValve("valve", feed);
+    valve.setOutletPressure(10.0, "bara");
+    valve.setCalculateSteadyState(false);
+
+    CountingController controller = new CountingController("pressure controller");
+    valve.setController(controller);
+
+    ProcessSystem process = new ProcessSystem("semi-implicit controller ownership");
+    process.add(feed);
+    process.add(valve);
+    process.add(controller);
+    process.setIntegrationMethod(ProcessSystem.IntegrationMethod.SEMI_IMPLICIT);
     process.run();
 
     process.runTransient(1.0, UUID.randomUUID());

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientControllerTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientControllerTest.java
@@ -1,0 +1,112 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Regression tests for controller ownership during transient process steps.
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public class ProcessSystemTransientControllerTest extends neqsim.NeqSimTest {
+  /**
+   * Controller that records every transient state update without requiring a transmitter.
+   */
+  private static final class CountingController extends ControllerDeviceBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private final AtomicInteger executionCount = new AtomicInteger();
+
+    /**
+     * Creates an active counting controller.
+     *
+     * @param name controller name
+     */
+    private CountingController(String name) {
+      super(name);
+      setActive(true);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void runTransient(double initResponse, double dt, UUID id) {
+      executionCount.incrementAndGet();
+    }
+
+    /**
+     * Returns the number of controller state updates.
+     *
+     * @return execution count
+     */
+    private int getExecutionCount() {
+      return executionCount.get();
+    }
+  }
+
+  /**
+   * An equipment-owned controller must not run again when it is also registered for process discovery.
+   */
+  @Test
+  public void embeddedAndStandaloneRegistrationRunsControllerOnce() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 20.0);
+    fluid.addComponent("methane", 1.0);
+
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    ThrottlingValve valve = new ThrottlingValve("valve", feed);
+    valve.setOutletPressure(10.0, "bara");
+    valve.setCalculateSteadyState(false);
+
+    CountingController controller = new CountingController("pressure controller");
+    valve.setController(controller);
+
+    ProcessSystem process = new ProcessSystem("controller ownership");
+    process.add(feed);
+    process.add(valve);
+    process.add(controller);
+    process.run();
+
+    process.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(1, controller.getExecutionCount());
+  }
+
+  /**
+   * Repeated standalone registration of the same controller identity schedules one update per timestep.
+   */
+  @Test
+  public void duplicateStandaloneRegistrationRunsControllerOnce() {
+    CountingController controller = new CountingController("standalone controller");
+    ProcessSystem process = new ProcessSystem("duplicate standalone controller");
+    process.add(controller);
+    process.add(controller);
+
+    process.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(1, controller.getExecutionCount());
+  }
+
+  /**
+   * Distinct controller identities remain independent across repeated timesteps, even when their names match.
+   */
+  @Test
+  public void distinctStandaloneControllersRunOncePerTimestep() {
+    CountingController firstController = new CountingController("shared tag");
+    CountingController secondController = new CountingController("shared tag");
+    ProcessSystem process = new ProcessSystem("distinct standalone controllers");
+    process.add(firstController);
+    process.add(secondController);
+
+    process.runTransient(1.0, UUID.randomUUID());
+    process.runTransient(1.0, UUID.randomUUID());
+
+    assertEquals(2, firstController.getExecutionCount());
+    assertEquals(2, secondController.getExecutionCount());
+  }
+}


### PR DESCRIPTION
## Root cause

`ProcessSystem.runTransient(dt, id)` executes equipment first and then scans controllers registered through `ProcessSystem.add(controller)`. A controller integrated by equipment and also registered for discovery was therefore advanced twice with the same physical timestep. Repeated standalone registration had the same effect. Under `SEMI_IMPLICIT`, equipment is deliberately evaluated twice with one calculation identifier, which could advance a built-in PID yet again.

The first patch attempted to reserve every controller attached to equipment. Review correctly identified that attachment does not prove execution: equipment such as `Heater` exposes controller association but does not integrate it in `runTransient`. Reserving attachments could suppress a controller entirely.

## Scope

- add the backward-compatible default `ControllerDeviceInterface.hasRunTransient(UUID)` contract
- make `ControllerDeviceBaseClass.runTransient(..., id)` idempotent for one non-null calculation identifier
- coalesce the standalone scan by object identity
- skip the standalone call only when the controller reports that exact timestep identifier
- preserve standalone execution for controllers merely attached to non-integrating equipment
- preserve distinct same-name controller objects and repeated execution on later timesteps
- document the contract in Javadocs, the dynamic guide, and the dynamic-simulation skill

No method is removed or behavior changed for custom controller implementations that do not opt into identifier tracking; the new interface method defaults to `false`.

## Baseline and before/after evidence

A deterministic counting-controller harness uses methane process cases and calculation identifiers, avoiding wall-clock assertions.

| Case | Current `master` | This branch |
|---|---:|---:|
| Dynamic valve controller also registered standalone, explicit step | 2 updates/timestep | 1 |
| Same valve case, semi-implicit equipment pass | 3 updates/timestep | 1 |
| Same standalone identity registered twice | 2 updates/timestep | 1 |
| Controller attached to a heater that does not execute it | 1 standalone update | 1 |

The heater case is the regression for the review finding: association alone must not be treated as execution.

## Engineering behavior

Controller state ownership is determined by both object identity and the calculation UUID:

- identity coalesces duplicate entries in the standalone registration list;
- the UUID proves that equipment actually completed the controller update in this timestep;
- `ControllerDeviceBaseClass` rejects repeated calls with that UUID, including semi-implicit re-evaluation;
- a later timestep uses a different UUID and advances normally;
- custom controllers remain conservative by default and can implement the same contract when equipment integrates them.

Controller timing relative to equipment, actuator coupling, registration/discovery lists, serialization fields, event scheduling, measurements, history, process time, thermodynamic calculations, initialization levels, tolerances, mass/energy equations, and phase behavior are otherwise unchanged.

## Tests and validation

Focused regression class: `ProcessSystemTransientControllerTest` (5 tests)

- equipment-executed plus standalone registration
- semi-implicit repeated equipment pass
- attachment-only heater fallback
- duplicate standalone identity
- distinct same-name identities across repeated timesteps

On repaired head `ade5eaf5`, every hosted check passes:

- focused `ProcessSystemTransientControllerTest` coverage is included in the successful fast-test suites
- Java 21 fast tests pass on Ubuntu and Windows
- Java 8 tests pass on Ubuntu and Windows
- all three Java 21 slow-test shards pass
- Javadocs, Spotless, pre-commit, skills/agents lint, PaperLab, documentation search, and CodeQL pass

No check was rerun selectively or weakened, and no tolerance or convergence criterion was changed.

## Compatibility and risk

- additive Java API only, implemented as a default method
- existing third-party controllers continue to execute conservatively unless they opt into identifier tracking
- built-in controller repeated calls with the same non-null UUID are now idempotent
- null identifiers are not coalesced
- distinct controller instances remain independent even when names match
- inactive controller behavior is unchanged
- no test tolerance or convergence criterion is changed

## Documentation impact

Updated:

- `ControllerDeviceInterface` and `ControllerDeviceBaseClass` Javadocs
- `ProcessSystem.add(ControllerDeviceInterface)` Javadoc
- `docs/process/dynamic-simulation-enhancements.md`
- `.github/skills/neqsim-dynamic-simulation/SKILL.md`

## Related work

Builds on merged transient execution fixes #2686, #2692, and #2695. No other open dynamic-simulation PR overlaps this change.

## Next dependency

Define explicit transient convergence semantics for recycle and implicit signal couplings, followed by incomplete-step rollback/state ownership.