### PR TITLE
Add multi-area host tie-in capacity planning

### DIFF
--- a/docs/fielddevelopment/HOST_TIE_IN_CAPACITY.md
+++ b/docs/fielddevelopment/HOST_TIE_IN_CAPACITY.md
@@ -9,7 +9,8 @@ Brownfield tieback decisions often fail because a host has spare capacity on pap
 
 1. Compare base-host production and satellite production against host nameplate capacities.
 2. Allocate constrained capacity with a clear policy.
-3. Optionally inject accepted production into an attached `ProcessSystem` and check equipment capacity constraints.
+3. Optionally inject accepted production into an attached `ProcessSystem` or multi-area `ProcessModel` and check
+   equipment capacity constraints across the complete host.
 4. Quantify held-back or deferred production and screen a debottleneck investment.
 
 Use this for early DG0-DG2 screening when the question is not only whether a route is hydraulically feasible, but whether the host can process the combined production without unacceptable holdback.
@@ -22,7 +23,7 @@ Use this for early DG0-DG2 screening when the question is not only whether a rou
 | `ProductionProfileSeries` | Ordered base-host or satellite production time series |
 | `CapacityAllocationPolicy` | Allocation rule: `BASE_FIRST`, `SATELLITE_FIRST`, `PRO_RATA`, or `VALUE_WEIGHTED` |
 | `HoldbackPolicy` | Holdback rule: curtail constrained production or defer it to later periods |
-| `HostTieInPoint` | Maps profile rates to a stream flow in an attached `ProcessSystem` |
+| `HostTieInPoint` | Maps profile rates to a stream flow in an attached `ProcessSystem` or `ProcessModel` |
 | `TieInCapacityPlanner` | Runs nameplate, process-capacity, holdback, and debottleneck calculations |
 | `TieInCapacityResult` | Aggregated result with period tables, totals, bottleneck summary, and decisions |
 
@@ -115,6 +116,44 @@ System.out.println(result.getPeriodResults().get(0).getProcessBottleneck());
 ```
 
 The example maps 1.0 MSm3/d gas to 1000 kg/hr. The host stream hard limit is 2500 kg/hr, so the planner accepts about 1.5 MSm3/d of the 4.0 MSm3/d satellite request after considering the base load.
+
+### Multi-Area Brownfield Host
+
+Use a `ProcessModel` when gathering, processing, utilities, and export are separate composable areas. Qualify the tie-in
+stream as `area::streamReference`; returned utilization keys and the limiting equipment retain the same area
+provenance.
+
+```java
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.processmodel.ProcessModel;
+
+ProcessSystem gathering = new ProcessSystem("gathering");
+gathering.add(hostFeed);
+
+Separator inletSeparator = new Separator("Inlet Separator", hostFeed);
+inletSeparator.addCapacityConstraint(
+    new CapacityConstraint("separatorFeedFlow", "kg/hr", ConstraintType.HARD)
+        .setDesignValue(2500.0)
+        .setValueSupplier(() -> hostFeed.getFlowRate("kg/hr")));
+ProcessSystem processing = new ProcessSystem("processing");
+processing.add(inletSeparator);
+
+ProcessModel hostModel = new ProcessModel();
+hostModel.add("gathering", gathering);
+hostModel.add("processing", processing);
+
+HostFacility multiAreaHost = HostFacility.builder("Example Host")
+    .gasCapacity(10.0)
+    .processModel(hostModel)
+    .build();
+HostTieInPoint qualifiedTieIn = new HostTieInPoint("gathering::Host Feed", "kg/hr")
+    .setGasToProcessRateFactor(1000.0);
+```
+
+The planner runs every area for each trial. If the separator is limiting, the period result reports
+`processing::Inlet Separator`; after the study it restores the original host-feed rate and reruns the full model. Bare
+stream names remain supported when unique across all areas. Duplicate bare names fail closed, so parallel trains must
+be addressed explicitly.
 
 ## Allocation Policies
 

--- a/docs/fielddevelopment/HOST_TIE_IN_CAPACITY.md
+++ b/docs/fielddevelopment/HOST_TIE_IN_CAPACITY.md
@@ -124,8 +124,23 @@ stream as `area::streamReference`; returned utilization keys and the limiting eq
 provenance.
 
 ```java
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.fielddevelopment.tieback.HostFacility;
+import neqsim.process.fielddevelopment.tieback.capacity.HostTieInPoint;
 import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+SystemInterface hostFluid = new SystemSrkEos(288.15, 60.0);
+hostFluid.addComponent("methane", 1.0);
+hostFluid.setMixingRule("classic");
+
+final Stream hostFeed = new Stream("Host Feed", hostFluid);
+hostFeed.setFlowRate(1000.0, "kg/hr");
 
 ProcessSystem gathering = new ProcessSystem("gathering");
 gathering.add(hostFeed);

--- a/src/main/java/neqsim/process/fielddevelopment/tieback/HostFacility.java
+++ b/src/main/java/neqsim/process/fielddevelopment/tieback/HostFacility.java
@@ -2,8 +2,10 @@ package neqsim.process.fielddevelopment.tieback;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import neqsim.process.fielddevelopment.evaluation.BottleneckAnalyzer;
 import neqsim.process.fielddevelopment.evaluation.BottleneckAnalyzer.BottleneckResult;
+import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 
 /**
@@ -124,6 +126,9 @@ public class HostFacility implements Serializable {
 
   /** Optional detailed process model for capacity analysis. */
   private transient ProcessSystem processSystem;
+
+  /** Optional detailed multi-area process model for capacity analysis. */
+  private transient ProcessModel processModel;
 
   // ============================================================================
   // ENUMS
@@ -247,9 +252,9 @@ public class HostFacility implements Serializable {
    * Assesses whether the host can accept additional production.
    *
    * <p>
-   * The method first checks the explicit nameplate spare capacities. If a detailed {@link ProcessSystem} is attached,
-   * it also runs {@link BottleneckAnalyzer} and flags active process bottlenecks that could make the nameplate spare
-   * capacity misleading.
+   * The method first checks the explicit nameplate spare capacities. If a detailed {@link ProcessSystem} or
+   * {@link ProcessModel} is attached, it also runs the simulation and flags active process bottlenecks that could make
+   * the nameplate spare capacity misleading.
    * </p>
    *
    * @param additionalGasMSm3d additional gas rate in MSm3/d
@@ -272,7 +277,31 @@ public class HostFacility implements Serializable {
     int activeBottleneckCount = 0;
     String processMessage = "No process model attached";
 
-    if (processSystem != null) {
+    if (processModel != null) {
+      processModelUsed = true;
+      try {
+        processModel.run();
+        neqsim.process.equipment.capacity.BottleneckResult primary = processModel.findBottleneck();
+        Map<String, Double> utilizationSummary = processModel.getCapacityUtilizationSummary();
+        for (Double utilizationPercent : utilizationSummary.values()) {
+          if (utilizationPercent != null && utilizationPercent.doubleValue() >= 95.0) {
+            activeBottleneckCount++;
+          }
+        }
+        if (primary != null && primary.hasBottleneck()) {
+          primaryBottleneckName = getAreaQualifiedBottleneckName(primary);
+          primaryBottleneckUtilization = primary.getUtilization();
+          processOk = primary.getUtilization() < 0.95 && !processModel.isAnyHardLimitExceeded();
+          processMessage = String.format("Primary process bottleneck %s at %.0f%% utilization",
+              primaryBottleneckName, primary.getUtilizationPercent());
+        } else {
+          processMessage = "Process model has no enabled capacity constraints";
+        }
+      } catch (Exception e) {
+        processOk = false;
+        processMessage = "Process model capacity check failed: " + e.getMessage();
+      }
+    } else if (processSystem != null) {
       processModelUsed = true;
       try {
         processSystem.run();
@@ -303,6 +332,22 @@ public class HostFacility implements Serializable {
         additionalGasMSm3d, getSpareGasCapacity(), additionalOilBopd, getSpareOilCapacity(), additionalWaterM3d,
         getSpareWaterCapacity(), additionalLiquidM3d, getSpareLiquidCapacity(), primaryBottleneckName,
         primaryBottleneckUtilization, activeBottleneckCount, summary);
+  }
+
+  /**
+   * Finds the area-qualified name of a ProcessModel bottleneck by equipment identity.
+   *
+   * @param bottleneck plant-wide bottleneck result
+   * @return {@code area::equipment}, or the equipment name when its area cannot be resolved
+   */
+  private String getAreaQualifiedBottleneckName(neqsim.process.equipment.capacity.BottleneckResult bottleneck) {
+    for (String areaName : processModel.getProcessSystemNames()) {
+      ProcessSystem area = processModel.get(areaName);
+      if (area.getUnit(bottleneck.getEquipmentName()) == bottleneck.getEquipment()) {
+        return areaName + "::" + bottleneck.getEquipmentName();
+      }
+    }
+    return bottleneck.getEquipmentName();
   }
 
   /**
@@ -648,6 +693,35 @@ public class HostFacility implements Serializable {
    */
   public void setProcessSystem(ProcessSystem processSystem) {
     this.processSystem = processSystem;
+    if (processSystem != null) {
+      this.processModel = null;
+    }
+  }
+
+  /**
+   * Gets the associated multi-area process model.
+   *
+   * @return process model or null
+   */
+  public ProcessModel getProcessModel() {
+    return processModel;
+  }
+
+  /**
+   * Sets the associated multi-area process model.
+   *
+   * <p>
+   * A host has one detailed simulation basis. Setting a non-null model clears any previously attached
+   * {@link ProcessSystem}; setting a non-null process system likewise clears this model.
+   * </p>
+   *
+   * @param processModel multi-area process model for detailed analysis
+   */
+  public void setProcessModel(ProcessModel processModel) {
+    this.processModel = processModel;
+    if (processModel != null) {
+      this.processSystem = null;
+    }
   }
 
   /**
@@ -1112,6 +1186,17 @@ public class HostFacility implements Serializable {
      */
     public Builder processSystem(ProcessSystem processSystem) {
       facility.setProcessSystem(processSystem);
+      return this;
+    }
+
+    /**
+     * Sets the associated multi-area process model.
+     *
+     * @param processModel process model for plant-wide capacity analysis
+     * @return this builder
+     */
+    public Builder processModel(ProcessModel processModel) {
+      facility.setProcessModel(processModel);
       return this;
     }
 

--- a/src/main/java/neqsim/process/fielddevelopment/tieback/HostFacility.java
+++ b/src/main/java/neqsim/process/fielddevelopment/tieback/HostFacility.java
@@ -292,8 +292,8 @@ public class HostFacility implements Serializable {
           primaryBottleneckName = getAreaQualifiedBottleneckName(primary);
           primaryBottleneckUtilization = primary.getUtilization();
           processOk = primary.getUtilization() < 0.95 && !processModel.isAnyHardLimitExceeded();
-          processMessage = String.format("Primary process bottleneck %s at %.0f%% utilization",
-              primaryBottleneckName, primary.getUtilizationPercent());
+          processMessage = String.format("Primary process bottleneck %s at %.0f%% utilization", primaryBottleneckName,
+              primary.getUtilizationPercent());
         } else {
           processMessage = "Process model has no enabled capacity constraints";
         }

--- a/src/main/java/neqsim/process/fielddevelopment/tieback/capacity/HostTieInPoint.java
+++ b/src/main/java/neqsim/process/fielddevelopment/tieback/capacity/HostTieInPoint.java
@@ -18,7 +18,7 @@ public final class HostTieInPoint implements Serializable {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000L;
 
-  /** Process stream reference, for example "Host Feed" or "HP Sep.gasOut". */
+  /** Process stream reference, for example "Host Feed", "HP Sep.gasOut", or "gathering::Host Feed". */
   private final String processStreamReference;
 
   /** Flow unit used when setting the process stream rate. */
@@ -42,7 +42,8 @@ public final class HostTieInPoint implements Serializable {
   /**
    * Creates a tie-in point for a process stream.
    *
-   * @param processStreamReference stream reference resolved by {@code ProcessSystem}
+   * @param processStreamReference stream reference resolved by {@code ProcessSystem}, or an
+   * {@code area::streamReference} resolved by {@code ProcessModel}
    * @param processRateUnit flow unit used by the target stream
    */
   public HostTieInPoint(String processStreamReference, String processRateUnit) {

--- a/src/main/java/neqsim/process/fielddevelopment/tieback/capacity/TieInCapacityPlanner.java
+++ b/src/main/java/neqsim/process/fielddevelopment/tieback/capacity/TieInCapacityPlanner.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import neqsim.process.equipment.capacity.BottleneckResult;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.fielddevelopment.tieback.HostFacility;
+import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 
 /**
@@ -479,11 +480,18 @@ public class TieInCapacityPlanner implements Serializable {
    * @return process outcome
    */
   private ProcessOutcome evaluateProcessCapacity(ProductionLoad acceptedBase, ProductionLoad acceptedSatellite) {
+    ProcessModel processModel = hostFacility.getProcessModel();
     ProcessSystem processSystem = hostFacility.getProcessSystem();
-    if (processSystem == null || tieInPoint == null) {
+    if ((processModel == null && processSystem == null) || tieInPoint == null) {
       return ProcessOutcome.notUsed();
     }
-    StreamInterface stream = processSystem.resolveStreamReference(tieInPoint.getProcessStreamReference());
+    StreamInterface stream;
+    try {
+      stream = processModel == null ? processSystem.resolveStreamReference(tieInPoint.getProcessStreamReference())
+          : processModel.resolveStreamReference(tieInPoint.getProcessStreamReference());
+    } catch (IllegalArgumentException exception) {
+      return ProcessOutcome.failed(exception.getMessage());
+    }
     if (stream == null) {
       return ProcessOutcome.failed("Missing stream: " + tieInPoint.getProcessStreamReference());
     }
@@ -493,20 +501,57 @@ public class TieInCapacityPlanner implements Serializable {
       originalFlow = stream.getFlowRate(tieInPoint.getProcessRateUnit());
       double targetFlow = calculateTargetProcessRate(originalFlow, acceptedBase, acceptedSatellite);
       stream.setFlowRate(targetFlow, tieInPoint.getProcessRateUnit());
-      processSystem.run();
-      BottleneckResult bottleneck = processSystem.findBottleneck();
-      Map<String, Double> utilizationSummary = processSystem.getCapacityUtilizationSummary();
+      runDetailedModel(processModel, processSystem);
+      BottleneckResult bottleneck = processModel == null ? processSystem.findBottleneck() : processModel.findBottleneck();
+      Map<String, Double> utilizationSummary = processModel == null ? processSystem.getCapacityUtilizationSummary()
+          : processModel.getCapacityUtilizationSummary();
       double utilization = bottleneck.hasBottleneck() ? bottleneck.getUtilization() : 0.0;
-      boolean capacityAvailable = utilization <= processUtilizationLimit && !processSystem.isAnyHardLimitExceeded();
-      return new ProcessOutcome(true, capacityAvailable, bottleneck.getEquipmentName(), utilization,
-          utilizationSummary);
+      boolean hardLimitExceeded = processModel == null ? processSystem.isAnyHardLimitExceeded()
+          : processModel.isAnyHardLimitExceeded();
+      boolean capacityAvailable = utilization <= processUtilizationLimit && !hardLimitExceeded;
+      String bottleneckName = getBottleneckName(processModel, bottleneck);
+      return new ProcessOutcome(true, capacityAvailable, bottleneckName, utilization, utilizationSummary);
     } catch (Exception exception) {
       Map<String, Double> utilizationSummary = new LinkedHashMap<String, Double>();
       return new ProcessOutcome(true, false, "process model error: " + exception.getMessage(), Double.POSITIVE_INFINITY,
           utilizationSummary);
     } finally {
-      restoreProcessStream(processSystem, stream, originalFlow);
+      restoreProcessStream(processModel, processSystem, stream, originalFlow);
     }
+  }
+
+  /**
+   * Runs the attached detailed host simulation.
+   *
+   * @param processModel optional multi-area process model
+   * @param processSystem optional single process system
+   */
+  private void runDetailedModel(ProcessModel processModel, ProcessSystem processSystem) {
+    if (processModel != null) {
+      processModel.run();
+    } else {
+      processSystem.run();
+    }
+  }
+
+  /**
+   * Gets an area-qualified bottleneck name for a multi-area model.
+   *
+   * @param processModel optional multi-area process model
+   * @param bottleneck plant-wide bottleneck result
+   * @return equipment name, area-qualified for a multi-area model
+   */
+  private String getBottleneckName(ProcessModel processModel, BottleneckResult bottleneck) {
+    if (processModel == null || !bottleneck.hasBottleneck()) {
+      return bottleneck.getEquipmentName();
+    }
+    for (String areaName : processModel.getProcessSystemNames()) {
+      ProcessSystem area = processModel.get(areaName);
+      if (area.getUnit(bottleneck.getEquipmentName()) == bottleneck.getEquipment()) {
+        return areaName + "::" + bottleneck.getEquipmentName();
+      }
+    }
+    return bottleneck.getEquipmentName();
   }
 
   /**
@@ -530,17 +575,19 @@ public class TieInCapacityPlanner implements Serializable {
   /**
    * Restores the process stream after a trial process-model run.
    *
-   * @param processSystem process system containing the stream
+   * @param processModel optional multi-area process model containing the stream
+   * @param processSystem optional single process system containing the stream
    * @param stream stream to restore
    * @param originalFlow original flow rate in the tie-in point rate unit
    */
-  private void restoreProcessStream(ProcessSystem processSystem, StreamInterface stream, double originalFlow) {
+  private void restoreProcessStream(ProcessModel processModel, ProcessSystem processSystem, StreamInterface stream,
+      double originalFlow) {
     if (Double.isNaN(originalFlow)) {
       return;
     }
     try {
       stream.setFlowRate(originalFlow, tieInPoint.getProcessRateUnit());
-      processSystem.run();
+      runDetailedModel(processModel, processSystem);
     } catch (Exception exception) {
       // The planner result already records process-model errors from the trial run.
     }

--- a/src/main/java/neqsim/process/fielddevelopment/tieback/capacity/TieInCapacityPlanner.java
+++ b/src/main/java/neqsim/process/fielddevelopment/tieback/capacity/TieInCapacityPlanner.java
@@ -502,7 +502,8 @@ public class TieInCapacityPlanner implements Serializable {
       double targetFlow = calculateTargetProcessRate(originalFlow, acceptedBase, acceptedSatellite);
       stream.setFlowRate(targetFlow, tieInPoint.getProcessRateUnit());
       runDetailedModel(processModel, processSystem);
-      BottleneckResult bottleneck = processModel == null ? processSystem.findBottleneck() : processModel.findBottleneck();
+      BottleneckResult bottleneck = processModel == null ? processSystem.findBottleneck()
+          : processModel.findBottleneck();
       Map<String, Double> utilizationSummary = processModel == null ? processSystem.getCapacityUtilizationSummary()
           : processModel.getCapacityUtilizationSummary();
       double utilization = bottleneck.hasBottleneck() ? bottleneck.getUtilization() : 0.0;

--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -973,6 +973,54 @@ public class ProcessModel implements Runnable, Serializable {
   }
 
   /**
+   * Resolves a stream reference across the process areas in this model.
+   *
+   * <p>
+   * Area-qualified references use {@code "area::streamRef"}, where {@code streamRef} follows
+   * {@link ProcessSystem#resolveStreamReference(String)} conventions such as {@code feed},
+   * {@code separator.gasOut}, or {@code splitter.split0}. An unqualified reference is accepted only when exactly one
+   * process area resolves it. If multiple areas contain the same unqualified reference, this method throws so callers
+   * cannot silently modify the wrong train.
+   * </p>
+   *
+   * @param reference area-qualified or unqualified stream reference
+   * @return resolved stream, or {@code null} when the area or stream does not exist
+   * @throws IllegalArgumentException if an unqualified reference matches more than one process area
+   */
+  public StreamInterface resolveStreamReference(String reference) {
+    if (reference == null || reference.trim().isEmpty()) {
+      return null;
+    }
+    String normalizedReference = reference.trim();
+    int areaSeparator = normalizedReference.indexOf("::");
+    if (areaSeparator >= 0) {
+      String areaName = normalizedReference.substring(0, areaSeparator).trim();
+      String localReference = normalizedReference.substring(areaSeparator + 2).trim();
+      if (areaName.isEmpty() || localReference.isEmpty()) {
+        return null;
+      }
+      ProcessSystem processSystem = processes.get(areaName);
+      return processSystem == null ? null : processSystem.resolveStreamReference(localReference);
+    }
+
+    StreamInterface resolved = null;
+    String resolvedArea = null;
+    for (Map.Entry<String, ProcessSystem> entry : processes.entrySet()) {
+      StreamInterface candidate = entry.getValue().resolveStreamReference(normalizedReference);
+      if (candidate == null) {
+        continue;
+      }
+      if (resolved != null) {
+        throw new IllegalArgumentException("Ambiguous stream reference '" + normalizedReference + "' in areas '"
+            + resolvedArea + "' and '" + entry.getKey() + "'; use area::streamRef");
+      }
+      resolved = candidate;
+      resolvedArea = entry.getKey();
+    }
+    return resolved;
+  }
+
+  /**
    * Returns the aggregated structured outcome of the most recent run across all process areas.
    *
    * <p>

--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -977,10 +977,10 @@ public class ProcessModel implements Runnable, Serializable {
    *
    * <p>
    * Area-qualified references use {@code "area::streamRef"}, where {@code streamRef} follows
-   * {@link ProcessSystem#resolveStreamReference(String)} conventions such as {@code feed},
-   * {@code separator.gasOut}, or {@code splitter.split0}. An unqualified reference is accepted only when exactly one
-   * process area resolves it. If multiple areas contain the same unqualified reference, this method throws so callers
-   * cannot silently modify the wrong train.
+   * {@link ProcessSystem#resolveStreamReference(String)} conventions such as {@code feed}, {@code separator.gasOut}, or
+   * {@code splitter.split0}. An unqualified reference is accepted only when exactly one process area resolves it. If
+   * multiple areas contain the same unqualified reference, this method throws so callers cannot silently modify the
+   * wrong train.
    * </p>
    *
    * @param reference area-qualified or unqualified stream reference

--- a/src/test/java/neqsim/process/fielddevelopment/tieback/capacity/TieInCapacityPlannerTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/tieback/capacity/TieInCapacityPlannerTest.java
@@ -2,12 +2,17 @@ package neqsim.process.fielddevelopment.tieback.capacity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
+import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.fielddevelopment.tieback.HostFacility;
+import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -107,6 +112,72 @@ class TieInCapacityPlannerTest {
     assertTrue(period.getHeldBackSatellite().getGasRateMSm3d() > 2.49);
     assertEquals(1000.0, hostFeed.getFlowRate("kg/hr"), 1.0e-6);
     assertFalse(result.getDebottleneckDecisions().isEmpty());
+  }
+
+  /**
+   * Verifies a multi-area host model applies the satellite at an area-qualified stream, finds the downstream
+   * bottleneck, and restores the complete model to its original operating point.
+   */
+  @Test
+  void multiAreaProcessModelFindsDownstreamBottleneckAndRestoresFeedRate() {
+    final Stream hostFeed = createHostFeed();
+    ProcessSystem gathering = new ProcessSystem("gathering");
+    gathering.add(hostFeed);
+
+    final Separator hostSeparator = new Separator("Host Separator", hostFeed);
+    hostSeparator.addCapacityConstraint(new CapacityConstraint("separatorFeedFlow", "kg/hr", ConstraintType.HARD)
+        .setDesignValue(2500.0).setValueSupplier(() -> hostFeed.getFlowRate("kg/hr")));
+    ProcessSystem processing = new ProcessSystem("processing");
+    processing.add(hostSeparator);
+
+    ProcessModel model = new ProcessModel();
+    model.add("gathering", gathering);
+    model.add("processing", processing);
+    model.run();
+
+    HostFacility host = HostFacility.builder("Host E").gasCapacity(10.0).processModel(model).build();
+    ProductionProfileSeries base = new ProductionProfileSeries("base").addPeriod(2028, 1.0, 0.0, 0.0, 0.0);
+    ProductionProfileSeries satellite = new ProductionProfileSeries("satellite").addPeriod(2028, 4.0, 0.0, 0.0, 0.0);
+    HostTieInPoint tieInPoint = new HostTieInPoint("gathering::Host Feed", "kg/hr")
+        .setGasToProcessRateFactor(1000.0);
+
+    TieInCapacityResult result = new TieInCapacityPlanner(host).setHostProductionProfile(base)
+        .setSatelliteProductionProfile(satellite).setTieInPoint(tieInPoint).setProcessUtilizationLimit(1.0).run();
+
+    TieInPeriodResult period = result.getPeriodResults().get(0);
+    assertTrue(period.isProcessModelUsed());
+    assertEquals("processing::Host Separator", period.getProcessBottleneck());
+    assertTrue(period.getProcessUtilizationSummary().containsKey("processing::Host Separator"));
+    assertTrue(period.getAcceptedSatellite().getGasRateMSm3d() > 1.49);
+    assertTrue(period.getAcceptedSatellite().getGasRateMSm3d() < 1.51);
+    assertEquals(1000.0, hostFeed.getFlowRate("kg/hr"), 1.0e-6);
+    assertEquals(1000.0, hostSeparator.getGasOutStream().getFlowRate("kg/hr"), 1.0e-6);
+
+    HostFacility.HostCapacityReport restoredReport = host.assessCapacity(0.0, 0.0, 0.0, 0.0);
+    assertTrue(restoredReport.isProcessModelUsed());
+    assertEquals("processing::Host Separator", restoredReport.getPrimaryBottleneckName());
+    assertEquals(0.4, restoredReport.getPrimaryBottleneckUtilization(), 1.0e-6);
+  }
+
+  /**
+   * Verifies ProcessModel stream addressing is deterministic and rejects ambiguous bare names.
+   */
+  @Test
+  void processModelStreamResolutionRequiresQualificationForDuplicateNames() {
+    Stream firstFeed = createHostFeed();
+    Stream secondFeed = createHostFeed();
+    ProcessSystem firstArea = new ProcessSystem("first");
+    firstArea.add(firstFeed);
+    ProcessSystem secondArea = new ProcessSystem("second");
+    secondArea.add(secondFeed);
+    ProcessModel model = new ProcessModel();
+    model.add("first", firstArea);
+    model.add("second", secondArea);
+
+    assertSame(firstFeed, model.resolveStreamReference("first::Host Feed"));
+    assertNull(model.resolveStreamReference("missing::Host Feed"));
+    assertNull(model.resolveStreamReference("first::Missing Feed"));
+    assertThrows(IllegalArgumentException.class, () -> model.resolveStreamReference("Host Feed"));
   }
 
   /**

--- a/src/test/java/neqsim/process/fielddevelopment/tieback/capacity/TieInCapacityPlannerTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/tieback/capacity/TieInCapacityPlannerTest.java
@@ -138,8 +138,7 @@ class TieInCapacityPlannerTest {
     HostFacility host = HostFacility.builder("Host E").gasCapacity(10.0).processModel(model).build();
     ProductionProfileSeries base = new ProductionProfileSeries("base").addPeriod(2028, 1.0, 0.0, 0.0, 0.0);
     ProductionProfileSeries satellite = new ProductionProfileSeries("satellite").addPeriod(2028, 4.0, 0.0, 0.0, 0.0);
-    HostTieInPoint tieInPoint = new HostTieInPoint("gathering::Host Feed", "kg/hr")
-        .setGasToProcessRateFactor(1000.0);
+    HostTieInPoint tieInPoint = new HostTieInPoint("gathering::Host Feed", "kg/hr").setGasToProcessRateFactor(1000.0);
 
     TieInCapacityResult result = new TieInCapacityPlanner(host).setHostProductionProfile(base)
         .setSatelliteProductionProfile(satellite).setTieInPoint(tieInPoint).setProcessUtilizationLimit(1.0).run();


### PR DESCRIPTION
## Production-engineering value

Brownfield tie-in studies can now attach a composable, multi-area `ProcessModel` to a `HostFacility`. The planner applies each candidate at an area-qualified stream, evaluates constraints across gathering, processing, utilities, and export areas, reports the limiting unit with area provenance, and restores the full host model after every trial.

This is a dependency for a small set of maintained NeqSim-Colab examples covering new-reservoir tie-ins, bottleneck identification, and upgrade planning.

## Baseline and measured target

- Base: `93561c004dbac3b82bf0c271874a4a8e1637efbd`
- Previous limitation: `TieInCapacityPlanner` accepted only one `ProcessSystem`; no public multi-area stream resolver existed.
- Analytical regression: 1,000 kg/h host base + 2,500 kg/h downstream HARD limit with 1,000 kg/h per MSm3/d mapping gives exactly 1.5 MSm3/d satellite ullage.
- Acceptance band: 1.49-1.51 MSm3/d, bottleneck `processing::Host Separator`, and restored host and separator outlet rates of 1,000 kg/h.

## Implementation

- Adds `ProcessModel.resolveStreamReference()` with `area::streamRef` syntax.
- Allows bare references only when unique; duplicate names fail closed.
- Adds mutually exclusive `processModel(...)` and existing `processSystem(...)` detailed-host associations.
- Reuses plant-wide `findBottleneck()`, utilization summaries, and hard-limit checks.
- Restores the original tie-in flow in `finally` and reruns the complete detailed model.
- Extends `HostFacility.assessCapacity()` to report area-qualified multi-area bottlenecks.

## Tests and validation

Added focused regressions for:

- two connected process areas with the limiting equipment downstream of the tie-in area;
- analytical satellite acceptance and holdback;
- area-qualified utilization and bottleneck provenance;
- live-model state restoration and rerun;
- deterministic qualified resolution, missing references, and ambiguous bare-name rejection;
- continued coverage of the existing single-`ProcessSystem` path.

Local `git diff --check` passes. Local Maven execution was attempted with:

```text
MAVEN_USER_HOME=/tmp/neqsim-prodopt-maven ./mvnw \
  -Dmaven.repo.local=/tmp/neqsim-prodopt-maven/repository \
  test -Dtest=TieInCapacityPlannerTest
```

The sandbox had no Maven dependency cache and could not resolve Maven Central, so compilation did not start. This draft PR is intentionally left draft while repository CI performs the reproducible Java, Javadoc, formatting, and regression gates. No test criterion has been weakened.

## Accuracy and compatibility review

- The regression uses an explicit synthetic HARD flow constraint and an independent analytical target; it does not claim validation of a separator design correlation.
- Existing thermodynamics, conservation equations, equipment solvers, and capacity strategies are unchanged.
- The public API change is additive; existing `processSystem(...)` behavior remains.
- Multi-area execution cost is proportional to the existing bounded 24-iteration bisection and is required to capture coupled downstream constraints.
- The existing monotonic-feasibility assumption of the bisection remains; non-monotonic operating envelopes require a different optimizer.

## Documentation impact

Updated Javadocs and `HOST_TIE_IN_CAPACITY.md` with multi-area addressing, bottleneck provenance, state restoration, and a brownfield example. No notebook is changed in this PR: the multi-area API is the prerequisite, and the follow-up NeqSim-Colab notebook must be cleanly executed and visually verified against a released or branch-built NeqSim artifact.

## Scope exclusions and next step

Excluded compressor-map physics, anti-surge control, new optimization algorithms, economics changes, and notebook publication. After this foundation passes, the next dependency-ordered change is a canonical NeqSim-Colab brownfield tie-in notebook linked from the examples page, using a realistic synthetic reservoir/well/gathering/host/export chain and comparing installed capacity with an upgrade case.

Never merge or enable auto-merge from this automation.