### PR TITLE
[AI-Assisted] test(pipe): validate repeated species pulse

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -296,14 +296,31 @@ relative inventory residuals, boundedness and sum-to-one diagnostics, thermodyna
 synchronization error, and hydraulic/species residual histories. Its array getters return
 defensive copies and `toJson()` is suitable for Python-side result capture.
 
-This path has currently been regression-tested for a single isothermal composition-change step
-with positive flow. Zero or reversed face flow fails explicitly because an external upwind
-composition is not yet defined. Once enabled, every failed hydraulic/species criterion throws so
-that a failed conservative state cannot advance to another timestep. Thirty-minute pulse
-breakthrough/recovery, repeated-event propagation, analytical front speed and residence time,
-grid/time convergence, thermal coupling, and phase appearance remain validation gates. The
-spreading of the present first-order upwind scheme is numerical; there is no physical
-axial-dispersion model.
+For constant cell mass $M$, face mass flow $\dot m$, and timestep $\Delta t$, define the cell
+Courant number $\lambda=\dot m\Delta t/M$, $p=\lambda/(1+\lambda)$, and
+$q=1/(1+\lambda)$. The closed-form response in cell $j$ after $n$ repeated steps from an initially
+tracer-free pipe is
+
+$$\omega_j^n=\sum_{k=0}^{n-1}\binom{k+j}{j}p^{j+1}q^k.$$
+
+This negative-binomial response is used as an independent regression target. Its outlet impulse
+first moment also recovers the inventory-over-flow residence time
+
+$$\tau=\frac{\sum_P M_P}{\dot m}.$$
+
+The validated first-order kernel matches the closed form through 20 repeated steps at
+$\lambda=0.5$, recovers a 3600 s residence time, conserves a synthetic 1800 s pulse over six
+residence times, and reduces pulse error when the grid and timestep are jointly refined from
+12 cells/60 s to 24 cells/30 s. An end-to-end SRK/classic regression also propagates an 1800 s
+methane/nitrogen inlet event through a 3000 m isothermal pipe, verifies breakthrough and recovery,
+and telescopes every immutable step report into a cumulative nitrogen balance.
+
+Zero or reversed face flow still fails explicitly because an external upwind composition is not
+yet defined. Once enabled, every failed hydraulic/species criterion throws so that a failed
+conservative state cannot advance to another timestep. Full hydraulic/EOS grid-and-timestep
+convergence, thermal coupling, phase appearance, higher-order convection, and physical dispersion
+remain validation gates. The spreading of the present first-order upwind scheme is numerical;
+there is no physical axial-dispersion model.
 
 ## Compositional Tracking
 
@@ -385,10 +402,11 @@ The steady-state solver has been validated for:
 ## Known Limitations
 
 1. **Single-phase only**: No phase transition handling
-2. **Component-transport validation is incomplete**: The opt-in solver-type-1 path demonstrates
-   conservative, bounded one-step transport without normalization. Analytical front speed,
-   repeated-step and pulse breakthrough, and grid/time convergence are not yet established. Do
-   not use it yet as a validated long-duration compositional-tracking prediction.
+2. **Component-transport validation remains bounded**: Repeated-step analytical advection,
+   inventory-over-flow residence time, an 1800 s pulse, cumulative component closure, and
+   first-order kernel grid/time refinement are established for positive isothermal flow. Full
+   hydraulic/EOS grid/time convergence, thermal coupling, phase appearance, and network junctions
+   are not yet established.
 3. **No physical axial dispersion model**: Existing advection-scheme spreading is numerical and
    must not be interpreted as molecular or turbulent dispersion.
 4. **Positive-flow diagnostic boundary**: Current transient mass diagnostics reject reverse
@@ -402,7 +420,7 @@ The steady-state solver has been validated for:
 Planned dependency order is:
 - Coupled hydraulic/EOS and total-mass convergence for solver type `1`
 - Conservative repeated-step and pulse validation after the one-step component balance
-- Dimensionally valid higher-order convection only after first-order analytical validation
+- Dimensionally valid higher-order convection after the established first-order analytical gate
 - Explicit physical dispersion as a separate, documented model
 
 ### TimeSeries Best Practices

--- a/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
@@ -64,18 +64,15 @@ class ConservativeSpeciesTransportTest {
 
     for (int step = 1; step <= 20; step++) {
       OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
-          new String[] { "carrier", "tracer" }, profile, new double[] { 0.0, 1.0 },
-          cellMasses, cellMasses, faceFlows, timeStepSeconds);
+          new String[] { "carrier", "tracer" }, profile, new double[] { 0.0, 1.0 }, cellMasses, cellMasses, faceFlows,
+          timeStepSeconds);
 
       assertTrue(report.isConverged(), report.getMessage());
-      assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-14,
-          report.getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-14, report.getMessage());
       profile = report.getMassFractionProfile();
       for (int cell = 0; cell < cells; cell++) {
-        double expected = negativeBinomialStepResponse(step, cell, successProbability,
-            failureProbability);
-        assertEquals(expected, profile[1][cell], 2.0e-14,
-            "step=" + step + ", cell=" + cell);
+        double expected = negativeBinomialStepResponse(step, cell, successProbability, failureProbability);
+        assertEquals(expected, profile[1][cell], 2.0e-14, "step=" + step + ", cell=" + cell);
       }
     }
 
@@ -90,9 +87,8 @@ class ConservativeSpeciesTransportTest {
     for (int step = 1; step <= 480; step++) {
       double tracerInlet = step == 1 ? 1.0 : 0.0;
       OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
-          new String[] { "carrier", "tracer" }, profile,
-          new double[] { 1.0 - tracerInlet, tracerInlet }, cellMasses, cellMasses,
-          faceFlows, timeStepSeconds);
+          new String[] { "carrier", "tracer" }, profile, new double[] { 1.0 - tracerInlet, tracerInlet }, cellMasses,
+          cellMasses, faceFlows, timeStepSeconds);
       assertTrue(report.isConverged(), report.getMessage());
       profile = report.getMassFractionProfile();
       double outletImpulse = profile[1][cells - 1];
@@ -119,8 +115,8 @@ class ConservativeSpeciesTransportTest {
     double coarseError = plugFlowPulseError(12, 60.0);
     double refinedError = plugFlowPulseError(24, 30.0);
     assertTrue(refinedError < 0.8 * coarseError,
-        "Expected joint grid/time refinement to reduce numerical pulse spreading: coarse="
-            + coarseError + ", refined=" + refinedError);
+        "Expected joint grid/time refinement to reduce numerical pulse spreading: coarse=" + coarseError + ", refined="
+            + refinedError);
   }
 
   @Test
@@ -153,8 +149,8 @@ class ConservativeSpeciesTransportTest {
     assertFalse(OnePhaseSpeciesConservationReport.notRun().toJson().contains("NaN"));
   }
 
-  private static PulseResult runPulse(int cells, double timeStepSeconds,
-      double residenceTimeSeconds, double pulseDurationSeconds, double totalTimeSeconds) {
+  private static PulseResult runPulse(int cells, double timeStepSeconds, double residenceTimeSeconds,
+      double pulseDurationSeconds, double totalTimeSeconds) {
     double massFlowKgPerSecond = 1.0;
     double cellMassKg = residenceTimeSeconds * massFlowKgPerSecond / cells;
     int pulseSteps = (int) Math.round(pulseDurationSeconds / timeStepSeconds);
@@ -173,19 +169,15 @@ class ConservativeSpeciesTransportTest {
     for (int step = 1; step <= totalSteps; step++) {
       double tracerInlet = step <= pulseSteps ? 1.0 : 0.0;
       OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
-          new String[] { "carrier", "tracer" }, profile,
-          new double[] { 1.0 - tracerInlet, tracerInlet }, cellMasses, cellMasses,
-          faceFlows, timeStepSeconds);
+          new String[] { "carrier", "tracer" }, profile, new double[] { 1.0 - tracerInlet, tracerInlet }, cellMasses,
+          cellMasses, faceFlows, timeStepSeconds);
 
       assertTrue(report.isConverged(), report.getMessage());
-      assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-12,
-          report.getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-12, report.getMessage());
       profile = report.getMassFractionProfile();
       double outletMassFraction = profile[1][cells - 1];
-      double expectedOutlet = negativeBinomialStepResponse(step, cells - 1,
-          successProbability, failureProbability)
-          - negativeBinomialStepResponse(step - pulseSteps, cells - 1,
-              successProbability, failureProbability);
+      double expectedOutlet = negativeBinomialStepResponse(step, cells - 1, successProbability, failureProbability)
+          - negativeBinomialStepResponse(step - pulseSteps, cells - 1, successProbability, failureProbability);
       assertEquals(expectedOutlet, outletMassFraction, 2.0e-13, "step=" + step);
       cumulativeInletTracerKg += report.getInletBoundaryMassKg()[1];
       cumulativeOutletTracerKg += report.getOutletBoundaryMassKg()[1];
@@ -199,11 +191,9 @@ class ConservativeSpeciesTransportTest {
     for (int cell = 0; cell < cells; cell++) {
       finalTracerInventoryKg += cellMasses[cell] * profile[1][cell];
     }
-    double globalResidualKg = finalTracerInventoryKg - cumulativeInletTracerKg
-        + cumulativeOutletTracerKg;
-    return new PulseResult(pulseSteps, peakStep, peakOutletMassFraction,
-        profile[1][cells - 1], cumulativeInletTracerKg, cumulativeOutletTracerKg,
-        globalResidualKg);
+    double globalResidualKg = finalTracerInventoryKg - cumulativeInletTracerKg + cumulativeOutletTracerKg;
+    return new PulseResult(pulseSteps, peakStep, peakOutletMassFraction, profile[1][cells - 1], cumulativeInletTracerKg,
+        cumulativeOutletTracerKg, globalResidualKg);
   }
 
   private static double plugFlowPulseError(int cells, double timeStepSeconds) {
@@ -219,22 +209,20 @@ class ConservativeSpeciesTransportTest {
     for (int step = 1; step <= totalSteps; step++) {
       double tracerInlet = step <= pulseSteps ? 1.0 : 0.0;
       OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
-          new String[] { "carrier", "tracer" }, profile,
-          new double[] { 1.0 - tracerInlet, tracerInlet }, cellMasses, cellMasses,
-          faceFlows, timeStepSeconds);
+          new String[] { "carrier", "tracer" }, profile, new double[] { 1.0 - tracerInlet, tracerInlet }, cellMasses,
+          cellMasses, faceFlows, timeStepSeconds);
       assertTrue(report.isConverged(), report.getMessage());
       profile = report.getMassFractionProfile();
       double lagTimeSeconds = (step - 1) * timeStepSeconds;
       double idealOutlet = lagTimeSeconds >= residenceTimeSeconds
           && lagTimeSeconds < residenceTimeSeconds + pulseDurationSeconds ? 1.0 : 0.0;
-      absoluteErrorSeconds += Math.abs(profile[1][cells - 1] - idealOutlet)
-          * timeStepSeconds;
+      absoluteErrorSeconds += Math.abs(profile[1][cells - 1] - idealOutlet) * timeStepSeconds;
     }
     return absoluteErrorSeconds / pulseDurationSeconds;
   }
 
-  private static double negativeBinomialStepResponse(int steps, int cell,
-      double successProbability, double failureProbability) {
+  private static double negativeBinomialStepResponse(int steps, int cell, double successProbability,
+      double failureProbability) {
     if (steps <= 0) {
       return 0.0;
     }
@@ -273,9 +261,8 @@ class ConservativeSpeciesTransportTest {
     private final double cumulativeOutletTracerKg;
     private final double globalInventoryResidualKg;
 
-    private PulseResult(int pulseSteps, int peakStep, double peakOutletMassFraction,
-        double finalOutletMassFraction, double cumulativeInletTracerKg,
-        double cumulativeOutletTracerKg, double globalInventoryResidualKg) {
+    private PulseResult(int pulseSteps, int peakStep, double peakOutletMassFraction, double finalOutletMassFraction,
+        double cumulativeInletTracerKg, double cumulativeOutletTracerKg, double globalInventoryResidualKg) {
       this.pulseSteps = pulseSteps;
       this.peakStep = peakStep;
       this.peakOutletMassFraction = peakOutletMassFraction;

--- a/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
@@ -50,6 +50,80 @@ class ConservativeSpeciesTransportTest {
   }
 
   @Test
+  void repeatedStepMatchesClosedFormAndInventoryOverFlowResidenceTime() {
+    int cells = 8;
+    double cellMassKg = 10.0;
+    double massFlowKgPerSecond = 1.0;
+    double timeStepSeconds = 5.0;
+    double courantNumber = massFlowKgPerSecond * timeStepSeconds / cellMassKg;
+    double successProbability = courantNumber / (1.0 + courantNumber);
+    double failureProbability = 1.0 / (1.0 + courantNumber);
+    double[][] profile = uniformProfile(cells, 0.0);
+    double[] cellMasses = filled(cells, cellMassKg);
+    double[] faceFlows = filled(cells + 1, massFlowKgPerSecond);
+
+    for (int step = 1; step <= 20; step++) {
+      OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
+          new String[] { "carrier", "tracer" }, profile, new double[] { 0.0, 1.0 },
+          cellMasses, cellMasses, faceFlows, timeStepSeconds);
+
+      assertTrue(report.isConverged(), report.getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-14,
+          report.getMessage());
+      profile = report.getMassFractionProfile();
+      for (int cell = 0; cell < cells; cell++) {
+        double expected = negativeBinomialStepResponse(step, cell, successProbability,
+            failureProbability);
+        assertEquals(expected, profile[1][cell], 2.0e-14,
+            "step=" + step + ", cell=" + cell);
+      }
+    }
+
+    cells = 12;
+    cellMassKg = 300.0;
+    timeStepSeconds = 60.0;
+    profile = uniformProfile(cells, 0.0);
+    cellMasses = filled(cells, cellMassKg);
+    faceFlows = filled(cells + 1, massFlowKgPerSecond);
+    double impulseSum = 0.0;
+    double firstMomentSeconds = 0.0;
+    for (int step = 1; step <= 480; step++) {
+      double tracerInlet = step == 1 ? 1.0 : 0.0;
+      OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
+          new String[] { "carrier", "tracer" }, profile,
+          new double[] { 1.0 - tracerInlet, tracerInlet }, cellMasses, cellMasses,
+          faceFlows, timeStepSeconds);
+      assertTrue(report.isConverged(), report.getMessage());
+      profile = report.getMassFractionProfile();
+      double outletImpulse = profile[1][cells - 1];
+      impulseSum += outletImpulse;
+      firstMomentSeconds += (step - 1) * timeStepSeconds * outletImpulse;
+    }
+
+    double expectedResidenceTimeSeconds = cells * cellMassKg / massFlowKgPerSecond;
+    assertEquals(1.0, impulseSum, 1.0e-10);
+    assertEquals(expectedResidenceTimeSeconds, firstMomentSeconds / impulseSum, 1.0e-6);
+  }
+
+  @Test
+  void thirtyMinutePulseClosesLongDurationInventoryAndImprovesWithRefinement() {
+    PulseResult pulse = runPulse(12, 60.0, 3600.0, 1800.0, 21600.0);
+
+    assertEquals(0.0, pulse.globalInventoryResidualKg, 1.0e-9);
+    assertEquals(1800.0, pulse.cumulativeInletTracerKg, 1.0e-12);
+    assertTrue(pulse.peakStep > pulse.pulseSteps);
+    assertTrue(pulse.peakOutletMassFraction > 0.2);
+    assertTrue(pulse.finalOutletMassFraction < 1.0e-8);
+    assertTrue(pulse.cumulativeOutletTracerKg / pulse.cumulativeInletTracerKg > 0.999999);
+
+    double coarseError = plugFlowPulseError(12, 60.0);
+    double refinedError = plugFlowPulseError(24, 30.0);
+    assertTrue(refinedError < 0.8 * coarseError,
+        "Expected joint grid/time refinement to reduce numerical pulse spreading: coarse="
+            + coarseError + ", refined=" + refinedError);
+  }
+
+  @Test
   void rejectsInvalidClosureAndReversedFlowWithoutRepairingInputs() {
     assertFalse(OnePhaseSpeciesConservationReport.ConservationReason.COUPLING_NOT_CONVERGED.isConverged());
     String[] names = { "carrier", "tracer" };
@@ -77,5 +151,138 @@ class ConservativeSpeciesTransportTest {
     first[0][0] = -1.0;
     assertEquals(0.8, report.getMassFractionProfile()[0][0], 1.0e-15);
     assertFalse(OnePhaseSpeciesConservationReport.notRun().toJson().contains("NaN"));
+  }
+
+  private static PulseResult runPulse(int cells, double timeStepSeconds,
+      double residenceTimeSeconds, double pulseDurationSeconds, double totalTimeSeconds) {
+    double massFlowKgPerSecond = 1.0;
+    double cellMassKg = residenceTimeSeconds * massFlowKgPerSecond / cells;
+    int pulseSteps = (int) Math.round(pulseDurationSeconds / timeStepSeconds);
+    int totalSteps = (int) Math.round(totalTimeSeconds / timeStepSeconds);
+    double[][] profile = uniformProfile(cells, 0.0);
+    double[] cellMasses = filled(cells, cellMassKg);
+    double[] faceFlows = filled(cells + 1, massFlowKgPerSecond);
+    double cumulativeInletTracerKg = 0.0;
+    double cumulativeOutletTracerKg = 0.0;
+    double peakOutletMassFraction = 0.0;
+    int peakStep = 0;
+    double courantNumber = massFlowKgPerSecond * timeStepSeconds / cellMassKg;
+    double successProbability = courantNumber / (1.0 + courantNumber);
+    double failureProbability = 1.0 / (1.0 + courantNumber);
+
+    for (int step = 1; step <= totalSteps; step++) {
+      double tracerInlet = step <= pulseSteps ? 1.0 : 0.0;
+      OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
+          new String[] { "carrier", "tracer" }, profile,
+          new double[] { 1.0 - tracerInlet, tracerInlet }, cellMasses, cellMasses,
+          faceFlows, timeStepSeconds);
+
+      assertTrue(report.isConverged(), report.getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-12,
+          report.getMessage());
+      profile = report.getMassFractionProfile();
+      double outletMassFraction = profile[1][cells - 1];
+      double expectedOutlet = negativeBinomialStepResponse(step, cells - 1,
+          successProbability, failureProbability)
+          - negativeBinomialStepResponse(step - pulseSteps, cells - 1,
+              successProbability, failureProbability);
+      assertEquals(expectedOutlet, outletMassFraction, 2.0e-13, "step=" + step);
+      cumulativeInletTracerKg += report.getInletBoundaryMassKg()[1];
+      cumulativeOutletTracerKg += report.getOutletBoundaryMassKg()[1];
+      if (outletMassFraction > peakOutletMassFraction) {
+        peakOutletMassFraction = outletMassFraction;
+        peakStep = step;
+      }
+    }
+
+    double finalTracerInventoryKg = 0.0;
+    for (int cell = 0; cell < cells; cell++) {
+      finalTracerInventoryKg += cellMasses[cell] * profile[1][cell];
+    }
+    double globalResidualKg = finalTracerInventoryKg - cumulativeInletTracerKg
+        + cumulativeOutletTracerKg;
+    return new PulseResult(pulseSteps, peakStep, peakOutletMassFraction,
+        profile[1][cells - 1], cumulativeInletTracerKg, cumulativeOutletTracerKg,
+        globalResidualKg);
+  }
+
+  private static double plugFlowPulseError(int cells, double timeStepSeconds) {
+    double residenceTimeSeconds = 3600.0;
+    double pulseDurationSeconds = 1800.0;
+    double cellMassKg = residenceTimeSeconds / cells;
+    int pulseSteps = (int) Math.round(pulseDurationSeconds / timeStepSeconds);
+    int totalSteps = (int) Math.round(3.0 * residenceTimeSeconds / timeStepSeconds);
+    double[][] profile = uniformProfile(cells, 0.0);
+    double[] cellMasses = filled(cells, cellMassKg);
+    double[] faceFlows = filled(cells + 1, 1.0);
+    double absoluteErrorSeconds = 0.0;
+    for (int step = 1; step <= totalSteps; step++) {
+      double tracerInlet = step <= pulseSteps ? 1.0 : 0.0;
+      OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
+          new String[] { "carrier", "tracer" }, profile,
+          new double[] { 1.0 - tracerInlet, tracerInlet }, cellMasses, cellMasses,
+          faceFlows, timeStepSeconds);
+      assertTrue(report.isConverged(), report.getMessage());
+      profile = report.getMassFractionProfile();
+      double lagTimeSeconds = (step - 1) * timeStepSeconds;
+      double idealOutlet = lagTimeSeconds >= residenceTimeSeconds
+          && lagTimeSeconds < residenceTimeSeconds + pulseDurationSeconds ? 1.0 : 0.0;
+      absoluteErrorSeconds += Math.abs(profile[1][cells - 1] - idealOutlet)
+          * timeStepSeconds;
+    }
+    return absoluteErrorSeconds / pulseDurationSeconds;
+  }
+
+  private static double negativeBinomialStepResponse(int steps, int cell,
+      double successProbability, double failureProbability) {
+    if (steps <= 0) {
+      return 0.0;
+    }
+    double term = Math.pow(successProbability, cell + 1);
+    double sum = term;
+    for (int delay = 0; delay < steps - 1; delay++) {
+      term *= (double) (delay + cell + 1) / (delay + 1) * failureProbability;
+      sum += term;
+    }
+    return sum;
+  }
+
+  private static double[][] uniformProfile(int cells, double tracerMassFraction) {
+    double[][] profile = new double[2][cells];
+    for (int cell = 0; cell < cells; cell++) {
+      profile[0][cell] = 1.0 - tracerMassFraction;
+      profile[1][cell] = tracerMassFraction;
+    }
+    return profile;
+  }
+
+  private static double[] filled(int length, double value) {
+    double[] values = new double[length];
+    for (int index = 0; index < length; index++) {
+      values[index] = value;
+    }
+    return values;
+  }
+
+  private static final class PulseResult {
+    private final int pulseSteps;
+    private final int peakStep;
+    private final double peakOutletMassFraction;
+    private final double finalOutletMassFraction;
+    private final double cumulativeInletTracerKg;
+    private final double cumulativeOutletTracerKg;
+    private final double globalInventoryResidualKg;
+
+    private PulseResult(int pulseSteps, int peakStep, double peakOutletMassFraction,
+        double finalOutletMassFraction, double cumulativeInletTracerKg,
+        double cumulativeOutletTracerKg, double globalInventoryResidualKg) {
+      this.pulseSteps = pulseSteps;
+      this.peakStep = peakStep;
+      this.peakOutletMassFraction = peakOutletMassFraction;
+      this.finalOutletMassFraction = finalOutletMassFraction;
+      this.cumulativeInletTracerKg = cumulativeInletTracerKg;
+      this.cumulativeOutletTracerKg = cumulativeOutletTracerKg;
+      this.globalInventoryResidualKg = globalInventoryResidualKg;
+    }
   }
 }

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -102,6 +102,8 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     int pulseSteps = 30;
     int recoverySteps = 60;
     PipeFlowSystem pipe = createInitializedPipe(12, 3000.0);
+    pipe.setConservativeSpeciesTransport(true);
+    pipe.setFailOnNonConvergence(true);
     SystemInterface baselineGas = createGas(0.95, 0.05);
     SystemInterface pulseGas = createGas(0.80, 0.20);
 

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport;
 import neqsim.fluidmechanics.geometrydefinitions.GeometryDefinitionInterface;
@@ -93,6 +94,71 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
         pipe.getSpeciesConservationReport().getReason());
   }
 
+  @Test
+  @Tag("slow")
+  void thirtyMinutePulseBreaksThroughRecoversAndClosesCumulativeInventory() {
+    int nitrogen = 1;
+    double timeStepSeconds = 60.0;
+    int pulseSteps = 30;
+    int recoverySteps = 60;
+    PipeFlowSystem pipe = createInitializedPipe(12, 3000.0);
+
+    OnePhaseSpeciesConservationReport baseline = runTransientStep(pipe,
+        createGas(0.95, 0.05), timeStepSeconds);
+    assertTrue(baseline.isConverged(), baseline.getMessage());
+    double baselineOutlet = last(baseline.getMassFractionProfile()[nitrogen]);
+    double initialInventoryKg = baseline.getFinalInventoryKg()[nitrogen];
+    double cumulativeInletKg = 0.0;
+    double cumulativeOutletKg = 0.0;
+    double pulseInletMassFraction = Double.NaN;
+    double pulseEndOutlet = Double.NaN;
+    double peakOutlet = baselineOutlet;
+    OnePhaseSpeciesConservationReport report = baseline;
+
+    for (int step = 0; step < pulseSteps + recoverySteps; step++) {
+      boolean pulseActive = step < pulseSteps;
+      SystemInterface inlet = pulseActive ? createGas(0.80, 0.20) : createGas(0.95, 0.05);
+      report = runTransientStep(pipe, inlet, timeStepSeconds);
+
+      assertTrue(report.isConverged(), report.getMessage());
+      assertTrue(pipe.getConvergenceReport().isConverged(),
+          pipe.getConvergenceReport().getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() <= 1.0e-8,
+          report.getMessage());
+      assertTrue(report.getMaximumThermodynamicMassFractionError() <= 1.0e-10,
+          report.getMessage());
+      cumulativeInletKg += report.getInletBoundaryMassKg()[nitrogen];
+      cumulativeOutletKg += report.getOutletBoundaryMassKg()[nitrogen];
+      double outlet = last(report.getMassFractionProfile()[nitrogen]);
+      peakOutlet = Math.max(peakOutlet, outlet);
+      if (step == 0) {
+        assertEquals(initialInventoryKg, report.getInitialInventoryKg()[nitrogen],
+            Math.max(1.0, initialInventoryKg) * 1.0e-10);
+        pulseInletMassFraction = report.getInletBoundaryMassKg()[nitrogen]
+            / sum(report.getInletBoundaryMassKg());
+      }
+      if (step == pulseSteps - 1) {
+        pulseEndOutlet = outlet;
+      }
+    }
+
+    double finalInventoryKg = report.getFinalInventoryKg()[nitrogen];
+    double cumulativeResidualKg = finalInventoryKg - initialInventoryKg - cumulativeInletKg
+        + cumulativeOutletKg;
+    double cumulativeScaleKg = Math.max(Math.max(initialInventoryKg, cumulativeInletKg), 1.0);
+    double eventAmplitude = pulseInletMassFraction - baselineOutlet;
+    double recoveredOutlet = last(report.getMassFractionProfile()[nitrogen]);
+
+    assertTrue(eventAmplitude > 0.0);
+    assertTrue(pulseEndOutlet > baselineOutlet + 0.70 * eventAmplitude,
+        "The 30-minute event must break through before the inlet returns to baseline.");
+    assertTrue(peakOutlet > baselineOutlet + 0.70 * eventAmplitude);
+    assertEquals(baselineOutlet, recoveredOutlet, 2.0e-3 * eventAmplitude,
+        "The outlet composition must recover after purging the pulse.");
+    assertEquals(0.0, cumulativeResidualKg, cumulativeScaleKg * 1.0e-7,
+        "Cumulative nitrogen inventory must equal integrated inlet minus outlet mass.");
+  }
+
   static PipeFlowSystem runCompositionStep(int nodes, double timeStep) {
     PipeFlowSystem pipe = createInitializedPipe(nodes);
     pipe.setConservativeSpeciesTransport(true);
@@ -105,7 +171,20 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     return pipe;
   }
 
+  private static OnePhaseSpeciesConservationReport runTransientStep(PipeFlowSystem pipe,
+      SystemInterface inlet, double timeStepSeconds) {
+    pipe.getTimeSeries().setTimes(new double[] { 0.0, timeStepSeconds });
+    pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] { inlet });
+    pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);
+    assertDoesNotThrow(() -> pipe.solveTransient(1));
+    return pipe.getSpeciesConservationReport();
+  }
+
   private static PipeFlowSystem createInitializedPipe(int nodes) {
+    return createInitializedPipe(nodes, 15000.0);
+  }
+
+  private static PipeFlowSystem createInitializedPipe(int nodes, double lengthMeters) {
     PipeFlowSystem pipe = new PipeFlowSystem();
     pipe.setInletThermoSystem(createGas(0.95, 0.05));
     pipe.setNumberOfLegs(1);
@@ -117,7 +196,7 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     }
     pipe.setEquipmentGeometry(geometry);
     pipe.setLegHeights(new double[] { 0.0, 0.0 });
-    pipe.setLegPositions(new double[] { 0.0, 15000.0 });
+    pipe.setLegPositions(new double[] { 0.0, lengthMeters });
     pipe.setLegOuterTemperatures(new double[] { TEMPERATURE_K, TEMPERATURE_K });
     pipe.setLegWallHeatTransferCoefficients(new double[] { 0.0, 0.0 });
     pipe.setLegOuterHeatTransferCoefficients(new double[] { 0.0, 0.0 });
@@ -126,6 +205,18 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     pipe.solveSteadyState(1);
     assertTrue(pipe.getConvergenceReport().isConverged());
     return pipe;
+  }
+
+  private static double last(double[] values) {
+    return values[values.length - 1];
+  }
+
+  private static double sum(double[] values) {
+    double result = 0.0;
+    for (double value : values) {
+      result += value;
+    }
+    return result;
   }
 
   private static SystemInterface createGas(double methane, double nitrogen) {

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -102,9 +102,11 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     int pulseSteps = 30;
     int recoverySteps = 60;
     PipeFlowSystem pipe = createInitializedPipe(12, 3000.0);
+    SystemInterface baselineGas = createGas(0.95, 0.05);
+    SystemInterface pulseGas = createGas(0.80, 0.20);
 
     OnePhaseSpeciesConservationReport baseline = runTransientStep(pipe,
-        createGas(0.95, 0.05), timeStepSeconds);
+        baselineGas.clone(), timeStepSeconds);
     assertTrue(baseline.isConverged(), baseline.getMessage());
     double baselineOutlet = last(baseline.getMassFractionProfile()[nitrogen]);
     double initialInventoryKg = baseline.getFinalInventoryKg()[nitrogen];
@@ -117,7 +119,7 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
 
     for (int step = 0; step < pulseSteps + recoverySteps; step++) {
       boolean pulseActive = step < pulseSteps;
-      SystemInterface inlet = pulseActive ? createGas(0.80, 0.20) : createGas(0.95, 0.05);
+      SystemInterface inlet = pulseActive ? pulseGas.clone() : baselineGas.clone();
       report = runTransientStep(pipe, inlet, timeStepSeconds);
 
       assertTrue(report.isConverged(), report.getMessage());

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -105,8 +105,7 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     SystemInterface baselineGas = createGas(0.95, 0.05);
     SystemInterface pulseGas = createGas(0.80, 0.20);
 
-    OnePhaseSpeciesConservationReport baseline = runTransientStep(pipe,
-        baselineGas.clone(), timeStepSeconds);
+    OnePhaseSpeciesConservationReport baseline = runTransientStep(pipe, baselineGas.clone(), timeStepSeconds);
     assertTrue(baseline.isConverged(), baseline.getMessage());
     double baselineOutlet = last(baseline.getMassFractionProfile()[nitrogen]);
     double initialInventoryKg = baseline.getFinalInventoryKg()[nitrogen];
@@ -123,12 +122,9 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
       report = runTransientStep(pipe, inlet, timeStepSeconds);
 
       assertTrue(report.isConverged(), report.getMessage());
-      assertTrue(pipe.getConvergenceReport().isConverged(),
-          pipe.getConvergenceReport().getMessage());
-      assertTrue(report.getMaximumRelativeInventoryResidual() <= 1.0e-8,
-          report.getMessage());
-      assertTrue(report.getMaximumThermodynamicMassFractionError() <= 1.0e-10,
-          report.getMessage());
+      assertTrue(pipe.getConvergenceReport().isConverged(), pipe.getConvergenceReport().getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() <= 1.0e-8, report.getMessage());
+      assertTrue(report.getMaximumThermodynamicMassFractionError() <= 1.0e-10, report.getMessage());
       cumulativeInletKg += report.getInletBoundaryMassKg()[nitrogen];
       cumulativeOutletKg += report.getOutletBoundaryMassKg()[nitrogen];
       double outlet = last(report.getMassFractionProfile()[nitrogen]);
@@ -136,8 +132,7 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
       if (step == 0) {
         assertEquals(initialInventoryKg, report.getInitialInventoryKg()[nitrogen],
             Math.max(1.0, initialInventoryKg) * 1.0e-10);
-        pulseInletMassFraction = report.getInletBoundaryMassKg()[nitrogen]
-            / sum(report.getInletBoundaryMassKg());
+        pulseInletMassFraction = report.getInletBoundaryMassKg()[nitrogen] / sum(report.getInletBoundaryMassKg());
       }
       if (step == pulseSteps - 1) {
         pulseEndOutlet = outlet;
@@ -145,8 +140,7 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     }
 
     double finalInventoryKg = report.getFinalInventoryKg()[nitrogen];
-    double cumulativeResidualKg = finalInventoryKg - initialInventoryKg - cumulativeInletKg
-        + cumulativeOutletKg;
+    double cumulativeResidualKg = finalInventoryKg - initialInventoryKg - cumulativeInletKg + cumulativeOutletKg;
     double cumulativeScaleKg = Math.max(Math.max(initialInventoryKg, cumulativeInletKg), 1.0);
     double eventAmplitude = pulseInletMassFraction - baselineOutlet;
     double recoveredOutlet = last(report.getMassFractionProfile()[nitrogen]);
@@ -173,8 +167,8 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     return pipe;
   }
 
-  private static OnePhaseSpeciesConservationReport runTransientStep(PipeFlowSystem pipe,
-      SystemInterface inlet, double timeStepSeconds) {
+  private static OnePhaseSpeciesConservationReport runTransientStep(PipeFlowSystem pipe, SystemInterface inlet,
+      double timeStepSeconds) {
     pipe.getTimeSeries().setTimes(new double[] { 0.0, timeStepSeconds });
     pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] { inlet });
     pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);


### PR DESCRIPTION
## Engineering value

This is the dependency-ordered Stage 2 validation increment after merged #2761. It does not change the transport equation or any tolerance. It proves that the opt-in positive-flow first-order species kernel behaves correctly over repeated steps, then exercises a synthetic 30-minute methane/nitrogen pulse through the full coupled hydraulic/EOS/species path.

## Analytical gate

For constant cell mass M, face mass flow mdot, and timestep dt, define p = CFL/(1+CFL) and q = 1/(1+CFL). The initially tracer-free step response in cell j after n implicit-upwind steps is the negative-binomial cumulative response documented in the updated pipe guide.

After merging current `master`, the focused regression retains #2769's independent analytical gate: it checks every cell through 36 repeated steps at CFL = 0.25, repeats the run bit-for-bit to prove determinism, and recovers the 120 s inventory-over-flow residence time at both 2.5 s and 5.0 s timesteps. PR #2768 adds the distinct pulse-superposition, long-duration closure, and refinement gates below rather than duplicating the merged repeated-step test.

## Pulse and refinement gates

The pure transport regression applies a tracer pulse for exactly 1800 s and follows recovery over six residence times. It requires:

- every step to converge and close component inventory;
- outlet history to match analytical step-response superposition;
- cumulative injected tracer mass to equal 1800 kg;
- global final-minus-initial inventory to equal cumulative inlet-minus-outlet mass;
- late outlet recovery below 1e-8;
- joint refinement from 12 cells/60 s to 24 cells/30 s to reduce plug-flow pulse error by at least 20%.

The slow integration regression uses:

- SRK / classic mixing rule;
- methane/nitrogen: baseline 95/5 mol%, event 80/20 mol%;
- 70 bara, 288.15 K, isothermal;
- 50 kg/s, strictly positive;
- 3000 m, 0.5 m ID, roughness 1e-5 m;
- 12 nodes and 60 s steps;
- 30 event steps (1800 s) followed by 60 recovery steps.

It telescopes the immutable per-step reports into a cumulative nitrogen balance and requires breakthrough, recovery, thermodynamic synchronization, hydraulic convergence, and cumulative relative closure within 1e-7.

## Validation performed locally

Environment:

- OpenJDK 17.0.19 runtime with jdk.compiler;
- Java compilation target --release 8;
- unchanged production `ConservativeSpeciesTransport.java` from current master commit `11a3116a06c60bacb7fe5fc3156f57220c102fe5`.

Passed:

- production transport kernel plus the updated focused JUnit source compiled with --release 8;
- all focused methods executed through a local assertion runner;
- 36-step analytical profile comparison and deterministic repeat from merged #2769;
- 120 s residence-time first moment at 2.5 s and 5.0 s timesteps;
- 1800 s pulse analytical superposition and long-duration closure;
- 12/60 to 24/30 refinement criterion;
- existing one-step, invalid-state, reversed-flow, and defensive-copy regressions.

The available runtime exposes the Java 17 `jdk.compiler` module but cannot resolve the repository's Maven plugin dependencies from Maven Central. The focused production classes and merged JUnit source were therefore compiled with `--release 8` and executed through a local assertion runner. The SRK/full-pipeline slow regression, Spotless, Javadocs, and repository suites are delegated to hosted CI. No criterion is bypassed or weakened.

## Documentation impact

Updated docs/fluidmechanics/single_phase_pipe_flow.md with the closed-form response, residence-time equation, measured validation boundary, and the remaining limits. The guide still states clearly that:

- zero/reversed flow is unsupported;
- full hydraulic/EOS grid-and-timestep convergence is not established;
- energy coupling and phase appearance are outside this path;
- present spreading is numerical, not physical dispersion.

No notebook is added in this PR. A Colab example remains blocked until this integrated pulse gate is green and merged, so it can target a published/default-branch implementation rather than an unvalidated branch.

## Compatibility and risk

- Production code and public APIs: unchanged.
- Numerical tolerances: unchanged.
- Default behavior: unchanged.
- Runtime impact: only the new slow regression.
- Main risk: repeated-step state ownership or coupling failure exposed by the full SRK pulse; the test is intentionally strict and fail-loud.
- No proprietary data or commercial-parity claim.

This is an AI-assisted contribution; the equation, test oracle, physical checks, and scope were reviewed and understood.