### PR TITLE
[AI-Assisted] Reuse accepted Naphtali line-search trials

### DIFF
--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -256,6 +256,9 @@ targets manipulated through condenser or reboiler temperature.
   temperature, and vapor flow as tray variables.
 - Builds a finite-difference block-tridiagonal Jacobian from neighboring tray couplings and uses a
   guarded Newton line search with flow and temperature trust limits.
+- Leaves the accepted line-search trial applied and reuses its evaluated MESH residual. The solver
+  does not restore the old tray state and repeat the same thermodynamic evaluation merely to apply
+  a step that the line search has already accepted.
 - Work diagnostics classify every currently assembled derivative column as finite-difference;
   `getLastNaphtaliAnalyticJacobianColumns()` remains available for compatibility and reports zero
   until a mixed analytic/numerical assembly is implemented.

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -35,6 +35,29 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @version 1.0
  */
 public class NaphtaliSandholmSolver {
+  /** Accepted line-search state and its already-evaluated residual. */
+  private static final class LineSearchResult {
+    /** Accepted step length. */
+    private final double alpha;
+    /** Residual vector at the accepted state. */
+    private final double[] residual;
+    /** Residual norm at the accepted state. */
+    private final double norm;
+
+    /**
+     * Create a line-search result.
+     *
+     * @param alpha accepted step length, or zero when no finite trial exists
+     * @param residual residual vector at the accepted state
+     * @param norm residual norm at the accepted state
+     */
+    private LineSearchResult(double alpha, double[] residual, double norm) {
+      this.alpha = alpha;
+      this.residual = residual;
+      this.norm = norm;
+    }
+  }
+
   /** Maximum number of non-descent line-search steps allowed before restoring the best state. */
   private static final int MAX_NON_DESCENT_LINE_SEARCH_STEPS = 3;
 
@@ -829,7 +852,8 @@ public class NaphtaliSandholmSolver {
         }
 
         // Line search: backtrack if step increases residual norm
-        double alpha = lineSearch(dx, norm);
+        LineSearchResult lineSearchResult = lineSearch(dx, norm);
+        double alpha = lineSearchResult.alpha;
         if (alpha <= 0.0) {
           logger.debug("NS: line search found no finite trial step; restoring best state");
           restoreTrayState(bestLiq, bestT, bestV);
@@ -839,14 +863,10 @@ public class NaphtaliSandholmSolver {
           break;
         }
 
-        // Apply update with step size alpha
-        applyUpdate(dx, alpha);
-
-        // Re-evaluate thermodynamics at new state
-        evaluateThermo();
-
-        residual = computeResidual();
-        double newNorm = vectorNorm(residual);
+        // The line search leaves its accepted state applied. Reuse the residual that
+        // selected that state instead of restoring and evaluating the same step again.
+        residual = lineSearchResult.residual;
+        double newNorm = lineSearchResult.norm;
 
         logger.debug("NS iter {}: ||F|| = {} alpha={}", iter, String.format("%.6e", newNorm),
             String.format("%.4f", alpha));
@@ -4341,9 +4361,9 @@ public class NaphtaliSandholmSolver {
    *
    * @param dx Newton direction
    * @param currentNorm current residual norm
-   * @return step size alpha in [0, 1]; zero when no finite trial exists
+   * @return accepted state and its already-evaluated residual; alpha is zero when no finite trial exists
    */
-  private double lineSearch(double[] dx, double currentNorm) {
+  private LineSearchResult lineSearch(double[] dx, double currentNorm) {
     double alpha = 1.0;
     double c = 1e-4; // Armijo constant
     double rho = 0.5; // backtracking factor
@@ -4361,30 +4381,28 @@ public class NaphtaliSandholmSolver {
 
     double bestAlpha = 0.0;
     double bestTrialNorm = Double.POSITIVE_INFINITY;
+    double[] bestResidual = null;
+    double lastEvaluatedAlpha = Double.NaN;
 
     for (int bt = 0; bt < maxBacktrack; bt++) {
       // Trial update
-      for (int j = 0; j < N; j++) {
-        for (int i = 0; i < C; i++) {
-          liq[j][i] = Math.max(saveLiq[j][i] - alpha * dx[j * varsPerTray + i], 1e-20);
-        }
-        if (Double.isNaN(fixedTemperature[j])) {
-          T[j] = Math.max(saveT[j] - alpha * dx[j * varsPerTray + C], 100.0);
-          T[j] = Math.min(T[j], 1000.0);
-        }
-        V[j] = Math.max(saveV[j] - alpha * dx[j * varsPerTray + C + 1], 0.0);
-      }
+      restoreTrayState(saveLiq, saveT, saveV);
+      applyUpdate(dx, alpha);
 
       evaluateThermo();
       double[] Ftrial = computeResidual();
       double trialNorm = vectorNorm(Ftrial);
+      lastEvaluatedAlpha = alpha;
 
       if (Double.isFinite(trialNorm) && trialNorm < bestTrialNorm) {
         bestTrialNorm = trialNorm;
         bestAlpha = alpha;
+        bestResidual = Ftrial;
       }
       if (Double.isFinite(trialNorm) && trialNorm < (1.0 - c * alpha) * currentNorm) {
         bestAlpha = alpha;
+        bestTrialNorm = trialNorm;
+        bestResidual = Ftrial;
         break;
       }
       if (alpha < 0.01) {
@@ -4394,16 +4412,20 @@ public class NaphtaliSandholmSolver {
       alpha *= rho;
     }
 
-    // ALWAYS restore the original state — the main loop's applyUpdate handles the
-    // final step
-    for (int j = 0; j < N; j++) {
-      System.arraycopy(saveLiq[j], 0, liq[j], 0, C);
-      T[j] = saveT[j];
-      V[j] = saveV[j];
+    if (bestAlpha <= 0.0 || bestResidual == null) {
+      restoreTrayState(saveLiq, saveT, saveV);
+      return new LineSearchResult(0.0, null, Double.POSITIVE_INFINITY);
     }
-    evaluateThermo();
 
-    return bestAlpha;
+    if (bestAlpha != lastEvaluatedAlpha) {
+      restoreTrayState(saveLiq, saveT, saveV);
+      applyUpdate(dx, bestAlpha);
+      evaluateThermo();
+      bestResidual = computeResidual();
+      bestTrialNorm = vectorNorm(bestResidual);
+    }
+
+    return new LineSearchResult(bestAlpha, bestResidual, bestTrialNorm);
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
@@ -522,12 +522,21 @@ public class ColumnSpecificationTest {
 
     column.run();
 
-    assertTrue(column.getGasOutStream().getFlowRate("kg/hr") >= 0.0);
+    double gasFlow = column.getGasOutStream().getFlowRate("kg/hr");
+    double liquidFlow = column.getLiquidOutStream().getFlowRate("kg/hr");
+    assertTrue(gasFlow >= 0.0);
+    assertTrue(liquidFlow >= 0.0);
+    assertEquals(237.6597295390127, gasFlow, 1.0e-8);
+    assertEquals(12.34027046098738, liquidFlow, 1.0e-8);
+    assertEquals(250.0, gasFlow + liquidFlow, 1.0e-8);
     assertEquals(0, column.getLastNaphtaliAnalyticJacobianColumns(),
         "the current implementation does not analytically differentiate any Jacobian column");
     assertEquals(800, column.getLastNaphtaliFiniteDifferenceJacobianColumns(),
         "eight stages times five variables times twenty Jacobian builds must all be finite-difference columns");
     assertTrue(column.getLastNaphtaliThermoEvaluationCount() > 0);
+    assertTrue(column.getLastNaphtaliThermoEvaluationCount() < 16000,
+        () -> "accepted line-search trials should be reused without restoring and reevaluating the same Newton step: "
+            + column.getLastNaphtaliThermoEvaluationCount());
     assertTrue(column.getLastNaphtaliThermoKValueIterationCount() >= column.getLastNaphtaliThermoEvaluationCount(),
         "each successful tray evaluation must perform at least one forced-root fugacity sweep");
     assertTrue(column.getLastNaphtaliThermoKValueIterationCount() < 2 * column.getLastNaphtaliThermoEvaluationCount(),
@@ -571,6 +580,9 @@ public class ColumnSpecificationTest {
     second.run();
 
     assertEquals(first.getLastNaphtaliThermoEvaluationCount(), second.getLastNaphtaliThermoEvaluationCount());
+    assertTrue(first.getLastNaphtaliThermoEvaluationCount() < 16000,
+        () -> "the nearby case should also reuse accepted line-search evaluations: "
+            + first.getLastNaphtaliThermoEvaluationCount());
     assertEquals(first.getLastNaphtaliThermoKValueIterationCount(), second.getLastNaphtaliThermoKValueIterationCount());
     assertEquals(first.getLastNaphtaliThermoKValueNonConvergedCount(),
         second.getLastNaphtaliThermoKValueNonConvergedCount());


### PR DESCRIPTION
## Problem

`NaphtaliSandholmSolver.lineSearch(...)` fully evaluated each trial state to select an Armijo/best step, but then always restored and reevaluated the old tray state. The main Newton loop subsequently reapplied and reevaluated the already-accepted trial. For every accepted Newton step this repeated two full-column thermodynamic passes without adding convergence information.

Affected scope: Naphtali-Sandholm Newton line search only. Solver selection, trust limits, Armijo parameters, residual equations, fallback coordination, convergence tolerances, and public APIs are unchanged.

## Change

Return the accepted line-search state together with its already-computed residual vector and norm:

- accepted current trial: leave its tray and thermodynamic state applied and reuse its residual;
- best earlier trial: restore, apply, and evaluate that best trial once;
- no finite trial: restore the original tray variables and preserve the existing best-state fallback.

Trial updates now use the existing bounded `applyUpdate(...)` path, keeping component-flow, temperature, fixed-temperature, and vapor-flow bounds identical.

## Reproduction and before/after evidence

Deterministic 8-stage propane / n-butane / n-pentane fractionator, 10 bar, total condenser and reboiler, 250 kg/h feed, 20 Naphtali Newton iterations:

| Feed temperature | Metric | master | change |
| --- | --- | ---: | ---: |
| 318.15 K | tray thermodynamic evaluations | 16,240 | 15,920 (**-320; -1.97%**) |
| 318.15 K | forced-root K sweeps | 31,052 | 30,412 (**-640; -2.06%**) |
| 318.15 K | outer iterations | 136 | 136 |
| 318.15 K | energy residual | 0.0026114531000510466 | 0.0026114531000510466 |
| 320.15 K | tray thermodynamic evaluations | 16,216 | 15,896 (**-320; -1.97%**) |
| 320.15 K | forced-root K sweeps | 30,850 | 30,210 (**-640; -2.07%**) |
| 320.15 K | outer iterations | 136 | 136 |
| 320.15 K | energy residual | 0.002220963841858695 | 0.002220963841858695 |

The saved 320 evaluations are exactly 20 Newton iterations × two redundant full-column passes × eight stages. The base product split remains exactly 237.6597295390127 kg/h gas plus 12.34027046098738 kg/h liquid. MESH norm, products, outer iterations, and repeated nearby-point telemetry remain deterministic.

The strengthened regression fails on unchanged master as intended:

`accepted line-search trials should be reused ...: 16240`

and passes with the candidate below 16,000 evaluations for both operating points. No wall-clock assertion was added.

## Validation

- focused changed regression plus nearby repeatability regression — pass
- unchanged-master regression with the new work bound — fails as intended at 16,240 evaluations
- `./mvnw -o -q -DexcludedTestGroups= -Dtest='neqsim.process.equipment.distillation.*Test' test` — 27 suites, 218 tests, 0 failures/errors, 2 pre-existing skips
- `python devtools/run_spotless.py apply` — exit 0; repeated apply produced no content changes
- `python devtools/run_spotless.py check` — exit 0
- `python devtools/check_documentation_search.py` — exit 0; 648 Markdown pages and 1 standalone HTML page audited

The standalone pre-commit executable was unavailable. This connector-only workflow intentionally did not use local Git; the direct Spotless and documentation gates were run explicitly. Hosted pre-commit supplies the repository-wide hook validation.

## Compatibility and risk

- no public API, serialization, clone, calculation-identity, tolerance, or specification change;
- accepted trial state is now the state whose residual actually satisfied the line-search decision, matching standard backtracking semantics;
- rejected and non-finite trial rollback remains guarded;
- the complete distillation suite covers direct/inside-out/matrix solvers, AUTO and damped fallback, side draws, warm state, reactive and packed columns, condenser/reboiler modes, and nearby/repeated cases.

## Documentation impact

Updated `docs/wiki/distillation_column.md` to describe accepted line-search state/residual reuse.

## Remaining limitations

The solver still uses a fully finite-difference Jacobian and at most two forced-root K sweeps per tray evaluation. This PR removes duplicated accepted-step work; it does not change inner K convergence or the Jacobian formulation.