### PR TITLE
fix: expose one-phase transient mass convergence

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -121,7 +121,7 @@ gas.initPhysicalProperties();
 gas.setTotalFlowRate(10.0, "MSm3/day");
 
 // Configure pipeline
-FlowSystemInterface pipe = new PipeFlowSystem();
+PipeFlowSystem pipe = new PipeFlowSystem();
 pipe.setInletThermoSystem(gas);
 pipe.setNumberOfLegs(10);
 pipe.setNumberOfNodesInLeg(20);
@@ -206,12 +206,13 @@ pipe.getTimeSeries().setInletThermoSystems(systems);
 pipe.getTimeSeries().setNumberOfTimeStepsInInterval(5);
 
 // Run transient simulation with full physics (type 20 = momentum + mass + energy + composition).
-// A coupled state that does not satisfy the finite-volume, EOS-density, and total-mass
-// criteria throws IllegalStateException instead of returning a stale result.
+// Strict mode throws when the finite-volume, EOS-density, and total-mass criteria fail.
+pipe.setFailOnNonConvergence(true);
 try {
     pipe.solveTransient(20);
 } catch (IllegalStateException nonConvergence) {
-    OnePhaseFlowConvergenceReport report = pipe.getConvergenceReport();
+    neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFlowConvergenceReport
+        report = pipe.getConvergenceReport();
     throw new IllegalStateException(report.toJson(), nonConvergence);
 }
 ```
@@ -219,8 +220,8 @@ try {
 ### Convergence and Total-Mass Diagnostics
 
 `PipeFlowSystem.getConvergenceReport()` returns an immutable report for the latest solve. For
-transient solver types that include total mass (`1`, `10`, and `20`), a completed solve requires
-all of the following:
+positive transient solver types that include total mass (including `1`, `10`, and `20`), a
+completed solve requires all of the following:
 
 - the nonlinear update residual is at most `1e-10`;
 - the maximum relative difference between the finite-volume and EOS density is at most `1e-8`;
@@ -229,11 +230,12 @@ all of the following:
 
 The report contains both residual histories, iteration count, initial/final finite-volume and EOS
 inventories in kg, integrated inlet and outlet masses in kg, and absolute/relative closure errors.
-If a transient mass/EOS solve misses any criterion, `solveTransient(...)` throws
-`IllegalStateException`; inspect the report to distinguish algebraic, density-consistency, and
-mass-balance failures. Node zero is a prescribed upstream boundary. The first accumulating
-control volume is node one, so the inlet density is imposed at row zero and only physical control
-volumes contribute to linepack.
+For backward-compatible control flow, the default logs a warning and returns the failed report.
+Call `pipe.setFailOnNonConvergence(true)` to make `solveTransient(...)` throw
+`IllegalStateException`; the report is recorded before either behavior and distinguishes
+algebraic, density-consistency, and mass-balance failures. Node zero is a prescribed upstream
+boundary. The first accumulating control volume is node one, so the inlet density is imposed at
+row zero and only physical control volumes contribute to linepack.
 
 ## Compositional Tracking
 

--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -205,9 +205,35 @@ SystemInterface[] systems = {coldGas, hotGas};
 pipe.getTimeSeries().setInletThermoSystems(systems);
 pipe.getTimeSeries().setNumberOfTimeStepsInInterval(5);
 
-// Run transient simulation with full physics (type 20 = momentum + mass + energy + composition)
-pipe.solveTransient(20);
+// Run transient simulation with full physics (type 20 = momentum + mass + energy + composition).
+// A coupled state that does not satisfy the finite-volume, EOS-density, and total-mass
+// criteria throws IllegalStateException instead of returning a stale result.
+try {
+    pipe.solveTransient(20);
+} catch (IllegalStateException nonConvergence) {
+    OnePhaseFlowConvergenceReport report = pipe.getConvergenceReport();
+    throw new IllegalStateException(report.toJson(), nonConvergence);
+}
 ```
+
+### Convergence and Total-Mass Diagnostics
+
+`PipeFlowSystem.getConvergenceReport()` returns an immutable report for the latest solve. For
+transient solver types that include total mass (`1`, `10`, and `20`), a completed solve requires
+all of the following:
+
+- the nonlinear update residual is at most `1e-10`;
+- the maximum relative difference between the finite-volume and EOS density is at most `1e-8`;
+- finite-volume and EOS inventory changes each agree with integrated inlet-minus-outlet mass to
+  a relative tolerance of `1e-8`.
+
+The report contains both residual histories, iteration count, initial/final finite-volume and EOS
+inventories in kg, integrated inlet and outlet masses in kg, and absolute/relative closure errors.
+If a transient mass/EOS solve misses any criterion, `solveTransient(...)` throws
+`IllegalStateException`; inspect the report to distinguish algebraic, density-consistency, and
+mass-balance failures. Node zero is a prescribed upstream boundary. The first accumulating
+control volume is node one, so the inlet density is imposed at row zero and only physical control
+volumes contribute to linepack.
 
 ## Compositional Tracking
 
@@ -221,7 +247,7 @@ In steady-state single-phase flow, composition is uniform throughout the pipelin
 
 ### Dynamic Composition Tracking
 
-Dynamic compositional tracking enables simulating slug flow, batch processing, and compositional transitions:
+The component equations provide an experimental basis for dynamic compositional transitions:
 
 1. `oldComposition[component][node]` stores previous time step values
 2. `setComponentConservationMatrix()` builds the discretized equations
@@ -289,17 +315,25 @@ The steady-state solver has been validated for:
 ## Known Limitations
 
 1. **Single-phase only**: No phase transition handling
-2. **Composition drift**: Small numerical drift (~1%) in composition over long pipelines
-3. **TimeSeries API**: Inlet systems array must have N-1 elements for N time points (one system per interval)
+2. **Component-transport validation is incomplete**: Conservative per-component inventories,
+   boundedness without normalization, analytical front speed, pulse breakthrough, and grid/time
+   convergence are not yet established. Do not use the current component result as a validated
+   compositional-tracking prediction.
+3. **No physical axial dispersion model**: Existing advection-scheme spreading is numerical and
+   must not be interpreted as molecular or turbulent dispersion.
+4. **Positive-flow diagnostic boundary**: Current transient mass diagnostics reject reverse
+   boundary flow because an external upwind thermodynamic state is not yet defined.
+5. **TimeSeries API**: Inlet systems array must have N-1 elements for N time points (one system per interval)
 
 ## Recommendations
 
 ### For Improved Mass Conservation
 
-Consider implementing:
+Planned dependency order is:
 - Pressure-velocity coupling (SIMPLE algorithm)
-- Higher-order convection schemes
-- Adaptive time stepping for transient simulations
+- Conservative per-component transport after total-mass/EOS convergence is demonstrated
+- Dimensionally valid higher-order convection only after first-order analytical validation
+- Explicit physical dispersion as a separate, documented model
 
 ### TimeSeries Best Practices
 
@@ -317,4 +351,3 @@ pipe.getTimeSeries().setInletThermoSystems(systems);
 
 1. Patankar, S.V. (1980). *Numerical Heat Transfer and Fluid Flow*. Hemisphere Publishing.
 2. Solbraa, E. (2002). *Equilibrium and Non-Equilibrium Thermodynamics of Natural Gas Processing*. PhD Thesis, NTNU.
-

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
@@ -42,8 +42,7 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   protected double[] oldInternalEnergy;
   protected double[] oldImpuls;
   protected double[] oldEnergy;
-  private OnePhaseFlowConvergenceReport lastConvergenceReport =
-      OnePhaseFlowConvergenceReport.notRun();
+  private OnePhaseFlowConvergenceReport lastConvergenceReport = OnePhaseFlowConvergenceReport.notRun();
 
   /**
    * Constructor for OnePhaseFixedStaggeredGrid.
@@ -95,8 +94,7 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
    * @return immutable convergence and total-mass report
    */
   public OnePhaseFlowConvergenceReport getLastConvergenceReport() {
-    return lastConvergenceReport == null ? OnePhaseFlowConvergenceReport.notRun()
-        : lastConvergenceReport;
+    return lastConvergenceReport == null ? OnePhaseFlowConvergenceReport.notRun() : lastConvergenceReport;
   }
 
   /**
@@ -1065,12 +1063,10 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
       nonlinearUpdateHistory[iterTop - 1] = Math.abs(maxDiff);
       densityResidualHistory[iterTop - 1] = densityResidual;
       // System.out.println("maxDiff " + maxDiff);
-    } while (!hasConverged(maxDiff, densityResidual)
-        && iterTop < MAXIMUM_NONLINEAR_ITERATIONS); // diffMatrix.norm2()/sol2Matrix.norm2())>0.1);
+    } while (!hasConverged(maxDiff, densityResidual) && iterTop < MAXIMUM_NONLINEAR_ITERATIONS); // diffMatrix.norm2()/sol2Matrix.norm2())>0.1);
 
-    lastConvergenceReport = createConvergenceReport(iterTop, maxDiff, densityResidual,
-        initialFiniteVolumeMass, Arrays.copyOf(nonlinearUpdateHistory, iterTop),
-        Arrays.copyOf(densityResidualHistory, iterTop));
+    lastConvergenceReport = createConvergenceReport(iterTop, maxDiff, densityResidual, initialFiniteVolumeMass,
+        Arrays.copyOf(nonlinearUpdateHistory, iterTop), Arrays.copyOf(densityResidualHistory, iterTop));
 
     if (dynamic && solverType > 0 && !lastConvergenceReport.isConverged()) {
       throw new IllegalStateException(lastConvergenceReport.getMessage());
@@ -1117,8 +1113,7 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   }
 
   private double getControlVolume(int node) {
-    return pipe.getNode(node).getGeometry().getArea()
-        * pipe.getNode(node).getGeometry().getNodeLength();
+    return pipe.getNode(node).getGeometry().getArea() * pipe.getNode(node).getGeometry().getNodeLength();
   }
 
   private double calculateMaximumRelativeDensityResidual() {
@@ -1129,10 +1124,8 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
     for (int i = 1; i < numberOfNodes; i++) {
       double finiteVolumeDensity = sol2Matrix.get(i, 0);
       double thermodynamicDensity = pipe.getNode(i).getBulkSystem().getPhases()[0].getDensity();
-      double scale = Math.max(Math.max(Math.abs(finiteVolumeDensity),
-          Math.abs(thermodynamicDensity)), 1.0e-30);
-      maximum = Math.max(maximum,
-          Math.abs(finiteVolumeDensity - thermodynamicDensity) / scale);
+      double scale = Math.max(Math.max(Math.abs(finiteVolumeDensity), Math.abs(thermodynamicDensity)), 1.0e-30);
+      maximum = Math.max(maximum, Math.abs(finiteVolumeDensity - thermodynamicDensity) / scale);
     }
     return maximum;
   }
@@ -1147,8 +1140,7 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
       return Double.NaN;
     }
 
-    double inletMassFlow = inletVelocity * pipe.getNode(0).getGeometry().getArea()
-        * sol2Matrix.get(0, 0);
+    double inletMassFlow = inletVelocity * pipe.getNode(0).getGeometry().getArea() * sol2Matrix.get(0, 0);
     return timeStep * inletMassFlow;
   }
 
@@ -1162,68 +1154,53 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
       return Double.NaN;
     }
 
-    double outletMassFlow = outletVelocity
-        * pipe.getNode(numberOfNodes - 1).getGeometry().getArea()
+    double outletMassFlow = outletVelocity * pipe.getNode(numberOfNodes - 1).getGeometry().getArea()
         * sol2Matrix.get(numberOfNodes - 1, 0);
     return timeStep * outletMassFlow;
   }
 
-  private OnePhaseFlowConvergenceReport createConvergenceReport(int nonlinearIterations,
-      double nonlinearUpdate, double densityResidual, double initialFiniteVolumeMass,
-      double[] nonlinearHistory, double[] densityHistory) {
+  private OnePhaseFlowConvergenceReport createConvergenceReport(int nonlinearIterations, double nonlinearUpdate,
+      double densityResidual, double initialFiniteVolumeMass, double[] nonlinearHistory, double[] densityHistory) {
     double finalFiniteVolumeMass = dynamic ? calculateFiniteVolumeMass() : Double.NaN;
     double finalThermodynamicMass = dynamic ? calculateThermodynamicMass() : Double.NaN;
     double inletBoundaryMass = calculateInletBoundaryMass();
     double outletBoundaryMass = calculateOutletBoundaryMass();
     double netBoundaryMass = inletBoundaryMass - outletBoundaryMass;
-    double finiteVolumeMassResidual = dynamic
-        ? finalFiniteVolumeMass - initialFiniteVolumeMass - netBoundaryMass
+    double finiteVolumeMassResidual = dynamic ? finalFiniteVolumeMass - initialFiniteVolumeMass - netBoundaryMass
         : Double.NaN;
-    double thermodynamicMassResidual = dynamic
-        ? finalThermodynamicMass - initialFiniteVolumeMass - netBoundaryMass
+    double thermodynamicMassResidual = dynamic ? finalThermodynamicMass - initialFiniteVolumeMass - netBoundaryMass
         : Double.NaN;
-    double massScale = dynamic
-        ? Math.max(Math.max(Math.abs(initialFiniteVolumeMass), Math.abs(netBoundaryMass)), 1.0)
+    double massScale = dynamic ? Math.max(Math.max(Math.abs(initialFiniteVolumeMass), Math.abs(netBoundaryMass)), 1.0)
         : Double.NaN;
-    double relativeFiniteVolumeMassResidual = dynamic
-        ? Math.abs(finiteVolumeMassResidual) / massScale
-        : Double.NaN;
-    double relativeThermodynamicMassResidual = dynamic
-        ? Math.abs(thermodynamicMassResidual) / massScale
-        : Double.NaN;
+    double relativeFiniteVolumeMassResidual = dynamic ? Math.abs(finiteVolumeMassResidual) / massScale : Double.NaN;
+    double relativeThermodynamicMassResidual = dynamic ? Math.abs(thermodynamicMassResidual) / massScale : Double.NaN;
 
     OnePhaseFlowConvergenceReport.ConvergenceReason reason;
     if (!diagnosticsAreFinite(nonlinearUpdate, densityResidual, relativeFiniteVolumeMassResidual,
         relativeThermodynamicMassResidual)) {
       reason = OnePhaseFlowConvergenceReport.ConvergenceReason.NON_FINITE_RESIDUAL;
-    } else if (!hasConverged(nonlinearUpdate, densityResidual)
-        && nonlinearIterations >= MAXIMUM_NONLINEAR_ITERATIONS) {
+    } else if (!hasConverged(nonlinearUpdate, densityResidual) && nonlinearIterations >= MAXIMUM_NONLINEAR_ITERATIONS) {
       reason = OnePhaseFlowConvergenceReport.ConvergenceReason.MAX_ITERATIONS_REACHED;
-    } else if (dynamic && solverType > 0
-        && densityResidual > DENSITY_RELATIVE_TOLERANCE) {
+    } else if (dynamic && solverType > 0 && densityResidual > DENSITY_RELATIVE_TOLERANCE) {
       reason = OnePhaseFlowConvergenceReport.ConvergenceReason.DENSITY_INCONSISTENT;
-    } else if (dynamic && solverType > 0
-        && (relativeFiniteVolumeMassResidual > MASS_BALANCE_RELATIVE_TOLERANCE
-            || relativeThermodynamicMassResidual > MASS_BALANCE_RELATIVE_TOLERANCE)) {
+    } else if (dynamic && solverType > 0 && (relativeFiniteVolumeMassResidual > MASS_BALANCE_RELATIVE_TOLERANCE
+        || relativeThermodynamicMassResidual > MASS_BALANCE_RELATIVE_TOLERANCE)) {
       reason = OnePhaseFlowConvergenceReport.ConvergenceReason.MASS_BALANCE_FAILED;
     } else {
       reason = OnePhaseFlowConvergenceReport.ConvergenceReason.CONVERGED;
     }
 
     String message = "One-phase pipe solve " + reason + " after " + nonlinearIterations
-        + " nonlinear iterations: update=" + Math.abs(nonlinearUpdate) + " (tolerance "
-        + NONLINEAR_UPDATE_TOLERANCE + "), EOS/FV density=" + densityResidual
-        + " (tolerance " + DENSITY_RELATIVE_TOLERANCE + "), FV mass residual="
-        + finiteVolumeMassResidual + " kg, EOS mass residual=" + thermodynamicMassResidual
-        + " kg (relative tolerance " + MASS_BALANCE_RELATIVE_TOLERANCE + ").";
+        + " nonlinear iterations: update=" + Math.abs(nonlinearUpdate) + " (tolerance " + NONLINEAR_UPDATE_TOLERANCE
+        + "), EOS/FV density=" + densityResidual + " (tolerance " + DENSITY_RELATIVE_TOLERANCE + "), FV mass residual="
+        + finiteVolumeMassResidual + " kg, EOS mass residual=" + thermodynamicMassResidual + " kg (relative tolerance "
+        + MASS_BALANCE_RELATIVE_TOLERANCE + ").";
 
-    return new OnePhaseFlowConvergenceReport(reason, dynamic, solverType,
-        nonlinearIterations, NONLINEAR_UPDATE_TOLERANCE, DENSITY_RELATIVE_TOLERANCE,
-        MASS_BALANCE_RELATIVE_TOLERANCE, Math.abs(nonlinearUpdate), densityResidual,
-        initialFiniteVolumeMass, finalFiniteVolumeMass, finalThermodynamicMass,
-        inletBoundaryMass, outletBoundaryMass, netBoundaryMass, finiteVolumeMassResidual,
-        thermodynamicMassResidual,
-        relativeFiniteVolumeMassResidual, relativeThermodynamicMassResidual,
+    return new OnePhaseFlowConvergenceReport(reason, dynamic, solverType, nonlinearIterations,
+        NONLINEAR_UPDATE_TOLERANCE, DENSITY_RELATIVE_TOLERANCE, MASS_BALANCE_RELATIVE_TOLERANCE,
+        Math.abs(nonlinearUpdate), densityResidual, initialFiniteVolumeMass, finalFiniteVolumeMass,
+        finalThermodynamicMass, inletBoundaryMass, outletBoundaryMass, netBoundaryMass, finiteVolumeMassResidual,
+        thermodynamicMassResidual, relativeFiniteVolumeMassResidual, relativeThermodynamicMassResidual,
         nonlinearHistory, densityHistory, message);
   }
 
@@ -1235,7 +1212,6 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
     if (!dynamic) {
       return true;
     }
-    return Double.isFinite(relativeFiniteVolumeMassResidual)
-        && Double.isFinite(relativeThermodynamicMassResidual);
+    return Double.isFinite(relativeFiniteVolumeMassResidual) && Double.isFinite(relativeThermodynamicMassResidual);
   }
 }

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
@@ -43,6 +43,7 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   protected double[] oldImpuls;
   protected double[] oldEnergy;
   private OnePhaseFlowConvergenceReport lastConvergenceReport = OnePhaseFlowConvergenceReport.notRun();
+  private boolean failOnNonConvergence;
 
   /**
    * Constructor for OnePhaseFixedStaggeredGrid.
@@ -95,6 +96,24 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
    */
   public OnePhaseFlowConvergenceReport getLastConvergenceReport() {
     return lastConvergenceReport == null ? OnePhaseFlowConvergenceReport.notRun() : lastConvergenceReport;
+  }
+
+  /**
+   * Configure whether a transient solve throws when the convergence report fails.
+   *
+   * @param failOnNonConvergence true to throw after recording a failed report; false to log a warning and return
+   */
+  public void setFailOnNonConvergence(boolean failOnNonConvergence) {
+    this.failOnNonConvergence = failOnNonConvergence;
+  }
+
+  /**
+   * Check whether failed transient convergence throws.
+   *
+   * @return true when strict fail-loud mode is enabled
+   */
+  public boolean isFailOnNonConvergence() {
+    return failOnNonConvergence;
   }
 
   /**
@@ -1069,7 +1088,10 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
         Arrays.copyOf(nonlinearUpdateHistory, iterTop), Arrays.copyOf(densityResidualHistory, iterTop));
 
     if (dynamic && solverType > 0 && !lastConvergenceReport.isConverged()) {
-      throw new IllegalStateException(lastConvergenceReport.getMessage());
+      if (failOnNonConvergence) {
+        throw new IllegalStateException(lastConvergenceReport.getMessage());
+      }
+      logger.warn("{}", lastConvergenceReport.getMessage());
     }
 
     initFinalResults();
@@ -1179,13 +1201,13 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
     if (!diagnosticsAreFinite(nonlinearUpdate, densityResidual, relativeFiniteVolumeMassResidual,
         relativeThermodynamicMassResidual)) {
       reason = OnePhaseFlowConvergenceReport.ConvergenceReason.NON_FINITE_RESIDUAL;
-    } else if (!hasConverged(nonlinearUpdate, densityResidual) && nonlinearIterations >= MAXIMUM_NONLINEAR_ITERATIONS) {
-      reason = OnePhaseFlowConvergenceReport.ConvergenceReason.MAX_ITERATIONS_REACHED;
     } else if (dynamic && solverType > 0 && densityResidual > DENSITY_RELATIVE_TOLERANCE) {
       reason = OnePhaseFlowConvergenceReport.ConvergenceReason.DENSITY_INCONSISTENT;
     } else if (dynamic && solverType > 0 && (relativeFiniteVolumeMassResidual > MASS_BALANCE_RELATIVE_TOLERANCE
         || relativeThermodynamicMassResidual > MASS_BALANCE_RELATIVE_TOLERANCE)) {
       reason = OnePhaseFlowConvergenceReport.ConvergenceReason.MASS_BALANCE_FAILED;
+    } else if (!hasConverged(nonlinearUpdate, densityResidual) && nonlinearIterations >= MAXIMUM_NONLINEAR_ITERATIONS) {
+      reason = OnePhaseFlowConvergenceReport.ConvergenceReason.MAX_ITERATIONS_REACHED;
     } else {
       reason = OnePhaseFlowConvergenceReport.ConvergenceReason.CONVERGED;
     }

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
@@ -6,6 +6,7 @@
 
 package neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver;
 
+import java.util.Arrays;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import Jama.Matrix;
@@ -24,6 +25,11 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(OnePhaseFixedStaggeredGrid.class);
 
+  private static final int MAXIMUM_NONLINEAR_ITERATIONS = 100;
+  private static final double NONLINEAR_UPDATE_TOLERANCE = 1.0e-10;
+  private static final double DENSITY_RELATIVE_TOLERANCE = 1.0e-8;
+  private static final double MASS_BALANCE_RELATIVE_TOLERANCE = 1.0e-8;
+
   Matrix diffMatrix;
   int iter = 0;
   Matrix[] diff4Matrix;
@@ -36,6 +42,8 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   protected double[] oldInternalEnergy;
   protected double[] oldImpuls;
   protected double[] oldEnergy;
+  private OnePhaseFlowConvergenceReport lastConvergenceReport =
+      OnePhaseFlowConvergenceReport.notRun();
 
   /**
    * Constructor for OnePhaseFixedStaggeredGrid.
@@ -79,6 +87,16 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
     }
 
     return clonedSystem;
+  }
+
+  /**
+   * Get diagnostics from the most recent solve.
+   *
+   * @return immutable convergence and total-mass report
+   */
+  public OnePhaseFlowConvergenceReport getLastConvergenceReport() {
+    return lastConvergenceReport == null ? OnePhaseFlowConvergenceReport.notRun()
+        : lastConvergenceReport;
   }
 
   /**
@@ -281,23 +299,12 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
       SU = pipe.getNode(0).getBulkSystem().getPhases()[0].getDensity();
       r[0] = SU;
     } else {
-      double Ae = pipe.getNode(1).getGeometry().getArea();
-      double Aw = pipe.getNode(0).getGeometry().getArea();
-      double Fw = pipe.getNode(0).getVelocityIn().doubleValue() * Aw;
-      double Fe = oldVelocity[1] * Ae;
-      // System.out.println("new- old : " +
-      // (pipe.getNode(0).getVelocityIn().doubleValue() - oldVelocity[0]));
-      oldMass[0] = 1.0 / timeStep * pipe.getNode(0).getGeometry().getArea()
-          * pipe.getNode(0).getGeometry().getNodeLength();
-
-      a[0] = Math.max(Fw, 0);
-      c[0] = Math.max(-Fe, 0);
-      b[0] = a[0] + c[0] + (Fe - Fw) + oldMass[0];
-      r[0] = oldMass[0] * oldDensity[0];
-
-      // setter ligningen paa rett form
-      // a[0] = - a[0];
-      // c[0] = -c[0];
+      // Node zero is the prescribed upstream boundary, not an accumulating control volume. The
+      // first physical control volume is node one and uses this density in its west-face flux.
+      a[0] = 0.0;
+      b[0] = 1.0;
+      c[0] = 0.0;
+      r[0] = pipe.getNode(0).getBulkSystem().getPhases()[0].getDensity();
     }
 
     for (int i = 1; i < numberOfNodes - 1; i++) {
@@ -951,7 +958,11 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
     int iter = 0;
     int iterTop = 0;
     double maxDiff = 1.0;
+    double densityResidual = Double.NaN;
     double diff = 0;
+    double[] nonlinearUpdateHistory = new double[MAXIMUM_NONLINEAR_ITERATIONS];
+    double[] densityResidualHistory = new double[MAXIMUM_NONLINEAR_ITERATIONS];
+    double initialFiniteVolumeMass = calculateInitialFiniteVolumeMass();
     xNew = new double[pipe.getNode(0).getBulkSystem().getPhases()[0].getNumberOfComponents()][numberOfNodes];
     if (!dynamic) {
       initProfiles();
@@ -1050,9 +1061,181 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
         } while (diff > 1e-15 && iter < 10);
       }
 
+      densityResidual = calculateMaximumRelativeDensityResidual();
+      nonlinearUpdateHistory[iterTop - 1] = Math.abs(maxDiff);
+      densityResidualHistory[iterTop - 1] = densityResidual;
       // System.out.println("maxDiff " + maxDiff);
-    } while (Math.abs(maxDiff) > 1e-10 && iterTop < 100); // diffMatrix.norm2()/sol2Matrix.norm2())>0.1);
+    } while (!hasConverged(maxDiff, densityResidual)
+        && iterTop < MAXIMUM_NONLINEAR_ITERATIONS); // diffMatrix.norm2()/sol2Matrix.norm2())>0.1);
+
+    lastConvergenceReport = createConvergenceReport(iterTop, maxDiff, densityResidual,
+        initialFiniteVolumeMass, Arrays.copyOf(nonlinearUpdateHistory, iterTop),
+        Arrays.copyOf(densityResidualHistory, iterTop));
+
+    if (dynamic && solverType > 0 && !lastConvergenceReport.isConverged()) {
+      throw new IllegalStateException(lastConvergenceReport.getMessage());
+    }
 
     initFinalResults();
+  }
+
+  private boolean hasConverged(double nonlinearUpdate, double densityResidual) {
+    if (!Double.isFinite(nonlinearUpdate) || !Double.isFinite(densityResidual)) {
+      return false;
+    }
+    if (Math.abs(nonlinearUpdate) > NONLINEAR_UPDATE_TOLERANCE) {
+      return false;
+    }
+    return !dynamic || solverType <= 0 || densityResidual <= DENSITY_RELATIVE_TOLERANCE;
+  }
+
+  private double calculateInitialFiniteVolumeMass() {
+    if (!dynamic || oldDensity == null) {
+      return Double.NaN;
+    }
+    double mass = 0.0;
+    for (int i = 1; i < numberOfNodes; i++) {
+      mass += oldDensity[i] * getControlVolume(i);
+    }
+    return mass;
+  }
+
+  private double calculateFiniteVolumeMass() {
+    double mass = 0.0;
+    for (int i = 1; i < numberOfNodes; i++) {
+      mass += sol2Matrix.get(i, 0) * getControlVolume(i);
+    }
+    return mass;
+  }
+
+  private double calculateThermodynamicMass() {
+    double mass = 0.0;
+    for (int i = 1; i < numberOfNodes; i++) {
+      mass += pipe.getNode(i).getBulkSystem().getPhases()[0].getDensity() * getControlVolume(i);
+    }
+    return mass;
+  }
+
+  private double getControlVolume(int node) {
+    return pipe.getNode(node).getGeometry().getArea()
+        * pipe.getNode(node).getGeometry().getNodeLength();
+  }
+
+  private double calculateMaximumRelativeDensityResidual() {
+    if (solverType <= 0) {
+      return 0.0;
+    }
+    double maximum = 0.0;
+    for (int i = 1; i < numberOfNodes; i++) {
+      double finiteVolumeDensity = sol2Matrix.get(i, 0);
+      double thermodynamicDensity = pipe.getNode(i).getBulkSystem().getPhases()[0].getDensity();
+      double scale = Math.max(Math.max(Math.abs(finiteVolumeDensity),
+          Math.abs(thermodynamicDensity)), 1.0e-30);
+      maximum = Math.max(maximum,
+          Math.abs(finiteVolumeDensity - thermodynamicDensity) / scale);
+    }
+    return maximum;
+  }
+
+  private double calculateInletBoundaryMass() {
+    if (!dynamic) {
+      return Double.NaN;
+    }
+
+    double inletVelocity = pipe.getNode(1).getVelocityIn().doubleValue();
+    if (inletVelocity < 0.0) {
+      return Double.NaN;
+    }
+
+    double inletMassFlow = inletVelocity * pipe.getNode(0).getGeometry().getArea()
+        * sol2Matrix.get(0, 0);
+    return timeStep * inletMassFlow;
+  }
+
+  private double calculateOutletBoundaryMass() {
+    if (!dynamic) {
+      return Double.NaN;
+    }
+
+    double outletVelocity = pipe.getNode(numberOfNodes - 1).getVelocity();
+    if (outletVelocity < 0.0) {
+      return Double.NaN;
+    }
+
+    double outletMassFlow = outletVelocity
+        * pipe.getNode(numberOfNodes - 1).getGeometry().getArea()
+        * sol2Matrix.get(numberOfNodes - 1, 0);
+    return timeStep * outletMassFlow;
+  }
+
+  private OnePhaseFlowConvergenceReport createConvergenceReport(int nonlinearIterations,
+      double nonlinearUpdate, double densityResidual, double initialFiniteVolumeMass,
+      double[] nonlinearHistory, double[] densityHistory) {
+    double finalFiniteVolumeMass = dynamic ? calculateFiniteVolumeMass() : Double.NaN;
+    double finalThermodynamicMass = dynamic ? calculateThermodynamicMass() : Double.NaN;
+    double inletBoundaryMass = calculateInletBoundaryMass();
+    double outletBoundaryMass = calculateOutletBoundaryMass();
+    double netBoundaryMass = inletBoundaryMass - outletBoundaryMass;
+    double finiteVolumeMassResidual = dynamic
+        ? finalFiniteVolumeMass - initialFiniteVolumeMass - netBoundaryMass
+        : Double.NaN;
+    double thermodynamicMassResidual = dynamic
+        ? finalThermodynamicMass - initialFiniteVolumeMass - netBoundaryMass
+        : Double.NaN;
+    double massScale = dynamic
+        ? Math.max(Math.max(Math.abs(initialFiniteVolumeMass), Math.abs(netBoundaryMass)), 1.0)
+        : Double.NaN;
+    double relativeFiniteVolumeMassResidual = dynamic
+        ? Math.abs(finiteVolumeMassResidual) / massScale
+        : Double.NaN;
+    double relativeThermodynamicMassResidual = dynamic
+        ? Math.abs(thermodynamicMassResidual) / massScale
+        : Double.NaN;
+
+    OnePhaseFlowConvergenceReport.ConvergenceReason reason;
+    if (!diagnosticsAreFinite(nonlinearUpdate, densityResidual, relativeFiniteVolumeMassResidual,
+        relativeThermodynamicMassResidual)) {
+      reason = OnePhaseFlowConvergenceReport.ConvergenceReason.NON_FINITE_RESIDUAL;
+    } else if (!hasConverged(nonlinearUpdate, densityResidual)
+        && nonlinearIterations >= MAXIMUM_NONLINEAR_ITERATIONS) {
+      reason = OnePhaseFlowConvergenceReport.ConvergenceReason.MAX_ITERATIONS_REACHED;
+    } else if (dynamic && solverType > 0
+        && densityResidual > DENSITY_RELATIVE_TOLERANCE) {
+      reason = OnePhaseFlowConvergenceReport.ConvergenceReason.DENSITY_INCONSISTENT;
+    } else if (dynamic && solverType > 0
+        && (relativeFiniteVolumeMassResidual > MASS_BALANCE_RELATIVE_TOLERANCE
+            || relativeThermodynamicMassResidual > MASS_BALANCE_RELATIVE_TOLERANCE)) {
+      reason = OnePhaseFlowConvergenceReport.ConvergenceReason.MASS_BALANCE_FAILED;
+    } else {
+      reason = OnePhaseFlowConvergenceReport.ConvergenceReason.CONVERGED;
+    }
+
+    String message = "One-phase pipe solve " + reason + " after " + nonlinearIterations
+        + " nonlinear iterations: update=" + Math.abs(nonlinearUpdate) + " (tolerance "
+        + NONLINEAR_UPDATE_TOLERANCE + "), EOS/FV density=" + densityResidual
+        + " (tolerance " + DENSITY_RELATIVE_TOLERANCE + "), FV mass residual="
+        + finiteVolumeMassResidual + " kg, EOS mass residual=" + thermodynamicMassResidual
+        + " kg (relative tolerance " + MASS_BALANCE_RELATIVE_TOLERANCE + ").";
+
+    return new OnePhaseFlowConvergenceReport(reason, dynamic, solverType,
+        nonlinearIterations, NONLINEAR_UPDATE_TOLERANCE, DENSITY_RELATIVE_TOLERANCE,
+        MASS_BALANCE_RELATIVE_TOLERANCE, Math.abs(nonlinearUpdate), densityResidual,
+        initialFiniteVolumeMass, finalFiniteVolumeMass, finalThermodynamicMass,
+        inletBoundaryMass, outletBoundaryMass, netBoundaryMass, finiteVolumeMassResidual,
+        thermodynamicMassResidual,
+        relativeFiniteVolumeMassResidual, relativeThermodynamicMassResidual,
+        nonlinearHistory, densityHistory, message);
+  }
+
+  private boolean diagnosticsAreFinite(double nonlinearUpdate, double densityResidual,
+      double relativeFiniteVolumeMassResidual, double relativeThermodynamicMassResidual) {
+    if (!Double.isFinite(nonlinearUpdate) || !Double.isFinite(densityResidual)) {
+      return false;
+    }
+    if (!dynamic) {
+      return true;
+    }
+    return Double.isFinite(relativeFiniteVolumeMassResidual)
+        && Double.isFinite(relativeThermodynamicMassResidual);
   }
 }

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFlowConvergenceReport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFlowConvergenceReport.java
@@ -8,9 +8,9 @@ import com.google.gson.GsonBuilder;
  * Immutable convergence and total-mass diagnostics from a one-phase pipe-flow solve.
  *
  * <p>
- * Nonlinear iterate changes, EOS-to-finite-volume density consistency, and transient total-mass
- * closure are reported separately. A small update does not establish convergence when the
- * thermodynamic density is inconsistent with the conservative density solution.
+ * Nonlinear iterate changes, EOS-to-finite-volume density consistency, and transient total-mass closure are reported
+ * separately. A small update does not establish convergence when the thermodynamic density is inconsistent with the
+ * conservative density solution.
  * </p>
  */
 public final class OnePhaseFlowConvergenceReport implements Serializable {
@@ -98,13 +98,12 @@ public final class OnePhaseFlowConvergenceReport implements Serializable {
    */
   public OnePhaseFlowConvergenceReport(ConvergenceReason reason, boolean dynamic, int solverType,
       int nonlinearIterations, double nonlinearUpdateTolerance, double densityRelativeTolerance,
-      double massBalanceRelativeTolerance, double maximumRelativeNonlinearUpdate,
-      double maximumRelativeDensityResidual, double initialFiniteVolumeMassKg,
-      double finalFiniteVolumeMassKg, double finalThermodynamicMassKg,
+      double massBalanceRelativeTolerance, double maximumRelativeNonlinearUpdate, double maximumRelativeDensityResidual,
+      double initialFiniteVolumeMassKg, double finalFiniteVolumeMassKg, double finalThermodynamicMassKg,
       double inletBoundaryMassKg, double outletBoundaryMassKg, double netBoundaryMassKg,
-      double finiteVolumeMassResidualKg, double thermodynamicMassResidualKg,
-      double relativeFiniteVolumeMassResidual, double relativeThermodynamicMassResidual,
-      double[] nonlinearUpdateHistory, double[] densityResidualHistory, String message) {
+      double finiteVolumeMassResidualKg, double thermodynamicMassResidualKg, double relativeFiniteVolumeMassResidual,
+      double relativeThermodynamicMassResidual, double[] nonlinearUpdateHistory, double[] densityResidualHistory,
+      String message) {
     this.reason = reason;
     this.dynamic = dynamic;
     this.solverType = solverType;
@@ -135,11 +134,9 @@ public final class OnePhaseFlowConvergenceReport implements Serializable {
    * @return not-run report
    */
   public static OnePhaseFlowConvergenceReport notRun() {
-    return new OnePhaseFlowConvergenceReport(ConvergenceReason.NOT_RUN, false, -1, 0,
-        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
-        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
-        Double.NaN, Double.NaN, Double.NaN, new double[0], new double[0],
-        "The solver has not run.");
+    return new OnePhaseFlowConvergenceReport(ConvergenceReason.NOT_RUN, false, -1, 0, Double.NaN, Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, new double[0], new double[0], "The solver has not run.");
   }
 
   /** @return reason why the solve stopped */

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFlowConvergenceReport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFlowConvergenceReport.java
@@ -3,6 +3,9 @@ package neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolv
 import java.io.Serializable;
 import java.util.Arrays;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
 
 /**
  * Immutable convergence and total-mass diagnostics from a one-phase pipe-flow solve.
@@ -260,7 +263,12 @@ public final class OnePhaseFlowConvergenceReport implements Serializable {
    * @return JSON representation
    */
   public String toJson() {
-    return new GsonBuilder().setPrettyPrinting().create().toJson(this);
+    JsonSerializer<Double> finiteDoubleSerializer = (value, type, context) -> value != null && Double.isFinite(value)
+        ? new JsonPrimitive(value)
+        : JsonNull.INSTANCE;
+    return new GsonBuilder().registerTypeAdapter(Double.class, finiteDoubleSerializer)
+        .registerTypeAdapter(Double.TYPE, finiteDoubleSerializer).serializeNulls().setPrettyPrinting().create()
+        .toJson(this);
   }
 
   private static double[] copy(double[] values) {

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFlowConvergenceReport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFlowConvergenceReport.java
@@ -1,0 +1,272 @@
+package neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Immutable convergence and total-mass diagnostics from a one-phase pipe-flow solve.
+ *
+ * <p>
+ * Nonlinear iterate changes, EOS-to-finite-volume density consistency, and transient total-mass
+ * closure are reported separately. A small update does not establish convergence when the
+ * thermodynamic density is inconsistent with the conservative density solution.
+ * </p>
+ */
+public final class OnePhaseFlowConvergenceReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Reason why the solve stopped. */
+  public enum ConvergenceReason {
+    /** No solve has been run. */
+    NOT_RUN(false),
+    /** Every applicable convergence criterion was satisfied. */
+    CONVERGED(true),
+    /** The maximum nonlinear iteration count was reached. */
+    MAX_ITERATIONS_REACHED(false),
+    /** At least one diagnostic was not finite. */
+    NON_FINITE_RESIDUAL(false),
+    /** EOS density remained inconsistent with finite-volume density. */
+    DENSITY_INCONSISTENT(false),
+    /** Finite-volume or thermodynamic total mass did not close. */
+    MASS_BALANCE_FAILED(false);
+
+    private final boolean converged;
+
+    ConvergenceReason(boolean converged) {
+      this.converged = converged;
+    }
+
+    /**
+     * Check whether this reason represents convergence.
+     *
+     * @return true only for {@link #CONVERGED}
+     */
+    public boolean isConverged() {
+      return converged;
+    }
+  }
+
+  private final ConvergenceReason reason;
+  private final boolean dynamic;
+  private final int solverType;
+  private final int nonlinearIterations;
+  private final double nonlinearUpdateTolerance;
+  private final double densityRelativeTolerance;
+  private final double massBalanceRelativeTolerance;
+  private final double maximumRelativeNonlinearUpdate;
+  private final double maximumRelativeDensityResidual;
+  private final double initialFiniteVolumeMassKg;
+  private final double finalFiniteVolumeMassKg;
+  private final double finalThermodynamicMassKg;
+  private final double inletBoundaryMassKg;
+  private final double outletBoundaryMassKg;
+  private final double netBoundaryMassKg;
+  private final double finiteVolumeMassResidualKg;
+  private final double thermodynamicMassResidualKg;
+  private final double relativeFiniteVolumeMassResidual;
+  private final double relativeThermodynamicMassResidual;
+  private final double[] nonlinearUpdateHistory;
+  private final double[] densityResidualHistory;
+  private final String message;
+
+  /**
+   * Create a convergence report.
+   *
+   * @param reason reason why the solve stopped
+   * @param dynamic true for a transient solve
+   * @param solverType selected solver type
+   * @param nonlinearIterations number of coupled nonlinear iterations
+   * @param nonlinearUpdateTolerance relative nonlinear update tolerance
+   * @param densityRelativeTolerance relative EOS-density tolerance
+   * @param massBalanceRelativeTolerance relative total-mass tolerance
+   * @param maximumRelativeNonlinearUpdate final nonlinear update residual
+   * @param maximumRelativeDensityResidual final EOS/FV density residual
+   * @param initialFiniteVolumeMassKg previous-time finite-volume mass in kg
+   * @param finalFiniteVolumeMassKg final conservative mass in kg
+   * @param finalThermodynamicMassKg final mass calculated from EOS densities in kg
+   * @param inletBoundaryMassKg integrated inlet mass in kg
+   * @param outletBoundaryMassKg integrated outlet mass in kg
+   * @param netBoundaryMassKg integrated inlet-minus-outlet boundary mass in kg
+   * @param finiteVolumeMassResidualKg conservative inventory residual in kg
+   * @param thermodynamicMassResidualKg thermodynamic inventory residual in kg
+   * @param relativeFiniteVolumeMassResidual relative conservative inventory residual
+   * @param relativeThermodynamicMassResidual relative thermodynamic inventory residual
+   * @param nonlinearUpdateHistory nonlinear update residual history
+   * @param densityResidualHistory EOS/FV density residual history
+   * @param message diagnostic summary
+   */
+  public OnePhaseFlowConvergenceReport(ConvergenceReason reason, boolean dynamic, int solverType,
+      int nonlinearIterations, double nonlinearUpdateTolerance, double densityRelativeTolerance,
+      double massBalanceRelativeTolerance, double maximumRelativeNonlinearUpdate,
+      double maximumRelativeDensityResidual, double initialFiniteVolumeMassKg,
+      double finalFiniteVolumeMassKg, double finalThermodynamicMassKg,
+      double inletBoundaryMassKg, double outletBoundaryMassKg, double netBoundaryMassKg,
+      double finiteVolumeMassResidualKg, double thermodynamicMassResidualKg,
+      double relativeFiniteVolumeMassResidual, double relativeThermodynamicMassResidual,
+      double[] nonlinearUpdateHistory, double[] densityResidualHistory, String message) {
+    this.reason = reason;
+    this.dynamic = dynamic;
+    this.solverType = solverType;
+    this.nonlinearIterations = nonlinearIterations;
+    this.nonlinearUpdateTolerance = nonlinearUpdateTolerance;
+    this.densityRelativeTolerance = densityRelativeTolerance;
+    this.massBalanceRelativeTolerance = massBalanceRelativeTolerance;
+    this.maximumRelativeNonlinearUpdate = maximumRelativeNonlinearUpdate;
+    this.maximumRelativeDensityResidual = maximumRelativeDensityResidual;
+    this.initialFiniteVolumeMassKg = initialFiniteVolumeMassKg;
+    this.finalFiniteVolumeMassKg = finalFiniteVolumeMassKg;
+    this.finalThermodynamicMassKg = finalThermodynamicMassKg;
+    this.inletBoundaryMassKg = inletBoundaryMassKg;
+    this.outletBoundaryMassKg = outletBoundaryMassKg;
+    this.netBoundaryMassKg = netBoundaryMassKg;
+    this.finiteVolumeMassResidualKg = finiteVolumeMassResidualKg;
+    this.thermodynamicMassResidualKg = thermodynamicMassResidualKg;
+    this.relativeFiniteVolumeMassResidual = relativeFiniteVolumeMassResidual;
+    this.relativeThermodynamicMassResidual = relativeThermodynamicMassResidual;
+    this.nonlinearUpdateHistory = copy(nonlinearUpdateHistory);
+    this.densityResidualHistory = copy(densityResidualHistory);
+    this.message = message;
+  }
+
+  /**
+   * Create a report for a solver that has not run.
+   *
+   * @return not-run report
+   */
+  public static OnePhaseFlowConvergenceReport notRun() {
+    return new OnePhaseFlowConvergenceReport(ConvergenceReason.NOT_RUN, false, -1, 0,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, new double[0], new double[0],
+        "The solver has not run.");
+  }
+
+  /** @return reason why the solve stopped */
+  public ConvergenceReason getReason() {
+    return reason;
+  }
+
+  /** @return true when every applicable criterion passed */
+  public boolean isConverged() {
+    return reason.isConverged();
+  }
+
+  /** @return true for a transient solve */
+  public boolean isDynamic() {
+    return dynamic;
+  }
+
+  /** @return selected solver type */
+  public int getSolverType() {
+    return solverType;
+  }
+
+  /** @return number of coupled nonlinear iterations */
+  public int getNonlinearIterations() {
+    return nonlinearIterations;
+  }
+
+  /** @return relative nonlinear update tolerance */
+  public double getNonlinearUpdateTolerance() {
+    return nonlinearUpdateTolerance;
+  }
+
+  /** @return relative EOS-density consistency tolerance */
+  public double getDensityRelativeTolerance() {
+    return densityRelativeTolerance;
+  }
+
+  /** @return relative total-mass tolerance */
+  public double getMassBalanceRelativeTolerance() {
+    return massBalanceRelativeTolerance;
+  }
+
+  /** @return final nonlinear update residual */
+  public double getMaximumRelativeNonlinearUpdate() {
+    return maximumRelativeNonlinearUpdate;
+  }
+
+  /** @return final maximum EOS/FV density residual */
+  public double getMaximumRelativeDensityResidual() {
+    return maximumRelativeDensityResidual;
+  }
+
+  /** @return previous-time finite-volume mass in kg */
+  public double getInitialFiniteVolumeMassKg() {
+    return initialFiniteVolumeMassKg;
+  }
+
+  /** @return final conservative finite-volume mass in kg */
+  public double getFinalFiniteVolumeMassKg() {
+    return finalFiniteVolumeMassKg;
+  }
+
+  /** @return final mass calculated from EOS densities in kg */
+  public double getFinalThermodynamicMassKg() {
+    return finalThermodynamicMassKg;
+  }
+
+  /** @return integrated inlet mass in kg */
+  public double getInletBoundaryMassKg() {
+    return inletBoundaryMassKg;
+  }
+
+  /** @return integrated outlet mass in kg */
+  public double getOutletBoundaryMassKg() {
+    return outletBoundaryMassKg;
+  }
+
+  /** @return integrated inlet-minus-outlet boundary mass in kg */
+  public double getNetBoundaryMassKg() {
+    return netBoundaryMassKg;
+  }
+
+  /** @return conservative inventory residual in kg */
+  public double getFiniteVolumeMassResidualKg() {
+    return finiteVolumeMassResidualKg;
+  }
+
+  /** @return thermodynamic inventory residual in kg */
+  public double getThermodynamicMassResidualKg() {
+    return thermodynamicMassResidualKg;
+  }
+
+  /** @return relative conservative inventory residual */
+  public double getRelativeFiniteVolumeMassResidual() {
+    return relativeFiniteVolumeMassResidual;
+  }
+
+  /** @return relative thermodynamic inventory residual */
+  public double getRelativeThermodynamicMassResidual() {
+    return relativeThermodynamicMassResidual;
+  }
+
+  /** @return defensive copy of nonlinear update history */
+  public double[] getNonlinearUpdateHistory() {
+    return copy(nonlinearUpdateHistory);
+  }
+
+  /** @return defensive copy of EOS/FV density residual history */
+  public double[] getDensityResidualHistory() {
+    return copy(densityResidualHistory);
+  }
+
+  /** @return diagnostic summary */
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Serialize this report as stable, pretty-printed JSON.
+   *
+   * @return JSON representation
+   */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(this);
+  }
+
+  private static double[] copy(double[] values) {
+    return values == null ? new double[0] : Arrays.copyOf(values, values.length);
+  }
+}

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFlowConvergenceReport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFlowConvergenceReport.java
@@ -263,9 +263,8 @@ public final class OnePhaseFlowConvergenceReport implements Serializable {
    * @return JSON representation
    */
   public String toJson() {
-    JsonSerializer<Double> finiteDoubleSerializer = (value, type, context) -> value != null && Double.isFinite(value)
-        ? new JsonPrimitive(value)
-        : JsonNull.INSTANCE;
+    JsonSerializer<Double> finiteDoubleSerializer = (value, type,
+        context) -> value != null && Double.isFinite(value) ? new JsonPrimitive(value) : JsonNull.INSTANCE;
     return new GsonBuilder().registerTypeAdapter(Double.class, finiteDoubleSerializer)
         .registerTypeAdapter(Double.TYPE, finiteDoubleSerializer).serializeNulls().setPrettyPrinting().create()
         .toJson(this);

--- a/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
@@ -1,6 +1,8 @@
 package neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem;
 
 import java.util.UUID;
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFixedStaggeredGrid;
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFlowConvergenceReport;
 import neqsim.fluidmechanics.util.fluidmechanicsvisualization.flowsystemvisualization.onephaseflowvisualization.pipeflowvisualization.PipeFlowVisualization;
 import neqsim.thermo.system.SystemInterface;
 
@@ -18,6 +20,23 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
    * Constructor for PipeFlowSystem.
    */
   public PipeFlowSystem() {
+  }
+
+  /**
+   * Get nonlinear convergence and total-mass diagnostics from the latest pipe solve.
+   *
+   * <p>
+   * The returned report is immutable. Before the first solve it has reason
+   * {@link OnePhaseFlowConvergenceReport.ConvergenceReason#NOT_RUN}.
+   * </p>
+   *
+   * @return latest one-phase convergence report
+   */
+  public OnePhaseFlowConvergenceReport getConvergenceReport() {
+    if (flowSolver instanceof OnePhaseFixedStaggeredGrid) {
+      return ((OnePhaseFixedStaggeredGrid) flowSolver).getLastConvergenceReport();
+    }
+    return OnePhaseFlowConvergenceReport.notRun();
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
@@ -15,6 +15,7 @@ import neqsim.thermo.system.SystemInterface;
 public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflowsystem.OnePhaseFlowSystem {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  private boolean failOnNonConvergence;
 
   /**
    * Constructor for PipeFlowSystem.
@@ -37,6 +38,36 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
       return ((OnePhaseFixedStaggeredGrid) flowSolver).getLastConvergenceReport();
     }
     return OnePhaseFlowConvergenceReport.notRun();
+  }
+
+  /**
+   * Configure whether a transient solve throws when its convergence report fails.
+   *
+   * <p>
+   * The default is false for source and behavioral compatibility. Failed convergence is still recorded by
+   * {@link #getConvergenceReport()} and logged as a warning.
+   * </p>
+   *
+   * @param failOnNonConvergence true to throw after recording a failed report
+   */
+  public void setFailOnNonConvergence(boolean failOnNonConvergence) {
+    this.failOnNonConvergence = failOnNonConvergence;
+    configureConvergencePolicy();
+  }
+
+  /**
+   * Check whether failed transient convergence throws.
+   *
+   * @return true when strict fail-loud mode is enabled
+   */
+  public boolean isFailOnNonConvergence() {
+    return failOnNonConvergence;
+  }
+
+  private void configureConvergencePolicy() {
+    if (flowSolver instanceof OnePhaseFixedStaggeredGrid) {
+      ((OnePhaseFixedStaggeredGrid) flowSolver).setFailOnNonConvergence(failOnNonConvergence);
+    }
   }
 
   /** {@inheritDoc} */
@@ -88,6 +119,7 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
     // getTotalNumberOfNodes());
     flowSolver = new neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFixedStaggeredGrid(
         this, getSystemLength(), getTotalNumberOfNodes(), false);
+    configureConvergencePolicy();
     flowSolver.setSolverType(type);
     flowSolver.solveTDMA();
     getTimeSeries().init(this);
@@ -101,6 +133,7 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
     getTimeSeries().init(this);
     display = new PipeFlowVisualization(this.getTotalNumberOfNodes(), getTimeSeries().getTime().length);
     flowSolver.setDynamic(true);
+    configureConvergencePolicy();
     flowSolver.setSolverType(type);
 
     int outletNodeIndex = getTotalNumberOfNodes() - 1;

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseFlowConvergenceTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseFlowConvergenceTest.java
@@ -77,9 +77,9 @@ class OnePhaseFlowConvergenceTest extends neqsim.NeqSimTest {
     pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);
 
     IllegalStateException failure = assertThrows(IllegalStateException.class, () -> pipe.solveTransient(20));
-    assertTrue(failure.getMessage().contains("EOS/FV density"));
-    assertTrue(failure.getMessage().contains("FV mass residual"));
-    return pipe.getConvergenceReport();
+    OnePhaseFlowConvergenceReport report = pipe.getConvergenceReport();
+    assertEquals(report.getMessage(), failure.getMessage());
+    return report;
   }
 
   private static PipeFlowSystem createInitializedPipe() {

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseFlowConvergenceTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseFlowConvergenceTest.java
@@ -1,0 +1,136 @@
+package neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFlowConvergenceReport;
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFlowConvergenceReport.ConvergenceReason;
+import neqsim.fluidmechanics.geometrydefinitions.GeometryDefinitionInterface;
+import neqsim.fluidmechanics.geometrydefinitions.pipe.PipeData;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests one-phase transient nonlinear and finite-volume mass diagnostics. */
+class OnePhaseFlowConvergenceTest extends neqsim.NeqSimTest {
+  private static final double TEMPERATURE_K = 288.15;
+  private static final double PRESSURE_BARA = 70.0;
+  private static final double MASS_FLOW_KG_PER_SECOND = 50.0;
+
+  @Test
+  void compositionStepClosesFiniteVolumeMassAndFailsOnStaleEosDensity() {
+    PipeFlowSystem pipe = createInitializedPipe();
+    OnePhaseFlowConvergenceReport report = runCompositionStep(pipe, 30.0);
+
+    assertEquals(ConvergenceReason.MAX_ITERATIONS_REACHED, report.getReason());
+    assertEquals(100, report.getNonlinearIterations());
+    assertTrue(report.getRelativeFiniteVolumeMassResidual() < 1.0e-12,
+        "The authoritative finite-volume inventory must close to roundoff: "
+            + report.getFiniteVolumeMassResidualKg() + " kg");
+    assertTrue(report.getMaximumRelativeDensityResidual() > report.getDensityRelativeTolerance(),
+        "The unconverged EOS density must remain visible.");
+    assertTrue(report.getRelativeThermodynamicMassResidual()
+        > report.getMassBalanceRelativeTolerance(),
+        "Thermodynamic inventory must not be accepted while EOS density is stale.");
+
+    double impliedInletMassFlow = report.getInletBoundaryMassKg() / 30.0;
+    assertTrue(impliedInletMassFlow > 45.0 && impliedInletMassFlow < 60.0,
+        "The prescribed inlet density must supply the approximately 50 kg/s boundary flux: "
+            + impliedInletMassFlow + " kg/s");
+
+    double[] nonlinearHistory = report.getNonlinearUpdateHistory();
+    double[] densityHistory = report.getDensityResidualHistory();
+    assertEquals(report.getNonlinearIterations(), nonlinearHistory.length);
+    assertEquals(report.getNonlinearIterations(), densityHistory.length);
+    assertTrue(nonlinearHistory[0] > nonlinearHistory[nonlinearHistory.length - 1],
+        "The update history must show the converged algebraic iterate.");
+    assertAllFinite(nonlinearHistory);
+    assertAllFinite(densityHistory);
+  }
+
+  @Test
+  void diagnosticsAreDeterministicAndExposeTimestepSensitivity() {
+    OnePhaseFlowConvergenceReport thirtySecondA =
+        runCompositionStep(createInitializedPipe(), 30.0);
+    OnePhaseFlowConvergenceReport thirtySecondB =
+        runCompositionStep(createInitializedPipe(), 30.0);
+    OnePhaseFlowConvergenceReport fifteenSecond =
+        runCompositionStep(createInitializedPipe(), 15.0);
+
+    assertEquals(thirtySecondA.getReason(), thirtySecondB.getReason());
+    assertEquals(thirtySecondA.getMaximumRelativeDensityResidual(),
+        thirtySecondB.getMaximumRelativeDensityResidual(), 0.0);
+    assertEquals(thirtySecondA.getFiniteVolumeMassResidualKg(),
+        thirtySecondB.getFiniteVolumeMassResidualKg(), 0.0);
+    assertArrayEquals(thirtySecondA.getNonlinearUpdateHistory(),
+        thirtySecondB.getNonlinearUpdateHistory(), 0.0);
+    assertArrayEquals(thirtySecondA.getDensityResidualHistory(),
+        thirtySecondB.getDensityResidualHistory(), 0.0);
+
+    assertTrue(fifteenSecond.getMaximumRelativeDensityResidual()
+        < thirtySecondA.getMaximumRelativeDensityResidual(),
+        "The shorter step must expose a smaller EOS/FV density inconsistency.");
+    assertTrue(Math.abs(fifteenSecond.getThermodynamicMassResidualKg())
+        < Math.abs(thirtySecondA.getThermodynamicMassResidualKg()),
+        "The shorter step must expose a smaller EOS inventory inconsistency.");
+    assertTrue(fifteenSecond.getRelativeFiniteVolumeMassResidual() < 1.0e-12);
+  }
+
+  private static OnePhaseFlowConvergenceReport runCompositionStep(PipeFlowSystem pipe,
+      double timeStep) {
+    SystemInterface eventGas = createGas(0.80, 0.20);
+    pipe.getTimeSeries().setTimes(new double[] {0.0, timeStep});
+    pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] {eventGas});
+    pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);
+
+    IllegalStateException failure =
+        assertThrows(IllegalStateException.class, () -> pipe.solveTransient(20));
+    assertTrue(failure.getMessage().contains("EOS/FV density"));
+    assertTrue(failure.getMessage().contains("FV mass residual"));
+    return pipe.getConvergenceReport();
+  }
+
+  private static PipeFlowSystem createInitializedPipe() {
+    PipeFlowSystem pipe = new PipeFlowSystem();
+    pipe.setInletThermoSystem(createGas(0.95, 0.05));
+    pipe.setNumberOfLegs(1);
+    pipe.setNumberOfNodesInLeg(40);
+
+    GeometryDefinitionInterface[] geometry = {new PipeData(), new PipeData()};
+    for (GeometryDefinitionInterface section : geometry) {
+      section.setDiameter(0.5);
+      section.setInnerSurfaceRoughness(1.0e-5);
+    }
+    pipe.setEquipmentGeometry(geometry);
+    pipe.setLegHeights(new double[] {0.0, 0.0});
+    pipe.setLegPositions(new double[] {0.0, 15000.0});
+    pipe.setLegOuterTemperatures(new double[] {TEMPERATURE_K, TEMPERATURE_K});
+    pipe.setLegWallHeatTransferCoefficients(new double[] {0.0, 0.0});
+    pipe.setLegOuterHeatTransferCoefficients(new double[] {0.0, 0.0});
+    pipe.createSystem();
+    pipe.init();
+    pipe.solveSteadyState(20);
+    assertTrue(pipe.getConvergenceReport().isConverged());
+    return pipe;
+  }
+
+  private static SystemInterface createGas(double methane, double nitrogen) {
+    SystemInterface gas = new SystemSrkEos(TEMPERATURE_K, PRESSURE_BARA);
+    gas.addComponent("methane", methane);
+    gas.addComponent("nitrogen", nitrogen);
+    gas.createDatabase(true);
+    gas.setMixingRule("classic");
+    gas.init(0);
+    gas.init(3);
+    gas.initPhysicalProperties();
+    gas.setTotalFlowRate(MASS_FLOW_KG_PER_SECOND, "kg/sec");
+    return gas;
+  }
+
+  private static void assertAllFinite(double[] values) {
+    for (double value : values) {
+      assertTrue(Double.isFinite(value), "Residual history must contain only finite values.");
+    }
+  }
+}

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseFlowConvergenceTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseFlowConvergenceTest.java
@@ -1,7 +1,9 @@
 package neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
@@ -23,7 +25,7 @@ class OnePhaseFlowConvergenceTest extends neqsim.NeqSimTest {
     PipeFlowSystem pipe = createInitializedPipe();
     OnePhaseFlowConvergenceReport report = runCompositionStep(pipe, 30.0);
 
-    assertEquals(ConvergenceReason.MAX_ITERATIONS_REACHED, report.getReason());
+    assertEquals(ConvergenceReason.DENSITY_INCONSISTENT, report.getReason());
     assertEquals(100, report.getNonlinearIterations());
     assertTrue(report.getRelativeFiniteVolumeMassResidual() < 1.0e-12,
         "The authoritative finite-volume inventory must close to roundoff: " + report.getFiniteVolumeMassResidualKg()
@@ -70,16 +72,33 @@ class OnePhaseFlowConvergenceTest extends neqsim.NeqSimTest {
     assertTrue(fifteenSecond.getRelativeFiniteVolumeMassResidual() < 1.0e-12);
   }
 
+  @Test
+  void compatibilityModeReturnsTheFailedReportWithoutThrowing() {
+    PipeFlowSystem pipe = createInitializedPipe();
+    configureCompositionStep(pipe, 30.0);
+
+    assertFalse(pipe.isFailOnNonConvergence());
+    assertDoesNotThrow(() -> pipe.solveTransient(20));
+    assertEquals(ConvergenceReason.DENSITY_INCONSISTENT, pipe.getConvergenceReport().getReason());
+    assertDoesNotThrow(() -> OnePhaseFlowConvergenceReport.notRun().toJson());
+  }
+
   private static OnePhaseFlowConvergenceReport runCompositionStep(PipeFlowSystem pipe, double timeStep) {
-    SystemInterface eventGas = createGas(0.80, 0.20);
-    pipe.getTimeSeries().setTimes(new double[] { 0.0, timeStep });
-    pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] { eventGas });
-    pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);
+    configureCompositionStep(pipe, timeStep);
+    pipe.setFailOnNonConvergence(true);
+    assertTrue(pipe.isFailOnNonConvergence());
 
     IllegalStateException failure = assertThrows(IllegalStateException.class, () -> pipe.solveTransient(20));
     OnePhaseFlowConvergenceReport report = pipe.getConvergenceReport();
     assertEquals(report.getMessage(), failure.getMessage());
     return report;
+  }
+
+  private static void configureCompositionStep(PipeFlowSystem pipe, double timeStep) {
+    SystemInterface eventGas = createGas(0.80, 0.20);
+    pipe.getTimeSeries().setTimes(new double[] { 0.0, timeStep });
+    pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] { eventGas });
+    pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);
   }
 
   private static PipeFlowSystem createInitializedPipe() {

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseFlowConvergenceTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseFlowConvergenceTest.java
@@ -26,18 +26,17 @@ class OnePhaseFlowConvergenceTest extends neqsim.NeqSimTest {
     assertEquals(ConvergenceReason.MAX_ITERATIONS_REACHED, report.getReason());
     assertEquals(100, report.getNonlinearIterations());
     assertTrue(report.getRelativeFiniteVolumeMassResidual() < 1.0e-12,
-        "The authoritative finite-volume inventory must close to roundoff: "
-            + report.getFiniteVolumeMassResidualKg() + " kg");
+        "The authoritative finite-volume inventory must close to roundoff: " + report.getFiniteVolumeMassResidualKg()
+            + " kg");
     assertTrue(report.getMaximumRelativeDensityResidual() > report.getDensityRelativeTolerance(),
         "The unconverged EOS density must remain visible.");
-    assertTrue(report.getRelativeThermodynamicMassResidual()
-        > report.getMassBalanceRelativeTolerance(),
+    assertTrue(report.getRelativeThermodynamicMassResidual() > report.getMassBalanceRelativeTolerance(),
         "Thermodynamic inventory must not be accepted while EOS density is stale.");
 
     double impliedInletMassFlow = report.getInletBoundaryMassKg() / 30.0;
     assertTrue(impliedInletMassFlow > 45.0 && impliedInletMassFlow < 60.0,
-        "The prescribed inlet density must supply the approximately 50 kg/s boundary flux: "
-            + impliedInletMassFlow + " kg/s");
+        "The prescribed inlet density must supply the approximately 50 kg/s boundary flux: " + impliedInletMassFlow
+            + " kg/s");
 
     double[] nonlinearHistory = report.getNonlinearUpdateHistory();
     double[] densityHistory = report.getDensityResidualHistory();
@@ -51,41 +50,33 @@ class OnePhaseFlowConvergenceTest extends neqsim.NeqSimTest {
 
   @Test
   void diagnosticsAreDeterministicAndExposeTimestepSensitivity() {
-    OnePhaseFlowConvergenceReport thirtySecondA =
-        runCompositionStep(createInitializedPipe(), 30.0);
-    OnePhaseFlowConvergenceReport thirtySecondB =
-        runCompositionStep(createInitializedPipe(), 30.0);
-    OnePhaseFlowConvergenceReport fifteenSecond =
-        runCompositionStep(createInitializedPipe(), 15.0);
+    OnePhaseFlowConvergenceReport thirtySecondA = runCompositionStep(createInitializedPipe(), 30.0);
+    OnePhaseFlowConvergenceReport thirtySecondB = runCompositionStep(createInitializedPipe(), 30.0);
+    OnePhaseFlowConvergenceReport fifteenSecond = runCompositionStep(createInitializedPipe(), 15.0);
 
     assertEquals(thirtySecondA.getReason(), thirtySecondB.getReason());
-    assertEquals(thirtySecondA.getMaximumRelativeDensityResidual(),
-        thirtySecondB.getMaximumRelativeDensityResidual(), 0.0);
-    assertEquals(thirtySecondA.getFiniteVolumeMassResidualKg(),
-        thirtySecondB.getFiniteVolumeMassResidualKg(), 0.0);
-    assertArrayEquals(thirtySecondA.getNonlinearUpdateHistory(),
-        thirtySecondB.getNonlinearUpdateHistory(), 0.0);
-    assertArrayEquals(thirtySecondA.getDensityResidualHistory(),
-        thirtySecondB.getDensityResidualHistory(), 0.0);
+    assertEquals(thirtySecondA.getMaximumRelativeDensityResidual(), thirtySecondB.getMaximumRelativeDensityResidual(),
+        0.0);
+    assertEquals(thirtySecondA.getFiniteVolumeMassResidualKg(), thirtySecondB.getFiniteVolumeMassResidualKg(), 0.0);
+    assertArrayEquals(thirtySecondA.getNonlinearUpdateHistory(), thirtySecondB.getNonlinearUpdateHistory(), 0.0);
+    assertArrayEquals(thirtySecondA.getDensityResidualHistory(), thirtySecondB.getDensityResidualHistory(), 0.0);
 
-    assertTrue(fifteenSecond.getMaximumRelativeDensityResidual()
-        < thirtySecondA.getMaximumRelativeDensityResidual(),
+    assertTrue(fifteenSecond.getMaximumRelativeDensityResidual() < thirtySecondA.getMaximumRelativeDensityResidual(),
         "The shorter step must expose a smaller EOS/FV density inconsistency.");
-    assertTrue(Math.abs(fifteenSecond.getThermodynamicMassResidualKg())
-        < Math.abs(thirtySecondA.getThermodynamicMassResidualKg()),
+    assertTrue(
+        Math.abs(fifteenSecond.getThermodynamicMassResidualKg()) < Math
+            .abs(thirtySecondA.getThermodynamicMassResidualKg()),
         "The shorter step must expose a smaller EOS inventory inconsistency.");
     assertTrue(fifteenSecond.getRelativeFiniteVolumeMassResidual() < 1.0e-12);
   }
 
-  private static OnePhaseFlowConvergenceReport runCompositionStep(PipeFlowSystem pipe,
-      double timeStep) {
+  private static OnePhaseFlowConvergenceReport runCompositionStep(PipeFlowSystem pipe, double timeStep) {
     SystemInterface eventGas = createGas(0.80, 0.20);
-    pipe.getTimeSeries().setTimes(new double[] {0.0, timeStep});
-    pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] {eventGas});
+    pipe.getTimeSeries().setTimes(new double[] { 0.0, timeStep });
+    pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] { eventGas });
     pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);
 
-    IllegalStateException failure =
-        assertThrows(IllegalStateException.class, () -> pipe.solveTransient(20));
+    IllegalStateException failure = assertThrows(IllegalStateException.class, () -> pipe.solveTransient(20));
     assertTrue(failure.getMessage().contains("EOS/FV density"));
     assertTrue(failure.getMessage().contains("FV mass residual"));
     return pipe.getConvergenceReport();
@@ -97,17 +88,17 @@ class OnePhaseFlowConvergenceTest extends neqsim.NeqSimTest {
     pipe.setNumberOfLegs(1);
     pipe.setNumberOfNodesInLeg(40);
 
-    GeometryDefinitionInterface[] geometry = {new PipeData(), new PipeData()};
+    GeometryDefinitionInterface[] geometry = { new PipeData(), new PipeData() };
     for (GeometryDefinitionInterface section : geometry) {
       section.setDiameter(0.5);
       section.setInnerSurfaceRoughness(1.0e-5);
     }
     pipe.setEquipmentGeometry(geometry);
-    pipe.setLegHeights(new double[] {0.0, 0.0});
-    pipe.setLegPositions(new double[] {0.0, 15000.0});
-    pipe.setLegOuterTemperatures(new double[] {TEMPERATURE_K, TEMPERATURE_K});
-    pipe.setLegWallHeatTransferCoefficients(new double[] {0.0, 0.0});
-    pipe.setLegOuterHeatTransferCoefficients(new double[] {0.0, 0.0});
+    pipe.setLegHeights(new double[] { 0.0, 0.0 });
+    pipe.setLegPositions(new double[] { 0.0, 15000.0 });
+    pipe.setLegOuterTemperatures(new double[] { TEMPERATURE_K, TEMPERATURE_K });
+    pipe.setLegWallHeatTransferCoefficients(new double[] { 0.0, 0.0 });
+    pipe.setLegOuterHeatTransferCoefficients(new double[] { 0.0, 0.0 });
     pipe.createSystem();
     pipe.init();
     pipe.solveSteadyState(20);


### PR DESCRIPTION
## Engineering value

Establishes a conservative Stage 1 diagnostic foundation for one-phase gas-pipeline tracking without breaking existing transient callers. A composition event could previously satisfy the algebraic update criterion while the finite-volume (FV) density, local SRK EOS density, and imposed inlet mass flux described different states.

This PR does **not** claim validated component tracking, commercial parity, or a completed coupled pressure-correction algorithm.

## Root cause

Node zero is the prescribed upstream boundary, but the transient density row treated it as an accumulating control volume with a west-neighbor TDMA coefficient that has no matrix unknown. During a 95/5 to 80/20 methane/nitrogen event, the 58.994 kg/m3 boundary density was solved down to 5.324 kg/m3 at 30 s. The implied inlet flux became 4.788 kg/s instead of approximately 50 kg/s.

Separately, convergence used only iterate changes. It did not check whether EOS density matched the authoritative FV density or whether EOS inventory closed against boundary flux. The current pressure update also freezes once consecutive FV-density iterates stop changing, even when EOS density remains inconsistent.

## Change

- Keep row zero as a Dirichlet inlet-density boundary in transient mass solves.
- Add immutable `OnePhaseFlowConvergenceReport` diagnostics with residual histories, stop reason, inventories, boundary masses, and closure errors.
- Classify a frozen EOS/FV mismatch as `DENSITY_INCONSISTENT`; reserve `MAX_ITERATIONS_REACHED` for an algebraic update that actually remains above tolerance.
- Expose the report through `PipeFlowSystem.getConvergenceReport()`.
- Preserve existing transient control flow by default: a failed report is logged and returned.
- Add `PipeFlowSystem.setFailOnNonConvergence(true)` for strict fail-loud operation; the report is recorded before `IllegalStateException` is thrown.
- Make `toJson()` emit valid, stable JSON for `NOT_RUN` and other non-finite diagnostics by serializing those numeric fields as `null`.
- Preserve older serialized solver compatibility by returning a `NOT_RUN` report when the new field deserializes as null.

## Frozen reproducer

- SRK EOS, classic mixing rule
- methane/nitrogen 95/5 -> 80/20 mole fraction
- 288.15 K, 70 bara absolute, 50 kg/s
- horizontal 15 km x 0.5 m pipe, 42 nodes
- first-order upwind, solver type 20
- 30 s and 15 s one-step cases
- tolerances: update 1e-10, relative density 1e-8, relative mass 1e-8
- inventory domain: physical control volumes 1-41; node zero is the boundary

## Evidence

| Metric | Master 30 s | PR 30 s | PR 15 s |
|---|---:|---:|---:|
| Solved inlet density | 5.324 kg/m3 | 58.994 kg/m3 | 58.994 kg/m3 |
| Implied inlet flow | 4.788 kg/s | 52.818 kg/s | 52.818 kg/s |
| FV inventory residual | 4.8e-11 kg* | 5.55e-11 kg | 4.55e-11 kg |
| EOS inventory residual | +1419.290 kg | -21.751 kg | -4.766 kg |
| Max EOS/FV density residual | hidden | 1.743e-2 | 1.024e-2 |
| Default result | silently returned | warning + failed report | warning + failed report |
| Strict result | unavailable | `DENSITY_INCONSISTENT` exception | `DENSITY_INCONSISTENT` exception |

*Master closes only against its incorrectly solved 4.788 kg/s inlet flux.

The algebraic update falls to approximately 2e-16 while density remains above 1e-8. Two independent 30 s executions were byte-identical. The shorter step reduces both density and EOS-inventory residuals without changing the frozen acceptance criteria.

## Tests and validation

`OnePhaseFlowConvergenceTest` covers:

- FV total-mass closure and correct inlet-flux scale;
- strict exception/report message identity;
- backward-compatible non-throwing mode with the same failed report;
- reachable, specific `DENSITY_INCONSISTENT` classification;
- finite residual histories, deterministic repeat execution, and timestep sensitivity;
- steady-solve availability;
- `NOT_RUN` JSON serialization without a NaN exception.

Local evidence on OpenJDK 17.0.19:

- production and test sources compiled with Java 8 targeting against public NeqSim 3.16.0;
- compatibility and strict 15 s probes both reproduced density residual `1.0236064e-2` and FV residual `4.55e-11 kg`;
- compatibility mode returned normally; strict mode threw with exact report-message identity;
- `NOT_RUN` JSON parsed successfully with non-finite numeric fields represented as `null`.

GitHub CI is the authoritative Java 8/21, Windows/Linux, Spotless, Javadoc, static-analysis, and full-suite gate.

## Compatibility and risk

- Public source compatibility is preserved; the report and strict-mode setter are additive.
- Existing transient simulations continue returning, but non-convergence is no longer silent because the full report is retained and a warning is logged.
- Safety- or optimization-critical callers can enable strict mode explicitly.
- Steady row equations are unchanged.
- Reverse boundary flow still lacks an external upwind state.
- This PR measures the coupled hydraulic/EOS defect; it does not hide it or claim to solve it.

## Documentation impact

Updated `docs/fluidmechanics/single_phase_pipe_flow.md` with report fields, units and tolerances, default/strict behavior, boundary ownership, positive-flow limitation, incomplete species-validation warning, and the absence of a physical axial-dispersion model.

No Colab change: the source capability is not mature enough to publish a component-tracking notebook.

## Next dependency-ordered gate

Build a reduced isothermal 3–5-cell continuity/momentum/EOS Jacobian test, verify its analytic or block-tridiagonal Jacobian against finite differences, then add line search and rollback. Acceptance remains EOS/FV density and EOS inventory residuals <= 1e-8, FV closure at roundoff, deterministic repeats, timestep sensitivity, and no material pressure/flow regression before conservative species transport proceeds.
