### PR TITLE
perf: avoid derivative init in heater entropy

### DIFF
--- a/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
@@ -783,9 +783,9 @@ public class Heater extends TwoPortEquipment
   public double getEntropyProduction(String unit) {
     UUID id = UUID.randomUUID();
     inStream.run(id);
-    inStream.getFluid().init(3);
+    inStream.getFluid().init(2);
     outStream.run(id);
-    outStream.getFluid().init(3);
+    outStream.getFluid().init(2);
 
     double entrop = outStream.getThermoSystem().getEntropy(unit) - inStream.getThermoSystem().getEntropy(unit);
 

--- a/src/test/java/neqsim/process/equipment/heatexchanger/HeaterTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/HeaterTest.java
@@ -130,8 +130,8 @@ public class HeaterTest {
   }
 
   /**
-   * Entropy requires caloric properties but not level-3 composition derivatives. The diagnostic must preserve its
-   * value and the surrounding stream state while using the minimum thermodynamic initialization level.
+   * Entropy requires caloric properties but not level-3 composition derivatives. The diagnostic must preserve its value
+   * and the surrounding stream state while using the minimum thermodynamic initialization level.
    */
   @Test
   void testEntropyProductionUsesMinimumThermodynamicInitializationLevel() {

--- a/src/test/java/neqsim/process/equipment/heatexchanger/HeaterTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/HeaterTest.java
@@ -128,4 +128,80 @@ public class HeaterTest {
     assertEquals(0, fluid.getLevelThreeCalls(), "Nearby operating points must retain minimal initialization");
     assertEquals(325.0, heater.getOutletStream().getTemperature("K"), 1.0e-10);
   }
+
+  /**
+   * Entropy requires caloric properties but not level-3 composition derivatives. The diagnostic must preserve its
+   * value and the surrounding stream state while using the minimum thermodynamic initialization level.
+   */
+  @Test
+  void testEntropyProductionUsesMinimumThermodynamicInitializationLevel() {
+    InitTrackingSystemSrkEos fluid = new InitTrackingSystemSrkEos(363.15, 40.0);
+    fluid.addComponent("nitrogen", 0.02);
+    fluid.addComponent("CO2", 0.03);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.04);
+    fluid.addComponent("n-heptane", 0.04);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("tracked entropy inlet", fluid);
+    inlet.setTemperature(90.0, "C");
+    inlet.setFlowRate(10000.0, "kg/hr");
+
+    Heater heater = new Heater("tracked entropy heater", inlet);
+    heater.setOutTemperature(130.0, "C");
+    ProcessSystem process = new ProcessSystem();
+    process.add(inlet);
+    process.add(heater);
+    process.run();
+
+    assertMinimumEntropyInitialization(fluid, heater);
+
+    inlet.setTemperature(95.0, "C");
+    process.run();
+    assertMinimumEntropyInitialization(fluid, heater);
+  }
+
+  private static void assertMinimumEntropyInitialization(InitTrackingSystemSrkEos fluid, Heater heater) {
+    double inletEnthalpy = heater.getInletStream().getFluid().getEnthalpy();
+    double outletEnthalpy = heater.getOutletStream().getFluid().getEnthalpy();
+    double inletFlow = heater.getInletStream().getFlowRate("kg/hr");
+    double outletFlow = heater.getOutletStream().getFlowRate("kg/hr");
+    int inletPhases = heater.getInletStream().getFluid().getNumberOfPhases();
+    int outletPhases = heater.getOutletStream().getFluid().getNumberOfPhases();
+
+    fluid.resetInitCounts();
+    double actualEntropy = heater.getEntropyProduction("J/K");
+    int actualLevelTwoCalls = fluid.getLevelTwoCalls();
+    int actualLevelThreeCalls = fluid.getLevelThreeCalls();
+    double actualInletEnthalpy = heater.getInletStream().getFluid().getEnthalpy();
+    double actualOutletEnthalpy = heater.getOutletStream().getFluid().getEnthalpy();
+    double actualInletFlow = heater.getInletStream().getFlowRate("kg/hr");
+    double actualOutletFlow = heater.getOutletStream().getFlowRate("kg/hr");
+    int actualInletPhases = heater.getInletStream().getFluid().getNumberOfPhases();
+    int actualOutletPhases = heater.getOutletStream().getFluid().getNumberOfPhases();
+
+    double expectedEntropy = referenceEntropyProduction(heater, "J/K");
+
+    assertEquals(expectedEntropy, actualEntropy, Math.max(1.0e-10, Math.abs(expectedEntropy) * 1.0e-12));
+    assertTrue(actualLevelTwoCalls >= 2, "Both inlet and outlet still require caloric initialization");
+    assertEquals(0, actualLevelThreeCalls, "Entropy diagnostics must not calculate composition derivatives");
+    assertEquals(inletEnthalpy, actualInletEnthalpy, Math.max(1.0e-6, Math.abs(inletEnthalpy) * 1.0e-12));
+    assertEquals(outletEnthalpy, actualOutletEnthalpy, Math.max(1.0e-6, Math.abs(outletEnthalpy) * 1.0e-12));
+    assertEquals(inletFlow, actualInletFlow, 1.0e-8);
+    assertEquals(outletFlow, actualOutletFlow, 1.0e-8);
+    assertEquals(actualInletFlow, actualOutletFlow, 1.0e-8);
+    assertEquals(inletPhases, actualInletPhases);
+    assertEquals(outletPhases, actualOutletPhases);
+  }
+
+  private static double referenceEntropyProduction(Heater heater, String unit) {
+    UUID id = UUID.randomUUID();
+    heater.getInletStream().run(id);
+    heater.getInletStream().getFluid().init(3);
+    heater.getOutletStream().run(id);
+    heater.getOutletStream().getFluid().init(3);
+    return heater.getOutletStream().getThermoSystem().getEntropy(unit)
+        - heater.getInletStream().getThermoSystem().getEntropy(unit);
+  }
 }


### PR DESCRIPTION
## Purpose

Remove one independently measured source of unnecessary thermodynamic derivative work from Heater entropy diagnostics. This is a focused contribution to #2698; it does not close the audit tracker.

## Bottleneck and implementation

`Heater.getEntropyProduction(...)` reruns its inlet and outlet streams and then requested `init(3)` for both fluids. The only downstream quantity is entropy, whose residual/caloric path is available after `init(2)`; level 3 additionally builds full composition-derivative state that this diagnostic never reads.

This PR changes only those two calls from `init(3)` to `init(2)`. The adjacent exergy diagnostic remains unchanged pending its own benchmark and regression evidence.

## Benchmark

Baseline: current `master` `c3c79de482614eb27b99dea942b47ca68f9ce4d0`.

Method:

- OpenJDK 17.0.19, G1, fixed 512 MiB heap
- exact current-source dependency closure compiled with Java 8 source/target compatibility
- 13-component SRK rich gas, classic mixing rule, 40 bara, 10,000 kg/h
- Heater from 90 °C to 130 °C
- state-changing inlet temperature alternated by ±0.2 °C
- five fresh JVM forks, paired baseline then candidate
- two warm-up blocks and 9 × 500 measured calls per fork
- direct Heater, `ProcessSystem`, and `ProcessModel` aggregation paths

Paired median gain across forks:

| Path | Gain |
|---|---:|
| Direct Heater | 1.01% |
| ProcessSystem | 4.38% |
| ProcessModel | 3.84% |

Every baseline and candidate fork produced the identical accumulated entropy checksum `3839622.8855253870`. The benchmark measures repeated diagnostic/reporting calls, not ordinary process execution without entropy reporting.

## Accuracy and robustness validation

The regression and standalone focused verifier cover both 90 °C and nearby 95 °C inlet states and prove:

- entropy equals an independent level-3 reference within `max(1e-10, |S| × 1e-12)`
- at least two level-2 initializations still occur
- zero level-3 initializations occur during the candidate diagnostic
- inlet/outlet enthalpy, mass flow, and phase count are preserved
- repeated execution at a nearby operating point remains deterministic

Local validation completed:

- Java 8 source/target compilation of the changed current-source dependency closure
- focused standalone execution of the regression invariants at both operating points
- `git diff --check`

Full Maven/JUnit, Spotless, Javadocs, and repository CI are left to the draft-PR workflows because this runtime did not have the repository Maven dependency cache.

## Compatibility and limitations

- no public API, signature, unit, default, or serialized field changes
- no change to thermodynamic results, phase behavior, mass balance, or energy state
- no shared cache or mutable static state introduced; thread-safety is unchanged
- benchmark evidence is for a representative 13-component SRK gas; no claim is made for every fluid model or component count
- exergy diagnostics and other equipment remain outside this PR

## Documentation impact

Documentation impact: none. Public API, results, units, inputs, outputs, defaults, and recommended usage are unchanged; this only removes unused internal derivative initialization from an existing diagnostic.

Relates to #2698.