### PR TITLE
perf(tpflash): reuse GDEM acceleration workspace

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -105,6 +105,12 @@ public class TPflash extends Flash {
   private PhaseType referenceSinglePhaseType = null;
   /** True after the bounded water-bearing ordinary-flash retry has been attempted in this run. */
   private boolean waterBearingRescueAttempted = false;
+  /** Reusable rollback state for GDEM acceleration; transient because it contains no thermodynamic state. */
+  private transient double[] accelerationSavedLnK;
+  /** Reusable accelerated log K-values; transient because it contains no thermodynamic state. */
+  private transient double[] accelerationLnK;
+  /** Reusable accelerated K-values; transient because it contains no thermodynamic state. */
+  private transient double[] accelerationK;
 
   /** Compact pre-multiphase snapshot used only for balanced neutral water-bearing endpoints. */
   private static final class BalancedTwoPhaseState {
@@ -224,10 +230,10 @@ public class TPflash extends Flash {
    */
   public void accselerateSucsSubs() {
     int nc = system.getPhase(0).getNumberOfComponents();
+    ensureAccelerationWorkspace(nc);
 
     // Save pre-acceleration lnK state for rollback on failure
-    double[] savedLnK = new double[nc];
-    System.arraycopy(lnK, 0, savedLnK, 0, nc);
+    System.arraycopy(lnK, 0, accelerationSavedLnK, 0, nc);
 
     // Compute dot products for both standard DEM and GDEM-2
     double b11 = 0.0;
@@ -258,7 +264,6 @@ public class TPflash extends Flash {
       useGDEM = mu1 > 0 && mu2 > 0 && mu1 < 1.5 && mu2 < 1.5;
     }
 
-    double[] acceleratedLnK = new double[nc];
     boolean safeAcceleration = true;
     if (!useGDEM) {
       if (!Double.isFinite(lambda) || Math.abs(1.0 - lambda) < 1.0e-12) {
@@ -269,25 +274,24 @@ public class TPflash extends Flash {
           safeAcceleration = false;
         }
         for (i = 0; i < nc; i++) {
-          acceleratedLnK[i] = lnK[i] + lambdaFactor * deltalnK[i];
+          accelerationLnK[i] = lnK[i] + lambdaFactor * deltalnK[i];
         }
       }
     } else {
       for (i = 0; i < nc; i++) {
-        acceleratedLnK[i] = lnK[i] + mu1 * deltalnK[i] + mu2 * oldDeltalnK[i];
+        accelerationLnK[i] = lnK[i] + mu1 * deltalnK[i] + mu2 * oldDeltalnK[i];
       }
     }
 
-    double[] acceleratedK = new double[nc];
     if (safeAcceleration) {
       for (i = 0; i < nc; i++) {
-        double logKStep = acceleratedLnK[i] - savedLnK[i];
-        if (!Double.isFinite(acceleratedLnK[i]) || Math.abs(logKStep) > MAX_ACCELERATION_LOG_K_STEP) {
+        double logKStep = accelerationLnK[i] - accelerationSavedLnK[i];
+        if (!Double.isFinite(accelerationLnK[i]) || Math.abs(logKStep) > MAX_ACCELERATION_LOG_K_STEP) {
           safeAcceleration = false;
           break;
         }
-        acceleratedK[i] = Math.exp(acceleratedLnK[i]);
-        if (!Double.isFinite(acceleratedK[i]) || acceleratedK[i] <= 0.0) {
+        accelerationK[i] = Math.exp(accelerationLnK[i]);
+        if (!Double.isFinite(accelerationK[i]) || accelerationK[i] <= 0.0) {
           safeAcceleration = false;
           break;
         }
@@ -302,9 +306,9 @@ public class TPflash extends Flash {
     neqsim.thermo.phase.PhaseInterface ph0 = system.getPhase(0);
     neqsim.thermo.phase.PhaseInterface ph1 = system.getPhase(1);
     for (i = 0; i < nc; i++) {
-      lnK[i] = acceleratedLnK[i];
-      ph0.getComponent(i).setK(acceleratedK[i]);
-      ph1.getComponent(i).setK(acceleratedK[i]);
+      lnK[i] = accelerationLnK[i];
+      ph0.getComponent(i).setK(accelerationK[i]);
+      ph1.getComponent(i).setK(accelerationK[i]);
     }
     double oldBeta = system.getBeta();
     try {
@@ -322,15 +326,33 @@ public class TPflash extends Flash {
     } catch (Exception initEx) {
       // GDEM extrapolation produced bad compositions - restore pre-acceleration state
       logger.debug("accselerateSucsSubs init failed, reverting: {}", initEx.getMessage());
-      System.arraycopy(savedLnK, 0, lnK, 0, nc);
+      System.arraycopy(accelerationSavedLnK, 0, lnK, 0, nc);
       for (i = 0; i < nc; i++) {
-        double expK = Math.exp(savedLnK[i]);
+        double expK = Math.exp(accelerationSavedLnK[i]);
         ph0.getComponent(i).setK(expK);
         ph1.getComponent(i).setK(expK);
       }
       system.setBeta(oldBeta);
       system.calc_x_y();
       system.init(1);
+    }
+  }
+
+  /**
+   * Ensures that GDEM acceleration has component-sized reusable work arrays.
+   *
+   * <p>
+   * The arrays are allocated lazily so deserialized and default-constructed flash operations remain supported. They
+   * are resized defensively if a caller replaces the underlying system before reusing the operation.
+   * </p>
+   *
+   * @param numberOfComponents active component count
+   */
+  private void ensureAccelerationWorkspace(int numberOfComponents) {
+    if (accelerationSavedLnK == null || accelerationSavedLnK.length != numberOfComponents) {
+      accelerationSavedLnK = new double[numberOfComponents];
+      accelerationLnK = new double[numberOfComponents];
+      accelerationK = new double[numberOfComponents];
     }
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -342,8 +342,8 @@ public class TPflash extends Flash {
    * Ensures that GDEM acceleration has component-sized reusable work arrays.
    *
    * <p>
-   * The arrays are allocated lazily so deserialized and default-constructed flash operations remain supported. They
-   * are resized defensively if a caller replaces the underlying system before reusing the operation.
+   * The arrays are allocated lazily so deserialized and default-constructed flash operations remain supported. They are
+   * resized defensively if a caller replaces the underlying system before reusing the operation.
    * </p>
    *
    * @param numberOfComponents active component count

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAccelerationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAccelerationTest.java
@@ -61,4 +61,38 @@ class TPflashAccelerationTest {
     double expectedLogKStep = 1.04 / (1.0 - 1.04) * 0.01;
     assertEquals(Math.exp(expectedLogKStep), system.getPhase(0).getComponent(0).getK() / methaneKBefore, 1.0e-10);
   }
+
+  @Test
+  void testAccelerationWorkspaceDoesNotRetainPreviousResult() {
+    SystemInterface initialSystem = new SystemPrEos(300.0, 50.0);
+    initialSystem.addComponent("methane", 0.8);
+    initialSystem.addComponent("n-heptane", 0.2);
+    initialSystem.setMixingRule("classic");
+    initialSystem.setMultiPhaseCheck(false);
+    new ThermodynamicOperations(initialSystem).TPflash();
+
+    TPflash flash = new TPflash(initialSystem.clone());
+    prepareBoundedAcceleration(flash);
+    flash.accselerateSucsSubs();
+    double expectedBeta = flash.system.getBeta();
+    double expectedMethaneK = flash.system.getPhase(0).getComponent(0).getK();
+    double expectedHeptaneK = flash.system.getPhase(0).getComponent(1).getK();
+
+    flash.system = initialSystem.clone();
+    prepareBoundedAcceleration(flash);
+    flash.accselerateSucsSubs();
+
+    assertEquals(expectedBeta, flash.system.getBeta(), 0.0);
+    assertEquals(expectedMethaneK, flash.system.getPhase(0).getComponent(0).getK(), 0.0);
+    assertEquals(expectedHeptaneK, flash.system.getPhase(0).getComponent(1).getK(), 0.0);
+  }
+
+  private void prepareBoundedAcceleration(TPflash flash) {
+    for (int componentIndex = 0; componentIndex < flash.system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      flash.lnK[componentIndex] = Math.log(flash.system.getPhase(0).getComponent(componentIndex).getK());
+      flash.oldDeltalnK[componentIndex] = 0.8;
+      flash.oldoldDeltalnK[componentIndex] = 1.0;
+      flash.deltalnK[componentIndex] = 1.0e-4 * (componentIndex + 1.0);
+    }
+  }
 }


### PR DESCRIPTION
## Problem and root cause

`TPflash.accselerateSucsSubs()` allocated three `double[nc]` arrays on every GDEM/DEM acceleration: rollback ln(K), accelerated ln(K), and accelerated K. Difficult flashes call this path repeatedly, so the arrays add avoidable allocation and garbage-collection pressure inside process simulations.

## Change

- Reuse three component-sized instance work arrays.
- Allocate lazily and resize defensively.
- Mark all three arrays `transient`: they are scratch space, not thermodynamic or serialized state.
- Preserve the existing rollback, bounded log-step, DEM/GDEM selection, Rachford–Rice, and initialization paths unchanged.
- Add a regression that reuses one `TPflash` operation on an independently restored fluid and requires bit-identical beta and K-values, guarding against stale scratch data.

A `TPflash` instance was already mutable and not thread-safe (iteration fields and convergence-history arrays are instance state); this change does not alter its thread-safety contract.

## Method and literature basis

The numerical method is unchanged. NeqSim continues to use accelerated successive substitution/GDEM followed by the existing safeguarded phase-split path. This PR only changes workspace lifetime.

Relevant existing basis:

- Michelsen, “The isothermal flash problem. Part II. Phase-split calculation,” *Fluid Phase Equilibria* 9 (1982), 21–40: https://doi.org/10.1016/0378-3812(82)85002-4
- Michelsen & Mollerup, *Thermodynamic Models: Fundamentals & Computational Aspects*, 2nd ed. (2007), especially the successive-substitution/acceleration treatment: https://books.google.com/books?id=qjmeOgAACAAJ

No proprietary commercial-simulator behavior or internal algorithm is inferred.

## Reproducible allocation/time benchmark

Base: `f49af02ca6dc9dd7fc05f5b5249b92c42049bcc7`.

Standalone Java 17 harness:

- SRK / classic mixing rule;
- 10-component N₂/CO₂/C1–C7 fluid at 300 K and 50 bara;
- 10,000 warm-up acceleration calls;
- 300,000 measured calls per JVM;
- nine independent JVM processes per variant, alternated baseline/proposed;
- fixed 512 MiB heap;
- thread allocations measured with `com.sun.management.ThreadMXBean`;
- identical prepared, bounded DEM history and output checksum.

| Metric | Baseline | Proposed | Change |
|---|---:|---:|---:|
| Allocated bytes/call | 976 | 688 | **−29.5%** |
| Median time/call | 3.009 µs | 2.580 µs | **−14.3%** |
| Time range across JVMs | 2.737–4.077 µs | 2.425–3.283 µs | ranges overlap |
| Output checksum | `1.7368590873307546E56` | same | bit-identical |

This is a focused acceleration-kernel benchmark, not an end-to-end TPflash speed claim. End-to-end benefit depends on component count and how often a difficult flash reaches the acceleration step.

## Thermodynamic regression matrix

A separate baseline/proposed exact comparison executed **1,728 TPflash endpoints**:

- models: SRK, PR, SRK-CPA;
- mixtures: gas, oil, water, hydrocarbon/water, CO₂-rich, hydrogen-rich, near-boundary, and large volatility contrast;
- ordinary and multiphase checks;
- 3 temperatures × 3 pressures;
- first run, repeated run, changed T/P, and deliberately poor beta guess.

Coverage produced 618 one-phase, 940 two-phase, and 170 three-phase endpoints, with zero exceptions and zero non-finite endpoints. Every serialized phase type, beta, phase composition, Gibbs energy, material residual, and fugacity residual was **bit-for-bit identical** before and after the patch.

### Separate baseline observation

The broader matrix also reproduced 64 pre-existing CO₂/water endpoints outside the strict `1e-8` fugacity/material residual gate and nine ordinary/multiphase first-state disagreements away from the already-fixed #2760 point. This PR does not change or hide them: baseline and proposed outputs are exactly identical. They remain the best next bounded flash-correctness target; combining that algorithmic investigation with this allocation-only change would violate the one-improvement scope.

## Tests and checks

Passed locally:

- Java 8 source compatibility compilation (`--release 8`) of current `TPflash` and `TPmultiflash`;
- all three `TPflashAccelerationTest` methods compiled and executed, including the new workspace-reuse regression;
- 1,728-state exact baseline/proposed matrix;
- nine-fork allocation/time benchmark;
- `git diff --check`;
- exact two-file branch comparison: 2 commits ahead, 0 behind.

Not run locally:

- Maven/JUnit suite and Spotless, because the isolated environment could not resolve the newly configured Maven plugins from Maven Central (`repo1.maven.org` DNS unavailable). Hosted CI is authoritative for Java 8/21, Linux/Windows, Spotless, Javadocs, CodeQL, and broader tests.

## Compatibility and risk

- Public API: unchanged.
- Numerical equations, tolerances, phase selection, convergence criteria, iteration count, and diagnostics: unchanged.
- Serialization: compatible; scratch arrays are transient and recreated lazily.
- Memory tradeoff: one component-sized three-array workspace per live `TPflash` instance instead of three arrays per acceleration call.
- Thread safety: unchanged; operation instances remain single-use/single-thread mutable solver objects.

## Documentation impact

Documentation impact: none — this is an internal allocation-lifetime optimization with unchanged public behavior, inputs, outputs, units, defaults, numerical method, and recommended usage. Adjacent private fields and the lazy workspace method include Javadocs explaining serialization and resize behavior.
