### PR TITLE
perf(flash): cache fugacity coefficients in multiphase beta objective

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -35,7 +35,7 @@ public class TPmultiflash extends TPflash {
   boolean multiPhaseTest = false;
   double[][] dQdbeta;
   double[][] Qmatrix;
-  private double[][] inverseFugacityCoefficients;
+  private double[][] fugacityCoefficients;
   double[] Erow;
   double Q = 0;
   boolean doStabilityAnalysis = true;
@@ -87,7 +87,7 @@ public class TPmultiflash extends TPflash {
   public void setDoubleArrays() {
     dQdbeta = new double[system.getNumberOfPhases()][1];
     Qmatrix = new double[system.getNumberOfPhases()][system.getNumberOfPhases()];
-    inverseFugacityCoefficients = new double[system.getNumberOfPhases()][system.getPhase(0).getNumberOfComponents()];
+    fugacityCoefficients = new double[system.getNumberOfPhases()][system.getPhase(0).getNumberOfComponents()];
   }
 
   /**
@@ -165,7 +165,7 @@ public class TPmultiflash extends TPflash {
      * double betaTotal = 0; for (int k = 0; k < system.getNumberOfPhases(); k++) { betaTotal +=
      * system.getPhase(k).getBeta(); } Q = betaTotal;
      */
-    calcEAndCacheInverseFugacityCoefficients();
+    calcEAndCacheFugacityCoefficients();
     /*
      * for (int i = 0; i < system.getPhase(0).getNumberOfComponents(); i++) { Q -= Math.log(E[i]) *
      * system.getPhase(0).getComponent(i).getz(); }
@@ -179,7 +179,7 @@ public class TPmultiflash extends TPflash {
     for (int k = 0; k < system.getNumberOfPhases(); k++) {
       dQdbeta[k][0] = 1.0;
       for (int i = 0; i < system.getPhase(0).getNumberOfComponents(); i++) {
-        dQdbeta[k][0] -= multTerm[i] * inverseFugacityCoefficients[k][i];
+        dQdbeta[k][0] -= multTerm[i] / fugacityCoefficients[k][i];
       }
     }
 
@@ -187,7 +187,7 @@ public class TPmultiflash extends TPflash {
       for (int j = 0; j < system.getNumberOfPhases(); j++) {
         Qmatrix[i][j] = 0.0;
         for (int k = 0; k < system.getPhase(0).getNumberOfComponents(); k++) {
-          Qmatrix[i][j] += multTerm2[k] * inverseFugacityCoefficients[j][k] * inverseFugacityCoefficients[i][k];
+          Qmatrix[i][j] += multTerm2[k] / (fugacityCoefficients[j][k] * fugacityCoefficients[i][k]);
         }
         if (i == j) {
           double reg = 1.0e-3;
@@ -208,16 +208,20 @@ public class TPmultiflash extends TPflash {
   }
 
   /**
-   * Calculate the phase-split denominator and cache inverse fugacity coefficients for the gradient and Hessian.
+   * Calculate the phase-split denominator and cache fugacity coefficients for the gradient and Hessian.
+   *
+   * <p>
+   * Retaining the original division sequence is intentional. Algebraically equivalent reciprocal multiplication changes
+   * rounding in repeated reservoir flashes and can alter accepted system-level trajectories.
+   * </p>
    */
-  private void calcEAndCacheInverseFugacityCoefficients() {
+  private void calcEAndCacheFugacityCoefficients() {
     for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
       Erow[component] = 0.0;
       for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
-        double inverseFugacityCoefficient = 1.0
-            / system.getPhase(phase).getComponent(component).getFugacityCoefficient();
-        inverseFugacityCoefficients[phase][component] = inverseFugacityCoefficient;
-        Erow[component] += system.getPhase(phase).getBeta() * inverseFugacityCoefficient;
+        double fugacityCoefficient = system.getPhase(phase).getComponent(component).getFugacityCoefficient();
+        fugacityCoefficients[phase][component] = fugacityCoefficient;
+        Erow[component] += system.getPhase(phase).getBeta() / fugacityCoefficient;
       }
       if (Erow[component] < 1e-100) {
         Erow[component] = 1e-100;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -35,6 +35,7 @@ public class TPmultiflash extends TPflash {
   boolean multiPhaseTest = false;
   double[][] dQdbeta;
   double[][] Qmatrix;
+  private double[][] inverseFugacityCoefficients;
   double[] Erow;
   double Q = 0;
   boolean doStabilityAnalysis = true;
@@ -86,6 +87,7 @@ public class TPmultiflash extends TPflash {
   public void setDoubleArrays() {
     dQdbeta = new double[system.getNumberOfPhases()][1];
     Qmatrix = new double[system.getNumberOfPhases()][system.getNumberOfPhases()];
+    inverseFugacityCoefficients = new double[system.getNumberOfPhases()][system.getPhase(0).getNumberOfComponents()];
   }
 
   /**
@@ -163,7 +165,7 @@ public class TPmultiflash extends TPflash {
      * double betaTotal = 0; for (int k = 0; k < system.getNumberOfPhases(); k++) { betaTotal +=
      * system.getPhase(k).getBeta(); } Q = betaTotal;
      */
-    this.calcE();
+    calcEAndCacheInverseFugacityCoefficients();
     /*
      * for (int i = 0; i < system.getPhase(0).getNumberOfComponents(); i++) { Q -= Math.log(E[i]) *
      * system.getPhase(0).getComponent(i).getz(); }
@@ -177,7 +179,7 @@ public class TPmultiflash extends TPflash {
     for (int k = 0; k < system.getNumberOfPhases(); k++) {
       dQdbeta[k][0] = 1.0;
       for (int i = 0; i < system.getPhase(0).getNumberOfComponents(); i++) {
-        dQdbeta[k][0] -= multTerm[i] / system.getPhase(k).getComponent(i).getFugacityCoefficient();
+        dQdbeta[k][0] -= multTerm[i] * inverseFugacityCoefficients[k][i];
       }
     }
 
@@ -185,8 +187,7 @@ public class TPmultiflash extends TPflash {
       for (int j = 0; j < system.getNumberOfPhases(); j++) {
         Qmatrix[i][j] = 0.0;
         for (int k = 0; k < system.getPhase(0).getNumberOfComponents(); k++) {
-          Qmatrix[i][j] += multTerm2[k] / (system.getPhase(j).getComponent(k).getFugacityCoefficient()
-              * system.getPhase(i).getComponent(k).getFugacityCoefficient());
+          Qmatrix[i][j] += multTerm2[k] * inverseFugacityCoefficients[j][k] * inverseFugacityCoefficients[i][k];
         }
         if (i == j) {
           double reg = 1.0e-3;
@@ -204,6 +205,28 @@ public class TPmultiflash extends TPflash {
       }
     }
     return Q;
+  }
+
+  /**
+   * Calculate the phase-split denominator and cache inverse fugacity coefficients for the gradient and Hessian.
+   */
+  private void calcEAndCacheInverseFugacityCoefficients() {
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
+      Erow[component] = 0.0;
+      for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+        double inverseFugacityCoefficient = 1.0
+            / system.getPhase(phase).getComponent(component).getFugacityCoefficient();
+        inverseFugacityCoefficients[phase][component] = inverseFugacityCoefficient;
+        Erow[component] += system.getPhase(phase).getBeta() * inverseFugacityCoefficient;
+      }
+      if (Erow[component] < 1e-100) {
+        Erow[component] = 1e-100;
+      }
+      if (Double.isNaN(Erow[component])) {
+        logger.error("Erow is NaN for component " + system.getPhase(0).getComponent(component).getName());
+        Erow[component] = 1e-100;
+      }
+    }
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
@@ -266,9 +266,9 @@ class TPmultiflashTest {
     assertTrue(Double.isFinite(correction.get(1, 0)));
   }
 
-  /** Verifies the beta objective reuses current inverse fugacity coefficients without changing its equations. */
+  /** Verifies the beta objective reuses current fugacity coefficients without changing its equations. */
   @Test
-  void testCalcQRefreshesInverseFugacityCoefficientCache() {
+  void testCalcQRefreshesFugacityCoefficientCache() {
     SystemInterface system = createMethaneHeptanePrSystem(0.0, false);
     system.setTemperature(250.0, "K");
     system.setPressure(30.0, "bara");
@@ -313,7 +313,7 @@ class TPmultiflashTest {
         double fugacityCoefficient = system.getPhase(phase).getComponent(component).getFugacityCoefficient();
         expectedGradient -= feedFraction / denominator[component] / fugacityCoefficient;
       }
-      assertEquals(expectedGradient, operation.dQdbeta[phase][0], 1.0e-14);
+      assertEquals(expectedGradient, operation.dQdbeta[phase][0]);
 
       for (int otherPhase = 0; otherPhase < numberOfPhases; otherPhase++) {
         double expectedHessian = 0.0;
@@ -322,13 +322,13 @@ class TPmultiflashTest {
           double phaseFugacityCoefficient = system.getPhase(phase).getComponent(component).getFugacityCoefficient();
           double otherPhaseFugacityCoefficient = system.getPhase(otherPhase).getComponent(component)
               .getFugacityCoefficient();
-          expectedHessian += feedFraction / (denominator[component] * denominator[component]) / phaseFugacityCoefficient
-              / otherPhaseFugacityCoefficient;
+          double feedOverDenominatorSquared = feedFraction / (denominator[component] * denominator[component]);
+          expectedHessian += feedOverDenominatorSquared / (otherPhaseFugacityCoefficient * phaseFugacityCoefficient);
         }
         if (phase == otherPhase) {
           expectedHessian += 1.0e-3;
         }
-        assertEquals(expectedHessian, operation.Qmatrix[phase][otherPhase], 1.0e-14);
+        assertEquals(expectedHessian, operation.Qmatrix[phase][otherPhase]);
       }
     }
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
@@ -266,6 +266,73 @@ class TPmultiflashTest {
     assertTrue(Double.isFinite(correction.get(1, 0)));
   }
 
+  /** Verifies the beta objective reuses current inverse fugacity coefficients without changing its equations. */
+  @Test
+  void testCalcQRefreshesInverseFugacityCoefficientCache() {
+    SystemInterface system = createMethaneHeptanePrSystem(0.0, false);
+    system.setTemperature(250.0, "K");
+    system.setPressure(30.0, "bara");
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+
+    assertEquals(2, system.getNumberOfPhases());
+    TPmultiflash operation = new TPmultiflash(system, false);
+    operation.setDoubleArrays();
+    operation.calcQ();
+    assertBetaObjectiveMatchesDirectEvaluation(system, operation);
+
+    double originalFugacityCoefficient = system.getPhase(1).getComponent(0).getFugacityCoefficient();
+    system.getPhase(1).getComponent(0).setFugacityCoefficient(2.0 * originalFugacityCoefficient);
+    operation.calcQ();
+
+    assertBetaObjectiveMatchesDirectEvaluation(system, operation);
+  }
+
+  /**
+   * Compares the cached beta-objective gradient and Hessian with their direct multiphase Rachford-Rice evaluation.
+   *
+   * @param system thermodynamic system supplying phase fractions and fugacity coefficients
+   * @param operation multiflash operation containing the evaluated objective derivatives
+   */
+  private void assertBetaObjectiveMatchesDirectEvaluation(SystemInterface system, TPmultiflash operation) {
+    int numberOfPhases = system.getNumberOfPhases();
+    int numberOfComponents = system.getPhase(0).getNumberOfComponents();
+    double[] denominator = new double[numberOfComponents];
+
+    for (int component = 0; component < numberOfComponents; component++) {
+      for (int phase = 0; phase < numberOfPhases; phase++) {
+        denominator[component] += system.getBeta(phase)
+            / system.getPhase(phase).getComponent(component).getFugacityCoefficient();
+      }
+    }
+
+    for (int phase = 0; phase < numberOfPhases; phase++) {
+      double expectedGradient = 1.0;
+      for (int component = 0; component < numberOfComponents; component++) {
+        double feedFraction = system.getPhase(0).getComponent(component).getz();
+        double fugacityCoefficient = system.getPhase(phase).getComponent(component).getFugacityCoefficient();
+        expectedGradient -= feedFraction / denominator[component] / fugacityCoefficient;
+      }
+      assertEquals(expectedGradient, operation.dQdbeta[phase][0], 1.0e-14);
+
+      for (int otherPhase = 0; otherPhase < numberOfPhases; otherPhase++) {
+        double expectedHessian = 0.0;
+        for (int component = 0; component < numberOfComponents; component++) {
+          double feedFraction = system.getPhase(0).getComponent(component).getz();
+          double phaseFugacityCoefficient = system.getPhase(phase).getComponent(component).getFugacityCoefficient();
+          double otherPhaseFugacityCoefficient = system.getPhase(otherPhase).getComponent(component)
+              .getFugacityCoefficient();
+          expectedHessian += feedFraction / (denominator[component] * denominator[component]) / phaseFugacityCoefficient
+              / otherPhaseFugacityCoefficient;
+        }
+        if (phase == otherPhase) {
+          expectedHessian += 1.0e-3;
+        }
+        assertEquals(expectedHessian, operation.Qmatrix[phase][otherPhase], 1.0e-14);
+      }
+    }
+  }
+
   /** Verifies a direct beta solve preserves a converged two-phase equilibrium and material balance. */
   @Test
   void testDirectBetaSolvePreservesConvergedTwoPhaseState() {


### PR DESCRIPTION
## Problem

`TPmultiflash.calcQ()` evaluates the multiphase phase-fraction objective on every beta Newton iteration. The same phase/component fugacity coefficient was repeatedly retrieved while forming the phase-split denominator, gradient, and Hessian. For `P` phases and `C` components, the Hessian alone performs `2P²C` component-path lookups.

## Reproduced compatibility defect

The initial reciprocal-cache implementation was algebraically equivalent but changed the floating-point sequence from division to multiplication. Two independent Windows Java 21 runs reproduced the same system-level failures:

- `SimpleReservoirTest.testRun2`: expected `355.048269201702 bara` ± `0.1 bara`; obtained `355.23200960538315 bara`.
- `NorwegianOilFieldLifecycleTest.facilityOperatingLimitEndsLifecycleGracefully`: expected `false`; obtained `true`.

The latest exact-head run executed 11,673 fast tests and reproduced exactly those two failures. Intervening master commits did not touch flash or reservoir numerics, isolating the reciprocal reassociation as the cause.

## Final method

The final implementation caches the raw fugacity coefficient `phi[p][i]` once per objective evaluation and reuses it for the gradient and Hessian:

```text
E[i]    = sum_p beta[p] / phi[p][i]
g[p]    = 1 - sum_i (z[i] / E[i]) / phi[p][i]
H[p][q] = sum_i (z[i] / E[i]^2) / (phi[q][i] * phi[p][i]) + regularization
```

This removes repeated phase/component traversal while deliberately retaining the original division and multiplication order. The cache is refreshed on every `calcQ()` call. Objective equations, regularization, Newton steps, stability analysis, phase appearance/disappearance behavior, convergence tolerances, and public APIs remain unchanged.

The regression independently evaluates the denominator, gradient, and Hessian in the accepted operation order, requires bit-identical derivatives, changes one fugacity coefficient, and verifies refresh on the next call.

## Literature basis

This is an implementation optimization of the existing multiphase phase-split equations, not a new thermodynamic method:

- Michelsen, “The isothermal flash problem. Part II. Phase-split calculation,” *Fluid Phase Equilibria* 9 (1982), 21–40: https://doi.org/10.1016/0378-3812(82)85002-4
- Okuno, Johns, and Sepehrnoori, “A New Algorithm for Rachford-Rice for Multiphase Compositional Simulation,” *SPE Journal* 15 (2010), 313–325: https://doi.org/10.2118/117752-PA

These papers establish the phase-split/Rachford–Rice context. The performance and compatibility results below are measured NeqSim evidence; no claim is made about proprietary commercial-simulator implementations.

## Before/after benchmarks

Fresh JVM forks used fixed heap (`-Xms1g -Xmx1g`), alternating order, deterministic inputs, and seven paired runs. Master has had no intervening flash-source changes since measurement.

| Case | Baseline median | Compatible cache median | Change | Paired wins |
|---|---:|---:|---:|---:|
| `calcQ`, 2-component PR, 2 phases | 357.737 ns | 214.597 ns | **40.01% faster** | 7/7 |
| `calcQ`, 11-component SRK-CPA, 3 phases | 1264.334 ns | 940.726 ns | **25.59% faster** | 6/7 |
| Complete 11-component SRK-CPA three-phase pass, extended run | 57.531 ms | 57.258 ms | 0.47% faster | 2/7 |

The objective kernel has a clear measured improvement. The extended complete-flash result is reported transparently and is not claimed as a statistically robust end-to-end speedup. Checksums were bit-identical and the cache adds only one phase-by-component table allocated with the existing beta arrays.

## Numerical evidence and tolerances

A deterministic standard-vs-multiphase matrix exercised gas, oil, pure water, hydrocarbon-water, CO2-rich, H2-rich, near-critical, large-volatility-contrast, one-, two-, and three-phase states with SRK, PR, and SRK-CPA/mixing-rule-10. It included repeat flashes and changed temperature/pressure.

- stable one/two-phase cross-algorithm checksum difference: `0.0`;
- repeated-execution checksum difference: `0.0`;
- three-phase component-balance maximum: `6.36e-15`;
- phase-composition normalization maximum: `1.11e-16`;
- log-fugacity equilibrium residual maximum: `1.05e-13`;
- phase fractions remained finite, bounded, and normalized;
- final beta-objective derivative regression: exact equality, no tolerance;
- existing poor-initial-beta and repeated-solve regressions retain `1e-10` solution tolerances.

## Validation

Passed on the exact final formatted contents:

- 71/71 focused and adjacent tests, including all `TPflash*Test`, `TPFlashTest`, and `TPmultiflash*Test` classes plus the two previously failing reservoir/lifecycle methods;
- all 3,148 production sources compiled before the focused suite;
- `python devtools/run_spotless.py apply` — passed repeatedly; final rerun produced stable file hashes;
- `python devtools/run_spotless.py check` — passed;
- `python devtools/check_documentation_search.py` — passed (648 Markdown + 1 standalone HTML source);
- `pre-commit run --all-files --hook-stage pre-commit` — passed;
- `pre-commit run --all-files --hook-stage pre-push` — passed;
- Maven used a task-local repository and the canonical `https://repo.maven.apache.org/maven2/` endpoint.

The earlier exact-head hosted run passed CodeQL, Spotless, pre-commit, PaperLab, Javadocs, and two slow shards. Its Windows failure is the defect fixed by the latest commit; slow shard 4 separately exceeded an existing hydrate wall-clock threshold (23.112 s versus 20 s). Hosted CI is rerunning on the repaired head.

## Compatibility and risk

Risk is low and localized to private beta-objective storage and lookups. The accepted floating-point operations and outputs are preserved exactly. No serialized/public state, EOS behavior, stability criterion, phase ordering, convergence tolerance, or user API changes.

The final diff contains only `TPmultiflash.java` and `TPmultiflashTest.java`.

## Documentation impact

Documentation impact: none. This is a private lookup optimization with unchanged equations, configuration, tolerances, public API, and user-visible thermodynamic behavior. The implementation Javadoc records why the original arithmetic order must be retained.