### PR TITLE
perf(process): reuse area plan in convergence diagnostics

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -1842,7 +1842,8 @@ public class ProcessModel implements Runnable, Serializable {
         // Capture current stream states and calculate errors
         Map<Object, double[]> currentBoundaryStreamStates = captureBoundaryStreamStates(boundaryStreams);
         boolean autoTuningChanged = applyAutoConvergenceTuning();
-        double[] errors = calculateConvergenceErrors(previousBoundaryStreamStates, currentBoundaryStreamStates);
+        double[] errors = calculateConvergenceErrors(previousBoundaryStreamStates, currentBoundaryStreamStates,
+            areaPlan);
         java.util.Set<Object> changedBoundaryStreams = findChangedBoundaryStreams(previousBoundaryStreamStates,
             currentBoundaryStreamStates);
         lastMaxFlowError = errors[0];
@@ -2790,6 +2791,19 @@ public class ProcessModel implements Runnable, Serializable {
    * @return array of [maxFlowError, maxTempError, maxPressError]
    */
   double[] calculateConvergenceErrors(Map<?, double[]> previous, Map<?, double[]> current) {
+    return calculateConvergenceErrors(previous, current, getAreaExecutionPlan());
+  }
+
+  /**
+   * Calculates convergence errors using an already resolved area execution plan.
+   *
+   * @param previous previous stream states
+   * @param current current stream states
+   * @param areaPlan area execution plan for the current model topology
+   * @return array of [maxFlowError, maxTempError, maxPressError]
+   */
+  private double[] calculateConvergenceErrors(Map<?, double[]> previous, Map<?, double[]> current,
+      AreaExecutionPlan areaPlan) {
     double maxFlowErr = 0.0;
     double maxTempErr = 0.0;
     double maxPressErr = 0.0;
@@ -2830,8 +2844,8 @@ public class ProcessModel implements Runnable, Serializable {
         double pressErr = Math.abs(curr[2] - prev[2]) / pressBase;
         maxPressErr = Math.max(maxPressErr, pressErr);
 
-        streamErrors.add(new BoundaryStreamError(getStreamName(key), getStreamProducerLabel(key), flowErr, tempErr,
-            pressErr, prev[0], curr[0]));
+        streamErrors.add(new BoundaryStreamError(getStreamName(key), getStreamProducerLabel(key, areaPlan), flowErr,
+            tempErr, pressErr, prev[0], curr[0]));
       }
     }
 
@@ -2859,14 +2873,15 @@ public class ProcessModel implements Runnable, Serializable {
    * Resolve the producing {@code "area::unit"} label for a boundary stream object.
    *
    * @param streamObject boundary stream object
+   * @param areaPlan area execution plan containing producer labels
    * @return the producer label, or an empty string when the producer cannot be resolved
    */
-  private String getStreamProducerLabel(Object streamObject) {
-    if (streamObject == null || processes.isEmpty()) {
+  private String getStreamProducerLabel(Object streamObject, AreaExecutionPlan areaPlan) {
+    if (streamObject == null || areaPlan == null || processes.isEmpty()) {
       return "";
     }
     try {
-      String label = getAreaExecutionPlan().streamProducers.get(streamObject);
+      String label = areaPlan.streamProducers.get(streamObject);
       return label == null ? "" : label;
     } catch (Exception e) {
       return "";

--- a/src/test/java/neqsim/process/processmodel/ProcessModelConvergenceFilterTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessModelConvergenceFilterTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
@@ -25,6 +26,37 @@ import neqsim.process.equipment.stream.StreamInterface;
  * @version $Id: $Id
  */
 public class ProcessModelConvergenceFilterTest extends neqsim.NeqSimTest {
+
+  /** ProcessSystem that counts topology-version reads. */
+  private static final class CountingStructureProcessSystem extends ProcessSystem {
+    /** Serialization version UID. */
+    private static final long serialVersionUID = 1L;
+
+    /** Number of topology-version reads. */
+    private final AtomicInteger structureVersionReads = new AtomicInteger();
+
+    /** Creates a counting process area. */
+    CountingStructureProcessSystem(String name) {
+      super(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long getStructureVersion() {
+      structureVersionReads.incrementAndGet();
+      return super.getStructureVersion();
+    }
+
+    /** Resets the topology-version read count. */
+    void resetStructureVersionReads() {
+      structureVersionReads.set(0);
+    }
+
+    /** Returns the topology-version read count. */
+    int getStructureVersionReads() {
+      return structureVersionReads.get();
+    }
+  }
 
   /** Flow of the real export stream on the previous outer iteration, kg/hr. */
   private static final double BIG_PREVIOUS_FLOW = 137709.1;
@@ -75,6 +107,31 @@ public class ProcessModelConvergenceFilterTest extends neqsim.NeqSimTest {
     // The stagnant 0.1 kg/hr leg (6.56 %) dominates the real 0.32 % residual.
     assertEquals(0.0656, errors[0], 1e-6);
     assertEquals(2, model.getLastBoundaryStreamErrors().size());
+  }
+
+  @Test
+  public void convergenceDiagnosticsResolveAreaPlanOncePerBatch() {
+    ProcessModel model = new ProcessModel();
+    CountingStructureProcessSystem first = new CountingStructureProcessSystem("first");
+    CountingStructureProcessSystem second = new CountingStructureProcessSystem("second");
+    model.add("first", first);
+    model.add("second", second);
+    first.resetStructureVersionReads();
+    second.resetStructureVersionReads();
+
+    Map<StreamInterface, double[]> previous = new LinkedHashMap<StreamInterface, double[]>();
+    Map<StreamInterface, double[]> current = new LinkedHashMap<StreamInterface, double[]>();
+    for (int streamIndex = 0; streamIndex < 3; streamIndex++) {
+      StreamInterface stream = new Stream("boundary " + streamIndex);
+      previous.put(stream, new double[] { 1000.0 + streamIndex, 300.0, 60.0 });
+      current.put(stream, new double[] { 1000.1 + streamIndex, 300.1, 60.1 });
+    }
+
+    model.calculateConvergenceErrors(previous, current);
+
+    assertEquals(1, first.getStructureVersionReads());
+    assertEquals(1, second.getStructureVersionReads());
+    assertEquals(3, model.getLastBoundaryStreamErrors().size());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Reuse the already validated `AreaExecutionPlan` while `ProcessModel.run()` calculates one batch of boundary-stream convergence diagnostics.

Previously, every diagnostic stream label called `getAreaExecutionPlan()`. Even on a cache hit that method checks whether the plan is stale by scanning every area's structure version, making one convergence pass O(boundary streams × process areas). The run loop already owns a validated plan for the complete outer iteration, so this PR passes that plan through the private diagnostic path instead.

The existing package-private two-argument `calculateConvergenceErrors(...)` entry point remains compatible and resolves the plan once before delegating. There is no public-API, serialization, equation, tolerance, label, convergence-order, thermodynamic-model, or process-result change.

This is separate from active TPmultiflash optimization #2918, distillation work #2919, and transient architecture #2913; none overlaps either changed file.

## Reproducible benchmark methodology

- baseline: current `master` `60a6bde70de6f0a99b7b59d454e9a936d61d296d`
- candidate: exact head from the same baseline
- OpenJDK 17.0.19, `-XX:+UseSerialGC`, fixed heaps
- fresh JVMs, alternating baseline/candidate order
- median of 9 measured blocks after warmup
- seven paired forks for the direct and full-orchestration cases
- allocation sampled with the JVM thread-allocation counter

### Results

| Workload | Baseline median | Candidate median | Gain |
|---|---:|---:|---:|
| Direct diagnostics, 10 areas / 100 boundary states | 8,466 ns/pass | 5,715 ns/pass | 32.5% |
| Direct diagnostics, 100 areas / 500 boundary states | 244,466 ns/pass | 34,910 ns/pass | 85.7% |
| Full `ProcessModel.run()`, 10 real `ProcessSystem` areas / 900 SRK methane boundary streams / 2 outer iterations | 299,999 ns/run | 216,215 ns/run | 27.9% |

All seven paired forks were faster in every measured workload. Allocation was effectively unchanged: 7,880 B/pass for the 10/100 case, approximately 38.8 kB/pass for 100/500 (+40 B, about 0.1%), and approximately 396.5 kB/full run (+45 B, about 0.01%).

A thermodynamic control used one `ProcessModel` with a 13-component rich-gas/water SRK/classic fluid, 80 bara, 50,000 kg/h and eight alternating heaters at nearby temperatures/duties. Median time was 12.426 ms baseline versus 12.390 ms candidate (0.3%, within fork noise), so no general flash-speed claim is made.

## Accuracy and robustness evidence

- 10/100 diagnostics: exact checksum `0.02763973072170046`, 100 diagnostics
- 100/500 diagnostics: exact checksum `0.0055279461443394585`, 500 diagnostics
- full orchestration: exact checksum `1279684.9999999972`, converged, exactly two outer iterations, 900 diagnostics
- thermodynamic control: exact checksum `-1.0048887946544045E9`, converged, exactly two iterations
- representative nearby heater temperature/duty points are included in the thermodynamic control
- no physics, mass/energy balance, phase, tolerance, ordering, thread-safety, determinism, or repeated-run semantics are changed

The new regression test proves a complete diagnostics batch reads each area's structure version once while preserving every boundary diagnostic. It fails on the baseline, where each stream revalidates the plan.

## Validation

Successful from the exact final checkout:

- focused: `./mvnw -q -o -Dtest=ProcessModelConvergenceFilterTest,ProcessModelBoundaryStreamDiagnosticsTest,ProcessModelExecutionOptimizationTest test` — 23 tests, 0 failures/errors/skips
- broader: `./mvnw -q -o -Dtest='neqsim.process.processmodel.ProcessModel*Test,neqsim.process.processmodel.ProcessSystem*Test,neqsim.process.processmodel.LowFlowBypassConvergenceTest' test` — 33 suites, 253 tests, 0 failures/errors/skips
- Java 8: `./mvnw -q -o -Dmaven.compiler.release=8 -Dmaven.compiler.useIncrementalCompilation=false -DskipTests test-compile` — exit 0
- `python devtools/run_spotless.py apply` — exit 0; repeated after final edits with unchanged candidate hashes
- `python devtools/run_spotless.py check` — exit 0
- `python devtools/check_documentation_search.py` — exit 0; 647 Markdown pages and 1 standalone HTML page audited
- `pre-commit run --all-files --hook-stage pre-commit` — exit 0
- `pre-commit run --all-files --hook-stage pre-push` — exit 0

Maven used the existing task-local offline dependency cache and canonical Maven Central configuration. No environment-only settings are committed.

## Compatibility and limitations

The speedup scales with both the number of boundary diagnostics and the number of process areas. Flash-dominated small models should expect little measurable end-to-end change, as the thermodynamic control demonstrates. The patch deliberately does not change area-plan invalidation, add caching state, suppress diagnostics, weaken convergence criteria, or alter parallel execution.

No notebooks are changed. Final remote comparison is exactly two source files, 78 additions and 6 deletions, zero commits behind the stated baseline, with connector blob SHAs matching the final local files.

## Documentation impact

Documentation impact: none — this only reuses the already validated internal area execution plan. The public `ProcessModel` API, convergence criteria, diagnostic schema/names, units, defaults, and recommended usage are unchanged.
