### PR TITLE
Fix side-draw candidate telemetry and Java 8 convergence

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -16,6 +16,9 @@
 - Failed and fallback-product trials no longer update the side-draw controller or replace the last
   accepted public column state. The safeguarded search uses only accepted flow observations for
   interpolation and bounded exploration.
+- When a cold trial is rejected after an accepted state exists, the same fraction is retried once
+  from the nearest accepted solved profile. This continuation path removes Java-runtime-dependent
+  cold-start failures without reusing a failed or fallback-product state.
 - `DistillationColumn` now reports rejected candidates, state rollbacks, accumulated inner-solver
   work, and the candidate history through its column-tear diagnostics. These values are transient
   and reset on copied or deserialized columns.

--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -451,6 +451,7 @@ fraction diagnostics, film/heat-transfer model choices, and equation-oriented re
 | `getLastColumnTearIterationCount()` | Outer side-draw, pumparound, and hydraulic tear iterations. |
 | `getLastColumnTearResidual()` | Maximum outer tear residual. |
 | `isLastColumnTearConverged()` | Whether active side-draw, pumparound, and hydraulic tear variables met tolerance. |
+| `getLastColumnTearCandidateHistory()` | Accepted/rejected single-side-draw attempts, including a guarded continuation retry when a cold solve fails after an accepted state exists. |
 | `getLastPumparoundRelativeChange()` | Maximum latest pumparound return-flow change. |
 | `getLastHydraulicPressureDropPa()` | Latest coupled hydraulic pressure drop in Pa. |
 | `getLastHydraulicPressureDropResidual()` | Relative pressure-profile change from hydraulic coupling. |

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -207,11 +207,14 @@ pressure profile that the tray sweeps depend on:
 target is physically impossible, the draw fraction is bounded by available tray traffic and the
 latest tear diagnostics report non-convergence instead of allowing an impossible product draw.
 
-A single independent side-draw flow specification is evaluated on cold copied candidate states.
-Only rigorous or reconciled inner-column solves can influence the controller or replace the public
-column result. Failed and fallback-product candidates are rejected, the last accepted state is
-retained, and subsequent interpolation or bounded exploration uses accepted flow observations
-only. Audit the search with `getLastColumnTearRejectedCandidateCount()`,
+A single independent side-draw flow specification is first evaluated on cold copied candidate
+states. Only rigorous or reconciled inner-column solves can influence the controller or replace the
+public column result. If a cold candidate is rejected after a rigorous state has been found, the
+same fraction is retried once by continuation from the nearest accepted state. This makes the
+controller robust to runtime-dependent cold-start basins without ever continuing from fallback
+products. Failed and fallback-product candidates are rejected, the last accepted state is retained,
+and subsequent interpolation or bounded exploration uses accepted flow observations only. Audit
+the cold and continuation attempts with `getLastColumnTearRejectedCandidateCount()`,
 `getLastColumnTearRollbackCount()`, `getLastColumnTearInnerIterationCount()`, and
 `getLastColumnTearCandidateHistory()`. These transient diagnostics reset after copying or
 deserialization.

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1435,11 +1435,13 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * Solve one side-draw flow target using independent cold candidates and accepted-state rollback.
    *
    * <p>
-   * Each proposed fraction is solved on a deep copy of the same cold column configuration. Only candidates whose inner
-   * solve reports an accepted status are copied back to the live column. Rejected fallback products therefore cannot
-   * become the basis for a controller update or leak into public product streams. Accepted probes are used for secant
-   * interpolation when they bracket the target; otherwise a multiplicative proposal is tried. A small deterministic
-   * fraction scan moves past isolated rejected candidates without using their invalid flow values.
+   * Each proposed fraction is first solved on a deep copy of the same cold column configuration. Only candidates whose
+   * inner solve reports an accepted status are copied back to the live column. When a cold candidate is rejected after
+   * at least one rigorous state exists, the same fraction is retried once by continuation from the nearest accepted
+   * state. Rejected fallback products therefore cannot become the basis for a controller update or leak into public
+   * product streams. Accepted probes are used for secant interpolation when they bracket the target; otherwise a
+   * multiplicative proposal is tried. A small deterministic fraction scan moves past isolated rejected candidates
+   * without using their invalid flow values.
    * </p>
    *
    * @param id calculation identifier
@@ -1452,6 +1454,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     List<Double> attemptedFractions = new ArrayList<Double>();
     List<Double> acceptedFractions = new ArrayList<Double>();
     List<Double> acceptedFlows = new ArrayList<Double>();
+    List<DistillationColumn> acceptedCandidates = new ArrayList<DistillationColumn>();
     StringBuilder candidateHistory = new StringBuilder();
     double maximumFraction = getMaximumSideDrawFraction(specification.getTrayNumber(), specification.getPhase());
     double candidateFraction = getSideDrawFraction(specification.getTrayNumber(), specification.getPhase());
@@ -1477,24 +1480,28 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       candidate.setSideDrawFractionWithinLimit(specification.getTrayNumber(), specification.getPhase(),
           candidateFraction);
       candidate.setDoInitializion(true);
-      double candidateFlow = Double.NaN;
-      try {
-        candidate.solveConfiguredColumn(id);
-        StreamInterface candidateDraw = candidate.getSideDrawStream(specification.getTrayNumber(),
-            specification.getPhase());
-        candidateFlow = candidateDraw.getFlowRate(specification.getFlowUnit());
-      } catch (RuntimeException exception) {
-        candidate.lastSolveStatus = SolveStatus.FAILED;
-        candidate.lastSolveStatusReason = "Side-draw candidate inner solve failed: " + exception.getMessage();
-        logger.debug("Side-draw candidate {} rejected for column {} because the inner solve threw.",
-            Double.valueOf(candidateFraction), getName(), exception);
-      }
+      double candidateFlow = solveSingleSideDrawCandidate(candidate, specification, candidateFraction, id);
       lastColumnTearIterationCount = iteration + 1;
-      lastColumnTearInnerIterationCount += Math.max(0, candidate.getLastIterationCount());
-
+      int candidateInnerIterations = Math.max(0, candidate.getLastIterationCount());
       boolean candidateAccepted = isAcceptedColumnTearCandidate(candidate) && Double.isFinite(candidateFlow);
-      appendSideDrawCandidateHistory(candidateHistory, iteration + 1, candidateFraction, candidateFlow,
-          candidate.getLastSolveStatus(), candidateAccepted);
+      boolean continuationRetried = false;
+      if (!candidateAccepted && !acceptedCandidates.isEmpty()) {
+        appendSideDrawCandidateHistory(candidateHistory, iteration + 1, "cold", candidateFraction, candidateFlow,
+            candidate.getLastSolveStatus(), false);
+        lastColumnTearRejectedCandidateCount++;
+        lastColumnTearRollbackCount++;
+
+        candidate = createSingleSideDrawContinuationCandidate(acceptedCandidates, acceptedFractions, candidateFraction,
+            specification);
+        candidateFlow = solveSingleSideDrawCandidate(candidate, specification, candidateFraction, id);
+        candidateInnerIterations += Math.max(0, candidate.getLastIterationCount());
+        candidateAccepted = isAcceptedColumnTearCandidate(candidate) && Double.isFinite(candidateFlow);
+        continuationRetried = true;
+      }
+      lastColumnTearInnerIterationCount += candidateInnerIterations;
+
+      appendSideDrawCandidateHistory(candidateHistory, iteration + 1, continuationRetried ? "continuation" : null,
+          candidateFraction, candidateFlow, candidate.getLastSolveStatus(), candidateAccepted);
       if (!candidateAccepted) {
         lastColumnTearRejectedCandidateCount++;
         if (acceptedAnyCandidate) {
@@ -1508,6 +1515,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       acceptedAnyCandidate = true;
       acceptedFractions.add(Double.valueOf(candidateFraction));
       acceptedFlows.add(Double.valueOf(candidateFlow));
+      acceptedCandidates.add(candidate);
       double residual = Math.abs(candidateFlow - specification.getTargetFlowRate())
           / Math.max(1.0e-12, Math.abs(specification.getTargetFlowRate()));
       if (residual < bestResidual) {
@@ -1563,6 +1571,69 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   private boolean isAcceptedColumnTearCandidate(DistillationColumn candidate) {
     return candidate.lastSolveStatus == SolveStatus.RIGOROUS_CONVERGED
         || candidate.lastSolveStatus == SolveStatus.RECONCILED_PRODUCTS;
+  }
+
+  /**
+   * Solve one configured side-draw candidate and convert an inner exception to a rejected state.
+   *
+   * @param candidate isolated candidate column
+   * @param specification active side-draw flow specification
+   * @param candidateFraction proposed side-draw fraction
+   * @param id calculation identifier
+   * @return candidate side-draw flow, or {@link Double#NaN} after an exception
+   */
+  private double solveSingleSideDrawCandidate(DistillationColumn candidate, ColumnSideDrawSpecification specification,
+      double candidateFraction, UUID id) {
+    try {
+      candidate.solveConfiguredColumn(id);
+      StreamInterface candidateDraw = candidate.getSideDrawStream(specification.getTrayNumber(),
+          specification.getPhase());
+      return candidateDraw.getFlowRate(specification.getFlowUnit());
+    } catch (RuntimeException exception) {
+      candidate.lastSolveStatus = SolveStatus.FAILED;
+      candidate.lastSolveStatusReason = "Side-draw candidate inner solve failed: " + exception.getMessage();
+      logger.debug("Side-draw candidate {} rejected for column {} because the inner solve threw.",
+          Double.valueOf(candidateFraction), getName(), exception);
+      return Double.NaN;
+    }
+  }
+
+  /**
+   * Create a one-shot continuation retry from the accepted state nearest the rejected fraction.
+   *
+   * <p>
+   * Deep-copy serialization clears transient warm-state ownership. The retry explicitly marks the copied tray network
+   * as a solved state for the updated fraction so the inner solver starts from that accepted profile instead of
+   * rebuilding the same runtime-sensitive cold initialization. No rejected state is retained or reused.
+   * </p>
+   *
+   * @param acceptedCandidates accepted solved candidate states
+   * @param acceptedFractions fractions corresponding to the accepted states
+   * @param candidateFraction rejected fraction to retry
+   * @param specification active side-draw flow specification
+   * @return isolated continuation candidate configured at the rejected fraction
+   */
+  private DistillationColumn createSingleSideDrawContinuationCandidate(List<DistillationColumn> acceptedCandidates,
+      List<Double> acceptedFractions, double candidateFraction, ColumnSideDrawSpecification specification) {
+    int nearestIndex = 0;
+    double nearestDistance = Double.POSITIVE_INFINITY;
+    for (int index = 0; index < acceptedFractions.size(); index++) {
+      double distance = Math.abs(acceptedFractions.get(index).doubleValue() - candidateFraction);
+      if (distance < nearestDistance) {
+        nearestDistance = distance;
+        nearestIndex = index;
+      }
+    }
+
+    DistillationColumn candidate = (DistillationColumn) acceptedCandidates.get(nearestIndex).copy();
+    candidate.resetLastSolveMetrics();
+    candidate.setSideDrawFractionWithinLimit(specification.getTrayNumber(), specification.getPhase(),
+        candidateFraction);
+    candidate.trayStateThermodynamicIdentitySignature = candidate.calculateThermodynamicIdentitySignature();
+    candidate.lastSequentialInitializationSignature = candidate.calculateSequentialInitializationSignature();
+    candidate.hasBeenSolvedBefore = true;
+    candidate.setDoInitializion(false);
+    return candidate;
   }
 
   /**
@@ -1752,13 +1823,17 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param status inner solve status
    * @param accepted whether the candidate was accepted
    */
-  private void appendSideDrawCandidateHistory(StringBuilder history, int iteration, double fraction, double flow,
-      SolveStatus status, boolean accepted) {
+  private void appendSideDrawCandidateHistory(StringBuilder history, int iteration, String attemptKind, double fraction,
+      double flow, SolveStatus status, boolean accepted) {
     if (history.length() > 0) {
       history.append("; ");
     }
-    history.append("#").append(iteration).append(" fraction=").append(fraction).append(", flow=").append(flow)
-        .append(", status=").append(status).append(", accepted=").append(accepted);
+    history.append("#").append(iteration);
+    if (attemptKind != null) {
+      history.append(" ").append(attemptKind);
+    }
+    history.append(" fraction=").append(fraction).append(", flow=").append(flow).append(", status=").append(status)
+        .append(", accepted=").append(accepted);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1473,6 +1473,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       attemptedFractions.add(Double.valueOf(candidateFraction));
 
       DistillationColumn candidate = (DistillationColumn) template.copy();
+      candidate.resetLastSolveMetrics();
       candidate.setSideDrawFractionWithinLimit(specification.getTrayNumber(), specification.getPhase(),
           candidateFraction);
       candidate.setDoInitializion(true);

--- a/src/test/java/neqsim/process/equipment/distillation/SimpleTraySideDrawTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SimpleTraySideDrawTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -20,6 +21,28 @@ import neqsim.thermo.system.SystemInterface;
  * @version 1.0
  */
 public class SimpleTraySideDrawTest {
+
+  /** Column whose copied candidates can be forced to fail before solver telemetry is reset. */
+  private static final class RejectingCandidateColumn extends DistillationColumn {
+    private static final long serialVersionUID = 1000L;
+    private boolean rejectDuringInitialization = false;
+
+    private RejectingCandidateColumn(String name, int numberOfTrays, boolean hasReboiler, boolean hasCondenser) {
+      super(name, numberOfTrays, hasReboiler, hasCondenser);
+    }
+
+    @Override
+    public void init() {
+      if (rejectDuringInitialization) {
+        throw new IllegalStateException("Deterministic candidate rejection before solver work");
+      }
+      super.init();
+    }
+
+    private void rejectDuringInitialization() {
+      rejectDuringInitialization = true;
+    }
+  }
 
   /**
    * Test that vapor side draws remove flow from internal tray traffic while conserving phase flow.
@@ -191,6 +214,39 @@ public class SimpleTraySideDrawTest {
     assertComponentMassBalance(feed, column.getSideDrawStream(3, DistillationColumn.SideDrawPhase.LIQUID), column);
   }
 
+  /** Test that rejected copied candidates do not report inherited inner iterations. */
+  @Test
+  public void rejectedCandidatesDoNotInheritStaleInnerIterationTelemetry() throws ReflectiveOperationException {
+    Stream feed = createFractionatorFeed("stale candidate telemetry feed");
+    feed.setTemperature(338.15, "K");
+    feed.run();
+    RejectingCandidateColumn column = createRejectingCandidateColumn("StaleCandidateTelemetryColumn", feed);
+    DistillationColumn.ColumnSideDrawSpecification specification = column.addSideDrawFlowSpecification(3,
+        DistillationColumn.SideDrawPhase.LIQUID, 20.160854543137464, "kg/hr");
+    specification.setTolerance(1.0e-5);
+    specification.setMaxIterations(12);
+    column.setMaxColumnTearIterations(12);
+
+    column.run(UUID.randomUUID());
+    assertTrue(column.isLastColumnTearConverged(), column.getConvergenceDiagnostics());
+
+    RejectingCandidateColumn template = (RejectingCandidateColumn) getPrivateField(column,
+        "singleSideDrawCandidateTemplate");
+    setPrivateInt(template, "lastIterationCount", 777);
+    template.rejectDuringInitialization();
+
+    column.run(UUID.randomUUID());
+
+    assertEquals(12, column.getLastColumnTearRejectedCandidateCount());
+    assertEquals(0, column.getLastColumnTearRollbackCount());
+    assertEquals(0, column.getLastColumnTearInnerIterationCount(),
+        "candidates rejected before solver work must not inherit copied iteration telemetry");
+    assertTrue(column.getLastColumnTearCandidateHistory().contains("#1 fraction="));
+    assertTrue(column.getLastColumnTearCandidateHistory().contains("#12 fraction="));
+    assertTrue(column.getLastColumnTearCandidateHistory().contains("status=FAILED, accepted=false"));
+    assertFalse(column.getLastColumnTearCandidateHistory().contains("accepted=true"));
+  }
+
   /**
    * Test that side-draw stream caches are refreshed when a tray is rerun.
    */
@@ -317,6 +373,33 @@ public class SimpleTraySideDrawTest {
     column.setReboilerTemperature(383.15);
     column.setCondenserRefluxRatio(1.5);
     return column;
+  }
+
+  /** Configure the fractionator variant used to reject copied candidates deterministically. */
+  private RejectingCandidateColumn createRejectingCandidateColumn(String name, Stream feed) {
+    RejectingCandidateColumn column = new RejectingCandidateColumn(name, 5, true, true);
+    column.addFeedStream(feed, 3);
+    column.setTopPressure(8.0);
+    column.setBottomPressure(8.3);
+    column.setCondenserTemperature(303.15);
+    column.setReboilerTemperature(383.15);
+    column.setCondenserRefluxRatio(1.5);
+    return column;
+  }
+
+  /** Read one private column field for deterministic failure-path setup. */
+  private Object getPrivateField(DistillationColumn column, String fieldName) throws ReflectiveOperationException {
+    Field field = DistillationColumn.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(column);
+  }
+
+  /** Set one private integer telemetry field for deterministic failure-path setup. */
+  private void setPrivateInt(DistillationColumn column, String fieldName, int value)
+      throws ReflectiveOperationException {
+    Field field = DistillationColumn.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.setInt(column, value);
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/SimpleTraySideDrawTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SimpleTraySideDrawTest.java
@@ -187,6 +187,8 @@ public class SimpleTraySideDrawTest {
     assertEquals(0.0, column.getMassBalance("kg/hr"), 1.0e-6, column.getConvergenceDiagnostics());
     assertTrue(column.getLastColumnTearRejectedCandidateCount() > 0,
         "the controller should reject the invalid large multiplicative candidate");
+    assertTrue(column.getLastColumnTearCandidateHistory().contains("continuation fraction="),
+        "the rejected cold candidate should be retried from an accepted state");
     assertComponentMassBalance(feed, column.getSideDrawStream(3, DistillationColumn.SideDrawPhase.LIQUID), column);
   }
 


### PR DESCRIPTION
## Summary

- reset copied side-draw candidate solve telemetry before candidate configuration and solver work
- keep failed and fallback-product trials out of controller interpolation and public column state
- when a cold trial is rejected after an accepted state exists, retry the same fraction once from the nearest accepted solved profile
- never seed continuation from a rejected or fallback-product candidate
- record cold and continuation attempts in the candidate history and assert that the high-multistage regression exercises the continuation path

## Root cause

The reusable cold candidate template legitimately carries prior solve state. Each probe deep-copied that template and accumulated `candidate.getLastIterationCount()` even when the probe threw before the inner solver reset its metrics, so the diagnostic counted copied history as new work.

Separately, the Java 8 direct-substitution path lands in different cold-start basins for the high-multistage liquid side-draw case. The controller found rigorous states at several fractions, but continued solving every new fraction from the cold template. Most later probes fell back to invalid product states, so the controller could not close the target even though a nearby accepted tray profile was available.

The guarded continuation retry preserves candidate isolation and rollback: cold solve remains the first attempt, and only an already accepted rigorous/reconciled profile can seed the one-shot retry.

## Validation

- hosted Java 8 regression before fix: `highMultistageLiquidSideDrawFlowSpecificationConverges` failed after 30 candidates with residual `0.052716450507086954` (about 383 s)
- local Temurin 8u502 after fix: clean `pomJava8.xml` build compiled 3,105 main and 1,634 test sources with Java 8 `javac`; the exact regression passed in 36.51 s
- focused high-multistage regression on Java 17: 1 test passed; the assertion confirms a continuation attempt occurred
- `SimpleTraySideDrawTest,DistillationColumnWarmStateCacheTest`: 31 tests passed
- stale-telemetry regression before fix: expected 0 inner iterations, observed 9,324 (= 12 × 777)
- `pre-commit run --all-files --hook-stage pre-commit`: passed
- `pre-commit run --all-files --hook-stage pre-push`: passed (Spotless + documentation search)
- hosted Java 21/Temurin 8 full CI: in progress on this commit

## Documentation impact

Updated the distillation-column guides and agent changelog to document the cold-first, accepted-state continuation retry and its candidate-history telemetry.

Closes #2851
