### PR TITLE
Add reactive hybrid EOS-GE gas-oil-aqueous flash

### DIFF
--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -266,6 +266,41 @@ The returned value is the calcite saturation ratio, where values above one indic
 It does not calculate precipitated mass or deposition kinetics. The fixed-role hybrid flash currently rejects explicit
 solid- and wax-phase checks.
 
+### Other electrolyte GE models
+
+The reactive hybrid solver is selected through the `HybridEosGeFlashModel` contract; it does not contain a Pitzer
+type check. `SystemDesmukhMather` and `SystemKentEisenberg` provide the same SRK-gas / SRK-oil / GE-aqueous roles.
+For example, a Desmukh-Mather amine system can retain an oil phase, solve aqueous speciation and evaluate the same
+activity-based scale-potential API:
+
+```java
+SystemDesmukhMather fluid = new SystemDesmukhMather(313.15, 5.0);
+fluid.addComponent("methane", 5.0);
+fluid.addComponent("CO2", 0.2);
+fluid.addComponent("n-heptane", 2.0);
+fluid.addComponent("MDEA", 1.0);
+fluid.addComponent("water", 9.0);
+fluid.addComponent("Ca++", 1.0e-4);
+fluid.addComponent("Na+", 1.0e-3);
+fluid.addComponent("Cl-", 2.0e-4);
+fluid.addComponent("HCO3-", 1.0e-3);
+fluid.chemicalReactionInit();
+fluid.createDatabase(true);
+fluid.setMixingRule("classic");
+fluid.setMultiPhaseCheck(true);
+
+ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+operations.TPflash();
+double calciteSaturationRatio = operations.getRelativeScalePotential("CaCO3");
+```
+
+Every `SystemEosGE` subclass can explicitly configure the same topology through `enableHybridEosGeFlash()`. This
+includes Wilson, NRTL, UNIFAC and specialised activity models, but it only supplies the phase-equilibrium topology: a
+model must still support water, the requested ions, aqueous reactions and appropriate interaction parameters before its
+scale result is meaningful. Pitzer remains the broadly parameterised choice for concentrated mineral-scale brines;
+Desmukh-Mather and Kent-Eisenberg are primarily amine/electrolyte screening models. `SystemDuanSun` is not included
+because its current system API accepts CO2 only and therefore cannot represent a gas-oil-aqueous electrolyte feed.
+
 ---
 
 ## 4. WaterCompatibilityScreener

--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -240,18 +240,31 @@ The Pitzer parameter database (`PitzerParameters.csv`) currently contains 30 cat
 ### Using the Pitzer Model
 
 ```java
-SystemInterface pitzer = new SystemPitzer(273.15 + 80.0, 100.0);
-pitzer.addComponent("water", 0.90);
-pitzer.addComponent("Na+", 0.03);
-pitzer.addComponent("Cl-", 0.035);
-pitzer.addComponent("Ca++", 0.005);
-pitzer.addComponent("SO4--", 0.002);
+SystemInterface pitzer = new SystemPitzer(313.15, 50.0);
+pitzer.addComponent("methane", 5.0);
+pitzer.addComponent("CO2", 0.05);
+pitzer.addComponent("n-heptane", 2.0);
+pitzer.addComponent("water", 55.5);
+pitzer.addComponent("Ca++", 1.0e-4);
+pitzer.addComponent("Na+", 1.0e-3);
+pitzer.addComponent("Cl-", 2.0e-4);
+pitzer.addComponent("HCO3-", 1.0e-3);
+pitzer.chemicalReactionInit();
+pitzer.createDatabase(true);
 pitzer.setMixingRule("classic");
+pitzer.setMultiPhaseCheck(true);
 
 ThermodynamicOperations ops = new ThermodynamicOperations(pitzer);
 ops.TPflash();
 pitzer.initProperties();
+
+double calciteScalePotential = ops.getRelativeScalePotential("CaCO3");
 ```
+
+The example couples SRK gas and oil phases to Pitzer aqueous chemistry. Remove `n-heptane` for a gas-aqueous case.
+The returned value is the calcite saturation ratio, where values above one indicate thermodynamic supersaturation.
+It does not calculate precipitated mass or deposition kinetics. The fixed-role hybrid flash currently rejects explicit
+solid- and wax-phase checks.
 
 ---
 

--- a/docs/thermo/fluid_creation_guide.md
+++ b/docs/thermo/fluid_creation_guide.md
@@ -354,10 +354,10 @@ The Chabab option is validated against NaCl-brine data at approximately 1-3 mol/
 and pressures up to 230 bar. See [Søreide-Whitson Model](SoreideWhitsonModel.md) for the
 correlation, units, comparison example, and extrapolation limits.
 
-### 7.3 Pitzer Model
+### 7.3 Electrolyte GE Models and Hybrid VLLE
 
-For concentrated electrolyte solutions. `SystemPitzer` can opt into a fixed-role hybrid flash in which gas and
-hydrocarbon liquid use SRK while the aqueous electrolyte liquid uses Pitzer.
+For electrolyte solutions, `SystemPitzer`, `SystemDesmukhMather` and `SystemKentEisenberg` provide a fixed-role hybrid
+flash in which gas and hydrocarbon liquid use SRK while the aqueous liquid uses the selected GE model.
 
 ```java
 import neqsim.thermo.phase.PhaseType;
@@ -386,6 +386,26 @@ aqueous Henry reference; water alone uses the Pitzer osmotic/Raoult solvent conv
 activity-based scale-potential screening after reactive gas-aqueous or gas-oil-aqueous flashes. The result is a
 saturation ratio; explicit mineral precipitation, solid amounts, solid-phase equilibrium and wax checks are not yet
 supported by the hybrid strategy.
+
+The solver is not restricted to Pitzer. Desmukh-Mather and Kent-Eisenberg use the same reactive coupling when
+`chemicalReactionInit()` and `setMultiPhaseCheck(true)` are enabled. Other `SystemEosGE` systems can opt in explicitly:
+
+```java
+SystemNRTL fluid = new SystemNRTL(313.15, 50.0);
+fluid.addComponent("methane", 5.0);
+fluid.addComponent("n-heptane", 2.0);
+fluid.addComponent("water", 55.5);
+fluid.createDatabase(true);
+fluid.setMixingRule("classic");
+fluid.enableHybridEosGeFlash();
+
+new ThermodynamicOperations(fluid).TPflash();
+```
+
+`enableHybridEosGeFlash()` configures topology, not electrolyte parameters. Scale calculations require a GE phase
+with meaningful activities for all requested aqueous species. Pitzer has the broadest concentrated-brine parameter
+coverage; the amine models retain their narrower component and validity ranges. `SystemDuanSun` remains excluded from
+this topology because its current public API accepts only CO2.
 
 ---
 

--- a/docs/thermo/fluid_creation_guide.md
+++ b/docs/thermo/fluid_creation_guide.md
@@ -381,8 +381,11 @@ boolean hasAqueousPhase = fluid.hasPhaseType(PhaseType.AQUEOUS);
 
 The creation-order role objects are stable even when active phases are density-ordered or disappear. A later flash
 reconsiders inactive roles from the current feed and conditions. Neutral non-water species in the Pitzer phase use an
-aqueous Henry reference; water alone uses the Pitzer osmotic/Raoult solvent convention. Reactive Pitzer systems keep
-the established chemical-equilibrium flash path. Solid and wax checks are not yet supported by the hybrid strategy.
+aqueous Henry reference; water alone uses the Pitzer osmotic/Raoult solvent convention. Calling
+`chemicalReactionInit()` couples aqueous reaction equilibrium to the same fixed gas/oil/aqueous roles. This supports
+activity-based scale-potential screening after reactive gas-aqueous or gas-oil-aqueous flashes. The result is a
+saturation ratio; explicit mineral precipitation, solid amounts, solid-phase equilibrium and wax checks are not yet
+supported by the hybrid strategy.
 
 ---
 

--- a/docs/thermo/fluid_creation_guide.md
+++ b/docs/thermo/fluid_creation_guide.md
@@ -356,13 +356,33 @@ correlation, units, comparison example, and extrapolation limits.
 
 ### 7.3 Pitzer Model
 
-For concentrated electrolyte solutions.
+For concentrated electrolyte solutions. `SystemPitzer` can opt into a fixed-role hybrid flash in which gas and
+hydrocarbon liquid use SRK while the aqueous electrolyte liquid uses Pitzer.
 
 ```java
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemPitzer;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
-SystemInterface fluid = new SystemPitzer(298.15, 1.0);
+SystemPitzer fluid = new SystemPitzer(313.15, 50.0);
+fluid.addComponent("methane", 5.0);
+fluid.addComponent("n-heptane", 2.0);
+fluid.addComponent("water", 55.5);
+fluid.addComponent("Na+", 1.0);
+fluid.addComponent("Cl-", 1.0);
+fluid.setMixingRule("classic");
+fluid.setMultiPhaseCheck(true);
+
+new ThermodynamicOperations(fluid).TPflash();
+
+// Material roles are selected from gas (SRK), oil (SRK), and aqueous (Pitzer).
+boolean hasAqueousPhase = fluid.hasPhaseType(PhaseType.AQUEOUS);
 ```
+
+The creation-order role objects are stable even when active phases are density-ordered or disappear. A later flash
+reconsiders inactive roles from the current feed and conditions. Neutral non-water species in the Pitzer phase use an
+aqueous Henry reference; water alone uses the Pitzer osmotic/Raoult solvent convention. Reactive Pitzer systems keep
+the established chemical-equilibrium flash path. Solid and wax checks are not yet supported by the hybrid strategy.
 
 ---
 

--- a/docs/thermo/thermodynamic_models.md
+++ b/docs/thermo/thermodynamic_models.md
@@ -572,11 +572,14 @@ ops.TPflash();
 
 | Class | Description | Use Case |
 |-------|-------------|----------|
-| `SystemPitzer` | Pitzer aqueous GE + optional SRK gas/oil | Concentrated brines and opt-in VLLE |
-| `SystemDesmukhMather` | Desmukh-Mather | Amine systems |
-| `SystemKentEisenberg` | Kent-Eisenberg | CO2/H2S in amines |
-| `SystemDuanSun` | Duan-Sun | CO2 solubility in brine |
+| `SystemPitzer` | Pitzer aqueous GE + SRK gas/oil | Concentrated brines and reactive VLLE |
+| `SystemDesmukhMather` | Desmukh-Mather aqueous GE + SRK gas/oil | Reactive amine VLLE; parameter-limited scale screening |
+| `SystemKentEisenberg` | Kent-Eisenberg aqueous GE + SRK gas/oil | Reactive CO2/H2S amine VLLE screening |
+| `SystemDuanSun` | Duan-Sun, currently CO2-only | CO2 correlation; not hybrid gas-oil-aqueous |
 | `SystemFurstElectrolyteEos` | Fürst electrolyte EoS | General electrolytes |
+
+All subclasses of `SystemEosGE` can call `enableHybridEosGeFlash()` to use the fixed EOS-gas / EOS-oil / GE-aqueous
+topology. This does not add missing ionic species, reactions or activity parameters to the selected GE model.
 
 ---
 

--- a/docs/thermo/thermodynamic_models.md
+++ b/docs/thermo/thermodynamic_models.md
@@ -572,7 +572,7 @@ ops.TPflash();
 
 | Class | Description | Use Case |
 |-------|-------------|----------|
-| `SystemPitzer` | Pitzer model | Concentrated brines |
+| `SystemPitzer` | Pitzer aqueous GE + optional SRK gas/oil | Concentrated brines and opt-in VLLE |
 | `SystemDesmukhMather` | Desmukh-Mather | Amine systems |
 | `SystemKentEisenberg` | Kent-Eisenberg | CO2/H2S in amines |
 | `SystemDuanSun` | Duan-Sun | CO2 solubility in brine |

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -29,7 +29,50 @@ public class ComponentGePitzer extends ComponentGE {
   @Override
   public double fugcoef(PhaseInterface phase) {
     getGamma(phase, phase.getNumberOfComponents(), phase.getTemperature(), phase.getPressure(), phase.getType());
+    // Pitzer's implemented solvent activity is water-specific. Other database solvents need an aqueous Henry
+    // reference; hydrocarbons have no Pitzer neutral-interaction parameters and are represented as effectively
+    // insoluble instead of being evaluated with the water osmotic coefficient.
+    if (Math.abs(getIonicCharge()) < 0.5 && !"water".equalsIgnoreCase(getComponentName())) {
+      double henryCoefficient = getHenryCoef(phase.getTemperature());
+      if (hasHydrocarbonFormula() || isHydrocarbon() || isIsTBPfraction() || !Double.isFinite(henryCoefficient)
+          || henryCoefficient > 1.0e12) {
+        henryCoefficient = 1.0e12;
+      }
+      fugacityCoefficient = gamma * henryCoefficient / phase.getPressure();
+      gammaRefCor = gamma;
+      return fugacityCoefficient;
+    }
     return super.fugcoef(phase);
+  }
+
+  /**
+   * Check the database molecular formula for a pure hydrocarbon.
+   *
+   * <p>
+   * Some GE initialization paths classify a normal database component as {@code normal} instead of {@code HC}, so
+   * {@link #isHydrocarbon()} alone is not a stable aqueous-reference discriminator.
+   * </p>
+   *
+   * @return {@code true} when the formula contains carbon and hydrogen only
+   */
+  private boolean hasHydrocarbonFormula() {
+    String formula = getFormulae();
+    if (formula == null || formula.isEmpty()) {
+      return false;
+    }
+    boolean carbon = false;
+    boolean hydrogen = false;
+    for (int index = 0; index < formula.length(); index++) {
+      char character = formula.charAt(index);
+      if (character == 'C') {
+        carbon = true;
+      } else if (character == 'H') {
+        hydrogen = true;
+      } else if (!Character.isDigit(character)) {
+        return false;
+      }
+    }
+    return carbon && hydrogen;
   }
 
   /** {@inheritDoc} */
@@ -61,7 +104,8 @@ public class ComponentGePitzer extends ComponentGE {
     double charge = getIonicCharge();
 
     // Solvent (water): compute gamma from Pitzer osmotic coefficient
-    if (Math.abs(charge) < 0.5 && "solvent".equals(referenceStateType)) {
+    if (Math.abs(charge) < 0.5 && "water".equalsIgnoreCase(getComponentName())
+        && "solvent".equals(referenceStateType)) {
       return getWaterGamma(phase, numberOfComponents, temperature);
     }
 

--- a/src/main/java/neqsim/thermo/system/HybridEosGeFlashModel.java
+++ b/src/main/java/neqsim/thermo/system/HybridEosGeFlashModel.java
@@ -15,6 +15,28 @@ package neqsim.thermo.system;
  */
 public interface HybridEosGeFlashModel extends EosGeFlashModel {
   /**
+   * Configure and enable the fixed-role EOS-gas / EOS-oil / GE-aqueous flash.
+   *
+   * <p>
+   * Implementations that expose a reusable GE liquid phase can promote that phase to the aqueous role and clone their
+   * EOS gas phase for the oil role. The default implementation rejects the request so a model cannot silently claim a
+   * topology that it has not configured.
+   * </p>
+   */
+  default void enableHybridEosGeFlash() {
+    throw new UnsupportedOperationException("This model does not expose configurable hybrid EOS-GE phase roles.");
+  }
+
+  /**
+   * Check whether fixed gas, oil and GE-aqueous creation-order roles have been configured.
+   *
+   * @return {@code true} when the model owns all three reusable fluid-role objects
+   */
+  default boolean isHybridEosGeTopologyConfigured() {
+    return false;
+  }
+
+  /**
    * Select the dedicated hybrid multiphase strategy.
    *
    * @return {@code true} when the current system state requires hybrid EOS-GE multiphase solving

--- a/src/main/java/neqsim/thermo/system/HybridEosGeFlashModel.java
+++ b/src/main/java/neqsim/thermo/system/HybridEosGeFlashModel.java
@@ -45,6 +45,22 @@ public interface HybridEosGeFlashModel extends EosGeFlashModel {
   }
 
   /**
+   * Synchronize reaction-adjusted overall species amounts across all model-owned phase roles.
+   *
+   * <p>
+   * Chemical equilibrium changes species amounts while conserving elements. A coupled reactive flash must therefore
+   * replace the feed-species {@code z} values before its next phase-fraction solve; otherwise generated species are
+   * discarded or rescaled to the original total mole count.
+   * </p>
+   *
+   * @param componentMoles reaction-adjusted overall moles by component index
+   * @param totalMoles sum of the reaction-adjusted component amounts
+   */
+  default void synchronizeHybridEosGeOverallComposition(double[] componentMoles, double totalMoles) {
+    // Ordinary systems do not own hybrid phase roles.
+  }
+
+  /**
    * Check whether an active phase number maps to the configured GE aqueous role.
    *
    * <p>

--- a/src/main/java/neqsim/thermo/system/HybridEosGeFlashModel.java
+++ b/src/main/java/neqsim/thermo/system/HybridEosGeFlashModel.java
@@ -1,0 +1,82 @@
+package neqsim.thermo.system;
+
+/**
+ * Opt-in contract for a multiphase flash with separate equation-of-state gas and oil phases and an excess-Gibbs-energy
+ * aqueous phase.
+ *
+ * <p>
+ * The hybrid path is deliberately separate from the two-phase direct gamma-phi K-value loop. A model prepares its
+ * creation-order phase roles, the dedicated multiphase strategy solves phase fractions and compositions using each
+ * phase's own fugacity model, and the model then validates and finalises the result. Ordinary EOS systems never
+ * implement this interface and therefore do not enter the hybrid dispatch.
+ * </p>
+ *
+ * @author NeqSim
+ */
+public interface HybridEosGeFlashModel extends EosGeFlashModel {
+  /**
+   * Select the dedicated hybrid multiphase strategy.
+   *
+   * @return {@code true} when the current system state requires hybrid EOS-GE multiphase solving
+   */
+  default boolean requiresHybridEosGeFlash() {
+    return false;
+  }
+
+  /**
+   * Restore creation-order gas, oil and aqueous roles and provide a finite initial phase split.
+   */
+  default void prepareHybridEosGeFlash() {
+    // Ordinary systems require no hybrid phase-role preparation.
+  }
+
+  /**
+   * Restore creation-order role mappings without changing current phase compositions or fractions.
+   */
+  default void restoreHybridEosGePhaseRoles() {
+    // Ordinary systems require no hybrid phase-role restoration.
+  }
+
+  /**
+   * Restore role types for the current active mapping without adding a missing role.
+   */
+  default void restoreHybridEosGeActivePhaseTypes() {
+    // Ordinary systems require no hybrid phase-role restoration.
+  }
+
+  /**
+   * Check whether an active phase number maps to the configured GE aqueous role.
+   *
+   * <p>
+   * This must use the model-owned creation-order mapping rather than a phase object's mutable type label. GE phase
+   * initialization may temporarily classify a hydrocarbon-rich trial composition as oil while the multiphase solver is
+   * still converging.
+   * </p>
+   *
+   * @param phaseNumber active phase number
+   * @return {@code true} when the active phase is the configured GE aqueous object
+   */
+  default boolean isHybridEosGeAqueousPhase(int phaseNumber) {
+    return false;
+  }
+
+  /**
+   * Validate and finalise a hybrid multiphase result.
+   *
+   * @param phaseFractionMinimumLimit minimum active phase fraction used by the solver
+   * @return {@code true} when the result is finite, balanced and consistent with the configured roles
+   */
+  default boolean finishHybridEosGeFlash(double phaseFractionMinimumLimit) {
+    return false;
+  }
+
+  /**
+   * Return model-specific diagnostics for a rejected hybrid result.
+   *
+   * @param phaseFractionMinimumLimit minimum active phase fraction used by the solver
+   * @return diagnostic text
+   */
+  default String getHybridEosGeFlashDiagnostics(double phaseFractionMinimumLimit) {
+    return "No model-specific hybrid EOS-GE diagnostics are available.";
+  }
+}

--- a/src/main/java/neqsim/thermo/system/SystemDesmukhMather.java
+++ b/src/main/java/neqsim/thermo/system/SystemDesmukhMather.java
@@ -1,16 +1,22 @@
 package neqsim.thermo.system;
 
 import neqsim.thermo.phase.PhaseDesmukhMather;
-import neqsim.thermo.phase.PhasePureComponentSolid;
 import neqsim.thermo.phase.PhaseSrkEos;
 
 /**
- * This class defines a thermodynamic system using the Desmukh Mather thermodynamic model.
+ * Thermodynamic system using SRK for gas and oil and Desmukh-Mather for the aqueous electrolyte phase.
+ *
+ * <p>
+ * Calling {@code setMultiPhaseCheck(true)} selects the fixed-role hybrid gas-oil-aqueous flash. If
+ * {@code chemicalReactionInit()} has loaded reactions, aqueous chemical equilibrium is coupled to phase equilibrium.
+ * Scale potential can then be evaluated from the Desmukh-Mather ion activities, subject to that model's component and
+ * interaction-parameter coverage.
+ * </p>
  *
  * @author Even Solbraa
  * @version $Id: $Id
  */
-public class SystemDesmukhMather extends SystemEos {
+public class SystemDesmukhMather extends SystemEosGE {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
 
@@ -43,22 +49,7 @@ public class SystemDesmukhMather extends SystemEos {
     modelName = "Desmukh-Mather-model";
     attractiveTermNumber = 0;
 
-    phaseArray[0] = new PhaseSrkEos();
-    phaseArray[0].setTemperature(T);
-    phaseArray[0].setPressure(P);
-    for (int i = 1; i < numberOfPhases; i++) {
-      phaseArray[i] = new PhaseDesmukhMather(); // new PhaseGENRTLmodifiedWS();
-      phaseArray[i].setTemperature(T);
-      phaseArray[i].setPressure(P);
-    }
-
-    if (solidPhaseCheck) {
-      setNumberOfPhases(4);
-      phaseArray[numberOfPhases - 1] = new PhasePureComponentSolid();
-      phaseArray[numberOfPhases - 1].setTemperature(T);
-      phaseArray[numberOfPhases - 1].setPressure(P);
-      phaseArray[numberOfPhases - 1].setRefPhase(phaseArray[1].getRefPhase());
-    }
+    configureHybridEosGePhases(T, P, new PhaseSrkEos(), new PhaseDesmukhMather(), new PhaseSrkEos());
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/system/SystemEosGE.java
+++ b/src/main/java/neqsim/thermo/system/SystemEosGE.java
@@ -12,10 +12,13 @@ import neqsim.thermo.phase.PhaseType;
  * {@code phaseArray[0]} as the EOS vapour phase and subsequent fluid slots as independent clones of the GE liquid
  * phase. Active phases can later be reordered through {@code phaseIndex}, so {@code getPhase(0)} is not guaranteed to
  * return the EOS slot. Concrete systems remain responsible for selecting the EOS, activity model, mixing rules and
- * parameter sources. Hybrid systems can opt into separate EOS gas and oil slots plus a GE aqueous slot through
+ * parameter sources. Any concrete EOS-GE system can opt into separate EOS gas and oil slots plus a GE aqueous slot by
+ * calling {@link #enableHybridEosGeFlash()}. Electrolyte systems may configure those roles directly through
  * {@link #configureHybridEosGePhases(double, double, PhaseInterface, PhaseInterface, PhaseInterface)}. The dedicated
  * multiphase strategy restores these creation-order roles before every flash, activates only feed-supported roles and
- * removes disappearing roles from the active mapping without replacing their phase objects.
+ * removes disappearing roles from the active mapping without replacing their phase objects. Reactive coupling and
+ * scale-potential accuracy remain governed by the selected aqueous model's species, activity formulation and parameter
+ * coverage; the topology does not turn a non-electrolyte GE model into an electrolyte model.
  * </p>
  *
  * @author NeqSim
@@ -150,6 +153,38 @@ public abstract class SystemEosGE extends SystemEos implements HybridEosGeFlashM
       setPhaseIndex(0, eosGasPhaseSlot);
       setPhaseIndex(1, geLiquidPhaseSlot);
     }
+  }
+
+  /**
+   * Enable the reusable hybrid gas-oil-aqueous topology for this EOS-GE system.
+   *
+   * <p>
+   * The existing creation-order EOS vapour and GE liquid objects are retained. A clone of the EOS object becomes the
+   * oil role, the GE object becomes the aqueous role, and multiphase checking is enabled. This makes the topology
+   * available to Wilson, NRTL, UNIFAC and specialised electrolyte-GE subclasses without placing model names in the
+   * flash solver. The selected GE phase must still implement meaningful aqueous fugacity and activity coefficients for
+   * the requested components and reactions.
+   * </p>
+   */
+  @Override
+  public final void enableHybridEosGeFlash() {
+    if (!hybridEosGeTopologyConfigured) {
+      PhaseInterface eosGasPhase = phaseArray[eosGasPhaseSlot];
+      PhaseInterface geAqueousPhase = phaseArray[geLiquidPhaseSlot];
+      if (eosGasPhase == null || geAqueousPhase == null
+          || !(geAqueousPhase instanceof neqsim.thermo.phase.PhaseGEInterface)) {
+        throw new IllegalStateException(
+            "The system must provide EOS gas and GE liquid phases before enabling the hybrid EOS-GE flash.");
+      }
+      configureHybridEosGePhases(getTemperature(), getPressure(), eosGasPhase, geAqueousPhase, eosGasPhase.clone());
+    }
+    setMultiPhaseCheck(true);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public final boolean isHybridEosGeTopologyConfigured() {
+    return hybridEosGeTopologyConfigured;
   }
 
   /**
@@ -501,6 +536,10 @@ public abstract class SystemEosGE extends SystemEos implements HybridEosGeFlashM
       collapseTraceHybridPhases(Math.max(HYBRID_ACTIVE_PHASE_FRACTION, 100.0 * phaseFractionMinimumLimit));
       orderByDensity();
       init(1);
+      // Phase implementations may classify any non-gas EOS root as a generic liquid during init. Reassert the
+      // model-owned semantic roles after the final property initialization so callers consistently observe GAS, OIL
+      // and AQUEOUS rather than implementation-specific temporary labels.
+      restoreHybridEosGeActivePhaseTypes();
     }
     return accepted;
   }
@@ -551,9 +590,11 @@ public abstract class SystemEosGE extends SystemEos implements HybridEosGeFlashM
       } else {
         continue;
       }
+      // Chemical-equilibrium operations can temporarily disable phase shifting while they force an aqueous phase.
+      // Write creation-order metadata directly so the role contract is restored even when setPhaseType would be a
+      // guarded no-op. A later init then receives the same role type as the phase object.
+      phaseType[creationOrderSlot] = roleType;
       restoreHybridPhaseObject(creationOrderSlot, roleType);
-      // setPhaseType accepts an active phase number, not a creation-order slot.
-      setPhaseType(phaseNumber, roleType);
     }
   }
 

--- a/src/main/java/neqsim/thermo/system/SystemEosGE.java
+++ b/src/main/java/neqsim/thermo/system/SystemEosGE.java
@@ -171,7 +171,7 @@ public abstract class SystemEosGE extends SystemEos implements HybridEosGeFlashM
   /** {@inheritDoc} */
   @Override
   public boolean requiresHybridEosGeFlash() {
-    return hybridEosGeTopologyConfigured && doMultiPhaseCheck() && !isChemicalSystem();
+    return hybridEosGeTopologyConfigured && doMultiPhaseCheck();
   }
 
   /** {@inheritDoc} */
@@ -201,6 +201,34 @@ public abstract class SystemEosGE extends SystemEos implements HybridEosGeFlashM
     restoreHybridPhaseObject(eosOilPhaseSlot, PhaseType.OIL);
     restoreHybridPhaseObject(geLiquidPhaseSlot, PhaseType.AQUEOUS);
     restoreHybridEosGeActivePhaseTypes();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void synchronizeHybridEosGeOverallComposition(double[] componentMoles, double totalMoles) {
+    if (!hybridEosGeTopologyConfigured) {
+      throw new IllegalStateException("Hybrid EOS-GE phase roles have not been configured.");
+    }
+    if (componentMoles == null || componentMoles.length != getNumberOfComponents()) {
+      throw new IllegalArgumentException("Reaction-adjusted component amounts must match the system component count.");
+    }
+    if (!(totalMoles > 0.0) || !Double.isFinite(totalMoles)) {
+      throw new IllegalArgumentException("Reaction-adjusted total moles must be finite and positive.");
+    }
+
+    setTotalNumberOfMoles(totalMoles);
+    int[] roleSlots = new int[] { eosGasPhaseSlot, eosOilPhaseSlot, geLiquidPhaseSlot };
+    for (int roleSlot : roleSlots) {
+      if (roleSlot < 0) {
+        continue;
+      }
+      PhaseInterface role = phaseArray[roleSlot];
+      for (int componentIndex = 0; componentIndex < componentMoles.length; componentIndex++) {
+        double moles = componentMoles[componentIndex];
+        role.getComponent(componentIndex).setNumberOfmoles(moles);
+        role.getComponent(componentIndex).setz(moles / totalMoles);
+      }
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/system/SystemEosGE.java
+++ b/src/main/java/neqsim/thermo/system/SystemEosGE.java
@@ -12,16 +12,59 @@ import neqsim.thermo.phase.PhaseType;
  * {@code phaseArray[0]} as the EOS vapour phase and subsequent fluid slots as independent clones of the GE liquid
  * phase. Active phases can later be reordered through {@code phaseIndex}, so {@code getPhase(0)} is not guaranteed to
  * return the EOS slot. Concrete systems remain responsible for selecting the EOS, activity model, mixing rules and
- * parameter sources. A future hybrid gas-oil-aqueous implementation can extend this base with separate EOS gas and oil
- * slots plus a GE aqueous slot; it must also provide a matching multiphase flash strategy rather than using the default
- * two-phase direct gamma-phi preparation.
+ * parameter sources. Hybrid systems can opt into separate EOS gas and oil slots plus a GE aqueous slot through
+ * {@link #configureHybridEosGePhases(double, double, PhaseInterface, PhaseInterface, PhaseInterface)}. The dedicated
+ * multiphase strategy restores these creation-order roles before every flash, activates only feed-supported roles and
+ * removes disappearing roles from the active mapping without replacing their phase objects.
  * </p>
  *
  * @author NeqSim
  */
-public abstract class SystemEosGE extends SystemEos implements EosGeFlashModel {
+public abstract class SystemEosGE extends SystemEos implements HybridEosGeFlashModel {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+
+  /** Initial minimum phase fraction used when restoring a missing hybrid role. */
+  private static final double HYBRID_INITIAL_PHASE_FRACTION = 1.0e-5;
+
+  /** Maximum component material-balance residual accepted after a non-reactive hybrid flash. */
+  private static final double HYBRID_MATERIAL_BALANCE_TOLERANCE = 1.0e-7;
+
+  /** Maximum phase-composition normalization residual accepted after a hybrid flash. */
+  private static final double HYBRID_NORMALIZATION_TOLERANCE = 1.0e-8;
+
+  /** Maximum cross-phase logarithmic fugacity residual accepted after a hybrid flash. */
+  private static final double HYBRID_LOG_FUGACITY_TOLERANCE = 1.0e-5;
+
+  /** Minimum practical phase fraction retained as an active hybrid phase. */
+  private static final double HYBRID_ACTIVE_PHASE_FRACTION = 1.0e-10;
+
+  /** Creation-order slot containing the EOS gas object. */
+  private int eosGasPhaseSlot = 0;
+
+  /** Creation-order slot containing the EOS oil object, or {@code -1} for two-phase topology. */
+  private int eosOilPhaseSlot = -1;
+
+  /** Creation-order slot containing the GE liquid or aqueous object. */
+  private int geLiquidPhaseSlot = 1;
+
+  /** Whether separate EOS gas, EOS oil and GE aqueous roles have been configured. */
+  private boolean hybridEosGeTopologyConfigured = false;
+
+  /** Last component material-balance residual calculated by hybrid acceptance. */
+  private transient double lastHybridMaterialBalanceResidual = Double.NaN;
+
+  /** Last phase-composition normalization residual calculated by hybrid acceptance. */
+  private transient double lastHybridNormalizationResidual = Double.NaN;
+
+  /** Last cross-phase logarithmic fugacity residual calculated by hybrid acceptance. */
+  private transient double lastHybridLogFugacityResidual = Double.NaN;
+
+  /** Component associated with the last maximum hybrid fugacity residual. */
+  private transient String lastHybridWorstFugacityComponent = null;
+
+  /** Component associated with the last maximum hybrid material-balance residual. */
+  private transient String lastHybridWorstMaterialBalanceComponent = null;
 
   /**
    * Constructor for an EOS-GE system.
@@ -44,6 +87,10 @@ public abstract class SystemEosGE extends SystemEos implements EosGeFlashModel {
    */
   protected final void configureEosGePhases(double temperature, double pressure, PhaseInterface eosPhase,
       PhaseInterface gePhase) {
+    hybridEosGeTopologyConfigured = false;
+    eosGasPhaseSlot = 0;
+    eosOilPhaseSlot = -1;
+    geLiquidPhaseSlot = 1;
     phaseArray[0] = eosPhase;
     initialisePhase(0, temperature, pressure, PhaseType.GAS);
     phaseArray[1] = gePhase;
@@ -56,6 +103,52 @@ public abstract class SystemEosGE extends SystemEos implements EosGeFlashModel {
       phaseArray[3] = new PhasePureComponentSolid();
       initialisePhase(3, temperature, pressure, PhaseType.SOLID);
       phaseArray[3].setRefPhase(phaseArray[1].getRefPhase());
+    }
+  }
+
+  /**
+   * Configure reusable creation-order roles for a hybrid gas-oil-aqueous system.
+   *
+   * <p>
+   * The slot layout deliberately preserves the historic electrolyte-GE convention: {@code phaseArray[0]} is EOS gas,
+   * {@code phaseArray[1]} is GE aqueous and {@code phaseArray[2]} is EOS oil. Active phases may be reordered or
+   * collapsed through {@code phaseIndex}; these three creation-order objects are never replaced by the hybrid flash.
+   * </p>
+   *
+   * @param temperature temperature in kelvin
+   * @param pressure pressure in bara
+   * @param eosGasPhase equation-of-state gas phase
+   * @param geAqueousPhase excess-Gibbs-energy aqueous phase
+   * @param eosOilPhase equation-of-state oil phase
+   */
+  protected final void configureHybridEosGePhases(double temperature, double pressure, PhaseInterface eosGasPhase,
+      PhaseInterface geAqueousPhase, PhaseInterface eosOilPhase) {
+    hybridEosGeTopologyConfigured = true;
+    eosGasPhaseSlot = 0;
+    geLiquidPhaseSlot = 1;
+    eosOilPhaseSlot = 2;
+
+    setMaxNumberOfPhases(solidPhaseCheck ? 4 : 3);
+    phaseArray[eosGasPhaseSlot] = eosGasPhase;
+    initialisePhase(eosGasPhaseSlot, temperature, pressure, PhaseType.GAS);
+    phaseArray[geLiquidPhaseSlot] = geAqueousPhase;
+    initialisePhase(geLiquidPhaseSlot, temperature, pressure, PhaseType.AQUEOUS);
+    phaseArray[eosOilPhaseSlot] = eosOilPhase;
+    initialisePhase(eosOilPhaseSlot, temperature, pressure, PhaseType.OIL);
+
+    if (solidPhaseCheck) {
+      phaseArray[3] = new PhasePureComponentSolid();
+      initialisePhase(3, temperature, pressure, PhaseType.SOLID);
+      phaseArray[3].setRefPhase(phaseArray[geLiquidPhaseSlot].getRefPhase());
+      setNumberOfPhases(4);
+      setPhaseIndex(0, eosGasPhaseSlot);
+      setPhaseIndex(1, geLiquidPhaseSlot);
+      setPhaseIndex(2, eosOilPhaseSlot);
+      setPhaseIndex(3, 3);
+    } else {
+      setNumberOfPhases(2);
+      setPhaseIndex(0, eosGasPhaseSlot);
+      setPhaseIndex(1, geLiquidPhaseSlot);
     }
   }
 
@@ -75,6 +168,476 @@ public abstract class SystemEosGE extends SystemEos implements EosGeFlashModel {
     setPhaseIndex(1, 1);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean requiresHybridEosGeFlash() {
+    return hybridEosGeTopologyConfigured && doMultiPhaseCheck() && !isChemicalSystem();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void prepareHybridEosGeFlash() {
+    if (!hybridEosGeTopologyConfigured) {
+      throw new IllegalStateException("Hybrid EOS-GE phase roles have not been configured.");
+    }
+
+    restoreHybridEosGePhaseRoles();
+    seedHybridPhaseCompositions();
+    seedHybridPhaseFractions();
+    activateSupportedHybridPhaseRoles();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreHybridEosGePhaseRoles() {
+    if (!hybridEosGeTopologyConfigured) {
+      throw new IllegalStateException("Hybrid EOS-GE phase roles have not been configured.");
+    }
+    setNumberOfPhases(3);
+    setPhaseIndex(0, eosGasPhaseSlot);
+    setPhaseIndex(1, eosOilPhaseSlot);
+    setPhaseIndex(2, geLiquidPhaseSlot);
+    restoreHybridPhaseObject(eosGasPhaseSlot, PhaseType.GAS);
+    restoreHybridPhaseObject(eosOilPhaseSlot, PhaseType.OIL);
+    restoreHybridPhaseObject(geLiquidPhaseSlot, PhaseType.AQUEOUS);
+    restoreHybridEosGeActivePhaseTypes();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isHybridEosGeAqueousPhase(int phaseNumber) {
+    return hybridEosGeTopologyConfigured && phaseNumber >= 0 && phaseNumber < getNumberOfPhases()
+        && getPhaseIndex(phaseNumber) == geLiquidPhaseSlot;
+  }
+
+  /**
+   * Seed role-specific compositions from the overall feed before multiphase fugacity iteration.
+   */
+  private void seedHybridPhaseCompositions() {
+    PhaseInterface gas = phaseArray[eosGasPhaseSlot];
+    PhaseInterface oil = phaseArray[eosOilPhaseSlot];
+    PhaseInterface aqueous = phaseArray[geLiquidPhaseSlot];
+
+    for (int componentIndex = 0; componentIndex < gas.getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = gas.getComponent(componentIndex);
+      double feedFraction = Math.max(component.getz(), 1.0e-50);
+      boolean ion = component.getIonicCharge() != 0 || component.isIsIon();
+      boolean aqueousComponent = isAqueousComponent(component);
+      boolean heavyHydrocarbon = component.isHydrocarbon() && component.getMolarMass() > 0.045;
+
+      double gasFraction;
+      double oilFraction;
+      double aqueousFraction;
+      if (ion) {
+        gasFraction = 1.0e-50;
+        oilFraction = 1.0e-50;
+        aqueousFraction = feedFraction;
+      } else if (aqueousComponent) {
+        gasFraction = Math.min(feedFraction * 1.0e-3, 1.0e-8);
+        oilFraction = Math.min(feedFraction * 1.0e-4, 1.0e-10);
+        aqueousFraction = feedFraction;
+      } else if (component.isHydrocarbon()) {
+        gasFraction = heavyHydrocarbon ? Math.max(feedFraction * 1.0e-2, 1.0e-16) : feedFraction;
+        oilFraction = heavyHydrocarbon ? feedFraction : Math.max(feedFraction * 5.0e-2, 1.0e-16);
+        aqueousFraction = Math.max(feedFraction * 1.0e-8, 1.0e-30);
+      } else {
+        gasFraction = feedFraction;
+        oilFraction = Math.max(feedFraction * 1.0e-1, 1.0e-16);
+        aqueousFraction = Math.max(feedFraction * 1.0e-2, 1.0e-20);
+      }
+
+      gas.getComponent(componentIndex).setx(gasFraction);
+      oil.getComponent(componentIndex).setx(oilFraction);
+      aqueous.getComponent(componentIndex).setx(aqueousFraction);
+    }
+    gas.normalize();
+    oil.normalize();
+    aqueous.normalize();
+  }
+
+  /**
+   * Seed finite gas, oil and aqueous fractions from component affinities in the overall feed.
+   */
+  private void seedHybridPhaseFractions() {
+    PhaseInterface gas = phaseArray[eosGasPhaseSlot];
+    double aqueousFeed = 0.0;
+    double oilFeed = 0.0;
+    double gasFeed = 0.0;
+
+    for (int componentIndex = 0; componentIndex < gas.getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = gas.getComponent(componentIndex);
+      double feedFraction = Math.max(component.getz(), 0.0);
+      if (isAqueousComponent(component)) {
+        aqueousFeed += feedFraction;
+      } else if (component.isHydrocarbon() && component.getMolarMass() > 0.045) {
+        oilFeed += feedFraction;
+      } else {
+        gasFeed += feedFraction;
+      }
+    }
+
+    gasFeed = Math.max(gasFeed, HYBRID_INITIAL_PHASE_FRACTION);
+    oilFeed = Math.max(oilFeed, HYBRID_INITIAL_PHASE_FRACTION);
+    aqueousFeed = Math.max(aqueousFeed, HYBRID_INITIAL_PHASE_FRACTION);
+    double total = gasFeed + oilFeed + aqueousFeed;
+    setBeta(0, gasFeed / total);
+    setBeta(1, oilFeed / total);
+    setBeta(2, aqueousFeed / total);
+    normalizeBeta();
+  }
+
+  /**
+   * Identify ions, water and common polar production solvents as aqueous-feed components.
+   *
+   * @param component component to classify
+   * @return {@code true} for an aqueous-feed component
+   */
+  private boolean isAqueousComponent(neqsim.thermo.component.ComponentInterface component) {
+    if (component.getIonicCharge() != 0 || component.isIsIon()) {
+      return true;
+    }
+    String name = component.getComponentName().toLowerCase();
+    return "water".equals(name) || "meg".equals(name) || "teg".equals(name) || "deg".equals(name)
+        || "methanol".equals(name) || "ethanol".equals(name);
+  }
+
+  /**
+   * Check whether the feed contains a hydrocarbon capable of supporting an EOS liquid at the current temperature.
+   *
+   * <p>
+   * This prevents a small metastable EOS-liquid root made only from supercritical methane and water from entering a
+   * gas-aqueous solve. The creation-order oil object is retained and is reconsidered from the current feed before every
+   * later flash.
+   * </p>
+   *
+   * @return {@code true} when an oil-forming feed component is present
+   */
+  private boolean hasHybridOilCandidate() {
+    PhaseInterface referencePhase = phaseArray[eosGasPhaseSlot];
+    for (int componentIndex = 0; componentIndex < referencePhase.getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = referencePhase.getComponent(componentIndex);
+      if (component.getz() > 1.0e-12 && (component.isHydrocarbon() || component.isIsTBPfraction())
+          && component.getTC() > getTemperature()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Check whether the feed contains a component with a Wilson estimate favouring an EOS gas root.
+   *
+   * @return {@code true} when a gas-forming feed component is present
+   */
+  private boolean hasHybridGasCandidate() {
+    PhaseInterface referencePhase = phaseArray[eosGasPhaseSlot];
+    for (int componentIndex = 0; componentIndex < referencePhase.getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = referencePhase.getComponent(componentIndex);
+      if (component.getz() <= 1.0e-12 || component.getIonicCharge() != 0 || component.isIsIon()) {
+        continue;
+      }
+      double criticalTemperature = component.getTC();
+      double criticalPressure = component.getPC();
+      if (!(criticalTemperature > 0.0) || !(criticalPressure > 0.0) || !(getPressure() > 0.0)) {
+        continue;
+      }
+      double wilsonK = criticalPressure / getPressure()
+          * Math.exp(5.373 * (1.0 + component.getAcentricFactor()) * (1.0 - criticalTemperature / getTemperature()));
+      if (Double.isFinite(wilsonK) && wilsonK > 1.0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Check whether the feed contains water, ions or a supported polar aqueous solvent.
+   *
+   * @return {@code true} when an aqueous-forming feed component is present
+   */
+  private boolean hasHybridAqueousCandidate() {
+    PhaseInterface referencePhase = phaseArray[eosGasPhaseSlot];
+    for (int componentIndex = 0; componentIndex < referencePhase.getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = referencePhase.getComponent(componentIndex);
+      if (component.getz() > 1.0e-12 && isAqueousComponent(component)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Activate only feed-supported hybrid roles while retaining a complete inactive creation-order mapping.
+   */
+  private void activateSupportedHybridPhaseRoles() {
+    int[] activeSlots = new int[3];
+    int activeCount = 0;
+    if (hasHybridGasCandidate()) {
+      activeSlots[activeCount++] = eosGasPhaseSlot;
+    }
+    if (hasHybridOilCandidate()) {
+      activeSlots[activeCount++] = eosOilPhaseSlot;
+    }
+    if (hasHybridAqueousCandidate()) {
+      activeSlots[activeCount++] = geLiquidPhaseSlot;
+    }
+    if (activeCount == 0) {
+      activeSlots[activeCount++] = eosGasPhaseSlot;
+    }
+
+    setNumberOfPhases(activeCount);
+    for (int phaseNumber = 0; phaseNumber < activeCount; phaseNumber++) {
+      setPhaseIndex(phaseNumber, activeSlots[phaseNumber]);
+    }
+    completeInactiveHybridPhaseMapping(activeSlots, activeCount);
+    normalizeBeta();
+    restoreHybridEosGeActivePhaseTypes();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean finishHybridEosGeFlash(double phaseFractionMinimumLimit) {
+    if (!hybridEosGeTopologyConfigured || getNumberOfPhases() < 1) {
+      return false;
+    }
+
+    restoreHybridEosGeActivePhaseTypes();
+    init(1);
+
+    lastHybridNormalizationResidual = 0.0;
+    lastHybridMaterialBalanceResidual = 0.0;
+    lastHybridLogFugacityResidual = 0.0;
+    lastHybridWorstFugacityComponent = null;
+    lastHybridWorstMaterialBalanceComponent = null;
+    double betaSum = 0.0;
+    for (int phaseIndex = 0; phaseIndex < getNumberOfPhases(); phaseIndex++) {
+      if (!isHybridRoleSlot(getPhaseIndex(phaseIndex))) {
+        return false;
+      }
+      betaSum += getBeta(phaseIndex);
+      double compositionSum = 0.0;
+      for (int componentIndex = 0; componentIndex < getPhase(phaseIndex).getNumberOfComponents(); componentIndex++) {
+        compositionSum += getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      lastHybridNormalizationResidual = Math.max(lastHybridNormalizationResidual, Math.abs(1.0 - compositionSum));
+    }
+    lastHybridNormalizationResidual = Math.max(lastHybridNormalizationResidual, Math.abs(1.0 - betaSum));
+
+    if (!isChemicalSystem()) {
+      for (int componentIndex = 0; componentIndex < getPhase(0).getNumberOfComponents(); componentIndex++) {
+        double calculatedFeedFraction = 0.0;
+        for (int phaseIndex = 0; phaseIndex < getNumberOfPhases(); phaseIndex++) {
+          calculatedFeedFraction += getBeta(phaseIndex) * getPhase(phaseIndex).getComponent(componentIndex).getx();
+        }
+        double residual = Math.abs(getPhase(0).getComponent(componentIndex).getz() - calculatedFeedFraction);
+        if (residual > lastHybridMaterialBalanceResidual) {
+          lastHybridMaterialBalanceResidual = residual;
+          lastHybridWorstMaterialBalanceComponent = getPhase(0).getComponent(componentIndex).getComponentName();
+        }
+      }
+    }
+
+    for (int componentIndex = 0; componentIndex < getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface referenceComponent = getPhase(0).getComponent(componentIndex);
+      if (referenceComponent.getIonicCharge() != 0 || referenceComponent.isIsIon()) {
+        continue;
+      }
+      double referenceLogFugacity = Double.NaN;
+      for (int phaseIndex = 0; phaseIndex < getNumberOfPhases(); phaseIndex++) {
+        if (getBeta(phaseIndex) <= 100.0 * phaseFractionMinimumLimit) {
+          continue;
+        }
+        neqsim.thermo.component.ComponentInterface phaseComponent = getPhase(phaseIndex).getComponent(componentIndex);
+        double moleFraction = phaseComponent.getx();
+        double fugacityCoefficient = phaseComponent.getFugacityCoefficient();
+        if (!(moleFraction > 1.0e-30) || !(fugacityCoefficient > 0.0) || !Double.isFinite(fugacityCoefficient)) {
+          continue;
+        }
+        double logFugacity = Math.log(moleFraction * fugacityCoefficient * getPhase(phaseIndex).getPressure());
+        if (Double.isNaN(referenceLogFugacity)) {
+          referenceLogFugacity = logFugacity;
+        } else {
+          double residual = Math.abs(logFugacity - referenceLogFugacity);
+          if (residual > lastHybridLogFugacityResidual) {
+            lastHybridLogFugacityResidual = residual;
+            lastHybridWorstFugacityComponent = phaseComponent.getComponentName();
+          }
+        }
+      }
+    }
+
+    boolean accepted = lastHybridNormalizationResidual <= HYBRID_NORMALIZATION_TOLERANCE
+        && (isChemicalSystem() || lastHybridMaterialBalanceResidual <= HYBRID_MATERIAL_BALANCE_TOLERANCE)
+        && lastHybridLogFugacityResidual <= HYBRID_LOG_FUGACITY_TOLERANCE;
+    if (accepted) {
+      collapseTraceHybridPhases(Math.max(HYBRID_ACTIVE_PHASE_FRACTION, 100.0 * phaseFractionMinimumLimit));
+      orderByDensity();
+      init(1);
+    }
+    return accepted;
+  }
+
+  /**
+   * Check whether a creation-order slot is one of the configured hybrid fluid roles.
+   *
+   * @param creationOrderSlot creation-order phase-array slot
+   * @return {@code true} for the EOS gas, EOS oil or GE aqueous slot
+   */
+  private boolean isHybridRoleSlot(int creationOrderSlot) {
+    return creationOrderSlot == eosGasPhaseSlot || creationOrderSlot == eosOilPhaseSlot
+        || creationOrderSlot == geLiquidPhaseSlot;
+  }
+
+  /**
+   * Restore temperature, pressure and type directly on a creation-order phase object.
+   *
+   * <p>
+   * System phase-type metadata is restored separately through active phase numbers because
+   * {@link #setPhaseType(int, PhaseType)} follows {@code phaseIndex}.
+   * </p>
+   *
+   * @param creationOrderSlot phase-array slot
+   * @param phaseType role type
+   */
+  private void restoreHybridPhaseObject(int creationOrderSlot, PhaseType phaseType) {
+    PhaseInterface phase = phaseArray[creationOrderSlot];
+    phase.setTemperature(getTemperature());
+    phase.setPressure(getPressure());
+    phase.setType(phaseType);
+  }
+
+  /**
+   * Restore role types for the currently active creation-order mapping.
+   */
+  @Override
+  public void restoreHybridEosGeActivePhaseTypes() {
+    for (int phaseNumber = 0; phaseNumber < getNumberOfPhases(); phaseNumber++) {
+      int creationOrderSlot = getPhaseIndex(phaseNumber);
+      PhaseType roleType;
+      if (creationOrderSlot == eosGasPhaseSlot) {
+        roleType = PhaseType.GAS;
+      } else if (creationOrderSlot == eosOilPhaseSlot) {
+        roleType = PhaseType.OIL;
+      } else if (creationOrderSlot == geLiquidPhaseSlot) {
+        roleType = PhaseType.AQUEOUS;
+      } else {
+        continue;
+      }
+      restoreHybridPhaseObject(creationOrderSlot, roleType);
+      // setPhaseType accepts an active phase number, not a creation-order slot.
+      setPhaseType(phaseNumber, roleType);
+    }
+  }
+
+  /**
+   * Remove trace roles from the active mapping without deleting or replacing their creation-order objects.
+   *
+   * @param threshold largest phase fraction considered absent
+   */
+  private void collapseTraceHybridPhases(double threshold) {
+    int[] survivingSlots = new int[3];
+    int survivorCount = 0;
+    int largestPhaseNumber = 0;
+    for (int phaseNumber = 0; phaseNumber < getNumberOfPhases(); phaseNumber++) {
+      if (getBeta(phaseNumber) > getBeta(largestPhaseNumber)) {
+        largestPhaseNumber = phaseNumber;
+      }
+      if (getBeta(phaseNumber) > threshold) {
+        survivingSlots[survivorCount++] = getPhaseIndex(phaseNumber);
+      }
+    }
+    if (survivorCount == 0) {
+      survivingSlots[survivorCount++] = getPhaseIndex(largestPhaseNumber);
+    }
+
+    setNumberOfPhases(survivorCount);
+    for (int phaseNumber = 0; phaseNumber < survivorCount; phaseNumber++) {
+      setPhaseIndex(phaseNumber, survivingSlots[phaseNumber]);
+    }
+    completeInactiveHybridPhaseMapping(survivingSlots, survivorCount);
+    normalizeBeta();
+    restoreHybridEosGeActivePhaseTypes();
+  }
+
+  /**
+   * Keep inactive {@code phaseIndex} entries as a permutation of the creation-order roles.
+   *
+   * <p>
+   * System component addition iterates to {@code maxNumberOfPhases} through {@link #getPhase(int)} even when fewer
+   * phases are active. Duplicate inactive mappings would therefore add a new component twice to one phase object.
+   * </p>
+   *
+   * @param activeSlots active creation-order slots
+   * @param activeCount number of active slots
+   */
+  private void completeInactiveHybridPhaseMapping(int[] activeSlots, int activeCount) {
+    int[] roleSlots = new int[] { eosGasPhaseSlot, eosOilPhaseSlot, geLiquidPhaseSlot };
+    int mappingIndex = activeCount;
+    for (int roleSlot : roleSlots) {
+      boolean active = false;
+      for (int activeIndex = 0; activeIndex < activeCount; activeIndex++) {
+        if (activeSlots[activeIndex] == roleSlot) {
+          active = true;
+          break;
+        }
+      }
+      if (!active) {
+        setPhaseIndex(mappingIndex++, roleSlot);
+      }
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getHybridEosGeFlashDiagnostics(double phaseFractionMinimumLimit) {
+    return "phaseFractionMinimumLimit=" + phaseFractionMinimumLimit + ", materialBalanceResidual="
+        + lastHybridMaterialBalanceResidual + ", normalizationResidual=" + lastHybridNormalizationResidual
+        + ", worstMaterialBalanceComponent=" + lastHybridWorstMaterialBalanceComponent + ", logFugacityResidual="
+        + lastHybridLogFugacityResidual + ", worstFugacityComponent=" + lastHybridWorstFugacityComponent
+        + ", activePhases=" + getNumberOfPhases() + ", phaseBetas=" + hybridPhaseBetaDiagnostics()
+        + ", componentPhases=" + hybridComponentDiagnostics();
+  }
+
+  /**
+   * Format active phase roles and fractions for rejected-flash diagnostics.
+   *
+   * @return compact active phase diagnostics
+   */
+  private String hybridPhaseBetaDiagnostics() {
+    StringBuilder diagnostics = new StringBuilder("[");
+    for (int phaseIndex = 0; phaseIndex < getNumberOfPhases(); phaseIndex++) {
+      if (phaseIndex > 0) {
+        diagnostics.append(", ");
+      }
+      diagnostics.append(getPhase(phaseIndex).getType()).append('=').append(getBeta(phaseIndex));
+    }
+    return diagnostics.append(']').toString();
+  }
+
+  /**
+   * Format mole fractions and fugacity coefficients for all components in a rejected state.
+   *
+   * @return compact component diagnostics
+   */
+  private String hybridComponentDiagnostics() {
+    StringBuilder diagnostics = new StringBuilder("[");
+    for (int componentIndex = 0; componentIndex < getPhase(0).getNumberOfComponents(); componentIndex++) {
+      if (componentIndex > 0) {
+        diagnostics.append("; ");
+      }
+      diagnostics.append(getPhase(0).getComponent(componentIndex).getComponentName()).append('=');
+      for (int phaseIndex = 0; phaseIndex < getNumberOfPhases(); phaseIndex++) {
+        if (phaseIndex > 0) {
+          diagnostics.append(',');
+        }
+        neqsim.thermo.component.ComponentInterface component = getPhase(phaseIndex).getComponent(componentIndex);
+        diagnostics.append(getPhase(phaseIndex).getType()).append("(x=").append(component.getx()).append(",phi=")
+            .append(component.getFugacityCoefficient()).append(')');
+      }
+    }
+    return diagnostics.append(']').toString();
+  }
+
   /**
    * Get the equation-of-state phase from its creation-order slot.
    *
@@ -86,7 +649,52 @@ public abstract class SystemEosGE extends SystemEos implements EosGeFlashModel {
    * @return EOS phase
    */
   public final PhaseInterface getEquationOfStatePhase() {
-    return phaseArray[0];
+    return phaseArray[eosGasPhaseSlot];
+  }
+
+  /**
+   * Get the EOS gas creation-order slot.
+   *
+   * @return EOS gas slot
+   */
+  public final int getEosGasPhaseSlot() {
+    return eosGasPhaseSlot;
+  }
+
+  /**
+   * Get the EOS oil creation-order slot.
+   *
+   * @return EOS oil slot, or {@code -1} when no hybrid oil role is configured
+   */
+  public final int getEosOilPhaseSlot() {
+    return eosOilPhaseSlot;
+  }
+
+  /**
+   * Get the GE liquid or aqueous creation-order slot.
+   *
+   * @return GE liquid slot
+   */
+  public final int getGeLiquidPhaseSlot() {
+    return geLiquidPhaseSlot;
+  }
+
+  /**
+   * Get the EOS oil phase from its creation-order slot.
+   *
+   * @return EOS oil phase, or {@code null} when no hybrid oil role is configured
+   */
+  public final PhaseInterface getEosOilPhase() {
+    return eosOilPhaseSlot < 0 ? null : phaseArray[eosOilPhaseSlot];
+  }
+
+  /**
+   * Get the GE liquid or aqueous phase from its creation-order slot.
+   *
+   * @return GE liquid or aqueous phase
+   */
+  public final PhaseInterface getGeLiquidPhase() {
+    return phaseArray[geLiquidPhaseSlot];
   }
 
   /**

--- a/src/main/java/neqsim/thermo/system/SystemKentEisenberg.java
+++ b/src/main/java/neqsim/thermo/system/SystemKentEisenberg.java
@@ -1,16 +1,22 @@
 package neqsim.thermo.system;
 
 import neqsim.thermo.phase.PhaseKentEisenberg;
-import neqsim.thermo.phase.PhasePureComponentSolid;
 import neqsim.thermo.phase.PhaseSrkEos;
 
 /**
- * This class defines a thermodynamic system using the Kent Eisenberg model.
+ * Thermodynamic system using SRK for gas and oil and Kent-Eisenberg for the aqueous electrolyte phase.
+ *
+ * <p>
+ * Calling {@code setMultiPhaseCheck(true)} selects the fixed-role hybrid gas-oil-aqueous flash. If
+ * {@code chemicalReactionInit()} has loaded reactions, aqueous chemical equilibrium is coupled to phase equilibrium.
+ * Scale-potential results use the Kent-Eisenberg phase activity coefficients and are limited by that screening model's
+ * component and parameter coverage.
+ * </p>
  *
  * @author Even Solbraa
  * @version $Id: $Id
  */
-public class SystemKentEisenberg extends SystemEos {
+public class SystemKentEisenberg extends SystemEosGE {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
 
@@ -43,22 +49,7 @@ public class SystemKentEisenberg extends SystemEos {
     modelName = "Kent Eisenberg-model";
     attractiveTermNumber = 0;
 
-    phaseArray[0] = new PhaseSrkEos();
-    phaseArray[0].setTemperature(T);
-    phaseArray[0].setPressure(P);
-    for (int i = 1; i < numberOfPhases; i++) {
-      phaseArray[i] = new PhaseKentEisenberg(); // new PhaseGENRTLmodifiedWS();
-      phaseArray[i].setTemperature(T);
-      phaseArray[i].setPressure(P);
-    }
-
-    if (solidPhaseCheck) {
-      setNumberOfPhases(4);
-      phaseArray[numberOfPhases - 1] = new PhasePureComponentSolid();
-      phaseArray[numberOfPhases - 1].setTemperature(T);
-      phaseArray[numberOfPhases - 1].setPressure(P);
-      phaseArray[numberOfPhases - 1].setRefPhase(phaseArray[1].getRefPhase());
-    }
+    configureHybridEosGePhases(T, P, new PhaseSrkEos(), new PhaseKentEisenberg(), new PhaseSrkEos());
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/system/SystemPitzer.java
+++ b/src/main/java/neqsim/thermo/system/SystemPitzer.java
@@ -10,8 +10,9 @@ import neqsim.thermo.phase.PhaseSrkEos;
  * Supports vapor-liquid-liquid equilibrium (VLLE) with creation-order roles {@code phaseArray[0]} = SRK gas,
  * {@code phaseArray[1]} = Pitzer aqueous and {@code phaseArray[2]} = SRK oil. Enable the dedicated hybrid strategy by
  * calling {@code setMultiPhaseCheck(true)} before running the flash. Phase disappearance only changes the active
- * mapping; repeated flashes, cloning and serialization retain the role objects. Reactive systems initialized through
- * {@code chemicalReactionInit()} continue to use the established chemical multiphase path.
+ * mapping; repeated flashes, cloning and serialization retain the role objects. Systems initialized through
+ * {@code chemicalReactionInit()} alternate fixed-role phase equilibrium with chemical equilibrium in the Pitzer aqueous
+ * phase, enabling reactive gas-aqueous and gas-oil-aqueous scale-potential calculations.
  * </p>
  *
  * <p>

--- a/src/main/java/neqsim/thermo/system/SystemPitzer.java
+++ b/src/main/java/neqsim/thermo/system/SystemPitzer.java
@@ -1,20 +1,27 @@
 package neqsim.thermo.system;
 
 import neqsim.thermo.phase.PhasePitzer;
-import neqsim.thermo.phase.PhasePureComponentSolid;
 import neqsim.thermo.phase.PhaseSrkEos;
 
 /**
  * Thermodynamic system using the Pitzer GE model for the aqueous phase and SRK EOS for gas and optional oil phases.
  *
  * <p>
- * Supports vapor-liquid-liquid equilibrium (VLLE): gas (SRK), oil (SRK), aqueous (Pitzer). Enable VLLE by calling
- * {@code setMultiPhaseCheck(true)} before running the flash.
+ * Supports vapor-liquid-liquid equilibrium (VLLE) with creation-order roles {@code phaseArray[0]} = SRK gas,
+ * {@code phaseArray[1]} = Pitzer aqueous and {@code phaseArray[2]} = SRK oil. Enable the dedicated hybrid strategy by
+ * calling {@code setMultiPhaseCheck(true)} before running the flash. Phase disappearance only changes the active
+ * mapping; repeated flashes, cloning and serialization retain the role objects. Reactive systems initialized through
+ * {@code chemicalReactionInit()} continue to use the established chemical multiphase path.
+ * </p>
+ *
+ * <p>
+ * The hybrid strategy currently supports fluid phases only. Solid and wax checks are rejected explicitly when the
+ * strategy is active.
  * </p>
  *
  * @author esol
  */
-public class SystemPitzer extends SystemEos {
+public class SystemPitzer extends SystemEosGE {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
 
@@ -47,50 +54,7 @@ public class SystemPitzer extends SystemEos {
     modelName = "Pitzer-GE-model";
     attractiveTermNumber = 0;
 
-    phaseArray[0] = new PhaseSrkEos();
-    phaseArray[0].setTemperature(T);
-    phaseArray[0].setPressure(P);
-    for (int i = 1; i < numberOfPhases; i++) {
-      phaseArray[i] = new PhasePitzer();
-      phaseArray[i].setTemperature(T);
-      phaseArray[i].setPressure(P);
-      phaseArray[i].setType(neqsim.thermo.phase.PhaseType.AQUEOUS);
-      setPhaseType(i, neqsim.thermo.phase.PhaseType.AQUEOUS);
-    }
-
-    if (solidPhaseCheck) {
-      setNumberOfPhases(4);
-      phaseArray[numberOfPhases - 1] = new PhasePureComponentSolid();
-      phaseArray[numberOfPhases - 1].setTemperature(T);
-      phaseArray[numberOfPhases - 1].setPressure(P);
-      phaseArray[numberOfPhases - 1].setRefPhase(phaseArray[1].getRefPhase());
-    }
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * <p>
-   * Overridden to create a SRK EOS oil phase (not a Pitzer clone) when enabling multi-phase (VLLE) checks. Phase
-   * layout: [0]=SRK(gas), [1]=Pitzer(aqueous), [2]=SRK(oil).
-   * </p>
-   */
-  @Override
-  public void setMultiPhaseCheck(boolean multiPhaseCheck) {
-    if (getMaxNumberOfPhases() < 3 && multiPhaseCheck) {
-      setMaxNumberOfPhases(3);
-      // Create oil phase as SRK EOS (not Pitzer) — clones from gas phase
-      if (phaseArray[0] != null) {
-        phaseArray[2] = phaseArray[0].clone();
-        phaseArray[2].setType(neqsim.thermo.phase.PhaseType.LIQUID);
-        phaseArray[2].resetMixingRule(phaseArray[0].getMixingRuleType());
-        phaseArray[2].resetPhysicalProperties();
-        phaseArray[2].initPhysicalProperties();
-      }
-    }
-    // Delegate to parent which sets the multiPhaseCheck flag.
-    // Since maxNumberOfPhases is already >= 3, the parent will NOT re-clone phaseArray[2].
-    super.setMultiPhaseCheck(multiPhaseCheck);
+    configureHybridEosGePhases(T, P, new PhaseSrkEos(), new PhasePitzer(), new PhaseSrkEos());
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -1,6 +1,7 @@
 package neqsim.thermodynamicoperations.flashops;
 
 import static neqsim.thermo.ThermodynamicModelSettings.phaseFractionMinimumLimit;
+import org.ejml.simple.SimpleMatrix;
 import neqsim.thermo.component.ComponentInterface;
 import neqsim.thermo.system.HybridEosGeFlashModel;
 import neqsim.thermo.system.SystemInterface;
@@ -30,6 +31,24 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** Fugacity-objective residual used to terminate the fixed-topology solve. */
   private static final double HYBRID_SOLVER_TOLERANCE = 1.0e-10;
 
+  /** Maximum aqueous-chemistry / phase-equilibrium outer iterations. */
+  private static final int MAXIMUM_REACTIVE_ITERATIONS = 100;
+
+  /** Minimum outer iterations used to certify a coupled reactive state. */
+  private static final int MINIMUM_REACTIVE_ITERATIONS = 3;
+
+  /** Sum of aqueous mole-fraction changes accepted for chemical-equilibrium convergence. */
+  private static final double REACTIVE_COMPOSITION_TOLERANCE = 1.0e-10;
+
+  /** Positive floor for trace species after conservative reaction-delta projection. */
+  private static final double MINIMUM_COUPLED_COMPONENT_MOLES = 1.0e-45;
+
+  /** Reaction-adjusted overall component fractions used by the coupled phase solve. */
+  private transient double[] coupledOverallFractions;
+
+  /** Exact reaction-adjusted overall component mole inventory. */
+  private transient double[] coupledOverallMoles;
+
   /**
    * Create a hybrid multiphase flash.
    *
@@ -52,6 +71,50 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     hybridModel.prepareHybridEosGeFlash();
     system.init(1);
     double residual = Double.POSITIVE_INFINITY;
+    double chemicalDeviation = system.isChemicalSystem() ? Double.POSITIVE_INFINITY : 0.0;
+    boolean coupledConverged = !system.isChemicalSystem();
+    int maximumOuterIterations = system.isChemicalSystem() ? MAXIMUM_REACTIVE_ITERATIONS : 1;
+
+    if (system.isChemicalSystem()) {
+      // Establish a feed-balanced phase split before chemistry sees the role-specific seed compositions.
+      residual = solveFixedTopologyPhaseEquilibrium();
+    }
+    for (int outerIteration = 0; outerIteration < maximumOuterIterations; outerIteration++) {
+      if (system.isChemicalSystem()) {
+        chemicalDeviation = solveAqueousChemicalEquilibrium(outerIteration == 0);
+      }
+      residual = solveFixedTopologyPhaseEquilibrium();
+      if (!system.isChemicalSystem()) {
+        coupledConverged = true;
+        break;
+      }
+      coupledConverged = outerIteration + 1 >= MINIMUM_REACTIVE_ITERATIONS
+          && chemicalDeviation <= REACTIVE_COMPOSITION_TOLERANCE && Double.isFinite(residual)
+          && residual <= HYBRID_SOLVER_TOLERANCE;
+      if (coupledConverged) {
+        break;
+      }
+    }
+
+    if (!coupledConverged) {
+      throw new IllegalStateException("Reactive hybrid EOS-GE TPflash did not converge: chemicalDeviation="
+          + chemicalDeviation + ", solverResidual=" + residual + ", "
+          + hybridModel.getHybridEosGeFlashDiagnostics(phaseFractionMinimumLimit));
+    }
+
+    if (!hybridModel.finishHybridEosGeFlash(phaseFractionMinimumLimit)) {
+      throw new IllegalStateException("Hybrid EOS-GE TPflash did not produce an acceptable state: "
+          + hybridModel.getHybridEosGeFlashDiagnostics(phaseFractionMinimumLimit) + ", solverResidual=" + residual);
+    }
+  }
+
+  /**
+   * Solve the fixed gas-oil-aqueous phase topology at the current chemical composition.
+   *
+   * @return final fugacity-objective residual
+   */
+  private double solveFixedTopologyPhaseEquilibrium() {
+    double residual = Double.POSITIVE_INFINITY;
     for (int iteration = 0; iteration < MAXIMUM_HYBRID_ITERATIONS; iteration++) {
       setDoubleArrays();
       checkOneRemove = false;
@@ -63,11 +126,164 @@ public class TPHybridEosGeFlash extends TPmultiflash {
         break;
       }
     }
+    return residual;
+  }
 
-    if (!hybridModel.finishHybridEosGeFlash(phaseFractionMinimumLimit)) {
-      throw new IllegalStateException("Hybrid EOS-GE TPflash did not produce an acceptable state: "
-          + hybridModel.getHybridEosGeFlashDiagnostics(phaseFractionMinimumLimit) + ", solverResidual=" + residual);
+  /**
+   * Re-equilibrate reactions in the model-owned aqueous phase and measure the composition update.
+   *
+   * @param initialise whether to request the linear-programming initial estimate before Newton refinement
+   * @return sum of absolute aqueous mole-fraction changes
+   */
+  private double solveAqueousChemicalEquilibrium(boolean initialise) {
+    int aqueousPhaseNumber = getHybridAqueousPhaseNumber();
+    if (aqueousPhaseNumber < 0) {
+      throw new IllegalStateException("Reactive hybrid EOS-GE flash requires an active aqueous phase.");
     }
+
+    system.init(1);
+    int numberOfComponents = system.getPhase(aqueousPhaseNumber).getNumberOfComponents();
+    double[] oldComposition = new double[numberOfComponents];
+    double[] oldAqueousMoles = new double[numberOfComponents];
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      oldComposition[componentIndex] = system.getPhase(aqueousPhaseNumber).getComponent(componentIndex).getx();
+      oldAqueousMoles[componentIndex] = system.getPhase(aqueousPhaseNumber).getComponent(componentIndex)
+          .getNumberOfMolesInPhase();
+    }
+    if (initialise) {
+      system.getChemicalReactionOperations().solveChemEq(aqueousPhaseNumber, 0);
+    }
+    system.getChemicalReactionOperations().solveChemEq(aqueousPhaseNumber, 1);
+    hybridModel.restoreHybridEosGeActivePhaseTypes();
+    updateCoupledOverallComposition(aqueousPhaseNumber, oldAqueousMoles);
+    system.init(1);
+
+    double chemicalDeviation = 0.0;
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      double moleFraction = system.getPhase(aqueousPhaseNumber).getComponent(componentIndex).getx();
+      if (!Double.isFinite(moleFraction) || moleFraction < 0.0) {
+        return Double.POSITIVE_INFINITY;
+      }
+      chemicalDeviation += Math.abs(oldComposition[componentIndex] - moleFraction);
+    }
+    return chemicalDeviation;
+  }
+
+  /**
+   * Find the active phase number mapped to the model-owned GE aqueous object.
+   *
+   * @return active aqueous phase number, or {@code -1} if no aqueous role is active
+   */
+  private int getHybridAqueousPhaseNumber() {
+    for (int phaseNumber = 0; phaseNumber < system.getNumberOfPhases(); phaseNumber++) {
+      if (hybridModel.isHybridEosGeAqueousPhase(phaseNumber)) {
+        return phaseNumber;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Capture the reaction-adjusted species inventory before the next interphase-equilibrium solve.
+   *
+   * <p>
+   * Chemical reactions conserve elements but change species amounts. The ordinary overall {@code z} values retain the
+   * feed species inventory, so using them here would remove bicarbonate, carbonate and other generated species during
+   * the next beta/composition update. The coupled inventory starts from the exact overall species amounts and applies
+   * only the mole changes produced by aqueous chemistry. It deliberately does not reconstruct the inventory from the
+   * latest phase split, because repeating that operation would accumulate the phase solver's finite material-balance
+   * residual. Synchronizing the exact inventory and its total preserves elements and charge while allowing reactions to
+   * change the total number of species moles.
+   * </p>
+   *
+   * @param aqueousPhaseNumber active aqueous phase number
+   * @param oldAqueousMoles aqueous component amounts before chemical equilibrium
+   */
+  private void updateCoupledOverallComposition(int aqueousPhaseNumber, double[] oldAqueousMoles) {
+    int numberOfComponents = system.getPhase(0).getNumberOfComponents();
+    if (coupledOverallMoles == null || coupledOverallMoles.length != numberOfComponents) {
+      coupledOverallMoles = new double[numberOfComponents];
+      for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+        coupledOverallMoles[componentIndex] = system.getPhase(0).getComponent(componentIndex).getNumberOfmoles();
+      }
+    }
+
+    double[] reactionDeltas = getConservativeReactionDeltas(aqueousPhaseNumber, oldAqueousMoles);
+    coupledOverallFractions = new double[numberOfComponents];
+    double totalMoles = 0.0;
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      coupledOverallMoles[componentIndex] += reactionDeltas[componentIndex];
+      if (!Double.isFinite(coupledOverallMoles[componentIndex]) || coupledOverallMoles[componentIndex] < -1.0e-9) {
+        coupledOverallFractions = null;
+        throw new IllegalStateException("Aqueous chemical equilibrium produced an invalid overall amount for component "
+            + system.getPhase(0).getComponent(componentIndex).getComponentName() + ": "
+            + coupledOverallMoles[componentIndex]);
+      }
+      coupledOverallMoles[componentIndex] = Math.max(MINIMUM_COUPLED_COMPONENT_MOLES,
+          coupledOverallMoles[componentIndex]);
+      totalMoles += coupledOverallMoles[componentIndex];
+    }
+
+    if (!(totalMoles > 0.0) || !Double.isFinite(totalMoles)) {
+      coupledOverallFractions = null;
+      return;
+    }
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      coupledOverallFractions[componentIndex] = coupledOverallMoles[componentIndex] / totalMoles;
+    }
+    hybridModel.synchronizeHybridEosGeOverallComposition(coupledOverallMoles, totalMoles);
+    system.initBeta();
+    system.normalizeBeta();
+  }
+
+  /**
+   * Project the aqueous reaction update onto the stoichiometric conservation null space.
+   *
+   * <p>
+   * The chemical solver is iterative, so its raw mole update can contain a small component normal to the element and
+   * charge constraints. Reusing that update in an outer phase/chemistry loop would accumulate the residual. The
+   * projection {@code delta - A+ A delta} retains only reaction directions satisfying {@code A delta = 0}.
+   * </p>
+   *
+   * @param aqueousPhaseNumber active aqueous phase number
+   * @param oldAqueousMoles aqueous component amounts before chemical equilibrium
+   * @return conservative overall component mole changes
+   */
+  private double[] getConservativeReactionDeltas(int aqueousPhaseNumber, double[] oldAqueousMoles) {
+    ComponentInterface[] reactiveComponents = system.getChemicalReactionOperations().getComponents();
+    double[][] conservationArray = system.getChemicalReactionOperations().getAmatrix();
+    double[] reactionDeltas = new double[system.getPhase(0).getNumberOfComponents()];
+    if (reactiveComponents == null || reactiveComponents.length == 0 || conservationArray == null
+        || conservationArray.length == 0) {
+      return reactionDeltas;
+    }
+
+    SimpleMatrix rawDelta = new SimpleMatrix(reactiveComponents.length, 1);
+    for (int reactiveIndex = 0; reactiveIndex < reactiveComponents.length; reactiveIndex++) {
+      int componentIndex = reactiveComponents[reactiveIndex].getComponentNumber();
+      double newMoles = system.getPhase(aqueousPhaseNumber).getComponent(componentIndex).getNumberOfMolesInPhase();
+      rawDelta.set(reactiveIndex, 0, newMoles - oldAqueousMoles[componentIndex]);
+    }
+    SimpleMatrix conservationMatrix = new SimpleMatrix(conservationArray);
+    SimpleMatrix conservativeDelta = rawDelta
+        .minus(conservationMatrix.pseudoInverse().mult(conservationMatrix).mult(rawDelta));
+    for (int reactiveIndex = 0; reactiveIndex < reactiveComponents.length; reactiveIndex++) {
+      reactionDeltas[reactiveComponents[reactiveIndex].getComponentNumber()] = conservativeDelta.get(reactiveIndex, 0);
+    }
+    return reactionDeltas;
+  }
+
+  /**
+   * Return the current overall species fraction used by the phase-equilibrium equations.
+   *
+   * @param componentIndex component index
+   * @return reaction-adjusted fraction for reactive systems, otherwise the feed fraction
+   */
+  private double getCoupledOverallFraction(int componentIndex) {
+    if (coupledOverallFractions != null && componentIndex >= 0 && componentIndex < coupledOverallFractions.length) {
+      return coupledOverallFractions[componentIndex];
+    }
+    return system.getPhase(0).getComponent(componentIndex).getz();
   }
 
   /** {@inheritDoc} */
@@ -90,9 +306,9 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   public double calcQ() {
     calcE();
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
-      multTerm[componentIndex] = system.getPhase(0).getComponent(componentIndex).getz() / Erow[componentIndex];
-      multTerm2[componentIndex] = system.getPhase(0).getComponent(componentIndex).getz()
-          / (Erow[componentIndex] * Erow[componentIndex]);
+      double overallFraction = getCoupledOverallFraction(componentIndex);
+      multTerm[componentIndex] = overallFraction / Erow[componentIndex];
+      multTerm2[componentIndex] = overallFraction / (Erow[componentIndex] * Erow[componentIndex]);
     }
 
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
@@ -124,11 +340,14 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       boolean aqueous = hybridModel.isHybridEosGeAqueousPhase(phaseIndex);
       double phaseFraction = Math.max(system.getPhase(phaseIndex).getBeta(), phaseFractionMinimumLimit);
+      double ionFractionSum = 0.0;
+      double neutralFractionSum = 0.0;
       for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
         ComponentInterface referenceComponent = system.getPhase(0).getComponent(componentIndex);
-        double feedFraction = referenceComponent.getz();
+        double feedFraction = getCoupledOverallFraction(componentIndex);
         double newMoleFraction;
-        if (referenceComponent.getIonicCharge() != 0 || referenceComponent.isIsIon()) {
+        boolean ion = referenceComponent.getIonicCharge() != 0 || referenceComponent.isIsIon();
+        if (ion) {
           newMoleFraction = aqueous ? feedFraction / phaseFraction : 1.0e-50;
         } else {
           newMoleFraction = feedFraction / Erow[componentIndex]
@@ -138,8 +357,29 @@ public class TPHybridEosGeFlash extends TPmultiflash {
           newMoleFraction = 1.0e-50;
         }
         system.getPhase(phaseIndex).getComponent(componentIndex).setx(newMoleFraction);
+        if (ion) {
+          ionFractionSum += newMoleFraction;
+        } else {
+          neutralFractionSum += newMoleFraction;
+        }
       }
-      system.getPhase(phaseIndex).normalize();
+      if (aqueous) {
+        if (!(ionFractionSum < 1.0) || !(neutralFractionSum > 0.0)) {
+          throw new IllegalStateException(
+              "Hybrid EOS-GE aqueous composition cannot accommodate overall ion amount: " + "ionFractionSum="
+                  + ionFractionSum + ", neutralFractionSum=" + neutralFractionSum + ", phaseFraction=" + phaseFraction);
+        }
+        double neutralScale = (1.0 - ionFractionSum) / neutralFractionSum;
+        for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+          ComponentInterface referenceComponent = system.getPhase(0).getComponent(componentIndex);
+          if (referenceComponent.getIonicCharge() == 0 && !referenceComponent.isIsIon()) {
+            ComponentInterface aqueousComponent = system.getPhase(phaseIndex).getComponent(componentIndex);
+            aqueousComponent.setx(aqueousComponent.getx() * neutralScale);
+          }
+        }
+      } else {
+        system.getPhase(phaseIndex).normalize();
+      }
     }
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -1,0 +1,167 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static neqsim.thermo.ThermodynamicModelSettings.phaseFractionMinimumLimit;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.system.HybridEosGeFlashModel;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Dedicated multiphase strategy for EOS-gas, EOS-oil and GE-aqueous phase topologies.
+ *
+ * <p>
+ * The strategy reuses the general multiphase fugacity and phase-fraction equations, but starts from model-owned fixed
+ * creation-order roles and disables phase-discovery logic that can replace those roles with clones of the wrong phase
+ * implementation. Phase disappearance only changes the active {@code phaseIndex} mapping; a later flash restores the
+ * original gas, oil and aqueous objects through {@link HybridEosGeFlashModel#prepareHybridEosGeFlash()}.
+ * </p>
+ *
+ * @author NeqSim
+ */
+public class TPHybridEosGeFlash extends TPmultiflash {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000;
+
+  /** Model that owns phase roles and final acceptance. */
+  private final HybridEosGeFlashModel hybridModel;
+
+  /** Maximum fixed-topology outer iterations. */
+  private static final int MAXIMUM_HYBRID_ITERATIONS = 50;
+
+  /** Fugacity-objective residual used to terminate the fixed-topology solve. */
+  private static final double HYBRID_SOLVER_TOLERANCE = 1.0e-10;
+
+  /**
+   * Create a hybrid multiphase flash.
+   *
+   * @param system thermodynamic system to solve
+   * @param hybridModel model owning the creation-order role contract
+   */
+  public TPHybridEosGeFlash(SystemInterface system, HybridEosGeFlashModel hybridModel) {
+    super(system, false);
+    this.hybridModel = hybridModel;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run() {
+    if (system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()) {
+      throw new UnsupportedOperationException(
+          "Hybrid EOS-GE TPflash currently supports fluid phases only; disable solid and wax checks.");
+    }
+
+    hybridModel.prepareHybridEosGeFlash();
+    system.init(1);
+    double residual = Double.POSITIVE_INFINITY;
+    for (int iteration = 0; iteration < MAXIMUM_HYBRID_ITERATIONS; iteration++) {
+      setDoubleArrays();
+      checkOneRemove = false;
+      removePhase = false;
+      residual = solveBeta();
+      hybridModel.restoreHybridEosGeActivePhaseTypes();
+      system.init(1);
+      if (Double.isFinite(residual) && residual <= HYBRID_SOLVER_TOLERANCE && iteration >= 4) {
+        break;
+      }
+    }
+
+    if (!hybridModel.finishHybridEosGeFlash(phaseFractionMinimumLimit)) {
+      throw new IllegalStateException("Hybrid EOS-GE TPflash did not produce an acceptable state: "
+          + hybridModel.getHybridEosGeFlashDiagnostics(phaseFractionMinimumLimit) + ", solverResidual=" + residual);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void calcE() {
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      Erow[componentIndex] = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        Erow[componentIndex] += system.getPhase(phaseIndex).getBeta()
+            * inverseFugacityCoefficient(phaseIndex, componentIndex);
+      }
+      if (!Double.isFinite(Erow[componentIndex]) || Erow[componentIndex] < 1.0e-100) {
+        Erow[componentIndex] = 1.0e-100;
+      }
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double calcQ() {
+    calcE();
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      multTerm[componentIndex] = system.getPhase(0).getComponent(componentIndex).getz() / Erow[componentIndex];
+      multTerm2[componentIndex] = system.getPhase(0).getComponent(componentIndex).getz()
+          / (Erow[componentIndex] * Erow[componentIndex]);
+    }
+
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      dQdbeta[phaseIndex][0] = 1.0;
+      for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+        dQdbeta[phaseIndex][0] -= multTerm[componentIndex] * inverseFugacityCoefficient(phaseIndex, componentIndex);
+      }
+    }
+
+    for (int rowPhase = 0; rowPhase < system.getNumberOfPhases(); rowPhase++) {
+      for (int columnPhase = 0; columnPhase < system.getNumberOfPhases(); columnPhase++) {
+        Qmatrix[rowPhase][columnPhase] = 0.0;
+        for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+          Qmatrix[rowPhase][columnPhase] += multTerm2[componentIndex]
+              * inverseFugacityCoefficient(rowPhase, componentIndex)
+              * inverseFugacityCoefficient(columnPhase, componentIndex);
+        }
+        if (rowPhase == columnPhase) {
+          Qmatrix[rowPhase][columnPhase] += 1.0e-10;
+        }
+      }
+    }
+    return Q;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setXY() {
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      boolean aqueous = hybridModel.isHybridEosGeAqueousPhase(phaseIndex);
+      double phaseFraction = Math.max(system.getPhase(phaseIndex).getBeta(), phaseFractionMinimumLimit);
+      for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+        ComponentInterface referenceComponent = system.getPhase(0).getComponent(componentIndex);
+        double feedFraction = referenceComponent.getz();
+        double newMoleFraction;
+        if (referenceComponent.getIonicCharge() != 0 || referenceComponent.isIsIon()) {
+          newMoleFraction = aqueous ? feedFraction / phaseFraction : 1.0e-50;
+        } else {
+          newMoleFraction = feedFraction / Erow[componentIndex]
+              * inverseFugacityCoefficient(phaseIndex, componentIndex);
+        }
+        if (!Double.isFinite(newMoleFraction) || newMoleFraction <= 0.0) {
+          newMoleFraction = 1.0e-50;
+        }
+        system.getPhase(phaseIndex).getComponent(componentIndex).setx(newMoleFraction);
+      }
+      system.getPhase(phaseIndex).normalize();
+    }
+  }
+
+  /**
+   * Return an allowed phase's inverse fugacity coefficient. Ions are excluded from EOS gas and oil phases exactly
+   * instead of relying on a large finite penalty.
+   *
+   * @param phaseIndex active phase index
+   * @param componentIndex component index
+   * @return inverse fugacity coefficient, or zero when the component is excluded from the phase
+   */
+  private double inverseFugacityCoefficient(int phaseIndex, int componentIndex) {
+    ComponentInterface referenceComponent = system.getPhase(0).getComponent(componentIndex);
+    if ((referenceComponent.getIonicCharge() != 0 || referenceComponent.isIsIon())
+        && !hybridModel.isHybridEosGeAqueousPhase(phaseIndex)) {
+      return 0.0;
+    }
+    double fugacityCoefficient = system.getPhase(phaseIndex).getComponent(componentIndex).getFugacityCoefficient();
+    if (!(fugacityCoefficient > 0.0) || !Double.isFinite(fugacityCoefficient)) {
+      return 0.0;
+    }
+    return 1.0 / fugacityCoefficient;
+  }
+
+}

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.Logger;
 import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.EosGeFlashModel;
+import neqsim.thermo.system.HybridEosGeFlashModel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.exception.IsNaNException;
@@ -139,6 +140,8 @@ public class TPflash extends Flash {
   private transient double[] accelerationK;
   /** Opt-in direct gamma-phi strategy, resolved once because a flash operation keeps one system. */
   private final EosGeFlashModel directGammaPhiModel;
+  /** Opt-in hybrid multiphase strategy, resolved once because a flash operation keeps one system. */
+  private final HybridEosGeFlashModel hybridEosGeFlashModel;
 
   /** Compact two-phase rollback snapshot used by bounded neutral endpoint refinements. */
   private static final class BalancedTwoPhaseState {
@@ -171,6 +174,7 @@ public class TPflash extends Flash {
    */
   public TPflash() {
     directGammaPhiModel = null;
+    hybridEosGeFlashModel = null;
   }
 
   /**
@@ -180,7 +184,10 @@ public class TPflash extends Flash {
    */
   public TPflash(SystemInterface system) {
     this.system = system;
-    directGammaPhiModel = resolveDirectGammaPhiModel(system);
+    EosGeFlashModel eosGeModel = resolveEosGeFlashModel(system);
+    directGammaPhiModel = eosGeModel != null && eosGeModel.requiresDirectGammaPhiFlash() ? eosGeModel : null;
+    hybridEosGeFlashModel = eosGeModel instanceof HybridEosGeFlashModel
+        && ((HybridEosGeFlashModel) eosGeModel).requiresHybridEosGeFlash() ? (HybridEosGeFlashModel) eosGeModel : null;
     lnOldOldOldK = new double[system.getPhases()[0].getNumberOfComponents()];
     lnOldOldK = new double[system.getPhases()[0].getNumberOfComponents()];
     lnOldK = new double[system.getPhases()[0].getNumberOfComponents()];
@@ -211,13 +218,22 @@ public class TPflash extends Flash {
   }
 
   /**
+   * Get the opt-in hybrid multiphase strategy for the active system.
+   *
+   * @return hybrid EOS-GE strategy, or {@code null} for the ordinary TP-flash path
+   */
+  private HybridEosGeFlashModel getHybridEosGeFlashModel() {
+    return hybridEosGeFlashModel;
+  }
+
+  /**
    * Resolve the opt-in direct gamma-phi strategy once when the flash operation is created.
    *
    * @param flashSystem thermodynamic system owned by the operation
    * @return direct EOS-GE strategy, or {@code null} for an ordinary EOS system
    */
-  private static EosGeFlashModel resolveDirectGammaPhiModel(SystemInterface flashSystem) {
-    if (flashSystem instanceof EosGeFlashModel && ((EosGeFlashModel) flashSystem).requiresDirectGammaPhiFlash()) {
+  private static EosGeFlashModel resolveEosGeFlashModel(SystemInterface flashSystem) {
+    if (flashSystem instanceof EosGeFlashModel) {
       return (EosGeFlashModel) flashSystem;
     }
     return null;
@@ -593,6 +609,12 @@ public class TPflash extends Flash {
   private void runInternal() {
     resetStabilityDiagnostics();
     waterBearingRescueAttempted = false;
+    HybridEosGeFlashModel hybridModel = getHybridEosGeFlashModel();
+    if (hybridModel != null) {
+      system.init(0);
+      new TPHybridEosGeFlash(system, hybridModel).run();
+      return;
+    }
     EosGeFlashModel gammaPhiModel = getDirectGammaPhiModel();
     if (gammaPhiModel != null && (solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck())) {
       throw new UnsupportedOperationException(

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -85,6 +85,7 @@ import neqsim.pvtsimulation.flowassurance.HydrateRiskMapper;
 import neqsim.pvtsimulation.flowassurance.ScaleMassCalculator;
 import neqsim.pvtsimulation.flowassurance.ScalePredictionCalculator;
 import neqsim.pvtsimulation.flowassurance.WaterCompatibilityScreener;
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.FluidBuilder;
 import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
 import neqsim.thermo.system.SystemInterface;
@@ -100,6 +101,26 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @version 1.0
  */
 public class DocExamplesCompilationTest {
+
+  /** Pitzer hybrid VLLE example from docs/thermo/fluid_creation_guide.md. */
+  @Test
+  public void testPitzerHybridVlleFluidCreationGuide() {
+    SystemPitzer fluid = new SystemPitzer(313.15, 50.0);
+    fluid.addComponent("methane", 5.0);
+    fluid.addComponent("n-heptane", 2.0);
+    fluid.addComponent("water", 55.5);
+    fluid.addComponent("Na+", 1.0);
+    fluid.addComponent("Cl-", 1.0);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    new ThermodynamicOperations(fluid).TPflash();
+
+    boolean hasAqueousPhase = fluid.hasPhaseType(PhaseType.AQUEOUS);
+    assertTrue(hasAqueousPhase);
+    assertTrue(fluid.hasPhaseType(PhaseType.GAS));
+    assertTrue(fluid.hasPhaseType(PhaseType.OIL));
+  }
 
   /**
    * Transient gas-network example from docs/process/gas_network_operations.md.

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -728,17 +728,27 @@ public class DocExamplesCompilationTest {
     String[][] table = ops.getResultTable();
     assertTrue(table.length > 1);
 
-    SystemInterface pitzer = new SystemPitzer(273.15 + 80.0, 100.0);
-    pitzer.addComponent("water", 0.90);
-    pitzer.addComponent("Na+", 0.03);
-    pitzer.addComponent("Cl-", 0.035);
-    pitzer.addComponent("Ca++", 0.005);
-    pitzer.addComponent("SO4--", 0.002);
+    SystemInterface pitzer = new SystemPitzer(313.15, 50.0);
+    pitzer.addComponent("methane", 5.0);
+    pitzer.addComponent("CO2", 0.05);
+    pitzer.addComponent("n-heptane", 2.0);
+    pitzer.addComponent("water", 55.5);
+    pitzer.addComponent("Ca++", 1.0e-4);
+    pitzer.addComponent("Na+", 1.0e-3);
+    pitzer.addComponent("Cl-", 2.0e-4);
+    pitzer.addComponent("HCO3-", 1.0e-3);
+    pitzer.chemicalReactionInit();
+    pitzer.createDatabase(true);
     pitzer.setMixingRule("classic");
+    pitzer.setMultiPhaseCheck(true);
     ThermodynamicOperations pitzerOps = new ThermodynamicOperations(pitzer);
     pitzerOps.TPflash();
     pitzer.initProperties();
-    assertTrue(pitzer.getNumberOfPhases() >= 1);
+    double calciteScalePotential = pitzerOps.getRelativeScalePotential("CaCO3");
+    assertTrue(pitzer.hasPhaseType("gas"));
+    assertTrue(pitzer.hasPhaseType("oil"));
+    assertTrue(pitzer.hasPhaseType("aqueous"));
+    assertTrue(Double.isFinite(calciteScalePotential) && calciteScalePotential > 0.0);
 
     WaterCompatibilityScreener screener = new WaterCompatibilityScreener();
     screener.setFormationWater(400, 200, 50, 2, 150, 10, 50000, 90, 200, 3.0, 6.2);

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -87,8 +87,10 @@ import neqsim.pvtsimulation.flowassurance.ScalePredictionCalculator;
 import neqsim.pvtsimulation.flowassurance.WaterCompatibilityScreener;
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.FluidBuilder;
+import neqsim.thermo.system.SystemDesmukhMather;
 import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemNRTL;
 import neqsim.thermo.system.SystemPitzer;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -120,6 +122,49 @@ public class DocExamplesCompilationTest {
     assertTrue(hasAqueousPhase);
     assertTrue(fluid.hasPhaseType(PhaseType.GAS));
     assertTrue(fluid.hasPhaseType(PhaseType.OIL));
+  }
+
+  /** Generic SystemEosGE opt-in example from docs/thermo/fluid_creation_guide.md. */
+  @Test
+  public void testGenericEosGeHybridVlleFluidCreationGuide() {
+    SystemNRTL fluid = new SystemNRTL(313.15, 50.0);
+    fluid.addComponent("methane", 5.0);
+    fluid.addComponent("n-heptane", 2.0);
+    fluid.addComponent("water", 55.5);
+    fluid.createDatabase(true);
+    fluid.setMixingRule("classic");
+    fluid.enableHybridEosGeFlash();
+
+    new ThermodynamicOperations(fluid).TPflash();
+
+    assertTrue(fluid.hasPhaseType(PhaseType.GAS));
+    assertTrue(fluid.hasPhaseType(PhaseType.OIL));
+    assertTrue(fluid.hasPhaseType(PhaseType.AQUEOUS));
+  }
+
+  /** Desmukh-Mather reactive hybrid example from docs/pvtsimulation/scale_prediction_api.md. */
+  @Test
+  public void testDesmukhMatherReactiveHybridScalePrediction() throws Exception {
+    SystemDesmukhMather fluid = new SystemDesmukhMather(313.15, 5.0);
+    fluid.addComponent("methane", 5.0);
+    fluid.addComponent("CO2", 0.2);
+    fluid.addComponent("n-heptane", 2.0);
+    fluid.addComponent("MDEA", 1.0);
+    fluid.addComponent("water", 9.0);
+    fluid.addComponent("Ca++", 1.0e-4);
+    fluid.addComponent("Na+", 1.0e-3);
+    fluid.addComponent("Cl-", 2.0e-4);
+    fluid.addComponent("HCO3-", 1.0e-3);
+    fluid.chemicalReactionInit();
+    fluid.createDatabase(true);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+    double calciteSaturationRatio = operations.getRelativeScalePotential("CaCO3");
+
+    assertTrue(Double.isFinite(calciteSaturationRatio) && calciteSaturationRatio > 0.0);
   }
 
   /**

--- a/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
@@ -1,0 +1,337 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseEos;
+import neqsim.thermo.phase.PhaseGEInterface;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.phase.PhasePitzer;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Regression tests for fixed-role EOS-gas / EOS-oil / GE-aqueous flashes. */
+class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
+  /** Material-balance tolerance used by the public hybrid acceptance contract. */
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-7;
+
+  /** Cross-phase logarithmic fugacity tolerance used by the public hybrid acceptance contract. */
+  private static final double LOG_FUGACITY_TOLERANCE = 1.0e-5;
+
+  /** Phase fraction below which a role is considered absent. */
+  private static final double MATERIAL_PHASE_FRACTION = 1.0e-10;
+
+  /**
+   * Build the synthetic hydrocarbon/brine system from issue 2862.
+   *
+   * @return configured unflashed system
+   */
+  private SystemPitzer createGasOilAqueousSystem() {
+    SystemPitzer system = new SystemPitzer(313.15, 50.0);
+    system.addComponent("methane", 5.0);
+    system.addComponent("n-heptane", 2.0);
+    system.addComponent("water", 55.5);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Cl-", 1.0);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    return system;
+  }
+
+  /** Gas, oil and electrolyte-GE aqueous phases satisfy topology, balance and fugacity acceptance. */
+  @Test
+  void gasOilAqueousFlashMeetsAcceptanceContract() {
+    SystemPitzer system = createGasOilAqueousSystem();
+    new ThermodynamicOperations(system).TPflash();
+
+    assertEquals(3, system.getNumberOfPhases());
+    assertTrue(system.getEquationOfStatePhase() instanceof PhaseEos);
+    assertTrue(system.getEosOilPhase() instanceof PhaseEos);
+    assertTrue(system.getGeLiquidPhase() instanceof PhasePitzer);
+    assertTrue(system.getGeLiquidPhase() instanceof PhaseGEInterface);
+    assertEquals(0, system.getEosGasPhaseSlot());
+    assertEquals(2, system.getEosOilPhaseSlot());
+    assertEquals(1, system.getGeLiquidPhaseSlot());
+    assertTrue(hasPhaseType(system, PhaseType.GAS));
+    assertTrue(hasPhaseType(system, PhaseType.OIL));
+    assertTrue(hasPhaseType(system, PhaseType.AQUEOUS));
+
+    assertBalancedAndAtEquilibrium(system);
+    PhaseInterface aqueous = findPhase(system, PhaseType.AQUEOUS);
+    assertTrue(aqueous.getComponent("n-heptane").getFugacityCoefficient() > 1.0e6,
+        "A non-water database solvent must use an aqueous Henry reference in Pitzer");
+    for (int componentIndex = 0; componentIndex < aqueous.getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = aqueous.getComponent(componentIndex);
+      if (component.getIonicCharge() != 0 || component.isIsIon()) {
+        assertTrue(component.getx() > 0.0);
+        for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+          if (system.getPhase(phaseIndex) != aqueous) {
+            assertTrue(system.getPhase(phaseIndex).getComponent(componentIndex).getx() <= 1.0e-40);
+          }
+        }
+      }
+    }
+  }
+
+  /** A trace oil role disappears from the active mapping and the same object is restored on a later flash. */
+  @Test
+  void disappearingOilRoleIsRestoredWithoutReplacement() {
+    SystemPitzer system = new SystemPitzer(313.15, 50.0);
+    system.addComponent("methane", 5.0);
+    system.addComponent("n-heptane", 0.0);
+    system.addComponent("water", 55.5);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Cl-", 1.0);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    PhaseInterface oilRole = system.getEosOilPhase();
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.TPflash();
+    assertEquals(2, system.getNumberOfPhases(), phaseDiagnostics(system));
+    assertFalse(hasPhaseType(system, PhaseType.OIL));
+    assertSame(oilRole, system.getEosOilPhase());
+    assertBalancedAndAtEquilibrium(system);
+
+    system.addComponent("n-heptane", 2.0);
+    operations.TPflash();
+    assertEquals(3, system.getNumberOfPhases());
+    assertTrue(hasPhaseType(system, PhaseType.OIL));
+    assertSame(oilRole, system.getEosOilPhase());
+    assertBalancedAndAtEquilibrium(system);
+  }
+
+  /** Gas-oil and oil-aqueous limits retain only their material creation-order roles. */
+  @Test
+  void twoPhaseRoleCombinationsConverge() {
+    SystemPitzer gasOil = new SystemPitzer(313.15, 50.0);
+    gasOil.addComponent("methane", 5.0);
+    gasOil.addComponent("n-heptane", 2.0);
+    gasOil.addComponent("water", 0.0);
+    gasOil.setMixingRule("classic");
+    gasOil.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(gasOil).TPflash();
+    assertEquals(2, gasOil.getNumberOfPhases(), phaseDiagnostics(gasOil));
+    assertTrue(hasPhaseType(gasOil, PhaseType.GAS));
+    assertTrue(hasPhaseType(gasOil, PhaseType.OIL));
+    assertFalse(hasPhaseType(gasOil, PhaseType.AQUEOUS));
+    assertBalancedAndAtEquilibrium(gasOil);
+
+    SystemPitzer oilAqueous = new SystemPitzer(298.15, 100.0);
+    oilAqueous.addComponent("methane", 0.0);
+    oilAqueous.addComponent("n-heptane", 2.0);
+    oilAqueous.addComponent("water", 55.5);
+    oilAqueous.addComponent("Na+", 1.0);
+    oilAqueous.addComponent("Cl-", 1.0);
+    oilAqueous.setMixingRule("classic");
+    oilAqueous.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(oilAqueous).TPflash();
+    assertEquals(2, oilAqueous.getNumberOfPhases(), phaseDiagnostics(oilAqueous));
+    assertFalse(hasPhaseType(oilAqueous, PhaseType.GAS));
+    assertTrue(hasPhaseType(oilAqueous, PhaseType.OIL));
+    assertTrue(hasPhaseType(oilAqueous, PhaseType.AQUEOUS));
+    assertBalancedAndAtEquilibrium(oilAqueous);
+  }
+
+  /** Nearby water-rich gas-condensate states retain finite balanced hybrid solutions. */
+  @Test
+  void waterRichGasCondensateNearbyStatesConverge() {
+    double[][] conditions = new double[][] { { 303.15, 40.0 }, { 323.15, 60.0 } };
+    for (double[] condition : conditions) {
+      SystemPitzer system = createGasOilAqueousSystem();
+      system.setTemperature(condition[0]);
+      system.setPressure(condition[1]);
+      new ThermodynamicOperations(system).TPflash();
+      assertTrue(system.getNumberOfPhases() >= 2, phaseDiagnostics(system));
+      assertTrue(hasPhaseType(system, PhaseType.AQUEOUS));
+      assertBalancedAndAtEquilibrium(system);
+    }
+  }
+
+  /** Density reordering, cloning and Java serialization preserve creation-order role ownership. */
+  @Test
+  void rolesSurviveReorderingCloneSerializationAndRepeatedFlash() throws Exception {
+    SystemPitzer system = createGasOilAqueousSystem();
+    PhaseInterface gasRole = system.getEquationOfStatePhase();
+    PhaseInterface oilRole = system.getEosOilPhase();
+    PhaseInterface aqueousRole = system.getGeLiquidPhase();
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+
+    operations.TPflash();
+    system.orderByDensity();
+    operations.TPflash();
+    assertSame(gasRole, system.getEquationOfStatePhase());
+    assertSame(oilRole, system.getEosOilPhase());
+    assertSame(aqueousRole, system.getGeLiquidPhase());
+    assertBalancedAndAtEquilibrium(system);
+
+    SystemPitzer clone = system.clone();
+    assertNotSame(gasRole, clone.getEquationOfStatePhase());
+    assertNotSame(oilRole, clone.getEosOilPhase());
+    assertNotSame(aqueousRole, clone.getGeLiquidPhase());
+    new ThermodynamicOperations(clone).TPflash();
+    assertBalancedAndAtEquilibrium(clone);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(system);
+    }
+    SystemPitzer restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (SystemPitzer) input.readObject();
+    }
+    assertEquals(0, restored.getEosGasPhaseSlot());
+    assertEquals(2, restored.getEosOilPhaseSlot());
+    assertEquals(1, restored.getGeLiquidPhaseSlot());
+    new ThermodynamicOperations(restored).TPflash();
+    assertBalancedAndAtEquilibrium(restored);
+  }
+
+  /** PH, PS and TV flashes recover the extensive state of a hybrid electrolyte-GE reference. */
+  @Test
+  void phPsAndTvFlashesRecoverReferenceState() {
+    SystemPitzer reference = createGasOilAqueousSystem();
+    new ThermodynamicOperations(reference).TPflash();
+    reference.initProperties();
+    double targetTemperature = reference.getTemperature();
+    double targetPressure = reference.getPressure();
+    double targetEnthalpy = reference.getEnthalpy();
+    double targetEntropy = reference.getEntropy();
+    double targetVolume = reference.getVolume();
+
+    assertTrue(Double.isFinite(targetEnthalpy));
+    assertTrue(Double.isFinite(targetEntropy));
+    assertTrue(Double.isFinite(targetVolume) && targetVolume > 0.0);
+
+    SystemPitzer phSystem = reference.clone();
+    phSystem.setTemperature(targetTemperature + 2.0);
+    new ThermodynamicOperations(phSystem).PHflash(targetEnthalpy);
+    phSystem.initProperties();
+    assertEquals(targetEnthalpy, phSystem.getEnthalpy(), Math.max(1.0e-6, Math.abs(targetEnthalpy) * 1.0e-5));
+    assertEquals(targetTemperature, phSystem.getTemperature(), 0.1);
+
+    SystemPitzer psSystem = reference.clone();
+    psSystem.setTemperature(targetTemperature + 2.0);
+    new ThermodynamicOperations(psSystem).PSflash(targetEntropy);
+    psSystem.initProperties();
+    assertEquals(targetEntropy, psSystem.getEntropy(), Math.max(1.0e-6, Math.abs(targetEntropy) * 1.0e-5));
+    assertEquals(targetTemperature, psSystem.getTemperature(), 0.1);
+
+    SystemPitzer tvSystem = reference.clone();
+    tvSystem.setPressure(targetPressure * 1.05);
+    new ThermodynamicOperations(tvSystem).TVflash(targetVolume);
+    tvSystem.initProperties();
+    assertEquals(targetVolume, tvSystem.getVolume(), Math.abs(targetVolume) * 1.0e-5);
+    assertEquals(targetPressure, tvSystem.getPressure(), 1.0e-3);
+  }
+
+  /**
+   * Assert normalization, component material balance and neutral-component fugacity equality.
+   *
+   * @param system flashed system
+   */
+  private void assertBalancedAndAtEquilibrium(SystemInterface system) {
+    double betaSum = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      betaSum += system.getBeta(phaseIndex);
+      double compositionSum = 0.0;
+      for (int componentIndex = 0; componentIndex < system.getPhase(phaseIndex)
+          .getNumberOfComponents(); componentIndex++) {
+        ComponentInterface component = system.getPhase(phaseIndex).getComponent(componentIndex);
+        assertTrue(Double.isFinite(component.getx()) && component.getx() > 0.0);
+        compositionSum += component.getx();
+      }
+      assertEquals(1.0, compositionSum, 1.0e-8);
+    }
+    assertEquals(1.0, betaSum, 1.0e-8);
+
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      ComponentInterface referenceComponent = system.getPhase(0).getComponent(componentIndex);
+      double calculatedFeedFraction = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        calculatedFeedFraction += system.getBeta(phaseIndex)
+            * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(referenceComponent.getz(), calculatedFeedFraction, MATERIAL_BALANCE_TOLERANCE,
+          referenceComponent.getComponentName());
+
+      if (referenceComponent.getz() <= 1.0e-30 || referenceComponent.getIonicCharge() != 0
+          || referenceComponent.isIsIon()) {
+        continue;
+      }
+      double referenceLogFugacity = Double.NaN;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        if (system.getBeta(phaseIndex) <= MATERIAL_PHASE_FRACTION) {
+          continue;
+        }
+        ComponentInterface phaseComponent = system.getPhase(phaseIndex).getComponent(componentIndex);
+        double logFugacity = Math.log(phaseComponent.getx() * phaseComponent.getFugacityCoefficient()
+            * system.getPhase(phaseIndex).getPressure());
+        assertTrue(Double.isFinite(logFugacity), referenceComponent.getComponentName());
+        if (Double.isNaN(referenceLogFugacity)) {
+          referenceLogFugacity = logFugacity;
+        } else {
+          assertEquals(referenceLogFugacity, logFugacity, LOG_FUGACITY_TOLERANCE,
+              referenceComponent.getComponentName());
+        }
+      }
+    }
+  }
+
+  /**
+   * Check whether an active phase type is present.
+   *
+   * @param system system to inspect
+   * @param phaseType phase type
+   * @return true when present
+   */
+  private boolean hasPhaseType(SystemInterface system, PhaseType phaseType) {
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex).getType() == phaseType) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Find an active phase by type.
+   *
+   * @param system system to inspect
+   * @param phaseType phase type
+   * @return matching phase
+   */
+  private PhaseInterface findPhase(SystemInterface system, PhaseType phaseType) {
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex).getType() == phaseType) {
+        return system.getPhase(phaseIndex);
+      }
+    }
+    throw new AssertionError("Missing phase type " + phaseType);
+  }
+
+  /**
+   * Format active phase fractions for assertion diagnostics.
+   *
+   * @param system system to inspect
+   * @return phase diagnostics
+   */
+  private String phaseDiagnostics(SystemInterface system) {
+    StringBuilder diagnostics = new StringBuilder();
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (phaseIndex > 0) {
+        diagnostics.append(", ");
+      }
+      diagnostics.append(system.getPhase(phaseIndex).getType()).append('=').append(system.getBeta(phaseIndex));
+    }
+    return diagnostics.toString();
+  }
+}

--- a/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
@@ -107,6 +107,82 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
     }
   }
 
+  /** Every SystemEosGE subclass can explicitly promote its GE liquid to the hybrid aqueous role. */
+  @Test
+  void genericNrtlSystemCanEnableHybridGasOilAqueousFlash() {
+    SystemNRTL system = new SystemNRTL(313.15, 50.0);
+    system.addComponent("methane", 5.0);
+    system.addComponent("n-heptane", 2.0);
+    system.addComponent("water", 55.5);
+    system.createDatabase(true);
+    system.setMixingRule("classic");
+
+    assertFalse(system.isHybridEosGeTopologyConfigured());
+    system.enableHybridEosGeFlash();
+    assertTrue(system.isHybridEosGeTopologyConfigured());
+    assertTrue(system.requiresHybridEosGeFlash());
+
+    new ThermodynamicOperations(system).TPflash();
+
+    assertTrue(system.getEquationOfStatePhase() instanceof PhaseEos);
+    assertTrue(system.getEosOilPhase() instanceof PhaseEos);
+    assertTrue(system.getGeLiquidPhase() instanceof PhaseGEInterface);
+    assertTrue(hasPhaseType(system, PhaseType.GAS));
+    assertTrue(hasPhaseType(system, PhaseType.OIL));
+    assertTrue(hasPhaseType(system, PhaseType.AQUEOUS));
+    assertBalancedAndAtEquilibrium(system);
+  }
+
+  /** Desmukh-Mather is registered as a reactive electrolyte-GE hybrid rather than a Pitzer special case. */
+  @Test
+  void reactiveDesmukhMatherSystemUsesSharedHybridCoupling() throws Exception {
+    SystemDesmukhMather system = new SystemDesmukhMather(313.15, 5.0);
+    system.addComponent("methane", 5.0);
+    system.addComponent("CO2", 0.2);
+    system.addComponent("n-heptane", 2.0);
+    system.addComponent("MDEA", 1.0);
+    system.addComponent("water", 9.0);
+    system.addComponent("Ca++", 1.0e-4);
+    system.addComponent("Na+", 1.0e-3);
+    system.addComponent("Cl-", 2.0e-4);
+    system.addComponent("HCO3-", 1.0e-3);
+    system.chemicalReactionInit();
+    system.createDatabase(true);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    double[] conservedQuantities = getReactiveConservedQuantities(system, true);
+
+    assertTrue(system.isHybridEosGeTopologyConfigured());
+    assertTrue(system.requiresHybridEosGeFlash());
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.TPflash();
+
+    assertTrue(hasPhaseType(system, PhaseType.GAS), phaseDiagnostics(system));
+    assertTrue(hasPhaseType(system, PhaseType.OIL), phaseDiagnostics(system));
+    assertTrue(hasPhaseType(system, PhaseType.AQUEOUS), phaseDiagnostics(system));
+    assertTrue(findPhase(system, PhaseType.AQUEOUS) instanceof neqsim.thermo.phase.PhaseDesmukhMather);
+    assertReactiveConservedQuantities(system, conservedQuantities);
+    double calciteSaturationRatio = operations.getRelativeScalePotential("CaCO3");
+    assertTrue(Double.isFinite(calciteSaturationRatio) && calciteSaturationRatio > 0.0,
+        "Scale potential must use the selected electrolyte-GE model's aqueous activities");
+  }
+
+  /** Built-in electrolyte GE systems expose the same fixed-role contract without Pitzer type checks. */
+  @Test
+  void electrolyteGeSystemsRegisterSharedHybridTopology() {
+    SystemEosGE[] systems = new SystemEosGE[] { new SystemDesmukhMather(313.15, 5.0),
+        new SystemKentEisenberg(313.15, 5.0) };
+    for (SystemEosGE system : systems) {
+      assertTrue(system.isHybridEosGeTopologyConfigured());
+      assertTrue(system.getEquationOfStatePhase() instanceof PhaseEos);
+      assertTrue(system.getEosOilPhase() instanceof PhaseEos);
+      assertTrue(system.getGeLiquidPhase() instanceof PhaseGEInterface);
+      system.setMultiPhaseCheck(true);
+      assertTrue(system.requiresHybridEosGeFlash());
+    }
+  }
+
   /** Reactive gas-aqueous Pitzer flash retains carbonate chemistry and exposes calcite scale potential. */
   @Test
   void reactiveGasAqueousFlashSupportsCalciteScalePotential() throws Exception {
@@ -396,7 +472,7 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
    * @param useTotalComponentMoles whether to read the feed totals instead of summing active phases
    * @return element quantities followed by net ionic charge
    */
-  private double[] getReactiveConservedQuantities(SystemPitzer system, boolean useTotalComponentMoles) {
+  private double[] getReactiveConservedQuantities(SystemInterface system, boolean useTotalComponentMoles) {
     ChemicalReactionOperations reactions = system.getChemicalReactionOperations();
     ComponentInterface[] reactiveComponents = reactions.getComponents();
     double[][] conservationMatrix = reactions.getAmatrix();
@@ -437,7 +513,7 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
    * @param system flashed reactive system
    * @param expectedQuantities element and charge quantities before the flash
    */
-  private void assertReactiveConservedQuantities(SystemPitzer system, double[] expectedQuantities) {
+  private void assertReactiveConservedQuantities(SystemInterface system, double[] expectedQuantities) {
     double[] actualQuantities = getReactiveConservedQuantities(system, false);
     assertEquals(expectedQuantities.length, actualQuantities.length);
     for (int quantityIndex = 0; quantityIndex < expectedQuantities.length; quantityIndex++) {
@@ -505,7 +581,9 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
       if (phaseIndex > 0) {
         diagnostics.append(", ");
       }
-      diagnostics.append(system.getPhase(phaseIndex).getType()).append('=').append(system.getBeta(phaseIndex));
+      diagnostics.append(system.getPhase(phaseIndex).getType()).append('[').append(system.getPhaseIndex(phaseIndex))
+          .append(':').append(system.getPhase(phaseIndex).getClass().getSimpleName()).append("]=")
+          .append(system.getBeta(phaseIndex));
     }
     return diagnostics.toString();
   }

--- a/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.Test;
+import neqsim.chemicalreactions.ChemicalReactionOperations;
 import neqsim.thermo.component.ComponentInterface;
 import neqsim.thermo.phase.PhaseEos;
 import neqsim.thermo.phase.PhaseGEInterface;
@@ -41,6 +42,31 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
     system.addComponent("water", 55.5);
     system.addComponent("Na+", 1.0);
     system.addComponent("Cl-", 1.0);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    return system;
+  }
+
+  /**
+   * Build a reactive carbonate-scale system with optional EOS oil.
+   *
+   * @param includeOil whether to add an oil-forming hydrocarbon
+   * @return configured unflashed reactive Pitzer system
+   */
+  private SystemPitzer createReactiveScaleSystem(boolean includeOil) {
+    SystemPitzer system = new SystemPitzer(313.15, 50.0);
+    system.addComponent("methane", 5.0);
+    system.addComponent("CO2", 0.05);
+    if (includeOil) {
+      system.addComponent("n-heptane", 2.0);
+    }
+    system.addComponent("water", 55.5);
+    system.addComponent("Ca++", 1.0e-4);
+    system.addComponent("Na+", 1.0e-3);
+    system.addComponent("Cl-", 2.0e-4);
+    system.addComponent("HCO3-", 1.0e-3);
+    system.chemicalReactionInit();
+    system.createDatabase(true);
     system.setMixingRule("classic");
     system.setMultiPhaseCheck(true);
     return system;
@@ -79,6 +105,48 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
         }
       }
     }
+  }
+
+  /** Reactive gas-aqueous Pitzer flash retains carbonate chemistry and exposes calcite scale potential. */
+  @Test
+  void reactiveGasAqueousFlashSupportsCalciteScalePotential() throws Exception {
+    SystemPitzer system = createReactiveScaleSystem(false);
+    double[] conservedQuantities = getReactiveConservedQuantities(system, true);
+    double initialCarbonateMoles = system.getPhase(0).getComponent("CO3--").getNumberOfmoles();
+    assertTrue(system.requiresHybridEosGeFlash(), "Reactive Pitzer systems must select the fixed-role hybrid strategy");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.TPflash();
+
+    assertEquals(2, system.getNumberOfPhases(), phaseDiagnostics(system));
+    assertTrue(hasPhaseType(system, PhaseType.GAS));
+    assertFalse(hasPhaseType(system, PhaseType.OIL));
+    assertTrue(hasPhaseType(system, PhaseType.AQUEOUS));
+    assertReactiveCarbonateScaleResult(system, operations, conservedQuantities, initialCarbonateMoles);
+  }
+
+  /** Reactive gas-oil-aqueous Pitzer flash retains all roles and exposes calcite scale potential. */
+  @Test
+  void reactiveGasOilAqueousFlashSupportsCalciteScalePotential() throws Exception {
+    SystemPitzer system = createReactiveScaleSystem(true);
+    double[] conservedQuantities = getReactiveConservedQuantities(system, true);
+    double initialCarbonateMoles = system.getPhase(0).getComponent("CO3--").getNumberOfmoles();
+    PhaseInterface gasRole = system.getEquationOfStatePhase();
+    PhaseInterface oilRole = system.getEosOilPhase();
+    PhaseInterface aqueousRole = system.getGeLiquidPhase();
+    assertTrue(system.requiresHybridEosGeFlash(), "Reactive Pitzer systems must select the fixed-role hybrid strategy");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.TPflash();
+
+    assertEquals(3, system.getNumberOfPhases(), phaseDiagnostics(system));
+    assertTrue(hasPhaseType(system, PhaseType.GAS));
+    assertTrue(hasPhaseType(system, PhaseType.OIL));
+    assertTrue(hasPhaseType(system, PhaseType.AQUEOUS));
+    assertSame(gasRole, system.getEquationOfStatePhase());
+    assertSame(oilRole, system.getEosOilPhase());
+    assertSame(aqueousRole, system.getGeLiquidPhase());
+    assertReactiveCarbonateScaleResult(system, operations, conservedQuantities, initialCarbonateMoles);
   }
 
   /** A trace oil role disappears from the active mapping and the same object is restored on a later flash. */
@@ -283,6 +351,113 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
               referenceComponent.getComponentName());
         }
       }
+    }
+  }
+
+  /**
+   * Assert reactive carbonate formation and a finite, repeatable Pitzer calcite saturation ratio.
+   *
+   * @param system flashed reactive Pitzer system
+   * @param operations operations bound to the flashed system
+   * @param conservedQuantities element and charge quantities before the flash
+   * @param initialCarbonateMoles carbonate trace amount before chemical equilibrium
+   * @throws Exception if scale-potential evaluation fails
+   */
+  private void assertReactiveCarbonateScaleResult(SystemPitzer system, ThermodynamicOperations operations,
+      double[] conservedQuantities, double initialCarbonateMoles) throws Exception {
+    PhaseInterface aqueous = findPhase(system, PhaseType.AQUEOUS);
+    assertTrue(aqueous instanceof PhasePitzer);
+    assertTrue(system.isChemicalSystem());
+    assertTrue(aqueous.hasComponent("HCO3-"));
+    assertTrue(aqueous.hasComponent("CO3--"));
+    double bicarbonateMoles = aqueous.getComponent("HCO3-").getNumberOfMolesInPhase();
+    double carbonateMoles = aqueous.getComponent("CO3--").getNumberOfMolesInPhase();
+    assertTrue(bicarbonateMoles > 0.0);
+    assertTrue(carbonateMoles > 0.0, "Aqueous bicarbonate reactions must retain carbonate: " + carbonateMoles);
+    assertTrue(Math.abs(carbonateMoles - initialCarbonateMoles) > initialCarbonateMoles * 1.0e-3,
+        "Aqueous chemical equilibrium must change carbonate from its trace seed");
+    assertReactiveConservedQuantities(system, conservedQuantities);
+
+    double firstScalePotential = operations.getRelativeScalePotential("CaCO3");
+    assertTrue(Double.isFinite(firstScalePotential) && firstScalePotential > 0.0,
+        "Pitzer calcite scale potential must be finite and positive");
+
+    operations.TPflash();
+    double repeatedScalePotential = operations.getRelativeScalePotential("CaCO3");
+    assertReactiveConservedQuantities(system, conservedQuantities);
+    assertEquals(firstScalePotential, repeatedScalePotential, Math.max(1.0e-8, Math.abs(firstScalePotential) * 1.0e-4),
+        "Repeated reactive hybrid flashes must retain the same calcite scale potential");
+  }
+
+  /**
+   * Calculate the chemical subsystem's conserved element and charge quantities.
+   *
+   * @param system reactive system
+   * @param useTotalComponentMoles whether to read the feed totals instead of summing active phases
+   * @return element quantities followed by net ionic charge
+   */
+  private double[] getReactiveConservedQuantities(SystemPitzer system, boolean useTotalComponentMoles) {
+    ChemicalReactionOperations reactions = system.getChemicalReactionOperations();
+    ComponentInterface[] reactiveComponents = reactions.getComponents();
+    double[][] conservationMatrix = reactions.getAmatrix();
+    double[] quantities = new double[conservationMatrix.length];
+
+    for (int reactiveIndex = 0; reactiveIndex < reactiveComponents.length; reactiveIndex++) {
+      int componentIndex = reactiveComponents[reactiveIndex].getComponentNumber();
+      double componentMoles = 0.0;
+      if (useTotalComponentMoles) {
+        componentMoles = system.getPhase(0).getComponent(componentIndex).getNumberOfmoles();
+      } else {
+        for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+          componentMoles += system.getPhase(phaseIndex).getComponent(componentIndex).getNumberOfMolesInPhase();
+        }
+      }
+      for (int quantityIndex = 0; quantityIndex < conservationMatrix.length - 1; quantityIndex++) {
+        quantities[quantityIndex] += conservationMatrix[quantityIndex][reactiveIndex] * componentMoles;
+      }
+    }
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      double componentMoles = 0.0;
+      if (useTotalComponentMoles) {
+        componentMoles = system.getPhase(0).getComponent(componentIndex).getNumberOfmoles();
+      } else {
+        for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+          componentMoles += system.getPhase(phaseIndex).getComponent(componentIndex).getNumberOfMolesInPhase();
+        }
+      }
+      quantities[quantities.length - 1] += system.getPhase(0).getComponent(componentIndex).getIonicCharge()
+          * componentMoles;
+    }
+    return quantities;
+  }
+
+  /**
+   * Assert conservation of every chemical element and net ionic charge through the coupled flash.
+   *
+   * @param system flashed reactive system
+   * @param expectedQuantities element and charge quantities before the flash
+   */
+  private void assertReactiveConservedQuantities(SystemPitzer system, double[] expectedQuantities) {
+    double[] actualQuantities = getReactiveConservedQuantities(system, false);
+    assertEquals(expectedQuantities.length, actualQuantities.length);
+    for (int quantityIndex = 0; quantityIndex < expectedQuantities.length; quantityIndex++) {
+      double tolerance = quantityIndex == expectedQuantities.length - 1 ? 1.0e-8
+          : Math.max(1.0e-6, Math.abs(expectedQuantities[quantityIndex]) * 1.0e-7);
+      assertEquals(expectedQuantities[quantityIndex], actualQuantities[quantityIndex], tolerance,
+          "Reactive element/charge conservation row " + quantityIndex);
+    }
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      if (component.getIonicCharge() == 0 && !component.isIsIon()) {
+        continue;
+      }
+      double actualMoles = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        actualMoles += system.getPhase(phaseIndex).getComponent(componentIndex).getNumberOfMolesInPhase();
+      }
+      assertEquals(component.getNumberOfmoles(), actualMoles,
+          Math.max(1.0e-12, Math.abs(component.getNumberOfmoles()) * 1.0e-8),
+          "Reactive ionic component balance for " + component.getComponentName());
     }
   }
 


### PR DESCRIPTION
## Summary

- Add an opt-in hybrid EOS–GE multiphase strategy with fixed creation-order roles for EOS gas, EOS oil, and GE/electrolyte aqueous phases.
- Keep active density ordering separate from role ownership, so phase disappearance, restoration, cloning, serialization, repeated flashes, chemical-equilibrium operations, and reordering do not overwrite or relabel model-specific phase objects.
- Make the strategy model-independent through `HybridEosGeFlashModel` and the public `SystemEosGE.enableHybridEosGeFlash()` opt-in.
- Register `SystemPitzer`, `SystemDesmukhMather`, and `SystemKentEisenberg` with native SRK-gas / SRK-oil / GE-aqueous roles.
- Allow Wilson, NRTL, UNIFAC, and specialised `SystemEosGE` subclasses to enable the same topology without adding model-name checks to the flash solver.
- Couple aqueous chemical reactions to fixed gas–aqueous and gas–oil–aqueous phase equilibrium for any registered electrolyte GE model.
- Support activity-based mineral scale-potential screening after the coupled flash, including `getRelativeScalePotential("CaCO3")`.
- Correct Pitzer neutral reference-state handling: water uses the osmotic/Raoult solvent convention; other neutral solutes use Henry reference behavior.
- Add model-generic topology, phase-role, repeated-run, stoichiometric conservation, ionic component balance, scale-potential, and executable-documentation regressions.

This PR is stacked on #2781 and should remain draft until that parent is merged.

Closes #2862.

## Design

`TPHybridEosGeFlash` reuses the established multiphase beta/composition equations while bypassing generic phase discovery that can clone the wrong phase implementation. The model-owned contract:

1. restores gas/oil/GE-aqueous creation-order objects;
2. activates only feed-supported roles;
3. confines ions to the configured GE aqueous role;
4. solves with each phase's own fugacity and activity model;
5. audits normalization, component balance, and cross-phase fugacity residuals before acceptance; and
6. removes trace roles only from the active mapping, preserving their objects for later restoration.

For chemical systems, the strategy first establishes a feed-balanced phase split, then alternates aqueous chemical equilibrium with fixed-role phase equilibrium. Reaction-generated species are retained in an exact coupled inventory instead of being reset to feed `z` values. Each aqueous reaction update is projected onto the stoichiometric element/charge conservation null space before the overall inventory and total moles are synchronized across all model-owned roles. Ionic amounts are preserved exactly while neutrals are renormalized around the ion inventory.

Chemical-equilibrium operations can temporarily force phase labels. Final role restoration writes creation-order metadata directly and reasserts GAS/OIL/AQUEOUS after property initialization, so an EOS oil role cannot be left labelled aqueous.

Dispatch is resolved once when a `TPflash` operation is constructed. Ordinary SRK/PR/CPA component loops are unchanged.

## Model and scale-potential scope

The documented Pitzer example uses an electrically neutral methane/CO2/n-heptane/water/Ca/Na/Cl/bicarbonate feed, calls `chemicalReactionInit()`, runs the coupled flash, and evaluates calcite with:

```java
double calciteSaturationRatio = ops.getRelativeScalePotential("CaCO3");
```

Remove n-heptane for the gas–aqueous topology.

A second executable example uses reactive `SystemDesmukhMather` with gas, oil, aqueous MDEA chemistry, Ca/Na/Cl/bicarbonate, and the same calcite saturation-ratio API. `SystemKentEisenberg` owns the same fixed roles. Any other `SystemEosGE` subclass can call `enableHybridEosGeFlash()`; NRTL is covered as a model-generic three-phase regression.

Topology support does not create missing ionic species, reactions, activity formulations, or interaction parameters. Pitzer remains the broadly parameterised choice for concentrated mineral-scale brines; Desmukh–Mather and Kent–Eisenberg retain their narrower amine/electrolyte screening validity. `SystemDuanSun` is excluded because its current public system API accepts CO2 only and cannot represent water, ions, or oil.

The scale result is the activity-based saturation ratio `IAP / Ksp`; values above one indicate thermodynamic supersaturation. It does **not** calculate precipitated mass, deposition rate, or kinetics. Explicit solid/mineral precipitation equilibrium and wax checks remain unsupported by the fixed-role hybrid strategy and are rejected clearly.

## Validation

Final-tree local validation on NeqSim 3.16.0, OpenJDK 17.0.19, and Maven 3.9.12:

- 112 focused tests passed across `SystemHybridEosGeFlashTest`, `SystemEosGEOperationsTest`, `SystemDesmukhMatherTest`, `SystemKentEisenbergTest`, `SystemPitzerTest`, and `DocExamplesCompilationTest`.
- 6 slow `SaltSaturationTest` cases passed with slow tests enabled (404.5 s).
- Pitzer regressions cover reactive gas–aqueous and gas–oil–aqueous topology, carbonate chemistry, repeated execution, finite positive calcite saturation ratio, C/H/O and charge conservation, and every ionic component balance.
- Desmukh–Mather regression covers reactive gas–oil–aqueous topology, model-owned aqueous phase, finite positive calcite saturation ratio, element/charge conservation, and ionic component balance.
- NRTL regression proves the public model-generic opt-in, three phase roles, normalization, material balance, and cross-phase neutral fugacity equality.
- `python3 -m pre_commit run --all-files --hook-stage pre-commit`: passed on the final tree.
- `python3 -m pre_commit run --all-files --hook-stage pre-push`: passed on the final tree, including Spotless and documentation-search coverage (646 Markdown pages and one standalone HTML page).
- Documentation impact: updated the fluid-creation guide, thermodynamic-model guide, scale-prediction API, model Javadocs, and executable documentation coverage.

Engineering evidence is conservation and thermodynamic-consistency testing (evidence-ladder level 3). Exact-head GitHub CI for `3e8ecdf` is still required before the PR can be considered ready for review or merge.
