### PR TITLE
Fix CPA one-phase aqueous stability selection

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -221,6 +221,15 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Replace only with a normalized, balanced, fugacity-equal, distinct,        │
 │       lower-Gibbs GAS+AQUEOUS endpoint; otherwise retain the original state       │
 │                                                                                 │
+│  IF ordinary CPA flash ends in one phase with water feed < 0.01:                │
+│     → Screen water fugacity against pure-water vapor pressure                    │
+│     → If f_water / p_water_sat >= 0.8, run the same aqueous TPD trial on a clone │
+│     → Rebuild and solve the two-phase active set when the trial adds a phase     │
+│     → Accept only a normalized, balanced, fugacity-equal, distinct GAS+AQUEOUS   │
+│       state that lowers Gibbs energy beyond max(1e-8 J, 1e-12 abs(G))            │
+│     → The saturation ratio gates cost only; TPD and strict acceptance decide     │
+│       stability                                                                   │
+│                                                                                 │
 │  IF ordinary, neutral, exactly-two-phase result contains an aqueous phase:       │
 │     → Evaluate gas-like and liquid-like roots of the non-aqueous cubic phase     │
 │     → Replace only with a lower-Gibbs root that already satisfies                │
@@ -270,6 +279,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Supplementary stability TPD limit | -1e-6 | Accept a converged amplified-K or composition-perturbation trial only when its reduced TPD exceeds that SSI solve's residual/step resolution and the trial composition is non-trivial |
 | Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for valid trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i)` is non-finite or above `1e-8`, allowing the bounded beta correction below without another stability calculation. An incipient trace-water GAS+OIL endpoint with `min(beta) <= 1e-4` also bypasses the threshold when its confirmed log-fugacity residual is non-finite or at least `1e-8`; the guarded candidate must then pass the strict feasibility and lower-Gibbs gates. |
 | Trace-water aqueous-stability screen | water feed `< 0.01`, GAS+OIL, `min(beta) <= 0.01`, and `x_water,oil >= 10 z_water` | Use the structural conditions only as a performance gate for an aqueous TPD trial. The TPD result, reduced-active-set convergence below `1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and lower Gibbs energy determine acceptance. Full recursive TPmultiflash is not run. |
+| CPA one-phase aqueous-stability screen | water feed `< 0.01`, one ordinary phase, CPA model, and `f_water / p_water_sat >= 0.8` | Use the fugacity ratio only as a conservative performance gate for the existing aqueous TPD trial. When the trial adds one phase, rebuild the two-phase active set and require beta-solver residual `< 1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and a Gibbs reduction larger than `max(1e-8 J, 1e-12 abs(G))`. The tighter Gibbs tolerance retains independently converged incipient aqueous fractions without treating the saturation screen itself as a stability criterion. |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
 | Dry cubic-root screen and acceptance | Screen normally ordered GAS+OIL endpoints when `max abs(Delta ln(f_i)) >= 1e-8`; accept below `1e-8` | Evaluate both roots for one phase at a time and retain a lower-Gibbs root seed only when the resulting unchanged composition split restores fugacity equality. Inverted mean-molar-mass order retains the paired-root comparison. |
 | Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
@@ -1735,6 +1745,13 @@ Commercial process simulators do not publish all implementation details, but pub
   feasible lower-Gibbs result. That invalid-endpoint retry is restricted to an incipient secondary phase with
   `min(beta) <= 1e-4`, so established valid gas/oil splits avoid even the component residual scan unless they satisfy
   the separate aqueous-stability screen.
+- A one-phase ordinary CPA endpoint containing trace water uses a cheap water-fugacity screen before the same aqueous
+  TPD trial. The screen compares water fugacity in the current phase with pure-water vapor pressure and triggers at a
+  ratio of `0.8`, conservatively below nominal saturation. This avoids a TPD calculation for clearly undersaturated
+  states. The ratio is not evidence that a second phase is stable: only the converged TPD candidate may add a phase,
+  and it must independently pass phase-fraction, normalization, material-balance, fugacity, distinct-composition, and
+  lower-Gibbs checks. For an incipient CPA aqueous split, the Gibbs comparison uses
+  `max(1e-8 J, 1e-12 abs(G))` so a valid small phase is not hidden by the broader endpoint-rescue tolerance.
 - When the tangent-plane stability path has already accepted a homogeneous state, an unnormalized aqueous trial seed
   cannot replace it. The guard is deliberately structural: each active phase composition must be finite, bounded in
   `[0, 1]`, and normalized within `1e-8`. It does not impose a universal material-balance or fugacity threshold on
@@ -1786,6 +1803,7 @@ Recommended regression coverage should include both numerical convergence and ph
 | Known phase-map spot cells | Methane/n-heptane PR cells at 78.5/194, 81/194, 186/424, and 191/418 bara/K | Each cold-start flash converges to gas-oil instead of an isolated one-phase island |
 | Critical-region robustness | Rich gas near cricondenbar and cricondentherm | No false single-phase result when TPD finds instability |
 | Polar/VLLE systems | Water, CO2, H2S, methanol, glycols, and CPA/electrolyte examples | Correct aqueous/oil/gas phase count and stable final split |
+| CPA aqueous appearance | Ordinary and explicit-multiphase flashes above and below the water-fugacity screen, including aqueous fractions near `1e-6` | Same stable phase set, beta, phase compositions, properties, material balance, fugacity equality, and deterministic repeatability |
 | Multiphase cleanup | Cases with small beta phases and duplicate aqueous candidates | Removed phases preserve total composition and final mass balance |
 | Documentation drift | Algorithm doc parameter table versus source constants | Stale thresholds are detected during review |
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -53,6 +53,19 @@ public class TPflash extends Flash {
   private static final double TRACE_WATER_AQUEOUS_STABILITY_BETA_LIMIT = 1.0e-2;
   /** Minimum water enrichment in the hydrocarbon liquid for the aqueous-stability trial. */
   private static final double TRACE_WATER_AQUEOUS_STABILITY_ENRICHMENT_LIMIT = 10.0;
+  /**
+   * Minimum ratio of water fugacity to pure-water vapor pressure for a CPA single-phase aqueous-stability trial.
+   *
+   * <p>
+   * The value is deliberately below unity so that the cheap screen remains conservative near aqueous phase appearance.
+   * It only decides whether to run the tangent-plane trial; it never accepts a phase split.
+   * </p>
+   */
+  private static final double CPA_WATER_SUPERSATURATION_SCREEN_LIMIT = 0.8;
+  /** Relative Gibbs-energy tolerance for accepting a balanced incipient CPA aqueous phase. */
+  private static final double CPA_AQUEOUS_GIBBS_RELATIVE_TOLERANCE = 1.0e-12;
+  /** Absolute Gibbs-energy tolerance (J) for accepting a balanced incipient CPA aqueous phase. */
+  private static final double CPA_AQUEOUS_GIBBS_ABSOLUTE_TOLERANCE_J = 1.0e-8;
   /** Maximum stored water K-value that justifies checking a collapsed water-bearing endpoint. */
   private static final double WATER_PHASE_COLLAPSE_WATER_K_UPPER_LIMIT = 1.0e-2;
   /** Minimum stored non-water K-value that justifies checking a collapsed water-bearing endpoint. */
@@ -997,7 +1010,7 @@ public class TPflash extends Flash {
       return;
     }
     if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
-        && (waterFeedFraction <= 0.0 || !shouldRefineTraceWaterGasOilEndpoint(waterFeedFraction))) {
+        && (waterFeedFraction <= 0.0 || !shouldRefineTraceWaterAqueousEndpoint(waterFeedFraction))) {
       return;
     }
     double materialBalanceResidual = maximumComponentMaterialBalanceResidual(system);
@@ -1019,8 +1032,11 @@ public class TPflash extends Flash {
         new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
         candidateConverged = true;
       }
+      boolean incipientCpaAqueousTrial = system.getNumberOfPhases() == 1 && !system.doMultiPhaseCheck()
+          && system.getModelName() != null && system.getModelName().contains("CPA");
       if (candidateConverged && candidate.getNumberOfPhases() == 2 && isBalancedEquilibriumCandidate(candidate)
-          && shouldAcceptWaterRichCandidate(candidate, referenceGibbsEnergy, materialBalanceInvalid)) {
+          && shouldAcceptWaterRichCandidate(candidate, referenceGibbsEnergy, materialBalanceInvalid,
+              incipientCpaAqueousTrial)) {
         copyFlashStateFrom(candidate);
       }
     } catch (Exception ex) {
@@ -1032,12 +1048,17 @@ public class TPflash extends Flash {
    * Screens a trace-water gas/oil endpoint for a missed lower-Gibbs aqueous split.
    *
    * @param waterFeedFraction overall water mole fraction
-   * @return true when the endpoint is already invalid, or its phase fraction and water enrichment justify an aqueous
-   * stability trial
+   * @return true when the endpoint is already invalid, its CPA water fugacity is near pure-water saturation, or its
+   * phase fraction and water enrichment justify an aqueous stability trial
    */
-  private boolean shouldRefineTraceWaterGasOilEndpoint(double waterFeedFraction) {
+  private boolean shouldRefineTraceWaterAqueousEndpoint(double waterFeedFraction) {
     if (isInvalidTraceWaterGasOilEndpoint()) {
       return true;
+    }
+    if (!system.doMultiPhaseCheck() && system.getNumberOfPhases() == 1) {
+      String modelName = system.getModelName();
+      return modelName != null && modelName.contains("CPA")
+          && isCpaWaterNearSaturation(CPA_WATER_SUPERSATURATION_SCREEN_LIMIT);
     }
     if (system.getNumberOfPhases() != 2 || system.hasPhaseType(PhaseType.AQUEOUS)
         || Math.min(system.getBeta(0), system.getBeta(1)) > TRACE_WATER_AQUEOUS_STABILITY_BETA_LIMIT) {
@@ -1065,6 +1086,32 @@ public class TPflash extends Flash {
   }
 
   /**
+   * Compares water fugacity in the current CPA phase with pure-water vapor pressure.
+   *
+   * <p>
+   * This is a performance screen, not a stability criterion. The subsequent tangent-plane-distance calculation and
+   * strict candidate acceptance checks decide whether an aqueous phase is stable.
+   * </p>
+   *
+   * @param minimumRatio minimum fugacity-to-vapor-pressure ratio that triggers a stability trial
+   * @return true when a finite water supersaturation ratio reaches the specified limit
+   */
+  private boolean isCpaWaterNearSaturation(double minimumRatio) {
+    PhaseInterface phase = system.getPhase(0);
+    for (int componentIndex = 0; componentIndex < phase.getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = phase.getComponent(componentIndex);
+      if (!"water".equalsIgnoreCase(component.getComponentName())) {
+        continue;
+      }
+      double vaporPressure = component.getAntoineVaporPressure(system.getTemperature());
+      double waterFugacity = component.getx() * component.getFugacityCoefficient() * system.getPressure();
+      double ratio = waterFugacity / vaporPressure;
+      return Double.isFinite(ratio) && ratio >= minimumRatio;
+    }
+    return false;
+  }
+
+  /**
    * Runs the existing tangent-plane trial and reconverges the reduced active phase set.
    *
    * <p>
@@ -1086,6 +1133,13 @@ public class TPflash extends Flash {
     }
     operation.setDoubleArrays();
     operation.solveBeta();
+    if (initialPhaseCount == 1 && candidate.getNumberOfPhases() == 2) {
+      candidate.normalizeBeta();
+      operation.setDoubleArrays();
+      double activeSetResidual = operation.solveBeta();
+      candidate.init(1);
+      return Double.isFinite(activeSetResidual) && activeSetResidual < 1.0e-10;
+    }
     int removedPhaseCount = 0;
     for (int phaseIndex = candidate.getNumberOfPhases() - 1; phaseIndex >= 0; phaseIndex--) {
       if (candidate.getNumberOfPhases() > 1 && candidate.getBeta(phaseIndex) <= 10.0 * phaseFractionMinimumLimit) {
@@ -1500,17 +1554,54 @@ public class TPflash extends Flash {
    *
    * @param candidate candidate system produced by the local seed retry
    * @param referenceGibbsEnergy Gibbs energy of the original one-phase endpoint
+   * @param referenceMaterialBalanceInvalid whether the reference is non-conservative and its Gibbs energy cannot be
+   * compared
    * @return true when the candidate is multiphase and has a lower Gibbs energy
    */
   private boolean shouldAcceptWaterRichCandidate(SystemInterface candidate, double referenceGibbsEnergy,
       boolean referenceMaterialBalanceInvalid) {
+    return shouldAcceptWaterRichCandidate(candidate, referenceGibbsEnergy, referenceMaterialBalanceInvalid, false);
+  }
+
+  /**
+   * Checks whether a water-rich candidate can replace its reference endpoint.
+   *
+   * @param candidate candidate system produced by the local seed retry
+   * @param referenceGibbsEnergy Gibbs energy of the original endpoint
+   * @param referenceMaterialBalanceInvalid whether the reference is non-conservative and its Gibbs energy cannot be
+   * compared
+   * @param incipientCpaAqueousTrial whether a one-phase CPA endpoint produced the candidate aqueous split
+   * @return true when the candidate passes the applicable strict thermodynamic acceptance gate
+   */
+  private boolean shouldAcceptWaterRichCandidate(SystemInterface candidate, double referenceGibbsEnergy,
+      boolean referenceMaterialBalanceInvalid, boolean incipientCpaAqueousTrial) {
     if (referenceMaterialBalanceInvalid) {
       return isBalancedEquilibriumCandidate(candidate);
+    }
+    if (incipientCpaAqueousTrial) {
+      double gibbsTolerance = Math.max(CPA_AQUEOUS_GIBBS_ABSOLUTE_TOLERANCE_J,
+          Math.abs(referenceGibbsEnergy) * CPA_AQUEOUS_GIBBS_RELATIVE_TOLERANCE);
+      return hasAcceptableMultiphaseCandidate(candidate)
+          && candidate.getGibbsEnergy() < referenceGibbsEnergy - gibbsTolerance;
     }
     return isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy);
   }
 
   private boolean isLowerGibbsMultiphaseCandidate(SystemInterface candidate, double referenceGibbsEnergy) {
+    if (!hasAcceptableMultiphaseCandidate(candidate)) {
+      return false;
+    }
+    double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceGibbsEnergy) * 1.0e-8);
+    return candidate.getGibbsEnergy() < referenceGibbsEnergy - gibbsTolerance;
+  }
+
+  /**
+   * Checks phase fractions and distinct compositions before comparing candidate Gibbs energy.
+   *
+   * @param candidate candidate system produced by a guarded stability trial
+   * @return true when the candidate has a normalized, non-vanishing, distinct multiphase active set
+   */
+  private boolean hasAcceptableMultiphaseCandidate(SystemInterface candidate) {
     if (candidate.getNumberOfPhases() < 2) {
       return false;
     }
@@ -1524,8 +1615,7 @@ public class TPflash extends Flash {
     if (Math.abs(betaTotal - 1.0) > 1.0e-6 || !hasDistinctPhaseCompositions(candidate)) {
       return false;
     }
-    double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceGibbsEnergy) * 1.0e-8);
-    return candidate.getGibbsEnergy() < referenceGibbsEnergy - gibbsTolerance;
+    return true;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCpaAqueousStabilityConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCpaAqueousStabilityConsistencyTest.java
@@ -1,0 +1,142 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashCpaAqueousStabilityConsistencyTest {
+  private static final String[] COMPONENTS = { "nitrogen", "CO2", "methane", "ethane", "propane", "nC10", "water" };
+
+  @Test
+  void ordinaryCpaFlashFindsStableAqueousPhaseAcrossAppearanceBoundary() {
+    double[][] states = { { 230.0, 120.0, 0.01, 0.001 }, { 270.0, 220.0, 0.0002, 0.003 } };
+
+    for (double[] state : states) {
+      SystemInterface ordinary = createAndFlash(state[0], state[1], state[2], state[3], false, false);
+      SystemInterface multiphase = createAndFlash(state[0], state[1], state[2], state[3], true, false);
+      SystemInterface poorGuess = createAndFlash(state[0], state[1], state[2], state[3], false, true);
+
+      assertBalancedGasAqueousEquilibrium(ordinary);
+      assertEquivalentEquilibrium(multiphase, ordinary);
+      assertEquivalentEquilibrium(ordinary, poorGuess);
+
+      SystemInterface repeated = ordinary.clone();
+      new ThermodynamicOperations(repeated).TPflash();
+      repeated.init(3);
+      assertEquivalentEquilibrium(ordinary, repeated);
+    }
+  }
+
+  @Test
+  void stableCpaGasRemainsSinglePhaseAndDeterministic() {
+    SystemInterface ordinary = createAndFlash(320.0, 5.0, 0.001, 0.001, false, false);
+    SystemInterface multiphase = createAndFlash(320.0, 5.0, 0.001, 0.001, true, false);
+    SystemInterface poorGuess = createAndFlash(320.0, 5.0, 0.001, 0.001, false, true);
+
+    assertEquals(1, ordinary.getNumberOfPhases());
+    assertEquals(PhaseType.GAS, ordinary.getPhase(0).getType());
+    assertEquivalentEquilibrium(multiphase, ordinary);
+    assertEquivalentEquilibrium(ordinary, poorGuess);
+
+    double gibbsEnergy = ordinary.getGibbsEnergy();
+    double enthalpy = ordinary.getEnthalpy();
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.init(3);
+    assertEquals(gibbsEnergy, ordinary.getGibbsEnergy(), 1.0e-10);
+    assertEquals(enthalpy, ordinary.getEnthalpy(), 1.0e-10);
+  }
+
+  private SystemInterface createAndFlash(double temperature, double pressure, double water, double decane,
+      boolean multiphaseCheck, boolean poorGuess) {
+    SystemInterface system = new SystemSrkCPAstatoil(temperature, pressure);
+    double[] amounts = { 0.02, 0.03, 0.85, 0.06, 0.03, decane, water };
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], amounts[componentIndex]);
+    }
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    if (poorGuess) {
+      system.setBeta(0, 1.0e-9);
+      system.setBeta(1, 1.0 - 1.0e-9);
+    }
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private void assertBalancedGasAqueousEquilibrium(SystemInterface system) {
+    assertEquals(2, system.getNumberOfPhases());
+    assertTrue(system.hasPhaseType(PhaseType.GAS));
+    assertTrue(system.hasPhaseType(PhaseType.AQUEOUS));
+    assertTrue(maximumComponentMaterialBalanceResidual(system) < 1.0e-8);
+    assertTrue(maximumLogFugacityResidual(system) < 1.0e-8);
+
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      assertTrue(system.getBeta(phaseIndex) > 0.0);
+      assertTrue(system.getBeta(phaseIndex) < 1.0);
+      betaTotal += system.getBeta(phaseIndex);
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        compositionTotal += system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-10);
+    }
+    assertEquals(1.0, betaTotal, 1.0e-12);
+  }
+
+  private void assertEquivalentEquilibrium(SystemInterface expected, SystemInterface actual) {
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-7);
+    assertEquals(expected.getEnthalpy(), actual.getEnthalpy(), 1.0e-7);
+    for (int expectedPhase = 0; expectedPhase < expected.getNumberOfPhases(); expectedPhase++) {
+      int actualPhase = findPhase(actual, expected.getPhase(expectedPhase).getType());
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), 1.0e-10);
+      assertEquals(expected.getPhase(expectedPhase).getDensity(), actual.getPhase(actualPhase).getDensity(), 1.0e-7);
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        assertEquals(expected.getPhase(expectedPhase).getComponent(componentIndex).getx(),
+            actual.getPhase(actualPhase).getComponent(componentIndex).getx(), 1.0e-10);
+      }
+    }
+  }
+
+  private int findPhase(SystemInterface system, PhaseType phaseType) {
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex).getType() == phaseType) {
+        return phaseIndex;
+      }
+    }
+    throw new AssertionError("Missing phase " + phaseType);
+  }
+
+  private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(system.getPhase(0).getComponent(componentIndex).getz() - recoveredFeed));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double firstLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+    }
+    return maximumResidual;
+  }
+}


### PR DESCRIPTION
## Problem

On exact `master` `a1f7817d57e013d14da31991cc160b570ca0cb62`, ordinary two-phase `TPflash` can accept a single CPA gas phase even though the explicit multiphase path finds a balanced, lower-Gibbs GAS+AQUEOUS equilibrium.

Minimal regression (SRK-CPA Statoil, mixing rule 2, 230 K, 120 bara; N2/CO2/CH4/C2/C3/nC10/water amounts 0.02/0.03/0.85/0.06/0.03/0.001/0.01):

- ordinary: one GAS phase, `G = 6353.903133419975 J`;
- explicit multiphase: GAS+AQUEOUS, `G = 6279.446755175433 J`;
- missed Gibbs reduction: `74.456378244542 J`.

This extends the trace-water consistency work in #2845 and #2853 to an ordinary one-phase CPA endpoint. It does not change the EOS-GE work in #2781 or stacked #2865.

## Root cause

The ordinary path's existing trace-water aqueous refinement only screened an already split GAS+OIL endpoint. A homogeneous CPA endpoint never reached the aqueous tangent-plane-distance trial. An unconditional CPA stability trial fixed the defect but made a clearly stable one-phase CPA flash roughly 8–9 times slower, so that approach was rejected.

A second boundary case exposed a separate acceptance-resolution issue: at 270 K and 220 bara the stable aqueous fraction is only `4.144427e-6`, and its `5.633e-5 J` Gibbs benefit was hidden by the broader endpoint-rescue tolerance.

## Method

1. For an ordinary, one-phase CPA endpoint with water feed below 0.01, compute the cheap performance screen
   `S_w = f_w / p_w^sat(T)`.
2. Run the existing Michelsen TPD trial only when `S_w >= 0.8`.
3. If the TPD trial adds an aqueous phase, rebuild and solve the two-phase active set.
4. Accept only when beta residual is below `1e-10`, phase fractions and compositions are normalized and bounded, component material balance and log-fugacity residuals are below `1e-8`, phase compositions are distinct, and Gibbs energy decreases by more than `max(1e-8 J, 1e-12 |G|)`.

The `0.8` screen is an empirically validated, deliberately conservative performance gate—not a phase-stability criterion. The TPD solve and strict thermodynamic acceptance remain authoritative.

Literature basis:

- Michelsen, “The isothermal flash problem. Part I. Stability,” *Fluid Phase Equilibria* 9 (1982), DOI [10.1016/0378-3812(82)85001-2](https://doi.org/10.1016/0378-3812%2882%2985001-2): tangent-plane stability testing.
- Michelsen, “The isothermal flash problem. Part II. Phase-split calculation,” *Fluid Phase Equilibria* 9 (1982), DOI [10.1016/0378-3812(82)85002-4](https://doi.org/10.1016/0378-3812%2882%2985002-4): stability-seeded phase split and second-order convergence.

Evidence versus inference: TPD, fugacity equality, conservation, and lower Gibbs energy are thermodynamic acceptance evidence. Using `f_w/p_w^sat` and the 0.8 margin is an implementation performance inference supported by the deterministic screens below.

## Before/after validation

Two deterministic audits were run against ordinary and explicit multiphase paths:

| Matrix | States | Failures | Valid ordinary→aqueous disagreements before | After |
|---|---:|---:|---:|---:|
| Broad CPA grid, 230–350 K, 1–200 bara | 1,470 | 0 | 54 | 0 |
| Dense appearance grid, 225–280 K, 80–220 bara | 2,880 | 0 | 1,148 | 0 |

The dense grid varied water from `5e-5` to `1e-2` and nC10 from `5e-4` to `3e-2`. The minimum screen ratio among the 1,148 confirmed aqueous instabilities was `0.894682`; the `0.8` screen therefore retained margin. It sent 10 stable one-phase states to TPD, where all were correctly rejected.

Representative final residuals:

| State | min(beta) | max component balance residual | max log-fugacity residual | ordinary/multiphase property agreement |
|---|---:|---:|---:|---:|
| 230 K, 120 bara | `1.3841e-2` | `1.96e-15` | `1.79e-10` | `|dG|=6.58e-10 J`, `|dH|=5.73e-9 J` |
| 270 K, 220 bara | `4.1444e-6` | `1.11e-16` | `6.54e-10` | `|dG|=1.82e-12 J`, `|dH|=7.55e-11 J` |

Repeated flashes and poor beta guesses were deterministic and matched the explicit multiphase state.

The audit still reports 39 valid CPA hydrocarbon-only ordinary/multiphase disagreements. They are retained and reported as a separate defect class; this PR does not hide them or loosen tolerances.

## Performance

Seven paired fresh-JVM runs, 20 warmups + 100 measured flashes per case:

| Case | master median | branch median | Interpretation |
|---|---:|---:|---|
| Stable one-phase CPA below screen | `958.5 us` | `908.8 us` | no regression; mixed-sign JVM noise |
| Dry CPA | `668.1 us` | `611.7 us` | unchanged path |
| SRK gas/oil | `1862.1 us` | `1987.7 us` | unchanged path; mixed-sign JVM noise |
| PR oil | `363.9 us` | `375.7 us` | unchanged path; mixed-sign JVM noise |
| Corrected CPA state | `2442.8 us` | `11455.9 us` | intentional TPD cost only for screened unstable state |

All unaffected-path checksums and phase counts were exact. No speedup is claimed; the measurable benefit is removal of the stable-phase-selection defect without the rejected 8–9x stable-CPA slowdown.

## Tests and gates

- New deterministic JUnit coverage: substantial and `4.14e-6` incipient aqueous phases, ordinary/multiphase equivalence, properties, conservation, fugacity, poor beta guesses, repeated execution, and a stable one-phase control.
- Focused `TPflash*Test,TPmultiflash*Test`: 46 passed on the rebased head.
- Post-format focused regression run: 9 passed.
- Java 17 compile: passed.
- `pre-commit run --all-files --hook-stage pre-commit`: passed.
- `pre-commit run --all-files --hook-stage pre-push`: passed.
- Spotless and documentation search over 646 Markdown pages plus one HTML page: passed.
- Local Javadoc generation was attempted but could not resolve offline-only Maven reporting dependencies; exact-head hosted Javadoc remains required.
- Full repository suite was not run locally.
- No notebook changed.

## Compatibility and risk

No public API, serialization field, EOS parameter, mixing rule, or user configuration changes. The new work is restricted to ordinary one-phase CPA systems containing trace water and passing the conservative saturation screen. Explicit multiphase, SRK, PR, chemical, ionic, solid, and wax paths retain their existing dispatch.

The primary compatibility risk is extra TPD cost for a small number of stable CPA states near the screen. The dense audit found 10 such false-positive screens out of 2,880 states; each retained the original state.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md` with the performance screen, active-set solve, numerical tolerances, evidence/inference distinction, and regression expectations. No notebook or release-installation guidance is affected.
