### PR TITLE
fix(tpflash): reject non-conservative aqueous endpoints

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -195,10 +195,10 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │                                                                                 │
 │  IF ordinary flash and water feed ≥ 0.01:                                       │
 │     → Refine a missing aqueous phase, or an existing two-phase aqueous           │
-│       endpoint only when max |Δ ln(fᵢ)| ≥ 1e-8                                  │
+│       endpoint when max |Δ ln(fᵢ)| ≥ 1e-8 or max |Δzᵢ| ≥ 1e-8                   │
 │     → Evaluate a cloned TPmultiflash candidate                                  │
-│     → Accept any two-phase candidate with lower Gibbs energy,                   │
-│       bounded/normalized phase fractions, and distinct phase compositions       │
+│     → Accept a lower-Gibbs physical candidate, or replace a non-conservative     │
+│       reference only with a balanced, equilibrated physical candidate            │
 │                                                                                 │
 │  IF ordinary, neutral, exactly-two-phase result contains an aqueous phase:       │
 │     → Evaluate gas-like and liquid-like roots of the non-aqueous cubic phase     │
@@ -222,7 +222,8 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | `maxNumberOfIterations` | 50 | Maximum iterations per convergence loop |
 | Convergence tolerance | 1e-10 | Deviation threshold for K-value convergence |
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
-| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; existing two-phase aqueous endpoints additionally require `max abs(Delta ln(f_i)) >= 1e-8` before refinement |
+| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; existing two-phase aqueous endpoints additionally require `max abs(Delta ln(f_i)) >= 1e-8` or `max abs(Delta z_i) >= 1e-8` before refinement |
+| Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
 
 ### 1.1 Problem Formulation
@@ -1659,8 +1660,10 @@ Commercial process simulators do not publish all implementation details, but pub
 - Explicit multiphase hydrocarbon flashes now retry a local lower-temperature seed before accepting an ambiguous single-phase endpoint, and keep the retry only if it gives a lower-Gibbs multiphase result.
 - A cheap post-flash K-envelope gate skips that rescue for clearly single-phase hydrocarbon endpoints, preserving ordinary `setMultiPhaseCheck(true)` speed.
 - Water-rich ordinary endpoints are not accepted from an aqueous phase label alone. An existing two-phase aqueous
-  endpoint is sent to multiphase refinement only when `max abs(Delta ln(f_i)) >= 1e-8`, and the candidate still must
-  lower Gibbs energy and pass phase-quality checks.
+  endpoint is sent to multiphase refinement when `max abs(Delta ln(f_i)) >= 1e-8` or its phase-recombined component
+  balance has `max abs(Delta z_i) >= 1e-8`. A feasible candidate normally must lower Gibbs energy; when the reference
+  is non-conservative and its Gibbs energy is therefore not comparable, the candidate must instead independently pass
+  phase-fraction, composition-normalization, material-balance, fugacity, and distinct-composition checks.
 - Ordinary neutral aqueous splits now compare both cubic roots of the non-aqueous phase at the converged composition. An alternate root is retained only when it lowers Gibbs energy and already satisfies `max abs(Delta ln(f_i)) < 1e-8`; no extra TPflash or multiphase stability calculation is run.
 - Enhanced stability checks are gated to polar, associating, electrolyte, sour, or explicitly requested multiphase systems, limiting unnecessary hydrocarbon phase-map artifacts.
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -47,6 +47,8 @@ public class TPflash extends Flash {
   private static final double LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN = 150.0;
   /** Minimum water feed fraction for ordinary water-rich endpoint refinement. */
   private static final double WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT = 0.01;
+  /** Maximum accepted component material-balance residual for water-rich endpoint refinement. */
+  private static final double WATER_RICH_MATERIAL_BALANCE_TOLERANCE = 1.0e-8;
   /** Maximum accepted log-fugacity residual when selecting an alternate cubic root. */
   private static final double PHASE_ROOT_EQUILIBRIUM_TOLERANCE = 1.0e-8;
   /** Cubic phase roots evaluated by the post-convergence aqueous root check. */
@@ -877,10 +879,13 @@ public class TPflash extends Flash {
    * The ordinary flash searches only the cubic gas/oil roots and can therefore leave a substantial water fraction
    * dissolved in a hydrocarbon-labelled phase even when a lower-Gibbs aqueous split exists. An existing aqueous phase
    * label is not by itself proof of equilibrium: phase typing can identify a water-rich phase after the ordinary
-   * gas/oil iteration has stopped. Such an endpoint is refined only when its component fugacity residual exceeds
-   * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE}. The one-mol-percent feed guard keeps trace-water process flashes on the
-   * existing fast path. A cloned multiphase candidate replaces the ordinary state only through the same strict
-   * phase-fraction, distinct-composition, and Gibbs-energy checks used by the liquid-liquid rescue.
+   * gas/oil iteration has stopped. Such an endpoint is refined when its component fugacity residual exceeds
+   * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE} or its component material balance exceeds
+   * {@link #WATER_RICH_MATERIAL_BALANCE_TOLERANCE}. The one-mol-percent feed guard keeps trace-water process flashes on
+   * the existing fast path. A cloned multiphase candidate normally replaces the ordinary state only when it lowers
+   * Gibbs energy. If the reference state is non-conservative, Gibbs energies are not comparable; a candidate may then
+   * replace it only after passing strict phase-fraction, composition-normalization, material-balance, fugacity, and
+   * distinct-composition checks.
    * </p>
    */
   private void rescueWaterRichEndpoint() {
@@ -904,7 +909,10 @@ public class TPflash extends Flash {
     if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
       return;
     }
-    if (hasAqueousPhase
+    double materialBalanceResidual = maximumComponentMaterialBalanceResidual(system);
+    boolean materialBalanceInvalid = !Double.isFinite(materialBalanceResidual)
+        || materialBalanceResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE;
+    if (hasAqueousPhase && !materialBalanceInvalid
         && maximumLogFugacityResidualWithReplacement(0, system.getPhase(0)) < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
       return;
     }
@@ -914,7 +922,8 @@ public class TPflash extends Flash {
     try {
       candidate.setMultiPhaseCheck(true);
       new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
-      if (candidate.getNumberOfPhases() == 2 && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
+      if (candidate.getNumberOfPhases() == 2
+          && shouldAcceptWaterRichCandidate(candidate, referenceGibbsEnergy, materialBalanceInvalid)) {
         copyFlashStateFrom(candidate);
       }
     } catch (Exception ex) {
@@ -1099,6 +1108,14 @@ public class TPflash extends Flash {
    * @param referenceGibbsEnergy Gibbs energy of the original one-phase endpoint
    * @return true when the candidate is multiphase and has a lower Gibbs energy
    */
+  private boolean shouldAcceptWaterRichCandidate(SystemInterface candidate, double referenceGibbsEnergy,
+      boolean referenceMaterialBalanceInvalid) {
+    if (referenceMaterialBalanceInvalid) {
+      return isBalancedEquilibriumCandidate(candidate);
+    }
+    return isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy);
+  }
+
   private boolean isLowerGibbsMultiphaseCandidate(SystemInterface candidate, double referenceGibbsEnergy) {
     if (candidate.getNumberOfPhases() < 2) {
       return false;
@@ -1115,6 +1132,91 @@ public class TPflash extends Flash {
     }
     double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceGibbsEnergy) * 1.0e-8);
     return candidate.getGibbsEnergy() < referenceGibbsEnergy - gibbsTolerance;
+  }
+
+  /**
+   * Checks whether a two-phase candidate closes material balance and component fugacity equality.
+   *
+   * @param candidate candidate system to inspect
+   * @return true when phase fractions, compositions, material balance, and equilibrium residuals are finite and satisfy
+   * the water-rich endpoint tolerances
+   */
+  private boolean isBalancedEquilibriumCandidate(SystemInterface candidate) {
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < candidate.getNumberOfPhases(); phaseIndex++) {
+      double phaseFraction = candidate.getBeta(phaseIndex);
+      if (!Double.isFinite(phaseFraction) || phaseFraction <= 10.0 * phaseFractionMinimumLimit) {
+        return false;
+      }
+      betaTotal += phaseFraction;
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < candidate.getPhase(phaseIndex)
+          .getNumberOfComponents(); componentIndex++) {
+        double phaseComposition = candidate.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        if (!Double.isFinite(phaseComposition) || phaseComposition < 0.0 || phaseComposition > 1.0) {
+          return false;
+        }
+        compositionTotal += phaseComposition;
+      }
+      if (!Double.isFinite(compositionTotal)
+          || Math.abs(compositionTotal - 1.0) > WATER_RICH_MATERIAL_BALANCE_TOLERANCE) {
+        return false;
+      }
+    }
+    if (!Double.isFinite(betaTotal) || Math.abs(betaTotal - 1.0) > 1.0e-6 || !hasDistinctPhaseCompositions(candidate)) {
+      return false;
+    }
+    if (maximumComponentMaterialBalanceResidual(candidate) > WATER_RICH_MATERIAL_BALANCE_TOLERANCE) {
+      return false;
+    }
+    double maximumFugacityResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < candidate.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      if (candidate.getPhase(0).getComponent(componentIndex).getz() <= 1.0e-50) {
+        continue;
+      }
+      double firstLogFugacity = Math
+          .log(Math.max(candidate.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(candidate.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math
+          .log(Math.max(candidate.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(candidate.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      if (!Double.isFinite(firstLogFugacity) || !Double.isFinite(secondLogFugacity)) {
+        return false;
+      }
+      maximumFugacityResidual = Math.max(maximumFugacityResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+    }
+    return maximumFugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE;
+  }
+
+  /**
+   * Calculates the maximum absolute component material-balance residual.
+   *
+   * @param candidate system to inspect
+   * @return maximum absolute difference between feed and phase-recombined composition, or positive infinity for a
+   * non-finite feed or phase state
+   */
+  private double maximumComponentMaterialBalanceResidual(SystemInterface candidate) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < candidate.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      double feedComposition = candidate.getPhase(0).getComponent(componentIndex).getz();
+      if (!Double.isFinite(feedComposition)) {
+        return Double.POSITIVE_INFINITY;
+      }
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < candidate.getNumberOfPhases(); phaseIndex++) {
+        double phaseFraction = candidate.getBeta(phaseIndex);
+        double phaseComposition = candidate.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        if (!Double.isFinite(phaseFraction) || !Double.isFinite(phaseComposition)) {
+          return Double.POSITIVE_INFINITY;
+        }
+        recoveredFeed += phaseFraction * phaseComposition;
+        if (!Double.isFinite(recoveredFeed)) {
+          return Double.POSITIVE_INFINITY;
+        }
+      }
+      maximumResidual = Math.max(maximumResidual, Math.abs(feedComposition - recoveredFeed));
+    }
+    return maximumResidual;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousMaterialBalanceRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousMaterialBalanceRefinementTest.java
@@ -1,0 +1,164 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.component.Component;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashAqueousMaterialBalanceRefinementTest {
+  private static final String[] COMPONENTS = { "methane", "nC10", "water" };
+  private static final double[] FEED = { 0.20, 0.60, 0.20 };
+
+  @Test
+  void ordinaryFlashRejectsNonConservativeAqueousEndpoint() {
+    SystemInterface ordinary = createAndFlash(false);
+    SystemInterface multiphase = createAndFlash(true);
+
+    assertEquivalentEquilibrium(multiphase, ordinary);
+    double firstGibbsEnergy = ordinary.getGibbsEnergy();
+
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.init(1);
+
+    assertEquals(firstGibbsEnergy, ordinary.getGibbsEnergy(), 1.0e-8);
+    assertEquivalentEquilibrium(multiphase, ordinary);
+  }
+
+  @Test
+  void nonFiniteCandidatesCannotPassFeasibilityGate() throws Exception {
+    Method materialBalanceMethod = TPflash.class.getDeclaredMethod("maximumComponentMaterialBalanceResidual",
+        SystemInterface.class);
+    materialBalanceMethod.setAccessible(true);
+    Method feasibilityMethod = TPflash.class.getDeclaredMethod("isBalancedEquilibriumCandidate", SystemInterface.class);
+    feasibilityMethod.setAccessible(true);
+
+    SystemInterface invalidPhaseFractionCandidate = createAndFlash(true);
+    invalidPhaseFractionCandidate.setBeta(0, Double.NaN);
+    TPflash flash = new TPflash(invalidPhaseFractionCandidate);
+
+    assertEquals(Double.POSITIVE_INFINITY,
+        ((Double) materialBalanceMethod.invoke(flash, invalidPhaseFractionCandidate)).doubleValue());
+    assertFalse(((Boolean) feasibilityMethod.invoke(flash, invalidPhaseFractionCandidate)).booleanValue());
+
+    for (double invalidComposition : new double[] { Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY }) {
+      SystemInterface invalidCompositionCandidate = createAndFlash(true);
+      setRawPhaseComposition(invalidCompositionCandidate, 0, 0, invalidComposition);
+      flash = new TPflash(invalidCompositionCandidate);
+
+      assertEquals(Double.POSITIVE_INFINITY,
+          ((Double) materialBalanceMethod.invoke(flash, invalidCompositionCandidate)).doubleValue());
+      assertFalse(((Boolean) feasibilityMethod.invoke(flash, invalidCompositionCandidate)).booleanValue());
+    }
+
+    for (double invalidComposition : new double[] { -1.0e-6, 1.0 + 1.0e-6 }) {
+      SystemInterface invalidCompositionCandidate = createAndFlash(true);
+      setRawPhaseComposition(invalidCompositionCandidate, 0, 0, invalidComposition);
+      flash = new TPflash(invalidCompositionCandidate);
+
+      assertFalse(((Boolean) feasibilityMethod.invoke(flash, invalidCompositionCandidate)).booleanValue());
+    }
+  }
+
+  @Test
+  void nonConservativeReferenceCannotUseGibbsOnlyAcceptance() throws Exception {
+    Method acceptanceMethod = TPflash.class.getDeclaredMethod("shouldAcceptWaterRichCandidate", SystemInterface.class,
+        double.class, boolean.class);
+    acceptanceMethod.setAccessible(true);
+
+    SystemInterface candidate = createAndFlash(true);
+    double betaShift = 0.1 * Math.min(candidate.getBeta(0), candidate.getBeta(1));
+    candidate.setBeta(0, candidate.getBeta(0) + betaShift);
+    candidate.setBeta(1, candidate.getBeta(1) - betaShift);
+    assertTrue(maximumComponentMaterialBalanceResidual(candidate) > 1.0e-8);
+
+    TPflash flash = new TPflash(candidate);
+    double higherReferenceGibbs = candidate.getGibbsEnergy()
+        + Math.max(1.0, Math.abs(candidate.getGibbsEnergy()) * 1.0e-3);
+    assertTrue(((Boolean) acceptanceMethod.invoke(flash, candidate, higherReferenceGibbs, false)).booleanValue());
+    assertFalse(((Boolean) acceptanceMethod.invoke(flash, candidate, higherReferenceGibbs, true)).booleanValue());
+  }
+
+  private void setRawPhaseComposition(SystemInterface system, int phaseIndex, int componentIndex, double value)
+      throws Exception {
+    Field compositionField = Component.class.getDeclaredField("x");
+    compositionField.setAccessible(true);
+    Object component = system.getPhase(phaseIndex).getComponent(componentIndex);
+    compositionField.setDouble(component, value);
+    assertEquals(value, system.getPhase(phaseIndex).getComponent(componentIndex).getx());
+  }
+
+  private SystemInterface createAndFlash(boolean multiphaseCheck) {
+    SystemInterface system = new SystemSrkEos(230.0, 50.0);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], FEED[componentIndex]);
+    }
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private void assertEquivalentEquilibrium(SystemInterface expected, SystemInterface actual) {
+    assertEquals(2, expected.getNumberOfPhases());
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(PhaseType.OIL, actual.getPhase(0).getType());
+    assertEquals(PhaseType.AQUEOUS, actual.getPhase(1).getType());
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-8);
+
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < expected.getNumberOfPhases(); phaseIndex++) {
+      assertEquals(expected.getPhase(phaseIndex).getType(), actual.getPhase(phaseIndex).getType());
+      assertEquals(expected.getBeta(phaseIndex), actual.getBeta(phaseIndex), 1.0e-12);
+      assertTrue(actual.getBeta(phaseIndex) > 0.0);
+      assertTrue(actual.getBeta(phaseIndex) < 1.0);
+      assertTrue(Double.isFinite(actual.getPhase(phaseIndex).getZ()));
+      assertTrue(actual.getPhase(phaseIndex).getZ() > 0.0);
+      betaTotal += actual.getBeta(phaseIndex);
+
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        assertEquals(expected.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            actual.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
+        compositionTotal += actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-12);
+    }
+    assertEquals(1.0, betaTotal, 1.0e-12);
+    assertTrue(maximumComponentMaterialBalanceResidual(actual) < 1.0e-8);
+    assertTrue(maximumLogFugacityResidual(actual) < 1.0e-8);
+  }
+
+  private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      maximumResidual = Math.max(maximumResidual, Math.abs(FEED[componentIndex] - recoveredFeed));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double firstLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+    }
+    return maximumResidual;
+  }
+}


### PR DESCRIPTION
## Problem

Ordinary TPflash can retain a two-phase aqueous endpoint whose phase fractions do not reconstruct the feed. For an SRK methane/n-decane/water case at 230 K and 50 bara, both flash paths report `OIL + AQUEOUS`, but the ordinary result has:

- maximum component material-balance residual: `2.9970713367e-1`
- maximum `|Delta ln(f_i)|`: `1.3857088`
- Gibbs energy: `-17658.3498517 J`

TPmultiflash returns a conservative equilibrium:

- maximum component material-balance residual: `2.52e-14`
- maximum `|Delta ln(f_i)|`: `2.56e-13`
- Gibbs energy: `-17209.6687049 J`

The ordinary state appears lower in Gibbs energy only because its phase fractions lose feed material. It is therefore not a feasible state and cannot be used as the reference in a constrained Gibbs comparison.

## Root cause

The water-rich endpoint refinement already creates a cloned TPmultiflash candidate when the ordinary endpoint has a large fugacity residual. It previously accepted that candidate only when its extensive Gibbs energy was below the ordinary result. That comparison is invalid when the ordinary result violates component material balance.

## Change

- Screen existing water-rich two-phase endpoints for maximum phase-recombined component material-balance residual.
- Keep the existing lower-Gibbs acceptance rule for conservative reference states.
- When the reference is non-conservative, accept a two-phase candidate only when it independently has:
  - bounded and normalized phase fractions;
  - bounded, normalized, and distinct phase compositions;
  - maximum component material-balance residual at or below `1e-8`;
  - maximum log-fugacity residual below `1e-8`.
- Retain the existing 0.01 water-feed gate and all chemical, electrolyte, solid, wax, and multiphase guards.
- Reject non-finite phase fractions, phase compositions, composition sums, feed values, and reconstructed material balances before candidate acceptance.
- Use only `init(1)`; no higher initialization level is introduced.

## Method and literature basis

This treats component material balance and fugacity equality as feasibility constraints before comparing Gibbs minima. The approach is consistent with Michelsen's tangent-plane stability and phase-split formulations:

- Michelsen, *The isothermal flash problem. Part I. Stability*, Fluid Phase Equilibria 9 (1982), https://doi.org/10.1016/0378-3812(82)85001-2
- Michelsen, *The isothermal flash problem. Part II. Phase-split calculation*, Fluid Phase Equilibria 9 (1982), https://doi.org/10.1016/0378-3812(82)85002-4

Evidence: the residuals and cross-algorithm results above are directly measured from NeqSim. Inference: a non-conservative state is outside the feasible flash manifold, so its lower extensive Gibbs value must not veto a balanced equilibrium candidate.

Public commercial-simulator material describes robust multiphase flash capability but does not document an equivalent internal acceptance rule; this PR makes no claim about proprietary implementations.

## Results

Focused regression, SRK/mixing rule 2, 230 K, 50 bara, feed methane/n-decane/water = 0.20/0.60/0.20:

| Metric | Before | After |
|---|---:|---:|
| Maximum component material residual | `2.997e-1` | `2.52e-14` |
| Maximum log-fugacity residual | `1.386` | `2.56e-13` |
| Ordinary/TPmultiflash Gibbs difference | `448.681 J` | `< 1e-8 J` |
| Phase fractions/compositions | disagree | agree within `1e-12` |

Deterministic cross-algorithm matrix:

- 450/450 flashes completed before and after.
- Structural disagreements: 0 before, 0 after.
- Numerical disagreements: 21 before, 13 after.
- The eight corrected states cover SRK and PR wet-gas/oil-water cases at 230 K and 50-300 bara.
- No new disagreement or conservation failure was introduced.

Timing, fresh JVM forks with 20 warmups and 120 measured flashes per fork:

- corrected oil-water case: median of fork medians `5.90 -> 5.98 ms/flash` (about 1.4%, within observed JVM variation);
- stable aqueous control: `4.23 -> 4.22 ms/flash`, identical checksum.

The expensive multiphase candidate was already evaluated before this change; the patch adds a linear component-balance scan and copies the candidate only when the old endpoint is invalid.

## Tests

- New focused Java regression fails on `master` and passes with the fix.
- Defensive regression injects a NaN phase fraction plus raw NaN/positive-infinity/negative-infinity phase compositions; all return an infinite material-balance residual and fail the feasibility gate. The raw-field helper is required because the public `Component.setx()` API intentionally ignores non-finite values. Separate raw `-1e-6` and `1 + 1e-6` compositions verify finite out-of-range values are also rejected.
- Acceptance-branch regression constructs an unbalanced two-phase candidate that passes the lower-Gibbs screen, then verifies it is rejected whenever the reference endpoint is non-conservative; Gibbs-only acceptance remains available only for conservative references.
- Java 8-target compilation passed for production and test sources using Eclipse ECJ.
- Deterministic focused harness passed, including repeated execution.
- 450-state SRK/PR/CPA ordinary-versus-multiphase matrix passed all flash completion, phase-structure, phase-fraction, composition-normalization, material-balance, fugacity, repeatability, and property checks.

Full Maven, Spotless, Javadocs, CodeQL, and platform test matrices are delegated to GitHub CI because the local environment does not contain the complete Maven checkout/dependency graph.

## Compatibility risk

Low and narrowly gated. Conservative equilibrated aqueous results stay on the current fast path. The alternate acceptance path is available only when the existing ordinary result exceeds the documented `1e-8` component material-balance tolerance, and the replacement must independently satisfy stricter physical and equilibrium checks. Corrupted non-finite states are now treated as infeasible rather than passing Java comparisons with NaN.

## Documentation impact

Updated TPflash Javadocs and `docs/thermodynamicoperations/TPflash_algorithm.md` to document the material-balance gate, tolerances, feasibility-before-Gibbs rule, and fast-path behavior.
