### PR TITLE
fix(tpflash): refine invalid aqueous two-phase endpoints

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -218,6 +218,15 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Replace only with a lower-Gibbs root that already satisfies                │
 │       max |Δ ln(fᵢ)| < 1e-8; phase fractions and compositions stay unchanged     │
 │                                                                                 │
+│  IF a final neutral two-phase aqueous endpoint with water feed ≥ 0.01 fails:     │
+│     → Audit max |Δzᵢ| and max |Δ ln(fᵢ)| against 1e-8                            │
+│     → Retain the selected two-phase active set and run at most three              │
+│       TPmultiflash Q-function/beta refinements                                   │
+│     → Keep only a normalized, material-balanced, fugacity-equal endpoint;         │
+│       otherwise restore the pre-refinement state                                 │
+│     → Reject a Gibbs increase unless the reference was non-conservative,          │
+│       because Gibbs energies of an unbalanced reference are not comparable       │
+│                                                                                 │
 │  IF ordinary, neutral, dry two-phase hydrocarbon roots are inverted:             │
 │     → Detect the vapor-labelled phase having the larger mean molar mass          │
 │     → Evaluate the vapor root on the light composition and liquid root on the    │
@@ -249,6 +258,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
 | Stable-single-phase aqueous-seed gate | `1e-8` in phase-composition normalization | Reject only a structurally invalid aqueous trial whose composition is non-finite, out of `[0, 1]`, or unnormalized; leave normalized endpoints to model-specific convergence and refinement paths |
 | Post-removal aqueous recovery | `1e-8` in `max abs(Delta z_i)` and `max abs(Delta ln(f_i))` | Restore a balanced neutral two-phase aqueous reference only when a rejected third-phase trial leaves the final two-phase endpoint infeasible; genuine three-phase and already feasible endpoints are retained |
+| Final aqueous active-set refinement | water feed `>= 0.01`; at most 3 beta refinements; `1e-8` in phase normalization, `max abs(Delta z_i)`, and `max abs(Delta ln(f_i))` | Preserve the selected neutral two-phase active set while correcting stale beta/compositions after phase cleanup or root selection. Roll back unless the result is feasible; also require no Gibbs increase when the reference material balance was valid. |
 | Stalled three-phase active-set fallback | `1e-8` in phase normalization, material balance, and `max abs(Delta ln(f_i))` | For neutral non-reactive systems only, evaluate each two-phase active set after a non-converged three-phase endpoint and accept the lowest-Gibbs feasible equilibrium only when it also lowers Gibbs energy relative to the stalled state |
 | Water-bearing single-phase-collapse screen | water feed `>= 0.01`, stored water `K < 1e-2`, and a non-water `K > 10` | Run one bounded ordinary-flash retry only after multiphase cleanup returns one phase with strong retained phase-preference evidence; accept only a balanced, distinct two-phase state that lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))` |
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -666,6 +666,7 @@ public class TPflash extends Flash {
         rescueLowerGibbsHydrocarbonPhaseRoots();
         rescueLiquidLiquidEndpoint();
         rescueWaterRichEndpoint();
+        refineInvalidAqueousTwoPhaseEndpoint();
         return;
       }
     }
@@ -862,6 +863,7 @@ public class TPflash extends Flash {
     rescueLiquidLiquidEndpoint();
     rescueWaterRichEndpoint();
     rescueLowerGibbsPhaseRoot();
+    refineInvalidAqueousTwoPhaseEndpoint();
 
     // Final chemical equilibrium call after all phase reordering
     // This ensures chemical equilibrium is solved on the final phase configuration
@@ -999,6 +1001,105 @@ public class TPflash extends Flash {
     } catch (Exception ex) {
       logger.debug("Water-rich endpoint refinement failed: {}", ex.getMessage());
     }
+  }
+
+  /**
+   * Performs a bounded final active-set refinement of an invalid neutral aqueous two-phase endpoint.
+   *
+   * <p>
+   * Phase-appearance cleanup and post-convergence cubic-root selection can leave the correct two active phases with
+   * stale phase fractions or compositions. The phase set is retained, but component material balance or fugacity
+   * equality can then remain outside the ordinary flash tolerance. A {@link TPmultiflash} beta update is phase-order
+   * independent and restores the constrained phase split without rerunning stability analysis. The refinement is
+   * attempted only for substantial-water endpoints that already contain exactly one other phase. The pre-refinement
+   * state is retained as a compact snapshot and restored unless the active-set update passes the existing strict
+   * equilibrium and Gibbs checks.
+   * </p>
+   */
+  private void refineInvalidAqueousTwoPhaseEndpoint() {
+    if (system.getNumberOfPhases() != 2 || !system.hasPhaseType(PhaseType.AQUEOUS) || system.isChemicalSystem()
+        || system.hasIons() || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()) {
+      return;
+    }
+
+    double waterFeedFraction = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      if ("water".equalsIgnoreCase(component.getComponentName())) {
+        waterFeedFraction = component.getz();
+        break;
+      }
+    }
+    if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
+      return;
+    }
+
+    system.init(1);
+    double referenceMaterialResidual = maximumComponentMaterialBalanceResidual(system);
+    double referenceFugacityResidual = maximumLogFugacityResidual(system.getPhase(0), system.getPhase(1));
+    if (Double.isFinite(referenceMaterialResidual) && Double.isFinite(referenceFugacityResidual)
+        && referenceMaterialResidual <= WATER_RICH_MATERIAL_BALANCE_TOLERANCE
+        && referenceFugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
+      return;
+    }
+
+    double referenceGibbsEnergy = system.getGibbsEnergy();
+    BalancedTwoPhaseState referenceState = new BalancedTwoPhaseState(system);
+    try {
+      TPmultiflash endpointSolver = new TPmultiflash(system, false);
+      endpointSolver.setDoubleArrays();
+      for (int refinement = 0; refinement < 3 && !isBalancedEquilibriumCandidate(system); refinement++) {
+        endpointSolver.solveBeta();
+      }
+      if (!isBalancedEquilibriumCandidate(system)
+          || !preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)) {
+        restoreTwoPhaseIterationState(referenceState);
+        return;
+      }
+
+      boolean referenceMaterialBalanceInvalid = !Double.isFinite(referenceMaterialResidual)
+          || referenceMaterialResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE;
+      double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceGibbsEnergy) * 1.0e-8);
+      if (!referenceMaterialBalanceInvalid && system.getGibbsEnergy() > referenceGibbsEnergy + gibbsTolerance) {
+        restoreTwoPhaseIterationState(referenceState);
+      }
+    } catch (Exception ex) {
+      restoreTwoPhaseIterationState(referenceState);
+      logger.debug("Final aqueous endpoint refinement failed: {}", ex.getMessage());
+    }
+  }
+
+
+  /**
+   * Checks that a bounded beta refinement has not changed either selected phase identity.
+   *
+   * @param candidate refined thermodynamic system
+   * @param referencePhaseTypes phase types captured before refinement
+   * @return true when the same two phase types remain at the same phase indices
+   */
+  static boolean preservesTwoPhaseActiveSet(SystemInterface candidate, PhaseType[] referencePhaseTypes) {
+    return candidate.getNumberOfPhases() == 2 && referencePhaseTypes != null && referencePhaseTypes.length == 2
+        && candidate.getPhase(0).getType() == referencePhaseTypes[0]
+        && candidate.getPhase(1).getType() == referencePhaseTypes[1];
+  }
+
+  /**
+   * Restores beta, compositions, and K-values changed by a rejected two-phase endpoint refinement.
+   *
+   * @param referenceState pre-refinement state
+   */
+  private void restoreTwoPhaseIterationState(BalancedTwoPhaseState referenceState) {
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      system.setPhaseType(phaseIndex, referenceState.phaseTypes[phaseIndex]);
+      system.setBeta(phaseIndex, referenceState.betas[phaseIndex]);
+      for (int componentIndex = 0; componentIndex < referenceState.compositions[phaseIndex].length; componentIndex++) {
+        system.getPhase(phaseIndex).getComponent(componentIndex)
+            .setx(referenceState.compositions[phaseIndex][componentIndex]);
+        system.getPhase(phaseIndex).getComponent(componentIndex).setK(referenceState.kValues[componentIndex]);
+      }
+    }
+    system.normalizeBeta();
+    system.init(1);
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1051,8 +1051,7 @@ public class TPflash extends Flash {
       for (int refinement = 0; refinement < 3 && !isBalancedEquilibriumCandidate(system); refinement++) {
         endpointSolver.solveBeta();
       }
-      if (!isBalancedEquilibriumCandidate(system)
-          || !preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)) {
+      if (!isBalancedEquilibriumCandidate(system) || !preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)) {
         restoreTwoPhaseIterationState(referenceState);
         return;
       }
@@ -1068,7 +1067,6 @@ public class TPflash extends Flash {
       logger.debug("Final aqueous endpoint refinement failed: {}", ex.getMessage());
     }
   }
-
 
   /**
    * Checks that a bounded beta refinement has not changed either selected phase identity.

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1043,8 +1043,8 @@ public class TPflash extends Flash {
       return;
     }
 
-    double referenceGibbsEnergy = system.getGibbsEnergy();
     BalancedTwoPhaseState referenceState = new BalancedTwoPhaseState(system);
+    double referenceGibbsEnergy = referenceState.gibbsEnergy;
     try {
       TPmultiflash endpointSolver = new TPmultiflash(system, false);
       endpointSolver.setDoubleArrays();

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousFinalRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousFinalRefinementTest.java
@@ -103,10 +103,14 @@ class TPflashAqueousFinalRefinementTest {
     double ordinaryCompositionTotal = 0.0;
     double multiphaseCompositionTotal = 0.0;
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
-      ordinaryCompositionTotal += ordinary.getPhase(ordinaryPhaseIndex).getComponent(componentIndex).getx();
-      multiphaseCompositionTotal += multiphase.getPhase(multiphasePhaseIndex).getComponent(componentIndex).getx();
-      assertEquals(multiphase.getPhase(multiphasePhaseIndex).getComponent(componentIndex).getx(),
-          ordinary.getPhase(ordinaryPhaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
+      double ordinaryMoleFraction = ordinary.getPhase(ordinaryPhaseIndex).getComponent(componentIndex).getx();
+      double multiphaseMoleFraction = multiphase.getPhase(multiphasePhaseIndex).getComponent(componentIndex).getx();
+      assertTrue(Double.isFinite(ordinaryMoleFraction) && ordinaryMoleFraction >= 0.0 && ordinaryMoleFraction <= 1.0);
+      assertTrue(
+          Double.isFinite(multiphaseMoleFraction) && multiphaseMoleFraction >= 0.0 && multiphaseMoleFraction <= 1.0);
+      ordinaryCompositionTotal += ordinaryMoleFraction;
+      multiphaseCompositionTotal += multiphaseMoleFraction;
+      assertEquals(multiphaseMoleFraction, ordinaryMoleFraction, 1.0e-12);
     }
     assertEquals(1.0, ordinaryCompositionTotal, 1.0e-12);
     assertEquals(1.0, multiphaseCompositionTotal, 1.0e-12);

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousFinalRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousFinalRefinementTest.java
@@ -42,13 +42,14 @@ class TPflashAqueousFinalRefinementTest {
     candidate.addComponent("CO2", 0.8);
     candidate.addComponent("water", 0.2);
     candidate.setNumberOfPhases(2);
-    candidate.setPhaseType(0, PhaseType.GAS);
-    candidate.setPhaseType(1, PhaseType.AQUEOUS);
+    candidate.getPhase(0).setType(PhaseType.GAS);
+    candidate.getPhase(1).setType(PhaseType.AQUEOUS);
 
-    PhaseType[] referenceTypes = new PhaseType[] { PhaseType.GAS, PhaseType.AQUEOUS };
+    PhaseType[] referenceTypes = new PhaseType[] { candidate.getPhase(0).getType(),
+        candidate.getPhase(1).getType() };
     assertTrue(TPflash.preservesTwoPhaseActiveSet(candidate, referenceTypes));
 
-    candidate.setPhaseType(0, PhaseType.LIQUID);
+    candidate.getPhase(0).setType(PhaseType.LIQUID);
 
     assertFalse(TPflash.preservesTwoPhaseActiveSet(candidate, referenceTypes),
         "A GAS-to-LIQUID mutation must not satisfy the selected active-set contract");

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousFinalRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousFinalRefinementTest.java
@@ -35,7 +35,6 @@ class TPflashAqueousFinalRefinementTest {
     assertTrue(maximumLogFugacityResidual(multiphase) < 1.0e-8);
   }
 
-
   /** A candidate whose beta solve changes a selected phase type must be rejected before it can replace the snapshot. */
   @Test
   void activeSetGuardRejectsPhaseTypeMutation() {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousFinalRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousFinalRefinementTest.java
@@ -1,0 +1,141 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashAqueousFinalRefinementTest {
+  private static final String[] COMPONENTS = { "CO2", "methane", "ethane", "water" };
+  private static final double[] REGRESSION_FEED = { 0.543865141103918, 0.2937712952303271, 0.07010605470616459,
+      0.09225750895959021 };
+  private static final double[] CO2_RICH_FEED = { 0.75, 0.15, 0.02, 0.08 };
+
+  @Test
+  void finalRefinementRestoresAqueousFugacityEquality() {
+    SystemInterface ordinary = createAndFlash(REGRESSION_FEED, 275.7756311717352, 74.76182177756704, false);
+    SystemInterface multiphase = createAndFlash(REGRESSION_FEED, 275.7756311717352, 74.76182177756704, true);
+
+    assertEquivalentBalancedEquilibrium(ordinary, multiphase, REGRESSION_FEED);
+    assertTrue(maximumLogFugacityResidual(ordinary) < 1.0e-8);
+    assertTrue(maximumLogFugacityResidual(multiphase) < 1.0e-8);
+  }
+
+  @Test
+  void finalRefinementRestoresAqueousMaterialBalance() {
+    SystemInterface ordinary = createAndFlash(CO2_RICH_FEED, 250.70511924703197, 149.52364355513407, false);
+    SystemInterface multiphase = createAndFlash(CO2_RICH_FEED, 250.70511924703197, 149.52364355513407, true);
+
+    assertEquivalentBalancedEquilibrium(ordinary, multiphase, CO2_RICH_FEED);
+    assertTrue(maximumLogFugacityResidual(ordinary) < 1.0e-8);
+    assertTrue(maximumLogFugacityResidual(multiphase) < 1.0e-8);
+  }
+
+
+  /** A candidate whose beta solve changes a selected phase type must be rejected before it can replace the snapshot. */
+  @Test
+  void activeSetGuardRejectsPhaseTypeMutation() {
+    SystemInterface candidate = new SystemSrkEos(275.0, 75.0);
+    candidate.addComponent("CO2", 0.8);
+    candidate.addComponent("water", 0.2);
+    candidate.setNumberOfPhases(2);
+    candidate.setPhaseType(0, PhaseType.GAS);
+    candidate.setPhaseType(1, PhaseType.AQUEOUS);
+
+    PhaseType[] referenceTypes = new PhaseType[] { PhaseType.GAS, PhaseType.AQUEOUS };
+    assertTrue(TPflash.preservesTwoPhaseActiveSet(candidate, referenceTypes));
+
+    candidate.setPhaseType(0, PhaseType.LIQUID);
+
+    assertFalse(TPflash.preservesTwoPhaseActiveSet(candidate, referenceTypes),
+        "A GAS-to-LIQUID mutation must not satisfy the selected active-set contract");
+  }
+
+  private SystemInterface createAndFlash(double[] feed, double temperature, double pressure, boolean multiphaseCheck) {
+    SystemInterface system = new SystemSrkEos(temperature, pressure);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], feed[componentIndex]);
+    }
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private void assertEquivalentBalancedEquilibrium(SystemInterface ordinary, SystemInterface multiphase,
+      double[] feed) {
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquals(2, multiphase.getNumberOfPhases());
+    int ordinaryAqueousPhase = phaseIndexOf(ordinary, PhaseType.AQUEOUS);
+    int multiphaseAqueousPhase = phaseIndexOf(multiphase, PhaseType.AQUEOUS);
+    assertTrue(ordinaryAqueousPhase >= 0);
+    assertTrue(multiphaseAqueousPhase >= 0);
+    assertEquals(multiphase.getGibbsEnergy(), ordinary.getGibbsEnergy(), 1.0e-8);
+
+    int ordinaryOtherPhase = ordinaryAqueousPhase == 0 ? 1 : 0;
+    int multiphaseOtherPhase = multiphaseAqueousPhase == 0 ? 1 : 0;
+    assertEquivalentPhaseState(ordinary, ordinaryAqueousPhase, multiphase, multiphaseAqueousPhase);
+    assertEquivalentPhaseState(ordinary, ordinaryOtherPhase, multiphase, multiphaseOtherPhase);
+
+    assertEquals(1.0, ordinary.getBeta(0) + ordinary.getBeta(1), 1.0e-12);
+    assertEquals(1.0, multiphase.getBeta(0) + multiphase.getBeta(1), 1.0e-12);
+    assertTrue(maximumMaterialBalanceResidual(ordinary, feed) < 1.0e-8);
+    assertTrue(maximumMaterialBalanceResidual(multiphase, feed) < 1.0e-8);
+  }
+
+  private int phaseIndexOf(SystemInterface system, PhaseType phaseType) {
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex).getType() == phaseType) {
+        return phaseIndex;
+      }
+    }
+    return -1;
+  }
+
+  private void assertEquivalentPhaseState(SystemInterface ordinary, int ordinaryPhaseIndex, SystemInterface multiphase,
+      int multiphasePhaseIndex) {
+    assertEquals(multiphase.getPhase(multiphasePhaseIndex).getType(), ordinary.getPhase(ordinaryPhaseIndex).getType());
+    assertEquals(multiphase.getBeta(multiphasePhaseIndex), ordinary.getBeta(ordinaryPhaseIndex), 1.0e-12);
+    double ordinaryCompositionTotal = 0.0;
+    double multiphaseCompositionTotal = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      ordinaryCompositionTotal += ordinary.getPhase(ordinaryPhaseIndex).getComponent(componentIndex).getx();
+      multiphaseCompositionTotal += multiphase.getPhase(multiphasePhaseIndex).getComponent(componentIndex).getx();
+      assertEquals(multiphase.getPhase(multiphasePhaseIndex).getComponent(componentIndex).getx(),
+          ordinary.getPhase(ordinaryPhaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
+    }
+    assertEquals(1.0, ordinaryCompositionTotal, 1.0e-12);
+    assertEquals(1.0, multiphaseCompositionTotal, 1.0e-12);
+  }
+
+  private double maximumMaterialBalanceResidual(SystemInterface system, double[] feed) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      maximumResidual = Math.max(maximumResidual, Math.abs(feed[componentIndex] - recoveredFeed));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double firstLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+    }
+    return maximumResidual;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousFinalRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousFinalRefinementTest.java
@@ -45,8 +45,7 @@ class TPflashAqueousFinalRefinementTest {
     candidate.getPhase(0).setType(PhaseType.GAS);
     candidate.getPhase(1).setType(PhaseType.AQUEOUS);
 
-    PhaseType[] referenceTypes = new PhaseType[] { candidate.getPhase(0).getType(),
-        candidate.getPhase(1).getType() };
+    PhaseType[] referenceTypes = new PhaseType[] { candidate.getPhase(0).getType(), candidate.getPhase(1).getType() };
     assertTrue(TPflash.preservesTwoPhaseActiveSet(candidate, referenceTypes));
 
     candidate.getPhase(0).setType(PhaseType.LIQUID);


### PR DESCRIPTION
## Problem

Neutral CO2/water flashes can finish with the correct gas/aqueous active phase set but stale phase fractions or compositions after phase cleanup or cubic-root selection. The endpoint can therefore look plausible while violating

- component balance: `max_i |z_i - sum_p beta_p x_{p,i}|`
- equilibrium: `max_i |ln(x_i phi_i)_0 - ln(x_i phi_i)_1|`

The minimal SRK/classic feed `CO2/methane/ethane/water = 0.543865141103918/0.2937712952303271/0.07010605470616459/0.09225750895959021` at 275.775631 K and 74.761822 bara returned gas + aqueous phases with a maximum log-fugacity residual of `5.449e-3`.

A second deterministic SRK CO2-rich case at 250.705119 K and 149.523644 bara returned a component-balance residual of `6.772e-2`.

## Root cause

The ordinary TPflash path already has bounded phase-appearance, cleanup, and root-selection safeguards, but it did not perform a final strict audit/refinement of the selected neutral aqueous two-phase active set. The existing water-rich retry can retain the same invalid endpoint, so correct phase identities alone did not guarantee a conservative equilibrium state.

## Change

Add a final, narrowly gated active-set refinement when all of the following hold:

- exactly two active phases, including aqueous
- neutral, non-reactive, non-solid, non-wax system
- water feed fraction at least `0.01`
- component-balance or log-fugacity residual exceeds `1e-8`

The method preserves the selected phases and runs at most three calls to the existing phase-order-independent `TPmultiflash.solveBeta()` Q-function/Newton update. It does not rerun stability analysis or add/remove phases.

A compact snapshot restores beta, compositions, and K-values unless the candidate satisfies the existing phase-fraction, composition-normalization, component-balance, fugacity, and distinct-phase checks. For a material-balanced reference, the candidate is also rejected if extensive Gibbs energy increases by more than `max(1e-6 J, 1e-8 |G|)`. Gibbs values are deliberately not compared to a non-conservative reference because its phase amounts are invalid.

## Numerical evidence

Focused regressions:

| Case | Metric | Before | After |
|---|---:|---:|---:|
| SRK regression feed | max log-fugacity residual | `5.449e-3` | `3.20e-14` |
| SRK CO2-rich feed | max component-balance residual | `6.772e-2` | `2.26e-14` |
| SRK CO2-rich feed | max log-fugacity residual | approximately `3e-13` | approximately `3e-13` |
| PR regression feed, 225.634607 K / 74.761822 bara | max component-balance residual | `7.666e-2` | `2.67e-14` |

A deterministic 2,160-endpoint matrix exercised ordinary and multiphase TPflash with SRK, PR, and CPA; gas, oil, water, hydrocarbon-water, CO2-rich, hydrogen-rich, near-boundary, and large-volatility-contrast feeds; one-, two-, and three-phase regions; repeated execution, changed T/P/composition, and poor beta guesses.

| Matrix result | Before | After |
|---|---:|---:|
| Invalid endpoints | 87 | 23 |
| Invalid two-phase endpoints | 79 | 15 |
| Applicable ordinary/multiphase disagreements | 4 | 0 |
| Exceptions | 0 | 0 |
| Repeat differences | 0 | 0 |
| Poor-guess differences | 0 | 0 |

The 64 repaired endpoints all had the selected two-phase aqueous active set. Fifteen pre-existing invalid two-phase endpoints and eight invalid three-phase endpoints remain outside this bounded change. Two higher-Gibbs three-phase selections also remain and are explicitly left for separate phase-set work.

## Runtime

No speedup is claimed.

- Full 2,160-endpoint matrix: `12,480.041 ms -> 12,480.890 ms`, no measurable wall-time regression.
- Focused defective-case benchmark, five alternating JVM forks: median `4.391 -> 4.503 ms/flash` (about 2.5%); ranges overlap. The added cost is one bounded beta refinement on endpoints that previously returned an invalid result.
- Valid aqueous endpoints exit after the residual audit without invoking the refinement; fork ranges overlap.

## Method and literature basis

This reuses NeqSim's existing constrained multiphase Q/beta solve. It is consistent with Michelsen's phase-split formulation, which refines a selected phase set toward equilibrium and minimum Gibbs energy, and with the feasible-region treatment of multiphase Rachford-Rice systems described by Okuno et al.

- Michelsen, M. L. (1982), *The isothermal flash problem. Part II. Phase-split calculation*, Fluid Phase Equilibria 9, 21-40: https://doi.org/10.1016/0378-3812(82)85002-4
- Okuno, R., Johns, R. T., and Sepehrnoori, K. (2010), *A New Algorithm for Rachford-Rice for Multiphase Compositional Simulation*, SPE Journal 15(2), 313-325: https://doi.org/10.2118/117752-PA

Modern safeguarded Newton/line-search work for CO2-rich phase equilibrium is relevant context, but no new line-search or trust-region algorithm is claimed or implemented here: https://doi.org/10.1021/acsomega.4c01394

## Test evidence

- Regression-first check: the new focused test fails on the baseline at the fugacity assertion.
- Java 8 source compilation passed using the JDK compiler module.
- `TPflashAqueousFinalRefinementTest`: 2/2 focused tests passed.
- `git diff --check`: passed.
- The deterministic matrices checked beta bounds/sum, composition bounds/normalization, component and total balance, fugacity equality, finite Gibbs/enthalpy/density, phase count/type, repeatability, poor guesses, and cross-algorithm consistency.
- Maven/Spotless and the full JUnit suite were not run locally because the sandbox could not resolve the Spotless/Maven artifacts. Hosted CI is expected to run formatting, build, Javadocs, and the broader suite.

## Compatibility and risk

The fast path adds only residual calculations for neutral two-phase aqueous endpoints with at least 1 mol% water. Existing valid endpoints are unchanged. Chemical/electrolyte, solid, wax, dry hydrocarbon, single-phase, and genuine three-phase paths are excluded. The refinement has a three-step hard bound and rollback on any exception or failed acceptance gate.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md` with the final audit/refinement flow, thresholds, rollback policy, and Gibbs acceptance rule.


## Exact-head follow-up

Rebased onto current `master` at `13a6f31ee4`. The bounded aqueous refinement now accepts a candidate only when the original two-phase phase-type ordering is preserved; a focused regression mutates the selected type and verifies rejection. This prevents `TPmultiflash.solveBeta()` from silently replacing the original aqueous/fluid active set. The previous Windows failure was a Maven Central TLS handshake, not a NeqSim test failure. Exact-head CI and Copilot review are required before readiness.


## Final feasibility assertions

The endpoint equivalence regression now requires every phase mole fraction to be finite and within [0, 1] before checking normalization and ordinary/multiphase equality. This prevents the fugacity-residual floor from masking a negative composition.
