### PR TITLE
Cache successful process run statuses

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -343,6 +343,11 @@ public class ProcessSystem extends SimulationBaseClass {
   private transient RunStatus lastRunStatus = new RunStatus();
 
   /**
+   * Immutable success records reused while the unit structure, names and types remain unchanged.
+   */
+  private transient List<UnitRunStatus> cachedSuccessfulRunStatuses = null;
+
+  /**
    * Interface for monitoring simulation progress during execution. Implementations receive callbacks after each unit
    * operation completes, enabling real-time visualization, progress tracking, and early termination detection.
    *
@@ -2854,22 +2859,53 @@ public class ProcessSystem extends SimulationBaseClass {
       return;
     }
     if (!runThrew) {
-      java.util.Set<String> failedNames = new java.util.HashSet<String>();
-      for (UnitRunStatus u : lastRunStatus.getUnits()) {
-        if (!u.isSuccess()) {
-          failedNames.add(u.getUnitName());
-        }
-      }
-      for (ProcessEquipmentInterface unit : unitOperations) {
-        if (unit == null) {
-          continue;
-        }
-        if (!failedNames.contains(unit.getName())) {
-          lastRunStatus.recordSuccess(unit.getName(), unit.getClass().getSimpleName());
-        }
+      List<UnitRunStatus> successfulStatuses = getSuccessfulRunStatuses();
+      for (UnitRunStatus status : successfulStatuses) {
+        lastRunStatus.recordSuccess(status);
       }
     }
     lastRunStatus.markComplete(!runThrew);
+  }
+
+  /**
+   * Returns cached immutable success records, rebuilding them if a unit was renamed or replaced without changing the
+   * structure version.
+   *
+   * @return success records in process execution order
+   */
+  private List<UnitRunStatus> getSuccessfulRunStatuses() {
+    int nonNullUnitCount = 0;
+    boolean cacheMatches = cachedSuccessfulRunStatuses != null;
+    for (ProcessEquipmentInterface unit : unitOperations) {
+      if (unit == null) {
+        continue;
+      }
+      if (cacheMatches) {
+        if (nonNullUnitCount >= cachedSuccessfulRunStatuses.size()) {
+          cacheMatches = false;
+        } else {
+          UnitRunStatus cached = cachedSuccessfulRunStatuses.get(nonNullUnitCount);
+          String unitType = unit.getClass().getSimpleName();
+          if (!java.util.Objects.equals(cached.getUnitName(), unit.getName())
+              || !java.util.Objects.equals(cached.getUnitType(), unitType)) {
+            cacheMatches = false;
+          }
+        }
+      }
+      nonNullUnitCount++;
+    }
+    if (cacheMatches && nonNullUnitCount == cachedSuccessfulRunStatuses.size()) {
+      return cachedSuccessfulRunStatuses;
+    }
+
+    List<UnitRunStatus> rebuilt = new ArrayList<UnitRunStatus>(nonNullUnitCount);
+    for (ProcessEquipmentInterface unit : unitOperations) {
+      if (unit != null) {
+        rebuilt.add(new UnitRunStatus(unit.getName(), unit.getClass().getSimpleName(), true, null, null));
+      }
+    }
+    cachedSuccessfulRunStatuses = rebuilt;
+    return rebuilt;
   }
 
   /**
@@ -7116,6 +7152,7 @@ public class ProcessSystem extends SimulationBaseClass {
    * clear it at one of the mutation sites.
    */
   private void invalidateStructureCaches() {
+    cachedSuccessfulRunStatuses = null;
     invalidateGraph();
   }
 

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -2881,7 +2881,7 @@ public class ProcessSystem extends SimulationBaseClass {
       if (unit == null) {
         continue;
       }
-      if (cacheMatches) {
+      if (cacheMatches && cachedStatuses != null) {
         if (nonNullUnitCount >= cachedStatuses.size()) {
           cacheMatches = false;
         } else {
@@ -2895,7 +2895,7 @@ public class ProcessSystem extends SimulationBaseClass {
       }
       nonNullUnitCount++;
     }
-    if (cacheMatches && nonNullUnitCount == cachedStatuses.size()) {
+    if (cacheMatches && cachedStatuses != null && nonNullUnitCount == cachedStatuses.size()) {
       return cachedStatuses;
     }
 

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -2875,16 +2875,17 @@ public class ProcessSystem extends SimulationBaseClass {
    */
   private List<UnitRunStatus> getSuccessfulRunStatuses() {
     int nonNullUnitCount = 0;
-    boolean cacheMatches = cachedSuccessfulRunStatuses != null;
+    List<UnitRunStatus> cachedStatuses = cachedSuccessfulRunStatuses;
+    boolean cacheMatches = cachedStatuses != null;
     for (ProcessEquipmentInterface unit : unitOperations) {
       if (unit == null) {
         continue;
       }
       if (cacheMatches) {
-        if (nonNullUnitCount >= cachedSuccessfulRunStatuses.size()) {
+        if (nonNullUnitCount >= cachedStatuses.size()) {
           cacheMatches = false;
         } else {
-          UnitRunStatus cached = cachedSuccessfulRunStatuses.get(nonNullUnitCount);
+          UnitRunStatus cached = cachedStatuses.get(nonNullUnitCount);
           String unitType = unit.getClass().getSimpleName();
           if (!java.util.Objects.equals(cached.getUnitName(), unit.getName())
               || !java.util.Objects.equals(cached.getUnitType(), unitType)) {
@@ -2894,8 +2895,8 @@ public class ProcessSystem extends SimulationBaseClass {
       }
       nonNullUnitCount++;
     }
-    if (cacheMatches && nonNullUnitCount == cachedSuccessfulRunStatuses.size()) {
-      return cachedSuccessfulRunStatuses;
+    if (cacheMatches && nonNullUnitCount == cachedStatuses.size()) {
+      return cachedStatuses;
     }
 
     List<UnitRunStatus> rebuilt = new ArrayList<UnitRunStatus>(nonNullUnitCount);

--- a/src/main/java/neqsim/process/processmodel/RunStatus.java
+++ b/src/main/java/neqsim/process/processmodel/RunStatus.java
@@ -71,6 +71,23 @@ public class RunStatus implements Serializable {
   }
 
   /**
+   * Records a previously created immutable success status.
+   *
+   * <p>
+   * Package-private for {@link ProcessSystem}, which can safely reuse success records while its unit structure and
+   * names are unchanged. Failure records are never reused because their error text belongs to one particular run.
+   * </p>
+   *
+   * @param unitStatus immutable successful unit status
+   */
+  void recordSuccess(UnitRunStatus unitStatus) {
+    if (!unitStatus.isSuccess()) {
+      throw new IllegalArgumentException("Only successful unit statuses can be reused");
+    }
+    units.add(unitStatus);
+  }
+
+  /**
    * Records that a unit failed to run. The first recorded failure is reported as the run's failed unit.
    *
    * @param unitName the unit operation name

--- a/src/test/java/neqsim/process/processmodel/RunStatusTest.java
+++ b/src/test/java/neqsim/process/processmodel/RunStatusTest.java
@@ -3,7 +3,9 @@ package neqsim.process.processmodel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.UUID;
@@ -117,6 +119,55 @@ class RunStatusTest {
     assertFalse(status.isSuccess(), "a failed run must not report success");
     assertEquals("BrokenUnit", status.getFailedUnitName());
     assertNotNull(status.getFailedUnitError());
+  }
+
+  @Test
+  void testSuccessfulUnitStatusesAreReusedUntilMetadataChanges() {
+    ProcessSystem process = buildProcess(50000.0);
+    process.run();
+    UnitRunStatus firstFeedStatus = process.getRunStatus().getUnits().get(0);
+    UnitRunStatus firstSeparatorStatus = process.getRunStatus().getUnits().get(1);
+
+    process.run();
+    assertSame(firstFeedStatus, process.getRunStatus().getUnits().get(0));
+    assertSame(firstSeparatorStatus, process.getRunStatus().getUnits().get(1));
+
+    process.getUnit("HP Sep").setName("Renamed separator");
+    process.run();
+    assertNotSame(firstFeedStatus, process.getRunStatus().getUnits().get(0));
+    assertNotSame(firstSeparatorStatus, process.getRunStatus().getUnits().get(1));
+    assertEquals("Renamed separator", process.getRunStatus().getUnits().get(1).getUnitName());
+  }
+
+  @Test
+  void testSuccessfulUnitStatusCacheTracksStructureChangesAndCopy() {
+    ProcessSystem process = buildProcess(50000.0);
+    process.run();
+    UnitRunStatus originalFeedStatus = process.getRunStatus().getUnits().get(0);
+
+    process.removeUnit("Compressor");
+    process.run();
+    assertEquals(2, process.getRunStatus().getUnits().size());
+    assertNotSame(originalFeedStatus, process.getRunStatus().getUnits().get(0));
+
+    ProcessSystem copy = process.copy();
+    copy.run();
+    assertEquals(process.getRunStatusJson(), copy.getRunStatusJson());
+    assertNotSame(process.getRunStatus().getUnits().get(0), copy.getRunStatus().getUnits().get(0));
+  }
+
+  @Test
+  void testFailureAfterSuccessfulRunDoesNotReuseSuccessRecords() {
+    ProcessSystem process = buildProcess(50000.0);
+    process.run();
+    process.clear();
+    process.add(new FailingUnit("BrokenUnit"));
+
+    assertThrows(RuntimeException.class, process::run);
+
+    assertEquals(1, process.getRunStatus().getUnits().size());
+    assertFalse(process.getRunStatus().getUnits().get(0).isSuccess());
+    assertEquals("BrokenUnit", process.getRunStatus().getFailedUnitName());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Reuse immutable successful `UnitRunStatus` records across repeated `ProcessSystem.run()` calls while the unit structure, names, and types remain unchanged.

The current success path allocates one status object per unit on every run and also creates a temporary `HashSet`, even though a clean run has no failures. The cache is transient, is invalidated by structural mutations, validates mutable names/types before reuse, and never reuses failure records.

## Benchmark methodology

Baseline: `master` at `56745eeb3b7fd46853c971bf854894e4370bc3f5`.

Candidate and baseline were compiled with `--release 8` and run in alternating fresh OpenJDK 17 JVMs. Each result is the median of nine steady-state blocks after warm-up. Main-thread allocation was measured with `com.sun.management.ThreadMXBean`.

- 50-unit sequential repeated-run workload, 7 A/B pairs:
  - median allocation: 2,415.4 -> 1,137.7 bytes/run (**52.9% lower**)
  - 6/7 pairs faster; median paired wall-time gain **9.9%**
  - aggregate median: 7,273.9 -> 5,416.7 ns/run
- 500-unit sequential repeated-run workload, 7 A/B pairs:
  - median allocation: 16,728.7 -> 903.1 bytes/run (**94.6% lower**)
  - 5/7 pairs faster
  - aggregate median: 16,248.6 -> 13,323.1 ns/run (**18.0% lower**)
- `ProcessModel`, 10 areas x 100 no-op units, 7 A/B pairs:
  - aggregate median: 171,162 -> 157,252 ns/run
  - paired results were noisy in both directions, so no robust end-to-end speedup is claimed
- Nine-unit rich-gas SRK feed/heater process, alternating 298.15/303.15 K, 5 A/B pairs:
  - aggregate median: 6.947 -> 6.610 ms/run
  - median paired difference: 1.9%; within run-to-run noise, with no observed regression

This optimization targets repeated orchestration-heavy process and agent/digital-twin workloads. Small flash-dominated flowsheets should be effectively neutral.

## Correctness and robustness

- Status unit count, success flag, ordering, JSON, and JSON hashes were identical before/after.
- Rich-gas outlet state checksum was identical: `50385.227192307524`.
- Regression coverage verifies:
  - reuse across unchanged successful runs
  - cache rebuild after unit rename
  - invalidation after removal
  - transient-cache rebuild after `ProcessSystem.copy()`
  - no stale success records after a later failed run
- Public API and serialization format are unchanged.
- `UnitRunStatus` is immutable. The existing synchronized `ProcessSystem.run()` path is unchanged; cache metadata is transient, structure changes invalidate it, and every run validates mutable names and types before reuse.

## Validation

- `./mvnw -q -Dtest=RunStatusTest,ProcessSystemTest,ProcessModelExecutionOptimizationTest,ProcessSystemExecutionPreparationTest test`: **81/81 passed**
- Direct Java compilation with `--release 8`: passed
- `pre-commit run --all-files --hook-stage pre-commit`: passed
- `pre-commit run --all-files --hook-stage pre-push`: passed
- Spotless check: passed
- Documentation search audit: 646 Markdown pages and one standalone HTML page passed
- `git diff --check`: passed

## Documentation impact

Documentation impact: none — this only changes internal allocation behavior for successful run-status bookkeeping. Public APIs, JSON schema, simulation inputs/outputs, numerical behavior, defaults, and recommended usage are unchanged.

## Limitations

The wall-time benefit scales with unit count and the fraction of runtime spent in process orchestration. No speedup is claimed for thermodynamic-flash-dominated flowsheets.