### PR TITLE
fix: model severe slugging as a flowline-riser system

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -225,14 +225,48 @@ if (Fr_liquid < 0.5) {
 }
 ```
 
-#### 2. Riser Base Severe Slugging
-Detects severe slugging potential using Pots criterion:
+#### 2. Flowline–Riser Severe-Slugging Stability
+
+Severe slugging is a system instability, not a local pipe-section threshold. After solving a
+flowline–riser case, call the explicit diagnostic with the index of the first continuously
+rising section:
+
 ```java
-double pi_ss = (inletPressure - outletPressure) / (rhoL * g * riserHeight);
-if (pi_ss > 1.0) {
-    // Severe slugging potential flagged
+SevereSluggingSystemDiagnostic.Result stability =
+    pipe.evaluateSevereSluggingSystem(riserBaseSection);
+
+if (stability.isApplicable() && stability.isSevereSluggingPossible()) {
+    System.out.printf("Pressure margin: %.0f Pa%n", stability.getPressureMarginPa());
 }
 ```
+
+The implementation uses the quasi-steady Taitel (1986) condition:
+
+$$
+P_{top,crit} = \phi\,\rho_L\,g\left(\frac{V_G}{A_r\,\alpha'} - H\right)
+$$
+
+where $P_{top}$ is **absolute** riser-outlet pressure [Pa], $\phi$ is average riser liquid
+holdup [-], $\rho_L$ is average riser liquid density [kg/m³], $V_G$ is upstream compressible
+gas volume [m³], $A_r$ is riser area [m²], $H$ is vertical riser height [m], and $\alpha'$ is
+the gas-cap void fraction [-]. The system is classified stable when
+$P_{top} + \Delta P_{choke} \ge P_{top,crit}$. A static choke pressure drop can be provided
+to represent one operating point; dynamic choke response is not modelled.
+
+The diagnostic is applicable only to a two-phase, low-rate, stratified flowline followed by
+a continuously rising, constant-area riser. It assumes isothermal ideal-gas compression and
+neglects wall and interfacial shear during incipient gas penetration. It deliberately returns
+a not-applicable status for invalid topology, non-stratified feeders, single-phase states, and
+unvalidated oil–water–gas cases. It predicts a stability boundary, not slug frequency, slug
+length, or transient cycle amplitude.
+
+The old `getSevereSluggingNumberProfile()` method is retained as a deprecated serialization/API
+alias. Its values are the local inclined-section gas-carryover screen now exposed accurately as
+`getInclinedSectionGasCarryoverNumberProfile()`; they must not be used as a flowline–riser
+stability criterion.
+
+Reference: Taitel, Y. (1986), *Stability of Severe Slugging*, International Journal of
+Multiphase Flow 12(2), 203–217, [doi:10.1016/0301-9322(86)90026-1](https://doi.org/10.1016/0301-9322(86)90026-1).
 
 #### 3. Uphill Liquid Fallback
 Uses Turner droplet model for critical gas velocity:

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -235,9 +235,9 @@ rising section:
 SevereSluggingSystemDiagnostic.Result stability =
     pipe.evaluateSevereSluggingSystem(riserBaseSection);
 
-if (stability.isApplicable() && stability.isSevereSluggingPossible()) {
-    System.out.printf("Pressure margin: %.0f Pa%n", stability.getPressureMarginPa());
-}
+boolean severeSluggingPossible =
+    stability.isApplicable() && stability.isSevereSluggingPossible();
+double pressureMarginPa = stability.getPressureMarginPa();
 ```
 
 The implementation uses the quasi-steady Taitel (1986) condition:

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -260,10 +260,18 @@ a not-applicable status for invalid topology, non-stratified feeders, single-pha
 unvalidated oil–water–gas cases. It predicts a stability boundary, not slug frequency, slug
 length, or transient cycle amplitude.
 
+The flowline and riser may have different diameters, and each flowline section contributes its
+own solved gas volume. Only the rising sections must have constant area. The public
+`SevereSluggingSystemDiagnostic.fromSections(...)` factory exposes the extracted descriptor for
+unit checking, audit, and reuse outside `TwoFluidPipe`.
+
 The old `getSevereSluggingNumberProfile()` method is retained as a deprecated serialization/API
 alias. Its values are the local inclined-section gas-carryover screen now exposed accurately as
 `getInclinedSectionGasCarryoverNumberProfile()`; they must not be used as a flowline–riser
 stability criterion.
+The associated local flag is available from
+`getInclinedSectionLiquidFallbackPotentialProfile()`. `getSevereSlugPotentialProfile()` is
+reserved for the explicit system result and is cleared by the next transient step.
 
 Reference: Taitel, Y. (1986), *Stability of Severe Slugging*, International Journal of
 Multiphase Flow 12(2), 203–217, [doi:10.1016/0301-9322(86)90026-1](https://doi.org/10.1016/0301-9322(86)90026-1).
@@ -353,7 +361,8 @@ System.out.println(pipe.getThermalSummary());
 | Water dropout | Velocity/holdup criterion | Accumulation risk flag |
 | **Terrain Effects** |
 | Low point accumulation | Froude criterion | Fr < 0.5 triggers accumulation |
-| Riser base slugging | Pots criterion | πSS > 1.0 indicates severe slugging |
+| Riser-base liquid fallback | Local gas-carryover screen | Indicates possible local fallback only |
+| Flowline-riser stability | Taitel (1986) quasi-steady criterion | Explicit topology-aware system diagnostic |
 | Uphill fallback | Turner model | Critical gas velocity check |
 | **Thermal Model** |
 | Multi-layer heat transfer | Series resistance | RadialThermalLayer class |
@@ -644,13 +653,13 @@ pipe.setSteadyStateMaxWallClockTime(60.0); // Allow 60 seconds
 - `testPressureDropComparison` - Compares pressure drop predictions between models
 
 **Pipeline Scenario Validation:**
-- `testOVIPCase1HorizontalGasCondensate` - 2km horizontal pipe, gas-condensate, 6-inch
-- `testOVIPCase2UphillRiserAccumulation` - 500m vertical riser, riser base accumulation
+- `testHorizontalGasCondensateScenario` - 2km horizontal pipe, gas-condensate, 6-inch
+- `testUphillRiserAccumulationScenario` - 500m vertical riser, riser-base accumulation
 - `testTerrainTrackingLowPointAccumulation` - V-shaped terrain with 30m dip
 - `testVelocityEffectOnHoldup` - High vs low velocity holdup comparison
 
 **Terrain-Induced Slugging Patterns:**
-- `testSevereSlugConditions` - Flowline + 200m riser, severe slugging (Pots criterion)
+- `testSevereSlugConditions` - Flowline-riser topology extraction smoke test; not a published dynamic validation case
 - `testHillyTerrainMultipleLowPoints` - Sinusoidal terrain ±20m, 3 low points
 - `testDownhillDrainage` - 50m downhill slope, liquid drainage validation
 

--- a/docs/wiki/two_fluid_model_olga_comparison.md
+++ b/docs/wiki/two_fluid_model_olga_comparison.md
@@ -534,10 +534,9 @@ pipe.runTransient(7200.0);  // 2 hours
 int riserBaseSection = 40;
 SevereSluggingSystemDiagnostic.Result stability =
     pipe.evaluateSevereSluggingSystem(riserBaseSection);
-if (stability.isSevereSluggingPossible()) {
-    System.out.println("WARNING: Taitel system screen is unstable");
-    System.out.println("Pressure margin [Pa]: " + stability.getPressureMarginPa());
-}
+boolean severeSluggingPossible = stability.isSevereSluggingPossible();
+double pressureMarginPa = stability.getPressureMarginPa();
+// Pass the status and margin to the application's logger or monitoring system.
 
 // Get holdup profile
 double[] positions = pipe.getPositionProfile();

--- a/docs/wiki/two_fluid_model_olga_comparison.md
+++ b/docs/wiki/two_fluid_model_olga_comparison.md
@@ -367,7 +367,7 @@ The slugs merge:
 ### Slug Tracking Modes
 
 ```java
-// Full OLGA-style Lagrangian tracking (default)
+// Detailed NeqSim Lagrangian tracking (default)
 pipe.setSlugTrackingMode(TwoFluidPipe.SlugTrackingMode.LAGRANGIAN);
 
 // Simplified slug unit model
@@ -420,9 +420,10 @@ $$
 
 Use `evaluateSevereSluggingSystem(riserBaseSection)` after solving the pipe. The result reports
 applicability, stable/unstable status, critical top pressure, pressure margin, stability ratio,
-and gas-expansion head. It rejects non-stratified, single-phase, three-phase, variable-area,
-and invalid flowline–riser topologies. This screen does not predict dynamic slug cycles and is
-not a claim of equivalence to a commercial simulator.
+and gas-expansion head. A flowline-to-riser diameter change is permitted, while the continuously
+rising riser itself must have constant area. The diagnostic rejects non-stratified, single-phase,
+three-phase, variable-area-riser, and invalid flowline–riser topologies. This screen does not
+predict dynamic slug cycles and is not a claim of equivalence to a commercial simulator.
 
 
 ---
@@ -521,7 +522,7 @@ double[] elevations = {0, -50, -100, -50, -150, 0};      // m (relative)
 // Set terrain profile
 pipe.setTerrainProfile(distances, elevations);
 pipe.setEnableTerrainTracking(true);
-pipe.setEnableSevereSlugModel(true);
+pipe.setEnableTerrainSlugClosures(true);
 
 // Configure terrain parameters
 pipe.setTerrainSlugCriticalHoldup(0.6);
@@ -737,7 +738,7 @@ Where $c$ is the mixture sound speed. Typical CFL = 0.5-0.8 for stability.
 
 ---
 
-## Recommendations for OLGA-Equivalent Results
+## Recommendations for Reproducible NeqSim Results
 
 1. **Use FULL model type** for best accuracy:
    ```java
@@ -753,7 +754,7 @@ Where $c$ is the mixture sound speed. Typical CFL = 0.5-0.8 for stability.
 3. **Enable terrain tracking** for undulating pipelines:
    ```java
    pipe.setEnableTerrainTracking(true);
-   pipe.setEnableSevereSlugModel(true);
+   pipe.setEnableTerrainSlugClosures(true);
    ```
 
 4. **Configure minimum holdup** based on system:

--- a/docs/wiki/two_fluid_model_olga_comparison.md
+++ b/docs/wiki/two_fluid_model_olga_comparison.md
@@ -433,6 +433,7 @@ not a claim of equivalence to a commercial simulator.
 
 ```java
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.twophasepipe.SevereSluggingSystemDiagnostic;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemSrkEos;
 

--- a/docs/wiki/two_fluid_model_olga_comparison.md
+++ b/docs/wiki/two_fluid_model_olga_comparison.md
@@ -407,20 +407,23 @@ A terrain-induced slug is released when:
 2. **Sufficient volume accumulated:** $V_{acc} > V_{min}$
 3. **Gas velocity increases** (pressure buildup behind liquid plug)
 
-### Bøe Criterion for Severe Slugging
+### Explicit Flowline–Riser Stability Diagnostic
 
-Severe slugging occurs in riser systems when:
+The former local “Bøe criterion” description did not match an implemented system model and
+has been removed. Severe slugging depends on the compressible upstream gas volume, the riser
+geometry, and the downstream pressure response. NeqSim now exposes the Taitel (1986)
+quasi-steady system screen:
 
 $$
-\Pi_G = \frac{P_{riser,base} - P_{separator}}{(\rho_L - \rho_G) g H_{riser}} < 1
+P_{top,crit} = \phi\rho_L g\left(\frac{V_G}{A_r\alpha'} - H\right)
 $$
 
-Where $\Pi_G$ is the gas penetration number.
+Use `evaluateSevereSluggingSystem(riserBaseSection)` after solving the pipe. The result reports
+applicability, stable/unstable status, critical top pressure, pressure margin, stability ratio,
+and gas-expansion head. It rejects non-stratified, single-phase, three-phase, variable-area,
+and invalid flowline–riser topologies. This screen does not predict dynamic slug cycles and is
+not a claim of equivalence to a commercial simulator.
 
-**Stability criterion:**
-$$
-\text{Severe slugging if } \Pi_G < 1 \text{ AND } \frac{v_{SL}}{v_{SG}} > 0.1
-$$
 
 ---
 
@@ -526,10 +529,13 @@ pipe.setLiquidFallbackCoefficient(0.3);
 // Run transient simulation
 pipe.runTransient(7200.0);  // 2 hours
 
-// Check for severe slugging
-if (pipe.isSevereSluggingDetected()) {
-    System.out.println("WARNING: Severe slugging detected!");
-    System.out.println("Bøe criterion: " + pipe.getBoeNumber());
+// Evaluate the explicit system after selecting the first rising section
+int riserBaseSection = 40;
+SevereSluggingSystemDiagnostic.Result stability =
+    pipe.evaluateSevereSluggingSystem(riserBaseSection);
+if (stability.isSevereSluggingPossible()) {
+    System.out.println("WARNING: Taitel system screen is unstable");
+    System.out.println("Pressure margin [Pa]: " + stability.getPressureMarginPa());
 }
 
 // Get holdup profile

--- a/docs/wiki/two_fluid_reporting_and_validation.md
+++ b/docs/wiki/two_fluid_reporting_and_validation.md
@@ -48,8 +48,9 @@ After `pipe.run()`, the following methods provide one value per pipe section:
 | `getWaterDropoutRiskProfile()` | boolean | Water dropout / accumulation risk |
 | `getEntrainmentFractionProfile()` | fraction | Estimated liquid entrainment in annular/mist flow |
 | `getEntrainedDropletDiameterProfile()` | m | Characteristic entrained droplet diameter |
-| `getSevereSluggingNumberProfile()` | dimensionless | Riser-base stability indicator |
-| `getSevereSlugPotentialProfile()` | boolean | Severe-slugging risk flag |
+| `getInclinedSectionGasCarryoverNumberProfile()` | dimensionless | Local uphill liquid-carryover screen; not a system stability criterion |
+| `getSevereSluggingNumberProfile()` | dimensionless | Deprecated alias for the local carryover screen |
+| `getSevereSlugPotentialProfile()` | boolean | Result flag from the most recent explicit flowline-riser evaluation |
 | `getHeatTransferProfile()` | W/(m2 K) | Heat-transfer coefficient profile, when configured |
 | `getSurfaceTemperatureProfile()` | K | Ambient/surface temperature profile, when configured |
 
@@ -67,7 +68,7 @@ double[] gasVelocity = pipe.getGasVelocityProfile();
 double[] liquidVelocity = pipe.getLiquidVelocityProfile();
 PipeSection.FlowRegime[] regimes = pipe.getFlowRegimeProfile();
 double[] entrainment = pipe.getEntrainmentFractionProfile();
-double[] severeSluggingNumber = pipe.getSevereSluggingNumberProfile();
+double[] gasCarryoverNumber = pipe.getInclinedSectionGasCarryoverNumberProfile();
 boolean[] waterWetting = pipe.getWaterWettingProfile();
 
 for (int i = 0; i < x.length; i++) {
@@ -121,6 +122,11 @@ entrainment_fraction,entrained_droplet_diameter_m,severe_slugging_number,
 severe_slug_potential
 ```
 
+The `severe_slugging_number` header is retained for CSV compatibility. It contains the local
+inclined-section gas-carryover number, not the explicit system stability result. Call
+`evaluateSevereSluggingSystem(...)` before exporting if `severe_slug_potential` should contain
+a system-level classification.
+
 ## Summary metrics
 
 Use these methods for an executive summary or design report:
@@ -156,8 +162,9 @@ validation. Each value is available both on `TwoFluidSection` and as a top-level
 | `isWaterDropoutRisk()` | `getWaterDropoutRiskProfile()` | Water dropout / accumulation risk |
 | `getEntrainmentFraction()` | `getEntrainmentFractionProfile()` | Estimated liquid entrainment fraction |
 | `getEntrainedDropletDiameter()` | `getEntrainedDropletDiameterProfile()` | Entrained droplet diameter |
-| `getSevereSluggingNumber()` | `getSevereSluggingNumberProfile()` | Riser-base stability indicator |
-| `isSevereSlugPotential()` | `getSevereSlugPotentialProfile()` | Severe-slugging risk flag |
+| `getInclinedSectionGasCarryoverNumber()` | `getInclinedSectionGasCarryoverNumberProfile()` | Local uphill liquid-carryover screen |
+| `getSevereSluggingNumber()` | `getSevereSluggingNumberProfile()` | Deprecated aliases for the same local screen |
+| `isSevereSlugPotential()` | `getSevereSlugPotentialProfile()` | Last explicit flowline-riser system result |
 
 The steady-state and transient profile CSV exporters include these diagnostics. Boolean values are
 written as `true` or `false`; a missing oil-water regime is written as an empty field.

--- a/docs/wiki/two_fluid_reporting_and_validation.md
+++ b/docs/wiki/two_fluid_reporting_and_validation.md
@@ -49,6 +49,7 @@ After `pipe.run()`, the following methods provide one value per pipe section:
 | `getEntrainmentFractionProfile()` | fraction | Estimated liquid entrainment in annular/mist flow |
 | `getEntrainedDropletDiameterProfile()` | m | Characteristic entrained droplet diameter |
 | `getInclinedSectionGasCarryoverNumberProfile()` | dimensionless | Local uphill liquid-carryover screen; not a system stability criterion |
+| `getInclinedSectionLiquidFallbackPotentialProfile()` | boolean | Local fallback flag from the carryover screen |
 | `getSevereSluggingNumberProfile()` | dimensionless | Deprecated alias for the local carryover screen |
 | `getSevereSlugPotentialProfile()` | boolean | Result flag from the most recent explicit flowline-riser evaluation |
 | `getHeatTransferProfile()` | W/(m2 K) | Heat-transfer coefficient profile, when configured |
@@ -69,6 +70,7 @@ double[] liquidVelocity = pipe.getLiquidVelocityProfile();
 PipeSection.FlowRegime[] regimes = pipe.getFlowRegimeProfile();
 double[] entrainment = pipe.getEntrainmentFractionProfile();
 double[] gasCarryoverNumber = pipe.getInclinedSectionGasCarryoverNumberProfile();
+boolean[] localFallback = pipe.getInclinedSectionLiquidFallbackPotentialProfile();
 boolean[] waterWetting = pipe.getWaterWettingProfile();
 
 for (int i = 0; i < x.length; i++) {
@@ -118,12 +120,14 @@ Recommended transient CSV columns:
 time_s,position_m,pressure_bara,temperature_C,liquid_holdup,water_cut,
 gas_velocity_m_s,liquid_velocity_m_s,oil_velocity_m_s,water_velocity_m_s,
 flow_regime,oil_water_flow_regime,water_wetting,water_dropout_risk,
-entrainment_fraction,entrained_droplet_diameter_m,severe_slugging_number,
-severe_slug_potential
+entrainment_fraction,entrained_droplet_diameter_m,
+inclined_section_gas_carryover_number,inclined_section_liquid_fallback_potential,
+severe_slugging_number,severe_slug_potential
 ```
 
-The `severe_slugging_number` header is retained for CSV compatibility. It contains the local
-inclined-section gas-carryover number, not the explicit system stability result. Call
+The `severe_slugging_number` header is retained as a deprecated duplicate for CSV compatibility.
+It contains the local inclined-section gas-carryover number, not the explicit system stability
+result. New consumers should use `inclined_section_gas_carryover_number`. Call
 `evaluateSevereSluggingSystem(...)` before exporting if `severe_slug_potential` should contain
 a system-level classification.
 
@@ -163,11 +167,14 @@ validation. Each value is available both on `TwoFluidSection` and as a top-level
 | `getEntrainmentFraction()` | `getEntrainmentFractionProfile()` | Estimated liquid entrainment fraction |
 | `getEntrainedDropletDiameter()` | `getEntrainedDropletDiameterProfile()` | Entrained droplet diameter |
 | `getInclinedSectionGasCarryoverNumber()` | `getInclinedSectionGasCarryoverNumberProfile()` | Local uphill liquid-carryover screen |
+| `isInclinedSectionLiquidFallbackPotential()` | `getInclinedSectionLiquidFallbackPotentialProfile()` | Local fallback flag |
 | `getSevereSluggingNumber()` | `getSevereSluggingNumberProfile()` | Deprecated aliases for the same local screen |
 | `isSevereSlugPotential()` | `getSevereSlugPotentialProfile()` | Last explicit flowline-riser system result |
 
 The steady-state and transient profile CSV exporters include these diagnostics. Boolean values are
 written as `true` or `false`; a missing oil-water regime is written as an empty field.
+The system-result profile is meaningful only after `evaluateSevereSluggingSystem(...)` and is
+cleared when the next transient step changes the solved state.
 
 ## Benchmark comparison format
 
@@ -193,11 +200,16 @@ oil_velocity_m_s
 water_velocity_m_s
 entrainment_fraction
 entrained_droplet_diameter_m
+inclined_section_gas_carryover_number
+inclined_section_liquid_fallback_flag
 severe_slugging_number
 water_wetting_flag
 water_dropout_risk_flag
 severe_slug_potential_flag
 ```
+
+`severe_slugging_number` is the deprecated benchmark key for
+`inclined_section_gas_carryover_number`; it is retained only for existing comparison files.
 
 Example use:
 

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -529,8 +529,8 @@ public class TwoFluidPipe extends Pipeline {
    * Critical holdup for terrain-induced slug initiation.
    *
    * <p>
-   * When liquid holdup in a low point exceeds this value, a terrain-induced slug is initiated. The
-   * default 0.6 is an empirical NeqSim setting, not a published commercial-simulator default.
+   * When liquid holdup in a low point exceeds this value, a terrain-induced slug is initiated. The default 0.6 is an
+   * empirical NeqSim setting, not a published commercial-simulator default.
    * </p>
    */
   private double terrainSlugCriticalHoldup = 0.6;
@@ -549,8 +549,8 @@ public class TwoFluidPipe extends Pipeline {
    * Enable empirical terrain-slug and riser-base liquid-fallback closures.
    *
    * <p>
-   * The serialized field name is retained for compatibility. These local closures are separate from
-   * the explicit flowline-riser system diagnostic.
+   * The serialized field name is retained for compatibility. These local closures are separate from the explicit
+   * flowline-riser system diagnostic.
    * </p>
    */
   private boolean enableSevereSlugModel = true;
@@ -572,8 +572,8 @@ public class TwoFluidPipe extends Pipeline {
    * Flow regime transition hysteresis factor.
    *
    * <p>
-   * NeqSim applies this hysteresis to prevent rapid switching between flow regimes. A value of
-   * 0.1 means a 10% band around transition boundaries.
+   * NeqSim applies this hysteresis to prevent rapid switching between flow regimes. A value of 0.1 means a 10% band
+   * around transition boundaries.
    * </p>
    */
   private double flowRegimeHysteresis = 0.1;
@@ -1854,8 +1854,7 @@ public class TwoFluidPipe extends Pipeline {
    * Update temperature using multi-layer thermal model.
    *
    * <p>
-   * This method implements radial heat transfer through multiple concentric layers. The heat
-   * transfer calculation uses:
+   * This method implements radial heat transfer through multiple concentric layers. The heat transfer calculation uses:
    * </p>
    * <ul>
    * <li>Inner convective resistance from fluid to pipe wall</li>
@@ -4874,8 +4873,8 @@ public class TwoFluidPipe extends Pipeline {
    * Get the local inclined-section liquid-fallback screen at each section.
    *
    * <p>
-   * This profile is maintained by local closure calculations. It is separate from the explicit
-   * flowline-riser severe-slugging system classification.
+   * This profile is maintained by local closure calculations. It is separate from the explicit flowline-riser
+   * severe-slugging system classification.
    * </p>
    *
    * @return local liquid-fallback flags
@@ -4906,10 +4905,9 @@ public class TwoFluidPipe extends Pipeline {
    * Get the most recent explicit severe-slugging system classification as a section profile.
    *
    * <p>
-   * The profile is all false until {@link #evaluateSevereSluggingSystem(int)} is called. An
-   * applicable unstable result marks only the selected riser-base section. Each subsequent
-   * {@link #runTransient(double, UUID)} call invalidates and clears the classification because the
-   * section state has changed.
+   * The profile is all false until {@link #evaluateSevereSluggingSystem(int)} is called. An applicable unstable result
+   * marks only the selected riser-base section. Each subsequent {@link #runTransient(double, UUID)} call invalidates
+   * and clears the classification because the section state has changed.
    * </p>
    *
    * @return explicit system-classification flags
@@ -4951,8 +4949,8 @@ public class TwoFluidPipe extends Pipeline {
    * </p>
    *
    * <p>
-   * Evaluation clears the previous system-classification profile and marks the selected riser-base
-   * section only when the result is applicable and unstable.
+   * Evaluation clears the previous system-classification profile and marks the selected riser-base section only when
+   * the result is applicable and unstable.
    * </p>
    *
    * @param riserBaseSection index of the first continuously rising section
@@ -4969,8 +4967,8 @@ public class TwoFluidPipe extends Pipeline {
       throw new IllegalArgumentException("riserBaseSection must be between 1 and numberOfSections - 1");
     }
 
-    SevereSluggingSystemDiagnostic.Input input = SevereSluggingSystemDiagnostic.fromSections(sections,
-        riserBaseSection, gasCapVoidFraction, staticChokePressureDropPa);
+    SevereSluggingSystemDiagnostic.Input input = SevereSluggingSystemDiagnostic.fromSections(sections, riserBaseSection,
+        gasCapVoidFraction, staticChokePressureDropPa);
     SevereSluggingSystemDiagnostic.Result result = SevereSluggingSystemDiagnostic.evaluate(input);
 
     clearSevereSluggingSystemClassification();
@@ -5064,8 +5062,7 @@ public class TwoFluidPipe extends Pipeline {
    * </p>
    * <ul>
    * <li><b>SIMPLIFIED:</b> Simple slug unit model with basic tracking</li>
-   * <li><b>LAGRANGIAN:</b> Detailed tracking with wake effects, frequency-based initiation,
-   * and slug statistics</li>
+   * <li><b>LAGRANGIAN:</b> Detailed tracking with wake effects, frequency-based initiation, and slug statistics</li>
    * <li><b>DISABLED:</b> No slug tracking</li>
    * </ul>
    *
@@ -6337,8 +6334,7 @@ public class TwoFluidPipe extends Pipeline {
    * Legacy alias for {@link #setEnableTerrainSlugClosures(boolean)}.
    *
    * @param enable true to enable the local closures
-   * @deprecated This switch does not enable or disable the explicit severe-slugging system
-   *             diagnostic.
+   * @deprecated This switch does not enable or disable the explicit severe-slugging system diagnostic.
    */
   @Deprecated
   public void setEnableSevereSlugModel(boolean enable) {
@@ -6349,8 +6345,7 @@ public class TwoFluidPipe extends Pipeline {
    * Legacy alias for {@link #isEnableTerrainSlugClosures()}.
    *
    * @return true if the local closures are enabled
-   * @deprecated This value does not report availability of the explicit severe-slugging system
-   *             diagnostic.
+   * @deprecated This value does not report availability of the explicit severe-slugging system diagnostic.
    */
   @Deprecated
   public boolean isEnableSevereSlugModel() {

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4984,8 +4984,8 @@ public class TwoFluidPipe extends Pipeline {
         .separatorPressurePa(sections[sections.length - 1].getPressure())
         .staticChokePressureDropPa(staticChokePressureDropPa).liquidDensityKgPerM3(liquidDensity)
         .riserLiquidHoldup(riserLiquidHoldup).gasCapVoidFraction(gasCapVoidFraction)
-        .validFlowlineRiserTopology(topologyValid).flowlineStratified(flowlineStratified).threePhase(threePhase)
-        .build();
+        .validFlowlineRiserTopology(topologyValid).flowlineStratified(flowlineStratified)
+        .flowlineContainsGasAndLiquid(flowlineContainsGasAndLiquid).threePhase(threePhase).build();
     SevereSluggingSystemDiagnostic.Result result = SevereSluggingSystemDiagnostic.evaluate(input);
 
     for (TwoFluidSection section : sections) {

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -181,7 +181,7 @@ public class TwoFluidPipe extends Pipeline {
   /** Slug tracker (simplified model). */
   private SlugTracker slugTracker;
 
-  /** Lagrangian slug tracker (OLGA-style full tracking). */
+  /** Detailed Lagrangian slug tracker. */
   private LagrangianSlugTracker lagrangianSlugTracker;
 
   /**
@@ -190,7 +190,7 @@ public class TwoFluidPipe extends Pipeline {
   public enum SlugTrackingMode {
     /** Simplified slug unit model. */
     SIMPLIFIED,
-    /** Full Lagrangian tracking (OLGA-style). */
+    /** Detailed Lagrangian tracking. */
     LAGRANGIAN,
     /** No slug tracking. */
     DISABLED
@@ -281,7 +281,7 @@ public class TwoFluidPipe extends Pipeline {
   /** Soil/burial thermal resistance (m²·K/W). */
   private double soilThermalResistance = 0.0;
 
-  /** Multi-layer thermal calculator for OLGA-style radial heat transfer. */
+  /** Multi-layer radial heat-transfer calculator. */
   private MultilayerThermalCalculator thermalCalculator = null;
 
   /** Enable multi-layer thermal model (vs simple U-value). */
@@ -516,7 +516,7 @@ public class TwoFluidPipe extends Pipeline {
   // ============ OLGA Terrain Tracking Parameters ============
 
   /**
-   * Enable full OLGA-style terrain tracking.
+   * Enable empirical NeqSim terrain tracking.
    *
    * <p>
    * When enabled, uses OLGA's terrain tracking algorithm which: - Identifies all low points and high points - Tracks
@@ -529,8 +529,8 @@ public class TwoFluidPipe extends Pipeline {
    * Critical holdup for terrain-induced slug initiation.
    *
    * <p>
-   * When liquid holdup in a low point exceeds this value, a terrain-induced slug is initiated. Default 0.6 based on
-   * OLGA recommendations.
+   * When liquid holdup in a low point exceeds this value, a terrain-induced slug is initiated. The
+   * default 0.6 is an empirical NeqSim setting, not a published commercial-simulator default.
    * </p>
    */
   private double terrainSlugCriticalHoldup = 0.6;
@@ -540,17 +540,17 @@ public class TwoFluidPipe extends Pipeline {
    *
    * <p>
    * Controls how much liquid falls back in uphill sections when gas velocity is insufficient to carry liquid upward.
-   * Higher values mean more liquid accumulation. OLGA default ~0.3.
+   * Higher values mean more liquid accumulation. The default 0.3 is an empirical NeqSim setting.
    * </p>
    */
   private double liquidFallbackCoefficient = 0.3;
 
   /**
-   * Enable severe slugging detection and modeling.
+   * Enable empirical terrain-slug and riser-base liquid-fallback closures.
    *
    * <p>
-   * Severe slugging occurs at riser bases when liquid periodically blocks gas flow. This cyclic phenomenon can cause
-   * large pressure and flow oscillations.
+   * The serialized field name is retained for compatibility. These local closures are separate from
+   * the explicit flowline-riser system diagnostic.
    * </p>
    */
   private boolean enableSevereSlugModel = true;
@@ -572,8 +572,8 @@ public class TwoFluidPipe extends Pipeline {
    * Flow regime transition hysteresis factor.
    *
    * <p>
-   * OLGA uses hysteresis to prevent rapid switching between flow regimes. A value of 0.1 means 10% hysteresis band
-   * around transition boundaries.
+   * NeqSim applies this hysteresis to prevent rapid switching between flow regimes. A value of
+   * 0.1 means a 10% band around transition boundaries.
    * </p>
    */
   private double flowRegimeHysteresis = 0.1;
@@ -1854,8 +1854,8 @@ public class TwoFluidPipe extends Pipeline {
    * Update temperature using multi-layer thermal model.
    *
    * <p>
-   * This method implements OLGA-style radial heat transfer through multiple concentric layers. The heat transfer
-   * calculation uses:
+   * This method implements radial heat transfer through multiple concentric layers. The heat
+   * transfer calculation uses:
    * </p>
    * <ul>
    * <li>Inner convective resistance from fluid to pipe wall</li>
@@ -2557,7 +2557,7 @@ public class TwoFluidPipe extends Pipeline {
     double WeG = rhoG * vsG * vsG * D / sigma;
     double ReL = rhoL * vsL * D / muL;
 
-    // Entrainment fraction (OLGA uses modified Ishii-Mishima)
+    // Entrainment fraction from the selected NeqSim closure set
     double entrainment = 0.0;
     if (WeG > 0 && ReL > 0) {
       double entrainmentArg = 7.25e-7 * Math.pow(WeG, 1.25) * Math.pow(ReL, 0.25);
@@ -2736,7 +2736,7 @@ public class TwoFluidPipe extends Pipeline {
    * Calculate terrain-induced liquid accumulation enhancement using OLGA methodology.
    *
    * <p>
-   * This implements the full OLGA terrain tracking algorithm which accounts for:
+   * This implements empirical NeqSim terrain holdup modifiers which account for:
    * </p>
    * <ul>
    * <li><b>Low Point Accumulation:</b> Liquid pools in valleys due to gravity. The volume of accumulated liquid depends
@@ -2790,7 +2790,7 @@ public class TwoFluidPipe extends Pipeline {
     // ========== LOW POINT ACCUMULATION (OLGA Valley Model) ==========
     if (isLowPoint || sec.isLowPoint()) {
       // At low points, liquid accumulates due to gravity pooling
-      // OLGA uses a modified Froude number criterion for accumulation
+      // NeqSim uses a modified Froude-number screen for accumulation
 
       // Elevation change into the low point
       double elevChange = (prev != null) ? Math.abs(sec.getElevation() - prev.getElevation()) : 0;
@@ -3261,6 +3261,7 @@ public class TwoFluidPipe extends Pipeline {
   public void runTransient(double dt, UUID id) {
     isTransientMode = true;
     lastMassBalanceReport = null;
+    clearSevereSluggingSystemClassification();
     double[] initialMassKg = getPhaseMassInventoriesKg();
     double[] integratedInletMassKg = new double[3];
     double[] integratedOutletMassKg = new double[3];
@@ -3276,7 +3277,7 @@ public class TwoFluidPipe extends Pipeline {
 
     boolean isIMEX = (timeIntegrator.getMethod() == TimeIntegrator.Method.IMEX_PRESSURE_CORRECTION);
 
-    // Calculate initial stable time step (OLGA-style: CFL from current velocities)
+    // Calculate initial stable time step from the current-velocity CFL limit
     double dtCFL = isIMEX ? calcConvectiveTimeStep() : calcStableTimeStep();
     if (enableAdaptiveTimestepping) {
       dtCFL *= adaptiveDtFactor;
@@ -3470,7 +3471,7 @@ public class TwoFluidPipe extends Pipeline {
         double inletMixtureVelocity = sections[0].getMixtureVelocity();
 
         if (slugTrackingMode == SlugTrackingMode.LAGRANGIAN) {
-          // OLGA-style full Lagrangian tracking
+          // Detailed Lagrangian tracking
           lagrangianSlugTracker.setReferenceVelocity(inletMixtureVelocity);
 
           // Check for terrain-induced slug initiation from accumulation zones
@@ -4870,6 +4871,27 @@ public class TwoFluidPipe extends Pipeline {
   }
 
   /**
+   * Get the local inclined-section liquid-fallback screen at each section.
+   *
+   * <p>
+   * This profile is maintained by local closure calculations. It is separate from the explicit
+   * flowline-riser severe-slugging system classification.
+   * </p>
+   *
+   * @return local liquid-fallback flags
+   */
+  public boolean[] getInclinedSectionLiquidFallbackPotentialProfile() {
+    if (sections == null) {
+      return new boolean[0];
+    }
+    boolean[] profile = new boolean[numberOfSections];
+    for (int i = 0; i < numberOfSections; i++) {
+      profile[i] = sections[i].isInclinedSectionLiquidFallbackPotential();
+    }
+    return profile;
+  }
+
+  /**
    * Legacy alias for {@link #getInclinedSectionGasCarryoverNumberProfile()}.
    *
    * @return local gas-carryover-number profile
@@ -4881,9 +4903,16 @@ public class TwoFluidPipe extends Pipeline {
   }
 
   /**
-   * Get the severe-slugging risk flag at each section.
+   * Get the most recent explicit severe-slugging system classification as a section profile.
    *
-   * @return severe-slugging potential flags
+   * <p>
+   * The profile is all false until {@link #evaluateSevereSluggingSystem(int)} is called. An
+   * applicable unstable result marks only the selected riser-base section. Each subsequent
+   * {@link #runTransient(double, UUID)} call invalidates and clears the classification because the
+   * section state has changed.
+   * </p>
+   *
+   * @return explicit system-classification flags
    */
   public boolean[] getSevereSlugPotentialProfile() {
     if (sections == null) {
@@ -4921,6 +4950,11 @@ public class TwoFluidPipe extends Pipeline {
    * return a not-applicable status.
    * </p>
    *
+   * <p>
+   * Evaluation clears the previous system-classification profile and marks the selected riser-base
+   * section only when the result is applicable and unstable.
+   * </p>
+   *
    * @param riserBaseSection index of the first continuously rising section
    * @param gasCapVoidFraction void fraction alpha-prime in the penetrating gas cap
    * @param staticChokePressureDropPa fixed choke pressure drop in Pa
@@ -4935,66 +4969,27 @@ public class TwoFluidPipe extends Pipeline {
       throw new IllegalArgumentException("riserBaseSection must be between 1 and numberOfSections - 1");
     }
 
-    double referenceArea = sections[riserBaseSection].getArea();
-    double upstreamGasVolume = 0.0;
-    double riserVolume = 0.0;
-    double riserLiquidVolume = 0.0;
-    double riserLiquidMass = 0.0;
-    double riserHeight = 0.0;
-    boolean topologyValid = true;
-    boolean flowlineStratified = true;
-    boolean flowlineContainsGasAndLiquid = false;
-    boolean threePhase = false;
-
-    for (int i = 0; i < sections.length; i++) {
-      TwoFluidSection section = sections[i];
-      double cellVolume = section.getArea() * section.getLength();
-      if (Math.abs(section.getArea() - referenceArea) > 1.0e-6 * referenceArea) {
-        topologyValid = false;
-      }
-      if (section.getOilHoldup() > 1.0e-10 && section.getWaterHoldup() > 1.0e-10) {
-        threePhase = true;
-      }
-
-      if (i < riserBaseSection) {
-        upstreamGasVolume += section.getGasHoldup() * cellVolume;
-        topologyValid &= section.getInclination() <= Math.toRadians(1.0);
-        if (section.getGasHoldup() > 1.0e-10 && section.getLiquidHoldup() > 1.0e-10) {
-          flowlineContainsGasAndLiquid = true;
-          FlowRegime regime = section.getFlowRegime();
-          flowlineStratified &= regime == FlowRegime.STRATIFIED_SMOOTH || regime == FlowRegime.STRATIFIED_WAVY;
-        }
-      } else {
-        topologyValid &= section.getInclination() > Math.toRadians(1.0);
-        riserHeight += Math.sin(section.getInclination()) * section.getLength();
-        riserVolume += cellVolume;
-        double liquidVolume = section.getLiquidHoldup() * cellVolume;
-        riserLiquidVolume += liquidVolume;
-        riserLiquidMass += liquidVolume * section.getLiquidDensity();
-      }
-    }
-
-    flowlineStratified &= flowlineContainsGasAndLiquid;
-    double riserLiquidHoldup = riserVolume > 0.0 ? riserLiquidVolume / riserVolume : 0.0;
-    double liquidDensity = riserLiquidVolume > 0.0 ? riserLiquidMass / riserLiquidVolume : 1.0;
-    topologyValid &= riserHeight > 0.0;
-
-    SevereSluggingSystemDiagnostic.Input input = SevereSluggingSystemDiagnostic.Input.builder()
-        .upstreamGasVolumeM3(upstreamGasVolume).riserAreaM2(referenceArea).riserHeightM(Math.max(riserHeight, 1.0e-12))
-        .separatorPressurePa(sections[sections.length - 1].getPressure())
-        .staticChokePressureDropPa(staticChokePressureDropPa).liquidDensityKgPerM3(liquidDensity)
-        .riserLiquidHoldup(riserLiquidHoldup).gasCapVoidFraction(gasCapVoidFraction)
-        .validFlowlineRiserTopology(topologyValid).flowlineStratified(flowlineStratified)
-        .flowlineContainsGasAndLiquid(flowlineContainsGasAndLiquid).threePhase(threePhase).build();
+    SevereSluggingSystemDiagnostic.Input input = SevereSluggingSystemDiagnostic.fromSections(sections,
+        riserBaseSection, gasCapVoidFraction, staticChokePressureDropPa);
     SevereSluggingSystemDiagnostic.Result result = SevereSluggingSystemDiagnostic.evaluate(input);
 
-    for (TwoFluidSection section : sections) {
-      section.setSevereSlugPotential(false);
-    }
+    clearSevereSluggingSystemClassification();
     if (result.isSevereSluggingPossible()) {
       sections[riserBaseSection].setSevereSlugPotential(true);
     }
     return result;
+  }
+
+  /** Clear the section marker produced by the explicit system diagnostic. */
+  private void clearSevereSluggingSystemClassification() {
+    if (sections == null) {
+      return;
+    }
+    for (TwoFluidSection section : sections) {
+      if (section != null) {
+        section.setSevereSlugPotential(false);
+      }
+    }
   }
 
   /**
@@ -5044,7 +5039,7 @@ public class TwoFluidPipe extends Pipeline {
   }
 
   /**
-   * Get Lagrangian slug tracker for OLGA-style slug tracking.
+   * Get the detailed Lagrangian slug tracker.
    *
    * @return Lagrangian slug tracker
    */
@@ -5069,8 +5064,8 @@ public class TwoFluidPipe extends Pipeline {
    * </p>
    * <ul>
    * <li><b>SIMPLIFIED:</b> Simple slug unit model with basic tracking</li>
-   * <li><b>LAGRANGIAN:</b> Full OLGA-style Lagrangian tracking with wake effects, frequency-based initiation, and
-   * detailed statistics</li>
+   * <li><b>LAGRANGIAN:</b> Detailed tracking with wake effects, frequency-based initiation,
+   * and slug statistics</li>
    * <li><b>DISABLED:</b> No slug tracking</li>
    * </ul>
    *
@@ -5085,7 +5080,7 @@ public class TwoFluidPipe extends Pipeline {
    * Configure Lagrangian slug tracker parameters.
    *
    * <p>
-   * This method provides access to advanced slug tracking configuration for the OLGA-style Lagrangian model.
+   * This method provides access to detailed Lagrangian slug-tracking configuration.
    * </p>
    *
    * @param enableInletGeneration enable hydrodynamic slug generation at inlet
@@ -6321,21 +6316,45 @@ public class TwoFluidPipe extends Pipeline {
   }
 
   /**
-   * Enable or disable severe slugging model for risers.
+   * Enable or disable empirical terrain-slug and riser-base liquid-fallback closures.
    *
-   * @param enable true to enable severe slugging detection (default true)
+   * @param enable true to enable the local closures
    */
-  public void setEnableSevereSlugModel(boolean enable) {
+  public void setEnableTerrainSlugClosures(boolean enable) {
     this.enableSevereSlugModel = enable;
   }
 
   /**
-   * Check if severe slugging model is enabled.
+   * Check whether empirical terrain-slug and riser-base liquid-fallback closures are enabled.
    *
-   * @return true if severe slugging model is enabled
+   * @return true if the local closures are enabled
    */
-  public boolean isEnableSevereSlugModel() {
+  public boolean isEnableTerrainSlugClosures() {
     return enableSevereSlugModel;
+  }
+
+  /**
+   * Legacy alias for {@link #setEnableTerrainSlugClosures(boolean)}.
+   *
+   * @param enable true to enable the local closures
+   * @deprecated This switch does not enable or disable the explicit severe-slugging system
+   *             diagnostic.
+   */
+  @Deprecated
+  public void setEnableSevereSlugModel(boolean enable) {
+    setEnableTerrainSlugClosures(enable);
+  }
+
+  /**
+   * Legacy alias for {@link #isEnableTerrainSlugClosures()}.
+   *
+   * @return true if the local closures are enabled
+   * @deprecated This value does not report availability of the explicit severe-slugging system
+   *             diagnostic.
+   */
+  @Deprecated
+  public boolean isEnableSevereSlugModel() {
+    return isEnableTerrainSlugClosures();
   }
 
   /**
@@ -6577,7 +6596,7 @@ public class TwoFluidPipe extends Pipeline {
   }
 
   /**
-   * Enable multi-layer thermal model for OLGA-style radial heat transfer.
+   * Enable the multi-layer radial heat-transfer model.
    *
    * <p>
    * When enabled, uses the MultilayerThermalCalculator for accurate heat transfer with proper modeling of:

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4851,8 +4851,10 @@ public class TwoFluidPipe extends Pipeline {
   /**
    * Get the local inclined-section gas-carryover number at each section.
    *
-   * <p>Values below 1 indicate possible liquid fallback. The number is a local closure screen;
-   * it does not diagnose severe slugging in a flowline-riser system.</p>
+   * <p>
+   * Values below 1 indicate possible liquid fallback. The number is a local closure screen; it does not diagnose severe
+   * slugging in a flowline-riser system.
+   * </p>
    *
    * @return local gas-carryover-number profile
    */
@@ -4897,38 +4899,40 @@ public class TwoFluidPipe extends Pipeline {
   /**
    * Evaluate severe-slugging stability for a flowline feeding a constant-area riser.
    *
-   * <p>The solved section states provide upstream gas volume, average riser holdup and
-   * density, riser height, and absolute outlet pressure. The default gas-cap void fraction
-   * is 0.89, following the air-water basis used in Taitel's published comparison.</p>
+   * <p>
+   * The solved section states provide upstream gas volume, average riser holdup and density, riser height, and absolute
+   * outlet pressure. The default gas-cap void fraction is 0.89, following the air-water basis used in Taitel's
+   * published comparison.
+   * </p>
    *
    * @param riserBaseSection index of the first continuously rising section
    * @return explicit system-level stability result
    */
-  public SevereSluggingSystemDiagnostic.Result evaluateSevereSluggingSystem(
-      int riserBaseSection) {
+  public SevereSluggingSystemDiagnostic.Result evaluateSevereSluggingSystem(int riserBaseSection) {
     return evaluateSevereSluggingSystem(riserBaseSection, 0.89, 0.0);
   }
 
   /**
    * Evaluate severe-slugging stability with explicit gas-cap and static-choke inputs.
    *
-   * <p>The static choke pressure drop is added to absolute outlet pressure. It represents
-   * one operating point only; dynamic choke response is outside this quasi-steady diagnostic.
-   * Three-phase systems and non-stratified feeders return a not-applicable status.</p>
+   * <p>
+   * The static choke pressure drop is added to absolute outlet pressure. It represents one operating point only;
+   * dynamic choke response is outside this quasi-steady diagnostic. Three-phase systems and non-stratified feeders
+   * return a not-applicable status.
+   * </p>
    *
    * @param riserBaseSection index of the first continuously rising section
    * @param gasCapVoidFraction void fraction alpha-prime in the penetrating gas cap
    * @param staticChokePressureDropPa fixed choke pressure drop in Pa
    * @return explicit system-level stability result
    */
-  public SevereSluggingSystemDiagnostic.Result evaluateSevereSluggingSystem(
-      int riserBaseSection, double gasCapVoidFraction, double staticChokePressureDropPa) {
+  public SevereSluggingSystemDiagnostic.Result evaluateSevereSluggingSystem(int riserBaseSection,
+      double gasCapVoidFraction, double staticChokePressureDropPa) {
     if (sections == null || sections.length != numberOfSections) {
       throw new IllegalStateException("Run the pipe before evaluating flowline-riser stability");
     }
     if (riserBaseSection <= 0 || riserBaseSection >= sections.length) {
-      throw new IllegalArgumentException(
-          "riserBaseSection must be between 1 and numberOfSections - 1");
+      throw new IllegalArgumentException("riserBaseSection must be between 1 and numberOfSections - 1");
     }
 
     double referenceArea = sections[riserBaseSection].getArea();
@@ -4958,8 +4962,7 @@ public class TwoFluidPipe extends Pipeline {
         if (section.getGasHoldup() > 1.0e-10 && section.getLiquidHoldup() > 1.0e-10) {
           flowlineContainsGasAndLiquid = true;
           FlowRegime regime = section.getFlowRegime();
-          flowlineStratified &= regime == FlowRegime.STRATIFIED_SMOOTH
-              || regime == FlowRegime.STRATIFIED_WAVY;
+          flowlineStratified &= regime == FlowRegime.STRATIFIED_SMOOTH || regime == FlowRegime.STRATIFIED_WAVY;
         }
       } else {
         topologyValid &= section.getInclination() > Math.toRadians(1.0);
@@ -4977,15 +4980,13 @@ public class TwoFluidPipe extends Pipeline {
     topologyValid &= riserHeight > 0.0;
 
     SevereSluggingSystemDiagnostic.Input input = SevereSluggingSystemDiagnostic.Input.builder()
-        .upstreamGasVolumeM3(upstreamGasVolume).riserAreaM2(referenceArea)
-        .riserHeightM(Math.max(riserHeight, 1.0e-12))
+        .upstreamGasVolumeM3(upstreamGasVolume).riserAreaM2(referenceArea).riserHeightM(Math.max(riserHeight, 1.0e-12))
         .separatorPressurePa(sections[sections.length - 1].getPressure())
-        .staticChokePressureDropPa(staticChokePressureDropPa)
-        .liquidDensityKgPerM3(liquidDensity).riserLiquidHoldup(riserLiquidHoldup)
-        .gasCapVoidFraction(gasCapVoidFraction).validFlowlineRiserTopology(topologyValid)
-        .flowlineStratified(flowlineStratified).threePhase(threePhase).build();
-    SevereSluggingSystemDiagnostic.Result result =
-        SevereSluggingSystemDiagnostic.evaluate(input);
+        .staticChokePressureDropPa(staticChokePressureDropPa).liquidDensityKgPerM3(liquidDensity)
+        .riserLiquidHoldup(riserLiquidHoldup).gasCapVoidFraction(gasCapVoidFraction)
+        .validFlowlineRiserTopology(topologyValid).flowlineStratified(flowlineStratified).threePhase(threePhase)
+        .build();
+    SevereSluggingSystemDiagnostic.Result result = SevereSluggingSystemDiagnostic.evaluate(input);
 
     for (TwoFluidSection section : sections) {
       section.setSevereSlugPotential(false);

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.pipeline.twophasepipe.FlowRegimeDetector;
 import neqsim.process.equipment.pipeline.twophasepipe.LagrangianSlugTracker;
 import neqsim.process.equipment.pipeline.twophasepipe.LiquidAccumulationTracker;
+import neqsim.process.equipment.pipeline.twophasepipe.SevereSluggingSystemDiagnostic;
 import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
 import neqsim.process.equipment.pipeline.twophasepipe.SlugTracker;
 import neqsim.process.equipment.pipeline.twophasepipe.ThermodynamicCoupling;
@@ -2839,22 +2840,22 @@ public class TwoFluidPipe extends Pipeline {
       }
     }
 
-    // ========== RISER BASE ACCUMULATION (Severe Slugging Model) ==========
+    // ========== RISER-BASE LIQUID FALLBACK CLOSURE ==========
     else if (isRiserBase && enableSevereSlugModel) {
-      // Riser base is particularly prone to severe slugging
-      // Use Pots severe slugging criterion: PI = (P_sep * L_riser) / (rho_L * g * H_riser)
+      // This local carryover closure adjusts holdup only. System severe-slugging stability is
+      // evaluated separately by evaluateSevereSluggingSystem().
 
-      // Simplified criterion: gas velocity must exceed critical to prevent buildup
+      // Gas velocity must exceed the local carryover velocity to prevent buildup
       double sinTheta = Math.sin(inclination);
       double vCritRiser = 1.5 * Math.sqrt(g * diameter * dRho * sinTheta / Math.max(rhoG, 1.0));
 
       if (vsG < vCritRiser) {
-        // Severe slugging conditions - high accumulation
+        // Local liquid-fallback conditions - high accumulation
         // Enhanced: use stronger factor for very low velocities
         double velocityRatio = vsG / vCritRiser;
         double severityFactor = 1.0 + 4.0 * Math.pow(1.0 - velocityRatio, 1.5);
         enhancedHoldup = Math.min(0.90, baseHoldup * severityFactor);
-        sec.setSevereSlugPotential(true);
+        sec.setInclinedSectionLiquidFallbackPotential(true);
       }
     }
 
@@ -4848,24 +4849,33 @@ public class TwoFluidPipe extends Pipeline {
   }
 
   /**
-   * Get the severe-slugging stability number at each section.
+   * Get the local inclined-section gas-carryover number at each section.
    *
-   * <p>
-   * Values below 1 indicate elevated severe-slugging risk. Sections where the diagnostic is not applicable retain
-   * {@link Double#POSITIVE_INFINITY}.
-   * </p>
+   * <p>Values below 1 indicate possible liquid fallback. The number is a local closure screen;
+   * it does not diagnose severe slugging in a flowline-riser system.</p>
    *
-   * @return severe-slugging stability-number profile
+   * @return local gas-carryover-number profile
    */
-  public double[] getSevereSluggingNumberProfile() {
+  public double[] getInclinedSectionGasCarryoverNumberProfile() {
     if (sections == null) {
       return new double[0];
     }
     double[] profile = new double[numberOfSections];
     for (int i = 0; i < numberOfSections; i++) {
-      profile[i] = sections[i].getSevereSluggingNumber();
+      profile[i] = sections[i].getInclinedSectionGasCarryoverNumber();
     }
     return profile;
+  }
+
+  /**
+   * Legacy alias for {@link #getInclinedSectionGasCarryoverNumberProfile()}.
+   *
+   * @return local gas-carryover-number profile
+   * @deprecated The returned quantity is not a severe-slugging system stability number.
+   */
+  @Deprecated
+  public double[] getSevereSluggingNumberProfile() {
+    return getInclinedSectionGasCarryoverNumberProfile();
   }
 
   /**
@@ -4882,6 +4892,108 @@ public class TwoFluidPipe extends Pipeline {
       profile[i] = sections[i].isSevereSlugPotential();
     }
     return profile;
+  }
+
+  /**
+   * Evaluate severe-slugging stability for a flowline feeding a constant-area riser.
+   *
+   * <p>The solved section states provide upstream gas volume, average riser holdup and
+   * density, riser height, and absolute outlet pressure. The default gas-cap void fraction
+   * is 0.89, following the air-water basis used in Taitel's published comparison.</p>
+   *
+   * @param riserBaseSection index of the first continuously rising section
+   * @return explicit system-level stability result
+   */
+  public SevereSluggingSystemDiagnostic.Result evaluateSevereSluggingSystem(
+      int riserBaseSection) {
+    return evaluateSevereSluggingSystem(riserBaseSection, 0.89, 0.0);
+  }
+
+  /**
+   * Evaluate severe-slugging stability with explicit gas-cap and static-choke inputs.
+   *
+   * <p>The static choke pressure drop is added to absolute outlet pressure. It represents
+   * one operating point only; dynamic choke response is outside this quasi-steady diagnostic.
+   * Three-phase systems and non-stratified feeders return a not-applicable status.</p>
+   *
+   * @param riserBaseSection index of the first continuously rising section
+   * @param gasCapVoidFraction void fraction alpha-prime in the penetrating gas cap
+   * @param staticChokePressureDropPa fixed choke pressure drop in Pa
+   * @return explicit system-level stability result
+   */
+  public SevereSluggingSystemDiagnostic.Result evaluateSevereSluggingSystem(
+      int riserBaseSection, double gasCapVoidFraction, double staticChokePressureDropPa) {
+    if (sections == null || sections.length != numberOfSections) {
+      throw new IllegalStateException("Run the pipe before evaluating flowline-riser stability");
+    }
+    if (riserBaseSection <= 0 || riserBaseSection >= sections.length) {
+      throw new IllegalArgumentException(
+          "riserBaseSection must be between 1 and numberOfSections - 1");
+    }
+
+    double referenceArea = sections[riserBaseSection].getArea();
+    double upstreamGasVolume = 0.0;
+    double riserVolume = 0.0;
+    double riserLiquidVolume = 0.0;
+    double riserLiquidMass = 0.0;
+    double riserHeight = 0.0;
+    boolean topologyValid = true;
+    boolean flowlineStratified = true;
+    boolean flowlineContainsGasAndLiquid = false;
+    boolean threePhase = false;
+
+    for (int i = 0; i < sections.length; i++) {
+      TwoFluidSection section = sections[i];
+      double cellVolume = section.getArea() * section.getLength();
+      if (Math.abs(section.getArea() - referenceArea) > 1.0e-6 * referenceArea) {
+        topologyValid = false;
+      }
+      if (section.getOilHoldup() > 1.0e-10 && section.getWaterHoldup() > 1.0e-10) {
+        threePhase = true;
+      }
+
+      if (i < riserBaseSection) {
+        upstreamGasVolume += section.getGasHoldup() * cellVolume;
+        topologyValid &= section.getInclination() <= Math.toRadians(1.0);
+        if (section.getGasHoldup() > 1.0e-10 && section.getLiquidHoldup() > 1.0e-10) {
+          flowlineContainsGasAndLiquid = true;
+          FlowRegime regime = section.getFlowRegime();
+          flowlineStratified &= regime == FlowRegime.STRATIFIED_SMOOTH
+              || regime == FlowRegime.STRATIFIED_WAVY;
+        }
+      } else {
+        topologyValid &= section.getInclination() > Math.toRadians(1.0);
+        riserHeight += Math.sin(section.getInclination()) * section.getLength();
+        riserVolume += cellVolume;
+        double liquidVolume = section.getLiquidHoldup() * cellVolume;
+        riserLiquidVolume += liquidVolume;
+        riserLiquidMass += liquidVolume * section.getLiquidDensity();
+      }
+    }
+
+    flowlineStratified &= flowlineContainsGasAndLiquid;
+    double riserLiquidHoldup = riserVolume > 0.0 ? riserLiquidVolume / riserVolume : 0.0;
+    double liquidDensity = riserLiquidVolume > 0.0 ? riserLiquidMass / riserLiquidVolume : 1.0;
+    topologyValid &= riserHeight > 0.0;
+
+    SevereSluggingSystemDiagnostic.Input input = SevereSluggingSystemDiagnostic.Input.builder()
+        .upstreamGasVolumeM3(upstreamGasVolume).riserAreaM2(referenceArea)
+        .riserHeightM(Math.max(riserHeight, 1.0e-12))
+        .separatorPressurePa(sections[sections.length - 1].getPressure())
+        .staticChokePressureDropPa(staticChokePressureDropPa)
+        .liquidDensityKgPerM3(liquidDensity).riserLiquidHoldup(riserLiquidHoldup)
+        .gasCapVoidFraction(gasCapVoidFraction).validFlowlineRiserTopology(topologyValid)
+        .flowlineStratified(flowlineStratified).threePhase(threePhase).build();
+    SevereSluggingSystemDiagnostic.Result result =
+        SevereSluggingSystemDiagnostic.evaluate(input);
+
+    for (TwoFluidSection section : sections) {
+      section.setSevereSlugPotential(false);
+    }
+    if (result.isSevereSluggingPossible()) {
+      sections[riserBaseSection].setSevereSlugPotential(true);
+    }
+    return result;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
@@ -294,6 +294,89 @@ public final class SevereSluggingSystemDiagnostic {
     }
   }
 
+  /**
+   * Build a system descriptor from solved pipe sections.
+   *
+   * <p>
+   * Sections before {@code riserBaseSection} form the level or downward-inclined feeder. Their
+   * gas-filled cell volumes are summed using each section's own area, so a flowline-to-riser
+   * diameter change is permitted. Sections from {@code riserBaseSection} onward must form a
+   * continuously rising, constant-area riser. The last section pressure is interpreted as the
+   * absolute pressure at the riser outlet.
+   * </p>
+   *
+   * @param sections solved sections in flow direction
+   * @param riserBaseSection index of the first continuously rising section
+   * @param gasCapVoidFraction void fraction alpha-prime in the penetrating gas cap
+   * @param staticChokePressureDropPa fixed pressure drop between the riser outlet and separator,
+   *        in Pa
+   * @return immutable system input with geometry, inventory, phase, and flow-regime evidence
+   */
+  public static Input fromSections(TwoFluidSection[] sections, int riserBaseSection,
+      double gasCapVoidFraction, double staticChokePressureDropPa) {
+    if (sections == null || sections.length < 2) {
+      throw new IllegalArgumentException("sections must contain a flowline and riser");
+    }
+    if (riserBaseSection <= 0 || riserBaseSection >= sections.length) {
+      throw new IllegalArgumentException("riserBaseSection must be between 1 and sections.length - 1");
+    }
+
+    double referenceArea = sections[riserBaseSection].getArea();
+    double upstreamGasVolume = 0.0;
+    double riserVolume = 0.0;
+    double riserLiquidVolume = 0.0;
+    double riserLiquidMass = 0.0;
+    double riserHeight = 0.0;
+    boolean topologyValid = true;
+    boolean flowlineStratified = true;
+    boolean flowlineContainsGasAndLiquid = false;
+    boolean threePhase = false;
+
+    for (int i = 0; i < sections.length; i++) {
+      TwoFluidSection section = sections[i];
+      if (section == null) {
+        throw new IllegalArgumentException("sections must not contain null entries");
+      }
+      double cellVolume = section.getArea() * section.getLength();
+      if (section.getOilHoldup() > 1.0e-10 && section.getWaterHoldup() > 1.0e-10) {
+        threePhase = true;
+      }
+
+      if (i < riserBaseSection) {
+        upstreamGasVolume += section.getGasHoldup() * cellVolume;
+        topologyValid &= section.getInclination() <= Math.toRadians(1.0);
+        if (section.getGasHoldup() > 1.0e-10 && section.getLiquidHoldup() > 1.0e-10) {
+          flowlineContainsGasAndLiquid = true;
+          PipeSection.FlowRegime regime = section.getFlowRegime();
+          flowlineStratified &= regime == PipeSection.FlowRegime.STRATIFIED_SMOOTH
+              || regime == PipeSection.FlowRegime.STRATIFIED_WAVY;
+        }
+      } else {
+        topologyValid &= Math.abs(section.getArea() - referenceArea) <= 1.0e-6 * referenceArea;
+        topologyValid &= section.getInclination() > Math.toRadians(1.0);
+        riserHeight += Math.sin(section.getInclination()) * section.getLength();
+        riserVolume += cellVolume;
+        double liquidVolume = section.getLiquidHoldup() * cellVolume;
+        riserLiquidVolume += liquidVolume;
+        riserLiquidMass += liquidVolume * section.getLiquidDensity();
+      }
+    }
+
+    flowlineStratified &= flowlineContainsGasAndLiquid;
+    double riserLiquidHoldup = riserVolume > 0.0 ? riserLiquidVolume / riserVolume : 0.0;
+    double liquidDensity = riserLiquidVolume > 0.0 ? riserLiquidMass / riserLiquidVolume : 1.0;
+    topologyValid &= riserHeight > 0.0;
+
+    return Input.builder().upstreamGasVolumeM3(upstreamGasVolume).riserAreaM2(referenceArea)
+        .riserHeightM(Math.max(riserHeight, 1.0e-12))
+        .separatorPressurePa(sections[sections.length - 1].getPressure())
+        .staticChokePressureDropPa(staticChokePressureDropPa)
+        .liquidDensityKgPerM3(liquidDensity).riserLiquidHoldup(riserLiquidHoldup)
+        .gasCapVoidFraction(gasCapVoidFraction).validFlowlineRiserTopology(topologyValid)
+        .flowlineStratified(flowlineStratified)
+        .flowlineContainsGasAndLiquid(flowlineContainsGasAndLiquid).threePhase(threePhase).build();
+  }
+
   /** Evaluates the input using the Taitel quasi-steady stability condition. */
   public static Result evaluate(Input input) {
     if (input == null) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
@@ -67,6 +67,7 @@ public final class SevereSluggingSystemDiagnostic {
     private final double gasCapVoidFraction;
     private final boolean validFlowlineRiserTopology;
     private final boolean flowlineStratified;
+    private final boolean flowlineContainsGasAndLiquid;
     private final boolean threePhase;
 
     private Input(Builder builder) {
@@ -80,6 +81,7 @@ public final class SevereSluggingSystemDiagnostic {
       gasCapVoidFraction = fraction(builder.gasCapVoidFraction, "gasCapVoidFraction", false);
       validFlowlineRiserTopology = builder.validFlowlineRiserTopology;
       flowlineStratified = builder.flowlineStratified;
+      flowlineContainsGasAndLiquid = builder.flowlineContainsGasAndLiquid;
       threePhase = builder.threePhase;
     }
 
@@ -131,6 +133,11 @@ public final class SevereSluggingSystemDiagnostic {
       return flowlineStratified;
     }
 
+    /** Return whether gas and liquid are both present in the feeding flowline. */
+    public boolean flowlineContainsGasAndLiquid() {
+      return flowlineContainsGasAndLiquid;
+    }
+
     public boolean isThreePhase() {
       return threePhase;
     }
@@ -147,6 +154,7 @@ public final class SevereSluggingSystemDiagnostic {
       private double gasCapVoidFraction = 0.89;
       private boolean validFlowlineRiserTopology = true;
       private boolean flowlineStratified = true;
+      private boolean flowlineContainsGasAndLiquid = true;
       private boolean threePhase;
 
       private Builder() {
@@ -205,6 +213,12 @@ public final class SevereSluggingSystemDiagnostic {
 
       public Builder flowlineStratified(boolean value) {
         flowlineStratified = value;
+        return this;
+      }
+
+      /** Set whether both phases are present in the feeding flowline. */
+      public Builder flowlineContainsGasAndLiquid(boolean value) {
+        flowlineContainsGasAndLiquid = value;
         return this;
       }
 
@@ -288,7 +302,8 @@ public final class SevereSluggingSystemDiagnostic {
     if (input.isThreePhase()) {
       return notApplicable(Status.NOT_VALIDATED_THREE_PHASE);
     }
-    if (input.getUpstreamGasVolumeM3() == 0.0 || input.getRiserLiquidHoldup() == 0.0) {
+    if (input.getUpstreamGasVolumeM3() == 0.0 || input.getRiserLiquidHoldup() == 0.0
+        || !input.flowlineContainsGasAndLiquid()) {
       return notApplicable(Status.NOT_APPLICABLE_SINGLE_PHASE);
     }
     if (!input.isFlowlineStratified()) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
@@ -1,0 +1,333 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import java.io.Serializable;
+
+/**
+ * Stability diagnostic for a stratified flowline feeding a liquid-filled riser.
+ *
+ * <p>The diagnostic implements the quasi-steady stability condition derived by Taitel for
+ * severe slugging at a flowline-riser junction:</p>
+ *
+ * <pre>
+ * P_top,critical = phi rho_L g (V_G / (A_r alpha_prime) - H)
+ * </pre>
+ *
+ * <p>Here {@code P_top} is absolute pressure at the riser outlet, {@code phi} is average
+ * liquid holdup in the riser, {@code rho_L} is average liquid density, {@code V_G} is the
+ * compressible upstream gas volume, {@code A_r} and {@code H} are riser area and vertical
+ * height, and {@code alpha_prime} is the void fraction in the gas cap penetrating the riser.
+ * The system is stable when the effective top pressure is at least the critical pressure.
+ * A non-positive critical pressure is geometrically stable in this reduced model.</p>
+ *
+ * <p>Validity is limited to a two-phase, low-rate, stratified flowline connected to a
+ * liquid-filled, constant-area rising section. The derivation assumes isothermal ideal-gas
+ * compression and neglects wall and interfacial shear during the incipient displacement.
+ * It is a stability screen, not a dynamic slug-frequency or slug-size model.</p>
+ *
+ * @see <a href="https://doi.org/10.1016/0301-9322(86)90026-1">Taitel (1986)</a>
+ */
+public final class SevereSluggingSystemDiagnostic {
+  /** Standard gravitational acceleration in m/s2. */
+  public static final double STANDARD_GRAVITY = 9.80665;
+
+  private SevereSluggingSystemDiagnostic() {}
+
+  /** Diagnostic classification. */
+  public enum Status {
+    /** The Taitel condition is applicable and predicts stable operation. */
+    STABLE,
+    /** The Taitel condition is applicable and predicts possible severe slugging. */
+    UNSTABLE,
+    /** The supplied geometry is not a downflow/level flowline followed by a rising section. */
+    NOT_APPLICABLE_INVALID_TOPOLOGY,
+    /** The feeding flowline is not stratified. */
+    NOT_APPLICABLE_NON_STRATIFIED_FLOWLINE,
+    /** Both gas and liquid inventories required by the derivation are not present. */
+    NOT_APPLICABLE_SINGLE_PHASE,
+    /** Oil-water-gas application is intentionally rejected because it is not validated. */
+    NOT_VALIDATED_THREE_PHASE
+  }
+
+  /** Immutable input descriptor for one flowline-riser system. */
+  public static final class Input implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final double upstreamGasVolumeM3;
+    private final double riserAreaM2;
+    private final double riserHeightM;
+    private final double separatorPressurePa;
+    private final double staticChokePressureDropPa;
+    private final double liquidDensityKgPerM3;
+    private final double riserLiquidHoldup;
+    private final double gasCapVoidFraction;
+    private final boolean validFlowlineRiserTopology;
+    private final boolean flowlineStratified;
+    private final boolean threePhase;
+
+    private Input(Builder builder) {
+      upstreamGasVolumeM3 = nonNegative(builder.upstreamGasVolumeM3, "upstreamGasVolumeM3");
+      riserAreaM2 = positive(builder.riserAreaM2, "riserAreaM2");
+      riserHeightM = positive(builder.riserHeightM, "riserHeightM");
+      separatorPressurePa = positive(builder.separatorPressurePa, "separatorPressurePa");
+      staticChokePressureDropPa =
+          nonNegative(builder.staticChokePressureDropPa, "staticChokePressureDropPa");
+      liquidDensityKgPerM3 = positive(builder.liquidDensityKgPerM3, "liquidDensityKgPerM3");
+      riserLiquidHoldup = fraction(builder.riserLiquidHoldup, "riserLiquidHoldup", true);
+      gasCapVoidFraction = fraction(builder.gasCapVoidFraction, "gasCapVoidFraction", false);
+      validFlowlineRiserTopology = builder.validFlowlineRiserTopology;
+      flowlineStratified = builder.flowlineStratified;
+      threePhase = builder.threePhase;
+    }
+
+    /** Creates a builder. Numeric quantities without documented defaults must be supplied. */
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public double getUpstreamGasVolumeM3() {
+      return upstreamGasVolumeM3;
+    }
+
+    public double getRiserAreaM2() {
+      return riserAreaM2;
+    }
+
+    public double getRiserHeightM() {
+      return riserHeightM;
+    }
+
+    /** Returns absolute separator pressure in Pa. */
+    public double getSeparatorPressurePa() {
+      return separatorPressurePa;
+    }
+
+    /** Returns the optional static choke pressure drop in Pa. */
+    public double getStaticChokePressureDropPa() {
+      return staticChokePressureDropPa;
+    }
+
+    public double getLiquidDensityKgPerM3() {
+      return liquidDensityKgPerM3;
+    }
+
+    public double getRiserLiquidHoldup() {
+      return riserLiquidHoldup;
+    }
+
+    /** Returns gas-cap void fraction alpha-prime. */
+    public double getGasCapVoidFraction() {
+      return gasCapVoidFraction;
+    }
+
+    public boolean hasValidFlowlineRiserTopology() {
+      return validFlowlineRiserTopology;
+    }
+
+    public boolean isFlowlineStratified() {
+      return flowlineStratified;
+    }
+
+    public boolean isThreePhase() {
+      return threePhase;
+    }
+
+    /** Builder for {@link Input}. */
+    public static final class Builder {
+      private double upstreamGasVolumeM3 = Double.NaN;
+      private double riserAreaM2 = Double.NaN;
+      private double riserHeightM = Double.NaN;
+      private double separatorPressurePa = Double.NaN;
+      private double staticChokePressureDropPa;
+      private double liquidDensityKgPerM3 = Double.NaN;
+      private double riserLiquidHoldup = Double.NaN;
+      private double gasCapVoidFraction = 0.89;
+      private boolean validFlowlineRiserTopology = true;
+      private boolean flowlineStratified = true;
+      private boolean threePhase;
+
+      private Builder() {}
+
+      public Builder upstreamGasVolumeM3(double value) {
+        upstreamGasVolumeM3 = value;
+        return this;
+      }
+
+      public Builder riserAreaM2(double value) {
+        riserAreaM2 = value;
+        return this;
+      }
+
+      public Builder riserHeightM(double value) {
+        riserHeightM = value;
+        return this;
+      }
+
+      /** Sets absolute pressure at the riser outlet in Pa. */
+      public Builder separatorPressurePa(double value) {
+        separatorPressurePa = value;
+        return this;
+      }
+
+      /** Sets a fixed choke pressure drop in Pa; dynamic choke response is outside the model. */
+      public Builder staticChokePressureDropPa(double value) {
+        staticChokePressureDropPa = value;
+        return this;
+      }
+
+      public Builder liquidDensityKgPerM3(double value) {
+        liquidDensityKgPerM3 = value;
+        return this;
+      }
+
+      public Builder riserLiquidHoldup(double value) {
+        riserLiquidHoldup = value;
+        return this;
+      }
+
+      /**
+       * Sets alpha-prime. The default 0.89 is the air-water value used in Taitel's comparison;
+       * applications outside that basis should provide a justified value.
+       */
+      public Builder gasCapVoidFraction(double value) {
+        gasCapVoidFraction = value;
+        return this;
+      }
+
+      public Builder validFlowlineRiserTopology(boolean value) {
+        validFlowlineRiserTopology = value;
+        return this;
+      }
+
+      public Builder flowlineStratified(boolean value) {
+        flowlineStratified = value;
+        return this;
+      }
+
+      public Builder threePhase(boolean value) {
+        threePhase = value;
+        return this;
+      }
+
+      public Input build() {
+        return new Input(this);
+      }
+    }
+  }
+
+  /** Immutable diagnostic result. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final Status status;
+    private final double criticalTopPressurePa;
+    private final double effectiveTopPressurePa;
+    private final double pressureMarginPa;
+    private final double stabilityRatio;
+    private final double gasExpansionHeadM;
+
+    private Result(Status status, double criticalTopPressurePa, double effectiveTopPressurePa,
+        double pressureMarginPa, double stabilityRatio, double gasExpansionHeadM) {
+      this.status = status;
+      this.criticalTopPressurePa = criticalTopPressurePa;
+      this.effectiveTopPressurePa = effectiveTopPressurePa;
+      this.pressureMarginPa = pressureMarginPa;
+      this.stabilityRatio = stabilityRatio;
+      this.gasExpansionHeadM = gasExpansionHeadM;
+    }
+
+    public Status getStatus() {
+      return status;
+    }
+
+    public boolean isApplicable() {
+      return status == Status.STABLE || status == Status.UNSTABLE;
+    }
+
+    public boolean isStable() {
+      return status == Status.STABLE;
+    }
+
+    public boolean isSevereSluggingPossible() {
+      return status == Status.UNSTABLE;
+    }
+
+    public double getCriticalTopPressurePa() {
+      return criticalTopPressurePa;
+    }
+
+    public double getEffectiveTopPressurePa() {
+      return effectiveTopPressurePa;
+    }
+
+    public double getPressureMarginPa() {
+      return pressureMarginPa;
+    }
+
+    public double getStabilityRatio() {
+      return stabilityRatio;
+    }
+
+    public double getGasExpansionHeadM() {
+      return gasExpansionHeadM;
+    }
+  }
+
+  /** Evaluates the input using the Taitel quasi-steady stability condition. */
+  public static Result evaluate(Input input) {
+    if (input == null) {
+      throw new IllegalArgumentException("input must not be null");
+    }
+    if (!input.hasValidFlowlineRiserTopology()) {
+      return notApplicable(Status.NOT_APPLICABLE_INVALID_TOPOLOGY);
+    }
+    if (input.isThreePhase()) {
+      return notApplicable(Status.NOT_VALIDATED_THREE_PHASE);
+    }
+    if (input.getUpstreamGasVolumeM3() == 0.0 || input.getRiserLiquidHoldup() == 0.0) {
+      return notApplicable(Status.NOT_APPLICABLE_SINGLE_PHASE);
+    }
+    if (!input.isFlowlineStratified()) {
+      return notApplicable(Status.NOT_APPLICABLE_NON_STRATIFIED_FLOWLINE);
+    }
+
+    double effectiveTopPressurePa =
+        input.getSeparatorPressurePa() + input.getStaticChokePressureDropPa();
+    double gasExpansionHeadM = input.getUpstreamGasVolumeM3()
+        / (input.getRiserAreaM2() * input.getGasCapVoidFraction());
+    double destabilizingHeadM = gasExpansionHeadM - input.getRiserHeightM();
+    double criticalTopPressurePa = Math.max(0.0, input.getRiserLiquidHoldup()
+        * input.getLiquidDensityKgPerM3() * STANDARD_GRAVITY * destabilizingHeadM);
+    double pressureMarginPa = effectiveTopPressurePa - criticalTopPressurePa;
+    double stabilityRatio = criticalTopPressurePa == 0.0 ? Double.POSITIVE_INFINITY
+        : effectiveTopPressurePa / criticalTopPressurePa;
+    Status status = pressureMarginPa >= 0.0 ? Status.STABLE : Status.UNSTABLE;
+    return new Result(status, criticalTopPressurePa, effectiveTopPressurePa, pressureMarginPa,
+        stabilityRatio, gasExpansionHeadM);
+  }
+
+  private static Result notApplicable(Status status) {
+    return new Result(status, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+  }
+
+  private static double positive(double value, String name) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and > 0");
+    }
+    return value;
+  }
+
+  private static double nonNegative(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and >= 0");
+    }
+    return value;
+  }
+
+  private static double fraction(double value, String name, boolean allowZero) {
+    if (!Double.isFinite(value) || value > 1.0 || (allowZero ? value < 0.0 : value <= 0.0)) {
+      throw new IllegalArgumentException(
+          name + (allowZero ? " must be in [0, 1]" : " must be in (0, 1]"));
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
@@ -85,7 +85,10 @@ public final class SevereSluggingSystemDiagnostic {
       threePhase = builder.threePhase;
     }
 
-    /** Creates a builder. Numeric quantities without documented defaults must be supplied. */
+    /**
+     * Creates a builder. Numeric quantities without documented defaults must be supplied;
+     * applicability flags default to false and must be confirmed explicitly.
+     */
     public static Builder builder() {
       return new Builder();
     }
@@ -152,9 +155,9 @@ public final class SevereSluggingSystemDiagnostic {
       private double liquidDensityKgPerM3 = Double.NaN;
       private double riserLiquidHoldup = Double.NaN;
       private double gasCapVoidFraction = 0.89;
-      private boolean validFlowlineRiserTopology = true;
-      private boolean flowlineStratified = true;
-      private boolean flowlineContainsGasAndLiquid = true;
+      private boolean validFlowlineRiserTopology;
+      private boolean flowlineStratified;
+      private boolean flowlineContainsGasAndLiquid;
       private boolean threePhase;
 
       private Builder() {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
@@ -298,22 +298,20 @@ public final class SevereSluggingSystemDiagnostic {
    * Build a system descriptor from solved pipe sections.
    *
    * <p>
-   * Sections before {@code riserBaseSection} form the level or downward-inclined feeder. Their
-   * gas-filled cell volumes are summed using each section's own area, so a flowline-to-riser
-   * diameter change is permitted. Sections from {@code riserBaseSection} onward must form a
-   * continuously rising, constant-area riser. The last section pressure is interpreted as the
-   * absolute pressure at the riser outlet.
+   * Sections before {@code riserBaseSection} form the level or downward-inclined feeder. Their gas-filled cell volumes
+   * are summed using each section's own area, so a flowline-to-riser diameter change is permitted. Sections from
+   * {@code riserBaseSection} onward must form a continuously rising, constant-area riser. The last section pressure is
+   * interpreted as the absolute pressure at the riser outlet.
    * </p>
    *
    * @param sections solved sections in flow direction
    * @param riserBaseSection index of the first continuously rising section
    * @param gasCapVoidFraction void fraction alpha-prime in the penetrating gas cap
-   * @param staticChokePressureDropPa fixed pressure drop between the riser outlet and separator,
-   *        in Pa
+   * @param staticChokePressureDropPa fixed pressure drop between the riser outlet and separator, in Pa
    * @return immutable system input with geometry, inventory, phase, and flow-regime evidence
    */
-  public static Input fromSections(TwoFluidSection[] sections, int riserBaseSection,
-      double gasCapVoidFraction, double staticChokePressureDropPa) {
+  public static Input fromSections(TwoFluidSection[] sections, int riserBaseSection, double gasCapVoidFraction,
+      double staticChokePressureDropPa) {
     if (sections == null || sections.length < 2) {
       throw new IllegalArgumentException("sections must contain a flowline and riser");
     }
@@ -368,12 +366,10 @@ public final class SevereSluggingSystemDiagnostic {
     topologyValid &= riserHeight > 0.0;
 
     return Input.builder().upstreamGasVolumeM3(upstreamGasVolume).riserAreaM2(referenceArea)
-        .riserHeightM(Math.max(riserHeight, 1.0e-12))
-        .separatorPressurePa(sections[sections.length - 1].getPressure())
-        .staticChokePressureDropPa(staticChokePressureDropPa)
-        .liquidDensityKgPerM3(liquidDensity).riserLiquidHoldup(riserLiquidHoldup)
-        .gasCapVoidFraction(gasCapVoidFraction).validFlowlineRiserTopology(topologyValid)
-        .flowlineStratified(flowlineStratified)
+        .riserHeightM(Math.max(riserHeight, 1.0e-12)).separatorPressurePa(sections[sections.length - 1].getPressure())
+        .staticChokePressureDropPa(staticChokePressureDropPa).liquidDensityKgPerM3(liquidDensity)
+        .riserLiquidHoldup(riserLiquidHoldup).gasCapVoidFraction(gasCapVoidFraction)
+        .validFlowlineRiserTopology(topologyValid).flowlineStratified(flowlineStratified)
         .flowlineContainsGasAndLiquid(flowlineContainsGasAndLiquid).threePhase(threePhase).build();
   }
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
@@ -86,8 +86,8 @@ public final class SevereSluggingSystemDiagnostic {
     }
 
     /**
-     * Creates a builder. Numeric quantities without documented defaults must be supplied;
-     * applicability flags default to false and must be confirmed explicitly.
+     * Creates a builder. Numeric quantities without documented defaults must be supplied; applicability flags default
+     * to false and must be confirmed explicitly.
      */
     public static Builder builder() {
       return new Builder();

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnostic.java
@@ -5,24 +5,28 @@ import java.io.Serializable;
 /**
  * Stability diagnostic for a stratified flowline feeding a liquid-filled riser.
  *
- * <p>The diagnostic implements the quasi-steady stability condition derived by Taitel for
- * severe slugging at a flowline-riser junction:</p>
+ * <p>
+ * The diagnostic implements the quasi-steady stability condition derived by Taitel for severe slugging at a
+ * flowline-riser junction:
+ * </p>
  *
  * <pre>
  * P_top,critical = phi rho_L g (V_G / (A_r alpha_prime) - H)
  * </pre>
  *
- * <p>Here {@code P_top} is absolute pressure at the riser outlet, {@code phi} is average
- * liquid holdup in the riser, {@code rho_L} is average liquid density, {@code V_G} is the
- * compressible upstream gas volume, {@code A_r} and {@code H} are riser area and vertical
- * height, and {@code alpha_prime} is the void fraction in the gas cap penetrating the riser.
- * The system is stable when the effective top pressure is at least the critical pressure.
- * A non-positive critical pressure is geometrically stable in this reduced model.</p>
+ * <p>
+ * Here {@code P_top} is absolute pressure at the riser outlet, {@code phi} is average liquid holdup in the riser,
+ * {@code rho_L} is average liquid density, {@code V_G} is the compressible upstream gas volume, {@code A_r} and
+ * {@code H} are riser area and vertical height, and {@code alpha_prime} is the void fraction in the gas cap penetrating
+ * the riser. The system is stable when the effective top pressure is at least the critical pressure. A non-positive
+ * critical pressure is geometrically stable in this reduced model.
+ * </p>
  *
- * <p>Validity is limited to a two-phase, low-rate, stratified flowline connected to a
- * liquid-filled, constant-area rising section. The derivation assumes isothermal ideal-gas
- * compression and neglects wall and interfacial shear during the incipient displacement.
- * It is a stability screen, not a dynamic slug-frequency or slug-size model.</p>
+ * <p>
+ * Validity is limited to a two-phase, low-rate, stratified flowline connected to a liquid-filled, constant-area rising
+ * section. The derivation assumes isothermal ideal-gas compression and neglects wall and interfacial shear during the
+ * incipient displacement. It is a stability screen, not a dynamic slug-frequency or slug-size model.
+ * </p>
  *
  * @see <a href="https://doi.org/10.1016/0301-9322(86)90026-1">Taitel (1986)</a>
  */
@@ -30,7 +34,8 @@ public final class SevereSluggingSystemDiagnostic {
   /** Standard gravitational acceleration in m/s2. */
   public static final double STANDARD_GRAVITY = 9.80665;
 
-  private SevereSluggingSystemDiagnostic() {}
+  private SevereSluggingSystemDiagnostic() {
+  }
 
   /** Diagnostic classification. */
   public enum Status {
@@ -69,8 +74,7 @@ public final class SevereSluggingSystemDiagnostic {
       riserAreaM2 = positive(builder.riserAreaM2, "riserAreaM2");
       riserHeightM = positive(builder.riserHeightM, "riserHeightM");
       separatorPressurePa = positive(builder.separatorPressurePa, "separatorPressurePa");
-      staticChokePressureDropPa =
-          nonNegative(builder.staticChokePressureDropPa, "staticChokePressureDropPa");
+      staticChokePressureDropPa = nonNegative(builder.staticChokePressureDropPa, "staticChokePressureDropPa");
       liquidDensityKgPerM3 = positive(builder.liquidDensityKgPerM3, "liquidDensityKgPerM3");
       riserLiquidHoldup = fraction(builder.riserLiquidHoldup, "riserLiquidHoldup", true);
       gasCapVoidFraction = fraction(builder.gasCapVoidFraction, "gasCapVoidFraction", false);
@@ -145,7 +149,8 @@ public final class SevereSluggingSystemDiagnostic {
       private boolean flowlineStratified = true;
       private boolean threePhase;
 
-      private Builder() {}
+      private Builder() {
+      }
 
       public Builder upstreamGasVolumeM3(double value) {
         upstreamGasVolumeM3 = value;
@@ -185,8 +190,8 @@ public final class SevereSluggingSystemDiagnostic {
       }
 
       /**
-       * Sets alpha-prime. The default 0.89 is the air-water value used in Taitel's comparison;
-       * applications outside that basis should provide a justified value.
+       * Sets alpha-prime. The default 0.89 is the air-water value used in Taitel's comparison; applications outside
+       * that basis should provide a justified value.
        */
       public Builder gasCapVoidFraction(double value) {
         gasCapVoidFraction = value;
@@ -225,8 +230,8 @@ public final class SevereSluggingSystemDiagnostic {
     private final double stabilityRatio;
     private final double gasExpansionHeadM;
 
-    private Result(Status status, double criticalTopPressurePa, double effectiveTopPressurePa,
-        double pressureMarginPa, double stabilityRatio, double gasExpansionHeadM) {
+    private Result(Status status, double criticalTopPressurePa, double effectiveTopPressurePa, double pressureMarginPa,
+        double stabilityRatio, double gasExpansionHeadM) {
       this.status = status;
       this.criticalTopPressurePa = criticalTopPressurePa;
       this.effectiveTopPressurePa = effectiveTopPressurePa;
@@ -290,19 +295,18 @@ public final class SevereSluggingSystemDiagnostic {
       return notApplicable(Status.NOT_APPLICABLE_NON_STRATIFIED_FLOWLINE);
     }
 
-    double effectiveTopPressurePa =
-        input.getSeparatorPressurePa() + input.getStaticChokePressureDropPa();
+    double effectiveTopPressurePa = input.getSeparatorPressurePa() + input.getStaticChokePressureDropPa();
     double gasExpansionHeadM = input.getUpstreamGasVolumeM3()
         / (input.getRiserAreaM2() * input.getGasCapVoidFraction());
     double destabilizingHeadM = gasExpansionHeadM - input.getRiserHeightM();
-    double criticalTopPressurePa = Math.max(0.0, input.getRiserLiquidHoldup()
-        * input.getLiquidDensityKgPerM3() * STANDARD_GRAVITY * destabilizingHeadM);
+    double criticalTopPressurePa = Math.max(0.0,
+        input.getRiserLiquidHoldup() * input.getLiquidDensityKgPerM3() * STANDARD_GRAVITY * destabilizingHeadM);
     double pressureMarginPa = effectiveTopPressurePa - criticalTopPressurePa;
     double stabilityRatio = criticalTopPressurePa == 0.0 ? Double.POSITIVE_INFINITY
         : effectiveTopPressurePa / criticalTopPressurePa;
     Status status = pressureMarginPa >= 0.0 ? Status.STABLE : Status.UNSTABLE;
-    return new Result(status, criticalTopPressurePa, effectiveTopPressurePa, pressureMarginPa,
-        stabilityRatio, gasExpansionHeadM);
+    return new Result(status, criticalTopPressurePa, effectiveTopPressurePa, pressureMarginPa, stabilityRatio,
+        gasExpansionHeadM);
   }
 
   private static Result notApplicable(Status status) {
@@ -325,8 +329,7 @@ public final class SevereSluggingSystemDiagnostic {
 
   private static double fraction(double value, String name, boolean allowZero) {
     if (!Double.isFinite(value) || value > 1.0 || (allowZero ? value < 0.0 : value <= 0.0)) {
-      throw new IllegalArgumentException(
-          name + (allowZero ? " must be in [0, 1]" : " must be in (0, 1]"));
+      throw new IllegalArgumentException(name + (allowZero ? " must be in [0, 1]" : " must be in (0, 1]"));
     }
     return value;
   }

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -424,13 +424,19 @@ public class TwoFluidConservationEquations implements Serializable {
       sec.setEntrainmentFraction(entrainment.entrainmentFraction);
       sec.setEntrainedDropletDiameter(entrainment.dropletDiameter);
 
-      double severeSluggingNumber = calcSevereSluggingNumber(sec);
-      sec.setSevereSluggingNumber(severeSluggingNumber);
-      sec.setSevereSlugPotential(severeSluggingNumber < 1.0);
+      double gasCarryoverNumber = calcInclinedSectionGasCarryoverNumber(sec);
+      sec.setInclinedSectionGasCarryoverNumber(gasCarryoverNumber);
+      sec.setInclinedSectionLiquidFallbackPotential(gasCarryoverNumber < 1.0);
     }
   }
 
-  private double calcSevereSluggingNumber(TwoFluidSection sec) {
+  /**
+   * Calculate a local inclined-section gas-carryover screen.
+   *
+   * <p>The result contains no upstream gas volume, riser height, top pressure, or choke
+   * response and therefore must not be interpreted as a severe-slugging system criterion.</p>
+   */
+  private double calcInclinedSectionGasCarryoverNumber(TwoFluidSection sec) {
     if (sec.getInclination() <= Math.toRadians(5.0)) {
       return Double.POSITIVE_INFINITY;
     }

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -437,6 +437,9 @@ public class TwoFluidConservationEquations implements Serializable {
    * The result contains no upstream gas volume, riser height, top pressure, or choke response and therefore must not be
    * interpreted as a severe-slugging system criterion.
    * </p>
+   *
+   * @param sec local solved pipe section
+   * @return dimensionless gas-carryover number, or positive infinity when not applicable
    */
   private double calcInclinedSectionGasCarryoverNumber(TwoFluidSection sec) {
     if (sec.getInclination() <= Math.toRadians(5.0)) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -433,8 +433,10 @@ public class TwoFluidConservationEquations implements Serializable {
   /**
    * Calculate a local inclined-section gas-carryover screen.
    *
-   * <p>The result contains no upstream gas volume, riser height, top pressure, or choke
-   * response and therefore must not be interpreted as a severe-slugging system criterion.</p>
+   * <p>
+   * The result contains no upstream gas volume, riser height, top pressure, or choke response and therefore must not be
+   * interpreted as a severe-slugging system criterion.
+   * </p>
    */
   private double calcInclinedSectionGasCarryoverNumber(TwoFluidSection sec) {
     if (sec.getInclination() <= Math.toRadians(5.0)) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSection.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSection.java
@@ -185,7 +185,9 @@ public class TwoFluidSection extends PipeSection {
   /**
    * Legacy storage for the local inclined-section gas-carryover number.
    *
-   * <p>The field name is retained for serialization compatibility.</p>
+   * <p>
+   * The field name is retained for serialization compatibility.
+   * </p>
    */
   private double severeSluggingNumber = Double.POSITIVE_INFINITY;
 
@@ -1004,8 +1006,8 @@ public class TwoFluidSection extends PipeSection {
   }
 
   /**
-   * Check whether the explicit flowline-riser system diagnostic predicts severe slugging at
-   * this section. The flag is not set by local closure relations.
+   * Check whether the explicit flowline-riser system diagnostic predicts severe slugging at this section. The flag is
+   * not set by local closure relations.
    *
    * @return true if the system-level diagnostic predicts severe slugging
    */
@@ -1145,8 +1147,9 @@ public class TwoFluidSection extends PipeSection {
   /**
    * Get the local inclined-section gas-carryover number.
    *
-   * <p>This is a local Froude/holdup screen and is not a severe-slugging system stability
-   * criterion.</p>
+   * <p>
+   * This is a local Froude/holdup screen and is not a severe-slugging system stability criterion.
+   * </p>
    *
    * @return local gas-carryover number, or positive infinity when not applicable
    */
@@ -1156,8 +1159,7 @@ public class TwoFluidSection extends PipeSection {
 
   /** Set the local inclined-section gas-carryover number. */
   public void setInclinedSectionGasCarryoverNumber(double number) {
-    severeSluggingNumber =
-        Double.isFinite(number) ? number : Double.POSITIVE_INFINITY;
+    severeSluggingNumber = Double.isFinite(number) ? number : Double.POSITIVE_INFINITY;
   }
 
   /** Return whether the local carryover screen indicates possible liquid fallback. */

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSection.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSection.java
@@ -182,8 +182,15 @@ public class TwoFluidSection extends PipeSection {
   /** Characteristic entrained droplet diameter (m). */
   private double entrainedDropletDiameter = 0.0;
 
-  /** Severe slugging stability number. Values below 1 indicate elevated risk. */
+  /**
+   * Legacy storage for the local inclined-section gas-carryover number.
+   *
+   * <p>The field name is retained for serialization compatibility.</p>
+   */
   private double severeSluggingNumber = Double.POSITIVE_INFINITY;
+
+  /** Local indication that gas velocity may be insufficient to carry liquid uphill. */
+  private boolean inclinedSectionLiquidFallbackPotential = false;
 
   /**
    * Default constructor.
@@ -997,9 +1004,10 @@ public class TwoFluidSection extends PipeSection {
   }
 
   /**
-   * Check if this section has severe slugging potential (typically riser base).
+   * Check whether the explicit flowline-riser system diagnostic predicts severe slugging at
+   * this section. The flag is not set by local closure relations.
    *
-   * @return true if severe slugging potential exists
+   * @return true if the system-level diagnostic predicts severe slugging
    */
   public boolean isSevereSlugPotential() {
     return severeSlugPotential;
@@ -1134,12 +1142,54 @@ public class TwoFluidSection extends PipeSection {
     this.entrainedDropletDiameter = Math.max(0.0, entrainedDropletDiameter);
   }
 
-  public double getSevereSluggingNumber() {
+  /**
+   * Get the local inclined-section gas-carryover number.
+   *
+   * <p>This is a local Froude/holdup screen and is not a severe-slugging system stability
+   * criterion.</p>
+   *
+   * @return local gas-carryover number, or positive infinity when not applicable
+   */
+  public double getInclinedSectionGasCarryoverNumber() {
     return severeSluggingNumber;
   }
 
+  /** Set the local inclined-section gas-carryover number. */
+  public void setInclinedSectionGasCarryoverNumber(double number) {
+    severeSluggingNumber =
+        Double.isFinite(number) ? number : Double.POSITIVE_INFINITY;
+  }
+
+  /** Return whether the local carryover screen indicates possible liquid fallback. */
+  public boolean isInclinedSectionLiquidFallbackPotential() {
+    return inclinedSectionLiquidFallbackPotential;
+  }
+
+  /** Set the local inclined-section liquid-fallback flag. */
+  public void setInclinedSectionLiquidFallbackPotential(boolean potential) {
+    inclinedSectionLiquidFallbackPotential = potential;
+  }
+
+  /**
+   * Legacy alias for {@link #getInclinedSectionGasCarryoverNumber()}.
+   *
+   * @return local inclined-section gas-carryover number
+   * @deprecated This value is not a severe-slugging system stability number.
+   */
+  @Deprecated
+  public double getSevereSluggingNumber() {
+    return getInclinedSectionGasCarryoverNumber();
+  }
+
+  /**
+   * Legacy alias for {@link #setInclinedSectionGasCarryoverNumber(double)}.
+   *
+   * @param severeSluggingNumber local inclined-section gas-carryover number
+   * @deprecated This value is not a severe-slugging system stability number.
+   */
+  @Deprecated
   public void setSevereSluggingNumber(double severeSluggingNumber) {
-    this.severeSluggingNumber = Double.isFinite(severeSluggingNumber) ? severeSluggingNumber : Double.POSITIVE_INFINITY;
+    setInclinedSectionGasCarryoverNumber(severeSluggingNumber);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReport.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReport.java
@@ -66,7 +66,7 @@ public final class TwoFluidPipeReport {
       this.waterDropoutRisk = pipe.getWaterDropoutRiskProfile();
       this.entrainmentFraction = pipe.getEntrainmentFractionProfile();
       this.entrainedDropletDiameter = pipe.getEntrainedDropletDiameterProfile();
-      this.severeSluggingNumber = pipe.getSevereSluggingNumberProfile();
+      this.severeSluggingNumber = pipe.getInclinedSectionGasCarryoverNumberProfile();
       this.severeSlugPotential = pipe.getSevereSlugPotentialProfile();
     }
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReport.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReport.java
@@ -68,8 +68,7 @@ public final class TwoFluidPipeReport {
       this.entrainmentFraction = pipe.getEntrainmentFractionProfile();
       this.entrainedDropletDiameter = pipe.getEntrainedDropletDiameterProfile();
       this.inclinedSectionGasCarryoverNumber = pipe.getInclinedSectionGasCarryoverNumberProfile();
-      this.inclinedSectionLiquidFallbackPotential = pipe
-          .getInclinedSectionLiquidFallbackPotentialProfile();
+      this.inclinedSectionLiquidFallbackPotential = pipe.getInclinedSectionLiquidFallbackPotentialProfile();
       this.severeSlugPotential = pipe.getSevereSlugPotentialProfile();
     }
 
@@ -255,8 +254,7 @@ public final class TwoFluidPipeReport {
         .append("water_holdup,gas_velocity_m_s,liquid_velocity_m_s,oil_velocity_m_s,")
         .append("water_velocity_m_s,flow_regime,oil_water_flow_regime,water_wetting,")
         .append("water_dropout_risk,entrainment_fraction,entrained_droplet_diameter_m,")
-        .append("inclined_section_gas_carryover_number,")
-        .append("inclined_section_liquid_fallback_potential,")
+        .append("inclined_section_gas_carryover_number,").append("inclined_section_liquid_fallback_potential,")
         .append("severe_slugging_number,severe_slug_potential\n");
 
     for (int i = 0; i < snapshot.positionMeters.length; i++) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReport.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReport.java
@@ -44,7 +44,8 @@ public final class TwoFluidPipeReport {
     private final boolean[] waterDropoutRisk;
     private final double[] entrainmentFraction;
     private final double[] entrainedDropletDiameter;
-    private final double[] severeSluggingNumber;
+    private final double[] inclinedSectionGasCarryoverNumber;
+    private final boolean[] inclinedSectionLiquidFallbackPotential;
     private final boolean[] severeSlugPotential;
 
     private ProfileSnapshot(TwoFluidPipe pipe) {
@@ -66,7 +67,9 @@ public final class TwoFluidPipeReport {
       this.waterDropoutRisk = pipe.getWaterDropoutRiskProfile();
       this.entrainmentFraction = pipe.getEntrainmentFractionProfile();
       this.entrainedDropletDiameter = pipe.getEntrainedDropletDiameterProfile();
-      this.severeSluggingNumber = pipe.getInclinedSectionGasCarryoverNumberProfile();
+      this.inclinedSectionGasCarryoverNumber = pipe.getInclinedSectionGasCarryoverNumberProfile();
+      this.inclinedSectionLiquidFallbackPotential = pipe
+          .getInclinedSectionLiquidFallbackPotentialProfile();
       this.severeSlugPotential = pipe.getSevereSlugPotentialProfile();
     }
 
@@ -252,6 +255,8 @@ public final class TwoFluidPipeReport {
         .append("water_holdup,gas_velocity_m_s,liquid_velocity_m_s,oil_velocity_m_s,")
         .append("water_velocity_m_s,flow_regime,oil_water_flow_regime,water_wetting,")
         .append("water_dropout_risk,entrainment_fraction,entrained_droplet_diameter_m,")
+        .append("inclined_section_gas_carryover_number,")
+        .append("inclined_section_liquid_fallback_potential,")
         .append("severe_slugging_number,severe_slug_potential\n");
 
     for (int i = 0; i < snapshot.positionMeters.length; i++) {
@@ -275,7 +280,9 @@ public final class TwoFluidPipeReport {
           .append(valueAt(snapshot.waterDropoutRisk, i)).append(',')
           .append(format(valueAt(snapshot.entrainmentFraction, i))).append(',')
           .append(format(valueAt(snapshot.entrainedDropletDiameter, i))).append(',')
-          .append(format(valueAt(snapshot.severeSluggingNumber, i))).append(',')
+          .append(format(valueAt(snapshot.inclinedSectionGasCarryoverNumber, i))).append(',')
+          .append(valueAt(snapshot.inclinedSectionLiquidFallbackPotential, i)).append(',')
+          .append(format(valueAt(snapshot.inclinedSectionGasCarryoverNumber, i))).append(',')
           .append(valueAt(snapshot.severeSlugPotential, i)).append('\n');
     }
     return csv.toString();

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
@@ -80,8 +80,7 @@ public final class TwoFluidBenchmarkHarness {
     variables.put("water_velocity_m_s", pipe.getWaterVelocityProfile());
     variables.put("entrainment_fraction", pipe.getEntrainmentFractionProfile());
     variables.put("entrained_droplet_diameter_m", pipe.getEntrainedDropletDiameterProfile());
-    variables.put("inclined_section_gas_carryover_number",
-        pipe.getInclinedSectionGasCarryoverNumberProfile());
+    variables.put("inclined_section_gas_carryover_number", pipe.getInclinedSectionGasCarryoverNumberProfile());
     variables.put("inclined_section_liquid_fallback_flag",
         toDouble(pipe.getInclinedSectionLiquidFallbackPotentialProfile()));
     // Deprecated key retained for benchmark-file compatibility.

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
@@ -80,6 +80,11 @@ public final class TwoFluidBenchmarkHarness {
     variables.put("water_velocity_m_s", pipe.getWaterVelocityProfile());
     variables.put("entrainment_fraction", pipe.getEntrainmentFractionProfile());
     variables.put("entrained_droplet_diameter_m", pipe.getEntrainedDropletDiameterProfile());
+    variables.put("inclined_section_gas_carryover_number",
+        pipe.getInclinedSectionGasCarryoverNumberProfile());
+    variables.put("inclined_section_liquid_fallback_flag",
+        toDouble(pipe.getInclinedSectionLiquidFallbackPotentialProfile()));
+    // Deprecated key retained for benchmark-file compatibility.
     variables.put("severe_slugging_number", pipe.getInclinedSectionGasCarryoverNumberProfile());
     variables.put("water_wetting_flag", toDouble(pipe.getWaterWettingProfile()));
     variables.put("water_dropout_risk_flag", toDouble(pipe.getWaterDropoutRiskProfile()));

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarness.java
@@ -80,7 +80,7 @@ public final class TwoFluidBenchmarkHarness {
     variables.put("water_velocity_m_s", pipe.getWaterVelocityProfile());
     variables.put("entrainment_fraction", pipe.getEntrainmentFractionProfile());
     variables.put("entrained_droplet_diameter_m", pipe.getEntrainedDropletDiameterProfile());
-    variables.put("severe_slugging_number", pipe.getSevereSluggingNumberProfile());
+    variables.put("severe_slugging_number", pipe.getInclinedSectionGasCarryoverNumberProfile());
     variables.put("water_wetting_flag", toDouble(pipe.getWaterWettingProfile()));
     variables.put("water_dropout_risk_flag", toDouble(pipe.getWaterDropoutRiskProfile()));
     variables.put("severe_slug_potential_flag", toDouble(pipe.getSevereSlugPotentialProfile()));

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
@@ -1,0 +1,118 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.twophasepipe.SevereSluggingSystemDiagnostic.Input;
+import neqsim.process.equipment.pipeline.twophasepipe.SevereSluggingSystemDiagnostic.Result;
+import neqsim.process.equipment.pipeline.twophasepipe.SevereSluggingSystemDiagnostic.Status;
+
+class SevereSluggingSystemDiagnosticTest {
+  private static Input.Builder baseInput() {
+    return Input.builder().upstreamGasVolumeM3(20.0).riserAreaM2(0.1)
+        .riserHeightM(100.0).separatorPressurePa(500_000.0).liquidDensityKgPerM3(800.0)
+        .riserLiquidHoldup(0.9).gasCapVoidFraction(0.8);
+  }
+
+  @Test
+  void reproducesTaitelAnalyticalCriterion() {
+    Result result = SevereSluggingSystemDiagnostic.evaluate(baseInput().build());
+
+    double expectedGasExpansionHead = 20.0 / (0.1 * 0.8);
+    double expectedCriticalPressure =
+        0.9 * 800.0 * SevereSluggingSystemDiagnostic.STANDARD_GRAVITY
+            * (expectedGasExpansionHead - 100.0);
+    assertEquals(expectedGasExpansionHead, result.getGasExpansionHeadM(), 1.0e-12);
+    assertEquals(expectedCriticalPressure, result.getCriticalTopPressurePa(), 1.0e-9);
+    assertEquals(500_000.0 - expectedCriticalPressure, result.getPressureMarginPa(), 1.0e-9);
+    assertEquals(Status.UNSTABLE, result.getStatus());
+    assertTrue(result.isSevereSluggingPossible());
+  }
+
+  @Test
+  void systemScaleAndBackpressureChangeThePrediction() {
+    Result compact = SevereSluggingSystemDiagnostic
+        .evaluate(baseInput().upstreamGasVolumeM3(10.0).separatorPressurePa(200_000.0).build());
+    Result longFlowline = SevereSluggingSystemDiagnostic
+        .evaluate(baseInput().upstreamGasVolumeM3(20.0).separatorPressurePa(200_000.0).build());
+    Result choked = SevereSluggingSystemDiagnostic.evaluate(baseInput().upstreamGasVolumeM3(20.0)
+        .separatorPressurePa(200_000.0).staticChokePressureDropPa(900_000.0).build());
+
+    assertEquals(Status.STABLE, compact.getStatus());
+    assertEquals(Status.UNSTABLE, longFlowline.getStatus());
+    assertEquals(Status.STABLE, choked.getStatus());
+    assertTrue(longFlowline.getCriticalTopPressurePa() > compact.getCriticalTopPressurePa());
+    assertEquals(1_100_000.0, choked.getEffectiveTopPressurePa(), 0.0);
+  }
+
+  @Test
+  void higherRiserAndTopPressureAreStabilisingTrends() {
+    Result shortRiser = SevereSluggingSystemDiagnostic
+        .evaluate(baseInput().riserHeightM(50.0).separatorPressurePa(800_000.0).build());
+    Result tallRiser = SevereSluggingSystemDiagnostic
+        .evaluate(baseInput().riserHeightM(180.0).separatorPressurePa(800_000.0).build());
+
+    assertEquals(Status.UNSTABLE, shortRiser.getStatus());
+    assertEquals(Status.STABLE, tallRiser.getStatus());
+    assertTrue(tallRiser.getCriticalTopPressurePa() < shortRiser.getCriticalTopPressurePa());
+  }
+
+  @Test
+  void rejectsStatesOutsideDocumentedValidityRange() {
+    assertEquals(Status.NOT_APPLICABLE_INVALID_TOPOLOGY,
+        SevereSluggingSystemDiagnostic
+            .evaluate(baseInput().validFlowlineRiserTopology(false).build()).getStatus());
+    assertEquals(Status.NOT_APPLICABLE_NON_STRATIFIED_FLOWLINE,
+        SevereSluggingSystemDiagnostic.evaluate(baseInput().flowlineStratified(false).build())
+            .getStatus());
+    assertEquals(Status.NOT_APPLICABLE_SINGLE_PHASE,
+        SevereSluggingSystemDiagnostic.evaluate(baseInput().upstreamGasVolumeM3(0.0).build())
+            .getStatus());
+    assertEquals(Status.NOT_VALIDATED_THREE_PHASE,
+        SevereSluggingSystemDiagnostic.evaluate(baseInput().threePhase(true).build()).getStatus());
+
+    Result notApplicable = SevereSluggingSystemDiagnostic
+        .evaluate(baseInput().validFlowlineRiserTopology(false).build());
+    assertFalse(notApplicable.isApplicable());
+    assertTrue(Double.isNaN(notApplicable.getStabilityRatio()));
+  }
+
+  @Test
+  void isDeterministicAndSerializable() throws Exception {
+    Input input = baseInput().build();
+    Result first = SevereSluggingSystemDiagnostic.evaluate(input);
+    Result second = SevereSluggingSystemDiagnostic.evaluate(input);
+    assertEquals(first.getCriticalTopPressurePa(), second.getCriticalTopPressurePa(), 0.0);
+    assertEquals(first.getStatus(), second.getStatus());
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(first);
+    }
+    Result restored;
+    try (ObjectInputStream inputStream =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (Result) inputStream.readObject();
+    }
+    assertEquals(first.getStatus(), restored.getStatus());
+    assertEquals(first.getCriticalTopPressurePa(), restored.getCriticalTopPressurePa(), 0.0);
+  }
+
+  @Test
+  void validatesUnitsAndFractionsAtConstruction() {
+    assertThrows(IllegalArgumentException.class,
+        () -> baseInput().separatorPressurePa(0.0).build());
+    assertThrows(IllegalArgumentException.class,
+        () -> baseInput().riserAreaM2(Double.NaN).build());
+    assertThrows(IllegalArgumentException.class,
+        () -> baseInput().gasCapVoidFraction(0.0).build());
+    assertThrows(IllegalArgumentException.class,
+        () -> baseInput().riserLiquidHoldup(1.01).build());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
@@ -16,7 +16,8 @@ import neqsim.process.equipment.pipeline.twophasepipe.SevereSluggingSystemDiagno
 class SevereSluggingSystemDiagnosticTest {
   private static Input.Builder baseInput() {
     return Input.builder().upstreamGasVolumeM3(20.0).riserAreaM2(0.1).riserHeightM(100.0).separatorPressurePa(500_000.0)
-        .liquidDensityKgPerM3(800.0).riserLiquidHoldup(0.9).gasCapVoidFraction(0.8);
+        .liquidDensityKgPerM3(800.0).riserLiquidHoldup(0.9).gasCapVoidFraction(0.8)
+        .validFlowlineRiserTopology(true).flowlineStratified(true).flowlineContainsGasAndLiquid(true);
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
@@ -51,6 +51,50 @@ class SevereSluggingSystemDiagnosticTest {
   }
 
   @Test
+  void extractsVariableAreaFlowlineAndConstantAreaRiser() {
+    TwoFluidSection[] sections = new TwoFluidSection[] {
+        section(100.0, 0.20, Math.toRadians(-2.0), 0.60, 0.40,
+            PipeSection.FlowRegime.STRATIFIED_SMOOTH, 300_000.0),
+        section(200.0, 0.30, 0.0, 0.50, 0.50, PipeSection.FlowRegime.STRATIFIED_WAVY,
+            280_000.0),
+        section(20.0, 0.10, Math.toRadians(30.0), 0.20, 0.80,
+            PipeSection.FlowRegime.SLUG, 240_000.0),
+        section(30.0, 0.10, Math.toRadians(90.0), 0.30, 0.70,
+            PipeSection.FlowRegime.SLUG, 200_000.0) };
+
+    Input input = SevereSluggingSystemDiagnostic.fromSections(sections, 2, 0.89, 0.0);
+    double expectedGasVolume = sections[0].getArea() * 100.0 * 0.60
+        + sections[1].getArea() * 200.0 * 0.50;
+
+    assertTrue(input.hasValidFlowlineRiserTopology());
+    assertTrue(input.isFlowlineStratified());
+    assertTrue(input.flowlineContainsGasAndLiquid());
+    assertEquals(expectedGasVolume, input.getUpstreamGasVolumeM3(), 1.0e-12);
+    assertEquals(40.0, input.getRiserHeightM(), 1.0e-12);
+    assertEquals(0.74, input.getRiserLiquidHoldup(), 1.0e-12);
+    assertEquals(800.0, input.getLiquidDensityKgPerM3(), 1.0e-12);
+    assertEquals(200_000.0, input.getSeparatorPressurePa(), 0.0);
+    assertTrue(SevereSluggingSystemDiagnostic.evaluate(input).isApplicable());
+  }
+
+  @Test
+  void rejectsAreaChangeInsideRiserButNotAtFlowlineRiserTransition() {
+    TwoFluidSection[] sections = new TwoFluidSection[] {
+        section(100.0, 0.20, 0.0, 0.60, 0.40,
+            PipeSection.FlowRegime.STRATIFIED_SMOOTH, 300_000.0),
+        section(20.0, 0.10, Math.toRadians(30.0), 0.20, 0.80,
+            PipeSection.FlowRegime.SLUG, 240_000.0),
+        section(30.0, 0.12, Math.toRadians(90.0), 0.30, 0.70,
+            PipeSection.FlowRegime.SLUG, 200_000.0) };
+
+    Input input = SevereSluggingSystemDiagnostic.fromSections(sections, 1, 0.89, 0.0);
+
+    assertFalse(input.hasValidFlowlineRiserTopology());
+    assertEquals(Status.NOT_APPLICABLE_INVALID_TOPOLOGY,
+        SevereSluggingSystemDiagnostic.evaluate(input).getStatus());
+  }
+
+  @Test
   void higherRiserAndTopPressureAreStabilisingTrends() {
     Result shortRiser = SevereSluggingSystemDiagnostic
         .evaluate(baseInput().riserHeightM(50.0).separatorPressurePa(800_000.0).build());
@@ -124,5 +168,16 @@ class SevereSluggingSystemDiagnosticTest {
     assertThrows(IllegalArgumentException.class, () -> baseInput().riserAreaM2(Double.NaN).build());
     assertThrows(IllegalArgumentException.class, () -> baseInput().gasCapVoidFraction(0.0).build());
     assertThrows(IllegalArgumentException.class, () -> baseInput().riserLiquidHoldup(1.01).build());
+  }
+
+  private static TwoFluidSection section(double lengthM, double diameterM, double inclinationRad,
+      double gasHoldup, double liquidHoldup, PipeSection.FlowRegime regime, double pressurePa) {
+    TwoFluidSection section = new TwoFluidSection(0.0, lengthM, diameterM, inclinationRad);
+    section.setGasHoldup(gasHoldup);
+    section.setLiquidHoldup(liquidHoldup);
+    section.setLiquidDensity(800.0);
+    section.setPressure(pressurePa);
+    section.setFlowRegime(regime);
+    return section;
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
@@ -16,8 +16,8 @@ import neqsim.process.equipment.pipeline.twophasepipe.SevereSluggingSystemDiagno
 class SevereSluggingSystemDiagnosticTest {
   private static Input.Builder baseInput() {
     return Input.builder().upstreamGasVolumeM3(20.0).riserAreaM2(0.1).riserHeightM(100.0).separatorPressurePa(500_000.0)
-        .liquidDensityKgPerM3(800.0).riserLiquidHoldup(0.9).gasCapVoidFraction(0.8)
-        .validFlowlineRiserTopology(true).flowlineStratified(true).flowlineContainsGasAndLiquid(true);
+        .liquidDensityKgPerM3(800.0).riserLiquidHoldup(0.9).gasCapVoidFraction(0.8).validFlowlineRiserTopology(true)
+        .flowlineStratified(true).flowlineContainsGasAndLiquid(true);
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
@@ -53,18 +53,13 @@ class SevereSluggingSystemDiagnosticTest {
   @Test
   void extractsVariableAreaFlowlineAndConstantAreaRiser() {
     TwoFluidSection[] sections = new TwoFluidSection[] {
-        section(100.0, 0.20, Math.toRadians(-2.0), 0.60, 0.40,
-            PipeSection.FlowRegime.STRATIFIED_SMOOTH, 300_000.0),
-        section(200.0, 0.30, 0.0, 0.50, 0.50, PipeSection.FlowRegime.STRATIFIED_WAVY,
-            280_000.0),
-        section(20.0, 0.10, Math.toRadians(30.0), 0.20, 0.80,
-            PipeSection.FlowRegime.SLUG, 240_000.0),
-        section(30.0, 0.10, Math.toRadians(90.0), 0.30, 0.70,
-            PipeSection.FlowRegime.SLUG, 200_000.0) };
+        section(100.0, 0.20, Math.toRadians(-2.0), 0.60, 0.40, PipeSection.FlowRegime.STRATIFIED_SMOOTH, 300_000.0),
+        section(200.0, 0.30, 0.0, 0.50, 0.50, PipeSection.FlowRegime.STRATIFIED_WAVY, 280_000.0),
+        section(20.0, 0.10, Math.toRadians(30.0), 0.20, 0.80, PipeSection.FlowRegime.SLUG, 240_000.0),
+        section(30.0, 0.10, Math.toRadians(90.0), 0.30, 0.70, PipeSection.FlowRegime.SLUG, 200_000.0) };
 
     Input input = SevereSluggingSystemDiagnostic.fromSections(sections, 2, 0.89, 0.0);
-    double expectedGasVolume = sections[0].getArea() * 100.0 * 0.60
-        + sections[1].getArea() * 200.0 * 0.50;
+    double expectedGasVolume = sections[0].getArea() * 100.0 * 0.60 + sections[1].getArea() * 200.0 * 0.50;
 
     assertTrue(input.hasValidFlowlineRiserTopology());
     assertTrue(input.isFlowlineStratified());
@@ -80,18 +75,14 @@ class SevereSluggingSystemDiagnosticTest {
   @Test
   void rejectsAreaChangeInsideRiserButNotAtFlowlineRiserTransition() {
     TwoFluidSection[] sections = new TwoFluidSection[] {
-        section(100.0, 0.20, 0.0, 0.60, 0.40,
-            PipeSection.FlowRegime.STRATIFIED_SMOOTH, 300_000.0),
-        section(20.0, 0.10, Math.toRadians(30.0), 0.20, 0.80,
-            PipeSection.FlowRegime.SLUG, 240_000.0),
-        section(30.0, 0.12, Math.toRadians(90.0), 0.30, 0.70,
-            PipeSection.FlowRegime.SLUG, 200_000.0) };
+        section(100.0, 0.20, 0.0, 0.60, 0.40, PipeSection.FlowRegime.STRATIFIED_SMOOTH, 300_000.0),
+        section(20.0, 0.10, Math.toRadians(30.0), 0.20, 0.80, PipeSection.FlowRegime.SLUG, 240_000.0),
+        section(30.0, 0.12, Math.toRadians(90.0), 0.30, 0.70, PipeSection.FlowRegime.SLUG, 200_000.0) };
 
     Input input = SevereSluggingSystemDiagnostic.fromSections(sections, 1, 0.89, 0.0);
 
     assertFalse(input.hasValidFlowlineRiserTopology());
-    assertEquals(Status.NOT_APPLICABLE_INVALID_TOPOLOGY,
-        SevereSluggingSystemDiagnostic.evaluate(input).getStatus());
+    assertEquals(Status.NOT_APPLICABLE_INVALID_TOPOLOGY, SevereSluggingSystemDiagnostic.evaluate(input).getStatus());
   }
 
   @Test
@@ -170,8 +161,8 @@ class SevereSluggingSystemDiagnosticTest {
     assertThrows(IllegalArgumentException.class, () -> baseInput().riserLiquidHoldup(1.01).build());
   }
 
-  private static TwoFluidSection section(double lengthM, double diameterM, double inclinationRad,
-      double gasHoldup, double liquidHoldup, PipeSection.FlowRegime regime, double pressurePa) {
+  private static TwoFluidSection section(double lengthM, double diameterM, double inclinationRad, double gasHoldup,
+      double liquidHoldup, PipeSection.FlowRegime regime, double pressurePa) {
     TwoFluidSection section = new TwoFluidSection(0.0, lengthM, diameterM, inclinationRad);
     section.setGasHoldup(gasHoldup);
     section.setLiquidHoldup(liquidHoldup);

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
@@ -69,6 +69,9 @@ class SevereSluggingSystemDiagnosticTest {
         SevereSluggingSystemDiagnostic.evaluate(baseInput().flowlineStratified(false).build()).getStatus());
     assertEquals(Status.NOT_APPLICABLE_SINGLE_PHASE,
         SevereSluggingSystemDiagnostic.evaluate(baseInput().upstreamGasVolumeM3(0.0).build()).getStatus());
+    assertEquals(Status.NOT_APPLICABLE_SINGLE_PHASE,
+        SevereSluggingSystemDiagnostic
+            .evaluate(baseInput().flowlineContainsGasAndLiquid(false).flowlineStratified(false).build()).getStatus());
     assertEquals(Status.NOT_VALIDATED_THREE_PHASE,
         SevereSluggingSystemDiagnostic.evaluate(baseInput().threePhase(true).build()).getStatus());
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
@@ -69,9 +69,8 @@ class SevereSluggingSystemDiagnosticTest {
         SevereSluggingSystemDiagnostic.evaluate(baseInput().flowlineStratified(false).build()).getStatus());
     assertEquals(Status.NOT_APPLICABLE_SINGLE_PHASE,
         SevereSluggingSystemDiagnostic.evaluate(baseInput().upstreamGasVolumeM3(0.0).build()).getStatus());
-    assertEquals(Status.NOT_APPLICABLE_SINGLE_PHASE,
-        SevereSluggingSystemDiagnostic
-            .evaluate(baseInput().flowlineContainsGasAndLiquid(false).flowlineStratified(false).build()).getStatus());
+    assertEquals(Status.NOT_APPLICABLE_SINGLE_PHASE, SevereSluggingSystemDiagnostic
+        .evaluate(baseInput().flowlineContainsGasAndLiquid(false).flowlineStratified(false).build()).getStatus());
     assertEquals(Status.NOT_VALIDATED_THREE_PHASE,
         SevereSluggingSystemDiagnostic.evaluate(baseInput().threePhase(true).build()).getStatus());
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
@@ -104,6 +104,23 @@ class SevereSluggingSystemDiagnosticTest {
     assertEquals(first.getCriticalTopPressurePa(), restored.getCriticalTopPressurePa(), 0.0);
   }
 
+  @SuppressWarnings("deprecation")
+  @Test
+  void preservesLegacyLocalScreenWithoutSettingSystemRisk() {
+    TwoFluidSection section = new TwoFluidSection(0.0, 10.0, 0.2, Math.toRadians(45.0));
+    section.setInclinedSectionGasCarryoverNumber(0.75);
+    section.setInclinedSectionLiquidFallbackPotential(true);
+
+    assertEquals(0.75, section.getSevereSluggingNumber(), 0.0);
+    assertTrue(section.isInclinedSectionLiquidFallbackPotential());
+    assertFalse(section.isSevereSlugPotential());
+
+    TwoFluidSection cloned = section.clone();
+    assertEquals(0.75, cloned.getInclinedSectionGasCarryoverNumber(), 0.0);
+    assertTrue(cloned.isInclinedSectionLiquidFallbackPotential());
+    assertFalse(cloned.isSevereSlugPotential());
+  }
+
   @Test
   void validatesUnitsAndFractionsAtConstruction() {
     assertThrows(IllegalArgumentException.class,

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingSystemDiagnosticTest.java
@@ -15,9 +15,8 @@ import neqsim.process.equipment.pipeline.twophasepipe.SevereSluggingSystemDiagno
 
 class SevereSluggingSystemDiagnosticTest {
   private static Input.Builder baseInput() {
-    return Input.builder().upstreamGasVolumeM3(20.0).riserAreaM2(0.1)
-        .riserHeightM(100.0).separatorPressurePa(500_000.0).liquidDensityKgPerM3(800.0)
-        .riserLiquidHoldup(0.9).gasCapVoidFraction(0.8);
+    return Input.builder().upstreamGasVolumeM3(20.0).riserAreaM2(0.1).riserHeightM(100.0).separatorPressurePa(500_000.0)
+        .liquidDensityKgPerM3(800.0).riserLiquidHoldup(0.9).gasCapVoidFraction(0.8);
   }
 
   @Test
@@ -25,9 +24,8 @@ class SevereSluggingSystemDiagnosticTest {
     Result result = SevereSluggingSystemDiagnostic.evaluate(baseInput().build());
 
     double expectedGasExpansionHead = 20.0 / (0.1 * 0.8);
-    double expectedCriticalPressure =
-        0.9 * 800.0 * SevereSluggingSystemDiagnostic.STANDARD_GRAVITY
-            * (expectedGasExpansionHead - 100.0);
+    double expectedCriticalPressure = 0.9 * 800.0 * SevereSluggingSystemDiagnostic.STANDARD_GRAVITY
+        * (expectedGasExpansionHead - 100.0);
     assertEquals(expectedGasExpansionHead, result.getGasExpansionHeadM(), 1.0e-12);
     assertEquals(expectedCriticalPressure, result.getCriticalTopPressurePa(), 1.0e-9);
     assertEquals(500_000.0 - expectedCriticalPressure, result.getPressureMarginPa(), 1.0e-9);
@@ -66,14 +64,11 @@ class SevereSluggingSystemDiagnosticTest {
   @Test
   void rejectsStatesOutsideDocumentedValidityRange() {
     assertEquals(Status.NOT_APPLICABLE_INVALID_TOPOLOGY,
-        SevereSluggingSystemDiagnostic
-            .evaluate(baseInput().validFlowlineRiserTopology(false).build()).getStatus());
+        SevereSluggingSystemDiagnostic.evaluate(baseInput().validFlowlineRiserTopology(false).build()).getStatus());
     assertEquals(Status.NOT_APPLICABLE_NON_STRATIFIED_FLOWLINE,
-        SevereSluggingSystemDiagnostic.evaluate(baseInput().flowlineStratified(false).build())
-            .getStatus());
+        SevereSluggingSystemDiagnostic.evaluate(baseInput().flowlineStratified(false).build()).getStatus());
     assertEquals(Status.NOT_APPLICABLE_SINGLE_PHASE,
-        SevereSluggingSystemDiagnostic.evaluate(baseInput().upstreamGasVolumeM3(0.0).build())
-            .getStatus());
+        SevereSluggingSystemDiagnostic.evaluate(baseInput().upstreamGasVolumeM3(0.0).build()).getStatus());
     assertEquals(Status.NOT_VALIDATED_THREE_PHASE,
         SevereSluggingSystemDiagnostic.evaluate(baseInput().threePhase(true).build()).getStatus());
 
@@ -96,8 +91,7 @@ class SevereSluggingSystemDiagnosticTest {
       output.writeObject(first);
     }
     Result restored;
-    try (ObjectInputStream inputStream =
-        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+    try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       restored = (Result) inputStream.readObject();
     }
     assertEquals(first.getStatus(), restored.getStatus());
@@ -123,13 +117,9 @@ class SevereSluggingSystemDiagnosticTest {
 
   @Test
   void validatesUnitsAndFractionsAtConstruction() {
-    assertThrows(IllegalArgumentException.class,
-        () -> baseInput().separatorPressurePa(0.0).build());
-    assertThrows(IllegalArgumentException.class,
-        () -> baseInput().riserAreaM2(Double.NaN).build());
-    assertThrows(IllegalArgumentException.class,
-        () -> baseInput().gasCapVoidFraction(0.0).build());
-    assertThrows(IllegalArgumentException.class,
-        () -> baseInput().riserLiquidHoldup(1.01).build());
+    assertThrows(IllegalArgumentException.class, () -> baseInput().separatorPressurePa(0.0).build());
+    assertThrows(IllegalArgumentException.class, () -> baseInput().riserAreaM2(Double.NaN).build());
+    assertThrows(IllegalArgumentException.class, () -> baseInput().gasCapVoidFraction(0.0).build());
+    assertThrows(IllegalArgumentException.class, () -> baseInput().riserLiquidHoldup(1.01).build());
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidPipeValidationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidPipeValidationTest.java
@@ -1,6 +1,5 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -244,23 +243,23 @@ class TwoFluidPipeValidationTest {
   }
 
   /**
-   * Tests based on published OLGA validation cases.
+   * Literature-inspired pipeline scenarios with evidence-specific assertions.
    */
   @Nested
-  @DisplayName("OLGA Validation Cases")
-  class OLGAValidationTests {
+  @DisplayName("Reference Pipeline Scenarios")
+  class ReferenceScenarioTests {
 
     /**
-     * Test Case 1: Horizontal gas-condensate flow (OLGA OVIP Case 1 style).
+     * Test Case 1: Horizontal gas-condensate flow.
      *
      * <p>
-     * Based on typical OVIP validation: Horizontal pipe, gas-condensate, moderate flow.
+     * A scenario smoke test for a horizontal pipe with gas condensate at moderate flow.
      * </p>
      */
     @Test
-    @DisplayName("OLGA OVIP-style Case 1: Horizontal gas-condensate")
-    void testOVIPCase1HorizontalGasCondensate() {
-      // Typical OVIP test conditions
+    @DisplayName("Horizontal gas-condensate scenario")
+    void testHorizontalGasCondensateScenario() {
+      // Synthetic scenario conditions
       SystemInterface fluid = new SystemSrkEos(303.15, 40.0);
       fluid.addComponent("methane", 0.85);
       fluid.addComponent("ethane", 0.08);
@@ -286,7 +285,7 @@ class TwoFluidPipeValidationTest {
       double outletP = pipe.getOutletStream().getPressure("bara");
       double avgHoldup = getAverageHoldup(pipe.getLiquidHoldupProfile());
 
-      logger.info("\n=== OVIP Case 1: Horizontal Gas-Condensate ===");
+      logger.info("\n=== Horizontal Gas-Condensate Scenario ===");
       logger.printf(org.apache.logging.log4j.Level.INFO, "Inlet: P=40 bar, T=30°C, m=8 kg/s%n");
       logger.printf(org.apache.logging.log4j.Level.INFO, "Pipe: L=2000m, D=6in%n");
       logger.printf(org.apache.logging.log4j.Level.INFO, "Results: Outlet P=%.2f bar, Avg Holdup=%.4f%n", outletP,
@@ -299,15 +298,15 @@ class TwoFluidPipeValidationTest {
     }
 
     /**
-     * Test Case 2: Uphill riser with accumulation (OLGA OVIP Case style).
+     * Test Case 2: Uphill riser with accumulation.
      *
      * <p>
      * Validates liquid accumulation at riser base.
      * </p>
      */
     @Test
-    @DisplayName("OLGA OVIP-style Case 2: Uphill riser accumulation")
-    void testOVIPCase2UphillRiserAccumulation() {
+    @DisplayName("Uphill riser accumulation scenario")
+    void testUphillRiserAccumulationScenario() {
       SystemInterface fluid = new SystemSrkEos(313.15, 80.0);
       fluid.addComponent("methane", 0.75);
       fluid.addComponent("ethane", 0.10);
@@ -339,27 +338,27 @@ class TwoFluidPipeValidationTest {
       double bottomHoldup = holdupProfile[1]; // First section after inlet
       double topHoldup = holdupProfile[holdupProfile.length - 1];
 
-      logger.info("\n=== OVIP Case 2: Uphill Riser ===");
+      logger.info("\n=== Uphill Riser Scenario ===");
       logger.printf(org.apache.logging.log4j.Level.INFO, "Riser: L=500m, D=4in, Vertical%n");
       logger.printf(org.apache.logging.log4j.Level.INFO, "Bottom holdup: %.4f (%.2f%%)%n", bottomHoldup,
           bottomHoldup * 100);
       logger.printf(org.apache.logging.log4j.Level.INFO, "Top holdup: %.4f (%.2f%%)%n", topHoldup, topHoldup * 100);
 
       // Riser base typically shows accumulation (higher holdup)
-      // This test validates the terrain tracking enhancement
+      // This test checks the expected physical trend; it is not experimental validation.
       assertTrue(bottomHoldup > 0, "Bottom holdup should be positive");
       assertTrue(topHoldup > 0, "Top holdup should be positive");
     }
 
     /**
-     * Test Case 3: Low point liquid accumulation (OLGA terrain tracking).
+     * Test Case 3: Low-point liquid accumulation.
      *
      * <p>
      * Validates liquid accumulates in pipeline low points.
      * </p>
      */
     @Test
-    @DisplayName("OLGA terrain tracking: Low point liquid accumulation")
+    @DisplayName("Terrain tracking: Low-point liquid accumulation")
     void testTerrainTrackingLowPointAccumulation() {
       SystemInterface fluid = new SystemSrkEos(303.15, 50.0);
       fluid.addComponent("methane", 0.80);
@@ -416,10 +415,10 @@ class TwoFluidPipeValidationTest {
     }
 
     /**
-     * Test Case 4: High velocity vs low velocity holdup (OLGA velocity effect).
+     * Test Case 4: High-velocity versus low-velocity holdup.
      */
     @Test
-    @DisplayName("OLGA velocity effect: High vs low velocity holdup")
+    @DisplayName("Velocity effect: High vs low velocity holdup")
     void testVelocityEffectOnHoldup() {
       SystemInterface fluid = new SystemSrkEos(303.15, 40.0);
       fluid.addComponent("methane", 0.82);
@@ -505,7 +504,7 @@ class TwoFluidPipeValidationTest {
       fluid.setMixingRule("classic");
 
       Stream inlet = new Stream("slug-inlet", fluid);
-      inlet.setFlowRate(2.0, "kg/sec"); // Low flow rate promotes slugging
+      inlet.setFlowRate(0.05, "kg/sec"); // Low rate keeps the feeder stratified
       inlet.setTemperature(10.0, "C");
       inlet.setPressure(30.0, "bara");
       inlet.run();
@@ -529,11 +528,12 @@ class TwoFluidPipeValidationTest {
 
       int riserBaseSection = 24;
       SevereSluggingSystemDiagnostic.Result stability = flowline.evaluateSevereSluggingSystem(riserBaseSection);
-      assertNotEquals(SevereSluggingSystemDiagnostic.Status.NOT_APPLICABLE_INVALID_TOPOLOGY, stability.getStatus());
+      assertTrue(stability.isApplicable(),
+          "Constructed two-phase stratified flowline-riser should be applicable, status=" + stability.getStatus());
 
       // Check conditions at riser base
       double[] holdupProfile = flowline.getLiquidHoldupProfile();
-      double riserBaseHoldup = holdupProfile[24];
+      double riserBaseHoldup = holdupProfile[riserBaseSection];
       double riserTopHoldup = holdupProfile[holdupProfile.length - 1];
 
       logger.info("\n=== Severe Slugging Test ===");
@@ -547,7 +547,7 @@ class TwoFluidPipeValidationTest {
       // Flow regime at various points
       PipeSection.FlowRegime[] regimes = flowline.getFlowRegimeProfile();
       logger.printf(org.apache.logging.log4j.Level.INFO, "Flowline regime: %s%n", regimes[10]);
-      logger.printf(org.apache.logging.log4j.Level.INFO, "Riser base regime: %s%n", regimes[24]);
+      logger.printf(org.apache.logging.log4j.Level.INFO, "Riser base regime: %s%n", regimes[riserBaseSection]);
       logger.printf(org.apache.logging.log4j.Level.INFO, "Riser top regime: %s%n", regimes[regimes.length - 1]);
 
       // Riser base typically shows higher holdup due to accumulation

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidPipeValidationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidPipeValidationTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,16 +14,13 @@ import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
 /**
- * Validation tests for TwoFluidPipe against published correlations and data.
+ * Correlation comparisons and physical-trend regression tests for TwoFluidPipe.
  *
  * <p>
- * This test class validates the TwoFluidPipe model against:
+ * The cases include a Beggs-Brill comparison and NeqSim scenario checks inspired by public
+ * multiphase-flow literature. Scenario smoke tests are not experimental validation and do not
+ * establish equivalence with a commercial simulator.
  * </p>
- * <ul>
- * <li>Beggs and Brill (1973) correlation - SPE-4007-PA</li>
- * <li>Published OLGA validation cases from literature</li>
- * <li>Terrain-induced slugging field data patterns</li>
- * </ul>
  *
  * <p>
  * References:
@@ -488,11 +486,10 @@ class TwoFluidPipeValidationTest {
   class TerrainSlugTests {
 
     /**
-     * Test severe slugging conditions at riser base.
+     * Smoke-test a low-rate flowline-riser state and the explicit system diagnostic.
      *
-     * <p>
-     * Reference: Pots et al. (1987) - Severe slugging criterion π_ss > 1
-     * </p>
+     * <p>This checks topology extraction and finite solved holdup; it is not a validation of a
+     * dynamic severe-slug cycle or a published transition point.</p>
      */
     @Test
     @DisplayName("Severe slugging: Riser base conditions")
@@ -518,24 +515,31 @@ class TwoFluidPipeValidationTest {
       flowline.setDiameter(0.1016); // 4 inch
       flowline.setNumberOfSections(30);
 
-      // Profile: Horizontal flowline, then 200m riser
+      // Profile: Horizontal flowline, then 240 m rise over the final 600 m
       double[] elevation = new double[31];
       for (int i = 0; i < 25; i++) {
         elevation[i] = 0; // Horizontal section
       }
       for (int i = 25; i <= 30; i++) {
-        elevation[i] = (i - 24) * 40.0; // 200m riser over last 600m
+        elevation[i] = (i - 24) * 40.0;
       }
       flowline.setElevationProfile(elevation);
       flowline.run();
 
-      // Check conditions at riser base (section 24)
+      int riserBaseSection = 24;
+      SevereSluggingSystemDiagnostic.Result stability =
+          flowline.evaluateSevereSluggingSystem(riserBaseSection);
+      assertNotEquals(SevereSluggingSystemDiagnostic.Status.NOT_APPLICABLE_INVALID_TOPOLOGY,
+          stability.getStatus());
+
+      // Check conditions at riser base
       double[] holdupProfile = flowline.getLiquidHoldupProfile();
       double riserBaseHoldup = holdupProfile[24];
       double riserTopHoldup = holdupProfile[holdupProfile.length - 1];
 
       logger.info("\n=== Severe Slugging Test ===");
-      logger.info("Configuration: 2.4km flowline + 200m riser");
+      logger.info("Configuration: 2.4 km flowline + 240 m rise");
+      logger.info("System stability status: {}", stability.getStatus());
       logger.printf(org.apache.logging.log4j.Level.INFO, "Riser base holdup: %.4f (%.2f%%)%n", riserBaseHoldup,
           riserBaseHoldup * 100);
       logger.printf(org.apache.logging.log4j.Level.INFO, "Riser top holdup: %.4f (%.2f%%)%n", riserTopHoldup,

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidPipeValidationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidPipeValidationTest.java
@@ -17,9 +17,8 @@ import neqsim.thermo.system.SystemSrkEos;
  * Correlation comparisons and physical-trend regression tests for TwoFluidPipe.
  *
  * <p>
- * The cases include a Beggs-Brill comparison and NeqSim scenario checks inspired by public
- * multiphase-flow literature. Scenario smoke tests are not experimental validation and do not
- * establish equivalence with a commercial simulator.
+ * The cases include a Beggs-Brill comparison and NeqSim scenario checks inspired by public multiphase-flow literature.
+ * Scenario smoke tests are not experimental validation and do not establish equivalence with a commercial simulator.
  * </p>
  *
  * <p>
@@ -488,8 +487,10 @@ class TwoFluidPipeValidationTest {
     /**
      * Smoke-test a low-rate flowline-riser state and the explicit system diagnostic.
      *
-     * <p>This checks topology extraction and finite solved holdup; it is not a validation of a
-     * dynamic severe-slug cycle or a published transition point.</p>
+     * <p>
+     * This checks topology extraction and finite solved holdup; it is not a validation of a dynamic severe-slug cycle
+     * or a published transition point.
+     * </p>
      */
     @Test
     @DisplayName("Severe slugging: Riser base conditions")
@@ -527,10 +528,8 @@ class TwoFluidPipeValidationTest {
       flowline.run();
 
       int riserBaseSection = 24;
-      SevereSluggingSystemDiagnostic.Result stability =
-          flowline.evaluateSevereSluggingSystem(riserBaseSection);
-      assertNotEquals(SevereSluggingSystemDiagnostic.Status.NOT_APPLICABLE_INVALID_TOPOLOGY,
-          stability.getStatus());
+      SevereSluggingSystemDiagnostic.Result stability = flowline.evaluateSevereSluggingSystem(riserBaseSection);
+      assertNotEquals(SevereSluggingSystemDiagnostic.Status.NOT_APPLICABLE_INVALID_TOPOLOGY, stability.getStatus());
 
       // Check conditions at riser base
       double[] holdupProfile = flowline.getLiquidHoldupProfile();

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
@@ -289,8 +290,9 @@ public class TwoFluidSectionTest {
     riserBase2.setPosition(riserBase.getLength());
     equations.calcRHS(new TwoFluidSection[] { riserBase, riserBase2 }, riserBase.getLength());
 
-    assertTrue(riserBase.getSevereSluggingNumber() < 1.0);
-    assertTrue(riserBase.isSevereSlugPotential());
+    assertTrue(riserBase.getInclinedSectionGasCarryoverNumber() < 1.0);
+    assertTrue(riserBase.isInclinedSectionLiquidFallbackPotential());
+    assertFalse(riserBase.isSevereSlugPotential());
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReportTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReportTest.java
@@ -38,7 +38,7 @@ class TwoFluidPipeReportTest {
     assertEquals(sectionCount, pipe.getWaterDropoutRiskProfile().length);
     assertEquals(sectionCount, pipe.getEntrainmentFractionProfile().length);
     assertEquals(sectionCount, pipe.getEntrainedDropletDiameterProfile().length);
-    assertEquals(sectionCount, pipe.getSevereSluggingNumberProfile().length);
+    assertEquals(sectionCount, pipe.getInclinedSectionGasCarryoverNumberProfile().length);
     assertEquals(sectionCount, pipe.getSevereSlugPotentialProfile().length);
     assertTrue(Arrays.stream(pipe.getEntrainmentFractionProfile()).allMatch(value -> value >= 0.0 && value <= 1.0));
     assertTrue(Arrays.stream(pipe.getEntrainedDropletDiameterProfile()).allMatch(value -> value >= 0.0));

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReportTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/reporting/TwoFluidPipeReportTest.java
@@ -29,6 +29,8 @@ class TwoFluidPipeReportTest {
     assertTrue(steadyCsv.startsWith("position_m,pressure_bara,temperature_C"));
     assertTrue(steadyCsv.contains("flow_regime"));
     assertTrue(steadyCsv.contains("entrainment_fraction"));
+    assertTrue(steadyCsv.contains("inclined_section_gas_carryover_number"));
+    assertTrue(steadyCsv.contains("inclined_section_liquid_fallback_potential"));
     assertTrue(steadyCsv.contains("severe_slugging_number"));
     assertEquals(pipe.getPositionProfile().length + 1, steadyCsv.split("\\R").length);
 
@@ -39,6 +41,7 @@ class TwoFluidPipeReportTest {
     assertEquals(sectionCount, pipe.getEntrainmentFractionProfile().length);
     assertEquals(sectionCount, pipe.getEntrainedDropletDiameterProfile().length);
     assertEquals(sectionCount, pipe.getInclinedSectionGasCarryoverNumberProfile().length);
+    assertEquals(sectionCount, pipe.getInclinedSectionLiquidFallbackPotentialProfile().length);
     assertEquals(sectionCount, pipe.getSevereSlugPotentialProfile().length);
     assertTrue(Arrays.stream(pipe.getEntrainmentFractionProfile()).allMatch(value -> value >= 0.0 && value <= 1.0));
     assertTrue(Arrays.stream(pipe.getEntrainedDropletDiameterProfile()).allMatch(value -> value >= 0.0));

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarnessTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/validation/TwoFluidBenchmarkHarnessTest.java
@@ -38,6 +38,8 @@ class TwoFluidBenchmarkHarnessTest {
 
     assertTrue(snapshot.getAvailableVariables().contains("entrainment_fraction"));
     assertTrue(snapshot.getAvailableVariables().contains("entrained_droplet_diameter_m"));
+    assertTrue(snapshot.getAvailableVariables().contains("inclined_section_gas_carryover_number"));
+    assertTrue(snapshot.getAvailableVariables().contains("inclined_section_liquid_fallback_flag"));
     assertTrue(snapshot.getAvailableVariables().contains("severe_slugging_number"));
     assertTrue(snapshot.getAvailableVariables().contains("water_wetting_flag"));
     assertTrue(snapshot.getAvailableVariables().contains("water_dropout_risk_flag"));


### PR DESCRIPTION
## Summary

Correct the public severe-slugging diagnostic boundary by separating a local inclined-section gas-carryover screen from an explicit flowline-riser system stability calculation.

Addresses #2741. This PR deliberately does **not** close the issue: it delivers the bounded diagnostic/API foundation, while the public transient experimental benchmark, velocity-map validation, mesh/timestep convergence, and phase-resolved dynamic evidence in #2741 remain outstanding.

## Root cause

On `master`, `getSevereSluggingNumberProfile()` reports

```
N_local = |v_sG| / (alpha_L sqrt(g D (rho_L-rho_G)/rho_L))
```

for local inclined cells. The value contains no upstream compressible gas volume, total riser rise, outlet pressure, or choke response, so it cannot represent flowline-riser system stability.

## What changed

- Added `SevereSluggingSystemDiagnostic` with the quasi-steady Taitel (1986) stability condition:
  ```
  P_top,critical = phi rho_L g (V_G / (A_r alpha_prime) - H)
  ```
- Added `SevereSluggingSystemDiagnostic.fromSections(...)` as the auditable system-descriptor factory.
  - upstream gas volume uses each flowline section's actual area;
  - a flowline-to-riser diameter change is valid;
  - only the continuously rising riser must have constant area.
- Added `TwoFluidPipe.evaluateSevereSluggingSystem(...)`.
- Renamed the local result to `getInclinedSectionGasCarryoverNumberProfile()` and added
  `getInclinedSectionLiquidFallbackPotentialProfile()`.
- Retained `getSevereSluggingNumberProfile()`, serialized state, CSV column, and benchmark key as documented deprecated aliases.
- Reserved `getSevereSlugPotentialProfile()` for the explicit system result and clear it when a transient step changes the solved state.
- Added accurate `setEnableTerrainSlugClosures(...)` / `isEnableTerrainSlugClosures()` APIs; legacy severe-slug model names remain deprecated aliases.
- Removed unsupported severe-slugging, OLGA-validation, OLGA-style, and equivalence wording in the affected implementation, tests, and guides.
- No conservation equation, transient flux, inventory balance, or time integrator was changed.

## Applicability and limitations

Applicable to low-rate two-phase stratified flow in a level/downward feeder followed by a continuously rising constant-area riser. The diagnostic assumes isothermal ideal-gas compression during incipient penetration and neglects wall/interfacial shear in that displacement.

It returns explicit not-applicable states for invalid topology, non-stratified feeder flow, single-phase state, and unvalidated oil-water-gas flow. The optional static choke pressure drop represents one operating point only; it is not a dynamic choke characteristic.

This is a stability screen, not a prediction of slug frequency, slug length, riser-base pressure cycle, or commercial-simulator equivalence.

## Validation added

Focused tests cover:

- independent analytical reproduction of the Taitel equation;
- different upstream gas volumes and outlet/choke pressures;
- stabilizing riser-height and backpressure trends;
- exact applicability rejection;
- variable-area flowline plus constant-area riser extraction;
- rejection of an area change within the riser;
- local-screen/system-flag separation;
- repeated deterministic evaluation and Java serialization;
- reporting and benchmark-key migration;
- a solved two-phase stratified flowline-riser adapter smoke test.

The previous head passed Java 8/21 fast tests, slow-test shards, Javadoc, formatting/pre-commit, CodeQL, and documentation checks. CI for the latest hardening commit is pending.

## Documentation impact

Updated:

- `docs/process/TWOFLUIDPIPE_MODEL.md`
- `docs/wiki/two_fluid_model_olga_comparison.md`
- `docs/wiki/two_fluid_reporting_and_validation.md`
- affected Javadocs and validation-test descriptions

The docs now state equations, SI units, provenance, topology, validity limits, migration behavior, CSV/benchmark aliases, and dynamic-validation limitations.

## Remaining work before #2741 can close

- encode a legally reproducible public Schmidt/Pots/Taitel, Park, Tengesdal, or Chang benchmark with full metadata and digitization uncertainty;
- sweep gas/liquid superficial velocities across the experimental boundary and report a confusion matrix or boundary error;
- validate dynamic stable/unstable cases for riser-base pressure period/amplitude, liquid-production cycling, maximum slug length relative to riser height, and phase inventories;
- demonstrate timestep and mesh convergence plus phase-resolved and total mass closure;
- document the resulting dynamic validity envelope without implying three-phase validation.

## References

- Taitel, Y. (1986), *Stability of Severe Slugging*, International Journal of Multiphase Flow 12(2), 203-217. https://doi.org/10.1016/0301-9322(86)90026-1
- Jansen, Shoham & Taitel (1996), *The elimination of severe slugging — experiments and modeling*. https://doi.org/10.1016/0301-9322(96)00027-4
- Pots, Bromilow & Konijn (1987), *Severe Slug Flow in Offshore Flowline/Riser Systems*. https://doi.org/10.2118/13723-PA
