### PR TITLE
Fix trace-water aqueous stability selection in TPflash

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -213,6 +213,14 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Accept a lower-Gibbs physical candidate, or replace a non-conservative     │
 │       reference only with a balanced, equilibrated physical candidate            │
 │                                                                                 │
+│  IF trace water, GAS+OIL, min(β) ≤ 0.01, and x_water,oil ≥ 10 z_water:           │
+│     → Run the existing aqueous tangent-plane stability trial on a clone          │
+│     → Solve the multiphase beta problem, remove exactly one disappearing phase   │
+│       or merge exactly one composition-identical duplicate, then rebuild and     │
+│       reconverge the resulting two-phase active set                              │
+│     → Replace only with a normalized, balanced, fugacity-equal, distinct,        │
+│       lower-Gibbs GAS+AQUEOUS endpoint; otherwise retain the original state       │
+│                                                                                 │
 │  IF ordinary, neutral, exactly-two-phase result contains an aqueous phase:       │
 │     → Evaluate gas-like and liquid-like roots of the non-aqueous cubic phase     │
 │     → Replace only with a lower-Gibbs root that already satisfies                │
@@ -259,7 +267,8 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Convergence tolerance | 1e-10 | Deviation threshold for K-value convergence |
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
 | Supplementary stability TPD limit | -1e-6 | Accept a converged amplified-K or composition-perturbation trial only when its reduced TPD exceeds that SSI solve's residual/step resolution and the trial composition is non-trivial |
-| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for valid trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i)` is non-finite or above `1e-8`, allowing the bounded beta correction below without another stability calculation. An incipient trace-water GAS+OIL endpoint with `min(beta) <= 1e-4` also bypasses the threshold when its confirmed log-fugacity residual is non-finite or at least `1e-8`; the existing guarded multiphase candidate must then pass the strict feasibility and lower-Gibbs gates. |
+| Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for valid trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i)` is non-finite or above `1e-8`, allowing the bounded beta correction below without another stability calculation. An incipient trace-water GAS+OIL endpoint with `min(beta) <= 1e-4` also bypasses the threshold when its confirmed log-fugacity residual is non-finite or at least `1e-8`; the guarded candidate must then pass the strict feasibility and lower-Gibbs gates. |
+| Trace-water aqueous-stability screen | water feed `< 0.01`, GAS+OIL, `min(beta) <= 0.01`, and `x_water,oil >= 10 z_water` | Use the structural conditions only as a performance gate for an aqueous TPD trial. The TPD result, reduced-active-set convergence below `1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and lower Gibbs energy determine acceptance. Full recursive TPmultiflash is not run. |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
 | Cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root assignment only when the existing composition split is already at equilibrium |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
@@ -1712,12 +1721,19 @@ Commercial process simulators do not publish all implementation details, but pub
   balance has `max abs(Delta z_i) >= 1e-8`. A feasible candidate normally must lower Gibbs energy; when the reference
   is non-conservative and its Gibbs energy is therefore not comparable, the candidate must instead independently pass
   phase-fraction, composition-normalization, material-balance, fugacity, and distinct-composition checks. The 0.01
-  water-feed gate still protects phase-search cost for valid endpoints. An already-active neutral aqueous split with a
+  water-feed gate still protects phase-search cost for valid endpoints. A trace-water GAS+OIL endpoint with a minor
+  phase no larger than `0.01` and at least tenfold water enrichment in its hydrocarbon liquid uses the existing aqueous
+  TPD trial on a clone. The resulting three-phase beta problem must lose exactly one numerical-floor phase or one
+  composition-identical duplicate before the reduced two-phase active set is rebuilt and reconverged. It replaces the
+  original only when phase fractions, normalization, material balance, fugacity equality, distinct compositions, and
+  lower Gibbs energy all pass. Thus the enrichment and beta values gate cost; they do not decide stability. An
+  already-active neutral aqueous split with a
   non-finite material residual or one above `1e-8` may use the existing three-step beta correction below that threshold;
   this does not search for or create a phase. A trace-water GAS+OIL endpoint with a confirmed non-finite or at-least
   `1e-8` log-fugacity residual may run the existing guarded multiphase candidate and is replaced only by a strictly
-  feasible lower-Gibbs result. This phase-selection retry is restricted to an incipient secondary phase with
-  `min(beta) <= 1e-4`, so established valid gas/oil splits avoid even the component residual scan.
+  feasible lower-Gibbs result. That invalid-endpoint retry is restricted to an incipient secondary phase with
+  `min(beta) <= 1e-4`, so established valid gas/oil splits avoid even the component residual scan unless they satisfy
+  the separate aqueous-stability screen.
 - When the tangent-plane stability path has already accepted a homogeneous state, an unnormalized aqueous trial seed
   cannot replace it. The guard is deliberately structural: each active phase composition must be finite, bounded in
   `[0, 1]`, and normalized within `1e-8`. It does not impose a universal material-balance or fugacity threshold on

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1014,7 +1014,7 @@ public class TPflash extends Flash {
       candidate.setMultiPhaseCheck(true);
       boolean candidateConverged;
       if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
-        candidateConverged = refineWaterRichCandidateActiveSet(candidate);
+        candidateConverged = refineTraceWaterAqueousCandidateActiveSet(candidate);
       } else {
         new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
         candidateConverged = true;
@@ -1077,7 +1077,7 @@ public class TPflash extends Flash {
    * @param candidate cloned gas/oil endpoint
    * @return true when exactly one disappearing or duplicate phase was removed and the two remaining phases converged
    */
-  private boolean refineWaterRichCandidateActiveSet(SystemInterface candidate) {
+  private boolean refineTraceWaterAqueousCandidateActiveSet(SystemInterface candidate) {
     int initialPhaseCount = candidate.getNumberOfPhases();
     TPmultiflash operation = new TPmultiflash(candidate, false);
     operation.stabilityAnalysis();

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -49,6 +49,10 @@ public class TPflash extends Flash {
   private static final double WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT = 0.01;
   /** Largest incipient secondary-phase fraction eligible for trace-water phase-selection retry. */
   private static final double TRACE_WATER_PHASE_SELECTION_BETA_LIMIT = 1.0e-4;
+  /** Largest secondary-phase fraction eligible for the trace-water aqueous-stability trial. */
+  private static final double TRACE_WATER_AQUEOUS_STABILITY_BETA_LIMIT = 1.0e-2;
+  /** Minimum water enrichment in the hydrocarbon liquid for the aqueous-stability trial. */
+  private static final double TRACE_WATER_AQUEOUS_STABILITY_ENRICHMENT_LIMIT = 10.0;
   /** Maximum stored water K-value that justifies checking a collapsed water-bearing endpoint. */
   private static final double WATER_PHASE_COLLAPSE_WATER_K_UPPER_LIMIT = 1.0e-2;
   /** Minimum stored non-water K-value that justifies checking a collapsed water-bearing endpoint. */
@@ -962,16 +966,18 @@ public class TPflash extends Flash {
    * gas/oil iteration has stopped. Such an endpoint is refined when its component fugacity residual exceeds
    * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE} or its component material balance exceeds
    * {@link #WATER_RICH_MATERIAL_BALANCE_TOLERANCE}. The one-mol-percent feed guard keeps valid trace-water process
-   * flashes on the existing fast path. A trace-water gas/oil endpoint whose fugacity residual is already outside the
-   * equilibrium tolerance may still use the cloned stability calculation because it is not an acceptable result. A
-   * cloned multiphase candidate normally replaces the ordinary state only when it lowers Gibbs energy. If the reference
-   * state is non-conservative, Gibbs energies are not comparable; a candidate may then replace it only after passing
-   * strict phase-fraction, composition-normalization, material-balance, fugacity, and distinct-composition checks.
+   * flashes outside the minor-phase trace-water screen on the existing fast path. A trace-water gas/oil endpoint whose
+   * fugacity residual is already outside the equilibrium tolerance may still use the cloned stability calculation
+   * because it is not an acceptable result. A cheap aqueous tangent-plane trial and safeguarded multiphase beta solve
+   * are used for trace-water gas/oil endpoints whose small hydrocarbon liquid disproportionately concentrates water.
+   * Full recursive multiphase flashing is avoided. A candidate replaces the original state only after a disappearing
+   * phase is removed, the remaining active set is reconverged, and strict phase-fraction, composition-normalization,
+   * material-balance, fugacity, distinct-composition, and lower-Gibbs checks pass.
    * </p>
    */
   private void rescueWaterRichEndpoint() {
-    if (system.doMultiPhaseCheck() || system.isChemicalSystem() || system.hasIons() || solidCheck
-        || system.isMultiphaseWaxCheck() || system.getNumberOfPhases() > 2) {
+    if (system.isChemicalSystem() || system.hasIons() || solidCheck || system.isMultiphaseWaxCheck()
+        || system.getNumberOfPhases() > 2) {
       return;
     }
 
@@ -987,8 +993,11 @@ public class TPflash extends Flash {
         break;
       }
     }
+    if (system.doMultiPhaseCheck() && waterFeedFraction >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
+      return;
+    }
     if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
-        && (waterFeedFraction <= 0.0 || !isInvalidTraceWaterGasOilEndpoint())) {
+        && (waterFeedFraction <= 0.0 || !shouldRefineTraceWaterGasOilEndpoint(waterFeedFraction))) {
       return;
     }
     double materialBalanceResidual = maximumComponentMaterialBalanceResidual(system);
@@ -1003,14 +1012,118 @@ public class TPflash extends Flash {
     SystemInterface candidate = system.clone();
     try {
       candidate.setMultiPhaseCheck(true);
-      new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
-      if (candidate.getNumberOfPhases() == 2
+      boolean candidateConverged;
+      if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
+        candidateConverged = refineWaterRichCandidateActiveSet(candidate);
+      } else {
+        new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+        candidateConverged = true;
+      }
+      if (candidateConverged && candidate.getNumberOfPhases() == 2 && isBalancedEquilibriumCandidate(candidate)
           && shouldAcceptWaterRichCandidate(candidate, referenceGibbsEnergy, materialBalanceInvalid)) {
         copyFlashStateFrom(candidate);
       }
     } catch (Exception ex) {
       logger.debug("Water-rich endpoint refinement failed: {}", ex.getMessage());
     }
+  }
+
+  /**
+   * Screens a trace-water gas/oil endpoint for a missed lower-Gibbs aqueous split.
+   *
+   * @param waterFeedFraction overall water mole fraction
+   * @return true when the endpoint is already invalid, or its phase fraction and water enrichment justify an aqueous
+   * stability trial
+   */
+  private boolean shouldRefineTraceWaterGasOilEndpoint(double waterFeedFraction) {
+    if (isInvalidTraceWaterGasOilEndpoint()) {
+      return true;
+    }
+    if (system.getNumberOfPhases() != 2 || system.hasPhaseType(PhaseType.AQUEOUS)
+        || Math.min(system.getBeta(0), system.getBeta(1)) > TRACE_WATER_AQUEOUS_STABILITY_BETA_LIMIT) {
+      return false;
+    }
+    boolean hasGasPhase = false;
+    int hydrocarbonLiquidPhase = -1;
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      PhaseType phaseType = system.getPhase(phaseIndex).getType();
+      hasGasPhase |= phaseType == PhaseType.GAS;
+      if (phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID) {
+        hydrocarbonLiquidPhase = phaseIndex;
+      }
+    }
+    if (!hasGasPhase || hydrocarbonLiquidPhase < 0) {
+      return false;
+    }
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      if ("water".equalsIgnoreCase(system.getPhase(0).getComponent(componentIndex).getComponentName())) {
+        double liquidWaterFraction = system.getPhase(hydrocarbonLiquidPhase).getComponent(componentIndex).getx();
+        return liquidWaterFraction >= TRACE_WATER_AQUEOUS_STABILITY_ENRICHMENT_LIMIT * waterFeedFraction;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Runs the existing tangent-plane trial and reconverges the reduced active phase set.
+   *
+   * <p>
+   * The first multiphase beta solve identifies a disappearing phase. Removing only a phase at the solver's numerical
+   * phase-fraction floor and rebuilding the beta workspace turns the trial into a well-conditioned two-phase solve. If
+   * the solver returns two duplicate phases instead, exactly one duplicate pair may be merged before the active set is
+   * rebuilt. The caller performs the final thermodynamic acceptance checks.
+   * </p>
+   *
+   * @param candidate cloned gas/oil endpoint
+   * @return true when exactly one disappearing or duplicate phase was removed and the two remaining phases converged
+   */
+  private boolean refineWaterRichCandidateActiveSet(SystemInterface candidate) {
+    int initialPhaseCount = candidate.getNumberOfPhases();
+    TPmultiflash operation = new TPmultiflash(candidate, false);
+    operation.stabilityAnalysis();
+    if (candidate.getNumberOfPhases() <= initialPhaseCount) {
+      return false;
+    }
+    operation.setDoubleArrays();
+    operation.solveBeta();
+    int removedPhaseCount = 0;
+    for (int phaseIndex = candidate.getNumberOfPhases() - 1; phaseIndex >= 0; phaseIndex--) {
+      if (candidate.getNumberOfPhases() > 1 && candidate.getBeta(phaseIndex) <= 10.0 * phaseFractionMinimumLimit) {
+        candidate.removePhaseKeepTotalComposition(phaseIndex);
+        removedPhaseCount++;
+      }
+    }
+    if (removedPhaseCount == 0 && candidate.getNumberOfPhases() == 3) {
+      for (int firstPhase = 0; firstPhase < candidate.getNumberOfPhases() - 1; firstPhase++) {
+        for (int secondPhase = firstPhase + 1; secondPhase < candidate.getNumberOfPhases(); secondPhase++) {
+          double maximumCompositionDifference = 0.0;
+          for (int componentIndex = 0; componentIndex < candidate.getPhase(0)
+              .getNumberOfComponents(); componentIndex++) {
+            maximumCompositionDifference = Math.max(maximumCompositionDifference,
+                Math.abs(candidate.getPhase(firstPhase).getComponent(componentIndex).getx()
+                    - candidate.getPhase(secondPhase).getComponent(componentIndex).getx()));
+          }
+          if (maximumCompositionDifference <= TRIVIAL_SPLIT_COMPOSITION_TOLERANCE) {
+            double mergedBeta = candidate.getBeta(firstPhase) + candidate.getBeta(secondPhase);
+            candidate.removePhaseKeepTotalComposition(secondPhase);
+            candidate.setBeta(firstPhase, mergedBeta);
+            removedPhaseCount++;
+            break;
+          }
+        }
+        if (removedPhaseCount > 0) {
+          break;
+        }
+      }
+    }
+    if (removedPhaseCount != 1 || candidate.getNumberOfPhases() != 2) {
+      return false;
+    }
+    candidate.normalizeBeta();
+    operation.setDoubleArrays();
+    double activeSetResidual = operation.solveBeta();
+    candidate.init(1);
+    return Double.isFinite(activeSetResidual) && activeSetResidual < 1.0e-10;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTraceAqueousRefinementTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashTraceAqueousRefinementTest.java
@@ -40,6 +40,30 @@ class TPflashTraceAqueousRefinementTest {
     assertEquivalentEquilibrium(multiphase, ordinary);
   }
 
+  @Test
+  void convergedTraceWaterGasOilEndpointSelectsStableAqueousSplit() {
+    SystemInterface ordinary = createAndFlashMissedAqueousCase(true, 275.7756311717352, 200.0, 0.001, 0.009, false,
+        false);
+    SystemInterface multiphase = createAndFlashMissedAqueousCase(true, 275.7756311717352, 200.0, 0.001, 0.009, true,
+        false);
+    SystemInterface poorGuess = createAndFlashMissedAqueousCase(true, 275.7756311717352, 200.0, 0.001, 0.009, false,
+        true);
+
+    assertBalancedEquilibrium(ordinary);
+    assertEquivalentEquilibrium(multiphase, ordinary);
+    assertEquivalentEquilibrium(ordinary, poorGuess);
+    assertEquals(9.436497907e-4, ordinary.getBeta(findPhase(ordinary, PhaseType.AQUEOUS)), 1.0e-10);
+  }
+
+  @Test
+  void enrichedMinorHydrocarbonLiquidUsesAqueousStabilityTrial() {
+    SystemInterface ordinary = createAndFlashMissedAqueousCase(false, 270.0, 220.0, 0.003, 0.012, false, false);
+    SystemInterface multiphase = createAndFlashMissedAqueousCase(false, 270.0, 220.0, 0.003, 0.012, true, false);
+
+    assertBalancedEquilibrium(ordinary);
+    assertEquivalentEquilibrium(multiphase, ordinary);
+  }
+
   private SystemInterface createAndFlash(boolean usePr, double waterFeedFraction, boolean multiphaseCheck) {
     SystemInterface system = usePr ? new SystemPrEos(230.0, 200.0) : new SystemSrkEos(230.0, 200.0);
     double[] feed = { 0.02, 0.03, 0.859 - waterFeedFraction, 0.06, 0.03, 0.001, waterFeedFraction };
@@ -61,6 +85,25 @@ class TPflashTraceAqueousRefinementTest {
     }
     system.setMixingRule(2);
     system.setMultiPhaseCheck(multiphaseCheck);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private SystemInterface createAndFlashMissedAqueousCase(boolean usePr, double temperature, double pressure,
+      double waterFeedFraction, double nC10FeedFraction, boolean multiphaseCheck, boolean poorGuess) {
+    SystemInterface system = usePr ? new SystemPrEos(temperature, pressure) : new SystemSrkEos(temperature, pressure);
+    double[] feed = { 0.02, 0.03, 0.86 - waterFeedFraction - nC10FeedFraction, 0.06, 0.03, nC10FeedFraction,
+        waterFeedFraction };
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], feed[componentIndex]);
+    }
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    if (poorGuess) {
+      system.setBeta(0, 1.0e-9);
+      system.setBeta(1, 1.0 - 1.0e-9);
+    }
     new ThermodynamicOperations(system).TPflash();
     system.init(1);
     return system;


### PR DESCRIPTION
## Summary

- recover lower-Gibbs trace-water GAS+AQUEOUS equilibria missed by ordinary two-phase TPflash
- use the existing aqueous tangent-plane stability trial plus a reduced two-phase active-set solve instead of recursively running full TPmultiflash
- keep the structural screen as a performance gate only; retain strict equilibrium and Gibbs-energy acceptance
- add exact PR and adjacent SRK regressions, including a deliberately poor beta guess
- document the screen, disappearing/duplicate-phase cleanup, rollback, and numerical tolerances

Closes #2845.

## Reproduced problem

At 275.7756311717352 K and 200 bar with PR/mixing rule 2 and trace water, ordinary TPflash converged locally to GAS+OIL while explicit multiphase TPflash found GAS+AQUEOUS:

| Path on master | Secondary beta | Gibbs energy | Max material residual | Max log-fugacity residual |
|---|---:|---:|---:|---:|
| Ordinary GAS+OIL | 1.561357815e-3 | 9217.52732657 J | 0 | 1.284e-9 |
| Multiphase GAS+AQUEOUS | 9.436497907e-4 | 9213.11559247 J | 3.727e-15 | 3.949e-12 |

The aqueous endpoint lowers Gibbs energy by 4.41173410 J. The defect is therefore phase stability/selection, not local SSI convergence.

## Root cause

The ordinary cubic GAS+OIL solve can satisfy two-phase fugacity equality while excluding an aqueous trial from its active phase set. In the regression, the small hydrocarbon liquid holds 16.72 times the overall water fraction. Existing full multiphase stability analysis discovers the aqueous direction, but recursively rerunning the complete TPflash/TPmultiflash workflow was unnecessarily expensive and could leave a disappearing or composition-duplicate third phase in the beta workspace.

## Method

For neutral, non-ionic, non-solid, non-wax trace-water GAS+OIL endpoints only:

1. screen for water feed below 0.01, a minor phase no larger than 0.01, and hydrocarbon-liquid water enrichment of at least 10 times overall water;
2. clone the endpoint and run the existing aqueous TPD/stability trial;
3. solve the multiphase beta problem;
4. remove exactly one numerical-floor phase, or merge exactly one composition-identical duplicate pair;
5. rebuild and reconverge the reduced two-phase active set;
6. replace the original only if beta bounds, phase normalization, component material balance, component fugacity equality, distinct compositions, reduced-active-set convergence, and lower extensive Gibbs energy all pass.

The beta/enrichment values only decide whether the trial is worth its cost. They do not decide stability. Established water-rich behavior (water feed >= 0.01) retains its previous recursive refinement, and a failed candidate mutates only the clone.

This follows Michelsen's [TPD stability criterion](https://doi.org/10.1016/0378-3812%2882%2985001-2) and [minimum-Gibbs phase-split formulation](https://doi.org/10.1016/0378-3812%2882%2985002-4). The reduced active-set beta solve is consistent with safeguarded multiphase Rachford-Rice practice described by [Okuno, Johns, and Sepehrnoori (2010)](https://doi.org/10.2118/117752-PA). Public commercial documentation establishes capability, not undocumented implementation claims: [PVTsim documents PT multiphase flash up to five phases](https://calsep.com/pvtsim-nova/find-a-pvtsim-package/full-package/).

## Numerical tolerances

- trace-water feed: < 0.01 mole fraction
- performance screen: min(beta) <= 0.01 and x_water,oil >= 10 z_water
- disappearing phase: beta <= 10 * phaseFractionMinimumLimit
- duplicate composition: max absolute component difference <= 1e-6
- reduced active-set solve residual: < 1e-10
- material balance and log-fugacity equality: <= 1e-8
- phase-composition normalization: <= 1e-8
- ordinary/multiphase test comparison: beta/compositions <= 1e-10; Gibbs <= 1e-7 J

## Before/after evidence

### Exact focused regression

The fixed ordinary and multiphase paths both return GAS+AQUEOUS:

- GAS beta: 0.9990563502092883
- AQUEOUS beta: 9.436497907117262e-4
- Gibbs: 9213.115592465203 J
- max material residual: 3.727e-15
- max log-fugacity residual: 3.949e-12

Across 13 deterministic exact/adjacent executions with repeated runs, changed T/P/composition, poor beta guesses, and disappearing/duplicate phases:

- master: 12/13 cross-algorithm failures
- this branch: 0/13 failures
- max ordinary/multiphase state difference: 2.055e-11
- max material residual: 9.248e-12
- max log-fugacity residual: 8.135e-9

### 4,410-state SRK/PR/CPA matrix

The deterministic matrix spans 7 temperatures, 7 pressures, 10 trace-water fractions, 3 nC10 fractions, SRK/PR/CPA, one/two/three-phase endpoints, tiny/disappearing phases, and large volatility contrast.

| Metric | master | branch |
|---|---:|---:|
| Executions | 4,410 | 4,410 |
| Runtime exceptions | 0 | 0 |
| Stable explicit-multiphase endpoints with <=2 phases | 2,136 | 2,136 |
| Ordinary/multiphase mismatches | 615 | 518 |
| Strict residual cases | 52 | 51 |
| Max material residual | 4.214e-9 | 4.214e-9 |
| Max composition-normalization residual | 5.319e-12 | 3.826e-12 |

All 97 SRK/PR trace-water GAS+OIL -> GAS+AQUEOUS mismatches were removed. The remaining 518 are pre-existing CPA categories and are not hidden by relaxed tolerances.

### Runtime

Seven paired fresh-JVM measurements used 20 warmups and 100 measured flashes per JVM. Median of the seven per-JVM medians:

| Case | master | branch |
|---|---:|---:|
| Screened exact defect | 0.679 ms | 2.545 ms |
| Unscreened valid GAS+OIL fast path | 0.385 ms | 0.381 ms |

The corrected state costs about 1.87 ms more because it now performs stability certification. The unaffected fast path has no reproducible regression. The bounded active-set path is also faster than the earlier full-recursive prototype (about 3.8-4.2 ms for screened flashes).

## Tests

Passed locally on Java 17:

- `TPflash*Test`, `TPmultiflash*Test`, `RachfordRice*Test`: 43 tests, 0 failures
- focused seven-class aqueous regression set: 16 tests, 0 failures
- deterministic 4,410-state SRK/PR/CPA audit: 0 runtime failures
- 13-run exact/adjacent cross-algorithm regression: 0 failures
- Spotless apply/check
- pre-commit hook stage
- pre-push hook stage
- documentation-search audit: 646 Markdown pages and 1 standalone HTML page

Not run locally:

- complete 11k+ test suite
- native Java 8 JVM job
- Javadocs/CodeQL/slow shards

Those remain CI gates. Java source uses Java-8-compatible syntax.

## Compatibility and risk

The behavior change is intentionally narrow but scientifically material: qualifying trace-water GAS+OIL endpoints may now become GAS+AQUEOUS when the existing TPD and strict thermodynamic gates establish that it is the lower-Gibbs equilibrium. Chemical, ionic, solid, wax, established non-trace water, one-phase, ordinary oil/gas, and genuine three-phase paths retain their existing behavior. The clone provides rollback on every failed trial.

Open draft PR #2781 also edits `TPflash.java` for an unrelated direct EOS-GE hook. This change is based on current master and touches the trace-water post-processing block; it does not duplicate the EOS-GE work.

## Documentation impact

Updated `TPflash` Javadocs and `docs/thermodynamicoperations/TPflash_algorithm.md` with the trigger, TPD/active-set sequence, phase-removal rules, rollback behavior, tolerances, performance implications, and literature basis. No notebook is changed.
