### PR TITLE
[AI-Assisted] Stop converged Naphtali K-value sweeps early

### DIFF
--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -259,13 +259,14 @@ targets manipulated through condenser or reboiler temperature.
 - Work diagnostics classify every currently assembled derivative column as finite-difference;
   `getLastNaphtaliAnalyticJacobianColumns()` remains available for compatibility and reports zero
   until a mixed analytic/numerical assembly is implemented.
-- Tray thermodynamics retain the established two forced-root fugacity sweeps. Diagnostics now
-  report their total count, the number of tray evaluations whose final
+- Tray thermodynamics perform up to two forced-root fugacity sweeps and stop after the first when
+  its `max(abs(log(Knew/Kold)))` is already at or below `1e-8`. Diagnostics report the actual sweep
+  count, the number of tray evaluations whose final
   `max(abs(log(Knew/Kold)))` exceeds `1e-8`, and the largest such final update through
   `getLastNaphtaliThermoKValueIterationCount()`,
   `getLastNaphtaliThermoKValueNonConvergedCount()`, and
   `getLastNaphtaliThermoMaxLogKValueUpdate()`. These metrics expose incomplete inner convergence;
-  they do not loosen the MESH acceptance criteria or silently add extra EOS work.
+  they do not loosen the MESH acceptance criteria or add extra EOS work.
 - Allows at most three line-search steps that fail to reduce the MESH residual. After three such
   non-descent steps, the solver restores the best finite tray state and returns the actual iteration
   count so the column can proceed to its coordinated fallback instead of exhausting the Newton

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -38,7 +38,7 @@ public class NaphtaliSandholmSolver {
   /** Maximum number of non-descent line-search steps allowed before restoring the best state. */
   private static final int MAX_NON_DESCENT_LINE_SEARCH_STEPS = 3;
 
-  /** Forced-root fugacity fixed-point sweeps performed for one tray evaluation. */
+  /** Maximum forced-root fugacity fixed-point sweeps for one tray evaluation. */
   private static final int THERMO_K_VALUE_ITERATIONS = 2;
 
   /** Convergence tolerance for the largest absolute logarithmic K-value update. */
@@ -3333,8 +3333,8 @@ public class NaphtaliSandholmSolver {
     }
 
     // Self-consistency loop: K = phi_L(x) / phi_V(y), then y = K x / sum(K x).
-    // Preserve the established two-sweep behavior, but measure the remaining
-    // scale-invariant logarithmic K-value update instead of assuming convergence.
+    // Perform at most two sweeps and stop once the existing convergence criterion
+    // is met so already-converged compositions do not pay for a redundant EOS call.
     boolean kOk = phiOk;
     boolean kConverged = false;
     double finalMaxLogKUpdate = Double.POSITIVE_INFINITY;
@@ -3365,6 +3365,7 @@ public class NaphtaliSandholmSolver {
         }
         if (finalMaxLogKUpdate <= THERMO_K_VALUE_TOLERANCE) {
           kConverged = true;
+          break;
         } else {
           kConverged = false;
         }

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
@@ -511,7 +511,7 @@ public class ColumnSpecificationTest {
   }
 
   /**
-   * Test that Naphtali-Sandholm classifies its numerical Jacobian work accurately.
+   * Test that Naphtali-Sandholm classifies its numerical Jacobian and converged K-value work accurately.
    */
   @Test
   public void naphtaliSandholmTelemetryRecordsJacobianWork() {
@@ -528,8 +528,12 @@ public class ColumnSpecificationTest {
     assertEquals(800, column.getLastNaphtaliFiniteDifferenceJacobianColumns(),
         "eight stages times five variables times twenty Jacobian builds must all be finite-difference columns");
     assertTrue(column.getLastNaphtaliThermoEvaluationCount() > 0);
-    assertEquals(2 * column.getLastNaphtaliThermoEvaluationCount(), column.getLastNaphtaliThermoKValueIterationCount(),
-        "the current evaluator performs two forced-root fugacity sweeps per tray evaluation");
+    assertTrue(column.getLastNaphtaliThermoKValueIterationCount() >= column.getLastNaphtaliThermoEvaluationCount(),
+        "each successful tray evaluation must perform at least one forced-root fugacity sweep");
+    assertTrue(column.getLastNaphtaliThermoKValueIterationCount() < 2 * column.getLastNaphtaliThermoEvaluationCount(),
+        () -> "already-converged tray evaluations should avoid a redundant second sweep: evaluations="
+            + column.getLastNaphtaliThermoEvaluationCount() + ", K-value iterations="
+            + column.getLastNaphtaliThermoKValueIterationCount());
     assertTrue(column.getLastNaphtaliThermoKValueNonConvergedCount() > 0,
         "this difficult case must expose two-sweep evaluations that remain above the log-K tolerance");
     assertTrue(column.getLastNaphtaliThermoKValueNonConvergedCount() <= column.getLastNaphtaliThermoEvaluationCount());
@@ -550,7 +554,7 @@ public class ColumnSpecificationTest {
   }
 
   /**
-   * Test that K-value work diagnostics and physical products repeat at a nearby feed temperature.
+   * Test that adaptive K-value work diagnostics and physical products repeat at a nearby feed temperature.
    */
   @Test
   public void naphtaliKValueTelemetryIsRepeatableAtNearbyOperatingPoint() {
@@ -573,6 +577,9 @@ public class ColumnSpecificationTest {
     assertEquals(first.getLastNaphtaliThermoMaxLogKValueUpdate(), second.getLastNaphtaliThermoMaxLogKValueUpdate());
     assertEquals(first.getLastMeshResidualNorm(), second.getLastMeshResidualNorm());
     assertEquals(first.getLastEnergyResidual(), second.getLastEnergyResidual());
+    assertTrue(first.getLastNaphtaliThermoKValueIterationCount() >= first.getLastNaphtaliThermoEvaluationCount());
+    assertTrue(first.getLastNaphtaliThermoKValueIterationCount() < 2 * first.getLastNaphtaliThermoEvaluationCount(),
+        "the nearby operating point should also avoid already-converged second fugacity sweeps");
 
     double firstGas = first.getGasOutStream().getFlowRate("kg/hr");
     double firstLiquid = first.getLiquidOutStream().getFlowRate("kg/hr");


### PR DESCRIPTION
## Problem

`NaphtaliSandholmSolver.evaluateThermoForTray` always executed both forced-root vapor fugacity sweeps, even when the first sweep had already satisfied the existing `max(abs(log(Knew/Kold))) <= 1e-8` criterion. The loop updated `kConverged` but did not act on it until after the fixed two-sweep loop. This spent an avoidable EOS evaluation on already-converged tray compositions in every Newton/Jacobian path.

Affected scope: Naphtali-Sandholm tray thermodynamics and its coordinated fallback cost. Other column solvers and acceptance gates are unchanged.

## Change

Stop the K-value loop immediately after a successful sweep meets the existing `1e-8` criterion. The cap remains two sweeps, failed fugacity evaluations retain the Wilson fallback, and evaluations above tolerance still perform the second sweep.

The telemetry regression now requires:
- at least one forced-root sweep for every successful tray evaluation;
- fewer than two sweeps per evaluation for the representative and nearby cases;
- deterministic work, products, MESH diagnostics, and energy residuals across repeated nearby runs.

## Before/after evidence

Deterministic 8-stage propane / n-butane / n-pentane fractionator, 10 bar, total condenser and reboiler, 250 kg/h feed:

| Feed temperature | Metric | master | change |
| --- | --- | ---: | ---: |
| 318.15 K | tray thermo evaluations | 16,184 | 16,240 |
| 318.15 K | forced-root K sweeps | 32,368 | 31,052 (**-4.1%**) |
| 318.15 K | outer iterations | 136 | 136 |
| 318.15 K | energy residual | 0.0026114531000510466 | 0.0026114531000510466 |
| 320.15 K | tray thermo evaluations | 16,200 | 16,216 |
| 320.15 K | forced-root K sweeps | 32,400 | 30,850 (**-4.8%**) |
| 320.15 K | outer iterations | 136 | 136 |
| 320.15 K | energy residual | 0.0022209638418586950 | 0.0022209638418586950 |

The base telemetry/fallback-path product remains 237.6597295390127 kg/h gas plus 12.34027046098738 kg/h liquid (250 kg/h total). The nearby point is exactly repeatable across two independent columns. The small increase in tray evaluations is included above; net forced-root EOS work still falls by 1,316 and 1,550 sweeps respectively. No wall-clock assertion was added.

A separate 24-component hydrocarbon column-study regression converges and validates tray temperature/pressure profiles, total and component mass closure, physical product compositions, repeated warm runs, and the nearby increased-feed operating point.

## Validation

- `python devtools/run_spotless.py apply` — exit 0; rerun produced no file changes
- `python devtools/run_spotless.py check` — exit 0
- `python devtools/check_documentation_search.py` — exit 0; 647 Markdown pages and 1 HTML page audited
- focused baseline regression on master — failed as intended with 16,184 evaluations and 32,368 sweeps
- focused changed regression and nearby repeatability regression — pass
- `./mvnw -q -DexcludedTestGroups= -Dtest=neqsim.process.equipment.distillation.ColumnSpecificationTest,neqsim.process.equipment.distillation.ColumnStudyRegressionTest test` — 38 tests, 0 failures/errors, 1 pre-existing skip
- `./mvnw -q -DexcludedTestGroups= -Dtest='neqsim.process.equipment.distillation.*Test' test` — 27 suites, 218 tests, 0 failures/errors, 2 pre-existing skips

The pre-commit hook runner was not invoked because this connector-only workflow intentionally has no local Git checkout, honoring the requirement not to use local Git. The direct Spotless and documentation gates that the hooks enforce were run explicitly and passed.

## Compatibility and risk

- no public API or serialization change;
- no tolerance, MESH equation, line-search, acceptance, or fallback change;
- results can differ only by omitting a second fixed-point update after the first update is already within `1e-8`;
- actual K-sweep telemetry now reflects one or two sweeps rather than always exactly two.

## Documentation impact

Updated `docs/wiki/distillation_column.md` to describe the tolerance-driven early exit and actual sweep-count semantics.

## Remaining limitations

Difficult tray evaluations above the tolerance still stop at the existing two-sweep cap. This change removes proven redundant work; it does not attempt acceleration or claim to resolve the remaining inner K-value convergence debt.


## Current-master refresh

On 2026-08-10 the branch was rebuilt from current `master` `704a13cb388791a3c07b8e1d05acbb3ae28c8763`. This includes merged TPmultiflash matrix reuse #2918 and documentation PRs #2920/#2921. The merged TPmultiflash source and regression blobs were synchronized locally before rerunning the 38 focused/specification plus 24-component column-study tests; all passed. The three candidate blob SHAs remain unchanged. Spotless apply/reapply/check and the documentation-search audit all exited 0. Hosted CI on the refreshed head provides complete final-tree validation.