### PR TITLE
fix(tpflash): refine nonequilibrium aqueous endpoints

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -193,7 +193,9 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │  Order phases by density                                                        │
 │  Final system.init(1)                                                           │
 │                                                                                 │
-│  IF ordinary flash, water feed ≥ 0.01, and no aqueous phase:                    │
+│  IF ordinary flash and water feed ≥ 0.01:                                       │
+│     → Refine a missing aqueous phase, or an existing two-phase aqueous           │
+│       endpoint only when max |Δ ln(fᵢ)| ≥ 1e-8                                  │
 │     → Evaluate a cloned TPmultiflash candidate                                  │
 │     → Accept any two-phase candidate with lower Gibbs energy,                   │
 │       bounded/normalized phase fractions, and distinct phase compositions       │
@@ -220,7 +222,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | `maxNumberOfIterations` | 50 | Maximum iterations per convergence loop |
 | Convergence tolerance | 1e-10 | Deviation threshold for K-value convergence |
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
-| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; accept an already-computed two-phase candidate only through Gibbs and phase-quality checks, independent of its phase labels |
+| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; existing two-phase aqueous endpoints additionally require `max abs(Delta ln(f_i)) >= 1e-8` before refinement |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
 
 ### 1.1 Problem Formulation
@@ -1656,6 +1658,9 @@ Commercial process simulators do not publish all implementation details, but pub
 - Pure-component fallback trials improve LLE/VLLE detection where Wilson K-based trials can report positive TPD even though a liquid-liquid split exists.
 - Explicit multiphase hydrocarbon flashes now retry a local lower-temperature seed before accepting an ambiguous single-phase endpoint, and keep the retry only if it gives a lower-Gibbs multiphase result.
 - A cheap post-flash K-envelope gate skips that rescue for clearly single-phase hydrocarbon endpoints, preserving ordinary `setMultiPhaseCheck(true)` speed.
+- Water-rich ordinary endpoints are not accepted from an aqueous phase label alone. An existing two-phase aqueous
+  endpoint is sent to multiphase refinement only when `max abs(Delta ln(f_i)) >= 1e-8`, and the candidate still must
+  lower Gibbs energy and pass phase-quality checks.
 - Ordinary neutral aqueous splits now compare both cubic roots of the non-aqueous phase at the converged composition. An alternate root is retained only when it lowers Gibbs energy and already satisfies `max abs(Delta ln(f_i)) < 1e-8`; no extra TPflash or multiphase stability calculation is run.
 - Enhanced stability checks are gated to polar, associating, electrolyte, sour, or explicitly requested multiphase systems, limiting unnecessary hydrocarbon phase-map artifacts.
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -875,12 +875,12 @@ public class TPflash extends Flash {
    *
    * <p>
    * The ordinary flash searches only the cubic gas/oil roots and can therefore leave a substantial water fraction
-   * dissolved in hydrocarbon-labelled phases, or miss a lower-Gibbs gas-oil split when water makes the generic
-   * hydrocarbon endpoint screen inapplicable. The one-mol-percent feed guard keeps trace-water process flashes on the
-   * existing fast path. A cloned multiphase candidate replaces the ordinary state only when it contains exactly two
-   * phases and passes the same strict phase-fraction, distinct-composition, and Gibbs-energy checks used by the
-   * liquid-liquid rescue. The candidate need not contain an aqueous-labelled phase: phase stability and Gibbs energy,
-   * rather than the expected phase label, decide whether the already-computed candidate is accepted.
+   * dissolved in a hydrocarbon-labelled phase even when a lower-Gibbs aqueous split exists. An existing aqueous phase
+   * label is not by itself proof of equilibrium: phase typing can identify a water-rich phase after the ordinary
+   * gas/oil iteration has stopped. Such an endpoint is refined only when its component fugacity residual exceeds
+   * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE}. The one-mol-percent feed guard keeps trace-water process flashes on the
+   * existing fast path. A cloned multiphase candidate replaces the ordinary state only through the same strict
+   * phase-fraction, distinct-composition, and Gibbs-energy checks used by the liquid-liquid rescue.
    * </p>
    */
   private void rescueWaterRichEndpoint() {
@@ -889,10 +889,11 @@ public class TPflash extends Flash {
       return;
     }
 
-    double waterFeedFraction = 0.0;
-    if (system.hasPhaseType(PhaseType.AQUEOUS)) {
+    boolean hasAqueousPhase = system.hasPhaseType(PhaseType.AQUEOUS);
+    if (hasAqueousPhase && system.getNumberOfPhases() < 2) {
       return;
     }
+    double waterFeedFraction = 0.0;
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
       if ("water".equalsIgnoreCase(component.getComponentName())) {
@@ -901,6 +902,11 @@ public class TPflash extends Flash {
       }
     }
     if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
+      return;
+    }
+    if (hasAqueousPhase
+        && maximumLogFugacityResidualWithReplacement(0, system.getPhase(0))
+            < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
       return;
     }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -905,8 +905,7 @@ public class TPflash extends Flash {
       return;
     }
     if (hasAqueousPhase
-        && maximumLogFugacityResidualWithReplacement(0, system.getPhase(0))
-            < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
+        && maximumLogFugacityResidualWithReplacement(0, system.getPhase(0)) < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
       return;
     }
 

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousResidualRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousResidualRefinementTest.java
@@ -9,9 +9,7 @@ import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 class TPflashAqueousResidualRefinementTest {
-  private static final String[] COMPONENTS = {
-      "nitrogen", "methane", "ethane", "propane", "nC10", "water"
-  };
+  private static final String[] COMPONENTS = { "nitrogen", "methane", "ethane", "propane", "nC10", "water" };
   private static final double[] FEED = { 0.01, 0.75, 0.08, 0.04, 0.02, 0.10 };
 
   @Test
@@ -71,8 +69,7 @@ class TPflashAqueousResidualRefinementTest {
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < actual.getNumberOfPhases(); phaseIndex++) {
-        recoveredFeed += actual.getBeta(phaseIndex)
-            * actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        recoveredFeed += actual.getBeta(phaseIndex) * actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
       assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-11);
     }
@@ -88,8 +85,7 @@ class TPflashAqueousResidualRefinementTest {
       double secondLogFugacity = Math
           .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
           + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
-      maximumResidual =
-          Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+      maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
     }
     return maximumResidual;
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousResidualRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousResidualRefinementTest.java
@@ -1,0 +1,96 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashAqueousResidualRefinementTest {
+  private static final String[] COMPONENTS = {
+      "nitrogen", "methane", "ethane", "propane", "nC10", "water"
+  };
+  private static final double[] FEED = { 0.01, 0.75, 0.08, 0.04, 0.02, 0.10 };
+
+  @Test
+  void ordinaryFlashRefinesNonequilibriumAqueousEndpoint() {
+    SystemInterface ordinary = createAndFlash(false);
+    SystemInterface multiphase = createAndFlash(true);
+
+    assertEquivalentEquilibrium(multiphase, ordinary);
+    double firstGibbsEnergy = ordinary.getGibbsEnergy();
+
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.init(1);
+
+    assertEquals(firstGibbsEnergy, ordinary.getGibbsEnergy(), 1.0e-8);
+    assertEquivalentEquilibrium(multiphase, ordinary);
+  }
+
+  private SystemInterface createAndFlash(boolean multiphaseCheck) {
+    SystemInterface system = new SystemSrkEos(273.15, 300.0);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], FEED[componentIndex]);
+    }
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private void assertEquivalentEquilibrium(SystemInterface expected, SystemInterface actual) {
+    assertEquals(2, expected.getNumberOfPhases());
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(PhaseType.GAS, actual.getPhase(0).getType());
+    assertEquals(PhaseType.AQUEOUS, actual.getPhase(1).getType());
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-8);
+
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < expected.getNumberOfPhases(); phaseIndex++) {
+      assertEquals(expected.getPhase(phaseIndex).getType(), actual.getPhase(phaseIndex).getType());
+      assertEquals(expected.getBeta(phaseIndex), actual.getBeta(phaseIndex), 1.0e-12);
+      assertTrue(actual.getBeta(phaseIndex) > 0.0);
+      assertTrue(actual.getBeta(phaseIndex) < 1.0);
+      assertTrue(Double.isFinite(actual.getPhase(phaseIndex).getZ()));
+      assertTrue(actual.getPhase(phaseIndex).getZ() > 0.0);
+      betaTotal += actual.getBeta(phaseIndex);
+
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        assertEquals(expected.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            actual.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
+        compositionTotal += actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-12);
+    }
+    assertEquals(1.0, betaTotal, 1.0e-12);
+
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < actual.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += actual.getBeta(phaseIndex)
+            * actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-11);
+    }
+    assertTrue(maximumLogFugacityResidual(actual) < 1.0e-8);
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double firstLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      maximumResidual =
+          Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+    }
+    return maximumResidual;
+  }
+}


### PR DESCRIPTION
## Reproduced problem

An SRK wet-gas flash at 273.15 K and 300 bara with mixing rule 2 and feed
`N2/CH4/C2H6/C3H8/nC10/H2O = 0.01/0.75/0.08/0.04/0.02/0.10`
returns two phases on both paths, but the ordinary TPflash endpoint is not at equilibrium:

| Metric | Ordinary before | TPmultiflash reference | Ordinary after |
|---|---:|---:|---:|
| Phases | GAS + AQUEOUS | GAS + AQUEOUS | GAS + AQUEOUS |
| Gibbs energy (J) | 8155.3510503 | 7499.2772159 | 7499.2772159 |
| max `abs(Delta ln(f_i))` | 8.1862564 | 2.57e-13 | 2.57e-13 |
| gas beta | 0.88124884 | 0.90009655 | 0.90009655 |

Repeated ordinary flashes and pressure/temperature continuation retain the defective endpoint.

## Root cause

`PhaseEos.init` can classify a water-rich liquid as `AQUEOUS` after the ordinary gas/oil iteration. `rescueWaterRichEndpoint()` treated that phase label as proof that aqueous equilibrium had already been solved and returned immediately. The label describes phase character; it does not certify component fugacity equality.

## Fix

For an existing neutral two-phase aqueous endpoint with at least 1 mol% feed water:

1. Calculate the existing log-fugacity equilibrium residual.
2. Keep the fast path when `max abs(Delta ln(f_i)) < 1e-8`.
3. Otherwise evaluate the existing cloned multiphase candidate.
4. Accept it only when it has exactly two phases, lowers Gibbs energy, has bounded/normalized phase fractions, and has distinct normalized phase compositions.

Missing-aqueous endpoints continue through the existing refinement. Single-phase aqueous, chemical, ionic, solid, wax, trace-water, and explicit-multiphase paths retain their existing guards. The equilibrium calculation and regression use only `init(1)`; no higher thermodynamic initialization level is introduced.

## Method and literature basis

This uses the same Michelsen stability and phase-split machinery already present in NeqSim. Equal component fugacities are the equilibrium condition, while lower Gibbs energy plus the existing phase-quality guards selects the stable candidate. A phase-type label is therefore a useful classifier, not an equilibrium certificate.

- Michelsen, *The isothermal flash problem. Part I. Stability*, Fluid Phase Equilibria 9 (1982), 1–19. https://doi.org/10.1016/0378-3812(82)85001-2
- Michelsen, *The isothermal flash problem. Part II. Phase-split calculation*, Fluid Phase Equilibria 9 (1982), 21–40. https://doi.org/10.1016/0378-3812(82)85002-4

The literature basis above is evidence for the fugacity/stability/Gibbs criteria. The diagnosis that NeqSim's phase label was being used as an invalid convergence shortcut is implementation evidence from this reproducer. No inference is made about proprietary commercial-simulator internals.

## Cross-algorithm matrix

The deterministic 450-state ordinary/multiphase matrix covers gas, oil, aqueous, hydrocarbon-water, CO2-rich, H2-rich, near-boundary, one-, two-, and three-phase states across SRK, PR, and CPA paths, including repeated and changed-state execution.

- Successful paired flashes: 450/450 before and after
- Structural disagreements: 0 before and after
- Numerical disagreements: 22 -> 21
- This minimal wet-gas defect: removed
- Component/total balance, beta bounds, composition normalization, finite positive compressibility, and deterministic repeatability: passed
- The other 21 numerical discrepancies are unchanged and remain separate investigation targets.

Numerical tolerances are `1e-8` for Gibbs energy and maximum log-fugacity residual, `1e-12` for cross-algorithm phase fractions/compositions, and `1e-11` for component material balance.

## Performance

Eight fresh-JVM forks with 120 flashes per case gave these median-of-fork-medians:

| Case | Before (ms/flash) | After (ms/flash) | Interpretation |
|---|---:|---:|---|
| Stable aqueous control | ~4.14 | ~4.05 | no measurable regression |
| CO2-water control | ~4.19 | ~4.26 | within run noise |
| Corrected wet-gas defect | ~8.00 | ~10.82 | ~2.8 ms paid only to obtain the stable solution |

Dry-gas and hydrocarbon paths exit before the new residual check; their implementation path and checksums are unchanged. This PR prioritizes correctness for a confirmed nonequilibrium endpoint while retaining the safe fast paths.

## Tests and validation

- Added `TPflashAqueousResidualRefinementTest`.
- The standalone deterministic regression fails against the master baseline with a Gibbs mismatch and passes with this patch.
- Candidate result matches TPmultiflash phase types, beta, phase compositions, and Gibbs energy at the stated tolerances.
- Repeated execution, material closure, normalization, beta bounds, finite positive Z, and fugacity equality pass.
- The focused source and executable regression harness compiled against the current packaged NeqSim classes.
- On the first PR revision, GitHub's full build/test/Javadoc matrix, CodeQL, documentation coverage, PaperLab, and the standalone Spotless workflow passed.
- Pre-commit then reported only the exact four Spotless line-wrapping differences; that generated patch has been applied without changing behavior.
- On the formatted head, Java 8 Ubuntu, Java 21 Ubuntu/Windows, all three Java 21 slow-test shards, Javadocs, CodeQL, documentation coverage, Spotless, pre-commit, and PaperLab passed.
- Java 8 Windows failed only in `DynamicCompressorNotebookRegressionTest` and `MultiStreamHeatExchangerTest`; neither test nor either production path is touched by this three-file TPflash diff, and the same failures are tracked independently from this PR.
- The branch is now current with `master` at `c868041`; fresh validation is running on the refreshed head.
- Full Maven, Spotless, and repository suites were not run locally because the available Maven wrapper attempted to write to a read-only `/root/.m2`; GitHub CI remains authoritative for those checks.

## Compatibility risk

Low and bounded. Stable aqueous endpoints add only a component-level log-residual screen. Multiphase refinement runs only for a water-rich ordinary endpoint that already violates the documented equilibrium tolerance, and the candidate must pass the existing lower-Gibbs and phase-quality acceptance checks. The corrected endpoint intentionally changes phase fractions, compositions, and thermodynamic properties to the stable solution.

## Documentation impact

Updated the `TPflash` Javadoc and `docs/thermodynamicoperations/TPflash_algorithm.md` to distinguish phase classification from equilibrium certification, document the `1e-8` trigger, and describe the acceptance safeguards.
