### PR TITLE
fix(column): reject conflicting condenser reflux controls

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -176,6 +176,14 @@ fixed-reflux shortfall exceeds its acceptance tolerance. The requested, availabl
 in
 `getConvergenceDiagnostics()`.
 
+A fixed liquid-reflux flow and a top `REFLUX_RATIO` specification are mutually exclusive because
+both control the condenser reflux split. Configuration rejects either setter order, and
+`validateSpecifications()` plus the run preflight detect contradictory state retained by an older
+serialized model or introduced through direct `Condenser` mutation. To recover, call
+`setCondenserMode(DistillationColumn.CondenserMode.PARTIAL)` or
+`setCondenserMode(DistillationColumn.CondenserMode.TOTAL)` to clear fixed-flow mode, or remove the
+top reflux-ratio specification.
+
 ## Solver Options
 
 | Solver type | Strategy | Typical use |

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1274,6 +1274,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     resetMatrixInsideOutDiagnostics();
     ensureIndependentSideDrawSpecifications();
     ensureIndependentPumparounds();
+    ensureIndependentTerminalSpecifications();
     assignUnassignedFeeds();
     convergenceHistory = new ArrayList<>();
     applyDirectSpecifications();
@@ -1690,6 +1691,49 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       return Math.abs(topTrayPressure - previousTopPressure) / Math.max(1.0e-12, Math.abs(previousTopPressure));
     }
     return 0.0;
+  }
+
+  /**
+   * Check whether the fixed liquid-reflux flow and top reflux-ratio specification claim the same condenser split.
+   *
+   * @return {@code true} when both mutually exclusive controls are active
+   */
+  private boolean hasConflictingCondenserRefluxSpecifications() {
+    Condenser condenser = hasCondenser ? getCondenser() : null;
+    return condenser != null && condenser.isSeparation_with_liquid_reflux()
+        && isTopRefluxRatioSpecification(topSpecification);
+  }
+
+  /**
+   * Check whether a specification controls the condenser reflux ratio.
+   *
+   * @param specification specification to inspect
+   * @return {@code true} for a top reflux-ratio specification
+   */
+  private boolean isTopRefluxRatioSpecification(ColumnSpecification specification) {
+    return specification != null && specification.getLocation() == ColumnSpecification.ProductLocation.TOP
+        && specification.getType() == ColumnSpecification.SpecificationType.REFLUX_RATIO;
+  }
+
+  /**
+   * Create an actionable message for contradictory condenser reflux controls.
+   *
+   * @return degrees-of-freedom error message
+   */
+  private String createConflictingCondenserRefluxSpecificationsMessage() {
+    return "Column " + getName() + " cannot combine a fixed liquid-reflux flow with a top reflux-ratio specification; "
+        + "select one condenser reflux control";
+  }
+
+  /**
+   * Reject contradictory condenser reflux controls retained through direct condenser mutation or serialization.
+   *
+   * @throws IllegalStateException if fixed liquid reflux and top reflux ratio both control the condenser split
+   */
+  private void ensureIndependentTerminalSpecifications() {
+    if (hasConflictingCondenserRefluxSpecifications()) {
+      throw new IllegalStateException(createConflictingCondenserRefluxSpecificationsMessage());
+    }
   }
 
   /** Apply specifications that map directly to condenser or reboiler controls. */
@@ -10409,10 +10453,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    *
    * @param value fixed liquid reflux flow rate
    * @param unit flow-rate unit for the fixed reflux value
+   * @throws IllegalArgumentException if a top reflux-ratio specification is already active
    * @throws IllegalStateException if the column has no condenser
    */
   public void setCondenserLiquidReflux(double value, String unit) {
     Condenser condenser = requireCondenser();
+    if (isTopRefluxRatioSpecification(topSpecification)) {
+      throw new IllegalArgumentException(createConflictingCondenserRefluxSpecificationsMessage());
+    }
     condenser.setTotalCondenser(false);
     condenser.setSeparation_with_liquid_reflux(true, value, unit);
     setDoInitializion(true);
@@ -12673,6 +12721,10 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     validateColumnSpecification(result, topSpecification, ColumnSpecification.ProductLocation.TOP);
     validateColumnSpecification(result, bottomSpecification, ColumnSpecification.ProductLocation.BOTTOM);
     validateProductFlowSpecificationsAgainstFeed(result);
+    if (hasConflictingCondenserRefluxSpecifications()) {
+      result.addError("specification.degreesOfFreedom", createConflictingCondenserRefluxSpecificationsMessage(),
+          "Call setCondenserMode(DistillationColumn.CondenserMode.PARTIAL) or setCondenserMode(DistillationColumn.CondenserMode.TOTAL) to clear fixed-flow mode, or remove the top reflux-ratio specification");
+    }
   }
 
   /**
@@ -13392,13 +13444,19 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * records the user's intent.
    *
    * @param refluxRatio the desired reflux ratio (L/D)
+   * @throws IllegalArgumentException if fixed liquid-reflux mode is active
    */
   public void setCondenserRefluxRatio(double refluxRatio) {
-    if (hasCondenser) {
-      getCondenser().setRefluxRatio(refluxRatio);
+    Condenser condenser = hasCondenser ? getCondenser() : null;
+    if (condenser != null && condenser.isSeparation_with_liquid_reflux()) {
+      throw new IllegalArgumentException(createConflictingCondenserRefluxSpecificationsMessage());
     }
-    this.topSpecification = new ColumnSpecification(ColumnSpecification.SpecificationType.REFLUX_RATIO,
+    ColumnSpecification specification = new ColumnSpecification(ColumnSpecification.SpecificationType.REFLUX_RATIO,
         ColumnSpecification.ProductLocation.TOP, refluxRatio);
+    if (condenser != null) {
+      condenser.setRefluxRatio(refluxRatio);
+    }
+    this.topSpecification = specification;
   }
 
   // ======================== Column specification convenience methods
@@ -13426,11 +13484,16 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * Sets the top column specification with location validation.
    *
    * @param spec the specification (must have location TOP)
-   * @throws IllegalArgumentException if the specification location is not TOP
+   * @throws IllegalArgumentException if the specification location is not TOP or a top reflux-ratio specification
+   * conflicts with fixed liquid-reflux mode
    */
   public void setTopSpecification(ColumnSpecification spec) {
     if (spec != null && spec.getLocation() != ColumnSpecification.ProductLocation.TOP) {
       throw new IllegalArgumentException("Top specification must have location TOP, got: " + spec.getLocation());
+    }
+    Condenser condenser = hasCondenser ? getCondenser() : null;
+    if (isTopRefluxRatioSpecification(spec) && condenser != null && condenser.isSeparation_with_liquid_reflux()) {
+      throw new IllegalArgumentException(createConflictingCondenserRefluxSpecificationsMessage());
     }
     this.topSpecification = spec;
   }

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -717,14 +717,15 @@ public class DocExamplesCompilationTest {
     assertNotNull(builderColumn.getTopSpecification());
     assertNotNull(builderColumn.getBottomSpecification());
 
-    apiColumn.setCondenserMode(DistillationColumn.CondenserMode.PARTIAL);
-    apiColumn.setCondenserMode(DistillationColumn.CondenserMode.TOTAL);
-    assertEquals(DistillationColumn.CondenserMode.TOTAL, apiColumn.getCondenserMode());
-    apiColumn.setCondenserLiquidReflux(500.0, "kg/hr");
-    assertEquals(DistillationColumn.CondenserMode.LIQUID_REFLUX_SPLIT, apiColumn.getCondenserMode());
-    apiColumn.setReboilerMode(DistillationColumn.ReboilerMode.EQUILIBRIUM);
-    apiColumn.setReboilerVaporBoilupRatio(1.8);
-    assertEquals(DistillationColumn.ReboilerMode.VAPOR_BOILUP_RATIO, apiColumn.getReboilerMode());
+    DistillationColumn modeColumn = new DistillationColumn("Doc Mode Column", 10, true, true);
+    modeColumn.setCondenserMode(DistillationColumn.CondenserMode.PARTIAL);
+    modeColumn.setCondenserMode(DistillationColumn.CondenserMode.TOTAL);
+    assertEquals(DistillationColumn.CondenserMode.TOTAL, modeColumn.getCondenserMode());
+    modeColumn.setCondenserLiquidReflux(500.0, "kg/hr");
+    assertEquals(DistillationColumn.CondenserMode.LIQUID_REFLUX_SPLIT, modeColumn.getCondenserMode());
+    modeColumn.setReboilerMode(DistillationColumn.ReboilerMode.EQUILIBRIUM);
+    modeColumn.setReboilerVaporBoilupRatio(1.8);
+    assertEquals(DistillationColumn.ReboilerMode.VAPOR_BOILUP_RATIO, modeColumn.getReboilerMode());
 
     apiColumn.setMurphreeEfficiency(0.70);
     apiColumn.setMurphreeEfficiency(3, 0.65);

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
@@ -2,6 +2,7 @@ package neqsim.process.equipment.distillation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.UUID;
@@ -32,6 +33,59 @@ public class DistillationColumnModeTest {
     assertEquals(DistillationColumn.CondenserMode.LIQUID_REFLUX_SPLIT, column.getCondenserMode());
     column.setCondenserMode(DistillationColumn.CondenserMode.PARTIAL);
     assertEquals(DistillationColumn.CondenserMode.PARTIAL, column.getCondenserMode());
+  }
+
+  /**
+   * Reject fixed liquid-reflux flow and reflux-ratio specifications that claim the same condenser split.
+   */
+  @Test
+  public void fixedLiquidRefluxAndRatioSpecificationAreMutuallyExclusive() {
+    ColumnSpecification refluxRatio = new ColumnSpecification(ColumnSpecification.SpecificationType.REFLUX_RATIO,
+        ColumnSpecification.ProductLocation.TOP, 0.8);
+
+    DistillationColumn fixedFirst = new DistillationColumn("fixed-first column", 2, true, true);
+    fixedFirst.setCondenserLiquidReflux(100.0, "kg/hr");
+    IllegalArgumentException ratioException = assertThrows(IllegalArgumentException.class,
+        () -> fixedFirst.setTopSpecification(refluxRatio));
+    String ratioMessage = ratioException.getMessage();
+    assertNotNull(ratioMessage);
+    assertTrue(ratioMessage.contains("fixed liquid-reflux"));
+    assertTrue(ratioMessage.contains("reflux-ratio"));
+    assertNull(fixedFirst.getTopSpecification());
+    assertEquals(DistillationColumn.CondenserMode.LIQUID_REFLUX_SPLIT, fixedFirst.getCondenserMode());
+
+    fixedFirst.setCondenserMode(DistillationColumn.CondenserMode.PARTIAL);
+    fixedFirst.setTopSpecification(refluxRatio);
+    assertEquals(refluxRatio, fixedFirst.getTopSpecification());
+
+    DistillationColumn ratioFirst = new DistillationColumn("ratio-first column", 2, true, true);
+    ratioFirst.setCondenserRefluxRatio(0.8);
+    IllegalArgumentException fixedException = assertThrows(IllegalArgumentException.class,
+        () -> ratioFirst.setCondenserLiquidReflux(100.0, "kg/hr"));
+    String fixedMessage = fixedException.getMessage();
+    assertNotNull(fixedMessage);
+    assertTrue(fixedMessage.contains("select one condenser reflux control"));
+    assertEquals(DistillationColumn.CondenserMode.PARTIAL, ratioFirst.getCondenserMode());
+    assertNotNull(ratioFirst.getTopSpecification());
+    assertEquals(0.8, ratioFirst.getTopSpecification().getTargetValue(), 0.0);
+
+    double retainedCondenserRatio = ratioFirst.getCondenser().getRefluxRatio();
+    ColumnSpecification retainedSpecification = ratioFirst.getTopSpecification();
+    assertThrows(IllegalArgumentException.class, () -> ratioFirst.setCondenserRefluxRatio(Double.NaN));
+    assertEquals(retainedCondenserRatio, ratioFirst.getCondenser().getRefluxRatio(), 0.0);
+    assertEquals(retainedSpecification, ratioFirst.getTopSpecification());
+
+    DistillationColumn legacyConflict = new DistillationColumn("legacy conflict column", 2, true, true);
+    legacyConflict.setTopSpecification(refluxRatio);
+    legacyConflict.getCondenser().setSeparation_with_liquid_reflux(true, 100.0, "kg/hr");
+    ValidationResult validation = legacyConflict.validateSpecifications();
+    assertTrue(!validation.isValid());
+    assertTrue(validation.getErrors().stream()
+        .anyMatch(error -> error.getCategory().equals("specification.degreesOfFreedom")));
+    IllegalStateException runException = assertThrows(IllegalStateException.class,
+        () -> legacyConflict.run(UUID.randomUUID()));
+    assertNotNull(runException.getMessage());
+    assertTrue(runException.getMessage().contains("select one condenser reflux control"));
   }
 
   /**


### PR DESCRIPTION
## Problem and root cause

A condenser could retain both:

- a fixed liquid-reflux flow configured through `setCondenserLiquidReflux(...)`; and
- a top `REFLUX_RATIO` `ColumnSpecification`.

Both claim the same condenser-split degree of freedom. During `run()`, the direct specification path wrote the stored ratio, while `Condenser.run(...)` remained in fixed-flow mode. A ratio could therefore appear configured without controlling the physical reflux. The conflict affected every solver path because it existed above sequential, AUTO, MESH, and fallback dispatch.

## Regression-first baseline

Base: current `master` at `4f88b44e7cee22a6d0b534ac12a14f022382071a`.

The first commit (`57f2940`) added a deterministic two-tray regression before production code. Inspection and execution paths on that baseline exposed four missing protections:

1. fixed-flow first, then top ratio was accepted;
2. ratio first, then fixed flow was accepted;
3. a legacy/directly-mutated contradictory state validated as structurally valid;
4. the same state reached `run()` without a condenser-control preflight.

The regression covers both setter orders, preservation of the first selected control, a nearby valid transition from fixed-flow to partial-condenser ratio control, legacy/direct mutation, actionable validation and run diagnostics, and atomic rejection of an invalid ratio.

## Change

- reject both public setter orders before mutating either control;
- report `specification.degreesOfFreedom` from specification validation;
- reject legacy/directly-mutated contradictory state before feeds, flashes, or solver iteration;
- keep condenser access null-safe for legacy/deserialized models;
- construct and validate a reflux-ratio specification before changing the condenser, so invalid values cannot leave partial state;
- document the mutually exclusive controls and copy-pasteable recovery API.

No solver equation, convergence tolerance, thermodynamic flash, stream state, product calculation, serialization field, or valid configuration changes. There is no speed claim; invalid models now stop before solver work.

## Measured result

Before: all four contradictory configuration paths above were unguarded.

After:

- conflicting setter calls throw and preserve the active control;
- validation reports `specification.degreesOfFreedom`;
- the run preflight fails with the condenser-control message;
- switching explicitly to `PARTIAL` and then applying ratio control remains valid;
- a rejected `NaN` ratio preserves both the prior condenser ratio and `ColumnSpecification`.

## Validation

Current rebased head: `e4ee67d7106c5bc352fc3b2948c68d64cd948b72`. The behavioral validation below ran on pre-rebase head `6c53338e61c86c03118e9b68c8c99ceb77489177`; the rebase preserved the three file blobs and diff exactly.

Passed:

- `DistillationColumnModeTest`: 9 tests, zero failures/errors on Java 21 Ubuntu and Windows;
- all four Java 21 slow-test shards;
- Javadocs;
- Spotless format patch and pre-commit;
- CodeQL;
- documentation search coverage;
- PaperLab replication gate.

The two full fast-test jobs continued past the affected column package with no reported failure, then the workflow was externally canceled while Ubuntu was in `NorwegianOilFieldLifecycleTest` and Windows was in `AcceleratedCPASolverTest`. Java 8 downstream jobs were consequently canceled before starting. After the no-content-change rebase, PaperLab, pre-commit, Spotless, documentation coverage, CodeQL, and Javadocs passed again; the repeated Java matrix is running. This PR remains draft pending a complete fast/Java 8 matrix; the cancellation did not identify a code or column-test failure.

## Compatibility and risk

The change is backward compatible for independent controls. Previously accepted over-specified configurations now fail early with an actionable recovery message. Directly mutated or serialized contradictory state is diagnosed rather than silently choosing one control. Risk is limited to terminal specification setup; valid solver and thermodynamic behavior are unchanged.

## Copilot review disposition

Accepted and validated suggestions:

- explicit null assertions in regression diagnostics;
- null-safe legacy condenser access;
- accurate recovery guidance in validation and documentation;
- complete `@throws` contracts;
- validate the ratio before condenser mutation;
- assert the actual preflight message;
- copy-pasteable enum syntax.

Rejected suggestions:

- replacing an exact `0.8` identity assertion with a tolerance. The value is stored directly without numerical calculation; exact preservation is intentional here;
- the claim that `setCondenserRefluxRatio` persists NaN/Infinity. It constructs and validates `ColumnSpecification` before condenser mutation; the constructor rejects non-finite and negative ratios, and the NaN atomicity regression passes on both platforms.

All current inline threads are resolved. No accepted suggestion remains untested.

## Remaining limitation

This structural guard does not solve the deeper fixed-reflux terminal material/energy coupling previously observed in nonlinear column convergence. That remains a separate solver target.

## Documentation compilation follow-up

The compiled documentation regression now uses a separate column for the fixed-liquid-reflux mode. This preserves both public examples without configuring a reflux ratio and a fixed reflux flow on the same condenser.
