### PR TITLE
Fail closed on unresolved production trips

### DIFF
--- a/docs/risk/production-impact.md
+++ b/docs/risk/production-impact.md
@@ -20,7 +20,10 @@ When equipment fails, production is affected in several ways:
 3. **Bottleneck shifts** - Different equipment becomes limiting
 4. **Quality changes** - Product specifications may change
 
-The `ProductionImpactAnalyzer` uses NeqSim simulation to calculate these effects accurately.
+The `ProductionImpactAnalyzer` uses NeqSim simulation to calculate these effects. A rate-only
+simulation cannot by itself prove that flow through an inactive or bypassed unit remains saleable.
+For complete trips, unchanged nominal product flow is therefore reported as unresolved unless a
+configured product specification or a topology-aware model resolves the consequence.
 
 ---
 
@@ -53,17 +56,27 @@ ProductionImpactAnalyzer analyzer = new ProductionImpactAnalyzer(processSystem);
 // Configure streams
 analyzer.setFeedStreamName("Well Feed");
 analyzer.setProductStreamName("Export Gas");
-analyzer.setProductPrice(500.0, "USD/tonne");
+analyzer.setProductPricePerKg(0.50);
+
+// Optional: only count product delivered at or above the contractual pressure.
+analyzer.setMinimumProductPressure(90.0, "bara");
 
 // Analyze a specific failure
 EquipmentFailureMode compressorTrip = EquipmentFailureMode.trip("HP Compressor");
-ProductionImpactResult result = analyzer.analyzeFailureImpact(compressorTrip);
+ProductionImpactResult result = analyzer.analyzeFailureImpact("HP Compressor", compressorTrip);
 
 // Get results
-System.out.println("Production loss: " + result.getPercentLoss() + "%");
-System.out.println("Revenue impact: $" + result.getRevenueImpact() + "/hour");
-System.out.println("Affected equipment: " + result.getAffectedEquipment());
+double productionLossPercent = result.getPercentLoss();
+double economicLossPerHour = result.getEconomicLossPerHour();
+List<String> affectedEquipment = result.getAffectedEquipment();
+boolean consequenceResolved = result.isConverged();
 ```
+
+When the failed product pressure is below the configured minimum, the analyzer reports zero
+saleable production even if nominal mass flow remains unchanged. Without a product specification,
+a complete trip that leaves nominal product flow unchanged returns `converged=false`,
+`RecommendedAction.MANUAL_REVIEW`, and an explanatory `analysisNotes` value. This fail-closed state
+prevents a rate-only result from being ranked as a confirmed 0% production loss.
 
 ### Analyzing All Equipment
 
@@ -99,25 +112,26 @@ The result object contains comprehensive impact data:
 ```java
 public class ProductionImpactResult {
     // Production metrics
-    double getNormalProduction();      // kg/hr before failure
-    double getDegradedProduction();    // kg/hr after failure
-    double getProductionLoss();        // kg/hr lost
-    double getPercentLoss();           // 0-100%
+    double getBaselineProductionRate(); // kg/hr before failure
+    double getProductionWithFailure();  // saleable kg/hr after failure
+    double getAbsoluteLoss();           // kg/hr lost
+    double getPercentLoss();            // 0-100%
 
     // Economic metrics
-    double getRevenueImpact();         // $/hr
-    double getEstimatedDailyCost();    // $/day
+    double getEconomicLossPerHour();    // $/hr
+    double getEconomicLossPerDay();     // $/day
 
     // Affected equipment
     List<String> getAffectedEquipment();
-    List<String> getCascadeEffects();
-
-    // Quality impacts (if applicable)
-    Map<String, Double> getQualityChanges();
 
     // Bottleneck analysis
     String getNewBottleneck();
-    double getBottleneckCapacity();
+    double getNewBottleneckUtilization();
+
+    // Resolution diagnostics
+    boolean isConverged();
+    String getAnalysisNotes();
+    RecommendedAction getRecommendedAction();
 }
 ```
 

--- a/src/main/java/neqsim/process/util/optimizer/ProductionImpactAnalyzer.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProductionImpactAnalyzer.java
@@ -18,6 +18,7 @@ import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.process.util.optimizer.ProductionImpactResult.RecommendedAction;
+import neqsim.util.unit.PressureUnit;
 
 /**
  * Analyzer for assessing production impact of equipment failures.
@@ -36,6 +37,12 @@ import neqsim.process.util.optimizer.ProductionImpactResult.RecommendedAction;
  * <li>Identify bottleneck shifts</li>
  * </ul>
  *
+ * <p>
+ * A complete failure that leaves nominal product flow unchanged is reported as unresolved unless a configured product
+ * specification proves whether the product remains saleable. This prevents an inactive unit or bypass-like model state
+ * from being interpreted as a converged zero-loss result.
+ * </p>
+ *
  * <h2>Example Usage</h2>
  *
  * <pre>
@@ -44,11 +51,12 @@ import neqsim.process.util.optimizer.ProductionImpactResult.RecommendedAction;
  * ProductionImpactAnalyzer analyzer = new ProductionImpactAnalyzer(processSystem);
  * analyzer.setFeedStreamName("Well Feed");
  * analyzer.setProductStreamName("Export Gas");
+ * analyzer.setMinimumProductPressure(90.0, "bara");
  *
  * // Analyze compressor failure
  * ProductionImpactResult result = analyzer.analyzeFailureImpact("HP Compressor");
- * System.out.println("Production loss: " + result.getPercentLoss() + "%");
- * System.out.println("Recommendation: " + result.getRecommendedAction());
+ * double productionLossPercent = result.getPercentLoss();
+ * RecommendedAction recommendation = result.getRecommendedAction();
  *
  * // Get criticality ranking
  * List<ProductionImpactResult> ranking = analyzer.rankEquipmentByCriticality();
@@ -82,6 +90,12 @@ public class ProductionImpactAnalyzer implements Serializable {
 
   /** Tolerance for flow rate optimization. */
   private double optimizationTolerance = 0.01;
+
+  /** Relative tolerance used to identify unchanged production after a complete failure. */
+  private static final double UNCHANGED_PRODUCTION_RELATIVE_TOLERANCE = 1.0e-9;
+
+  /** Optional minimum saleable-product pressure in bara. */
+  private Double minimumProductPressureBara = null;
 
   /** Maximum iterations for optimization. */
   private int maxOptimizationIterations = 50;
@@ -155,6 +169,29 @@ public class ProductionImpactAnalyzer implements Serializable {
    */
   public ProductionImpactAnalyzer setProductStreamName(String name) {
     this.productStreamName = name;
+    clearCache();
+    return this;
+  }
+
+  /**
+   * Sets the minimum pressure for product flow to count as saleable production.
+   *
+   * <p>
+   * When a failed case is below this pressure, its saleable production is reported as zero even if the process model
+   * still carries the same nominal mass flow through an inactive or bypassed unit.
+   * </p>
+   *
+   * @param pressure finite positive minimum product pressure
+   * @param unit pressure unit supported by {@link PressureUnit}
+   * @return this analyzer for chaining
+   */
+  public ProductionImpactAnalyzer setMinimumProductPressure(double pressure, String unit) {
+    double pressureBara = new PressureUnit(pressure, unit).getValue("bara");
+    if (!Double.isFinite(pressureBara) || pressureBara <= 0.0) {
+      throw new IllegalArgumentException("Minimum product pressure must be finite and positive");
+    }
+    this.minimumProductPressureBara = pressureBara;
+    clearCache();
     return this;
   }
 
@@ -211,6 +248,8 @@ public class ProductionImpactAnalyzer implements Serializable {
    */
   public ProductionImpactResult analyzeFailureImpact(String equipmentName, EquipmentFailureMode failureMode) {
     long startTime = System.currentTimeMillis();
+    boolean failedProcessConverged = false;
+    boolean consequenceResolved = true;
 
     ProductionImpactResult result = new ProductionImpactResult(equipmentName, failureMode);
     result.setProductPricePerKg(productPricePerKg);
@@ -238,11 +277,26 @@ public class ProductionImpactAnalyzer implements Serializable {
       // Run the failed process
       try {
         failedProcess.run();
+        failedProcessConverged = true;
 
         // Get production with failure
-        double productionWithFailure = getProductionRate(failedProcess);
+        double simulatedProductionWithFailure = getProductionRate(failedProcess);
+        ProductSpecificationStatus productStatus = evaluateProductSpecification(failedProcess, result);
+        double productionWithFailure = productStatus == ProductSpecificationStatus.OFF_SPECIFICATION ? 0.0
+            : simulatedProductionWithFailure;
         result.setProductionWithFailure(productionWithFailure);
         result.setPowerWithFailure(getTotalPower(failedProcess));
+
+        if (productStatus == ProductSpecificationStatus.UNRESOLVED) {
+          consequenceResolved = false;
+        } else if (failureMode != null && failureMode.isCompleteFailure()
+            && productStatus == ProductSpecificationStatus.NOT_CONFIGURED
+            && productionIsUnchanged(result.getBaselineProductionRate(), simulatedProductionWithFailure)) {
+          consequenceResolved = false;
+          appendAnalysisNote(result,
+              "Complete equipment trip left nominal product flow unchanged; saleable-throughput consequence is "
+                  + "unresolved. Configure a product specification or topology-aware isolation/bypass model.");
+        }
 
         // Find new bottleneck
         BottleneckResult newBottleneck = findBottleneck(failedProcess);
@@ -256,10 +310,12 @@ public class ProductionImpactAnalyzer implements Serializable {
         result.setProductionWithFailure(0.0);
         result.setPowerWithFailure(0.0);
         result.setAnalysisNotes("Failed process did not converge: " + e.getMessage());
+        failedProcessConverged = false;
       }
 
       // Optimize degraded operation if requested
-      if (optimizeDegradedOperation && result.getProductionWithFailure() > 0) {
+      if (optimizeDegradedOperation && failedProcessConverged && consequenceResolved
+          && result.getProductionWithFailure() > 0) {
         optimizeDegradedOperation(failedProcess, equipmentName, result);
       }
 
@@ -274,7 +330,12 @@ public class ProductionImpactAnalyzer implements Serializable {
         result.setEstimatedRecoveryTime(failureMode.getMttr());
       }
 
-      result.setConverged(true);
+      result.setConverged(failedProcessConverged && consequenceResolved);
+      if (!consequenceResolved) {
+        result.setRecommendedAction(RecommendedAction.MANUAL_REVIEW);
+        result.setRecommendationReason(
+            "Failure consequence is unresolved; unchanged nominal flow must not be counted as confirmed saleable output");
+      }
 
     } catch (Exception e) {
       logger.error("Error analyzing failure impact for {}: {}", equipmentName, e.getMessage());
@@ -295,6 +356,7 @@ public class ProductionImpactAnalyzer implements Serializable {
     if (cachedBaselineProduction == null) {
       // Run baseline
       processSystem.run();
+      validateBaselineProductSpecification(processSystem);
       cachedBaselineProduction = getProductionRate(processSystem);
       cachedBaselinePower = getTotalPower(processSystem);
 
@@ -463,28 +525,118 @@ public class ProductionImpactAnalyzer implements Serializable {
    * @return the production rate in kg/hr, or 0.0 if unavailable
    */
   private double getProductionRate(ProcessSystem process) {
+    StreamInterface productStream = getProductStream(process);
+    return productStream == null ? 0.0 : productStream.getFlowRate("kg/hr");
+  }
+
+  /** Product-specification state for the simulated product stream. */
+  private enum ProductSpecificationStatus {
+    /** No product specification was configured. */
+    NOT_CONFIGURED,
+    /** Product stream satisfies the configured specification. */
+    ON_SPECIFICATION,
+    /** Product stream violates the configured specification. */
+    OFF_SPECIFICATION,
+    /** Product specification could not be evaluated. */
+    UNRESOLVED
+  }
+
+  /**
+   * Gets the configured product stream or the outlet of configured two-port equipment.
+   *
+   * @param process process containing the configured product
+   * @return product stream, or null if it cannot be resolved
+   */
+  private StreamInterface getProductStream(ProcessSystem process) {
     if (productStreamName == null) {
-      return 0.0;
+      return null;
     }
 
     ProcessEquipmentInterface unit = process.getUnit(productStreamName);
     if (unit instanceof StreamInterface) {
-      return ((StreamInterface) unit).getFlowRate("kg/hr");
+      return (StreamInterface) unit;
+    }
+    if (unit instanceof neqsim.process.equipment.TwoPortInterface) {
+      return ((neqsim.process.equipment.TwoPortInterface) unit).getOutletStream();
+    }
+    return null;
+  }
+
+  /**
+   * Validates that the baseline product satisfies any configured minimum pressure.
+   *
+   * @param process baseline process
+   */
+  private void validateBaselineProductSpecification(ProcessSystem process) {
+    if (minimumProductPressureBara == null) {
+      return;
+    }
+    StreamInterface productStream = getProductStream(process);
+    if (productStream == null) {
+      throw new IllegalStateException("Configured product stream could not be resolved for pressure specification");
+    }
+    double pressureBara = productStream.getPressure("bara");
+    if (!Double.isFinite(pressureBara) || pressureBara < minimumProductPressureBara) {
+      throw new IllegalStateException(
+          String.format("Baseline product pressure %.6g bara is below the configured minimum %.6g bara", pressureBara,
+              minimumProductPressureBara));
+    }
+  }
+
+  /**
+   * Evaluates the failed product against the configured minimum pressure.
+   *
+   * @param process failed process
+   * @param result result receiving diagnostic notes
+   * @return product specification status
+   */
+  private ProductSpecificationStatus evaluateProductSpecification(ProcessSystem process,
+      ProductionImpactResult result) {
+    if (minimumProductPressureBara == null) {
+      return ProductSpecificationStatus.NOT_CONFIGURED;
+    }
+    StreamInterface productStream = getProductStream(process);
+    if (productStream == null) {
+      appendAnalysisNote(result,
+          "Configured product stream could not be resolved; product specification is unresolved.");
+      return ProductSpecificationStatus.UNRESOLVED;
     }
 
-    // Try to get outlet stream via TwoPortInterface
-    try {
-      if (unit instanceof neqsim.process.equipment.TwoPortInterface) {
-        StreamInterface outlet = ((neqsim.process.equipment.TwoPortInterface) unit).getOutletStream();
-        if (outlet != null) {
-          return outlet.getFlowRate("kg/hr");
-        }
-      }
-    } catch (Exception e) {
-      // Equipment doesn't have outlet stream
+    double pressureBara = productStream.getPressure("bara");
+    if (!Double.isFinite(pressureBara)) {
+      appendAnalysisNote(result, "Failed product pressure is non-finite; product specification is unresolved.");
+      return ProductSpecificationStatus.UNRESOLVED;
     }
+    if (pressureBara < minimumProductPressureBara) {
+      appendAnalysisNote(result,
+          String.format("Product pressure %.6g bara is below minimum %.6g bara; saleable production set to zero.",
+              pressureBara, minimumProductPressureBara));
+      return ProductSpecificationStatus.OFF_SPECIFICATION;
+    }
+    return ProductSpecificationStatus.ON_SPECIFICATION;
+  }
 
-    return 0.0;
+  /**
+   * Checks whether failed production is unchanged from the baseline within numerical tolerance.
+   *
+   * @param baselineProduction baseline production rate
+   * @param failedProduction failed-case production rate
+   * @return true when rates are numerically unchanged
+   */
+  private boolean productionIsUnchanged(double baselineProduction, double failedProduction) {
+    double scale = Math.max(1.0, Math.max(Math.abs(baselineProduction), Math.abs(failedProduction)));
+    return Math.abs(baselineProduction - failedProduction) <= UNCHANGED_PRODUCTION_RELATIVE_TOLERANCE * scale;
+  }
+
+  /**
+   * Appends a diagnostic note without discarding an earlier note.
+   *
+   * @param result result to update
+   * @param note note to append
+   */
+  private void appendAnalysisNote(ProductionImpactResult result, String note) {
+    String existing = result.getAnalysisNotes();
+    result.setAnalysisNotes(existing == null || existing.trim().isEmpty() ? note : existing + " " + note);
   }
 
   /**
@@ -545,6 +697,10 @@ public class ProductionImpactAnalyzer implements Serializable {
 
     // Full shutdown produces nothing
     result.setFullShutdownProduction(0.0);
+
+    if (!result.isConverged()) {
+      return result;
+    }
 
     // Recalculate metrics with this in mind
     result.calculateDerivedMetrics();

--- a/src/main/java/neqsim/process/util/optimizer/ProductionImpactResult.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProductionImpactResult.java
@@ -63,7 +63,12 @@ public class ProductionImpactResult implements Serializable {
     /**
      * Switch to standby/spare equipment.
      */
-    USE_STANDBY
+    USE_STANDBY,
+
+    /**
+     * Failure consequence is unresolved and requires an explicit product specification or topology review.
+     */
+    MANUAL_REVIEW
   }
 
   // Equipment identification

--- a/src/test/java/neqsim/process/util/optimizer/ProductionImpactAnalyzerTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProductionImpactAnalyzerTest.java
@@ -81,6 +81,27 @@ public class ProductionImpactAnalyzerTest {
     process.add(compressor2);
   }
 
+  private ProcessSystem createSingleCompressorIssueProcess() {
+    SystemInterface gas = new SystemSrkEos(298.15, 50.0);
+    gas.addComponent("methane", 0.90);
+    gas.addComponent("ethane", 0.10);
+    gas.setMixingRule("classic");
+
+    Stream issueFeed = new Stream("Issue Feed", gas);
+    issueFeed.setFlowRate(10000.0, "kg/hr");
+    Separator issueSeparator = new Separator("Issue Separator", issueFeed);
+    Compressor issueCompressor = new Compressor("Issue Compressor", issueSeparator.getGasOutStream());
+    issueCompressor.setOutletPressure(100.0, "bara");
+    Stream gasOut = new Stream("Gas Out", issueCompressor.getOutletStream());
+
+    ProcessSystem issueProcess = new ProcessSystem();
+    issueProcess.add(issueFeed);
+    issueProcess.add(issueSeparator);
+    issueProcess.add(issueCompressor);
+    issueProcess.add(gasOut);
+    return issueProcess;
+  }
+
   @Test
   @DisplayName("Analyzer initialization auto-detects streams")
   void testAutoDetectStreams() {
@@ -103,7 +124,7 @@ public class ProductionImpactAnalyzerTest {
     ProductionImpactResult result = analyzer.analyzeFailureImpact("Stage 1 Compressor");
 
     assertNotNull(result);
-    assertTrue(result.isConverged());
+    assertFalse(result.isConverged());
     assertEquals("Stage 1 Compressor", result.getEquipmentName());
     assertEquals("Compressor", result.getEquipmentType());
 
@@ -111,6 +132,38 @@ public class ProductionImpactAnalyzerTest {
     assertTrue(result.getBaselineProductionRate() > 0, "Baseline should have production");
 
     logger.info(result);
+  }
+
+  @Test
+  @DisplayName("Complete trip with unchanged throughput is reported as unresolved")
+  void testCompleteTripWithUnchangedThroughputIsUnresolved() {
+    ProcessSystem issueProcess = createSingleCompressorIssueProcess();
+    ProductionImpactAnalyzer analyzer = new ProductionImpactAnalyzer(issueProcess, "Issue Feed", "Gas Out");
+    analyzer.setOptimizeDegradedOperation(false);
+    ProductionImpactResult result = analyzer.analyzeFailureImpact("Issue Compressor");
+
+    assertFalse(result.isConverged());
+    assertEquals(result.getBaselineProductionRate(), result.getProductionWithFailure(), 1.0e-8);
+    assertEquals(0.0, result.getPercentLoss(), 1.0e-8);
+    assertTrue(result.getAnalysisNotes().contains("unresolved"));
+    assertEquals(RecommendedAction.MANUAL_REVIEW, result.getRecommendedAction());
+  }
+
+  @Test
+  @DisplayName("Minimum product pressure rejects unchanged off-spec trip throughput")
+  void testMinimumProductPressureRejectsOffSpecTripThroughput() {
+    ProcessSystem issueProcess = createSingleCompressorIssueProcess();
+    ProductionImpactAnalyzer analyzer = new ProductionImpactAnalyzer(issueProcess, "Issue Feed", "Gas Out");
+    analyzer.setOptimizeDegradedOperation(false);
+    analyzer.setMinimumProductPressure(90.0, "bara");
+    ProductionImpactResult result = analyzer.analyzeFailureImpact("Issue Compressor");
+
+    assertTrue(result.isConverged());
+    assertTrue(result.getBaselineProductionRate() > 0.0);
+    assertEquals(0.0, result.getProductionWithFailure(), 0.0);
+    assertEquals(100.0, result.getPercentLoss(), 1.0e-8);
+    assertEquals(RecommendedAction.FULL_SHUTDOWN, result.getRecommendedAction());
+    assertTrue(result.getAnalysisNotes().contains("below minimum"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- treat unchanged nominal product flow after a complete equipment trip as an unresolved consequence when no product specification is configured
- return `converged=false`, `RecommendedAction.MANUAL_REVIEW`, and an explicit diagnostic instead of a confirmed 0% loss
- add an optional minimum product-pressure gate so off-spec throughput counts as zero saleable production
- preserve the raw unchanged flow for unresolved diagnostics and skip degraded-operation optimization until the consequence is resolved
- correct the production-impact guide to use current APIs and document the rate-only limitation

## Root cause

Complete failures deactivate the unit, but several NeqSim unit operations preserve or bypass nominal mass flow when inactive. The analyzer measured only product mass rate and then unconditionally set the result to converged, so an inactive compressor or separator could be reported as full saleable production.

## Validation

- The issue reproducer failed before the fix because a 10,000 kg/h compressor trip returned `converged=true` with unchanged flow and 0% loss.
- `ProductionImpactAnalyzerTest`: 14 tests passed on the Java 17 build.
- Clean `pomJava8.xml` compile targeting Java 8 plus all 14 focused tests: passed. The local runtime was JDK 17; GitHub CI remains the authoritative JDK 8 runtime check.
- `./mvnw spotless:apply` and `./mvnw spotless:check`: passed.
- `pre-commit run --all-files --hook-stage pre-commit`: passed.
- `pre-commit run --all-files --hook-stage pre-push`: passed, including documentation search coverage.
- Maven Checkstyle could not start locally because its uncached plugin dependencies were blocked by the restricted Maven Central network path; no Checkstyle result is claimed.

## Documentation impact

Updated class Javadoc and `docs/risk/production-impact.md` to document unresolved rate-only trips, `MANUAL_REVIEW`, the minimum product-pressure gate, and current analyzer/result APIs.

Closes #2859