### PR TITLE
[AI-Assisted] Add DEXPI Process topology evidence

### DIFF
--- a/docs/integration/dexpi-20-conformance.md
+++ b/docs/integration/dexpi-20-conformance.md
@@ -37,6 +37,33 @@ Files.write(Paths.get("gas-processing-pfd.conformance.json"),
     report.toJson().getBytes(StandardCharsets.UTF_8));
 ```
 
+For a migration or regression gate, also compare the supported material topology with the shared
+canonical diagram graph:
+
+```java
+Dexpi20ProcessTopologyAssessment.Report topology =
+    Dexpi20ProcessModelWriter.writeAndAssessTopology(
+        process, exchange, "PLANT-001", "A");
+if (!topology.isSchemaProfileAndSupportedTopologyValid()) {
+  throw new IllegalStateException(topology.getDiagnostics().toString());
+}
+Files.write(Paths.get("gas-processing-pfd.topology.json"),
+    topology.toJson().getBytes(StandardCharsets.UTF_8));
+```
+
+The topology report records the canonical graph fingerprint and stable connection IDs,
+calculated/review-required source provenance, the canonical and exported directed
+material-connection manifests, every exported stream and its distinct source/target port IDs, and structured diagnostics. Connection comparison
+is multiplicity-sensitive, so two parallel streams between the same steps must remain two streams.
+Synthetic product sinks are retained in the exported-connection inventory but excluded from the
+in-model topology comparison.
+
+The current writer still traverses `ProcessSystem` directly. The assessment is migration evidence,
+not a claim that the writer already consumes the canonical graph. It reports energy and signal
+connections, multi-area `ProcessModel` hierarchy, controlled document/sheet semantics, and drawing
+graphics as unsupported scopes. These warnings do not hide a supported material-topology error;
+missing, unexpected, unresolved-port, and reused-port findings are errors.
+
 Each process connection has a dedicated source and target `MaterialPort`. The ports and
 `Process.Stream` carry reciprocal references, stable identifiers, nominal directions, and explicit
 mass-flow, absolute-pressure, and temperature quantities when finite simulation values are
@@ -96,6 +123,8 @@ Record that separate evidence through `DexpiToolQualificationRunner` and
   accountable semantic-difference review together.
 - Compare the committed native golden fixture and semantic inventory when modifying type mappings,
   topology, units, or serialization order.
+- Retain the canonical topology fingerprint, structured topology report, and source model revision
+  beside the XML and conformance report when using `writeAndAssessTopology(...)`.
 - Treat graphics, project standard-library restrictions, vendor extensions, and CAE certification as
   separate qualification scopes.
 

--- a/docs/process/processmodel/process_diagram_export_inventory.md
+++ b/docs/process/processmodel/process_diagram_export_inventory.md
@@ -33,8 +33,8 @@ API-stability classification.
 | Legacy `ProcessSystem` Graphviz | `ProcessSystem.exportToGraphviz(...)`, `ProcessSystemGraphvizExporter.export(...)` | Equipment stream introspection and export options | Legacy Graphviz file with optional stream values and property table | Retain as a compatibility output; do not silently redirect it through a new model or renderer |
 | Legacy minimal PFD DOT | `ProcessFlowDiagramExporter(ProcessSystem).toDot()` | Shared stream identity plus explicit `ProcessConnection` declarations | Minimal equipment-node/stream-edge DOT | Preserve the constructor and `toDot()` result contract while public callers remain supported |
 | Multi-area Graphviz | `ProcessModel.toDOT()`, `createGraphvizExporter()`, `exportToGraphviz(...)`, `exportAreaDOT(...)`, and `ProcessModelGraphvizExporter` | Ordered areas and shared stream identity | One clustered plant DOT and optional per-area DOT files | Preserve current combined and per-area APIs. Per-area files are compatibility views, not the future controlled multi-sheet document model |
-| Canonical topology adapter | `ProcessDiagramGraphAdapter.fromProcessSystem(...)`, `fromProcessModel(...)` | `ProcessSystem`, explicit connections, and ordered `ProcessModel` areas | Defensive deterministic `EngineeringGraph`, fingerprint, and structured diagnostics | Reuse as the shared topology foundation; it currently has no renderer or DEXPI consumer and remains calculated, review-required evidence |
-| Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter.write(...)`, `writeAndAssess(...)` | Direct `ProcessSystem` equipment and connection traversal | Native DEXPI 2.0 Process XML with steps, material ports, streams, quantities, and conformance report | Preserve the native Process profile and fail-closed assessment; migrate only after semantic-equivalence and loss-report tests pass |
+| Canonical topology adapter | `ProcessDiagramGraphAdapter.fromProcessSystem(...)`, `fromProcessModel(...)` | `ProcessSystem`, explicit connections, and ordered `ProcessModel` areas | Defensive deterministic `EngineeringGraph`, fingerprint, and structured diagnostics | Reuse as the shared topology foundation; DEXPI Process assessment consumes it as an equivalence baseline, while renderers and writers still use their compatibility paths |
+| Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter.write(...)`, `writeAndAssess(...)`, `writeAndAssessTopology(...)` | Direct `ProcessSystem` equipment and connection traversal, compared with the canonical graph by the topology assessment | Native DEXPI 2.0 Process XML with steps, material ports, streams, quantities, conformance report, and optional structured topology evidence | Preserve the native Process profile and fail-closed assessment; migrate traversal only after the equivalence evidence remains green |
 | Native DEXPI 2.0 Plant | `Dexpi20XmlWriter.write(...)`, `writeAndAssess(...)` | Direct `ProcessSystem` engineering/plant mapping | Native DEXPI 2.0 Plant XML and conformance report | Keep separate from Process/PFD exchange and from Proteus compatibility output |
 | Proteus-compatible DEXPI | `DexpiXmlWriter.write(...)`, `writeForPyDexpi(...)`, `write(ProcessModel, ...)`, `writeSheets(...)` | Direct process/engineering mapping plus `DexpiLayoutEngine` | Proteus-compatible P&ID XML, pyDEXPI variant, layouts, and per-area sheets | Preserve import/export compatibility. Combined export flattens areas and logs/skips distinct equipment with duplicate names; per-area sheets expose boundary feeds but do not yet form a controlled, paired-reference document set |
 | Proteus import and simulation reconstruction | `DexpiXmlReader`, `DexpiSimulationBuilder`, `DexpiTopologyResolver`, `DexpiEquipmentFactory` | Imported nozzles, piping segments, equipment, instruments, and mappings | DEXPI/Proteus XML to a runnable `ProcessSystem` with explicit loss and validation boundaries | Keep as the detailed P&ID workflow; do not infer that a simulation-only PFD contains complete piping, valve, nozzle, instrument, or safeguard design |
@@ -64,15 +64,15 @@ source contract has no independent connection ID; the adapter reports
 |---|---:|---:|---:|---:|
 | `ProcessSystem` | Present | Missing | Present | Present |
 | Multi-area `ProcessModel` | Present | Missing | Missing | Present |
-| Stable plant/area/equipment/port/connection IDs through canonical adapter | Present as a separate topology baseline | Foundation only | Not yet consumed | Not yet consumed as the shared graph |
+| Stable plant/area/equipment/port/connection IDs through canonical adapter | Present as a separate topology baseline | Foundation only | Canonical fingerprint and stable topology baseline recorded by assessment; writer IDs remain compatibility-sequential | Not yet consumed as the shared graph |
 | Material, energy, and signal topology | Present in canonical baseline; renderer coverage varies | Missing | Material-focused | Present where supported by the detailed profile |
-| Parallel connection preservation | Golden topology evidence for distinct material/energy/signal endpoints | Missing | Not yet proved against golden cases | Profile-specific tests only |
+| Parallel connection preservation | Golden topology evidence for distinct material/energy/signal endpoints | Missing | Multiplicity-sensitive evidence for supported simple and parallel-branch material cases | Profile-specific tests only |
 | Units and provenance | Optional stream labels/tables; canonical topology provenance | Missing document model | Selected physical quantities with explicit units | Simulation/design metadata and governed package artifacts |
 | Controlled multi-document/multi-sheet hierarchy | Per-area compatibility files only | Missing | Missing | Partial sheet/layout features, not the shared controlled document set |
 | Paired off-page connectors with direction and sheet/grid references | Missing | Missing | Missing | Graphical off-page features exist, but shared connection/document completeness is not qualified |
 | Title/revision blocks and drawing status | Missing controlled model | Missing | Missing | Some rendered metadata exists; full shared revision/status governance remains unqualified |
 | Native rendering without Graphviz | No | Missing | XML only | XML plus external/tool-specific rendering paths |
-| Structured loss diagnostics | Canonical adapter diagnostics | Missing | Conformance assessment, but no canonical topology loss comparison | Reader/writer/engineering validation paths |
+| Structured loss diagnostics | Canonical adapter diagnostics | Missing | Canonical/exported topology comparison plus explicit unsupported energy, signal, multi-area, document, and graphics scopes | Reader/writer/engineering validation paths |
 
 ## Test and example inventory
 
@@ -80,12 +80,12 @@ The following tests are the executable evidence closest to the public paths:
 
 | Evidence | Coverage |
 |---|---|
-| `ProcessDiagramTopologyEquivalenceTest` | Golden simple, parallel/recycle, and multi-area directed topology across `ProcessGraph`, canonical `EngineeringGraph`, PFD DOT, and legacy/multi-area Graphviz projections |
+| `ProcessDiagramTopologyEquivalenceTest`, `ProcessDiagramGoldenFixtures` | Reusable golden simple and parallel-branch manifests plus parallel/recycle and multi-area directed topology across `ProcessGraph`, canonical `EngineeringGraph`, PFD DOT, and legacy/multi-area Graphviz projections |
 | `ProcessDiagramGraphAdapterTest` | Stable identities, explicit ports, material/energy/signal connections, parallel endpoints, multi-area hierarchy, deterministic snapshots, defensive copies, and structured diagnostics |
 | `ProcessDiagramExporterTest` | DOT structure, diagram styles/options, stream annotations/tables, and Graphviz-backed exports when Graphviz is available |
 | `ProcessSystemGraphvizExportTest` | Legacy complex-oil, three-phase, anti-surge, and annotated stream/property-table exports |
 | `HysysStyleDiagramTest`, `OilStabilizationDiagramTest`, `GasOilWaterProcessSvgExportTest` | Professional-looking simulator examples and representative process diagrams; visual examples, not standards qualification |
-| `Dexpi20ProcessModelWriterTest`, `Dexpi20SemanticValidatorTest` | Native DEXPI 2.0 Process structure, physical quantities, semantic rules, and scoped conformance evidence |
+| `Dexpi20ProcessModelWriterTest`, `Dexpi20SemanticValidatorTest` | Native DEXPI 2.0 Process structure, physical quantities, semantic rules, simple/parallel material-topology equivalence, explicit ports, and scoped loss/conformance evidence |
 | `DexpiXmlWriterTest`, `DexpiXmlReaderTest`, `DexpiTopologyResolverTest` | Proteus-compatible export/import, equipment/nozzle/piping topology, round trip, instrumentation, safety metadata, and schema variants |
 | `DexpiRenderingImprovementsTest` | Proteus layout, routing, crossing hops, off-page symbols, line styles, title-block fields, multi-area export, and structural XML checks |
 | P&ID package tests under `process/engineering/pid` | Proposal synthesis, controls/safeguards, completeness findings, materialization, and governed engineering-package behavior |
@@ -126,12 +126,12 @@ Future increments shall follow these rules:
 
 ## Dependency-ordered next work
 
-The inventory shows that the canonical topology foundation exists, while exporters still traverse
-their own source models. The next safe implementation increment is therefore to make the golden
-topology manifest reusable and prove DEXPI 2.0 Process semantic equivalence for supported simple
-and branched cases. That increment must retain the Proteus/P&ID workflow and report unsupported
-energy, signal, multi-area, document, and graphical semantics explicitly.
+The canonical topology foundation and the DEXPI Process comparison gate now exist, while exporters
+still traverse their compatibility source models. After this evidence is merged, the next safe
+increment is to migrate one exporter at a time behind the equivalence gate, starting with the
+supported DEXPI Process material subset. Multi-area hierarchy and energy/signal mappings require
+separate reviewed extensions rather than silent flattening or loss.
 
-After that evidence is merged, migrate one exporter at a time. The native professional document
-model and renderer remain later work because controlled document/sheet identity, layout ownership,
-revision semantics, and licensed symbol qualification are not yet available.
+The native professional document model and renderer remain later work because controlled
+document/sheet identity, layout ownership, revision semantics, and licensed symbol qualification
+are not yet available.

--- a/src/main/java/neqsim/mcp/runners/ModelRegistry.java
+++ b/src/main/java/neqsim/mcp/runners/ModelRegistry.java
@@ -538,8 +538,8 @@ public final class ModelRegistry {
    *
    * <p>
    * The subject is taken from the identity the transport already validated, never from a tool argument, so a client
-   * cannot claim another principal. Callers the transport did not authenticate share the anonymous subject, which
-   * keeps single-user desktop use working while still denying them every model registered by a named principal.
+   * cannot claim another principal. Callers the transport did not authenticate share the anonymous subject, which keeps
+   * single-user desktop use working while still denying them every model registered by a named principal.
    * </p>
    *
    * @return the owner identifier
@@ -567,10 +567,10 @@ public final class ModelRegistry {
    * Builds the storage key that scopes a handle to the caller that registered it.
    *
    * <p>
-   * Handles are content-derived, so without a scoped key two principals registering the same definition would share
-   * one entry: a revision by one would silently change what the other resolves, and the second registration would hand
-   * back the first caller's record. Qualifying the key with tenant and owner keeps the entries independent while the
-   * handle itself stays stable for its owner.
+   * Handles are content-derived, so without a scoped key two principals registering the same definition would share one
+   * entry: a revision by one would silently change what the other resolves, and the second registration would hand back
+   * the first caller's record. Qualifying the key with tenant and owner keeps the entries independent while the handle
+   * itself stays stable for its owner.
    * </p>
    *
    * @param modelId the model handle

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriter.java
@@ -70,6 +70,24 @@ public final class Dexpi20ProcessModelWriter {
     return Dexpi20ConformanceAssessment.assess(file.toPath(), Dexpi20ConformanceAssessment.Profile.PROCESS_PFD_BFD);
   }
 
+  /**
+   * Writes a Process exchange and compares supported material topology with the canonical diagram graph.
+   *
+   * @param processSystem source simulation topology
+   * @param file destination DEXPI XML file
+   * @param plantId persistent plant or project identifier used by the canonical graph
+   * @param revision controlled source-model revision
+   * @return schema/profile conformance plus structured topology-equivalence and scope evidence
+   * @throws IOException if serialization, validation, or assessment fails
+   */
+  public static Dexpi20ProcessTopologyAssessment.Report writeAndAssessTopology(ProcessSystem processSystem, File file,
+      String plantId, String revision) throws IOException {
+    write(processSystem, file);
+    Dexpi20ConformanceAssessment.Report conformance = Dexpi20ConformanceAssessment.assess(file.toPath(),
+        Dexpi20ConformanceAssessment.Profile.PROCESS_PFD_BFD);
+    return Dexpi20ProcessTopologyAssessment.assess(processSystem, file.toPath(), plantId, revision, conformance);
+  }
+
   /** Writes a native DEXPI 2.0 Process model to a stream. */
   public static void write(ProcessSystem processSystem, OutputStream outputStream) throws IOException {
     if (processSystem == null || outputStream == null) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessTopologyAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessTopologyAssessment.java
@@ -1,0 +1,480 @@
+package neqsim.process.processmodel.dexpi;
+
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringNode;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.processmodel.diagram.ProcessDiagramGraphAdapter;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/** Compares native DEXPI 2.0 Process material topology with the canonical diagram graph. */
+public final class Dexpi20ProcessTopologyAssessment {
+  private Dexpi20ProcessTopologyAssessment() {
+  }
+
+  /** Severity of one structured topology or export-scope diagnostic. */
+  public enum Severity {
+    INFO, WARNING, ERROR
+  }
+
+  /** Immutable structured topology or scope diagnostic. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subject;
+
+    Diagnostic(Severity severity, String code, String message, String subject) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subject = subject == null ? "" : subject;
+    }
+
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    public String getCode() {
+      return code;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public String getSubject() {
+      return subject;
+    }
+
+    @Override
+    public String toString() {
+      return severity + ":" + code + (subject.isEmpty() ? "" : ":" + subject);
+    }
+  }
+
+  /** One exported DEXPI material connection with explicit port identities. */
+  public static final class ExportedConnection implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String streamId;
+    private final String streamLabel;
+    private final String sourceStep;
+    private final String targetStep;
+    private final String sourcePortId;
+    private final String targetPortId;
+    private final boolean boundaryTarget;
+
+    ExportedConnection(String streamId, String streamLabel, String sourceStep, String targetStep, String sourcePortId,
+        String targetPortId, boolean boundaryTarget) {
+      this.streamId = streamId;
+      this.streamLabel = streamLabel;
+      this.sourceStep = sourceStep;
+      this.targetStep = targetStep;
+      this.sourcePortId = sourcePortId;
+      this.targetPortId = targetPortId;
+      this.boundaryTarget = boundaryTarget;
+    }
+
+    public String getStreamId() {
+      return streamId;
+    }
+
+    public String getStreamLabel() {
+      return streamLabel;
+    }
+
+    public String getSourceStep() {
+      return sourceStep;
+    }
+
+    public String getTargetStep() {
+      return targetStep;
+    }
+
+    public String getSourcePortId() {
+      return sourcePortId;
+    }
+
+    public String getTargetPortId() {
+      return targetPortId;
+    }
+
+    public boolean isBoundaryTarget() {
+      return boundaryTarget;
+    }
+
+    String materialKey() {
+      return sourceStep + "->" + targetStep;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("streamId", streamId);
+      result.put("streamLabel", streamLabel);
+      result.put("sourceStep", sourceStep);
+      result.put("targetStep", targetStep);
+      result.put("sourcePortId", sourcePortId);
+      result.put("targetPortId", targetPortId);
+      result.put("boundaryTarget", Boolean.valueOf(boundaryTarget));
+      return result;
+    }
+  }
+
+  /** Immutable conformance and canonical-topology evidence for one Process exchange. */
+  public static final class Report implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Dexpi20ConformanceAssessment.Report conformanceReport;
+    private final String canonicalFingerprint;
+    private final List<String> canonicalConnectionIds;
+    private final List<String> canonicalMaterialConnections;
+    private final List<String> exportedMaterialConnections;
+    private final List<ExportedConnection> exportedConnections;
+    private final List<Diagnostic> diagnostics;
+
+    Report(Dexpi20ConformanceAssessment.Report conformanceReport, String canonicalFingerprint,
+        List<String> canonicalConnectionIds, List<String> canonicalMaterialConnections,
+        List<String> exportedMaterialConnections, List<ExportedConnection> exportedConnections,
+        List<Diagnostic> diagnostics) {
+      this.conformanceReport = conformanceReport;
+      this.canonicalFingerprint = canonicalFingerprint;
+      this.canonicalConnectionIds = immutableCopy(canonicalConnectionIds);
+      this.canonicalMaterialConnections = immutableCopy(canonicalMaterialConnections);
+      this.exportedMaterialConnections = immutableCopy(exportedMaterialConnections);
+      this.exportedConnections = Collections.unmodifiableList(new ArrayList<ExportedConnection>(exportedConnections));
+      this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+    }
+
+    public Dexpi20ConformanceAssessment.Report getConformanceReport() {
+      return conformanceReport;
+    }
+
+    public String getCanonicalFingerprint() {
+      return canonicalFingerprint;
+    }
+
+    public List<String> getCanonicalConnectionIds() {
+      return canonicalConnectionIds;
+    }
+
+    public List<String> getCanonicalMaterialConnections() {
+      return canonicalMaterialConnections;
+    }
+
+    public List<String> getExportedMaterialConnections() {
+      return exportedMaterialConnections;
+    }
+
+    public List<ExportedConnection> getExportedConnections() {
+      return exportedConnections;
+    }
+
+    public List<Diagnostic> getDiagnostics() {
+      return diagnostics;
+    }
+
+    public boolean isSupportedMaterialTopologyEquivalent() {
+      return canonicalMaterialConnections.equals(exportedMaterialConnections) && !hasErrors(diagnostics);
+    }
+
+    public boolean isSchemaProfileAndSupportedTopologyValid() {
+      return conformanceReport.isSchemaAndProfileConformant() && isSupportedMaterialTopologyEquivalent();
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", "neqsim_dexpi_2_0_process_topology_assessment.v1");
+      result.put("canonicalFingerprint", canonicalFingerprint);
+      result.put("canonicalConnectionIds", new ArrayList<String>(canonicalConnectionIds));
+      result.put("sourceProvenance", "SIMULATION_MODEL");
+      result.put("engineeringState", "CALCULATED");
+      result.put("approvalStatus", "REVIEW_REQUIRED");
+      result.put("canonicalMaterialConnections", new ArrayList<String>(canonicalMaterialConnections));
+      result.put("exportedMaterialConnections", new ArrayList<String>(exportedMaterialConnections));
+      List<Map<String, Object>> connectionMaps = new ArrayList<Map<String, Object>>();
+      for (ExportedConnection connection : exportedConnections) {
+        connectionMaps.add(connection.toMap());
+      }
+      result.put("exportedConnections", connectionMaps);
+      List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+      for (Diagnostic diagnostic : diagnostics) {
+        Map<String, Object> item = new LinkedHashMap<String, Object>();
+        item.put("severity", diagnostic.getSeverity().name());
+        item.put("code", diagnostic.getCode());
+        item.put("message", diagnostic.getMessage());
+        item.put("subject", diagnostic.getSubject());
+        diagnosticMaps.add(item);
+      }
+      result.put("diagnostics", diagnosticMaps);
+      result.put("supportedMaterialTopologyEquivalent", Boolean.valueOf(isSupportedMaterialTopologyEquivalent()));
+      result.put("conformance", conformanceReport.toMap());
+      return result;
+    }
+
+    public String toJson() {
+      return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+    }
+  }
+
+  static Report assess(ProcessSystem processSystem, Path file, String plantId, String revision,
+      Dexpi20ConformanceAssessment.Report conformanceReport) throws IOException {
+    if (processSystem == null || file == null || conformanceReport == null) {
+      throw new IllegalArgumentException("processSystem, file, and conformanceReport must not be null");
+    }
+    ProcessDiagramGraphAdapter.Result canonical = ProcessDiagramGraphAdapter.fromProcessSystem(processSystem, plantId,
+        revision);
+    List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+    copyAdapterDiagnostics(canonical, diagnostics);
+    EngineeringGraph graph = canonical.getGraph();
+    List<String> connectionIds = canonicalConnectionIds(graph);
+    List<String> expected = canonicalMaterialConnections(graph, diagnostics);
+    List<ExportedConnection> exported = exportedConnections(file, diagnostics);
+    List<String> actual = materialConnections(exported);
+    compareMaterialConnections(expected, actual, diagnostics);
+    diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_MULTI_AREA_UNSUPPORTED",
+        "Native DEXPI 2.0 Process export currently accepts ProcessSystem only; ProcessModel area hierarchy is not exchanged",
+        processSystem.getName()));
+    diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_DOCUMENT_SEMANTICS_UNSUPPORTED",
+        "Controlled document, sheet, revision-block, drawing-status, and off-page-reference semantics are not exchanged",
+        processSystem.getName()));
+    diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_GRAPHICS_UNSUPPORTED",
+        "Native DEXPI 2.0 Process export contains semantic steps and streams but no governed drawing layout",
+        processSystem.getName()));
+    return new Report(conformanceReport, canonical.getFingerprint(), connectionIds, expected, actual, exported,
+        diagnostics);
+  }
+
+  private static void copyAdapterDiagnostics(ProcessDiagramGraphAdapter.Result canonical,
+      List<Diagnostic> diagnostics) {
+    for (ProcessDiagramGraphAdapter.Diagnostic source : canonical.getDiagnostics()) {
+      Severity severity = source.getSeverity() == ProcessDiagramGraphAdapter.Severity.ERROR ? Severity.ERROR
+          : source.getSeverity() == ProcessDiagramGraphAdapter.Severity.WARNING ? Severity.WARNING : Severity.INFO;
+      diagnostics.add(new Diagnostic(severity, source.getCode(), source.getMessage(), source.getSubject()));
+    }
+  }
+
+  private static List<String> canonicalMaterialConnections(EngineeringGraph graph, List<Diagnostic> diagnostics) {
+    List<String> result = new ArrayList<String>();
+    for (EngineeringNode node : graph.getNodes().values()) {
+      if (node.getKind() == EngineeringNode.Kind.PIPE_SEGMENT) {
+        result.add(connectionKey(node));
+      } else if (node.getKind() == EngineeringNode.Kind.ENERGY_CONNECTION) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_ENERGY_CONNECTION_UNSUPPORTED",
+            "Energy connections are present in the canonical graph but are not emitted by the current Process writer",
+            node.getId()));
+      } else if (node.getKind() == EngineeringNode.Kind.SIGNAL_CONNECTION) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_SIGNAL_CONNECTION_UNSUPPORTED",
+            "Signal connections are present in the canonical graph but are not emitted by the current Process writer",
+            node.getId()));
+      }
+    }
+    Collections.sort(result);
+    return result;
+  }
+
+  private static List<String> canonicalConnectionIds(EngineeringGraph graph) {
+    List<String> result = new ArrayList<String>();
+    for (EngineeringNode node : graph.getNodes().values()) {
+      if (node.getKind() == EngineeringNode.Kind.PIPE_SEGMENT) {
+        result.add(node.getId());
+      }
+    }
+    Collections.sort(result);
+    return result;
+  }
+
+  private static String connectionKey(EngineeringNode node) {
+    return String.valueOf(node.getProperties().get("sourceEquipment")) + "->"
+        + String.valueOf(node.getProperties().get("targetEquipment"));
+  }
+
+  private static List<ExportedConnection> exportedConnections(Path file, List<Diagnostic> diagnostics)
+      throws IOException {
+    Document document = parse(file);
+    Map<String, StepReference> stepByPort = new LinkedHashMap<String, StepReference>();
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element object = (Element) objects.item(index);
+      if (!"Process/Process.MaterialPort".equals(object.getAttribute("type"))) {
+        continue;
+      }
+      Element step = ancestorProcessStep(object);
+      if (step != null) {
+        stepByPort.put(object.getAttribute("id"),
+            new StepReference(directString(step, "Identifier"), step.getAttribute("type")));
+      }
+    }
+    List<ExportedConnection> result = new ArrayList<ExportedConnection>();
+    Set<String> usedPorts = new LinkedHashSet<String>();
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element stream = (Element) objects.item(index);
+      if (!"Process/Process.Stream".equals(stream.getAttribute("type"))) {
+        continue;
+      }
+      String sourcePort = reference(stream, "Source");
+      String targetPort = reference(stream, "Target");
+      StepReference source = stepByPort.get(sourcePort);
+      StepReference target = stepByPort.get(targetPort);
+      if (source == null || target == null) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "DEXPI_PROCESS_UNRESOLVED_EXPORTED_PORT",
+            "A DEXPI Process stream does not resolve to source and target material ports", stream.getAttribute("id")));
+        continue;
+      }
+      if (!usedPorts.add(sourcePort) || !usedPorts.add(targetPort)) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "DEXPI_PROCESS_EXPORTED_PORT_REUSED",
+            "Each exported material connection must own distinct source and target ports", stream.getAttribute("id")));
+      }
+      boolean boundary = "Process/Process.Sink".equals(target.type);
+      if (boundary) {
+        diagnostics.add(new Diagnostic(Severity.INFO, "DEXPI_PROCESS_BOUNDARY_SINK_SYNTHESIZED",
+            "An unconsumed material outlet was projected to a DEXPI Process sink", stream.getAttribute("id")));
+      }
+      result.add(new ExportedConnection(stream.getAttribute("id"), directString(stream, "Label"), source.name,
+          target.name, sourcePort, targetPort, boundary));
+    }
+    Collections.sort(result, new Comparator<ExportedConnection>() {
+      @Override
+      public int compare(ExportedConnection first, ExportedConnection second) {
+        int byConnection = first.materialKey().compareTo(second.materialKey());
+        return byConnection == 0 ? first.getStreamId().compareTo(second.getStreamId()) : byConnection;
+      }
+    });
+    return result;
+  }
+
+  private static List<String> materialConnections(List<ExportedConnection> connections) {
+    List<String> result = new ArrayList<String>();
+    for (ExportedConnection connection : connections) {
+      if (!connection.isBoundaryTarget()) {
+        result.add(connection.materialKey());
+      }
+    }
+    Collections.sort(result);
+    return result;
+  }
+
+  private static void compareMaterialConnections(List<String> expected, List<String> actual,
+      List<Diagnostic> diagnostics) {
+    Map<String, Integer> expectedCounts = counts(expected);
+    Map<String, Integer> actualCounts = counts(actual);
+    Set<String> keys = new LinkedHashSet<String>();
+    keys.addAll(expectedCounts.keySet());
+    keys.addAll(actualCounts.keySet());
+    for (String key : keys) {
+      int required = value(expectedCounts, key);
+      int exported = value(actualCounts, key);
+      if (required > exported) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "DEXPI_PROCESS_MATERIAL_CONNECTION_MISSING",
+            "Canonical material connection multiplicity " + required + " exceeds exported multiplicity " + exported,
+            key));
+      } else if (exported > required) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "DEXPI_PROCESS_MATERIAL_CONNECTION_UNEXPECTED",
+            "Exported material connection multiplicity " + exported + " exceeds canonical multiplicity " + required,
+            key));
+      }
+    }
+  }
+
+  private static Map<String, Integer> counts(List<String> values) {
+    Map<String, Integer> result = new LinkedHashMap<String, Integer>();
+    for (String value : values) {
+      result.put(value, Integer.valueOf(value(result, value) + 1));
+    }
+    return result;
+  }
+
+  private static int value(Map<String, Integer> values, String key) {
+    Integer value = values.get(key);
+    return value == null ? 0 : value.intValue();
+  }
+
+  private static Document parse(Path file) throws IOException {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setXIncludeAware(false);
+      factory.setExpandEntityReferences(false);
+      return factory.newDocumentBuilder().parse(file.toFile());
+    } catch (ParserConfigurationException ex) {
+      throw new IOException("Could not configure DEXPI Process topology parser", ex);
+    } catch (SAXException ex) {
+      throw new IOException("Could not parse DEXPI Process topology", ex);
+    }
+  }
+
+  private static Element ancestorProcessStep(Element port) {
+    for (Node node = port.getParentNode(); node != null; node = node.getParentNode()) {
+      if (node instanceof Element && "Object".equals(((Element) node).getTagName())) {
+        Element object = (Element) node;
+        String type = object.getAttribute("type");
+        if (type.startsWith("Process/Process.") && !"Process/Process.MaterialPort".equals(type)) {
+          return object;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static String directString(Element parent, String property) {
+    for (Node child = parent.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "Data".equals(((Element) child).getTagName())
+          && property.equals(((Element) child).getAttribute("property"))) {
+        NodeList strings = ((Element) child).getElementsByTagName("String");
+        return strings.getLength() == 0 ? "" : strings.item(0).getTextContent();
+      }
+    }
+    return "";
+  }
+
+  private static String reference(Element parent, String property) {
+    for (Node child = parent.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "References".equals(((Element) child).getTagName())
+          && property.equals(((Element) child).getAttribute("property"))) {
+        return ((Element) child).getAttribute("objects").replaceFirst("^#", "");
+      }
+    }
+    return "";
+  }
+
+  private static boolean hasErrors(List<Diagnostic> diagnostics) {
+    for (Diagnostic diagnostic : diagnostics) {
+      if (diagnostic.getSeverity() == Severity.ERROR) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static List<String> immutableCopy(List<String> values) {
+    return Collections.unmodifiableList(new ArrayList<String>(values));
+  }
+
+  private static final class StepReference {
+    private final String name;
+    private final String type;
+
+    StepReference(String name, String type) {
+      this.name = name;
+      this.type = type;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
@@ -14,6 +14,9 @@
  * <li>{@link neqsim.process.processmodel.dexpi.DexpiStream} - Runnable stream with DEXPI metadata</li>
  * <li>{@link neqsim.process.processmodel.dexpi.DexpiMetadata} - Shared constants for DEXPI exchanges</li>
  * <li>{@link neqsim.process.processmodel.dexpi.DexpiRoundTripProfile} - Validation for round-trip fidelity</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessModelWriter} - Native DEXPI 2.0 Process exchange</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessTopologyAssessment} - Canonical material-topology and
+ * structured scope evidence for native Process exchange</li>
  * </ul>
  *
  * <h2>Usage Example</h2>

--- a/src/test/java/neqsim/mcp/runners/ModelRegistryOwnerScopingTest.java
+++ b/src/test/java/neqsim/mcp/runners/ModelRegistryOwnerScopingTest.java
@@ -156,8 +156,8 @@ class ModelRegistryOwnerScopingTest {
   }
 
   /**
-   * The worst case: a foreign revision would make the owner's next run answer from someone else's edits, and the
-   * result would look entirely normal. The stored definition must be untouched.
+   * The worst case: a foreign revision would make the owner's next run answer from someone else's edits, and the result
+   * would look entirely normal. The stored definition must be untouched.
    */
   @Test
   @DisplayName("revise is refused for another principal and leaves the owner's definition intact")
@@ -262,8 +262,8 @@ class ModelRegistryOwnerScopingTest {
   }
 
   /**
-   * An unresolved caller must fail closed rather than fall into a bucket shared with named principals. A token
-   * carrying no tenant claim falls back to the same default scope as an unbound caller, so ownership is the only thing
+   * An unresolved caller must fail closed rather than fall into a bucket shared with named principals. A token carrying
+   * no tenant claim falls back to the same default scope as an unbound caller, so ownership is the only thing
    * separating them.
    */
   @Test
@@ -276,8 +276,9 @@ class ModelRegistryOwnerScopingTest {
     McpRequestContext.clear();
     assertRefusedAsUnknown("get", act("get", modelId));
     assertRefusedAsUnknown("delete", act("delete", modelId));
-    assertEquals(0, JsonParser.parseString(ModelRegistry.run("{\"action\": \"list\"}")).getAsJsonObject().get("count")
-        .getAsInt(), "An anonymous caller must not see a named principal's models");
+    assertEquals(0,
+        JsonParser.parseString(ModelRegistry.run("{\"action\": \"list\"}")).getAsJsonObject().get("count").getAsInt(),
+        "An anonymous caller must not see a named principal's models");
     assertThrows(IllegalArgumentException.class, new Executable() {
       @Override
       public void execute() {
@@ -290,8 +291,8 @@ class ModelRegistryOwnerScopingTest {
   }
 
   /**
-   * A refusal must be indistinguishable from a handle that was never registered, so the registry cannot be used to
-   * test whether a given model exists.
+   * A refusal must be indistinguishable from a handle that was never registered, so the registry cannot be used to test
+   * whether a given model exists.
    */
   @Test
   @DisplayName("a refused handle is indistinguishable from an unknown handle")

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
@@ -1,16 +1,20 @@
 package neqsim.process.processmodel.dexpi;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.pipeline.AdiabaticPipe;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessConnection;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.processmodel.diagram.ProcessDiagramGoldenFixtures;
 import neqsim.thermo.system.SystemSrkEos;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -19,6 +23,33 @@ import org.junit.jupiter.api.io.TempDir;
 class Dexpi20ProcessModelWriterTest {
   @TempDir
   Path temporaryDirectory;
+
+  @Test
+  void provesSimpleAndParallelBranchTopologyAgainstCanonicalManifest() throws Exception {
+    assertGoldenTopology(ProcessDiagramGoldenFixtures.simpleTrain(), "DEXPI-GOLDEN-SIMPLE", "simple.dexpi.xml");
+    assertGoldenTopology(ProcessDiagramGoldenFixtures.parallelBranchTrain(), "DEXPI-GOLDEN-BRANCH",
+        "parallel-branch.dexpi.xml");
+  }
+
+  @Test
+  void reportsUnsupportedTopologyAndDocumentScopesWithoutHidingMaterialEquivalence() throws Exception {
+    ProcessDiagramGoldenFixtures.Fixture fixture = ProcessDiagramGoldenFixtures.simpleTrain();
+    ProcessSystem process = fixture.getProcessSystem();
+    process.connect("heater", "temperatureSignal", "feed", "temperatureSetpoint",
+        ProcessConnection.ConnectionType.SIGNAL);
+    process.connect("heater", "calculatedDuty", "feed", "availableDuty", ProcessConnection.ConnectionType.ENERGY);
+    Path output = temporaryDirectory.resolve("scoped-losses.dexpi.xml");
+
+    Dexpi20ProcessTopologyAssessment.Report report = Dexpi20ProcessModelWriter.writeAndAssessTopology(process,
+        output.toFile(), "DEXPI-SCOPED-LOSSES", "A");
+
+    assertTrue(report.isSupportedMaterialTopologyEquivalent(), report.getDiagnostics().toString());
+    assertTrue(hasDiagnostic(report, "DEXPI_PROCESS_SIGNAL_CONNECTION_UNSUPPORTED"));
+    assertTrue(hasDiagnostic(report, "DEXPI_PROCESS_ENERGY_CONNECTION_UNSUPPORTED"));
+    assertTrue(hasDiagnostic(report, "DEXPI_PROCESS_MULTI_AREA_UNSUPPORTED"));
+    assertTrue(hasDiagnostic(report, "DEXPI_PROCESS_DOCUMENT_SEMANTICS_UNSUPPORTED"));
+    assertTrue(hasDiagnostic(report, "DEXPI_PROCESS_GRAPHICS_UNSUPPORTED"));
+  }
 
   @Test
   void writesSchemaValidProcessModelWithStepsPortsStreamsAndPhysicalQuantities() throws Exception {
@@ -124,6 +155,42 @@ class Dexpi20ProcessModelWriterTest {
     process.add(separator);
     process.add(compressor);
     return process;
+  }
+
+  private void assertGoldenTopology(ProcessDiagramGoldenFixtures.Fixture fixture, String plantId, String fileName)
+      throws Exception {
+    Path output = temporaryDirectory.resolve(fileName);
+
+    Dexpi20ProcessTopologyAssessment.Report report = Dexpi20ProcessModelWriter
+        .writeAndAssessTopology(fixture.getProcessSystem(), output.toFile(), plantId, "A");
+
+    assertTrue(report.isSchemaProfileAndSupportedTopologyValid(), report.getDiagnostics().toString());
+    assertTrue(report.isSupportedMaterialTopologyEquivalent(), report.getDiagnostics().toString());
+    assertTrue(report.getConformanceReport().isSchemaAndProfileConformant());
+    assertEquals(64, report.getCanonicalFingerprint().length());
+    assertEquals(fixture.getMaterialConnections(), report.getCanonicalMaterialConnections());
+    assertEquals(fixture.getMaterialConnections(), report.getExportedMaterialConnections());
+    assertEquals(fixture.getMaterialConnections().size(),
+        new java.util.LinkedHashSet<String>(report.getCanonicalConnectionIds()).size());
+    assertTrue(hasDistinctPorts(report.getExportedConnections()));
+  }
+
+  private static boolean hasDistinctPorts(List<Dexpi20ProcessTopologyAssessment.ExportedConnection> connections) {
+    java.util.Set<String> ports = new java.util.LinkedHashSet<String>();
+    for (Dexpi20ProcessTopologyAssessment.ExportedConnection connection : connections) {
+      ports.add(connection.getSourcePortId());
+      ports.add(connection.getTargetPortId());
+    }
+    return ports.size() == connections.size() * 2;
+  }
+
+  private static boolean hasDiagnostic(Dexpi20ProcessTopologyAssessment.Report report, String code) {
+    for (Dexpi20ProcessTopologyAssessment.Diagnostic diagnostic : report.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private ProcessSystem process() {

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramGoldenFixtures.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramGoldenFixtures.java
@@ -1,0 +1,83 @@
+package neqsim.process.processmodel.diagram;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.splitter.Splitter;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Reusable fresh-model fixtures and directed-connection manifests for diagram projections. */
+public final class ProcessDiagramGoldenFixtures {
+  private ProcessDiagramGoldenFixtures() {
+  }
+
+  /** One fresh process fixture with its deterministic material-topology manifest. */
+  public static final class Fixture {
+    private final ProcessSystem processSystem;
+    private final List<String> materialConnections;
+
+    private Fixture(ProcessSystem processSystem, String... materialConnections) {
+      this.processSystem = processSystem;
+      List<String> sortedConnections = new ArrayList<String>(Arrays.asList(materialConnections));
+      Collections.sort(sortedConnections);
+      this.materialConnections = Collections.unmodifiableList(sortedConnections);
+    }
+
+    public ProcessSystem getProcessSystem() {
+      return processSystem;
+    }
+
+    public List<String> getMaterialConnections() {
+      return materialConnections;
+    }
+  }
+
+  /** Creates the three-element linear train used by canonical, DOT, and DEXPI tests. */
+  public static Fixture simpleTrain() {
+    Stream feed = createFeed("feed");
+    Heater heater = new Heater("heater", feed);
+    Cooler cooler = new Cooler("cooler", heater.getOutletStream());
+    ProcessSystem process = new ProcessSystem("simple train");
+    process.add(feed);
+    process.add(heater);
+    process.add(cooler);
+    return new Fixture(process, "feed->heater", "heater->cooler");
+  }
+
+  /** Creates a splitter/mixer train with two parallel material connections. */
+  public static Fixture parallelBranchTrain() {
+    Stream feed = createFeed("branch feed");
+    feed.run();
+    Splitter splitter = new Splitter("branch splitter", feed);
+    splitter.setSplitFactors(new double[] { 0.4, 0.6 });
+    splitter.run();
+    StreamInterface firstBranch = splitter.getSplitStream(0);
+    StreamInterface secondBranch = splitter.getSplitStream(1);
+    Mixer mixer = new Mixer("branch mixer");
+    mixer.addStream(firstBranch);
+    mixer.addStream(secondBranch);
+    ProcessSystem process = new ProcessSystem("parallel branch train");
+    process.add(feed);
+    process.add(splitter);
+    process.add(mixer);
+    return new Fixture(process, "branch feed->branch splitter", "branch splitter->branch mixer",
+        "branch splitter->branch mixer");
+  }
+
+  private static Stream createFeed(String name) {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-heptane", 0.2);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream(name, fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    return feed;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramTopologyEquivalenceTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramTopologyEquivalenceTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import neqsim.process.engineering.model.EngineeringGraph;
 import neqsim.process.engineering.model.EngineeringNode;
-import neqsim.process.equipment.heatexchanger.Cooler;
 import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.mixer.Mixer;
 import neqsim.process.equipment.separator.Separator;
@@ -37,17 +36,20 @@ class ProcessDiagramTopologyEquivalenceTest {
 
   @Test
   void simpleTrainHasEquivalentCanonicalAndDotTopology(@TempDir Path tempDir) throws IOException {
-    Stream feed = createFeed("feed");
-    Heater heater = new Heater("heater", feed);
-    Cooler cooler = new Cooler("cooler", heater.getOutletStream());
-    ProcessSystem process = new ProcessSystem("simple train");
-    process.add(feed);
-    process.add(heater);
-    process.add(cooler);
+    ProcessDiagramGoldenFixtures.Fixture fixture = ProcessDiagramGoldenFixtures.simpleTrain();
+    List<String> expected = withRecycleFlag(fixture.getMaterialConnections(), false);
 
-    List<String> expected = sorted("feed->heater|false", "heater->cooler|false");
+    assertSystemTopology(expected, expected, fixture.getProcessSystem(), "GOLDEN-SIMPLE",
+        tempDir.resolve("simple.dot"));
+  }
 
-    assertSystemTopology(expected, expected, process, "GOLDEN-SIMPLE", tempDir.resolve("simple.dot"));
+  @Test
+  void parallelBranchManifestPreservesConnectionMultiplicity(@TempDir Path tempDir) throws IOException {
+    ProcessDiagramGoldenFixtures.Fixture fixture = ProcessDiagramGoldenFixtures.parallelBranchTrain();
+    List<String> expected = withRecycleFlag(fixture.getMaterialConnections(), false);
+
+    assertSystemTopology(expected, expected, fixture.getProcessSystem(), "GOLDEN-BRANCH",
+        tempDir.resolve("parallel-branch.dot"));
   }
 
   @Test
@@ -203,6 +205,15 @@ class ProcessDiagramTopologyEquivalenceTest {
 
   private static List<String> sorted(String... values) {
     List<String> result = new ArrayList<String>(Arrays.asList(values));
+    Collections.sort(result);
+    return result;
+  }
+
+  private static List<String> withRecycleFlag(List<String> connections, boolean recycle) {
+    List<String> result = new ArrayList<String>();
+    for (String connection : connections) {
+      result.add(connection + "|" + recycle);
+    }
     Collections.sort(result);
     return result;
   }


### PR DESCRIPTION
## Summary

- add `Dexpi20ProcessTopologyAssessment` and `writeAndAssessTopology(...)` as an additive, opt-in topology gate for native DEXPI 2.0 Process export
- compare multiplicity-sensitive material connections with the canonical `ProcessDiagramGraphAdapter` snapshot while retaining the existing writer and public APIs
- record canonical fingerprints and stable connection IDs, every exported stream and its explicit source/target port IDs, calculated/review-required provenance, and structured diagnostics
- make simple and parallel-branch topology fixtures reusable across canonical, DOT/Graphviz, and DEXPI tests
- report energy, signal, multi-area `ProcessModel`, controlled document/sheet, and graphical semantics as unsupported scopes instead of implying they were exchanged
- apply the two current-`master` Spotless-only MCP line-wrap corrections required for the repository-wide pre-push gate

## Compatibility and engineering boundary

The existing `write(...)` and `writeAndAssess(...)` APIs and serialization remain unchanged. The writer still traverses `ProcessSystem` directly; this PR adds migration evidence and does **not** yet redirect the writer through the canonical graph.

Synthetic product sinks remain in the exported inventory but are excluded from the in-model material comparison. Missing/unexpected multiplicity, unresolved ports, and port reuse are errors. Unsupported energy, signal, multi-area, controlled-document, and graphics scopes are structured warnings.

This is calculated simulation evidence with `REVIEW_REQUIRED` status. It does not claim ISO 10628 conformance, DEXPI e.V. certification, named-CAE qualification, or complete P&ID engineering content. The Proteus/DEXPI P&ID workflow is unchanged.

## Validation

- cached Eclipse compiler: changed production and test sources compile with Java 8 source/target rules
- standalone JUnit focused/broader set: **15 passed, 0 failed**
  - `ProcessDiagramGraphAdapterTest`
  - `ProcessDiagramTopologyEquivalenceTest`
  - new simple/parallel DEXPI topology tests
  - unsupported-scope diagnostic test
  - existing incomplete-port semantic validation test
- `python devtools/run_spotless.py apply`: passed and stable
- `python devtools/run_spotless.py check`: passed
- `python devtools/check_documentation_search.py`: passed (648 Markdown pages, 1 standalone HTML page)
- pre-commit stage: passed
- pre-push stage: passed
- `git diff --check`: passed

The normal Maven test lifecycle could not enter compilation because the sandbox cannot resolve `repo.maven.apache.org` and several current dependency descriptors are not cached. Maven Central was checked: the requested Commons Math artifact is published there, so this is an environment/DNS limitation rather than evidence of a missing coordinate. Hosted CI remains required for the full Maven matrix.

## Documentation impact

Updated the native DEXPI 2.0 conformance guide, process-diagram exporter/API inventory, and DEXPI package documentation. No notebook is changed because this increment adds a low-level regression/evidence API rather than the native professional PFD renderer or controlled document-set workflow.

## Current limitations and next dependency

Still unsupported by the native Process writer: multi-area `ProcessModel` exchange, energy/signal mapping, controlled documents/sheets, paired off-page connectors, graphical layout, revisions/title blocks, and native professional SVG/PDF rendering.

After this evidence is reviewed and merged, the next safe increment is to migrate the supported DEXPI Process material subset to consume the canonical graph behind this equivalence gate, without flattening multi-area hierarchy or changing legacy DOT/Graphviz and Proteus/P&ID behavior.

Relates to #1332. Coordinates with #2899.