### PR TITLE
feat(pipe): retain time-aligned conservative species history

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -304,12 +304,17 @@ requires both composition and EOS-density residuals to converge.
 
 ```java
 pipe.setConservativeSpeciesTransport(true);
+pipe.setStoreSpeciesConservationHistory(true);
 pipe.setFailOnNonConvergence(true);
 pipe.solveTransient(1);
 
 OnePhaseSpeciesConservationReport species = pipe.getSpeciesConservationReport();
 double[] componentResidualKg = species.getInventoryResidualKg();
 double[][] componentMassFractionByCell = species.getMassFractionProfile();
+
+OnePhaseSpeciesConservationHistory history = pipe.getSpeciesConservationHistory();
+double[] acceptedStepTimesSeconds = history.getElapsedTimeSeconds();
+String pythonReadyHistoryJson = history.toJson();
 ```
 
 `OnePhaseSpeciesConservationReport` exposes component names, physical-cell mass-fraction profiles,
@@ -317,6 +322,17 @@ initial/final component inventories, integrated inlet/outlet component masses, a
 relative inventory residuals, boundedness and sum-to-one diagnostics, thermodynamic
 synchronization error, and hydraulic/species residual histories. Its array getters return
 defensive copies and `toJson()` is suitable for Python-side result capture.
+
+After `setStoreSpeciesConservationHistory(true)`,
+`PipeFlowSystem.getSpeciesConservationHistory()` retains the immutable report from every accepted
+step in the latest multi-step transient solve, aligned with elapsed step-end times in seconds.
+Storage is off by default so long simulations do not retain every component-by-cell profile. The
+history is reset when a new transient solve starts and contains only successfully accepted steps;
+if a later step fails loudly, earlier accepted diagnostics remain available. Its defensive array
+getters and `toJson()` expose distance profiles, outlet breakthrough, component linepack, boundary
+integrals, and cumulative pulse-balance inputs without requiring Python to call one step at a time.
+The history records existing solver evidence and does not change transport equations, tolerances,
+or finite-volume state ownership.
 
 This path has been regression-tested for a single coupled isothermal composition-change step and
 an 1800 s methane/nitrogen pulse through the coupled hydraulic/EOS/species path at positive flow.

--- a/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseSpeciesConservationHistory.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseSpeciesConservationHistory.java
@@ -1,0 +1,97 @@
+package neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport;
+
+/** Immutable time-aligned history of accepted conservative one-phase species reports. */
+public final class OnePhaseSpeciesConservationHistory implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final double[] elapsedTimeSeconds;
+  private final OnePhaseSpeciesConservationReport[] reports;
+
+  private OnePhaseSpeciesConservationHistory(double[] elapsedTimeSeconds, OnePhaseSpeciesConservationReport[] reports) {
+    this.elapsedTimeSeconds = elapsedTimeSeconds.clone();
+    this.reports = reports.clone();
+  }
+
+  /**
+   * Create an empty history for a system that has not completed a conservative transient step.
+   *
+   * @return empty immutable history
+   */
+  public static OnePhaseSpeciesConservationHistory empty() {
+    return new OnePhaseSpeciesConservationHistory(new double[0], new OnePhaseSpeciesConservationReport[0]);
+  }
+
+  OnePhaseSpeciesConservationHistory append(double elapsedSeconds, OnePhaseSpeciesConservationReport report) {
+    if (!Double.isFinite(elapsedSeconds) || elapsedSeconds < 0.0) {
+      throw new IllegalArgumentException("Species-history time must be finite and non-negative: " + elapsedSeconds);
+    }
+    if (report == null) {
+      throw new IllegalArgumentException("Species-history report cannot be null.");
+    }
+    if (elapsedTimeSeconds.length > 0 && elapsedSeconds <= elapsedTimeSeconds[elapsedTimeSeconds.length - 1]) {
+      throw new IllegalArgumentException("Species-history times must increase strictly: previous="
+          + elapsedTimeSeconds[elapsedTimeSeconds.length - 1] + ", next=" + elapsedSeconds);
+    }
+
+    double[] updatedTimes = Arrays.copyOf(elapsedTimeSeconds, elapsedTimeSeconds.length + 1);
+    updatedTimes[updatedTimes.length - 1] = elapsedSeconds;
+    OnePhaseSpeciesConservationReport[] updatedReports = Arrays.copyOf(reports, reports.length + 1);
+    updatedReports[updatedReports.length - 1] = report;
+    return new OnePhaseSpeciesConservationHistory(updatedTimes, updatedReports);
+  }
+
+  /** @return number of accepted conservative transient steps */
+  public int size() {
+    return reports.length;
+  }
+
+  /** @return true when no conservative transient step has completed */
+  public boolean isEmpty() {
+    return reports.length == 0;
+  }
+
+  /** @return defensive copy of elapsed accepted-step end times in seconds */
+  public double[] getElapsedTimeSeconds() {
+    return elapsedTimeSeconds.clone();
+  }
+
+  /** @return defensive copy of immutable per-step reports */
+  public OnePhaseSpeciesConservationReport[] getReports() {
+    return reports.clone();
+  }
+
+  /**
+   * Get one accepted-step report.
+   *
+   * @param index zero-based accepted-step index
+   * @return immutable conservative species report
+   */
+  public OnePhaseSpeciesConservationReport getReport(int index) {
+    return reports[index];
+  }
+
+  /**
+   * Serialize elapsed times and reports as stable, pretty-printed JSON.
+   *
+   * <p>
+   * Non-finite diagnostic values are represented as JSON null rather than invalid JSON tokens.
+   * </p>
+   *
+   * @return JSON representation suitable for Python-side result capture
+   */
+  public String toJson() {
+    JsonSerializer<Double> finiteDoubleSerializer = (value, type,
+        context) -> value != null && Double.isFinite(value) ? new JsonPrimitive(value) : JsonNull.INSTANCE;
+    return new GsonBuilder().registerTypeAdapter(Double.class, finiteDoubleSerializer)
+        .registerTypeAdapter(Double.TYPE, finiteDoubleSerializer).serializeNulls().setPrettyPrinting().create()
+        .toJson(this);
+  }
+}

--- a/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
@@ -18,6 +18,8 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
   private static final long serialVersionUID = 1000;
   private boolean failOnNonConvergence;
   private boolean conservativeSpeciesTransportEnabled;
+  private boolean storeSpeciesConservationHistory;
+  private OnePhaseSpeciesConservationHistory speciesConservationHistory = OnePhaseSpeciesConservationHistory.empty();
 
   /**
    * Constructor for PipeFlowSystem.
@@ -52,6 +54,45 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
       return ((OnePhaseFixedStaggeredGrid) flowSolver).getLastSpeciesConservationReport();
     }
     return OnePhaseSpeciesConservationReport.notRun();
+  }
+
+  /**
+   * Get time-aligned diagnostics for every accepted conservative step in the latest transient solve.
+   *
+   * <p>
+   * The immutable history is reset at the start of each {@link #solveTransient(int, UUID)} call. It contains only steps
+   * that completed successfully, so a fail-loud solve retains diagnostics for any previously accepted steps. Each
+   * report contains component profiles, inventories, boundary masses, residuals, boundedness, and EOS-coupling
+   * diagnostics. {@link OnePhaseSpeciesConservationHistory#toJson()} provides a stable Python capture path.
+   * </p>
+   *
+   * @return immutable accepted-step history, empty before a conservative transient solve
+   */
+  public OnePhaseSpeciesConservationHistory getSpeciesConservationHistory() {
+    return speciesConservationHistory;
+  }
+
+  /**
+   * Configure storage of full per-step conservative species diagnostics.
+   *
+   * <p>
+   * Storage is off by default to avoid retaining every component-by-cell profile in long simulations. Enabling it does
+   * not alter the conservative solve, finite-volume state, or convergence criteria.
+   * </p>
+   *
+   * @param store true to retain one immutable report for every accepted conservative step
+   */
+  public void setStoreSpeciesConservationHistory(boolean store) {
+    storeSpeciesConservationHistory = store;
+  }
+
+  /**
+   * Check whether full accepted-step species diagnostics are retained.
+   *
+   * @return true when per-step report storage is enabled
+   */
+  public boolean isSpeciesConservationHistoryStorageEnabled() {
+    return storeSpeciesConservationHistory;
   }
 
   /**
@@ -172,6 +213,7 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
   public void solveTransient(int type, UUID id) {
     getTimeSeries().init(this);
     display = new PipeFlowVisualization(this.getTotalNumberOfNodes(), getTimeSeries().getTime().length);
+    speciesConservationHistory = OnePhaseSpeciesConservationHistory.empty();
     flowSolver.setDynamic(true);
     configureConvergencePolicy();
     flowSolver.setSolverType(type);
@@ -190,6 +232,10 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
 
       getSolver().setTimeStep(this.getTimeSeries().getTimeStep()[i]);
       flowSolver.solveTDMA();
+      if (conservativeSpeciesTransportEnabled && storeSpeciesConservationHistory) {
+        speciesConservationHistory = speciesConservationHistory.append(getTimeSeries().getTime(i),
+            getSpeciesConservationReport());
+      }
       display.setNextData(this, this.getTimeSeries().getTime(i));
     }
     calcIdentifier = id;

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -3,6 +3,7 @@ package neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Tag;
@@ -86,6 +87,49 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     assertTrue(thirtySecondFront > fifteenSecondFront,
         "A longer first-order implicit step must advance more inlet tracer mass.");
     assertTrue(fifteenSecond.getSpeciesConservationReport().isConverged());
+  }
+
+  @Test
+  void multiStepSolvePublishesTimeAlignedPythonAccessibleHistory() {
+    PipeFlowSystem first = runThreeStepCompositionEvent();
+    PipeFlowSystem repeated = runThreeStepCompositionEvent();
+
+    OnePhaseSpeciesConservationHistory history = first.getSpeciesConservationHistory();
+    assertEquals(3, history.size());
+    assertArrayEquals(new double[] { 30.0, 60.0, 90.0 }, history.getElapsedTimeSeconds(), 0.0);
+    assertEquals(history.toJson(), repeated.getSpeciesConservationHistory().toJson());
+    assertTrue(history.toJson().contains("\"elapsedTimeSeconds\""));
+    assertTrue(history.toJson().contains("\"finalInventoryKg\""));
+
+    double[] returnedTimes = history.getElapsedTimeSeconds();
+    returnedTimes[0] = Double.NaN;
+    assertEquals(30.0, history.getElapsedTimeSeconds()[0], 0.0);
+    OnePhaseSpeciesConservationReport[] returnedReports = history.getReports();
+    returnedReports[0] = null;
+    assertTrue(history.getReport(0).isConverged());
+
+    double[] initialInventory = history.getReport(0).getInitialInventoryKg();
+    double[] finalInventory = history.getReport(history.size() - 1).getFinalInventoryKg();
+    double[] cumulativeInlet = new double[initialInventory.length];
+    double[] cumulativeOutlet = new double[initialInventory.length];
+    for (OnePhaseSpeciesConservationReport report : history.getReports()) {
+      assertTrue(report.isConverged(), report.getMessage());
+      for (int component = 0; component < initialInventory.length; component++) {
+        cumulativeInlet[component] += report.getInletBoundaryMassKg()[component];
+        cumulativeOutlet[component] += report.getOutletBoundaryMassKg()[component];
+      }
+    }
+    for (int component = 0; component < initialInventory.length; component++) {
+      double cumulativeResidual = finalInventory[component] - initialInventory[component] - cumulativeInlet[component]
+          + cumulativeOutlet[component];
+      assertEquals(0.0, cumulativeResidual, Math.max(1.0, initialInventory[component]) * 1.0e-8,
+          "history must telescope the component inventory for component " + component);
+    }
+
+    OnePhaseSpeciesConservationReport latest = first.getSpeciesConservationReport();
+    assertArrayEquals(latest.getFinalInventoryKg(), finalInventory, 0.0);
+    assertArrayEquals(latest.getMassFractionProfile()[1],
+        history.getReport(history.size() - 1).getMassFractionProfile()[1], 0.0);
   }
 
   @Test
@@ -303,6 +347,23 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     pipe.getTimeSeries().setTimes(new double[] { 0.0, timeStep });
     pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] { createGas(0.80, 0.20) });
     pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);
+
+    assertDoesNotThrow(() -> pipe.solveTransient(1));
+    return pipe;
+  }
+
+  private static PipeFlowSystem runThreeStepCompositionEvent() {
+    PipeFlowSystem pipe = createInitializedPipe(12, 3000.0);
+    pipe.setConservativeSpeciesTransport(true);
+    assertFalse(pipe.isSpeciesConservationHistoryStorageEnabled());
+    pipe.setStoreSpeciesConservationHistory(true);
+    assertTrue(pipe.isSpeciesConservationHistoryStorageEnabled());
+    pipe.setFailOnNonConvergence(true);
+    pipe.getTimeSeries().setTimes(new double[] { 0.0, 30.0, 60.0, 90.0 });
+    pipe.getTimeSeries().setInletThermoSystems(
+        new SystemInterface[] { createGas(0.80, 0.20), createGas(0.80, 0.20), createGas(0.95, 0.05) });
+    pipe.getTimeSeries().setNumberOfTimeStepsInInterval(1);
+    pipe.getTimeSeries().setOutletMolarFlowRate(null);
 
     assertDoesNotThrow(() -> pipe.solveTransient(1));
     return pipe;


### PR DESCRIPTION
## Engineering value

A multi-step conservative one-phase composition solve previously retained only the latest `OnePhaseSpeciesConservationReport`. The solver already calculated immutable component-by-cell profiles, inventories, boundary masses, residuals, boundedness, and EOS-coupling diagnostics at every accepted step, but a Python caller could not recover outlet breakthrough or cumulative pulse/linepack evidence after one `solveTransient(...)` call without manually advancing one step at a time.

This change adds an explicitly enabled, immutable, time-aligned history of those existing accepted-step reports. It does not change the finite-volume transport equation, component closure, EOS synchronization, hydraulic solve, tolerances, clipping/normalization behavior, or boundary model.

## Frozen baseline and acceptance criteria

Baseline: `master` `16127ce4da8006e866f98a6ffd334dc3e97d1e9c`, containing merged Stage 1 PR #2803.

Case: SRK/classic methane/nitrogen gas at 288.15 K and 70 bara; 3000 m × 0.5 m isothermal pipe; 50 kg/s; 12 nodes; inlet changes from 5% to 20% nitrogen for two 30 s steps and returns to 5% for one 30 s step.

Source-level baseline limitation: `PipeFlowSystem` exposed only `getSpeciesConservationReport()`, so after the three-step solve only the 90 s report remained addressable.

Frozen criteria:

* accepted history times must be exactly [30, 60, 90] s and strictly increasing;
* every stored report must retain the existing convergence, total/component inventory, boundedness, sum-to-one, thermodynamic synchronization, and EOS-density gates;
* first initial inventory, summed boundary masses, and last final inventory must telescope component-by-component within the existing relative `1e-8` criterion;
* the last history report must be bit-identical to the solver's latest report for final inventory and nitrogen profile;
* repeated identical runs must produce identical JSON;
* returned arrays must be defensive;
* history storage must be opt-in and off by default so normal runtime and memory behavior remain unchanged;
* existing 30-minute pulse/recovery, grid/timestep refinement, closed-outlet, pressure, flow, and convergence regressions must remain green.

## Implementation

* `OnePhaseSpeciesConservationHistory` is immutable and serializable.
* It aligns accepted step-end times in seconds with immutable `OnePhaseSpeciesConservationReport` objects.
* `getElapsedTimeSeconds()` and `getReports()` return defensive copies.
* `toJson()` produces stable Python-ready JSON and represents non-finite diagnostic values as JSON `null`.
* `PipeFlowSystem.setStoreSpeciesConservationHistory(true)` enables retention.
* The history resets at the start of each transient solve and appends only after a step is accepted. If a later fail-loud step throws, diagnostics from earlier accepted steps remain available.
* Default storage is disabled to avoid retaining every component-by-cell profile for long simulations.

## Validation

Local environment: OpenJDK Runtime 17.0.19; NeqSim source at the stated base commit.

Commands:

```bash
HOME=/workspace ./mvnw -q \
  -Dmaven.repo.local=/workspace/scratch/ab308ea4a4a5/maven-repository \
  -Dtest=PipeFlowSystemTest,SinglePhaseGasPipeFlowTest,OnePhaseFlowConvergenceTest,OnePhaseConservativeSpeciesTest,ConservativeSpeciesTransportTest test

HOME=/workspace ./mvnw -q \
  -Dmaven.repo.local=/workspace/scratch/ab308ea4a4a5/maven-repository \
  -Dtest=OnePhaseConservativeSpeciesTest -Dgroups=slow -DexcludedTestGroups= test

pre-commit run --all-files --hook-stage pre-commit
pre-commit run --all-files --hook-stage pre-push
```

Results:

* 56 regular one-phase pipe/convergence/species tests: 0 failures/errors/skips.
* Two slow integrated 30-minute pulse/refinement tests: 0 failures/errors/skips, 28.65 s.
* Spotless apply/check passed.
* Both pre-commit stages passed.
* Documentation search source audit passed: 646 Markdown pages and one standalone HTML page.
* `git diff --check` passed.
* Local Javadoc execution was attempted but unavailable because this runtime contains a JRE without the `javadoc` executable. Exact-head hosted Javadoc and Java 8/21 CI are required before merge readiness.

## Compatibility, performance, and scope

* New public API only; no existing signature or default changes.
* Opt-in storage adds one report reference and elapsed time per accepted step; default performance and memory behavior are unchanged.
* Reports were already created by the solver; this change retains them rather than recomputing physics.
* Positive-flow, one-phase, isothermal conservative-transport limits remain unchanged.
* No TVD, higher-order convection, physical dispersion, thermal coupling, reverse-flow handling, phase appearance, or multiphase transport is added.
* This PR is separate from TwoFluidPipe outlet-flux PR #2816 and has no file overlap.
* No notebook changes: the core Colab example remains dependency-blocked until the one-phase public diagnostics are merged and the numerical grid/timestep values are frozen.

## Documentation impact

Updated `docs/fluidmechanics/single_phase_pipe_flow.md` with opt-in history setup, elapsed-time units, JSON capture, retained profiles/inventories/boundary integrals, fail-loud partial-history semantics, and the default-off memory contract.

## Attempts

1. Initial history API and three-step regression compiled after switching Maven to an available workspace cache; first test exposed a stale two-element legacy outlet array left by steady initialization.
2. Test setup reset the optional outlet array exactly as the production convenience API does; focused history test passed.
3. Critical memory review made full history retention explicitly opt-in; all focused, broader, slow, formatting, pre-commit, and documentation gates passed.

## Next gate

After this PR is merged, record and freeze the actual 6/120 → 12/60 → 24/30 coupled Cauchy error values and use this API for a Python-facing pulse/outlet/linepack integration regression. TVD and physical dispersion remain blocked.