### PR TITLE
Fix StaticPhaseMixer phase mass conservation

### DIFF
--- a/src/main/java/neqsim/process/equipment/mixer/StaticPhaseMixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/StaticPhaseMixer.java
@@ -1,10 +1,23 @@
 package neqsim.process.equipment.mixer;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.UUID;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
 
 /**
- * StaticPhaseMixer class.
+ * Mixes streams without flashing the combined inventory back to equilibrium.
+ *
+ * <p>
+ * Active gas, hydrocarbon-liquid, aqueous, and solid phases are transferred by component identity into deterministic
+ * output phase slots. This preserves the separated phase inventories while allowing the result to be used as a normal
+ * NeqSim stream.
+ * </p>
  *
  * @author Even Solbraa
  * @version $Id: $Id
@@ -25,66 +38,193 @@ public class StaticPhaseMixer extends StaticMixer {
   /** {@inheritDoc} */
   @Override
   public void mixStream() {
-    int index = 0;
-    String compName = new String();
+    SystemInterface outputSystem = mixedStream.getThermoSystem();
+    List<PhaseType> outputPhaseTypes = collectOutputPhaseTypes();
+    if (outputPhaseTypes.isEmpty()) {
+      outputSystem.init_x_y();
+      outputSystem.initBeta();
+      outputSystem.init(2);
+      return;
+    }
 
-    for (int k = 1; k < streams.size(); k++) {
-      if (streams.get(k).getFlowRate("kg/hr") <= getMinimumFlow()) {
+    outputSystem.setNumberOfPhases(outputPhaseTypes.size());
+    ensureComponentSlate(outputSystem);
+    clearInventory(outputSystem);
+    for (int phaseIndex = 0; phaseIndex < outputPhaseTypes.size(); phaseIndex++) {
+      outputSystem.setPhaseType(phaseIndex, outputPhaseTypes.get(phaseIndex));
+    }
+
+    double[] phaseTemperatures = new double[outputPhaseTypes.size()];
+    for (int phaseIndex = 0; phaseIndex < phaseTemperatures.length; phaseIndex++) {
+      phaseTemperatures[phaseIndex] = Double.NaN;
+    }
+
+    for (int streamIndex = 0; streamIndex < streams.size(); streamIndex++) {
+      if (streams.get(streamIndex).getFlowRate("kg/hr") <= getMinimumFlow()) {
         continue;
       }
-      for (int i = 0; i < streams.get(k).getThermoSystem().getPhases()[0].getNumberOfComponents(); i++) {
-        boolean gotComponent = false;
-        String componentName = streams.get(k).getThermoSystem().getPhases()[0].getComponent(i).getName();
-        System.out.println("adding: " + componentName);
-        int numberOfPhases = streams.get(k).getThermoSystem().getNumberOfPhases();
-        double[] moles = new double[numberOfPhases];
-        PhaseType[] phaseType = new PhaseType[numberOfPhases];
-
-        // her maa man egentlig sjekke at phase typen er den samme !!! antar at begge er
-        // to fase elle gass - tofase
-        for (int p = 0; p < numberOfPhases; p++) {
-          moles[p] = streams.get(k).getThermoSystem().getPhase(p).getComponent(i).getNumberOfMolesInPhase();
-          phaseType[p] = streams.get(k).getThermoSystem().getPhase(p).getType();
+      SystemInterface inputSystem = streams.get(streamIndex).getThermoSystem();
+      for (int inputPhaseIndex = 0; inputPhaseIndex < inputSystem.getNumberOfPhases(); inputPhaseIndex++) {
+        if (inputSystem.getPhase(inputPhaseIndex).getNumberOfMolesInPhase() <= 0.0) {
+          continue;
         }
-        if (k == 1) {
-          phaseType[0] = PhaseType.LIQUID;
-          mixedStream.getThermoSystem().getPhase(1).setTemperature(streams.get(k).getThermoSystem().getTemperature());
+        int outputPhaseIndex =
+            outputPhaseTypes.indexOf(canonicalPhaseType(inputSystem.getPhase(inputPhaseIndex).getType()));
+        if (Double.isNaN(phaseTemperatures[outputPhaseIndex])) {
+          phaseTemperatures[outputPhaseIndex] = inputSystem.getPhase(inputPhaseIndex).getTemperature();
         }
+        transferPhaseInventory(inputSystem, inputPhaseIndex, outputSystem, outputPhaseIndex);
+      }
+    }
 
-        for (int p = 0; p < mixedStream.getThermoSystem().getPhases()[0].getNumberOfComponents(); p++) {
-          if (mixedStream.getThermoSystem().getPhases()[0].getComponent(p).getName().equals(componentName)) {
-            gotComponent = true;
-            index = mixedStream.getThermoSystem().getPhases()[0].getComponent(p).getComponentNumber();
-            compName = mixedStream.getThermoSystem().getPhases()[0].getComponent(p).getComponentName();
-            break;
-          }
+    for (int phaseIndex = 0; phaseIndex < phaseTemperatures.length; phaseIndex++) {
+      if (Double.isFinite(phaseTemperatures[phaseIndex])) {
+        outputSystem.getPhase(phaseIndex).setTemperature(phaseTemperatures[phaseIndex]);
+      }
+    }
+    outputSystem.init_x_y();
+    outputSystem.initBeta();
+    outputSystem.init(2);
+  }
+
+  /**
+   * Collect the distinct active inlet phase types in deterministic output order.
+   *
+   * @return ordered phase types for the mixed stream
+   */
+  private List<PhaseType> collectOutputPhaseTypes() {
+    List<PhaseType> phaseTypes = new ArrayList<PhaseType>();
+    for (int streamIndex = 0; streamIndex < streams.size(); streamIndex++) {
+      if (streams.get(streamIndex).getFlowRate("kg/hr") <= getMinimumFlow()) {
+        continue;
+      }
+      SystemInterface inputSystem = streams.get(streamIndex).getThermoSystem();
+      for (int phaseIndex = 0; phaseIndex < inputSystem.getNumberOfPhases(); phaseIndex++) {
+        if (inputSystem.getPhase(phaseIndex).getNumberOfMolesInPhase() <= 0.0) {
+          continue;
         }
-
-        if (gotComponent) {
-          System.out.println("adding moles starting....");
-          for (int p = 0; p < numberOfPhases; p++) {
-            if (phaseType[p] == PhaseType.LIQUID) {
-              System.out.println("adding liq");
-              mixedStream.getThermoSystem().addComponent(index, moles[p], 1);
-            } else if (phaseType[p] == PhaseType.GAS) {
-              System.out.println("adding gas");
-              mixedStream.getThermoSystem().addComponent(index, moles[p], 0);
-            } else {
-              System.out.println("not here....");
-            }
-          }
-          System.out.println("adding moles finished");
-        } else {
-          System.out.println("ikke gaa hit");
-          for (int p = 0; p < numberOfPhases; p++) {
-            mixedStream.getThermoSystem().addComponent(compName, moles[p], p);
-          }
+        PhaseType phaseType = canonicalPhaseType(inputSystem.getPhase(phaseIndex).getType());
+        if (!phaseTypes.contains(phaseType)) {
+          phaseTypes.add(phaseType);
         }
       }
     }
-    mixedStream.getThermoSystem().init_x_y();
-    mixedStream.getThermoSystem().initBeta();
-    mixedStream.getThermoSystem().init(2);
+    Collections.sort(phaseTypes, new Comparator<PhaseType>() {
+      @Override
+      public int compare(PhaseType first, PhaseType second) {
+        return Integer.compare(phaseRank(first), phaseRank(second));
+      }
+    });
+    return phaseTypes;
+  }
+
+  /**
+   * Treat the generic and oil phase labels as one hydrocarbon-liquid inventory.
+   *
+   * @param phaseType inlet phase type
+   * @return canonical phase type used in the mixed stream
+   */
+  private PhaseType canonicalPhaseType(PhaseType phaseType) {
+    if (phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID) {
+      return PhaseType.LIQUID;
+    }
+    return phaseType;
+  }
+
+  /**
+   * Rank phase types so active-phase creation order cannot change the mixed result.
+   *
+   * @param phaseType phase type to rank
+   * @return deterministic phase rank
+   */
+  private int phaseRank(PhaseType phaseType) {
+    if (phaseType == PhaseType.GAS) {
+      return 0;
+    }
+    if (phaseType == PhaseType.LIQUID) {
+      return 1;
+    }
+    if (phaseType == PhaseType.AQUEOUS) {
+      return 2;
+    }
+    return 3 + phaseType.ordinal();
+  }
+
+  /**
+   * Add components that are absent from the cloned template without adding inventory.
+   *
+   * @param outputSystem mixed-stream thermodynamic system
+   */
+  private void ensureComponentSlate(SystemInterface outputSystem) {
+    boolean componentAdded = false;
+    for (int streamIndex = 0; streamIndex < streams.size(); streamIndex++) {
+      if (streams.get(streamIndex).getFlowRate("kg/hr") <= getMinimumFlow()) {
+        continue;
+      }
+      SystemInterface inputSystem = streams.get(streamIndex).getThermoSystem();
+      for (int componentIndex = 0; componentIndex < inputSystem.getPhase(0).getNumberOfComponents();
+          componentIndex++) {
+        ComponentInterface sourceComponent = inputSystem.getPhase(0).getComponent(componentIndex);
+        if (outputSystem.getPhase(0).hasComponent(sourceComponent.getName())) {
+          continue;
+        }
+        if (sourceComponent.isIsTBPfraction() || sourceComponent.isIsPlusFraction()) {
+          String rawName = sourceComponent.getName().replaceFirst("_PC$", "");
+          outputSystem.addTBPfraction(rawName, 0.0, sourceComponent.getMolarMass(),
+              sourceComponent.getNormalLiquidDensity());
+        } else {
+          outputSystem.addComponent(sourceComponent.getName(), 0.0);
+        }
+        componentAdded = true;
+      }
+    }
+    if (componentAdded) {
+      outputSystem.setMixingRule(outputSystem.getMixingRule());
+    }
+  }
+
+  /**
+   * Clear all component inventory while retaining the cloned model and component parameters.
+   *
+   * @param outputSystem mixed-stream thermodynamic system
+   */
+  private void clearInventory(SystemInterface outputSystem) {
+    for (PhaseInterface phase : outputSystem.getPhases()) {
+      if (phase == null) {
+        continue;
+      }
+      for (int componentIndex = 0; componentIndex < phase.getNumberOfComponents(); componentIndex++) {
+        phase.getComponent(componentIndex).setNumberOfMolesInPhase(0.0);
+        phase.getComponent(componentIndex).setNumberOfmoles(0.0);
+      }
+    }
+    outputSystem.setTotalNumberOfMoles(0.0);
+  }
+
+  /**
+   * Transfer one active inlet phase into the matching output phase by component name.
+   *
+   * @param inputSystem inlet thermodynamic system
+   * @param inputPhaseIndex active inlet phase index
+   * @param outputSystem mixed-stream thermodynamic system
+   * @param outputPhaseIndex matching output phase index
+   */
+  private void transferPhaseInventory(SystemInterface inputSystem, int inputPhaseIndex, SystemInterface outputSystem,
+      int outputPhaseIndex) {
+    for (int componentIndex = 0; componentIndex < inputSystem.getPhase(inputPhaseIndex).getNumberOfComponents();
+        componentIndex++) {
+      ComponentInterface sourceComponent = inputSystem.getPhase(inputPhaseIndex).getComponent(componentIndex);
+      double sourceMoles = sourceComponent.getNumberOfMolesInPhase();
+      if (sourceMoles == 0.0) {
+        continue;
+      }
+      ComponentInterface destinationComponent = outputSystem.getPhase(0).getComponent(sourceComponent.getName());
+      double destinationMoles = sourceMoles;
+      if (destinationComponent.getMolarMass() > 0.0) {
+        destinationMoles *= sourceComponent.getMolarMass() / destinationComponent.getMolarMass();
+      }
+      outputSystem.addComponent(destinationComponent.getComponentNumber(), destinationMoles, outputPhaseIndex);
+    }
   }
 
   /** {@inheritDoc} */
@@ -105,10 +245,6 @@ public class StaticPhaseMixer extends StaticMixer {
     }
 
     mixedStream.setThermoSystem((streams.get(templateIndex).getThermoSystem().clone()));
-    mixedStream.getThermoSystem().init(0);
-    mixedStream.getThermoSystem().setBeta(1, 1e-10);
-    mixedStream.getThermoSystem().init(2);
-    mixedStream.getThermoSystem().reInitPhaseType();
 
     mixStream();
 

--- a/src/main/java/neqsim/process/equipment/mixer/StaticPhaseMixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/StaticPhaseMixer.java
@@ -41,11 +41,7 @@ public class StaticPhaseMixer extends StaticMixer {
     SystemInterface outputSystem = mixedStream.getThermoSystem();
     List<PhaseType> outputPhaseTypes = collectOutputPhaseTypes();
     if (outputPhaseTypes.isEmpty()) {
-      if (outputSystem.getTotalNumberOfMoles() > 0.0) {
-        outputSystem.init_x_y();
-        outputSystem.initBeta();
-        outputSystem.init(2);
-      }
+      clearInventory(outputSystem);
       return;
     }
 
@@ -169,7 +165,11 @@ public class StaticPhaseMixer extends StaticMixer {
         if (outputSystem.getPhase(0).hasComponent(sourceComponent.getName())) {
           continue;
         }
-        if (sourceComponent.isIsTBPfraction() || sourceComponent.isIsPlusFraction()) {
+        if (sourceComponent.isIsPlusFraction()) {
+          String rawName = sourceComponent.getName().replaceFirst("_PC$", "");
+          outputSystem.addPlusFraction(rawName, 0.0, sourceComponent.getMolarMass(),
+              sourceComponent.getNormalLiquidDensity());
+        } else if (sourceComponent.isIsTBPfraction()) {
           String rawName = sourceComponent.getName().replaceFirst("_PC$", "");
           outputSystem.addTBPfraction(rawName, 0.0, sourceComponent.getMolarMass(),
               sourceComponent.getNormalLiquidDensity());
@@ -194,10 +194,7 @@ public class StaticPhaseMixer extends StaticMixer {
       if (phase == null) {
         continue;
       }
-      for (int componentIndex = 0; componentIndex < phase.getNumberOfComponents(); componentIndex++) {
-        phase.getComponent(componentIndex).setNumberOfMolesInPhase(0.0);
-        phase.getComponent(componentIndex).setNumberOfmoles(0.0);
-      }
+      phase.setEmptyFluid();
     }
     outputSystem.setTotalNumberOfMoles(0.0);
   }
@@ -242,9 +239,16 @@ public class StaticPhaseMixer extends StaticMixer {
       }
     }
     if (templateIndex < 0) {
-      templateIndex = 0;
+      SystemInterface outputSystem = streams.get(0).getThermoSystem().clone();
+      clearInventory(outputSystem);
+      mixedStream.setThermoSystem(outputSystem);
+      isActive(false);
+      mixedStream.setCalculationIdentifier(id);
+      setCalculationIdentifier(id);
+      return;
     }
 
+    isActive(true);
     mixedStream.setThermoSystem((streams.get(templateIndex).getThermoSystem().clone()));
 
     mixStream();

--- a/src/main/java/neqsim/process/equipment/mixer/StaticPhaseMixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/StaticPhaseMixer.java
@@ -68,8 +68,8 @@ public class StaticPhaseMixer extends StaticMixer {
         if (inputSystem.getPhase(inputPhaseIndex).getNumberOfMolesInPhase() <= 0.0) {
           continue;
         }
-        int outputPhaseIndex =
-            outputPhaseTypes.indexOf(canonicalPhaseType(inputSystem.getPhase(inputPhaseIndex).getType()));
+        int outputPhaseIndex = outputPhaseTypes
+            .indexOf(canonicalPhaseType(inputSystem.getPhase(inputPhaseIndex).getType()));
         if (Double.isNaN(phaseTemperatures[outputPhaseIndex])) {
           phaseTemperatures[outputPhaseIndex] = inputSystem.getPhase(inputPhaseIndex).getTemperature();
         }
@@ -162,8 +162,7 @@ public class StaticPhaseMixer extends StaticMixer {
         continue;
       }
       SystemInterface inputSystem = streams.get(streamIndex).getThermoSystem();
-      for (int componentIndex = 0; componentIndex < inputSystem.getPhase(0).getNumberOfComponents();
-          componentIndex++) {
+      for (int componentIndex = 0; componentIndex < inputSystem.getPhase(0).getNumberOfComponents(); componentIndex++) {
         ComponentInterface sourceComponent = inputSystem.getPhase(0).getComponent(componentIndex);
         if (outputSystem.getPhase(0).hasComponent(sourceComponent.getName())) {
           continue;
@@ -211,8 +210,8 @@ public class StaticPhaseMixer extends StaticMixer {
    */
   private void transferPhaseInventory(SystemInterface inputSystem, int inputPhaseIndex, SystemInterface outputSystem,
       int outputPhaseIndex) {
-    for (int componentIndex = 0; componentIndex < inputSystem.getPhase(inputPhaseIndex).getNumberOfComponents();
-        componentIndex++) {
+    for (int componentIndex = 0; componentIndex < inputSystem.getPhase(inputPhaseIndex)
+        .getNumberOfComponents(); componentIndex++) {
       ComponentInterface sourceComponent = inputSystem.getPhase(inputPhaseIndex).getComponent(componentIndex);
       double sourceMoles = sourceComponent.getNumberOfMolesInPhase();
       if (sourceMoles == 0.0) {

--- a/src/main/java/neqsim/process/equipment/mixer/StaticPhaseMixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/StaticPhaseMixer.java
@@ -41,9 +41,11 @@ public class StaticPhaseMixer extends StaticMixer {
     SystemInterface outputSystem = mixedStream.getThermoSystem();
     List<PhaseType> outputPhaseTypes = collectOutputPhaseTypes();
     if (outputPhaseTypes.isEmpty()) {
-      outputSystem.init_x_y();
-      outputSystem.initBeta();
-      outputSystem.init(2);
+      if (outputSystem.getTotalNumberOfMoles() > 0.0) {
+        outputSystem.init_x_y();
+        outputSystem.initBeta();
+        outputSystem.init(2);
+      }
       return;
     }
 

--- a/src/main/java/neqsim/process/equipment/mixer/StaticPhaseMixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/StaticPhaseMixer.java
@@ -249,7 +249,9 @@ public class StaticPhaseMixer extends StaticMixer {
 
     mixStream();
 
-    mixedStream.getThermoSystem().initProperties();
+    if (mixedStream.getThermoSystem().getTotalNumberOfMoles() > 0.0) {
+      mixedStream.getThermoSystem().initProperties();
+    }
     mixedStream.setCalculationIdentifier(id);
     setCalculationIdentifier(id);
   }

--- a/src/test/java/neqsim/process/equipment/mixer/StaticPhaseMixerTest.java
+++ b/src/test/java/neqsim/process/equipment/mixer/StaticPhaseMixerTest.java
@@ -42,12 +42,16 @@ class StaticPhaseMixerTest {
       ByteArrayOutputStream standardError = new ByteArrayOutputStream();
       PrintStream originalOutput = System.out;
       PrintStream originalError = System.err;
+      PrintStream capturedOutput = new PrintStream(standardOutput, true);
+      PrintStream capturedError = new PrintStream(standardError, true);
       try {
-        System.setOut(new PrintStream(standardOutput));
-        System.setErr(new PrintStream(standardError));
+        System.setOut(capturedOutput);
+        System.setErr(capturedError);
         mixer.run();
         mixer.run();
       } finally {
+        capturedOutput.flush();
+        capturedError.flush();
         System.setOut(originalOutput);
         System.setErr(originalError);
       }
@@ -141,6 +145,25 @@ class StaticPhaseMixerTest {
     assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("gas"));
     assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("liquid"));
     assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("aqueous"));
+  }
+
+  @Test
+  void testZeroFlowBypassKeepsFinitePhaseFractions() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream zeroFlow = new Stream("zero flow", fluid);
+    zeroFlow.setFlowRate(0.0, "kg/hr");
+
+    StaticPhaseMixer mixer = new StaticPhaseMixer("zero-flow phase mixer");
+    mixer.addStream(zeroFlow);
+    mixer.run();
+
+    assertEquals(0.0, mixer.getOutletStream().getFlowRate("kg/hr"), 0.0);
+    for (int phaseIndex = 0; phaseIndex < mixer.getOutletStream().getThermoSystem().getNumberOfPhases();
+        phaseIndex++) {
+      assertTrue(Double.isFinite(mixer.getOutletStream().getThermoSystem().getBeta(phaseIndex)));
+    }
   }
 
   private static SystemInterface createSeparatorFeed(double temperature) {

--- a/src/test/java/neqsim/process/equipment/mixer/StaticPhaseMixerTest.java
+++ b/src/test/java/neqsim/process/equipment/mixer/StaticPhaseMixerTest.java
@@ -160,8 +160,7 @@ class StaticPhaseMixerTest {
     mixer.run();
 
     assertEquals(0.0, mixer.getOutletStream().getFlowRate("kg/hr"), 0.0);
-    for (int phaseIndex = 0; phaseIndex < mixer.getOutletStream().getThermoSystem().getNumberOfPhases();
-        phaseIndex++) {
+    for (int phaseIndex = 0; phaseIndex < mixer.getOutletStream().getThermoSystem().getNumberOfPhases(); phaseIndex++) {
       assertTrue(Double.isFinite(mixer.getOutletStream().getThermoSystem().getBeta(phaseIndex)));
     }
   }

--- a/src/test/java/neqsim/process/equipment/mixer/StaticPhaseMixerTest.java
+++ b/src/test/java/neqsim/process/equipment/mixer/StaticPhaseMixerTest.java
@@ -18,7 +18,7 @@ class StaticPhaseMixerTest {
 
   @Test
   void testSeparatorRecombinationConservesMassAtBaseAndNearbyTemperatures() {
-    double[] temperatures = new double[] {288.15, 293.15};
+    double[] temperatures = new double[] { 288.15, 293.15 };
 
     for (double temperature : temperatures) {
       SystemInterface fluid = createSeparatorFeed(temperature);
@@ -163,11 +163,9 @@ class StaticPhaseMixerTest {
     return fluid;
   }
 
-  private static void assertComponentMassBalance(StreamInterface gas, StreamInterface liquid,
-      StreamInterface outlet) {
+  private static void assertComponentMassBalance(StreamInterface gas, StreamInterface liquid, StreamInterface outlet) {
     SystemInterface outletSystem = outlet.getThermoSystem();
-    for (int componentIndex = 0; componentIndex < outletSystem.getPhase(0).getNumberOfComponents();
-        componentIndex++) {
+    for (int componentIndex = 0; componentIndex < outletSystem.getPhase(0).getNumberOfComponents(); componentIndex++) {
       ComponentInterface outletComponent = outletSystem.getPhase(0).getComponent(componentIndex);
       String componentName = outletComponent.getName();
       double inletComponentMass = componentMass(gas.getThermoSystem(), componentName)

--- a/src/test/java/neqsim/process/equipment/mixer/StaticPhaseMixerTest.java
+++ b/src/test/java/neqsim/process/equipment/mixer/StaticPhaseMixerTest.java
@@ -44,10 +44,14 @@ class StaticPhaseMixerTest {
       PrintStream originalError = System.err;
       PrintStream capturedOutput = new PrintStream(standardOutput, true);
       PrintStream capturedError = new PrintStream(standardError, true);
+      double firstRunMass;
+      double[] firstRunComponentMasses;
       try {
         System.setOut(capturedOutput);
         System.setErr(capturedError);
         mixer.run();
+        firstRunMass = mixer.getOutletStream().getFlowRate("kg/hr");
+        firstRunComponentMasses = componentMasses(mixer.getOutletStream().getThermoSystem());
         mixer.run();
       } finally {
         capturedOutput.flush();
@@ -67,10 +71,14 @@ class StaticPhaseMixerTest {
       double outletMass = mixer.getOutletStream().getFlowRate("kg/hr");
       assertEquals(inletMass, outletMass, inletMass * 1.0e-10,
           "total mass must close after separator phase recombination");
+      assertEquals(firstRunMass, outletMass, inletMass * 1.0e-12,
+          "repeated runs must preserve the mixed mass inventory");
 
       assertComponentMassBalance(gas, liquid, mixer.getOutletStream());
+      assertComponentMassesEqual(firstRunComponentMasses, mixer.getOutletStream().getThermoSystem());
       assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("gas"));
-      assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("liquid"));
+      assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("oil"),
+          "the hydrocarbon-liquid phase assignment must be preserved");
       assertTrue(liquid.getThermoSystem().hasPhaseType("aqueous"),
           "the regression fluid must exercise the separator's aqueous phase");
       assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("aqueous"));
@@ -99,6 +107,7 @@ class StaticPhaseMixerTest {
     SystemInterface liquidFluid = new SystemSrkEos(303.15, 30.0);
     liquidFluid.addComponent("methane", 0.2);
     liquidFluid.addComponent("n-heptane", 0.8);
+    liquidFluid.addPlusFraction("C20", 0.1, 0.250, 0.85);
     liquidFluid.setMixingRule("classic");
     liquidFluid.setForceSinglePhase(PhaseType.LIQUID);
     Stream liquid = new Stream("liquid with sparse slate", liquidFluid);
@@ -113,6 +122,8 @@ class StaticPhaseMixerTest {
     double inletMass = gas.getFlowRate("kg/hr") + liquid.getFlowRate("kg/hr");
     assertEquals(inletMass, sparseMixer.getOutletStream().getFlowRate("kg/hr"), inletMass * 1.0e-10);
     assertTrue(sparseMixer.getOutletStream().getThermoSystem().getPhase(0).hasComponent("n-heptane"));
+    assertTrue(sparseMixer.getOutletStream().getThermoSystem().getPhase(0).getComponent("C20_PC").isIsPlusFraction(),
+        "sparse plus-fraction characterization must be preserved");
   }
 
   @Test
@@ -143,7 +154,8 @@ class StaticPhaseMixerTest {
     assertEquals(inletMass, mixer.getOutletStream().getFlowRate("kg/hr"), inletMass * 1.0e-10);
     assertComponentMassBalance(gas, reorderedLiquid, mixer.getOutletStream());
     assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("gas"));
-    assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("liquid"));
+    assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("oil"),
+        "the hydrocarbon-liquid phase assignment must be preserved");
     assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("aqueous"));
   }
 
@@ -163,6 +175,13 @@ class StaticPhaseMixerTest {
     for (int phaseIndex = 0; phaseIndex < mixer.getOutletStream().getThermoSystem().getNumberOfPhases(); phaseIndex++) {
       assertTrue(Double.isFinite(mixer.getOutletStream().getThermoSystem().getBeta(phaseIndex)));
     }
+
+    zeroFlow.setFlowRate(0.5, "kg/hr");
+    mixer.setMinimumFlow(1.0);
+    mixer.run();
+    assertEquals(0.0, mixer.getOutletStream().getFlowRate("kg/hr"), 0.0,
+        "sub-threshold inlet inventory must be cleared");
+    assertTrue(!mixer.isActive(), "a sub-threshold mixer must be marked inactive");
   }
 
   private static SystemInterface createSeparatorFeed(double temperature) {
@@ -206,5 +225,22 @@ class StaticPhaseMixerTest {
       mass += component.getNumberOfMolesInPhase() * component.getMolarMass();
     }
     return mass;
+  }
+
+  private static double[] componentMasses(SystemInterface system) {
+    double[] masses = new double[system.getPhase(0).getNumberOfComponents()];
+    for (int componentIndex = 0; componentIndex < masses.length; componentIndex++) {
+      masses[componentIndex] = componentMass(system, system.getPhase(0).getComponent(componentIndex).getName());
+    }
+    return masses;
+  }
+
+  private static void assertComponentMassesEqual(double[] expectedMasses, SystemInterface system) {
+    for (int componentIndex = 0; componentIndex < expectedMasses.length; componentIndex++) {
+      String componentName = system.getPhase(0).getComponent(componentIndex).getName();
+      double tolerance = Math.max(1.0e-12, expectedMasses[componentIndex] * 1.0e-12);
+      assertEquals(expectedMasses[componentIndex], componentMass(system, componentName), tolerance,
+          "repeated runs must preserve component mass for " + componentName);
+    }
   }
 }

--- a/src/test/java/neqsim/process/equipment/mixer/StaticPhaseMixerTest.java
+++ b/src/test/java/neqsim/process/equipment/mixer/StaticPhaseMixerTest.java
@@ -1,0 +1,190 @@
+package neqsim.process.equipment.mixer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression tests for phase-preserving static mixing. */
+class StaticPhaseMixerTest {
+
+  @Test
+  void testSeparatorRecombinationConservesMassAtBaseAndNearbyTemperatures() {
+    double[] temperatures = new double[] {288.15, 293.15};
+
+    for (double temperature : temperatures) {
+      SystemInterface fluid = createSeparatorFeed(temperature);
+      Stream feed = new Stream("feed", fluid);
+      feed.setFlowRate(50000.0, "kg/hr");
+      feed.run();
+
+      Separator separator = new Separator("separator", feed);
+      separator.run();
+
+      StreamInterface gas = separator.getGasOutStream();
+      StreamInterface liquid = separator.getLiquidOutStream();
+      double gasMassBefore = gas.getFlowRate("kg/hr");
+      double liquidMassBefore = liquid.getFlowRate("kg/hr");
+
+      StaticPhaseMixer mixer = new StaticPhaseMixer("phase mixer");
+      mixer.addStream(gas);
+      mixer.addStream(liquid);
+
+      ByteArrayOutputStream standardOutput = new ByteArrayOutputStream();
+      ByteArrayOutputStream standardError = new ByteArrayOutputStream();
+      PrintStream originalOutput = System.out;
+      PrintStream originalError = System.err;
+      try {
+        System.setOut(new PrintStream(standardOutput));
+        System.setErr(new PrintStream(standardError));
+        mixer.run();
+        mixer.run();
+      } finally {
+        System.setOut(originalOutput);
+        System.setErr(originalError);
+      }
+
+      assertEquals("", standardOutput.toString(), "normal operation must not write to stdout");
+      assertEquals("", standardError.toString(), "normal operation must not write to stderr");
+      assertEquals(gasMassBefore, gas.getFlowRate("kg/hr"), gasMassBefore * 1.0e-12,
+          "mixer must not mutate the gas inlet");
+      assertEquals(liquidMassBefore, liquid.getFlowRate("kg/hr"), liquidMassBefore * 1.0e-12,
+          "mixer must not mutate the liquid inlet");
+
+      double inletMass = gasMassBefore + liquidMassBefore;
+      double outletMass = mixer.getOutletStream().getFlowRate("kg/hr");
+      assertEquals(inletMass, outletMass, inletMass * 1.0e-10,
+          "total mass must close after separator phase recombination");
+
+      assertComponentMassBalance(gas, liquid, mixer.getOutletStream());
+      assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("gas"));
+      assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("liquid"));
+      assertTrue(liquid.getThermoSystem().hasPhaseType("aqueous"),
+          "the regression fluid must exercise the separator's aqueous phase");
+      assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("aqueous"));
+      assertTrue(Double.isFinite(mixer.getOutletStream().getThermoSystem().getDensity("kg/m3")));
+    }
+  }
+
+  @Test
+  void testOnePhaseAndSparseComponentSlates() {
+    SystemInterface gasFluid = new SystemSrkEos(303.15, 30.0);
+    gasFluid.addComponent("methane", 0.9);
+    gasFluid.addComponent("ethane", 0.1);
+    gasFluid.setMixingRule("classic");
+    gasFluid.setForceSinglePhase(PhaseType.GAS);
+    Stream gas = new Stream("gas", gasFluid);
+    gas.setFlowRate(1000.0, "kg/hr");
+    gas.run();
+
+    StaticPhaseMixer onePhaseMixer = new StaticPhaseMixer("one phase mixer");
+    onePhaseMixer.addStream(gas);
+    onePhaseMixer.run();
+    assertEquals(gas.getFlowRate("kg/hr"), onePhaseMixer.getOutletStream().getFlowRate("kg/hr"),
+        gas.getFlowRate("kg/hr") * 1.0e-10);
+    assertTrue(onePhaseMixer.getOutletStream().getThermoSystem().hasPhaseType("gas"));
+
+    SystemInterface liquidFluid = new SystemSrkEos(303.15, 30.0);
+    liquidFluid.addComponent("methane", 0.2);
+    liquidFluid.addComponent("n-heptane", 0.8);
+    liquidFluid.setMixingRule("classic");
+    liquidFluid.setForceSinglePhase(PhaseType.LIQUID);
+    Stream liquid = new Stream("liquid with sparse slate", liquidFluid);
+    liquid.setFlowRate(750.0, "kg/hr");
+    liquid.run();
+
+    StaticPhaseMixer sparseMixer = new StaticPhaseMixer("sparse component mixer");
+    sparseMixer.addStream(gas);
+    sparseMixer.addStream(liquid);
+    sparseMixer.run();
+
+    double inletMass = gas.getFlowRate("kg/hr") + liquid.getFlowRate("kg/hr");
+    assertEquals(inletMass, sparseMixer.getOutletStream().getFlowRate("kg/hr"), inletMass * 1.0e-10);
+    assertTrue(sparseMixer.getOutletStream().getThermoSystem().getPhase(0).hasComponent("n-heptane"));
+  }
+
+  @Test
+  void testActivePhaseReorderingDoesNotChangeInventory() {
+    SystemInterface fluid = createSeparatorFeed(288.15);
+    Stream feed = new Stream("reordering feed", fluid);
+    feed.setFlowRate(50000.0, "kg/hr");
+    feed.run();
+
+    Separator separator = new Separator("reordering separator", feed);
+    separator.run();
+    StreamInterface gas = separator.getGasOutStream();
+    SystemInterface reorderedLiquidSystem = separator.getLiquidOutStream().getThermoSystem().clone();
+    assertTrue(reorderedLiquidSystem.getNumberOfPhases() >= 2,
+        "the regression fluid must provide two liquid-outlet phases to reorder");
+    int firstPhysicalPhase = reorderedLiquidSystem.getPhaseIndex(0);
+    int secondPhysicalPhase = reorderedLiquidSystem.getPhaseIndex(1);
+    reorderedLiquidSystem.setPhaseIndex(0, secondPhysicalPhase);
+    reorderedLiquidSystem.setPhaseIndex(1, firstPhysicalPhase);
+    Stream reorderedLiquid = new Stream("reordered liquid", reorderedLiquidSystem);
+
+    StaticPhaseMixer mixer = new StaticPhaseMixer("reordered phase mixer");
+    mixer.addStream(gas);
+    mixer.addStream(reorderedLiquid);
+    mixer.run();
+
+    double inletMass = gas.getFlowRate("kg/hr") + reorderedLiquid.getFlowRate("kg/hr");
+    assertEquals(inletMass, mixer.getOutletStream().getFlowRate("kg/hr"), inletMass * 1.0e-10);
+    assertComponentMassBalance(gas, reorderedLiquid, mixer.getOutletStream());
+    assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("gas"));
+    assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("liquid"));
+    assertTrue(mixer.getOutletStream().getThermoSystem().hasPhaseType("aqueous"));
+  }
+
+  private static SystemInterface createSeparatorFeed(double temperature) {
+    SystemInterface fluid = new SystemSrkEos(temperature, 55.0);
+    fluid.addComponent("nitrogen", 0.010);
+    fluid.addComponent("CO2", 0.025);
+    fluid.addComponent("methane", 0.720);
+    fluid.addComponent("ethane", 0.090);
+    fluid.addComponent("propane", 0.060);
+    fluid.addComponent("i-butane", 0.018);
+    fluid.addComponent("n-butane", 0.025);
+    fluid.addComponent("i-pentane", 0.012);
+    fluid.addComponent("n-pentane", 0.012);
+    fluid.addComponent("n-hexane", 0.010);
+    fluid.addComponent("n-heptane", 0.008);
+    fluid.addComponent("n-octane", 0.005);
+    fluid.addComponent("water", 0.005);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  private static void assertComponentMassBalance(StreamInterface gas, StreamInterface liquid,
+      StreamInterface outlet) {
+    SystemInterface outletSystem = outlet.getThermoSystem();
+    for (int componentIndex = 0; componentIndex < outletSystem.getPhase(0).getNumberOfComponents();
+        componentIndex++) {
+      ComponentInterface outletComponent = outletSystem.getPhase(0).getComponent(componentIndex);
+      String componentName = outletComponent.getName();
+      double inletComponentMass = componentMass(gas.getThermoSystem(), componentName)
+          + componentMass(liquid.getThermoSystem(), componentName);
+      double outletComponentMass = componentMass(outletSystem, componentName);
+      double tolerance = Math.max(1.0e-12, inletComponentMass * 1.0e-10);
+      assertEquals(inletComponentMass, outletComponentMass, tolerance,
+          "component mass must close for " + componentName);
+    }
+  }
+
+  private static double componentMass(SystemInterface system, String componentName) {
+    double mass = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      ComponentInterface component = system.getPhase(phaseIndex).getComponent(componentName);
+      mass += component.getNumberOfMolesInPhase() * component.getMolarMass();
+    }
+    return mass;
+  }
+}


### PR DESCRIPTION
## Summary

- rebuild the static mixed stream from every active inlet phase instead of assuming physical phase slot 0
- preserve gas, hydrocarbon-liquid, aqueous, and supported additional phase inventories in deterministic phase order
- transfer components by name with molar-mass scaling, including sparse TBP and plus-fraction slates
- reset both component inventories and each phase's cached mole total before rebuilding
- preserve low/zero-flow bypass semantics and remove all unconditional stdout diagnostics
- add regressions for the reported separator recombination at 288.15 K and 293.15 K, repeated runs, caller-owned inlet preservation, active-phase reordering, one-phase input, sparse slates, plus-fraction metadata, phase assignment, and finite properties

## Root cause

`StaticPhaseMixer.mixStream()` inspected components through the physical `getPhases()[0]` slot but read active phases through `getPhase(p)`. It then routed only `GAS` and generic `LIQUID`; the separator liquid outlet's active `AQUEOUS` inventory was skipped. The forced `phaseType[0] = LIQUID` also made the result depend on inlet and phase order.

During regression hardening, component fields were initially zeroed directly while the enclosing phase's cached mole total remained stale. Rebuilding through `PhaseInterface.setEmptyFluid()` now clears both bookkeeping layers before any inventory is transferred.

## Validation

- exact 13-component separator recombination regression at 288.15 K and 293.15 K: passed locally
- total and per-component balance, first-run/repeated-run determinism, inlet preservation, active-phase reordering, aqueous phase, sparse components, plus metadata, zero/sub-threshold flow, and stdout/stderr checks: passed locally
- Maven main and test compilation with the cached dependency set: passed
- `git diff --check`: passed
- corrected-path acceptance benchmark (state-changing workload; no comparison or speedup claim):
  - `ProcessSystem`: 7 measured runs, 11.165 ms/run, 49,999.999999999 kg/h checksum
  - four-area `ProcessModel`: 5 measured model runs, 19.907 ms/model-run, 199,999.999999997 kg/h checksum
- GitHub CI is the authoritative full cross-platform suite for the current head

## Documentation impact

Updated the `StaticPhaseMixer` class Javadoc to document phase-preserving, component-identity-based behavior. No public API, units, configuration, or serialization contract changes.

Closes #2806
