### PR TITLE
style(test): restore ASTM D4052 Spotless layout

### DIFF
--- a/src/test/java/neqsim/standards/oilquality/OilQualityStandardsTest.java
+++ b/src/test/java/neqsim/standards/oilquality/OilQualityStandardsTest.java
@@ -468,8 +468,7 @@ public class OilQualityStandardsTest {
     assertTrue(flashed.hasPhaseType(PhaseType.GAS), "Test fluid should contain a gas phase");
     assertTrue(flashed.hasPhaseType(PhaseType.OIL) || flashed.hasPhaseType(PhaseType.LIQUID),
         "Test fluid should contain a hydrocarbon liquid phase");
-    PhaseType liquidPhaseType =
-        flashed.hasPhaseType(PhaseType.OIL) ? PhaseType.OIL : PhaseType.LIQUID;
+    PhaseType liquidPhaseType = flashed.hasPhaseType(PhaseType.OIL) ? PhaseType.OIL : PhaseType.LIQUID;
     double expectedOilDensity = flashed.getPhase(liquidPhaseType).getDensity("kg/m3");
 
     Standard_ASTM_D4052 standard = new Standard_ASTM_D4052(crude);


### PR DESCRIPTION
## Summary

Restores the exact repository Spotless layout in `OilQualityStandardsTest` after #2829 merged.

This is a one-line formatting-only change. It unblocks the hosted pre-push gate for PRs tested against current `master`.

## Validation

- `pre-commit run --all-files --hook-stage pre-push`: pass
- Spotless check: pass
- Documentation search coverage: pass (646 Markdown + 1 HTML)
- `git diff --check`: pass
- no behavioral code changed

Closes #2839