### PR TITLE
fix(tpflash): recover aqueous equilibrium after rejected phase trial

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -182,7 +182,10 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │ STEP 7: POST-PROCESSING                                                         │
 ├─────────────────────────────────────────────────────────────────────────────────┤
 │  IF multiPhaseCheck enabled:                                                    │
+│     → Preserve an already balanced neutral two-phase aqueous reference          │
 │     → Delegate to TPmultiflash for stability analysis and phase split           │
+│     → If a rejected third-phase trial leaves an invalid two-phase aqueous       │
+│       endpoint, restore the balanced reference                                  │
 │  ELSE:                                                                          │
 │     → Final phase type check (gas vs liquid Gibbs energy)                       │
 │                                                                                 │
@@ -232,6 +235,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
 | Stable-single-phase aqueous-seed gate | `1e-8` in phase-composition normalization | Reject only a structurally invalid aqueous trial whose composition is non-finite, out of `[0, 1]`, or unnormalized; leave normalized endpoints to model-specific convergence and refinement paths |
+| Post-removal aqueous recovery | `1e-8` in `max abs(Delta z_i)` and `max abs(Delta ln(f_i))` | Restore a balanced neutral two-phase aqueous reference only when a rejected third-phase trial leaves the final two-phase endpoint infeasible; genuine three-phase and already feasible endpoints are retained |
 
 ### 1.1 Problem Formulation
 
@@ -1676,6 +1680,10 @@ Commercial process simulators do not publish all implementation details, but pub
   `[0, 1]`, and normalized within `1e-8`. It does not impose a universal material-balance or fugacity threshold on
   normalized endpoints because specialized fluid and solid-phase models retain their existing convergence and
   refinement paths.
+- A neutral, balanced two-phase aqueous state is preserved before multiphase phase-appearance trials. If a trial third
+  phase is subsequently removed but its phase fractions leave the surviving two-phase state outside `1e-8` component
+  material-balance or fugacity tolerances, the pre-trial state is restored. The recovery does not run another flash and
+  is not considered for chemical, ionic, solid, wax, genuine three-phase, or already feasible endpoints.
 - Ordinary neutral aqueous splits now compare both cubic roots of the non-aqueous phase at the converged composition. An alternate root is retained only when it lowers Gibbs energy and already satisfies `max abs(Delta ln(f_i)) < 1e-8`; no extra TPflash or multiphase stability calculation is run.
 - Enhanced stability checks are gated to polar, associating, electrolyte, sour, or explicitly requested multiphase systems, limiting unnecessary hydrocarbon phase-map artifacts.
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -918,7 +918,7 @@ public class TPflash extends Flash {
    * </p>
    */
   private void rescueWaterRichEndpoint() {
-    if (system.doMultiPhaseCheck() || system.isChemicalSystem() || system.hasIons() || solidCheck || system.doSolidPhaseCheck()
+    if (system.doMultiPhaseCheck() || system.isChemicalSystem() || system.hasIons() || solidCheck
         || system.isMultiphaseWaxCheck() || system.getNumberOfPhases() > 2) {
       return;
     }
@@ -1229,7 +1229,7 @@ public class TPflash extends Flash {
    */
   private AqueousTwoPhaseState balancedAqueousReferenceBeforeMultiphaseCheck() {
     if (system.getNumberOfPhases() != 2 || system.isChemicalSystem() || system.hasIons() || solidCheck
-        || system.isMultiphaseWaxCheck() || !system.hasPhaseType(PhaseType.AQUEOUS)
+        || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck() || !system.hasPhaseType(PhaseType.AQUEOUS)
         || !isBalancedEquilibriumCandidate(system)) {
       return null;
     }
@@ -1245,8 +1245,8 @@ public class TPflash extends Flash {
    * a near-boundary hydrocarbon-liquid trial. If that trial disappears during {@link TPmultiflash} cleanup, the
    * remaining phases can retain phase fractions from the rejected three-phase iterate. Composition normalization alone
    * does not repair the resulting component material-balance or fugacity residuals. The pre-trial state is restored
-   * only when the final endpoint still has exactly two phases including an aqueous phase and fails the same strict acceptance checks.
-   * Genuine three-phase results and feasible multiphase refinements are unchanged.
+   * only when the final endpoint still has exactly two phases including an aqueous phase and fails the same strict
+   * acceptance checks. Genuine three-phase results and feasible multiphase refinements are unchanged.
    * </p>
    *
    * @param balancedReference feasible pre-trial state, or {@code null} when recovery is not applicable

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -100,6 +100,31 @@ public class TPflash extends Flash {
    */
   private PhaseType referenceSinglePhaseType = null;
 
+  /** Compact pre-multiphase snapshot used only for balanced neutral aqueous endpoints. */
+  private static final class AqueousTwoPhaseState {
+    private final PhaseType[] phaseTypes = new PhaseType[2];
+    private final double[] betas = new double[2];
+    private final double[][] compositions;
+    private final double[] kValues;
+
+    private AqueousTwoPhaseState(SystemInterface source) {
+      int numberOfComponents = source.getPhase(0).getNumberOfComponents();
+      compositions = new double[2][numberOfComponents];
+      kValues = new double[numberOfComponents];
+      for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+        phaseTypes[phaseIndex] = source.getPhase(phaseIndex).getType();
+        betas[phaseIndex] = source.getBeta(phaseIndex);
+        for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+          compositions[phaseIndex][componentIndex] =
+              source.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        }
+      }
+      for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+        kValues[componentIndex] = source.getPhase(0).getComponent(componentIndex).getK();
+      }
+    }
+  }
+
   /**
    * Constructor for TPflash.
    */
@@ -735,8 +760,11 @@ public class TPflash extends Flash {
       sucsSubs();
     }
     if (system.doMultiPhaseCheck()) {
+      AqueousTwoPhaseState balancedAqueousReference =
+          balancedAqueousReferenceBeforeMultiphaseCheck();
       TPmultiflash operation = new TPmultiflash(system, system.doSolidPhaseCheck());
       operation.run();
+      restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(balancedAqueousReference);
       rescueSinglePhaseMultiphaseEndpoint();
       // rescueSpuriousMultiphaseEndpoint() is called once at the end of runInternal()
       // after orderByDensity(), so it is intentionally not repeated here.
@@ -1189,6 +1217,62 @@ public class TPflash extends Flash {
       maximumFugacityResidual = Math.max(maximumFugacityResidual, Math.abs(firstLogFugacity - secondLogFugacity));
     }
     return maximumFugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE;
+  }
+
+  /**
+   * Captures a feasible aqueous equilibrium before multiphase phase-appearance trials.
+   *
+   * <p>
+   * The compact snapshot is restricted to neutral, exactly-two-phase aqueous endpoints that already satisfy the strict
+   * feasibility and equilibrium checks. It avoids a full system clone, and other flashes allocate no snapshot.
+   * </p>
+   *
+   * @return balanced state, or {@code null} when recovery is not applicable
+   */
+  private AqueousTwoPhaseState balancedAqueousReferenceBeforeMultiphaseCheck() {
+    if (system.getNumberOfPhases() != 2 || system.isChemicalSystem() || system.hasIons() || solidCheck
+        || system.isMultiphaseWaxCheck() || !system.hasPhaseType(PhaseType.AQUEOUS)
+        || !isBalancedEquilibriumCandidate(system)) {
+      return null;
+    }
+    return new AqueousTwoPhaseState(system);
+  }
+
+  /**
+   * Restores a feasible aqueous equilibrium when a rejected phase-appearance trial leaves an invalid two-phase
+   * endpoint.
+   *
+   * <p>
+   * A balanced gas/aqueous flash can be temporarily expanded to three phases when tangent-plane stability testing
+   * finds a near-boundary hydrocarbon-liquid trial. If that trial disappears during {@link TPmultiflash} cleanup, the
+   * remaining phases can retain phase fractions from the rejected three-phase iterate. Composition normalization alone
+   * does not repair the resulting component material-balance or fugacity residuals. The pre-trial state is restored only
+   * when the final endpoint still has exactly two aqueous phases and fails the same strict acceptance checks. Genuine
+   * three-phase results and feasible multiphase refinements are unchanged.
+   * </p>
+   *
+   * @param balancedReference feasible pre-trial state, or {@code null} when recovery is not applicable
+   */
+  private void restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(
+      AqueousTwoPhaseState balancedReference) {
+    if (balancedReference == null || system.getNumberOfPhases() != 2
+        || !system.hasPhaseType(PhaseType.AQUEOUS) || isBalancedEquilibriumCandidate(system)) {
+      return;
+    }
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      system.setPhaseType(phaseIndex, balancedReference.phaseTypes[phaseIndex]);
+      system.setBeta(phaseIndex, balancedReference.betas[phaseIndex]);
+      for (int componentIndex = 0;
+          componentIndex < balancedReference.compositions[phaseIndex].length;
+          componentIndex++) {
+        system.getPhase(phaseIndex).getComponent(componentIndex)
+            .setx(balancedReference.compositions[phaseIndex][componentIndex]);
+        system.getPhase(phaseIndex).getComponent(componentIndex)
+            .setK(balancedReference.kValues[componentIndex]);
+      }
+    }
+    system.normalizeBeta();
+    system.init(1);
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -115,8 +115,7 @@ public class TPflash extends Flash {
         phaseTypes[phaseIndex] = source.getPhase(phaseIndex).getType();
         betas[phaseIndex] = source.getBeta(phaseIndex);
         for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
-          compositions[phaseIndex][componentIndex] =
-              source.getPhase(phaseIndex).getComponent(componentIndex).getx();
+          compositions[phaseIndex][componentIndex] = source.getPhase(phaseIndex).getComponent(componentIndex).getx();
         }
       }
       for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
@@ -760,8 +759,7 @@ public class TPflash extends Flash {
       sucsSubs();
     }
     if (system.doMultiPhaseCheck()) {
-      AqueousTwoPhaseState balancedAqueousReference =
-          balancedAqueousReferenceBeforeMultiphaseCheck();
+      AqueousTwoPhaseState balancedAqueousReference = balancedAqueousReferenceBeforeMultiphaseCheck();
       TPmultiflash operation = new TPmultiflash(system, system.doSolidPhaseCheck());
       operation.run();
       restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(balancedAqueousReference);
@@ -920,7 +918,7 @@ public class TPflash extends Flash {
    * </p>
    */
   private void rescueWaterRichEndpoint() {
-    if (system.doMultiPhaseCheck() || system.isChemicalSystem() || system.hasIons() || solidCheck
+    if (system.doMultiPhaseCheck() || system.isChemicalSystem() || system.hasIons() || solidCheck || system.doSolidPhaseCheck()
         || system.isMultiphaseWaxCheck() || system.getNumberOfPhases() > 2) {
       return;
     }
@@ -1243,32 +1241,28 @@ public class TPflash extends Flash {
    * endpoint.
    *
    * <p>
-   * A balanced gas/aqueous flash can be temporarily expanded to three phases when tangent-plane stability testing
-   * finds a near-boundary hydrocarbon-liquid trial. If that trial disappears during {@link TPmultiflash} cleanup, the
+   * A balanced gas/aqueous flash can be temporarily expanded to three phases when tangent-plane stability testing finds
+   * a near-boundary hydrocarbon-liquid trial. If that trial disappears during {@link TPmultiflash} cleanup, the
    * remaining phases can retain phase fractions from the rejected three-phase iterate. Composition normalization alone
-   * does not repair the resulting component material-balance or fugacity residuals. The pre-trial state is restored only
-   * when the final endpoint still has exactly two aqueous phases and fails the same strict acceptance checks. Genuine
-   * three-phase results and feasible multiphase refinements are unchanged.
+   * does not repair the resulting component material-balance or fugacity residuals. The pre-trial state is restored
+   * only when the final endpoint still has exactly two phases including an aqueous phase and fails the same strict acceptance checks.
+   * Genuine three-phase results and feasible multiphase refinements are unchanged.
    * </p>
    *
    * @param balancedReference feasible pre-trial state, or {@code null} when recovery is not applicable
    */
-  private void restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(
-      AqueousTwoPhaseState balancedReference) {
-    if (balancedReference == null || system.getNumberOfPhases() != 2
-        || !system.hasPhaseType(PhaseType.AQUEOUS) || isBalancedEquilibriumCandidate(system)) {
+  private void restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(AqueousTwoPhaseState balancedReference) {
+    if (balancedReference == null || system.getNumberOfPhases() != 2 || !system.hasPhaseType(PhaseType.AQUEOUS)
+        || isBalancedEquilibriumCandidate(system)) {
       return;
     }
     for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
       system.setPhaseType(phaseIndex, balancedReference.phaseTypes[phaseIndex]);
       system.setBeta(phaseIndex, balancedReference.betas[phaseIndex]);
-      for (int componentIndex = 0;
-          componentIndex < balancedReference.compositions[phaseIndex].length;
-          componentIndex++) {
+      for (int componentIndex = 0; componentIndex < balancedReference.compositions[phaseIndex].length; componentIndex++) {
         system.getPhase(phaseIndex).getComponent(componentIndex)
             .setx(balancedReference.compositions[phaseIndex][componentIndex]);
-        system.getPhase(phaseIndex).getComponent(componentIndex)
-            .setK(balancedReference.kValues[componentIndex]);
+        system.getPhase(phaseIndex).getComponent(componentIndex).setK(balancedReference.kValues[componentIndex]);
       }
     }
     system.normalizeBeta();

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousPhaseRemovalRecoveryTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousPhaseRemovalRecoveryTest.java
@@ -1,0 +1,133 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashAqueousPhaseRemovalRecoveryTest {
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
+
+  @Test
+  void failedThirdPhaseTrialCannotReplaceBalancedAqueousEquilibrium() {
+    for (boolean pengRobinson : new boolean[] {false, true}) {
+      SystemInterface ordinary = createAndFlash(pengRobinson, 16.0, false);
+      SystemInterface multiphase = createAndFlash(pengRobinson, 16.0, true);
+
+      assertEquivalentTwoPhaseState(ordinary, multiphase);
+      double firstGibbsEnergy = multiphase.getGibbsEnergy();
+      double firstGasBeta = multiphase.getBeta(0);
+
+      new ThermodynamicOperations(multiphase).TPflash();
+      multiphase.init(1);
+
+      assertEquals(firstGibbsEnergy, multiphase.getGibbsEnergy(), 1.0e-8);
+      assertEquals(firstGasBeta, multiphase.getBeta(0), 1.0e-12);
+      assertEquivalentTwoPhaseState(ordinary, multiphase);
+    }
+  }
+
+  @Test
+  void nearbyGenuineThreePhaseEquilibriumIsRetained() {
+    for (boolean pengRobinson : new boolean[] {false, true}) {
+      SystemInterface multiphase = createAndFlash(pengRobinson, 24.0, true);
+
+      assertEquals(3, multiphase.getNumberOfPhases());
+      assertTrue(maximumComponentMaterialBalanceResidual(multiphase)
+          < MATERIAL_BALANCE_TOLERANCE);
+      assertBetaAndCompositionClosure(multiphase);
+    }
+  }
+
+  private SystemInterface createAndFlash(boolean pengRobinson, double pressureBara,
+      boolean multiphaseCheck) {
+    SystemInterface system = pengRobinson ? new SystemPrEos(250.0, pressureBara)
+        : new SystemSrkEos(250.0, pressureBara);
+    system.addComponent("CO2", 0.7894736842105263);
+    system.addComponent("methane", 0.15789473684210525);
+    system.addComponent("water", 0.05263157894736842);
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private void assertEquivalentTwoPhaseState(SystemInterface expected,
+      SystemInterface actual) {
+    assertEquals(2, expected.getNumberOfPhases());
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-8);
+    assertTrue(maximumComponentMaterialBalanceResidual(actual)
+        < MATERIAL_BALANCE_TOLERANCE);
+    assertTrue(maximumLogFugacityResidual(actual) < 1.0e-8);
+    assertBetaAndCompositionClosure(actual);
+
+    for (int phaseIndex = 0; phaseIndex < expected.getNumberOfPhases(); phaseIndex++) {
+      assertEquals(expected.getPhase(phaseIndex).getType(),
+          actual.getPhase(phaseIndex).getType());
+      assertEquals(expected.getBeta(phaseIndex), actual.getBeta(phaseIndex), 1.0e-12);
+      assertEquals(expected.getPhase(phaseIndex).getZ(),
+          actual.getPhase(phaseIndex).getZ(), 1.0e-12);
+      for (int componentIndex = 0;
+          componentIndex < expected.getPhase(phaseIndex).getNumberOfComponents();
+          componentIndex++) {
+        assertEquals(expected.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            actual.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
+      }
+    }
+  }
+
+  private void assertBetaAndCompositionClosure(SystemInterface system) {
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      betaTotal += system.getBeta(phaseIndex);
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0;
+          componentIndex < system.getPhase(phaseIndex).getNumberOfComponents();
+          componentIndex++) {
+        compositionTotal += system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-12);
+    }
+    assertEquals(1.0, betaTotal, 1.0e-12);
+  }
+
+  private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0;
+        componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex)
+            * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(system.getPhase(0).getComponent(componentIndex).getz() - recoveredFeed));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0;
+        componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      double reference = logFugacity(system, 0, componentIndex);
+      for (int phaseIndex = 1; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        maximumResidual = Math.max(maximumResidual,
+            Math.abs(reference - logFugacity(system, phaseIndex, componentIndex)));
+      }
+    }
+    return maximumResidual;
+  }
+
+  private double logFugacity(SystemInterface system, int phaseIndex, int componentIndex) {
+    return Math.log(Math.max(
+        system.getPhase(phaseIndex).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+        + Math.log(system.getPhase(phaseIndex).getComponent(componentIndex)
+            .getFugacityCoefficient());
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousPhaseRemovalRecoveryTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousPhaseRemovalRecoveryTest.java
@@ -13,7 +13,7 @@ class TPflashAqueousPhaseRemovalRecoveryTest {
 
   @Test
   void failedThirdPhaseTrialCannotReplaceBalancedAqueousEquilibrium() {
-    for (boolean pengRobinson : new boolean[] {false, true}) {
+    for (boolean pengRobinson : new boolean[] { false, true }) {
       SystemInterface ordinary = createAndFlash(pengRobinson, 16.0, false);
       SystemInterface multiphase = createAndFlash(pengRobinson, 16.0, true);
 
@@ -32,18 +32,16 @@ class TPflashAqueousPhaseRemovalRecoveryTest {
 
   @Test
   void nearbyGenuineThreePhaseEquilibriumIsRetained() {
-    for (boolean pengRobinson : new boolean[] {false, true}) {
+    for (boolean pengRobinson : new boolean[] { false, true }) {
       SystemInterface multiphase = createAndFlash(pengRobinson, 24.0, true);
 
       assertEquals(3, multiphase.getNumberOfPhases());
-      assertTrue(maximumComponentMaterialBalanceResidual(multiphase)
-          < MATERIAL_BALANCE_TOLERANCE);
+      assertTrue(maximumComponentMaterialBalanceResidual(multiphase) < MATERIAL_BALANCE_TOLERANCE);
       assertBetaAndCompositionClosure(multiphase);
     }
   }
 
-  private SystemInterface createAndFlash(boolean pengRobinson, double pressureBara,
-      boolean multiphaseCheck) {
+  private SystemInterface createAndFlash(boolean pengRobinson, double pressureBara, boolean multiphaseCheck) {
     SystemInterface system = pengRobinson ? new SystemPrEos(250.0, pressureBara)
         : new SystemSrkEos(250.0, pressureBara);
     system.addComponent("CO2", 0.7894736842105263);
@@ -56,25 +54,20 @@ class TPflashAqueousPhaseRemovalRecoveryTest {
     return system;
   }
 
-  private void assertEquivalentTwoPhaseState(SystemInterface expected,
-      SystemInterface actual) {
+  private void assertEquivalentTwoPhaseState(SystemInterface expected, SystemInterface actual) {
     assertEquals(2, expected.getNumberOfPhases());
     assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
     assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-8);
-    assertTrue(maximumComponentMaterialBalanceResidual(actual)
-        < MATERIAL_BALANCE_TOLERANCE);
+    assertTrue(maximumComponentMaterialBalanceResidual(actual) < MATERIAL_BALANCE_TOLERANCE);
     assertTrue(maximumLogFugacityResidual(actual) < 1.0e-8);
     assertBetaAndCompositionClosure(actual);
 
     for (int phaseIndex = 0; phaseIndex < expected.getNumberOfPhases(); phaseIndex++) {
-      assertEquals(expected.getPhase(phaseIndex).getType(),
-          actual.getPhase(phaseIndex).getType());
+      assertEquals(expected.getPhase(phaseIndex).getType(), actual.getPhase(phaseIndex).getType());
       assertEquals(expected.getBeta(phaseIndex), actual.getBeta(phaseIndex), 1.0e-12);
-      assertEquals(expected.getPhase(phaseIndex).getZ(),
-          actual.getPhase(phaseIndex).getZ(), 1.0e-12);
-      for (int componentIndex = 0;
-          componentIndex < expected.getPhase(phaseIndex).getNumberOfComponents();
-          componentIndex++) {
+      assertEquals(expected.getPhase(phaseIndex).getZ(), actual.getPhase(phaseIndex).getZ(), 1.0e-12);
+      for (int componentIndex = 0; componentIndex < expected.getPhase(phaseIndex)
+          .getNumberOfComponents(); componentIndex++) {
         assertEquals(expected.getPhase(phaseIndex).getComponent(componentIndex).getx(),
             actual.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
       }
@@ -86,9 +79,8 @@ class TPflashAqueousPhaseRemovalRecoveryTest {
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       betaTotal += system.getBeta(phaseIndex);
       double compositionTotal = 0.0;
-      for (int componentIndex = 0;
-          componentIndex < system.getPhase(phaseIndex).getNumberOfComponents();
-          componentIndex++) {
+      for (int componentIndex = 0; componentIndex < system.getPhase(phaseIndex)
+          .getNumberOfComponents(); componentIndex++) {
         compositionTotal += system.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
       assertEquals(1.0, compositionTotal, 1.0e-12);
@@ -98,12 +90,10 @@ class TPflashAqueousPhaseRemovalRecoveryTest {
 
   private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
     double maximumResidual = 0.0;
-    for (int componentIndex = 0;
-        componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
-        recoveredFeed += system.getBeta(phaseIndex)
-            * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
       maximumResidual = Math.max(maximumResidual,
           Math.abs(system.getPhase(0).getComponent(componentIndex).getz() - recoveredFeed));
@@ -113,8 +103,7 @@ class TPflashAqueousPhaseRemovalRecoveryTest {
 
   private double maximumLogFugacityResidual(SystemInterface system) {
     double maximumResidual = 0.0;
-    for (int componentIndex = 0;
-        componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       double reference = logFugacity(system, 0, componentIndex);
       for (int phaseIndex = 1; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
         maximumResidual = Math.max(maximumResidual,
@@ -125,9 +114,7 @@ class TPflashAqueousPhaseRemovalRecoveryTest {
   }
 
   private double logFugacity(SystemInterface system, int phaseIndex, int componentIndex) {
-    return Math.log(Math.max(
-        system.getPhase(phaseIndex).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
-        + Math.log(system.getPhase(phaseIndex).getComponent(componentIndex)
-            .getFugacityCoefficient());
+    return Math.log(Math.max(system.getPhase(phaseIndex).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+        + Math.log(system.getPhase(phaseIndex).getComponent(componentIndex).getFugacityCoefficient());
   }
 }


### PR DESCRIPTION
## Problem

The residual cross-algorithm matrix after #2731 exposed a deterministic CO2-rich aqueous defect. At 250 K and 16 bara, ordinary `TPflash` returns a balanced gas/aqueous equilibrium, while `setMultiPhaseCheck(true)` temporarily adds an oil trial, later rejects it, and returns two surviving phases with phase fractions from the rejected three-phase iterate.

Minimal reproducer (SRK and PR, classical mixing rule 2):

- CO2 = 0.7894736842105263
- methane = 0.15789473684210525
- water = 0.05263157894736842
- T = 250 K, P = 16 bara

Before this change, the reduced SRK/PR endpoints had maximum component material-balance residuals of `5.629e-4` and `1.868e-3`, respectively. In the broader CO2-rich matrix cell, maximum log-fugacity residuals were `1.018e-2` (SRK) and `3.643e-2` (PR). Composition normalization alone did not expose or repair the stale phase fractions.

## Root cause

Michelsen tangent-plane stability testing correctly treats trial-phase generation separately from phase-split acceptance. Here, `TPmultiflash` expands the already-converged gas/aqueous state to a near-boundary three-phase trial. Cleanup removes the vanishing trial, but the bounded rerun preserves phase fractions from the last three-phase iterate. The result is normalized in total beta and within each phase, yet violates component material balance and fugacity equality.

## Method

Before delegating an ordinary result to `TPmultiflash`, preserve a compact snapshot only when all of these are true:

- neutral, non-ionic, non-chemical calculation;
- no solid or wax check;
- exactly two phases including an aqueous phase;
- finite phase fractions and compositions;
- beta and composition normalization;
- distinct phase compositions;
- `max |Delta z_i| < 1e-8`;
- `max |Delta ln(f_i)| < 1e-8`.

After the multiphase calculation, restore that snapshot only if the endpoint is still exactly two-phase aqueous and fails the same feasibility/equilibrium gate. Genuine three-phase results and already feasible refinements are untouched. The snapshot stores only phase types, betas, compositions, and K-values; it does not clone or rerun the full system.

This follows the separation between stability analysis and feasible phase-split calculation in Michelsen's classical work:

- [Michelsen, 1982, Part I: Stability](https://doi.org/10.1016/0378-3812%2882%2985001-2)
- [Michelsen, 1982, Part II: Phase-split calculation](https://doi.org/10.1016/0378-3812%2882%2985002-4)

The literature evidence is that accepted phase splits must satisfy material balance and equal fugacity while stability testing supplies phase candidates. Restoring the already-converged feasible state after a rejected trial is the implementation inference. No proprietary commercial-simulator algorithm is claimed.

## Results

Deterministic 675-state paired matrix (9 mixtures x SRK/PR/CPA x 5 temperatures x 5 pressures):

- paired flashes completed: `675/675` before and after;
- exceptions: `0 -> 0`;
- invalid endpoints: `2 -> 0`;
- applicable one-/two-phase disagreements: `6 -> 4`;
- the nearby 24 bara SRK and PR controls remain balanced three-phase equilibria;
- repeated execution of the fixed 16 bara endpoint is deterministic;
- fixed material-balance residual: at most `2.22e-16`;
- fixed log-fugacity residual: at most `1.17e-14`;
- ordinary/multiphase beta, composition, compressibility, and Gibbs-energy comparisons use `1e-12` to `1e-8` documented tolerances.

Matrix coverage includes dry gas, volatile oil, water-rich, hydrocarbon/water, CO2-rich, hydrogen-rich, near-critical, wide-volatility, and oil/water mixtures; one-, two-, and three-phase regions; SRK, PR, and CPA; repeated flashes and neighboring T/P states.

### Runtime

Five fresh JVM forks, each with 30 warmups and 7 x 40 timed flashes; values are median-of-fork medians in ms/flash:

| Case | Before | After | Interpretation |
|---|---:|---:|---|
| dry gas | 0.3489 | 0.3261 | ranges overlap; no speedup claimed |
| failing 16 bara recovery | 1.2893 | 1.3035 | +1.1% for feasibility validation and recovery |
| genuine 24 bara VLLE | 0.1785 | 0.1822 | ranges overlap; no speedup claimed |

The implementation avoids a full-system clone and adds no snapshot allocation outside balanced, neutral, exactly-two-phase aqueous candidates.

## Tests

Added `TPflashAqueousPhaseRemovalRecoveryTest` covering:

- SRK and PR minimal failures;
- ordinary/multiphase phase state, beta, composition, Z, and Gibbs equality;
- beta/composition closure, component material balance, and fugacity equality;
- deterministic repeat execution;
- nearby genuine three-phase retention.

Validated locally:

- Java 8 production compilation of `TPflash` and `TPmultiflash`: pass;
- focused Java regression compiled and executed against patched classes: pass;
- deterministic 675-state external matrix: pass;
- `git diff --check`: pass.

Maven dependency resolution is unavailable in the restricted local environment, so Spotless, Javadocs, and the repository Maven suites were not run locally; CI is expected to provide those gates.

## Compatibility and risk

Risk is low and deliberately bounded. Public APIs, EOS models, mixing rules, tolerances, chemical/electrolyte paths, solid/wax paths, valid two-/three-phase solutions, and one-phase behavior are unchanged. The fallback can act only when it has a previously verified feasible aqueous reference and the final two-phase endpoint is demonstrably infeasible.

## Documentation impact

Updated `TPflash_algorithm.md` with the post-removal feasibility gate, numerical tolerances, scope, and performance behavior.
