### PR TITLE
Scope registered process models to their owner, not only to the tenant

### DIFF
--- a/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
+++ b/neqsim-mcp-server/src/main/java/neqsim/mcp/server/NeqSimTools.java
@@ -56,6 +56,7 @@ import neqsim.mcp.runners.HazopScenarioRunner;
 import neqsim.mcp.runners.IndustrialProfile;
 import neqsim.mcp.runners.LOPARunner;
 import neqsim.mcp.runners.MaterialsReviewRunner;
+import neqsim.mcp.runners.McpRequestContext;
 import neqsim.mcp.runners.ModelRegistry;
 import neqsim.mcp.runners.NorsokS001Clause10ReviewRunner;
 import neqsim.mcp.runners.OpenDrainReviewRunner;
@@ -159,6 +160,8 @@ public class NeqSimTools {
           withAutoValidation(FlashRunner.run(json.toString()), "flash"), "general");
     } catch (Exception e) {
       return errorJson("Flash calculation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -191,6 +194,8 @@ public class NeqSimTools {
           withAutoValidation(ProcessRunner.validateAndRun(resolveModel(processJson)), "process"), "general");
     } catch (Exception e) {
       return errorJson("Process simulation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -214,6 +219,8 @@ public class NeqSimTools {
       return standardizeResponse("validateInput", Validator.validate(resolveModel(inputJson)), "general");
     } catch (Exception e) {
       return errorJson("Validation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -238,6 +245,8 @@ public class NeqSimTools {
       return standardizeResponse("searchComponents", ComponentQuery.search(query), "general");
     } catch (Exception e) {
       return errorJson("Component search failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -267,13 +276,17 @@ public class NeqSimTools {
     if (policyBlocked != null) {
       return policyBlocked;
     }
-    String example = ExampleCatalog.getExample(category, name);
-    if (example != null) {
-      return example;
+    try {
+      String example = ExampleCatalog.getExample(category, name);
+      if (example != null) {
+        return example;
+      }
+      return errorJson("Example not found: " + category + "/" + name
+          + ". Use getExample with a listed category such as flash, process, validation, "
+          + "safety, or tool");
+    } finally {
+      McpRequestContext.clear();
     }
-    return errorJson("Example not found: " + category + "/" + name
-        + ". Use getExample with a listed category such as flash, process, validation, "
-        + "safety, or tool");
   }
 
   /**
@@ -299,11 +312,15 @@ public class NeqSimTools {
     if (policyBlocked != null) {
       return policyBlocked;
     }
-    String schema = SchemaCatalog.getSchema(toolName, schemaType);
-    if (schema != null) {
-      return schema;
+    try {
+      String schema = SchemaCatalog.getSchema(toolName, schemaType);
+      if (schema != null) {
+        return schema;
+      }
+      return errorJson("Schema not found: " + toolName + "/" + schemaType);
+    } finally {
+      McpRequestContext.clear();
     }
-    return errorJson("Schema not found: " + toolName + "/" + schemaType);
   }
 
   /**
@@ -327,6 +344,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Failed to list units: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -355,6 +374,8 @@ public class NeqSimTools {
           AutomationRunner.listVariables(resolveModel(processJson), unitName), "general");
     } catch (Exception e) {
       return errorJson("Failed to list variables: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -387,6 +408,8 @@ public class NeqSimTools {
           AutomationRunner.getVariable(resolveModel(processJson), address, unit), "general");
     } catch (Exception e) {
       return errorJson("Failed to get variable: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -419,6 +442,8 @@ public class NeqSimTools {
           AutomationRunner.setVariableAndRun(resolveModel(processJson), address, value, unit), "general");
     } catch (Exception e) {
       return errorJson("Failed to set variable: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -448,6 +473,8 @@ public class NeqSimTools {
           AutomationRunner.saveState(resolveModel(processJson), stateName, stateVersion), "general");
     } catch (Exception e) {
       return errorJson("Failed to save state: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -474,6 +501,8 @@ public class NeqSimTools {
           AutomationRunner.compareStates(stateJson1, stateJson2), "general");
     } catch (Exception e) {
       return errorJson("Failed to compare states: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -506,6 +535,8 @@ public class NeqSimTools {
           AutomationRunner.diagnose(resolveModel(processJson), failedAddress, operation), "general");
     } catch (Exception e) {
       return errorJson("Failed to diagnose: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -531,6 +562,8 @@ public class NeqSimTools {
           AutomationRunner.getLearningReport(resolveModel(processJson)), "general");
     } catch (Exception e) {
       return errorJson("Failed to get learning report: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -567,6 +600,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Operational study failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
   // ═══════════════════════════════════════════════════════════════════════════
@@ -647,6 +682,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Property table calculation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -678,6 +715,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Phase envelope calculation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -703,6 +742,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Failed to get capabilities: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -750,6 +791,8 @@ public class NeqSimTools {
       return standardizeResponse("runBatch", BatchRunner.run(json.toString()), "general");
     } catch (Exception e) {
       return errorJson("Batch calculation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -797,6 +840,8 @@ public class NeqSimTools {
           CrossValidationRunner.crossValidate(crossValidationJson), "general");
     } catch (Exception e) {
       return errorJson("Cross-validation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -826,6 +871,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Parametric study failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -860,6 +907,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("PVT simulation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -895,6 +944,8 @@ public class NeqSimTools {
           withAutoValidation(FlowAssuranceRunner.run(flowAssuranceJson), "pipeline"), "general");
     } catch (Exception e) {
       return errorJson("Flow assurance analysis failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -921,6 +972,8 @@ public class NeqSimTools {
       return standardizeResponse("runChemistry", ChemistryRunner.run(chemistryJson), "general");
     } catch (Exception e) {
       return errorJson("Chemistry analysis failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -949,6 +1002,8 @@ public class NeqSimTools {
           withAutoValidation(MaterialsReviewRunner.run(materialsReviewJson), "general"), "general");
     } catch (Exception e) {
       return errorJson("Materials review failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -978,6 +1033,8 @@ public class NeqSimTools {
           withAutoValidation(OpenDrainReviewRunner.run(openDrainReviewJson), "general"), "general");
     } catch (Exception e) {
       return errorJson("Open-drain review failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1011,6 +1068,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("NORSOK S-001 Clause 10 review failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1046,6 +1105,8 @@ public class NeqSimTools {
           withAutoValidation(StandardsRunner.run(standardJson), "general"), "general");
     } catch (Exception e) {
       return errorJson("Standard calculation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1077,6 +1138,8 @@ public class NeqSimTools {
           withAutoValidation(PipelineRunner.run(pipelineJson), "pipeline"), "general");
     } catch (Exception e) {
       return errorJson("Pipeline simulation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1107,6 +1170,8 @@ public class NeqSimTools {
           withAutoValidation(WaterHammerRunner.run(waterHammerJson), "pipeline"), "general");
     } catch (Exception e) {
       return errorJson("Water-hammer study failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1139,6 +1204,8 @@ public class NeqSimTools {
       return standardizeResponse("runReservoir", ReservoirRunner.run(reservoirJson), "general");
     } catch (Exception e) {
       return errorJson("Reservoir simulation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1176,6 +1243,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Field economics calculation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1208,6 +1277,8 @@ public class NeqSimTools {
       return standardizeResponse("runDynamic", DynamicRunner.run(dynamicJson), "general");
     } catch (Exception e) {
       return errorJson("Dynamic simulation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1246,6 +1317,8 @@ public class NeqSimTools {
       return standardizeResponse("runBioprocess", BioprocessRunner.run(bioprocessJson), "general");
     } catch (Exception e) {
       return errorJson("Bioprocess simulation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1289,6 +1362,8 @@ public class NeqSimTools {
       return standardizeResponse("manageSession", SessionRunner.run(sessionJson), "general");
     } catch (Exception e) {
       return errorJson("Session operation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1313,6 +1388,8 @@ public class NeqSimTools {
           AutomationRunner.getAdjustableParameters(resolveModel(processJson)), "general");
     } catch (Exception e) {
       return errorJson("Adjustable-parameter enumeration failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1355,6 +1432,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Process loop failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1388,6 +1467,8 @@ public class NeqSimTools {
       return standardizeResponse("solveTask", TaskSolverRunner.solveTask(taskJson), "general");
     } catch (Exception e) {
       return errorJson("Task solving failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1416,6 +1497,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Workflow composition failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1444,6 +1527,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Agentic engineering failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1479,6 +1564,8 @@ public class NeqSimTools {
           EngineeringValidator.validate(resultsJson, context), "general");
     } catch (Exception e) {
       return errorJson("Validation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1510,6 +1597,8 @@ public class NeqSimTools {
       return standardizeResponse("generateReport", ReportRunner.run(reportJson), "general");
     } catch (Exception e) {
       return errorJson("Report generation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1544,6 +1633,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Task workflow bridge failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1584,6 +1675,8 @@ public class NeqSimTools {
       }
     } catch (Exception e) {
       return errorJson("Plugin operation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1621,6 +1714,8 @@ public class NeqSimTools {
       }
     } catch (Exception e) {
       return errorJson("Progress query failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1652,6 +1747,8 @@ public class NeqSimTools {
       return standardizeResponse("streamSimulation", StreamingRunner.run(streamJson), "general");
     } catch (Exception e) {
       return errorJson("Streaming operation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1683,6 +1780,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Visualization failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1717,6 +1816,8 @@ public class NeqSimTools {
           CompositionRunner.run(compositionJson), "general");
     } catch (Exception e) {
       return errorJson("Composition failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1747,6 +1848,8 @@ public class NeqSimTools {
       return standardizeResponse("manageSecurity", SecurityRunner.run(securityJson), "general");
     } catch (Exception e) {
       return errorJson("Security operation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1777,6 +1880,8 @@ public class NeqSimTools {
       return standardizeResponse("manageState", StatePersistenceRunner.run(persistJson), "general");
     } catch (Exception e) {
       return errorJson("State persistence failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1810,6 +1915,8 @@ public class NeqSimTools {
           ValidationProfileRunner.run(profileJson), "general");
     } catch (Exception e) {
       return errorJson("Validation profile operation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1841,6 +1948,8 @@ public class NeqSimTools {
       return standardizeResponse("queryDataCatalog", DataCatalogRunner.run(catalogJson), "general");
     } catch (Exception e) {
       return errorJson("Data catalog query failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1867,6 +1976,8 @@ public class NeqSimTools {
       return standardizeResponse("sizeEquipment", EquipmentSizingRunner.run(sizingJson), "general");
     } catch (Exception e) {
       return errorJson("Equipment sizing failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1896,6 +2007,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Utility design failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1921,6 +2034,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Process comparison failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1959,6 +2074,8 @@ public class NeqSimTools {
       return standardizeResponse("runRelief", ReliefRunner.run(reliefJson), "general");
     } catch (Exception e) {
       return errorJson("Relief sizing failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -1988,6 +2105,8 @@ public class NeqSimTools {
       return standardizeResponse("runLOPA", LOPARunner.run(lopaJson), "general");
     } catch (Exception e) {
       return errorJson("LOPA calculation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2015,6 +2134,8 @@ public class NeqSimTools {
       return standardizeResponse("runSIL", SILRunner.run(silJson), "general");
     } catch (Exception e) {
       return errorJson("SIL verification failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2041,6 +2162,8 @@ public class NeqSimTools {
       return standardizeResponse("runRiskMatrix", RiskMatrixRunner.run(riskJson), "general");
     } catch (Exception e) {
       return errorJson("Risk matrix scoring failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2066,6 +2189,8 @@ public class NeqSimTools {
       return standardizeResponse("runFlareNetwork", FlareRadiationRunner.run(flareJson), "general");
     } catch (Exception e) {
       return errorJson("Flare radiation calculation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2096,6 +2221,8 @@ public class NeqSimTools {
       return standardizeResponse("runHAZOP", HAZOPStudyRunner.run(hazopJson), "general");
     } catch (Exception e) {
       return errorJson("HAZOP study generation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2127,6 +2254,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("HAZOP scenario evaluation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2154,6 +2283,8 @@ public class NeqSimTools {
           "general");
     } catch (Exception e) {
       return errorJson("Barrier register analysis failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2180,6 +2311,8 @@ public class NeqSimTools {
           SafetySystemPerformanceRunner.run(safetySystemJson), "general");
     } catch (Exception e) {
       return errorJson("Safety-system performance analysis failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2215,6 +2348,8 @@ public class NeqSimTools {
       return standardizeResponse("runRootCauseAnalysis", RootCauseRunner.run(rcaJson), "general");
     } catch (Exception e) {
       return errorJson("Root cause analysis failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2327,6 +2462,8 @@ public class NeqSimTools {
       }
     } catch (Exception e) {
       return errorJson("Industrial profile operation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2366,6 +2503,8 @@ public class NeqSimTools {
       }
     } catch (Exception e) {
       return errorJson("Benchmark trust query failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2415,6 +2554,8 @@ public class NeqSimTools {
       return standardizeResponse("checkToolAccess", GSON_PRETTY.toJson(result), "general");
     } catch (Exception e) {
       return errorJson("Tool access check failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2445,6 +2586,8 @@ public class NeqSimTools {
       return standardizeResponse("manageModel", ModelRegistry.run(modelJson), "general");
     } catch (Exception e) {
       return errorJson("Model registry operation failed: " + e.getMessage());
+    } finally {
+      McpRequestContext.clear();
     }
   }
 
@@ -2469,6 +2612,13 @@ public class NeqSimTools {
    * Governance then evaluates a real principal instead of a null credential.
    * </p>
    *
+   * <p>
+   * The binding is thread-local, so every caller must release it again. Tool methods do that in a
+   * {@code finally} block around their body; when access is denied the body never runs, so the
+   * binding is released here instead. Without this a pooled HTTP worker thread would keep the
+   * previous caller's credential and subject resident between requests.
+   * </p>
+   *
    * @param toolName the MCP tool name
    * @return null if execution may continue, otherwise a standardized blocked response
    */
@@ -2480,7 +2630,11 @@ public class NeqSimTools {
     if (blocked == null) {
       return null;
     }
-    return standardizeResponse(toolName, blocked, "policy");
+    try {
+      return standardizeResponse(toolName, blocked, "policy");
+    } finally {
+      McpRequestContext.clear();
+    }
   }
 
   /**

--- a/src/main/java/neqsim/mcp/runners/ModelRegistry.java
+++ b/src/main/java/neqsim/mcp/runners/ModelRegistry.java
@@ -29,8 +29,12 @@ import neqsim.process.processmodel.SimulationResult;
  * </p>
  *
  * <p>
- * Models are scoped to the tenant of the authenticated principal, so a handle issued in one tenant is not resolvable
- * from another. Storage is in-memory: this is a working set for a running server, not a document archive.
+ * Models are scoped to the owner and the tenant of the authenticated principal: a handle is resolvable only by the
+ * principal that registered it. A directory tenant is shared by every user of one organisation, so tenant alone is not
+ * an isolation boundary — ownership is enforced on every read, revision, deletion, listing and internal resolution. A
+ * handle owned by another principal is reported as unknown rather than as forbidden, so the registry cannot be used to
+ * enumerate other users' models. Storage is in-memory: this is a working set for a running server, not a document
+ * archive.
  * </p>
  *
  * @author Even Solbraa
@@ -46,10 +50,13 @@ public final class ModelRegistry {
   /** Max registered models per tenant, guarding against unbounded memory growth. */
   private static final int MAX_MODELS_PER_TENANT = 100;
 
-  /** Registered models keyed by model id. */
+  /** Separator joining tenant, owner and handle into a storage key; cannot occur in any of the three. */
+  private static final char SCOPE_SEPARATOR = '\0';
+
+  /** Registered models keyed by the scope-qualified model id. */
   private static final ConcurrentHashMap<String, ModelRecord> MODELS = new ConcurrentHashMap<String, ModelRecord>();
 
-  /** Solved process systems keyed by model id, so repeated reads do not re-solve. */
+  /** Solved process systems keyed by the scope-qualified model id, so repeated reads do not re-solve. */
   private static final ConcurrentHashMap<String, SolvedModel> SOLVED = new ConcurrentHashMap<String, SolvedModel>();
 
   /** Max solved models held in memory; a solved flowsheet is far heavier than its definition. */
@@ -127,8 +134,8 @@ public final class ModelRegistry {
       return processJsonOrModelId;
     }
     String modelId = processJsonOrModelId.trim();
-    ModelRecord record = MODELS.get(modelId);
-    if (record == null || !record.tenant.equals(currentTenant())) {
+    ModelRecord record = MODELS.get(scopeKey(modelId));
+    if (!isVisibleTo(record)) {
       throw new IllegalArgumentException("Unknown model handle '" + modelId
           + "'. Register the model first with manageModel(action='register'), or pass the process JSON inline.");
     }
@@ -153,7 +160,8 @@ public final class ModelRegistry {
    */
   public static ProcessSystem solvedProcess(String modelId) {
     String definition = resolve(modelId);
-    String key = modelId.trim();
+    String handle = modelId.trim();
+    String key = scopeKey(handle);
     ModelRecord record = MODELS.get(key);
     int revision = record != null ? record.revision : 0;
 
@@ -166,7 +174,7 @@ public final class ModelRegistry {
 
     SimulationResult result = ProcessSystem.fromJsonAndRun(definition);
     if (result.isError() || result.getProcessSystem() == null) {
-      throw new IllegalStateException("Model '" + key + "' failed to solve: " + result.getErrors());
+      throw new IllegalStateException("Model '" + handle + "' failed to solve: " + result.getErrors());
     }
 
     SolvedModel solved = new SolvedModel();
@@ -185,7 +193,7 @@ public final class ModelRegistry {
    * @return reuse count, or 0 when nothing is cached
    */
   public static int solvedHits(String modelId) {
-    SolvedModel cached = modelId != null ? SOLVED.get(modelId.trim()) : null;
+    SolvedModel cached = modelId != null ? SOLVED.get(scopeKey(modelId.trim())) : null;
     return cached != null ? cached.hits : 0;
   }
 
@@ -196,7 +204,7 @@ public final class ModelRegistry {
    */
   public static void invalidateSolved(String modelId) {
     if (modelId != null) {
-      SOLVED.remove(modelId.trim());
+      SOLVED.remove(scopeKey(modelId.trim()));
     }
   }
 
@@ -250,17 +258,17 @@ public final class ModelRegistry {
     record.version = optionalString(input, "version", "1.0.0");
     record.definition = definition;
     record.tenant = tenant;
-    record.owner = McpRequestContext.currentSubject();
+    record.owner = currentOwner();
     record.revision = 1;
     record.createdAt = Instant.now().toString();
     record.lastAccess = System.currentTimeMillis();
 
-    ModelRecord existing = MODELS.get(record.modelId);
-    if (existing != null && existing.tenant.equals(tenant)) {
-      // Identical content in the same tenant is the same model; return the existing handle.
+    ModelRecord existing = MODELS.get(scopeKey(record.modelId));
+    if (isVisibleTo(existing)) {
+      // Identical content from the same principal is the same model; return the existing handle.
       return modelResponse("register", existing, "Model already registered with identical content");
     }
-    MODELS.put(record.modelId, record);
+    MODELS.put(scopeKey(record.modelId), record);
     return modelResponse("register", record, "Model registered");
   }
 
@@ -318,7 +326,7 @@ public final class ModelRegistry {
     String tenant = currentTenant();
     List<ModelRecord> visible = new ArrayList<ModelRecord>();
     for (ModelRecord record : MODELS.values()) {
-      if (record.tenant.equals(tenant)) {
+      if (isVisibleTo(record)) {
         visible.add(record);
       }
     }
@@ -337,6 +345,7 @@ public final class ModelRegistry {
     response.add("models", models);
     response.addProperty("count", models.size());
     response.addProperty("tenant", tenant);
+    response.addProperty("owner", currentOwner());
     return envelope("list", response, "Registered models listed");
   }
 
@@ -388,7 +397,7 @@ public final class ModelRegistry {
     if (record == null) {
       return unknownModelError(input);
     }
-    MODELS.remove(record.modelId);
+    MODELS.remove(scopeKey(record.modelId));
     invalidateSolved(record.modelId);
     JsonObject response = new JsonObject();
     response.addProperty("modelId", record.modelId);
@@ -490,7 +499,7 @@ public final class ModelRegistry {
   }
 
   /**
-   * Looks up a model referenced by the request, honouring tenant isolation.
+   * Looks up a model referenced by the request, honouring owner and tenant isolation.
    *
    * @param input the request object
    * @return the model record, or null when absent or not visible
@@ -499,11 +508,8 @@ public final class ModelRegistry {
     if (!input.has("modelId")) {
       return null;
     }
-    ModelRecord record = MODELS.get(input.get("modelId").getAsString().trim());
-    if (record == null || !record.tenant.equals(currentTenant())) {
-      return null;
-    }
-    return record;
+    ModelRecord record = MODELS.get(scopeKey(input.get("modelId").getAsString().trim()));
+    return isVisibleTo(record) ? record : null;
   }
 
   /**
@@ -525,6 +531,53 @@ public final class ModelRegistry {
    */
   private static String currentTenant() {
     return McpRequestContext.current().getTenant();
+  }
+
+  /**
+   * Returns the owner scope of the current caller.
+   *
+   * <p>
+   * The subject is taken from the identity the transport already validated, never from a tool argument, so a client
+   * cannot claim another principal. Callers the transport did not authenticate share the anonymous subject, which
+   * keeps single-user desktop use working while still denying them every model registered by a named principal.
+   * </p>
+   *
+   * @return the owner identifier
+   */
+  private static String currentOwner() {
+    return McpRequestContext.currentSubject();
+  }
+
+  /**
+   * Returns whether a record belongs to the current caller.
+   *
+   * <p>
+   * One directory tenant covers every user of an organisation, so a tenant check alone leaves all of them in one
+   * namespace; ownership is the check that keeps one engineer's flowsheet out of another engineer's session.
+   * </p>
+   *
+   * @param record the model record, may be null
+   * @return true when the record exists and is owned by the caller within the caller's tenant
+   */
+  private static boolean isVisibleTo(ModelRecord record) {
+    return record != null && currentTenant().equals(record.tenant) && currentOwner().equals(record.owner);
+  }
+
+  /**
+   * Builds the storage key that scopes a handle to the caller that registered it.
+   *
+   * <p>
+   * Handles are content-derived, so without a scoped key two principals registering the same definition would share
+   * one entry: a revision by one would silently change what the other resolves, and the second registration would hand
+   * back the first caller's record. Qualifying the key with tenant and owner keeps the entries independent while the
+   * handle itself stays stable for its owner.
+   * </p>
+   *
+   * @param modelId the model handle
+   * @return the scope-qualified storage key
+   */
+  private static String scopeKey(String modelId) {
+    return currentTenant() + SCOPE_SEPARATOR + currentOwner() + SCOPE_SEPARATOR + modelId;
   }
 
   /**

--- a/src/test/java/neqsim/mcp/runners/McpSecurityStudyTeamProfileTest.java
+++ b/src/test/java/neqsim/mcp/runners/McpSecurityStudyTeamProfileTest.java
@@ -1,0 +1,168 @@
+package neqsim.mcp.runners;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import neqsim.mcp.runners.IndustrialProfile.DeploymentMode;
+import neqsim.mcp.runners.IndustrialProfile.ToolCategory;
+import neqsim.mcp.runners.IndustrialProfile.ToolTier;
+
+/**
+ * Regression tests for the STUDY_TEAM deployment profile.
+ *
+ * <p>
+ * STUDY_TEAM is the profile hosted deployments run with ({@code NEQSIM_MCP_PROFILE=STUDY_TEAM}), and the governance
+ * promise attached to it is explicit: Tier 1 (TRUSTED_CORE) and Tier 2 (ENGINEERING_ADVANCED) tools are available, Tier
+ * 3 (EXPERIMENTAL) tools are refused at call time — not merely hidden from discovery. These tests pin that promise,
+ * including the shape of the refusal envelope and the tier a tool is actually classified in, so a future retiering
+ * cannot silently widen the hosted surface.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+class McpSecurityStudyTeamProfileTest {
+
+  /** Deployment mode active before this class ran, restored afterwards. */
+  private static DeploymentMode originalMode;
+
+  /**
+   * Captures the process-global deployment mode so this class cannot poison other tests.
+   */
+  @BeforeAll
+  static void captureDeploymentMode() {
+    originalMode = IndustrialProfile.getActiveMode();
+  }
+
+  /**
+   * Restores the process-global deployment mode captured before this class ran.
+   */
+  @AfterAll
+  static void restoreDeploymentMode() {
+    IndustrialProfile.setActiveMode(originalMode);
+  }
+
+  /**
+   * Activates the hosted profile with enforcement state reset, so tool-tier filtering is the only thing under test.
+   */
+  @BeforeEach
+  void useStudyTeamProfile() {
+    SecurityRunner.resetForTests();
+    McpRequestContext.clear();
+    IndustrialProfile.setActiveMode(DeploymentMode.STUDY_TEAM);
+  }
+
+  /**
+   * Restores mutated global state after every test, including the deployment mode.
+   */
+  @AfterEach
+  void resetGlobalState() {
+    McpRequestContext.clear();
+    SecurityRunner.resetForTests();
+    IndustrialProfile.setActiveMode(originalMode);
+  }
+
+  /**
+   * A Tier 3 tool must be refused at call time, with an envelope that names the mode, the tier and a remediation — this
+   * is the governance promise made for hosted deployments.
+   */
+  @Test
+  @DisplayName("STUDY_TEAM: Tier 3 solveTask is blocked at call time")
+  void testExperimentalToolIsBlockedAtCallTime() {
+    assertEquals(ToolTier.EXPERIMENTAL, IndustrialProfile.getToolTier("solveTask"),
+        "solveTask must stay classified as Tier 3");
+    assertFalse(IndustrialProfile.isToolAllowed("solveTask"), "solveTask must not be allowed in STUDY_TEAM");
+
+    String blocked = IndustrialProfile.enforceAccess("solveTask");
+    assertNotNull(blocked, "STUDY_TEAM must refuse Tier 3 tools at call time, not just hide them");
+
+    JsonObject root = JsonParser.parseString(blocked).getAsJsonObject();
+    assertEquals("blocked", root.get("status").getAsString());
+    assertEquals("solveTask", root.get("tool").getAsString());
+    assertEquals("STUDY_TEAM", root.get("mode").getAsString());
+    assertEquals("EXPERIMENTAL", root.get("tier").getAsString());
+    assertTrue(root.get("reason").getAsString().contains("not available in STUDY_TEAM mode"),
+        "Refusal must state the mode: " + blocked);
+    assertTrue(root.has("remediation"), "Refusal must carry a remediation hint");
+    JsonObject data = root.getAsJsonObject("data");
+    assertEquals("STUDY_TEAM", data.get("mode").getAsString());
+    assertEquals("EXPERIMENTAL", data.get("policyCode").getAsString());
+    assertFalse(data.get("approvalRequired").getAsBoolean(),
+        "A tier refusal is not an approval prompt — it must not look recoverable by approving");
+    assertFalse(root.getAsJsonObject("validation").get("valid").getAsBoolean());
+    assertEquals("blocked", root.getAsJsonObject("qualityGate").get("verdict").getAsString());
+  }
+
+  /**
+   * The whole Tier 3 set must be refused, not just the tool this test happened to name.
+   */
+  @Test
+  @DisplayName("STUDY_TEAM: every Tier 3 tool is blocked")
+  void testEveryExperimentalToolIsBlocked() {
+    for (String tool : IndustrialProfile.getExperimentalTools()) {
+      String blocked = IndustrialProfile.enforceAccess(tool);
+      assertNotNull(blocked, "Tier 3 tool '" + tool + "' must be blocked in STUDY_TEAM");
+      JsonObject root = JsonParser.parseString(blocked).getAsJsonObject();
+      assertEquals("blocked", root.get("status").getAsString(), "Tier 3 tool '" + tool + "' must be blocked");
+    }
+  }
+
+  /**
+   * Tier 1 stays available — blocking Tier 3 must not collaterally break the trusted core.
+   */
+  @Test
+  @DisplayName("STUDY_TEAM: Tier 1 runFlash is allowed")
+  void testTrustedCoreToolIsAllowed() {
+    assertEquals(ToolTier.TRUSTED_CORE, IndustrialProfile.getToolTier("runFlash"),
+        "runFlash must stay classified as Tier 1");
+    assertNull(IndustrialProfile.enforceAccess("runFlash"), "Tier 1 tools must be callable in STUDY_TEAM");
+
+    for (String tool : IndustrialProfile.getIndustrialCore()) {
+      assertNull(IndustrialProfile.enforceAccess(tool), "Tier 1 tool '" + tool + "' must be allowed in STUDY_TEAM");
+    }
+  }
+
+  /**
+   * Tier 2 stays available — STUDY_TEAM is the collaborative engineering profile, not a read-only one.
+   */
+  @Test
+  @DisplayName("STUDY_TEAM: Tier 2 runPVT is allowed")
+  void testEngineeringAdvancedToolIsAllowed() {
+    assertEquals(ToolTier.ENGINEERING_ADVANCED, IndustrialProfile.getToolTier("runPVT"),
+        "runPVT must stay classified as Tier 2");
+    assertNull(IndustrialProfile.enforceAccess("runPVT"), "Tier 2 tools must be callable in STUDY_TEAM");
+
+    for (String tool : IndustrialProfile.getEngineeringAdvanced()) {
+      assertNull(IndustrialProfile.enforceAccess(tool), "Tier 2 tool '" + tool + "' must be allowed in STUDY_TEAM");
+    }
+  }
+
+  /**
+   * manageModel writes server-side state but is classified Tier 1, so it is reachable in every hosted profile. Pinning
+   * the classification here means a later retiering shows up as a failing governance test rather than as a silent
+   * change to the hosted tool surface.
+   */
+  @Test
+  @DisplayName("STUDY_TEAM: manageModel is Tier 1 and therefore allowed")
+  void testManageModelIsTrustedCoreAndAllowed() {
+    assertEquals(ToolTier.TRUSTED_CORE, IndustrialProfile.getToolTier("manageModel"),
+        "manageModel is Tier 1 (TRUSTED_CORE); retiering it changes which profiles may call it");
+    assertEquals(ToolCategory.EXECUTION, IndustrialProfile.getToolCategory("manageModel"),
+        "manageModel is a state-modifying tool, so approval gates apply to it in gated profiles");
+    assertTrue(IndustrialProfile.isToolAllowed("manageModel"));
+    assertNull(IndustrialProfile.enforceAccess("manageModel"),
+        "manageModel must stay callable in STUDY_TEAM as long as it is Tier 1");
+    assertFalse(IndustrialProfile.requiresApproval("manageModel"),
+        "STUDY_TEAM has no approval gate, so manageModel must not prompt for approval");
+  }
+}

--- a/src/test/java/neqsim/mcp/runners/ModelRegistryOwnerScopingTest.java
+++ b/src/test/java/neqsim/mcp/runners/ModelRegistryOwnerScopingTest.java
@@ -1,0 +1,397 @@
+package neqsim.mcp.runners;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Tests that registered models are reachable only by the principal that registered them.
+ *
+ * <p>
+ * The registry used to scope entries by tenant alone. One directory tenant covers every user of an organisation, so
+ * that left all of them in a single namespace: any caller could list every handle, read another engineer's flowsheet,
+ * delete it, or revise it so its owner's next run silently computed on someone else's edits and still returned a
+ * normal-looking result. These tests pin the ownership check on every access path.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+class ModelRegistryOwnerScopingTest {
+
+  /** Tenant shared by every principal in these tests, as a single directory tenant is in production. */
+  private static final String SHARED_TENANT = "equinor-tid";
+
+  /** Name of the model owned by Alice; used to detect leakage of another owner's metadata. */
+  private static final String OWNED_MODEL_NAME = "wisting-flowsheet";
+
+  /**
+   * Clears registry and identity state before each test.
+   */
+  @BeforeEach
+  void reset() {
+    ModelRegistry.resetForTests();
+    McpRequestContext.clear();
+  }
+
+  /**
+   * Clears registry and identity state after each test so bound principals do not leak.
+   */
+  @AfterEach
+  void clearIdentity() {
+    ModelRegistry.resetForTests();
+    McpRequestContext.clear();
+  }
+
+  /**
+   * Binds an authenticated principal in the shared tenant.
+   *
+   * @param subject the subject identifier
+   */
+  private void authenticateAs(String subject) {
+    McpRequestContext.set(
+        McpRequestContext.Principal.ofClaims(subject, SHARED_TENANT, Collections.<String>emptySet(), "test-issuer"));
+  }
+
+  /**
+   * Builds a minimal valid single-area definition carrying a recognisable pressure.
+   *
+   * @param pressureBara the feed pressure used as a content marker
+   * @return the process definition JSON
+   */
+  private static String processJson(double pressureBara) {
+    return "{\"fluid\": {\"components\": {\"methane\": 0.9, \"ethane\": 0.1}, \"model\": \"SRK\","
+        + " \"temperature_C\": 25.0, \"pressure_bara\": " + pressureBara + "}, \"process\": ["
+        + "{\"type\": \"stream\", \"name\": \"feed\", \"flowRate\": {\"value\": 1000.0, \"unit\": \"kg/hr\"}},"
+        + "{\"type\": \"separator\", \"name\": \"sep\", \"inlet\": \"feed\"}]}";
+  }
+
+  /**
+   * Registers a definition for the currently bound principal.
+   *
+   * @param name the model name
+   * @param definition the process definition JSON
+   * @return the raw registration response
+   */
+  private static String registerResponse(String name, String definition) {
+    return ModelRegistry.run("{\"action\": \"register\", \"name\": \"" + name + "\", \"processJson\": "
+        + JsonParser.parseString(definition) + "}");
+  }
+
+  /**
+   * Registers a definition for the currently bound principal and returns its handle.
+   *
+   * @param name the model name
+   * @param definition the process definition JSON
+   * @return the issued model id
+   */
+  private static String register(String name, String definition) {
+    String response = registerResponse(name, definition);
+    JsonObject root = JsonParser.parseString(response).getAsJsonObject();
+    assertEquals("success", root.get("status").getAsString(), "Registration must succeed: " + response);
+    return root.get("modelId").getAsString();
+  }
+
+  /**
+   * Runs a single-handle action for the currently bound principal.
+   *
+   * @param action the registry action
+   * @param modelId the model handle
+   * @return the raw response
+   */
+  private static String act(String action, String modelId) {
+    return ModelRegistry.run("{\"action\": \"" + action + "\", \"modelId\": \"" + modelId + "\"}");
+  }
+
+  /**
+   * Asserts that a response refused the request as an unknown handle without disclosing the real owner or content.
+   *
+   * @param action the attempted action, used in assertion messages
+   * @param response the raw response
+   */
+  private static void assertRefusedAsUnknown(String action, String response) {
+    JsonObject root = JsonParser.parseString(response).getAsJsonObject();
+    assertEquals("error", root.get("status").getAsString(), action + " must be refused: " + response);
+    assertEquals("UNKNOWN_MODEL", root.get("code").getAsString(),
+        action + " must look like an unknown handle, not a forbidden one: " + response);
+    assertFalse(response.contains("alice"), action + " must not disclose the owner: " + response);
+    assertFalse(response.contains(OWNED_MODEL_NAME), action + " must not disclose the model name: " + response);
+    assertFalse(response.contains("separator"), action + " must not disclose the definition: " + response);
+  }
+
+  /**
+   * Reading another principal's model must fail even though both callers share one directory tenant.
+   */
+  @Test
+  @DisplayName("get is refused for a model owned by another principal in the same tenant")
+  void testGetIsRefusedForAnotherOwner() {
+    authenticateAs("alice");
+    String modelId = register(OWNED_MODEL_NAME, processJson(50.0));
+
+    authenticateAs("bob");
+    assertRefusedAsUnknown("get", act("get", modelId));
+  }
+
+  /**
+   * Structure disclosure is disclosure: inspect must be refused as well.
+   */
+  @Test
+  @DisplayName("inspect is refused for a model owned by another principal")
+  void testInspectIsRefusedForAnotherOwner() {
+    authenticateAs("alice");
+    String modelId = register(OWNED_MODEL_NAME, processJson(50.0));
+
+    authenticateAs("bob");
+    assertRefusedAsUnknown("inspect", act("inspect", modelId));
+  }
+
+  /**
+   * The worst case: a foreign revision would make the owner's next run answer from someone else's edits, and the
+   * result would look entirely normal. The stored definition must be untouched.
+   */
+  @Test
+  @DisplayName("revise is refused for another principal and leaves the owner's definition intact")
+  void testReviseIsRefusedForAnotherOwner() {
+    authenticateAs("alice");
+    String modelId = register(OWNED_MODEL_NAME, processJson(50.0));
+
+    authenticateAs("bob");
+    String tampered = ModelRegistry.run("{\"action\": \"revise\", \"modelId\": \"" + modelId + "\", \"processJson\": "
+        + JsonParser.parseString(processJson(90.0)) + "}");
+    assertRefusedAsUnknown("revise", tampered);
+
+    authenticateAs("alice");
+    String stored = ModelRegistry.resolve(modelId);
+    assertTrue(stored.contains("50.0"), "The owner's definition must be unchanged: " + stored);
+    assertFalse(stored.contains("90.0"), "Another principal's edit must not reach the owner's model: " + stored);
+    assertEquals(1, JsonParser.parseString(act("get", modelId)).getAsJsonObject().get("revision").getAsInt(),
+        "A refused revision must not increment the revision");
+  }
+
+  /**
+   * Deletion by a non-owner must be refused and must not remove the model.
+   */
+  @Test
+  @DisplayName("delete is refused for another principal and leaves the model registered")
+  void testDeleteIsRefusedForAnotherOwner() {
+    authenticateAs("alice");
+    String modelId = register(OWNED_MODEL_NAME, processJson(50.0));
+
+    authenticateAs("bob");
+    assertRefusedAsUnknown("delete", act("delete", modelId));
+
+    authenticateAs("alice");
+    assertTrue(ModelRegistry.resolve(modelId).contains("50.0"), "The owner's model must survive a refused delete");
+  }
+
+  /**
+   * Listing must not become an inventory of everyone's models.
+   */
+  @Test
+  @DisplayName("list returns only the caller's own models")
+  void testListIsScopedToTheOwner() {
+    authenticateAs("alice");
+    register(OWNED_MODEL_NAME, processJson(50.0));
+
+    authenticateAs("bob");
+    register("bob-flowsheet", processJson(70.0));
+    String response = ModelRegistry.run("{\"action\": \"list\"}");
+    JsonObject root = JsonParser.parseString(response).getAsJsonObject();
+    JsonArray models = root.getAsJsonArray("models");
+
+    assertEquals(1, root.get("count").getAsInt(), "Only the caller's own model must be listed: " + response);
+    assertEquals(1, models.size(), response);
+    assertEquals("bob", models.get(0).getAsJsonObject().get("owner").getAsString(), response);
+    assertFalse(response.contains(OWNED_MODEL_NAME), "Listing must not expose another owner's model: " + response);
+
+    authenticateAs("alice");
+    JsonObject own = JsonParser.parseString(ModelRegistry.run("{\"action\": \"list\"}")).getAsJsonObject();
+    assertEquals(1, own.get("count").getAsInt(), "The owner must still see her own model");
+    assertEquals(OWNED_MODEL_NAME, own.getAsJsonArray("models").get(0).getAsJsonObject().get("name").getAsString());
+  }
+
+  /**
+   * Resolution is the path every process-taking tool uses when a handle is passed instead of inline JSON, so it is the
+   * path that must not hand another principal's flowsheet to runProcess and friends.
+   */
+  @Test
+  @DisplayName("resolve refuses a handle owned by another principal")
+  void testResolveIsRefusedForAnotherOwner() {
+    authenticateAs("alice");
+    final String modelId = register(OWNED_MODEL_NAME, processJson(50.0));
+
+    authenticateAs("bob");
+    IllegalArgumentException error = assertThrows(IllegalArgumentException.class, new Executable() {
+      @Override
+      public void execute() {
+        ModelRegistry.resolve(modelId);
+      }
+    }, "Another principal must not resolve the handle");
+    assertTrue(error.getMessage().startsWith("Unknown model handle"),
+        "Refusal must read as an unknown handle: " + error.getMessage());
+    assertFalse(error.getMessage().contains("alice"), "Refusal must not disclose the owner: " + error.getMessage());
+  }
+
+  /**
+   * The cached-solve path must be guarded too, otherwise the automation tools would read a solved flowsheet that the
+   * caller was never allowed to see.
+   */
+  @Test
+  @DisplayName("solvedProcess refuses a handle owned by another principal")
+  void testSolvedProcessIsRefusedForAnotherOwner() {
+    authenticateAs("alice");
+    final String modelId = register(OWNED_MODEL_NAME, processJson(50.0));
+
+    authenticateAs("bob");
+    assertThrows(IllegalArgumentException.class, new Executable() {
+      @Override
+      public void execute() {
+        ModelRegistry.solvedProcess(modelId);
+      }
+    }, "Another principal must not reach the solved flowsheet");
+  }
+
+  /**
+   * An unresolved caller must fail closed rather than fall into a bucket shared with named principals. A token
+   * carrying no tenant claim falls back to the same default scope as an unbound caller, so ownership is the only thing
+   * separating them.
+   */
+  @Test
+  @DisplayName("an anonymous caller cannot reach a named owner's model")
+  void testAnonymousCannotReachANamedOwnersModel() {
+    McpRequestContext
+        .set(McpRequestContext.Principal.ofClaims("alice", null, Collections.<String>emptySet(), "test-issuer"));
+    final String modelId = register(OWNED_MODEL_NAME, processJson(50.0));
+
+    McpRequestContext.clear();
+    assertRefusedAsUnknown("get", act("get", modelId));
+    assertRefusedAsUnknown("delete", act("delete", modelId));
+    assertEquals(0, JsonParser.parseString(ModelRegistry.run("{\"action\": \"list\"}")).getAsJsonObject().get("count")
+        .getAsInt(), "An anonymous caller must not see a named principal's models");
+    assertThrows(IllegalArgumentException.class, new Executable() {
+      @Override
+      public void execute() {
+        ModelRegistry.resolve(modelId);
+      }
+    });
+
+    McpRequestContext.set(McpRequestContext.Principal.ofApiKey("service-key-1234"));
+    assertRefusedAsUnknown("get", act("get", modelId));
+  }
+
+  /**
+   * A refusal must be indistinguishable from a handle that was never registered, so the registry cannot be used to
+   * test whether a given model exists.
+   */
+  @Test
+  @DisplayName("a refused handle is indistinguishable from an unknown handle")
+  void testRefusalIsNotAnEnumerationOracle() {
+    authenticateAs("alice");
+    String modelId = register(OWNED_MODEL_NAME, processJson(50.0));
+
+    authenticateAs("bob");
+    String unknownId = ModelRegistry.MODEL_ID_PREFIX + "0123456789abcdef";
+    JsonObject real = JsonParser.parseString(act("get", modelId)).getAsJsonObject();
+    JsonObject unknown = JsonParser.parseString(act("get", unknownId)).getAsJsonObject();
+
+    assertEquals(unknown.get("code").getAsString(), real.get("code").getAsString(),
+        "An existing handle must not be distinguishable by error code");
+    assertEquals(unknown.get("message").getAsString().replace(unknownId, modelId), real.get("message").getAsString(),
+        "An existing handle must not be distinguishable by message");
+    assertEquals(unknown.get("remediation").getAsString(), real.get("remediation").getAsString(),
+        "An existing handle must not be distinguishable by remediation");
+  }
+
+  /**
+   * Ownership must restrict other principals only — the owner keeps the full lifecycle.
+   */
+  @Test
+  @DisplayName("the owner retains get, inspect, revise, list and delete")
+  void testOwnerRetainsFullAccess() {
+    authenticateAs("alice");
+    final String modelId = register(OWNED_MODEL_NAME, processJson(50.0));
+
+    assertEquals("success", JsonParser.parseString(act("get", modelId)).getAsJsonObject().get("status").getAsString());
+    assertEquals("success",
+        JsonParser.parseString(act("inspect", modelId)).getAsJsonObject().get("status").getAsString());
+
+    String revised = ModelRegistry.run("{\"action\": \"revise\", \"modelId\": \"" + modelId + "\", \"processJson\": "
+        + JsonParser.parseString(processJson(70.0)) + "}");
+    JsonObject revision = JsonParser.parseString(revised).getAsJsonObject();
+    assertEquals("success", revision.get("status").getAsString(), revised);
+    assertEquals(2, revision.get("revision").getAsInt(), revised);
+    assertTrue(ModelRegistry.resolve(modelId).contains("70.0"), "The owner must resolve her own revision");
+
+    assertEquals(1,
+        JsonParser.parseString(ModelRegistry.run("{\"action\": \"list\"}")).getAsJsonObject().get("count").getAsInt());
+    assertEquals("success",
+        JsonParser.parseString(act("delete", modelId)).getAsJsonObject().get("status").getAsString());
+    assertThrows(IllegalArgumentException.class, new Executable() {
+      @Override
+      public void execute() {
+        ModelRegistry.resolve(modelId);
+      }
+    });
+  }
+
+  /**
+   * Handles are content-derived, so two principals registering the same flowsheet must still get independent entries;
+   * otherwise one caller's revision would silently change what the other resolves.
+   */
+  @Test
+  @DisplayName("identical definitions registered by two principals stay independent")
+  void testIdenticalDefinitionsStayIndependentPerOwner() {
+    authenticateAs("alice");
+    String aliceModel = register(OWNED_MODEL_NAME, processJson(50.0));
+
+    authenticateAs("bob");
+    String response = registerResponse("bob-copy", processJson(50.0));
+    JsonObject registered = JsonParser.parseString(response).getAsJsonObject();
+    assertEquals("success", registered.get("status").getAsString(), response);
+    assertEquals("bob", registered.get("owner").getAsString(),
+        "Registering identical content must not hand back another principal's record: " + response);
+    assertEquals("bob-copy", registered.get("name").getAsString(), response);
+    String bobModel = registered.get("modelId").getAsString();
+
+    ModelRegistry.run("{\"action\": \"revise\", \"modelId\": \"" + bobModel + "\", \"processJson\": "
+        + JsonParser.parseString(processJson(90.0)) + "}");
+    assertTrue(ModelRegistry.resolve(bobModel).contains("90.0"), "Bob must resolve his own revision");
+
+    authenticateAs("alice");
+    String stored = ModelRegistry.resolve(aliceModel);
+    assertTrue(stored.contains("50.0"), "Alice must still resolve her own definition: " + stored);
+    assertFalse(stored.contains("90.0"), "Another principal's revision must not reach Alice's model: " + stored);
+  }
+
+  /**
+   * Single-user desktop use has no bound identity, and must keep working exactly as before.
+   */
+  @Test
+  @DisplayName("unauthenticated desktop use keeps the full model lifecycle")
+  void testAnonymousDesktopUseIsUnchanged() {
+    McpRequestContext.clear();
+    final String modelId = register("desktop-model", processJson(50.0));
+
+    assertEquals("success", JsonParser.parseString(act("get", modelId)).getAsJsonObject().get("status").getAsString());
+    assertEquals("success",
+        JsonParser.parseString(act("inspect", modelId)).getAsJsonObject().get("status").getAsString());
+    assertTrue(ModelRegistry.resolve(modelId).contains("50.0"), "A desktop caller must resolve its own handle");
+    assertEquals(1,
+        JsonParser.parseString(ModelRegistry.run("{\"action\": \"list\"}")).getAsJsonObject().get("count").getAsInt(),
+        "A desktop caller must see the model it registered");
+    assertEquals(modelId, register("desktop-model", processJson(50.0)),
+        "Registration must stay idempotent for one caller");
+    assertEquals("success",
+        JsonParser.parseString(act("delete", modelId)).getAsJsonObject().get("status").getAsString());
+  }
+}


### PR DESCRIPTION
Follow-up to #2874 / #2875, found while getting a real 156-operation asset flowsheet running through the hosted MCP server. Three commits: one security fix, one hygiene fix, one missing regression test.

## 1. Registered models are scoped to the tenant, not the owner

`ModelRegistry` keys entries by the tenant from `McpIdentityResolver`, which reads the JWT `tid` claim. A directory tenant is one whole organisation — every employee shares it — so tenant alone is not an isolation boundary. `owner` was recorded at registration but never checked in `resolve()`, `lookup()`, `list()` or the `register` dedupe.

On a hosted deployment with several authenticated users that means any user can `list` every model handle, `get` another user's process definition, `delete` it, or `revise` it. `revise` is the one that concerns me most: the owner's next read resolves the edited definition and returns a normal-looking result with full provenance, so a wrong answer is presented as an authoritative one.

The fix enforces owner **and** tenant on every access path, and makes the storage key `tenant \0 owner \0 handle`. That second part matters independently: handles are content-derived, so before this change two principals registering the same flowsheet collapsed onto one record — the second registrant silently received the first one's record, and either party's `revise` changed what the other resolved.

A handle owned by someone else is reported as **unknown**, reusing the existing `UNKNOWN_MODEL` envelope, rather than as forbidden — so the registry cannot be used to enumerate other users' models.

Anonymous callers fail closed: they keep working for single-user desktop/STDIO use, but cannot reach anything registered by a named principal.

## 2. The thread-bound principal is never released

`McpRequestContext` documents a finally-clear contract — "so pooled threads never leak identity" — but `clear()` was only ever called from tests. `McpRequestContext` itself needed no change; the caller did. Every tool now releases the binding in a `finally`.

Not a demonstrated authorization bypass, since each tool rebinds on entry and fails closed to anonymous. It is a contract violation that leaves the previous caller's subject resident on idle pooled worker threads, which is worth avoiding on a server handling per-user delegated identities.

Verified at the bytecode level rather than by eye: `javap -c` shows every one of the 70 methods calling `clear()` carries a catch-all entry covering the body, the catch block and the handler, so an `Error` escaping a solver also releases identity.

## 3. No test covered the STUDY_TEAM tier promise

`McpSecurityEnforcementTest` pins `DESKTOP_ENGINEER`. The behaviour that hosted deployments actually depend on — STUDY_TEAM permits Tier 1 + Tier 2 and blocks Tier 3 at call time — had no coverage.

The new test asserts all 14 experimental tools are blocked with the full refusal envelope, every Tier‑1 and Tier‑2 tool is allowed, and pins `manageModel` as `TRUSTED_CORE`/`EXECUTION` so a future retiering fails loudly. `activeMode` is process-global, so it is captured and restored in both `@AfterEach` and `@AfterAll`; the whole `neqsim.mcp.**` package passes unchanged.

## An open design question, and one thing I did not fix

**Shared or private?** I have enforced ownership on *all* operations, which is clearly right for `revise` and `delete`. Read access is a genuine product decision: if the model library is meant to be a shared team resource, then private mutation with shared `list`/`get` may fit better than full isolation. I am happy to change the semantics — say which you prefer.

**Handles never reach the solved-model cache.** Every tool wraps its argument in `resolveModel()` before calling the runner, which converts a handle back into inline JSON, so `AutomationRunner.solvedProcess`'s `isModelHandle` branch never fires and each read re-solves. For a large flowsheet behind a request timeout that removes most of the benefit of registering a model. It is pre-existing and out of scope here, but worth a look — and note `ModelRegistryTest` does not catch it because it passes the handle straight to `AutomationRunner`, a path the server does not take.

**Separately:** deploying 3.17.0 with `QUARKUS_PROFILE=enterprise` behind a TLS-terminating ingress fails at startup — `%enterprise.quarkus.http.insecure-requests=redirect` with no keystore makes Quarkus 3.37 throw *"Cannot set quarkus.http.insecure-requests without enabling SSL"*. Reproducible with the published image. We worked around it with `QUARKUS_HTTP_INSECURE_REQUESTS=enabled`, but anyone running that profile hosted will hit it.

## Testing

86 tests pass across `ModelRegistryOwnerScopingTest` (12, new), `ModelRegistryTest` (17), `McpSecurityStudyTeamProfileTest` (5, new), `McpSecurityEnforcementTest` (6), `McpPrincipalScopingTest` (7) and `IndustrialProfileTest` (39), in both alphabetical and reverse order.

Negative control on the security fix: reverting only `ModelRegistry.java` fails 10 of the 12 new tests — the two that still pass are the backward-compatibility guards.

Core files stay Java 8 compatible.
