### PR TITLE
fix: close TwoFluidPipe transient phase mass balances

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -397,24 +397,49 @@ At the steady-to-transient handoff, `run()` converts the final pressure, phase-h
 velocity profiles into conservative phase mass, momentum, and energy exactly once. This conversion
 defines the initial condition and advances no simulation time. For three-phase flow, the oil and
 water momenta retain the independent phase velocities from the steady slip closure rather than being
-collapsed to the bulk-liquid velocity. After the transient solve starts,
-the conservative phase masses own cell inventory. A stream-connected inlet may update boundary
-composition and velocity for its inlet flux, but it must not replace the first finite-volume cell's
-oil or water mass. This prevents an unchanged, near-zero-time handoff from producing an inventory or
-holdup jump that scales with pipe volume.
+collapsed to the bulk-liquid velocity. After the transient solve starts, the conservative phase
+masses own cell inventory. A stream-connected inlet may update boundary composition and velocity for
+its inlet flux, but it must not replace the first finite-volume cell's oil or water mass. This prevents
+an unchanged, near-zero-time handoff from producing an inventory or holdup jump that scales with pipe
+volume.
 
-For a domain with no external mass source, validate the discrete balance
+For each phase $k$ and for the total domain, validate the discrete balance
 
 $$
-M(t + \Delta t) - M(t) =
-\int_t^{t+\Delta t} \left(\dot m_{in} - \dot m_{out}\right)\,dt,
+M_k(t + \Delta t) - M_k(t) =
+\int_t^{t+\Delta t} \left(\dot m_{k,in} - \dot m_{k,out} + S_k\right)\,dt,
 \qquad
 M = \sum_i \left(m'_{g,i} + m'_{o,i} + m'_{w,i}\right)\Delta x_i .
 $$
 
 Use `getTotalMassInventory()` to read $M$ in kg directly from the conservative gas, oil, and water
-masses. A steady-state solution remains a useful long-time comparison, but agreement must result
-from the transient balances and closure forces rather than overwriting the conserved state.
+masses. After each `runTransient(...)`, `getLastMassBalanceReport()` provides initial and final
+inventory, integrated inlet and outlet fluxes, integrated sources, signed residual in kg, and
+relative residual for `GAS`, `OIL`, `WATER`, `LIQUID`, and `TOTAL`:
+
+```java
+pipe.runTransient(0.1, UUID.randomUUID());
+TwoFluidMassBalanceReport balance = pipe.getLastMassBalanceReport();
+double totalResidualKg = balance.getResidualKg(TwoFluidMassBalanceReport.Phase.TOTAL);
+double totalRelativeResidual = balance.getRelativeResidual(TwoFluidMassBalanceReport.Phase.TOTAL);
+boolean closes = balance.isWithinTolerance(TwoFluidMassBalanceReport.Phase.TOTAL, 1.0e-7, 1.0e-10);
+```
+
+The boundary and source integrals use the accepted internal substeps and the same Euler,
+Runge-Kutta, or IMEX stage weights as the conservative update. For deterministic regression cases,
+an absolute tolerance of $10^{-7}$ kg or a relative tolerance of $10^{-10}$ is appropriate; choose a
+larger engineering tolerance for long simulations after demonstrating time-step and mesh
+sensitivity. Positivity limiting or any future non-conservative correction appears explicitly as a
+non-zero residual rather than being hidden.
+
+Gas-liquid phase transfer is added to one phase and removed from the other, so it cancels from the
+total source. Oil-water segregation is represented by separate phase momentum and face fluxes; it
+does not use a local oil-to-water mass relaxation. The IMEX pressure correction likewise changes
+phase momenta, not phase masses. Closed boundaries therefore have zero integrated boundary flux,
+while open boundaries close against the actual phase-resolved inlet and outlet fluxes.
+
+A steady-state solution remains a useful long-time comparison, but agreement must result from the
+transient balances and closure forces rather than overwriting the conserved state.
 
 ### Boundary Conditions
 
@@ -461,7 +486,7 @@ Guidelines:
 | Section length | Keep `dx = length / sections` small enough to resolve terrain and holdup changes. A low point or riser should span several sections, not one cell. |
 | Time step | Start with 0.5-2 s for compact regression models and 5-60 s for long slow-flow pipelines when adaptive time stepping is enabled. Reduce it for valve closures, slug fronts, or fast pressure waves. |
 | Adaptive stepping | `setEnableAdaptiveTimestepping(true)` is recommended for difficult multiphase transients. It recomputes the stable internal step as velocities and holdups change. |
-| CFL number | `setCflNumber(0.3-0.8)` is typical. Lower values are more stable; higher values are faster but less conservative. |
+| CFL number | `setCflNumber(0.3-0.8)` is typical. Lower values provide more stability margin and temporal resolution; higher values are faster. |
 | Settling time | Run until pressure and holdup profiles stop changing or match a new stationary reference. The required physical time scales with pipeline length, flow velocity, compressibility, and liquid inventory. |
 
 For a pressure-boundary step, a compact 300 m regression pipe may settle in a few seconds. A real
@@ -515,7 +540,7 @@ Select the time integration method via `setTimeIntegrationMethod(TimeIntegrator.
 | `SSP_RK3` | Acoustic | Strong Stability Preserving RK3 |
 | `RK2` | Acoustic | Heun's method (2nd order) |
 | `EULER` | Acoustic | Forward Euler (1st order) |
-| `IMEX_PRESSURE_CORRECTION` | Convective only | Semi-implicit; ~10x larger dt. Not recommended for vertical risers. |
+| `IMEX_PRESSURE_CORRECTION` | Convective only | Semi-implicit momentum pressure correction with conservative explicit phase-mass transport; ~10x larger dt. Not recommended for vertical risers. |
 
 ```java
 pipe.setTimeIntegrationMethod(TimeIntegrator.Method.RK4);       // default

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidMassBalanceReport.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidMassBalanceReport.java
@@ -6,11 +6,9 @@ import java.io.Serializable;
  * Discrete phase and total-mass balance for one accepted {@link TwoFluidPipe} transient call.
  *
  * <p>
- * Boundary and source terms are integrated with the same Runge-Kutta stage weights as the
- * conservative state. The signed residual is
- * {@code final - initial - (inlet - outlet + source)}. A positive source adds mass to the
- * reported phase. Oil and water source terms include gas-liquid phase transfer splits; their sum
- * is the liquid source.
+ * Boundary and source terms are integrated with the same Runge-Kutta stage weights as the conservative state. The
+ * signed residual is {@code final - initial - (inlet - outlet + source)}. A positive source adds mass to the reported
+ * phase. Oil and water source terms include gas-liquid phase transfer splits; their sum is the liquid source.
  * </p>
  */
 public final class TwoFluidMassBalanceReport implements Serializable {
@@ -188,9 +186,8 @@ public final class TwoFluidMassBalanceReport implements Serializable {
    * Get absolute residual relative to the largest relevant inventory or integrated transfer.
    *
    * <p>
-   * The denominator is the maximum of initial inventory, final inventory, and the sum of absolute
-   * inlet, outlet, and source contributions. This definition remains finite for phase appearance
-   * from zero initial inventory.
+   * The denominator is the maximum of initial inventory, final inventory, and the sum of absolute inlet, outlet, and
+   * source contributions. This definition remains finite for phase appearance from zero initial inventory.
    * </p>
    *
    * @param phase phase or aggregate
@@ -217,7 +214,6 @@ public final class TwoFluidMassBalanceReport implements Serializable {
     if (absoluteToleranceKg < 0.0 || relativeTolerance < 0.0) {
       throw new IllegalArgumentException("Mass-balance tolerances must be non-negative");
     }
-    return Math.abs(getResidualKg(phase)) <= absoluteToleranceKg
-        || getRelativeResidual(phase) <= relativeTolerance;
+    return Math.abs(getResidualKg(phase)) <= absoluteToleranceKg || getRelativeResidual(phase) <= relativeTolerance;
   }
 }

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidMassBalanceReport.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidMassBalanceReport.java
@@ -1,0 +1,223 @@
+package neqsim.process.equipment.pipeline;
+
+import java.io.Serializable;
+
+/**
+ * Discrete phase and total-mass balance for one accepted {@link TwoFluidPipe} transient call.
+ *
+ * <p>
+ * Boundary and source terms are integrated with the same Runge-Kutta stage weights as the
+ * conservative state. The signed residual is
+ * {@code final - initial - (inlet - outlet + source)}. A positive source adds mass to the
+ * reported phase. Oil and water source terms include gas-liquid phase transfer splits; their sum
+ * is the liquid source.
+ * </p>
+ */
+public final class TwoFluidMassBalanceReport implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private static final int GAS_INDEX = 0;
+  private static final int OIL_INDEX = 1;
+  private static final int WATER_INDEX = 2;
+  private static final int PHASE_COUNT = 3;
+  private static final double RELATIVE_SCALE_FLOOR_KG = 1.0e-12;
+
+  /** Mass aggregation to query. */
+  public enum Phase {
+    /** Gas phase. */
+    GAS,
+    /** Hydrocarbon-liquid phase. */
+    OIL,
+    /** Aqueous phase. */
+    WATER,
+    /** Oil plus water. */
+    LIQUID,
+    /** Gas plus oil plus water. */
+    TOTAL
+  }
+
+  private final double elapsedTimeSeconds;
+  private final int acceptedSubsteps;
+  private final double[] initialMassKg;
+  private final double[] finalMassKg;
+  private final double[] inletMassKg;
+  private final double[] outletMassKg;
+  private final double[] sourceMassKg;
+
+  /**
+   * Create a report from phase-resolved integrals.
+   *
+   * @param elapsedTimeSeconds accepted elapsed time in seconds
+   * @param acceptedSubsteps number of accepted internal time steps
+   * @param initialMassKg initial gas, oil, and water inventory in kg
+   * @param finalMassKg final gas, oil, and water inventory in kg
+   * @param inletMassKg integrated gas, oil, and water inlet flux in kg
+   * @param outletMassKg integrated gas, oil, and water outlet flux in kg
+   * @param sourceMassKg integrated gas, oil, and water source terms in kg
+   */
+  TwoFluidMassBalanceReport(double elapsedTimeSeconds, int acceptedSubsteps, double[] initialMassKg,
+      double[] finalMassKg, double[] inletMassKg, double[] outletMassKg, double[] sourceMassKg) {
+    this.elapsedTimeSeconds = elapsedTimeSeconds;
+    this.acceptedSubsteps = acceptedSubsteps;
+    this.initialMassKg = requirePhaseValues(initialMassKg, "initialMassKg");
+    this.finalMassKg = requirePhaseValues(finalMassKg, "finalMassKg");
+    this.inletMassKg = requirePhaseValues(inletMassKg, "inletMassKg");
+    this.outletMassKg = requirePhaseValues(outletMassKg, "outletMassKg");
+    this.sourceMassKg = requirePhaseValues(sourceMassKg, "sourceMassKg");
+  }
+
+  private static double[] requirePhaseValues(double[] values, String name) {
+    if (values == null || values.length != PHASE_COUNT) {
+      throw new IllegalArgumentException(name + " must contain gas, oil, and water values");
+    }
+    double[] copy = values.clone();
+    for (double value : copy) {
+      if (!Double.isFinite(value)) {
+        throw new IllegalArgumentException(name + " must contain only finite values");
+      }
+    }
+    return copy;
+  }
+
+  private static double aggregate(double[] values, Phase phase) {
+    switch (phase) {
+    case GAS:
+      return values[GAS_INDEX];
+    case OIL:
+      return values[OIL_INDEX];
+    case WATER:
+      return values[WATER_INDEX];
+    case LIQUID:
+      return values[OIL_INDEX] + values[WATER_INDEX];
+    case TOTAL:
+      return values[GAS_INDEX] + values[OIL_INDEX] + values[WATER_INDEX];
+    default:
+      throw new IllegalArgumentException("Unsupported phase aggregation: " + phase);
+    }
+  }
+
+  /**
+   * Get accepted elapsed time.
+   *
+   * @return elapsed time in seconds
+   */
+  public double getElapsedTimeSeconds() {
+    return elapsedTimeSeconds;
+  }
+
+  /**
+   * Get number of accepted internal time steps.
+   *
+   * @return accepted substep count
+   */
+  public int getAcceptedSubsteps() {
+    return acceptedSubsteps;
+  }
+
+  /**
+   * Get initial inventory.
+   *
+   * @param phase phase or aggregate
+   * @return mass in kg
+   */
+  public double getInitialMassKg(Phase phase) {
+    return aggregate(initialMassKg, phase);
+  }
+
+  /**
+   * Get final inventory.
+   *
+   * @param phase phase or aggregate
+   * @return mass in kg
+   */
+  public double getFinalMassKg(Phase phase) {
+    return aggregate(finalMassKg, phase);
+  }
+
+  /**
+   * Get inventory change.
+   *
+   * @param phase phase or aggregate
+   * @return final minus initial mass in kg
+   */
+  public double getMassChangeKg(Phase phase) {
+    return getFinalMassKg(phase) - getInitialMassKg(phase);
+  }
+
+  /**
+   * Get time-integrated inlet flux.
+   *
+   * @param phase phase or aggregate
+   * @return mass entering the domain in kg
+   */
+  public double getInletMassKg(Phase phase) {
+    return aggregate(inletMassKg, phase);
+  }
+
+  /**
+   * Get time-integrated outlet flux.
+   *
+   * @param phase phase or aggregate
+   * @return mass leaving the domain in kg
+   */
+  public double getOutletMassKg(Phase phase) {
+    return aggregate(outletMassKg, phase);
+  }
+
+  /**
+   * Get time-integrated source contribution.
+   *
+   * @param phase phase or aggregate
+   * @return signed source mass in kg
+   */
+  public double getSourceMassKg(Phase phase) {
+    return aggregate(sourceMassKg, phase);
+  }
+
+  /**
+   * Get signed discrete balance residual.
+   *
+   * @param phase phase or aggregate
+   * @return residual in kg
+   */
+  public double getResidualKg(Phase phase) {
+    double expectedChange = getInletMassKg(phase) - getOutletMassKg(phase) + getSourceMassKg(phase);
+    return getMassChangeKg(phase) - expectedChange;
+  }
+
+  /**
+   * Get absolute residual relative to the largest relevant inventory or integrated transfer.
+   *
+   * <p>
+   * The denominator is the maximum of initial inventory, final inventory, and the sum of absolute
+   * inlet, outlet, and source contributions. This definition remains finite for phase appearance
+   * from zero initial inventory.
+   * </p>
+   *
+   * @param phase phase or aggregate
+   * @return non-negative relative residual
+   */
+  public double getRelativeResidual(Phase phase) {
+    double transferScale = Math.abs(getInletMassKg(phase)) + Math.abs(getOutletMassKg(phase))
+        + Math.abs(getSourceMassKg(phase));
+    double scale = Math.max(Math.abs(getInitialMassKg(phase)), Math.abs(getFinalMassKg(phase)));
+    scale = Math.max(scale, transferScale);
+    scale = Math.max(scale, RELATIVE_SCALE_FLOOR_KG);
+    return Math.abs(getResidualKg(phase)) / scale;
+  }
+
+  /**
+   * Check an absolute-or-relative balance tolerance.
+   *
+   * @param phase phase or aggregate
+   * @param absoluteToleranceKg absolute tolerance in kg
+   * @param relativeTolerance relative tolerance
+   * @return true when either tolerance is met
+   */
+  public boolean isWithinTolerance(Phase phase, double absoluteToleranceKg, double relativeTolerance) {
+    if (absoluteToleranceKg < 0.0 || relativeTolerance < 0.0) {
+      throw new IllegalArgumentException("Mass-balance tolerances must be non-negative");
+    }
+    return Math.abs(getResidualKg(phase)) <= absoluteToleranceKg
+        || getRelativeResidual(phase) <= relativeTolerance;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -3466,8 +3466,8 @@ public class TwoFluidPipe extends Pipeline {
         }
       }
 
-      accumulateAcceptedMassBalance(stageMassBalanceRates, dtActual, integratedInletMassKg,
-          integratedOutletMassKg, integratedSourceMassKg);
+      accumulateAcceptedMassBalance(stageMassBalanceRates, dtActual, integratedInletMassKg, integratedOutletMassKg,
+          integratedSourceMassKg);
       acceptedElapsedTime += dtActual;
       acceptedSubsteps++;
 
@@ -4531,8 +4531,8 @@ public class TwoFluidPipe extends Pipeline {
    * Get the discrete mass balance from the most recent {@link #runTransient(double, UUID)} call.
    *
    * <p>
-   * Boundary fluxes and source terms are integrated with the same stage weights as the configured time integrator.
-   * The report includes gas, oil, water, combined-liquid, and total residuals in kg and relative form. A steady-state
+   * Boundary fluxes and source terms are integrated with the same stage weights as the configured time integrator. The
+   * report includes gas, oil, water, combined-liquid, and total residuals in kg and relative form. A steady-state
    * {@link #run(UUID)} clears the previous report.
    * </p>
    *

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -1,5 +1,7 @@
 package neqsim.process.equipment.pipeline;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -638,6 +640,9 @@ public class TwoFluidPipe extends Pipeline {
 
   /** Flag indicating transient mode (inlet P is free, not fixed from stream). */
   private boolean isTransientMode = false;
+
+  /** Discrete mass balance from the most recent transient call. */
+  private TwoFluidMassBalanceReport lastMassBalanceReport = null;
 
   // ============ Results storage ============
 
@@ -3241,6 +3246,8 @@ public class TwoFluidPipe extends Pipeline {
 
   @Override
   public void run(UUID id) {
+    lastMassBalanceReport = null;
+
     // Initialize sections
     initializeSections();
 
@@ -3262,6 +3269,20 @@ public class TwoFluidPipe extends Pipeline {
   @Override
   public void runTransient(double dt, UUID id) {
     isTransientMode = true;
+    lastMassBalanceReport = null;
+    double[] initialMassKg = getPhaseMassInventoriesKg();
+    double[] integratedInletMassKg = new double[3];
+    double[] integratedOutletMassKg = new double[3];
+    double[] integratedSourceMassKg = new double[3];
+    double acceptedElapsedTime = 0.0;
+    int acceptedSubsteps = 0;
+
+    // Boundary changes must affect the first accepted finite-volume step. With the
+    // conservative state initialized by run(), this updates flux primitives and
+    // momenta only; it does not replace cell phase inventory.
+    applyBoundaryConditions();
+    validateSectionStates();
+
     boolean isIMEX = (timeIntegrator.getMethod() == TimeIntegrator.Method.IMEX_PRESSURE_CORRECTION);
 
     // Calculate initial stable time step (OLGA-style: CFL from current velocities)
@@ -3310,10 +3331,18 @@ public class TwoFluidPipe extends Pipeline {
 
       // 3. Calculate RHS and advance solution
       final double dtFinal = dtActual;
+      final List<TwoFluidConservationEquations.MassBalanceRate> stageMassBalanceRates = new ArrayList<>();
 
       TimeIntegrator.RHSFunction rhs = (state, t) -> {
         equations.applyState(sections, state);
-        return equations.calcRHS(sections, dx);
+        // Boundary conditions are part of the semi-discrete operator and must be
+        // enforced for every Runge-Kutta stage, not only after an accepted step.
+        // This is especially important for CLOSED boundaries because intermediate
+        // stage momenta can otherwise create a spurious boundary flux.
+        applyBoundaryConditions();
+        double[][] derivative = equations.calcRHS(sections, dx);
+        stageMassBalanceRates.add(equations.getLastMassBalanceRate());
+        return derivative;
       };
 
       // For IMEX: provide cell sound speeds and densities for implicit pressure solve
@@ -3437,6 +3466,11 @@ public class TwoFluidPipe extends Pipeline {
         }
       }
 
+      accumulateAcceptedMassBalance(stageMassBalanceRates, dtActual, integratedInletMassKg,
+          integratedOutletMassKg, integratedSourceMassKg);
+      acceptedElapsedTime += dtActual;
+      acceptedSubsteps++;
+
       // 8. Update accumulation tracking and slug tracking
       if (enableSlugTracking && slugTrackingMode != SlugTrackingMode.DISABLED) {
         accumulationTracker.updateAccumulation(sections, dtActual);
@@ -3502,7 +3536,54 @@ public class TwoFluidPipe extends Pipeline {
     updateOutletStream();
     updateResultArrays();
 
+    lastMassBalanceReport = new TwoFluidMassBalanceReport(acceptedElapsedTime, acceptedSubsteps, initialMassKg,
+        getPhaseMassInventoriesKg(), integratedInletMassKg, integratedOutletMassKg, integratedSourceMassKg);
+
     setCalculationIdentifier(id);
+  }
+
+  private void accumulateAcceptedMassBalance(List<TwoFluidConservationEquations.MassBalanceRate> stageRates,
+      double timeStepSeconds, double[] inletMassKg, double[] outletMassKg, double[] sourceMassKg) {
+    double[] weights = getMassBalanceStageWeights(stageRates.size());
+    for (int stage = 0; stage < stageRates.size(); stage++) {
+      TwoFluidConservationEquations.MassBalanceRate rate = stageRates.get(stage);
+      double[] inletRate = rate.getInletMassFlowKgPerSecond();
+      double[] outletRate = rate.getOutletMassFlowKgPerSecond();
+      double[] sourceRate = rate.getSourceMassFlowKgPerSecond();
+      double weightedTime = weights[stage] * timeStepSeconds;
+      for (int phase = 0; phase < 3; phase++) {
+        inletMassKg[phase] += inletRate[phase] * weightedTime;
+        outletMassKg[phase] += outletRate[phase] * weightedTime;
+        sourceMassKg[phase] += sourceRate[phase] * weightedTime;
+      }
+    }
+  }
+
+  private double[] getMassBalanceStageWeights(int stageCount) {
+    TimeIntegrator.Method method = timeIntegrator.getMethod();
+    double[] weights;
+    switch (method) {
+    case EULER:
+    case IMEX_PRESSURE_CORRECTION:
+      weights = new double[] { 1.0 };
+      break;
+    case RK2:
+      weights = new double[] { 0.5, 0.5 };
+      break;
+    case RK4:
+      weights = new double[] { 1.0 / 6.0, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 6.0 };
+      break;
+    case SSP_RK3:
+      weights = new double[] { 1.0 / 6.0, 1.0 / 6.0, 2.0 / 3.0 };
+      break;
+    default:
+      throw new IllegalStateException("Unsupported time integration method: " + method);
+    }
+    if (stageCount != weights.length) {
+      throw new IllegalStateException(
+          "Expected " + weights.length + " mass-balance stages for " + method + " but received " + stageCount);
+    }
+    return weights;
   }
 
   /**
@@ -4427,15 +4508,38 @@ public class TwoFluidPipe extends Pipeline {
    * @return total domain mass in kg
    */
   public double getTotalMassInventory() {
+    double[] phaseMasses = getPhaseMassInventoriesKg();
+    return phaseMasses[0] + phaseMasses[1] + phaseMasses[2];
+  }
+
+  private double[] getPhaseMassInventoriesKg() {
+    double[] phaseMasses = new double[3];
     if (sections == null) {
-      return 0.0;
+      return phaseMasses;
     }
 
-    double mass = 0.0;
     for (TwoFluidSection sec : sections) {
-      mass += (sec.getGasMassPerLength() + sec.getOilMassPerLength() + sec.getWaterMassPerLength()) * sec.getLength();
+      double sectionLength = sec.getLength();
+      phaseMasses[0] += sec.getGasMassPerLength() * sectionLength;
+      phaseMasses[1] += sec.getOilMassPerLength() * sectionLength;
+      phaseMasses[2] += sec.getWaterMassPerLength() * sectionLength;
     }
-    return mass;
+    return phaseMasses;
+  }
+
+  /**
+   * Get the discrete mass balance from the most recent {@link #runTransient(double, UUID)} call.
+   *
+   * <p>
+   * Boundary fluxes and source terms are integrated with the same stage weights as the configured time integrator.
+   * The report includes gas, oil, water, combined-liquid, and total residuals in kg and relative form. A steady-state
+   * {@link #run(UUID)} clears the previous report.
+   * </p>
+   *
+   * @return last transient mass-balance report, or {@code null} before a transient call
+   */
+  public TwoFluidMassBalanceReport getLastMassBalanceReport() {
+    return lastMassBalanceReport;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -129,6 +129,53 @@ public class TwoFluidConservationEquations implements Serializable {
   /** Timestep for virtual mass force calculation. */
   private double dt = 0.01;
 
+  /** Most recent phase-resolved boundary and source rates calculated by {@link #calcRHS}. */
+  private MassBalanceRate lastMassBalanceRate = new MassBalanceRate(new double[3], new double[3], new double[3]);
+
+  /**
+   * Instantaneous phase-resolved terms in the finite-volume domain mass balance.
+   */
+  public static final class MassBalanceRate implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final double[] inletMassFlowKgPerSecond;
+    private final double[] outletMassFlowKgPerSecond;
+    private final double[] sourceMassFlowKgPerSecond;
+
+    private MassBalanceRate(double[] inletMassFlowKgPerSecond, double[] outletMassFlowKgPerSecond,
+        double[] sourceMassFlowKgPerSecond) {
+      this.inletMassFlowKgPerSecond = inletMassFlowKgPerSecond.clone();
+      this.outletMassFlowKgPerSecond = outletMassFlowKgPerSecond.clone();
+      this.sourceMassFlowKgPerSecond = sourceMassFlowKgPerSecond.clone();
+    }
+
+    /**
+     * Get gas, oil, and water inlet mass-flow rates.
+     *
+     * @return three-element array in kg/s
+     */
+    public double[] getInletMassFlowKgPerSecond() {
+      return inletMassFlowKgPerSecond.clone();
+    }
+
+    /**
+     * Get gas, oil, and water outlet mass-flow rates.
+     *
+     * @return three-element array in kg/s
+     */
+    public double[] getOutletMassFlowKgPerSecond() {
+      return outletMassFlowKgPerSecond.clone();
+    }
+
+    /**
+     * Get gas, oil, and water domain-integrated source rates.
+     *
+     * @return three-element array in kg/s
+     */
+    public double[] getSourceMassFlowKgPerSecond() {
+      return sourceMassFlowKgPerSecond.clone();
+    }
+  }
+
   /**
    * Constructor.
    */
@@ -168,6 +215,11 @@ public class TwoFluidConservationEquations implements Serializable {
     // Calculate source terms for each cell
     double[][] sources = calcSourceTerms(sections);
 
+    // Calculate the two external boundary fluxes once. These exact values are also
+    // retained for a stage-consistent domain mass-balance diagnostic.
+    double[] inletFlux = calcInletFlux(sections[0]);
+    double[] outletFlux = calcOutletFlux(sections[nCells - 1]);
+
     // Assemble RHS: dU/dt = -1/dx_i * (F_{i+1/2} - F_{i-1/2}) + S_i
     //
     // Boundary treatment:
@@ -181,13 +233,13 @@ public class TwoFluidConservationEquations implements Serializable {
         // Inlet cell: Inlet BC maintains the state, so inlet flux = outlet flux from cell 0
         // This creates a "quasi-steady" inlet where what enters = what leaves for the cell
         // The mass is replenished by the boundary condition after each step
-        fluxLeft = calcInletFlux(sections[0]);
+        fluxLeft = inletFlux;
         fluxRight = fluxes[0];
       } else if (i == nCells - 1) {
         // Outlet cell: left flux from last interface, right flux uses extrapolation
         // For transmissive outlet, we compute the outgoing flux from the outlet cell state
         fluxLeft = fluxes[nCells - 2];
-        fluxRight = calcOutletFlux(sections[nCells - 1]);
+        fluxRight = outletFlux;
       } else {
         // Interior cells: use interface fluxes normally
         fluxLeft = fluxes[i - 1];
@@ -202,7 +254,28 @@ public class TwoFluidConservationEquations implements Serializable {
       }
     }
 
+    double[] inletMassFlow = { inletFlux[IDX_GAS_MASS], inletFlux[IDX_OIL_MASS], inletFlux[IDX_WATER_MASS] };
+    double[] outletMassFlow = { outletFlux[IDX_GAS_MASS], outletFlux[IDX_OIL_MASS],
+        outletFlux[IDX_WATER_MASS] };
+    double[] sourceMassFlow = new double[3];
+    for (int i = 0; i < nCells; i++) {
+      double sectionLength = sections[i].getLength();
+      sourceMassFlow[0] += sources[i][IDX_GAS_MASS] * sectionLength;
+      sourceMassFlow[1] += sources[i][IDX_OIL_MASS] * sectionLength;
+      sourceMassFlow[2] += sources[i][IDX_WATER_MASS] * sectionLength;
+    }
+    lastMassBalanceRate = new MassBalanceRate(inletMassFlow, outletMassFlow, sourceMassFlow);
+
     return dUdt;
+  }
+
+  /**
+   * Get the phase-resolved boundary and source rates from the most recent right-hand-side evaluation.
+   *
+   * @return immutable mass-balance rate snapshot
+   */
+  public MassBalanceRate getLastMassBalanceRate() {
+    return lastMassBalanceRate;
   }
 
   /**
@@ -545,71 +618,12 @@ public class TwoFluidConservationEquations implements Serializable {
       // Assemble source terms - now with separate oil and water mass equations
       sources[i][IDX_GAS_MASS] = Gamma_G;
 
-      // Oil and water mass sources (no phase change between oil/water for now)
-      // Gravity-driven segregation source term for water accumulation in low points
-      //
-      // Physical basis: Water (denser) tends to accumulate in valleys while oil
-      // (lighter) accumulates at peaks. The settling rate depends on:
-      // - Density difference (buoyancy driving force)
-      // - Pipe inclination (gravity component)
-      // - Liquid holdup (more liquid = more stratification potential)
-      // - Residence time (slower flow = more settling)
-      //
-      // We use a relaxation approach rather than direct advection to maintain stability.
-      double waterSegregationSource = 0;
-      double oilSegregationSource = 0;
-
-      if (rhoW > rhoO && rhoO > 100 && alphaL > 0.05 && alphaW > 1e-6 && alphaO > 1e-6) {
-        // Settling velocity based on Stokes law for droplets
-        double deltaRho = rhoW - rhoO;
-        double muL_eff = sec.getLiquidViscosity();
-        if (muL_eff < 1e-6)
-          muL_eff = 1e-3; // Default viscosity
-        double dropletDiameter = 0.002; // 2 mm typical droplet
-        double stokesVelocity = deltaRho * GRAVITY * dropletDiameter * dropletDiameter / (18.0 * muL_eff);
-        stokesVelocity = Math.min(stokesVelocity, 0.1); // Cap at 10 cm/s
-
-        // Settling is enhanced in inclined sections
-        // In downhill (sinTheta < 0): water moves forward faster (settles ahead)
-        // In uphill (sinTheta > 0): water slips back (accumulates)
-        double inclinationEffect = Math.abs(sinTheta);
-
-        // Detect valleys (low points) by checking if we're at a local minimum
-        // Valley = previous section going down, next section going up
-        boolean isValley = false;
-        boolean isPeak = false;
-        if (i > 0 && i < nCells - 1) {
-          double elevPrev = sections[i - 1].getElevation();
-          double elevCurr = sec.getElevation();
-          double elevNext = sections[i + 1].getElevation();
-          isValley = (elevPrev > elevCurr) && (elevNext > elevCurr);
-          isPeak = (elevPrev < elevCurr) && (elevNext < elevCurr);
-        }
-
-        // Base settling rate (kg/m/s) - proportional to density difference and gravity
-        double baseRate = 0.0001 * deltaRho * GRAVITY * A;
-
-        if (isValley) {
-          // In valleys: water accumulates, increase local water cut
-          // Rate limited by available oil and existing water content
-          double maxWaterIncrease = alphaO * rhoO * A * 0.001; // Max 0.1% per time unit
-          waterSegregationSource = Math.min(baseRate * (1.0 + 5.0 * inclinationEffect), maxWaterIncrease);
-          oilSegregationSource = -waterSegregationSource * rhoO / rhoW; // Mass balance
-        } else if (isPeak) {
-          // At peaks: water drains faster, decrease local water cut
-          double maxWaterDecrease = alphaW * rhoW * A * 0.001; // Max 0.1% per time unit
-          waterSegregationSource = -Math.min(baseRate * (1.0 + 3.0 * inclinationEffect), maxWaterDecrease);
-          oilSegregationSource = -waterSegregationSource * rhoO / rhoW;
-        } else if (sinTheta > 0.01) {
-          // Uphill sections: water slips back slightly
-          double slipRate = baseRate * 0.3 * sinTheta;
-          waterSegregationSource = Math.min(slipRate, alphaO * rhoO * A * 0.0005);
-          oilSegregationSource = -waterSegregationSource * rhoO / rhoW;
-        }
-      }
-
-      sources[i][IDX_OIL_MASS] = Gamma_L * (1.0 - waterCut) + oilSegregationSource;
-      sources[i][IDX_WATER_MASS] = Gamma_L * waterCut + waterSegregationSource;
+      // Oil-water segregation is driven by the separate momentum equations and
+      // transported through phase fluxes. A local mass relaxation would convert oil
+      // into water (or vice versa) and, because their densities differ, would also
+      // change total inventory without a conservative face flux.
+      sources[i][IDX_OIL_MASS] = Gamma_L * (1.0 - waterCut);
+      sources[i][IDX_WATER_MASS] = Gamma_L * waterCut;
 
       // Virtual mass force calculation (Drew & Lahey, 1987)
       // F_vm = C_vm * alpha_dispersed * rho_continuous * (dv_dispersed/dt - dv_continuous/dt)

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -255,8 +255,7 @@ public class TwoFluidConservationEquations implements Serializable {
     }
 
     double[] inletMassFlow = { inletFlux[IDX_GAS_MASS], inletFlux[IDX_OIL_MASS], inletFlux[IDX_WATER_MASS] };
-    double[] outletMassFlow = { outletFlux[IDX_GAS_MASS], outletFlux[IDX_OIL_MASS],
-        outletFlux[IDX_WATER_MASS] };
+    double[] outletMassFlow = { outletFlux[IDX_GAS_MASS], outletFlux[IDX_OIL_MASS], outletFlux[IDX_WATER_MASS] };
     double[] sourceMassFlow = new double[3];
     for (int i = 0; i < nCells; i++) {
       double sectionLength = sections[i].getLength();

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
@@ -511,10 +511,10 @@ public class TimeIntegrator implements Serializable {
    * <ol>
    * <li><b>Predictor (explicit):</b> Advance mass and momentum using the explicit RHS (advection + source terms) to
    * obtain intermediate values U*.</li>
-   * <li><b>Pressure correction (implicit):</b> Solve a tridiagonal Helmholtz equation for the pressure correction dp
-   * that enforces mass conservation implicitly. The pressure wave equation dp - (c*dt/dx)^2 * d^2(dp)/dx^2 = RHS
-   * removes the acoustic CFL constraint.</li>
-   * <li><b>Corrector:</b> Update momenta using the pressure correction gradient.</li>
+   * <li><b>Pressure correction (implicit):</b> Solve a tridiagonal Helmholtz equation for the pressure correction dp.
+   * The pressure wave equation dp - (c*dt/dx)^2 * d^2(dp)/dx^2 = RHS removes the acoustic CFL constraint.</li>
+   * <li><b>Corrector:</b> Update phase momenta using the pressure correction gradient while leaving the phase masses
+   * from the conservative predictor unchanged.</li>
    * </ol>
    *
    * <p>
@@ -634,22 +634,15 @@ public class TimeIntegrator implements Serializable {
         dpdx = (dp[i + 1] - dp[i - 1]) / (2.0 * imexDx);
       }
 
-      // Correct mass equations with implicit pressure contribution.
-      double c = Math.max(cellSoundSpeeds[i], 1.0);
       double area = getCellArea(i);
-      double massCorrectionTotal = area * dp[i] / (c * c);
 
-      // Distribute mass correction proportionally to existing phase masses
+      // Phase masses remain exactly as advanced by the conservative explicit
+      // predictor. Pressure correction acts on momenta; directly adding area*dp/c^2
+      // to cell mass would be an unbalanced volume source.
       double totalMass = 0;
       int nMassEq = Math.min(3, nVars);
       for (int k = 0; k < nMassEq; k++) {
         totalMass += Math.max(Ustar[i][k], 0);
-      }
-      if (totalMass > 1e-12) {
-        for (int k = 0; k < nMassEq; k++) {
-          double fraction = Math.max(Ustar[i][k], 0) / totalMass;
-          Unew[i][k] = Ustar[i][k] + fraction * massCorrectionTotal;
-        }
       }
 
       // Correct momentum equations using the two-fluid pressure source:

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeMassBalanceTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeMassBalanceTest.java
@@ -25,8 +25,8 @@ class TwoFluidPipeMassBalanceTest {
     assertReportCloses(fine);
     assertTrue(coarse.getInletMassKg(Phase.TOTAL) > 0.0);
     assertTrue(coarse.getOutletMassKg(Phase.TOTAL) > 0.0);
-    assertTrue(Math.abs(fine.getResidualKg(Phase.TOTAL))
-        <= 10.0 * Math.abs(coarse.getResidualKg(Phase.TOTAL)) + ABSOLUTE_BALANCE_TOLERANCE_KG);
+    assertTrue(Math.abs(fine.getResidualKg(Phase.TOTAL)) <= 10.0 * Math.abs(coarse.getResidualKg(Phase.TOTAL))
+        + ABSOLUTE_BALANCE_TOLERANCE_KG);
   }
 
   @Test
@@ -134,8 +134,8 @@ class TwoFluidPipeMassBalanceTest {
     assertTrue(report.getAcceptedSubsteps() > 0);
     for (Phase phase : Phase.values()) {
       assertTrue(report.isWithinTolerance(phase, ABSOLUTE_BALANCE_TOLERANCE_KG, RELATIVE_BALANCE_TOLERANCE),
-          phase + " residual was " + report.getResidualKg(phase) + " kg (relative "
-              + report.getRelativeResidual(phase) + ")");
+          phase + " residual was " + report.getResidualKg(phase) + " kg (relative " + report.getRelativeResidual(phase)
+              + ")");
     }
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeMassBalanceTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeMassBalanceTest.java
@@ -1,0 +1,141 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
+import neqsim.process.equipment.pipeline.twophasepipe.numerics.TimeIntegrator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression tests for phase-resolved transient mass conservation. */
+class TwoFluidPipeMassBalanceTest {
+  private static final double ABSOLUTE_BALANCE_TOLERANCE_KG = 1.0e-7;
+  private static final double RELATIVE_BALANCE_TOLERANCE = 1.0e-10;
+
+  @Test
+  void testOpenBoundaryBalanceClosesAcrossTimeAndMeshRefinement() {
+    TwoFluidMassBalanceReport coarse = runOpenBoundaryCase(6, 1.0e-3, TimeIntegrator.Method.RK4);
+    TwoFluidMassBalanceReport fine = runOpenBoundaryCase(12, 5.0e-4, TimeIntegrator.Method.RK4);
+
+    assertReportCloses(coarse);
+    assertReportCloses(fine);
+    assertTrue(coarse.getInletMassKg(Phase.TOTAL) > 0.0);
+    assertTrue(coarse.getOutletMassKg(Phase.TOTAL) > 0.0);
+    assertTrue(Math.abs(fine.getResidualKg(Phase.TOTAL))
+        <= 10.0 * Math.abs(coarse.getResidualKg(Phase.TOTAL)) + ABSOLUTE_BALANCE_TOLERANCE_KG);
+  }
+
+  @Test
+  void testClosedBoundariesConserveEveryPhase() {
+    TwoFluidPipe pipe = createPipe("closed-balance", 8);
+    pipe.run();
+    pipe.closeInlet();
+    pipe.closeOutlet();
+
+    pipe.runTransient(1.0e-3, UUID.fromString("00000000-0000-0000-0000-000000002705"));
+
+    TwoFluidMassBalanceReport report = pipe.getLastMassBalanceReport();
+    assertNotNull(report);
+    assertEquals(0.0, report.getInletMassKg(Phase.TOTAL), 1.0e-12);
+    assertEquals(0.0, report.getOutletMassKg(Phase.TOTAL), 1.0e-12);
+    assertEquals(report.getInitialMassKg(Phase.TOTAL), report.getFinalMassKg(Phase.TOTAL),
+        ABSOLUTE_BALANCE_TOLERANCE_KG);
+    assertReportCloses(report);
+  }
+
+  @Test
+  void testImexPressureCorrectionDoesNotChangePhaseMass() {
+    TwoFluidPipe pipe = createPipe("imex-balance", 8);
+    pipe.setTimeIntegrationMethod(TimeIntegrator.Method.IMEX_PRESSURE_CORRECTION);
+    pipe.run();
+
+    pipe.runTransient(1.0e-3, UUID.fromString("00000000-0000-0000-0000-000000012705"));
+
+    assertReportCloses(pipe.getLastMassBalanceReport());
+  }
+
+  @Test
+  void testStageWeightedReportClosesForEveryExplicitIntegrator() {
+    TimeIntegrator.Method[] methods = { TimeIntegrator.Method.EULER, TimeIntegrator.Method.RK2,
+        TimeIntegrator.Method.SSP_RK3 };
+
+    for (TimeIntegrator.Method method : methods) {
+      TwoFluidPipe pipe = createPipe("stage-balance-" + method, 6);
+      pipe.setTimeIntegrationMethod(method);
+      pipe.run();
+      pipe.runTransient(1.0e-3, UUID.fromString("00000000-0000-0000-0000-000000042705"));
+
+      assertReportCloses(pipe.getLastMassBalanceReport());
+    }
+  }
+
+  @Test
+  void testFlashDrivenPhaseTransferCancelsFromTotalMass() {
+    TwoFluidPipe pipe = createPipe("phase-transfer-balance", 8);
+    pipe.setIncludeMassTransfer(true);
+    pipe.setMassTransferRelaxationTime(5.0);
+    pipe.run();
+
+    pipe.runTransient(1.0e-3, UUID.fromString("00000000-0000-0000-0000-000000022705"));
+
+    TwoFluidMassBalanceReport report = pipe.getLastMassBalanceReport();
+    assertNotNull(report);
+    assertEquals(0.0, report.getSourceMassKg(Phase.TOTAL), 1.0e-12);
+    assertEquals(-report.getSourceMassKg(Phase.GAS), report.getSourceMassKg(Phase.LIQUID), 1.0e-12);
+    assertReportCloses(report);
+  }
+
+  private TwoFluidMassBalanceReport runOpenBoundaryCase(int sections, double timeStep,
+      TimeIntegrator.Method integrationMethod) {
+    TwoFluidPipe pipe = createPipe("open-balance-" + sections, sections);
+    pipe.setTimeIntegrationMethod(integrationMethod);
+    pipe.run();
+    pipe.runTransient(timeStep, UUID.fromString("00000000-0000-0000-0000-000000032705"));
+    return pipe.getLastMassBalanceReport();
+  }
+
+  private TwoFluidPipe createPipe(String name, int sections) {
+    SystemInterface fluid = new SystemSrkEos(293.15, 80.0);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.06);
+    fluid.addComponent("propane", 0.04);
+    fluid.addComponent("n-pentane", 0.03);
+    fluid.addComponent("n-heptane", 0.02);
+    fluid.addComponent("nC10", 0.02);
+    fluid.addComponent("water", 0.03);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream inlet = new Stream(name + "-inlet", fluid);
+    inlet.setFlowRate(6.0, "kg/sec");
+    inlet.setTemperature(20.0, "C");
+    inlet.setPressure(80.0, "bara");
+    inlet.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe(name + "-pipe", inlet);
+    pipe.setLength(300.0);
+    pipe.setDiameter(0.15);
+    pipe.setRoughness(1.0e-5);
+    pipe.setNumberOfSections(sections);
+    pipe.setOutletPressure(60.0, "bara");
+    pipe.setEnableAdaptiveTimestepping(false);
+    pipe.setEnableSlugTracking(false);
+    pipe.setThermodynamicUpdateInterval(Integer.MAX_VALUE);
+    pipe.setSteadyStateMaxWallClockTime(1.0);
+    return pipe;
+  }
+
+  private void assertReportCloses(TwoFluidMassBalanceReport report) {
+    assertNotNull(report);
+    assertTrue(report.getAcceptedSubsteps() > 0);
+    for (Phase phase : Phase.values()) {
+      assertTrue(report.isWithinTolerance(phase, ABSOLUTE_BALANCE_TOLERANCE_KG, RELATIVE_BALANCE_TOLERANCE),
+          phase + " residual was " + report.getResidualKg(phase) + " kg (relative "
+              + report.getRelativeResidual(phase) + ")");
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
@@ -344,8 +344,7 @@ public class TwoFluidSectionTest {
     assertFiniteNonNegativePhaseMasses(disappearing[1]);
   }
 
-  private TwoFluidSection[] createUniformTransferSections(double gasMassPerLength,
-      double massTransferRateKgPerSecond) {
+  private TwoFluidSection[] createUniformTransferSections(double gasMassPerLength, double massTransferRateKgPerSecond) {
     TwoFluidSection[] transferSections = new TwoFluidSection[3];
     for (int index = 0; index < transferSections.length; index++) {
       TwoFluidSection transferSection = createThreePhaseBalanceSection(index * 10.0, 0.0, 0.0);

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
@@ -313,13 +313,14 @@ public class TwoFluidSectionTest {
   void testPhaseAppearanceAndDisappearanceRemainFiniteAndConservative() {
     TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
     equations.setIncludeMassTransfer(true);
+    double dtSeconds = 1.0;
 
     TwoFluidSection[] appearing = createUniformTransferSections(0.0, 0.1);
     double initialAppearingMass = totalMassPerLength(appearing[1]);
     double[][] appearanceRate = equations.calcRHS(appearing, 10.0);
     double[] appearedState = appearing[1].getStateVector();
     for (int equation = 0; equation < appearedState.length; equation++) {
-      appearedState[equation] += appearanceRate[1][equation];
+      appearedState[equation] += dtSeconds * appearanceRate[1][equation];
     }
     appearing[1].setStateVector(appearedState);
     appearing[1].extractPrimitiveVariables();
@@ -333,7 +334,7 @@ public class TwoFluidSectionTest {
     double[][] disappearanceRate = equations.calcRHS(disappearing, 10.0);
     double[] disappearedState = disappearing[1].getStateVector();
     for (int equation = 0; equation < disappearedState.length; equation++) {
-      disappearedState[equation] += disappearanceRate[1][equation];
+      disappearedState[equation] += dtSeconds * disappearanceRate[1][equation];
     }
     disappearing[1].setStateVector(disappearedState);
     disappearing[1].extractPrimitiveVariables();

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
@@ -294,6 +294,124 @@ public class TwoFluidSectionTest {
   }
 
   @Test
+  void testTerrainSegregationDoesNotCreateOilOrWaterMass() {
+    TwoFluidSection upstream = createThreePhaseBalanceSection(0.0, 1.0, -0.1);
+    TwoFluidSection valley = createThreePhaseBalanceSection(10.0, 0.0, 0.1);
+    TwoFluidSection downstream = createThreePhaseBalanceSection(20.0, 1.0, 0.1);
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+
+    equations.calcRHS(new TwoFluidSection[] { upstream, valley, downstream }, 10.0);
+
+    double[] sourceRates = equations.getLastMassBalanceRate().getSourceMassFlowKgPerSecond();
+    assertEquals(0.0, sourceRates[0] + sourceRates[1] + sourceRates[2], 1.0e-12,
+        "Oil-water segregation must be represented by momentum and fluxes, not a net domain mass source");
+    assertEquals(0.0, sourceRates[1], 1.0e-12, "Segregation must not convert oil mass locally");
+    assertEquals(0.0, sourceRates[2], 1.0e-12, "Segregation must not create water mass locally");
+  }
+
+  @Test
+  void testPhaseAppearanceAndDisappearanceRemainFiniteAndConservative() {
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    equations.setIncludeMassTransfer(true);
+
+    TwoFluidSection[] appearing = createUniformTransferSections(0.0, 0.1);
+    double initialAppearingMass = totalMassPerLength(appearing[1]);
+    double[][] appearanceRate = equations.calcRHS(appearing, 10.0);
+    double[] appearedState = appearing[1].getStateVector();
+    for (int equation = 0; equation < appearedState.length; equation++) {
+      appearedState[equation] += appearanceRate[1][equation];
+    }
+    appearing[1].setStateVector(appearedState);
+    appearing[1].extractPrimitiveVariables();
+
+    assertTrue(appearing[1].getGasMassPerLength() > 0.0, "Evaporation should make gas appear");
+    assertEquals(initialAppearingMass, totalMassPerLength(appearing[1]), 1.0e-12);
+    assertFiniteNonNegativePhaseMasses(appearing[1]);
+
+    TwoFluidSection[] disappearing = createUniformTransferSections(0.01, -0.1);
+    double initialDisappearingMass = totalMassPerLength(disappearing[1]);
+    double[][] disappearanceRate = equations.calcRHS(disappearing, 10.0);
+    double[] disappearedState = disappearing[1].getStateVector();
+    for (int equation = 0; equation < disappearedState.length; equation++) {
+      disappearedState[equation] += disappearanceRate[1][equation];
+    }
+    disappearing[1].setStateVector(disappearedState);
+    disappearing[1].extractPrimitiveVariables();
+
+    assertEquals(0.0, disappearing[1].getGasMassPerLength(), 1.0e-12,
+        "Condensation should allow gas to disappear without a negative phase mass");
+    assertEquals(initialDisappearingMass, totalMassPerLength(disappearing[1]), 1.0e-12);
+    assertFiniteNonNegativePhaseMasses(disappearing[1]);
+  }
+
+  private TwoFluidSection[] createUniformTransferSections(double gasMassPerLength,
+      double massTransferRateKgPerSecond) {
+    TwoFluidSection[] transferSections = new TwoFluidSection[3];
+    for (int index = 0; index < transferSections.length; index++) {
+      TwoFluidSection transferSection = createThreePhaseBalanceSection(index * 10.0, 0.0, 0.0);
+      transferSection.setGasMassPerLength(gasMassPerLength);
+      transferSection.setGasMomentumPerLength(0.0);
+      transferSection.setOilVelocity(0.0);
+      transferSection.setWaterVelocity(0.0);
+      transferSection.setLiquidVelocity(0.0);
+      transferSection.setOilMomentumPerLength(0.0);
+      transferSection.setWaterMomentumPerLength(0.0);
+      transferSection.setLiquidMomentumPerLength(0.0);
+      transferSection.setMassTransferRate(massTransferRateKgPerSecond);
+      transferSection.extractPrimitiveVariables();
+      transferSections[index] = transferSection;
+    }
+    return transferSections;
+  }
+
+  private double totalMassPerLength(TwoFluidSection balanceSection) {
+    return balanceSection.getGasMassPerLength() + balanceSection.getOilMassPerLength()
+        + balanceSection.getWaterMassPerLength();
+  }
+
+  private void assertFiniteNonNegativePhaseMasses(TwoFluidSection balanceSection) {
+    assertTrue(Double.isFinite(balanceSection.getGasMassPerLength()));
+    assertTrue(Double.isFinite(balanceSection.getOilMassPerLength()));
+    assertTrue(Double.isFinite(balanceSection.getWaterMassPerLength()));
+    assertTrue(balanceSection.getGasMassPerLength() >= 0.0);
+    assertTrue(balanceSection.getOilMassPerLength() >= 0.0);
+    assertTrue(balanceSection.getWaterMassPerLength() >= 0.0);
+  }
+
+  private TwoFluidSection createThreePhaseBalanceSection(double position, double elevation, double inclination) {
+    TwoFluidSection balanceSection = new TwoFluidSection(position, 10.0, 0.1, inclination);
+    balanceSection.setElevation(elevation);
+    balanceSection.setPressure(50.0e5);
+    balanceSection.setTemperature(300.0);
+    balanceSection.setGasDensity(40.0);
+    balanceSection.setOilDensity(700.0);
+    balanceSection.setWaterDensity(1000.0);
+    balanceSection.setLiquidDensity(850.0);
+    balanceSection.setGasViscosity(1.2e-5);
+    balanceSection.setOilViscosity(1.0e-3);
+    balanceSection.setWaterViscosity(1.0e-3);
+    balanceSection.setLiquidViscosity(1.0e-3);
+    balanceSection.setGasSoundSpeed(300.0);
+    balanceSection.setLiquidSoundSpeed(1200.0);
+    balanceSection.setGasEnthalpy(1.0e5);
+    balanceSection.setLiquidEnthalpy(5.0e4);
+    balanceSection.setSurfaceTension(0.02);
+    balanceSection.setGasHoldup(0.6);
+    balanceSection.setLiquidHoldup(0.4);
+    balanceSection.setOilHoldup(0.2);
+    balanceSection.setWaterHoldup(0.2);
+    balanceSection.setWaterCut(0.5);
+    balanceSection.setOilFractionInLiquid(0.5);
+    balanceSection.setGasVelocity(3.0);
+    balanceSection.setLiquidVelocity(0.5);
+    balanceSection.setOilVelocity(0.55);
+    balanceSection.setWaterVelocity(0.45);
+    balanceSection.updateConservativeVariables();
+    balanceSection.updateDerivedQuantities();
+    return balanceSection;
+  }
+
+  @Test
   void testShearStresses() {
     section.setGasWallShear(5.0);
     section.setLiquidWallShear(15.0);


### PR DESCRIPTION
## Summary

Complete the transient conservation work for `TwoFluidPipe` and make the phase-wise discrete balance directly observable.

This branch builds on the steady-to-transient handoff fix merged in #2724 and the primitive-projection removal merged in #2718, and addresses the remaining mass sources and diagnostics required by #2705.

Closes #2705.

## Root causes

Two additional non-conservative operations remained after #2718:

1. The terrain closure applied a local oil/water “segregation” mass relaxation. Its oil source was scaled by `rhoO / rhoW`, so it neither conserved oil/water separately nor cancelled in total mass. A deterministic three-cell valley produced a spurious `3.506354157104872e-3 kg/s` domain source.
2. The IMEX pressure corrector added `A * dp / c²` directly to conservative phase masses without a balancing boundary flux or physical source. A deterministic 1 ms step produced a `-3.720007720516873e-5 kg` total residual.
3. Closed boundary conditions were applied only between accepted steps. Intermediate RK stages could therefore regenerate boundary momentum and leak a small artificial mass flux.

## Implementation

- Remove the local oil/water mass relaxation. Segregation remains represented by separate phase momenta and conservative face fluxes.
- Leave phase masses unchanged in the IMEX pressure correction; the implicit correction acts on phase momenta only.
- Enforce boundary conditions at every RK/IMEX RHS evaluation.
- Record the exact phase-resolved inlet, outlet, and domain source rates used by each RHS stage.
- Integrate those terms only for accepted substeps with the matching Euler, RK2, RK4, SSP-RK3, or IMEX weights.
- Add `TwoFluidMassBalanceReport` with gas, oil, water, combined-liquid, and total inventories, transfers, signed residuals in kg, relative residuals, elapsed time, and tolerance checks.
- Preserve the #2724 one-time steady primitive-to-conservative handoff and conservative inlet-cell ownership.

The reported residual is:

`(final - initial) - (inlet - outlet + source)`.

Its relative scale remains finite when a phase starts from zero inventory.

## Validation

Deterministic Java 8 compilation and executable probes passed for:

- 6- and 12-section open pipes with 1 ms and 0.5 ms steps;
- closed inlet and outlet, including exactly zero integrated boundary flux;
- Euler, RK2, RK4, SSP-RK3, and IMEX;
- flash-driven gas/liquid transfer with equal-and-opposite total source;
- phase appearance from zero and disappearance to zero with finite, non-negative state and unchanged total mass;
- three-cell terrain valley source cancellation.

Every phase and aggregate report met `1e-7 kg` absolute or `1e-10` relative tolerance in these cases. Changed production and regression sources compile with Java 8 language targeting, and `git diff --check` passes.

The repository CI matrix remains the authoritative Maven/JUnit, Spotless, Javadoc, Java 8/21, Windows/Linux, and static-analysis validation because Maven Central resolution is unavailable in the local runtime.

## Regression coverage

- New end-to-end phase balance matrix for open/closed boundaries, mesh/time refinement, all integrators, IMEX, and flash transfer.
- New deterministic terrain source regression.
- New phase appearance/disappearance conservation regression.
- Retains #2724 steady/dynamic handoff and one-/two-/three-phase continuity regressions.
- Retains #2718 rate-step and inventory regressions.

## Documentation impact

`docs/process/TWOFLUIDPIPE_MODEL.md` now defines:

- conservative state ownership at the steady/transient handoff;
- the phase-resolved discrete balance and source sign convention;
- report API usage and deterministic tolerance guidance;
- accepted-stage integration behavior;
- conservative oil/water segregation and IMEX pressure correction behavior;
- closed- and open-boundary interpretations.

## Scope

This is a conservation and diagnostics correction. It does not claim OLGA/LedaFlow equivalence or recalibrate closure correlations.

## Coordination

#2724 merged while this draft was being prepared. The branch was then rebased onto its merge commit `e7b9e51d7a96898567b0f6269c7b7ebfc5237bf3`, so this PR contains only the remaining conservation and diagnostics diff.