### PR TITLE
feat(distillation): expose tray K-value convergence work

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -18,6 +18,14 @@ tie behavior, and schema version remain unchanged. Python and AI consumers shoul
 process areas may legitimately reuse the same unit name.
 
 ---
+## 2026-08-09 — Expose Naphtali-Sandholm tray K-value convergence work
+
+- Naphtali-Sandholm diagnostics now report forced-root K-value sweep count, the number of tray
+  evaluations still above the `1e-8` log-K update criterion after two sweeps, and the maximum final
+  update.
+- The two-sweep numerical path, MESH equations, acceptance gates, and fallback behavior are
+  unchanged. The telemetry establishes the baseline needed for a later bounded convergence method.
+
 ## 2026-08-09 — Correct Naphtali-Sandholm Jacobian work classification
 
 - Naphtali-Sandholm diagnostics now count each numerically perturbed Jacobian column only as

--- a/docs/development/TASK_LOG.md
+++ b/docs/development/TASK_LOG.md
@@ -36,6 +36,12 @@ requirement`, or `confidential compressor route`.
 
 <!-- Add new entries at the top. Most recent first. -->
 
+### 2026-08-09 — Expose Naphtali-Sandholm tray K-value convergence work
+**Type:** E (Feature)
+**Keywords:** distillation, Naphtali-Sandholm, MESH, fugacity, K-value, convergence, diagnostics, telemetry
+**Solution:** `NaphtaliSandholmSolver.evaluateThermoForTray`, `DistillationColumn` convergence diagnostics, and `ColumnSpecificationTest.naphtaliSandholmTelemetryRecordsJacobianWork`
+**Notes:** The solver retains its established two forced-root fugacity sweeps per tray evaluation but no longer assumes they converged. Additive telemetry records sweep count, evaluations whose final maximum absolute logarithmic K update remains above `1e-8`, and the worst final update. The base and nearby operating points preserve the numerical trajectory and expose the inner convergence debt deterministically.
+
 ### 2026-08-09 — Correct Naphtali-Sandholm Jacobian work telemetry
 **Type:** E (Feature)
 **Keywords:** distillation, Naphtali-Sandholm, MESH, Jacobian, finite difference, diagnostics, telemetry, solver benchmark

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -259,6 +259,13 @@ targets manipulated through condenser or reboiler temperature.
 - Work diagnostics classify every currently assembled derivative column as finite-difference;
   `getLastNaphtaliAnalyticJacobianColumns()` remains available for compatibility and reports zero
   until a mixed analytic/numerical assembly is implemented.
+- Tray thermodynamics retain the established two forced-root fugacity sweeps. Diagnostics now
+  report their total count, the number of tray evaluations whose final
+  `max(abs(log(Knew/Kold)))` exceeds `1e-8`, and the largest such final update through
+  `getLastNaphtaliThermoKValueIterationCount()`,
+  `getLastNaphtaliThermoKValueNonConvergedCount()`, and
+  `getLastNaphtaliThermoMaxLogKValueUpdate()`. These metrics expose incomplete inner convergence;
+  they do not loosen the MESH acceptance criteria or silently add extra EOS work.
 - Allows at most three line-search steps that fail to reduce the MESH residual. After three such
   non-descent steps, the solver restores the best finite tray state and returns the actual iteration
   count so the column can proceed to its coordinated fallback instead of exhausting the Newton

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -789,6 +789,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   private transient int lastNaphtaliFiniteDifferenceJacobianColumns = 0;
   /** Latest Naphtali-Sandholm tray thermodynamic evaluation count. */
   private transient int lastNaphtaliThermoEvaluationCount = 0;
+  /** Latest Naphtali-Sandholm forced-root K-value iteration count. */
+  private transient int lastNaphtaliThermoKValueIterationCount = 0;
+  /** Latest count of tray evaluations that reached the K-value iteration cap. */
+  private transient int lastNaphtaliThermoKValueNonConvergedCount = 0;
+  /** Latest maximum final absolute logarithmic K-value update. */
+  private transient double lastNaphtaliThermoMaxLogKValueUpdate = 0.0;
   /** Latest Naphtali-Sandholm thermodynamic cache hit count. */
   private transient int lastNaphtaliThermoCacheHitCount = 0;
   /** Latest Naphtali-Sandholm Jacobian build wall time in seconds. */
@@ -3584,6 +3590,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     lastNaphtaliAnalyticJacobianColumns = solver.getLastAnalyticJacobianColumns();
     lastNaphtaliFiniteDifferenceJacobianColumns = solver.getLastFiniteDifferenceJacobianColumns();
     lastNaphtaliThermoEvaluationCount = solver.getLastThermoEvaluationCount();
+    lastNaphtaliThermoKValueIterationCount = solver.getLastThermoKValueIterationCount();
+    lastNaphtaliThermoKValueNonConvergedCount = solver.getLastThermoKValueNonConvergedCount();
+    lastNaphtaliThermoMaxLogKValueUpdate = solver.getLastThermoMaxLogKValueUpdate();
     lastNaphtaliThermoCacheHitCount = solver.getLastThermoCacheHitCount();
     lastNaphtaliJacobianBuildTimeSeconds = solver.getLastJacobianBuildTimeSeconds();
     lastNaphtaliBlockLinearSolveCount = solver.getLastBlockLinearSolveCount();
@@ -3807,6 +3816,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     this.lastNaphtaliAnalyticJacobianColumns = candidate.lastNaphtaliAnalyticJacobianColumns;
     this.lastNaphtaliFiniteDifferenceJacobianColumns = candidate.lastNaphtaliFiniteDifferenceJacobianColumns;
     this.lastNaphtaliThermoEvaluationCount = candidate.lastNaphtaliThermoEvaluationCount;
+    this.lastNaphtaliThermoKValueIterationCount = candidate.lastNaphtaliThermoKValueIterationCount;
+    this.lastNaphtaliThermoKValueNonConvergedCount = candidate.lastNaphtaliThermoKValueNonConvergedCount;
+    this.lastNaphtaliThermoMaxLogKValueUpdate = candidate.lastNaphtaliThermoMaxLogKValueUpdate;
     this.lastNaphtaliThermoCacheHitCount = candidate.lastNaphtaliThermoCacheHitCount;
     this.lastNaphtaliJacobianBuildTimeSeconds = candidate.lastNaphtaliJacobianBuildTimeSeconds;
     this.lastNaphtaliBlockLinearSolveCount = candidate.lastNaphtaliBlockLinearSolveCount;
@@ -3967,6 +3979,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     int analyticJacobianColumns = lastNaphtaliAnalyticJacobianColumns;
     int finiteDifferenceJacobianColumns = lastNaphtaliFiniteDifferenceJacobianColumns;
     int thermoEvaluationCount = lastNaphtaliThermoEvaluationCount;
+    int thermoKValueIterationCount = lastNaphtaliThermoKValueIterationCount;
+    int thermoKValueNonConvergedCount = lastNaphtaliThermoKValueNonConvergedCount;
+    double thermoMaxLogKValueUpdate = lastNaphtaliThermoMaxLogKValueUpdate;
     int thermoCacheHitCount = lastNaphtaliThermoCacheHitCount;
     double jacobianBuildTimeSeconds = lastNaphtaliJacobianBuildTimeSeconds;
     int blockLinearSolveCount = lastNaphtaliBlockLinearSolveCount;
@@ -3983,6 +3998,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     lastNaphtaliAnalyticJacobianColumns = analyticJacobianColumns;
     lastNaphtaliFiniteDifferenceJacobianColumns = finiteDifferenceJacobianColumns;
     lastNaphtaliThermoEvaluationCount = thermoEvaluationCount;
+    lastNaphtaliThermoKValueIterationCount = thermoKValueIterationCount;
+    lastNaphtaliThermoKValueNonConvergedCount = thermoKValueNonConvergedCount;
+    lastNaphtaliThermoMaxLogKValueUpdate = thermoMaxLogKValueUpdate;
     lastNaphtaliThermoCacheHitCount = thermoCacheHitCount;
     lastNaphtaliJacobianBuildTimeSeconds = jacobianBuildTimeSeconds;
     lastNaphtaliBlockLinearSolveCount = blockLinearSolveCount;
@@ -9279,6 +9297,33 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
+   * Retrieve latest Naphtali-Sandholm forced-root fugacity fixed-point iteration count.
+   *
+   * @return K-value iterations performed by the latest Naphtali solve
+   */
+  public int getLastNaphtaliThermoKValueIterationCount() {
+    return lastNaphtaliThermoKValueIterationCount;
+  }
+
+  /**
+   * Retrieve how many tray thermodynamic evaluations reached the K-value iteration cap.
+   *
+   * @return non-converged tray thermodynamic evaluation count
+   */
+  public int getLastNaphtaliThermoKValueNonConvergedCount() {
+    return lastNaphtaliThermoKValueNonConvergedCount;
+  }
+
+  /**
+   * Retrieve the largest final logarithmic K-value update from the latest Naphtali solve.
+   *
+   * @return maximum {@code abs(log(Knew / Kold))}
+   */
+  public double getLastNaphtaliThermoMaxLogKValueUpdate() {
+    return lastNaphtaliThermoMaxLogKValueUpdate;
+  }
+
+  /**
    * Retrieve latest Naphtali-Sandholm thermodynamic cache hit count.
    *
    * @return tray thermodynamic evaluations avoided by cache reuse
@@ -9564,6 +9609,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       diagnostics.append("    finite-difference columns: ").append(lastNaphtaliFiniteDifferenceJacobianColumns)
           .append("\n");
       diagnostics.append("    thermodynamic evaluations: ").append(lastNaphtaliThermoEvaluationCount).append("\n");
+      diagnostics.append("    K-value iterations: ").append(lastNaphtaliThermoKValueIterationCount).append("\n");
+      diagnostics.append("    K-value evaluations at iteration cap: ").append(lastNaphtaliThermoKValueNonConvergedCount)
+          .append("\n");
+      diagnostics.append("    maximum final log K-value update: ").append(lastNaphtaliThermoMaxLogKValueUpdate)
+          .append("\n");
       diagnostics.append("    thermodynamic cache hits: ").append(lastNaphtaliThermoCacheHitCount).append("\n");
       diagnostics.append("    jacobian build time: ").append(lastNaphtaliJacobianBuildTimeSeconds).append(" s\n");
       diagnostics.append("    block linear solves: ").append(lastNaphtaliBlockLinearSolveCount).append("\n");
@@ -13070,6 +13120,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     lastNaphtaliAnalyticJacobianColumns = 0;
     lastNaphtaliFiniteDifferenceJacobianColumns = 0;
     lastNaphtaliThermoEvaluationCount = 0;
+    lastNaphtaliThermoKValueIterationCount = 0;
+    lastNaphtaliThermoKValueNonConvergedCount = 0;
+    lastNaphtaliThermoMaxLogKValueUpdate = 0.0;
     lastNaphtaliThermoCacheHitCount = 0;
     lastNaphtaliJacobianBuildTimeSeconds = 0.0;
     lastNaphtaliBlockLinearSolveCount = 0;

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -38,6 +38,12 @@ public class NaphtaliSandholmSolver {
   /** Maximum number of non-descent line-search steps allowed before restoring the best state. */
   private static final int MAX_NON_DESCENT_LINE_SEARCH_STEPS = 3;
 
+  /** Forced-root fugacity fixed-point sweeps performed for one tray evaluation. */
+  private static final int THERMO_K_VALUE_ITERATIONS = 2;
+
+  /** Convergence tolerance for the largest absolute logarithmic K-value update. */
+  private static final double THERMO_K_VALUE_TOLERANCE = 1.0e-8;
+
   /** Logger for this class. */
   private static final Logger logger = LogManager.getLogger(NaphtaliSandholmSolver.class);
 
@@ -241,6 +247,15 @@ public class NaphtaliSandholmSolver {
   /** Number of tray thermodynamic evaluations in the last solve. */
   private int lastThermoEvaluationCount;
 
+  /** Number of forced-root fugacity fixed-point iterations in the last solve. */
+  private int lastThermoKValueIterationCount;
+
+  /** Number of tray evaluations that reached the K-value iteration cap. */
+  private int lastThermoKValueNonConvergedCount;
+
+  /** Largest final absolute logarithmic K-value update from the last solve. */
+  private double lastThermoMaxLogKValueUpdate;
+
   /** Number of cached tray thermodynamic evaluations reused in the last solve. */
   private int lastThermoCacheHitCount;
 
@@ -352,6 +367,33 @@ public class NaphtaliSandholmSolver {
    */
   int getLastThermoEvaluationCount() {
     return lastThermoEvaluationCount;
+  }
+
+  /**
+   * Get the number of forced-root fugacity fixed-point iterations in the latest solve.
+   *
+   * @return K-value iteration count
+   */
+  int getLastThermoKValueIterationCount() {
+    return lastThermoKValueIterationCount;
+  }
+
+  /**
+   * Get the number of tray evaluations that reached the K-value iteration cap.
+   *
+   * @return non-converged tray thermodynamic evaluation count
+   */
+  int getLastThermoKValueNonConvergedCount() {
+    return lastThermoKValueNonConvergedCount;
+  }
+
+  /**
+   * Get the largest final absolute logarithmic K-value update in the latest solve.
+   *
+   * @return maximum {@code abs(log(Knew / Kold))}
+   */
+  double getLastThermoMaxLogKValueUpdate() {
+    return lastThermoMaxLogKValueUpdate;
   }
 
   /**
@@ -918,6 +960,9 @@ public class NaphtaliSandholmSolver {
     lastAnalyticJacobianColumns = 0;
     lastFiniteDifferenceJacobianColumns = 0;
     lastThermoEvaluationCount = 0;
+    lastThermoKValueIterationCount = 0;
+    lastThermoKValueNonConvergedCount = 0;
+    lastThermoMaxLogKValueUpdate = 0.0;
     lastThermoCacheHitCount = 0;
     lastJacobianBuildTimeSeconds = 0.0;
     lastBlockLinearSolveCount = 0;
@@ -3288,20 +3333,29 @@ public class NaphtaliSandholmSolver {
     }
 
     // Self-consistency loop: K = phi_L(x) / phi_V(y), then y = K x / sum(K x).
-    // Two inner sweeps are sufficient for HC mixtures at modest pressures since
-    // phi_V for a cubic EOS in the vapor root depends weakly on y.
+    // Preserve the established two-sweep behavior, but measure the remaining
+    // scale-invariant logarithmic K-value update instead of assuming convergence.
     boolean kOk = phiOk;
+    boolean kConverged = false;
+    double finalMaxLogKUpdate = Double.POSITIVE_INFINITY;
     if (kOk) {
-      for (int sweep = 0; sweep < 2; sweep++) {
+      for (int sweep = 0; sweep < THERMO_K_VALUE_ITERATIONS; sweep++) {
         if (!computeSinglePhaseFugacityCoefficients(y, T[j], Pbar, true, phiV)) {
           kOk = false;
           break;
         }
+        lastThermoKValueIterationCount++;
         double sumKxLocal = 0;
+        finalMaxLogKUpdate = 0.0;
         for (int i = 0; i < C; i++) {
+          double previousK = K[j][i];
+          if (!(previousK > 1e-20 && previousK < 1e15)) {
+            previousK = wilsonK(i, T[j], Pbar);
+          }
           double Knew = phiL[i] / Math.max(phiV[i], 1e-30);
           Knew = Math.max(Knew, 1e-15);
           Knew = Math.min(Knew, 1e15);
+          finalMaxLogKUpdate = Math.max(finalMaxLogKUpdate, Math.abs(Math.log(Knew / previousK)));
           K[j][i] = Knew;
           y[i] = Knew * x[i];
           sumKxLocal += y[i];
@@ -3309,6 +3363,18 @@ public class NaphtaliSandholmSolver {
         for (int i = 0; i < C; i++) {
           y[i] = (sumKxLocal > 1e-20) ? y[i] / sumKxLocal : x[i];
         }
+        if (finalMaxLogKUpdate <= THERMO_K_VALUE_TOLERANCE) {
+          kConverged = true;
+        } else {
+          kConverged = false;
+        }
+      }
+    }
+
+    if (kOk) {
+      lastThermoMaxLogKValueUpdate = Math.max(lastThermoMaxLogKValueUpdate, finalMaxLogKUpdate);
+      if (!kConverged) {
+        lastThermoKValueNonConvergedCount++;
       }
     }
 

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
@@ -528,6 +528,13 @@ public class ColumnSpecificationTest {
     assertEquals(800, column.getLastNaphtaliFiniteDifferenceJacobianColumns(),
         "eight stages times five variables times twenty Jacobian builds must all be finite-difference columns");
     assertTrue(column.getLastNaphtaliThermoEvaluationCount() > 0);
+    assertEquals(2 * column.getLastNaphtaliThermoEvaluationCount(), column.getLastNaphtaliThermoKValueIterationCount(),
+        "the current evaluator performs two forced-root fugacity sweeps per tray evaluation");
+    assertTrue(column.getLastNaphtaliThermoKValueNonConvergedCount() > 0,
+        "this difficult case must expose two-sweep evaluations that remain above the log-K tolerance");
+    assertTrue(column.getLastNaphtaliThermoKValueNonConvergedCount() <= column.getLastNaphtaliThermoEvaluationCount());
+    assertTrue(Double.isFinite(column.getLastNaphtaliThermoMaxLogKValueUpdate()));
+    assertTrue(column.getLastNaphtaliThermoMaxLogKValueUpdate() > 1.0e-8);
     assertTrue(column.getLastNaphtaliThermoCacheHitCount() >= 0);
     assertTrue(column.getLastNaphtaliJacobianBuildTimeSeconds() >= 0.0);
     assertTrue(column.getLastNaphtaliBlockLinearSolveCount() > 0);
@@ -536,8 +543,44 @@ public class ColumnSpecificationTest {
     assertTrue(column.getConvergenceDiagnostics().contains("Naphtali-Sandholm Jacobian"));
     assertTrue(column.getConvergenceDiagnostics().contains("analytic columns: 0"));
     assertTrue(column.getConvergenceDiagnostics().contains("finite-difference columns: 800"));
+    assertTrue(column.getConvergenceDiagnostics().contains("K-value iterations"));
+    assertTrue(column.getConvergenceDiagnostics().contains("K-value evaluations at iteration cap"));
     assertTrue(column.getConvergenceDiagnostics().contains("thermodynamic cache hits"));
     assertTrue(column.getConvergenceDiagnostics().contains("block linear solves"));
+  }
+
+  /**
+   * Test that K-value work diagnostics and physical products repeat at a nearby feed temperature.
+   */
+  @Test
+  public void naphtaliKValueTelemetryIsRepeatableAtNearbyOperatingPoint() {
+    DistillationColumn first = createBinaryFractionator("NaphtaliKNearbyFirst", "propane", "n-butane", "n-pentane",
+        10.0, 273.15 + 47.0, 273.15 + 30.0, 273.15 + 90.0);
+    DistillationColumn second = createBinaryFractionator("NaphtaliKNearbySecond", "propane", "n-butane", "n-pentane",
+        10.0, 273.15 + 47.0, 273.15 + 30.0, 273.15 + 90.0);
+    first.setSolverType(DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    second.setSolverType(DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    first.setMaxNumberOfIterations(20);
+    second.setMaxNumberOfIterations(20);
+
+    first.run();
+    second.run();
+
+    assertEquals(first.getLastNaphtaliThermoEvaluationCount(), second.getLastNaphtaliThermoEvaluationCount());
+    assertEquals(first.getLastNaphtaliThermoKValueIterationCount(), second.getLastNaphtaliThermoKValueIterationCount());
+    assertEquals(first.getLastNaphtaliThermoKValueNonConvergedCount(),
+        second.getLastNaphtaliThermoKValueNonConvergedCount());
+    assertEquals(first.getLastNaphtaliThermoMaxLogKValueUpdate(), second.getLastNaphtaliThermoMaxLogKValueUpdate());
+    assertEquals(first.getLastMeshResidualNorm(), second.getLastMeshResidualNorm());
+    assertEquals(first.getLastEnergyResidual(), second.getLastEnergyResidual());
+
+    double firstGas = first.getGasOutStream().getFlowRate("kg/hr");
+    double firstLiquid = first.getLiquidOutStream().getFlowRate("kg/hr");
+    assertTrue(firstGas >= 0.0);
+    assertTrue(firstLiquid >= 0.0);
+    assertEquals(250.0, firstGas + firstLiquid, 1.0e-8);
+    assertEquals(firstGas, second.getGasOutStream().getFlowRate("kg/hr"));
+    assertEquals(firstLiquid, second.getLiquidOutStream().getFlowRate("kg/hr"));
   }
 
   /**


### PR DESCRIPTION
## Problem and root cause

The Naphtali–Sandholm tray thermodynamics performs exactly two forced-root fugacity fixed-point sweeps per uncached tray evaluation, but it previously exposed only the number of tray evaluations. It therefore provided no way to determine whether those two sweeps made the cached tray K-values self-consistent or how much equation-of-state work they represented.

A deterministic multicomponent hydrocarbon column showed that the final K update commonly remains material after the second sweep. Increasing the sweep count or adding log-K damping changed the fallback trajectory and did not establish a robust general improvement, so those experimental algorithm changes were rejected.

## Affected solver and change

This change retains the existing equations, exactly two sweeps, EOS-call order, cache behavior, Newton/fallback coordination, and convergence tolerances. It adds:

- total forced-root K-value sweep count;
- tray-evaluation count whose final `max(abs(log(Knew/Kold)))` exceeds `1e-8`;
- largest final logarithmic K-value update;
- public `DistillationColumn` getters and convergence-report output;
- preservation across best-state/warm-candidate save and restore paths.

The implementation adds only scalar arithmetic inside existing component loops—no added flashes, residual evaluations, array allocations, or solver iterations.

## Before/after evidence

Baseline: master `01879d605f0ceecd9efb211a2ea0f76fa3269f40`, eight-stage propane/n-butane/n-pentane column, 250 kg/h feed.

| Feed T | Observable | Before | After |
|---|---:|---:|---:|
| 318.15 K | column iterations | 136 | 136 |
| 318.15 K | thermo evaluations | 16,184 | 16,184 |
| 318.15 K | energy residual | 0.00261145310005 | 0.00261145310005 |
| 318.15 K | gas / liquid product | 237.659729539 / 12.3402704610 kg/h | identical |
| 318.15 K | mass closure | 5.68434188608e-14 kg/h | identical |
| 318.15 K | K sweeps / above limit / max update | unavailable | 32,368 / 13,150 / 2.92646086691 |
| 320.15 K | column iterations | 136 | 136 |
| 320.15 K | thermo evaluations | 16,200 | 16,200 |
| 320.15 K | energy residual | 0.00222096384186 | 0.00222096384186 |
| 320.15 K | products and mass closure | identical to baseline | identical |
| 320.15 K | K sweeps / above limit / max update | unavailable | 32,400 / 13,368 / 2.92268336502 |

Both operating points were repeated independently; telemetry, residuals, and products were bit-for-bit deterministic. This known difficult case proceeds through the coordinated fallback, and the new diagnostics expose—rather than conceal—the remaining K-consistency limitation.

## Validation

- focused telemetry and nearby-point regression: 2 tests, 0 failures
- `ColumnSpecificationTest,ColumnStudyRegressionTest,DistillationSolverBenchmarkTest,DistillationColumnConvergenceGateTest`: 78 tests, 0 failures/errors, 1 skipped
- complete `neqsim.process.equipment.distillation.*Test` suite: 218 tests, 0 failures/errors, 2 skipped
- Java 8 source compatibility: direct `javac --release 8` of both changed production classes passed
- `python devtools/run_spotless.py apply`: passed twice; second run produced no further changes
- `python devtools/run_spotless.py check`: passed
- `python devtools/check_documentation_search.py`: passed (646 Markdown, 1 HTML)
- `pre-commit run --all-files --hook-stage pre-commit`: passed
- `pre-commit run --all-files --hook-stage pre-push`: passed
- checkstyle/SpotBugs/PMD invocation was attempted, but Maven could not resolve uncached plugin dependencies because `repo.maven.apache.org` had a temporary DNS-resolution failure; hosted checks remain required before merge readiness

## Compatibility, risk, and documentation

All new column fields are transient. Existing public APIs and numerical behavior are unchanged. Runtime risk is limited to inexpensive scalar logarithms and counters in an already active component loop. Documentation and task/release catalogs describe the diagnostic semantics and tolerance.

## Remaining limitation and next step

This PR deliberately does not claim that two K sweeps are converged. The next dependency-ordered improvement is to use this telemetry to validate a bounded, residual-aware forced-root K iteration (with safeguarded acceleration or damping) across direct convergence and fallback cases before changing the established numerical path.
