### PR TITLE
test: rebaseline TEG reboiler duty after absorber conservation fix

### DIFF
--- a/src/test/java/neqsim/process/processmodel/MLA_bug_test.java
+++ b/src/test/java/neqsim/process/processmodel/MLA_bug_test.java
@@ -315,8 +315,9 @@ public class MLA_bug_test extends neqsim.NeqSimTest {
     // logger.info("water in gas " + dehydratedGas.getFluid().getComponent("water").getx());
 
     assertEquals(-19.1886678, p.getMeasurementDevice("water dew point analyser3").getMeasuredValue("C"), 1e-1);
-    assertEquals(203.08,
-        ((Reboiler) ((DistillationColumn) p.getUnit("TEG regeneration column")).getReboiler()).getDuty() / 1e3, 0.2);
+    double reboilerDutyKw =
+        ((Reboiler) ((DistillationColumn) p.getUnit("TEG regeneration column")).getReboiler()).getDuty() / 1e3;
+    assertEquals(202.67072595963504, reboilerDutyKw, 5e-2);
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/MLA_bug_test.java
+++ b/src/test/java/neqsim/process/processmodel/MLA_bug_test.java
@@ -315,8 +315,8 @@ public class MLA_bug_test extends neqsim.NeqSimTest {
     // logger.info("water in gas " + dehydratedGas.getFluid().getComponent("water").getx());
 
     assertEquals(-19.1886678, p.getMeasurementDevice("water dew point analyser3").getMeasuredValue("C"), 1e-1);
-    double reboilerDutyKw =
-        ((Reboiler) ((DistillationColumn) p.getUnit("TEG regeneration column")).getReboiler()).getDuty() / 1e3;
+    double reboilerDutyKw = ((Reboiler) ((DistillationColumn) p.getUnit("TEG regeneration column")).getReboiler())
+        .getDuty() / 1e3;
     assertEquals(202.67072595963504, reboilerDutyKw, 5e-2);
   }
 


### PR DESCRIPTION
## Summary

- re-baseline `MLA_bug_test.runProcessTEG` to the deterministic 202.67072595963504 kW reboiler duty produced after the conservative absorber fix in #2678
- tighten the duty tolerance from 0.2 kW back to 0.05 kW
- name the calculated duty before asserting it so future failures report a focused regression value

## Root cause

PR #2678 replaced the broken custom `SimpleTEGAbsorber.mixStream()` component loop with `SystemInterface.addFluid(...)`. The corrected absorber now carries the complete gas and solvent inventories, including transferred water, into the downstream TEG-regeneration section. That physically valid mass-conservation correction changed the converged reboiler duty from the stale 203.08 kW test baseline to 202.67072595963504 kW (a 0.20% shift).

The issue reproduction is bit-identical on a clean baseline, and the absorber correction is already protected by component, water, and total-mass balance regressions. Production behavior should therefore be preserved; the golden test value was stale.

## Validation

- remote branch is based on current `master` commit `95de19d5d0ec8eaea6c5205690320dbb527693e0`
- connector comparison: one commit ahead, zero behind, only `MLA_bug_test.java` changed
- local and remote blob SHA match: `1574eaa0aa3991f3e743e027f330c18342c6d843`
- `git diff --check` passes
- the exact Spotless formatting patch reported by the first CI attempt was applied
- focused Maven execution was attempted but could not resolve `maven-enforcer-plugin:3.6.3` because this environment cannot reach `repo1.maven.org`; GitHub CI must execute the Java and Spotless gates

## Documentation impact

Documentation impact: none. This changes only an internal regression baseline to match the already-documented conservative `SimpleTEGAbsorber` behavior introduced by #2678; no public API, units, workflow, or recommended usage changes.

Closes #2713