### PR TITLE
fix: reject unconverged column tear solves

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -373,7 +373,7 @@ fraction diagnostics, film/heat-transfer model choices, and equation-oriented re
 
 | Getter | Description |
 |--------|-------------|
-| `solved()` | Current convergence flag. |
+| `solved()` | Current convergence flag, including active side-draw, pumparound, and hydraulic outer tears. |
 | `getLastSolverTypeUsed()` | Concrete solver that completed the latest run, especially useful when requested solver is `AUTO`. |
 | `getLastSolveStatus()` | Strict solve status: rigorous convergence, reconciled products, fallback products, failure, or not run. |
 | `getLastSolveStatusReason()` | Concise explanation for fallback or rejected candidate states. |
@@ -401,6 +401,12 @@ fraction diagnostics, film/heat-transfer model choices, and equation-oriented re
 | `getLastMeshProductDrawResidualNorm()` | Terminal product-draw residual norm. |
 | `getLastMeshSpecificationResidualNorm()` | Active endpoint specification residual norm. |
 | `getLastMeshResidualVector()` | Copy of the complete scaled residual vector. |
+
+An accepted inner tray solution is not sufficient when an outer tear variable is active. If the
+side-draw, pumparound, or hydraulic tear stops or exhausts its iteration budget above tolerance,
+`solved()` returns `false`, `getLastSolveStatus()` returns `FAILED`, and
+`getLastSolveStatusReason()` reports the outer residual, tolerance, and iteration count. Product
+streams remain available for diagnostics but must not be treated as a converged process result.
 
 The MESH residual gate is diagnostic-only for legacy sequential solvers by default. It is effective
 by default for `NAPHTALI_SANDHOLM` and `MESH_RESIDUAL`; call

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1356,12 +1356,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
         updateSideDrawSpecificationResidualsOnly();
         lastColumnTearResidual = Math.max(relativeChange, getMaxSideDrawSpecificationResidual());
         lastColumnTearConverged = lastColumnTearResidual <= tolerance;
+        finalizeColumnTearConvergenceStatus(tolerance);
         return;
       }
       if (!columnTearVariablesChanged) {
         updateSideDrawSpecificationResidualsOnly();
         lastColumnTearResidual = Math.max(relativeChange, getMaxSideDrawSpecificationResidual());
         lastColumnTearConverged = false;
+        finalizeColumnTearConvergenceStatus(tolerance);
         return;
       }
       if (iteration < iterationLimit - 1) {
@@ -1373,6 +1375,33 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     updateSideDrawSpecificationResidualsOnly();
     lastColumnTearResidual = Math.max(lastColumnTearResidual, getMaxSideDrawSpecificationResidual());
     lastColumnTearConverged = lastColumnTearResidual <= tolerance;
+    finalizeColumnTearConvergenceStatus(tolerance);
+  }
+
+  /**
+   * Make an exhausted outer tear authoritative for the public column solve status.
+   *
+   * <p>
+   * Inner tray solvers call {@link #solved()} while the outer tear loop is still active, so the outer gate cannot be
+   * added directly to the generic residual predicate without triggering premature accelerator fallbacks. This method is
+   * called only after an outer convergence decision has been made. It preserves an existing inner failure reason and
+   * converts only an otherwise accepted inner result to a failed coordinated solve.
+   * </p>
+   *
+   * @param tolerance active outer tear-variable tolerance
+   */
+  private void finalizeColumnTearConvergenceStatus(double tolerance) {
+    if (lastColumnTearConverged) {
+      return;
+    }
+    boolean innerSolveAccepted = lastSolveStatus == SolveStatus.RIGOROUS_CONVERGED
+        || lastSolveStatus == SolveStatus.RECONCILED_PRODUCTS;
+    if (!innerSolveAccepted) {
+      return;
+    }
+    lastSolveStatus = SolveStatus.FAILED;
+    lastSolveStatusReason = "Column tear-variable solve did not converge after " + lastColumnTearIterationCount
+        + " iteration(s): residual " + lastColumnTearResidual + " exceeds tolerance " + tolerance;
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -388,6 +388,47 @@ public class ColumnStudyRegressionTest {
   }
 
   /**
+   * Verify that an exhausted pumparound tear solve cannot report the column as solved.
+   *
+   * <p>
+   * The inner tray solve can converge while the outer pumparound return-stream tear remains open. A one-iteration limit
+   * and strict tolerance reproduce that distinction deterministically at two nearby draw fractions.
+   * </p>
+   */
+  @Test
+  public void unconvergedPumparoundTearDoesNotReportSolved() {
+    final double tearTolerance = 1.0e-16;
+    double[] drawFractions = { 0.03, 0.04 };
+    for (int caseIndex = 0; caseIndex < drawFractions.length; caseIndex++) {
+      SystemInterface baseFluid = createBaseFluid();
+      StreamInterface feedStream = createStream("limited_pumparound_main_feed_" + caseIndex, baseFluid,
+          MAIN_FEED_COMPOSITION, MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
+      StreamInterface topFeedStream = createStream("limited_pumparound_top_feed_" + caseIndex, baseFluid,
+          TOP_FEED_COMPOSITION, TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA, TOP_FEED_MASS_FLOW_KG_HR);
+      DistillationColumn column = createColumn(feedStream, topFeedStream);
+      column.addLiquidPumparound("limited column-study pumparound", answerTrayToNeqSimStage(7),
+          answerTrayToNeqSimStage(5), drawFractions[caseIndex], 5.0);
+      column.setMaxColumnTearIterations(1);
+      column.setMaxPumparoundIterations(1);
+      column.setColumnTearTolerance(tearTolerance);
+
+      column.run();
+
+      assertFalse(column.isLastColumnTearConverged(),
+          "one outer iteration should leave the pumparound tear open at draw fraction " + drawFractions[caseIndex]);
+      assertTrue(column.getLastColumnTearResidual() > tearTolerance,
+          "reported tear residual should remain above the configured tolerance");
+      assertFalse(column.solved(), "an open outer tear must make the public solved status false");
+      assertEquals(DistillationColumn.SolveStatus.FAILED, column.getLastSolveStatus(),
+          "an exhausted outer tear must be reported as a failed column solve");
+      assertTrue(column.getLastSolveStatusReason().contains("tear"),
+          "the failure reason should identify the unconverged tear-variable solve");
+      assertPhysicalProduct(column.getGasOutStream(), "limited-pumparound overhead");
+      assertPhysicalProduct(column.getLiquidOutStream(), "limited-pumparound bottoms");
+    }
+  }
+
+  /**
    * Reports cold, unchanged warm, and 10-percent-increased inlet solve times for the column-study case.
    *
    * <p>


### PR DESCRIPTION
## Problem and reproduced control-flow defect

A distillation column with an active side-draw, pumparound, or hydraulic outer tear can exhaust its outer iteration budget while the final inner tray solve remains accepted. On pre-fix `master`, `solveWithColumnTearVariables(...)` records `lastColumnTearConverged = false` but leaves the accepted inner `SolveStatus` unchanged. Because `solved()` checks that status plus inner residual gates, callers can receive `solved() == true` together with `isLastColumnTearConverged() == false`.

The reproduction uses the industrial column-study hydrocarbon case with a liquid pumparound at two nearby draw fractions, 0.03 and 0.04. A one-iteration outer budget and `1e-16` tolerance deterministically leave the tear residual above tolerance while retaining finite diagnostic products.

## Root cause

Outer tear convergence was diagnostic-only. Adding the tear flag directly to the generic `solved()` predicate would be unsafe because accelerator wrappers call `solved()` during inner iterations and could trigger premature fallback before the outer tear has converged.

## Implementation

- Finalize coordinated solve status only after each terminal outer-tear decision.
- Convert only an otherwise accepted inner result to `SolveStatus.FAILED` when the outer tear remains open.
- Preserve existing inner failure status and reasons.
- Report outer iteration count, residual, and tolerance through `getLastSolveStatusReason()`.
- Leave thermodynamic equations, products, iteration algorithms, tolerances, and public signatures unchanged.

## Engineering validation

The two-point regression verifies:

- the outer tear remains demonstrably above the configured tolerance;
- public `solved()` is false and status is `FAILED`;
- the reason identifies the tear failure;
- overhead and bottoms retain finite, positive flows and temperatures with normalized physical compositions.

The neighboring existing converged-pumparound case continues to require both `solved() == true` and `isLastColumnTearConverged() == true`. This is a constant-time terminal status check; no speed claim or numerical-path change is made.

## Validation

Current head `479bb97bfe6674b562cdd486eaefb3aa4cacefc8`, based on `master` `10d12aaf4564be7e6217cf16ef8c2387a56cd73f`, passed:

- Java 21 Ubuntu and Windows fast suites
- all three Java 21 Ubuntu slow-test shards
- Java 8 Ubuntu and Windows downstream tests
- Java 21 Javadocs
- Spotless and pre-commit
- CodeQL
- PaperLab replication gate
- documentation search coverage
- agent/skill cross-reference validation

The branch is three intended commits ahead, zero commits behind, mergeable, and changes exactly the solver, focused regression, and distillation documentation.

## Copilot review disposition

Both technical Copilot findings were accepted and validated:

1. the production status gate is placed after the outer decision, preserving inner fallback behavior;
2. the test uses one local `tearTolerance` constant.

Both findings have validation replies and resolved threads. The post-refresh Copilot review added no suggestion. No Copilot comment is unassessed and no review thread is unresolved.

## Compatibility and risk

No public API, serialization field, thermodynamic equation, product state, solver tolerance, or iteration budget changes. The intentional behavior change is diagnostic correctness: an unconverged coordinated outer tear is no longer advertised as solved. Existing inner failures are not overwritten.

## Documentation impact

Updated `docs/process/equipment/distillation.md` to define that `solved()` includes active side-draw, pumparound, and hydraulic outer-tear convergence, and to document failure diagnostics and diagnostic-only product availability.
