### PR TITLE
fix(flash): normalize final active phase fractions

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -199,6 +199,9 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │  Remove phases with β < βmin                                                    │
 │  Order phases by density                                                        │
 │  Final system.init(1)                                                           │
+│  After all rescue/refinement and chemical-equilibrium paths:                    │
+│     → Normalize the final active phase fractions when |Σβₖ - 1| ≥ 1e-12        │
+│     → A one-phase endpoint therefore returns β₀ = 1                             │
 │                                                                                 │
 │  IF aqueous multiphase checking follows an accepted stable single-phase test:    │
 │     → Reject an endpoint only when a phase composition contains non-finite or     │

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1078,6 +1078,7 @@ public class TPflash extends Flash {
         logger.warn("Final chemical eq init failed: " + ex.getMessage());
       }
     }
+    normalizeActivePhaseFractions();
   }
 
   /**
@@ -2555,7 +2556,7 @@ public class TPflash extends Flash {
    * and reinitializes level 1 properties for the adjusted phase amounts.
    * </p>
    */
-  private void normalizeActivePhaseFractions() {
+  void normalizeActivePhaseFractions() {
     int numberOfPhases = system.getNumberOfPhases();
     if (numberOfPhases == 1) {
       double beta = system.getBeta(0);

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -2650,6 +2650,7 @@ public class TPmultiflash extends TPflash {
        * if (!secondTime) { secondTime = true; doStabilityAnalysis = false; run(); }
        */
     }
+    normalizeActivePhaseFractions();
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPFlashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPFlashTest.java
@@ -108,23 +108,36 @@ class TPFlashTest {
 
   @Test
   void testRun5() {
-    neqsim.thermo.system.SystemInterface testSystem5 = new neqsim.thermo.system.SystemUMRPRUMCEos(243.15, 300.0);
-    testSystem5.addComponent("methane", 4.16683e-1);
-    testSystem5.addComponent("ethane", 1.7522e-1);
-    testSystem5.addComponent("n-pentane", 3.58009e-1);
-    testSystem5.addComponent("nC16", 5.00888e-2);
-    testSystem5.setMixingRule("classic");
-    testSystem5.setMultiPhaseCheck(true);
-    testSystem5.setPressure(90.03461693, "bara");
-    testSystem5.setTemperature(293.15, "K");
-    testSystem5.setTotalFlowRate(4.925e-07, "kg/sec");
-    testOps = new ThermodynamicOperations(testSystem5);
-    testOps.TPflash();
-    testSystem5.initProperties();
-    // testSystem5.prettyPrint();
-    double beta = testSystem5.getBeta();
-    // Updated expected value due to thermodynamic model changes
-    assertEquals(0.10377442547868508, beta, 1e-4);
+    SystemInterface multiphaseSystem = new neqsim.thermo.system.SystemUMRPRUMCEos(243.15, 300.0);
+    multiphaseSystem.addComponent("methane", 4.16683e-1);
+    multiphaseSystem.addComponent("ethane", 1.7522e-1);
+    multiphaseSystem.addComponent("n-pentane", 3.58009e-1);
+    multiphaseSystem.addComponent("nC16", 5.00888e-2);
+    multiphaseSystem.setMixingRule("classic");
+    multiphaseSystem.setPressure(90.03461693, "bara");
+    multiphaseSystem.setTemperature(293.15, "K");
+    multiphaseSystem.setTotalFlowRate(4.925e-07, "kg/sec");
+
+    SystemInterface ordinarySystem = multiphaseSystem.clone();
+    ordinarySystem.setMultiPhaseCheck(false);
+    new ThermodynamicOperations(ordinarySystem).TPflash();
+    ordinarySystem.initProperties();
+
+    multiphaseSystem.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(multiphaseSystem).TPflash();
+    multiphaseSystem.initProperties();
+
+    assertEquals(1, ordinarySystem.getNumberOfPhases());
+    assertEquals(1, multiphaseSystem.getNumberOfPhases());
+    assertEquals(1.0, ordinarySystem.getBeta(0), 1.0e-12);
+    assertEquals(ordinarySystem.getBeta(0), multiphaseSystem.getBeta(0), 1.0e-12);
+    assertEquals(ordinarySystem.getPhase(0).getType(), multiphaseSystem.getPhase(0).getType());
+    assertEquals(ordinarySystem.getPhase(0).getZ(), multiphaseSystem.getPhase(0).getZ(), 1.0e-11);
+    for (int componentIndex = 0; componentIndex < ordinarySystem.getPhase(0)
+        .getNumberOfComponents(); componentIndex++) {
+      assertEquals(ordinarySystem.getPhase(0).getComponent(componentIndex).getx(),
+          multiphaseSystem.getPhase(0).getComponent(componentIndex).getx(), 1.0e-11);
+    }
   }
 
   @Test


### PR DESCRIPTION
Closes #2889

## Summary

- reuse the existing active-beta normalization at the final return point of both `TPflash` and `TPmultiflash`
- preserve the existing 1e-12 no-op tolerance so already closed endpoints do not reinitialize
- update the UMR-PRU regression to compare ordinary and multiphase one-phase endpoints
- document the final active-phase-fraction invariant

## Root cause

Late UMR-PRU rescue/refinement can collapse the active phase set after the earlier normalization point, leaving one active phase with beta different from one.

## Validation

- complete `TPFlashTest`: 14/14 passed
- reproducer now returns one OIL phase with beta = 1.0
- ordinary/multiphase phase type, Z, and phase compositions agree within the regression tolerances
- documentation search: 646 Markdown pages and one standalone HTML page

## Validation limitation

This draft is not merge-ready until CI completes the repository Spotless gates. The exact commands were run:

- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`

Documentation Search Coverage passed. Spotless alone could not run because Maven could not resolve `com.diffplug.spotless:spotless-maven-plugin:3.9.0`: `repo1.maven.org` failed DNS resolution, and a temporary mirror retry using `https://repo.maven.apache.org/maven2/` also failed from Maven/Java with `Temporary failure in name resolution`. No `--no-verify` bypass was used.

All direct compilation used OpenJDK 17.0.19 with `--release 8` against NeqSim 3.17.0. `git diff --check` passed.