### PR TITLE
perf(tpflash): reduce beta-solver matrix allocation

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -210,23 +210,18 @@ public class TPmultiflash extends TPflash {
    * @return a double
    */
   public double solveBeta() {
-    SimpleMatrix betaMatrix = new SimpleMatrix(1, system.getNumberOfPhases());
     SimpleMatrix ans = null;
     double err = 1.0;
     double gradResidual = 1.0;
     int iter = 1;
     do {
       iter++;
-      for (int k = 0; k < system.getNumberOfPhases(); k++) {
-        betaMatrix.set(0, k, system.getPhase(k).getBeta());
-      }
-
       calcQ();
       SimpleMatrix dQM = new SimpleMatrix(dQdbeta);
       gradResidual = dQM.normF();
       SimpleMatrix dQdBM = new SimpleMatrix(Qmatrix);
       try {
-        ans = dQdBM.solve(dQM).transpose();
+        ans = dQdBM.solve(dQM);
       } catch (Exception ex) {
         if (shouldApplyEnhancedMultiPhaseCheck()) {
           for (int kk = 0; kk < system.getNumberOfPhases(); kk++) {
@@ -234,7 +229,7 @@ public class TPmultiflash extends TPflash {
           }
           dQdBM = new SimpleMatrix(Qmatrix);
           try {
-            ans = dQdBM.solve(dQM).transpose();
+            ans = dQdBM.solve(dQM);
           } catch (Exception ex2) {
             logger.error(ex2.getMessage());
             break;
@@ -245,10 +240,12 @@ public class TPmultiflash extends TPflash {
         }
       }
 
-      betaMatrix = betaMatrix.minus(ans.scale(iter / (iter + 3.0)));
+      // The linear solve already returns a column vector. Apply it directly to avoid allocating
+      // transposed, scaled, and subtracted temporary matrices in every beta iteration.
+      double betaStepScale = iter / (iter + 3.0);
       removePhase = false;
       for (int k = 0; k < system.getNumberOfPhases(); k++) {
-        double currBeta = betaMatrix.get(0, k);
+        double currBeta = system.getPhase(k).getBeta() - ans.get(k, 0) * betaStepScale;
         if (currBeta < phaseFractionMinimumLimit) {
           system.setBeta(k, phaseFractionMinimumLimit);
           if (checkOneRemove) {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
@@ -249,4 +249,52 @@ class TPmultiflashTest {
         "A run without a beta solve must clear stall state retained by a reused operation");
   }
 
+  /** Verifies a direct beta solve preserves a converged two-phase equilibrium and material balance. */
+  @Test
+  void testDirectBetaSolvePreservesConvergedTwoPhaseState() {
+    SystemInterface system = createMethaneHeptanePrSystem(0.0, false);
+    system.setTemperature(250.0, "K");
+    system.setPressure(30.0, "bara");
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+
+    assertEquals(2, system.getNumberOfPhases());
+    double[] referenceBeta = new double[2];
+    double[] referenceZ = new double[2];
+    double[][] referenceComposition = new double[2][system.getPhase(0).getNumberOfComponents()];
+    for (int phase = 0; phase < 2; phase++) {
+      referenceBeta[phase] = system.getBeta(phase);
+      referenceZ[phase] = system.getPhase(phase).getZ();
+      for (int component = 0; component < referenceComposition[phase].length; component++) {
+        referenceComposition[phase][component] = system.getPhase(phase).getComponent(component).getx();
+      }
+    }
+
+    TPmultiflash operation = new TPmultiflash(system, false);
+    operation.setDoubleArrays();
+    double residual = operation.solveBeta();
+
+    assertTrue(Double.isFinite(residual));
+    assertTrue(residual <= 1.0e-10);
+    for (int phase = 0; phase < 2; phase++) {
+      assertEquals(referenceBeta[phase], system.getBeta(phase), 1.0e-11);
+      assertEquals(referenceZ[phase], system.getPhase(phase).getZ(), 1.0e-11);
+      double compositionSum = 0.0;
+      for (int component = 0; component < referenceComposition[phase].length; component++) {
+        assertEquals(referenceComposition[phase][component], system.getPhase(phase).getComponent(component).getx(),
+            1.0e-11);
+        compositionSum += system.getPhase(phase).getComponent(component).getx();
+      }
+      assertEquals(1.0, compositionSum, 1.0e-12);
+    }
+
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
+      double recoveredFeed = 0.0;
+      for (int phase = 0; phase < 2; phase++) {
+        recoveredFeed += system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
+      }
+      assertEquals(system.getPhase(0).getComponent(component).getz(), recoveredFeed, 1.0e-11);
+    }
+  }
+
 }


### PR DESCRIPTION
## Summary

- apply the Newton beta correction directly from the column vector returned by EJML
- remove the per-iteration row-vector snapshot, transpose, scale, and matrix-subtraction temporaries
- preserve both required `system.init(1)` calls, damping, clipping, normalization, fallback regularization, phase removal, convergence criteria, and numerical tolerances
- add a direct two-phase beta-solve regression covering phase fractions, compositions, Z factors, normalization, residual, and component material balance

Refs #2698.

## Reproduced performance problem

In `TPmultiflash.solveBeta()`, EJML solves

```
Q'' Δβ = Q'
```

and returns `Δβ` as an `Nphase × 1` column vector. The previous implementation then:

1. copied current phase fractions into a `1 × Nphase` `SimpleMatrix`;
2. transposed the solution;
3. allocated a scaled solution;
4. allocated the result of the matrix subtraction.

Those matrices are temporary implementation artifacts; the solver ultimately reads each corrected beta only once.

## Method and equivalence

The retained update is algebraically identical:

```
β(k+1)_p = β(k)_p - [iter / (iter + 3)] Δβ_p
```

The candidate reads `Δβ_p` directly as `ans.get(p, 0)` and applies the scalar update to the existing phase beta. It does not change the Hessian, gradient, Newton solution, damping, bounds, beta normalization, EOS initialization, composition update, or phase topology logic.

Michelsen's phase-split formulation describes stability-assisted multiphase equilibrium and second-order convergence methods: https://doi.org/10.1016/0378-3812(82)85002-4. Okuno, Johns and Sepehrnoori describe multiphase Rachford–Rice solution-domain handling: https://doi.org/10.2118/117752-PA. Those sources are the public method basis; this PR only removes allocation from NeqSim's equivalent vector update. The performance measurements below are implementation evidence. No proprietary Aspen HYSYS, UniSim, Multiflash, or PVTsim algorithm is claimed or inferred.

## Before/after benchmark

Exact baseline: `c1bea04e28de91f7d53e775de706a81a827e856c`.

Direct converged two-phase PR/classic methane–n-heptane beta solve at 250 K and 30 bara:

- OpenJDK 17.0.19, SerialGC, fixed 256 MiB heap
- seven fresh-JVM alternating-order pairs
- 5,000 warmups + 100,000 measured solves per fork
- baseline median: **4.522 µs/solve**
- candidate median: **4.227 µs/solve**
- median improvement: **6.5%**
- candidate faster in **7/7** pairs
- thread allocation median: **3,649.6 → 2,895.0 byte/solve**, **20.7% lower**
- every fork returned the identical checksum `757887.3375872583`, two phases, `beta0 = 0.610668243716026`, and `beta1 = 0.389331756283974`

A full fresh-system TPflash benchmark was intentionally interpreted conservatively: median **3.573 → 3.488 ms/flash** (2.4%), but candidate direction was only 4/7 pairs and full-flash allocation was dominated by approximately 2.3 MB of system/EOS construction. No general end-to-end TPflash speedup is claimed.

## Numerical tolerances

The new direct-solver regression requires:

- Newton step residual: `<= 1e-10`
- beta, phase composition, Z, and recovered component feed parity: `1e-11` absolute
- per-phase composition closure: `1e-12`

The existing flash matrix retains its stricter and model-specific tolerances. No tolerance was relaxed.

## Validation

Completed on the exact final two-file tree:

- standard and multiphase flash selection: **69/69 passed**
  - `TPFlashTest`, `TPFlashTestWellFluid`, `TPFlashTestHighTemp`, `TPflash*Test`, `TPmultiflash*Test`
  - covers SRK/PR/CPA/UMR-PRU/GE paths, gas/oil/water and hydrocarbon-water cases, CO2/H2-rich and phase-boundary cases, one/two/three-phase behavior, repeat/warm-start, tiny/disappearing phases, balance, normalization, equilibrium residuals, phase selection, and ordinary/multiphase consistency
- adjacent EOS–GE, hybrid, CPA/electrolyte and reactive flash suites: **95 passed, 1 existing skip**
  - `SystemHybridEosGeFlashTest`, `SystemEosGEOperationsTest`, `SystemKentEisenbergTest`, `SystemElectrolyteCPATest`, `ReactiveFlashBenchmarkTest`
- Java 8 test compilation: passed with `-Dmaven.compiler.release=8 -Dmaven.compiler.useIncrementalCompilation=false -DskipTests test-compile`
- `python devtools/run_spotless.py apply`: passed; repeated apply produced no intended-file changes
- `python devtools/run_spotless.py check`: passed
- `python devtools/check_documentation_search.py`: passed for 646 Markdown pages and one standalone HTML page
- `pre-commit run --all-files --hook-stage pre-commit`: passed
- `pre-commit run --all-files --hook-stage pre-push`: passed
- `git diff --check`: passed
- final diff: two intended Java files; no generated, notebook, documentation, or sensitive files

The full repository suite was not run locally; hosted CI remains required before merge readiness.

## Compatibility and risk

Low. This is an allocation-only algebraic refactor inside an existing public method. Public APIs, serialization, EOS equations, mixing rules, fugacity calculations, initialization ordering, convergence criteria, phase selection, chemical-equilibrium handling, and returned numerical tolerances are unchanged. The fallback regularization path uses the same column-vector update.

## Documentation impact

Documentation impact: none — the change is internal allocation removal with no public API, input, output, unit, default, model, numerical method, recommended usage, or expected result change. The focused JUnit regression documents the retained numerical contract.