### PR TITLE
[AI-Assisted] fix(column): include fixed reflux product in MESH balance

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -171,8 +171,9 @@ DistillationColumn.ReboilerMode reboilerMode = column.getReboilerMode();
 `setCondenserLiquidReflux(value, unit)` configures the `LIQUID_REFLUX_SPLIT` mode. Use it instead
 of calling `setCondenserMode(LIQUID_REFLUX_SPLIT)` directly because the fixed reflux flow is
 required.
-The condenser exposes the non-refluxed condensate through `getLiquidProductStream()`; MESH material
-and per-tray balance diagnostics count that stream as a third top-stage outlet.
+The condenser exposes the non-refluxed condensate through
+`column.getCondenser().getLiquidProductStream()`; MESH material and per-tray balance diagnostics
+count that stream as a third top-stage outlet.
 
 ## Solver Options
 

--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -171,6 +171,8 @@ DistillationColumn.ReboilerMode reboilerMode = column.getReboilerMode();
 `setCondenserLiquidReflux(value, unit)` configures the `LIQUID_REFLUX_SPLIT` mode. Use it instead
 of calling `setCondenserMode(LIQUID_REFLUX_SPLIT)` directly because the fixed reflux flow is
 required.
+The condenser exposes the non-refluxed condensate through `getLiquidProductStream()`; MESH material
+and per-tray balance diagnostics count that stream as a third top-stage outlet.
 
 ## Solver Options
 

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnMeshResidualEvaluator.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnMeshResidualEvaluator.java
@@ -87,8 +87,7 @@ final class ColumnMeshResidualEvaluator {
    * @param state column state snapshot
    * @param builder residual builder
    */
-  private static void addMaterialResiduals(DistillationColumn column, ColumnMeshState state,
-      ResidualBuilder builder) {
+  private static void addMaterialResiduals(DistillationColumn column, ColumnMeshState state, ResidualBuilder builder) {
     String[] componentNames = state.getComponentNames();
     for (int tray = 0; tray < state.getTrayCount(); tray++) {
       for (int comp = 0; comp < state.getComponentCount(); comp++) {
@@ -97,8 +96,7 @@ final class ColumnMeshResidualEvaluator {
         double feedIn = state.getFeedComponentFlow(tray, comp);
         double vaporOut = state.getVaporComponentFlow(tray, comp);
         double liquidOut = state.getLiquidComponentFlow(tray, comp);
-        double condenserLiquidProductOut = condenserLiquidProductComponentFlow(column, tray,
-            componentNames[comp]);
+        double condenserLiquidProductOut = condenserLiquidProductComponentFlow(column, tray, componentNames[comp]);
         double inlet = vaporIn + liquidIn + feedIn;
         double outlet = vaporOut + liquidOut + condenserLiquidProductOut;
         double scale = Math.max(ColumnMeshState.getMinimumScale(), Math.abs(inlet) + Math.abs(outlet));

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnMeshResidualEvaluator.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnMeshResidualEvaluator.java
@@ -53,6 +53,7 @@ final class ColumnMeshResidualEvaluator {
    */
   static double evaluateMaxTrayMaterialImbalance(DistillationColumn column) {
     ColumnMeshState state = ColumnMeshState.from(column);
+    String[] componentNames = state.getComponentNames();
     double worstImbalance = 0.0;
     for (int tray = 0; tray < state.getTrayCount(); tray++) {
       double imbalance = 0.0;
@@ -64,7 +65,7 @@ final class ColumnMeshResidualEvaluator {
         double vaporOut = state.getVaporComponentFlow(tray, comp);
         double liquidOut = state.getLiquidComponentFlow(tray, comp);
         double condenserLiquidProductOut = condenserLiquidProductComponentFlow(column, tray,
-            state.getComponentNames()[comp]);
+            componentNames[comp]);
         double inlet = vaporIn + liquidIn + feedIn;
         double outlet = vaporOut + liquidOut + condenserLiquidProductOut;
         imbalance += Math.abs(outlet - inlet);
@@ -132,7 +133,11 @@ final class ColumnMeshResidualEvaluator {
     if (liquidProduct == null || liquidProduct.getFluid() == null) {
       return 0.0;
     }
-    return liquidProduct.getFluid().getComponent(componentName).getTotalFlowRate("mol/hr");
+    try {
+      return liquidProduct.getFluid().getComponent(componentName).getTotalFlowRate("mol/hr");
+    } catch (Exception ex) {
+      return 0.0;
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnMeshResidualEvaluator.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnMeshResidualEvaluator.java
@@ -29,7 +29,7 @@ final class ColumnMeshResidualEvaluator {
   static ColumnMeshResidual evaluate(DistillationColumn column) {
     ColumnMeshState state = ColumnMeshState.from(column);
     ResidualBuilder builder = new ResidualBuilder();
-    addMaterialResiduals(state, builder);
+    addMaterialResiduals(column, state, builder);
     addEquilibriumResiduals(column, state, builder);
     addSummationResiduals(state, builder);
     addEnergyResiduals(column, builder);
@@ -63,8 +63,10 @@ final class ColumnMeshResidualEvaluator {
         double feedIn = state.getFeedComponentFlow(tray, comp);
         double vaporOut = state.getVaporComponentFlow(tray, comp);
         double liquidOut = state.getLiquidComponentFlow(tray, comp);
+        double condenserLiquidProductOut = condenserLiquidProductComponentFlow(column, tray,
+            state.getComponentNames()[comp]);
         double inlet = vaporIn + liquidIn + feedIn;
-        double outlet = vaporOut + liquidOut;
+        double outlet = vaporOut + liquidOut + condenserLiquidProductOut;
         imbalance += Math.abs(outlet - inlet);
         throughput += Math.abs(inlet) + Math.abs(outlet);
       }
@@ -81,10 +83,12 @@ final class ColumnMeshResidualEvaluator {
   /**
    * Add tray component material residuals.
    *
+   * @param column column to inspect
    * @param state column state snapshot
    * @param builder residual builder
    */
-  private static void addMaterialResiduals(ColumnMeshState state, ResidualBuilder builder) {
+  private static void addMaterialResiduals(DistillationColumn column, ColumnMeshState state,
+      ResidualBuilder builder) {
     String[] componentNames = state.getComponentNames();
     for (int tray = 0; tray < state.getTrayCount(); tray++) {
       for (int comp = 0; comp < state.getComponentCount(); comp++) {
@@ -93,12 +97,44 @@ final class ColumnMeshResidualEvaluator {
         double feedIn = state.getFeedComponentFlow(tray, comp);
         double vaporOut = state.getVaporComponentFlow(tray, comp);
         double liquidOut = state.getLiquidComponentFlow(tray, comp);
+        double condenserLiquidProductOut = condenserLiquidProductComponentFlow(column, tray,
+            componentNames[comp]);
         double inlet = vaporIn + liquidIn + feedIn;
-        double outlet = vaporOut + liquidOut;
+        double outlet = vaporOut + liquidOut + condenserLiquidProductOut;
         double scale = Math.max(ColumnMeshState.getMinimumScale(), Math.abs(inlet) + Math.abs(outlet));
         builder.add((outlet - inlet) / scale, ColumnMeshEquationType.MATERIAL, tray, componentNames[comp]);
       }
     }
+  }
+
+  /**
+   * Get the external condenser liquid-product component flow for a terminal material balance.
+   *
+   * <p>
+   * In fixed-liquid-reflux mode the condenser splitter returns stream zero to the column and exposes stream one as an
+   * additional external product. {@link ColumnMeshState} records the returned liquid stream, so the external product
+   * must be added separately to the top-stage outlets.
+   * </p>
+   *
+   * @param column column to inspect
+   * @param trayIndex zero-based tray index
+   * @param componentName component name
+   * @return external liquid-product component flow in mol/hr, or zero when the mode is inactive
+   */
+  private static double condenserLiquidProductComponentFlow(DistillationColumn column, int trayIndex,
+      String componentName) {
+    if (!column.hasCondenser() || trayIndex != column.getTrays().size() - 1) {
+      return 0.0;
+    }
+    Condenser condenser = column.getCondenser();
+    if (!condenser.isSeparation_with_liquid_reflux()) {
+      return 0.0;
+    }
+    StreamInterface liquidProduct = condenser.getLiquidProductStream();
+    if (liquidProduct == null || liquidProduct.getFluid() == null) {
+      return 0.0;
+    }
+    return liquidProduct.getFluid().getComponent(componentName).getTotalFlowRate("mol/hr");
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnMeshResidualEvaluator.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnMeshResidualEvaluator.java
@@ -64,8 +64,7 @@ final class ColumnMeshResidualEvaluator {
         double feedIn = state.getFeedComponentFlow(tray, comp);
         double vaporOut = state.getVaporComponentFlow(tray, comp);
         double liquidOut = state.getLiquidComponentFlow(tray, comp);
-        double condenserLiquidProductOut = condenserLiquidProductComponentFlow(column, tray,
-            componentNames[comp]);
+        double condenserLiquidProductOut = condenserLiquidProductComponentFlow(column, tray, componentNames[comp]);
         double inlet = vaporIn + liquidIn + feedIn;
         double outlet = vaporOut + liquidOut + condenserLiquidProductOut;
         imbalance += Math.abs(outlet - inlet);

--- a/src/test/java/neqsim/process/equipment/distillation/FixedLiquidRefluxMeshBalanceTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/FixedLiquidRefluxMeshBalanceTest.java
@@ -1,0 +1,219 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for fixed-liquid condenser product accounting in MESH diagnostics.
+ *
+ * @author esol
+ * @version 1.0
+ */
+public class FixedLiquidRefluxMeshBalanceTest {
+  /** Feed mass rate used by the industrial-style fractionator cases in kg/hr. */
+  private static final double FEED_FLOW_KG_PER_HOUR = 5000.0;
+
+  /**
+   * The condenser liquid product is an external outlet and must be included in the top-stage material equations.
+   */
+  @Test
+  public void fixedLiquidProductClosesTopStageMaterialBalance() {
+    assertFixedLiquidRefluxCase(100.0);
+    assertFixedLiquidRefluxCase(120.0);
+  }
+
+  /**
+   * Build and validate one nearby fixed-liquid-reflux operating point.
+   *
+   * @param refluxFlowKgPerHour specified liquid return in kg/hr
+   */
+  private static void assertFixedLiquidRefluxCase(double refluxFlowKgPerHour) {
+    ColumnCase columnCase = buildColumn(refluxFlowKgPerHour);
+    DistillationColumn column = columnCase.column;
+    column.run();
+
+    StreamInterface overhead = column.getGasOutStream();
+    StreamInterface bottoms = column.getLiquidOutStream();
+    StreamInterface condenserLiquidProduct = column.getCondenser().getLiquidProductStream();
+    assertNotNull(condenserLiquidProduct, "fixed-liquid mode must expose the separated liquid product");
+    assertEquals(refluxFlowKgPerHour, column.getCondenser().getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-6,
+        "condenser liquid return must satisfy its fixed flow specification");
+
+    assertTrue(column.getLastTrayMaterialBalanceError() <= column.getTrayMaterialBalanceTolerance(),
+        column.getConvergenceDiagnostics());
+    assertTrue(column.getLastMeshMaterialResidualNorm() <= column.getTrayMaterialBalanceTolerance(),
+        column.getConvergenceDiagnostics());
+    assertTrue(column.getLastEnergyResidual() <= column.getEnthalpyBalanceTolerance(),
+        column.getConvergenceDiagnostics());
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+
+    assertThreeProductBalance(columnCase.feed, overhead, bottoms, condenserLiquidProduct);
+    assertPhysicalStream(overhead);
+    assertPhysicalStream(bottoms);
+    assertPhysicalStream(condenserLiquidProduct);
+    assertEquals(20.0, columnCase.feed.getTemperature("C"), 1.0e-9,
+        "column iteration must preserve the caller-owned feed state");
+
+    double overheadFlow = overhead.getFlowRate("mol/hr");
+    double bottomsFlow = bottoms.getFlowRate("mol/hr");
+    double condenserProductFlow = condenserLiquidProduct.getFlowRate("mol/hr");
+    double[] overheadComposition = overhead.getThermoSystem().getMolarComposition().clone();
+    double[] bottomsComposition = bottoms.getThermoSystem().getMolarComposition().clone();
+    double[] condenserProductComposition =
+        condenserLiquidProduct.getThermoSystem().getMolarComposition().clone();
+
+    column.run();
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertEquals(overheadFlow, column.getGasOutStream().getFlowRate("mol/hr"),
+        Math.max(1.0e-9, Math.abs(overheadFlow) * 1.0e-8), "unchanged overhead flow must repeat");
+    assertEquals(bottomsFlow, column.getLiquidOutStream().getFlowRate("mol/hr"),
+        Math.max(1.0e-9, Math.abs(bottomsFlow) * 1.0e-8), "unchanged bottoms flow must repeat");
+    assertEquals(condenserProductFlow, column.getCondenser().getLiquidProductStream().getFlowRate("mol/hr"),
+        Math.max(1.0e-9, Math.abs(condenserProductFlow) * 1.0e-8),
+        "unchanged condenser liquid product must repeat");
+    assertCompositionEquals(overheadComposition,
+        column.getGasOutStream().getThermoSystem().getMolarComposition());
+    assertCompositionEquals(bottomsComposition,
+        column.getLiquidOutStream().getThermoSystem().getMolarComposition());
+    assertCompositionEquals(condenserProductComposition,
+        column.getCondenser().getLiquidProductStream().getThermoSystem().getMolarComposition());
+    assertThreeProductBalance(columnCase.feed, column.getGasOutStream(), column.getLiquidOutStream(),
+        column.getCondenser().getLiquidProductStream());
+  }
+
+  /**
+   * Build a six-stage SRK hydrocarbon column with a partial condenser and fixed liquid return.
+   *
+   * @param refluxFlowKgPerHour specified liquid return in kg/hr
+   * @return feed and unrun column
+   */
+  private static ColumnCase buildColumn(double refluxFlowKgPerHour) {
+    SystemInterface fluid = new SystemSrkEos(293.15, 10.0);
+    fluid.addComponent("propane", 40.0);
+    fluid.addComponent("n-butane", 30.0);
+    fluid.addComponent("n-pentane", 30.0);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("fixed liquid reflux feed", fluid);
+    feed.setFlowRate(FEED_FLOW_KG_PER_HOUR, "kg/hr");
+    feed.setTemperature(20.0, "C");
+    feed.setPressure(10.0, "bara");
+    feed.run();
+
+    DistillationColumn column = new DistillationColumn("fixed liquid reflux balance column", 6, true, true);
+    column.addFeedStream(feed, 3);
+    column.setTopPressure(10.0);
+    column.setBottomPressure(10.5);
+    column.getCondenser().setOutTemperature(293.15);
+    column.getReboiler().setOutTemperature(353.15);
+    column.getCondenser().setSeparation_with_liquid_reflux(true, refluxFlowKgPerHour, "kg/hr");
+    column.setSolverType(DistillationColumn.SolverType.DAMPED_SUBSTITUTION);
+    column.setRelaxationFactor(0.2);
+    column.setMaxNumberOfIterations(120, true);
+    return new ColumnCase(feed, column);
+  }
+
+  /**
+   * Verify total and component molar closure across overhead, bottoms and condenser liquid product.
+   *
+   * @param feed column feed
+   * @param overhead overhead product
+   * @param bottoms bottoms product
+   * @param condenserLiquidProduct condenser liquid product
+   */
+  private static void assertThreeProductBalance(StreamInterface feed, StreamInterface overhead,
+      StreamInterface bottoms, StreamInterface condenserLiquidProduct) {
+    double feedFlow = feed.getFlowRate("mol/hr");
+    double productFlow = overhead.getFlowRate("mol/hr") + bottoms.getFlowRate("mol/hr")
+        + condenserLiquidProduct.getFlowRate("mol/hr");
+    assertEquals(feedFlow, productFlow, Math.max(1.0e-6, Math.abs(feedFlow) * 5.0e-3),
+        "three external products must close total molar flow");
+
+    String[] componentNames = feed.getThermoSystem().getComponentNames();
+    double[] feedComposition = feed.getThermoSystem().getMolarComposition();
+    for (int componentIndex = 0; componentIndex < componentNames.length; componentIndex++) {
+      double feedComponentFlow = feedFlow * feedComposition[componentIndex];
+      double productComponentFlow = componentFlow(overhead, componentNames[componentIndex])
+          + componentFlow(bottoms, componentNames[componentIndex])
+          + componentFlow(condenserLiquidProduct, componentNames[componentIndex]);
+      assertEquals(feedComponentFlow, productComponentFlow,
+          Math.max(1.0e-6, Math.abs(feedComponentFlow) * 5.0e-3),
+          "component balance must close for " + componentNames[componentIndex]);
+    }
+  }
+
+  /**
+   * Get one component molar flow.
+   *
+   * @param stream stream to inspect
+   * @param componentName component name
+   * @return component flow in mol/hr
+   */
+  private static double componentFlow(StreamInterface stream, String componentName) {
+    return stream.getFluid().getComponent(componentName).getTotalFlowRate("mol/hr");
+  }
+
+  /**
+   * Verify finite physical bounds for a product stream.
+   *
+   * @param stream stream to inspect
+   */
+  private static void assertPhysicalStream(StreamInterface stream) {
+    double flow = stream.getFlowRate("mol/hr");
+    assertTrue(Double.isFinite(flow) && flow >= 0.0, "product flow must be finite and non-negative");
+    assertTrue(Double.isFinite(stream.getPressure("bara")) && stream.getPressure("bara") > 0.0,
+        "product pressure must be physical");
+    if (flow > 0.0) {
+      assertTrue(Double.isFinite(stream.getTemperature("K")) && stream.getTemperature("K") > 150.0
+          && stream.getTemperature("K") < 800.0, "flowing product temperature must be physical");
+    }
+    double compositionSum = 0.0;
+    for (double moleFraction : stream.getThermoSystem().getMolarComposition()) {
+      assertTrue(Double.isFinite(moleFraction) && moleFraction >= -1.0e-12
+          && moleFraction <= 1.0 + 1.0e-12, "product composition must be finite and bounded");
+      compositionSum += moleFraction;
+    }
+    assertEquals(1.0, compositionSum, 1.0e-8, "product composition must be normalized");
+  }
+
+  /**
+   * Verify deterministic composition repeatability.
+   *
+   * @param expected expected composition
+   * @param actual actual composition
+   */
+  private static void assertCompositionEquals(double[] expected, double[] actual) {
+    assertEquals(expected.length, actual.length, "component count must remain unchanged");
+    for (int componentIndex = 0; componentIndex < expected.length; componentIndex++) {
+      assertEquals(expected[componentIndex], actual[componentIndex], 1.0e-8,
+          "component composition must repeat at index " + componentIndex);
+    }
+  }
+
+  /** Feed and column references for one regression case. */
+  private static final class ColumnCase {
+    /** Caller-owned feed. */
+    private final Stream feed;
+    /** Configured column. */
+    private final DistillationColumn column;
+
+    /**
+     * Create a case.
+     *
+     * @param feed caller-owned feed
+     * @param column configured column
+     */
+    private ColumnCase(Stream feed, DistillationColumn column) {
+      this.feed = feed;
+      this.column = column;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/FixedLiquidRefluxMeshBalanceTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/FixedLiquidRefluxMeshBalanceTest.java
@@ -48,7 +48,7 @@ public class FixedLiquidRefluxMeshBalanceTest {
 
     assertTrue(column.getLastTrayMaterialBalanceError() <= column.getTrayMaterialBalanceTolerance(),
         column.getConvergenceDiagnostics());
-    assertTrue(column.getLastMeshMaterialResidualNorm() <= column.getTrayMaterialBalanceTolerance(),
+    assertTrue(column.getLastMeshMaterialResidualNorm() <= column.getMeshResidualTolerance(),
         column.getConvergenceDiagnostics());
     assertTrue(column.getLastEnergyResidual() <= column.getEnthalpyBalanceTolerance(),
         column.getConvergenceDiagnostics());
@@ -110,7 +110,7 @@ public class FixedLiquidRefluxMeshBalanceTest {
     column.setBottomPressure(10.5);
     column.getCondenser().setOutTemperature(293.15);
     column.getReboiler().setOutTemperature(353.15);
-    column.getCondenser().setSeparation_with_liquid_reflux(true, refluxFlowKgPerHour, "kg/hr");
+    column.setCondenserLiquidReflux(refluxFlowKgPerHour, "kg/hr");
     column.setSolverType(DistillationColumn.SolverType.DAMPED_SUBSTITUTION);
     column.setRelaxationFactor(0.2);
     column.setMaxNumberOfIterations(120, true);

--- a/src/test/java/neqsim/process/equipment/distillation/FixedLiquidRefluxMeshBalanceTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/FixedLiquidRefluxMeshBalanceTest.java
@@ -66,8 +66,7 @@ public class FixedLiquidRefluxMeshBalanceTest {
     double condenserProductFlow = condenserLiquidProduct.getFlowRate("mol/hr");
     double[] overheadComposition = overhead.getThermoSystem().getMolarComposition().clone();
     double[] bottomsComposition = bottoms.getThermoSystem().getMolarComposition().clone();
-    double[] condenserProductComposition =
-        condenserLiquidProduct.getThermoSystem().getMolarComposition().clone();
+    double[] condenserProductComposition = condenserLiquidProduct.getThermoSystem().getMolarComposition().clone();
 
     column.run();
 
@@ -77,12 +76,9 @@ public class FixedLiquidRefluxMeshBalanceTest {
     assertEquals(bottomsFlow, column.getLiquidOutStream().getFlowRate("mol/hr"),
         Math.max(1.0e-9, Math.abs(bottomsFlow) * 1.0e-8), "unchanged bottoms flow must repeat");
     assertEquals(condenserProductFlow, column.getCondenser().getLiquidProductStream().getFlowRate("mol/hr"),
-        Math.max(1.0e-9, Math.abs(condenserProductFlow) * 1.0e-8),
-        "unchanged condenser liquid product must repeat");
-    assertCompositionEquals(overheadComposition,
-        column.getGasOutStream().getThermoSystem().getMolarComposition());
-    assertCompositionEquals(bottomsComposition,
-        column.getLiquidOutStream().getThermoSystem().getMolarComposition());
+        Math.max(1.0e-9, Math.abs(condenserProductFlow) * 1.0e-8), "unchanged condenser liquid product must repeat");
+    assertCompositionEquals(overheadComposition, column.getGasOutStream().getThermoSystem().getMolarComposition());
+    assertCompositionEquals(bottomsComposition, column.getLiquidOutStream().getThermoSystem().getMolarComposition());
     assertCompositionEquals(condenserProductComposition,
         column.getCondenser().getLiquidProductStream().getThermoSystem().getMolarComposition());
     assertThreeProductBalance(columnCase.feed, column.getGasOutStream(), column.getLiquidOutStream(),
@@ -129,8 +125,8 @@ public class FixedLiquidRefluxMeshBalanceTest {
    * @param bottoms bottoms product
    * @param condenserLiquidProduct condenser liquid product
    */
-  private static void assertThreeProductBalance(StreamInterface feed, StreamInterface overhead,
-      StreamInterface bottoms, StreamInterface condenserLiquidProduct) {
+  private static void assertThreeProductBalance(StreamInterface feed, StreamInterface overhead, StreamInterface bottoms,
+      StreamInterface condenserLiquidProduct) {
     double feedFlow = feed.getFlowRate("mol/hr");
     double productFlow = overhead.getFlowRate("mol/hr") + bottoms.getFlowRate("mol/hr")
         + condenserLiquidProduct.getFlowRate("mol/hr");
@@ -144,8 +140,7 @@ public class FixedLiquidRefluxMeshBalanceTest {
       double productComponentFlow = componentFlow(overhead, componentNames[componentIndex])
           + componentFlow(bottoms, componentNames[componentIndex])
           + componentFlow(condenserLiquidProduct, componentNames[componentIndex]);
-      assertEquals(feedComponentFlow, productComponentFlow,
-          Math.max(1.0e-6, Math.abs(feedComponentFlow) * 5.0e-3),
+      assertEquals(feedComponentFlow, productComponentFlow, Math.max(1.0e-6, Math.abs(feedComponentFlow) * 5.0e-3),
           "component balance must close for " + componentNames[componentIndex]);
     }
   }
@@ -177,8 +172,8 @@ public class FixedLiquidRefluxMeshBalanceTest {
     }
     double compositionSum = 0.0;
     for (double moleFraction : stream.getThermoSystem().getMolarComposition()) {
-      assertTrue(Double.isFinite(moleFraction) && moleFraction >= -1.0e-12
-          && moleFraction <= 1.0 + 1.0e-12, "product composition must be finite and bounded");
+      assertTrue(Double.isFinite(moleFraction) && moleFraction >= -1.0e-12 && moleFraction <= 1.0 + 1.0e-12,
+          "product composition must be finite and bounded");
       compositionSum += moleFraction;
     }
     assertEquals(1.0, compositionSum, 1.0e-8, "product composition must be normalized");


### PR DESCRIPTION
## Problem

Fixed-liquid condenser operation creates three top-stage outlets: vapor product, liquid reflux returned to the column, and a separated liquid product. The MESH material evaluator counted only vapor and reflux, so it reported valid condensate withdrawal as leaked material.

## Root cause and affected solvers

`ColumnMeshState` correctly stores the condenser's returned liquid stream. Both the scaled MATERIAL residual and the throughput-weighted per-tray balance then formed the top-stage outlet as vapor plus returned liquid only. This affects diagnostics and convergence gating shared by MESH-aware column solvers; thermodynamic flashes and sequential tray equations are unchanged.

## Baseline reproduction

Regression-only head `28a9809` adds an industrial-style six-stage SRK propane/n-butane/n-pentane column at 10.0–10.5 bara and 5000 kg/hr. It exercises 100 and 120 kg/hr fixed liquid return. Earlier source-level reproduction measured approximately 0.41 per-tray imbalance against a 0.02 tolerance despite overall three-product closure. The exact hosted regression-only rerun is still pending because subsequent corrective pushes cancelled earlier attempts.

The regression checks:
- the fixed liquid-return specification;
- total and component closure across overhead, bottoms and condenser liquid product;
- energy, MESH and per-tray diagnostics;
- physical temperature, pressure, flow and composition bounds;
- caller feed preservation and unchanged-run repeatability;
- a nearby 120 kg/hr operating point.

## Algorithmic change

The evaluator now adds `column.getCondenser().getLiquidProductStream()` component flow as a third top-stage outlet only when fixed-liquid-reflux mode is active. The same term is used in both material diagnostics. Component names are cached once per evaluation, and the new lookup follows the evaluator's existing fail-safe diagnostic behavior.

No flash, splitter, damping, tolerance, specification or solver-iteration equation changes.

## Validation status

Final head: `73aa5ac`.

- PaperLab passes.
- The final exact-head Copilot review reports no new findings.
- Documentation search, CodeQL, Spotless and the Java build/test/Javadoc matrix are running.
- Pre-commit currently stops on two pre-existing Spotless violations on `master` in `TPmultiflash.java` and `TPmultiflashPhaseDisappearanceTest.java`; the PR's three intended files are formatter-clean.
- Exact before/after residual values and the complete Java matrix remain required before this draft can be considered ready.

No speedup is claimed; this is diagnostic correctness with one avoided component-name clone per inner-loop evaluation.

## Compatibility and risk

The public API, serialization, stream states, calculation identity and physical results are unchanged. Ratio reflux, total condensers and columns without condensers return zero for the additional outlet term and retain their prior behavior.

## Documentation impact

The distillation guide now identifies the fixed-liquid condensate API and states that MESH/per-tray diagnostics count it as a third top-stage outlet.