### PR TITLE
Fix Java 8 side-draw rollback telemetry assertion

### DIFF
--- a/src/test/java/neqsim/process/equipment/distillation/SimpleTraySideDrawTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SimpleTraySideDrawTest.java
@@ -168,8 +168,9 @@ public class SimpleTraySideDrawTest {
     assertEquals(0.0, column.getMassBalance("kg/hr"), 1.0e-6, column.getConvergenceDiagnostics());
     assertTrue(column.getEnergyBalanceError() < 1.0e-2, column.getConvergenceDiagnostics());
     assertTrue(column.getLastColumnTearRejectedCandidateCount() > 0,
-        "the regression should exercise rejected-candidate rollback");
-    assertEquals(column.getLastColumnTearRejectedCandidateCount(), column.getLastColumnTearRollbackCount());
+        "the regression should exercise rejected-candidate isolation");
+    assertTrue(column.getLastColumnTearRollbackCount() <= column.getLastColumnTearRejectedCandidateCount(),
+        "only rejections after an accepted state exists can require rollback");
     assertTrue(column.getLastColumnTearCandidateHistory().contains("FALLBACK_PRODUCTS"));
     assertComponentMassBalance(feed, column.getSideDrawStream(3, DistillationColumn.SideDrawPhase.LIQUID), column);
 
@@ -219,6 +220,10 @@ public class SimpleTraySideDrawTest {
     assertEquals(0.0, column.getMassBalance("kg/hr"), 1.0e-6, column.getConvergenceDiagnostics());
     assertTrue(column.getLastColumnTearRejectedCandidateCount() > 0,
         "the controller should reject the invalid large multiplicative candidate");
+    assertTrue(column.getLastColumnTearRollbackCount() > 0,
+        "the rejected cold candidate should retain the previously accepted state");
+    assertTrue(column.getLastColumnTearRollbackCount() <= column.getLastColumnTearRejectedCandidateCount(),
+        "rollback count cannot exceed the rejected candidate count");
     assertTrue(column.getLastColumnTearCandidateHistory().contains("continuation fraction="),
         "the rejected cold candidate should be retried from an accepted state");
     assertComponentMassBalance(feed, column.getSideDrawStream(3, DistillationColumn.SideDrawPhase.LIQUID), column);


### PR DESCRIPTION
## Problem

The Java 8 Windows job in workflow run 31148697774 failed only at `SimpleTraySideDrawTest.multistageLiquidSideDrawFlowSpecificationConverges`:

```
expected: <5> but was: <0>
SimpleTraySideDrawTest.java:172
```

The assertion required `rejectedCandidateCount == rollbackCount`. That is not the telemetry contract: a rejected cold candidate increments the rejection count, but it cannot increment the accepted-state rollback count until an accepted state exists. The same test class already verifies this deterministically with 12 rejected candidates and 0 rollbacks.

No open pull request was found for this exact failure.

## Change

- keep the ordinary multistage regression's rejected-candidate isolation coverage;
- require `rollbackCount <= rejectedCandidateCount`, allowing valid pre-acceptance rejections;
- preserve explicit rollback coverage in the high-target continuation regression by requiring at least one rollback, bounding it by the rejection count, and retaining the continuation-history assertion.

No solver tolerance or production behavior is changed.

## Validation

- `pomJava8.xml` compiled 3,105 main and 1,635 test sources with Java 8 source/target compatibility.
- Normal + high multistage side-draw regressions: 2 tests passed, 0 failures.
- Deterministic pre-acceptance rejection regression: 1 test passed, 0 failures; it retains the expected 12 rejected / 0 rollback contract.
- `./mvnw spotless:apply`: passed, 0 files changed.
- `./mvnw spotless:check`: passed.
- `pre-commit run --all-files --hook-stage pre-commit`: passed.
- `pre-commit run --all-files --hook-stage pre-push`: passed, including Spotless and documentation-search coverage.
- `git diff --check`: passed.

Local runtime was OpenJDK 17 with `pomJava8.xml`; the hosted Java 8 Ubuntu/Windows matrix remains the runtime verification gate.

## Documentation impact

Documentation impact: none. This is a test-only correction aligning assertions with the existing documented telemetry semantics; public APIs, calculations, units, defaults, and solver behavior are unchanged.

## Checklist

- [x] Focused affected tests pass with Java 8 compilation target.
- [x] Spotless and repository pre-commit/pre-push gates pass.
- [x] Documentation impact assessed.
- [ ] Full hosted Java 8/21 matrix pending.
