### PR TITLE
fix(tpflash): clear stale beta-solver stall state

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -2125,6 +2125,7 @@ public class TPmultiflash extends TPflash {
   public void run() {
     int aqueousPhaseNumber = 0;
     enhancedStabilityChecked = false;
+    betaSolveStalled = false;
     // logger.info("Starting multiphase-flash....");
 
     // For systems with ions, temporarily remove ions before stability analysis

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
@@ -223,9 +223,10 @@ class TPmultiflashTest {
     // may not predict it for all parameter combinations, but we verify no crashes
     assertTrue(threePhaseCount >= 0, "Scan completed without errors");
   }
+
   /**
-   * A reused multiflash operation must not carry a previous beta-solver stall into a pass that does not execute the beta
-   * solver. Otherwise the later active-set rescue can act on stale convergence state.
+   * A reused multiflash operation must not carry a previous beta-solver stall into a pass that does not execute the
+   * beta solver. Otherwise the later active-set rescue can act on stale convergence state.
    *
    * @throws Exception if the private lifecycle field cannot be inspected
    */

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
@@ -1,7 +1,9 @@
 package neqsim.thermodynamicoperations.flashops;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.lang.reflect.Field;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Tag;
@@ -221,4 +223,29 @@ class TPmultiflashTest {
     // may not predict it for all parameter combinations, but we verify no crashes
     assertTrue(threePhaseCount >= 0, "Scan completed without errors");
   }
+  /**
+   * A reused multiflash operation must not carry a previous beta-solver stall into a pass that does not execute the beta
+   * solver. Otherwise the later active-set rescue can act on stale convergence state.
+   *
+   * @throws Exception if the private lifecycle field cannot be inspected
+   */
+  @Test
+  void testRunClearsStaleBetaSolveStateWhenNoBetaSolveRuns() throws Exception {
+    SystemInterface singlePhase = new neqsim.thermo.system.SystemSrkEos(298.15, 50.0);
+    singlePhase.addComponent("methane", 1.0);
+    singlePhase.setMixingRule("classic");
+    singlePhase.setMultiPhaseCheck(false);
+    singlePhase.init(0);
+
+    TPmultiflash operation = new TPmultiflash(singlePhase, false);
+    Field stalledField = TPmultiflash.class.getDeclaredField("betaSolveStalled");
+    stalledField.setAccessible(true);
+    stalledField.setBoolean(operation, true);
+
+    operation.run();
+
+    assertFalse(stalledField.getBoolean(operation),
+        "A run without a beta solve must clear stall state retained by a reused operation");
+  }
+
 }


### PR DESCRIPTION
## Problem

Merged #2767 stores `betaSolveStalled` on the `TPmultiflash` operation, but only assigns it inside the `multiPhaseTest` beta-solver block. Re-entering or reusing the same operation for a pass where that block does not execute can therefore retain a previous `true` value. The later three-phase rescue reads the field unconditionally.

## Change

- reset `betaSolveStalled` at the start of every `run()`;
- add a focused reuse regression that plants a prior stall state, executes a single-phase pass without a beta solve, and requires the state to be cleared.

No flash equation, phase-selection rule, tolerance, public API, or successful beta-solver result changes.

## Validation

Hosted CI will run the focused and complete repository gates. The regression is intentionally state-lifecycle focused and fails on current master because the planted value remains true.

## Copilot disposition

This directly addresses the unresolved stale-`betaSolveStalled` thread on merged #2767. All new Copilot feedback on this PR must be assessed and validated before it is marked ready.

Documentation impact: none — this restores private per-run solver-state ownership and does not change documented thermodynamic behavior or API usage.

Follow-up to #2767.