### PR TITLE
fix(pipe): safeguard conservative low-flow initialization

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -221,10 +221,12 @@ try {
 
 `PipeFlowSystem.getConvergenceReport()` returns an immutable report for the latest solve. Solver
 type `1` uses a safeguarded coupled Newton solve for the physical-cell pressures and staggered
-face velocities. The outlet pressure is prescribed; neither boundary node is counted as an
-accumulating control volume. This coupled path currently supports positive flow only and fails
-with an explicit message for reversed flow. A completed transient solve requires all of the
-following:
+face velocities. When conservative species transport is enabled, the steady solve enters the
+coupled path directly; it does not first accept segregated pressure/velocity iterates that can
+reverse an otherwise supported low positive flow. The outlet pressure is prescribed; neither
+boundary node is counted as an accumulating control volume. This coupled path currently supports
+positive flow only and fails with an explicit message for reversed flow. A completed transient
+solve requires all of the following:
 
 - the maximum scaled continuity/momentum equation residual is at most `1e-10`; each row uses a
   fixed dimensional scale formed from the absolute equation terms at the initial iterate;
@@ -233,8 +235,12 @@ following:
   a relative tolerance of `1e-8`.
 
 Use `solveSteadyState(1)` before `solveTransient(1)` when selecting this validated hydraulic/EOS
-path. The coupled steady refinement is intentionally limited to type `1`; it does not overwrite
-the temperature or composition results produced by staged solver types `10` and `20`.
+path. The direct coupled steady path is selected by `setConservativeSpeciesTransport(true)` and is
+intentionally limited to type `1`; it does not overwrite the temperature or composition results
+produced by staged solver types `10` and `20`. There is no universal minimum-flow cutoff: supported
+low positive flow is determined by convergence of the scaled continuity and momentum equations and
+a finite, positive hydraulic/EOS state. Zero or reversed flow remains outside this coupled path's
+documented validity range and fails loudly.
 
 The pressure and velocity unknowns are interleaved so each equation couples only to its two
 nearest unknowns on either side. The Newton matrix is therefore stored and solved as a compact

--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -240,7 +240,10 @@ intentionally limited to type `1`; it does not overwrite the temperature or comp
 produced by staged solver types `10` and `20`. There is no universal minimum-flow cutoff: supported
 low positive flow is determined by convergence of the scaled continuity and momentum equations and
 a finite, positive hydraulic/EOS state. Zero or reversed flow remains outside this coupled path's
-documented validity range and fails loudly.
+documented validity range and fails loudly. A non-converged direct conservative steady solve also
+throws with its residual and iteration diagnostics before that state can initialize a transient;
+the compatibility setting that permits a failed report to return applies only to legacy,
+non-conservative operation.
 
 The pressure and velocity unknowns are interleaved so each equation couples only to its two
 nearest unknowns on either side. The Newton matrix is therefore stored and solved as a compact

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
@@ -1071,8 +1071,8 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
     }
     initMatrix();
 
-    if (dynamic && solverType == 1) {
-      if (conservativeSpeciesTransportEnabled) {
+    if (solverType == 1 && (dynamic || conservativeSpeciesTransportEnabled)) {
+      if (dynamic && conservativeSpeciesTransportEnabled) {
         solveCoupledHydraulicEosSpecies(initialFiniteVolumeMass);
       } else {
         solveCoupledHydraulicEos(initialFiniteVolumeMass);

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseFixedStaggeredGrid.java
@@ -1473,11 +1473,13 @@ public class OnePhaseFixedStaggeredGrid extends OnePhasePipeFlowSolver
         massEquationHistory[iteration], momentumEquationHistory[iteration],
         Arrays.copyOf(massEquationHistory, iteration + 1), Arrays.copyOf(momentumEquationHistory, iteration + 1),
         lineSearchFailed, numericalFailureDetail, true);
-    if (dynamic && !lastConvergenceReport.isConverged()) {
-      if (failOnNonConvergence) {
+    if (!lastConvergenceReport.isConverged()) {
+      if (conservativeSpeciesTransportEnabled || (dynamic && failOnNonConvergence)) {
         throw new IllegalStateException(lastConvergenceReport.getMessage());
       }
-      logger.warn("{}", lastConvergenceReport.getMessage());
+      if (dynamic) {
+        logger.warn("{}", lastConvergenceReport.getMessage());
+      }
     }
   }
 

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -104,6 +104,23 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  void unsupportedLowerFlowSteadyInitializationFailsWithResidualDiagnostics() {
+    PipeFlowSystem pipe = createConfiguredPipe(40, 15000.0, 0.1);
+
+    assertFalse(pipe.isFailOnNonConvergence());
+    IllegalStateException exception = assertThrows(IllegalStateException.class, () -> pipe.solveSteadyState(1));
+    OnePhaseFlowConvergenceReport report = pipe.getConvergenceReport();
+
+    assertFalse(report.isConverged());
+    assertTrue(report.isNonlinearMetricEquationResidual());
+    assertTrue(report.getNonlinearIterations() > 0);
+    assertEquals(report.getMessage(), exception.getMessage());
+    assertTrue(exception.getMessage().contains("scaled equation residual="));
+    assertTrue(exception.getMessage().contains("Final scaled continuity residual="));
+    assertTrue(exception.getMessage().contains("momentum residual="));
+  }
+
+  @Test
   void highResolutionSpeciesStepRetainsHydraulicEosSynchronization() {
     PipeFlowSystem pipe = createInitializedPipe(12, 3000.0);
     pipe.setConservativeSpeciesTransport(true);
@@ -490,6 +507,13 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
   }
 
   private static PipeFlowSystem createInitializedPipe(int nodes, double lengthMeters, double massFlowKgPerSecond) {
+    PipeFlowSystem pipe = createConfiguredPipe(nodes, lengthMeters, massFlowKgPerSecond);
+    pipe.solveSteadyState(1);
+    assertTrue(pipe.getConvergenceReport().isConverged(), pipe.getConvergenceReport().getMessage());
+    return pipe;
+  }
+
+  private static PipeFlowSystem createConfiguredPipe(int nodes, double lengthMeters, double massFlowKgPerSecond) {
     PipeFlowSystem pipe = new PipeFlowSystem();
     pipe.setInletThermoSystem(createGas(0.95, 0.05, massFlowKgPerSecond));
     pipe.setNumberOfLegs(1);
@@ -508,8 +532,6 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     pipe.createSystem();
     pipe.init();
     pipe.setConservativeSpeciesTransport(true);
-    pipe.solveSteadyState(1);
-    assertTrue(pipe.getConvergenceReport().isConverged(), pipe.getConvergenceReport().getMessage());
     return pipe;
   }
 

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/onephaseflowsystem/pipeflowsystem/OnePhaseConservativeSpeciesTest.java
@@ -73,6 +73,37 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  void lowPositiveFlowSteadyInitializationConvergesBeforeConservativeSpeciesStep() {
+    PipeFlowSystem first = runCompositionStep(40, 30.0, 2.5);
+    PipeFlowSystem repeated = runCompositionStep(40, 30.0, 2.5);
+    PipeFlowSystem nearby = createInitializedPipe(40, 15000.0, 1.25);
+
+    OnePhaseFlowConvergenceReport firstFlow = first.getConvergenceReport();
+    OnePhaseSpeciesConservationReport firstSpecies = first.getSpeciesConservationReport();
+    assertTrue(firstFlow.isConverged(), firstFlow.getMessage());
+    assertTrue(firstFlow.isNonlinearMetricEquationResidual(), firstFlow.getMessage());
+    assertTrue(firstFlow.getMaximumScaledMassEquationResidual() <= 1.0e-10, firstFlow.getMessage());
+    assertTrue(firstFlow.getMaximumScaledMomentumEquationResidual() <= 1.0e-10, firstFlow.getMessage());
+    assertTrue(firstSpecies.isConverged(), firstSpecies.getMessage());
+    assertTrue(firstSpecies.getMaximumRelativeInventoryResidual() < 1.0e-8, firstSpecies.getMessage());
+    assertTrue(firstSpecies.getMaximumThermodynamicMassFractionError() <= 1.0e-10, firstSpecies.getMessage());
+    assertArrayEquals(firstSpecies.getFinalInventoryKg(), repeated.getSpeciesConservationReport().getFinalInventoryKg(),
+        0.0);
+    assertArrayEquals(firstSpecies.getMassFractionProfile()[1],
+        repeated.getSpeciesConservationReport().getMassFractionProfile()[1], 0.0);
+
+    OnePhaseFlowConvergenceReport nearbyFlow = nearby.getConvergenceReport();
+    assertTrue(nearbyFlow.isConverged(), nearbyFlow.getMessage());
+    assertTrue(nearbyFlow.getMaximumScaledMassEquationResidual() <= 1.0e-10, nearbyFlow.getMessage());
+    assertTrue(nearbyFlow.getMaximumScaledMomentumEquationResidual() <= 1.0e-10, nearbyFlow.getMessage());
+    for (int node = 0; node < nearby.getTotalNumberOfNodes(); node++) {
+      assertTrue(Double.isFinite(nearby.getNode(node).getVelocity()));
+      assertTrue(nearby.getNode(node).getVelocity() > 0.0,
+          "Supported positive-flow initialization must remain positive at node " + node);
+    }
+  }
+
+  @Test
   void highResolutionSpeciesStepRetainsHydraulicEosSynchronization() {
     PipeFlowSystem pipe = createInitializedPipe(12, 3000.0);
     pipe.setConservativeSpeciesTransport(true);
@@ -397,7 +428,11 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
   }
 
   static PipeFlowSystem runCompositionStep(int nodes, double timeStep) {
-    PipeFlowSystem pipe = createInitializedPipe(nodes);
+    return runCompositionStep(nodes, timeStep, MASS_FLOW_KG_PER_SECOND);
+  }
+
+  private static PipeFlowSystem runCompositionStep(int nodes, double timeStep, double massFlowKgPerSecond) {
+    PipeFlowSystem pipe = createInitializedPipe(nodes, 15000.0, massFlowKgPerSecond);
     pipe.setConservativeSpeciesTransport(true);
     pipe.setFailOnNonConvergence(true);
     pipe.getTimeSeries().setTimes(new double[] { 0.0, timeStep });
@@ -451,8 +486,12 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
   }
 
   private static PipeFlowSystem createInitializedPipe(int nodes, double lengthMeters) {
+    return createInitializedPipe(nodes, lengthMeters, MASS_FLOW_KG_PER_SECOND);
+  }
+
+  private static PipeFlowSystem createInitializedPipe(int nodes, double lengthMeters, double massFlowKgPerSecond) {
     PipeFlowSystem pipe = new PipeFlowSystem();
-    pipe.setInletThermoSystem(createGas(0.95, 0.05));
+    pipe.setInletThermoSystem(createGas(0.95, 0.05, massFlowKgPerSecond));
     pipe.setNumberOfLegs(1);
     pipe.setNumberOfNodesInLeg(nodes);
     GeometryDefinitionInterface[] geometry = { new PipeData(), new PipeData() };
@@ -468,6 +507,7 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     pipe.setLegOuterHeatTransferCoefficients(new double[] { 0.0, 0.0 });
     pipe.createSystem();
     pipe.init();
+    pipe.setConservativeSpeciesTransport(true);
     pipe.solveSteadyState(1);
     assertTrue(pipe.getConvergenceReport().isConverged(), pipe.getConvergenceReport().getMessage());
     return pipe;
@@ -580,6 +620,10 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
   }
 
   private static SystemInterface createGas(double methane, double nitrogen) {
+    return createGas(methane, nitrogen, MASS_FLOW_KG_PER_SECOND);
+  }
+
+  private static SystemInterface createGas(double methane, double nitrogen, double massFlowKgPerSecond) {
     SystemInterface gas = new SystemSrkEos(TEMPERATURE_K, PRESSURE_BARA);
     gas.addComponent("methane", methane);
     gas.addComponent("nitrogen", nitrogen);
@@ -588,7 +632,7 @@ class OnePhaseConservativeSpeciesTest extends neqsim.NeqSimTest {
     gas.init(0);
     gas.init(3);
     gas.initPhysicalProperties();
-    gas.setTotalFlowRate(MASS_FLOW_KG_PER_SECOND, "kg/sec");
+    gas.setTotalFlowRate(massFlowKgPerSecond, "kg/sec");
     return gas;
   }
 }


### PR DESCRIPTION
## Summary

Route opt-in conservative solver type 1 directly through the existing safeguarded coupled hydraulic/EOS Newton solve during steady initialization. This prevents the legacy segregated pre-sweep from creating an unaccepted reversed-flow iterate before conservative transient species tracking begins.

A conservative steady solve must now either converge or throw the existing residual/iteration report. It can no longer return an unaccepted hydraulic/EOS state merely because transient `failOnNonConvergence` compatibility is disabled.

Refs #899.

## Reproducible baseline

Tested from current `master` `a1f7817d57e013d14da31991cc160b570ca0cb62`:

- SRK EOS with classic mixing rule
- methane/nitrogen = 95/5 mole fraction
- 288.15 K and 70 bara
- horizontal 15,000 m × 0.5 m pipe
- 40 requested nodes; roughness `1e-5 m`
- positive inlet mass flow 2.5 kg/s
- one 30 s inlet composition step to methane/nitrogen = 80/20

Unmodified master fails during steady initialization with:

```
IllegalStateException: Cannot synchronize a non-finite one-phase molar flow with the EOS state.
```

The segregated iteration had previously been traced in #899 to an artificial local sign reversal followed by non-finite wall friction and momentum coefficients. This is a numerical-initialization defect, not evidence for a universal minimum-flow cutoff.

The follow-up audit found a second fail-loud gap on the PR head: `solveCoupledHydraulicEos` created a failed convergence report but only threw in dynamic mode. Consequently `OnePhasePipeLine.run()` could mark an unconverged conservative steady state initialized. Frozen acceptance criterion: any direct conservative steady solve must converge inside the existing equation-residual tolerances or throw the exact actionable report before transient state ownership.

## Implementation

The finite-volume hydraulic equations and closures are unchanged:

```
d(rho A)/dt + d(rho u A)/dx = 0
d(rho u A)/dt + d(rho u^2 A)/dx + A dp/dx = wall friction + gravity
```

All quantities remain SI internally: pressure Pa, density kg/m³, velocity m/s, mass flow kg/s, length m, and time s.

When `setConservativeSpeciesTransport(true)` and solver type 1 are selected, steady initialization now enters the same positive-pressure/positive-flow safeguarded Newton path already used for accepted transient hydraulic/EOS steps. The steady solve remains hydraulic only; conservative species inventories advance only in dynamic mode. A failed direct conservative steady solve always throws its immutable convergence report; the compatibility option allowing a failed report to return remains limited to legacy non-conservative operation. Legacy non-conservative steady type 1 and staged solver types 10/20 otherwise retain their existing behavior and fixed-point regression.

Validity remains one gas phase with strictly positive flow. Zero/reversed flow is still rejected explicitly. No clipping, flow threshold, tolerance relaxation, transport limiter, axial-dispersion model, EOS, friction closure, or public API changed.

## Validation

Low-flow positive controls:

- 2.5 kg/s steady scaled continuity residual: `2.303e-13`
- 2.5 kg/s steady scaled momentum residual: `4.415e-11`
- density synchronization residual: `0`
- 30 s component inventory residual: `1.309e-11`
- thermodynamic mass-fraction synchronization: `2.220e-16`
- 4 hydraulic/species coupling iterations
- repeated 2.5 kg/s runs are bit-identical
- nearby 1.25 kg/s case converges with maximum scaled residual `9.593e-11` and positive finite velocity at every node
- unchanged-boundary legacy fixed-point behavior remains exact

Fail-loud regression at a lower positive but currently unsupported operating point:

- 0.1 kg/s, otherwise identical state and geometry
- deterministic `LINE_SEARCH_FAILED` after 3 nonlinear iterations
- scaled equation residual `2.2284121770077547e-10` versus frozen `1e-10` tolerance
- final continuity residual `6.94e-17`; momentum residual `2.228e-10`; EOS/FV density residual `0`
- throws before initialization even with `failOnNonConvergence == false`
- exception text exactly equals the immutable convergence report and includes scaled equation, continuity, momentum, and iteration diagnostics

Final test set: 66 focused/relevant tests passed across `OnePhaseConservativeSpeciesTest`, `PipeFlowSystemTest`, `OnePhaseFlowConvergenceTest`, `ConservativeSpeciesTransportTest`, `OnePhasePipeLineCompositionalTest`, `TwoFluidPipeComponentTransportTest`, `TwoFluidPipeMassBalanceTest`, and `TransientThreePhaseFlowTest`.

The explicit TwoFluid final gate included:

- closed wet-gas cooling across the water dew point with per-component and phase mass closure, equal/opposite interphase transfer, and latent-inclusive energy closure;
- open/closed gas-liquid mass-balance and outlet-flux cases across explicit/IMEX integrators;
- a CPA gas/oil/water transient with finite, bounded liquid inventory.

Formatting and repository gates:

- Java 17 / Maven 3.9.12, NeqSim 3.16.0
- Java 8 Temurin 1.8.0_502 source compilation: pass; changed production class bytecode major version 52
- `./mvnw -o -Dtest=OnePhaseConservativeSpeciesTest test`: 11/11 pass
- broader pipeline/TwoFluid matrix: 65/65 pass
- explicit slow `TransientThreePhaseFlowTest`: 1/1 pass
- `./mvnw spotless:apply`: pass
- `./mvnw spotless:check`: pass
- `pre-commit run --all-files --hook-stage pre-commit`: pass
- `pre-commit run --all-files --hook-stage pre-push`: pass
- documentation search: pass, 646 Markdown pages + 1 standalone HTML page
- `git diff --check`: pass

Local Javadoc generation could not run because the isolated Maven cache lacks reporting dependencies; no Javadocs were changed. Hosted Javadoc CI remains required before merge readiness.

## Evidence and limitations

The change closes the initialization prerequisite only. It does not claim OLGA or LedaFlow equivalence and does not modify TwoFluid closures. The dependency ordering is consistent with published work that separates conservative hydraulic initialization from numerical spreading and higher-resolution composition transport:

- [Chaczykowski et al. (2018), Gas composition tracking in transient pipeline flow](https://doi.org/10.1016/j.jngse.2018.03.014)
- [Bleschke & Chaczykowski (2024), Composition tracking using high-resolution schemes](https://doi.org/10.1016/j.ijhydene.2024.06.402)
- [Gyrya & Zlotnik (2019), conservative staggered-grid transient gas pipeline method](https://doi.org/10.1016/j.apm.2018.07.051)

Publicly documented commercial scope was reviewed only to prioritize gaps: [OLGA core](https://www.slb.com/products-and-services/delivering-digital-at-scale/software/olga/olga-pipeline-management/olga-core-system) describes transient three-phase slip, while [LedaFlow 2.13](https://kongsbergdigital.com/news/releasing-ledaflow-2.13) documents recent slug-capturing/dispersion work. No proprietary implementation detail was used.

Remaining dependency-ordered gap map:

1. P1: public TwoFluid pressure/holdup transient benchmark ladder and phase-transition sweeps.
2. P1: severe-slug topology/dynamic benchmark completion in #2741.
3. P2: hydrodynamic slug growth, period, amplitude, frequency, and mesh/time convergence.
4. P2: independently validated oil-water-gas slip, inversion, wetting, and phase appearance.
5. P2: startup/shutdown, minimum stable flow, and turndown after the above foundations.
6. P3: broader heat/mass-transfer benchmarks and performance optimization.

## Documentation impact

Updated `docs/fluidmechanics/single_phase_pipe_flow.md` to document direct conservative steady ownership, positive-flow validity, equation-residual acceptance, fail-loud behavior before transient initialization, and the absence of a universal mass-flow cutoff. No notebook or executable example changed.
