### PR TITLE
fix(pipeline): close Lagrangian slug mass audit

### DIFF
--- a/docs/wiki/two_fluid_model_olga_comparison.md
+++ b/docs/wiki/two_fluid_model_olga_comparison.md
@@ -512,6 +512,13 @@ System.out.printf("  Max volume: %.4f m³%n", tracker.getMaxSlugVolumeAtOutlet()
 System.out.printf("  Outlet frequency: %.4f Hz%n", tracker.getOutletSlugFrequency());
 ```
 
+The tracker-level liquid-mass audit is
+`borrowed - returned to Eulerian - exited at outlet - active slug mass`. Use
+`getMassConservationError()` for the residual and
+`getTotalMassExitedAtOutlet()` for the cumulative interval-accounted outlet
+mass. This diagnostic audit is distinct from the conservative phase-resolved
+`TwoFluidMassBalanceReport` produced by `TwoFluidPipe`.
+
 ### Terrain Profile with Slugging
 
 ```java

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/LagrangianSlugTracker.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/LagrangianSlugTracker.java
@@ -299,6 +299,9 @@ public class LagrangianSlugTracker implements Serializable {
   /** Total mass returned to Eulerian field (kg). */
   private double totalMassReturned = 0;
 
+  /** Total tracked slug mass that exited through the pipe outlet (kg). */
+  private double totalMassExitedAtOutlet = 0;
+
   /** Reference mixture velocity (m/s). */
   private double referenceMixtureVelocity = 1.0;
 
@@ -721,6 +724,7 @@ public class LagrangianSlugTracker implements Serializable {
    * @param dt time step (s)
    */
   private void advanceSlug(SlugBubbleUnit slug, PipeSection[] sections, double dt) {
+    double previousSlugLiquidMass = slug.slugLiquidMass;
     slug.age += dt;
 
     // Find section at slug front
@@ -785,6 +789,7 @@ public class LagrangianSlugTracker implements Serializable {
     // Update mass
     double rhoL = frontSection.getLiquidDensity();
     slug.slugLiquidMass = rhoL * slug.slugLiquidVolume;
+    accountSlugMassChange(previousSlugLiquidMass, slug.slugLiquidMass);
 
     // Determine growth/decay state
     double equilibriumLength = calculateEquilibriumLength(frontSection);
@@ -969,6 +974,27 @@ public class LagrangianSlugTracker implements Serializable {
 
     // Net mass rate
     slug.netMassRate = slug.pickupRate - slug.sheddingRate;
+  }
+
+  /**
+   * Account for the actual liquid-mass change implied by the updated slug geometry.
+   *
+   * <p>
+   * The geometric slug state is authoritative because length, area, holdup, and local liquid density can all change in
+   * one time step. A positive change is liquid borrowed from the Eulerian field; a negative change is liquid returned
+   * to it. The pickup and shedding rates remain diagnostic instantaneous rates.
+   * </p>
+   *
+   * @param previousMass liquid mass before the update (kg)
+   * @param currentMass liquid mass after the update (kg)
+   */
+  private void accountSlugMassChange(double previousMass, double currentMass) {
+    double massChange = currentMass - previousMass;
+    if (massChange > 0.0) {
+      totalMassBorrowed += massChange;
+    } else if (massChange < 0.0) {
+      totalMassReturned -= massChange;
+    }
   }
 
   /**
@@ -1180,7 +1206,7 @@ public class LagrangianSlugTracker implements Serializable {
       if (slug.tailPosition > pipeLength) {
         slug.hasExited = true;
         recordSlugAtOutlet(slug);
-        totalMassReturned += slug.slugLiquidMass;
+        totalMassExitedAtOutlet += slug.slugLiquidMass;
         totalSlugsExited++;
         iter.remove();
         continue;
@@ -1603,14 +1629,19 @@ public class LagrangianSlugTracker implements Serializable {
   /**
    * Get mass conservation error.
    *
-   * @return error (kg), should be ~0
+   * <p>
+   * The tracker audit is {@code borrowed - returned - exited - active}. It is separate from the conservative
+   * TwoFluidPipe mass-balance report and should remain near zero throughout tracking.
+   * </p>
+   *
+   * @return tracker accounting error (kg), should be near zero
    */
   public double getMassConservationError() {
     double massInActive = 0;
     for (SlugBubbleUnit slug : slugs) {
       massInActive += slug.slugLiquidMass;
     }
-    return totalMassBorrowed - totalMassReturned - massInActive;
+    return totalMassBorrowed - totalMassReturned - totalMassExitedAtOutlet - massInActive;
   }
 
   /**
@@ -1629,6 +1660,15 @@ public class LagrangianSlugTracker implements Serializable {
    */
   public double getTotalMassReturnedToEulerian() {
     return totalMassReturned;
+  }
+
+  /**
+   * Get total tracked slug liquid mass that exited through the pipe outlet.
+   *
+   * @return cumulative outlet mass (kg)
+   */
+  public double getTotalMassExitedAtOutlet() {
+    return totalMassExitedAtOutlet;
   }
 
   /**
@@ -1677,6 +1717,7 @@ public class LagrangianSlugTracker implements Serializable {
     timeSinceLastInletSlug = 0;
     totalMassBorrowed = 0;
     totalMassReturned = 0;
+    totalMassExitedAtOutlet = 0;
     lastOutletArrivalTime = -1;
     outletSlugLengths.clear();
     outletSlugVolumes.clear();
@@ -1705,6 +1746,7 @@ public class LagrangianSlugTracker implements Serializable {
     sb.append(String.format("Max slug volume at outlet: %.4f m³\n", maxSlugVolumeAtOutlet));
     sb.append(String.format("Mass borrowed: %.3f kg\n", totalMassBorrowed));
     sb.append(String.format("Mass returned: %.3f kg\n", totalMassReturned));
+    sb.append(String.format("Mass exited at outlet: %.3f kg\n", totalMassExitedAtOutlet));
     sb.append(String.format("Mass conservation error: %.6f kg\n", getMassConservationError()));
 
     if (!outletSlugLengths.isEmpty()) {
@@ -1735,6 +1777,9 @@ public class LagrangianSlugTracker implements Serializable {
     sb.append(String.format("  \"averageSlugLength\": %.4f,\n", averageSlugLength));
     sb.append(String.format("  \"maxSlugLength\": %.4f,\n", maxObservedSlugLength));
     sb.append(String.format("  \"maxSlugVolumeAtOutlet\": %.6f,\n", maxSlugVolumeAtOutlet));
+    sb.append(String.format("  \"massBorrowed\": %.9f,\n", totalMassBorrowed));
+    sb.append(String.format("  \"massReturned\": %.9f,\n", totalMassReturned));
+    sb.append(String.format("  \"massExitedAtOutlet\": %.9f,\n", totalMassExitedAtOutlet));
     sb.append(String.format("  \"massConservationError\": %.9f,\n", getMassConservationError()));
     sb.append("  \"activeSlugs\": [\n");
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/LagrangianSlugTrackerTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/LagrangianSlugTrackerTest.java
@@ -283,6 +283,35 @@ class LagrangianSlugTrackerTest {
   }
 
   @Test
+  void testMassConservationClosesAfterTerrainSlugExits() {
+    tracker.setEnableInletSlugGeneration(false);
+    tracker.setEnableStochasticInitiation(false);
+
+    LiquidAccumulationTracker.SlugCharacteristics chars = new LiquidAccumulationTracker.SlugCharacteristics();
+    chars.frontPosition = 98.0;
+    chars.tailPosition = 96.0;
+    chars.length = 2.0;
+    chars.velocity = 2.5;
+    chars.holdup = 0.85;
+    chars.volume = 0.01;
+
+    tracker.initializeTerrainSlug(chars, sections);
+
+    for (int i = 0; i < 100 && tracker.getSlugCount() > 0; i++) {
+      tracker.advanceTimeStep(sections, 0.5);
+    }
+
+    assertEquals(0, tracker.getSlugCount(), "Terrain slug should leave the pipe");
+    assertEquals(1, tracker.getTotalSlugsExited(), "Exactly one terrain slug should exit");
+    assertTrue(tracker.getTotalMassExitedAtOutlet() > 0.0, "Exited slug mass should be recorded separately");
+    assertEquals(0.0, tracker.getMassConservationError(), 1.0e-9,
+        "Tracker mass audit should close after the final slug exits");
+    assertEquals(tracker.getTotalMassBorrowedFromEulerian(),
+        tracker.getTotalMassReturnedToEulerian() + tracker.getTotalMassExitedAtOutlet(), 1.0e-9,
+        "Borrowed mass should equal returned plus exited mass with no active slug");
+  }
+
+  @Test
   void testSlugStatistics() {
     // Disable inlet generation for controlled test
     tracker.setEnableInletSlugGeneration(false);
@@ -367,6 +396,7 @@ class LagrangianSlugTrackerTest {
     assertEquals(0, tracker.getTotalSlugsMerged());
     assertEquals(0, tracker.getTotalSlugsDissipated());
     assertEquals(0, tracker.getTotalSlugsExited());
+    assertEquals(0.0, tracker.getTotalMassExitedAtOutlet());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes the Lagrangian slug tracker's liquid-mass ledger when tracked slug geometry changes and when a slug leaves the pipe outlet.

The previous audit recorded a terrain slug's initial borrowed mass, then recomputed its liquid mass from changing length, area, holdup, and local density without booking the corresponding mass change. On outlet exit it also classified the remaining slug mass as returned to the Eulerian field. The resulting `borrowed - returned - active` residual could remain large after every slug had exited.

This change:

- books positive geometric mass changes as borrowed and negative changes as returned;
- records final tracked slug mass in a separate cumulative outlet-exit ledger;
- defines the audit as `borrowed - returned - exited - active`;
- exposes `getTotalMassExitedAtOutlet()` and includes the three ledger terms in statistics/JSON;
- documents that this tracker diagnostic is distinct from `TwoFluidMassBalanceReport`.

## Regression evidence

A deterministic terrain slug is initialized near the outlet, advanced until it exits, and required to satisfy:

- zero active slugs;
- exactly one outlet exit;
- positive recorded outlet-exit mass;
- tracker residual within `1e-9 kg`;
- `borrowed = returned + exited` when no slug remains active.

## Validation

- `./mvnw -Dtest=LagrangianSlugTrackerTest test -q`
- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`
- Spotless check passed
- Documentation search audit passed: 646 Markdown pages and 1 standalone HTML page

Documentation impact: the existing OLGA-comparison page now defines the tracker audit equation and new outlet-exit getter. No thermodynamic model or public method behavior was changed beyond correcting this diagnostic accounting and adding the new getter.

Fixes #2813