### PR TITLE
fix(tpflash): refine inconsistent trace-aqueous endpoints

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -259,13 +259,13 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Convergence tolerance | 1e-10 | Deviation threshold for K-value convergence |
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
 | Supplementary stability TPD limit | -1e-6 | Accept a converged amplified-K or composition-perturbation trial only when its reduced TPD exceeds that SSI solve's residual/step resolution and the trial composition is non-trivial |
-| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid multiphase overhead for trace-water flashes; existing two-phase aqueous endpoints additionally require `max abs(Delta ln(f_i)) >= 1e-8` or `max abs(Delta z_i) >= 1e-8` before refinement |
+| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i) > 1e-8`, allowing the bounded beta correction below without another stability calculation. |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
 | Cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root assignment only when the existing composition split is already at equilibrium |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
 | Stable-single-phase aqueous-seed gate | `1e-8` in phase-composition normalization | Reject only a structurally invalid aqueous trial whose composition is non-finite, out of `[0, 1]`, or unnormalized; leave normalized endpoints to model-specific convergence and refinement paths |
 | Post-removal aqueous recovery | `1e-8` in `max abs(Delta z_i)` and `max abs(Delta ln(f_i))` | Restore a balanced neutral two-phase aqueous reference only when a rejected third-phase trial leaves the final two-phase endpoint infeasible; genuine three-phase and already feasible endpoints are retained |
-| Final aqueous active-set refinement | water feed `>= 0.01`; at most 3 beta refinements; `1e-8` in phase normalization, `max abs(Delta z_i)`, and `max abs(Delta ln(f_i))` | Preserve the selected neutral two-phase active set while correcting stale beta/compositions after phase cleanup or root selection. Roll back unless the result is feasible; also require no Gibbs increase when the reference material balance was valid. |
+| Final aqueous active-set refinement | water feed `>= 0.01`, or an active aqueous split with `max abs(Delta z_i) > 1e-8`; at most 3 beta refinements; `1e-8` in phase normalization, `max abs(Delta z_i)`, and `max abs(Delta ln(f_i))` | Preserve the selected neutral two-phase active set while correcting stale beta/compositions after phase cleanup or root selection. Trace-water bypass does not run phase search. Roll back unless the result is feasible; also require no Gibbs increase when the reference material balance was valid. |
 | Final neutral gas/oil equilibrium refinement | `1e-8 <= max abs(Delta ln(f_i)) <= 1e-5`; at most 8 SSI updates | Repair only balanced, near-converged vapor-liquid endpoints after post-convergence root handling. Preserve both phase types and roll back unless phase fractions, compositions, material balance, fugacity equality, and Gibbs energy pass the strict acceptance checks. |
 | Stalled three-phase active-set fallback | `1e-8` in phase normalization, material balance, and `max abs(Delta ln(f_i))` | For neutral non-reactive systems only, evaluate each two-phase active set after a non-converged three-phase endpoint and accept the lowest-Gibbs feasible equilibrium only when it also lowers Gibbs energy relative to the stalled state |
 | Water-bearing single-phase-collapse screen | water feed `>= 0.01`, stored water `K < 1e-2`, and a non-water `K > 10` | Run one bounded ordinary-flash retry only after multiphase cleanup returns one phase with strong retained phase-preference evidence; accept only a balanced, distinct two-phase state that lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))` |
@@ -1711,7 +1711,10 @@ Commercial process simulators do not publish all implementation details, but pub
   endpoint is sent to multiphase refinement when `max abs(Delta ln(f_i)) >= 1e-8` or its phase-recombined component
   balance has `max abs(Delta z_i) >= 1e-8`. A feasible candidate normally must lower Gibbs energy; when the reference
   is non-conservative and its Gibbs energy is therefore not comparable, the candidate must instead independently pass
-  phase-fraction, composition-normalization, material-balance, fugacity, and distinct-composition checks.
+  phase-fraction, composition-normalization, material-balance, fugacity, and distinct-composition checks. The 0.01
+  water-feed gate still protects phase-search cost, but an already-active neutral aqueous split with a material residual
+  above `1e-8` may use the existing three-step beta correction below that threshold; this does not search for or create
+  a phase.
 - When the tangent-plane stability path has already accepted a homogeneous state, an unnormalized aqueous trial seed
   cannot replace it. The guard is deliberately structural: each active phase composition must be finite, bounded in
   `[0, 1]`, and normalized within `1e-8`. It does not impose a universal material-balance or fugacity threshold on

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1017,9 +1017,10 @@ public class TPflash extends Flash {
    * stale phase fractions or compositions. The phase set is retained, but component material balance or fugacity
    * equality can then remain outside the ordinary flash tolerance. A {@link TPmultiflash} beta update is phase-order
    * independent and restores the constrained phase split without rerunning stability analysis. The refinement is
-   * attempted only for substantial-water endpoints that already contain exactly one other phase. The pre-refinement
-   * state is retained as a compact snapshot and restored unless the active-set update passes the existing strict
-   * equilibrium and Gibbs checks.
+   * attempted for substantial-water endpoints and for trace-water endpoints whose already-active aqueous split is
+   * non-conservative. The latter bypasses only the water-feed threshold, not phase stability or phase appearance. The
+   * pre-refinement state is retained as a compact snapshot and restored unless the active-set update passes the
+   * existing strict equilibrium and Gibbs checks.
    * </p>
    */
   private void refineInvalidAqueousTwoPhaseEndpoint() {
@@ -1037,7 +1038,11 @@ public class TPflash extends Flash {
       }
     }
     if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
-      return;
+      double preRefinementMaterialResidual = maximumComponentMaterialBalanceResidual(system);
+      if (Double.isFinite(preRefinementMaterialResidual)
+          && preRefinementMaterialResidual <= WATER_RICH_MATERIAL_BALANCE_TOLERANCE) {
+        return;
+      }
     }
 
     system.init(1);

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTraceAqueousRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTraceAqueousRefinementTest.java
@@ -1,0 +1,119 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashTraceAqueousRefinementTest {
+  private static final String[] COMPONENTS = { "nitrogen", "CO2", "methane", "ethane", "propane", "nC10", "water" };
+  private static final double[] WATER_FEED_FRACTIONS = { 1.0e-4, 1.0e-3, 9.0e-3 };
+
+  @Test
+  void traceAqueousEndpointsRemainBalancedAndMatchMultiphaseFlash() {
+    for (boolean usePr : new boolean[] { false, true }) {
+      for (double waterFeedFraction : WATER_FEED_FRACTIONS) {
+        SystemInterface ordinary = createAndFlash(usePr, waterFeedFraction, false);
+        SystemInterface multiphase = createAndFlash(usePr, waterFeedFraction, true);
+
+        assertBalancedEquilibrium(ordinary, waterFeedFraction);
+        assertEquivalentEquilibrium(multiphase, ordinary);
+
+        SystemInterface repeated = ordinary.clone();
+        new ThermodynamicOperations(repeated).TPflash();
+        repeated.init(1);
+        assertEquivalentEquilibrium(ordinary, repeated);
+      }
+    }
+  }
+
+  private SystemInterface createAndFlash(boolean usePr, double waterFeedFraction, boolean multiphaseCheck) {
+    SystemInterface system = usePr ? new SystemPrEos(230.0, 200.0) : new SystemSrkEos(230.0, 200.0);
+    double[] feed = { 0.02, 0.03, 0.859 - waterFeedFraction, 0.06, 0.03, 0.001, waterFeedFraction };
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], feed[componentIndex]);
+    }
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private void assertBalancedEquilibrium(SystemInterface system, double waterFeedFraction) {
+    assertEquals(2, system.getNumberOfPhases());
+    assertTrue(system.hasPhaseType(PhaseType.GAS));
+    assertTrue(system.hasPhaseType(PhaseType.AQUEOUS));
+    assertTrue(maximumComponentMaterialBalanceResidual(system, waterFeedFraction) < 1.0e-8);
+    assertTrue(maximumLogFugacityResidual(system) < 1.0e-8);
+
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      assertTrue(system.getBeta(phaseIndex) > 0.0);
+      assertTrue(system.getBeta(phaseIndex) < 1.0);
+      betaTotal += system.getBeta(phaseIndex);
+
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        compositionTotal += system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-10);
+    }
+    assertEquals(1.0, betaTotal, 1.0e-12);
+  }
+
+  private void assertEquivalentEquilibrium(SystemInterface expected, SystemInterface actual) {
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    for (int phaseIndex = 0; phaseIndex < expected.getNumberOfPhases(); phaseIndex++) {
+      PhaseType phaseType = expected.getPhase(phaseIndex).getType();
+      int actualPhaseIndex = findPhase(actual, phaseType);
+      assertEquals(expected.getBeta(phaseIndex), actual.getBeta(actualPhaseIndex), 1.0e-10);
+      assertEquals(expected.getPhase(phaseIndex).getZ(), actual.getPhase(actualPhaseIndex).getZ(), 1.0e-10);
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        assertEquals(expected.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            actual.getPhase(actualPhaseIndex).getComponent(componentIndex).getx(), 1.0e-10);
+      }
+    }
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-7);
+  }
+
+  private int findPhase(SystemInterface system, PhaseType phaseType) {
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex).getType() == phaseType) {
+        return phaseIndex;
+      }
+    }
+    throw new AssertionError("Missing phase " + phaseType);
+  }
+
+  private double maximumComponentMaterialBalanceResidual(SystemInterface system, double waterFeedFraction) {
+    double[] feed = { 0.02, 0.03, 0.859 - waterFeedFraction, 0.06, 0.03, 0.001, waterFeedFraction };
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      maximumResidual = Math.max(maximumResidual, Math.abs(feed[componentIndex] - recoveredFeed));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double firstLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+    }
+    return maximumResidual;
+  }
+}


### PR DESCRIPTION
## Reproduced problem

The ordinary two-phase TPflash can retain an already-active GAS+AQUEOUS split with trace water below 0.01 feed mole fraction while violating both component material balance and fugacity equality. The final active-set refinement returned before auditing that endpoint solely because the water feed was below the water-rich phase-search threshold.

Minimal deterministic case (mixing rule 2, 230 K, 200 bar):

```text
nitrogen 0.02, CO2 0.03, methane 0.859-water,
ethane 0.06, propane 0.03, nC10 0.001,
water = 0.0001, 0.001, or 0.009
EOS = SRK or PR
```

Exact `master` fails the added regression on the first material-balance assertion.

## Root cause and bounded fix

`refineInvalidAqueousTwoPhaseEndpoint()` applied the 0.01 water-feed threshold before its existing material-balance audit. That threshold is appropriate for phase-search work, but it also suppressed the already-implemented, phase-order-independent `TPmultiflash.solveBeta()` correction when an aqueous phase had already been selected.

The fix adds one O(Ncomponent) material-balance audit. A trace-water endpoint returns early only when that audit is finite and no larger than `1e-8`. An already-active, non-conservative aqueous split can then use the existing maximum of three beta refinements. This does **not** lower the phase-search threshold, run stability analysis, create a phase, change EOS roots, or change public APIs. Existing active-set, normalization, material, fugacity, phase-identity, Gibbs, and rollback gates remain unchanged.

## Method and literature basis

For a fixed active phase set, the correction enforces the same component-balance and equal-fugacity conditions used by NeqSim's multiphase split solver. Preserving the selected active set while accepting only a feasible, non-increasing-Gibbs endpoint is consistent with Michelsen's phase-split formulation: [Michelsen (1982), Fluid Phase Equilibria 9, 1-19](https://doi.org/10.1016/0378-3812%2882%2985002-4).

This PR reuses NeqSim's existing multiphase Rachford-Rice/beta update and safeguards. It does not alter tangent-plane-distance stability testing, accelerated SSI, Newton/trust-region logic, Gibbs minimization, continuation, or phase appearance/disappearance algorithms, and makes no inference about proprietary commercial-simulator internals.

## Before / after accuracy

| EOS | water feed | max material residual before | max fugacity residual before | max material residual after | max fugacity residual after |
|---|---:|---:|---:|---:|---:|
| SRK | 0.0001 | 9.694e-8 | 1.001e-3 | 2.22e-16 | 2.56e-13 |
| SRK | 0.001 | 9.978e-7 | 1.001e-3 | 2.53e-16 | 2.57e-13 |
| SRK | 0.009 | 9.006e-6 | 1.010e-3 | 2.29e-15 | 2.66e-13 |
| PR | 0.0001 | 9.902e-8 | 1.001e-3 | 3.33e-16 | 2.54e-13 |
| PR | 0.001 | 9.999e-7 | 1.002e-3 | 2.54e-16 | 2.54e-13 |
| PR | 0.009 | 9.008e-6 | 1.010e-3 | 2.29e-15 | 2.58e-13 |

The ordinary and multiphase paths match phase types, phase fractions, phase compositions, compressibility factors, and Gibbs energy within the regression's documented tolerances. The initial 0.009 nC10 reproducer was deliberately moved to 0.001 nC10 after Java 8 resolved the higher-heavy-component case as a valid GAS+OIL+AQUEOUS state; the revised case retains the same defect while remaining well inside the two-phase GAS+AQUEOUS region across supported JVMs.

## Deterministic matrix

The reproducible 600-state / 2,400-execution SRK, PR, and CPA matrix covers gas, oil, water, hydrocarbon-water, CO2-rich, hydrogen-rich, near-critical, and large-volatility-contrast feeds over 230-350 K and 1-200 bar. Each state exercises ordinary, repeated, poor-beta-initialized, and multiphase TPflash paths.

| Metric | master | candidate |
|---|---:|---:|
| Exceptions | 0 | 0 |
| Invalid executions | 38 | 32 |
| Comparable multiphase endpoints | 280 | 280 |
| Ordinary/multiphase disagreements | 5 | 3 |
| Repeat differences | 0 | 0 |
| Poor-guess differences | 0 | 0 |

The remaining invalid and disagreement cases are unchanged, visible, and outside this trace-aqueous active-set fix. No general runtime improvement is claimed: total matrix timings varied by JVM run. The component audit runs only for trace-water endpoints after all existing two-phase/aqueous/neutral guards, avoiding any redundant pass for substantial-water endpoints; the beta solver runs only for an already-active, non-conservative endpoint.

## Numerical tolerances

- Candidate phase normalization, beta sum, component material balance, and maximum log-fugacity residual: `1e-8`
- Regression phase fractions, phase compositions, and Z factors across algorithms/repeats: `1e-10`
- Regression Gibbs energy across algorithms/repeats: `1e-7 J`
- At most three existing beta refinements, followed by strict rollback on any failed gate

## Validation

- Java 8-compatible direct production and regression compilation: pass
- Regression demonstrated failing against exact `master`: pass
- Maven focused suite: 7 tests, 0 failures/errors/skips
  - `TPflashTraceAqueousRefinementTest`
  - `TPflashAqueousMaterialBalanceRefinementTest`
  - `TPflashAqueousFinalRefinementTest`
- `pre-commit run --all-files --hook-stage pre-commit`: pass
- `pre-commit run --all-files --hook-stage pre-push`: pass
- Spotless apply/check: pass
- Documentation search coverage: 646 Markdown pages and 1 HTML page, pass
- `git diff --check`: pass
- Previous head: Java 21 Ubuntu/Windows, four slow shards, Javadocs, CodeQL, PaperLab, Spotless, and documentation search passed
- Previous Java 8 jobs exposed the phase-boundary regression input described above; revised exact-head Java 8/21 matrix is pending CI

## Compatibility and risk

The behavior change is restricted to neutral, non-ionic, non-chemical, non-solid, non-wax, exactly-two-phase endpoints that already contain an aqueous phase and have a non-finite or greater-than-`1e-8` material residual. Stable trace-water endpoints continue to return before initialization or beta solving. Substantial-water endpoints do not perform the new pre-initialization audit. Strict state restoration protects endpoints that do not improve.

## Documentation impact

Updated `TPflash_algorithm.md` and the method Javadoc to distinguish the 0.01 phase-search threshold from the bounded beta-only correction for an already-active, non-conservative trace-aqueous split.
