### PR TITLE
fix: preserve TwoFluidPipe steady-to-transient handoff

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -395,7 +395,9 @@ model-development work.
 
 At the steady-to-transient handoff, `run()` converts the final pressure, phase-holdup, density, and
 velocity profiles into conservative phase mass, momentum, and energy exactly once. This conversion
-defines the initial condition and advances no simulation time. After the transient solve starts,
+defines the initial condition and advances no simulation time. For three-phase flow, the oil and
+water momenta retain the independent phase velocities from the steady slip closure rather than being
+collapsed to the bulk-liquid velocity. After the transient solve starts,
 the conservative phase masses own cell inventory. A stream-connected inlet may update boundary
 composition and velocity for its inlet flux, but it must not replace the first finite-volume cell's
 oil or water mass. This prevents an unchanged, near-zero-time handoff from producing an inventory or

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -393,6 +393,14 @@ Auxiliary terrain and slug trackers may maintain primitive diagnostics, but they
 finite-volume phase masses. Conservative source or flux coupling for those trackers remains future
 model-development work.
 
+At the steady-to-transient handoff, `run()` converts the final pressure, phase-holdup, density, and
+velocity profiles into conservative phase mass, momentum, and energy exactly once. This conversion
+defines the initial condition and advances no simulation time. After the transient solve starts,
+the conservative phase masses own cell inventory. A stream-connected inlet may update boundary
+composition and velocity for its inlet flux, but it must not replace the first finite-volume cell's
+oil or water mass. This prevents an unchanged, near-zero-time handoff from producing an inventory or
+holdup jump that scales with pipe volume.
+
 For a domain with no external mass source, validate the discrete balance
 
 $$

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -1086,6 +1086,8 @@ public class TwoFluidPipe extends Pipeline {
    * <li><b>Phase 2 — Iterative refinement:</b> Under-relaxed fixed-point iteration with sparse flash updates (every
    * {@code ssFlashInterval} iterations) to account for condensation effects. Includes a wall-clock time guard to
    * prevent infinite run times.</li>
+   * <li><b>Transient handoff:</b> Converts the final primitive profiles to conservative phase mass, momentum, and
+   * energy once, so the first transient step starts from the reported steady state.</li>
    * </ul>
    */
   private void runSteadyState() {
@@ -1372,6 +1374,13 @@ public class TwoFluidPipe extends Pipeline {
     // Update outlet pressure from converged profile (if not user-specified)
     if (!outletPressureSet) {
       outletPressure = sections[numberOfSections - 1].getPressure();
+    }
+
+    // The steady solver works in primitive pressure, holdup, and velocity variables.
+    // Initialize the finite-volume state from the final converged primitives exactly once,
+    // before the transient solver makes conservative phase mass authoritative.
+    for (TwoFluidSection sec : sections) {
+      sec.updateConservativeVariables();
     }
 
     // Store initial profiles
@@ -3995,13 +4004,9 @@ public class TwoFluidPipe extends Pipeline {
       inlet.setWaterHoldup(alphaW_target);
       inlet.setOilHoldup(alphaO_target);
 
-      // Update mass per length to be consistent with holdups
-      inlet.setWaterMassPerLength(alphaW_target * rhoWater * area);
-      inlet.setOilMassPerLength(alphaO_target * rhoOil * area);
-
-      // Update momentum to be consistent with velocities
-      // Note: We do NOT reset the mass per length here - that would violate mass conservation
-      // The solver evolves the mass, we only set velocities for flux calculation
+      // The inlet flux uses these primitive boundary values. Do not overwrite the
+      // finite-volume phase masses: they are cell inventory advanced by the PDE.
+      // Replacing them here would create a domain-volume-scaled mass impulse.
       inlet.setGasMomentumPerLength(inlet.getGasMassPerLength() * inlet.getGasVelocity());
       inlet.setOilMomentumPerLength(inlet.getOilMassPerLength() * inlet.getOilVelocity());
       inlet.setWaterMomentumPerLength(inlet.getWaterMassPerLength() * inlet.getWaterVelocity());

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -1380,7 +1380,18 @@ public class TwoFluidPipe extends Pipeline {
     // Initialize the finite-volume state from the final converged primitives exactly once,
     // before the transient solver makes conservative phase mass authoritative.
     for (TwoFluidSection sec : sections) {
+      double oilVelocity = sec.getOilVelocity();
+      double waterVelocity = sec.getWaterVelocity();
       sec.updateConservativeVariables();
+      if (sec.getOilHoldup() > 1.0e-12 && sec.getWaterHoldup() > 1.0e-12) {
+        // Preserve the independent phase velocities produced by the three-phase steady closure;
+        // updateConservativeVariables() otherwise initializes both momenta from bulk-liquid velocity.
+        double oilMomentum = sec.getOilMassPerLength() * oilVelocity;
+        double waterMomentum = sec.getWaterMassPerLength() * waterVelocity;
+        sec.setOilMomentumPerLength(oilMomentum);
+        sec.setWaterMomentumPerLength(waterMomentum);
+        sec.setLiquidMomentumPerLength(oilMomentum + waterMomentum);
+      }
     }
 
     // Store initial profiles

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -419,6 +419,13 @@ class TwoFluidPipeBoundaryConditionTest {
     }
   }
 
+  @Test
+  @DisplayName("Steady-state handoff preserves inventory and avoids an O(1) hydraulic jump")
+  void testSteadyStateToTransientHandoffIsContinuous() {
+    assertSteadyStateToTransientHandoffIsContinuous("two-phase", createTwoPhaseFluid(), 6.0, 75.0, 58.0);
+    assertSteadyStateToTransientHandoffIsContinuous("three-phase", createThreePhaseFluid(), 6.0, 80.0, 60.0);
+  }
+
   // =====================================================================
   // Stationary and Transient Boundary Regression Tests
   // =====================================================================
@@ -586,6 +593,55 @@ class TwoFluidPipeBoundaryConditionTest {
     regressionPipe.setCflNumber(0.8);
     regressionPipe.setSteadyStateMaxWallClockTime(1.0);
     return regressionPipe;
+  }
+
+  /**
+   * Verify that switching numerical modes without changing a boundary does not introduce an O(1) state jump.
+   *
+   * @param name case name
+   * @param fluid inlet fluid
+   * @param flowRateKgSec flow rate in kg/s
+   * @param inletPressureBara inlet pressure in bara
+   * @param outletPressureBara outlet pressure in bara
+   */
+  private void assertSteadyStateToTransientHandoffIsContinuous(String name, SystemInterface fluid,
+      double flowRateKgSec, double inletPressureBara, double outletPressureBara) {
+    TwoFluidPipe handoffPipe = createRegressionPipe(name + "-handoff", fluid, flowRateKgSec, inletPressureBara,
+        outletPressureBara);
+    handoffPipe.setThermodynamicUpdateInterval(Integer.MAX_VALUE);
+    handoffPipe.run();
+
+    double[] pressureBefore = handoffPipe.getPressureProfile();
+    double[] liquidHoldupBefore = handoffPipe.getLiquidHoldupProfile();
+    double[] gasVelocityBefore = handoffPipe.getGasVelocityProfile();
+    double[] liquidVelocityBefore = handoffPipe.getLiquidVelocityProfile();
+    double massBefore = handoffPipe.getTotalMassInventory();
+
+    double timeStep = 1.0e-9;
+    UUID calculationId = UUID.fromString("00000000-0000-0000-0000-000000002723");
+    handoffPipe.runTransient(timeStep, calculationId);
+
+    double pressureRmsPa = rmsDifference(handoffPipe.getPressureProfile(), pressureBefore);
+    double liquidHoldupRms = rmsDifference(handoffPipe.getLiquidHoldupProfile(), liquidHoldupBefore);
+    double gasVelocityRms = rmsDifference(handoffPipe.getGasVelocityProfile(), gasVelocityBefore);
+    double liquidVelocityRms = rmsDifference(handoffPipe.getLiquidVelocityProfile(), liquidVelocityBefore);
+    double massChangeKg = Math.abs(handoffPipe.getTotalMassInventory() - massBefore);
+
+    logger.printf(org.apache.logging.log4j.Level.INFO,
+        "%s steady/transient handoff: pressure RMS %.6f Pa, holdup RMS %.9f, "
+            + "gas velocity RMS %.9f m/s, liquid velocity RMS %.9f m/s, mass change %.9g kg%n",
+        name, pressureRmsPa, liquidHoldupRms, gasVelocityRms, liquidVelocityRms, massChangeKg);
+
+    assertTrue(pressureRmsPa <= 500.0,
+        name + " pressure changed sharply across an unchanged near-zero-time handoff: RMS " + pressureRmsPa + " Pa");
+    assertTrue(liquidHoldupRms <= 1.0e-7,
+        name + " liquid holdup changed across an unchanged near-zero-time handoff: RMS " + liquidHoldupRms);
+    assertTrue(gasVelocityRms <= 0.10,
+        name + " gas velocity changed across an unchanged near-zero-time handoff: RMS " + gasVelocityRms + " m/s");
+    assertTrue(liquidVelocityRms <= 0.05, name
+        + " liquid velocity changed across an unchanged near-zero-time handoff: RMS " + liquidVelocityRms + " m/s");
+    assertTrue(massChangeKg <= 4.0 * flowRateKgSec * timeStep,
+        name + " domain mass changed faster than the boundary-flux envelope: " + massChangeKg + " kg");
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -632,9 +632,11 @@ class TwoFluidPipeBoundaryConditionTest {
     double liquidVelocityRms = rmsDifference(handoffPipe.getLiquidVelocityProfile(), liquidVelocityBefore);
     boolean hasOilWaterSlip = "three-phase".equals(name);
     double oilVelocityRms = hasOilWaterSlip
-        ? rmsDifferenceInterior(handoffPipe.getOilVelocityProfile(), oilVelocityBefore) : 0.0;
+        ? rmsDifferenceInterior(handoffPipe.getOilVelocityProfile(), oilVelocityBefore)
+        : 0.0;
     double waterVelocityRms = hasOilWaterSlip
-        ? rmsDifferenceInterior(handoffPipe.getWaterVelocityProfile(), waterVelocityBefore) : 0.0;
+        ? rmsDifferenceInterior(handoffPipe.getWaterVelocityProfile(), waterVelocityBefore)
+        : 0.0;
     double massChangeKg = Math.abs(handoffPipe.getTotalMassInventory() - massBefore);
 
     logger.printf(org.apache.logging.log4j.Level.INFO,
@@ -655,12 +657,12 @@ class TwoFluidPipeBoundaryConditionTest {
     if (hasOilWaterSlip) {
       assertTrue(rmsDifferenceInterior(oilVelocityBefore, waterVelocityBefore) > 1.0e-3,
           "Three-phase regression case must exercise non-zero oil/water slip");
-      assertTrue(oilVelocityRms <= 1.0e-4, name
-          + " interior oil velocity changed across an unchanged near-zero-time handoff: RMS " + oilVelocityRms
-          + " m/s");
-      assertTrue(waterVelocityRms <= 1.0e-4, name
-          + " interior water velocity changed across an unchanged near-zero-time handoff: RMS " + waterVelocityRms
-          + " m/s");
+      assertTrue(oilVelocityRms <= 1.0e-4,
+          name + " interior oil velocity changed across an unchanged near-zero-time handoff: RMS " + oilVelocityRms
+              + " m/s");
+      assertTrue(waterVelocityRms <= 1.0e-4,
+          name + " interior water velocity changed across an unchanged near-zero-time handoff: RMS " + waterVelocityRms
+              + " m/s");
     }
     assertTrue(massChangeKg <= 4.0 * flowRateKgSec * timeStep,
         name + " domain mass changed faster than the boundary-flux envelope: " + massChangeKg + " kg");

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -608,6 +608,9 @@ class TwoFluidPipeBoundaryConditionTest {
       double inletPressureBara, double outletPressureBara) {
     TwoFluidPipe handoffPipe = createRegressionPipe(name + "-handoff", fluid, flowRateKgSec, inletPressureBara,
         outletPressureBara);
+    if ("three-phase".equals(name)) {
+      handoffPipe.setElevationProfile(new double[] { 0.0, 0.1, 0.2, 0.3, 0.4, 0.5 });
+    }
     handoffPipe.setThermodynamicUpdateInterval(Integer.MAX_VALUE);
     handoffPipe.run();
 
@@ -615,6 +618,8 @@ class TwoFluidPipeBoundaryConditionTest {
     double[] liquidHoldupBefore = handoffPipe.getLiquidHoldupProfile();
     double[] gasVelocityBefore = handoffPipe.getGasVelocityProfile();
     double[] liquidVelocityBefore = handoffPipe.getLiquidVelocityProfile();
+    double[] oilVelocityBefore = handoffPipe.getOilVelocityProfile();
+    double[] waterVelocityBefore = handoffPipe.getWaterVelocityProfile();
     double massBefore = handoffPipe.getTotalMassInventory();
 
     double timeStep = 1.0e-9;
@@ -625,12 +630,19 @@ class TwoFluidPipeBoundaryConditionTest {
     double liquidHoldupRms = rmsDifference(handoffPipe.getLiquidHoldupProfile(), liquidHoldupBefore);
     double gasVelocityRms = rmsDifference(handoffPipe.getGasVelocityProfile(), gasVelocityBefore);
     double liquidVelocityRms = rmsDifference(handoffPipe.getLiquidVelocityProfile(), liquidVelocityBefore);
+    boolean hasOilWaterSlip = "three-phase".equals(name);
+    double oilVelocityRms = hasOilWaterSlip
+        ? rmsDifferenceInterior(handoffPipe.getOilVelocityProfile(), oilVelocityBefore) : 0.0;
+    double waterVelocityRms = hasOilWaterSlip
+        ? rmsDifferenceInterior(handoffPipe.getWaterVelocityProfile(), waterVelocityBefore) : 0.0;
     double massChangeKg = Math.abs(handoffPipe.getTotalMassInventory() - massBefore);
 
     logger.printf(org.apache.logging.log4j.Level.INFO,
         "%s steady/transient handoff: pressure RMS %.6f Pa, holdup RMS %.9f, "
-            + "gas velocity RMS %.9f m/s, liquid velocity RMS %.9f m/s, mass change %.9g kg%n",
-        name, pressureRmsPa, liquidHoldupRms, gasVelocityRms, liquidVelocityRms, massChangeKg);
+            + "gas velocity RMS %.9f m/s, liquid velocity RMS %.9f m/s, oil velocity RMS %.9f m/s, "
+            + "water velocity RMS %.9f m/s, mass change %.9g kg%n",
+        name, pressureRmsPa, liquidHoldupRms, gasVelocityRms, liquidVelocityRms, oilVelocityRms, waterVelocityRms,
+        massChangeKg);
 
     assertTrue(pressureRmsPa <= 500.0,
         name + " pressure changed sharply across an unchanged near-zero-time handoff: RMS " + pressureRmsPa + " Pa");
@@ -640,6 +652,16 @@ class TwoFluidPipeBoundaryConditionTest {
         name + " gas velocity changed across an unchanged near-zero-time handoff: RMS " + gasVelocityRms + " m/s");
     assertTrue(liquidVelocityRms <= 0.05, name
         + " liquid velocity changed across an unchanged near-zero-time handoff: RMS " + liquidVelocityRms + " m/s");
+    if (hasOilWaterSlip) {
+      assertTrue(rmsDifferenceInterior(oilVelocityBefore, waterVelocityBefore) > 1.0e-3,
+          "Three-phase regression case must exercise non-zero oil/water slip");
+      assertTrue(oilVelocityRms <= 1.0e-4, name
+          + " interior oil velocity changed across an unchanged near-zero-time handoff: RMS " + oilVelocityRms
+          + " m/s");
+      assertTrue(waterVelocityRms <= 1.0e-4, name
+          + " interior water velocity changed across an unchanged near-zero-time handoff: RMS " + waterVelocityRms
+          + " m/s");
+    }
     assertTrue(massChangeKg <= 4.0 * flowRateKgSec * timeStep,
         name + " domain mass changed faster than the boundary-flux envelope: " + massChangeKg + " kg");
   }
@@ -952,6 +974,23 @@ class TwoFluidPipeBoundaryConditionTest {
       sumSquares += diff * diff;
     }
     return Math.sqrt(sumSquares / length);
+  }
+
+  /**
+   * Calculate RMS difference over finite-volume interior cells, excluding boundary cells.
+   *
+   * @param left first profile
+   * @param right second profile
+   * @return interior RMS difference
+   */
+  private double rmsDifferenceInterior(double[] left, double[] right) {
+    int length = Math.min(left.length, right.length);
+    double sumSquares = 0.0;
+    for (int i = 1; i < length - 1; i++) {
+      double diff = left[i] - right[i];
+      sumSquares += diff * diff;
+    }
+    return Math.sqrt(sumSquares / (length - 2));
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -604,8 +604,8 @@ class TwoFluidPipeBoundaryConditionTest {
    * @param inletPressureBara inlet pressure in bara
    * @param outletPressureBara outlet pressure in bara
    */
-  private void assertSteadyStateToTransientHandoffIsContinuous(String name, SystemInterface fluid,
-      double flowRateKgSec, double inletPressureBara, double outletPressureBara) {
+  private void assertSteadyStateToTransientHandoffIsContinuous(String name, SystemInterface fluid, double flowRateKgSec,
+      double inletPressureBara, double outletPressureBara) {
     TwoFluidPipe handoffPipe = createRegressionPipe(name + "-handoff", fluid, flowRateKgSec, inletPressureBara,
         outletPressureBara);
     handoffPipe.setThermodynamicUpdateInterval(Integer.MAX_VALUE);


### PR DESCRIPTION
## Summary

Preserve the reported `TwoFluidPipe` steady-state solution when switching to transient integration.

The steady solver works in primitive pressure, holdup, density, and velocity variables. The transient solver reads conservative phase mass, momentum, and energy. Current `master` never synchronized the final steady primitives into that conservative state, although `TwoFluidConservationEquations.extractState()` explicitly assumed that synchronization existed. The default `STREAM_CONNECTED` inlet then also rebuilt oil and water mass in the first finite-volume cell after each substep.

The result was an O(1) numerical mode-switch disturbance even when no boundary changed and only 1 ns elapsed.

Related to the steady/dynamic consistency and conservation acceptance criteria in #2705. This PR intentionally does not close that broader issue.

## Reproducible baseline

Deterministic public-fluid cases used SRK with classic mixing rules, 300 m pipe length, 0.15 m diameter, six sections, fixed outlet pressure, unchanged inlet, and a 1e-9 s first transient step.

| Case | Pressure RMS | Liquid-holdup RMS | Gas-velocity RMS | Liquid-velocity RMS | Artificial inventory change |
|---|---:|---:|---:|---:|---:|
| Gas-condensate, master | 1,534 Pa | 0.020732 | 0.605 m/s | 1.307 m/s | 12.861 kg |
| Gas-oil-water, master | 3,172 Pa | 0.019984 | 0.565 m/s | 0.0669 m/s | 11.251 kg |

A 12-section, 1e-6 s nearby check reproduced the same O(1) signature: 0.02039-0.02001 holdup RMS and 5.63-6.43 kg inventory change. The disturbance therefore did not scale with elapsed time and was not a physical transient.

## Implementation

- Convert the final steady primitive profiles to conservative phase mass, momentum, and energy exactly once at the end of `runSteadyState()`.
- Preserve the independent oil and water velocities from the three-phase steady slip closure when initializing phase momenta.
- Keep conservative phase mass authoritative after transient integration starts.
- Stop `STREAM_CONNECTED` boundary handling from replacing oil and water inventory in the first finite-volume cell.
- Add a two- and three-phase regression that advances an unchanged steady state by 1e-9 s and gates pressure, holdup, velocity, and mass continuity.
- Preserve all public APIs.

## Validation

Post-fix results for the same six-section cases:

| Case | Pressure RMS | Liquid-holdup RMS | Gas-velocity RMS | Liquid-velocity RMS | Inventory change |
|---|---:|---:|---:|---:|---:|
| Gas-condensate | 395 Pa | 2.93e-13 | 0.0806 m/s | 0.0348 m/s | 2.50e-12 kg |
| Gas-oil-water | 7.40 Pa | 4.86e-15 | 2.15e-9 m/s | 0.0149 m/s | 3.02e-11 kg |

Additional checks:

- 12-section cases at 1e-6 s retain holdup RMS below 4.2e-10 and inventory change below 6.8e-8 kg.
- A slightly inclined three-phase case exercises non-zero oil-water slip; interior oil and water velocity RMS changes are below 5e-9 m/s across the 1e-9 s handoff. Boundary cells are excluded from this slip-specific check because they intentionally receive external boundary velocities.
- One-phase gas remains finite and conservative; no liquid holdup is introduced.
- Existing 6 -> 12 and 6 -> 30 kg/s constant-flow rate-step probes change inventory by 0.00136 kg, within their 0.036 and 0.072 kg boundary-throughput envelopes.
- Production source and the regression source compile with Java 8 language targeting.
- `git diff --check` passes.

Local Maven/JUnit and Spotless execution was blocked because this runtime could not resolve Maven Central and had no complete cached plugin/dependency repository. The PR remains draft so the repository CI matrix can run the authoritative Maven, Spotless, Java 8/21, Windows/Linux, Javadoc, and static-analysis gates.

## Limitations

This is an initialization/state-ownership correction, not a closure calibration or an OLGA/LedaFlow equivalence claim. A smaller residual inlet-velocity adjustment remains because the current stream-connected boundary is represented through the first computational cell rather than a dedicated ghost/interface state. Conservative ghost-boundary momentum coupling, full phase-wise flux residual reporting, phase appearance/disappearance, and terrain/slug conservative source coupling remain in #2705.

## Documentation impact

Updated `TwoFluidPipe` Javadoc and `docs/process/TWOFLUIDPIPE_MODEL.md` to define:

- the one-time primitive-to-conservative initialization, including preservation of three-phase oil-water slip momentum;
- conservative cell-inventory ownership after transient start;
- why stream-connected boundary handling must not replace cell phase mass.

## References

- Bendiksen et al. (1991), *The Dynamic Two-Fluid Model OLGA: Theory and Application*: https://onepetro.org/PO/article/6/02/171/53376/
- Masella et al. (1998), *Transient Simulation of Two-Phase Flows in Pipes*: https://ifp.hal.science/hal-02079048/document
- Krasnopolsky and Lukyanov (2018), *A conservative fully implicit algorithm for predicting slug flows*: https://doi.org/10.1016/j.jcp.2017.11.032
- Sanderse and Veldman, *Constraint-consistent Runge-Kutta methods for one-dimensional incompressible multiphase flow*: https://arxiv.org/abs/1809.06114
