### PR TITLE
feat(twofluid): integrate configurable bubble-size closure

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -182,10 +182,7 @@ $$
 
 Bubble and dispersed-bubble regimes use the explicit algebraic diameter closure
 
-$
-d_b=\min\left(2\sqrt{\frac{0.725\,\sigma_b}
-{g|\rho_L-\rho_G|}},\; f_D\,D\right).
-$
+`d_b = min(2 sqrt(0.725 sigma_b / (g |rho_L-rho_G|)), f_D D)`.
 
 The defaults $\sigma_b=0.02$ N/m and $f_D=0.20$ preserve the historical calculation. Change the
 fixed values, or explicitly use each section's thermodynamic phase-property surface tension, through

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -180,10 +180,26 @@ F_i=\frac{3}{4} C_D \rho_L \alpha_G \frac{A}{d_b}
 \qquad f_i=\frac{C_D}{4}.
 $$
 
-The implementation uses the existing Hinze bubble diameter, capped at one fifth of the pipe
-diameter, and the existing fixed 0.02 N/m surface-tension assumption. Schiller-Naumann describes
-rigid spherical particles in a dilute continuous phase; the closure does not model deformation,
-coalescence, breakup, or a bubble-size distribution.
+Bubble and dispersed-bubble regimes use the explicit algebraic diameter closure
+
+$
+d_b=\min\left(2\sqrt{\frac{0.725\,\sigma_b}
+{g|\rho_L-\rho_G|}},\; f_DD\right).
+$
+
+The defaults $\sigma_b=0.02$ N/m and $f_D=0.20$ preserve the historical calculation. Change the
+fixed values, or explicitly use each section's thermodynamic phase-property surface tension, through
+the public pipe API:
+
+```java
+pipe.setBubbleSurfaceTension(0.025);
+pipe.setMaximumBubbleDiameterFraction(0.15);
+pipe.setUseLocalBubbleSurfaceTension(true);
+```
+
+Local mode uses the surface tension already stored for each section by the thermodynamic coupling;
+the default remains fixed for compatibility. This single algebraic scale does not model a
+bubble-size distribution, deformation, coalescence, breakup, or turbulent-dissipation dependence.
 
 The source operator solves the active gas and combined-liquid momenta by backward Euler and applies
 one half-step on each side of the transport update. It conserves total active-phase momentum to

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -184,7 +184,7 @@ Bubble and dispersed-bubble regimes use the explicit algebraic diameter closure
 
 $
 d_b=\min\left(2\sqrt{\frac{0.725\,\sigma_b}
-{g|\rho_L-\rho_G|}},\; f_DD\right).
+{g|\rho_L-\rho_G|}},\; f_D\,D\right).
 $
 
 The defaults $\sigma_b=0.02$ N/m and $f_D=0.20$ preserve the historical calculation. Change the

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -406,9 +406,9 @@ f_i = f_G × enhancement
 For drag on individual bubbles in liquid continuum:
 
 ```java
-// Bubble diameter (Hinze correlation)
-d_b = 2 × (0.725 × σ / ((ρ_L - ρ_G) × g))^0.5
-d_b = min(d_b, D/5)
+// Configurable algebraic bubble diameter
+d_b = 2 × (0.725 × σ_b / (|ρ_L - ρ_G| × g))^0.5
+d_b = min(d_b, f_D × D)
 
 // Bubble Reynolds number
 Re_b = ρ_L × |v_slip| × d_b / μ_L
@@ -441,9 +441,18 @@ the liquid impulse in proportion to active mass, preserving their relative veloc
 dispersed-bubble classifications use the same source treatment; neighboring regimes retain their
 existing closures.
 
-The bubble diameter is the existing Hinze estimate capped at `D/5`; the current closure assumes a
-fixed surface tension of 0.02 N/m. Schiller-Naumann assumes a dilute population of rigid spherical
-particles and does not represent bubble deformation, coalescence, breakup, or a size distribution.
+The defaults `σ_b = 0.02 N/m` and `f_D = 0.20` preserve the historical calculation. The
+configuration is exposed on the public pipe API:
+
+```java
+pipe.setBubbleSurfaceTension(0.025);
+pipe.setMaximumBubbleDiameterFraction(0.15);
+pipe.setUseLocalBubbleSurfaceTension(true);
+```
+
+The opt-in local mode uses the thermodynamic phase-property surface tension already stored for each
+section; fixed mode remains the default. This is a single algebraic size scale. It does not represent
+a bubble-size distribution, deformation, coalescence, breakup, or turbulent-dissipation dependence.
 
 The stiff corrected mode is opt-in. Existing simulations retain the legacy `C_D × d_b/(4D)` scaling
 unless enabled, because the corrected mode is not yet quantitatively validated by the public

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -6314,8 +6314,8 @@ public class TwoFluidPipe extends Pipeline {
    * Set the fixed bubble-size surface tension.
    *
    * <p>
-   * This value is used by default and preserves legacy behavior at {@code 0.02 N/m}. Enable local
-   * surface tension explicitly to use each section's thermodynamic phase-property value instead.
+   * This value is used by default and preserves legacy behavior at {@code 0.02 N/m}. Enable local surface tension
+   * explicitly to use each section's thermodynamic phase-property value instead.
    * </p>
    *
    * @param surfaceTension fixed surface tension in N/m

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -15,6 +15,7 @@ import neqsim.process.equipment.pipeline.twophasepipe.ThermodynamicCoupling;
 import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidComponentTransport;
 import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidConservationEquations;
 import neqsim.process.equipment.pipeline.twophasepipe.TwoFluidSection;
+import neqsim.process.equipment.pipeline.twophasepipe.closure.BubbleSizeClosure;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.OilWaterFlowRegimeDetector.OilWaterFlowRegime;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.ConservativeStateLimiter;
 import neqsim.process.equipment.pipeline.twophasepipe.numerics.TimeIntegrator;
@@ -6298,6 +6299,62 @@ public class TwoFluidPipe extends Pipeline {
    */
   public boolean isStiffBubbleDragEnabled() {
     return equations.isStiffBubbleDragEnabled();
+  }
+
+  /**
+   * Get the bubble-size closure used by bubble and dispersed-bubble regimes.
+   *
+   * @return mutable bubble-size closure configuration
+   */
+  public BubbleSizeClosure getBubbleSizeClosure() {
+    return equations.getBubbleSizeClosure();
+  }
+
+  /**
+   * Set the fixed bubble-size surface tension.
+   *
+   * <p>
+   * This value is used by default and preserves legacy behavior at {@code 0.02 N/m}. Enable local
+   * surface tension explicitly to use each section's thermodynamic phase-property value instead.
+   * </p>
+   *
+   * @param surfaceTension fixed surface tension in N/m
+   */
+  public void setBubbleSurfaceTension(double surfaceTension) {
+    getBubbleSizeClosure().setSurfaceTension(surfaceTension);
+  }
+
+  /** @return configured fixed bubble-size surface tension in N/m */
+  public double getBubbleSurfaceTension() {
+    return getBubbleSizeClosure().getSurfaceTension();
+  }
+
+  /**
+   * Select local thermodynamic phase-property surface tension for the bubble-size closure.
+   *
+   * @param useLocal true to use the surface tension stored for each pipe section
+   */
+  public void setUseLocalBubbleSurfaceTension(boolean useLocal) {
+    getBubbleSizeClosure().setUseLocalSurfaceTension(useLocal);
+  }
+
+  /** @return true when section-local surface tension is selected */
+  public boolean isUseLocalBubbleSurfaceTension() {
+    return getBubbleSizeClosure().isUseLocalSurfaceTension();
+  }
+
+  /**
+   * Set the maximum bubble diameter as a fraction of pipe diameter.
+   *
+   * @param fraction fraction in the interval (0, 1]
+   */
+  public void setMaximumBubbleDiameterFraction(double fraction) {
+    getBubbleSizeClosure().setMaximumPipeDiameterFraction(fraction);
+  }
+
+  /** @return maximum bubble diameter divided by pipe diameter */
+  public double getMaximumBubbleDiameterFraction() {
+    return getBubbleSizeClosure().getMaximumPipeDiameterFraction();
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
 import java.io.Serializable;
+import neqsim.process.equipment.pipeline.twophasepipe.closure.BubbleSizeClosure;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.GeometryCalculator;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.WallFriction;
@@ -1433,6 +1434,15 @@ public class TwoFluidConservationEquations implements Serializable {
 
   public InterfacialFriction getInterfacialFriction() {
     return interfacialFriction;
+  }
+
+  /**
+   * Get the bubble-size closure used by the interfacial momentum model.
+   *
+   * @return mutable bubble-size closure configuration
+   */
+  public BubbleSizeClosure getBubbleSizeClosure() {
+    return interfacialFriction.getBubbleSizeClosure();
   }
 
   public FlowRegimeDetector getFlowRegimeDetector() {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosure.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosure.java
@@ -6,15 +6,15 @@ import java.io.Serializable;
  * Configurable algebraic bubble-size closure for liquid-continuous bubbly-flow models.
  *
  * <p>
- * The closure exposes the historical TwoFluidPipe buoyancy/capillary diameter scale as explicit
- * configuration. By default it uses a fixed {@code 0.02 N/m} surface tension and a {@code D/5}
- * geometry cap, preserving the existing bubble and dispersed-bubble calculations. Callers may opt
- * into the local phase-property surface tension already supplied by the pipe section.
+ * The closure exposes the historical TwoFluidPipe buoyancy/capillary diameter scale as explicit configuration. By
+ * default it uses a fixed {@code 0.02 N/m} surface tension and a {@code D/5} geometry cap, preserving the existing
+ * bubble and dispersed-bubble calculations. Callers may opt into the local phase-property surface tension already
+ * supplied by the pipe section.
  * </p>
  *
  * <p>
- * This is a single algebraic characteristic size. It does not model a bubble-size distribution,
- * deformation, coalescence, breakup, or turbulent-dissipation dependence.
+ * This is a single algebraic characteristic size. It does not model a bubble-size distribution, deformation,
+ * coalescence, breakup, or turbulent-dissipation dependence.
  * </p>
  */
 public final class BubbleSizeClosure implements Serializable {
@@ -59,9 +59,8 @@ public final class BubbleSizeClosure implements Serializable {
    * Selects the local phase-property surface tension supplied for each pipe section.
    *
    * <p>
-   * The default is {@code false}, which preserves the historical fixed {@code 0.02 N/m}
-   * calculation. When enabled, the five-argument estimate validates and uses its local surface
-   * tension argument.
+   * The default is {@code false}, which preserves the historical fixed {@code 0.02 N/m} calculation. When enabled, the
+   * five-argument estimate validates and uses its local surface tension argument.
    * </p>
    *
    * @param useLocal true to use the caller-supplied local surface tension
@@ -101,20 +100,18 @@ public final class BubbleSizeClosure implements Serializable {
    * @param gravity gravitational acceleration magnitude in m/s2
    * @return characteristic bubble diameter in m
    */
-  public double estimateDiameter(double pipeDiameter, double continuousPhaseDensity,
-      double dispersedPhaseDensity, double gravity) {
-    return estimate(pipeDiameter, continuousPhaseDensity, dispersedPhaseDensity, gravity,
-        surfaceTension);
+  public double estimateDiameter(double pipeDiameter, double continuousPhaseDensity, double dispersedPhaseDensity,
+      double gravity) {
+    return estimate(pipeDiameter, continuousPhaseDensity, dispersedPhaseDensity, gravity, surfaceTension);
   }
 
   /**
    * Estimates a characteristic bubble diameter with optional local phase-property surface tension.
    *
    * <p>
-   * The uncapped historical scale is
-   * {@code 2 * sqrt(0.725 * sigma / (g * abs(deltaRho)))}. The returned value is capped at
-   * {@code maximumPipeDiameterFraction * pipeDiameter}. The {@code localSurfaceTension} argument is
-   * used only when {@link #isUseLocalSurfaceTension()} is true.
+   * The uncapped historical scale is {@code 2 * sqrt(0.725 * sigma / (g * abs(deltaRho)))}. The returned value is
+   * capped at {@code maximumPipeDiameterFraction * pipeDiameter}. The {@code localSurfaceTension} argument is used only
+   * when {@link #isUseLocalSurfaceTension()} is true.
    * </p>
    *
    * @param pipeDiameter internal pipe diameter in m
@@ -124,19 +121,18 @@ public final class BubbleSizeClosure implements Serializable {
    * @param localSurfaceTension local phase-property surface tension in N/m
    * @return characteristic bubble diameter in m
    */
-  public double estimateDiameter(double pipeDiameter, double continuousPhaseDensity,
-      double dispersedPhaseDensity, double gravity, double localSurfaceTension) {
+  public double estimateDiameter(double pipeDiameter, double continuousPhaseDensity, double dispersedPhaseDensity,
+      double gravity, double localSurfaceTension) {
     double selectedSurfaceTension = surfaceTension;
     if (useLocalSurfaceTension) {
       requirePositiveFinite(localSurfaceTension, "localSurfaceTension");
       selectedSurfaceTension = localSurfaceTension;
     }
-    return estimate(pipeDiameter, continuousPhaseDensity, dispersedPhaseDensity, gravity,
-        selectedSurfaceTension);
+    return estimate(pipeDiameter, continuousPhaseDensity, dispersedPhaseDensity, gravity, selectedSurfaceTension);
   }
 
-  private double estimate(double pipeDiameter, double continuousPhaseDensity,
-      double dispersedPhaseDensity, double gravity, double selectedSurfaceTension) {
+  private double estimate(double pipeDiameter, double continuousPhaseDensity, double dispersedPhaseDensity,
+      double gravity, double selectedSurfaceTension) {
     requirePositiveFinite(pipeDiameter, "pipeDiameter");
     requirePositiveFinite(continuousPhaseDensity, "continuousPhaseDensity");
     requirePositiveFinite(dispersedPhaseDensity, "dispersedPhaseDensity");
@@ -146,9 +142,8 @@ public final class BubbleSizeClosure implements Serializable {
     if (densityDifference == 0.0) {
       return geometryBound;
     }
-    double unconstrained =
-        2.0 * Math.pow(HISTORICAL_SCALE_COEFFICIENT * selectedSurfaceTension
-            / (gravity * densityDifference), 0.5);
+    double unconstrained = 2.0
+        * Math.pow(HISTORICAL_SCALE_COEFFICIENT * selectedSurfaceTension / (gravity * densityDifference), 0.5);
     return Math.min(unconstrained, geometryBound);
   }
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosure.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosure.java
@@ -3,35 +3,36 @@ package neqsim.process.equipment.pipeline.twophasepipe.closure;
 import java.io.Serializable;
 
 /**
- * Configurable algebraic bubble-size closure for bubbly-flow momentum-transfer models.
+ * Configurable algebraic bubble-size closure for liquid-continuous bubbly-flow models.
  *
  * <p>
- * The closure estimates a characteristic spherical-bubble diameter from surface tension, continuous/dispersed-phase
- * density difference, and gravity, and limits the result by a configurable fraction of pipe diameter. It is
- * intentionally independent of a particular flow-regime model so callers can supply phase-property values from the
- * thermodynamic state.
+ * The closure exposes the historical TwoFluidPipe buoyancy/capillary diameter scale as explicit
+ * configuration. By default it uses a fixed {@code 0.02 N/m} surface tension and a {@code D/5}
+ * geometry cap, preserving the existing bubble and dispersed-bubble calculations. Callers may opt
+ * into the local phase-property surface tension already supplied by the pipe section.
  * </p>
  *
  * <p>
- * The default surface tension of {@code 0.02 N/m} and diameter cap of {@code D/5} reproduce the historical TwoFluidPipe
- * assumptions. Setting different values is explicit and does not imply validation outside approximately spherical,
- * liquid-continuous bubbly flow.
+ * This is a single algebraic characteristic size. It does not model a bubble-size distribution,
+ * deformation, coalescence, breakup, or turbulent-dissipation dependence.
  * </p>
  */
 public final class BubbleSizeClosure implements Serializable {
   private static final long serialVersionUID = 1000L;
   private static final double DEFAULT_SURFACE_TENSION = 0.02;
   private static final double DEFAULT_PIPE_DIAMETER_FRACTION = 0.20;
+  private static final double HISTORICAL_SCALE_COEFFICIENT = 0.725;
 
   private double surfaceTension = DEFAULT_SURFACE_TENSION;
   private double maximumPipeDiameterFraction = DEFAULT_PIPE_DIAMETER_FRACTION;
+  private boolean useLocalSurfaceTension;
 
   /** Creates a closure with the historical TwoFluidPipe assumptions. */
   public BubbleSizeClosure() {
   }
 
   /**
-   * Creates a closure with explicit surface tension.
+   * Creates a closure with explicit fixed surface tension.
    *
    * @param surfaceTension surface tension in N/m
    */
@@ -40,20 +41,38 @@ public final class BubbleSizeClosure implements Serializable {
   }
 
   /**
-   * Sets the gas-liquid surface tension used by the bubble-size estimate.
+   * Sets the fixed gas-liquid surface tension used by the bubble-size estimate.
    *
    * @param surfaceTension surface tension in N/m, strictly positive and finite
    */
   public void setSurfaceTension(double surfaceTension) {
-    if (!Double.isFinite(surfaceTension) || surfaceTension <= 0.0) {
-      throw new IllegalArgumentException("surfaceTension must be finite and > 0 N/m");
-    }
+    requirePositiveFinite(surfaceTension, "surfaceTension");
     this.surfaceTension = surfaceTension;
   }
 
-  /** @return configured surface tension in N/m */
+  /** @return configured fixed surface tension in N/m */
   public double getSurfaceTension() {
     return surfaceTension;
+  }
+
+  /**
+   * Selects the local phase-property surface tension supplied for each pipe section.
+   *
+   * <p>
+   * The default is {@code false}, which preserves the historical fixed {@code 0.02 N/m}
+   * calculation. When enabled, the five-argument estimate validates and uses its local surface
+   * tension argument.
+   * </p>
+   *
+   * @param useLocal true to use the caller-supplied local surface tension
+   */
+  public void setUseLocalSurfaceTension(boolean useLocal) {
+    useLocalSurfaceTension = useLocal;
+  }
+
+  /** @return true when the caller-supplied local surface tension is selected */
+  public boolean isUseLocalSurfaceTension() {
+    return useLocalSurfaceTension;
   }
 
   /**
@@ -74,13 +93,7 @@ public final class BubbleSizeClosure implements Serializable {
   }
 
   /**
-   * Estimates a characteristic spherical-bubble diameter.
-   *
-   * <p>
-   * The uncapped estimate is {@code sqrt(sigma / (g * abs(deltaRho)))}. The returned value is capped at
-   * {@code maximumPipeDiameterFraction * pipeDiameter}. This algebraic scale preserves the existing TwoFluidPipe form
-   * while making all physical inputs and the geometry cap explicit.
-   * </p>
+   * Estimates a characteristic bubble diameter using the configured fixed surface tension.
    *
    * @param pipeDiameter internal pipe diameter in m
    * @param continuousPhaseDensity continuous-phase density in kg/m3
@@ -88,18 +101,55 @@ public final class BubbleSizeClosure implements Serializable {
    * @param gravity gravitational acceleration magnitude in m/s2
    * @return characteristic bubble diameter in m
    */
-  public double estimateDiameter(double pipeDiameter, double continuousPhaseDensity, double dispersedPhaseDensity,
-      double gravity) {
+  public double estimateDiameter(double pipeDiameter, double continuousPhaseDensity,
+      double dispersedPhaseDensity, double gravity) {
+    return estimate(pipeDiameter, continuousPhaseDensity, dispersedPhaseDensity, gravity,
+        surfaceTension);
+  }
+
+  /**
+   * Estimates a characteristic bubble diameter with optional local phase-property surface tension.
+   *
+   * <p>
+   * The uncapped historical scale is
+   * {@code 2 * sqrt(0.725 * sigma / (g * abs(deltaRho)))}. The returned value is capped at
+   * {@code maximumPipeDiameterFraction * pipeDiameter}. The {@code localSurfaceTension} argument is
+   * used only when {@link #isUseLocalSurfaceTension()} is true.
+   * </p>
+   *
+   * @param pipeDiameter internal pipe diameter in m
+   * @param continuousPhaseDensity continuous-phase density in kg/m3
+   * @param dispersedPhaseDensity dispersed-phase density in kg/m3
+   * @param gravity gravitational acceleration magnitude in m/s2
+   * @param localSurfaceTension local phase-property surface tension in N/m
+   * @return characteristic bubble diameter in m
+   */
+  public double estimateDiameter(double pipeDiameter, double continuousPhaseDensity,
+      double dispersedPhaseDensity, double gravity, double localSurfaceTension) {
+    double selectedSurfaceTension = surfaceTension;
+    if (useLocalSurfaceTension) {
+      requirePositiveFinite(localSurfaceTension, "localSurfaceTension");
+      selectedSurfaceTension = localSurfaceTension;
+    }
+    return estimate(pipeDiameter, continuousPhaseDensity, dispersedPhaseDensity, gravity,
+        selectedSurfaceTension);
+  }
+
+  private double estimate(double pipeDiameter, double continuousPhaseDensity,
+      double dispersedPhaseDensity, double gravity, double selectedSurfaceTension) {
     requirePositiveFinite(pipeDiameter, "pipeDiameter");
     requirePositiveFinite(continuousPhaseDensity, "continuousPhaseDensity");
     requirePositiveFinite(dispersedPhaseDensity, "dispersedPhaseDensity");
     requirePositiveFinite(gravity, "gravity");
+    double geometryBound = maximumPipeDiameterFraction * pipeDiameter;
     double densityDifference = Math.abs(continuousPhaseDensity - dispersedPhaseDensity);
     if (densityDifference == 0.0) {
-      return maximumPipeDiameterFraction * pipeDiameter;
+      return geometryBound;
     }
-    double unconstrained = Math.sqrt(surfaceTension / (gravity * densityDifference));
-    return Math.min(unconstrained, maximumPipeDiameterFraction * pipeDiameter);
+    double unconstrained =
+        2.0 * Math.sqrt(HISTORICAL_SCALE_COEFFICIENT * selectedSurfaceTension
+            / (gravity * densityDifference));
+    return Math.min(unconstrained, geometryBound);
   }
 
   private static void requirePositiveFinite(double value, String name) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosure.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosure.java
@@ -147,8 +147,8 @@ public final class BubbleSizeClosure implements Serializable {
       return geometryBound;
     }
     double unconstrained =
-        2.0 * Math.sqrt(HISTORICAL_SCALE_COEFFICIENT * selectedSurfaceTension
-            / (gravity * densityDifference));
+        2.0 * Math.pow(HISTORICAL_SCALE_COEFFICIENT * selectedSurfaceTension
+            / (gravity * densityDifference), 0.5);
     return Math.min(unconstrained, geometryBound);
   }
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFriction.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFriction.java
@@ -38,6 +38,9 @@ public class InterfacialFriction implements Serializable {
   /** Retain validated compatibility scaling unless corrected stiff drag is explicitly selected. */
   private boolean useCorrectedBubbleDrag = false;
 
+  /** Configurable bubble-size closure; lazily restored for legacy serialized objects. */
+  private BubbleSizeClosure bubbleSizeClosure = new BubbleSizeClosure();
+
   /** Geometry calculator for stratified flow. */
   private GeometryCalculator geometryCalc;
 
@@ -110,7 +113,7 @@ public class InterfacialFriction implements Serializable {
     case BUBBLE:
     case DISPERSED_BUBBLE:
       return calcBubble(gasVelocity, liquidVelocity, gasDensity, liquidDensity, gasViscosity, liquidViscosity,
-          liquidHoldup, diameter);
+          liquidHoldup, diameter, surfaceTension);
 
     case SINGLE_PHASE_GAS:
     case SINGLE_PHASE_LIQUID:
@@ -414,20 +417,18 @@ public class InterfacialFriction implements Serializable {
    * @return interfacial friction calculation result
    */
   private InterfacialFrictionResult calcBubble(double vG, double vL, double rhoG, double rhoL, double muG, double muL,
-      double alphaL, double D) {
-    return calcBubble(vG, vL, rhoG, rhoL, muG, muL, alphaL, D, useCorrectedBubbleDrag);
+      double alphaL, double D, double surfaceTension) {
+    return calcBubble(vG, vL, rhoG, rhoL, muG, muL, alphaL, D, surfaceTension, useCorrectedBubbleDrag);
   }
 
   private InterfacialFrictionResult calcBubble(double vG, double vL, double rhoG, double rhoL, double muG, double muL,
-      double alphaL, double D, boolean useCorrectedDrag) {
+      double alphaL, double D, double surfaceTension, boolean useCorrectedDrag) {
     InterfacialFrictionResult result = new InterfacialFrictionResult();
 
     result.slipVelocity = vG - vL;
 
-    // Bubble diameter (Hinze)
-    double sigma = 0.02; // Assume typical surface tension if not provided
-    double d_b = 2.0 * Math.pow(0.725 * sigma / ((rhoL - rhoG) * GRAVITY), 0.5);
-    d_b = Math.min(d_b, D / 5.0);
+    // Historical algebraic buoyancy/capillary scale with explicit closure configuration.
+    double d_b = getBubbleSizeClosure().estimateDiameter(D, rhoL, rhoG, GRAVITY, surfaceTension);
 
     // Interfacial area concentration
     double alphaG = 1.0 - alphaL;
@@ -524,9 +525,27 @@ public class InterfacialFriction implements Serializable {
       return calcInterfacialForce(flowRegime, gasVelocity, liquidVelocity, gasDensity, liquidDensity, gasViscosity,
           liquidViscosity, liquidHoldup, diameter, surfaceTension);
     }
-    InterfacialFrictionResult result = calcBubble(gasVelocity, liquidVelocity, gasDensity, liquidDensity, gasViscosity,
-        liquidViscosity, liquidHoldup, diameter, true);
+    InterfacialFrictionResult result =
+        calcBubble(gasVelocity, liquidVelocity, gasDensity, liquidDensity, gasViscosity, liquidViscosity,
+            liquidHoldup, diameter, surfaceTension, true);
     return result.interfacialShear * result.interfacialAreaPerLength;
+  }
+
+  /**
+   * Get the configurable bubble-size closure used by bubble and dispersed-bubble regimes.
+   *
+   * <p>
+   * Lazy initialization preserves compatibility when reading serialized objects created before the
+   * closure was attached to this model.
+   * </p>
+   *
+   * @return mutable bubble-size closure configuration
+   */
+  public BubbleSizeClosure getBubbleSizeClosure() {
+    if (bubbleSizeClosure == null) {
+      bubbleSizeClosure = new BubbleSizeClosure();
+    }
+    return bubbleSizeClosure;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFriction.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFriction.java
@@ -525,9 +525,8 @@ public class InterfacialFriction implements Serializable {
       return calcInterfacialForce(flowRegime, gasVelocity, liquidVelocity, gasDensity, liquidDensity, gasViscosity,
           liquidViscosity, liquidHoldup, diameter, surfaceTension);
     }
-    InterfacialFrictionResult result =
-        calcBubble(gasVelocity, liquidVelocity, gasDensity, liquidDensity, gasViscosity, liquidViscosity,
-            liquidHoldup, diameter, surfaceTension, true);
+    InterfacialFrictionResult result = calcBubble(gasVelocity, liquidVelocity, gasDensity, liquidDensity, gasViscosity,
+        liquidViscosity, liquidHoldup, diameter, surfaceTension, true);
     return result.interfacialShear * result.interfacialAreaPerLength;
   }
 
@@ -535,8 +534,8 @@ public class InterfacialFriction implements Serializable {
    * Get the configurable bubble-size closure used by bubble and dispersed-bubble regimes.
    *
    * <p>
-   * Lazy initialization preserves compatibility when reading serialized objects created before the
-   * closure was attached to this model.
+   * Lazy initialization preserves compatibility when reading serialized objects created before the closure was attached
+   * to this model.
    * </p>
    *
    * @return mutable bubble-size closure configuration

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/BubbleSizeClosureConfigurationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/BubbleSizeClosureConfigurationTest.java
@@ -1,0 +1,29 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import org.junit.jupiter.api.Test;
+
+/** Public API regression for TwoFluidPipe bubble-size configuration. */
+class BubbleSizeClosureConfigurationTest {
+
+  @Test
+  void publicPipeApiExposesCompatibleDefaultsAndExplicitLocalMode() {
+    TwoFluidPipe pipe = new TwoFluidPipe("bubble-size configuration");
+
+    assertEquals(0.02, pipe.getBubbleSurfaceTension(), 0.0);
+    assertEquals(0.20, pipe.getMaximumBubbleDiameterFraction(), 0.0);
+    assertFalse(pipe.isUseLocalBubbleSurfaceTension());
+
+    pipe.setBubbleSurfaceTension(0.03);
+    pipe.setMaximumBubbleDiameterFraction(0.15);
+    pipe.setUseLocalBubbleSurfaceTension(true);
+
+    assertEquals(0.03, pipe.getBubbleSurfaceTension(), 0.0);
+    assertEquals(0.15, pipe.getMaximumBubbleDiameterFraction(), 0.0);
+    assertTrue(pipe.isUseLocalBubbleSurfaceTension());
+    assertTrue(pipe.getBubbleSizeClosure().isUseLocalSurfaceTension());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/StiffBubbleDragSerializationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/StiffBubbleDragSerializationTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
@@ -16,6 +17,9 @@ class StiffBubbleDragSerializationTest {
     TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
     assertFalse(equations.isStiffBubbleDragEnabled());
     equations.setEnableStiffBubbleDrag(true);
+    equations.getBubbleSizeClosure().setSurfaceTension(0.035);
+    equations.getBubbleSizeClosure().setMaximumPipeDiameterFraction(0.15);
+    equations.getBubbleSizeClosure().setUseLocalSurfaceTension(true);
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     ObjectOutputStream output = new ObjectOutputStream(bytes);
@@ -28,6 +32,9 @@ class StiffBubbleDragSerializationTest {
 
     assertTrue(copy.isStiffBubbleDragEnabled());
     assertTrue(copy.getInterfacialFriction().isUseCorrectedBubbleDrag());
+    assertEquals(0.035, copy.getBubbleSizeClosure().getSurfaceTension(), 0.0);
+    assertEquals(0.15, copy.getBubbleSizeClosure().getMaximumPipeDiameterFraction(), 0.0);
+    assertTrue(copy.getBubbleSizeClosure().isUseLocalSurfaceTension());
     copy.setEnableStiffBubbleDrag(false);
     assertFalse(copy.isStiffBubbleDragEnabled());
   }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosureTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosureTest.java
@@ -67,12 +67,9 @@ class BubbleSizeClosureTest {
 
     assertThrows(IllegalArgumentException.class, () -> closure.setSurfaceTension(0.0));
     assertThrows(IllegalArgumentException.class, () -> closure.setMaximumPipeDiameterFraction(1.1));
-    assertThrows(IllegalArgumentException.class,
-        () -> closure.estimateDiameter(0.0, 1000.0, 5.0, 9.81));
-    assertThrows(IllegalArgumentException.class,
-        () -> closure.estimateDiameter(0.1, Double.NaN, 5.0, 9.81));
+    assertThrows(IllegalArgumentException.class, () -> closure.estimateDiameter(0.0, 1000.0, 5.0, 9.81));
+    assertThrows(IllegalArgumentException.class, () -> closure.estimateDiameter(0.1, Double.NaN, 5.0, 9.81));
     closure.setUseLocalSurfaceTension(true);
-    assertThrows(IllegalArgumentException.class,
-        () -> closure.estimateDiameter(0.1, 1000.0, 5.0, 9.81, Double.NaN));
+    assertThrows(IllegalArgumentException.class, () -> closure.estimateDiameter(0.1, 1000.0, 5.0, 9.81, Double.NaN));
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosureTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosureTest.java
@@ -9,11 +9,11 @@ import org.junit.jupiter.api.Test;
 class BubbleSizeClosureTest {
 
   @Test
-  void reproducesHistoricalDefaultAssumptions() {
+  void reproducesHistoricalDefaultDiameterExactly() {
     BubbleSizeClosure closure = new BubbleSizeClosure();
     double diameter = closure.estimateDiameter(0.10, 1000.0, 5.0, 9.81);
 
-    double expected = Math.min(Math.sqrt(0.02 / (9.81 * 995.0)), 0.02);
+    double expected = Math.min(2.0 * Math.sqrt(0.725 * 0.02 / (9.81 * 995.0)), 0.02);
     assertEquals(0.02, closure.getSurfaceTension(), 0.0);
     assertEquals(0.20, closure.getMaximumPipeDiameterFraction(), 0.0);
     assertEquals(expected, diameter, 1.0e-15);
@@ -29,6 +29,19 @@ class BubbleSizeClosureTest {
 
     assertTrue(highDiameter > lowDiameter);
     assertEquals(2.0, highDiameter / lowDiameter, 1.0e-12);
+  }
+
+  @Test
+  void usesLocalSurfaceTensionOnlyWhenExplicitlyEnabled() {
+    BubbleSizeClosure closure = new BubbleSizeClosure();
+    double fixed = closure.estimateDiameter(1.0, 900.0, 20.0, 9.81, 0.08);
+    assertEquals(closure.estimateDiameter(1.0, 900.0, 20.0, 9.81), fixed, 0.0);
+
+    closure.setUseLocalSurfaceTension(true);
+    double local = closure.estimateDiameter(1.0, 900.0, 20.0, 9.81, 0.08);
+
+    assertTrue(closure.isUseLocalSurfaceTension());
+    assertEquals(2.0, local / fixed, 1.0e-12);
   }
 
   @Test
@@ -54,7 +67,12 @@ class BubbleSizeClosureTest {
 
     assertThrows(IllegalArgumentException.class, () -> closure.setSurfaceTension(0.0));
     assertThrows(IllegalArgumentException.class, () -> closure.setMaximumPipeDiameterFraction(1.1));
-    assertThrows(IllegalArgumentException.class, () -> closure.estimateDiameter(0.0, 1000.0, 5.0, 9.81));
-    assertThrows(IllegalArgumentException.class, () -> closure.estimateDiameter(0.1, Double.NaN, 5.0, 9.81));
+    assertThrows(IllegalArgumentException.class,
+        () -> closure.estimateDiameter(0.0, 1000.0, 5.0, 9.81));
+    assertThrows(IllegalArgumentException.class,
+        () -> closure.estimateDiameter(0.1, Double.NaN, 5.0, 9.81));
+    closure.setUseLocalSurfaceTension(true);
+    assertThrows(IllegalArgumentException.class,
+        () -> closure.estimateDiameter(0.1, 1000.0, 5.0, 9.81, Double.NaN));
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosureTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/BubbleSizeClosureTest.java
@@ -13,10 +13,10 @@ class BubbleSizeClosureTest {
     BubbleSizeClosure closure = new BubbleSizeClosure();
     double diameter = closure.estimateDiameter(0.10, 1000.0, 5.0, 9.81);
 
-    double expected = Math.min(2.0 * Math.sqrt(0.725 * 0.02 / (9.81 * 995.0)), 0.02);
+    double expected = Math.min(2.0 * Math.pow(0.725 * 0.02 / (9.81 * 995.0), 0.5), 0.02);
     assertEquals(0.02, closure.getSurfaceTension(), 0.0);
     assertEquals(0.20, closure.getMaximumPipeDiameterFraction(), 0.0);
-    assertEquals(expected, diameter, 1.0e-15);
+    assertEquals(expected, diameter, 0.0);
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFrictionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFrictionTest.java
@@ -73,8 +73,7 @@ class InterfacialFrictionTest {
   void bubbleDiameterConfigurationControlsInterfacialAreaWithoutChangingDefault() {
     InterfacialFriction friction = new InterfacialFriction();
     double defaultDiameter = inferredBubbleDiameter(friction, 0.072);
-    double expectedDefault = 2.0
-        * Math.sqrt(0.725 * DEFAULT_BUBBLE_SURFACE_TENSION / ((1000.0 - 5.0) * GRAVITY));
+    double expectedDefault = 2.0 * Math.sqrt(0.725 * DEFAULT_BUBBLE_SURFACE_TENSION / ((1000.0 - 5.0) * GRAVITY));
 
     assertEquals(expectedDefault, defaultDiameter, 1.0e-15);
 
@@ -107,9 +106,8 @@ class InterfacialFrictionTest {
   private static double inferredBubbleDiameter(InterfacialFriction friction, double surfaceTension) {
     double diameter = 1.0;
     double liquidHoldup = 0.9;
-    InterfacialFriction.InterfacialFrictionResult result =
-        friction.calculate(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0, 1.5e-5,
-            1.0e-3, liquidHoldup, diameter, surfaceTension);
+    InterfacialFriction.InterfacialFrictionResult result = friction.calculate(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0,
+        1.5e-5, 1.0e-3, liquidHoldup, diameter, surfaceTension);
     double gasHoldup = 1.0 - liquidHoldup;
     double area = Math.PI * diameter * diameter / 4.0;
     return 6.0 * gasHoldup * area / result.interfacialAreaPerLength;

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFrictionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/closure/InterfacialFrictionTest.java
@@ -70,6 +70,24 @@ class InterfacialFrictionTest {
   }
 
   @Test
+  void bubbleDiameterConfigurationControlsInterfacialAreaWithoutChangingDefault() {
+    InterfacialFriction friction = new InterfacialFriction();
+    double defaultDiameter = inferredBubbleDiameter(friction, 0.072);
+    double expectedDefault = 2.0
+        * Math.sqrt(0.725 * DEFAULT_BUBBLE_SURFACE_TENSION / ((1000.0 - 5.0) * GRAVITY));
+
+    assertEquals(expectedDefault, defaultDiameter, 1.0e-15);
+
+    friction.getBubbleSizeClosure().setSurfaceTension(0.08);
+    double configuredDiameter = inferredBubbleDiameter(friction, 0.072);
+    assertEquals(2.0, configuredDiameter / defaultDiameter, 1.0e-12);
+
+    friction.getBubbleSizeClosure().setUseLocalSurfaceTension(true);
+    double localDiameter = inferredBubbleDiameter(friction, 0.045);
+    assertEquals(Math.sqrt(0.045 / 0.08), localDiameter / configuredDiameter, 1.0e-12);
+  }
+
+  @Test
   void compatibilityScalingRemainsTheDefaultAndFreezesLegacyUnderprediction() {
     InterfacialFriction friction = new InterfacialFriction();
     double diameter = 0.1;
@@ -84,6 +102,17 @@ class InterfacialFrictionTest {
     assertFalse(friction.isUseCorrectedBubbleDrag());
     assertTrue(legacy < corrected);
     assertEquals(bubbleDiameter / diameter, legacy / corrected, 1.0e-14);
+  }
+
+  private static double inferredBubbleDiameter(InterfacialFriction friction, double surfaceTension) {
+    double diameter = 1.0;
+    double liquidHoldup = 0.9;
+    InterfacialFriction.InterfacialFrictionResult result =
+        friction.calculate(FlowRegime.BUBBLE, 0.7, 0.5, 5.0, 1000.0, 1.5e-5,
+            1.0e-3, liquidHoldup, diameter, surfaceTension);
+    double gasHoldup = 1.0 - liquidHoldup;
+    double area = Math.PI * diameter * diameter / 4.0;
+    return 6.0 * gasHoldup * area / result.interfacialAreaPerLength;
   }
 
   private double expectedBubbleDragForcePerLength(double gasVelocity, double liquidVelocity, double gasDensity,


### PR DESCRIPTION
## Roadmap

Advances the next dependency-ready P0 item in #2907 after merged #2943: integrate the explicit bubble-size closure into the real TwoFluidPipe interfacial-momentum path and make section-local surface tension an opt-in public configuration.

## Root cause

Merged #2943 added an isolated helper only. Its default estimate `sqrt(sigma/(g*|delta rho|))` did not reproduce the existing bubble/dispersed-bubble diameter used by `InterfacialFriction`:

`d_b = 2 sqrt(0.725 sigma/(g |rho_L-rho_G|))`, capped at `D/5`.

The production path still hard-coded `0.02 N/m`, so changing the helper had no effect.

## Change

- restore the exact historical algebraic coefficient and geometry cap in `BubbleSizeClosure`;
- wire the closure into both compatibility and corrected Schiller-Naumann bubble paths;
- preserve fixed `0.02 N/m` as the default, while allowing explicit fixed values or opt-in use of each section's existing thermodynamic surface tension;
- expose Java/Python-friendly configuration through `TwoFluidPipe`;
- preserve closure settings across serialization and lazily initialize the field for legacy serialized objects;
- document equations, units, migration, defaults, and the single-size validity boundary.

## Public API

```java
pipe.setBubbleSurfaceTension(0.025);
pipe.setMaximumBubbleDiameterFraction(0.15);
pipe.setUseLocalBubbleSurfaceTension(true);
```

## Physics and compatibility

The configured diameter is

`d_b = min(2 sqrt(0.725 sigma_b/(g |rho_L-rho_G|)), f_D D)`.

Defaults `sigma_b=0.02 N/m` and `f_D=0.20` preserve the historical production result. Local surface tension remains opt-in. No flow-regime, stiff-source, transport, phase-transfer, slugging, or benchmark acceptance bound changes.

This is an algebraic characteristic size, not a bubble population balance or a model of deformation, coalescence, breakup, or turbulent dissipation. Corrected bubble drag remains opt-in and retains the documented 3/6 Tengesdal limitation from #2933.

## Validation contract

Tests cover:

- exact historical default diameter;
- `sqrt(sigma)` scaling, density-order symmetry, geometry cap, equal-density limit, and invalid inputs;
- default fixed versus explicit fixed versus opt-in local surface tension in the production interfacial-area calculation;
- public `TwoFluidPipe` configuration;
- serialization of fixed tension, cap, and local-mode selection;
- existing compatibility/corrected force regressions without changed acceptance bounds.

## Validation

VALIDATION PENDING CI on exact head `8b74ea37f74a243a67aaa2976d9428df0405fb42`.

- On prior head `7fbc8e9279e2bb9bfd5d020d749bb9ad8a368266`, PaperLab, documentation search, and Java 21 Javadoc passed.
- Pre-commit failed only because five changed Java files did not match Spotless.
- The exact formatter patch from workflow run `31484321159`, artifact `9098488887`, digest `sha256:ba962081157d2ee1d0dd1ff7f304893f9dd61c2899795636e6a3c7943dc77ba4`, was applied verbatim without changing physics or assertions.
- Local Maven, Spotless, pre-commit and documentation search were not run and are not claimed as passed because this run used the connector-verified remote tree.
- On exact head `8b74ea37f74a243a67aaa2976d9428df0405fb42`, PaperLab, Spotless, pre-commit/pre-push, documentation search, CodeQL, and Java 21 Javadoc are green.
- The Java 21 fast/slow test matrix and later Java 8 matrix remain in progress.
- Exact-head GitHub CI is the validator; no readiness claim is made while checks remain incomplete.

## Documentation impact

Updated both public TwoFluid model guides. No notebook is changed because the authoritative public example remains a later milestone after quantitative closure qualification.

## Ownership boundary

This PR stays within #2907 Two-Fluid R&D ownership. It does not alter #2935 one-phase conservative transport or #2911 shared transient-engine/orchestration architecture.