### PR TITLE
fix: reject invalid transient timesteps before mutation

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -26,6 +26,10 @@ historian tag mapping, and event schedule before running `runTransient`.
 ## Dynamic Simulation Architecture
 
 NeqSim dynamic simulation uses the `runTransient(double dt)` method on `ProcessSystem`.
+Pass a finite, positive timestep. Process and model entry points reject zero,
+negative, NaN, and infinite values before any area or equipment state changes.
+Adaptive stepping rejects invalid requests rather than clamping them.
+
 Each timestep:
 1. Flowsheet-wide settings are applied. Each setter unit receives exactly one
    transient call, applying its specification and advancing its own clock once.

--- a/docs/process/dynamic-simulation-enhancements.md
+++ b/docs/process/dynamic-simulation-enhancements.md
@@ -519,6 +519,12 @@ double actualDt = process.runTransientAdaptive(1.0, id);
 // actualDt may be smaller or larger than the requested 1.0
 ```
 
+Every `ProcessSystem` and `ProcessModel` transient entry point requires a
+finite, positive timestep. Zero, negative, NaN, and infinite values throw
+`IllegalArgumentException` before snapshots, setters, events, process areas,
+equipment, controllers, clocks, or identifiers can change. Adaptive stepping
+rejects invalid requested values instead of silently clamping them.
+
 The adaptive algorithm compares state changes between the full step and two
 half-steps, reducing or increasing $\Delta t$ based on the relative error.
 
@@ -614,7 +620,7 @@ process.setIntegrationMethod(IntegrationMethod.RUNGE_KUTTA_4);    // Higher-orde
 
 ## 6. Test Coverage
 
-The features in this guide are covered by seven focused test classes with 81
+The features in this guide are covered by eight focused test classes with 85
 total tests:
 
 | Test Class | Tests | Coverage |
@@ -626,11 +632,12 @@ total tests:
 | `ProcessSystemTransientSetterTest` | 3 | Single setter application, repeated-step clock advancement, and explicit, semi-implicit, and parallel execution |
 | `ProcessSystemTransientControllerTest` | 5 | Equipment execution, semi-implicit passes, attachment-only fallback, duplicate standalone registration, identity semantics, and repeated timesteps |
 | `ProcessSystemTransientAlgebraicTimeTest` | 4 | Repeated algebraic evaluation, semi-implicit recycle iteration, low-flow completion identifiers, null-ID compatibility, and one clock advance per timestep |
+| `ProcessSystemTransientTimestepValidationTest` | 4 | Finite-positive process, adaptive, and multi-area timestep preflight plus valid nearby steps |
 
 Run all tests:
 
 ```bash
-./mvnw test -Dtest=DynamicImprovementsTest,DynamicImprovementsPhase2Test,DynamicImprovementsPhase3Test,ProcessSystemParallelTransientTest,ProcessSystemTransientSetterTest,ProcessSystemTransientControllerTest,ProcessSystemTransientAlgebraicTimeTest
+./mvnw test -Dtest=DynamicImprovementsTest,DynamicImprovementsPhase2Test,DynamicImprovementsPhase3Test,ProcessSystemParallelTransientTest,ProcessSystemTransientSetterTest,ProcessSystemTransientControllerTest,ProcessSystemTransientAlgebraicTimeTest,ProcessSystemTransientTimestepValidationTest
 ```
 
 ---

--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -1393,10 +1393,12 @@ public class ProcessModel implements Runnable, Serializable {
    * single scheduler can coordinate events across all areas.
    * </p>
    *
-   * @param dt timestep size in seconds (must be {@code > 0})
+   * @param dt finite timestep size in seconds (must be {@code > 0})
    * @param id calculation UUID forwarded to each child {@code ProcessSystem.runTransient}
+   * @throws IllegalArgumentException if {@code dt} is not finite and greater than zero
    */
   public void runTransient(double dt, UUID id) {
+    ProcessSystem.validateTransientTimestep(dt);
     for (ProcessSystem area : processes.values()) {
       area.runTransient(dt, id);
     }

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4081,6 +4081,18 @@ public class ProcessSystem extends SimulationBaseClass {
    */
 
   /**
+   * Validates a requested transient timestep before any process state is changed.
+   *
+   * @param dt timestep in seconds
+   * @throws IllegalArgumentException if {@code dt} is not finite and greater than zero
+   */
+  static void validateTransientTimestep(double dt) {
+    if (!Double.isFinite(dt) || dt <= 0.0) {
+      throw new IllegalArgumentException("Transient timestep must be finite and greater than zero: " + dt);
+    }
+  }
+
+  /**
    * runTransient.
    */
   public void runTransient() {
@@ -4098,9 +4110,11 @@ public class ProcessSystem extends SimulationBaseClass {
    *
    * @param dt timestep in seconds
    * @param id calculation identifier shared by the timestep
+   * @throws IllegalArgumentException if {@code dt} is not finite and greater than zero
    */
   @Override
   public synchronized void runTransient(double dt, UUID id) {
+    validateTransientTimestep(dt);
     ensureInitialStateSnapshot();
     applyFlowsheetWideSettings();
 
@@ -4332,8 +4346,10 @@ public class ProcessSystem extends SimulationBaseClass {
    * @param dt the requested timestep in seconds
    * @param id calculation identifier
    * @return the actual timestep used (may differ from dt)
+   * @throws IllegalArgumentException if {@code dt} is not finite and greater than zero
    */
   public double runTransientAdaptive(double dt, UUID id) {
+    validateTransientTimestep(dt);
     if (!adaptiveTimestepEnabled) {
       runTransient(dt, id);
       return dt;

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientTimestepValidationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientTimestepValidationTest.java
@@ -1,0 +1,120 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression tests for finite-positive transient timestep validation. */
+public class ProcessSystemTransientTimestepValidationTest extends neqsim.NeqSimTest {
+  private static final double[] INVALID_TIMESTEPS =
+      new double[] {0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY};
+
+  /**
+   * Invalid direct process steps must fail before clocks, identifiers, or algebraic equipment state change.
+   */
+  @Test
+  public void processSystemRejectsInvalidTimestepsBeforeMutation() {
+    for (double invalidTimestep : INVALID_TIMESTEPS) {
+      Recycle recycle = createRecycle();
+      ProcessSystem process = createProcess("invalid process step", recycle);
+      UUID previousIdentifier = UUID.randomUUID();
+      recycle.setCalculationIdentifier(previousIdentifier);
+      double configuredTimestep = process.getTimeStep();
+
+      IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+          () -> process.runTransient(invalidTimestep, UUID.randomUUID()));
+
+      assertTrue(exception.getMessage().contains("finite and greater than zero"));
+      assertEquals(0.0, process.getTime(), 0.0);
+      assertEquals(configuredTimestep, process.getTimeStep(), 0.0);
+      assertEquals(0, recycle.getIterations());
+      assertEquals(0.0, recycle.getTime(), 0.0);
+      assertEquals(previousIdentifier, recycle.getCalculationIdentifier());
+    }
+  }
+
+  /**
+   * Adaptive stepping must reject invalid requests rather than silently clamping them to the minimum timestep.
+   */
+  @Test
+  public void adaptiveTransientRejectsInvalidTimestepsBeforeMutation() {
+    for (double invalidTimestep : INVALID_TIMESTEPS) {
+      Recycle recycle = createRecycle();
+      ProcessSystem process = createProcess("invalid adaptive step", recycle);
+      process.setAdaptiveTimestepEnabled(true);
+
+      assertThrows(IllegalArgumentException.class,
+          () -> process.runTransientAdaptive(invalidTimestep, UUID.randomUUID()));
+
+      assertEquals(0.0, process.getTime(), 0.0);
+      assertEquals(0, recycle.getIterations());
+      assertEquals(0.0, recycle.getTime(), 0.0);
+    }
+  }
+
+  /**
+   * Model-level validation must happen before the first area advances, preserving atomic preflight across areas.
+   */
+  @Test
+  public void processModelRejectsInvalidTimestepsBeforeAnyAreaAdvances() {
+    for (double invalidTimestep : INVALID_TIMESTEPS) {
+      Recycle firstRecycle = createRecycle();
+      Recycle secondRecycle = createRecycle();
+      ProcessSystem firstArea = createProcess("first area", firstRecycle);
+      ProcessSystem secondArea = createProcess("second area", secondRecycle);
+      ProcessModel model = new ProcessModel();
+      model.add("first", firstArea);
+      model.add("second", secondArea);
+
+      assertThrows(IllegalArgumentException.class,
+          () -> model.runTransient(invalidTimestep, UUID.randomUUID()));
+
+      assertEquals(0.0, firstArea.getTime(), 0.0);
+      assertEquals(0.0, secondArea.getTime(), 0.0);
+      assertEquals(0, firstRecycle.getIterations());
+      assertEquals(0, secondRecycle.getIterations());
+    }
+  }
+
+  /**
+   * Nearby valid steps retain normal process and equipment time evolution.
+   */
+  @Test
+  public void validTimestepsAdvanceProcessAndEquipmentState() {
+    Recycle recycle = createRecycle();
+    ProcessSystem process = createProcess("valid steps", recycle);
+
+    process.runTransient(0.25, UUID.randomUUID());
+    process.runTransient(0.50, UUID.randomUUID());
+
+    assertEquals(0.75, process.getTime(), 0.0);
+    assertEquals(0.75, recycle.getTime(), 0.0);
+    assertEquals(2, recycle.getIterations());
+  }
+
+  private static ProcessSystem createProcess(String name, Recycle recycle) {
+    ProcessSystem process = new ProcessSystem(name);
+    process.add(recycle.getStream(0));
+    process.add(recycle);
+    return process;
+  }
+
+  private static Recycle createRecycle() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 1.0);
+
+    Stream inlet = new Stream("recycle inlet", fluid);
+    inlet.setFlowRate(100.0, "kg/hr");
+    Stream outlet = inlet.clone("recycle outlet");
+
+    Recycle recycle = new Recycle("recycle");
+    recycle.addStream(inlet);
+    recycle.setOutletStream(outlet);
+    return recycle;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientTimestepValidationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientTimestepValidationTest.java
@@ -11,8 +11,8 @@ import neqsim.thermo.system.SystemSrkEos;
 
 /** Regression tests for finite-positive transient timestep validation. */
 public class ProcessSystemTransientTimestepValidationTest extends neqsim.NeqSimTest {
-  private static final double[] INVALID_TIMESTEPS = new double[] {0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY,
-      Double.NEGATIVE_INFINITY};
+  private static final double[] INVALID_TIMESTEPS = new double[] { 0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY,
+      Double.NEGATIVE_INFINITY };
 
   /**
    * Invalid direct process steps must fail before clocks, identifiers, or algebraic equipment state change.

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientTimestepValidationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientTimestepValidationTest.java
@@ -11,8 +11,8 @@ import neqsim.thermo.system.SystemSrkEos;
 
 /** Regression tests for finite-positive transient timestep validation. */
 public class ProcessSystemTransientTimestepValidationTest extends neqsim.NeqSimTest {
-  private static final double[] INVALID_TIMESTEPS =
-      new double[] {0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY};
+  private static final double[] INVALID_TIMESTEPS = new double[] {0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY,
+      Double.NEGATIVE_INFINITY};
 
   /**
    * Invalid direct process steps must fail before clocks, identifiers, or algebraic equipment state change.
@@ -71,8 +71,7 @@ public class ProcessSystemTransientTimestepValidationTest extends neqsim.NeqSimT
       model.add("first", firstArea);
       model.add("second", secondArea);
 
-      assertThrows(IllegalArgumentException.class,
-          () -> model.runTransient(invalidTimestep, UUID.randomUUID()));
+      assertThrows(IllegalArgumentException.class, () -> model.runTransient(invalidTimestep, UUID.randomUUID()));
 
       assertEquals(0.0, firstArea.getTime(), 0.0);
       assertEquals(0.0, secondArea.getTime(), 0.0);


### PR DESCRIPTION
## Root cause

`ProcessModel.runTransient(dt, id)` documented `dt > 0`, but neither the model nor process boundary validated it. `ProcessSystem.runTransient` applied snapshots/settings, ran setters, stored the timestep, and advanced the process clock before any check. Adaptive stepping also clamped negative or non-finite requests instead of rejecting them.

This allowed invalid numerical inputs to move physical time backwards, execute a zero-duration stateful step, or contaminate clocks and equipment state with NaN/infinity. A multi-area model had no atomic preflight before its first area ran.

## Scope and engineering behavior

- Add one package-private finite-positive timestep validator shared by `ProcessSystem` and `ProcessModel`.
- Validate at the first instruction of direct process stepping, adaptive stepping, and model stepping.
- Reject zero, negative, NaN, and positive/negative infinity with `IllegalArgumentException`.
- Leave configured timestep setters and direct equipment APIs unchanged; validation belongs to process/model execution boundaries.
- Preserve every finite positive timestep, public signature, integration method, execution order, convergence rule, thermodynamic calculation, and identifier contract.

## Baseline and result

Deterministic master control flow, captured by the regression:

| Case | Before | After |
|---|---|---|
| `ProcessSystem.runTransient(-1, id)` | process clock moves backward and equipment executes | exception before mutation |
| `runTransient(0, id)` | complete zero-duration step pipeline executes | exception before mutation |
| adaptive negative request | silently clamps to minimum timestep | exception before mutation |
| invalid `ProcessModel` step | child areas are entered in insertion order | model-level exception before first area |

Nearby valid steps of 0.25 s and 0.50 s still advance both process and recycle clocks to exactly 0.75 s with two algebraic executions.

## Regression coverage

`ProcessSystemTransientTimestepValidationTest` contains four focused tests:

1. all five invalid values at the direct process boundary, asserting clocks, configured timestep, recycle iterations, and calculation identity remain unchanged;
2. the adaptive boundary, proving invalid requests are not clamped or executed;
3. a two-area `ProcessModel` with stateful recycles, proving atomic preflight before the first area;
4. repeated nearby valid steps, proving unchanged time evolution.

Assertions use deterministic state/work metrics; there are no wall-clock checks.

## Validation

Branch: `automation/transient-timestep-validation`
Base: master `875d1458f9346af78a68405ba4524370c2cbb66e`

GitHub CI is starting. No local test pass is claimed.

## Compatibility and risk

Public Java/Python call shapes are unchanged. This is an intentional fail-fast correction only for inputs that cannot represent a forward physical timestep. Valid model states, thermodynamic accuracy, mass/energy balances, phase behavior, controllers, recycles, serialization, cloning, and determinism are unaffected.

Direct calls to individual equipment `runTransient(dt, id)` retain their existing behavior; the bounded contract here covers `ProcessSystem`, adaptive process stepping, and `ProcessModel`.

## Documentation impact

Updated:

- `ProcessSystem` and `ProcessModel` Javadocs;
- the dynamic-simulation enhancements guide and its test matrix;
- the repository dynamic-simulation skill.

## Next dependency-ordered work

Define explicit per-timestep recycle convergence/status semantics, then address incomplete-step rollback and transactional state restoration.
