### PR TITLE
fix(twofluid): correct dispersed-bubble drag force

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -167,6 +167,19 @@ Separate momentum equations for each phase:
 | Wall friction | Pipe roughness-based (Colebrook/Blasius correlations) |
 | Interfacial friction | Flow-regime dependent correlations |
 
+For `BUBBLE` and `DISPERSED_BUBBLE`, the liquid-continuum closure uses the Schiller-Naumann drag
+coefficient and the spherical-bubble interfacial-area concentration $a_i=6\alpha_G/d_b$. The force
+per pipe length is
+
+$$F_i=\frac{3}{4}C_D\rho_L\frac{\alpha_G A}{d_b}(v_G-v_L)|v_G-v_L|.$$
+
+The equivalent internal shear representation uses $S_i=a_iA$, $f_i=C_D/4$, and
+$\tau_i=\tfrac12 f_i\rho_L(v_G-v_L)|v_G-v_L|$. This form is odd in slip velocity, vanishes with
+gas holdup, and preserves equal-and-opposite interphase momentum when assembled in the gas and
+liquid equations. Its current bubble-size estimate assumes a fixed `0.02 N/m` surface tension and
+caps $d_b$ at $D/5$; it is a bounded dispersed-bubble closure, not a population-balance model or a
+commercial-simulator equivalence claim.
+
 #### Optional virtual-mass coupling
 
 `setEnableVirtualMassForce(true)` enables a local added-inertia coupling between gas and combined

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -318,12 +318,12 @@ The `InterfacialFriction` class calculates the shear stress at the gas-liquid in
 The interfacial shear stress follows the standard form:
 
 ```
-τ_i = 0.5 × f_i × ρ_G × (v_G - v_L) × |v_G - v_L|
+τ_i = 0.5 × f_i × ρ_c × (v_G - v_L) × |v_G - v_L|
 ```
 
 Where:
 - `f_i` = interfacial friction factor (dimensionless)
-- `ρ_G` = gas density (kg/m³)
+- `ρ_c` = continuous-phase density selected by the regime closure (kg/m³)
 - `v_G - v_L` = slip velocity (m/s)
 
 The force per unit length appearing in the momentum equations is:
@@ -421,9 +421,24 @@ else if (Re_b < 1000):
 else:
     C_D = 0.44          // Newton regime
 
-// Friction factor
-f_i = C_D × d_b / (4 × D)
+// Interfacial area concentration and force per pipe length
+a_i = 6 × α_G / d_b
+S_i = a_i × A
+F_i = 3/4 × C_D × ρ_L × α_G × A/d_b × v_slip × |v_slip|
+
+// Equivalent shear representation used by InterfacialFriction
+f_i = C_D / 4
+τ_i = 0.5 × f_i × ρ_L × v_slip × |v_slip|
+F_i = τ_i × S_i
 ```
+
+This dispersed-bubble closure assumes approximately spherical bubbles in a liquid continuum. The
+implemented diameter estimate uses a fixed default surface tension of `0.02 N/m` and caps the
+bubble diameter at `D/5`; applications outside that assumption require a separately validated
+diameter/population closure. The regression range covers pipe diameters `0.05-0.30 m`, liquid
+holdup `0.80` through the vanishing-gas limit, and forward and reverse slip in the laminar-to-Newton
+drag ranges. It verifies the independent Schiller-Naumann force identity and does not claim
+OLGA/LedaFlow equivalence.
 
 #### Hart et al. (1989) Correlation
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFriction.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFriction.java
@@ -23,7 +23,8 @@ import neqsim.process.equipment.pipeline.twophasepipe.closure.GeometryCalculator
  * <h2>Sign Convention</h2>
  * <p>
  * Positive interfacial shear acts to accelerate the liquid and decelerate the gas (gas faster than liquid). The shear
- * stress is defined as: τ_i = 0.5 * f_i * ρ_G * (v_G - v_L) * |v_G - v_L|
+ * stress is defined as: τ_i = 0.5 * f_i * ρ_c * (v_G - v_L) * |v_G - v_L|, where ρ_c is the continuous-phase density
+ * selected by the regime closure.
  * </p>
  *
  * @author Even Solbraa
@@ -446,8 +447,11 @@ public class InterfacialFriction implements Serializable {
       C_D = 0.44;
     }
 
-    // Friction factor
-    result.frictionFactor = C_D * d_b / (4.0 * D);
+    // Express the standard dispersed-phase drag force
+    // F_D/V = 3/4 C_D rho_L alpha_G |u_r| u_r / d_b
+    // as tau_i * a_i, with a_i = 6 alpha_G/d_b and
+    // tau_i = 1/8 C_D rho_L |u_r| u_r = 1/2 f_i rho_L |u_r| u_r.
+    result.frictionFactor = C_D / 4.0;
 
     // Interfacial shear (drag force per unit volume * characteristic length)
     result.interfacialShear = 0.5 * result.frictionFactor * rhoL * result.slipVelocity * Math.abs(result.slipVelocity);

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFrictionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFrictionTest.java
@@ -1,0 +1,77 @@
+package neqsim.process.equipment.pipeline.twophasepipe.closure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
+
+/** Tests for gas-liquid interfacial-friction closures. */
+class InterfacialFrictionTest {
+  private static final double GRAVITY = 9.81;
+  private static final double DEFAULT_BUBBLE_SURFACE_TENSION = 0.02;
+
+  @Test
+  void dispersedBubbleForceMatchesSchillerNaumannDragLaw() {
+    InterfacialFriction friction = new InterfacialFriction();
+    double[] diameters = { 0.05, 0.10, 0.30 };
+    double[] liquidHoldups = { 0.80, 0.95, 1.0 - 1.0e-8 };
+    double[] slipVelocities = { -1.0, -0.10, 0.10, 1.0 };
+
+    for (double diameter : diameters) {
+      for (double liquidHoldup : liquidHoldups) {
+        for (double slipVelocity : slipVelocities) {
+          double gasVelocity = 0.5 + slipVelocity;
+          double liquidVelocity = 0.5;
+          double expected = expectedBubbleDragForcePerLength(gasVelocity, liquidVelocity, 5.0, 1000.0, 1.0e-3,
+              liquidHoldup, diameter);
+
+          double actual = friction.calcInterfacialForce(FlowRegime.DISPERSED_BUBBLE, gasVelocity, liquidVelocity, 5.0,
+              1000.0, 1.5e-5, 1.0e-3, liquidHoldup, diameter, 0.072);
+
+          assertEquals(expected, actual, Math.max(1.0e-12, Math.abs(expected) * 1.0e-12),
+              "Schiller-Naumann force mismatch at D=" + diameter + " m, alphaL=" + liquidHoldup + ", slip="
+                  + slipVelocity + " m/s");
+        }
+      }
+    }
+  }
+
+  @Test
+  void bubbleDragIsOddInSlipAndVanishesAtPhaseLimits() {
+    InterfacialFriction friction = new InterfacialFriction();
+    double forward = friction.calcInterfacialForce(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3, 0.9, 0.1,
+        0.072);
+    double reverse = friction.calcInterfacialForce(FlowRegime.BUBBLE, 0.3, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3, 0.9, 0.1,
+        0.072);
+    double zeroSlip = friction.calcInterfacialForce(FlowRegime.BUBBLE, 0.5, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3, 0.9, 0.1,
+        0.072);
+    double noGas = friction.calcInterfacialForce(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3, 1.0, 0.1,
+        0.072);
+
+    assertTrue(forward > 0.0);
+    assertEquals(-forward, reverse, Math.abs(forward) * 1.0e-12);
+    assertEquals(0.0, zeroSlip, 0.0);
+    assertEquals(0.0, noGas, 0.0);
+  }
+
+  private double expectedBubbleDragForcePerLength(double gasVelocity, double liquidVelocity, double gasDensity,
+      double liquidDensity, double liquidViscosity, double liquidHoldup, double diameter) {
+    double bubbleDiameter = 2.0
+        * Math.sqrt(0.725 * DEFAULT_BUBBLE_SURFACE_TENSION / ((liquidDensity - gasDensity) * GRAVITY));
+    bubbleDiameter = Math.min(bubbleDiameter, diameter / 5.0);
+    double slipVelocity = gasVelocity - liquidVelocity;
+    double bubbleReynoldsNumber = liquidDensity * Math.abs(slipVelocity) * bubbleDiameter / liquidViscosity;
+    double dragCoefficient;
+    if (bubbleReynoldsNumber < 0.1) {
+      dragCoefficient = 240.0;
+    } else if (bubbleReynoldsNumber < 1000.0) {
+      dragCoefficient = 24.0 / bubbleReynoldsNumber * (1.0 + 0.15 * Math.pow(bubbleReynoldsNumber, 0.687));
+    } else {
+      dragCoefficient = 0.44;
+    }
+    double gasHoldup = 1.0 - liquidHoldup;
+    double area = Math.PI * diameter * diameter / 4.0;
+    return 0.75 * dragCoefficient * liquidDensity * gasHoldup * area / bubbleDiameter * slipVelocity
+        * Math.abs(slipVelocity);
+  }
+}


### PR DESCRIPTION
Relates to campaign #2907.

## Engineering value

The declared Schiller-Naumann closure for `BUBBLE` and `DISPERSED_BUBBLE` flow under-predicts interphase momentum exchange by the factor `d_b / D`. This is a dimensional implementation defect, not a calibration choice: bubble drag depends on bubble diameter, while the current force accidentally scales with pipe diameter.

This PR changes one bounded item only: the algebraic conversion from dispersed-bubble drag coefficient to NeqSim's internal shear representation. It does not change flow-regime detection, bubble-size selection, thermodynamics, wall friction, virtual mass, mass transfer, or any other regime closure.

## Reproducible baseline on master

Base: `635b9596bf0fa1e304e9282ba8d893a291dd03ca` (current `master` when published).

For a 0.05 m pipe, liquid holdup 0.80, gas/liquid density 5/1000 kg/m3, liquid viscosity 0.001 Pa s, and -1 m/s gas-minus-liquid slip:

- independent Schiller-Naumann force: **-53.16255840722495 N/m**
- unmodified master: **-2.5918139392115793 N/m**
- master/required ratio: **0.04875**, equal to `d_b / D`
- under-prediction factor: **20.51**

The regression was added first and failed on unmodified master with those exact values.

## Equation and correction

The dispersed spherical-bubble drag force per mixture volume is

```text
F_D / V = 3/4 C_D rho_L alpha_G |u_r| u_r / d_b      [N/m3]
```

and per pipe length, with cross-sectional area `A`,

```text
F_D / L = 3/4 C_D rho_L alpha_G A |u_r| u_r / d_b    [N/m].
```

NeqSim stores the interfacial area per length as

```text
S_i = a_i A,   a_i = 6 alpha_G / d_b.
```

Therefore its shear form

```text
tau_i = 1/2 f_i rho_L |u_r| u_r
F_D / L = tau_i S_i
```

requires **`f_i = C_D / 4`**.

Master used `f_i = C_D d_b / (4D)`. Combined with `S_i = 6 alpha_G A / d_b`, this canceled `d_b` and produced `3/4 C_D rho_L alpha_G A |u_r|u_r / D`. The PR removes only that spurious `d_b/D` factor.

## Closure assumptions, provenance, and validity

- `u_r = v_G - v_L` in m/s; force sign follows slip and the gas/liquid source assembly remains equal and opposite.
- `rho_L` is the continuous-liquid density in kg/m3.
- `C_D = 24/Re_b (1 + 0.15 Re_b^0.687)` for `0.1 <= Re_b < 1000`; `C_D = 0.44` above 1000; the existing low-`Re_b` branch is unchanged.
- The existing bubble diameter is retained: an algebraic spherical-bubble estimate with fixed `0.02 N/m` surface tension, capped at `D/5`.
- The current closure is therefore bounded to approximately spherical bubbles in a liquid continuum. It is not a bubble population-balance model and is not asserted valid for deformed/coalescing high-holdup bubbles.
- No OLGA or LedaFlow implementation was inspected or copied, and no simulator-equivalence claim is made.

Literature context:

- Enwald et al. (1996), Eulerian two-fluid interfacial momentum transfer, [doi:10.1016/S0301-9322(96)00004-X](https://doi.org/10.1016/S0301-9322(96)00004-X).
- Draw et al. (2024), Euler-Euler bubbly-flow simulations using Schiller-Naumann drag, [doi:10.1016/j.ijmultiphaseflow.2024.104969](https://doi.org/10.1016/j.ijmultiphaseflow.2024.104969).
- Hayashi et al. (2025), drag limits for spherical/contaminated bubbles, [doi:10.1016/j.ijmultiphaseflow.2025.105173](https://doi.org/10.1016/j.ijmultiphaseflow.2025.105173).

Public [OLGA core](https://www.software.slb.com/products/olga/olga-solids-management/core-system) and [LedaFlow](https://kongsbergdigital.com/hubfs/Content/Images/Simulation/pdf/202506%20LedaFlow%20PS.pdf?hsLang=en) capability descriptions were used only to prioritize three-phase/transient use cases in #2907.

## Validation

New analytical regression matrix:

- 3 diameters: 0.05, 0.10, 0.30 m
- 3 liquid holdups: 0.80, 0.95, and `1 - 1e-8`
- 4 slips: -1.0, -0.10, +0.10, +1.0 m/s
- 36 nearby points spanning both Schiller-Naumann and constant-`C_D` branches
- force agreement within `1e-12` relative
- exact zero at zero slip and absent gas
- odd force sign under reversed slip
- finite, monotone disappearance with gas holdup
- pipe-diameter scaling follows area and `d_b`, not an extra `D`

Local results:

- `InterfacialFrictionTest` — 2/2 passed on the exact rebased tree
- complete `twophasepipe` package selection — 352 tests passed, 17 existing skips
- broader pipeline, boundary, phase-degeneracy, literature, mass-balance and virtual-mass selection — 139 tests passed
- direct affected-source compilation with `--release 8` — passed before and after rebase
- `python devtools/run_spotless.py apply` — passed, clean repeat; repeated after rebase
- `python devtools/run_spotless.py check` — passed after rebase
- `python devtools/check_documentation_search.py` — passed for 646 Markdown pages and one standalone HTML page
- `pre-commit run --all-files --hook-stage pre-commit` — passed after rebase
- `pre-commit run --all-files --hook-stage pre-push` — passed after rebase
- `git diff --check` — passed
- exact connector comparison: one commit ahead, zero behind; four intended files only

The broad 352/139 selections ran before the final non-overlapping master advance from #2893; that advance changed only `OnePhasePipeLine` files. The exact rebased head reran the focused analytical tests, Java 8 source compilation, Spotless, documentation, pre-commit and pre-push gates. Hosted exact-head CI remains authoritative for the full repository matrix.

Environment: NeqSim 3.17.0 source; OpenJDK 17.0.19; Maven 3.9.12; Java 8 source target checked through the compiler module.

## Compatibility and numerical behavior

- Public API: unchanged.
- Serialization/copy/thread-safety: unchanged; no field or mutable state added.
- Determinism/repeated RHS: unchanged; closure remains a pure algebraic function of supplied state.
- Mass and energy equations: unchanged.
- Momentum: the gas/liquid interfacial sources remain equal and opposite; only the declared dispersed-bubble force magnitude is corrected.
- Performance: no allocation or asymptotic cost change.
- Other flow regimes: bitwise unchanged.

## Documentation impact

Updated both user-facing TwoFluidPipe model guides to state the force equation, SI units, equivalent shear representation, continuous-phase density, tested range, bubble-size assumptions, and the explicit non-equivalence limitation. No notebook or executable example changed, so notebook execution/render gates are not applicable.

## Overlap and next dependency

Fresh searches immediately before publication found no open issue or PR for `InterfacialFriction`, bubble drag, or this Schiller-Naumann dimensional defect. #2892 had just merged and changes virtual-mass stage purity, not this closure.

After this PR merges, the next P0 target in #2907 is making bubble diameter/surface-tension provenance configurable and phase-property-aware, with public-data validation before broad bubbly-flow accuracy claims.