### PR TITLE
docs: correct transient timestep contracts

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -25,7 +25,7 @@ historian tag mapping, and event schedule before running `runTransient`.
 
 ## Dynamic Simulation Architecture
 
-NeqSim dynamic simulation uses the `runTransient(double dt)` method on `ProcessSystem`.
+NeqSim dynamic simulation advances a `ProcessSystem` with `runTransient()` (using the configured timestep) or `runTransient(double dt, UUID id)` (using an explicit timestep and calculation identifier).
 Pass a finite, positive timestep. Process and model entry points reject zero,
 negative, NaN, and infinite values before any area or equipment state changes.
 Adaptive stepping rejects invalid requests rather than clamping them.

--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -25,7 +25,9 @@ historian tag mapping, and event schedule before running `runTransient`.
 
 ## Dynamic Simulation Architecture
 
-NeqSim dynamic simulation advances a `ProcessSystem` with `runTransient()` (using the configured timestep) or `runTransient(double dt, UUID id)` (using an explicit timestep and calculation identifier).
+NeqSim dynamic simulation advances a `ProcessSystem` with `runTransient()`
+(using the configured timestep) or `runTransient(double dt, UUID id)` (using an
+explicit timestep and calculation identifier).
 Pass a finite, positive timestep. Process and model entry points reject zero,
 negative, NaN, and infinite values before any area or equipment state changes.
 Adaptive stepping rejects invalid requests rather than clamping them.

--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -1429,7 +1429,7 @@ public class ProcessModel implements Runnable, Serializable {
    *
    * @param dt finite timestep size in seconds (must be {@code > 0})
    * @param id calculation UUID forwarded to each child {@code ProcessSystem.runTransient}
-   * @throws IllegalArgumentException if {@code dt} is not finite and greater than zero
+   * @throws IllegalArgumentException if {@code dt} is non-finite or not greater than zero
    */
   public void runTransient(double dt, UUID id) {
     ProcessSystem.validateTransientTimestep(dt);

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4084,7 +4084,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * Validates a requested transient timestep before any process state is changed.
    *
    * @param dt timestep in seconds
-   * @throws IllegalArgumentException if {@code dt} is not finite and greater than zero
+   * @throws IllegalArgumentException if {@code dt} is non-finite or not greater than zero
    */
   static void validateTransientTimestep(double dt) {
     if (!Double.isFinite(dt) || dt <= 0.0) {
@@ -4110,7 +4110,7 @@ public class ProcessSystem extends SimulationBaseClass {
    *
    * @param dt timestep in seconds
    * @param id calculation identifier shared by the timestep
-   * @throws IllegalArgumentException if {@code dt} is not finite and greater than zero
+   * @throws IllegalArgumentException if {@code dt} is non-finite or not greater than zero
    */
   @Override
   public synchronized void runTransient(double dt, UUID id) {
@@ -4346,7 +4346,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * @param dt the requested timestep in seconds
    * @param id calculation identifier
    * @return the actual timestep used (may differ from dt)
-   * @throws IllegalArgumentException if {@code dt} is not finite and greater than zero
+   * @throws IllegalArgumentException if {@code dt} is non-finite or not greater than zero
    */
   public double runTransientAdaptive(double dt, UUID id) {
     validateTransientTimestep(dt);


### PR DESCRIPTION
## Root cause

Post-merge review of #2715 found two documentation defects:

- four Javadoc contracts described the rejection predicate as “not finite **and** greater than zero,” while the implementation rejects `!Double.isFinite(dt) || dt <= 0.0`;
- the dynamic-simulation skill named a nonexistent `ProcessSystem.runTransient(double dt)` overload.

## Scope and engineering behavior

- Describe invalid timesteps as non-finite **or** not greater than zero in `ProcessSystem` and `ProcessModel` Javadocs.
- Name the actual `ProcessSystem.runTransient()` and `runTransient(double, UUID)` entry points in the dynamic-simulation skill.
- No production statements, signatures, exceptions, tolerances, numerical behavior, state mutation, or public API changed.

## Evidence and validation

The merged #2715 regression covers zero, negative, NaN, and both infinities for direct, adaptive, and two-area model stepping, plus nearby valid 0.25 s and 0.50 s steps. Its final head passed Java 8 and 21 on Ubuntu and Windows, all Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation coverage, CodeQL, skills lint, and PaperLab.

This follow-up changes 10 lines across three documentation-bearing files. GitHub CI is expected to re-run Javadocs, Spotless, pre-commit, skills lint, documentation coverage, and the repository test matrices. No new runtime test is warranted because runtime behavior is unchanged.

## Compatibility and risk

Compatibility risk is negligible: this is documentation-only and makes the stated contract match the existing predicate and real overloads.

## Documentation impact

Javadocs and the NeqSim dynamic-simulation skill are corrected. The user guide already states the finite-positive contract accurately and needs no change.

Related: #2715
