### PR TITLE
perf: avoid derivative init in heat exchanger entropy

### DIFF
--- a/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
@@ -771,9 +771,9 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface, Sta
     for (int i = 0; i < 2; i++) {
       UUID id = UUID.randomUUID();
       inStream[i].run(id);
-      inStream[i].getFluid().init(3);
+      inStream[i].getFluid().init(2);
       outStream[i].run(id);
-      outStream[i].getFluid().init(3);
+      outStream[i].getFluid().init(2);
       entrop += outStream[i].getThermoSystem().getEntropy(unit) - inStream[i].getThermoSystem().getEntropy(unit);
     }
 

--- a/src/test/java/neqsim/process/equipment/heatexchanger/HeatExchangerTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/HeatExchangerTest.java
@@ -1,6 +1,9 @@
 package neqsim.process.equipment.heatexchanger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.separator.Separator;
@@ -17,6 +20,47 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @since 2.2.3
  */
 public class HeatExchangerTest extends neqsim.NeqSimTest {
+  private static class InitTrackingSystemSrkEos extends neqsim.thermo.system.SystemSrkEos {
+    private static final long serialVersionUID = 1000L;
+    private AtomicInteger levelTwoCalls = new AtomicInteger();
+    private AtomicInteger levelThreeCalls = new AtomicInteger();
+
+    InitTrackingSystemSrkEos(double temperature, double pressure) {
+      super(temperature, pressure);
+    }
+
+    @Override
+    public InitTrackingSystemSrkEos clone() {
+      InitTrackingSystemSrkEos cloned = (InitTrackingSystemSrkEos) super.clone();
+      cloned.levelTwoCalls = levelTwoCalls;
+      cloned.levelThreeCalls = levelThreeCalls;
+      return cloned;
+    }
+
+    @Override
+    public void init(int initType) {
+      super.init(initType);
+      if (levelTwoCalls != null && initType == 2) {
+        levelTwoCalls.incrementAndGet();
+      } else if (levelThreeCalls != null && initType == 3) {
+        levelThreeCalls.incrementAndGet();
+      }
+    }
+
+    void resetInitCounts() {
+      levelTwoCalls.set(0);
+      levelThreeCalls.set(0);
+    }
+
+    int getLevelTwoCalls() {
+      return levelTwoCalls.get();
+    }
+
+    int getLevelThreeCalls() {
+      return levelThreeCalls.get();
+    }
+  }
+
   static neqsim.thermo.system.SystemInterface testSystem;
   Stream gasStream;
 
@@ -106,6 +150,87 @@ public class HeatExchangerTest extends neqsim.NeqSimTest {
     heatExchanger1.run();
 
     assertEquals(15780.77130, heatExchanger1.getUAvalue(), 1e-3);
+  }
+
+  /**
+   * Entropy requires caloric properties but not level-3 composition derivatives. This is also a deterministic
+   * performance gate: the diagnostic must preserve its value while avoiding four unused derivative initializations.
+   */
+  @Test
+  void testEntropyProductionUsesMinimumThermodynamicInitializationLevel() {
+    InitTrackingSystemSrkEos fluid = new InitTrackingSystemSrkEos(333.15, 20.0);
+    fluid.addComponent("nitrogen", 0.02);
+    fluid.addComponent("CO2", 0.03);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.04);
+    fluid.addComponent("n-heptane", 0.04);
+    fluid.setMixingRule("classic");
+
+    Stream hot = new Stream("tracked hot", fluid);
+    hot.setTemperature(100.0, "C");
+    hot.setFlowRate(10000.0, "kg/hr");
+    Stream cold = new Stream("tracked cold", fluid.clone());
+    cold.setTemperature(20.0, "C");
+    cold.setFlowRate(8000.0, "kg/hr");
+
+    HeatExchanger heatExchanger = new HeatExchanger("tracked exchanger", hot, cold);
+    heatExchanger.setGuessOutTemperature(70.0, "C");
+    heatExchanger.setUAvalue(5000.0);
+    heatExchanger.run(UUID.randomUUID());
+
+    assertMinimumEntropyInitialization(fluid, heatExchanger);
+
+    hot.setTemperature(105.0, "C");
+    heatExchanger.run(UUID.randomUUID());
+    assertMinimumEntropyInitialization(fluid, heatExchanger);
+  }
+
+  private static void assertMinimumEntropyInitialization(InitTrackingSystemSrkEos fluid,
+      HeatExchanger heatExchanger) {
+    double expectedEntropy = referenceEntropyProduction(heatExchanger, "J/K");
+    double hotSideDuty = heatExchanger.getOutStream(0).getFluid().getEnthalpy()
+        - heatExchanger.getInStream(0).getFluid().getEnthalpy();
+    double coldSideDuty = heatExchanger.getOutStream(1).getFluid().getEnthalpy()
+        - heatExchanger.getInStream(1).getFluid().getEnthalpy();
+
+    fluid.resetInitCounts();
+    double actualEntropy = heatExchanger.getEntropyProduction("J/K");
+
+    assertEquals(expectedEntropy, actualEntropy, Math.max(1.0e-10, Math.abs(expectedEntropy) * 1.0e-12));
+    assertTrue(fluid.getLevelTwoCalls() >= 4, "Every inlet and outlet still requires caloric initialization");
+    assertEquals(0, fluid.getLevelThreeCalls(), "Entropy diagnostics must not calculate composition derivatives");
+    assertEquals(0.0, hotSideDuty + coldSideDuty,
+        Math.max(1.0e-6, Math.max(Math.abs(hotSideDuty), Math.abs(coldSideDuty)) * 1.0e-10));
+    assertEquals(Math.abs(hotSideDuty), Math.abs(heatExchanger.getDuty()),
+        Math.max(1.0e-6, Math.abs(hotSideDuty) * 1.0e-10));
+    assertEquals(heatExchanger.getInStream(0).getFlowRate("kg/hr"),
+        heatExchanger.getOutStream(0).getFlowRate("kg/hr"), 1.0e-8);
+    assertEquals(heatExchanger.getInStream(1).getFlowRate("kg/hr"),
+        heatExchanger.getOutStream(1).getFlowRate("kg/hr"), 1.0e-8);
+  }
+
+  private static double referenceEntropyProduction(HeatExchanger heatExchanger, String unit) {
+    double entropy = 0.0;
+    for (int index = 0; index < 2; index++) {
+      UUID id = UUID.randomUUID();
+      heatExchanger.getInStream(index).run(id);
+      heatExchanger.getInStream(index).getFluid().init(3);
+      heatExchanger.getOutStream(index).run(id);
+      heatExchanger.getOutStream(index).getFluid().init(3);
+      entropy += heatExchanger.getOutStream(index).getThermoSystem().getEntropy(unit)
+          - heatExchanger.getInStream(index).getThermoSystem().getEntropy(unit);
+    }
+
+    int hotStream = 0;
+    int coldStream = 1;
+    if (heatExchanger.getInStream(0).getTemperature() < heatExchanger.getInStream(1).getTemperature()) {
+      hotStream = 1;
+      coldStream = 0;
+    }
+    return entropy + Math.abs(heatExchanger.getDuty())
+        * (1.0 / heatExchanger.getInStream(coldStream).getTemperature()
+            - 1.0 / heatExchanger.getInStream(hotStream).getTemperature());
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/heatexchanger/HeatExchangerTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/HeatExchangerTest.java
@@ -32,6 +32,9 @@ public class HeatExchangerTest extends neqsim.NeqSimTest {
     @Override
     public InitTrackingSystemSrkEos clone() {
       InitTrackingSystemSrkEos cloned = (InitTrackingSystemSrkEos) super.clone();
+      if (cloned == null) {
+        throw new IllegalStateException("Failed to clone initialization-tracking fluid");
+      }
       cloned.levelTwoCalls = levelTwoCalls;
       cloned.levelThreeCalls = levelThreeCalls;
       return cloned;

--- a/src/test/java/neqsim/process/equipment/heatexchanger/HeatExchangerTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/HeatExchangerTest.java
@@ -201,9 +201,9 @@ public class HeatExchangerTest extends neqsim.NeqSimTest {
     assertTrue(fluid.getLevelTwoCalls() >= 4, "Every inlet and outlet still requires caloric initialization");
     assertEquals(0, fluid.getLevelThreeCalls(), "Entropy diagnostics must not calculate composition derivatives");
     assertEquals(0.0, hotSideDuty + coldSideDuty,
-        Math.max(1.0e-6, Math.max(Math.abs(hotSideDuty), Math.abs(coldSideDuty)) * 1.0e-10));
+        Math.max(1.0e-6, Math.max(Math.abs(hotSideDuty), Math.abs(coldSideDuty)) * 1.0e-8));
     assertEquals(Math.abs(hotSideDuty), Math.abs(heatExchanger.getDuty()),
-        Math.max(1.0e-6, Math.abs(hotSideDuty) * 1.0e-10));
+        Math.max(1.0e-6, Math.abs(hotSideDuty) * 1.0e-8));
     assertEquals(heatExchanger.getInStream(0).getFlowRate("kg/hr"),
         heatExchanger.getOutStream(0).getFlowRate("kg/hr"), 1.0e-8);
     assertEquals(heatExchanger.getInStream(1).getFlowRate("kg/hr"),

--- a/src/test/java/neqsim/process/equipment/heatexchanger/HeatExchangerTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/HeatExchangerTest.java
@@ -186,8 +186,7 @@ public class HeatExchangerTest extends neqsim.NeqSimTest {
     assertMinimumEntropyInitialization(fluid, heatExchanger);
   }
 
-  private static void assertMinimumEntropyInitialization(InitTrackingSystemSrkEos fluid,
-      HeatExchanger heatExchanger) {
+  private static void assertMinimumEntropyInitialization(InitTrackingSystemSrkEos fluid, HeatExchanger heatExchanger) {
     double expectedEntropy = referenceEntropyProduction(heatExchanger, "J/K");
     double hotSideDuty = heatExchanger.getOutStream(0).getFluid().getEnthalpy()
         - heatExchanger.getInStream(0).getFluid().getEnthalpy();
@@ -204,10 +203,10 @@ public class HeatExchangerTest extends neqsim.NeqSimTest {
         Math.max(1.0e-6, Math.max(Math.abs(hotSideDuty), Math.abs(coldSideDuty)) * 1.0e-8));
     assertEquals(Math.abs(hotSideDuty), Math.abs(heatExchanger.getDuty()),
         Math.max(1.0e-6, Math.abs(hotSideDuty) * 1.0e-8));
-    assertEquals(heatExchanger.getInStream(0).getFlowRate("kg/hr"),
-        heatExchanger.getOutStream(0).getFlowRate("kg/hr"), 1.0e-8);
-    assertEquals(heatExchanger.getInStream(1).getFlowRate("kg/hr"),
-        heatExchanger.getOutStream(1).getFlowRate("kg/hr"), 1.0e-8);
+    assertEquals(heatExchanger.getInStream(0).getFlowRate("kg/hr"), heatExchanger.getOutStream(0).getFlowRate("kg/hr"),
+        1.0e-8);
+    assertEquals(heatExchanger.getInStream(1).getFlowRate("kg/hr"), heatExchanger.getOutStream(1).getFlowRate("kg/hr"),
+        1.0e-8);
   }
 
   private static double referenceEntropyProduction(HeatExchanger heatExchanger, String unit) {
@@ -228,9 +227,8 @@ public class HeatExchangerTest extends neqsim.NeqSimTest {
       hotStream = 1;
       coldStream = 0;
     }
-    return entropy + Math.abs(heatExchanger.getDuty())
-        * (1.0 / heatExchanger.getInStream(coldStream).getTemperature()
-            - 1.0 / heatExchanger.getInStream(hotStream).getTemperature());
+    return entropy + Math.abs(heatExchanger.getDuty()) * (1.0 / heatExchanger.getInStream(coldStream).getTemperature()
+        - 1.0 / heatExchanger.getInStream(hotStream).getTemperature());
   }
 
   /**


### PR DESCRIPTION
## Bottleneck

`HeatExchanger.getEntropyProduction(...)` reruns both inlet and outlet streams and then explicitly requests thermodynamic initialization level 3 on all four states. The method only consumes entropy, temperature, and duty. Entropy is a caloric property available at level 2; level 3 additionally computes composition-derivative matrices that this diagnostic never reads.

This path is reached directly and through both `ProcessSystem.getEntropyProduction(...)` and `ProcessModel.getEntropyProduction(...)`, including process safety/exergy reporting.

Refs #2698.

## Change

Use `init(2)` for the two inlet and two outlet states in the two-stream heat-exchanger entropy diagnostic.

The change is intentionally limited to `HeatExchanger`. Adjacent `Heater`, `Cooler`, `MultiStreamHeatExchanger`, and mass-balance diagnostics remain unchanged until each has independent profiling evidence.

## Reproducible benchmark

Java 17.0.19, G1, fixed 512 MiB heap. Each result used five fresh JVM forks. Within each fork:

- build independent baseline/candidate SRK exchanger cases;
- 50 alternating warmups;
- 9 alternating-order samples;
- 250 calls per sample;
- report the median per fork, then the median across forks;
- candidate is the exact four-call level-3 to level-2 replacement;
- entropy is checked after every scope.

13-component rich-gas case:

| Scope | Baseline median | Candidate median | Paired median gain |
|---|---:|---:|---:|
| direct `HeatExchanger` | 0.485181 ms | 0.463317 ms | 4.51% |
| `ProcessSystem` | 0.489873 ms | 0.454363 ms | 5.80% |
| `ProcessModel` | 0.488592 ms | 0.450288 ms | 7.79% |

The five-component direct case was noise-level (0.180813 vs 0.185726 ms; overlapping sample ranges), so no small-fluid speedup is claimed.

Maximum baseline/candidate entropy difference across all forks and scopes: `0.0 J/K`.

The benchmark used the public NeqSim 3.16.0 fat JAR for the runtime baseline and a subclass containing only this replacement. The current-master target method and file blob were verified unchanged before publication. Exact-head Maven validation is delegated to GitHub Actions because this workspace cannot resolve the Maven Enforcer plugin from Central.

## Regression and engineering validation

The regression uses a clone-stable initialization counter and an independent level-3 reference calculation. It verifies at the base case and a nearby +5 K hot-inlet point that:

- entropy matches the level-3 reference;
- all four states still receive level-2 caloric initialization;
- no level-3 derivative initialization is requested by this method;
- hot/cold energy balance closes;
- exchanger duty is preserved;
- both side mass flows are preserved.

No public API, EOS, mixing rule, flash algorithm, tolerance, convergence criterion, thread-safety contract, serialization field, or process result changes.

## Documentation impact

Documentation impact: none. This changes only an internal initialization depth for a diagnostic; its public API, result, units, assumptions, and recommended usage are unchanged. Existing thermodynamic-property documentation already identifies level 2 as the caloric-property level and level 3 as composition derivatives.

## Limitations

This optimization matters for richer multicomponent diagnostics and aggregated model reporting. It does not accelerate the exchanger solve itself, and no speedup is claimed for the five-component case.