### PR TITLE
perf(tpflash): reuse beta solver work matrices

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.dense.row.CommonOps_DDRM;
+import org.ejml.dense.row.MatrixFeatures_DDRM;
 import org.ejml.dense.row.NormOps_DDRM;
 import org.ejml.simple.SimpleMatrix;
 import neqsim.thermo.component.ComponentInterface;
@@ -226,7 +227,7 @@ public class TPmultiflash extends TPflash {
       boolean solved = false;
       Exception solveException = null;
       try {
-        solved = CommonOps_DDRM.solve(betaHessian, betaGradient, betaCorrection);
+        solved = solveBetaCorrection(betaHessian, betaGradient, betaCorrection);
       } catch (Exception ex) {
         solveException = ex;
       }
@@ -237,7 +238,7 @@ public class TPmultiflash extends TPflash {
           }
           copyBetaSolverInputs(betaGradient, betaHessian);
           try {
-            solved = CommonOps_DDRM.solve(betaHessian, betaGradient, betaCorrection);
+            solved = solveBetaCorrection(betaHessian, betaGradient, betaCorrection);
           } catch (Exception ex2) {
             solveException = ex2;
           }
@@ -279,6 +280,26 @@ public class TPmultiflash extends TPflash {
     } while (((err > 1e-12 || gradResidual > 1e-10) && iter < 50) || iter < 3);
     // logger.info("iterations " + iter);
     return err;
+  }
+
+  /**
+   * Solve one beta Newton system and reject non-finite corrections.
+   *
+   * <p>
+   * EJML's raw common-operations solve can report success for a singular matrix while writing NaN values to the
+   * correction vector. The former {@link SimpleMatrix#solve(SimpleMatrix)} path raised a singular-matrix exception in
+   * that case, allowing enhanced mode to regularize the Hessian and ordinary mode to stop without corrupting phase
+   * fractions.
+   * </p>
+   *
+   * @param betaHessian beta-Hessian matrix
+   * @param betaGradient beta-gradient column vector
+   * @param betaCorrection destination for the Newton correction
+   * @return true only when EJML reports success and every correction entry is finite
+   */
+  static boolean solveBetaCorrection(DMatrixRMaj betaHessian, DMatrixRMaj betaGradient, DMatrixRMaj betaCorrection) {
+    return CommonOps_DDRM.solve(betaHessian, betaGradient, betaCorrection)
+        && !MatrixFeatures_DDRM.hasUncountable(betaCorrection);
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.dense.row.CommonOps_DDRM;
+import org.ejml.dense.row.NormOps_DDRM;
 import org.ejml.simple.SimpleMatrix;
 import neqsim.thermo.component.ComponentInterface;
 import neqsim.thermo.phase.PhaseType;
@@ -210,32 +211,39 @@ public class TPmultiflash extends TPflash {
    * @return a double
    */
   public double solveBeta() {
-    SimpleMatrix ans = null;
+    int numberOfPhases = system.getNumberOfPhases();
+    DMatrixRMaj betaGradient = new DMatrixRMaj(numberOfPhases, 1);
+    DMatrixRMaj betaHessian = new DMatrixRMaj(numberOfPhases, numberOfPhases);
+    DMatrixRMaj betaCorrection = new DMatrixRMaj(numberOfPhases, 1);
     double err = 1.0;
     double gradResidual = 1.0;
     int iter = 1;
     do {
       iter++;
       calcQ();
-      SimpleMatrix dQM = new SimpleMatrix(dQdbeta);
-      gradResidual = dQM.normF();
-      SimpleMatrix dQdBM = new SimpleMatrix(Qmatrix);
+      copyBetaSolverInputs(betaGradient, betaHessian);
+      gradResidual = NormOps_DDRM.normF(betaGradient);
+      boolean solved = false;
+      Exception solveException = null;
       try {
-        ans = dQdBM.solve(dQM);
+        solved = CommonOps_DDRM.solve(betaHessian, betaGradient, betaCorrection);
       } catch (Exception ex) {
+        solveException = ex;
+      }
+      if (!solved) {
         if (shouldApplyEnhancedMultiPhaseCheck()) {
           for (int kk = 0; kk < system.getNumberOfPhases(); kk++) {
             Qmatrix[kk][kk] += 1.0e-2;
           }
-          dQdBM = new SimpleMatrix(Qmatrix);
+          copyBetaSolverInputs(betaGradient, betaHessian);
           try {
-            ans = dQdBM.solve(dQM);
+            solved = CommonOps_DDRM.solve(betaHessian, betaGradient, betaCorrection);
           } catch (Exception ex2) {
-            logger.error(ex2.getMessage());
-            break;
+            solveException = ex2;
           }
-        } else {
-          logger.error(ex.getMessage());
+        }
+        if (!solved) {
+          logger.error(solveException == null ? "Beta Hessian solve failed" : solveException.getMessage());
           break;
         }
       }
@@ -245,7 +253,7 @@ public class TPmultiflash extends TPflash {
       double betaStepScale = iter / (iter + 3.0);
       removePhase = false;
       for (int k = 0; k < system.getNumberOfPhases(); k++) {
-        double currBeta = system.getPhase(k).getBeta() - ans.get(k, 0) * betaStepScale;
+        double currBeta = system.getPhase(k).getBeta() - betaCorrection.get(k, 0) * betaStepScale;
         if (currBeta < phaseFractionMinimumLimit) {
           system.setBeta(k, phaseFractionMinimumLimit);
           if (checkOneRemove) {
@@ -267,10 +275,27 @@ public class TPmultiflash extends TPflash {
       calcE();
       setXY();
       system.init(1);
-      err = ans.normF();
+      err = NormOps_DDRM.normF(betaCorrection);
     } while (((err > 1e-12 || gradResidual > 1e-10) && iter < 50) || iter < 3);
     // logger.info("iterations " + iter);
     return err;
+  }
+
+  /**
+   * Copy the current beta gradient and Hessian into reusable EJML work matrices. Every attempt is refreshed so a
+   * regularized retry uses the updated Hessian without allocating new wrappers.
+   *
+   * @param betaGradient reusable beta-gradient column vector
+   * @param betaHessian reusable beta-Hessian matrix
+   */
+  private void copyBetaSolverInputs(DMatrixRMaj betaGradient, DMatrixRMaj betaHessian) {
+    int numberOfPhases = system.getNumberOfPhases();
+    for (int row = 0; row < numberOfPhases; row++) {
+      betaGradient.set(row, 0, dQdbeta[row][0]);
+      for (int column = 0; column < numberOfPhases; column++) {
+        betaHessian.set(row, column, Qmatrix[row][column]);
+      }
+    }
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Field;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.ejml.data.DMatrixRMaj;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.mixingrule.EosMixingRulesInterface;
@@ -247,6 +248,22 @@ class TPmultiflashTest {
 
     assertFalse(stalledField.getBoolean(operation),
         "A run without a beta solve must clear stall state retained by a reused operation");
+  }
+
+  /** A raw EJML solve must not accept a non-finite correction from a singular beta Hessian. */
+  @Test
+  void testBetaCorrectionRejectsSingularSolveReportedAsSuccessful() {
+    DMatrixRMaj singularHessian = new DMatrixRMaj(new double[][] { { 1.0, 1.0 }, { 1.0, 1.0 } });
+    DMatrixRMaj gradient = new DMatrixRMaj(new double[][] { { 1.0 }, { 1.0 } });
+    DMatrixRMaj correction = new DMatrixRMaj(2, 1);
+
+    assertFalse(TPmultiflash.solveBetaCorrection(singularHessian, gradient, correction));
+
+    singularHessian.set(0, 0, singularHessian.get(0, 0) + 1.0e-2);
+    singularHessian.set(1, 1, singularHessian.get(1, 1) + 1.0e-2);
+    assertTrue(TPmultiflash.solveBetaCorrection(singularHessian, gradient, correction));
+    assertTrue(Double.isFinite(correction.get(0, 0)));
+    assertTrue(Double.isFinite(correction.get(1, 0)));
   }
 
   /** Verifies a direct beta solve preserves a converged two-phase equilibrium and material balance. */

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
@@ -297,4 +297,45 @@ class TPmultiflashTest {
     }
   }
 
+  /** Verifies reused beta-solver work matrices converge repeatedly from poor phase fractions. */
+  @Test
+  void testReusedBetaSolverMatricesConvergeFromPoorPhaseFractions() {
+    SystemInterface system = createMethaneHeptanePrSystem(0.0, false);
+    system.setTemperature(250.0, "K");
+    system.setPressure(30.0, "bara");
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+
+    assertEquals(2, system.getNumberOfPhases());
+    double[] referenceBeta = new double[] { system.getBeta(0), system.getBeta(1) };
+    double[][] referenceComposition = new double[2][system.getPhase(0).getNumberOfComponents()];
+    for (int phase = 0; phase < 2; phase++) {
+      for (int component = 0; component < referenceComposition[phase].length; component++) {
+        referenceComposition[phase][component] = system.getPhase(phase).getComponent(component).getx();
+      }
+    }
+
+    system.setBeta(0, 0.9);
+    system.setBeta(1, 0.1);
+    system.init(1);
+    TPmultiflash operation = new TPmultiflash(system, false);
+    operation.setDoubleArrays();
+
+    for (int execution = 0; execution < 2; execution++) {
+      double residual = operation.solveBeta();
+      assertTrue(Double.isFinite(residual));
+      assertTrue(residual <= 1.0e-10);
+      for (int phase = 0; phase < 2; phase++) {
+        assertEquals(referenceBeta[phase], system.getBeta(phase), 1.0e-10);
+        double compositionSum = 0.0;
+        for (int component = 0; component < referenceComposition[phase].length; component++) {
+          assertEquals(referenceComposition[phase][component], system.getPhase(phase).getComponent(component).getx(),
+              1.0e-10);
+          compositionSum += system.getPhase(phase).getComponent(component).getx();
+        }
+        assertEquals(1.0, compositionSum, 1.0e-12);
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
## Summary

Reuse raw EJML work matrices inside `TPmultiflash.solveBeta()` instead of constructing `SimpleMatrix` gradient/Hessian wrappers and a fresh solution matrix on every Newton iteration.

This is a focused follow-up to #2914 and the allocation hypothesis recorded in #2698. It does not change phase-stability logic, fugacity calculations, beta damping, clipping, normalization, phase appearance/disappearance handling, or either required `system.init(1)` pass.

Relates to #2698.

## Reproduced problem

After #2914 removed transpose/scale/subtraction temporaries, every beta iteration still performed:

```java
SimpleMatrix dQM = new SimpleMatrix(dQdbeta);
SimpleMatrix dQdBM = new SimpleMatrix(Qmatrix);
ans = dQdBM.solve(dQM);
```

A deterministic converged two-phase methane/n-heptane PR flash showed 2,056.145 bytes allocated per `solveBeta()` call at the median. The solver executes twice even at the converged endpoint, so these short-lived wrappers/results remain a measurable hot-path cost.

## Root cause and method

The gradient, Hessian, and correction dimensions are fixed for the duration of one `solveBeta()` call. This change allocates three `DMatrixRMaj` work objects once per call, refreshes their values on every iteration (and before a regularized retry), and solves

```text
H_beta * delta_beta = gradient_beta
beta_next = beta - [iter / (iter + 3)] * delta_beta
```

through `CommonOps_DDRM.solve`. `NormOps_DDRM.normF` preserves the existing gradient and correction residual definitions. A false solve result and thrown exception both retain the existing enhanced-mode regularization/failure path.

EJML documents `CommonOps_DDRM.solve(A, b, x)` as solving `A*x=b`, returning false when it cannot solve, leaving `A` and `b` unmodified, and writing `x`: https://ejml.org/javadoc/org/ejml/dense/row/CommonOps_DDRM.html#solve(org.ejml.data.DMatrixRMaj,org.ejml.data.DMatrixRMaj,org.ejml.data.DMatrixRMaj)

## Literature and engineering basis

The thermodynamic algorithm is unchanged. The implementation remains a damped Newton phase-split update within the phase-stability/phase-split framework described by:

- Michelsen, *The isothermal flash problem. Part II. Phase-split calculation*, Fluid Phase Equilibria 9 (1982), 21–40: https://doi.org/10.1016/0378-3812%2882%2985002-4
- Okuno, Johns and Sepehrnoori, *A New Algorithm for Rachford-Rice for Multiphase Compositional Simulation*, SPE Journal 15 (2010), 313–325: https://doi.org/10.2118/117752-PA

Those papers support stability-led multiphase split calculations and safeguarded Newton work; they do not provide evidence for this Java allocation optimization. No claim is made about undocumented commercial-simulator internals.

## Before/after benchmark

Exact baseline: current `master` `db5b98b3446c21b7a3daf4cd472a5303c02a88ac`.
Candidate: `5c5309b8d95b20397f56e2143bfae81c8de429b5`.

OpenJDK 17.0.19, SerialGC, fixed 256 MiB heap, seven alternating-order fresh JVM pairs, 5,000 warmups plus 100,000 measured calls per variant. Workload: converged PR/classic methane/n-heptane equilibrium at 250 K and 30 bara.

| Metric | Baseline | Candidate | Result |
|---|---:|---:|---:|
| Median wall time | 3.809 µs/solve | 3.639 µs/solve | 4.5% faster |
| Median allocation | 2,056.145 B/solve | 1,418.188 B/solve | 31.0% lower |
| Newton iterations | 2.000/solve | 2.000/solve | unchanged |
| Measured failures | 0 / 700,000 | 0 / 700,000 | unchanged |
| Faster paired forks | — | 5 / 7 | directionally consistent |

All 14 runs produced the exact checksum `757887.337587258300000`, two phases, and betas `0.610668243716026 / 0.389331756283974`. The benchmark supports the allocation reduction and a modest solver-local speedup; it does not claim an end-to-end process-simulation speedup.

## Numerical regression and tolerances

The new regression starts the converged two-phase case from deliberately poor betas `0.9 / 0.1`, reuses the same operation for two solves, and requires:

- finite returned residual and residual <= `1e-10`;
- phase fractions and phase compositions within `1e-10` of the TPflash reference;
- each phase composition sum within `1e-12` of unity.

The existing focused matrix also checks standard versus multiphase paths, material closure, phase topology and disappearance, tiny aqueous phases, repeated/changed states, poor cubic-root guesses, terminal fugacity refinement, near-critical/phase-boundary cases, and one-, two-, and three-phase behavior across SRK, PR, SRK-CPA, UMR-PRU and relevant mixing rules. Adjacent validation covers EOS-GE/hybrid, Kent-Eisenberg, electrolyte CPA, and reactive hydrogen/CO2 systems.

## Validation

Passed on the exact final formatted checkout:

- `MAVEN_USER_HOME=/tmp/neqsim-perf-home/.m2 ./mvnw -o -q -Dmaven.repo.local=/tmp/neqsim-pfd-maven/repository -Dtest='neqsim.thermodynamicoperations.flashops.TPFlashTest,neqsim.thermodynamicoperations.flashops.TPFlashTestWellFluid,neqsim.thermodynamicoperations.flashops.TPFlashTestHighTemp,neqsim.thermodynamicoperations.flashops.TPflash*Test,neqsim.thermodynamicoperations.flashops.TPmultiflash*Test' test` — exit 0; 70 passed, 0 skipped.
- Adjacent EOS/GE/electrolyte/reactive selection — exit 0; 95 passed, one existing skip.
- `python devtools/run_spotless.py apply` with the task-local canonical Maven cache — exit 0, rerun exit 0 with unchanged file hashes.
- `python devtools/run_spotless.py check` — exit 0.
- `python devtools/check_documentation_search.py` — exit 0; 647 Markdown pages and one standalone HTML page.
- `pre-commit run --all-files --hook-stage pre-commit` — passed.
- `pre-commit run --all-files --hook-stage pre-push` — passed.
- Connector compare: exactly two intended Java files, two commits ahead and zero behind `master`.

The full repository test suite was not run locally; hosted CI remains authoritative for the proportionate broader matrix. No notebooks changed.

## Compatibility and risk

Low compatibility risk: no public API, serialization field, input, output, tolerance, thermodynamic model, phase-selection rule, or default changes. The same EJML dependency and general dense solve are used. The main numerical risk is a difference between the wrapper and raw solve paths; exact benchmark outputs, the poor-beta regression, 70 focused tests, and 95 adjacent passes found none.

## Documentation impact

Documentation impact: none. This is an internal allocation/layout change with no user-visible behavior or API change. The new private helper has Javadoc; external numerical-method guidance and release usage remain unchanged.
