### PR TITLE
Fix MCP security lockout and propagate caller identity

### DIFF
--- a/neqsim-mcp-server/src/main/java/neqsim/mcp/server/McpIdentityResolver.java
+++ b/neqsim-mcp-server/src/main/java/neqsim/mcp/server/McpIdentityResolver.java
@@ -1,0 +1,137 @@
+package neqsim.mcp.server;
+
+import java.util.HashSet;
+import java.util.Set;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import neqsim.mcp.runners.McpRequestContext;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+/**
+ * Resolves the caller identity for one MCP tool invocation and binds it to
+ * {@link McpRequestContext}.
+ *
+ * <p>
+ * Identity is never accepted as a tool argument. It is resolved from, in order:
+ * </p>
+ * <ol>
+ * <li>the Quarkus {@link SecurityIdentity} established by the OIDC bearer-token filter on the HTTP
+ * transport — the enterprise path used by Microsoft Copilot Studio and other remote clients;</li>
+ * <li>the {@code NEQSIM_MCP_API_KEY} environment variable — the service-to-service and CI path for
+ * the stdio transport, where no HTTP request context exists;</li>
+ * <li>anonymous, which is correct for local desktop use with security enforcement disabled.</li>
+ * </ol>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+@ApplicationScoped
+public class McpIdentityResolver {
+
+  /** Environment variable carrying a service credential for the stdio transport. */
+  static final String API_KEY_ENV = "NEQSIM_MCP_API_KEY";
+
+  /** Claim holding the tenant or project scope in Entra ID / generic OIDC tokens. */
+  private static final String TENANT_CLAIM = "tid";
+
+  /** Quarkus security identity, unsatisfied or context-less on the stdio transport. */
+  @Inject
+  Instance<SecurityIdentity> securityIdentity;
+
+  /**
+   * Binds the resolved principal to the current thread for the duration of one tool invocation.
+   *
+   * <p>
+   * Never throws: identity resolution must not be able to fail a calculation. Any failure degrades
+   * to the anonymous principal, which the security layer then rejects when enforcement is on.
+   * </p>
+   */
+  public void bindCurrentPrincipal() {
+    McpRequestContext.Principal principal = resolve();
+    McpRequestContext.set(principal);
+  }
+
+  /**
+   * Resolves the caller identity from the available transport context.
+   *
+   * @return the resolved principal, or {@link McpRequestContext.Principal#anonymous()}
+   */
+  private McpRequestContext.Principal resolve() {
+    McpRequestContext.Principal fromToken = resolveFromSecurityIdentity();
+    if (fromToken != null) {
+      return fromToken;
+    }
+    String envKey = System.getenv(API_KEY_ENV);
+    if (envKey != null && !envKey.trim().isEmpty()) {
+      return McpRequestContext.Principal.ofApiKey(envKey.trim());
+    }
+    return McpRequestContext.Principal.anonymous();
+  }
+
+  /**
+   * Resolves the principal from a validated OIDC bearer token, when one is present.
+   *
+   * @return a principal built from token claims, or null when no authenticated identity is available
+   */
+  private McpRequestContext.Principal resolveFromSecurityIdentity() {
+    try {
+      if (securityIdentity == null || securityIdentity.isUnsatisfied()) {
+        return null;
+      }
+      SecurityIdentity identity = securityIdentity.get();
+      if (identity == null || identity.isAnonymous() || identity.getPrincipal() == null) {
+        return null;
+      }
+      String subject = identity.getPrincipal().getName();
+      if (subject == null || subject.trim().isEmpty()) {
+        return null;
+      }
+      Set<String> roles = new HashSet<String>(identity.getRoles());
+      return McpRequestContext.Principal.ofClaims(subject, tenantClaim(identity), roles, issuerClaim(identity));
+    } catch (Exception e) {
+      // No active request context (stdio transport) or OIDC disabled — fall through to anonymous.
+      return null;
+    }
+  }
+
+  /**
+   * Reads the tenant claim from a JWT-backed identity.
+   *
+   * @param identity the authenticated identity
+   * @return the tenant claim value, or null when unavailable
+   */
+  private String tenantClaim(SecurityIdentity identity) {
+    JsonWebToken token = asJwt(identity);
+    if (token == null) {
+      return null;
+    }
+    Object tenant = token.getClaim(TENANT_CLAIM);
+    return tenant != null ? String.valueOf(tenant) : null;
+  }
+
+  /**
+   * Reads the issuer claim from a JWT-backed identity.
+   *
+   * @param identity the authenticated identity
+   * @return the issuer claim value, or null when unavailable
+   */
+  private String issuerClaim(SecurityIdentity identity) {
+    JsonWebToken token = asJwt(identity);
+    return token != null ? token.getIssuer() : null;
+  }
+
+  /**
+   * Returns the identity principal as a JWT when the token type supports claims.
+   *
+   * @param identity the authenticated identity
+   * @return the JWT principal, or null for non-JWT identities
+   */
+  private JsonWebToken asJwt(SecurityIdentity identity) {
+    if (identity.getPrincipal() instanceof JsonWebToken) {
+      return (JsonWebToken) identity.getPrincipal();
+    }
+    return null;
+  }
+}

--- a/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
+++ b/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
@@ -95,6 +95,10 @@ import neqsim.mcp.runners.Validator;
 @ApplicationScoped
 public class NeqSimTools {
 
+  /** Resolves the caller identity from the transport for each tool invocation. */
+  @jakarta.inject.Inject
+  McpIdentityResolver identityResolver;
+
   /**
    * Run a thermodynamic flash calculation on a fluid mixture.
    *
@@ -2426,10 +2430,19 @@ public class NeqSimTools {
   /**
    * Enforces shared MCP server policy for a tool invocation.
    *
+   * <p>
+   * This is the single choke point every {@code @Tool} method calls first, so it is also where the
+   * transport-resolved caller identity is bound to {@link neqsim.mcp.runners.McpRequestContext}.
+   * Governance then evaluates a real principal instead of a null credential.
+   * </p>
+   *
    * @param toolName the MCP tool name
    * @return null if execution may continue, otherwise a standardized blocked response
    */
-  private static String enforceToolAccess(String toolName) {
+  private String enforceToolAccess(String toolName) {
+    if (identityResolver != null) {
+      identityResolver.bindCurrentPrincipal();
+    }
     String blocked = IndustrialProfile.enforceAccess(toolName);
     if (blocked == null) {
       return null;

--- a/src/main/java/neqsim/mcp/runners/IndustrialProfile.java
+++ b/src/main/java/neqsim/mcp/runners/IndustrialProfile.java
@@ -97,7 +97,7 @@ public final class IndustrialProfile {
   /** Environment variable containing the admin token for governed runtime changes. */
   private static final String ADMIN_TOKEN_ENV = "NEQSIM_MCP_ADMIN_TOKEN";
 
-  /** One-shot approvals keyed by MCP tool name. */
+  /** One-shot approvals keyed by principal subject and MCP tool name. */
   private static final Set<String> APPROVED_ONCE = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
   /** Active deployment mode. */
@@ -341,10 +341,11 @@ public final class IndustrialProfile {
    * @return null if allowed, or a JSON error string if blocked
    */
   public static String enforceAccess(String toolName) {
-    String securityBlocked = SecurityRunner.checkAccess(null, toolName);
+    String securityBlocked = SecurityRunner.checkAccess(McpRequestContext.currentCredential(), toolName);
     if (securityBlocked != null) {
       return policyErrorJson("blocked", toolName, "SECURITY", "Security policy denied access",
-          "Inspect manageSecurity/getStatus and provide valid credentials when security is enabled.");
+          "Authenticate at the transport layer (API key header or OAuth bearer token), "
+              + "then retry. Use manageSecurity/getStatus to inspect enforcement state.");
     }
     if (isToolAllowed(toolName)) {
       if (requiresApproval(toolName) && !consumeApproval(toolName)) {
@@ -382,11 +383,12 @@ public final class IndustrialProfile {
       return policyErrorJson("blocked", toolName, "UNKNOWN_TOOL", "Cannot approve unknown MCP tool '" + toolName + "'.",
           "Use checkToolAccess or getCapabilities to choose a valid tool name.");
     }
-    APPROVED_ONCE.add(toolName);
+    APPROVED_ONCE.add(approvalKey(toolName));
     JsonObject response = new JsonObject();
     response.addProperty("status", "success");
     response.addProperty("tool", toolName);
     response.addProperty("approval", "next_invocation");
+    response.addProperty("approvedFor", McpRequestContext.currentSubject());
     response.addProperty("message", "Next invocation of " + toolName + " is approved once.");
     ApiEnvelope.applyStandardFields(response, "manageIndustrialProfile", null,
         ApiEnvelope.validationStatus(true, "policy", "Approval recorded"),
@@ -429,13 +431,23 @@ public final class IndustrialProfile {
   }
 
   /**
-   * Consumes a pending one-shot approval.
+   * Consumes a pending one-shot approval for the calling principal.
    *
    * @param toolName the tool being invoked
    * @return true if an approval was available and consumed
    */
   private static boolean consumeApproval(String toolName) {
-    return APPROVED_ONCE.remove(toolName);
+    return APPROVED_ONCE.remove(approvalKey(toolName));
+  }
+
+  /**
+   * Builds the approval key binding a tool to the principal it was approved for.
+   *
+   * @param toolName the MCP tool name
+   * @return the approval key
+   */
+  private static String approvalKey(String toolName) {
+    return McpRequestContext.currentSubject() + "::" + toolName;
   }
 
   /**

--- a/src/main/java/neqsim/mcp/runners/McpRequestContext.java
+++ b/src/main/java/neqsim/mcp/runners/McpRequestContext.java
@@ -1,0 +1,251 @@
+package neqsim.mcp.runners;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Per-request caller identity for the NeqSim MCP server.
+ *
+ * <p>
+ * The MCP tool facade does not accept credentials as tool arguments — secrets must never travel through model-visible
+ * tool parameters. Instead the transport layer (stdio launcher, HTTP filter, or OAuth resource-server filter) resolves
+ * the caller once and binds a {@link Principal} to the serving thread. Governance code such as
+ * {@link IndustrialProfile#enforceAccess(String)} and {@link SecurityRunner#checkAccess(String, String)} then reads the
+ * bound principal instead of receiving a hard-coded null credential.
+ * </p>
+ *
+ * <p>
+ * When nothing is bound, {@link #current()} returns {@link Principal#anonymous()}. That keeps local desktop usage
+ * (security disabled) working unchanged while allowing enforcement to fail closed when security is enabled.
+ * </p>
+ *
+ * <p>
+ * Typical transport usage:
+ * </p>
+ *
+ * <pre>
+ * McpRequestContext.set(Principal.ofApiKey(apiKeyFromHeader));
+ * try {
+ *   return tool.invoke(arguments);
+ * } finally {
+ *   McpRequestContext.clear();
+ * }
+ * </pre>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public final class McpRequestContext {
+
+  /** Thread-bound principal for the request currently being served. */
+  private static final ThreadLocal<Principal> CURRENT = new ThreadLocal<Principal>();
+
+  /**
+   * Private constructor — utility class.
+   */
+  private McpRequestContext() {
+  }
+
+  /**
+   * Binds a principal to the current thread for the duration of one MCP request.
+   *
+   * @param principal the resolved caller identity, or null to clear the binding
+   */
+  public static void set(Principal principal) {
+    if (principal == null) {
+      CURRENT.remove();
+    } else {
+      CURRENT.set(principal);
+    }
+  }
+
+  /**
+   * Returns the principal bound to the current thread.
+   *
+   * @return the bound principal, or {@link Principal#anonymous()} when nothing is bound
+   */
+  public static Principal current() {
+    Principal principal = CURRENT.get();
+    return principal != null ? principal : Principal.anonymous();
+  }
+
+  /**
+   * Returns the credential of the current principal.
+   *
+   * @return the API key or bearer subject credential, or null when the caller is anonymous
+   */
+  public static String currentCredential() {
+    return current().getCredential();
+  }
+
+  /**
+   * Returns the audit subject of the current principal.
+   *
+   * @return a non-null subject identifier suitable for audit records
+   */
+  public static String currentSubject() {
+    return current().getSubject();
+  }
+
+  /**
+   * Removes any principal bound to the current thread. Transports must call this in a finally block so pooled threads
+   * never leak identity between requests.
+   */
+  public static void clear() {
+    CURRENT.remove();
+  }
+
+  /**
+   * Immutable caller identity resolved by the transport layer.
+   */
+  public static final class Principal {
+
+    /** Shared anonymous principal used when no identity is bound. */
+    private static final Principal ANONYMOUS = new Principal(null, "anonymous", "default",
+        Collections.<String>emptySet(), null, false);
+
+    /** Raw credential presented by the caller (API key, or bearer token subject). */
+    private final String credential;
+
+    /** Stable subject identifier used for audit records. */
+    private final String subject;
+
+    /** Tenant or project scope the request belongs to. */
+    private final String tenant;
+
+    /** Roles granted to the caller. */
+    private final Set<String> roles;
+
+    /** Token issuer, when the identity came from an OIDC provider. */
+    private final String issuer;
+
+    /** Whether the transport actually authenticated this caller. */
+    private final boolean authenticated;
+
+    /**
+     * Creates a principal.
+     *
+     * @param credential raw credential, or null for anonymous callers
+     * @param subject stable subject identifier, must not be null
+     * @param tenant tenant or project scope, must not be null
+     * @param roles granted roles, must not be null
+     * @param issuer token issuer, or null when not applicable
+     * @param authenticated whether the transport authenticated the caller
+     */
+    private Principal(String credential, String subject, String tenant, Set<String> roles, String issuer,
+        boolean authenticated) {
+      this.credential = credential;
+      this.subject = subject;
+      this.tenant = tenant;
+      this.roles = Collections.unmodifiableSet(new HashSet<String>(roles));
+      this.issuer = issuer;
+      this.authenticated = authenticated;
+    }
+
+    /**
+     * Returns the shared anonymous principal.
+     *
+     * @return an unauthenticated principal with no credential
+     */
+    public static Principal anonymous() {
+      return ANONYMOUS;
+    }
+
+    /**
+     * Creates an authenticated principal from an API key presented at the transport layer.
+     *
+     * @param apiKey the API key, must not be null or empty
+     * @return a principal carrying the API key as its credential
+     */
+    public static Principal ofApiKey(String apiKey) {
+      if (apiKey == null || apiKey.trim().isEmpty()) {
+        return ANONYMOUS;
+      }
+      return new Principal(apiKey, "apikey:" + shortHint(apiKey), "default", Collections.<String>emptySet(), null,
+          true);
+    }
+
+    /**
+     * Creates an authenticated principal from validated OIDC/OAuth token claims.
+     *
+     * @param subject the token subject claim, must not be null or empty
+     * @param tenant the tenant or project scope, may be null
+     * @param roles granted roles, may be null
+     * @param issuer the token issuer claim, may be null
+     * @return a principal carrying the subject as its credential
+     */
+    public static Principal ofClaims(String subject, String tenant, Set<String> roles, String issuer) {
+      if (subject == null || subject.trim().isEmpty()) {
+        return ANONYMOUS;
+      }
+      Set<String> grantedRoles = roles != null ? roles : Collections.<String>emptySet();
+      String scope = tenant != null && !tenant.trim().isEmpty() ? tenant : "default";
+      return new Principal(subject, subject, scope, grantedRoles, issuer, true);
+    }
+
+    /**
+     * Returns a short non-reversible hint of a credential for audit records.
+     *
+     * @param value the credential
+     * @return the first characters of the credential, safe to log
+     */
+    private static String shortHint(String value) {
+      return value.substring(0, Math.min(8, value.length()));
+    }
+
+    /**
+     * Returns the raw credential.
+     *
+     * @return the credential, or null for anonymous callers
+     */
+    public String getCredential() {
+      return credential;
+    }
+
+    /**
+     * Returns the audit subject.
+     *
+     * @return a non-null subject identifier
+     */
+    public String getSubject() {
+      return subject;
+    }
+
+    /**
+     * Returns the tenant or project scope.
+     *
+     * @return a non-null scope identifier
+     */
+    public String getTenant() {
+      return tenant;
+    }
+
+    /**
+     * Returns the granted roles.
+     *
+     * @return an unmodifiable set of role names
+     */
+    public Set<String> getRoles() {
+      return roles;
+    }
+
+    /**
+     * Returns the token issuer.
+     *
+     * @return the issuer, or null when the identity did not come from a token
+     */
+    public String getIssuer() {
+      return issuer;
+    }
+
+    /**
+     * Returns whether the transport authenticated this caller.
+     *
+     * @return true when the identity was verified by the transport
+     */
+    public boolean isAuthenticated() {
+      return authenticated;
+    }
+  }
+}

--- a/src/main/java/neqsim/mcp/runners/SecurityRunner.java
+++ b/src/main/java/neqsim/mcp/runners/SecurityRunner.java
@@ -2,9 +2,12 @@ package neqsim.mcp.runners;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -64,6 +67,21 @@ public final class SecurityRunner {
   private static final AtomicLong REQUEST_COUNTER = new AtomicLong(0);
 
   /**
+   * Tools that stay reachable without a credential so an operator can authenticate after security has been enabled.
+   * Without this exemption, enabling enforcement locks every caller out of the server permanently — including the
+   * management tool needed to disable it again.
+   */
+  private static final Set<String> BOOTSTRAP_TOOLS = Collections
+      .unmodifiableSet(new HashSet<String>(Arrays.asList("manageSecurity")));
+
+  /**
+   * Security actions that expose or grant privilege. When enforcement is enabled these require the configured admin
+   * token, otherwise any caller reaching the bootstrap-exempt manageSecurity tool could mint an admin key for itself.
+   */
+  private static final Set<String> PRIVILEGED_ACTIONS = Collections.unmodifiableSet(
+      new HashSet<String>(Arrays.asList("createApiKey", "revokeApiKey", "setConfig", "getAuditLog", "getRateLimits")));
+
+  /**
    * Private constructor — all methods are static.
    */
   private SecurityRunner() {
@@ -79,6 +97,11 @@ public final class SecurityRunner {
     try {
       JsonObject input = JsonParser.parseString(json).getAsJsonObject();
       String action = input.has("action") ? input.get("action").getAsString() : "";
+
+      String privilegeDenied = checkPrivilegedAction(action, input);
+      if (privilegeDenied != null) {
+        return privilegeDenied;
+      }
 
       switch (action) {
       case "createApiKey":
@@ -108,34 +131,51 @@ public final class SecurityRunner {
    * Checks authentication and rate limiting for an incoming request. Call this at the beginning of any protected tool
    * invocation.
    *
-   * @param apiKey the API key (optional if security is disabled)
+   * <p>
+   * When no explicit key is supplied the credential bound by the transport layer through {@link McpRequestContext} is
+   * used. Credentials are never accepted as MCP tool arguments.
+   * </p>
+   *
+   * @param apiKey the API key, or null to resolve the credential from {@link McpRequestContext}
    * @param tool the tool being invoked
    * @return null if allowed, or an error JSON string if denied
    */
   public static String checkAccess(String apiKey, String tool) {
-    long reqId = REQUEST_COUNTER.incrementAndGet();
+    REQUEST_COUNTER.incrementAndGet();
+
+    McpRequestContext.Principal principal = McpRequestContext.current();
+    String credential = apiKey != null && !apiKey.isEmpty() ? apiKey : principal.getCredential();
+    String subject = principal.getSubject();
 
     if (!enabled) {
       // Log even when not enforcing
-      logAudit("anonymous", tool, "allowed", "Security disabled");
+      logAudit(subject, tool, "allowed", "Security disabled");
       return null;
     }
 
-    // Check API key
-    if (apiKey == null || apiKey.isEmpty()) {
-      logAudit("anonymous", tool, "denied", "Missing API key");
-      return errorJson("AUTH_REQUIRED", "API key required",
-          "Provide 'apiKey' field in request or disable security enforcement");
+    if (BOOTSTRAP_TOOLS.contains(tool)) {
+      // Reachable without a credential so an operator can still authenticate or read status.
+      // Privileged actions inside the tool are separately gated by checkPrivilegedAction.
+      logAudit(subject, tool, "allowed", "Bootstrap tool");
+      return null;
     }
 
-    UserContext user = API_KEYS.get(apiKey);
+    if (credential == null || credential.isEmpty()) {
+      logAudit(subject, tool, "denied", "No authenticated principal");
+      return errorJson("AUTH_REQUIRED", "Authenticated caller required",
+          "Authenticate at the transport layer (API key header or OAuth bearer token). "
+              + "Credentials are not accepted as tool arguments.");
+    }
+
+    UserContext user = API_KEYS.get(credential);
     if (user == null) {
-      logAudit("unknown:" + apiKey.substring(0, Math.min(8, apiKey.length())), tool, "denied", "Invalid API key");
-      return errorJson("AUTH_FAILED", "Invalid API key", "Check your API key");
+      logAudit("unknown:" + credential.substring(0, Math.min(8, credential.length())), tool, "denied",
+          "Invalid credential");
+      return errorJson("AUTH_FAILED", "Invalid credential", "Check the API key or bearer token used by the transport");
     }
 
     // Check rate limit
-    if (!checkRateLimit(apiKey, user.rateLimit)) {
+    if (!checkRateLimit(credential, user.rateLimit)) {
       logAudit(user.userId, tool, "rate_limited", "Exceeded " + user.rateLimit + " requests/minute");
       return errorJson("RATE_LIMITED", "Rate limit exceeded: " + user.rateLimit + " requests/minute",
           "Wait and retry, or request a higher rate limit");
@@ -143,6 +183,47 @@ public final class SecurityRunner {
 
     logAudit(user.userId, tool, "allowed", null);
     return null; // Access granted
+  }
+
+  /**
+   * Resets all global security state. Test-only hook: the key store, audit log, rate-limit counters and the enforcement
+   * flag are process-wide, so tests that enable enforcement must be able to restore a clean state deterministically.
+   */
+  static void resetForTests() {
+    enabled = false;
+    API_KEYS.clear();
+    RATE_LIMITS.clear();
+    AUDIT_LOG.clear();
+  }
+
+  /**
+   * Gates privileged security actions behind the configured admin token while enforcement is on.
+   *
+   * <p>
+   * Enforcement is only applied when {@link #enabled} is true. With security disabled the server is a single-user
+   * desktop tool and the management actions stay open, which preserves local workflows and existing behaviour.
+   * </p>
+   *
+   * @param action the requested security action
+   * @param input the raw request object, which may carry an adminToken field
+   * @return null when the action may proceed, otherwise an error JSON string
+   */
+  private static String checkPrivilegedAction(String action, JsonObject input) {
+    if (!enabled || !PRIVILEGED_ACTIONS.contains(action)) {
+      return null;
+    }
+    if (!IndustrialProfile.isAdminConfigured()) {
+      logAudit(McpRequestContext.currentSubject(), "manageSecurity:" + action, "denied", "No admin token configured");
+      return errorJson("ADMIN_NOT_CONFIGURED", "Security enforcement is enabled but no admin token is configured",
+          "Set NEQSIM_MCP_ADMIN_TOKEN (or -Dneqsim.mcp.adminToken) on the server before enabling security");
+    }
+    String adminToken = input.has("adminToken") ? input.get("adminToken").getAsString() : null;
+    if (!IndustrialProfile.isAdminAuthorized(adminToken)) {
+      logAudit(McpRequestContext.currentSubject(), "manageSecurity:" + action, "denied", "Admin authorization failed");
+      return errorJson("ADMIN_REQUIRED", "Action '" + action + "' requires administrator authorization",
+          "Supply the configured admin token as 'adminToken'");
+    }
+    return null;
   }
 
   /**
@@ -212,6 +293,10 @@ public final class SecurityRunner {
    */
   private static String authenticate(JsonObject input) {
     String apiKey = input.has("apiKey") ? input.get("apiKey").getAsString() : "";
+    if (apiKey.isEmpty()) {
+      String bound = McpRequestContext.currentCredential();
+      apiKey = bound != null ? bound : "";
+    }
 
     if (!enabled) {
       JsonObject response = new JsonObject();
@@ -371,6 +456,7 @@ public final class SecurityRunner {
     AuditEntry entry = new AuditEntry();
     entry.timestamp = Instant.now().toString();
     entry.userId = userId;
+    entry.tenant = McpRequestContext.current().getTenant();
     entry.tool = tool;
     entry.result = result;
     entry.details = details;
@@ -492,6 +578,9 @@ public final class SecurityRunner {
     /** User identifier. */
     String userId = "";
 
+    /** Tenant or project scope the request was made in. */
+    String tenant = "default";
+
     /** Tool invoked. */
     String tool = "";
 
@@ -513,6 +602,7 @@ public final class SecurityRunner {
       JsonObject obj = new JsonObject();
       obj.addProperty("timestamp", timestamp);
       obj.addProperty("userId", userId);
+      obj.addProperty("tenant", tenant);
       obj.addProperty("tool", tool);
       obj.addProperty("result", result);
       if (details != null) {

--- a/src/test/java/neqsim/mcp/runners/McpSecurityEnforcementTest.java
+++ b/src/test/java/neqsim/mcp/runners/McpSecurityEnforcementTest.java
@@ -1,0 +1,176 @@
+package neqsim.mcp.runners;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Regression tests for MCP security enforcement.
+ *
+ * <p>
+ * Enforcement previously evaluated a hard-coded null credential, so enabling it denied every tool call — including the
+ * management tool needed to disable it again. These tests pin the fixed behaviour: an authenticated principal is
+ * honoured, an unauthenticated caller is denied, the bootstrap tool stays reachable, and privileged security actions
+ * require the admin token.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+class McpSecurityEnforcementTest {
+
+  /** System property holding the admin token. */
+  private static final String ADMIN_TOKEN_PROPERTY = "neqsim.mcp.adminToken";
+
+  /**
+   * Pins the deployment mode so tool-tier filtering cannot vary with test execution order.
+   */
+  @BeforeEach
+  void useDesktopProfile() {
+    SecurityRunner.resetForTests();
+    McpRequestContext.clear();
+    IndustrialProfile.setActiveMode(IndustrialProfile.DeploymentMode.DESKTOP_ENGINEER);
+  }
+
+  /**
+   * Restores global state so enabling security in one test cannot affect others.
+   */
+  @AfterEach
+  void resetSecurityState() {
+    McpRequestContext.clear();
+    SecurityRunner.resetForTests();
+    System.clearProperty(ADMIN_TOKEN_PROPERTY);
+  }
+
+  /**
+   * Enables enforcement using the admin token.
+   *
+   * @param adminToken the token to configure and use
+   */
+  private void enableSecurity(String adminToken) {
+    System.setProperty(ADMIN_TOKEN_PROPERTY, adminToken);
+    String response = SecurityRunner
+        .run("{\"action\": \"setConfig\", \"enabled\": true, \"adminToken\": \"" + adminToken + "\"}");
+    JsonObject root = JsonParser.parseString(response).getAsJsonObject();
+    assertEquals("success", root.get("status").getAsString(), "Enabling security must succeed: " + response);
+  }
+
+  /**
+   * Creates an API key using the admin token.
+   *
+   * @param adminToken the configured admin token
+   * @param userId the user the key belongs to
+   * @return the issued API key
+   */
+  private String createKey(String adminToken, String userId) {
+    String response = SecurityRunner
+        .run("{\"action\": \"createApiKey\", \"userId\": \"" + userId + "\", \"adminToken\": \"" + adminToken + "\"}");
+    JsonObject root = JsonParser.parseString(response).getAsJsonObject();
+    assertEquals("success", root.get("status").getAsString(), "Key creation must succeed: " + response);
+    return root.get("apiKey").getAsString();
+  }
+
+  /**
+   * With security disabled the server behaves as a single-user desktop tool and nothing is blocked.
+   */
+  @Test
+  @DisplayName("Security disabled: tools are not blocked")
+  void testDisabledSecurityAllowsTools() {
+    assertNull(SecurityRunner.checkAccess(null, "runFlash"), "Disabled security must not block tools");
+  }
+
+  /**
+   * An authenticated principal bound by the transport must be accepted. This is the case that was broken: the
+   * credential never reached the check, so every call was denied.
+   */
+  @Test
+  @DisplayName("Security enabled: transport-bound principal is accepted")
+  void testBoundPrincipalIsAccepted() {
+    String adminToken = "test-admin-token";
+    enableSecurity(adminToken);
+    String apiKey = createKey(adminToken, "engineer-1");
+
+    McpRequestContext.set(McpRequestContext.Principal.ofApiKey(apiKey));
+    try {
+      assertNull(IndustrialProfile.enforceAccess("runFlash"),
+          "An authenticated caller must not be blocked when security is enabled");
+    } finally {
+      McpRequestContext.clear();
+    }
+  }
+
+  /**
+   * An unauthenticated caller must be denied when enforcement is on.
+   */
+  @Test
+  @DisplayName("Security enabled: anonymous caller is denied")
+  void testAnonymousCallerIsDenied() {
+    String adminToken = "test-admin-token";
+    enableSecurity(adminToken);
+    McpRequestContext.clear();
+
+    String blocked = IndustrialProfile.enforceAccess("runFlash");
+    assertNotNull(blocked, "Anonymous caller must be denied when security is enabled");
+    JsonObject root = JsonParser.parseString(blocked).getAsJsonObject();
+    assertEquals("blocked", root.get("status").getAsString());
+  }
+
+  /**
+   * The bootstrap tool must stay reachable so an operator can recover, otherwise enabling security is a one-way
+   * lockout.
+   */
+  @Test
+  @DisplayName("Security enabled: manageSecurity stays reachable for recovery")
+  void testBootstrapToolIsNotLockedOut() {
+    String adminToken = "test-admin-token";
+    enableSecurity(adminToken);
+    McpRequestContext.clear();
+
+    assertNull(IndustrialProfile.enforceAccess("manageSecurity"),
+        "manageSecurity must stay reachable so enforcement can be inspected and disabled");
+
+    String status = SecurityRunner.run("{\"action\": \"getStatus\"}");
+    JsonObject root = JsonParser.parseString(status).getAsJsonObject();
+    assertEquals("success", root.get("status").getAsString(), "getStatus must work without credentials");
+  }
+
+  /**
+   * Because manageSecurity is bootstrap-exempt, privileged actions inside it must require the admin token — otherwise
+   * any caller could mint an admin key for itself.
+   */
+  @Test
+  @DisplayName("Security enabled: minting an API key requires the admin token")
+  void testKeyCreationRequiresAdminToken() {
+    String adminToken = "test-admin-token";
+    enableSecurity(adminToken);
+
+    String response = SecurityRunner.run("{\"action\": \"createApiKey\", \"userId\": \"attacker\"}");
+    JsonObject root = JsonParser.parseString(response).getAsJsonObject();
+    assertEquals("error", root.get("status").getAsString(), "Unauthenticated key creation must fail: " + response);
+    assertTrue(response.contains("ADMIN_REQUIRED"), "Denial must state that admin authorization is required");
+  }
+
+  /**
+   * Enabling enforcement without a configured admin token must not silently create an unrecoverable or ungoverned
+   * state.
+   */
+  @Test
+  @DisplayName("Security enabled without admin token: privileged actions fail closed")
+  void testPrivilegedActionsFailClosedWithoutAdminConfig() {
+    System.clearProperty(ADMIN_TOKEN_PROPERTY);
+    SecurityRunner.run("{\"action\": \"setConfig\", \"enabled\": true}");
+
+    String response = SecurityRunner.run("{\"action\": \"createApiKey\", \"userId\": \"anyone\"}");
+    JsonObject root = JsonParser.parseString(response).getAsJsonObject();
+    assertEquals("error", root.get("status").getAsString());
+    assertTrue(response.contains("ADMIN_NOT_CONFIGURED") || response.contains("ADMIN_REQUIRED"),
+        "Must refuse privileged actions when no admin token is configured: " + response);
+  }
+}


### PR DESCRIPTION
## Problem

Enabling MCP application-level security made the server unusable, and enabling it was a one-way door.

`IndustrialProfile.enforceAccess` called the authorization check with a hard-coded `null` credential:

```java
String securityBlocked = SecurityRunner.checkAccess(null, toolName);
```

With `SecurityRunner` enforcement on, `checkAccess` rejects a null credential. Every tool call was therefore denied — including `manageSecurity`, the only tool that can turn enforcement back off. The server had to be restarted to recover.

Two further problems sat behind it:

- **Privilege escalation.** `manageSecurity`'s `createApiKey` required no authorization, so any caller able to reach it could mint itself an `admin`-role key.
- **Shared approvals.** One-shot approvals were keyed by tool name alone, so an approval granted to one engineer could be consumed by a different caller.

## Change

Identity is resolved once per request by the transport and bound to the serving thread. Credentials are never accepted as MCP tool arguments.

**`McpRequestContext`** (new, core) — thread-bound `Principal` carrying credential, subject, tenant, roles and issuer. Returns an anonymous principal when nothing is bound, so local desktop use with enforcement disabled is unchanged.

**`McpIdentityResolver`** (new, server module) — resolves the caller in order: Quarkus `SecurityIdentity` from a validated OIDC bearer token (HTTP/enterprise), then `NEQSIM_MCP_API_KEY` (stdio/CI), then anonymous. Never throws; any failure degrades to anonymous, which enforcement then rejects.

**`NeqSimTools.enforceToolAccess`** — every `@Tool` method already calls this first, so it is the natural place to bind identity. Changed from `static` to an instance method; no call sites changed.

**`SecurityRunner.checkAccess`** — uses the bound credential when no explicit key is passed. Adds a bootstrap exemption so `manageSecurity` stays reachable without a credential, and gates `createApiKey`, `revokeApiKey`, `setConfig`, `getAuditLog` and `getRateLimits` behind the configured admin token **when enforcement is on**. With security disabled the server is a single-user desktop tool and these stay open, so existing local behaviour and tests are unaffected. Audit entries now record the tenant alongside the subject.

**`IndustrialProfile`** — passes the real credential; one-shot approvals are keyed `subject::tool`.

## Why the bootstrap exemption is safe

Exempting `manageSecurity` from the credential check is what makes enforcement recoverable, but on its own it would leave key minting open. That is why admin gating is part of the same change: the exemption lets an operator *inspect and disable* enforcement, while anything that grants or exposes privilege still requires `NEQSIM_MCP_ADMIN_TOKEN`. If enforcement is enabled with no admin token configured, privileged actions fail closed with `ADMIN_NOT_CONFIGURED` rather than silently allowing them.

## Tests

`McpSecurityEnforcementTest` (new, 6 tests):

| Test | Pins |
|---|---|
| `testDisabledSecurityAllowsTools` | desktop behaviour unchanged |
| `testBoundPrincipalIsAccepted` | **the regression** — an authenticated caller is no longer denied |
| `testAnonymousCallerIsDenied` | enforcement still denies unauthenticated callers |
| `testBootstrapToolIsNotLockedOut` | `manageSecurity` stays reachable; recovery is possible |
| `testKeyCreationRequiresAdminToken` | no self-service admin keys |
| `testPrivilegedActionsFailClosedWithoutAdminConfig` | fails closed when misconfigured |

`SecurityRunner.resetForTests()` was added because the key store, audit log and enforcement flag are process-wide static state; without a deterministic reset, a test that enables enforcement leaks into others.

**Verified:** `mvnw test -Dtest=neqsim.mcp.**` → 402 tests, 0 failures. Spotless clean.

## Scope

Deliberately minimal so it can merge on its own: no tool-surface, catalog or schema changes, and no tool-count changes. Model handles, execution limits and the response size guard follow in a separate PR.

## Risk

Low for existing users. Security enforcement is **disabled by default**, and with it disabled behaviour is unchanged. The change only affects deployments that had enabled enforcement — where the server was previously locked out entirely.
