### PR TITLE
fix: preserve matrix inside-out phase state

### DIFF
--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumnMatrixSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumnMatrixSolver.java
@@ -533,7 +533,8 @@ public class DistillationColumnMatrixSolver {
     }
     system.setTotalNumberOfMoles(Math.max(0.0, totalFlow));
     try {
-      system.init(0);
+      // init(1) updates phase state and fugacity coefficients without resetting the
+      // phase mapping and beta values that the cached K-value model is advancing.
       system.init(1);
     } catch (RuntimeException exception) {
       logger.debug("Matrix inside-out tray system init failed on tray {}", trayIndex, exception);

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationSolverBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationSolverBenchmarkTest.java
@@ -357,8 +357,15 @@ public class DistillationSolverBenchmarkTest {
         "Large columns should attempt the matrix warm-start stage");
     assertTrue(column.wasMatrixInsideOutWarmStartUsed(),
         "Regression case should accept the matrix warm start before polishing");
+    assertTrue(column.getLastMatrixInsideOutTemperatureResidual() <= 1.0e-1,
+        "Matrix warm start should meet its temperature tolerance before rigorous polishing");
+    assertTrue(column.getLastMatrixInsideOutIterationCount() < column.getNumberOfTrays(),
+        "Matrix warm start should converge before its tray-count iteration cap");
     assertTrue(column.getLastIterationCount() > column.getLastMatrixInsideOutIterationCount(),
         "Rigorous polish iterations must be included after matrix warm-start iterations");
+    double outletFlow = column.getGasOutStream().getFlowRate("kg/hr")
+        + column.getLiquidOutStream().getFlowRate("kg/hr");
+    assertEquals(100.0, outletFlow, 1.0e-6, "Polished products should close the total mass balance");
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationSolverBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationSolverBenchmarkTest.java
@@ -357,15 +357,19 @@ public class DistillationSolverBenchmarkTest {
         "Large columns should attempt the matrix warm-start stage");
     assertTrue(column.wasMatrixInsideOutWarmStartUsed(),
         "Regression case should accept the matrix warm start before polishing");
-    assertTrue(column.getLastMatrixInsideOutTemperatureResidual() <= 1.0e-1,
-        "Matrix warm start should meet its temperature tolerance before rigorous polishing");
-    assertTrue(column.getLastMatrixInsideOutIterationCount() < column.getNumberOfTrays(),
-        "Matrix warm start should converge before its tray-count iteration cap");
+    double matrixTemperatureTolerance = Math.max(column.getTemperatureTolerance(), 5.0e-2);
+    assertTrue(column.getLastMatrixInsideOutTemperatureResidual() <= matrixTemperatureTolerance,
+        "Matrix warm start should meet its configured temperature tolerance before rigorous polishing");
+    int matrixIterationLimit = Math.max(2,
+        Math.min(Math.max(4, column.getNumberOfTrays()), Math.max(2, column.getMaxNumberOfIterations() / 4)));
+    assertTrue(column.getLastMatrixInsideOutIterationCount() < matrixIterationLimit,
+        "Matrix warm start should converge before its configured iteration cap");
     assertTrue(column.getLastIterationCount() > column.getLastMatrixInsideOutIterationCount(),
         "Rigorous polish iterations must be included after matrix warm-start iterations");
     double outletFlow = column.getGasOutStream().getFlowRate("kg/hr")
         + column.getLiquidOutStream().getFlowRate("kg/hr");
-    assertEquals(100.0, outletFlow, 1.0e-6, "Polished products should close the total mass balance");
+    assertEquals(feed.getFlowRate("kg/hr"), outletFlow, 1.0e-6,
+        "Polished products should close the total mass balance");
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationSolverBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationSolverBenchmarkTest.java
@@ -368,8 +368,9 @@ public class DistillationSolverBenchmarkTest {
         "Rigorous polish iterations must be included after matrix warm-start iterations");
     double outletFlow = column.getGasOutStream().getFlowRate("kg/hr")
         + column.getLiquidOutStream().getFlowRate("kg/hr");
-    assertEquals(feed.getFlowRate("kg/hr"), outletFlow, 1.0e-6,
-        "Polished products should close the total mass balance");
+    double feedFlow = feed.getFlowRate("kg/hr");
+    assertEquals(feedFlow, outletFlow, feedFlow * 1.0e-6,
+        "Polished products should close the total mass balance within one part per million");
   }
 
   /**


### PR DESCRIPTION
## Problem

The matrix inside-out warm-start solver explicitly called `system.init(0)` and then `system.init(1)` after updating each tray composition. `init(0)` is not a harmless prerequisite: `SystemThermo.initAnalytic(0)` resets phase types, phase indices, and every beta value before `init(1)` evaluates the fixed-T/P phase state and fugacity coefficients.

That reset disrupts the phase state being advanced by the cached K-value model. The existing 14-stage propane/n-butane regression accepts a finite matrix state but reaches its tray-count iteration cap with a 0.873 K temperature residual instead of meeting the configured 0.1 K warm-start tolerance.

This is a focused implementation of the repository's lowest-sufficient-initialization rule and advances the audit intent in #2698 without bulk-changing other call sites.

## Root cause and change

`updateTraySystemComposition(...)` already writes component totals, phase component amounts, and phase mole fractions directly. The next calculation needs fixed-T/P phase state and fugacity coefficients for the K-value cache. `init(1)` provides those quantities.

The change removes only the preceding `init(0)` and documents why the matrix phase mapping and beta state must be preserved. No initialization level is raised, and the separate outlet-stream `init(2)` remains unchanged because that path reads caloric properties.

Affected solver: `MATRIX_INSIDE_OUT` warm-start stage. Rigorous inside-out polishing and all fallback selection remain unchanged.

## Before/after evidence

Stable solver metrics from separate baseline and candidate JVMs:

| Case | Metric | `master` | This branch |
|---|---|---:|---:|
| 14-stage propane/n-butane, 323.15 K feed | matrix iterations | 14 (cap) | 5 |
|  | matrix temperature residual | 0.872675 K | 0.0555187 K |
|  | total reported iterations | 24 | 15 |
| Nearby 326.15 K feed | matrix iterations | 14 (cap) | 5 |
|  | matrix temperature residual | 1.02857 K | 0.0412992 K |
|  | total reported iterations | 23 | 14 |
| 15-stage, 11-component deethanizer, 216 K feed | matrix iterations | 15 (cap) | 11 |
|  | matrix temperature residual | 1.44439 K | 0.0830677 K |
| Nearby 220 K feed | matrix iterations | 15 (cap) | 9 |
|  | matrix temperature residual | 0.872702 K | 0.0903311 K |

The removed work is also deterministic: one unnecessary `init(0)` per tray per matrix iteration. The 15-stage baseline therefore performed 225 unnecessary phase resets. No wall-clock speed claim is made.

For both binary points and both deethanizer points, final gas/liquid product flows, product temperatures, mass residuals, energy diagnostics, and repeat runs were numerically identical between baseline and candidate. Representative total mass closure was `2.13e-16` at 323.15 K and `1.86e-16` at 326.15 K; the 11-component cases closed to `4.94e-13` and `4.05e-15` relative error. All product flows and temperatures were finite and physical.

## Regression coverage

Strengthens the existing realistic large-column matrix test to require that the matrix warm start:

- derives the matrix tolerance from the configured column tolerance and solver floor;
- derives the matrix iteration cap from stage count and the configured iteration budget;
- is still followed by rigorous inside-out polishing;
- closes total product mass against the actual feed flow within one part per million.

The new convergence assertions fail on current `master` and pass with this change.

## Validation

Local validation:

- current `DistillationColumnMatrixSolver.java` compiled with Java 8 source/target compatibility on Java 17;
- exact binary regression and 3 K nearby point executed on baseline and candidate;
- 11-component deethanizer and 4 K nearby point executed on baseline and candidate;
- deterministic independent-build repeatability checked;
- final diff verified as exactly the intended production and test files.

Review repair on head `5c767b7` removes duplicated test constants: tolerance and iteration-cap assertions are derived from column configuration, mass closure uses the actual feed flow, and the tolerance scales at one part per million. Both visible Copilot threads have validation replies and remain resolved; the suppressed scale-independence suggestion was accepted and dispositioned in the PR conversation.

Hosted validation on head `5c767b7`: Spotless produced an empty patch; pre-commit, PaperLab, agent-skill cross-reference validation, and Javadocs pass. CodeQL passes. Java 21 Ubuntu/Windows tests and the three Java 21 slow-test shards remain in progress; no result is claimed for them yet. Copilot's post-push two-file review generated no new comments.

The workspace could not resolve the current Maven plugin set because external Maven Central DNS was unavailable, so the full JUnit class and broader repository suite are delegated to GitHub CI.

## Compatibility and risk

Low and localized. There is no public API, serialization, cloning, thread-safety, specification, tolerance, or calculation-identity change. The matrix stage still uses `init(1)` and rigorous polishing remains authoritative. The behavioral change is preservation of the existing phase mapping/beta state during matrix composition updates, which lets the warm-start residual actually satisfy its configured tolerance.

## Documentation impact

Documentation impact: none. This fixes an internal initialization sequence to comply with the already-documented minimal thermodynamic initialization contract; no user-facing API, configuration, units, or recommended workflow changes.