### PR TITLE
Fix flash compatibility density units

### DIFF
--- a/src/main/java/neqsim/mcp/runners/FlashRunner.java
+++ b/src/main/java/neqsim/mcp/runners/FlashRunner.java
@@ -305,7 +305,7 @@ public class FlashRunner {
 
       // Fluid data
       JsonObject fluidObj = JsonParser.parseString(fluidJson).getAsJsonObject();
-      addCompatibilityFields(fluidObj);
+      addCompatibilityFields(fluidObj, fluid);
       result.add("fluid", fluidObj);
 
       // Provenance (trust metadata)
@@ -392,25 +392,18 @@ public class FlashRunner {
    * Adds backward-compatible flattened fields used by older clients and tests.
    *
    * @param fluidObj fluid response JSON object
+   * @param fluid flashed fluid used to populate fields with fixed units
    */
-  private static void addCompatibilityFields(JsonObject fluidObj) {
+  private static void addCompatibilityFields(JsonObject fluidObj, SystemInterface fluid) {
     if (fluidObj == null) {
       return;
     }
 
     if (fluidObj.has("properties") && fluidObj.get("properties").isJsonObject()) {
       JsonObject properties = fluidObj.getAsJsonObject("properties");
-      if (properties.has("overall") && properties.get("overall").isJsonObject()) {
-        JsonObject overall = properties.getAsJsonObject("overall");
-        if (overall.has("density") && overall.get("density").isJsonObject()) {
-          JsonObject density = overall.getAsJsonObject("density");
-          if (density.has("value")) {
-            try {
-              properties.addProperty("density_kgm3", density.get("value").getAsDouble());
-            } catch (Exception ignored) {
-            }
-          }
-        }
+      try {
+        properties.addProperty("density_kgm3", fluid.getDensity("kg/m3"));
+      } catch (Exception ignored) {
       }
     }
 

--- a/src/test/java/neqsim/mcp/runners/FlashRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/FlashRunnerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import neqsim.util.unit.Units;
 
 /**
  * Tests for {@link FlashRunner}.
@@ -121,6 +122,29 @@ class FlashRunnerTest {
       }
     }
     assertTrue(hasViscosity, "Expected transport properties in phase data");
+  }
+
+  @Test
+  void testTPFlash_compatibilityDensityUsesKgPerCubicMeter() {
+    String json = "{" + "\"model\": \"SRK\"," + "\"temperature\": {\"value\": 25.0, \"unit\": \"C\"},"
+        + "\"pressure\": {\"value\": 100.0, \"unit\": \"bara\"}," + "\"components\": {\"methane\": 1.0}" + "}";
+
+    Units.activateFieldUnits();
+    try {
+      String result = FlashRunner.run(json);
+      JsonObject root = JsonParser.parseString(result).getAsJsonObject();
+
+      assertEquals("success", root.get("status").getAsString());
+      JsonObject properties = root.getAsJsonObject("fluid").getAsJsonObject("properties");
+      JsonObject reportedDensity = properties.getAsJsonObject("overall").getAsJsonObject("density");
+      assertEquals("lb/ft3", reportedDensity.get("unit").getAsString());
+
+      double densityLbPerFt3 = reportedDensity.get("value").getAsDouble();
+      double densityKgPerM3 = properties.get("density_kgm3").getAsDouble();
+      assertEquals(densityLbPerFt3 * 16.01846337396, densityKgPerM3, 1.0e-6);
+    } finally {
+      Units.activateDefaultUnits();
+    }
   }
 
   // --- PH flash tests ---


### PR DESCRIPTION
## Summary

- populate `density_kgm3` from an explicit `kg/m3` calculation instead of the active reporting unit
- add a regression test that runs the flash response under field units and verifies the compatibility field remains SI

## Root cause

`FluidResponse` correctly respects the globally active unit profile. The compatibility-field adapter copied that unit-dependent numeric value into a field named `density_kgm3`, so a preceding test that selected field units caused `4.68 lb/ft3` to be mislabeled as `4.68 kg/m3`.

## Validation

- `FlashRunnerTest`: 28 tests passed
- deterministic former failure (`FluidReportTest` followed by `BenchmarkValidationTest`): 8 tests passed
- Java 8 build via `pomJava8.xml`: 35 relevant tests passed
- `StatePersistenceRunnerTest`: 7 tests passed with a writable test home (the only other local full-suite failure was the read-only sandbox home)
- Spotless apply/check passed

The current red master workflow was also affected by the ongoing GitHub Actions outage; jobs failed or were cancelled while downloading actions or waiting for runners.

## Documentation impact

None. This restores the existing compatibility-field contract without changing the public schema.