### PR TITLE
[AI-Assisted] Treat dispersed-bubble drag as a stiff conservative source

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -167,6 +167,38 @@ Separate momentum equations for each phase:
 | Wall friction | Pipe roughness-based (Colebrook/Blasius correlations) |
 | Interfacial friction | Flow-regime dependent correlations |
 
+#### Optional stiff dispersed-bubble drag
+
+`setEnableStiffBubbleDrag(true)` opts into the dimensionally correct Schiller-Naumann
+dispersed-bubble force and a conservative local implicit source solve. For a spherical bubble
+population,
+
+$$
+F_i=\frac{3}{4} C_D \rho_L \alpha_G \frac{A}{d_b}
+(v_G-v_L)|v_G-v_L|,
+\qquad a_i=\frac{6\alpha_G}{d_b},
+\qquad f_i=\frac{C_D}{4}.
+$$
+
+The implementation uses the existing Hinze bubble diameter, capped at one fifth of the pipe
+diameter, and the existing fixed 0.02 N/m surface-tension assumption. Schiller-Naumann describes
+rigid spherical particles in a dilute continuous phase; the closure does not model deformation,
+coalescence, breakup, or a bubble-size distribution.
+
+The source operator solves the active gas and combined-liquid momenta by backward Euler and applies
+one half-step on each side of the transport update. It conserves total active-phase momentum to
+roundoff, decreases slip and kinetic energy, removes exactly absent phases instead of applying a
+mass floor, and partitions the liquid impulse by active oil/water mass so existing oil-water slip is
+preserved. The source evaluation is local and retains no stage history.
+
+This mode is opt-in for migration compatibility. The legacy force scaling remains the default
+because the corrected closure, although numerically stable, is not yet quantitatively validated by
+the public Tengesdal severe-slugging benchmark. Without relaxing its acceptance bounds, the opt-in
+model passes 3 of 6 cases: its smallest pressure swing is 167.1 kPa against 98 +/- 5 kPa, its slug
+length ratio is 1.164, and the 16-section, 0.1 s case does not establish a repeated cycle. The
+compatibility default continues to pass all 6 cases. These results indicate a remaining closure or
+regime-transition limitation rather than a stiff-source instability.
+
 #### Optional virtual-mass coupling
 
 `setEnableVirtualMassForce(true)` enables a local added-inertia coupling between gas and combined

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -421,9 +421,37 @@ else if (Re_b < 1000):
 else:
     C_D = 0.44          // Newton regime
 
-// Friction factor
-f_i = C_D × d_b / (4 × D)
+// Corrected dispersed-bubble friction factor
+f_i = C_D / 4
 ```
+
+With interfacial area concentration `a_i = 6 × α_G / d_b`, the corresponding force per pipe length
+is
+
+$$
+F_i=\frac{3}{4}C_D\rho_L\alpha_G\frac{A}{d_b}
+(v_G-v_L)|v_G-v_L|.
+$$
+
+The corrected force uses liquid-continuum density and is selected together with a local implicit
+source solve by calling `TwoFluidPipe.setEnableStiffBubbleDrag(true)`. The local backward-Euler
+operator is split into half-steps around transport, conserves active gas-oil-water momentum to
+roundoff, cannot increase kinetic energy, and introduces no phase-mass floor. Oil and water receive
+the liquid impulse in proportion to active mass, preserving their relative velocity. Bubble and
+dispersed-bubble classifications use the same source treatment; neighboring regimes retain their
+existing closures.
+
+The bubble diameter is the existing Hinze estimate capped at `D/5`; the current closure assumes a
+fixed surface tension of 0.02 N/m. Schiller-Naumann assumes a dilute population of rigid spherical
+particles and does not represent bubble deformation, coalescence, breakup, or a size distribution.
+
+The stiff corrected mode is opt-in. Existing simulations retain the legacy `C_D × d_b/(4D)` scaling
+unless enabled, because the corrected mode is not yet quantitatively validated by the public
+Tengesdal severe-slugging benchmark. With the published bounds unchanged, the compatibility default
+passes 6 of 6 cases, while the stable corrected mode passes 3 of 6. Its smallest pressure swing is
+167.1 kPa against 98 +/- 5 kPa, its slug-length ratio is 1.164, and the 16-section, 0.1 s case does
+not establish a repeated cycle. This is a documented physical closure/regime-transition limitation,
+not evidence of numerical source instability.
 
 #### Hart et al. (1989) Correlation
 

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -3682,7 +3682,9 @@ public class TwoFluidPipe extends Pipeline {
             outletPressure, outletFixed);
       }
 
-      double[][] U_new = timeIntegrator.step(U_prev, rhs, dtFinal);
+      double[][] splitState = applyStiffBubbleDragSourceStep(U_prev, 0.5 * dtFinal);
+      double[][] U_new = timeIntegrator.step(splitState, rhs, dtFinal);
+      U_new = applyStiffBubbleDragSourceStep(U_new, 0.5 * dtFinal);
 
       // 4. ADAPTIVE: check RAW state for NaN/Inf/negative mass BEFORE clamping
       // Only hard-reject on unphysical values. Normal transient changes (even large)
@@ -3875,6 +3877,16 @@ public class TwoFluidPipe extends Pipeline {
     updateResultArrays();
 
     setCalculationIdentifier(id);
+  }
+
+  private double[][] applyStiffBubbleDragSourceStep(double[][] state, double timeStep) {
+    if (!equations.isStiffBubbleDragEnabled() || timeStep == 0.0) {
+      return state;
+    }
+    equations.applyState(sections, state);
+    applyBoundaryConditions();
+    double[][] boundaryState = equations.extractState(sections);
+    return equations.applyStiffBubbleDrag(sections, boundaryState, timeStep);
   }
 
   private void accumulateAcceptedMassBalance(List<TwoFluidConservationEquations.MassBalanceRate> stageRates,
@@ -6262,6 +6274,30 @@ public class TwoFluidPipe extends Pipeline {
       return timeIntegrator.getMethod();
     }
     return TimeIntegrator.Method.RK4;
+  }
+
+  /**
+   * Enable or disable conservative local implicit treatment of dispersed-bubble drag.
+   *
+   * <p>
+   * The treatment is opt-in because the corrected closure is not yet quantitatively validated by the public Tengesdal
+   * severe-slugging benchmark. Enabling it selects the dimensionally correct Schiller-Naumann force and the local
+   * implicit source solve together.
+   * </p>
+   *
+   * @param enable true to use the local stiff source solve
+   */
+  public void setEnableStiffBubbleDrag(boolean enable) {
+    equations.setEnableStiffBubbleDrag(enable);
+  }
+
+  /**
+   * Check whether dispersed-bubble drag uses the conservative local implicit source solve.
+   *
+   * @return true when the stiff source treatment is enabled
+   */
+  public boolean isStiffBubbleDragEnabled() {
+    return equations.isStiffBubbleDragEnabled();
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -7,6 +7,7 @@ import neqsim.process.equipment.pipeline.twophasepipe.closure.WallFriction;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.AUSMPlusFluxCalculator;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.AUSMPlusFluxCalculator.PhaseFlux;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.AUSMPlusFluxCalculator.PhaseState;
+import neqsim.process.equipment.pipeline.twophasepipe.numerics.DispersedBubbleDragSolver;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.MUSCLReconstructor;
 
 /**
@@ -119,6 +120,9 @@ public class TwoFluidConservationEquations implements Serializable {
    * practice.
    */
   private double virtualMassCoefficient = 0.5;
+
+  /** Treat corrected bubble drag with a conservative local implicit source step when opted in. */
+  private boolean enableStiffBubbleDrag = false;
 
   /** Retained timestep setting for source compatibility with existing callers. */
   private double dt = 0.01;
@@ -735,8 +739,9 @@ public class TwoFluidConservationEquations implements Serializable {
 
       // Interfacial friction force (N/m)
       // Positive interfacial shear decelerates gas, accelerates liquid
-      double F_iG = -sec.getInterfacialShear() * S_i;
-      double F_iL = sec.getInterfacialShear() * S_i;
+      boolean stiffBubbleDrag = enableStiffBubbleDrag && isDispersedBubbleRegime(sec.getFlowRegime());
+      double F_iG = stiffBubbleDrag ? 0.0 : -sec.getInterfacialShear() * S_i;
+      double F_iL = stiffBubbleDrag ? 0.0 : sec.getInterfacialShear() * S_i;
 
       // Gravity forces (N/m) - calculated separately for oil and water
       double F_gG = -alphaG * rhoG * GRAVITY * A * sinTheta;
@@ -928,6 +933,62 @@ public class TwoFluidConservationEquations implements Serializable {
       sec.setGasMomentumSource(sec.getGasMomentumSource() + gasVirtualMassForce);
       sec.setLiquidMomentumSource(sec.getLiquidMomentumSource() - gasVirtualMassForce);
     }
+  }
+
+  /**
+   * Advance corrected dispersed-bubble drag with a pure local implicit source solve.
+   *
+   * <p>
+   * The input state is not modified. Gas and combined-liquid momentum are coupled conservatively; the liquid impulse is
+   * distributed by active oil/water mass so water-oil slip is preserved. The energy state is unchanged, making lost
+   * kinetic energy available as internal energy.
+   * </p>
+   *
+   * @param sections sections whose primitive properties correspond to {@code state}
+   * @param state conservative state before the drag source step
+   * @param timeStep source-step duration in s
+   * @return a new conservative state after dispersed-bubble drag
+   * @throws IllegalArgumentException if section/state dimensions or the time step are invalid
+   */
+  public double[][] applyStiffBubbleDrag(TwoFluidSection[] sections, double[][] state, double timeStep) {
+    if (sections == null || state == null || sections.length != state.length) {
+      throw new IllegalArgumentException("Section and state dimensions must agree");
+    }
+    if (!Double.isFinite(timeStep) || timeStep < 0.0) {
+      throw new IllegalArgumentException("Bubble-drag source-step duration must be finite and non-negative");
+    }
+
+    double[][] result = new double[state.length][NUM_EQUATIONS];
+    for (int sectionIndex = 0; sectionIndex < state.length; sectionIndex++) {
+      if (state[sectionIndex] == null || state[sectionIndex].length != NUM_EQUATIONS) {
+        throw new IllegalArgumentException("Every section state must contain seven conservative variables");
+      }
+      System.arraycopy(state[sectionIndex], 0, result[sectionIndex], 0, NUM_EQUATIONS);
+      if (!enableStiffBubbleDrag || timeStep == 0.0) {
+        continue;
+      }
+
+      TwoFluidSection section = sections[sectionIndex];
+      PipeSection.FlowRegime regime = flowRegimeDetector.detectFlowRegime(section);
+      if (!isDispersedBubbleRegime(regime)) {
+        continue;
+      }
+      double[] masses = { state[sectionIndex][IDX_GAS_MASS], state[sectionIndex][IDX_OIL_MASS],
+          state[sectionIndex][IDX_WATER_MASS] };
+      double[] momenta = { state[sectionIndex][IDX_GAS_MOMENTUM], state[sectionIndex][IDX_OIL_MOMENTUM],
+          state[sectionIndex][IDX_WATER_MOMENTUM] };
+      double[] relaxedMomenta = DispersedBubbleDragSolver.relax(regime, masses, momenta, section.getGasDensity(),
+          section.getLiquidDensity(), section.getGasViscosity(), section.getLiquidViscosity(),
+          section.getLiquidHoldup(), section.getDiameter(), section.getSurfaceTension(), timeStep, interfacialFriction);
+      result[sectionIndex][IDX_GAS_MOMENTUM] = relaxedMomenta[0];
+      result[sectionIndex][IDX_OIL_MOMENTUM] = relaxedMomenta[1];
+      result[sectionIndex][IDX_WATER_MOMENTUM] = relaxedMomenta[2];
+    }
+    return result;
+  }
+
+  private boolean isDispersedBubbleRegime(PipeSection.FlowRegime flowRegime) {
+    return flowRegime == PipeSection.FlowRegime.BUBBLE || flowRegime == PipeSection.FlowRegime.DISPERSED_BUBBLE;
   }
 
   /**
@@ -1496,6 +1557,30 @@ public class TwoFluidConservationEquations implements Serializable {
    */
   public double getVirtualMassCoefficient() {
     return virtualMassCoefficient;
+  }
+
+  /**
+   * Enable or disable conservative local implicit treatment of bubble drag.
+   *
+   * <p>
+   * This mode is opt-in because the corrected closure is not yet quantitatively validated by the public Tengesdal
+   * severe-slugging benchmark. Enabling it selects the corrected force and the stiff source treatment together.
+   * </p>
+   *
+   * @param enable true to use the local stiff source solve
+   */
+  public void setEnableStiffBubbleDrag(boolean enable) {
+    this.enableStiffBubbleDrag = enable;
+    interfacialFriction.setUseCorrectedBubbleDrag(enable);
+  }
+
+  /**
+   * Check whether corrected bubble drag uses the local stiff source solve.
+   *
+   * @return true when conservative implicit bubble drag is enabled
+   */
+  public boolean isStiffBubbleDragEnabled() {
+    return enableStiffBubbleDrag;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFriction.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFriction.java
@@ -23,7 +23,8 @@ import neqsim.process.equipment.pipeline.twophasepipe.closure.GeometryCalculator
  * <h2>Sign Convention</h2>
  * <p>
  * Positive interfacial shear acts to accelerate the liquid and decelerate the gas (gas faster than liquid). The shear
- * stress is defined as: τ_i = 0.5 * f_i * ρ_G * (v_G - v_L) * |v_G - v_L|
+ * stress is defined as: τ_i = 0.5 * f_i * ρ_c * (v_G - v_L) * |v_G - v_L|, where ρ_c is the continuous-phase density
+ * selected by the regime closure.
  * </p>
  *
  * @author Even Solbraa
@@ -33,6 +34,9 @@ public class InterfacialFriction implements Serializable {
 
   private static final long serialVersionUID = 1L;
   private static final double GRAVITY = 9.81;
+
+  /** Retain validated compatibility scaling unless corrected stiff drag is explicitly selected. */
+  private boolean useCorrectedBubbleDrag = false;
 
   /** Geometry calculator for stratified flow. */
   private GeometryCalculator geometryCalc;
@@ -411,6 +415,11 @@ public class InterfacialFriction implements Serializable {
    */
   private InterfacialFrictionResult calcBubble(double vG, double vL, double rhoG, double rhoL, double muG, double muL,
       double alphaL, double D) {
+    return calcBubble(vG, vL, rhoG, rhoL, muG, muL, alphaL, D, useCorrectedBubbleDrag);
+  }
+
+  private InterfacialFrictionResult calcBubble(double vG, double vL, double rhoG, double rhoL, double muG, double muL,
+      double alphaL, double D, boolean useCorrectedDrag) {
     InterfacialFrictionResult result = new InterfacialFrictionResult();
 
     result.slipVelocity = vG - vL;
@@ -446,8 +455,17 @@ public class InterfacialFriction implements Serializable {
       C_D = 0.44;
     }
 
-    // Friction factor
-    result.frictionFactor = C_D * d_b / (4.0 * D);
+    if (useCorrectedDrag) {
+      // Express the standard dispersed-phase drag force
+      // F_D/V = 3/4 C_D rho_L alpha_G |u_r| u_r / d_b
+      // as tau_i * a_i, with a_i = 6 alpha_G/d_b and
+      // tau_i = 1/8 C_D rho_L |u_r| u_r = 1/2 f_i rho_L |u_r| u_r.
+      result.frictionFactor = C_D / 4.0;
+    } else {
+      // Preserve the existing quantitatively benchmarked response until the corrected
+      // closure is validated for the public severe-slugging case.
+      result.frictionFactor = C_D * d_b / (4.0 * D);
+    }
 
     // Interfacial shear (drag force per unit volume * characteristic length)
     result.interfacialShear = 0.5 * result.frictionFactor * rhoL * result.slipVelocity * Math.abs(result.slipVelocity);
@@ -482,6 +500,56 @@ public class InterfacialFriction implements Serializable {
         gasViscosity, liquidViscosity, liquidHoldup, diameter, surfaceTension);
 
     return result.interfacialShear * result.interfacialAreaPerLength;
+  }
+
+  /**
+   * Calculate the dimensionally correct Schiller-Naumann force independently of compatibility mode.
+   *
+   * @param flowRegime bubble or dispersed-bubble flow regime
+   * @param gasVelocity gas velocity in m/s
+   * @param liquidVelocity liquid velocity in m/s
+   * @param gasDensity gas density in kg/m3
+   * @param liquidDensity liquid density in kg/m3
+   * @param gasViscosity gas viscosity in Pa s
+   * @param liquidViscosity liquid viscosity in Pa s
+   * @param liquidHoldup liquid volume fraction
+   * @param diameter pipe internal diameter in m
+   * @param surfaceTension gas-liquid surface tension in N/m
+   * @return corrected drag force per pipe length in N/m
+   */
+  public double calcCorrectedBubbleDragForce(FlowRegime flowRegime, double gasVelocity, double liquidVelocity,
+      double gasDensity, double liquidDensity, double gasViscosity, double liquidViscosity, double liquidHoldup,
+      double diameter, double surfaceTension) {
+    if (flowRegime != FlowRegime.BUBBLE && flowRegime != FlowRegime.DISPERSED_BUBBLE) {
+      return calcInterfacialForce(flowRegime, gasVelocity, liquidVelocity, gasDensity, liquidDensity, gasViscosity,
+          liquidViscosity, liquidHoldup, diameter, surfaceTension);
+    }
+    InterfacialFrictionResult result = calcBubble(gasVelocity, liquidVelocity, gasDensity, liquidDensity, gasViscosity,
+        liquidViscosity, liquidHoldup, diameter, true);
+    return result.interfacialShear * result.interfacialAreaPerLength;
+  }
+
+  /**
+   * Select the corrected dispersed-bubble force representation.
+   *
+   * <p>
+   * This is configured automatically by {@code TwoFluidPipe.setEnableStiffBubbleDrag(true)}. Direct use without a stiff
+   * source integrator can violate the explicit time-step limit.
+   * </p>
+   *
+   * @param useCorrected true for {@code f_i = C_D/4}; false for compatibility scaling
+   */
+  public void setUseCorrectedBubbleDrag(boolean useCorrected) {
+    this.useCorrectedBubbleDrag = useCorrected;
+  }
+
+  /**
+   * Check whether the corrected dispersed-bubble force representation is selected.
+   *
+   * @return true for the dimensionally correct Schiller-Naumann representation
+   */
+  public boolean isUseCorrectedBubbleDrag() {
+    return useCorrectedBubbleDrag;
   }
 
   // ============ Hart Correlation (1989) for Stratified Wavy Flow ============

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/DispersedBubbleDragSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/DispersedBubbleDragSolver.java
@@ -1,0 +1,176 @@
+package neqsim.process.equipment.pipeline.twophasepipe.numerics;
+
+import java.util.Arrays;
+import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
+import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction;
+
+/**
+ * Pure local implicit solver for Schiller-Naumann dispersed-bubble momentum exchange.
+ *
+ * <p>
+ * Oil and water are treated as one constrained continuous-liquid momentum during gas-liquid drag. The liquid impulse is
+ * distributed by active phase mass, so the oil-water velocity difference is unchanged. This preserves total
+ * gas-oil-water momentum and makes kinetic energy non-increasing without inventing an absent phase. Oil-water
+ * interfacial shear remains a separate closure.
+ * </p>
+ */
+public final class DispersedBubbleDragSolver {
+  private static final int BISECTION_ITERATIONS = 100;
+
+  private DispersedBubbleDragSolver() {
+  }
+
+  /**
+   * Advance gas, oil, and water momenta through one backward-Euler bubble-drag step.
+   *
+   * @param flowRegime current gas-liquid flow regime
+   * @param masses gas, oil, and water masses per pipe length in kg/m
+   * @param momenta gas, oil, and water momenta per pipe length in kg/s
+   * @param gasDensity gas density in kg/m3
+   * @param liquidDensity continuous-liquid density in kg/m3
+   * @param gasViscosity gas viscosity in Pa s
+   * @param liquidViscosity continuous-liquid viscosity in Pa s
+   * @param liquidHoldup total liquid holdup
+   * @param diameter pipe internal diameter in m
+   * @param surfaceTension gas-liquid surface tension in N/m
+   * @param timeStep time step in s
+   * @param dragLaw interfacial drag closure
+   * @return gas, oil, and water momenta after the local drag step in kg/s
+   * @throws IllegalArgumentException if an input is invalid
+   * @throws IllegalStateException if the closure is non-finite or the step is not dissipative
+   */
+  public static double[] relax(FlowRegime flowRegime, double[] masses, double[] momenta, double gasDensity,
+      double liquidDensity, double gasViscosity, double liquidViscosity, double liquidHoldup, double diameter,
+      double surfaceTension, double timeStep, InterfacialFriction dragLaw) {
+    validateInputs(masses, momenta, gasDensity, liquidDensity, gasViscosity, liquidViscosity, liquidHoldup, diameter,
+        surfaceTension, timeStep, dragLaw);
+    double[] result = momenta.clone();
+    if (!isDispersedBubbleRegime(flowRegime) || timeStep == 0.0) {
+      return result;
+    }
+    for (int phase = 0; phase < masses.length; phase++) {
+      if (masses[phase] == 0.0) {
+        result[phase] = 0.0;
+      }
+    }
+
+    double gasMass = masses[0];
+    double oilMass = masses[1];
+    double waterMass = masses[2];
+    double liquidMass = oilMass + waterMass;
+    if (gasMass == 0.0 || liquidMass == 0.0) {
+      return result;
+    }
+
+    double gasMomentum = momenta[0];
+    double liquidMomentum = (oilMass > 0.0 ? momenta[1] : 0.0) + (waterMass > 0.0 ? momenta[2] : 0.0);
+    double gasVelocity = gasMomentum / gasMass;
+    double liquidVelocity = liquidMomentum / liquidMass;
+    double initialSlip = gasVelocity - liquidVelocity;
+    double initialSlipMagnitude = Math.abs(initialSlip);
+    if (initialSlipMagnitude < 1.0e-10) {
+      return result;
+    }
+
+    double inverseMassSum = 1.0 / gasMass + 1.0 / liquidMass;
+    double slipSign = Math.signum(initialSlip);
+    double lowerSlip = 0.0;
+    double upperSlip = initialSlipMagnitude;
+    for (int iteration = 0; iteration < BISECTION_ITERATIONS; iteration++) {
+      double trialSlip = 0.5 * (lowerSlip + upperSlip);
+      double force = bubbleForceMagnitude(dragLaw, flowRegime, slipSign * trialSlip, gasDensity, liquidDensity,
+          gasViscosity, liquidViscosity, liquidHoldup, diameter, surfaceTension);
+      double residual = trialSlip + timeStep * inverseMassSum * force - initialSlipMagnitude;
+      if (residual > 0.0) {
+        upperSlip = trialSlip;
+      } else {
+        lowerSlip = trialSlip;
+      }
+    }
+    double relaxedSlip = 0.5 * (lowerSlip + upperSlip);
+    double relaxedForce = bubbleForceMagnitude(dragLaw, flowRegime, slipSign * relaxedSlip, gasDensity, liquidDensity,
+        gasViscosity, liquidViscosity, liquidHoldup, diameter, surfaceTension);
+    double pairCoefficient = relaxedSlip > 0.0 ? relaxedForce / relaxedSlip : 0.0;
+
+    double[] pseudoMasses = { gasMass, liquidMass };
+    double[] pseudoMomenta = { gasMomentum, liquidMomentum };
+    double[][] pairCoefficients = { { 0.0, pairCoefficient }, { pairCoefficient, 0.0 } };
+    double[] relaxedPseudoMomenta = StiffInterphaseMomentumSolver.solve(pseudoMasses, pseudoMomenta, pairCoefficients,
+        timeStep);
+
+    result[0] = relaxedPseudoMomenta[0];
+    double liquidVelocityChange = relaxedPseudoMomenta[1] / liquidMass - liquidVelocity;
+    if (oilMass > 0.0) {
+      result[1] = momenta[1] + oilMass * liquidVelocityChange;
+    } else {
+      result[1] = 0.0;
+    }
+    if (waterMass > 0.0) {
+      result[2] = momenta[2] + waterMass * liquidVelocityChange;
+    } else {
+      result[2] = 0.0;
+    }
+    double liquidMomentumResidual = relaxedPseudoMomenta[1] - result[1] - result[2];
+    if (oilMass >= waterMass && oilMass > 0.0) {
+      result[1] += liquidMomentumResidual;
+    } else if (waterMass > 0.0) {
+      result[2] += liquidMomentumResidual;
+    }
+
+    double initialEnergy = kineticEnergy(masses, momenta);
+    double finalEnergy = kineticEnergy(masses, result);
+    double tolerance = 1.0e-10 * Math.max(1.0, initialEnergy);
+    if (finalEnergy > initialEnergy + tolerance) {
+      throw new IllegalStateException("Dispersed-bubble drag increased kinetic energy from " + initialEnergy + " to "
+          + finalEnergy + "; masses=" + Arrays.toString(masses) + "; momenta=" + Arrays.toString(momenta) + "; result="
+          + Arrays.toString(result));
+    }
+    return result;
+  }
+
+  private static boolean isDispersedBubbleRegime(FlowRegime flowRegime) {
+    return flowRegime == FlowRegime.BUBBLE || flowRegime == FlowRegime.DISPERSED_BUBBLE;
+  }
+
+  private static double bubbleForceMagnitude(InterfacialFriction dragLaw, FlowRegime flowRegime, double slipVelocity,
+      double gasDensity, double liquidDensity, double gasViscosity, double liquidViscosity, double liquidHoldup,
+      double diameter, double surfaceTension) {
+    double force = dragLaw.calcCorrectedBubbleDragForce(flowRegime, slipVelocity, 0.0, gasDensity, liquidDensity,
+        gasViscosity, liquidViscosity, liquidHoldup, diameter, surfaceTension);
+    if (!Double.isFinite(force)) {
+      throw new IllegalStateException("Dispersed-bubble drag force must be finite");
+    }
+    return Math.abs(force);
+  }
+
+  private static void validateInputs(double[] masses, double[] momenta, double gasDensity, double liquidDensity,
+      double gasViscosity, double liquidViscosity, double liquidHoldup, double diameter, double surfaceTension,
+      double timeStep, InterfacialFriction dragLaw) {
+    if (masses == null || momenta == null || masses.length != 3 || momenta.length != 3) {
+      throw new IllegalArgumentException("Gas, oil, and water mass and momentum arrays are required");
+    }
+    for (int phase = 0; phase < masses.length; phase++) {
+      if (!Double.isFinite(masses[phase]) || masses[phase] < 0.0 || !Double.isFinite(momenta[phase])) {
+        throw new IllegalArgumentException("Phase masses and momenta must be finite and masses non-negative");
+      }
+    }
+    if (!Double.isFinite(gasDensity) || gasDensity <= 0.0 || !Double.isFinite(liquidDensity)
+        || liquidDensity <= gasDensity || !Double.isFinite(gasViscosity) || gasViscosity <= 0.0
+        || !Double.isFinite(liquidViscosity) || liquidViscosity <= 0.0 || !Double.isFinite(liquidHoldup)
+        || liquidHoldup < 0.0 || liquidHoldup > 1.0 || !Double.isFinite(diameter) || diameter <= 0.0
+        || !Double.isFinite(surfaceTension) || surfaceTension < 0.0 || !Double.isFinite(timeStep) || timeStep < 0.0
+        || dragLaw == null) {
+      throw new IllegalArgumentException("Dispersed-bubble drag inputs are outside their valid range");
+    }
+  }
+
+  private static double kineticEnergy(double[] masses, double[] momenta) {
+    double energy = 0.0;
+    for (int phase = 0; phase < masses.length; phase++) {
+      if (masses[phase] > 0.0) {
+        energy += 0.5 * momenta[phase] * momenta[phase] / masses[phase];
+      }
+    }
+    return energy;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/StiffInterphaseMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/StiffInterphaseMomentumSolver.java
@@ -1,0 +1,190 @@
+package neqsim.process.equipment.pipeline.twophasepipe.numerics;
+
+/**
+ * Local backward-Euler solver for conservative pairwise interphase momentum exchange.
+ *
+ * <p>
+ * For active phases {@code i}, the solver advances velocity with the symmetric system
+ * </p>
+ *
+ * <pre>
+ * (m_i + dt sum_j b_ij) u_i - dt sum_j b_ij u_j = p_i,
+ * </pre>
+ *
+ * <p>
+ * where {@code m_i} is mass per pipe length, {@code p_i} is momentum per pipe length, and {@code b_ij = b_ji >= 0}.
+ * Summing the rows proves conservation of total active-phase momentum. The symmetric non-negative coupling also makes
+ * kinetic energy non-increasing.
+ * </p>
+ */
+public final class StiffInterphaseMomentumSolver {
+  private static final double SYMMETRY_TOLERANCE = 1.0e-12;
+
+  private StiffInterphaseMomentumSolver() {
+  }
+
+  /**
+   * Advance phase momenta through one local implicit exchange step.
+   *
+   * <p>
+   * A phase with exactly zero mass is removed from the active matrix. No mass floor is introduced and no phase
+   * inventory is created.
+   * </p>
+   *
+   * @param masses phase masses per pipe length in kg/m
+   * @param momenta phase momenta per pipe length in kg/s
+   * @param pairCoefficients symmetric pair coefficients in kg/(m s)
+   * @param timeStep time step in s
+   * @return updated phase momenta in kg/s
+   * @throws IllegalArgumentException if dimensions disagree or an input is invalid
+   * @throws IllegalStateException if the local system cannot be solved dissipatively
+   */
+  public static double[] solve(double[] masses, double[] momenta, double[][] pairCoefficients, double timeStep) {
+    validateInputs(masses, momenta, pairCoefficients, timeStep);
+    double[] result = momenta.clone();
+    if (timeStep == 0.0) {
+      return result;
+    }
+
+    int[] active = new int[masses.length];
+    int activeCount = 0;
+    for (int phase = 0; phase < masses.length; phase++) {
+      if (masses[phase] > 0.0) {
+        active[activeCount++] = phase;
+      } else {
+        result[phase] = 0.0;
+      }
+    }
+    if (activeCount == 0) {
+      return result;
+    }
+
+    double[][] matrix = new double[activeCount][activeCount];
+    double[] rightHandSide = new double[activeCount];
+    for (int row = 0; row < activeCount; row++) {
+      int phase = active[row];
+      matrix[row][row] = masses[phase];
+      rightHandSide[row] = momenta[phase];
+      for (int column = 0; column < activeCount; column++) {
+        if (row == column) {
+          continue;
+        }
+        int otherPhase = active[column];
+        double coupling = timeStep * pairCoefficients[phase][otherPhase];
+        matrix[row][row] += coupling;
+        matrix[row][column] -= coupling;
+      }
+    }
+
+    double[] velocities = solveLinearSystem(matrix, rightHandSide);
+    double initialMomentum = 0.0;
+    double finalMomentum = 0.0;
+    double initialKineticEnergy = 0.0;
+    double finalKineticEnergy = 0.0;
+    int correctionPhase = active[0];
+    for (int row = 0; row < activeCount; row++) {
+      int phase = active[row];
+      result[phase] = masses[phase] * velocities[row];
+      initialMomentum += momenta[phase];
+      finalMomentum += result[phase];
+      initialKineticEnergy += 0.5 * momenta[phase] * momenta[phase] / masses[phase];
+      finalKineticEnergy += 0.5 * result[phase] * result[phase] / masses[phase];
+      if (masses[phase] > masses[correctionPhase]) {
+        correctionPhase = phase;
+      }
+    }
+
+    result[correctionPhase] += initialMomentum - finalMomentum;
+    finalKineticEnergy = kineticEnergy(masses, result);
+    double energyTolerance = 5.0e-13 * Math.max(1.0, initialKineticEnergy);
+    if (finalKineticEnergy > initialKineticEnergy + energyTolerance) {
+      throw new IllegalStateException("Implicit interphase momentum solve increased kinetic energy");
+    }
+    return result;
+  }
+
+  private static void validateInputs(double[] masses, double[] momenta, double[][] pairCoefficients, double timeStep) {
+    if (masses == null || momenta == null || pairCoefficients == null || masses.length == 0
+        || masses.length != momenta.length || pairCoefficients.length != masses.length) {
+      throw new IllegalArgumentException("Mass, momentum, and pair-coefficient dimensions must agree");
+    }
+    if (!Double.isFinite(timeStep) || timeStep < 0.0) {
+      throw new IllegalArgumentException("Time step must be finite and non-negative");
+    }
+    for (int phase = 0; phase < masses.length; phase++) {
+      if (!Double.isFinite(masses[phase]) || masses[phase] < 0.0 || !Double.isFinite(momenta[phase])) {
+        throw new IllegalArgumentException("Phase masses and momenta must be finite and masses non-negative");
+      }
+      if (pairCoefficients[phase] == null || pairCoefficients[phase].length != masses.length) {
+        throw new IllegalArgumentException("Pair-coefficient matrix must be square");
+      }
+    }
+    for (int phase = 0; phase < masses.length; phase++) {
+      for (int otherPhase = 0; otherPhase < masses.length; otherPhase++) {
+        double coefficient = pairCoefficients[phase][otherPhase];
+        if (!Double.isFinite(coefficient) || coefficient < 0.0) {
+          throw new IllegalArgumentException("Pair coefficients must be finite and non-negative");
+        }
+        if (phase == otherPhase && coefficient != 0.0) {
+          throw new IllegalArgumentException("Pair-coefficient diagonal must be zero");
+        }
+        double reverse = pairCoefficients[otherPhase][phase];
+        double tolerance = SYMMETRY_TOLERANCE * Math.max(1.0, Math.max(coefficient, reverse));
+        if (!Double.isFinite(reverse) || Math.abs(coefficient - reverse) > tolerance) {
+          throw new IllegalArgumentException("Pair coefficients must be symmetric");
+        }
+      }
+    }
+  }
+
+  private static double[] solveLinearSystem(double[][] matrix, double[] rightHandSide) {
+    int size = rightHandSide.length;
+    for (int pivotColumn = 0; pivotColumn < size; pivotColumn++) {
+      int pivotRow = pivotColumn;
+      for (int row = pivotColumn + 1; row < size; row++) {
+        if (Math.abs(matrix[row][pivotColumn]) > Math.abs(matrix[pivotRow][pivotColumn])) {
+          pivotRow = row;
+        }
+      }
+      if (matrix[pivotRow][pivotColumn] <= 0.0) {
+        throw new IllegalStateException("Interphase momentum matrix is not positive definite");
+      }
+      if (pivotRow != pivotColumn) {
+        double[] temporaryRow = matrix[pivotColumn];
+        matrix[pivotColumn] = matrix[pivotRow];
+        matrix[pivotRow] = temporaryRow;
+        double temporaryValue = rightHandSide[pivotColumn];
+        rightHandSide[pivotColumn] = rightHandSide[pivotRow];
+        rightHandSide[pivotRow] = temporaryValue;
+      }
+
+      for (int row = pivotColumn + 1; row < size; row++) {
+        double factor = matrix[row][pivotColumn] / matrix[pivotColumn][pivotColumn];
+        for (int column = pivotColumn; column < size; column++) {
+          matrix[row][column] -= factor * matrix[pivotColumn][column];
+        }
+        rightHandSide[row] -= factor * rightHandSide[pivotColumn];
+      }
+    }
+
+    double[] solution = new double[size];
+    for (int row = size - 1; row >= 0; row--) {
+      double value = rightHandSide[row];
+      for (int column = row + 1; column < size; column++) {
+        value -= matrix[row][column] * solution[column];
+      }
+      solution[row] = value / matrix[row][row];
+    }
+    return solution;
+  }
+
+  private static double kineticEnergy(double[] masses, double[] momenta) {
+    double energy = 0.0;
+    for (int phase = 0; phase < masses.length; phase++) {
+      if (masses[phase] > 0.0) {
+        energy += 0.5 * momenta[phase] * momenta[phase] / masses[phase];
+      }
+    }
+    return energy;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/StiffBubbleDragSerializationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/StiffBubbleDragSerializationTest.java
@@ -1,0 +1,34 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+
+/** Serialization regression for the stiff bubble-drag configuration. */
+class StiffBubbleDragSerializationTest {
+
+  @Test
+  void stiffBubbleDragSettingSurvivesSerialization() throws Exception {
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    assertFalse(equations.isStiffBubbleDragEnabled());
+    equations.setEnableStiffBubbleDrag(true);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    output.writeObject(equations);
+    output.close();
+
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    TwoFluidConservationEquations copy = (TwoFluidConservationEquations) input.readObject();
+    input.close();
+
+    assertTrue(copy.isStiffBubbleDragEnabled());
+    assertTrue(copy.getInterfacialFriction().isUseCorrectedBubbleDrag());
+    copy.setEnableStiffBubbleDrag(false);
+    assertFalse(copy.isStiffBubbleDragEnabled());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFrictionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFrictionTest.java
@@ -1,0 +1,109 @@
+package neqsim.process.equipment.pipeline.twophasepipe.closure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
+
+/** Tests for gas-liquid interfacial-friction closures. */
+class InterfacialFrictionTest {
+  private static final double GRAVITY = 9.81;
+  private static final double DEFAULT_BUBBLE_SURFACE_TENSION = 0.02;
+
+  @Test
+  void dispersedBubbleForceMatchesSchillerNaumannDragLaw() {
+    InterfacialFriction friction = new InterfacialFriction();
+    double[] diameters = { 0.05, 0.10, 0.30 };
+    double[] liquidHoldups = { 0.80, 0.95, 1.0 - 1.0e-8 };
+    double[] slipVelocities = { -1.0, -0.10, 0.10, 1.0 };
+
+    for (double diameter : diameters) {
+      for (double liquidHoldup : liquidHoldups) {
+        for (double slipVelocity : slipVelocities) {
+          double gasVelocity = 0.5 + slipVelocity;
+          double liquidVelocity = 0.5;
+          double expected = expectedBubbleDragForcePerLength(gasVelocity, liquidVelocity, 5.0, 1000.0, 1.0e-3,
+              liquidHoldup, diameter);
+
+          double actual = friction.calcCorrectedBubbleDragForce(FlowRegime.DISPERSED_BUBBLE, gasVelocity,
+              liquidVelocity, 5.0, 1000.0, 1.5e-5, 1.0e-3, liquidHoldup, diameter, 0.072);
+
+          assertEquals(expected, actual, Math.max(1.0e-12, Math.abs(expected) * 1.0e-12),
+              "Schiller-Naumann force mismatch at D=" + diameter + " m, alphaL=" + liquidHoldup + ", slip="
+                  + slipVelocity + " m/s");
+        }
+      }
+    }
+  }
+
+  @Test
+  void bubbleDragIsOddInSlipAndVanishesAtPhaseLimits() {
+    InterfacialFriction friction = new InterfacialFriction();
+    double forward = friction.calcCorrectedBubbleDragForce(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3,
+        0.9, 0.1, 0.072);
+    double reverse = friction.calcCorrectedBubbleDragForce(FlowRegime.BUBBLE, 0.3, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3,
+        0.9, 0.1, 0.072);
+    double zeroSlip = friction.calcCorrectedBubbleDragForce(FlowRegime.BUBBLE, 0.5, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3,
+        0.9, 0.1, 0.072);
+    double noGas = friction.calcCorrectedBubbleDragForce(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3, 1.0,
+        0.1, 0.072);
+
+    assertTrue(forward > 0.0);
+    assertEquals(-forward, reverse, Math.abs(forward) * 1.0e-12);
+    assertEquals(0.0, zeroSlip, 0.0);
+    assertEquals(0.0, noGas, 0.0);
+  }
+
+  @Test
+  void correctedForceQueryDoesNotMutateCompatibilityMode() {
+    InterfacialFriction friction = new InterfacialFriction();
+    double corrected = friction.calcCorrectedBubbleDragForce(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3,
+        0.9, 0.1, 0.072);
+
+    assertFalse(friction.isUseCorrectedBubbleDrag());
+    friction.setUseCorrectedBubbleDrag(true);
+    double selected = friction.calcInterfacialForce(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3, 0.9, 0.1,
+        0.072);
+
+    assertEquals(corrected, selected, Math.abs(corrected) * 1.0e-14);
+  }
+
+  @Test
+  void compatibilityScalingRemainsTheDefaultAndFreezesLegacyUnderprediction() {
+    InterfacialFriction friction = new InterfacialFriction();
+    double diameter = 0.1;
+    double liquidHoldup = 0.9;
+    double legacy = friction.calcInterfacialForce(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3,
+        liquidHoldup, diameter, 0.072);
+    double corrected = friction.calcCorrectedBubbleDragForce(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0, 1.5e-5, 1.0e-3,
+        liquidHoldup, diameter, 0.072);
+    double bubbleDiameter = 2.0 * Math.sqrt(0.725 * DEFAULT_BUBBLE_SURFACE_TENSION / ((1000.0 - 5.0) * GRAVITY));
+    bubbleDiameter = Math.min(bubbleDiameter, diameter / 5.0);
+
+    assertFalse(friction.isUseCorrectedBubbleDrag());
+    assertTrue(legacy < corrected);
+    assertEquals(bubbleDiameter / diameter, legacy / corrected, 1.0e-14);
+  }
+
+  private double expectedBubbleDragForcePerLength(double gasVelocity, double liquidVelocity, double gasDensity,
+      double liquidDensity, double liquidViscosity, double liquidHoldup, double diameter) {
+    double bubbleDiameter = 2.0
+        * Math.sqrt(0.725 * DEFAULT_BUBBLE_SURFACE_TENSION / ((liquidDensity - gasDensity) * GRAVITY));
+    bubbleDiameter = Math.min(bubbleDiameter, diameter / 5.0);
+    double slipVelocity = gasVelocity - liquidVelocity;
+    double bubbleReynoldsNumber = liquidDensity * Math.abs(slipVelocity) * bubbleDiameter / liquidViscosity;
+    double dragCoefficient;
+    if (bubbleReynoldsNumber < 0.1) {
+      dragCoefficient = 240.0;
+    } else if (bubbleReynoldsNumber < 1000.0) {
+      dragCoefficient = 24.0 / bubbleReynoldsNumber * (1.0 + 0.15 * Math.pow(bubbleReynoldsNumber, 0.687));
+    } else {
+      dragCoefficient = 0.44;
+    }
+    double gasHoldup = 1.0 - liquidHoldup;
+    double area = Math.PI * diameter * diameter / 4.0;
+    return 0.75 * dragCoefficient * liquidDensity * gasHoldup * area / bubbleDiameter * slipVelocity
+        * Math.abs(slipVelocity);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/DispersedBubbleDragSolverTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/DispersedBubbleDragSolverTest.java
@@ -1,0 +1,177 @@
+package neqsim.process.equipment.pipeline.twophasepipe.numerics;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
+import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction;
+
+/** Tests for the local implicit Schiller-Naumann source solve. */
+class DispersedBubbleDragSolverTest {
+  private static final double GAS_DENSITY = 5.0;
+  private static final double LIQUID_DENSITY = 1000.0;
+  private static final double GAS_VISCOSITY = 1.5e-5;
+  private static final double LIQUID_VISCOSITY = 1.0e-3;
+  private static final double LIQUID_HOLDUP = 0.8;
+  private static final double DIAMETER = 0.05;
+  private static final double SURFACE_TENSION = 0.072;
+
+  @Test
+  void nonlinearDragIsStableConservativeAndMonotoneThroughDtOverTauOneThousand() {
+    InterfacialFriction dragLaw = new InterfacialFriction();
+    double[] masses = { 1.0, 4.0, 0.0 };
+    double[] momenta = { 1.0, 0.0, 0.0 };
+    double initialSlip = 1.0;
+    double force = Math.abs(dragLaw.calcCorrectedBubbleDragForce(FlowRegime.BUBBLE, initialSlip, 0.0, GAS_DENSITY,
+        LIQUID_DENSITY, GAS_VISCOSITY, LIQUID_VISCOSITY, LIQUID_HOLDUP, DIAMETER, SURFACE_TENSION));
+    double relaxationTime = initialSlip / ((1.0 / masses[0] + 1.0 / masses[1]) * force);
+    double[] stiffnessRatios = { 1.0e-3, 0.1, 1.0, 10.0, 1.0e3 };
+
+    for (double stiffnessRatio : stiffnessRatios) {
+      double[] result = relax(FlowRegime.BUBBLE, masses, momenta, stiffnessRatio * relaxationTime, dragLaw);
+      double resultSlip = result[0] / masses[0] - result[1] / masses[1];
+
+      assertEquals(sum(momenta), sum(result), 2.0e-14);
+      assertTrue(resultSlip > 0.0);
+      assertTrue(resultSlip <= initialSlip);
+      assertTrue(kineticEnergy(masses, result) <= kineticEnergy(masses, momenta) + 1.0e-13);
+    }
+  }
+
+  @Test
+  void reverseSlipIsSymmetricAndZeroSlipIsAnExactFixedPoint() {
+    InterfacialFriction dragLaw = new InterfacialFriction();
+    double[] masses = { 1.0, 4.0, 0.0 };
+    double[] forwardMomenta = { 1.0, 0.0, 0.0 };
+    double[] reverseMomenta = { -1.0, 0.0, 0.0 };
+    double[] zeroSlipMomenta = { 1.0, 4.0, 0.0 };
+
+    double[] forward = relax(FlowRegime.DISPERSED_BUBBLE, masses, forwardMomenta, 2.0, dragLaw);
+    double[] reverse = relax(FlowRegime.DISPERSED_BUBBLE, masses, reverseMomenta, 2.0, dragLaw);
+    double[] zeroSlip = relax(FlowRegime.BUBBLE, masses, zeroSlipMomenta, 2.0, dragLaw);
+
+    for (int phase = 0; phase < masses.length; phase++) {
+      assertEquals(-forward[phase], reverse[phase], 2.0e-14);
+    }
+    assertArrayEquals(zeroSlipMomenta, zeroSlip, 0.0);
+  }
+
+  @Test
+  void threePhasePseudoLiquidPreservesOilWaterSlipAndDissipates() {
+    InterfacialFriction dragLaw = new InterfacialFriction();
+    double[] masses = { 1.0, 2.0, 3.0 };
+    double[] momenta = { 1.0, 2.8, 0.0 };
+    double initialOilWaterSlip = momenta[1] / masses[1] - momenta[2] / masses[2];
+
+    double[] result = relax(FlowRegime.BUBBLE, masses, momenta, 5.0, dragLaw);
+
+    double finalOilWaterSlip = result[1] / masses[1] - result[2] / masses[2];
+    assertEquals(initialOilWaterSlip, finalOilWaterSlip, 2.0e-14);
+    assertEquals(sum(momenta), sum(result), 2.0e-14);
+    assertTrue(kineticEnergy(masses, result) <= kineticEnergy(masses, momenta) + 1.0e-13);
+  }
+
+  @Test
+  void absentPhasesAreNotCreatedAndNonBubbleRegimeIsUntouched() {
+    InterfacialFriction dragLaw = new InterfacialFriction();
+    double[] oilOnlyLiquidMasses = { 1.0, 4.0, 0.0 };
+    double[] momenta = { 1.0, 0.0, 0.2 };
+    double[] noGasMasses = { 0.0, 4.0, 0.0 };
+    double[] noGasMomenta = { 3.0e-9, 2.0, 0.0 };
+
+    double[] oilOnly = relax(FlowRegime.BUBBLE, oilOnlyLiquidMasses, momenta, 1.0, dragLaw);
+    double[] noGas = relax(FlowRegime.BUBBLE, noGasMasses, noGasMomenta, 1.0, dragLaw);
+    double[] slug = relax(FlowRegime.SLUG, oilOnlyLiquidMasses, momenta, 1.0, dragLaw);
+
+    assertEquals(0.0, oilOnly[2], 0.0);
+    assertEquals(momenta[0] + momenta[1], oilOnly[0] + oilOnly[1], 2.0e-14);
+    assertEquals(0.0, noGas[0], 0.0);
+    assertEquals(noGasMomenta[1], noGas[1], 0.0);
+    assertEquals(0.0, noGas[2], 0.0);
+    assertArrayEquals(momenta, slug, 0.0);
+  }
+
+  @Test
+  void repeatedCallsAreDeterministicAndDoNotMutateInputs() {
+    InterfacialFriction dragLaw = new InterfacialFriction();
+    double[] masses = { 1.0, 2.0, 3.0 };
+    double[] momenta = { 1.0, 2.8, 0.0 };
+    double[] originalMasses = masses.clone();
+    double[] originalMomenta = momenta.clone();
+
+    double[] first = relax(FlowRegime.BUBBLE, masses, momenta, 0.5, dragLaw);
+    double[] second = relax(FlowRegime.BUBBLE, masses, momenta, 0.5, dragLaw);
+
+    assertArrayEquals(first, second, 0.0);
+    assertArrayEquals(originalMasses, masses, 0.0);
+    assertArrayEquals(originalMomenta, momenta, 0.0);
+  }
+
+  @Test
+  void bubbleClassificationsAgreeAndNonlinearRefinementConverges() {
+    InterfacialFriction dragLaw = new InterfacialFriction();
+    double[] masses = { 1.0, 4.0, 0.0 };
+    double[] momenta = { 1.0, 0.0, 0.0 };
+    double totalTime = 0.2;
+    double[] bubble = relax(FlowRegime.BUBBLE, masses, momenta, totalTime, dragLaw);
+    double[] dispersed = relax(FlowRegime.DISPERSED_BUBBLE, masses, momenta, totalTime, dragLaw);
+    double[] reference = repeatedRelax(masses, momenta, totalTime, 256, dragLaw);
+    double[] twoSteps = repeatedRelax(masses, momenta, totalTime, 2, dragLaw);
+
+    assertArrayEquals(bubble, dispersed, 0.0);
+    assertTrue(slipError(masses, twoSteps, reference) < slipError(masses, bubble, reference));
+  }
+
+  @Test
+  void tracePositivePhaseRemainsFiniteWithoutAHiddenMassFloor() {
+    InterfacialFriction dragLaw = new InterfacialFriction();
+    double[] masses = { 1.0e-12, 4.0, 0.0 };
+    double[] momenta = { 1.0e-12, 0.0, 0.0 };
+
+    double[] result = relax(FlowRegime.BUBBLE, masses, momenta, 1.0, dragLaw);
+
+    assertTrue(Double.isFinite(result[0]));
+    assertTrue(Double.isFinite(result[1]));
+    assertEquals(sum(momenta), sum(result), 1.0e-20);
+  }
+
+  private double[] repeatedRelax(double[] masses, double[] initialMomenta, double totalTime, int steps,
+      InterfacialFriction dragLaw) {
+    double[] result = initialMomenta.clone();
+    for (int step = 0; step < steps; step++) {
+      result = relax(FlowRegime.BUBBLE, masses, result, totalTime / steps, dragLaw);
+    }
+    return result;
+  }
+
+  private double slipError(double[] masses, double[] actual, double[] expected) {
+    double actualSlip = actual[0] / masses[0] - actual[1] / masses[1];
+    double expectedSlip = expected[0] / masses[0] - expected[1] / masses[1];
+    return Math.abs(actualSlip - expectedSlip);
+  }
+
+  private double[] relax(FlowRegime regime, double[] masses, double[] momenta, double timeStep,
+      InterfacialFriction dragLaw) {
+    return DispersedBubbleDragSolver.relax(regime, masses, momenta, GAS_DENSITY, LIQUID_DENSITY, GAS_VISCOSITY,
+        LIQUID_VISCOSITY, LIQUID_HOLDUP, DIAMETER, SURFACE_TENSION, timeStep, dragLaw);
+  }
+
+  private double kineticEnergy(double[] masses, double[] momenta) {
+    double energy = 0.0;
+    for (int phase = 0; phase < masses.length; phase++) {
+      if (masses[phase] > 0.0) {
+        energy += 0.5 * momenta[phase] * momenta[phase] / masses[phase];
+      }
+    }
+    return energy;
+  }
+
+  private double sum(double[] values) {
+    double result = 0.0;
+    for (double value : values) {
+      result += value;
+    }
+    return result;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/StiffInterphaseMomentumSolverTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/StiffInterphaseMomentumSolverTest.java
@@ -1,0 +1,112 @@
+package neqsim.process.equipment.pipeline.twophasepipe.numerics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the conservative local implicit momentum solver. */
+class StiffInterphaseMomentumSolverTest {
+
+  @Test
+  void twoPhaseSolveIsConservativeDissipativeAndStableAcrossStiffnessRange() {
+    double[] masses = { 2.0, 3.0 };
+    double[] momenta = { 8.0, -3.0 };
+    double pairCoefficient = 7.5;
+    double[][] coefficients = { { 0.0, pairCoefficient }, { pairCoefficient, 0.0 } };
+    double initialSlip = momenta[0] / masses[0] - momenta[1] / masses[1];
+    double relaxationTime = 1.0 / (pairCoefficient * (1.0 / masses[0] + 1.0 / masses[1]));
+    double[] stiffnessRatios = { 1.0e-3, 0.1, 1.0, 10.0, 1.0e3 };
+
+    for (double stiffnessRatio : stiffnessRatios) {
+      double[] result = StiffInterphaseMomentumSolver.solve(masses, momenta, coefficients,
+          stiffnessRatio * relaxationTime);
+      double resultSlip = result[0] / masses[0] - result[1] / masses[1];
+
+      assertEquals(initialSlip / (1.0 + stiffnessRatio), resultSlip, Math.abs(initialSlip) * 2.0e-12);
+      assertEquals(sum(momenta), sum(result), 2.0e-14);
+      assertTrue(kineticEnergy(masses, result) <= kineticEnergy(masses, momenta) + 1.0e-13);
+      assertTrue(resultSlip > 0.0);
+    }
+  }
+
+  @Test
+  void threePhaseSolvePreservesMomentumAndCannotCreateKineticEnergy() {
+    double[] masses = { 1.0, 2.0, 3.0 };
+    double[] momenta = { 1.0, 2.8, 0.0 };
+    double[][] coefficients = { { 0.0, 4.0, 2.0 }, { 4.0, 0.0, 1.5 }, { 2.0, 1.5, 0.0 } };
+
+    double[] result = StiffInterphaseMomentumSolver.solve(masses, momenta, coefficients, 100.0);
+
+    assertEquals(sum(momenta), sum(result), 2.0e-14);
+    assertTrue(kineticEnergy(masses, result) <= kineticEnergy(masses, momenta) + 1.0e-13);
+    double centreVelocity = sum(momenta) / sum(masses);
+    for (int phase = 0; phase < masses.length; phase++) {
+      assertEquals(centreVelocity, result[phase] / masses[phase], 5.0e-3);
+    }
+  }
+
+  @Test
+  void absentPhaseIsEliminatedWithoutMassFloor() {
+    double[] masses = { 1.0, 2.0, 0.0 };
+    double[] momenta = { 1.0, -2.0, 7.0e-9 };
+    double[][] coefficients = { { 0.0, 3.0, 20.0 }, { 3.0, 0.0, 10.0 }, { 20.0, 10.0, 0.0 } };
+
+    double[] result = StiffInterphaseMomentumSolver.solve(masses, momenta, coefficients, 2.0);
+
+    assertEquals(0.0, result[2], 0.0);
+    assertEquals(momenta[0] + momenta[1], sum(result), 2.0e-14);
+    assertTrue(kineticEnergy(masses, result) <= kineticEnergy(masses, momenta) + 1.0e-13);
+  }
+
+  @Test
+  void solveIsSignSymmetricAndBackwardEulerConvergesAtFirstOrder() {
+    double[] masses = { 2.0, 3.0 };
+    double[] momenta = { 8.0, -3.0 };
+    double[][] coefficients = { { 0.0, 7.5 }, { 7.5, 0.0 } };
+    double[] reverseMomenta = { -momenta[0], -momenta[1] };
+    double[] forward = StiffInterphaseMomentumSolver.solve(masses, momenta, coefficients, 0.2);
+    double[] reverse = StiffInterphaseMomentumSolver.solve(masses, reverseMomenta, coefficients, 0.2);
+
+    assertEquals(-forward[0], reverse[0], 1.0e-14);
+    assertEquals(-forward[1], reverse[1], 1.0e-14);
+
+    double relaxationRate = coefficients[0][1] * (1.0 / masses[0] + 1.0 / masses[1]);
+    double totalTime = 0.4 / relaxationRate;
+    double initialSlip = momenta[0] / masses[0] - momenta[1] / masses[1];
+    double exactSlip = initialSlip * Math.exp(-relaxationRate * totalTime);
+    double coarseSlip = repeatedSlip(masses, momenta, coefficients, totalTime, 1);
+    double fineSlip = repeatedSlip(masses, momenta, coefficients, totalTime, 2);
+    double coarseError = Math.abs(coarseSlip - exactSlip);
+    double fineError = Math.abs(fineSlip - exactSlip);
+
+    assertTrue(fineError < coarseError);
+    assertTrue(coarseError / fineError > 1.5);
+  }
+
+  private double repeatedSlip(double[] masses, double[] initialMomenta, double[][] coefficients, double totalTime,
+      int steps) {
+    double[] momenta = initialMomenta.clone();
+    for (int step = 0; step < steps; step++) {
+      momenta = StiffInterphaseMomentumSolver.solve(masses, momenta, coefficients, totalTime / steps);
+    }
+    return momenta[0] / masses[0] - momenta[1] / masses[1];
+  }
+
+  private double kineticEnergy(double[] masses, double[] momenta) {
+    double energy = 0.0;
+    for (int phase = 0; phase < masses.length; phase++) {
+      if (masses[phase] > 0.0) {
+        energy += 0.5 * momenta[phase] * momenta[phase] / masses[phase];
+      }
+    }
+    return energy;
+  }
+
+  private double sum(double[] values) {
+    double result = 0.0;
+    for (double value : values) {
+      result += value;
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary

- preserve the benchmarked legacy dispersed-bubble scaling by default and expose the corrected Schiller–Naumann force as an explicit opt-in
- advance corrected bubble drag with a pure local backward-Euler source solve, split into half-steps around transport
- solve only active gas/oil/water inventories, conserve total active-phase momentum to roundoff, avoid mass floors, preserve oil-water slip, and prevent kinetic-energy growth
- document the closure assumptions, additive API, migration behavior, and remaining Tengesdal limitation

Enable the new path with `TwoFluidPipe.setEnableStiffBubbleDrag(true)`. Existing callers retain current behavior.

## Physics and validation

The corrected representation removes the erroneous `d_b / D` scaling and uses

`F_i = 3/4 C_D rho_L alpha_G A / d_b (v_G-v_L)|v_G-v_L|`

with `a_i = 6 alpha_G / d_b` and `f_i = C_D / 4`.

Coverage includes 36 analytical force points, both slip signs, zero slip, absent and trace phases, gas-oil-water conservation, monotone slip and kinetic energy, deterministic repeated calls, serialization, nearby regime transitions, nonlinear refinement, and `dt/tau` from `1e-3` through `1e3`.

The published severe-slug bounds were not relaxed:

- compatibility default: 6/6 cases pass
- corrected opt-in diagnostic: 3/6 cases pass
- remaining misses: 167.1 kPa minimum pressure swing versus 98 +/- 5 kPa, slug-length ratio 1.164, and no repeated cycle for 16 sections at 0.1 s

The stable opt-in misses are documented as a remaining physical closure/regime-transition limitation, not claimed as quantitative validation.

## Verification

- `./mvnw -o -Dtest=InterfacialFrictionTest,StiffInterphaseMomentumSolverTest,DispersedBubbleDragSolverTest,StiffBubbleDragSerializationTest test` — 16 passed
- `./mvnw -o -Dtest='TwoFluid*Test,neqsim.process.equipment.pipeline.twophasepipe.**' test` — 509 passed, 17 skipped
- `./mvnw -o -DexcludedTestGroups= -Dtest=SevereSluggingExperimentalBenchmarkTest test` — 6 passed
- `python devtools/run_spotless.py check` — passed
- `python devtools/check_documentation_search.py` — passed
- changed production sources compiled directly with JDK `--release 8` — passed
- JDK Javadoc/doclint for changed APIs — passed (the Maven Javadoc goal could not resolve uncached reporting dependencies in the offline environment)

The local `pre-commit` executable was unavailable, so the mandatory direct gates above were run explicitly.

Relates #2909