### PR TITLE
Closed: fixed reflux cache test exposed non-conservative split

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -170,7 +170,9 @@ DistillationColumn.ReboilerMode reboilerMode = column.getReboilerMode();
 
 `setCondenserLiquidReflux(value, unit)` configures the `LIQUID_REFLUX_SPLIT` mode. Use it instead
 of calling `setCondenserMode(LIQUID_REFLUX_SPLIT)` directly because the fixed reflux flow is
-required.
+required. Fixed-split warm-state identity includes both the configured value and unit, so changing
+either input forces the condenser equations to be solved again while an unchanged specification
+remains eligible for exact reuse.
 
 ## Solver Options
 

--- a/src/main/java/neqsim/process/equipment/distillation/Condenser.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Condenser.java
@@ -49,6 +49,25 @@ public class Condenser extends SimpleTray {
   }
 
   /**
+   * Get the configured fixed liquid reflux value.
+   *
+   * @return fixed reflux value in {@link #getLiquidRefluxUnit()}, or the last configured value when fixed-split mode is
+   * inactive
+   */
+  double getLiquidRefluxValue() {
+    return reflux_value;
+  }
+
+  /**
+   * Get the configured fixed liquid reflux unit.
+   *
+   * @return flow-rate unit, or {@code null} before fixed liquid reflux has been configured
+   */
+  String getLiquidRefluxUnit() {
+    return reflux_unit;
+  }
+
+  /**
    * Sets the separation with liquid reflux parameters.
    *
    * @param separation_with_liquid_reflux a boolean indicating if separation with liquid reflux is set

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2857,8 +2857,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     }
     if (hasCondenser && getCondenser() != null) {
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, getCondenser().isRefluxSet() ? 1L : 0L);
-      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature,
-          getCondenser().isSeparation_with_liquid_reflux() ? 1L : 0L);
+      boolean fixedLiquidReflux = getCondenser().isSeparation_with_liquid_reflux();
+      updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, fixedLiquidReflux ? 1L : 0L);
+      if (fixedLiquidReflux) {
+        updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature,
+            getCondenser().getLiquidRefluxValue());
+        updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature,
+            getCondenser().getLiquidRefluxUnit());
+      }
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, getCondenser().getRefluxRatio());
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature,
           getCondenser().isTotalCondenser() ? 1L : 0L);

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2862,8 +2862,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       if (fixedLiquidReflux) {
         updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature,
             getCondenser().getLiquidRefluxValue());
-        updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature,
-            getCondenser().getLiquidRefluxUnit());
+        updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, getCondenser().getLiquidRefluxUnit());
       }
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature, getCondenser().getRefluxRatio());
       updatedSignature = updateNaphtaliSandholmInputSignature(updatedSignature,

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -193,6 +193,40 @@ public class DistillationColumnWarmStateCacheTest {
   }
 
   /**
+   * Changing the fixed liquid reflux flow must invalidate an otherwise identical warm state.
+   *
+   * <p>
+   * The fixed-split mode flag alone does not identify the condenser equations: the specified flow and unit determine the
+   * returned liquid traffic. Reusing a state accepted for zero reflux after changing the target to a non-zero nearby
+   * operating point leaves the previous splitter products in place without executing a tray iteration.
+   * </p>
+   */
+  @Test
+  public void fixedLiquidRefluxValueInvalidatesWarmState() {
+    DistillationColumn column = buildCondenserColumn();
+    column.getCondenser().setSeparation_with_liquid_reflux(true, 0.0, "kg/hr");
+    column.run();
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+
+    column.run();
+    assertTrue(column.wasSequentialWarmStateReused(),
+        "an unchanged fixed liquid reflux case must reuse its accepted state");
+    assertEquals(0, column.getLastIterationCount(), "unchanged exact reuse must execute zero tray iterations");
+
+    double changedRefluxKgPerHour = 0.1;
+    column.getCondenser().setSeparation_with_liquid_reflux(true, changedRefluxKgPerHour, "kg/hr");
+    column.run();
+
+    assertFalse(column.wasSequentialWarmStateReused(),
+        "a changed fixed reflux flow must solve the changed condenser equations");
+    assertTrue(column.getLastIterationCount() > 0, "the changed fixed reflux equations must execute tray iterations");
+    assertEquals(changedRefluxKgPerHour, column.getCondenser().getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-8,
+        "the returned liquid stream must satisfy the changed fixed reflux flow");
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertPhysicalAndBalancedWithCondenserProduct(column.getFeedStreams(1).get(0), column);
+  }
+
+  /**
    * A column pressure change must invalidate the warm state. {@code setTopPressure} and {@code setBottomPressure} do
    * not mark the column for re-initialization either.
    */

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -220,7 +220,7 @@ public class DistillationColumnWarmStateCacheTest {
     assertFalse(column.wasSequentialWarmStateReused(),
         "a changed fixed reflux value must solve the changed condenser equations");
     assertTrue(column.getLastIterationCount() > 0, "the changed fixed reflux equations must execute tray iterations");
-    assertEquals(changedRefluxValue, column.getCondenser().getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-10,
+    assertEquals(changedRefluxValue, column.getCondenser().getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-8,
         "the returned liquid stream must satisfy the changed fixed reflux value");
     assertTrue(column.solved(), column.getConvergenceDiagnostics());
     assertPhysicalAndBalancedWithCondenserProduct(column.getFeedStreams(1).get(0), column);

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -196,13 +196,13 @@ public class DistillationColumnWarmStateCacheTest {
    * Changing the fixed liquid reflux flow must invalidate an otherwise identical warm state.
    *
    * <p>
-   * The fixed-split mode flag alone does not identify the condenser equations: the specified flow and unit determine the
-   * returned liquid traffic. Reusing a state accepted for zero reflux after changing the target to a non-zero nearby
-   * operating point leaves the previous splitter products in place without executing a tray iteration.
+   * The fixed-split mode flag alone does not identify the condenser equations: the specified flow and unit determine
+   * the returned liquid traffic. Reusing a state accepted for zero reflux after changing the target to a non-zero
+   * nearby operating point leaves the previous splitter products in place without executing a tray iteration.
    * </p>
    */
   @Test
-  public void fixedLiquidRefluxValueInvalidatesWarmState() {
+  public void fixedLiquidRefluxValueAndUnitInvalidateWarmState() {
     DistillationColumn column = buildCondenserColumn();
     column.getCondenser().setSeparation_with_liquid_reflux(true, 0.0, "kg/hr");
     column.run();
@@ -213,15 +213,30 @@ public class DistillationColumnWarmStateCacheTest {
         "an unchanged fixed liquid reflux case must reuse its accepted state");
     assertEquals(0, column.getLastIterationCount(), "unchanged exact reuse must execute zero tray iterations");
 
-    double changedRefluxKgPerHour = 0.1;
-    column.getCondenser().setSeparation_with_liquid_reflux(true, changedRefluxKgPerHour, "kg/hr");
+    double changedRefluxValue = 1.0e-3;
+    column.getCondenser().setSeparation_with_liquid_reflux(true, changedRefluxValue, "kg/hr");
     column.run();
 
     assertFalse(column.wasSequentialWarmStateReused(),
-        "a changed fixed reflux flow must solve the changed condenser equations");
+        "a changed fixed reflux value must solve the changed condenser equations");
     assertTrue(column.getLastIterationCount() > 0, "the changed fixed reflux equations must execute tray iterations");
-    assertEquals(changedRefluxKgPerHour, column.getCondenser().getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-8,
-        "the returned liquid stream must satisfy the changed fixed reflux flow");
+    assertEquals(changedRefluxValue, column.getCondenser().getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-10,
+        "the returned liquid stream must satisfy the changed fixed reflux value");
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertPhysicalAndBalancedWithCondenserProduct(column.getFeedStreams(1).get(0), column);
+
+    column.run();
+    assertTrue(column.wasSequentialWarmStateReused(),
+        "the accepted nearby fixed reflux value must remain exactly reusable when unchanged");
+
+    column.getCondenser().setSeparation_with_liquid_reflux(true, changedRefluxValue, "kg/sec");
+    column.run();
+
+    assertFalse(column.wasSequentialWarmStateReused(),
+        "the same numeric reflux value in a different unit must solve the changed condenser equations");
+    assertTrue(column.getLastIterationCount() > 0, "the changed fixed reflux unit must execute tray iterations");
+    assertEquals(3.6, column.getCondenser().getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-8,
+        "the returned liquid stream must apply the changed fixed reflux unit");
     assertTrue(column.solved(), column.getConvergenceDiagnostics());
     assertPhysicalAndBalancedWithCondenserProduct(column.getFeedStreams(1).get(0), column);
   }


### PR DESCRIPTION
## Closed unmerged: engineering validation exposed a deeper fixed-reflux defect

This cache-only change is not publishable because the deterministic regression reached a nonphysical fixed-reflux state after the cache was correctly invalidated.

## Inspected area

- Current `master` column architecture and solver/fallback routing
- Sequential and Naphtali-Sandholm exact warm reuse
- Condenser fixed-liquid split implementation
- Recent column commits and open PRs/issues
- Closed PR #2766 and its terminal material/energy-coupling evidence

No open PR duplicated this target.

## Confirmed cache defect

Both sequential exact reuse and Naphtali-Sandholm exact reuse depend on `updateColumnConfigurationSignature(...)`. On `master`, that signature records the fixed-split mode but omits its value and unit. Regression-only commit `3b0ae24` documents the collision.

The proposed implementation correctly folded the active value/unit pair into the shared fingerprint. The Java run passed the cache-specific assertions: changing the target invalidated exact reuse, executed tray iterations, and produced the requested reflux stream.

## Engineering validation failure

The subsequent three-product conservation check failed:

- feed: `7200.0 mol/hr`
- overhead + bottoms + condenser liquid product: `7286.830178040899 mol/hr`
- artificial excess: `86.830178040899 mol/hr`

The failure occurs after `Condenser.run()` raises an insufficient liquid stream to `reflux_value + 1` before splitting it. For this SRK methane/ethane case that legacy safeguard creates approximately 1 kg/hr of liquid inventory. The column still reports solved, so retaining only the cache-key fix would make a stale-cache bug expose a false-converged, non-conservative result.

No tolerance was loosened and the conservation assertion was not removed.

## Validation completed

Final experimental head: `5b138f3`.

Passed:

- pre-commit
- Spotless
- PaperLab
- documentation search
- CodeQL
- Javadocs
- all four Java 21 slow-test shards
- final Copilot review of all four files with no new comments

Failed as intended by the engineering gate:

- Java 21 Windows fast suite: 11,175 tests, one failure in `fixedLiquidRefluxValueAndUnitInvalidateWarmState`
- Java 21 Ubuntu fast suite was cancelled after the matrix failure

All Copilot suggestions were assessed. The value/unit fingerprint suggestion and stable assertion tolerance were implemented; the cache behavior was validated before the mass-balance assertion. The review thread has been replied to with evidence and resolved because this PR is closing unmerged.

## Publication decision

Closed unmerged. No source, test, or documentation change from this PR is retained for publication.

## Documentation impact

None. The experimental documentation change is closed with the unmerged branch, so user-visible behavior remains unchanged.

## Next dependency-ordered target

Replace the fixed-reflux `reflux_value + 1` inventory creation with a conservative, specification-aware product-split treatment. The next solution must:

1. never create or destroy component inventory;
2. represent fixed reflux as a coupled tear/MESH specification;
3. report an infeasible target as failed rather than solved;
4. preserve a valid zero/nearby operating point and unchanged-input warm reuse;
5. validate total/component and energy closure, specification residual, bounds and repeatability before any cache optimization is reintroduced.

This is consistent with the deeper terminal coupling limitation already exposed by closed PR #2766.