### PR TITLE
perf: skip redundant nested active-state scan

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -3377,11 +3377,14 @@ public class ProcessSystem extends SimulationBaseClass {
     // unchanged feed, the unit would be skipped by needRecalculation() and would not get a
     // chance to re-bypass itself, so we must leave its sticky bypass state alone.
     boolean outermost = getRunDepth().get().intValue() <= 1;
+    if (!outermost) {
+      return;
+    }
     for (ProcessEquipmentInterface unit : unitOperations) {
       if (unit.isLockedInactive()) {
         // Manually locked-off equipment must stay inactive across runs.
         unit.isActive(false);
-      } else if (outermost && needsRecalculation(unit)) {
+      } else if (needsRecalculation(unit)) {
         // Fresh user-invoked solve AND inputs have changed: give the unit a chance to
         // re-evaluate its low-flow status. Its run() will be invoked and any auto-bypass
         // unit (Splitter/Separator/Heater/Compressor) will re-check flow via

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemExecutionPreparationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemExecutionPreparationTest.java
@@ -3,7 +3,9 @@ package neqsim.process.processmodel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
@@ -13,6 +15,54 @@ import neqsim.thermo.system.SystemSrkEos;
  * Verifies that public process dispatchers prepare a flowsheet once before concrete execution.
  */
 class ProcessSystemExecutionPreparationTest {
+  /** Stable unit that counts active-state inspection calls. */
+  private static final class CountingActiveStateUnit extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private int lockedInactiveChecks;
+
+    /**
+     * Creates a stable counting unit.
+     *
+     * @param name unit name
+     */
+    CountingActiveStateUnit(String name) {
+      super(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isLockedInactive() {
+      lockedInactiveChecks++;
+      return super.isLockedInactive();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean needRecalculation() {
+      return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+
+    /** Resets the inspection count. */
+    void resetLockedInactiveChecks() {
+      lockedInactiveChecks = 0;
+    }
+
+    /**
+     * Returns the active-state inspection count.
+     *
+     * @return number of calls to {@link #isLockedInactive()}
+     */
+    int getLockedInactiveChecks() {
+      return lockedInactiveChecks;
+    }
+  }
+
   /**
    * Stream that records how often a flowsheet-wide property setting is applied.
    */
@@ -104,6 +154,35 @@ class ProcessSystemExecutionPreparationTest {
   @Test
   void sequentialDispatcherPreparesFlowsheetOnce() {
     assertSinglePreparation(false);
+  }
+
+  /** Verifies nested optimized dispatch does not repeat the outer active-state scan. */
+  @Test
+  void optimizedDispatcherChecksActiveStateOnce() {
+    CountingActiveStateUnit unit = new CountingActiveStateUnit("stable unit");
+    ProcessSystem process = new ProcessSystem("active-state preparation");
+    process.add(unit);
+
+    unit.resetLockedInactiveChecks();
+    process.run();
+
+    assertEquals(1, unit.getLockedInactiveChecks(),
+        "run() must not repeat the active-state scan in its nested concrete dispatcher");
+    assertTrue(process.getRunStatus().isSuccess());
+  }
+
+  /** Verifies a direct optimized-dispatch call retains its required active-state scan. */
+  @Test
+  void directOptimizedDispatcherChecksActiveStateOnce() {
+    CountingActiveStateUnit unit = new CountingActiveStateUnit("stable unit");
+    ProcessSystem process = new ProcessSystem("direct active-state preparation");
+    process.add(unit);
+
+    unit.resetLockedInactiveChecks();
+    process.runOptimized(UUID.randomUUID());
+
+    assertEquals(1, unit.getLockedInactiveChecks(),
+        "a direct runOptimized() call must still prepare active state before dispatch");
   }
 
   /**


### PR DESCRIPTION
## Summary

Skip the redundant full-unit active-state scan performed by the concrete optimized dispatcher when it is nested inside `ProcessSystem.run(UUID) -> runOptimized(UUID)`.

The outer `run(UUID)` scope has already completed that scan before strategy selection. Nested concrete dispatch therefore returns immediately from `resetActiveStates()`; direct calls to `runOptimized`, `runParallel`, `runDataflow`, `runHybrid`, and `runSequential` retain their existing preparation. Low-flow reactivation and manually locked equipment semantics are unchanged.

This is a bounded follow-up to #2687. It does not overlap the distillation-only current-master change in #2900 or the successful-status allocation optimization in #2896.

## Reproducible benchmark

Current base: `01879d605f0ceecd9efb211a2ea0f76fa3269f40`. That commit changed only Naphtali-Sandholm telemetry; the benchmarked `ProcessSystem.java` baseline is identical to current master.

Runtime: OpenJDK 17.0.19, SerialGC, fixed 256 MiB heap, disabled PerfData. Baseline and candidate were run in alternating order across seven fresh JVM pairs. Every per-fork result is the median of nine measured blocks after warm-up. Main-thread allocation used `com.sun.management.ThreadMXBean`.

The stable-unit workload uses default optimized execution. Units complete once and then report `needRecalculation() == false`, representing repeated orchestration-heavy digital-twin, agent, and reporting cycles.

| Workload | Warm-up | Runs/block | Baseline median | Candidate median | Median paired gain | Faster pairs | Allocation |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 50 stable units | 10,000 | 200,000 | 1,080.521 ns/run | 1,069.761 ns/run | 1.11% | 5/7 | 520 -> 520 B/run |
| 500 stable units | 5,000 | 50,000 | 7,586.171 ns/run | 7,204.988 ns/run | **4.54%** | **6/7** | 520 -> 520 B/run |
| one-area `ProcessModel`, 500 units | 2,000 | 20,000 | 16,009.974 ns/run | 15,705.324 ns/run | 0.36% | 5/7 | not interpreted |

The one-area `ProcessModel` result is noise-level, so no robust model-level speedup is claimed. The optimization removes one scan and no allocation, so benefit scales with unit count and the fraction of runtime spent in orchestration.

A separate nine-unit rich-gas SRK `Stream -> 8 Heaters` workload alternated 298.15/303.15 K and all heater set points by 5 K. Five fresh JVM pairs used 30 warm-ups and 9 x 80 measured runs. The candidate was faster in 4/5 pairs, but the paired range was -1.92% to +21.14%; no general flash-dominated speedup is claimed.

## Correctness and robustness

The new deterministic regression proves:

- current master performs two active-state inspections for nested default optimized dispatch and fails with expected 1, observed 2;
- this branch performs exactly one outer inspection;
- a direct public `runOptimized(UUID)` call still performs exactly one required inspection.

Existing low-flow coverage verifies that a changed feed reactivates an auto-bypassed heater. The implementation does not change equipment execution, dirty-state calculation, graph selection, calculation identifiers, thermodynamic calls, convergence rules, shared state, serialization, or public APIs.

The rich-gas baseline and candidate matched exactly at both operating points and on repeated runs:

- accumulated state/duty checksum: `326834251.326814`;
- maximum mass-flow residual across all heaters: `0.0 kg/hr`;
- final state: `322.15 K`, `70.0 bara`, one phase;
- identical run-status JSON hash: `1174690866`.

Thread safety is unchanged: `ProcessSystem.run(UUID)` remains synchronized, and the existing per-instance `ThreadLocal` run-depth contract is retained.

## Tests and validation

Exact final checkout after rebasing onto current master:

- `python devtools/run_spotless.py apply`: pass; repeated apply produced no further changes.
- `./mvnw -q -o -Dmaven.repo.local=/tmp/neqsim-pfd-maven/repository -Dtest=ProcessSystemExecutionPreparationTest,ProcessSystemLowFlowBypassTest,ProcessSystemTest,ProcessModelExecutionOptimizationTest test`: **80/80 passed**.
- Baseline overlay of `ProcessSystem` against the new focused test: expected **1/5 failure**, observed two inspections instead of one.
- `pre-commit run --all-files --hook-stage pre-commit`: pass.
- `python devtools/run_spotless.py check`: pass.
- `python devtools/check_documentation_search.py`: pass; 646 Markdown pages and one standalone HTML page.
- `pre-commit run --all-files --hook-stage pre-push`: pass.
- `git diff --check`: pass.
- Final connector-published blobs exactly match the locally tested Git blob SHAs.

The full repository matrix is left to hosted CI; the local Maven dependency cache was sufficient for compilation, focused/relevant tests, Spotless, and documentation gates but not a complete package lifecycle.

## Documentation impact

Documentation impact: none — this removes only an internal redundant dispatcher scan. Public APIs, inputs, outputs, units, defaults, execution-strategy selection, low-flow behavior, numerical results, and recommended usage are unchanged. The adjacent graph-execution, parallel-simulation, and low-flow-bypass documentation remains accurate.

## Compatibility and limitations

- Public Java/Python API and serialization format: unchanged.
- Determinism, phase behavior, mass/energy calculations, convergence, repeated-run behavior: unchanged.
- Largest measured benefit is for wide, warm, orchestration-dominated optimized `ProcessSystem` runs.
- No robust `ProcessModel` or thermodynamics-dominated speedup is claimed.
- No notebooks or generated artifacts are changed.
