### PR TITLE
Fix stale CO2-rich TPflash cubic root

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -233,12 +233,13 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Keep only a normalized, balanced, fugacity-equal result with no Gibbs       │
 │       increase; otherwise restore beta, compositions, K-values, and phase types   │
 │                                                                                 │
-│  IF ordinary, neutral, dry two-phase hydrocarbon roots are inverted:             │
-│     → Detect the vapor-labelled phase having the larger mean molar mass          │
-│     → Evaluate the vapor root on the light composition and liquid root on the    │
-│       heavy composition                                                         │
-│     → Replace both roots only for lower Gibbs energy and                         │
-│       max |Δ ln(fᵢ)| < 1e-8; beta, x, and material balance stay unchanged         │
+│  IF ordinary, neutral, dry two-phase hydrocarbon roots are inconsistent:         │
+│     → Trigger for inverted mean-molar-mass order or max |Δ ln(fᵢ)| ≥ 1e-8        │
+│     → For inverted order, evaluate vapor/light and liquid/heavy roots together   │
+│     → Otherwise evaluate both roots on each phase while leaving the other fixed  │
+│     → Retain the selected root seed and public phase identity only for lower     │
+│       Gibbs energy and max |Δ ln(fᵢ)| < 1e-8                                     │
+│     → In both cases, beta, x, and material balance stay unchanged                │
 │                                                                                 │
 │  IF chemical system:                                                            │
 │     → Final chemical equilibrium solve in aqueous/liquid phases                 │
@@ -261,7 +262,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Supplementary stability TPD limit | -1e-6 | Accept a converged amplified-K or composition-perturbation trial only when its reduced TPD exceeds that SSI solve's residual/step resolution and the trial composition is non-trivial |
 | Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for valid trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i)` is non-finite or above `1e-8`, allowing the bounded beta correction below without another stability calculation. An incipient trace-water GAS+OIL endpoint with `min(beta) <= 1e-4` also bypasses the threshold when its confirmed log-fugacity residual is non-finite or at least `1e-8`; the existing guarded multiphase candidate must then pass the strict feasibility and lower-Gibbs gates. |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
-| Cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root assignment only when the existing composition split is already at equilibrium |
+| Dry cubic-root screen and acceptance | Screen normally ordered GAS+OIL endpoints when `max abs(Delta ln(f_i)) >= 1e-8`; accept below `1e-8` | Evaluate both roots for one phase at a time and retain a lower-Gibbs root seed only when the resulting unchanged composition split restores fugacity equality. Inverted mean-molar-mass order retains the paired-root comparison. |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
 | Stable-single-phase aqueous-seed gate | `1e-8` in phase-composition normalization | Reject only a structurally invalid aqueous trial whose composition is non-finite, out of `[0, 1]`, or unnormalized; leave normalized endpoints to model-specific convergence and refinement paths |
 | Post-removal aqueous recovery | `1e-8` in `max abs(Delta z_i)` and `max abs(Delta ln(f_i))` | Restore a balanced neutral two-phase aqueous reference only when a rejected third-phase trial leaves the final two-phase endpoint infeasible; genuine three-phase and already feasible endpoints are retained |
@@ -1733,11 +1734,13 @@ Commercial process simulators do not publish all implementation details, but pub
   already converged endpoints or attempting to rescue grossly invalid states. The original endpoint is restored unless
   phase identity, normalization, material balance, fugacity equality, and Gibbs energy all pass.
 - Near a hydrocarbon critical boundary, the ordinary flash can converge the correct light and heavy compositions but
-  retain the liquid cubic root on the light phase and the vapor root on the heavy phase. A molar-mass ordering screen
-  detects that inverted labelling without adding trial-root work to normal results. The two roots are reassigned
-  together only when the resulting state lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 * abs(G))` and already
-  satisfies `max abs(Delta ln(f_i)) < 1e-8`. This is a post-convergence root selection, consistent with the minimum-Gibbs
-  acceptance principle in Michelsen's phase-split formulation; it is not an additional stability or TPflash solve.
+  retain an inconsistent cubic volume root. Inverted mean-molar-mass order still triggers the paired vapor/light and
+  liquid/heavy root comparison. A normally ordered endpoint triggers only when its current
+  `max abs(Delta ln(f_i)) >= 1e-8`; both cubic root seeds are then reinitialized on one cloned phase at a time while the
+  other phase remains fixed. The lowest-Gibbs candidate is retained only when it restores
+  `max abs(Delta ln(f_i)) < 1e-8`, and its root seed is stored separately from the unchanged public GAS/OIL phase label
+  so later property initialization does not recreate the stale root. Phase fractions, compositions, and material
+  balance remain unchanged. This is a post-convergence root selection, not an additional stability or TPflash solve.
 - Converged supplementary near-critical stability trials accept reduced TPD below `-1e-6`, matching the residual and
   step convergence resolution of that SSI solve. This replaces the former `-1e-4` cutoff while rejecting negative
   values below the solver's numerical resolution. The standard stability decision retains its `-1e-8` limit, and the

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -63,7 +63,7 @@ public class TPflash extends Flash {
   private static final int MAX_FINAL_EQUILIBRIUM_REFINEMENT_ITERATIONS = 8;
   /** Largest residual considered near enough to convergence for bounded final SSI refinement. */
   private static final double MAX_FINAL_EQUILIBRIUM_REFINEMENT_RESIDUAL = 1.0e-5;
-  /** Cubic phase roots evaluated by the post-convergence aqueous root check. */
+  /** Cubic phase roots evaluated by the post-convergence root checks. */
   private static final PhaseType[] CUBIC_ROOT_PHASE_TYPES = { PhaseType.GAS, PhaseType.LIQUID };
   /**
    * Minimum extensive Gibbs-energy reduction (J) required for the spurious-multiphase rescue to collapse a two-phase
@@ -1798,16 +1798,18 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Corrects an inverted vapor/liquid cubic-root assignment in an ordinary hydrocarbon flash.
+   * Corrects an inconsistent vapor/liquid cubic-root assignment in an ordinary hydrocarbon flash.
    *
    * <p>
    * Near a critical boundary the ordinary two-phase iteration can converge the light and heavy compositions while
-   * retaining the liquid cubic root on the light phase and the vapor root on the heavy phase. This is a stationary
-   * flash-equation solution, but it has a higher Gibbs energy than the same split with the roots assigned consistently.
-   * A cheap molar-mass ordering check avoids trial-root work on normally labelled results. For an inverted result, the
-   * two roots are evaluated together on cloned phases. The replacement is accepted only when it lowers extensive Gibbs
-   * energy beyond numerical noise and satisfies component fugacity equality within
-   * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE}. Compositions, phase fractions, and material balance are unchanged.
+   * retaining the liquid cubic root on the light phase and the vapor root on the heavy phase. A normally ordered split
+   * can likewise retain one stale cubic root and therefore fail component fugacity equality after convergence. Both are
+   * higher-Gibbs states than the same composition split with consistently selected roots. A cheap molar-mass and
+   * current fugacity-residual check avoids trial-root work on already consistent results. An inverted split evaluates
+   * both roots together; a normally ordered split evaluates both roots on one phase at a time while the other remains
+   * fixed. A replacement is accepted only when it lowers extensive Gibbs energy beyond numerical noise and satisfies
+   * component fugacity equality within {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE}. Compositions, phase fractions, and
+   * material balance are unchanged.
    * </p>
    *
    * <p>
@@ -1847,8 +1849,19 @@ public class TPflash extends Flash {
       }
       hasHydrocarbon |= component.isHydrocarbon();
     }
-    if (!hasHydrocarbon
-        || system.getPhase(gasPhaseIndex).getMolarMass() <= system.getPhase(liquidPhaseIndex).getMolarMass()) {
+    if (!hasHydrocarbon) {
+      return;
+    }
+
+    boolean invertedCompositionOrder = system.getPhase(gasPhaseIndex).getMolarMass() > system.getPhase(liquidPhaseIndex)
+        .getMolarMass();
+    double currentFugacityResidual = maximumLogFugacityResidual(system.getPhase(gasPhaseIndex),
+        system.getPhase(liquidPhaseIndex));
+    if (!invertedCompositionOrder && currentFugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
+      return;
+    }
+    if (!invertedCompositionOrder) {
+      rescueLowerGibbsIndividualPhaseRoot();
       return;
     }
 
@@ -1886,6 +1899,62 @@ public class TPflash extends Flash {
     } catch (Exception ex) {
       logger.debug("Hydrocarbon phase-root comparison failed: {}", ex.getMessage());
     }
+  }
+
+  /**
+   * Replaces one stale cubic root in an otherwise normally ordered gas/liquid split.
+   *
+   * <p>
+   * Each available root is initialized on a clone of one phase while the other phase remains unchanged. The best
+   * candidate must lower extensive Gibbs energy and restore component fugacity equality. The phase composition,
+   * fraction, storage order, and public phase label remain unchanged.
+   * </p>
+   */
+  private void rescueLowerGibbsIndividualPhaseRoot() {
+    int selectedPhaseIndex = -1;
+    PhaseType selectedPhaseType = null;
+    PhaseType selectedRoot = null;
+    PhaseInterface selectedPhase = null;
+    double maximumGibbsReduction = 0.0;
+    double currentGibbsEnergy = system.getGibbsEnergy();
+
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      PhaseType originalPhaseType = system.getPhase(phaseIndex).getType();
+      double currentPhaseGibbsEnergy = system.getPhase(phaseIndex).getGibbsEnergy();
+      for (PhaseType trialRoot : CUBIC_ROOT_PHASE_TYPES) {
+        try {
+          PhaseInterface trialPhase = system.getPhase(phaseIndex).clone();
+          trialPhase.init(system.getTotalNumberOfMoles(), trialPhase.getNumberOfComponents(), 1, trialRoot,
+              system.getBeta(phaseIndex));
+          for (int componentIndex = 0; componentIndex < trialPhase.getNumberOfComponents(); componentIndex++) {
+            trialPhase.getComponent(componentIndex).fugcoef(trialPhase);
+          }
+          double trialGibbsEnergy = currentGibbsEnergy - currentPhaseGibbsEnergy + trialPhase.getGibbsEnergy();
+          double gibbsReduction = currentGibbsEnergy - trialGibbsEnergy;
+          double fugacityResidual = maximumLogFugacityResidualWithReplacement(phaseIndex, trialPhase);
+          if (Double.isFinite(gibbsReduction) && gibbsReduction > maximumGibbsReduction
+              && fugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
+            maximumGibbsReduction = gibbsReduction;
+            selectedPhaseIndex = phaseIndex;
+            selectedPhaseType = originalPhaseType;
+            selectedRoot = trialRoot;
+            selectedPhase = trialPhase;
+          }
+        } catch (Exception ex) {
+          logger.debug("Individual phase-root comparison failed for phase {} root {}: {}", phaseIndex, trialRoot,
+              ex.getMessage());
+        }
+      }
+    }
+
+    double gibbsTolerance = Math.max(1.0e-6, Math.abs(currentGibbsEnergy) * 1.0e-8);
+    if (selectedPhaseIndex < 0 || maximumGibbsReduction <= gibbsTolerance) {
+      return;
+    }
+
+    selectedPhase.setType(selectedPhaseType);
+    system.setPhase(selectedPhase, system.getPhaseIndex(selectedPhaseIndex));
+    system.setPhaseType(selectedPhaseIndex, selectedRoot);
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCubicRootSelectionTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCubicRootSelectionTest.java
@@ -15,6 +15,8 @@ class TPflashCubicRootSelectionTest {
   private static final String[] NEAR_CRITICAL_COMPONENTS = { "methane", "ethane", "propane", "n-butane" };
   private static final double[] NEAR_CRITICAL_FEED = { 0.5833884211682981, 0.16475359157041228, 0.19866217294783825,
       0.053195814313451245 };
+  private static final String[] CO2_RICH_COMPONENTS = { "CO2", "methane", "nC10" };
+  private static final double[] CO2_RICH_FEED = { 0.80, 0.15, 0.05 };
 
   @Test
   void ordinaryAndMultiphaseFlashSelectSameLowestGibbsCubicRoots() {
@@ -66,6 +68,64 @@ class TPflashCubicRootSelectionTest {
     assertFlashClosure(multiphase, NEAR_CRITICAL_FEED);
   }
 
+  @Test
+  void ordinaryCo2RichFlashReinitializesGasCubicRoot() {
+    SystemInterface ordinary = createAndFlashCo2Rich(false, false);
+    SystemInterface multiphase = createAndFlashCo2Rich(true, false);
+
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquals(2, multiphase.getNumberOfPhases());
+    assertEquals(multiphase.getGibbsEnergy(), ordinary.getGibbsEnergy(), 1.0e-7);
+    assertEquals(multiphase.getEnthalpy(), ordinary.getEnthalpy(), 1.0e-7);
+
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      assertEquals(multiphase.getPhase(phaseIndex).getType(), ordinary.getPhase(phaseIndex).getType());
+      assertEquals(multiphase.getBeta(phaseIndex), ordinary.getBeta(phaseIndex), 1.0e-12);
+      assertEquals(multiphase.getPhase(phaseIndex).getDensity(), ordinary.getPhase(phaseIndex).getDensity(), 1.0e-8);
+      for (int componentIndex = 0; componentIndex < CO2_RICH_COMPONENTS.length; componentIndex++) {
+        assertEquals(multiphase.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            ordinary.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-12);
+        assertEquals(multiphase.getPhase(phaseIndex).getComponent(componentIndex).getFugacityCoefficient(),
+            ordinary.getPhase(phaseIndex).getComponent(componentIndex).getFugacityCoefficient(), 1.0e-10);
+      }
+    }
+
+    assertFlashClosure(ordinary, CO2_RICH_FEED);
+    assertFlashClosure(multiphase, CO2_RICH_FEED);
+  }
+
+  @Test
+  void nearbyCo2RichStatesPreserveCubicRootAcrossPhaseBoundary() {
+    double[][] states = { { 275.0, 75.0, 0.78, 0.17, 0.05 }, { 285.0, 85.0, 0.82, 0.13, 0.05 },
+        { 300.0, 100.0, 0.80, 0.15, 0.05 }, { 320.0, 150.0, 0.80, 0.15, 0.05 }, { 280.0, 250.0, 0.80, 0.15, 0.05 } };
+    boolean observedSinglePhase = false;
+    boolean observedTwoPhase = false;
+
+    for (double[] state : states) {
+      double[] feed = { state[2], state[3], state[4] };
+      SystemInterface ordinary = createAndFlashCo2Rich(state[0], state[1], feed, false, false);
+      SystemInterface multiphase = createAndFlashCo2Rich(state[0], state[1], feed, true, false);
+
+      assertEquivalentCo2RichState(multiphase, ordinary, feed);
+      observedSinglePhase |= ordinary.getNumberOfPhases() == 1;
+      observedTwoPhase |= ordinary.getNumberOfPhases() == 2;
+    }
+
+    assertTrue(observedSinglePhase, "nearby-state matrix must exercise a single-phase endpoint");
+    assertTrue(observedTwoPhase, "nearby-state matrix must exercise a two-phase endpoint");
+  }
+
+  @Test
+  void co2RichRootSelectionSurvivesPoorBetaGuessAndRepeatedFlash() {
+    SystemInterface reference = createAndFlashCo2Rich(false, false);
+    SystemInterface poorGuess = createAndFlashCo2Rich(false, true);
+
+    assertEquivalentCo2RichState(reference, poorGuess, CO2_RICH_FEED);
+    new ThermodynamicOperations(poorGuess).TPflash();
+    poorGuess.init(3);
+    assertEquivalentCo2RichState(reference, poorGuess, CO2_RICH_FEED);
+  }
+
   private SystemInterface createAndFlash(boolean multiphaseCheck) {
     SystemInterface system = new SystemPrEos(220.0, 100.0);
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
@@ -88,6 +148,75 @@ class TPflashCubicRootSelectionTest {
     new ThermodynamicOperations(system).TPflash();
     system.init(3);
     return system;
+  }
+
+  private SystemInterface createAndFlashCo2Rich(boolean multiphaseCheck, boolean poorGuess) {
+    return createAndFlashCo2Rich(280.0, 80.0, CO2_RICH_FEED, multiphaseCheck, poorGuess);
+  }
+
+  private SystemInterface createAndFlashCo2Rich(double temperature, double pressure, double[] feed,
+      boolean multiphaseCheck, boolean poorGuess) {
+    SystemInterface system = new SystemPrEos(temperature, pressure);
+    for (int componentIndex = 0; componentIndex < CO2_RICH_COMPONENTS.length; componentIndex++) {
+      system.addComponent(CO2_RICH_COMPONENTS[componentIndex], feed[componentIndex]);
+    }
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    if (poorGuess) {
+      system.setBeta(0, 1.0e-9);
+      system.setBeta(1, 1.0 - 1.0e-9);
+    }
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private void assertEquivalentCo2RichState(SystemInterface expected, SystemInterface actual, double[] feed) {
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-6);
+    assertEquals(expected.getEnthalpy(), actual.getEnthalpy(), 1.0e-6);
+    for (int phaseIndex = 0; phaseIndex < expected.getNumberOfPhases(); phaseIndex++) {
+      assertEquals(expected.getPhase(phaseIndex).getType(), actual.getPhase(phaseIndex).getType());
+      assertEquals(expected.getBeta(phaseIndex), actual.getBeta(phaseIndex), 1.0e-10);
+      assertEquals(expected.getPhase(phaseIndex).getDensity(), actual.getPhase(phaseIndex).getDensity(), 1.0e-7);
+      assertEquals(expected.getPhase(phaseIndex).getZ(), actual.getPhase(phaseIndex).getZ(), 1.0e-10);
+      for (int componentIndex = 0; componentIndex < feed.length; componentIndex++) {
+        assertEquals(expected.getPhase(phaseIndex).getComponent(componentIndex).getx(),
+            actual.getPhase(phaseIndex).getComponent(componentIndex).getx(), 1.0e-10);
+        assertEquals(expected.getPhase(phaseIndex).getComponent(componentIndex).getFugacityCoefficient(),
+            actual.getPhase(phaseIndex).getComponent(componentIndex).getFugacityCoefficient(), 1.0e-8);
+      }
+    }
+    assertMaterialBalanceAndEquilibrium(expected, feed);
+    assertMaterialBalanceAndEquilibrium(actual, feed);
+  }
+
+  private void assertMaterialBalanceAndEquilibrium(SystemInterface system, double[] feed) {
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      betaTotal += system.getBeta(phaseIndex);
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < feed.length; componentIndex++) {
+        compositionTotal += system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-8);
+    }
+    assertEquals(1.0, betaTotal, 1.0e-8);
+
+    for (int componentIndex = 0; componentIndex < feed.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(feed[componentIndex], recoveredFeed, 1.0e-8);
+      if (system.getNumberOfPhases() == 2) {
+        double firstPhaseFugacity = system.getPhase(0).getComponent(componentIndex).getx()
+            * system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient();
+        double secondPhaseFugacity = system.getPhase(1).getComponent(componentIndex).getx()
+            * system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient();
+        assertTrue(Math.abs(Math.log(firstPhaseFugacity / secondPhaseFugacity)) < 1.0e-8);
+      }
+    }
   }
 
   private void assertFlashClosure(SystemInterface system, double[] feed) {


### PR DESCRIPTION
## Summary

- extend the ordinary dry GAS+OIL post-convergence root check to normally ordered splits whose component fugacities are inconsistent
- reinitialize both cubic root seeds on one cloned phase at a time while leaving beta, composition, phase order, and the other phase unchanged
- retain a candidate only when it lowers extensive Gibbs energy beyond numerical noise and restores `max abs(Delta ln(f_i)) < 1e-8`
- store the selected EOS root seed separately from the unchanged public GAS/OIL phase label so later property initialization cannot recreate the stale root
- document the root-selection and acceptance path

## Root cause

The ordinary PR flash converged the same phase fractions and compositions as the multiphase path, but its GAS phase retained the vapor-side root seed (`Z = 0.7316841107`) instead of the lower-Gibbs root (`Z = 0.2155392303`). The existing dry-root safeguard only evaluated candidates when the phase mean-molar-mass order was inverted. This CO2-rich endpoint is normally ordered, so the stale GAS root and fugacity state survived post-processing.

NeqSim stores the root seed separately from the public phase label. Replacing the initialized phase while restoring GAS as the root seed would recreate the wrong root on the next `init`. The fix therefore keeps the public phase identity but retains the accepted trial root seed.

## Validation

- regression before fix: expected multiphase Gibbs energy `6389.354431608633 J`, ordinary returned `6989.404374608063 J`
- exact issue state now agrees on phase types, beta, compositions, fugacity coefficients, Gibbs energy, enthalpy, density, material balance, normalization, and component fugacity equality
- nearby CO2 composition and T/P matrix covers both one- and two-phase endpoints
- poor beta seed and repeated TP flash preserve the selected root
- `TPflashCubicRootSelectionTest`: 5 tests passed
- combined `TPflashCubicRootSelectionTest,TPFlashTest,TPmultiflashTest,TPflashTerminalEquilibriumRefinementTest`: 24 tests passed
- `pre-commit run --all-files --hook-stage pre-commit`: passed
- `pre-commit run --all-files --hook-stage pre-push`: passed (Spotless + documentation search)

The local Java 8 POM cannot resolve the uncached `flatten-maven-plugin:1.7.3` because Maven Central is unavailable in this runtime; hosted CI remains the Java 8 verification.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md` with the normally ordered stale-root screen, single-phase root trials, strict acceptance conditions, and the root-seed/public-label distinction.

## Coordination

PR #2853 changes nearby TPflash post-processing for a distinct trace-water endpoint. This PR remains draft while CI runs and will be rebased if #2853 lands first.

Closes #2852