### PR TITLE
fix(tpflash): refine near-converged gas-liquid endpoints

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -227,6 +227,12 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Reject a Gibbs increase unless the reference was non-conservative,          │
 │       because Gibbs energies of an unbalanced reference are not comparable       │
 │                                                                                 │
+│  IF a final neutral gas/oil endpoint is balanced but near-converged:             │
+│     → Trigger only for 1e-8 ≤ max |Δ ln(fᵢ)| ≤ 1e-5                              │
+│     → Run at most eight SSI updates without changing the selected phase types     │
+│     → Keep only a normalized, balanced, fugacity-equal result with no Gibbs       │
+│       increase; otherwise restore beta, compositions, K-values, and phase types   │
+│                                                                                 │
 │  IF ordinary, neutral, dry two-phase hydrocarbon roots are inverted:             │
 │     → Detect the vapor-labelled phase having the larger mean molar mass          │
 │     → Evaluate the vapor root on the light composition and liquid root on the    │
@@ -260,6 +266,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Stable-single-phase aqueous-seed gate | `1e-8` in phase-composition normalization | Reject only a structurally invalid aqueous trial whose composition is non-finite, out of `[0, 1]`, or unnormalized; leave normalized endpoints to model-specific convergence and refinement paths |
 | Post-removal aqueous recovery | `1e-8` in `max abs(Delta z_i)` and `max abs(Delta ln(f_i))` | Restore a balanced neutral two-phase aqueous reference only when a rejected third-phase trial leaves the final two-phase endpoint infeasible; genuine three-phase and already feasible endpoints are retained |
 | Final aqueous active-set refinement | water feed `>= 0.01`; at most 3 beta refinements; `1e-8` in phase normalization, `max abs(Delta z_i)`, and `max abs(Delta ln(f_i))` | Preserve the selected neutral two-phase active set while correcting stale beta/compositions after phase cleanup or root selection. Roll back unless the result is feasible; also require no Gibbs increase when the reference material balance was valid. |
+| Final neutral gas/oil equilibrium refinement | `1e-8 <= max abs(Delta ln(f_i)) <= 1e-5`; at most 8 SSI updates | Repair only balanced, near-converged vapor-liquid endpoints after post-convergence root handling. Preserve both phase types and roll back unless phase fractions, compositions, material balance, fugacity equality, and Gibbs energy pass the strict acceptance checks. |
 | Stalled three-phase active-set fallback | `1e-8` in phase normalization, material balance, and `max abs(Delta ln(f_i))` | For neutral non-reactive systems only, evaluate each two-phase active set after a non-converged three-phase endpoint and accept the lowest-Gibbs feasible equilibrium only when it also lowers Gibbs energy relative to the stalled state |
 | Water-bearing single-phase-collapse screen | water feed `>= 0.01`, stored water `K < 1e-2`, and a non-water `K > 10` | Run one bounded ordinary-flash retry only after multiphase cleanup returns one phase with strong retained phase-preference evidence; accept only a balanced, distinct two-phase state that lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))` |
 
@@ -1715,6 +1722,10 @@ Commercial process simulators do not publish all implementation details, but pub
   material-balance or fugacity tolerances, the pre-trial state is restored. The recovery does not run another flash and
   is not considered for chemical, ionic, solid, wax, genuine three-phase, or already feasible endpoints.
 - Ordinary neutral aqueous splits now compare both cubic roots of the non-aqueous phase at the converged composition. An alternate root is retained only when it lowers Gibbs energy and already satisfies `max abs(Delta ln(f_i)) < 1e-8`; no extra TPflash or multiphase stability calculation is run.
+- Balanced neutral gas/oil endpoints whose terminal fugacity residual is between `1e-8` and `1e-5` receive at most
+  eight additional SSI updates. This targets stale, near-converged K-values after root selection without adding work to
+  already converged endpoints or attempting to rescue grossly invalid states. The original endpoint is restored unless
+  phase identity, normalization, material balance, fugacity equality, and Gibbs energy all pass.
 - Near a hydrocarbon critical boundary, the ordinary flash can converge the correct light and heavy compositions but
   retain the liquid cubic root on the light phase and the vapor root on the heavy phase. A molar-mass ordering screen
   detects that inverted labelling without adding trial-root work to normal results. The two roots are reassigned

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -57,6 +57,10 @@ public class TPflash extends Flash {
   private static final double AQUEOUS_SEED_COMPOSITION_NORMALIZATION_TOLERANCE = 1.0e-8;
   /** Maximum accepted log-fugacity residual when selecting an alternate cubic root. */
   private static final double PHASE_ROOT_EQUILIBRIUM_TOLERANCE = 1.0e-8;
+  /** Maximum final SSI updates used to repair a stale neutral two-phase endpoint. */
+  private static final int MAX_FINAL_EQUILIBRIUM_REFINEMENT_ITERATIONS = 8;
+  /** Largest residual considered near enough to convergence for bounded final SSI refinement. */
+  private static final double MAX_FINAL_EQUILIBRIUM_REFINEMENT_RESIDUAL = 1.0e-5;
   /** Cubic phase roots evaluated by the post-convergence aqueous root check. */
   private static final PhaseType[] CUBIC_ROOT_PHASE_TYPES = { PhaseType.GAS, PhaseType.LIQUID };
   /**
@@ -112,7 +116,7 @@ public class TPflash extends Flash {
   /** Reusable accelerated K-values; transient because it contains no thermodynamic state. */
   private transient double[] accelerationK;
 
-  /** Compact pre-multiphase snapshot used only for balanced neutral water-bearing endpoints. */
+  /** Compact two-phase rollback snapshot used by bounded neutral endpoint refinements. */
   private static final class BalancedTwoPhaseState {
     private final PhaseType[] phaseTypes = new PhaseType[2];
     private final double[] betas = new double[2];
@@ -667,6 +671,7 @@ public class TPflash extends Flash {
         rescueLiquidLiquidEndpoint();
         rescueWaterRichEndpoint();
         refineInvalidAqueousTwoPhaseEndpoint();
+        refineInvalidNeutralGasLiquidTwoPhaseEndpoint();
         return;
       }
     }
@@ -864,6 +869,7 @@ public class TPflash extends Flash {
     rescueWaterRichEndpoint();
     rescueLowerGibbsPhaseRoot();
     refineInvalidAqueousTwoPhaseEndpoint();
+    refineInvalidNeutralGasLiquidTwoPhaseEndpoint();
 
     // Final chemical equilibrium call after all phase reordering
     // This ensures chemical equilibrium is solved on the final phase configuration
@@ -1065,6 +1071,64 @@ public class TPflash extends Flash {
     } catch (Exception ex) {
       restoreTwoPhaseIterationState(referenceState);
       logger.debug("Final aqueous endpoint refinement failed: {}", ex.getMessage());
+    }
+  }
+
+  /**
+   * Performs a bounded final SSI refinement of a stale neutral gas/liquid two-phase endpoint.
+   *
+   * <p>
+   * Post-convergence phase-root selection can leave a gas/oil split with valid material balance but component
+   * fugacities just outside the flash tolerance. The refinement is attempted only for a neutral, non-aqueous,
+   * exactly-two-phase endpoint whose material balance already closes. It retains the selected active set and accepts
+   * the result only when phase fractions, compositions, material balance, fugacity equality, and Gibbs energy pass
+   * the existing strict checks. Otherwise the complete two-phase iteration state is restored.
+   * </p>
+   */
+  private void refineInvalidNeutralGasLiquidTwoPhaseEndpoint() {
+    if (system.getNumberOfPhases() != 2 || system.hasPhaseType(PhaseType.AQUEOUS) || system.isChemicalSystem()
+        || system.hasIons() || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()) {
+      return;
+    }
+    boolean hasGasPhase = false;
+    boolean hasLiquidPhase = false;
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      PhaseType phaseType = system.getPhase(phaseIndex).getType();
+      if (phaseType != PhaseType.GAS && phaseType != PhaseType.OIL && phaseType != PhaseType.LIQUID) {
+        return;
+      }
+      hasGasPhase |= phaseType == PhaseType.GAS;
+      hasLiquidPhase |= phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID;
+    }
+    if (!hasGasPhase || !hasLiquidPhase) {
+      return;
+    }
+
+    double referenceMaterialResidual = maximumComponentMaterialBalanceResidual(system);
+    double referenceFugacityResidual = maximumLogFugacityResidual(system.getPhase(0), system.getPhase(1));
+    if (!Double.isFinite(referenceMaterialResidual) || !Double.isFinite(referenceFugacityResidual)
+        || referenceMaterialResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE
+        || referenceFugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE
+        || referenceFugacityResidual > MAX_FINAL_EQUILIBRIUM_REFINEMENT_RESIDUAL) {
+      return;
+    }
+
+    BalancedTwoPhaseState referenceState = new BalancedTwoPhaseState(system);
+    try {
+      for (int refinement = 0;
+          refinement < MAX_FINAL_EQUILIBRIUM_REFINEMENT_ITERATIONS && !isBalancedEquilibriumCandidate(system);
+          refinement++) {
+        sucsSubs();
+      }
+      double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
+      if (!isBalancedEquilibriumCandidate(system)
+          || !preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)
+          || system.getGibbsEnergy() > referenceState.gibbsEnergy + gibbsTolerance) {
+        restoreTwoPhaseIterationState(referenceState);
+      }
+    } catch (Exception ex) {
+      restoreTwoPhaseIterationState(referenceState);
+      logger.debug("Final neutral hydrocarbon endpoint refinement failed: {}", ex.getMessage());
     }
   }
 
@@ -1308,7 +1372,7 @@ public class TPflash extends Flash {
    *
    * @param candidate candidate system to inspect
    * @return true when phase fractions, compositions, material balance, and equilibrium residuals are finite and satisfy
-   * the water-rich endpoint tolerances
+   * the strict two-phase endpoint tolerances
    */
   private boolean isBalancedEquilibriumCandidate(SystemInterface candidate) {
     double betaTotal = 0.0;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1081,8 +1081,8 @@ public class TPflash extends Flash {
    * Post-convergence phase-root selection can leave a gas/oil split with valid material balance but component
    * fugacities just outside the flash tolerance. The refinement is attempted only for a neutral, non-aqueous,
    * exactly-two-phase endpoint whose material balance already closes. It retains the selected active set and accepts
-   * the result only when phase fractions, compositions, material balance, fugacity equality, and Gibbs energy pass
-   * the existing strict checks. Otherwise the complete two-phase iteration state is restored.
+   * the result only when phase fractions, compositions, material balance, fugacity equality, and Gibbs energy pass the
+   * existing strict checks. Otherwise the complete two-phase iteration state is restored.
    * </p>
    */
   private void refineInvalidNeutralGasLiquidTwoPhaseEndpoint() {
@@ -1104,6 +1104,7 @@ public class TPflash extends Flash {
       return;
     }
 
+    system.init(1);
     double referenceMaterialResidual = maximumComponentMaterialBalanceResidual(system);
     double referenceFugacityResidual = maximumLogFugacityResidual(system.getPhase(0), system.getPhase(1));
     if (!Double.isFinite(referenceMaterialResidual) || !Double.isFinite(referenceFugacityResidual)
@@ -1115,14 +1116,12 @@ public class TPflash extends Flash {
 
     BalancedTwoPhaseState referenceState = new BalancedTwoPhaseState(system);
     try {
-      for (int refinement = 0;
-          refinement < MAX_FINAL_EQUILIBRIUM_REFINEMENT_ITERATIONS && !isBalancedEquilibriumCandidate(system);
-          refinement++) {
+      for (int refinement = 0; refinement < MAX_FINAL_EQUILIBRIUM_REFINEMENT_ITERATIONS
+          && !isBalancedEquilibriumCandidate(system); refinement++) {
         sucsSubs();
       }
       double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
-      if (!isBalancedEquilibriumCandidate(system)
-          || !preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)
+      if (!isBalancedEquilibriumCandidate(system) || !preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)
           || system.getGibbsEnergy() > referenceState.gibbsEnergy + gibbsTolerance) {
         restoreTwoPhaseIterationState(referenceState);
       }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTerminalEquilibriumRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTerminalEquilibriumRefinementTest.java
@@ -1,0 +1,122 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashTerminalEquilibriumRefinementTest {
+  private static final String[] COMPONENTS = { "nitrogen", "CO2", "methane", "ethane", "propane", "nC10",
+      "water" };
+  private static final double[] FEED = { 0.02, 0.05, 0.55, 0.18, 0.12, 0.06, 0.02 };
+
+  @Test
+  void boundedFinalSsiRestoresNeutralGasOilEquilibrium() {
+    SystemInterface ordinary = createAndFlash(false, false);
+    SystemInterface poorGuess = createAndFlash(false, true);
+    SystemInterface multiphase = createAndFlash(true, false);
+
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertTrue(ordinary.hasPhaseType(PhaseType.GAS));
+    assertTrue(ordinary.hasPhaseType(PhaseType.OIL));
+    assertClosure(ordinary);
+    assertClosure(poorGuess);
+    assertEquivalentEndpoint(ordinary, poorGuess);
+
+    assertEquals(3, multiphase.getNumberOfPhases());
+    assertTrue(multiphase.hasPhaseType(PhaseType.AQUEOUS));
+    assertClosure(multiphase);
+    assertTrue(multiphase.getGibbsEnergy() < ordinary.getGibbsEnergy(),
+        "The ordinary two-phase endpoint is a converged metastable split, not the stable three-phase state");
+
+    double referenceGibbsEnergy = ordinary.getGibbsEnergy();
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.init(1);
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquals(referenceGibbsEnergy, ordinary.getGibbsEnergy(), 1.0e-8);
+    assertClosure(ordinary);
+  }
+
+  private SystemInterface createAndFlash(boolean multiphaseCheck, boolean poorGuess) {
+    SystemInterface system = new SystemSrkCPAstatoil(275.7756311717352, 20.0);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], FEED[componentIndex]);
+    }
+    system.setMixingRule(10);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    if (poorGuess) {
+      system.setBeta(1.0e-12);
+    }
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private void assertClosure(SystemInterface system) {
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      double beta = system.getBeta(phaseIndex);
+      assertTrue(Double.isFinite(beta) && beta >= 0.0 && beta <= 1.0);
+      betaTotal += beta;
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        double moleFraction = system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        assertTrue(Double.isFinite(moleFraction) && moleFraction >= 0.0 && moleFraction <= 1.0);
+        compositionTotal += moleFraction;
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-10);
+    }
+    assertEquals(1.0, betaTotal, 1.0e-10);
+    assertTrue(maximumMaterialResidual(system) < 1.0e-8);
+    assertTrue(maximumLogFugacityResidual(system) < 1.0e-8);
+  }
+
+  private void assertEquivalentEndpoint(SystemInterface reference, SystemInterface candidate) {
+    assertEquals(reference.getNumberOfPhases(), candidate.getNumberOfPhases());
+    assertEquals(reference.getGibbsEnergy(), candidate.getGibbsEnergy(), 1.0e-8);
+    for (PhaseType phaseType : new PhaseType[] { PhaseType.GAS, PhaseType.OIL }) {
+      int referencePhase = reference.getPhaseNumberOfPhase(phaseType.getDesc());
+      int candidatePhase = candidate.getPhaseNumberOfPhase(phaseType.getDesc());
+      assertEquals(reference.getBeta(referencePhase), candidate.getBeta(candidatePhase), 1.0e-10);
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        assertEquals(reference.getPhase(referencePhase).getComponent(componentIndex).getx(),
+            candidate.getPhase(candidatePhase).getComponent(componentIndex).getx(), 1.0e-10);
+      }
+    }
+  }
+
+  private double maximumMaterialResidual(SystemInterface system) {
+    double maximum = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recovered = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        recovered += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      maximum = Math.max(maximum, Math.abs(FEED[componentIndex] - recovered));
+    }
+    return maximum;
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    if (system.getNumberOfPhases() < 2) {
+      return 0.0;
+    }
+    double maximum = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      for (int phaseIndex = 1; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        maximum = Math.max(maximum, Math.abs(logFugacity(system, 0, componentIndex)
+            - logFugacity(system, phaseIndex, componentIndex)));
+      }
+    }
+    return maximum;
+  }
+
+  private double logFugacity(SystemInterface system, int phaseIndex, int componentIndex) {
+    double composition = Math.max(system.getPhase(phaseIndex).getComponent(componentIndex).getx(), Double.MIN_NORMAL);
+    double fugacityCoefficient = system.getPhase(phaseIndex).getComponent(componentIndex).getFugacityCoefficient();
+    return Math.log(composition) + Math.log(fugacityCoefficient);
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTerminalEquilibriumRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTerminalEquilibriumRefinementTest.java
@@ -9,8 +9,7 @@ import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 class TPflashTerminalEquilibriumRefinementTest {
-  private static final String[] COMPONENTS = { "nitrogen", "CO2", "methane", "ethane", "propane", "nC10",
-      "water" };
+  private static final String[] COMPONENTS = { "nitrogen", "CO2", "methane", "ethane", "propane", "nC10", "water" };
   private static final double[] FEED = { 0.02, 0.05, 0.55, 0.18, 0.12, 0.06, 0.02 };
 
   @Test
@@ -107,8 +106,8 @@ class TPflashTerminalEquilibriumRefinementTest {
     double maximum = 0.0;
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
       for (int phaseIndex = 1; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
-        maximum = Math.max(maximum, Math.abs(logFugacity(system, 0, componentIndex)
-            - logFugacity(system, phaseIndex, componentIndex)));
+        maximum = Math.max(maximum,
+            Math.abs(logFugacity(system, 0, componentIndex) - logFugacity(system, phaseIndex, componentIndex)));
       }
     }
     return maximum;


### PR DESCRIPTION
## Reproduced problem

A deterministic CPA gas/oil endpoint can leave the ordinary two-phase TP flash materially balanced but outside NeqSim's strict fugacity-equality tolerance after the main iteration and terminal phase/root handling.

```text
SystemSrkCPAstatoil
T = 275.7756311717352 K
P = 20.0 bara
mixing rule = 10
components = nitrogen/CO2/methane/ethane/propane/nC10/water
feed = 0.02/0.05/0.55/0.18/0.12/0.06/0.02
```

Before this change, ordinary TPflash returns GAS/OIL with:

- beta = `0.8600261271516492 / 0.13997387284835083`
- maximum component material residual = `3.47e-18`
- maximum `abs(Delta ln(f_i)) = 4.60e-8`, above the existing `1e-8` acceptance limit
- Gibbs energy = `2398.13554363345 J`

The multiphase path correctly finds the lower-Gibbs GAS/OIL/AQUEOUS state (`2269.71282589 J`) with a fugacity residual of `3.06e-13`. The ordinary two-phase result is therefore a metastable phase set, but its selected two-phase split must still satisfy its own material and fugacity equations.

## Root cause and method

Evidence: five additional ordinary successive-substitution updates reduce the same endpoint's fugacity residual monotonically from `4.60e-8` to `8.91e-9` without changing its active phase set. This demonstrates stale terminal K-values rather than a missing two-phase solution.

Inference from the call sequence: post-convergence phase/root handling can leave a near-converged endpoint slightly outside the tolerance reached earlier in the main loop.

The fix adds a bounded terminal SSI refinement only when all of these conditions hold:

- exactly one gas and one oil/liquid phase;
- neutral, non-chemical, non-ionic, non-solid, non-wax endpoint;
- no active aqueous phase;
- component material residual at or below `1e-8`;
- fugacity residual in the narrow interval `[1e-8, 1e-5]`.

At most eight SSI updates are allowed. The full two-phase state is snapshotted first and restored unless phase identity, beta bounds, composition normalization, material balance, fugacity equality, and non-increasing Gibbs energy all pass the existing strict checks. Already converged and grossly invalid endpoints do no additional work.

This is a bounded continuation of the classical phase-split successive-substitution solve described by Michelsen, [The isothermal flash problem, Part II](https://doi.org/10.1016/0378-3812%2882%2985002-4). It does not add a new stability algorithm or make claims about undocumented commercial-simulator internals.

## Before/after evidence

Focused endpoint after the change:

- maximum `abs(Delta ln(f_i))`: `4.60e-8 -> 8.91e-9`
- maximum material residual: `3.47e-18 -> 1.96e-12`, still below `1e-8`
- Gibbs energy: `2398.13554363345 -> 2398.13554359218 J`
- phase set remains GAS/OIL
- poor-beta and repeated-flash endpoints agree within the test tolerances
- corrected path uses five additional SSI updates

Deterministic matrix: 600 states and 2,400 executions spanning eight feeds (gas, oil, water, hydrocarbon-water, CO2-rich, H2-rich, near-critical, and large volatility contrast), SRK/PR/CPA, five temperatures, five pressures, ordinary/multiphase, repeat, and poor-beta paths.

| Metric | master | candidate |
| --- | ---: | ---: |
| Exceptions | 0 | 0 |
| Invalid executions | 51 | 24 |
| Ordinary/multiphase differences where multiphase had <=2 phases | 0 / 261 | 0 / 261 |
| Repeat differences | 1 | 1 |
| Poor-guess differences | 4 | 4 |

The 27 repaired executions are exactly nine near-converged GAS/OIL states across ordinary, repeat, and poor-beta paths. The remaining 24 severe or different-active-set failures remain visible and are outside this bounded change.

Three fresh interleaved JVM forks, 150 flashes/fork:

- corrected endpoint median: `18.364 -> 19.061 ms/flash`; ranges `17.620-24.478` and `18.048-20.667` overlap;
- converged control median: `17.362 -> 15.982 ms/flash`; ranges `16.105-21.093` and `15.767-24.297` overlap.

No speedup or measurable normal-path regression is claimed. The corrected path deliberately pays for five SSI updates.

## Tests and compatibility

Added `TPflashTerminalEquilibriumRefinementTest` covering:

- the exact CPA regression;
- material balance, beta bounds, and phase-composition normalization;
- fugacity equality;
- repeated execution and a poor beta guess;
- ordinary/multiphase phase-state and Gibbs comparison;
- deterministic repeated endpoint behavior.

Local evidence:

- current `TPflash.java` and `TPmultiflash.java` compile with the Java compiler using `--release 8`;
- the focused test compiles and passes against the candidate;
- the same test fails against exact master at the fugacity closure assertion;
- `git diff --check` passes.

Maven/Spotless and the full Java suites are delegated to exact-head CI because the runtime has no locally cached Maven plugins. No public API, serialization form, EOS, mixing rule, convergence tolerance, or phase-stability threshold changes.

Draft #2781 also modifies TPflash for an opt-in EOS-GE gamma-phi path. Its direct path returns before this ordinary terminal refinement, so behavior is disjoint; the shared source-file insertion was reviewed for compatibility.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md` with the trigger interval, eight-iteration bound, active-set preservation, acceptance checks, rollback behavior, and performance scope.

No notebook is changed.