### PR TITLE
[AI-Assisted] fix(pipeline): enable ProcessSystem transient snapshots

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -380,6 +380,44 @@ same report/history objects directly.
 that call. Legacy `setCompositionalTracking(true)` still selects type `20` for compatibility and
 must not be interpreted as the validated conservative path.
 
+### ProcessSystem event integration
+
+The conservative wrapper can be advanced by `ProcessSystem` so scheduled composition and mass-flow
+events share the process clock and calculation identifier:
+
+```java
+ProcessSystem process = new ProcessSystem("export gas transient");
+process.add(inletStream);
+process.add(pipeline);
+
+EventScheduler scheduler = new EventScheduler();
+process.setEventScheduler(scheduler);
+scheduler.scheduleEvent(60.0, "start pulse",
+    () -> inletStream.setThermoSystem(pulseGas.clone()));
+scheduler.scheduleEvent(120.0, "restore baseline",
+    () -> inletStream.setThermoSystem(baselineGas.clone()));
+
+process.run(UUID.randomUUID());
+process.runTransient(60.0, UUID.randomUUID());
+process.runTransient(60.0, UUID.randomUUID());
+```
+
+Before the first process-level transient step, `ProcessSystem` captures a deep snapshot for its
+copy/reset lifecycle. NeqSim's built-in one-phase pipe flow nodes, geometry surroundings, wall
+layers, interphase-transport strategies, and node selector are serializable so this snapshot
+cannot be bypassed by calling the pipeline directly. Custom geometry or transport implementations
+stored in the pipeline graph must also keep every non-transient field serializable; otherwise the
+snapshot fails before advancing time and reports the offending class.
+
+The regression uses SRK/classic methane/nitrogen gas in a 3 km, 0.5 m pipe with 12 nodes at
+70 bara absolute and 288.15 K. A 60 kg/s pulse followed by the 50 kg/s baseline in two 60 s process
+steps must contribute 3600 kg and 3000 kg at the authoritative finite-volume inlet boundary,
+respectively. Each step must retain the existing component-inventory, EOS synchronization,
+boundedness, process/pipe clock, event-count, and calculation-identifier gates. This establishes
+process-level event propagation for positive-flow, one-phase, solver-type-1 operation; it does not
+yet establish event replay after `ProcessSystem.reset()`, dynamic energy transport, phase
+appearance, or zero/reversed-flow support.
+
 `OnePhaseSpeciesConservationReport` exposes component names, physical-cell mass-fraction profiles,
 initial/final component inventories, integrated inlet/outlet component masses, absolute and
 relative inventory residuals, boundedness and sum-to-one diagnostics, thermodynamic

--- a/src/main/java/neqsim/fluidmechanics/flownode/FlowNodeSelector.java
+++ b/src/main/java/neqsim/fluidmechanics/flownode/FlowNodeSelector.java
@@ -9,7 +9,9 @@ import neqsim.fluidmechanics.flownode.twophasenode.twophasepipeflownode.Stratifi
  * @author asmund
  * @version $Id: $Id
  */
-public class FlowNodeSelector {
+public class FlowNodeSelector implements java.io.Serializable {
+  private static final long serialVersionUID = 1000L;
+
   /**
    * Constructor for FlowNodeSelector.
    */

--- a/src/main/java/neqsim/fluidmechanics/flownode/fluidboundary/interphasetransportcoefficient/InterphaseTransportCoefficientBaseClass.java
+++ b/src/main/java/neqsim/fluidmechanics/flownode/fluidboundary/interphasetransportcoefficient/InterphaseTransportCoefficientBaseClass.java
@@ -8,7 +8,10 @@ import neqsim.fluidmechanics.flownode.FlowNodeInterface;
  * @author esol
  * @version $Id: $Id
  */
-public class InterphaseTransportCoefficientBaseClass implements InterphaseTransportCoefficientInterface {
+public class InterphaseTransportCoefficientBaseClass
+    implements InterphaseTransportCoefficientInterface, java.io.Serializable {
+  private static final long serialVersionUID = 1000L;
+
   /**
    * Constructor for InterphaseTransportCoefficientBaseClass.
    */

--- a/src/main/java/neqsim/fluidmechanics/geometrydefinitions/internalgeometry/wall/MaterialLayer.java
+++ b/src/main/java/neqsim/fluidmechanics/geometrydefinitions/internalgeometry/wall/MaterialLayer.java
@@ -22,7 +22,8 @@ package neqsim.fluidmechanics.geometrydefinitions.internalgeometry.wall;
  * @author ESOL
  * @version $Id: $Id
  */
-public class MaterialLayer {
+public class MaterialLayer implements java.io.Serializable {
+  private static final long serialVersionUID = 1000L;
 
   /** Layer thickness in meters. */
   private double thickness = 0.01;

--- a/src/main/java/neqsim/fluidmechanics/geometrydefinitions/internalgeometry/wall/PipeWall.java
+++ b/src/main/java/neqsim/fluidmechanics/geometrydefinitions/internalgeometry/wall/PipeWall.java
@@ -35,6 +35,7 @@ import java.util.List;
  * @version $Id: $Id
  */
 public class PipeWall extends Wall {
+  private static final long serialVersionUID = 1000L;
 
   /** Inner radius of the pipe in meters. */
   private double innerRadius = 0.0;

--- a/src/main/java/neqsim/fluidmechanics/geometrydefinitions/internalgeometry/wall/Wall.java
+++ b/src/main/java/neqsim/fluidmechanics/geometrydefinitions/internalgeometry/wall/Wall.java
@@ -24,7 +24,8 @@ import java.util.List;
  * @version $Id: $Id
  * @see PipeWall
  */
-public class Wall implements WallInterface {
+public class Wall implements WallInterface, java.io.Serializable {
+  private static final long serialVersionUID = 1000L;
 
   /** List of material layers from inside to outside. */
   private ArrayList<MaterialLayer> wallMaterialLayers = new ArrayList<MaterialLayer>();

--- a/src/main/java/neqsim/fluidmechanics/geometrydefinitions/surrounding/PipeSurroundingEnvironment.java
+++ b/src/main/java/neqsim/fluidmechanics/geometrydefinitions/surrounding/PipeSurroundingEnvironment.java
@@ -32,6 +32,7 @@ import neqsim.fluidmechanics.geometrydefinitions.internalgeometry.wall.PipeMater
  * @version $Id: $Id
  */
 public class PipeSurroundingEnvironment extends SurroundingEnvironmentBaseClass {
+  private static final long serialVersionUID = 1000L;
 
   /**
    * Environment types for pipe surroundings.

--- a/src/main/java/neqsim/fluidmechanics/geometrydefinitions/surrounding/SurroundingEnvironmentBaseClass.java
+++ b/src/main/java/neqsim/fluidmechanics/geometrydefinitions/surrounding/SurroundingEnvironmentBaseClass.java
@@ -6,7 +6,9 @@ package neqsim.fluidmechanics.geometrydefinitions.surrounding;
  * @author ESOL
  * @version $Id: $Id
  */
-public class SurroundingEnvironmentBaseClass implements SurroundingEnvironment {
+public class SurroundingEnvironmentBaseClass implements SurroundingEnvironment, java.io.Serializable {
+  private static final long serialVersionUID = 1000L;
+
   private double heatTransferCoefficient = 20.0;
   private double temperature = 298.15;
 

--- a/src/main/java/neqsim/util/util/DoubleCloneable.java
+++ b/src/main/java/neqsim/util/util/DoubleCloneable.java
@@ -15,7 +15,9 @@ import org.apache.logging.log4j.Logger;
  * @author esol
  * @version $Id: $Id
  */
-public class DoubleCloneable implements Cloneable {
+public class DoubleCloneable implements Cloneable, java.io.Serializable {
+  private static final long serialVersionUID = 1000L;
+
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(DoubleCloneable.class);
   double doubleValue;

--- a/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
@@ -17,6 +17,7 @@ import neqsim.fluidmechanics.flowsolver.AdvectionScheme;
 import neqsim.fluidmechanics.flowsolver.SpeciesAdvectionScheme;
 import neqsim.fluidmechanics.flowsolver.onephaseflowsolver.onephasepipeflowsolver.OnePhaseSpeciesConservationReport;
 import neqsim.fluidmechanics.flowsystem.onephaseflowsystem.pipeflowsystem.OnePhaseSpeciesConservationHistory;
+import neqsim.process.dynamics.EventScheduler;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.mixingrule.EosMixingRulesInterface;
@@ -454,41 +455,62 @@ public class OnePhasePipeLineCompositionalTest {
   }
 
   @Test
-  @DisplayName("OnePhasePipeLine should work with ProcessSystem")
-  void testWithProcessSystem() {
-    Stream inlet = new Stream("inlet", naturalGas);
-    inlet.setFlowRate(1.0, "kg/sec");
+  @DisplayName("Conservative OnePhasePipeLine should follow ProcessSystem events and clock")
+  void testConservativePipelineWithProcessSystemEvents() {
+    SystemInterface baselineGas = createTransmissionGas(0.95, 0.05, 50.0);
+    SystemInterface pulseGas = createTransmissionGas(0.80, 0.20, 60.0);
+    Stream inlet = new Stream("scheduled inlet", baselineGas);
+    inlet.setFlowRate(50.0, "kg/sec");
+    inlet.run();
 
-    OnePhasePipeLine pipe = new OnePhasePipeLine("TestPipe", inlet);
-    pipe.setNumberOfLegs(1);
-    pipe.setNumberOfNodesInLeg(10);
-    pipe.setPipeDiameters(new double[] { 0.1, 0.1 });
-    pipe.setLegPositions(new double[] { 0.0, 100.0 });
-    pipe.setHeightProfile(new double[] { 0.0, 0.0 });
-    pipe.setPipeWallRoughness(new double[] { 1e-5, 1e-5 });
-    pipe.setOuterTemperatures(new double[] { 280.0, 280.0 });
-    pipe.setAdvectionScheme(AdvectionScheme.TVD_VAN_LEER);
-    pipe.setCompositionalTracking(true);
+    OnePhasePipeLine pipe = createTransmissionPipe(inlet);
+    pipe.setConservativeCompositionalTracking(true);
+    pipe.setStoreSpeciesConservationHistory(true);
+    pipe.setFailOnNonConvergence(true);
+    pipe.setInternalTimeStep(60.0);
 
-    ProcessSystem process = new ProcessSystem();
+    ProcessSystem process = new ProcessSystem("conservative pipeline process");
     process.add(inlet);
     process.add(pipe);
 
-    // Run initial steady state
-    process.run();
+    EventScheduler scheduler = new EventScheduler();
+    process.setEventScheduler(scheduler);
+    scheduler.scheduleEvent(60.0, "start composition and rate pulse", () -> inlet.setThermoSystem(pulseGas.clone()));
+    scheduler.scheduleEvent(120.0, "restore baseline composition and rate",
+        () -> inlet.setThermoSystem(baselineGas.clone()));
+
+    UUID initializationId = UUID.randomUUID();
+    process.run(initializationId);
 
     assertNotNull(pipe.getOutletStream());
     assertTrue(pipe.getOutletStream().getPressure() > 0);
+    assertEquals(0.0, process.getTime(), 0.0);
+    assertEquals(0.0, pipe.getSimulationTime(), 0.0);
 
-    // Run transient loop using direct pipe.runTransient (avoiding ProcessSystem serialization)
-    UUID id = UUID.randomUUID();
-    for (int i = 0; i < 3; i++) {
-      inlet.run(id); // Update inlet
-      pipe.runTransient(1.0, id); // Run pipe transient directly
-    }
+    UUID pulseStepId = UUID.randomUUID();
+    process.runTransient(60.0, pulseStepId);
+    OnePhaseSpeciesConservationReport pulseReport = pipe.getSpeciesConservationReport();
+    assertConservativeReport(pulseReport);
+    assertEquals(3600.0, sum(pulseReport.getInletBoundaryMassKg()), 1.0e-8);
+    assertEquals(60.0, process.getTime(), 0.0);
+    assertEquals(process.getTime(), pipe.getSimulationTime(), 0.0);
+    assertEquals(pulseStepId, process.getCalculationIdentifier());
+    assertEquals(pulseStepId, pipe.getCalculationIdentifier());
+    assertEquals(pulseStepId, pipe.getOutletStream().getCalculationIdentifier());
+    assertEquals(1, scheduler.getFiredEvents().size());
 
-    // Should have advanced time
-    assertTrue(pipe.getSimulationTime() > 0);
+    UUID recoveryStepId = UUID.randomUUID();
+    process.runTransient(60.0, recoveryStepId);
+    OnePhaseSpeciesConservationReport recoveryReport = pipe.getSpeciesConservationReport();
+    assertConservativeReport(recoveryReport);
+    assertEquals(3000.0, sum(recoveryReport.getInletBoundaryMassKg()), 1.0e-8);
+    assertEquals(120.0, process.getTime(), 0.0);
+    assertEquals(process.getTime(), pipe.getSimulationTime(), 0.0);
+    assertEquals(recoveryStepId, process.getCalculationIdentifier());
+    assertEquals(recoveryStepId, pipe.getCalculationIdentifier());
+    assertEquals(recoveryStepId, pipe.getOutletStream().getCalculationIdentifier());
+    assertEquals(2, scheduler.getFiredEvents().size());
+    assertEquals(0, scheduler.getPendingEvents().size());
   }
 
   @Test


### PR DESCRIPTION
## Engineering value

A conservative one-phase gas pipeline cannot currently be advanced through `ProcessSystem.runTransient(...)`. Before the first process-level timestep, `ProcessSystem` captures its reset snapshot by Java serialization; the initialized pipeline graph contains non-serializable geometry, wall, interphase-transport, node-selector, and mutable velocity state. The existing test explicitly avoided this path and called `pipe.runTransient(...)` directly.

This change makes the built-in pipeline state graph serializable and replaces that workaround with a real scheduled ProcessSystem composition/feed-rate regression. It does not change hydraulic, EOS, species, TVD, dispersion, or energy equations.

## Reproducible baseline

Base: `db5b98b3446c21b7a3daf4cd472a5303c02a88ac`.

Frozen case:

- SRK EOS, classic mixing rule
- methane/nitrogen baseline 95/5 mol-%, pulse 80/20 mol-%
- 288.15 K and 70 bara absolute
- one gas phase
- horizontal 3 km pipe, 0.5 m diameter, 12 configured nodes, roughness `1e-5 m`
- baseline/recovery 50 kg/s; pulse 60 kg/s
- two 60 s ProcessSystem steps
- composition/rate event at 60 s and restoration at 120 s
- conservative solver type 1, fail-on-non-convergence and accepted-step history enabled

On unmodified current master, the regression failed before the first transient step:

```text
RuntimeException: Failed to copy ProcessSystem
Caused by: NotSerializableException:
neqsim.fluidmechanics.geometrydefinitions.surrounding.SurroundingEnvironmentBaseClass
```

The prior test concealed the defect with the comment `avoiding ProcessSystem serialization`.

## Method

The concrete built-in classes retained by the pipeline snapshot now implement `Serializable` with explicit `serialVersionUID = 1000L`:

- surrounding-environment base and pipe specialization;
- wall base, pipe wall, and material layers;
- interphase-transport base strategy;
- flow-node selector;
- mutable double wrapper used by node velocities.

Public method signatures and strategy interfaces are unchanged. Custom injected implementations remain responsible for serializable non-transient state; an invalid graph still fails loudly before time advances.

The regression now:

1. initializes the conservative pipeline through `ProcessSystem`;
2. schedules simultaneous composition and rate changes through `EventScheduler`;
3. advances only through `ProcessSystem.runTransient(...)`;
4. checks snapshot success, event counts, clocks, calculation identifiers, boundedness, EOS/species synchronization, and finite-volume boundary inventory.

## Results and frozen criteria

Both steps converge without relaxing any existing tolerance:

- pulse inlet inventory: exactly `3600 kg` within `1e-8 kg`;
- recovery inlet inventory: exactly `3000 kg` within `1e-8 kg`;
- maximum relative component-inventory residual: existing limit `1e-8`;
- thermodynamic/conservative mass-fraction mismatch: existing limit `1e-10`;
- fractions remain in `[0,1]` and sum to one within `1e-12`;
- ProcessSystem and pipeline clocks are exactly 60 s and 120 s;
- ProcessSystem, pipeline, and outlet calculation identifiers equal each step identifier;
- both scheduled events fire once and no event remains pending.

The complete existing 30-minute pulse/recovery and timestep/determinism regressions remain green.

## Validation

Environment: NeqSim 3.17.0 source, OpenJDK 17.0.19, Maven 3.9.12, Python 3.12.13, pre-commit 4.6.1.

- focused ProcessSystem event regression — passed
- `./mvnw -Dtest=OnePhasePipeLineCompositionalTest test` — 13/13 passed
- `./mvnw -Dtest=OnePhasePipeLineCompositionalTest -Dgroups=slow -DexcludedTestGroups= test` — 2/2 slow pulse tests passed
- ProcessSystem reset/runTransient/serialization/event/parallel/controller plus wall and pipeline suite — 83/83 passed
- `./mvnw -Dtest=DocExamplesCompilationTest test` — 59/59 passed
- changed production and regression sources compiled with the JDK compiler API using `--release 8` — passed
- `python devtools/run_spotless.py apply` — passed; clean repeat
- `pre-commit run --all-files --hook-stage pre-commit` — passed
- `python devtools/run_spotless.py check` — passed
- `python devtools/check_documentation_search.py` — passed for 647 Markdown pages and one HTML page
- `pre-commit run --all-files --hook-stage pre-push` — passed
- `git diff --check` — passed
- connector comparison — one commit ahead, zero behind, ten intended files only

Local aggregate Javadoc generation could not download uncached Maven-plugin dependencies because both `repo1.maven.org` and the canonical `repo.maven.apache.org` endpoint returned temporary DNS failures. No public method signature or Javadoc was changed; hosted Javadoc CI remains mandatory before merge readiness.

## Documentation impact

Updated `docs/fluidmechanics/single_phase_pipe_flow.md` with executable ProcessSystem/EventScheduler usage, snapshot ownership, the frozen mass-flow/inventory case, custom-state serialization responsibility, and explicit limits.

No notebook changed, so notebook execution, rendering, visual inspection, and catalog gates are not applicable.

## Compatibility, risk, and limits

- public API signatures and numerical defaults: unchanged
- hydraulic, thermal, EOS, species, TVD, and physical-dispersion equations: unchanged
- conservative finite-volume inventories remain authoritative
- serialization adds no mutable state and does not change thread ownership
- ordinary direct pipeline execution remains compatible
- validated for positive-flow, one-phase, solver-type-1 operation
- dynamic energy, zero/reversed flow, phase appearance, and multiphase transport remain outside scope
- EventScheduler replay after `ProcessSystem.reset()` remains a separate Stage 6 gate
- no proprietary algorithm, dataset, or commercial-simulator parity claim

## Next dependency gate

After merge, freeze and validate scheduler/reset replay and repeated ProcessSystem execution semantics before ProcessModel/Python integration or notebook publication.
