### PR TITLE
perf: avoid composition derivatives in mixer enthalpy

### DIFF
--- a/src/main/java/neqsim/process/equipment/mixer/Mixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/Mixer.java
@@ -377,7 +377,7 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
     double enthalpy = 0;
     for (int k = 0; k < streams.size(); k++) {
       if (streams.get(k).getFlowRate("kg/hr") > getMinimumFlow()) {
-        streams.get(k).getThermoSystem().init(3);
+        streams.get(k).getThermoSystem().init(2);
         enthalpy += streams.get(k).getThermoSystem().getEnthalpy();
       }
     }

--- a/src/test/java/neqsim/process/equipment/mixer/MixerTest.java
+++ b/src/test/java/neqsim/process/equipment/mixer/MixerTest.java
@@ -3,6 +3,7 @@ package neqsim.process.equipment.mixer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
@@ -14,6 +15,50 @@ import neqsim.thermo.system.SystemSrkEos;
  * @author ESOL
  */
 class MixerTest {
+  private static class InitTrackingSystemSrkEos extends SystemSrkEos {
+    private static final long serialVersionUID = 1000L;
+    private AtomicInteger levelTwoCalls = new AtomicInteger();
+    private AtomicInteger levelThreeCalls = new AtomicInteger();
+
+    InitTrackingSystemSrkEos(double temperature, double pressure) {
+      super(temperature, pressure);
+    }
+
+    @Override
+    public InitTrackingSystemSrkEos clone() {
+      InitTrackingSystemSrkEos cloned = (InitTrackingSystemSrkEos) super.clone();
+      if (cloned == null) {
+        throw new IllegalStateException("Failed to clone initialization-tracking fluid");
+      }
+      cloned.levelTwoCalls = levelTwoCalls;
+      cloned.levelThreeCalls = levelThreeCalls;
+      return cloned;
+    }
+
+    @Override
+    public void init(int initType) {
+      super.init(initType);
+      if (levelTwoCalls != null && initType == 2) {
+        levelTwoCalls.incrementAndGet();
+      } else if (levelThreeCalls != null && initType == 3) {
+        levelThreeCalls.incrementAndGet();
+      }
+    }
+
+    void resetInitCounts() {
+      levelTwoCalls.set(0);
+      levelThreeCalls.set(0);
+    }
+
+    int getLevelTwoCalls() {
+      return levelTwoCalls.get();
+    }
+
+    int getLevelThreeCalls() {
+      return levelThreeCalls.get();
+    }
+  }
+
   static neqsim.thermo.system.SystemInterface testSystem;
   static neqsim.thermo.system.SystemInterface waterSystem;
   static Stream gasStream;
@@ -189,6 +234,73 @@ class MixerTest {
     testMixer.run();
 
     assertEquals(inletEnthalpyJ, testMixer.getOutletStream().getFluid().getEnthalpy("J"), 1e-3);
+  }
+
+  /**
+   * Mixer inlet enthalpy requires caloric properties but not level-3 composition derivatives. The optimized path must
+   * match a level-3 reference at the base state and a nearby operating point.
+   */
+  @Test
+  void testMixStreamEnthalpyUsesMinimumThermodynamicInitializationLevel() {
+    InitTrackingSystemSrkEos fluid = new InitTrackingSystemSrkEos(323.15, 70.0);
+    fluid.addComponent("nitrogen", 0.02);
+    fluid.addComponent("CO2", 0.03);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.04);
+    fluid.addComponent("n-heptane", 0.04);
+    fluid.setMixingRule("classic");
+
+    Stream hotStream = new Stream("tracked hot stream", fluid);
+    hotStream.setFlowRate(15000.0, "kg/hr");
+    hotStream.run();
+
+    Stream coolStream = new Stream("tracked cool stream", fluid.clone());
+    coolStream.setTemperature(313.15, "K");
+    coolStream.setFlowRate(10000.0, "kg/hr");
+    coolStream.run();
+
+    Mixer mixer = new Mixer("tracked enthalpy mixer");
+    mixer.addStream(hotStream);
+    mixer.addStream(coolStream);
+
+    assertMinimumEnthalpyInitialization(fluid, mixer);
+
+    coolStream.setTemperature(318.15, "K");
+    coolStream.run();
+    assertMinimumEnthalpyInitialization(fluid, mixer);
+  }
+
+  private static void assertMinimumEnthalpyInitialization(InitTrackingSystemSrkEos fluid, Mixer mixer) {
+    double expectedEnthalpy = 0.0;
+    for (StreamInterface inlet : mixer.getInletStreams()) {
+      inlet.getThermoSystem().init(3);
+      expectedEnthalpy += inlet.getThermoSystem().getEnthalpy();
+    }
+
+    double[] temperatures = new double[mixer.getInletStreams().size()];
+    double[] pressures = new double[mixer.getInletStreams().size()];
+    double[] flows = new double[mixer.getInletStreams().size()];
+    for (int index = 0; index < mixer.getInletStreams().size(); index++) {
+      StreamInterface inlet = mixer.getInletStreams().get(index);
+      temperatures[index] = inlet.getTemperature("K");
+      pressures[index] = inlet.getPressure("bara");
+      flows[index] = inlet.getFlowRate("kg/hr");
+    }
+
+    fluid.resetInitCounts();
+    double actualEnthalpy = mixer.calcMixStreamEnthalpy();
+
+    assertEquals(expectedEnthalpy, actualEnthalpy, Math.max(1.0e-8, Math.abs(expectedEnthalpy) * 1.0e-12));
+    assertEquals(mixer.getInletStreams().size(), fluid.getLevelTwoCalls(),
+        "Every active inlet still requires caloric initialization");
+    assertEquals(0, fluid.getLevelThreeCalls(), "Mixer enthalpy must not calculate composition derivatives");
+    for (int index = 0; index < mixer.getInletStreams().size(); index++) {
+      StreamInterface inlet = mixer.getInletStreams().get(index);
+      assertEquals(temperatures[index], inlet.getTemperature("K"), 0.0);
+      assertEquals(pressures[index], inlet.getPressure("bara"), 0.0);
+      assertEquals(flows[index], inlet.getFlowRate("kg/hr"), 0.0);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Reduce the thermodynamic initialization depth used by `Mixer.calcMixStreamEnthalpy()` from level 3 to level 2.

Mixer enthalpy needs caloric properties and first temperature derivatives. Level 3 additionally computes the full composition-derivative matrix for every active inlet, but that matrix is not consumed before `getEnthalpy()`.

Related audit: #2698.

## Reproducible benchmark

Baseline source: `master` at `f49af02ca6dc9dd7fc05f5b5249b92c42049bcc7`.

A standalone Java 17 harness used the packaged NeqSim 3.16.0 fat JAR and compared:

- baseline `Mixer.calcMixStreamEnthalpy()`;
- a subclass overriding only that method with the proposed `init(2)`;
- four active SRK feeds;
- ten components per feed;
- classic mixing rule;
- 70 bara and 315.15–327.15 K;
- 100 warm-up calls;
- nine alternating samples of 400 calls per JVM;
- seven independent JVM processes.

Median enthalpy-stage time:

| Variant | Time per call |
|---|---:|
| `init(3)` baseline | 23.480 µs |
| `init(2)` proposed | 17.664 µs |

Measured gain: **1.33× faster (24.8% lower time)**. Independent-process speedup range was 1.30–1.35×.

Full `Mixer.run()` timing was deliberately not used as acceptance evidence because the PH flash dominates and short-run timing was noisy. The gain should scale with inlet and component count because level 3 computes unused composition derivatives.

## Accuracy and robustness

The benchmark produced identical outlet results for both paths:

- base outlet temperature: 322.059090909091 K; delta 0.0 K;
- base outlet enthalpy: -45,353.564742589250 J; delta 0.0 J;
- nearby inlet-temperature case outlet temperature: 323.195454545455 K; delta 0.0 K;
- nearby case outlet enthalpy: 20,506.563745887730 J; delta 0.0 J.

The new regression test:

- compares level-2 mixer inlet enthalpy against a level-3 reference;
- covers the base state and a nearby +5 K inlet-temperature point;
- asserts exactly one level-2 initialization per active inlet;
- rejects any level-3 initialization in this path;
- verifies inlet temperature, pressure, and flow are unchanged.

Existing `MixerTest` coverage continues to check outlet enthalpy closure and mass conservation.

## Tests

- Standalone benchmark/accuracy harness: passed on Java 17.
- `git diff --check`: passed.
- GitHub pre-commit checks: passed.
- GitHub Spotless format run: passed with an empty formatting patch.
- GitHub Java 21 javadoc: passed.
- Full Java 21 build, fast/slow test matrix, Javadoc, and CodeQL: passed.
- Focused Maven execution was unavailable locally because the isolated runtime could not resolve the newly configured Maven plugins from Maven Central.

## Compatibility and limitations

- No public API or serialized state changes.
- No changes to flash algorithms, phase selection, convergence settings, or physical-property initialization.
- Expected benefit varies with fluid component count and number of active mixer inlets.

Documentation impact: none — this is an internal initialization-depth optimization with unchanged public behavior, inputs, outputs, units, defaults, and recommended usage.
