### PR TITLE
ci: rebalance slow tests across four shards

### DIFF
--- a/.github/workflows/verify_build.yml
+++ b/.github/workflows/verify_build.yml
@@ -124,11 +124,13 @@ jobs:
       matrix:
         include:
           - shard: 0
-            label: 1/3
+            label: 1/4
           - shard: 1
-            label: 2/3
+            label: 2/4
           - shard: 2
-            label: 3/3
+            label: 3/4
+          - shard: 3
+            label: 4/4
     steps:
       - uses: actions/checkout@v7
         with:
@@ -149,7 +151,7 @@ jobs:
           )
           selected=()
           for index in "${!slow_files[@]}"; do
-            if ((index % 3 == ${{ matrix.shard }})); then
+            if ((index % 4 == ${{ matrix.shard }})); then
               class_name="${slow_files[$index]#src/test/java/}"
               class_name="${class_name%.java}"
               selected+=("${class_name//\//.}")

--- a/.github/workflows/verify_build.yml
+++ b/.github/workflows/verify_build.yml
@@ -34,6 +34,7 @@ jobs:
             run_tests:
               - '**/*.java'
               - '**/*.xml'
+              - '.github/workflows/verify_build.yml'
 
   test_javadoc:
     name: Assert javadoc with Java 21 on Ubuntu


### PR DESCRIPTION
## Summary

- expand the Java 21 slow-test matrix from three to four shards
- update the deterministic filename modulo from 3 to 4
- retain every `@Tag("slow")` class, Maven group selection, and the 60-minute per-job guard
- make changes to `verify_build.yml` trigger its own build/test jobs so this CI fix is validated rather than skipped

## Root cause

[Workflow run 30706155741, job 91385681483](https://github.com/equinor/neqsim/actions/runs/30706155741/job/91385681483) was cancelled at the 60-minute job limit without an assertion failure.

The filename-round-robin assignment placed the two dominant classes in the same 2/3 lane:

- `TransientThreePhaseFlowTest`: 1,922 s (32:02)
- `SolverSpeedBenchmark`: 1,027 s (17:07)

That lane also ran `ThreePhaseSeparatorTest` for 280 s, `DistillationColumnTest` for 167 s, and the remaining assigned slow tests. The other two lanes completed in 9:26 and 16:21, so the failure is sharding imbalance rather than a test defect.

## Validation

- source: current `master` at `b982811513f7ffe30c0b10c77dfbc578e9d5af0c`
- branch comparison: two commits ahead, zero behind
- changed files: only `.github/workflows/verify_build.yml`
- parsed the updated workflow with PyYAML and asserted the exact matrix `[(0, 1/4), (1, 2/4), (2, 3/4), (3, 4/4)]`
- asserted that the workflow's path filter includes `.github/workflows/verify_build.yml`; the first PR run exposed and skipped on this missing self-validation trigger
- verified 39 currently indexed slow-test files remain selected exactly once
- replayed the deterministic assignment against the original job's completed per-class timings: the 32-minute transient test and 17-minute solver benchmark now run in separate lanes
- fresh [PR workflow run 30708835571](https://github.com/equinor/neqsim/actions/runs/30708835571) executed all four slow lanes successfully:
  - 1/4: 43 tests, 10:28
  - 2/4: 42 tests, 44:02
  - 3/4: 71 tests, 26:48
  - 4/4: 68 tests, 13:53
- all 224 slow-test executions completed with zero failures and zero errors; the longest lane retained 15:58 margin below the unchanged 60-minute guard
- CodeQL, pre-commit, Spotless, Javadocs, and the full 10,992-test Java 21 suites on Ubuntu and Windows also passed on the fresh head

## Coverage and risk

No test is skipped, shortened, weakened, or reclassified. This only adds one parallel Ubuntu runner and rebalances the existing complete slow suite. The matrix remains deterministic and fails if a shard discovers no tests.

## Documentation impact

Documentation impact: none. This is an internal CI scheduling change; test commands, tags, public APIs, numerical behavior, and developer usage are unchanged.
