### PR TITLE
[AI-Assisted] feat: preserve capacity evidence in throughput results

### DIFF
--- a/.github/skills/neqsim-production-optimization/SKILL.md
+++ b/.github/skills/neqsim-production-optimization/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-production-optimization
 description: "Production optimization, bottleneck analysis, decline modeling, decline-curve history matching (Arps + Duong), reservoir material balance surveillance (OGIP/OOIP, drive indices, aquifer influx), and IOR/EOR screening with NeqSim. USE WHEN: optimizing production rates, identifying facility bottlenecks, forecasting production profiles, fitting decline curves to production history, estimating reserves from pressure/production data, analyzing gas lift allocation, evaluating IOR/EOR options, or running multi-scenario production comparisons."
-last_verified: "2026-07-11"
+last_verified: "2026-08-04"
 ---
 
 # NeqSim Production Optimization Skill
@@ -533,4 +533,4 @@ Map<String, Double> breakdown = decom.getBreakdown();
 | Encoding minimum limits as design/max constraints | Safe NPSH, minimum-flow, or residence-time margins appear overloaded | Use `setMinValue(...)` without `setDesignValue(...)`; use a HARD constraint type for trip/infeasibility limits |
 | Recomputing every engineering margin as `design - current` | Minimum limits show infinite or incorrectly signed spare capacity | Use the evaluator/throughput result's `minimumConstraint` direction; feasible margins are `current - minimum` for lower limits and `maximum - current` for upper limits |
 | Dropping `dataSource` when exporting bottlenecks | Installed, calculated, and default limits become indistinguishable to Python or AI workflows | Set provenance on each `CapacityConstraint` and preserve the throughput row's `dataSource` in ranking, recommendations, and archives |
-| Treating every constraint as equally credible and universally applicable | AI or optimization recommendations can rely on a screening/default limit outside its evidence range | Set `confidence` and a validity range on `CapacityConstraint`; treat them as evidence metadata, require review when absent/out of range, and never interpret confidence as a safety probability |
+| Treating every constraint as equally credible and universally applicable | AI or optimization recommendations can rely on a screening/default limit outside its evidence range | Set `confidence` and a validity range on `CapacityConstraint`; consume the propagated `ThroughputCaseRow` presence flags, bounds, and in-range state in Java/JSON/CSV; require review when absent/out of range, and never interpret confidence as a safety probability |

--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,28 @@
 
 ---
 
+## 2026-08-04 — Capacity evidence in bottleneck and throughput results
+
+### Added
+
+`ProcessModelSimulationEvaluator.BottleneckStatus` and `ThroughputCaseRow` now snapshot the
+active constraint's confidence presence/value, scalar validity-range presence/bounds, and whether
+the evaluated current value lies inside the inclusive range. The metadata is available through
+Java getters and is retained by throughput JSON and CSV exports.
+
+### Compatibility and reporting
+
+Existing constructors remain available and represent evidence metadata as unset. Manually constructed
+snapshots normalize inconsistent enabled metadata (non-finite/out-of-range confidence or
+non-finite/reversed bounds) to the same unset state, and derive applicability from the current value
+and retained bounds. Bottleneck scans read dynamic constraint suppliers once per candidate and use
+that scalar for both utilization and applicability. JSON includes presence flags and uses `null` for
+unset confidence, bounds, and applicability. CSV includes the same flags and uses blank cells for
+unset values. Utilization, constraint direction, margins, feasibility, thermodynamics, hydraulics,
+and throughput search are unchanged.
+
+---
+
 ## 2026-08-04 — ConeFlowMeter rejects non-physical geometry (Copilot review round 11)
 
 ### Fixed
@@ -229,8 +251,8 @@ Existing constructors and serialized constraints remain compatible. Unset and le
 reported as absent and numeric getters return `NaN`. The metadata does not alter utilization,
 constraint direction, margins, violation status, feasibility, or optimizer search. Confidence is
 an evidence-quality score, not a probability of safety or constraint satisfaction. This release
-does not yet propagate confidence or validity into throughput case rows or implement a
-multidimensional operating envelope.
+propagates confidence and validity into throughput case rows as of 2026-08-04, but does not
+implement a multidimensional operating envelope.
 ## 2026-08-03 — TwoFluidPipe phase-resolved flash transfer
 
 ### Corrected

--- a/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
+++ b/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
@@ -93,8 +93,16 @@ constructed with `setMinValue(...)` only. Each row also carries `dataSource`, co
 underlying `CapacityConstraint`, so Python and external optimizers can distinguish an installed
 data-sheet limit from mechanical-design output, an operating envelope, or an untagged `not_set`
 limit. Preserve this provenance in ranked recommendations and result archives.
-`utilizationMargin` remains `1 - utilization` for both
-directions.
+
+Evidence metadata is also snapshotted from the active `CapacityConstraint`. Java rows expose
+`hasConfidence()`, `getConfidence()`, `hasValidityRange()`, `getValidityMinimum()`,
+`getValidityMaximum()`, and `isCurrentValueWithinValidityRange()`. JSON represents unset
+numeric and applicability values as `null`; CSV includes the presence flags and leaves unset
+value cells blank. External and AI optimizers should preserve these diagnostics, require
+engineering review for missing or out-of-range evidence, and must not treat confidence as a
+probability of safety. The fields do not change feasibility or ranking automatically.
+
+`utilizationMargin` remains `1 - utilization` for both directions.
 
 ## Key Concepts
 

--- a/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
+++ b/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
@@ -284,6 +284,20 @@ and use the constraint's own unit. An unset confidence or range remains explicit
 through `hasConfidence()` and `hasValidityRange()`; the numeric getters return `NaN` when unset.
 Invalid scores, non-finite bounds, and reversed ranges fail fast.
 
+When the constraint becomes the active full-model bottleneck,
+`ProcessModelSimulationEvaluator.BottleneckStatus` and `ThroughputCaseRow` preserve the same
+confidence, validity bounds, and snapshotted in-range result. Java callers can use
+`hasConfidence()`, `getConfidence()`, `hasValidityRange()`, `getValidityMinimum()`,
+`getValidityMaximum()`, and `isCurrentValueWithinValidityRange()`. JSON rows include the
+`hasConfidence` and `hasValidityRange` flags; unset numeric or applicability values are
+`null`. CSV traces include the same flags and leave unset confidence, bounds, and applicability
+cells blank. Public snapshot constructors also normalize inconsistent enabled metadata (non-finite
+confidence or bounds, confidence outside [0, 1], or reversed bounds) to this unset state.
+Applicability is derived from each snapshot's current value and retained bounds rather than accepted
+as caller-provided state. Dynamic value suppliers are read once per bottleneck candidate, and that
+same scalar is used for utilization and applicability. This prevents legacy, malformed, or unqualified limits from being mistaken
+for zero-confidence or out-of-range evidence.
+
 This first validity contract is deliberately scalar. Compressor maps and other models whose
 applicability depends on several variables still require a separate multidimensional operating
 envelope. Confidence and validity metadata do not change utilization, feasibility, or optimizer

--- a/docs/process/optimization/OPTIMIZATION_OVERVIEW.md
+++ b/docs/process/optimization/OPTIMIZATION_OVERVIEW.md
@@ -267,6 +267,12 @@ ThroughputCaseRow firstLimit = result.getFirstInfeasibleCase();
 result.exportToCSV("throughput_trace.csv");
 ```
 
+Active bottleneck rows preserve limit provenance, evidence-quality confidence, the inclusive
+scalar validity range, and whether the snapshotted current load is inside that range. Check
+`hasConfidence()` and `hasValidityRange()` before reading numeric metadata. JSON uses `null`
+for unset values; CSV retains explicit presence flags and blank unset-value cells. These fields are
+diagnostics only and do not change feasibility or throughput search.
+
 The installed-capacity table uses one row per equipment limit:
 
 ```text

--- a/src/main/java/neqsim/process/equipment/capacity/CapacityConstraint.java
+++ b/src/main/java/neqsim/process/equipment/capacity/CapacityConstraint.java
@@ -382,18 +382,31 @@ public class CapacityConstraint implements Serializable {
    * @return utilization as fraction (1.0 = 100% of design)
    */
   public double getUtilization() {
-    double current = getCurrentValue();
+    return getUtilization(getCurrentValue());
+  }
+
+  /**
+   * Gets utilization for an explicitly snapshotted current value without invoking the configured value supplier.
+   *
+   * <p>
+   * This overload is useful when a caller must report the same scalar value used to calculate utilization.
+   * </p>
+   *
+   * @param currentValue snapshotted current constraint value
+   * @return utilization as fraction (1.0 = 100% of design)
+   */
+  public double getUtilization(double currentValue) {
     if (minValue > 0 && designValue == Double.MAX_VALUE) {
       // This is a minimum constraint (e.g., residence time)
-      if (current <= 0) {
+      if (currentValue <= 0) {
         return MAX_UTILIZATION;
       }
-      return Math.min(minValue / current, MAX_UTILIZATION);
+      return Math.min(minValue / currentValue, MAX_UTILIZATION);
     }
     if (designValue <= 0 || designValue == Double.MAX_VALUE) {
       return 0.0;
     }
-    return Math.min(current / designValue, MAX_UTILIZATION);
+    return Math.min(currentValue / designValue, MAX_UTILIZATION);
   }
 
   /**

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
@@ -879,6 +879,24 @@ public class ProcessModelSimulationEvaluator implements Serializable {
     /** Provenance of the active constraint limit. */
     private String dataSource = "not_set";
 
+    /** Whether confidence was explicitly assigned to the active constraint. */
+    private boolean confidenceSet;
+
+    /** Evidence-quality confidence of the active constraint. */
+    private double confidence = Double.NaN;
+
+    /** Whether a scalar validity range was assigned to the active constraint. */
+    private boolean validityRangeSet;
+
+    /** Lower inclusive validity bound in the constraint unit. */
+    private double validityMinimum = Double.NaN;
+
+    /** Upper inclusive validity bound in the constraint unit. */
+    private double validityMaximum = Double.NaN;
+
+    /** Whether the snapshotted current value lies inside the assigned validity range. */
+    private boolean currentValueWithinValidityRange;
+
     /** Constraint unit. */
     private String unit;
 
@@ -943,6 +961,35 @@ public class ProcessModelSimulationEvaluator implements Serializable {
     public BottleneckStatus(String areaName, String equipmentName, String constraintName, double utilization,
         double currentValue, double designValue, boolean minimumConstraint, String dataSource, String unit,
         boolean feasible) {
+      this(areaName, equipmentName, constraintName, utilization, currentValue, designValue, minimumConstraint,
+          dataSource, false, Double.NaN, false, Double.NaN, Double.NaN, unit, feasible);
+    }
+
+    /**
+     * Creates a bottleneck status with evidence-quality and scalar-validity metadata. Enabled metadata that is
+     * non-finite, outside the confidence range, or has reversed bounds is normalized to the explicit unset state.
+     * Applicability is derived from the snapshotted current value and retained bounds.
+     *
+     * @param areaName process area name
+     * @param equipmentName equipment name
+     * @param constraintName constraint name
+     * @param utilization utilization fraction
+     * @param currentValue current constraint value
+     * @param designValue reported design or minimum limit
+     * @param minimumConstraint true when values below the limit are worse
+     * @param dataSource provenance of the reported limit
+     * @param confidenceSet true to retain a finite confidence in the range [0, 1]
+     * @param confidence evidence-quality confidence, or NaN when unset
+     * @param validityRangeSet true to retain finite, ordered scalar validity bounds
+     * @param validityMinimum lower inclusive validity bound, or NaN when unset
+     * @param validityMaximum upper inclusive validity bound, or NaN when unset
+     * @param unit constraint unit
+     * @param feasible true when utilization is less than or equal to one
+     */
+    public BottleneckStatus(String areaName, String equipmentName, String constraintName, double utilization,
+        double currentValue, double designValue, boolean minimumConstraint, String dataSource, boolean confidenceSet,
+        double confidence, boolean validityRangeSet, double validityMinimum, double validityMaximum, String unit,
+        boolean feasible) {
       this.areaName = areaName;
       this.equipmentName = equipmentName;
       this.constraintName = constraintName;
@@ -951,6 +998,16 @@ public class ProcessModelSimulationEvaluator implements Serializable {
       this.designValue = designValue;
       this.minimumConstraint = minimumConstraint;
       this.dataSource = dataSource == null ? "not_set" : dataSource;
+      this.confidenceSet = confidenceSet && !Double.isNaN(confidence) && !Double.isInfinite(confidence)
+          && confidence >= 0.0 && confidence <= 1.0;
+      this.confidence = this.confidenceSet ? confidence : Double.NaN;
+      this.validityRangeSet = validityRangeSet && !Double.isNaN(validityMinimum) && !Double.isInfinite(validityMinimum)
+          && !Double.isNaN(validityMaximum) && !Double.isInfinite(validityMaximum)
+          && validityMinimum <= validityMaximum;
+      this.validityMinimum = this.validityRangeSet ? validityMinimum : Double.NaN;
+      this.validityMaximum = this.validityRangeSet ? validityMaximum : Double.NaN;
+      this.currentValueWithinValidityRange = this.validityRangeSet && currentValue >= this.validityMinimum
+          && currentValue <= this.validityMaximum;
       this.unit = unit;
       this.feasible = feasible;
     }
@@ -1046,6 +1103,60 @@ public class ProcessModelSimulationEvaluator implements Serializable {
      */
     public String getDataSource() {
       return dataSource == null ? "not_set" : dataSource;
+    }
+
+    /**
+     * Checks whether confidence was explicitly assigned to the active constraint.
+     *
+     * @return true when confidence is available
+     */
+    public boolean hasConfidence() {
+      return confidenceSet;
+    }
+
+    /**
+     * Gets the active constraint's evidence-quality confidence.
+     *
+     * @return confidence from zero to one, or NaN when unset
+     */
+    public double getConfidence() {
+      return confidenceSet ? confidence : Double.NaN;
+    }
+
+    /**
+     * Checks whether a scalar validity range was assigned to the active constraint.
+     *
+     * @return true when validity bounds are available
+     */
+    public boolean hasValidityRange() {
+      return validityRangeSet;
+    }
+
+    /**
+     * Gets the lower inclusive validity bound.
+     *
+     * @return lower bound in the constraint unit, or NaN when unset
+     */
+    public double getValidityMinimum() {
+      return validityRangeSet ? validityMinimum : Double.NaN;
+    }
+
+    /**
+     * Gets the upper inclusive validity bound.
+     *
+     * @return upper bound in the constraint unit, or NaN when unset
+     */
+    public double getValidityMaximum() {
+      return validityRangeSet ? validityMaximum : Double.NaN;
+    }
+
+    /**
+     * Checks whether the snapshotted current value is inside the assigned validity range.
+     *
+     * @return true when a range is assigned and the current value is inside its inclusive bounds
+     */
+    public boolean isCurrentValueWithinValidityRange() {
+      return validityRangeSet && currentValueWithinValidityRange;
     }
 
     /**
@@ -1919,13 +2030,16 @@ public class ProcessModelSimulationEvaluator implements Serializable {
           if (capacityConstraint == null || !capacityConstraint.isEnabled()) {
             continue;
           }
-          double utilization = capacityConstraint.getUtilization();
+          double currentValue = capacityConstraint.getCurrentValue();
+          double utilization = capacityConstraint.getUtilization(currentValue);
           if (!Double.isNaN(utilization) && utilization > highestUtilization) {
             highestUtilization = utilization;
-            active = new BottleneckStatus(areaName, equipment.getName(), entry.getKey(), utilization,
-                capacityConstraint.getCurrentValue(), capacityConstraint.getDisplayDesignValue(),
-                capacityConstraint.isMinimumConstraint(), capacityConstraint.getDataSource(),
-                capacityConstraint.getUnit(), utilization <= 1.0);
+            boolean validityRangeSet = capacityConstraint.hasValidityRange();
+            active = new BottleneckStatus(areaName, equipment.getName(), entry.getKey(), utilization, currentValue,
+                capacityConstraint.getDisplayDesignValue(), capacityConstraint.isMinimumConstraint(),
+                capacityConstraint.getDataSource(), capacityConstraint.hasConfidence(),
+                capacityConstraint.getConfidence(), validityRangeSet, capacityConstraint.getValidityMinimum(),
+                capacityConstraint.getValidityMaximum(), capacityConstraint.getUnit(), utilization <= 1.0);
           }
         }
       }

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelThroughputResult.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelThroughputResult.java
@@ -247,7 +247,8 @@ public class ProcessModelThroughputResult implements Serializable {
    * @return JSON result string
    */
   public String toJson() {
-    return new GsonBuilder().setPrettyPrinting().serializeSpecialFloatingPointValues().create().toJson(toMap());
+    return new GsonBuilder().setPrettyPrinting().serializeNulls().serializeSpecialFloatingPointValues().create()
+        .toJson(toMap());
   }
 
   /**
@@ -271,8 +272,9 @@ public class ProcessModelThroughputResult implements Serializable {
     try {
       writer.write("caseNumber,throughputMultiplier,objectiveValue,feasible,"
           + "simulationConverged,activeArea,activeEquipment,activeConstraint,"
-          + "utilization,currentValue,designValue,minimumConstraint,dataSource,capacityMargin,utilizationMargin,unit,"
-          + "errorMessage,evaluationTimeMs");
+          + "utilization,currentValue,designValue,minimumConstraint,dataSource,hasConfidence,confidence,"
+          + "hasValidityRange,validityMinimum,validityMaximum,currentValueWithinValidityRange,"
+          + "capacityMargin,utilizationMargin,unit,errorMessage,evaluationTimeMs");
       writer.newLine();
       for (ThroughputCaseRow row : caseRows) {
         writer.write(Integer.toString(row.getCaseNumber()));
@@ -300,6 +302,26 @@ public class ProcessModelThroughputResult implements Serializable {
         writer.write(Boolean.toString(row.isMinimumConstraint()));
         writer.write(",");
         writer.write(csvEscape(row.getDataSource()));
+        writer.write(",");
+        writer.write(Boolean.toString(row.hasConfidence()));
+        writer.write(",");
+        if (row.hasConfidence()) {
+          writer.write(Double.toString(row.getConfidence()));
+        }
+        writer.write(",");
+        writer.write(Boolean.toString(row.hasValidityRange()));
+        writer.write(",");
+        if (row.hasValidityRange()) {
+          writer.write(Double.toString(row.getValidityMinimum()));
+        }
+        writer.write(",");
+        if (row.hasValidityRange()) {
+          writer.write(Double.toString(row.getValidityMaximum()));
+        }
+        writer.write(",");
+        if (row.hasValidityRange()) {
+          writer.write(Boolean.toString(row.isCurrentValueWithinValidityRange()));
+        }
         writer.write(",");
         writer.write(Double.toString(row.getCapacityMargin()));
         writer.write(",");

--- a/src/main/java/neqsim/process/util/optimizer/ThroughputCaseRow.java
+++ b/src/main/java/neqsim/process/util/optimizer/ThroughputCaseRow.java
@@ -56,6 +56,24 @@ public class ThroughputCaseRow implements Serializable {
   /** Provenance of the active bottleneck limit. */
   private final String dataSource;
 
+  /** Whether confidence was explicitly assigned to the active bottleneck. */
+  private final boolean confidenceSet;
+
+  /** Evidence-quality confidence of the active bottleneck. */
+  private final double confidence;
+
+  /** Whether a scalar validity range was assigned to the active bottleneck. */
+  private final boolean validityRangeSet;
+
+  /** Lower inclusive validity bound in the bottleneck unit. */
+  private final double validityMinimum;
+
+  /** Upper inclusive validity bound in the bottleneck unit. */
+  private final double validityMaximum;
+
+  /** Whether the snapshotted current value lies inside the validity range. */
+  private final boolean currentValueWithinValidityRange;
+
   /** Remaining capacity in engineering units. */
   private final double capacityMargin;
 
@@ -160,6 +178,48 @@ public class ThroughputCaseRow implements Serializable {
       String activeConstraint, double utilization, double currentValue, double designValue, boolean minimumConstraint,
       String dataSource, double capacityMargin, double utilizationMargin, String unit, String errorMessage,
       long evaluationTimeMs) {
+    this(caseNumber, throughputMultiplier, producerMultipliers, objectiveValue, feasible, simulationConverged,
+        activeArea, activeEquipment, activeConstraint, utilization, currentValue, designValue, minimumConstraint,
+        dataSource, false, Double.NaN, false, Double.NaN, Double.NaN, capacityMargin, utilizationMargin, unit,
+        errorMessage, evaluationTimeMs);
+  }
+
+  /**
+   * Creates a throughput case row with capacity evidence-quality and scalar-validity metadata. Enabled metadata that is
+   * non-finite, outside the confidence range, or has reversed bounds is normalized to the explicit unset state.
+   * Applicability is derived from the snapshotted current value and retained bounds.
+   *
+   * @param caseNumber case sequence number
+   * @param throughputMultiplier scalar throughput multiplier
+   * @param producerMultipliers producer multipliers used in the case
+   * @param objectiveValue raw objective value
+   * @param feasible true when all hard constraints are satisfied
+   * @param simulationConverged true when the model converged
+   * @param activeArea active bottleneck area name
+   * @param activeEquipment active bottleneck equipment name
+   * @param activeConstraint active bottleneck constraint name
+   * @param utilization active bottleneck utilization
+   * @param currentValue current bottleneck load
+   * @param designValue bottleneck design or minimum limit
+   * @param minimumConstraint true when values below the limit are worse
+   * @param dataSource provenance of the bottleneck limit
+   * @param confidenceSet true to retain a finite confidence in the range [0, 1]
+   * @param confidence evidence-quality confidence, or NaN when unset
+   * @param validityRangeSet true to retain finite, ordered scalar validity bounds
+   * @param validityMinimum lower inclusive validity bound, or NaN when unset
+   * @param validityMaximum upper inclusive validity bound, or NaN when unset
+   * @param capacityMargin signed remaining capacity in engineering units
+   * @param utilizationMargin remaining utilization margin
+   * @param unit bottleneck unit
+   * @param errorMessage error message if the case failed
+   * @param evaluationTimeMs evaluation wall-clock time in milliseconds
+   */
+  public ThroughputCaseRow(int caseNumber, double throughputMultiplier, Map<String, Double> producerMultipliers,
+      double objectiveValue, boolean feasible, boolean simulationConverged, String activeArea, String activeEquipment,
+      String activeConstraint, double utilization, double currentValue, double designValue, boolean minimumConstraint,
+      String dataSource, boolean confidenceSet, double confidence, boolean validityRangeSet, double validityMinimum,
+      double validityMaximum, double capacityMargin, double utilizationMargin, String unit, String errorMessage,
+      long evaluationTimeMs) {
     this.caseNumber = caseNumber;
     this.throughputMultiplier = throughputMultiplier;
     this.producerMultipliers = new LinkedHashMap<String, Double>(producerMultipliers);
@@ -174,6 +234,15 @@ public class ThroughputCaseRow implements Serializable {
     this.designValue = designValue;
     this.minimumConstraint = minimumConstraint;
     this.dataSource = dataSource == null ? "not_set" : dataSource;
+    this.confidenceSet = confidenceSet && !Double.isNaN(confidence) && !Double.isInfinite(confidence)
+        && confidence >= 0.0 && confidence <= 1.0;
+    this.confidence = this.confidenceSet ? confidence : Double.NaN;
+    this.validityRangeSet = validityRangeSet && !Double.isNaN(validityMinimum) && !Double.isInfinite(validityMinimum)
+        && !Double.isNaN(validityMaximum) && !Double.isInfinite(validityMaximum) && validityMinimum <= validityMaximum;
+    this.validityMinimum = this.validityRangeSet ? validityMinimum : Double.NaN;
+    this.validityMaximum = this.validityRangeSet ? validityMaximum : Double.NaN;
+    this.currentValueWithinValidityRange = this.validityRangeSet && currentValue >= this.validityMinimum
+        && currentValue <= this.validityMaximum;
     this.capacityMargin = capacityMargin;
     this.utilizationMargin = utilizationMargin;
     this.unit = unit;
@@ -205,8 +274,9 @@ public class ThroughputCaseRow implements Serializable {
     return new ThroughputCaseRow(caseNumber, throughputMultiplier, producerMultipliers, objectiveValue,
         evaluation.isFeasible(), evaluation.isSimulationConverged(), bottleneck.getAreaName(),
         bottleneck.getEquipmentName(), bottleneck.getConstraintName(), utilization, currentValue, designValue,
-        minimumConstraint, bottleneck.getDataSource(), capacityMargin, 1.0 - utilization, bottleneck.getUnit(),
-        evaluation.getErrorMessage(), evaluation.getEvaluationTimeMs());
+        minimumConstraint, bottleneck.getDataSource(), bottleneck.hasConfidence(), bottleneck.getConfidence(),
+        bottleneck.hasValidityRange(), bottleneck.getValidityMinimum(), bottleneck.getValidityMaximum(), capacityMargin,
+        1.0 - utilization, bottleneck.getUnit(), evaluation.getErrorMessage(), evaluation.getEvaluationTimeMs());
   }
 
   /**
@@ -336,6 +406,60 @@ public class ThroughputCaseRow implements Serializable {
   }
 
   /**
+   * Checks whether confidence was explicitly assigned to the active bottleneck.
+   *
+   * @return true when confidence is available
+   */
+  public boolean hasConfidence() {
+    return confidenceSet;
+  }
+
+  /**
+   * Gets evidence-quality confidence for the active bottleneck.
+   *
+   * @return confidence from zero to one, or NaN when unset
+   */
+  public double getConfidence() {
+    return confidenceSet ? confidence : Double.NaN;
+  }
+
+  /**
+   * Checks whether a scalar validity range was assigned to the active bottleneck.
+   *
+   * @return true when validity bounds are available
+   */
+  public boolean hasValidityRange() {
+    return validityRangeSet;
+  }
+
+  /**
+   * Gets the lower inclusive validity bound.
+   *
+   * @return lower bound in the bottleneck unit, or NaN when unset
+   */
+  public double getValidityMinimum() {
+    return validityRangeSet ? validityMinimum : Double.NaN;
+  }
+
+  /**
+   * Gets the upper inclusive validity bound.
+   *
+   * @return upper bound in the bottleneck unit, or NaN when unset
+   */
+  public double getValidityMaximum() {
+    return validityRangeSet ? validityMaximum : Double.NaN;
+  }
+
+  /**
+   * Checks whether the snapshotted current value is inside the assigned validity range.
+   *
+   * @return true when a range is assigned and the current value is inside its inclusive bounds
+   */
+  public boolean isCurrentValueWithinValidityRange() {
+    return validityRangeSet && currentValueWithinValidityRange;
+  }
+
+  /**
    * Gets remaining capacity.
    *
    * @return remaining capacity in engineering units
@@ -401,6 +525,13 @@ public class ThroughputCaseRow implements Serializable {
     map.put("designValue", designValue);
     map.put("minimumConstraint", minimumConstraint);
     map.put("dataSource", getDataSource());
+    map.put("hasConfidence", hasConfidence());
+    map.put("confidence", hasConfidence() ? Double.valueOf(getConfidence()) : null);
+    map.put("hasValidityRange", hasValidityRange());
+    map.put("validityMinimum", hasValidityRange() ? Double.valueOf(getValidityMinimum()) : null);
+    map.put("validityMaximum", hasValidityRange() ? Double.valueOf(getValidityMaximum()) : null);
+    map.put("currentValueWithinValidityRange",
+        hasValidityRange() ? Boolean.valueOf(isCurrentValueWithinValidityRange()) : null);
     map.put("capacityMargin", capacityMargin);
     map.put("utilizationMargin", utilizationMargin);
     map.put("unit", unit);

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.DoubleSupplier;
 import java.util.function.ToDoubleFunction;
 import org.junit.jupiter.api.Test;
@@ -135,8 +136,9 @@ class ProcessModelSimulationEvaluatorTest {
   void capacityConstraintsIdentifyActiveModelBottleneck() {
     final ModelFixture fixture = createModelFixture();
     CapacityConstraint installedCapacity = new CapacityConstraint("installedGasCapacity", "kg/hr", ConstraintType.HARD)
-        .setDesignValue(5000.0).setMaxValue(12000.0).setSeverity(ConstraintSeverity.HARD)
-        .setDataSource("mechanicalDesign").setValueSupplier(new DoubleSupplier() {
+        .setDesignValue(12000.0).setMaxValue(13200.0).setSeverity(ConstraintSeverity.HARD)
+        .setDataSource("mechanicalDesign").setConfidence(0.95).setValidityRange(8000.0, 12000.0)
+        .setValueSupplier(new DoubleSupplier() {
           /** {@inheritDoc} */
           @Override
           public double getAsDouble() {
@@ -147,6 +149,7 @@ class ProcessModelSimulationEvaluatorTest {
     fixture.separator.addCapacityConstraint(installedCapacity);
 
     ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    evaluator.setIncludeStrategyCapacityConstraints(false);
     evaluator.addParameter("wells::feed.flowRate", 5000.0, 20000.0, "kg/hr")
         .addObjective("gas", new ToDoubleFunction<ProcessModel>() {
           /** {@inheritDoc} */
@@ -165,9 +168,41 @@ class ProcessModelSimulationEvaluatorTest {
     assertEquals("separation", bottleneck.getAreaName());
     assertEquals("separator", bottleneck.getEquipmentName());
     assertEquals("installedGasCapacity", bottleneck.getConstraintName());
-    assertTrue(bottleneck.getUtilization() > 1.0, "bottleneck should be over capacity");
+    assertEquals(13.0 / 12.0, bottleneck.getUtilization(), 1.0e-12, "metadata must not alter utilization");
     assertEquals("mechanicalDesign", bottleneck.getDataSource());
+    assertTrue(bottleneck.hasConfidence());
+    assertEquals(0.95, bottleneck.getConfidence(), 0.0);
+    assertTrue(bottleneck.hasValidityRange());
+    assertEquals(8000.0, bottleneck.getValidityMinimum(), 0.0);
+    assertEquals(12000.0, bottleneck.getValidityMaximum(), 0.0);
+    assertFalse(bottleneck.isCurrentValueWithinValidityRange());
     assertEquals("separation::separator", bottleneck.getQualifiedEquipmentName());
+  }
+
+  /** Verifies bottleneck utilization and evidence share one supplier snapshot. */
+  @Test
+  void bottleneckSnapshotInvokesValueSupplierOnce() {
+    final ModelFixture fixture = createModelFixture();
+    final AtomicInteger supplierCalls = new AtomicInteger();
+    CapacityConstraint dynamicCapacity = new CapacityConstraint("dynamicGasCapacity", "kg/hr", ConstraintType.HARD)
+        .setDesignValue(12000.0).setValidityRange(8000.0, 12000.0).setValueSupplier(new DoubleSupplier() {
+          /** {@inheritDoc} */
+          @Override
+          public double getAsDouble() {
+            return supplierCalls.incrementAndGet() == 1 ? 13000.0 : 9000.0;
+          }
+        });
+    fixture.separator.clearCapacityConstraints();
+    fixture.separator.addCapacityConstraint(dynamicCapacity);
+
+    ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    evaluator.setIncludeStrategyCapacityConstraints(false);
+    ProcessModelSimulationEvaluator.BottleneckStatus bottleneck = evaluator.findActiveBottleneck(fixture.model);
+
+    assertEquals(1, supplierCalls.get());
+    assertEquals(13000.0, bottleneck.getCurrentValue(), 0.0);
+    assertEquals(13.0 / 12.0, bottleneck.getUtilization(), 1.0e-12);
+    assertFalse(bottleneck.isCurrentValueWithinValidityRange());
   }
 
   /**
@@ -200,6 +235,34 @@ class ProcessModelSimulationEvaluatorTest {
     assertEquals(50.0, bottleneck.getCurrentValue(), 1.0e-12);
     assertEquals(45.0, bottleneck.getDesignValue(), 1.0e-12, "minimum limit must not be reported as Double.MAX_VALUE");
     assertTrue(bottleneck.isMinimumConstraint());
+  }
+
+  /**
+   * Verifies malformed manually constructed bottleneck evidence cannot leak non-finite output.
+   */
+  @Test
+  void bottleneckStatusNormalizesMalformedEvidenceToUnset() {
+    ProcessModelSimulationEvaluator.BottleneckStatus bottleneck = new ProcessModelSimulationEvaluator.BottleneckStatus(
+        "separation", "separator", "installedGasCapacity", 1.0, 12000.0, 12000.0, false, "manual", true,
+        Double.POSITIVE_INFINITY, true, 12000.0, 8000.0, "kg/hr", true);
+
+    assertFalse(bottleneck.hasConfidence());
+    assertTrue(Double.isNaN(bottleneck.getConfidence()));
+    assertFalse(bottleneck.hasValidityRange());
+    assertTrue(Double.isNaN(bottleneck.getValidityMinimum()));
+    assertTrue(Double.isNaN(bottleneck.getValidityMaximum()));
+    assertFalse(bottleneck.isCurrentValueWithinValidityRange());
+  }
+
+  /** Verifies applicability is derived rather than accepted as contradictory external input. */
+  @Test
+  void bottleneckStatusDerivesValidityApplicabilityFromSnapshot() {
+    ProcessModelSimulationEvaluator.BottleneckStatus bottleneck = new ProcessModelSimulationEvaluator.BottleneckStatus(
+        "separation", "separator", "installedGasCapacity", 13.0 / 12.0, 13000.0, 12000.0, false, "manual", true, 0.95,
+        true, 8000.0, 12000.0, "kg/hr", false);
+
+    assertTrue(bottleneck.hasValidityRange());
+    assertFalse(bottleneck.isCurrentValueWithinValidityRange());
   }
 
   /**

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelThroughputOptimizerTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelThroughputOptimizerTest.java
@@ -1,6 +1,7 @@
 package neqsim.process.util.optimizer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
@@ -115,6 +116,7 @@ class ProcessModelThroughputOptimizerTest {
   private void addSeparatorCapacity(final ModelFixture fixture, double designValue) {
     CapacityConstraint installedCapacity = new CapacityConstraint("installedGasCapacity", "kg/hr", ConstraintType.HARD)
         .setDesignValue(designValue).setMaxValue(designValue * 1.1).setSeverity(ConstraintSeverity.HARD)
+        .setDataSource("installedDataSheet").setConfidence(0.95).setValidityRange(8000.0, designValue)
         .setValueSupplier(new DoubleSupplier() {
           /** {@inheritDoc} */
           @Override
@@ -181,7 +183,18 @@ class ProcessModelThroughputOptimizerTest {
     assertEquals("separation", result.getFirstInfeasibleCase().getActiveArea());
     assertEquals("separator", result.getFirstInfeasibleCase().getActiveEquipment());
     assertEquals("installedGasCapacity", result.getFirstInfeasibleCase().getActiveConstraint());
-    assertTrue(result.toJson().contains("caseRows"));
+    ThroughputCaseRow best = result.getBestFeasibleCase();
+    ThroughputCaseRow firstInfeasible = result.getFirstInfeasibleCase();
+    assertEquals("installedDataSheet", best.getDataSource());
+    assertTrue(best.hasConfidence());
+    assertEquals(0.95, best.getConfidence(), 0.0);
+    assertTrue(best.hasValidityRange());
+    assertEquals(8000.0, best.getValidityMinimum(), 0.0);
+    assertEquals(15000.0, best.getValidityMaximum(), 0.0);
+    assertTrue(best.isCurrentValueWithinValidityRange());
+    assertFalse(firstInfeasible.isCurrentValueWithinValidityRange());
+    assertTrue(result.toJson().contains("\"confidence\": 0.95"));
+    assertTrue(result.toJson().contains("\"currentValueWithinValidityRange\": false"));
   }
 
   /**
@@ -208,7 +221,13 @@ class ProcessModelThroughputOptimizerTest {
     assertEquals(1, records.size());
     assertTrue(fixture.separator.getCapacityConstraints().containsKey("installedGasCapacity"));
     assertEquals(1.5, result.getOptimalMultiplier(), 0.02);
-    assertTrue(new String(Files.readAllBytes(caseTable), StandardCharsets.UTF_8).contains("activeConstraint"));
+    String csv = new String(Files.readAllBytes(caseTable), StandardCharsets.UTF_8);
+    assertTrue(csv.contains("hasConfidence,confidence,hasValidityRange,validityMinimum,validityMaximum,"
+        + "currentValueWithinValidityRange"));
+    assertTrue(result.toJson().contains("\"hasConfidence\": false"));
+    assertTrue(result.toJson().contains("\"confidence\": null"));
+    assertFalse(result.getBestFeasibleCase().hasConfidence());
+    assertTrue(Double.isNaN(result.getBestFeasibleCase().getConfidence()));
   }
 
   /**
@@ -245,6 +264,39 @@ class ProcessModelThroughputOptimizerTest {
     assertTrue(csv.contains("operatingEnvelope"));
     assertTrue(result.toJson().contains("\"minimumConstraint\": true"));
     assertTrue(result.toJson().contains("\"dataSource\": \"operatingEnvelope\""));
+  }
+
+  /**
+   * Verifies malformed manually constructed row evidence cannot leak non-finite JSON or CSV output.
+   */
+  @Test
+  void throughputRowNormalizesMalformedEvidenceToUnset() {
+    ThroughputCaseRow row = new ThroughputCaseRow(1, 1.0, new java.util.LinkedHashMap<String, Double>(), 10000.0, true,
+        true, "separation", "separator", "installedGasCapacity", 1.0, 12000.0, 12000.0, false, "manual", true,
+        Double.NaN, true, 8000.0, Double.POSITIVE_INFINITY, 0.0, 0.0, "kg/hr", null, 0L);
+
+    assertFalse(row.hasConfidence());
+    assertTrue(Double.isNaN(row.getConfidence()));
+    assertFalse(row.hasValidityRange());
+    assertTrue(Double.isNaN(row.getValidityMinimum()));
+    assertTrue(Double.isNaN(row.getValidityMaximum()));
+    assertFalse(row.isCurrentValueWithinValidityRange());
+    assertTrue(row.toMap().get("confidence") == null);
+    assertTrue(row.toMap().get("validityMinimum") == null);
+    assertTrue(row.toMap().get("validityMaximum") == null);
+    assertTrue(row.toMap().get("currentValueWithinValidityRange") == null);
+  }
+
+  /** Verifies row applicability is derived from the row's current value and retained bounds. */
+  @Test
+  void throughputRowDerivesValidityApplicabilityFromSnapshot() {
+    ThroughputCaseRow row = new ThroughputCaseRow(1, 1.0, new java.util.LinkedHashMap<String, Double>(), 10000.0, true,
+        true, "separation", "separator", "installedGasCapacity", 10.0 / 12.0, 10000.0, 12000.0, false, "manual", true,
+        0.95, true, 8000.0, 12000.0, 2000.0, 2.0 / 12.0, "kg/hr", null, 0L);
+
+    assertTrue(row.hasValidityRange());
+    assertTrue(row.isCurrentValueWithinValidityRange());
+    assertEquals(Boolean.TRUE, row.toMap().get("currentValueWithinValidityRange"));
   }
 
   /**


### PR DESCRIPTION
## Engineering question

Can the confidence and scalar validity metadata introduced on `CapacityConstraint` be preserved through full-model bottleneck snapshots and throughput JSON/CSV results, so Python and AI workflows can distinguish supported, unsupported, and out-of-range limits without changing production feasibility or ranking?

## Reproducible baseline

Inspected current `master` at `13a6f31ee4ce3d5394291edc2179ffb6993eb130`.

At baseline:

- `CapacityConstraint` exposes confidence and validity metadata.
- `ProcessModelSimulationEvaluator.BottleneckStatus` preserves only direction and `dataSource`.
- `ThroughputCaseRow` and `ProcessModelThroughputResult` silently drop confidence, validity bounds, and applicability.
- No open PR or issue overlaps this bounded propagation change.
- Prior program PR #2786 was merged as `23afb0d`; this PR implements its recorded dependency-ready next step.

## Bounded change

- Snapshot confidence presence/value, validity-range presence/bounds, and current-value applicability in `BottleneckStatus`.
- Read each dynamic capacity supplier once per candidate and use that scalar for utilization and evidence reporting.
- Preserve the snapshot in `ThroughputCaseRow`.
- Export explicit presence flags plus values in JSON and CSV.
- Represent unset JSON values as `null` and unset CSV values as blank cells; do not serialize unset `NaN` values.
- Preserve all existing constructors and legacy unset behavior.
- Add focused real-process evaluator and throughput-search regressions.
- Update the capacity guide, optimizer overview, external-optimizer guide, changelog, and production-optimization skill.

## Acceptance and measured result

A real two-area SRK process evaluates an installed separator gas-capacity limit at 13,000 kg/h:

| Result | Value |
|---|---:|
| Design limit | 12,000 kg/h |
| Utilization | 1.0833333333333333 |
| Feasible | false |
| Data source | installedDataSheet / mechanicalDesign |
| Confidence | 0.95 |
| Validity range | 8,000–12,000 kg/h |
| Current value in range | false |

The same throughput search retains in-range metadata for the best feasible case and out-of-range metadata for the first infeasible case. Legacy/unset rows report `hasConfidence=false`, `hasValidityRange=false`, JSON `null` values, and blank CSV value cells. Malformed enabled metadata is normalized to unset, and applicability is derived from each snapshot's current value and retained bounds so contradictory caller state cannot be exported.

No utilization, constraint margin, feasibility, thermodynamic, hydraulic, equipment-sizing, or search calculation changed.

## Validation

Local environment:

- OpenJDK Runtime 17.0.19
- Python 3.12.13 (version recorded; no Python execution required)
- Node.js 24.14.0 / npm 11.9.0 / java-parser 3.0.1
- Java source compatibility target: Java 8
- Exact five modified Java source/test files parsed with `java-parser`: **pass**
- Java 8 source-mode throughput-row regression: **pass**
- Java 8 source-mode CSV set/unset regression: **pass**
- Java 8 source-mode single-supplier-read regression: **pass**
- Hosted pre-commit, Spotless, skills lint, and PaperLab: **pass**
- Copilot latest review: **approved**, 11/11 files, no unresolved threads
- Hosted Java 21 Javadocs: **pass**
- Hosted broader Java 21 tests, documentation coverage, and CodeQL: **in progress**
- Measured utilization: `1.0833333333333333`
- Confidence: `0.95`
- Validity: `8000.0..12000.0`
- Applicability at 13,000 kg/h: `false`
- Connector compare: 10 intended files; branch 0 commits behind master

Exact local commands:

```text
node validation/parse.mjs <five modified Java source/test files>
java --source 8 validation/RuntimeCapacityEvidenceRegression.java
java --source 8 validation/RuntimeCapacityCsvRegression.java
```

This runtime does not provide `javac`, Maven, or the repository dependency cache. Hosted Spotless artifacts were applied verbatim after implementation and review hardening; local parsing and both Java 8 runtime regressions passed after the final behavioral update. Hosted Javadocs, static analysis, and the full JUnit/regression matrix remain authoritative; no gate is weakened.

## Engineering basis and scope

- NASA-STD-7009B and the February 3, 2026 NASA-HDBK-7009B companion guidance emphasize reporting model credibility, uncertainty, caveats, and violations of limits of operation with simulation results.
- Petroleum Experts GAP publicly documents integrated production/injection models, constraint-honoring optimization, safe flowing envelopes, and physical models across wells, pipelines, chokes, compressors, and surface equipment.
- SLB PIPESIM publicly documents bottleneck identification, multiple facility and asset-integrity constraints, upgrade-benefit evaluation, and full-field deliverability.

These sources support retaining qualifying evidence with optimization results. The exact Java/JSON/CSV schema is a NeqSim implementation inference. No proprietary algorithm, data, confidence taxonomy, or implementation is copied, and no parity claim is made.

Sources:

- https://standards.nasa.gov/sites/default/files/standards/NASA/B/1/NASA-STD-7009B-Final-3-5-2024.pdf
- https://standards.nasa.gov/system/files/tmp/NASA-HDBK-7009B_Final%2002-03-2026.pdf
- https://www.petex.com/pe-engineering/ipm-suite/gap/
- https://www.slb.com/products-and-services/delivering-digital-at-scale/software/pipesim-steady-state-multiphase-flow-simulator/pipesim-network-simulation-optimization

## Compatibility, performance, and risk

- Source compatibility: existing constructors remain; new constructor/getters are additive.
- Serialization: unchanged `serialVersionUID`; legacy fields default to unset flags and getters return `NaN`.
- Evidence integrity: non-finite/out-of-domain constructor metadata is normalized to unset; applicability is always derived from current value and retained bounds.
- Python: additive getters and JSON/CSV fields are available through JPype/files.
- Determinism: applicability is calculated from the same snapshotted current scalar value stored in the result.
- Runtime: constant-size primitive metadata and map/CSV writes only; no extra simulation, and one fewer dynamic-supplier invocation per active-bottleneck candidate.
- Ranking/feasibility: unchanged; consumers must interpret evidence explicitly.
- Excluded: confidence-based ranking, uncertainty derivation, multidimensional compressor-map validity envelopes, and notebook changes.

## Documentation impact

Updated:

- `docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md`
- `docs/process/optimization/OPTIMIZATION_OVERVIEW.md`
- `docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md`
- `CHANGELOG_AGENT_NOTES.md`
- `.github/skills/neqsim-production-optimization/SKILL.md`

No notebook changed; notebook execution/rendering impact: none.

## Persistent loop history — 2026-08-04 08:05 Europe/Oslo

- Inspected master: `13a6f31ee4ce3d5394291edc2179ffb6993eb130`.
- Prior PR #2786: merged externally as `23afb0d`; review thread resolved.
- Reviewed open PRs/issues, recent commits, current source/tests/docs, NASA-STD-7009B, NASA-HDBK-7009B (approved 2026-02-03), GAP, and PIPESIM public capability descriptions.
- Candidates: canonical Colab mechanical-sizing extension; confidence-based ranking; multidimensional validity envelope; metadata propagation. Chosen: metadata propagation because it is the recorded foundation required before ranking or AI use.
- Attempt 1: established baseline and API/output acceptance criteria on unmodified master.
- Attempt 2: implemented bottleneck, row, JSON, and CSV propagation plus focused tests.
- Attempt 3: exact modified sources parsed; Java 8 set/unset runtime regressions passed.
- Attempt 4: completed documentation-impact assessment and updated all directly affected guides, changelog, and skill.
- Attempt 5: hosted Spotless/review gates identified formatting and evidence-integrity edge cases. Applied the exact formatter artifacts, normalized malformed metadata, derived applicability from snapshot values, changed bottleneck scans to a single supplier read, added focused regressions, resolved both inline threads, and reran exact-source parsing plus all Java 8 runtime regressions successfully. Latest Copilot review approved all 11 files.
- Branch: `automation/propagate-capacity-evidence-metadata`.
- Files changed: 11.
- Next dependency-ready step after this PR: add evidence-aware diagnostics to bottleneck ranking (without using confidence as a safety probability) before any AI-assisted canonical Colab workflow.

This is an AI-assisted contribution; the engineering behavior, code, tests, and documentation were inspected and understood.

## CI repair and rebase — 2026-08-04 20:11 Europe/Oslo

- Reproduced the exact hosted failure evidence from run 30885354161: Windows Java 21 reported two failures in changed tests.
- Root cause 1: the installed-capacity evaluator regression left strategy-generated equipment constraints enabled, so an unrelated wells-area constraint could outrank the separator constraint. The test now disables strategy constraints and isolates the declared installed-capacity behavior.
- Root cause 2: the result map stored explicit null sentinels, but Gson omitted them because the serializer did not enable null serialization. `ProcessModelThroughputResult.toJson()` now uses `serializeNulls()`, matching the documented JSON contract and existing assertion.
- Rebased the branch onto current `master` `12f05e26d7a378537e13ccbd161482b61974c220`, preserving all concurrent flow-meter changelog entries. The PR is one commit ahead, zero behind, mergeable, and conflict-free at head `374c72aab85e3bf0d85991394c10e0c6ac54d597`.
- Local `git diff --check`: pass. A focused Maven rerun could not start locally because the available persistent Maven cache lacks `maven-enforcer-plugin:3.6.3` and this sandbox cannot reach Maven Central; this is an environment-resolution blocker, not a NeqSim test result.
- Exact-head hosted CI and a new Copilot review are pending. No acceptance criterion or test was weakened.
- Documentation impact: the existing five documentation/skill updates remain applicable; the changelog was conflict-resolved against current master. No notebook changed.
