### PR TITLE
fix(column): reject duplicate side-draw specifications

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -240,6 +240,13 @@ double drawResidual = spec.getLastRelativeResidual();
 boolean tearConverged = column.isLastColumnTearConverged();
 ```
 
+Each tray-phase pair has one manipulated split fraction and therefore accepts at most one flow
+specification. Adding a second target for the same tray and phase fails immediately with an
+`IllegalArgumentException`; opposite phases on the same tray and the same phase on different trays
+remain independent specifications. This degrees-of-freedom check prevents contradictory targets
+from alternately overwriting one tear variable. Older serialized columns retaining duplicates also
+fail before solver iteration and report the affected tray and phase.
+
 If the requested side-draw flow is physically impossible, the split is bounded by available tray
 traffic and the latest tear-variable diagnostics report non-convergence.
 

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1272,6 +1272,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     lastFullFractionatorFastPathApplied = false;
     lastFullFractionatorFastPathReason = "";
     resetMatrixInsideOutDiagnostics();
+    ensureIndependentSideDrawSpecifications();
     assignUnassignedFeeds();
     convergenceHistory = new ArrayList<>();
     applyDirectSpecifications();
@@ -9662,18 +9663,66 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param flowRate target flow rate
    * @param unit flow-rate unit
    * @return configured side-draw specification
-   * @throws IllegalArgumentException if the tray number, phase, flow rate, or unit is invalid
+   * @throws IllegalArgumentException if the tray number, phase, flow rate, or unit is invalid, or another flow
+   * specification already controls the same tray and phase
    */
   public ColumnSideDrawSpecification addSideDrawFlowSpecification(int trayNumber, SideDrawPhase phase, double flowRate,
       String unit) {
     validateTrayIndex(trayNumber, "side draw specification tray");
     ColumnSideDrawSpecification specification = new ColumnSideDrawSpecification(trayNumber, phase, flowRate, unit);
+    if (findSideDrawFlowSpecification(trayNumber, phase) != null) {
+      throw new IllegalArgumentException(createDuplicateSideDrawSpecificationMessage(trayNumber, phase));
+    }
     sideDrawSpecifications.add(specification);
     if (flowRate > 0.0 && getSideDrawFraction(trayNumber, phase) <= 0.0) {
       setSideDrawFractionWithinLimit(trayNumber, phase, 0.05);
     }
     setDoInitializion(true);
     return specification;
+  }
+
+  /**
+   * Find the flow specification controlling one tray-phase draw fraction.
+   *
+   * @param trayNumber bottom-up tray index
+   * @param phase side-draw phase
+   * @return matching specification, or {@code null} when the fraction is not flow-controlled
+   */
+  private ColumnSideDrawSpecification findSideDrawFlowSpecification(int trayNumber, SideDrawPhase phase) {
+    for (ColumnSideDrawSpecification specification : sideDrawSpecifications) {
+      if (specification.getTrayNumber() == trayNumber && specification.getPhase() == phase) {
+        return specification;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Create an actionable message for an over-specified side-draw fraction.
+   *
+   * @param trayNumber bottom-up tray index
+   * @param phase side-draw phase
+   * @return duplicate-control error message
+   */
+  private String createDuplicateSideDrawSpecificationMessage(int trayNumber, SideDrawPhase phase) {
+    return "Column " + getName() + " already has a " + phase + " side-draw flow specification on tray " + trayNumber
+        + "; configure at most one target for each tray and phase";
+  }
+
+  /**
+   * Reject duplicate controls retained in a column serialized by an older NeqSim version.
+   *
+   * @throws IllegalStateException if two specifications manipulate the same tray-phase draw fraction
+   */
+  private void ensureIndependentSideDrawSpecifications() {
+    Set<String> controlledFractions = new HashSet<>();
+    for (ColumnSideDrawSpecification specification : sideDrawSpecifications) {
+      String controlKey = specification.getTrayNumber() + ":" + specification.getPhase();
+      if (!controlledFractions.add(controlKey)) {
+        throw new IllegalStateException(
+            createDuplicateSideDrawSpecificationMessage(specification.getTrayNumber(), specification.getPhase()));
+      }
+    }
   }
 
   /**
@@ -12674,7 +12723,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param result validation result receiving issues
    */
   private void validateSideDrawSpecifications(ValidationResult result) {
+    Set<String> controlledFractions = new HashSet<>();
     for (ColumnSideDrawSpecification specification : sideDrawSpecifications) {
+      String controlKey = specification.getTrayNumber() + ":" + specification.getPhase();
+      if (!controlledFractions.add(controlKey)) {
+        result.addError("sidedraw.degreesOfFreedom",
+            createDuplicateSideDrawSpecificationMessage(specification.getTrayNumber(), specification.getPhase()),
+            "Keep one flow target for each tray and phase");
+      }
       if (specification.getTrayNumber() < 0 || specification.getTrayNumber() >= numberOfTrays) {
         result.addError("sidedraw.tray", "Side-draw specification tray is outside the column",
             "Use a tray number between 0 and column.getNumberOfTrays() - 1");

--- a/src/test/java/neqsim/process/equipment/distillation/SimpleTraySideDrawTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SimpleTraySideDrawTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
@@ -129,6 +130,34 @@ public class SimpleTraySideDrawTest {
   }
 
   /**
+   * Test that duplicate flow targets for one tray-phase side draw are rejected at registration.
+   */
+  @Test
+  public void duplicateSideDrawFlowSpecificationsAreRejectedAtRegistration() {
+    Stream feed = createFractionatorFeed("duplicate side draw feed");
+    DistillationColumn column = new DistillationColumn("DuplicateSideDrawColumn", 5, true, true);
+    column.addFeedStream(feed, 3);
+    column.setTopPressure(8.0);
+    column.setBottomPressure(8.3);
+    column.setCondenserTemperature(303.15);
+    column.setReboilerTemperature(383.15);
+    column.setCondenserRefluxRatio(1.5);
+
+    column.addSideDrawFlowSpecification(3, DistillationColumn.SideDrawPhase.LIQUID, 25.0, "kg/hr");
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> column.addSideDrawFlowSpecification(3, DistillationColumn.SideDrawPhase.LIQUID, 30.0, "kg/hr"));
+
+    String message = String.valueOf(exception.getMessage()).toLowerCase(Locale.ROOT);
+    assertTrue(message.contains("tray 3"));
+    assertTrue(message.contains("liquid"));
+    assertEquals(1, column.getSideDrawSpecifications().size());
+
+    column.addSideDrawFlowSpecification(3, DistillationColumn.SideDrawPhase.GAS, 5.0, "kg/hr");
+    column.addSideDrawFlowSpecification(4, DistillationColumn.SideDrawPhase.LIQUID, 5.0, "kg/hr");
+    assertEquals(3, column.getSideDrawSpecifications().size());
+  }
+
+  /**
    * Test that invalid side-draw fractions are rejected.
    */
   @Test
@@ -146,6 +175,25 @@ public class SimpleTraySideDrawTest {
     SimpleTray tray = new SimpleTray("liquid split validation tray");
     tray.setLiquidSideDrawFraction(0.60);
     assertThrows(IllegalArgumentException.class, () -> tray.setLiquidPumparoundDrawFraction(0.50));
+  }
+
+  /**
+   * Create a multicomponent hydrocarbon feed for fractionator configuration tests.
+   *
+   * @param name stream name
+   * @return initialized fractionator feed
+   */
+  private Stream createFractionatorFeed(String name) {
+    SystemSrkEos fluid = new SystemSrkEos(333.15, 8.0);
+    fluid.addComponent("propane", 0.20);
+    fluid.addComponent("n-butane", 0.35);
+    fluid.addComponent("n-pentane", 0.30);
+    fluid.addComponent("n-hexane", 0.15);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream(name, fluid);
+    feed.setFlowRate(250.0, "kg/hr");
+    feed.run();
+    return feed;
   }
 
   /**


### PR DESCRIPTION
## Problem and root cause

A side-draw flow specification manipulates exactly one tray split fraction identified by `(tray, phase)`. Current `master` allowed multiple flow targets to be registered for that same pair. During every outer tear iteration, both specifications read the same product stream and successively write the same fraction, so the last target overwrote the first. Contradictory equations therefore consumed iterations without defining a solvable degree-of-freedom set.

The defect affects every column solver used inside the side-draw tear loop, including sequential substitution, AUTO fallbacks, MESH residual, and Naphtali-Sandholm paths. It is a configuration/outer-coupling error rather than a thermodynamic-equation error.

## Baseline reproduction

A test-only commit configured a four-component SRK fractionator feed (propane through n-hexane), 250 kg/hr, 8.0–8.3 bara, with condenser, reboiler, and liquid side-draw flow control on tray 3. It then registered a contradictory second liquid-flow target on the same tray.

Java 21 Windows ran **11,177 tests** on that commit. The new regression was the only failure:

- `SimpleTraySideDrawTest.duplicateSideDrawFlowSpecificationsAreRejectedByDegreesOfFreedom`
- expected `IllegalArgumentException`, but no exception was thrown;
- **1 failure, 0 errors, 212 skipped**.

## Algorithmic change

- Reject a second flow specification for an already controlled tray-phase pair at registration.
- Preserve the first accepted specification without partial mutation.
- Check the same uniqueness invariant immediately before solving, so columns serialized by older versions fail before any tray iteration.
- Report duplicate control through `validateSetup()` as `sidedraw.degreesOfFreedom`.
- Keep opposite phases on one tray and the same phase on different trays as independent valid controls.

No flash, MESH, damping, tolerance, material, or energy equations changed.

## Regression and engineering validation

The deterministic regression uses an industrial-style multicomponent hydrocarbon fractionator configuration. It verifies:

- contradictory liquid targets on tray 3 are rejected;
- the diagnostic identifies both tray 3 and the liquid phase;
- the original accepted specification remains intact;
- a gas target on tray 3 is accepted as a nearby independent control;
- a liquid target on adjacent tray 4 is accepted as another nearby independent control.

Existing affected tests continue to cover achievable and impossible side-draw targets, bounded draw fractions, total mass balance, side-product exposure, and repeated tray-run cache refresh.

Final integrated validation on the branch base
(`5cf6719a5d78fc93732d7c0dffc85915d499e32c`, including merged fixed-reflux conservation PR #2775):

- `SimpleTraySideDrawTest`: **8 tests, 0 failures/errors**.
- Java 21 Windows fast suite: **11,180 tests, 0 failures, 0 errors, 212 skipped**; build success.
- Java 21 Ubuntu fast suite with JaCoCo: pass.
- All four Java 21 slow-test shards: pass.
- Java 21 Javadocs, pre-commit, Spotless, PaperLab, documentation coverage, and CodeQL: pass.
- Java 8 compatibility suites on Ubuntu and Windows remain in progress; no failure is reported.

After this validation started, unrelated pipe-test commit
`f49af02ca6dc9dd7fc05f5b5249b92c42049bcc7` merged to `master`. The PR is therefore one
unrelated commit behind while remaining mergeable; the three-file column diff is unchanged.

## Documentation impact

Updated `docs/process/equipment/distillation.md` to state the one-target-per-tray-phase rule, valid independent neighboring controls, registration failure, and backward-compatible pre-solve guard for serialized models.

## Compatibility and risk

Valid columns are unchanged. The public method signature and specification objects are retained. The intentional behavior change is fail-fast rejection of a configuration that was mathematically over-specified and could not converge to both targets. Legacy serialized columns with that invalid configuration now fail explicitly rather than iterating ambiguously. No performance claim is made; valid cases add only a small linear uniqueness check over the configured side-draw specifications.

## Remaining limitation

This change detects duplicate ownership of one side-draw fraction. It does not yet perform a complete structural rank analysis across terminal product, reflux, boilup, pumparound, and side-draw specifications.