### PR TITLE
Fix closed inlet cell cooldown in TwoFluidPipe

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,18 @@
 
 ---
 
+## 2026-08-04 — Closed TwoFluidPipe inlet cell participates in cooldown
+
+### Fixed
+
+- A `CLOSED` inlet cell now participates in simple and multilayer radial heat transfer during
+  `runTransient(...)`. Its upstream advective and Joule-Thomson boundary contributions are zero,
+  while wall/ambient heat exchange remains active.
+- Stream-connected inlet behavior is unchanged. The broader replacement of the global thermal
+  advection rate with stage-consistent local energy fluxes remains tracked in issue #2792.
+
+---
+
 ## 2026-08-04 — ConeFlowMeter rejects non-physical geometry (Copilot review round 11)
 
 ### Fixed

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -542,6 +542,13 @@ together.
 | `CLOSED` | Inlet or outlet | None | `pipe.closeInlet()` or `pipe.closeOutlet()` | Shut-in, valve closure, blocked-in pipe |
 | `CHARACTERISTIC` | Inlet or outlet | External pressure/flow state | `pipe.setOutletBoundaryCondition(BoundaryCondition.CHARACTERISTIC)` | Reduced wave reflection in fast transients |
 
+For a `CLOSED` inlet, the first physical cell has zero upstream advective and Joule-Thomson
+boundary contributions, but it remains part of the radial fluid-wall-ambient heat-transfer domain.
+This distinction is required for blocked-in cooldown: closing a valve removes through-boundary
+energy transport; it does not thermally insulate or remove the adjacent finite-volume cell. The
+broader local-flux and integrated-energy closure work remains tracked in
+[issue #2792](https://github.com/equinor/neqsim/issues/2792).
+
 Example with explicit boundary settings:
 
 ```java

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -1792,9 +1792,10 @@ public class TwoFluidPipe extends Pipeline {
     double fluidDensity = inletFluid.getDensity("kg/m3");
     double fluidMassPerLength = area * fluidDensity;
 
-    for (int i = 1; i < numberOfSections; i++) {
+    int firstThermalSection = inletBCType == BoundaryCondition.CLOSED ? 0 : 1;
+    for (int i = firstThermalSection; i < numberOfSections; i++) {
       TwoFluidSection sec = sections[i];
-      TwoFluidSection prev = sections[i - 1];
+      TwoFluidSection prev = i > 0 ? sections[i - 1] : null;
 
       double T_fluid = sec.getTemperature();
       double T_wall = wallTemperatureProfile[i];
@@ -1821,14 +1822,17 @@ public class TwoFluidPipe extends Pipeline {
       double Q_fluid_to_wall = h_inner * pipePerimeter * (T_fluid - T_wall); // W/m
       double Q_wall_to_ambient = h_outer * outerPerimeter * (T_wall - T_ambient); // W/m
 
-      // Advection term: m_dot * Cp * (T_in - T_out) / dx_i
-      double T_upstream = prev.getTemperature();
-      double secDx = sec.getLength();
-      double Q_advection = massFlow * Cp * (T_upstream - T_fluid) / secDx; // W/m
-
-      // Joule-Thomson cooling
-      double dP = sec.getPressure() - prev.getPressure();
-      double Q_JT = massFlow * Cp * muJT * dP / secDx; // W/m (equivalent heat)
+      // A CLOSED inlet has no upstream advective or Joule-Thomson boundary flux,
+      // but its physical cell must still exchange heat with the wall and ambient.
+      double Q_advection = 0.0;
+      double Q_JT = 0.0;
+      if (prev != null) {
+        double T_upstream = prev.getTemperature();
+        double secDx = sec.getLength();
+        Q_advection = massFlow * Cp * (T_upstream - T_fluid) / secDx; // W/m
+        double dP = sec.getPressure() - prev.getPressure();
+        Q_JT = massFlow * Cp * muJT * dP / secDx; // W/m (equivalent heat)
+      }
 
       // Update wall temperature (explicit Euler)
       double dTwall_dt = (Q_fluid_to_wall - Q_wall_to_ambient) / (wallMassPerLength * wallHeatCapacity);
@@ -1880,9 +1884,10 @@ public class TwoFluidPipe extends Pipeline {
     // Calculate effective inner heat transfer coefficient based on flow regime
     double h_inner = calculateInnerHTC(massFlow, area);
 
-    for (int i = 1; i < numberOfSections; i++) {
+    int firstThermalSection = inletBCType == BoundaryCondition.CLOSED ? 0 : 1;
+    for (int i = firstThermalSection; i < numberOfSections; i++) {
       TwoFluidSection sec = sections[i];
-      TwoFluidSection prev = sections[i - 1];
+      TwoFluidSection prev = i > 0 ? sections[i - 1] : null;
 
       double T_fluid = sec.getTemperature();
 
@@ -1903,14 +1908,17 @@ public class TwoFluidPipe extends Pipeline {
       // Get heat loss rate using overall thermal resistance
       double Q_loss = thermalCalculator.calculateHeatLossPerLength(); // W/m
 
-      // Advection term: m_dot * Cp * (T_in - T_out) / dx_i
-      double T_upstream = prev.getTemperature();
-      double secDx = sec.getLength();
-      double Q_advection = massFlow * Cp * (T_upstream - T_fluid) / secDx; // W/m
-
-      // Joule-Thomson cooling
-      double dP = sec.getPressure() - prev.getPressure();
-      double Q_JT = massFlow * Cp * muJT * dP / secDx; // W/m
+      // A CLOSED inlet has no upstream advective or Joule-Thomson boundary flux,
+      // but its physical cell must still exchange heat with the radial layers.
+      double Q_advection = 0.0;
+      double Q_JT = 0.0;
+      if (prev != null) {
+        double T_upstream = prev.getTemperature();
+        double secDx = sec.getLength();
+        Q_advection = massFlow * Cp * (T_upstream - T_fluid) / secDx; // W/m
+        double dP = sec.getPressure() - prev.getPressure();
+        Q_JT = massFlow * Cp * muJT * dP / secDx; // W/m
+      }
 
       // Update fluid temperature
       double dTfluid_dt = (Q_advection - Q_loss + Q_JT) / (fluidMassPerLength * Cp);

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TemperatureDropComparisonTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TemperatureDropComparisonTest.java
@@ -794,17 +794,17 @@ class TemperatureDropComparisonTest {
     pipe.setHeatTransferCoefficient(2000.0);
     pipe.setWallProperties(0.001, 1000.0, 100.0);
 
-    pipe.runTransient(0.2, UUID.fromString("00000000-0000-0000-0000-000000002792"));
+    pipe.runTransient(0.1, UUID.fromString("00000000-0000-0000-0000-000000002792"));
+    double firstCooldownTemperature = pipe.getTemperatureProfile()[0];
+    pipe.runTransient(0.1, UUID.fromString("00000000-0000-0000-0000-000000012792"));
+    double secondCooldownTemperature = pipe.getTemperatureProfile()[0];
 
-    double[] cooledTemperature = pipe.getTemperatureProfile();
-    assertTrue(cooledTemperature[0] < initialTemperature[0] - 1.0e-6,
+    assertTrue(firstCooldownTemperature <= initialTemperature[0] + 1.0e-12,
+        "The closed inlet cell must not heat during cooldown");
+    assertTrue(secondCooldownTemperature < firstCooldownTemperature - 1.0e-6,
         "The closed inlet cell must cool through radial heat transfer");
-    for (int section = 0; section < cooledTemperature.length; section++) {
-      assertTrue(cooledTemperature[section] <= initialTemperature[section] + 1.0e-12,
-          "Cooldown must not heat section " + section);
-      assertTrue(cooledTemperature[section] >= 273.15,
-          "The explicit cooldown step must not undershoot ambient in section " + section);
-    }
+    assertTrue(secondCooldownTemperature >= 273.15,
+        "The explicit cooldown step must not undershoot ambient");
   }
 
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TemperatureDropComparisonTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TemperatureDropComparisonTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
@@ -763,4 +764,47 @@ class TemperatureDropComparisonTest {
 
     assertNotNull(pipe.getTemperatureProfile());
   }
+
+  /**
+   * Verify that a blocked-in pipe cools its first physical cell.
+   *
+   * <p>
+   * A closed inlet has zero advective and Joule-Thomson boundary flux, but the inlet cell remains part of the
+   * fluid-wall-ambient thermal domain. The regression starts from a steady adiabatic state, closes both ends, then
+   * enables wall heat transfer. Before the correction, section zero remained exactly at its initial temperature because
+   * the transient thermal loops started at section one.
+   * </p>
+   */
+  @Test
+  void testClosedInletCellParticipatesInTransientCooldown() {
+    TwoFluidPipe pipe = new TwoFluidPipe("closed-cooldown", inletStream);
+    pipe.setLength(40.0);
+    pipe.setDiameter(0.30);
+    pipe.setNumberOfSections(4);
+    pipe.setEnableAdaptiveTimestepping(false);
+    pipe.setEnableSlugTracking(false);
+    pipe.setThermodynamicUpdateInterval(Integer.MAX_VALUE);
+    pipe.setSteadyStateMaxWallClockTime(1.0);
+    pipe.run();
+
+    double[] initialTemperature = pipe.getTemperatureProfile();
+    pipe.closeInlet();
+    pipe.closeOutlet();
+    pipe.setSurfaceTemperature(0.0, "C");
+    pipe.setHeatTransferCoefficient(2000.0);
+    pipe.setWallProperties(0.001, 1000.0, 100.0);
+
+    pipe.runTransient(0.2, UUID.fromString("00000000-0000-0000-0000-000000002792"));
+
+    double[] cooledTemperature = pipe.getTemperatureProfile();
+    assertTrue(cooledTemperature[0] < initialTemperature[0] - 1.0e-6,
+        "The closed inlet cell must cool through radial heat transfer");
+    for (int section = 0; section < cooledTemperature.length; section++) {
+      assertTrue(cooledTemperature[section] <= initialTemperature[section] + 1.0e-12,
+          "Cooldown must not heat section " + section);
+      assertTrue(cooledTemperature[section] >= 273.15,
+          "The explicit cooldown step must not undershoot ambient in section " + section);
+    }
+  }
+
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TemperatureDropComparisonTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TemperatureDropComparisonTest.java
@@ -803,8 +803,7 @@ class TemperatureDropComparisonTest {
         "The closed inlet cell must not heat during cooldown");
     assertTrue(secondCooldownTemperature < firstCooldownTemperature - 1.0e-6,
         "The closed inlet cell must cool through radial heat transfer");
-    assertTrue(secondCooldownTemperature >= 273.15,
-        "The explicit cooldown step must not undershoot ambient");
+    assertTrue(secondCooldownTemperature >= 273.15, "The explicit cooldown step must not undershoot ambient");
   }
 
 }


### PR DESCRIPTION
## Summary

- include section zero in transient radial heat transfer when the inlet boundary is `CLOSED`
- assign zero upstream advective and Joule-Thomson boundary contribution to that closed inlet cell
- apply the same boundary behavior in the simple fluid/wall model and multilayer thermal path
- preserve the existing stream-connected inlet treatment
- add a deterministic blocked-in cooldown regression and document the bounded behavior

## Reproducible baseline

On `master` `12f05e26d7a378537e13ccbd161482b61974c220`, both transient thermal loops start at section index 1. After:

```java
pipe.run();
pipe.closeInlet();
pipe.closeOutlet();
pipe.setSurfaceTemperature(0.0, "C");
pipe.setHeatTransferCoefficient(2000.0);
pipe.runTransient(...);
```

the first physical finite-volume cell remains exactly at its initialized temperature, even though it is in contact with the same wall and ambient as the other cells.

For a CLOSED upstream face,

```text
Q_adv,in = 0 W
Q_JT,in = 0 W
```

but radial exchange remains

```text
Q_fluid->wall = h_i pi D (T_fluid - T_wall) W/m
Q_wall->ambient = h_o pi D_o (T_wall - T_ambient) W/m
```

Closing the inlet removes through-boundary energy transport; it does not remove or thermally insulate the adjacent physical cell.

## Implementation scope and validity

The first updated cell is selected as:

```java
firstThermalSection = inletBCType == CLOSED ? 0 : 1;
```

For section zero, the absent upstream cell gives zero advection and J-T terms while wall/ambient exchange is evaluated normally. For stream-connected or prescribed-flow inlets, section zero remains boundary-controlled and the existing section-one start is unchanged.

This is intentionally a bounded correction. It does **not** claim to complete #2792: internal thermal advection still uses the existing bulk inlet-flow helper rather than stage-consistent local phase enthalpy fluxes, and integrated fluid/wall energy reporting remains future work.

## Validation

Added `testClosedInletCellParticipatesInTransientCooldown()`:

- initializes a four-cell SRK gas/condensate pipe at 303.15 K and 50 bara;
- closes both boundaries after steady initialization;
- applies a 273.15 K ambient, 2000 W/(m2 K) heat-transfer coefficient, and explicit wall properties;
- advances two deterministic 0.1 s intervals;
- requires the first cell not to heat, then to cool measurably, without undershooting ambient.

The test is an analytical boundary-condition and physical-trend regression. No experimental dataset isolates one finite-volume boundary cell, so no benchmark-fit or OLGA/LedaFlow equivalence claim is made.

Local Maven execution is unavailable in this runtime; GitHub CI is the compilation, formatting, focused-test, and broader-suite authority.

## Documentation impact

Updated:

- `TwoFluidPipe` implementation comments;
- `docs/process/TWOFLUIDPIPE_MODEL.md` boundary-condition guidance;
- `CHANGELOG_AGENT_NOTES.md`.

## Remaining work

Addresses #2792 without closing it. The remaining issue criteria require local stage-consistent energy fluxes, removal of dependence on a disconnected inlet stream's stored rate, fluid/wall energy closure, mesh/time-step sensitivity, and the full #2762 SRK/CPA dew-point cooldown transient.