### PR TITLE
perf(optimizer): sample evaluation callbacks once

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,19 @@
 
 ---
 
+## 2026-08-05 — External process evaluators sample result callbacks once
+
+- `ProcessSimulationEvaluator.evaluate(...)` and `ProcessModelSimulationEvaluator.evaluate(...)`
+  now invoke each registered objective and constraint callback exactly once per completed
+  simulation point.
+- Raw and minimizer-sign objectives reuse one scalar. Constraint value, margin, feasibility, and
+  penalty likewise reuse one scalar, avoiding repeated report or serialization work and preventing
+  internally inconsistent results from mutable diagnostics.
+- Direct calls to objective and constraint definition methods retain their existing behavior and
+  public signatures.
+
+---
+
 ## 2026-08-05 — TwoFluidPipe transient thermal-energy closure
 
 - The multilayer cooldown path now removes fluid energy with the same instantaneous fluid-to-first-layer flux that

--- a/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
+++ b/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
@@ -123,6 +123,13 @@ Process restrictions that must be satisfied:
 - **Range**: lower ≤ g(x) ≤ upper
 - **Equality**: g(x) = target ± tolerance
 
+For both `ProcessSimulationEvaluator` and `ProcessModelSimulationEvaluator`, one completed
+`evaluate(...)` call samples each objective and constraint callback exactly once after the
+simulation. Raw and sign-adjusted objectives, plus constraint values, margins, feasibility, and
+penalties, are derived from those same scalar samples. This matters when result extraction includes
+costly reporting or serialization and prevents inconsistent fields when a callback reads mutable
+diagnostics. Callbacks should nevertheless remain side-effect free.
+
 ## Java Setup
 
 ```java

--- a/docs/util/optimizer_guide.md
+++ b/docs/util/optimizer_guide.md
@@ -549,6 +549,12 @@ double[] constraintMargins =
     evaluator.getConstraintMarginVector(process);
 ```
 
+One completed `evaluate(...)` call samples every registered objective and constraint callback
+exactly once after the process run. The evaluator derives the minimizer sign, constraint margin,
+feasibility, and penalty from that sampled scalar. This keeps one `EvaluationResult` internally
+consistent and avoids repeating expensive result extraction. Callbacks should still be free of
+side effects because optimizers evaluate many distinct simulation points.
+
 ### Constraint Conversion Between Layers
 
 Constraints can be converted between the internal and external optimizer representations:

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
@@ -435,8 +435,7 @@ public class ProcessModelSimulationEvaluator implements Serializable {
      * @return sign-adjusted objective value
      */
     public double evaluate(ProcessModel model) {
-      double value = evaluateRaw(model);
-      return direction == Direction.MAXIMIZE ? -value : value;
+      return toMinimizerValue(evaluateRaw(model));
     }
 
     /**
@@ -450,6 +449,16 @@ public class ProcessModelSimulationEvaluator implements Serializable {
         throw new IllegalStateException("Objective evaluator is not set for " + name);
       }
       return evaluator.applyAsDouble(model);
+    }
+
+    /**
+     * Applies the minimizer sign convention to an already sampled objective value.
+     *
+     * @param rawValue raw objective value
+     * @return sign-adjusted objective value
+     */
+    private double toMinimizerValue(double rawValue) {
+      return direction == Direction.MAXIMIZE ? -rawValue : rawValue;
     }
   }
 
@@ -796,7 +805,16 @@ public class ProcessModelSimulationEvaluator implements Serializable {
      * @return positive margin when satisfied and negative margin when violated
      */
     public double margin(ProcessModel model) {
-      double value = evaluate(model);
+      return marginFromValue(evaluate(model));
+    }
+
+    /**
+     * Computes the constraint margin from an already sampled value.
+     *
+     * @param value sampled constraint value
+     * @return positive margin when satisfied and negative margin when violated
+     */
+    private double marginFromValue(double value) {
       switch (type) {
       case LOWER_BOUND:
         return value - lowerBound;
@@ -828,7 +846,16 @@ public class ProcessModelSimulationEvaluator implements Serializable {
      * @return zero when satisfied, otherwise a positive quadratic penalty
      */
     public double penalty(ProcessModel model) {
-      double margin = margin(model);
+      return penaltyFromMargin(margin(model));
+    }
+
+    /**
+     * Computes the violation penalty from an already derived margin.
+     *
+     * @param margin sampled constraint margin
+     * @return zero when satisfied, otherwise a positive quadratic penalty
+     */
+    private double penaltyFromMargin(double margin) {
       if (margin >= 0.0) {
         return 0.0;
       }
@@ -1907,6 +1934,12 @@ public class ProcessModelSimulationEvaluator implements Serializable {
   /**
    * Evaluates the process model at the supplied parameter values.
    *
+   * <p>
+   * Each registered objective and constraint callback is sampled exactly once after the model run. Raw and
+   * sign-adjusted objectives, and constraint values, margins, feasibility, and penalties, are derived from those same
+   * samples.
+   * </p>
+   *
    * @param parameterValues parameter vector with length equal to {@link #getParameterCount()}
    * @return complete evaluation result
    */
@@ -1933,8 +1966,9 @@ public class ProcessModelSimulationEvaluator implements Serializable {
       double[] objectiveValues = new double[objectives.size()];
       double[] rawObjectiveValues = new double[objectives.size()];
       for (int objectiveIndex = 0; objectiveIndex < objectives.size(); objectiveIndex++) {
-        rawObjectiveValues[objectiveIndex] = objectives.get(objectiveIndex).evaluateRaw(processModel);
-        objectiveValues[objectiveIndex] = objectives.get(objectiveIndex).evaluate(processModel);
+        ObjectiveDefinition objective = objectives.get(objectiveIndex);
+        rawObjectiveValues[objectiveIndex] = objective.evaluateRaw(processModel);
+        objectiveValues[objectiveIndex] = objective.toMinimizerValue(rawObjectiveValues[objectiveIndex]);
       }
       result.setObjectives(objectiveValues);
       result.setObjectivesRaw(rawObjectiveValues);
@@ -1946,9 +1980,9 @@ public class ProcessModelSimulationEvaluator implements Serializable {
       for (int constraintIndex = 0; constraintIndex < constraints.size(); constraintIndex++) {
         ConstraintDefinition constraint = constraints.get(constraintIndex);
         constraintValues[constraintIndex] = constraint.evaluate(processModel);
-        margins[constraintIndex] = constraint.margin(processModel);
+        margins[constraintIndex] = constraint.marginFromValue(constraintValues[constraintIndex]);
         if (margins[constraintIndex] < 0.0) {
-          penaltySum += constraint.penalty(processModel);
+          penaltySum += constraint.penaltyFromMargin(margins[constraintIndex]);
           if (constraint.isHard()) {
             feasible = false;
           }

--- a/src/main/java/neqsim/process/util/optimizer/ProcessSimulationEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessSimulationEvaluator.java
@@ -319,8 +319,7 @@ public class ProcessSimulationEvaluator implements Serializable {
      * @return objective value (sign-adjusted for minimization)
      */
     public double evaluate(ProcessSystem process) {
-      double value = evaluator.applyAsDouble(process);
-      return direction == Direction.MAXIMIZE ? -value : value;
+      return toMinimizerValue(evaluator.applyAsDouble(process));
     }
 
     /**
@@ -331,6 +330,16 @@ public class ProcessSimulationEvaluator implements Serializable {
      */
     public double evaluateRaw(ProcessSystem process) {
       return evaluator.applyAsDouble(process);
+    }
+
+    /**
+     * Applies the minimizer sign convention to an already sampled objective value.
+     *
+     * @param rawValue raw objective value
+     * @return sign-adjusted objective value
+     */
+    private double toMinimizerValue(double rawValue) {
+      return direction == Direction.MAXIMIZE ? -rawValue : rawValue;
     }
   }
 
@@ -499,7 +508,16 @@ public class ProcessSimulationEvaluator implements Serializable {
      */
     @Override
     public double margin(ProcessSystem process) {
-      double value = evaluate(process);
+      return marginFromValue(evaluate(process));
+    }
+
+    /**
+     * Calculates the constraint margin from an already sampled value.
+     *
+     * @param value sampled constraint value
+     * @return constraint margin
+     */
+    private double marginFromValue(double value) {
       switch (type) {
       case LOWER_BOUND:
         return value - lowerBound;
@@ -533,11 +551,20 @@ public class ProcessSimulationEvaluator implements Serializable {
      */
     @Override
     public double penalty(ProcessSystem process) {
-      double m = margin(process);
-      if (m >= 0) {
+      return penaltyFromMargin(margin(process));
+    }
+
+    /**
+     * Calculates the violation penalty from an already derived margin.
+     *
+     * @param margin sampled constraint margin
+     * @return penalty (0 if satisfied, positive if violated)
+     */
+    private double penaltyFromMargin(double margin) {
+      if (margin >= 0) {
         return 0.0;
       }
-      return penaltyWeight * m * m;
+      return penaltyWeight * margin * margin;
     }
 
     /** {@inheritDoc} */
@@ -1151,6 +1178,12 @@ public class ProcessSimulationEvaluator implements Serializable {
    * <li>Returns a complete result object</li>
    * </ol>
    *
+   * <p>
+   * Each registered objective and constraint callback is sampled exactly once after the simulation. Raw and
+   * sign-adjusted objectives, and constraint values, margins, feasibility, and penalties, are derived from those same
+   * samples.
+   * </p>
+   *
    * @param x array of parameter values (length must match parameter count)
    * @return evaluation result with objectives, constraints, and feasibility
    */
@@ -1182,8 +1215,9 @@ public class ProcessSimulationEvaluator implements Serializable {
       double[] objValues = new double[objectives.size()];
       double[] objRaw = new double[objectives.size()];
       for (int i = 0; i < objectives.size(); i++) {
-        objRaw[i] = objectives.get(i).evaluateRaw(process);
-        objValues[i] = objectives.get(i).evaluate(process);
+        ObjectiveDefinition objective = objectives.get(i);
+        objRaw[i] = objective.evaluateRaw(process);
+        objValues[i] = objective.toMinimizerValue(objRaw[i]);
       }
       result.setObjectives(objValues);
       result.setObjectivesRaw(objRaw);
@@ -1194,11 +1228,12 @@ public class ProcessSimulationEvaluator implements Serializable {
       double penaltySum = 0.0;
       boolean feasible = true;
       for (int i = 0; i < constraints.size(); i++) {
-        constraintVals[i] = constraints.get(i).evaluate(process);
-        margins[i] = constraints.get(i).margin(process);
+        ConstraintDefinition constraint = constraints.get(i);
+        constraintVals[i] = constraint.evaluate(process);
+        margins[i] = constraint.marginFromValue(constraintVals[i]);
         if (margins[i] < 0) {
           feasible = false;
-          penaltySum += constraints.get(i).penalty(process);
+          penaltySum += constraint.penaltyFromMargin(margins[i]);
         }
       }
       result.setConstraintValues(constraintVals);

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
@@ -130,6 +130,30 @@ class ProcessModelSimulationEvaluatorTest {
   }
 
   /**
+   * Verifies that one completed model point samples each user result callback once.
+   */
+  @Test
+  void evaluateSamplesEachResultCallbackOnce() {
+    ModelFixture fixture = createModelFixture();
+    ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    AtomicInteger objectiveCalls = new AtomicInteger();
+    AtomicInteger constraintCalls = new AtomicInteger();
+    evaluator.addObjective("statefulObjective", model -> 42.0 + objectiveCalls.getAndIncrement(),
+        ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE);
+    evaluator.addConstraintUpperBound("statefulConstraint", model -> 11.0 + constraintCalls.getAndIncrement(), 10.0);
+
+    ProcessModelSimulationEvaluator.EvaluationResult result = evaluator.evaluate(new double[0]);
+
+    assertEquals(1, objectiveCalls.get(), "one simulated point must sample each objective once");
+    assertEquals(1, constraintCalls.get(), "one simulated point must sample each constraint once");
+    assertEquals(42.0, result.getObjectivesRaw()[0], 0.0);
+    assertEquals(-42.0, result.getObjectives()[0], 0.0);
+    assertEquals(11.0, result.getConstraintValues()[0], 0.0);
+    assertEquals(-1.0, result.getConstraintMargins()[0], 0.0);
+    assertEquals(1000.0, result.getPenaltySum(), 0.0);
+  }
+
+  /**
    * Verifies installed capacity discovery and active bottleneck reporting across model areas.
    */
   @Test

--- a/src/test/java/neqsim/process/util/optimizer/ProcessSimulationEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessSimulationEvaluatorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.separator.Separator;
@@ -498,5 +499,24 @@ class ProcessSimulationEvaluatorTest {
     // For MAXIMIZE, the returned objective should be negated
     assertTrue(result.getObjective() < 0); // Negated for minimization form
     assertTrue(result.getObjectivesRaw()[0] > 0); // Raw value is positive
+  }
+
+  @Test
+  void evaluateSamplesEachResultCallbackOnce() {
+    AtomicInteger objectiveCalls = new AtomicInteger();
+    AtomicInteger constraintCalls = new AtomicInteger();
+    evaluator.addObjective("statefulObjective", process -> 42.0 + objectiveCalls.getAndIncrement(),
+        ProcessSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE);
+    evaluator.addConstraintUpperBound("statefulConstraint", process -> 11.0 + constraintCalls.getAndIncrement(), 10.0);
+
+    ProcessSimulationEvaluator.EvaluationResult result = evaluator.evaluate(new double[0]);
+
+    assertEquals(1, objectiveCalls.get(), "one simulated point must sample each objective once");
+    assertEquals(1, constraintCalls.get(), "one simulated point must sample each constraint once");
+    assertEquals(42.0, result.getObjectivesRaw()[0], 0.0);
+    assertEquals(-42.0, result.getObjectives()[0], 0.0);
+    assertEquals(11.0, result.getConstraintValues()[0], 0.0);
+    assertEquals(-1.0, result.getConstraintMargins()[0], 0.0);
+    assertEquals(1000.0, result.getPenaltySum(), 0.0);
   }
 }


### PR DESCRIPTION
## Summary

Samples each registered objective and constraint callback exactly once after one completed process-simulation point in both:

- `ProcessSimulationEvaluator`
- `ProcessModelSimulationEvaluator`

The raw objective is reused for minimizer sign adjustment. The sampled constraint value is reused for its reported value, margin, feasibility, and penalty.

Closes #2812.

## Root cause

`evaluate(...)` previously called every objective through both `evaluateRaw(...)` and `evaluate(...)`. A violated constraint was sampled once for its reported value, again for its margin, and a third time while calculating its penalty.

Besides duplicate work, mutable or lazy diagnostics could produce internally inconsistent fields in one `EvaluationResult`.

## Reproducible baseline and regression

The new deterministic regressions use one maximizing objective and one violated upper-bound constraint backed by counters.

| Result | `master` | This PR |
|---|---:|---:|
| Objective callback calls | 2 | 1 |
| Violated-constraint callback calls | 3 | 1 |
| Raw objective | 42.0 | 42.0 |
| Minimizer objective | inconsistent for a stateful callback | -42.0 |
| Constraint value | 11.0 | 11.0 |
| Margin | inconsistent for a stateful callback | -1.0 |
| Penalty | inconsistent for a stateful callback | 1000.0 |

The regressions fail against exact base `641c871677a02a25b0c62c2278b8d286d20e11a4` and pass on this head.

## Benchmark

OpenJDK 17, fresh JVM for every baseline/candidate sample, alternating execution order, rich ten-component SRK/classic gas at 50,000 kg/h and 70 bara.

The `ProcessSystem` workload is `Stream -> Heater -> ThrottlingValve -> Separator`. The `ProcessModel` workload contains four nearby-temperature copies. Objective and violated-constraint callbacks each build the normal JSON report before returning stable scalars, representing result extraction with reporting/serialization overhead.

Seven interleaved pairs used 8 warmups/30 measured evaluations for `ProcessSystem` and 4/12 for the four-area `ProcessModel`.

| Workload | Baseline median | Candidate median | Median paired gain | Faster pairs |
|---|---:|---:|---:|---:|
| `ProcessSystem` | 18.927 ms/point | 12.055 ms/point | **31.60%** | 7/7 |
| Four-area `ProcessModel` | 80.131 ms/point | 54.158 ms/point | **39.12%** | 6/7 |

Every measured fork returned the identical checksum `95.0000000010000`. A nearby 303.15 K operating point also retained the same baseline/candidate checksum for both workloads.

The gain depends on callback cost. Cheap scalar getters may show little end-to-end speedup, but still avoid duplicate calls and now produce one internally consistent result sample.

## Validation

- 345 tests in `neqsim.process.util.optimizer`: 0 failures, 0 errors, 0 skipped.
- Focused evaluator and unified-constraint tests: 62 tests, all passed.
- Java project compilation passed with the repository's Java 8 source contract.
- `pre-commit run --all-files --hook-stage pre-commit`: passed.
- `pre-commit run --all-files --hook-stage pre-push`: passed.
- Spotless apply/check: passed.
- Documentation search: 646 Markdown pages and one standalone HTML page passed.
- `git diff --check`: passed.
- Local Javadoc was attempted but this runtime has no `javadoc` executable; hosted Javadoc remains a required exact-head gate.

## Compatibility and scientific scope

- No public signature, parameter, bound, unit, default, solver, thermodynamic model, or process topology changes.
- Direct calls to objective/constraint definition methods preserve their existing behavior.
- The change occurs only after a completed simulation and does not alter flashes, physical properties, convergence, phase behavior, mass/energy balances, cloning, serialization format, or thread-safety policy.
- No general simulation speedup is claimed outside evaluator result callbacks.

## Documentation impact

Updated the external-optimizer integration guide, optimizer guide, public method Javadocs, and agent changelog to define the one-sample-per-point contract and side-effect guidance.

## Files

Only the two evaluator implementations, their two focused regression classes, two optimizer guides, and the agent changelog are changed. No notebooks or generated artifacts are included.