### PR TITLE
fix: restore unchanged TPflash one-phase beta closure

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -260,6 +260,11 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │                                                                                 │
 │  IF chemical system:                                                            │
 │     → Final chemical equilibrium solve in aqueous/liquid phases                 │
+│                                                                                 │
+│  FINALIZE active phase fractions:                                               │
+│     → If multiphase checking returns the unchanged stable one-phase state,       │
+│       normalize its stale beta to one                                            │
+│     → That unchanged one-phase endpoint therefore returns beta = 1              │
 └─────────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -268,6 +273,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Parameter | Value | Description |
 |-----------|-------|-------------|
 | `phaseFractionMinimumLimit` | ~1e-12 | Minimum allowed phase fraction |
+| Unchanged one-phase closure | `abs(beta - 1) < 1e-12`; `abs(delta Z) <= 1e-11`; `max abs(delta x_i) <= 1e-11` | When multiphase checking finds no new stable phase and returns the same phase type, compressibility factor, and composition as the accepted one-phase reference, normalize a stale beta and reinitialize. Different roots, chemical-equilibrium states, and internal multiphase trial states retain their existing finalization paths. |
 | Trace duplicate phase cleanup | `min(beta_i, beta_j) < 10 beta_min`, same `PhaseType`, and `max abs(x_i - x_j) < 1e-6` | Merge and remove an already-disappeared numerical duplicate for any EOS while conserving phase fraction. Material-fraction duplicate cleanup remains limited to CPA models to protect near-critical cubic-EOS splits. |
 | Initial SSI iterations | 3 | Preliminary iterations before stability check |
 | `accelerateInterval` | 5 | Apply DEM every 5th iteration in the ordinary TPflash loop |

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -78,6 +78,8 @@ public class TPflash extends Flash {
   private static final double AQUEOUS_SEED_COMPOSITION_NORMALIZATION_TOLERANCE = 1.0e-8;
   /** Maximum accepted log-fugacity residual when selecting an alternate cubic root. */
   private static final double PHASE_ROOT_EQUILIBRIUM_TOLERANCE = 1.0e-8;
+  /** Maximum absolute Z or composition change for recognizing an unchanged stable one-phase state. */
+  private static final double UNCHANGED_SINGLE_PHASE_STATE_TOLERANCE = 1.0e-11;
   /** Maximum final SSI updates used to repair a stale neutral two-phase endpoint. */
   private static final int MAX_FINAL_EQUILIBRIUM_REFINEMENT_ITERATIONS = 8;
   /** Largest residual considered near enough to convergence for bounded final SSI refinement. */
@@ -796,6 +798,17 @@ public class TPflash extends Flash {
         isStable = false;
       }
       if (isStable) {
+        PhaseType stableSinglePhaseType = null;
+        double stableSinglePhaseZ = Double.NaN;
+        double[] stableSinglePhaseComposition = null;
+        if (system.doMultiPhaseCheck() && !system.isChemicalSystem() && system.getNumberOfPhases() == 1) {
+          stableSinglePhaseType = system.getPhase(0).getType();
+          stableSinglePhaseZ = system.getPhase(0).getZ();
+          stableSinglePhaseComposition = new double[system.getPhase(0).getNumberOfComponents()];
+          for (int componentIndex = 0; componentIndex < stableSinglePhaseComposition.length; componentIndex++) {
+            stableSinglePhaseComposition[componentIndex] = system.getPhase(0).getComponent(componentIndex).getx();
+          }
+        }
         if (system.doMultiPhaseCheck()) {
           // logger.info("one phase flash is stable - checking multiphase flash....");
           TPmultiflash operation = new TPmultiflash(system, system.doSolidPhaseCheck());
@@ -844,6 +857,8 @@ public class TPflash extends Flash {
         rescueWaterRichEndpoint();
         refineInvalidAqueousTwoPhaseEndpoint();
         refineInvalidNeutralGasLiquidTwoPhaseEndpoint();
+        normalizeUnchangedStableSinglePhaseEndpoint(stableSinglePhaseType, stableSinglePhaseZ,
+            stableSinglePhaseComposition);
         return;
       }
     }
@@ -1078,6 +1093,39 @@ public class TPflash extends Flash {
         logger.warn("Final chemical eq init failed: " + ex.getMessage());
       }
     }
+  }
+
+  /**
+   * Restores beta closure when a multiphase check returns the unchanged stable one-phase state.
+   *
+   * <p>
+   * {@link TPmultiflash} is also used for internal trial states, so normalizing every multiphase return can perturb
+   * continuation and chemical-equilibrium calculations. This narrowly handles the no-new-phase result: phase type,
+   * compressibility factor, and every phase composition must match the stable state captured before the multiphase
+   * check. Only its stale phase fraction is then normalized.
+   * </p>
+   *
+   * @param stablePhaseType phase type before the multiphase check
+   * @param stableZ compressibility factor before the multiphase check
+   * @param stableComposition phase composition before the multiphase check
+   */
+  private void normalizeUnchangedStableSinglePhaseEndpoint(PhaseType stablePhaseType, double stableZ,
+      double[] stableComposition) {
+    double currentZ = system.getNumberOfPhases() == 1 ? system.getPhase(0).getZ() : Double.NaN;
+    if (stablePhaseType == null || stableComposition == null || system.getNumberOfPhases() != 1
+        || system.getPhase(0).getType() != stablePhaseType || !Double.isFinite(stableZ) || !Double.isFinite(currentZ)
+        || Math.abs(currentZ - stableZ) > UNCHANGED_SINGLE_PHASE_STATE_TOLERANCE
+        || system.getPhase(0).getNumberOfComponents() != stableComposition.length) {
+      return;
+    }
+    for (int componentIndex = 0; componentIndex < stableComposition.length; componentIndex++) {
+      double currentComposition = system.getPhase(0).getComponent(componentIndex).getx();
+      if (!Double.isFinite(stableComposition[componentIndex]) || !Double.isFinite(currentComposition) || Math
+          .abs(currentComposition - stableComposition[componentIndex]) > UNCHANGED_SINGLE_PHASE_STATE_TOLERANCE) {
+        return;
+      }
+    }
+    normalizeActivePhaseFractions();
   }
 
   /**
@@ -2551,8 +2599,8 @@ public class TPflash extends Flash {
    *
    * <p>
    * Late phase-removal and rescue paths can leave the active beta values slightly below or above unity even when the
-   * remaining phase compositions are valid. Normalizing at the final acceptance point restores phase-fraction closure
-   * and reinitializes level 1 properties for the adjusted phase amounts.
+   * remaining phase compositions are valid. Calling this helper at a validated acceptance point restores phase-fraction
+   * closure and reinitializes level 1 properties for the adjusted phase amounts.
    * </p>
    */
   private void normalizeActivePhaseFractions() {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPFlashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPFlashTest.java
@@ -123,8 +123,8 @@ class TPFlashTest {
     testSystem5.initProperties();
     // testSystem5.prettyPrint();
     double beta = testSystem5.getBeta();
-    // Updated expected value due to thermodynamic model changes
-    assertEquals(0.10377442547868508, beta, 1e-4);
+    assertEquals(1, testSystem5.getNumberOfPhases());
+    assertEquals(1.0, beta, 1.0e-12);
   }
 
   @Test

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashIncipientPhaseStabilityTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashIncipientPhaseStabilityTest.java
@@ -9,6 +9,8 @@ import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 class TPflashIncipientPhaseStabilityTest {
+  private static final double CROSS_ALGORITHM_COMPOSITION_TOLERANCE = 1.0e-11;
+  private static final double CROSS_ALGORITHM_PROPERTY_TOLERANCE = 1.0e-11;
   private static final String[] COMPONENTS = { "methane", "ethane", "propane", "n-butane" };
   private static final double[] FEED = { 0.5833884211682981, 0.16475359157041228, 0.19866217294783825,
       0.053195814313451245 };
@@ -43,21 +45,32 @@ class TPflashIncipientPhaseStabilityTest {
 
   @Test
   void subResidualTpdDoesNotOverrideExistingUmrPruSolution() {
-    SystemInterface system = new neqsim.thermo.system.SystemUMRPRUMCEos(243.15, 300.0);
-    system.addComponent("methane", 0.416683);
-    system.addComponent("ethane", 0.17522);
-    system.addComponent("n-pentane", 0.358009);
-    system.addComponent("nC16", 0.0500888);
-    system.setMixingRule("classic");
-    system.setMultiPhaseCheck(true);
-    system.setPressure(90.03461693, "bara");
-    system.setTemperature(293.15, "K");
-    system.setTotalFlowRate(4.925e-07, "kg/sec");
+    SystemInterface multiphase = new neqsim.thermo.system.SystemUMRPRUMCEos(243.15, 300.0);
+    multiphase.addComponent("methane", 0.416683);
+    multiphase.addComponent("ethane", 0.17522);
+    multiphase.addComponent("n-pentane", 0.358009);
+    multiphase.addComponent("nC16", 0.0500888);
+    multiphase.setMixingRule("classic");
+    multiphase.setPressure(90.03461693, "bara");
+    multiphase.setTemperature(293.15, "K");
+    multiphase.setTotalFlowRate(4.925e-07, "kg/sec");
 
-    new ThermodynamicOperations(system).TPflash();
+    SystemInterface ordinary = multiphase.clone();
+    ordinary.setMultiPhaseCheck(false);
+    multiphase.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(ordinary).TPflash();
+    new ThermodynamicOperations(multiphase).TPflash();
 
-    assertEquals(1, system.getNumberOfPhases());
-    assertEquals(0.10377442547868508, system.getBeta(), 1.0e-4);
+    assertEquals(1, ordinary.getNumberOfPhases());
+    assertEquals(1, multiphase.getNumberOfPhases());
+    assertEquals(1.0, ordinary.getBeta(), 1.0e-12);
+    assertEquals(ordinary.getBeta(), multiphase.getBeta(), 1.0e-12);
+    assertEquals(ordinary.getPhase(0).getType(), multiphase.getPhase(0).getType());
+    assertEquals(ordinary.getPhase(0).getZ(), multiphase.getPhase(0).getZ(), CROSS_ALGORITHM_PROPERTY_TOLERANCE);
+    for (int componentIndex = 0; componentIndex < multiphase.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      assertEquals(ordinary.getPhase(0).getComponent(componentIndex).getx(),
+          multiphase.getPhase(0).getComponent(componentIndex).getx(), CROSS_ALGORITHM_COMPOSITION_TOLERANCE);
+    }
   }
 
   private SystemInterface createSystem(boolean multiphaseCheck) {


### PR DESCRIPTION
## Summary

- restore `beta = 1` only when multiphase checking returns the same stable one-phase state accepted before the check
- require the phase type, compressibility factor, and every phase composition to match before normalization
- leave chemical-equilibrium states, different cubic roots, and internal `TPmultiflash` trial/continuation states unchanged
- strengthen deterministic ordinary/multiphase consistency coverage and document the acceptance tolerances

Closes #2889.

## Reproduced problem

Against `master` `01879d605f0ceecd9efb211a2ea0f76fa3269f40`, the deterministic UMR-PRU case in `TPFlashTest.testRun5` ends with one active OIL phase but multiphase `beta = 0.103774415939611`. Ordinary TPflash returns the same phase type, composition, and compressibility factor with `beta = 1.0`.

This violates the one-phase material-balance definition and ordinary/multiphase consistency.

## Root cause and bounded fix

The one-phase stability path invokes `TPmultiflash` to search for missed phases. In this case the search collapses back to the original stable OIL phase but retains a stale phase fraction from the discarded trial topology.

The first PR revision normalized every final `TPmultiflash.run()` return. Fresh A/B diagnosis showed that this was too broad because `TPmultiflash` is also an internal trial and continuation solver:

- candidate: `SystemKentEisenbergTest` failed with invalid H2S loading and the Norwegian field-lifecycle operating-limit test returned no annual results
- the same two tests passed on current master
- removing the multiphase-return hook and guarding chemical finalization restored those suites
- a generic top-level normalization still changed the lifecycle result

The final fix captures the already accepted stable one-phase phase type, Z, and composition before multiphase checking. It normalizes only if the returned endpoint is still one phase and matches that reference within `1e-11`; otherwise it is a no-op. This closes the reproduced defect without mutating internal trials, chemical states, or a different root.

## Method and literature basis

The constraint `sum_k beta_k = 1` is part of the multiphase material-balance formulation; see Michelsen, *The isothermal flash problem. Part II. Phase-split calculation*, Fluid Phase Equilibria 9 (1982), 21–40, https://doi.org/10.1016/0378-3812(82)85002-4. For multiphase Rachford-Rice solution-domain handling, see Okuno, Johns and Sepehrnoori, SPE Journal 15 (2010), 313–325, https://doi.org/10.2118/117752-PA.

Those are public primary-literature bases. The repository behavior and A/B tests are implementation evidence. The conclusion that broad normalization perturbs internal continuation states is an inference from the call graph plus the controlled regressions. No proprietary Aspen HYSYS, UniSim, Multiflash, or PVTsim implementation is claimed or inferred.

## Before/after evidence

| Measure | Master | Candidate |
|---|---:|---:|
| UMR-PRU active phases/type | 1 / OIL | 1 / OIL |
| Multiphase beta | 0.103774415939611 | 1.0 |
| Ordinary/multiphase beta residual | 0.896225584060389 | 0.0 within `1e-12` |
| Deterministic matrix invariant failures | 1 / 20 paths | 0 / 20 paths |
| Phase composition and Z | ordinary reference | unchanged within `1e-11` |

The reproducible 10-family/20-path matrix covered dry gas, heavy oil, water-rich CPA, gas-oil-water, CO2-rich, hydrogen-rich, incipient/near-boundary vapor, phase disappearance, PC-SAFT wide-volatility contrast, and UMR-PRU; SRK, PR, CPA, PC-SAFT, and UMR-PRU with relevant classic mixing rules; one-, two-, and three-phase endpoints; repeat runs, T/P round trips, composition changes, adversarial K values (`1e-12`/`1e12`), and near-bound beta guesses. It checked beta/composition bounds, normalization, component balance, finite positive Z, determinism, and applicable cross-path consistency.

Exact-final-tree UMR-PRU microbenchmark: eight fresh JVM forks, each with 8 warmups and 25 measured full system constructions plus multiphase TP flashes:

- master median: 48.94 ms/flash (44.68–69.65 ms)
- candidate median: 47.04 ms/flash (44.43–625.48 ms)
- two candidate forks and one master fork were scheduling/noise outliers; medians show no systematic slowdown, but no speedup is claimed
- every master fork returned the defective beta; every candidate fork returned exactly 1.0
- the normal path adds one O(N-components) snapshot and comparison only after an accepted stable one-phase state with multiphase checking enabled; it adds no flash iteration

## Numerical tolerances

- final unchanged one-phase beta: `1e-12`
- unchanged reference Z and each phase mole fraction: `1e-11` absolute
- stress-matrix cross-path comparisons: `1e-8` relative
- measured ordinary/multiphase Z difference in the focused UMR-PRU regression: below `1e-11`

The state-match tolerance is an acceptance guard, not a relaxation of the beta defect.

## Validation

Completed on exact candidate head `5c397cae3cad09c6bf8ccc1eda35c759a3fbb635`:

- `TPFlashTest, TPFlashTestWellFluid, TPFlashTestHighTemp, TPflash*Test, TPmultiflash*Test`: 68/68 passed
- focused UMR regressions plus `SystemKentEisenbergTest` and `NorwegianOilFieldLifecycleTest.facilityOperatingLimitEndsLifecycleGracefully`: 12/12 passed
- `python devtools/run_spotless.py apply`: passed twice with no second-pass changes
- `python devtools/run_spotless.py check`: passed
- `python devtools/check_documentation_search.py`: passed for 646 Markdown pages and one standalone HTML page
- `pre-commit run --all-files --hook-stage pre-commit`: passed
- `pre-commit run --all-files --hook-stage pre-push`: passed
- `git diff --check`: passed
- final diff: one commit, four intended files, no notebook or generated-file changes

The full repository test suite was not run locally. Hosted CI is required before merge readiness.

## Compatibility and risk

Low and localized, with explicit protection against the regressions found in the first revision. No public API, EOS equation, mixing rule, stability criterion, fugacity iteration, phase selection, or different-root state changes. The only intended numerical change is the stale beta of a multiphase check that returned the unchanged stable one-phase equilibrium.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md` and the helper Javadocs because this is user-visible numerical behavior. The guide documents beta closure, the `1e-11` unchanged-state guard, and the excluded chemical/internal-trial paths.