### PR TITLE
fix(pipe): make one-phase node molar-flow updates idempotent

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -271,7 +271,7 @@ component from one fixed pre-update total, so repeated trial-state evaluations d
 loop-order-dependent mole changes. A zero-velocity node retains its last finite positive
 thermodynamic reference amount while its hydraulic flow variables remain zero; an EOS phase cannot
 be made empty merely to represent zero flow. The conservative finite-volume cell inventories
-remain authoritative, and every synchronization reinitializes EOS density and physical properties.
+remain authoritative, and every synchronization reinitializes the thermodynamic EOS state.
 For backward-compatible control flow, the default logs a warning and returns the failed report.
 Call `pipe.setFailOnNonConvergence(true)` to make `solveTransient(...)` throw
 `IllegalStateException`; the report is recorded before either behavior and distinguishes

--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -266,7 +266,11 @@ declared band, and reports the largest dense derivative outside that band. It al
 largest per-node relative drift between the repeated evaluations for phase and component moles,
 density, inlet and mean velocity, mass and volumetric flow, Reynolds number, and wall-friction
 factor. These diagnostics are evaluated only after failure, restore the accepted state, and do not
-weaken the frozen acceptance criteria.
+weaken the frozen acceptance criteria. One-phase node initialization replaces the complete
+component molar-flow vector in one operation, so repeated trial-state evaluations do not
+accumulate loop-order-dependent mole changes. The accepted conservative finite-volume
+inventories remain authoritative; this update only synchronizes the thermodynamic flow
+representation used for EOS and hydraulic properties.
 For backward-compatible control flow, the default logs a warning and returns the failed report.
 Call `pipe.setFailOnNonConvergence(true)` to make `solveTransient(...)` throw
 `IllegalStateException`; the report is recorded before either behavior and distinguishes

--- a/src/main/java/neqsim/fluidmechanics/flownode/onephasenode/onePhaseFlowNode.java
+++ b/src/main/java/neqsim/fluidmechanics/flownode/onephasenode/onePhaseFlowNode.java
@@ -82,11 +82,15 @@ public abstract class onePhaseFlowNode extends FlowNode {
   /** {@inheritDoc} */
   @Override
   public void updateMolarFlow() {
-    for (int i = 0; i < getBulkSystem().getPhases()[0].getNumberOfComponents(); i++) {
-      double diff = (getBulkSystem().getPhases()[0].getComponent(i).getx()
-          * (molarFlowRate[0] - getBulkSystem().getPhases()[0].getNumberOfMolesInPhase()));
-      getBulkSystem().addComponent(getBulkSystem().getPhase(0).getComponent(i).getComponentName(), diff);
+    double[] componentMolarFlow =
+        new double[getBulkSystem().getPhases()[0].getNumberOfComponents()];
+    for (int i = 0; i < componentMolarFlow.length; i++) {
+      componentMolarFlow[i] =
+          getBulkSystem().getPhases()[0].getComponent(i).getx() * molarFlowRate[0];
     }
+    // Replace the complete vector atomically. Incremental additions make later components depend
+    // on the loop order because every addition changes the phase total used by the next one.
+    getBulkSystem().setMolarFlowRates(componentMolarFlow);
     getBulkSystem().init_x_y();
     getBulkSystem().init(3);
   }

--- a/src/main/java/neqsim/fluidmechanics/flownode/onephasenode/onePhaseFlowNode.java
+++ b/src/main/java/neqsim/fluidmechanics/flownode/onephasenode/onePhaseFlowNode.java
@@ -116,7 +116,7 @@ public abstract class onePhaseFlowNode extends FlowNode {
               "Cannot synchronize one-phase molar flow because component " + i + " has a non-finite update.");
         }
         if (delta != 0.0) {
-          getBulkSystem().getPhase(0).addMoles(i, delta);
+          getBulkSystem().addComponent(i, delta, 0);
         }
       }
     }

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -95,10 +95,14 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     node.init();
 
     double[] componentMoles = new double[node.getBulkSystem().getPhase(0).getNumberOfComponents()];
+    double[] overallComponentMoles = new double[componentMoles.length];
     for (int component = 0; component < componentMoles.length; component++) {
       componentMoles[component] = node.getBulkSystem().getPhase(0).getComponent(component).getNumberOfMolesInPhase();
+      overallComponentMoles[component] =
+          node.getBulkSystem().getPhase(0).getComponent(component).getNumberOfmoles();
     }
     double phaseMoles = node.getBulkSystem().getPhase(0).getNumberOfMolesInPhase();
+    double systemMoles = node.getBulkSystem().getTotalNumberOfMoles();
     double density = node.getBulkSystem().getPhase(0).getDensity();
     double massFlow = node.getMassFlowRate(0);
     double reynoldsNumber = node.getReynoldsNumber();
@@ -109,10 +113,15 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     for (int component = 0; component < componentMoles.length; component++) {
       assertRelativeEquals(componentMoles[component],
           node.getBulkSystem().getPhase(0).getComponent(component).getNumberOfMolesInPhase(),
-          "component molar flow must be idempotent for component " + component);
+          "phase component amount must be idempotent for component " + component);
+      assertRelativeEquals(overallComponentMoles[component],
+          node.getBulkSystem().getPhase(0).getComponent(component).getNumberOfmoles(),
+          "overall component amount must be idempotent for component " + component);
     }
     assertRelativeEquals(phaseMoles, node.getBulkSystem().getPhase(0).getNumberOfMolesInPhase(),
-        "phase molar flow must be idempotent");
+        "phase reference amount must be idempotent");
+    assertRelativeEquals(systemMoles, node.getBulkSystem().getTotalNumberOfMoles(),
+        "system reference amount must be idempotent");
     assertRelativeEquals(density, node.getBulkSystem().getPhase(0).getDensity(), "EOS density must be idempotent");
     assertRelativeEquals(massFlow, node.getMassFlowRate(0), "mass flow must be idempotent");
     assertRelativeEquals(reynoldsNumber, node.getReynoldsNumber(), "Reynolds number must be idempotent");

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -89,6 +89,39 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  void repeatedNodeInitializationDoesNotAccumulateMolarFlowDrift() {
+    PipeFlowSystem pipe = createInitializedPipe(24, 3000.0);
+    neqsim.fluidmechanics.flownode.FlowNodeInterface node = pipe.getNode(22);
+    node.init();
+
+    double[] componentMoles = new double[node.getBulkSystem().getPhase(0).getNumberOfComponents()];
+    for (int component = 0; component < componentMoles.length; component++) {
+      componentMoles[component] =
+          node.getBulkSystem().getPhase(0).getComponent(component).getNumberOfMolesInPhase();
+    }
+    double phaseMoles = node.getBulkSystem().getPhase(0).getNumberOfMolesInPhase();
+    double density = node.getBulkSystem().getPhase(0).getDensity();
+    double massFlow = node.getMassFlowRate(0);
+    double reynoldsNumber = node.getReynoldsNumber();
+    double frictionFactor = node.getWallFrictionFactor();
+
+    node.init();
+
+    for (int component = 0; component < componentMoles.length; component++) {
+      assertRelativeEquals(componentMoles[component],
+          node.getBulkSystem().getPhase(0).getComponent(component).getNumberOfMolesInPhase(),
+          "component molar flow must be idempotent for component " + component);
+    }
+    assertRelativeEquals(phaseMoles, node.getBulkSystem().getPhase(0).getNumberOfMolesInPhase(),
+        "phase molar flow must be idempotent");
+    assertRelativeEquals(density, node.getBulkSystem().getPhase(0).getDensity(),
+        "EOS density must be idempotent");
+    assertRelativeEquals(massFlow, node.getMassFlowRate(0), "mass flow must be idempotent");
+    assertRelativeEquals(reynoldsNumber, node.getReynoldsNumber(), "Reynolds number must be idempotent");
+    assertRelativeEquals(frictionFactor, node.getWallFrictionFactor(), "friction factor must be idempotent");
+  }
+
+  @Test
   void optInSpeciesTransportFailsLoudlyForReversedFlowWithoutLegacyStrictFlag() {
     PipeFlowSystem pipe = createInitializedPipe(3);
     pipe.setConservativeSpeciesTransport(true);
@@ -110,20 +143,6 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
 
     assertEquals(OnePhaseSpeciesConservationReport.ConservationReason.NOT_RUN,
         pipe.getSpeciesConservationReport().getReason());
-  }
-
-  @Test
-  @Tag("slow")
-  void finePulseFailureReportsRepeatedNodeStateMutation() {
-    AssertionError failure = assertThrows(AssertionError.class, () -> runIntegratedPulse(24, 30.0));
-    String message = failure.getMessage();
-
-    assertTrue(message.contains("LINE_SEARCH_FAILED"), message);
-    assertTrue(message.contains("repeated node-state relative drifts"), message);
-    assertTrue(message.contains("phaseMoles="), message);
-    assertTrue(message.contains("componentMoles="), message);
-    assertTrue(message.contains("density="), message);
-    assertTrue(message.contains("frictionFactor="), message);
   }
 
   @Test
@@ -359,6 +378,11 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
       result += value;
     }
     return result;
+  }
+
+  private static void assertRelativeEquals(double expected, double actual, String message) {
+    double scale = Math.max(Math.max(Math.abs(expected), Math.abs(actual)), 1.0e-30);
+    assertEquals(expected, actual, 1.0e-12 * scale, message);
   }
 
   private static void assertRawBitsEqual(double expected, double actual, String message) {

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -131,8 +131,8 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     node.setVelocity(0.0);
     assertDoesNotThrow(node::init);
 
+    assertEquals(0.0, node.getVelocity(), 0.0);
     assertEquals(0.0, node.getMassFlowRate(0), 0.0);
-    assertEquals(0.0, node.getMolarFlowRate(0), 0.0);
     assertRelativeEquals(phaseMoles, node.getBulkSystem().getPhase(0).getNumberOfMolesInPhase(),
         "zero hydraulic flow must retain a positive EOS reference amount");
     assertRelativeEquals(methaneFraction, node.getBulkSystem().getPhase(0).getComponent(0).getx(),

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -98,8 +98,7 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     double[] overallComponentMoles = new double[componentMoles.length];
     for (int component = 0; component < componentMoles.length; component++) {
       componentMoles[component] = node.getBulkSystem().getPhase(0).getComponent(component).getNumberOfMolesInPhase();
-      overallComponentMoles[component] =
-          node.getBulkSystem().getPhase(0).getComponent(component).getNumberOfmoles();
+      overallComponentMoles[component] = node.getBulkSystem().getPhase(0).getComponent(component).getNumberOfmoles();
     }
     double phaseMoles = node.getBulkSystem().getPhase(0).getNumberOfMolesInPhase();
     double systemMoles = node.getBulkSystem().getTotalNumberOfMoles();


### PR DESCRIPTION
## Engineering value

One-phase hydraulic/EOS residual evaluations must be idempotent. The previous component-by-component `SystemInterface.addComponent(...)` loop recomputed its correction after every addition, so later components depended on loop order. On the 24-node/30 s coupled composition-pulse case, repeated evaluations drifted and the nonlinear solve stopped at `LINE_SEARCH_FAILED`.

This change synchronizes the existing one-phase EOS reference state from one fixed pre-update total. It does not change the authoritative finite-volume cell inventories, component closure, solver tolerances, or acceptance criteria.

## Frozen baseline and acceptance criteria

Baseline: merged `master` diagnostic behavior from #2784, SRK/classic CH4/N2 gas at 288.15 K and 70 bara, 3000 m x 0.5 m pipe, 50 kg/s, 30-minute 5% -> 20% N2 inlet pulse followed by 60-minute recovery.

* Baseline 24 nodes / 30 s failed at recovery step 60.
* Final aggregate residual: `5.669516555530997e-3` versus `1e-10`.
* FV/EOS mass residual: `23.408210914547794 kg`.
* Identical residual evaluations drifted by up to `5.10e-6`.
* Frozen criteria remain: nonlinear residual <= `1e-10`, EOS density <= `1e-8`, total and component inventory closure <= `1e-8`, thermodynamic composition error <= `1e-10`, fractions bounded and summing to one, deterministic repeatability, and a decreasing 6/120 -> 12/60 -> 24/30 common-time Cauchy difference.
* Existing closed-outlet transients must remain finite and exception-free.
* Repeated positive-flow node initialization must agree within relative `1e-12`; zero velocity must retain finite EOS density and composition while public hydraulic velocity and mass flow are exactly zero.

## Method

For finite positive flow, let `N` be the pre-update phase amount and `F = |n_dot| / N`. Every component is updated from the same pre-update state:

```
delta n_i = n_i (F - 1)
```

This is loop-order independent and reuses the existing phase. It avoids clearing/rebuilding the thermodynamic system or populating inactive phases.

At zero flow, the signed hydraulic variables remain zero but the last finite positive thermodynamic reference amount is retained. EOS pressure, temperature, composition, density, and physical properties are therefore defined. Non-finite flow or an empty/non-finite reference phase fails loudly with an actionable exception.

## Demonstrated improvement and current validation

Exact-head CI for the first atomic-vector attempt (`fb2ed1d`) demonstrated that the formerly failing active coupled gate now passes:

* Java 21 slow shard 3: `OnePhaseConservativeSpeciesTest` 2 tests, 0 failures/errors/skips, 36.66 s.
* All four slow shards, Javadoc, CodeQL, documentation search, PaperLab, and Spotless workflow passed.
* The full Windows suite exposed two closed-outlet regressions because rebuilding the fluid with an all-zero vector emptied the EOS phase. That implementation has been removed.

Current head `468b39a25f9c8c1d92b59b9b5b4ad67687497db4` replaces reconstruction with the in-place fixed-scale method, adds a zero-velocity EOS regression, preserves the active Cauchy gate, and merges latest `master` `1458ae72550fe3928954c4f2080d0b777f573ec3`. Exact-head CI is required before this PR can be considered engineering-ready.

## Tests

Focused gates:

* `OnePhaseConservativeSpeciesTest`, including deterministic 30-minute pulse and active 6/120-12/60-24/30 refinement.
* `SinglePhaseGasPipeFlowTest.testClosedOutletBoundaryType`.
* `SinglePhaseGasPipeFlowTest.testRunTransientClosedOutletSimple`.

Proportionate full Java 8/21 Ubuntu/Windows and all slow shards are required.

## Compatibility, performance, and scope

* No public API or serialization change.
* No tolerance change, clipping, normalization, TVD, physical dispersion, or multiphase transport.
* The hot path no longer allocates a component vector or rebuilds the complete thermodynamic system.
* Conservative transient species transport remains explicitly positive-flow only.
* Documentation impact: `docs/fluidmechanics/single_phase_pipe_flow.md` now explains state ownership, zero-flow EOS handling, and the active coupled refinement gate.
* Notebook impact: none; Stage 1 behavior is still being stabilized.

## Attempts

1. Complete-vector `setMolarFlowRates`: passed the former 24/30 convergence blocker, but failed two closed-outlet tests by creating an empty EOS phase.
2. In-place fixed-scale synchronization with retained zero-flow EOS reference: model implementation retained; first exact-head run stopped at test compilation because `FlowNodeInterface` has no public molar-flow getter.
3. Test fixture corrected to assert the public zero velocity and mass flow. The active pulse/refinement shard passed, but exact-head review identified stale system-level mole totals in the phase-only update.
4. Phase-specific `SystemInterface.addComponent(index, delta, 0)` now updates phase and system totals together; new assertions cover overall component and system totals, and documentation no longer overstates physical-property initialization. The active pulse/refinement shard and exact-head review passed; pre-commit found one formatting-only line break.
5. Applied the exact Spotless-generated line layout only. No model, tolerance, or acceptance criterion changed; final exact-head validation pending.

## Next gate

All exact-head checks and reviews must pass, including the two closed-outlet regressions and the active coupled Cauchy study. After merge, the next dependency-ready Stage 2 gate is to record the actual coupled grid/timestep error values and expose stable Python-accessible pulse/inventory diagnostics before any TVD or physical-dispersion work.