### PR TITLE
feat(pipe): add conservative one-phase species step

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -298,10 +298,12 @@ defensive copies and `toJson()` is suitable for Python-side result capture.
 
 This path has currently been regression-tested for a single isothermal composition-change step
 with positive flow. Zero or reversed face flow fails explicitly because an external upwind
-composition is not yet defined. Thirty-minute pulse breakthrough/recovery, repeated-event
-propagation, analytical front speed and residence time, grid/time convergence, thermal coupling,
-and phase appearance remain validation gates. The spreading of the present first-order upwind
-scheme is numerical; there is no physical axial-dispersion model.
+composition is not yet defined. Once enabled, every failed hydraulic/species criterion throws so
+that a failed conservative state cannot advance to another timestep. Thirty-minute pulse
+breakthrough/recovery, repeated-event propagation, analytical front speed and residence time,
+grid/time convergence, thermal coupling, and phase appearance remain validation gates. The
+spreading of the present first-order upwind scheme is numerical; there is no physical
+axial-dispersion model.
 
 ## Compositional Tracking
 

--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -260,10 +260,48 @@ accumulating control volume is node one, so the inlet density is imposed at row 
 physical control volumes contribute to linepack.
 
 Solver types `10` and `20` retain the staged energy/component algorithm. They expose the same
-report shape, but coupled hydraulic/EOS convergence under a changing composition is not yet
-validated for those paths. Conservative component transport, front/breakthrough accuracy,
-bounded fractions, numerical diffusion, and physical axial dispersion remain outside the
-validated capability; do not interpret type `20` as satisfying those transport guarantees.
+hydraulic report shape, but coupled hydraulic/EOS convergence under a changing composition is not
+yet validated for those paths. Do not interpret type `20` as satisfying the conservative transport
+guarantees described below.
+
+### Opt-in Conservative Species Step
+
+Transient solver type `1` has an opt-in first-order finite-volume species path. For positive face
+mass flow, each independent component mass fraction is solved from
+
+$$
+(M_P^{n+1} + \Delta t\,\dot m_e)\,\omega_{i,P}^{n+1}
+= M_P^n\,\omega_{i,P}^n + \Delta t\,\dot m_w\,\omega_{i,W}^{n+1}.
+$$
+
+Here, $M_P$ is the authoritative total mass in a physical control volume and $\dot m_w$ and
+$\dot m_e$ are west/east face mass flows. The final component is set algebraically to one minus
+the sum of the other mass fractions. The implementation does not clip fractions or renormalize
+the result. A hydraulic/species fixed-point iteration then synchronizes the EOS composition and
+requires both composition and EOS-density residuals to converge.
+
+```java
+pipe.setConservativeSpeciesTransport(true);
+pipe.setFailOnNonConvergence(true);
+pipe.solveTransient(1);
+
+OnePhaseSpeciesConservationReport species = pipe.getSpeciesConservationReport();
+double[] componentResidualKg = species.getInventoryResidualKg();
+double[][] componentMassFractionByCell = species.getMassFractionProfile();
+```
+
+`OnePhaseSpeciesConservationReport` exposes component names, physical-cell mass-fraction profiles,
+initial/final component inventories, integrated inlet/outlet component masses, absolute and
+relative inventory residuals, boundedness and sum-to-one diagnostics, thermodynamic
+synchronization error, and hydraulic/species residual histories. Its array getters return
+defensive copies and `toJson()` is suitable for Python-side result capture.
+
+This path has currently been regression-tested for a single isothermal composition-change step
+with positive flow. Zero or reversed face flow fails explicitly because an external upwind
+composition is not yet defined. Thirty-minute pulse breakthrough/recovery, repeated-event
+propagation, analytical front speed and residence time, grid/time convergence, thermal coupling,
+and phase appearance remain validation gates. The spreading of the present first-order upwind
+scheme is numerical; there is no physical axial-dispersion model.
 
 ## Compositional Tracking
 
@@ -345,10 +383,10 @@ The steady-state solver has been validated for:
 ## Known Limitations
 
 1. **Single-phase only**: No phase transition handling
-2. **Component-transport validation is incomplete**: Conservative per-component inventories,
-   boundedness without normalization, analytical front speed, pulse breakthrough, and grid/time
-   convergence are not yet established. Do not use the current component result as a validated
-   compositional-tracking prediction.
+2. **Component-transport validation is incomplete**: The opt-in solver-type-1 path demonstrates
+   conservative, bounded one-step transport without normalization. Analytical front speed,
+   repeated-step and pulse breakthrough, and grid/time convergence are not yet established. Do
+   not use it yet as a validated long-duration compositional-tracking prediction.
 3. **No physical axial dispersion model**: Existing advection-scheme spreading is numerical and
    must not be interpreted as molecular or turbulent dispersion.
 4. **Positive-flow diagnostic boundary**: Current transient mass diagnostics reject reverse
@@ -360,8 +398,8 @@ The steady-state solver has been validated for:
 ### For Improved Mass Conservation
 
 Planned dependency order is:
-- Pressure-velocity coupling (SIMPLE algorithm)
-- Conservative per-component transport after total-mass/EOS convergence is demonstrated
+- Coupled hydraulic/EOS and total-mass convergence for solver type `1`
+- Conservative repeated-step and pulse validation after the one-step component balance
 - Dimensionally valid higher-order convection only after first-order analytical validation
 - Explicit physical dispersion as a separate, documented model
 
@@ -381,3 +419,12 @@ pipe.getTimeSeries().setInletThermoSystems(systems);
 
 1. Patankar, S.V. (1980). *Numerical Heat Transfer and Fluid Flow*. Hemisphere Publishing.
 2. Solbraa, E. (2002). *Equilibrium and Non-Equilibrium Thermodynamics of Natural Gas Processing*. PhD Thesis, NTNU.
+3. Chaczykowski, M., Sund, F., Zarodkiewicz, P. and Hope, S.M. (2018). “Gas composition
+   tracking in transient pipeline flow.” *Journal of Natural Gas Science and Engineering*, 55,
+   321–330. <https://doi.org/10.1016/j.jngse.2018.03.014>.
+4. Urh, B. et al. (2024). “Gas composition tracking feasibility using transient finite difference
+   theta-scheme model for binary gas mixtures.” *International Journal of Hydrogen Energy*, 49,
+   1319–1331. <https://doi.org/10.1016/j.ijhydene.2023.11.031>.
+5. Chen, Q. et al. (2024). “A transient gas pipeline network simulation model for decoupling the
+   hydraulic-thermal process and the component tracking process.” *Energy*, 301, 131613.
+   <https://doi.org/10.1016/j.energy.2024.131613>.

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransport.java
@@ -1,0 +1,181 @@
+package neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver;
+
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport.ConservationReason;
+
+/** Positive-flow, first-order implicit finite-volume transport for n-1 species. */
+final class ConservativeSpeciesTransport {
+  static final double INVENTORY_RELATIVE_TOLERANCE = 1.0e-8;
+  static final double MASS_FRACTION_TOLERANCE = 1.0e-12;
+
+  private ConservativeSpeciesTransport() {
+  }
+
+  static OnePhaseSpeciesConservationReport solve(String[] componentNames, double[][] oldMassFraction,
+      double[] inletMassFraction, double[] oldCellMassKg, double[] newCellMassKg, double[] faceMassFlowKgPerSecond,
+      double timeStepSeconds) {
+    String validation = validate(componentNames, oldMassFraction, inletMassFraction, oldCellMassKg, newCellMassKg,
+        faceMassFlowKgPerSecond, timeStepSeconds);
+    if (validation != null) {
+      return failed(ConservationReason.INVALID_STATE, componentNames, validation);
+    }
+    for (double faceFlow : faceMassFlowKgPerSecond) {
+      if (faceFlow <= 0.0) {
+        return failed(ConservationReason.UNSUPPORTED_FLOW, componentNames,
+            "Conservative species transport currently requires strictly positive face mass flow; "
+                + "zero and reversed flow require an explicit external upwind state.");
+      }
+    }
+
+    int components = componentNames.length;
+    int cells = oldCellMassKg.length;
+    double[][] massFraction = new double[components][cells];
+
+    for (int component = 0; component < components - 1; component++) {
+      for (int cell = 0; cell < cells; cell++) {
+        double westMassFraction = cell == 0 ? inletMassFraction[component] : massFraction[component][cell - 1];
+        double numerator = oldCellMassKg[cell] * oldMassFraction[component][cell]
+            + timeStepSeconds * faceMassFlowKgPerSecond[cell] * westMassFraction;
+        double denominator = newCellMassKg[cell] + timeStepSeconds * faceMassFlowKgPerSecond[cell + 1];
+        if (!Double.isFinite(numerator) || !Double.isFinite(denominator) || denominator <= 0.0) {
+          return failed(ConservationReason.INVALID_STATE, componentNames,
+              "Component transport produced a non-finite or non-positive implicit coefficient " + "at component "
+                  + component + ", cell " + cell + ".");
+        }
+        massFraction[component][cell] = numerator / denominator;
+      }
+    }
+
+    for (int cell = 0; cell < cells; cell++) {
+      double independentSum = 0.0;
+      for (int component = 0; component < components - 1; component++) {
+        independentSum += massFraction[component][cell];
+      }
+      massFraction[components - 1][cell] = 1.0 - independentSum;
+    }
+
+    return createReport(componentNames, oldMassFraction, inletMassFraction, oldCellMassKg, newCellMassKg,
+        faceMassFlowKgPerSecond, timeStepSeconds, massFraction);
+  }
+
+  private static OnePhaseSpeciesConservationReport createReport(String[] componentNames, double[][] oldMassFraction,
+      double[] inletMassFraction, double[] oldCellMassKg, double[] newCellMassKg, double[] faceMassFlowKgPerSecond,
+      double timeStepSeconds, double[][] massFraction) {
+    int components = componentNames.length;
+    int cells = oldCellMassKg.length;
+    double[] initialInventory = new double[components];
+    double[] finalInventory = new double[components];
+    double[] inletMass = new double[components];
+    double[] outletMass = new double[components];
+    double[] residual = new double[components];
+    double[] relativeResidual = new double[components];
+    double maximumRelativeResidual = 0.0;
+    double minimumMassFraction = Double.POSITIVE_INFINITY;
+    double maximumMassFraction = Double.NEGATIVE_INFINITY;
+    double maximumSumError = 0.0;
+
+    for (int component = 0; component < components; component++) {
+      for (int cell = 0; cell < cells; cell++) {
+        initialInventory[component] += oldCellMassKg[cell] * oldMassFraction[component][cell];
+        finalInventory[component] += newCellMassKg[cell] * massFraction[component][cell];
+        minimumMassFraction = Math.min(minimumMassFraction, massFraction[component][cell]);
+        maximumMassFraction = Math.max(maximumMassFraction, massFraction[component][cell]);
+      }
+      inletMass[component] = timeStepSeconds * faceMassFlowKgPerSecond[0] * inletMassFraction[component];
+      outletMass[component] = timeStepSeconds * faceMassFlowKgPerSecond[cells] * massFraction[component][cells - 1];
+      residual[component] = finalInventory[component] - initialInventory[component] - inletMass[component]
+          + outletMass[component];
+      double scale = Math.max(
+          Math.max(Math.abs(initialInventory[component]), Math.abs(inletMass[component] - outletMass[component])), 1.0);
+      relativeResidual[component] = Math.abs(residual[component]) / scale;
+      maximumRelativeResidual = Math.max(maximumRelativeResidual, relativeResidual[component]);
+    }
+
+    for (int cell = 0; cell < cells; cell++) {
+      double sum = 0.0;
+      for (int component = 0; component < components; component++) {
+        sum += massFraction[component][cell];
+      }
+      maximumSumError = Math.max(maximumSumError, Math.abs(sum - 1.0));
+    }
+
+    ConservationReason reason = ConservationReason.CONVERGED;
+    if (!Double.isFinite(minimumMassFraction) || !Double.isFinite(maximumMassFraction)
+        || minimumMassFraction < -MASS_FRACTION_TOLERANCE || maximumMassFraction > 1.0 + MASS_FRACTION_TOLERANCE
+        || maximumSumError > MASS_FRACTION_TOLERANCE) {
+      reason = ConservationReason.COMPOSITION_BOUNDS_FAILED;
+    } else if (!Double.isFinite(maximumRelativeResidual) || maximumRelativeResidual > INVENTORY_RELATIVE_TOLERANCE) {
+      reason = ConservationReason.COMPONENT_BALANCE_FAILED;
+    }
+
+    String message = "One-phase conservative species transport " + reason
+        + ": maximum relative component inventory residual=" + maximumRelativeResidual + " (tolerance "
+        + INVENTORY_RELATIVE_TOLERANCE + "), mass-fraction range=[" + minimumMassFraction + ", " + maximumMassFraction
+        + "], maximum sum error=" + maximumSumError + " (tolerance " + MASS_FRACTION_TOLERANCE + ").";
+    return new OnePhaseSpeciesConservationReport(reason, componentNames, massFraction, initialInventory, finalInventory,
+        inletMass, outletMass, residual, relativeResidual, maximumRelativeResidual, minimumMassFraction,
+        maximumMassFraction, maximumSumError, Double.NaN, message);
+  }
+
+  private static String validate(String[] componentNames, double[][] oldMassFraction, double[] inletMassFraction,
+      double[] oldCellMassKg, double[] newCellMassKg, double[] faceMassFlowKgPerSecond, double timeStepSeconds) {
+    if (componentNames == null || componentNames.length < 2) {
+      return "At least two named components are required for n-1 transport.";
+    }
+    if (oldMassFraction == null || oldMassFraction.length != componentNames.length || inletMassFraction == null
+        || inletMassFraction.length != componentNames.length || oldCellMassKg == null || newCellMassKg == null
+        || oldCellMassKg.length == 0 || newCellMassKg.length != oldCellMassKg.length || faceMassFlowKgPerSecond == null
+        || faceMassFlowKgPerSecond.length != oldCellMassKg.length + 1 || !Double.isFinite(timeStepSeconds)
+        || timeStepSeconds <= 0.0) {
+      return "Species transport dimensions or timestep are invalid.";
+    }
+
+    double inletSum = 0.0;
+    for (int component = 0; component < componentNames.length; component++) {
+      if (componentNames[component] == null || componentNames[component].trim().isEmpty()
+          || oldMassFraction[component] == null || oldMassFraction[component].length != oldCellMassKg.length
+          || !isBounded(inletMassFraction[component])) {
+        return "Component names, profiles, or inlet fractions are invalid at component " + component + ".";
+      }
+      inletSum += inletMassFraction[component];
+      for (double value : oldMassFraction[component]) {
+        if (!isBounded(value)) {
+          return "Previous-time mass fractions must be finite and bounded without clipping.";
+        }
+      }
+    }
+    if (Math.abs(inletSum - 1.0) > MASS_FRACTION_TOLERANCE) {
+      return "Inlet mass fractions must sum to one without normalization; sum=" + inletSum + ".";
+    }
+    for (int cell = 0; cell < oldCellMassKg.length; cell++) {
+      if (!Double.isFinite(oldCellMassKg[cell]) || oldCellMassKg[cell] <= 0.0 || !Double.isFinite(newCellMassKg[cell])
+          || newCellMassKg[cell] <= 0.0) {
+        return "Cell masses must be finite and positive at cell " + cell + ".";
+      }
+      double sum = 0.0;
+      for (int component = 0; component < componentNames.length; component++) {
+        sum += oldMassFraction[component][cell];
+      }
+      if (Math.abs(sum - 1.0) > MASS_FRACTION_TOLERANCE) {
+        return "Previous-time cell mass fractions must sum to one without normalization; cell=" + cell + ", sum=" + sum
+            + ".";
+      }
+    }
+    for (double faceFlow : faceMassFlowKgPerSecond) {
+      if (!Double.isFinite(faceFlow)) {
+        return "Face mass flows must be finite.";
+      }
+    }
+    return null;
+  }
+
+  private static boolean isBounded(double value) {
+    return Double.isFinite(value) && value >= 0.0 && value <= 1.0;
+  }
+
+  private static OnePhaseSpeciesConservationReport failed(ConservationReason reason, String[] componentNames,
+      String message) {
+    return new OnePhaseSpeciesConservationReport(reason, componentNames, new double[0][0], new double[0], new double[0],
+        new double[0], new double[0], new double[0], new double[0], Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        Double.NaN, message);
+  }
+}

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
@@ -34,6 +34,9 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   private static final double FINITE_DIFFERENCE_RELATIVE_STEP = 1.0e-7;
   private static final int COUPLED_HALF_BANDWIDTH = 2;
   private static final int COUPLED_JACOBIAN_COLORS = 2 * COUPLED_HALF_BANDWIDTH + 1;
+  private static final int MAXIMUM_SPECIES_COUPLING_ITERATIONS = 100;
+  private static final double SPECIES_COUPLING_TOLERANCE = 1.0e-10;
+  private static final double THERMODYNAMIC_COMPOSITION_TOLERANCE = 1.0e-10;
 
   Matrix diffMatrix;
   int iter = 0;
@@ -48,7 +51,9 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   protected double[] oldImpuls;
   protected double[] oldEnergy;
   private OnePhaseFlowConvergenceReport lastConvergenceReport = OnePhaseFlowConvergenceReport.notRun();
+  private OnePhaseSpeciesConservationReport lastSpeciesConservationReport = OnePhaseSpeciesConservationReport.notRun();
   private boolean failOnNonConvergence;
+  private boolean conservativeSpeciesTransportEnabled;
   private double[] coupledMassEquationScale;
   private double[] coupledMomentumEquationScale;
 
@@ -103,6 +108,34 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
    */
   public OnePhaseFlowConvergenceReport getLastConvergenceReport() {
     return lastConvergenceReport == null ? OnePhaseFlowConvergenceReport.notRun() : lastConvergenceReport;
+  }
+
+  /**
+   * Get conservative component-inventory diagnostics from the most recent solve.
+   *
+   * @return immutable species-conservation report
+   */
+  public OnePhaseSpeciesConservationReport getLastSpeciesConservationReport() {
+    return lastSpeciesConservationReport == null ? OnePhaseSpeciesConservationReport.notRun()
+        : lastSpeciesConservationReport;
+  }
+
+  /**
+   * Enable conservative n-1 species transport on the validated isothermal solver-type-1 path.
+   *
+   * @param enabled true to couple positive-flow component inventories to hydraulics and EOS
+   */
+  public void setConservativeSpeciesTransportEnabled(boolean enabled) {
+    conservativeSpeciesTransportEnabled = enabled;
+  }
+
+  /**
+   * Check whether conservative species transport is enabled.
+   *
+   * @return true when the opt-in conservative component path is active
+   */
+  public boolean isConservativeSpeciesTransportEnabled() {
+    return conservativeSpeciesTransportEnabled;
   }
 
   /**
@@ -994,7 +1027,12 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
     initMatrix();
 
     if (dynamic && solverType == 1) {
-      solveCoupledHydraulicEos(initialFiniteVolumeMass);
+      if (conservativeSpeciesTransportEnabled) {
+        solveCoupledHydraulicEosSpecies(initialFiniteVolumeMass);
+      } else {
+        solveCoupledHydraulicEos(initialFiniteVolumeMass);
+        lastSpeciesConservationReport = OnePhaseSpeciesConservationReport.notRun();
+      }
       initFinalResults();
       return;
     }
@@ -1120,6 +1158,188 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
     }
 
     initFinalResults();
+  }
+
+  private void solveCoupledHydraulicEosSpecies(double initialFiniteVolumeMass) {
+    double maximumCompositionChange = Double.POSITIVE_INFINITY;
+    double densityResidual = Double.POSITIVE_INFINITY;
+    double[] compositionChangeHistory = new double[MAXIMUM_SPECIES_COUPLING_ITERATIONS];
+    double[] speciesDensityHistory = new double[MAXIMUM_SPECIES_COUPLING_ITERATIONS];
+    int couplingIteration = 0;
+
+    while (couplingIteration < MAXIMUM_SPECIES_COUPLING_ITERATIONS
+        && (maximumCompositionChange > SPECIES_COUPLING_TOLERANCE || densityResidual > DENSITY_RELATIVE_TOLERANCE)) {
+      solveCoupledHydraulicEos(initialFiniteVolumeMass);
+      OnePhaseSpeciesConservationReport candidate = solveConservativeSpeciesStep();
+      if (!candidate.isConverged()) {
+        lastSpeciesConservationReport = candidate;
+        handleSpeciesFailure(candidate);
+        return;
+      }
+      maximumCompositionChange = maximumConservativeCompositionChange(candidate);
+      synchronizeThermodynamicComposition(candidate);
+      densityResidual = calculateMaximumRelativeDensityResidual();
+      compositionChangeHistory[couplingIteration] = maximumCompositionChange;
+      speciesDensityHistory[couplingIteration] = densityResidual;
+      lastSpeciesConservationReport = candidate;
+      couplingIteration++;
+    }
+
+    lastSpeciesConservationReport = lastSpeciesConservationReport.withCouplingDiagnostics(couplingIteration,
+        Arrays.copyOf(compositionChangeHistory, couplingIteration),
+        Arrays.copyOf(speciesDensityHistory, couplingIteration));
+    double thermodynamicSyncError = calculateMaximumThermodynamicMassFractionError(lastSpeciesConservationReport);
+    lastSpeciesConservationReport = lastSpeciesConservationReport.withThermodynamicSync(thermodynamicSyncError,
+        THERMODYNAMIC_COMPOSITION_TOLERANCE);
+    OnePhaseFlowConvergenceReport hydraulicReport = lastConvergenceReport;
+    double[] densityHistory = hydraulicReport.getDensityResidualHistory();
+    if (densityHistory.length > 0) {
+      densityHistory[densityHistory.length - 1] = densityResidual;
+    }
+    lastConvergenceReport = createConvergenceReport(hydraulicReport.getNonlinearIterations(),
+        hydraulicReport.getMaximumRelativeNonlinearUpdate(), densityResidual, initialFiniteVolumeMass,
+        hydraulicReport.getNonlinearUpdateHistory(), densityHistory, false, null, true);
+
+    if (maximumCompositionChange > SPECIES_COUPLING_TOLERANCE || densityResidual > DENSITY_RELATIVE_TOLERANCE) {
+      lastSpeciesConservationReport = lastSpeciesConservationReport.withReason(
+          OnePhaseSpeciesConservationReport.ConservationReason.THERMODYNAMIC_SYNC_FAILED,
+          "Hydraulic/species fixed point did not converge after " + couplingIteration
+              + " iterations: maximum mass-fraction change=" + maximumCompositionChange + " (tolerance "
+              + SPECIES_COUPLING_TOLERANCE + "), EOS/FV density=" + densityResidual + " (tolerance "
+              + DENSITY_RELATIVE_TOLERANCE + ").");
+    }
+
+    if (!lastSpeciesConservationReport.isConverged()) {
+      handleSpeciesFailure(lastSpeciesConservationReport);
+    }
+    if (!lastConvergenceReport.isConverged()) {
+      handleHydraulicFailure(lastConvergenceReport);
+    }
+  }
+
+  private OnePhaseSpeciesConservationReport solveConservativeSpeciesStep() {
+    int components = pipe.getNode(0).getBulkSystem().getPhase(0).getNumberOfComponents();
+    int cells = numberOfNodes - 2;
+    String[] componentNames = new String[components];
+    double[][] previousMassFraction = new double[components][cells];
+    double[] inletMassFraction = new double[components];
+    double[] previousCellMassKg = new double[cells];
+    double[] finalCellMassKg = new double[cells];
+    double[] faceMassFlowKgPerSecond = new double[cells + 1];
+
+    for (int component = 0; component < components; component++) {
+      componentNames[component] = pipe.getNode(0).getBulkSystem().getPhase(0).getComponent(component).getName();
+      inletMassFraction[component] = componentMassFraction(0, component);
+      for (int cell = 0; cell < cells; cell++) {
+        previousMassFraction[component][cell] = oldComposition[component][cell + 1];
+      }
+    }
+    for (int cell = 0; cell < cells; cell++) {
+      int node = cell + 1;
+      double volume = getControlVolume(node);
+      previousCellMassKg[cell] = oldDensity[node] * volume;
+      finalCellMassKg[cell] = sol2Matrix.get(node, 0) * volume;
+    }
+    faceMassFlowKgPerSecond[0] = pipe.getNode(1).getVelocityIn().doubleValue() * pipe.getNode(0).getGeometry().getArea()
+        * sol2Matrix.get(0, 0);
+    for (int face = 1; face < cells; face++) {
+      int upstreamNode = face;
+      faceMassFlowKgPerSecond[face] = pipe.getNode(upstreamNode).getVelocityOut().doubleValue()
+          * pipe.getNode(upstreamNode).getGeometry().getArea() * sol2Matrix.get(upstreamNode, 0);
+    }
+    int outletCellNode = numberOfNodes - 2;
+    faceMassFlowKgPerSecond[cells] = pipe.getNode(outletCellNode).getVelocityOut().doubleValue()
+        * pipe.getNode(outletCellNode).getGeometry().getArea() * sol2Matrix.get(outletCellNode, 0);
+
+    return ConservativeSpeciesTransport.solve(componentNames, previousMassFraction, inletMassFraction,
+        previousCellMassKg, finalCellMassKg, faceMassFlowKgPerSecond, timeStep);
+  }
+
+  private double maximumConservativeCompositionChange(OnePhaseSpeciesConservationReport report) {
+    double[][] massFraction = report.getMassFractionProfile();
+    double maximum = 0.0;
+    for (int component = 0; component < massFraction.length; component++) {
+      for (int cell = 0; cell < massFraction[component].length; cell++) {
+        maximum = Math.max(maximum,
+            Math.abs(massFraction[component][cell] - componentMassFraction(cell + 1, component)));
+      }
+    }
+    return maximum;
+  }
+
+  private void synchronizeThermodynamicComposition(OnePhaseSpeciesConservationReport report) {
+    double[][] massFraction = report.getMassFractionProfile();
+    for (int cell = 0; cell < massFraction[0].length; cell++) {
+      int node = cell + 1;
+      double[] moleFraction = massToMoleFractions(node, massFraction, cell);
+      pipe.getNode(node).getBulkSystem().setMolarComposition(moleFraction);
+      pipe.getNode(node).getBulkSystem().init(0);
+      pipe.getNode(node).getBulkSystem().init(1);
+      pipe.getNode(node).init();
+      for (int component = 0; component < massFraction.length; component++) {
+        sol4Matrix[component].set(node, 0, massFraction[component][cell]);
+      }
+    }
+
+    int outletNode = numberOfNodes - 1;
+    double[] outletMoleFraction = massToMoleFractions(numberOfNodes - 2, massFraction, massFraction[0].length - 1);
+    pipe.getNode(outletNode).getBulkSystem().setMolarComposition(outletMoleFraction);
+    pipe.getNode(outletNode).getBulkSystem().init(0);
+    pipe.getNode(outletNode).getBulkSystem().init(1);
+    pipe.getNode(outletNode).init();
+    for (int component = 0; component < massFraction.length; component++) {
+      sol4Matrix[component].set(outletNode, 0, massFraction[component][massFraction[component].length - 1]);
+    }
+  }
+
+  private double[] massToMoleFractions(int node, double[][] massFraction, int cell) {
+    int components = massFraction.length;
+    double[] moleFraction = new double[components];
+    double molarDenominator = 0.0;
+    for (int component = 0; component < components; component++) {
+      molarDenominator += massFraction[component][cell]
+          / pipe.getNode(node).getBulkSystem().getPhase(0).getComponent(component).getMolarMass();
+    }
+    double independentSum = 0.0;
+    for (int component = 0; component < components - 1; component++) {
+      moleFraction[component] = massFraction[component][cell]
+          / pipe.getNode(node).getBulkSystem().getPhase(0).getComponent(component).getMolarMass() / molarDenominator;
+      independentSum += moleFraction[component];
+    }
+    moleFraction[components - 1] = 1.0 - independentSum;
+    return moleFraction;
+  }
+
+  private double calculateMaximumThermodynamicMassFractionError(OnePhaseSpeciesConservationReport report) {
+    double[][] massFraction = report.getMassFractionProfile();
+    double maximum = 0.0;
+    for (int component = 0; component < massFraction.length; component++) {
+      for (int cell = 0; cell < massFraction[component].length; cell++) {
+        maximum = Math.max(maximum,
+            Math.abs(massFraction[component][cell] - componentMassFraction(cell + 1, component)));
+      }
+    }
+    return maximum;
+  }
+
+  private double componentMassFraction(int node, int component) {
+    return pipe.getNode(node).getBulkSystem().getPhase(0).getComponent(component).getx()
+        * pipe.getNode(node).getBulkSystem().getPhase(0).getComponent(component).getMolarMass()
+        / pipe.getNode(node).getBulkSystem().getPhase(0).getMolarMass();
+  }
+
+  private void handleSpeciesFailure(OnePhaseSpeciesConservationReport report) {
+    if (failOnNonConvergence) {
+      throw new IllegalStateException(report.getMessage());
+    }
+    logger.warn("{}", report.getMessage());
+  }
+
+  private void handleHydraulicFailure(OnePhaseFlowConvergenceReport report) {
+    if (failOnNonConvergence) {
+      throw new IllegalStateException(report.getMessage());
+    }
+    logger.warn("{}", report.getMessage());
   }
 
   private void solveCoupledHydraulicEos(double initialFiniteVolumeMass) {

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
@@ -1011,6 +1011,7 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   /** {@inheritDoc} */
   @Override
   public void solveTDMA() {
+    lastSpeciesConservationReport = OnePhaseSpeciesConservationReport.notRun();
     double[] d;
     int iter = 0;
     int iterTop = 0;
@@ -1031,7 +1032,6 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
         solveCoupledHydraulicEosSpecies(initialFiniteVolumeMass);
       } else {
         solveCoupledHydraulicEos(initialFiniteVolumeMass);
-        lastSpeciesConservationReport = OnePhaseSpeciesConservationReport.notRun();
       }
       initFinalResults();
       return;

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
@@ -1205,7 +1205,7 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
 
     if (maximumCompositionChange > SPECIES_COUPLING_TOLERANCE || densityResidual > DENSITY_RELATIVE_TOLERANCE) {
       lastSpeciesConservationReport = lastSpeciesConservationReport.withReason(
-          OnePhaseSpeciesConservationReport.ConservationReason.THERMODYNAMIC_SYNC_FAILED,
+          OnePhaseSpeciesConservationReport.ConservationReason.COUPLING_NOT_CONVERGED,
           "Hydraulic/species fixed point did not converge after " + couplingIteration
               + " iterations: maximum mass-fraction change=" + maximumCompositionChange + " (tolerance "
               + SPECIES_COUPLING_TOLERANCE + "), EOS/FV density=" + densityResidual + " (tolerance "

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
@@ -1170,6 +1170,9 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
     while (couplingIteration < MAXIMUM_SPECIES_COUPLING_ITERATIONS
         && (maximumCompositionChange > SPECIES_COUPLING_TOLERANCE || densityResidual > DENSITY_RELATIVE_TOLERANCE)) {
       solveCoupledHydraulicEos(initialFiniteVolumeMass);
+      if (!lastConvergenceReport.isConverged()) {
+        throw new IllegalStateException(lastConvergenceReport.getMessage());
+      }
       OnePhaseSpeciesConservationReport candidate = solveConservativeSpeciesStep();
       if (!candidate.isConverged()) {
         lastSpeciesConservationReport = candidate;
@@ -1213,7 +1216,7 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
       handleSpeciesFailure(lastSpeciesConservationReport);
     }
     if (!lastConvergenceReport.isConverged()) {
-      handleHydraulicFailure(lastConvergenceReport);
+      throw new IllegalStateException(lastConvergenceReport.getMessage());
     }
   }
 
@@ -1329,10 +1332,7 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   }
 
   private void handleSpeciesFailure(OnePhaseSpeciesConservationReport report) {
-    if (failOnNonConvergence) {
-      throw new IllegalStateException(report.getMessage());
-    }
-    logger.warn("{}", report.getMessage());
+    throw new IllegalStateException(report.getMessage());
   }
 
   private void handleHydraulicFailure(OnePhaseFlowConvergenceReport report) {

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseSpeciesConservationReport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseSpeciesConservationReport.java
@@ -25,6 +25,8 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
     COMPONENT_BALANCE_FAILED(false),
     /** Calculated mass fractions were negative, exceeded one, or did not close to unity. */
     COMPOSITION_BOUNDS_FAILED(false),
+    /** Hydraulic/species fixed-point residuals did not converge within the iteration limit. */
+    COUPLING_NOT_CONVERGED(false),
     /** The synchronized thermodynamic composition was inconsistent with conservative state. */
     THERMODYNAMIC_SYNC_FAILED(false);
 

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseSpeciesConservationReport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseSpeciesConservationReport.java
@@ -1,0 +1,272 @@
+package neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
+
+/** Immutable conservative-species diagnostics for one transient pipe-flow step. */
+public final class OnePhaseSpeciesConservationReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Reason why conservative species transport stopped. */
+  public enum ConservationReason {
+    /** No conservative species solve has run. */
+    NOT_RUN(false),
+    /** Every component inventory and composition criterion was satisfied. */
+    CONVERGED(true),
+    /** The supplied state was non-finite, negative, or dimensionally inconsistent. */
+    INVALID_STATE(false),
+    /** A zero or reversed face flow is outside the currently validated boundary model. */
+    UNSUPPORTED_FLOW(false),
+    /** A component inventory did not close to the integrated boundary flux. */
+    COMPONENT_BALANCE_FAILED(false),
+    /** Calculated mass fractions were negative, exceeded one, or did not close to unity. */
+    COMPOSITION_BOUNDS_FAILED(false),
+    /** The synchronized thermodynamic composition was inconsistent with conservative state. */
+    THERMODYNAMIC_SYNC_FAILED(false);
+
+    private final boolean converged;
+
+    ConservationReason(boolean converged) {
+      this.converged = converged;
+    }
+
+    /**
+     * Check whether the species solve converged.
+     *
+     * @return true only for {@link #CONVERGED}
+     */
+    public boolean isConverged() {
+      return converged;
+    }
+  }
+
+  private final ConservationReason reason;
+  private final String[] componentNames;
+  private final double[][] massFractionProfile;
+  private final double[] initialInventoryKg;
+  private final double[] finalInventoryKg;
+  private final double[] inletBoundaryMassKg;
+  private final double[] outletBoundaryMassKg;
+  private final double[] inventoryResidualKg;
+  private final double[] relativeInventoryResidual;
+  private final double maximumRelativeInventoryResidual;
+  private final double minimumMassFraction;
+  private final double maximumMassFraction;
+  private final double maximumMassFractionSumError;
+  private final double maximumThermodynamicMassFractionError;
+  private final int couplingIterations;
+  private final double[] maximumMassFractionChangeHistory;
+  private final double[] densityResidualHistory;
+  private final String message;
+
+  OnePhaseSpeciesConservationReport(ConservationReason reason, String[] componentNames, double[][] massFractionProfile,
+      double[] initialInventoryKg, double[] finalInventoryKg, double[] inletBoundaryMassKg,
+      double[] outletBoundaryMassKg, double[] inventoryResidualKg, double[] relativeInventoryResidual,
+      double maximumRelativeInventoryResidual, double minimumMassFraction, double maximumMassFraction,
+      double maximumMassFractionSumError, double maximumThermodynamicMassFractionError, String message) {
+    this(reason, componentNames, massFractionProfile, initialInventoryKg, finalInventoryKg, inletBoundaryMassKg,
+        outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual, maximumRelativeInventoryResidual,
+        minimumMassFraction, maximumMassFraction, maximumMassFractionSumError, maximumThermodynamicMassFractionError, 0,
+        new double[0], new double[0], message);
+  }
+
+  private OnePhaseSpeciesConservationReport(ConservationReason reason, String[] componentNames,
+      double[][] massFractionProfile, double[] initialInventoryKg, double[] finalInventoryKg,
+      double[] inletBoundaryMassKg, double[] outletBoundaryMassKg, double[] inventoryResidualKg,
+      double[] relativeInventoryResidual, double maximumRelativeInventoryResidual, double minimumMassFraction,
+      double maximumMassFraction, double maximumMassFractionSumError, double maximumThermodynamicMassFractionError,
+      int couplingIterations, double[] maximumMassFractionChangeHistory, double[] densityResidualHistory,
+      String message) {
+    this.reason = reason;
+    this.componentNames = copy(componentNames);
+    this.massFractionProfile = copy(massFractionProfile);
+    this.initialInventoryKg = copy(initialInventoryKg);
+    this.finalInventoryKg = copy(finalInventoryKg);
+    this.inletBoundaryMassKg = copy(inletBoundaryMassKg);
+    this.outletBoundaryMassKg = copy(outletBoundaryMassKg);
+    this.inventoryResidualKg = copy(inventoryResidualKg);
+    this.relativeInventoryResidual = copy(relativeInventoryResidual);
+    this.maximumRelativeInventoryResidual = maximumRelativeInventoryResidual;
+    this.minimumMassFraction = minimumMassFraction;
+    this.maximumMassFraction = maximumMassFraction;
+    this.maximumMassFractionSumError = maximumMassFractionSumError;
+    this.maximumThermodynamicMassFractionError = maximumThermodynamicMassFractionError;
+    this.couplingIterations = couplingIterations;
+    this.maximumMassFractionChangeHistory = copy(maximumMassFractionChangeHistory);
+    this.densityResidualHistory = copy(densityResidualHistory);
+    this.message = message;
+  }
+
+  /**
+   * Create a report for a solver that has not run.
+   *
+   * @return not-run report
+   */
+  public static OnePhaseSpeciesConservationReport notRun() {
+    return new OnePhaseSpeciesConservationReport(ConservationReason.NOT_RUN, new String[0], new double[0][0],
+        new double[0], new double[0], new double[0], new double[0], new double[0], new double[0], Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, "Conservative species transport has not run.");
+  }
+
+  /** @return reason why transport stopped */
+  public ConservationReason getReason() {
+    return reason;
+  }
+
+  /** @return true when every conservative species criterion passed */
+  public boolean isConverged() {
+    return reason.isConverged();
+  }
+
+  /** @return defensive copy of component names in solver order */
+  public String[] getComponentNames() {
+    return copy(componentNames);
+  }
+
+  /** @return defensive copy of component-by-cell mass fractions */
+  public double[][] getMassFractionProfile() {
+    return copy(massFractionProfile);
+  }
+
+  /** @return defensive copy of previous-time component inventories in kg */
+  public double[] getInitialInventoryKg() {
+    return copy(initialInventoryKg);
+  }
+
+  /** @return defensive copy of final component inventories in kg */
+  public double[] getFinalInventoryKg() {
+    return copy(finalInventoryKg);
+  }
+
+  /** @return defensive copy of integrated inlet component masses in kg */
+  public double[] getInletBoundaryMassKg() {
+    return copy(inletBoundaryMassKg);
+  }
+
+  /** @return defensive copy of integrated outlet component masses in kg */
+  public double[] getOutletBoundaryMassKg() {
+    return copy(outletBoundaryMassKg);
+  }
+
+  /** @return defensive copy of component inventory residuals in kg */
+  public double[] getInventoryResidualKg() {
+    return copy(inventoryResidualKg);
+  }
+
+  /** @return defensive copy of relative component inventory residuals */
+  public double[] getRelativeInventoryResidual() {
+    return copy(relativeInventoryResidual);
+  }
+
+  /** @return maximum relative component inventory residual */
+  public double getMaximumRelativeInventoryResidual() {
+    return maximumRelativeInventoryResidual;
+  }
+
+  /** @return minimum mass fraction across components and physical cells */
+  public double getMinimumMassFraction() {
+    return minimumMassFraction;
+  }
+
+  /** @return maximum mass fraction across components and physical cells */
+  public double getMaximumMassFraction() {
+    return maximumMassFraction;
+  }
+
+  /** @return maximum absolute cell-wise mass-fraction sum error */
+  public double getMaximumMassFractionSumError() {
+    return maximumMassFractionSumError;
+  }
+
+  /** @return maximum conservative-versus-thermodynamic mass-fraction error */
+  public double getMaximumThermodynamicMassFractionError() {
+    return maximumThermodynamicMassFractionError;
+  }
+
+  /** @return number of hydraulic/species fixed-point iterations */
+  public int getCouplingIterations() {
+    return couplingIterations;
+  }
+
+  /** @return defensive copy of maximum mass-fraction changes by coupling iteration */
+  public double[] getMaximumMassFractionChangeHistory() {
+    return copy(maximumMassFractionChangeHistory);
+  }
+
+  /** @return defensive copy of EOS/FV density residuals by coupling iteration */
+  public double[] getDensityResidualHistory() {
+    return copy(densityResidualHistory);
+  }
+
+  /** @return diagnostic summary */
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Serialize this report as stable, pretty-printed JSON.
+   *
+   * @return JSON representation
+   */
+  public String toJson() {
+    JsonSerializer<Double> finiteDoubleSerializer = (value, type,
+        context) -> value != null && Double.isFinite(value) ? new JsonPrimitive(value) : JsonNull.INSTANCE;
+    return new GsonBuilder().registerTypeAdapter(Double.class, finiteDoubleSerializer)
+        .registerTypeAdapter(Double.TYPE, finiteDoubleSerializer).serializeNulls().setPrettyPrinting().create()
+        .toJson(this);
+  }
+
+  OnePhaseSpeciesConservationReport withThermodynamicSync(double maximumError, double tolerance) {
+    ConservationReason updatedReason = reason;
+    if (reason == ConservationReason.CONVERGED && (!Double.isFinite(maximumError) || maximumError > tolerance)) {
+      updatedReason = ConservationReason.THERMODYNAMIC_SYNC_FAILED;
+    }
+    String updatedMessage = message + " Thermodynamic mass-fraction synchronization error=" + maximumError
+        + " (tolerance " + tolerance + ").";
+    return new OnePhaseSpeciesConservationReport(updatedReason, componentNames, massFractionProfile, initialInventoryKg,
+        finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
+        maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
+        maximumError, couplingIterations, maximumMassFractionChangeHistory, densityResidualHistory, updatedMessage);
+  }
+
+  OnePhaseSpeciesConservationReport withCouplingDiagnostics(int iterations, double[] massFractionChangeHistory,
+      double[] eosDensityResidualHistory) {
+    String updatedMessage = message + " Hydraulic/species fixed point iterations=" + iterations + ".";
+    return new OnePhaseSpeciesConservationReport(reason, componentNames, massFractionProfile, initialInventoryKg,
+        finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
+        maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
+        maximumThermodynamicMassFractionError, iterations, massFractionChangeHistory, eosDensityResidualHistory,
+        updatedMessage);
+  }
+
+  OnePhaseSpeciesConservationReport withReason(ConservationReason updatedReason, String updatedMessage) {
+    return new OnePhaseSpeciesConservationReport(updatedReason, componentNames, massFractionProfile, initialInventoryKg,
+        finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
+        maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
+        maximumThermodynamicMassFractionError, couplingIterations, maximumMassFractionChangeHistory,
+        densityResidualHistory, updatedMessage);
+  }
+
+  private static double[] copy(double[] values) {
+    return values == null ? new double[0] : Arrays.copyOf(values, values.length);
+  }
+
+  private static String[] copy(String[] values) {
+    return values == null ? new String[0] : Arrays.copyOf(values, values.length);
+  }
+
+  private static double[][] copy(double[][] values) {
+    if (values == null) {
+      return new double[0][0];
+    }
+    double[][] result = new double[values.length][];
+    for (int i = 0; i < values.length; i++) {
+      result[i] = copy(values[i]);
+    }
+    return result;
+  }
+}

--- a/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
@@ -58,8 +58,8 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
    * Enable conservative n-1 species transport for transient solver type 1.
    *
    * <p>
-   * The path is currently isothermal and requires strictly positive flow. Unsupported zero or reversed flow is reported
-   * explicitly; use {@link #setFailOnNonConvergence(boolean)} for strict exception behavior.
+   * The path is currently isothermal and requires strictly positive flow. Unsupported flow and any failed
+   * hydraulic/species criterion throw so that a failed conservative state cannot advance to the next timestep.
    * </p>
    *
    * @param enabled true to couple conservative component inventories to hydraulics and EOS

--- a/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
@@ -3,6 +3,7 @@ package neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem;
 import java.util.UUID;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFixedStaggeredGrid;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFlowConvergenceReport;
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport;
 import neqsim.fluidmechanics.util.fluidmechanicsvisualization.flowsystemvisualization.onephaseflowvisualization.pipeflowvisualization.PipeFlowVisualization;
 import neqsim.thermo.system.SystemInterface;
 
@@ -16,6 +17,7 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
   private boolean failOnNonConvergence;
+  private boolean conservativeSpeciesTransportEnabled;
 
   /**
    * Constructor for PipeFlowSystem.
@@ -38,6 +40,42 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
       return ((OnePhaseFixedStaggeredGrid) flowSolver).getLastConvergenceReport();
     }
     return OnePhaseFlowConvergenceReport.notRun();
+  }
+
+  /**
+   * Get component inventories, boundary masses, residuals, and boundedness diagnostics.
+   *
+   * @return latest conservative species report, or a not-run report before opt-in transport
+   */
+  public OnePhaseSpeciesConservationReport getSpeciesConservationReport() {
+    if (flowSolver instanceof OnePhaseFixedStaggeredGrid) {
+      return ((OnePhaseFixedStaggeredGrid) flowSolver).getLastSpeciesConservationReport();
+    }
+    return OnePhaseSpeciesConservationReport.notRun();
+  }
+
+  /**
+   * Enable conservative n-1 species transport for transient solver type 1.
+   *
+   * <p>
+   * The path is currently isothermal and requires strictly positive flow. Unsupported zero or reversed flow is reported
+   * explicitly; use {@link #setFailOnNonConvergence(boolean)} for strict exception behavior.
+   * </p>
+   *
+   * @param enabled true to couple conservative component inventories to hydraulics and EOS
+   */
+  public void setConservativeSpeciesTransport(boolean enabled) {
+    conservativeSpeciesTransportEnabled = enabled;
+    configureConvergencePolicy();
+  }
+
+  /**
+   * Check whether conservative species transport is enabled.
+   *
+   * @return true when the opt-in component path is active
+   */
+  public boolean isConservativeSpeciesTransportEnabled() {
+    return conservativeSpeciesTransportEnabled;
   }
 
   /**
@@ -66,7 +104,9 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
 
   private void configureConvergencePolicy() {
     if (flowSolver instanceof OnePhaseFixedStaggeredGrid) {
-      ((OnePhaseFixedStaggeredGrid) flowSolver).setFailOnNonConvergence(failOnNonConvergence);
+      OnePhaseFixedStaggeredGrid onePhaseSolver = (OnePhaseFixedStaggeredGrid) flowSolver;
+      onePhaseSolver.setFailOnNonConvergence(failOnNonConvergence);
+      onePhaseSolver.setConservativeSpeciesTransportEnabled(conservativeSpeciesTransportEnabled);
     }
   }
 

--- a/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
@@ -1,0 +1,80 @@
+package neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+/** Tests conservative n-1 implicit finite-volume species transport. */
+class ConservativeSpeciesTransportTest {
+  @Test
+  void closesEveryComponentWithoutNormalizationOrClipping() {
+    String[] names = { "methane", "nitrogen", "carbon dioxide" };
+    double[][] oldMassFraction = { { 0.80, 0.75 }, { 0.15, 0.20 }, { 0.05, 0.05 } };
+    double[] inletMassFraction = { 0.70, 0.20, 0.10 };
+    double[] oldCellMassKg = { 100.0, 100.0 };
+    double[] newCellMassKg = { 105.0, 100.0 };
+    double[] faceMassFlowKgPerSecond = { 1.0, 0.5, 0.5 };
+
+    OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(names, oldMassFraction,
+        inletMassFraction, oldCellMassKg, newCellMassKg, faceMassFlowKgPerSecond, 10.0);
+
+    assertEquals(OnePhaseSpeciesConservationReport.ConservationReason.CONVERGED, report.getReason(),
+        report.getMessage());
+    assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-14, report.getMessage());
+    assertEquals(0.0, report.getMaximumMassFractionSumError(), 0.0);
+    assertTrue(report.getMinimumMassFraction() >= 0.0);
+    assertTrue(report.getMaximumMassFraction() <= 1.0);
+
+    double[][] profile = report.getMassFractionProfile();
+    assertEquals((80.0 + 10.0 * 1.0 * 0.70) / (105.0 + 10.0 * 0.5), profile[0][0], 1.0e-15);
+    assertEquals((75.0 + 10.0 * 0.5 * profile[0][0]) / (100.0 + 10.0 * 0.5), profile[0][1], 1.0e-15);
+  }
+
+  @Test
+  void reproducesImplicitUpwindStepRecurrence() {
+    String[] names = { "carrier", "tracer" };
+    double[][] oldMassFraction = { { 1.0, 1.0, 1.0, 1.0 }, { 0.0, 0.0, 0.0, 0.0 } };
+    double[] inletMassFraction = { 0.0, 1.0 };
+    double[] cellMassKg = { 10.0, 10.0, 10.0, 10.0 };
+    double[] faceMassFlowKgPerSecond = { 1.0, 1.0, 1.0, 1.0, 1.0 };
+
+    OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(names, oldMassFraction,
+        inletMassFraction, cellMassKg, cellMassKg, faceMassFlowKgPerSecond, 5.0);
+
+    assertTrue(report.isConverged(), report.getMessage());
+    double[] expectedTracer = { 1.0 / 3.0, 1.0 / 9.0, 1.0 / 27.0, 1.0 / 81.0 };
+    assertArrayEquals(expectedTracer, report.getMassFractionProfile()[1], 1.0e-15);
+    assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-14);
+  }
+
+  @Test
+  void rejectsInvalidClosureAndReversedFlowWithoutRepairingInputs() {
+    String[] names = { "carrier", "tracer" };
+    double[][] invalidOld = { { 0.8 }, { 0.3 } };
+    OnePhaseSpeciesConservationReport invalid = ConservativeSpeciesTransport.solve(names, invalidOld,
+        new double[] { 0.8, 0.2 }, new double[] { 10.0 }, new double[] { 10.0 }, new double[] { 1.0, 1.0 }, 1.0);
+
+    assertEquals(OnePhaseSpeciesConservationReport.ConservationReason.INVALID_STATE, invalid.getReason());
+    assertFalse(invalid.isConverged());
+    assertTrue(invalid.getMessage().contains("sum to one without normalization"));
+
+    double[][] validOld = { { 0.8 }, { 0.2 } };
+    OnePhaseSpeciesConservationReport reversed = ConservativeSpeciesTransport.solve(names, validOld,
+        new double[] { 0.8, 0.2 }, new double[] { 10.0 }, new double[] { 10.0 }, new double[] { 1.0, -1.0 }, 1.0);
+    assertEquals(OnePhaseSpeciesConservationReport.ConservationReason.UNSUPPORTED_FLOW, reversed.getReason());
+    assertTrue(reversed.getMessage().contains("zero and reversed flow"));
+  }
+
+  @Test
+  void reportDefensivelyCopiesProfiles() {
+    OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(new String[] { "carrier", "tracer" },
+        new double[][] { { 0.8 }, { 0.2 } }, new double[] { 0.8, 0.2 }, new double[] { 10.0 }, new double[] { 10.0 },
+        new double[] { 1.0, 1.0 }, 1.0);
+    double[][] first = report.getMassFractionProfile();
+    first[0][0] = -1.0;
+    assertEquals(0.8, report.getMassFractionProfile()[0][0], 1.0e-15);
+    assertFalse(OnePhaseSpeciesConservationReport.notRun().toJson().contains("NaN"));
+  }
+}

--- a/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
@@ -51,6 +51,7 @@ class ConservativeSpeciesTransportTest {
 
   @Test
   void rejectsInvalidClosureAndReversedFlowWithoutRepairingInputs() {
+    assertFalse(OnePhaseSpeciesConservationReport.ConservationReason.COUPLING_NOT_CONVERGED.isConverged());
     String[] names = { "carrier", "tracer" };
     double[][] invalidOld = { { 0.8 }, { 0.3 } };
     OnePhaseSpeciesConservationReport invalid = ConservativeSpeciesTransport.solve(names, invalidOld,

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -1,0 +1,118 @@
+package neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport;
+import neqsim.fluidmechanics.geometrydefinitions.GeometryDefinitionInterface;
+import neqsim.fluidmechanics.geometrydefinitions.pipe.PipeData;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests conservative one-phase species transport coupled to hydraulic/EOS state. */
+class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
+  private static final double TEMPERATURE_K = 288.15;
+  private static final double PRESSURE_BARA = 70.0;
+  private static final double MASS_FLOW_KG_PER_SECOND = 50.0;
+
+  @Test
+  void compositionStepClosesEveryComponentAndSynchronizesThermodynamics() {
+    PipeFlowSystem pipe = runCompositionStep(40, 30.0);
+    OnePhaseSpeciesConservationReport report = pipe.getSpeciesConservationReport();
+
+    assertEquals(OnePhaseSpeciesConservationReport.ConservationReason.CONVERGED, report.getReason(),
+        report.getMessage());
+    assertTrue(pipe.getConvergenceReport().isConverged(), pipe.getConvergenceReport().getMessage());
+    assertTrue(pipe.getConvergenceReport().getMaximumRelativeDensityResidual() <= pipe.getConvergenceReport()
+        .getDensityRelativeTolerance());
+    assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-8, report.getMessage());
+    assertTrue(report.getMinimumMassFraction() >= 0.0, report.getMessage());
+    assertTrue(report.getMaximumMassFraction() <= 1.0, report.getMessage());
+    assertTrue(report.getMaximumMassFractionSumError() <= 1.0e-12, report.getMessage());
+    assertTrue(report.getMaximumThermodynamicMassFractionError() <= 1.0e-10, report.getMessage());
+    assertTrue(report.getCouplingIterations() > 0, report.getMessage());
+    assertEquals(report.getCouplingIterations(), report.getMaximumMassFractionChangeHistory().length);
+    assertEquals(report.getCouplingIterations(), report.getDensityResidualHistory().length);
+    assertTrue(report.getMaximumMassFractionChangeHistory()[report.getCouplingIterations() - 1] <= 1.0e-10,
+        report.getMessage());
+    assertTrue(report.getDensityResidualHistory()[report.getCouplingIterations() - 1] <= pipe.getConvergenceReport()
+        .getDensityRelativeTolerance(), report.getMessage());
+
+    int nitrogen = 1;
+    assertEquals(report.getFinalInventoryKg()[nitrogen] - report.getInitialInventoryKg()[nitrogen],
+        report.getInletBoundaryMassKg()[nitrogen] - report.getOutletBoundaryMassKg()[nitrogen],
+        Math.max(1.0, report.getInitialInventoryKg()[nitrogen]) * 1.0e-8);
+    double firstCellNitrogen = pipe.getNode(1).getBulkSystem().getPhase(0).getComponent(nitrogen).getx();
+    assertTrue(firstCellNitrogen > 0.05 && firstCellNitrogen < 0.20,
+        "The bounded inlet front must enter the first physical cell: " + firstCellNitrogen);
+  }
+
+  @Test
+  void conservativeSpeciesStepIsDeterministicAndTimestepSensitive() {
+    PipeFlowSystem thirtySecondA = runCompositionStep(12, 30.0);
+    PipeFlowSystem thirtySecondB = runCompositionStep(12, 30.0);
+    PipeFlowSystem fifteenSecond = runCompositionStep(12, 15.0);
+
+    OnePhaseSpeciesConservationReport reportA = thirtySecondA.getSpeciesConservationReport();
+    OnePhaseSpeciesConservationReport reportB = thirtySecondB.getSpeciesConservationReport();
+    assertArrayEquals(reportA.getFinalInventoryKg(), reportB.getFinalInventoryKg(), 0.0);
+    assertArrayEquals(reportA.getInventoryResidualKg(), reportB.getInventoryResidualKg(), 0.0);
+    assertArrayEquals(reportA.getMassFractionProfile()[1], reportB.getMassFractionProfile()[1], 0.0);
+
+    double thirtySecondFront = thirtySecondA.getNode(1).getBulkSystem().getPhase(0).getComponent(1).getx();
+    double fifteenSecondFront = fifteenSecond.getNode(1).getBulkSystem().getPhase(0).getComponent(1).getx();
+    assertTrue(thirtySecondFront > fifteenSecondFront,
+        "A longer first-order implicit step must advance more inlet tracer mass.");
+    assertTrue(fifteenSecond.getSpeciesConservationReport().isConverged());
+  }
+
+  static PipeFlowSystem runCompositionStep(int nodes, double timeStep) {
+    PipeFlowSystem pipe = createInitializedPipe(nodes);
+    pipe.setConservativeSpeciesTransport(true);
+    pipe.setFailOnNonConvergence(true);
+    pipe.getTimeSeries().setTimes(new double[] { 0.0, timeStep });
+    pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] { createGas(0.80, 0.20) });
+    pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);
+
+    assertDoesNotThrow(() -> pipe.solveTransient(1));
+    return pipe;
+  }
+
+  private static PipeFlowSystem createInitializedPipe(int nodes) {
+    PipeFlowSystem pipe = new PipeFlowSystem();
+    pipe.setInletThermoSystem(createGas(0.95, 0.05));
+    pipe.setNumberOfLegs(1);
+    pipe.setNumberOfNodesInLeg(nodes);
+    GeometryDefinitionInterface[] geometry = { new PipeData(), new PipeData() };
+    for (GeometryDefinitionInterface section : geometry) {
+      section.setDiameter(0.5);
+      section.setInnerSurfaceRoughness(1.0e-5);
+    }
+    pipe.setEquipmentGeometry(geometry);
+    pipe.setLegHeights(new double[] { 0.0, 0.0 });
+    pipe.setLegPositions(new double[] { 0.0, 15000.0 });
+    pipe.setLegOuterTemperatures(new double[] { TEMPERATURE_K, TEMPERATURE_K });
+    pipe.setLegWallHeatTransferCoefficients(new double[] { 0.0, 0.0 });
+    pipe.setLegOuterHeatTransferCoefficients(new double[] { 0.0, 0.0 });
+    pipe.createSystem();
+    pipe.init();
+    pipe.solveSteadyState(1);
+    assertTrue(pipe.getConvergenceReport().isConverged());
+    return pipe;
+  }
+
+  private static SystemInterface createGas(double methane, double nitrogen) {
+    SystemInterface gas = new SystemSrkEos(TEMPERATURE_K, PRESSURE_BARA);
+    gas.addComponent("methane", methane);
+    gas.addComponent("nitrogen", nitrogen);
+    gas.createDatabase(true);
+    gas.setMixingRule("classic");
+    gas.init(0);
+    gas.init(3);
+    gas.initPhysicalProperties();
+    gas.setTotalFlowRate(MASS_FLOW_KG_PER_SECOND, "kg/sec");
+    return gas;
+  }
+}

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -82,6 +82,17 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     assertTrue(exception.getMessage().contains("supports positive flow only"));
   }
 
+  @Test
+  void reportDoesNotRemainStaleAfterNonConservativeSolverPath() {
+    PipeFlowSystem pipe = runCompositionStep(3, 30.0);
+    assertTrue(pipe.getSpeciesConservationReport().isConverged());
+
+    pipe.solveTransient(0);
+
+    assertEquals(OnePhaseSpeciesConservationReport.ConservationReason.NOT_RUN,
+        pipe.getSpeciesConservationReport().getReason());
+  }
+
   static PipeFlowSystem runCompositionStep(int nodes, double timeStep) {
     PipeFlowSystem pipe = createInitializedPipe(nodes);
     pipe.setConservativeSpeciesTransport(true);

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -3,6 +3,7 @@ package neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport;
@@ -66,6 +67,19 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     assertTrue(thirtySecondFront > fifteenSecondFront,
         "A longer first-order implicit step must advance more inlet tracer mass.");
     assertTrue(fifteenSecond.getSpeciesConservationReport().isConverged());
+  }
+
+  @Test
+  void optInSpeciesTransportFailsLoudlyForReversedFlowWithoutLegacyStrictFlag() {
+    PipeFlowSystem pipe = createInitializedPipe(3);
+    pipe.setConservativeSpeciesTransport(true);
+    pipe.getTimeSeries().setTimes(new double[] { 0.0, 30.0 });
+    pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] { createGas(0.80, 0.20) });
+    pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);
+    pipe.getNode(2).setVelocityIn(-Math.abs(pipe.getNode(2).getVelocityIn().doubleValue()));
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class, () -> pipe.solveTransient(1));
+    assertTrue(exception.getMessage().contains("supports positive flow only"));
   }
 
   static PipeFlowSystem runCompositionStep(int nodes, double timeStep) {


### PR DESCRIPTION
## Engineering value

This is the first bounded Stage 2 increment after merged Stage 1 (#2747). It adds an **opt-in**, isothermal, positive-flow conservative species step to transient `PipeFlowSystem` solver type `1`, while leaving the default and legacy solver paths unchanged.

The finite-volume total-mass matrix remains authoritative. The implementation solves `n-1` component mass balances and obtains the final mass fraction by algebraic closure. It performs no clipping or post-hoc normalization, synchronizes the thermodynamic composition, and iterates hydraulics/species to the existing EOS-density tolerance.

## Frozen reproducer

Base: `52773a54a4325f56385315057427601ecd398beb`

- EOS/mixing rule: SRK / classic
- gas: methane/nitrogen, initially 95/5 mol%, inlet event 80/20 mol%
- state: 70 bara, 288.15 K, isothermal
- flow: 50 kg/s, strictly positive
- pipe: 15,000 m, 0.5 m ID, roughness `1e-5 m`, level elevation
- grid/timestep: 40 nodes, one 30 s step
- boundary ownership: node 0 prescribed inlet; last node prescribed outlet pressure; nodes 1..`N-2` accumulate inventory
- acceptance: every component relative inventory residual `<=1e-8`; fractions bounded and summing to one within `1e-12` without repair; thermodynamic/conservative mass fractions within `1e-10`; hydraulic equation residual `<=1e-10`; EOS/FV density residual `<=1e-8`; deterministic repeats; 15/30 s sensitivity; unchanged opt-out Stage 1 behavior

On unmodified master, legacy solver type `20` changed the nitrogen inventory by 2.781 kg while the integrated nitrogen boundary flux required 335.811 kg: residual **-333.031 kg**. The local nitrogen mole fraction moved only 5.0015% to 5.0384%.

## Method

For independent component (i) in physical cell (P), positive-flow implicit upwind transport uses:

```
(M_new[P] + dt * F_e) * w_new[i,P]
  = M_old[P] * w_old[i,P] + dt * F_w * w_new[i,W]
```

The last component is `1 - sum(w_independent)`. Component inventories and integrated inlet/outlet component masses are reported directly. Invalid sums, non-finite state, non-positive cell mass, and zero/reversed face flow fail explicitly.

A hydraulic/species fixed point repeats the merged Stage 1 coupled hydraulic/EOS solve, conservative species solve, and thermodynamic synchronization. It stores mass-fraction-change and EOS-density residual histories and stops only at the frozen tolerances.

This ordering is consistent with published work that couples or iterates composition tracking with hydraulic/thermal state and separately identifies first-order implicit numerical diffusion:
- [Chaczykowski et al. (2018)](https://doi.org/10.1016/j.jngse.2018.03.014)
- [Urh et al. (2024)](https://doi.org/10.1016/j.ijhydene.2023.11.031)
- [Chen et al. (2024)](https://doi.org/10.1016/j.energy.2024.131613)

No proprietary method or data is used, and no commercial-parity claim is made.

## Measured result

The frozen 40-node/30 s candidate reports:

| Criterion | Result |
|---|---:|
| maximum relative component inventory residual | `2.94613e-10` |
| methane inventory residual | `4.32e-12 kg` |
| nitrogen inventory residual | `-3.95215e-6 kg` |
| mass-fraction range | `[0.0841675, 0.915833]` |
| maximum sum-to-one error | `0.0` |
| thermodynamic mass-fraction synchronization error | `4.35763e-13` |
| coupling iterations | `19` |
| maximum mass-fraction change | `6.01588e-2 -> 4.93036e-11` |
| EOS/FV density residual | `1.96377e-2 -> 1.60350e-11` |

Two independently initialized 12-node/30 s runs produce bit-for-bit equal inventories, residuals, and nitrogen profiles. The 30 s first-cell front advances farther than the 15 s result. The pure transport kernel also reproduces the analytical implicit-upwind CFL=0.5 tracer recurrence `[1/3, 1/9, 1/27, 1/81]`.

Merged Stage 1 opt-out regressions remain unchanged across 3/12/40 nodes and 15/30 s: nonlinear residuals `7.83e-12` to `6.57e-11`, relative total-mass errors `8.32e-12` to `5.17e-11`, and five nonlinear iterations in each case.

## Public diagnostics and compatibility

- `PipeFlowSystem.setConservativeSpeciesTransport(boolean)`
- `PipeFlowSystem.getSpeciesConservationReport()`
- immutable/serializable `OnePhaseSpeciesConservationReport`, including JSON and defensive array copies
- feature default is `false`; existing solver selection and behavior are unchanged
- every failed hydraulic/species criterion on the opt-in path throws before state advancement; `setFailOnNonConvergence(...)` retains its legacy control for non-conservative paths
- no serialized field was removed and no tolerance was weakened
- the additional fixed-point work occurs only on the opt-in path; measured solver work for the frozen case is 19 coupling iterations

## Validation

Environment:
- OpenJDK `17.0.19`, compilation target `--release 8`
- Maven wrapper `3.9.12`
- Python `3.12.13` (no Python changes)
- public dependency jar `neqsim-3.16.0.jar` plus exact compiled merged Stage 1/master source overrides

Passed:
- Java 8 production/test slice compilation using `jdk.compiler`
- `ConservativeSpeciesTransportTestRunner`
- `OnePhaseConservativeSpeciesTestRunner`, including opt-in reversed-flow failure without the legacy strict flag
- `OnePhaseFlowConvergenceTestRunner`
- `BandedLinearSystemSolverTestRunner`
- `ProductionStage1Harness` (3/12/40 nodes, 15/30 s)
- Javadoc/doclint for changed production classes (only pre-existing missing-field-comment warnings)
- `git diff --check`
- Eclipse formatter profile applied with JDT 4.45 and verified idempotent

Exact focused compilation used:

```bash
java -m jdk.compiler/com.sun.tools.javac.Main --release 8   -cp /tmp/neqsim-stage1-verify-20260802-1331:/tmp/neqsim-3.16.0.jar   -d /tmp/neqsim-stage2-integration-classes-9   <changed production sources> <focused tests> <local runners>
```

The Maven test and Spotless goals could not resolve their plugins because Maven Central DNS is unavailable in the sandbox. Hosted CI remains authoritative for those gates; criteria were not bypassed or relaxed.

## Documentation impact

Updated `docs/fluidmechanics/single_phase_pipe_flow.md` with the equation, API, diagnostics, units, positive-flow/isothermal support boundary, literature, and remaining validation gates.

No notebook is added: a long-duration Colab example would be premature until repeated-step pulse propagation, analytical front/residence time, and grid/timestep convergence pass.

## Explicit limits and next gate

This PR does **not** complete Stage 2. It validates one conservative composition-change step only. It does not yet validate a 30-minute pulse and return, outlet breakthrough/recovery, repeated-event state ownership, long-duration component closure, grid convergence, zero/reversed flow, energy coupling, phase appearance, TVD, or physical dispersion. Solver types `10` and `20` remain outside this validated path.

Next dependency-ready experiment after this PR is accepted is a repeated-step pure-advection/front-speed and residence-time regression, followed by the synthetic 30-minute pulse inventory/breakthrough case. TVD and physical dispersion remain blocked.

## Persistent progress record — 2026-08-02 19:49 +0200

- masters inspected: NeqSim `52773a54a4325f56385315057427601ecd398beb`; NeqSim-Colab `613ea1b91b1d5c0cd270c4635484a544009d5b7a`
- Stage 1 merge verified: `4de26eb5cc3ebdfebce4d22d828db421a050be8f`; merged-master Stage 1 tests passed
- open PRs/reviews checked; #2760 touches TPflash only; #2756 overlaps the flow-assurance skill, so that optional skill edit was removed; stale #873 is semantically related but its old one-line `solveTDMA()` fix is already present on master and uses pre-refactor paths
- current gap: Stage 2 conservative one-phase species; one-step gate selected
- attempts: (1) 12 coupling iterations failed loudly at composition `9.97e-8` and density `3.25e-8`; (2) unchanged tolerances with a measured 100-iteration ceiling converged in 19; (3) final review made every opt-in coupling failure unconditional and added a public reversed-flow regression; (4) accepted review feedback added `COUPLING_NOT_CONVERGED` so fixed-point failure is distinct from thermodynamic-sync failure; no criterion changed
- baseline/improvement: nitrogen residual `-333.031 kg -> -3.95215e-6 kg`; maximum relative component residual `2.94613e-10`
- branch/head: `automation/stage2-conservative-species-step` / `6c89aae17bde067782760ac3dfd9ca6c3947b942`
- files: seven code/test/doc files; no unrelated edits or sensitive data
- notebook/render/catalog: no notebook change; Colab intentionally deferred; documentation updated and API exercised by the focused integration test
- infrastructure: local Maven Central DNS/plugin cache unavailable; hosted pre-commit currently fails only on unchanged master file `TPflashCubicRootSelectionTest.java`, while the dedicated Spotless format workflow passes
- next gate: CI/review, then repeated-step analytical advection and 30-minute pulse
