### PR TITLE
[AI-Assisted] Reduce ProcessModel convergence diagnostic allocation

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -2807,7 +2807,9 @@ public class ProcessModel implements Runnable, Serializable {
     double maxFlowErr = 0.0;
     double maxTempErr = 0.0;
     double maxPressErr = 0.0;
-    List<BoundaryStreamError> streamErrors = new ArrayList<>();
+    int expectedStreamErrors = lastBoundaryStreamErrors == null ? 0
+        : Math.min(current.size(), lastBoundaryStreamErrors.size());
+    List<BoundaryStreamError> streamErrors = new ArrayList<>(expectedStreamErrors);
 
     for (Object key : current.keySet()) {
       if (previous.containsKey(key)) {

--- a/src/test/java/neqsim/process/processmodel/ProcessModelConvergenceFilterTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessModelConvergenceFilterTest.java
@@ -150,6 +150,23 @@ public class ProcessModelConvergenceFilterTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  public void repeatedDiagnosticsFollowCurrentFlowFloor() {
+    ProcessModel model = new ProcessModel();
+
+    model.calculateConvergenceErrors(previousStates(), currentStates());
+    assertEquals(2, model.getLastBoundaryStreamErrors().size());
+
+    model.setBoundaryFlowFloor(1.0);
+    model.calculateConvergenceErrors(previousStates(), currentStates());
+    assertEquals(1, model.getLastBoundaryStreamErrors().size());
+    assertEquals("NGL mixer mixed stream", model.getLastBoundaryStreamErrors().get(0).getStreamName());
+
+    model.setBoundaryFlowFloor(ProcessModel.DEFAULT_BOUNDARY_FLOW_FLOOR);
+    model.calculateConvergenceErrors(previousStates(), currentStates());
+    assertEquals(2, model.getLastBoundaryStreamErrors().size());
+  }
+
+  @Test
   public void absoluteFlowToleranceIgnoresNegligibleAbsoluteChange() {
     ProcessModel model = new ProcessModel();
     model.setAbsoluteFlowTolerance(1.0);


### PR DESCRIPTION
## Problem

`ProcessModel.calculateConvergenceErrors(...)` creates one `BoundaryStreamError` for every active inter-area stream on every outer convergence iteration. The diagnostic `ArrayList` was created with the default capacity, so representative large models repeatedly grew and copied its backing array even though the previous iteration already exposed a useful cardinality estimate.

The current map size is not a safe exact sizing target because `boundaryFlowFloor` can filter most entries.

## Change

Pre-size the next diagnostic list from the previous completed diagnostic count, capped by the current state-map size.

- the first calculation retains the existing default allocation behavior;
- subsequent calculations reuse only an instance-local observation;
- changing the flow floor remains supported and adapts after one calculation;
- ordering, filtering, error equations, tolerance decisions, and the published immutable diagnostic snapshot are unchanged;
- no static/shared cache is introduced.

A regression now exercises repeated calculations while changing the flow floor from default -> filtering -> default and verifies the exact diagnostic cardinality and stream identity on every pass.

## Benchmark methodology

Baseline: `ProcessModel` from exact current `master` commit `b8f6872e924b8dbfa14141e8025951bb92f094c1` (its blob is unchanged from the measured `4b92a15b56ad44d67706cec4da0a8493f1f95f47` baseline).
Candidate: this branch, with only the two files in this PR changed.

Environment: OpenJDK 17.0.19, Linux x86_64, `-Xms/-Xmx` fixed per workload. A package-local standalone harness calls the exact `calculateConvergenceErrors` execution path on stable identity-keyed maps. Each variant is warmed up, then measured in a fresh JVM fork. `System.nanoTime()` records throughput and `com.sun.management.ThreadMXBean.getThreadAllocatedBytes(...)` records allocation. Seven alternating baseline/candidate fork pairs were used. Checksums and resulting diagnostic cardinality were compared in every fork; no wall-clock assertion was added to the test suite.

| Workload | Warmup / measured per fork | Baseline median | Candidate median | Time | Allocation / iteration |
| --- | ---: | ---: | ---: | ---: | ---: |
| 4,500 active streams | 300 / 1,000 | 1,814,328 ns | 1,555,562 ns | **-14.26%** (7/7 faster) | 363,312 -> 306,112 B (**-15.75%**) |
| 900 active streams | 1,000 / 3,000 | 260,017 ns | 238,978 ns | **-8.09%** (5/7 faster) | 72,696 -> 61,312 B (**-15.66%**) |
| 4,500 mapped, 450 active after flow-floor filtering | 500 / 1,500 | 416,515 ns | 412,051 ns | **-1.07%** (5/7 faster) | 35,632 -> 30,712 B (**-13.81%**) |

The 4,500-stream result removes exactly 57,200 allocated bytes per iteration. Every fork produced exactly the expected number of diagnostics and the same `0.130000000000` checksum.

## Correctness and robustness

- diagnostic calculations, iteration order, convergence maxima, and filter semantics are not modified;
- the capacity hint cannot alter thermodynamic state, flashes, physical-property initialization, mass/energy balances, phase behavior, or convergence decisions;
- the hint is bounded by current input cardinality and remains per-`ProcessModel`, preserving thread-safety characteristics;
- regression explicitly covers repeated-run behavior across changing filter cardinality;
- public API and serialized fields are unchanged.

## Validation

- `ProcessModelConvergenceFilterTest` plus boundary diagnostics, execution optimization, low-flow parallel trains, and serialization suites: **45 tests, 45 passed, 0 failed/skipped**
- `python devtools/run_spotless.py apply`: exit 0; repeated apply produced no content changes
- `python devtools/run_spotless.py check`: exit 0
- `python devtools/check_documentation_search.py`: exit 0; 648 Markdown pages and 1 standalone HTML page audited
- `pre-commit run --all-files --hook-stage pre-commit`: exit 0
- `pre-commit run --all-files --hook-stage pre-push`: exit 0

After synchronizing the branch onto `b8f6872e924b8dbfa14141e8025951bb92f094c1`, all direct gates and the 45 tests above were rerun successfully. The focused/adjacent tests were compiled against the published NeqSim 3.17.0 shaded artifact with the exact candidate `ProcessModel` overlaid because this isolated runtime could not resolve general Maven dependencies from the JVM. Hosted CI is expected to provide the full repository build and test matrix before readiness is assessed.

## Documentation impact

Documentation impact: none. This is a private backing-array capacity hint with no user-visible API, configuration, defaults, convergence semantics, numerical result, or operational workflow change.

## Limitations

- No benefit is expected on the first diagnostic calculation.
- The wall-clock benefit is deliberately small when most mapped streams are filtered; the allocation reduction remains measurable.
- This does not reduce the number of boundary comparisons or change convergence logic.