### PR TITLE
perf: avoid derivative init in valve entropy

### DIFF
--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -1116,8 +1116,8 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
   /** {@inheritDoc} */
   @Override
   public double getEntropyProduction(String unit) {
-    outStream.getThermoSystem().init(3);
-    inStream.getThermoSystem().init(3);
+    outStream.getThermoSystem().init(2);
+    inStream.getThermoSystem().init(2);
     return outStream.getThermoSystem().getEntropy(unit) - inStream.getThermoSystem().getEntropy(unit);
   }
 

--- a/src/test/java/neqsim/process/equipment/valve/ThrottlingValveTest.java
+++ b/src/test/java/neqsim/process/equipment/valve/ThrottlingValveTest.java
@@ -616,8 +616,8 @@ public class ThrottlingValveTest {
   }
 
   /**
-   * Valve entropy requires caloric properties but not level-3 composition derivatives. The diagnostic must preserve
-   * the level-3 reference result and surrounding stream state at the base condition and a nearby operating point.
+   * Valve entropy requires caloric properties but not level-3 composition derivatives. The diagnostic must preserve the
+   * level-3 reference result and surrounding stream state at the base condition and a nearby operating point.
    */
   @Test
   void testEntropyProductionUsesMinimumThermodynamicInitializationLevel() {
@@ -646,8 +646,7 @@ public class ThrottlingValveTest {
     assertMinimumEntropyInitialization(fluid, valve);
   }
 
-  private static void assertMinimumEntropyInitialization(InitTrackingSystemSrkEos fluid,
-      ThrottlingValve valve) {
+  private static void assertMinimumEntropyInitialization(InitTrackingSystemSrkEos fluid, ThrottlingValve valve) {
     valve.getInletStream().getFluid().init(3);
     valve.getOutletStream().getFluid().init(3);
     double expectedEntropy = valve.getOutletStream().getFluid().getEntropy("J/K")

--- a/src/test/java/neqsim/process/equipment/valve/ThrottlingValveTest.java
+++ b/src/test/java/neqsim/process/equipment/valve/ThrottlingValveTest.java
@@ -3,14 +3,60 @@ package neqsim.process.equipment.valve;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.mechanicaldesign.valve.ControlValveSizing_IEC_60534;
 import neqsim.process.mechanicaldesign.valve.ControlValveSizing_simple;
 import neqsim.process.mechanicaldesign.valve.ValveMechanicalDesign;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
 
 public class ThrottlingValveTest {
+  private static class InitTrackingSystemSrkEos extends SystemSrkEos {
+    private static final long serialVersionUID = 1000L;
+    private AtomicInteger levelTwoCalls = new AtomicInteger();
+    private AtomicInteger levelThreeCalls = new AtomicInteger();
+
+    InitTrackingSystemSrkEos(double temperature, double pressure) {
+      super(temperature, pressure);
+    }
+
+    @Override
+    public InitTrackingSystemSrkEos clone() {
+      InitTrackingSystemSrkEos cloned = (InitTrackingSystemSrkEos) super.clone();
+      if (cloned == null) {
+        throw new IllegalStateException("Failed to clone initialization-tracking fluid");
+      }
+      cloned.levelTwoCalls = levelTwoCalls;
+      cloned.levelThreeCalls = levelThreeCalls;
+      return cloned;
+    }
+
+    @Override
+    public void init(int initType) {
+      super.init(initType);
+      if (levelTwoCalls != null && initType == 2) {
+        levelTwoCalls.incrementAndGet();
+      } else if (levelThreeCalls != null && initType == 3) {
+        levelThreeCalls.incrementAndGet();
+      }
+    }
+
+    void resetInitCounts() {
+      levelTwoCalls.set(0);
+      levelThreeCalls.set(0);
+    }
+
+    int getLevelTwoCalls() {
+      return levelTwoCalls.get();
+    }
+
+    int getLevelThreeCalls() {
+      return levelThreeCalls.get();
+    }
+  }
+
   /**
    * Test method for calculating the flow coefficient (Cv) of a gas through a throttling valve.
    * <p>
@@ -567,5 +613,72 @@ public class ThrottlingValveTest {
 
     // Both should give the same result
     assertEquals(cv, cv2, 1.0, "Cv from standalone run and ProcessSystem run should match");
+  }
+
+  /**
+   * Valve entropy requires caloric properties but not level-3 composition derivatives. The diagnostic must preserve
+   * the level-3 reference result and surrounding stream state at the base condition and a nearby operating point.
+   */
+  @Test
+  void testEntropyProductionUsesMinimumThermodynamicInitializationLevel() {
+    InitTrackingSystemSrkEos fluid = new InitTrackingSystemSrkEos(363.15, 80.0);
+    fluid.addComponent("nitrogen", 0.02);
+    fluid.addComponent("CO2", 0.03);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.07);
+    fluid.addComponent("propane", 0.04);
+    fluid.addComponent("n-heptane", 0.04);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("tracked valve inlet", fluid);
+    inlet.setFlowRate(50000.0, "kg/hr");
+    inlet.run();
+
+    ThrottlingValve valve = new ThrottlingValve("tracked entropy valve", inlet);
+    valve.setOutletPressure(40.0, "bara");
+    valve.run();
+
+    assertMinimumEntropyInitialization(fluid, valve);
+
+    inlet.setTemperature(368.15, "K");
+    inlet.run();
+    valve.run();
+    assertMinimumEntropyInitialization(fluid, valve);
+  }
+
+  private static void assertMinimumEntropyInitialization(InitTrackingSystemSrkEos fluid,
+      ThrottlingValve valve) {
+    valve.getInletStream().getFluid().init(3);
+    valve.getOutletStream().getFluid().init(3);
+    double expectedEntropy = valve.getOutletStream().getFluid().getEntropy("J/K")
+        - valve.getInletStream().getFluid().getEntropy("J/K");
+
+    double inletTemperature = valve.getInletStream().getTemperature("K");
+    double outletTemperature = valve.getOutletStream().getTemperature("K");
+    double inletPressure = valve.getInletStream().getPressure("bara");
+    double outletPressure = valve.getOutletStream().getPressure("bara");
+    double massFlow = valve.getOutletStream().getFlowRate("kg/hr");
+    double inletEnthalpy = valve.getInletStream().getFluid().getEnthalpy("J");
+    double outletEnthalpy = valve.getOutletStream().getFluid().getEnthalpy("J");
+    int inletPhases = valve.getInletStream().getFluid().getNumberOfPhases();
+    int outletPhases = valve.getOutletStream().getFluid().getNumberOfPhases();
+
+    fluid.resetInitCounts();
+    double actualEntropy = valve.getEntropyProduction("J/K");
+
+    assertEquals(expectedEntropy, actualEntropy, Math.max(1.0e-9, Math.abs(expectedEntropy) * 1.0e-12));
+    assertEquals(2, fluid.getLevelTwoCalls(), "Inlet and outlet still require caloric initialization");
+    assertEquals(0, fluid.getLevelThreeCalls(), "Valve entropy must not calculate composition derivatives");
+    assertEquals(inletTemperature, valve.getInletStream().getTemperature("K"), 0.0);
+    assertEquals(outletTemperature, valve.getOutletStream().getTemperature("K"), 0.0);
+    assertEquals(inletPressure, valve.getInletStream().getPressure("bara"), 0.0);
+    assertEquals(outletPressure, valve.getOutletStream().getPressure("bara"), 0.0);
+    assertEquals(massFlow, valve.getOutletStream().getFlowRate("kg/hr"), 0.0);
+    assertEquals(inletEnthalpy, valve.getInletStream().getFluid().getEnthalpy("J"), 0.0);
+    assertEquals(outletEnthalpy, valve.getOutletStream().getFluid().getEnthalpy("J"), 0.0);
+    assertEquals(inletPhases, valve.getInletStream().getFluid().getNumberOfPhases());
+    assertEquals(outletPhases, valve.getOutletStream().getFluid().getNumberOfPhases());
+    assertEquals(actualEntropy, valve.getEntropyProduction("J/K"), 0.0,
+        "Repeated diagnostic calls must remain bit-identical");
   }
 }


### PR DESCRIPTION
## Summary

Reduce the thermodynamic initialization depth in `ThrottlingValve.getEntropyProduction(...)` from level 3 to level 2.

The diagnostic reads only inlet and outlet entropy. NeqSim documents entropy as a level-2 caloric property, so the previous calls calculated unused level-3 composition derivatives. The adjacent exergy diagnostic remains unchanged and outside this bounded change.

Related audit: #2698.

## Reproducible benchmark

Baseline: current `master` at `4f88b44e7cee22a6d0b534ac12a14f022382071a`.

The benchmark compiled the exact current `ThrottlingValve` baseline and candidate source as overlays on the available NeqSim 3.16.0 dependency closure. It used OpenJDK 17, G1, a fixed 512 MiB heap, seven fresh JVMs, alternating baseline/candidate order, 200 warm-up calls, and 9 × 300 measured calls per fork.

Workload: six independent throttling valves, each with a 13-component SRK rich gas, approximately 50,000 kg/h, and pressure reduction from about 80 bara to 40 bara. The stream temperature changed between calls so initialization work was not hidden by a solved-state cache.

| Scope | Baseline median | Candidate median | Median paired reduction |
|---|---:|---:|---:|
| Direct six-valve diagnostic | 142.901 µs/call | 88.724 µs/call | 38.1% |
| `ProcessSystem.getEntropyProduction` | 141.979 µs/call | 90.852 µs/call | 36.9% |
| `ProcessModel.getEntropyProduction` | 128.141 µs/call | 89.808 µs/call | 30.3% |

Every baseline/candidate fork produced the identical accumulated checksum `51492129.100119640`.

## Correctness and robustness

The focused regression compares the optimized result with an independent level-3 reference at:

- 363.15 K and 80 bara inlet / 40 bara outlet;
- a nearby +5 K inlet condition.

It verifies:

- exactly two level-2 initializations and zero level-3 calls in the diagnostic;
- unchanged entropy production;
- unchanged inlet/outlet temperature and pressure;
- unchanged outlet mass flow;
- unchanged inlet/outlet enthalpy;
- unchanged phase counts;
- bit-identical repeated diagnostic calls.

Valve execution, PH flashes, sizing, flow calculation, convergence, mass/energy balances, phase equilibrium, serialization, and public APIs are untouched.

## Validation

- Java 8 source compatibility compile of the exact changed production class: passed.
- Java 8 syntax compile of `ThrottlingValveTest`: passed.
- Executable current-source validation at the baseline and +5 K point: passed.
- Seven-fork direct/`ProcessSystem`/`ProcessModel` benchmark: passed with identical checksums.
- `git diff --check`: passed.
- Full Maven execution and Spotless were unavailable locally because Maven Central DNS is blocked in the isolated runtime; hosted CI is expected to run the complete repository gates.

## Compatibility and limitations

- No public API, input, output, default, unit, or serialized-state change.
- The measured percentage is for the entropy-reporting path, not the full steady-state simulation.
- Benefit is largest when diagnostics follow changing stream states; repeated reporting of an already initialized state can be cache-dominated.
- This PR does not change `getExergyChange(...)` or other equipment classes.

Documentation impact: none — adjacent thermodynamic documentation already states that entropy requires `init(2)`; public behavior and recommended valve usage are unchanged.