### PR TITLE
fix(tpflash): recover invalid incipient trace-water splits

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -259,7 +259,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Convergence tolerance | 1e-10 | Deviation threshold for K-value convergence |
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
 | Supplementary stability TPD limit | -1e-6 | Accept a converged amplified-K or composition-perturbation trial only when its reduced TPD exceeds that SSI solve's residual/step resolution and the trial composition is non-trivial |
-| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i) > 1e-8`, allowing the bounded beta correction below without another stability calculation. |
+| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for valid trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i)` is non-finite or above `1e-8`, allowing the bounded beta correction below without another stability calculation. An incipient trace-water GAS+OIL endpoint with `min(beta) <= 1e-4` also bypasses the threshold when its confirmed log-fugacity residual is non-finite or at least `1e-8`; the existing guarded multiphase candidate must then pass the strict feasibility and lower-Gibbs gates. |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
 | Cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root assignment only when the existing composition split is already at equilibrium |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
@@ -1712,9 +1712,12 @@ Commercial process simulators do not publish all implementation details, but pub
   balance has `max abs(Delta z_i) >= 1e-8`. A feasible candidate normally must lower Gibbs energy; when the reference
   is non-conservative and its Gibbs energy is therefore not comparable, the candidate must instead independently pass
   phase-fraction, composition-normalization, material-balance, fugacity, and distinct-composition checks. The 0.01
-  water-feed gate still protects phase-search cost, but an already-active neutral aqueous split with a material residual
-  above `1e-8` may use the existing three-step beta correction below that threshold; this does not search for or create
-  a phase.
+  water-feed gate still protects phase-search cost for valid endpoints. An already-active neutral aqueous split with a
+  non-finite material residual or one above `1e-8` may use the existing three-step beta correction below that threshold;
+  this does not search for or create a phase. A trace-water GAS+OIL endpoint with a confirmed non-finite or at-least
+  `1e-8` log-fugacity residual may run the existing guarded multiphase candidate and is replaced only by a strictly
+  feasible lower-Gibbs result. This phase-selection retry is restricted to an incipient secondary phase with
+  `min(beta) <= 1e-4`, so established valid gas/oil splits avoid even the component residual scan.
 - When the tangent-plane stability path has already accepted a homogeneous state, an unnormalized aqueous trial seed
   cannot replace it. The guard is deliberately structural: each active phase composition must be finite, bounded in
   `[0, 1]`, and normalized within `1e-8`. It does not impose a universal material-balance or fugacity threshold on

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -47,6 +47,8 @@ public class TPflash extends Flash {
   private static final double LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN = 150.0;
   /** Minimum water feed fraction for ordinary water-rich endpoint refinement. */
   private static final double WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT = 0.01;
+  /** Largest incipient secondary-phase fraction eligible for trace-water phase-selection retry. */
+  private static final double TRACE_WATER_PHASE_SELECTION_BETA_LIMIT = 1.0e-4;
   /** Maximum stored water K-value that justifies checking a collapsed water-bearing endpoint. */
   private static final double WATER_PHASE_COLLAPSE_WATER_K_UPPER_LIMIT = 1.0e-2;
   /** Minimum stored non-water K-value that justifies checking a collapsed water-bearing endpoint. */
@@ -959,11 +961,12 @@ public class TPflash extends Flash {
    * label is not by itself proof of equilibrium: phase typing can identify a water-rich phase after the ordinary
    * gas/oil iteration has stopped. Such an endpoint is refined when its component fugacity residual exceeds
    * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE} or its component material balance exceeds
-   * {@link #WATER_RICH_MATERIAL_BALANCE_TOLERANCE}. The one-mol-percent feed guard keeps trace-water process flashes on
-   * the existing fast path. A cloned multiphase candidate normally replaces the ordinary state only when it lowers
-   * Gibbs energy. If the reference state is non-conservative, Gibbs energies are not comparable; a candidate may then
-   * replace it only after passing strict phase-fraction, composition-normalization, material-balance, fugacity, and
-   * distinct-composition checks.
+   * {@link #WATER_RICH_MATERIAL_BALANCE_TOLERANCE}. The one-mol-percent feed guard keeps valid trace-water process
+   * flashes on the existing fast path. A trace-water gas/oil endpoint whose fugacity residual is already outside the
+   * equilibrium tolerance may still use the cloned stability calculation because it is not an acceptable result. A
+   * cloned multiphase candidate normally replaces the ordinary state only when it lowers Gibbs energy. If the reference
+   * state is non-conservative, Gibbs energies are not comparable; a candidate may then replace it only after passing
+   * strict phase-fraction, composition-normalization, material-balance, fugacity, and distinct-composition checks.
    * </p>
    */
   private void rescueWaterRichEndpoint() {
@@ -984,7 +987,8 @@ public class TPflash extends Flash {
         break;
       }
     }
-    if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
+    if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
+        && (waterFeedFraction <= 0.0 || !isInvalidTraceWaterGasOilEndpoint())) {
       return;
     }
     double materialBalanceResidual = maximumComponentMaterialBalanceResidual(system);
@@ -1007,6 +1011,46 @@ public class TPflash extends Flash {
     } catch (Exception ex) {
       logger.debug("Water-rich endpoint refinement failed: {}", ex.getMessage());
     }
+  }
+
+  /**
+   * Checks whether an ordinary trace-water gas/oil endpoint already fails fugacity equality.
+   *
+   * <p>
+   * Valid trace-water flashes with established phase fractions return before a component residual scan. For an
+   * incipient secondary phase, a valid residual returns without another initialization or stability calculation. Only
+   * an invalid neutral gas/oil endpoint is reinitialized to confirm the residual before the guarded lower-Gibbs aqueous
+   * candidate is evaluated.
+   * </p>
+   *
+   * @return true when the endpoint is a neutral gas/oil split whose confirmed fugacity residual is non-finite or not
+   * below the equilibrium tolerance
+   */
+  private boolean isInvalidTraceWaterGasOilEndpoint() {
+    if (system.getNumberOfPhases() != 2 || system.hasPhaseType(PhaseType.AQUEOUS)) {
+      return false;
+    }
+    boolean hasGasPhase = false;
+    boolean hasLiquidPhase = false;
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      PhaseType phaseType = system.getPhase(phaseIndex).getType();
+      hasGasPhase |= phaseType == PhaseType.GAS;
+      hasLiquidPhase |= phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID;
+    }
+    if (!hasGasPhase || !hasLiquidPhase) {
+      return false;
+    }
+    if (Math.min(system.getBeta(0), system.getBeta(1)) > TRACE_WATER_PHASE_SELECTION_BETA_LIMIT) {
+      return false;
+    }
+
+    double residual = maximumLogFugacityResidual(system.getPhase(0), system.getPhase(1));
+    if (Double.isFinite(residual) && residual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
+      return false;
+    }
+    system.init(1);
+    residual = maximumLogFugacityResidual(system.getPhase(0), system.getPhase(1));
+    return !Double.isFinite(residual) || residual >= PHASE_ROOT_EQUILIBRIUM_TOLERANCE;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTraceAqueousRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTraceAqueousRefinementTest.java
@@ -20,7 +20,7 @@ class TPflashTraceAqueousRefinementTest {
         SystemInterface ordinary = createAndFlash(usePr, waterFeedFraction, false);
         SystemInterface multiphase = createAndFlash(usePr, waterFeedFraction, true);
 
-        assertBalancedEquilibrium(ordinary, waterFeedFraction);
+        assertBalancedEquilibrium(ordinary);
         assertEquivalentEquilibrium(multiphase, ordinary);
 
         SystemInterface repeated = ordinary.clone();
@@ -29,6 +29,15 @@ class TPflashTraceAqueousRefinementTest {
         assertEquivalentEquilibrium(ordinary, repeated);
       }
     }
+  }
+
+  @Test
+  void invalidTraceWaterGasOilEndpointSelectsLowerGibbsAqueousSplit() {
+    SystemInterface ordinary = createAndFlashAtPhaseSelectionBoundary(false);
+    SystemInterface multiphase = createAndFlashAtPhaseSelectionBoundary(true);
+
+    assertBalancedEquilibrium(ordinary);
+    assertEquivalentEquilibrium(multiphase, ordinary);
   }
 
   private SystemInterface createAndFlash(boolean usePr, double waterFeedFraction, boolean multiphaseCheck) {
@@ -44,11 +53,24 @@ class TPflashTraceAqueousRefinementTest {
     return system;
   }
 
-  private void assertBalancedEquilibrium(SystemInterface system, double waterFeedFraction) {
+  private SystemInterface createAndFlashAtPhaseSelectionBoundary(boolean multiphaseCheck) {
+    SystemInterface system = new SystemSrkEos(260.0, 200.0);
+    double[] feed = { 0.02, 0.03, 0.85, 0.06, 0.03, 0.009, 0.001 };
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], feed[componentIndex]);
+    }
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private void assertBalancedEquilibrium(SystemInterface system) {
     assertEquals(2, system.getNumberOfPhases());
     assertTrue(system.hasPhaseType(PhaseType.GAS));
     assertTrue(system.hasPhaseType(PhaseType.AQUEOUS));
-    assertTrue(maximumComponentMaterialBalanceResidual(system, waterFeedFraction) < 1.0e-8);
+    assertTrue(maximumComponentMaterialBalanceResidual(system) < 1.0e-8);
     assertTrue(maximumLogFugacityResidual(system) < 1.0e-8);
 
     double betaTotal = 0.0;
@@ -90,15 +112,15 @@ class TPflashTraceAqueousRefinementTest {
     throw new AssertionError("Missing phase " + phaseType);
   }
 
-  private double maximumComponentMaterialBalanceResidual(SystemInterface system, double waterFeedFraction) {
-    double[] feed = { 0.02, 0.03, 0.859 - waterFeedFraction, 0.06, 0.03, 0.001, waterFeedFraction };
+  private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
     double maximumResidual = 0.0;
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
         recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
-      maximumResidual = Math.max(maximumResidual, Math.abs(feed[componentIndex] - recoveredFeed));
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(system.getPhase(0).getComponent(componentIndex).getz() - recoveredFeed));
     }
     return maximumResidual;
   }


### PR DESCRIPTION
## Reproduced problem

On current `master` (`7ae08253b45180045a99a700314f23c9a7001b3c`), the ordinary SRK TP flash returned an incipient GAS+OIL split for this deterministic trace-water case:

- 260 K, 200 bar, mixing rule 2
- N2 0.02, CO2 0.03, methane 0.85, ethane 0.06, propane 0.03, nC10 0.009, water 0.001 mole fraction

The ordinary endpoint had `beta_oil = 2.0076e-5` and a maximum component log-fugacity residual of `1.262e-7`, above the documented `1e-8` equilibrium tolerance. The explicit multiphase path instead found GAS+AQUEOUS with a lower Gibbs energy.

A deterministic 600-state / 2,400-execution SRK, PR, and CPA matrix reproduced this as one of three ordinary/multiphase disagreements. The matrix covers gas, oil, water, hydrocarbon-water, CO2-rich, hydrogen-rich, near-critical, and large-volatility-contrast feeds; 230-350 K; 1-200 bar; one-, two-, and three-phase regions; repeated execution; poor beta guesses; and both ordinary and multiphase paths.

## Root cause

`rescueWaterRichEndpoint()` returned immediately whenever the overall water fraction was below 0.01. That performance gate also suppressed the existing cloned multiphase/lower-Gibbs selection path when the ordinary result was already demonstrably outside fugacity equilibrium.

## Change

The trace-water fast path remains unchanged for valid endpoints. The existing guarded multiphase candidate is retried only when all of these hold:

- overall water is positive and below 0.01;
- the ordinary result is exactly a neutral GAS+OIL/LIQUID split;
- the smaller phase fraction is at most `1e-4`;
- the log-fugacity residual is non-finite or at least `1e-8`, and remains so after `init(1)`.

The candidate still replaces the ordinary result only through the existing strict feasibility and lower-Gibbs acceptance gates. No public API, phase-fraction tolerance, material-balance tolerance, or general stability algorithm changes.

## Numerical evidence

| Metric | Before | After |
|---|---:|---:|
| Stable phases | GAS + OIL | GAS + AQUEOUS |
| Secondary beta | `2.0076e-5` | `9.6122e-4` |
| Max material residual | `0` | `3.459e-15` |
| Max log-fugacity residual | `1.262e-7` | `3.848e-12` |
| Extensive Gibbs energy | `8566.7205 J` | `8561.7826 J` |
| Matrix invalid executions | 32 | 29 |
| Matrix ordinary/multiphase disagreements | 3 | 2 |
| Exceptions / repeat differences / poor-guess differences | 0 / 0 / 0 | 0 / 0 / 0 |

The remaining PR and CPA disagreements are retained as visible, out-of-scope hypotheses because their ordinary endpoints already satisfy the current convergence checks or are single phase.

## Runtime

Seven interleaved fresh-JVM pairs measured an established valid PR GAS+OIL trace-water endpoint (20 warmups, 100 flashes per JVM):

- baseline median: `10.197995600 ms/flash`
- candidate median: `10.141304110 ms/flash`
- candidate faster in 3/7 pairs
- thermodynamic checksum identical: `921852.576522`

This is noise-level evidence, so no speedup is claimed. The `min(beta) <= 1e-4` gate keeps established valid splits out of the residual scan and removes the earlier measurable candidate overhead.

## Method and literature basis

This is a bounded phase-selection retry built on NeqSim's existing Michelsen-style phase-stability / phase-split machinery and minimum-Gibbs acceptance, not a new proprietary algorithm. The theoretical basis is Michelsen, “The isothermal flash problem. Part I. Stability” and “Part II. Phase-split calculation,” *Fluid Phase Equilibria* 9 (1982), including the [phase-split formulation](https://doi.org/10.1016/0378-3812%2882%2985002-4). The implementation evidence is the reproduced residual, conservation, lower Gibbs energy, and exact cross-path agreement above. No inference about undocumented commercial-simulator internals is made.

## Validation

- ECJ 3.41.0 with Java 8 source/bytecode mode compiled the changed production and test sources.
- Eight focused JUnit test methods passed by direct execution, including trace-aqueous consistency, final aqueous refinement, rollback/feasibility gates, and the new phase-selection boundary.
- Final deterministic matrix: 600 states, 2,400 executions, 0 exceptions, 0 repeat differences, 0 poor-guess differences.
- `pre-commit run --all-files --hook-stage pre-commit`: passed.
- `pre-commit run --all-files --hook-stage pre-push`: passed (Spotless check and documentation search over 646 Markdown pages plus one HTML page).
- `git diff --check`: passed.
- Full Maven Java 8/21 and hosted broader suites are pending CI.

## Tolerances and compatibility risk

The new eligibility limits are intentionally narrow: water fraction `(0, 0.01)`, incipient secondary beta `<= 1e-4`, and confirmed log-fugacity residual `>= 1e-8` or non-finite. Candidate acceptance continues to require finite bounded phase fractions, normalized compositions, component material balance, fugacity equality, distinct phases, and lower Gibbs energy.

Compatibility risk is low but thermodynamically meaningful: a previously returned invalid trace-water GAS+OIL endpoint can now become the lower-Gibbs GAS+AQUEOUS equilibrium. Valid established two-phase process flashes retain their fast path.

## Documentation impact

Updated `TPflash` Javadocs and `docs/thermodynamicoperations/TPflash_algorithm.md` to document the trigger, thresholds, strict acceptance/rollback behavior, and the distinction between beta-only trace-aqueous correction and phase-selection retry.

## Checklist

- [ ] Confirm `./mvnw test` runs successfully (hosted CI pending)
- [x] Verify formatting through the repository Spotless pre-commit and pre-push gates
- [x] Update relevant algorithm documentation and Javadocs
- [ ] Link an associated issue (no matching open issue was found; no duplicate issue created)
- [ ] Request applicable CODEOWNERS / independent domain review
- [x] No major public contract or migration change
