### PR TITLE
feat(pipe): expose validated conservative tracking API

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -338,9 +338,10 @@ single-gas-phase inlet system per interval, and a positive number of equal solve
 interval. The authoritative component profiles and outlet accessor are mass fractions; the
 existing `getOutletMoleFraction(...)` remains explicitly molar. Python/JPype callers can pass
 `JArray(JDouble)` and `JArray(SystemInterface)` and read the same report/history objects directly.
-`runTransient(dt, id)` also selects type `1` when conservative mode is enabled and retains every
-internal accepted step from that call. Legacy `setCompositionalTracking(true)` still selects type
-`20` for compatibility and must not be interpreted as the validated conservative path.
+`runTransient(dt, id)` also selects type `1` when conservative mode is enabled. When
+`setStoreSpeciesConservationHistory(true)` is enabled, it retains every internal accepted step from
+that call. Legacy `setCompositionalTracking(true)` still selects type `20` for compatibility and
+must not be interpreted as the validated conservative path.
 
 `OnePhaseSpeciesConservationReport` exposes component names, physical-cell mass-fraction profiles,
 initial/final component inventories, integrated inlet/outlet component masses, absolute and

--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -317,6 +317,31 @@ double[] acceptedStepTimesSeconds = history.getElapsedTimeSeconds();
 String pythonReadyHistoryJson = history.toJson();
 ```
 
+The process-equipment wrapper exposes the same validated path without requiring callers to reach
+into `PipeFlowSystem`:
+
+```java
+OnePhasePipeLine pipeline = new OnePhasePipeLine("export gas", inletStream);
+pipeline.setConservativeCompositionalTracking(true);
+pipeline.setStoreSpeciesConservationHistory(true);
+pipeline.setFailOnNonConvergence(true);
+pipeline.run();
+pipeline.runConservativeTransient(new double[] {0.0, 1800.0, 5400.0},
+    new SystemInterface[] {pulseGas, baselineGas}, 60, UUID.randomUUID());
+
+double[] outletCellMassFraction = pipeline.getConservativeMassFractionProfile("nitrogen");
+String pythonReadyHistoryJson = pipeline.getSpeciesConservationHistory().toJson();
+```
+
+`runConservativeTransient(...)` takes elapsed interval boundaries in seconds, one initialized
+single-gas-phase inlet system per interval, and a positive number of equal solver steps per
+interval. The authoritative component profiles and outlet accessor are mass fractions; the
+existing `getOutletMoleFraction(...)` remains explicitly molar. Python/JPype callers can pass
+`JArray(JDouble)` and `JArray(SystemInterface)` and read the same report/history objects directly.
+`runTransient(dt, id)` also selects type `1` when conservative mode is enabled and retains every
+internal accepted step from that call. Legacy `setCompositionalTracking(true)` still selects type
+`20` for compatibility and must not be interpreted as the validated conservative path.
+
 `OnePhaseSpeciesConservationReport` exposes component names, physical-cell mass-fraction profiles,
 initial/final component inventories, integrated inlet/outlet component masses, absolute and
 relative inventory residuals, boundedness and sum-to-one diagnostics, thermodynamic
@@ -370,11 +395,12 @@ convergence check and does not define an exact analytical solution for the coupl
 case.
 
 Zero or reversed face flow still fails explicitly because an external upwind composition is not
-yet defined. Once enabled, every failed hydraulic/species criterion throws so that a failed
-conservative state cannot advance to another timestep. Full hydraulic/EOS grid-and-timestep
-convergence, thermal coupling, phase appearance, higher-order convection, and physical dispersion
-remain validation gates. The spreading of the present first-order upwind scheme is numerical;
-there is no physical axial-dispersion model.
+yet defined. `OnePhasePipeLine` also performs an independent multiphase TP flash on cloned schedule
+inputs and rejects actual phase appearance before advancing the finite-volume state. Once enabled,
+every failed hydraulic/species criterion throws so that a failed conservative state cannot advance
+to another timestep. Full hydraulic/EOS grid-and-timestep convergence, thermal coupling,
+higher-order convection, and physical dispersion remain validation gates. The spreading of the
+present first-order upwind scheme is numerical; there is no physical axial-dispersion model.
 
 ## Compositional Tracking
 

--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -329,7 +329,7 @@ pipeline.run();
 pipeline.runConservativeTransient(new double[] {0.0, 1800.0, 5400.0},
     new SystemInterface[] {pulseGas, baselineGas}, 60, UUID.randomUUID());
 
-double[] outletCellMassFraction = pipeline.getConservativeMassFractionProfile("nitrogen");
+double[] nitrogenMassFractionProfile = pipeline.getConservativeMassFractionProfile("nitrogen");
 String pythonReadyHistoryJson = pipeline.getSpeciesConservationHistory().toJson();
 ```
 

--- a/docs/wiki/pipeline_flow_equations.md
+++ b/docs/wiki/pipeline_flow_equations.md
@@ -348,19 +348,29 @@ pipe.setNumberOfNodesInLeg(100);
 pipe.setPipeDiameters(new double[] {0.3, 0.3});
 pipe.setLegPositions(new double[] {0.0, 5000.0});
 
-// Enable compositional tracking with TVD scheme
-pipe.setCompositionalTracking(true);
-pipe.setAdvectionScheme(AdvectionScheme.TVD_VAN_LEER);
+// Select the validated, conservative one-phase solver type 1 path
+pipe.setConservativeCompositionalTracking(true);
+pipe.setStoreSpeciesConservationHistory(true);
+pipe.setFailOnNonConvergence(true);
 
 // Run steady-state initialization
 pipe.run();
 
-// Run transient simulation
+// Run transient simulation and retain accepted-step component balances
 UUID id = UUID.randomUUID();
 for (int step = 0; step < 100; step++) {
     pipe.runTransient(1.0, id);  // 1 second time step
 }
+
+OnePhaseSpeciesConservationReport report = pipe.getSpeciesConservationReport();
+double[] componentInventoryResidualKg = report.getInventoryResidualKg();
 ```
+
+This conservative mode uses first-order finite-volume species transport and explicitly fails for
+zero/reversed flow or phase appearance. The older `setCompositionalTracking(true)` mode selects
+staged solver type `20`; it remains source compatible but does not carry the coupled
+hydraulic/EOS/component-conservation validation above. Configured TVD schemes apply only to that
+legacy route and are not a substitute for physical dispersion.
 
 ---
 

--- a/src/main/java/neqsim/process/equipment/pipeline/OnePhasePipeLine.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/OnePhasePipeLine.java
@@ -560,7 +560,7 @@ public class OnePhasePipeLine extends Pipeline {
     for (int interval = 0; interval < inletSystems.length; interval++) {
       SystemInterface inletSystem = inletSystems[interval];
       if (inletSystem == null) {
-        throw new IllegalStateException(
+        throw new IllegalArgumentException(
             "Conservative OnePhasePipeLine requires a non-null inlet system for interval " + interval + ".");
       }
       double inletMassFlowKgPerSecond = inletSystem.getFlowRate("kg/sec");

--- a/src/main/java/neqsim/process/equipment/pipeline/OnePhasePipeLine.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/OnePhasePipeLine.java
@@ -8,9 +8,13 @@ package neqsim.process.equipment.pipeline;
 
 import java.util.UUID;
 import neqsim.fluidmechanics.flowsolver.AdvectionScheme;
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFlowConvergenceReport;
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport;
 import neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem.PipeFlowSystem;
+import neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem.OnePhaseSpeciesConservationHistory;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
  * One-phase pipeline with compositional tracking support.
@@ -21,16 +25,18 @@ import neqsim.thermo.system.SystemInterface;
  * transitions).
  * </p>
  *
- * <h2>Transient Compositional Tracking</h2>
+ * <h2>Validated conservative compositional tracking</h2>
  * <p>
- * For gas switching scenarios, use {@link #setAdvectionScheme(AdvectionScheme)} to select a higher-order scheme that
- * reduces numerical dispersion:
+ * Use {@link #setConservativeCompositionalTracking(boolean)} for the validated one-phase, positive-flow, finite-volume
+ * species path. It uses solver type 1, keeps component inventories authoritative, synchronizes the thermodynamic
+ * composition, and exposes convergence, inventory, profile, and accepted-step history diagnostics.
  * </p>
- * <ul>
- * <li>{@link AdvectionScheme#FIRST_ORDER_UPWIND} - Default, most stable but high dispersion</li>
- * <li>{@link AdvectionScheme#TVD_VAN_LEER} - Recommended for compositional tracking</li>
- * <li>{@link AdvectionScheme#TVD_SUPERBEE} - Sharpest fronts, best for gas switching</li>
- * </ul>
+ * <p>
+ * The older {@link #setCompositionalTracking(boolean)} route selects staged solver type 20. It remains available for
+ * compatibility, but is not the validated conservative hydraulic/EOS path. Higher-order advection schemes configured
+ * through {@link #setAdvectionScheme(AdvectionScheme)} belong to that legacy route and are not applied by the
+ * conservative mode.
+ * </p>
  *
  * <h2>Example: Gas Switching Simulation</h2>
  *
@@ -42,22 +48,18 @@ import neqsim.thermo.system.SystemInterface;
  * pipe.setPipeDiameters(new double[] { 0.3, 0.3 });
  * pipe.setLegPositions(new double[] { 0.0, 5000.0 });
  *
- * // Select TVD scheme for sharp composition fronts
- * pipe.setAdvectionScheme(AdvectionScheme.TVD_VAN_LEER);
- * pipe.setCompositionalTracking(true);
+ * pipe.setConservativeCompositionalTracking(true);
+ * pipe.setStoreSpeciesConservationHistory(true);
+ * pipe.setFailOnNonConvergence(true);
  *
  * // Initialize with steady state
  * pipe.run();
  *
- * // Run transient with changing inlet composition
+ * // Run a three-interval event with changing inlet composition
  * UUID id = UUID.randomUUID();
- * for (int step = 0; step < 100; step++) {
- *   // Update inlet stream composition if needed
- *   pipe.runTransient(1.0, id); // 1 second time step
- *
- *   // Access outlet composition
- *   double methane = pipe.getOutletStream().getFluid().getComponent("methane").getx();
- * }
+ * pipe.runConservativeTransient(new double[] { 0.0, 30.0, 60.0, 90.0 },
+ *     new SystemInterface[] { pulseGas, pulseGas, baselineGas }, 1, id);
+ * String pythonReadyHistory = pipe.getSpeciesConservationHistory().toJson();
  * }</pre>
  *
  * @author esol
@@ -69,6 +71,9 @@ public class OnePhasePipeLine extends Pipeline {
 
   /** Whether to track composition during transient simulation. */
   private boolean compositionalTracking = false;
+
+  /** Whether to use validated conservative species transport with solver type 1. */
+  private boolean conservativeCompositionalTracking = false;
 
   /** Whether the pipe system has been initialized. */
   private boolean initialized = false;
@@ -161,6 +166,117 @@ public class OnePhasePipeLine extends Pipeline {
    */
   public boolean isCompositionalTracking() {
     return compositionalTracking;
+  }
+
+  /**
+   * Enable or disable validated conservative one-phase compositional tracking.
+   *
+   * <p>
+   * When enabled, steady initialization and transient propagation use solver type 1 with component inventories,
+   * hydraulic/EOS coupling, bounded mass fractions, and fail-loud unsupported-flow diagnostics. This mode currently
+   * supports a single gas phase with strictly positive flow. If both legacy and conservative tracking flags are true,
+   * conservative mode takes precedence.
+   * </p>
+   *
+   * @param enable true to use the validated conservative species path
+   */
+  public void setConservativeCompositionalTracking(boolean enable) {
+    conservativeCompositionalTracking = enable;
+    getPipeFlowSystem().setConservativeSpeciesTransport(enable);
+  }
+
+  /**
+   * Check whether validated conservative compositional tracking is enabled.
+   *
+   * @return true when solver type 1 conservative species transport is selected
+   */
+  public boolean isConservativeCompositionalTracking() {
+    return conservativeCompositionalTracking;
+  }
+
+  /**
+   * Configure storage of immutable diagnostics for every accepted conservative step.
+   *
+   * @param store true to retain the full accepted-step history
+   */
+  public void setStoreSpeciesConservationHistory(boolean store) {
+    getPipeFlowSystem().setStoreSpeciesConservationHistory(store);
+  }
+
+  /**
+   * Configure whether failed hydraulic/EOS convergence throws after recording diagnostics.
+   *
+   * @param fail true to fail loudly on non-convergence
+   */
+  public void setFailOnNonConvergence(boolean fail) {
+    getPipeFlowSystem().setFailOnNonConvergence(fail);
+  }
+
+  /**
+   * Get hydraulic/EOS convergence diagnostics from the latest solve.
+   *
+   * @return immutable one-phase convergence report
+   */
+  public OnePhaseFlowConvergenceReport getConvergenceReport() {
+    return getPipeFlowSystem().getConvergenceReport();
+  }
+
+  /**
+   * Get component inventory, boundary-mass, boundedness, and synchronization diagnostics.
+   *
+   * @return immutable report from the latest conservative step
+   */
+  public OnePhaseSpeciesConservationReport getSpeciesConservationReport() {
+    return getPipeFlowSystem().getSpeciesConservationReport();
+  }
+
+  /**
+   * Get time-aligned reports from the latest conservative transient call.
+   *
+   * @return immutable accepted-step history with elapsed times in seconds
+   */
+  public OnePhaseSpeciesConservationHistory getSpeciesConservationHistory() {
+    return getPipeFlowSystem().getSpeciesConservationHistory();
+  }
+
+  /**
+   * Get the authoritative conservative mass-fraction profile for one component.
+   *
+   * <p>
+   * The returned array contains physical finite-volume cells in inlet-to-outlet order. It is distinct from
+   * {@link #getCompositionProfile(String)}, which reconstructs mass fractions from thermodynamic node mole fractions
+   * and includes boundary nodes.
+   * </p>
+   *
+   * @param componentName component name, matched case-insensitively
+   * @return defensive copy of component mass fraction by physical cell
+   * @throws IllegalStateException if conservative species transport has not run
+   * @throws IllegalArgumentException if the component is absent from the report
+   */
+  public double[] getConservativeMassFractionProfile(String componentName) {
+    OnePhaseSpeciesConservationReport report = getSpeciesConservationReport();
+    String[] componentNames = report.getComponentNames();
+    if (componentNames.length == 0) {
+      throw new IllegalStateException("Conservative species transport has not produced a component profile.");
+    }
+    double[][] profiles = report.getMassFractionProfile();
+    for (int component = 0; component < componentNames.length; component++) {
+      if (componentNames[component].equalsIgnoreCase(componentName)) {
+        return profiles[component];
+      }
+    }
+    throw new IllegalArgumentException("Component is absent from conservative species report: " + componentName);
+  }
+
+  /**
+   * Get the authoritative conservative outlet-cell mass fraction for one component.
+   *
+   * @param componentName component name, matched case-insensitively
+   * @return component mass fraction in the final physical cell
+   */
+  public double getConservativeOutletMassFraction(String componentName) {
+    double[] profile = getConservativeMassFractionProfile(componentName);
+    return profile[profile.length - 1];
   }
 
   /**
@@ -287,7 +403,7 @@ public class OnePhasePipeLine extends Pipeline {
     UUID oldid = getCalculationIdentifier();
     super.run(id);
     setCalculationIdentifier(oldid);
-    pipe.solveSteadyState(10, id);
+    pipe.solveSteadyState(conservativeCompositionalTracking ? 1 : 10, id);
     initialized = true;
     simulationTime = 0.0;
 
@@ -315,6 +431,20 @@ public class OnePhasePipeLine extends Pipeline {
    */
   @Override
   public void runTransient(double dt, UUID id) {
+    if (conservativeCompositionalTracking) {
+      if (!Double.isFinite(dt) || dt <= 0.0) {
+        throw new IllegalArgumentException("Conservative transient duration must be finite and positive: " + dt);
+      }
+      if (!Double.isFinite(internalTimeStep) || internalTimeStep <= 0.0) {
+        throw new IllegalStateException(
+            "Conservative internal timestep must be finite and positive: " + internalTimeStep);
+      }
+      int steps = (int) Math.ceil(dt / internalTimeStep);
+      runConservativeTransient(new double[] { 0.0, dt }, new SystemInterface[] { inStream.getThermoSystem().clone() },
+          steps, id);
+      return;
+    }
+
     // Initialize if not already done
     if (!initialized) {
       run(id);
@@ -353,12 +483,100 @@ public class OnePhasePipeLine extends Pipeline {
   }
 
   /**
+   * Run a validated conservative composition schedule in one time-aligned solve.
+   *
+   * <p>
+   * Times are elapsed seconds relative to the start of this call and must begin at zero. Each inlet system applies over
+   * the corresponding interval, so {@code inletSystems.length == elapsedTimesSeconds.length - 1}. Every interval is
+   * divided into {@code stepsPerInterval} equal accepted-step candidates. This shape maps directly to Java arrays from
+   * Python/JPype and retains one report for every accepted step when history storage is enabled.
+   * </p>
+   *
+   * @param elapsedTimesSeconds strictly increasing elapsed interval boundaries beginning at 0 s
+   * @param inletSystems one single-gas-phase inlet system per interval
+   * @param stepsPerInterval positive number of equal solver steps in every interval
+   * @param id calculation identifier
+   * @throws IllegalStateException if conservative mode is disabled or an inlet is not one gas phase
+   * @throws IllegalArgumentException if the schedule is dimensionally invalid
+   */
+  public void runConservativeTransient(double[] elapsedTimesSeconds, SystemInterface[] inletSystems,
+      int stepsPerInterval, UUID id) {
+    validateConservativeSchedule(elapsedTimesSeconds, inletSystems, stepsPerInterval);
+    if (!initialized) {
+      run(id);
+    }
+
+    SystemInterface[] copiedInletSystems = new SystemInterface[inletSystems.length];
+    for (int interval = 0; interval < inletSystems.length; interval++) {
+      copiedInletSystems[interval] = inletSystems[interval].clone();
+    }
+    pipe.getTimeSeries().setTimes(elapsedTimesSeconds.clone());
+    pipe.getTimeSeries().setInletThermoSystems(copiedInletSystems);
+    pipe.getTimeSeries().setNumberOfTimeStepsInInterval(stepsPerInterval);
+    pipe.getTimeSeries().setOutletMolarFlowRate(null);
+    pipe.solveTransient(1, id);
+
+    simulationTime += elapsedTimesSeconds[elapsedTimesSeconds.length - 1];
+    updateOutletStream();
+    outStream.setCalculationIdentifier(id);
+    setCalculationIdentifier(id);
+  }
+
+  /**
    * Update the inlet boundary condition from the current inlet stream.
    */
   private void updateInletBoundary() {
     SystemInterface inletSystem = inStream.getThermoSystem().clone();
     pipe.getNode(0).setBulkSystem(inletSystem);
     pipe.getNode(0).initFlowCalc();
+  }
+
+  private PipeFlowSystem getPipeFlowSystem() {
+    return (PipeFlowSystem) pipe;
+  }
+
+  private void validateConservativeSchedule(double[] elapsedTimesSeconds, SystemInterface[] inletSystems,
+      int stepsPerInterval) {
+    if (!conservativeCompositionalTracking) {
+      throw new IllegalStateException(
+          "Enable conservative compositional tracking before running a conservative schedule.");
+    }
+    if (elapsedTimesSeconds == null || elapsedTimesSeconds.length < 2 || elapsedTimesSeconds[0] != 0.0) {
+      throw new IllegalArgumentException("Conservative elapsed times must contain at least [0.0, endSeconds].");
+    }
+    if (inletSystems == null || inletSystems.length != elapsedTimesSeconds.length - 1) {
+      throw new IllegalArgumentException("Conservative schedule requires one inlet system per time interval.");
+    }
+    if (stepsPerInterval <= 0) {
+      throw new IllegalArgumentException("Conservative steps per interval must be positive: " + stepsPerInterval);
+    }
+    for (int boundary = 0; boundary < elapsedTimesSeconds.length; boundary++) {
+      double time = elapsedTimesSeconds[boundary];
+      if (!Double.isFinite(time) || (boundary > 0 && time <= elapsedTimesSeconds[boundary - 1])) {
+        throw new IllegalArgumentException(
+            "Conservative elapsed times must be finite and strictly increasing at index " + boundary + ".");
+      }
+    }
+    for (int interval = 0; interval < inletSystems.length; interval++) {
+      SystemInterface inletSystem = inletSystems[interval];
+      if (inletSystem == null) {
+        throw new IllegalStateException(
+            "Conservative OnePhasePipeLine requires a non-null inlet system for interval " + interval + ".");
+      }
+      double inletMassFlowKgPerSecond = inletSystem.getFlowRate("kg/sec");
+      if (!Double.isFinite(inletMassFlowKgPerSecond) || inletMassFlowKgPerSecond <= 0.0) {
+        throw new IllegalStateException(
+            "Conservative OnePhasePipeLine currently supports strictly positive inlet mass flow only; invalid "
+                + "interval " + interval + " has " + inletMassFlowKgPerSecond + " kg/s.");
+      }
+      SystemInterface phaseCheck = inletSystem.clone();
+      phaseCheck.setMultiPhaseCheck(true);
+      new ThermodynamicOperations(phaseCheck).TPflash();
+      if (phaseCheck.getNumberOfPhases() != 1 || !phaseCheck.hasPhaseType("gas")) {
+        throw new IllegalStateException(
+            "Conservative OnePhasePipeLine currently supports one gas phase only; invalid interval " + interval + ".");
+      }
+    }
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
@@ -130,7 +130,9 @@ public class OnePhasePipeLineCompositionalTest {
     assertTrue(latest.isConverged(), latest.getMessage());
     assertTrue(pipe.getConvergenceReport().isConverged(), pipe.getConvergenceReport().getMessage());
     assertArrayEquals(latest.getFinalInventoryKg(), history.getReport(2).getFinalInventoryKg(), 0.0);
-    assertArrayEquals(latest.getMassFractionProfile()[1], pipe.getConservativeMassFractionProfile("nitrogen"), 0.0);
+    int nitrogen = componentIndex(latest, "nitrogen");
+    assertArrayEquals(latest.getMassFractionProfile()[nitrogen], pipe.getConservativeMassFractionProfile("nitrogen"),
+        0.0);
     assertTrue(history.toJson().contains("\"elapsedTimeSeconds\""));
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
@@ -1,18 +1,26 @@
 package neqsim.process.equipment.pipeline;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import neqsim.fluidmechanics.flowsolver.AdvectionScheme;
+import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport;
+import neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem.OnePhaseSpeciesConservationHistory;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.mixingrule.EosMixingRulesInterface;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
 import neqsim.thermo.system.SystemSrkEos;
 
 /**
@@ -87,6 +95,149 @@ public class OnePhasePipeLineCompositionalTest {
     // Should be able to enable
     pipe.setCompositionalTracking(true);
     assertTrue(pipe.isCompositionalTracking());
+    assertFalse(pipe.isConservativeCompositionalTracking());
+  }
+
+  @Test
+  @DisplayName("OnePhasePipeLine should expose validated conservative pulse diagnostics")
+  void testValidatedConservativePulseDiagnostics() {
+    SystemInterface baselineGas = createTransmissionGas(0.95, 0.05);
+    SystemInterface pulseGas = createTransmissionGas(0.80, 0.20);
+    Stream inlet = new Stream("conservative inlet", baselineGas);
+    inlet.setFlowRate(50.0, "kg/sec");
+    inlet.run();
+
+    OnePhasePipeLine pipe = createTransmissionPipe(inlet);
+    pipe.setConservativeCompositionalTracking(true);
+    pipe.setStoreSpeciesConservationHistory(true);
+    pipe.setFailOnNonConvergence(true);
+
+    UUID id = UUID.randomUUID();
+    pipe.run(id);
+    pipe.runConservativeTransient(new double[] { 0.0, 30.0, 60.0, 90.0 },
+        new SystemInterface[] { pulseGas, pulseGas, baselineGas }, 1, id);
+
+    OnePhaseSpeciesConservationHistory history = pipe.getSpeciesConservationHistory();
+    assertEquals(3, history.size());
+    assertArrayEquals(new double[] { 30.0, 60.0, 90.0 }, history.getElapsedTimeSeconds(), 0.0);
+    for (OnePhaseSpeciesConservationReport report : history.getReports()) {
+      assertTrue(report.isConverged(), report.getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() <= 1.0e-8, report.getMessage());
+      assertTrue(report.getMaximumThermodynamicMassFractionError() <= 1.0e-10, report.getMessage());
+    }
+
+    OnePhaseSpeciesConservationReport latest = pipe.getSpeciesConservationReport();
+    assertTrue(latest.isConverged(), latest.getMessage());
+    assertTrue(pipe.getConvergenceReport().isConverged(), pipe.getConvergenceReport().getMessage());
+    assertArrayEquals(latest.getFinalInventoryKg(), history.getReport(2).getFinalInventoryKg(), 0.0);
+    assertArrayEquals(latest.getMassFractionProfile()[1], pipe.getConservativeMassFractionProfile("nitrogen"), 0.0);
+    assertTrue(history.toJson().contains("\"elapsedTimeSeconds\""));
+  }
+
+  @Test
+  @DisplayName("Validated conservative tracking should reject phase appearance before advancing")
+  void testValidatedConservativeTrackingRejectsPhaseAppearance() {
+    SystemInterface baselineGas = createTransmissionGas(0.95, 0.05);
+    Stream inlet = new Stream("phase-limit inlet", baselineGas);
+    inlet.setFlowRate(50.0, "kg/sec");
+    inlet.run();
+
+    OnePhasePipeLine pipe = createTransmissionPipe(inlet);
+    pipe.setConservativeCompositionalTracking(true);
+    pipe.setStoreSpeciesConservationHistory(true);
+    pipe.setFailOnNonConvergence(true);
+    pipe.run(UUID.randomUUID());
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class,
+        () -> pipe.runConservativeTransient(new double[] { 0.0, 30.0 },
+            new SystemInterface[] { createKnownGasOilFluid() }, 1, UUID.randomUUID()));
+
+    assertTrue(exception.getMessage().contains("one gas phase only"));
+    assertEquals(0.0, pipe.getSimulationTime(), 0.0, "Rejected phase appearance must not advance the pipeline clock.");
+  }
+
+  @Test
+  @DisplayName("Validated conservative tracking should reject reversed inlet flow before advancing")
+  void testValidatedConservativeTrackingRejectsReversedFlow() {
+    SystemInterface baselineGas = createTransmissionGas(0.95, 0.05);
+    Stream inlet = new Stream("flow-limit inlet", baselineGas);
+    inlet.setFlowRate(50.0, "kg/sec");
+    inlet.run();
+
+    OnePhasePipeLine pipe = createTransmissionPipe(inlet);
+    pipe.setConservativeCompositionalTracking(true);
+    pipe.setStoreSpeciesConservationHistory(true);
+    pipe.setFailOnNonConvergence(true);
+    pipe.run(UUID.randomUUID());
+
+    SystemInterface reversedGas = createTransmissionGas(0.80, 0.20);
+    reversedGas.setTotalFlowRate(-50.0, "kg/sec");
+    IllegalStateException exception = assertThrows(IllegalStateException.class,
+        () -> pipe.runConservativeTransient(new double[] { 0.0, 30.0 }, new SystemInterface[] { reversedGas }, 1,
+            UUID.randomUUID()));
+
+    assertTrue(exception.getMessage().contains("strictly positive inlet mass flow only"));
+    assertEquals(0.0, pipe.getSimulationTime(), 0.0, "Rejected reversed flow must not advance the pipeline clock.");
+  }
+
+  @Test
+  @Tag("slow")
+  @DisplayName("OnePhasePipeLine should conserve a 30-minute pulse and recover")
+  void testValidatedThirtyMinutePulseBreakthroughAndRecovery() {
+    SystemInterface baselineGas = createTransmissionGas(0.95, 0.05);
+    SystemInterface pulseGas = createTransmissionGas(0.80, 0.20);
+    Stream inlet = new Stream("30-minute pulse inlet", baselineGas);
+    inlet.setFlowRate(50.0, "kg/sec");
+    inlet.run();
+
+    OnePhasePipeLine pipe = createTransmissionPipe(inlet);
+    pipe.setConservativeCompositionalTracking(true);
+    pipe.setStoreSpeciesConservationHistory(true);
+    pipe.setFailOnNonConvergence(true);
+
+    UUID id = UUID.randomUUID();
+    pipe.run(id);
+    double baselineOutlet = pipe.getOutletMassFraction("nitrogen");
+    pipe.runConservativeTransient(new double[] { 0.0, 1800.0, 5400.0 }, new SystemInterface[] { pulseGas, baselineGas },
+        60, id);
+
+    OnePhaseSpeciesConservationHistory history = pipe.getSpeciesConservationHistory();
+    assertEquals(120, history.size());
+    assertEquals(30.0, history.getElapsedTimeSeconds()[0], 0.0);
+    assertEquals(1800.0, history.getElapsedTimeSeconds()[59], 0.0);
+    assertEquals(5400.0, history.getElapsedTimeSeconds()[119], 0.0);
+
+    int nitrogen = componentIndex(history.getReport(0), "nitrogen");
+    double initialInventoryKg = history.getReport(0).getInitialInventoryKg()[nitrogen];
+    double cumulativeInletKg = 0.0;
+    double cumulativeOutletKg = 0.0;
+    double pulseEndOutlet = Double.NaN;
+    for (int step = 0; step < history.size(); step++) {
+      OnePhaseSpeciesConservationReport report = history.getReport(step);
+      assertTrue(report.isConverged(), report.getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() <= 1.0e-8, report.getMessage());
+      cumulativeInletKg += report.getInletBoundaryMassKg()[nitrogen];
+      cumulativeOutletKg += report.getOutletBoundaryMassKg()[nitrogen];
+      if (step == 59) {
+        pulseEndOutlet = last(report.getMassFractionProfile()[nitrogen]);
+      }
+    }
+
+    OnePhaseSpeciesConservationReport lastReport = history.getReport(history.size() - 1);
+    double finalInventoryKg = lastReport.getFinalInventoryKg()[nitrogen];
+    double cumulativeResidualKg = finalInventoryKg - initialInventoryKg - cumulativeInletKg + cumulativeOutletKg;
+    double pulseInletMassFraction = history.getReport(0).getInletBoundaryMassKg()[nitrogen]
+        / sum(history.getReport(0).getInletBoundaryMassKg());
+    double eventAmplitude = pulseInletMassFraction - baselineOutlet;
+    double recoveredOutlet = last(lastReport.getMassFractionProfile()[nitrogen]);
+
+    assertTrue(pulseEndOutlet > baselineOutlet + 0.70 * eventAmplitude,
+        "The 30-minute pulse must break through before the inlet returns to baseline.");
+    assertEquals(baselineOutlet, recoveredOutlet, 2.0e-3 * eventAmplitude);
+    assertEquals(0.0, cumulativeResidualKg, Math.max(Math.max(initialInventoryKg, cumulativeInletKg), 1.0) * 1.0e-7);
+    logger.info(
+        "Conservative OnePhasePipeLine pulse: baseline outlet={}, pulse-end outlet={}, recovered outlet={}, cumulative nitrogen residual={} kg",
+        baselineOutlet, pulseEndOutlet, recoveredOutlet, cumulativeResidualKg);
   }
 
   @Test
@@ -269,5 +420,62 @@ public class OnePhasePipeLineCompositionalTest {
     logger.info("  - TVD_VAN_LEER: Best balance of accuracy and stability");
     logger.info("  - TVD_SUPERBEE: Sharpest fronts, use for critical tracking");
     logger.info("  - FIRST_ORDER_UPWIND: Use only for coarse/quick estimates");
+  }
+
+  private static OnePhasePipeLine createTransmissionPipe(Stream inlet) {
+    OnePhasePipeLine pipe = new OnePhasePipeLine("3 km conservative gas pipe", inlet);
+    pipe.setNumberOfLegs(1);
+    pipe.setNumberOfNodesInLeg(12);
+    pipe.setPipeDiameters(new double[] { 0.5, 0.5 });
+    pipe.setLegPositions(new double[] { 0.0, 3000.0 });
+    pipe.setHeightProfile(new double[] { 0.0, 0.0 });
+    pipe.setPipeWallRoughness(new double[] { 1.0e-5, 1.0e-5 });
+    pipe.setOuterTemperatures(new double[] { 288.15, 288.15 });
+    return pipe;
+  }
+
+  private static SystemInterface createTransmissionGas(double methaneMoleFraction, double nitrogenMoleFraction) {
+    SystemInterface gas = new SystemSrkEos(288.15, 70.0);
+    gas.addComponent("methane", methaneMoleFraction);
+    gas.addComponent("nitrogen", nitrogenMoleFraction);
+    gas.createDatabase(true);
+    gas.setMixingRule("classic");
+    gas.setTotalFlowRate(50.0, "kg/sec");
+    gas.init(0);
+    gas.init(1);
+    return gas;
+  }
+
+  private static SystemInterface createKnownGasOilFluid() {
+    SystemInterface fluid = new SystemPrEos(424.0, 186.0);
+    fluid.addComponent("methane", 70.0);
+    fluid.addComponent("n-heptane", 30.0);
+    fluid.setMixingRule("classic");
+    ((EosMixingRulesInterface) fluid.getPhase(0).getMixingRule()).setBinaryInteractionParameter(0, 1, 0.05);
+    ((EosMixingRulesInterface) fluid.getPhase(1).getMixingRule()).setBinaryInteractionParameter(0, 1, 0.05);
+    fluid.setTotalFlowRate(50.0, "kg/sec");
+    return fluid;
+  }
+
+  private static int componentIndex(OnePhaseSpeciesConservationReport report, String componentName) {
+    String[] names = report.getComponentNames();
+    for (int component = 0; component < names.length; component++) {
+      if (names[component].equalsIgnoreCase(componentName)) {
+        return component;
+      }
+    }
+    throw new IllegalArgumentException("Missing component in conservative report: " + componentName);
+  }
+
+  private static double last(double[] values) {
+    return values[values.length - 1];
+  }
+
+  private static double sum(double[] values) {
+    double total = 0.0;
+    for (double value : values) {
+      total += value;
+    }
+    return total;
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
@@ -137,6 +137,24 @@ public class OnePhasePipeLineCompositionalTest {
   }
 
   @Test
+  @DisplayName("Validated conservative tracking should reject null schedule inputs as invalid arguments")
+  void testValidatedConservativeTrackingRejectsNullScheduleInput() {
+    SystemInterface baselineGas = createTransmissionGas(0.95, 0.05);
+    Stream inlet = new Stream("null-schedule inlet", baselineGas);
+    inlet.setFlowRate(50.0, "kg/sec");
+    inlet.run();
+
+    OnePhasePipeLine pipe = createTransmissionPipe(inlet);
+    pipe.setConservativeCompositionalTracking(true);
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> pipe
+        .runConservativeTransient(new double[] { 0.0, 30.0 }, new SystemInterface[] { null }, 1, UUID.randomUUID()));
+
+    assertTrue(exception.getMessage().contains("non-null inlet system"));
+    assertEquals(0.0, pipe.getSimulationTime(), 0.0, "Rejected input must not advance the pipeline clock.");
+  }
+
+  @Test
   @DisplayName("Validated conservative tracking should reject phase appearance before advancing")
   void testValidatedConservativeTrackingRejectsPhaseAppearance() {
     SystemInterface baselineGas = createTransmissionGas(0.95, 0.05);


### PR DESCRIPTION
## Engineering value

Exposes the already validated conservative one-phase species solver through the process-equipment `OnePhasePipeLine` API used by Java and Python/JPype. The existing `setCompositionalTracking(true)` behavior remains source compatible and continues to select legacy staged type 20; the new opt-in mode selects coupled solver type 1 explicitly.

Closes #2824 when merged.

## Frozen baseline and acceptance case

- Base: `7ae08253b45180045a99a700314f23c9a7001b3c`
- Colab master inspected: `93bd7804366b0e66d440b7e3de4430329f9d4a2a`
- Fluid: SRK/classic methane/nitrogen, baseline 95/5 mol%, pulse 80/20 mol%
- State: 288.15 K, 70 bara, one gas phase
- Geometry: 3000 m × 0.5 m, horizontal, 12 nodes, roughness 1e-5 m
- Boundary: 50 kg/s; mass units kg and kg/s; thermodynamic composition supplied on a molar basis
- Event: 1800 s pulse, return to baseline through 5400 s; 60 steps per interval (30 s then 60 s)
- Frozen gates: every accepted report converged; component inventory residual <= 1e-8; thermodynamic mass-fraction synchronization <= 1e-10; exact step-end timestamps; pulse breakthrough >70% of event amplitude; outlet recovery within 0.2% of event amplitude; cumulative nitrogen closure <= 1e-7 of inventory/inlet scale; explicit phase/reverse-flow failure before time advances; legacy default unchanged.

On unmodified master the regression failed at compile time because the high-level conservative setters, schedule runner, reports, history, and profile accessors did not exist.

## Change

- Adds explicit opt-in conservative mode and direct report/history/profile accessors.
- Adds a JPype-friendly interval schedule API using Java arrays.
- Uses one solver-type-1 transient call so accepted-step timestamps and immutable history remain aligned.
- Independently TP-flashes schedule fluids and rejects phase appearance.
- Rejects non-positive/non-finite inlet mass flow before simulation time advances.
- Keeps conservative finite-volume inventories authoritative; this wrapper does not add normalization, clipping, TVD, or physical dispersion.
- Documents the validated type 1 route separately from legacy type 10/20 and existing TVD settings.

For each accepted step the delegated solver checks component inventory closure
`m_i^(n+1) - m_i^n = m_in,i - m_out,i` using integrated boundary masses, while synchronizing EOS composition to the conservative state.

## Measurements

Python/JPype three-step smoke:
- history: 3 reports at exactly 30, 60, 90 s
- maximum relative component inventory residual: `2.0361e-15`
- maximum thermodynamic mass-fraction error: `2.22045e-16`
- JSON report count: 3

High-level 30-minute pulse:
- accepted reports: 120
- baseline outlet N2 mass fraction: `0.0841674666`
- pulse-end outlet: `0.3038556784`
- recovered outlet: `0.0841674667`
- maximum per-step relative inventory residual: `4.54257e-10`
- maximum thermodynamic synchronization error: `2.22045e-16`
- cumulative nitrogen residual: `-2.43679e-5 kg` (passes the frozen scale-relative gate)

## Validation

- 38 focused ordinary pipeline/solver tests: pass
- 11 ordinary `OnePhasePipeLineCompositionalTest` tests after final reverse-flow gate: pass
- 3 slow integrated pulse/refinement tests: pass
- final high-level 30-minute slow regression: pass
- Python 3.12.13 / JPype against compiled Java master classes: pass
- OpenJDK 17.0.19; Maven 3.9.12
- Spotless apply/check: pass
- pre-commit and pre-push stages: pass
- documentation search: 646 Markdown + 1 HTML page, pass
- diff and sensitive-material checks: pass

Exact focused commands used:
```
./mvnw -Dtest=OnePhasePipeLineCompositionalTest,OnePhaseConservativeSpeciesTest,PipeFlowSystemTest,OnePhaseFlowConvergenceTest,ConservativeSpeciesTransportTest -DexcludedGroups=slow test
./mvnw -Dtest=OnePhasePipeLineCompositionalTest,OnePhaseConservativeSpeciesTest -Dgroups=slow -DexcludedTestGroups= -Djacoco.skip=true test
pre-commit run --all-files --hook-stage pre-commit
pre-commit run --all-files --hook-stage pre-push
```

The local Java 8 command was attempted but could not resolve the separate `pomJava8.xml` clean/flatten plugins because the offline cache lacked them and Maven Central DNS failed. Hosted Java 8/21, Windows, Javadocs, CodeQL, documentation, PaperLab, and Copilot review are therefore mandatory blockers before merge readiness.

## Compatibility, performance, and limits

- Existing flags and legacy solver selection are unchanged.
- New behavior is opt-in.
- Full history storage remains separately opt-in.
- No notebook changed; the authoritative transmission-pipeline notebook remains gated on this public API reaching master.
- Current supported domain is one gas phase with strictly positive inlet/face flow.
- First-order spreading is numerical diffusion. No TVD improvement or physical dispersion is claimed here.
- Phase appearance, zero/reversed flow, network junctions, and multiphase species transport remain later dependency-ordered work.
- No overlap with the merged TwoFluid handoff/outlet-flux work was found.

## Attempt history

1. Raw thermodynamic phase-array count falsely rejected a stable gas because inactive phase objects remain allocated; rejected without weakening the physical criterion.
2. Replaced that check with an independent multiphase TP flash; focused and 30-minute regressions passed.
3. Added explicit known GAS/OIL rejection at 424 K and 186 bara; it fails before clock advancement.
4. Added high-level non-positive inlet-flow validation and reverse-flow regression; all final focused/slow gates passed.

## Documentation impact

Updated class Javadocs plus the single-phase pipe guide and equations wiki. They state units, solver ownership, conservative diagnostics, Python array shape, supported phase/flow domain, legacy type 20 status, and the separation between numerical diffusion and physical dispersion.

## Next gate

After exact-head hosted CI and review pass, merge of this PR would make stable Python-accessible Stage 2 pulse/inventory diagnostics available on master. The next run should freeze the actual 6/120 -> 12/60 -> 24/30 outlet-difference values before beginning any Stage 3 TVD work.

## Review follow-up (exact head `6204552ced04773f57dc6b0c4856def83e0e8b44`)

- Replaced the brittle nitrogen index with case-insensitive component-name lookup.
- Classifies a null interval inlet as `IllegalArgumentException` and covers that contract with a regression test.
- Renamed the documentation variable to state that the accessor returns a full profile.
- All 3 Copilot review threads are resolved.
- Review-head validation: 12/12 ordinary `OnePhasePipeLineCompositionalTest` tests pass; pre-commit and pre-push stages pass.
