### PR TITLE
fix(column): invalidate warm cache when reboiler mode changes

### DIFF
--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2785,8 +2785,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    *
    * <p>
    * Feed streams and the optional top/bottom {@link ColumnSpecification}s are not the whole input. Column pressure and
-   * the reboiler/condenser temperature and ratio settings change the solution just as much, and several of their
-   * setters ({@link #setTopPressure(double)}, {@link #setBottomPressure(double)},
+   * the reboiler/condenser temperature, operating mode, and ratio settings change the solution just as much, and
+   * several of their setters ({@link #setTopPressure(double)}, {@link #setBottomPressure(double)},
    * {@code getReboiler().setOutTemperature(...)}) deliberately do not mark the column for re-initialization. Without
    * them in the fingerprint, a parametric sweep or optimizer that varies column pressure or a column-end temperature
    * against an unchanged feed silently receives the previous solution.
@@ -2852,6 +2852,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, tray.getLiquidSideDrawFraction());
     }
     if (hasReboiler && getReboiler() != null) {
+      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, getReboiler().isRefluxSet() ? 1L : 0L);
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, getReboiler().getRefluxRatio());
     }
     if (hasCondenser && getCondenser() != null) {

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -103,6 +103,8 @@ public class DistillationColumnWarmStateCacheTest {
         "activating ratio mode must update the overhead flow");
     assertNotEquals(firstBottomFlow, column.getLiquidOutStream().getFlowRate("kg/hr"), 1.0,
         "activating ratio mode must update the bottoms flow");
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertPhysicalAndBalanced(new ColumnCase(column.getFeedStreams(3).get(0), column));
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -104,7 +104,7 @@ public class DistillationColumnWarmStateCacheTest {
     assertNotEquals(firstBottomFlow, column.getLiquidOutStream().getFlowRate("kg/hr"), 1.0,
         "activating ratio mode must update the bottoms flow");
     assertTrue(column.solved(), column.getConvergenceDiagnostics());
-    assertPhysicalAndBalanced(new ColumnCase(column.getFeedStreams(3).get(0), column));
+    assertPhysicalAndBalanced(column.getFeedStreams(3).get(0), column);
   }
 
   /**
@@ -303,22 +303,32 @@ public class DistillationColumnWarmStateCacheTest {
    * @param columnCase solved column case
    */
   private static void assertPhysicalAndBalanced(ColumnCase columnCase) {
-    StreamInterface gas = columnCase.column.getGasOutStream();
-    StreamInterface liquid = columnCase.column.getLiquidOutStream();
-    String[] feedComponents = columnCase.feed.getThermoSystem().getComponentNames();
+    assertPhysicalAndBalanced(columnCase.feed, columnCase.column);
+  }
+
+  /**
+   * Verify finite, physical products and component/total molar closure for general stream and column types.
+   *
+   * @param feed column feed
+   * @param column solved column
+   */
+  private static void assertPhysicalAndBalanced(StreamInterface feed, DistillationColumn column) {
+    StreamInterface gas = column.getGasOutStream();
+    StreamInterface liquid = column.getLiquidOutStream();
+    String[] feedComponents = feed.getThermoSystem().getComponentNames();
     assertArrayEquals(feedComponents, gas.getThermoSystem().getComponentNames(),
         "overhead must use the current feed component identities");
     assertArrayEquals(feedComponents, liquid.getThermoSystem().getComponentNames(),
         "bottoms must use the current feed component identities");
 
-    double feedFlow = columnCase.feed.getFlowRate("mol/hr");
+    double feedFlow = feed.getFlowRate("mol/hr");
     double gasFlow = gas.getFlowRate("mol/hr");
     double liquidFlow = liquid.getFlowRate("mol/hr");
     assertTrue(Double.isFinite(gasFlow) && gasFlow > 0.0, "overhead flow must be finite and positive");
     assertTrue(Double.isFinite(liquidFlow) && liquidFlow > 0.0, "bottoms flow must be finite and positive");
     assertEquals(feedFlow, gasFlow + liquidFlow, 5.0e-3 * feedFlow, "total product flow must close the feed");
 
-    double[] feedComposition = columnCase.feed.getThermoSystem().getMolarComposition();
+    double[] feedComposition = feed.getThermoSystem().getMolarComposition();
     double[] gasComposition = gas.getThermoSystem().getMolarComposition();
     double[] liquidComposition = liquid.getThermoSystem().getMolarComposition();
     for (int componentIndex = 0; componentIndex < feedComponents.length; componentIndex++) {

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -77,6 +77,35 @@ public class DistillationColumnWarmStateCacheTest {
   }
 
   /**
+   * Changing only the active reboiler operating mode must invalidate an otherwise identical warm state.
+   *
+   * <p>
+   * The legacy tray API stores a default reflux ratio even while ratio control is inactive. Activating that same
+   * numeric ratio changes the reboiler from temperature/equilibrium operation to a PV reflux flash, so the mode flag is
+   * part of the mathematical problem even though the stored ratio value is unchanged.
+   * </p>
+   */
+  @Test
+  public void reboilerModeChangeWithUnchangedStoredRatioInvalidatesWarmState() {
+    DistillationColumn column = buildColumn();
+    column.run();
+    double firstGasFlow = column.getGasOutStream().getFlowRate("kg/hr");
+    double firstBottomFlow = column.getLiquidOutStream().getFlowRate("kg/hr");
+    double storedRatio = column.getReboiler().getRefluxRatio();
+    assertFalse(column.getReboiler().isRefluxSet(), "the baseline should use temperature/equilibrium operation");
+
+    column.getReboiler().setRefluxRatio(storedRatio);
+    column.run();
+
+    assertFalse(column.wasNaphtaliSandholmWarmStateReused(),
+        "activating ratio mode must solve the changed reboiler equations instead of reusing the old state");
+    assertNotEquals(firstGasFlow, column.getGasOutStream().getFlowRate("kg/hr"), 1.0,
+        "activating ratio mode must update the overhead flow");
+    assertNotEquals(firstBottomFlow, column.getLiquidOutStream().getFlowRate("kg/hr"), 1.0,
+        "activating ratio mode must update the bottoms flow");
+  }
+
+  /**
    * A column pressure change must invalidate the warm state. {@code setTopPressure} and {@code setBottomPressure} do
    * not mark the column for re-initialization either.
    */


### PR DESCRIPTION
## Problem and root cause

`Reboiler` stores both:
- a numeric vapor boilup/reflux ratio; and
- an independent flag indicating whether ratio-controlled PV reflux flashing is active.

The accepted column warm-state fingerprint recorded only the numeric ratio. A legacy API transition from temperature/equilibrium operation to the already-stored default ratio of 0.1 therefore produced the same fingerprint even though the governing reboiler equations changed. Naphtali-Sandholm then returned the old products through exact reuse without solving the requested operating mode.

## Baseline reproduction

Regression-only head `dc45939` was run before the implementation change.

- realistic SRK propane/n-butane/n-pentane stripper;
- six trays plus reboiler, 5,000 kg/h at 10 bara;
- accepted Naphtali-Sandholm temperature/equilibrium solution;
- activate the same stored ratio (0.1) through the supported legacy reboiler API.

Java 21 Windows ran 11,001 tests and failed only the new assertion:

`expected false but was true` — the changed reboiler equations were incorrectly treated as an exact warm-state reuse.

All four slow-test shards passed on that baseline head, confirming the failure is isolated to the new regression.

## Change

Add the active reboiler ratio-mode flag to the deterministic column-configuration fingerprint before the ratio value.

This is the smallest general correction: mode and value jointly identify the reboiler mathematical problem. The unchanged-input cache remains enabled.

## Validation

Exact head `b4c807b` passes:
- Java 8 and Java 21 on Linux and Windows;
- all four Java 21 slow-test shards;
- Javadocs and the agent-skill cross-reference check;
- Spotless, pre-commit, CodeQL, and PaperLab.

The regression verifies:
- the changed mode is not exact-reused;
- overhead and bottoms flows both update by more than 1 kg/h;
- the accepted solve has physical temperature, pressure, flow, and composition bounds;
- total and per-component molar balances close;
- the nearby existing 30 K reboiler-temperature case still invalidates correctly;
- unchanged repeated solves still reuse the accepted state.

Both technically justified Copilot findings were implemented, validated on the exact head, answered, and resolved. The final Copilot review generated no new comments.

## Compatibility and risk

- no public API change;
- no solver equation, tolerance, damping, iteration budget, or selection change;
- no change for unchanged operating modes;
- one additional boolean folded into a 64-bit cache key;
- calculation identifiers continue to be refreshed by the existing reuse/solve paths.

Documentation impact: none. This corrects internal cache identity semantics already described by the warm-state API and Javadocs.

## Remaining limitation

This PR covers the confirmed reboiler mode collision only. Condenser-mode and fixed-liquid-reflux identity are separate candidates and were not changed without an independently reproduced defect.