### PR TITLE
Fix column side-draw energy balance diagnostics

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -444,6 +444,7 @@ fraction diagnostics, film/heat-transfer model choices, and equation-oriented re
 | `getLastTemperatureResidual()` | Average tray-temperature residual in Kelvin. |
 | `getLastMassResidual()` | Relative mass-balance residual. |
 | `getLastEnergyResidual()` | Relative enthalpy-balance residual. |
+| `getEnergyBalanceError()` | Maximum tray/column enthalpy imbalance, including external side draws and excluding zero-flow phase templates. |
 | `getLastTopSpecificationResidual()`, `getLastBottomSpecificationResidual()` | Endpoint spec errors. |
 | `getLastSpecificationResidual()` | Maximum absolute endpoint spec error. |
 | `getSpecificationHomotopySteps()` | Configured number of staged continuation targets for adjustable product specifications. |

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -11464,6 +11464,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   /**
    * Calculates the relative enthalpy imbalance across all trays.
    *
+   * <p>
+   * External gas and liquid side draws are included with the main inter-tray outlets. Zero-flow streams are ignored
+   * because a phase template can retain a finite molar enthalpy even when it carries no material or energy.
+   * </p>
+   *
    * @return maximum of tray-wise and overall relative enthalpy imbalance
    */
   public double getEnergyBalanceError() {
@@ -11480,6 +11485,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
 
       double outlet = getFiniteStreamEnthalpy(trays.get(i).getGasOutStream());
       outlet += getFiniteStreamEnthalpy(trays.get(i).getLiquidOutStream());
+      if (trays.get(i).getGasSideDrawFraction() > 0.0) {
+        outlet += getFiniteStreamEnthalpy(trays.get(i).getGasSideDrawStream());
+      }
+      if (trays.get(i).getLiquidSideDrawFraction() > 0.0) {
+        outlet += getFiniteStreamEnthalpy(trays.get(i).getLiquidSideDrawStream());
+      }
 
       if (trays.get(i) instanceof Reboiler) {
         inlet += getFiniteDiagnosticValue(((Reboiler) trays.get(i)).getDuty());
@@ -11510,13 +11521,13 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     if (stream == null || stream.getThermoSystem() == null) {
       return 0.0;
     }
+    double flowRate = Math.abs(stream.getThermoSystem().getFlowRate("kg/hr"));
+    if (!Double.isFinite(flowRate) || flowRate <= 1.0e-12) {
+      return 0.0;
+    }
     double enthalpy = stream.getFluid().getEnthalpy();
     if (Double.isFinite(enthalpy)) {
       return enthalpy;
-    }
-    double flowRate = Math.abs(stream.getThermoSystem().getFlowRate("kg/hr"));
-    if (flowRate <= 1.0e-12) {
-      return 0.0;
     }
     return 0.0;
   }

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -6237,6 +6237,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     int iter = 0;
     double massErr = 1.0e10;
     double energyErr = 1.0e10;
+    double adaptiveDampingEnergyErr = 1.0e10;
     double previousCombinedResidual = Double.POSITIVE_INFINITY;
 
     long startTime = System.nanoTime();
@@ -6388,6 +6389,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       if (evaluateBalances || !massEnergyEvaluated) {
         massErr = getMassBalanceError();
         energyErr = getEnergyBalanceError();
+        adaptiveDampingEnergyErr = getAdaptiveDampingEnergyBalanceError();
         massEnergyEvaluated = true;
       }
 
@@ -6395,7 +6397,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       // undamped fixed-point residual in err.
       double tempScaled = appliedTemperatureStepResidual / baseTempTolerance;
       double massScaled = massErr / baseMassTolerance;
-      double energyScaled = energyErr / baseEnergyTolerance;
+      double energyScaled = adaptiveDampingEnergyErr / baseEnergyTolerance;
       double combinedResidual = Math.max(tempScaled, massScaled);
       if (Double.isFinite(energyScaled)) {
         combinedResidual = Math.max(combinedResidual, Math.min(energyScaled, maxEnergyRelaxationWeight));
@@ -6767,6 +6769,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     int iter = 0;
     double massErr = 1.0e10;
     double energyErr = 1.0e10;
+    double adaptiveDampingEnergyErr = 1.0e10;
     double previousCombinedResidual = Double.POSITIVE_INFINITY;
 
     long startTime = System.nanoTime();
@@ -6985,12 +6988,13 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       if (evaluateBalances || !massEnergyEvaluated) {
         massErr = getMassBalanceError();
         energyErr = getEnergyBalanceError();
+        adaptiveDampingEnergyErr = getAdaptiveDampingEnergyBalanceError();
         massEnergyEvaluated = true;
       }
 
       double tempScaled = err / baseTempTolerance;
       double massScaled = massErr / baseMassTolerance;
-      double energyScaled = energyErr / baseEnergyTolerance;
+      double energyScaled = adaptiveDampingEnergyErr / baseEnergyTolerance;
       double combinedResidual = Math.max(tempScaled, massScaled);
       if (Double.isFinite(energyScaled)) {
         combinedResidual = Math.max(combinedResidual, Math.min(energyScaled, maxEnergyRelaxationWeight));
@@ -11472,6 +11476,32 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @return maximum of tray-wise and overall relative enthalpy imbalance
    */
   public double getEnergyBalanceError() {
+    return calculateEnergyBalanceError(true, true);
+  }
+
+  /**
+   * Calculate the historical energy signal used by the adaptive relaxation controller.
+   *
+   * <p>
+   * The controller was calibrated against main tray outlets and finite phase-template enthalpies. Keep that signal
+   * stable while exposing the physically complete balance through {@link #getEnergyBalanceError()}; changing the
+   * controller requires separate solver-wide convergence validation.
+   * </p>
+   *
+   * @return energy residual compatible with the established adaptive relaxation controller
+   */
+  private double getAdaptiveDampingEnergyBalanceError() {
+    return calculateEnergyBalanceError(false, false);
+  }
+
+  /**
+   * Calculate a relative tray and column energy imbalance.
+   *
+   * @param includeSideDraws whether external gas and liquid side draws are included as outlets
+   * @param ignoreZeroFlowStreams whether streams carrying no material are excluded
+   * @return maximum of tray-wise and overall relative enthalpy imbalance
+   */
+  private double calculateEnergyBalanceError(boolean includeSideDraws, boolean ignoreZeroFlowStreams) {
     double trayRelativeError = 0.0;
     double totalInlet = 0.0;
     double totalResidual = 0.0;
@@ -11480,16 +11510,16 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       double inlet = 0.0;
       int numberOfInputStreams = trays.get(i).getNumberOfInputStreams();
       for (int j = 0; j < numberOfInputStreams; j++) {
-        inlet += getFiniteStreamEnthalpy(trays.get(i).getStream(j));
+        inlet += getFiniteStreamEnthalpy(trays.get(i).getStream(j), ignoreZeroFlowStreams);
       }
 
-      double outlet = getFiniteStreamEnthalpy(trays.get(i).getGasOutStream());
-      outlet += getFiniteStreamEnthalpy(trays.get(i).getLiquidOutStream());
-      if (trays.get(i).getGasSideDrawFraction() > 0.0) {
-        outlet += getFiniteStreamEnthalpy(trays.get(i).getGasSideDrawStream());
+      double outlet = getFiniteStreamEnthalpy(trays.get(i).getGasOutStream(), ignoreZeroFlowStreams);
+      outlet += getFiniteStreamEnthalpy(trays.get(i).getLiquidOutStream(), ignoreZeroFlowStreams);
+      if (includeSideDraws && trays.get(i).getGasSideDrawFraction() > 0.0) {
+        outlet += getFiniteStreamEnthalpy(trays.get(i).getGasSideDrawStream(), true);
       }
-      if (trays.get(i).getLiquidSideDrawFraction() > 0.0) {
-        outlet += getFiniteStreamEnthalpy(trays.get(i).getLiquidSideDrawStream());
+      if (includeSideDraws && trays.get(i).getLiquidSideDrawFraction() > 0.0) {
+        outlet += getFiniteStreamEnthalpy(trays.get(i).getLiquidSideDrawStream(), true);
       }
 
       if (trays.get(i) instanceof Reboiler) {
@@ -11515,15 +11545,18 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * Read stream enthalpy for diagnostics, treating non-finite values as no contribution.
    *
    * @param stream stream to inspect
+   * @param ignoreZeroFlow whether zero-flow streams are excluded before reading enthalpy
    * @return finite stream enthalpy contribution
    */
-  private double getFiniteStreamEnthalpy(StreamInterface stream) {
+  private double getFiniteStreamEnthalpy(StreamInterface stream, boolean ignoreZeroFlow) {
     if (stream == null || stream.getThermoSystem() == null) {
       return 0.0;
     }
-    double flowRate = Math.abs(stream.getThermoSystem().getFlowRate("kg/hr"));
-    if (!Double.isFinite(flowRate) || flowRate <= 1.0e-12) {
-      return 0.0;
+    if (ignoreZeroFlow) {
+      double flowRate = Math.abs(stream.getThermoSystem().getFlowRate("kg/hr"));
+      if (!Double.isFinite(flowRate) || flowRate <= 1.0e-12) {
+        return 0.0;
+      }
     }
     double enthalpy = stream.getFluid().getEnthalpy();
     if (Double.isFinite(enthalpy)) {

--- a/src/test/java/neqsim/process/equipment/distillation/SimpleTraySideDrawTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SimpleTraySideDrawTest.java
@@ -87,6 +87,37 @@ public class SimpleTraySideDrawTest {
     assertEquals(0.0, column.getMassBalance("kg/hr"), feed.getFlowRate("kg/hr") * 1.0e-6);
   }
 
+  /** Test that energy diagnostics include gas and liquid side draws and ignore empty phase templates. */
+  @Test
+  public void columnEnergyBalanceIncludesSideDrawStreams() {
+    Stream gasFeed = createMethaneFeed("gas energy-balance feed");
+    DistillationColumn gasColumn = new DistillationColumn("GasEnergyBalanceColumn", 1, false, false);
+    gasColumn.addFeedStream(gasFeed, 0);
+    gasColumn.setGasSideDrawFraction(0, 0.25);
+    gasColumn.run(UUID.randomUUID());
+
+    assertEquals(DistillationColumn.SolveStatus.RIGOROUS_CONVERGED, gasColumn.getLastSolveStatus());
+    assertEquals(25.0, gasColumn.getSideDrawStream(0, DistillationColumn.SideDrawPhase.GAS).getFlowRate("kg/hr"),
+        25.0e-8);
+    assertEquals(0.0, gasColumn.getEnergyBalanceError(), 1.0e-12);
+
+    SystemSrkEos liquidFluid = new SystemSrkEos(300.0, 2.0);
+    liquidFluid.addComponent("n-pentane", 1.0);
+    liquidFluid.setMixingRule("classic");
+    Stream liquidFeed = new Stream("liquid energy-balance feed", liquidFluid);
+    liquidFeed.setFlowRate(100.0, "kg/hr");
+    liquidFeed.run();
+    DistillationColumn liquidColumn = new DistillationColumn("LiquidEnergyBalanceColumn", 1, false, false);
+    liquidColumn.addFeedStream(liquidFeed, 0);
+    liquidColumn.setLiquidSideDrawFraction(0, 0.25);
+    liquidColumn.run(UUID.randomUUID());
+
+    assertEquals(DistillationColumn.SolveStatus.RIGOROUS_CONVERGED, liquidColumn.getLastSolveStatus());
+    assertEquals(25.0, liquidColumn.getSideDrawStream(0, DistillationColumn.SideDrawPhase.LIQUID).getFlowRate("kg/hr"),
+        25.0e-8);
+    assertEquals(0.0, liquidColumn.getEnergyBalanceError(), 1.0e-12);
+  }
+
   /**
    * Test that a side-draw flow specification adjusts the draw fraction to meet target flow.
    */
@@ -135,6 +166,7 @@ public class SimpleTraySideDrawTest {
     assertEquals(specification.getTargetFlowRate(), specification.getLastActualFlowRate(),
         specification.getTargetFlowRate() * specification.getTolerance());
     assertEquals(0.0, column.getMassBalance("kg/hr"), 1.0e-6, column.getConvergenceDiagnostics());
+    assertTrue(column.getEnergyBalanceError() < 1.0e-2, column.getConvergenceDiagnostics());
     assertTrue(column.getLastColumnTearRejectedCandidateCount() > 0,
         "the regression should exercise rejected-candidate rollback");
     assertEquals(column.getLastColumnTearRejectedCandidateCount(), column.getLastColumnTearRollbackCount());


### PR DESCRIPTION
## Problem

`DistillationColumn.getEnergyBalanceError()` can report physically meaningless residuals for columns with side draws:

1. gas and liquid side-draw product enthalpy is omitted from the tray outlet sum; and
2. zero-flow phase-template streams are accepted whenever their stored enthalpy is finite, even though those templates carry no material or energy.

The defect was reproduced on exact `master` `472bf86b81695027d030f76ee506d9efd99eb45f`; the affected column sources were unchanged on the current branch base, `a1f7817d57e013d14da31991cc160b570ca0cb62`. A one-tray 25% methane gas draw reported an energy error of `0.4994854614974569`, and the analogous n-pentane liquid draw reported `0.7877870281068996`, despite total mass residuals at numerical precision.

A realistic five-stage SRK hydrocarbon fractionator with a tray-3 liquid side draw reported `8.04e10` because zero-flow phase templates retained enthalpies on the order of `1e16`.

## Root cause and change

`getFiniteStreamEnthalpy()` checked enthalpy before flow, so a finite enthalpy from a zero-flow phase template was counted. The column-level calculation also included only the main gas and liquid inter-tray outlets.

This change:

- rejects null, non-finite-flow, and effectively zero-flow streams before reading the public diagnostic enthalpy;
- includes active external gas and liquid side-draw streams in each tray outlet sum;
- documents the diagnostic contract; and
- adds deterministic gas, liquid, and multistage regressions.

Exact-head CI then exposed a backward-compatibility coupling: the sequential and inside-out adaptive relaxation controllers also consume the energy residual, even when energy tolerance enforcement is disabled. Feeding the corrected diagnostic directly into that historical controller changed its relaxation path and caused two warm-state/cache regressions on Java 21 Windows. A direct local reproduction reached a per-tray material imbalance of `0.1508`.

The follow-up separates the two responsibilities:

- the public, reported, and optionally enforced energy residual is the physically corrected balance;
- a private compatibility signal preserves the controller input against which the existing relaxation factors were calibrated.

No tolerance is loosened and no failed solve is hidden. Recalibrating adaptive damping against the corrected physical energy residual is deliberately deferred to a solver-wide convergence study rather than being bundled into this diagnostic correction.

## Before / after evidence

Exact-master isolated reproduction and the changed implementation were run with the same inputs:

| Case | Before | After |
|---|---:|---:|
| One-tray methane, 25% gas draw | `0.4994854614974569` | `1.673940460815495e-16` |
| One-tray n-pentane, 25% liquid draw | `0.7877870281068996` | `1.9838485729617138e-16` |
| Five-stage SRK fractionator, base liquid-draw target | `8.039803905645384e10` | `0.006216390310073232` |
| Same fractionator, higher nearby target | `8.899258046129561e10` | `0.0030376748671535592` |
| Same fractionator, nearby 260 kg/h feed | `8.323326757419275e10` | `0.006666420744689447` |

The one-tray draws remain exactly 25 kg/h. Total/component mass balances, specification satisfaction, solve status, physical flows, and repeated-run behavior are unchanged. The finite residual remaining in the multistage cases is the existing reboiler/solver energy closure, not an omitted product or ghost zero-flow contribution.

No performance claim is made.

## Validation

Before publication and after rebasing:

- Java 17: `SimpleTraySideDrawTest` — 13/13 passed.
- Java 17 broader affected suite: `DistillationColumnModeTest`, `TegRegenerationEnergyBalanceTest`, `DistillationColumnTest`, and `ColumnSpecificationTest` — 10 applicable tests passed.
- Java 8 exact new regression method — 1/1 passed.
- Spotless apply/check, mandatory pre-commit/pre-push hooks, and documentation search across 646 Markdown files plus one standalone HTML file passed.
- No notebook changed.

Compatibility follow-up after the hosted Windows failure:

- unchanged master behavior: both affected warm-state methods passed in 3/3 repeated pairs;
- direct corrected-energy controller input: reproduced the failed identity-change solve locally;
- simply disabling non-enforced energy damping: still failed, with per-tray material residual `0.1508`;
- separated diagnostic/controller signals: both affected methods passed in 5/5 repeated pairs;
- one-tray gas/liquid and five-stage side-draw energy regressions passed;
- all relevant main Java sources compiled with Java 8 source/bytecode targeting against the public NeqSim 3.16.0 dependency set.

The exact-head hosted matrix passed on follow-up head `6579776c673e6e9571e0cc86d26a13df45fc718f`, including Java 8/21 on Ubuntu and Windows, all four slow-test shards, Javadocs, CodeQL, pre-commit, Spotless, PaperLab, and documentation coverage.

## Compatibility and risk

The public API is unchanged. Callers that inspect or enforce `getEnergyBalanceError()` now receive the physical balance for external side draws instead of a value dominated by omitted products or empty internal templates. The `1e-12 kg/h` diagnostic cutoff matches the existing numerical-zero scale used in this method.

The internal adaptive damping trajectory remains backward compatible by design. That private compatibility path is documented in source and should only be removed after representative sequential and inside-out columns have been recalibrated against the physical energy signal.

Pumparound energy accounting is deliberately out of scope: its internal draw/return enthalpy difference requires explicit cooler/heater duty treatment and separate validation.
