### PR TITLE
fix(optimizer): preserve two-sided constraint conversion

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,20 @@
 
 ---
 
+## 2026-08-05 — Lossless external-to-internal constraint conversion
+
+- `ProcessSimulationEvaluator.ConstraintDefinition.toOptimizationConstraints()` now converts
+  lower/upper bounds to one immutable-list element and range/equality definitions to explicit
+  `_lower` and `_upper` internal constraints.
+- Both generated sides retain the source evaluator, severity, and penalty weight, preventing
+  operating envelopes and tolerance bands from silently losing their lower bound.
+- The singular `toOptimizationConstraint()` API is unchanged for compatibility and remains lossy
+  for range and equality definitions. New integrations must use the plural method.
+- Interpret sensitivities and shadow values for the generated lower and upper constraints
+  separately.
+
+---
+
 ## 2026-08-05 — Column pumparound returns remain internal recycles
 
 - `DistillationColumn` no longer captures a named pumparound return stream as a legacy direct

--- a/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
+++ b/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
@@ -130,6 +130,26 @@ penalties, are derived from those same scalar samples. This matters when result 
 costly reporting or serialization and prevents inconsistent fields when a callback reads mutable
 diagnostics. Callbacks should nevertheless remain side-effect free.
 
+## Converting Constraints to the Internal Optimizer
+
+Use the plural conversion when a `ConstraintDefinition` is passed to `ProductionOptimizer`:
+
+```java
+List<ProductionOptimizer.OptimizationConstraint> internalConstraints =
+    externalConstraint.toOptimizationConstraints();
+```
+
+A lower or upper bound produces one immutable-list element. A range produces `name_lower` and
+`name_upper`; an equality target produces the equivalent `target - tolerance` lower side and
+`target + tolerance` upper side. Each generated side keeps the source evaluator, hard/soft
+severity, and penalty weight.
+
+The singular `toOptimizationConstraint()` method remains available for compatibility. It is
+lossless only for one-sided constraints; for range and equality types it retains the historical
+upper-side-only behavior. Do not use that method for operating envelopes, product-quality bands,
+equipment turndown ranges, or market-nomination tolerances. Treat lower- and upper-side
+sensitivities separately because only one side can normally be active at a given operating point.
+
 ## Java Setup
 
 ```java

--- a/docs/util/optimizer_guide.md
+++ b/docs/util/optimizer_guide.md
@@ -567,8 +567,20 @@ ProcessSimulationEvaluator.ConstraintDefinition external =
 
 // External -> Internal
 ProcessSimulationEvaluator.ConstraintDefinition def = ...;
-OptimizationConstraint opt = def.toOptimizationConstraint();
+List<OptimizationConstraint> internalConstraints =
+    def.toOptimizationConstraints();
 ```
+
+Use the plural conversion for all general-purpose bridges. It returns one immutable-list element
+for a lower or upper bound and two elements for a range or equality tolerance band. The generated
+two-sided names end in `_lower` and `_upper`; both sides retain the original evaluator, severity,
+and penalty weight. This prevents a pressure, temperature, quality, or nomination envelope from
+silently losing its lower limit.
+
+The older singular `toOptimizationConstraint()` method remains source- and binary-compatible, but
+its historical range/equality behavior returns only the upper side. Use it only when the source
+constraint is known to be one-sided. Sensitivities or shadow values belong to the generated active
+side, not to one combined two-sided constraint.
 
 ---
 
@@ -673,7 +685,9 @@ boolean ok = calc.isFeasible(process);
 - **`CapacityConstraintAdapter`**: Wraps equipment `CapacityConstraint` as `ProcessConstraint` for direct use in any optimizer
 - **`ConstraintPenaltyCalculator`**: Reusable adaptive penalty calculator with auto-discovery of equipment constraints
 - **`ProcessSimulationEvaluator` bridge**: `addEquipmentCapacityConstraints()`, `getAllProcessConstraints()`, `getConstraintMarginVector()` for NLP solver integration
-- **Constraint conversions**: `OptimizationConstraint.toConstraintDefinition()` and `ConstraintDefinition.toOptimizationConstraint()` for bidirectional conversion
+- **Constraint conversions**: `OptimizationConstraint.toConstraintDefinition()` and lossless
+  `ConstraintDefinition.toOptimizationConstraints()` for bidirectional conversion; the legacy
+  singular method remains lossy for range and equality types
 
 ### Algorithm and Engine Improvements (January 2026)
 - **Configurable PSO seed**: `useFixedSeed(true).randomSeed(42L)` for reproducible results

--- a/src/main/java/neqsim/process/util/optimizer/ProcessSimulationEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessSimulationEvaluator.java
@@ -3,6 +3,7 @@ package neqsim.process.util.optimizer;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -578,11 +579,12 @@ public class ProcessSimulationEvaluator implements Serializable {
      * optimizer.
      *
      * <p>
-     * Only LOWER_BOUND and UPPER_BOUND types can be converted directly. RANGE constraints are converted to an
-     * UPPER_BOUND constraint (using the tightest bound). EQUALITY constraints are approximated as a tight range.
+     * <strong>Compatibility note:</strong> this singular method preserves its historical lossy behavior for two-sided
+     * constraints. RANGE and EQUALITY constraints return only their upper side. Use
+     * {@link #toOptimizationConstraints()} whenever both sides must remain enforced.
      * </p>
      *
-     * @return equivalent OptimizationConstraint
+     * @return equivalent single OptimizationConstraint; lossy for RANGE and EQUALITY
      * @throws IllegalStateException if the evaluator function is null
      */
     public ProductionOptimizer.OptimizationConstraint toOptimizationConstraint() {
@@ -618,6 +620,57 @@ public class ProcessSimulationEvaluator implements Serializable {
       default:
         return ProductionOptimizer.OptimizationConstraint.lessThan(name, evaluator, upperBound, sev, penaltyWeight,
             "Converted from ConstraintDefinition");
+      }
+    }
+
+    /**
+     * Converts this constraint without losing either side of a two-sided bound.
+     *
+     * <p>
+     * LOWER_BOUND and UPPER_BOUND constraints produce one internal constraint. RANGE constraints produce
+     * {@code name_lower} and {@code name_upper}. EQUALITY constraints produce the tolerance band
+     * {@code value >= target - tolerance} and {@code value <= target + tolerance} with the same suffixes. Every
+     * generated constraint retains the evaluator, severity, and penalty weight of this definition.
+     * </p>
+     *
+     * @return immutable list containing one or two equivalent OptimizationConstraint instances
+     * @throws IllegalStateException if the evaluator function is null
+     */
+    public List<ProductionOptimizer.OptimizationConstraint> toOptimizationConstraints() {
+      if (evaluator == null) {
+        throw new IllegalStateException(
+            "Cannot convert to OptimizationConstraint: evaluator is null (was this deserialized?)");
+      }
+      ProductionOptimizer.ConstraintSeverity severity = isHard ? ProductionOptimizer.ConstraintSeverity.HARD
+          : ProductionOptimizer.ConstraintSeverity.SOFT;
+      switch (type) {
+      case UPPER_BOUND:
+        return Collections.singletonList(ProductionOptimizer.OptimizationConstraint.lessThan(name, evaluator,
+            upperBound, severity, penaltyWeight, "Converted from ConstraintDefinition"));
+      case LOWER_BOUND:
+        return Collections.singletonList(ProductionOptimizer.OptimizationConstraint.greaterThan(name, evaluator,
+            lowerBound, severity, penaltyWeight, "Converted from ConstraintDefinition"));
+      case RANGE:
+        List<ProductionOptimizer.OptimizationConstraint> rangeConstraints = new ArrayList<ProductionOptimizer.OptimizationConstraint>(
+            2);
+        rangeConstraints.add(ProductionOptimizer.OptimizationConstraint.greaterThan(name + "_lower", evaluator,
+            lowerBound, severity, penaltyWeight, "Converted from range ConstraintDefinition (lower bound)"));
+        rangeConstraints.add(ProductionOptimizer.OptimizationConstraint.lessThan(name + "_upper", evaluator, upperBound,
+            severity, penaltyWeight, "Converted from range ConstraintDefinition (upper bound)"));
+        return Collections.unmodifiableList(rangeConstraints);
+      case EQUALITY:
+        List<ProductionOptimizer.OptimizationConstraint> equalityConstraints = new ArrayList<ProductionOptimizer.OptimizationConstraint>(
+            2);
+        equalityConstraints.add(ProductionOptimizer.OptimizationConstraint.greaterThan(name + "_lower", evaluator,
+            lowerBound - equalityTolerance, severity, penaltyWeight,
+            "Converted from equality ConstraintDefinition (lower bound)"));
+        equalityConstraints.add(ProductionOptimizer.OptimizationConstraint.lessThan(name + "_upper", evaluator,
+            lowerBound + equalityTolerance, severity, penaltyWeight,
+            "Converted from equality ConstraintDefinition (upper bound)"));
+        return Collections.unmodifiableList(equalityConstraints);
+      default:
+        return Collections.singletonList(ProductionOptimizer.OptimizationConstraint.lessThan(name, evaluator,
+            upperBound, severity, penaltyWeight, "Converted from ConstraintDefinition"));
       }
     }
   }

--- a/src/test/java/neqsim/process/util/optimizer/ProcessSimulationEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessSimulationEvaluatorTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
@@ -348,6 +349,128 @@ class ProcessSimulationEvaluatorTest {
 
     double penalty = constraint.penalty(processSystem);
     assertEquals(100.0 * 25.0, penalty, 0.01); // 100 * (-5)^2 = 2500
+  }
+
+  @Test
+  void convertsOneSidedConstraintsWithoutLoss() {
+    final double[] metric = { 5.0 };
+    ProcessSimulationEvaluator.ConstraintDefinition lower = new ProcessSimulationEvaluator.ConstraintDefinition(
+        "minimum", p -> metric[0], 2.0);
+    lower.setHard(false);
+    lower.setPenaltyWeight(37.0);
+
+    ProcessSimulationEvaluator.ConstraintDefinition upper = new ProcessSimulationEvaluator.ConstraintDefinition();
+    upper.setName("maximum");
+    upper.setEvaluator(p -> metric[0]);
+    upper.setUpperBound(8.0);
+    upper.setType(ProcessSimulationEvaluator.ConstraintDefinition.Type.UPPER_BOUND);
+    upper.setPenaltyWeight(41.0);
+
+    List<ProductionOptimizer.OptimizationConstraint> convertedLower = lower.toOptimizationConstraints();
+    List<ProductionOptimizer.OptimizationConstraint> convertedUpper = upper.toOptimizationConstraints();
+
+    assertEquals(1, convertedLower.size());
+    assertEquals("minimum", convertedLower.get(0).getName());
+    assertEquals(ProductionOptimizer.ConstraintDirection.GREATER_THAN, convertedLower.get(0).getDirection());
+    assertEquals(2.0, convertedLower.get(0).getLimit(), 0.0);
+    assertEquals(ProductionOptimizer.ConstraintSeverity.SOFT, convertedLower.get(0).getSeverity());
+    assertEquals(37.0, convertedLower.get(0).getPenaltyWeight(), 0.0);
+    assertEquals(3.0, convertedLower.get(0).margin(processSystem), 0.0);
+
+    assertEquals(1, convertedUpper.size());
+    assertEquals("maximum", convertedUpper.get(0).getName());
+    assertEquals(ProductionOptimizer.ConstraintDirection.LESS_THAN, convertedUpper.get(0).getDirection());
+    assertEquals(8.0, convertedUpper.get(0).getLimit(), 0.0);
+    assertEquals(ProductionOptimizer.ConstraintSeverity.HARD, convertedUpper.get(0).getSeverity());
+    assertEquals(41.0, convertedUpper.get(0).getPenaltyWeight(), 0.0);
+    assertEquals(3.0, convertedUpper.get(0).margin(processSystem), 0.0);
+
+    assertThrows(UnsupportedOperationException.class, () -> convertedLower.add(convertedUpper.get(0)));
+    assertThrows(UnsupportedOperationException.class, () -> convertedUpper.clear());
+  }
+
+  @Test
+  void convertsRangeConstraintWithoutDroppingEitherBound() {
+    final double[] metric = { 1.0 };
+    ProcessSimulationEvaluator.ConstraintDefinition range = new ProcessSimulationEvaluator.ConstraintDefinition(
+        "operatingEnvelope", p -> metric[0], 2.0, 8.0);
+    range.setHard(false);
+    range.setPenaltyWeight(37.0);
+
+    List<ProductionOptimizer.OptimizationConstraint> converted = range.toOptimizationConstraints();
+
+    assertEquals(2, converted.size());
+    assertEquals("operatingEnvelope_lower", converted.get(0).getName());
+    assertEquals("operatingEnvelope_upper", converted.get(1).getName());
+    assertEquals(ProductionOptimizer.ConstraintDirection.GREATER_THAN, converted.get(0).getDirection());
+    assertEquals(ProductionOptimizer.ConstraintDirection.LESS_THAN, converted.get(1).getDirection());
+    assertEquals(2.0, converted.get(0).getLimit(), 0.0);
+    assertEquals(8.0, converted.get(1).getLimit(), 0.0);
+    assertEquals(ProductionOptimizer.ConstraintSeverity.SOFT, converted.get(0).getSeverity());
+    assertEquals(ProductionOptimizer.ConstraintSeverity.SOFT, converted.get(1).getSeverity());
+    assertEquals(37.0, converted.get(0).getPenaltyWeight(), 0.0);
+    assertEquals(37.0, converted.get(1).getPenaltyWeight(), 0.0);
+    assertTrue(converted.get(0).getDescription().contains("range ConstraintDefinition (lower bound)"));
+    assertTrue(converted.get(1).getDescription().contains("range ConstraintDefinition (upper bound)"));
+
+    assertEquals(-1.0, converted.get(0).margin(processSystem), 0.0);
+    assertEquals(7.0, converted.get(1).margin(processSystem), 0.0);
+    assertFalse(converted.get(0).isSatisfied(processSystem));
+    metric[0] = 5.0;
+    assertEquals(3.0, converted.get(0).margin(processSystem), 0.0);
+    assertEquals(3.0, converted.get(1).margin(processSystem), 0.0);
+    assertTrue(converted.get(0).isSatisfied(processSystem));
+    assertTrue(converted.get(1).isSatisfied(processSystem));
+    metric[0] = 9.0;
+    assertEquals(7.0, converted.get(0).margin(processSystem), 0.0);
+    assertEquals(-1.0, converted.get(1).margin(processSystem), 0.0);
+    assertFalse(converted.get(1).isSatisfied(processSystem));
+    assertThrows(UnsupportedOperationException.class, () -> converted.remove(0));
+
+    ProductionOptimizer.OptimizationConstraint singular = range.toOptimizationConstraint();
+    assertEquals("operatingEnvelope_upper", singular.getName());
+    assertEquals(ProductionOptimizer.ConstraintDirection.LESS_THAN, singular.getDirection());
+    assertEquals(8.0, singular.getLimit(), 0.0);
+  }
+
+  @Test
+  void convertsEqualityConstraintToToleranceBand() {
+    final double[] metric = { 4.0 };
+    ProcessSimulationEvaluator.ConstraintDefinition equality = new ProcessSimulationEvaluator.ConstraintDefinition();
+    equality.setName("qualityTarget");
+    equality.setEvaluator(p -> metric[0]);
+    equality.setLowerBound(5.0);
+    equality.setEqualityTolerance(0.1);
+    equality.setType(ProcessSimulationEvaluator.ConstraintDefinition.Type.EQUALITY);
+    equality.setPenaltyWeight(53.0);
+
+    List<ProductionOptimizer.OptimizationConstraint> converted = equality.toOptimizationConstraints();
+
+    assertEquals(2, converted.size());
+    assertEquals("qualityTarget_lower", converted.get(0).getName());
+    assertEquals("qualityTarget_upper", converted.get(1).getName());
+    assertEquals(4.9, converted.get(0).getLimit(), 1.0e-12);
+    assertEquals(5.1, converted.get(1).getLimit(), 1.0e-12);
+    assertEquals(ProductionOptimizer.ConstraintDirection.GREATER_THAN, converted.get(0).getDirection());
+    assertEquals(ProductionOptimizer.ConstraintDirection.LESS_THAN, converted.get(1).getDirection());
+    assertEquals(53.0, converted.get(0).getPenaltyWeight(), 0.0);
+    assertEquals(53.0, converted.get(1).getPenaltyWeight(), 0.0);
+    assertTrue(converted.get(0).getDescription().contains("equality ConstraintDefinition (lower bound)"));
+    assertTrue(converted.get(1).getDescription().contains("equality ConstraintDefinition (upper bound)"));
+
+    assertEquals(-0.9, converted.get(0).margin(processSystem), 1.0e-12);
+    assertTrue(converted.get(1).margin(processSystem) > 0.0);
+    metric[0] = 5.0;
+    assertEquals(0.1, converted.get(0).margin(processSystem), 1.0e-12);
+    assertEquals(0.1, converted.get(1).margin(processSystem), 1.0e-12);
+    metric[0] = 6.0;
+    assertTrue(converted.get(0).margin(processSystem) > 0.0);
+    assertEquals(-0.9, converted.get(1).margin(processSystem), 1.0e-12);
+
+    ProductionOptimizer.OptimizationConstraint singular = equality.toOptimizationConstraint();
+    assertEquals("qualityTarget_eq", singular.getName());
+    assertEquals(ProductionOptimizer.ConstraintDirection.LESS_THAN, singular.getDirection());
+    assertEquals(5.1, singular.getLimit(), 1.0e-12);
   }
 
   @Test


### PR DESCRIPTION
## Production-engineering value

Preserves both sides of external optimizer constraints when they are converted for `ProductionOptimizer`. This prevents lower pressure, temperature, product-quality, equipment-turndown, and market-nomination limits from being silently dropped.

Closes #2842.

## Reproduced problem

On the unchanged optimizer API, the singular conversion is intentionally upper-side-only for `RANGE` and `EQUALITY`:

- range `2 <= m <= 8` at `m=1`: source margin `-1`, converted upper-only margin `+7`;
- equality `5 ± 0.1` at `m=4`: the source lower side fails, while the converted upper side passes.

The regression fails on the unmodified evaluator because no lossless plural API exists.

## Change

- Add `ConstraintDefinition.toOptimizationConstraints()`.
- Return one immutable-list element for lower/upper bounds.
- Return deterministic `_lower` and `_upper` elements for ranges.
- Convert equality to `target - tolerance <= value <= target + tolerance`.
- Preserve evaluator behavior, hard/soft severity, penalty weight, direction, limit, and traceable descriptions.
- Keep `toOptimizationConstraint()` behavior and signature unchanged for source/binary compatibility.
- Document that sensitivities and shadow values belong to the generated active side.

## Deterministic validation

The focused regressions cover all four constraint types and prove:

- range below/inside/above: `(-1,+7)`, `(+3,+3)`, and `(+7,-1)`;
- equality `5 ± 0.1` below/at/above: lower, neither, and upper violation respectively;
- one-sided conversions retain name, direction, limit, severity, penalty weight, and evaluator behavior;
- generated lists reject mutation;
- the historical singular range/equality conversion remains unchanged.

After rebasing onto current `master` `cc655d42931a3040be9ad5c4ba18aabc840086ba`:

- 348 optimizer tests: 0 failures, 0 errors, 0 skipped.
- Java compilation passes under the repository Java 8 source contract on OpenJDK 17.0.19.
- `pre-commit run --all-files --hook-stage pre-commit`: pass.
- `pre-commit run --all-files --hook-stage pre-push`: pass.
- Spotless check: pass.
- Documentation search: 646 Markdown + 1 standalone HTML page, pass.
- `git diff --check`: pass.
- Exact-head hosted Java 8/21, Windows, slow shards, Javadocs, CodeQL, and review remain mandatory before readiness.

## Documentation impact

Updated:

- public method Javadocs;
- external-optimizer integration guide;
- optimizer guide and conversion example;
- agent changelog.

## Compatibility and scope

- Additive public API only.
- Existing singular API, serialized fields, evaluator callbacks, penalty equations, defaults, solvers, thermodynamics, process execution, and constraint registration are unchanged.
- No notebook or Python package change is required; the returned Java `List` is directly visible through JPype.
- No performance gain is claimed.

## Stack resolution

Formatter repair #2840 is merged. This PR is now a clean five-file diff directly on current `master`; the temporary formatter file and stacked commit are no longer present.