### PR TITLE
[AI-Assisted] Add process diagram topology equivalence fixtures

### DIFF
--- a/docs/process/processmodel/diagram_export.md
+++ b/docs/process/processmodel/diagram_export.md
@@ -33,6 +33,24 @@ The existing DOT and DEXPI exporters have not yet been migrated to consume this 
 migration is complete, this adapter is a shared topology contract rather than a new rendering or
 standards-conformance claim.
 
+### Topology-equivalence reference cases
+
+`ProcessDiagramTopologyEquivalenceTest` is the executable baseline for comparing the runnable
+`ProcessGraph`, the canonical `EngineeringGraph`, and the current DOT projections. It fixes the
+expected directed connectivity for three deliberately small cases:
+
+- a simple feed, heater, and cooler train;
+- a branched train with two distinct parallel material streams and a recycle loop; and
+- one semantic plant containing upstream and downstream `ProcessSystem` areas joined by a live
+  cross-area stream.
+
+Equivalence is semantic rather than text-identical. In particular, the legacy Graphviz view may
+retain a named stream as an explicit intermediate node while the canonical graph represents the
+same physical connection directly between equipment ports. The reference tests require the same
+directional path and multiplicity, including both parallel branches, without changing the existing
+DOT serialization. These cases are topology fixtures only; they do not qualify layout, symbols,
+drawing metadata, DEXPI round trips, or ISO 10628 conformance.
+
 ## Quick Start
 
 ```java

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramTopologyEquivalenceTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramTopologyEquivalenceTest.java
@@ -1,0 +1,219 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringNode;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.splitter.Splitter;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessModelGraphvizExporter;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.processmodel.graph.ProcessEdge;
+import neqsim.process.processmodel.graph.ProcessGraph;
+import neqsim.process.processmodel.graph.ProcessGraphBuilder;
+import neqsim.thermo.system.SystemSrkEos;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Golden topology-equivalence cases shared by canonical and legacy diagram projections. */
+class ProcessDiagramTopologyEquivalenceTest {
+
+  @Test
+  void simpleTrainHasEquivalentCanonicalAndDotTopology(@TempDir Path tempDir) throws IOException {
+    Stream feed = createFeed("feed");
+    Heater heater = new Heater("heater", feed);
+    Cooler cooler = new Cooler("cooler", heater.getOutletStream());
+    ProcessSystem process = new ProcessSystem("simple train");
+    process.add(feed);
+    process.add(heater);
+    process.add(cooler);
+
+    List<String> expected = sorted("feed->heater|false", "heater->cooler|false");
+
+    assertSystemTopology(expected, expected, process, "GOLDEN-SIMPLE", tempDir.resolve("simple.dot"));
+  }
+
+  @Test
+  void parallelRecycleTrainHasEquivalentCanonicalAndDotTopology(@TempDir Path tempDir) throws IOException {
+    Stream feed = createFeed("branch feed");
+    feed.run();
+    Splitter splitter = new Splitter("branch splitter", feed);
+    splitter.setSplitFactors(new double[] { 0.4, 0.6 });
+    splitter.run();
+    StreamInterface firstBranch = splitter.getSplitStream(0);
+    StreamInterface secondBranch = splitter.getSplitStream(1);
+    Mixer branchMixer = new Mixer("branch mixer");
+    branchMixer.addStream(firstBranch);
+    branchMixer.addStream(secondBranch);
+
+    Stream tear = new Stream("tear seed", feed.getThermoSystem().clone());
+    Mixer loopMixer = new Mixer("loop mixer");
+    loopMixer.addStream(branchMixer.getOutletStream());
+    loopMixer.addStream(tear);
+    Separator separator = new Separator("loop separator", loopMixer.getOutletStream());
+    Recycle recycle = new Recycle("liquid recycle");
+    recycle.addStream(separator.getLiquidOutStream());
+    recycle.setOutletStream(tear);
+
+    ProcessSystem process = new ProcessSystem("parallel recycle train");
+    process.add(feed);
+    process.add(splitter);
+    process.add(branchMixer);
+    process.add(tear);
+    process.add(loopMixer);
+    process.add(separator);
+    process.add(recycle);
+
+    List<String> expected = sorted("branch feed->branch splitter|false", "branch splitter->branch mixer|false",
+        "branch splitter->branch mixer|false", "branch mixer->loop mixer|false", "liquid recycle->tear seed|true",
+        "liquid recycle->loop mixer|true", "loop mixer->loop separator|false", "loop separator->liquid recycle|true");
+
+    // The legacy Graphviz view retains the tear stream as an explicit node, so its two-hop
+    // liquid recycle -> tear seed -> loop mixer projection is equivalent to the canonical
+    // physical connection liquid recycle -> loop mixer.
+    List<String> legacyExpected = sorted("branch feed->branch splitter|false", "branch splitter->branch mixer|false",
+        "branch splitter->branch mixer|false", "branch mixer->loop mixer|false", "liquid recycle->tear seed|true",
+        "tear seed->loop mixer|false", "loop mixer->loop separator|false", "loop separator->liquid recycle|true");
+
+    assertSystemTopology(expected, legacyExpected, process, "GOLDEN-RECYCLE", tempDir.resolve("parallel-recycle.dot"));
+  }
+
+  @Test
+  void multiAreaPlantHasOneEquivalentPlantWideTopology() {
+    Stream feed = createFeed("upstream feed");
+    Heater upstreamHeater = new Heater("upstream heater", feed);
+    ProcessSystem upstream = new ProcessSystem("upstream system");
+    upstream.add(feed);
+    upstream.add(upstreamHeater);
+
+    Heater downstreamHeater = new Heater("downstream heater", upstreamHeater.getOutletStream());
+    ProcessSystem downstream = new ProcessSystem("downstream system");
+    downstream.add(downstreamHeater);
+
+    ProcessModel plant = new ProcessModel();
+    plant.add("Upstream", upstream);
+    plant.add("Downstream", downstream);
+
+    List<String> expected = sorted("upstream feed->upstream heater|false", "upstream heater->downstream heater|false");
+    EngineeringGraph canonical = ProcessDiagramGraphAdapter.fromProcessModel(plant, "GOLDEN-MULTI", "A").getGraph();
+
+    assertEquals(expected, canonicalConnections(canonical));
+    assertEquals(2, countNodeKind(canonical, EngineeringNode.Kind.AREA));
+
+    ProcessModelGraphvizExporter graphviz = new ProcessModelGraphvizExporter(plant);
+    String combinedDot = graphviz.toDot();
+    assertTrue(combinedDot.contains("\"Upstream::upstream feed\" -> \"Upstream::upstream heater\""));
+    assertTrue(combinedDot.contains("\"Upstream::upstream heater\" -> \"Downstream::downstream heater\""));
+    assertEquals(Arrays.asList("Upstream", "Downstream"), new ArrayList<String>(graphviz.toAreaDots().keySet()));
+    assertDotContainsConnections(graphviz.toAreaDots().get("Upstream"), sorted("upstream feed->upstream heater|false"));
+  }
+
+  private static void assertSystemTopology(List<String> expected, List<String> legacyExpected, ProcessSystem process,
+      String plantId, Path legacyDotPath) throws IOException {
+    ProcessGraph executionGraph = ProcessGraphBuilder.buildGraph(process);
+    EngineeringGraph canonical = ProcessDiagramGraphAdapter.fromProcessSystem(process, plantId, "A").getGraph();
+
+    assertEquals(expected, processConnections(executionGraph));
+    assertEquals(expected, canonicalConnections(canonical));
+    assertDotContainsConnections(process.toDOT(), expected);
+
+    process.exportToGraphviz(legacyDotPath.toString());
+    String legacyDot = new String(Files.readAllBytes(legacyDotPath), StandardCharsets.UTF_8);
+    assertDotContainsConnections(legacyDot, legacyExpected);
+  }
+
+  private static List<String> processConnections(ProcessGraph graph) {
+    List<String> connections = new ArrayList<String>();
+    for (ProcessEdge edge : graph.getEdges()) {
+      connections.add(connectionKey(edge.getSource().getName(), edge.getTarget().getName(), edge.isRecycle()));
+    }
+    Collections.sort(connections);
+    return connections;
+  }
+
+  private static List<String> canonicalConnections(EngineeringGraph graph) {
+    List<String> connections = new ArrayList<String>();
+    for (EngineeringNode node : graph.getNodes().values()) {
+      if (node.getKind() != EngineeringNode.Kind.PIPE_SEGMENT) {
+        continue;
+      }
+      connections.add(connectionKey(String.valueOf(node.getProperties().get("sourceEquipment")),
+          String.valueOf(node.getProperties().get("targetEquipment")),
+          Boolean.TRUE.equals(node.getProperties().get("recycle"))));
+    }
+    Collections.sort(connections);
+    return connections;
+  }
+
+  private static void assertDotContainsConnections(String dot, List<String> expected) {
+    Map<String, Integer> requiredCounts = new LinkedHashMap<String, Integer>();
+    for (String expectedConnection : expected) {
+      String pair = expectedConnection.substring(0, expectedConnection.lastIndexOf('|'));
+      Integer count = requiredCounts.get(pair);
+      requiredCounts.put(pair, Integer.valueOf(count == null ? 1 : count.intValue() + 1));
+    }
+    for (Map.Entry<String, Integer> entry : requiredCounts.entrySet()) {
+      String[] endpoints = entry.getKey().split("->", -1);
+      String edgeToken = "\"" + endpoints[0] + "\" -> \"" + endpoints[1] + "\"";
+      assertTrue(countOccurrences(dot, edgeToken) >= entry.getValue().intValue(),
+          "DOT projection lost expected connection " + entry.getKey());
+    }
+  }
+
+  private static int countOccurrences(String text, String token) {
+    int count = 0;
+    int offset = 0;
+    while ((offset = text.indexOf(token, offset)) >= 0) {
+      count++;
+      offset += token.length();
+    }
+    return count;
+  }
+
+  private static int countNodeKind(EngineeringGraph graph, EngineeringNode.Kind kind) {
+    int count = 0;
+    for (EngineeringNode node : graph.getNodes().values()) {
+      if (node.getKind() == kind) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static String connectionKey(String source, String target, boolean recycle) {
+    return source + "->" + target + "|" + recycle;
+  }
+
+  private static List<String> sorted(String... values) {
+    List<String> result = new ArrayList<String>(Arrays.asList(values));
+    Collections.sort(result);
+    return result;
+  }
+
+  private static Stream createFeed(String name) {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-heptane", 0.2);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream(name, fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    return feed;
+  }
+}


### PR DESCRIPTION
## Summary

- add executable golden topology-equivalence cases for a simple train, a branched/parallel recycle train, and one multi-area plant
- compare exact directed connection multiplicity between the runnable `ProcessGraph` and the canonical `EngineeringGraph`
- verify current simulator-style DOT projections preserve each semantic path, including both parallel material branches and the cross-area connection
- document the deliberate legacy Graphviz projection in which a named recycle tear stream remains an intermediate node

## Roadmap criterion advanced

Advances #1332 Phase 0 topology-equivalence and golden-reference coverage. This is a test-and-documentation increment on top of merged #2905; it does not mark the campaign criteria complete until merge.

## Problem, basis, and engineering value

NeqSim has complementary execution, canonical engineering, legacy Graphviz, PFD-style DOT, and multi-area DOT paths. Without explicit reference cases, a topology change can silently lose a branch, recycle, or cross-area connection while each individual exporter still produces syntactically valid output.

The expected topology is derived from runnable NeqSim `ProcessSystem`/`ProcessModel` objects and the merged `ProcessGraphBuilder` + `ProcessDiagramGraphAdapter` contracts. The tests compare direction and connection multiplicity. They intentionally treat `liquid recycle -> tear seed -> loop mixer` in legacy Graphviz as semantically equivalent to the canonical equipment-level physical connection `liquid recycle -> loop mixer`.

## Scope and exclusions

Included:

- exact simple-train topology
- two distinct parallel splitter-to-mixer material connections
- a closed recycle path
- one plant-wide cross-area connection
- `ProcessSystem` and multi-area `ProcessModel`
- existing DOT and canonical graph projections

Deliberately excluded:

- renderer migration to consume the canonical graph
- symbol, routing, sheet, document, revision, title-block, or off-page connector qualification
- DEXPI graphical/document round trips
- P&ID engineering inference
- any ISO 10628 conformance claim

No production class or public API changes are made. Existing DOT serialization is unchanged.

## Validation

- test-first failure reproduced the legacy tear-stream projection difference before the equivalence rule was encoded
- 81 focused and proportionate broader tests passed, 1 skipped:
  - `ProcessDiagramTopologyEquivalenceTest`
  - `ProcessDiagramGraphAdapterTest`
  - `ProcessGraphParallelConnectionsTest`
  - `ProcessDiagramExporterTest`
  - `ProcessSystemGraphvizExportTest`
  - `ProcessModelSerializationTest`
  - `Dexpi20ProcessModelWriterTest`
  - `DexpiTopologyResolverTest`
- `python devtools/run_spotless.py apply` repeated until stable
- `python devtools/run_spotless.py check` passed
- `python devtools/check_documentation_search.py` passed (646 Markdown pages, 1 standalone HTML page)
- pre-commit stage passed
- pre-push stage passed
- `git diff --check` passed

## Units, provenance, and approval boundary

The fixtures use kg/hr, bara, and kelvin-compatible NeqSim thermodynamic inputs only to instantiate runnable stream objects; assertions concern semantic topology, not numerical process performance. Model provenance is the in-test NeqSim object graph at revision `A`. Outputs remain calculated topology evidence requiring review and are not discipline-approved engineering drawings.

## Documentation impact

Updated `docs/process/processmodel/diagram_export.md` with the three reference cases, the semantic-equivalence rule, and explicit qualification exclusions. No new documentation page or reference-manual index entry is required.

## Limitations and next increment

These cases establish topology baselines, not visual or exchange qualification. After this PR merges, the next dependency-ready increment is to make the topology reference manifest reusable by DEXPI 2.0 Process export/import semantic-equivalence tests while retaining structured loss diagnostics and the separate Proteus/P&ID workflow.

Relates to #1332.
Coordinates with #2899; no Proteus/P&ID workflow is changed.