### PR TITLE
test(pipe): validate repeated conservative advection

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -296,14 +296,20 @@ relative inventory residuals, boundedness and sum-to-one diagnostics, thermodyna
 synchronization error, and hydraulic/species residual histories. Its array getters return
 defensive copies and `toJson()` is suitable for Python-side result capture.
 
-This path has currently been regression-tested for a single isothermal composition-change step
-with positive flow. Zero or reversed face flow fails explicitly because an external upwind
-composition is not yet defined. Once enabled, every failed hydraulic/species criterion throws so
-that a failed conservative state cannot advance to another timestep. Thirty-minute pulse
-breakthrough/recovery, repeated-event propagation, analytical front speed and residence time,
-grid/time convergence, thermal coupling, and phase appearance remain validation gates. The
-spreading of the present first-order upwind scheme is numerical; there is no physical
-axial-dispersion model.
+This path has been regression-tested for a single coupled isothermal composition-change step with
+positive flow. The isolated conservative kernel is also checked over repeated uniform-cell steps.
+For constant cell mass \(M\), face mass flow \(F\), and timestep \(\Delta t\), the regression
+compares every cell with the closed-form repeated solution of the implicit upwind recurrence. It
+also obtains the outlet-response first moment at two timesteps and recovers the mass-coordinate
+residence time \(\sum_P M_P/F\). These checks establish the algebraic transport speed for the
+isolated kernel; they do not establish a coupled compressible-pipeline breakthrough prediction.
+
+Zero or reversed face flow fails explicitly because an external upwind composition is not yet
+defined. Once enabled, every failed hydraulic/species criterion throws so that a failed
+conservative state cannot advance to another timestep. Thirty-minute pulse breakthrough/recovery,
+coupled repeated-event propagation, spatial-grid convergence, thermal coupling, and phase
+appearance remain validation gates. The spreading of the present first-order upwind scheme is
+numerical; there is no physical axial-dispersion model.
 
 ## Compositional Tracking
 
@@ -386,9 +392,10 @@ The steady-state solver has been validated for:
 
 1. **Single-phase only**: No phase transition handling
 2. **Component-transport validation is incomplete**: The opt-in solver-type-1 path demonstrates
-   conservative, bounded one-step transport without normalization. Analytical front speed,
-   repeated-step and pulse breakthrough, and grid/time convergence are not yet established. Do
-   not use it yet as a validated long-duration compositional-tracking prediction.
+   conservative, bounded one-step coupled transport without normalization, while its isolated
+   transport kernel matches repeated-step and mass-coordinate residence-time solutions. Coupled
+   front propagation, pulse breakthrough/recovery, and grid/time convergence are not yet
+   established. Do not use it yet as a validated long-duration compositional-tracking prediction.
 3. **No physical axial dispersion model**: Existing advection-scheme spreading is numerical and
    must not be interpreted as molecular or turbulent dispersion.
 4. **Positive-flow diagnostic boundary**: Current transient mass diagnostics reject reverse

--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -298,10 +298,11 @@ defensive copies and `toJson()` is suitable for Python-side result capture.
 
 This path has been regression-tested for a single coupled isothermal composition-change step with
 positive flow. The isolated conservative kernel is also checked over repeated uniform-cell steps.
-For constant cell mass \(M\), face mass flow \(F\), and timestep \(\Delta t\), the regression
+For constant cell mass $M$, face mass flow $F$, and timestep $\Delta t$, the regression
 compares every cell with the closed-form repeated solution of the implicit upwind recurrence. It
-also obtains the outlet-response first moment at two timesteps and recovers the mass-coordinate
-residence time \(\sum_P M_P/F\). These checks establish the algebraic transport speed for the
+also subtracts the inlet-event first moment from the outlet-response first moment at two timesteps
+and recovers the mass-coordinate residence time $\sum_P M_P/F$. These checks establish the
+algebraic transport speed for the
 isolated kernel; they do not establish a coupled compressible-pipeline breakthrough prediction.
 
 Zero or reversed face flow fails explicitly because an external upwind composition is not yet

--- a/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
@@ -77,8 +77,8 @@ class ConservativeSpeciesTransportTest {
       assertEquals(0.0, report.getMaximumMassFractionSumError(), 0.0);
       profile = report.getMassFractionProfile();
       for (int cell = 0; cell < cells; cell++) {
-        assertEquals(analyticalTracer(step, cell, cellMassKg, massFlowKgPerSecond, timeStepSeconds),
-            profile[1][cell], 5.0e-14);
+        assertEquals(analyticalTracer(step, cell, cellMassKg, massFlowKgPerSecond, timeStepSeconds), profile[1][cell],
+            5.0e-14);
       }
     }
     return profile[1];

--- a/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
@@ -100,15 +100,18 @@ class ConservativeSpeciesTransportTest {
           new String[] { "carrier", "tracer" }, profile, new double[] { 0.0, 1.0 }, cellMass, cellMass, faceFlow,
           timeStepSeconds);
       assertTrue(report.isConverged(), report.getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-13, report.getMessage());
+      assertEquals(0.0, report.getMaximumMassFractionSumError(), 0.0);
       profile = report.getMassFractionProfile();
       double outlet = profile[1][cells - 1];
       double responseIncrement = outlet - previousOutlet;
       responseMass += responseIncrement;
-      responseFirstMoment += step * timeStepSeconds * responseIncrement;
+      responseFirstMoment += (step + 1.0) * timeStepSeconds * responseIncrement;
       previousOutlet = outlet;
     }
     assertEquals(1.0, responseMass, 1.0e-14, "Step-response increments must integrate to one");
-    return responseFirstMoment / responseMass;
+    double inletEventFirstMoment = timeStepSeconds;
+    return responseFirstMoment / responseMass - inletEventFirstMoment;
   }
 
   private static double analyticalTracer(int steps, int cell, double cellMassKg, double massFlowKgPerSecond,

--- a/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 /** Tests conservative n-1 implicit finite-volume species transport. */
@@ -47,6 +48,93 @@ class ConservativeSpeciesTransportTest {
     double[] expectedTracer = { 1.0 / 3.0, 1.0 / 9.0, 1.0 / 27.0, 1.0 / 81.0 };
     assertArrayEquals(expectedTracer, report.getMassFractionProfile()[1], 1.0e-15);
     assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-14);
+  }
+
+  @Test
+  void repeatedStepMatchesAnalyticalProfileAndMassResidenceTime() {
+    double[] firstProfile = runRepeatedStep(2.5, 36);
+    double[] repeatedProfile = runRepeatedStep(2.5, 36);
+    assertArrayEquals(firstProfile, repeatedProfile, 0.0, "Repeated runs must be deterministic");
+
+    assertEquals(120.0, calculateResidenceTime(2.5), 2.0e-10);
+    assertEquals(120.0, calculateResidenceTime(5.0), 2.0e-10);
+  }
+
+  private static double[] runRepeatedStep(double timeStepSeconds, int steps) {
+    int cells = 12;
+    double cellMassKg = 10.0;
+    double massFlowKgPerSecond = 1.0;
+    double[][] profile = uniformInitialProfile(cells);
+    double[] cellMass = constantArray(cells, cellMassKg);
+    double[] faceFlow = constantArray(cells + 1, massFlowKgPerSecond);
+
+    for (int step = 1; step <= steps; step++) {
+      OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
+          new String[] { "carrier", "tracer" }, profile, new double[] { 0.0, 1.0 }, cellMass, cellMass, faceFlow,
+          timeStepSeconds);
+      assertTrue(report.isConverged(), report.getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-13, report.getMessage());
+      assertEquals(0.0, report.getMaximumMassFractionSumError(), 0.0);
+      profile = report.getMassFractionProfile();
+      for (int cell = 0; cell < cells; cell++) {
+        assertEquals(analyticalTracer(step, cell, cellMassKg, massFlowKgPerSecond, timeStepSeconds),
+            profile[1][cell], 5.0e-14);
+      }
+    }
+    return profile[1];
+  }
+
+  private static double calculateResidenceTime(double timeStepSeconds) {
+    int cells = 12;
+    double cellMassKg = 10.0;
+    double massFlowKgPerSecond = 1.0;
+    double[][] profile = uniformInitialProfile(cells);
+    double[] cellMass = constantArray(cells, cellMassKg);
+    double[] faceFlow = constantArray(cells + 1, massFlowKgPerSecond);
+    double previousOutlet = 0.0;
+    double responseMass = 0.0;
+    double responseFirstMoment = 0.0;
+
+    for (int step = 0; step < 500; step++) {
+      OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
+          new String[] { "carrier", "tracer" }, profile, new double[] { 0.0, 1.0 }, cellMass, cellMass, faceFlow,
+          timeStepSeconds);
+      assertTrue(report.isConverged(), report.getMessage());
+      profile = report.getMassFractionProfile();
+      double outlet = profile[1][cells - 1];
+      double responseIncrement = outlet - previousOutlet;
+      responseMass += responseIncrement;
+      responseFirstMoment += step * timeStepSeconds * responseIncrement;
+      previousOutlet = outlet;
+    }
+    assertEquals(1.0, responseMass, 1.0e-14, "Step-response increments must integrate to one");
+    return responseFirstMoment / responseMass;
+  }
+
+  private static double analyticalTracer(int steps, int cell, double cellMassKg, double massFlowKgPerSecond,
+      double timeStepSeconds) {
+    double denominator = cellMassKg + timeStepSeconds * massFlowKgPerSecond;
+    double spatialFactor = timeStepSeconds * massFlowKgPerSecond / denominator;
+    double temporalFactor = cellMassKg / denominator;
+    double term = Math.pow(temporalFactor, steps);
+    double carrier = term;
+    for (int offset = 1; offset <= cell; offset++) {
+      term *= spatialFactor * (steps + offset - 1.0) / offset;
+      carrier += term;
+    }
+    return 1.0 - carrier;
+  }
+
+  private static double[][] uniformInitialProfile(int cells) {
+    double[][] profile = new double[][] { new double[cells], new double[cells] };
+    Arrays.fill(profile[0], 1.0);
+    return profile;
+  }
+
+  private static double[] constantArray(int length, double value) {
+    double[] values = new double[length];
+    Arrays.fill(values, value);
+    return values;
   }
 
   @Test


### PR DESCRIPTION
## Engineering value

Adds the missing repeated pure-advection benchmark for the opt-in conservative one-phase species kernel merged in #2761. It freezes front propagation in finite-volume mass coordinates and residence time before coupled pulse/grid studies. No production solver, tolerance, API, hydraulic path, EOS model, or physical-dispersion behavior changes.

## Frozen reproducer and acceptance criteria

Base: `194f2d50b62adfb8534bbc2622080ad3959455be` (merged master).

- binary carrier/tracer mass fractions: initially `[1, 0]`, inlet step `[0, 1]`;
- 12 uniform accumulating cells, `M_P = 10 kg` per cell;
- every face has strictly positive `F = 1 kg/s`;
- fixed `Δt = 2.5 s` for 36 repeated profile steps; residence moment repeated at `Δt = 2.5 s` and `5 s`;
- isolated isothermal transport kernel: no EOS, pressure, temperature, standard-volume, molar conversion, or physical dispersion enters this deliberately narrow benchmark;
- maximum pointwise error versus the closed form: `≤ 5e-14`;
- every-step relative component inventory residual: `< 1e-13`;
- cell-wise mass-fraction sum error: exactly zero;
- repeat profile: bit-identical;
- outlet step-response increments integrate to one within `1e-14`;
- residence time is the outlet first moment minus the inlet-event first moment: `Σ M_P/F = 120 s` within `2e-10 s`.

The tolerances were frozen before editing. Master already produced maximum profile error `2.1094237467877974e-15`, maximum relative component residual `1.7763568466762080e-15`, zero sum error, response mass `1.0`, and residence time `120.00000000000010 s`. The demonstrated gap was absent regression coverage, so this PR intentionally changes tests/docs only.

## Analytical reference

For constant cell mass and face flow, the implemented implicit-upwind step is

```text
w[j,n] = r w[j,n-1] + s w[j-1,n]
r = M/(M + F Δt),  s = F Δt/(M + F Δt)
```

For a tracer inlet step into an initially tracer-free line, the independent closed form used by the test is

```text
tracer[j,n] = 1 - r^n Σ(m=0..j) C(n+m-1,m) s^m.
```

With inlet and outlet response increments timestamped consistently at interval end, each cell's relative first-moment delay is `M/F`; 12 cells therefore have mass-coordinate residence time `12 M/F = 120 s`. This checks the solver against an independently evaluated formula, not against stored benchmark output.

Relevant composition-tracking evidence: [Chaczykowski et al. (2018)](https://doi.org/10.1016/j.jngse.2018.03.014) and [Urh & Pantoš (2024)](https://doi.org/10.1016/j.ijhydene.2023.11.031). Both distinguish transport-time prediction from implicit-scheme front smearing. This PR does not tune or add a higher-order/dispersion method.

## Verification

Local focused equation harness and proposed test compilation:

```text
java -m jdk.compiler/com.sun.tools.javac.Main ...
java ...RepeatedStepHarness
steps=36 cells=12 CFL_mass=0.250000
max_profile_error=2.1094237467877974e-15
max_relative_inventory_residual=1.7763568466762080e-15
max_sum_error=0.0
step_response_mass=1.0
relative_outlet_minus_inlet_residence_time_s=120.00000000000010
expected_residence_time_s=120.0

java ...TestRunner
ConservativeSpeciesTransportTest: 4 executable kernel tests passed
```

Runtime: OpenJDK 17.0.19. The image exposes `jdk.compiler` but no `javac` launcher or Maven; repository CI is required for the full JUnit/Java 8/21/Spotless/Javadocs gates.

## Documentation, compatibility, and limits

Documentation now records what the repeated isolated-kernel test establishes and explicitly retains the coupled-pipeline limitations. Documentation impact is therefore addressed in the same branch. No notebook change: publishing the transmission-pipeline Colab still waits for coupled pulse/breakthrough and convergence gates.

Compatibility/performance: test/docs only; no runtime allocation, API, serialization, hydraulic, EOS, or pressure/flow impact.

Still out of scope and unresolved: coupled compressible-pipeline repeated propagation, 30-minute pulse breakthrough/recovery, per-component transient accumulation across the full event, grid/time convergence, low/zero/reversed-flow boundary models, TVD, physical dispersion, thermal coupling, feed-rate events, and multiphase behavior.

## Next dependency gate

After this PR passes review and is merged, reproduce a finite coupled step/pulse on merged master and freeze total/per-component inventory, outlet breakthrough/recovery, front, deterministic-repeat, and grid/timestep criteria.