### PR TITLE
fix: converge anti-surge recycles and stop reporting low-flow bypass as failure

### DIFF
--- a/src/main/java/neqsim/process/equipment/manifold/Manifold.java
+++ b/src/main/java/neqsim/process/equipment/manifold/Manifold.java
@@ -754,11 +754,25 @@ public class Manifold extends ProcessEquipmentBaseClass
   // MASS BALANCE AND JSON
   // ============================================================================
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * The balance is taken directly across the manifold's own boundary: the sum of the streams fed into the internal
+   * mixer against the sum of the split outlets. Deriving the inlet total from the internal mixer's residual instead
+   * ({@code mixer.getMassBalance() + mixerOutlet}) double-counted that residual and reported the manifold imbalance
+   * with the opposite sign whenever the internal mixer was not itself perfectly balanced - which is exactly the
+   * mid-iteration state a mass-balance check is used to detect.
+   * </p>
+   */
   @Override
   public double getMassBalance(String unit) {
-    double inletFlow = localmixer.getMassBalance(unit)
-        + localmixer.getOutletStream().getThermoSystem().getFlowRate(unit);
+    double inletFlow = 0.0;
+    for (StreamInterface inlet : localmixer.getInletStreams()) {
+      if (inlet != null && inlet.getThermoSystem() != null) {
+        inletFlow += inlet.getThermoSystem().getFlowRate(unit);
+      }
+    }
     double outletFlow = 0.0;
     for (int i = 0; i < getNumberOfOutputStreams(); i++) {
       outletFlow += getSplitStream(i).getThermoSystem().getFlowRate(unit);

--- a/src/main/java/neqsim/process/equipment/util/Calculator.java
+++ b/src/main/java/neqsim/process/equipment/util/Calculator.java
@@ -129,7 +129,22 @@ public class Calculator extends ProcessEquipmentBaseClass {
 
     double inletFlow = compressor.getInletStream().getFlowRate("m3/hr");
     double surgeFlow = compressor.getSurgeFlowRate();
-    double currentRecycle = antiSurgeSplitter.getSplitStream(1).getFlowRate("m3/hr");
+
+    // The surge curve, and therefore every quantity in the control law below, is
+    // referenced to compressor SUCTION volumetric flow. The anti-surge splitter sits
+    // on the DISCHARGE side, so reading its recycle leg directly in m3/hr mixes two
+    // different sets of conditions: the same mass is a much smaller volume after
+    // compression. Adding a suction-sized step to a discharge-sized volume - and then
+    // writing the result back as a discharge-referenced setpoint - overshoots the
+    // intended recycle by roughly the volume ratio across the machine, which is one
+    // of the drivers of anti-surge hunting on turned-down trains. Convert through
+    // mass instead, using the suction density implied by the compressor inlet stream
+    // itself so the conversion is exactly consistent with inletFlow.
+    double inletMassFlow = compressor.getInletStream().getFlowRate("kg/hr");
+    double suctionDensity = inletFlow > 0.0 ? inletMassFlow / inletFlow : Double.NaN;
+    boolean useMassSetpoint = Double.isFinite(suctionDensity) && suctionDensity > 0.0;
+    double currentRecycle = useMassSetpoint ? antiSurgeSplitter.getSplitStream(1).getFlowRate("kg/hr") / suctionDensity
+        : antiSurgeSplitter.getSplitStream(1).getFlowRate("m3/hr");
 
     // Guard against a surge flow extrapolated far beyond the surge curve data.
     // The surge curve interpolates flow from the operating head; when the head
@@ -174,15 +189,26 @@ public class Calculator extends ProcessEquipmentBaseClass {
       return;
     }
 
-    // If we are comfortably above the surge line, close the recycle valve to
-    // (effectively) zero. This short-circuit avoids the proportional step
-    // overshooting when the compressor is operating far from surge.
-    if (inletFlow > 1.2 * surgeFlow) {
+    // If the compressor is comfortably above the surge line WITHOUT the help of the
+    // recycle, close the recycle valve to (effectively) zero. This short-circuit
+    // avoids the proportional step overshooting when the machine is operating far
+    // from surge on fresh feed alone.
+    //
+    // The recycle is fed back into the compressor suction, so it is already part of
+    // getInletStream(). Testing the raw inlet flow against the surge line therefore
+    // asks "is the machine safe *because of* the recycle?" and then removes exactly
+    // the flow that made it safe. On a deeply turned-down train that produces a
+    // limit cycle: the recycle slams shut, the next pass finds the machine below
+    // surge and re-opens it to tens of tonnes per hour, and the recycle tear stream
+    // swings between ~0 and its full value forever (Recycle.flowBalanceCheck then
+    // reports a 100 % flow error and the area never reports solved). Subtracting the
+    // current recycle first makes the test physically correct - only fresh feed can
+    // justify closing the recycle - and lets the proportional step below close the
+    // valve gradually when the recycle is what is holding the machine up.
+    double freshFeed = inletFlow - Math.max(currentRecycle, 0.0);
+    if (freshFeed > 1.2 * surgeFlow) {
       double minRecycle = Math.max(inletFlow / 1.0e6, 1.0e-6);
-      antiSurgeSplitter.setFlowRates(new double[] { -1, minRecycle }, "m3/hr");
-      antiSurgeSplitter.getSplitStream(1).setFlowRate(minRecycle, "m3/hr");
-      antiSurgeSplitter.getSplitStream(1).run();
-      antiSurgeSplitter.setCalculationIdentifier(id);
+      applyRecycleSetpoint(antiSurgeSplitter, minRecycle, suctionDensity, useMassSetpoint, id);
       return;
     }
 
@@ -207,10 +233,7 @@ public class Calculator extends ProcessEquipmentBaseClass {
       flowAntiSurge = maxRecycle;
     }
 
-    antiSurgeSplitter.setFlowRates(new double[] { -1, flowAntiSurge }, "m3/hr");
-    antiSurgeSplitter.getSplitStream(1).setFlowRate(flowAntiSurge, "m3/hr");
-    antiSurgeSplitter.getSplitStream(1).run();
-    antiSurgeSplitter.setCalculationIdentifier(id);
+    applyRecycleSetpoint(antiSurgeSplitter, flowAntiSurge, suctionDensity, useMassSetpoint, id);
 
     // Diagnostic: if (inletFlow + flowAntiSurge) is still well below surge
     // after this update, the loop is likely stuck (e.g. recycle path is not
@@ -222,6 +245,42 @@ public class Calculator extends ProcessEquipmentBaseClass {
           + " m3/hr, surge=" + surgeFlow + " m3/hr). Check that the recycle stream feeds back into the compressor "
           + "inlet and that the outer recycle iteration cap is sufficient.");
     }
+  }
+
+  /**
+   * Writes a suction-referenced anti-surge recycle setpoint onto the splitter.
+   *
+   * <p>
+   * The control law works in compressor-suction volumetric flow because that is what the surge curve is referenced to,
+   * but the splitter sits on the discharge side. The setpoint is therefore converted to a mass flow through the suction
+   * density and written in kg/hr, which is condition independent. When the suction density is not usable (no inlet flow
+   * yet) the legacy volumetric setpoint is written instead so a cold-started flowsheet still gets a value.
+   * </p>
+   *
+   * <p>
+   * The recycle leg is written directly instead of by re-running the splitter, and that is deliberate.
+   * {@link Splitter#calcSplitFactors()} scales a requested outlet flow down so it can never exceed the splitter's
+   * present inlet - but on a deeply turned-down train that inlet is itself produced by the recycle. Forcing the
+   * setpoint to fit inside the present inlet therefore removes the only mechanism by which the circulation can grow,
+   * and the loop can then only gain the (tiny) fresh feed on each pass. Letting the setpoint lead makes the fixed-point
+   * iteration converge to {@code inletFlow == surgeFlow}; the lead - and with it the transient splitter mass-balance
+   * offset seen mid-iteration - vanishes once the loop has converged.
+   * </p>
+   *
+   * @param antiSurgeSplitter the anti-surge recycle splitter to configure
+   * @param recycleAtSuction desired recycle flow expressed as compressor-suction volumetric flow in m3/hr
+   * @param suctionDensity compressor suction density in kg/m3
+   * @param useMassSetpoint true when {@code suctionDensity} is finite and positive
+   * @param id current calculation identifier
+   */
+  private void applyRecycleSetpoint(Splitter antiSurgeSplitter, double recycleAtSuction, double suctionDensity,
+      boolean useMassSetpoint, UUID id) {
+    double setpoint = useMassSetpoint ? recycleAtSuction * suctionDensity : recycleAtSuction;
+    String setpointUnit = useMassSetpoint ? "kg/hr" : "m3/hr";
+    antiSurgeSplitter.setFlowRates(new double[] { -1, setpoint }, setpointUnit);
+    antiSurgeSplitter.getSplitStream(1).setFlowRate(setpoint, setpointUnit);
+    antiSurgeSplitter.getSplitStream(1).run();
+    antiSurgeSplitter.setCalculationIdentifier(id);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/util/Recycle.java
+++ b/src/main/java/neqsim/process/equipment/util/Recycle.java
@@ -344,6 +344,34 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
     }
   }
 
+  /**
+   * Deactivates this recycle because its loop flow has collapsed below the configured {@link #getMinimumFlow()} cutoff.
+   *
+   * <p>
+   * A recycle below the cutoff carries no physically meaningful inventory, so it is marked inactive and its four
+   * residuals are reported as exactly zero. The previous-iteration snapshot is refreshed at the same time; without that
+   * refresh the flow, temperature and pressure balance checks would keep comparing the (negligible) current stream
+   * against a stale pre-collapse snapshot, so the recycle would report {@code solved() == false} forever. That in turn
+   * makes the owning {@link neqsim.process.processmodel.ProcessSystem} report NOT SOLVED and spend its whole iteration
+   * budget on a dead leg.
+   * </p>
+   *
+   * @param inletSystem clone of the (negligible) inlet thermodynamic system to publish on the outlet
+   * @param id current calculation identifier
+   */
+  private void deactivateOnLowFlow(SystemInterface inletSystem, UUID id) {
+    isActive(false);
+    mixedStream.setThermoSystem(inletSystem);
+    setErrorCompositon(0.0);
+    setErrorFlow(0.0);
+    setErrorTemperature(0.0);
+    setErrorPressure(0.0);
+    lastIterationStream = mixedStream.clone();
+    outletStream.setThermoSystem(mixedStream.getThermoSystem());
+    outletStream.setCalculationIdentifier(id);
+    setCalculationIdentifier(id);
+  }
+
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
@@ -355,14 +383,7 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
     double enthalpy = 0.0;
     SystemInterface thermoSystem2 = streams.get(0).getThermoSystem().clone();
     if (numberOfInputStreams == 1 && thermoSystem2.getFlowRate("kg/hr") < minimumFlow) {
-      isActive(false);
-      mixedStream.setThermoSystem(thermoSystem2);
-      setErrorCompositon(0.0);
-      setErrorFlow(flowBalanceCheck());
-      setErrorTemperature(temperatureBalanceCheck());
-      setErrorPressure(pressureBalanceCheck());
-      outletStream.setThermoSystem(mixedStream.getThermoSystem());
-      outletStream.setCalculationIdentifier(id);
+      deactivateOnLowFlow(thermoSystem2, id);
       return;
     }
     mixedStream.setThermoSystem(thermoSystem2);
@@ -375,14 +396,7 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
       mixStream();
 
       if (mixedStream.getFlowRate("kg/hr") < minimumFlow) {
-        isActive(false);
-        mixedStream.setThermoSystem(thermoSystem2);
-        setErrorCompositon(0.0);
-        setErrorFlow(flowBalanceCheck());
-        setErrorTemperature(temperatureBalanceCheck());
-        setErrorPressure(pressureBalanceCheck());
-        outletStream.setThermoSystem(mixedStream.getThermoSystem());
-        outletStream.setCalculationIdentifier(id);
+        deactivateOnLowFlow(thermoSystem2, id);
         return;
       }
 
@@ -885,11 +899,24 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
     this.priority = priority;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * A recycle that has been deactivated by the low-flow cutoff (see {@link #setMinimumFlow(double)}) is reported as
+   * solved: it carries no meaningful inventory, so there is nothing left to converge and holding the flowsheet open for
+   * it would only burn the iteration budget on a dead leg.
+   * </p>
+   */
   @Override
   public boolean solved() {
-    if (getOutletStream().getFlowRate("kg/hr") < 1e-20 && lastIterationStream.getFlowRate("kg/hr") < 1e-20
-        && iterations > 1) {
+    if (!isActive() && iterations > 0) {
+      return true;
+    }
+
+    double zeroFlowFloor = Math.max(minimumFlow, 1e-20);
+    if (getOutletStream().getFlowRate("kg/hr") < zeroFlowFloor
+        && lastIterationStream.getFlowRate("kg/hr") < zeroFlowFloor && iterations > 1) {
       return true;
     }
 

--- a/src/main/java/neqsim/process/equipment/util/RecycleController.java
+++ b/src/main/java/neqsim/process/equipment/util/RecycleController.java
@@ -121,6 +121,9 @@ public class RecycleController implements java.io.Serializable {
    */
   public boolean solvedCurrentPriorityLevel() {
     for (Recycle recyc : recycleArray) {
+      if (isDeactivated(recyc)) {
+        continue;
+      }
       if (recyc.getPriority() == currentPriorityLevel) {
         if (!recyc.solved()) {
           return false;
@@ -128,6 +131,22 @@ public class RecycleController implements java.io.Serializable {
       }
     }
     return true;
+  }
+
+  /**
+   * Reports whether a recycle is currently bypassed and must therefore be excluded from the convergence gates.
+   *
+   * <p>
+   * A recycle is bypassed either because the user locked it inactive or because its loop flow fell below the configured
+   * low-flow cutoff. Such a recycle never executes its balance equations, so requiring it to converge would keep the
+   * whole flowsheet iterating on a dead leg.
+   * </p>
+   *
+   * @param recycle recycle to test
+   * @return true when the recycle is locked inactive or has been auto-deactivated on low flow
+   */
+  private static boolean isDeactivated(Recycle recycle) {
+    return recycle.isLockedInactive() || !recycle.isActive();
   }
 
   /**
@@ -170,6 +189,9 @@ public class RecycleController implements java.io.Serializable {
    */
   public boolean solvedAll() {
     for (Recycle recyc : recycleArray) {
+      if (isDeactivated(recyc)) {
+        continue;
+      }
       if (logger.isDebugEnabled()) {
         logger.debug(recyc.getName() + " solved " + recyc.solved());
       }
@@ -191,6 +213,9 @@ public class RecycleController implements java.io.Serializable {
   public double getMaxNormalizedError() {
     double maxNorm = 0.0;
     for (Recycle recyc : recycleArray) {
+      if (isDeactivated(recyc)) {
+        continue;
+      }
       maxNorm = Math.max(maxNorm, normalizedError(recyc.getErrorFlow(), recyc.getFlowTolerance()));
       maxNorm = Math.max(maxNorm, normalizedError(recyc.getErrorComposition(), recyc.getCompositionTolerance()));
       maxNorm = Math.max(maxNorm, normalizedError(recyc.getErrorTemperature(), recyc.getTemperatureTolerance()));

--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -2649,7 +2649,11 @@ public class ProcessModel implements Runnable, Serializable {
     sb.append("\nProcess Status:\n");
     for (Map.Entry<String, ProcessSystem> entry : processes.entrySet()) {
       boolean processSolved = entry.getValue().solved();
-      sb.append(String.format(Locale.US, "  %-30s: %s\n", entry.getKey(), processSolved ? "SOLVED" : "NOT SOLVED"));
+      List<String> bypassedUnits = getBypassedUnitNames(entry.getValue());
+      String bypassNote = bypassedUnits.isEmpty() ? ""
+          : String.format(Locale.US, " (%d unit(s) bypassed on low flow)", bypassedUnits.size());
+      sb.append(String.format(Locale.US, "  %-30s: %s%s\n", entry.getKey(), processSolved ? "SOLVED" : "NOT SOLVED",
+          bypassNote));
       if (!processSolved) {
         List<String> unsolvedUnits = getUnsolvedUnitNames(entry.getValue());
         if (!unsolvedUnits.isEmpty()) {
@@ -2842,6 +2846,11 @@ public class ProcessModel implements Runnable, Serializable {
         }
       }
       area.add("unsolvedUnits", unsolved);
+      JsonArray bypassed = new JsonArray();
+      for (String unitName : getBypassedUnitNames(entry.getValue())) {
+        bypassed.add(unitName);
+      }
+      area.add("bypassedUnits", bypassed);
       areas.add(area);
     }
     root.add("areas", areas);
@@ -2892,13 +2901,38 @@ public class ProcessModel implements Runnable, Serializable {
   /**
    * Gets names of unit operations that currently report unsolved status.
    *
+   * <p>
+   * Bypassed units (locked inactive, or auto-bypassed because their inlet flow fell below the configured low-flow
+   * threshold) are excluded: they never execute, so their {@code solved()} flag carries no information. Use
+   * {@link #getBypassedUnitNames(ProcessSystem)} to list those separately.
+   * </p>
+   *
    * @param process process system to inspect
    * @return list of unsolved unit names in process execution order
    */
   private List<String> getUnsolvedUnitNames(ProcessSystem process) {
     List<String> names = new ArrayList<>();
     for (ProcessEquipmentInterface unit : process.getUnitOperations()) {
+      if (unit.isLockedInactive() || !unit.isActive()) {
+        continue;
+      }
       if (!unit.solved()) {
+        names.add(unit.getName());
+      }
+    }
+    return names;
+  }
+
+  /**
+   * Gets names of unit operations that are currently bypassed in the given process area.
+   *
+   * @param process process system to inspect
+   * @return list of bypassed unit names in process execution order
+   */
+  private List<String> getBypassedUnitNames(ProcessSystem process) {
+    List<String> names = new ArrayList<>();
+    for (ProcessEquipmentInterface unit : process.getUnitOperations()) {
+      if (unit.isLockedInactive() || !unit.isActive()) {
         names.add(unit.getName());
       }
     }

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4385,16 +4385,29 @@ public class ProcessSystem extends SimulationBaseClass {
     return currentDt;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * Units that are bypassed - either locked inactive by the user or auto-bypassed because their inlet flow fell below
+   * the configured low-flow threshold (see {@link #setSectionLowFlowThreshold(double)}) - are excluded from the check.
+   * A bypassed unit never executes, so its {@code solved()} flag carries no information and would otherwise make an
+   * otherwise fully converged area report NOT SOLVED.
+   * </p>
+   */
   @Override
   public boolean solved() {
     /* */
     if (recycleController.solvedAll()) {
       for (int i = 0; i < unitOperations.size(); i++) {
-        if (logger.isDebugEnabled()) {
-          logger.debug("unit " + unitOperations.get(i).getName() + " solved: " + unitOperations.get(i).solved());
+        ProcessEquipmentInterface unit = unitOperations.get(i);
+        if (unit.isLockedInactive() || !unit.isActive()) {
+          continue;
         }
-        if (!unitOperations.get(i).solved()) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("unit " + unit.getName() + " solved: " + unit.solved());
+        }
+        if (!unit.solved()) {
           return false;
         }
       }
@@ -5522,20 +5535,27 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Check mass balance of all unit operations in the process system.
    *
+   * <p>
+   * Bypassed units (locked inactive or auto-bypassed on low flow) are still reported, but are tagged via
+   * {@link MassBalanceResult#isBypassed()} so callers can exclude them: a unit that never executed has no meaningful
+   * inlet/outlet balance, and on a near-zero dead leg the percentage error degenerates towards 100 %.
+   * </p>
+   *
    * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
    * @return a map with unit operation name as key and mass balance result as value
    */
   public Map<String, MassBalanceResult> checkMassBalance(String unit) {
     Map<String, MassBalanceResult> massBalanceResults = new HashMap<>();
     for (ProcessEquipmentInterface unitOp : unitOperations) {
+      boolean bypassed = unitOp.isLockedInactive() || !unitOp.isActive();
       try {
         double massBalanceError = unitOp.getMassBalance(unit);
         double inletFlow = calculateInletFlow(unitOp, unit);
         double percentError = calculatePercentError(massBalanceError, inletFlow);
-        massBalanceResults.put(unitOp.getName(), new MassBalanceResult(massBalanceError, percentError, unit));
+        massBalanceResults.put(unitOp.getName(), new MassBalanceResult(massBalanceError, percentError, unit, bypassed));
       } catch (Exception e) {
         logger.warn("Failed to calculate mass balance for unit: " + unitOp.getName(), e);
-        massBalanceResults.put(unitOp.getName(), new MassBalanceResult(Double.NaN, Double.NaN, unit));
+        massBalanceResults.put(unitOp.getName(), new MassBalanceResult(Double.NaN, Double.NaN, unit, bypassed));
       }
     }
     return massBalanceResults;
@@ -5553,6 +5573,13 @@ public class ProcessSystem extends SimulationBaseClass {
   /**
    * Get unit operations that failed mass balance check based on percentage error threshold.
    *
+   * <p>
+   * Bypassed units and units whose inlet flow is below their own low-flow cutoff
+   * ({@link neqsim.process.equipment.ProcessEquipmentInterface#getMinimumFlow()}) are skipped: a leg that has been
+   * declared negligible cannot produce a meaningful percentage balance, and a near-zero stream trivially reports ~100 %
+   * error.
+   * </p>
+   *
    * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
    * @param percentThreshold percentage error threshold (default: 0.1%)
    * @return a map with failed unit operation names and their mass balance results
@@ -5563,8 +5590,15 @@ public class ProcessSystem extends SimulationBaseClass {
 
     // Convert minimum flow threshold to the requested unit
     double minimumFlowInUnit = minimumFlowForMassBalanceError;
+    // Conversion of a unit's own low-flow cutoff (always kg/hr) into the requested
+    // reporting unit. NaN means "no meaningful conversion", so the per-unit cutoff
+    // filter is skipped for that reporting unit.
+    double kgPerHourToUnit = Double.NaN;
     if (unit.equals("kg/hr")) {
       minimumFlowInUnit *= 3600.0; // kg/sec to kg/hr
+      kgPerHourToUnit = 1.0;
+    } else if (unit.equals("kg/sec")) {
+      kgPerHourToUnit = 1.0 / 3600.0;
     } else if (unit.equals("mole/sec")) {
       // For mole/sec, we use the kg/sec threshold as approximation
       // since we don't have molecular weight info here
@@ -5573,12 +5607,25 @@ public class ProcessSystem extends SimulationBaseClass {
 
     for (Map.Entry<String, MassBalanceResult> entry : allResults.entrySet()) {
       MassBalanceResult result = entry.getValue();
+      if (result.isBypassed()) {
+        continue;
+      }
       ProcessEquipmentInterface unitOp = getUnit(entry.getKey());
       double inletFlow = calculateInletFlow(unitOp, unit);
 
       // Skip units with insignificant inlet flow
       if (Math.abs(inletFlow) < minimumFlowInUnit) {
         continue;
+      }
+
+      // Skip units whose inlet flow is below their own configured low-flow cutoff: the
+      // leg has explicitly been declared negligible, so a percentage balance on it is
+      // numerical noise rather than a mass-conservation defect.
+      if (unitOp != null && !Double.isNaN(kgPerHourToUnit)) {
+        double unitCutoff = unitOp.getMinimumFlow() * kgPerHourToUnit;
+        if (unitCutoff > 0.0 && Math.abs(inletFlow) < unitCutoff) {
+          continue;
+        }
       }
 
       if (Double.isNaN(result.getPercentError()) || Math.abs(result.getPercentError()) > percentThreshold) {
@@ -5869,6 +5916,7 @@ public class ProcessSystem extends SimulationBaseClass {
     private final double absoluteError;
     private final double percentError;
     private final String unit;
+    private final boolean bypassed;
 
     /**
      * Constructor for MassBalanceResult.
@@ -5878,9 +5926,23 @@ public class ProcessSystem extends SimulationBaseClass {
      * @param unit unit of measurement
      */
     public MassBalanceResult(double absoluteError, double percentError, String unit) {
+      this(absoluteError, percentError, unit, false);
+    }
+
+    /**
+     * Constructor for MassBalanceResult.
+     *
+     * @param absoluteError absolute mass balance error (outlet - inlet)
+     * @param percentError percentage error
+     * @param unit unit of measurement
+     * @param bypassed true when the unit was bypassed (locked inactive or auto-bypassed on low flow) and the balance
+     * therefore carries no information
+     */
+    public MassBalanceResult(double absoluteError, double percentError, String unit, boolean bypassed) {
       this.absoluteError = absoluteError;
       this.percentError = percentError;
       this.unit = unit;
+      this.bypassed = bypassed;
     }
 
     /**
@@ -5910,9 +5972,23 @@ public class ProcessSystem extends SimulationBaseClass {
       return unit;
     }
 
+    /**
+     * Reports whether the unit was bypassed when the balance was taken.
+     *
+     * <p>
+     * A bypassed unit never executed, so its inlet/outlet balance is not a mass-conservation result. Callers should
+     * exclude these from pass/fail reporting; {@link ProcessSystem#getFailedMassBalance(String, double)} already does.
+     * </p>
+     *
+     * @return true when the unit was locked inactive or auto-bypassed on low flow
+     */
+    public boolean isBypassed() {
+      return bypassed;
+    }
+
     @Override
     public String toString() {
-      return String.format("%.6f %s (%.4f%%)", absoluteError, unit, percentError);
+      return String.format("%.6f %s (%.4f%%)%s", absoluteError, unit, percentError, bypassed ? " [bypassed]" : "");
     }
   }
 

--- a/src/test/java/neqsim/process/equipment/util/CalculatorAntiSurgeTest.java
+++ b/src/test/java/neqsim/process/equipment/util/CalculatorAntiSurgeTest.java
@@ -174,4 +174,83 @@ public class CalculatorAntiSurgeTest {
         "recycle must remain finite when surge data is missing, got " + recycleAfter);
     assertEquals(recycleBefore, recycleAfter, 1e-9, "recycle should be unchanged when calculator skips");
   }
+
+  /**
+   * The recycle must not be slammed shut when it is the recycle itself that holds the compressor above the surge line.
+   *
+   * <p>
+   * The recycle is fed back into the compressor suction, so {@code getInletStream()} already contains it. Testing the
+   * raw inlet flow against {@code 1.2 * surgeFlow} therefore asked "is the machine safe because of the recycle?" and
+   * then removed exactly the flow that made it safe, producing a limit cycle in which the recycle tear stream swung
+   * between ~0 and its full value on every pass and the owning process never reported solved.
+   * </p>
+   */
+  @Test
+  public void testRecycleNotSlammedShutWhenItIsHoldingTheMachineAboveSurge() {
+    Compressor comp = buildCompressorWithSurgeCurve(200000.0);
+    double inletFlow = comp.getInletStream().getFlowRate("m3/hr");
+    double inletMassFlow = comp.getInletStream().getFlowRate("kg/hr");
+    double surgeFlow = comp.getSurgeFlowRate();
+    assertTrue(inletFlow > 1.2 * surgeFlow,
+        "test precondition: raw inlet " + inletFlow + " must exceed 1.2 * surge " + surgeFlow);
+
+    // Configure a recycle large enough that the fresh feed alone (inlet - recycle)
+    // sits below the 1.2 * surge shortcut threshold.
+    double suctionDensity = inletMassFlow / inletFlow;
+    double targetRecycleMass = (inletFlow - 1.1 * surgeFlow) * suctionDensity;
+    Splitter splitter = new Splitter("anti surge splitter", comp.getOutletStream(), 2);
+    splitter.setFlowRates(new double[] { -1.0, targetRecycleMass }, "kg/hr");
+    splitter.run();
+
+    double recycleMassBefore = splitter.getSplitStream(1).getFlowRate("kg/hr");
+    assertTrue(inletFlow - recycleMassBefore / suctionDensity < 1.2 * surgeFlow,
+        "test precondition: fresh feed must be below the shortcut threshold");
+
+    Calculator calc = new Calculator("anti surge calc");
+    calc.addInputVariable(comp);
+    calc.setOutputVariable(splitter);
+    calc.runAntiSurgeCalc(UUID.randomUUID());
+
+    double recycleMassAfter = splitter.getSplitStream(1).getFlowRate("kg/hr");
+    assertTrue(recycleMassAfter > 0.01 * recycleMassBefore, "recycle must be closed gradually, not slammed to zero: "
+        + recycleMassBefore + " -> " + recycleMassAfter + " kg/hr");
+  }
+
+  /**
+   * The recycle setpoint must be expressed at compressor-suction conditions.
+   *
+   * <p>
+   * The surge curve, and therefore the whole control law, is referenced to suction volumetric flow, but the anti-surge
+   * splitter sits on the discharge side where the same mass occupies a much smaller volume. Writing a suction-sized
+   * volumetric number straight onto the discharge-side splitter overshot the intended recycle by roughly the volume
+   * ratio across the machine. The setpoint is therefore converted through the suction density and written as a mass
+   * flow.
+   * </p>
+   */
+  @Test
+  public void testRecycleSetpointIsReferencedToSuctionConditions() {
+    Compressor comp = buildCompressorWithSurgeCurve(20000.0);
+    double inletVolFlow = comp.getInletStream().getFlowRate("m3/hr");
+    double inletMassFlow = comp.getInletStream().getFlowRate("kg/hr");
+    double suctionDensity = inletMassFlow / inletVolFlow;
+
+    Splitter splitter = new Splitter("anti surge splitter", comp.getOutletStream(), 2);
+    splitter.setFlowRates(new double[] { -1.0, 1.0 }, "kg/hr");
+    splitter.run();
+
+    Calculator calc = new Calculator("anti surge calc");
+    calc.addInputVariable(comp);
+    calc.setOutputVariable(splitter);
+    calc.runAntiSurgeCalc(UUID.randomUUID());
+
+    // Convert the resulting recycle mass back to a suction volume and check it is a
+    // physically sensible fraction of the surge flow rather than a discharge volume
+    // mistaken for a suction volume (which inflates it by the compression ratio).
+    double recycleAtSuction = splitter.getSplitStream(1).getFlowRate("kg/hr") / suctionDensity;
+    double surgeFlow = comp.getSurgeFlowRate();
+    // Calculator caps the recycle setpoint at 2 x the surge flow.
+    assertTrue(recycleAtSuction <= 2.0 * surgeFlow + 1.0e-6, "recycle referenced to suction (" + recycleAtSuction
+        + " m3/hr) must respect the surge-flow cap (" + surgeFlow + " m3/hr)");
+    assertTrue(recycleAtSuction >= 0.0, "recycle must be non-negative, got " + recycleAtSuction);
+  }
 }

--- a/src/test/java/neqsim/process/processmodel/LowFlowBypassConvergenceTest.java
+++ b/src/test/java/neqsim/process/processmodel/LowFlowBypassConvergenceTest.java
@@ -1,0 +1,205 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.manifold.Manifold;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Regression tests for how a low-flow bypass is reported by the convergence and mass-balance diagnostics.
+ *
+ * <p>
+ * A section that has been deliberately switched off with a low-flow threshold must not make the flowsheet look broken:
+ * the owning {@link ProcessSystem} must still report {@code solved()}, a {@link ProcessModel} must still report all
+ * areas solved, and the bypassed units must not appear as mass-balance failures (their percentage balance degenerates
+ * towards 100 % on a near-zero leg).
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class LowFlowBypassConvergenceTest {
+
+  /**
+   * Builds a small gas fluid used by all tests in this class.
+   *
+   * @return a three-component SRK gas system
+   */
+  private static SystemInterface gas() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.03);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  /**
+   * A unit whose inlet flow is below its low-flow threshold auto-bypasses, and the owning process must still report
+   * solved instead of NOT SOLVED.
+   */
+  @Test
+  public void bypassedUnitDoesNotBlockProcessSolved() {
+    Stream feed = new Stream("feed", gas());
+    feed.setFlowRate(0.5, "kg/hr");
+    feed.setTemperature(25.0, "C");
+    feed.setPressure(10.0, "bara");
+
+    Heater heater = new Heater("dead leg heater", feed);
+    heater.setOutTemperature(40.0, "C");
+    heater.setMinimumFlow(50.0);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(heater);
+    process.run();
+
+    assertFalse(heater.isActive(), "heater inlet is below its low-flow threshold and must bypass");
+    assertTrue(process.getBypassedUnits().contains("dead leg heater"));
+    assertTrue(process.solved(), "a bypassed unit must not make the process report NOT SOLVED");
+  }
+
+  /**
+   * A recycle whose loop flow collapses below its minimum flow is deactivated. It must report zero residuals and
+   * {@code solved() == true}, otherwise the process keeps iterating on a dead leg and reports NOT SOLVED forever.
+   */
+  @Test
+  public void recycleDeactivatedOnLowFlowReportsSolved() {
+    Stream tearFeed = new Stream("tear feed", gas());
+    tearFeed.setFlowRate(1.0e-6, "kg/hr");
+    tearFeed.setTemperature(25.0, "C");
+    tearFeed.setPressure(10.0, "bara");
+
+    Stream tear = new Stream("tear", gas().clone());
+    tear.setFlowRate(1.0e-6, "kg/hr");
+    tear.setTemperature(25.0, "C");
+    tear.setPressure(10.0, "bara");
+
+    Recycle recycle = new Recycle("dead recycle");
+    recycle.addStream(tearFeed);
+    recycle.setOutletStream(tear);
+    recycle.setMinimumFlow(1.0e-3);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(tearFeed);
+    process.add(tear);
+    process.add(recycle);
+    process.run();
+
+    assertFalse(recycle.isActive(), "recycle flow is below minimumFlow and must deactivate");
+    assertTrue(recycle.solved(), "a deactivated recycle has nothing left to converge");
+    assertTrue(process.solved(), "a deactivated recycle must not make the process report NOT SOLVED");
+  }
+
+  /**
+   * The multi-area convergence report must mark a bypassed area as solved and name the bypassed units instead of
+   * listing them as unsolved.
+   */
+  @Test
+  public void convergenceReportSeparatesBypassedFromUnsolved() {
+    Stream feed = new Stream("feed", gas());
+    feed.setFlowRate(0.5, "kg/hr");
+    feed.setTemperature(25.0, "C");
+    feed.setPressure(10.0, "bara");
+
+    Heater heater = new Heater("dead leg heater", feed);
+    heater.setOutTemperature(40.0, "C");
+    heater.setMinimumFlow(50.0);
+
+    ProcessSystem area = new ProcessSystem();
+    area.add(feed);
+    area.add(heater);
+
+    ProcessModel model = new ProcessModel();
+    model.add("stagnant area", area);
+    model.runUntilConverged(5, 1.0e-3);
+
+    String summary = model.getConvergenceSummary();
+    assertTrue(summary.contains("All process areas solved: YES"),
+        "bypassed units must not flip the all-areas-solved flag:\n" + summary);
+    assertTrue(summary.contains("bypassed on low flow"), "summary must explain the bypass:\n" + summary);
+    assertFalse(summary.contains("Unsolved units:"), "a bypassed unit is not an unsolved unit:\n" + summary);
+
+    String json = model.getConvergenceReportJson();
+    assertTrue(json.contains("bypassedUnits"), "JSON report must expose the bypassed units: " + json);
+    assertTrue(json.contains("dead leg heater"), "JSON report must name the bypassed unit: " + json);
+  }
+
+  /**
+   * A bypassed unit never executed, so it must not be reported as a mass-balance failure even though its percentage
+   * balance on a near-zero leg degenerates towards 100 %.
+   */
+  @Test
+  public void bypassedUnitIsNotAMassBalanceFailure() {
+    Stream feed = new Stream("feed", gas());
+    feed.setFlowRate(0.5, "kg/hr");
+    feed.setTemperature(25.0, "C");
+    feed.setPressure(10.0, "bara");
+
+    Heater heater = new Heater("dead leg heater", feed);
+    heater.setOutTemperature(40.0, "C");
+    heater.setMinimumFlow(50.0);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(heater);
+    process.run();
+
+    Map<String, ProcessSystem.MassBalanceResult> all = process.checkMassBalance("kg/hr");
+    assertTrue(all.get("dead leg heater").isBypassed(), "the result must be tagged as bypassed");
+
+    Map<String, ProcessSystem.MassBalanceResult> failed = process.getFailedMassBalance("kg/hr", 0.1);
+    assertFalse(failed.containsKey("dead leg heater"),
+        "a bypassed unit must not be reported as a mass-balance failure");
+  }
+
+  /**
+   * A manifold must report its mass balance across its own boundary (split outlets minus mixer inlets), with the
+   * correct sign.
+   *
+   * <p>
+   * The balance used to be derived from the internal mixer's residual, which double-counted that residual and flipped
+   * the sign whenever the internal mixer was not itself perfectly balanced - exactly the mid-iteration state a
+   * mass-balance check exists to detect.
+   * </p>
+   */
+  @Test
+  public void manifoldMassBalanceIsTakenAcrossItsOwnBoundary() {
+    Stream feedA = new Stream("feed A", gas());
+    feedA.setFlowRate(1000.0, "kg/hr");
+    feedA.setTemperature(25.0, "C");
+    feedA.setPressure(10.0, "bara");
+    feedA.run();
+
+    Stream feedB = new Stream("feed B", gas().clone());
+    feedB.setFlowRate(500.0, "kg/hr");
+    feedB.setTemperature(25.0, "C");
+    feedB.setPressure(10.0, "bara");
+    feedB.run();
+
+    Manifold manifold = new Manifold("test manifold");
+    manifold.addStream(feedA);
+    manifold.addStream(feedB);
+    manifold.setSplitFactors(new double[] { 0.6, 0.4 });
+    manifold.run();
+
+    assertEquals(0.0, manifold.getMassBalance("kg/hr"), 1.0e-6,
+        "a converged manifold must balance exactly across its own boundary");
+
+    // Perturb one inlet WITHOUT re-running the manifold. This reproduces the
+    // mid-iteration state in which an upstream area has already refreshed a feed: the
+    // manifold now passes 100 kg/hr more than it receives, so the balance must be
+    // +100 kg/hr, not -100 kg/hr.
+    feedB.setFlowRate(400.0, "kg/hr");
+    feedB.run();
+    assertEquals(100.0, manifold.getMassBalance("kg/hr"), 1.0e-3,
+        "manifold balance must be outlets - inlets, with the correct sign");
+  }
+}


### PR DESCRIPTION
## Summary

A large multi-area `ProcessModel` could report `Converged: YES` together with
`All process areas solved: NO` and a long list of mass-balance failures, even
though the plant boundary streams had converged well inside tolerance. Digging
into a 459-unit, 18-area production-plant model showed three independent defects
behind that misleading picture. This PR fixes all three and makes the low-flow
bypass explicit in the convergence report.

## 1. Anti-surge recycle limit cycle (`Calculator.runAntiSurgeCalc`)

Two bugs made a turned-down anti-surge loop oscillate instead of converge:

* **The "well above surge" shortcut used the raw compressor inlet flow.** The
  recycle is fed back into the compressor suction, so it is already part of
  `getInletStream()`. Testing `inletFlow > 1.2 * surgeFlow` therefore asked
  *"is the machine safe **because of** the recycle?"* and then closed exactly the
  flow that made it safe. The next pass found the machine below surge and
  re-opened the recycle to full value — a stable limit cycle in which the recycle
  tear stream swung between ~0 and tens of tonnes per hour forever. The test is
  now made on the fresh feed, `inletFlow - currentRecycle`, so only fresh feed can
  justify closing the recycle; when the recycle is what holds the machine up, the
  proportional step closes it gradually.
* **The setpoint mixed suction and discharge conditions.** The surge curve — and
  therefore the whole control law — is referenced to compressor *suction*
  volumetric flow, but the anti-surge splitter sits on the *discharge* side where
  the same mass occupies a much smaller volume. Reading `currentRecycle` in m3/hr
  at the splitter and writing the result back as a discharge-referenced setpoint
  overshot the intended recycle by roughly the volume ratio across the machine.
  The setpoint is now converted through the suction density and written in kg/hr,
  which is condition independent.

The recycle leg is still written directly rather than by re-running the splitter.
That is deliberate and now documented: `Splitter.calcSplitFactors()` scales a
requested outlet flow down so it can never exceed the splitter's present inlet,
but on a deeply turned-down train that inlet is itself produced by the recycle.
Forcing the setpoint to fit inside the present inlet removes the only mechanism
by which the circulation can grow, and the loop can then only gain the (tiny)
fresh feed per pass. The transient splitter offset vanishes once the loop has
converged.

## 2. A low-flow bypass was reported as a convergence failure

`setSectionLowFlowThreshold()` / `setMinimumFlow()` deliberately switch off a
stagnant section, but the solver still demanded that those units converge:

* `Recycle` deactivated on low flow zeroed only the *composition* residual. The
  flow, temperature and pressure balance checks kept comparing the collapsed
  stream against a stale pre-collapse snapshot, because `lastIterationStream` was
  never refreshed in that branch — so the recycle reported `solved() == false`
  forever. It now zeroes all four residuals and refreshes the snapshot.
* `Recycle.solved()` returns `true` when the recycle is inactive, and its
  zero-flow shortcut uses the configured `minimumFlow` instead of a hard-coded
  `1e-20`.
* `RecycleController.solvedAll()`, `solvedCurrentPriorityLevel()` and
  `getMaxNormalizedError()` skip deactivated recycles — mirroring the bypass guard
  that `ProcessSystem.runSequential()` already applied to adjusters.
* `ProcessSystem.solved()` skips locked/inactive units.

## 3. Reporting: bypass is now visible instead of silent

* `ProcessModel.getConvergenceSummary()` annotates each area, e.g.
  `HT injection process A : SOLVED (4 unit(s) bypassed on low flow)`, and no
  longer lists bypassed units under `Unsolved units:`.
* `getConvergenceReportJson()` gains a `bypassedUnits` array per area.
* `ProcessSystem.MassBalanceResult.isBypassed()` tags results from units that
  never executed, and `getFailedMassBalance()` skips them plus any unit whose
  inlet flow is below its own `getMinimumFlow()`. A near-zero dead leg trivially
  reports ~100 % imbalance and was drowning out real residuals.

## 4. `Manifold.getMassBalance()` sign fix

The balance derived the inlet total from the internal mixer's residual
(`mixer.getMassBalance() + mixerOutlet`), which double-counts that residual and
reports the manifold imbalance with the **opposite sign** whenever the internal
mixer is not itself perfectly balanced — exactly the mid-iteration state a
mass-balance check exists to detect. It is now taken directly across the
manifold's own boundary: split outlets minus mixer inlets.

## Verification

On the 459-unit, 18-area reference plant model (unchanged flowsheet, same feed
year and case), before → after:

| | before | after |
|---|---|---|
| Outer iterations | 5 | 4 |
| `All process areas solved` | **NO** | **YES** |
| Areas reporting NOT SOLVED | 2 (both separation trains) | 0 |
| Units failing mass balance (>0.1 %) | 13 | **1** |
| Worst mass-balance offender | 55 346 kg/hr (137 %) | 1 302 kg/hr (0.95 %) |

The two ±55 t/hr and ±36 t/hr equal-and-opposite pairs (anti-surge splitter vs.
the mixer closing its recycle) are gone — they were the signature of the limit
cycle, not of lost mass. Boundary-stream errors are unchanged and remain well
inside tolerance (flow 1.4e-04 vs. 1e-03). The single remaining offender is an
inter-area snapshot lag on a manifold whose inlets are refreshed by areas that
run later in the sweep.

## Tests

* New `neqsim.process.processmodel.LowFlowBypassConvergenceTest` (5 tests):
  bypassed unit does not block `ProcessSystem.solved()`; a recycle deactivated on
  low flow reports solved; the convergence report separates bypassed from
  unsolved (text + JSON); a bypassed unit is not a mass-balance failure; the
  manifold balance is taken across its own boundary with the correct sign.
* `CalculatorAntiSurgeTest` gains two regression tests: the recycle is not
  slammed shut when it is the recycle holding the machine above surge, and the
  setpoint is referenced to suction conditions.
* Existing `SafeSplineSurgeCurveTest` (including the deep-turndown full-recycle
  case), `AntiSurgeCalculatorTest`, `RecycleControllerTest`, `ManifoldTest` and
  `SplitterTest` pass unchanged.

Java 8 compatible; `spotless:apply` run on all touched files.

> Note: `MLA_bug_test.runProcessTEG` fails on this branch with
> `expected: <203.08> but was: <202.67072595963504>` — verified to fail with the
> identical value on an untouched worktree of the base commit, so it is
> pre-existing and unrelated to this change.
