### PR TITLE
Reject non-physical artificial lift results

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,17 @@
 
 ---
 
+## 2026-08-06 — Artificial-lift screening rejects non-physical calculated results
+
+- `ArtificialLiftScreener.screen()` now rejects a calculated method result before ranking when its
+  production rate is non-finite or non-positive, or when its power consumption is non-finite or
+  negative.
+- Rejected results have zero reported rate and power, negative-infinite NPV, rank zero, and an
+  explicit infeasibility reason. A method reported as feasible therefore always has a finite,
+  positive rate and finite, non-negative power.
+- The field-development API example now uses the current `ArtificialLiftScreener` method names,
+  units, and `ScreeningResult` return type.
+
 ## 2026-08-06 — Evidence-aware full-model capacity ranking
 
 - `ProcessModelSimulationEvaluator.rankCapacityConstraints(model)` returns every enabled

--- a/docs/fielddevelopment/API_GUIDE.md
+++ b/docs/fielddevelopment/API_GUIDE.md
@@ -861,36 +861,40 @@ List<String> mitigations = report.getRecommendations();
 ### ArtificialLiftScreener
 
 ```java
+import java.util.List;
 import neqsim.process.fielddevelopment.screening.*;
+import neqsim.process.fielddevelopment.screening.ArtificialLiftScreener.LiftMethod;
+import neqsim.process.fielddevelopment.screening.ArtificialLiftScreener.MethodResult;
+import neqsim.process.fielddevelopment.screening.ArtificialLiftScreener.ScreeningResult;
 
 ArtificialLiftScreener lift = new ArtificialLiftScreener();
 
 // Configure well conditions
-lift.setReservoirPressure(180.0);     // Depleted reservoir
+lift.setReservoirPressure(180.0, "bara"); // Depleted reservoir
 lift.setWaterCut(0.70);
-lift.setGor(100.0);
+lift.setFormationGOR(100.0);
 lift.setProductivityIndex(15.0);
-lift.setWellDepth(2800.0);
-lift.setDeviation(45.0);               // degrees
-lift.setTemperature(95.0);
-lift.setGasAvailable(true);
-lift.setSandProduction(false);
-lift.setH2sPresent(false);
+lift.setWellDepth(2800.0, "m");
+lift.setReservoirTemperature(95.0, "C");
+lift.setGasLiftAvailable(true);
+lift.setElectricityAvailable(true);
 
 // Screen all methods
-List<MethodResult> results = lift.screenAllMethods();
+ScreeningResult screening = lift.screen();
+List<MethodResult> results = screening.getAllMethods();
 
 for (MethodResult method : results) {
-    System.out.printf("%s: %s%n",
-        method.getMethod().name(),
-        method.isFeasible() ?
-            String.format("Feasible (Score: %.0f/100)", method.getScore()) :
-            "Not feasible - " + method.getRationale());
+    if (method.feasible) {
+        // Feasible results always have positive finite rate and non-negative finite power.
+        double productionRateSm3PerDay = method.productionRate;
+        double powerConsumptionKw = method.powerConsumption;
+    } else {
+        String reason = method.infeasibilityReason;
+    }
 }
 
 // Get recommended method
-LiftMethod recommended = lift.getRecommendedMethod();
-System.out.println("Recommended: " + recommended);
+LiftMethod recommended = screening.getRecommendedMethod();
 ```
 
 ### EmissionsTracker

--- a/src/main/java/neqsim/process/fielddevelopment/screening/ArtificialLiftScreener.java
+++ b/src/main/java/neqsim/process/fielddevelopment/screening/ArtificialLiftScreener.java
@@ -31,6 +31,11 @@ import java.util.List;
  * <li><b>Risk Assessment:</b> Considers reliability and operational complexity</li>
  * </ol>
  *
+ * <p>
+ * A method is only reported as feasible when its calculated production rate is finite and positive and its power
+ * consumption is finite and non-negative. Results outside those physical bounds are rejected before economic ranking.
+ * </p>
+ *
  * <h2>Operating Envelope Limits</h2>
  * <table border="1">
  * <caption>Operating Envelope Limits by Method</caption>
@@ -101,11 +106,8 @@ import java.util.List;
  * screener.setElectricityAvailable(true);
  *
  * ScreeningResult result = screener.screen();
- *
- * System.out.println("Recommended: " + result.getRecommendedMethod());
- * for (MethodResult method : result.getAllMethods()) {
- *   System.out.println(method);
- * }
+ * LiftMethod recommended = result.getRecommendedMethod();
+ * List&lt;MethodResult&gt; evaluatedMethods = result.getAllMethods();
  * }</pre>
  *
  * @author ESOL
@@ -227,7 +229,6 @@ public class ArtificialLiftScreener implements Serializable {
     // Calculate natural flow baseline
     MethodResult naturalFlow = evaluateNaturalFlow();
     result.addMethod(naturalFlow);
-    result.naturalFlowRate = naturalFlow.productionRate;
 
     // Evaluate each artificial lift method
     if (gasLiftAvailable) {
@@ -261,10 +262,41 @@ public class ArtificialLiftScreener implements Serializable {
       }
     }
 
+    rejectNonPhysicalCalculatedResults(result);
+    result.naturalFlowRate = naturalFlow.productionRate;
+
     // Rank methods
     result.rankMethods();
 
     return result;
+  }
+
+  /**
+   * Reject calculated method results that cannot represent a physical operating point.
+   *
+   * @param result screening result containing the evaluated methods
+   */
+  private void rejectNonPhysicalCalculatedResults(ScreeningResult result) {
+    for (MethodResult method : result.methods) {
+      if (!method.feasible) {
+        continue;
+      }
+
+      if (!Double.isFinite(method.productionRate) || method.productionRate <= 0.0) {
+        method.feasible = false;
+        method.infeasibilityReason = String.format("Calculated production rate is not finite and positive: %.6g Sm3/d",
+            method.productionRate);
+        method.productionRate = 0.0;
+        method.powerConsumption = 0.0;
+        method.npv = Double.NEGATIVE_INFINITY;
+      } else if (!Double.isFinite(method.powerConsumption) || method.powerConsumption < 0.0) {
+        method.feasible = false;
+        method.infeasibilityReason = String
+            .format("Calculated power consumption is not finite and non-negative: %.6g kW", method.powerConsumption);
+        method.powerConsumption = 0.0;
+        method.npv = Double.NEGATIVE_INFINITY;
+      }
+    }
   }
 
   /**
@@ -954,7 +986,7 @@ public class ArtificialLiftScreener implements Serializable {
 
     /** Lift method. */
     public LiftMethod method;
-    /** Whether method is feasible. */
+    /** Whether method is feasible with finite positive production and finite non-negative power. */
     public boolean feasible = true;
     /** Reason if infeasible. */
     public String infeasibilityReason = "";

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -53,6 +53,10 @@ import neqsim.process.fielddevelopment.concept.FieldConcept;
 import neqsim.process.fielddevelopment.concept.GreenfieldConceptFactory;
 import neqsim.process.fielddevelopment.evaluation.ConceptEvaluator;
 import neqsim.process.fielddevelopment.evaluation.ConceptKPIs;
+import neqsim.process.fielddevelopment.screening.ArtificialLiftScreener;
+import neqsim.process.fielddevelopment.screening.ArtificialLiftScreener.LiftMethod;
+import neqsim.process.fielddevelopment.screening.ArtificialLiftScreener.MethodResult;
+import neqsim.process.fielddevelopment.screening.ArtificialLiftScreener.ScreeningResult;
 import neqsim.process.fielddevelopment.tieback.HostFacility;
 import neqsim.process.fielddevelopment.tieback.capacity.CapacityAllocationPolicy;
 import neqsim.process.fielddevelopment.tieback.capacity.HostTieInPoint;
@@ -368,6 +372,36 @@ public class DocExamplesCompilationTest {
     assertNotNull(fpso.getSummary());
     assertTrue(tieback.getFacilityConfig().getBlocks().size() > 0);
     assertTrue(fpso.getTotalCapexMusd() > tieback.getTotalCapexMusd());
+  }
+
+  /**
+   * Artificial-lift screening example from docs/fielddevelopment/API_GUIDE.md.
+   */
+  @Test
+  public void testArtificialLiftScreenerApiGuideExample() {
+    ArtificialLiftScreener lift = new ArtificialLiftScreener();
+    lift.setReservoirPressure(180.0, "bara");
+    lift.setWaterCut(0.70);
+    lift.setFormationGOR(100.0);
+    lift.setProductivityIndex(15.0);
+    lift.setWellDepth(2800.0, "m");
+    lift.setReservoirTemperature(95.0, "C");
+    lift.setGasLiftAvailable(true);
+    lift.setElectricityAvailable(true);
+
+    ScreeningResult screening = lift.screen();
+    List<MethodResult> results = screening.getAllMethods();
+    for (MethodResult method : results) {
+      if (method.feasible) {
+        assertTrue(Double.isFinite(method.productionRate) && method.productionRate > 0.0);
+        assertTrue(Double.isFinite(method.powerConsumption) && method.powerConsumption >= 0.0);
+      } else {
+        assertNotNull(method.infeasibilityReason);
+      }
+    }
+
+    LiftMethod recommended = screening.getRecommendedMethod();
+    assertNotNull(recommended);
   }
 
   /**

--- a/src/test/java/neqsim/process/fielddevelopment/screening/ArtificialLiftScreenerTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/screening/ArtificialLiftScreenerTest.java
@@ -139,6 +139,44 @@ class ArtificialLiftScreenerTest {
   }
 
   @Test
+  @DisplayName("Test calculated results must be physically valid before ranking")
+  void testCalculatedResultsMustBePhysicalBeforeRanking() {
+    screener.setReservoirPressure(245.0, "bara");
+    screener.setReservoirTemperature(82.0, "C");
+    screener.setWellheadPressure(18.0, "bara");
+    screener.setWellDepth(2738.0, "m");
+    screener.setProductivityIndex(10.0);
+    screener.setOilGravity(33.0, "API");
+    screener.setWaterCut(0.48);
+    screener.setFormationGOR(135.0);
+    screener.setOilViscosity(4.0, "cP");
+    screener.setGasLiftAvailable(true);
+    screener.setElectricityAvailable(true);
+
+    ScreeningResult result = screener.screen();
+    MethodResult rodPump = null;
+    for (MethodResult method : result.getAllMethods()) {
+      if (method.feasible) {
+        assertTrue(Double.isFinite(method.productionRate) && method.productionRate > 0.0,
+            method.getMethodName() + " must have a finite positive production rate when feasible");
+        assertTrue(Double.isFinite(method.powerConsumption) && method.powerConsumption >= 0.0,
+            method.getMethodName() + " must have finite non-negative power when feasible");
+      }
+      if (method.method == LiftMethod.ROD_PUMP) {
+        rodPump = method;
+      }
+    }
+
+    assertNotNull(rodPump);
+    assertFalse(rodPump.feasible);
+    assertEquals(0.0, rodPump.productionRate, 0.0);
+    assertEquals(0.0, rodPump.powerConsumption, 0.0);
+    assertEquals(0, rodPump.rank);
+    assertEquals(Double.NEGATIVE_INFINITY, rodPump.npv);
+    assertTrue(rodPump.infeasibilityReason.contains("production rate"));
+  }
+
+  @Test
   @DisplayName("Test PCP good for high viscosity")
   void testPCPHighViscosity() {
     screener.setWellDepth(2000.0, "m"); // Within PCP range


### PR DESCRIPTION
## Summary

- reject any calculated artificial-lift method result before ranking when production rate is non-finite or non-positive
- reject non-finite or negative calculated power consumption
- normalize rejected rate and power to zero, set NPV to negative infinity and rank to zero, and retain an explicit infeasibility reason
- correct and compile-test the field-development API example

## Root cause

The rod-pump evaluator marked the method feasible immediately after its operating-envelope checks. For sufficiently deep wells, the simplified drawdown estimate could then become negative, producing negative rate and power while the result remained eligible for ranking.

The validation is centralized after every method evaluation so the feasible-result invariant applies to natural flow, gas lift, ESP, rod pump, PCP, and jet pump rather than special-casing one calculation.

## Validation

- Regression first reproduced the failure: the rod-pump case from #2858 was feasible with a negative rate.
- Java 17: `ArtificialLiftScreenerTest` plus the new API-guide documentation test — 14 tests passed.
- Java 8 compatibility build: clean compile with `pomJava8.xml` targeting Java 8 plus the same 14 focused tests — passed. The local runtime was JDK 17; GitHub CI remains the authoritative JDK 8 runtime check.
- `./mvnw spotless:apply` — passed.
- `./mvnw spotless:check` — passed.
- `pre-commit run --all-files --hook-stage pre-commit` — passed.
- `pre-commit run --all-files --hook-stage pre-push` — passed, including documentation search coverage.

## Documentation impact

Updated `ArtificialLiftScreener` Javadoc, `docs/fielddevelopment/API_GUIDE.md`, and `CHANGELOG_AGENT_NOTES.md`. Added a compilation regression for the corrected API-guide example.

Closes #2858