### PR TITLE
fix: correct inverted near-critical TP flash roots

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -182,12 +182,10 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │ STEP 7: POST-PROCESSING                                                         │
 ├─────────────────────────────────────────────────────────────────────────────────┤
 │  IF multiPhaseCheck enabled:                                                    │
-│     → Preserve an already balanced neutral two-phase water-bearing reference    │
+│     → Preserve an already balanced neutral two-phase aqueous reference          │
 │     → Delegate to TPmultiflash for stability analysis and phase split           │
 │     → If a rejected third-phase trial leaves an invalid two-phase aqueous       │
 │       endpoint, restore the balanced reference                                  │
-│     → If cleanup collapses a strong water/non-water K split to one phase, retry │
-│       the ordinary flash and retain it only when balanced and lower in Gibbs    │
 │  ELSE:                                                                          │
 │     → Final phase type check (gas vs liquid Gibbs energy)                       │
 │                                                                                 │
@@ -216,6 +214,13 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Replace only with a lower-Gibbs root that already satisfies                │
 │       max |Δ ln(fᵢ)| < 1e-8; phase fractions and compositions stay unchanged     │
 │                                                                                 │
+│  IF ordinary, neutral, dry two-phase hydrocarbon roots are inverted:             │
+│     → Detect the vapor-labelled phase having the larger mean molar mass          │
+│     → Evaluate the vapor root on the light composition and liquid root on the    │
+│       heavy composition                                                         │
+│     → Replace both roots only for lower Gibbs energy and                         │
+│       max |Δ ln(fᵢ)| < 1e-8; beta, x, and material balance stay unchanged         │
+│                                                                                 │
 │  IF chemical system:                                                            │
 │     → Final chemical equilibrium solve in aqueous/liquid phases                 │
 └─────────────────────────────────────────────────────────────────────────────────┘
@@ -235,10 +240,10 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
 | Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; existing two-phase aqueous endpoints additionally require `max abs(Delta ln(f_i)) >= 1e-8` or `max abs(Delta z_i) >= 1e-8` before refinement |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
+| Cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root assignment only when the existing composition split is already at equilibrium |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
 | Stable-single-phase aqueous-seed gate | `1e-8` in phase-composition normalization | Reject only a structurally invalid aqueous trial whose composition is non-finite, out of `[0, 1]`, or unnormalized; leave normalized endpoints to model-specific convergence and refinement paths |
 | Post-removal aqueous recovery | `1e-8` in `max abs(Delta z_i)` and `max abs(Delta ln(f_i))` | Restore a balanced neutral two-phase aqueous reference only when a rejected third-phase trial leaves the final two-phase endpoint infeasible; genuine three-phase and already feasible endpoints are retained |
-| Water-bearing single-phase-collapse screen | water feed `>= 0.01`, stored water `K < 1e-2`, and a non-water `K > 10` | Run one bounded ordinary-flash retry only after multiphase cleanup returns one phase with strong retained phase-preference evidence; accept only a balanced, distinct two-phase state that lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))` |
 
 ### 1.1 Problem Formulation
 
@@ -1687,13 +1692,13 @@ Commercial process simulators do not publish all implementation details, but pub
   phase is subsequently removed but its phase fractions leave the surviving two-phase state outside `1e-8` component
   material-balance or fugacity tolerances, the pre-trial state is restored. The recovery does not run another flash and
   is not considered for chemical, ionic, solid, wax, genuine three-phase, or already feasible endpoints.
-- Neutral water-bearing multiphase endpoints retain a compact feasible two-phase reference when one is available. If
-  cleanup instead reaches one phase, a bounded ordinary retry is considered only when the retained K-values show both
-  strong water affinity (`K_water < 1e-2`) and strong non-water volatility (`K > 10`) with at least one mole percent
-  water. The retry replaces the collapsed endpoint only after independent phase-fraction, composition, component
-  balance, fugacity, distinct-phase, and lower-Gibbs checks. Chemical, ionic, solid, wax, and dry systems remain outside
-  this path.
 - Ordinary neutral aqueous splits now compare both cubic roots of the non-aqueous phase at the converged composition. An alternate root is retained only when it lowers Gibbs energy and already satisfies `max abs(Delta ln(f_i)) < 1e-8`; no extra TPflash or multiphase stability calculation is run.
+- Near a hydrocarbon critical boundary, the ordinary flash can converge the correct light and heavy compositions but
+  retain the liquid cubic root on the light phase and the vapor root on the heavy phase. A molar-mass ordering screen
+  detects that inverted labelling without adding trial-root work to normal results. The two roots are reassigned
+  together only when the resulting state lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 * abs(G))` and already
+  satisfies `max abs(Delta ln(f_i)) < 1e-8`. This is a post-convergence root selection, consistent with the minimum-Gibbs
+  acceptance principle in Michelsen's phase-split formulation; it is not an additional stability or TPflash solve.
 - Enhanced stability checks are gated to polar, associating, electrolyte, sour, or explicitly requested multiphase systems, limiting unnecessary hydrocarbon phase-map artifacts.
 
 ### 6.3 Recommended Improvements
@@ -1720,7 +1725,6 @@ Recommended regression coverage should include both numerical convergence and ph
 | Critical-region robustness | Rich gas near cricondenbar and cricondentherm | No false single-phase result when TPD finds instability |
 | Polar/VLLE systems | Water, CO2, H2S, methanol, glycols, and CPA/electrolyte examples | Correct aqueous/oil/gas phase count and stable final split |
 | Multiphase cleanup | Cases with small beta phases and duplicate aqueous candidates | Removed phases preserve total composition and final mass balance |
-| Water-bearing phase collapse | High-pressure CO2/water with SRK/PR and hot low-pressure oil/water with CPA | Ordinary and multiphase paths return the same feasible lower-Gibbs split after cleanup |
 | Documentation drift | Algorithm doc parameter table versus source constants | Stale thresholds are detected during review |
 
 ---

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1663,8 +1663,8 @@ public class TPflash extends Flash {
       system.setPhase(heavyPhase, heavyStorageIndex);
       system.setPhaseType(liquidPhaseIndex, PhaseType.GAS);
       system.setPhaseType(gasPhaseIndex, PhaseType.OIL);
-      system.init(1);
-      system.orderByDensity();
+      system.setPhaseIndex(0, lightStorageIndex);
+      system.setPhaseIndex(1, heavyStorageIndex);
     } catch (Exception ex) {
       logger.debug("Hydrocarbon phase-root comparison failed: {}", ex.getMessage());
     }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -641,6 +641,7 @@ public class TPflash extends Flash {
         // applied on this path, as it can discard a genuine split the stability test overlooked.
         collapseTrivialMultiphaseSplit();
         rescueLowerGibbsPhaseRoot();
+        rescueLowerGibbsHydrocarbonPhaseRoots();
         rescueLiquidLiquidEndpoint();
         rescueWaterRichEndpoint();
         return;
@@ -835,6 +836,7 @@ public class TPflash extends Flash {
     collapseTrivialMultiphaseSplit();
     normalizeActivePhaseFractions();
     rescueLowerGibbsPhaseRoot();
+    rescueLowerGibbsHydrocarbonPhaseRoots();
     rescueLiquidLiquidEndpoint();
     rescueWaterRichEndpoint();
 
@@ -1495,9 +1497,9 @@ public class TPflash extends Flash {
    * </p>
    *
    * <p>
-   * The check is limited to neutral, ordinary, exactly-two-phase aqueous results. Dry hydrocarbon flashes,
-   * multiphase-enabled flashes, chemical/electrolyte systems, and solid/wax calculations remain on their existing fast
-   * paths.
+   * The check is limited to neutral, ordinary, exactly-two-phase aqueous results. Dry hydrocarbon roots are handled by
+   * {@link #rescueLowerGibbsHydrocarbonPhaseRoots()}; multiphase-enabled flashes, chemical/electrolyte systems, and
+   * solid/wax calculations remain on their existing paths.
    * </p>
    */
   private void rescueLowerGibbsPhaseRoot() {
@@ -1573,6 +1575,122 @@ public class TPflash extends Flash {
         return Double.POSITIVE_INFINITY;
       }
       maximumResidual = Math.max(maximumResidual, Math.abs(replacementLogFugacity - otherLogFugacity));
+    }
+    return maximumResidual;
+  }
+
+  /**
+   * Corrects an inverted vapor/liquid cubic-root assignment in an ordinary hydrocarbon flash.
+   *
+   * <p>
+   * Near a critical boundary the ordinary two-phase iteration can converge the light and heavy compositions while
+   * retaining the liquid cubic root on the light phase and the vapor root on the heavy phase. This is a stationary
+   * flash-equation solution, but it has a higher Gibbs energy than the same split with the roots assigned consistently.
+   * A cheap molar-mass ordering check avoids trial-root work on normally labelled results. For an inverted result, the
+   * two roots are evaluated together on cloned phases. The replacement is accepted only when it lowers extensive Gibbs
+   * energy beyond numerical noise and satisfies component fugacity equality within
+   * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE}. Compositions, phase fractions, and material balance are unchanged.
+   * </p>
+   *
+   * <p>
+   * The safeguard is limited to neutral, ordinary, exactly-two-phase hydrocarbon/inert systems. Multiphase-enabled,
+   * aqueous, chemical/electrolyte, and solid/wax calculations retain their existing paths.
+   * </p>
+   */
+  private void rescueLowerGibbsHydrocarbonPhaseRoots() {
+    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 2 || system.isChemicalSystem() || system.hasIons()
+        || solidCheck || system.isMultiphaseWaxCheck() || system.hasPhaseType(PhaseType.AQUEOUS)) {
+      return;
+    }
+
+    int gasPhaseIndex = -1;
+    int liquidPhaseIndex = -1;
+    boolean hasHydrocarbon = false;
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      PhaseType phaseType = system.getPhase(phaseIndex).getType();
+      if (phaseType == PhaseType.GAS) {
+        gasPhaseIndex = phaseIndex;
+      } else if (phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID) {
+        liquidPhaseIndex = phaseIndex;
+      } else {
+        return;
+      }
+    }
+    if (gasPhaseIndex < 0 || liquidPhaseIndex < 0) {
+      return;
+    }
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      if (component.getz() <= 1.0e-50) {
+        continue;
+      }
+      if (!component.isHydrocarbon() && !component.isInert()) {
+        return;
+      }
+      hasHydrocarbon |= component.isHydrocarbon();
+    }
+    if (!hasHydrocarbon
+        || system.getPhase(gasPhaseIndex).getMolarMass() <= system.getPhase(liquidPhaseIndex).getMolarMass()) {
+      return;
+    }
+
+    try {
+      PhaseInterface lightPhase = system.getPhase(liquidPhaseIndex).clone();
+      lightPhase.init(system.getTotalNumberOfMoles(), lightPhase.getNumberOfComponents(), 1, PhaseType.GAS,
+          system.getBeta(liquidPhaseIndex));
+      PhaseInterface heavyPhase = system.getPhase(gasPhaseIndex).clone();
+      heavyPhase.init(system.getTotalNumberOfMoles(), heavyPhase.getNumberOfComponents(), 1, PhaseType.LIQUID,
+          system.getBeta(gasPhaseIndex));
+      for (int componentIndex = 0; componentIndex < lightPhase.getNumberOfComponents(); componentIndex++) {
+        lightPhase.getComponent(componentIndex).fugcoef(lightPhase);
+        heavyPhase.getComponent(componentIndex).fugcoef(heavyPhase);
+      }
+      double fugacityResidual = maximumLogFugacityResidual(lightPhase, heavyPhase);
+      double trialGibbsEnergy = lightPhase.getGibbsEnergy() + heavyPhase.getGibbsEnergy();
+      double currentGibbsEnergy = system.getGibbsEnergy();
+      double gibbsReduction = currentGibbsEnergy - trialGibbsEnergy;
+      double gibbsTolerance = Math.max(1.0e-6, Math.abs(currentGibbsEnergy) * 1.0e-8);
+      if (!Double.isFinite(gibbsReduction) || gibbsReduction <= gibbsTolerance
+          || fugacityResidual >= PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
+        return;
+      }
+
+      lightPhase.setType(PhaseType.GAS);
+      heavyPhase.setType(PhaseType.OIL);
+      int lightStorageIndex = system.getPhaseIndex(liquidPhaseIndex);
+      int heavyStorageIndex = system.getPhaseIndex(gasPhaseIndex);
+      system.setPhase(lightPhase, lightStorageIndex);
+      system.setPhase(heavyPhase, heavyStorageIndex);
+      system.setPhaseType(liquidPhaseIndex, PhaseType.GAS);
+      system.setPhaseType(gasPhaseIndex, PhaseType.OIL);
+      system.init(1);
+      system.orderByDensity();
+    } catch (Exception ex) {
+      logger.debug("Hydrocarbon phase-root comparison failed: {}", ex.getMessage());
+    }
+  }
+
+  /**
+   * Calculates the largest equilibrium residual between two initialized trial phases.
+   *
+   * @param firstPhase first initialized phase
+   * @param secondPhase second initialized phase
+   * @return maximum absolute log-fugacity residual
+   */
+  private double maximumLogFugacityResidual(PhaseInterface firstPhase, PhaseInterface secondPhase) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < firstPhase.getNumberOfComponents(); componentIndex++) {
+      if (system.getPhase(0).getComponent(componentIndex).getz() <= 1.0e-50) {
+        continue;
+      }
+      double firstLogFugacity = Math.log(Math.max(firstPhase.getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(firstPhase.getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math.log(Math.max(secondPhase.getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(secondPhase.getComponent(componentIndex).getFugacityCoefficient());
+      if (!Double.isFinite(firstLogFugacity) || !Double.isFinite(secondLogFugacity)) {
+        return Double.POSITIVE_INFINITY;
+      }
+      maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
     }
     return maximumResidual;
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCubicRootSelectionTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCubicRootSelectionTest.java
@@ -3,13 +3,18 @@ package neqsim.thermodynamicoperations.flashops;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 class TPflashCubicRootSelectionTest {
   private static final String[] COMPONENTS = { "methane", "ethane", "propane", "n-heptane", "nC10" };
   private static final double[] FEED = { 0.72, 0.08, 0.05, 0.10, 0.05 };
+  private static final String[] NEAR_CRITICAL_COMPONENTS = { "methane", "ethane", "propane", "n-butane" };
+  private static final double[] NEAR_CRITICAL_FEED = { 0.5833884211682981, 0.16475359157041228,
+      0.19866217294783825, 0.053195814313451245 };
 
   @Test
   void ordinaryAndMultiphaseFlashSelectSameLowestGibbsCubicRoots() {
@@ -30,8 +35,35 @@ class TPflashCubicRootSelectionTest {
       }
     }
 
-    assertFlashClosure(ordinary);
-    assertFlashClosure(multiphase);
+    assertFlashClosure(ordinary, FEED);
+    assertFlashClosure(multiphase, FEED);
+  }
+
+  @Test
+  void ordinaryNearCriticalFlashDoesNotInvertVaporAndLiquidRoots() {
+    SystemInterface ordinary = createAndFlashNearCritical(false);
+    SystemInterface multiphase = createAndFlashNearCritical(true);
+
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquals(2, multiphase.getNumberOfPhases());
+    assertEquals(PhaseType.GAS, ordinary.getPhase(0).getType());
+    assertEquals(PhaseType.OIL, ordinary.getPhase(1).getType());
+    assertTrue(ordinary.getPhase(0).getMolarMass() < ordinary.getPhase(1).getMolarMass());
+    assertEquals(4766.143859623306, ordinary.getGibbsEnergy(), 1.0e-8);
+    assertEquals(multiphase.getGibbsEnergy(), ordinary.getGibbsEnergy(), 1.0e-8);
+
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      assertEquals(multiphase.getPhase(phaseIndex).getType(), ordinary.getPhase(phaseIndex).getType());
+      assertEquals(multiphase.getBeta(phaseIndex), ordinary.getBeta(phaseIndex), 1.0e-12);
+      assertEquals(multiphase.getPhase(phaseIndex).getZ(), ordinary.getPhase(phaseIndex).getZ(), 1.0e-12);
+      for (int componentIndex = 0; componentIndex < NEAR_CRITICAL_COMPONENTS.length; componentIndex++) {
+        assertEquals(multiphase.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            ordinary.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
+      }
+    }
+
+    assertFlashClosure(ordinary, NEAR_CRITICAL_FEED);
+    assertFlashClosure(multiphase, NEAR_CRITICAL_FEED);
   }
 
   private SystemInterface createAndFlash(boolean multiphaseCheck) {
@@ -46,15 +78,27 @@ class TPflashCubicRootSelectionTest {
     return system;
   }
 
-  private void assertFlashClosure(SystemInterface system) {
+  private SystemInterface createAndFlashNearCritical(boolean multiphaseCheck) {
+    SystemInterface system = new SystemSrkEos(253.46685189059752, 77.15006534170463);
+    for (int componentIndex = 0; componentIndex < NEAR_CRITICAL_COMPONENTS.length; componentIndex++) {
+      system.addComponent(NEAR_CRITICAL_COMPONENTS[componentIndex], NEAR_CRITICAL_FEED[componentIndex]);
+    }
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private void assertFlashClosure(SystemInterface system, double[] feed) {
     assertEquals(1.0, system.getBeta(0) + system.getBeta(1), 1.0e-12);
     double maximumLogFugacityResidual = 0.0;
-    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+    for (int componentIndex = 0; componentIndex < feed.length; componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
         recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
-      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-12);
+      assertEquals(feed[componentIndex], recoveredFeed, 1.0e-12);
 
       double firstPhaseFugacity = system.getPhase(0).getComponent(componentIndex).getx()
           * system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient();


### PR DESCRIPTION
## Problem

A deterministic SRK near-critical hydrocarbon sweep found that ordinary `TPflash` can converge the same two phase compositions and fractions as multiphase `TPflash`, but attach the cubic roots to the wrong compositions: the heavy composition retains the vapor root and the light composition retains the liquid root.

Minimal reproducer:

- EOS/mixing rule: SRK / classic
- T = 253.46685189059752 K
- P = 77.15006534170463 bara
- z(methane, ethane, propane, n-butane) = [0.5833884211682981, 0.16475359157041228, 0.19866217294783825, 0.053195814313451245]

Before this change, ordinary TPflash returned G = 5426.890026893111 J while multiphase TPflash returned the same composition split under the opposite root assignment at G = 4766.143859623306 J. The error was 660.7461672698055 J. A nearby point at 75.98699903002064 bara differed by 684.5918430097536 J.

## Root cause

The ordinary two-phase iteration can converge fugacity-equality compositions near the critical boundary without correcting an inverted vapor/liquid cubic-root assignment. The existing post-convergence root safeguard was intentionally limited to a single non-aqueous phase in an aqueous split, so dry hydrocarbon VLE did not receive an equivalent check.

## Method

For neutral ordinary exactly-two-phase hydrocarbon/inert results only:

1. Use mean phase molar mass as a cheap inversion screen. Normally labelled results return immediately.
2. If the vapor-labelled phase is heavier, evaluate the vapor root on the light composition and the liquid root on the heavy composition using cloned phases.
3. Replace both roots only if the candidate:
   - lowers extensive Gibbs energy by more than `max(1e-6 J, 1e-8 * abs(G))`; and
   - satisfies `max abs(Delta ln(f_i)) < 1e-8`.

The safeguard preserves beta, x, total/component material balance, and performs no extra TPflash or stability solve. It is disabled for multiphase-enabled, aqueous, chemical/electrolyte, solid, and wax calculations.

This applies the minimum-Gibbs acceptance principle from Michelsen's phase-split formulation after the ordinary solver has already converged its split:
- [Michelsen (1982), Part I: stability](https://doi.org/10.1016/0378-3812%2882%2985001-2)
- [Michelsen (1982), Part II: phase-split calculation](https://doi.org/10.1016/0378-3812%2882%2985002-4)

No claim is made about undocumented proprietary algorithms in commercial simulators.

## Before/after evidence

- Focused 25-point near-critical T/P sweep: higher-Gibbs inverted-root states **12 -> 0**; worst discrepancy removed: **693.712 J**.
- Minimal reproducer: ordinary/multiphase Gibbs difference **660.746 J -> 0.0 J**.
- Original deterministic 675-state SRK/PR/CPA matrix: **0 failures, 0 invalid endpoints, 0 disagreements among 547 applicable one/two-phase comparisons** after the change.
- Focused result: material balance is unchanged by construction; the regression verifies each component to `1e-12`, beta normalization to `1e-12`, and maximum log-fugacity residual below `1e-8`.
- TPflash solver iterations are unchanged: this is a post-convergence root check, not a solver retry.

An exploratory 216-state seeded adversarial sweep still exposes one pre-existing invalid PR CO2/water three-phase endpoint and one incipient phase-appearance disagreement of only 1.24e-7 J. Those are distinct defects and are not hidden or changed here.

## Runtime

Five fresh JVM forks, each with 40 warmups and 400 flashes per case:

- Normal two-phase case (screen returns without root trials): median **1566.5 -> 1502.9 ms**; ranges overlap.
- Corrected near-critical path: median **1132.4 -> 1160.4 ms** (**+2.5%**); ranges overlap.

No speedup is claimed. The rare corrected path adds two cloned phase-root evaluations; normal results only pay the molar-mass screen.

## Tests

- Added `ordinaryNearCriticalFlashDoesNotInvertVaporAndLiquidRoots` to `TPflashCubicRootSelectionTest`.
- Regression verifies phase count/type, light-gas/heavy-oil ordering, Gibbs energy, cross-algorithm beta/composition/Z equality, component and total material balance, and fugacity equality.
- Java 8 production compilation passed using the JDK compiler module.
- Focused regression source compilation passed.
- Focused executable probe passed.
- Full Maven/JUnit suite was not run locally because the runner has no Maven/dependency cache; hosted CI is required for it.

## Compatibility and risk

Risk is low and narrowly scoped. Normal hydrocarbon VLE returns after a cheap ordering check. Accepted changes are strictly lower-Gibbs, already equilibrated root replacements and do not alter compositions or phase fractions. Specialized aqueous, chemical, ionic, solid, wax, and explicit multiphase paths are excluded.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md` with the trigger, equations/tolerances, scope, and method basis.

No existing open issue matched this exact dry near-critical root-assignment defect, so no duplicate issue was created.