### PR TITLE
[AI-Assisted] fix: preserve directed capacity margins

### DIFF
--- a/.github/skills/neqsim-production-optimization/SKILL.md
+++ b/.github/skills/neqsim-production-optimization/SKILL.md
@@ -531,3 +531,4 @@ Map<String, Double> breakdown = decom.getBreakdown();
 | Over-producing from best wells | Premature water/gas coning | Balanced withdrawal per reservoir zone |
 | Ignoring backpressure coupling | Wrong wellhead pressures | Network solver captures well-to-well interactions |
 | Encoding minimum limits as design/max constraints | Safe NPSH, minimum-flow, or residence-time margins appear overloaded | Use `setMinValue(...)` without `setDesignValue(...)`; use a HARD constraint type for trip/infeasibility limits |
+| Recomputing every engineering margin as `design - current` | Minimum limits show infinite or incorrectly signed spare capacity | Use the evaluator/throughput result's `minimumConstraint` direction; feasible margins are `current - minimum` for lower limits and `maximum - current` for upper limits |

--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,22 @@
 
 ---
 
+## 2026-08-02 — Directed capacity margins in process-model throughput results
+
+### Corrected
+
+`ProcessModelSimulationEvaluator.BottleneckStatus` and `ThroughputCaseRow` now preserve whether an
+equipment bottleneck is minimum-directed. Minimum-only constraints report their finite
+`getDisplayDesignValue()` limit instead of the internal unset `Double.MAX_VALUE` design sentinel.
+Engineering-unit `capacityMargin` is `current - minimum` for lower limits and remains
+`limit - current` for upper limits, so non-negative consistently means feasible.
+
+### Compatibility and reporting
+
+Existing constructors remain available and default to maximum-directed behavior. JSON case rows
+and CSV throughput traces add `minimumConstraint`; the CSV column is inserted after `designValue`.
+No thermodynamic, hydraulic, utilization, feasibility, or optimizer search calculation changed.
+
 ## 2026-08-02 — DNV-RP-F101 isolated metal-loss pressure screening added
 
 ### Added

--- a/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
+++ b/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
@@ -85,6 +85,13 @@ separation,separator,installedGasCapacity,wells::feed.flowRate,15000,16500,kg/hr
 
 By default, the helper uses explicit installed capacity limits attached directly to equipment. Enable strategy-generated constraints with `setIncludeStrategyCapacityConstraints(true)` when you want generic screening limits to participate in addition to installed design data.
 
+Each throughput row records `minimumConstraint` so engineering-unit margins remain unambiguous.
+For a maximum-directed limit, `capacityMargin = limit - current`; for a minimum-directed limit,
+`capacityMargin = current - limit`. A non-negative margin is therefore feasible in both cases, and
+the reported `designValue` is the applicable finite limit even when the equipment constraint was
+constructed with `setMinValue(...)` only. `utilizationMargin` remains `1 - utilization` for both
+directions.
+
 ## Key Concepts
 
 ### Decision Variables (Parameters)

--- a/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
+++ b/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
@@ -2061,3 +2061,4 @@ double util = expander.getMaxUtilization(); // |getPower| / 5000 kW, no spurious
 - [Mechanical Design](mechanical_design)
 - [Optimizer Plugin Architecture](optimization/OPTIMIZER_PLUGIN_ARCHITECTURE)
 - [Optimization Examples](../examples/index)
+

--- a/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
+++ b/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
@@ -244,6 +244,12 @@ CapacityConstraint speedConstraint = new CapacityConstraint("speed", "RPM", Cons
 > service- and pump-specific; use vendor or applicable Hydraulic Institute design data instead of
 > treating a generic screening default as an approved installed limit.
 
+`ProcessModelSimulationEvaluator.BottleneckStatus` and `ThroughputCaseRow` preserve this direction
+with `isMinimumConstraint()`. Their reported design value is the applicable finite limit. The
+engineering-unit capacity margin is positive on the feasible side: `limit - current` for maximum
+constraints and `current - limit` for minimum constraints. This convention prevents a minimum-only
+constraint's internal unset design sentinel from appearing in JSON or CSV throughput results.
+
 ### 2. CapacityConstrainedEquipment (Interface)
 
 Interface that equipment classes implement to participate in capacity tracking.
@@ -2055,4 +2061,3 @@ double util = expander.getMaxUtilization(); // |getPower| / 5000 kW, no spurious
 - [Mechanical Design](mechanical_design)
 - [Optimizer Plugin Architecture](optimization/OPTIMIZER_PLUGIN_ARCHITECTURE)
 - [Optimization Examples](../examples/index)
-

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
@@ -873,6 +873,9 @@ public class ProcessModelSimulationEvaluator implements Serializable {
     /** Design constraint value. */
     private double designValue;
 
+    /** Whether the active constraint is a minimum-directed limit. */
+    private boolean minimumConstraint;
+
     /** Constraint unit. */
     private String unit;
 
@@ -897,12 +900,31 @@ public class ProcessModelSimulationEvaluator implements Serializable {
      */
     public BottleneckStatus(String areaName, String equipmentName, String constraintName, double utilization,
         double currentValue, double designValue, String unit, boolean feasible) {
+      this(areaName, equipmentName, constraintName, utilization, currentValue, designValue, false, unit, feasible);
+    }
+
+    /**
+     * Creates a bottleneck status with explicit limit direction.
+     *
+     * @param areaName process area name
+     * @param equipmentName equipment name
+     * @param constraintName constraint name
+     * @param utilization utilization fraction
+     * @param currentValue current constraint value
+     * @param designValue reported design or minimum limit
+     * @param minimumConstraint true when values below the limit are worse
+     * @param unit constraint unit
+     * @param feasible true when utilization is less than or equal to one
+     */
+    public BottleneckStatus(String areaName, String equipmentName, String constraintName, double utilization,
+        double currentValue, double designValue, boolean minimumConstraint, String unit, boolean feasible) {
       this.areaName = areaName;
       this.equipmentName = equipmentName;
       this.constraintName = constraintName;
       this.utilization = utilization;
       this.currentValue = currentValue;
       this.designValue = designValue;
+      this.minimumConstraint = minimumConstraint;
       this.unit = unit;
       this.feasible = feasible;
     }
@@ -980,6 +1002,15 @@ public class ProcessModelSimulationEvaluator implements Serializable {
      */
     public double getDesignValue() {
       return designValue;
+    }
+
+    /**
+     * Checks whether the bottleneck is a minimum-directed constraint.
+     *
+     * @return true when values below the reported design value are worse
+     */
+    public boolean isMinimumConstraint() {
+      return minimumConstraint;
     }
 
     /**
@@ -1857,8 +1888,8 @@ public class ProcessModelSimulationEvaluator implements Serializable {
           if (!Double.isNaN(utilization) && utilization > highestUtilization) {
             highestUtilization = utilization;
             active = new BottleneckStatus(areaName, equipment.getName(), entry.getKey(), utilization,
-                capacityConstraint.getCurrentValue(), capacityConstraint.getDesignValue(), capacityConstraint.getUnit(),
-                utilization <= 1.0);
+                capacityConstraint.getCurrentValue(), capacityConstraint.getDisplayDesignValue(),
+                capacityConstraint.isMinimumConstraint(), capacityConstraint.getUnit(), utilization <= 1.0);
           }
         }
       }

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelThroughputResult.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelThroughputResult.java
@@ -271,7 +271,7 @@ public class ProcessModelThroughputResult implements Serializable {
     try {
       writer.write("caseNumber,throughputMultiplier,objectiveValue,feasible,"
           + "simulationConverged,activeArea,activeEquipment,activeConstraint,"
-          + "utilization,currentValue,designValue,capacityMargin,utilizationMargin,unit,"
+          + "utilization,currentValue,designValue,minimumConstraint,capacityMargin,utilizationMargin,unit,"
           + "errorMessage,evaluationTimeMs");
       writer.newLine();
       for (ThroughputCaseRow row : caseRows) {
@@ -296,6 +296,8 @@ public class ProcessModelThroughputResult implements Serializable {
         writer.write(Double.toString(row.getCurrentValue()));
         writer.write(",");
         writer.write(Double.toString(row.getDesignValue()));
+        writer.write(",");
+        writer.write(Boolean.toString(row.isMinimumConstraint()));
         writer.write(",");
         writer.write(Double.toString(row.getCapacityMargin()));
         writer.write(",");

--- a/src/main/java/neqsim/process/util/optimizer/ThroughputCaseRow.java
+++ b/src/main/java/neqsim/process/util/optimizer/ThroughputCaseRow.java
@@ -50,6 +50,9 @@ public class ThroughputCaseRow implements Serializable {
   /** Bottleneck design value. */
   private final double designValue;
 
+  /** Whether the active bottleneck is a minimum-directed constraint. */
+  private final boolean minimumConstraint;
+
   /** Remaining capacity in engineering units. */
   private final double capacityMargin;
 
@@ -90,6 +93,37 @@ public class ThroughputCaseRow implements Serializable {
       double objectiveValue, boolean feasible, boolean simulationConverged, String activeArea, String activeEquipment,
       String activeConstraint, double utilization, double currentValue, double designValue, double capacityMargin,
       double utilizationMargin, String unit, String errorMessage, long evaluationTimeMs) {
+    this(caseNumber, throughputMultiplier, producerMultipliers, objectiveValue, feasible, simulationConverged,
+        activeArea, activeEquipment, activeConstraint, utilization, currentValue, designValue, false, capacityMargin,
+        utilizationMargin, unit, errorMessage, evaluationTimeMs);
+  }
+
+  /**
+   * Creates a throughput case row with explicit capacity-limit direction.
+   *
+   * @param caseNumber case sequence number
+   * @param throughputMultiplier scalar throughput multiplier
+   * @param producerMultipliers producer multipliers used in the case
+   * @param objectiveValue raw objective value
+   * @param feasible true when all hard constraints are satisfied
+   * @param simulationConverged true when the model converged
+   * @param activeArea active bottleneck area name
+   * @param activeEquipment active bottleneck equipment name
+   * @param activeConstraint active bottleneck constraint name
+   * @param utilization active bottleneck utilization
+   * @param currentValue current bottleneck load
+   * @param designValue bottleneck design or minimum limit
+   * @param minimumConstraint true when values below the limit are worse
+   * @param capacityMargin signed remaining capacity in engineering units
+   * @param utilizationMargin remaining utilization margin
+   * @param unit bottleneck unit
+   * @param errorMessage error message if the case failed
+   * @param evaluationTimeMs evaluation wall-clock time in milliseconds
+   */
+  public ThroughputCaseRow(int caseNumber, double throughputMultiplier, Map<String, Double> producerMultipliers,
+      double objectiveValue, boolean feasible, boolean simulationConverged, String activeArea, String activeEquipment,
+      String activeConstraint, double utilization, double currentValue, double designValue, boolean minimumConstraint,
+      double capacityMargin, double utilizationMargin, String unit, String errorMessage, long evaluationTimeMs) {
     this.caseNumber = caseNumber;
     this.throughputMultiplier = throughputMultiplier;
     this.producerMultipliers = new LinkedHashMap<String, Double>(producerMultipliers);
@@ -102,6 +136,7 @@ public class ThroughputCaseRow implements Serializable {
     this.utilization = utilization;
     this.currentValue = currentValue;
     this.designValue = designValue;
+    this.minimumConstraint = minimumConstraint;
     this.capacityMargin = capacityMargin;
     this.utilizationMargin = utilizationMargin;
     this.unit = unit;
@@ -127,12 +162,13 @@ public class ThroughputCaseRow implements Serializable {
     }
     double currentValue = bottleneck.getCurrentValue();
     double designValue = bottleneck.getDesignValue();
-    double capacityMargin = designValue - currentValue;
+    boolean minimumConstraint = bottleneck.isMinimumConstraint();
+    double capacityMargin = minimumConstraint ? currentValue - designValue : designValue - currentValue;
     double utilization = bottleneck.getUtilization();
     return new ThroughputCaseRow(caseNumber, throughputMultiplier, producerMultipliers, objectiveValue,
         evaluation.isFeasible(), evaluation.isSimulationConverged(), bottleneck.getAreaName(),
         bottleneck.getEquipmentName(), bottleneck.getConstraintName(), utilization, currentValue, designValue,
-        capacityMargin, 1.0 - utilization, bottleneck.getUnit(), evaluation.getErrorMessage(),
+        minimumConstraint, capacityMargin, 1.0 - utilization, bottleneck.getUnit(), evaluation.getErrorMessage(),
         evaluation.getEvaluationTimeMs());
   }
 
@@ -245,6 +281,15 @@ public class ThroughputCaseRow implements Serializable {
   }
 
   /**
+   * Checks whether the active bottleneck is a minimum-directed constraint.
+   *
+   * @return true when values below the design value are worse
+   */
+  public boolean isMinimumConstraint() {
+    return minimumConstraint;
+  }
+
+  /**
    * Gets remaining capacity.
    *
    * @return remaining capacity in engineering units
@@ -308,6 +353,7 @@ public class ThroughputCaseRow implements Serializable {
     map.put("utilization", utilization);
     map.put("currentValue", currentValue);
     map.put("designValue", designValue);
+    map.put("minimumConstraint", minimumConstraint);
     map.put("capacityMargin", capacityMargin);
     map.put("utilizationMargin", utilizationMargin);
     map.put("unit", unit);

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
@@ -170,6 +170,40 @@ class ProcessModelSimulationEvaluatorTest {
   }
 
   /**
+   * Verifies that minimum-directed capacity limits retain their engineering-unit limit in
+   * model-level bottleneck reporting.
+   */
+  @Test
+  void minimumCapacityConstraintReportsItsFiniteLimit() {
+    final ModelFixture fixture = createModelFixture();
+    CapacityConstraint minimumHeadroom = new CapacityConstraint("availableHeadroom", "m", ConstraintType.HARD)
+        .setMinValue(45.0).setSeverity(ConstraintSeverity.HARD).setValueSupplier(new DoubleSupplier() {
+          /** {@inheritDoc} */
+          @Override
+          public double getAsDouble() {
+            return 50.0;
+          }
+        });
+    fixture.separator.clearCapacityConstraints();
+    fixture.separator.addCapacityConstraint(minimumHeadroom);
+
+    ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    evaluator.setIncludeStrategyCapacityConstraints(false);
+    evaluator.addParameter("wells::feed.flowRate", 5000.0, 20000.0, "kg/hr")
+        .addEquipmentCapacityConstraints();
+
+    ProcessModelSimulationEvaluator.EvaluationResult result = evaluator.evaluate(new double[] { 10000.0 });
+    ProcessModelSimulationEvaluator.BottleneckStatus bottleneck = result.getActiveBottleneck();
+
+    assertTrue(result.isFeasible());
+    assertEquals(0.9, bottleneck.getUtilization(), 1.0e-12);
+    assertEquals(50.0, bottleneck.getCurrentValue(), 1.0e-12);
+    assertEquals(45.0, bottleneck.getDesignValue(), 1.0e-12,
+        "minimum limit must not be reported as Double.MAX_VALUE");
+    assertTrue(bottleneck.isMinimumConstraint());
+  }
+
+  /**
    * Verifies exported problem metadata for external optimizer bridges.
    */
   @Test

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
@@ -170,8 +170,8 @@ class ProcessModelSimulationEvaluatorTest {
   }
 
   /**
-   * Verifies that minimum-directed capacity limits retain their engineering-unit limit in
-   * model-level bottleneck reporting.
+   * Verifies that minimum-directed capacity limits retain their engineering-unit limit in model-level bottleneck
+   * reporting.
    */
   @Test
   void minimumCapacityConstraintReportsItsFiniteLimit() {
@@ -189,8 +189,7 @@ class ProcessModelSimulationEvaluatorTest {
 
     ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
     evaluator.setIncludeStrategyCapacityConstraints(false);
-    evaluator.addParameter("wells::feed.flowRate", 5000.0, 20000.0, "kg/hr")
-        .addEquipmentCapacityConstraints();
+    evaluator.addParameter("wells::feed.flowRate", 5000.0, 20000.0, "kg/hr").addEquipmentCapacityConstraints();
 
     ProcessModelSimulationEvaluator.EvaluationResult result = evaluator.evaluate(new double[] { 10000.0 });
     ProcessModelSimulationEvaluator.BottleneckStatus bottleneck = result.getActiveBottleneck();
@@ -198,8 +197,7 @@ class ProcessModelSimulationEvaluatorTest {
     assertTrue(result.isFeasible());
     assertEquals(0.9, bottleneck.getUtilization(), 1.0e-12);
     assertEquals(50.0, bottleneck.getCurrentValue(), 1.0e-12);
-    assertEquals(45.0, bottleneck.getDesignValue(), 1.0e-12,
-        "minimum limit must not be reported as Double.MAX_VALUE");
+    assertEquals(45.0, bottleneck.getDesignValue(), 1.0e-12, "minimum limit must not be reported as Double.MAX_VALUE");
     assertTrue(bottleneck.isMinimumConstraint());
   }
 

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelThroughputOptimizerTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelThroughputOptimizerTest.java
@@ -127,6 +127,25 @@ class ProcessModelThroughputOptimizerTest {
   }
 
   /**
+   * Adds a synthetic minimum headroom constraint that decreases as production rises.
+   *
+   * @param fixture model fixture
+   * @param minimumHeadroom minimum permitted headroom
+   */
+  private void addMinimumHeadroomCapacity(final ModelFixture fixture, double minimumHeadroom) {
+    CapacityConstraint availableHeadroom = new CapacityConstraint("availableHeadroom", "kg/hr", ConstraintType.HARD)
+        .setMinValue(minimumHeadroom).setSeverity(ConstraintSeverity.HARD).setValueSupplier(new DoubleSupplier() {
+          /** {@inheritDoc} */
+          @Override
+          public double getAsDouble() {
+            return 50000.0 - fixture.feed.getFlowRate("kg/hr");
+          }
+        });
+    fixture.separator.clearCapacityConstraints();
+    fixture.separator.addCapacityConstraint(availableHeadroom);
+  }
+
+  /**
    * Creates a throughput optimizer with feed scaling and gas export objective.
    *
    * @param fixture model fixture
@@ -189,6 +208,38 @@ class ProcessModelThroughputOptimizerTest {
     assertTrue(fixture.separator.getCapacityConstraints().containsKey("installedGasCapacity"));
     assertEquals(1.5, result.getOptimalMultiplier(), 0.02);
     assertTrue(new String(Files.readAllBytes(caseTable), StandardCharsets.UTF_8).contains("activeConstraint"));
+  }
+
+  /**
+   * Verifies finite, correctly signed engineering margins for minimum-directed bottlenecks.
+   *
+   * @throws Exception if CSV export fails
+   */
+  @Test
+  void minimumConstraintProducesDirectedThroughputMargins() throws Exception {
+    ModelFixture fixture = createModelFixture();
+    addMinimumHeadroomCapacity(fixture, 35000.0);
+
+    ProcessModelThroughputResult result = createOptimizer(fixture).findMaximumThroughput(1.0, 2.0, 0.01);
+    ThroughputCaseRow best = result.getBestFeasibleCase();
+    ThroughputCaseRow firstLimit = result.getFirstInfeasibleCase();
+
+    assertNotNull(best);
+    assertNotNull(firstLimit);
+    assertEquals(1.5, result.getOptimalMultiplier(), 0.02);
+    assertTrue(best.isMinimumConstraint());
+    assertTrue(firstLimit.isMinimumConstraint());
+    assertEquals(35000.0, best.getDesignValue(), 1.0e-12);
+    assertTrue(best.getCapacityMargin() >= 0.0, "safe minimum constraint must have non-negative margin");
+    assertTrue(firstLimit.getCapacityMargin() < 0.0, "violated minimum constraint must have negative margin");
+    assertTrue(Double.isFinite(best.getCapacityMargin()));
+    assertTrue(Double.isFinite(firstLimit.getCapacityMargin()));
+
+    Path caseTable = temporaryDirectory.resolve("minimum_constraint_trace.csv");
+    result.exportToCSV(caseTable);
+    String csv = new String(Files.readAllBytes(caseTable), StandardCharsets.UTF_8);
+    assertTrue(csv.contains("minimumConstraint"));
+    assertTrue(result.toJson().contains("\"minimumConstraint\": true"));
   }
 
   /**


### PR DESCRIPTION
## Engineering problem

Current `master` (`52773a54a4325f56385315057427601ecd398beb`) preserves minimum-directed utilization inside `CapacityConstraint`, but model-level bottleneck reporting discards that direction:

- `BottleneckStatus` stores `getDesignValue()`, which is the internal unset sentinel `Double.MAX_VALUE` for a `setMinValue(...)`-only constraint.
- `ThroughputCaseRow` always computes `capacityMargin = designValue - currentValue`.

A minimum headroom constraint therefore reports effectively infinite positive spare capacity whether it is safe or violated.

## Reproducible baseline

Executed against the packaged NeqSim 3.16.0 API using a HARD minimum constraint with a 45 m required headroom:

| Case | Current (m) | Limit reported before | Utilization | Engineering margin before |
|---|---:|---:|---:|---:|
| Safe | 50.0 | 1.7976931348623157E308 | 0.900 | 1.7976931348623157E308 |
| Violated | 40.0 | 1.7976931348623157E308 | 1.125 | 1.7976931348623157E308 |

The analytical margin must be `current - minimum`: +5 m safe and −5 m violated.

## Bounded change

- Preserve `minimumConstraint` in `ProcessModelSimulationEvaluator.BottleneckStatus`.
- Report `CapacityConstraint.getDisplayDesignValue()`, so minimum-only limits are finite.
- Preserve direction in `ThroughputCaseRow`, its JSON map, and CSV export.
- Compute engineering-unit margin as:
  - maximum constraint: `limit - current`
  - minimum constraint: `current - limit`
- Keep the existing public constructors as compatibility overloads defaulting to maximum-directed behavior.
- Add focused model-level and throughput-search regressions.
- Update adjacent API guidance, the capacity guide, changelog, and production-optimization skill.

No thermodynamic, hydraulic, utilization, feasibility, search, equipment, or mechanical-design calculation is changed.

## Acceptance and measured result

Executed with an SRK/classic methane–ethane feed, valve, and separator composed as two named `ProcessSystem` areas in a `ProcessModel`:

| Case | Current | Limit | Direction | Utilization | Margin | Feasible |
|---|---:|---:|---|---:|---:|---|
| Minimum safe | 50.0 m | 45.0 m | minimum | 0.900 | +5.0 m | true |
| Minimum violated | 40.0 m | 45.0 m | minimum | 1.125 | −5.0 m | false |
| Maximum control | 50.0 | 55.0 | maximum | 0.909 | +5.0 | true |

The same model-level regression is repeated through the scalar throughput optimizer with a synthetic headroom that falls monotonically as production rises. It checks finite positive/negative case-row margins, the 1.5 throughput limit, and the JSON/CSV direction field.

## Validation

Local environment:

- OpenJDK Runtime 17.0.19
- ECJ 3.45.0 compiling with Java 8 source/target
- packaged NeqSim 3.16.0 as the independent runtime dependency
- changed Java production slice: Java 8 ECJ compilation **pass**
- both focused JUnit source files: Java 8 ECJ signature compilation **pass**
- executed two-area NeqSim process regression: safe/violated/max-control results above **pass**
- `git diff --check`: **pass**
- connector compare: 9 intended files only; no unrelated or sensitive material
- hosted repository CI: pending on this draft PR

The local Maven run is blocked before compilation because the available cache contains only a failed marker for `maven-enforcer-plugin:3.6.3`, while Maven Central is unavailable in this runtime. No criterion or test was weakened; GitHub Actions must provide Spotless, Javadocs, static analysis, and the full focused/regression execution.

## Engineering basis and provenance

This is a reporting correction derived from the existing NeqSim minimum-constraint equation and the invariant that a positive signed margin denotes feasibility. It supports integrated production optimization where lower and upper equipment constraints must remain distinguishable.

Established simulator evidence reviewed:

- SLB PIPESIM network optimization: https://www.slb.com/products-and-services/delivering-digital-at-scale/software/pipesim-steady-state-multiphase-flow-simulator/pipesim-network-simulation-optimization
- Petroleum Experts GAP/IPM: https://www.petex.com/pe-engineering/ipm-suite/gap/
- Hoffmann et al., coupled reservoir-to-sales optimization under operational constraints: https://doi.org/10.1007/s13202-019-0613-1

These sources support full-system constrained optimization and traceable bottleneck handling. The signed-margin convention is a NeqSim implementation inference; no proprietary method or data is copied.

## Compatibility, performance, and risk

- Source compatibility: existing `BottleneckStatus` and `ThroughputCaseRow` constructors remain.
- Serialized additions default to `false` for legacy maximum-directed rows.
- JSON adds `minimumConstraint`.
- CSV inserts `minimumConstraint` after `designValue`; consumers that bind by column position must update.
- Runtime/performance impact: negligible boolean propagation and one branch per case row.
- Numerical risk: low; utilization and feasibility are unchanged.
- Excluded: representing simultaneous independent upper and lower limits in one `CapacityConstraint`, changing installed-capacity CSV input, selecting service-specific limits, or changing optimizer algorithms.

## Documentation impact

Updated:

- `docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md`
- `docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md`
- `CHANGELOG_AGENT_NOTES.md`
- `.github/skills/neqsim-production-optimization/SKILL.md`

No notebook changed; notebook execution/rendering impact: none.

## Persistent loop history — 2026-08-02 20:02 Europe/Oslo

- Inspected master: `52773a54a4325f56385315057427601ecd398beb`.
- Prior program PR #2742: merged externally; its loop record identified this direction-loss gap.
- Reviewed all open PRs; none overlaps model-level directed margin reporting. Relevant current PRs #2761, #2760, #2756, and #2740 affect other subsystems.
- Reviewed current evaluator, throughput row/result, capacity constraint, focused tests, capacity/external-optimizer docs, production-optimization skill, master commit, and available status data.
- Candidates considered: installed-vs-autosized Colab extension; broader constraint schema redesign; directed model-level margins. Chosen: directed margins because it is foundational, reproduced, backward-compatible, and independent of unavailable notebook rendering.
- Attempt 1: reproduced infinite safe and violated margins on unmodified packaged API.
- Attempt 2: propagated finite limit and direction; Java 8 production slice compiled.
- Attempt 3: executed safe, violated, and maximum-control process cases; all analytical values matched.
- Attempt 4: added throughput-search/serialization regressions, compiled focused test sources, updated documentation, and verified the intended diff.
- Attempt 5: hosted CI/review inspection follows this draft publication.
- Branch: `automation/report-directed-capacity-margins`.
- Files changed: 9.
- Blocker: local full Maven/Spotless/Javadocs unavailable because the enforcer plugin is absent from the offline cache.
- Next dependency-ready step after this PR: expose limit provenance/validity/confidence alongside direction in throughput case rows before adding installed-versus-auto-sized Colab comparisons.

This is an AI-assisted contribution; the reproduced engineering behavior, code, tests, and documentation were inspected and understood.

## Latest hosted status — head `ff32b66eb2b9118b3ed29d1f9b66d95df18b6bc2`

- Copilot reviewed all 9 changed files and generated no comments or unresolved threads.
- Spotless format patch: **success** after applying the formatter's three changes to the new evaluator regression.
- Java 21 Javadocs: **success**.
- Skills/agents lint: **success**.
- PaperLab replication gate: **success**.
- Documentation coverage, CodeQL, fast tests, and slow-test shards: in progress at the last inspection.
- Pre-commit: the changed files are clean; the job now fails only on pre-existing formatting in
  `src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCubicRootSelectionTest.java` from
  current `master`. That unrelated file is not changed here and belongs to the active TP-flash workstream.
