### PR TITLE
Add dynamic capability and transient step contracts

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-dynamic-simulation
 description: "Dynamic simulation guidance for NeqSim. USE WHEN: running transient simulations, modeling startup/shutdown, tuning PID controllers, analyzing pressure/level dynamics, performing blowdown/depressurization, or setting up measurement devices and control loops. Covers runTransient, DynamicProcessHelper, controller tuning, and dynamic equipment configuration."
-last_verified: "2026-08-03"
+last_verified: "2026-08-10"
 ---
 
 # Dynamic Simulation Guidance
@@ -43,7 +43,7 @@ Each timestep:
    Steady-state algebraic equipment still evaluates on every requested pass,
    but its local clock advances once per non-null timestep calculation identifier.
    Reusing an identifier may refine a recycle without advancing physical time;
-   use a new identifier for the next timestep.
+   use a new identifier for the next physical timestep.
 4. Standalone controllers run; controllers actually executed inside equipment
    retain their equipment-specific timing for compatibility. Execution is
    coalesced by object identity and the timestep calculation identifier. Merely
@@ -54,6 +54,21 @@ Each timestep:
    integrated by equipment must implement the same identifier contract through
    `hasRunTransient(UUID)`.
 5. Measurement devices are sampled, alarms are evaluated, and history is stored.
+
+A non-null UUID therefore identifies **one physical timestep**, not an entire
+outer time-marching simulation. Refinements of that physical step reuse the
+same physical-step UUID; the next accepted physical step must use a different
+UUID. For ordinary loops `runTransient()` is safe because it creates a fresh
+UUID each call. Deterministic safety/OTS workflows can use
+`TransientStepIdentifier.deterministicPhysicalStep(scope, stepIndex)`.
+
+`ProcessSystem.runTransientAdaptive(...)` is **not yet a transactional adaptive
+integrator**. The current implementation validates the request, advances trial
+state directly, estimates a temperature-change heuristic, and chooses a
+subsequent timestep. It does not yet provide rejected-step process/event/control
+rollback or a full-step versus two-half-step error estimate. Do not use it as
+evidence of qualified stiff/adaptive professional dynamics until the #2911
+transactional-step work is complete.
 
 ## Basic Dynamic Setup
 
@@ -216,10 +231,11 @@ LC100.setReverseActing(false);                 // liquid-outlet level valve = di
 LC100.setControllerParameters(1.0, 300.0, 0.0); // averaging level: loose Kp, long Ti, no Td
 liqValve.addController("LC-100", LC100);
 
-// 5. Advance the transient with a fixed time step.
-java.util.UUID id = java.util.UUID.randomUUID();
-for (int i = 0; i < 600; i++) {
-  process.runTransient(1.0, id);   // dt = 1 s
+// 5. Advance the transient with a fresh physical-step identity each step.
+for (long step = 0; step < 600; step++) {
+  java.util.UUID physicalStepId =
+      neqsim.process.dynamics.TransientStepIdentifier.deterministicPhysicalStep("level-loop", step);
+  process.runTransient(1.0, physicalStepId);   // dt = 1 s
 }
 ```
 
@@ -232,6 +248,9 @@ for (int i = 0; i < 600; i++) {
   reduces the measured value (e.g. a controller manipulating an inlet/feed valve).
 - **Set `setLiquidLevel` after `run()`** — a steady-state solve resets the level,
   so set the starting level and geometry after the first `run()`.
+- **One UUID per physical step** — do not create one UUID before the outer time
+  loop and reuse it. Built-in controllers/equipment intentionally treat repeated
+  calls with one UUID as refinements of the same physical timestep.
 - For an averaging level loop, use a loose `Kp` and long `Ti` (see the tuning
   table) and consider an SP-PV deadband only with care (see the limit-cycle note
   above).
@@ -527,29 +546,31 @@ TransferFunctionBlock leadLag = new TransferFunctionBlock();
 
 1. **Always run steady state first**: Call `process.run()` before `runTransient()`
 2. **Timestep size**: Start with 1.0 s, reduce if oscillating (0.1-0.5 s)
-3. **Reverse acting**: Level controllers are usually reverse-acting (level up = open valve)
+3. **Liquid-outlet level-controller direction**: use `setReverseActing(false)` so level up drives the outlet valve further open. Reverse acting on this configuration drives the loop the wrong way.
 4. **Controller windup**: Large setpoint changes can cause integral windup
 5. **Separator dimensions**: Must set `setInternalDiameter()` and `setSeparatorLength()` for meaningful level dynamics. For dynamic simulation, set directly on the separator; for design purposes, configure via `SeparatorMechanicalDesign` (see neqsim-api-patterns skill)
 6. **Measurement range**: Set min/max on transmitters to match process range
 7. **Enable dynamic (inventory) mode for level loops**: after `process.run()` (steady), call `setCalculateSteadyState(false)` on the separator AND every valve, then `separator.setLiquidLevel(startFraction)`, before `runTransient`. If steady-state mode is left on, the separator liquid level stays pinned at its default (0.5) and the level controller never acts. The valve `Cv` is auto-derived from the steady solve. A **liquid-outlet** level valve is `setReverseActing(false)` (level up -> valve opens); put a pressure controller on the gas-outlet valve so the vessel pressure is held and the level loop is isolated.
-
+8. **Physical-step UUIDs**: never reuse one non-null UUID across multiple outer timesteps. Reuse is reserved for refinement/evaluation of one physical step.
 
 ## Pluggable Integrator Strategies
 
-Beyond the default fixed-step explicit-Euler loop, `ProcessSystem` accepts a
-pluggable `IntegratorStrategy`. Implementations live in `neqsim.process.dynamics`:
+`ProcessSystem` accepts a pluggable `IntegratorStrategy`, but this hook does not
+by itself make the complete flowsheet a stiff vector ODE/DAE system. Implementations
+live in `neqsim.process.dynamics`:
 
 | Strategy | Class | Notes |
 |----------|-------|-------|
 | Explicit Euler | `ExplicitEulerIntegrator` | Default; fast, conditionally stable |
-| BDF-1 (Implicit Euler) | `BDFIntegrator` | Newton + FD Jacobian (tol 1e-8, maxIter 25). Falls back to explicit Euler if Newton diverges; check `lastStepFellBack()` |
+| BDF-1 (Implicit Euler) | `BDFIntegrator` | Experimental local strategy. Newton + FD Jacobian; can fall back to explicit Euler when Newton diverges. Inspect `lastStepFellBack()` and do not treat fallback runs as qualified stiff/DAE evidence. |
 
 ```java
 import neqsim.process.dynamics.BDFIntegrator;
 import neqsim.process.dynamics.ExplicitEulerIntegrator;
 import neqsim.process.dynamics.IntegratorStrategy;
 
-process.setIntegratorStrategy(new BDFIntegrator());   // stiff dynamics
+BDFIntegrator bdf = new BDFIntegrator();
+process.setIntegratorStrategy(bdf);
 // process.setIntegratorStrategy(new ExplicitEulerIntegrator()); // explicit default
 // process.setIntegratorStrategy(null);  // reset to default ExplicitEulerIntegrator
 IntegratorStrategy current = process.getIntegratorStrategy();
@@ -558,12 +579,15 @@ IntegratorStrategy current = process.getIntegratorStrategy();
 For multi-area plants the strategy is propagated to every child area:
 `plant.setIntegratorStrategy(new BDFIntegrator())`.
 
+A professional stiff-solver acceptance path must fail loudly or expose explicit
+fallback diagnostics; silent fallback is not an acceptable qualification result.
+
 ## Event Scheduling (ESD, IOA, setpoint changes)
 
 Time-stamped events (ESD trips, valve closures, setpoint ramps) are managed by
-`EventScheduler` in `neqsim.process.dynamics`. Every call to
-`runTransient(dt, id)` fires events with `time <= currentTime` at the top of
-the step, before equipment runs.
+`EventScheduler` in `neqsim.process.dynamics`. `ProcessSystem.runTransient(dt, id)`
+advances the process clock, then fires events with `time <= currentTime` before
+equipment runs.
 
 ```java
 import neqsim.process.dynamics.EventScheduler;
@@ -578,12 +602,30 @@ events.scheduleEvent(300.0, "Setpoint ramp", new Runnable() {
 process.setEventScheduler(events);
 
 for (int i = 0; i < nSteps; i++) {
-  process.runTransient(dt);   // due events fire automatically
+  process.runTransient(dt);   // fresh physical-step ID; due events fire automatically
 }
 
 int fired = events.getFiredEvents().size();
 int pending = events.getPendingEvents().size();
 ```
+
+For event-aware/adaptive work, inspect event state without mutating it and
+checkpoint scheduler bookkeeping explicitly:
+
+```java
+EventScheduler.Snapshot eventState = events.snapshot();
+double nextEventTime = events.getNextEventTime();
+java.util.List<EventScheduler.ScheduledEvent> due = events.getDueEvents(process.getTime());
+
+// If a trial is rejected, restore pending/fired membership.
+events.restore(eventState);
+```
+
+`restore(...)` restores only scheduler pending/fired membership. It cannot undo
+an already executed `Runnable` side effect. A rejected trial must defer external
+actions until acceptance or restore every object those actions mutate as part of
+the same transaction. This is required before safety/OTS event replay can be
+called transactional.
 
 For multi-area plants install the scheduler once on the `ProcessModel`; it is
 propagated to every child area, and `plant.runTransient(dt, id)` advances all
@@ -597,6 +639,8 @@ plant.runTransient(dt, java.util.UUID.randomUUID());
 **Note**: `EventScheduler` is declared `transient` on `ProcessSystem` because
 event `Runnable` payloads (lambdas, anonymous classes) are usually not
 serializable. Re-install the scheduler after deserialising a saved process.
+`EventScheduler.Snapshot` itself can be serialized when its event actions are
+serializable, which is useful for explicit checkpoint/restart coordination.
 
 ## New Measurement Devices (v3.11)
 

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -49,6 +49,32 @@ requested dynamic path.
 but is currently left in its steady-state/algebraic mode. This is not automatically wrong. Mixed algebraic/dynamic
 flowsheets are normal, but the list makes the modelling choice explicit for engineering review.
 
+## Strict transient preflight
+
+The report also provides an explicit, opt-in preflight for workflows that must not continue with unaudited custom
+transient implementations:
+
+```java
+DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+
+if (!report.isStrictPreflightReady()) {
+  for (String issue : report.getStrictPreflightIssues()) {
+    logger.warn("Dynamic preflight: {}", issue);
+  }
+}
+
+report.assertStrictTransientReady();
+```
+
+Strict preflight combines known unsupported runtime configurations with `UNCLASSIFIED_DYNAMIC` review items. It does
+**not** reject an audited dynamic unit merely because the unit is intentionally left in steady-state mode. The preflight
+is not automatically called by `runTransient(...)`; it is an explicit qualification gate so existing transient APIs and
+mixed algebraic/dynamic models remain backwards compatible.
+
+Passing strict preflight only means that the capability audit found no known unsupported configuration or unaudited
+custom transient method. It does not establish conservation accuracy, timestep independence, pressure-flow correctness,
+control/safety fidelity, OTS real-time performance, or engineering approval.
+
 ## Inspect a ProcessModel
 
 ```java
@@ -64,6 +90,28 @@ Multi-area reports preserve the process-area identity so identical equipment or 
 collapse into one audit entry. Controllers attached directly to equipment are included and de-duplicated by object
 identity if they are also registered as standalone controllers.
 
+## Nested process modules
+
+`DynamicCapabilityReport` recursively inspects initialized `ModuleInterface` contents instead of stopping at the module
+container. Nested entries retain a deterministic container path:
+
+```text
+separation train::Inlet separator
+topside::separation train::HP gas scrubber
+```
+
+The module container itself remains visible in the report. Current `ProcessModuleBaseClass.runTransient(...)` delegates
+to its internal `ProcessSystem`, but the campaign has not yet qualified all module-level initialization, state ownership,
+restart, error propagation, or nested transient semantics; modules therefore remain reviewable according to their own
+capability classification while their instantiated child operations are audited independently.
+
+The report never initializes a module as a side effect. A module whose internal `ProcessSystem` has not yet been built
+can only expose the container at audit time. Initialize/build the module through its normal model lifecycle before using
+the report as a complete nested-unit inventory.
+
+Identity-based de-duplication prevents the same process element or nested `ProcessSystem` object from being counted
+repeatedly and prevents accidental recursive container cycles from causing unbounded traversal.
+
 ## Initial audited mapping
 
 The initial contract intentionally classifies only core implementations whose current source contains clear stored-state
@@ -75,9 +123,9 @@ semantics:
 - control: registered controllers and measurement devices.
 
 `Stream` and stream subclasses that inherit the standard `Stream.runTransient(...)` boundary are classified as
-`ALGEBRAIC`: that method re-evaluates the stream and advances its execution clock, but does not integrate stored
-physical state. A stream subclass that provides its own transient override remains `UNCLASSIFIED_DYNAMIC` until its
-state and equations are audited.
+`ALGEBRAIC`: that method re-evaluates the stream and advances its execution clock, but does not integrate stored physical
+state. A stream subclass that provides its own transient override remains `UNCLASSIFIED_DYNAMIC` until its state and
+equations are audited.
 
 Other custom transient implementations remain `UNCLASSIFIED_DYNAMIC` until their state variables, conservation equations,
 initialization, timestep constraints, event behaviour, snapshot/restart semantics, and quantitative validation are
@@ -90,6 +138,6 @@ dynamics. In particular, it does not add global pressure-flow residual assembly,
 rejection/rollback, event localization, or multi-rate pipeline subcycling. Those capabilities build on this contract so
 the solver can reason explicitly about which objects own dynamic state and which objects are algebraic constraints.
 
-The report also does not certify that a model is suitable for a control, relief, HIPPS/SIS, HAZOP, DEXPI/P&ID, or other
-safety-critical study. Those studies require scenario-specific modelling, validation evidence, engineering limits, and
-appropriate review.
+The report also does not certify that a model is suitable for a control, relief, HIPPS/SIS, HAZOP, DEXPI/P&ID, virtual
+commissioning, OTS, or other safety-critical study. Those studies require scenario-specific modelling, validation
+evidence, engineering limits, deterministic timing/replay evidence where applicable, and appropriate review.

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -34,8 +34,10 @@ import neqsim.process.dynamics.DynamicCapabilityReport;
 DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
 
 report.getCapabilityCounts();
+report.getActivationCounts();
 report.getBlockingIssues();
 report.getReviewItems();
+report.getUnverifiedActivationElements();
 report.getInactiveAuditedDynamicElements();
 String json = report.toJson();
 ```
@@ -49,10 +51,43 @@ requested dynamic path.
 but is currently left in its steady-state/algebraic mode. This is not automatically wrong. Mixed algebraic/dynamic
 flowsheets are normal, but the list makes the modelling choice explicit for engineering review.
 
+## Runtime activation is separate from state ownership
+
+`DynamicCapability` answers **what kind of state an implementation can own**. `DynamicActivationStatus` answers a
+different question: **is that stateful path actually active for this runtime configuration?** Keeping these dimensions
+separate prevents a `DYNAMIC_LUMPED` or `DYNAMIC_DISTRIBUTED` label from being mistaken for proof that the current case is
+executing the state equations.
+
+| Activation status | Meaning |
+|---|---|
+| `NOT_APPLICABLE` | The audited element is algebraic and has no independent stateful path to activate. |
+| `ACTIVE` | A type-specific audit verifies that the current configuration selects the stateful path. |
+| `INACTIVE` | A type-specific audit verifies that the current configuration selects a non-stateful path. |
+| `INCOMPLETE_CONFIGURATION` | Dynamic execution is requested or inherent, but a required physical/runtime prerequisite is missing. |
+| `UNVERIFIED` | The element owns audited state, but its runtime activation rules have not yet been audited explicitly. |
+
+Activation is intentionally type-specific rather than inferred from `calculateSteadyState` alone. Current audited
+examples illustrate why:
+
+- `HeatExchanger` enters its wall-energy transient path only when `dynamicModelEnabled` is true and both wall mass and
+  heat-transfer area are positive. Requesting dynamic mode while those prerequisites are missing is reported as
+  `INCOMPLETE_CONFIGURATION` and blocks strict preflight.
+- `BatteryStorage.runTransient(...)` always evaluates stored-energy and ramped-power state. A positive storage capacity
+  is therefore an activation prerequisite, while the inherited `calculateSteadyState` flag does not decide whether the
+  battery state is integrated.
+- `Expander` uses `calculateSteadyState` directly: true selects algebraic expansion thermodynamics for the timestep;
+  false activates nozzle-position, recovered-power and shaft-speed/inertia state integration.
+
+Other state-owning families remain `UNVERIFIED` until their actual runtime branch conditions and physical prerequisites
+are audited. `UNVERIFIED` is visible through `getUnverifiedActivationElements()` but is not yet a strict-preflight failure;
+this lets the Phase-0 inventory improve incrementally without silently promoting generic flags to engineering evidence.
+Activation status is also not quantitative maturity: an `ACTIVE` implementation can still lack conservation,
+timestep/mesh, benchmark, safety or OTS qualification.
+
 ## Strict transient preflight
 
-The report also provides an explicit, opt-in preflight for workflows that must not continue with unaudited custom
-transient implementations:
+The report also provides an explicit, opt-in preflight for workflows that must not continue with known unsupported,
+incompletely configured, or unaudited custom transient implementations:
 
 ```java
 DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
@@ -66,14 +101,15 @@ if (!report.isStrictPreflightReady()) {
 report.assertStrictTransientReady();
 ```
 
-Strict preflight combines known unsupported runtime configurations with `UNCLASSIFIED_DYNAMIC` review items. It does
-**not** reject an audited dynamic unit merely because the unit is intentionally left in steady-state mode. The preflight
-is not automatically called by `runTransient(...)`; it is an explicit qualification gate so existing transient APIs and
-mixed algebraic/dynamic models remain backwards compatible.
+Strict preflight combines known unsupported runtime configurations, type-specific `INCOMPLETE_CONFIGURATION` activation
+findings, and `UNCLASSIFIED_DYNAMIC` review items. It does **not** reject an audited dynamic unit merely because the unit
+is intentionally inactive, and it does not yet reject a state-owning family solely because activation remains
+`UNVERIFIED`. The preflight is not automatically called by `runTransient(...)`; it is an explicit qualification gate so
+existing transient APIs and mixed algebraic/dynamic models remain backwards compatible.
 
-Passing strict preflight only means that the capability audit found no known unsupported configuration or unaudited
-custom transient method. It does not establish conservation accuracy, timestep independence, pressure-flow correctness,
-control/safety fidelity, OTS real-time performance, or engineering approval.
+Passing strict preflight only means that the capability audit found no currently known unsupported/incomplete
+configuration or unaudited custom transient method. It does not establish conservation accuracy, timestep independence,
+pressure-flow correctness, control/safety fidelity, OTS real-time performance, or engineering approval.
 
 ## Physical-step versus refinement identity
 
@@ -156,8 +192,8 @@ semantics:
 
 - algebraic: standard `Stream` execution, composite module containers, `EnergyNetworkSolver`, ISO-5167 `Orifice`, and
   `WellFlow` IPR pressure-flow relations;
-- lumped: separators, tanks, two-stream heat exchangers, compressors, pumps, throttling/control valves, and
-  `EnergyConverter`-based motors/generators/gearboxes/inverters/transformers;
+- lumped: separators, tanks, two-stream heat exchangers, compressors/expanders, pumps, throttling/control valves,
+  `EnergyConverter`-based motors/generators/gearboxes/inverters/transformers, and `BatteryStorage`;
 - distributed: `OnePhasePipeLine`, `TwoFluidPipe`, drift-flux `TransientPipe`, and `WaterHammerPipe`;
 - boundary: `SimpleReservoir`;
 - control: registered controllers and measurement devices.
@@ -175,6 +211,16 @@ identifier recompute from the output that existed at the start of that step, so 
 second time or advance the converter clock again. A new physical-step identifier captures the previously accepted output
 as the next step's starting state. Infinite ramp rate remains a memoryless runtime configuration, illustrating why state
 ownership and runtime activation/maturity are separate dimensions.
+
+`BatteryStorage` owns stored electrical energy in Wh plus the ramp-limited converter-power state. Same-ID refinement
+restores both values to physical-step start before recomputation. Runtime activation is independent of the inherited
+generic steady-state flag; a non-positive storage capacity is instead surfaced as incomplete configuration by the
+activation audit. This classification is an execution/state-ownership statement, not an electrochemical-fidelity claim.
+
+`Expander` owns nozzle/guide-vane position, ramped recovered shaft power and rotor speed/inertia when its dynamic branch
+is selected. Same-ID refinement restores those states to physical-step start before re-solving the same timestep. With
+`calculateSteadyState=true`, the expander performs the algebraic thermodynamic calculation without integrating those
+states, so the activation report records the stateful path as inactive.
 
 `Stream` and stream subclasses that inherit the standard `Stream.runTransient(...)` boundary are classified as
 `ALGEBRAIC`: that method re-evaluates the stream and advances its execution clock, but does not integrate stored physical

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -3,8 +3,6 @@ title: Dynamic capability contract
 description: Machine-readable classification and audit of algebraic, lumped, distributed, boundary, and control-system transient behaviour in ProcessSystem and ProcessModel.
 ---
 
-# Dynamic capability contract
-
 NeqSim distinguishes **participation in a transient flowsheet** from **having audited dynamic state**. This is important
 because an algebraic unit operation can be re-evaluated at every physical timestep without containing inventory, inertia,
 or another state that is integrated through time.

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -1,0 +1,92 @@
+---
+title: Dynamic capability contract
+description: Machine-readable classification and audit of algebraic, lumped, distributed, boundary, and control-system transient behaviour in ProcessSystem and ProcessModel.
+---
+
+# Dynamic capability contract
+
+NeqSim distinguishes **participation in a transient flowsheet** from **having audited dynamic state**. This is important
+because an algebraic unit operation can be re-evaluated at every physical timestep without containing inventory, inertia,
+or another state that is integrated through time.
+
+The capability contract is a Phase-0 foundation for professional dynamic simulation on both `ProcessSystem` and
+multi-area `ProcessModel`. It is diagnostic metadata, not a claim of commercial-simulator parity, quantitative model
+validation, standards conformance, or accountable safety approval.
+
+## Capability categories
+
+| Capability | Meaning |
+|---|---|
+| `ALGEBRAIC` | No audited stored physical state. The element may still be solved as an algebraic relation at each timestep. |
+| `DYNAMIC_LUMPED` | Audited lumped state such as vessel inventory, thermal storage, actuator position, or rotating inertia. |
+| `DYNAMIC_DISTRIBUTED` | Spatially distributed transient state, for example finite-volume or method-of-characteristics pipeline state. |
+| `BOUNDARY_DYNAMIC` | Time-varying boundary/source state such as reservoir depletion or another imposed dynamic boundary. |
+| `CONTROL_DYNAMIC` | Controller, transmitter, signal, logic, or sampled control-system transient state. |
+| `UNCLASSIFIED_DYNAMIC` | A custom `runTransient` implementation exists, but its state/equations have not yet been audited. |
+| `UNSUPPORTED_DYNAMIC` | The element explicitly declares that a transient interpretation is unsupported. |
+
+`UNCLASSIFIED_DYNAMIC` is deliberately conservative. The presence of a `runTransient()` override is not sufficient
+evidence that an implementation is a physically complete dynamic model.
+
+## Inspect a ProcessSystem
+
+```java
+import neqsim.process.dynamics.DynamicCapabilityReport;
+
+DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+
+report.getCapabilityCounts();
+report.getBlockingIssues();
+report.getReviewItems();
+report.getInactiveAuditedDynamicElements();
+String json = report.toJson();
+```
+
+A normal algebraic element is **not** a blocking issue. It becomes a blocking configuration only when the caller sets
+`calculateSteadyState = false` even though the element has no audited difference-equation implementation. This catches a
+common failure mode where a flowsheet appears to be configured for dynamics but the selected unit cannot execute the
+requested dynamic path.
+
+`getInactiveAuditedDynamicElements()` has the opposite purpose: it identifies equipment that has audited dynamic state
+but is currently left in its steady-state/algebraic mode. This is not automatically wrong. Mixed algebraic/dynamic
+flowsheets are normal, but the list makes the modelling choice explicit for engineering review.
+
+## Inspect a ProcessModel
+
+```java
+DynamicCapabilityReport plantReport = DynamicCapabilityReport.from(processModel);
+
+for (DynamicCapabilityReport.Entry entry : plantReport.getEntries()) {
+  String object = entry.getQualifiedName();  // e.g. "compression::K-100"
+  DynamicCapability capability = entry.getCapability();
+}
+```
+
+Multi-area reports preserve the process-area identity so identical equipment or stream names in separate areas do not
+collapse into one audit entry. Controllers attached directly to equipment are included and de-duplicated by object
+identity if they are also registered as standalone controllers.
+
+## Initial audited mapping
+
+The initial contract intentionally classifies only core implementations whose current source contains clear stored-state
+semantics:
+
+- lumped: separators, tanks, two-stream heat exchangers, compressors, pumps, and throttling/control valves;
+- distributed: `TwoFluidPipe`, drift-flux `TransientPipe`, and `WaterHammerPipe`;
+- boundary: `SimpleReservoir`;
+- control: registered controllers and measurement devices.
+
+Other custom transient implementations remain `UNCLASSIFIED_DYNAMIC` until their state variables, conservation equations,
+initialization, timestep constraints, event behaviour, snapshot/restart semantics, and quantitative validation are
+reviewed. The mapping is expected to expand as that audit is completed.
+
+## What this does not solve
+
+This contract does not yet provide the plant-wide vector ODE/DAE solver required for strongly coupled professional
+dynamics. In particular, it does not add global pressure-flow residual assembly, sparse Jacobians, whole-model timestep
+rejection/rollback, event localization, or multi-rate pipeline subcycling. Those capabilities build on this contract so
+the solver can reason explicitly about which objects own dynamic state and which objects are algebraic constraints.
+
+The report also does not certify that a model is suitable for a control, relief, HIPPS/SIS, HAZOP, DEXPI/P&ID, or other
+safety-critical study. Those studies require scenario-specific modelling, validation evidence, engineering limits, and
+appropriate review.

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -16,7 +16,7 @@ validation, standards conformance, or accountable safety approval.
 | Capability | Meaning |
 |---|---|
 | `ALGEBRAIC` | No audited stored physical state. The element may still be solved as an algebraic relation at each timestep. |
-| `DYNAMIC_LUMPED` | Audited lumped state such as vessel inventory, thermal storage, actuator position, or rotating inertia. |
+| `DYNAMIC_LUMPED` | Audited lumped state such as vessel inventory, thermal storage, actuator position, rotating inertia, or rate-limited converter output. |
 | `DYNAMIC_DISTRIBUTED` | Spatially distributed transient state, for example finite-volume or method-of-characteristics pipeline state. |
 | `BOUNDARY_DYNAMIC` | Time-varying boundary/source state such as reservoir depletion or another imposed dynamic boundary. |
 | `CONTROL_DYNAMIC` | Controller, transmitter, signal, logic, or sampled control-system transient state. |
@@ -154,7 +154,8 @@ repeatedly and prevents accidental recursive container cycles from causing unbou
 The initial contract intentionally classifies only core implementations whose current source contains clear stored-state
 semantics:
 
-- lumped: separators, tanks, two-stream heat exchangers, compressors, pumps, and throttling/control valves;
+- lumped: separators, tanks, two-stream heat exchangers, compressors, pumps, throttling/control valves, and
+  `EnergyConverter`-based motors/generators/gearboxes/inverters/transformers;
 - distributed: `OnePhasePipeLine`, `TwoFluidPipe`, drift-flux `TransientPipe`, and `WaterHammerPipe`;
 - boundary: `SimpleReservoir`;
 - control: registered controllers and measurement devices.
@@ -165,6 +166,13 @@ component inventories and accepted-step diagnostics, and its ProcessSystem snaps
 boundedness, synchronized thermodynamic composition, clocks and calculation identifiers. The classification describes
 **distributed state ownership**, not blanket validity of every pipeline mode. Legacy staged compositional transport,
 zero/reversed flow, phase appearance and multiphase operation remain outside that evidence until separately qualified.
+
+`EnergyConverter` owns the previous useful-output state when a finite ramp rate is configured. Its transient ramp is
+therefore classified as `DYNAMIC_LUMPED`. Repeated nonlinear/refinement evaluations with the same non-null physical-step
+identifier recompute from the output that existed at the start of that step, so refinement cannot consume the ramp a
+second time or advance the converter clock again. A new physical-step identifier captures the previously accepted output
+as the next step's starting state. Infinite ramp rate remains a memoryless runtime configuration, illustrating why state
+ownership and runtime activation/maturity are separate dimensions.
 
 `Stream` and stream subclasses that inherit the standard `Stream.runTransient(...)` boundary are classified as
 `ALGEBRAIC`: that method re-evaluates the stream and advances its execution clock, but does not integrate stored physical

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -75,6 +75,40 @@ Passing strict preflight only means that the capability audit found no known uns
 custom transient method. It does not establish conservation accuracy, timestep independence, pressure-flow correctness,
 control/safety fidelity, OTS real-time performance, or engineering approval.
 
+## Physical-step versus refinement identity
+
+A non-null calculation identifier supplied to `ProcessSystem.runTransient(dt, id)` or `ProcessModel.runTransient(dt, id)`
+identifies **one physical timestep**. Stateful equipment and controllers use that identifier to prevent repeated
+algebraic/nonlinear evaluations inside the same physical timestep from advancing clocks, controller integrals or other
+mutable state more than once. Therefore:
+
+- repeated evaluations/refinements inside physical step A reuse physical-step ID A;
+- the next physical timestep uses a different physical-step ID B;
+- a fixed UUID must not be reused across an outer time-marching loop;
+- `runTransient(dt)` is safe for ordinary loops because it creates a fresh UUID for each call;
+- deterministic safety/OTS/replay workflows can use `TransientStepIdentifier.deterministicPhysicalStep(scope, index)`.
+
+```java
+import neqsim.process.dynamics.TransientStepIdentifier;
+
+for (long step = 0; step < 600; step++) {
+  java.util.UUID physicalStepId =
+      TransientStepIdentifier.deterministicPhysicalStep("startup-case-A", step);
+  process.runTransient(1.0, physicalStepId);
+}
+```
+
+Do **not** create one UUID before the loop and pass it to every timestep. That pattern can suppress later controller
+updates because built-in controller execution is idempotent for one physical-step identifier.
+
+`TransientStepIdentifier.deterministicEvaluation(physicalStepId, evaluationIndex)` provides a separate deterministic
+identity for nonlinear/refinement diagnostics. It is metadata for residual histories and solver bookkeeping; it must not
+replace the parent physical-step ID in equipment/controller `runTransient` calls. This preserves the A/refine-A/B
+contract: refinements share A for state idempotency while their diagnostic evaluations can still be distinguished.
+
+`DynamicSafetyScenarioRunner` uses deterministic physical-step identifiers derived from scenario ID and step index so a
+replayed scenario is reproducible without freezing controllers after its first timestep.
+
 ## Inspect a ProcessModel
 
 ```java

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -172,6 +172,32 @@ Other custom transient implementations remain `UNCLASSIFIED_DYNAMIC` until their
 initialization, timestep constraints, event behaviour, snapshot/restart semantics, and quantitative validation are
 reviewed. The mapping is expected to expand as that audit is completed.
 
+## Event-scheduler rollback boundary
+
+Transactional timestep rejection must restore more than process thermodynamic state. The event scheduler itself owns
+mutable bookkeeping: a due event moves from the pending queue into the fired-event log. `EventScheduler.snapshot()` and
+`restore(snapshot)` provide an explicit checkpoint for that pending/fired membership so a trial step can recover the
+scheduler state that existed before the trial.
+
+```java
+EventScheduler.Snapshot eventState = scheduler.snapshot();
+
+// trial work that may move events from pending -> fired
+
+scheduler.restore(eventState);
+```
+
+This is deliberately **not** presented as complete event rollback. Restoring scheduler membership cannot reverse an
+external side effect already performed by an event `Runnable`: a file write, network call, external DCS command, or
+mutation of an object that is not part of the separately restored process state remains observable. Therefore a qualified
+rejected adaptive trial must either defer externally visible event actions until the physical timestep is accepted, or
+execute only actions whose complete mutated state participates in the same transaction. This boundary is especially
+important for safety replay, virtual commissioning and OTS integration.
+
+The scheduler attached to `ProcessSystem` is a transient runtime service and is not automatically serialized by
+`ProcessSystem.copy()`/Java serialization. Scheduler checkpointing must therefore be coordinated explicitly by the future
+whole-step transaction boundary rather than assumed to come from the process graph copy.
+
 ## What this does not solve
 
 This contract does not yet provide the plant-wide vector ODE/DAE solver required for strongly coupled professional

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -152,9 +152,16 @@ The initial contract intentionally classifies only core implementations whose cu
 semantics:
 
 - lumped: separators, tanks, two-stream heat exchangers, compressors, pumps, and throttling/control valves;
-- distributed: `TwoFluidPipe`, drift-flux `TransientPipe`, and `WaterHammerPipe`;
+- distributed: `OnePhasePipeLine`, `TwoFluidPipe`, drift-flux `TransientPipe`, and `WaterHammerPipe`;
 - boundary: `SimpleReservoir`;
 - control: registered controllers and measurement devices.
+
+The `OnePhasePipeLine` distributed classification is supported by merged ProcessSystem-level quantitative evidence for
+the conservative one-phase, positive-flow finite-volume path: the pipeline owns spatial hydraulic/species state,
+component inventories and accepted-step diagnostics, and its ProcessSystem snapshot/event path has verified conservation,
+boundedness, synchronized thermodynamic composition, clocks and calculation identifiers. The classification describes
+**distributed state ownership**, not blanket validity of every pipeline mode. Legacy staged compositional transport,
+zero/reversed flow, phase appearance and multiphase operation remain outside that evidence until separately qualified.
 
 `Stream` and stream subclasses that inherit the standard `Stream.runTransient(...)` boundary are classified as
 `ALGEBRAIC`: that method re-evaluates the stream and advances its execution clock, but does not integrate stored physical

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -35,6 +35,7 @@ DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
 
 report.getCapabilityCounts();
 report.getActivationCounts();
+report.getExecutionIssues();
 report.getBlockingIssues();
 report.getReviewItems();
 report.getUnverifiedActivationElements();
@@ -87,7 +88,7 @@ timestep/mesh, benchmark, safety or OTS qualification.
 ## Strict transient preflight
 
 The report also provides an explicit, opt-in preflight for workflows that must not continue with known unsupported,
-incompletely configured, or unaudited custom transient implementations:
+incompletely configured, unaudited, or execution-contract-incomplete transient configurations:
 
 ```java
 DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
@@ -102,14 +103,33 @@ report.assertStrictTransientReady();
 ```
 
 Strict preflight combines known unsupported runtime configurations, type-specific `INCOMPLETE_CONFIGURATION` activation
-findings, and `UNCLASSIFIED_DYNAMIC` review items. It does **not** reject an audited dynamic unit merely because the unit
-is intentionally inactive, and it does not yet reject a state-owning family solely because activation remains
-`UNVERIFIED`. The preflight is not automatically called by `runTransient(...)`; it is an explicit qualification gate so
-existing transient APIs and mixed algebraic/dynamic models remain backwards compatible.
+findings, `UNCLASSIFIED_DYNAMIC` review items, and known process-level execution modes whose numerical/error semantics are
+not yet safe for strict professional qualification. `getExecutionIssues()` exposes those process-level findings
+separately so they are not confused with equipment state ownership or activation.
+
+Two execution modes are explicitly blocked by the current Phase-0 contract:
+
+- **parallel transient execution** is not strict-ready while equipment worker failures can be logged/swallowed instead of
+  propagating fail-loudly to abort the physical step. Disabling parallel transient execution avoids that specific worker
+  failure path, but it does not create rejected-step rollback or a whole-model transaction;
+- **adaptive transient execution** is not strict-ready while `runTransientAdaptive(...)` mutates one full timestep and
+  derives a following timestep recommendation without a full-step/two-half-step error estimate, rejected-step restore,
+  retry, and one accepted-step commit boundary.
+
+These diagnostics are collected recursively through initialized process modules and preserve `ProcessModel` area paths.
+They make current limitations explicit instead of presenting the modes as qualified transient numerics. Once the
+underlying execution semantics are repaired and quantitatively tested, the corresponding blocker should be removed
+rather than retained as a permanent policy restriction.
+
+Strict preflight does **not** reject an audited dynamic unit merely because the unit is intentionally inactive, and it
+does not yet reject a state-owning family solely because activation remains `UNVERIFIED`. The preflight is not
+automatically called by `runTransient(...)`; it is an explicit qualification gate so existing transient APIs and mixed
+algebraic/dynamic models remain backwards compatible.
 
 Passing strict preflight only means that the capability audit found no currently known unsupported/incomplete
-configuration or unaudited custom transient method. It does not establish conservation accuracy, timestep independence,
-pressure-flow correctness, control/safety fidelity, OTS real-time performance, or engineering approval.
+configuration, unqualified process execution mode, or unaudited custom transient method. It does not establish
+conservation accuracy, timestep independence, pressure-flow correctness, control/safety fidelity, OTS real-time
+performance, or engineering approval.
 
 ## Physical-step versus refinement identity
 
@@ -158,7 +178,8 @@ for (DynamicCapabilityReport.Entry entry : plantReport.getEntries()) {
 
 Multi-area reports preserve the process-area identity so identical equipment or stream names in separate areas do not
 collapse into one audit entry. Controllers attached directly to equipment are included and de-duplicated by object
-identity if they are also registered as standalone controllers.
+identity if they are also registered as standalone controllers. Process-level execution issues are area-qualified by the
+same report so an unsafe execution mode in one area does not become an untraceable plant-wide diagnostic.
 
 ## Nested process modules
 
@@ -267,8 +288,10 @@ whole-step transaction boundary rather than assumed to come from the process gra
 
 This contract does not yet provide the plant-wide vector ODE/DAE solver required for strongly coupled professional
 dynamics. In particular, it does not add global pressure-flow residual assembly, sparse Jacobians, whole-model timestep
-rejection/rollback, event localization, or multi-rate pipeline subcycling. Those capabilities build on this contract so
-the solver can reason explicitly about which objects own dynamic state and which objects are algebraic constraints.
+rejection/rollback, event localization, or multi-rate pipeline subcycling. The strict execution diagnostics make known
+parallel/adaptive limitations explicit; they do not repair those underlying execution paths. Those capabilities build on
+this contract so the solver can reason explicitly about which objects own dynamic state, which objects are algebraic
+constraints, and which execution modes have qualified transaction/error semantics.
 
 The report also does not certify that a model is suitable for a control, relief, HIPPS/SIS, HAZOP, DEXPI/P&ID, virtual
 commissioning, OTS, or other safety-critical study. Those studies require scenario-specific modelling, validation

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -134,10 +134,13 @@ separation train::Inlet separator
 topside::separation train::HP gas scrubber
 ```
 
-The module container itself remains visible in the report. Current `ProcessModuleBaseClass.runTransient(...)` delegates
-to its internal `ProcessSystem`, but the campaign has not yet qualified all module-level initialization, state ownership,
-restart, error propagation, or nested transient semantics; modules therefore remain reviewable according to their own
-capability classification while their instantiated child operations are audited independently.
+The module container itself remains visible in the report but is classified as `ALGEBRAIC`. The established
+`ProcessModuleBaseClass.runTransient(...)` implementation delegates transient execution to its internal `ProcessSystem`;
+the container does not own an additional independent physical inventory merely because that delegating method is an
+override. Its instantiated child operations are audited recursively, and any `UNCLASSIFIED_DYNAMIC` child remains a
+strict-preflight review item. Module initialization, restart and error-propagation semantics still require their own
+engineering qualification, but the composite container must not create a false capability-review blocker on top of its
+children.
 
 The report never initializes a module as a side effect. A module whose internal `ProcessSystem` has not yet been built
 can only expose the container at audit time. Initialize/build the module through its normal model lifecycle before using

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -154,6 +154,8 @@ repeatedly and prevents accidental recursive container cycles from causing unbou
 The initial contract intentionally classifies only core implementations whose current source contains clear stored-state
 semantics:
 
+- algebraic: standard `Stream` execution, composite module containers, `EnergyNetworkSolver`, ISO-5167 `Orifice`, and
+  `WellFlow` IPR pressure-flow relations;
 - lumped: separators, tanks, two-stream heat exchangers, compressors, pumps, throttling/control valves, and
   `EnergyConverter`-based motors/generators/gearboxes/inverters/transformers;
 - distributed: `OnePhasePipeLine`, `TwoFluidPipe`, drift-flux `TransientPipe`, and `WaterHammerPipe`;
@@ -178,6 +180,12 @@ ownership and runtime activation/maturity are separate dimensions.
 `ALGEBRAIC`: that method re-evaluates the stream and advances its execution clock, but does not integrate stored physical
 state. A stream subclass that provides its own transient override remains `UNCLASSIFIED_DYNAMIC` until its state and
 equations are audited.
+
+`WellFlow` is also algebraic: its IPR/Vogel/Fetkovich/backpressure/table calculations map the current reservoir/well
+pressure-flow boundary without owning an additional transient inventory, and it inherits the standard physical-step
+clock contract. `Orifice` is a custom pressure-driven transient relation, but still owns no accumulation. Its ISO-5167
+relation is re-evaluated for every requested refinement while its local execution clock and calculation ID follow the
+same A/refine-A/B physical-step contract as other algebraic equipment, including the negligible-flow early return.
 
 Other custom transient implementations remain `UNCLASSIFIED_DYNAMIC` until their state variables, conservation equations,
 initialization, timestep constraints, event behaviour, snapshot/restart semantics, and quantitative validation are

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -74,6 +74,11 @@ semantics:
 - boundary: `SimpleReservoir`;
 - control: registered controllers and measurement devices.
 
+`Stream` and stream subclasses that inherit the standard `Stream.runTransient(...)` boundary are classified as
+`ALGEBRAIC`: that method re-evaluates the stream and advances its execution clock, but does not integrate stored
+physical state. A stream subclass that provides its own transient override remains `UNCLASSIFIED_DYNAMIC` until its
+state and equations are audited.
+
 Other custom transient implementations remain `UNCLASSIFIED_DYNAMIC` until their state variables, conservation equations,
 initialization, timestep constraints, event behaviour, snapshot/restart semantics, and quantitative validation are
 reviewed. The mapping is expected to expand as that audit is completed.

--- a/src/main/java/neqsim/mcp/runners/ModelRegistry.java
+++ b/src/main/java/neqsim/mcp/runners/ModelRegistry.java
@@ -538,8 +538,8 @@ public final class ModelRegistry {
    *
    * <p>
    * The subject is taken from the identity the transport already validated, never from a tool argument, so a client
-   * cannot claim another principal. Callers the transport did not authenticate share the anonymous subject, which
-   * keeps single-user desktop use working while still denying them every model registered by a named principal.
+   * cannot claim another principal. Callers the transport did not authenticate share the anonymous subject, which keeps
+   * single-user desktop use working while still denying them every model registered by a named principal.
    * </p>
    *
    * @return the owner identifier
@@ -567,10 +567,10 @@ public final class ModelRegistry {
    * Builds the storage key that scopes a handle to the caller that registered it.
    *
    * <p>
-   * Handles are content-derived, so without a scoped key two principals registering the same definition would share
-   * one entry: a revision by one would silently change what the other resolves, and the second registration would hand
-   * back the first caller's record. Qualifying the key with tenant and owner keeps the entries independent while the
-   * handle itself stays stable for its owner.
+   * Handles are content-derived, so without a scoped key two principals registering the same definition would share one
+   * entry: a revision by one would silently change what the other resolves, and the second registration would hand back
+   * the first caller's record. Qualifying the key with tenant and owner keeps the entries independent while the handle
+   * itself stays stable for its owner.
    * </p>
    *
    * @param modelId the model handle

--- a/src/main/java/neqsim/process/ProcessElementInterface.java
+++ b/src/main/java/neqsim/process/ProcessElementInterface.java
@@ -25,9 +25,10 @@ public interface ProcessElementInterface extends NamedInterface, Serializable {
    *
    * <p>
    * The capability is distinct from the current runtime steady-state/dynamic setting. In particular,
-   * {@link DynamicCapability#ALGEBRAIC} means the element may be re-evaluated as an algebraic relation during a transient
-   * study but does not expose audited stored physical state of its own. A custom class can override this method once its
-   * dynamic state, equations, initialization, timestep constraints, and validation evidence have been established.
+   * {@link DynamicCapability#ALGEBRAIC} means the element may be re-evaluated as an algebraic relation during a
+   * transient study but does not expose audited stored physical state of its own. A custom class can override this
+   * method once its dynamic state, equations, initialization, timestep constraints, and validation evidence have been
+   * established.
    * </p>
    *
    * <p>

--- a/src/main/java/neqsim/process/ProcessElementInterface.java
+++ b/src/main/java/neqsim/process/ProcessElementInterface.java
@@ -1,6 +1,8 @@
 package neqsim.process;
 
 import java.io.Serializable;
+import neqsim.process.dynamics.DynamicCapability;
+import neqsim.process.dynamics.DynamicCapabilityResolver;
 import neqsim.util.NamedInterface;
 
 /**
@@ -18,4 +20,24 @@ import neqsim.util.NamedInterface;
  * @version $Id: $Id
  */
 public interface ProcessElementInterface extends NamedInterface, Serializable {
+  /**
+   * Returns the audited transient semantics of this process element.
+   *
+   * <p>
+   * The capability is distinct from the current runtime steady-state/dynamic setting. In particular,
+   * {@link DynamicCapability#ALGEBRAIC} means the element may be re-evaluated as an algebraic relation during a transient
+   * study but does not expose audited stored physical state of its own. A custom class can override this method once its
+   * dynamic state, equations, initialization, timestep constraints, and validation evidence have been established.
+   * </p>
+   *
+   * <p>
+   * This method reports software capability only. It does not imply quantitative validation, standards conformance, or
+   * suitability for accountable engineering or safety approval.
+   * </p>
+   *
+   * @return dynamic capability; never null
+   */
+  default DynamicCapability getDynamicCapability() {
+    return DynamicCapabilityResolver.resolve(this);
+  }
 }

--- a/src/main/java/neqsim/process/dynamics/BDFIntegrator.java
+++ b/src/main/java/neqsim/process/dynamics/BDFIntegrator.java
@@ -1,5 +1,8 @@
 package neqsim.process.dynamics;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 /**
  * BDF-1 (backward differentiation formula of order 1, i.e. implicit Euler) integrator:
  *
@@ -15,9 +18,15 @@ package neqsim.process.dynamics;
  *
  * <p>
  * The Jacobian ∂f/∂x is approximated by a central finite difference with step
- * {@code max(jacobianEps, jacobianEps · |x|)}. Newton stops when {@code |Δx| < tolerance} or after
- * {@code maxIterations}, whichever comes first; if Newton fails to converge the integrator falls back to a single
- * explicit-Euler step so that the simulation remains stable rather than throwing.
+ * {@code max(jacobianEps, jacobianEps · |x|)}. Newton stops when both the update and implicit-equation residual satisfy
+ * the configured tolerance. Newton non-convergence is fail-loud by default; an explicit-Euler fallback is available
+ * only through the deliberately opt-in {@link #setExplicitEulerFallbackEnabled(boolean)} compatibility switch. A
+ * fallback is never reported as a converged BDF step.
+ * </p>
+ *
+ * <p>
+ * This class remains a scalar BDF-1 foundation. It is not a vector sparse BDF or DAE solver and must not be used as
+ * evidence of plant-wide stiff/DAE qualification.
  * </p>
  *
  * @author Even Solbraa
@@ -26,11 +35,16 @@ package neqsim.process.dynamics;
 public class BDFIntegrator implements IntegratorStrategy {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000L;
+  private static final Logger logger = LogManager.getLogger(BDFIntegrator.class);
 
   private double tolerance = 1.0e-8;
   private int maxIterations = 25;
   private double jacobianEps = 1.0e-6;
+  private boolean explicitEulerFallbackEnabled = false;
   private boolean lastStepFellBack = false;
+  private boolean lastStepConverged = true;
+  private int lastNewtonIterations = 0;
+  private double lastResidual = Double.NaN;
 
   /**
    * Default constructor; tolerance 1e-8, maxIterations 25, Jacobian epsilon 1e-6.
@@ -42,7 +56,7 @@ public class BDFIntegrator implements IntegratorStrategy {
   /**
    * Constructor with custom Newton settings.
    *
-   * @param tolerance Newton tolerance on |Δx| (must be {@code > 0})
+   * @param tolerance Newton tolerance on update and scaled residual (must be {@code > 0})
    * @param maxIterations maximum Newton iterations (must be {@code >= 1})
    * @param jacobianEps finite-difference perturbation (must be {@code > 0})
    */
@@ -68,13 +82,68 @@ public class BDFIntegrator implements IntegratorStrategy {
   }
 
   /**
-   * Indicates whether the most recent {@link #step} call had to fall back to explicit Euler because Newton iteration
-   * did not converge.
+   * Indicates whether the most recent {@link #step} call used the explicitly enabled Euler compatibility fallback.
    *
-   * @return true when last step fell back
+   * <p>
+   * A fallback means the requested BDF step did not converge. It is therefore not a successful implicit step and must
+   * not be counted as stiff-integration qualification evidence.
+   * </p>
+   *
+   * @return true when the last step used explicit Euler after BDF non-convergence
    */
   public boolean lastStepFellBack() {
     return lastStepFellBack;
+  }
+
+  /**
+   * Indicates whether the most recent BDF Newton solve converged.
+   *
+   * @return true only when the implicit BDF equation converged
+   */
+  public boolean lastStepConverged() {
+    return lastStepConverged;
+  }
+
+  /**
+   * Returns the number of Newton iterations attempted by the most recent step.
+   *
+   * @return Newton iteration count
+   */
+  public int getLastNewtonIterations() {
+    return lastNewtonIterations;
+  }
+
+  /**
+   * Returns the absolute implicit-equation residual from the most recent Newton evaluation.
+   *
+   * @return absolute residual, or NaN before the first Newton evaluation
+   */
+  public double getLastResidual() {
+    return lastResidual;
+  }
+
+  /**
+   * Enables or disables the legacy explicit-Euler fallback after BDF Newton non-convergence.
+   *
+   * <p>
+   * The default is {@code false}: non-convergence throws {@link IllegalStateException} so a physical-step coordinator
+   * can reject and restore the step. Enabling this switch is an explicit compatibility choice; the returned Euler
+   * state is marked by {@link #lastStepFellBack()} and {@link #lastStepConverged()} remains false.
+   * </p>
+   *
+   * @param enabled true to return an explicit-Euler compatibility step after BDF failure
+   */
+  public void setExplicitEulerFallbackEnabled(boolean enabled) {
+    explicitEulerFallbackEnabled = enabled;
+  }
+
+  /**
+   * Returns whether the explicit-Euler compatibility fallback is enabled.
+   *
+   * @return true when fallback is enabled
+   */
+  public boolean isExplicitEulerFallbackEnabled() {
+    return explicitEulerFallbackEnabled;
   }
 
   /**
@@ -101,31 +170,63 @@ public class BDFIntegrator implements IntegratorStrategy {
     if (slope == null) {
       throw new IllegalArgumentException("slope must not be null");
     }
-    if (!(dt > 0.0)) {
-      throw new IllegalArgumentException("dt must be > 0, got " + dt);
+    if (!Double.isFinite(dt) || dt <= 0.0) {
+      throw new IllegalArgumentException("dt must be finite and > 0, got " + dt);
     }
     lastStepFellBack = false;
+    lastStepConverged = false;
+    lastNewtonIterations = 0;
+    lastResidual = Double.NaN;
+
     double tNext = time + dt;
-    // Initial guess: explicit Euler predictor
     double x = state + dt * slope.dxdt(time, state);
-    // Solve G(x) = x - state - dt * f(tNext, x) = 0 via Newton
+    double residualScale = Math.max(1.0, Math.abs(state));
+
+    // Solve G(x) = x - state - dt * f(tNext, x) = 0 via Newton.
     for (int it = 0; it < maxIterations; it++) {
+      lastNewtonIterations = it + 1;
       double fAtX = slope.dxdt(tNext, x);
       double g = x - state - dt * fAtX;
+      lastResidual = Math.abs(g);
       double h = Math.max(jacobianEps, jacobianEps * Math.abs(x));
-      double dfdx = (slope.dxdt(tNext, x + h) - slope.dxdt(tNext, x - h)) / (2.0 * h);
+      double fPlus = slope.dxdt(tNext, x + h);
+      double fMinus = slope.dxdt(tNext, x - h);
+      double dfdx = (fPlus - fMinus) / (2.0 * h);
       double dgdx = 1.0 - dt * dfdx;
-      if (Math.abs(dgdx) < 1.0e-14) {
+
+      if (!Double.isFinite(g) || !Double.isFinite(dgdx) || Math.abs(dgdx) < 1.0e-14) {
         break;
       }
+
       double dx = -g / dgdx;
+      if (!Double.isFinite(dx)) {
+        break;
+      }
       x += dx;
-      if (Math.abs(dx) < tolerance) {
+      if (!Double.isFinite(x)) {
+        break;
+      }
+
+      double residualAfter = x - state - dt * slope.dxdt(tNext, x);
+      lastResidual = Math.abs(residualAfter);
+      if (Math.abs(dx) < tolerance && Double.isFinite(lastResidual)
+          && lastResidual <= tolerance * residualScale) {
+        lastStepConverged = true;
         return x;
       }
     }
-    // Fall back to explicit Euler for this step
-    lastStepFellBack = true;
-    return state + dt * slope.dxdt(time, state);
+
+    if (explicitEulerFallbackEnabled) {
+      lastStepFellBack = true;
+      logger.warn(
+          "BDF-1 Newton did not converge at t={} s with dt={} s after {} iterations (|residual|={}); "
+              + "using explicitly enabled Euler compatibility fallback",
+          Double.valueOf(time), Double.valueOf(dt), Integer.valueOf(lastNewtonIterations), Double.valueOf(lastResidual));
+      return state + dt * slope.dxdt(time, state);
+    }
+
+    throw new IllegalStateException("BDF-1 Newton did not converge at t=" + time + " s with dt=" + dt + " s after "
+        + lastNewtonIterations + " iterations; |residual|=" + lastResidual
+        + ". Reduce the timestep or enable the explicit-Euler compatibility fallback deliberately.");
   }
 }

--- a/src/main/java/neqsim/process/dynamics/BDFIntegrator.java
+++ b/src/main/java/neqsim/process/dynamics/BDFIntegrator.java
@@ -127,8 +127,8 @@ public class BDFIntegrator implements IntegratorStrategy {
    *
    * <p>
    * The default is {@code false}: non-convergence throws {@link IllegalStateException} so a physical-step coordinator
-   * can reject and restore the step. Enabling this switch is an explicit compatibility choice; the returned Euler
-   * state is marked by {@link #lastStepFellBack()} and {@link #lastStepConverged()} remains false.
+   * can reject and restore the step. Enabling this switch is an explicit compatibility choice; the returned Euler state
+   * is marked by {@link #lastStepFellBack()} and {@link #lastStepConverged()} remains false.
    * </p>
    *
    * @param enabled true to return an explicit-Euler compatibility step after BDF failure
@@ -209,8 +209,7 @@ public class BDFIntegrator implements IntegratorStrategy {
 
       double residualAfter = x - state - dt * slope.dxdt(tNext, x);
       lastResidual = Math.abs(residualAfter);
-      if (Math.abs(dx) < tolerance && Double.isFinite(lastResidual)
-          && lastResidual <= tolerance * residualScale) {
+      if (Math.abs(dx) < tolerance && Double.isFinite(lastResidual) && lastResidual <= tolerance * residualScale) {
         lastStepConverged = true;
         return x;
       }
@@ -221,7 +220,8 @@ public class BDFIntegrator implements IntegratorStrategy {
       logger.warn(
           "BDF-1 Newton did not converge at t={} s with dt={} s after {} iterations (|residual|={}); "
               + "using explicitly enabled Euler compatibility fallback",
-          Double.valueOf(time), Double.valueOf(dt), Integer.valueOf(lastNewtonIterations), Double.valueOf(lastResidual));
+          Double.valueOf(time), Double.valueOf(dt), Integer.valueOf(lastNewtonIterations),
+          Double.valueOf(lastResidual));
       return state + dt * slope.dxdt(time, state);
     }
 

--- a/src/main/java/neqsim/process/dynamics/DynamicActivationResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicActivationResolver.java
@@ -67,8 +67,7 @@ public final class DynamicActivationResolver {
 
     if (element instanceof SimulationInterface) {
       boolean requested = !((SimulationInterface) element).getCalculateSteadyState();
-      return requested
-          ? "dynamic mode is requested, but type-specific runtime activation has not been audited"
+      return requested ? "dynamic mode is requested, but type-specific runtime activation has not been audited"
           : "dynamic mode is not requested by calculateSteadyState, but type-specific activation has not been audited";
     }
     return "type-specific runtime activation has not been audited";

--- a/src/main/java/neqsim/process/dynamics/DynamicActivationResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicActivationResolver.java
@@ -2,6 +2,8 @@ package neqsim.process.dynamics;
 
 import neqsim.process.ProcessElementInterface;
 import neqsim.process.SimulationInterface;
+import neqsim.process.equipment.battery.BatteryStorage;
+import neqsim.process.equipment.expander.Expander;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
 
 /**
@@ -41,6 +43,12 @@ public final class DynamicActivationResolver {
     if (element instanceof HeatExchanger) {
       return resolveHeatExchanger((HeatExchanger) element);
     }
+    if (element instanceof BatteryStorage) {
+      return resolveBatteryStorage((BatteryStorage) element);
+    }
+    if (element instanceof Expander) {
+      return resolveExpander((Expander) element);
+    }
 
     return DynamicActivationStatus.UNVERIFIED;
   }
@@ -63,6 +71,12 @@ public final class DynamicActivationResolver {
 
     if (element instanceof HeatExchanger) {
       return heatExchangerDiagnostic((HeatExchanger) element);
+    }
+    if (element instanceof BatteryStorage) {
+      return batteryStorageDiagnostic((BatteryStorage) element);
+    }
+    if (element instanceof Expander) {
+      return expanderDiagnostic((Expander) element);
     }
 
     if (element instanceof SimulationInterface) {
@@ -102,6 +116,30 @@ public final class DynamicActivationResolver {
       return "dynamicModelEnabled is true but heatTransferArea is not positive";
     }
     return "dynamic heat-exchanger wall-energy path is active";
+  }
+
+  private static DynamicActivationStatus resolveBatteryStorage(BatteryStorage battery) {
+    if (battery.getCapacity() <= 0.0) {
+      return DynamicActivationStatus.INCOMPLETE_CONFIGURATION;
+    }
+    return DynamicActivationStatus.ACTIVE;
+  }
+
+  private static String batteryStorageDiagnostic(BatteryStorage battery) {
+    if (battery.getCapacity() <= 0.0) {
+      return "battery transient state is always evaluated by runTransient but storage capacity is not positive";
+    }
+    return "battery stored-energy and ramped-power state is active independently of calculateSteadyState";
+  }
+
+  private static DynamicActivationStatus resolveExpander(Expander expander) {
+    return isDynamicModeRequested(expander) ? DynamicActivationStatus.ACTIVE : DynamicActivationStatus.INACTIVE;
+  }
+
+  private static String expanderDiagnostic(Expander expander) {
+    return isDynamicModeRequested(expander)
+        ? "expander nozzle, recovered-power and shaft-speed state is active"
+        : "calculateSteadyState selects algebraic expander thermodynamics without nozzle/power/speed integration";
   }
 
   private static boolean isDynamicModeRequested(SimulationInterface element) {

--- a/src/main/java/neqsim/process/dynamics/DynamicActivationResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicActivationResolver.java
@@ -137,8 +137,7 @@ public final class DynamicActivationResolver {
   }
 
   private static String expanderDiagnostic(Expander expander) {
-    return isDynamicModeRequested(expander)
-        ? "expander nozzle, recovered-power and shaft-speed state is active"
+    return isDynamicModeRequested(expander) ? "expander nozzle, recovered-power and shaft-speed state is active"
         : "calculateSteadyState selects algebraic expander thermodynamics without nozzle/power/speed integration";
   }
 

--- a/src/main/java/neqsim/process/dynamics/DynamicActivationResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicActivationResolver.java
@@ -1,0 +1,111 @@
+package neqsim.process.dynamics;
+
+import neqsim.process.ProcessElementInterface;
+import neqsim.process.SimulationInterface;
+import neqsim.process.equipment.heatexchanger.HeatExchanger;
+
+/**
+ * Conservative resolver for the runtime activation of audited dynamic implementations.
+ *
+ * <p>
+ * This resolver is intentionally type-specific. A generic {@code calculateSteadyState == false} flag records requested
+ * execution mode but does not prove that a subclass actually enters a stateful path; individual equipment families can
+ * have additional enable flags and physical-parameter prerequisites. Types without an explicit activation audit remain
+ * {@link DynamicActivationStatus#UNVERIFIED} rather than being promoted from API presence alone.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public final class DynamicActivationResolver {
+  /** Utility class. */
+  private DynamicActivationResolver() {
+  }
+
+  /**
+   * Resolve runtime activation status for one process element.
+   *
+   * @param element process element to inspect
+   * @return activation status; never null
+   */
+  public static DynamicActivationStatus resolve(ProcessElementInterface element) {
+    if (element == null) {
+      return DynamicActivationStatus.UNVERIFIED;
+    }
+
+    DynamicCapability capability = element.getDynamicCapability();
+    if (capability == DynamicCapability.ALGEBRAIC) {
+      return DynamicActivationStatus.NOT_APPLICABLE;
+    }
+
+    if (element instanceof HeatExchanger) {
+      return resolveHeatExchanger((HeatExchanger) element);
+    }
+
+    return DynamicActivationStatus.UNVERIFIED;
+  }
+
+  /**
+   * Human-readable reason for the resolved activation status.
+   *
+   * @param element process element to inspect
+   * @return diagnostic reason suitable for capability reports
+   */
+  public static String diagnostic(ProcessElementInterface element) {
+    if (element == null) {
+      return "element is null";
+    }
+
+    DynamicCapability capability = element.getDynamicCapability();
+    if (capability == DynamicCapability.ALGEBRAIC) {
+      return "algebraic relation has no independent stateful path";
+    }
+
+    if (element instanceof HeatExchanger) {
+      return heatExchangerDiagnostic((HeatExchanger) element);
+    }
+
+    if (element instanceof SimulationInterface) {
+      boolean requested = !((SimulationInterface) element).getCalculateSteadyState();
+      return requested
+          ? "dynamic mode is requested, but type-specific runtime activation has not been audited"
+          : "dynamic mode is not requested by calculateSteadyState, but type-specific activation has not been audited";
+    }
+    return "type-specific runtime activation has not been audited";
+  }
+
+  private static DynamicActivationStatus resolveHeatExchanger(HeatExchanger exchanger) {
+    if (!exchanger.isDynamicModelEnabled()) {
+      if (isDynamicModeRequested(exchanger)) {
+        return DynamicActivationStatus.INCOMPLETE_CONFIGURATION;
+      }
+      return DynamicActivationStatus.INACTIVE;
+    }
+    if (exchanger.getWallMass() <= 0.0 || exchanger.getHeatTransferArea() <= 0.0) {
+      return DynamicActivationStatus.INCOMPLETE_CONFIGURATION;
+    }
+    return DynamicActivationStatus.ACTIVE;
+  }
+
+  private static String heatExchangerDiagnostic(HeatExchanger exchanger) {
+    if (!exchanger.isDynamicModelEnabled()) {
+      return isDynamicModeRequested(exchanger)
+          ? "calculateSteadyState requests dynamic mode but dynamicModelEnabled is false"
+          : "dynamicModelEnabled is false";
+    }
+    if (exchanger.getWallMass() <= 0.0 && exchanger.getHeatTransferArea() <= 0.0) {
+      return "dynamicModelEnabled is true but wallMass and heatTransferArea are not positive";
+    }
+    if (exchanger.getWallMass() <= 0.0) {
+      return "dynamicModelEnabled is true but wallMass is not positive";
+    }
+    if (exchanger.getHeatTransferArea() <= 0.0) {
+      return "dynamicModelEnabled is true but heatTransferArea is not positive";
+    }
+    return "dynamic heat-exchanger wall-energy path is active";
+  }
+
+  private static boolean isDynamicModeRequested(SimulationInterface element) {
+    return !element.getCalculateSteadyState();
+  }
+}

--- a/src/main/java/neqsim/process/dynamics/DynamicActivationStatus.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicActivationStatus.java
@@ -1,0 +1,30 @@
+package neqsim.process.dynamics;
+
+/**
+ * Runtime activation state for an audited transient implementation.
+ *
+ * <p>
+ * This dimension is intentionally separate from {@link DynamicCapability}. Capability describes what kind of state an
+ * element can own; activation describes whether that stateful path is actually selected by the current runtime
+ * configuration. Neither value is a quantitative validation or professional-readiness certificate.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public enum DynamicActivationStatus {
+  /** The element is algebraic and therefore has no independent stateful path to activate. */
+  NOT_APPLICABLE,
+
+  /** A type-specific audit verifies that the stateful transient path is active for the current configuration. */
+  ACTIVE,
+
+  /** A type-specific audit verifies that the stateful transient path is inactive for the current configuration. */
+  INACTIVE,
+
+  /** Dynamic execution is requested/enabled but required runtime configuration is incomplete. */
+  INCOMPLETE_CONFIGURATION,
+
+  /** Runtime activation semantics for this element type have not yet been audited explicitly. */
+  UNVERIFIED
+}

--- a/src/main/java/neqsim/process/dynamics/DynamicCapability.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapability.java
@@ -1,0 +1,71 @@
+package neqsim.process.dynamics;
+
+/**
+ * Describes the audited transient semantics of a process element.
+ *
+ * <p>
+ * This classification is deliberately separate from a runtime steady-state/dynamic-mode switch. It states what kind of
+ * transient behaviour an element is known to provide, not whether that behaviour is currently enabled. The contract is
+ * used to distinguish genuine stored-state dynamics from algebraic equipment that is merely re-evaluated at each
+ * simulation timestamp.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public enum DynamicCapability {
+  /** Algebraic relation with no audited physical state integrated across timesteps. */
+  ALGEBRAIC,
+
+  /** Lumped dynamic state such as inventory, energy storage, actuator position, or rotating inertia. */
+  DYNAMIC_LUMPED,
+
+  /** Spatially distributed transient state such as a finite-volume or method-of-characteristics pipeline model. */
+  DYNAMIC_DISTRIBUTED,
+
+  /** Time-varying boundary or source state, for example reservoir depletion or an external dynamic boundary. */
+  BOUNDARY_DYNAMIC,
+
+  /** Controller, instrumentation, signal, logic, or other sampled control-system transient state. */
+  CONTROL_DYNAMIC,
+
+  /** A custom transient implementation exists, but its physical state/equations have not yet been audited. */
+  UNCLASSIFIED_DYNAMIC,
+
+  /** The element explicitly declares that a transient interpretation is unsupported. */
+  UNSUPPORTED_DYNAMIC;
+
+  /**
+   * Returns whether this capability has an audited semantic category.
+   *
+   * @return true unless the element still requires transient capability review
+   */
+  public boolean isAudited() {
+    return this != UNCLASSIFIED_DYNAMIC;
+  }
+
+  /**
+   * Returns whether this category represents explicit time-dependent state rather than a purely algebraic relation.
+   *
+   * @return true for lumped, distributed, boundary, and control-system dynamics
+   */
+  public boolean hasExplicitDynamicState() {
+    return this == DYNAMIC_LUMPED || this == DYNAMIC_DISTRIBUTED || this == BOUNDARY_DYNAMIC
+        || this == CONTROL_DYNAMIC;
+  }
+
+  /**
+   * Returns whether an element with this capability may participate in a transient study.
+   *
+   * <p>
+   * Algebraic elements are valid participants when evaluated as algebraic constraints at each physical timestep. The
+   * only category that is categorically excluded is {@link #UNSUPPORTED_DYNAMIC}. An unclassified custom transient
+   * implementation may run, but remains an engineering-review item until its state/equations are audited.
+   * </p>
+   *
+   * @return false only for explicitly unsupported transient behaviour
+   */
+  public boolean canParticipateInTransientStudy() {
+    return this != UNSUPPORTED_DYNAMIC;
+  }
+}

--- a/src/main/java/neqsim/process/dynamics/DynamicCapability.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapability.java
@@ -50,8 +50,7 @@ public enum DynamicCapability {
    * @return true for lumped, distributed, boundary, and control-system dynamics
    */
   public boolean hasExplicitDynamicState() {
-    return this == DYNAMIC_LUMPED || this == DYNAMIC_DISTRIBUTED || this == BOUNDARY_DYNAMIC
-        || this == CONTROL_DYNAMIC;
+    return this == DYNAMIC_LUMPED || this == DYNAMIC_DISTRIBUTED || this == BOUNDARY_DYNAMIC || this == CONTROL_DYNAMIC;
   }
 
   /**

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
@@ -25,21 +25,23 @@ import neqsim.process.processmodel.ProcessSystem;
  * <p>
  * The report is intentionally diagnostic rather than a readiness certificate. It distinguishes audited stored-state
  * dynamics from algebraic timestep evaluation, reports type-specific runtime activation separately from state
- * ownership, identifies explicitly requested configurations that cannot use the default transient boundary, and keeps
- * unaudited custom transient implementations visible as review items.
+ * ownership, identifies explicitly requested configurations that cannot use the default transient boundary, keeps
+ * unaudited custom transient implementations visible as review items, and exposes process-level execution modes whose
+ * current numerical/error semantics are not yet strict-professional ready.
  * </p>
  *
  * @author Even Solbraa
- * @version 1.1
+ * @version 1.2
  */
 public final class DynamicCapabilityReport implements Serializable {
   private static final long serialVersionUID = 1000L;
 
   /** Schema version for serialized/JSON reports. */
-  private static final String SCHEMA_VERSION = "1.1";
+  private static final String SCHEMA_VERSION = "1.2";
 
   private final String schemaVersion = SCHEMA_VERSION;
   private final List<Entry> entries;
+  private final List<String> executionIssues;
 
   /**
    * Immutable record describing one process element in the capability audit.
@@ -240,8 +242,9 @@ public final class DynamicCapabilityReport implements Serializable {
     }
   }
 
-  private DynamicCapabilityReport(List<Entry> entries) {
+  private DynamicCapabilityReport(List<Entry> entries, List<String> executionIssues) {
     this.entries = Collections.unmodifiableList(new ArrayList<Entry>(entries));
+    this.executionIssues = Collections.unmodifiableList(new ArrayList<String>(executionIssues));
   }
 
   /**
@@ -256,8 +259,9 @@ public final class DynamicCapabilityReport implements Serializable {
       throw new IllegalArgumentException("process must not be null");
     }
     List<Entry> collected = new ArrayList<Entry>();
-    collectArea("", process, collected);
-    return new DynamicCapabilityReport(collected);
+    List<String> executionIssues = new ArrayList<String>();
+    collectArea("", process, collected, executionIssues);
+    return new DynamicCapabilityReport(collected, executionIssues);
   }
 
   /**
@@ -272,13 +276,14 @@ public final class DynamicCapabilityReport implements Serializable {
       throw new IllegalArgumentException("model must not be null");
     }
     List<Entry> collected = new ArrayList<Entry>();
+    List<String> executionIssues = new ArrayList<String>();
     for (String areaName : model.getProcessSystemNames()) {
       ProcessSystem process = model.get(areaName);
       if (process != null) {
-        collectArea(areaName, process, collected);
+        collectArea(areaName, process, collected, executionIssues);
       }
     }
-    return new DynamicCapabilityReport(collected);
+    return new DynamicCapabilityReport(collected, executionIssues);
   }
 
   /**
@@ -297,6 +302,21 @@ public final class DynamicCapabilityReport implements Serializable {
    */
   public List<Entry> getEntries() {
     return entries;
+  }
+
+  /**
+   * Process-level execution configurations that are not yet safe for strict-professional transient qualification.
+   *
+   * <p>
+   * These diagnostics are intentionally separate from per-element state ownership and activation. They describe a
+   * process execution mode whose current solver/error contract is known to be incomplete even if every individual
+   * element is otherwise classified.
+   * </p>
+   *
+   * @return immutable area/module-qualified diagnostics
+   */
+  public List<String> getExecutionIssues() {
+    return executionIssues;
   }
 
   /**
@@ -341,6 +361,7 @@ public final class DynamicCapabilityReport implements Serializable {
    */
   public List<String> getBlockingIssues() {
     List<String> issues = new ArrayList<String>();
+    issues.addAll(executionIssues);
     for (Entry entry : entries) {
       if (entry.hasUnsupportedDynamicConfiguration()) {
         if (entry.getCapability() == DynamicCapability.ALGEBRAIC) {
@@ -399,10 +420,10 @@ public final class DynamicCapabilityReport implements Serializable {
    * Returns all issues that fail the opt-in strict transient preflight.
    *
    * <p>
-   * Strict preflight combines known unsupported runtime configurations, incomplete type-specific activation, and
-   * unaudited custom transient implementations. It deliberately does not reject audited dynamic equipment that is
-   * intentionally inactive, nor does it reject families whose activation semantics are still marked UNVERIFIED; those
-   * remain visible through dedicated review diagnostics.
+   * Strict preflight combines known unsupported runtime configurations, process-level execution modes with incomplete
+   * solver/error semantics, incomplete type-specific activation, and unaudited custom transient implementations. It
+   * deliberately does not reject audited dynamic equipment that is intentionally inactive, nor does it reject families
+   * whose activation semantics are still marked UNVERIFIED; those remain visible through dedicated review diagnostics.
    * </p>
    *
    * @return immutable list of strict-preflight issues
@@ -418,9 +439,9 @@ public final class DynamicCapabilityReport implements Serializable {
    * Whether the process/model passes the opt-in strict transient capability preflight.
    *
    * <p>
-   * A true result only means that no currently known unsupported configuration, incomplete audited activation, or
-   * unaudited custom transient implementation was found. It is not a quantitative validation, conformance, safety, or
-   * professional-readiness certificate.
+   * A true result only means that no currently known unsupported configuration, incomplete audited activation,
+   * unqualified process execution mode, or unaudited custom transient implementation was found. It is not a quantitative
+   * validation, conformance, safety, or professional-readiness certificate.
    * </p>
    *
    * @return true when {@link #getStrictPreflightIssues()} is empty
@@ -468,7 +489,7 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   /**
-   * Whether the report contains a known unsupported or incomplete runtime configuration.
+   * Whether the report contains a known unsupported, incomplete, or unqualified runtime configuration.
    *
    * <p>
    * A false result is not a professional-readiness or validation certificate; review items, activation audits, and
@@ -478,6 +499,9 @@ public final class DynamicCapabilityReport implements Serializable {
    * @return true if one or more blocking configuration issues exist
    */
   public boolean hasBlockingIssues() {
+    if (!executionIssues.isEmpty()) {
+      return true;
+    }
     for (Entry entry : entries) {
       if (entry.hasUnsupportedDynamicConfiguration() || entry.hasIncompleteDynamicActivation()) {
         return true;
@@ -495,25 +519,29 @@ public final class DynamicCapabilityReport implements Serializable {
     return new GsonBuilder().setPrettyPrinting().create().toJson(this);
   }
 
-  private static void collectArea(String areaName, ProcessSystem process, List<Entry> target) {
+  private static void collectArea(String areaName, ProcessSystem process, List<Entry> target,
+      List<String> executionIssues) {
     Set<ProcessElementInterface> seenElements = Collections
         .newSetFromMap(new IdentityHashMap<ProcessElementInterface, Boolean>());
     Set<ProcessSystem> seenProcesses = Collections.newSetFromMap(new IdentityHashMap<ProcessSystem, Boolean>());
-    collectProcess(areaName, "", process, target, seenElements, seenProcesses);
+    collectProcess(areaName, "", process, target, executionIssues, seenElements, seenProcesses);
   }
 
   private static void collectProcess(String areaName, String containerPath, ProcessSystem process, List<Entry> target,
-      Set<ProcessElementInterface> seenElements, Set<ProcessSystem> seenProcesses) {
+      List<String> executionIssues, Set<ProcessElementInterface> seenElements, Set<ProcessSystem> seenProcesses) {
     if (process == null || !seenProcesses.add(process)) {
       return;
     }
+
+    addExecutionIssues(areaName, containerPath, process, executionIssues);
 
     for (ProcessElementInterface element : process.getAllElements()) {
       boolean added = addEntry(areaName, containerPath, element, target, seenElements);
       if (added && element instanceof ModuleInterface) {
         ModuleInterface module = (ModuleInterface) element;
         String nestedPath = appendContainerPath(containerPath, element);
-        collectProcess(areaName, nestedPath, module.getOperations(), target, seenElements, seenProcesses);
+        collectProcess(areaName, nestedPath, module.getOperations(), target, executionIssues, seenElements,
+            seenProcesses);
       }
     }
 
@@ -526,6 +554,30 @@ public final class DynamicCapabilityReport implements Serializable {
         addEntry(areaName, containerPath, controller, target, seenElements);
       }
     }
+  }
+
+  private static void addExecutionIssues(String areaName, String containerPath, ProcessSystem process,
+      List<String> executionIssues) {
+    String processName = qualifiedProcessName(areaName, containerPath, process);
+    if (process.isParallelTransientEnabled()) {
+      executionIssues.add(processName
+          + " enables parallel transient execution, whose equipment worker failures are not yet fail-loud; disable parallel transient mode for strict qualification until worker failures propagate and whole-step rollback exists");
+    }
+    if (process.isAdaptiveTimestepEnabled()) {
+      executionIssues.add(processName
+          + " enables adaptive transient execution, but runTransientAdaptive currently mutates one full step and adjusts a following timestep without rejected-step rollback or full-step/two-half-step error estimation");
+    }
+  }
+
+  private static String qualifiedProcessName(String areaName, String containerPath, ProcessSystem process) {
+    if (containerPath != null && !containerPath.isEmpty()) {
+      return areaName == null || areaName.isEmpty() ? containerPath : areaName + "::" + containerPath;
+    }
+    if (areaName != null && !areaName.isEmpty()) {
+      return areaName;
+    }
+    String name = process.getName();
+    return name == null || name.trim().isEmpty() ? "process" : name;
   }
 
   private static boolean addEntry(String areaName, String containerPath, ProcessElementInterface element,

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
@@ -15,6 +15,7 @@ import neqsim.process.SimulationInterface;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
+import neqsim.process.processmodel.ModuleInterface;
 import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 
@@ -49,14 +50,16 @@ public final class DynamicCapabilityReport implements Serializable {
     private static final long serialVersionUID = 1000L;
 
     private final String areaName;
+    private final String containerPath;
     private final String category;
     private final String name;
     private final String className;
     private final DynamicCapability capability;
     private final Boolean calculateSteadyState;
 
-    private Entry(String areaName, ProcessElementInterface element) {
+    private Entry(String areaName, String containerPath, ProcessElementInterface element) {
       this.areaName = areaName == null ? "" : areaName;
+      this.containerPath = containerPath == null ? "" : containerPath;
       this.category = categoryOf(element);
       this.name = element.getName() == null ? "" : element.getName();
       this.className = element.getClass().getName();
@@ -76,7 +79,16 @@ public final class DynamicCapabilityReport implements Serializable {
     }
 
     /**
-     * Element category: equipment, measurement, controller, or element.
+     * Nested module/container path, empty for an element registered directly in the audited process area.
+     *
+     * @return module path using {@code ::} separators
+     */
+    public String getContainerPath() {
+      return containerPath;
+    }
+
+    /**
+     * Element category: module, equipment, measurement, controller, or element.
      *
      * @return category string
      */
@@ -121,12 +133,13 @@ public final class DynamicCapabilityReport implements Serializable {
     }
 
     /**
-     * Area-qualified name suitable for diagnostics.
+     * Area- and module-qualified name suitable for diagnostics.
      *
-     * @return {@code area::name} for a model report, otherwise the element name
+     * @return {@code area::module::name} where applicable
      */
     public String getQualifiedName() {
-      return areaName.isEmpty() ? name : areaName + "::" + name;
+      String localName = containerPath.isEmpty() ? name : containerPath + "::" + name;
+      return areaName.isEmpty() ? localName : areaName + "::" + localName;
     }
 
     /**
@@ -144,14 +157,15 @@ public final class DynamicCapabilityReport implements Serializable {
      * <p>
      * An algebraic element is a valid participant in a transient flowsheet while it remains in algebraic mode. It is a
      * blocking configuration error only when its difference-equation mode is explicitly requested even though no
-     * audited dynamic implementation exists.
+     * audited dynamic implementation exists. A module is a composite container and is therefore not rejected merely
+     * because the container itself has no independent state; its nested contents are audited separately.
      * </p>
      *
-     * @return true for an explicitly unsupported capability or algebraic element forced into dynamic mode
+     * @return true for an explicitly unsupported capability or algebraic non-module element forced into dynamic mode
      */
     public boolean hasUnsupportedDynamicConfiguration() {
       return capability == DynamicCapability.UNSUPPORTED_DYNAMIC
-          || (capability == DynamicCapability.ALGEBRAIC && isDynamicModeRequested());
+          || (capability == DynamicCapability.ALGEBRAIC && isDynamicModeRequested() && !"module".equals(category));
     }
 
     /**
@@ -179,7 +193,7 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   /**
-   * Builds a capability report for one process system.
+   * Builds a capability report for one process system, recursively including initialized process modules.
    *
    * @param process process system to audit
    * @return capability report
@@ -195,7 +209,7 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   /**
-   * Builds a capability report for every process area in a model.
+   * Builds a capability report for every process area in a model, recursively including initialized process modules.
    *
    * @param model multi-area process model to audit
    * @return capability report with area-qualified entries
@@ -225,7 +239,7 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   /**
-   * All audited entries in deterministic area/registration order.
+   * All audited entries in deterministic area/registration/module order.
    *
    * @return immutable list of entries
    */
@@ -287,6 +301,56 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   /**
+   * Returns all issues that fail the opt-in strict transient preflight.
+   *
+   * <p>
+   * Strict preflight combines known unsupported runtime configurations with unaudited custom transient
+   * implementations. It deliberately does not reject audited dynamic equipment that remains in steady-state mode,
+   * because mixed algebraic/dynamic flowsheets are valid when that choice is intentional.
+   * </p>
+   *
+   * @return immutable list of strict-preflight issues
+   */
+  public List<String> getStrictPreflightIssues() {
+    List<String> issues = new ArrayList<String>();
+    issues.addAll(getBlockingIssues());
+    issues.addAll(getReviewItems());
+    return Collections.unmodifiableList(issues);
+  }
+
+  /**
+   * Whether the process/model passes the opt-in strict transient capability preflight.
+   *
+   * <p>
+   * A true result only means that no currently known unsupported configuration or unaudited custom transient
+   * implementation was found. It is not a quantitative validation, conformance, safety, or professional-readiness
+   * certificate.
+   * </p>
+   *
+   * @return true when {@link #getStrictPreflightIssues()} is empty
+   */
+  public boolean isStrictPreflightReady() {
+    return getStrictPreflightIssues().isEmpty();
+  }
+
+  /**
+   * Fail fast when the opt-in strict transient capability preflight contains issues.
+   *
+   * @throws IllegalStateException with all current strict-preflight diagnostics when the preflight fails
+   */
+  public void assertStrictTransientReady() {
+    List<String> issues = getStrictPreflightIssues();
+    if (issues.isEmpty()) {
+      return;
+    }
+    StringBuilder message = new StringBuilder("Strict transient capability preflight failed");
+    for (String issue : issues) {
+      message.append("; ").append(issue);
+    }
+    throw new IllegalStateException(message.toString());
+  }
+
+  /**
    * Returns audited dynamic elements that are currently configured to use their steady-state/algebraic path.
    *
    * <p>
@@ -335,11 +399,25 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   private static void collectArea(String areaName, ProcessSystem process, List<Entry> target) {
-    Set<ProcessElementInterface> seen = Collections
+    Set<ProcessElementInterface> seenElements = Collections
         .newSetFromMap(new IdentityHashMap<ProcessElementInterface, Boolean>());
+    Set<ProcessSystem> seenProcesses = Collections.newSetFromMap(new IdentityHashMap<ProcessSystem, Boolean>());
+    collectProcess(areaName, "", process, target, seenElements, seenProcesses);
+  }
+
+  private static void collectProcess(String areaName, String containerPath, ProcessSystem process, List<Entry> target,
+      Set<ProcessElementInterface> seenElements, Set<ProcessSystem> seenProcesses) {
+    if (process == null || !seenProcesses.add(process)) {
+      return;
+    }
 
     for (ProcessElementInterface element : process.getAllElements()) {
-      addEntry(areaName, element, target, seen);
+      boolean added = addEntry(areaName, containerPath, element, target, seenElements);
+      if (added && element instanceof ModuleInterface) {
+        ModuleInterface module = (ModuleInterface) element;
+        String nestedPath = appendContainerPath(containerPath, element);
+        collectProcess(areaName, nestedPath, module.getOperations(), target, seenElements, seenProcesses);
+      }
     }
 
     for (ProcessEquipmentInterface equipment : process.getUnitOperations()) {
@@ -348,17 +426,26 @@ public final class DynamicCapabilityReport implements Serializable {
         continue;
       }
       for (ControllerDeviceInterface controller : controllers) {
-        addEntry(areaName, controller, target, seen);
+        addEntry(areaName, containerPath, controller, target, seenElements);
       }
     }
   }
 
-  private static void addEntry(String areaName, ProcessElementInterface element, List<Entry> target,
-      Set<ProcessElementInterface> seen) {
-    if (element == null || !seen.add(element)) {
-      return;
+  private static boolean addEntry(String areaName, String containerPath, ProcessElementInterface element,
+      List<Entry> target, Set<ProcessElementInterface> seenElements) {
+    if (element == null || !seenElements.add(element)) {
+      return false;
     }
-    target.add(new Entry(areaName, element));
+    target.add(new Entry(areaName, containerPath, element));
+    return true;
+  }
+
+  private static String appendContainerPath(String containerPath, ProcessElementInterface element) {
+    String name = element.getName();
+    if (name == null || name.trim().isEmpty()) {
+      name = element.getClass().getSimpleName();
+    }
+    return containerPath == null || containerPath.isEmpty() ? name : containerPath + "::" + name;
   }
 
   private static String categoryOf(ProcessElementInterface element) {
@@ -367,6 +454,9 @@ public final class DynamicCapabilityReport implements Serializable {
     }
     if (element instanceof MeasurementDeviceInterface) {
       return "measurement";
+    }
+    if (element instanceof ModuleInterface) {
+      return "module";
     }
     if (element instanceof ProcessEquipmentInterface) {
       return "equipment";

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
@@ -1,0 +1,375 @@
+package neqsim.process.dynamics;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import com.google.gson.GsonBuilder;
+import neqsim.process.ProcessElementInterface;
+import neqsim.process.SimulationInterface;
+import neqsim.process.controllerdevice.ControllerDeviceInterface;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.measurementdevice.MeasurementDeviceInterface;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+
+/**
+ * Machine-readable audit of transient semantics in a {@link ProcessSystem} or multi-area {@link ProcessModel}.
+ *
+ * <p>
+ * The report is intentionally diagnostic rather than a readiness certificate. It distinguishes audited stored-state
+ * dynamics from algebraic timestep evaluation, identifies explicitly requested configurations that cannot use the
+ * default transient boundary, and keeps unaudited custom transient implementations visible as review items.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public final class DynamicCapabilityReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Schema version for serialized/JSON reports. */
+  private static final String SCHEMA_VERSION = "1.0";
+
+  private final String schemaVersion = SCHEMA_VERSION;
+  private final List<Entry> entries;
+
+  /**
+   * Immutable record describing one process element in the capability audit.
+   *
+   * @author Even Solbraa
+   * @version 1.0
+   */
+  public static final class Entry implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String areaName;
+    private final String category;
+    private final String name;
+    private final String className;
+    private final DynamicCapability capability;
+    private final Boolean calculateSteadyState;
+
+    private Entry(String areaName, ProcessElementInterface element) {
+      this.areaName = areaName == null ? "" : areaName;
+      this.category = categoryOf(element);
+      this.name = element.getName() == null ? "" : element.getName();
+      this.className = element.getClass().getName();
+      this.capability = element.getDynamicCapability();
+      this.calculateSteadyState = element instanceof SimulationInterface
+          ? Boolean.valueOf(((SimulationInterface) element).getCalculateSteadyState())
+          : null;
+    }
+
+    /**
+     * Process-area name, empty for a standalone {@link ProcessSystem} report.
+     *
+     * @return process-area name
+     */
+    public String getAreaName() {
+      return areaName;
+    }
+
+    /**
+     * Element category: equipment, measurement, controller, or element.
+     *
+     * @return category string
+     */
+    public String getCategory() {
+      return category;
+    }
+
+    /**
+     * Element name.
+     *
+     * @return element name
+     */
+    public String getName() {
+      return name;
+    }
+
+    /**
+     * Runtime Java class name.
+     *
+     * @return fully qualified class name
+     */
+    public String getClassName() {
+      return className;
+    }
+
+    /**
+     * Audited dynamic capability.
+     *
+     * @return capability
+     */
+    public DynamicCapability getCapability() {
+      return capability;
+    }
+
+    /**
+     * Runtime steady-state flag for simulation elements, or null for non-simulation control/measurement elements.
+     *
+     * @return steady-state flag or null
+     */
+    public Boolean getCalculateSteadyState() {
+      return calculateSteadyState;
+    }
+
+    /**
+     * Area-qualified name suitable for diagnostics.
+     *
+     * @return {@code area::name} for a model report, otherwise the element name
+     */
+    public String getQualifiedName() {
+      return areaName.isEmpty() ? name : areaName + "::" + name;
+    }
+
+    /**
+     * Whether the runtime configuration requests the element-specific difference-equation path.
+     *
+     * @return true when a {@link SimulationInterface} has {@code calculateSteadyState == false}
+     */
+    public boolean isDynamicModeRequested() {
+      return calculateSteadyState != null && !calculateSteadyState.booleanValue();
+    }
+
+    /**
+     * Whether this element is configured in a way known to be incompatible with its audited capability.
+     *
+     * <p>
+     * An algebraic element is a valid participant in a transient flowsheet while it remains in algebraic mode. It is a
+     * blocking configuration error only when its difference-equation mode is explicitly requested even though no
+     * audited dynamic implementation exists.
+     * </p>
+     *
+     * @return true for an explicitly unsupported capability or algebraic element forced into dynamic mode
+     */
+    public boolean hasUnsupportedDynamicConfiguration() {
+      return capability == DynamicCapability.UNSUPPORTED_DYNAMIC
+          || (capability == DynamicCapability.ALGEBRAIC && isDynamicModeRequested());
+    }
+
+    /**
+     * Whether a custom transient implementation still needs engineering capability review.
+     *
+     * @return true for {@link DynamicCapability#UNCLASSIFIED_DYNAMIC}
+     */
+    public boolean requiresCapabilityReview() {
+      return capability == DynamicCapability.UNCLASSIFIED_DYNAMIC;
+    }
+
+    /**
+     * Whether an audited stored-state dynamic implementation exists but is currently evaluated in steady-state mode.
+     *
+     * @return true for known physical dynamic equipment with {@code calculateSteadyState == true}
+     */
+    public boolean hasInactiveAuditedDynamicState() {
+      return calculateSteadyState != null && calculateSteadyState.booleanValue() && capability.hasExplicitDynamicState();
+    }
+  }
+
+  private DynamicCapabilityReport(List<Entry> entries) {
+    this.entries = Collections.unmodifiableList(new ArrayList<Entry>(entries));
+  }
+
+  /**
+   * Builds a capability report for one process system.
+   *
+   * @param process process system to audit
+   * @return capability report
+   * @throws IllegalArgumentException if process is null
+   */
+  public static DynamicCapabilityReport from(ProcessSystem process) {
+    if (process == null) {
+      throw new IllegalArgumentException("process must not be null");
+    }
+    List<Entry> collected = new ArrayList<Entry>();
+    collectArea("", process, collected);
+    return new DynamicCapabilityReport(collected);
+  }
+
+  /**
+   * Builds a capability report for every process area in a model.
+   *
+   * @param model multi-area process model to audit
+   * @return capability report with area-qualified entries
+   * @throws IllegalArgumentException if model is null
+   */
+  public static DynamicCapabilityReport from(ProcessModel model) {
+    if (model == null) {
+      throw new IllegalArgumentException("model must not be null");
+    }
+    List<Entry> collected = new ArrayList<Entry>();
+    for (String areaName : model.getProcessSystemNames()) {
+      ProcessSystem process = model.get(areaName);
+      if (process != null) {
+        collectArea(areaName, process, collected);
+      }
+    }
+    return new DynamicCapabilityReport(collected);
+  }
+
+  /**
+   * Report schema version.
+   *
+   * @return schema version
+   */
+  public String getSchemaVersion() {
+    return schemaVersion;
+  }
+
+  /**
+   * All audited entries in deterministic area/registration order.
+   *
+   * @return immutable list of entries
+   */
+  public List<Entry> getEntries() {
+    return entries;
+  }
+
+  /**
+   * Counts entries by capability category.
+   *
+   * @return enum map containing every capability, including zero-count categories
+   */
+  public Map<DynamicCapability, Integer> getCapabilityCounts() {
+    Map<DynamicCapability, Integer> counts = new EnumMap<DynamicCapability, Integer>(DynamicCapability.class);
+    for (DynamicCapability capability : DynamicCapability.values()) {
+      counts.put(capability, Integer.valueOf(0));
+    }
+    for (Entry entry : entries) {
+      DynamicCapability capability = entry.getCapability();
+      counts.put(capability, Integer.valueOf(counts.get(capability).intValue() + 1));
+    }
+    return Collections.unmodifiableMap(counts);
+  }
+
+  /**
+   * Returns configuration errors that should block a transient run configured in strict professional-audit mode.
+   *
+   * @return immutable diagnostic strings
+   */
+  public List<String> getBlockingIssues() {
+    List<String> issues = new ArrayList<String>();
+    for (Entry entry : entries) {
+      if (entry.hasUnsupportedDynamicConfiguration()) {
+        if (entry.getCapability() == DynamicCapability.ALGEBRAIC) {
+          issues.add(entry.getQualifiedName() + " requests difference-equation mode but is classified ALGEBRAIC ("
+              + entry.getClassName() + ")");
+        } else {
+          issues.add(entry.getQualifiedName() + " is classified UNSUPPORTED_DYNAMIC (" + entry.getClassName() + ")");
+        }
+      }
+    }
+    return Collections.unmodifiableList(issues);
+  }
+
+  /**
+   * Returns custom transient implementations whose physical state/equations still require audit.
+   *
+   * @return immutable diagnostic strings
+   */
+  public List<String> getReviewItems() {
+    List<String> review = new ArrayList<String>();
+    for (Entry entry : entries) {
+      if (entry.requiresCapabilityReview()) {
+        review.add(entry.getQualifiedName() + " has a custom transient implementation that is not yet classified ("
+            + entry.getClassName() + ")");
+      }
+    }
+    return Collections.unmodifiableList(review);
+  }
+
+  /**
+   * Returns audited dynamic elements that are currently configured to use their steady-state/algebraic path.
+   *
+   * <p>
+   * These are not errors: mixed algebraic/dynamic flowsheets are legitimate. The list is exposed so an engineer can
+   * verify that a unit expected to carry inventory or inertia was actually switched into its dynamic mode.
+   * </p>
+   *
+   * @return immutable list of area-qualified element names
+   */
+  public List<String> getInactiveAuditedDynamicElements() {
+    List<String> inactive = new ArrayList<String>();
+    for (Entry entry : entries) {
+      if (entry.hasInactiveAuditedDynamicState()) {
+        inactive.add(entry.getQualifiedName());
+      }
+    }
+    return Collections.unmodifiableList(inactive);
+  }
+
+  /**
+   * Whether the report contains a known unsupported runtime configuration.
+   *
+   * <p>
+   * A false result is not a professional-readiness or validation certificate; review items and quantitative model
+   * qualification remain separate requirements.
+   * </p>
+   *
+   * @return true if one or more blocking configuration issues exist
+   */
+  public boolean hasBlockingIssues() {
+    for (Entry entry : entries) {
+      if (entry.hasUnsupportedDynamicConfiguration()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Serializes the report for notebooks, MCP clients, CI qualification, and engineering tooling.
+   *
+   * @return pretty-printed JSON
+   */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(this);
+  }
+
+  private static void collectArea(String areaName, ProcessSystem process, List<Entry> target) {
+    Set<ProcessElementInterface> seen = Collections
+        .newSetFromMap(new IdentityHashMap<ProcessElementInterface, Boolean>());
+
+    for (ProcessElementInterface element : process.getAllElements()) {
+      addEntry(areaName, element, target, seen);
+    }
+
+    for (ProcessEquipmentInterface equipment : process.getUnitOperations()) {
+      Collection<ControllerDeviceInterface> controllers = equipment.getControllers();
+      if (controllers == null) {
+        continue;
+      }
+      for (ControllerDeviceInterface controller : controllers) {
+        addEntry(areaName, controller, target, seen);
+      }
+    }
+  }
+
+  private static void addEntry(String areaName, ProcessElementInterface element, List<Entry> target,
+      Set<ProcessElementInterface> seen) {
+    if (element == null || !seen.add(element)) {
+      return;
+    }
+    target.add(new Entry(areaName, element));
+  }
+
+  private static String categoryOf(ProcessElementInterface element) {
+    if (element instanceof ControllerDeviceInterface) {
+      return "controller";
+    }
+    if (element instanceof MeasurementDeviceInterface) {
+      return "measurement";
+    }
+    if (element instanceof ProcessEquipmentInterface) {
+      return "equipment";
+    }
+    return "element";
+  }
+}

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
@@ -304,9 +304,9 @@ public final class DynamicCapabilityReport implements Serializable {
    * Returns all issues that fail the opt-in strict transient preflight.
    *
    * <p>
-   * Strict preflight combines known unsupported runtime configurations with unaudited custom transient
-   * implementations. It deliberately does not reject audited dynamic equipment that remains in steady-state mode,
-   * because mixed algebraic/dynamic flowsheets are valid when that choice is intentional.
+   * Strict preflight combines known unsupported runtime configurations with unaudited custom transient implementations.
+   * It deliberately does not reject audited dynamic equipment that remains in steady-state mode, because mixed
+   * algebraic/dynamic flowsheets are valid when that choice is intentional.
    * </p>
    *
    * @return immutable list of strict-preflight issues

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
@@ -322,8 +322,8 @@ public final class DynamicCapabilityReport implements Serializable {
    * @return enum map containing every activation status, including zero-count categories
    */
   public Map<DynamicActivationStatus, Integer> getActivationCounts() {
-    Map<DynamicActivationStatus, Integer> counts =
-        new EnumMap<DynamicActivationStatus, Integer>(DynamicActivationStatus.class);
+    Map<DynamicActivationStatus, Integer> counts = new EnumMap<DynamicActivationStatus, Integer>(
+        DynamicActivationStatus.class);
     for (DynamicActivationStatus status : DynamicActivationStatus.values()) {
       counts.put(status, Integer.valueOf(0));
     }
@@ -496,8 +496,8 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   private static void collectArea(String areaName, ProcessSystem process, List<Entry> target) {
-    Set<ProcessElementInterface> seenElements =
-        Collections.newSetFromMap(new IdentityHashMap<ProcessElementInterface, Boolean>());
+    Set<ProcessElementInterface> seenElements = Collections
+        .newSetFromMap(new IdentityHashMap<ProcessElementInterface, Boolean>());
     Set<ProcessSystem> seenProcesses = Collections.newSetFromMap(new IdentityHashMap<ProcessSystem, Boolean>());
     collectProcess(areaName, "", process, target, seenElements, seenProcesses);
   }

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
@@ -24,18 +24,19 @@ import neqsim.process.processmodel.ProcessSystem;
  *
  * <p>
  * The report is intentionally diagnostic rather than a readiness certificate. It distinguishes audited stored-state
- * dynamics from algebraic timestep evaluation, identifies explicitly requested configurations that cannot use the
- * default transient boundary, and keeps unaudited custom transient implementations visible as review items.
+ * dynamics from algebraic timestep evaluation, reports type-specific runtime activation separately from state
+ * ownership, identifies explicitly requested configurations that cannot use the default transient boundary, and keeps
+ * unaudited custom transient implementations visible as review items.
  * </p>
  *
  * @author Even Solbraa
- * @version 1.0
+ * @version 1.1
  */
 public final class DynamicCapabilityReport implements Serializable {
   private static final long serialVersionUID = 1000L;
 
   /** Schema version for serialized/JSON reports. */
-  private static final String SCHEMA_VERSION = "1.0";
+  private static final String SCHEMA_VERSION = "1.1";
 
   private final String schemaVersion = SCHEMA_VERSION;
   private final List<Entry> entries;
@@ -44,7 +45,7 @@ public final class DynamicCapabilityReport implements Serializable {
    * Immutable record describing one process element in the capability audit.
    *
    * @author Even Solbraa
-   * @version 1.0
+   * @version 1.1
    */
   public static final class Entry implements Serializable {
     private static final long serialVersionUID = 1000L;
@@ -56,6 +57,8 @@ public final class DynamicCapabilityReport implements Serializable {
     private final String className;
     private final DynamicCapability capability;
     private final Boolean calculateSteadyState;
+    private final DynamicActivationStatus activationStatus;
+    private final String activationDiagnostic;
 
     private Entry(String areaName, String containerPath, ProcessElementInterface element) {
       this.areaName = areaName == null ? "" : areaName;
@@ -67,6 +70,8 @@ public final class DynamicCapabilityReport implements Serializable {
       this.calculateSteadyState = element instanceof SimulationInterface
           ? Boolean.valueOf(((SimulationInterface) element).getCalculateSteadyState())
           : null;
+      this.activationStatus = DynamicActivationResolver.resolve(element);
+      this.activationDiagnostic = DynamicActivationResolver.diagnostic(element);
     }
 
     /**
@@ -133,6 +138,24 @@ public final class DynamicCapabilityReport implements Serializable {
     }
 
     /**
+     * Type-specific runtime activation status, kept separate from state ownership.
+     *
+     * @return activation status
+     */
+    public DynamicActivationStatus getActivationStatus() {
+      return activationStatus;
+    }
+
+    /**
+     * Diagnostic explaining the current runtime activation status.
+     *
+     * @return activation diagnostic
+     */
+    public String getActivationDiagnostic() {
+      return activationDiagnostic;
+    }
+
+    /**
      * Area- and module-qualified name suitable for diagnostics.
      *
      * @return {@code area::module::name} where applicable
@@ -143,7 +166,13 @@ public final class DynamicCapabilityReport implements Serializable {
     }
 
     /**
-     * Whether the runtime configuration requests the element-specific difference-equation path.
+     * Whether the runtime configuration requests the element-specific difference-equation path through the generic
+     * simulation flag.
+     *
+     * <p>
+     * This is a requested-mode indicator only. It does not prove that a subclass enters its stateful path; use
+     * {@link #getActivationStatus()} for type-specific activation evidence where available.
+     * </p>
      *
      * @return true when a {@link SimulationInterface} has {@code calculateSteadyState == false}
      */
@@ -169,6 +198,15 @@ public final class DynamicCapabilityReport implements Serializable {
     }
 
     /**
+     * Whether a type-specific activation audit found a requested/enabled dynamic path with missing prerequisites.
+     *
+     * @return true when runtime activation configuration is incomplete
+     */
+    public boolean hasIncompleteDynamicActivation() {
+      return activationStatus == DynamicActivationStatus.INCOMPLETE_CONFIGURATION;
+    }
+
+    /**
      * Whether a custom transient implementation still needs engineering capability review.
      *
      * @return true for {@link DynamicCapability#UNCLASSIFIED_DYNAMIC}
@@ -178,13 +216,27 @@ public final class DynamicCapabilityReport implements Serializable {
     }
 
     /**
-     * Whether an audited stored-state dynamic implementation exists but is currently evaluated in steady-state mode.
+     * Whether an audited stored-state dynamic implementation is currently known to be inactive.
      *
-     * @return true for known physical dynamic equipment with {@code calculateSteadyState == true}
+     * <p>
+     * Type-specific activation evidence takes precedence over the generic steady-state flag. For equipment families
+     * whose activation semantics are still unverified, the historical {@code calculateSteadyState} flag remains a
+     * conservative engineering review aid rather than a proof of actual runtime activation.
+     * </p>
+     *
+     * @return true when the dynamic state is known or conservatively indicated to be inactive
      */
     public boolean hasInactiveAuditedDynamicState() {
-      return calculateSteadyState != null && calculateSteadyState.booleanValue()
-          && capability.hasExplicitDynamicState();
+      if (!capability.hasExplicitDynamicState()) {
+        return false;
+      }
+      if (activationStatus == DynamicActivationStatus.INACTIVE) {
+        return true;
+      }
+      if (activationStatus != DynamicActivationStatus.UNVERIFIED) {
+        return false;
+      }
+      return calculateSteadyState != null && calculateSteadyState.booleanValue();
     }
   }
 
@@ -265,6 +317,24 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   /**
+   * Counts entries by runtime activation status.
+   *
+   * @return enum map containing every activation status, including zero-count categories
+   */
+  public Map<DynamicActivationStatus, Integer> getActivationCounts() {
+    Map<DynamicActivationStatus, Integer> counts =
+        new EnumMap<DynamicActivationStatus, Integer>(DynamicActivationStatus.class);
+    for (DynamicActivationStatus status : DynamicActivationStatus.values()) {
+      counts.put(status, Integer.valueOf(0));
+    }
+    for (Entry entry : entries) {
+      DynamicActivationStatus status = entry.getActivationStatus();
+      counts.put(status, Integer.valueOf(counts.get(status).intValue() + 1));
+    }
+    return Collections.unmodifiableMap(counts);
+  }
+
+  /**
    * Returns configuration errors that should block a transient run configured in strict professional-audit mode.
    *
    * @return immutable diagnostic strings
@@ -279,6 +349,10 @@ public final class DynamicCapabilityReport implements Serializable {
         } else {
           issues.add(entry.getQualifiedName() + " is classified UNSUPPORTED_DYNAMIC (" + entry.getClassName() + ")");
         }
+      }
+      if (entry.hasIncompleteDynamicActivation()) {
+        issues.add(entry.getQualifiedName() + " has incomplete runtime dynamic activation: "
+            + entry.getActivationDiagnostic() + " (" + entry.getClassName() + ")");
       }
     }
     return Collections.unmodifiableList(issues);
@@ -301,12 +375,34 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   /**
+   * Returns elements with explicit dynamic capability whose type-specific runtime activation is still unaudited.
+   *
+   * <p>
+   * These are review aids, not strict-preflight failures. The capability campaign can therefore add activation audits
+   * incrementally without making every existing mixed algebraic/dynamic model unusable in the meantime.
+   * </p>
+   *
+   * @return immutable area-qualified element names
+   */
+  public List<String> getUnverifiedActivationElements() {
+    List<String> unverified = new ArrayList<String>();
+    for (Entry entry : entries) {
+      if (entry.getCapability().hasExplicitDynamicState()
+          && entry.getActivationStatus() == DynamicActivationStatus.UNVERIFIED) {
+        unverified.add(entry.getQualifiedName());
+      }
+    }
+    return Collections.unmodifiableList(unverified);
+  }
+
+  /**
    * Returns all issues that fail the opt-in strict transient preflight.
    *
    * <p>
-   * Strict preflight combines known unsupported runtime configurations with unaudited custom transient implementations.
-   * It deliberately does not reject audited dynamic equipment that remains in steady-state mode, because mixed
-   * algebraic/dynamic flowsheets are valid when that choice is intentional.
+   * Strict preflight combines known unsupported runtime configurations, incomplete type-specific activation, and
+   * unaudited custom transient implementations. It deliberately does not reject audited dynamic equipment that is
+   * intentionally inactive, nor does it reject families whose activation semantics are still marked UNVERIFIED; those
+   * remain visible through dedicated review diagnostics.
    * </p>
    *
    * @return immutable list of strict-preflight issues
@@ -322,9 +418,9 @@ public final class DynamicCapabilityReport implements Serializable {
    * Whether the process/model passes the opt-in strict transient capability preflight.
    *
    * <p>
-   * A true result only means that no currently known unsupported configuration or unaudited custom transient
-   * implementation was found. It is not a quantitative validation, conformance, safety, or professional-readiness
-   * certificate.
+   * A true result only means that no currently known unsupported configuration, incomplete audited activation, or
+   * unaudited custom transient implementation was found. It is not a quantitative validation, conformance, safety, or
+   * professional-readiness certificate.
    * </p>
    *
    * @return true when {@link #getStrictPreflightIssues()} is empty
@@ -351,11 +447,12 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   /**
-   * Returns audited dynamic elements that are currently configured to use their steady-state/algebraic path.
+   * Returns audited dynamic elements that are currently configured or conservatively indicated to use a non-stateful
+   * path.
    *
    * <p>
-   * These are not errors: mixed algebraic/dynamic flowsheets are legitimate. The list is exposed so an engineer can
-   * verify that a unit expected to carry inventory or inertia was actually switched into its dynamic mode.
+   * These are not errors: mixed algebraic/dynamic flowsheets are legitimate. Type-specific activation status takes
+   * precedence over the generic {@code calculateSteadyState} flag where available.
    * </p>
    *
    * @return immutable list of area-qualified element names
@@ -371,18 +468,18 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   /**
-   * Whether the report contains a known unsupported runtime configuration.
+   * Whether the report contains a known unsupported or incomplete runtime configuration.
    *
    * <p>
-   * A false result is not a professional-readiness or validation certificate; review items and quantitative model
-   * qualification remain separate requirements.
+   * A false result is not a professional-readiness or validation certificate; review items, activation audits, and
+   * quantitative model qualification remain separate requirements.
    * </p>
    *
    * @return true if one or more blocking configuration issues exist
    */
   public boolean hasBlockingIssues() {
     for (Entry entry : entries) {
-      if (entry.hasUnsupportedDynamicConfiguration()) {
+      if (entry.hasUnsupportedDynamicConfiguration() || entry.hasIncompleteDynamicActivation()) {
         return true;
       }
     }
@@ -399,8 +496,8 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   private static void collectArea(String areaName, ProcessSystem process, List<Entry> target) {
-    Set<ProcessElementInterface> seenElements = Collections
-        .newSetFromMap(new IdentityHashMap<ProcessElementInterface, Boolean>());
+    Set<ProcessElementInterface> seenElements =
+        Collections.newSetFromMap(new IdentityHashMap<ProcessElementInterface, Boolean>());
     Set<ProcessSystem> seenProcesses = Collections.newSetFromMap(new IdentityHashMap<ProcessSystem, Boolean>());
     collectProcess(areaName, "", process, target, seenElements, seenProcesses);
   }

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
@@ -169,7 +169,8 @@ public final class DynamicCapabilityReport implements Serializable {
      * @return true for known physical dynamic equipment with {@code calculateSteadyState == true}
      */
     public boolean hasInactiveAuditedDynamicState() {
-      return calculateSteadyState != null && calculateSteadyState.booleanValue() && capability.hasExplicitDynamicState();
+      return calculateSteadyState != null && calculateSteadyState.booleanValue()
+          && capability.hasExplicitDynamicState();
     }
   }
 

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
@@ -440,8 +440,8 @@ public final class DynamicCapabilityReport implements Serializable {
    *
    * <p>
    * A true result only means that no currently known unsupported configuration, incomplete audited activation,
-   * unqualified process execution mode, or unaudited custom transient implementation was found. It is not a quantitative
-   * validation, conformance, safety, or professional-readiness certificate.
+   * unqualified process execution mode, or unaudited custom transient implementation was found. It is not a
+   * quantitative validation, conformance, safety, or professional-readiness certificate.
    * </p>
    *
    * @return true when {@link #getStrictPreflightIssues()} is empty

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
@@ -7,6 +7,7 @@ import neqsim.process.SimulationInterface;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.equipment.pipeline.OnePhasePipeLine;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
 import neqsim.process.equipment.pipeline.WaterHammerPipe;
 import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
@@ -53,7 +54,8 @@ public final class DynamicCapabilityResolver {
       return DynamicCapability.CONTROL_DYNAMIC;
     }
 
-    if (element instanceof TwoFluidPipe || element instanceof TransientPipe || element instanceof WaterHammerPipe) {
+    if (element instanceof OnePhasePipeLine || element instanceof TwoFluidPipe || element instanceof TransientPipe
+        || element instanceof WaterHammerPipe) {
       return DynamicCapability.DYNAMIC_DISTRIBUTED;
     }
 

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
@@ -6,6 +6,7 @@ import neqsim.process.ProcessElementInterface;
 import neqsim.process.SimulationInterface;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.energy.EnergyConverter;
 import neqsim.process.equipment.energy.EnergyNetworkSolver;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
 import neqsim.process.equipment.pipeline.OnePhasePipeLine;
@@ -74,7 +75,8 @@ public final class DynamicCapabilityResolver {
     }
 
     if (element instanceof Separator || element instanceof Tank || element instanceof HeatExchanger
-        || element instanceof Compressor || element instanceof Pump || element instanceof ThrottlingValve) {
+        || element instanceof Compressor || element instanceof Pump || element instanceof ThrottlingValve
+        || element instanceof EnergyConverter) {
       return DynamicCapability.DYNAMIC_LUMPED;
     }
 

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
@@ -13,6 +13,7 @@ import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.reservoir.SimpleReservoir;
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.tank.Tank;
 import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
@@ -65,11 +66,38 @@ public final class DynamicCapabilityResolver {
       return DynamicCapability.DYNAMIC_LUMPED;
     }
 
+    if (element instanceof Stream && usesStandardStreamTransientBoundary(element)) {
+      return DynamicCapability.ALGEBRAIC;
+    }
+
     if (hasCustomTransientImplementation(element)) {
       return DynamicCapability.UNCLASSIFIED_DYNAMIC;
     }
 
     return DynamicCapability.ALGEBRAIC;
+  }
+
+  /**
+   * Whether a stream uses NeqSim's established algebraic transient boundary.
+   *
+   * <p>
+   * {@link Stream#runTransient(double, UUID)} re-evaluates the stream and advances its execution clock, but it does not
+   * integrate stored physical state. Stream subclasses that inherit that method remain algebraic; subclasses that
+   * override it continue through the conservative custom-implementation audit below.
+   * </p>
+   *
+   * @param element stream element to inspect
+   * @return true when the effective transient method is declared by {@link Stream}
+   */
+  private static boolean usesStandardStreamTransientBoundary(ProcessElementInterface element) {
+    try {
+      Method method = element.getClass().getMethod("runTransient", Double.TYPE, UUID.class);
+      return method.getDeclaringClass() == Stream.class;
+    } catch (NoSuchMethodException ex) {
+      return false;
+    } catch (SecurityException ex) {
+      return false;
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
@@ -18,6 +18,7 @@ import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.tank.Tank;
 import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
+import neqsim.process.processmodel.ModuleInterface;
 
 /**
  * Transitional resolver for the dynamic capability of existing NeqSim process elements.
@@ -52,6 +53,10 @@ public final class DynamicCapabilityResolver {
 
     if (element instanceof ControllerDeviceInterface || element instanceof MeasurementDeviceInterface) {
       return DynamicCapability.CONTROL_DYNAMIC;
+    }
+
+    if (element instanceof ModuleInterface) {
+      return DynamicCapability.ALGEBRAIC;
     }
 
     if (element instanceof OnePhasePipeLine || element instanceof TwoFluidPipe || element instanceof TransientPipe

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
@@ -6,6 +6,7 @@ import neqsim.process.ProcessElementInterface;
 import neqsim.process.SimulationInterface;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.diffpressure.Orifice;
 import neqsim.process.equipment.energy.EnergyConverter;
 import neqsim.process.equipment.energy.EnergyNetworkSolver;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
@@ -15,6 +16,7 @@ import neqsim.process.equipment.pipeline.WaterHammerPipe;
 import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.reservoir.SimpleReservoir;
+import neqsim.process.equipment.reservoir.WellFlow;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.tank.Tank;
@@ -61,7 +63,7 @@ public final class DynamicCapabilityResolver {
       return DynamicCapability.ALGEBRAIC;
     }
 
-    if (element instanceof EnergyNetworkSolver) {
+    if (element instanceof EnergyNetworkSolver || element instanceof Orifice || element instanceof WellFlow) {
       return DynamicCapability.ALGEBRAIC;
     }
 

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
@@ -1,0 +1,100 @@
+package neqsim.process.dynamics;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+import neqsim.process.ProcessElementInterface;
+import neqsim.process.SimulationInterface;
+import neqsim.process.controllerdevice.ControllerDeviceInterface;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.WaterHammerPipe;
+import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
+import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.reservoir.SimpleReservoir;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.tank.Tank;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.measurementdevice.MeasurementDeviceInterface;
+
+/**
+ * Transitional resolver for the dynamic capability of existing NeqSim process elements.
+ *
+ * <p>
+ * The long-term contract allows individual element types to override
+ * {@link neqsim.process.ProcessElementInterface#getDynamicCapability()}. During the capability-audit campaign, this
+ * resolver provides conservative classifications for core models whose state semantics are already evident from their
+ * implementations. A class that overrides the standard transient boundary but has not yet been audited is deliberately
+ * returned as {@link DynamicCapability#UNCLASSIFIED_DYNAMIC}; it is never silently promoted to a professional dynamic
+ * model just because a {@code runTransient} method exists.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public final class DynamicCapabilityResolver {
+  /** Utility class. */
+  private DynamicCapabilityResolver() {
+  }
+
+  /**
+   * Resolve the best currently audited dynamic capability for an element.
+   *
+   * @param element process element to classify
+   * @return dynamic capability; never null
+   */
+  public static DynamicCapability resolve(ProcessElementInterface element) {
+    if (element == null) {
+      return DynamicCapability.UNSUPPORTED_DYNAMIC;
+    }
+
+    if (element instanceof ControllerDeviceInterface || element instanceof MeasurementDeviceInterface) {
+      return DynamicCapability.CONTROL_DYNAMIC;
+    }
+
+    if (element instanceof TwoFluidPipe || element instanceof TransientPipe || element instanceof WaterHammerPipe) {
+      return DynamicCapability.DYNAMIC_DISTRIBUTED;
+    }
+
+    if (element instanceof SimpleReservoir) {
+      return DynamicCapability.BOUNDARY_DYNAMIC;
+    }
+
+    if (element instanceof Separator || element instanceof Tank || element instanceof HeatExchanger
+        || element instanceof Compressor || element instanceof Pump || element instanceof ThrottlingValve) {
+      return DynamicCapability.DYNAMIC_LUMPED;
+    }
+
+    if (hasCustomTransientImplementation(element)) {
+      return DynamicCapability.UNCLASSIFIED_DYNAMIC;
+    }
+
+    return DynamicCapability.ALGEBRAIC;
+  }
+
+  /**
+   * Detects whether a simulation object overrides the default algebraic transient boundary.
+   *
+   * <p>
+   * This is a discovery mechanism only. An override proves that custom transient code exists; it does not prove that
+   * the implementation contains physically valid stored state, conserves the appropriate quantities, or has been
+   * quantitatively validated.
+   * </p>
+   *
+   * @param element process element to inspect
+   * @return true if {@code runTransient(double, UUID)} is declared outside {@link SimulationInterface}
+   */
+  static boolean hasCustomTransientImplementation(ProcessElementInterface element) {
+    if (!(element instanceof SimulationInterface)) {
+      return false;
+    }
+    try {
+      Method method = element.getClass().getMethod("runTransient", Double.TYPE, UUID.class);
+      return method.getDeclaringClass() != SimulationInterface.class;
+    } catch (NoSuchMethodException ex) {
+      return false;
+    } catch (SecurityException ex) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
@@ -6,6 +6,8 @@ import neqsim.process.ProcessElementInterface;
 import neqsim.process.SimulationInterface;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.diffpressure.Orifice;
+import neqsim.process.equipment.energy.EnergyNetworkSolver;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
 import neqsim.process.equipment.pipeline.OnePhasePipeLine;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
@@ -56,6 +58,10 @@ public final class DynamicCapabilityResolver {
     }
 
     if (element instanceof ModuleInterface) {
+      return DynamicCapability.ALGEBRAIC;
+    }
+
+    if (element instanceof Orifice || element instanceof EnergyNetworkSolver) {
       return DynamicCapability.ALGEBRAIC;
     }
 

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
@@ -6,7 +6,6 @@ import neqsim.process.ProcessElementInterface;
 import neqsim.process.SimulationInterface;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.equipment.compressor.Compressor;
-import neqsim.process.equipment.diffpressure.Orifice;
 import neqsim.process.equipment.energy.EnergyNetworkSolver;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
 import neqsim.process.equipment.pipeline.OnePhasePipeLine;
@@ -61,7 +60,7 @@ public final class DynamicCapabilityResolver {
       return DynamicCapability.ALGEBRAIC;
     }
 
-    if (element instanceof Orifice || element instanceof EnergyNetworkSolver) {
+    if (element instanceof EnergyNetworkSolver) {
       return DynamicCapability.ALGEBRAIC;
     }
 

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import neqsim.process.ProcessElementInterface;
 import neqsim.process.SimulationInterface;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
+import neqsim.process.equipment.battery.BatteryStorage;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.diffpressure.Orifice;
 import neqsim.process.equipment.energy.EnergyConverter;
@@ -78,7 +79,7 @@ public final class DynamicCapabilityResolver {
 
     if (element instanceof Separator || element instanceof Tank || element instanceof HeatExchanger
         || element instanceof Compressor || element instanceof Pump || element instanceof ThrottlingValve
-        || element instanceof EnergyConverter) {
+        || element instanceof EnergyConverter || element instanceof BatteryStorage) {
       return DynamicCapability.DYNAMIC_LUMPED;
     }
 

--- a/src/main/java/neqsim/process/dynamics/EventScheduler.java
+++ b/src/main/java/neqsim/process/dynamics/EventScheduler.java
@@ -205,21 +205,36 @@ public class EventScheduler implements Serializable {
   }
 
   /**
-   * Fires all events with {@code time <= now} in time order. Each event is removed from the pending queue and appended
-   * to the fired log.
+   * Fires all events with {@code time <= now} in time order.
+   *
+   * <p>
+   * An event is removed from the pending queue and appended to the fired log only after its action completes
+   * successfully. If an action throws a {@link RuntimeException}, the failure is logged and rethrown immediately. The
+   * failing event remains pending, later due events are not executed, and the caller can abort the physical-step
+   * attempt instead of silently continuing after a failed trip, setpoint, or operator action.
+   * </p>
+   *
+   * <p>
+   * This fail-loud bookkeeping contract is not a whole-process transaction: an action that mutates external state and
+   * then throws may already have produced side effects. Qualified rejected-step execution must still restore every
+   * mutated object or defer side effects until step acceptance.
+   * </p>
    *
    * @param now current simulation time in seconds
-   * @return number of events fired in this call
+   * @return number of events fired successfully in this call
+   * @throws RuntimeException if a due event action fails
    */
   public int fireDueEvents(double now) {
     int count = 0;
     while (!queue.isEmpty() && queue.get(0).time <= now) {
-      ScheduledEvent e = queue.remove(0);
+      ScheduledEvent e = queue.get(0);
       try {
         e.action.run();
       } catch (RuntimeException ex) {
         logger.error("EventScheduler event '{}' failed: {}", e.label, ex.getMessage(), ex);
+        throw ex;
       }
+      queue.remove(0);
       fired.add(e);
       count++;
     }

--- a/src/main/java/neqsim/process/dynamics/EventScheduler.java
+++ b/src/main/java/neqsim/process/dynamics/EventScheduler.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Simple priority-queue-backed event scheduler for dynamic process simulations and safety studies.
@@ -25,9 +27,9 @@ import java.util.List;
  * </ul>
  *
  * <p>
- * Events are {@link Serializable} so a scheduler instance can be carried inside a serialized {@code ProcessSystem}
- * snapshot. The {@link Runnable} payload must therefore also be serializable; agent code typically uses a tiny static
- * class or a lambda over serializable fields.
+ * The scheduler itself is {@link Serializable}. It can therefore be serialized independently when every
+ * {@link Runnable} payload is also serializable. The scheduler attached to {@code ProcessSystem} is intentionally a
+ * transient runtime service and is not included automatically in a serialized process snapshot.
  * </p>
  *
  * @author Even Solbraa
@@ -36,6 +38,7 @@ import java.util.List;
 public class EventScheduler implements Serializable {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000L;
+  private static final Logger logger = LogManager.getLogger(EventScheduler.class);
 
   /**
    * A scheduled event: trigger time, label, and payload.
@@ -53,7 +56,7 @@ public class EventScheduler implements Serializable {
      *
      * @param time absolute simulation time in seconds (must be finite and {@code >= 0})
      * @param label short tag for diagnostics
-     * @param action payload (must be non-null and serializable)
+     * @param action payload (must be non-null; must also be serializable when the scheduler itself is serialized)
      */
     public ScheduledEvent(double time, String label, Runnable action) {
       if (Double.isNaN(time) || Double.isInfinite(time) || time < 0.0) {
@@ -101,6 +104,45 @@ public class EventScheduler implements Serializable {
     }
   }
 
+  /**
+   * Immutable scheduler-bookkeeping snapshot used by transient step transactions.
+   *
+   * <p>
+   * Scheduled events are immutable, so the snapshot can retain their identities while copying the pending/fired list
+   * membership. Restoring this snapshot rolls back scheduler bookkeeping only. It cannot undo side effects already
+   * performed by an event {@link Runnable}; rejected trial steps must therefore defer externally visible event actions
+   * or restore every object mutated by those actions separately.
+   * </p>
+   */
+  public static final class Snapshot implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final List<ScheduledEvent> pendingEvents;
+    private final List<ScheduledEvent> firedEvents;
+
+    private Snapshot(List<ScheduledEvent> pendingEvents, List<ScheduledEvent> firedEvents) {
+      this.pendingEvents = new ArrayList<ScheduledEvent>(pendingEvents);
+      this.firedEvents = new ArrayList<ScheduledEvent>(firedEvents);
+    }
+
+    /**
+     * Number of pending events represented by this snapshot.
+     *
+     * @return pending event count
+     */
+    public int getPendingEventCount() {
+      return pendingEvents.size();
+    }
+
+    /**
+     * Number of already-fired events represented by this snapshot.
+     *
+     * @return fired event count
+     */
+    public int getFiredEventCount() {
+      return firedEvents.size();
+    }
+  }
+
   private final List<ScheduledEvent> queue = new ArrayList<ScheduledEvent>();
   private final List<ScheduledEvent> fired = new ArrayList<ScheduledEvent>();
 
@@ -116,7 +158,7 @@ public class EventScheduler implements Serializable {
    *
    * @param time absolute simulation time in seconds
    * @param label short tag (may be null)
-   * @param action serializable payload
+   * @param action payload
    * @return the scheduled event
    */
   public ScheduledEvent scheduleEvent(double time, String label, Runnable action) {
@@ -140,13 +182,48 @@ public class EventScheduler implements Serializable {
       try {
         e.action.run();
       } catch (RuntimeException ex) {
-        // surface but do not propagate — dynamic loop must keep running
-        System.err.println("EventScheduler: event '" + e.label + "' threw: " + ex.getMessage());
+        logger.error("EventScheduler event '{}' failed: {}", e.label, ex.getMessage(), ex);
       }
       fired.add(e);
       count++;
     }
     return count;
+  }
+
+  /**
+   * Captures the pending/fired scheduler bookkeeping for deterministic transient rollback.
+   *
+   * <p>
+   * This operation does not execute, clone, or serialize event actions. The returned snapshot is independent of later
+   * queue/list changes because it copies both event lists.
+   * </p>
+   *
+   * @return immutable scheduler bookkeeping snapshot
+   */
+  public Snapshot snapshot() {
+    return new Snapshot(queue, fired);
+  }
+
+  /**
+   * Restores pending/fired scheduler bookkeeping from a previous {@link #snapshot()}.
+   *
+   * <p>
+   * Restoring membership does not reverse side effects from actions that have already executed. A rejected transient
+   * trial must not rely on this method alone when an event mutates external state.
+   * </p>
+   *
+   * @param snapshot snapshot to restore
+   * @throws IllegalArgumentException if snapshot is null
+   */
+  public void restore(Snapshot snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("snapshot must not be null");
+    }
+    queue.clear();
+    queue.addAll(snapshot.pendingEvents);
+    Collections.sort(queue);
+    fired.clear();
+    fired.addAll(snapshot.firedEvents);
   }
 
   /**

--- a/src/main/java/neqsim/process/dynamics/EventScheduler.java
+++ b/src/main/java/neqsim/process/dynamics/EventScheduler.java
@@ -169,6 +169,42 @@ public class EventScheduler implements Serializable {
   }
 
   /**
+   * Returns the earliest pending event time without mutating scheduler state.
+   *
+   * <p>
+   * Adaptive/event-aware integrators can use this value to shorten a proposed timestep so an accepted physical step
+   * lands exactly on an event boundary rather than stepping past a trip, setpoint change, or operator action.
+   * </p>
+   *
+   * @return earliest pending absolute event time in seconds, or positive infinity when no event is pending
+   */
+  public double getNextEventTime() {
+    return queue.isEmpty() ? Double.POSITIVE_INFINITY : queue.get(0).time;
+  }
+
+  /**
+   * Returns pending events that are due at or before {@code now} without firing or removing them.
+   *
+   * <p>
+   * The returned list is an immutable copy in scheduler order. This allows a transient transaction/event-localization
+   * layer to inspect an event boundary without changing pending/fired bookkeeping or executing event actions.
+   * </p>
+   *
+   * @param now absolute simulation time in seconds
+   * @return immutable copy of due pending events
+   */
+  public List<ScheduledEvent> getDueEvents(double now) {
+    List<ScheduledEvent> due = new ArrayList<ScheduledEvent>();
+    for (ScheduledEvent event : queue) {
+      if (event.time > now) {
+        break;
+      }
+      due.add(event);
+    }
+    return Collections.unmodifiableList(due);
+  }
+
+  /**
    * Fires all events with {@code time <= now} in time order. Each event is removed from the pending queue and appended
    * to the fired log.
    *

--- a/src/main/java/neqsim/process/dynamics/TransientStepIdentifier.java
+++ b/src/main/java/neqsim/process/dynamics/TransientStepIdentifier.java
@@ -75,7 +75,7 @@ public final class TransientStepIdentifier {
   }
 
   private static UUID nameUuid(String kind, String scope, long index) {
-    String value = NAMESPACE + "\u0000" + kind + "\u0000" + scope + "\u0000" + index;
+    String value = NAMESPACE + ":" + kind.length() + ":" + kind + ":" + scope.length() + ":" + scope + ":" + index;
     return UUID.nameUUIDFromBytes(value.getBytes(StandardCharsets.UTF_8));
   }
 

--- a/src/main/java/neqsim/process/dynamics/TransientStepIdentifier.java
+++ b/src/main/java/neqsim/process/dynamics/TransientStepIdentifier.java
@@ -13,8 +13,9 @@ import java.util.UUID;
  * </p>
  *
  * <p>
- * Evaluation identifiers are separate diagnostic identities for nonlinear/refinement/substep work. They must not replace
- * the physical-step identifier when invoking equipment or controllers whose idempotency is keyed to the physical step.
+ * Evaluation identifiers are separate diagnostic identities for nonlinear/refinement/substep work. They must not
+ * replace the physical-step identifier when invoking equipment or controllers whose idempotency is keyed to the
+ * physical step.
  * </p>
  *
  * @author Even Solbraa

--- a/src/main/java/neqsim/process/dynamics/TransientStepIdentifier.java
+++ b/src/main/java/neqsim/process/dynamics/TransientStepIdentifier.java
@@ -1,0 +1,93 @@
+package neqsim.process.dynamics;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * Creates calculation identifiers with explicit transient physical-step semantics.
+ *
+ * <p>
+ * A non-null identifier passed to {@code ProcessSystem.runTransient(dt, id)} identifies one physical timestep. The same
+ * physical-step identifier may be reused for repeated algebraic/nonlinear evaluations inside that timestep so mutable
+ * clocks and controllers remain idempotent. The next physical timestep must use a different identifier.
+ * </p>
+ *
+ * <p>
+ * Evaluation identifiers are separate diagnostic identities for nonlinear/refinement/substep work. They must not replace
+ * the physical-step identifier when invoking equipment or controllers whose idempotency is keyed to the physical step.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public final class TransientStepIdentifier {
+  private static final String NAMESPACE = "neqsim-transient-step-v1";
+
+  private TransientStepIdentifier() {
+  }
+
+  /**
+   * Creates a random identifier for one physical timestep.
+   *
+   * @return new physical-step identifier
+   */
+  public static UUID randomPhysicalStep() {
+    return UUID.randomUUID();
+  }
+
+  /**
+   * Creates a reproducible identifier for one physical timestep in a named run or scenario.
+   *
+   * <p>
+   * This is useful for deterministic safety scenarios, regression tests and OTS replay. The same scope and step index
+   * always produce the same UUID, while adjacent physical steps produce different UUIDs.
+   * </p>
+   *
+   * @param scope stable run, scenario or replay identity
+   * @param physicalStepIndex zero-based physical-step index
+   * @return deterministic physical-step identifier
+   */
+  public static UUID deterministicPhysicalStep(String scope, long physicalStepIndex) {
+    validateScope(scope);
+    validateIndex("physicalStepIndex", physicalStepIndex);
+    return nameUuid("physical", scope, physicalStepIndex);
+  }
+
+  /**
+   * Creates a reproducible diagnostic identity for one refinement/nonlinear evaluation within a physical timestep.
+   *
+   * <p>
+   * This identity is for diagnostics, residual histories and solver bookkeeping. Continue passing the parent
+   * {@code physicalStepIdentifier} to equipment/controller {@code runTransient} calls so one physical step advances
+   * mutable state exactly once.
+   * </p>
+   *
+   * @param physicalStepIdentifier parent physical-step identifier
+   * @param evaluationIndex zero-based evaluation/refinement index
+   * @return deterministic evaluation identifier
+   */
+  public static UUID deterministicEvaluation(UUID physicalStepIdentifier, long evaluationIndex) {
+    if (physicalStepIdentifier == null) {
+      throw new IllegalArgumentException("physicalStepIdentifier must not be null");
+    }
+    validateIndex("evaluationIndex", evaluationIndex);
+    return nameUuid("evaluation", physicalStepIdentifier.toString(), evaluationIndex);
+  }
+
+  private static UUID nameUuid(String kind, String scope, long index) {
+    String value = NAMESPACE + "\u0000" + kind + "\u0000" + scope + "\u0000" + index;
+    return UUID.nameUUIDFromBytes(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void validateScope(String scope) {
+    if (scope == null || scope.trim().isEmpty()) {
+      throw new IllegalArgumentException("scope must not be null or empty");
+    }
+  }
+
+  private static void validateIndex(String name, long index) {
+    if (index < 0L) {
+      throw new IllegalArgumentException(name + " must be >= 0: " + index);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
+++ b/src/main/java/neqsim/process/equipment/battery/BatteryStorage.java
@@ -37,6 +37,12 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
   private double maximumDischargePower = Double.POSITIVE_INFINITY;
   private double powerRampRate = Double.POSITIVE_INFINITY;
   private boolean tripped = false;
+  /** Power at the start of the current physical transient step. */
+  private double transientStepStartPower = 0.0;
+  /** Stored energy at the start of the current physical transient step, in Wh. */
+  private double transientStepStartStateOfCharge = 0.0;
+  /** Physical transient-step identifier associated with the saved step-start state. */
+  private UUID transientStepIdentifier = null;
 
   /**
    * Constructs a battery.
@@ -79,6 +85,7 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
     stateOfCharge = Math.min(capacity, stateOfCharge + energyIn);
     currentPower = -actualPower;
     targetPower = currentPower;
+    transientStepIdentifier = null;
   }
 
   /**
@@ -99,6 +106,7 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
     stateOfCharge = Math.max(0.0, stateOfCharge - energyNeeded);
     currentPower = actualPower;
     targetPower = currentPower;
+    transientStepIdentifier = null;
     return actualPower;
   }
 
@@ -121,6 +129,7 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
       throw new IllegalArgumentException("State of charge must be finite");
     }
     this.stateOfCharge = Math.max(0.0, Math.min(capacity, stateOfCharge));
+    transientStepIdentifier = null;
   }
 
   /**
@@ -143,6 +152,7 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
     }
     this.capacity = capacity;
     stateOfCharge = Math.min(stateOfCharge, capacity);
+    transientStepIdentifier = null;
   }
 
   /**
@@ -260,15 +270,37 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
   @Override
   public void run(UUID id) {
     publishPower(false);
+    transientStepIdentifier = null;
     setCalculationIdentifier(id);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * A non-null calculation identifier represents one physical transient step. Repeated refinement evaluations with the
+   * same identifier recompute the power ramp and state-of-charge update from the state that existed at the start of the
+   * physical step. They therefore do not consume stored energy or advance the battery clock a second time. A different
+   * identifier starts the next physical step from the previously accepted battery state. Null identifiers preserve the
+   * legacy one-call-per-step behavior.
+   * </p>
+   */
   @Override
   public void runTransient(double dt, UUID id) {
     if (!Double.isFinite(dt) || dt < 0.0) {
       throw new IllegalArgumentException("Battery timestep must be non-negative and finite");
     }
+
+    boolean repeatedEvaluation = id != null && id.equals(transientStepIdentifier);
+    if (!repeatedEvaluation) {
+      transientStepStartPower = currentPower;
+      transientStepStartStateOfCharge = stateOfCharge;
+      transientStepIdentifier = id;
+    } else {
+      currentPower = transientStepStartPower;
+      stateOfCharge = transientStepStartStateOfCharge;
+    }
+
     double requestedPower = tripped ? 0.0 : targetPower;
     if (getEnergyPort(ELECTRICAL_PORT).isConnected()
         && getEnergyPort(ELECTRICAL_PORT).getMode() == EnergyPortMode.BALANCE
@@ -310,7 +342,9 @@ public class BatteryStorage extends ProcessEquipmentBaseClass {
     }
 
     publishPower(true);
-    increaseTime(dt);
+    if (!repeatedEvaluation) {
+      increaseTime(dt);
+    }
     setCalculationIdentifier(id);
   }
 

--- a/src/main/java/neqsim/process/equipment/diffpressure/Orifice.java
+++ b/src/main/java/neqsim/process/equipment/diffpressure/Orifice.java
@@ -295,16 +295,22 @@ public class Orifice extends TwoPortEquipment {
    * <p>
    * <b>Important:</b> In dynamic simulations, the orifice DETERMINES the flow rate based on available ΔP. This is
    * different from steady-state mode where flow may be specified upstream. The calculated flow is set on both the
-   * thermoSystem and inStream to ensure consistency in the process network.
+   * thermoSystem and inStream to ensure consistency in the process network. The orifice owns no accumulation or stored
+   * physical state; it is a quasi-steady algebraic relation evaluated at each physical timestep.
    * </p>
    *
-   * @param dt Time step in seconds (not used for orifice as it has no accumulation/storage)
-   * @param id Unique identifier for this simulation run
+   * <p>
+   * Repeated nonlinear/refinement evaluations with the same non-null calculation identifier still recompute the
+   * pressure-flow relation, but advance this equipment clock only once for that physical timestep. A new non-null ID
+   * advances the next physical step. A null ID preserves legacy uncoalesced timing.
+   * </p>
+   *
+   * @param dt Time step in seconds (used only for the algebraic equipment execution clock)
+   * @param id Physical-step calculation identifier, or null for legacy uncoalesced timing
    */
   @Override
   public void runTransient(double dt, UUID id) {
-    // For orifice, transient behavior is quasi-steady (no accumulation)
-    // Just run steady-state calculation
+    boolean alreadyEvaluatedForStep = id != null && id.equals(getCalculationIdentifier());
     SystemInterface thermoSystem = inStream.getThermoSystem().clone();
 
     // Handle zero or very low flow cases
@@ -312,6 +318,12 @@ public class Orifice extends TwoPortEquipment {
     if (flowRate < 1e-10) {
       // For negligible flow, just set outlet to inlet conditions
       outStream.setFluid(thermoSystem);
+      if (id != null) {
+        setCalculationIdentifier(id);
+      }
+      if (!alreadyEvaluatedForStep) {
+        increaseTime(dt);
+      }
       return;
     }
 
@@ -358,5 +370,11 @@ public class Orifice extends TwoPortEquipment {
     thermoSystem.setPressure(P2, "bara");
     outStream.setFluid(thermoSystem);
     inStream.run();
+    if (id != null) {
+      setCalculationIdentifier(id);
+    }
+    if (!alreadyEvaluatedForStep) {
+      increaseTime(dt);
+    }
   }
 }

--- a/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
@@ -283,11 +283,11 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
    * {@inheritDoc}
    *
    * <p>
-   * A non-null calculation identifier represents one physical transient step. Repeated nonlinear/refinement
-   * evaluations with the same identifier recompute the ramped output from the output power that existed at the start of
-   * that physical step; they do not integrate the ramp or advance the converter clock a second time. A different
-   * identifier starts the next physical step. Null identifiers preserve the legacy behavior where every direct call is
-   * treated as a new physical step.
+   * A non-null calculation identifier represents one physical transient step. Repeated nonlinear/refinement evaluations
+   * with the same identifier recompute the ramped output from the output power that existed at the start of that
+   * physical step; they do not integrate the ramp or advance the converter clock a second time. A different identifier
+   * starts the next physical step. Null identifiers preserve the legacy behavior where every direct call is treated as
+   * a new physical step.
    * </p>
    */
   @Override
@@ -330,7 +330,7 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
    * output that can be supported by the supplied input.
    * </p>
    *
-   * @param input available input power in W
+   * @param input available input in W
    * @return useful output in W
    */
   protected double calculateTargetOutput(double input) {
@@ -343,8 +343,8 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   /**
    * Calculates required input for useful output.
    *
-   * @param output useful output power in W
-   * @return required input power in W
+   * @param output useful output in W
+   * @return required input in W
    */
   protected double calculateRequiredInputForOutput(double output) {
     if (output <= 0.0) {

--- a/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyConverter.java
@@ -44,6 +44,10 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
   private double currentOutputPower = 0.0;
   private double heatLoss = 0.0;
   private boolean tripped = false;
+  /** Output power at the start of the current physical transient step. */
+  private double transientStepStartOutputPower = 0.0;
+  /** Physical transient-step identifier associated with {@link #transientStepStartOutputPower}. */
+  private UUID transientStepIdentifier = null;
 
   /**
    * Creates an energy converter.
@@ -271,22 +275,40 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
     double availableInput = readAvailableInput();
     double output = calculateTargetOutput(availableInput);
     publish(calculateRealizedInput(availableInput, output), output);
+    transientStepIdentifier = null;
     setCalculationIdentifier(id);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * A non-null calculation identifier represents one physical transient step. Repeated nonlinear/refinement
+   * evaluations with the same identifier recompute the ramped output from the output power that existed at the start of
+   * that physical step; they do not integrate the ramp or advance the converter clock a second time. A different
+   * identifier starts the next physical step. Null identifiers preserve the legacy behavior where every direct call is
+   * treated as a new physical step.
+   * </p>
+   */
   @Override
   public void runTransient(double dt, UUID id) {
     if (!Double.isFinite(dt) || dt < 0.0) {
       throw new IllegalArgumentException("Converter timestep must be non-negative and finite");
     }
 
+    boolean repeatedEvaluation = id != null && id.equals(transientStepIdentifier);
+    if (!repeatedEvaluation) {
+      transientStepStartOutputPower = currentOutputPower;
+      transientStepIdentifier = id;
+    }
+
     double availableInput = readAvailableInput();
     double targetOutput = calculateTargetOutput(availableInput);
     double maximumChange = rampRate * dt;
     double rampedOutput = targetOutput;
-    if (Double.isFinite(maximumChange) && Math.abs(targetOutput - currentOutputPower) > maximumChange) {
-      rampedOutput = currentOutputPower + Math.copySign(maximumChange, targetOutput - currentOutputPower);
+    if (Double.isFinite(maximumChange) && Math.abs(targetOutput - transientStepStartOutputPower) > maximumChange) {
+      rampedOutput = transientStepStartOutputPower
+          + Math.copySign(maximumChange, targetOutput - transientStepStartOutputPower);
     }
 
     // A memoryless converter cannot sustain a ramp-limited output using energy that is no longer available.
@@ -294,7 +316,9 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
     // thermodynamically available target.
     double output = Math.min(targetOutput, Math.max(0.0, rampedOutput));
     publish(calculateRealizedInput(availableInput, output), output);
-    increaseTime(dt);
+    if (!repeatedEvaluation) {
+      increaseTime(dt);
+    }
     setCalculationIdentifier(id);
   }
 
@@ -356,7 +380,7 @@ public class EnergyConverter extends ProcessEquipmentBaseClass {
    * Publishes converter results to connected output and loss ports.
    *
    * @param input realized input power in W
-   * @param output useful output power in W
+   * @param output useful output in W
    */
   private void publish(double input, double output) {
     if (!Double.isFinite(input) || input < 0.0 || !Double.isFinite(output) || output < 0.0 || output > input) {

--- a/src/main/java/neqsim/process/equipment/energy/EnergyNetworkSolver.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyNetworkSolver.java
@@ -97,14 +97,28 @@ public class EnergyNetworkSolver extends ProcessEquipmentBaseClass {
     setCalculationIdentifier(id);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Re-solves the algebraic energy-bus allocation for a physical timestep.
+   *
+   * <p>
+   * Repeated nonlinear/refinement evaluations with the same non-null calculation identifier still recalculate the bus
+   * balance, but advance this solver's local clock only once for that physical timestep. A null identifier preserves the
+   * legacy behavior and advances the local clock on every successful evaluation.
+   * </p>
+   *
+   * @param dt physical timestep in seconds
+   * @param id physical-step calculation identifier, or null for legacy uncoalesced timing
+   */
   @Override
   public void runTransient(double dt, UUID id) {
+    boolean alreadyEvaluatedForStep = id != null && id.equals(getCalculationIdentifier());
     for (EnergyBus energyBus : energyBuses) {
       energyBus.clearRealizedBalancePowers();
     }
     run(id);
-    increaseTime(dt);
+    if (!alreadyEvaluatedForStep) {
+      increaseTime(dt);
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/energy/EnergyNetworkSolver.java
+++ b/src/main/java/neqsim/process/equipment/energy/EnergyNetworkSolver.java
@@ -102,8 +102,8 @@ public class EnergyNetworkSolver extends ProcessEquipmentBaseClass {
    *
    * <p>
    * Repeated nonlinear/refinement evaluations with the same non-null calculation identifier still recalculate the bus
-   * balance, but advance this solver's local clock only once for that physical timestep. A null identifier preserves the
-   * legacy behavior and advances the local clock on every successful evaluation.
+   * balance, but advance this solver's local clock only once for that physical timestep. A null identifier preserves
+   * the legacy behavior and advances the local clock on every successful evaluation.
    * </p>
    *
    * @param dt physical timestep in seconds

--- a/src/main/java/neqsim/process/equipment/expander/Expander.java
+++ b/src/main/java/neqsim/process/equipment/expander/Expander.java
@@ -72,6 +72,21 @@ public class Expander extends Compressor implements ExpanderInterface {
   /** Speed multiplier from expander shaft speed to the coupled compressor speed. */
   private double coupledCompressorSpeedRatio = 1.0;
 
+  /** Nozzle opening at the start of the current physical transient step. */
+  private double transientStepStartNozzleOpening = 1.0;
+
+  /** Recovered-power state at the start of the current physical transient step, in kW. */
+  private double transientStepStartRecoveredPowerKW = 0.0;
+
+  /** Shaft speed at the start of the current physical transient step, in rpm. */
+  private double transientStepStartSpeedRPM = 0.0;
+
+  /** Physical transient-step identifier associated with the saved step-start state. */
+  private UUID transientStepIdentifier = null;
+
+  /** Guards the steady thermodynamic calculation invoked from {@link #runTransient(double, UUID)}. */
+  private transient boolean transientCalculationInProgress = false;
+
   /**
    * Constructor for Expander.
    *
@@ -129,15 +144,13 @@ public class Expander extends Compressor implements ExpanderInterface {
     return expanderMechanicalDesign;
   }
 
-  /**
-   * Initialize the expander mechanical design.
-   */
+  /** Initialize the expander mechanical design. */
   private void initExpanderMechanicalDesign() {
     expanderMechanicalDesign = new ExpanderMechanicalDesign(this);
   }
 
   /**
-   * Gets the rated recovered shaft power of the expander.
+   * Gets the rated recovered shaft power of the expander in kW.
    *
    * @return rated recovered power in kW; {@code 0} means no recovered-power limit is defined
    */
@@ -179,6 +192,7 @@ public class Expander extends Compressor implements ExpanderInterface {
    */
   public void setNozzleOpening(double opening) {
     this.nozzleOpening = clampOpening(opening);
+    transientStepIdentifier = null;
   }
 
   /**
@@ -210,6 +224,7 @@ public class Expander extends Compressor implements ExpanderInterface {
     this.maximumNozzleOpening = Math.max(this.minimumNozzleOpening, Math.min(1.0, maximumOpening));
     this.nozzleOpening = clampOpening(nozzleOpening);
     this.targetNozzleOpening = clampOpening(targetNozzleOpening);
+    transientStepIdentifier = null;
   }
 
   /**
@@ -307,7 +322,7 @@ public class Expander extends Compressor implements ExpanderInterface {
   }
 
   /**
-   * Sets the speed ratio from the expander shaft to the coupled compressor shaft.
+   * Sets the speed ratio from the expander shaft speed to the coupled compressor shaft speed.
    *
    * @param coupledCompressorSpeedRatio speed ratio; negative values are treated as zero
    */
@@ -388,12 +403,37 @@ public class Expander extends Compressor implements ExpanderInterface {
     return true;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * A non-null calculation identifier represents one physical transient step. Repeated same-ID evaluations restore
+   * nozzle opening, recovered-power ramp state, and shaft speed to their values at physical-step start before
+   * recomputing the step. The expander clock therefore advances once per physical step instead of once per nonlinear or
+   * semi-implicit refinement. A different identifier starts the next physical step from the previously accepted state.
+   * Null identifiers retain the legacy one-call-per-step behavior.
+   * </p>
+   */
   @Override
   public void runTransient(double dt, UUID id) {
+    boolean repeatedEvaluation = id != null && id.equals(transientStepIdentifier);
+    if (!repeatedEvaluation) {
+      transientStepStartNozzleOpening = nozzleOpening;
+      transientStepStartRecoveredPowerKW = dynamicRecoveredPowerKW;
+      transientStepStartSpeedRPM = getSpeed();
+      transientStepIdentifier = id;
+    } else {
+      nozzleOpening = transientStepStartNozzleOpening;
+      dynamicRecoveredPowerKW = transientStepStartRecoveredPowerKW;
+      setSpeed(transientStepStartSpeedRPM);
+    }
+
     if (getCalculateSteadyState()) {
-      run(id);
-      increaseTime(dt);
+      runSteadyCalculationWithinTransient(id);
+      if (!repeatedEvaluation) {
+        increaseTime(dt);
+      }
+      setCalculationIdentifier(id);
       return;
     }
 
@@ -410,7 +450,7 @@ public class Expander extends Compressor implements ExpanderInterface {
     pressure = effectivePressure;
     isentropicEfficiency = targetEfficiency * (0.5 + 0.5 * nozzleOpening);
 
-    run(id);
+    runSteadyCalculationWithinTransient(id);
 
     double steadyRecoveredKW = Math.max(0.0, Math.abs(getPower("kW")));
     updateRecoveredPower(steadyRecoveredKW, dt);
@@ -419,8 +459,24 @@ public class Expander extends Compressor implements ExpanderInterface {
 
     pressure = targetPressure;
     isentropicEfficiency = targetEfficiency;
-    increaseTime(dt);
+    if (!repeatedEvaluation) {
+      increaseTime(dt);
+    }
     setCalculationIdentifier(id);
+  }
+
+  /**
+   * Runs the thermodynamic expander calculation without invalidating the current physical-step anchor.
+   *
+   * @param id calculation identifier
+   */
+  private void runSteadyCalculationWithinTransient(UUID id) {
+    transientCalculationInProgress = true;
+    try {
+      run(id);
+    } finally {
+      transientCalculationInProgress = false;
+    }
   }
 
   /**
@@ -605,6 +661,9 @@ public class Expander extends Compressor implements ExpanderInterface {
     getEnergyPort("shaftPower").setDuty(-dH);
     // thermoSystem.display();
     outStream.setThermoSystem(getThermoSystem());
+    if (!transientCalculationInProgress) {
+      transientStepIdentifier = null;
+    }
     setCalculationIdentifier(id);
   }
 }

--- a/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioRunner.java
+++ b/src/main/java/neqsim/process/safety/scenario/DynamicSafetyScenarioRunner.java
@@ -1,6 +1,5 @@
 package neqsim.process.safety.scenario;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -8,6 +7,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStepIdentifier;
 import neqsim.process.logic.ProcessLogic;
 import neqsim.process.processmodel.ProcessSystem;
 
@@ -46,7 +46,7 @@ public final class DynamicSafetyScenarioRunner {
 
     double time = 0.0;
     boolean triggered = false;
-    UUID simulationId = UUID.nameUUIDFromBytes(scenario.getId().getBytes(StandardCharsets.UTF_8));
+    long physicalStepIndex = 0L;
     while (errors.isEmpty() && time <= scenario.getDurationSeconds() + 1.0e-9) {
       if (!triggered && time + 1.0e-9 >= scenario.getTriggerTimeSeconds()) {
         scenario.getInitiatingEvent().apply(process);
@@ -67,10 +67,12 @@ public final class DynamicSafetyScenarioRunner {
         break;
       }
       try {
-        process.runTransient(scenario.getTimeStepSeconds(), simulationId);
+        UUID physicalStepId = TransientStepIdentifier.deterministicPhysicalStep(scenario.getId(), physicalStepIndex);
+        process.runTransient(scenario.getTimeStepSeconds(), physicalStepId);
       } catch (RuntimeException ex) {
         errors.add("Transient simulation failed at " + time + " s: " + failureMessage(ex));
       }
+      physicalStepIndex++;
       time += scenario.getTimeStepSeconds();
     }
 

--- a/src/test/java/neqsim/mcp/runners/ModelRegistryOwnerScopingTest.java
+++ b/src/test/java/neqsim/mcp/runners/ModelRegistryOwnerScopingTest.java
@@ -156,8 +156,8 @@ class ModelRegistryOwnerScopingTest {
   }
 
   /**
-   * The worst case: a foreign revision would make the owner's next run answer from someone else's edits, and the
-   * result would look entirely normal. The stored definition must be untouched.
+   * The worst case: a foreign revision would make the owner's next run answer from someone else's edits, and the result
+   * would look entirely normal. The stored definition must be untouched.
    */
   @Test
   @DisplayName("revise is refused for another principal and leaves the owner's definition intact")
@@ -262,8 +262,8 @@ class ModelRegistryOwnerScopingTest {
   }
 
   /**
-   * An unresolved caller must fail closed rather than fall into a bucket shared with named principals. A token
-   * carrying no tenant claim falls back to the same default scope as an unbound caller, so ownership is the only thing
+   * An unresolved caller must fail closed rather than fall into a bucket shared with named principals. A token carrying
+   * no tenant claim falls back to the same default scope as an unbound caller, so ownership is the only thing
    * separating them.
    */
   @Test
@@ -276,8 +276,9 @@ class ModelRegistryOwnerScopingTest {
     McpRequestContext.clear();
     assertRefusedAsUnknown("get", act("get", modelId));
     assertRefusedAsUnknown("delete", act("delete", modelId));
-    assertEquals(0, JsonParser.parseString(ModelRegistry.run("{\"action\": \"list\"}")).getAsJsonObject().get("count")
-        .getAsInt(), "An anonymous caller must not see a named principal's models");
+    assertEquals(0,
+        JsonParser.parseString(ModelRegistry.run("{\"action\": \"list\"}")).getAsJsonObject().get("count").getAsInt(),
+        "An anonymous caller must not see a named principal's models");
     assertThrows(IllegalArgumentException.class, new Executable() {
       @Override
       public void execute() {
@@ -290,8 +291,8 @@ class ModelRegistryOwnerScopingTest {
   }
 
   /**
-   * A refusal must be indistinguishable from a handle that was never registered, so the registry cannot be used to
-   * test whether a given model exists.
+   * A refusal must be indistinguishable from a handle that was never registered, so the registry cannot be used to test
+   * whether a given model exists.
    */
   @Test
   @DisplayName("a refused handle is indistinguishable from an unknown handle")

--- a/src/test/java/neqsim/process/dynamics/BDFIntegratorReferenceTest.java
+++ b/src/test/java/neqsim/process/dynamics/BDFIntegratorReferenceTest.java
@@ -1,0 +1,84 @@
+package neqsim.process.dynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Quantitative reference and timestep-refinement evidence for the scalar BDF-1 integrator. */
+class BDFIntegratorReferenceTest {
+  private static final class LinearDecay implements IntegratorStrategy.Slope {
+    private static final long serialVersionUID = 1L;
+    private final double rate;
+
+    private LinearDecay(double rate) {
+      this.rate = rate;
+    }
+
+    @Override
+    public double dxdt(double time, double state) {
+      return -rate * state;
+    }
+  }
+
+  @Test
+  void linearDecayMatchesClosedFormBackwardEulerStep() {
+    BDFIntegrator bdf = new BDFIntegrator(1.0e-11, 25, 1.0e-6);
+    LinearDecay decay = new LinearDecay(100.0);
+    double state = 1.0;
+    double dt = 0.05;
+
+    for (int step = 0; step < 20; step++) {
+      double expected = state / (1.0 + 100.0 * dt);
+      state = bdf.step(step * dt, state, decay, dt);
+      assertEquals(expected, state, 1.0e-10,
+          "BDF-1 must satisfy the closed-form backward-Euler result for linear decay");
+      assertTrue(bdf.lastStepConverged());
+      assertFalse(bdf.lastStepFellBack());
+      assertTrue(bdf.getLastResidual() <= bdf.getTolerance());
+    }
+  }
+
+  @Test
+  void timestepHalvingShowsFirstOrderConvergenceToAnalyticDecay() {
+    double coarseError = integrateError(0.2);
+    double mediumError = integrateError(0.1);
+    double fineError = integrateError(0.05);
+
+    assertTrue(mediumError < coarseError, "halving dt must reduce the global error");
+    assertTrue(fineError < mediumError, "a second dt halving must reduce the global error again");
+    assertTrue(coarseError / mediumError > 1.7,
+        "BDF-1 should approach first-order convergence under timestep refinement");
+    assertTrue(mediumError / fineError > 1.7,
+        "BDF-1 should retain first-order convergence on the finer refinement pair");
+  }
+
+  @Test
+  void veryStiffSingleStepRemainsBoundedAndMatchesBackwardEulerReference() {
+    BDFIntegrator bdf = new BDFIntegrator(1.0e-11, 25, 1.0e-6);
+    LinearDecay decay = new LinearDecay(1000.0);
+    double dt = 0.1;
+
+    double state = bdf.step(0.0, 1.0, decay, dt);
+    double expected = 1.0 / (1.0 + 1000.0 * dt);
+
+    assertEquals(expected, state, 1.0e-10);
+    assertTrue(state > 0.0 && state < 1.0, "L-stable BDF-1 decay must remain positive and bounded");
+    assertTrue(bdf.lastStepConverged());
+    assertFalse(bdf.lastStepFellBack());
+  }
+
+  private static double integrateError(double dt) {
+    BDFIntegrator bdf = new BDFIntegrator(1.0e-11, 25, 1.0e-6);
+    LinearDecay decay = new LinearDecay(1.0);
+    double state = 1.0;
+    double time = 0.0;
+    int steps = (int) Math.round(1.0 / dt);
+    for (int step = 0; step < steps; step++) {
+      state = bdf.step(time, state, decay, dt);
+      time += dt;
+    }
+    return Math.abs(state - Math.exp(-1.0));
+  }
+}

--- a/src/test/java/neqsim/process/dynamics/DynamicActivationReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicActivationReportTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.battery.BatteryStorage;
+import neqsim.process.equipment.expander.Expander;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
@@ -52,6 +54,47 @@ public class DynamicActivationReportTest extends neqsim.NeqSimTest {
     assertTrue(active.getInactiveAuditedDynamicElements().isEmpty());
     assertEquals(1, active.getActivationCounts().get(DynamicActivationStatus.ACTIVE).intValue());
     assertTrue(active.toJson().contains("\"activationStatus\": \"ACTIVE\""));
+  }
+
+  /** Battery state is always transient, while zero storage capacity is a blocking configuration error. */
+  @Test
+  public void batteryActivationDoesNotDependOnGenericSteadyStateFlag() {
+    BatteryStorage battery = new BatteryStorage("battery", 0.0);
+    ProcessSystem process = new ProcessSystem("electrical system");
+    process.add(battery);
+
+    DynamicCapabilityReport incomplete = DynamicCapabilityReport.from(process);
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, incomplete.getEntries().get(0).getCapability());
+    assertEquals(DynamicActivationStatus.INCOMPLETE_CONFIGURATION,
+        incomplete.getEntries().get(0).getActivationStatus());
+    assertTrue(incomplete.hasBlockingIssues());
+    assertTrue(incomplete.getBlockingIssues().get(0).contains("storage capacity"));
+
+    battery.setCapacity(1000.0);
+    DynamicCapabilityReport active = DynamicCapabilityReport.from(process);
+    assertEquals(DynamicActivationStatus.ACTIVE, active.getEntries().get(0).getActivationStatus());
+    assertFalse(active.hasBlockingIssues());
+    assertTrue(active.getEntries().get(0).getActivationDiagnostic().contains("independently of calculateSteadyState"));
+  }
+
+  /** Expander runtime activation follows the branch that integrates nozzle, power and rotor-speed state. */
+  @Test
+  public void expanderActivationTracksStatefulRuntimeBranch() {
+    Stream feed = createFeed("expander feed", 320.0);
+    Expander expander = new Expander("expander", feed);
+    ProcessSystem process = new ProcessSystem("power recovery");
+    process.add(expander);
+
+    DynamicCapabilityReport inactive = DynamicCapabilityReport.from(process);
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, inactive.getEntries().get(0).getCapability());
+    assertEquals(DynamicActivationStatus.INACTIVE, inactive.getEntries().get(0).getActivationStatus());
+    assertEquals(1, inactive.getInactiveAuditedDynamicElements().size());
+
+    expander.setCalculateSteadyState(false);
+    DynamicCapabilityReport active = DynamicCapabilityReport.from(process);
+    assertEquals(DynamicActivationStatus.ACTIVE, active.getEntries().get(0).getActivationStatus());
+    assertTrue(active.getInactiveAuditedDynamicElements().isEmpty());
+    assertFalse(active.hasBlockingIssues());
   }
 
   /**

--- a/src/test/java/neqsim/process/dynamics/DynamicActivationReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicActivationReportTest.java
@@ -26,7 +26,7 @@ public class DynamicActivationReportTest extends neqsim.NeqSimTest {
     process.add(exchanger);
 
     DynamicCapabilityReport inactive = DynamicCapabilityReport.from(process);
-    assertEquals("1.1", inactive.getSchemaVersion());
+    assertEquals("1.2", inactive.getSchemaVersion());
     assertEquals(DynamicActivationStatus.INACTIVE, inactive.getEntries().get(0).getActivationStatus());
     assertFalse(inactive.hasBlockingIssues());
     assertEquals(1, inactive.getInactiveAuditedDynamicElements().size());

--- a/src/test/java/neqsim/process/dynamics/DynamicActivationReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicActivationReportTest.java
@@ -1,0 +1,103 @@
+package neqsim.process.dynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests the runtime-activation dimension of the Phase-0 dynamic capability report. */
+public class DynamicActivationReportTest extends neqsim.NeqSimTest {
+
+  /** HeatExchanger activation follows the runtime branch used by runTransient rather than a generic mode flag alone. */
+  @Test
+  public void heatExchangerActivationIsReportedFromActualPrerequisites() {
+    Stream hot = createFeed("hot feed", 330.0);
+    Stream cold = createFeed("cold feed", 290.0);
+    HeatExchanger exchanger = new HeatExchanger("HX-100", hot, cold);
+    ProcessSystem process = new ProcessSystem("topside");
+    process.add(exchanger);
+
+    DynamicCapabilityReport inactive = DynamicCapabilityReport.from(process);
+    assertEquals("1.1", inactive.getSchemaVersion());
+    assertEquals(DynamicActivationStatus.INACTIVE, inactive.getEntries().get(0).getActivationStatus());
+    assertFalse(inactive.hasBlockingIssues());
+    assertEquals(1, inactive.getInactiveAuditedDynamicElements().size());
+
+    exchanger.setCalculateSteadyState(false);
+    DynamicCapabilityReport requestedButDisabled = DynamicCapabilityReport.from(process);
+    assertEquals(DynamicActivationStatus.INCOMPLETE_CONFIGURATION,
+        requestedButDisabled.getEntries().get(0).getActivationStatus());
+    assertTrue(requestedButDisabled.hasBlockingIssues());
+    assertFalse(requestedButDisabled.isStrictPreflightReady());
+    assertTrue(requestedButDisabled.getBlockingIssues().get(0).contains("dynamicModelEnabled is false"));
+
+    exchanger.setDynamicModelEnabled(true);
+    DynamicCapabilityReport missingPhysicalParameters = DynamicCapabilityReport.from(process);
+    assertEquals(DynamicActivationStatus.INCOMPLETE_CONFIGURATION,
+        missingPhysicalParameters.getEntries().get(0).getActivationStatus());
+    assertTrue(missingPhysicalParameters.getBlockingIssues().get(0).contains("wallMass"));
+    assertTrue(missingPhysicalParameters.getBlockingIssues().get(0).contains("heatTransferArea"));
+
+    exchanger.setWallMass(1200.0);
+    exchanger.setHeatTransferArea(80.0);
+    DynamicCapabilityReport active = DynamicCapabilityReport.from(process);
+    assertEquals(DynamicActivationStatus.ACTIVE, active.getEntries().get(0).getActivationStatus());
+    assertFalse(active.hasBlockingIssues());
+    assertTrue(active.getInactiveAuditedDynamicElements().isEmpty());
+    assertEquals(1, active.getActivationCounts().get(DynamicActivationStatus.ACTIVE).intValue());
+    assertTrue(active.toJson().contains("\"activationStatus\": \"ACTIVE\""));
+  }
+
+  /** Activation gaps remain explicit review aids without pretending every DYNAMIC_LUMPED classification is qualified. */
+  @Test
+  public void unverifiedActivationRemainsVisibleForOtherDynamicFamilies() {
+    Stream feed = createFeed("separator feed", 300.0);
+    Separator separator = new Separator("separator", feed);
+    ProcessSystem process = new ProcessSystem("separation");
+    process.add(separator);
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, report.getEntries().get(0).getCapability());
+    assertEquals(DynamicActivationStatus.UNVERIFIED, report.getEntries().get(0).getActivationStatus());
+    assertEquals(1, report.getUnverifiedActivationElements().size());
+    assertEquals("separator", report.getUnverifiedActivationElements().get(0));
+    assertFalse(report.hasBlockingIssues());
+  }
+
+  /** Multi-area reports retain area identity for activation diagnostics. */
+  @Test
+  public void processModelActivationDiagnosticsAreAreaQualified() {
+    Stream hot = createFeed("hot feed", 330.0);
+    Stream cold = createFeed("cold feed", 290.0);
+    HeatExchanger exchanger = new HeatExchanger("HX-200", hot, cold);
+    exchanger.setCalculateSteadyState(false);
+
+    ProcessSystem topside = new ProcessSystem("topside system");
+    topside.add(exchanger);
+    ProcessModel model = new ProcessModel();
+    model.add("topside", topside);
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(model);
+
+    assertTrue(report.hasBlockingIssues());
+    assertTrue(report.getBlockingIssues().get(0).contains("topside::HX-200"));
+    assertEquals("topside::HX-200", report.getEntries().get(0).getQualifiedName());
+  }
+
+  private static Stream createFeed(String name, double temperature) {
+    SystemSrkEos fluid = new SystemSrkEos(temperature, 50.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream(name, fluid);
+    stream.setFlowRate(1000.0, "kg/hr");
+    return stream;
+  }
+}

--- a/src/test/java/neqsim/process/dynamics/DynamicActivationReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicActivationReportTest.java
@@ -54,7 +54,9 @@ public class DynamicActivationReportTest extends neqsim.NeqSimTest {
     assertTrue(active.toJson().contains("\"activationStatus\": \"ACTIVE\""));
   }
 
-  /** Activation gaps remain explicit review aids without pretending every DYNAMIC_LUMPED classification is qualified. */
+  /**
+   * Activation gaps remain explicit review aids without pretending every DYNAMIC_LUMPED classification is qualified.
+   */
   @Test
   public void unverifiedActivationRemainsVisibleForOtherDynamicFamilies() {
     Stream feed = createFeed("separator feed", 300.0);

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityModuleContainerTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityModuleContainerTest.java
@@ -1,0 +1,48 @@
+package neqsim.process.dynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.processmodel.processmodules.SeparationTrainModule;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression coverage for composite process-module dynamic capability semantics. */
+public class DynamicCapabilityModuleContainerTest extends neqsim.NeqSimTest {
+  /**
+   * A process module delegates transient execution to its child ProcessSystem and must not be treated as an independent
+   * unaudited dynamic state owner. Child equipment remains recursively audited.
+   */
+  @Test
+  public void moduleContainerIsAlgebraicWhileChildrenRemainAudited() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("module feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    feed.setPressure(50.0, "bara");
+    feed.setTemperature(25.0, "C");
+
+    SeparationTrainModule module = new SeparationTrainModule("separation train");
+    module.addInputStream("feed stream", feed);
+
+    ProcessSystem process = new ProcessSystem("module process");
+    process.add(module);
+
+    assertEquals(DynamicCapability.ALGEBRAIC, module.getDynamicCapability());
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+    assertTrue(report.getEntries().size() > 10);
+    assertTrue(report.getReviewItems().size() > 0,
+        "Unaudited child implementations must remain visible through recursive module audit");
+
+    for (String reviewItem : report.getReviewItems()) {
+      assertFalse(reviewItem.startsWith("separation train has a custom transient implementation"),
+          "The composite module container itself must not create a false strict-preflight review item");
+    }
+  }
+}

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -33,6 +33,8 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     Stream cold = createFeed("cold");
 
     assertEquals(DynamicCapability.ALGEBRAIC, feed.getDynamicCapability());
+    assertEquals(DynamicCapability.ALGEBRAIC,
+        new PassiveDerivedStream("derived feed", createFluid()).getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_LUMPED, new Separator("separator", feed).getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_LUMPED, new Tank("tank", feed).getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_LUMPED, new HeatExchanger("hx", feed, cold).getDynamicCapability());
@@ -194,6 +196,14 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
       run(id);
       increaseTime(dt);
       setCalculationIdentifier(id);
+    }
+  }
+
+  private static final class PassiveDerivedStream extends Stream {
+    private static final long serialVersionUID = 1000L;
+
+    private PassiveDerivedStream(String name, SystemSrkEos fluid) {
+      super(name, fluid);
     }
   }
 }

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -49,7 +49,8 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
 
     assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new TwoFluidPipe("two fluid", feed).getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new TransientPipe("drift flux", feed).getDynamicCapability());
-    assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new WaterHammerPipe("water hammer", feed).getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED,
+        new WaterHammerPipe("water hammer", feed).getDynamicCapability());
   }
 
   /** Control and instrumentation elements are reported separately from process-equipment physics. */
@@ -79,7 +80,9 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertTrue(report.getReviewItems().get(0).contains("custom"));
   }
 
-  /** Algebraic equipment is valid in transient flowsheets until its unsupported difference-equation mode is requested. */
+  /**
+   * Algebraic equipment is valid in transient flowsheets until its unsupported difference-equation mode is requested.
+   */
   @Test
   public void algebraicElementForcedIntoDynamicModeIsBlocking() {
     Stream feed = createFeed("feed");

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -52,8 +52,7 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
   public void distributedPipeModelsAreClassified() {
     Stream feed = createFeed("pipe feed");
 
-    assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED,
-        new OnePhasePipeLine("one phase", feed).getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new OnePhasePipeLine("one phase", feed).getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new TwoFluidPipe("two fluid", feed).getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new TransientPipe("drift flux", feed).getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED,

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
+import neqsim.process.equipment.adsorber.AdsorptionBed;
+import neqsim.process.equipment.battery.BatteryStorage;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
 import neqsim.process.equipment.pipeline.OnePhasePipeLine;
@@ -88,6 +90,30 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertEquals(1, report.getStrictPreflightIssues().size());
     IllegalStateException exception = assertThrows(IllegalStateException.class, report::assertStrictTransientReady);
     assertTrue(exception.getMessage().contains("custom"));
+  }
+
+  /** Stateful adsorption/power models stay review items until their #2911 step/conservation contracts are qualified. */
+  @Test
+  public void knownStatefulButUnauditedFamiliesRemainReviewItems() {
+    Stream feed = createFeed("adsorption feed");
+    AdsorptionBed bed = new AdsorptionBed("adsorption bed", feed);
+    BatteryStorage battery = new BatteryStorage("battery", 1000.0);
+
+    assertEquals(DynamicCapability.UNCLASSIFIED_DYNAMIC, bed.getDynamicCapability());
+    assertEquals(DynamicCapability.UNCLASSIFIED_DYNAMIC, battery.getDynamicCapability());
+
+    ProcessSystem process = new ProcessSystem("treatment and power");
+    process.add(feed);
+    process.add(bed);
+    process.add(battery);
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+
+    assertEquals(2, report.getCapabilityCounts().get(DynamicCapability.UNCLASSIFIED_DYNAMIC).intValue());
+    assertEquals(2, report.getReviewItems().size());
+    assertFalse(report.isStrictPreflightReady());
+    assertTrue(containsDiagnostic(report.getReviewItems(), "adsorption bed"));
+    assertTrue(containsDiagnostic(report.getReviewItems(), "battery"));
   }
 
   /**
@@ -220,6 +246,15 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
   private static boolean hasQualifiedEntry(DynamicCapabilityReport report, String qualifiedName) {
     for (DynamicCapabilityReport.Entry entry : report.getEntries()) {
       if (qualifiedName.equals(entry.getQualifiedName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean containsDiagnostic(java.util.List<String> diagnostics, String text) {
+    for (String diagnostic : diagnostics) {
+      if (diagnostic.contains(text)) {
         return true;
       }
     }

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -87,7 +87,45 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
     assertTrue(report.isStrictPreflightReady());
     assertTrue(report.getReviewItems().isEmpty());
+    assertTrue(report.getExecutionIssues().isEmpty());
     assertEquals(1, report.getCapabilityCounts().get(DynamicCapability.ALGEBRAIC).intValue());
+  }
+
+  /** Known process-level execution defects are explicit strict-preflight blockers for ProcessSystem and ProcessModel. */
+  @Test
+  public void unsafeExecutionModesAreExplicitStrictPreflightBlockers() {
+    ProcessSystem parallel = new ProcessSystem("parallel area");
+    parallel.add(createFeed("parallel feed"));
+    parallel.setParallelTransientEnabled(true);
+
+    DynamicCapabilityReport parallelReport = DynamicCapabilityReport.from(parallel);
+    assertEquals("1.2", parallelReport.getSchemaVersion());
+    assertEquals(1, parallelReport.getExecutionIssues().size());
+    assertTrue(parallelReport.getExecutionIssues().get(0).contains("parallel transient"));
+    assertTrue(parallelReport.getExecutionIssues().get(0).contains("not yet fail-loud"));
+    assertTrue(parallelReport.hasBlockingIssues());
+    assertFalse(parallelReport.isStrictPreflightReady());
+
+    ProcessSystem adaptive = new ProcessSystem("adaptive area");
+    adaptive.add(createFeed("adaptive feed"));
+    adaptive.setAdaptiveTimestepEnabled(true);
+
+    DynamicCapabilityReport adaptiveReport = DynamicCapabilityReport.from(adaptive);
+    assertEquals(1, adaptiveReport.getExecutionIssues().size());
+    assertTrue(adaptiveReport.getExecutionIssues().get(0).contains("runTransientAdaptive"));
+    assertTrue(adaptiveReport.getExecutionIssues().get(0).contains("rejected-step rollback"));
+    assertTrue(adaptiveReport.hasBlockingIssues());
+    assertFalse(adaptiveReport.isStrictPreflightReady());
+
+    ProcessModel model = new ProcessModel();
+    model.add("subsea", parallel);
+    model.add("topside", adaptive);
+
+    DynamicCapabilityReport modelReport = DynamicCapabilityReport.from(model);
+    assertEquals(2, modelReport.getExecutionIssues().size());
+    assertTrue(containsDiagnostic(modelReport.getExecutionIssues(), "subsea"));
+    assertTrue(containsDiagnostic(modelReport.getExecutionIssues(), "topside"));
+    assertTrue(modelReport.toJson().contains("executionIssues"));
   }
 
   /** An unaudited custom runTransient override is visible instead of being promoted to a dynamic model. */

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -91,7 +91,9 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertEquals(1, report.getCapabilityCounts().get(DynamicCapability.ALGEBRAIC).intValue());
   }
 
-  /** Known process-level execution defects are explicit strict-preflight blockers for ProcessSystem and ProcessModel. */
+  /**
+   * Known process-level execution defects are explicit strict-preflight blockers for ProcessSystem and ProcessModel.
+   */
   @Test
   public void unsafeExecutionModesAreExplicitStrictPreflightBlockers() {
     ProcessSystem parallel = new ProcessSystem("parallel area");

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.equipment.pipeline.OnePhasePipeLine;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
 import neqsim.process.equipment.pipeline.WaterHammerPipe;
 import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
@@ -51,6 +52,8 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
   public void distributedPipeModelsAreClassified() {
     Stream feed = createFeed("pipe feed");
 
+    assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED,
+        new OnePhasePipeLine("one phase", feed).getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new TwoFluidPipe("two fluid", feed).getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new TransientPipe("drift flux", feed).getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED,

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -109,15 +109,15 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertTrue(exception.getMessage().contains("custom"));
   }
 
-  /** Stateful adsorption/power models stay review items until their #2911 step/conservation contracts are qualified. */
+  /** Audited battery state no longer hides the still-unaudited adsorption model in the capability inventory. */
   @Test
-  public void knownStatefulButUnauditedFamiliesRemainReviewItems() {
+  public void auditedBatteryDoesNotMaskUnauditedAdsorption() {
     Stream feed = createFeed("adsorption feed");
     AdsorptionBed bed = new AdsorptionBed("adsorption bed", feed);
     BatteryStorage battery = new BatteryStorage("battery", 1000.0);
 
     assertEquals(DynamicCapability.UNCLASSIFIED_DYNAMIC, bed.getDynamicCapability());
-    assertEquals(DynamicCapability.UNCLASSIFIED_DYNAMIC, battery.getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, battery.getDynamicCapability());
 
     ProcessSystem process = new ProcessSystem("treatment and power");
     process.add(feed);
@@ -126,11 +126,42 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
 
     DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
 
-    assertEquals(2, report.getCapabilityCounts().get(DynamicCapability.UNCLASSIFIED_DYNAMIC).intValue());
-    assertEquals(2, report.getReviewItems().size());
+    assertEquals(1, report.getCapabilityCounts().get(DynamicCapability.UNCLASSIFIED_DYNAMIC).intValue());
+    assertEquals(1, report.getCapabilityCounts().get(DynamicCapability.DYNAMIC_LUMPED).intValue());
+    assertEquals(1, report.getReviewItems().size());
     assertFalse(report.isStrictPreflightReady());
     assertTrue(containsDiagnostic(report.getReviewItems(), "adsorption bed"));
-    assertTrue(containsDiagnostic(report.getReviewItems(), "battery"));
+    assertFalse(containsDiagnostic(report.getReviewItems(), "battery"));
+  }
+
+  /** Runtime activation is a separate audited dimension from state ownership and requested dynamic mode. */
+  @Test
+  public void heatExchangerActivationRequiresItsActualRuntimePrerequisites() {
+    Stream hot = createFeed("hot feed");
+    Stream cold = createFeed("cold feed");
+    HeatExchanger exchanger = new HeatExchanger("dynamic hx", hot, cold);
+
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, exchanger.getDynamicCapability());
+    assertEquals(DynamicActivationStatus.INACTIVE, DynamicActivationResolver.resolve(exchanger));
+    assertTrue(DynamicActivationResolver.diagnostic(exchanger).contains("dynamicModelEnabled is false"));
+
+    exchanger.setCalculateSteadyState(false);
+    assertEquals(DynamicActivationStatus.INCOMPLETE_CONFIGURATION, DynamicActivationResolver.resolve(exchanger));
+    assertTrue(DynamicActivationResolver.diagnostic(exchanger).contains("calculateSteadyState"));
+
+    exchanger.setDynamicModelEnabled(true);
+    assertEquals(DynamicActivationStatus.INCOMPLETE_CONFIGURATION, DynamicActivationResolver.resolve(exchanger));
+    assertTrue(DynamicActivationResolver.diagnostic(exchanger).contains("wallMass"));
+    assertTrue(DynamicActivationResolver.diagnostic(exchanger).contains("heatTransferArea"));
+
+    exchanger.setWallMass(1000.0);
+    exchanger.setHeatTransferArea(50.0);
+    assertEquals(DynamicActivationStatus.ACTIVE, DynamicActivationResolver.resolve(exchanger));
+    assertTrue(DynamicActivationResolver.diagnostic(exchanger).contains("wall-energy path is active"));
+
+    assertEquals(DynamicActivationStatus.NOT_APPLICABLE, DynamicActivationResolver.resolve(hot));
+    assertEquals(DynamicActivationStatus.UNVERIFIED,
+        DynamicActivationResolver.resolve(new Separator("unqualified activation", hot)));
   }
 
   /**

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -11,7 +11,6 @@ import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.equipment.adsorber.AdsorptionBed;
 import neqsim.process.equipment.battery.BatteryStorage;
 import neqsim.process.equipment.compressor.Compressor;
-import neqsim.process.equipment.diffpressure.Orifice;
 import neqsim.process.equipment.energy.EnergyNetworkSolver;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
 import neqsim.process.equipment.pipeline.OnePhasePipeLine;
@@ -75,23 +74,20 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertEquals(DynamicCapability.CONTROL_DYNAMIC, controller.getDynamicCapability());
   }
 
-  /** Quasi-steady pressure-flow and energy-network adapters remain algebraic constraints in a transient flowsheet. */
+  /** An audited algebraic energy-network step may participate without creating a strict-preflight review item. */
   @Test
-  public void quasiSteadyTransientAdaptersRemainAlgebraic() {
-    Orifice orifice = new Orifice("orifice", 0.20, 0.10, 50.0, 45.0, 0.61);
+  public void algebraicEnergyNetworkSolverPassesCapabilityPreflight() {
     EnergyNetworkSolver energyNetwork = new EnergyNetworkSolver("energy network");
 
-    assertEquals(DynamicCapability.ALGEBRAIC, orifice.getDynamicCapability());
     assertEquals(DynamicCapability.ALGEBRAIC, energyNetwork.getDynamicCapability());
 
-    ProcessSystem process = new ProcessSystem("algebraic transient adapters");
-    process.add(orifice);
+    ProcessSystem process = new ProcessSystem("algebraic energy adapter");
     process.add(energyNetwork);
 
     DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
     assertTrue(report.isStrictPreflightReady());
     assertTrue(report.getReviewItems().isEmpty());
-    assertEquals(2, report.getCapabilityCounts().get(DynamicCapability.ALGEBRAIC).intValue());
+    assertEquals(1, report.getCapabilityCounts().get(DynamicCapability.ALGEBRAIC).intValue());
   }
 
   /** An unaudited custom runTransient override is visible instead of being promoted to a dynamic model. */

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -1,0 +1,196 @@
+package neqsim.process.dynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.WaterHammerPipe;
+import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
+import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.reservoir.SimpleReservoir;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.tank.Tank;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.measurementdevice.PressureTransmitter;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests the Phase-0 machine-readable dynamic capability contract. */
+public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
+
+  /** Core audited equipment categories remain explicit and conservative. */
+  @Test
+  public void coreEquipmentHasExpectedCapability() {
+    Stream feed = createFeed("feed");
+    Stream cold = createFeed("cold");
+
+    assertEquals(DynamicCapability.ALGEBRAIC, feed.getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, new Separator("separator", feed).getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, new Tank("tank", feed).getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, new HeatExchanger("hx", feed, cold).getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, new Compressor("compressor", feed).getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, new Pump("pump", feed).getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, new ThrottlingValve("valve", feed).getDynamicCapability());
+    assertEquals(DynamicCapability.BOUNDARY_DYNAMIC, new SimpleReservoir("reservoir").getDynamicCapability());
+  }
+
+  /** Distributed pipe models are distinguished from lumped process equipment. */
+  @Test
+  public void distributedPipeModelsAreClassified() {
+    Stream feed = createFeed("pipe feed");
+
+    assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new TwoFluidPipe("two fluid", feed).getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new TransientPipe("drift flux", feed).getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, new WaterHammerPipe("water hammer", feed).getDynamicCapability());
+  }
+
+  /** Control and instrumentation elements are reported separately from process-equipment physics. */
+  @Test
+  public void controlElementsUseControlDynamicCategory() {
+    Stream feed = createFeed("control feed");
+    PressureTransmitter transmitter = new PressureTransmitter("PT-100", feed);
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("PC-100");
+    controller.setTransmitter(transmitter);
+
+    assertEquals(DynamicCapability.CONTROL_DYNAMIC, transmitter.getDynamicCapability());
+    assertEquals(DynamicCapability.CONTROL_DYNAMIC, controller.getDynamicCapability());
+  }
+
+  /** An unaudited custom runTransient override is visible instead of being promoted to a dynamic model. */
+  @Test
+  public void customTransientOverrideRequiresReview() {
+    CustomTransientStream custom = new CustomTransientStream("custom", createFluid());
+    assertEquals(DynamicCapability.UNCLASSIFIED_DYNAMIC, custom.getDynamicCapability());
+
+    ProcessSystem process = new ProcessSystem("custom process");
+    process.add(custom);
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+
+    assertFalse(report.hasBlockingIssues());
+    assertEquals(1, report.getReviewItems().size());
+    assertTrue(report.getReviewItems().get(0).contains("custom"));
+  }
+
+  /** Algebraic equipment is valid in transient flowsheets until its unsupported difference-equation mode is requested. */
+  @Test
+  public void algebraicElementForcedIntoDynamicModeIsBlocking() {
+    Stream feed = createFeed("feed");
+    Separator separator = new Separator("separator", feed);
+    separator.setCalculateSteadyState(false);
+
+    ProcessSystem process = new ProcessSystem("process");
+    process.add(feed);
+    process.add(separator);
+
+    DynamicCapabilityReport validReport = DynamicCapabilityReport.from(process);
+    assertFalse(validReport.hasBlockingIssues());
+    assertTrue(validReport.getInactiveAuditedDynamicElements().isEmpty());
+
+    feed.setCalculateSteadyState(false);
+    DynamicCapabilityReport invalidReport = DynamicCapabilityReport.from(process);
+    assertTrue(invalidReport.hasBlockingIssues());
+    assertEquals(1, invalidReport.getBlockingIssues().size());
+    assertTrue(invalidReport.getBlockingIssues().get(0).contains("feed"));
+    assertTrue(invalidReport.getBlockingIssues().get(0).contains("ALGEBRAIC"));
+  }
+
+  /** Attached controllers are included once even when also registered standalone. */
+  @Test
+  public void reportDeduplicatesAttachedAndStandaloneControllerIdentity() {
+    Stream feed = createFeed("feed");
+    ThrottlingValve valve = new ThrottlingValve("valve", feed);
+    PressureTransmitter transmitter = new PressureTransmitter("PT-100", feed);
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("PC-100");
+    controller.setTransmitter(transmitter);
+    valve.addController("PC-100", controller);
+
+    ProcessSystem process = new ProcessSystem("controlled process");
+    process.add(feed);
+    process.add(valve);
+    process.add(transmitter);
+    process.add(controller);
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+    Map<DynamicCapability, Integer> counts = report.getCapabilityCounts();
+
+    assertEquals(2, counts.get(DynamicCapability.CONTROL_DYNAMIC).intValue());
+  }
+
+  /** Multi-area reports preserve area identity so identical unit names remain distinguishable. */
+  @Test
+  public void processModelReportQualifiesAreas() {
+    ProcessSystem upstream = new ProcessSystem("upstream");
+    upstream.add(createFeed("feed"));
+    ProcessSystem topside = new ProcessSystem("topside");
+    topside.add(createFeed("feed"));
+
+    ProcessModel model = new ProcessModel();
+    model.add("reservoir and wells", upstream);
+    model.add("topside", topside);
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(model);
+
+    assertEquals(2, report.getEntries().size());
+    assertEquals("reservoir and wells::feed", report.getEntries().get(0).getQualifiedName());
+    assertEquals("topside::feed", report.getEntries().get(1).getQualifiedName());
+    assertEquals(2, report.getCapabilityCounts().get(DynamicCapability.ALGEBRAIC).intValue());
+    assertTrue(report.toJson().contains("reservoir and wells"));
+    assertTrue(report.toJson().contains("ALGEBRAIC"));
+  }
+
+  /** Audited dynamic equipment left in steady-state mode is reported as an engineering review aid, not an error. */
+  @Test
+  public void inactiveAuditedDynamicStateIsVisibleButNotBlocking() {
+    Stream feed = createFeed("feed");
+    Separator separator = new Separator("separator", feed);
+
+    ProcessSystem process = new ProcessSystem("process");
+    process.add(feed);
+    process.add(separator);
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+
+    assertFalse(report.hasBlockingIssues());
+    assertEquals(1, report.getInactiveAuditedDynamicElements().size());
+    assertEquals("separator", report.getInactiveAuditedDynamicElements().get(0));
+  }
+
+  private static Stream createFeed(String name) {
+    Stream stream = new Stream(name, createFluid());
+    stream.setFlowRate(1000.0, "kg/hr");
+    stream.setPressure(50.0, "bara");
+    stream.setTemperature(25.0, "C");
+    return stream;
+  }
+
+  private static SystemSrkEos createFluid() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  private static final class CustomTransientStream extends Stream {
+    private static final long serialVersionUID = 1000L;
+
+    private CustomTransientStream(String name, SystemSrkEos fluid) {
+      super(name, fluid);
+    }
+
+    @Override
+    public void runTransient(double dt, UUID id) {
+      run(id);
+      increaseTime(dt);
+      setCalculationIdentifier(id);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -11,6 +11,8 @@ import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.equipment.adsorber.AdsorptionBed;
 import neqsim.process.equipment.battery.BatteryStorage;
 import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.diffpressure.Orifice;
+import neqsim.process.equipment.energy.EnergyNetworkSolver;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
 import neqsim.process.equipment.pipeline.OnePhasePipeLine;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
@@ -71,6 +73,25 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
 
     assertEquals(DynamicCapability.CONTROL_DYNAMIC, transmitter.getDynamicCapability());
     assertEquals(DynamicCapability.CONTROL_DYNAMIC, controller.getDynamicCapability());
+  }
+
+  /** Quasi-steady pressure-flow and energy-network adapters remain algebraic constraints in a transient flowsheet. */
+  @Test
+  public void quasiSteadyTransientAdaptersRemainAlgebraic() {
+    Orifice orifice = new Orifice("orifice", 0.20, 0.10, 50.0, 45.0, 0.61);
+    EnergyNetworkSolver energyNetwork = new EnergyNetworkSolver("energy network");
+
+    assertEquals(DynamicCapability.ALGEBRAIC, orifice.getDynamicCapability());
+    assertEquals(DynamicCapability.ALGEBRAIC, energyNetwork.getDynamicCapability());
+
+    ProcessSystem process = new ProcessSystem("algebraic transient adapters");
+    process.add(orifice);
+    process.add(energyNetwork);
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+    assertTrue(report.isStrictPreflightReady());
+    assertTrue(report.getReviewItems().isEmpty());
+    assertEquals(2, report.getCapabilityCounts().get(DynamicCapability.ALGEBRAIC).intValue());
   }
 
   /** An unaudited custom runTransient override is visible instead of being promoted to a dynamic model. */

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -165,7 +165,6 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     Stream feed = createFeed("module feed");
     SeparationTrainModule module = new SeparationTrainModule("separation train");
     module.addInputStream("feed stream", feed);
-    module.initializeModule();
 
     ProcessSystem process = new ProcessSystem("module process");
     process.add(module);
@@ -187,7 +186,6 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     Stream feed = createFeed("module feed");
     SeparationTrainModule module = new SeparationTrainModule("separation train");
     module.addInputStream("feed stream", feed);
-    module.initializeModule();
 
     ProcessSystem process = new ProcessSystem("topside");
     process.add(module);

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -2,6 +2,7 @@ package neqsim.process.dynamics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Map;
 import java.util.UUID;
@@ -21,6 +22,7 @@ import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.measurementdevice.PressureTransmitter;
 import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.processmodel.processmodules.SeparationTrainModule;
 import neqsim.thermo.system.SystemSrkEos;
 
 /** Tests the Phase-0 machine-readable dynamic capability contract. */
@@ -80,6 +82,10 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertFalse(report.hasBlockingIssues());
     assertEquals(1, report.getReviewItems().size());
     assertTrue(report.getReviewItems().get(0).contains("custom"));
+    assertFalse(report.isStrictPreflightReady());
+    assertEquals(1, report.getStrictPreflightIssues().size());
+    IllegalStateException exception = assertThrows(IllegalStateException.class, report::assertStrictTransientReady);
+    assertTrue(exception.getMessage().contains("custom"));
   }
 
   /**
@@ -98,6 +104,7 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     DynamicCapabilityReport validReport = DynamicCapabilityReport.from(process);
     assertFalse(validReport.hasBlockingIssues());
     assertTrue(validReport.getInactiveAuditedDynamicElements().isEmpty());
+    assertTrue(validReport.isStrictPreflightReady());
 
     feed.setCalculateSteadyState(false);
     DynamicCapabilityReport invalidReport = DynamicCapabilityReport.from(process);
@@ -105,6 +112,7 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertEquals(1, invalidReport.getBlockingIssues().size());
     assertTrue(invalidReport.getBlockingIssues().get(0).contains("feed"));
     assertTrue(invalidReport.getBlockingIssues().get(0).contains("ALGEBRAIC"));
+    assertFalse(invalidReport.isStrictPreflightReady());
   }
 
   /** Attached controllers are included once even when also registered standalone. */
@@ -151,6 +159,47 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertTrue(report.toJson().contains("ALGEBRAIC"));
   }
 
+  /** Initialized process-module contents are recursively inventoried with stable diagnostic paths. */
+  @Test
+  public void reportRecursesThroughInitializedProcessModules() {
+    Stream feed = createFeed("module feed");
+    SeparationTrainModule module = new SeparationTrainModule("separation train");
+    module.addInputStream("feed stream", feed);
+    module.initializeModule();
+
+    ProcessSystem process = new ProcessSystem("module process");
+    process.add(module);
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+
+    assertTrue(report.getEntries().size() > 10);
+    assertTrue(hasQualifiedEntry(report, "separation train::Inlet separator"));
+    assertTrue(hasQualifiedEntry(report, "separation train::HP gas scrubber"));
+    assertTrue(report.getCapabilityCounts().get(DynamicCapability.DYNAMIC_LUMPED).intValue() > 0);
+    assertTrue(report.getCapabilityCounts().get(DynamicCapability.UNCLASSIFIED_DYNAMIC).intValue() > 0);
+    assertFalse(report.isStrictPreflightReady());
+    assertTrue(report.getStrictPreflightIssues().get(0).contains("separation train"));
+  }
+
+  /** Nested module paths remain area-qualified in multi-area ProcessModel reports. */
+  @Test
+  public void nestedModuleEntriesRetainProcessModelAreaIdentity() {
+    Stream feed = createFeed("module feed");
+    SeparationTrainModule module = new SeparationTrainModule("separation train");
+    module.addInputStream("feed stream", feed);
+    module.initializeModule();
+
+    ProcessSystem process = new ProcessSystem("topside");
+    process.add(module);
+    ProcessModel model = new ProcessModel();
+    model.add("topside", process);
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(model);
+
+    assertTrue(hasQualifiedEntry(report, "topside::separation train::Inlet separator"));
+    assertTrue(report.toJson().contains("containerPath"));
+  }
+
   /** Audited dynamic equipment left in steady-state mode is reported as an engineering review aid, not an error. */
   @Test
   public void inactiveAuditedDynamicStateIsVisibleButNotBlocking() {
@@ -166,6 +215,15 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertFalse(report.hasBlockingIssues());
     assertEquals(1, report.getInactiveAuditedDynamicElements().size());
     assertEquals("separator", report.getInactiveAuditedDynamicElements().get(0));
+  }
+
+  private static boolean hasQualifiedEntry(DynamicCapabilityReport report, String qualifiedName) {
+    for (DynamicCapabilityReport.Entry entry : report.getEntries()) {
+      if (qualifiedName.equals(entry.getQualifiedName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static Stream createFeed(String name) {

--- a/src/test/java/neqsim/process/dynamics/EventSchedulerSnapshotTest.java
+++ b/src/test/java/neqsim/process/dynamics/EventSchedulerSnapshotTest.java
@@ -2,6 +2,7 @@ package neqsim.process.dynamics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -58,6 +59,33 @@ public class EventSchedulerSnapshotTest extends neqsim.NeqSimTest {
     assertEquals("third", scheduler.getPendingEvents().get(1).getLabel());
     assertEquals(1, scheduler.getFiredEvents().size());
     assertEquals("first", scheduler.getFiredEvents().get(0).getLabel());
+  }
+
+  /** Event-boundary inspection is ordered and read-only so trial-step selection cannot mutate scheduler state. */
+  @Test
+  public void eventBoundaryInspectionDoesNotMutateScheduler() {
+    EventScheduler scheduler = new EventScheduler();
+    AtomicInteger actionCount = new AtomicInteger();
+    scheduler.scheduleEvent(3.0, "third", actionCount::incrementAndGet);
+    scheduler.scheduleEvent(1.0, "first", actionCount::incrementAndGet);
+    scheduler.scheduleEvent(2.0, "second", actionCount::incrementAndGet);
+
+    assertEquals(1.0, scheduler.getNextEventTime(), 0.0);
+    List<EventScheduler.ScheduledEvent> due = scheduler.getDueEvents(2.0);
+
+    assertEquals(2, due.size());
+    assertEquals("first", due.get(0).getLabel());
+    assertEquals("second", due.get(1).getLabel());
+    assertEquals(3, scheduler.getPendingEvents().size());
+    assertEquals(0, scheduler.getFiredEvents().size());
+    assertEquals(0, actionCount.get());
+
+    assertEquals(1, scheduler.fireDueEvents(1.0));
+    assertEquals(2.0, scheduler.getNextEventTime(), 0.0);
+    assertEquals(1, actionCount.get());
+
+    scheduler.fireDueEvents(3.0);
+    assertEquals(Double.POSITIVE_INFINITY, scheduler.getNextEventTime(), 0.0);
   }
 
   /** Null state is rejected before existing scheduler bookkeeping can be changed. */

--- a/src/test/java/neqsim/process/dynamics/EventSchedulerSnapshotTest.java
+++ b/src/test/java/neqsim/process/dynamics/EventSchedulerSnapshotTest.java
@@ -2,6 +2,10 @@ package neqsim.process.dynamics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
@@ -86,6 +90,36 @@ public class EventSchedulerSnapshotTest extends neqsim.NeqSimTest {
 
     scheduler.fireDueEvents(3.0);
     assertEquals(Double.POSITIVE_INFINITY, scheduler.getNextEventTime(), 0.0);
+  }
+
+  /** Serializable actions make scheduler checkpoints usable across a Java checkpoint/restart boundary. */
+  @Test
+  public void snapshotRoundTripsThroughJavaSerialization() throws Exception {
+    EventScheduler scheduler = new EventScheduler();
+    scheduler.scheduleEvent(1.0, "first", new NoOpAction());
+    scheduler.scheduleEvent(2.0, "second", new NoOpAction());
+    scheduler.fireDueEvents(1.0);
+
+    EventScheduler.Snapshot original = scheduler.snapshot();
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+      out.writeObject(original);
+    }
+
+    EventScheduler.Snapshot restoredSnapshot;
+    try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restoredSnapshot = (EventScheduler.Snapshot) in.readObject();
+    }
+
+    EventScheduler restoredScheduler = new EventScheduler();
+    restoredScheduler.restore(restoredSnapshot);
+
+    assertEquals(1, restoredSnapshot.getPendingEventCount());
+    assertEquals(1, restoredSnapshot.getFiredEventCount());
+    assertEquals(1, restoredScheduler.getPendingEvents().size());
+    assertEquals("second", restoredScheduler.getPendingEvents().get(0).getLabel());
+    assertEquals(1, restoredScheduler.getFiredEvents().size());
+    assertEquals("first", restoredScheduler.getFiredEvents().get(0).getLabel());
   }
 
   /** Null state is rejected before existing scheduler bookkeeping can be changed. */

--- a/src/test/java/neqsim/process/dynamics/EventSchedulerSnapshotTest.java
+++ b/src/test/java/neqsim/process/dynamics/EventSchedulerSnapshotTest.java
@@ -1,0 +1,82 @@
+package neqsim.process.dynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for transactional event-scheduler bookkeeping snapshots. */
+public class EventSchedulerSnapshotTest extends neqsim.NeqSimTest {
+  /** Restoring a snapshot recovers pending/fired membership without pretending to undo action side effects. */
+  @Test
+  public void restoreRecoversBookkeepingButDoesNotUndoExternalActionEffects() {
+    EventScheduler scheduler = new EventScheduler();
+    AtomicInteger actionCount = new AtomicInteger();
+    scheduler.scheduleEvent(1.0, "first", actionCount::incrementAndGet);
+    scheduler.scheduleEvent(2.0, "second", actionCount::incrementAndGet);
+
+    EventScheduler.Snapshot beforeStep = scheduler.snapshot();
+    assertEquals(2, beforeStep.getPendingEventCount());
+    assertEquals(0, beforeStep.getFiredEventCount());
+
+    assertEquals(1, scheduler.fireDueEvents(1.0));
+    assertEquals(1, actionCount.get());
+    assertEquals(1, scheduler.getPendingEvents().size());
+    assertEquals(1, scheduler.getFiredEvents().size());
+
+    scheduler.restore(beforeStep);
+
+    assertEquals(2, scheduler.getPendingEvents().size());
+    assertEquals(0, scheduler.getFiredEvents().size());
+    assertEquals(1, actionCount.get(), "scheduler rollback cannot undo an external Runnable side effect");
+
+    assertEquals(1, scheduler.fireDueEvents(1.0));
+    assertEquals(2, actionCount.get(), "restored scheduler state permits deterministic replay of the event");
+  }
+
+  /** A checkpoint taken after one event fires restores that exact pending/fired boundary. */
+  @Test
+  public void snapshotRestoresIntermediateEventBoundary() {
+    EventScheduler scheduler = new EventScheduler();
+    scheduler.scheduleEvent(1.0, "first", new NoOpAction());
+    scheduler.scheduleEvent(2.0, "second", new NoOpAction());
+    scheduler.scheduleEvent(3.0, "third", new NoOpAction());
+
+    assertEquals(1, scheduler.fireDueEvents(1.0));
+    EventScheduler.Snapshot afterFirst = scheduler.snapshot();
+
+    assertEquals(2, afterFirst.getPendingEventCount());
+    assertEquals(1, afterFirst.getFiredEventCount());
+    assertEquals(2, scheduler.fireDueEvents(3.0));
+    assertEquals(0, scheduler.getPendingEvents().size());
+    assertEquals(3, scheduler.getFiredEvents().size());
+
+    scheduler.restore(afterFirst);
+
+    assertEquals(2, scheduler.getPendingEvents().size());
+    assertEquals("second", scheduler.getPendingEvents().get(0).getLabel());
+    assertEquals("third", scheduler.getPendingEvents().get(1).getLabel());
+    assertEquals(1, scheduler.getFiredEvents().size());
+    assertEquals("first", scheduler.getFiredEvents().get(0).getLabel());
+  }
+
+  /** Null state is rejected before existing scheduler bookkeeping can be changed. */
+  @Test
+  public void nullSnapshotIsRejectedWithoutMutation() {
+    EventScheduler scheduler = new EventScheduler();
+    scheduler.scheduleEvent(1.0, "event", new NoOpAction());
+
+    assertThrows(IllegalArgumentException.class, () -> scheduler.restore(null));
+    assertEquals(1, scheduler.getPendingEvents().size());
+    assertEquals(0, scheduler.getFiredEvents().size());
+  }
+
+  private static final class NoOpAction implements Runnable, java.io.Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    @Override
+    public void run() {
+      // Intentional no-op test event.
+    }
+  }
+}

--- a/src/test/java/neqsim/process/dynamics/IntegratorsAndSchedulerTest.java
+++ b/src/test/java/neqsim/process/dynamics/IntegratorsAndSchedulerTest.java
@@ -2,7 +2,6 @@ package neqsim.process.dynamics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,7 @@ class IntegratorsAndSchedulerTest {
   @Test
   void bdfMatchesAnalyticForStiffStep() {
     // BDF (implicit Euler) handles a much larger step than explicit Euler would tolerate.
-    IntegratorStrategy bdf = new BDFIntegrator();
+    BDFIntegrator bdf = new BDFIntegrator();
     double k = 100.0; // stiff
     double x = 1.0;
     double t = 0.0;
@@ -60,8 +59,38 @@ class IntegratorsAndSchedulerTest {
     // Implicit Euler is monotone-stable; reading at t=1.0 should be a small positive number.
     assertTrue(x > 0.0, "implicit Euler must remain positive for monotone decay, got " + x);
     assertTrue(x < 1.0e-3, "implicit Euler should have decayed below 1e-3, got " + x);
-    assertFalse(((BDFIntegrator) bdf).lastStepFellBack(),
-        "BDF should converge on linear decay, not fall back to explicit");
+    assertTrue(bdf.lastStepConverged(), "BDF should report the implicit Newton solve as converged");
+    assertFalse(bdf.lastStepFellBack(), "BDF should converge on linear decay, not fall back to explicit");
+    assertTrue(bdf.getLastNewtonIterations() > 0);
+    assertTrue(bdf.getLastResidual() <= bdf.getTolerance());
+  }
+
+  @Test
+  void bdfNonConvergenceFailsLoudUnlessFallbackIsExplicitlyEnabled() {
+    IntegratorStrategy.Slope nonlinear = new IntegratorStrategy.Slope() {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public double dxdt(double time, double state) {
+        return state * state;
+      }
+    };
+    BDFIntegrator bdf = new BDFIntegrator(1.0e-12, 1, 1.0e-6);
+
+    IllegalStateException failure = assertThrows(IllegalStateException.class, () -> bdf.step(0.0, 1.0, nonlinear, 0.1));
+    assertTrue(failure.getMessage().contains("did not converge"));
+    assertTrue(failure.getMessage().contains("dt=0.1 s"));
+    assertFalse(bdf.lastStepConverged());
+    assertFalse(bdf.lastStepFellBack());
+    assertEquals(1, bdf.getLastNewtonIterations());
+    assertTrue(Double.isFinite(bdf.getLastResidual()));
+
+    bdf.setExplicitEulerFallbackEnabled(true);
+    assertTrue(bdf.isExplicitEulerFallbackEnabled());
+    double fallback = bdf.step(0.0, 1.0, nonlinear, 0.1);
+    assertEquals(1.1, fallback, 1.0e-12);
+    assertFalse(bdf.lastStepConverged(), "an Euler compatibility fallback is not a converged BDF step");
+    assertTrue(bdf.lastStepFellBack());
   }
 
   @Test
@@ -85,6 +114,7 @@ class IntegratorsAndSchedulerTest {
     assertThrows(IllegalArgumentException.class, () -> bdf.step(0.0, 1.0, null, 0.1));
     assertThrows(IllegalArgumentException.class, () -> bdf.step(0.0, 1.0, d, 0.0));
     assertThrows(IllegalArgumentException.class, () -> bdf.step(0.0, 1.0, d, -0.1));
+    assertThrows(IllegalArgumentException.class, () -> bdf.step(0.0, 1.0, d, Double.POSITIVE_INFINITY));
     assertThrows(IllegalArgumentException.class, () -> new BDFIntegrator(0.0, 10, 1e-6));
     assertThrows(IllegalArgumentException.class, () -> new BDFIntegrator(1e-8, 0, 1e-6));
     assertThrows(IllegalArgumentException.class, () -> new BDFIntegrator(1e-8, 10, 0.0));
@@ -150,17 +180,27 @@ class IntegratorsAndSchedulerTest {
   }
 
   @Test
-  void eventSchedulerSwallowsExceptions() {
+  void eventSchedulerFailsLoudAndLeavesFailedEventPending() {
     EventScheduler sched = new EventScheduler();
+    final int[] laterEventRuns = new int[] {0};
     sched.scheduleEvent(1.0, "bad", new Runnable() {
       @Override
       public void run() {
-        throw new RuntimeException("boom");
+        throw new IllegalStateException("boom");
       }
     });
-    // Should not throw; should still log as fired.
-    assertEquals(1, sched.fireDueEvents(2.0));
-    assertEquals(1, sched.getFiredEvents().size());
-    assertNotNull(sched.getFiredEvents().get(0));
+    sched.scheduleEvent(1.5, "later", new Runnable() {
+      @Override
+      public void run() {
+        laterEventRuns[0]++;
+      }
+    });
+
+    IllegalStateException failure = assertThrows(IllegalStateException.class, () -> sched.fireDueEvents(2.0));
+    assertEquals("boom", failure.getMessage());
+    assertEquals(2, sched.getPendingEvents().size(), "failed event and later events must remain pending");
+    assertEquals("bad", sched.getPendingEvents().get(0).getLabel());
+    assertEquals(0, sched.getFiredEvents().size(), "failed actions are not recorded as successfully fired");
+    assertEquals(0, laterEventRuns[0], "later due events must not execute after an earlier failure");
   }
 }

--- a/src/test/java/neqsim/process/dynamics/IntegratorsAndSchedulerTest.java
+++ b/src/test/java/neqsim/process/dynamics/IntegratorsAndSchedulerTest.java
@@ -182,7 +182,7 @@ class IntegratorsAndSchedulerTest {
   @Test
   void eventSchedulerFailsLoudAndLeavesFailedEventPending() {
     EventScheduler sched = new EventScheduler();
-    final int[] laterEventRuns = new int[] {0};
+    final int[] laterEventRuns = new int[] { 0 };
     sched.scheduleEvent(1.0, "bad", new Runnable() {
       @Override
       public void run() {

--- a/src/test/java/neqsim/process/dynamics/PressureFlowDynamicCapabilityTest.java
+++ b/src/test/java/neqsim/process/dynamics/PressureFlowDynamicCapabilityTest.java
@@ -1,0 +1,30 @@
+package neqsim.process.dynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.diffpressure.Orifice;
+import neqsim.process.equipment.reservoir.WellFlow;
+import neqsim.process.processmodel.ProcessSystem;
+
+/** Regression coverage for audited quasi-steady pressure-flow relations. */
+public class PressureFlowDynamicCapabilityTest extends neqsim.NeqSimTest {
+  /** Orifice and well IPR relations own no integrated physical inventory of their own. */
+  @Test
+  public void auditedPressureFlowRelationsAreAlgebraicTransientParticipants() {
+    Orifice orifice = new Orifice("orifice");
+    WellFlow wellFlow = new WellFlow("well flow");
+
+    assertEquals(DynamicCapability.ALGEBRAIC, orifice.getDynamicCapability());
+    assertEquals(DynamicCapability.ALGEBRAIC, wellFlow.getDynamicCapability());
+
+    ProcessSystem process = new ProcessSystem("pressure-flow relations");
+    process.add(orifice);
+    process.add(wellFlow);
+
+    DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
+    assertTrue(report.isStrictPreflightReady());
+    assertTrue(report.getReviewItems().isEmpty());
+    assertEquals(2, report.getCapabilityCounts().get(DynamicCapability.ALGEBRAIC).intValue());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/battery/BatteryStorageTest.java
+++ b/src/test/java/neqsim/process/equipment/battery/BatteryStorageTest.java
@@ -1,7 +1,11 @@
 package neqsim.process.equipment.battery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import neqsim.process.dynamics.DynamicCapability;
+import neqsim.process.dynamics.DynamicCapabilityResolver;
+import neqsim.process.dynamics.TransientStepIdentifier;
 
 public class BatteryStorageTest extends neqsim.NeqSimTest {
   @Test
@@ -20,5 +24,37 @@ public class BatteryStorageTest extends neqsim.NeqSimTest {
     double expectedSoc = 95.0 - 50.0 / 0.95;
     assertEquals(expectedSoc, battery.getStateOfCharge(), 1e-6);
     assertEquals(-50.0, battery.getEnergyStream().getDuty(), 1e-6);
+  }
+
+  /** Same-ID refinements recompute from physical-step start without consuming ramp or energy twice. */
+  @Test
+  void transientRefinementIsIdempotentForPowerStateOfChargeAndClock() {
+    BatteryStorage battery = new BatteryStorage("dynamic battery", 1000.0);
+    battery.setStateOfCharge(500.0);
+    battery.setEfficiencies(1.0, 1.0);
+    battery.setPowerLimits(1000.0, 1000.0);
+    battery.setPowerRampRate(100.0);
+    battery.setTargetPower(1000.0);
+
+    UUID physicalStepA = TransientStepIdentifier.deterministicPhysicalStep("battery-refinement", 0L);
+    UUID physicalStepB = TransientStepIdentifier.deterministicPhysicalStep("battery-refinement", 1L);
+
+    battery.runTransient(2.0, physicalStepA);
+    double stateAfterA = battery.getStateOfCharge();
+    assertEquals(200.0, battery.getCurrentPower(), 1.0e-12);
+    assertEquals(500.0 - 200.0 * 2.0 / 3600.0, stateAfterA, 1.0e-12);
+    assertEquals(2.0, battery.getTime(), 0.0);
+
+    battery.runTransient(2.0, physicalStepA);
+    assertEquals(200.0, battery.getCurrentPower(), 1.0e-12);
+    assertEquals(stateAfterA, battery.getStateOfCharge(), 1.0e-12);
+    assertEquals(2.0, battery.getTime(), 0.0);
+
+    battery.runTransient(2.0, physicalStepB);
+    assertEquals(400.0, battery.getCurrentPower(), 1.0e-12);
+    assertEquals(stateAfterA - 400.0 * 2.0 / 3600.0, battery.getStateOfCharge(), 1.0e-12);
+    assertEquals(4.0, battery.getTime(), 0.0);
+    assertEquals(physicalStepB, battery.getCalculationIdentifier());
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, DynamicCapabilityResolver.resolve(battery));
   }
 }

--- a/src/test/java/neqsim/process/equipment/diffpressure/OrificeTest.java
+++ b/src/test/java/neqsim/process/equipment/diffpressure/OrificeTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.equipment.diffpressure;
 
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -67,5 +68,63 @@ public class OrificeTest {
     // orifice type ("D").
     double m = Orifice.calculateMassFlowRate(0.07366, 0.05, 200000.0, 183000.0, 999.1, 0.0011, 1.33, "D");
     Assertions.assertEquals(7.702338, m, 1e-6);
+  }
+
+  /** A/refine-A/B recalculates the algebraic restriction but owns only two physical clock advances. */
+  @Test
+  void transientOrificeUsesPhysicalStepIdentifierForClockOwnership() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("transient inlet", fluid);
+    inlet.setFlowRate(1000.0, "kg/hr");
+    inlet.run();
+
+    Orifice orifice = new Orifice("transient orifice", 0.10, 0.05, 50.0, 20.0, 0.61);
+    orifice.setInletStream(inlet);
+
+    UUID stepA = UUID.randomUUID();
+    UUID stepB = UUID.randomUUID();
+
+    orifice.runTransient(2.0, stepA);
+    double firstFlow = inlet.getFlowRate("kg/sec");
+    Assertions.assertTrue(firstFlow > 0.0);
+    Assertions.assertEquals(2.0, orifice.getTime(), 0.0);
+    Assertions.assertEquals(stepA, orifice.getCalculationIdentifier());
+
+    orifice.runTransient(2.0, stepA);
+    Assertions.assertEquals(firstFlow, inlet.getFlowRate("kg/sec"), 1e-12);
+    Assertions.assertEquals(2.0, orifice.getTime(), 0.0);
+    Assertions.assertEquals(stepA, orifice.getCalculationIdentifier());
+
+    orifice.runTransient(2.0, stepB);
+    Assertions.assertEquals(firstFlow, inlet.getFlowRate("kg/sec"), 1e-12);
+    Assertions.assertEquals(4.0, orifice.getTime(), 0.0);
+    Assertions.assertEquals(stepB, orifice.getCalculationIdentifier());
+  }
+
+  /** The low-flow early return follows the same A/refine-A/B physical-step timing contract. */
+  @Test
+  void transientOrificeLowFlowStillRecordsPhysicalStepCompletion() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("zero-flow inlet", fluid);
+    inlet.setFlowRate(0.0, "kg/hr");
+    inlet.run();
+
+    Orifice orifice = new Orifice("zero-flow orifice", 0.10, 0.05, 50.0, 20.0, 0.61);
+    orifice.setInletStream(inlet);
+
+    UUID stepA = UUID.randomUUID();
+    UUID stepB = UUID.randomUUID();
+    orifice.runTransient(2.0, stepA);
+    orifice.runTransient(2.0, stepA);
+    orifice.runTransient(2.0, stepB);
+
+    Assertions.assertEquals(4.0, orifice.getTime(), 0.0);
+    Assertions.assertEquals(stepB, orifice.getCalculationIdentifier());
   }
 }

--- a/src/test/java/neqsim/process/equipment/energy/EnergyConverterTest.java
+++ b/src/test/java/neqsim/process/equipment/energy/EnergyConverterTest.java
@@ -2,7 +2,9 @@ package neqsim.process.equipment.energy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import neqsim.process.dynamics.DynamicCapability;
 import neqsim.process.equipment.stream.EnergyBus;
 import neqsim.process.equipment.stream.EnergyPort;
 import neqsim.process.equipment.stream.EnergyPortDirection;
@@ -59,6 +61,40 @@ class EnergyConverterTest {
     inverter.runTransient(2.0);
     assertEquals(0.0, inverter.getOutputPower(), 1.0e-12);
     assertTrue(inverter.isTripped());
+  }
+
+  @Test
+  void transientRefinementRecomputesFromPhysicalStepStartWithoutDoubleAdvance() {
+    EnergyBus input = new EnergyBus("input", EnergyType.ELECTRICAL);
+    EnergyBus output = new EnergyBus("output", EnergyType.ELECTRICAL);
+    EnergyPort source = port("source", EnergyType.ELECTRICAL, EnergyPortDirection.OUTPUT, EnergyPortMode.CALCULATED,
+        input);
+    Inverter inverter = new Inverter("inverter");
+    inverter.connectEnergyStream(EnergyConverter.INPUT_PORT, input, EnergyPortMode.SPECIFICATION);
+    inverter.connectEnergyStream(EnergyConverter.OUTPUT_PORT, output, EnergyPortMode.CALCULATED);
+    inverter.setRequestedInputPower(1000.0);
+    inverter.setRampRate(100.0);
+    source.setDuty(1000.0);
+    input.solveBalance();
+
+    UUID physicalStepA = UUID.randomUUID();
+    UUID physicalStepB = UUID.randomUUID();
+
+    inverter.runTransient(2.0, physicalStepA);
+    assertEquals(200.0, inverter.getOutputPower(), 1.0e-12);
+    assertEquals(2.0, inverter.getTime(), 0.0);
+    assertEquals(physicalStepA, inverter.getCalculationIdentifier());
+
+    inverter.runTransient(2.0, physicalStepA);
+    assertEquals(200.0, inverter.getOutputPower(), 1.0e-12);
+    assertEquals(2.0, inverter.getTime(), 0.0);
+    assertEquals(physicalStepA, inverter.getCalculationIdentifier());
+
+    inverter.runTransient(2.0, physicalStepB);
+    assertEquals(400.0, inverter.getOutputPower(), 1.0e-12);
+    assertEquals(4.0, inverter.getTime(), 0.0);
+    assertEquals(physicalStepB, inverter.getCalculationIdentifier());
+    assertEquals(DynamicCapability.DYNAMIC_LUMPED, inverter.getDynamicCapability());
   }
 
   private static EnergyPort port(String owner, EnergyType type, EnergyPortDirection direction, EnergyPortMode mode,

--- a/src/test/java/neqsim/process/equipment/expander/ExpanderDynamicTest.java
+++ b/src/test/java/neqsim/process/equipment/expander/ExpanderDynamicTest.java
@@ -3,6 +3,7 @@ package neqsim.process.equipment.expander;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import neqsim.process.dynamics.TransientStepIdentifier;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.processmodel.ProcessSystem;
@@ -60,9 +61,7 @@ public class ExpanderDynamicTest {
     return expander;
   }
 
-  /**
-   * Verifies that transient execution ramps nozzle opening, recovered power and shaft speed.
-   */
+  /** Verifies that transient execution ramps nozzle opening, recovered power and shaft speed. */
   @Test
   void testDynamicNozzlePowerAndSpeedRamp() {
     Expander expander = buildDynamicExpander();
@@ -75,9 +74,37 @@ public class ExpanderDynamicTest {
     Assertions.assertTrue(expander.getPower("kW") < 0.0, "Expander should still report recovered steady power");
   }
 
-  /**
-   * Verifies that an external shaft load decelerates the expander shaft when it exceeds recovered power.
-   */
+  /** Same-ID refinement must not integrate nozzle, power ramp, rotor speed or clock twice. */
+  @Test
+  void testRepeatedPhysicalStepEvaluationRestoresDynamicStepStartState() {
+    Expander expander = buildDynamicExpander();
+    UUID physicalStepA = TransientStepIdentifier.deterministicPhysicalStep("expander-refinement", 0L);
+    UUID physicalStepB = TransientStepIdentifier.deterministicPhysicalStep("expander-refinement", 1L);
+
+    expander.runTransient(1.0, physicalStepA);
+    double nozzleAfterA = expander.getNozzleOpening();
+    double powerAfterA = expander.getDynamicRecoveredPower("kW");
+    double speedAfterA = expander.getSpeed();
+
+    Assertions.assertEquals(0.30, nozzleAfterA, 1.0e-10);
+    Assertions.assertEquals(250.0, powerAfterA, 1.0e-8);
+    Assertions.assertEquals(1.0, expander.getTime(), 0.0);
+
+    expander.runTransient(1.0, physicalStepA);
+    Assertions.assertEquals(nozzleAfterA, expander.getNozzleOpening(), 1.0e-10);
+    Assertions.assertEquals(powerAfterA, expander.getDynamicRecoveredPower("kW"), 1.0e-8);
+    Assertions.assertEquals(speedAfterA, expander.getSpeed(), 1.0e-8);
+    Assertions.assertEquals(1.0, expander.getTime(), 0.0);
+
+    expander.runTransient(1.0, physicalStepB);
+    Assertions.assertEquals(0.40, expander.getNozzleOpening(), 1.0e-10);
+    Assertions.assertEquals(500.0, expander.getDynamicRecoveredPower("kW"), 1.0e-8);
+    Assertions.assertTrue(expander.getSpeed() > speedAfterA, "The next physical step should continue rotor acceleration");
+    Assertions.assertEquals(2.0, expander.getTime(), 0.0);
+    Assertions.assertEquals(physicalStepB, expander.getCalculationIdentifier());
+  }
+
+  /** Verifies that an external shaft load decelerates the expander shaft when it exceeds recovered power. */
   @Test
   void testExternalLoadDeceleratesShaft() {
     Expander expander = buildDynamicExpander();
@@ -88,9 +115,7 @@ public class ExpanderDynamicTest {
     Assertions.assertTrue(expander.getSpeed() < 3000.0, "External load should decelerate the shaft");
   }
 
-  /**
-   * Verifies that the expander propagates shaft speed to a coupled compressor load.
-   */
+  /** Verifies that the expander propagates shaft speed to a coupled compressor load. */
   @Test
   void testCoupledCompressorReceivesShaftSpeed() {
     Expander expander = buildDynamicExpander();
@@ -105,9 +130,7 @@ public class ExpanderDynamicTest {
     Assertions.assertTrue(load.getPower("kW") > 0.0, "Coupled compressor should run as a positive shaft load");
   }
 
-  /**
-   * Verifies process-level transient execution reaches the expander dynamic branch.
-   */
+  /** Verifies process-level transient execution reaches the expander dynamic branch. */
   @Test
   void testProcessSystemRunTransientExecutesDynamicExpander() {
     Stream feed = buildFeedStream();

--- a/src/test/java/neqsim/process/equipment/expander/ExpanderDynamicTest.java
+++ b/src/test/java/neqsim/process/equipment/expander/ExpanderDynamicTest.java
@@ -99,7 +99,8 @@ public class ExpanderDynamicTest {
     expander.runTransient(1.0, physicalStepB);
     Assertions.assertEquals(0.40, expander.getNozzleOpening(), 1.0e-10);
     Assertions.assertEquals(500.0, expander.getDynamicRecoveredPower("kW"), 1.0e-8);
-    Assertions.assertTrue(expander.getSpeed() > speedAfterA, "The next physical step should continue rotor acceleration");
+    Assertions.assertTrue(expander.getSpeed() > speedAfterA,
+        "The next physical step should continue rotor acceleration");
     Assertions.assertEquals(2.0, expander.getTime(), 0.0);
     Assertions.assertEquals(physicalStepB, expander.getCalculationIdentifier());
   }

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientFailureContractTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientFailureContractTest.java
@@ -1,0 +1,82 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+
+/** Baseline physical-step failure semantics that parallel execution must preserve. */
+class ProcessSystemTransientFailureContractTest {
+  @Test
+  void sequentialEquipmentFailureStopsDownstreamExecutionAndStepCommit() {
+    ProcessSystem process = new ProcessSystem("sequential transient failure");
+    FailingTransientEquipment failing = new FailingTransientEquipment("failing unit");
+    RecordingTransientEquipment downstream = new RecordingTransientEquipment("downstream unit");
+    process.add(failing);
+    process.add(downstream);
+
+    UUID stepId = UUID.randomUUID();
+    IllegalStateException failure =
+        assertThrows(IllegalStateException.class, () -> process.runTransient(1.0, stepId));
+
+    assertEquals("intentional transient failure", failure.getMessage());
+    assertEquals(1, failing.getTransientCalls());
+    assertEquals(0, downstream.getTransientCalls(), "downstream equipment must not run after a failed unit");
+    assertNotEquals(stepId, process.getCalculationIdentifier(),
+        "a failed physical step must not commit the ProcessSystem calculation identifier");
+    assertEquals(0, process.getHistorySize(), "a failed physical step must not append measurement history");
+    assertEquals(1.0, process.getTime(), 0.0,
+        "the current engine advances time before equipment; whole-step rollback remains a separate Phase-0 dependency");
+  }
+
+  private static final class FailingTransientEquipment extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private int transientCalls;
+
+    private FailingTransientEquipment(String name) {
+      super(name);
+    }
+
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+
+    @Override
+    public void runTransient(double dt, UUID id) {
+      transientCalls++;
+      throw new IllegalStateException("intentional transient failure");
+    }
+
+    private int getTransientCalls() {
+      return transientCalls;
+    }
+  }
+
+  private static final class RecordingTransientEquipment extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private int transientCalls;
+
+    private RecordingTransientEquipment(String name) {
+      super(name);
+    }
+
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+
+    @Override
+    public void runTransient(double dt, UUID id) {
+      transientCalls++;
+      setCalculationIdentifier(id);
+    }
+
+    private int getTransientCalls() {
+      return transientCalls;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientFailureContractTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientFailureContractTest.java
@@ -19,8 +19,7 @@ class ProcessSystemTransientFailureContractTest {
     process.add(downstream);
 
     UUID stepId = UUID.randomUUID();
-    IllegalStateException failure =
-        assertThrows(IllegalStateException.class, () -> process.runTransient(1.0, stepId));
+    IllegalStateException failure = assertThrows(IllegalStateException.class, () -> process.runTransient(1.0, stepId));
 
     assertEquals("intentional transient failure", failure.getMessage());
     assertEquals(1, failing.getTransientCalls());

--- a/src/test/java/neqsim/process/processmodel/RunTransientEventSchedulerTest.java
+++ b/src/test/java/neqsim/process/processmodel/RunTransientEventSchedulerTest.java
@@ -15,6 +15,7 @@ import neqsim.process.dynamics.BDFIntegrator;
 import neqsim.process.dynamics.EventScheduler;
 import neqsim.process.dynamics.ExplicitEulerIntegrator;
 import neqsim.process.dynamics.IntegratorStrategy;
+import neqsim.process.dynamics.TransientStepIdentifier;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
@@ -87,15 +88,16 @@ public class RunTransientEventSchedulerTest {
       }
     });
 
-    UUID id = UUID.randomUUID();
-    // Step 1 → t=0.5, Step 2 → t=1.0, Step 3 → t=1.5 (event due), Step 4 → t=2.0
-    p.runTransient(0.5, id);
+    // Step 1 → t=0.5, Step 2 → t=1.0, Step 3 → t=1.5 (event due), Step 4 → t=2.0.
+    // Each physical step has its own identifier; one identifier is only reused for
+    // refinement/evaluation work inside that physical step.
+    p.runTransient(0.5, TransientStepIdentifier.deterministicPhysicalStep("event-fire", 0L));
     assertEquals(0, count.get(), "Event must not fire before its time");
-    p.runTransient(0.5, id);
+    p.runTransient(0.5, TransientStepIdentifier.deterministicPhysicalStep("event-fire", 1L));
     assertEquals(0, count.get(), "Event must not fire before its time");
-    p.runTransient(0.5, id);
+    p.runTransient(0.5, TransientStepIdentifier.deterministicPhysicalStep("event-fire", 2L));
     assertEquals(1, count.get(), "Event must fire when current time reaches 1.5s");
-    p.runTransient(0.5, id);
+    p.runTransient(0.5, TransientStepIdentifier.deterministicPhysicalStep("event-fire", 3L));
     assertEquals(1, count.get(), "Event must fire only once");
 
     assertEquals(1, s.getFiredEvents().size());
@@ -314,9 +316,9 @@ public class RunTransientEventSchedulerTest {
     plant.add("first", firstArea);
     plant.add("second", secondArea);
 
-    UUID stepIdentifier = UUID.randomUUID();
     for (int step = 1; step <= 4; step++) {
-      plant.runTransient(0.25, stepIdentifier);
+      UUID physicalStepId = TransientStepIdentifier.deterministicPhysicalStep("aligned-model", step - 1L);
+      plant.runTransient(0.25, physicalStepId);
       assertEquals(step * 0.25, firstArea.getTime(), 0.0);
       assertEquals(firstArea.getTime(), secondArea.getTime(), 0.0);
     }

--- a/src/test/java/neqsim/process/processmodel/RunTransientEventSchedulerTest.java
+++ b/src/test/java/neqsim/process/processmodel/RunTransientEventSchedulerTest.java
@@ -144,8 +144,8 @@ public class RunTransientEventSchedulerTest {
       }
     });
 
-    IllegalStateException failure =
-        assertThrows(IllegalStateException.class, () -> p.runTransient(0.5, failedPhysicalStep));
+    IllegalStateException failure = assertThrows(IllegalStateException.class,
+        () -> p.runTransient(0.5, failedPhysicalStep));
 
     assertEquals("trip actuator failed", failure.getMessage());
     assertEquals(1, s.getPendingEvents().size(), "failed event must remain retryable");

--- a/src/test/java/neqsim/process/processmodel/RunTransientEventSchedulerTest.java
+++ b/src/test/java/neqsim/process/processmodel/RunTransientEventSchedulerTest.java
@@ -124,6 +124,73 @@ public class RunTransientEventSchedulerTest {
   }
 
   /**
+   * A failing safety/operator event must abort the ProcessSystem physical-step attempt before equipment and process
+   * calculation identifiers are committed. The already-advanced process clock documents the remaining whole-step
+   * transaction gap and should be rolled back by the future #2911 transaction layer.
+   */
+  @Test
+  public void testEventFailureAbortsProcessStepBeforeEquipmentCommit() {
+    ProcessSystem p = buildMinimalProcess();
+    EventScheduler s = new EventScheduler();
+    p.setEventScheduler(s);
+    UUID previousProcessIdentifier = p.getCalculationIdentifier();
+    UUID previousSeparatorIdentifier = p.getUnit("sep").getCalculationIdentifier();
+    UUID failedPhysicalStep = TransientStepIdentifier.deterministicPhysicalStep("failed-event", 0L);
+
+    s.scheduleEvent(0.5, "failed trip", new Runnable() {
+      @Override
+      public void run() {
+        throw new IllegalStateException("trip actuator failed");
+      }
+    });
+
+    IllegalStateException failure =
+        assertThrows(IllegalStateException.class, () -> p.runTransient(0.5, failedPhysicalStep));
+
+    assertEquals("trip actuator failed", failure.getMessage());
+    assertEquals(1, s.getPendingEvents().size(), "failed event must remain retryable");
+    assertEquals(0, s.getFiredEvents().size(), "failed event must not be recorded as successfully fired");
+    assertEquals(previousProcessIdentifier, p.getCalculationIdentifier(),
+        "failed physical step must not commit the ProcessSystem calculation identifier");
+    assertEquals(previousSeparatorIdentifier, p.getUnit("sep").getCalculationIdentifier(),
+        "event failure occurs before equipment execution and must not commit the separator identifier");
+    assertEquals(0.5, p.getTime(), 0.0,
+        "current ProcessSystem still advances its clock before event execution; whole-step rollback remains required");
+  }
+
+  /**
+   * A shared failing event must propagate out of multi-area ProcessModel execution instead of allowing later areas to
+   * continue. The first area's already-advanced clock records the remaining model-wide transaction requirement.
+   */
+  @Test
+  public void testEventFailureStopsLaterProcessModelAreas() {
+    ProcessSystem firstArea = new ProcessSystem("first area");
+    ProcessSystem secondArea = new ProcessSystem("second area");
+    ProcessModel plant = new ProcessModel();
+    plant.add("first", firstArea);
+    plant.add("second", secondArea);
+
+    EventScheduler shared = new EventScheduler();
+    plant.setEventScheduler(shared);
+    shared.scheduleEvent(0.5, "failed shared trip", new Runnable() {
+      @Override
+      public void run() {
+        throw new IllegalStateException("shared trip failed");
+      }
+    });
+
+    IllegalStateException failure = assertThrows(IllegalStateException.class,
+        () -> plant.runTransient(0.5, TransientStepIdentifier.deterministicPhysicalStep("failed-model-event", 0L)));
+
+    assertEquals("shared trip failed", failure.getMessage());
+    assertEquals(0.5, firstArea.getTime(), 0.0,
+        "first area currently advances before the shared event failure; model-wide rollback remains required");
+    assertEquals(0.0, secondArea.getTime(), 0.0, "later areas must not continue after a failed shared event");
+    assertEquals(1, shared.getPendingEvents().size());
+    assertEquals(0, shared.getFiredEvents().size());
+  }
+
+  /**
    * IntegratorStrategy default is ExplicitEulerIntegrator; setter+getter roundtrip; null restores default.
    */
   @Test

--- a/src/test/java/neqsim/process/processmodel/TransientPhysicalStepIdentityTest.java
+++ b/src/test/java/neqsim/process/processmodel/TransientPhysicalStepIdentityTest.java
@@ -1,0 +1,129 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
+import neqsim.process.dynamics.TransientStepIdentifier;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.process.measurementdevice.PressureTransmitter;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression tests for physical-step versus refinement calculation identity. */
+public class TransientPhysicalStepIdentityTest extends neqsim.NeqSimTest {
+
+  /** Repeated evaluations inside one physical step share an ID without advancing local time twice. */
+  @Test
+  public void refinementReusesPhysicalStepIdentifierWithoutDoubleClockAdvance() {
+    Recycle recycle = createRecycle();
+    UUID physicalStepA = TransientStepIdentifier.deterministicPhysicalStep("recycle-refinement", 0L);
+    UUID physicalStepB = TransientStepIdentifier.deterministicPhysicalStep("recycle-refinement", 1L);
+
+    recycle.runTransient(2.0, physicalStepA);
+    recycle.runTransient(2.0, physicalStepA);
+    recycle.runTransient(2.0, physicalStepB);
+
+    assertEquals(3, recycle.getIterations());
+    assertEquals(4.0, recycle.getTime(), 0.0);
+    assertEquals(physicalStepB, recycle.getCalculationIdentifier());
+  }
+
+  /** Consecutive physical steps use distinct IDs so a mutable controller advances exactly once per step. */
+  @Test
+  public void consecutiveProcessSystemStepsAdvanceControllerOnceEach() {
+    ProcessSystem process = createControlledProcess("process");
+    ControllerDeviceBaseClass controller = (ControllerDeviceBaseClass) process.getControllerDevices().get(0);
+    UUID physicalStepA = TransientStepIdentifier.deterministicPhysicalStep("controller-loop", 0L);
+    UUID physicalStepB = TransientStepIdentifier.deterministicPhysicalStep("controller-loop", 1L);
+
+    process.runTransient(1.0, physicalStepA);
+    process.runTransient(1.0, physicalStepB);
+
+    assertNotEquals(physicalStepA, physicalStepB);
+    assertEquals(2.0, process.getTime(), 0.0);
+    assertEquals(2, controller.getEventLog().size());
+    assertEquals(physicalStepB, controller.getCalculationIdentifier());
+  }
+
+  /** One model-level physical-step ID is shared across areas, while the following step receives a new ID. */
+  @Test
+  public void processModelSharesOnePhysicalStepIdAcrossAreasAndChangesItNextStep() {
+    ProcessSystem areaA = createControlledProcess("area A");
+    ProcessSystem areaB = createControlledProcess("area B");
+    ProcessModel model = new ProcessModel();
+    model.add("A", areaA);
+    model.add("B", areaB);
+
+    UUID physicalStepA = TransientStepIdentifier.deterministicPhysicalStep("multi-area", 0L);
+    UUID physicalStepB = TransientStepIdentifier.deterministicPhysicalStep("multi-area", 1L);
+
+    model.runTransient(0.5, physicalStepA);
+    assertEquals(physicalStepA, areaA.getCalculationIdentifier());
+    assertEquals(physicalStepA, areaB.getCalculationIdentifier());
+    assertEquals(0.5, areaA.getTime(), 0.0);
+    assertEquals(areaA.getTime(), areaB.getTime(), 0.0);
+
+    model.runTransient(0.5, physicalStepB);
+    assertEquals(physicalStepB, areaA.getCalculationIdentifier());
+    assertEquals(physicalStepB, areaB.getCalculationIdentifier());
+    assertEquals(1.0, areaA.getTime(), 0.0);
+    assertEquals(areaA.getTime(), areaB.getTime(), 0.0);
+    assertEquals(2, ((ControllerDeviceBaseClass) areaA.getControllerDevices().get(0)).getEventLog().size());
+    assertEquals(2, ((ControllerDeviceBaseClass) areaB.getControllerDevices().get(0)).getEventLog().size());
+  }
+
+  /** Refinement identities are diagnostic metadata and remain separate from the physical-step identity. */
+  @Test
+  public void evaluationIdentifiersAreDistinctFromPhysicalStepIdentifier() {
+    UUID physicalStep = TransientStepIdentifier.deterministicPhysicalStep("newton-step", 7L);
+    UUID evaluation0 = TransientStepIdentifier.deterministicEvaluation(physicalStep, 0L);
+    UUID evaluation1 = TransientStepIdentifier.deterministicEvaluation(physicalStep, 1L);
+
+    assertNotEquals(physicalStep, evaluation0);
+    assertNotEquals(physicalStep, evaluation1);
+    assertNotEquals(evaluation0, evaluation1);
+    assertEquals(physicalStep, TransientStepIdentifier.deterministicPhysicalStep("newton-step", 7L));
+    assertEquals(evaluation0, TransientStepIdentifier.deterministicEvaluation(physicalStep, 0L));
+  }
+
+  private static ProcessSystem createControlledProcess(String name) {
+    Stream feed = createFeed(name + " feed");
+    PressureTransmitter transmitter = new PressureTransmitter(name + " PT", feed);
+    transmitter.setUnit("bara");
+
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass(name + " PC");
+    controller.setTransmitter(transmitter);
+    controller.setUnit("bara");
+    controller.setControllerSetPoint(50.0);
+    controller.setControllerParameters(1.0, 20.0, 0.0);
+
+    ProcessSystem process = new ProcessSystem(name);
+    process.add(feed);
+    process.add(transmitter);
+    process.add(controller);
+    process.run();
+    return process;
+  }
+
+  private static Stream createFeed(String name) {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream(name, fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    feed.setPressure(50.0, "bara");
+    feed.setTemperature(25.0, "C");
+    return feed;
+  }
+
+  private static Recycle createRecycle() {
+    Stream inlet = createFeed("recycle inlet");
+    Stream outlet = inlet.clone("recycle outlet");
+    Recycle recycle = new Recycle("recycle");
+    recycle.addStream(inlet);
+    recycle.setOutletStream(outlet);
+    return recycle;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/TransientPhysicalStepIdentityTest.java
+++ b/src/test/java/neqsim/process/processmodel/TransientPhysicalStepIdentityTest.java
@@ -2,6 +2,7 @@ package neqsim.process.processmodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
@@ -44,7 +45,7 @@ public class TransientPhysicalStepIdentityTest extends neqsim.NeqSimTest {
     assertNotEquals(physicalStepA, physicalStepB);
     assertEquals(2.0, process.getTime(), 0.0);
     assertEquals(2, controller.getEventLog().size());
-    assertEquals(physicalStepB, controller.getCalculationIdentifier());
+    assertTrue(controller.hasRunTransient(physicalStepB));
   }
 
   /** One model-level physical-step ID is shared across areas, while the following step receives a new ID. */

--- a/src/test/java/neqsim/process/processmodel/TransientPhysicalStepIdentityTest.java
+++ b/src/test/java/neqsim/process/processmodel/TransientPhysicalStepIdentityTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.dynamics.TransientStepIdentifier;
+import neqsim.process.equipment.energy.EnergyNetworkSolver;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.util.Recycle;
 import neqsim.process.measurementdevice.PressureTransmitter;
@@ -29,6 +30,21 @@ public class TransientPhysicalStepIdentityTest extends neqsim.NeqSimTest {
     assertEquals(3, recycle.getIterations());
     assertEquals(4.0, recycle.getTime(), 0.0);
     assertEquals(physicalStepB, recycle.getCalculationIdentifier());
+  }
+
+  /** Algebraic energy-network refinement recalculates but advances its local clock once per physical step. */
+  @Test
+  public void energyNetworkRefinementAdvancesClockOncePerPhysicalStep() {
+    EnergyNetworkSolver energyNetwork = new EnergyNetworkSolver("energy network");
+    UUID physicalStepA = TransientStepIdentifier.deterministicPhysicalStep("energy-refinement", 0L);
+    UUID physicalStepB = TransientStepIdentifier.deterministicPhysicalStep("energy-refinement", 1L);
+
+    energyNetwork.runTransient(2.0, physicalStepA);
+    energyNetwork.runTransient(2.0, physicalStepA);
+    energyNetwork.runTransient(2.0, physicalStepB);
+
+    assertEquals(4.0, energyNetwork.getTime(), 0.0);
+    assertEquals(physicalStepB, energyNetwork.getCalculationIdentifier());
   }
 
   /** Consecutive physical steps use distinct IDs so a mutable controller advances exactly once per step. */


### PR DESCRIPTION
## Summary

Advances **#2911 Phase 0** with a machine-readable transient capability audit for `ProcessSystem` and multi-area `ProcessModel`, recursive module inventory, runtime-activation diagnostics, physical-timestep calculation-ID semantics, deterministic safety/OTS step IDs, event-scheduler checkpoint state, audited same-step behavior for selected algebraic/lumped-state equipment, and an explicit **process-execution qualification dimension**.

The PR deliberately keeps these engineering questions separate:

1. **state ownership** — algebraic vs lumped/distributed/boundary/control state;
2. **runtime activation/configuration** — whether the current case actually selects the stateful path;
3. **physical-step/refinement safety** — whether A/refine-A/B re-evaluation advances state exactly once;
4. **process execution semantics** — whether the selected parallel/adaptive process-level execution mode is currently safe for strict qualification;
5. **quantitative maturity** — conservation, timestep/mesh convergence, benchmarks and control/safety/OTS evidence.

A `runTransient(...)` override, `DYNAMIC_*` label, or API switch alone is not professional transient qualification. This PR does **not** claim that `runTransientAdaptive(...)` is transactional, that current parallel transient execution is fail-loud, that current `ProcessModel` execution is a plant-wide DAE solve, or that every listed dynamic model is quantitatively qualified for every operating regime.

## Roadmap criterion advanced

**#2911 Phase 0:** dynamic capability matrix, runtime activation/configuration visibility, process-execution qualification, physical-step/clock/calculation-ID contract, event rollback foundation, and unit-operation inventory.

No #2911 completion checkbox is justified until this open PR is merged and the remaining Phase-0 transaction/benchmark criteria are satisfied.

## Capability / inventory contract

Adds `DynamicCapability`: `ALGEBRAIC`, `DYNAMIC_LUMPED`, `DYNAMIC_DISTRIBUTED`, `BOUNDARY_DYNAMIC`, `CONTROL_DYNAMIC`, `UNCLASSIFIED_DYNAMIC`, `UNSUPPORTED_DYNAMIC`.

Current conservative mapping includes:

- **algebraic:** standard `Stream` execution, composite `ModuleInterface` containers, `EnergyNetworkSolver`, ISO-5167 `Orifice`, and `WellFlow` IPR relations;
- **lumped state ownership:** `Separator`, `Tank`, `HeatExchanger`, `Compressor`/`Expander`, `Pump`, `ThrottlingValve`, `EnergyConverter` families, and `BatteryStorage`;
- **distributed state ownership:** `OnePhasePipeLine`, `TwoFluidPipe`, drift-flux `TransientPipe`, `WaterHammerPipe`;
- **boundary state:** `SimpleReservoir`;
- **control state:** controllers and measurement devices.

`DynamicCapabilityReport` recursively walks initialized module child `ProcessSystem`s, retaining area/container paths and identity de-duplication. Strict preflight remains opt-in through `getStrictPreflightIssues()`, `isStrictPreflightReady()` and `assertStrictTransientReady()`.

Passing capability preflight is **not** a conservation, control, safety, DEXPI, OTS or engineering-approval certificate.

## Runtime activation/configuration

`DynamicActivationStatus` separates runtime activation from state ownership: `NOT_APPLICABLE`, `ACTIVE`, `INACTIVE`, `INCOMPLETE_CONFIGURATION`, `UNVERIFIED`.

Current type-specific activation rules include:

- **HeatExchanger:** wall-energy dynamics require `dynamicModelEnabled == true`, positive wall mass and positive heat-transfer area;
- **BatteryStorage:** stored-energy/ramped-power state is inherent to its transient call and requires positive storage capacity; inherited `calculateSteadyState` is not treated as its activation switch;
- **Expander:** `calculateSteadyState=true` selects algebraic thermodynamic execution while false activates nozzle, recovered-power and rotor-speed/inertia integration;
- other state-owning families remain `UNVERIFIED` until their actual branch conditions/prerequisites are audited.

`UNVERIFIED` remains a review diagnostic rather than a blanket strict-preflight failure. Activation status is also not quantitative maturity.

## Process-execution qualification

`DynamicCapabilityReport` schema is now **1.2** and exposes `getExecutionIssues()` separately from element state/activation.

Two currently selectable process-level modes are explicitly blocked by strict professional preflight because current source does not yet satisfy the campaign numerical/error contract:

- **parallel transient execution:** current `ProcessSystem.runEquipmentTransientParallel(...)` catches/logs equipment worker failures and can allow the physical step to continue. Until worker failures propagate fail-loudly and the whole-step transaction exists, a strict report states that parallel transient execution is unqualified;
- **adaptive transient execution:** current `runTransientAdaptive(...)` mutates one full step and derives a following timestep recommendation. It does not yet perform full-step versus two-half-step error estimation, rejected-step restore, retry, and exactly-one accepted-step commit. Enabling adaptive timestep therefore creates a strict execution issue.

These execution diagnostics are collected for standalone `ProcessSystem`, each area of `ProcessModel`, and initialized nested module `ProcessSystem`s with stable area/container-qualified paths. They are temporary engineering gates tied to verified source limitations, not permanent policy restrictions: once the underlying execution semantics are repaired and tested, the corresponding blocker should be removed.

This increment makes unsupported/unqualified numerics explicit without changing existing `runTransient(...)` behavior or automatically invoking strict preflight.

## Physical equations / state variables

No thermodynamic constitutive equation is changed by the new execution-preflight increment.

Existing state repaired/qualified in this PR includes:

- **BatteryStorage:** stored electrical energy `stateOfCharge` [Wh] and ramp-limited converter power [W]. Charge/discharge changes stored energy over `dt/3600`, applies configured efficiencies and clamps to `[0, capacity]`;
- **Expander:** nozzle/guide-vane opening, recovered shaft-power ramp [kW], and rotor speed/inertia; same-ID refinement restores step-start state before re-solving thermodynamics and reintegrating the same physical step;
- **EnergyConverter:** previous useful-output state with finite ramp [W/s];
- **Orifice/WellFlow:** no integrated inventory; algebraic pressure-flow relations.

Distributed TwoFluid/TransientPipe equations are not modified. The stiff dispersed-bubble/severe-slug quantitative limitation remains owned by #2909 and is not weakened or duplicated.

## Physical-step identity

`TransientStepIdentifier` formalizes A/refine-A/B. A non-null UUID identifies one **physical timestep**; repeated nonlinear/refinement evaluations reuse that physical-step ID, while the next accepted physical timestep gets a different ID. Diagnostic evaluation IDs are separate metadata.

User-facing fixed-ID outer loops and `DynamicSafetyScenarioRunner` were corrected to use one physical-step identifier per timestep. `runTransient(dt)` continues to create a fresh UUID for ordinary loops.

Qualified same-step evidence in this PR includes:

- `EnergyConverter`: 1000 W available, 100 W/s ramp, `dt=2 s` -> A/refine-A/B = **200/200/400 W**, local time **2/2/4 s**;
- `BatteryStorage`: 1000 Wh capacity, 500 Wh initial SOC, unity efficiencies, 100 W/s ramp, `dt=2 s` -> **200/200/400 W**, refine-A preserves A's SOC, local time **2/2/4 s**;
- `Expander`: 60 -> 20 bara rich gas, 0.20 initial nozzle, 0.10 fraction/s stroke, 250 kW/s recovered-power ramp, `dt=1 s` -> A **0.30/250 kW/1 s**, refine-A reproduces nozzle/power/speed, B **0.40/500 kW/2 s**;
- `EnergyNetworkSolver` and `Orifice`: algebraic recalculation remains allowed on refinement while local time advances once per non-null physical-step ID.

## Event transaction foundation

`EventScheduler` provides pending/fired `Snapshot`/`restore`, `getNextEventTime()` and non-mutating ordered due-event inspection.

This restores scheduler membership only. It cannot undo an external side effect already performed by an event `Runnable`. A qualified rejected adaptive trial must defer externally visible actions until acceptance or include every mutated object in the same whole-step transaction. `ProcessSystem.copy()` does not automatically restore this transient runtime service.

## Tests / quantitative evidence

Focused regression coverage includes:

- `DynamicActivationReportTest` — HeatExchanger, BatteryStorage and Expander activation rules plus multi-area diagnostics;
- `DynamicCapabilityReportTest` — capability categories, strict preflight, controls, multi-area/module inventory, and new standalone/multi-area **parallel/adaptive execution blocker** assertions;
- `DynamicCapabilityModuleContainerTest` — real initialized `SeparationTrainModule` child inventory;
- `PressureFlowDynamicCapabilityTest` — audited `Orifice`/`WellFlow` capability and preflight;
- `TransientPhysicalStepIdentityTest` — recycle, energy network, controllers, `ProcessModel`, physical/evaluation IDs;
- `BatteryStorageTest`, `ExpanderDynamicTest`, `OrificeTest`, `EnergyConverterTest`, `EventSchedulerSnapshotTest` — A/refine-A/B state/timing/checkpoint evidence.

The new execution-preflight test verifies that:

- a standalone process with parallel transient execution reports exactly one explicit fail-loud qualification issue;
- a standalone process with adaptive timestep execution reports exactly one rejected-step/error-estimator qualification issue;
- multi-area `ProcessModel` preserves both area identities in `executionIssues` JSON.

No new global conservation claim is made by the metadata increment. Merged #2917 remains the current ProcessSystem-level quantitative one-phase compositional pipeline conservation/event baseline. TwoFluid severe-slug qualification remains blocked by #2909.

## Solver / control / event / safety / OTS evidence

- **Solver:** physical-step identity, explicit unsafe execution-mode preflight and scheduler checkpoint semantics improve Phase-0 honesty; the plant is still not a common vector ODE/DAE solve.
- **Control:** deterministic physical-step identity avoids the known fixed-ID controller-freeze pattern; a unified sampled controller/transmitter/external-I/O clock is still missing.
- **Events/safety:** deterministic scenario-step IDs and scheduler bookkeeping are useful foundations. Whole-process rejected-step rollback and side-effect deferral are still missing, so this is not accountable safety qualification.
- **OTS/virtual commissioning:** strict preflight can now reject known unsafe parallel/adaptive execution configurations before they are presented as professional-ready. There is still no qualified real-time-factor/jitter, deterministic I/O scan, external closed-loop or whole-model snapshot/restore evidence.

## Performance / backwards compatibility

Capability/activation/execution reporting is diagnostic and linear in the audited process graph. The new process-level checks are constant-time per recursively visited `ProcessSystem` and run only when a report is requested.

No thermodynamic hot-path algorithm, pressure-flow equation or nonlinear iteration was added. Existing public steady-state/transient signatures and runtime behavior remain unchanged. Strict preflight is opt-in, so existing applications that use parallel or adaptive modes are not silently changed; they receive the new diagnostic only if they ask for qualification.

## DEXPI / P&ID / PFD impact

No competing dynamic/DEXPI/PFD graph is introduced. Stable equipment, area and module identity remains coordinated with the canonical EngineeringGraph/topology work shared by #1332 and #2899. Future DEXPI-linked dynamic evidence can consume capability/activation/execution diagnostics instead of duplicating object identity or process topology.

No NeqSim-Colab update is warranted for this low-level qualification-only increment; the acceptance notebooks should advance when a user-visible transaction/adaptive/OTS workflow exists.

## Current master / validation

- exact branch head: `203b3b4ee38c79684afc4af0e54d38b937768a94`
- current `master`: `275b188db57be71df899abaa02a760002c6a8c4e`
- `behind_by=0`; GitHub reports the PR mergeable
- compare against current master contains **31 intended campaign files**
- no submitted reviews or unresolved inline review threads at the latest recheck

The two exact-head CI failures from `5b45fa56...` are repaired without weakening the contract:

- `DynamicActivationReportTest` now expects capability-report schema `1.2`, matching the execution-issues field introduced by this PR;
- `ProcessSystemTransientFailureContractTest` carries the exact Spotless wrap;
- the repository-wide `ModelRegistry.java` and `ModelRegistryOwnerScopingTest.java` formatter output is identical to current master and therefore disappears from the current-master campaign diff.

Validation on the exact merged tree before publication:

- `python devtools/run_spotless.py apply` twice: passed with no second-pass source change;
- `python devtools/run_spotless.py check`: passed;
- `python devtools/check_documentation_search.py`: passed, 648 Markdown pages plus one standalone HTML page;
- `pre-commit run --all-files --hook-stage pre-commit`: passed;
- `pre-commit run --all-files --hook-stage pre-push`: passed;
- focused dynamic suite: **28 tests, 0 failures/errors/skips** across `DynamicActivationReportTest`, `ProcessSystemTransientFailureContractTest`, `IntegratorsAndSchedulerTest`, `RunTransientEventSchedulerTest`, and `BDFIntegratorReferenceTest`;
- `git diff --check`: passed.

The first focused-test attempt used an incomplete task-local Maven cache and was blocked by unavailable Maven Central DNS. The retry used a complete task-local cache in offline mode and passed; no acceptance criterion or source behavior was changed to bypass infrastructure.

Fresh hosted workflows are running on exact head `203b3b4e...`. Skills/agents lint is already successful; no pending hosted job is claimed passed. The PR remains draft and is **not READY TO MERGE** until the complete applicable exact-head matrix and final review/mergeability recheck are clean.

## Remaining engineering limitations / next dependency

Still not implemented/qualified here:

- machine-readable quantitative-maturity status separate from state/activation/execution configuration;
- complete activation/refinement audit for remaining dynamic unit families;
- **fail-loud propagation of worker exceptions from the current parallel-transient equipment pass**;
- identity-preserving whole-step `ProcessSystem`/`ProcessModel` transaction;
- rejected-step rollback of equipment/controllers/measurements/alarms/history/runtime services;
- deferred transactional event actions;
- full-step/substep adaptive error estimator and accepted/rejected-step semantics;
- vector ODE/DAE state/residual assembly, sparse Jacobians and plant-wide pressure-flow causality;
- multi-rate subcycling;
- explicit instrument/control/external-I/O scan scheduler and real-time OTS layer.

Legacy `ProcessSystem.storeInitialState()/reset()` is **not** the adaptive rollback transaction: its restore replaces copied graph objects and does not restore all controllers, connections, adaptive bookkeeping or the transient scheduler as one identity-preserving transaction.

**Next dependency:** make parallel transient equipment failures propagate fail-loudly, then introduce the identity-preserving whole-step transaction for both `ProcessSystem` and multi-area `ProcessModel`. Only after that transaction exists should adaptive execution become trial -> error decision -> reject/restore -> retry -> commit exactly one accepted physical step with safe event localization.

Advances Phase 0 of #2911; the campaign remains open.