### PR TITLE
test(pipe): require deterministic integrated species pulse

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -314,9 +314,10 @@ $$\tau=\frac{\sum_P M_P}{\dot m}.$$
 The validated first-order kernel matches analytical repeated-step profiles at two timesteps,
 recovers the inventory-over-flow residence time, conserves a synthetic 1800 s pulse over six
 residence times, and reduces pulse error when the grid and timestep are jointly refined from
-12 cells/60 s to 24 cells/30 s. The end-to-end SRK/classic regression propagates the same 1800 s
-event through a 3000 m isothermal pipe, verifies breakthrough and recovery, and telescopes every
-immutable step report into a cumulative nitrogen balance.
+12 cells/60 s to 24 cells/30 s. The end-to-end SRK/classic regression repeats the same 1800 s
+event independently through a 3000 m isothermal pipe, requires bit-identical outlet histories,
+final profiles, and component inventories, verifies breakthrough and recovery, and telescopes
+every immutable step report into a cumulative nitrogen balance.
 
 Zero or reversed face flow still fails explicitly because an external upwind composition is not
 yet defined. Once enabled, every failed hydraulic/species criterion throws so that a failed

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -100,21 +100,23 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     IntegratedPulseResult pulse = runIntegratedPulse();
     IntegratedPulseResult repeatedPulse = runIntegratedPulse();
 
-    assertArrayEquals(pulse.outletNitrogenHistory, repeatedPulse.outletNitrogenHistory, 0.0,
+    assertRawBitsEqual(pulse.outletNitrogenHistory, repeatedPulse.outletNitrogenHistory,
         "Independent coupled pulse runs must have bit-identical outlet histories.");
-    assertArrayEquals(pulse.densityResidualHistory, repeatedPulse.densityResidualHistory, 0.0,
+    assertRawBitsEqual(pulse.densityResidualHistory, repeatedPulse.densityResidualHistory,
         "Independent coupled pulse runs must have bit-identical EOS/FV density residuals.");
     assertArrayEquals(pulse.couplingIterationHistory, repeatedPulse.couplingIterationHistory,
         "Independent coupled pulse runs must perform identical fixed-point work.");
-    assertArrayEquals(pulse.finalInventoryKg, repeatedPulse.finalInventoryKg, 0.0,
+    assertRawBitsEqual(pulse.finalInventoryKg, repeatedPulse.finalInventoryKg,
         "Independent coupled pulse runs must have bit-identical final inventories.");
     assertEquals(pulse.finalMassFractionProfile.length, repeatedPulse.finalMassFractionProfile.length);
     for (int component = 0; component < pulse.finalMassFractionProfile.length; component++) {
-      assertArrayEquals(pulse.finalMassFractionProfile[component], repeatedPulse.finalMassFractionProfile[component],
-          0.0, "Independent coupled pulse runs must have bit-identical final profiles.");
+      assertRawBitsEqual(pulse.finalMassFractionProfile[component], repeatedPulse.finalMassFractionProfile[component],
+          "Independent coupled pulse runs must have bit-identical final profiles.");
     }
-    assertEquals(pulse.cumulativeInletKg, repeatedPulse.cumulativeInletKg, 0.0);
-    assertEquals(pulse.cumulativeOutletKg, repeatedPulse.cumulativeOutletKg, 0.0);
+    assertRawBitsEqual(pulse.cumulativeInletKg, repeatedPulse.cumulativeInletKg,
+        "Independent coupled pulse runs must have bit-identical cumulative inlet mass.");
+    assertRawBitsEqual(pulse.cumulativeOutletKg, repeatedPulse.cumulativeOutletKg,
+        "Independent coupled pulse runs must have bit-identical cumulative outlet mass.");
 
     double eventAmplitude = pulse.pulseInletMassFraction - pulse.baselineOutlet;
     double cumulativeScaleKg = Math.max(Math.max(pulse.initialInventoryKg, pulse.cumulativeInletKg), 1.0);
@@ -247,6 +249,17 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
       result += value;
     }
     return result;
+  }
+
+  private static void assertRawBitsEqual(double expected, double actual, String message) {
+    assertEquals(Double.doubleToRawLongBits(expected), Double.doubleToRawLongBits(actual), message);
+  }
+
+  private static void assertRawBitsEqual(double[] expected, double[] actual, String message) {
+    assertEquals(expected.length, actual.length, message);
+    for (int index = 0; index < expected.length; index++) {
+      assertRawBitsEqual(expected[index], actual[index], message + " index=" + index);
+    }
   }
 
   private static final class IntegratedPulseResult {

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -97,6 +97,39 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
   @Test
   @Tag("slow")
   void thirtyMinutePulseBreaksThroughRecoversAndClosesCumulativeInventory() {
+    IntegratedPulseResult pulse = runIntegratedPulse();
+    IntegratedPulseResult repeatedPulse = runIntegratedPulse();
+
+    assertArrayEquals(pulse.outletNitrogenHistory, repeatedPulse.outletNitrogenHistory, 0.0,
+        "Independent coupled pulse runs must have bit-identical outlet histories.");
+    assertArrayEquals(pulse.densityResidualHistory, repeatedPulse.densityResidualHistory, 0.0,
+        "Independent coupled pulse runs must have bit-identical EOS/FV density residuals.");
+    assertArrayEquals(pulse.couplingIterationHistory, repeatedPulse.couplingIterationHistory,
+        "Independent coupled pulse runs must perform identical fixed-point work.");
+    assertArrayEquals(pulse.finalInventoryKg, repeatedPulse.finalInventoryKg, 0.0,
+        "Independent coupled pulse runs must have bit-identical final inventories.");
+    assertEquals(pulse.finalMassFractionProfile.length, repeatedPulse.finalMassFractionProfile.length);
+    for (int component = 0; component < pulse.finalMassFractionProfile.length; component++) {
+      assertArrayEquals(pulse.finalMassFractionProfile[component], repeatedPulse.finalMassFractionProfile[component],
+          0.0, "Independent coupled pulse runs must have bit-identical final profiles.");
+    }
+    assertEquals(pulse.cumulativeInletKg, repeatedPulse.cumulativeInletKg, 0.0);
+    assertEquals(pulse.cumulativeOutletKg, repeatedPulse.cumulativeOutletKg, 0.0);
+
+    double eventAmplitude = pulse.pulseInletMassFraction - pulse.baselineOutlet;
+    double cumulativeScaleKg = Math.max(Math.max(pulse.initialInventoryKg, pulse.cumulativeInletKg), 1.0);
+
+    assertTrue(eventAmplitude > 0.0);
+    assertTrue(pulse.pulseEndOutlet > pulse.baselineOutlet + 0.70 * eventAmplitude,
+        "The 30-minute event must break through before the inlet returns to baseline.");
+    assertTrue(pulse.peakOutlet > pulse.baselineOutlet + 0.70 * eventAmplitude);
+    assertEquals(pulse.baselineOutlet, pulse.recoveredOutlet, 2.0e-3 * eventAmplitude,
+        "The outlet composition must recover after purging the pulse.");
+    assertEquals(0.0, pulse.cumulativeResidualKg, cumulativeScaleKg * 1.0e-7,
+        "Cumulative nitrogen inventory must equal integrated inlet minus outlet mass.");
+  }
+
+  private static IntegratedPulseResult runIntegratedPulse() {
     int nitrogen = 1;
     double timeStepSeconds = 60.0;
     int pulseSteps = 30;
@@ -116,6 +149,9 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     double pulseInletMassFraction = Double.NaN;
     double pulseEndOutlet = Double.NaN;
     double peakOutlet = baselineOutlet;
+    double[] outletNitrogenHistory = new double[pulseSteps + recoverySteps];
+    double[] densityResidualHistory = new double[pulseSteps + recoverySteps];
+    int[] couplingIterationHistory = new int[pulseSteps + recoverySteps];
     OnePhaseSpeciesConservationReport report = baseline;
 
     for (int step = 0; step < pulseSteps + recoverySteps; step++) {
@@ -130,6 +166,9 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
       cumulativeInletKg += report.getInletBoundaryMassKg()[nitrogen];
       cumulativeOutletKg += report.getOutletBoundaryMassKg()[nitrogen];
       double outlet = last(report.getMassFractionProfile()[nitrogen]);
+      outletNitrogenHistory[step] = outlet;
+      densityResidualHistory[step] = pipe.getConvergenceReport().getMaximumRelativeDensityResidual();
+      couplingIterationHistory[step] = report.getCouplingIterations();
       peakOutlet = Math.max(peakOutlet, outlet);
       if (step == 0) {
         assertEquals(initialInventoryKg, report.getInitialInventoryKg()[nitrogen],
@@ -143,18 +182,11 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
 
     double finalInventoryKg = report.getFinalInventoryKg()[nitrogen];
     double cumulativeResidualKg = finalInventoryKg - initialInventoryKg - cumulativeInletKg + cumulativeOutletKg;
-    double cumulativeScaleKg = Math.max(Math.max(initialInventoryKg, cumulativeInletKg), 1.0);
-    double eventAmplitude = pulseInletMassFraction - baselineOutlet;
     double recoveredOutlet = last(report.getMassFractionProfile()[nitrogen]);
-
-    assertTrue(eventAmplitude > 0.0);
-    assertTrue(pulseEndOutlet > baselineOutlet + 0.70 * eventAmplitude,
-        "The 30-minute event must break through before the inlet returns to baseline.");
-    assertTrue(peakOutlet > baselineOutlet + 0.70 * eventAmplitude);
-    assertEquals(baselineOutlet, recoveredOutlet, 2.0e-3 * eventAmplitude,
-        "The outlet composition must recover after purging the pulse.");
-    assertEquals(0.0, cumulativeResidualKg, cumulativeScaleKg * 1.0e-7,
-        "Cumulative nitrogen inventory must equal integrated inlet minus outlet mass.");
+    return new IntegratedPulseResult(baselineOutlet, initialInventoryKg, cumulativeInletKg, cumulativeOutletKg,
+        pulseInletMassFraction, pulseEndOutlet, peakOutlet, recoveredOutlet, cumulativeResidualKg,
+        outletNitrogenHistory, densityResidualHistory, couplingIterationHistory, report.getFinalInventoryKg(),
+        report.getMassFractionProfile());
   }
 
   static PipeFlowSystem runCompositionStep(int nodes, double timeStep) {
@@ -215,6 +247,44 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
       result += value;
     }
     return result;
+  }
+
+  private static final class IntegratedPulseResult {
+    private final double baselineOutlet;
+    private final double initialInventoryKg;
+    private final double cumulativeInletKg;
+    private final double cumulativeOutletKg;
+    private final double pulseInletMassFraction;
+    private final double pulseEndOutlet;
+    private final double peakOutlet;
+    private final double recoveredOutlet;
+    private final double cumulativeResidualKg;
+    private final double[] outletNitrogenHistory;
+    private final double[] densityResidualHistory;
+    private final int[] couplingIterationHistory;
+    private final double[] finalInventoryKg;
+    private final double[][] finalMassFractionProfile;
+
+    private IntegratedPulseResult(double baselineOutlet, double initialInventoryKg, double cumulativeInletKg,
+        double cumulativeOutletKg, double pulseInletMassFraction, double pulseEndOutlet, double peakOutlet,
+        double recoveredOutlet, double cumulativeResidualKg, double[] outletNitrogenHistory,
+        double[] densityResidualHistory, int[] couplingIterationHistory, double[] finalInventoryKg,
+        double[][] finalMassFractionProfile) {
+      this.baselineOutlet = baselineOutlet;
+      this.initialInventoryKg = initialInventoryKg;
+      this.cumulativeInletKg = cumulativeInletKg;
+      this.cumulativeOutletKg = cumulativeOutletKg;
+      this.pulseInletMassFraction = pulseInletMassFraction;
+      this.pulseEndOutlet = pulseEndOutlet;
+      this.peakOutlet = peakOutlet;
+      this.recoveredOutlet = recoveredOutlet;
+      this.cumulativeResidualKg = cumulativeResidualKg;
+      this.outletNitrogenHistory = outletNitrogenHistory;
+      this.densityResidualHistory = densityResidualHistory;
+      this.couplingIterationHistory = couplingIterationHistory;
+      this.finalInventoryKg = finalInventoryKg;
+      this.finalMassFractionProfile = finalMassFractionProfile;
+    }
   }
 
   private static SystemInterface createGas(double methane, double nitrogen) {


### PR DESCRIPTION
## Engineering value

This is the next dependency-ordered Stage 2 validation increment after merged #2768. Current master runs one coupled 30-minute methane/nitrogen pulse, so it cannot detect nondeterministic transient-state ownership, iteration work, or EOS/species coupling across independently initialized runs.

The change runs the complete integrated pulse twice and requires bit-identical:

- nitrogen outlet histories for all 90 event/recovery steps;
- EOS/FV density-residual histories;
- hydraulic/species fixed-point iteration counts;
- final mass-fraction profiles;
- final component inventories; and
- cumulative inlet/outlet nitrogen masses.

No production equation, numerical tolerance, default, or API changes.

## Frozen case and acceptance criteria

Base: `5c010191b00c2ec3cc7a09533f7f9010f4be4c82`.

Fluid and boundaries:

- SRK EOS / classic mixing rule;
- methane/nitrogen baseline 95/5 mol%, event 80/20 mol%;
- 70 bara absolute, 288.15 K, isothermal;
- 50 kg/s positive mass flow;
- 3000 m horizontal pipe, 0.5 m ID, roughness 1e-5 m;
- 12 nodes and 60 s timesteps;
- 30 event steps (1800 s) and 60 recovery steps.

Both independent runs must satisfy all existing fail-loud hydraulic, EOS synchronization, boundedness, per-step component closure, outlet breakthrough/recovery, and cumulative nitrogen closure gates. Determinism uses zero tolerance; the scientific tolerances are unchanged.

## Baseline and change

On master, the full pulse is executed once. That establishes conservation and breakthrough but provides no repeated-run evidence. The existing method was extracted into one reusable scenario runner; the same frozen scenario is then initialized and executed twice. Immutable diagnostic arrays are retained only by the test.

This is validation evidence, not a claim that coupled grid/timestep convergence is complete. That remains the next Stage 2 gate.

## Validation

Local environment:

- OpenJDK runtime 17.0.19;
- Python 3.12.13;
- Java source target remains repository Java 8;
- Maven repository/dependencies are unavailable in the automation workspace.

Performed locally:

- exact diff review against master;
- Java compiler parser/type-shape pass on the changed source; diagnostics were only expected missing repository/JUnit classes;
- changed Java lines checked for repository line-length/style shape;
- no notebook or generated output changed.

Hosted CI is authoritative for compilation, the focused slow regression, Java 8/21 compatibility, Spotless, Javadocs, documentation checks, CodeQL, and broader suites. The PR remains draft and will not be marked ready or merged here.

## Documentation impact

Updated `docs/fluidmechanics/single_phase_pipe_flow.md` to state the exact deterministic evidence and retained limits. Full hydraulic/EOS grid-and-timestep convergence, thermal coupling, zero/reversed flow, TVD, physical dispersion, phase appearance, and Colab remain explicitly outside this increment.

## Compatibility and performance

- Public API: unchanged.
- Production behavior: unchanged.
- Numerical tolerances: unchanged.
- Test runtime: the existing slow integrated scenario executes twice.
- No proprietary data, commercial algorithm, or parity claim.

## Program history

- NeqSim master: `5c010191b00c2ec3cc7a09533f7f9010f4be4c82`.
- NeqSim-Colab master inspected: `5408e1991be2e6509f94a2efc12386e87bbec653`; no notebook change is dependency-ready.
- #2724 is merged in separate `TwoFluidPipe` files. Open #2775 is distillation-only; other open PRs do not overlap these two files.
- Stage: 2, integrated pulse determinism. Next gate after merge: coupled grid/timestep convergence without adding TVD or physical dispersion.
