### PR TITLE
fix(twofluid): make virtual-mass coupling stage-pure

### DIFF
--- a/docs/development/CODE_PATTERNS.md
+++ b/docs/development/CODE_PATTERNS.md
@@ -387,7 +387,7 @@ double ratio = dpTF / dpBB;
 ### Two-Fluid Pipe with Virtual Mass Force
 
 ```java
-// Enable virtual mass force for improved slug dynamics and pressure surge prediction
+// Enable optional gas-liquid added-inertia coupling
 TwoFluidPipe pipe = new TwoFluidPipe("Pipeline", feedStream);
 pipe.setLength(5000);
 pipe.setDiameter(0.3);
@@ -395,11 +395,14 @@ pipe.setNumberOfSections(100);
 
 // Enable virtual mass force (Drew & Lahey 1987)
 pipe.getEquations().setEnableVirtualMassForce(true);
-pipe.getEquations().setVirtualMassCoefficient(0.5);  // Default for spheres
-pipe.getEquations().setTimestep(0.1);  // Required for dv/dt calculation
+pipe.getEquations().setVirtualMassCoefficient(0.5);  // Spherical-bubble value
 
 pipe.run();
 ```
+
+The coupling is algebraic and stage-pure: it uses the complete current RHS and retains no previous
+velocity or integration-stage history. Treat `0.5` as a closure assumption, not a general accuracy
+claim, and validate it for the intended flow regime and transient.
 
 ### Two-Fluid Pipe with Junction/Bend Losses
 

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -167,6 +167,32 @@ Separate momentum equations for each phase:
 | Wall friction | Pipe roughness-based (Colebrook/Blasius correlations) |
 | Interfacial friction | Flow-regime dependent correlations |
 
+#### Optional virtual-mass coupling
+
+`setEnableVirtualMassForce(true)` enables a local added-inertia coupling between gas and combined
+liquid momentum. After the complete uncoupled finite-volume right-hand side is assembled, the model
+computes
+
+$$
+K=C_{vm}\alpha_G\rho_L A,
+\qquad
+F_{vm,G}=\frac{-K(a_{G,0}-a_{L,0})}
+{1+K(1/m_G+1/m_L)},
+\qquad F_{vm,L}=-F_{vm,G}.
+$$
+
+Here $a_{k,0}=(d(m_kv_k)/dt-v_kdm_k/dt)/m_k$ is obtained from the current integration-stage
+state and its complete uncoupled rate. The operator retains no velocity history, so repeated RHS
+evaluations and rejected integrator stages cannot change a later evaluation. For gas-oil-water
+flow, the combined liquid correction is partitioned between oil and water by conservative liquid
+mass, preserving mixture momentum without creating oil-water transfer. Coupling tends continuously
+to zero when either phase inventory is absent.
+
+The default $C_{vm}=0.5$ is the spherical-bubble value. It is not a universal calibration for slug,
+churn, or annular flow, and enabling it does not establish accuracy parity with a commercial
+multiphase simulator. Validate the coefficient and transient response against applicable public or
+project data before engineering use.
+
 ### Energy Conservation
 
 | Feature | Description |

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -505,21 +505,28 @@ f_i = 0.01 × (1 + 10 × Fr²)    // capped at 0.1
 
 ## Virtual Mass Force
 
-The virtual mass (added mass) force accounts for the inertia of the displaced phase during rapid accelerations. This is important for slug flow dynamics, pressure surges, and transient simulations with fast-changing velocities.
+The virtual mass (added mass) force accounts for the inertia of displaced liquid during gas-liquid acceleration. It is an optional local momentum coupling for transient simulations.
 
 ### Physical Basis
 
-When a gas bubble accelerates through liquid, it must also accelerate a portion of the surrounding liquid. This "added mass" effect creates an additional force proportional to the relative acceleration:
+When gas accelerates through liquid, it must also accelerate a portion of the surrounding liquid. After the complete uncoupled finite-volume right-hand side is assembled, NeqSim solves the local added-inertia relation algebraically:
 
 $$
-F_{vm} = C_{vm} \cdot \alpha_G \cdot \rho_L \cdot \left(\frac{dv_G}{dt} - \frac{dv_L}{dt}\right)
+K=C_{vm}\alpha_G\rho_LA,
+\qquad
+F_{vm,G}=\frac{-K(a_{G,0}-a_{L,0})}{1+K(1/m_G+1/m_L)},
+\qquad F_{vm,L}=-F_{vm,G}
 $$
 
 Where:
 - `C_vm` = virtual mass coefficient (0.5 for spheres, default)
 - `α_G` = gas holdup
 - `ρ_L` = liquid density
-- `dv_G/dt - dv_L/dt` = relative acceleration between phases
+- `A` = pipe cross-sectional area
+- `m_G`, `m_L` = conservative gas and combined-liquid masses per length
+- `a_k,0 = (d(m_k v_k)/dt - v_k dm_k/dt) / m_k` = uncoupled stage acceleration
+
+The calculation uses only the supplied integration-stage state and its complete uncoupled rate; it does not retain velocities from previous RHS calls. In gas-oil-water flow, the liquid correction is divided between oil and water by their conservative masses. The gas and combined-liquid forces are equal and opposite, and coupling tends continuously to zero when either phase is absent.
 
 ### Enabling Virtual Mass Force
 
@@ -529,8 +536,8 @@ pipe.setLength(5000);
 pipe.setDiameter(0.3);
 pipe.setNumberOfSections(100);
 
-// Note: Virtual mass force is handled internally by the two-fluid solver.
-// The solver uses C_vm = 0.5 (spherical bubble coefficient) by default.
+pipe.getEquations().setEnableVirtualMassForce(true);
+pipe.getEquations().setVirtualMassCoefficient(0.5); // Spherical-bubble value
 
 pipe.run();
 ```
@@ -542,10 +549,7 @@ The virtual mass force appears as source terms in the phase momentum equations:
 - **Gas momentum:** `+F_vm` (accelerates gas when liquid decelerates)
 - **Liquid momentum:** `-F_vm` (decelerates liquid when gas accelerates)
 
-This coupling improves:
-- Pressure surge prediction during slug passage (±10-20% more accurate)
-- Transient response during flow rate changes
-- Wave speed calculation for fast transients
+The spherical-bubble coefficient is not a universal slug, churn, or annular-flow calibration. The implementation does not by itself establish improved field accuracy or parity with a commercial simulator. Validate the coefficient, discretization, and complete opt-in transient against data applicable to the intended operating envelope.
 
 ### Reference
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -893,8 +893,7 @@ public class TwoFluidConservationEquations implements Serializable {
       }
 
       double gasVelocity = sec.getGasVelocity();
-      double gasAcceleration =
-          (dUdt[i][IDX_GAS_MOMENTUM] - gasVelocity * dUdt[i][IDX_GAS_MASS]) / gasMass;
+      double gasAcceleration = (dUdt[i][IDX_GAS_MOMENTUM] - gasVelocity * dUdt[i][IDX_GAS_MASS]) / gasMass;
 
       double liquidMomentumRate;
       double liquidMassVelocityRate;
@@ -904,8 +903,7 @@ public class TwoFluidConservationEquations implements Serializable {
             + sec.getWaterVelocity() * dUdt[i][IDX_WATER_MASS];
       } else {
         liquidMomentumRate = dUdt[i][IDX_OIL_MOMENTUM];
-        liquidMassVelocityRate =
-            sec.getLiquidVelocity() * (dUdt[i][IDX_OIL_MASS] + dUdt[i][IDX_WATER_MASS]);
+        liquidMassVelocityRate = sec.getLiquidVelocity() * (dUdt[i][IDX_OIL_MASS] + dUdt[i][IDX_WATER_MASS]);
       }
       double liquidAcceleration = (liquidMomentumRate - liquidMassVelocityRate) / liquidMass;
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -897,7 +897,7 @@ public class TwoFluidConservationEquations implements Serializable {
 
       double liquidMomentumRate;
       double liquidMassVelocityRate;
-      if (enableWaterOilSlip && NUM_EQUATIONS == 7) {
+      if (enableWaterOilSlip) {
         liquidMomentumRate = dUdt[i][IDX_OIL_MOMENTUM] + dUdt[i][IDX_WATER_MOMENTUM];
         liquidMassVelocityRate = sec.getOilVelocity() * dUdt[i][IDX_OIL_MASS]
             + sec.getWaterVelocity() * dUdt[i][IDX_WATER_MASS];
@@ -915,7 +915,7 @@ public class TwoFluidConservationEquations implements Serializable {
       }
 
       dUdt[i][IDX_GAS_MOMENTUM] += gasVirtualMassForce;
-      if (enableWaterOilSlip && NUM_EQUATIONS == 7) {
+      if (enableWaterOilSlip) {
         double liquidVirtualMassForce = -gasVirtualMassForce;
         double oilVirtualMassForce = liquidVirtualMassForce * oilMass / liquidMass;
         double waterVirtualMassForce = liquidVirtualMassForce - oilVirtualMassForce;

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -120,13 +120,7 @@ public class TwoFluidConservationEquations implements Serializable {
    */
   private double virtualMassCoefficient = 0.5;
 
-  /** Previous velocities for virtual mass force calculation (stored between timesteps). */
-  private double[] prevGasVelocities;
-
-  /** Previous velocities for virtual mass force calculation (stored between timesteps). */
-  private double[] prevLiquidVelocities;
-
-  /** Timestep for virtual mass force calculation. */
+  /** Retained timestep setting for source compatibility with existing callers. */
   private double dt = 0.01;
 
   /** Most recent phase-resolved boundary and source rates calculated by {@link #calcRHS}. */
@@ -261,6 +255,8 @@ public class TwoFluidConservationEquations implements Serializable {
         dUdt[i][j] = -1.0 / secDx * (fluxRight[j] - fluxLeft[j]) + sources[i][j];
       }
     }
+
+    applyVirtualMassCoupling(sections, dUdt);
 
     double[] inletMassFlow = { inletFlux[IDX_GAS_MASS], inletFlux[IDX_OIL_MASS], inletFlux[IDX_WATER_MASS] };
     double[] outletMassFlow = { outletFlux[IDX_GAS_MASS], outletFlux[IDX_OIL_MASS], outletFlux[IDX_WATER_MASS] };
@@ -778,41 +774,7 @@ public class TwoFluidConservationEquations implements Serializable {
       lastPhaseMassSourcesPerLength[i][1] = Gamma_O;
       lastPhaseMassSourcesPerLength[i][2] = Gamma_W;
 
-      // Virtual mass force calculation (Drew & Lahey, 1987)
-      // F_vm = C_vm * alpha_dispersed * rho_continuous * (dv_dispersed/dt - dv_continuous/dt)
-      // For gas-liquid: gas is dispersed, liquid is continuous
-      double F_vmG = 0;
-      double F_vmL = 0;
-
-      if (enableVirtualMassForce) {
-        // Initialize previous velocity arrays if needed
-        if (prevGasVelocities == null || prevGasVelocities.length != sections.length) {
-          prevGasVelocities = new double[sections.length];
-          prevLiquidVelocities = new double[sections.length];
-          for (int j = 0; j < sections.length; j++) {
-            prevGasVelocities[j] = sections[j].getGasVelocity();
-            prevLiquidVelocities[j] = sections[j].getLiquidVelocity();
-          }
-        }
-
-        // Rate of change of velocities
-        double dvG_dt = 0;
-        double dvL_dt = 0;
-        if (dt > 1e-10) {
-          dvG_dt = (sec.getGasVelocity() - prevGasVelocities[i]) / dt;
-          dvL_dt = (sec.getLiquidVelocity() - prevLiquidVelocities[i]) / dt;
-        }
-
-        // Virtual mass force per unit length (N/m)
-        // Convention: positive F_vmG accelerates gas (added to gas momentum)
-        // The force on gas = -C_vm * alpha_G * rho_L * A * (dv_G/dt - dv_L/dt)
-        // (liquid adds inertia to gas motion)
-        double relAccel = dvG_dt - dvL_dt;
-        F_vmG = -virtualMassCoefficient * alphaG * rhoL * A * relAccel;
-        F_vmL = -F_vmG; // Newton's third law: equal and opposite on liquid
-      }
-
-      sources[i][IDX_GAS_MOMENTUM] = F_wG + F_iG + F_gG + F_vmG + transferMomentum[0];
+      sources[i][IDX_GAS_MOMENTUM] = F_wG + F_iG + F_gG + transferMomentum[0];
 
       if (enableWaterOilSlip && NUM_EQUATIONS == 7) {
         // Separate oil and water momentum equations
@@ -865,18 +827,14 @@ public class TwoFluidConservationEquations implements Serializable {
         double F_ow_oil = -tau_ow * S_ow;
         double F_ow_water = tau_ow * S_ow; // Opposite sign
 
-        // Virtual mass force partitioned to oil and water
-        double F_vmO = F_vmL * oilHoldupFrac;
-        double F_vmW = F_vmL * waterHoldupFrac;
-
         // Assemble oil momentum source
-        sources[i][IDX_OIL_MOMENTUM] = F_wO + F_iO + F_gO + F_ow_oil + F_vmO + transferMomentum[1];
+        sources[i][IDX_OIL_MOMENTUM] = F_wO + F_iO + F_gO + F_ow_oil + transferMomentum[1];
 
         // Assemble water momentum source
-        sources[i][IDX_WATER_MOMENTUM] = F_wW + F_iW + F_gW + F_ow_water + F_vmW + transferMomentum[2];
+        sources[i][IDX_WATER_MOMENTUM] = F_wW + F_iW + F_gW + F_ow_water + transferMomentum[2];
       } else {
         // Combined liquid momentum (original 6-equation model)
-        sources[i][IDX_OIL_MOMENTUM] = F_wL + F_iL + F_gL + F_vmL + transferMomentum[1] + transferMomentum[2];
+        sources[i][IDX_OIL_MOMENTUM] = F_wL + F_iL + F_gL + transferMomentum[1] + transferMomentum[2];
         sources[i][IDX_WATER_MOMENTUM] = 0; // Not used in 6-equation mode
       }
 
@@ -896,14 +854,82 @@ public class TwoFluidConservationEquations implements Serializable {
       sec.setLiquidMomentumSource(liquidMomSource);
       sec.setEnergySource(sources[i][IDX_ENERGY]);
 
-      // Update previous velocities for next timestep virtual mass calculation
-      if (enableVirtualMassForce && prevGasVelocities != null) {
-        prevGasVelocities[i] = sec.getGasVelocity();
-        prevLiquidVelocities[i] = sec.getLiquidVelocity();
-      }
     }
 
     return sources;
+  }
+
+  /**
+   * Apply the local, stage-pure virtual-mass momentum coupling.
+   *
+   * <p>
+   * The uncoupled conservative rates already contain flux divergence, pressure, gravity, friction, and transfer
+   * sources. Converting those rates to phase accelerations and solving the two-phase added-inertia relation
+   * algebraically avoids hidden velocity history and makes repeated RHS evaluations deterministic.
+   * </p>
+   *
+   * @param sections current stage state
+   * @param dUdt complete uncoupled conservative-variable rates, modified in place
+   */
+  void applyVirtualMassCoupling(TwoFluidSection[] sections, double[][] dUdt) {
+    if (!enableVirtualMassForce || virtualMassCoefficient <= 0.0) {
+      return;
+    }
+
+    for (int i = 0; i < sections.length; i++) {
+      TwoFluidSection sec = sections[i];
+      double gasMass = sec.getGasMassPerLength();
+      double oilMass = sec.getOilMassPerLength();
+      double waterMass = sec.getWaterMassPerLength();
+      double liquidMass = oilMass + waterMass;
+      double liquidDensity = sec.getLiquidDensity();
+      double area = sec.getArea();
+      double gasHoldup = Math.max(0.0, Math.min(1.0, sec.getGasHoldup()));
+
+      if (!Double.isFinite(gasMass) || !Double.isFinite(liquidMass) || !Double.isFinite(liquidDensity)
+          || !Double.isFinite(area) || gasMass <= 0.0 || liquidMass <= 0.0 || liquidDensity <= 0.0 || area <= 0.0
+          || gasHoldup <= 0.0) {
+        continue;
+      }
+
+      double gasVelocity = sec.getGasVelocity();
+      double gasAcceleration =
+          (dUdt[i][IDX_GAS_MOMENTUM] - gasVelocity * dUdt[i][IDX_GAS_MASS]) / gasMass;
+
+      double liquidMomentumRate;
+      double liquidMassVelocityRate;
+      if (enableWaterOilSlip && NUM_EQUATIONS == 7) {
+        liquidMomentumRate = dUdt[i][IDX_OIL_MOMENTUM] + dUdt[i][IDX_WATER_MOMENTUM];
+        liquidMassVelocityRate = sec.getOilVelocity() * dUdt[i][IDX_OIL_MASS]
+            + sec.getWaterVelocity() * dUdt[i][IDX_WATER_MASS];
+      } else {
+        liquidMomentumRate = dUdt[i][IDX_OIL_MOMENTUM];
+        liquidMassVelocityRate =
+            sec.getLiquidVelocity() * (dUdt[i][IDX_OIL_MASS] + dUdt[i][IDX_WATER_MASS]);
+      }
+      double liquidAcceleration = (liquidMomentumRate - liquidMassVelocityRate) / liquidMass;
+
+      double addedMassPerLength = virtualMassCoefficient * gasHoldup * liquidDensity * area;
+      double denominator = 1.0 + addedMassPerLength * (1.0 / gasMass + 1.0 / liquidMass);
+      double gasVirtualMassForce = -addedMassPerLength * (gasAcceleration - liquidAcceleration) / denominator;
+      if (!Double.isFinite(gasVirtualMassForce)) {
+        continue;
+      }
+
+      dUdt[i][IDX_GAS_MOMENTUM] += gasVirtualMassForce;
+      if (enableWaterOilSlip && NUM_EQUATIONS == 7) {
+        double liquidVirtualMassForce = -gasVirtualMassForce;
+        double oilVirtualMassForce = liquidVirtualMassForce * oilMass / liquidMass;
+        double waterVirtualMassForce = liquidVirtualMassForce - oilVirtualMassForce;
+        dUdt[i][IDX_OIL_MOMENTUM] += oilVirtualMassForce;
+        dUdt[i][IDX_WATER_MOMENTUM] += waterVirtualMassForce;
+      } else {
+        dUdt[i][IDX_OIL_MOMENTUM] -= gasVirtualMassForce;
+      }
+
+      sec.setGasMomentumSource(sec.getGasMomentumSource() + gasVirtualMassForce);
+      sec.setLiquidMomentumSource(sec.getLiquidMomentumSource() - gasVirtualMassForce);
+    }
   }
 
   /**
@@ -1475,10 +1501,11 @@ public class TwoFluidConservationEquations implements Serializable {
   }
 
   /**
-   * Set the timestep used for virtual mass force calculation.
+   * Retain the timestep setting used by earlier virtual-mass implementations.
    *
    * <p>
-   * This should match the simulation timestep for accurate acceleration calculation.
+   * The stage-pure algebraic coupling no longer depends on a stored timestep. This method remains for source and
+   * serialization compatibility.
    * </p>
    *
    * @param timestep Timestep in seconds
@@ -1488,7 +1515,7 @@ public class TwoFluidConservationEquations implements Serializable {
   }
 
   /**
-   * Get the timestep used for virtual mass force calculation.
+   * Get the retained legacy timestep setting.
    *
    * @return Timestep in seconds
    */
@@ -1496,15 +1523,8 @@ public class TwoFluidConservationEquations implements Serializable {
     return dt;
   }
 
-  /**
-   * Reset the stored previous velocities.
-   *
-   * <p>
-   * Call this when restarting a simulation or changing geometry to avoid spurious accelerations.
-   * </p>
-   */
+  /** Reset legacy virtual-mass history (no-op for the stage-pure implementation). */
   public void resetVirtualMassState() {
-    prevGasVelocities = null;
-    prevLiquidVelocities = null;
+    // No hidden history is retained.
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidVirtualMassTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidVirtualMassTest.java
@@ -1,0 +1,248 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.twophasepipe.numerics.TimeIntegrator;
+
+/** Tests for the stage-pure virtual-mass momentum coupling. */
+class TwoFluidVirtualMassTest {
+
+  @Test
+  void identicalRhsEvaluationsAreBitwiseDeterministic() {
+    TwoFluidConservationEquations equations = enabledEquations(0.5);
+    TwoFluidSection[] sections = { createSection(0.0, 0.5), createSection(10.0, 0.5) };
+
+    double[][] first = equations.calcRHS(sections, 10.0);
+    double[][] second = equations.calcRHS(sections, 10.0);
+
+    assertMatrixEquals(first, second, 0.0);
+
+    final double[][] initialState = { createSection(0.0, 0.5).getStateVector() };
+    TimeIntegrator.RHSFunction rhs = (state, time) -> {
+      TwoFluidSection stageSection = createSection(0.0, 0.5);
+      stageSection.setStateVector(state[0]);
+      stageSection.extractPrimitiveVariables();
+      double[][] rates = accelerationRates(stageSection, 100.0, -2.0);
+      equations.applyVirtualMassCoupling(new TwoFluidSection[] { stageSection }, rates);
+      return rates;
+    };
+    for (TimeIntegrator.Method method : TimeIntegrator.Method.values()) {
+      TimeIntegrator integrator = new TimeIntegrator(method);
+      double[][] integratedFirst = integrator.step(copy(initialState), rhs, 1.0e-4);
+      double[][] integratedSecond = integrator.step(copy(initialState), rhs, 1.0e-4);
+      assertMatrixEquals(integratedFirst, integratedSecond, 0.0);
+      for (double value : integratedFirst[0]) {
+        assertTrue(Double.isFinite(value), method + " returned a non-finite stage result");
+      }
+    }
+  }
+
+  @Test
+  void matchesClosedFormTwoBodySolution() {
+    TwoFluidConservationEquations equations = enabledEquations(0.5);
+    TwoFluidSection section = createSection(0.0, 0.5);
+    double[][] rates = new double[1][TwoFluidConservationEquations.NUM_EQUATIONS];
+    rates[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM] = 8.0;
+    rates[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM] = -2.0;
+
+    equations.applyVirtualMassCoupling(new TwoFluidSection[] { section }, rates);
+
+    assertEquals(0.5116279069767442, rates[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM], 1.0e-12);
+    assertEquals(5.488372093023256, rates[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM], 1.0e-12);
+    double gasAcceleration = rates[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM]
+        / section.getGasMassPerLength();
+    double liquidAcceleration = rates[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM]
+        / section.getOilMassPerLength();
+    assertEquals(4.767245737257357, gasAcceleration - liquidAcceleration, 1.0e-11);
+  }
+
+  @Test
+  void preservesMixtureMomentumAndPartitionsLiquidByMass() {
+    TwoFluidConservationEquations equations = enabledEquations(0.5);
+    TwoFluidSection section = createThreePhaseSection();
+    double[][] rates = new double[1][TwoFluidConservationEquations.NUM_EQUATIONS];
+    rates[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM] = 8.0;
+    rates[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM] = -1.0;
+    rates[0][TwoFluidConservationEquations.IDX_WATER_MOMENTUM] = -1.0;
+    double momentumBefore = totalMomentumRate(rates[0]);
+
+    equations.applyVirtualMassCoupling(new TwoFluidSection[] { section }, rates);
+
+    assertEquals(momentumBefore, totalMomentumRate(rates[0]), 0.0);
+    double oilCorrection = rates[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM] + 1.0;
+    double waterCorrection = rates[0][TwoFluidConservationEquations.IDX_WATER_MOMENTUM] + 1.0;
+    assertEquals(section.getOilMassPerLength() / section.getWaterMassPerLength(), oilCorrection / waterCorrection,
+        1.0e-12);
+  }
+
+  @Test
+  void disabledAndZeroCoefficientPathsAreExactNoOps() {
+    TwoFluidSection section = createSection(0.0, 0.5);
+    double[][] reference = new double[1][TwoFluidConservationEquations.NUM_EQUATIONS];
+    reference[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM] = 8.0;
+    reference[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM] = -2.0;
+
+    double[][] disabled = copy(reference);
+    new TwoFluidConservationEquations().applyVirtualMassCoupling(new TwoFluidSection[] { section }, disabled);
+    assertMatrixEquals(reference, disabled, 0.0);
+
+    double[][] zeroCoefficient = copy(reference);
+    TwoFluidConservationEquations equations = enabledEquations(0.0);
+    equations.applyVirtualMassCoupling(new TwoFluidSection[] { section }, zeroCoefficient);
+    assertMatrixEquals(reference, zeroCoefficient, 0.0);
+  }
+
+  @Test
+  void couplingIsFiniteAcrossHoldupsAndCoefficientsAndSkipsAbsentLiquid() {
+    double[] gasHoldups = { 1.0e-8, 0.1, 0.5, 0.9, 1.0 - 1.0e-8 };
+    double[] coefficients = { 0.3, 0.5, 0.7 };
+    for (double gasHoldup : gasHoldups) {
+      double previousRelativeAcceleration = Double.POSITIVE_INFINITY;
+      for (double coefficient : coefficients) {
+        TwoFluidSection section = createSection(0.0, gasHoldup);
+        double[][] rates = accelerationRates(section, 100.0, -2.0);
+        enabledEquations(coefficient).applyVirtualMassCoupling(new TwoFluidSection[] { section }, rates);
+        double relativeAcceleration = relativeAcceleration(section, rates[0]);
+        assertTrue(Double.isFinite(relativeAcceleration));
+        assertTrue(Math.abs(relativeAcceleration) < previousRelativeAcceleration);
+        previousRelativeAcceleration = Math.abs(relativeAcceleration);
+      }
+    }
+
+    TwoFluidSection gasOnly = createSection(0.0, 1.0);
+    double[][] gasOnlyRates = accelerationRates(gasOnly, 100.0, 0.0);
+    double[][] gasOnlyReference = copy(gasOnlyRates);
+    enabledEquations(0.5).applyVirtualMassCoupling(new TwoFluidSection[] { gasOnly }, gasOnlyRates);
+    assertMatrixEquals(gasOnlyReference, gasOnlyRates, 0.0);
+  }
+
+  @Test
+  void serializationRoundTripRetainsStagePureConfiguration() throws Exception {
+    TwoFluidConservationEquations original = enabledEquations(0.7);
+    original.setTimestep(0.2);
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(original);
+    }
+
+    TwoFluidConservationEquations restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (TwoFluidConservationEquations) input.readObject();
+    }
+
+    assertTrue(restored.isVirtualMassForceEnabled());
+    assertEquals(0.7, restored.getVirtualMassCoefficient(), 0.0);
+    assertEquals(0.2, restored.getTimestep(), 0.0);
+    TwoFluidSection section = createSection(0.0, 0.5);
+    double[][] originalRates = accelerationRates(section, 100.0, -2.0);
+    double[][] restoredRates = copy(originalRates);
+    original.applyVirtualMassCoupling(new TwoFluidSection[] { section }, originalRates);
+    restored.applyVirtualMassCoupling(new TwoFluidSection[] { section }, restoredRates);
+    assertMatrixEquals(originalRates, restoredRates, 0.0);
+  }
+
+  private TwoFluidConservationEquations enabledEquations(double coefficient) {
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    equations.setEnableVirtualMassForce(true);
+    equations.setVirtualMassCoefficient(coefficient);
+    return equations;
+  }
+
+  private TwoFluidSection createSection(double position, double gasHoldup) {
+    TwoFluidSection section = new TwoFluidSection(position, 10.0, 0.1, 0.0);
+    double liquidHoldup = 1.0 - gasHoldup;
+    section.setPressure(50.0e5);
+    section.setTemperature(300.0);
+    section.setGasDensity(20.0);
+    section.setOilDensity(800.0);
+    section.setWaterDensity(1000.0);
+    section.setLiquidDensity(800.0);
+    section.setGasViscosity(1.5e-5);
+    section.setOilViscosity(5.0e-3);
+    section.setWaterViscosity(1.0e-3);
+    section.setLiquidViscosity(5.0e-3);
+    section.setGasSoundSpeed(300.0);
+    section.setLiquidSoundSpeed(1200.0);
+    section.setGasEnthalpy(1.0e5);
+    section.setLiquidEnthalpy(5.0e4);
+    section.setSurfaceTension(0.025);
+    section.setGasHoldup(gasHoldup);
+    section.setLiquidHoldup(liquidHoldup);
+    section.setOilHoldup(liquidHoldup);
+    section.setWaterHoldup(0.0);
+    section.setWaterCut(0.0);
+    section.setOilFractionInLiquid(1.0);
+    section.setGasVelocity(2.0);
+    section.setLiquidVelocity(0.5);
+    section.setOilVelocity(0.5);
+    section.setWaterVelocity(0.5);
+    section.updateConservativeVariables();
+    section.updateDerivedQuantities();
+    return section;
+  }
+
+  private TwoFluidSection createThreePhaseSection() {
+    TwoFluidSection section = createSection(0.0, 0.5);
+    section.setOilDensity(800.0);
+    section.setWaterDensity(1000.0);
+    section.setLiquidDensity(900.0);
+    section.setLiquidHoldup(0.5);
+    section.setOilHoldup(0.25);
+    section.setWaterHoldup(0.25);
+    section.setWaterCut(0.5);
+    section.setOilFractionInLiquid(0.5);
+    section.setOilVelocity(0.6);
+    section.setWaterVelocity(0.4);
+    section.updateConservativeVariables();
+    section.updateWaterOilConservativeVariables();
+    return section;
+  }
+
+  private double[][] accelerationRates(TwoFluidSection section, double gasAcceleration,
+      double liquidAcceleration) {
+    double[][] rates = new double[1][TwoFluidConservationEquations.NUM_EQUATIONS];
+    rates[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM] =
+        gasAcceleration * section.getGasMassPerLength();
+    rates[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM] =
+        liquidAcceleration * section.getOilMassPerLength();
+    rates[0][TwoFluidConservationEquations.IDX_WATER_MOMENTUM] =
+        liquidAcceleration * section.getWaterMassPerLength();
+    return rates;
+  }
+
+  private double relativeAcceleration(TwoFluidSection section, double[] rates) {
+    double gasAcceleration = rates[TwoFluidConservationEquations.IDX_GAS_MOMENTUM]
+        / section.getGasMassPerLength();
+    double liquidMass = section.getOilMassPerLength() + section.getWaterMassPerLength();
+    double liquidAcceleration = (rates[TwoFluidConservationEquations.IDX_OIL_MOMENTUM]
+        + rates[TwoFluidConservationEquations.IDX_WATER_MOMENTUM]) / liquidMass;
+    return gasAcceleration - liquidAcceleration;
+  }
+
+  private double totalMomentumRate(double[] rates) {
+    return rates[TwoFluidConservationEquations.IDX_GAS_MOMENTUM]
+        + rates[TwoFluidConservationEquations.IDX_OIL_MOMENTUM]
+        + rates[TwoFluidConservationEquations.IDX_WATER_MOMENTUM];
+  }
+
+  private double[][] copy(double[][] values) {
+    double[][] result = new double[values.length][];
+    for (int i = 0; i < values.length; i++) {
+      result[i] = values[i].clone();
+    }
+    return result;
+  }
+
+  private void assertMatrixEquals(double[][] expected, double[][] actual, double tolerance) {
+    assertEquals(expected.length, actual.length);
+    for (int i = 0; i < expected.length; i++) {
+      assertArrayEquals(expected[i], actual[i], tolerance);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidVirtualMassTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidVirtualMassTest.java
@@ -55,8 +55,7 @@ class TwoFluidVirtualMassTest {
 
     assertEquals(0.5116279069767442, rates[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM], 1.0e-12);
     assertEquals(5.488372093023256, rates[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM], 1.0e-12);
-    double gasAcceleration = rates[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM]
-        / section.getGasMassPerLength();
+    double gasAcceleration = rates[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM] / section.getGasMassPerLength();
     double liquidAcceleration = rates[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM]
         / section.getOilMassPerLength();
     assertEquals(4.767245737257357, gasAcceleration - liquidAcceleration, 1.0e-11);
@@ -204,21 +203,16 @@ class TwoFluidVirtualMassTest {
     return section;
   }
 
-  private double[][] accelerationRates(TwoFluidSection section, double gasAcceleration,
-      double liquidAcceleration) {
+  private double[][] accelerationRates(TwoFluidSection section, double gasAcceleration, double liquidAcceleration) {
     double[][] rates = new double[1][TwoFluidConservationEquations.NUM_EQUATIONS];
-    rates[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM] =
-        gasAcceleration * section.getGasMassPerLength();
-    rates[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM] =
-        liquidAcceleration * section.getOilMassPerLength();
-    rates[0][TwoFluidConservationEquations.IDX_WATER_MOMENTUM] =
-        liquidAcceleration * section.getWaterMassPerLength();
+    rates[0][TwoFluidConservationEquations.IDX_GAS_MOMENTUM] = gasAcceleration * section.getGasMassPerLength();
+    rates[0][TwoFluidConservationEquations.IDX_OIL_MOMENTUM] = liquidAcceleration * section.getOilMassPerLength();
+    rates[0][TwoFluidConservationEquations.IDX_WATER_MOMENTUM] = liquidAcceleration * section.getWaterMassPerLength();
     return rates;
   }
 
   private double relativeAcceleration(TwoFluidSection section, double[] rates) {
-    double gasAcceleration = rates[TwoFluidConservationEquations.IDX_GAS_MOMENTUM]
-        / section.getGasMassPerLength();
+    double gasAcceleration = rates[TwoFluidConservationEquations.IDX_GAS_MOMENTUM] / section.getGasMassPerLength();
     double liquidMass = section.getOilMassPerLength() + section.getWaterMassPerLength();
     double liquidAcceleration = (rates[TwoFluidConservationEquations.IDX_OIL_MOMENTUM]
         + rates[TwoFluidConservationEquations.IDX_WATER_MOMENTUM]) / liquidMass;
@@ -226,8 +220,7 @@ class TwoFluidVirtualMassTest {
   }
 
   private double totalMomentumRate(double[] rates) {
-    return rates[TwoFluidConservationEquations.IDX_GAS_MOMENTUM]
-        + rates[TwoFluidConservationEquations.IDX_OIL_MOMENTUM]
+    return rates[TwoFluidConservationEquations.IDX_GAS_MOMENTUM] + rates[TwoFluidConservationEquations.IDX_OIL_MOMENTUM]
         + rates[TwoFluidConservationEquations.IDX_WATER_MOMENTUM];
   }
 


### PR DESCRIPTION
Closes #2891

## Summary

- replace mutable previous-velocity history with a local algebraic acceleration coupling applied after complete RHS assembly
- preserve equal-and-opposite gas/combined-liquid momentum and partition the liquid correction by conservative oil/water mass
- retain legacy timestep and reset APIs for source and serialization compatibility without hidden stage state
- document the equation, phase limits, coefficient assumptions, and absence of an unsupported accuracy claim

## Root cause

`calcSourceTerms()` updated previous velocities during every RHS evaluation. RK and rejected/adaptive stages therefore changed later evaluations of the same supplied state.

## Validation

- focused `TwoFluidVirtualMassTest`: 6/6 passed
- repeated RHS calls are bitwise deterministic across all configured `TimeIntegrator` methods
- analytical reference: gas/liquid momentum rates 0.511627906977 / 5.48837209302 N/m, total 6 N/m
- exact disabled/zero-coefficient identity, finite holdup/coefficient sweeps, absent-liquid limit, and serialization passed
- related package run: 337 tests passed; three fixture tests initially lacked test resources and all 3 passed when rerun with `src/test/resources`
- documentation search: 646 Markdown pages and one standalone HTML page

## Validation limitation

This draft is not merge-ready until CI completes the repository Spotless gates. The exact commands were run:

- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`

Documentation Search Coverage passed. Spotless alone could not run because Maven could not resolve `com.diffplug.spotless:spotless-maven-plugin:3.9.0`: `repo1.maven.org` failed DNS resolution, and a temporary mirror retry using `https://repo.maven.apache.org/maven2/` also failed from Maven/Java with `Temporary failure in name resolution`. No `--no-verify` bypass was used.

All direct compilation used OpenJDK 17.0.19 with `--release 8` against NeqSim 3.17.0. `git diff --check` passed.