### PR TITLE
fix(column): clear rejected fixed-reflux fallback product

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,21 @@
 
 ---
 
+## 2026-08-04 — Fixed-reflux fallback product inventory
+
+### Corrected
+
+When a fixed-liquid-reflux column rejects its tray state and installs guarded full-feed fallback
+products, the condenser's separate liquid product is now cleared. The fallback gas and bottom
+streams already contain the complete feed inventory; retaining the rejected liquid product beside
+them previously exposed more material than entered the column. Fixed-reflux availability,
+delivery, and residual diagnostics are invalidated because they no longer describe the exposed
+fallback products.
+
+The solve status remains `FALLBACK_PRODUCTS`, `solved()` remains false, and no tray equation,
+tolerance, flash, or iteration rule changed. Callers must continue to inspect the solve status
+before treating column products as a rigorous fixed-reflux solution.
+
 ## 2026-08-04 — TwoFluidPipe closed thermal boundary consistency
 
 - Transient temperature advection now consumes the conservative solver's retained phase-resolved face mass fluxes,

--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -183,6 +183,13 @@ fixed-reflux shortfall exceeds its acceptance tolerance. The requested, availabl
 in
 `getConvergenceDiagnostics()`.
 
+If the column rejects the tray state and installs guarded full-feed fallback products, the
+condenser's separate liquid product from that rejected state is cleared. The fallback gas and
+bottom streams already contain the complete feed inventory, so exposing the old liquid product
+would double-count material. Fixed-reflux delivery diagnostics are invalidated in this state;
+callers must check for `SolveStatus.FALLBACK_PRODUCTS` and must not treat it as a rigorous
+fixed-reflux solution.
+
 A fixed liquid-reflux flow and a top `REFLUX_RATIO` specification are mutually exclusive because
 both control the condenser reflux split. Configuration rejects either setter order, and
 `validateSpecifications()` plus the run preflight detect contradictory state retained by an older

--- a/src/main/java/neqsim/process/equipment/distillation/Condenser.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Condenser.java
@@ -252,13 +252,14 @@ public class Condenser extends SimpleTray {
   }
 
   /**
-   * Discard the separate liquid product after the owning column replaces rejected tray products
-   * with a full-feed fallback.
+   * Discard the separate liquid product after the owning column replaces rejected tray products with a full-feed
+   * fallback.
    *
-   * <p>The fallback already exposes the complete feed inventory through the column's gas and
-   * bottom product streams. Retaining this rejected condenser product beside those streams would
-   * double-count material. Fixed-reflux availability and delivery diagnostics are invalidated
-   * because they describe the rejected tray state, not the fallback products.
+   * <p>
+   * The fallback already exposes the complete feed inventory through the column's gas and bottom product streams.
+   * Retaining this rejected condenser product beside those streams would double-count material. Fixed-reflux
+   * availability and delivery diagnostics are invalidated because they describe the rejected tray state, not the
+   * fallback products.
    *
    * @param id calculation identifier assigned to the cleared product stream
    */

--- a/src/main/java/neqsim/process/equipment/distillation/Condenser.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Condenser.java
@@ -251,6 +251,28 @@ public class Condenser extends SimpleTray {
     }
   }
 
+  /**
+   * Discard the separate liquid product after the owning column replaces rejected tray products
+   * with a full-feed fallback.
+   *
+   * <p>The fallback already exposes the complete feed inventory through the column's gas and
+   * bottom product streams. Retaining this rejected condenser product beside those streams would
+   * double-count material. Fixed-reflux availability and delivery diagnostics are invalidated
+   * because they describe the rejected tray state, not the fallback products.
+   *
+   * @param id calculation identifier assigned to the cleared product stream
+   */
+  void discardLiquidProductAfterColumnFallback(UUID id) {
+    StreamInterface liquidProduct = getLiquidProductStream();
+    if (liquidProduct != null) {
+      liquidProduct.setFlowRate(0.0, "kg/hr");
+      liquidProduct.setCalculationIdentifier(id);
+    }
+    lastAvailableLiquidReflux = Double.NaN;
+    lastFixedLiquidReflux = Double.NaN;
+    lastFixedLiquidRefluxResidual = Double.NaN;
+  }
+
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -11296,6 +11296,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
         && updateProductsFromOverallFeedFlash(id)) {
       fallbackProductsApplied = true;
     }
+    if (fallbackProductsApplied && hasCondenser && getCondenser().isSeparation_with_liquid_reflux()) {
+      getCondenser().discardLiquidProductAfterColumnFallback(id);
+    }
     synchronizeColumnEndProductStreams(id);
     synchronizeTerminalProductDrawStreams(id);
     lastUsedFeedFlashFallback = fallbackProductsApplied;

--- a/src/test/java/neqsim/process/equipment/distillation/CondenserFixedLiquidRefluxTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/CondenserFixedLiquidRefluxTest.java
@@ -123,6 +123,71 @@ public class CondenserFixedLiquidRefluxTest {
     assertPhysical(externalProducts);
   }
 
+  /** A rejected fixed-reflux tray state must not survive beside full-feed fallback products. */
+  @Test
+  public void fixedRefluxFallbackDiscardsRejectedLiquidProductInventory() {
+    assertFixedRefluxFallbackClosesExternalBalance(100.0);
+    assertFixedRefluxFallbackClosesExternalBalance(120.0);
+  }
+
+  /**
+   * Run one fixed-reflux fallback case and verify that only one feed inventory remains exposed.
+   *
+   * @param refluxFlowKgPerHour requested fixed reflux in kg/hr
+   */
+  private static void assertFixedRefluxFallbackClosesExternalBalance(double refluxFlowKgPerHour) {
+    SystemSrkEos fluid = new SystemSrkEos(293.15, 10.0);
+    fluid.addComponent("propane", 40.0);
+    fluid.addComponent("n-butane", 30.0);
+    fluid.addComponent("n-pentane", 30.0);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("fixed reflux fallback feed", fluid);
+    feed.setFlowRate(5000.0, "kg/hr");
+    feed.setTemperature(20.0, "C");
+    feed.setPressure(10.0, "bara");
+    feed.run();
+
+    DistillationColumn column = new DistillationColumn("fixed reflux fallback column", 6, true, true);
+    column.addFeedStream(feed, 3);
+    column.setTopPressure(10.0);
+    column.setBottomPressure(10.5);
+    column.getCondenser().setOutTemperature(293.15);
+    column.getReboiler().setOutTemperature(353.15);
+    column.setCondenserLiquidReflux(refluxFlowKgPerHour, "kg/hr");
+    column.setSolverType(DistillationColumn.SolverType.DAMPED_SUBSTITUTION);
+    column.setRelaxationFactor(0.2);
+    column.setMaxNumberOfIterations(120, true);
+    column.run();
+
+    assertTrue(column.wasFeedFlashFallbackApplied(), "the regression must exercise guarded fallback handling");
+    assertEquals(DistillationColumn.SolveStatus.FALLBACK_PRODUCTS, column.getLastSolveStatus());
+    assertFalse(column.solved(), "balanced fallback products must not be reported as a rigorous column solution");
+    assertFalse(column.getCondenser().isFixedLiquidRefluxSpecificationSatisfied(),
+        "the rejected condenser split must not retain a satisfied specification diagnostic");
+
+    StreamInterface liquidProduct = column.getCondenser().getLiquidProductStream();
+    assertNotNull(liquidProduct);
+    assertEquals(0.0, liquidProduct.getFlowRate("kg/hr"), 1.0e-12,
+        "fallback products already contain the full feed inventory");
+    List<StreamInterface> products = new ArrayList<>();
+    products.add(column.getGasOutStream());
+    products.add(column.getLiquidOutStream());
+    products.add(liquidProduct);
+    assertMassAndComponentBalance(feed, products);
+    assertPhysical(products);
+
+    column.run();
+    assertTrue(column.wasFeedFlashFallbackApplied());
+    assertEquals(0.0, column.getCondenser().getLiquidProductStream().getFlowRate("kg/hr"), 1.0e-12);
+    products.set(0, column.getGasOutStream());
+    products.set(1, column.getLiquidOutStream());
+    products.set(2, column.getCondenser().getLiquidProductStream());
+    assertMassAndComponentBalance(feed, products);
+    assertEquals(20.0, feed.getTemperature("C"), 1.0e-12,
+        "column fallback handling must preserve the caller-owned feed state");
+  }
+
   private static Stream createHydrocarbonFeed() {
     SystemSrkEos fluid = new SystemSrkEos(298.15, 8.0);
     fluid.addComponent("methane", 0.05);


### PR DESCRIPTION
## Problem

A fixed-liquid-reflux column can reject its tray state and install the guarded overall-feed flash fallback. That fallback replaces the public overhead and bottoms with one complete feed inventory, but the condenser's separate liquid product still retained material from the rejected tray state. A caller following the documented three-product interface could therefore observe more material leaving the column than entered it.

## Reproduction and root cause

A deterministic six-stage SRK propane/n-butane/n-pentane fractionator was run at 5,000 kg/hr, 10.0–10.5 bara, with fixed liquid reflux requests of 100 and 120 kg/hr.

Before this change:

| Fixed reflux | Feed | Exposed products | Retained rejected liquid |
|---:|---:|---:|---:|
| 100 kg/hr | 5,000.000 kg/hr | 6,089.580 kg/hr | 1,089.580 kg/hr |
| 120 kg/hr | 5,000.000 kg/hr | 6,156.237 kg/hr | 1,156.237 kg/hr |

Both runs correctly reported `FALLBACK_PRODUCTS`, but `finalizeSolve()` replaced only the column gas and bottom streams. It did not clear `Condenser.getLiquidProductStream()`, whose state came from the rejected tray calculation.

## Change

When, and only when, the guarded full-feed fallback is successfully applied in fixed-liquid-reflux mode:

- clear the condenser's rejected separate liquid product;
- assign the current calculation identifier to that cleared stream;
- invalidate fixed-reflux availability, delivery, and residual diagnostics because they no longer describe the exposed products.

No tray equation, specification tolerance, flash, damping rule, iteration rule, temperature, or fallback product split changes. The column remains explicitly non-converged.

## Evidence

After this change, both 100 and 120 kg/hr cases expose exactly 5,000.000 kg/hr. Maximum relative component-balance error is `4.13e-16`; the separate liquid product is zero; fixed-reflux satisfaction is false; and repeat runs preserve the result and caller-owned feed state.

Iteration counts remain 11 and 15 respectively, and both cases still report `FALLBACK_PRODUCTS` with `solved() == false`. No performance improvement is claimed.

## Validation

- Deterministic regression covers both fixed-reflux values.
- Total and per-component mass balance checked across overhead, bottoms, and separate liquid product.
- Physical flow, temperature, pressure, and composition bounds checked.
- Repeated-run determinism and feed preservation checked.
- Current distillation package sources compile on Java 17 with the bundled NeqSim runtime.
- Standalone before/after reproduction executed against the current package sources.
- Remote file blobs were re-read and matched the intended contents exactly.
- Branch is based on current `master` `1458ae72550fe3928954c4f2080d0b777f573ec3`, with five intended files only.

## Compatibility and risk

Normal fixed-reflux solutions, direct condenser use, non-fixed-reflux columns, and failed fallback construction are unchanged. The observable change is limited to a guarded fallback state that already contains the full feed in the public gas and bottom products.

The remaining limitation is unchanged: this does not make the fixed-reflux tray profile rigorous. A coordinated terminal material/energy tear with robust damping or line search remains future solver work. Callers must continue to inspect solve status.

## Documentation impact

The distillation equipment guide and agent changelog now describe fallback product ownership and the invalid fixed-reflux diagnostics in this state. No notebook changed.