### PR TITLE
perf(pipe): accumulate species history in linear time

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -331,6 +331,9 @@ history is reset when a new transient solve starts and contains only successfull
 if a later step fails loudly, earlier accepted diagnostics remain available. Its defensive array
 getters and `toJson()` expose distance profiles, outlet breakthrough, component linepack, boundary
 integrals, and cumulative pulse-balance inputs without requiring Python to call one step at a time.
+Accepted reports accumulate in amortized linear time and are copied into one immutable snapshot at
+the end of a successful solve. An explicit getter after a failed solve creates the same immutable
+snapshot from the steps accepted before failure.
 The history records existing solver evidence and does not change transport equations, tolerances,
 or finite-volume state ownership.
 

--- a/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseSpeciesConservationHistory.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseSpeciesConservationHistory.java
@@ -12,12 +12,67 @@ import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolve
 public final class OnePhaseSpeciesConservationHistory implements Serializable {
   private static final long serialVersionUID = 1000L;
 
+  /** Amortized-linear accumulator used while a transient solve is running. */
+  static final class Builder implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private static final int INITIAL_CAPACITY = 16;
+
+    private double[] elapsedTimeSeconds = new double[INITIAL_CAPACITY];
+    private OnePhaseSpeciesConservationReport[] reports = new OnePhaseSpeciesConservationReport[INITIAL_CAPACITY];
+    private int size;
+
+    /**
+     * Append one accepted-step report.
+     *
+     * @param elapsedSeconds finite, non-negative step-end time in seconds, strictly greater than the previous time
+     * @param report non-null immutable conservative species report
+     * @throws IllegalArgumentException if the time or report violates the accepted-history contract
+     */
+    void append(double elapsedSeconds, OnePhaseSpeciesConservationReport report) {
+      if (!Double.isFinite(elapsedSeconds) || elapsedSeconds < 0.0) {
+        throw new IllegalArgumentException("Species-history time must be finite and non-negative: " + elapsedSeconds);
+      }
+      if (report == null) {
+        throw new IllegalArgumentException("Species-history report cannot be null.");
+      }
+      if (size > 0 && elapsedSeconds <= elapsedTimeSeconds[size - 1]) {
+        throw new IllegalArgumentException("Species-history times must increase strictly: previous="
+            + elapsedTimeSeconds[size - 1] + ", next=" + elapsedSeconds);
+      }
+
+      ensureCapacity(size + 1);
+      elapsedTimeSeconds[size] = elapsedSeconds;
+      reports[size] = report;
+      size++;
+    }
+
+    /**
+     * Create an immutable snapshot without changing the accumulated accepted steps.
+     *
+     * @return immutable history snapshot
+     */
+    OnePhaseSpeciesConservationHistory build() {
+      return new OnePhaseSpeciesConservationHistory(Arrays.copyOf(elapsedTimeSeconds, size),
+          Arrays.copyOf(reports, size));
+    }
+
+    private void ensureCapacity(int requiredCapacity) {
+      if (requiredCapacity <= elapsedTimeSeconds.length) {
+        return;
+      }
+      int expandedCapacity = elapsedTimeSeconds.length + (elapsedTimeSeconds.length >> 1);
+      int newCapacity = Math.max(requiredCapacity, expandedCapacity);
+      elapsedTimeSeconds = Arrays.copyOf(elapsedTimeSeconds, newCapacity);
+      reports = Arrays.copyOf(reports, newCapacity);
+    }
+  }
+
   private final double[] elapsedTimeSeconds;
   private final OnePhaseSpeciesConservationReport[] reports;
 
   private OnePhaseSpeciesConservationHistory(double[] elapsedTimeSeconds, OnePhaseSpeciesConservationReport[] reports) {
-    this.elapsedTimeSeconds = elapsedTimeSeconds.clone();
-    this.reports = reports.clone();
+    this.elapsedTimeSeconds = elapsedTimeSeconds;
+    this.reports = reports;
   }
 
   /**
@@ -29,23 +84,8 @@ public final class OnePhaseSpeciesConservationHistory implements Serializable {
     return new OnePhaseSpeciesConservationHistory(new double[0], new OnePhaseSpeciesConservationReport[0]);
   }
 
-  OnePhaseSpeciesConservationHistory append(double elapsedSeconds, OnePhaseSpeciesConservationReport report) {
-    if (!Double.isFinite(elapsedSeconds) || elapsedSeconds < 0.0) {
-      throw new IllegalArgumentException("Species-history time must be finite and non-negative: " + elapsedSeconds);
-    }
-    if (report == null) {
-      throw new IllegalArgumentException("Species-history report cannot be null.");
-    }
-    if (elapsedTimeSeconds.length > 0 && elapsedSeconds <= elapsedTimeSeconds[elapsedTimeSeconds.length - 1]) {
-      throw new IllegalArgumentException("Species-history times must increase strictly: previous="
-          + elapsedTimeSeconds[elapsedTimeSeconds.length - 1] + ", next=" + elapsedSeconds);
-    }
-
-    double[] updatedTimes = Arrays.copyOf(elapsedTimeSeconds, elapsedTimeSeconds.length + 1);
-    updatedTimes[updatedTimes.length - 1] = elapsedSeconds;
-    OnePhaseSpeciesConservationReport[] updatedReports = Arrays.copyOf(reports, reports.length + 1);
-    updatedReports[updatedReports.length - 1] = report;
-    return new OnePhaseSpeciesConservationHistory(updatedTimes, updatedReports);
+  static Builder builder() {
+    return new Builder();
   }
 
   /** @return number of accepted conservative transient steps */

--- a/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
@@ -20,6 +20,7 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
   private boolean conservativeSpeciesTransportEnabled;
   private boolean storeSpeciesConservationHistory;
   private OnePhaseSpeciesConservationHistory speciesConservationHistory = OnePhaseSpeciesConservationHistory.empty();
+  private OnePhaseSpeciesConservationHistory.Builder speciesConservationHistoryBuilder;
 
   /**
    * Constructor for PipeFlowSystem.
@@ -69,7 +70,8 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
    * @return immutable accepted-step history, empty before a conservative transient solve
    */
   public OnePhaseSpeciesConservationHistory getSpeciesConservationHistory() {
-    return speciesConservationHistory;
+    return speciesConservationHistoryBuilder == null ? speciesConservationHistory
+        : speciesConservationHistoryBuilder.build();
   }
 
   /**
@@ -214,6 +216,9 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
     getTimeSeries().init(this);
     display = new PipeFlowVisualization(this.getTotalNumberOfNodes(), getTimeSeries().getTime().length);
     speciesConservationHistory = OnePhaseSpeciesConservationHistory.empty();
+    speciesConservationHistoryBuilder = conservativeSpeciesTransportEnabled && storeSpeciesConservationHistory
+        ? OnePhaseSpeciesConservationHistory.builder()
+        : null;
     flowSolver.setDynamic(true);
     configureConvergencePolicy();
     flowSolver.setSolverType(type);
@@ -232,11 +237,14 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
 
       getSolver().setTimeStep(this.getTimeSeries().getTimeStep()[i]);
       flowSolver.solveTDMA();
-      if (conservativeSpeciesTransportEnabled && storeSpeciesConservationHistory) {
-        speciesConservationHistory = speciesConservationHistory.append(getTimeSeries().getTime(i),
-            getSpeciesConservationReport());
+      if (speciesConservationHistoryBuilder != null) {
+        speciesConservationHistoryBuilder.append(getTimeSeries().getTime(i), getSpeciesConservationReport());
       }
       display.setNextData(this, this.getTimeSeries().getTime(i));
+    }
+    if (speciesConservationHistoryBuilder != null) {
+      speciesConservationHistory = speciesConservationHistoryBuilder.build();
+      speciesConservationHistoryBuilder = null;
     }
     calcIdentifier = id;
   }

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -133,6 +133,31 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  void historyBuilderScalesToManyAcceptedStepsAndPreservesValidation() {
+    OnePhaseSpeciesConservationHistory.Builder builder = OnePhaseSpeciesConservationHistory.builder();
+    OnePhaseSpeciesConservationReport report = OnePhaseSpeciesConservationReport.notRun();
+    builder.append(0.5, report);
+    OnePhaseSpeciesConservationHistory partialHistory = builder.build();
+    int acceptedSteps = 10000;
+    for (int step = 1; step <= acceptedSteps; step++) {
+      builder.append(step, report);
+    }
+
+    OnePhaseSpeciesConservationHistory history = builder.build();
+    assertEquals(1, partialHistory.size());
+    assertEquals(0.5, partialHistory.getElapsedTimeSeconds()[0], 0.0);
+    assertEquals(acceptedSteps + 1, history.size());
+    assertEquals(0.5, history.getElapsedTimeSeconds()[0], 0.0);
+    assertEquals(acceptedSteps, history.getElapsedTimeSeconds()[acceptedSteps], 0.0);
+    assertEquals(report, history.getReport(acceptedSteps));
+
+    assertThrows(IllegalArgumentException.class, () -> builder.append(acceptedSteps, report));
+    assertThrows(IllegalArgumentException.class,
+        () -> OnePhaseSpeciesConservationHistory.builder().append(Double.NaN, report));
+    assertThrows(IllegalArgumentException.class, () -> OnePhaseSpeciesConservationHistory.builder().append(1.0, null));
+  }
+
+  @Test
   void repeatedNodeInitializationDoesNotAccumulateMolarFlowDrift() {
     PipeFlowSystem pipe = createInitializedPipe(24, 3000.0);
     neqsim.fluidmechanics.flownode.FlowNodeInterface node = pipe.getNode(22);


### PR DESCRIPTION
## Engineering value

Merged PR #2817 made conservative one-phase species history available after a multi-step transient solve, but its immutable `append(...)` copied both complete arrays with `Arrays.copyOf` and then cloned both arrays again on every accepted step. That makes opt-in history construction quadratic in the number of timesteps and creates avoidable CPU/GC pressure for realistic long pipeline events.

This follow-up uses a private, serializable primitive-array builder with geometric capacity growth while the solve runs, then creates one immutable snapshot after success. If the solver fails loudly, `getSpeciesConservationHistory()` still creates an immutable snapshot of the previously accepted steps. No finite-volume equation, thermodynamic state, convergence criterion, boundary condition, tolerance, JSON field, or public signature changes.

## Frozen baseline and acceptance criteria

Baseline: merged `master` `641c871677a02a25b0c62c2278b8d286d20e11a4`.

Source-level reproduction: for accepted step `k`, the merged implementation copies `k-1` elements with each `Arrays.copyOf` and then `k` elements with each constructor clone. For 10,000 accepted steps, the two arrays therefore require exactly:

`2 × sum(k=1..10000, 2k-1) = 200,000,000` element copies.

Frozen criteria:

* accepted-step accumulation must be amortized O(n), with only one O(n) immutable snapshot on normal completion;
* a 10,000-step deterministic construction must retain all ordered times and report references;
* non-finite, negative, non-increasing times and null reports must still fail loudly;
* an earlier snapshot must remain immutable after further builder appends;
* the existing three-step JSON, defensive-copy, determinism, final-profile, and component-inventory closure regression must remain unchanged;
* the 30-minute pulse/recovery and 6/120 → 12/60 → 24/30 refinement regressions must remain green;
* Java 8 source compatibility and default-off behavior must remain unchanged.

## Implementation and measurement

The package-private `Builder` owns primitive `double[]` and report-reference arrays, grows capacity by 1.5×, and transfers copies into the immutable history only in `build()`. `PipeFlowSystem` builds once after a successful solve; its getter snapshots the builder on demand after fail-loud interruption.

For 10,000 accepted steps, deterministic array-copy accounting is:

* merged baseline: 200,000,000 copied elements;
* candidate: 61,516 copied elements, including geometric growth and the final snapshot;
* reduction: 99.969%.

The benchmark is structural rather than wall-clock based, so it is deterministic across JVMs and does not weaken physics or correctness gates.

## Validation

Local runtime: OpenJDK 17.0.19; source and branch start exactly at the stated master commit.

```bash
./mvnw -q -Dmaven.repo.local=<cache> spotless:apply
./mvnw -q -Dmaven.repo.local=<cache> spotless:check
./mvnw -q -Dmaven.repo.local=<cache> \
  -Dtest=PipeFlowSystemTest,SinglePhaseGasPipeFlowTest,OnePhaseFlowConvergenceTest,OnePhaseConservativeSpeciesTest,ConservativeSpeciesTransportTest test
./mvnw -q -Dmaven.repo.local=<cache> \
  -Dtest=OnePhaseConservativeSpeciesTest -Dgroups=slow -DexcludedTestGroups= test
python3 devtools/check_documentation_search.py
git diff --check
```

Results:

* 57 regular/focused tests: zero failures, errors, or skips.
* Two slow integrated 30-minute pulse/refinement tests: zero failures/errors/skips, 27.003 s.
* Focused two-test builder/history run: zero failures/errors/skips, 2.126 s.
* Spotless apply/check passed.
* Documentation search passed for 646 Markdown pages and one standalone HTML page.
* Diff check passed.
* The `pre-commit` executable is not installed in this runtime; its repository-local Spotless and documentation hook commands were run directly and passed.
* Local Javadoc remains unavailable because this runtime has no `javadoc` executable; hosted exact-head Javadoc and Java 8/21 CI are required before readiness.

## Compatibility, scope, and limits

* No public API removal or default change; the removed `append` method was package-private.
* The builder is serializable because `PipeFlowSystem` is serializable.
* Completed histories remain immutable and defensive.
* Normal history storage is still opt-in and off by default.
* No species transport, hydraulic/EOS, pressure/flow, TVD, dispersion, phase, thermal, low-flow, or reverse-flow behavior changes.
* No notebook changes; the authoritative Colab example remains blocked on frozen coupled Cauchy values and Python integration.

## Documentation impact

The single-phase pipe guide now states amortized-linear accumulation, one normal-completion snapshot, and fail-loud partial-history snapshot behavior. The builder append contract explicitly documents time/report validity and its exception.

## Review history and next gate

This directly addresses both unresolved Copilot threads on merged PR #2817: the missing append-contract Javadoc and the O(n²) accumulation. After this PR passes all exact-head CI/review gates and is merged, the next Stage 2 gate remains freezing the actual 6/120 → 12/60 → 24/30 coupled Cauchy error values and exercising this history through Python before any TVD or physical-dispersion work.