### PR TITLE
Fix phase-resolved flash transfer in TwoFluidPipe

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-dynamic-simulation
 description: "Dynamic simulation guidance for NeqSim. USE WHEN: running transient simulations, modeling startup/shutdown, tuning PID controllers, analyzing pressure/level dynamics, performing blowdown/depressurization, or setting up measurement devices and control loops. Covers runTransient, DynamicProcessHelper, controller tuning, and dynamic equipment configuration."
-last_verified: "2026-07-31"
+last_verified: "2026-08-03"
 ---
 
 # Dynamic Simulation Guidance
@@ -375,6 +375,32 @@ vendor acceptance without certifying the protection system. For piping, pass ord
 line-pack balance before pressure, slug, velocity and stress limits, and deliberately does
 not treat a quasi-steady time series as distributed-transient evidence. Production mode
 requires the controlled context attribute `distributedTransientModel=approved`.
+
+## TwoFluidPipe Phase Appearance and Disappearance
+
+When `TwoFluidPipe.setIncludeMassTransfer(true)` is enabled, flash-driven transfer is phase
+resolved. Condensation must use equilibrium hydrocarbon-liquid and aqueous-liquid **mass**
+contributions; never use the current cell water cut to identify a phase that is not yet present.
+For evaporation, withdraw from the actual oil and water conservative inventories and bound each
+withdrawal by `phase mass / relaxation time`. An absent phase must have exactly zero evaporation
+source.
+
+Transferred momentum follows donor velocity. During condensation, gas loses mass and momentum at
+gas velocity and the receiving oil/water phases gain that momentum. During evaporation, each liquid
+loses momentum at its own velocity and gas receives their sum. Validate both invariants:
+
+```text
+gas mass source + oil mass source + water mass source = 0
+gas momentum source + oil momentum source + water momentum source = 0
+```
+
+For a phase-transition regression, cross a real SRK/CPA dew point in both directions without finite
+oil or water seeding. Check gas, oil, water, liquid, and total closure with
+`TwoFluidMassBalanceReport`; sweep nearby temperatures, refine time step and mesh, repeat the run,
+and compare rigorous flash with `FlashTable`. The flash table must retain the oil/aqueous liquid mass
+split. Record EOS, mixing rule, composition, absolute pressure, temperature, mass-transfer
+relaxation time, and units. The current hydrodynamic state transports bulk phase inventories, not a
+full component-composition vector per cell, and does not establish OLGA or LedaFlow equivalence.
 
 ## Running Dynamic Simulation
 

--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,27 @@
 
 ---
 
+## 2026-08-03 — TwoFluidPipe phase-resolved flash transfer
+
+### Corrected
+
+`ThermodynamicCoupling` now identifies phases by `PhaseType`, aggregates all hydrocarbon and
+aqueous liquid contributions, and returns immutable `PhaseMassTransfer` gas/oil/water sources.
+Condensation follows equilibrium liquid mass contributions. Evaporation follows and is limited by
+the actual conservative oil and water inventories. Transfer momentum uses donor velocity and is
+conservative across all three phases.
+
+`FlashTable` now stores the aggregate liquid fraction, oil/aqueous mass split, and gas/liquid molar
+masses. Existing serialized tables without these arrays return a rebuild diagnostic instead of
+silently reconstructing ambiguous liquid identity.
+
+### Compatibility and validation
+
+`calcMassTransferRatePerLength(...)` and the internal two-element gas/liquid adapter remain
+available. Code needing phase identity should call `calcPhaseMassTransferRatePerLength(...)` and
+read the SI-unit gas, oil, and water sources. Validate each phase with `TwoFluidMassBalanceReport`;
+total-mass closure alone does not prove correct liquid identity.
+
 ## 2026-08-03 — Capacity provenance in process-model throughput results
 
 ### Added

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -1,13 +1,13 @@
 ---
 title: TwoFluidPipe Model Documentation
-description: The NeqSim `TwoFluidPipe` model implements a transient two-fluid multiphase flow solver for pipeline and riser simulations. It solves separate conservation equations for gas and liquid phases, enablin...
+description: The NeqSim `TwoFluidPipe` model implements a transient multiphase-flow solver with phase-resolved gas, hydrocarbon-liquid, and aqueous-liquid conservation equations.
 ---
 
 # TwoFluidPipe Model Documentation
 
 ## Overview
 
-The NeqSim `TwoFluidPipe` model implements a transient two-fluid multiphase flow solver for pipeline and riser simulations. It solves separate conservation equations for gas and liquid phases, enabling accurate prediction of:
+The NeqSim `TwoFluidPipe` model implements a transient two-fluid multiphase flow solver for pipeline and riser simulations. It solves phase-resolved gas, hydrocarbon-liquid, and aqueous-liquid conservation equations, enabling prediction of:
 
 - Liquid holdup and accumulation
 - Pressure drop along the pipeline
@@ -22,19 +22,46 @@ The selectable closure sets are literature-inspired NeqSim implementations. Hist
 ## Conservation Equations
 
 ### Mass Conservation
-Separate mass conservation equations for gas and liquid phases:
+Separate mass conservation equations are solved for gas, hydrocarbon liquid, and aqueous liquid:
 
 | Equation | Mathematical Form | Description |
 |----------|-------------------|-------------|
-| Gas mass | ∂(αG ρG)/∂t + ∂(αG ρG vG)/∂x = ΓG | Gas phase continuity with mass transfer |
-| Liquid mass | ∂(αL ρL)/∂t + ∂(αL ρL vL)/∂x = -ΓG | Liquid phase continuity with mass transfer |
-| Mass transfer ΓG | Flash-based calculation | Evaporation/condensation with optional kinetic limits |
+| Gas mass | ∂(A αG ρG)/∂t + ∂(A αG ρG vG)/∂x = ΓG | Gas phase continuity with mass transfer |
+| Oil mass | ∂(A αO ρO)/∂t + ∂(A αO ρO vO)/∂x = ΓO | Hydrocarbon-liquid continuity |
+| Water mass | ∂(A αW ρW)/∂t + ∂(A αW ρW vW)/∂x = ΓW | Aqueous-liquid continuity |
+| Phase transfer | ΓG + ΓO + ΓW = 0 | Flash-based transfer with inventory limits |
 
 Where:
-- αG, αL = Gas and liquid volume fractions (holdup)
-- ρG, ρL = Phase densities [kg/m³]
-- vG, vL = Phase velocities [m/s]
-- ΓG = Mass transfer rate [kg/(m³·s)]
+- αG, αO, αW = gas, oil, and water volume fractions (holdup)
+- A = pipe cross-sectional area [m²]
+- ρG, ρO, ρW = phase densities [kg/m³]
+- vG, vO, vW = phase velocities [m/s]
+- ΓG, ΓO, ΓW = phase mass sources [kg/(m·s)] in the finite-volume implementation
+
+#### Flash-driven phase identity
+
+`ThermodynamicCoupling` identifies phases by `PhaseType`; it does not assume gas, oil, or aqueous
+phases occupy fixed array positions. A gas + oil + aqueous PT flash aggregates both liquid phases
+in the equilibrium-liquid target. For condensation, the new liquid is split using equilibrium oil
+and aqueous **mass** contributions. The current hydrodynamic water cut is intentionally not used at
+phase appearance because a gas-only cell contains no information about the identity of its first
+liquid.
+
+For evaporation, oil and water withdrawals are distributed from the actual conservative phase
+inventories. Each withdrawal is bounded by `phase mass / relaxation time`, so an absent phase cannot
+evaporate and no phase can be removed faster than the relaxation step permits. The immutable
+`PhaseMassTransfer` result reports gas, oil, and water sources in kg/(m s), together with flash
+convergence and applicability metadata.
+
+Transferred momentum uses donor velocity: condensing gas gives each receiving liquid gas momentum,
+while evaporating oil and water give the gas their respective liquid momenta. Transfer-only gas,
+oil, and water momentum sources therefore sum to zero. This closure preserves phase and total mass
+and mixture momentum, but the current hydrodynamic state still does not transport full component
+compositions independently in every cell.
+
+`FlashTable` stores the same aggregate liquid fraction, oil/aqueous liquid mass split, and gas/liquid
+molar masses as the rigorous flash path. Interpolated liquid identity fractions are clamped and
+renormalized; an identity that is absent at all surrounding grid points remains exactly zero.
 
 ### Momentum Conservation
 Separate momentum equations for each phase:
@@ -343,8 +370,9 @@ System.out.println(pipe.getThermalSummary());
 | Category | Feature | Method/Correlation |
 |----------|---------|--------------------|
 | **Conservation Equations** |
-| Gas mass | Full continuity equation | Flash-based mass transfer |
-| Liquid mass | Full continuity equation | Flash-based mass transfer |
+| Gas mass | Full continuity equation | Phase-resolved flash transfer |
+| Oil mass | Full continuity equation | Equilibrium mass split / donor inventory |
+| Water mass | Full continuity equation | Equilibrium mass split / donor inventory |
 | Gas momentum | 1D momentum balance | Wall and interfacial shear |
 | Liquid momentum | 1D momentum balance | Wall and interfacial shear |
 | Mixture energy | Full energy balance | Optional J-T effect |
@@ -490,11 +518,12 @@ larger engineering tolerance for long simulations after demonstrating time-step 
 sensitivity. Positivity limiting or any future non-conservative correction appears explicitly as a
 non-zero residual rather than being hidden.
 
-Gas-liquid phase transfer is added to one phase and removed from the other, so it cancels from the
-total source. Oil-water segregation is represented by separate phase momentum and face fluxes; it
-does not use a local oil-to-water mass relaxation. The IMEX pressure correction likewise changes
-phase momenta, not phase masses. Closed boundaries therefore have zero integrated boundary flux,
-while open boundaries close against the actual phase-resolved inlet and outlet fluxes.
+Flash-driven phase transfer is added to gas, oil, and water with
+$\Gamma_G+\Gamma_O+\Gamma_W=0$, so it cancels from the total source without losing liquid identity.
+Oil-water segregation is represented by separate phase momentum and face fluxes; it does not use a
+local oil-to-water mass relaxation. The IMEX pressure correction likewise changes phase momenta,
+not phase masses. Closed boundaries therefore have zero integrated boundary flux, while open
+boundaries close against the actual phase-resolved inlet and outlet fluxes.
 
 A steady-state solution remains a useful long-time comparison, but agreement must result from the
 transient balances and closure forces rather than overwriting the conserved state.

--- a/docs/wiki/two_fluid_reporting_and_validation.md
+++ b/docs/wiki/two_fluid_reporting_and_validation.md
@@ -125,6 +125,35 @@ inclined_section_gas_carryover_number,inclined_section_liquid_fallback_potential
 severe_slugging_number,severe_slug_potential
 ```
 
+### Phase-transfer validation
+
+When `setIncludeMassTransfer(true)` is enabled, validate gas, oil, and water separately rather than
+checking total mass alone. Condensation is assigned from the equilibrium oil/aqueous mass split,
+whereas evaporation is withdrawn from the actual donor inventories. The transfer-only requirements
+are:
+
+$$\Gamma_G+\Gamma_O+\Gamma_W=0$$
+
+and, using donor velocity for transferred momentum,
+
+$$S_{p,G}+S_{p,O}+S_{p,W}=0$$
+
+Use `TwoFluidMassBalanceReport` to check `GAS`, `OIL`, `WATER`, `LIQUID`, and `TOTAL`. A useful
+phase-transition test starts from a cell with no liquid seed, crosses the SRK/CPA dew point in both
+directions, and sweeps at least three nearby temperatures on each side. Report the EOS, mixing rule,
+composition, absolute pressure, temperature, relaxation time, time step, mesh, and phase inventories.
+Repeat the run to verify deterministic behavior and compare a refined time step and mesh.
+
+For an aqueous-first transition, the first condensation source must be water even though the
+gas-only hydrodynamic water cut defaults to zero. For an oil-first transition, the water source must
+remain zero. In a gas + oil + aqueous flash, the reported equilibrium liquid mass fractions must both
+be included and sum to one. `FlashTable` and rigorous-flash runs should give the same phase identity;
+use sufficiently fine tables near phase boundaries.
+
+The phase-resolved closure conserves bulk phase inventories, but it does not yet transport a full
+component-composition vector in every hydrodynamic cell. Do not interpret it as commercial-simulator
+equivalence or use total-mass closure alone as validation of liquid identity.
+
 The `severe_slugging_number` header is retained as a deprecated duplicate for CSV compatibility.
 It contains the local inclined-section gas-carryover number, not the explicit system stability
 result. New consumers should use `inclined_section_gas_carryover_number`. Call

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -5877,6 +5877,13 @@ public class TwoFluidPipe extends Pipeline {
   /**
    * Enable/disable mass transfer (flashing/condensation).
    *
+   * <p>
+   * When enabled, PT-flash equilibrium generates conservative gas, hydrocarbon-liquid, and aqueous-liquid sources.
+   * Condensation follows the equilibrium liquid mass split, while evaporation is limited by the actual oil and water
+   * inventories. Transferred momentum uses donor velocity. The hydrodynamic state tracks bulk phase inventories, not a
+   * complete component-composition vector in every cell.
+   * </p>
+   *
    * @param include true to include mass transfer
    */
   public void setIncludeMassTransfer(boolean include) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/FlashTable.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/FlashTable.java
@@ -74,6 +74,11 @@ public class FlashTable implements Serializable {
   private double[][] liquidSoundSpeed;
   private double[][] surfaceTension;
   private double[][] gasVaporFraction;
+  private double[][] liquidFraction;
+  private double[][] oilMassFractionOfLiquid;
+  private double[][] aqueousMassFractionOfLiquid;
+  private double[][] gasMolarMass;
+  private double[][] liquidMolarMass;
   private double[][] gasCp;
   private double[][] liquidCp;
   private double[][] gasCompressibility;
@@ -134,6 +139,11 @@ public class FlashTable implements Serializable {
     liquidSoundSpeed = new double[nP][nT];
     surfaceTension = new double[nP][nT];
     gasVaporFraction = new double[nP][nT];
+    liquidFraction = new double[nP][nT];
+    oilMassFractionOfLiquid = new double[nP][nT];
+    aqueousMassFractionOfLiquid = new double[nP][nT];
+    gasMolarMass = new double[nP][nT];
+    liquidMolarMass = new double[nP][nT];
     gasCp = new double[nP][nT];
     liquidCp = new double[nP][nT];
     gasCompressibility = new double[nP][nT];
@@ -157,6 +167,11 @@ public class FlashTable implements Serializable {
         liquidSoundSpeed[i][j] = props.liquidSoundSpeed;
         surfaceTension[i][j] = props.surfaceTension;
         gasVaporFraction[i][j] = props.gasVaporFraction;
+        liquidFraction[i][j] = props.liquidFraction;
+        oilMassFractionOfLiquid[i][j] = props.oilMassFractionOfLiquid;
+        aqueousMassFractionOfLiquid[i][j] = props.aqueousMassFractionOfLiquid;
+        gasMolarMass[i][j] = props.gasMolarMass;
+        liquidMolarMass[i][j] = props.liquidMolarMass;
         gasCp[i][j] = props.gasCp;
         liquidCp[i][j] = props.liquidCp;
         gasCompressibility[i][j] = props.gasCompressibility;
@@ -180,6 +195,12 @@ public class FlashTable implements Serializable {
     if (!isBuilt) {
       props.converged = false;
       props.errorMessage = "Flash table not built";
+      return props;
+    }
+    if (liquidFraction == null || oilMassFractionOfLiquid == null || aqueousMassFractionOfLiquid == null
+        || gasMolarMass == null || liquidMolarMass == null) {
+      props.converged = false;
+      props.errorMessage = "Flash table predates phase-resolved properties and must be rebuilt";
       return props;
     }
 
@@ -214,12 +235,30 @@ public class FlashTable implements Serializable {
     props.liquidSoundSpeed = bilinearInterp(liquidSoundSpeed, iP, iT, wP, wT);
     props.surfaceTension = bilinearInterp(surfaceTension, iP, iT, wP, wT);
     props.gasVaporFraction = bilinearInterp(gasVaporFraction, iP, iT, wP, wT);
+    props.liquidFraction = bilinearInterp(liquidFraction, iP, iT, wP, wT);
+    props.oilMassFractionOfLiquid = bilinearInterp(oilMassFractionOfLiquid, iP, iT, wP, wT);
+    props.aqueousMassFractionOfLiquid = bilinearInterp(aqueousMassFractionOfLiquid, iP, iT, wP, wT);
+    props.gasMolarMass = bilinearInterp(gasMolarMass, iP, iT, wP, wT);
+    props.liquidMolarMass = bilinearInterp(liquidMolarMass, iP, iT, wP, wT);
     props.gasCp = bilinearInterp(gasCp, iP, iT, wP, wT);
     props.liquidCp = bilinearInterp(liquidCp, iP, iT, wP, wT);
     props.gasCompressibility = bilinearInterp(gasCompressibility, iP, iT, wP, wT);
     props.liquidCompressibility = bilinearInterp(liquidCompressibility, iP, iT, wP, wT);
 
-    props.liquidFraction = 1.0 - props.gasVaporFraction;
+    double fluidFractionSum = Math.max(0.0, props.gasVaporFraction) + Math.max(0.0, props.liquidFraction);
+    if (fluidFractionSum > 0.0) {
+      props.gasVaporFraction = Math.max(0.0, props.gasVaporFraction) / fluidFractionSum;
+      props.liquidFraction = 1.0 - props.gasVaporFraction;
+    }
+    double liquidMassFractionSum = Math.max(0.0, props.oilMassFractionOfLiquid)
+        + Math.max(0.0, props.aqueousMassFractionOfLiquid);
+    if (props.liquidFraction > 0.0 && liquidMassFractionSum > 0.0) {
+      props.oilMassFractionOfLiquid = Math.max(0.0, props.oilMassFractionOfLiquid) / liquidMassFractionSum;
+      props.aqueousMassFractionOfLiquid = 1.0 - props.oilMassFractionOfLiquid;
+    } else {
+      props.oilMassFractionOfLiquid = 0.0;
+      props.aqueousMassFractionOfLiquid = 0.0;
+    }
     props.converged = true;
 
     return props;
@@ -279,6 +318,12 @@ public class FlashTable implements Serializable {
       return props.surfaceTension;
     case "gasvaporfraction":
       return props.gasVaporFraction;
+    case "liquidfraction":
+      return props.liquidFraction;
+    case "oilmassfractionofliquid":
+      return props.oilMassFractionOfLiquid;
+    case "aqueousmassfractionofliquid":
+      return props.aqueousMassFractionOfLiquid;
     default:
       return Double.NaN;
     }
@@ -380,8 +425,8 @@ public class FlashTable implements Serializable {
    * @return Approximate memory usage in bytes
    */
   public long estimateMemoryUsage() {
-    // 14 property tables * nP * nT * 8 bytes per double
-    return 14L * nP * nT * 8;
+    // 19 property tables * nP * nT * 8 bytes per double
+    return 19L * nP * nT * 8;
   }
 
   /**
@@ -400,6 +445,11 @@ public class FlashTable implements Serializable {
     liquidSoundSpeed = null;
     surfaceTension = null;
     gasVaporFraction = null;
+    liquidFraction = null;
+    oilMassFractionOfLiquid = null;
+    aqueousMassFractionOfLiquid = null;
+    gasMolarMass = null;
+    liquidMolarMass = null;
     gasCp = null;
     liquidCp = null;
     gasCompressibility = null;

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/PhaseMassTransfer.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/PhaseMassTransfer.java
@@ -1,0 +1,127 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import java.io.Serializable;
+
+/**
+ * Immutable phase-resolved flash mass-transfer sources for a pipe cell.
+ *
+ * <p>
+ * Positive source values add mass to a phase and negative values remove mass. All values use SI units of kg/(m s). A
+ * valid result conserves mass across gas, hydrocarbon liquid, and aqueous liquid to floating-point precision.
+ * </p>
+ */
+public final class PhaseMassTransfer implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final double gasSourceKgPerMetreSecond;
+  private final double oilSourceKgPerMetreSecond;
+  private final double waterSourceKgPerMetreSecond;
+  private final boolean flashConverged;
+  private final boolean applicable;
+  private final String errorMessage;
+
+  /**
+   * Create a phase-resolved mass-transfer result.
+   *
+   * @param gasSourceKgPerMetreSecond gas source in kg/(m s)
+   * @param oilSourceKgPerMetreSecond hydrocarbon-liquid source in kg/(m s)
+   * @param waterSourceKgPerMetreSecond aqueous-liquid source in kg/(m s)
+   * @param flashConverged whether the equilibrium flash converged
+   * @param applicable whether phase transfer was applicable at the evaluated state
+   * @param errorMessage diagnostic message, or {@code null} when no error occurred
+   */
+  public PhaseMassTransfer(double gasSourceKgPerMetreSecond, double oilSourceKgPerMetreSecond,
+      double waterSourceKgPerMetreSecond, boolean flashConverged, boolean applicable, String errorMessage) {
+    if (!Double.isFinite(gasSourceKgPerMetreSecond) || !Double.isFinite(oilSourceKgPerMetreSecond)
+        || !Double.isFinite(waterSourceKgPerMetreSecond)) {
+      throw new IllegalArgumentException("Phase mass-transfer sources must be finite");
+    }
+    double scale = Math.max(1.0, Math.max(Math.abs(gasSourceKgPerMetreSecond),
+        Math.max(Math.abs(oilSourceKgPerMetreSecond), Math.abs(waterSourceKgPerMetreSecond))));
+    double residual = gasSourceKgPerMetreSecond + oilSourceKgPerMetreSecond + waterSourceKgPerMetreSecond;
+    if (Math.abs(residual) > 1.0e-12 * scale) {
+      throw new IllegalArgumentException("Phase mass-transfer sources must sum to zero");
+    }
+    this.gasSourceKgPerMetreSecond = gasSourceKgPerMetreSecond;
+    this.oilSourceKgPerMetreSecond = oilSourceKgPerMetreSecond;
+    this.waterSourceKgPerMetreSecond = waterSourceKgPerMetreSecond;
+    this.flashConverged = flashConverged;
+    this.applicable = applicable;
+    this.errorMessage = errorMessage;
+  }
+
+  /**
+   * Create a zero-source result.
+   *
+   * @param flashConverged whether the equilibrium flash converged
+   * @param applicable whether phase transfer was applicable at the evaluated state
+   * @param errorMessage diagnostic message, or {@code null}
+   * @return immutable zero-source result
+   */
+  public static PhaseMassTransfer zero(boolean flashConverged, boolean applicable, String errorMessage) {
+    return new PhaseMassTransfer(0.0, 0.0, 0.0, flashConverged, applicable, errorMessage);
+  }
+
+  /**
+   * Get the gas source.
+   *
+   * @return gas source in kg/(m s)
+   */
+  public double getGasSourceKgPerMetreSecond() {
+    return gasSourceKgPerMetreSecond;
+  }
+
+  /**
+   * Get the hydrocarbon-liquid source.
+   *
+   * @return oil source in kg/(m s)
+   */
+  public double getOilSourceKgPerMetreSecond() {
+    return oilSourceKgPerMetreSecond;
+  }
+
+  /**
+   * Get the aqueous-liquid source.
+   *
+   * @return water source in kg/(m s)
+   */
+  public double getWaterSourceKgPerMetreSecond() {
+    return waterSourceKgPerMetreSecond;
+  }
+
+  /**
+   * Get the sum of all phase sources.
+   *
+   * @return total source in kg/(m s), nominally zero
+   */
+  public double getTotalSourceKgPerMetreSecond() {
+    return gasSourceKgPerMetreSecond + oilSourceKgPerMetreSecond + waterSourceKgPerMetreSecond;
+  }
+
+  /**
+   * Check whether the flash converged.
+   *
+   * @return {@code true} when the equilibrium flash converged
+   */
+  public boolean isFlashConverged() {
+    return flashConverged;
+  }
+
+  /**
+   * Check whether the transfer calculation was applicable.
+   *
+   * @return {@code true} when the result applies to the evaluated state
+   */
+  public boolean isApplicable() {
+    return applicable;
+  }
+
+  /**
+   * Get the diagnostic error message.
+   *
+   * @return error message, or {@code null}
+   */
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/ThermodynamicCoupling.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/ThermodynamicCoupling.java
@@ -1,6 +1,8 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
 import java.io.Serializable;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
@@ -15,7 +17,8 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * <h2>Key Functions</h2>
  * <ul>
  * <li>Update phase densities, viscosities, and enthalpies from P-T flash</li>
- * <li>Calculate phase compositions and mass transfer rates</li>
+ * <li>Aggregate gas, hydrocarbon-liquid, and aqueous-liquid contributions by {@link PhaseType}</li>
+ * <li>Calculate conservative phase-resolved mass transfer rates with donor-inventory limits</li>
  * <li>Provide sound speeds for wave propagation</li>
  * <li>Support for both rigorous flash and table interpolation</li>
  * </ul>
@@ -75,6 +78,12 @@ public class ThermodynamicCoupling implements Serializable {
 
     /** Liquid mole fraction. */
     public double liquidFraction;
+
+    /** Hydrocarbon-liquid mass fraction of total equilibrium liquid. */
+    public double oilMassFractionOfLiquid;
+
+    /** Aqueous-liquid mass fraction of total equilibrium liquid. */
+    public double aqueousMassFractionOfLiquid;
 
     // Densities
     /** Gas density (kg/m³). */
@@ -223,80 +232,7 @@ public class ThermodynamicCoupling implements Serializable {
       ops.TPflash();
       fluid.initProperties();
 
-      // Extract phase fractions
-      if (fluid.getNumberOfPhases() >= 2) {
-        props.gasVaporFraction = fluid.getPhase(0).getBeta();
-        props.liquidFraction = fluid.getPhase(1).getBeta();
-      } else if (fluid.getNumberOfPhases() == 1) {
-        // Single phase - determine if gas or liquid
-        double density = fluid.getPhase(0).getDensity("kg/m3");
-        if (density < 100.0) {
-          props.gasVaporFraction = 1.0;
-          props.liquidFraction = 0.0;
-        } else {
-          props.gasVaporFraction = 0.0;
-          props.liquidFraction = 1.0;
-        }
-      }
-
-      // Extract gas properties (phase 0 = vapor)
-      if (fluid.hasPhaseType("gas")) {
-        int gasIndex = fluid.getPhaseIndex("gas");
-        props.gasDensity = fluid.getPhase(gasIndex).getDensity("kg/m3");
-        props.gasViscosity = fluid.getPhase(gasIndex).getViscosity("kg/msec");
-        props.gasEnthalpy = fluid.getPhase(gasIndex).getEnthalpy("J/kg");
-        props.gasSoundSpeed = fluid.getPhase(gasIndex).getSoundSpeed("m/s");
-        props.gasMolarMass = fluid.getPhase(gasIndex).getMolarMass() * 1000; // kg/kmol
-        props.gasCompressibility = fluid.getPhase(gasIndex).getZ();
-        props.gasCp = fluid.getPhase(gasIndex).getCp("J/kgK");
-        props.gasThermalConductivity = fluid.getPhase(gasIndex).getThermalConductivity("W/mK");
-      } else {
-        // Default gas properties for single-phase liquid
-        props.gasDensity = 1.0;
-        props.gasViscosity = 1e-5;
-        props.gasSoundSpeed = 340.0;
-      }
-
-      // Extract liquid properties (phase 1 = oil, or phase 2 = aqueous)
-      if (fluid.hasPhaseType("oil")) {
-        int liqIndex = fluid.getPhaseIndex("oil");
-        props.liquidDensity = fluid.getPhase(liqIndex).getDensity("kg/m3");
-        props.liquidViscosity = fluid.getPhase(liqIndex).getViscosity("kg/msec");
-        props.liquidEnthalpy = fluid.getPhase(liqIndex).getEnthalpy("J/kg");
-        props.liquidSoundSpeed = fluid.getPhase(liqIndex).getSoundSpeed("m/s");
-        props.liquidMolarMass = fluid.getPhase(liqIndex).getMolarMass() * 1000;
-        props.liquidCompressibility = fluid.getPhase(liqIndex).getZ();
-        props.liquidCp = fluid.getPhase(liqIndex).getCp("J/kgK");
-        props.liquidThermalConductivity = fluid.getPhase(liqIndex).getThermalConductivity("W/mK");
-      } else if (fluid.hasPhaseType("aqueous")) {
-        int liqIndex = fluid.getPhaseIndex("aqueous");
-        props.liquidDensity = fluid.getPhase(liqIndex).getDensity("kg/m3");
-        props.liquidViscosity = fluid.getPhase(liqIndex).getViscosity("kg/msec");
-        props.liquidEnthalpy = fluid.getPhase(liqIndex).getEnthalpy("J/kg");
-        props.liquidSoundSpeed = fluid.getPhase(liqIndex).getSoundSpeed("m/s");
-        props.liquidMolarMass = fluid.getPhase(liqIndex).getMolarMass() * 1000;
-        props.liquidCompressibility = fluid.getPhase(liqIndex).getZ();
-        props.liquidCp = fluid.getPhase(liqIndex).getCp("J/kgK");
-        props.liquidThermalConductivity = fluid.getPhase(liqIndex).getThermalConductivity("W/mK");
-      } else {
-        // Default liquid properties for single-phase gas
-        props.liquidDensity = 800.0;
-        props.liquidViscosity = 1e-3;
-        props.liquidSoundSpeed = 1200.0;
-      }
-
-      // Surface tension
-      if (fluid.getNumberOfPhases() >= 2) {
-        try {
-          props.surfaceTension = fluid.getInterphaseProperties().getSurfaceTension(0, 1);
-        } catch (Exception e) {
-          props.surfaceTension = 0.02; // Default 20 mN/m
-        }
-      } else {
-        props.surfaceTension = 0.02;
-      }
-
-      props.converged = true;
+      props = extractProperties(fluid);
 
     } catch (Exception e) {
       props.converged = false;
@@ -313,6 +249,180 @@ public class ThermodynamicCoupling implements Serializable {
     }
 
     return props;
+  }
+
+  /**
+   * Extract phase-aggregated properties by phase identity rather than phase-array position.
+   *
+   * <p>
+   * Hydrocarbon phases of type {@link PhaseType#OIL}, {@link PhaseType#LIQUID}, and {@link PhaseType#LIQUID_ASPHALTENE}
+   * are accumulated as oil. All aqueous contributions are accumulated separately. Aggregate liquid transport properties
+   * are mass weighted, while the aggregate liquid density is calculated from total liquid mass divided by total liquid
+   * volume.
+   * </p>
+   *
+   * @param fluid flashed and property-initialized fluid
+   * @return phase-aggregated properties
+   */
+  ThermoProperties extractProperties(SystemInterface fluid) {
+    ThermoProperties props = new ThermoProperties();
+    double gasMoles = 0.0;
+    double gasMass = 0.0;
+    double gasVolume = 0.0;
+    double oilMoles = 0.0;
+    double oilMass = 0.0;
+    double oilVolume = 0.0;
+    double aqueousMoles = 0.0;
+    double aqueousMass = 0.0;
+    double aqueousVolume = 0.0;
+    double gasViscosityMassSum = 0.0;
+    double gasEnthalpyMassSum = 0.0;
+    double gasSoundSpeedMassSum = 0.0;
+    double gasCpMassSum = 0.0;
+    double gasConductivityMassSum = 0.0;
+    double gasCompressibilityMoleSum = 0.0;
+    double liquidViscosityMassSum = 0.0;
+    double liquidEnthalpyMassSum = 0.0;
+    double liquidSoundSpeedMassSum = 0.0;
+    double liquidCpMassSum = 0.0;
+    double liquidConductivityMassSum = 0.0;
+    double liquidCompressibilityMoleSum = 0.0;
+    int gasPhaseIndex = -1;
+    double surfaceTensionMassSum = 0.0;
+
+    for (int phaseIndex = 0; phaseIndex < fluid.getNumberOfPhases(); phaseIndex++) {
+      PhaseInterface phase = fluid.getPhase(phaseIndex);
+      PhaseType phaseType = phase.getType();
+      double beta = Math.max(0.0, phase.getBeta());
+      double molarMass = Math.max(0.0, phase.getMolarMass() * 1000.0);
+      double massContribution = beta * molarMass;
+      double density = Math.max(phase.getDensity("kg/m3"), 1.0e-12);
+      double volumeContribution = massContribution / density;
+
+      if (phaseType == PhaseType.GAS) {
+        gasPhaseIndex = phaseIndex;
+        gasMoles += beta;
+        gasMass += massContribution;
+        gasVolume += volumeContribution;
+        gasViscosityMassSum += massContribution * phase.getViscosity("kg/msec");
+        gasEnthalpyMassSum += massContribution * phase.getEnthalpy("J/kg");
+        gasSoundSpeedMassSum += massContribution * phase.getSoundSpeed("m/s");
+        gasCpMassSum += massContribution * phase.getCp("J/kgK");
+        gasConductivityMassSum += massContribution * phase.getThermalConductivity("W/mK");
+        gasCompressibilityMoleSum += beta * phase.getZ();
+      } else if (isHydrocarbonLiquid(phaseType) || phaseType == PhaseType.AQUEOUS) {
+        if (phaseType == PhaseType.AQUEOUS) {
+          aqueousMoles += beta;
+          aqueousMass += massContribution;
+          aqueousVolume += volumeContribution;
+        } else {
+          oilMoles += beta;
+          oilMass += massContribution;
+          oilVolume += volumeContribution;
+        }
+        liquidViscosityMassSum += massContribution * phase.getViscosity("kg/msec");
+        liquidEnthalpyMassSum += massContribution * phase.getEnthalpy("J/kg");
+        liquidSoundSpeedMassSum += massContribution * phase.getSoundSpeed("m/s");
+        liquidCpMassSum += massContribution * phase.getCp("J/kgK");
+        liquidConductivityMassSum += massContribution * phase.getThermalConductivity("W/mK");
+        liquidCompressibilityMoleSum += beta * phase.getZ();
+      }
+    }
+
+    double liquidMoles = oilMoles + aqueousMoles;
+    double liquidMass = oilMass + aqueousMass;
+    double liquidVolume = oilVolume + aqueousVolume;
+    double classifiedMoles = gasMoles + liquidMoles;
+    if (classifiedMoles > 0.0) {
+      props.gasVaporFraction = gasMoles / classifiedMoles;
+      props.liquidFraction = liquidMoles / classifiedMoles;
+    }
+    if (liquidMass > 0.0) {
+      props.oilMassFractionOfLiquid = oilMass / liquidMass;
+      props.aqueousMassFractionOfLiquid = 1.0 - props.oilMassFractionOfLiquid;
+    }
+
+    if (gasMass > 0.0 && gasMoles > 0.0 && gasVolume > 0.0) {
+      props.gasDensity = gasMass / gasVolume;
+      props.gasMolarMass = gasMass / gasMoles;
+      props.gasViscosity = gasViscosityMassSum / gasMass;
+      props.gasEnthalpy = gasEnthalpyMassSum / gasMass;
+      props.gasSoundSpeed = gasSoundSpeedMassSum / gasMass;
+      props.gasCp = gasCpMassSum / gasMass;
+      props.gasThermalConductivity = gasConductivityMassSum / gasMass;
+      props.gasCompressibility = gasCompressibilityMoleSum / gasMoles;
+    } else {
+      setDefaultGasProperties(props);
+    }
+
+    if (liquidMass > 0.0 && liquidMoles > 0.0 && liquidVolume > 0.0) {
+      props.liquidDensity = liquidMass / liquidVolume;
+      props.liquidMolarMass = liquidMass / liquidMoles;
+      props.liquidViscosity = liquidViscosityMassSum / liquidMass;
+      props.liquidEnthalpy = liquidEnthalpyMassSum / liquidMass;
+      props.liquidSoundSpeed = liquidSoundSpeedMassSum / liquidMass;
+      props.liquidCp = liquidCpMassSum / liquidMass;
+      props.liquidThermalConductivity = liquidConductivityMassSum / liquidMass;
+      props.liquidCompressibility = liquidCompressibilityMoleSum / liquidMoles;
+    } else {
+      setDefaultLiquidProperties(props);
+    }
+
+    if (gasPhaseIndex >= 0 && liquidMass > 0.0) {
+      for (int phaseIndex = 0; phaseIndex < fluid.getNumberOfPhases(); phaseIndex++) {
+        PhaseInterface phase = fluid.getPhase(phaseIndex);
+        if (isHydrocarbonLiquid(phase.getType()) || phase.getType() == PhaseType.AQUEOUS) {
+          double phaseMass = Math.max(0.0, phase.getBeta() * phase.getMolarMass() * 1000.0);
+          try {
+            surfaceTensionMassSum += phaseMass
+                * fluid.getInterphaseProperties().getSurfaceTension(gasPhaseIndex, phaseIndex);
+          } catch (Exception ignored) {
+            surfaceTensionMassSum += phaseMass * 0.02;
+          }
+        }
+      }
+      props.surfaceTension = surfaceTensionMassSum / liquidMass;
+    } else {
+      props.surfaceTension = 0.02;
+    }
+    props.converged = true;
+    return props;
+  }
+
+  /**
+   * Check whether a NeqSim phase type belongs to the hydrocarbon-liquid inventory.
+   *
+   * @param phaseType phase identity
+   * @return {@code true} for oil-like liquid phase types
+   */
+  private boolean isHydrocarbonLiquid(PhaseType phaseType) {
+    return phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID || phaseType == PhaseType.LIQUID_ASPHALTENE;
+  }
+
+  /**
+   * Set finite gas placeholders when no equilibrium gas phase is present.
+   *
+   * @param props property result to update
+   */
+  private void setDefaultGasProperties(ThermoProperties props) {
+    props.gasDensity = 1.0;
+    props.gasViscosity = 1.0e-5;
+    props.gasSoundSpeed = 340.0;
+    props.gasMolarMass = 20.0;
+    props.gasCompressibility = 1.0;
+  }
+
+  /**
+   * Set finite liquid placeholders when no equilibrium liquid phase is present.
+   *
+   * @param props property result to update
+   */
+  private void setDefaultLiquidProperties(ThermoProperties props) {
+    props.liquidDensity = 800.0;
+    props.liquidViscosity = 1.0e-3;
+    props.liquidSoundSpeed = 1200.0;
+    props.liquidMolarMass = 100.0;
+    props.liquidCompressibility = 0.01;
   }
 
   /**
@@ -446,14 +556,77 @@ public class ThermodynamicCoupling implements Serializable {
    * @return gas mass source per length, kg/(m*s)
    */
   public double calcMassTransferRatePerLength(TwoFluidSection section, double relaxationTime) {
+    return calcPhaseMassTransferRatePerLength(section, relaxationTime).getGasSourceKgPerMetreSecond();
+  }
+
+  /**
+   * Calculate conservative gas, hydrocarbon-liquid, and aqueous-liquid transfer sources.
+   *
+   * <p>
+   * Condensation is split using equilibrium liquid mass contributions from the PT flash. Evaporation is split using the
+   * actual donor inventories and each withdrawal is limited by that phase inventory divided by the relaxation time.
+   * Consequently an absent oil or water phase cannot evaporate. Positive gas source denotes evaporation and negative
+   * gas source denotes condensation.
+   * </p>
+   *
+   * @param section current pipe section
+   * @param relaxationTime relaxation time toward flash equilibrium in seconds
+   * @return immutable phase-resolved sources in kg/(m s)
+   */
+  public PhaseMassTransfer calcPhaseMassTransferRatePerLength(TwoFluidSection section, double relaxationTime) {
     if (referenceFluid == null || relaxationTime <= 0.0 || !Double.isFinite(relaxationTime)) {
-      return 0.0;
+      return PhaseMassTransfer.zero(false, false, "Reference fluid and a positive relaxation time are required");
     }
 
     ThermoProperties eqProps = flashPT(section.getPressure(), section.getTemperature());
     if (!eqProps.converged) {
-      return 0.0;
+      return PhaseMassTransfer.zero(false, false, eqProps.errorMessage);
     }
+
+    double gasSource = calculateScalarGasSourcePerLength(section, relaxationTime, eqProps);
+    if (gasSource < 0.0) {
+      double oilFraction = Math.max(0.0, eqProps.oilMassFractionOfLiquid);
+      double waterFraction = Math.max(0.0, eqProps.aqueousMassFractionOfLiquid);
+      double fractionSum = oilFraction + waterFraction;
+      if (fractionSum <= 1.0e-15) {
+        return PhaseMassTransfer.zero(true, false,
+            "Equilibrium liquid exists but its oil/aqueous identity is unavailable");
+      }
+      oilFraction /= fractionSum;
+      double liquidSource = -gasSource;
+      double oilSource = liquidSource * oilFraction;
+      double waterSource = -gasSource - oilSource;
+      return new PhaseMassTransfer(gasSource, oilSource, waterSource, true, true, null);
+    }
+
+    if (gasSource > 0.0) {
+      double oilInventory = Math.max(0.0, section.getOilMassPerLength());
+      double waterInventory = Math.max(0.0, section.getWaterMassPerLength());
+      double liquidInventory = oilInventory + waterInventory;
+      if (liquidInventory <= 0.0) {
+        return PhaseMassTransfer.zero(true, true, null);
+      }
+      double oilWithdrawal = Math.min(gasSource * oilInventory / liquidInventory, oilInventory / relaxationTime);
+      double waterWithdrawal = Math.min(gasSource - oilWithdrawal, waterInventory / relaxationTime);
+      double boundedGasSource = oilWithdrawal + waterWithdrawal;
+      double oilSource = -oilWithdrawal;
+      double waterSource = -boundedGasSource - oilSource;
+      return new PhaseMassTransfer(boundedGasSource, oilSource, waterSource, true, true, null);
+    }
+
+    return PhaseMassTransfer.zero(true, true, null);
+  }
+
+  /**
+   * Calculate the legacy aggregate gas source from departure from equilibrium liquid inventory.
+   *
+   * @param section current pipe section
+   * @param relaxationTime relaxation time in seconds
+   * @param eqProps equilibrium properties at section pressure and temperature
+   * @return aggregate gas source in kg/(m s)
+   */
+  private double calculateScalarGasSourcePerLength(TwoFluidSection section, double relaxationTime,
+      ThermoProperties eqProps) {
 
     double gasDensity = Math.max(eqProps.gasDensity, 0.1);
     double liquidDensity = Math.max(eqProps.liquidDensity, 100.0);

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -612,15 +612,15 @@ public class TwoFluidConservationEquations implements Serializable {
       }
 
       // Mass transfer source (if enabled)
-      double Gamma_G = 0;
-      double Gamma_L = 0;
+      PhaseMassTransfer phaseMassTransfer = PhaseMassTransfer.zero(true, true, null);
       if (includeMassTransfer) {
-        // Simplified equilibrium departure model
-        // Positive Gamma = evaporation (liquid to gas)
-        double[] massTransfer = calcMassTransfer(sec);
-        Gamma_G = massTransfer[0];
-        Gamma_L = massTransfer[1];
+        phaseMassTransfer = calcPhaseMassTransfer(sec);
       }
+      double Gamma_G = phaseMassTransfer.getGasSourceKgPerMetreSecond();
+      double Gamma_O = phaseMassTransfer.getOilSourceKgPerMetreSecond();
+      double Gamma_W = phaseMassTransfer.getWaterSourceKgPerMetreSecond();
+      double Gamma_L = Gamma_O + Gamma_W;
+      double[] transferMomentum = calcTransferMomentumSources(sec, phaseMassTransfer);
 
       // Assemble source terms - now with separate oil and water mass equations
       sources[i][IDX_GAS_MASS] = Gamma_G;
@@ -629,8 +629,8 @@ public class TwoFluidConservationEquations implements Serializable {
       // transported through phase fluxes. A local mass relaxation would convert oil
       // into water (or vice versa) and, because their densities differ, would also
       // change total inventory without a conservative face flux.
-      sources[i][IDX_OIL_MASS] = Gamma_L * (1.0 - waterCut);
-      sources[i][IDX_WATER_MASS] = Gamma_L * waterCut;
+      sources[i][IDX_OIL_MASS] = Gamma_O;
+      sources[i][IDX_WATER_MASS] = Gamma_W;
 
       // Virtual mass force calculation (Drew & Lahey, 1987)
       // F_vm = C_vm * alpha_dispersed * rho_continuous * (dv_dispersed/dt - dv_continuous/dt)
@@ -666,7 +666,7 @@ public class TwoFluidConservationEquations implements Serializable {
         F_vmL = -F_vmG; // Newton's third law: equal and opposite on liquid
       }
 
-      sources[i][IDX_GAS_MOMENTUM] = F_wG + F_iG + F_gG + F_vmG + Gamma_G * sec.getGasVelocity();
+      sources[i][IDX_GAS_MOMENTUM] = F_wG + F_iG + F_gG + F_vmG + transferMomentum[0];
 
       if (enableWaterOilSlip && NUM_EQUATIONS == 7) {
         // Separate oil and water momentum equations
@@ -724,15 +724,13 @@ public class TwoFluidConservationEquations implements Serializable {
         double F_vmW = F_vmL * waterHoldupFrac;
 
         // Assemble oil momentum source
-        sources[i][IDX_OIL_MOMENTUM] = F_wO + F_iO + F_gO + F_ow_oil + F_vmO
-            + Gamma_L * (1.0 - waterCut) * sec.getOilVelocity();
+        sources[i][IDX_OIL_MOMENTUM] = F_wO + F_iO + F_gO + F_ow_oil + F_vmO + transferMomentum[1];
 
         // Assemble water momentum source
-        sources[i][IDX_WATER_MOMENTUM] = F_wW + F_iW + F_gW + F_ow_water + F_vmW
-            + Gamma_L * waterCut * sec.getWaterVelocity();
+        sources[i][IDX_WATER_MOMENTUM] = F_wW + F_iW + F_gW + F_ow_water + F_vmW + transferMomentum[2];
       } else {
         // Combined liquid momentum (original 6-equation model)
-        sources[i][IDX_OIL_MOMENTUM] = F_wL + F_iL + F_gL + F_vmL + Gamma_L * sec.getLiquidVelocity();
+        sources[i][IDX_OIL_MOMENTUM] = F_wL + F_iL + F_gL + F_vmL + transferMomentum[1] + transferMomentum[2];
         sources[i][IDX_WATER_MOMENTUM] = 0; // Not used in 6-equation mode
       }
 
@@ -880,25 +878,108 @@ public class TwoFluidConservationEquations implements Serializable {
    */
   double[] calcMassTransfer(TwoFluidSection sec) {
     if (thermodynamicCoupling != null) {
-      double gamma = thermodynamicCoupling.calcMassTransferRatePerLength(sec, massTransferRelaxationTime);
-      return conservedMassTransferPair(gamma);
+      PhaseMassTransfer transfer = calcPhaseMassTransfer(sec);
+      return new double[] { transfer.getGasSourceKgPerMetreSecond(),
+          transfer.getOilSourceKgPerMetreSecond() + transfer.getWaterSourceKgPerMetreSecond() };
     }
 
+    return conservedMassTransferPair(getPrescribedGasSourcePerLength(sec));
+  }
+
+  /**
+   * Calculate phase-resolved mass-transfer sources for a section.
+   *
+   * <p>
+   * Flash-driven transfer delegates to {@link ThermodynamicCoupling}. A prescribed evaporation source is distributed
+   * over the actual oil and water donor inventories. A prescribed condensation source has no equilibrium phase
+   * identity, so the explicitly configured hydrodynamic water cut is retained for backward compatibility.
+   * </p>
+   *
+   * @param sec pipe section
+   * @return immutable phase-resolved transfer result in kg/(m s)
+   */
+  PhaseMassTransfer calcPhaseMassTransfer(TwoFluidSection sec) {
+    if (thermodynamicCoupling != null) {
+      return thermodynamicCoupling.calcPhaseMassTransferRatePerLength(sec, massTransferRelaxationTime);
+    }
+
+    double gasSource = getPrescribedGasSourcePerLength(sec);
+    if (gasSource > 0.0) {
+      double oilInventory = Math.max(0.0, sec.getOilMassPerLength());
+      double waterInventory = Math.max(0.0, sec.getWaterMassPerLength());
+      double liquidInventory = oilInventory + waterInventory;
+      if (liquidInventory <= 0.0) {
+        return PhaseMassTransfer.zero(true, false, "No liquid donor inventory for prescribed evaporation");
+      }
+      double oilSource = -gasSource * oilInventory / liquidInventory;
+      double waterSource = -gasSource - oilSource;
+      return new PhaseMassTransfer(gasSource, oilSource, waterSource, true, true, null);
+    }
+    if (gasSource < 0.0) {
+      double waterFraction = Math.max(0.0, Math.min(1.0, sec.getWaterCut()));
+      double oilSource = -gasSource * (1.0 - waterFraction);
+      double waterSource = -gasSource - oilSource;
+      return new PhaseMassTransfer(gasSource, oilSource, waterSource, true, true, null);
+    }
+    return PhaseMassTransfer.zero(true, true, null);
+  }
+
+  /**
+   * Convert a prescribed section transfer rate to a gas source per unit pipe length.
+   *
+   * @param sec pipe section
+   * @return gas source in kg/(m s)
+   */
+  private double getPrescribedGasSourcePerLength(TwoFluidSection sec) {
     double prescribedRate = sec.getMassTransferRate();
     if (!Double.isFinite(prescribedRate)) {
       throw new IllegalStateException("Mass transfer rate must be finite");
     }
-
-    double gamma = 0.0;
-    if (Math.abs(prescribedRate) > 0.0) {
-      double sectionLength = sec.getLength();
-      if (!Double.isFinite(sectionLength) || sectionLength <= 0.0) {
-        throw new IllegalStateException("Section length must be positive for mass transfer");
-      }
-      gamma = prescribedRate / sectionLength;
+    if (Math.abs(prescribedRate) == 0.0) {
+      return 0.0;
     }
+    double sectionLength = sec.getLength();
+    if (!Double.isFinite(sectionLength) || sectionLength <= 0.0) {
+      throw new IllegalStateException("Section length must be positive for mass transfer");
+    }
+    return prescribedRate / sectionLength;
+  }
 
-    return conservedMassTransferPair(gamma);
+  /**
+   * Calculate transfer-only phase momentum sources using donor velocity.
+   *
+   * <p>
+   * During evaporation the gas receives the momentum removed from each liquid donor. During condensation the gas loses
+   * momentum at gas velocity and each receiving liquid gains momentum at that same donor velocity. The three returned
+   * sources therefore sum to zero apart from round-off.
+   * </p>
+   *
+   * @param sec pipe section containing phase velocities
+   * @param transfer phase-resolved mass-transfer sources
+   * @return gas, oil, and water momentum sources in N/m
+   */
+  double[] calcTransferMomentumSources(TwoFluidSection sec, PhaseMassTransfer transfer) {
+    double gasMassSource = transfer.getGasSourceKgPerMetreSecond();
+    double oilMassSource = transfer.getOilSourceKgPerMetreSecond();
+    double waterMassSource = transfer.getWaterSourceKgPerMetreSecond();
+    double gasMomentumSource;
+    double oilMomentumSource;
+    double waterMomentumSource;
+
+    if (gasMassSource > 0.0) {
+      oilMomentumSource = oilMassSource * sec.getOilVelocity();
+      waterMomentumSource = waterMassSource * sec.getWaterVelocity();
+      gasMomentumSource = -oilMomentumSource - waterMomentumSource;
+    } else if (gasMassSource < 0.0) {
+      gasMomentumSource = gasMassSource * sec.getGasVelocity();
+      oilMomentumSource = oilMassSource * sec.getGasVelocity();
+      waterMomentumSource = -gasMomentumSource - oilMomentumSource;
+    } else {
+      gasMomentumSource = 0.0;
+      oilMomentumSource = 0.0;
+      waterMomentumSource = 0.0;
+    }
+    return new double[] { gasMomentumSource, oilMomentumSource, waterMomentumSource };
   }
 
   private double[] conservedMassTransferPair(double gasSource) {

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlashTableTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlashTableTest.java
@@ -7,10 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.pipeline.twophasepipe.ThermodynamicCoupling.ThermoProperties;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.thermo.system.SystemSrkEos;
 
 /**
@@ -145,8 +150,8 @@ class FlashTableTest {
 
     long memory = table.estimateMemoryUsage();
 
-    // 14 property tables * nP * nT * 8 bytes
-    long expected = 14L * nP * nT * 8;
+    // 19 property tables * nP * nT * 8 bytes
+    long expected = 19L * nP * nT * 8;
     assertEquals(expected, memory, "Memory estimate should match formula");
   }
 
@@ -194,5 +199,81 @@ class FlashTableTest {
     // Density should be similar (within 5%)
     double densityRatio = props2.gasDensity / props1.gasDensity;
     assertTrue(densityRatio > 0.95 && densityRatio < 1.05, "Properties at nearby points should be similar");
+  }
+
+  @Test
+  void testGasOilTableKeepsAbsentAqueousIdentityAtAndBetweenGridPoints() {
+    SystemInterface gasOil = new SystemSrkEos(313.15, 10.0);
+    gasOil.addComponent("methane", 0.70);
+    gasOil.addComponent("n-heptane", 0.30);
+    gasOil.setMixingRule("classic");
+    gasOil.setMultiPhaseCheck(true);
+    table.build(gasOil, 9.0e5, 11.0e5, 3, 308.15, 318.15, 3);
+
+    ThermoProperties exact = table.interpolate(10.0e5, 313.15);
+    ThermoProperties between = table.interpolate(10.5e5, 315.65);
+
+    assertTrue(exact.liquidFraction > 0.0);
+    assertEquals(1.0, exact.oilMassFractionOfLiquid, 1.0e-12);
+    assertEquals(0.0, exact.aqueousMassFractionOfLiquid, 1.0e-12);
+    assertEquals(0.0, between.aqueousMassFractionOfLiquid, 1.0e-12);
+  }
+
+  @Test
+  void testGasWaterTableKeepsAbsentOilIdentityAtAndBetweenGridPoints() {
+    SystemInterface gasWater = new SystemSrkCPAstatoil(313.15, 10.0);
+    gasWater.addComponent("methane", 0.70);
+    gasWater.addComponent("water", 0.30);
+    gasWater.setMixingRule(10);
+    gasWater.setMultiPhaseCheck(true);
+    table.build(gasWater, 9.0e5, 11.0e5, 3, 308.15, 318.15, 3);
+
+    ThermoProperties exact = table.interpolate(10.0e5, 313.15);
+    ThermoProperties between = table.interpolate(10.5e5, 315.65);
+
+    assertTrue(exact.liquidFraction > 0.0);
+    assertEquals(0.0, exact.oilMassFractionOfLiquid, 1.0e-12);
+    assertEquals(1.0, exact.aqueousMassFractionOfLiquid, 1.0e-12);
+    assertEquals(0.0, between.oilMassFractionOfLiquid, 1.0e-12);
+  }
+
+  @Test
+  void testThreePhaseTableNormalizesBothLiquidMassContributions() {
+    SystemInterface threePhase = new SystemSrkEos(300.0, 50.0);
+    threePhase.addComponent("methane", 0.40);
+    threePhase.addComponent("propane", 0.10);
+    threePhase.addComponent("n-heptane", 0.15);
+    threePhase.addComponent("n-octane", 0.15);
+    threePhase.addComponent("water", 0.20);
+    threePhase.setMixingRule("classic");
+    threePhase.setMultiPhaseCheck(true);
+    table.build(threePhase, 45.0e5, 55.0e5, 3, 295.0, 305.0, 3);
+
+    ThermoProperties exact = table.interpolate(50.0e5, 300.0);
+    ThermoProperties between = table.interpolate(52.5e5, 302.5);
+
+    assertTrue(exact.oilMassFractionOfLiquid > 0.0);
+    assertTrue(exact.aqueousMassFractionOfLiquid > 0.0);
+    assertEquals(1.0, exact.oilMassFractionOfLiquid + exact.aqueousMassFractionOfLiquid, 1.0e-12);
+    assertEquals(1.0, between.oilMassFractionOfLiquid + between.aqueousMassFractionOfLiquid, 1.0e-12);
+  }
+
+  @Test
+  void testSerializationPreservesPhaseResolvedInterpolation() throws Exception {
+    table.build(testFluid, 10e5, 50e5, 3, 280.0, 340.0, 3);
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    output.writeObject(table);
+    output.close();
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    FlashTable restored = (FlashTable) input.readObject();
+    input.close();
+
+    ThermoProperties expected = table.interpolate(30e5, 310.0);
+    ThermoProperties actual = restored.interpolate(30e5, 310.0);
+    assertEquals(expected.gasVaporFraction, actual.gasVaporFraction, 1.0e-12);
+    assertEquals(expected.liquidFraction, actual.liquidFraction, 1.0e-12);
+    assertEquals(expected.oilMassFractionOfLiquid, actual.oilMassFractionOfLiquid, 1.0e-12);
+    assertEquals(expected.aqueousMassFractionOfLiquid, actual.aqueousMassFractionOfLiquid, 1.0e-12);
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/PhaseMassTransferTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/PhaseMassTransferTest.java
@@ -1,0 +1,48 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the immutable phase-resolved mass-transfer result. */
+class PhaseMassTransferTest {
+  @Test
+  void testRejectsNonConservativeSources() {
+    assertThrows(IllegalArgumentException.class, () -> new PhaseMassTransfer(-0.2, 0.1, 0.0, true, true, null));
+  }
+
+  @Test
+  void testSerializationPreservesSourcesAndMetadata() throws Exception {
+    PhaseMassTransfer expected = new PhaseMassTransfer(-0.2, 0.05, 0.15, true, true, null);
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    output.writeObject(expected);
+    output.close();
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    PhaseMassTransfer actual = (PhaseMassTransfer) input.readObject();
+    input.close();
+
+    assertEquals(expected.getGasSourceKgPerMetreSecond(), actual.getGasSourceKgPerMetreSecond(), 0.0);
+    assertEquals(expected.getOilSourceKgPerMetreSecond(), actual.getOilSourceKgPerMetreSecond(), 0.0);
+    assertEquals(expected.getWaterSourceKgPerMetreSecond(), actual.getWaterSourceKgPerMetreSecond(), 0.0);
+    assertTrue(actual.isFlashConverged());
+    assertTrue(actual.isApplicable());
+    assertEquals(0.0, actual.getTotalSourceKgPerMetreSecond(), 1.0e-15);
+  }
+
+  @Test
+  void testZeroResultCanReportInapplicableFlash() {
+    PhaseMassTransfer result = PhaseMassTransfer.zero(false, false, "flash failed");
+
+    assertFalse(result.isFlashConverged());
+    assertFalse(result.isApplicable());
+    assertEquals("flash failed", result.getErrorMessage());
+    assertEquals(0.0, result.getTotalSourceKgPerMetreSecond(), 0.0);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThermodynamicCouplingTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/ThermodynamicCouplingTest.java
@@ -1,11 +1,15 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.pipeline.twophasepipe.ThermodynamicCoupling.ThermoProperties;
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
  * Unit tests for ThermodynamicCoupling class.
@@ -118,5 +122,233 @@ class ThermodynamicCouplingTest {
     // Vapor fraction should typically increase with temperature
     assertTrue(propsHighT.gasVaporFraction >= propsLowT.gasVaporFraction,
         "Vapor fraction should generally increase with temperature");
+  }
+
+  @Test
+  void testAqueousFirstLiquidUsesEquilibriumPhaseIdentity() {
+    ThermoProperties aqueousEquilibrium = liquidEquilibrium(0.0, 1.0);
+    ThermodynamicCoupling fixedCoupling = fixedEquilibriumCoupling(aqueousEquilibrium);
+    TwoFluidSection gasOnlySection = gasOnlySectionWithTwoTenthsKgEquilibriumLiquid();
+
+    PhaseMassTransfer transfer = fixedCoupling.calcPhaseMassTransferRatePerLength(gasOnlySection, 1.0);
+
+    assertEquals(-0.2, transfer.getGasSourceKgPerMetreSecond(), 1.0e-12);
+    assertEquals(0.0, transfer.getOilSourceKgPerMetreSecond(), 1.0e-12);
+    assertEquals(0.2, transfer.getWaterSourceKgPerMetreSecond(), 1.0e-12);
+    assertEquals(0.0, transfer.getTotalSourceKgPerMetreSecond(), 1.0e-15);
+    assertTrue(transfer.isApplicable());
+  }
+
+  @Test
+  void testOilFirstLiquidDoesNotCreateWater() {
+    ThermoProperties oilEquilibrium = liquidEquilibrium(1.0, 0.0);
+    ThermodynamicCoupling fixedCoupling = fixedEquilibriumCoupling(oilEquilibrium);
+    TwoFluidSection gasOnlySection = gasOnlySectionWithTwoTenthsKgEquilibriumLiquid();
+
+    PhaseMassTransfer transfer = fixedCoupling.calcPhaseMassTransferRatePerLength(gasOnlySection, 1.0);
+
+    assertEquals(-0.2, transfer.getGasSourceKgPerMetreSecond(), 1.0e-12);
+    assertEquals(0.2, transfer.getOilSourceKgPerMetreSecond(), 1.0e-12);
+    assertEquals(0.0, transfer.getWaterSourceKgPerMetreSecond(), 1.0e-12);
+  }
+
+  @Test
+  void testEvaporationUsesAndLimitsActualDonorInventory() {
+    ThermoProperties gasEquilibrium = new ThermoProperties();
+    gasEquilibrium.gasVaporFraction = 1.0;
+    gasEquilibrium.gasDensity = 10.0;
+    gasEquilibrium.gasMolarMass = 20.0;
+    gasEquilibrium.liquidDensity = 800.0;
+    gasEquilibrium.liquidMolarMass = 100.0;
+    gasEquilibrium.converged = true;
+    ThermodynamicCoupling fixedCoupling = fixedEquilibriumCoupling(gasEquilibrium);
+    TwoFluidSection oilOnlySection = new TwoFluidSection(0.0, 1.0, 0.1, 0.0);
+    oilOnlySection.setPressure(50.0e5);
+    oilOnlySection.setTemperature(300.0);
+    oilOnlySection.setLiquidMassPerLength(0.03);
+    oilOnlySection.setOilMassPerLength(0.03);
+    oilOnlySection.setWaterMassPerLength(0.0);
+
+    PhaseMassTransfer transfer = fixedCoupling.calcPhaseMassTransferRatePerLength(oilOnlySection, 2.0);
+
+    assertEquals(0.015, transfer.getGasSourceKgPerMetreSecond(), 1.0e-12);
+    assertEquals(-0.015, transfer.getOilSourceKgPerMetreSecond(), 1.0e-12);
+    assertEquals(0.0, transfer.getWaterSourceKgPerMetreSecond(), 1.0e-12);
+    assertTrue(-transfer.getOilSourceKgPerMetreSecond() <= oilOnlySection.getOilMassPerLength() / 2.0);
+  }
+
+  @Test
+  void testRealCpaWaterDewPointCrossesInBothDirections() throws Exception {
+    SystemInterface wetGas = createWetGasAtWaterDewPointConditions();
+    SystemInterface dewPointFluid = wetGas.clone();
+    new ThermodynamicOperations(dewPointFluid).waterDewPointTemperatureMultiphaseFlash();
+    double dewPointTemperature = dewPointFluid.getTemperature();
+    ThermodynamicCoupling cpaCoupling = new ThermodynamicCoupling(wetGas);
+    TwoFluidSection section = gasOnlySectionWithTwoTenthsKgEquilibriumLiquid();
+    section.setPressure(70.0e5);
+    section.setGasMassPerLength(10.0);
+
+    double[] temperatureOffsets = { -1.0, -0.5, -0.2 };
+    double previousWaterSource = Double.POSITIVE_INFINITY;
+    double condensedWaterInventory = 0.0;
+    for (double offset : temperatureOffsets) {
+      section.setTemperature(dewPointTemperature + offset);
+      PhaseMassTransfer transfer = cpaCoupling.calcPhaseMassTransferRatePerLength(section, 30.0);
+      assertTrue(transfer.isFlashConverged());
+      assertTrue(transfer.isApplicable());
+      assertTrue(transfer.getGasSourceKgPerMetreSecond() < 0.0);
+      assertEquals(0.0, transfer.getOilSourceKgPerMetreSecond(), 1.0e-12);
+      assertTrue(transfer.getWaterSourceKgPerMetreSecond() > 0.0);
+      assertEquals(0.0, transfer.getTotalSourceKgPerMetreSecond(), 1.0e-15);
+      assertTrue(transfer.getWaterSourceKgPerMetreSecond() <= previousWaterSource,
+          "Condensation should vanish continuously as the water dew point is approached");
+      previousWaterSource = transfer.getWaterSourceKgPerMetreSecond();
+      if (condensedWaterInventory == 0.0) {
+        condensedWaterInventory = transfer.getWaterSourceKgPerMetreSecond() * 30.0;
+      }
+    }
+
+    section.setLiquidMassPerLength(condensedWaterInventory);
+    section.setOilMassPerLength(0.0);
+    section.setWaterMassPerLength(section.getLiquidMassPerLength());
+    section.setTemperature(dewPointTemperature + 1.0);
+    PhaseMassTransfer warmTransfer = cpaCoupling.calcPhaseMassTransferRatePerLength(section, 30.0);
+
+    assertTrue(warmTransfer.isFlashConverged());
+    assertTrue(warmTransfer.getGasSourceKgPerMetreSecond() > 0.0);
+    assertEquals(0.0, warmTransfer.getOilSourceKgPerMetreSecond(), 1.0e-12);
+    assertTrue(warmTransfer.getWaterSourceKgPerMetreSecond() < 0.0);
+    assertTrue(-warmTransfer.getWaterSourceKgPerMetreSecond() <= section.getWaterMassPerLength() / 30.0 + 1.0e-15);
+    assertEquals(0.0, warmTransfer.getTotalSourceKgPerMetreSecond(), 1.0e-15);
+  }
+
+  @Test
+  void testThreePhaseAggregationIncludesBothLiquidsAndIgnoresPhaseOrder() {
+    SystemInterface threePhaseFluid = createThreePhaseFluid();
+    ThermodynamicOperations operations = new ThermodynamicOperations(threePhaseFluid);
+    operations.TPflash();
+    threePhaseFluid.initProperties();
+    assertTrue(threePhaseFluid.hasPhaseType(PhaseType.GAS));
+    assertTrue(threePhaseFluid.hasPhaseType(PhaseType.OIL));
+    assertTrue(threePhaseFluid.hasPhaseType(PhaseType.AQUEOUS));
+
+    ThermodynamicCoupling threePhaseCoupling = new ThermodynamicCoupling(threePhaseFluid);
+    ThermoProperties original = threePhaseCoupling.extractProperties(threePhaseFluid);
+    int firstPhaseIndex = threePhaseFluid.getPhaseIndex(0);
+    int lastPhase = threePhaseFluid.getNumberOfPhases() - 1;
+    int lastPhaseIndex = threePhaseFluid.getPhaseIndex(lastPhase);
+    threePhaseFluid.setPhaseIndex(0, lastPhaseIndex);
+    threePhaseFluid.setPhaseIndex(lastPhase, firstPhaseIndex);
+    ThermoProperties reordered = threePhaseCoupling.extractProperties(threePhaseFluid);
+
+    assertTrue(original.liquidFraction > 0.0);
+    assertTrue(original.oilMassFractionOfLiquid > 0.0);
+    assertTrue(original.aqueousMassFractionOfLiquid > 0.0);
+    assertEquals(1.0, original.oilMassFractionOfLiquid + original.aqueousMassFractionOfLiquid, 1.0e-12);
+    assertEquals(original.gasVaporFraction, reordered.gasVaporFraction, 1.0e-12);
+    assertEquals(original.liquidFraction, reordered.liquidFraction, 1.0e-12);
+    assertEquals(original.oilMassFractionOfLiquid, reordered.oilMassFractionOfLiquid, 1.0e-12);
+    assertEquals(original.aqueousMassFractionOfLiquid, reordered.aqueousMassFractionOfLiquid, 1.0e-12);
+
+    int gasPhase = threePhaseFluid.getPhaseNumberOfPhase("gas");
+    int oilPhase = threePhaseFluid.getPhaseNumberOfPhase("oil");
+    int aqueousPhase = threePhaseFluid.getPhaseNumberOfPhase("aqueous");
+    assertAggregatedTopology(threePhaseCoupling, selectPhases(threePhaseFluid, gasPhase), true, false, false);
+    assertAggregatedTopology(threePhaseCoupling, selectPhases(threePhaseFluid, oilPhase), false, true, false);
+    assertAggregatedTopology(threePhaseCoupling, selectPhases(threePhaseFluid, aqueousPhase), false, false, true);
+    assertAggregatedTopology(threePhaseCoupling, selectPhases(threePhaseFluid, gasPhase, oilPhase), true, true, false);
+    assertAggregatedTopology(threePhaseCoupling, selectPhases(threePhaseFluid, gasPhase, aqueousPhase), true, false,
+        true);
+    assertAggregatedTopology(threePhaseCoupling, selectPhases(threePhaseFluid, oilPhase, aqueousPhase), false, true,
+        true);
+  }
+
+  private ThermodynamicCoupling fixedEquilibriumCoupling(final ThermoProperties equilibrium) {
+    return new ThermodynamicCoupling(testFluid) {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public ThermoProperties flashPT(double pressure, double temperature) {
+        return equilibrium;
+      }
+    };
+  }
+
+  private ThermoProperties liquidEquilibrium(double oilMassFraction, double aqueousMassFraction) {
+    ThermoProperties equilibrium = new ThermoProperties();
+    equilibrium.gasVaporFraction = 0.0;
+    equilibrium.liquidFraction = 1.0;
+    equilibrium.oilMassFractionOfLiquid = oilMassFraction;
+    equilibrium.aqueousMassFractionOfLiquid = aqueousMassFraction;
+    equilibrium.gasDensity = 1.0;
+    equilibrium.gasMolarMass = 20.0;
+    equilibrium.liquidDensity = 100.0;
+    equilibrium.liquidMolarMass = 18.0;
+    equilibrium.converged = true;
+    return equilibrium;
+  }
+
+  private TwoFluidSection gasOnlySectionWithTwoTenthsKgEquilibriumLiquid() {
+    double area = 0.002;
+    double diameter = Math.sqrt(4.0 * area / Math.PI);
+    TwoFluidSection gasOnlySection = new TwoFluidSection(0.0, 1.0, diameter, 0.0);
+    gasOnlySection.setPressure(50.0e5);
+    gasOnlySection.setTemperature(300.0);
+    gasOnlySection.setGasMassPerLength(1.0);
+    gasOnlySection.setLiquidMassPerLength(0.0);
+    gasOnlySection.setOilMassPerLength(0.0);
+    gasOnlySection.setWaterMassPerLength(0.0);
+    gasOnlySection.setWaterCut(0.0);
+    return gasOnlySection;
+  }
+
+  private SystemInterface createThreePhaseFluid() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 50.0);
+    fluid.addComponent("methane", 0.40);
+    fluid.addComponent("propane", 0.10);
+    fluid.addComponent("n-heptane", 0.15);
+    fluid.addComponent("n-octane", 0.15);
+    fluid.addComponent("water", 0.20);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  private SystemInterface createWetGasAtWaterDewPointConditions() {
+    double waterMoleFraction = 22.0e-6;
+    SystemInterface fluid = new SystemSrkCPAstatoil(260.15, 70.0);
+    fluid.addComponent("CO2", 0.02);
+    fluid.addComponent("nitrogen", 0.01);
+    fluid.addComponent("methane", 0.9 - waterMoleFraction);
+    fluid.addComponent("ethane", 0.05);
+    fluid.addComponent("propane", 0.01);
+    fluid.addComponent("i-butane", 0.005);
+    fluid.addComponent("n-butane", 0.005);
+    fluid.addComponent("water", waterMoleFraction);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  private SystemInterface selectPhases(SystemInterface source, int... phaseNumbers) {
+    SystemInterface topology = source.clone();
+    topology.setNumberOfPhases(phaseNumbers.length);
+    for (int phase = 0; phase < phaseNumbers.length; phase++) {
+      topology.setPhaseIndex(phase, source.getPhaseIndex(phaseNumbers[phase]));
+    }
+    return topology;
+  }
+
+  private void assertAggregatedTopology(ThermodynamicCoupling threePhaseCoupling, SystemInterface topology,
+      boolean expectGas, boolean expectOil, boolean expectAqueous) {
+    topology.initProperties();
+    ThermoProperties properties = threePhaseCoupling.extractProperties(topology);
+    assertEquals(expectGas ? 1.0 : 0.0, properties.gasVaporFraction > 0.0 ? 1.0 : 0.0, 0.0);
+    assertEquals(expectOil || expectAqueous ? 1.0 : 0.0, properties.liquidFraction > 0.0 ? 1.0 : 0.0, 0.0);
+    assertEquals(expectOil ? 1.0 : 0.0, properties.oilMassFractionOfLiquid > 0.0 ? 1.0 : 0.0, 0.0);
+    assertEquals(expectAqueous ? 1.0 : 0.0, properties.aqueousMassFractionOfLiquid > 0.0 ? 1.0 : 0.0, 0.0);
+    if (expectOil || expectAqueous) {
+      assertEquals(1.0, properties.oilMassFractionOfLiquid + properties.aqueousMassFractionOfLiquid, 1.0e-12);
+    }
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidSectionTest.java
@@ -254,6 +254,57 @@ public class TwoFluidSectionTest {
   }
 
   @Test
+  void testPhaseResolvedTransferMomentumUsesDonorVelocityAndConservesMomentum() {
+    section.setGasVelocity(5.0);
+    section.setOilVelocity(2.0);
+    section.setWaterVelocity(1.0);
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+
+    PhaseMassTransfer condensation = new PhaseMassTransfer(-0.2, 0.0, 0.2, true, true, null);
+    double[] condensationMomentum = equations.calcTransferMomentumSources(section, condensation);
+    assertEquals(-1.0, condensationMomentum[0], 1.0e-12);
+    assertEquals(0.0, condensationMomentum[1], 1.0e-12);
+    assertEquals(1.0, condensationMomentum[2], 1.0e-12);
+    assertEquals(0.0, condensationMomentum[0] + condensationMomentum[1] + condensationMomentum[2], 1.0e-12);
+
+    PhaseMassTransfer evaporation = new PhaseMassTransfer(0.2, -0.05, -0.15, true, true, null);
+    double[] evaporationMomentum = equations.calcTransferMomentumSources(section, evaporation);
+    assertEquals(0.25, evaporationMomentum[0], 1.0e-12);
+    assertEquals(-0.1, evaporationMomentum[1], 1.0e-12);
+    assertEquals(-0.15, evaporationMomentum[2], 1.0e-12);
+    assertEquals(0.0, evaporationMomentum[0] + evaporationMomentum[1] + evaporationMomentum[2], 1.0e-12);
+  }
+
+  @Test
+  void testDisabledMassTransferProducesNoPhaseSources() {
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    TwoFluidSection[] transferSections = createUniformTransferSections(0.01, -0.1);
+
+    equations.calcRHS(transferSections, 10.0);
+
+    double[] sourceRates = equations.getLastMassBalanceRate().getSourceMassFlowKgPerSecond();
+    assertEquals(0.0, sourceRates[0], 0.0);
+    assertEquals(0.0, sourceRates[1], 0.0);
+    assertEquals(0.0, sourceRates[2], 0.0);
+  }
+
+  @Test
+  void testPhaseResolvedPrescribedTransferIsDeterministic() {
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    section.setOilMassPerLength(3.0);
+    section.setWaterMassPerLength(1.0);
+    section.setLiquidMassPerLength(4.0);
+    section.setMassTransferRate(2.0);
+
+    PhaseMassTransfer first = equations.calcPhaseMassTransfer(section);
+    PhaseMassTransfer second = equations.calcPhaseMassTransfer(section);
+
+    assertEquals(first.getGasSourceKgPerMetreSecond(), second.getGasSourceKgPerMetreSecond(), 0.0);
+    assertEquals(first.getOilSourceKgPerMetreSecond(), second.getOilSourceKgPerMetreSecond(), 0.0);
+    assertEquals(first.getWaterSourceKgPerMetreSecond(), second.getWaterSourceKgPerMetreSecond(), 0.0);
+  }
+
+  @Test
   void testClosurePassUpdatesEntrainmentAndSevereSlugDiagnostics() {
     section.setGasDensity(25.0);
     section.setLiquidDensity(750.0);


### PR DESCRIPTION
## Summary

- identify flashed phases by `PhaseType` and aggregate hydrocarbon-liquid and aqueous-liquid contributions independently of phase-array order
- add immutable, conservative gas/oil/water transfer sources; condensation follows the equilibrium liquid mass split and evaporation is limited by actual donor inventories
- transfer momentum at donor velocity so transfer-only mixture momentum closes exactly
- retain liquid fraction, oil/aqueous mass split, and gas/liquid molar masses in `FlashTable`, including clamped/renormalized interpolation and an explicit rebuild diagnostic for legacy serialized tables
- preserve the existing aggregate mass-transfer API while adding a phase-resolved result
- document equations, SI units, assumptions, validity limits, and validation guidance

## Reproducible baseline and root cause

For a gas-only cell with `waterCut = 0` and an equilibrium aqueous condensation rate of 0.2 kg/(m s), the old source split returned:

```text
gas = -0.2, oil = +0.2, water = 0.0 kg/(m s)
```

Total mass closed, but phase identity was wrong. The old implementation split aggregate liquid transfer with the pre-transition hydrodynamic water cut and also retained only one liquid beta in a three-phase flash.

The corrected analytical result is:

```text
gas = -0.2, oil = 0.0, water = +0.2 kg/(m s)
```

with `Gamma_G + Gamma_O + Gamma_W = 0` to floating-point precision.

## Equations and assumptions

For condensation (`Gamma_G < 0`):

```text
Gamma_O = -Gamma_G w_O,eq
Gamma_W = -Gamma_G w_W,eq
w_O,eq + w_W,eq = 1
```

The equilibrium liquid split is mass based. For evaporation, withdrawal follows the actual oil/water donor inventories and each phase is bounded by `m_phase / tau`. Transfer momentum uses donor velocity, so the three transfer-only momentum sources also sum to zero.

Units are kg/(m s) for phase mass sources and N/m for momentum sources. The closure is valid for the current bulk phase-inventory model; it does not transport a complete component-composition vector in every hydrodynamic cell.

## Validation

Initial CI on the implementation commit established that production code compiled and Javadocs passed. All four Java 21 slow-test shards passed. The Windows fast suite ran 11,194 tests and found one failure in the new topology test.

That failure was a test-construction defect: `phaseToSystem(int,int)` collapses the selected material into one phase. The branch now constructs one-, two-, and three-phase test topologies by selecting explicit phase indices, preserving the identities under test. The branch is rebased onto current `master` `f49af02c`; replacement CI is running.

Additional checks:

- CI-generated Spotless patch applied to all changed Java files
- `git diff --check`
- `python devtools/verify_skills_agents.py`: 0 errors; one unrelated existing keyword warning
- analytical aqueous-first and oil-first source regressions
- gas/oil/water mass and donor-velocity momentum closure
- inventory-limited evaporation and absent-phase checks
- phase-order-independent gas/oil/aqueous aggregation
- `FlashTable` exact-grid/interpolation identity and serialization checks
- real SRK-CPA water-dew-point source sweep in both directions

Local Maven execution remains unavailable because this runtime cannot resolve Maven Central. CI is therefore the compilation and executable-test authority.

## Evidence and limitations

The analytical conservation/phase-identity baseline is the primary validation for this bounded correction. The CPA dew-point test provides a real NeqSim phase-transition trend check. No public experimental dataset directly measures the oil-versus-water allocation of this internal relaxation source, so no unsupported benchmark fit or OLGA/LedaFlow equivalence claim is made.

Clean-room numerical context:

- Zou, Zhao & Zhang (2016), phase appearance/disappearance in a conservative two-fluid six-equation model: https://www.osti.gov/servlets/purl/1303258
- Cordier, Degond & Kumbaro (2012), positivity and vanishing-phase behavior: https://arxiv.org/abs/1110.0597
- Niu et al. (2022), two-fluid phase appearance/disappearance benchmark methodology: https://doi.org/10.1016/j.anucene.2022.109230

Public commercial-tool material is used only to prioritize phase-rich transient use cases, not as implementation evidence:

- https://ledaflow.com/
- https://www.software.slb.com/sitecore/content/software-v2/home-v2/trainingcourse?ItemName=OLGA&product=olga

A full closed-domain `TwoFluidPipe` transient crossing a real dew point, including mesh/time-step sensitivity, remains follow-up validation in #2762. This PR therefore **addresses** #2762 but intentionally does not close it yet.

## Documentation impact

Documentation updated in the same branch:

- `TwoFluidPipe.setIncludeMassTransfer(...)` Javadoc
- `ThermodynamicCoupling` Javadoc
- `docs/process/TWOFLUIDPIPE_MODEL.md`
- `docs/wiki/two_fluid_reporting_and_validation.md`
- `CHANGELOG_AGENT_NOTES.md`
- dynamic-simulation skill guidance

The governing equations now include pipe area explicitly, keeping the documented kg/(m s) finite-volume source units dimensionally consistent.

Addresses #2762