### PR TITLE
Fix high-water CPA gas phase seeding

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -594,7 +594,7 @@ When `system.setMultiPhaseCheck(true)` is called, NeqSim uses the `TPmultiflash`
 │ STEP 3: HEURISTIC PHASE SEEDING                                                 │
 ├─────────────────────────────────────────────────────────────────────────────────┤
 │  IF NOT multiPhaseTest AND seedAdditionalPhaseFromFeed():                       │
-│     → Add gas phase seeded from feed composition                                │
+│     → Add bounded vapor-like gas seed, xᵢ ∝ zᵢKᵢ(Wilson)                       │
 │     → multiPhaseTest = true                                                     │
 │                                                                                 │
 │  IF seedHydrocarbonLiquidFromFeed():                                           │
@@ -1466,9 +1466,21 @@ The complete workflow in `TPmultiflash.run()` is:
 
 Beyond stability analysis, NeqSim uses heuristic phase seeding to improve convergence:
 
-#### 3.5.1 Gas Phase Seeding from Feed
+#### 3.5.1 Vapor-like Gas Phase Seeding
 
-When an aqueous phase exists without a gas phase, seed a gas phase:
+When an aqueous phase and material hydrocarbon feed exist without a gas phase, the fallback creates a vapor-like trial
+instead of copying the water-dominated feed composition. The initial trial is
+
+$$x_i^{trial}=\frac{z_iK_i^{Wilson}}{\sum_j z_jK_j^{Wilson}}$$
+
+with
+
+$$\ln K_i^{Wilson}=\ln\left(\frac{P_{c,i}}{P}\right)+5.373(1+\omega_i)\left(1-\frac{T_{c,i}}{T}\right)$$
+
+The calculation is performed in log space and bounds $\ln K_i$ to $[-50,50]$ to remain finite for large volatility
+contrasts. This is an initialization strategy only: the multiphase beta solve, component material balance, composition
+normalization, fugacity equality, phase-stability logic, and Gibbs-energy comparisons still determine whether the gas
+phase is retained.
 
 ```java
 private boolean seedAdditionalPhaseFromFeed() {
@@ -1484,12 +1496,14 @@ private boolean seedAdditionalPhaseFromFeed() {
     }
     if (!hasAqueous || hasGas) return false;
 
-    // Seed gas phase with feed composition
+    // Seed a vapor-like trial in bounded log space
     system.addPhase();
     system.setPhaseType(phaseIndex, PhaseType.GAS);
     for (int comp = 0; comp < ncomp; comp++) {
-        system.getPhase(phaseIndex).getComponent(comp).setx(z[comp]);
+        logTrial[comp] = log(z[comp]) + clamp(log(KWilson[comp]), -50, 50);
+        xTrial[comp] = exp(logTrial[comp] - max(logTrial));
     }
+    normalize(xTrial);
     system.setBeta(phaseIndex, 1e-3);
     return true;
 }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -1880,6 +1880,17 @@ public class TPmultiflash extends TPflash {
     // system.display();
   }
 
+  /**
+   * Adds a bounded vapor-like trial when an aqueous/hydrocarbon endpoint contains no gas phase.
+   *
+   * <p>
+   * The trial uses {@code x_i proportional to z_i K_i^Wilson} in log space. Wilson K-values are only an initial guess;
+   * the existing multiphase beta solve, material-balance checks, and fugacity-equality checks determine the accepted
+   * equilibrium. Bounding {@code ln(K_i)} avoids overflow for component sets with large volatility contrasts.
+   * </p>
+   *
+   * @return {@code true} when a gas trial was added and initialized
+   */
   private boolean seedAdditionalPhaseFromFeed() {
     if (!system.doMultiPhaseCheck()) {
       return false;
@@ -1928,9 +1939,27 @@ public class TPmultiflash extends TPflash {
     system.addPhase();
     int phaseIndex = system.getNumberOfPhases() - 1;
     system.setPhaseType(phaseIndex, PhaseType.GAS);
+    double[] logTrialComposition = new double[system.getPhase(0).getNumberOfComponents()];
+    double maximumLogTrialComposition = Double.NEGATIVE_INFINITY;
     for (int comp = 0; comp < system.getPhase(0).getNumberOfComponents(); comp++) {
-      double z = system.getPhase(0).getComponent(comp).getz();
-      system.getPhase(phaseIndex).getComponent(comp).setx(z > 0 ? z : 1.0e-16);
+      ComponentInterface component = system.getPhase(0).getComponent(comp);
+      double z = component.getz();
+      double logTrial = Math.log(Math.max(z, 1.0e-100));
+      double criticalTemperature = component.getTC();
+      double criticalPressure = component.getPC();
+      if (z > 0.0 && criticalTemperature > 0.0 && criticalPressure > 0.0) {
+        double logWilsonK = Math.log(criticalPressure / system.getPressure())
+            + 5.373 * (1.0 + component.getAcentricFactor()) * (1.0 - criticalTemperature / system.getTemperature());
+        if (Double.isFinite(logWilsonK)) {
+          logTrial += Math.max(-50.0, Math.min(50.0, logWilsonK));
+        }
+      }
+      logTrialComposition[comp] = logTrial;
+      maximumLogTrialComposition = Math.max(maximumLogTrialComposition, logTrial);
+    }
+    for (int comp = 0; comp < system.getPhase(0).getNumberOfComponents(); comp++) {
+      double x = Math.exp(logTrialComposition[comp] - maximumLogTrialComposition);
+      system.getPhase(phaseIndex).getComponent(comp).setx(Math.max(x, 1.0e-16));
     }
     system.getPhases()[phaseIndex].normalize();
     double initialBeta = Math.max(1.0e-3, 1000.0 * phaseFractionMinimumLimit);

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashHighWaterGasSeedTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashHighWaterGasSeedTest.java
@@ -1,0 +1,145 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Regression coverage for gas-phase persistence in water-dominated CPA flashes. */
+class TPmultiflashHighWaterGasSeedTest {
+  private static final double[] WATER_MASS_FRACTIONS = { 0.40, 0.45, 0.50, 0.55, 0.60, 0.70, 0.80 };
+  private static final double[] EXPECTED_GAS_BETAS = { 0.0441902453511, 0.0372773421590, 0.0313666680101,
+      0.0262550011428, 0.0217905845743, 0.0143670367332, 0.00844359351489 };
+
+  @Test
+  void gasPhasePersistsAcrossHighWaterFractionSweep() {
+    double previousGasMoles = Double.POSITIVE_INFINITY;
+    for (int point = 0; point < WATER_MASS_FRACTIONS.length; point++) {
+      double waterMassFraction = WATER_MASS_FRACTIONS[point];
+      SystemInterface system = createFluid(waterMassFraction);
+      new ThermodynamicOperations(system).TPflash();
+
+      assertEquals(3, system.getNumberOfPhases(), "Expected gas-oil-aqueous equilibrium at " + waterMassFraction);
+      assertTrue(system.hasPhaseType(PhaseType.GAS),
+          "Expected gas phase at water mass fraction " + waterMassFraction + ", phases=" + system.getNumberOfPhases());
+      assertTrue(system.hasPhaseType(PhaseType.OIL), "Expected oil phase at water mass fraction " + waterMassFraction);
+      assertTrue(system.hasPhaseType(PhaseType.AQUEOUS),
+          "Expected aqueous phase at water mass fraction " + waterMassFraction);
+
+      int gasPhase = system.getPhaseNumberOfPhase("gas");
+      assertEquals(EXPECTED_GAS_BETAS[point], system.getBeta(gasPhase), 1.0e-8);
+      double gasMoles = system.getPhase(gasPhase).getNumberOfMolesInPhase();
+      assertTrue(gasMoles > 20.0 && gasMoles < 25.0, "Gas amount must remain physical at " + waterMassFraction);
+      assertTrue(gasMoles <= previousGasMoles + 1.0e-8,
+          "Gas amount must vary continuously as immiscible water is added at " + waterMassFraction);
+      previousGasMoles = gasMoles;
+      assertFlashClosure(system);
+
+      new ThermodynamicOperations(system).TPflash();
+      assertEquals(3, system.getNumberOfPhases(), "Repeated flash phase count at " + waterMassFraction);
+      assertEquals(EXPECTED_GAS_BETAS[point], system.getBeta(system.getPhaseNumberOfPhase("gas")), 1.0e-8,
+          "Repeated flash gas fraction at " + waterMassFraction);
+      assertFlashClosure(system);
+    }
+  }
+
+  @Test
+  void vaporLikeSeedRecoversFromPoorBetaGuessesAtNearbyConditions() {
+    double[][] conditions = { { 312.65, 19.5 }, { 313.15, 20.0 }, { 313.65, 20.5 } };
+    for (double[] condition : conditions) {
+      SystemInterface system = createFluid(0.55);
+      system.setTemperature(condition[0]);
+      system.setPressure(condition[1]);
+      system.init(0);
+      system.setBeta(0, 1.0e-10);
+      system.setBeta(1, 1.0 - 1.0e-10);
+
+      new ThermodynamicOperations(system).TPflash();
+
+      assertEquals(3, system.getNumberOfPhases(),
+          "Expected gas-oil-aqueous equilibrium at T=" + condition[0] + " K, P=" + condition[1] + " bara");
+      assertFlashClosure(system);
+    }
+  }
+
+  @Test
+  void threePhaseSeparatorKeepsContinuousGasProductAcrossFormerPhaseIsland() {
+    double previousGasMoles = Double.POSITIVE_INFINITY;
+    for (double waterMassFraction : new double[] { 0.50, 0.55, 0.60, 0.70 }) {
+      Stream feed = new Stream("high-water feed", createFluid(waterMassFraction));
+      feed.run();
+      ThreePhaseSeparator separator = new ThreePhaseSeparator("three-phase separator", feed);
+
+      separator.run();
+
+      double gasMoles = separator.getGasOutStream().getThermoSystem().getTotalNumberOfMoles();
+      assertTrue(gasMoles > 20.0 && gasMoles < 25.0,
+          "Separator gas product must remain physical at " + waterMassFraction);
+      assertTrue(gasMoles <= previousGasMoles + 1.0e-8,
+          "Separator gas product must vary continuously as immiscible water is added at " + waterMassFraction);
+      previousGasMoles = gasMoles;
+    }
+  }
+
+  private void assertFlashClosure(SystemInterface system) {
+    double betaSum = 0.0;
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      double beta = system.getBeta(phase);
+      assertTrue(Double.isFinite(beta) && beta > 0.0 && beta <= 1.0, "Phase fraction must be finite and bounded");
+      betaSum += beta;
+
+      double compositionSum = 0.0;
+      for (int component = 0; component < system.getPhase(phase).getNumberOfComponents(); component++) {
+        double composition = system.getPhase(phase).getComponent(component).getx();
+        assertTrue(Double.isFinite(composition) && composition >= 0.0 && composition <= 1.0,
+            "Phase composition must be finite and bounded");
+        compositionSum += composition;
+      }
+      assertEquals(1.0, compositionSum, 1.0e-8, "Phase composition must be normalized");
+    }
+    assertEquals(1.0, betaSum, 1.0e-8, "Phase fractions must be normalized");
+
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
+      double recoveredComposition = 0.0;
+      double referenceLogFugacity = Double.NaN;
+      for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+        double composition = system.getPhase(phase).getComponent(component).getx();
+        recoveredComposition += system.getBeta(phase) * composition;
+        double logFugacity = Math.log(Math.max(composition, Double.MIN_NORMAL))
+            + Math.log(system.getPhase(phase).getComponent(component).getFugacityCoefficient());
+        assertTrue(Double.isFinite(logFugacity), "Component log fugacity must be finite");
+        if (phase == 0) {
+          referenceLogFugacity = logFugacity;
+        } else {
+          assertEquals(referenceLogFugacity, logFugacity, 2.0e-8, "Component fugacity must be equal across phases");
+        }
+      }
+      assertEquals(system.getPhase(0).getComponent(component).getz(), recoveredComposition, 2.0e-8,
+          "Component material balance must close");
+    }
+  }
+
+  private SystemInterface createFluid(double waterMassFraction) {
+    SystemInterface system = new SystemSrkCPAstatoil(313.15, 20.0);
+    system.addComponent("methane", 25.0);
+    system.addComponent("ethane", 5.0);
+    system.addComponent("propane", 5.0);
+    system.addComponent("n-butane", 4.0);
+    system.addComponent("n-pentane", 4.0);
+    system.addComponent("n-hexane", 6.0);
+    system.addComponent("n-heptane", 8.0);
+    system.addComponent("n-octane", 8.0);
+    system.addTBPfraction("C10", 15.0, 0.142, 0.78);
+    system.addTBPfraction("C20", 20.0, 0.282, 0.88);
+    double waterMoles = 11.29556 / 0.01801528 * waterMassFraction / (1.0 - waterMassFraction);
+    system.addComponent("water", waterMoles);
+    system.setMixingRule(10);
+    system.setMultiPhaseCheck(true);
+    return system;
+  }
+}


### PR DESCRIPTION
## Problem

Issue #2856 reproduces a nonphysical phase-topology island in a water-dominated SRK-CPA separator fluid at 313.15 K and 20 bara. The current multiphase fallback copies the overall feed composition into a missing gas phase. Across 50–70 wt-% added water, that creates a trial gas containing 80.7–96.2 mol-% water; the gas phase then disappears even though the neighboring 40–45 and 80 wt-% states converge to gas/oil/aqueous equilibrium.

On current `master`, the deterministic 40, 45, 50, 55, 60, 70, and 80 wt-% sweep returns phase counts `3, 3, 2, 2, 2, 2, 3`. The three-phase separator consequently loses its gas product over the same interval.

Closes #2856.

## Root cause and method

The defect is limited to `TPmultiflash.seedAdditionalPhaseFromFeed()`: an aqueous, hydrocarbon-bearing endpoint without gas was seeded with `x_i = z_i`. This is a poor gas trial when the overall feed is dominated by immiscible water.

The fallback now initializes the gas trial as

```text
x_i(trial) ∝ z_i K_i(Wilson)
ln K_i = ln(Pc_i/P) + 5.373 (1 + omega_i) (1 - Tc_i/T)
```

The calculation is performed in log space, with `ln K_i` bounded to `[-50, 50]`, a `1e-100` feed floor before the logarithm, and a `1e-16` composition floor before normalization. These safeguards cover zero-feed components and large volatility contrasts.

Wilson values are initialization only. The existing multiphase beta solve, material balance, composition normalization, fugacity equality, stability handling, phase disappearance logic, and Gibbs comparisons remain authoritative. No convergence or acceptance tolerance is relaxed.

## Literature basis

This is consistent with Michelsen's phase-stability/phase-split workflow, where useful stability-derived trial compositions are central to robust phase-split initialization: [Michelsen, Fluid Phase Equilibria 9 (1982), Part II](https://doi.org/10.1016/0378-3812%2882%2985002-4). It also preserves NeqSim's existing feasible beta/composition handling rather than replacing it; compare the non-negative-composition feasible-region and safeguarded Newton approach in [Okuno, Johns, and Sepehrnoori (2010)](https://doi.org/10.2118/117752-PA).

Evidence: the A/B reproduction changes only the missing-gas trial composition and removes the phase island. Inference: the water-like trial prevented recovery of the stable vapor basin in the affected states. No claim is made about proprietary Aspen HYSYS, UniSim, Multiflash, or PVTsim internals; public material does not document a directly comparable fallback seed.

## Numerical evidence

The corrected water sweep returns gas/oil/aqueous equilibrium at every point:

| Water mass fraction | Gas beta |
| ---: | ---: |
| 0.40 | 0.0441902453511 |
| 0.45 | 0.0372773421590 |
| 0.50 | 0.0313666680101 |
| 0.55 | 0.0262550011428 |
| 0.60 | 0.0217905845743 |
| 0.70 | 0.0143670367332 |
| 0.80 | 0.00844359351489 |

Gas product inventory decreases smoothly from 22.8905 to 22.0209 mol across the sweep. Maximum component-balance error is below `8e-14`; phase fractions and every phase composition normalize within `1e-8`; maximum pairwise log-fugacity residual is `1.64e-11`.

A deterministic matrix also covered SRK lean gas, PR heavy oil, CPA water, CPA wet gas, PR CO2-rich fluid, SRK hydrogen-rich fluid, a PR methane/heptane near-boundary case with a binary interaction parameter, and the three-phase high-water CPA case. It exercised one-, two-, and three-phase regions, repeated flashes, changed temperature/pressure, poor beta guesses, disappearing phases, and broad volatility contrasts. All finite-property, phase-bound, normalization, balance, fugacity, repeatability, and plausibility checks passed.

For all seven stable one/two-phase matrix cases, standard TPflash and multiphase TPflash matched phase types, betas, phase compositions, density, Gibbs energy, and enthalpy within `2e-8`.

## Benchmark

Each target fork ran 20 repetitions of five high-water states (100 flashes/fork), with three fresh JVM forks:

| Variant | Median wall time | Wrong phase topology |
| --- | ---: | ---: |
| Current master | 12,772 ms | 240/300 flashes (80%) |
| Vapor-like seed | 3,310 ms | 0/300 flashes |
| Change | **-74.1%** | **-100%** |

A separate ordinary one/two-phase benchmark ran four SRK/PR/CPA cases 100 times in each of nine alternating-order forks. The numerical checksum was identical in every run. Pooled median wall time was 3,603 ms before and 3,361 ms after; this noisy 6.7% difference is treated only as evidence of no observed slowdown, not as a claimed general speedup.

`TPmultiflash` does not expose a stable aggregate iteration count. Adding a diagnostic API would broaden this bounded fix, so this benchmark records end-to-end wall time, exact solution checks, and phase-topology failure rate instead.

## Tests

- Java 17 focused and adjacent suite: 24 tests, 0 failures/errors.
- Clean Java 8 profile: 7 focused/adjacent tests, 0 failures/errors.
- New regression verifies the full 40–80 wt-% sweep, repeatability, poor initial beta guesses at nearby conditions, material/fugacity closure, and continuous three-phase-separator gas product.
- Deterministic cross-EOS/cross-algorithm matrix: all checks passed.
- `pre-commit run --all-files --hook-stage pre-commit`: passed.
- `pre-commit run --all-files --hook-stage pre-push`: Spotless and documentation-search checks passed.
- Full slow suite was not run locally; hosted CI is required before merge readiness.

## Compatibility and risk

The changed branch is reached only when multiphase checking is enabled, an aqueous phase is present, material hydrocarbon feed exists, and gas is absent. The final equilibrium acceptance path is unchanged. Main risks are Wilson estimates for associating/polar components and extreme critical data; log-space bounds and existing stability/Gibbs gates contain those risks, while the adversarial volatility-contrast and CPA cases exercise them.

## Documentation impact

Updated the method Javadoc and `docs/thermodynamicoperations/TPflash_algorithm.md` with the equation, bounds, assumptions, and explicit statement that this is initialization rather than an equilibrium acceptance criterion. No notebook is affected.
