### PR TITLE
fix(column): clear stale boilup specification in equilibrium mode

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -168,6 +168,13 @@ column.setReboilerVaporBoilupRatio(1.8);
 DistillationColumn.ReboilerMode reboilerMode = column.getReboilerMode();
 ```
 
+`setReboilerVaporBoilupRatio(ratio)` configures the direct reboiler mode.
+`setReboilerBoilupRatio(ratio)` also records the target as the bottom `REFLUX_RATIO`
+specification. After either route, `setReboilerMode(DistillationColumn.ReboilerMode.EQUILIBRIUM)`
+clears the active reboiler ratio and any stored bottom reflux-ratio specification, so a later run
+cannot silently restore the old ratio. Bottom purity, recovery, product-flow, and duty
+specifications are preserved.
+
 `setCondenserLiquidReflux(value, unit)` configures the `LIQUID_REFLUX_SPLIT` mode. Use it instead
 of calling `setCondenserMode(LIQUID_REFLUX_SPLIT)` directly because the fixed reflux flow is
 required. The split never creates condensate to satisfy an oversized request: it returns at most the

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1716,6 +1716,17 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
+   * Check whether a specification controls the reboiler boilup ratio.
+   *
+   * @param specification specification to inspect
+   * @return {@code true} for a bottom reflux-ratio specification
+   */
+  private boolean isBottomRefluxRatioSpecification(ColumnSpecification specification) {
+    return specification != null && specification.getLocation() == ColumnSpecification.ProductLocation.BOTTOM
+        && specification.getType() == ColumnSpecification.SpecificationType.REFLUX_RATIO;
+  }
+
+  /**
    * Create an actionable message for contradictory condenser reflux controls.
    *
    * @return degrees-of-freedom error message
@@ -10481,7 +10492,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
-   * Configure the reboiler operating mode.
+   * Configure the reboiler operating mode. Selecting equilibrium mode clears the active reboiler ratio and its stored
+   * bottom reflux-ratio specification while preserving unrelated bottom specifications.
    *
    * @param mode reboiler operating mode
    * @throws IllegalStateException if the column has no reboiler
@@ -10491,6 +10503,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     requireReboiler();
     if (mode == ReboilerMode.EQUILIBRIUM) {
       getReboiler().clearRefluxRatio();
+      if (isBottomRefluxRatioSpecification(bottomSpecification)) {
+        bottomSpecification = null;
+      }
       setDoInitializion(true);
     } else if (mode == ReboilerMode.VAPOR_BOILUP_RATIO) {
       throw new IllegalArgumentException("Use setReboilerVaporBoilupRatio(ratio) to configure vapor boilup ratio mode");

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
@@ -3,6 +3,7 @@ package neqsim.process.equipment.distillation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.UUID;
@@ -96,10 +97,20 @@ public class DistillationColumnModeTest {
     DistillationColumn column = new DistillationColumn("reboiler mode column", 2, true, true);
 
     assertEquals(DistillationColumn.ReboilerMode.EQUILIBRIUM, column.getReboilerMode());
-    column.setReboilerVaporBoilupRatio(0.8);
+    column.setReboilerBoilupRatio(0.8);
     assertEquals(DistillationColumn.ReboilerMode.VAPOR_BOILUP_RATIO, column.getReboilerMode());
+    assertNotNull(column.getBottomSpecification());
+    assertEquals(ColumnSpecification.SpecificationType.REFLUX_RATIO, column.getBottomSpecification().getType());
+
     column.setReboilerMode(DistillationColumn.ReboilerMode.EQUILIBRIUM);
     assertEquals(DistillationColumn.ReboilerMode.EQUILIBRIUM, column.getReboilerMode());
+    assertNull(column.getBottomSpecification());
+
+    column.setBottomProductPurity("n-pentane", 0.95);
+    ColumnSpecification bottomPurity = column.getBottomSpecification();
+    column.setReboilerVaporBoilupRatio(1.0);
+    column.setReboilerMode(DistillationColumn.ReboilerMode.EQUILIBRIUM);
+    assertSame(bottomPurity, column.getBottomSpecification());
   }
 
   /**


### PR DESCRIPTION
## Problem

`setReboilerBoilupRatio(...)` stores the target in both the `Reboiler` operating mode and a bottom `REFLUX_RATIO` specification. On `master`, `setReboilerMode(EQUILIBRIUM)` clears only the reboiler flag. The stale bottom specification survives, and `applyDirectSpecifications()` silently restores vapor-boilup mode on the next run.

This affects sequential, AUTO, MESH, Naphtali–Sandholm, and fallback paths because direct terminal specifications are applied before solver dispatch.

## Regression-first baseline

Base: `master` at `3bcd669ac3c960b6cf4e44b693fe938b9ed1d514`.

The first commit is test-only. Its deterministic mode transition fails on the baseline at `assertNull(column.getBottomSpecification())`: after setting a boilup ratio of `0.8` and selecting equilibrium mode, the stored bottom `REFLUX_RATIO` remains. The nearby compatibility case requires an unrelated bottom n-pentane purity target of `0.95` to retain the exact mutable specification object.

## Root cause and change

`setReboilerMode(EQUILIBRIUM)` now:

- clears the active reboiler ratio;
- removes the stored bottom specification only when it is a bottom `REFLUX_RATIO`;
- preserves purity, recovery, flow, duty, and other unrelated bottom specifications;
- marks the column for reinitialization as before.

The change is configuration synchronization only. It does not alter MESH equations, tolerances, flashes, stage states, product flows, serialization fields, or calculation identity.

## Validation

Exact head: `7c7f3a9502ad92ae95dbcf0a0909fb17d022a733`.

Passing on the exact PR merge ref:

- Java 21 fast suites on Ubuntu and Windows;
- Java 8 suites on Ubuntu and Windows;
- slow-test shards 1/4, 2/4, and 4/4;
- Javadocs, Spotless, pre-commit, CodeQL, documentation search coverage, and PaperLab.

Slow shard 3/4 was cancelled at the one-hour job limit while its first unrelated test, `neqsim.process.equipment.pipeline.twophasepipe.TransientThreePhaseFlowTest`, was still running. No column test failed. A job-only rerun is in progress to distinguish transient runner delay from the existing repository-wide slow-test blocker.

The focused regression covers the `0.8` stale-specification case and the nearby `0.95` bottom-purity preservation case. The final branch is mergeable, zero commits behind `master`, and contains three focused commits affecting exactly three intended files.

## Review disposition

Copilot's suggestion to compare only specification values was not adopted because `ColumnSpecification` is mutable; reconstructing it could discard tolerance/iteration settings and external references. The test now uses `assertSame` to make the preservation contract explicit. The thread was answered and resolved.

## Compatibility and risk

Backward compatible for valid configurations. The only behavior change is that explicitly selecting equilibrium reboiler mode can no longer be undone by a stale stored boilup-ratio specification. Existing unrelated bottom specifications remain untouched.

## Remaining limitations

This does not address the deeper fixed-reflux terminal material/energy coupling limitation previously reproduced in PR #2766.