### PR TITLE
perf(process): avoid dataflow scheduler for serial flowsheets

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -258,10 +258,13 @@ public class ProcessSystem extends SimulationBaseClass {
   private static final class DataflowExecutionPlan {
     private final List<List<ProcessNode>> tasks;
     private final List<java.util.Set<Integer>> taskPredecessors;
+    private final boolean hasParallelTasks;
 
-    private DataflowExecutionPlan(List<List<ProcessNode>> tasks, List<java.util.Set<Integer>> taskPredecessors) {
+    private DataflowExecutionPlan(List<List<ProcessNode>> tasks, List<java.util.Set<Integer>> taskPredecessors,
+        boolean hasParallelTasks) {
       this.tasks = tasks;
       this.taskPredecessors = taskPredecessors;
+      this.hasParallelTasks = hasParallelTasks;
     }
   }
 
@@ -1520,12 +1523,12 @@ public class ProcessSystem extends SimulationBaseClass {
           runSequential(id);
         }
       } else {
-        // Feed-forward process with single-input equipment only. For larger
-        // flowsheets use dataflow scheduling (no level barriers, units fire as
-        // soon as predecessors complete); for small trees the CompletableFuture
-        // overhead outweighs the straggler benefit, so stay on runParallel.
+        // Feed-forward process with single-input equipment only. For larger,
+        // genuinely wide flowsheets use dataflow scheduling (no level barriers,
+        // units fire as soon as predecessors complete). Serial plans cannot
+        // benefit from futures, and small trees do not amortize their overhead.
         try {
-          if (unitOperations.size() >= DATAFLOW_UNIT_THRESHOLD) {
+          if (unitOperations.size() >= DATAFLOW_UNIT_THRESHOLD && getCachedDataflowPlan().hasParallelTasks) {
             runDataflow(id);
           } else {
             runParallel(id);
@@ -1786,7 +1789,11 @@ public class ProcessSystem extends SimulationBaseClass {
     }
 
     List<List<ProcessNode>> tasks = new ArrayList<>();
+    boolean hasParallelTasks = false;
     for (List<List<ProcessNode>> level : getCachedParallelPlan()) {
+      if (level.size() > 1) {
+        hasParallelTasks = true;
+      }
       tasks.addAll(level);
     }
 
@@ -1814,7 +1821,7 @@ public class ProcessSystem extends SimulationBaseClass {
       taskPredecessors.add(predSet);
     }
 
-    cachedDataflowPlan = new DataflowExecutionPlan(tasks, taskPredecessors);
+    cachedDataflowPlan = new DataflowExecutionPlan(tasks, taskPredecessors, hasParallelTasks);
     return cachedDataflowPlan;
   }
 

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemDataflowDispatchTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemDataflowDispatchTest.java
@@ -1,0 +1,100 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests automatic selection between level-based and dataflow process execution. */
+class ProcessSystemDataflowDispatchTest {
+  /** Process system that records the selected concrete dispatcher. */
+  private static final class RecordingProcessSystem extends ProcessSystem {
+    private static final long serialVersionUID = 1000L;
+    private int parallelRuns;
+    private int dataflowRuns;
+
+    /** Creates an empty recording process. */
+    RecordingProcessSystem() {
+      super("dispatch recording process");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void runParallel(UUID id) {
+      parallelRuns++;
+      setCalculationIdentifier(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void runDataflow(UUID id) {
+      dataflowRuns++;
+      setCalculationIdentifier(id);
+    }
+  }
+
+  /**
+   * Creates a simple gas fluid for graph construction.
+   *
+   * @return configured gas fluid
+   */
+  private static SystemInterface createFluid() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  /**
+   * Adds one serial stream/heater chain.
+   *
+   * @param process process to populate
+   * @param prefix unique unit-name prefix
+   * @param heaterCount number of heaters after the feed
+   */
+  private static void addSerialChain(ProcessSystem process, String prefix, int heaterCount) {
+    StreamInterface current = new Stream(prefix + " feed", createFluid());
+    process.add(current);
+    for (int i = 0; i < heaterCount; i++) {
+      Heater heater = new Heater(prefix + " heater " + i, current);
+      process.add(heater);
+      current = heater.getOutletStream();
+    }
+  }
+
+  /** Verifies a large serial process avoids dataflow and invalidates that decision on branching. */
+  @Test
+  void serialProcessUsesParallelLevelsUntilTopologyBecomesWide() {
+    RecordingProcessSystem process = new RecordingProcessSystem();
+    addSerialChain(process, "serial", 8);
+
+    process.runOptimized(UUID.randomUUID());
+
+    assertEquals(1, process.parallelRuns, "serial topology should avoid CompletableFuture scheduling");
+    assertEquals(0, process.dataflowRuns);
+
+    addSerialChain(process, "branch", 1);
+    process.runOptimized(UUID.randomUUID());
+
+    assertEquals(1, process.parallelRuns);
+    assertEquals(1, process.dataflowRuns, "topology mutation must enable dataflow for independent tasks");
+  }
+
+  /** Verifies a genuinely wide process retains dataflow dispatch. */
+  @Test
+  void independentChainsUseDataflow() {
+    RecordingProcessSystem process = new RecordingProcessSystem();
+    addSerialChain(process, "left", 4);
+    addSerialChain(process, "right", 4);
+
+    process.runOptimized(UUID.randomUUID());
+
+    assertEquals(0, process.parallelRuns);
+    assertEquals(1, process.dataflowRuns);
+  }
+}


### PR DESCRIPTION
Closes #2883

## Bottleneck and bounded change

`ProcessSystem.runOptimized(UUID)` selected `runDataflow` for every single-input feed-forward process with at least eight registered units. A fully serial plan therefore created and scheduled one `CompletableFuture` per task although its grouped topology had no level with more than one independently executable group.

This PR caches one `hasParallelTasks` boolean in the existing transient `DataflowExecutionPlan`. Automatic dispatch now selects dataflow only when both conditions hold:

1. the existing eight-unit threshold is met; and
2. at least one grouped level contains more than one independent task.

Serial plans use the existing level-based `runParallel` path. Direct `runDataflow(UUID)`, genuine wide-flow dispatch, graph grouping, execution order, dirty-state handling, calculation identifiers, and topology-cache invalidation remain unchanged.

Base: current `master` `dae39c5b879220cde16fff8c00893bb2f0f8f9f8`; the relevant current-master `ProcessSystem.java` blob was `fed6edafd1c2bab6d780db600fe298e3e4b80658`.

## Reproducible benchmark

OpenJDK 17.0.19, G1, fixed 512 MiB heap, seven alternating-order fresh-JVM pairs. Each fork used 30 warmups and the median of 9 blocks x 120 state-changing runs.

Workload:

- 13-component SRK/classic rich gas with water;
- 50,000 kg/h at 80 bara;
- `Stream -> 8 Heater` serial chain;
- alternating 298.15/303.15 K inlet and nearby heater duties;
- direct comparison of the two existing concrete execution paths selected before/after this change.

| Metric | Dataflow baseline | Level-based candidate |
|---|---:|---:|
| Across-fork median | 6.964 ms/run | 6.512 ms/run |
| Median paired gain | — | **6.63%** |
| Faster pairs | — | **6/7** |

Paired gains were 5.47%, 12.86%, -0.51%, 6.63%, 7.90%, 11.92%, and 0.81%.

Every fork retained:

- identical aggregate checksum: `-1.4872354162589555E9`;
- exactly `0.0 kg/h` inlet/outlet mass residual;
- two phases and 80.0 bara outlet pressure;
- deterministic repeated nearby-state behavior.

Earlier issue-gate evidence on the same implementation shape found a 15.21% paired median gain for default dispatch, noise-level +0.29% on a genuinely parallel asymmetric process, and noise-level -0.91% for a three-area `ProcessModel`. No universal flash-dominated speedup is claimed.

## Regression and validation

The new regression failed on current dispatch exactly as intended: 1/2 tests failed because the nine-unit serial chain selected dataflow. It now proves:

- a nine-unit serial chain selects level-based execution;
- adding an independent branch invalidates the cached topology decision and enables dataflow;
- two independent chains retain dataflow scheduling.

Final validation:

- focused/relevant Maven suite: **85/85 passed**
  - `ProcessSystemDataflowDispatchTest`: 2
  - `ProcessSystemExecutionPreparationTest`: 5
  - `ProcessSystemTest`: 60
  - `ProcessModelExecutionOptimizationTest`: 11
  - `GraphVsSequentialExecutionTest`: 7
- direct Java 8 compilation of changed production and test sources: passed
- `python devtools/run_spotless.py apply`: passed; clean on repeat
- `pre-commit run --all-files --hook-stage pre-commit`: passed
- `python devtools/run_spotless.py check`: passed
- `python devtools/check_documentation_search.py`: passed (646 Markdown, 1 HTML)
- `pre-commit run --all-files --hook-stage pre-push`: passed
- `git diff --check`: passed
- connector-published blobs match the tested local blobs exactly:
  - `ProcessSystem.java`: `0c0e6944b381ed27f5a3b82bab6a468f380d1aae`
  - regression test: `d6e465d075ae97ac44e85712e2e131dd8f47cf5b`

Hosted full Java 8/21, Windows, Javadoc, static-analysis, documentation, and security checks remain required before merge readiness.

## Compatibility, risk, and limitations

- public Java/Python APIs and serialization: unchanged;
- thermodynamic calculations, flashes, tolerances, phase behavior, balances, convergence, and thread-safety: unchanged;
- the new flag is immutable and stored only in the existing transient per-process execution plan;
- small processes remain on level-based execution;
- wide plans retain dataflow;
- benefit is expected for serial plans at or above the threshold and varies with the proportion of time spent in scheduling versus thermodynamics.

## Documentation impact

Documentation impact: none — this changes only private automatic selection between two existing, numerically equivalent execution paths. Public APIs, inputs, outputs, units, defaults, recommended `runOptimized()` usage, and user-visible execution contracts remain unchanged. The adjacent private source comment now states the topology-width condition.
