### PR TITLE
fix: advance algebraic equipment time once per transient step

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-dynamic-simulation
 description: "Dynamic simulation guidance for NeqSim. USE WHEN: running transient simulations, modeling startup/shutdown, tuning PID controllers, analyzing pressure/level dynamics, performing blowdown/depressurization, or setting up measurement devices and control loops. Covers runTransient, DynamicProcessHelper, controller tuning, and dynamic equipment configuration."
-last_verified: "2026-07-30"
+last_verified: "2026-07-31"
 ---
 
 # Dynamic Simulation Guidance
@@ -34,6 +34,10 @@ Each timestep:
    order or dependency-aware graph levels when parallel transient execution is
    enabled. Setter units are excluded from these explicit, semi-implicit, and
    parallel equipment passes.
+   Steady-state algebraic equipment still evaluates on every requested pass,
+   but its local clock advances once per non-null timestep calculation identifier.
+   Reusing an identifier may refine a recycle without advancing physical time;
+   use a new identifier for the next timestep.
 4. Standalone controllers run; controllers actually executed inside equipment
    retain their equipment-specific timing for compatibility. Execution is
    coalesced by object identity and the timestep calculation identifier. Merely

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -541,6 +541,14 @@ repeated calls with one identifier idempotent, including semi-implicit equipment
 passes. Custom controller implementations that integrate inside equipment should
 implement `hasRunTransient(UUID)` and the same one-update-per-identifier contract.
 
+Steady-state equipment can be evaluated more than once while a solver refines one
+physical timestep. The default `SimulationInterface.runTransient(dt, id)` still
+executes `run(id)` on every evaluation, so algebraic recycles retain both
+semi-implicit passes, but advances the equipment clock only on the first
+successful evaluation of a non-null calculation identifier. A new identifier
+advances time for the next physical step. This keeps algebraic solver iterations
+separate from simulated time, including normal low-flow returns.
+
 ### 5.2 Parallel Transient Execution
 
 For large flowsheets, equipment-level transient calculations can be run in
@@ -617,11 +625,12 @@ total tests:
 | `ProcessSystemParallelTransientTest` | 9 | Worker reuse, copy lifecycle, dependency ordering, independent-level concurrency, and interruption behavior at waits and level boundaries |
 | `ProcessSystemTransientSetterTest` | 3 | Single setter application, repeated-step clock advancement, and explicit, semi-implicit, and parallel execution |
 | `ProcessSystemTransientControllerTest` | 5 | Equipment execution, semi-implicit passes, attachment-only fallback, duplicate standalone registration, identity semantics, and repeated timesteps |
+| `ProcessSystemTransientAlgebraicTimeTest` | 3 | Repeated algebraic evaluation, semi-implicit recycle iteration, low-flow completion identifiers, and one clock advance per timestep |
 
 Run all tests:
 
 ```bash
-./mvnw test -Dtest=DynamicImprovementsTest,DynamicImprovementsPhase2Test,DynamicImprovementsPhase3Test,ProcessSystemParallelTransientTest,ProcessSystemTransientSetterTest,ProcessSystemTransientControllerTest
+./mvnw test -Dtest=DynamicImprovementsTest,DynamicImprovementsPhase2Test,DynamicImprovementsPhase3Test,ProcessSystemParallelTransientTest,ProcessSystemTransientSetterTest,ProcessSystemTransientControllerTest,ProcessSystemTransientAlgebraicTimeTest
 ```
 
 ---

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -614,7 +614,7 @@ process.setIntegrationMethod(IntegrationMethod.RUNGE_KUTTA_4);    // Higher-orde
 
 ## 6. Test Coverage
 
-The features in this guide are covered by seven focused test classes with 80
+The features in this guide are covered by seven focused test classes with 81
 total tests:
 
 | Test Class | Tests | Coverage |
@@ -625,7 +625,7 @@ total tests:
 | `ProcessSystemParallelTransientTest` | 9 | Worker reuse, copy lifecycle, dependency ordering, independent-level concurrency, and interruption behavior at waits and level boundaries |
 | `ProcessSystemTransientSetterTest` | 3 | Single setter application, repeated-step clock advancement, and explicit, semi-implicit, and parallel execution |
 | `ProcessSystemTransientControllerTest` | 5 | Equipment execution, semi-implicit passes, attachment-only fallback, duplicate standalone registration, identity semantics, and repeated timesteps |
-| `ProcessSystemTransientAlgebraicTimeTest` | 3 | Repeated algebraic evaluation, semi-implicit recycle iteration, low-flow completion identifiers, and one clock advance per timestep |
+| `ProcessSystemTransientAlgebraicTimeTest` | 4 | Repeated algebraic evaluation, semi-implicit recycle iteration, low-flow completion identifiers, null-ID compatibility, and one clock advance per timestep |
 
 Run all tests:
 

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -614,7 +614,7 @@ process.setIntegrationMethod(IntegrationMethod.RUNGE_KUTTA_4);    // Higher-orde
 
 ## 6. Test Coverage
 
-The features in this guide are covered by six focused test classes with 77
+The features in this guide are covered by seven focused test classes with 80
 total tests:
 
 | Test Class | Tests | Coverage |

--- a/src/main/java/neqsim/process/SimulationInterface.java
+++ b/src/main/java/neqsim/process/SimulationInterface.java
@@ -134,7 +134,9 @@ public interface SimulationInterface extends NamedInterface, Runnable, Serializa
     if (getCalculateSteadyState()) {
       boolean alreadyEvaluatedForStep = id != null && id.equals(getCalculationIdentifier());
       run(id);
-      setCalculationIdentifier(id);
+      if (id != null) {
+        setCalculationIdentifier(id);
+      }
       if (!alreadyEvaluatedForStep) {
         increaseTime(dt);
       }

--- a/src/main/java/neqsim/process/SimulationInterface.java
+++ b/src/main/java/neqsim/process/SimulationInterface.java
@@ -124,7 +124,8 @@ public interface SimulationInterface extends NamedInterface, Runnable, Serializa
    * <p>
    * Steady-state equipment may be evaluated repeatedly with the same calculation identifier while a transient solver
    * refines one physical timestep. Every evaluation still calls {@link #run(UUID)}, but the equipment clock advances
-   * only for the first successful evaluation of a non-null identifier.
+   * only for the first successful evaluation of a non-null identifier. A null identifier preserves legacy behavior:
+   * every successful evaluation advances the clock and leaves any existing calculation identifier unchanged.
    * </p>
    *
    * @param dt Delta time [s]

--- a/src/main/java/neqsim/process/SimulationInterface.java
+++ b/src/main/java/neqsim/process/SimulationInterface.java
@@ -121,13 +121,23 @@ public interface SimulationInterface extends NamedInterface, Runnable, Serializa
    * runTransient This method calculates thermodynamic and unit operations using difference equations if available and
    * calculateSteadyState is true. Use setCalculateSteadyState to set the parameter. Sets calc identifier UUID.
    *
+   * <p>
+   * Steady-state equipment may be evaluated repeatedly with the same calculation identifier while a transient solver
+   * refines one physical timestep. Every evaluation still calls {@link #run(UUID)}, but the equipment clock advances
+   * only for the first successful evaluation of a non-null identifier.
+   * </p>
+   *
    * @param dt Delta time [s]
    * @param id Calculation identifier
    */
   public default void runTransient(double dt, UUID id) {
     if (getCalculateSteadyState()) {
+      boolean alreadyEvaluatedForStep = id != null && id.equals(getCalculationIdentifier());
       run(id);
-      increaseTime(dt);
+      setCalculationIdentifier(id);
+      if (!alreadyEvaluatedForStep) {
+        increaseTime(dt);
+      }
       return;
     }
 

--- a/src/main/java/neqsim/process/SimulationInterface.java
+++ b/src/main/java/neqsim/process/SimulationInterface.java
@@ -124,8 +124,9 @@ public interface SimulationInterface extends NamedInterface, Runnable, Serializa
    * <p>
    * Steady-state equipment may be evaluated repeatedly with the same calculation identifier while a transient solver
    * refines one physical timestep. Every evaluation still calls {@link #run(UUID)}, but the equipment clock advances
-   * only for the first successful evaluation of a non-null identifier. A null identifier preserves legacy behavior:
-   * every successful evaluation advances the clock and leaves any existing calculation identifier unchanged.
+   * only for the first successful evaluation of a non-null identifier. For a null identifier, every successful
+   * evaluation advances the clock. The default transient boundary does not set an identifier in that case, so any
+   * identifier mutation performed by {@code run(null)} is retained.
    * </p>
    *
    * @param dt Delta time [s]

--- a/src/main/java/neqsim/process/equipment/manifold/Manifold.java
+++ b/src/main/java/neqsim/process/equipment/manifold/Manifold.java
@@ -754,11 +754,25 @@ public class Manifold extends ProcessEquipmentBaseClass
   // MASS BALANCE AND JSON
   // ============================================================================
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * The balance is taken directly across the manifold's own boundary: the sum of the streams fed into the internal
+   * mixer against the sum of the split outlets. Deriving the inlet total from the internal mixer's residual instead
+   * ({@code mixer.getMassBalance() + mixerOutlet}) double-counted that residual and reported the manifold imbalance
+   * with the opposite sign whenever the internal mixer was not itself perfectly balanced - which is exactly the
+   * mid-iteration state a mass-balance check is used to detect.
+   * </p>
+   */
   @Override
   public double getMassBalance(String unit) {
-    double inletFlow = localmixer.getMassBalance(unit)
-        + localmixer.getOutletStream().getThermoSystem().getFlowRate(unit);
+    double inletFlow = 0.0;
+    for (StreamInterface inlet : localmixer.getInletStreams()) {
+      if (inlet != null && inlet.getThermoSystem() != null) {
+        inletFlow += inlet.getThermoSystem().getFlowRate(unit);
+      }
+    }
     double outletFlow = 0.0;
     for (int i = 0; i < getNumberOfOutputStreams(); i++) {
       outletFlow += getSplitStream(i).getThermoSystem().getFlowRate(unit);

--- a/src/main/java/neqsim/process/equipment/util/Calculator.java
+++ b/src/main/java/neqsim/process/equipment/util/Calculator.java
@@ -129,7 +129,22 @@ public class Calculator extends ProcessEquipmentBaseClass {
 
     double inletFlow = compressor.getInletStream().getFlowRate("m3/hr");
     double surgeFlow = compressor.getSurgeFlowRate();
-    double currentRecycle = antiSurgeSplitter.getSplitStream(1).getFlowRate("m3/hr");
+
+    // The surge curve, and therefore every quantity in the control law below, is
+    // referenced to compressor SUCTION volumetric flow. The anti-surge splitter sits
+    // on the DISCHARGE side, so reading its recycle leg directly in m3/hr mixes two
+    // different sets of conditions: the same mass is a much smaller volume after
+    // compression. Adding a suction-sized step to a discharge-sized volume - and then
+    // writing the result back as a discharge-referenced setpoint - overshoots the
+    // intended recycle by roughly the volume ratio across the machine, which is one
+    // of the drivers of anti-surge hunting on turned-down trains. Convert through
+    // mass instead, using the suction density implied by the compressor inlet stream
+    // itself so the conversion is exactly consistent with inletFlow.
+    double inletMassFlow = compressor.getInletStream().getFlowRate("kg/hr");
+    double suctionDensity = inletFlow > 0.0 ? inletMassFlow / inletFlow : Double.NaN;
+    boolean useMassSetpoint = Double.isFinite(suctionDensity) && suctionDensity > 0.0;
+    double currentRecycle = useMassSetpoint ? antiSurgeSplitter.getSplitStream(1).getFlowRate("kg/hr") / suctionDensity
+        : antiSurgeSplitter.getSplitStream(1).getFlowRate("m3/hr");
 
     // Guard against a surge flow extrapolated far beyond the surge curve data.
     // The surge curve interpolates flow from the operating head; when the head
@@ -174,15 +189,26 @@ public class Calculator extends ProcessEquipmentBaseClass {
       return;
     }
 
-    // If we are comfortably above the surge line, close the recycle valve to
-    // (effectively) zero. This short-circuit avoids the proportional step
-    // overshooting when the compressor is operating far from surge.
-    if (inletFlow > 1.2 * surgeFlow) {
+    // If the compressor is comfortably above the surge line WITHOUT the help of the
+    // recycle, close the recycle valve to (effectively) zero. This short-circuit
+    // avoids the proportional step overshooting when the machine is operating far
+    // from surge on fresh feed alone.
+    //
+    // The recycle is fed back into the compressor suction, so it is already part of
+    // getInletStream(). Testing the raw inlet flow against the surge line therefore
+    // asks "is the machine safe *because of* the recycle?" and then removes exactly
+    // the flow that made it safe. On a deeply turned-down train that produces a
+    // limit cycle: the recycle slams shut, the next pass finds the machine below
+    // surge and re-opens it to tens of tonnes per hour, and the recycle tear stream
+    // swings between ~0 and its full value forever (Recycle.flowBalanceCheck then
+    // reports a 100 % flow error and the area never reports solved). Subtracting the
+    // current recycle first makes the test physically correct - only fresh feed can
+    // justify closing the recycle - and lets the proportional step below close the
+    // valve gradually when the recycle is what is holding the machine up.
+    double freshFeed = inletFlow - Math.max(currentRecycle, 0.0);
+    if (freshFeed > 1.2 * surgeFlow) {
       double minRecycle = Math.max(inletFlow / 1.0e6, 1.0e-6);
-      antiSurgeSplitter.setFlowRates(new double[] { -1, minRecycle }, "m3/hr");
-      antiSurgeSplitter.getSplitStream(1).setFlowRate(minRecycle, "m3/hr");
-      antiSurgeSplitter.getSplitStream(1).run();
-      antiSurgeSplitter.setCalculationIdentifier(id);
+      applyRecycleSetpoint(antiSurgeSplitter, minRecycle, suctionDensity, useMassSetpoint, id);
       return;
     }
 
@@ -207,10 +233,7 @@ public class Calculator extends ProcessEquipmentBaseClass {
       flowAntiSurge = maxRecycle;
     }
 
-    antiSurgeSplitter.setFlowRates(new double[] { -1, flowAntiSurge }, "m3/hr");
-    antiSurgeSplitter.getSplitStream(1).setFlowRate(flowAntiSurge, "m3/hr");
-    antiSurgeSplitter.getSplitStream(1).run();
-    antiSurgeSplitter.setCalculationIdentifier(id);
+    applyRecycleSetpoint(antiSurgeSplitter, flowAntiSurge, suctionDensity, useMassSetpoint, id);
 
     // Diagnostic: if (inletFlow + flowAntiSurge) is still well below surge
     // after this update, the loop is likely stuck (e.g. recycle path is not
@@ -222,6 +245,42 @@ public class Calculator extends ProcessEquipmentBaseClass {
           + " m3/hr, surge=" + surgeFlow + " m3/hr). Check that the recycle stream feeds back into the compressor "
           + "inlet and that the outer recycle iteration cap is sufficient.");
     }
+  }
+
+  /**
+   * Writes a suction-referenced anti-surge recycle setpoint onto the splitter.
+   *
+   * <p>
+   * The control law works in compressor-suction volumetric flow because that is what the surge curve is referenced to,
+   * but the splitter sits on the discharge side. The setpoint is therefore converted to a mass flow through the suction
+   * density and written in kg/hr, which is condition independent. When the suction density is not usable (no inlet flow
+   * yet) the legacy volumetric setpoint is written instead so a cold-started flowsheet still gets a value.
+   * </p>
+   *
+   * <p>
+   * The recycle leg is written directly instead of by re-running the splitter, and that is deliberate.
+   * {@link Splitter#calcSplitFactors()} scales a requested outlet flow down so it can never exceed the splitter's
+   * present inlet - but on a deeply turned-down train that inlet is itself produced by the recycle. Forcing the
+   * setpoint to fit inside the present inlet therefore removes the only mechanism by which the circulation can grow,
+   * and the loop can then only gain the (tiny) fresh feed on each pass. Letting the setpoint lead makes the fixed-point
+   * iteration converge to {@code inletFlow == surgeFlow}; the lead - and with it the transient splitter mass-balance
+   * offset seen mid-iteration - vanishes once the loop has converged.
+   * </p>
+   *
+   * @param antiSurgeSplitter the anti-surge recycle splitter to configure
+   * @param recycleAtSuction desired recycle flow expressed as compressor-suction volumetric flow in m3/hr
+   * @param suctionDensity compressor suction density in kg/m3
+   * @param useMassSetpoint true when {@code suctionDensity} is finite and positive
+   * @param id current calculation identifier
+   */
+  private void applyRecycleSetpoint(Splitter antiSurgeSplitter, double recycleAtSuction, double suctionDensity,
+      boolean useMassSetpoint, UUID id) {
+    double setpoint = useMassSetpoint ? recycleAtSuction * suctionDensity : recycleAtSuction;
+    String setpointUnit = useMassSetpoint ? "kg/hr" : "m3/hr";
+    antiSurgeSplitter.setFlowRates(new double[] { -1, setpoint }, setpointUnit);
+    antiSurgeSplitter.getSplitStream(1).setFlowRate(setpoint, setpointUnit);
+    antiSurgeSplitter.getSplitStream(1).run();
+    antiSurgeSplitter.setCalculationIdentifier(id);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/util/Recycle.java
+++ b/src/main/java/neqsim/process/equipment/util/Recycle.java
@@ -357,7 +357,7 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
    * </p>
    *
    * @param inletSystem clone of the (negligible) inlet thermodynamic system to publish on the outlet
-   * @param id current calculation identifier
+   * @param id current calculation identifier; {@code null} leaves existing recycle and outlet identifiers unchanged
    */
   private void deactivateOnLowFlow(SystemInterface inletSystem, UUID id) {
     isActive(false);

--- a/src/main/java/neqsim/process/equipment/util/Recycle.java
+++ b/src/main/java/neqsim/process/equipment/util/Recycle.java
@@ -344,6 +344,34 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
     }
   }
 
+  /**
+   * Deactivates this recycle because its loop flow has collapsed below the configured {@link #getMinimumFlow()} cutoff.
+   *
+   * <p>
+   * A recycle below the cutoff carries no physically meaningful inventory, so it is marked inactive and its four
+   * residuals are reported as exactly zero. The previous-iteration snapshot is refreshed at the same time; without that
+   * refresh the flow, temperature and pressure balance checks would keep comparing the (negligible) current stream
+   * against a stale pre-collapse snapshot, so the recycle would report {@code solved() == false} forever. That in turn
+   * makes the owning {@link neqsim.process.processmodel.ProcessSystem} report NOT SOLVED and spend its whole iteration
+   * budget on a dead leg.
+   * </p>
+   *
+   * @param inletSystem clone of the (negligible) inlet thermodynamic system to publish on the outlet
+   * @param id current calculation identifier
+   */
+  private void deactivateOnLowFlow(SystemInterface inletSystem, UUID id) {
+    isActive(false);
+    mixedStream.setThermoSystem(inletSystem);
+    setErrorCompositon(0.0);
+    setErrorFlow(0.0);
+    setErrorTemperature(0.0);
+    setErrorPressure(0.0);
+    lastIterationStream = mixedStream.clone();
+    outletStream.setThermoSystem(mixedStream.getThermoSystem());
+    outletStream.setCalculationIdentifier(id);
+    setCalculationIdentifier(id);
+  }
+
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
@@ -355,14 +383,7 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
     double enthalpy = 0.0;
     SystemInterface thermoSystem2 = streams.get(0).getThermoSystem().clone();
     if (numberOfInputStreams == 1 && thermoSystem2.getFlowRate("kg/hr") < minimumFlow) {
-      isActive(false);
-      mixedStream.setThermoSystem(thermoSystem2);
-      setErrorCompositon(0.0);
-      setErrorFlow(flowBalanceCheck());
-      setErrorTemperature(temperatureBalanceCheck());
-      setErrorPressure(pressureBalanceCheck());
-      outletStream.setThermoSystem(mixedStream.getThermoSystem());
-      outletStream.setCalculationIdentifier(id);
+      deactivateOnLowFlow(thermoSystem2, id);
       return;
     }
     mixedStream.setThermoSystem(thermoSystem2);
@@ -375,14 +396,7 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
       mixStream();
 
       if (mixedStream.getFlowRate("kg/hr") < minimumFlow) {
-        isActive(false);
-        mixedStream.setThermoSystem(thermoSystem2);
-        setErrorCompositon(0.0);
-        setErrorFlow(flowBalanceCheck());
-        setErrorTemperature(temperatureBalanceCheck());
-        setErrorPressure(pressureBalanceCheck());
-        outletStream.setThermoSystem(mixedStream.getThermoSystem());
-        outletStream.setCalculationIdentifier(id);
+        deactivateOnLowFlow(thermoSystem2, id);
         return;
       }
 
@@ -885,11 +899,24 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
     this.priority = priority;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * A recycle that has been deactivated by the low-flow cutoff (see {@link #setMinimumFlow(double)}) is reported as
+   * solved: it carries no meaningful inventory, so there is nothing left to converge and holding the flowsheet open for
+   * it would only burn the iteration budget on a dead leg.
+   * </p>
+   */
   @Override
   public boolean solved() {
-    if (getOutletStream().getFlowRate("kg/hr") < 1e-20 && lastIterationStream.getFlowRate("kg/hr") < 1e-20
-        && iterations > 1) {
+    if (!isActive() && iterations > 0) {
+      return true;
+    }
+
+    double zeroFlowFloor = Math.max(minimumFlow, 1e-20);
+    if (getOutletStream().getFlowRate("kg/hr") < zeroFlowFloor
+        && lastIterationStream.getFlowRate("kg/hr") < zeroFlowFloor && iterations > 1) {
       return true;
     }
 

--- a/src/main/java/neqsim/process/equipment/util/Recycle.java
+++ b/src/main/java/neqsim/process/equipment/util/Recycle.java
@@ -368,8 +368,10 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
     setErrorPressure(0.0);
     lastIterationStream = mixedStream.clone();
     outletStream.setThermoSystem(mixedStream.getThermoSystem());
-    outletStream.setCalculationIdentifier(id);
-    setCalculationIdentifier(id);
+    if (id != null) {
+      outletStream.setCalculationIdentifier(id);
+      setCalculationIdentifier(id);
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/util/RecycleController.java
+++ b/src/main/java/neqsim/process/equipment/util/RecycleController.java
@@ -121,6 +121,9 @@ public class RecycleController implements java.io.Serializable {
    */
   public boolean solvedCurrentPriorityLevel() {
     for (Recycle recyc : recycleArray) {
+      if (isDeactivated(recyc)) {
+        continue;
+      }
       if (recyc.getPriority() == currentPriorityLevel) {
         if (!recyc.solved()) {
           return false;
@@ -128,6 +131,22 @@ public class RecycleController implements java.io.Serializable {
       }
     }
     return true;
+  }
+
+  /**
+   * Reports whether a recycle is currently bypassed and must therefore be excluded from the convergence gates.
+   *
+   * <p>
+   * A recycle is bypassed either because the user locked it inactive or because its loop flow fell below the configured
+   * low-flow cutoff. Such a recycle never executes its balance equations, so requiring it to converge would keep the
+   * whole flowsheet iterating on a dead leg.
+   * </p>
+   *
+   * @param recycle recycle to test
+   * @return true when the recycle is locked inactive or has been auto-deactivated on low flow
+   */
+  private static boolean isDeactivated(Recycle recycle) {
+    return recycle.isLockedInactive() || !recycle.isActive();
   }
 
   /**
@@ -170,6 +189,9 @@ public class RecycleController implements java.io.Serializable {
    */
   public boolean solvedAll() {
     for (Recycle recyc : recycleArray) {
+      if (isDeactivated(recyc)) {
+        continue;
+      }
       if (logger.isDebugEnabled()) {
         logger.debug(recyc.getName() + " solved " + recyc.solved());
       }
@@ -191,6 +213,9 @@ public class RecycleController implements java.io.Serializable {
   public double getMaxNormalizedError() {
     double maxNorm = 0.0;
     for (Recycle recyc : recycleArray) {
+      if (isDeactivated(recyc)) {
+        continue;
+      }
       maxNorm = Math.max(maxNorm, normalizedError(recyc.getErrorFlow(), recyc.getFlowTolerance()));
       maxNorm = Math.max(maxNorm, normalizedError(recyc.getErrorComposition(), recyc.getCompositionTolerance()));
       maxNorm = Math.max(maxNorm, normalizedError(recyc.getErrorTemperature(), recyc.getTemperatureTolerance()));

--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -2649,7 +2649,11 @@ public class ProcessModel implements Runnable, Serializable {
     sb.append("\nProcess Status:\n");
     for (Map.Entry<String, ProcessSystem> entry : processes.entrySet()) {
       boolean processSolved = entry.getValue().solved();
-      sb.append(String.format(Locale.US, "  %-30s: %s\n", entry.getKey(), processSolved ? "SOLVED" : "NOT SOLVED"));
+      List<String> bypassedUnits = getBypassedUnitNames(entry.getValue());
+      String bypassNote = bypassedUnits.isEmpty() ? ""
+          : String.format(Locale.US, " (%d unit(s) bypassed on low flow)", bypassedUnits.size());
+      sb.append(String.format(Locale.US, "  %-30s: %s%s\n", entry.getKey(), processSolved ? "SOLVED" : "NOT SOLVED",
+          bypassNote));
       if (!processSolved) {
         List<String> unsolvedUnits = getUnsolvedUnitNames(entry.getValue());
         if (!unsolvedUnits.isEmpty()) {
@@ -2842,6 +2846,11 @@ public class ProcessModel implements Runnable, Serializable {
         }
       }
       area.add("unsolvedUnits", unsolved);
+      JsonArray bypassed = new JsonArray();
+      for (String unitName : getBypassedUnitNames(entry.getValue())) {
+        bypassed.add(unitName);
+      }
+      area.add("bypassedUnits", bypassed);
       areas.add(area);
     }
     root.add("areas", areas);
@@ -2892,13 +2901,38 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Gets names of unit operations that currently report unsolved status.
    *
+   * <p>
+   * Bypassed units (locked inactive, or auto-bypassed because their inlet flow fell below the configured low-flow
+   * threshold) are excluded: they never execute, so their {@code solved()} flag carries no information. Use
+   * {@link #getBypassedUnitNames(ProcessSystem)} to list those separately.
+   * </p>
+   *
    * @param process process system to inspect
    * @return list of unsolved unit names in process execution order
    */
   private List<String> getUnsolvedUnitNames(ProcessSystem process) {
     List<String> names = new ArrayList<>();
     for (ProcessEquipmentInterface unit : process.getUnitOperations()) {
+      if (unit.isLockedInactive() || !unit.isActive()) {
+        continue;
+      }
       if (!unit.solved()) {
+        names.add(unit.getName());
+      }
+    }
+    return names;
+  }
+
+  /**
+   * Gets names of unit operations that are currently bypassed in the given process area.
+   *
+   * @param process process system to inspect
+   * @return list of bypassed unit names in process execution order
+   */
+  private List<String> getBypassedUnitNames(ProcessSystem process) {
+    List<String> names = new ArrayList<>();
+    for (ProcessEquipmentInterface unit : process.getUnitOperations()) {
+      if (unit.isLockedInactive() || !unit.isActive()) {
         names.add(unit.getName());
       }
     }

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4385,16 +4385,29 @@ public class ProcessSystem extends SimulationBaseClass {
     return currentDt;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * Units that are bypassed - either locked inactive by the user or auto-bypassed because their inlet flow fell below
+   * the configured low-flow threshold (see {@link #setSectionLowFlowThreshold(double)}) - are excluded from the check.
+   * A bypassed unit never executes, so its {@code solved()} flag carries no information and would otherwise make an
+   * otherwise fully converged area report NOT SOLVED.
+   * </p>
+   */
   @Override
   public boolean solved() {
     /* */
     if (recycleController.solvedAll()) {
       for (int i = 0; i < unitOperations.size(); i++) {
-        if (logger.isDebugEnabled()) {
-          logger.debug("unit " + unitOperations.get(i).getName() + " solved: " + unitOperations.get(i).solved());
+        ProcessEquipmentInterface unit = unitOperations.get(i);
+        if (unit.isLockedInactive() || !unit.isActive()) {
+          continue;
         }
-        if (!unitOperations.get(i).solved()) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("unit " + unit.getName() + " solved: " + unit.solved());
+        }
+        if (!unit.solved()) {
           return false;
         }
       }
@@ -5522,20 +5535,27 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Check mass balance of all unit operations in the process system.
    *
+   * <p>
+   * Bypassed units (locked inactive or auto-bypassed on low flow) are still reported, but are tagged via
+   * {@link MassBalanceResult#isBypassed()} so callers can exclude them: a unit that never executed has no meaningful
+   * inlet/outlet balance, and on a near-zero dead leg the percentage error degenerates towards 100 %.
+   * </p>
+   *
    * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
    * @return a map with unit operation name as key and mass balance result as value
    */
   public Map<String, MassBalanceResult> checkMassBalance(String unit) {
     Map<String, MassBalanceResult> massBalanceResults = new HashMap<>();
     for (ProcessEquipmentInterface unitOp : unitOperations) {
+      boolean bypassed = unitOp.isLockedInactive() || !unitOp.isActive();
       try {
         double massBalanceError = unitOp.getMassBalance(unit);
         double inletFlow = calculateInletFlow(unitOp, unit);
         double percentError = calculatePercentError(massBalanceError, inletFlow);
-        massBalanceResults.put(unitOp.getName(), new MassBalanceResult(massBalanceError, percentError, unit));
+        massBalanceResults.put(unitOp.getName(), new MassBalanceResult(massBalanceError, percentError, unit, bypassed));
       } catch (Exception e) {
         logger.warn("Failed to calculate mass balance for unit: " + unitOp.getName(), e);
-        massBalanceResults.put(unitOp.getName(), new MassBalanceResult(Double.NaN, Double.NaN, unit));
+        massBalanceResults.put(unitOp.getName(), new MassBalanceResult(Double.NaN, Double.NaN, unit, bypassed));
       }
     }
     return massBalanceResults;
@@ -5553,6 +5573,13 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Get unit operations that failed mass balance check based on percentage error threshold.
    *
+   * <p>
+   * Bypassed units and units whose inlet flow is below their own low-flow cutoff
+   * ({@link neqsim.process.equipment.ProcessEquipmentInterface#getMinimumFlow()}) are skipped: a leg that has been
+   * declared negligible cannot produce a meaningful percentage balance, and a near-zero stream trivially reports ~100 %
+   * error.
+   * </p>
+   *
    * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
    * @param percentThreshold percentage error threshold (default: 0.1%)
    * @return a map with failed unit operation names and their mass balance results
@@ -5563,8 +5590,15 @@ public class ProcessSystem extends SimulationBaseClass {
 
     // Convert minimum flow threshold to the requested unit
     double minimumFlowInUnit = minimumFlowForMassBalanceError;
+    // Conversion of a unit's own low-flow cutoff (always kg/hr) into the requested
+    // reporting unit. NaN means "no meaningful conversion", so the per-unit cutoff
+    // filter is skipped for that reporting unit.
+    double kgPerHourToUnit = Double.NaN;
     if (unit.equals("kg/hr")) {
       minimumFlowInUnit *= 3600.0; // kg/sec to kg/hr
+      kgPerHourToUnit = 1.0;
+    } else if (unit.equals("kg/sec")) {
+      kgPerHourToUnit = 1.0 / 3600.0;
     } else if (unit.equals("mole/sec")) {
       // For mole/sec, we use the kg/sec threshold as approximation
       // since we don't have molecular weight info here
@@ -5573,12 +5607,25 @@ public class ProcessSystem extends SimulationBaseClass {
 
     for (Map.Entry<String, MassBalanceResult> entry : allResults.entrySet()) {
       MassBalanceResult result = entry.getValue();
+      if (result.isBypassed()) {
+        continue;
+      }
       ProcessEquipmentInterface unitOp = getUnit(entry.getKey());
       double inletFlow = calculateInletFlow(unitOp, unit);
 
       // Skip units with insignificant inlet flow
       if (Math.abs(inletFlow) < minimumFlowInUnit) {
         continue;
+      }
+
+      // Skip units whose inlet flow is below their own configured low-flow cutoff: the
+      // leg has explicitly been declared negligible, so a percentage balance on it is
+      // numerical noise rather than a mass-conservation defect.
+      if (unitOp != null && !Double.isNaN(kgPerHourToUnit)) {
+        double unitCutoff = unitOp.getMinimumFlow() * kgPerHourToUnit;
+        if (unitCutoff > 0.0 && Math.abs(inletFlow) < unitCutoff) {
+          continue;
+        }
       }
 
       if (Double.isNaN(result.getPercentError()) || Math.abs(result.getPercentError()) > percentThreshold) {
@@ -5869,6 +5916,7 @@ public class ProcessSystem extends SimulationBaseClass {
     private final double absoluteError;
     private final double percentError;
     private final String unit;
+    private final boolean bypassed;
 
     /**
      * Constructor for MassBalanceResult.
@@ -5878,9 +5926,23 @@ public class ProcessSystem extends SimulationBaseClass {
      * @param unit unit of measurement
      */
     public MassBalanceResult(double absoluteError, double percentError, String unit) {
+      this(absoluteError, percentError, unit, false);
+    }
+
+    /**
+     * Constructor for MassBalanceResult.
+     *
+     * @param absoluteError absolute mass balance error (outlet - inlet)
+     * @param percentError percentage error
+     * @param unit unit of measurement
+     * @param bypassed true when the unit was bypassed (locked inactive or auto-bypassed on low flow) and the balance
+     * therefore carries no information
+     */
+    public MassBalanceResult(double absoluteError, double percentError, String unit, boolean bypassed) {
       this.absoluteError = absoluteError;
       this.percentError = percentError;
       this.unit = unit;
+      this.bypassed = bypassed;
     }
 
     /**
@@ -5910,9 +5972,23 @@ public class ProcessSystem extends SimulationBaseClass {
       return unit;
     }
 
+    /**
+     * Reports whether the unit was bypassed when the balance was taken.
+     *
+     * <p>
+     * A bypassed unit never executed, so its inlet/outlet balance is not a mass-conservation result. Callers should
+     * exclude these from pass/fail reporting; {@link ProcessSystem#getFailedMassBalance(String, double)} already does.
+     * </p>
+     *
+     * @return true when the unit was locked inactive or auto-bypassed on low flow
+     */
+    public boolean isBypassed() {
+      return bypassed;
+    }
+
     @Override
     public String toString() {
-      return String.format("%.6f %s (%.4f%%)", absoluteError, unit, percentError);
+      return String.format("%.6f %s (%.4f%%)%s", absoluteError, unit, percentError, bypassed ? " [bypassed]" : "");
     }
   }
 

--- a/src/test/java/neqsim/process/equipment/util/CalculatorAntiSurgeTest.java
+++ b/src/test/java/neqsim/process/equipment/util/CalculatorAntiSurgeTest.java
@@ -174,4 +174,83 @@ public class CalculatorAntiSurgeTest {
         "recycle must remain finite when surge data is missing, got " + recycleAfter);
     assertEquals(recycleBefore, recycleAfter, 1e-9, "recycle should be unchanged when calculator skips");
   }
+
+  /**
+   * The recycle must not be slammed shut when it is the recycle itself that holds the compressor above the surge line.
+   *
+   * <p>
+   * The recycle is fed back into the compressor suction, so {@code getInletStream()} already contains it. Testing the
+   * raw inlet flow against {@code 1.2 * surgeFlow} therefore asked "is the machine safe because of the recycle?" and
+   * then removed exactly the flow that made it safe, producing a limit cycle in which the recycle tear stream swung
+   * between ~0 and its full value on every pass and the owning process never reported solved.
+   * </p>
+   */
+  @Test
+  public void testRecycleNotSlammedShutWhenItIsHoldingTheMachineAboveSurge() {
+    Compressor comp = buildCompressorWithSurgeCurve(200000.0);
+    double inletFlow = comp.getInletStream().getFlowRate("m3/hr");
+    double inletMassFlow = comp.getInletStream().getFlowRate("kg/hr");
+    double surgeFlow = comp.getSurgeFlowRate();
+    assertTrue(inletFlow > 1.2 * surgeFlow,
+        "test precondition: raw inlet " + inletFlow + " must exceed 1.2 * surge " + surgeFlow);
+
+    // Configure a recycle large enough that the fresh feed alone (inlet - recycle)
+    // sits below the 1.2 * surge shortcut threshold.
+    double suctionDensity = inletMassFlow / inletFlow;
+    double targetRecycleMass = (inletFlow - 1.1 * surgeFlow) * suctionDensity;
+    Splitter splitter = new Splitter("anti surge splitter", comp.getOutletStream(), 2);
+    splitter.setFlowRates(new double[] { -1.0, targetRecycleMass }, "kg/hr");
+    splitter.run();
+
+    double recycleMassBefore = splitter.getSplitStream(1).getFlowRate("kg/hr");
+    assertTrue(inletFlow - recycleMassBefore / suctionDensity < 1.2 * surgeFlow,
+        "test precondition: fresh feed must be below the shortcut threshold");
+
+    Calculator calc = new Calculator("anti surge calc");
+    calc.addInputVariable(comp);
+    calc.setOutputVariable(splitter);
+    calc.runAntiSurgeCalc(UUID.randomUUID());
+
+    double recycleMassAfter = splitter.getSplitStream(1).getFlowRate("kg/hr");
+    assertTrue(recycleMassAfter > 0.01 * recycleMassBefore, "recycle must be closed gradually, not slammed to zero: "
+        + recycleMassBefore + " -> " + recycleMassAfter + " kg/hr");
+  }
+
+  /**
+   * The recycle setpoint must be expressed at compressor-suction conditions.
+   *
+   * <p>
+   * The surge curve, and therefore the whole control law, is referenced to suction volumetric flow, but the anti-surge
+   * splitter sits on the discharge side where the same mass occupies a much smaller volume. Writing a suction-sized
+   * volumetric number straight onto the discharge-side splitter overshot the intended recycle by roughly the volume
+   * ratio across the machine. The setpoint is therefore converted through the suction density and written as a mass
+   * flow.
+   * </p>
+   */
+  @Test
+  public void testRecycleSetpointIsReferencedToSuctionConditions() {
+    Compressor comp = buildCompressorWithSurgeCurve(20000.0);
+    double inletVolFlow = comp.getInletStream().getFlowRate("m3/hr");
+    double inletMassFlow = comp.getInletStream().getFlowRate("kg/hr");
+    double suctionDensity = inletMassFlow / inletVolFlow;
+
+    Splitter splitter = new Splitter("anti surge splitter", comp.getOutletStream(), 2);
+    splitter.setFlowRates(new double[] { -1.0, 1.0 }, "kg/hr");
+    splitter.run();
+
+    Calculator calc = new Calculator("anti surge calc");
+    calc.addInputVariable(comp);
+    calc.setOutputVariable(splitter);
+    calc.runAntiSurgeCalc(UUID.randomUUID());
+
+    // Convert the resulting recycle mass back to a suction volume and check it is a
+    // physically sensible fraction of the surge flow rather than a discharge volume
+    // mistaken for a suction volume (which inflates it by the compression ratio).
+    double recycleAtSuction = splitter.getSplitStream(1).getFlowRate("kg/hr") / suctionDensity;
+    double surgeFlow = comp.getSurgeFlowRate();
+    // Calculator caps the recycle setpoint at 2 x the surge flow.
+    assertTrue(recycleAtSuction <= 2.0 * surgeFlow + 1.0e-6, "recycle referenced to suction (" + recycleAtSuction
+        + " m3/hr) must respect the surge-flow cap (" + surgeFlow + " m3/hr)");
+    assertTrue(recycleAtSuction >= 0.0, "recycle must be non-negative, got " + recycleAtSuction);
+  }
 }

--- a/src/test/java/neqsim/process/processmodel/LowFlowBypassConvergenceTest.java
+++ b/src/test/java/neqsim/process/processmodel/LowFlowBypassConvergenceTest.java
@@ -1,0 +1,205 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.manifold.Manifold;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Regression tests for how a low-flow bypass is reported by the convergence and mass-balance diagnostics.
+ *
+ * <p>
+ * A section that has been deliberately switched off with a low-flow threshold must not make the flowsheet look broken:
+ * the owning {@link ProcessSystem} must still report {@code solved()}, a {@link ProcessModel} must still report all
+ * areas solved, and the bypassed units must not appear as mass-balance failures (their percentage balance degenerates
+ * towards 100 % on a near-zero leg).
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class LowFlowBypassConvergenceTest {
+
+  /**
+   * Builds a small gas fluid used by all tests in this class.
+   *
+   * @return a three-component SRK gas system
+   */
+  private static SystemInterface gas() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.03);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  /**
+   * A unit whose inlet flow is below its low-flow threshold auto-bypasses, and the owning process must still report
+   * solved instead of NOT SOLVED.
+   */
+  @Test
+  public void bypassedUnitDoesNotBlockProcessSolved() {
+    Stream feed = new Stream("feed", gas());
+    feed.setFlowRate(0.5, "kg/hr");
+    feed.setTemperature(25.0, "C");
+    feed.setPressure(10.0, "bara");
+
+    Heater heater = new Heater("dead leg heater", feed);
+    heater.setOutTemperature(40.0, "C");
+    heater.setMinimumFlow(50.0);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(heater);
+    process.run();
+
+    assertFalse(heater.isActive(), "heater inlet is below its low-flow threshold and must bypass");
+    assertTrue(process.getBypassedUnits().contains("dead leg heater"));
+    assertTrue(process.solved(), "a bypassed unit must not make the process report NOT SOLVED");
+  }
+
+  /**
+   * A recycle whose loop flow collapses below its minimum flow is deactivated. It must report zero residuals and
+   * {@code solved() == true}, otherwise the process keeps iterating on a dead leg and reports NOT SOLVED forever.
+   */
+  @Test
+  public void recycleDeactivatedOnLowFlowReportsSolved() {
+    Stream tearFeed = new Stream("tear feed", gas());
+    tearFeed.setFlowRate(1.0e-6, "kg/hr");
+    tearFeed.setTemperature(25.0, "C");
+    tearFeed.setPressure(10.0, "bara");
+
+    Stream tear = new Stream("tear", gas().clone());
+    tear.setFlowRate(1.0e-6, "kg/hr");
+    tear.setTemperature(25.0, "C");
+    tear.setPressure(10.0, "bara");
+
+    Recycle recycle = new Recycle("dead recycle");
+    recycle.addStream(tearFeed);
+    recycle.setOutletStream(tear);
+    recycle.setMinimumFlow(1.0e-3);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(tearFeed);
+    process.add(tear);
+    process.add(recycle);
+    process.run();
+
+    assertFalse(recycle.isActive(), "recycle flow is below minimumFlow and must deactivate");
+    assertTrue(recycle.solved(), "a deactivated recycle has nothing left to converge");
+    assertTrue(process.solved(), "a deactivated recycle must not make the process report NOT SOLVED");
+  }
+
+  /**
+   * The multi-area convergence report must mark a bypassed area as solved and name the bypassed units instead of
+   * listing them as unsolved.
+   */
+  @Test
+  public void convergenceReportSeparatesBypassedFromUnsolved() {
+    Stream feed = new Stream("feed", gas());
+    feed.setFlowRate(0.5, "kg/hr");
+    feed.setTemperature(25.0, "C");
+    feed.setPressure(10.0, "bara");
+
+    Heater heater = new Heater("dead leg heater", feed);
+    heater.setOutTemperature(40.0, "C");
+    heater.setMinimumFlow(50.0);
+
+    ProcessSystem area = new ProcessSystem();
+    area.add(feed);
+    area.add(heater);
+
+    ProcessModel model = new ProcessModel();
+    model.add("stagnant area", area);
+    model.runUntilConverged(5, 1.0e-3);
+
+    String summary = model.getConvergenceSummary();
+    assertTrue(summary.contains("All process areas solved: YES"),
+        "bypassed units must not flip the all-areas-solved flag:\n" + summary);
+    assertTrue(summary.contains("bypassed on low flow"), "summary must explain the bypass:\n" + summary);
+    assertFalse(summary.contains("Unsolved units:"), "a bypassed unit is not an unsolved unit:\n" + summary);
+
+    String json = model.getConvergenceReportJson();
+    assertTrue(json.contains("bypassedUnits"), "JSON report must expose the bypassed units: " + json);
+    assertTrue(json.contains("dead leg heater"), "JSON report must name the bypassed unit: " + json);
+  }
+
+  /**
+   * A bypassed unit never executed, so it must not be reported as a mass-balance failure even though its percentage
+   * balance on a near-zero leg degenerates towards 100 %.
+   */
+  @Test
+  public void bypassedUnitIsNotAMassBalanceFailure() {
+    Stream feed = new Stream("feed", gas());
+    feed.setFlowRate(0.5, "kg/hr");
+    feed.setTemperature(25.0, "C");
+    feed.setPressure(10.0, "bara");
+
+    Heater heater = new Heater("dead leg heater", feed);
+    heater.setOutTemperature(40.0, "C");
+    heater.setMinimumFlow(50.0);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(heater);
+    process.run();
+
+    Map<String, ProcessSystem.MassBalanceResult> all = process.checkMassBalance("kg/hr");
+    assertTrue(all.get("dead leg heater").isBypassed(), "the result must be tagged as bypassed");
+
+    Map<String, ProcessSystem.MassBalanceResult> failed = process.getFailedMassBalance("kg/hr", 0.1);
+    assertFalse(failed.containsKey("dead leg heater"),
+        "a bypassed unit must not be reported as a mass-balance failure");
+  }
+
+  /**
+   * A manifold must report its mass balance across its own boundary (split outlets minus mixer inlets), with the
+   * correct sign.
+   *
+   * <p>
+   * The balance used to be derived from the internal mixer's residual, which double-counted that residual and flipped
+   * the sign whenever the internal mixer was not itself perfectly balanced - exactly the mid-iteration state a
+   * mass-balance check exists to detect.
+   * </p>
+   */
+  @Test
+  public void manifoldMassBalanceIsTakenAcrossItsOwnBoundary() {
+    Stream feedA = new Stream("feed A", gas());
+    feedA.setFlowRate(1000.0, "kg/hr");
+    feedA.setTemperature(25.0, "C");
+    feedA.setPressure(10.0, "bara");
+    feedA.run();
+
+    Stream feedB = new Stream("feed B", gas().clone());
+    feedB.setFlowRate(500.0, "kg/hr");
+    feedB.setTemperature(25.0, "C");
+    feedB.setPressure(10.0, "bara");
+    feedB.run();
+
+    Manifold manifold = new Manifold("test manifold");
+    manifold.addStream(feedA);
+    manifold.addStream(feedB);
+    manifold.setSplitFactors(new double[] { 0.6, 0.4 });
+    manifold.run();
+
+    assertEquals(0.0, manifold.getMassBalance("kg/hr"), 1.0e-6,
+        "a converged manifold must balance exactly across its own boundary");
+
+    // Perturb one inlet WITHOUT re-running the manifold. This reproduces the
+    // mid-iteration state in which an upstream area has already refreshed a feed: the
+    // manifold now passes 100 kg/hr more than it receives, so the balance must be
+    // +100 kg/hr, not -100 kg/hr.
+    feedB.setFlowRate(400.0, "kg/hr");
+    feedB.run();
+    assertEquals(100.0, manifold.getMassBalance("kg/hr"), 1.0e-3,
+        "manifold balance must be outlets - inlets, with the correct sign");
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
@@ -1,0 +1,88 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Regression tests for physical-time ownership during repeated algebraic transient evaluations.
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public class ProcessSystemTransientAlgebraicTimeTest extends neqsim.NeqSimTest {
+  /**
+   * Semi-implicit evaluation may refine an algebraic recycle twice, but both evaluations belong to
+   * one physical timestep.
+   */
+  @Test
+  public void semiImplicitRecycleAdvancesClockOnce() {
+    Recycle recycle = createRecycle(100.0);
+    ProcessSystem process = new ProcessSystem("semi-implicit recycle");
+    process.add(recycle.getStream(0));
+    process.add(recycle);
+    process.setIntegrationMethod(ProcessSystem.IntegrationMethod.SEMI_IMPLICIT);
+
+    UUID id = UUID.randomUUID();
+    process.runTransient(2.0, id);
+
+    assertEquals(2, recycle.getIterations());
+    assertEquals(2.0, process.getTime(), 0.0);
+    assertEquals(2.0, recycle.getTime(), 0.0);
+    assertEquals(id, recycle.getCalculationIdentifier());
+  }
+
+  /**
+   * Reusing one identifier refines the same step without moving time; a new identifier owns a new
+   * timestep.
+   */
+  @Test
+  public void calculationIdentifierOwnsAlgebraicClockAdvance() {
+    Recycle recycle = createRecycle(100.0);
+    UUID firstStep = UUID.randomUUID();
+
+    recycle.runTransient(2.0, firstStep);
+    recycle.runTransient(2.0, firstStep);
+    recycle.runTransient(2.0, UUID.randomUUID());
+
+    assertEquals(3, recycle.getIterations());
+    assertEquals(4.0, recycle.getTime(), 0.0);
+  }
+
+  /**
+   * A normal low-flow return must still record completion so a second algebraic evaluation cannot
+   * advance the local clock again.
+   */
+  @Test
+  public void lowFlowRecycleRecordsTimestepIdentifier() {
+    Recycle recycle = createRecycle(0.0);
+    ProcessSystem process = new ProcessSystem("low-flow recycle");
+    process.add(recycle.getStream(0));
+    process.add(recycle);
+    process.setIntegrationMethod(ProcessSystem.IntegrationMethod.SEMI_IMPLICIT);
+
+    UUID id = UUID.randomUUID();
+    process.runTransient(2.0, id);
+
+    assertEquals(2, recycle.getIterations());
+    assertEquals(2.0, recycle.getTime(), 0.0);
+    assertEquals(id, recycle.getCalculationIdentifier());
+  }
+
+  private static Recycle createRecycle(double flowRate) {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 1.0);
+
+    Stream inlet = new Stream("recycle inlet", fluid);
+    inlet.setFlowRate(flowRate, "kg/hr");
+    Stream outlet = inlet.clone("recycle outlet");
+
+    Recycle recycle = new Recycle("recycle");
+    recycle.addStream(inlet);
+    recycle.setOutletStream(outlet);
+    return recycle;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
@@ -79,7 +79,9 @@ public class ProcessSystemTransientAlgebraicTimeTest extends neqsim.NeqSimTest {
   public void nullIdentifierPreservesPreviousIdentifierAndClockBehavior() {
     Recycle recycle = createRecycle(0.0);
     UUID previousIdentifier = UUID.randomUUID();
+    UUID previousOutletIdentifier = UUID.randomUUID();
     recycle.setCalculationIdentifier(previousIdentifier);
+    recycle.getOutletStream().setCalculationIdentifier(previousOutletIdentifier);
 
     recycle.runTransient(2.0, null);
     recycle.runTransient(2.0, null);
@@ -87,6 +89,8 @@ public class ProcessSystemTransientAlgebraicTimeTest extends neqsim.NeqSimTest {
     assertEquals(2, recycle.getIterations());
     assertEquals(4.0, recycle.getTime(), 0.0);
     assertEquals(previousIdentifier, recycle.getCalculationIdentifier());
+    assertEquals(previousOutletIdentifier,
+        recycle.getOutletStream().getCalculationIdentifier());
   }
 
   private static Recycle createRecycle(double flowRate) {

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
@@ -72,8 +72,8 @@ public class ProcessSystemTransientAlgebraicTimeTest extends neqsim.NeqSimTest {
   }
 
   /**
-   * Null identifiers retain the legacy behavior: every evaluation advances time and no identifier
-   * is written by the shared transient boundary.
+   * Null identifiers retain the legacy behavior: every evaluation advances time and no identifier is written by the
+   * shared transient boundary.
    */
   @Test
   public void nullIdentifierPreservesPreviousIdentifierAndClockBehavior() {

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
@@ -89,8 +89,7 @@ public class ProcessSystemTransientAlgebraicTimeTest extends neqsim.NeqSimTest {
     assertEquals(2, recycle.getIterations());
     assertEquals(4.0, recycle.getTime(), 0.0);
     assertEquals(previousIdentifier, recycle.getCalculationIdentifier());
-    assertEquals(previousOutletIdentifier,
-        recycle.getOutletStream().getCalculationIdentifier());
+    assertEquals(previousOutletIdentifier, recycle.getOutletStream().getCalculationIdentifier());
   }
 
   private static Recycle createRecycle(double flowRate) {

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
@@ -71,6 +71,24 @@ public class ProcessSystemTransientAlgebraicTimeTest extends neqsim.NeqSimTest {
     assertEquals(id, recycle.getCalculationIdentifier());
   }
 
+  /**
+   * Null identifiers retain the legacy behavior: every evaluation advances time and no identifier
+   * is written by the shared transient boundary.
+   */
+  @Test
+  public void nullIdentifierPreservesPreviousIdentifierAndClockBehavior() {
+    Recycle recycle = createRecycle(0.0);
+    UUID previousIdentifier = UUID.randomUUID();
+    recycle.setCalculationIdentifier(previousIdentifier);
+
+    recycle.runTransient(2.0, null);
+    recycle.runTransient(2.0, null);
+
+    assertEquals(2, recycle.getIterations());
+    assertEquals(4.0, recycle.getTime(), 0.0);
+    assertEquals(previousIdentifier, recycle.getCalculationIdentifier());
+  }
+
   private static Recycle createRecycle(double flowRate) {
     SystemSrkEos fluid = new SystemSrkEos(298.15, 10.0);
     fluid.addComponent("methane", 1.0);

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientAlgebraicTimeTest.java
@@ -15,8 +15,8 @@ import neqsim.thermo.system.SystemSrkEos;
  */
 public class ProcessSystemTransientAlgebraicTimeTest extends neqsim.NeqSimTest {
   /**
-   * Semi-implicit evaluation may refine an algebraic recycle twice, but both evaluations belong to
-   * one physical timestep.
+   * Semi-implicit evaluation may refine an algebraic recycle twice, but both evaluations belong to one physical
+   * timestep.
    */
   @Test
   public void semiImplicitRecycleAdvancesClockOnce() {
@@ -36,8 +36,7 @@ public class ProcessSystemTransientAlgebraicTimeTest extends neqsim.NeqSimTest {
   }
 
   /**
-   * Reusing one identifier refines the same step without moving time; a new identifier owns a new
-   * timestep.
+   * Reusing one identifier refines the same step without moving time; a new identifier owns a new timestep.
    */
   @Test
   public void calculationIdentifierOwnsAlgebraicClockAdvance() {
@@ -53,8 +52,8 @@ public class ProcessSystemTransientAlgebraicTimeTest extends neqsim.NeqSimTest {
   }
 
   /**
-   * A normal low-flow return must still record completion so a second algebraic evaluation cannot
-   * advance the local clock again.
+   * A normal low-flow return must still record completion so a second algebraic evaluation cannot advance the local
+   * clock again.
    */
   @Test
   public void lowFlowRecycleRecordsTimestepIdentifier() {


### PR DESCRIPTION
## Root cause

`ProcessSystem.runTransient(dt, id)` deliberately reuses one calculation identifier for both semi-implicit equipment passes. Steady-state equipment inherits `SimulationInterface.runTransient(dt, id)`, which called `run(id)` and `increaseTime(dt)` on every solver evaluation. A `Recycle` therefore performed two useful algebraic evaluations but advanced its local physical clock twice.

Normal low-flow recycle returns also leave the recycle calculation identifier unset, so the repeated evaluation could not be associated with the timestep.

## Scope and engineering behavior

- Keep every algebraic `run(id)` evaluation. Semi-implicit recycles still receive two fixed-point updates.
- After a successful return, record each non-null calculation identifier at the shared default transient boundary.
- Advance an algebraic equipment clock only on the first evaluation of a non-null timestep identifier.
- Preserve prior behavior for `null` identifiers: every evaluation advances time, the shared boundary does not write an identifier, and equipment-specific mutations inside `run(null)` are retained. Low-flow recycles preserve their existing recycle and outlet identifiers.
- Preserve the unsupported-difference-equation behavior for equipment with `calculateSteadyState == false`.
- Do not change thermodynamic calculations, recycle tolerances, acceleration, execution ordering, convergence decisions, or public API signatures.

## Baseline and result

Deterministic work/state metrics for a 2 s semi-implicit step:

| Metric | Before fix | After fix |
|---|---:|---:|
| Process clock | 2 s | 2 s |
| Recycle evaluations / iterations | 2 | 2 |
| Recycle clock | 4 s | 2 s |
| Low-flow recycle calculation identifier | unset | timestep UUID |

Direct repeated evaluation with identifiers `A, A, B` and `dt = 2 s` remains three algebraic runs, while physical time changes from 6 s to 4 s.

## Regression coverage

`ProcessSystemTransientAlgebraicTimeTest` covers:

1. a realistic methane recycle in semi-implicit `ProcessSystem` execution;
2. repeated evaluation with the same identifier followed by a nearby new timestep;
3. the zero-flow limiting path that returns early from `Recycle.run(id)`;
4. null-ID compatibility, including repeated clock advancement and preservation of existing recycle and outlet identifiers on the low-flow return.

The assertions use stable evaluation counts, calculation identifiers, and simulation clocks; there are no wall-clock timing assertions.

## Validation

Final PR head: `57304218e79b9849fc7a0605a1649e24d4fe1868`. The validated merge candidate combined this head with master `ad05f29129f357efdf993aca31018183afd87f26`.

Passed:

- Java 21 fast tests on Ubuntu and Windows;
- all three Java 21 Ubuntu slow-test shards;
- Java 8 tests on Ubuntu and Windows;
- Javadocs with Java 21 on Ubuntu;
- Spotless and pre-commit;
- skills/agents lint and agent-skill cross-reference validation;
- documentation search coverage;
- CodeQL;
- PaperLab.

An earlier Java 8 Ubuntu attempt failed in unrelated `DynamicCompressorNotebookRegressionTest` and `MultiStreamHeatExchangerTest` cases; both passed on unchanged retry. Integration with #2710 then exposed the focused null-ID low-flow regression on Windows. The low-flow identifier writes were guarded, recycle and outlet coverage was added, and the complete integrated matrix passed without weakening any assertion or tolerance.

The PR was merged externally on July 31, 2026 as `875d1458f9346af78a68405ba4524370c2cbb66e`; this automation did not merge it or enable auto-merge.

## Review disposition

Copilot's explicit null-identifier compatibility concern was valid, fixed, tested, replied to, and resolved. Post-push reviews produced no new review threads.

Suppressed suggestions were technically dispositioned:

- the default-boundary Javadoc now accurately states that mutations performed inside `run(null)` are retained;
- an explicit mixing rule is unnecessary for the single-component methane fixture and would not strengthen this clock/identifier regression;
- #2710's anti-surge and bypass files appeared only because the branch was synchronized with master; they are not part of this PR's net change.

## Compatibility and risk

Public Java and Python call shapes are unchanged. Thermodynamic state, recycle mass/energy calculations, phase behavior, and the number/order of algebraic evaluations are unchanged. The observable correction is limited to algebraic equipment local time and completion identity when one timestep is evaluated repeatedly.

This does not define iterative transient recycle convergence, parallel recycle execution, incomplete-step rollback, or transactional state restoration. Those remain separate dependency-ordered work.

## Documentation impact

Updated:

- `SimulationInterface.runTransient(dt, id)` Javadoc;
- the low-flow recycle identifier Javadoc;
- the numerical-infrastructure section and test matrix in the dynamic-simulation enhancements guide;
- the repository dynamic-simulation skill.

## Related work

Builds on the timestep calculation-identity semantics established by #2700 without overlapping the AgentRCA benchmark in #2707 or the TwoFluidPipe conservation work in #2705.
