### PR TITLE
perf: avoid derivative init in cooler entropy

### DIFF
--- a/src/main/java/neqsim/process/equipment/heatexchanger/Cooler.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Cooler.java
@@ -54,15 +54,11 @@ public class Cooler extends Heater {
   public double getEntropyProduction(String unit) {
     UUID id = UUID.randomUUID();
     inStream.run(id);
-    inStream.getFluid().init(3);
+    inStream.getFluid().init(2);
     getOutletStream().run(id);
-    getOutletStream().getFluid().init(3);
+    getOutletStream().getFluid().init(2);
 
-    double heatTransferEntropyProd = coolingMediumTemperature * getDuty();
-    System.out.println("heat entropy " + heatTransferEntropyProd);
-    double entrop = getOutletStream().getThermoSystem().getEntropy(unit) - inStream.getThermoSystem().getEntropy(unit);
-
-    return entrop;
+    return getOutletStream().getThermoSystem().getEntropy(unit) - inStream.getThermoSystem().getEntropy(unit);
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/process/equipment/heatexchanger/CoolerTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/CoolerTest.java
@@ -201,23 +201,30 @@ class CoolerTest {
   }
 
   private static void assertMinimumEntropyInitialization(InitTrackingSystemSrkEos fluid, Cooler cooler) {
-    double expectedEntropy = referenceEntropyProduction(cooler, "J/K");
     double inletEnthalpy = cooler.getInletStream().getFluid().getEnthalpy();
     double outletEnthalpy = cooler.getOutletStream().getFluid().getEnthalpy();
+    double inletFlow = cooler.getInletStream().getFlowRate("kg/hr");
+    double outletFlow = cooler.getOutletStream().getFlowRate("kg/hr");
     int inletPhases = cooler.getInletStream().getFluid().getNumberOfPhases();
     int outletPhases = cooler.getOutletStream().getFluid().getNumberOfPhases();
 
     fluid.resetInitCounts();
     double actualEntropy = cooler.getEntropyProduction("J/K");
+    int actualLevelTwoCalls = fluid.getLevelTwoCalls();
+    int actualLevelThreeCalls = fluid.getLevelThreeCalls();
+    int actualInletPhases = cooler.getInletStream().getFluid().getNumberOfPhases();
+    int actualOutletPhases = cooler.getOutletStream().getFluid().getNumberOfPhases();
+
+    double expectedEntropy = referenceEntropyProduction(cooler, "J/K");
 
     assertEquals(expectedEntropy, actualEntropy, Math.max(1.0e-10, Math.abs(expectedEntropy) * 1.0e-12));
-    assertTrue(fluid.getLevelTwoCalls() >= 2, "Both inlet and outlet still require caloric initialization");
-    assertEquals(0, fluid.getLevelThreeCalls(), "Entropy diagnostics must not calculate composition derivatives");
+    assertTrue(actualLevelTwoCalls >= 2, "Both inlet and outlet still require caloric initialization");
+    assertEquals(0, actualLevelThreeCalls, "Entropy diagnostics must not calculate composition derivatives");
     assertEquals(outletEnthalpy - inletEnthalpy, cooler.getDuty(),
         Math.max(1.0e-6, Math.abs(cooler.getDuty()) * 1.0e-8));
-    assertEquals(cooler.getInletStream().getFlowRate("kg/hr"), cooler.getOutletStream().getFlowRate("kg/hr"), 1.0e-8);
-    assertEquals(inletPhases, cooler.getInletStream().getFluid().getNumberOfPhases());
-    assertEquals(outletPhases, cooler.getOutletStream().getFluid().getNumberOfPhases());
+    assertEquals(inletFlow, outletFlow, 1.0e-8);
+    assertEquals(inletPhases, actualInletPhases);
+    assertEquals(outletPhases, actualOutletPhases);
   }
 
   private static double referenceEntropyProduction(Cooler cooler, String unit) {

--- a/src/test/java/neqsim/process/equipment/heatexchanger/CoolerTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/CoolerTest.java
@@ -212,6 +212,10 @@ class CoolerTest {
     double actualEntropy = cooler.getEntropyProduction("J/K");
     int actualLevelTwoCalls = fluid.getLevelTwoCalls();
     int actualLevelThreeCalls = fluid.getLevelThreeCalls();
+    double actualInletEnthalpy = cooler.getInletStream().getFluid().getEnthalpy();
+    double actualOutletEnthalpy = cooler.getOutletStream().getFluid().getEnthalpy();
+    double actualInletFlow = cooler.getInletStream().getFlowRate("kg/hr");
+    double actualOutletFlow = cooler.getOutletStream().getFlowRate("kg/hr");
     int actualInletPhases = cooler.getInletStream().getFluid().getNumberOfPhases();
     int actualOutletPhases = cooler.getOutletStream().getFluid().getNumberOfPhases();
 
@@ -220,9 +224,13 @@ class CoolerTest {
     assertEquals(expectedEntropy, actualEntropy, Math.max(1.0e-10, Math.abs(expectedEntropy) * 1.0e-12));
     assertTrue(actualLevelTwoCalls >= 2, "Both inlet and outlet still require caloric initialization");
     assertEquals(0, actualLevelThreeCalls, "Entropy diagnostics must not calculate composition derivatives");
-    assertEquals(outletEnthalpy - inletEnthalpy, cooler.getDuty(),
+    assertEquals(inletEnthalpy, actualInletEnthalpy, Math.max(1.0e-6, Math.abs(inletEnthalpy) * 1.0e-12));
+    assertEquals(outletEnthalpy, actualOutletEnthalpy, Math.max(1.0e-6, Math.abs(outletEnthalpy) * 1.0e-12));
+    assertEquals(actualOutletEnthalpy - actualInletEnthalpy, cooler.getDuty(),
         Math.max(1.0e-6, Math.abs(cooler.getDuty()) * 1.0e-8));
-    assertEquals(inletFlow, outletFlow, 1.0e-8);
+    assertEquals(inletFlow, actualInletFlow, 1.0e-8);
+    assertEquals(outletFlow, actualOutletFlow, 1.0e-8);
+    assertEquals(actualInletFlow, actualOutletFlow, 1.0e-8);
     assertEquals(inletPhases, actualInletPhases);
     assertEquals(outletPhases, actualOutletPhases);
   }

--- a/src/test/java/neqsim/process/equipment/heatexchanger/CoolerTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/CoolerTest.java
@@ -166,6 +166,7 @@ class CoolerTest {
     cooler.setOutTemperature(273.15 + 20.0);
     assertTrue(cooler.needRecalculation());
   }
+
   /**
    * Entropy requires caloric properties but not level-3 composition derivatives. This is also a deterministic
    * performance gate: the diagnostic must preserve its value without derivative initialization.

--- a/src/test/java/neqsim/process/equipment/heatexchanger/CoolerTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/CoolerTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
@@ -11,6 +13,51 @@ import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemSrkEos;
 
 class CoolerTest {
+
+  private static class InitTrackingSystemSrkEos extends SystemSrkEos {
+    private static final long serialVersionUID = 1000L;
+    private AtomicInteger levelTwoCalls = new AtomicInteger();
+    private AtomicInteger levelThreeCalls = new AtomicInteger();
+
+    InitTrackingSystemSrkEos(double temperature, double pressure) {
+      super(temperature, pressure);
+    }
+
+    @Override
+    public InitTrackingSystemSrkEos clone() {
+      InitTrackingSystemSrkEos cloned = (InitTrackingSystemSrkEos) super.clone();
+      if (cloned == null) {
+        throw new IllegalStateException("Failed to clone initialization-tracking fluid");
+      }
+      cloned.levelTwoCalls = levelTwoCalls;
+      cloned.levelThreeCalls = levelThreeCalls;
+      return cloned;
+    }
+
+    @Override
+    public void init(int initType) {
+      super.init(initType);
+      if (levelTwoCalls != null && initType == 2) {
+        levelTwoCalls.incrementAndGet();
+      } else if (levelThreeCalls != null && initType == 3) {
+        levelThreeCalls.incrementAndGet();
+      }
+    }
+
+    void resetInitCounts() {
+      levelTwoCalls.set(0);
+      levelThreeCalls.set(0);
+    }
+
+    int getLevelTwoCalls() {
+      return levelTwoCalls.get();
+    }
+
+    int getLevelThreeCalls() {
+      return levelThreeCalls.get();
+    }
+  }
+
   neqsim.thermo.system.SystemInterface testSystem;
   Stream inletStream;
   ProcessSystem process;
@@ -119,4 +166,67 @@ class CoolerTest {
     cooler.setOutTemperature(273.15 + 20.0);
     assertTrue(cooler.needRecalculation());
   }
+  /**
+   * Entropy requires caloric properties but not level-3 composition derivatives. This is also a deterministic
+   * performance gate: the diagnostic must preserve its value without derivative initialization.
+   */
+  @Test
+  void testEntropyProductionUsesMinimumThermodynamicInitializationLevel() {
+    InitTrackingSystemSrkEos fluid = new InitTrackingSystemSrkEos(363.15, 40.0);
+    fluid.addComponent("nitrogen", 0.02);
+    fluid.addComponent("CO2", 0.03);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.04);
+    fluid.addComponent("n-heptane", 0.04);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("tracked inlet", fluid);
+    inlet.setTemperature(90.0, "C");
+    inlet.setFlowRate(10000.0, "kg/hr");
+
+    Cooler cooler = new Cooler("tracked cooler", inlet);
+    cooler.setOutTemperature(30.0, "C");
+    ProcessSystem trackedProcess = new ProcessSystem();
+    trackedProcess.add(inlet);
+    trackedProcess.add(cooler);
+    trackedProcess.run();
+
+    assertMinimumEntropyInitialization(fluid, cooler);
+
+    inlet.setTemperature(95.0, "C");
+    trackedProcess.run();
+    assertMinimumEntropyInitialization(fluid, cooler);
+  }
+
+  private static void assertMinimumEntropyInitialization(InitTrackingSystemSrkEos fluid, Cooler cooler) {
+    double expectedEntropy = referenceEntropyProduction(cooler, "J/K");
+    double inletEnthalpy = cooler.getInletStream().getFluid().getEnthalpy();
+    double outletEnthalpy = cooler.getOutletStream().getFluid().getEnthalpy();
+    int inletPhases = cooler.getInletStream().getFluid().getNumberOfPhases();
+    int outletPhases = cooler.getOutletStream().getFluid().getNumberOfPhases();
+
+    fluid.resetInitCounts();
+    double actualEntropy = cooler.getEntropyProduction("J/K");
+
+    assertEquals(expectedEntropy, actualEntropy, Math.max(1.0e-10, Math.abs(expectedEntropy) * 1.0e-12));
+    assertTrue(fluid.getLevelTwoCalls() >= 2, "Both inlet and outlet still require caloric initialization");
+    assertEquals(0, fluid.getLevelThreeCalls(), "Entropy diagnostics must not calculate composition derivatives");
+    assertEquals(outletEnthalpy - inletEnthalpy, cooler.getDuty(),
+        Math.max(1.0e-6, Math.abs(cooler.getDuty()) * 1.0e-8));
+    assertEquals(cooler.getInletStream().getFlowRate("kg/hr"), cooler.getOutletStream().getFlowRate("kg/hr"), 1.0e-8);
+    assertEquals(inletPhases, cooler.getInletStream().getFluid().getNumberOfPhases());
+    assertEquals(outletPhases, cooler.getOutletStream().getFluid().getNumberOfPhases());
+  }
+
+  private static double referenceEntropyProduction(Cooler cooler, String unit) {
+    UUID id = UUID.randomUUID();
+    cooler.getInletStream().run(id);
+    cooler.getInletStream().getFluid().init(3);
+    cooler.getOutletStream().run(id);
+    cooler.getOutletStream().getFluid().init(3);
+    return cooler.getOutletStream().getThermoSystem().getEntropy(unit)
+        - cooler.getInletStream().getThermoSystem().getEntropy(unit);
+  }
+
 }


### PR DESCRIPTION
## Bottleneck

`Cooler.getEntropyProduction(...)` reruns its inlet and outlet streams, then explicitly requests thermodynamic initialization level 3 on both states even though it only reads entropy. Entropy is a level-2 caloric property; level 3 additionally computes composition-derivative matrices that this diagnostic never consumes.

The method also calculates an unused heat-transfer value and writes it directly to `System.out` on every call. This adds allocation, formatting, synchronization, and environment-dependent I/O to direct diagnostics and to `ProcessSystem` / `ProcessModel` entropy aggregation.

This is independent of the merged two-stream exchanger optimization in #2738 and does not overlap the active ProcessModel/convergence or column-cache work.

Refs #2698.

## Change

- initialize the cooler inlet and outlet at level 2;
- remove the unused heat-transfer multiplication and unconditional console output;
- preserve the returned entropy calculation exactly.

No neighboring heater, exchanger, solve, or transport-property path is changed.

## Reproducible benchmark

OpenJDK 17.0.19, G1, fixed 512 MiB heap, public NeqSim 3.16.0 fat JAR. The current-master `Cooler.java` blob was inspected before the run. Five fresh JVM forks were used. Within each fork:

- build independent baseline and candidate SRK cooler cases;
- 50 alternating warmups;
- 9 alternating-order samples;
- 500 calls per sample;
- report the median in each fork and the paired median gain across forks;
- use a 13-component rich gas at 40 bara, cooled from 90 to 30 °C;
- route baseline stdout to `/dev/null`, making the logging result a conservative lower bound;
- compare entropy after every scope.

| Scope | Baseline median-of-fork-medians | Candidate median-of-fork-medians | Paired median gain |
|---|---:|---:|---:|
| direct `Cooler` | 0.305494 ms | 0.285994 ms | 5.80% |
| `ProcessSystem` | 0.307475 ms | 0.281892 ms | 8.32% |
| `ProcessModel` | 0.301595 ms | 0.279063 ms | 8.31% |

A nearby 95 °C inlet produced an 8.41% paired median direct gain. Maximum baseline/candidate entropy difference across all forks and scopes was `0.0 J/K`.

The five-component case was noisy (-16.8% to +15.1% by fork), so no small-fluid speedup is claimed. Real console-backed execution should benefit more than this deliberately stdout-discarded benchmark, but no unmeasured I/O gain is claimed.

## Regression and engineering validation

The added regression uses a clone-stable initialization counter and an independent level-3 reference calculation. At 90 °C and a nearby 95 °C inlet it verifies:

- entropy equals the level-3 reference;
- inlet and outlet still receive level-2 caloric initialization;
- no level-3 derivative initialization is requested by this diagnostic;
- duty remains the inlet/outlet enthalpy difference;
- mass flow and phase counts remain unchanged.

The five-fork benchmark also exercised direct, `ProcessSystem`, and `ProcessModel` repeated calls with exact entropy equality.

No public API, EOS, mixing rule, flash algorithm, tolerance, convergence criterion, serialized field, cloning contract, or thread-safety contract changes.

## Documentation impact

Documentation impact: none. This removes internal diagnostic overhead and an accidental console side effect; the public method, return value, units, assumptions, and recommended usage are unchanged. Existing thermodynamic-property documentation already identifies level 2 as caloric initialization and level 3 as composition derivatives.

## Limitations

This accelerates entropy/exergy diagnostics and aggregate reporting, not the cooler solve itself. No speedup is claimed for the noisy five-component benchmark. Repository Maven, Spotless, Java 8/21, Windows/Linux, Javadocs, and static-analysis gates are delegated to GitHub Actions because this workspace does not contain a Maven checkout.