### PR TITLE
[AI-Assisted] Add canonical operating-case stream values

### DIFF
--- a/docs/process/processmodel/diagram_export.md
+++ b/docs/process/processmodel/diagram_export.md
@@ -34,9 +34,37 @@ of silently losing the ambiguity. The result owns a deterministic JSON snapshot 
 defensive graph copy. Consumers should review structured diagnostics before treating an adaptation
 as complete.
 
-The existing DOT and DEXPI exporters have not yet been migrated to consume this graph. Until that
-migration is complete, this adapter is a shared topology contract rather than a new rendering or
-standards-conformance claim.
+### Operating-case enrichment
+
+After a successful simulation, use the opt-in four-argument overload to capture selected current
+stream results in the same canonical plant snapshot:
+
+```java
+process.run();
+ProcessDiagramGraphAdapter.Result operatingSnapshot =
+    ProcessDiagramGraphAdapter.fromProcessSystem(
+        process, "PLANT-001", "A", "NORMAL-001");
+```
+
+The overload works for both `ProcessSystem` and multi-area `ProcessModel`. It creates one stable
+plant-wide operating-case node and, when each result is finite and available, three calculation
+nodes per registered stream:
+
+- thermodynamic temperature in K;
+- absolute pressure in bara; and
+- mass flow in kg/s.
+
+Every value names its unit and quantity basis, references its stream and operating case, and carries
+`SIMULATION_RESULT` provenance with `CALCULATED` engineering state and
+`REVIEW_REQUIRED` approval status. Values are captured only for areas whose latest run completed
+successfully. An unrun or failed area remains in the topology and emits
+`DIAGRAM_OPERATING_CASE_NOT_SUCCESSFUL` instead of publishing potentially stale values.
+
+The established three-argument overload remains topology-only, so existing fingerprints and
+consumers do not acquire simulation values silently. The assessed DEXPI 2.0 Process path consumes
+the canonical material projection, but it does not yet consume these canonical operating-value
+nodes. Legacy DOT, Graphviz, and DEXPI compatibility APIs remain unchanged. This adapter is still a
+shared semantic contract rather than a rendering or standards-conformance claim.
 
 ### Topology-equivalence reference cases
 

--- a/docs/process/processmodel/process_diagram_export_inventory.md
+++ b/docs/process/processmodel/process_diagram_export_inventory.md
@@ -33,7 +33,7 @@ API-stability classification.
 | Legacy `ProcessSystem` Graphviz | `ProcessSystem.exportToGraphviz(...)`, `ProcessSystemGraphvizExporter.export(...)` | Equipment stream introspection and export options | Legacy Graphviz file with optional stream values and property table | Retain as a compatibility output; do not silently redirect it through a new model or renderer |
 | Legacy minimal PFD DOT | `ProcessFlowDiagramExporter(ProcessSystem).toDot()` | Shared stream identity plus explicit `ProcessConnection` declarations | Minimal equipment-node/stream-edge DOT | Preserve the constructor and `toDot()` result contract while public callers remain supported |
 | Multi-area Graphviz | `ProcessModel.toDOT()`, `createGraphvizExporter()`, `exportToGraphviz(...)`, `exportAreaDOT(...)`, and `ProcessModelGraphvizExporter` | Ordered areas and shared stream identity | One clustered plant DOT and optional per-area DOT files | Preserve current combined and per-area APIs. Per-area files are compatibility views, not the future controlled multi-sheet document model |
-| Canonical topology adapter | `ProcessDiagramGraphAdapter.fromProcessSystem(...)`, `fromProcessModel(...)` | `ProcessSystem`, explicit connections, and ordered `ProcessModel` areas | Defensive deterministic `EngineeringGraph`, fingerprint, and structured diagnostics | Reuse as the shared topology foundation; the assessed DEXPI Process path consumes one snapshot, while legacy renderers and compatibility writers retain their established paths |
+| Canonical topology adapter | `ProcessDiagramGraphAdapter.fromProcessSystem(...)`, `fromProcessModel(...)` | `ProcessSystem`, explicit connections, and ordered `ProcessModel` areas; opt-in successful-run operating case | Defensive deterministic `EngineeringGraph`, fingerprint, structured diagnostics, and optional unit-explicit stream operating values | Reuse as the shared semantic foundation; the assessed DEXPI Process path consumes one topology snapshot, while legacy renderers and compatibility writers retain their established paths |
 | Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter.write(...)`, `writeAndAssess(...)`, `writeAndAssessTopology(...)` | Direct `ProcessSystem` traversal for compatibility APIs; canonical material projection for `writeAndAssessTopology(...)` | Native DEXPI 2.0 Process XML with steps, material ports, streams, quantities, conformance report, and optional structured topology evidence | Preserve the native Process profile and existing sequential serialization; expand canonical consumption only behind equivalence evidence |
 | Native DEXPI 2.0 Plant | `Dexpi20XmlWriter.write(...)`, `writeAndAssess(...)` | Direct `ProcessSystem` engineering/plant mapping | Native DEXPI 2.0 Plant XML and conformance report | Keep separate from Process/PFD exchange and from Proteus compatibility output |
 | Proteus-compatible DEXPI | `DexpiXmlWriter.write(...)`, `writeForPyDexpi(...)`, `write(ProcessModel, ...)`, `writeSheets(...)` | Direct process/engineering mapping plus `DexpiLayoutEngine` | Proteus-compatible P&ID XML, pyDEXPI variant, layouts, and per-area sheets | Preserve import/export compatibility. Combined export flattens areas and logs/skips distinct equipment with duplicate names; per-area sheets expose boundary feeds but do not yet form a controlled, paired-reference document set |
@@ -47,7 +47,7 @@ API-stability classification.
 |---|---|---|
 | `ProcessGraph` | Execution topology and dependency scheduling | Execution-oriented; not a drawing/document model |
 | `EngineeringGraph` | Exchange-neutral engineering objects and revision comparison | Mutable and broader than a qualified process-diagram document contract |
-| `ProcessDiagramGraphAdapter.Result` | Deterministic projection of `ProcessSystem` or multi-area `ProcessModel` into `EngineeringGraph` | Stable plant/area/equipment/port/connection IDs exist, but document/sheet IDs, controlled views, operating cases, and persistent layout are absent |
+| `ProcessDiagramGraphAdapter.Result` | Deterministic projection of `ProcessSystem` or multi-area `ProcessModel` into `EngineeringGraph` | Stable topology and an opt-in current operating case with temperature, absolute pressure, mass flow, units, and provenance are present; tags/stream numbers, document/sheet IDs, controlled views, operating envelopes, and persistent layout remain absent |
 | `ProcessDiagramExporter` configuration | Simulator-style content and Graphviz layout policy | Layout is renderer-specific and has no document-set, revision-block, approval, or controlled off-page-reference model |
 | DEXPI 2.0 Process model | Tool-neutral BFD/PFD exchange | The opt-in assessed path consumes canonical `ProcessSystem` material topology; compatibility APIs remain direct, and no multi-area `ProcessModel` overload exists |
 | Proteus/DEXPI P&ID model | Detailed P&ID proposal, import/export, and graphical interchange | Separate profile with richer piping/instrument semantics; must remain an engineering proposal until accountable data are present |
@@ -67,7 +67,7 @@ source contract has no independent connection ID; the adapter reports
 | Stable plant/area/equipment/port/connection IDs through canonical adapter | Present as a separate topology baseline | Foundation only | Assessed material projection consumes the canonical snapshot and records its stable IDs; writer IDs remain compatibility-sequential | Not yet consumed as the shared graph |
 | Material, energy, and signal topology | Present in canonical baseline; renderer coverage varies | Missing | Material-focused | Present where supported by the detailed profile |
 | Parallel connection preservation | Golden topology evidence for distinct material/energy/signal endpoints | Missing | Multiplicity-sensitive evidence for supported simple and parallel-branch material cases | Profile-specific tests only |
-| Units and provenance | Optional stream labels/tables; canonical topology provenance | Missing document model | Selected physical quantities with explicit units | Simulation/design metadata and governed package artifacts |
+| Units and provenance | Optional stream labels/tables; canonical topology plus opt-in current-case stream values in K, bara absolute, and kg/s with review-required simulation provenance | Missing document model | Selected physical quantities with explicit units; canonical value nodes are not yet consumed by the writer | Simulation/design metadata and governed package artifacts |
 | Controlled multi-document/multi-sheet hierarchy | Per-area compatibility files only | Missing | Missing | Partial sheet/layout features, not the shared controlled document set |
 | Paired off-page connectors with direction and sheet/grid references | Missing | Missing | Missing | Graphical off-page features exist, but shared connection/document completeness is not qualified |
 | Title/revision blocks and drawing status | Missing controlled model | Missing | Missing | Some rendered metadata exists; full shared revision/status governance remains unqualified |
@@ -81,7 +81,7 @@ The following tests are the executable evidence closest to the public paths:
 | Evidence | Coverage |
 |---|---|
 | `ProcessDiagramTopologyEquivalenceTest`, `ProcessDiagramGoldenFixtures` | Reusable golden simple and parallel-branch manifests plus parallel/recycle and multi-area directed topology across `ProcessGraph`, canonical `EngineeringGraph`, PFD DOT, and legacy/multi-area Graphviz projections |
-| `ProcessDiagramGraphAdapterTest` | Stable identities, explicit ports, material/energy/signal connections, parallel endpoints, multi-area hierarchy, deterministic snapshots, defensive copies, and structured diagnostics |
+| `ProcessDiagramGraphAdapterTest` | Stable identities, explicit ports, material/energy/signal connections, parallel endpoints, multi-area hierarchy, deterministic snapshots, case-scoped unit-explicit operating values and provenance, stale-value prevention, defensive copies, and structured diagnostics |
 | `ProcessDiagramExporterTest` | DOT structure, diagram styles/options, stream annotations/tables, and Graphviz-backed exports when Graphviz is available |
 | `ProcessSystemGraphvizExportTest` | Legacy complex-oil, three-phase, anti-surge, and annotated stream/property-table exports |
 | `HysysStyleDiagramTest`, `OilStabilizationDiagramTest`, `GasOilWaterProcessSvgExportTest` | Professional-looking simulator examples and representative process diagrams; visual examples, not standards qualification |
@@ -126,12 +126,13 @@ Future increments shall follow these rules:
 
 ## Dependency-ordered next work
 
-The canonical topology foundation and DEXPI Process comparison gate now drive the opt-in assessed
-material projection. Compatibility APIs still traverse their established source model and retain
-their sequential XML identities. The next dependency-ready increment is to carry selected operating
-values, explicit units, case identity, and provenance in the canonical model before widening the
-exchange to multi-area `ProcessModel`. Multi-area hierarchy and energy/signal mappings require
-separate reviewed extensions rather than silent flattening or loss.
+The canonical topology foundation now supports an opt-in, successful-run operating-case snapshot,
+and the DEXPI Process comparison gate drives the assessed material projection. Compatibility APIs
+still traverse their established source model and retain their sequential XML identities. The next
+dependency-ready increment is to make the assessed DEXPI 2.0 Process path consume the canonical
+operating-value nodes while proving unchanged XML values and explicit loss behavior. A later
+reviewed extension can then widen exchange to multi-area `ProcessModel`; hierarchy and
+energy/signal mappings must not be silently flattened or lost.
 
 The native professional document model and renderer remain later work because controlled
 document/sheet identity, layout ownership, revision semantics, and licensed symbol qualification

--- a/src/main/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapter.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapter.java
@@ -175,6 +175,34 @@ public final class ProcessDiagramGraphAdapter {
   }
 
   /**
+   * Builds one canonical diagram snapshot with selected current stream operating values.
+   *
+   * <p>
+   * This opt-in overload preserves the topology-only output of the established three-argument method. Values are
+   * captured only after a successful process run and are represented as unit-explicit, case-scoped calculation nodes
+   * with simulation-result provenance and review-required status.
+   * </p>
+   *
+   * @param processSystem process system; unsuccessful run state produces a diagnostic rather than values
+   * @param plantId persistent plant or project identifier
+   * @param revision controlled source-model revision
+   * @param operatingCaseId stable operating-case identifier
+   * @return immutable canonical snapshot and diagnostics
+   */
+  public static Result fromProcessSystem(ProcessSystem processSystem, String plantId, String revision,
+      String operatingCaseId) {
+    if (processSystem == null) {
+      throw new IllegalArgumentException("processSystem must not be null");
+    }
+    Builder builder = new Builder(plantId, revision, "PROCESS_SYSTEM");
+    builder.addArea(areaName(processSystem), processSystem);
+    builder.addLocalTopology();
+    builder.addExplicitConnections();
+    builder.addOperatingCase(operatingCaseId);
+    return builder.result();
+  }
+
+  /**
    * Builds one plant-wide canonical diagram-topology snapshot from all areas in a {@link ProcessModel}.
    *
    * @param processModel runnable multi-area process model
@@ -196,6 +224,40 @@ public final class ProcessDiagramGraphAdapter {
     builder.addLocalTopology();
     builder.addExplicitConnections();
     builder.addCrossAreaTopology();
+    return builder.result();
+  }
+
+  /**
+   * Builds one plant-wide canonical diagram snapshot with selected current stream operating values.
+   *
+   * <p>
+   * One operating-case node owns the values captured across every successfully run area. An area that has not completed
+   * successfully is retained topologically and reported through a structured diagnostic; stale values are not published
+   * for that area.
+   * </p>
+   *
+   * @param processModel multi-area process model; each unsuccessful area produces a diagnostic rather than values
+   * @param plantId persistent plant or project identifier
+   * @param revision controlled source-model revision
+   * @param operatingCaseId stable plant-wide operating-case identifier
+   * @return immutable plant-wide canonical snapshot and diagnostics
+   */
+  public static Result fromProcessModel(ProcessModel processModel, String plantId, String revision,
+      String operatingCaseId) {
+    if (processModel == null) {
+      throw new IllegalArgumentException("processModel must not be null");
+    }
+    Builder builder = new Builder(plantId, revision, "PROCESS_MODEL");
+    for (String areaName : processModel.getProcessSystemNames()) {
+      ProcessSystem processSystem = processModel.get(areaName);
+      if (processSystem != null) {
+        builder.addArea(areaName, processSystem);
+      }
+    }
+    builder.addLocalTopology();
+    builder.addExplicitConnections();
+    builder.addCrossAreaTopology();
+    builder.addOperatingCase(operatingCaseId);
     return builder.result();
   }
 
@@ -373,6 +435,91 @@ public final class ProcessDiagramGraphAdapter {
           }
         }
       }
+    }
+
+    private void addOperatingCase(String requestedCaseId) {
+      String caseId = requireText(requestedCaseId, "operatingCaseId");
+      String caseExternalKey = resolveExternalKey(EngineeringNode.Kind.DESIGN_CASE,
+          plantId + "/operating-case/" + caseId, "");
+      String caseNodeId = EngineeringIds.nodeId(EngineeringNode.Kind.DESIGN_CASE, caseExternalKey);
+      EngineeringNode caseNode = new EngineeringNode(caseNodeId, EngineeringNode.Kind.DESIGN_CASE, caseExternalKey,
+          caseId).putProperty("caseId", caseId).putProperty("type", "OPERATING")
+          .putProperty("engineeringState", "CALCULATED").putProperty("approvalStatus", "REVIEW_REQUIRED")
+          .putProperty("simulationStatus", "CALCULATED").addProvenance(
+              new EngineeringProvenance("SIMULATION_CASE", caseId).setMethod("Current process operating-state capture")
+                  .setDesignCaseId(caseId).setApprovalStatus("REVIEW_REQUIRED"));
+      graph.addNode(caseNode);
+      addEdgeIfAbsent(EngineeringEdge.Kind.CONTAINS, projectNodeId, caseNodeId, "operatingCase");
+
+      for (AreaReference area : areas) {
+        if (!area.processSystem.getRunStatus().isSuccess()) {
+          caseNode.putProperty("simulationStatus", "INCOMPLETE");
+          diagnostics.add(new Diagnostic(Severity.WARNING, "DIAGRAM_OPERATING_CASE_NOT_SUCCESSFUL",
+              "Operating values were not captured because the process area has no successful completed run", area.name,
+              caseId));
+          continue;
+        }
+        for (ElementReference element : area.elementsByName.values()) {
+          if (element.equipment instanceof StreamInterface) {
+            addStreamOperatingValues(element, (StreamInterface) element.equipment, caseId, caseNodeId);
+          }
+        }
+      }
+    }
+
+    private void addStreamOperatingValues(ElementReference element, StreamInterface stream, String caseId,
+        String caseNodeId) {
+      try {
+        addOperatingValue(element, caseId, caseNodeId, "temperature", stream.getTemperature("K"), "K",
+            "THERMODYNAMIC_ABSOLUTE");
+      } catch (RuntimeException exception) {
+        operatingValueUnavailable(element, caseId, "temperature", exception);
+      }
+      try {
+        addOperatingValue(element, caseId, caseNodeId, "pressure", stream.getPressure("bara"), "bara", "ABSOLUTE");
+      } catch (RuntimeException exception) {
+        operatingValueUnavailable(element, caseId, "pressure", exception);
+      }
+      try {
+        addOperatingValue(element, caseId, caseNodeId, "massFlow", stream.getFlowRate("kg/sec"), "kg/s", "MASS");
+      } catch (RuntimeException exception) {
+        operatingValueUnavailable(element, caseId, "massFlow", exception);
+      }
+    }
+
+    private void addOperatingValue(ElementReference element, String caseId, String caseNodeId, String quantity,
+        double value, String unit, String quantityBasis) {
+      if (!Double.isFinite(value)) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "DIAGRAM_OPERATING_VALUE_NONFINITE",
+            "A non-finite simulation result was excluded from the canonical operating case", element.areaName,
+            element.equipment.getName() + "/" + quantity));
+        return;
+      }
+      String requestedExternalKey = element.externalKey + "/operating-case/" + caseId + "/" + quantity;
+      String externalKey = resolveExternalKey(EngineeringNode.Kind.CALCULATION, requestedExternalKey, element.areaName);
+      String nodeId = EngineeringIds.nodeId(EngineeringNode.Kind.CALCULATION, externalKey);
+      graph.addNode(new EngineeringNode(nodeId, EngineeringNode.Kind.CALCULATION, externalKey,
+          element.equipment.getName() + " " + quantity).putProperty("subjectNodeId", element.nodeId)
+          .putProperty("subjectName", element.equipment.getName()).putProperty("areaName", element.areaName)
+          .putProperty("quantity", quantity).putProperty("quantityBasis", quantityBasis)
+          .putProperty("resultValue", Double.valueOf(value)).putProperty("resultUnit", unit)
+          .putProperty("designCaseId", caseId).putProperty("status", "CALCULATED")
+          .putProperty("engineeringState", "CALCULATED").putProperty("approvalStatus", "REVIEW_REQUIRED").addProvenance(
+              new EngineeringProvenance("SIMULATION_RESULT", element.areaName + "/" + element.equipment.getName())
+                  .setMethod("Current ProcessSystem stream operating result snapshot").setDesignCaseId(caseId)
+                  .setApprovalStatus("REVIEW_REQUIRED")));
+      addEdgeIfAbsent(EngineeringEdge.Kind.CONTAINS, projectNodeId, nodeId, "operatingValue");
+      addEdgeIfAbsent(EngineeringEdge.Kind.GOVERNS, nodeId, element.nodeId, quantity);
+      addEdgeIfAbsent(EngineeringEdge.Kind.GENERATED_FROM, nodeId, caseNodeId, "operatingCase");
+    }
+
+    private void operatingValueUnavailable(ElementReference element, String caseId, String quantity,
+        RuntimeException exception) {
+      diagnostics
+          .add(new Diagnostic(Severity.WARNING, "DIAGRAM_OPERATING_VALUE_UNAVAILABLE",
+              "A simulation result could not be captured for operating case " + caseId + ": "
+                  + exception.getClass().getSimpleName(),
+              element.areaName, element.equipment.getName() + "/" + quantity));
     }
 
     private void addConnection(ElementReference source, ElementReference target, ProcessConnection.ConnectionType type,

--- a/src/main/java/neqsim/process/processmodel/diagram/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/package-info.java
@@ -15,6 +15,7 @@
  * <li><b>Equipment semantics</b> - Separator outlets correctly positioned</li>
  * <li><b>DEXPI integration</b> - Import P&amp;ID data and generate diagrams</li>
  * <li><b>Canonical topology</b> - Stable plant, area, equipment, port, and connection identities</li>
+ * <li><b>Operating evidence</b> - Opt-in case-scoped stream values with explicit units and provenance</li>
  * <li><b>Multiple detail levels</b> - MINIMAL, STANDARD, DETAILED, DEBUG</li>
  * <li><b>Deterministic output</b> - Same model always produces same diagram</li>
  * </ul>

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapterTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapterTest.java
@@ -209,6 +209,94 @@ class ProcessDiagramGraphAdapterTest {
     assertFalse(secondCopy.getNodes().containsKey(temporaryId));
   }
 
+  @Test
+  void capturesCaseScopedUnitExplicitOperatingValuesWithoutChangingTopologyOnlyApi() {
+    Stream feed = createFeed("operating feed");
+    Heater heater = new Heater("operating heater", feed);
+    ProcessSystem process = new ProcessSystem("operating area");
+    process.add(feed);
+    process.add(heater);
+    process.run();
+
+    EngineeringGraph topologyOnly = ProcessDiagramGraphAdapter.fromProcessSystem(process, "PLANT-OPERATING", "A")
+        .getGraph();
+    EngineeringGraph enriched = ProcessDiagramGraphAdapter
+        .fromProcessSystem(process, "PLANT-OPERATING", "A", "NORMAL-001").getGraph();
+
+    assertEquals(0, countNodeKind(topologyOnly, EngineeringNode.Kind.DESIGN_CASE));
+    assertEquals(0, countNodeKind(topologyOnly, EngineeringNode.Kind.CALCULATION));
+    assertEquals(1, countNodeKind(enriched, EngineeringNode.Kind.DESIGN_CASE));
+    assertEquals(3, countNodeKind(enriched, EngineeringNode.Kind.CALCULATION));
+
+    EngineeringNode pressure = findOperatingValue(enriched, "operating feed", "pressure");
+    EngineeringNode temperature = findOperatingValue(enriched, "operating feed", "temperature");
+    EngineeringNode massFlow = findOperatingValue(enriched, "operating feed", "massFlow");
+    assertNotNull(pressure);
+    assertNotNull(temperature);
+    assertNotNull(massFlow);
+    assertEquals(40.0, ((Number) pressure.getProperties().get("resultValue")).doubleValue(), 1.0e-12);
+    assertEquals("bara", pressure.getProperties().get("resultUnit"));
+    assertEquals("ABSOLUTE", pressure.getProperties().get("quantityBasis"));
+    assertEquals(298.15, ((Number) temperature.getProperties().get("resultValue")).doubleValue(), 1.0e-12);
+    assertEquals("K", temperature.getProperties().get("resultUnit"));
+    assertEquals(1000.0 / 3600.0, ((Number) massFlow.getProperties().get("resultValue")).doubleValue(), 1.0e-12);
+    assertEquals("kg/s", massFlow.getProperties().get("resultUnit"));
+    assertEquals("NORMAL-001", pressure.getProperties().get("designCaseId"));
+    assertEquals("SIMULATION_RESULT", pressure.getProvenance().get(0).getSourceType());
+    assertEquals("NORMAL-001", pressure.getProvenance().get(0).getDesignCaseId());
+    assertEquals("REVIEW_REQUIRED", pressure.getProvenance().get(0).getApprovalStatus());
+    assertTrue(EngineeringPackageValidator.validateGraph(enriched).isValid());
+  }
+
+  @Test
+  void capturesOneOperatingCaseAcrossMultiAreaProcessModel() {
+    ProcessModel plant = createFourAreaPlant();
+    plant.run();
+
+    ProcessDiagramGraphAdapter.Result result = ProcessDiagramGraphAdapter.fromProcessModel(plant,
+        "PLANT-MULTI-OPERATING", "A", "NORMAL-001");
+
+    assertEquals(1, countNodeKind(result.getGraph(), EngineeringNode.Kind.DESIGN_CASE));
+    assertEquals(3, countNodeKind(result.getGraph(), EngineeringNode.Kind.CALCULATION));
+    assertNotNull(findOperatingValue(result.getGraph(), "deterministic feed", "pressure"));
+    assertTrue(EngineeringPackageValidator.validateGraph(result.getGraph()).isValid());
+  }
+
+  @Test
+  void reportsMissingSuccessfulRunInsteadOfPublishingStaleOperatingValues() {
+    Stream feed = createFeed("not run feed");
+    ProcessSystem process = new ProcessSystem("not run area");
+    process.add(feed);
+
+    ProcessDiagramGraphAdapter.Result result = ProcessDiagramGraphAdapter.fromProcessSystem(process, "PLANT-NOT-RUN",
+        "A", "NORMAL-001");
+
+    assertEquals(1, countNodeKind(result.getGraph(), EngineeringNode.Kind.DESIGN_CASE));
+    assertEquals(0, countNodeKind(result.getGraph(), EngineeringNode.Kind.CALCULATION));
+    assertTrue(hasDiagnostic(result, "DIAGRAM_OPERATING_CASE_NOT_SUCCESSFUL"));
+    assertTrue(EngineeringPackageValidator.validateGraph(result.getGraph()).isValid());
+  }
+
+  @Test
+  void keepsOperatingCaseSnapshotDeterministicAcrossEquivalentFreshModels() {
+    String expectedJson = null;
+    for (int attempt = 0; attempt < 8; attempt++) {
+      Stream feed = createFeed("deterministic operating feed");
+      Heater heater = new Heater("deterministic operating heater", feed);
+      ProcessSystem process = new ProcessSystem("deterministic operating area");
+      process.add(feed);
+      process.add(heater);
+      process.run();
+      String graphJson = ProcessDiagramGraphAdapter
+          .fromProcessSystem(process, "PLANT-DETERMINISTIC-OPERATING", "A", "NORMAL-001").getGraphJson();
+      if (expectedJson == null) {
+        expectedJson = graphJson;
+      } else {
+        assertEquals(expectedJson, graphJson);
+      }
+    }
+  }
+
   private static Stream createFeed(String name) {
     SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
     fluid.addComponent("methane", 1.0);
@@ -251,6 +339,16 @@ class ProcessDiagramGraphAdapterTest {
 
   private static int countNodeKind(EngineeringGraph graph, EngineeringNode.Kind kind) {
     return nodesOfKind(graph, kind).size();
+  }
+
+  private static EngineeringNode findOperatingValue(EngineeringGraph graph, String subjectName, String quantity) {
+    for (EngineeringNode node : nodesOfKind(graph, EngineeringNode.Kind.CALCULATION)) {
+      if (subjectName.equals(node.getProperties().get("subjectName"))
+          && quantity.equals(node.getProperties().get("quantity"))) {
+        return node;
+      }
+    }
+    return null;
   }
 
   private static List<EngineeringNode> nodesOfKind(EngineeringGraph graph, EngineeringNode.Kind kind) {


### PR DESCRIPTION
## Summary

- add opt-in canonical operating-case enrichment for both `ProcessSystem` and multi-area `ProcessModel`
- capture current registered-stream temperature, absolute pressure, and mass flow with explicit units, quantity basis, stable case/value IDs, and simulation-result provenance
- exclude stale, unavailable, or non-finite results with structured diagnostics
- keep all existing three-argument adapter calls topology-only and leave legacy DOT/Graphviz, compatibility DEXPI, and Proteus/P&ID output unchanged

## Campaign increment

This is **PFD-C008**, the next dependency-ordered Phase 1 increment after merged #2932. It adds simulation evidence to the shared canonical engineering-diagram model before any renderer or further exporter migration.

This PR does not claim ISO 10628 conformance. The native professional SVG/PDF document model, controlled multi-sheet layout, symbols, and standards qualification remain later reviewed work.

## Compatibility contract

- Existing public adapter signatures and outputs are unchanged.
- New behavior is available only through four-argument overloads with an explicit operating-case ID.
- One case spans all successfully run areas of a `ProcessModel`; an unsuccessful area retains topology but contributes no potentially stale values.
- Assessed DEXPI topology export does not yet consume the new value nodes, so current XML quantities and identities are unchanged.
- P&ID content remains an engineering proposal workflow and is not inferred from simulation-only PFD evidence.

## Validation

Candidate commit: `89293d706540574b61d65c81527feffb6ae1b4ea`

- 24 focused/broader tests passed: 12 adapter, 4 topology-equivalence, and 8 DEXPI Process writer tests
- exact final candidate: 12 adapter tests passed
- `python devtools/run_spotless.py apply` and `check`: passed
- `python devtools/check_documentation_search.py`: passed (647 Markdown pages, 1 standalone HTML page)
- pre-commit and pre-push stages: passed
- Java 8 source compilation of the changed production class with ECJ: passed (one pre-existing unused-field warning)
- full local Java 8 Maven execution was unavailable because Maven's JVM could not resolve Maven Central while fetching an uncached plugin; the artifact endpoint itself returned HTTP 200, and hosted Java 8 CI remains the acceptance gate
- branch is one commit ahead and zero behind current master; exactly five intended files differ

## Documentation impact

Updated the process-diagram guide, exporter/API inventory, capability matrix, executable evidence, dependency ordering, and package documentation. No notebook or visual artifact is warranted for this low-level opt-in semantic-model increment.

## Remaining limitations and next dependency

The canonical model still lacks tags/stream numbers, controlled document/sheet identity, layout ownership, off-page references, revision blocks, and qualified symbols. The next dependency-ready increment is to make the assessed DEXPI 2.0 Process path consume these canonical operating-value nodes while proving unchanged XML values and explicit loss behavior. Multi-area DEXPI exchange follows separately to avoid silent hierarchy flattening.

Relates #1332 and coordinates #2899.