### PR TITLE
Preserve converged pumparound return state

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -317,7 +317,11 @@ duplicate draw ownership fail before solver iteration, and `validateSetup()` rep
 `pumparound.degreesOfFreedom`.
 
 The `temperatureDrop` argument is in Kelvin. Positive values cool the returned liquid; negative
-values heat it. A non-finite or below-zero-K return temperature fails explicitly.
+values heat it. A non-finite or below-zero-K return temperature fails explicitly. The column uses
+a thermodynamic snapshot while seeding tray profiles, so initialization cannot change the public
+return temperature. After a converged solve, the draw-to-return temperature difference therefore
+equals the configured drop; the return flow and composition remain coupled through the outer tear
+iteration.
 
 ## Hydraulics and Pressure-Drop Coupling
 

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -1150,6 +1150,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       return;
     }
     setDoInitializion(false);
+    List<SystemInterface> pumparoundReturnSystems = snapshotPumparoundReturnSystems();
 
     // Capture legacy direct feeds before recording the identity of the tray network. Otherwise the
     // first initialized state omits those feeds from the fingerprint and appears incompatible on
@@ -1170,6 +1171,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
 
     // If feed streams are empty, nothing to do
     if (feedStreams.isEmpty() && directExternalFeedStreams.isEmpty()) {
+      restorePumparoundReturnSystems(pumparoundReturnSystems);
       resetLastSolveMetrics();
       return;
     }
@@ -1263,6 +1265,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     // temperatures. Restore the caller-owned feed thermodynamic states before the actual
     // column solver starts so the solved mass and energy balances use the requested feeds.
     refreshInternalExternalFeedSystems();
+    restorePumparoundReturnSystems(pumparoundReturnSystems);
   }
 
   /**
@@ -1391,7 +1394,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       lastColumnTearIterationCount = iteration + 1;
       lastColumnTearResidual = relativeChange;
       if (relativeChange <= tolerance) {
-        if (columnTearVariablesChanged) {
+        if (columnTearVariablesChanged && !hasPumparoundTearVariablesOnly()) {
           setDoInitializion(true);
           solveConfiguredColumn(id);
           lastColumnTearInnerIterationCount += Math.max(0, lastIterationCount);
@@ -1429,6 +1432,21 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    */
   private boolean hasSingleSideDrawFlowSpecificationOnly() {
     return sideDrawSpecifications.size() == 1 && pumparounds.isEmpty() && !hydraulicPressureDropCouplingEnabled;
+  }
+
+  /**
+   * Check whether all active outer tear variables are pumparound returns.
+   *
+   * <p>
+   * A pumparound update is calculated directly from the just-solved tray draw. Running one more unmeasured inner solve
+   * would leave the public return synchronized to the previous draw while exposing products from the new state. The
+   * accepted fixed-point residual already bounds the difference between the applied and updated return streams.
+   * </p>
+   *
+   * @return {@code true} when one or more pumparounds are the only active tear variables
+   */
+  private boolean hasPumparoundTearVariablesOnly() {
+    return !pumparounds.isEmpty() && sideDrawSpecifications.isEmpty() && !hydraulicPressureDropCouplingEnabled;
   }
 
   /**
@@ -10807,6 +10825,41 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       for (int streamIndex = 0; streamIndex < externalFeeds.size(); streamIndex++) {
         SystemInterface cloned = externalFeeds.get(streamIndex).getThermoSystem().clone();
         trays.get(trayIndex).getStream(streamIndex).setThermoSystem(cloned);
+      }
+    }
+  }
+
+  /**
+   * Snapshot configured pumparound returns before tray-profile initialization changes inlet temperatures.
+   *
+   * @return thermodynamic state for each configured return, with {@code null} before its first draw update
+   */
+  private List<SystemInterface> snapshotPumparoundReturnSystems() {
+    List<SystemInterface> returnSystems = new ArrayList<>(pumparounds.size());
+    for (ColumnPumparound pumparound : pumparounds) {
+      StreamInterface returnStream = pumparound.getReturnStream();
+      returnSystems.add(returnStream == null ? null : returnStream.getThermoSystem().clone());
+    }
+    return returnSystems;
+  }
+
+  /**
+   * Restore configured pumparound returns after tray-profile initialization.
+   *
+   * <p>
+   * {@link SimpleTray#init()} seeds tray inputs at the local tray temperature. Restoring the saved thermodynamic
+   * systems preserves the established return-stream identity and tray coupling while preventing initialization from
+   * overwriting the configured draw-to-return temperature change.
+   * </p>
+   *
+   * @param returnSystems thermodynamic states captured before initialization
+   */
+  private void restorePumparoundReturnSystems(List<SystemInterface> returnSystems) {
+    for (int i = 0; i < pumparounds.size(); i++) {
+      StreamInterface returnStream = pumparounds.get(i).getReturnStream();
+      SystemInterface returnSystem = returnSystems.get(i);
+      if (returnStream != null && returnSystem != null) {
+        returnStream.setThermoSystem(returnSystem);
       }
     }
   }

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
@@ -259,8 +259,7 @@ public class DistillationColumnModeTest {
       double feedComponentFlow = feedFlow * feedComposition[componentIndex];
       double productComponentFlow = gasFlow * gasComposition[componentIndex]
           + liquidFlow * liquidComposition[componentIndex];
-      assertEquals(feedComponentFlow, productComponentFlow,
-          Math.max(1.0e-6, 5.0e-3 * Math.abs(feedComponentFlow)));
+      assertEquals(feedComponentFlow, productComponentFlow, Math.max(1.0e-6, 5.0e-3 * Math.abs(feedComponentFlow)));
     }
   }
 

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
@@ -159,6 +159,36 @@ public class DistillationColumnModeTest {
     assertTrue(column.getLastPumparoundRelativeChange() >= 0.0);
   }
 
+  /** Test that reinitialization preserves the configured multistage pumparound return state. */
+  @Test
+  public void cooledMultistagePumparoundPreservesReturnState() {
+    double[] temperatureDrops = { 4.0, 5.0 };
+    for (double temperatureDrop : temperatureDrops) {
+      DistillationColumn column = createMultistagePumparoundColumn(temperatureDrop);
+      DistillationColumn.ColumnPumparound pumparound = column.getPumparounds().get(0);
+      column.run(UUID.randomUUID());
+
+      double duty = pumparound.getReturnStream().getFluid().getEnthalpy()
+          - pumparound.getDrawStream().getFluid().getEnthalpy();
+      double returnFlow = pumparound.getReturnStream().getFlowRate("kg/hr");
+      assertTrue(column.solved(), column.getConvergenceDiagnostics());
+      assertTrue(column.isLastColumnTearConverged());
+      assertEquals(temperatureDrop,
+          pumparound.getDrawStream().getTemperature() - pumparound.getReturnStream().getTemperature(), 1.0e-9);
+      assertTrue(returnFlow > 0.0 && returnFlow < 10000.0);
+      assertTrue(duty < 0.0);
+      assertTrue(Math.abs(column.getMassBalance("kg/hr")) < 1.0e-8);
+
+      column.run(UUID.randomUUID());
+      double repeatedDuty = pumparound.getReturnStream().getFluid().getEnthalpy()
+          - pumparound.getDrawStream().getFluid().getEnthalpy();
+      assertEquals(temperatureDrop,
+          pumparound.getDrawStream().getTemperature() - pumparound.getReturnStream().getTemperature(), 1.0e-9);
+      assertEquals(returnFlow, pumparound.getReturnStream().getFlowRate("kg/hr"), 5.0e-5 * returnFlow);
+      assertEquals(duty, repeatedDuty, 5.0e-5 * Math.abs(duty));
+    }
+  }
+
   /**
    * Test hydraulic pressure-drop coupling API and diagnostics.
    */
@@ -200,6 +230,34 @@ public class DistillationColumnModeTest {
     column.addLiquidPumparound("PA-cold", 0, 0, 0.20, 400.0);
 
     assertThrows(IllegalStateException.class, () -> column.run(UUID.randomUUID()));
+  }
+
+  /**
+   * Create the convergent multicomponent reboiler column used by pumparound state tests.
+   *
+   * @param temperatureDrop configured pumparound cooling in Kelvin
+   * @return unrun column with one liquid pumparound
+   */
+  private DistillationColumn createMultistagePumparoundColumn(double temperatureDrop) {
+    SystemSrkEos fluid = new SystemSrkEos(293.15, 10.0);
+    fluid.addComponent("propane", 40.0);
+    fluid.addComponent("n-butane", 30.0);
+    fluid.addComponent("n-pentane", 30.0);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("fractionator pumparound feed", fluid);
+    feed.setFlowRate(10000.0, "kg/hr");
+    feed.run();
+
+    DistillationColumn column = new DistillationColumn("fractionator pumparound column", 6, true, false);
+    column.addFeedStream(feed, 3);
+    column.getReboiler().setOutTemperature(353.15);
+    column.setTopPressure(10.0);
+    column.setBottomPressure(10.5);
+    column.setSolverType(DistillationColumn.SolverType.DAMPED_SUBSTITUTION);
+    column.addLiquidPumparound("PA-multistage", 3, 5, 0.02, temperatureDrop);
+    column.setMaxPumparoundIterations(12);
+    column.setPumparoundTolerance(1.0e-4);
+    return column;
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.util.validation.ValidationResult;
 
@@ -178,6 +179,7 @@ public class DistillationColumnModeTest {
       assertTrue(returnFlow > 0.0 && returnFlow < 10000.0);
       assertTrue(duty < 0.0);
       assertTrue(Math.abs(column.getMassBalance("kg/hr")) < 1.0e-8);
+      assertPumparoundProductsPhysicalAndBalanced(column);
 
       column.run(UUID.randomUUID());
       double repeatedDuty = pumparound.getReturnStream().getFluid().getEnthalpy()
@@ -186,6 +188,7 @@ public class DistillationColumnModeTest {
           pumparound.getDrawStream().getTemperature() - pumparound.getReturnStream().getTemperature(), 1.0e-9);
       assertEquals(returnFlow, pumparound.getReturnStream().getFlowRate("kg/hr"), 5.0e-5 * returnFlow);
       assertEquals(duty, repeatedDuty, 5.0e-5 * Math.abs(duty));
+      assertPumparoundProductsPhysicalAndBalanced(column);
     }
   }
 
@@ -230,6 +233,35 @@ public class DistillationColumnModeTest {
     column.addLiquidPumparound("PA-cold", 0, 0, 0.20, 400.0);
 
     assertThrows(IllegalStateException.class, () -> column.run(UUID.randomUUID()));
+  }
+
+  /** Verify physical terminal products and per-component material closure for the pumparound case. */
+  private void assertPumparoundProductsPhysicalAndBalanced(DistillationColumn column) {
+    StreamInterface feed = column.getFeedStreams(3).get(0);
+    StreamInterface gas = column.getGasOutStream();
+    StreamInterface liquid = column.getLiquidOutStream();
+    double feedFlow = feed.getFlowRate("mol/hr");
+    double gasFlow = gas.getFlowRate("mol/hr");
+    double liquidFlow = liquid.getFlowRate("mol/hr");
+
+    assertTrue(Double.isFinite(gasFlow) && gasFlow >= 0.0);
+    assertTrue(Double.isFinite(liquidFlow) && liquidFlow >= 0.0);
+    assertTrue(Double.isFinite(gas.getTemperature()) && gas.getTemperature() > 0.0);
+    assertTrue(Double.isFinite(liquid.getTemperature()) && liquid.getTemperature() > 0.0);
+    assertEquals(feedFlow, gasFlow + liquidFlow, 5.0e-3 * feedFlow);
+
+    double[] feedComposition = feed.getThermoSystem().getMolarComposition();
+    double[] gasComposition = gas.getThermoSystem().getMolarComposition();
+    double[] liquidComposition = liquid.getThermoSystem().getMolarComposition();
+    for (int componentIndex = 0; componentIndex < feedComposition.length; componentIndex++) {
+      assertTrue(gasComposition[componentIndex] >= 0.0 && gasComposition[componentIndex] <= 1.0);
+      assertTrue(liquidComposition[componentIndex] >= 0.0 && liquidComposition[componentIndex] <= 1.0);
+      double feedComponentFlow = feedFlow * feedComposition[componentIndex];
+      double productComponentFlow = gasFlow * gasComposition[componentIndex]
+          + liquidFlow * liquidComposition[componentIndex];
+      assertEquals(feedComponentFlow, productComponentFlow,
+          Math.max(1.0e-6, 5.0e-3 * Math.abs(feedComponentFlow)));
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

A converged liquid pumparound can expose a public return stream that no longer satisfies its configured temperature drop. The column updates the return from a solved tray draw, then performs one additional unmeasured inner solve during outer-tear finalization. During that initialization, `SimpleTray.init()` seeds inlet temperatures at the tray temperature and mutates the canonical pumparound return stream.

On exact master `a1f7817d57e013d14da31991cc160b570ca0cb62`, a six-stage SRK propane/n-butane/n-pentane reboiler column requested 5 K of pumparound cooling but returned 34.6428204128211 K while reporting `RIGOROUS_CONVERGED` and a converged outer tear. The relevant pumparound initialization and tear code was unchanged when side-draw energy PR #2868 advanced master to `efc6507656377f05c0151fefa8cd757c653982f5`.

## Root cause and change

This change keeps the existing sequential solver and stream identity:

- snapshot each existing pumparound return thermodynamic system before tray-profile initialization;
- restore that system after profile seeding, including the no-feed early return;
- for pumparound-only outer tears, accept the measured fixed-point residual from the just-solved draw instead of running one extra inner solve whose changed return is never measured;
- retain the existing final re-solve for side-draw and hydraulic tear variables; and
- document the return-state contract.

No solver tolerance, EOS, flash, tray equation, public API, serialization field, or calculation identity is changed.

## Before / after evidence

| Case | Before | After |
|---|---:|---:|
| Requested draw-to-return drop, base case | 5 K requested, 34.6428204128211 K exposed | 5.000000000000 K |
| Nearby cooling point | not accepted as a baseline claim | 4.000000000000 K |
| Return flow | 262.4039167756102 kg/h | 261.337170842425 kg/h at 5 K; 261.270123104469 kg/h at 4 K |
| Circuit enthalpy change | state was thermodynamically inconsistent | -1009.519279507891 W at 5 K; -809.047995349465 W at 4 K |
| Total mass residual | 0 kg/h | 0 kg/h |
| Outer tear | 4 iterations, reported converged | 4 iterations; residual 8.7953e-6 at 5 K and 8.4293e-6 at 4 K |

Repeated warm runs preserve the exact configured temperature drop. Return flow and calculated draw/return enthalpy change repeat within `5e-5` relative, consistent with the configured `1e-4` outer-tear tolerance.

No speed claim is made.

## Validation

On the original base before master advanced:

- 56 ordinary affected column tests passed: pumparound mode, warm-state/cache, side-draw, solver tuning, convergence-gate, and solved-consistency coverage.
- 53 slow `DistillationColumnTest` and `ColumnSpecificationTest` cases passed after a clean Java 17 build; one pre-existing disabled test was skipped.
- The two focused regressions passed from a clean Java 8 profile build, and the compiled class was bytecode version 52.

After rebasing the three intended files onto current master `efc6507656377f05c0151fefa8cd757c653982f5`:

- the new multistage pumparound regression passed at 4 K and 5 K, including per-component/total material closure and physical flow, temperature, and composition bounds;
- the existing warm-state pumparound regression passed;
- both newly merged side-draw energy regression methods passed;
- the focused tests, including the strengthened component-balance checks, again passed from a clean Java 8 profile build;
- Spotless apply/check, mandatory pre-commit and pre-push hooks, Checkstyle, PMD, and documentation search over 646 Markdown pages plus one standalone HTML page passed.

Local Javadoc generation could not run because this runtime contains a JRE but no `javadoc` executable. Hosted Javadoc and the full Java 8/21 matrix remain required before merge readiness. No notebook changed.

## Compatibility and risk

The return `StreamInterface` object remains the same object, preserving callers that retain it. Only its thermodynamic state is protected across tray-profile seeding. The pumparound-only fixed-point path no longer exposes products from an unmeasured extra solve; combined side-draw or hydraulic tear configurations keep their prior finalization path.

The main residual risk is interactions with less common multiple-pumparound and combined-tear configurations, which hosted broad tests must screen.

## Remaining limitation

Explicit pumparound cooler/heater duty and inclusion of that utility duty in column energy accounting are intentionally out of scope. They are the next dependency-ordered improvement now that draw/return state is internally consistent.

Documentation impact: the pumparound return-temperature contract is updated in `docs/process/equipment/distillation.md`.