### PR TITLE
fix(tpflash): remove trace duplicate cubic-EOS phases

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -244,6 +244,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Parameter | Value | Description |
 |-----------|-------|-------------|
 | `phaseFractionMinimumLimit` | ~1e-12 | Minimum allowed phase fraction |
+| Trace duplicate phase cleanup | `min(beta_i, beta_j) < 10 beta_min`, same `PhaseType`, and `max abs(x_i - x_j) < 1e-6` | Merge and remove an already-disappeared numerical duplicate for any EOS while conserving phase fraction. Material-fraction duplicate cleanup remains limited to CPA models to protect near-critical cubic-EOS splits. |
 | Initial SSI iterations | 3 | Preliminary iterations before stability check |
 | `accelerateInterval` | 5 | Apply DEM every 5th iteration in the ordinary TPflash loop |
 | `newtonLimit` | 12 | Switch to Newton-Raphson after 12 SSI iterations when derivatives are available |
@@ -668,6 +669,10 @@ When `system.setMultiPhaseCheck(true)` is called, NeqSim uses the `TPmultiflash`
 │        IF β < 1.1 × βmin:                                                      │
 │           → removePhaseKeepTotalComposition()                                   │
 │           → hasRemovedPhase = true                                              │
+│                                                                                 │
+│  Merge trace composition duplicates for any EOS:                                │
+│     IF same PhaseType, min(βi, βj) < 10 βmin, and max |xi - xj| < 1e-6:         │
+│        → Merge βi + βj, remove the duplicate, and re-check stability             │
 │                                                                                 │
 │  Detect trivial solutions (phases with same density):                           │
 │     FOR each pair of phases (i, j):                                             │

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -2570,16 +2570,21 @@ public class TPmultiflash extends TPflash {
       // non-converged numerical duplicates. Restricting to same PhaseType
       // avoids removing legitimate near-critical V/L pairs (issue #1980).
       //
-      // Restricted to CPA-family models only (issue #2117): for non-CPA EOS
-      // (PR, SRK, UMR-PR-UMC, ...) near-critical V/L and multi-liquid systems
-      // can transiently look like duplicates during stability iteration but
-      // later separate physically (e.g. SimpleReservoirTest.testRun2 with
-      // SystemPrEos, TPFlashTest.testRun5 with SystemUMRPRUMCEos). The
-      // duplicate-phase symptom is specific to CPA association in TEG/MEG
-      // /water-rich flowsheets.
+      // CPA-family models may produce duplicate phases at material phase fractions
+      // (issue #2117). Cubic EOS can also retain an already-disappeared phase just
+      // above the generic beta-removal threshold. Extend the composition test to
+      // every model only for such trace phases; this cannot collapse a material
+      // near-critical V/L pair and still requires the same PhaseType and composition.
       String modelName = system.getModelName();
       boolean isCpaModel = modelName != null && modelName.contains("CPA");
-      if (isCpaModel) {
+      boolean hasTracePhase = false;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        if (system.getBeta(phaseIndex) < 10.0 * phaseFractionMinimumLimit) {
+          hasTracePhase = true;
+          break;
+        }
+      }
+      if (isCpaModel || hasTracePhase) {
         for (int i = 0; i < system.getNumberOfPhases() - 1; i++) {
           for (int j = i + 1; j < system.getNumberOfPhases(); j++) {
             if (system.getPhase(i).getType() != system.getPhase(j).getType()) {
@@ -2590,7 +2595,9 @@ public class TPmultiflash extends TPflash {
               maxCompDiff = Math.max(maxCompDiff,
                   Math.abs(system.getPhase(i).getComponent(k).getx() - system.getPhase(j).getComponent(k).getx()));
             }
-            if (maxCompDiff < 1.0e-6) {
+            boolean traceDuplicatePair = Math.min(system.getBeta(i), system.getBeta(j))
+                < 10.0 * phaseFractionMinimumLimit;
+            if (maxCompDiff < 1.0e-6 && (isCpaModel || traceDuplicatePair)) {
               mergeAndRemoveDuplicatePhase(i, j);
               doStabilityAnalysis = false;
               hasRemovedPhase = true;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -2595,8 +2595,8 @@ public class TPmultiflash extends TPflash {
               maxCompDiff = Math.max(maxCompDiff,
                   Math.abs(system.getPhase(i).getComponent(k).getx() - system.getPhase(j).getComponent(k).getx()));
             }
-            boolean traceDuplicatePair = Math.min(system.getBeta(i), system.getBeta(j))
-                < 10.0 * phaseFractionMinimumLimit;
+            boolean traceDuplicatePair = Math.min(system.getBeta(i), system.getBeta(j)) < 10.0
+                * phaseFractionMinimumLimit;
             if (maxCompDiff < 1.0e-6 && (isCpaModel || traceDuplicatePair)) {
               mergeAndRemoveDuplicatePhase(i, j);
               doStabilityAnalysis = false;

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashPhaseDisappearanceTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashPhaseDisappearanceTest.java
@@ -3,14 +3,19 @@ package neqsim.thermodynamicoperations.flashops;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 class TPmultiflashPhaseDisappearanceTest {
   private static final String[] COMPONENTS = { "CO2", "methane", "ethane", "water" };
   private static final double[] FEED = { 0.543865141103918, 0.2937712952303271, 0.07010605470616459,
       0.09225750895959021 };
+  private static final String[] TRACE_DUPLICATE_COMPONENTS = { "nitrogen", "CO2", "methane", "ethane", "propane",
+      "nC10", "water" };
+  private static final double[] TRACE_DUPLICATE_FEED = { 0.01, 0.05, 0.70, 0.08, 0.04, 0.02, 0.10 };
 
   @Test
   void stalledThreePhaseTrialReturnsStableTwoPhaseEndpoint() {
@@ -38,6 +43,29 @@ class TPmultiflashPhaseDisappearanceTest {
     assertFlashClosure(multiphase);
   }
 
+  @Test
+  void traceDuplicatePhaseDisappearsForCubicEos() {
+    SystemInterface ordinary = createTraceDuplicateCase(false);
+    SystemInterface multiphase = createTraceDuplicateCase(true);
+
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquals(2, multiphase.getNumberOfPhases());
+    assertTrue(ordinary.hasPhaseType(PhaseType.AQUEOUS));
+    assertTrue(multiphase.hasPhaseType(PhaseType.AQUEOUS));
+    assertFlashClosure(ordinary, TRACE_DUPLICATE_COMPONENTS, TRACE_DUPLICATE_FEED);
+    assertFlashClosure(multiphase, TRACE_DUPLICATE_COMPONENTS, TRACE_DUPLICATE_FEED);
+    assertEquivalentPhaseState(ordinary, multiphase, PhaseType.AQUEOUS, TRACE_DUPLICATE_COMPONENTS.length);
+    assertEquivalentPhaseState(ordinary, multiphase, PhaseType.OIL, TRACE_DUPLICATE_COMPONENTS.length);
+    assertEquals(multiphase.getGibbsEnergy(), ordinary.getGibbsEnergy(), 1.0e-8);
+
+    double firstGibbsEnergy = multiphase.getGibbsEnergy();
+    new ThermodynamicOperations(multiphase).TPflash();
+    multiphase.init(1);
+    assertEquals(2, multiphase.getNumberOfPhases());
+    assertEquals(firstGibbsEnergy, multiphase.getGibbsEnergy(), 1.0e-8);
+    assertFlashClosure(multiphase, TRACE_DUPLICATE_COMPONENTS, TRACE_DUPLICATE_FEED);
+  }
+
   private SystemInterface createAndFlash(boolean multiphaseCheck) {
     SystemInterface system = new SystemPrEos(250.70511924703197, 74.76182177756704);
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
@@ -50,31 +78,61 @@ class TPmultiflashPhaseDisappearanceTest {
     return system;
   }
 
+  private SystemInterface createTraceDuplicateCase(boolean multiphaseCheck) {
+    SystemInterface system = new SystemSrkEos(250.70511924703197, 300.0);
+    for (int componentIndex = 0; componentIndex < TRACE_DUPLICATE_COMPONENTS.length; componentIndex++) {
+      system.addComponent(TRACE_DUPLICATE_COMPONENTS[componentIndex], TRACE_DUPLICATE_FEED[componentIndex]);
+    }
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
   private void assertFlashClosure(SystemInterface system) {
+    assertFlashClosure(system, COMPONENTS, FEED);
+  }
+
+  private void assertFlashClosure(SystemInterface system, String[] components, double[] feed) {
     double betaTotal = 0.0;
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       betaTotal += system.getBeta(phaseIndex);
       double compositionTotal = 0.0;
-      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
-        compositionTotal += system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      for (int componentIndex = 0; componentIndex < components.length; componentIndex++) {
+        double moleFraction = system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        assertTrue(Double.isFinite(moleFraction));
+        assertTrue(moleFraction >= 0.0 && moleFraction <= 1.0);
+        compositionTotal += moleFraction;
       }
       assertEquals(1.0, compositionTotal, 1.0e-12);
     }
     assertEquals(1.0, betaTotal, 1.0e-12);
 
     double maximumLogFugacityResidual = 0.0;
-    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+    for (int componentIndex = 0; componentIndex < components.length; componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
         recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
-      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-10);
+      assertEquals(feed[componentIndex], recoveredFeed, 1.0e-10);
 
       double firstLogFugacity = logFugacity(system, 0, componentIndex);
       double secondLogFugacity = logFugacity(system, 1, componentIndex);
       maximumLogFugacityResidual = Math.max(maximumLogFugacityResidual, Math.abs(firstLogFugacity - secondLogFugacity));
     }
     assertTrue(maximumLogFugacityResidual < 1.0e-8);
+  }
+
+  private void assertEquivalentPhaseState(SystemInterface ordinary, SystemInterface multiphase, PhaseType phaseType,
+      int numberOfComponents) {
+    int ordinaryPhase = ordinary.getPhaseNumberOfPhase(phaseType.getDesc());
+    int multiphasePhase = multiphase.getPhaseNumberOfPhase(phaseType.getDesc());
+    assertEquals(multiphase.getBeta(multiphasePhase), ordinary.getBeta(ordinaryPhase), 1.0e-12);
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      assertEquals(multiphase.getPhase(multiphasePhase).getComponent(componentIndex).getx(),
+          ordinary.getPhase(ordinaryPhase).getComponent(componentIndex).getx(), 1.0e-12);
+    }
   }
 
   private double logFugacity(SystemInterface system, int phaseIndex, int componentIndex) {


### PR DESCRIPTION
## Problem

Current `master` at `3bcd669ac3c960b6cf4e44b693fe938b9ed1d514` can retain an already-disappeared duplicate phase in a neutral cubic-EOS multiphase flash.

Minimal deterministic case:

- SRK EOS, classic mixing rule
- `nitrogen/CO2/methane/ethane/propane/nC10/water = 0.01/0.05/0.70/0.08/0.04/0.02/0.10`
- 250.705119247 K and 300 bara

The ordinary path returned GAS + OIL with exact material balance but a maximum log-fugacity residual of `1.624594` and Gibbs energy `6691.1487 J`. The multiphase path returned OIL + OIL + AQUEOUS; the second oil phase had beta `1.2997e-12` and differed from the dominant oil composition by only approximately `1.4e-8`.

That trace duplicate made an effectively two-phase stable state look three-phase and prevented the ordinary and multiphase paths from selecting the same equilibrium.

## Root cause

The generic cleanup removes beta below `1.1 * phaseFractionMinimumLimit`; the duplicate landed just above that threshold. The density-based duplicate screen also missed it by a small margin. Composition-based same-`PhaseType` cleanup was deliberately restricted to CPA models because material near-critical cubic-EOS phases can temporarily resemble one another.

The missing safe case was a cubic-EOS pair where one phase is already numerically extinct.

## Change

Retain the CPA behavior and extend composition-based duplicate cleanup to other EOS only for a specific phase pair satisfying all of:

- same `PhaseType`
- `min(beta_i, beta_j) < 10 * phaseFractionMinimumLimit`
- `max_k |x_i,k - x_j,k| < 1e-6`

The duplicate beta is merged into its near-identical survivor before removal, preserving material. The existing bounded stability rerun then certifies the reduced active set. A trace phase of a different type cannot authorize removal of two material phases; the beta gate is evaluated on the candidate pair itself.

No tolerance for equilibrium, material balance, or cross-algorithm comparison is widened.

## Focused result

| Metric | Before | After |
|---|---:|---:|
| Multiphase phase count | 3 | 2 |
| Ordinary phase types | GAS + OIL | OIL + AQUEOUS |
| Multiphase phase types | OIL + OIL + AQUEOUS | OIL + AQUEOUS |
| Maximum component-balance residual | 0 | `3.61e-14` |
| Maximum log-fugacity residual | `1.624594` | `4.03e-13` |
| Gibbs energy | `6691.1487 J` | `5480.4787 J` |
| Ordinary/multiphase agreement | no | yes |

Repeated execution retains the exact two-phase endpoint.

## Matrix evidence

A deterministic matrix used SRK, PR, and SRK-CPA/classic-CPA with gas, oil, water, hydrocarbon-water, CO2-rich, hydrogen-rich, near-critical, and large-volatility-contrast feeds over 220-390 K and 1-300 bara. It exercised ordinary and multiphase TPflash, repeat execution, and a beta guess of `1e-12 / (1 - 1e-12)`.

The 600 thermodynamic states produced 2,400 flash executions including reruns:

| Result | Master | Candidate |
|---|---:|---:|
| Exceptions | 0 | 0 |
| Invalid initial endpoints | 3 | 1 |
| One-phase initial endpoints | 581 | 581 |
| Two-phase initial endpoints | 503 | 504 |
| Three-phase initial endpoints | 116 | 115 |
| Applicable ordinary/multiphase comparisons | 484 | 485 |
| Cross-path disagreements | 0 | 0 |
| Poor-guess differences | 1 | 0 |
| Repeat differences at the audit's `1e-11` signature resolution | 10 | 10 |
| Worst material residual | `7.01e-12` | `7.01e-12` |
| Worst fugacity residual | `1.624594` | `2.29e-7` |

The remaining CPA fugacity endpoint and the unchanged repeat-signature differences are pre-existing and outside this bounded active-set correction; they are not hidden by looser tolerances.

## Runtime

No speedup is claimed.

- Full matrix: `7644.5 -> 7788.9 ms` in one local JVM run (about 1.9%; not a statistically controlled benchmark).
- Corrected case, three fresh alternating JVM forks:
  - master: `9.957-13.732 ms/flash`, median `10.742`
  - candidate: `12.826-13.425 ms/flash`, median `13.051`
  - the corrected endpoint performs phase removal plus a stability rerun; ranges overlap.
- Already-valid aqueous case, three fresh alternating JVM forks:
  - master: `10.157-12.419 ms/flash`, median `11.332`
  - candidate: `10.076-11.056 ms/flash`, median `10.098`
  - checksums are identical and ranges overlap.

The new scan is bounded by NeqSim's maximum active-phase count and does not trigger a rerun on normal endpoints.

## Method and literature basis

This is an active-set cleanup around NeqSim's existing phase-split and stability methods, not a new proprietary flash algorithm.

- Michelsen's phase-split formulation uses stability analysis and second-order refinement to determine a stable multiphase equilibrium: https://doi.org/10.1016/0378-3812(82)85002-4
- Okuno, Johns, and Sepehrnoori formulate multiphase Rachford-Rice in constrained phase-fraction variables with nonnegative equilibrium compositions: https://doi.org/10.2118/117752-PA

Evidence: the removed pair has the same phase identity, near-identical composition, and a beta at the numerical disappearance limit. Inference: merging that extinct duplicate before the existing stability rerun is the conservative active-set reduction. No claim is made about undocumented commercial-simulator internals.

## Tests

- Regression-first: the new test fails on unmodified master with `expected: <2> but was: <3>`.
- Candidate focused regression methods: 2/2 pass.
- Relevant TPflash/TPmultiflash regression methods: 19/19 pass.
- Java 17 Maven compilation of 3,083 production and 1,618 test sources: pass.
- Java 8 source compilation of changed flash classes: pass.
- `git diff --check`: pass.
- Full Surefire execution was not available locally because the cached offline Maven repository lacked `surefire-junit-platform:3.5.6`; hosted CI must run the normal Ubuntu/Windows suites and slow shards.
- Local Spotless execution was unavailable because the Spotless plugin artifact was not cached; hosted CI must run the repository formatter.

## Compatibility and risk

- Public API: unchanged.
- EOS equations, mixing rules, stability thresholds, equilibrium tolerances, and normal active sets: unchanged.
- The new non-CPA path is restricted to an individually trace-sized same-type pair with composition difference below `1e-6`.
- Material-fraction composition cleanup remains CPA-only, preserving the existing near-critical cubic-EOS safeguard.
- No notebook changed.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md` with the exact beta/composition/type gates, conservative beta merge, and the distinction between trace cleanup for all EOS and material-fraction cleanup for CPA models.
