### PR TITLE
fix(tpflash): reject infeasible tiny multiphase seeds

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -193,12 +193,11 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │  Order phases by density                                                        │
 │  Final system.init(1)                                                           │
 │                                                                                 │
-│  IF multiphase checking follows an accepted stable single-phase test:            │
-│     → Keep a two-phase endpoint only when phase fractions and compositions       │
-│       are finite and normalized, max |Δzᵢ| < 1e-8, and                          │
-│       max |Δ ln(fᵢ)| < 1e-8                                                     │
-│     → Otherwise discard the unequilibrated trial seed and restore the stable     │
-│       single-phase reference                                                     │
+│  IF aqueous multiphase checking follows an accepted stable single-phase test:    │
+│     → Reject an endpoint only when a phase composition contains non-finite or     │
+│       out-of-range values, or fails |Σxᵢ - 1| ≤ 1e-8                            │
+│     → Keep normalized endpoints for model-specific convergence and refinement    │
+│       paths                                                                       │
 │                                                                                 │
 │  IF ordinary flash and water feed ≥ 0.01:                                       │
 │     → Refine a missing aqueous phase, or an existing two-phase aqueous           │
@@ -232,7 +231,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; existing two-phase aqueous endpoints additionally require `max abs(Delta ln(f_i)) >= 1e-8` or `max abs(Delta z_i) >= 1e-8` before refinement |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
-| Stable-single-phase multiphase endpoint gate | 1e-8 in composition normalization, `max abs(Delta z_i)`, and `max abs(Delta ln(f_i))` | Retain a genuine incipient split, including a tiny phase, only when the proposed two-phase endpoint independently satisfies feasibility and equilibrium; otherwise restore the stable homogeneous state |
+| Stable-single-phase aqueous-seed gate | `1e-8` in phase-composition normalization | Reject only a structurally invalid aqueous trial whose composition is non-finite, out of `[0, 1]`, or unnormalized; leave normalized endpoints to model-specific convergence and refinement paths |
 
 ### 1.1 Problem Formulation
 
@@ -1672,11 +1671,11 @@ Commercial process simulators do not publish all implementation details, but pub
   balance has `max abs(Delta z_i) >= 1e-8`. A feasible candidate normally must lower Gibbs energy; when the reference
   is non-conservative and its Gibbs energy is therefore not comparable, the candidate must instead independently pass
   phase-fraction, composition-normalization, material-balance, fugacity, and distinct-composition checks.
-- When the tangent-plane stability path has already accepted a homogeneous state, the subsequent multiphase search
-  cannot replace it with an unequilibrated phase-addition seed. A proposed two-phase endpoint must independently pass
-  finite phase-fraction and composition checks, composition normalization, component material balance, distinct-phase,
-  and component-fugacity equality checks. This preserves feasible incipient phases instead of deleting them by phase
-  fraction alone.
+- When the tangent-plane stability path has already accepted a homogeneous state, an unnormalized aqueous trial seed
+  cannot replace it. The guard is deliberately structural: each active phase composition must be finite, bounded in
+  `[0, 1]`, and normalized within `1e-8`. It does not impose a universal material-balance or fugacity threshold on
+  normalized endpoints because specialized fluid and solid-phase models retain their existing convergence and
+  refinement paths.
 - Ordinary neutral aqueous splits now compare both cubic roots of the non-aqueous phase at the converged composition. An alternate root is retained only when it lowers Gibbs energy and already satisfies `max abs(Delta ln(f_i)) < 1e-8`; no extra TPflash or multiphase stability calculation is run.
 - Enhanced stability checks are gated to polar, associating, electrolyte, sour, or explicitly requested multiphase systems, limiting unnecessary hydrocarbon phase-map artifacts.
 

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -193,6 +193,13 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │  Order phases by density                                                        │
 │  Final system.init(1)                                                           │
 │                                                                                 │
+│  IF multiphase checking follows an accepted stable single-phase test:            │
+│     → Keep a two-phase endpoint only when phase fractions and compositions       │
+│       are finite and normalized, max |Δzᵢ| < 1e-8, and                          │
+│       max |Δ ln(fᵢ)| < 1e-8                                                     │
+│     → Otherwise discard the unequilibrated trial seed and restore the stable     │
+│       single-phase reference                                                     │
+│                                                                                 │
 │  IF ordinary flash and water feed ≥ 0.01:                                       │
 │     → Refine a missing aqueous phase, or an existing two-phase aqueous           │
 │       endpoint when max |Δ ln(fᵢ)| ≥ 1e-8 or max |Δzᵢ| ≥ 1e-8                   │
@@ -225,6 +232,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; existing two-phase aqueous endpoints additionally require `max abs(Delta ln(f_i)) >= 1e-8` or `max abs(Delta z_i) >= 1e-8` before refinement |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
+| Stable-single-phase multiphase endpoint gate | 1e-8 in composition normalization, `max abs(Delta z_i)`, and `max abs(Delta ln(f_i))` | Retain a genuine incipient split, including a tiny phase, only when the proposed two-phase endpoint independently satisfies feasibility and equilibrium; otherwise restore the stable homogeneous state |
 
 ### 1.1 Problem Formulation
 
@@ -1664,6 +1672,11 @@ Commercial process simulators do not publish all implementation details, but pub
   balance has `max abs(Delta z_i) >= 1e-8`. A feasible candidate normally must lower Gibbs energy; when the reference
   is non-conservative and its Gibbs energy is therefore not comparable, the candidate must instead independently pass
   phase-fraction, composition-normalization, material-balance, fugacity, and distinct-composition checks.
+- When the tangent-plane stability path has already accepted a homogeneous state, the subsequent multiphase search
+  cannot replace it with an unequilibrated phase-addition seed. A proposed two-phase endpoint must independently pass
+  finite phase-fraction and composition checks, composition normalization, component material balance, distinct-phase,
+  and component-fugacity equality checks. This preserves feasible incipient phases instead of deleting them by phase
+  fraction alone.
 - Ordinary neutral aqueous splits now compare both cubic roots of the non-aqueous phase at the converged composition. An alternate root is retained only when it lowers Gibbs energy and already satisfies `max abs(Delta ln(f_i)) < 1e-8`; no extra TPflash or multiphase stability calculation is run.
 - Enhanced stability checks are gated to polar, associating, electrolyte, sour, or explicitly requested multiphase systems, limiting unnecessary hydrocarbon phase-map artifacts.
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -584,7 +584,7 @@ public class TPflash extends Flash {
           logger.debug("Post-stability init failed: {}", ex.getMessage());
         }
         rescueSinglePhaseMultiphaseEndpoint();
-        rejectInfeasibleMultiphaseEndpointAfterStableSinglePhase();
+        rejectUnnormalizedAqueousEndpointAfterStableSinglePhase();
 
         // Chemical equilibrium for stable single-phase case
         if (system.isChemicalSystem()) {
@@ -1480,31 +1480,46 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Rejects an infeasible two-phase result created while checking an already stable single-phase state.
+   * Rejects an unnormalized aqueous trial phase created while checking an already stable single-phase state.
    *
    * <p>
-   * The multiphase stability path can seed a trial phase at a small positive phase fraction. If the beta solver does
-   * not move that seed to an equilibrium solution, the seed can survive the generic minimum-beta cleanup even though
-   * its composition is not normalized, it does not reconstruct the feed, and component fugacities are unequal. The
-   * preceding stability analysis has already accepted the homogeneous state, so such an infeasible trial must not
-   * replace it. A genuine incipient phase is retained because it independently passes the same strict balance,
-   * normalization, distinct-composition, and fugacity checks used for water-rich candidate acceptance.
+   * The multiphase stability path can seed an aqueous trial phase at a small positive phase fraction. If the beta
+   * solver does not move that seed, its composition can remain unnormalized and survive the generic minimum-beta
+   * cleanup. Such a structurally invalid trial must not replace the accepted homogeneous state.
    * </p>
    *
    * <p>
-   * Chemical and ionic systems are excluded because their equilibrium constraints include reactions or ion
-   * partitioning beyond the neutral two-phase fugacity test.
+   * This guard deliberately does not impose a universal material-balance or fugacity-residual threshold. Some
+   * specialized fluid and solid-phase models use model-specific convergence and refinement paths, so normalized
+   * endpoints remain available to those paths. Chemical, ionic, solid, wax, and non-aqueous endpoints are excluded.
    * </p>
    */
-  private void rejectInfeasibleMultiphaseEndpointAfterStableSinglePhase() {
-    if (system.getNumberOfPhases() != 2 || system.isChemicalSystem() || system.hasIons()
-        || referenceSinglePhaseType == null || isBalancedEquilibriumCandidate(system)) {
+  private void rejectUnnormalizedAqueousEndpointAfterStableSinglePhase() {
+    if (system.getNumberOfPhases() != 2 || system.isChemicalSystem() || system.hasIons() || solidCheck
+        || system.isMultiphaseWaxCheck() || referenceSinglePhaseType == null
+        || !system.hasPhaseType(PhaseType.AQUEOUS)) {
       return;
     }
-    if (logger.isDebugEnabled()) {
-      logger.debug("Rejecting infeasible multiphase endpoint after stable single-phase check");
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < system.getPhase(phaseIndex)
+          .getNumberOfComponents(); componentIndex++) {
+        double phaseComposition = system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        if (!Double.isFinite(phaseComposition) || phaseComposition < 0.0 || phaseComposition > 1.0) {
+          collapseToReferenceSinglePhase();
+          return;
+        }
+        compositionTotal += phaseComposition;
+      }
+      if (!Double.isFinite(compositionTotal)
+          || Math.abs(compositionTotal - 1.0) > WATER_RICH_MATERIAL_BALANCE_TOLERANCE) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("Rejecting unnormalized aqueous endpoint after stable single-phase check");
+        }
+        collapseToReferenceSinglePhase();
+        return;
+      }
     }
-    collapseToReferenceSinglePhase();
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -49,6 +49,8 @@ public class TPflash extends Flash {
   private static final double WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT = 0.01;
   /** Maximum accepted component material-balance residual for water-rich endpoint refinement. */
   private static final double WATER_RICH_MATERIAL_BALANCE_TOLERANCE = 1.0e-8;
+  /** Maximum accepted phase-composition normalization residual for an aqueous trial seed. */
+  private static final double AQUEOUS_SEED_COMPOSITION_NORMALIZATION_TOLERANCE = 1.0e-8;
   /** Maximum accepted log-fugacity residual when selecting an alternate cubic root. */
   private static final double PHASE_ROOT_EQUILIBRIUM_TOLERANCE = 1.0e-8;
   /** Cubic phase roots evaluated by the post-convergence aqueous root check. */
@@ -1506,15 +1508,20 @@ public class TPflash extends Flash {
           .getNumberOfComponents(); componentIndex++) {
         double phaseComposition = system.getPhase(phaseIndex).getComponent(componentIndex).getx();
         if (!Double.isFinite(phaseComposition) || phaseComposition < 0.0 || phaseComposition > 1.0) {
+          if (logger.isDebugEnabled()) {
+            logger.debug("Rejecting invalid aqueous endpoint composition: phase={}, component={}, x={}", phaseIndex,
+                componentIndex, phaseComposition);
+          }
           collapseToReferenceSinglePhase();
           return;
         }
         compositionTotal += phaseComposition;
       }
       if (!Double.isFinite(compositionTotal)
-          || Math.abs(compositionTotal - 1.0) > WATER_RICH_MATERIAL_BALANCE_TOLERANCE) {
+          || Math.abs(compositionTotal - 1.0) > AQUEOUS_SEED_COMPOSITION_NORMALIZATION_TOLERANCE) {
         if (logger.isDebugEnabled()) {
-          logger.debug("Rejecting unnormalized aqueous endpoint after stable single-phase check");
+          logger.debug("Rejecting unnormalized aqueous endpoint composition: phase={}, sum(x)={}", phaseIndex,
+              compositionTotal);
         }
         collapseToReferenceSinglePhase();
         return;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -584,6 +584,7 @@ public class TPflash extends Flash {
           logger.debug("Post-stability init failed: {}", ex.getMessage());
         }
         rescueSinglePhaseMultiphaseEndpoint();
+        rejectInfeasibleMultiphaseEndpointAfterStableSinglePhase();
 
         // Chemical equilibrium for stable single-phase case
         if (system.isChemicalSystem()) {
@@ -1474,6 +1475,34 @@ public class TPflash extends Flash {
     if (logger.isDebugEnabled()) {
       logger.debug("Collapsing trivial two-phase split: max composition difference {} < {}", maxCompositionDifference,
           TRIVIAL_SPLIT_COMPOSITION_TOLERANCE);
+    }
+    collapseToReferenceSinglePhase();
+  }
+
+  /**
+   * Rejects an infeasible two-phase result created while checking an already stable single-phase state.
+   *
+   * <p>
+   * The multiphase stability path can seed a trial phase at a small positive phase fraction. If the beta solver does
+   * not move that seed to an equilibrium solution, the seed can survive the generic minimum-beta cleanup even though
+   * its composition is not normalized, it does not reconstruct the feed, and component fugacities are unequal. The
+   * preceding stability analysis has already accepted the homogeneous state, so such an infeasible trial must not
+   * replace it. A genuine incipient phase is retained because it independently passes the same strict balance,
+   * normalization, distinct-composition, and fugacity checks used for water-rich candidate acceptance.
+   * </p>
+   *
+   * <p>
+   * Chemical and ionic systems are excluded because their equilibrium constraints include reactions or ion
+   * partitioning beyond the neutral two-phase fugacity test.
+   * </p>
+   */
+  private void rejectInfeasibleMultiphaseEndpointAfterStableSinglePhase() {
+    if (system.getNumberOfPhases() != 2 || system.isChemicalSystem() || system.hasIons()
+        || referenceSinglePhaseType == null || isBalancedEquilibriumCandidate(system)) {
+      return;
+    }
+    if (logger.isDebugEnabled()) {
+      logger.debug("Rejecting infeasible multiphase endpoint after stable single-phase check");
     }
     collapseToReferenceSinglePhase();
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTinyAqueousSeedRejectionTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTinyAqueousSeedRejectionTest.java
@@ -1,0 +1,97 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashTinyAqueousSeedRejectionTest {
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
+
+  @Test
+  void infeasibleTinyAqueousSeedCannotReplaceStableGas() {
+    SystemInterface ordinary = createAndFlash(1.0, false);
+    SystemInterface multiphase = createAndFlash(1.0, true);
+
+    assertStableGasEquivalent(ordinary, multiphase);
+    double firstGibbsEnergy = multiphase.getGibbsEnergy();
+
+    new ThermodynamicOperations(multiphase).TPflash();
+    multiphase.init(1);
+
+    assertEquals(firstGibbsEnergy, multiphase.getGibbsEnergy(), 1.0e-10);
+    assertStableGasEquivalent(ordinary, multiphase);
+  }
+
+  @Test
+  void feasibleNearbyAqueousSplitIsRetained() {
+    SystemInterface ordinary = createAndFlash(3.0, false);
+    SystemInterface multiphase = createAndFlash(3.0, true);
+
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquals(ordinary.getNumberOfPhases(), multiphase.getNumberOfPhases());
+    assertEquals(ordinary.getGibbsEnergy(), multiphase.getGibbsEnergy(), 1.0e-8);
+    assertTrue(maximumComponentMaterialBalanceResidual(multiphase) < MATERIAL_BALANCE_TOLERANCE);
+    assertTrue(maximumLogFugacityResidual(multiphase) < 1.0e-8);
+  }
+
+  private SystemInterface createAndFlash(double pressure, boolean multiphaseCheck) {
+    SystemInterface system = new SystemSrkEos(400.0, pressure);
+    system.addComponent("methane", 0.02);
+    system.addComponent("water", 0.98);
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private void assertStableGasEquivalent(SystemInterface expected, SystemInterface actual) {
+    assertEquals(1, expected.getNumberOfPhases());
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(PhaseType.GAS, actual.getPhase(0).getType());
+    assertEquals(1.0, actual.getBeta(0), 1.0e-12);
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-10);
+    assertEquals(expected.getPhase(0).getZ(), actual.getPhase(0).getZ(), 1.0e-12);
+    assertTrue(maximumComponentMaterialBalanceResidual(actual) < MATERIAL_BALANCE_TOLERANCE);
+
+    double compositionTotal = 0.0;
+    for (int componentIndex = 0; componentIndex < actual.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      assertEquals(expected.getPhase(0).getComponent(componentIndex).getx(),
+          actual.getPhase(0).getComponent(componentIndex).getx(), 1.0e-12);
+      compositionTotal += actual.getPhase(0).getComponent(componentIndex).getx();
+    }
+    assertEquals(1.0, compositionTotal, 1.0e-12);
+  }
+
+  private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex)
+            * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(system.getPhase(0).getComponent(componentIndex).getz() - recoveredFeed));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      double firstLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+    }
+    return maximumResidual;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTinyAqueousSeedRejectionTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTinyAqueousSeedRejectionTest.java
@@ -72,8 +72,7 @@ class TPflashTinyAqueousSeedRejectionTest {
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
-        recoveredFeed +=
-            system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
       maximumResidual = Math.max(maximumResidual,
           Math.abs(system.getPhase(0).getComponent(componentIndex).getz() - recoveredFeed));

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTinyAqueousSeedRejectionTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTinyAqueousSeedRejectionTest.java
@@ -22,7 +22,7 @@ class TPflashTinyAqueousSeedRejectionTest {
     new ThermodynamicOperations(multiphase).TPflash();
     multiphase.init(1);
 
-    assertEquals(firstGibbsEnergy, multiphase.getGibbsEnergy(), 1.0e-10);
+    assertEquals(firstGibbsEnergy, multiphase.getGibbsEnergy(), 1.0e-8);
     assertStableGasEquivalent(ordinary, multiphase);
   }
 
@@ -54,7 +54,7 @@ class TPflashTinyAqueousSeedRejectionTest {
     assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
     assertEquals(PhaseType.GAS, actual.getPhase(0).getType());
     assertEquals(1.0, actual.getBeta(0), 1.0e-12);
-    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-10);
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-8);
     assertEquals(expected.getPhase(0).getZ(), actual.getPhase(0).getZ(), 1.0e-12);
     assertTrue(maximumComponentMaterialBalanceResidual(actual) < MATERIAL_BALANCE_TOLERANCE);
 
@@ -72,8 +72,8 @@ class TPflashTinyAqueousSeedRejectionTest {
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
-        recoveredFeed += system.getBeta(phaseIndex)
-            * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        recoveredFeed +=
+            system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
       maximumResidual = Math.max(maximumResidual,
           Math.abs(system.getPhase(0).getComponent(componentIndex).getz() - recoveredFeed));


### PR DESCRIPTION
## Problem

A deterministic SRK methane/water flash at 400 K and 1 bara exposes a cross-algorithm defect:

- feed: methane 0.02, water 0.98; mixing rule 2
- ordinary `TPflash`: one stable gas phase
- `setMultiPhaseCheck(true)`: gas plus a seeded aqueous phase at beta = 9.9999e-6
- seeded aqueous composition sum: 0.98
- maximum component material-balance residual: 1.99998e-7
- maximum log-fugacity residual: 18.8945

The two-phase result is neither normalized, conservative, nor at fugacity equilibrium. It is also 0.03595 J above the accepted homogeneous Gibbs energy. Repeated flashes return the same invalid seed.

## Root cause

After the tangent-plane stability path accepts the homogeneous state, `TPmultiflash` may seed an aqueous trial phase. If its beta solver does not move that trial, the seed can remain above the generic minimum-beta cleanup. The existing trivial-split check does not remove it because the unnormalized seed composition differs from the feed.

This is an endpoint-acceptance defect, not a tolerance issue.

## Method and literature basis

The phase search remains unchanged. After an accepted stable single-phase result, the guard applies only to a neutral, aqueous, exactly-two-phase endpoint. It restores the accepted homogeneous reference only if an active phase composition:

- contains a non-finite value,
- contains a mole fraction outside `[0, 1]`, or
- fails `abs(sum(x_i) - 1) <= 1e-8`.

The guard deliberately does **not** impose a universal material-balance or fugacity-residual threshold. The first CI revision did so and incorrectly collapsed normalized UMR-CPA methane/water and oil/asphaltene endpoints that rely on model-specific convergence or refinement paths. Chemical, ionic, solid, wax, and non-aqueous endpoints are excluded.

This follows the separation between stability testing and feasible phase-split calculation in Michelsen, *The isothermal flash problem*, Parts I and II, Fluid Phase Equilibria 9 (1982), while keeping the fix limited to the demonstrated structural invariant.

## Before / after

| Metric, 400 K / 1 bara | Before | After |
|---|---:|---:|
| Multiphase phase count | 2 | 1 |
| aqueous beta | 9.9999e-6 | absent |
| max composition normalization residual | 2.0000e-2 | 0 |
| max component balance residual | 1.99998e-7 | 0 |
| max log-fugacity residual | 18.8945 | 0 |
| Gibbs energy, J | -1258.5018628 | -1258.5378099 |
| ordinary/multiphase agreement | no | exact within test tolerances |

A nearby genuine split at 400 K and 3 bara remains retained with material residual 1.11e-16 and log-fugacity residual 7.38e-15.

## Runtime benchmark

The initial candidate was benchmarked over seven batches of 1,000 cloned multiphase flashes after 100 warmups. Before/after ranges overlapped (1-bara rejection: 832.3-1154.1 vs 827.8-1381.1 us/flash; 3-bara retained split: 47.8-96.0 vs 43.7-68.2 us/flash), so this PR claims **no standalone speedup**. The narrowed guard performs only a bounded composition scan on the already-stable aqueous two-phase path.

## Tests

Added `TPflashTinyAqueousSeedRejectionTest`:

- rejects the minimal invalid seed and matches ordinary TPflash phase state, beta, composition, Gibbs energy, and compressibility
- verifies deterministic repeated execution
- preserves the nearby equilibrated aqueous split
- checks component balance and fugacity residuals
- uses the package-standard `1e-8` Gibbs equality tolerance

Validation evidence:

- production class compiled with `javac --release 8`
- deterministic reduced sweep covered methane fraction 1e-6 to 0.10 and pressure 0.8 to 10 bara
- the original 675-case SRK/PR/CPA diagnostic sweep completed without exceptions
- the first full CI run exposed the over-broad gate through existing UMR-CPA and asphaltene regressions; the implementation is now scoped to unnormalized aqueous compositions
- narrowed revision `e3dd11e` passed Java 8 and Java 21 fast suites on Ubuntu and Windows, Javadocs, pre-commit, Spotless, CodeQL, PaperLab, documentation coverage, skill-reference validation, and slow shards 1/3 and 3/3
- slow shard 2/3 was cancelled at the repository's 60-minute job cap after all completed tests passed; its largest costs were `TransientThreePhaseFlowTest` (1884 s) and `SolverSpeedBenchmark` (895.6 s)
- final `f070f17` only introduces a dedicated normalization constant and consistent debug logging; fresh CI is running

## Compatibility risk

Low and narrowly scoped. The guard runs only after an accepted stable single-phase result and only for a neutral, aqueous, exactly-two-phase endpoint with a structurally invalid composition. It does not modify TPD, Rachford-Rice, Q-minimization, iteration limits, convergence tolerances, or normalized model-specific endpoints.

## Documentation impact

Updated `TPflash_algorithm.md` with the structural aqueous-seed gate, its `1e-8` normalization tolerance, exclusions, and rationale.
