### PR TITLE
[AI-Assisted] Project DEXPI Process export through canonical topology

### DIFF
--- a/docs/integration/dexpi-20-conformance.md
+++ b/docs/integration/dexpi-20-conformance.md
@@ -51,18 +51,23 @@ Files.write(Paths.get("gas-processing-pfd.topology.json"),
     topology.toJson().getBytes(StandardCharsets.UTF_8));
 ```
 
-The topology report records the canonical graph fingerprint and stable connection IDs,
-calculated/review-required source provenance, the canonical and exported directed
+The topology report records `exportTopologySource=CANONICAL_ENGINEERING_GRAPH`, the canonical graph
+fingerprint and stable connection IDs, calculated/review-required source provenance, the canonical and exported directed
 material-connection manifests, every exported stream and its distinct source/target port IDs, and structured diagnostics. Connection comparison
 is multiplicity-sensitive, so two parallel streams between the same steps must remain two streams.
 Synthetic product sinks are retained in the exported-connection inventory but excluded from the
 in-model topology comparison.
 
-The current writer still traverses `ProcessSystem` directly. The assessment is migration evidence,
-not a claim that the writer already consumes the canonical graph. It reports energy and signal
-connections, multi-area `ProcessModel` hierarchy, controlled document/sheet semantics, and drawing
-graphics as unsupported scopes. These warnings do not hide a supported material-topology error;
-missing, unexpected, unresolved-port, and reused-port findings are errors.
+`writeAndAssessTopology(...)` builds one canonical snapshot, uses its supported material-connection
+projection to drive the native Process exchange, and assesses the same snapshot. Regression coverage
+requires the assessed simple and parallel-branch output to preserve the existing sequential DEXPI
+serialization. The compatibility APIs `write(...)` and `writeAndAssess(...)` still use their direct
+`ProcessSystem` traversal and remain unchanged.
+
+The assessed path reports energy and signal connections, multi-area `ProcessModel` hierarchy,
+controlled document/sheet semantics, and drawing graphics as unsupported scopes. These warnings do
+not hide a supported material-topology error; missing, unexpected, unresolved-port, and reused-port
+findings are errors.
 
 Each process connection has a dedicated source and target `MaterialPort`. The ports and
 `Process.Stream` carry reciprocal references, stable identifiers, nominal directions, and explicit

--- a/docs/process/processmodel/process_diagram_export_inventory.md
+++ b/docs/process/processmodel/process_diagram_export_inventory.md
@@ -33,8 +33,8 @@ API-stability classification.
 | Legacy `ProcessSystem` Graphviz | `ProcessSystem.exportToGraphviz(...)`, `ProcessSystemGraphvizExporter.export(...)` | Equipment stream introspection and export options | Legacy Graphviz file with optional stream values and property table | Retain as a compatibility output; do not silently redirect it through a new model or renderer |
 | Legacy minimal PFD DOT | `ProcessFlowDiagramExporter(ProcessSystem).toDot()` | Shared stream identity plus explicit `ProcessConnection` declarations | Minimal equipment-node/stream-edge DOT | Preserve the constructor and `toDot()` result contract while public callers remain supported |
 | Multi-area Graphviz | `ProcessModel.toDOT()`, `createGraphvizExporter()`, `exportToGraphviz(...)`, `exportAreaDOT(...)`, and `ProcessModelGraphvizExporter` | Ordered areas and shared stream identity | One clustered plant DOT and optional per-area DOT files | Preserve current combined and per-area APIs. Per-area files are compatibility views, not the future controlled multi-sheet document model |
-| Canonical topology adapter | `ProcessDiagramGraphAdapter.fromProcessSystem(...)`, `fromProcessModel(...)` | `ProcessSystem`, explicit connections, and ordered `ProcessModel` areas | Defensive deterministic `EngineeringGraph`, fingerprint, and structured diagnostics | Reuse as the shared topology foundation; DEXPI Process assessment consumes it as an equivalence baseline, while renderers and writers still use their compatibility paths |
-| Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter.write(...)`, `writeAndAssess(...)`, `writeAndAssessTopology(...)` | Direct `ProcessSystem` equipment and connection traversal, compared with the canonical graph by the topology assessment | Native DEXPI 2.0 Process XML with steps, material ports, streams, quantities, conformance report, and optional structured topology evidence | Preserve the native Process profile and fail-closed assessment; migrate traversal only after the equivalence evidence remains green |
+| Canonical topology adapter | `ProcessDiagramGraphAdapter.fromProcessSystem(...)`, `fromProcessModel(...)` | `ProcessSystem`, explicit connections, and ordered `ProcessModel` areas | Defensive deterministic `EngineeringGraph`, fingerprint, and structured diagnostics | Reuse as the shared topology foundation; the assessed DEXPI Process path consumes one snapshot, while legacy renderers and compatibility writers retain their established paths |
+| Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter.write(...)`, `writeAndAssess(...)`, `writeAndAssessTopology(...)` | Direct `ProcessSystem` traversal for compatibility APIs; canonical material projection for `writeAndAssessTopology(...)` | Native DEXPI 2.0 Process XML with steps, material ports, streams, quantities, conformance report, and optional structured topology evidence | Preserve the native Process profile and existing sequential serialization; expand canonical consumption only behind equivalence evidence |
 | Native DEXPI 2.0 Plant | `Dexpi20XmlWriter.write(...)`, `writeAndAssess(...)` | Direct `ProcessSystem` engineering/plant mapping | Native DEXPI 2.0 Plant XML and conformance report | Keep separate from Process/PFD exchange and from Proteus compatibility output |
 | Proteus-compatible DEXPI | `DexpiXmlWriter.write(...)`, `writeForPyDexpi(...)`, `write(ProcessModel, ...)`, `writeSheets(...)` | Direct process/engineering mapping plus `DexpiLayoutEngine` | Proteus-compatible P&ID XML, pyDEXPI variant, layouts, and per-area sheets | Preserve import/export compatibility. Combined export flattens areas and logs/skips distinct equipment with duplicate names; per-area sheets expose boundary feeds but do not yet form a controlled, paired-reference document set |
 | Proteus import and simulation reconstruction | `DexpiXmlReader`, `DexpiSimulationBuilder`, `DexpiTopologyResolver`, `DexpiEquipmentFactory` | Imported nozzles, piping segments, equipment, instruments, and mappings | DEXPI/Proteus XML to a runnable `ProcessSystem` with explicit loss and validation boundaries | Keep as the detailed P&ID workflow; do not infer that a simulation-only PFD contains complete piping, valve, nozzle, instrument, or safeguard design |
@@ -49,7 +49,7 @@ API-stability classification.
 | `EngineeringGraph` | Exchange-neutral engineering objects and revision comparison | Mutable and broader than a qualified process-diagram document contract |
 | `ProcessDiagramGraphAdapter.Result` | Deterministic projection of `ProcessSystem` or multi-area `ProcessModel` into `EngineeringGraph` | Stable plant/area/equipment/port/connection IDs exist, but document/sheet IDs, controlled views, operating cases, and persistent layout are absent |
 | `ProcessDiagramExporter` configuration | Simulator-style content and Graphviz layout policy | Layout is renderer-specific and has no document-set, revision-block, approval, or controlled off-page-reference model |
-| DEXPI 2.0 Process model | Tool-neutral BFD/PFD exchange | Currently consumes `ProcessSystem` directly and has no `ProcessModel` overload or canonical-graph equivalence proof |
+| DEXPI 2.0 Process model | Tool-neutral BFD/PFD exchange | The opt-in assessed path consumes canonical `ProcessSystem` material topology; compatibility APIs remain direct, and no multi-area `ProcessModel` overload exists |
 | Proteus/DEXPI P&ID model | Detailed P&ID proposal, import/export, and graphical interchange | Separate profile with richer piping/instrument semantics; must remain an engineering proposal until accountable data are present |
 
 `ProcessConnection` distinguishes material, energy, and signal connections and records explicit
@@ -64,7 +64,7 @@ source contract has no independent connection ID; the adapter reports
 |---|---:|---:|---:|---:|
 | `ProcessSystem` | Present | Missing | Present | Present |
 | Multi-area `ProcessModel` | Present | Missing | Missing | Present |
-| Stable plant/area/equipment/port/connection IDs through canonical adapter | Present as a separate topology baseline | Foundation only | Canonical fingerprint and stable topology baseline recorded by assessment; writer IDs remain compatibility-sequential | Not yet consumed as the shared graph |
+| Stable plant/area/equipment/port/connection IDs through canonical adapter | Present as a separate topology baseline | Foundation only | Assessed material projection consumes the canonical snapshot and records its stable IDs; writer IDs remain compatibility-sequential | Not yet consumed as the shared graph |
 | Material, energy, and signal topology | Present in canonical baseline; renderer coverage varies | Missing | Material-focused | Present where supported by the detailed profile |
 | Parallel connection preservation | Golden topology evidence for distinct material/energy/signal endpoints | Missing | Multiplicity-sensitive evidence for supported simple and parallel-branch material cases | Profile-specific tests only |
 | Units and provenance | Optional stream labels/tables; canonical topology provenance | Missing document model | Selected physical quantities with explicit units | Simulation/design metadata and governed package artifacts |
@@ -126,10 +126,11 @@ Future increments shall follow these rules:
 
 ## Dependency-ordered next work
 
-The canonical topology foundation and the DEXPI Process comparison gate now exist, while exporters
-still traverse their compatibility source models. After this evidence is merged, the next safe
-increment is to migrate one exporter at a time behind the equivalence gate, starting with the
-supported DEXPI Process material subset. Multi-area hierarchy and energy/signal mappings require
+The canonical topology foundation and DEXPI Process comparison gate now drive the opt-in assessed
+material projection. Compatibility APIs still traverse their established source model and retain
+their sequential XML identities. The next dependency-ready increment is to carry selected operating
+values, explicit units, case identity, and provenance in the canonical model before widening the
+exchange to multi-area `ProcessModel`. Multi-area hierarchy and energy/signal mappings require
 separate reviewed extensions rather than silent flattening or loss.
 
 The native professional document model and renderer remain later work because controlled

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriter.java
@@ -19,6 +19,8 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringNode;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.distillation.DistillationColumn;
@@ -35,6 +37,7 @@ import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.equipment.tank.Tank;
 import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.processmodel.diagram.ProcessDiagramGraphAdapter;
 
 /** Writes the official DEXPI 2.0 Process information model for PFD/BFD data exchange. */
 public final class Dexpi20ProcessModelWriter {
@@ -82,10 +85,13 @@ public final class Dexpi20ProcessModelWriter {
    */
   public static Dexpi20ProcessTopologyAssessment.Report writeAndAssessTopology(ProcessSystem processSystem, File file,
       String plantId, String revision) throws IOException {
-    write(processSystem, file);
+    ProcessDiagramGraphAdapter.Result canonical = ProcessDiagramGraphAdapter.fromProcessSystem(processSystem, plantId,
+        revision);
+    writeCanonical(processSystem, file, canonical);
     Dexpi20ConformanceAssessment.Report conformance = Dexpi20ConformanceAssessment.assess(file.toPath(),
         Dexpi20ConformanceAssessment.Profile.PROCESS_PFD_BFD);
-    return Dexpi20ProcessTopologyAssessment.assess(processSystem, file.toPath(), plantId, revision, conformance);
+    return Dexpi20ProcessTopologyAssessment.assess(processSystem, file.toPath(), conformance, canonical,
+        "CANONICAL_ENGINEERING_GRAPH");
   }
 
   /** Writes a native DEXPI 2.0 Process model to a stream. */
@@ -93,6 +99,11 @@ public final class Dexpi20ProcessModelWriter {
     if (processSystem == null || outputStream == null) {
       throw new IllegalArgumentException("processSystem and outputStream must not be null");
     }
+    write(processSystem, outputStream, topology(processSystem));
+  }
+
+  private static void write(ProcessSystem processSystem, OutputStream outputStream, ModelTopology topology)
+      throws IOException {
     try {
       Document document = createDocument();
       Element model = document.createElement("Model");
@@ -109,7 +120,6 @@ public final class Dexpi20ProcessModelWriter {
       Element processModel = object(document, "ProcessModel1", "Process/ProcessModel");
       conceptualModel.appendChild(processModel);
 
-      ModelTopology topology = topology(processSystem);
       Element processSteps = components(document, processModel, "ProcessSteps");
       Map<ProcessEquipmentInterface, Step> steps = new IdentityHashMap<ProcessEquipmentInterface, Step>();
       int stepNumber = 1;
@@ -166,6 +176,25 @@ public final class Dexpi20ProcessModelWriter {
     }
   }
 
+  private static void writeCanonical(ProcessSystem processSystem, File file,
+      ProcessDiagramGraphAdapter.Result canonical) throws IOException {
+    if (file == null || canonical == null) {
+      throw new IllegalArgumentException("file and canonical must not be null");
+    }
+    FileOutputStream stream = new FileOutputStream(file);
+    try {
+      write(processSystem, stream, topology(processSystem, canonical));
+    } finally {
+      stream.close();
+    }
+    try {
+      Dexpi20XmlValidator.validate(file.toPath());
+      Dexpi20SemanticValidator.validateOrThrow(file.toPath());
+    } catch (org.xml.sax.SAXException ex) {
+      throw new IOException("Generated DEXPI 2.0 Process XML failed schema validation", ex);
+    }
+  }
+
   private static ModelTopology topology(ProcessSystem processSystem) {
     List<ProcessEquipmentInterface> units = new ArrayList<ProcessEquipmentInterface>();
     Map<StreamInterface, ProcessEquipmentInterface> sourceByStream = new IdentityHashMap<StreamInterface, ProcessEquipmentInterface>();
@@ -214,6 +243,55 @@ public final class Dexpi20ProcessModelWriter {
       throw new IllegalArgumentException("DEXPI Process export requires at least one material connection");
     }
     return new ModelTopology(units, links);
+  }
+
+  private static ModelTopology topology(ProcessSystem processSystem, ProcessDiagramGraphAdapter.Result canonical) {
+    ModelTopology direct = topology(processSystem);
+    EngineeringGraph graph = canonical.getGraph();
+    List<Link> projected = new ArrayList<Link>();
+    Map<Link, Boolean> consumed = new IdentityHashMap<Link, Boolean>();
+    for (EngineeringNode node : graph.getNodes().values()) {
+      if (node.getKind() != EngineeringNode.Kind.PIPE_SEGMENT) {
+        continue;
+      }
+      Link match = findDirectLink(direct.links, consumed, node);
+      if (match != null) {
+        projected.add(match);
+        consumed.put(match, Boolean.TRUE);
+      }
+    }
+    for (Link link : direct.links) {
+      if (!consumed.containsKey(link)) {
+        projected.add(link);
+      }
+    }
+    return new ModelTopology(direct.units, projected);
+  }
+
+  private static Link findDirectLink(List<Link> links, Map<Link, Boolean> consumed, EngineeringNode connection) {
+    String sourceName = property(connection, "sourceEquipment");
+    String targetName = property(connection, "targetEquipment");
+    String carriedName = property(connection, "carriedObjectName");
+    for (Link link : links) {
+      if (link.target != null && !consumed.containsKey(link) && sourceName.equals(link.source.getName())
+          && targetName.equals(link.target.getName()) && carriedName.equals(streamName(link.stream))) {
+        return link;
+      }
+    }
+    return null;
+  }
+
+  private static String property(EngineeringNode node, String name) {
+    Object value = node.getProperties().get(name);
+    return value == null ? "" : String.valueOf(value);
+  }
+
+  private static String streamName(StreamInterface stream) {
+    try {
+      return stream == null || stream.getName() == null ? "" : stream.getName();
+    } catch (RuntimeException ex) {
+      return "";
+    }
   }
 
   private static Step appendStep(Document document, Element processSteps, String id, String name, String type) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessTopologyAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessTopologyAssessment.java
@@ -142,6 +142,7 @@ public final class Dexpi20ProcessTopologyAssessment {
   public static final class Report implements Serializable {
     private static final long serialVersionUID = 1000L;
     private final Dexpi20ConformanceAssessment.Report conformanceReport;
+    private final String exportTopologySource;
     private final String canonicalFingerprint;
     private final List<String> canonicalConnectionIds;
     private final List<String> canonicalMaterialConnections;
@@ -149,11 +150,12 @@ public final class Dexpi20ProcessTopologyAssessment {
     private final List<ExportedConnection> exportedConnections;
     private final List<Diagnostic> diagnostics;
 
-    Report(Dexpi20ConformanceAssessment.Report conformanceReport, String canonicalFingerprint,
-        List<String> canonicalConnectionIds, List<String> canonicalMaterialConnections,
+    Report(Dexpi20ConformanceAssessment.Report conformanceReport, String exportTopologySource,
+        String canonicalFingerprint, List<String> canonicalConnectionIds, List<String> canonicalMaterialConnections,
         List<String> exportedMaterialConnections, List<ExportedConnection> exportedConnections,
         List<Diagnostic> diagnostics) {
       this.conformanceReport = conformanceReport;
+      this.exportTopologySource = exportTopologySource;
       this.canonicalFingerprint = canonicalFingerprint;
       this.canonicalConnectionIds = immutableCopy(canonicalConnectionIds);
       this.canonicalMaterialConnections = immutableCopy(canonicalMaterialConnections);
@@ -164,6 +166,11 @@ public final class Dexpi20ProcessTopologyAssessment {
 
     public Dexpi20ConformanceAssessment.Report getConformanceReport() {
       return conformanceReport;
+    }
+
+    /** @return topology source that drove the assessed export */
+    public String getExportTopologySource() {
+      return exportTopologySource;
     }
 
     public String getCanonicalFingerprint() {
@@ -201,6 +208,7 @@ public final class Dexpi20ProcessTopologyAssessment {
     public Map<String, Object> toMap() {
       Map<String, Object> result = new LinkedHashMap<String, Object>();
       result.put("schemaVersion", "neqsim_dexpi_2_0_process_topology_assessment.v1");
+      result.put("exportTopologySource", exportTopologySource);
       result.put("canonicalFingerprint", canonicalFingerprint);
       result.put("canonicalConnectionIds", new ArrayList<String>(canonicalConnectionIds));
       result.put("sourceProvenance", "SIMULATION_MODEL");
@@ -233,13 +241,14 @@ public final class Dexpi20ProcessTopologyAssessment {
     }
   }
 
-  static Report assess(ProcessSystem processSystem, Path file, String plantId, String revision,
-      Dexpi20ConformanceAssessment.Report conformanceReport) throws IOException {
+  static Report assess(ProcessSystem processSystem, Path file, Dexpi20ConformanceAssessment.Report conformanceReport,
+      ProcessDiagramGraphAdapter.Result canonical, String exportTopologySource) throws IOException {
     if (processSystem == null || file == null || conformanceReport == null) {
       throw new IllegalArgumentException("processSystem, file, and conformanceReport must not be null");
     }
-    ProcessDiagramGraphAdapter.Result canonical = ProcessDiagramGraphAdapter.fromProcessSystem(processSystem, plantId,
-        revision);
+    if (canonical == null || exportTopologySource == null || exportTopologySource.trim().isEmpty()) {
+      throw new IllegalArgumentException("canonical and exportTopologySource must not be null or blank");
+    }
     List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
     copyAdapterDiagnostics(canonical, diagnostics);
     EngineeringGraph graph = canonical.getGraph();
@@ -257,8 +266,8 @@ public final class Dexpi20ProcessTopologyAssessment {
     diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_GRAPHICS_UNSUPPORTED",
         "Native DEXPI 2.0 Process export contains semantic steps and streams but no governed drawing layout",
         processSystem.getName()));
-    return new Report(conformanceReport, canonical.getFingerprint(), connectionIds, expected, actual, exported,
-        diagnostics);
+    return new Report(conformanceReport, exportTopologySource, canonical.getFingerprint(), connectionIds, expected,
+        actual, exported, diagnostics);
   }
 
   private static void copyAdapterDiagnostics(ProcessDiagramGraphAdapter.Result canonical,

--- a/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
@@ -15,8 +15,8 @@
  * <li>{@link neqsim.process.processmodel.dexpi.DexpiMetadata} - Shared constants for DEXPI exchanges</li>
  * <li>{@link neqsim.process.processmodel.dexpi.DexpiRoundTripProfile} - Validation for round-trip fidelity</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessModelWriter} - Native DEXPI 2.0 Process exchange</li>
- * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessTopologyAssessment} - Canonical material-topology and
- * structured scope evidence for native Process exchange</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessTopologyAssessment} - Canonical material-topology
+ * projection and structured scope evidence for assessed native Process exchange</li>
  * </ul>
  *
  * <h2>Usage Example</h2>

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
@@ -32,6 +32,24 @@ class Dexpi20ProcessModelWriterTest {
   }
 
   @Test
+  void assessedExportConsumesCanonicalSnapshotWithoutChangingLegacyXml() throws Exception {
+    Path legacyOutput = temporaryDirectory.resolve("legacy-parallel-branch.dexpi.xml");
+    Path canonicalOutput = temporaryDirectory.resolve("canonical-parallel-branch.dexpi.xml");
+    Dexpi20ProcessModelWriter.write(ProcessDiagramGoldenFixtures.parallelBranchTrain().getProcessSystem(),
+        legacyOutput.toFile());
+
+    Dexpi20ProcessTopologyAssessment.Report report = Dexpi20ProcessModelWriter.writeAndAssessTopology(
+        ProcessDiagramGoldenFixtures.parallelBranchTrain().getProcessSystem(), canonicalOutput.toFile(),
+        "DEXPI-CANONICAL-PROJECTION", "A");
+
+    assertEquals(new String(Files.readAllBytes(legacyOutput), StandardCharsets.UTF_8),
+        new String(Files.readAllBytes(canonicalOutput), StandardCharsets.UTF_8));
+    assertEquals("CANONICAL_ENGINEERING_GRAPH", report.getExportTopologySource());
+    assertTrue(report.toJson().contains("\"exportTopologySource\": \"CANONICAL_ENGINEERING_GRAPH\""));
+    assertTrue(report.isSchemaProfileAndSupportedTopologyValid(), report.getDiagnostics().toString());
+  }
+
+  @Test
   void reportsUnsupportedTopologyAndDocumentScopesWithoutHidingMaterialEquivalence() throws Exception {
     ProcessDiagramGoldenFixtures.Fixture fixture = ProcessDiagramGoldenFixtures.simpleTrain();
     ProcessSystem process = fixture.getProcessSystem();
@@ -49,6 +67,21 @@ class Dexpi20ProcessModelWriterTest {
     assertTrue(hasDiagnostic(report, "DEXPI_PROCESS_MULTI_AREA_UNSUPPORTED"));
     assertTrue(hasDiagnostic(report, "DEXPI_PROCESS_DOCUMENT_SEMANTICS_UNSUPPORTED"));
     assertTrue(hasDiagnostic(report, "DEXPI_PROCESS_GRAPHICS_UNSUPPORTED"));
+  }
+
+  @Test
+  void reportsCanonicalMaterialConnectionWithoutSimulationStreamAsLoss() throws Exception {
+    ProcessSystem process = ProcessDiagramGoldenFixtures.simpleTrain().getProcessSystem();
+    process.connect("heater", "manualRecycleOutlet", "feed", "manualRecycleInlet",
+        ProcessConnection.ConnectionType.MATERIAL);
+    Path output = temporaryDirectory.resolve("unresolved-canonical-material.dexpi.xml");
+
+    Dexpi20ProcessTopologyAssessment.Report report = Dexpi20ProcessModelWriter.writeAndAssessTopology(process,
+        output.toFile(), "DEXPI-CANONICAL-LOSS", "A");
+
+    assertFalse(report.isSupportedMaterialTopologyEquivalent());
+    assertTrue(hasDiagnostic(report, "DEXPI_PROCESS_MATERIAL_CONNECTION_MISSING"));
+    assertTrue(report.getConformanceReport().isSchemaAndProfileConformant());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- build one `ProcessDiagramGraphAdapter` snapshot for the topology-assessed DEXPI 2.0 Process path
- project the supported material subset from that canonical engineering graph while preserving the existing sequential DEXPI identifiers, physical quantities, and XML structure
- assess the same snapshot and expose `exportTopologySource=CANONICAL_ENGINEERING_GRAPH` as reviewable evidence
- keep unmatched direct material links visible to structured loss diagnostics instead of silently dropping them
- add byte-equivalence and fail-visible regression coverage, plus conformance and exporter-inventory documentation

## Compatibility

The public `write(...)` and `writeAndAssess(...)` paths are unchanged. Legacy Graphviz/DOT output, Proteus/P&ID export, and existing DEXPI XML identifiers remain unchanged. This increment is limited to `ProcessSystem`; it does not claim ISO 10628 or full DEXPI conformance.

## Validation

- `./mvnw -o -Dtest=ProcessDiagramGraphAdapterTest,ProcessDiagramTopologyEquivalenceTest,Dexpi20ProcessModelWriterTest test`: **20 tests passed**; Maven compiled 3,148 production and 1,672 test sources
- changed production and test sources compiled with ECJ `-source 1.8 -target 1.8`
- `python devtools/run_spotless.py apply` stable
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`: 648 Markdown and 1 HTML file checked
- pre-commit and pre-push stages
- `git diff --check`
- hosted `Assert javadoc with Java 21 on Ubuntu`: **passed**

The local offline Javadoc attempt lacked report-plugin artifacts in its cache; the successful hosted Javadoc job confirms this was environmental.

## Documentation impact

Updated the DEXPI 2.0 conformance guide, the process-diagram exporter inventory, and package documentation. No notebook or visual artifact is appropriate for this low-level topology migration.

## Limitations and next dependency

This does not yet add multi-area `ProcessModel` export, energy/signal exchange, canonical operating-value provenance, document/sheet/off-page metadata, graphics/layout, native SVG/PDF, or a stable-ID migration for DEXPI XML. The next dependency-ordered increment is to carry selected operating values, units, case, and provenance in the canonical model before widening the exporter to multi-area `ProcessModel`.

Relates to #1332 and coordinates with #2899.