### PR TITLE
Add conservative transient species transport for gas networks

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,27 @@
 
 ---
 
+## 2026-08-05 — Conservative transient gas-network species transport
+
+- Added `TransientCompositionalPipeNetwork` for prescribed positive-flow,
+  one-phase, isothermal gathering networks. Source composition and mass-flow
+  schedules propagate through finite-volume edge inventories and conservative
+  component-name junction mixing without an instantaneous manual handoff.
+- `TransientCompositionalPipeNetworkHistory` exposes defensive, time-aligned
+  node mass fractions plus immutable edge, junction, and cumulative network
+  conservation reports. The history and reports provide JSON capture for
+  Python/JPype.
+- The first validated scope is a directed acyclic network with at most one
+  outgoing edge per node. Reverse flow, branching splits, recirculation,
+  hydraulic/thermal coupling, dispersion, and phase appearance fail explicitly
+  or remain outside this API.
+- Added a two-source finite-CO2-pulse regression with deterministic repeat,
+  component-order independence, balance/boundedness gates, linepack delay and
+  broadening, unsupported-state diagnostics, and joint grid/timestep
+  refinement.
+
+---
+
 ## 2026-08-05 — External process evaluators sample result callbacks once
 
 - `ProcessSimulationEvaluator.evaluate(...)` and `ProcessModelSimulationEvaluator.evaluate(...)`

--- a/devtools/neqsim_dev_setup.py
+++ b/devtools/neqsim_dev_setup.py
@@ -363,6 +363,9 @@ def neqsim_classes(ns):
     ns.PipeBeggsAndBrills = JClass(
         "neqsim.process.equipment.pipeline.PipeBeggsAndBrills"
     )
+    ns.TransientCompositionalPipeNetwork = JClass(
+        "neqsim.process.equipment.network.TransientCompositionalPipeNetwork"
+    )
     ns.Pump = JClass("neqsim.process.equipment.pump.Pump")
     ns.Manifold = JClass("neqsim.process.equipment.manifold.Manifold")
     ns.StreamSaturatorUtil = JClass(

--- a/docs/process/gas_network_operations.md
+++ b/docs/process/gas_network_operations.md
@@ -214,6 +214,128 @@ The planning layer is a steady-period screening model. It does not replace a
 high-frequency transient pipeline simulation for rapid valve actions, thermal
 fronts, surge, or control-system verification.
 
+## Conservative transient species transport
+
+`TransientCompositionalPipeNetwork` propagates a finite composition event
+through source branches, conservative junction mixing, edge linepack, and a
+delivery point. It is a separate high-frequency species model for prescribed
+flows; it does not alter the steady hydraulics or planning APIs above.
+
+For physical cell $j$, fixed gas mass $M_j$, component mass fraction
+$Y_{i,j}$, positive edge mass rate $q$, and timestep $\Delta t$, the
+implicit upwind balance is
+
+$$
+M_j\left(Y_{i,j}^{n+1}-Y_{i,j}^{n}\right)
+=\Delta t\,q\left(Y_{i,j-1}^{n+1}-Y_{i,j}^{n+1}\right).
+$$
+
+The inlet of cell zero is the accepted upstream node state. At a junction,
+incoming integrated component masses are combined by canonical NeqSim
+component name:
+
+$$
+Y_{i,\mathrm{mix}}=
+\frac{\sum_e m_{i,e}^{out}}{\sum_k\sum_e m_{k,e}^{out}}.
+$$
+
+The mixed mass rate and composition become the downstream edge boundary in the
+same timestep. Consequently internal edge boundaries cancel from the
+whole-network balance, while every edge retains its own distributed inventory
+and residence-time delay.
+
+The synthetic Åsgard/Kristin-to-Kårstø teaching topology is:
+
+```java
+TransientCompositionalPipeNetwork transientNetwork =
+    new TransientCompositionalPipeNetwork("Norwegian export teaching case");
+transientNetwork.addNode("asgard");
+transientNetwork.addNode("kristin");
+transientNetwork.addNode("junction");
+transientNetwork.addNode("karsto");
+
+// All fluids in this example are one-phase gases at 300 K and 70 bara.
+transientNetwork.addPipe(
+    "asgardBranch", "asgard", "junction", 2000.0, 0.4, 12, asgardGas);
+transientNetwork.addPipe(
+    "kristinBranch", "kristin", "junction", 2000.0, 0.4, 12, kristinGas);
+transientNetwork.addPipe(
+    "export", "junction", "karsto", 4000.0, 0.4, 12, mixedGas);
+
+transientNetwork.setSourceSchedule(
+    "asgard",
+    new double[] {0.0},
+    new SystemInterface[] {asgardGas},
+    new double[] {20.0}); // kg/s
+transientNetwork.setSourceSchedule(
+    "kristin",
+    new double[] {0.0, 600.0, 1800.0},
+    new SystemInterface[] {kristinGas, kristinHighCo2, kristinGas},
+    new double[] {20.0, 18.0, 20.0});
+
+transientNetwork.run(5400.0, 60.0);
+TransientCompositionalPipeNetworkHistory species =
+    transientNetwork.getSpeciesHistory();
+double[] junctionCo2 =
+    species.getNodeMassFractionHistory("junction", "CO2");
+double[] karstoCo2 =
+    species.getNodeMassFractionHistory("karsto", "CO2");
+
+if (species.getFinalNetworkReport()
+    .getMaximumRelativeInventoryResidual() > 1.0e-8) {
+  throw new IllegalStateException(
+      species.getFinalNetworkReport().getMessage());
+}
+```
+
+`getNodeMassFractionHistory` returns **mass fraction**, not mole fraction.
+`getEdgeReports`, `getJunctionReports`, and `getNetworkReports` expose immutable,
+time-aligned inventory, cumulative boundary-mass, cumulative residual,
+boundedness, and profile data.
+All array getters return defensive copies. `toJson()` on the history or an
+individual report is the stable Python/JPype capture path.
+
+With `neqsim_dev_setup.py`, Python can use the same API:
+
+```python
+import jpype
+
+SystemInterface = jpype.JClass("neqsim.thermo.system.SystemInterface")
+DoubleArray = jpype.JArray(jpype.JDouble)
+FluidArray = jpype.JArray(SystemInterface)
+
+network = ns.TransientCompositionalPipeNetwork("transient export")
+# Add the four nodes and three pipes as in the Java example.
+network.setSourceSchedule(
+    "kristin",
+    DoubleArray([0.0, 600.0, 1800.0]),
+    FluidArray([kristin_gas, kristin_high_co2, kristin_gas]),
+    DoubleArray([20.0, 18.0, 20.0]),
+)
+network.run(5400.0, 60.0)
+history = network.getSpeciesHistory()
+karsto_co2_mass_fraction = list(
+    history.getNodeMassFractionHistory("karsto", "CO2")
+)
+history_json = str(history.toJson())
+```
+
+Validated scope and required diagnostics:
+
+- directed acyclic gathering topology with at most one outgoing edge per node;
+- strictly positive prescribed source flows and conservative mixing flow
+  continuity;
+- one gas phase and one common temperature across initial and scheduled states;
+- no hydraulic coupling, flow splitting, reverse flow, recirculation, thermal
+  transport, dispersion, or phase appearance;
+- edge mass initialized from EOS density and geometric volume, then held fixed;
+- default fail-loud relative component-balance tolerance $10^{-8}$.
+
+Use a joint grid/timestep refinement study for each engineering case. Flow
+reversal, a two-phase flash, a temperature mismatch, an unsupported topology,
+or a failed conservation/boundedness criterion raises an explicit exception
+before the state is accepted.
+
 ## JSON and reproducibility
 
 Quality profiles, compliance reports, candidate evaluations, and planning

--- a/src/main/java/neqsim/process/equipment/network/TransientCompositionalPipeNetwork.java
+++ b/src/main/java/neqsim/process/equipment/network/TransientCompositionalPipeNetwork.java
@@ -1,0 +1,789 @@
+package neqsim.process.equipment.network;
+
+import java.io.Serializable;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Conservative transient component transport through a prescribed-flow gas gathering network.
+ *
+ * <p>
+ * The v1 model is intentionally bounded to directed acyclic networks with strictly positive flow, one outgoing edge per
+ * source or mixing node, one gas phase, and one common temperature. Each edge owns fixed gas mass in equal-volume
+ * finite-volume cells. A first-order implicit upwind balance advances every named component while retaining edge
+ * linepack delay:
+ * </p>
+ *
+ * <p>
+ * {@code M_j (Y_j^(n+1) - Y_j^n) = dt q (Y_(j-1)^(n+1) - Y_j^(n+1))}.
+ * </p>
+ *
+ * <p>
+ * Junction inlet component masses are summed by component name and become the downstream edge boundary state in the
+ * same accepted timestep. The implementation reports edge, junction, and cumulative whole-network residuals and throws
+ * before accepting a state that violates balance, boundedness, phase, topology, or flow-direction criteria. Hydraulic
+ * coupling, branching flow splits, recirculation, reverse flow, thermal transport, dispersion, and phase appearance are
+ * outside this first validated scope.
+ * </p>
+ */
+public final class TransientCompositionalPipeNetwork implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final double MINIMUM_SCALE_KG = 1.0e-12;
+  private static final double TEMPERATURE_TOLERANCE_K = 1.0e-8;
+
+  private final String name;
+  private final Map<String, NetworkNode> nodes = new LinkedHashMap<String, NetworkNode>();
+  private final Map<String, TransientEdge> edges = new LinkedHashMap<String, TransientEdge>();
+  private final Map<String, SourceSchedule> sourceSchedules = new LinkedHashMap<String, SourceSchedule>();
+  private double conservationTolerance = 1.0e-8;
+  private TransientCompositionalPipeNetworkHistory speciesHistory = TransientCompositionalPipeNetworkHistory.empty();
+
+  /**
+   * Create a prescribed-flow transient species network.
+   *
+   * @param name network name
+   */
+  public TransientCompositionalPipeNetwork(String name) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("Network name cannot be blank");
+    }
+    this.name = name;
+  }
+
+  /** @return network name */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Add a named source, junction, or sink node.
+   *
+   * @param nodeName unique node name
+   */
+  public void addNode(String nodeName) {
+    requireName(nodeName, "Node");
+    if (nodes.containsKey(nodeName)) {
+      throw new IllegalArgumentException("Node '" + nodeName + "' already exists");
+    }
+    nodes.put(nodeName, new NetworkNode(nodeName));
+  }
+
+  /**
+   * Add a directed pipe edge with its initial gas state.
+   *
+   * <p>
+   * The number of cells is the number of physical finite volumes. Edge mass is initialized from the flashed gas density
+   * and internal geometric volume and then held fixed while named species are transported.
+   * </p>
+   *
+   * @param edgeName unique edge name
+   * @param fromNode upstream node
+   * @param toNode downstream node
+   * @param lengthMeters internal pipe length in m
+   * @param diameterMeters internal diameter in m
+   * @param numberOfCells number of finite-volume cells
+   * @param initialFluid initial one-phase gas composition, pressure, and temperature
+   */
+  public void addPipe(String edgeName, String fromNode, String toNode, double lengthMeters, double diameterMeters,
+      int numberOfCells, SystemInterface initialFluid) {
+    requireName(edgeName, "Edge");
+    if (edges.containsKey(edgeName)) {
+      throw new IllegalArgumentException("Edge '" + edgeName + "' already exists");
+    }
+    NetworkNode upstream = requireNode(fromNode);
+    NetworkNode downstream = requireNode(toNode);
+    if (fromNode.equals(toNode)) {
+      throw new IllegalArgumentException("Edge '" + edgeName + "' cannot connect a node to itself");
+    }
+    requirePositiveFinite(lengthMeters, "Pipe length");
+    requirePositiveFinite(diameterMeters, "Pipe diameter");
+    if (numberOfCells < 1) {
+      throw new IllegalArgumentException("Pipe edge requires at least one finite-volume cell");
+    }
+    if (initialFluid == null) {
+      throw new IllegalArgumentException("Initial pipe fluid cannot be null");
+    }
+    TransientEdge edge = new TransientEdge(edgeName, upstream, downstream, lengthMeters, diameterMeters, numberOfCells,
+        initialFluid.clone());
+    edges.put(edgeName, edge);
+    upstream.outgoing.add(edge);
+    downstream.incoming.add(edge);
+  }
+
+  /**
+   * Assign a piecewise-constant composition and positive mass-flow schedule to a source node.
+   *
+   * <p>
+   * Event times are elapsed seconds and must start at zero. A value remains active until the next event. Component
+   * identity is read from each thermodynamic state by name, so array order may differ between schedule entries.
+   * </p>
+   *
+   * @param nodeName source node without incoming edges
+   * @param eventTimesSeconds strictly increasing event times beginning at zero
+   * @param fluids one-phase gas states at the events
+   * @param massFlowRatesKgS strictly positive source mass rates at the events
+   */
+  public void setSourceSchedule(String nodeName, double[] eventTimesSeconds, SystemInterface[] fluids,
+      double[] massFlowRatesKgS) {
+    requireNode(nodeName);
+    if (eventTimesSeconds == null || fluids == null || massFlowRatesKgS == null || eventTimesSeconds.length == 0
+        || eventTimesSeconds.length != fluids.length || eventTimesSeconds.length != massFlowRatesKgS.length) {
+      throw new IllegalArgumentException("Source schedule arrays must have the same non-zero length");
+    }
+    if (Math.abs(eventTimesSeconds[0]) > 1.0e-12) {
+      throw new IllegalArgumentException("Source schedule for '" + nodeName + "' must start at time zero");
+    }
+    double previousTime = -1.0;
+    SystemInterface[] scheduleFluids = new SystemInterface[fluids.length];
+    for (int index = 0; index < eventTimesSeconds.length; index++) {
+      double eventTime = eventTimesSeconds[index];
+      if (!Double.isFinite(eventTime) || eventTime < 0.0 || eventTime <= previousTime) {
+        throw new IllegalArgumentException("Source schedule event times must be finite and strictly increasing");
+      }
+      if (fluids[index] == null) {
+        throw new IllegalArgumentException("Source schedule fluid at index " + index + " cannot be null");
+      }
+      if (!Double.isFinite(massFlowRatesKgS[index]) || massFlowRatesKgS[index] <= 0.0) {
+        throw new IllegalArgumentException(
+            "Unsupported reverse flow at source '" + nodeName + "': prescribed mass flow must be strictly positive");
+      }
+      scheduleFluids[index] = fluids[index].clone();
+      previousTime = eventTime;
+    }
+    sourceSchedules.put(nodeName, new SourceSchedule(eventTimesSeconds, scheduleFluids, massFlowRatesKgS));
+  }
+
+  /**
+   * Set the fail-loud relative component-balance tolerance.
+   *
+   * @param tolerance positive finite relative tolerance
+   */
+  public void setConservationTolerance(double tolerance) {
+    requirePositiveFinite(tolerance, "Conservation tolerance");
+    conservationTolerance = tolerance;
+  }
+
+  /** @return configured relative component-balance tolerance */
+  public double getConservationTolerance() {
+    return conservationTolerance;
+  }
+
+  /**
+   * Run from the configured initial linepack using a uniform timestep.
+   *
+   * <p>
+   * Every invocation reconstructs the initial component inventories, making repeated runs deterministic. The end time
+   * must contain an integer number of timesteps. Schedule events are sampled at accepted-step start times.
+   * </p>
+   *
+   * @param endTimeSeconds final elapsed time in seconds
+   * @param timeStepSeconds uniform timestep in seconds
+   */
+  public void run(double endTimeSeconds, double timeStepSeconds) {
+    requirePositiveFinite(endTimeSeconds, "End time");
+    requirePositiveFinite(timeStepSeconds, "Timestep");
+    double rawStepCount = endTimeSeconds / timeStepSeconds;
+    int stepCount = (int) Math.round(rawStepCount);
+    if (stepCount < 1 || Math.abs(rawStepCount - stepCount) > 1.0e-10 * Math.max(1.0, rawStepCount)) {
+      throw new IllegalArgumentException("End time must contain an integer number of timesteps");
+    }
+
+    List<NetworkNode> topologicalNodes = validateAndSortTopology();
+    PreparedModel prepared = prepareModel();
+    String[] componentNames = prepared.componentNames;
+    double[] initialNetworkInventory = initializeEdgeInventories(componentNames, prepared.preparedInitialFluids);
+
+    double[] elapsedTimes = new double[stepCount];
+    Map<String, double[][]> nodeHistory = new LinkedHashMap<String, double[][]>();
+    Map<String, List<TransientSpeciesConservationReport>> edgeHistory = new LinkedHashMap<String, List<TransientSpeciesConservationReport>>();
+    Map<String, List<TransientSpeciesConservationReport>> junctionHistory = new LinkedHashMap<String, List<TransientSpeciesConservationReport>>();
+    Map<String, double[]> cumulativeJunctionInlet = new LinkedHashMap<String, double[]>();
+    Map<String, double[]> cumulativeJunctionOutlet = new LinkedHashMap<String, double[]>();
+    List<TransientSpeciesConservationReport> networkHistory = new ArrayList<TransientSpeciesConservationReport>();
+
+    for (String nodeName : nodes.keySet()) {
+      nodeHistory.put(nodeName, new double[stepCount][componentNames.length]);
+      NetworkNode node = nodes.get(nodeName);
+      if (!sourceSchedules.containsKey(nodeName) && !node.outgoing.isEmpty()) {
+        junctionHistory.put(nodeName, new ArrayList<TransientSpeciesConservationReport>());
+        cumulativeJunctionInlet.put(nodeName, new double[componentNames.length]);
+        cumulativeJunctionOutlet.put(nodeName, new double[componentNames.length]);
+      }
+    }
+    for (String edgeName : edges.keySet()) {
+      edgeHistory.put(edgeName, new ArrayList<TransientSpeciesConservationReport>());
+    }
+
+    double[] cumulativeExternalInlet = new double[componentNames.length];
+    double[] cumulativeExternalOutlet = new double[componentNames.length];
+
+    for (int step = 0; step < stepCount; step++) {
+      double stepStartTime = step * timeStepSeconds;
+      double stepEndTime = (step + 1) * timeStepSeconds;
+      elapsedTimes[step] = stepEndTime;
+
+      for (NetworkNode node : topologicalNodes) {
+        NodeBoundary boundary;
+        SourceSchedule sourceSchedule = sourceSchedules.get(node.name);
+        if (sourceSchedule != null) {
+          int scheduleIndex = sourceSchedule.indexAt(stepStartTime);
+          SystemInterface sourceFluid = prepared.preparedSourceFluids.get(node.name)[scheduleIndex];
+          boundary = new NodeBoundary(massFractions(sourceFluid, componentNames),
+              sourceSchedule.massFlowRatesKgS[scheduleIndex], null);
+        } else {
+          boundary = mixIncomingBoundary(node, componentNames, timeStepSeconds);
+        }
+
+        nodeHistory.get(node.name)[step] = Arrays.copyOf(boundary.massFractions, boundary.massFractions.length);
+
+        if (node.outgoing.isEmpty()) {
+          if (sourceSchedule != null) {
+            throw new IllegalStateException("Source node '" + node.name + "' must have one outgoing pipe edge");
+          }
+          addInPlace(cumulativeExternalOutlet, boundary.integratedIncomingMassKg);
+          continue;
+        }
+
+        TransientEdge edge = node.outgoing.get(0);
+        TransientSpeciesConservationReport edgeReport = edge.advance(boundary.massFractions, boundary.massFlowRateKgS,
+            timeStepSeconds, stepEndTime, componentNames, conservationTolerance);
+        edgeHistory.get(edge.name).add(edgeReport);
+        if (!edgeReport.isConverged()) {
+          throw new IllegalStateException(edgeReport.getMessage());
+        }
+
+        if (sourceSchedule != null) {
+          addInPlace(cumulativeExternalInlet, edge.lastStepInletMassKg);
+        } else {
+          addInPlace(cumulativeJunctionInlet.get(node.name), boundary.integratedIncomingMassKg);
+          addInPlace(cumulativeJunctionOutlet.get(node.name), edge.lastStepInletMassKg);
+          TransientSpeciesConservationReport junctionReport = createJunctionReport(node.name, stepEndTime,
+              componentNames, cumulativeJunctionInlet.get(node.name), cumulativeJunctionOutlet.get(node.name));
+          junctionHistory.get(node.name).add(junctionReport);
+          if (!junctionReport.isConverged()) {
+            throw new IllegalStateException(junctionReport.getMessage());
+          }
+        }
+      }
+
+      double[] currentNetworkInventory = totalNetworkInventory(componentNames.length);
+      TransientSpeciesConservationReport networkReport = createNetworkReport(stepEndTime, componentNames,
+          initialNetworkInventory, currentNetworkInventory, cumulativeExternalInlet, cumulativeExternalOutlet);
+      networkHistory.add(networkReport);
+      if (!networkReport.isConverged()) {
+        throw new IllegalStateException(networkReport.getMessage());
+      }
+    }
+
+    speciesHistory = new TransientCompositionalPipeNetworkHistory(elapsedTimes, componentNames, nodeHistory,
+        edgeHistory, junctionHistory, networkHistory);
+  }
+
+  /** @return immutable history from the latest completed run, empty before the first run */
+  public TransientCompositionalPipeNetworkHistory getSpeciesHistory() {
+    return speciesHistory;
+  }
+
+  /**
+   * Get the current physical-cell mass-fraction profile for an edge.
+   *
+   * @param edgeName edge name
+   * @return defensive component-by-cell profile
+   */
+  public double[][] getEdgeMassFractionProfile(String edgeName) {
+    TransientEdge edge = edges.get(edgeName);
+    if (edge == null) {
+      throw new IllegalArgumentException("Edge '" + edgeName + "' does not exist");
+    }
+    if (edge.massFractionProfile == null) {
+      throw new IllegalStateException("Transient compositional network has not run");
+    }
+    return copy(edge.massFractionProfile);
+  }
+
+  /**
+   * Get fixed cell gas masses for a pipe edge.
+   *
+   * @param edgeName edge name
+   * @return defensive cell-mass array in kg
+   */
+  public double[] getEdgeCellMassesKg(String edgeName) {
+    TransientEdge edge = edges.get(edgeName);
+    if (edge == null) {
+      throw new IllegalArgumentException("Edge '" + edgeName + "' does not exist");
+    }
+    if (edge.cellMassesKg == null) {
+      throw new IllegalStateException("Transient compositional network has not run");
+    }
+    return Arrays.copyOf(edge.cellMassesKg, edge.cellMassesKg.length);
+  }
+
+  private List<NetworkNode> validateAndSortTopology() {
+    if (nodes.isEmpty() || edges.isEmpty()) {
+      throw new IllegalStateException("Transient compositional network requires nodes and pipe edges");
+    }
+    for (NetworkNode node : nodes.values()) {
+      boolean source = sourceSchedules.containsKey(node.name);
+      if (source && !node.incoming.isEmpty()) {
+        throw new IllegalStateException("Source node '" + node.name + "' cannot have incoming pipe edges");
+      }
+      if (source && node.outgoing.size() != 1) {
+        throw new IllegalStateException("Source node '" + node.name + "' must have exactly one outgoing pipe edge");
+      }
+      if (!source && node.incoming.isEmpty()) {
+        throw new IllegalStateException("Node '" + node.name + "' has no incoming edge or source schedule");
+      }
+      if (node.outgoing.size() > 1) {
+        throw new IllegalStateException(
+            "Branching flow splits at node '" + node.name + "' are outside the validated one-outgoing-edge scope");
+      }
+    }
+
+    Map<String, Integer> indegree = new LinkedHashMap<String, Integer>();
+    Deque<NetworkNode> ready = new ArrayDeque<NetworkNode>();
+    for (NetworkNode node : nodes.values()) {
+      indegree.put(node.name, node.incoming.size());
+      if (node.incoming.isEmpty()) {
+        ready.addLast(node);
+      }
+    }
+    List<NetworkNode> order = new ArrayList<NetworkNode>();
+    while (!ready.isEmpty()) {
+      NetworkNode node = ready.removeFirst();
+      order.add(node);
+      for (TransientEdge edge : node.outgoing) {
+        int remaining = indegree.get(edge.to.name) - 1;
+        indegree.put(edge.to.name, remaining);
+        if (remaining == 0) {
+          ready.addLast(edge.to);
+        }
+      }
+    }
+    if (order.size() != nodes.size()) {
+      throw new IllegalStateException("Recirculation is outside the validated directed-acyclic-network scope");
+    }
+    return order;
+  }
+
+  private PreparedModel prepareModel() {
+    TreeSet<String> componentSet = new TreeSet<String>();
+    Map<String, SystemInterface> preparedInitialFluids = new LinkedHashMap<String, SystemInterface>();
+    Map<String, SystemInterface[]> preparedSourceFluids = new LinkedHashMap<String, SystemInterface[]>();
+    double referenceTemperature = Double.NaN;
+
+    for (TransientEdge edge : edges.values()) {
+      SystemInterface prepared = prepareOnePhaseFluid(edge.initialFluid, "initial fluid for edge '" + edge.name + "'");
+      referenceTemperature = validateTemperature(referenceTemperature, prepared.getTemperature(), edge.name);
+      collectComponentNames(prepared, componentSet);
+      preparedInitialFluids.put(edge.name, prepared);
+    }
+    for (Map.Entry<String, SourceSchedule> entry : sourceSchedules.entrySet()) {
+      SystemInterface[] preparedStates = new SystemInterface[entry.getValue().fluids.length];
+      for (int index = 0; index < preparedStates.length; index++) {
+        preparedStates[index] = prepareOnePhaseFluid(entry.getValue().fluids[index],
+            "source schedule '" + entry.getKey() + "' at index " + index);
+        referenceTemperature = validateTemperature(referenceTemperature, preparedStates[index].getTemperature(),
+            entry.getKey());
+        collectComponentNames(preparedStates[index], componentSet);
+      }
+      preparedSourceFluids.put(entry.getKey(), preparedStates);
+    }
+    if (componentSet.size() < 2) {
+      throw new IllegalStateException("Transient species transport requires at least two named components");
+    }
+    return new PreparedModel(componentSet.toArray(new String[componentSet.size()]), preparedInitialFluids,
+        preparedSourceFluids);
+  }
+
+  private double[] initializeEdgeInventories(String[] componentNames,
+      Map<String, SystemInterface> preparedInitialFluids) {
+    double[] totalInventory = new double[componentNames.length];
+    for (TransientEdge edge : edges.values()) {
+      SystemInterface fluid = preparedInitialFluids.get(edge.name);
+      double densityKgM3 = fluid.getDensity("kg/m3");
+      requirePositiveFinite(densityKgM3, "Initial gas density for edge '" + edge.name + "'");
+      double internalVolumeM3 = Math.PI * edge.diameterMeters * edge.diameterMeters * edge.lengthMeters / 4.0;
+      double cellMassKg = densityKgM3 * internalVolumeM3 / edge.numberOfCells;
+      edge.cellMassesKg = new double[edge.numberOfCells];
+      Arrays.fill(edge.cellMassesKg, cellMassKg);
+      double[] initialMassFractions = massFractions(fluid, componentNames);
+      edge.massFractionProfile = new double[componentNames.length][edge.numberOfCells];
+      for (int componentIndex = 0; componentIndex < componentNames.length; componentIndex++) {
+        Arrays.fill(edge.massFractionProfile[componentIndex], initialMassFractions[componentIndex]);
+        totalInventory[componentIndex] += cellMassKg * edge.numberOfCells * initialMassFractions[componentIndex];
+      }
+      edge.lastReport = null;
+      edge.runInitialInventoryKg = edge.inventory();
+      edge.cumulativeInletMassKg = new double[componentNames.length];
+      edge.cumulativeOutletMassKg = new double[componentNames.length];
+      edge.lastStepInletMassKg = new double[componentNames.length];
+      edge.lastStepOutletMassKg = new double[componentNames.length];
+    }
+    return totalInventory;
+  }
+
+  private NodeBoundary mixIncomingBoundary(NetworkNode node, String[] componentNames, double timeStepSeconds) {
+    double[] incomingMass = new double[componentNames.length];
+    for (TransientEdge edge : node.incoming) {
+      if (edge.lastReport == null) {
+        throw new IllegalStateException("Upstream edge '" + edge.name + "' has no accepted current-step state");
+      }
+      addInPlace(incomingMass, edge.lastStepOutletMassKg);
+    }
+    double totalMass = sum(incomingMass);
+    if (!(totalMass > 0.0) || !Double.isFinite(totalMass)) {
+      throw new IllegalStateException("Junction '" + node.name + "' requires strictly positive incoming flow");
+    }
+    double[] fractions = new double[componentNames.length];
+    for (int componentIndex = 0; componentIndex < componentNames.length; componentIndex++) {
+      fractions[componentIndex] = incomingMass[componentIndex] / totalMass;
+    }
+    return new NodeBoundary(fractions, totalMass / timeStepSeconds, incomingMass);
+  }
+
+  private TransientSpeciesConservationReport createJunctionReport(String nodeName, double elapsedTimeSeconds,
+      String[] componentNames, double[] incomingMass, double[] outgoingMass) {
+    double[] residual = new double[componentNames.length];
+    double[] relative = new double[componentNames.length];
+    double maximumRelativeResidual = 0.0;
+    for (int index = 0; index < componentNames.length; index++) {
+      residual[index] = outgoingMass[index] - incomingMass[index];
+      double scale = Math.max(MINIMUM_SCALE_KG, Math.max(Math.abs(incomingMass[index]), Math.abs(outgoingMass[index])));
+      relative[index] = residual[index] / scale;
+      maximumRelativeResidual = Math.max(maximumRelativeResidual, Math.abs(relative[index]));
+    }
+    boolean converged = maximumRelativeResidual <= conservationTolerance;
+    String message = "Junction '" + nodeName + "' component-name mixing " + (converged ? "converged" : "failed")
+        + " with maximum relative residual=" + maximumRelativeResidual + ".";
+    return new TransientSpeciesConservationReport(nodeName, TransientSpeciesConservationReport.LocationType.JUNCTION,
+        elapsedTimeSeconds, componentNames, new double[0][0], new double[componentNames.length],
+        new double[componentNames.length], incomingMass, outgoingMass, residual, relative, maximumRelativeResidual,
+        Double.NaN, Double.NaN, Double.NaN, converged, message);
+  }
+
+  private TransientSpeciesConservationReport createNetworkReport(double elapsedTimeSeconds, String[] componentNames,
+      double[] initialInventory, double[] finalInventory, double[] cumulativeInlet, double[] cumulativeOutlet) {
+    double[] residual = new double[componentNames.length];
+    double[] relative = new double[componentNames.length];
+    double maximumRelativeResidual = 0.0;
+    for (int index = 0; index < componentNames.length; index++) {
+      residual[index] = finalInventory[index] - initialInventory[index] - cumulativeInlet[index]
+          + cumulativeOutlet[index];
+      double scale = balanceScale(initialInventory[index], finalInventory[index], cumulativeInlet[index],
+          cumulativeOutlet[index]);
+      relative[index] = residual[index] / scale;
+      maximumRelativeResidual = Math.max(maximumRelativeResidual, Math.abs(relative[index]));
+    }
+    boolean converged = maximumRelativeResidual <= conservationTolerance;
+    String message = "Network '" + name + "' cumulative component balance " + (converged ? "converged" : "failed")
+        + " with maximum relative residual=" + maximumRelativeResidual + ".";
+    return new TransientSpeciesConservationReport(name, TransientSpeciesConservationReport.LocationType.NETWORK,
+        elapsedTimeSeconds, componentNames, new double[0][0], initialInventory, finalInventory, cumulativeInlet,
+        cumulativeOutlet, residual, relative, maximumRelativeResidual, Double.NaN, Double.NaN, Double.NaN, converged,
+        message);
+  }
+
+  private double[] totalNetworkInventory(int componentCount) {
+    double[] inventory = new double[componentCount];
+    for (TransientEdge edge : edges.values()) {
+      for (int componentIndex = 0; componentIndex < componentCount; componentIndex++) {
+        for (int cellIndex = 0; cellIndex < edge.numberOfCells; cellIndex++) {
+          inventory[componentIndex] += edge.cellMassesKg[cellIndex]
+              * edge.massFractionProfile[componentIndex][cellIndex];
+        }
+      }
+    }
+    return inventory;
+  }
+
+  private static SystemInterface prepareOnePhaseFluid(SystemInterface source, String context) {
+    SystemInterface fluid = source.clone();
+    try {
+      ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+      operations.TPflash();
+      fluid.initProperties();
+    } catch (Exception exception) {
+      throw new IllegalStateException("Unable to initialize " + context + ": " + exception.getMessage(), exception);
+    }
+    if (fluid.getNumberOfPhases() != 1) {
+      throw new IllegalArgumentException("Unsupported phase appearance in " + context
+          + ": conservative transient network transport requires exactly one gas phase");
+    }
+    return fluid;
+  }
+
+  private static double validateTemperature(double referenceTemperature, double temperature, String context) {
+    requirePositiveFinite(temperature, "Temperature for '" + context + "'");
+    if (!Double.isFinite(referenceTemperature)) {
+      return temperature;
+    }
+    if (Math.abs(referenceTemperature - temperature) > TEMPERATURE_TOLERANCE_K) {
+      throw new IllegalArgumentException("Thermal transport is unsupported: '" + context + "' has temperature "
+          + temperature + " K instead of the network isothermal temperature " + referenceTemperature + " K");
+    }
+    return referenceTemperature;
+  }
+
+  private static void collectComponentNames(SystemInterface fluid, TreeSet<String> componentNames) {
+    for (int index = 0; index < fluid.getNumberOfComponents(); index++) {
+      componentNames.add(fluid.getPhase(0).getComponent(index).getComponentName());
+    }
+  }
+
+  private static double[] massFractions(SystemInterface fluid, String[] componentNames) {
+    Map<String, Double> fractionsByName = new LinkedHashMap<String, Double>();
+    double[] molarComposition = fluid.getMolarComposition();
+    double totalMass = 0.0;
+    for (int index = 0; index < fluid.getNumberOfComponents(); index++) {
+      String componentName = fluid.getPhase(0).getComponent(index).getComponentName();
+      double componentMass = molarComposition[index] * fluid.getPhase(0).getComponent(index).getMolarMass();
+      fractionsByName.put(componentName, componentMass);
+      totalMass += componentMass;
+    }
+    if (!(totalMass > 0.0) || !Double.isFinite(totalMass)) {
+      throw new IllegalStateException("Cannot calculate positive finite source component mass fractions");
+    }
+    double[] result = new double[componentNames.length];
+    for (int index = 0; index < componentNames.length; index++) {
+      Double componentMass = fractionsByName.get(componentNames[index]);
+      result[index] = componentMass == null ? 0.0 : componentMass / totalMass;
+    }
+    return result;
+  }
+
+  private NetworkNode requireNode(String nodeName) {
+    NetworkNode node = nodes.get(nodeName);
+    if (node == null) {
+      throw new IllegalArgumentException("Node '" + nodeName + "' does not exist");
+    }
+    return node;
+  }
+
+  private static void requireName(String value, String kind) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(kind + " name cannot be blank");
+    }
+  }
+
+  private static void requirePositiveFinite(double value, String description) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(description + " must be positive and finite");
+    }
+  }
+
+  private static void addInPlace(double[] target, double[] increment) {
+    if (target == null || increment == null || target.length != increment.length) {
+      throw new IllegalArgumentException("Component arrays must have identical dimensions");
+    }
+    for (int index = 0; index < target.length; index++) {
+      target[index] += increment[index];
+    }
+  }
+
+  private static double sum(double[] values) {
+    double result = 0.0;
+    for (double value : values) {
+      result += value;
+    }
+    return result;
+  }
+
+  private static double balanceScale(double initial, double closing, double inlet, double outlet) {
+    return Math.max(MINIMUM_SCALE_KG,
+        Math.max(Math.max(Math.abs(initial), Math.abs(closing)), Math.max(Math.abs(inlet), Math.abs(outlet))));
+  }
+
+  private static double[][] copy(double[][] values) {
+    double[][] result = new double[values.length][];
+    for (int index = 0; index < values.length; index++) {
+      result[index] = Arrays.copyOf(values[index], values[index].length);
+    }
+    return result;
+  }
+
+  private static final class NetworkNode implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final List<TransientEdge> incoming = new ArrayList<TransientEdge>();
+    private final List<TransientEdge> outgoing = new ArrayList<TransientEdge>();
+
+    private NetworkNode(String name) {
+      this.name = name;
+    }
+  }
+
+  private static final class SourceSchedule implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double[] eventTimesSeconds;
+    private final SystemInterface[] fluids;
+    private final double[] massFlowRatesKgS;
+
+    private SourceSchedule(double[] eventTimesSeconds, SystemInterface[] fluids, double[] massFlowRatesKgS) {
+      this.eventTimesSeconds = Arrays.copyOf(eventTimesSeconds, eventTimesSeconds.length);
+      this.fluids = Arrays.copyOf(fluids, fluids.length);
+      this.massFlowRatesKgS = Arrays.copyOf(massFlowRatesKgS, massFlowRatesKgS.length);
+    }
+
+    private int indexAt(double elapsedTimeSeconds) {
+      int result = 0;
+      for (int index = 1; index < eventTimesSeconds.length; index++) {
+        if (eventTimesSeconds[index] > elapsedTimeSeconds) {
+          break;
+        }
+        result = index;
+      }
+      return result;
+    }
+  }
+
+  private static final class TransientEdge implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final NetworkNode from;
+    private final NetworkNode to;
+    private final double lengthMeters;
+    private final double diameterMeters;
+    private final int numberOfCells;
+    private final SystemInterface initialFluid;
+    private double[] cellMassesKg;
+    private double[][] massFractionProfile;
+    private TransientSpeciesConservationReport lastReport;
+    private double[] runInitialInventoryKg;
+    private double[] cumulativeInletMassKg;
+    private double[] cumulativeOutletMassKg;
+    private double[] lastStepInletMassKg;
+    private double[] lastStepOutletMassKg;
+
+    private TransientEdge(String name, NetworkNode from, NetworkNode to, double lengthMeters, double diameterMeters,
+        int numberOfCells, SystemInterface initialFluid) {
+      this.name = name;
+      this.from = from;
+      this.to = to;
+      this.lengthMeters = lengthMeters;
+      this.diameterMeters = diameterMeters;
+      this.numberOfCells = numberOfCells;
+      this.initialFluid = initialFluid;
+    }
+
+    private TransientSpeciesConservationReport advance(double[] inletMassFractions, double massFlowRateKgS,
+        double timeStepSeconds, double elapsedTimeSeconds, String[] componentNames, double tolerance) {
+      if (!Double.isFinite(massFlowRateKgS) || massFlowRateKgS <= 0.0) {
+        throw new IllegalArgumentException(
+            "Unsupported reverse flow on edge '" + name + "': mass flow must remain strictly positive");
+      }
+      double[] stepInitialInventory = inventory();
+      double[] inletMass = new double[componentNames.length];
+      double[] outletMass = new double[componentNames.length];
+      double[][] updatedProfile = new double[componentNames.length][numberOfCells];
+
+      for (int componentIndex = 0; componentIndex < componentNames.length; componentIndex++) {
+        double upstreamMassFraction = inletMassFractions[componentIndex];
+        inletMass[componentIndex] = timeStepSeconds * massFlowRateKgS * upstreamMassFraction;
+        for (int cellIndex = 0; cellIndex < numberOfCells; cellIndex++) {
+          double transportedMassKg = timeStepSeconds * massFlowRateKgS;
+          double updatedMassFraction = (cellMassesKg[cellIndex] * massFractionProfile[componentIndex][cellIndex]
+              + transportedMassKg * upstreamMassFraction) / (cellMassesKg[cellIndex] + transportedMassKg);
+          updatedProfile[componentIndex][cellIndex] = updatedMassFraction;
+          upstreamMassFraction = updatedMassFraction;
+        }
+        outletMass[componentIndex] = timeStepSeconds * massFlowRateKgS * upstreamMassFraction;
+      }
+
+      massFractionProfile = updatedProfile;
+      double[] finalInventory = inventory();
+      double maximumStepRelativeResidual = 0.0;
+      for (int index = 0; index < componentNames.length; index++) {
+        double stepResidual = finalInventory[index] - stepInitialInventory[index] - inletMass[index]
+            + outletMass[index];
+        double stepScale = balanceScale(stepInitialInventory[index], finalInventory[index], inletMass[index],
+            outletMass[index]);
+        maximumStepRelativeResidual = Math.max(maximumStepRelativeResidual, Math.abs(stepResidual / stepScale));
+      }
+      lastStepInletMassKg = Arrays.copyOf(inletMass, inletMass.length);
+      lastStepOutletMassKg = Arrays.copyOf(outletMass, outletMass.length);
+      addInPlace(cumulativeInletMassKg, inletMass);
+      addInPlace(cumulativeOutletMassKg, outletMass);
+      double[] residual = new double[componentNames.length];
+      double[] relative = new double[componentNames.length];
+      double maximumRelativeResidual = 0.0;
+      for (int index = 0; index < componentNames.length; index++) {
+        residual[index] = finalInventory[index] - runInitialInventoryKg[index] - cumulativeInletMassKg[index]
+            + cumulativeOutletMassKg[index];
+        double scale = balanceScale(runInitialInventoryKg[index], finalInventory[index], cumulativeInletMassKg[index],
+            cumulativeOutletMassKg[index]);
+        relative[index] = residual[index] / scale;
+        maximumRelativeResidual = Math.max(maximumRelativeResidual, Math.abs(relative[index]));
+      }
+
+      double minimumMassFraction = Double.POSITIVE_INFINITY;
+      double maximumMassFraction = Double.NEGATIVE_INFINITY;
+      double maximumSumError = 0.0;
+      for (int cellIndex = 0; cellIndex < numberOfCells; cellIndex++) {
+        double sum = 0.0;
+        for (int componentIndex = 0; componentIndex < componentNames.length; componentIndex++) {
+          double value = updatedProfile[componentIndex][cellIndex];
+          minimumMassFraction = Math.min(minimumMassFraction, value);
+          maximumMassFraction = Math.max(maximumMassFraction, value);
+          sum += value;
+        }
+        maximumSumError = Math.max(maximumSumError, Math.abs(sum - 1.0));
+      }
+      boolean bounded = minimumMassFraction >= -tolerance && maximumMassFraction <= 1.0 + tolerance
+          && maximumSumError <= tolerance;
+      boolean converged = maximumRelativeResidual <= tolerance && maximumStepRelativeResidual <= tolerance && bounded;
+      String message = "Edge '" + name + "' conservative species step " + (converged ? "converged" : "failed")
+          + "; cumulative maximum relative residual=" + maximumRelativeResidual + ", step maximum relative residual="
+          + maximumStepRelativeResidual + ", mass-fraction range=[" + minimumMassFraction + ", " + maximumMassFraction
+          + "], maximum sum error=" + maximumSumError + ".";
+      lastReport = new TransientSpeciesConservationReport(name, TransientSpeciesConservationReport.LocationType.EDGE,
+          elapsedTimeSeconds, componentNames, updatedProfile, runInitialInventoryKg, finalInventory,
+          cumulativeInletMassKg, cumulativeOutletMassKg, residual, relative, maximumRelativeResidual,
+          minimumMassFraction, maximumMassFraction, maximumSumError, converged, message);
+      return lastReport;
+    }
+
+    private double[] inventory() {
+      double[] result = new double[massFractionProfile.length];
+      for (int componentIndex = 0; componentIndex < massFractionProfile.length; componentIndex++) {
+        for (int cellIndex = 0; cellIndex < numberOfCells; cellIndex++) {
+          result[componentIndex] += cellMassesKg[cellIndex] * massFractionProfile[componentIndex][cellIndex];
+        }
+      }
+      return result;
+    }
+  }
+
+  private static final class NodeBoundary {
+    private final double[] massFractions;
+    private final double massFlowRateKgS;
+    private final double[] integratedIncomingMassKg;
+
+    private NodeBoundary(double[] massFractions, double massFlowRateKgS, double[] integratedIncomingMassKg) {
+      this.massFractions = massFractions;
+      this.massFlowRateKgS = massFlowRateKgS;
+      this.integratedIncomingMassKg = integratedIncomingMassKg;
+    }
+  }
+
+  private static final class PreparedModel {
+    private final String[] componentNames;
+    private final Map<String, SystemInterface> preparedInitialFluids;
+    private final Map<String, SystemInterface[]> preparedSourceFluids;
+
+    private PreparedModel(String[] componentNames, Map<String, SystemInterface> preparedInitialFluids,
+        Map<String, SystemInterface[]> preparedSourceFluids) {
+      this.componentNames = componentNames;
+      this.preparedInitialFluids = Collections.unmodifiableMap(preparedInitialFluids);
+      this.preparedSourceFluids = Collections.unmodifiableMap(preparedSourceFluids);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/network/TransientCompositionalPipeNetwork.java
+++ b/src/main/java/neqsim/process/equipment/network/TransientCompositionalPipeNetwork.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
@@ -514,7 +515,7 @@ public final class TransientCompositionalPipeNetwork implements Serializable {
     } catch (Exception exception) {
       throw new IllegalStateException("Unable to initialize " + context + ": " + exception.getMessage(), exception);
     }
-    if (fluid.getNumberOfPhases() != 1) {
+    if (fluid.getNumberOfPhases() != 1 || fluid.getPhase(0).getType() != PhaseType.GAS) {
       throw new IllegalArgumentException("Unsupported phase appearance in " + context
           + ": conservative transient network transport requires exactly one gas phase");
     }

--- a/src/main/java/neqsim/process/equipment/network/TransientCompositionalPipeNetwork.java
+++ b/src/main/java/neqsim/process/equipment/network/TransientCompositionalPipeNetwork.java
@@ -205,8 +205,8 @@ public final class TransientCompositionalPipeNetwork implements Serializable {
 
     double[] elapsedTimes = new double[stepCount];
     Map<String, double[][]> nodeHistory = new LinkedHashMap<String, double[][]>();
-    Map<String, List<TransientSpeciesConservationReport>> edgeHistory = new LinkedHashMap<String, List<TransientSpeciesConservationReport>>();
-    Map<String, List<TransientSpeciesConservationReport>> junctionHistory = new LinkedHashMap<String, List<TransientSpeciesConservationReport>>();
+    Map<String, List<TransientSpeciesConservationReport>> edgeHistory = new LinkedHashMap<>();
+    Map<String, List<TransientSpeciesConservationReport>> junctionHistory = new LinkedHashMap<>();
     Map<String, double[]> cumulativeJunctionInlet = new LinkedHashMap<String, double[]>();
     Map<String, double[]> cumulativeJunctionOutlet = new LinkedHashMap<String, double[]>();
     List<TransientSpeciesConservationReport> networkHistory = new ArrayList<TransientSpeciesConservationReport>();

--- a/src/main/java/neqsim/process/equipment/network/TransientCompositionalPipeNetworkHistory.java
+++ b/src/main/java/neqsim/process/equipment/network/TransientCompositionalPipeNetworkHistory.java
@@ -137,9 +137,12 @@ public final class TransientCompositionalPipeNetworkHistory implements Serializa
   public String toJson() {
     JsonSerializer<Double> finiteDoubleSerializer = (value, type,
         context) -> value != null && Double.isFinite(value) ? new JsonPrimitive(value) : JsonNull.INSTANCE;
-    return new GsonBuilder().registerTypeAdapter(Double.class, finiteDoubleSerializer)
-        .registerTypeAdapter(Double.TYPE, finiteDoubleSerializer).serializeNulls().setPrettyPrinting().create()
-        .toJson(this);
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.registerTypeAdapter(Double.class, finiteDoubleSerializer);
+    gsonBuilder.registerTypeAdapter(Double.TYPE, finiteDoubleSerializer);
+    gsonBuilder.serializeNulls();
+    gsonBuilder.setPrettyPrinting();
+    return gsonBuilder.create().toJson(this);
   }
 
   private int componentIndex(String componentName) {
@@ -170,7 +173,7 @@ public final class TransientCompositionalPipeNetworkHistory implements Serializa
 
   private static Map<String, List<TransientSpeciesConservationReport>> copyReports(
       Map<String, List<TransientSpeciesConservationReport>> reports) {
-    Map<String, List<TransientSpeciesConservationReport>> result = new LinkedHashMap<String, List<TransientSpeciesConservationReport>>();
+    Map<String, List<TransientSpeciesConservationReport>> result = new LinkedHashMap<>();
     for (Map.Entry<String, List<TransientSpeciesConservationReport>> entry : reports.entrySet()) {
       result.put(entry.getKey(),
           Collections.unmodifiableList(new ArrayList<TransientSpeciesConservationReport>(entry.getValue())));

--- a/src/main/java/neqsim/process/equipment/network/TransientCompositionalPipeNetworkHistory.java
+++ b/src/main/java/neqsim/process/equipment/network/TransientCompositionalPipeNetworkHistory.java
@@ -1,0 +1,199 @@
+package neqsim.process.equipment.network;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
+
+/** Immutable, time-aligned species history from a transient compositional pipe network run. */
+public final class TransientCompositionalPipeNetworkHistory implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final double[] elapsedTimeSeconds;
+  private final String[] componentNames;
+  private final Map<String, double[][]> nodeMassFractionHistory;
+  private final Map<String, List<TransientSpeciesConservationReport>> edgeReports;
+  private final Map<String, List<TransientSpeciesConservationReport>> junctionReports;
+  private final List<TransientSpeciesConservationReport> networkReports;
+
+  TransientCompositionalPipeNetworkHistory(double[] elapsedTimeSeconds, String[] componentNames,
+      Map<String, double[][]> nodeMassFractionHistory,
+      Map<String, List<TransientSpeciesConservationReport>> edgeReports,
+      Map<String, List<TransientSpeciesConservationReport>> junctionReports,
+      List<TransientSpeciesConservationReport> networkReports) {
+    this.elapsedTimeSeconds = copy(elapsedTimeSeconds);
+    this.componentNames = copy(componentNames);
+    this.nodeMassFractionHistory = copyProfiles(nodeMassFractionHistory);
+    this.edgeReports = copyReports(edgeReports);
+    this.junctionReports = copyReports(junctionReports);
+    this.networkReports = Collections
+        .unmodifiableList(new ArrayList<TransientSpeciesConservationReport>(networkReports));
+  }
+
+  /**
+   * Create an empty history before the first run.
+   *
+   * @return immutable empty history
+   */
+  public static TransientCompositionalPipeNetworkHistory empty() {
+    return new TransientCompositionalPipeNetworkHistory(new double[0], new String[0],
+        Collections.<String, double[][]>emptyMap(),
+        Collections.<String, List<TransientSpeciesConservationReport>>emptyMap(),
+        Collections.<String, List<TransientSpeciesConservationReport>>emptyMap(),
+        Collections.<TransientSpeciesConservationReport>emptyList());
+  }
+
+  /** @return accepted-step end times in seconds */
+  public double[] getElapsedTimeSeconds() {
+    return copy(elapsedTimeSeconds);
+  }
+
+  /** @return deterministic component-name order used by all arrays */
+  public String[] getComponentNames() {
+    return copy(componentNames);
+  }
+
+  /**
+   * Get all component mass fractions at a node.
+   *
+   * @param nodeName node name
+   * @return defensive time-by-component array
+   */
+  public double[][] getNodeMassFractionHistory(String nodeName) {
+    double[][] values = nodeMassFractionHistory.get(nodeName);
+    if (values == null) {
+      throw new IllegalArgumentException("No species history exists for node '" + nodeName + "'");
+    }
+    return copy(values);
+  }
+
+  /**
+   * Get one named component's node history.
+   *
+   * @param nodeName node name
+   * @param componentName NeqSim component name
+   * @return defensive time-aligned mass-fraction series
+   */
+  public double[] getNodeMassFractionHistory(String nodeName, String componentName) {
+    int componentIndex = componentIndex(componentName);
+    double[][] profile = getNodeMassFractionHistory(nodeName);
+    double[] result = new double[profile.length];
+    for (int timeIndex = 0; timeIndex < profile.length; timeIndex++) {
+      result[timeIndex] = profile[timeIndex][componentIndex];
+    }
+    return result;
+  }
+
+  /**
+   * Get immutable edge reports as a defensive array.
+   *
+   * @param edgeName edge name
+   * @return reports aligned with {@link #getElapsedTimeSeconds()}
+   */
+  public TransientSpeciesConservationReport[] getEdgeReports(String edgeName) {
+    return reportArray(edgeReports, edgeName, "edge");
+  }
+
+  /**
+   * Get immutable junction reports as a defensive array.
+   *
+   * @param nodeName junction name
+   * @return reports aligned with {@link #getElapsedTimeSeconds()}
+   */
+  public TransientSpeciesConservationReport[] getJunctionReports(String nodeName) {
+    return reportArray(junctionReports, nodeName, "junction");
+  }
+
+  /** @return defensive array of cumulative whole-network reports */
+  public TransientSpeciesConservationReport[] getNetworkReports() {
+    return networkReports.toArray(new TransientSpeciesConservationReport[networkReports.size()]);
+  }
+
+  /**
+   * Get the last whole-network report.
+   *
+   * @return final cumulative report
+   * @throws IllegalStateException before a run
+   */
+  public TransientSpeciesConservationReport getFinalNetworkReport() {
+    if (networkReports.isEmpty()) {
+      throw new IllegalStateException("Transient compositional network has not run");
+    }
+    return networkReports.get(networkReports.size() - 1);
+  }
+
+  /**
+   * Serialize all histories for Python/JPype capture.
+   *
+   * @return stable, pretty-printed JSON
+   */
+  public String toJson() {
+    JsonSerializer<Double> finiteDoubleSerializer = (value, type,
+        context) -> value != null && Double.isFinite(value) ? new JsonPrimitive(value) : JsonNull.INSTANCE;
+    return new GsonBuilder().registerTypeAdapter(Double.class, finiteDoubleSerializer)
+        .registerTypeAdapter(Double.TYPE, finiteDoubleSerializer).serializeNulls().setPrettyPrinting().create()
+        .toJson(this);
+  }
+
+  private int componentIndex(String componentName) {
+    for (int index = 0; index < componentNames.length; index++) {
+      if (componentNames[index].equals(componentName)) {
+        return index;
+      }
+    }
+    throw new IllegalArgumentException("Component '" + componentName + "' is not present in this network history");
+  }
+
+  private static TransientSpeciesConservationReport[] reportArray(
+      Map<String, List<TransientSpeciesConservationReport>> reports, String name, String kind) {
+    List<TransientSpeciesConservationReport> values = reports.get(name);
+    if (values == null) {
+      throw new IllegalArgumentException("No " + kind + " species reports exist for '" + name + "'");
+    }
+    return values.toArray(new TransientSpeciesConservationReport[values.size()]);
+  }
+
+  private static Map<String, double[][]> copyProfiles(Map<String, double[][]> profiles) {
+    Map<String, double[][]> result = new LinkedHashMap<String, double[][]>();
+    for (Map.Entry<String, double[][]> entry : profiles.entrySet()) {
+      result.put(entry.getKey(), copy(entry.getValue()));
+    }
+    return Collections.unmodifiableMap(result);
+  }
+
+  private static Map<String, List<TransientSpeciesConservationReport>> copyReports(
+      Map<String, List<TransientSpeciesConservationReport>> reports) {
+    Map<String, List<TransientSpeciesConservationReport>> result = new LinkedHashMap<String, List<TransientSpeciesConservationReport>>();
+    for (Map.Entry<String, List<TransientSpeciesConservationReport>> entry : reports.entrySet()) {
+      result.put(entry.getKey(),
+          Collections.unmodifiableList(new ArrayList<TransientSpeciesConservationReport>(entry.getValue())));
+    }
+    return Collections.unmodifiableMap(result);
+  }
+
+  private static double[] copy(double[] values) {
+    return values == null ? new double[0] : Arrays.copyOf(values, values.length);
+  }
+
+  private static String[] copy(String[] values) {
+    return values == null ? new String[0] : Arrays.copyOf(values, values.length);
+  }
+
+  private static double[][] copy(double[][] values) {
+    if (values == null) {
+      return new double[0][0];
+    }
+    double[][] result = new double[values.length][];
+    for (int index = 0; index < values.length; index++) {
+      result[index] = copy(values[index]);
+    }
+    return result;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/network/TransientSpeciesConservationReport.java
+++ b/src/main/java/neqsim/process/equipment/network/TransientSpeciesConservationReport.java
@@ -156,9 +156,12 @@ public final class TransientSpeciesConservationReport implements Serializable {
   public String toJson() {
     JsonSerializer<Double> finiteDoubleSerializer = (value, type,
         context) -> value != null && Double.isFinite(value) ? new JsonPrimitive(value) : JsonNull.INSTANCE;
-    return new GsonBuilder().registerTypeAdapter(Double.class, finiteDoubleSerializer)
-        .registerTypeAdapter(Double.TYPE, finiteDoubleSerializer).serializeNulls().setPrettyPrinting().create()
-        .toJson(this);
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.registerTypeAdapter(Double.class, finiteDoubleSerializer);
+    gsonBuilder.registerTypeAdapter(Double.TYPE, finiteDoubleSerializer);
+    gsonBuilder.serializeNulls();
+    gsonBuilder.setPrettyPrinting();
+    return gsonBuilder.create().toJson(this);
   }
 
   private static double[] copy(double[] values) {

--- a/src/main/java/neqsim/process/equipment/network/TransientSpeciesConservationReport.java
+++ b/src/main/java/neqsim/process/equipment/network/TransientSpeciesConservationReport.java
@@ -1,0 +1,182 @@
+package neqsim.process.equipment.network;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
+
+/** Immutable component-inventory diagnostics for one transient network location and timestep. */
+public final class TransientSpeciesConservationReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Location represented by a report. */
+  public enum LocationType {
+    /** One finite-volume pipe edge. */
+    EDGE,
+    /** One conservative mixing junction. */
+    JUNCTION,
+    /** The complete network, including every edge inventory. */
+    NETWORK
+  }
+
+  private final String locationName;
+  private final LocationType locationType;
+  private final double elapsedTimeSeconds;
+  private final String[] componentNames;
+  private final double[][] massFractionProfile;
+  private final double[] initialInventoryKg;
+  private final double[] finalInventoryKg;
+  private final double[] inletBoundaryMassKg;
+  private final double[] outletBoundaryMassKg;
+  private final double[] inventoryResidualKg;
+  private final double[] relativeInventoryResidual;
+  private final double maximumRelativeInventoryResidual;
+  private final double minimumMassFraction;
+  private final double maximumMassFraction;
+  private final double maximumMassFractionSumError;
+  private final boolean converged;
+  private final String message;
+
+  TransientSpeciesConservationReport(String locationName, LocationType locationType, double elapsedTimeSeconds,
+      String[] componentNames, double[][] massFractionProfile, double[] initialInventoryKg, double[] finalInventoryKg,
+      double[] inletBoundaryMassKg, double[] outletBoundaryMassKg, double[] inventoryResidualKg,
+      double[] relativeInventoryResidual, double maximumRelativeInventoryResidual, double minimumMassFraction,
+      double maximumMassFraction, double maximumMassFractionSumError, boolean converged, String message) {
+    this.locationName = locationName;
+    this.locationType = locationType;
+    this.elapsedTimeSeconds = elapsedTimeSeconds;
+    this.componentNames = copy(componentNames);
+    this.massFractionProfile = copy(massFractionProfile);
+    this.initialInventoryKg = copy(initialInventoryKg);
+    this.finalInventoryKg = copy(finalInventoryKg);
+    this.inletBoundaryMassKg = copy(inletBoundaryMassKg);
+    this.outletBoundaryMassKg = copy(outletBoundaryMassKg);
+    this.inventoryResidualKg = copy(inventoryResidualKg);
+    this.relativeInventoryResidual = copy(relativeInventoryResidual);
+    this.maximumRelativeInventoryResidual = maximumRelativeInventoryResidual;
+    this.minimumMassFraction = minimumMassFraction;
+    this.maximumMassFraction = maximumMassFraction;
+    this.maximumMassFractionSumError = maximumMassFractionSumError;
+    this.converged = converged;
+    this.message = message;
+  }
+
+  /** @return edge, junction, or network name */
+  public String getLocationName() {
+    return locationName;
+  }
+
+  /** @return represented location type */
+  public LocationType getLocationType() {
+    return locationType;
+  }
+
+  /** @return accepted-step end time in seconds */
+  public double getElapsedTimeSeconds() {
+    return elapsedTimeSeconds;
+  }
+
+  /** @return defensive copy of component names */
+  public String[] getComponentNames() {
+    return copy(componentNames);
+  }
+
+  /** @return defensive component-by-cell mass-fraction profile, empty for non-edge reports */
+  public double[][] getMassFractionProfile() {
+    return copy(massFractionProfile);
+  }
+
+  /** @return component inventories at the beginning of the run in kg */
+  public double[] getInitialInventoryKg() {
+    return copy(initialInventoryKg);
+  }
+
+  /** @return component inventories at this accepted time in kg */
+  public double[] getFinalInventoryKg() {
+    return copy(finalInventoryKg);
+  }
+
+  /** @return cumulative integrated inlet component masses through this accepted time in kg */
+  public double[] getInletBoundaryMassKg() {
+    return copy(inletBoundaryMassKg);
+  }
+
+  /** @return cumulative integrated outlet component masses through this accepted time in kg */
+  public double[] getOutletBoundaryMassKg() {
+    return copy(outletBoundaryMassKg);
+  }
+
+  /** @return final minus initial minus inlet plus outlet component residuals in kg */
+  public double[] getInventoryResidualKg() {
+    return copy(inventoryResidualKg);
+  }
+
+  /** @return component residuals divided by their conservative balance scale */
+  public double[] getRelativeInventoryResidual() {
+    return copy(relativeInventoryResidual);
+  }
+
+  /** @return maximum absolute relative component residual */
+  public double getMaximumRelativeInventoryResidual() {
+    return maximumRelativeInventoryResidual;
+  }
+
+  /** @return minimum mass fraction, or NaN for reports without a composition profile */
+  public double getMinimumMassFraction() {
+    return minimumMassFraction;
+  }
+
+  /** @return maximum mass fraction, or NaN for reports without a composition profile */
+  public double getMaximumMassFraction() {
+    return maximumMassFraction;
+  }
+
+  /** @return maximum cell-wise absolute mass-fraction sum error */
+  public double getMaximumMassFractionSumError() {
+    return maximumMassFractionSumError;
+  }
+
+  /** @return true when balance and boundedness criteria passed */
+  public boolean isConverged() {
+    return converged;
+  }
+
+  /** @return diagnostic summary */
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Serialize this immutable report for Python/JPype capture.
+   *
+   * @return stable, pretty-printed JSON
+   */
+  public String toJson() {
+    JsonSerializer<Double> finiteDoubleSerializer = (value, type,
+        context) -> value != null && Double.isFinite(value) ? new JsonPrimitive(value) : JsonNull.INSTANCE;
+    return new GsonBuilder().registerTypeAdapter(Double.class, finiteDoubleSerializer)
+        .registerTypeAdapter(Double.TYPE, finiteDoubleSerializer).serializeNulls().setPrettyPrinting().create()
+        .toJson(this);
+  }
+
+  private static double[] copy(double[] values) {
+    return values == null ? new double[0] : Arrays.copyOf(values, values.length);
+  }
+
+  private static String[] copy(String[] values) {
+    return values == null ? new String[0] : Arrays.copyOf(values, values.length);
+  }
+
+  private static double[][] copy(double[][] values) {
+    if (values == null) {
+      return new double[0][0];
+    }
+    double[][] result = new double[values.length][];
+    for (int index = 0; index < values.length; index++) {
+      result[index] = copy(values[index]);
+    }
+    return result;
+  }
+}

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -24,6 +24,8 @@ import neqsim.process.equipment.distillation.internals.ColumnInternalsDesigner;
 import neqsim.process.equipment.energy.EnergyNetworkSolver;
 import neqsim.process.equipment.heatexchanger.CoolingWaterSystem;
 import neqsim.process.equipment.heatexchanger.FiredHeater;
+import neqsim.process.equipment.network.TransientCompositionalPipeNetwork;
+import neqsim.process.equipment.network.TransientCompositionalPipeNetworkHistory;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction.InterfacialFrictionResult;
 import neqsim.process.equipment.pump.Pump;
@@ -84,6 +86,53 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @version 1.0
  */
 public class DocExamplesCompilationTest {
+
+  /**
+   * Transient gas-network example from docs/process/gas_network_operations.md.
+   */
+  @Test
+  public void testTransientCompositionalPipeNetworkDocumentationExample() {
+    SystemInterface asgardGas = new SystemSrkEos(300.0, 70.0);
+    asgardGas.addComponent("methane", 0.98);
+    asgardGas.addComponent("CO2", 0.02);
+    asgardGas.setMixingRule("classic");
+
+    SystemInterface kristinGas = new SystemSrkEos(300.0, 70.0);
+    kristinGas.addComponent("methane", 0.95);
+    kristinGas.addComponent("CO2", 0.05);
+    kristinGas.setMixingRule("classic");
+
+    SystemInterface kristinHighCo2 = new SystemSrkEos(300.0, 70.0);
+    kristinHighCo2.addComponent("methane", 0.75);
+    kristinHighCo2.addComponent("CO2", 0.25);
+    kristinHighCo2.setMixingRule("classic");
+
+    SystemInterface mixedGas = new SystemSrkEos(300.0, 70.0);
+    mixedGas.addComponent("methane", 0.965);
+    mixedGas.addComponent("CO2", 0.035);
+    mixedGas.setMixingRule("classic");
+
+    TransientCompositionalPipeNetwork transientNetwork = new TransientCompositionalPipeNetwork(
+        "Norwegian export teaching case");
+    transientNetwork.addNode("asgard");
+    transientNetwork.addNode("kristin");
+    transientNetwork.addNode("junction");
+    transientNetwork.addNode("karsto");
+    transientNetwork.addPipe("asgardBranch", "asgard", "junction", 2000.0, 0.4, 12, asgardGas);
+    transientNetwork.addPipe("kristinBranch", "kristin", "junction", 2000.0, 0.4, 12, kristinGas);
+    transientNetwork.addPipe("export", "junction", "karsto", 4000.0, 0.4, 12, mixedGas);
+    transientNetwork.setSourceSchedule("asgard", new double[] { 0.0 }, new SystemInterface[] { asgardGas },
+        new double[] { 20.0 });
+    transientNetwork.setSourceSchedule("kristin", new double[] { 0.0, 600.0, 1800.0 },
+        new SystemInterface[] { kristinGas, kristinHighCo2, kristinGas }, new double[] { 20.0, 18.0, 20.0 });
+
+    transientNetwork.run(5400.0, 60.0);
+    TransientCompositionalPipeNetworkHistory species = transientNetwork.getSpeciesHistory();
+    assertEquals(90, species.getElapsedTimeSeconds().length);
+    assertEquals(90, species.getNodeMassFractionHistory("karsto", "CO2").length);
+    assertTrue(species.getFinalNetworkReport().getMaximumRelativeInventoryResidual() <= 1.0e-8,
+        species.getFinalNetworkReport().getMessage());
+  }
 
   /**
    * Quick-start example shared by docs/index.md and docs/README.md.

--- a/src/test/java/neqsim/process/equipment/network/TransientCompositionalPipeNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/TransientCompositionalPipeNetworkTest.java
@@ -1,0 +1,237 @@
+package neqsim.process.equipment.network;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Tests for conservative prescribed-flow species transport through a gas gathering network. */
+class TransientCompositionalPipeNetworkTest extends neqsim.NeqSimTest {
+  private static final double TIME_STEP_SECONDS = 60.0;
+  private static final double END_TIME_SECONDS = 5400.0;
+
+  @Test
+  void finiteCo2PulseIsDelayedBroadenedAndConservative() {
+    TransientCompositionalPipeNetwork network = createNetwork(12);
+    network.run(END_TIME_SECONDS, TIME_STEP_SECONDS);
+
+    TransientCompositionalPipeNetworkHistory history = network.getSpeciesHistory();
+    double[] times = history.getElapsedTimeSeconds();
+    double[] junctionCo2 = history.getNodeMassFractionHistory("junction", "CO2");
+    double[] deliveryCo2 = history.getNodeMassFractionHistory("karsto", "CO2");
+    assertEquals((int) (END_TIME_SECONDS / TIME_STEP_SECONDS), times.length);
+
+    double baseline = deliveryCo2[0];
+    double junctionPeak = maximum(junctionCo2);
+    double deliveryPeak = maximum(deliveryCo2);
+    double threshold = baseline + 0.10 * (junctionPeak - baseline);
+    int junctionBreakthrough = firstAbove(junctionCo2, threshold);
+    int deliveryBreakthrough = firstAbove(deliveryCo2, threshold);
+
+    assertTrue(junctionPeak > baseline + 0.02, "The finite Kristin CO2 event must reach the junction.");
+    assertTrue(deliveryBreakthrough > junctionBreakthrough,
+        "Export-pipe linepack must delay the Kårstø response relative to the junction.");
+    assertTrue(deliveryPeak < junctionPeak,
+        "Finite-volume edge inventories must broaden the pulse and reduce its downstream peak.");
+    assertTrue(deliveryCo2[deliveryCo2.length - 1] < baseline + 2.0e-3,
+        "The delivery composition must return close to its initial state after the pulse.");
+
+    for (String edgeName : new String[] { "asgardBranch", "kristinBranch", "export" }) {
+      TransientSpeciesConservationReport[] reports = history.getEdgeReports(edgeName);
+      assertEquals(times.length, reports.length);
+      assertTrue(sum(reports[reports.length - 1].getInletBoundaryMassKg()) > sum(reports[0].getInletBoundaryMassKg()),
+          "Edge boundary masses must be cumulative in time.");
+      for (TransientSpeciesConservationReport report : reports) {
+        assertTrue(report.isConverged(), report.getMessage());
+        assertTrue(report.getMaximumRelativeInventoryResidual() <= 1.0e-8, report.getMessage());
+        assertTrue(report.getMinimumMassFraction() >= 0.0, report.getMessage());
+        assertTrue(report.getMaximumMassFraction() <= 1.0, report.getMessage());
+      }
+    }
+    for (TransientSpeciesConservationReport report : history.getJunctionReports("junction")) {
+      assertTrue(report.isConverged(), report.getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() <= 1.0e-8, report.getMessage());
+    }
+    for (TransientSpeciesConservationReport report : history.getNetworkReports()) {
+      assertTrue(report.isConverged(), report.getMessage());
+      assertTrue(report.getMaximumRelativeInventoryResidual() <= 1.0e-8, report.getMessage());
+    }
+  }
+
+  @Test
+  void componentIdentityUsesNamesAndHistoriesAreImmutable() {
+    TransientCompositionalPipeNetwork network = createNetwork(8);
+    network.run(600.0, TIME_STEP_SECONDS);
+    TransientCompositionalPipeNetworkHistory history = network.getSpeciesHistory();
+
+    assertArrayEquals(new String[] { "CO2", "methane" }, history.getComponentNames());
+    double sourceACo2 = massFraction(gas(0.98, 0.02, false), "CO2");
+    double sourceBCo2 = massFraction(gas(0.95, 0.05, true), "CO2");
+    double expectedInitialJunctionCo2 = 0.5 * (sourceACo2 + sourceBCo2);
+    double[] junctionCo2 = history.getNodeMassFractionHistory("junction", "CO2");
+    assertEquals(expectedInitialJunctionCo2, junctionCo2[0], 1.0e-12,
+        "Component order differences in source fluids must not swap methane and CO2.");
+
+    double original = junctionCo2[0];
+    junctionCo2[0] = 99.0;
+    assertEquals(original, history.getNodeMassFractionHistory("junction", "CO2")[0], 0.0);
+
+    TransientSpeciesConservationReport edgeReport = history.getEdgeReports("export")[0];
+    double[][] profile = edgeReport.getMassFractionProfile();
+    double profileValue = profile[0][0];
+    profile[0][0] = 99.0;
+    assertEquals(profileValue, edgeReport.getMassFractionProfile()[0][0], 0.0);
+    assertTrue(history.toJson().contains("nodeMassFractionHistory"));
+  }
+
+  @Test
+  void repeatedRunIsDeterministic() {
+    TransientCompositionalPipeNetwork network = createNetwork(8);
+    network.run(2400.0, TIME_STEP_SECONDS);
+    String first = network.getSpeciesHistory().toJson();
+    network.run(2400.0, TIME_STEP_SECONDS);
+    assertEquals(first, network.getSpeciesHistory().toJson());
+  }
+
+  @Test
+  @Tag("slow")
+  void jointGridAndTimestepRefinementReducesCommonTimeDifference() {
+    double[] coarse = runDeliveryHistory(4, 120.0);
+    double[] medium = runDeliveryHistory(8, 60.0);
+    double[] fine = runDeliveryHistory(16, 30.0);
+
+    double coarseToMedium = commonTimeMeanAbsoluteDifference(coarse, 120.0, medium, 60.0, 120.0);
+    double mediumToFine = commonTimeMeanAbsoluteDifference(medium, 60.0, fine, 30.0, 120.0);
+    assertTrue(coarseToMedium > 0.0);
+    assertTrue(mediumToFine < coarseToMedium, "Joint refinement must reduce outlet-history difference: coarse-medium="
+        + coarseToMedium + ", medium-fine=" + mediumToFine);
+  }
+
+  @Test
+  void unsupportedReverseFlowAndPhaseAppearanceFailLoudly() {
+    TransientCompositionalPipeNetwork reverse = new TransientCompositionalPipeNetwork("reverse");
+    reverse.addNode("source");
+    reverse.addNode("sink");
+    reverse.addPipe("pipe", "source", "sink", 1000.0, 0.3, 4, gas(0.98, 0.02, false));
+    IllegalArgumentException reverseError = assertThrows(IllegalArgumentException.class,
+        () -> reverse.setSourceSchedule("source", new double[] { 0.0 },
+            new SystemInterface[] { gas(0.98, 0.02, false) }, new double[] { -1.0 }));
+    assertTrue(reverseError.getMessage().contains("reverse flow"));
+
+    TransientCompositionalPipeNetwork phaseAppearance = new TransientCompositionalPipeNetwork("two phase");
+    phaseAppearance.addNode("source");
+    phaseAppearance.addNode("sink");
+    SystemInterface twoPhase = twoPhaseFluid();
+    phaseAppearance.addPipe("pipe", "source", "sink", 1000.0, 0.3, 4, twoPhase);
+    phaseAppearance.setSourceSchedule("source", new double[] { 0.0 }, new SystemInterface[] { twoPhase },
+        new double[] { 10.0 });
+    IllegalArgumentException phaseError = assertThrows(IllegalArgumentException.class,
+        () -> phaseAppearance.run(60.0, 60.0));
+    assertTrue(phaseError.getMessage().contains("phase appearance"));
+  }
+
+  private static double[] runDeliveryHistory(int cells, double timeStepSeconds) {
+    TransientCompositionalPipeNetwork network = createNetwork(cells);
+    network.run(END_TIME_SECONDS, timeStepSeconds);
+    return network.getSpeciesHistory().getNodeMassFractionHistory("karsto", "CO2");
+  }
+
+  private static TransientCompositionalPipeNetwork createNetwork(int cells) {
+    SystemInterface initialMixed = gas(0.965, 0.035, false);
+    TransientCompositionalPipeNetwork network = new TransientCompositionalPipeNetwork("Norwegian export teaching case");
+    network.addNode("asgard");
+    network.addNode("kristin");
+    network.addNode("junction");
+    network.addNode("karsto");
+    network.addPipe("asgardBranch", "asgard", "junction", 2000.0, 0.4, cells, gas(0.98, 0.02, false));
+    network.addPipe("kristinBranch", "kristin", "junction", 2000.0, 0.4, cells, gas(0.95, 0.05, true));
+    network.addPipe("export", "junction", "karsto", 4000.0, 0.4, cells, initialMixed);
+
+    network.setSourceSchedule("asgard", new double[] { 0.0 }, new SystemInterface[] { gas(0.98, 0.02, false) },
+        new double[] { 20.0 });
+    network.setSourceSchedule("kristin", new double[] { 0.0, 600.0, 1800.0 },
+        new SystemInterface[] { gas(0.95, 0.05, true), gas(0.75, 0.25, false), gas(0.95, 0.05, true) },
+        new double[] { 20.0, 18.0, 20.0 });
+    return network;
+  }
+
+  private static SystemInterface gas(double methaneMoleFraction, double co2MoleFraction, boolean reverseOrder) {
+    SystemInterface fluid = new SystemSrkEos(300.0, 70.0);
+    if (reverseOrder) {
+      fluid.addComponent("CO2", co2MoleFraction);
+      fluid.addComponent("methane", methaneMoleFraction);
+    } else {
+      fluid.addComponent("methane", methaneMoleFraction);
+      fluid.addComponent("CO2", co2MoleFraction);
+    }
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  private static SystemInterface twoPhaseFluid() {
+    SystemInterface fluid = new SystemSrkEos(240.0, 20.0);
+    fluid.addComponent("methane", 0.5);
+    fluid.addComponent("n-heptane", 0.5);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  private static double massFraction(SystemInterface fluid, String componentName) {
+    new ThermodynamicOperations(fluid).TPflash();
+    fluid.initProperties();
+    double total = 0.0;
+    double selected = 0.0;
+    double[] z = fluid.getMolarComposition();
+    for (int index = 0; index < fluid.getNumberOfComponents(); index++) {
+      double mass = z[index] * fluid.getPhase(0).getComponent(index).getMolarMass();
+      total += mass;
+      if (componentName.equals(fluid.getPhase(0).getComponent(index).getComponentName())) {
+        selected = mass;
+      }
+    }
+    return selected / total;
+  }
+
+  private static int firstAbove(double[] values, double threshold) {
+    for (int index = 0; index < values.length; index++) {
+      if (values[index] > threshold) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  private static double maximum(double[] values) {
+    double maximum = Double.NEGATIVE_INFINITY;
+    for (double value : values) {
+      maximum = Math.max(maximum, value);
+    }
+    return maximum;
+  }
+
+  private static double sum(double[] values) {
+    double total = 0.0;
+    for (double value : values) {
+      total += value;
+    }
+    return total;
+  }
+
+  private static double commonTimeMeanAbsoluteDifference(double[] coarse, double coarseStep, double[] fine,
+      double fineStep, double comparisonStep) {
+    int points = (int) Math.floor(Math.min(coarse.length * coarseStep, fine.length * fineStep) / comparisonStep);
+    double totalDifference = 0.0;
+    for (int point = 1; point <= points; point++) {
+      int coarseIndex = (int) Math.round(point * comparisonStep / coarseStep) - 1;
+      int fineIndex = (int) Math.round(point * comparisonStep / fineStep) - 1;
+      totalDifference += Math.abs(coarse[coarseIndex] - fine[fineIndex]);
+    }
+    return totalDifference / points;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/network/TransientCompositionalPipeNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/TransientCompositionalPipeNetworkTest.java
@@ -45,8 +45,9 @@ class TransientCompositionalPipeNetworkTest extends neqsim.NeqSimTest {
     for (String edgeName : new String[] { "asgardBranch", "kristinBranch", "export" }) {
       TransientSpeciesConservationReport[] reports = history.getEdgeReports(edgeName);
       assertEquals(times.length, reports.length);
-      assertTrue(sum(reports[reports.length - 1].getInletBoundaryMassKg()) > sum(reports[0].getInletBoundaryMassKg()),
-          "Edge boundary masses must be cumulative in time.");
+      double cumulativeInletMass = sum(reports[reports.length - 1].getInletBoundaryMassKg());
+      double firstStepInletMass = sum(reports[0].getInletBoundaryMassKg());
+      assertTrue(cumulativeInletMass > firstStepInletMass, "Edge boundary masses must be cumulative in time.");
       for (TransientSpeciesConservationReport report : reports) {
         assertTrue(report.isConverged(), report.getMessage());
         assertTrue(report.getMaximumRelativeInventoryResidual() <= 1.0e-8, report.getMessage());

--- a/src/test/java/neqsim/process/equipment/network/TransientCompositionalPipeNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/TransientCompositionalPipeNetworkTest.java
@@ -134,6 +134,17 @@ class TransientCompositionalPipeNetworkTest extends neqsim.NeqSimTest {
     IllegalArgumentException phaseError = assertThrows(IllegalArgumentException.class,
         () -> phaseAppearance.run(60.0, 60.0));
     assertTrue(phaseError.getMessage().contains("phase appearance"));
+
+    TransientCompositionalPipeNetwork liquidNetwork = new TransientCompositionalPipeNetwork("liquid");
+    liquidNetwork.addNode("source");
+    liquidNetwork.addNode("sink");
+    SystemInterface liquid = singlePhaseLiquid();
+    liquidNetwork.addPipe("pipe", "source", "sink", 1000.0, 0.3, 4, liquid);
+    liquidNetwork.setSourceSchedule("source", new double[] { 0.0 }, new SystemInterface[] { liquid },
+        new double[] { 10.0 });
+    IllegalArgumentException liquidError = assertThrows(IllegalArgumentException.class,
+        () -> liquidNetwork.run(60.0, 60.0));
+    assertTrue(liquidError.getMessage().contains("exactly one gas phase"));
   }
 
   private static double[] runDeliveryHistory(int cells, double timeStepSeconds) {
@@ -178,6 +189,13 @@ class TransientCompositionalPipeNetworkTest extends neqsim.NeqSimTest {
     SystemInterface fluid = new SystemSrkEos(240.0, 20.0);
     fluid.addComponent("methane", 0.5);
     fluid.addComponent("n-heptane", 0.5);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  private static SystemInterface singlePhaseLiquid() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 10.0);
+    fluid.addComponent("n-heptane", 1.0);
     fluid.setMixingRule("classic");
     return fluid;
   }


### PR DESCRIPTION
## Summary

- add a dedicated `TransientCompositionalPipeNetwork` for prescribed positive-flow, one-phase, isothermal gathering networks
- propagate piecewise-constant source composition and mass-flow schedules through fixed edge inventories with implicit conservative finite-volume transport
- mix junction boundary masses by canonical component name and retain linepack delay through every downstream edge
- expose defensive Java/Python histories with cumulative edge, junction, and whole-network component balances
- document the equations, Åsgard/Kristin-to-Kårstø teaching topology, JPype access, and explicit v1 limitations

## Root cause

NeqSim had steady conservative junction mixing and conservative single-pipe species transport, but no accepted-timestep network layer connecting source schedules, edge inventories, junction mixing, and downstream delivery histories. Examples therefore needed an instantaneous manual handoff.

## Validation

- `TransientCompositionalPipeNetworkTest`: 5/5 tests passed, including the normally excluded slow refinement test
- finite CO2 pulse is delayed and broadened by branch/export inventories
- component identity is independent of source array order
- variable source-flow schedule, deterministic repeat, immutable histories, reverse-flow and phase-appearance diagnostics covered
- edge, junction, and network cumulative relative residuals remain below `1e-8`; JPype smoke final network residual was `1.13e-16`
- `spotless:check`, pre-commit, pre-push, documentation-search audit, `git diff --check`, and Python syntax check passed
- local Javadoc generation is unavailable in the trimmed runtime image, so this remains draft until the remote build/Javadoc check completes

## Documentation impact

Updated `docs/process/gas_network_operations.md`, `devtools/neqsim_dev_setup.py`, and `CHANGELOG_AGENT_NOTES.md`.

Closes #2825