### PR TITLE
feat(pipe): add physical axial species dispersion

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -305,6 +305,7 @@ requires both composition and EOS-density residuals to converge.
 
 ```java
 pipe.setSpeciesAdvectionScheme(SpeciesAdvectionScheme.TVD_VAN_LEER_SSP_RK2);
+pipe.setAxialDispersionModel(new ConstantAxialDispersion(1.0)); // physical D_ax [m2/s]
 pipe.setConservativeSpeciesTransport(true);
 pipe.setStoreSpeciesConservationHistory(true);
 pipe.setFailOnNonConvergence(true);
@@ -317,6 +318,9 @@ SpeciesTransportDiagnostics resolution = species.getTransportDiagnostics();
 double maximumFullStepCfl = resolution.getMaximumCellCourantNumber();
 double firstOrderReferenceM2PerSecond =
     resolution.getMaximumFirstOrderImplicitNumericalDispersionM2PerSecond();
+double physicalDispersionM2PerSecond =
+    resolution.getMaximumPhysicalAxialDispersionM2PerSecond();
+double[] physicalCellPeclet = resolution.getCellPecletNumbers();
 
 OnePhaseSpeciesConservationHistory history = pipe.getSpeciesConservationHistory();
 double[] acceptedStepTimesSeconds = history.getElapsedTimeSeconds();
@@ -327,8 +331,10 @@ String pythonReadyHistoryJson = history.toJson();
 `TVD_VAN_LEER_SSP_RK2` method uses MUSCL face reconstruction with a Van Leer limiter and a
 two-stage strong-stability-preserving Runge-Kutta update. It automatically divides an accepted
 hydraulic step into conservative transport substeps until every local mass Courant number is at
-most 0.45. The limited positive-flow update is bounded without clipping and remains second order
-in smooth constant-coefficient regions. `SpeciesAdvectionScheme` is separate from the legacy
+most 0.45. When explicit physical dispersion is enabled, the substep criterion includes both
+advective CFL and the physical face-conductance dispersion number. The limited positive-flow
+update is bounded without clipping and remains second order in smooth constant-coefficient
+regions. `SpeciesAdvectionScheme` is separate from the legacy
 `AdvectionScheme`; setting the latter does not silently change the validated component-inventory
 path.
 
@@ -365,7 +371,9 @@ relative inventory residuals, boundedness and sum-to-one diagnostics, thermodyna
 synchronization error, hydraulic/species residual histories, and a per-step
 `SpeciesTransportDiagnostics` object. The diagnostic records the selected method, full-step local
 and effective CFL values, the number of bounded substeps, and the first-order implicit numerical-
-dispersion reference. Its array getters return defensive copies and `toJson()` is suitable for
+dispersion reference. It separately records the selected physical model, physical coefficient
+profile/range, cell Peclet numbers, full-step physical dispersion numbers, and boundary
+conditions. Its array getters return defensive copies and `toJson()` is suitable for
 Python-side result capture.
 
 For constant velocity and cell length, modified-equation analysis of the compatibility method
@@ -378,10 +386,45 @@ $$
 The diagnostic reports this quantity in m²/s when cell lengths are available, including when the
 TVD method is selected so the avoided first-order spreading remains visible. A flux limiter does
 not have one constant equivalent diffusion coefficient, so the value is explicitly a first-order
-reference rather than a TVD calibration. Physical axial dispersion is still disabled: cell
-Peclet entries are therefore unavailable (`NaN` in Java and `null` in JSON). Physical dispersion
-must be added as a separate flux model and must not be inferred from a grid-dependent numerical
-coefficient.
+reference rather than a TVD calibration.
+
+Physical axial dispersion is a separate opt-in flux model. `NoAxialDispersion` is the default and
+reproduces pure-advection behavior exactly. `ConstantAxialDispersion(D_ax)` supplies a finite
+non-negative physical coefficient in m²/s for analytical tests, calibration, and uncertainty
+studies. For every internal face the solver constructs one conservative conductance by adding the
+two adjacent half-cell resistances from cell line density, length, and coefficient. This remains
+consistent on a nonuniform grid. The same component flux leaves the west cell and enters the east
+cell. The independent $n-1$ component fluxes are advanced and the final component flux is their
+negative sum, preserving sum-to-one without clipping or normalization.
+
+The physical boundary conditions are explicit:
+
+- `DIRICHLET_INLET`: the inlet thermodynamic-system mass fraction is the external composition for
+  both advection and physical dispersion;
+- `ZERO_GRADIENT_OUTLET`: physical dispersive flux is zero, while advective component mass leaves
+  with the outlet composition.
+
+First-order advection and physical dispersion use one coupled implicit tridiagonal solve. The TVD
+path applies the physical face flux in both SSP-RK2 stages and automatically substeps the combined
+explicit operator. Diagnostics report
+
+$$
+Pe_P=\frac{u_P\,\Delta x_P}{D_{ax,P}}
+$$
+
+only when $D_{ax,P}>0$. A constant coefficient is a user hypothesis, not a turbulent-pipe
+correlation. Molecular diffusion, Taylor/shear dispersion, network mixing, and grid-dependent
+numerical spreading must be evaluated separately. Calibrate $D_{ax}$ only after a grid/time study
+with the physical model held fixed; never tune it to cancel numerical diffusion.
+
+Published validation should follow the operational comparison in Chaczykowski et al. (2018):
+align measured inlet composition, flow/pressure history, geometry, and outlet gas-chromatograph
+timestamps; report transport-time error separately from profile-shape error; and repeat the study
+under grid/time refinement with one fixed physical coefficient. If the Norwegian and Polish
+machine-readable operational series cannot be redistributed, use permissioned data in a private
+validation job and publish only aggregate error metrics. The repository's Gaussian-variance and
+finite-pulse tests remain the non-proprietary analytical regression and must not be presented as
+operational calibration.
 
 After `setStoreSpeciesConservationHistory(true)`,
 `PipeFlowSystem.getSpeciesConservationHistory()` retains the immutable report from every accepted
@@ -523,8 +566,9 @@ The steady-state solver has been validated for:
    first-order kernel grid/time refinement are established for positive isothermal flow. Full
    hydraulic/EOS grid/time convergence, thermal coupling, phase appearance, and network junctions
    are not yet established.
-3. **No physical axial dispersion model**: Existing advection-scheme spreading is numerical and
-   must not be interpreted as molecular or turbulent dispersion.
+3. **Physical-dispersion scope is deliberately narrow**: `NoAxialDispersion` and a user-specified
+   constant coefficient are available. No compressible turbulent-pipe correlation is asserted;
+   project use requires tracer/gas-quality calibration and a documented validity range.
 4. **Positive-flow diagnostic boundary**: Current transient mass diagnostics reject reverse
    boundary flow because an external upwind thermodynamic state is not yet defined.
 5. **TimeSeries API**: Inlet systems array must have N-1 elements for N time points (one system per interval)
@@ -537,7 +581,8 @@ Planned dependency order is:
 - Coupled hydraulic/EOS and total-mass convergence for solver type `1`
 - Conservative repeated-step and pulse validation after the one-step component balance
 - Dimensionally valid higher-order convection after the established first-order analytical gate
-- Explicit physical dispersion as a separate, documented model
+- Published and permissioned operational validation of constant physical dispersion, followed by
+  review of any turbulent/shear correlation before it becomes a selectable model
 
 ### TimeSeries Best Practices
 
@@ -564,3 +609,5 @@ pipe.getTimeSeries().setInletThermoSystems(systems);
 5. Chen, Q. et al. (2024). “A transient gas pipeline network simulation model for decoupling the
    hydraulic-thermal process and the component tracking process.” *Energy*, 301, 131613.
    <https://doi.org/10.1016/j.energy.2024.131613>.
+6. Taylor, G. I. (1954). “The dispersion of matter in turbulent flow through a pipe.”
+   *Proceedings of the Royal Society A*, 223, 446–468. <https://doi.org/10.1098/rspa.1954.0130>.

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/AxialDispersionBoundaryCondition.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/AxialDispersionBoundaryCondition.java
@@ -1,0 +1,9 @@
+package neqsim.fluidmechanics.flowsolver;
+
+/** Boundary conditions used by physical axial dispersion in one-phase component transport. */
+public enum AxialDispersionBoundaryCondition {
+  /** Inlet mass fraction is prescribed by the transient inlet thermodynamic system. */
+  DIRICHLET_INLET,
+  /** Outlet physical diffusive flux is zero; component departure remains convective. */
+  ZERO_GRADIENT_OUTLET
+}

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/AxialDispersionModel.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/AxialDispersionModel.java
@@ -1,0 +1,31 @@
+package neqsim.fluidmechanics.flowsolver;
+
+import java.io.Serializable;
+
+/**
+ * Physical axial-dispersion model for conservative one-phase component transport.
+ *
+ * <p>
+ * Implementations return a physical coefficient in m2/s. This API is deliberately separate from
+ * {@link SpeciesAdvectionScheme}: numerical spreading from an advection discretization must not be fitted or reported
+ * as physical dispersion.
+ * </p>
+ */
+public interface AxialDispersionModel extends Serializable {
+  /**
+   * Get the physical axial-dispersion coefficient for a cell.
+   *
+   * @param cellIndex zero-based physical-cell index
+   * @param cellLengthM physical cell length in m
+   * @param cellMassKg reference gas mass in the cell in kg
+   * @param massFlowKgPerSecond reference positive mass flow in kg/s
+   * @return finite non-negative physical coefficient in m2/s
+   */
+  double getCoefficientM2PerSecond(int cellIndex, double cellLengthM, double cellMassKg, double massFlowKgPerSecond);
+
+  /** @return stable human-readable model name for diagnostics */
+  String getName();
+
+  /** @return true when the model can contribute a non-zero physical dispersive flux */
+  boolean isEnabled();
+}

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/ConstantAxialDispersion.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/ConstantAxialDispersion.java
@@ -1,0 +1,44 @@
+package neqsim.fluidmechanics.flowsolver;
+
+/** User-specified constant physical axial-dispersion coefficient. */
+public final class ConstantAxialDispersion implements AxialDispersionModel {
+  private static final long serialVersionUID = 1000L;
+  private final double coefficientM2PerSecond;
+
+  /**
+   * Create a constant physical-dispersion model.
+   *
+   * @param coefficientM2PerSecond finite non-negative coefficient in m2/s
+   * @throws IllegalArgumentException if the coefficient is negative or non-finite
+   */
+  public ConstantAxialDispersion(double coefficientM2PerSecond) {
+    if (!Double.isFinite(coefficientM2PerSecond) || coefficientM2PerSecond < 0.0) {
+      throw new IllegalArgumentException("Physical axial dispersion must be finite and non-negative in m2/s.");
+    }
+    this.coefficientM2PerSecond = coefficientM2PerSecond;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getCoefficientM2PerSecond(int cellIndex, double cellLengthM, double cellMassKg,
+      double massFlowKgPerSecond) {
+    return coefficientM2PerSecond;
+  }
+
+  /** @return configured constant physical coefficient in m2/s */
+  public double getConstantCoefficientM2PerSecond() {
+    return coefficientM2PerSecond;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getName() {
+    return "constant";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isEnabled() {
+    return coefficientM2PerSecond > 0.0;
+  }
+}

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/NoAxialDispersion.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/NoAxialDispersion.java
@@ -1,6 +1,13 @@
 package neqsim.fluidmechanics.flowsolver;
 
-/** Default physical-dispersion model: pure advection with {@code D_ax = 0}. */
+/**
+ * Default physical-dispersion model: pure advection with {@code D_ax = 0}.
+ *
+ * <p>
+ * Deserialization returns {@link #INSTANCE}, preserving the canonical immutable default across serialized process
+ * models. The public constructor remains available for straightforward Java and JPype configuration.
+ * </p>
+ */
 public final class NoAxialDispersion implements AxialDispersionModel {
   private static final long serialVersionUID = 1000L;
 
@@ -9,6 +16,15 @@ public final class NoAxialDispersion implements AxialDispersionModel {
 
   /** Public constructor for straightforward Java and JPype configuration. */
   public NoAxialDispersion() {
+  }
+
+  /**
+   * Preserve the canonical default instance after Java deserialization.
+   *
+   * @return shared immutable default instance
+   */
+  private Object readResolve() {
+    return INSTANCE;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/NoAxialDispersion.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/NoAxialDispersion.java
@@ -1,0 +1,32 @@
+package neqsim.fluidmechanics.flowsolver;
+
+/** Default physical-dispersion model: pure advection with {@code D_ax = 0}. */
+public final class NoAxialDispersion implements AxialDispersionModel {
+  private static final long serialVersionUID = 1000L;
+
+  /** Shared immutable default instance. */
+  public static final NoAxialDispersion INSTANCE = new NoAxialDispersion();
+
+  /** Public constructor for straightforward Java and JPype configuration. */
+  public NoAxialDispersion() {
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getCoefficientM2PerSecond(int cellIndex, double cellLengthM, double cellMassKg,
+      double massFlowKgPerSecond) {
+    return 0.0;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getName() {
+    return "none";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+}

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransport.java
@@ -1,6 +1,8 @@
 package neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver;
 
 import java.util.Arrays;
+import neqsim.fluidmechanics.flowsolver.AxialDispersionModel;
+import neqsim.fluidmechanics.flowsolver.NoAxialDispersion;
 import neqsim.fluidmechanics.flowsolver.SpeciesAdvectionScheme;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport.ConservationReason;
 
@@ -17,14 +19,23 @@ final class ConservativeSpeciesTransport {
       double[] inletMassFraction, double[] oldCellMassKg, double[] newCellMassKg, double[] faceMassFlowKgPerSecond,
       double timeStepSeconds) {
     return solve(componentNames, oldMassFraction, inletMassFraction, oldCellMassKg, newCellMassKg,
-        faceMassFlowKgPerSecond, timeStepSeconds, SpeciesAdvectionScheme.FIRST_ORDER_IMPLICIT, null);
+        faceMassFlowKgPerSecond, timeStepSeconds, SpeciesAdvectionScheme.FIRST_ORDER_IMPLICIT, null,
+        NoAxialDispersion.INSTANCE);
   }
 
   static OnePhaseSpeciesConservationReport solve(String[] componentNames, double[][] oldMassFraction,
       double[] inletMassFraction, double[] oldCellMassKg, double[] newCellMassKg, double[] faceMassFlowKgPerSecond,
       double timeStepSeconds, SpeciesAdvectionScheme scheme, double[] cellLengthM) {
+    return solve(componentNames, oldMassFraction, inletMassFraction, oldCellMassKg, newCellMassKg,
+        faceMassFlowKgPerSecond, timeStepSeconds, scheme, cellLengthM, NoAxialDispersion.INSTANCE);
+  }
+
+  static OnePhaseSpeciesConservationReport solve(String[] componentNames, double[][] oldMassFraction,
+      double[] inletMassFraction, double[] oldCellMassKg, double[] newCellMassKg, double[] faceMassFlowKgPerSecond,
+      double timeStepSeconds, SpeciesAdvectionScheme scheme, double[] cellLengthM,
+      AxialDispersionModel axialDispersionModel) {
     String validation = validate(componentNames, oldMassFraction, inletMassFraction, oldCellMassKg, newCellMassKg,
-        faceMassFlowKgPerSecond, timeStepSeconds, scheme, cellLengthM);
+        faceMassFlowKgPerSecond, timeStepSeconds, scheme, cellLengthM, axialDispersionModel);
     if (validation != null) {
       return failed(ConservationReason.INVALID_STATE, componentNames, validation);
     }
@@ -37,7 +48,7 @@ final class ConservativeSpeciesTransport {
     }
 
     SpeciesTransportDiagnostics diagnostics = createDiagnostics(scheme, oldCellMassKg, newCellMassKg,
-        faceMassFlowKgPerSecond, timeStepSeconds, cellLengthM);
+        faceMassFlowKgPerSecond, timeStepSeconds, cellLengthM, axialDispersionModel);
     if (diagnostics.getSubsteps() > MAXIMUM_TRANSPORT_SUBSTEPS) {
       return failed(ConservationReason.INVALID_STATE, componentNames,
           "High-resolution species transport requires " + diagnostics.getSubsteps()
@@ -46,32 +57,54 @@ final class ConservativeSpeciesTransport {
     }
     if (scheme == SpeciesAdvectionScheme.TVD_VAN_LEER_SSP_RK2) {
       return solveTvdVanLeer(componentNames, oldMassFraction, inletMassFraction, oldCellMassKg, newCellMassKg,
-          faceMassFlowKgPerSecond, timeStepSeconds, diagnostics);
+          faceMassFlowKgPerSecond, timeStepSeconds, cellLengthM, diagnostics);
     }
     return solveFirstOrderImplicit(componentNames, oldMassFraction, inletMassFraction, oldCellMassKg, newCellMassKg,
-        faceMassFlowKgPerSecond, timeStepSeconds, diagnostics);
+        faceMassFlowKgPerSecond, timeStepSeconds, cellLengthM, diagnostics);
   }
 
   private static OnePhaseSpeciesConservationReport solveFirstOrderImplicit(String[] componentNames,
       double[][] oldMassFraction, double[] inletMassFraction, double[] oldCellMassKg, double[] newCellMassKg,
-      double[] faceMassFlowKgPerSecond, double timeStepSeconds, SpeciesTransportDiagnostics diagnostics) {
+      double[] faceMassFlowKgPerSecond, double timeStepSeconds, double[] cellLengthM,
+      SpeciesTransportDiagnostics diagnostics) {
     int components = componentNames.length;
     int cells = oldCellMassKg.length;
     double[][] massFraction = new double[components][cells];
+    double[] averagedCellMassKg = interpolate(oldCellMassKg, newCellMassKg, 0.5);
+    double[] dispersionConductanceKgPerSecond = dispersionConductance(averagedCellMassKg, cellLengthM,
+        diagnostics.getPhysicalAxialDispersionM2PerSecond());
+    double[] inletBoundaryMassKg = new double[components];
+    double[] outletBoundaryMassKg = new double[components];
 
     for (int component = 0; component < components - 1; component++) {
+      double[] lower = new double[cells];
+      double[] diagonal = new double[cells];
+      double[] upper = new double[cells];
+      double[] rightHandSide = new double[cells];
       for (int cell = 0; cell < cells; cell++) {
-        double westMassFraction = cell == 0 ? inletMassFraction[component] : massFraction[component][cell - 1];
-        double numerator = oldCellMassKg[cell] * oldMassFraction[component][cell]
-            + timeStepSeconds * faceMassFlowKgPerSecond[cell] * westMassFraction;
-        double denominator = newCellMassKg[cell] + timeStepSeconds * faceMassFlowKgPerSecond[cell + 1];
-        if (!Double.isFinite(numerator) || !Double.isFinite(denominator) || denominator <= 0.0) {
-          return failed(ConservationReason.INVALID_STATE, componentNames,
-              "Component transport produced a non-finite or non-positive implicit coefficient " + "at component "
-                  + component + ", cell " + cell + ".");
+        double westDispersion = dispersionConductanceKgPerSecond[cell];
+        double eastDispersion = dispersionConductanceKgPerSecond[cell + 1];
+        diagonal[cell] = newCellMassKg[cell]
+            + timeStepSeconds * (faceMassFlowKgPerSecond[cell + 1] + westDispersion + eastDispersion);
+        rightHandSide[cell] = oldCellMassKg[cell] * oldMassFraction[component][cell];
+        upper[cell] = -timeStepSeconds * eastDispersion;
+        if (cell == 0) {
+          rightHandSide[cell] += timeStepSeconds * (faceMassFlowKgPerSecond[0] + westDispersion)
+              * inletMassFraction[component];
+        } else {
+          lower[cell] = -timeStepSeconds * (faceMassFlowKgPerSecond[cell] + westDispersion);
         }
-        massFraction[component][cell] = numerator / denominator;
       }
+      massFraction[component] = solveTridiagonal(lower, diagonal, upper, rightHandSide);
+      if (massFraction[component] == null) {
+        return failed(ConservationReason.INVALID_STATE, componentNames,
+            "Component transport produced a non-finite or non-positive implicit tridiagonal coefficient at component "
+                + component + ".");
+      }
+      inletBoundaryMassKg[component] = timeStepSeconds * (faceMassFlowKgPerSecond[0] * inletMassFraction[component]
+          + dispersionConductanceKgPerSecond[0] * (inletMassFraction[component] - massFraction[component][0]));
+      outletBoundaryMassKg[component] = timeStepSeconds * faceMassFlowKgPerSecond[cells]
+          * massFraction[component][cells - 1];
     }
 
     for (int cell = 0; cell < cells; cell++) {
@@ -81,14 +114,20 @@ final class ConservativeSpeciesTransport {
       }
       massFraction[components - 1][cell] = 1.0 - independentSum;
     }
+    inletBoundaryMassKg[components - 1] = timeStepSeconds * faceMassFlowKgPerSecond[0];
+    outletBoundaryMassKg[components - 1] = timeStepSeconds * faceMassFlowKgPerSecond[cells];
+    for (int component = 0; component < components - 1; component++) {
+      inletBoundaryMassKg[components - 1] -= inletBoundaryMassKg[component];
+      outletBoundaryMassKg[components - 1] -= outletBoundaryMassKg[component];
+    }
 
     return createReport(componentNames, oldMassFraction, inletMassFraction, oldCellMassKg, newCellMassKg,
-        faceMassFlowKgPerSecond, timeStepSeconds, massFraction, null, null, diagnostics);
+        faceMassFlowKgPerSecond, timeStepSeconds, massFraction, inletBoundaryMassKg, outletBoundaryMassKg, diagnostics);
   }
 
   private static OnePhaseSpeciesConservationReport solveTvdVanLeer(String[] componentNames, double[][] oldMassFraction,
       double[] inletMassFraction, double[] oldCellMassKg, double[] newCellMassKg, double[] faceMassFlowKgPerSecond,
-      double timeStepSeconds, SpeciesTransportDiagnostics diagnostics) {
+      double timeStepSeconds, double[] cellLengthM, SpeciesTransportDiagnostics diagnostics) {
     int components = componentNames.length;
     int independentComponents = components - 1;
     int cells = oldCellMassKg.length;
@@ -97,6 +136,7 @@ final class ConservativeSpeciesTransport {
     double[][] componentMassKg = new double[independentComponents][cells];
     double[] inletBoundaryMassKg = new double[components];
     double[] outletBoundaryMassKg = new double[components];
+    double[] physicalDispersionM2PerSecond = diagnostics.getPhysicalAxialDispersionM2PerSecond();
 
     for (int component = 0; component < independentComponents; component++) {
       for (int cell = 0; cell < cells; cell++) {
@@ -109,24 +149,34 @@ final class ConservativeSpeciesTransport {
       double endFraction = (double) (substep + 1) / substeps;
       double[] startCellMassKg = interpolate(oldCellMassKg, newCellMassKg, startFraction);
       double[] endCellMassKg = interpolate(oldCellMassKg, newCellMassKg, endFraction);
+      double[] startDispersionConductanceKgPerSecond = dispersionConductance(startCellMassKg, cellLengthM,
+          physicalDispersionM2PerSecond);
+      double[] endDispersionConductanceKgPerSecond = dispersionConductance(endCellMassKg, cellLengthM,
+          physicalDispersionM2PerSecond);
 
       for (int component = 0; component < independentComponents; component++) {
         double[] startMassFraction = divide(componentMassKg[component], startCellMassKg);
         double[] startFaceMassFraction = reconstructPositiveFlowFaces(startMassFraction, inletMassFraction[component]);
+        double[] startDispersiveFluxKgPerSecond = physicalDispersiveFlux(startMassFraction,
+            inletMassFraction[component], startDispersionConductanceKgPerSecond);
         double[] eulerComponentMassKg = conservativeEulerStep(componentMassKg[component], startFaceMassFraction,
-            faceMassFlowKgPerSecond, substepSeconds);
+            faceMassFlowKgPerSecond, startDispersiveFluxKgPerSecond, substepSeconds);
         double[] endEulerMassFraction = divide(eulerComponentMassKg, endCellMassKg);
         double[] endFaceMassFraction = reconstructPositiveFlowFaces(endEulerMassFraction, inletMassFraction[component]);
+        double[] endDispersiveFluxKgPerSecond = physicalDispersiveFlux(endEulerMassFraction,
+            inletMassFraction[component], endDispersionConductanceKgPerSecond);
         double[] secondEulerComponentMassKg = conservativeEulerStep(eulerComponentMassKg, endFaceMassFraction,
-            faceMassFlowKgPerSecond, substepSeconds);
+            faceMassFlowKgPerSecond, endDispersiveFluxKgPerSecond, substepSeconds);
 
         for (int cell = 0; cell < cells; cell++) {
           componentMassKg[component][cell] = 0.5
               * (componentMassKg[component][cell] + secondEulerComponentMassKg[cell]);
         }
-        inletBoundaryMassKg[component] += substepSeconds * faceMassFlowKgPerSecond[0] * inletMassFraction[component];
-        outletBoundaryMassKg[component] += 0.5 * substepSeconds * faceMassFlowKgPerSecond[cells]
-            * (startFaceMassFraction[cells] + endFaceMassFraction[cells]);
+        inletBoundaryMassKg[component] += substepSeconds * (faceMassFlowKgPerSecond[0] * inletMassFraction[component]
+            + 0.5 * (startDispersiveFluxKgPerSecond[0] + endDispersiveFluxKgPerSecond[0]));
+        outletBoundaryMassKg[component] += 0.5 * substepSeconds
+            * (faceMassFlowKgPerSecond[cells] * (startFaceMassFraction[cells] + endFaceMassFraction[cells])
+                + startDispersiveFluxKgPerSecond[cells] + endDispersiveFluxKgPerSecond[cells]);
       }
     }
 
@@ -218,9 +268,15 @@ final class ConservativeSpeciesTransport {
 
   private static String validate(String[] componentNames, double[][] oldMassFraction, double[] inletMassFraction,
       double[] oldCellMassKg, double[] newCellMassKg, double[] faceMassFlowKgPerSecond, double timeStepSeconds,
-      SpeciesAdvectionScheme scheme, double[] cellLengthM) {
+      SpeciesAdvectionScheme scheme, double[] cellLengthM, AxialDispersionModel axialDispersionModel) {
     if (scheme == null) {
       return "A conservative species advection scheme is required.";
+    }
+    if (axialDispersionModel == null) {
+      return "A non-null physical axial-dispersion model is required; use NoAxialDispersion for pure advection.";
+    }
+    if (axialDispersionModel.getName() == null || axialDispersionModel.getName().trim().isEmpty()) {
+      return "A physical axial-dispersion model must expose a non-empty diagnostic name.";
     }
     if (componentNames == null || componentNames.length < 2) {
       return "At least two named components are required for n-1 transport.";
@@ -279,38 +335,86 @@ final class ConservativeSpeciesTransport {
         }
       }
     }
+    if (axialDispersionModel.isEnabled() && cellLengthM == null) {
+      return "Physical axial dispersion requires one positive length for each physical cell.";
+    }
+    if (cellLengthM != null) {
+      for (int cell = 0; cell < oldCellMassKg.length; cell++) {
+        double referenceCellMassKg = Math.min(oldCellMassKg[cell], newCellMassKg[cell]);
+        double referenceMassFlowKgPerSecond = Math.max(faceMassFlowKgPerSecond[cell],
+            faceMassFlowKgPerSecond[cell + 1]);
+        double coefficient = axialDispersionModel.getCoefficientM2PerSecond(cell, cellLengthM[cell],
+            referenceCellMassKg, referenceMassFlowKgPerSecond);
+        if (!Double.isFinite(coefficient) || coefficient < 0.0) {
+          return "Physical axial-dispersion coefficients must be finite and non-negative; cell=" + cell
+              + ", coefficient=" + coefficient + " m2/s.";
+        }
+      }
+    }
     return null;
   }
 
   private static SpeciesTransportDiagnostics createDiagnostics(SpeciesAdvectionScheme scheme, double[] oldCellMassKg,
-      double[] newCellMassKg, double[] faceMassFlowKgPerSecond, double timeStepSeconds, double[] cellLengthM) {
+      double[] newCellMassKg, double[] faceMassFlowKgPerSecond, double timeStepSeconds, double[] cellLengthM,
+      AxialDispersionModel axialDispersionModel) {
     int cells = oldCellMassKg.length;
     double[] courantNumber = new double[cells];
     double[] numericalDispersion = new double[cells];
     double[] cellPecletNumber = new double[cells];
+    double[] physicalDispersion = new double[cells];
+    double[] physicalDispersionNumber = new double[cells];
     Arrays.fill(numericalDispersion, Double.NaN);
     Arrays.fill(cellPecletNumber, Double.NaN);
+    Arrays.fill(physicalDispersionNumber, Double.NaN);
     double courantSum = 0.0;
-    double maximumCourant = 0.0;
     for (int cell = 0; cell < cells; cell++) {
       double referenceCellMassKg = Math.min(oldCellMassKg[cell], newCellMassKg[cell]);
       double referenceMassFlowKgPerSecond = Math.max(faceMassFlowKgPerSecond[cell], faceMassFlowKgPerSecond[cell + 1]);
       courantNumber[cell] = timeStepSeconds * referenceMassFlowKgPerSecond / referenceCellMassKg;
       courantSum += courantNumber[cell];
-      maximumCourant = Math.max(maximumCourant, courantNumber[cell]);
       if (cellLengthM != null) {
         double velocityMPerSecond = referenceMassFlowKgPerSecond / referenceCellMassKg * cellLengthM[cell];
         numericalDispersion[cell] = 0.5 * velocityMPerSecond * cellLengthM[cell] * (1.0 + courantNumber[cell]);
+        physicalDispersion[cell] = axialDispersionModel.getCoefficientM2PerSecond(cell, cellLengthM[cell],
+            referenceCellMassKg, referenceMassFlowKgPerSecond);
+        if (physicalDispersion[cell] > 0.0) {
+          cellPecletNumber[cell] = velocityMPerSecond * cellLengthM[cell] / physicalDispersion[cell];
+        }
       }
     }
+    if (cellLengthM != null) {
+      double[] referenceCellMassKg = new double[cells];
+      for (int cell = 0; cell < cells; cell++) {
+        referenceCellMassKg[cell] = Math.min(oldCellMassKg[cell], newCellMassKg[cell]);
+      }
+      double[] conductance = dispersionConductance(referenceCellMassKg, cellLengthM, physicalDispersion);
+      for (int cell = 0; cell < cells; cell++) {
+        physicalDispersionNumber[cell] = timeStepSeconds * (conductance[cell] + conductance[cell + 1])
+            / referenceCellMassKg[cell];
+      }
+    }
+    double maximumCombinedExplicitNumber = 0.0;
+    for (int cell = 0; cell < cells; cell++) {
+      double combined = courantNumber[cell]
+          + (Double.isFinite(physicalDispersionNumber[cell]) ? physicalDispersionNumber[cell] : 0.0);
+      maximumCombinedExplicitNumber = Math.max(maximumCombinedExplicitNumber, combined);
+    }
     int substeps = scheme.isHighResolution()
-        ? Math.max(1, (int) Math.ceil(maximumCourant / scheme.getMaximumCourantNumber()))
+        ? Math.max(1, (int) Math.ceil(maximumCombinedExplicitNumber / scheme.getMaximumCourantNumber()))
         : 1;
+    boolean physicalDispersionIncluded = false;
+    for (double coefficient : physicalDispersion) {
+      physicalDispersionIncluded |= coefficient > 0.0;
+    }
     String message = "Full-step mass CFL is reported before " + substeps + " transport substep(s). "
-        + "The numerical-dispersion array is the modified-equation reference for first-order implicit upwind; "
-        + "physical axial dispersion is disabled, so cell Peclet numbers are unavailable.";
+        + "The numerical-dispersion array is the modified-equation reference for first-order implicit upwind. "
+        + "Physical axial dispersion model='" + axialDispersionModel.getName() + "' is "
+        + (physicalDispersionIncluded ? "enabled" : "disabled")
+        + " with DIRICHLET_INLET and ZERO_GRADIENT_OUTLET boundary conditions; physical and numerical coefficients "
+        + "are reported separately.";
     return new SpeciesTransportDiagnostics(scheme, courantNumber, courantSum / cells, substeps, numericalDispersion,
-        cellPecletNumber, false, message);
+        cellPecletNumber, axialDispersionModel.getName(), physicalDispersion, physicalDispersionNumber,
+        physicalDispersionIncluded, message);
   }
 
   private static double[] interpolate(double[] oldValues, double[] newValues, double fraction) {
@@ -329,12 +433,78 @@ final class ConservativeSpeciesTransport {
     return result;
   }
 
+  private static double[] dispersionConductance(double[] cellMassKg, double[] cellLengthM,
+      double[] dispersionM2PerSecond) {
+    int cells = cellMassKg.length;
+    double[] conductanceKgPerSecond = new double[cells + 1];
+    if (cellLengthM == null || dispersionM2PerSecond.length == 0) {
+      return conductanceKgPerSecond;
+    }
+    double inletConductivityKgMPerSecond = cellMassKg[0] / cellLengthM[0] * dispersionM2PerSecond[0];
+    conductanceKgPerSecond[0] = inletConductivityKgMPerSecond / (0.5 * cellLengthM[0]);
+    for (int face = 1; face < cells; face++) {
+      double leftConductivity = cellMassKg[face - 1] / cellLengthM[face - 1] * dispersionM2PerSecond[face - 1];
+      double rightConductivity = cellMassKg[face] / cellLengthM[face] * dispersionM2PerSecond[face];
+      if (leftConductivity > 0.0 && rightConductivity > 0.0) {
+        double leftHalfCellResistance = 0.5 * cellLengthM[face - 1] / leftConductivity;
+        double rightHalfCellResistance = 0.5 * cellLengthM[face] / rightConductivity;
+        conductanceKgPerSecond[face] = 1.0 / (leftHalfCellResistance + rightHalfCellResistance);
+      }
+    }
+    conductanceKgPerSecond[cells] = 0.0;
+    return conductanceKgPerSecond;
+  }
+
+  private static double[] physicalDispersiveFlux(double[] massFraction, double inletMassFraction,
+      double[] conductanceKgPerSecond) {
+    int cells = massFraction.length;
+    double[] fluxKgPerSecond = new double[cells + 1];
+    fluxKgPerSecond[0] = conductanceKgPerSecond[0] * (inletMassFraction - massFraction[0]);
+    for (int face = 1; face < cells; face++) {
+      fluxKgPerSecond[face] = conductanceKgPerSecond[face] * (massFraction[face - 1] - massFraction[face]);
+    }
+    fluxKgPerSecond[cells] = 0.0;
+    return fluxKgPerSecond;
+  }
+
   private static double[] conservativeEulerStep(double[] componentMassKg, double[] faceMassFraction,
-      double[] faceMassFlowKgPerSecond, double timeStepSeconds) {
+      double[] faceMassFlowKgPerSecond, double[] dispersiveFluxKgPerSecond, double timeStepSeconds) {
     double[] result = new double[componentMassKg.length];
     for (int cell = 0; cell < result.length; cell++) {
-      result[cell] = componentMassKg[cell] + timeStepSeconds * (faceMassFlowKgPerSecond[cell] * faceMassFraction[cell]
-          - faceMassFlowKgPerSecond[cell + 1] * faceMassFraction[cell + 1]);
+      result[cell] = componentMassKg[cell]
+          + timeStepSeconds * (faceMassFlowKgPerSecond[cell] * faceMassFraction[cell] + dispersiveFluxKgPerSecond[cell]
+              - faceMassFlowKgPerSecond[cell + 1] * faceMassFraction[cell + 1] - dispersiveFluxKgPerSecond[cell + 1]);
+    }
+    return result;
+  }
+
+  private static double[] solveTridiagonal(double[] lower, double[] diagonal, double[] upper, double[] rightHandSide) {
+    int size = diagonal.length;
+    double[] upperPrime = new double[size];
+    double[] rightHandSidePrime = new double[size];
+    double denominator = diagonal[0];
+    if (!Double.isFinite(denominator) || denominator <= 0.0) {
+      return null;
+    }
+    upperPrime[0] = upper[0] / denominator;
+    rightHandSidePrime[0] = rightHandSide[0] / denominator;
+    for (int row = 1; row < size; row++) {
+      denominator = diagonal[row] - lower[row] * upperPrime[row - 1];
+      if (!Double.isFinite(denominator) || denominator <= 0.0) {
+        return null;
+      }
+      upperPrime[row] = row == size - 1 ? 0.0 : upper[row] / denominator;
+      rightHandSidePrime[row] = (rightHandSide[row] - lower[row] * rightHandSidePrime[row - 1]) / denominator;
+    }
+    double[] result = new double[size];
+    result[size - 1] = rightHandSidePrime[size - 1];
+    for (int row = size - 2; row >= 0; row--) {
+      result[row] = rightHandSidePrime[row] - upperPrime[row] * result[row + 1];
+    }
+    for (double value : result) {
+      if (!Double.isFinite(value)) {
+        return null;
+      }
     }
     return result;
   }

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
@@ -13,6 +13,8 @@ import Jama.Matrix;
 import neqsim.mathlib.generalmath.BandedLinearSystemSolver;
 import neqsim.mathlib.generalmath.TDMAsolve;
 import neqsim.fluidmechanics.flowsolver.SpeciesAdvectionScheme;
+import neqsim.fluidmechanics.flowsolver.AxialDispersionModel;
+import neqsim.fluidmechanics.flowsolver.NoAxialDispersion;
 
 /**
  * OnePhaseFixedStaggeredGrid class.
@@ -58,6 +60,7 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   private boolean failOnNonConvergence;
   private boolean conservativeSpeciesTransportEnabled;
   private SpeciesAdvectionScheme speciesAdvectionScheme = SpeciesAdvectionScheme.FIRST_ORDER_IMPLICIT;
+  private AxialDispersionModel axialDispersionModel = NoAxialDispersion.INSTANCE;
   private double[] coupledMassEquationScale;
   private double[] coupledMomentumEquationScale;
 
@@ -158,6 +161,25 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
   /** @return selected conservative component-inventory advection scheme */
   public SpeciesAdvectionScheme getSpeciesAdvectionScheme() {
     return speciesAdvectionScheme;
+  }
+
+  /**
+   * Select the physical axial-dispersion model used by conservative component transport.
+   *
+   * @param model non-null model; use {@link NoAxialDispersion} for pure advection
+   * @throws IllegalArgumentException if {@code model} is null
+   */
+  public void setAxialDispersionModel(AxialDispersionModel model) {
+    if (model == null) {
+      throw new IllegalArgumentException(
+          "Physical axial-dispersion model cannot be null; use NoAxialDispersion for pure advection.");
+    }
+    axialDispersionModel = model;
+  }
+
+  /** @return selected non-null physical axial-dispersion model */
+  public AxialDispersionModel getAxialDispersionModel() {
+    return axialDispersionModel;
   }
 
   /**
@@ -1283,7 +1305,8 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
         * pipe.getNode(outletCellNode).getGeometry().getArea() * sol2Matrix.get(outletCellNode, 0);
 
     return ConservativeSpeciesTransport.solve(componentNames, previousMassFraction, inletMassFraction,
-        previousCellMassKg, finalCellMassKg, faceMassFlowKgPerSecond, timeStep, speciesAdvectionScheme, cellLengthM);
+        previousCellMassKg, finalCellMassKg, faceMassFlowKgPerSecond, timeStep, speciesAdvectionScheme, cellLengthM,
+        axialDispersionModel);
   }
 
   private double maximumConservativeCompositionChange(OnePhaseSpeciesConservationReport report) {

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/SpeciesTransportDiagnostics.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/SpeciesTransportDiagnostics.java
@@ -6,6 +6,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
+import neqsim.fluidmechanics.flowsolver.AxialDispersionBoundaryCondition;
 import neqsim.fluidmechanics.flowsolver.SpeciesAdvectionScheme;
 
 /** Immutable resolution and numerical-spreading diagnostics for one conservative species step. */
@@ -28,14 +29,31 @@ public final class SpeciesTransportDiagnostics implements Serializable {
   private final double maximumFirstOrderImplicitNumericalDispersionM2PerSecond;
   /** Physical cell Peclet numbers, unavailable until a dispersion model is enabled. */
   private final double[] cellPecletNumbers;
+  /** Selected physical axial-dispersion model name. */
+  private final String physicalDispersionModelName;
+  /** Physical axial-dispersion coefficient by cell in m2/s. */
+  private final double[] physicalAxialDispersionM2PerSecond;
+  /** Minimum finite physical axial-dispersion coefficient in m2/s. */
+  private final double minimumPhysicalAxialDispersionM2PerSecond;
+  /** Maximum finite physical axial-dispersion coefficient in m2/s. */
+  private final double maximumPhysicalAxialDispersionM2PerSecond;
+  /** Full-step explicit physical-dispersion number by cell. */
+  private final double[] cellPhysicalDispersionNumbers;
+  /** Maximum full-step explicit physical-dispersion number. */
+  private final double maximumCellPhysicalDispersionNumber;
   /** Whether physical axial dispersion contributed to the accepted step. */
   private final boolean physicalDispersionIncluded;
+  /** Physical inlet boundary condition. */
+  private final AxialDispersionBoundaryCondition inletDispersionBoundaryCondition;
+  /** Physical outlet boundary condition. */
+  private final AxialDispersionBoundaryCondition outletDispersionBoundaryCondition;
   /** Human-readable interpretation and limitations. */
   private final String message;
 
   SpeciesTransportDiagnostics(SpeciesAdvectionScheme scheme, double[] cellCourantNumbers,
       double effectiveCellCourantNumber, int substeps, double[] numericalDispersionM2PerSecond,
-      double[] cellPecletNumbers, boolean physicalDispersionIncluded, String message) {
+      double[] cellPecletNumbers, String physicalDispersionModelName, double[] physicalAxialDispersionM2PerSecond,
+      double[] cellPhysicalDispersionNumbers, boolean physicalDispersionIncluded, String message) {
     this.scheme = scheme;
     this.cellCourantNumbers = copy(cellCourantNumbers);
     this.maximumCellCourantNumber = maximumFinite(this.cellCourantNumbers);
@@ -45,7 +63,15 @@ public final class SpeciesTransportDiagnostics implements Serializable {
     this.maximumFirstOrderImplicitNumericalDispersionM2PerSecond = maximumFinite(
         this.firstOrderImplicitNumericalDispersionM2PerSecond);
     this.cellPecletNumbers = copy(cellPecletNumbers);
+    this.physicalDispersionModelName = physicalDispersionModelName;
+    this.physicalAxialDispersionM2PerSecond = copy(physicalAxialDispersionM2PerSecond);
+    this.minimumPhysicalAxialDispersionM2PerSecond = minimumFinite(this.physicalAxialDispersionM2PerSecond);
+    this.maximumPhysicalAxialDispersionM2PerSecond = maximumFinite(this.physicalAxialDispersionM2PerSecond);
+    this.cellPhysicalDispersionNumbers = copy(cellPhysicalDispersionNumbers);
+    this.maximumCellPhysicalDispersionNumber = maximumFinite(this.cellPhysicalDispersionNumbers);
     this.physicalDispersionIncluded = physicalDispersionIncluded;
+    this.inletDispersionBoundaryCondition = AxialDispersionBoundaryCondition.DIRICHLET_INLET;
+    this.outletDispersionBoundaryCondition = AxialDispersionBoundaryCondition.ZERO_GRADIENT_OUTLET;
     this.message = message;
   }
 
@@ -56,7 +82,8 @@ public final class SpeciesTransportDiagnostics implements Serializable {
    */
   public static SpeciesTransportDiagnostics notRun() {
     return new SpeciesTransportDiagnostics(SpeciesAdvectionScheme.FIRST_ORDER_IMPLICIT, new double[0], Double.NaN, 0,
-        new double[0], new double[0], false, "Conservative species transport has not run.");
+        new double[0], new double[0], "none", new double[0], new double[0], false,
+        "Conservative species transport has not run.");
   }
 
   /** @return selected conservative species scheme */
@@ -112,9 +139,58 @@ public final class SpeciesTransportDiagnostics implements Serializable {
     return copy(cellPecletNumbers);
   }
 
+  /** @return stable selected physical axial-dispersion model name */
+  public String getPhysicalDispersionModelName() {
+    return physicalDispersionModelName;
+  }
+
+  /** @return defensive copy of physical axial-dispersion coefficients by cell in m2/s */
+  public double[] getPhysicalAxialDispersionM2PerSecond() {
+    return copy(physicalAxialDispersionM2PerSecond);
+  }
+
+  /** @return minimum finite physical axial-dispersion coefficient in m2/s */
+  public double getMinimumPhysicalAxialDispersionM2PerSecond() {
+    return minimumPhysicalAxialDispersionM2PerSecond;
+  }
+
+  /** @return maximum finite physical axial-dispersion coefficient in m2/s */
+  public double getMaximumPhysicalAxialDispersionM2PerSecond() {
+    return maximumPhysicalAxialDispersionM2PerSecond;
+  }
+
+  /**
+   * Get full-step explicit physical-dispersion numbers.
+   *
+   * <p>
+   * Each cell value is {@code dt * (G_w + G_e) / M}, where {@code G} is the conservative physical-dispersion face
+   * conductance. It controls explicit TVD substepping; first-order implicit transport remains unconditionally stable.
+   * </p>
+   *
+   * @return defensive copy of cell physical-dispersion numbers
+   */
+  public double[] getCellPhysicalDispersionNumbers() {
+    return copy(cellPhysicalDispersionNumbers);
+  }
+
+  /** @return maximum full-step explicit physical-dispersion number */
+  public double getMaximumCellPhysicalDispersionNumber() {
+    return maximumCellPhysicalDispersionNumber;
+  }
+
   /** @return true when physical axial dispersion contributed to this step */
   public boolean isPhysicalDispersionIncluded() {
     return physicalDispersionIncluded;
+  }
+
+  /** @return fixed physical inlet boundary condition used for this step */
+  public AxialDispersionBoundaryCondition getInletDispersionBoundaryCondition() {
+    return inletDispersionBoundaryCondition;
+  }
+
+  /** @return fixed physical outlet boundary condition used for this step */
+  public AxialDispersionBoundaryCondition getOutletDispersionBoundaryCondition() {
+    return outletDispersionBoundaryCondition;
   }
 
   /** @return diagnostic interpretation and limitations */
@@ -147,5 +223,15 @@ public final class SpeciesTransportDiagnostics implements Serializable {
       }
     }
     return maximum;
+  }
+
+  private static double minimumFinite(double[] values) {
+    double minimum = Double.NaN;
+    for (double value : values) {
+      if (Double.isFinite(value) && (!Double.isFinite(minimum) || value < minimum)) {
+        minimum = value;
+      }
+    }
+    return minimum;
   }
 }

--- a/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/PipeFlowSystem.java
@@ -1,6 +1,8 @@
 package neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem;
 
 import java.util.UUID;
+import neqsim.fluidmechanics.flowsolver.AxialDispersionModel;
+import neqsim.fluidmechanics.flowsolver.NoAxialDispersion;
 import neqsim.fluidmechanics.flowsolver.SpeciesAdvectionScheme;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFixedStaggeredGrid;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFlowConvergenceReport;
@@ -21,6 +23,8 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
   private boolean conservativeSpeciesTransportEnabled;
   /** Selected finite-volume method for conservative component transport. */
   private SpeciesAdvectionScheme speciesAdvectionScheme = SpeciesAdvectionScheme.FIRST_ORDER_IMPLICIT;
+  /** Optional physical axial dispersion, disabled by default. */
+  private AxialDispersionModel axialDispersionModel = NoAxialDispersion.INSTANCE;
   private boolean storeSpeciesConservationHistory;
   private OnePhaseSpeciesConservationHistory speciesConservationHistory = OnePhaseSpeciesConservationHistory.empty();
   private OnePhaseSpeciesConservationHistory.Builder speciesConservationHistoryBuilder;
@@ -153,6 +157,32 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
   }
 
   /**
+   * Select a physical axial-dispersion model for conservative component transport.
+   *
+   * <p>
+   * Physical dispersion is independent of the selected numerical advection scheme. Use {@link NoAxialDispersion} to
+   * retain pure advection. The validated boundary conditions are a prescribed inlet composition and zero physical
+   * diffusive flux at the outlet.
+   * </p>
+   *
+   * @param model non-null physical axial-dispersion model
+   * @throws IllegalArgumentException if {@code model} is null
+   */
+  public void setAxialDispersionModel(AxialDispersionModel model) {
+    if (model == null) {
+      throw new IllegalArgumentException(
+          "Physical axial-dispersion model cannot be null; use NoAxialDispersion for pure advection.");
+    }
+    axialDispersionModel = model;
+    configureConvergencePolicy();
+  }
+
+  /** @return selected non-null physical axial-dispersion model */
+  public AxialDispersionModel getAxialDispersionModel() {
+    return axialDispersionModel;
+  }
+
+  /**
    * Configure whether a transient solve throws when its convergence report fails.
    *
    * <p>
@@ -182,6 +212,7 @@ public class PipeFlowSystem extends neqsim.fluidmechanics.flowsystem.onephaseflo
       onePhaseSolver.setFailOnNonConvergence(failOnNonConvergence);
       onePhaseSolver.setConservativeSpeciesTransportEnabled(conservativeSpeciesTransportEnabled);
       onePhaseSolver.setSpeciesAdvectionScheme(speciesAdvectionScheme);
+      onePhaseSolver.setAxialDispersionModel(axialDispersionModel);
     }
   }
 

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -15,6 +15,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 import neqsim.integration.EOSComparison;
+import neqsim.fluidmechanics.flowsolver.AxialDispersionBoundaryCondition;
+import neqsim.fluidmechanics.flowsolver.ConstantAxialDispersion;
 import neqsim.fluidmechanics.flowsolver.SpeciesAdvectionScheme;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.SpeciesTransportDiagnostics;
 import neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem.PipeFlowSystem;
@@ -1432,18 +1434,26 @@ public class DocExamplesCompilationTest {
   }
 
   /**
-   * Bounded species-advection API from docs/fluidmechanics/single_phase_pipe_flow.md.
+   * Bounded species-advection and physical-dispersion API from docs/fluidmechanics/single_phase_pipe_flow.md.
    */
   @Test
   public void testSinglePhaseSpeciesAdvectionDocExampleCompiles() {
     PipeFlowSystem pipe = new PipeFlowSystem();
     pipe.setSpeciesAdvectionScheme(SpeciesAdvectionScheme.TVD_VAN_LEER_SSP_RK2);
+    ConstantAxialDispersion physicalDispersion = new ConstantAxialDispersion(250.0);
+    pipe.setAxialDispersionModel(physicalDispersion);
 
     SpeciesTransportDiagnostics diagnostics = SpeciesTransportDiagnostics.notRun();
 
     assertEquals(SpeciesAdvectionScheme.TVD_VAN_LEER_SSP_RK2, pipe.getSpeciesAdvectionScheme());
+    assertEquals("constant", pipe.getAxialDispersionModel().getName());
+    assertEquals(250.0, physicalDispersion.getConstantCoefficientM2PerSecond(), 0.0);
     assertEquals(SpeciesAdvectionScheme.FIRST_ORDER_IMPLICIT, diagnostics.getScheme());
     assertEquals(0, diagnostics.getCellCourantNumbers().length);
+    assertFalse(diagnostics.isPhysicalDispersionIncluded());
+    assertEquals(AxialDispersionBoundaryCondition.DIRICHLET_INLET, diagnostics.getInletDispersionBoundaryCondition());
+    assertEquals(AxialDispersionBoundaryCondition.ZERO_GRADIENT_OUTLET,
+        diagnostics.getOutletDispersionBoundaryCondition());
   }
 
   /**

--- a/src/test/java/neqsim/fluidmechanics/flowsolver/AxialDispersionModelTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsolver/AxialDispersionModelTest.java
@@ -1,0 +1,39 @@
+package neqsim.fluidmechanics.flowsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem.PipeFlowSystem;
+
+/** Tests the public Java/JPype-facing physical axial-dispersion API. */
+class AxialDispersionModelTest {
+  @Test
+  void pipeUsesPureAdvectionByDefault() {
+    PipeFlowSystem pipe = new PipeFlowSystem();
+
+    assertSame(NoAxialDispersion.INSTANCE, pipe.getAxialDispersionModel());
+    assertEquals("none", pipe.getAxialDispersionModel().getName());
+    assertFalse(pipe.getAxialDispersionModel().isEnabled());
+    assertEquals(0.0, pipe.getAxialDispersionModel().getCoefficientM2PerSecond(0, 100.0, 10.0, 1.0), 0.0);
+  }
+
+  @Test
+  void pipeAcceptsValidatedConstantPhysicalCoefficient() {
+    PipeFlowSystem pipe = new PipeFlowSystem();
+    ConstantAxialDispersion model = new ConstantAxialDispersion(1.25);
+    pipe.setAxialDispersionModel(model);
+
+    assertSame(model, pipe.getAxialDispersionModel());
+    assertEquals("constant", model.getName());
+    assertTrue(model.isEnabled());
+    assertEquals(1.25, model.getConstantCoefficientM2PerSecond(), 0.0);
+    assertEquals(1.25, model.getCoefficientM2PerSecond(7, 25.0, 80.0, 3.0), 0.0);
+    assertThrows(IllegalArgumentException.class, () -> pipe.setAxialDispersionModel(null));
+    assertThrows(IllegalArgumentException.class, () -> new ConstantAxialDispersion(-1.0));
+    assertThrows(IllegalArgumentException.class, () -> new ConstantAxialDispersion(Double.NaN));
+    assertFalse(new ConstantAxialDispersion(0.0).isEnabled());
+  }
+}

--- a/src/test/java/neqsim/fluidmechanics/flowsolver/AxialDispersionModelTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsolver/AxialDispersionModelTest.java
@@ -5,6 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.Test;
 import neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem.PipeFlowSystem;
 
@@ -35,5 +40,20 @@ class AxialDispersionModelTest {
     assertThrows(IllegalArgumentException.class, () -> new ConstantAxialDispersion(-1.0));
     assertThrows(IllegalArgumentException.class, () -> new ConstantAxialDispersion(Double.NaN));
     assertFalse(new ConstantAxialDispersion(0.0).isEnabled());
+  }
+
+  @Test
+  void pureAdvectionDefaultRetainsSingletonIdentityAfterSerialization() throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream serializedBytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(serializedBytes)) {
+      output.writeObject(NoAxialDispersion.INSTANCE);
+    }
+
+    Object restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serializedBytes.toByteArray()))) {
+      restored = input.readObject();
+    }
+
+    assertSame(NoAxialDispersion.INSTANCE, restored);
   }
 }

--- a/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransportTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import neqsim.fluidmechanics.flowsolver.AxialDispersionBoundaryCondition;
+import neqsim.fluidmechanics.flowsolver.ConstantAxialDispersion;
 import neqsim.fluidmechanics.flowsolver.SpeciesAdvectionScheme;
 
 /** Tests conservative n-1 implicit finite-volume species transport. */
@@ -78,6 +80,8 @@ class ConservativeSpeciesTransportTest {
     assertEquals(SpeciesAdvectionScheme.TVD_VAN_LEER_SSP_RK2, report.getTransportDiagnostics().getScheme());
     assertTrue(report.getTransportDiagnostics().getMaximumFirstOrderImplicitNumericalDispersionM2PerSecond() > 0.0);
     assertFalse(report.getTransportDiagnostics().isPhysicalDispersionIncluded());
+    assertEquals("none", report.getTransportDiagnostics().getPhysicalDispersionModelName());
+    assertEquals(0.0, report.getTransportDiagnostics().getMaximumPhysicalAxialDispersionM2PerSecond(), 0.0);
     assertTrue(report.getTransportDiagnostics().toJson().contains("\"cellPecletNumbers\""));
     double[] returnedCourantNumbers = report.getTransportDiagnostics().getCellCourantNumbers();
     returnedCourantNumbers[0] = Double.NaN;
@@ -101,6 +105,61 @@ class ConservativeSpeciesTransportTest {
   }
 
   @Test
+  void constantPhysicalDispersionIsImplicitConservativeAndExplicitlyDiagnosed() {
+    int cells = 8;
+    double[][] initialProfile = uniformProfile(cells, 0.0);
+    double[] cellMasses = filled(cells, 1.0);
+    double[] faceFlows = filled(cells + 1, 0.1);
+
+    OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(new String[] { "carrier", "tracer" },
+        initialProfile, new double[] { 0.0, 1.0 }, cellMasses, cellMasses, faceFlows, 1.0,
+        SpeciesAdvectionScheme.FIRST_ORDER_IMPLICIT, filled(cells, 1.0), new ConstantAxialDispersion(0.2));
+
+    assertTrue(report.isConverged(), report.getMessage());
+    assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-13, report.getMessage());
+    assertTrue(report.getMinimumMassFraction() >= 0.0, report.getMessage());
+    assertTrue(report.getMaximumMassFraction() <= 1.0, report.getMessage());
+    SpeciesTransportDiagnostics diagnostics = report.getTransportDiagnostics();
+    assertTrue(diagnostics.isPhysicalDispersionIncluded());
+    assertEquals("constant", diagnostics.getPhysicalDispersionModelName());
+    assertArrayEquals(filled(cells, 0.2), diagnostics.getPhysicalAxialDispersionM2PerSecond(), 0.0);
+    assertEquals(0.2, diagnostics.getMinimumPhysicalAxialDispersionM2PerSecond(), 0.0);
+    assertEquals(0.2, diagnostics.getMaximumPhysicalAxialDispersionM2PerSecond(), 0.0);
+    assertEquals(0.5, diagnostics.getCellPecletNumbers()[0], 1.0e-15);
+    assertEquals(0.6, diagnostics.getMaximumCellPhysicalDispersionNumber(), 1.0e-15);
+    assertEquals(1, diagnostics.getSubsteps(), "First-order advection-dispersion is fully implicit");
+    assertEquals(AxialDispersionBoundaryCondition.DIRICHLET_INLET, diagnostics.getInletDispersionBoundaryCondition());
+    assertEquals(AxialDispersionBoundaryCondition.ZERO_GRADIENT_OUTLET,
+        diagnostics.getOutletDispersionBoundaryCondition());
+    assertTrue(report.getInletBoundaryMassKg()[1] > faceFlows[0],
+        "Dirichlet inlet must add the physical dispersive tracer flux to convection");
+    assertEquals(faceFlows[cells] * report.getMassFractionProfile()[1][cells - 1], report.getOutletBoundaryMassKg()[1],
+        1.0e-15, "Zero-gradient outlet must have no physical dispersive tracer flux");
+    assertTrue(diagnostics.getMaximumFirstOrderImplicitNumericalDispersionM2PerSecond() > 0.0);
+    assertTrue(diagnostics.toJson().contains("\"physicalDispersionModelName\": \"constant\""));
+    double[] returnedCoefficients = diagnostics.getPhysicalAxialDispersionM2PerSecond();
+    returnedCoefficients[0] = Double.NaN;
+    assertEquals(0.2, diagnostics.getPhysicalAxialDispersionM2PerSecond()[0], 0.0);
+  }
+
+  @Test
+  void physicalFaceConductanceUsesHalfCellSeriesResistanceOnNonuniformGrid() {
+    double[][] initialProfile = uniformProfile(2, 0.0);
+    double[] cellMasses = { 2.0, 8.0 };
+    double[] faceFlows = { 0.1, 0.1, 0.1 };
+    double[] cellLengths = { 1.0, 2.0 };
+
+    OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(new String[] { "carrier", "tracer" },
+        initialProfile, new double[] { 0.0, 1.0 }, cellMasses, cellMasses, faceFlows, 1.0,
+        SpeciesAdvectionScheme.FIRST_ORDER_IMPLICIT, cellLengths, new ConstantAxialDispersion(0.5));
+
+    assertTrue(report.isConverged(), report.getMessage());
+    assertArrayEquals(new double[] { 1.5, 0.125 }, report.getTransportDiagnostics().getCellPhysicalDispersionNumbers(),
+        1.0e-15);
+    assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-13, report.getMessage());
+  }
+
+  @Test
   void tvdSchemeSubstepsHighCourantStepsConservatively() {
     int cells = 8;
     double[][] initialProfile = uniformProfile(cells, 0.0);
@@ -114,6 +173,25 @@ class ConservativeSpeciesTransportTest {
     assertTrue(report.isConverged(), report.getMessage());
     assertEquals(1.0, report.getTransportDiagnostics().getMaximumCellCourantNumber(), 0.0);
     assertEquals(3, report.getTransportDiagnostics().getSubsteps());
+    assertTrue(report.getMinimumMassFraction() >= 0.0, report.getMessage());
+    assertTrue(report.getMaximumMassFraction() <= 1.0, report.getMessage());
+    assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-13, report.getMessage());
+  }
+
+  @Test
+  void tvdSchemeSubstepsCombinedAdvectionAndPhysicalDispersionNumber() {
+    int cells = 8;
+    double[][] initialProfile = uniformProfile(cells, 0.0);
+    double[] cellMasses = filled(cells, 1.0);
+    double[] faceFlows = filled(cells + 1, 0.1);
+
+    OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(new String[] { "carrier", "tracer" },
+        initialProfile, new double[] { 0.0, 1.0 }, cellMasses, cellMasses, faceFlows, 1.0,
+        SpeciesAdvectionScheme.TVD_VAN_LEER_SSP_RK2, filled(cells, 1.0), new ConstantAxialDispersion(1.0));
+
+    assertTrue(report.isConverged(), report.getMessage());
+    assertEquals(3.0, report.getTransportDiagnostics().getMaximumCellPhysicalDispersionNumber(), 1.0e-15);
+    assertEquals(7, report.getTransportDiagnostics().getSubsteps());
     assertTrue(report.getMinimumMassFraction() >= 0.0, report.getMessage());
     assertTrue(report.getMaximumMassFraction() <= 1.0, report.getMessage());
     assertTrue(report.getMaximumRelativeInventoryResidual() < 1.0e-13, report.getMessage());
@@ -154,6 +232,36 @@ class ConservativeSpeciesTransportTest {
         "Expected medium grid to improve L1 error: coarse=" + coarse.l1Error + ", medium=" + medium.l1Error);
     assertTrue(fine.l1Error < medium.l1Error,
         "Expected fine grid to improve L1 error: medium=" + medium.l1Error + ", fine=" + fine.l1Error);
+  }
+
+  @Test
+  void constantPhysicalDispersionMatchesGaussianVarianceAndConvergesWithRefinement() {
+    PhysicalDispersionResult coarse = runGaussianDispersion(100);
+    PhysicalDispersionResult medium = runGaussianDispersion(200);
+    PhysicalDispersionResult fine = runGaussianDispersion(400);
+    double analyticalMeanM = 64.0;
+    double analyticalVarianceM2 = 36.0;
+
+    assertTrue(Math.abs(medium.varianceM2 - analyticalVarianceM2) < Math.abs(coarse.varianceM2 - analyticalVarianceM2));
+    assertTrue(Math.abs(fine.varianceM2 - analyticalVarianceM2) < Math.abs(medium.varianceM2 - analyticalVarianceM2));
+    assertEquals(analyticalMeanM, fine.meanM, 0.08);
+    assertEquals(analyticalVarianceM2, fine.varianceM2, 0.3);
+    assertEquals(0.0, fine.globalInventoryResidualKg, 2.0e-12);
+    assertTrue(fine.maximumStepRelativeResidual < 1.0e-12);
+    assertTrue(fine.minimumMassFraction >= -ConservativeSpeciesTransport.MASS_FRACTION_TOLERANCE);
+    assertTrue(fine.maximumMassFraction <= 1.0 + ConservativeSpeciesTransport.MASS_FRACTION_TOLERANCE);
+  }
+
+  @Test
+  void constantPhysicalDispersionMatchesFinitePulseSolution() {
+    PhysicalDispersionResult result = runFinitePulseDispersion(400);
+
+    assertTrue(result.normalizedL1Error < 0.035,
+        "Expected the numerical finite pulse to match the analytical advection-diffusion profile; L1="
+            + result.normalizedL1Error);
+    assertEquals(0.0, result.globalInventoryResidualKg, 2.0e-12);
+    assertTrue(result.maximumStepRelativeResidual < 1.0e-12);
+    assertTrue(result.maximumSubsteps >= 1);
   }
 
   @Test
@@ -281,6 +389,12 @@ class ConservativeSpeciesTransportTest {
         new double[] { 0.8, 0.2 }, new double[] { 10.0 }, new double[] { 10.0 }, new double[] { 1.0, -1.0 }, 1.0);
     assertEquals(OnePhaseSpeciesConservationReport.ConservationReason.UNSUPPORTED_FLOW, reversed.getReason());
     assertTrue(reversed.getMessage().contains("zero and reversed flow"));
+
+    OnePhaseSpeciesConservationReport missingLength = ConservativeSpeciesTransport.solve(names, validOld,
+        new double[] { 0.8, 0.2 }, new double[] { 10.0 }, new double[] { 10.0 }, new double[] { 1.0, 1.0 }, 1.0,
+        SpeciesAdvectionScheme.TVD_VAN_LEER_SSP_RK2, null, new ConstantAxialDispersion(1.0));
+    assertEquals(OnePhaseSpeciesConservationReport.ConservationReason.INVALID_STATE, missingLength.getReason());
+    assertTrue(missingLength.getMessage().contains("requires one positive length"));
   }
 
   @Test
@@ -449,6 +563,170 @@ class ConservativeSpeciesTransportTest {
     return new SchemePulseResult(peakOutletMassFraction, l1ErrorSeconds / pulseDurationSeconds,
         Math.sqrt(l2ErrorSeconds / pulseDurationSeconds), minimumMassFraction, maximumMassFraction, globalResidualKg,
         maximumSubsteps, maximumFirstOrderDispersion);
+  }
+
+  private static PhysicalDispersionResult runGaussianDispersion(int cells) {
+    double domainLengthM = 200.0;
+    double cellLengthM = domainLengthM / cells;
+    double velocityMPerSecond = 0.2;
+    double dispersionM2PerSecond = 0.5;
+    double totalTimeSeconds = 20.0;
+    double timeStepSeconds = 0.1 * cellLengthM * cellLengthM / dispersionM2PerSecond;
+    int steps = (int) Math.round(totalTimeSeconds / timeStepSeconds);
+    double lineDensityKgPerM = 1.0;
+    double cellMassKg = lineDensityKgPerM * cellLengthM;
+    double massFlowKgPerSecond = lineDensityKgPerM * velocityMPerSecond;
+    double initialCenterM = 60.0;
+    double initialVarianceM2 = 16.0;
+    double amplitude = 0.2;
+    double[][] profile = new double[2][cells];
+    for (int cell = 0; cell < cells; cell++) {
+      double positionM = (cell + 0.5) * cellLengthM;
+      profile[1][cell] = amplitude
+          * Math.exp(-0.5 * (positionM - initialCenterM) * (positionM - initialCenterM) / initialVarianceM2);
+      profile[0][cell] = 1.0 - profile[1][cell];
+    }
+    return runPhysicalDispersion(profile, cellLengthM, cellMassKg, massFlowKgPerSecond, timeStepSeconds, steps,
+        velocityMPerSecond, dispersionM2PerSecond, Double.NaN, Double.NaN, amplitude);
+  }
+
+  private static PhysicalDispersionResult runFinitePulseDispersion(int cells) {
+    double domainLengthM = 200.0;
+    double cellLengthM = domainLengthM / cells;
+    double velocityMPerSecond = 0.2;
+    double dispersionM2PerSecond = 0.5;
+    double totalTimeSeconds = 20.0;
+    double timeStepSeconds = 0.1 * cellLengthM * cellLengthM / dispersionM2PerSecond;
+    int steps = (int) Math.round(totalTimeSeconds / timeStepSeconds);
+    double lineDensityKgPerM = 1.0;
+    double cellMassKg = lineDensityKgPerM * cellLengthM;
+    double massFlowKgPerSecond = lineDensityKgPerM * velocityMPerSecond;
+    double initialCenterM = 60.0;
+    double halfWidthM = 5.0;
+    double amplitude = 0.2;
+    double[][] profile = new double[2][cells];
+    for (int cell = 0; cell < cells; cell++) {
+      double positionM = (cell + 0.5) * cellLengthM;
+      profile[1][cell] = Math.abs(positionM - initialCenterM) <= halfWidthM ? amplitude : 0.0;
+      profile[0][cell] = 1.0 - profile[1][cell];
+    }
+    return runPhysicalDispersion(profile, cellLengthM, cellMassKg, massFlowKgPerSecond, timeStepSeconds, steps,
+        velocityMPerSecond, dispersionM2PerSecond, initialCenterM, halfWidthM, amplitude);
+  }
+
+  private static PhysicalDispersionResult runPhysicalDispersion(double[][] initialProfile, double cellLengthM,
+      double cellMassKg, double massFlowKgPerSecond, double timeStepSeconds, int steps, double velocityMPerSecond,
+      double dispersionM2PerSecond, double pulseCenterM, double pulseHalfWidthM, double pulseAmplitude) {
+    int cells = initialProfile[0].length;
+    double[][] profile = new double[][] { Arrays.copyOf(initialProfile[0], cells),
+        Arrays.copyOf(initialProfile[1], cells) };
+    double[] cellMasses = filled(cells, cellMassKg);
+    double[] faceFlows = filled(cells + 1, massFlowKgPerSecond);
+    double[] cellLengths = filled(cells, cellLengthM);
+    ConstantAxialDispersion model = new ConstantAxialDispersion(dispersionM2PerSecond);
+    double initialTracerInventoryKg = tracerInventory(profile[1], cellMassKg);
+    double cumulativeInletTracerKg = 0.0;
+    double cumulativeOutletTracerKg = 0.0;
+    double maximumStepRelativeResidual = 0.0;
+    double minimumMassFraction = Double.POSITIVE_INFINITY;
+    double maximumMassFraction = Double.NEGATIVE_INFINITY;
+    int maximumSubsteps = 0;
+
+    for (int step = 0; step < steps; step++) {
+      OnePhaseSpeciesConservationReport report = ConservativeSpeciesTransport.solve(
+          new String[] { "carrier", "tracer" }, profile, new double[] { 1.0, 0.0 }, cellMasses, cellMasses, faceFlows,
+          timeStepSeconds, SpeciesAdvectionScheme.TVD_VAN_LEER_SSP_RK2, cellLengths, model);
+      assertTrue(report.isConverged(), "physical-dispersion step=" + step + ": " + report.getMessage());
+      profile = report.getMassFractionProfile();
+      cumulativeInletTracerKg += report.getInletBoundaryMassKg()[1];
+      cumulativeOutletTracerKg += report.getOutletBoundaryMassKg()[1];
+      maximumStepRelativeResidual = Math.max(maximumStepRelativeResidual, report.getMaximumRelativeInventoryResidual());
+      minimumMassFraction = Math.min(minimumMassFraction, report.getMinimumMassFraction());
+      maximumMassFraction = Math.max(maximumMassFraction, report.getMaximumMassFraction());
+      maximumSubsteps = Math.max(maximumSubsteps, report.getTransportDiagnostics().getSubsteps());
+      assertTrue(report.getTransportDiagnostics().isPhysicalDispersionIncluded());
+      assertEquals(dispersionM2PerSecond,
+          report.getTransportDiagnostics().getMaximumPhysicalAxialDispersionM2PerSecond(), 0.0);
+    }
+
+    double finalTracerInventoryKg = tracerInventory(profile[1], cellMassKg);
+    double globalResidualKg = finalTracerInventoryKg - initialTracerInventoryKg - cumulativeInletTracerKg
+        + cumulativeOutletTracerKg;
+    double totalWeight = 0.0;
+    double firstMoment = 0.0;
+    for (int cell = 0; cell < cells; cell++) {
+      double positionM = (cell + 0.5) * cellLengthM;
+      totalWeight += profile[1][cell];
+      firstMoment += positionM * profile[1][cell];
+    }
+    double meanM = firstMoment / totalWeight;
+    double varianceM2 = 0.0;
+    for (int cell = 0; cell < cells; cell++) {
+      double positionM = (cell + 0.5) * cellLengthM;
+      varianceM2 += (positionM - meanM) * (positionM - meanM) * profile[1][cell];
+    }
+    varianceM2 /= totalWeight;
+
+    double normalizedL1Error = Double.NaN;
+    if (Double.isFinite(pulseCenterM)) {
+      double elapsedTimeSeconds = steps * timeStepSeconds;
+      double advectedCenterM = pulseCenterM + velocityMPerSecond * elapsedTimeSeconds;
+      double denominator = Math.sqrt(4.0 * dispersionM2PerSecond * elapsedTimeSeconds);
+      double absoluteError = 0.0;
+      double analyticalMass = 0.0;
+      for (int cell = 0; cell < cells; cell++) {
+        double positionM = (cell + 0.5) * cellLengthM;
+        double analytical = 0.5 * pulseAmplitude
+            * (errorFunction((positionM - advectedCenterM + pulseHalfWidthM) / denominator)
+                - errorFunction((positionM - advectedCenterM - pulseHalfWidthM) / denominator));
+        absoluteError += Math.abs(profile[1][cell] - analytical);
+        analyticalMass += analytical;
+      }
+      normalizedL1Error = absoluteError / analyticalMass;
+    }
+    return new PhysicalDispersionResult(meanM, varianceM2, normalizedL1Error, globalResidualKg,
+        maximumStepRelativeResidual, minimumMassFraction, maximumMassFraction, maximumSubsteps);
+  }
+
+  private static double tracerInventory(double[] tracerMassFraction, double cellMassKg) {
+    double inventoryKg = 0.0;
+    for (double value : tracerMassFraction) {
+      inventoryKg += cellMassKg * value;
+    }
+    return inventoryKg;
+  }
+
+  private static double errorFunction(double value) {
+    double sign = value < 0.0 ? -1.0 : 1.0;
+    double x = Math.abs(value);
+    double t = 1.0 / (1.0 + 0.3275911 * x);
+    double polynomial = (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t + 0.254829592)
+        * t;
+    return sign * (1.0 - polynomial * Math.exp(-x * x));
+  }
+
+  private static final class PhysicalDispersionResult {
+    private final double meanM;
+    private final double varianceM2;
+    private final double normalizedL1Error;
+    private final double globalInventoryResidualKg;
+    private final double maximumStepRelativeResidual;
+    private final double minimumMassFraction;
+    private final double maximumMassFraction;
+    private final int maximumSubsteps;
+
+    private PhysicalDispersionResult(double meanM, double varianceM2, double normalizedL1Error,
+        double globalInventoryResidualKg, double maximumStepRelativeResidual, double minimumMassFraction,
+        double maximumMassFraction, int maximumSubsteps) {
+      this.meanM = meanM;
+      this.varianceM2 = varianceM2;
+      this.normalizedL1Error = normalizedL1Error;
+      this.globalInventoryResidualKg = globalInventoryResidualKg;
+      this.maximumStepRelativeResidual = maximumStepRelativeResidual;
+      this.minimumMassFraction = minimumMassFraction;
+      this.maximumMassFraction = maximumMassFraction;
+      this.maximumSubsteps = maximumSubsteps;
+    }
   }
 
   private static final class SchemePulseResult {

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import neqsim.fluidmechanics.flowsolver.ConstantAxialDispersion;
 import neqsim.fluidmechanics.flowsolver.SpeciesAdvectionScheme;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseFlowConvergenceReport;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport;
@@ -76,6 +77,7 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     PipeFlowSystem pipe = createInitializedPipe(12, 3000.0);
     pipe.setConservativeSpeciesTransport(true);
     pipe.setSpeciesAdvectionScheme(SpeciesAdvectionScheme.TVD_VAN_LEER_SSP_RK2);
+    pipe.setAxialDispersionModel(new ConstantAxialDispersion(0.5));
     pipe.setFailOnNonConvergence(true);
     pipe.getTimeSeries().setTimes(new double[] { 0.0, 30.0 });
     pipe.getTimeSeries().setInletThermoSystems(new SystemInterface[] { createGas(0.80, 0.20) });
@@ -93,6 +95,10 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     assertTrue(report.getMaximumMassFraction() <= 1.0, report.getMessage());
     assertTrue(report.getTransportDiagnostics().getMaximumCellCourantNumber() > 0.0);
     assertTrue(report.getTransportDiagnostics().getMaximumFirstOrderImplicitNumericalDispersionM2PerSecond() > 0.0);
+    assertTrue(report.getTransportDiagnostics().isPhysicalDispersionIncluded());
+    assertEquals("constant", report.getTransportDiagnostics().getPhysicalDispersionModelName());
+    assertEquals(0.5, report.getTransportDiagnostics().getMaximumPhysicalAxialDispersionM2PerSecond(), 0.0);
+    assertTrue(report.getTransportDiagnostics().getCellPecletNumbers()[0] > 0.0);
   }
 
   @Test


### PR DESCRIPTION
## Engineering value

Adds an opt-in physical axial-dispersion term for one-phase conservative component tracking, explicitly separated from numerical spreading. This lets gas-quality pulses be calibrated against tracer or gas-chromatograph data without treating first-order numerical diffusion as a physical coefficient.

Closes #2831 when merged.

## Stack

This draft targets `agent/issue-2830-bounded-species-advection` so the physical-dispersion change remains reviewable independently. Retarget to `master` after #2835 merges.

## Change

- Adds public Java/JPype-facing `AxialDispersionModel` API.
- Keeps `NoAxialDispersion.INSTANCE` as the exact compatibility default.
- Adds validated `ConstantAxialDispersion(D_ax)` in m2/s for analytical tests, calibration, and uncertainty studies.
- Uses one conservative physical face flux:
  - internal conductance uses the two adjacent half-cell resistances and remains consistent on nonuniform grids;
  - `DIRICHLET_INLET` uses the inlet thermodynamic-system composition;
  - `ZERO_GRADIENT_OUTLET` gives zero physical dispersive outlet flux.
- Advances n-1 independent components and closes the final component algebraically, so physical component fluxes sum to zero without clipping or renormalization.
- Couples first-order advection and physical dispersion in one implicit tridiagonal solve.
- Includes physical face fluxes in both TVD SSP-RK2 stages and substeps using the combined advective CFL plus physical dispersion number.
- Extends immutable diagnostics with:
  - selected physical model;
  - cell coefficient profile and range;
  - cell Peclet number;
  - physical dispersion number;
  - explicit inlet/outlet boundary conditions;
  - physical-inclusion flag.
- Retains the first-order modified-equation numerical-dispersion reference as a separate diagnostic.

## Validation

- 28 feature-focused tests pass with zero failures:
  - exact no-dispersion compatibility;
  - public model/API validation and defensive diagnostics;
  - implicit and TVD conservation/boundedness;
  - combined advection-dispersion substepping;
  - nonuniform-grid half-cell resistance conductance;
  - Gaussian variance growth and coarse/medium/fine convergence;
  - finite-pulse analytical advection-diffusion profile;
  - coupled variable-density hydraulic/EOS synchronization.
- The 53-test documentation compilation suite also passes, including the public advection/dispersion example.
- Gaussian regression at the finest grid recovers mean within 0.08 m and variance within 0.3 m2 of the analytical solution.
- Finite-pulse normalized L1 error is below 0.035.
- Maximum analytical-regression inventory residual is below 2e-12 kg.
- `pre-commit run --all-files --hook-stage pre-commit`: pass.
- `pre-commit run --all-files --hook-stage pre-push`: pass.
- Spotless and documentation-search coverage: pass (646 Markdown + 1 HTML).

Hosted build/test/Javadoc and reviewer checks remain mandatory before this draft is marked ready.

## Physical interpretation and limits

A constant `D_ax` is a user hypothesis, not a built-in turbulent-pipe correlation. Documentation requires grid/time refinement with the physical model fixed, and recommends operational calibration only after aligning inlet composition, flow/pressure history, geometry, and outlet timestamps. Molecular diffusion, Taylor/shear dispersion, fittings, network mixing, reverse flow, and phase appearance remain separate effects or work items.

## Stack synchronization validation (2026-08-05)

- Merged updated stack parent `63746700cfd69df301d5335f12b483bad25d83a7`; GitHub reports the stacked PR mergeable.
- Added `OnePhasePipeLine` delegation for `AxialDispersionModel`, preserving `NoAxialDispersion.INSTANCE` as the default and keeping physical dispersion independent of numerical advection.
- Focused stacked integration suite: 96 tests passed (0 failures/errors), covering axial-dispersion models, conservative transport, the process wrapper, gas-network transport, and documentation examples.
- `pre-commit run --all-files --hook-stage pre-commit`: pass.
- `pre-commit run --all-files --hook-stage pre-push`: pass; Spotless and documentation search passed (646 Markdown + 1 HTML).
- Documentation impact: updated the single-phase pipe-flow example and `OnePhasePipeLine` Javadocs for process-level physical-dispersion selection.


## Review disposition before automatic merge (2026-08-05)

- Accepted: preserve `NoAxialDispersion.INSTANCE` across Java serialization. Added `readResolve()` and a singleton-identity serialization regression in commit `cfba1941c2e6e42eb9161e346b12dc335522b0c2`; 3 focused tests pass.
- Rejected as non-actionable: four static-analysis comments flag the parameters of `AxialDispersionModel.getCoefficientM2PerSecond(...)` as unused. They are part of the public strategy contract and are required by spatially and state-dependent implementations; removing them would prevent the intended extensibility even though the constant/no-dispersion implementations do not consume every argument.
- `pre-commit run --all-files --hook-stage pre-commit`: pass.
- `pre-commit run --all-files --hook-stage pre-push`: pass.
- Documentation impact: updated `NoAxialDispersion` Javadoc to document canonical-instance behavior after deserialization; no user-guide change is needed because coefficients, inputs, defaults, and numerical behavior are unchanged.
