### PR TITLE
[AI-Assisted] Preserve parallel process graph connections

### DIFF
--- a/docs/simulation/graph_based_process_simulation.md
+++ b/docs/simulation/graph_based_process_simulation.md
@@ -180,6 +180,10 @@ The `ProcessGraphBuilder` automatically detects stream connections for the follo
 | **Turbomachinery** | TurboExpanderCompressor | Expander + compressor outlets |
 | **Columns** | DistillationColumn | Condenser + reboiler outlets |
 
+Connections are identified by stream-object identity. If two distinct material streams connect the
+same source and target equipment, both edges are retained. Repeated discovery of the same stream
+through equipment-specific and generic inlet APIs is represented by one edge.
+
 ---
 
 ## Basic Usage

--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -1072,16 +1072,19 @@ public final class ProcessGraphBuilder {
       ProcessNode sourceNode = graph.getNode(producer);
       ProcessNode targetNode = graph.getNode(consumer);
       if (sourceNode != null && targetNode != null) {
-        // Avoid duplicate edges
+        StreamInterface streamIface = stream instanceof StreamInterface ? (StreamInterface) stream : null;
+
+        // The same stream may be discovered through both equipment-specific and
+        // uniform inlet APIs. Deduplicate that discovery by stream identity, but
+        // preserve distinct parallel streams between the same equipment pair.
         boolean edgeExists = false;
         for (ProcessEdge edge : sourceNode.getOutgoingEdges()) {
-          if (edge.getTarget() == targetNode) {
+          if (edge.getTarget() == targetNode && edge.getStream() == streamIface) {
             edgeExists = true;
             break;
           }
         }
         if (!edgeExists) {
-          StreamInterface streamIface = stream instanceof StreamInterface ? (StreamInterface) stream : null;
           graph.addEdge(sourceNode, targetNode, streamIface);
         }
       }

--- a/src/test/java/neqsim/process/processmodel/graph/ProcessGraphParallelConnectionsTest.java
+++ b/src/test/java/neqsim/process/processmodel/graph/ProcessGraphParallelConnectionsTest.java
@@ -1,0 +1,91 @@
+package neqsim.process.processmodel.graph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.splitter.Splitter;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+import org.junit.jupiter.api.Test;
+
+/** Tests preservation of distinct parallel connections in the process graph. */
+class ProcessGraphParallelConnectionsTest {
+
+  @Test
+  void preservesParallelMaterialStreamsBetweenTheSameEquipmentPair() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-heptane", 0.2);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    feed.run();
+
+    Splitter splitter = new Splitter("parallel splitter", feed);
+    splitter.setSplitFactors(new double[] { 0.4, 0.6 });
+    splitter.run();
+
+    StreamInterface firstBranch = splitter.getSplitStream(0);
+    StreamInterface secondBranch = splitter.getSplitStream(1);
+    Mixer mixer = new Mixer("parallel mixer");
+    mixer.addStream(firstBranch);
+    mixer.addStream(secondBranch);
+
+    ProcessSystem process = new ProcessSystem("parallel material connections");
+    process.add(feed);
+    process.add(splitter);
+    process.add(mixer);
+
+    ProcessGraph graph = process.buildGraph();
+    ProcessNode splitterNode = graph.getNode(splitter);
+    ProcessNode mixerNode = graph.getNode(mixer);
+    List<ProcessEdge> parallelEdges = new ArrayList<ProcessEdge>();
+    for (ProcessEdge edge : splitterNode.getOutgoingEdges()) {
+      if (edge.getTarget() == mixerNode) {
+        parallelEdges.add(edge);
+      }
+    }
+
+    assertEquals(2, parallelEdges.size());
+    Set<StreamInterface> connectedStreams = Collections.newSetFromMap(new IdentityHashMap<StreamInterface, Boolean>());
+    for (ProcessEdge edge : parallelEdges) {
+      connectedStreams.add(edge.getStream());
+    }
+    assertTrue(connectedStreams.contains(firstBranch));
+    assertTrue(connectedStreams.contains(secondBranch));
+  }
+
+  @Test
+  void deduplicatesRepeatedDiscoveryOfTheSameMaterialStream() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("feed", fluid);
+    Heater heater = new Heater("heater", feed);
+    ProcessSystem process = new ProcessSystem("duplicate discovery");
+    process.add(feed);
+    process.add(heater);
+
+    ProcessGraph graph = process.buildGraph();
+    ProcessNode feedNode = graph.getNode(feed);
+    ProcessNode heaterNode = graph.getNode(heater);
+    int connectionCount = 0;
+    for (ProcessEdge edge : feedNode.getOutgoingEdges()) {
+      if (edge.getTarget() == heaterNode) {
+        connectionCount++;
+      }
+    }
+
+    assertEquals(1, connectionCount);
+  }
+}


### PR DESCRIPTION
## Summary

Preserve distinct parallel material-stream connections in `ProcessGraphBuilder` while still deduplicating repeated discovery of the same stream object.

This is the first implementation increment (`PFD-C001`) in the professional ISO 10628 PFD campaign tracked by #1332. Faithful graph topology is a prerequisite for DOT, future ISO-oriented renderers, and DEXPI export: two physical streams connecting the same equipment pair must not collapse into one diagram edge.

## Root cause

`createEdgeFromProducer` treated any existing edge with the same source and target as a duplicate. That incorrectly collapsed distinct stream objects routed in parallel between the same equipment.

## Changes

- Deduplicate graph connections by target **and stream-object identity**.
- Preserve separate edges for distinct parallel material streams.
- Add regression tests for both parallel-stream preservation and same-stream rediscovery.
- Document the process-graph connection identity rule.

## Validation

- `./mvnw -Dtest=ProcessGraphParallelConnectionsTest test` — 2 tests passed
- `./mvnw -Dtest=ProcessGraphTest,ProcessGraphParallelConnectionsTest,GraphVsSequentialExecutionTest test` — 67 tests passed
- `python devtools/run_spotless.py apply` — clean on second pass
- `pre-commit run --all-files --hook-stage pre-commit` — passed
- `python devtools/run_spotless.py check` — passed
- `python devtools/check_documentation_search.py` — passed
- `pre-commit run --all-files --hook-stage pre-push` — passed
- `git diff --check` — passed

## Hosted CI

At commit `abe570ba64c95fd7ac389720b1bfa27fa2d3f80b`, all six pull-request workflows completed successfully on 9 August 2026:

- Run build, test and Javadoc
- Pre-commit checks
- Spotless format patch
- Documentation search coverage
- CodeQL Security Analysis
- PaperLab Replication Gate

GitHub reports the draft PR as mergeable. The current `master` commit `4cb8d182b0a5cca1c667f18a459f356148112f72` changes separate `ProcessModel` capacity-reporting files and does not overlap this PR's three files.

## Scope and compatibility

No public API or persisted model format changes. This PR only corrects graph topology and adds supporting tests/documentation.

Canonical diagram IR, ISO 10628 symbols, deterministic layout, sheet partitioning/off-page connectors, and P&ID-level detail remain separate campaign increments.

Relates to #1332. Coordinates with the DEXPI/P&ID campaign in #2899.

> AI-assisted contribution: implementation, tests, documentation, and local validation were prepared with Codex; maintainer review is requested before merge.