### PR TITLE
[AI-Assisted] Preserve parallel energy and signal diagram topology

### DIFF
--- a/docs/process/processmodel/diagram_export.md
+++ b/docs/process/processmodel/diagram_export.md
@@ -26,8 +26,13 @@ List<ProcessDiagramGraphAdapter.Diagnostic> diagnostics = topology.getDiagnostic
 The adapter creates one semantic plant graph with explicit area hierarchy, area-qualified equipment
 and line identities, ports or nozzles, and distinct material, energy, and signal connection segments.
 Shared live streams are represented as cross-area connections, and parallel material streams retain
-separate connection identities. The result owns a deterministic JSON snapshot and returns a defensive
-graph copy. Consumers should review structured diagnostics before treating an adaptation as complete.
+separate connection identities. Parallel energy and signal declarations are likewise retained when
+they use distinct source and target ports. Repeated declarations with the same connection type and
+the same port endpoints cannot be distinguished by the current `ProcessConnection` contract; the
+adapter retains one connection and emits `DIAGRAM_TOPOLOGY_DUPLICATE_CONNECTION_COLLAPSED` instead
+of silently losing the ambiguity. The result owns a deterministic JSON snapshot and returns a
+defensive graph copy. Consumers should review structured diagnostics before treating an adaptation
+as complete.
 
 The existing DOT and DEXPI exporters have not yet been migrated to consume this graph. Until that
 migration is complete, this adapter is a shared topology contract rather than a new rendering or

--- a/src/main/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapter.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapter.java
@@ -390,6 +390,9 @@ public final class ProcessDiagramGraphAdapter {
           source.areaName + "->" + target.areaName);
       String connectionId = EngineeringIds.nodeId(connectionKind, connectionExternalKey);
       if (graph.getNode(connectionId) != null) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "DIAGRAM_TOPOLOGY_DUPLICATE_CONNECTION_COLLAPSED",
+            "Multiple connection declarations resolved to the same type and port endpoints; one canonical connection was retained",
+            source.areaName, requestedConnectionExternalKey));
         return;
       }
       EngineeringNode connectionNode = new EngineeringNode(connectionId, connectionKind, connectionExternalKey,

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapterTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapterTest.java
@@ -79,6 +79,53 @@ class ProcessDiagramGraphAdapterTest {
   }
 
   @Test
+  void preservesParallelEnergyAndSignalConnectionsByExplicitPorts() {
+    Stream feed = createFeed("parallel explicit feed");
+    Heater source = new Heater("parallel explicit source", feed);
+    Heater target = new Heater("parallel explicit target", source.getOutletStream());
+    ProcessSystem process = new ProcessSystem("parallel explicit area");
+    process.add(feed);
+    process.add(source);
+    process.add(target);
+    process.connect(source.getName(), "duty-out-a", target.getName(), "duty-in-a",
+        ProcessConnection.ConnectionType.ENERGY);
+    process.connect(source.getName(), "duty-out-b", target.getName(), "duty-in-b",
+        ProcessConnection.ConnectionType.ENERGY);
+    process.connect(target.getName(), "temperature-signal-a", source.getName(), "temperature-setpoint-a",
+        ProcessConnection.ConnectionType.SIGNAL);
+    process.connect(target.getName(), "temperature-signal-b", source.getName(), "temperature-setpoint-b",
+        ProcessConnection.ConnectionType.SIGNAL);
+
+    EngineeringGraph graph = ProcessDiagramGraphAdapter.fromProcessSystem(process, "PLANT-PARALLEL-EXPLICIT", "A")
+        .getGraph();
+
+    assertEquals(2, countNodeKind(graph, EngineeringNode.Kind.ENERGY_CONNECTION));
+    assertEquals(2, countNodeKind(graph, EngineeringNode.Kind.SIGNAL_CONNECTION));
+    assertEquals(4, countEdgeKind(graph, EngineeringEdge.Kind.ENERGY_FLOW));
+    assertEquals(4, countEdgeKind(graph, EngineeringEdge.Kind.SIGNAL_FLOW));
+    assertTrue(EngineeringPackageValidator.validateGraph(graph).isValid());
+  }
+
+  @Test
+  void reportsAmbiguousDuplicateConnectionDeclarationsInsteadOfSilentlyLosingMultiplicity() {
+    Stream feed = createFeed("duplicate connection feed");
+    Heater heater = new Heater("duplicate connection heater", feed);
+    ProcessSystem process = new ProcessSystem("duplicate connection area");
+    process.add(feed);
+    process.add(heater);
+    process.connect(heater.getName(), "temperature-signal", feed.getName(), "temperature-setpoint",
+        ProcessConnection.ConnectionType.SIGNAL);
+    process.connect(heater.getName(), "temperature-signal", feed.getName(), "temperature-setpoint",
+        ProcessConnection.ConnectionType.SIGNAL);
+
+    ProcessDiagramGraphAdapter.Result result = ProcessDiagramGraphAdapter.fromProcessSystem(process,
+        "PLANT-DUPLICATE-CONNECTION", "A");
+
+    assertEquals(1, countNodeKind(result.getGraph(), EngineeringNode.Kind.SIGNAL_CONNECTION));
+    assertTrue(hasDiagnostic(result, "DIAGRAM_TOPOLOGY_DUPLICATE_CONNECTION_COLLAPSED"));
+  }
+
+  @Test
   void representsMultiAreaPlantAsOneGraphWithCrossAreaConnection() {
     Stream feed = createFeed("plant feed");
     Heater upstreamHeater = new Heater("upstream heater", feed);


### PR DESCRIPTION
## Summary

- prove that the canonical process-diagram adapter preserves parallel energy and signal connections when each declaration has explicit, distinct source and target ports
- add structured `DIAGRAM_TOPOLOGY_DUPLICATE_CONNECTION_COLLAPSED` diagnostics when repeated declarations resolve to the same type and port endpoints
- document the current connection-identity boundary without changing legacy DOT/Graphviz or DEXPI output

## Roadmap criterion advanced

Advances #1332 Phase 0: preserve distinct parallel material, energy, and signal connections. Material-stream multiplicity is already covered by merged #2901 and #2905; this increment adds the missing energy/signal evidence and makes unrepresentable duplicate ambiguity visible. The criterion remains in progress until this PR merges.

## Problem and root cause

`ProcessDiagramGraphAdapter` already generated stable port-qualified connection identities. Distinct-port energy and signal declarations were therefore preserved, but no regression locked that behavior. When two declarations used the same connection type and identical source/target ports, both resolved to the same canonical ID and the later declaration returned silently.

The current `ProcessConnection` contract has no independent connection identifier, so identical type-and-port declarations cannot be proven to represent separate physical connections. Silently collapsing them hid a possible topology loss.

## Implementation

- add parallel energy and signal regression coverage with two explicit port pairs of each type
- retain all four distinct connections and validate the resulting `EngineeringGraph`
- emit a structured warning when ambiguous identical declarations collapse to one representable canonical connection
- keep deterministic IDs, graph snapshots, explicit ports, provenance, and defensive copies unchanged

## Engineering boundary and compatibility

No public API changes are made. Existing DOT/Graphviz, DEXPI 2.0 Process, and Proteus/P&ID output are unchanged. The new diagnostic reports ambiguity; it does not infer a second connection or claim to qualify the model.

The tests use synthetic NeqSim streams at 298.15 K, 40 bara, and 1000 kg/hr only to create runnable process objects. Assertions concern semantic topology, not process performance. Generated topology remains calculated, review-required evidence and does not claim ISO 10628 conformance.

## Validation

- test-first regression failed because duplicate same-port declarations had no diagnostic
- `ProcessDiagramGraphAdapterTest`: 8 passed
- focused/proportionate regression set: 83 passed, 1 skipped across canonical topology, topology equivalence, parallel process graph, PFD DOT, legacy Graphviz, multi-area serialization, and DEXPI topology/writer tests
- `python devtools/run_spotless.py apply` repeated until stable
- `python devtools/run_spotless.py check` passed
- `python devtools/check_documentation_search.py` passed (646 Markdown pages, 1 standalone HTML page)
- pre-commit stage passed
- pre-push stage passed
- `git diff --check` passed

Maven used the existing task-specific cache configured for canonical `https://repo.maven.apache.org/maven2/`; a fresh empty cache encountered transient DNS resolution failure, while the populated canonical-cache run completed successfully.

## Documentation impact

Updated `docs/process/processmodel/diagram_export.md` to describe distinct-port parallel energy/signal preservation and the structured diagnostic for ambiguous duplicate declarations. No new page, migration note, or reference-manual index entry is required because the public API and output formats are unchanged.

## Limitations and next increment

The adapter cannot preserve two declarations that are identical in type and endpoints until the source contract provides a stable per-connection identity. It now reports that limitation rather than hiding it.

After merge, the next dependency-ready increment is to reuse the merged golden topology cases in DEXPI 2.0 Process semantic-equivalence tests while keeping the existing Proteus/P&ID workflow separate.

Relates to #1332.
Coordinates with #2899; no Proteus/P&ID workflow is changed.