### PR TITLE
build: use canonical Maven Central endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,13 @@
 	<repositories>
 		<repository>
 			<id>central</id>
-			<url>https://repo1.maven.org/maven2/</url>
+			<url>https://repo.maven.apache.org/maven2/</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>
 		<pluginRepository>
 			<id>central</id>
-			<url>https://repo1.maven.org/maven2/</url>
+			<url>https://repo.maven.apache.org/maven2/</url>
 		</pluginRepository>
 	</pluginRepositories>
 


### PR DESCRIPTION
## Summary

- replace the legacy `repo1.maven.org` URL in both dependency and plugin repository declarations
- use Maven Central's canonical `https://repo.maven.apache.org/maven2/` endpoint
- align the POM with the endpoint already used by `.mvn/wrapper/maven-wrapper.properties`

## Root cause

The POM overrode Maven Central for both artifacts and plugins with `repo1.maven.org`. In environments where that hostname fails DNS resolution, Maven cannot resolve the Spotless plugin even when the canonical Maven Central endpoint is reachable.

## Validation

- confirmed the Spotless 3.9.0 POM is available from the canonical endpoint
- `./mvnw spotless:check`: passed, 4,805 Java files clean
- `pre-commit run --all-files --hook-stage pre-commit`: passed
- `pre-commit run --all-files --hook-stage pre-push`: passed
- Documentation Search Coverage: passed (646 Markdown pages and one standalone HTML page)
- `pom.xml` XML parsing: passed
- `git diff --check`: passed
- final diff: one file, two URL substitutions

The local execution environment required a writable Maven home and an already provisioned canonical-central cache because Java processes cannot use its HTTP proxy directly. That environment-specific setup is separate from the repository correction; hosted CI remains authoritative for fresh online resolution.

## Compatibility

No dependency versions, plugin versions, build phases, Java sources, APIs, or runtime behavior change.

## Documentation impact

Documentation impact: none — this corrects an internal build repository endpoint. User-facing APIs, model behavior, inputs, outputs, units, defaults, and recommended NeqSim usage are unchanged.