### PR TITLE
fix: preserve TwoFluidPipe mass after transient closure update

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -386,6 +386,9 @@ There is no separate post-step projection toward the steady-state holdup correla
 projection changes phase inventory without a boundary flux or mass-transfer source and makes the
 error scale with pipe length. The earlier unreferenced 4 s relaxation time has therefore been
 removed; steady-state closures remain part of initialization and the local closure/source terms.
+Auxiliary terrain and slug trackers may maintain primitive diagnostics, but they do not rebuild the
+finite-volume phase masses. Conservative source or flux coupling for those trackers remains future
+model-development work.
 
 For a domain with no external mass source, validate the discrete balance
 

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -381,6 +381,25 @@ root-mean-square pressure difference across all sections; for compact tests a li
 useful sanity check. For multiphase cases, also compare liquid, oil, and water holdup profiles so
 the dynamic calculation has settled hydraulically, not only acoustically.
 
+Transient holdup is reconstructed from the phase masses advanced by the finite-volume equations.
+There is no separate post-step projection toward the steady-state holdup correlation. Such a
+projection changes phase inventory without a boundary flux or mass-transfer source and makes the
+error scale with pipe length. The earlier unreferenced 4 s relaxation time has therefore been
+removed; steady-state closures remain part of initialization and the local closure/source terms.
+
+For a domain with no external mass source, validate the discrete balance
+
+$$
+M(t + \Delta t) - M(t) =
+\int_t^{t+\Delta t} \left(\dot m_{in} - \dot m_{out}\right)\,dt,
+\qquad
+M = \sum_i \left(m'_{g,i} + m'_{o,i} + m'_{w,i}\right)\Delta x_i .
+$$
+
+Use `getTotalMassInventory()` to read $M$ in kg directly from the conservative gas, oil, and water
+masses. A steady-state solution remains a useful long-time comparison, but agreement must result
+from the transient balances and closure forces rather than overwriting the conserved state.
+
 ### Boundary Conditions
 
 Use `setInletBoundaryCondition(...)` and `setOutletBoundaryCondition(...)` for explicit boundary

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -378,8 +378,11 @@ while (elapsedTime < 60.0) {
 For regression tests, compare the transient profile after the boundary change with a second
 `TwoFluidPipe` solved directly at the new boundary condition. A practical pressure-profile metric is
 root-mean-square pressure difference across all sections; for compact tests a limit of 1-2 bar is a
-useful sanity check. For multiphase cases, also compare liquid, oil, and water holdup profiles so
-the dynamic calculation has settled hydraulically, not only acoustically.
+useful sanity check. Treat acoustic pressure settling and material-inventory settling as separate
+checks. Pressure waves can settle quickly, while liquid, oil, and water holdup profiles may require
+one or more residence times to approach a stationary distribution. Do not impose the pressure-test
+horizon on holdup convergence or force agreement by reconstructing conservative phase masses from
+the stationary closure.
 
 Transient holdup is reconstructed from the phase masses advanced by the finite-volume equations.
 There is no separate post-step projection toward the steady-state holdup correlation. Such a

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -3463,7 +3463,6 @@ public class TwoFluidPipe extends Pipeline {
           trackOutletSlugs();
         }
 
-        synchronizeConservativeStateWithPrimitiveState();
       }
 
       // 9. Update temperature profile if heat transfer is enabled
@@ -3486,25 +3485,6 @@ public class TwoFluidPipe extends Pipeline {
     setCalculationIdentifier(id);
   }
 
-  /**
-   * Synchronize conservative variables after models have changed primitive section state.
-   *
-   * <p>
-   * The transient solver advances conservative masses and momenta, while terrain accumulation and slug-return models
-   * may explicitly update primitive holdups and velocities. This method keeps the next transient state extraction and
-   * inventory reporting consistent with those accepted submodel updates.
-   * </p>
-   */
-  private void synchronizeConservativeStateWithPrimitiveState() {
-    if (sections == null) {
-      return;
-    }
-    for (TwoFluidSection sec : sections) {
-      if (sec != null) {
-        sec.updateConservativeVariables();
-      }
-    }
-  }
 
   /**
    * Validate and correct state vector to prevent numerical instabilities.

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4487,6 +4487,30 @@ public class TwoFluidPipe extends Pipeline {
   // ============ Result access methods ============
 
   /**
+   * Get the total gas, oil, and water mass stored in the computational domain.
+   *
+   * <p>
+   * The inventory is integrated directly from the conservative phase masses per unit length. It is therefore suitable
+   * for checking the finite-volume balance
+   * {@code M(t + dt) - M(t) = integral(mDotIn - mDotOut) dt} for cases without external mass sources.
+   * </p>
+   *
+   * @return total domain mass in kg
+   */
+  public double getTotalMassInventory() {
+    if (sections == null) {
+      return 0.0;
+    }
+
+    double mass = 0.0;
+    for (TwoFluidSection sec : sections) {
+      mass += (sec.getGasMassPerLength() + sec.getOilMassPerLength() + sec.getWaterMassPerLength())
+          * sec.getLength();
+    }
+    return mass;
+  }
+
+  /**
    * Get total liquid inventory in the pipe.
    *
    * <p>

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -3479,12 +3479,6 @@ public class TwoFluidPipe extends Pipeline {
       timeIntegrator.advanceTime(dtActual);
     }
 
-    if (relaxHoldupTowardSteadyClosure(dt)) {
-      reconstructPressureProfile();
-      applyBoundaryConditions();
-      validateSectionStates();
-    }
-
     // Update outlet stream and result arrays
     updateOutletStream();
     updateResultArrays();
@@ -3493,72 +3487,12 @@ public class TwoFluidPipe extends Pipeline {
   }
 
   /**
-   * Relax transient phase holdups toward the same local closure used by the steady solver.
-   *
-   * <p>
-   * The transient conservative update carries inventory and momentum, while the two-fluid closure supplies the
-   * slip/holdup relation. Applying a mild relaxation for open-flow boundary conditions keeps long transients consistent
-   * with the stationary solution after a changed pressure boundary.
-   * </p>
-   *
-   * @param dt elapsed transient step in seconds
-   * @return true if the section primitive state was relaxed
-   */
-  private boolean relaxHoldupTowardSteadyClosure(double dt) {
-    if (sections == null || sections.length == 0 || dt <= 0.0) {
-      return false;
-    }
-    if (outletBCType == BoundaryCondition.CLOSED || inletBCType == BoundaryCondition.CLOSED) {
-      return false;
-    }
-
-    double massFlow = inletBCType == BoundaryCondition.CONSTANT_FLOW && inletMassFlowSet ? inletMassFlow
-        : getInletStream().getFlowRate("kg/sec");
-    if (massFlow <= 0.0) {
-      return false;
-    }
-
-    double[] phaseMassFractions = calculateInletPhaseMassFractions(getInletStream().getFluid());
-    double mDotGas = massFlow * phaseMassFractions[0];
-    double mDotLiq = massFlow * (phaseMassFractions[1] + phaseMassFractions[2]);
-    double area = Math.PI * diameter * diameter / 4.0;
-    double relaxation = 1.0 - Math.exp(-dt / 4.0);
-
-    for (int i = 0; i < numberOfSections; i++) {
-      TwoFluidSection sec = sections[i];
-      TwoFluidSection prev = i > 0 ? sections[i - 1] : null;
-      double[] targetHoldups = calculateLocalHoldup(sec, prev, mDotGas, mDotLiq, area);
-      double alphaL = sec.getLiquidHoldup() + relaxation * (targetHoldups[0] - sec.getLiquidHoldup());
-      alphaL = Math.max(0.0, Math.min(1.0, alphaL));
-      double alphaG = 1.0 - alphaL;
-
-      sec.setLiquidHoldup(alphaL);
-      sec.setGasHoldup(alphaG);
-      if (alphaG > 0.001 && sec.getGasDensity() > 0.0) {
-        sec.setGasVelocity(mDotGas / (area * alphaG * sec.getGasDensity()));
-      }
-      if (alphaL > 0.001 && sec.getLiquidDensity() > 0.0) {
-        sec.setLiquidVelocity(mDotLiq / (area * alphaL * sec.getLiquidDensity()));
-        updateLiquidPhaseSplit(sec, prev, alphaL, area);
-      } else {
-        sec.setLiquidVelocity(0.0);
-        sec.setWaterHoldup(0.0);
-        sec.setOilHoldup(0.0);
-      }
-      sec.updateDerivedQuantities();
-      sec.updateStratifiedGeometry();
-      sec.updateConservativeVariables();
-    }
-    return true;
-  }
-
-  /**
    * Synchronize conservative variables after models have changed primitive section state.
    *
    * <p>
-   * The transient solver advances conservative masses and momenta, while terrain accumulation, slug return, and closure
-   * relaxation deliberately update primitive holdups and velocities. This method keeps the next transient state
-   * extraction and inventory reporting consistent with those accepted primitive updates.
+   * The transient solver advances conservative masses and momenta, while terrain accumulation and slug-return models
+   * may explicitly update primitive holdups and velocities. This method keeps the next transient state extraction and
+   * inventory reporting consistent with those accepted submodel updates.
    * </p>
    */
   private void synchronizeConservativeStateWithPrimitiveState() {
@@ -4491,8 +4425,8 @@ public class TwoFluidPipe extends Pipeline {
    *
    * <p>
    * The inventory is integrated directly from the conservative phase masses per unit length. It is therefore suitable
-   * for checking the finite-volume balance
-   * {@code M(t + dt) - M(t) = integral(mDotIn - mDotOut) dt} for cases without external mass sources.
+   * for checking the finite-volume balance {@code M(t + dt) - M(t) = integral(mDotIn - mDotOut) dt} for cases without
+   * external mass sources.
    * </p>
    *
    * @return total domain mass in kg
@@ -4504,8 +4438,7 @@ public class TwoFluidPipe extends Pipeline {
 
     double mass = 0.0;
     for (TwoFluidSection sec : sections) {
-      mass += (sec.getGasMassPerLength() + sec.getOilMassPerLength() + sec.getWaterMassPerLength())
-          * sec.getLength();
+      mass += (sec.getGasMassPerLength() + sec.getOilMassPerLength() + sec.getWaterMassPerLength()) * sec.getLength();
     }
     return mass;
   }

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -3485,7 +3485,6 @@ public class TwoFluidPipe extends Pipeline {
     setCalculationIdentifier(id);
   }
 
-
   /**
    * Validate and correct state vector to prevent numerical instabilities.
    *

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -685,7 +685,7 @@ class TwoFluidPipeBoundaryConditionTest {
         "Transient pressure profile should move toward new stationary target. Initial RMS: " + initialDistance
             + " Pa, final RMS: " + settling.pressureRmsPa + " Pa");
     assertTrue(settling.settled,
-        name + " did not reach the new stationary solution within " + maxReasonableTime + " s. Pressure RMS: "
+        name + " pressure profile did not settle within " + maxReasonableTime + " s. Pressure RMS: "
             + settling.pressureRmsPa + " Pa, liquid holdup RMS: " + settling.liquidHoldupRms + ", elapsed time: "
             + settling.elapsedTime + " s");
   }
@@ -715,7 +715,8 @@ class TwoFluidPipeBoundaryConditionTest {
     assertOutletPressure(transientPipe, changedOutletBara);
     assertPressureProfilePhysical(transientPipe);
     assertTrue(settling.settled,
-        name + " should settle within " + maxReasonableTime + " s. Settling time: " + settling.elapsedTime
+        name + " pressure profile should settle within " + maxReasonableTime + " s. Settling time: "
+            + settling.elapsedTime
             + " s, pressure RMS: " + settling.pressureRmsPa + " Pa, liquid holdup RMS: " + settling.liquidHoldupRms);
   }
 
@@ -797,7 +798,7 @@ class TwoFluidPipeBoundaryConditionTest {
       result.oilHoldupRms = rmsDifference(transientPipe.getOilHoldupProfile(), stationaryPipe.getOilHoldupProfile());
       result.waterHoldupRms = rmsDifference(transientPipe.getWaterHoldupProfile(),
           stationaryPipe.getWaterHoldupProfile());
-      result.settled = isSettledToStationaryState(result, stationaryPipe);
+      result.settled = isSettledToStationaryPressureProfile(result);
       if (result.settled) {
         logger.printf(org.apache.logging.log4j.Level.INFO,
             "%s reached new stationary state in %.1f s " + "(pressure RMS %.0f Pa, liquid holdup RMS %.4f)%n",
@@ -809,20 +810,20 @@ class TwoFluidPipeBoundaryConditionTest {
   }
 
   /**
-   * Check pressure and phase holdup profile convergence against a stationary target.
+   * Check acoustic pressure-profile convergence against a stationary target.
+   *
+   * <p>
+   * Liquid inventory can require a much longer material-residence time to reach its stationary
+   * distribution. Holdup differences remain recorded in {@link SettlingResult} for diagnostics,
+   * but must not be used to gate this bounded pressure-response check.
+   * </p>
    *
    * @param result current settling result
-   * @param stationaryPipe stationary target pipe
-   * @return true if settled
+   * @return true if the pressure profile has settled
    */
-  private boolean isSettledToStationaryState(SettlingResult result, TwoFluidPipe stationaryPipe) {
+  private boolean isSettledToStationaryPressureProfile(SettlingResult result) {
     double pressureLimitPa = 2.0e5;
-    double liquidHoldupLimit = averageArray(stationaryPipe.getLiquidHoldupProfile()) > 1e-6 ? 0.08 : 1e-6;
-    double targetOilHoldup = averageArray(stationaryPipe.getOilHoldupProfile());
-    double targetWaterHoldup = averageArray(stationaryPipe.getWaterHoldupProfile());
-    return result.pressureRmsPa <= pressureLimitPa && result.liquidHoldupRms <= liquidHoldupLimit
-        && (targetOilHoldup <= 1e-6 || result.oilHoldupRms <= 0.08)
-        && (targetWaterHoldup <= 1e-6 || result.waterHoldupRms <= 0.08);
+    return result.pressureRmsPa <= pressureLimitPa;
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -394,6 +394,7 @@ class TwoFluidPipeBoundaryConditionTest {
     double initialFlowRate = 6.0;
     double timeStep = 1.0e-3;
     double[] steppedFlowRates = { 12.0, 30.0 };
+    UUID calculationId = UUID.fromString("00000000-0000-0000-0000-000000002718");
 
     for (double steppedFlowRate : steppedFlowRates) {
       TwoFluidPipe transientPipe = createRegressionPipe("mass-balance-" + steppedFlowRate, createTwoPhaseFluid(),
@@ -406,7 +407,7 @@ class TwoFluidPipeBoundaryConditionTest {
 
       double massBefore = transientPipe.getTotalMassInventory();
       transientPipe.setInletMassFlow(steppedFlowRate, "kg/sec");
-      transientPipe.runTransient(timeStep, UUID.randomUUID());
+      transientPipe.runTransient(timeStep, calculationId);
       double massAfter = transientPipe.getTotalMassInventory();
 
       double massChange = Math.abs(massAfter - massBefore);

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -388,6 +388,38 @@ class TwoFluidPipeBoundaryConditionTest {
     assertEquals(BoundaryCondition.CONSTANT_FLOW, pipe.getInletBoundaryCondition());
   }
 
+  @Test
+  @DisplayName("CONSTANT_FLOW rate step changes domain mass only through boundary fluxes")
+  void testConstantFlowStepDoesNotCreateDomainMass() {
+    double initialFlowRate = 6.0;
+    double timeStep = 1.0e-3;
+    double[] steppedFlowRates = {12.0, 30.0};
+
+    for (double steppedFlowRate : steppedFlowRates) {
+      TwoFluidPipe transientPipe =
+          createRegressionPipe("mass-balance-" + steppedFlowRate, createTwoPhaseFluid(),
+              initialFlowRate, 75.0, 58.0);
+      transientPipe.setLength(3000.0);
+      transientPipe.setNumberOfSections(12);
+      transientPipe.setInletBoundaryCondition(BoundaryCondition.CONSTANT_FLOW);
+      transientPipe.setInletMassFlow(initialFlowRate, "kg/sec");
+      transientPipe.run();
+
+      double massBefore = transientPipe.getTotalMassInventory();
+      transientPipe.setInletMassFlow(steppedFlowRate, "kg/sec");
+      transientPipe.runTransient(timeStep, UUID.randomUUID());
+      double massAfter = transientPipe.getTotalMassInventory();
+
+      double massChange = Math.abs(massAfter - massBefore);
+      double boundaryFluxEnvelope =
+          2.0 * (initialFlowRate + steppedFlowRate) * timeStep;
+      assertTrue(massChange <= boundaryFluxEnvelope,
+          "A short rate step must not create domain-volume-scaled mass. Flow step "
+              + initialFlowRate + " -> " + steppedFlowRate + " kg/s changed inventory by "
+              + massChange + " kg; flux envelope was " + boundaryFluxEnvelope + " kg");
+    }
+  }
+
   // =====================================================================
   // Stationary and Transient Boundary Regression Tests
   // =====================================================================

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -716,8 +716,8 @@ class TwoFluidPipeBoundaryConditionTest {
     assertPressureProfilePhysical(transientPipe);
     assertTrue(settling.settled,
         name + " pressure profile should settle within " + maxReasonableTime + " s. Settling time: "
-            + settling.elapsedTime
-            + " s, pressure RMS: " + settling.pressureRmsPa + " Pa, liquid holdup RMS: " + settling.liquidHoldupRms);
+            + settling.elapsedTime + " s, pressure RMS: " + settling.pressureRmsPa + " Pa, liquid holdup RMS: "
+            + settling.liquidHoldupRms);
   }
 
   /**
@@ -813,9 +813,9 @@ class TwoFluidPipeBoundaryConditionTest {
    * Check acoustic pressure-profile convergence against a stationary target.
    *
    * <p>
-   * Liquid inventory can require a much longer material-residence time to reach its stationary
-   * distribution. Holdup differences remain recorded in {@link SettlingResult} for diagnostics,
-   * but must not be used to gate this bounded pressure-response check.
+   * Liquid inventory can require a much longer material-residence time to reach its stationary distribution. Holdup
+   * differences remain recorded in {@link SettlingResult} for diagnostics, but must not be used to gate this bounded
+   * pressure-response check.
    * </p>
    *
    * @param result current settling result

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -801,7 +801,7 @@ class TwoFluidPipeBoundaryConditionTest {
       result.settled = isSettledToStationaryPressureProfile(result);
       if (result.settled) {
         logger.printf(org.apache.logging.log4j.Level.INFO,
-            "%s reached new stationary state in %.1f s " + "(pressure RMS %.0f Pa, liquid holdup RMS %.4f)%n",
+            "%s pressure profile settled in %.1f s " + "(pressure RMS %.0f Pa, liquid holdup RMS %.4f)%n",
             transientPipe.getName(), result.elapsedTime, result.pressureRmsPa, result.liquidHoldupRms);
         return result;
       }

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -393,12 +393,11 @@ class TwoFluidPipeBoundaryConditionTest {
   void testConstantFlowStepDoesNotCreateDomainMass() {
     double initialFlowRate = 6.0;
     double timeStep = 1.0e-3;
-    double[] steppedFlowRates = {12.0, 30.0};
+    double[] steppedFlowRates = { 12.0, 30.0 };
 
     for (double steppedFlowRate : steppedFlowRates) {
-      TwoFluidPipe transientPipe =
-          createRegressionPipe("mass-balance-" + steppedFlowRate, createTwoPhaseFluid(),
-              initialFlowRate, 75.0, 58.0);
+      TwoFluidPipe transientPipe = createRegressionPipe("mass-balance-" + steppedFlowRate, createTwoPhaseFluid(),
+          initialFlowRate, 75.0, 58.0);
       transientPipe.setLength(3000.0);
       transientPipe.setNumberOfSections(12);
       transientPipe.setInletBoundaryCondition(BoundaryCondition.CONSTANT_FLOW);
@@ -411,12 +410,11 @@ class TwoFluidPipeBoundaryConditionTest {
       double massAfter = transientPipe.getTotalMassInventory();
 
       double massChange = Math.abs(massAfter - massBefore);
-      double boundaryFluxEnvelope =
-          2.0 * (initialFlowRate + steppedFlowRate) * timeStep;
+      double boundaryFluxEnvelope = 2.0 * (initialFlowRate + steppedFlowRate) * timeStep;
       assertTrue(massChange <= boundaryFluxEnvelope,
-          "A short rate step must not create domain-volume-scaled mass. Flow step "
-              + initialFlowRate + " -> " + steppedFlowRate + " kg/s changed inventory by "
-              + massChange + " kg; flux envelope was " + boundaryFluxEnvelope + " kg");
+          "A short rate step must not create domain-volume-scaled mass. Flow step " + initialFlowRate + " -> "
+              + steppedFlowRate + " kg/s changed inventory by " + massChange + " kg; flux envelope was "
+              + boundaryFluxEnvelope + " kg");
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the foundational transient state-ownership defect in #2705 by removing two post-step paths that rebuilt finite-volume mass from primitive holdup:

1. the unreferenced 4 s relaxation toward steady-state holdup; and
2. the unconditional primitive-to-conservative synchronization after slug/terrain tracking.

Gas, oil, and water masses advanced by the finite-volume equations remain authoritative. The PR also adds `getTotalMassInventory()` for direct balance diagnostics.

## Reproducible evidence

The removed closure projection used:

```text
alphaL* = alphaL + [1 - exp(-dt / 4 s)] (alphaL,steady - alphaL)
mL'     = alphaL* rhoL A
mG'     = (1 - alphaL*) rhoG A
```

without a boundary flux or mass-transfer source. For D = 0.20 m, rhoG = 40 kg/m3, rhoL = 700 kg/m3, alphaL = 0.05, target alphaL = 0.15, and dt = 1 s, it changes total mass by 0.4586 kg/m, or about 459 kg over 1 km.

A hosted 3 km regression initialized at 6 kg/s and stepped to 12 kg/s for 1 ms then exposed the second path: inventory changed by 1925.252 kg although the conservative inlet-plus-outlet flux envelope was only 0.036 kg. The default Lagrangian pass made no accepted conservative transfer, but `synchronizeConservativeStateWithPrimitiveState()` still called `updateConservativeVariables()` on every section and recreated domain-volume-scaled mass.

## Governing balance

```text
M(t+dt) - M(t) = integral_t^(t+dt) [mDot_in - mDot_out] dt
M = sum_i (mGas'_i + mOil'_i + mWater'_i) dx_i
```

Phase mass per length is kg/m, section length is m, inventory is kg, boundary flow is kg/s, and time is s. Internal phase transfer must be equal and opposite and cancel in total mass.

## Implementation

- Remove `relaxHoldupTowardSteadyClosure()` and its post-step pressure/state reconstruction.
- Remove unconditional slug/terrain primitive-to-conservative synchronization.
- Keep PDE flux integration, thermodynamics, boundary APIs, steady-state initialization, and public signatures unchanged.
- Add read-only `getTotalMassInventory()`.
- Preserve deterministic calculation identity in the regression.

Auxiliary slug and terrain trackers can retain diagnostic primitive state, but cannot promote it into conservative phase mass without an explicit conservative flux or source formulation.

## Pressure versus inventory settling

After the conservative correction, the mass regression and one-phase pressure cases pass. The two- and three-phase pressure disturbances also reduce from 600,000 Pa to 9,757 Pa and 16,444 Pa respectively, both far inside the unchanged 200,000 Pa pressure limit.

The remaining failures came only from also requiring liquid-holdup RMS <= 0.08 inside the same 60 s acoustic-pressure test. That is not a valid shared timescale: pressure waves settle acoustically, while liquid inventory approaches a stationary distribution by material transport and may require one or more residence times. The regression now gates the 60 s scenario only on the unchanged pressure criterion; holdup RMS remains calculated and reported diagnostically. The strict mass-flux envelope is unchanged.

## Validation

Current head: `816eb5ebde2520ba17dafa9ef832ba22683afabb`.

Coverage includes:

- 6 -> 12 and 6 -> 30 kg/s rate steps over 1 ms;
- one-, two-, and three-phase outlet-pressure steps;
- independent stationary pressure targets;
- pressure, liquid-, oil-, and water-holdup diagnostics;
- full repository Java 8/21, Ubuntu/Windows, and slow-test matrices.

On the exact current head, Java 21 Ubuntu and Windows, all three Java 21 slow-test shards, Javadocs, Spotless, pre-commit, CodeQL, PaperLab, documentation search, and agent-skill checks pass. The Java 8 Ubuntu and Windows jobs are still running. The immediately preceding head passed both Java 8 jobs; the only later source change corrected a diagnostic test log from "reached new stationary state" to "pressure profile settled." All Copilot findings have been dispositioned and no review threads are open.

## Compatibility and risk

Public APIs remain compatible. The production change removes an unbalanced state projection; it does not change correlations, tolerances, phase equilibrium, or boundary values. It does not claim experimental validation of pressure, holdup, or slug frequency.

## Documentation impact

Updated `TwoFluidPipe` Javadocs and `docs/process/TWOFLUIDPIPE_MODEL.md` with the inventory equation, units, diagnostic API, state ownership, and the distinction between acoustic pressure settling and material-inventory settling.

## References

- Bendiksen et al. (1991), *The Dynamic Two-Fluid Model OLGA: Theory and Application*: https://onepetro.org/PO/article/6/02/171/53376/The-Dynamic-Two-Fluid-Model-OLGA-Theory-and
- Krasnopolsky & Lukyanov (2018), *Journal of Computational Physics* 355, 597–619: https://doi.org/10.1016/j.jcp.2017.11.032
- Public LedaFlow validation context: https://www.sintef.no/en/publications/publication/0198cc94bc36-07055a4c-7131-4f85-a956-faab6d1c2755/

Related: #2705. Keep that issue open until conservative terrain/slug source coupling and the complete acceptance matrix are implemented.