### PR TITLE
fix: stop non-descent Naphtali line-search stalls

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -183,7 +183,7 @@ required.
 | `WEGSTEIN` | Accelerated successive substitution after warm-up. | Well-conditioned fixed-point problems. |
 | `SUM_RATES` | Flow-corrected tearing method. | Absorbers, strippers, and flow-sensitive columns. |
 | `NEWTON` | Tray-temperature Newton accelerator. | Difficult temperature convergence. It is not full simultaneous MESH Newton. |
-| `NAPHTALI_SANDHOLM` | Guarded simultaneous correction of MESH blocks after inside-out warm start. | Residual-driven hydrocarbon fractionators. |
+| `NAPHTALI_SANDHOLM` | Guarded simultaneous correction of MESH blocks after inside-out warm start, with early return to coordinated fallback after repeated non-descent minimum steps. | Residual-driven hydrocarbon fractionators. |
 | `MESH_RESIDUAL` | Inside-out initialization plus full residual auditing. | Material, equilibrium, summation, energy, product-draw, and spec residual checks. |
 | `AUTO` | Runs a feasibility pre-screen, initializes a copied candidate, solves a relaxed damped base case, probes candidate strategies on column copies, and accepts the first solved non-fallback candidate or the best valid fallback. | Agent workflows and uncertain cases where robust automatic selection and diagnostics are useful. |
 

--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -183,7 +183,7 @@ required.
 | `WEGSTEIN` | Accelerated successive substitution after warm-up. | Well-conditioned fixed-point problems. |
 | `SUM_RATES` | Flow-corrected tearing method. | Absorbers, strippers, and flow-sensitive columns. |
 | `NEWTON` | Tray-temperature Newton accelerator. | Difficult temperature convergence. It is not full simultaneous MESH Newton. |
-| `NAPHTALI_SANDHOLM` | Guarded simultaneous correction of MESH blocks after inside-out warm start, with early return to coordinated fallback after repeated non-descent minimum steps. | Residual-driven hydrocarbon fractionators. |
+| `NAPHTALI_SANDHOLM` | Guarded simultaneous correction of MESH blocks after inside-out warm start, with early return to coordinated fallback after repeated non-descent steps. | Residual-driven hydrocarbon fractionators. |
 | `MESH_RESIDUAL` | Inside-out initialization plus full residual auditing. | Material, equilibrium, summation, energy, product-draw, and spec residual checks. |
 | `AUTO` | Runs a feasibility pre-screen, initializes a copied candidate, solves a relaxed damped base case, probes candidate strategies on column copies, and accepts the first solved non-fallback candidate or the best valid fallback. | Agent workflows and uncertain cases where robust automatic selection and diagnostics are useful. |
 

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -233,9 +233,10 @@ targets manipulated through condenser or reboiler temperature.
   temperature, and vapor flow as tray variables.
 - Builds a finite-difference block-tridiagonal Jacobian from neighboring tray couplings and uses a
   guarded Newton line search with flow and temperature trust limits.
-- Allows at most three line-search steps that fail to reduce the MESH residual. Repeated non-descent
-  restores the best finite tray state and returns the actual iteration count so the
-  column can proceed to its coordinated fallback instead of exhausting the Newton budget.
+- Allows at most three line-search steps that fail to reduce the MESH residual. After three such
+  non-descent steps, the solver restores the best finite tray state and returns the actual iteration
+  count so the column can proceed to its coordinated fallback instead of exhausting the Newton
+  budget.
 - Supports optional `setSeedTemperature(stageIndex, temperatureK)` warm-start guesses. Seeds are
   initial values only; they do not pin tray temperatures or replace energy-balance residuals.
 - Accepts the Newton-refined state only when the scaled MESH residual improves; otherwise the

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -233,8 +233,8 @@ targets manipulated through condenser or reboiler temperature.
   temperature, and vapor flow as tray variables.
 - Builds a finite-difference block-tridiagonal Jacobian from neighboring tray couplings and uses a
   guarded Newton line search with flow and temperature trust limits.
-- Allows at most three minimum line-search steps that fail to reduce the MESH residual. Repeated
-  non-descent restores the best finite tray state and returns the actual iteration count so the
+- Allows at most three line-search steps that fail to reduce the MESH residual. Repeated non-descent
+  restores the best finite tray state and returns the actual iteration count so the
   column can proceed to its coordinated fallback instead of exhausting the Newton budget.
 - Supports optional `setSeedTemperature(stageIndex, temperatureK)` warm-start guesses. Seeds are
   initial values only; they do not pin tray temperatures or replace energy-balance residuals.

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -233,6 +233,9 @@ targets manipulated through condenser or reboiler temperature.
   temperature, and vapor flow as tray variables.
 - Builds a finite-difference block-tridiagonal Jacobian from neighboring tray couplings and uses a
   guarded Newton line search with flow and temperature trust limits.
+- Allows at most three minimum line-search steps that fail to reduce the MESH residual. Repeated
+  non-descent restores the best finite tray state and returns the actual iteration count so the
+  column can proceed to its coordinated fallback instead of exhausting the Newton budget.
 - Supports optional `setSeedTemperature(stageIndex, temperatureK)` warm-start guesses. Seeds are
   initial values only; they do not pin tray temperatures or replace energy-balance residuals.
 - Accepts the Newton-refined state only when the scaled MESH residual improves; otherwise the

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -35,6 +35,8 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @version 1.0
  */
 public class NaphtaliSandholmSolver {
+  /** Maximum number of minimum line-search steps allowed without reducing the residual norm. */
+  private static final int MAX_NON_DESCENT_LINE_SEARCH_STEPS = 3;
 
   /** Logger for this class. */
   private static final Logger logger = LogManager.getLogger(NaphtaliSandholmSolver.class);
@@ -716,9 +718,12 @@ public class NaphtaliSandholmSolver {
 
       int failedSteps = 0;
       int stagnationCount = 0;
+      int nonDescentLineSearchSteps = 0;
+      int completedNewtonIterations = 0;
       double prevBestNorm = bestNorm;
 
       for (int iter = 1; iter <= maxIterations; iter++) {
+        completedNewtonIterations = iter;
         // Time guard for Newton iterations
         if (System.nanoTime() - newtonStart > maxNewtonTimeNs) {
           logger.info("NS Newton: time limit reached at iter {}", iter);
@@ -778,6 +783,14 @@ public class NaphtaliSandholmSolver {
 
         // Line search: backtrack if step increases residual norm
         double alpha = lineSearch(dx, norm);
+        if (alpha <= 0.0) {
+          logger.debug("NS: line search found no finite trial step; restoring best state");
+          restoreTrayState(bestLiq, bestT, bestV);
+          evaluateThermo();
+          residual = computeResidual();
+          norm = vectorNorm(residual);
+          break;
+        }
 
         // Apply update with step size alpha
         applyUpdate(dx, alpha);
@@ -832,6 +845,21 @@ public class NaphtaliSandholmSolver {
           continue;
         }
 
+        if (newNorm >= norm) {
+          nonDescentLineSearchSteps++;
+          if (nonDescentLineSearchSteps >= MAX_NON_DESCENT_LINE_SEARCH_STEPS) {
+            restoreTrayState(bestLiq, bestT, bestV);
+            evaluateThermo();
+            residual = computeResidual();
+            norm = vectorNorm(residual);
+            logger.debug(
+                "NS: stopped after {} minimum line-search steps without residual descent; "
+                    + "restored best norm {}",
+                nonDescentLineSearchSteps, String.format("%.6e", norm));
+            break;
+          }
+        }
+
         norm = newNorm;
         failedSteps = 0;
 
@@ -869,9 +897,9 @@ public class NaphtaliSandholmSolver {
         }
       }
 
-      logger.warn("Naphtali-Sandholm did not converge in {} iterations, ||F|| = {}", maxIterations,
+      logger.warn("Naphtali-Sandholm did not converge in {} iterations, ||F|| = {}", completedNewtonIterations,
           String.format("%.6e", norm));
-      applyResultsToColumn(id, maxIterations, norm, startTime);
+      applyResultsToColumn(id, completedNewtonIterations, norm, startTime);
       // Partial convergence is only acceptable when each component balance still closes; a leaky
       // profile must be reported as not accepted so the column does not present it as a solution.
       return norm < tolerance * 100 && meshClosureAcceptable("partial convergence");
@@ -4262,7 +4290,8 @@ public class NaphtaliSandholmSolver {
       saveV[j] = V[j];
     }
 
-    double bestAlpha = alpha;
+    double bestAlpha = 0.0;
+    double bestTrialNorm = Double.POSITIVE_INFINITY;
 
     for (int bt = 0; bt < maxBacktrack; bt++) {
       // Trial update
@@ -4281,12 +4310,23 @@ public class NaphtaliSandholmSolver {
       double[] Ftrial = computeResidual();
       double trialNorm = vectorNorm(Ftrial);
 
-      if (trialNorm < (1.0 - c * alpha) * currentNorm || alpha < 0.01) {
+      if (Double.isFinite(trialNorm) && trialNorm < bestTrialNorm) {
+        bestTrialNorm = trialNorm;
         bestAlpha = alpha;
+      }
+      if (Double.isFinite(trialNorm) && trialNorm < (1.0 - c * alpha) * currentNorm) {
+        bestAlpha = alpha;
+        break;
+      }
+      if (alpha < 0.01) {
         break;
       }
 
       alpha *= rho;
+    }
+
+    if (bestTrialNorm >= currentNorm) {
+      bestAlpha = Math.min(bestAlpha, alpha);
     }
 
     // ALWAYS restore the original state — the main loop's applyUpdate handles the

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -4324,10 +4324,6 @@ public class NaphtaliSandholmSolver {
       alpha *= rho;
     }
 
-    if (bestTrialNorm >= currentNorm) {
-      bestAlpha = Math.min(bestAlpha, alpha);
-    }
-
     // ALWAYS restore the original state — the main loop's applyUpdate handles the
     // final step
     for (int j = 0; j < N; j++) {

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -853,8 +853,7 @@ public class NaphtaliSandholmSolver {
             residual = computeResidual();
             norm = vectorNorm(residual);
             logger.debug(
-                "NS: stopped after {} minimum line-search steps without residual descent; "
-                    + "restored best norm {}",
+                "NS: stopped after {} minimum line-search steps without residual descent; " + "restored best norm {}",
                 nonDescentLineSearchSteps, String.format("%.6e", norm));
             break;
           }

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -35,7 +35,7 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @version 1.0
  */
 public class NaphtaliSandholmSolver {
-  /** Maximum number of minimum line-search steps allowed without reducing the residual norm. */
+  /** Maximum number of non-descent line-search steps allowed before restoring the best state. */
   private static final int MAX_NON_DESCENT_LINE_SEARCH_STEPS = 3;
 
   /** Logger for this class. */
@@ -852,8 +852,7 @@ public class NaphtaliSandholmSolver {
             evaluateThermo();
             residual = computeResidual();
             norm = vectorNorm(residual);
-            logger.debug(
-                "NS: stopped after {} minimum line-search steps without residual descent; " + "restored best norm {}",
+            logger.debug("NS: stopped after {} non-descent line-search steps; restored best norm {}",
                 nonDescentLineSearchSteps, String.format("%.6e", norm));
             break;
           }

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -4270,7 +4270,7 @@ public class NaphtaliSandholmSolver {
    *
    * @param dx Newton direction
    * @param currentNorm current residual norm
-   * @return step size alpha in (0, 1]
+   * @return step size alpha in [0, 1]; zero when no finite trial exists
    */
   private double lineSearch(double[] dx, double currentNorm) {
     double alpha = 1.0;

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -1,7 +1,9 @@
 package neqsim.process.equipment.distillation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
@@ -124,6 +126,48 @@ public class ColumnStudyRegressionTest {
     assertTrayPressureProfile(column);
     assertOverallMassBalance(feedStream, topFeedStream, column);
     assertComponentMassBalances(feedStream, topFeedStream, column);
+  }
+
+  /**
+   * Reject a severely perturbed warm start without spending the entire Newton iteration budget on repeated
+   * non-descent minimum steps.
+   *
+   * <p>
+   * The accepted column-study solution is deliberately perturbed by up to 90 K before a direct simultaneous-correction
+   * warm start. The case is outside the local Newton basin, but it remains a finite, realistic multicomponent
+   * hydrocarbon column state. The solver should preserve its best physical state and return control to the coordinated
+   * fallback path once three minimum line-search steps have failed to reduce the MESH residual.
+   * </p>
+   */
+  @Test
+  public void severeWarmStartPerturbationStopsNonDescentNewtonStall() {
+    SystemInterface baseFluid = createBaseFluid();
+    StreamInterface feedStream = createStream("stall_guard_main_feed", baseFluid, MAIN_FEED_COMPOSITION,
+        MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
+    StreamInterface topFeedStream = createStream("stall_guard_top_feed", baseFluid, TOP_FEED_COMPOSITION,
+        TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA, TOP_FEED_MASS_FLOW_KG_HR);
+    DistillationColumn column = createColumn(feedStream, topFeedStream);
+    column.init();
+
+    for (int trayIndex = 0; trayIndex < column.getNumberOfTrays(); trayIndex++) {
+      double perturbedTemperature = column.getTray(trayIndex).getTemperature()
+          + 90.0 * Math.sin((trayIndex + 1.0) * 1.9);
+      column.getTray(trayIndex).setTemperature(perturbedTemperature);
+      column.getTray(trayIndex).getThermoSystem().setTemperature(perturbedTemperature);
+    }
+
+    NaphtaliSandholmSolver solver = new NaphtaliSandholmSolver(column);
+    solver.setWarmStartFromColumn(true);
+    solver.setMaxIterations(80);
+    boolean accepted = solver.solve(UUID.randomUUID());
+
+    assertFalse(accepted, "the severely perturbed state must be rejected for coordinated fallback");
+    assertTrue(solver.getLastIterations() <= 30,
+        "the non-descent guard should stop the stalled Newton solve before the 80-iteration cap");
+    assertTrue(solver.getLastMassBalanceError() < 1.0e-3,
+        "the restored best state should preserve total molar closure before fallback");
+    assertPhysicalProduct(column.getGasOutStream(), "stalled warm-start gas product");
+    assertPhysicalProduct(column.getLiquidOutStream(), "stalled warm-start liquid product");
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -159,7 +159,7 @@ public class ColumnStudyRegressionTest {
     NaphtaliSandholmSolver solver = new NaphtaliSandholmSolver(column);
     solver.setWarmStartFromColumn(true);
     solver.setMaxIterations(80);
-    boolean accepted = solver.solve(UUID.randomUUID());
+    boolean accepted = solver.solve(new UUID(0L, 1L));
 
     assertFalse(accepted, "the severely perturbed state must be rejected for coordinated fallback");
     assertTrue(solver.getLastIterations() <= 30,

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -129,8 +129,8 @@ public class ColumnStudyRegressionTest {
   }
 
   /**
-   * Reject a severely perturbed warm start without spending the entire Newton iteration budget on repeated
-   * non-descent minimum steps.
+   * Reject a severely perturbed warm start without spending the entire Newton iteration budget on repeated non-descent
+   * minimum steps.
    *
    * <p>
    * The accepted column-study solution is deliberately perturbed by up to 90 K before a direct simultaneous-correction

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -130,13 +130,13 @@ public class ColumnStudyRegressionTest {
 
   /**
    * Reject a severely perturbed warm start without spending the entire Newton iteration budget on repeated non-descent
-   * minimum steps.
+   * line-search steps.
    *
    * <p>
    * The accepted column-study solution is deliberately perturbed by up to 90 K before a direct simultaneous-correction
    * warm start. The case is outside the local Newton basin, but it remains a finite, realistic multicomponent
    * hydrocarbon column state. The solver should preserve its best physical state and return control to the coordinated
-   * fallback path once three minimum line-search steps have failed to reduce the MESH residual.
+   * fallback path once three line-search steps have failed to reduce the MESH residual.
    * </p>
    */
   @Test

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -133,7 +133,7 @@ public class ColumnStudyRegressionTest {
    * line-search steps.
    *
    * <p>
-   * The accepted column-study solution is deliberately perturbed by up to 90 K before a direct simultaneous-correction
+   * The initialized column-study state is deliberately perturbed by up to 90 K before a direct simultaneous-correction
    * warm start. The case is outside the local Newton basin, but it remains a finite, realistic multicomponent
    * hydrocarbon column state. The solver should preserve its best physical state and return control to the coordinated
    * fallback path once three line-search steps have failed to reduce the MESH residual.


### PR DESCRIPTION
## Problem

The Naphtali–Sandholm backtracking search accepted a trial whenever `alpha < 0.01`, even when the MESH residual norm increased. A finite warm start outside the local Newton basin could therefore keep accepting minimum steps and consume the full Newton/Jacobian budget before the column's coordinated fallback was allowed to run.

This affects direct `NAPHTALI_SANDHOLM` use and any coordinated solver path that probes it. It does not change thermodynamic initialization levels.

## Root cause and change

- Track the best finite line-search trial and accept Armijo descent normally.
- When no descent trial exists, use the finite trial with the lowest evaluated residual; if every trial is non-finite, return a zero step and restore the best state.
- Stop after three non-descent steps across the Newton solve, restore the best finite tray state, report the actual iteration count, and return the rejected candidate to coordinated fallback.
- Document the fallback behavior in both distillation guides.

No public API, tolerance, thermodynamic model, specification, or accepted-solution criterion changes.

## Regression and measured evidence

The regression uses the existing realistic column-study case:

- SRK, 24-component hydrocarbon feed
- 11 stages including reboiler
- two feeds
- fixed 137.309 °C reboiler
- about 5.21 bara
- finite warm start perturbed by up to 90 K

Before this change, the direct simultaneous correction accepted nine residual-increasing minimum steps and exhausted all 80 iterations while remaining unaccepted (final residual norm about 5.683813).

After this change, it stops after the third non-descent line-search step at iteration 22, restores the best state (residual norm about 5.855657), preserves total molar closure at `6.93e-4`, and remains explicitly unaccepted so fallback can continue. This avoids 58 expensive Newton/Jacobian iterations (72.5%) without a wall-clock assertion.

Nearby perturbations are unchanged:

| Warm-start perturbation | Iterations | Final residual norm |
|---:|---:|---:|
| 0 K | 14 | 2.80e-9 |
| 20 K | 16 | 4.78e-9 |
| 50 K | 22 | 8.08e-9 |

The ordinary public column-study run still converges in the established 17 iterations and retains its product/profile and mass-balance assertions.

## Validation

Locally compiled the affected current column sources against the cached NeqSim runtime and executed all six no-argument tests in `ColumnStudyRegressionTest`:

- normal column-study profile and mass balances
- severe warm-start stall regression
- legacy direct-feed coupling
- liquid side draw
- gas side draw
- pumparound coordinated fallback

All six passed after the Copilot changes. The regression uses a fixed calculation UUID and asserts rejection for fallback, early termination, total molar closure, finite positive product flows, and normalized physical phase compositions.

Full Maven, Spotless, Javadocs, CodeQL, and platform suites are left to repository CI because this runner has no writable/resolved Maven cache.

## Compatibility and risk

Risk is limited to already-unaccepted Naphtali–Sandholm trajectories that repeatedly cannot reduce the residual. Convergent nearby states and the established column-study operating point are unchanged. The restored state is the best finite state already tracked by the solver, and normal coordinated fallback remains responsible for obtaining an accepted solution.

## Copilot disposition

Both comments were accepted, validated, replied to, and resolved:

- the line search now cannot substitute an alpha whose evaluated residual was non-finite;
- the regression uses a fixed UUID.

## Remaining limitations

This does not enlarge the local Newton convergence basin or optimize Jacobian construction. A later dependency-ordered improvement can focus on initialization/conditioning or residual-evaluation cost after this stall behavior is bounded.
