### PR TITLE
fix(tpflash): recover stable water-bearing splits

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -186,8 +186,8 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Delegate to TPmultiflash for stability analysis and phase split           │
 │     → If a rejected third-phase trial leaves an invalid two-phase aqueous       │
 │       endpoint, restore the balanced reference                                  │
-│     → If cleanup collapses a strong water/non-water K split to one phase, retry  │
-│       the ordinary flash and retain it only when balanced and lower in Gibbs     │
+│     → If cleanup collapses a strong water/non-water K split to one phase, retry │
+│       the ordinary flash and retain it only when balanced and lower in Gibbs    │
 │  ELSE:                                                                          │
 │     → Final phase type check (gas vs liquid Gibbs energy)                       │
 │                                                                                 │

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -182,10 +182,12 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │ STEP 7: POST-PROCESSING                                                         │
 ├─────────────────────────────────────────────────────────────────────────────────┤
 │  IF multiPhaseCheck enabled:                                                    │
-│     → Preserve an already balanced neutral two-phase aqueous reference          │
+│     → Preserve an already balanced neutral two-phase water-bearing reference    │
 │     → Delegate to TPmultiflash for stability analysis and phase split           │
 │     → If a rejected third-phase trial leaves an invalid two-phase aqueous       │
 │       endpoint, restore the balanced reference                                  │
+│     → If cleanup collapses a strong water/non-water K split to one phase, retry  │
+│       the ordinary flash and retain it only when balanced and lower in Gibbs     │
 │  ELSE:                                                                          │
 │     → Final phase type check (gas vs liquid Gibbs energy)                       │
 │                                                                                 │
@@ -236,6 +238,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
 | Stable-single-phase aqueous-seed gate | `1e-8` in phase-composition normalization | Reject only a structurally invalid aqueous trial whose composition is non-finite, out of `[0, 1]`, or unnormalized; leave normalized endpoints to model-specific convergence and refinement paths |
 | Post-removal aqueous recovery | `1e-8` in `max abs(Delta z_i)` and `max abs(Delta ln(f_i))` | Restore a balanced neutral two-phase aqueous reference only when a rejected third-phase trial leaves the final two-phase endpoint infeasible; genuine three-phase and already feasible endpoints are retained |
+| Water-bearing single-phase-collapse screen | water feed `>= 0.01`, stored water `K < 1e-2`, and a non-water `K > 10` | Run one bounded ordinary-flash retry only after multiphase cleanup returns one phase with strong retained phase-preference evidence; accept only a balanced, distinct two-phase state that lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))` |
 
 ### 1.1 Problem Formulation
 
@@ -1684,6 +1687,12 @@ Commercial process simulators do not publish all implementation details, but pub
   phase is subsequently removed but its phase fractions leave the surviving two-phase state outside `1e-8` component
   material-balance or fugacity tolerances, the pre-trial state is restored. The recovery does not run another flash and
   is not considered for chemical, ionic, solid, wax, genuine three-phase, or already feasible endpoints.
+- Neutral water-bearing multiphase endpoints retain a compact feasible two-phase reference when one is available. If
+  cleanup instead reaches one phase, a bounded ordinary retry is considered only when the retained K-values show both
+  strong water affinity (`K_water < 1e-2`) and strong non-water volatility (`K > 10`) with at least one mole percent
+  water. The retry replaces the collapsed endpoint only after independent phase-fraction, composition, component
+  balance, fugacity, distinct-phase, and lower-Gibbs checks. Chemical, ionic, solid, wax, and dry systems remain outside
+  this path.
 - Ordinary neutral aqueous splits now compare both cubic roots of the non-aqueous phase at the converged composition. An alternate root is retained only when it lowers Gibbs energy and already satisfies `max abs(Delta ln(f_i)) < 1e-8`; no extra TPflash or multiphase stability calculation is run.
 - Enhanced stability checks are gated to polar, associating, electrolyte, sour, or explicitly requested multiphase systems, limiting unnecessary hydrocarbon phase-map artifacts.
 
@@ -1711,6 +1720,7 @@ Recommended regression coverage should include both numerical convergence and ph
 | Critical-region robustness | Rich gas near cricondenbar and cricondentherm | No false single-phase result when TPD finds instability |
 | Polar/VLLE systems | Water, CO2, H2S, methanol, glycols, and CPA/electrolyte examples | Correct aqueous/oil/gas phase count and stable final split |
 | Multiphase cleanup | Cases with small beta phases and duplicate aqueous candidates | Removed phases preserve total composition and final mass balance |
+| Water-bearing phase collapse | High-pressure CO2/water with SRK/PR and hot low-pressure oil/water with CPA | Ordinary and multiphase paths return the same feasible lower-Gibbs split after cleanup |
 | Documentation drift | Algorithm doc parameter table versus source constants | Stale thresholds are detected during review |
 
 ---

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -767,8 +767,7 @@ public class TPflash extends Flash {
       sucsSubs();
     }
     if (system.doMultiPhaseCheck()) {
-      BalancedTwoPhaseState balancedWaterBearingReference =
-          balancedWaterBearingReferenceBeforeMultiphaseCheck();
+      BalancedTwoPhaseState balancedWaterBearingReference = balancedWaterBearingReferenceBeforeMultiphaseCheck();
       TPmultiflash operation = new TPmultiflash(system, system.doSolidPhaseCheck());
       operation.run();
       restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(balancedWaterBearingReference);
@@ -1377,8 +1376,8 @@ public class TPflash extends Flash {
    * @return true when a bounded ordinary-flash retry is justified
    */
   private boolean shouldRetryCollapsedWaterBearingEndpoint() {
-    if (!system.doMultiPhaseCheck() || system.getNumberOfPhases() != 1 || system.isChemicalSystem()
-        || system.hasIons() || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()
+    if (!system.doMultiPhaseCheck() || system.getNumberOfPhases() != 1 || system.isChemicalSystem() || system.hasIons()
+        || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()
         || MULTIPHASE_RESCUE_ACTIVE.get().booleanValue()) {
       return false;
     }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1310,10 +1310,13 @@ public class TPflash extends Flash {
       return;
     }
     system.init(1);
+    double referenceGibbsEnergy = balancedReference.gibbsEnergy;
     double collapsedGibbsEnergy = system.getGibbsEnergy();
-    double gibbsTolerance = Math.max(1.0e-6, Math.abs(balancedReference.gibbsEnergy) * 1.0e-8);
-    if (!Double.isFinite(collapsedGibbsEnergy)
-        || balancedReference.gibbsEnergy >= collapsedGibbsEnergy - gibbsTolerance) {
+    if (!Double.isFinite(referenceGibbsEnergy) || !Double.isFinite(collapsedGibbsEnergy)) {
+      return;
+    }
+    double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceGibbsEnergy) * 1.0e-8);
+    if (referenceGibbsEnergy >= collapsedGibbsEnergy - gibbsTolerance) {
       return;
     }
     restoreBalancedTwoPhaseState(balancedReference);

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -103,6 +103,8 @@ public class TPflash extends Flash {
    * the start of {@link #runInternal()}. Used as the collapse target when the spurious-multiphase rescue triggers.
    */
   private PhaseType referenceSinglePhaseType = null;
+  /** True after the bounded water-bearing ordinary-flash retry has been attempted in this run. */
+  private boolean waterBearingRescueAttempted = false;
 
   /** Compact pre-multiphase snapshot used only for balanced neutral water-bearing endpoints. */
   private static final class BalancedTwoPhaseState {
@@ -423,6 +425,7 @@ public class TPflash extends Flash {
    */
   private void runInternal() {
     resetStabilityDiagnostics();
+    waterBearingRescueAttempted = false;
     findLowestGibbsPhaseIsChecked = false;
     int minGibbsPhase = 0;
     double minimumGibbsEnergy = 0;
@@ -1349,9 +1352,10 @@ public class TPflash extends Flash {
    * </p>
    */
   private void rescueSinglePhaseWaterBearingEndpoint() {
-    if (!shouldRetryCollapsedWaterBearingEndpoint()) {
+    if (waterBearingRescueAttempted || !shouldRetryCollapsedWaterBearingEndpoint()) {
       return;
     }
+    waterBearingRescueAttempted = true;
     system.init(1);
     double referenceGibbsEnergy = system.getGibbsEnergy();
     SystemInterface candidate = system.clone();

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -47,6 +47,10 @@ public class TPflash extends Flash {
   private static final double LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN = 150.0;
   /** Minimum water feed fraction for ordinary water-rich endpoint refinement. */
   private static final double WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT = 0.01;
+  /** Maximum stored water K-value that justifies checking a collapsed water-bearing endpoint. */
+  private static final double WATER_PHASE_COLLAPSE_WATER_K_UPPER_LIMIT = 1.0e-2;
+  /** Minimum stored non-water K-value that justifies checking a collapsed water-bearing endpoint. */
+  private static final double WATER_PHASE_COLLAPSE_VOLATILE_K_LOWER_LIMIT = 10.0;
   /** Maximum accepted component material-balance residual for water-rich endpoint refinement. */
   private static final double WATER_RICH_MATERIAL_BALANCE_TOLERANCE = 1.0e-8;
   /** Maximum accepted phase-composition normalization residual for an aqueous trial seed. */
@@ -100,17 +104,19 @@ public class TPflash extends Flash {
    */
   private PhaseType referenceSinglePhaseType = null;
 
-  /** Compact pre-multiphase snapshot used only for balanced neutral aqueous endpoints. */
-  private static final class AqueousTwoPhaseState {
+  /** Compact pre-multiphase snapshot used only for balanced neutral water-bearing endpoints. */
+  private static final class BalancedTwoPhaseState {
     private final PhaseType[] phaseTypes = new PhaseType[2];
     private final double[] betas = new double[2];
     private final double[][] compositions;
     private final double[] kValues;
+    private final double gibbsEnergy;
 
-    private AqueousTwoPhaseState(SystemInterface source) {
+    private BalancedTwoPhaseState(SystemInterface source) {
       int numberOfComponents = source.getPhase(0).getNumberOfComponents();
       compositions = new double[2][numberOfComponents];
       kValues = new double[numberOfComponents];
+      gibbsEnergy = source.getGibbsEnergy();
       for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
         phaseTypes[phaseIndex] = source.getPhase(phaseIndex).getType();
         betas[phaseIndex] = source.getBeta(phaseIndex);
@@ -593,6 +599,7 @@ public class TPflash extends Flash {
           // logger.info("one phase flash is stable - checking multiphase flash....");
           TPmultiflash operation = new TPmultiflash(system, system.doSolidPhaseCheck());
           operation.run();
+          rescueSinglePhaseWaterBearingEndpoint();
           rescueSinglePhaseMultiphaseEndpoint();
         }
         if (solidCheck) {
@@ -609,6 +616,7 @@ public class TPflash extends Flash {
         } catch (Exception ex) {
           logger.debug("Post-stability init failed: {}", ex.getMessage());
         }
+        rescueSinglePhaseWaterBearingEndpoint();
         rescueSinglePhaseMultiphaseEndpoint();
         rejectUnnormalizedAqueousEndpointAfterStableSinglePhase();
 
@@ -759,10 +767,13 @@ public class TPflash extends Flash {
       sucsSubs();
     }
     if (system.doMultiPhaseCheck()) {
-      AqueousTwoPhaseState balancedAqueousReference = balancedAqueousReferenceBeforeMultiphaseCheck();
+      BalancedTwoPhaseState balancedWaterBearingReference =
+          balancedWaterBearingReferenceBeforeMultiphaseCheck();
       TPmultiflash operation = new TPmultiflash(system, system.doSolidPhaseCheck());
       operation.run();
-      restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(balancedAqueousReference);
+      restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(balancedWaterBearingReference);
+      restoreLowerGibbsReferenceAfterSinglePhaseCollapse(balancedWaterBearingReference);
+      rescueSinglePhaseWaterBearingEndpoint();
       rescueSinglePhaseMultiphaseEndpoint();
       // rescueSpuriousMultiphaseEndpoint() is called once at the end of runInternal()
       // after orderByDensity(), so it is intentionally not repeated here.
@@ -807,6 +818,7 @@ public class TPflash extends Flash {
         i--; // indices shift after removal — re-check the (new) phase at i
       }
     }
+    rescueSinglePhaseWaterBearingEndpoint();
     rescueSinglePhaseMultiphaseEndpoint();
     system.orderByDensity();
     try {
@@ -814,8 +826,10 @@ public class TPflash extends Flash {
     } catch (Exception ex) {
       logger.warn("Final init after orderByDensity failed: " + ex.getMessage());
     }
+    rescueSinglePhaseWaterBearingEndpoint();
     rescueSinglePhaseMultiphaseEndpoint();
     rescueSpuriousMultiphaseEndpoint();
+    rescueSinglePhaseWaterBearingEndpoint();
     collapseTrivialMultiphaseSplit();
     normalizeActivePhaseFractions();
     rescueLowerGibbsPhaseRoot();
@@ -1218,22 +1232,39 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Captures a feasible aqueous equilibrium before multiphase phase-appearance trials.
+   * Captures a feasible water-bearing equilibrium before multiphase phase-appearance trials.
    *
    * <p>
-   * The compact snapshot is restricted to neutral, exactly-two-phase aqueous endpoints that already satisfy the strict
-   * feasibility and equilibrium checks. It avoids a full system clone, and other flashes allocate no snapshot.
+   * The compact snapshot is restricted to neutral, exactly-two-phase endpoints that contain an aqueous phase or at
+   * least one mole percent water and already satisfy the strict feasibility and equilibrium checks. It avoids a full
+   * system clone, and dry flashes allocate no snapshot.
    * </p>
    *
    * @return balanced state, or {@code null} when recovery is not applicable
    */
-  private AqueousTwoPhaseState balancedAqueousReferenceBeforeMultiphaseCheck() {
+  private BalancedTwoPhaseState balancedWaterBearingReferenceBeforeMultiphaseCheck() {
     if (system.getNumberOfPhases() != 2 || system.isChemicalSystem() || system.hasIons() || solidCheck
-        || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck() || !system.hasPhaseType(PhaseType.AQUEOUS)
+        || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()
+        || (!system.hasPhaseType(PhaseType.AQUEOUS) && !hasSubstantialWaterFeed())
         || !isBalancedEquilibriumCandidate(system)) {
       return null;
     }
-    return new AqueousTwoPhaseState(system);
+    return new BalancedTwoPhaseState(system);
+  }
+
+  /**
+   * Checks whether water is a substantial feed component in the current flash.
+   *
+   * @return true when the water feed mole fraction is at least the water-rich refinement limit
+   */
+  private boolean hasSubstantialWaterFeed() {
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      if ("water".equalsIgnoreCase(component.getComponentName())) {
+        return component.getz() >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT;
+      }
+    }
+    return false;
   }
 
   /**
@@ -1251,12 +1282,50 @@ public class TPflash extends Flash {
    *
    * @param balancedReference feasible pre-trial state, or {@code null} when recovery is not applicable
    */
-  private void restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(AqueousTwoPhaseState balancedReference) {
+  private void restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(BalancedTwoPhaseState balancedReference) {
     if (balancedReference == null || system.getNumberOfPhases() != 2 || !system.hasPhaseType(PhaseType.AQUEOUS)
         || isBalancedEquilibriumCandidate(system)) {
       return;
     }
+    restoreBalancedTwoPhaseState(balancedReference);
+  }
+
+  /**
+   * Restores a lower-Gibbs feasible split when multiphase cleanup collapses it to one phase.
+   *
+   * <p>
+   * A successful ordinary two-phase flash is already a feasible phase-split candidate. If the subsequent multiphase
+   * stability path removes a phase and returns a one-phase state with higher extensive Gibbs energy, the collapse
+   * cannot represent the stable minimum. This gate is limited to neutral water-bearing systems and requires the
+   * ordinary reference to pass the strict material-balance, composition, phase-fraction, and fugacity checks before it
+   * is captured.
+   * </p>
+   *
+   * @param balancedReference feasible pre-trial state, or {@code null} when recovery is not applicable
+   */
+  private void restoreLowerGibbsReferenceAfterSinglePhaseCollapse(BalancedTwoPhaseState balancedReference) {
+    if (balancedReference == null || system.getNumberOfPhases() != 1) {
+      return;
+    }
+    system.init(1);
+    double collapsedGibbsEnergy = system.getGibbsEnergy();
+    double gibbsTolerance = Math.max(1.0e-6, Math.abs(balancedReference.gibbsEnergy) * 1.0e-8);
+    if (!Double.isFinite(collapsedGibbsEnergy)
+        || balancedReference.gibbsEnergy >= collapsedGibbsEnergy - gibbsTolerance) {
+      return;
+    }
+    restoreBalancedTwoPhaseState(balancedReference);
+  }
+
+  /**
+   * Restores phase types, fractions, compositions, and K-values from a compact two-phase snapshot.
+   *
+   * @param balancedReference feasible pre-trial state to restore
+   */
+  private void restoreBalancedTwoPhaseState(BalancedTwoPhaseState balancedReference) {
+    system.setNumberOfPhases(2);
     for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      system.setPhaseIndex(phaseIndex, phaseIndex);
       system.setPhaseType(phaseIndex, balancedReference.phaseTypes[phaseIndex]);
       system.setBeta(phaseIndex, balancedReference.betas[phaseIndex]);
       for (int componentIndex = 0; componentIndex < balancedReference.compositions[phaseIndex].length; componentIndex++) {
@@ -1267,6 +1336,72 @@ public class TPflash extends Flash {
     }
     system.normalizeBeta();
     system.init(1);
+  }
+
+  /**
+   * Retries a suspicious water-bearing single-phase collapse through the ordinary flash path.
+   *
+   * <p>
+   * In some high-pressure CO2/water states the multiphase solver removes an aqueous phase even though the ordinary
+   * flash converges to a feasible lower-Gibbs oil/aqueous split. The stored post-removal K-values retain a strong phase
+   * preference: water has a very small K-value while at least one non-water component has a large K-value. Only this
+   * inexpensive screen triggers the retry. The ordinary result replaces the collapsed state only after it passes the
+   * existing phase-fraction, distinct-composition, and lower-Gibbs acceptance checks.
+   * </p>
+   */
+  private void rescueSinglePhaseWaterBearingEndpoint() {
+    if (!shouldRetryCollapsedWaterBearingEndpoint()) {
+      return;
+    }
+    system.init(1);
+    double referenceGibbsEnergy = system.getGibbsEnergy();
+    SystemInterface candidate = system.clone();
+    MULTIPHASE_RESCUE_ACTIVE.set(Boolean.TRUE);
+    try {
+      candidate.setMultiPhaseCheck(false);
+      new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+      if (isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)
+          && isBalancedEquilibriumCandidate(candidate)) {
+        copyFlashStateFrom(candidate);
+      }
+    } catch (Exception ex) {
+      logger.debug("Water-bearing endpoint recovery failed: {}", ex.getMessage());
+    } finally {
+      MULTIPHASE_RESCUE_ACTIVE.set(Boolean.FALSE);
+    }
+  }
+
+  /**
+   * Screens a collapsed water-bearing endpoint using retained phase-preference K-values.
+   *
+   * @return true when a bounded ordinary-flash retry is justified
+   */
+  private boolean shouldRetryCollapsedWaterBearingEndpoint() {
+    if (!system.doMultiPhaseCheck() || system.getNumberOfPhases() != 1 || system.isChemicalSystem()
+        || system.hasIons() || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()
+        || MULTIPHASE_RESCUE_ACTIVE.get().booleanValue()) {
+      return false;
+    }
+    boolean hasSubstantialWaterWithSmallK = false;
+    boolean hasVolatileNonWaterComponent = false;
+    neqsim.thermo.phase.PhaseInterface phase = system.getPhase(0);
+    for (int componentIndex = 0; componentIndex < phase.getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = phase.getComponent(componentIndex);
+      if (component.getz() <= 1.0e-50) {
+        continue;
+      }
+      double kValue = component.getK();
+      if (!Double.isFinite(kValue) || kValue <= 0.0) {
+        return false;
+      }
+      if ("water".equalsIgnoreCase(component.getComponentName())) {
+        hasSubstantialWaterWithSmallK = component.getz() >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
+            && kValue < WATER_PHASE_COLLAPSE_WATER_K_UPPER_LIMIT;
+      } else if (kValue > WATER_PHASE_COLLAPSE_VOLATILE_K_LOWER_LIMIT) {
+        hasVolatileNonWaterComponent = true;
+      }
+    }
+    return hasSubstantialWaterWithSmallK && hasVolatileNonWaterComponent;
   }
 
   /**

--- a/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
+++ b/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
@@ -378,8 +378,10 @@ class EclipseFluidReadWriteTest extends neqsim.NeqSimTest {
     // (0.45724333333)
     Assertions.assertEquals(-4636.211412902174, ent, 1e-3);
 
-    // Oil outlet stream is single-phase oil after separation
-    Assertions.assertEquals(1, separator.getOilOutStream().getFluid().getNumberOfPhases());
+    // Aqueous entrainment leaves a stable oil/aqueous split in the oil outlet.
+    Assertions.assertEquals(2, separator.getOilOutStream().getFluid().getNumberOfPhases());
+    Assertions.assertTrue(separator.getOilOutStream().getFluid().hasPhaseType("oil"));
+    Assertions.assertTrue(separator.getOilOutStream().getFluid().hasPhaseType("aqueous"));
 
     ThrottlingValve throttlingValve = new ThrottlingValve("throttlingValve", separator.getOilOutStream());
     throttlingValve.setOutletPressure(3.0, "bara");

--- a/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
+++ b/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
@@ -376,7 +376,7 @@ class EclipseFluidReadWriteTest extends neqsim.NeqSimTest {
     // Updated expected value: OMEGAA from file (0.45724) now applied instead of
     // default
     // (0.45724333333)
-    Assertions.assertEquals(-4639.239569750378, ent, 1e-3);
+    Assertions.assertEquals(-4636.211412902174, ent, 1e-3);
 
     // Oil outlet stream is single-phase oil after separation
     Assertions.assertEquals(1, separator.getOilOutStream().getFluid().getNumberOfPhases());

--- a/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
+++ b/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
@@ -377,10 +377,9 @@ class EclipseFluidReadWriteTest extends neqsim.NeqSimTest {
     // instead of collapsing to a higher-Gibbs oil-only endpoint.
     Assertions.assertEquals(-4636.211412902174, ent, 1e-3);
 
-    // Aqueous entrainment leaves a stable oil/aqueous split in the oil outlet.
+    // The outlet stream's equilibrium rerun retains two phases including oil.
     Assertions.assertEquals(2, separator.getOilOutStream().getFluid().getNumberOfPhases());
     Assertions.assertTrue(separator.getOilOutStream().getFluid().hasPhaseType("oil"));
-    Assertions.assertTrue(separator.getOilOutStream().getFluid().hasPhaseType("aqueous"));
 
     ThrottlingValve throttlingValve = new ThrottlingValve("throttlingValve", separator.getOilOutStream());
     throttlingValve.setOutletPressure(3.0, "bara");

--- a/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
+++ b/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
@@ -388,8 +388,8 @@ class EclipseFluidReadWriteTest extends neqsim.NeqSimTest {
     // throttlingValve.getOutletStream().getFluid().prettyPrint();
     // After throttling, may flash to 2 or 3 phases depending on conditions
     Assertions.assertTrue(throttlingValve.getOutletStream().getFluid().getNumberOfPhases() >= 2);
-    // Updated expected temperature due to thermodynamic model changes
-    Assertions.assertEquals(55.35081, throttlingValve.getOutletStream().getFluid().getTemperature("C"), 1e-3);
+    // The isenthalpic valve uses the recovered two-phase inlet enthalpy.
+    Assertions.assertEquals(55.4102663081153, throttlingValve.getOutletStream().getFluid().getTemperature("C"), 1e-3);
   }
 
   @Test

--- a/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
+++ b/src/test/java/neqsim/thermo/util/readwrite/EclipseFluidReadWriteTest.java
@@ -373,9 +373,8 @@ class EclipseFluidReadWriteTest extends neqsim.NeqSimTest {
     double ent = separator.getOilOutStream().getFluid().getEnthalpy();
     separator.getOilOutStream().run();
     // separator.getOilOutStream().getFluid().prettyPrint();
-    // Updated expected value: OMEGAA from file (0.45724) now applied instead of
-    // default
-    // (0.45724333333)
+    // The explicit aqueous entrainment now remains as a stable oil/aqueous split
+    // instead of collapsing to a higher-Gibbs oil-only endpoint.
     Assertions.assertEquals(-4636.211412902174, ent, 1e-3);
 
     // Aqueous entrainment leaves a stable oil/aqueous split in the oil outlet.

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterBearingPhaseCollapseRecoveryTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterBearingPhaseCollapseRecoveryTest.java
@@ -1,0 +1,128 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashWaterBearingPhaseCollapseRecoveryTest {
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
+
+  @Test
+  void co2WaterSplitSurvivesMultiphaseCleanup() {
+    assertEquivalentCo2WaterSplit(false, 160.0);
+    assertEquivalentCo2WaterSplit(true, 160.0);
+    assertEquivalentCo2WaterSplit(true, 320.0);
+  }
+
+  @Test
+  void cpaOilWaterSplitSurvivesMultiphaseCleanup() {
+    SystemInterface ordinary = createOilWaterSystem(false);
+    SystemInterface multiphase = createOilWaterSystem(true);
+
+    assertEquivalentTwoPhaseState(ordinary, multiphase);
+    assertDeterministicRepeat(multiphase);
+  }
+
+  private void assertEquivalentCo2WaterSplit(boolean pengRobinson, double pressureBara) {
+    SystemInterface ordinary = createCo2WaterSystem(pengRobinson, pressureBara, false);
+    SystemInterface multiphase = createCo2WaterSystem(pengRobinson, pressureBara, true);
+
+    assertEquivalentTwoPhaseState(ordinary, multiphase);
+    assertDeterministicRepeat(multiphase);
+  }
+
+  private SystemInterface createCo2WaterSystem(boolean pengRobinson, double pressureBara,
+      boolean multiphaseCheck) {
+    SystemInterface system = pengRobinson ? new SystemPrEos(250.0, pressureBara)
+        : new SystemSrkEos(250.0, pressureBara);
+    system.addComponent("CO2", 0.75);
+    system.addComponent("methane", 0.15);
+    system.addComponent("ethane", 0.05);
+    system.addComponent("water", 0.05);
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private SystemInterface createOilWaterSystem(boolean multiphaseCheck) {
+    SystemInterface system = new SystemSrkCPAstatoil(370.0, 2.0);
+    system.addComponent("n-heptane", 0.45);
+    system.addComponent("nC10", 0.45);
+    system.addComponent("water", 0.10);
+    system.setMixingRule(10);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private void assertEquivalentTwoPhaseState(SystemInterface expected, SystemInterface actual) {
+    assertEquals(2, expected.getNumberOfPhases());
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-8);
+    assertTrue(maximumComponentMaterialBalanceResidual(actual) < MATERIAL_BALANCE_TOLERANCE);
+    assertTrue(maximumLogFugacityResidual(actual) < 1.0e-8);
+
+    for (int phaseIndex = 0; phaseIndex < expected.getNumberOfPhases(); phaseIndex++) {
+      assertEquals(expected.getPhase(phaseIndex).getType(), actual.getPhase(phaseIndex).getType());
+      assertEquals(expected.getBeta(phaseIndex), actual.getBeta(phaseIndex), 1.0e-12);
+      for (int componentIndex = 0; componentIndex < expected.getPhase(phaseIndex)
+          .getNumberOfComponents(); componentIndex++) {
+        assertEquals(expected.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            actual.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
+      }
+    }
+  }
+
+  private void assertDeterministicRepeat(SystemInterface system) {
+    double firstGibbsEnergy = system.getGibbsEnergy();
+    double firstPhaseFraction = system.getBeta(0);
+
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+
+    assertEquals(2, system.getNumberOfPhases());
+    assertEquals(firstGibbsEnergy, system.getGibbsEnergy(), 1.0e-8);
+    assertEquals(firstPhaseFraction, system.getBeta(0), 1.0e-12);
+    assertTrue(maximumComponentMaterialBalanceResidual(system) < MATERIAL_BALANCE_TOLERANCE);
+    assertTrue(maximumLogFugacityResidual(system) < 1.0e-8);
+  }
+
+  private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex)
+            * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(system.getPhase(0).getComponent(componentIndex).getz() - recoveredFeed));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      double reference = logFugacity(system, 0, componentIndex);
+      for (int phaseIndex = 1; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        maximumResidual = Math.max(maximumResidual,
+            Math.abs(reference - logFugacity(system, phaseIndex, componentIndex)));
+      }
+    }
+    return maximumResidual;
+  }
+
+  private double logFugacity(SystemInterface system, int phaseIndex, int componentIndex) {
+    return Math.log(Math.max(system.getPhase(phaseIndex).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+        + Math.log(system.getPhase(phaseIndex).getComponent(componentIndex).getFugacityCoefficient());
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterBearingPhaseCollapseRecoveryTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterBearingPhaseCollapseRecoveryTest.java
@@ -36,8 +36,7 @@ class TPflashWaterBearingPhaseCollapseRecoveryTest {
     assertDeterministicRepeat(multiphase);
   }
 
-  private SystemInterface createCo2WaterSystem(boolean pengRobinson, double pressureBara,
-      boolean multiphaseCheck) {
+  private SystemInterface createCo2WaterSystem(boolean pengRobinson, double pressureBara, boolean multiphaseCheck) {
     SystemInterface system = pengRobinson ? new SystemPrEos(250.0, pressureBara)
         : new SystemSrkEos(250.0, pressureBara);
     system.addComponent("CO2", 0.75);
@@ -100,8 +99,7 @@ class TPflashWaterBearingPhaseCollapseRecoveryTest {
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
-        recoveredFeed += system.getBeta(phaseIndex)
-            * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
       maximumResidual = Math.max(maximumResidual,
           Math.abs(system.getPhase(0).getComponent(componentIndex).getz() - recoveredFeed));


### PR DESCRIPTION
## Problem

The cross-algorithm matrix remaining after #2736 exposed four deterministic water-bearing cases where ordinary `TPflash` returns a feasible two-phase equilibrium but `setMultiPhaseCheck(true)` removes phases and finishes in a higher-Gibbs one-phase state.

Reproducers on current `master` (`00ff56b`):

| EOS / mixture | T (K) | P (bara) | Ordinary | Multiphase | Gibbs penalty after collapse |
|---|---:|---:|---|---|---:|
| SRK, 75% CO2 / 15% methane / 5% ethane / 5% water | 250 | 160 | oil + aqueous | oil | 353.16 J |
| PR, same feed | 250 | 160 | oil + aqueous | oil | 444.36 J |
| PR, same feed | 250 | 320 | oil + aqueous | oil | 437.84 J |
| CPA rule 10, 45% n-heptane / 45% nC10 / 10% water | 370 | 2 | gas + oil | oil | 247.09 J |

The ordinary splits close component material balance to at most `3.10e-15` and log-fugacity equality to at most `7.82e-14`; their minor phase fractions are 0.0495–0.1188, so these are not trace-phase canonicalization differences.

## Root cause

`TPmultiflash` can keep three trial phases until the late Gibbs-based cleanup, then collapse the endpoint to one phase. Existing recovery paths either require a pre-multiphase aqueous snapshot, exclude water-bearing single-phase endpoints, or run before this late collapse. Consequently, no final gate compares the collapsed state with the already reproducible feasible water-bearing split.

Michelsen's framework separates tangent-plane stability trials from feasible phase-split acceptance. A removed trial does not establish that a higher-Gibbs homogeneous endpoint is the stable minimum:

- [Michelsen 1982, Part I: Stability](https://doi.org/10.1016/0378-3812%2882%2985001-2)
- [Michelsen 1982, Part II: Phase-split calculation](https://doi.org/10.1016/0378-3812%2882%2985002-4)

The literature evidence is the stability/phase-split separation and Gibbs-minimum requirement. The retained-K screen and bounded ordinary retry are implementation choices inferred for NeqSim; no proprietary commercial-simulator algorithm is claimed.

## Method

- Generalize the compact pre-trial snapshot to balanced neutral water-bearing two-phase states.
- If cleanup reaches one phase, use a cheap retained-K screen:
  - water feed >= 0.01;
  - stored water `K < 1e-2`;
  - at least one non-water component with `K > 10`.
- Run one bounded ordinary-flash retry only after that screen.
- Accept the retry only when it:
  - has at least two non-trace phases;
  - has normalized betas and phase compositions;
  - has distinct phase compositions;
  - closes component material balance;
  - satisfies component fugacity equality;
  - lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))`.
- Keep chemical, ionic, solid, wax, dry, and ordinary one-phase paths outside the recovery.

## Results

Deterministic paired matrix: 9 mixtures x SRK/PR/CPA x 5 temperatures x 5 pressures = 675 states.

| Metric | Before | After |
|---|---:|---:|
| Completed flashes | 675/675 | 675/675 |
| Exceptions | 0 | 0 |
| Invalid endpoints | 0 | 0 |
| Applicable one-/two-phase comparisons | 547 | 547 |
| Cross-algorithm disagreements | 4 | 0 |

Coverage includes dry gas, volatile oil, water-rich, hydrocarbon/water, CO2-rich, hydrogen-rich, near-critical, wide-volatility, and oil/water mixtures; one-, two-, and three-phase regions; SRK, PR, and CPA; and repeated execution.

### Runtime

Three fresh alternating JVM forks of the full matrix:

- baseline multiphase time: 7.888–8.030 s, median 7.890 s;
- candidate multiphase time: 7.566–8.145 s, median 7.693 s.

Ranges overlap; no matrix speedup is claimed. Targeted per-flash ranges also overlap:

- recovered SRK CO2 case: 5.34–6.37 ms before, 4.88–5.72 ms after;
- recovered PR CO2 case: 5.85–6.39 ms before, 5.54–6.43 ms after;
- dry-gas control: 3.46–4.23 ms before, 3.45–3.73 ms after.

The additional ordinary retry is limited to a one-phase water-bearing endpoint with strong retained phase-preference evidence. Dry flashes perform only the existing short-circuit guards.

## Tests

Added `TPflashWaterBearingPhaseCollapseRecoveryTest` covering:

- SRK CO2/water at 250 K and 160 bara;
- PR CO2/water at 250 K and 160/320 bara;
- CPA oil/water at 370 K and 2 bara;
- ordinary/multiphase phase count, type, beta, composition, Gibbs, material balance, and fugacity equality;
- deterministic repeated execution.

Local validation:

- Java 8 source/target production compilation against the packaged NeqSim 3.16.0 API: pass;
- focused regression runner: fails on merged baseline (`2 != 1`) and passes with the candidate;
- deterministic 675-state paired matrix: pass;
- candidate production code compiled cleanly except for the expected JDK 17 cross-compilation bootstrap warning.

The restricted workspace does not contain a Maven checkout, so Spotless, Javadocs, and repository Maven suites were not run locally. GitHub Actions must provide those gates.

## Compatibility and risk

Public APIs, EOS implementations, mixing rules, input units, ordinary TPflash behavior, chemical/electrolyte paths, solids, wax, and genuine three-phase endpoints are unchanged. The main risk is a bounded extra ordinary flash for a rare water-bearing one-phase endpoint; strict lower-Gibbs and feasibility gates prevent the retry from replacing a valid result speculatively.

This is AI-assisted work; the reproduced physics, guards, and acceptance checks were inspected and validated as described above.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md` with the collapse screen, thresholds, Gibbs acceptance criterion, scope exclusions, and regression coverage.


## Final validation

Exact head `3f7524c` passed the complete hosted validation:

- Java 21 fast suites on Ubuntu and Windows (11,020 tests on Windows);
- all four Java 21 slow-test shards;
- Java 8 test suites on Ubuntu and Windows;
- Javadocs, CodeQL, Spotless, pre-commit, PaperLab, documentation coverage, and agent-skill checks.

The full-suite regression in `EclipseFluidReadWriteTest.testFluidWater3` was traced through every downstream assertion. The recovered equilibrium changes oil-product enthalpy by 3.028 J (0.0653%), preserves a two-phase outlet containing oil after its equilibrium rerun, and changes the isenthalpic 3 bara valve outlet by 0.05946 °C. Exact reference values were updated without widening either `1e-3` tolerance. Both actionable review threads are resolved.
