### PR TITLE
style: format transient three-phase test

### DIFF
--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientThreePhaseFlowTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TransientThreePhaseFlowTest.java
@@ -13,8 +13,7 @@ import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkCPAstatoil;
 
 /**
- * Test for three-phase transient flow in a pipeline. Based on the
- * TransientPipelineLiquidAccumulationExample.
+ * Test for three-phase transient flow in a pipeline. Based on the TransientPipelineLiquidAccumulationExample.
  */
 @Tag("slow")
 class TransientThreePhaseFlowTest {
@@ -94,8 +93,7 @@ class TransientThreePhaseFlowTest {
     assertTrue(finalInventory < 1000, "Liquid inventory should not blow up");
 
     double ratio = finalInventory / initialInventory;
-    assertTrue(ratio > 0.2 && ratio < 5.0,
-        "Inventory ratio should be reasonable. Initial: " + initialInventory + ", Final: "
-            + finalInventory + ", Ratio: " + ratio);
+    assertTrue(ratio > 0.2 && ratio < 5.0, "Inventory ratio should be reasonable. Initial: " + initialInventory
+        + ", Final: " + finalInventory + ", Ratio: " + ratio);
   }
 }


### PR DESCRIPTION
## Summary
- Apply the repository Spotless formatting to `TransientThreePhaseFlowTest` after #2801.
- Change only JavaDoc and assertion line wrapping; test inputs, assertions, tolerances, and runtime remain unchanged.

## Why
Current `master` at `f91e0c37c39e0d336e7b027ed0bc2c1a01186311` fails the pre-commit Spotless check on this file, blocking otherwise unrelated pull requests rebased onto master.

## Validation
Exact-head Spotless and pre-commit are required. No runtime behavior changes.