### PR TITLE
feat(twofluid): add configurable bubble-size closure

### DIFF
--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosure.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosure.java
@@ -1,0 +1,109 @@
+package neqsim.process.equipment.pipeline.twophasepipe.closure;
+
+import java.io.Serializable;
+
+/**
+ * Configurable algebraic bubble-size closure for bubbly-flow momentum-transfer models.
+ *
+ * <p>
+ * The closure estimates a characteristic spherical-bubble diameter from surface tension,
+ * continuous/dispersed-phase density difference, and gravity, and limits the result by a
+ * configurable fraction of pipe diameter. It is intentionally independent of a particular
+ * flow-regime model so callers can supply phase-property values from the thermodynamic state.
+ * </p>
+ *
+ * <p>
+ * The default surface tension of {@code 0.02 N/m} and diameter cap of {@code D/5} reproduce the
+ * historical TwoFluidPipe assumptions. Setting different values is explicit and does not imply
+ * validation outside approximately spherical, liquid-continuous bubbly flow.
+ * </p>
+ */
+public final class BubbleSizeClosure implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final double DEFAULT_SURFACE_TENSION = 0.02;
+  private static final double DEFAULT_PIPE_DIAMETER_FRACTION = 0.20;
+
+  private double surfaceTension = DEFAULT_SURFACE_TENSION;
+  private double maximumPipeDiameterFraction = DEFAULT_PIPE_DIAMETER_FRACTION;
+
+  /** Creates a closure with the historical TwoFluidPipe assumptions. */
+  public BubbleSizeClosure() {}
+
+  /**
+   * Creates a closure with explicit surface tension.
+   *
+   * @param surfaceTension surface tension in N/m
+   */
+  public BubbleSizeClosure(double surfaceTension) {
+    setSurfaceTension(surfaceTension);
+  }
+
+  /**
+   * Sets the gas-liquid surface tension used by the bubble-size estimate.
+   *
+   * @param surfaceTension surface tension in N/m, strictly positive and finite
+   */
+  public void setSurfaceTension(double surfaceTension) {
+    if (!Double.isFinite(surfaceTension) || surfaceTension <= 0.0) {
+      throw new IllegalArgumentException("surfaceTension must be finite and > 0 N/m");
+    }
+    this.surfaceTension = surfaceTension;
+  }
+
+  /** @return configured surface tension in N/m */
+  public double getSurfaceTension() {
+    return surfaceTension;
+  }
+
+  /**
+   * Sets the upper bubble-diameter limit as a fraction of pipe diameter.
+   *
+   * @param fraction fraction in the interval (0, 1]
+   */
+  public void setMaximumPipeDiameterFraction(double fraction) {
+    if (!Double.isFinite(fraction) || fraction <= 0.0 || fraction > 1.0) {
+      throw new IllegalArgumentException("fraction must be finite and in (0, 1]");
+    }
+    maximumPipeDiameterFraction = fraction;
+  }
+
+  /** @return configured maximum bubble diameter divided by pipe diameter */
+  public double getMaximumPipeDiameterFraction() {
+    return maximumPipeDiameterFraction;
+  }
+
+  /**
+   * Estimates a characteristic spherical-bubble diameter.
+   *
+   * <p>
+   * The uncapped estimate is {@code sqrt(sigma / (g * abs(deltaRho)))}. The returned value is
+   * capped at {@code maximumPipeDiameterFraction * pipeDiameter}. This algebraic scale preserves
+   * the existing TwoFluidPipe form while making all physical inputs and the geometry cap explicit.
+   * </p>
+   *
+   * @param pipeDiameter internal pipe diameter in m
+   * @param continuousPhaseDensity continuous-phase density in kg/m3
+   * @param dispersedPhaseDensity dispersed-phase density in kg/m3
+   * @param gravity gravitational acceleration magnitude in m/s2
+   * @return characteristic bubble diameter in m
+   */
+  public double estimateDiameter(double pipeDiameter, double continuousPhaseDensity,
+      double dispersedPhaseDensity, double gravity) {
+    requirePositiveFinite(pipeDiameter, "pipeDiameter");
+    requirePositiveFinite(continuousPhaseDensity, "continuousPhaseDensity");
+    requirePositiveFinite(dispersedPhaseDensity, "dispersedPhaseDensity");
+    requirePositiveFinite(gravity, "gravity");
+    double densityDifference = Math.abs(continuousPhaseDensity - dispersedPhaseDensity);
+    if (densityDifference == 0.0) {
+      return maximumPipeDiameterFraction * pipeDiameter;
+    }
+    double unconstrained = Math.sqrt(surfaceTension / (gravity * densityDifference));
+    return Math.min(unconstrained, maximumPipeDiameterFraction * pipeDiameter);
+  }
+
+  private static void requirePositiveFinite(double value, String name) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and > 0");
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosure.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosure.java
@@ -6,16 +6,16 @@ import java.io.Serializable;
  * Configurable algebraic bubble-size closure for bubbly-flow momentum-transfer models.
  *
  * <p>
- * The closure estimates a characteristic spherical-bubble diameter from surface tension,
- * continuous/dispersed-phase density difference, and gravity, and limits the result by a
- * configurable fraction of pipe diameter. It is intentionally independent of a particular
- * flow-regime model so callers can supply phase-property values from the thermodynamic state.
+ * The closure estimates a characteristic spherical-bubble diameter from surface tension, continuous/dispersed-phase
+ * density difference, and gravity, and limits the result by a configurable fraction of pipe diameter. It is
+ * intentionally independent of a particular flow-regime model so callers can supply phase-property values from the
+ * thermodynamic state.
  * </p>
  *
  * <p>
- * The default surface tension of {@code 0.02 N/m} and diameter cap of {@code D/5} reproduce the
- * historical TwoFluidPipe assumptions. Setting different values is explicit and does not imply
- * validation outside approximately spherical, liquid-continuous bubbly flow.
+ * The default surface tension of {@code 0.02 N/m} and diameter cap of {@code D/5} reproduce the historical TwoFluidPipe
+ * assumptions. Setting different values is explicit and does not imply validation outside approximately spherical,
+ * liquid-continuous bubbly flow.
  * </p>
  */
 public final class BubbleSizeClosure implements Serializable {
@@ -27,7 +27,8 @@ public final class BubbleSizeClosure implements Serializable {
   private double maximumPipeDiameterFraction = DEFAULT_PIPE_DIAMETER_FRACTION;
 
   /** Creates a closure with the historical TwoFluidPipe assumptions. */
-  public BubbleSizeClosure() {}
+  public BubbleSizeClosure() {
+  }
 
   /**
    * Creates a closure with explicit surface tension.
@@ -76,9 +77,9 @@ public final class BubbleSizeClosure implements Serializable {
    * Estimates a characteristic spherical-bubble diameter.
    *
    * <p>
-   * The uncapped estimate is {@code sqrt(sigma / (g * abs(deltaRho)))}. The returned value is
-   * capped at {@code maximumPipeDiameterFraction * pipeDiameter}. This algebraic scale preserves
-   * the existing TwoFluidPipe form while making all physical inputs and the geometry cap explicit.
+   * The uncapped estimate is {@code sqrt(sigma / (g * abs(deltaRho)))}. The returned value is capped at
+   * {@code maximumPipeDiameterFraction * pipeDiameter}. This algebraic scale preserves the existing TwoFluidPipe form
+   * while making all physical inputs and the geometry cap explicit.
    * </p>
    *
    * @param pipeDiameter internal pipe diameter in m
@@ -87,8 +88,8 @@ public final class BubbleSizeClosure implements Serializable {
    * @param gravity gravitational acceleration magnitude in m/s2
    * @return characteristic bubble diameter in m
    */
-  public double estimateDiameter(double pipeDiameter, double continuousPhaseDensity,
-      double dispersedPhaseDensity, double gravity) {
+  public double estimateDiameter(double pipeDiameter, double continuousPhaseDensity, double dispersedPhaseDensity,
+      double gravity) {
     requirePositiveFinite(pipeDiameter, "pipeDiameter");
     requirePositiveFinite(continuousPhaseDensity, "continuousPhaseDensity");
     requirePositiveFinite(dispersedPhaseDensity, "dispersedPhaseDensity");

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosureTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosureTest.java
@@ -1,0 +1,61 @@
+package neqsim.process.equipment.pipeline.twophasepipe.closure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+/** Tests the configurable bubbly-flow diameter closure. */
+class BubbleSizeClosureTest {
+
+  @Test
+  void reproducesHistoricalDefaultAssumptions() {
+    BubbleSizeClosure closure = new BubbleSizeClosure();
+    double diameter = closure.estimateDiameter(0.10, 1000.0, 5.0, 9.81);
+
+    double expected = Math.min(Math.sqrt(0.02 / (9.81 * 995.0)), 0.02);
+    assertEquals(0.02, closure.getSurfaceTension(), 0.0);
+    assertEquals(0.20, closure.getMaximumPipeDiameterFraction(), 0.0);
+    assertEquals(expected, diameter, 1.0e-15);
+  }
+
+  @Test
+  void respondsMonotonicallyToSurfaceTensionBeforeGeometryCap() {
+    BubbleSizeClosure low = new BubbleSizeClosure(0.01);
+    BubbleSizeClosure high = new BubbleSizeClosure(0.04);
+
+    double lowDiameter = low.estimateDiameter(1.0, 900.0, 20.0, 9.81);
+    double highDiameter = high.estimateDiameter(1.0, 900.0, 20.0, 9.81);
+
+    assertTrue(highDiameter > lowDiameter);
+    assertEquals(2.0, highDiameter / lowDiameter, 1.0e-12);
+  }
+
+  @Test
+  void appliesExplicitPipeDiameterCapAndDensitySymmetry() {
+    BubbleSizeClosure closure = new BubbleSizeClosure(0.5);
+    closure.setMaximumPipeDiameterFraction(0.10);
+
+    assertEquals(0.005, closure.estimateDiameter(0.05, 5.0, 1000.0, 9.81), 1.0e-15);
+    assertEquals(0.005, closure.estimateDiameter(0.05, 1000.0, 5.0, 9.81), 1.0e-15);
+  }
+
+  @Test
+  void equalPhaseDensitiesFallBackToGeometryBound() {
+    BubbleSizeClosure closure = new BubbleSizeClosure();
+    closure.setMaximumPipeDiameterFraction(0.15);
+
+    assertEquals(0.03, closure.estimateDiameter(0.20, 500.0, 500.0, 9.81), 1.0e-15);
+  }
+
+  @Test
+  void rejectsNonPhysicalInputs() {
+    BubbleSizeClosure closure = new BubbleSizeClosure();
+
+    assertThrows(IllegalArgumentException.class, () -> closure.setSurfaceTension(0.0));
+    assertThrows(IllegalArgumentException.class, () -> closure.setMaximumPipeDiameterFraction(1.1));
+    assertThrows(IllegalArgumentException.class, () -> closure.estimateDiameter(0.0, 1000.0, 5.0, 9.81));
+    assertThrows(IllegalArgumentException.class,
+        () -> closure.estimateDiameter(0.1, Double.NaN, 5.0, 9.81));
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosureTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosureTest.java
@@ -55,7 +55,6 @@ class BubbleSizeClosureTest {
     assertThrows(IllegalArgumentException.class, () -> closure.setSurfaceTension(0.0));
     assertThrows(IllegalArgumentException.class, () -> closure.setMaximumPipeDiameterFraction(1.1));
     assertThrows(IllegalArgumentException.class, () -> closure.estimateDiameter(0.0, 1000.0, 5.0, 9.81));
-    assertThrows(IllegalArgumentException.class,
-        () -> closure.estimateDiameter(0.1, Double.NaN, 5.0, 9.81));
+    assertThrows(IllegalArgumentException.class, () -> closure.estimateDiameter(0.1, Double.NaN, 5.0, 9.81));
   }
 }


### PR DESCRIPTION
## Roadmap

Advances the next P0 item in #2907 after merged #2933: replace the fixed `0.02 N/m` bubble-size surface-tension assumption and single implicit diameter rule with an explicit, configurable closure architecture before broad bubbly-flow validity claims.

## Scope

This PR intentionally introduces the closure and regression contract only. It does **not** yet wire the closure into `TwoFluidPipe`; that behavioral integration is the next dependency-ordered increment after CI/review. This keeps the change additive and preserves current simulation behavior exactly.

## Physics and units

`BubbleSizeClosure` exposes:

- surface tension `sigma` [N/m], default `0.02 N/m` to reproduce the historical assumption;
- maximum bubble diameter as a fraction of pipe diameter, default `0.20 = D/5`;
- characteristic algebraic diameter `sqrt(sigma / (g * |rho_c-rho_d|))`, capped by the configured geometry bound.

All inputs are explicit SI quantities. The class is intentionally independent of a specific regime model so `TwoFluidPipe` can subsequently supply phase-property values from its thermodynamic state instead of burying a fixed constant inside the solver.

## Validation contract

Focused tests cover:

- exact reproduction of historical default assumptions;
- monotonic `sqrt(sigma)` dependence before the geometry cap;
- explicit `D`-fraction cap;
- density-order symmetry;
- equal-density geometry fallback;
- rejection of non-physical/non-finite inputs.

## Compatibility

- no existing source file changed;
- no public TwoFluidPipe behavior changed;
- no serialization or transient state added to TwoFluidPipe;
- no claim of broad bubbly-flow validation or commercial-simulator equivalence.

## Validation

VALIDATION PENDING CI

- On original head `f4becc98d0f21b942374b74bb5ca97d69dfa4fd7`, pre-commit failed only because the two added
  Java files did not match Spotless; documentation-search passed, and CodeQL plus PaperLab succeeded.
- The exact formatter output from Spotless workflow run `31469908699`
  (artifact digest `sha256:452f4011b837cbf9101cc032d6a34ad1dcb51b5e50cf39ccc2622d944871b752`) was applied
  verbatim, without changing physics or assertions.
- Local Maven, Spotless and pre-commit were not run and are not claimed as passed.
- Fresh GitHub CI is pending on exact head `1caf1ae2eb1844da682d0692cc2944dc51e5f6a0`.

## Documentation impact

Documentation impact: none. This repair is formatting-only, and the additive closure's current public contract, units,
defaults, validity boundary and exceptions are documented in its class and method Javadocs. It is not yet wired into
`TwoFluidPipe`, so no existing user configuration or simulation behavior is exposed or changed.