### PR TITLE
fix(column): ignore inactive gates in exact warm reuse

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -16,7 +16,10 @@
 Naphtali-Sandholm exact unchanged-input reuse now requires the active convergence-gate
 configuration to match the snapshot recorded after the accepted public solve. Changing an enforced
 tolerance no longer returns the previous state with zero iterations under a different convergence
-contract. Unchanged gates retain the existing reuse performance.
+contract. Disabled energy and MESH tolerances, plus outer tear tolerances when no tear variable is
+configured, are excluded from the cache key so irrelevant setting changes retain zero-iteration
+reuse.
+
 ## 2026-08-05 — ProcessModel unit-level mass closure is reported again
 
 ### Added

--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -226,11 +226,12 @@ iteration counts, solve times, and fallback notes. For product-specification cas
 `getLastSpecificationHomotopyStepCount()` to confirm whether staged continuation was used.
 
 Exact unchanged-input reuse is conditional on both an identical problem fingerprint and the same
-convergence-gate configuration that was recorded after the accepted public solve. Changing mass,
-energy, MESH, product-draw, specification, or other enforced tolerances disqualifies the
-zero-iteration cache hit. The next invocation executes the solver path and either meets the new
-contract or reports non-convergence explicitly. Rerunning with unchanged gates preserves eligible
-exact reuse.
+active convergence-gate configuration that was recorded after the accepted public solve. Changing
+an enforced mass, energy, MESH, product-draw, specification, or other tolerance disqualifies the
+zero-iteration cache hit. Tolerances for disabled energy and MESH gates, and outer tear tolerances
+when no tear variable is configured, do not participate in the cache key. The next invocation
+executes the solver path after an active-gate change and either meets the new contract or reports
+non-convergence explicitly.
 
 ## Side Draws
 

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2531,7 +2531,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     boolean acceptedStatus = lastSolveStatus == SolveStatus.RIGOROUS_CONVERGED
         || lastSolveStatus == SolveStatus.RECONCILED_PRODUCTS;
     boolean signatureMatches = inputSignature == lastNaphtaliSandholmInputSignature;
-    boolean convergenceGateSignatureMatches = calculateNaphtaliSandholmConvergenceGateSignature() == lastNaphtaliSandholmConvergenceGateSignature;
+    long currentConvergenceGateSignature = calculateNaphtaliSandholmConvergenceGateSignature();
+    boolean convergenceGateSignatureMatches =
+        currentConvergenceGateSignature == lastNaphtaliSandholmConvergenceGateSignature;
     boolean reusable = hasNaphtaliSandholmWarmState && naphtaliSandholmStateOwned
         && lastSolverTypeUsed == SolverType.NAPHTALI_SANDHOLM && acceptedStatus && !isDoInitializion()
         && signatureMatches && convergenceGateSignatureMatches;

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1309,8 +1309,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     hasNaphtaliSandholmWarmState = acceptedNaphtaliSolve;
     if (acceptedNaphtaliSolve) {
       lastNaphtaliSandholmInputSignature = calculateNaphtaliSandholmInputSignature();
-      lastNaphtaliSandholmConvergenceGateSignature =
-          calculateNaphtaliSandholmConvergenceGateSignature();
+      lastNaphtaliSandholmConvergenceGateSignature = calculateNaphtaliSandholmConvergenceGateSignature();
     }
   }
 
@@ -2532,8 +2531,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     boolean acceptedStatus = lastSolveStatus == SolveStatus.RIGOROUS_CONVERGED
         || lastSolveStatus == SolveStatus.RECONCILED_PRODUCTS;
     boolean signatureMatches = inputSignature == lastNaphtaliSandholmInputSignature;
-    boolean convergenceGateSignatureMatches = calculateNaphtaliSandholmConvergenceGateSignature()
-        == lastNaphtaliSandholmConvergenceGateSignature;
+    boolean convergenceGateSignatureMatches = calculateNaphtaliSandholmConvergenceGateSignature() == lastNaphtaliSandholmConvergenceGateSignature;
     boolean reusable = hasNaphtaliSandholmWarmState && naphtaliSandholmStateOwned
         && lastSolverTypeUsed == SolverType.NAPHTALI_SANDHOLM && acceptedStatus && !isDoInitializion()
         && signatureMatches && convergenceGateSignatureMatches;
@@ -2799,8 +2797,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    *
    * <p>
    * This fingerprint is recorded only after the complete public column solve, including coordinated fallback and
-   * product reconciliation. Exact reuse therefore depends on the caller retaining the same convergence contract, not
-   * on mutable residual telemetry from an intermediate solver stage.
+   * product reconciliation. Exact reuse therefore depends on the caller retaining the same convergence contract, not on
+   * mutable residual telemetry from an intermediate solver stage.
    * </p>
    *
    * @return convergence-gate configuration fingerprint
@@ -2809,15 +2807,24 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     long signature = 1125899906842597L;
     signature = updateNaphtaliSandholmInputSignature(signature, getEffectiveTemperatureTolerance());
     signature = updateNaphtaliSandholmInputSignature(signature, getEffectiveMassBalanceTolerance());
-    signature = updateNaphtaliSandholmInputSignature(signature, getEffectiveEnthalpyBalanceTolerance());
     signature = updateNaphtaliSandholmInputSignature(signature, enforceEnergyBalanceTolerance ? 1L : 0L);
-    signature = updateNaphtaliSandholmInputSignature(signature,
-        isEffectiveMeshResidualToleranceEnforced() ? 1L : 0L);
-    signature = updateNaphtaliSandholmInputSignature(signature, meshResidualTolerance);
-    signature = updateNaphtaliSandholmInputSignature(signature, trayMaterialBalanceTolerance);
-    signature = updateNaphtaliSandholmInputSignature(signature, meshProductDrawResidualTolerance);
-    signature = updateNaphtaliSandholmInputSignature(signature, columnTearTolerance);
-    return updateNaphtaliSandholmInputSignature(signature, pumparoundTolerance);
+    if (enforceEnergyBalanceTolerance) {
+      signature = updateNaphtaliSandholmInputSignature(signature, getEffectiveEnthalpyBalanceTolerance());
+    }
+    boolean meshResidualGateEnforced = isEffectiveMeshResidualToleranceEnforced();
+    signature = updateNaphtaliSandholmInputSignature(signature, meshResidualGateEnforced ? 1L : 0L);
+    if (meshResidualGateEnforced) {
+      signature = updateNaphtaliSandholmInputSignature(signature, meshResidualTolerance);
+      signature = updateNaphtaliSandholmInputSignature(signature, trayMaterialBalanceTolerance);
+      signature = updateNaphtaliSandholmInputSignature(signature, meshProductDrawResidualTolerance);
+    }
+    boolean columnTearGateActive = hasActiveColumnTearVariables();
+    signature = updateNaphtaliSandholmInputSignature(signature, columnTearGateActive ? 1L : 0L);
+    if (columnTearGateActive) {
+      signature = updateNaphtaliSandholmInputSignature(signature, columnTearTolerance);
+      signature = updateNaphtaliSandholmInputSignature(signature, pumparoundTolerance);
+    }
+    return signature;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2532,8 +2532,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
         || lastSolveStatus == SolveStatus.RECONCILED_PRODUCTS;
     boolean signatureMatches = inputSignature == lastNaphtaliSandholmInputSignature;
     long currentConvergenceGateSignature = calculateNaphtaliSandholmConvergenceGateSignature();
-    boolean convergenceGateSignatureMatches =
-        currentConvergenceGateSignature == lastNaphtaliSandholmConvergenceGateSignature;
+    boolean convergenceGateSignatureMatches = currentConvergenceGateSignature == lastNaphtaliSandholmConvergenceGateSignature;
     boolean reusable = hasNaphtaliSandholmWarmState && naphtaliSandholmStateOwned
         && lastSolverTypeUsed == SolverType.NAPHTALI_SANDHOLM && acceptedStatus && !isDoInitializion()
         && signatureMatches && convergenceGateSignatureMatches;

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2531,8 +2531,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     boolean acceptedStatus = lastSolveStatus == SolveStatus.RIGOROUS_CONVERGED
         || lastSolveStatus == SolveStatus.RECONCILED_PRODUCTS;
     boolean signatureMatches = inputSignature == lastNaphtaliSandholmInputSignature;
-    long currentConvergenceGateSignature = calculateNaphtaliSandholmConvergenceGateSignature();
-    boolean convergenceGateSignatureMatches = currentConvergenceGateSignature == lastNaphtaliSandholmConvergenceGateSignature;
+    long currentGateSignature = calculateNaphtaliSandholmConvergenceGateSignature();
+    boolean convergenceGateSignatureMatches = currentGateSignature == lastNaphtaliSandholmConvergenceGateSignature;
     boolean reusable = hasNaphtaliSandholmWarmState && naphtaliSandholmStateOwned
         && lastSolverTypeUsed == SolverType.NAPHTALI_SANDHOLM && acceptedStatus && !isDoInitializion()
         && signatureMatches && convergenceGateSignatureMatches;

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -270,7 +270,7 @@ public class DistillationColumnWarmStateCacheTest {
    */
   @Test
   public void inactiveToleranceChangesRetainNaphtaliExactReuse() {
-    for (double feedTemperatureC : new double[] {20.0, 25.0}) {
+    for (double feedTemperatureC : new double[] { 20.0, 25.0 }) {
       DistillationColumn column = buildColumn();
       StreamInterface feed = column.getFeedStreams(3).get(0);
       feed.setTemperature(feedTemperatureC, "C");

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -270,34 +270,39 @@ public class DistillationColumnWarmStateCacheTest {
    */
   @Test
   public void inactiveToleranceChangesRetainNaphtaliExactReuse() {
-    DistillationColumn column = buildColumn();
-    column.setEnforceMeshResidualTolerance(false);
-    column.setEnforceEnergyBalanceTolerance(false);
-    column.run();
-    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    for (double feedTemperatureC : new double[] {20.0, 25.0}) {
+      DistillationColumn column = buildColumn();
+      StreamInterface feed = column.getFeedStreams(3).get(0);
+      feed.setTemperature(feedTemperatureC, "C");
+      feed.run();
+      column.setEnforceMeshResidualTolerance(false);
+      column.setEnforceEnergyBalanceTolerance(false);
+      column.run();
+      assertTrue(column.solved(), column.getConvergenceDiagnostics());
 
-    column.run();
-    assertTrue(column.wasNaphtaliSandholmWarmStateReused());
-    assertEquals(0, column.getLastIterationCount());
-    double gasFlow = column.getGasOutStream().getFlowRate("kg/hr");
-    double liquidFlow = column.getLiquidOutStream().getFlowRate("kg/hr");
+      column.run();
+      assertTrue(column.wasNaphtaliSandholmWarmStateReused());
+      assertEquals(0, column.getLastIterationCount());
+      double gasFlow = column.getGasOutStream().getFlowRate("kg/hr");
+      double liquidFlow = column.getLiquidOutStream().getFlowRate("kg/hr");
 
-    column.setMeshResidualTolerance(column.getMeshResidualTolerance() * 0.5);
-    column.setTrayMaterialBalanceTolerance(column.getTrayMaterialBalanceTolerance() * 0.5);
-    column.setMeshProductDrawResidualTolerance(column.getMeshProductDrawResidualTolerance() * 0.5);
-    column.setEnthalpyBalanceTolerance(column.getEnthalpyBalanceTolerance() * 0.5);
-    column.setColumnTearTolerance(5.0e-5);
-    column.setPumparoundTolerance(5.0e-5);
+      column.setMeshResidualTolerance(column.getMeshResidualTolerance() * 0.5);
+      column.setTrayMaterialBalanceTolerance(column.getTrayMaterialBalanceTolerance() * 0.5);
+      column.setMeshProductDrawResidualTolerance(column.getMeshProductDrawResidualTolerance() * 0.5);
+      column.setEnthalpyBalanceTolerance(column.getEnthalpyBalanceTolerance() * 0.5);
+      column.setColumnTearTolerance(5.0e-5);
+      column.setPumparoundTolerance(5.0e-5);
 
-    assertTrue(column.willReuseNaphtaliSandholmWarmState(),
-        "inactive tolerances are not part of the active convergence contract");
-    column.run();
+      assertTrue(column.willReuseNaphtaliSandholmWarmState(),
+          "inactive tolerances are not part of the active convergence contract");
+      column.run();
 
-    assertTrue(column.wasNaphtaliSandholmWarmStateReused());
-    assertEquals(0, column.getLastIterationCount());
-    assertEquals(gasFlow, column.getGasOutStream().getFlowRate("kg/hr"), 1.0e-9);
-    assertEquals(liquidFlow, column.getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-9);
-    assertPhysicalAndBalanced(column.getFeedStreams(3).get(0), column);
+      assertTrue(column.wasNaphtaliSandholmWarmStateReused());
+      assertEquals(0, column.getLastIterationCount());
+      assertEquals(gasFlow, column.getGasOutStream().getFlowRate("kg/hr"), 1.0e-9);
+      assertEquals(liquidFlow, column.getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-9);
+      assertPhysicalAndBalanced(feed, column);
+    }
   }
 
   /** Molar feed rate used to make identity-only input changes collide with the legacy fingerprint. */

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnWarmStateCacheTest.java
@@ -265,6 +265,41 @@ public class DistillationColumnWarmStateCacheTest {
     assertPhysicalAndBalanced(column.getFeedStreams(3).get(0), column);
   }
 
+  /**
+   * Changing inactive convergence tolerances must not invalidate an otherwise exact cache hit.
+   */
+  @Test
+  public void inactiveToleranceChangesRetainNaphtaliExactReuse() {
+    DistillationColumn column = buildColumn();
+    column.setEnforceMeshResidualTolerance(false);
+    column.setEnforceEnergyBalanceTolerance(false);
+    column.run();
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+
+    column.run();
+    assertTrue(column.wasNaphtaliSandholmWarmStateReused());
+    assertEquals(0, column.getLastIterationCount());
+    double gasFlow = column.getGasOutStream().getFlowRate("kg/hr");
+    double liquidFlow = column.getLiquidOutStream().getFlowRate("kg/hr");
+
+    column.setMeshResidualTolerance(column.getMeshResidualTolerance() * 0.5);
+    column.setTrayMaterialBalanceTolerance(column.getTrayMaterialBalanceTolerance() * 0.5);
+    column.setMeshProductDrawResidualTolerance(column.getMeshProductDrawResidualTolerance() * 0.5);
+    column.setEnthalpyBalanceTolerance(column.getEnthalpyBalanceTolerance() * 0.5);
+    column.setColumnTearTolerance(5.0e-5);
+    column.setPumparoundTolerance(5.0e-5);
+
+    assertTrue(column.willReuseNaphtaliSandholmWarmState(),
+        "inactive tolerances are not part of the active convergence contract");
+    column.run();
+
+    assertTrue(column.wasNaphtaliSandholmWarmStateReused());
+    assertEquals(0, column.getLastIterationCount());
+    assertEquals(gasFlow, column.getGasOutStream().getFlowRate("kg/hr"), 1.0e-9);
+    assertEquals(liquidFlow, column.getLiquidOutStream().getFlowRate("kg/hr"), 1.0e-9);
+    assertPhysicalAndBalanced(column.getFeedStreams(3).get(0), column);
+  }
+
   /** Molar feed rate used to make identity-only input changes collide with the legacy fingerprint. */
   private static final double IDENTITY_TEST_FLOW_MOL_PER_HOUR = 100000.0;
 


### PR DESCRIPTION
## Problem

Merged PR #2807 correctly made Naphtali-Sandholm exact reuse honor the convergence contract, but its fingerprint included tolerance values even when their gates were inactive. A caller changing a disabled MESH or energy tolerance, or an outer tear tolerance on a column with no tear variables, therefore lost a valid zero-iteration cache hit although the mathematical convergence contract had not changed.

## Reproduction and baseline

Baseline: current `master` `7def8e44e20afb67eed7326167626da483466ff5`.

The deterministic six-stage SRK propane/n-butane/n-pentane stripper from `DistillationColumnWarmStateCacheTest` is solved with `NAPHTALI_SANDHOLM`, rerun unchanged, and then given changed stored tolerances while:

- the MESH gate is explicitly disabled;
- the energy gate is disabled;
- no side-draw, pumparound, or hydraulic tear variable is configured.

On unmodified merged source:

- `willReuseNaphtaliSandholmWarmState()`: `false`;
- next invocation: 5 tray iterations;
- product inputs and the active convergence contract are unchanged.

This is an avoidable solver invocation, not a request to loosen a convergence tolerance.

## Change

The convergence-gate fingerprint now always records the active/inactive state of optional gates and records their numeric tolerance only when the gate is active:

- enthalpy tolerance only when energy-balance enforcement is enabled;
- MESH, tray-material, and product-draw tolerances only when the effective MESH gate is enabled;
- column-tear and pumparound tolerances only when an outer tear variable exists.

Temperature and mass gates remain fingerprinted unconditionally. Active-gate changes still invalidate exact reuse exactly as introduced by #2807.

No tray equations, thermodynamic flashes, residual definitions, tolerances, damping, fallback behavior, serialization contract, or public API changes.

## Before / after evidence

| Case | master | candidate |
|---|---:|---:|
| 20 °C feed, inactive tolerance-only change | 5 iterations, no exact reuse | 0 iterations, exact reuse |
| 25 °C nearby feed, inactive tolerance-only change | fingerprint-identical limitation | 0 iterations, exact reuse |
| Active tightened MESH gate regression from #2807 | solver path required | solver path still required |

For both candidate temperatures, overhead and bottoms mass flows are bit-stable to the test's `1e-9 kg/h` absolute comparison, total/component mass balance passes, products remain finite/non-negative, and repeated exact reuse is deterministic.

## Validation

Environment: OpenJDK 17.0.19.

- New focused regression on final two-temperature case: pass.
- `DistillationColumnWarmStateCacheTest` + `DistillationColumnConvergenceGateTest`: pass.
- Entire regular `neqsim.process.equipment.distillation.*Test` package: 150 tests, 0 failures/errors, 1 existing skip.
- Spotless apply/check: pass.
- Exact-head hosted Java 8/21, slow shards, Javadocs, pre-commit, CodeQL, and documentation gates: pending.

No wall-clock speed claim is made; the stable work metric is removal of five unnecessary tray iterations in the reproduced base case while preserving the active-gate invalidation test.

## Compatibility and risk

The change only restores exact reuse after settings that cannot affect the current convergence decision are changed. Enabling a gate, changing an enabled gate, or configuring an outer tear variable changes the fingerprint and forces the solver path. The warm-state fields remain transient, so cloning/serialization behavior is unchanged.

## Documentation impact

Updated the distillation solver guide and agent changelog to define which optional tolerances participate in the cache key. No notebook changed.

## Remaining limitation / next step

The cache uses an exact deterministic configuration fingerprint by design. It does not attempt residual-based reuse under a different active tolerance because post-solver reconciliation can mutate diagnostics; that broader policy remains deliberately conservative.