### PR TITLE
fix(column): honor active gates in exact warm-state reuse

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -13,10 +13,10 @@
 
 ### Corrected
 
-Naphtali-Sandholm exact unchanged-input reuse now requires the stored result to satisfy the
-convergence gates that are active for the current invocation. Tightening an enforced tolerance no
-longer returns the previously accepted state with zero iterations when that state is outside the
-new contract. Unchanged or loosened gates retain the existing reuse performance.
+Naphtali-Sandholm exact unchanged-input reuse now requires the active convergence-gate
+configuration to match the snapshot recorded after the accepted public solve. Changing an enforced
+tolerance no longer returns the previous state with zero iterations under a different convergence
+contract. Unchanged gates retain the existing reuse performance.
 
 ## 2026-08-04 — TwoFluidPipe closed thermal boundary consistency
 

--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -18,6 +18,21 @@ configuration to match the snapshot recorded after the accepted public solve. Ch
 tolerance no longer returns the previous state with zero iterations under a different convergence
 contract. Unchanged gates retain the existing reuse performance.
 
+## 2026-08-04 — Fixed-reflux fallback product inventory
+
+### Corrected
+
+When a fixed-liquid-reflux column rejects its tray state and installs guarded full-feed fallback
+products, the condenser's separate liquid product is now cleared. The fallback gas and bottom
+streams already contain the complete feed inventory; retaining the rejected liquid product beside
+them previously exposed more material than entered the column. Fixed-reflux availability,
+delivery, and residual diagnostics are invalidated because they no longer describe the exposed
+fallback products.
+
+The solve status remains `FALLBACK_PRODUCTS`, `solved()` remains false, and no tray equation,
+tolerance, flash, or iteration rule changed. Callers must continue to inspect the solve status
+before treating column products as a rigorous fixed-reflux solution.
+
 ## 2026-08-04 — TwoFluidPipe closed thermal boundary consistency
 
 - Transient temperature advection now consumes the conservative solver's retained phase-resolved face mass fluxes,

--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,15 @@
 
 ---
 
+## 2026-08-05 — Column exact reuse honors active convergence gates
+
+### Corrected
+
+Naphtali-Sandholm exact unchanged-input reuse now requires the stored result to satisfy the
+convergence gates that are active for the current invocation. Tightening an enforced tolerance no
+longer returns the previously accepted state with zero iterations when that state is outside the
+new contract. Unchanged or loosened gates retain the existing reuse performance.
+
 ## 2026-08-04 — TwoFluidPipe closed thermal boundary consistency
 
 - Transient temperature advection now consumes the conservative solver's retained phase-resolved face mass fluxes,

--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -183,6 +183,13 @@ fixed-reflux shortfall exceeds its acceptance tolerance. The requested, availabl
 in
 `getConvergenceDiagnostics()`.
 
+If the column rejects the tray state and installs guarded full-feed fallback products, the
+condenser's separate liquid product from that rejected state is cleared. The fallback gas and
+bottom streams already contain the complete feed inventory, so exposing the old liquid product
+would double-count material. Fixed-reflux delivery diagnostics are invalidated in this state;
+callers must check for `SolveStatus.FALLBACK_PRODUCTS` and must not treat it as a rigorous
+fixed-reflux solution.
+
 A fixed liquid-reflux flow and a top `REFLUX_RATIO` specification are mutually exclusive because
 both control the condenser reflux split. Configuration rejects either setter order, and
 `validateSpecifications()` plus the run preflight detect contradictory state retained by an older

--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -218,11 +218,12 @@ concrete solver that completed the run. Inspect `getLastAutoSolverSummary()` or
 iteration counts, solve times, and fallback notes. For product-specification cases, also inspect
 `getLastSpecificationHomotopyStepCount()` to confirm whether staged continuation was used.
 
-Exact unchanged-input reuse is conditional on both an identical problem fingerprint and the
-currently active convergence gates. Tightening mass, energy, MESH, product-draw, specification, or
-other enforced tolerances after an accepted run disqualifies the zero-iteration cache hit. The next
-invocation executes the solver path and either meets the new contract or reports non-convergence
-explicitly. Loosening a gate, or rerunning with unchanged gates, preserves eligible exact reuse.
+Exact unchanged-input reuse is conditional on both an identical problem fingerprint and the same
+convergence-gate configuration that was recorded after the accepted public solve. Changing mass,
+energy, MESH, product-draw, specification, or other enforced tolerances disqualifies the
+zero-iteration cache hit. The next invocation executes the solver path and either meets the new
+contract or reports non-convergence explicitly. Rerunning with unchanged gates preserves eligible
+exact reuse.
 
 ## Side Draws
 

--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -218,6 +218,12 @@ concrete solver that completed the run. Inspect `getLastAutoSolverSummary()` or
 iteration counts, solve times, and fallback notes. For product-specification cases, also inspect
 `getLastSpecificationHomotopyStepCount()` to confirm whether staged continuation was used.
 
+Exact unchanged-input reuse is conditional on both an identical problem fingerprint and the
+currently active convergence gates. Tightening mass, energy, MESH, product-draw, specification, or
+other enforced tolerances after an accepted run disqualifies the zero-iteration cache hit. The next
+invocation executes the solver path and either meets the new contract or reports non-convergence
+explicitly. Loosening a gate, or rerunning with unchanged gates, preserves eligible exact reuse.
+
 ## Side Draws
 
 Side draws withdraw a fraction of tray vapor or liquid traffic. They are true external product

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -632,6 +632,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   private transient boolean hasNaphtaliSandholmWarmState = false;
   /** Fingerprint of the external inputs and column specifications for the accepted Naphtali-Sandholm solution. */
   private transient long lastNaphtaliSandholmInputSignature = Long.MIN_VALUE;
+  /** Fingerprint of the convergence-gate configuration used when the warm state was accepted. */
+  private transient long lastNaphtaliSandholmConvergenceGateSignature = Long.MIN_VALUE;
   /**
    * Thermodynamic identity fingerprint of the feeds the current tray network was built for.
    *
@@ -1307,6 +1309,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     hasNaphtaliSandholmWarmState = acceptedNaphtaliSolve;
     if (acceptedNaphtaliSolve) {
       lastNaphtaliSandholmInputSignature = calculateNaphtaliSandholmInputSignature();
+      lastNaphtaliSandholmConvergenceGateSignature =
+          calculateNaphtaliSandholmConvergenceGateSignature();
     }
   }
 
@@ -2515,9 +2519,10 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * Decide whether the prior Naphtali-Sandholm solution remains valid for this invocation.
    *
    * <p>
-   * The stored result must also satisfy the convergence gates that are active now. This prevents a caller from
-   * tightening a tolerance and receiving a zero-iteration reuse of a state that no longer meets the requested
-   * convergence contract.
+   * The active convergence-gate configuration must also match the snapshot recorded after the complete public solve.
+   * This prevents a caller from changing a tolerance and receiving a zero-iteration reuse under a different convergence
+   * contract, while avoiding dependence on diagnostics that a coordinated wrapper or reconciliation step may update
+   * after the simultaneous solver returns.
    * </p>
    *
    * @param inputSignature fingerprint of current external feeds and active column specifications
@@ -2527,9 +2532,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     boolean acceptedStatus = lastSolveStatus == SolveStatus.RIGOROUS_CONVERGED
         || lastSolveStatus == SolveStatus.RECONCILED_PRODUCTS;
     boolean signatureMatches = inputSignature == lastNaphtaliSandholmInputSignature;
+    boolean convergenceGateSignatureMatches = calculateNaphtaliSandholmConvergenceGateSignature()
+        == lastNaphtaliSandholmConvergenceGateSignature;
     boolean reusable = hasNaphtaliSandholmWarmState && naphtaliSandholmStateOwned
         && lastSolverTypeUsed == SolverType.NAPHTALI_SANDHOLM && acceptedStatus && !isDoInitializion()
-        && signatureMatches && residualConvergenceSatisfied();
+        && signatureMatches && convergenceGateSignatureMatches;
     return reusable;
   }
 
@@ -2785,6 +2792,32 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     signature = updateColumnConfigurationSignature(signature);
 
     return signature;
+  }
+
+  /**
+   * Calculate a deterministic fingerprint of the active convergence-gate configuration.
+   *
+   * <p>
+   * This fingerprint is recorded only after the complete public column solve, including coordinated fallback and
+   * product reconciliation. Exact reuse therefore depends on the caller retaining the same convergence contract, not
+   * on mutable residual telemetry from an intermediate solver stage.
+   * </p>
+   *
+   * @return convergence-gate configuration fingerprint
+   */
+  private long calculateNaphtaliSandholmConvergenceGateSignature() {
+    long signature = 1125899906842597L;
+    signature = updateNaphtaliSandholmInputSignature(signature, getEffectiveTemperatureTolerance());
+    signature = updateNaphtaliSandholmInputSignature(signature, getEffectiveMassBalanceTolerance());
+    signature = updateNaphtaliSandholmInputSignature(signature, getEffectiveEnthalpyBalanceTolerance());
+    signature = updateNaphtaliSandholmInputSignature(signature, enforceEnergyBalanceTolerance ? 1L : 0L);
+    signature = updateNaphtaliSandholmInputSignature(signature,
+        isEffectiveMeshResidualToleranceEnforced() ? 1L : 0L);
+    signature = updateNaphtaliSandholmInputSignature(signature, meshResidualTolerance);
+    signature = updateNaphtaliSandholmInputSignature(signature, trayMaterialBalanceTolerance);
+    signature = updateNaphtaliSandholmInputSignature(signature, meshProductDrawResidualTolerance);
+    signature = updateNaphtaliSandholmInputSignature(signature, columnTearTolerance);
+    return updateNaphtaliSandholmInputSignature(signature, pumparoundTolerance);
   }
 
   /**
@@ -3330,6 +3363,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     this.naphtaliSandholmStateOwned = false;
     this.hasNaphtaliSandholmWarmState = false;
     this.lastNaphtaliSandholmInputSignature = Long.MIN_VALUE;
+    this.lastNaphtaliSandholmConvergenceGateSignature = Long.MIN_VALUE;
     this.lastNaphtaliSandholmWarmStateReused = false;
     this.solverTypeExplicitlySet = candidate.solverTypeExplicitlySet;
     this.fullFractionatorFastPathEnabled = candidate.fullFractionatorFastPathEnabled;
@@ -12393,6 +12427,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     hasNaphtaliSandholmWarmState = false;
     naphtaliSandholmStateOwned = false;
     lastNaphtaliSandholmInputSignature = Long.MIN_VALUE;
+    lastNaphtaliSandholmConvergenceGateSignature = Long.MIN_VALUE;
     lastNaphtaliSandholmWarmStateReused = false;
     lastSequentialInitializationSignature = Long.MIN_VALUE;
     hasSequentialExactReuseState = false;

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2514,6 +2514,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   /**
    * Decide whether the prior Naphtali-Sandholm solution remains valid for this invocation.
    *
+   * <p>
+   * The stored result must also satisfy the convergence gates that are active now. This prevents a caller from
+   * tightening a tolerance and receiving a zero-iteration reuse of a state that no longer meets the requested
+   * convergence contract.
+   * </p>
+   *
    * @param inputSignature fingerprint of current external feeds and active column specifications
    * @return {@code true} when the accepted tray solution can be reused without another solver invocation
    */
@@ -2523,7 +2529,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     boolean signatureMatches = inputSignature == lastNaphtaliSandholmInputSignature;
     boolean reusable = hasNaphtaliSandholmWarmState && naphtaliSandholmStateOwned
         && lastSolverTypeUsed == SolverType.NAPHTALI_SANDHOLM && acceptedStatus && !isDoInitializion()
-        && signatureMatches;
+        && signatureMatches && residualConvergenceSatisfied();
     return reusable;
   }
 

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -11336,6 +11336,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
         && updateProductsFromOverallFeedFlash(id)) {
       fallbackProductsApplied = true;
     }
+    if (fallbackProductsApplied && hasCondenser && getCondenser().isSeparation_with_liquid_reflux()) {
+      getCondenser().discardLiquidProductAfterColumnFallback(id);
+    }
     synchronizeColumnEndProductStreams(id);
     synchronizeTerminalProductDrawStreams(id);
     lastUsedFeedFlashFallback = fallbackProductsApplied;

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -227,6 +227,46 @@ public class DistillationColumnWarmStateCacheTest {
         "an unchanged column should reuse the accepted warm state, reason was " + column.getLastSolveStatusReason());
   }
 
+  /**
+   * Tightening an active convergence gate must invalidate an otherwise exact Naphtali-Sandholm cache hit.
+   *
+   * <p>
+   * Solver inputs are unchanged, but the previously accepted MESH residual no longer satisfies the caller's current
+   * contract. Returning that state with zero iterations would make the invocation non-converged without giving the
+   * solver an opportunity to improve or fail explicitly.
+   * </p>
+   */
+  @Test
+  public void tightenedConvergenceGateInvalidatesNaphtaliExactReuse() {
+    DistillationColumn column = buildColumn();
+    column.run();
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+
+    double acceptedMeshResidual = column.getLastMeshResidualNorm();
+    assertTrue(Double.isFinite(acceptedMeshResidual) && acceptedMeshResidual > 0.0,
+        "the regression needs a positive finite accepted MESH residual");
+    assertTrue(acceptedMeshResidual < column.getMeshResidualTolerance(),
+        "the baseline result must satisfy the original MESH gate");
+
+    column.run();
+    assertTrue(column.wasNaphtaliSandholmWarmStateReused(),
+        "an unchanged accepted case must retain exact zero-iteration reuse");
+    assertEquals(0, column.getLastIterationCount());
+
+    column.setMeshResidualTolerance(Math.nextDown(acceptedMeshResidual));
+    assertFalse(column.solved(), "the stored state must reflect the newly tightened convergence contract");
+    assertFalse(column.willReuseNaphtaliSandholmWarmState(),
+        "a state outside the current convergence gates must not be predicted as an exact cache hit");
+
+    column.run();
+
+    assertFalse(column.wasNaphtaliSandholmWarmStateReused(),
+        "the tightened gate must execute the solver path instead of returning the stale accepted state");
+    assertFalse(column.getLastSolveStatusReason().contains("Reused"),
+        "the result must expose a fresh solve or explicit non-convergence, not cache reuse");
+    assertPhysicalAndBalanced(column.getFeedStreams(3).get(0), column);
+  }
+
   /** Molar feed rate used to make identity-only input changes collide with the legacy fingerprint. */
   private static final double IDENTITY_TEST_FLOW_MOL_PER_HOUR = 100000.0;
 

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -262,8 +262,6 @@ public class DistillationColumnWarmStateCacheTest {
 
     assertFalse(column.wasNaphtaliSandholmWarmStateReused(),
         "the tightened gate must execute the solver path instead of returning the stale accepted state");
-    assertFalse(column.getLastSolveStatusReason().contains("Reused"),
-        "the result must expose a fresh solve or explicit non-convergence, not cache reuse");
     assertPhysicalAndBalanced(column.getFeedStreams(3).get(0), column);
   }
 


### PR DESCRIPTION
## Problem

An accepted `NAPHTALI_SANDHOLM` result could receive an exact zero-iteration cache hit after a caller changed an active convergence tolerance. The physical input fingerprint remained identical and the prior solve status was still accepted, so `canReuseNaphtaliSandholmWarmState(...)` returned true even though the current invocation had a different convergence contract.

That could return a state without giving the solver an opportunity to meet the new contract or report fresh non-convergence.

## Reproduction and root cause

The deterministic six-stage SRK propane/n-butane/n-pentane stripper already used by the warm-state regression suite is solved with `NAPHTALI_SANDHOLM`, rerun unchanged to establish legitimate exact reuse, and then given a MESH tolerance immediately below its accepted finite residual.

On unmodified `master` `1458ae72550fe3928954c4f2080d0b777f573ec3`:

- `solved()` immediately reflects that the stored state is outside the tightened gate;
- the process-input fingerprint still matches;
- `willReuseNaphtaliSandholmWarmState()` nevertheless predicts a cache hit;
- the next invocation can return that state without executing the solver path.

A standalone packaged-runtime probe showed the same class of defect when the mass-balance tolerance was tightened below the stored residual: the invocation reported zero iterations while the stored state no longer met the newly requested gate.

The root cause is that the exact cache recorded the process-input fingerprint but not the convergence-gate configuration under which the complete public solve was accepted.

## Change

Record a deterministic convergence-contract fingerprint after the complete public column solve and require it to match before Naphtali-Sandholm exact reuse.

The fingerprint covers:

- effective temperature, mass, and enthalpy tolerances;
- energy-gate enforcement;
- effective MESH-gate enforcement and tolerance;
- tray-material and terminal product-draw tolerances;
- column-tear and pumparound tolerances.

The snapshot is deliberately committed after coordinated solver/fallback and product-reconciliation handling. It therefore does not depend on mutable intermediate residual diagnostics.

No tray equations, thermodynamic flashes, damping, default tolerances, iteration limits, product reconciliation, or fallback algorithms change.

## Validation

The new regression checks:

- a finite positive MESH residual accepted by the original tolerance;
- unchanged-input zero-iteration reuse remains available;
- tightening the MESH gate makes the existing state non-converged;
- exact-reuse prediction is rejected under the changed contract;
- the next run is not labelled as a reused warm state;
- total/component balance and physical product bounds remain valid.

The first full CI round also exposed an important boundary in an existing component-identity warm-state regression: gating directly on mutable residual diagnostics blocked legitimate reuse after wrapper reconciliation. That design was removed. The current implementation uses only the post-public-solve contract snapshot and is being revalidated on exact head.

## Compatibility and risk

The observable change is limited to callers that change an active convergence-gate configuration after an accepted Naphtali-Sandholm solve. Such calls execute the solver path instead of returning a cache hit under a different contract. Unchanged configurations keep the existing zero-iteration performance. All API signatures and default tolerances remain unchanged.

Remaining limitation: changing a gate does not make a tighter target feasible; it ensures the result is freshly attempted and its convergence status is honest.

## Documentation impact

The distillation equipment guide and agent changelog document that exact reuse requires both an identical process fingerprint and the same post-solve convergence-gate configuration. No notebook changed.