### PR TITLE
fix(distillation): report Jacobian work accurately

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,13 @@
 
 ---
 
+## 2026-08-09 — Correct Naphtali-Sandholm Jacobian work classification
+
+- Naphtali-Sandholm diagnostics now count each numerically perturbed Jacobian column only as
+  finite-difference work; the analytic-column counter reports zero for the current implementation.
+- Both public telemetry getters remain available. Solver equations, Jacobian values, convergence,
+  and fallback behavior are unchanged.
+
 ## 2026-08-07 — Flow-accelerated corrosion + in-situ pH at temperature (new classes) + DEA protonation enabled
 
 **New in `neqsim.process.corrosion`** — for closed heating- and cooling-medium loops,

--- a/docs/development/TASK_LOG.md
+++ b/docs/development/TASK_LOG.md
@@ -36,6 +36,12 @@ requirement`, or `confidential compressor route`.
 
 <!-- Add new entries at the top. Most recent first. -->
 
+### 2026-08-09 — Correct Naphtali-Sandholm Jacobian work telemetry
+**Type:** E (Feature)
+**Keywords:** distillation, Naphtali-Sandholm, MESH, Jacobian, finite difference, diagnostics, telemetry, solver benchmark
+**Solution:** `NaphtaliSandholmSolver.computeJacobian`, `DistillationColumn` convergence diagnostics, and `ColumnSpecificationTest.naphtaliSandholmTelemetryRecordsJacobianWork`
+**Notes:** The block-tridiagonal Jacobian numerically perturbs every variable, but each column was counted as both analytic and finite-difference work. The analytic counter now remains zero while the finite-difference counter retains the complete work count. Base and nearby operating points preserved iterations, thermodynamic evaluations, residuals, energy, mass, products, and deterministic behavior exactly.
+
 ### 2026-07-16 — Historical FeS wall inventory to elemental-sulfur compressor deposition
 **Type:** E (Feature) / B (Process)
 **Keywords:** iron sulfide, FeS, mackinawite, pyrrhotite, siderite, FeCO3, carbon steel, seawater, oxygen ingress, nitrogen purge, elemental sulfur, S8, wall inventory, compressor deposit, entrained condensate, warm shaft

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -256,6 +256,9 @@ targets manipulated through condenser or reboiler temperature.
   temperature, and vapor flow as tray variables.
 - Builds a finite-difference block-tridiagonal Jacobian from neighboring tray couplings and uses a
   guarded Newton line search with flow and temperature trust limits.
+- Work diagnostics classify every currently assembled derivative column as finite-difference;
+  `getLastNaphtaliAnalyticJacobianColumns()` remains available for compatibility and reports zero
+  until a mixed analytic/numerical assembly is implemented.
 - Allows at most three line-search steps that fail to reduce the MESH residual. After three such
   non-descent steps, the solver restores the best finite tray state and returns the actual iteration
   count so the column can proceed to its coordinated fallback instead of exhausting the Newton

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -783,7 +783,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   private transient double lastMatrixInsideOutTemperatureResidual = Double.NaN;
   /** Matrix warm-start wall time from the latest solve in seconds. */
   private transient double lastMatrixInsideOutSolveTimeSeconds = 0.0;
-  /** Latest Naphtali-Sandholm semi-analytic Jacobian column count. */
+  /** Latest Naphtali-Sandholm analytically differentiated Jacobian column count. */
   private transient int lastNaphtaliAnalyticJacobianColumns = 0;
   /** Latest Naphtali-Sandholm finite-difference Jacobian column count. */
   private transient int lastNaphtaliFiniteDifferenceJacobianColumns = 0;
@@ -9247,9 +9247,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
-   * Retrieve latest Naphtali-Sandholm semi-analytic Jacobian columns.
+   * Retrieve latest Naphtali-Sandholm analytically differentiated Jacobian columns.
    *
-   * @return semi-analytic Jacobian column count
+   * <p>
+   * This is zero for the current finite-difference implementation. The getter is retained for compatibility and for a
+   * future mixed analytic/numerical Jacobian.
+   * </p>
+   *
+   * @return analytically differentiated Jacobian column count
    */
   public int getLastNaphtaliAnalyticJacobianColumns() {
     return lastNaphtaliAnalyticJacobianColumns;
@@ -9555,7 +9560,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     if (lastNaphtaliAnalyticJacobianColumns > 0 || lastNaphtaliFiniteDifferenceJacobianColumns > 0
         || lastNaphtaliThermoEvaluationCount > 0) {
       diagnostics.append("  Naphtali-Sandholm Jacobian:\n");
-      diagnostics.append("    semi-analytic columns: ").append(lastNaphtaliAnalyticJacobianColumns).append("\n");
+      diagnostics.append("    analytic columns: ").append(lastNaphtaliAnalyticJacobianColumns).append("\n");
       diagnostics.append("    finite-difference columns: ").append(lastNaphtaliFiniteDifferenceJacobianColumns)
           .append("\n");
       diagnostics.append("    thermodynamic evaluations: ").append(lastNaphtaliThermoEvaluationCount).append("\n");

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -232,7 +232,7 @@ public class NaphtaliSandholmSolver {
   /** Solve time in seconds from the last solve. */
   private double lastSolveTimeSeconds;
 
-  /** Number of semi-analytic Jacobian columns assembled in the last solve. */
+  /** Number of analytically differentiated Jacobian columns assembled in the last solve. */
   private int lastAnalyticJacobianColumns;
 
   /** Number of finite-difference Jacobian columns assembled in the last solve. */
@@ -323,9 +323,14 @@ public class NaphtaliSandholmSolver {
   }
 
   /**
-   * Get the number of semi-analytic Jacobian columns used by the latest solve.
+   * Get the number of analytically differentiated Jacobian columns used by the latest solve.
    *
-   * @return number of semi-analytic Jacobian columns
+   * <p>
+   * The current block-tridiagonal implementation evaluates every derivative column by finite difference, so this
+   * counter is zero. The getter is retained for compatibility and for a future mixed analytic/numerical assembly.
+   * </p>
+   *
+   * @return number of analytically differentiated Jacobian columns
    */
   int getLastAnalyticJacobianColumns() {
     return lastAnalyticJacobianColumns;
@@ -3130,7 +3135,6 @@ public class NaphtaliSandholmSolver {
       }
     }
 
-    lastAnalyticJacobianColumns += totalVars;
     lastFiniteDifferenceJacobianColumns += totalVars;
     lastJacobianBuildTimeSeconds += (System.nanoTime() - jacobianStart) / 1.0e9;
     return J;

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
@@ -511,7 +511,7 @@ public class ColumnSpecificationTest {
   }
 
   /**
-   * Test that Naphtali-Sandholm exposes semi-analytic Jacobian speed telemetry.
+   * Test that Naphtali-Sandholm classifies its numerical Jacobian work accurately.
    */
   @Test
   public void naphtaliSandholmTelemetryRecordsJacobianWork() {
@@ -523,8 +523,10 @@ public class ColumnSpecificationTest {
     column.run();
 
     assertTrue(column.getGasOutStream().getFlowRate("kg/hr") >= 0.0);
-    assertTrue(column.getLastNaphtaliAnalyticJacobianColumns() > 0);
-    assertTrue(column.getLastNaphtaliFiniteDifferenceJacobianColumns() >= 0);
+    assertEquals(0, column.getLastNaphtaliAnalyticJacobianColumns(),
+        "the current implementation does not analytically differentiate any Jacobian column");
+    assertEquals(800, column.getLastNaphtaliFiniteDifferenceJacobianColumns(),
+        "eight stages times five variables times twenty Jacobian builds must all be finite-difference columns");
     assertTrue(column.getLastNaphtaliThermoEvaluationCount() > 0);
     assertTrue(column.getLastNaphtaliThermoCacheHitCount() >= 0);
     assertTrue(column.getLastNaphtaliJacobianBuildTimeSeconds() >= 0.0);
@@ -532,6 +534,8 @@ public class ColumnSpecificationTest {
     assertTrue(column.getLastNaphtaliDenseLinearSolveCount() >= 0);
     assertTrue(column.getLastNaphtaliLinearSolveTimeSeconds() >= 0.0);
     assertTrue(column.getConvergenceDiagnostics().contains("Naphtali-Sandholm Jacobian"));
+    assertTrue(column.getConvergenceDiagnostics().contains("analytic columns: 0"));
+    assertTrue(column.getConvergenceDiagnostics().contains("finite-difference columns: 800"));
     assertTrue(column.getConvergenceDiagnostics().contains("thermodynamic cache hits"));
     assertTrue(column.getConvergenceDiagnostics().contains("block linear solves"));
   }


### PR DESCRIPTION
## Summary

- correct Naphtali-Sandholm Jacobian telemetry so every currently numerical derivative column is counted only as finite-difference work
- keep the public analytic-column getter for compatibility, returning zero until a mixed analytic/numerical assembly exists
- update convergence diagnostics, Javadocs, the distillation guide, task memory, and agent changelog
- strengthen the existing realistic three-component column regression with exact work-count assertions

Related investigation: #2887.

## Problem and root cause

`NaphtaliSandholmSolver.computeJacobian(...)` perturbs every tray variable and forms every derivative column as

```text
(F(x + h e_k) - F(x)) / h
```

The Jacobian is stored and solved with block-tridiagonal structure, but that sparsity structure does not make a derivative analytic. After each build, the implementation nevertheless incremented both `lastAnalyticJacobianColumns` and `lastFiniteDifferenceJacobianColumns` by `totalVars`.

Optimization and benchmark consumers therefore observed twice the actual Jacobian-column work and could incorrectly infer that a semi-analytic assembly was active.

## Reproduction on master

Baseline commit: `56745eeb3b7fd46853c971bf854894e4370bc3f5`.

SRK/classic case:

- propane / n-butane / n-pentane = 0.35 / 0.45 / 0.20
- 250 kg/h at 318.15 K and 10 bara
- six equilibrium stages plus reboiler and condenser
- 10.0–10.2 bara
- condenser 303.15 K, reboiler 363.15 K, reflux ratio 1.8
- explicit `NAPHTALI_SANDHOLM`, 20 Newton iterations

Before:

```text
analytic columns = 800
finite-difference columns = 800
```

Code inspection and the exact 800 finite-difference perturbations prove that the analytic count should be zero.

## Before/after evidence

| Case | Metric | Master | Candidate |
|---|---|---:|---:|
| base | analytic / finite-difference columns | 800 / 800 | 0 / 800 |
| base | iterations / thermo evaluations / block solves | 20 / 16,240 / 20 | unchanged |
| base | residual / energy residual | 0.136216657071 / 0.0326344015323 | unchanged |
| +2 K | analytic / finite-difference columns | 800 / 800 | 0 / 800 |
| +2 K | iterations / thermo evaluations / block solves | 20 / 16,216 / 20 | unchanged |
| +2 K | residual / energy residual | 0.162437113551 / 0.0413399159883 | unchanged |

Both operating points were repeated twice and were bit-for-bit deterministic. Total mass closed exactly in the direct probe; product flows, solver acceptance/fallback path, Jacobian values, thermodynamic trajectory, and all other telemetry were unchanged.

No speed claim is made. The implementation removes only one integer counter addition per Jacobian build.

## Validation

- focused telemetry regression: 1/1 passed
- `ColumnSpecificationTest,ColumnStudyRegressionTest,DistillationSolverBenchmarkTest,DistillationColumnConvergenceGateTest`: 77 tests passed, 1 skipped
- complete `neqsim.process.equipment.distillation.*Test` package: 159 tests passed, 1 skipped
- modified production classes compiled with `--release 8`
- `./mvnw spotless:apply`: passed; 4,802 Java files clean, zero changed
- `./mvnw spotless:check`: passed
- `pre-commit run --all-files --hook-stage pre-commit`: passed
- `pre-commit run --all-files --hook-stage pre-push`: passed
- documentation search: 646 Markdown pages and one standalone HTML page passed
- final remote diff: one commit, six intended files, no sensitive or unrelated changes

The local gate used the canonical Maven Central endpoint and provisioned offline cache while master still contains the legacy `repo1` URL. The endpoint correction is isolated in draft PR #2897 and is not included here.

## Compatibility and risk

Low and diagnostic-only:

- public getters remain source/binary compatible
- transient telemetry fields and serialization behavior are unchanged
- no MESH equation, Jacobian entry, perturbation, scaling, damping, line search, tolerance, thermodynamic evaluation, initialization, solver selection, or fallback behavior changes
- consumers that treated the inaccurate positive analytic count as real work will now receive the truthful zero

## Documentation impact

Updated:

- adjacent solver and public getter Javadocs
- human-readable convergence diagnostic label (`semi-analytic columns` → `analytic columns`)
- `docs/wiki/distillation_column.md`
- `docs/development/TASK_LOG.md`
- `CHANGELOG_AGENT_NOTES.md`

## Remaining limitation and next step

The solver still performs a fully finite-difference Jacobian and its tray fugacity iteration remains stateful with two fixed sweeps. A future performance change should first make tray thermodynamic evaluation converge to an explicit tolerance with an iteration cap and telemetry; only then should analytical columns or EOS-restore coalescing be introduced and counted here.