### PR TITLE
fix(column): reject duplicate pumparound draw ownership

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -266,6 +266,13 @@ StreamInterface returnStream = pumparound.getReturnStream();
 double latestChange = column.getLastPumparoundRelativeChange();
 ```
 
+Each draw tray exposes one liquid pumparound fraction and one draw stream, so it can feed at most
+one pumparound circuit. A zero-fraction standby circuit still owns that draw tray. Registering
+another circuit for the same draw tray throws `IllegalArgumentException` without replacing the
+first circuit; different draw trays remain independent. Legacy serialized columns containing
+duplicate draw ownership fail before solver iteration, and `validateSetup()` reports
+`pumparound.degreesOfFreedom`.
+
 The `temperatureDrop` argument is in Kelvin. Positive values cool the returned liquid; negative
 values heat it. A non-finite or below-zero-K return temperature fails explicitly.
 

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1273,6 +1273,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     lastFullFractionatorFastPathReason = "";
     resetMatrixInsideOutDiagnostics();
     ensureIndependentSideDrawSpecifications();
+    ensureIndependentPumparounds();
     assignUnassignedFeeds();
     convergenceHistory = new ArrayList<>();
     applyDirectSpecifications();
@@ -9895,8 +9896,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     if (!Double.isFinite(temperatureDrop)) {
       throw new IllegalArgumentException("Pumparound temperature drop must be finite");
     }
-    if (getTray(drawTrayNumber).getLiquidPumparoundDrawFraction() > 0.0 && drawFraction > 0.0) {
-      throw new IllegalArgumentException("Only one liquid pumparound draw is supported per tray");
+    if (findPumparoundByDrawTray(drawTrayNumber) != null) {
+      throw new IllegalArgumentException(createDuplicatePumparoundMessage(drawTrayNumber));
     }
 
     ColumnPumparound pumparound = new ColumnPumparound(name, drawTrayNumber, returnTrayNumber, drawFraction,
@@ -9905,6 +9906,46 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     getTray(drawTrayNumber).setLiquidPumparoundDrawFraction(drawFraction);
     setDoInitializion(true);
     return pumparound;
+  }
+
+  /**
+   * Find the pumparound that owns one tray's liquid draw stream.
+   *
+   * @param drawTrayNumber bottom-up draw tray index
+   * @return matching pumparound, or {@code null} when the tray has no pumparound
+   */
+  private ColumnPumparound findPumparoundByDrawTray(int drawTrayNumber) {
+    for (ColumnPumparound pumparound : pumparounds) {
+      if (pumparound.getDrawTrayNumber() == drawTrayNumber) {
+        return pumparound;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Create an actionable message for duplicate pumparound ownership.
+   *
+   * @param drawTrayNumber bottom-up draw tray index
+   * @return duplicate-ownership error message
+   */
+  private String createDuplicatePumparoundMessage(int drawTrayNumber) {
+    return "Column " + getName() + " already has a liquid pumparound drawing from tray " + drawTrayNumber
+        + "; configure at most one pumparound for each draw tray";
+  }
+
+  /**
+   * Reject duplicate draw ownership retained in a column serialized by an older NeqSim version.
+   *
+   * @throws IllegalStateException if two pumparounds use the same liquid draw tray
+   */
+  private void ensureIndependentPumparounds() {
+    Set<Integer> controlledDrawTrays = new HashSet<>();
+    for (ColumnPumparound pumparound : pumparounds) {
+      if (!controlledDrawTrays.add(pumparound.getDrawTrayNumber())) {
+        throw new IllegalStateException(createDuplicatePumparoundMessage(pumparound.getDrawTrayNumber()));
+      }
+    }
   }
 
   /**
@@ -12756,6 +12797,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param result validation result receiving issues
    */
   private void validatePumparounds(ValidationResult result) {
+    Set<Integer> controlledDrawTrays = new HashSet<>();
     if (!isPositiveFiniteValue(pumparoundTolerance)) {
       result.addError("pumparound.tolerance", "Pumparound tolerance is not positive finite",
           "Set a positive finite tolerance with column.setPumparoundTolerance(tolerance)");
@@ -12765,6 +12807,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
           "Set max pumparound iterations to a positive value");
     }
     for (ColumnPumparound pumparound : pumparounds) {
+      if (!controlledDrawTrays.add(pumparound.getDrawTrayNumber())) {
+        result.addError("pumparound.degreesOfFreedom",
+            createDuplicatePumparoundMessage(pumparound.getDrawTrayNumber()),
+            "Keep one liquid pumparound for each draw tray");
+      }
       if (pumparound.getDrawTrayNumber() < 0 || pumparound.getDrawTrayNumber() >= numberOfTrays
           || pumparound.getReturnTrayNumber() < 0 || pumparound.getReturnTrayNumber() >= numberOfTrays) {
         result.addError("pumparound.tray", "Pumparound tray is outside the column",

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -12808,8 +12808,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     }
     for (ColumnPumparound pumparound : pumparounds) {
       if (!controlledDrawTrays.add(pumparound.getDrawTrayNumber())) {
-        result.addError("pumparound.degreesOfFreedom",
-            createDuplicatePumparoundMessage(pumparound.getDrawTrayNumber()),
+        result.addError("pumparound.degreesOfFreedom", createDuplicatePumparoundMessage(pumparound.getDrawTrayNumber()),
             "Keep one liquid pumparound for each draw tray");
       }
       if (pumparound.getDrawTrayNumber() < 0 || pumparound.getDrawTrayNumber() >= numberOfTrays

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -2,7 +2,9 @@ package neqsim.process.equipment.distillation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Locale;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -353,6 +355,42 @@ public class ColumnStudyRegressionTest {
     assertPhysicalProduct(sideDraw, "gas side draw");
     assertTrue(column.getLastIterationCount() <= 300,
         "gas side-draw simultaneous solve should remain inside the configured iteration budget");
+  }
+
+  /**
+   * Verify that one tray cannot feed two liquid pumparound circuits.
+   *
+   * <p>
+   * A zero-fraction circuit represents a realistic standby configuration. It still owns the tray's single liquid
+   * pumparound draw stream and must prevent a second circuit from claiming the same manipulated fraction.
+   * </p>
+   */
+  @Test
+  public void duplicatePumparoundDrawTraysAreRejectedAtRegistration() {
+    SystemInterface baseFluid = createBaseFluid();
+    StreamInterface feedStream = createStream("standby_pumparound_main_feed", baseFluid, MAIN_FEED_COMPOSITION,
+        MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
+    StreamInterface topFeedStream = createStream("standby_pumparound_top_feed", baseFluid, TOP_FEED_COMPOSITION,
+        TOP_FEED_TEMPERATURE_C, TOP_FEED_PRESSURE_BARA, TOP_FEED_MASS_FLOW_KG_HR);
+    DistillationColumn column = createColumn(feedStream, topFeedStream);
+    int drawTray = answerTrayToNeqSimStage(7);
+
+    DistillationColumn.ColumnPumparound standby = column.addLiquidPumparound("standby column-study pumparound",
+        drawTray, answerTrayToNeqSimStage(5), 0.0, 5.0);
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> column.addLiquidPumparound("active duplicate column-study pumparound", drawTray,
+            answerTrayToNeqSimStage(4), 0.03, 7.0));
+    String message = String.valueOf(exception.getMessage()).toLowerCase(Locale.ROOT);
+    assertTrue(message.contains("tray " + drawTray));
+    assertTrue(message.contains("pumparound"));
+    assertEquals(1, column.getPumparounds().size());
+    assertEquals(standby, column.getPumparounds().get(0));
+    assertEquals(0.0, column.getTray(drawTray).getLiquidPumparoundDrawFraction(), 0.0);
+
+    column.addLiquidPumparound("independent column-study pumparound", drawTray + 1, answerTrayToNeqSimStage(4), 0.03,
+        7.0);
+    assertEquals(2, column.getPumparounds().size());
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -382,7 +382,8 @@ public class ColumnStudyRegressionTest {
         () -> column.addLiquidPumparound("active duplicate column-study pumparound", drawTray,
             answerTrayToNeqSimStage(4), 0.03, 7.0));
     String message = String.valueOf(exception.getMessage()).toLowerCase(Locale.ROOT);
-    assertTrue(message.contains("tray " + drawTray));
+    assertTrue(message.contains("tray"));
+    assertTrue(message.contains(String.valueOf(drawTray)));
     assertTrue(message.contains("pumparound"));
     assertEquals(1, column.getPumparounds().size());
     assertEquals(standby, column.getPumparounds().get(0));


### PR DESCRIPTION
## Problem

A `DistillationColumn` stores only one liquid pumparound draw fraction and one draw stream on each `SimpleTray`. However, `addLiquidPumparound(...)` previously inferred ownership from the current draw fraction. A configured zero-fraction standby circuit therefore did not reserve its draw tray, so a second active circuit on the same tray was accepted.

During the outer pumparound tear, both `ColumnPumparound` objects then consumed the tray's same shared draw stream and each returned it independently. This over-specifies that tray and can duplicate its internal recycle/material. The limitation affects the sequential/AUTO outer iteration and the coordinated MESH fallback; Naphtali–Sandholm also falls back to MESH when active pumparounds are present.

## Baseline reproduction

A deterministic regression uses the existing realistic multicomponent SRK fractionator from `ColumnStudyRegressionTest`:

- configure a zero-fraction standby pumparound on draw tray 7;
- attempt to add an active pumparound on the same draw tray;
- verify the first specification and tray state are preserved;
- verify a nearby independent circuit on draw tray 8 remains valid.

On the test-only baseline commit, Java 21 Windows ran **11,198 tests** and produced exactly **1 failure, 0 errors, 212 skipped**: the new registration assertion failed because no exception was thrown. All four Java 21 slow shards passed. Pre-commit and Spotless also passed.

## Root cause and change

Pumparound identity belongs to the configured draw tray, not to the mutable draw fraction.

This change:

- enforces at most one liquid pumparound for each draw tray by looking up configured objects, including zero-fraction standby circuits;
- performs the check before mutating the list or tray, so the first accepted specification is retained;
- preflights the same invariant at the start of `run()` to reject duplicate objects restored from legacy serialized state before any solver iteration;
- reports the structural error through `validatePumparounds()` as `pumparound.degreesOfFreedom`;
- documents the contract and recovery behavior.

Independent pumparounds on different draw trays remain supported.

## Solver and thermodynamic impact

No flash algorithm, phase-equilibrium equation, MESH residual, damping, convergence tolerance, or valid column path changes. The patch prevents a structurally impossible configuration from entering the outer tear/fallback solver, so no runtime speedup is claimed.

## Validation

Final head `e4817b84`:

- `ColumnStudyRegressionTest`: **9/9**
- Java 21 Ubuntu: **11,204 tests, 0 failures, 0 errors, 212 skipped**
- Java 21 Windows: **11,204 tests, 0 failures, 0 errors, 212 skipped**
- Java 8 Ubuntu: **11,204 tests, 0 failures, 0 errors, 212 skipped**
- Java 8 Windows: **11,204 tests, 0 failures, 0 errors, 212 skipped**
- all four Java 21 slow-test shards: pass
- Javadocs, Spotless, pre-commit, PaperLab, documentation coverage, CodeQL, and agent-skill reference checks: pass
- all three Copilot threads were technically assessed, accepted, validated, replied to, and resolved; the final three-file review produced no new comments

The final diff contains only the implementation, focused regression, and adjacent user documentation.

## Compatibility and risk

Valid models are unchanged. Invalid duplicate draw-tray ownership now fails at registration. Legacy serialized duplicates fail explicitly before iteration rather than producing a misleading fallback state. The implementation uses existing public APIs and preserves calculation identity, cloning/serialization behavior, and independent draw-tray configurations.

## Documentation impact

User-visible specification behavior changed, so `docs/process/equipment/distillation.md` now documents one pumparound per draw tray, zero-fraction standby ownership, registration behavior, independent draw trays, legacy pre-run rejection, and the `pumparound.degreesOfFreedom` diagnostic.

## Remaining limitation

This is one structural degree-of-freedom guard, not a full column specification rank analysis. Reflux/boilup, terminal product specifications, side draws, and pumparounds still need coordinated cross-specification validation.