### PR TITLE
docs(optimizer): repair external integration contracts

### DIFF
--- a/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
+++ b/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
@@ -3,9 +3,7 @@ title: External Optimizer Integration Guide
 description: This guide explains how to use NeqSim's simulation evaluators to integrate process simulations and multi-area process models with external optimization frameworks like Python's SciPy, NLopt, or other optimization libraries.
 ---
 
-# External Optimizer Integration Guide
-
-> **New to process optimization?** Start with the [Optimization Overview](../process/optimization/OPTIMIZATION_OVERVIEW) to understand when to use which optimizer.
+> **New to process optimization?** Start with the [Optimization Overview](../process/optimization/OPTIMIZATION_OVERVIEW.md) to understand when to use which optimizer.
 
 This guide explains how to use NeqSim's simulation evaluators to integrate process simulation with external optimization frameworks like Python's SciPy, NLopt, or other optimization libraries.
 
@@ -13,10 +11,10 @@ This guide explains how to use NeqSim's simulation evaluators to integrate proce
 
 | Document | Description |
 |----------|-------------|
-| [Optimization Overview](../process/optimization/OPTIMIZATION_OVERVIEW) | When to use which optimizer |
-| [Production Optimization Guide](../examples/PRODUCTION_OPTIMIZATION_GUIDE) | ProductionOptimizer examples |
-| [Practical Examples](../process/optimization/PRACTICAL_EXAMPLES) | Code samples |
-| [Capacity Constraint Framework](../process/CAPACITY_CONSTRAINT_FRAMEWORK) | Installed equipment limits and bottleneck detection |
+| [Optimization Overview](../process/optimization/OPTIMIZATION_OVERVIEW.md) | When to use which optimizer |
+| [Production Optimization Guide](../examples/PRODUCTION_OPTIMIZATION_GUIDE.md) | ProductionOptimizer examples |
+| [Practical Examples](../process/optimization/PRACTICAL_EXAMPLES.md) | Code samples |
+| [Capacity Constraint Framework](../process/CAPACITY_CONSTRAINT_FRAMEWORK.md) | Installed equipment limits and bottleneck detection |
 
 ## Overview
 
@@ -177,30 +175,31 @@ evaluator.addConstraintUpperBound("maxTemperature",
     80.0);
 ```
 
-## Python Integration with JPype
+## Python integration through neqsim-python
 
 ### Installation
 
 ```bash
-pip install jpype1 scipy numpy
+pip install neqsim scipy numpy
 ```
 
-### Basic Setup
+### Basic setup
+
+The public `neqsim` package starts and configures the Java gateway. Do not start a second JVM or
+assume that a local NeqSim JAR file exists.
 
 ```python
-import jpype
-import jpype.imports
 import numpy as np
-from scipy.optimize import minimize, differential_evolution
+from scipy.optimize import differential_evolution, minimize
+from neqsim import jneqsim
 
-# Start JVM with NeqSim
-jpype.startJVM(classpath=['neqsim.jar'])
-
-from neqsim.process.util.optimizer import ProcessSimulationEvaluator
-from neqsim.process.processmodel import ProcessSystem
-from neqsim.process.equipment.stream import Stream
-from neqsim.process.equipment.valve import ThrottlingValve
-from neqsim.thermo.system import SystemSrkEos
+ProcessSimulationEvaluator = (
+    jneqsim.process.util.optimizer.ProcessSimulationEvaluator
+)
+ProcessSystem = jneqsim.process.processmodel.ProcessSystem
+Stream = jneqsim.process.equipment.stream.Stream
+ThrottlingValve = jneqsim.process.equipment.valve.ThrottlingValve
+SystemSrkEos = jneqsim.thermo.system.SystemSrkEos
 ```
 
 ### Creating the Process
@@ -402,44 +401,15 @@ x_opt = opt.optimize(evaluator.getInitialValues())
 
 ## Using with Pyomo
 
-```python
-from pyomo.environ import *
+An ordinary Pyomo `Objective(rule=...)` or `Constraint(rule=...)` must build a symbolic
+expression. Reading `.value` from Pyomo variables inside those rules and immediately calling
+NeqSim evaluates only the construction-time values; it does not create a live connection that
+Pyomo can differentiate or re-evaluate while solving.
 
-def create_pyomo_model():
-    """Create a Pyomo model that calls NeqSim evaluator"""
-    model = ConcreteModel()
-
-    # Get bounds from evaluator
-    n = evaluator.getParameterCount()
-    bounds_array = evaluator.getBounds()
-
-    # Decision variables
-    model.x = Var(range(n),
-                  bounds=lambda m, i: (bounds_array[i][0], bounds_array[i][1]))
-
-    # Initialize
-    x0 = evaluator.getInitialValues()
-    for i in range(n):
-        model.x[i] = x0[i]
-
-    # External function for objective
-    def obj_rule(m):
-        x = [m.x[i].value for i in range(n)]
-        return evaluator.evaluateObjective(x)
-
-    model.obj = Objective(rule=obj_rule, sense=minimize)
-
-    # External constraints (simplified approach)
-    def constraint_rule(m, j):
-        x = [m.x[i].value for i in range(n)]
-        margins = evaluator.getConstraintMargins(x)
-        return margins[j] >= 0
-
-    model.constraints = Constraint(range(evaluator.getConstraintCount()),
-                                    rule=constraint_rule)
-
-    return model
-```
+NeqSim does not currently provide a maintained Pyomo `ExternalFunction` or PyNumero callback
+adapter. Use the SciPy or NLopt black-box patterns above, or implement and validate a dedicated
+Pyomo external-function bridge with explicit value, gradient, lifecycle, and failure handling.
+Do not present a construction-time numeric callback as a Pyomo optimization model.
 
 ## Advanced Features
 
@@ -456,17 +426,18 @@ evaluator.addParameterWithSetter(
 )
 ```
 
-### Caching for Expensive Evaluations
+### Evaluation accounting
 
-The evaluator tracks evaluation count and can be configured for caching:
+`ProcessSimulationEvaluator` counts evaluation attempts:
 
 ```python
-# Check evaluation statistics
 print(f"Total evaluations: {evaluator.getEvaluationCount()}")
-
-# Reset counter
 evaluator.resetEvaluationCount()
 ```
+
+These methods measure work; they do not enable result caching. Add caching in the external
+optimizer only when the complete parameter vector, model identity, operating case, and mutable
+process state are part of a safe cache key.
 
 ### Gradient Configuration
 
@@ -580,33 +551,36 @@ print("Objectives:", problem['objectives'])
 print("Constraints:", problem['constraints'])
 ```
 
-### Process Cloning for Thread Safety
+### Process cloning and parallel evaluation
 
-For parallel evaluations (e.g., with Dask or multiprocessing):
+Only `ProcessSimulationEvaluator` exposes `setCloneForEvaluation(true)`. It clones the
+`ProcessSystem` used for an evaluation so the registered base process is not mutated by that
+call:
 
 ```python
-# Enable process cloning for thread safety
 evaluator.setCloneForEvaluation(True)
 ```
+
+This switch does not make one evaluator instance safe for concurrent calls: counters, last-result
+state, and registered definitions remain mutable. Use one evaluator and one JVM-owned process
+model per worker, and validate deterministic equivalence before parallel production studies.
 
 ## Complete Example: Gas Processing Optimization
 
 ```python
-import jpype
-import jpype.imports
+import matplotlib.pyplot as plt
 import numpy as np
 from scipy.optimize import minimize
-import matplotlib.pyplot as plt
+from neqsim import jneqsim
 
-# Start JVM
-jpype.startJVM(classpath=['neqsim.jar'])
-
-from neqsim.process.util.optimizer import ProcessSimulationEvaluator
-from neqsim.process.processmodel import ProcessSystem
-from neqsim.process.equipment.stream import Stream
-from neqsim.process.equipment.compressor import Compressor
-from neqsim.process.equipment.cooler import Cooler
-from neqsim.thermo.system import SystemSrkEos
+ProcessSimulationEvaluator = (
+    jneqsim.process.util.optimizer.ProcessSimulationEvaluator
+)
+ProcessSystem = jneqsim.process.processmodel.ProcessSystem
+Stream = jneqsim.process.equipment.stream.Stream
+Compressor = jneqsim.process.equipment.compressor.Compressor
+Cooler = jneqsim.process.equipment.cooler.Cooler
+SystemSrkEos = jneqsim.thermo.system.SystemSrkEos
 
 # Create process
 fluid = SystemSrkEos(273.15 + 30.0, 20.0)
@@ -707,12 +681,21 @@ jpype.shutdownJVM()
 | `getConstraintMargins(double[] x)` | Get constraint slack values |
 | `estimateGradient(double[] x)` | Finite-difference gradient |
 | `estimateConstraintJacobian(double[] x)` | Constraint Jacobian matrix |
-| `estimateSensitivitiesWithQuality(double[] x)` | Fine-step gradient/Jacobian plus immutable parameter/objective/constraint identity, base-point values and margins, capacity origin, steps, convergence, feasibility, and step-halving evidence |
 | `getBounds()` | Get parameter bounds array |
 | `getLowerBounds()` | Get lower bounds vector |
 | `getUpperBounds()` | Get upper bounds vector |
 | `getInitialValues()` | Get initial parameter values |
 | `toJson()` | Export problem definition |
+
+### ProcessModelSimulationEvaluator
+
+| Method | Description |
+|--------|-------------|
+| `estimateSensitivitiesWithQuality(double[] x)` | Primary-objective fine-step gradient and constraint-margin Jacobian, plus immutable parameter/objective/constraint identity, base values, capacity origin, perturbation convergence, feasibility, and step-halving evidence |
+| `estimateSensitivitiesWithQuality(double[] x, int objectiveIndex)` | The same evidence for the selected registered objective |
+
+The sensitivity-quality methods belong to `ProcessModelSimulationEvaluator`; they are not methods
+on `ProcessSimulationEvaluator`.
 
 ### EvaluationResult
 
@@ -731,7 +714,7 @@ jpype.shutdownJVM()
 
 ## See Also
 
-- [OPTIMIZER_PLUGIN_ARCHITECTURE.md](../process/optimization/OPTIMIZER_PLUGIN_ARCHITECTURE) - Plugin architecture for equipment-specific optimization
-- [flow-rate-optimization.md](../process/optimization/flow-rate-optimization) - FlowRateOptimizer for lift curve generation
-- [pressure_boundary_optimization.md](../process/pressure_boundary_optimization) - Simplified pressure boundary optimizer
-- [PRODUCTION_OPTIMIZATION_GUIDE.md](../examples/PRODUCTION_OPTIMIZATION_GUIDE) - Complete production optimization examples
+- [OPTIMIZER_PLUGIN_ARCHITECTURE.md](../process/optimization/OPTIMIZER_PLUGIN_ARCHITECTURE.md) - Plugin architecture for equipment-specific optimization
+- [flow-rate-optimization.md](../process/optimization/flow-rate-optimization.md) - FlowRateOptimizer for lift curve generation
+- [pressure_boundary_optimization.md](../process/pressure_boundary_optimization.md) - Simplified pressure boundary optimizer
+- [PRODUCTION_OPTIMIZATION_GUIDE.md](../examples/PRODUCTION_OPTIMIZATION_GUIDE.md) - Complete production optimization examples

--- a/docs/process/optimization/OPTIMIZATION_OVERVIEW.md
+++ b/docs/process/optimization/OPTIMIZATION_OVERVIEW.md
@@ -3,8 +3,6 @@ title: Process Optimization in NeqSim - Overview
 description: This document provides a high-level introduction to the process optimization capabilities in NeqSim, explaining how the different components relate to each other and when to use each one.
 ---
 
-# Process Optimization in NeqSim - Overview
-
 This document provides a high-level introduction to the process optimization capabilities in NeqSim, explaining how the different components relate to each other and when to use each one.
 
 ## Table of Contents
@@ -16,7 +14,7 @@ This document provides a high-level introduction to the process optimization cap
 - [When to Use Which Optimizer](#when-to-use-which-optimizer)
 - [Key Concepts](#key-concepts)
 - [Search Algorithms](#search-algorithms)
-- [Python Usage via JPype](#python-usage-via-jpype)
+- [Python usage through neqsim-python](#python-usage-through-neqsim-python)
 - [Getting Started](#getting-started)
 - [Complete Examples](#complete-examples)
 - [Related Documentation](#related-documentation)
@@ -27,19 +25,19 @@ This document provides a high-level introduction to the process optimization cap
 
 | I want to... | Use this class | Documentation |
 |--------------|----------------|---------------|
-| Find maximum throughput for given pressures | `ProcessOptimizationEngine` | [Optimizer Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE) |
-| Optimize arbitrary objectives with constraints | `ProductionOptimizer` | [Production Optimization Guide](../../examples/PRODUCTION_OPTIMIZATION_GUIDE) |
-| Do multi-objective Pareto optimization | `ProductionOptimizer.optimizePareto()` | [Multi-Objective Optimization](multi-objective-optimization) |
-| Run batch parameter studies | `BatchStudy` | [Batch Studies](batch-studies) |
-| Generate and rank candidate flowsheets from feed/product targets | `ProcessResearcher` | [Process Researcher](process-researcher) |
-| Calculate flow rates for pressure boundaries | `FlowRateOptimizer` | [Flow Rate Optimization](flow-rate-optimization) |
-| Generate Eclipse lift curves (VFP tables) | `EclipseVFPExporter` | [Optimizer Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE#eclipsevfpexporter) |
+| Find maximum throughput for given pressures | `ProcessOptimizationEngine` | [Optimizer Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE.md) |
+| Optimize arbitrary objectives with constraints | `ProductionOptimizer` | [Production Optimization Guide](../../examples/PRODUCTION_OPTIMIZATION_GUIDE.md) |
+| Do multi-objective Pareto optimization | `ProductionOptimizer.optimizePareto()` | [Multi-Objective Optimization](multi-objective-optimization.md) |
+| Run batch parameter studies | `BatchStudy` | [Batch Studies](batch-studies.md) |
+| Generate and rank candidate flowsheets from feed/product targets | `ProcessResearcher` | [Process Researcher](process-researcher.md) |
+| Calculate flow rates for pressure boundaries | `FlowRateOptimizer` | [Flow Rate Optimization](flow-rate-optimization.md) |
+| Generate Eclipse lift curves (VFP tables) | `EclipseVFPExporter` | [Optimizer Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE.md#eclipse-vfp-export) |
 | Evaluate equipment constraints | `ProcessConstraintEvaluator` | [Capacity Constraint Framework](../CAPACITY_CONSTRAINT_FRAMEWORK.md) |
 | Integrate with external optimizers (SciPy, NLopt) | `ProcessSimulationEvaluator` | [External Optimizer Integration](../../integration/EXTERNAL_OPTIMIZER_INTEGRATION.md) |
 | Optimize full multi-area process models | `ProcessModelSimulationEvaluator` | Use area-qualified `ProcessAutomation` addresses and installed `CapacityConstraint` limits |
 | Ramp producers until a full facility reaches a bottleneck | `ProcessModelThroughputOptimizer` | Use producer mappings, installed capacity tables, and exported case traces |
-| Solve constrained NLP (equality + inequality) | `SQPoptimizer` | [SQP Optimizer](sqp_optimizer) |
-| Calibrate model parameters to data | `BatchParameterEstimator` | [Data Reconciliation and Steady-State Detection](data-reconciliation) |
+| Solve constrained NLP (equality + inequality) | `SQPoptimizer` | [SQP Optimizer](sqp_optimizer.md) |
+| Calibrate model parameters to data | `BatchParameterEstimator` | [Data Reconciliation and Steady-State Detection](data-reconciliation.md) |
 | Load optimization config from YAML/JSON | `ProductionOptimizationSpecLoader` | [YAML Spec Format](#yaml-specification-files) |
 
 ---
@@ -49,9 +47,9 @@ This document provides a high-level introduction to the process optimization cap
 
 If you are new to process optimization in NeqSim, begin with:
 
-1. [Getting Started](getting-started)
-2. [Optimization & Constraints Guide](OPTIMIZATION_AND_CONSTRAINTS)
-3. [Constraint Framework](constraint-framework)
+1. [Getting Started](getting-started.md)
+2. [Optimization & Constraints Guide](OPTIMIZATION_AND_CONSTRAINTS.md)
+3. [Constraint Framework](constraint-framework.md)
 
 This sequence covers base-run requirements, optimizer selection, and safe variable access through `ProcessAutomation`.
 
@@ -62,20 +60,20 @@ This sequence covers base-run requirements, optimizer selection, and safe variab
 | Document | Purpose |
 |----------|---------|
 | **This Document** | High-level overview and when to use which optimizer |
-| **[Optimization & Constraints Guide](OPTIMIZATION_AND_CONSTRAINTS)** | **COMPREHENSIVE: Complete guide to algorithms, constraint types, bottleneck analysis, practical examples** |
-| **[ProductionOptimizer Tutorial (Jupyter)](../../examples/ProductionOptimizer_Tutorial)** | **Interactive notebook: algorithms, single/multi-variable, Pareto, constraints** |
-| **[Python Optimization Tutorial (Jupyter)](../../examples/NeqSim_Python_Optimization)** | **Using SciPy/Python optimizers with NeqSim: constraints, Pareto, global opt** |
-| [Optimizer Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE) | Equipment capacity strategies, ProcessOptimizationEngine API, VFP export |
-| [Production Optimization Guide](../../examples/PRODUCTION_OPTIMIZATION_GUIDE) | Complete examples for ProductionOptimizer with Java/Python |
-| [Practical Examples](PRACTICAL_EXAMPLES) | Code samples for common optimization tasks |
-| [Process Researcher](process-researcher) | Candidate flowsheet generation and ranking from feed/product specifications |
-| [Multi-Objective Optimization](multi-objective-optimization) | Pareto fronts, weighted-sum, epsilon-constraint methods |
-| [Batch Studies](batch-studies) | Parallel parameter sweeps and sensitivity analysis |
-| [Flow Rate Optimization](flow-rate-optimization) | FlowRateOptimizer and lift curve tables |
+| **[Optimization & Constraints Guide](OPTIMIZATION_AND_CONSTRAINTS.md)** | **COMPREHENSIVE: Complete guide to algorithms, constraint types, bottleneck analysis, practical examples** |
+| **[ProductionOptimizer Tutorial (Jupyter)](../../examples/ProductionOptimizer_Tutorial.md)** | **Interactive notebook: algorithms, single/multi-variable, Pareto, constraints** |
+| **[Python Optimization Tutorial (Jupyter)](../../examples/NeqSim_Python_Optimization.md)** | **Using SciPy/Python optimizers with NeqSim: constraints, Pareto, global opt** |
+| [Optimizer Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE.md) | Equipment capacity strategies, ProcessOptimizationEngine API, VFP export |
+| [Production Optimization Guide](../../examples/PRODUCTION_OPTIMIZATION_GUIDE.md) | Complete examples for ProductionOptimizer with Java/Python |
+| [Practical Examples](PRACTICAL_EXAMPLES.md) | Code samples for common optimization tasks |
+| [Process Researcher](process-researcher.md) | Candidate flowsheet generation and ranking from feed/product specifications |
+| [Multi-Objective Optimization](multi-objective-optimization.md) | Pareto fronts, weighted-sum, epsilon-constraint methods |
+| [Batch Studies](batch-studies.md) | Parallel parameter sweeps and sensitivity analysis |
+| [Flow Rate Optimization](flow-rate-optimization.md) | FlowRateOptimizer and lift curve tables |
 | [External Optimizer Integration](../../integration/EXTERNAL_OPTIMIZER_INTEGRATION.md) | ProcessSimulationEvaluator and ProcessModelSimulationEvaluator for Python/SciPy integration |
-| [Getting Started](getting-started) | Step-by-step first optimization workflow for process models/systems |
-| [Optimizer Guide](../../util/optimizer_guide) | Detailed API reference for all optimizer classes |
-| [SQP Optimizer](sqp_optimizer) | Sequential Quadratic Programming — constrained NLP with BFGS + active-set QP |
+| [Getting Started](getting-started.md) | Step-by-step first optimization workflow for process models/systems |
+| [Optimizer Guide](../../util/optimizer_guide.md) | Detailed API reference for all optimizer classes |
+| [SQP Optimizer](sqp_optimizer.md) | Sequential Quadratic Programming — constrained NLP with BFGS + active-set QP |
 | [Capacity Constraint Framework](../CAPACITY_CONSTRAINT_FRAMEWORK.md) | Equipment constraints and bottleneck detection |
 
 ---
@@ -394,9 +392,9 @@ Equipment constraints define operating limits. Each equipment type has a strateg
 > **⚠️ Important**: Most equipment constraints are **disabled by default** for backward compatibility. The optimizer automatically falls back to traditional capacity methods (`getCapacityMax()`/`getCapacityDuty()`) when no enabled constraints exist. To use multi-constraint capacity analysis, you must explicitly enable constraints:
 >
 > ```java
-> separator.useEquinorConstraints();  // Enable Equinor TR3500 constraints
-> // OR
-> separator.enableConstraints();       // Enable all constraints
+separator.useEquinorConstraints();  // Enable Equinor TR3500 constraints
+// OR
+separator.enableConstraints();       // Enable all constraints
 > ```
 >
 > See [Capacity Constraint Framework - Constraints Disabled by Default](../CAPACITY_CONSTRAINT_FRAMEWORK.md#important-constraints-disabled-by-default) for details.
@@ -469,18 +467,18 @@ config.searchMode(SearchMode.PARTICLE_SWARM_SCORE);
 config.searchMode(SearchMode.GRADIENT_DESCENT_SCORE);  // New (Jan 2026)
 ```
 
-> **January 2026 Update:** ProductionOptimizer now includes `GRADIENT_DESCENT_SCORE` algorithm, configuration validation, stagnation detection, warm start, bounded LRU cache, and infeasibility diagnostics. See [Production Optimization Guide](../../examples/PRODUCTION_OPTIMIZATION_GUIDE) for details.
+> **January 2026 Update:** ProductionOptimizer now includes `GRADIENT_DESCENT_SCORE` algorithm, configuration validation, stagnation detection, warm start, bounded LRU cache, and infeasibility diagnostics. See [Production Optimization Guide](../../examples/PRODUCTION_OPTIMIZATION_GUIDE.md) for details.
 
 ---
 
-## Python Usage via JPype
+## Python usage through neqsim-python
 
 Both optimizers work seamlessly from Python using neqsim-python:
 
 ### ProcessOptimizationEngine from Python
 
 ```python
-from neqsim.neqsimpython import jneqsim
+from neqsim import jneqsim
 
 # Get classes
 ProcessOptimizationEngine = jneqsim.process.util.optimizer.ProcessOptimizationEngine
@@ -499,7 +497,7 @@ print(f"Bottleneck: {result.getBottleneck()}")
 ### ProductionOptimizer from Python
 
 ```python
-from neqsim.neqsimpython import jneqsim
+from neqsim import jneqsim
 from jpype import JImplements, JOverride
 
 # Get classes
@@ -675,23 +673,25 @@ for (ScenarioRequest scenario : scenarios) {
 
 ---
 
+## Related Documentation
+
 ## Class Summary
 
 | Class | Purpose | Key Method | Documentation |
 |-------|---------|------------|---------------|
-| `ProcessOptimizationEngine` | Throughput-focused optimization | `findMaximumThroughput()` | [Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE) |
-| `ProductionOptimizer` | General-purpose optimization | `optimize()`, `optimizePareto()` | [Production Guide](../../examples/PRODUCTION_OPTIMIZATION_GUIDE) |
-| `FlowRateOptimizer` | Flow rate for pressure boundaries | `findMaxFlowRate()` | [Flow Rate Optimization](flow-rate-optimization) |
-| `MultiObjectiveOptimizer` | Pareto front generation | `optimize()` | [Multi-Objective](multi-objective-optimization) |
-| `BatchStudy` | Parallel parameter sweeps | `run()` | [Batch Studies](batch-studies) |
+| `ProcessOptimizationEngine` | Throughput-focused optimization | `findMaximumThroughput()` | [Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE.md) |
+| `ProductionOptimizer` | General-purpose optimization | `optimize()`, `optimizePareto()` | [Production Guide](../../examples/PRODUCTION_OPTIMIZATION_GUIDE.md) |
+| `FlowRateOptimizer` | Flow rate for pressure boundaries | `findMaxFlowRate()` | [Flow Rate Optimization](flow-rate-optimization.md) |
+| `MultiObjectiveOptimizer` | Pareto front generation | `optimize()` | [Multi-Objective](multi-objective-optimization.md) |
+| `BatchStudy` | Parallel parameter sweeps | `run()` | [Batch Studies](batch-studies.md) |
 | `ProcessConstraintEvaluator` | Constraint evaluation | `evaluate()` | [Capacity Framework](../CAPACITY_CONSTRAINT_FRAMEWORK.md) |
 | `ProcessSimulationEvaluator` | External optimizer interface | `evaluate()` | [External Integration](../../integration/EXTERNAL_OPTIMIZER_INTEGRATION.md) |
 | `ProcessModelSimulationEvaluator` | External optimizer interface for multi-area `ProcessModel` studies | `evaluate()` | [External Integration](../../integration/EXTERNAL_OPTIMIZER_INTEGRATION.md) |
 | `ProcessModelThroughputOptimizer` | Full-model throughput-to-bottleneck study helper | `findMaximumThroughput()` | [External Integration](../../integration/EXTERNAL_OPTIMIZER_INTEGRATION.md) |
 | `InstalledCapacityTableLoader` | Attach fixed equipment limits from CSV | `load()` | [Capacity Framework](../CAPACITY_CONSTRAINT_FRAMEWORK.md) |
-| `EclipseVFPExporter` | Eclipse VFP tables | `exportVFPPROD()` | [Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE#eclipsevfpexporter) |
-| `LiftCurveGenerator` | Lift curve tables | `generateLiftCurve()` | [Flow Rate Optimization](flow-rate-optimization) |
-| `BatchParameterEstimator` | Model calibration | `solve()` | [Data Reconciliation and Steady-State Detection](data-reconciliation) |
+| `EclipseVFPExporter` | Eclipse VFP tables | `exportVFPPROD()` | [Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE.md#eclipse-vfp-export) |
+| `LiftCurveGenerator` | Lift curve tables | `generateLiftCurve()` | [Flow Rate Optimization](flow-rate-optimization.md) |
+| `BatchParameterEstimator` | Model calibration | `solve()` | [Data Reconciliation and Steady-State Detection](data-reconciliation.md) |
 | `ProductionOptimizationSpecLoader` | YAML/JSON config loading | `load()` | [YAML Format](#yaml-specification-files) |
 
 ---

--- a/docs/test_optimizer_documentation.py
+++ b/docs/test_optimizer_documentation.py
@@ -1,0 +1,122 @@
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = DOCS_DIR.parent
+EXTERNAL_GUIDE = DOCS_DIR / "integration" / "EXTERNAL_OPTIMIZER_INTEGRATION.md"
+OVERVIEW = DOCS_DIR / "process" / "optimization" / "OPTIMIZATION_OVERVIEW.md"
+PROCESS_EVALUATOR = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/util/optimizer/ProcessSimulationEvaluator.java"
+)
+MODEL_EVALUATOR = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java"
+)
+
+
+class OptimizerDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.documents = {
+            EXTERNAL_GUIDE: EXTERNAL_GUIDE.read_text(encoding="utf-8"),
+            OVERVIEW: OVERVIEW.read_text(encoding="utf-8"),
+        }
+
+    def test_front_matter_links_and_fences_are_repository_safe(self):
+        link_pattern = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+        for source_path, content in self.documents.items():
+            content_without_fences = re.sub(
+                r"```.*?```",
+                "",
+                content,
+                flags=re.DOTALL,
+            )
+            with self.subTest(source=source_path.name):
+                self.assertTrue(content.startswith("---\n"))
+                self.assertEqual(content.count("```") % 2, 0)
+                self.assertNotRegex(
+                    content_without_fences,
+                    re.compile(r"^# ", re.MULTILINE),
+                )
+
+            for destination in link_pattern.findall(content):
+                if destination.startswith(("http://", "https://", "mailto:")):
+                    continue
+
+                target_path, separator, fragment = destination.partition("#")
+                if target_path:
+                    relative_path = unquote(target_path)
+                    resolved = (source_path.parent / relative_path).resolve()
+                    with self.subTest(
+                        source=source_path.name,
+                        destination=destination,
+                    ):
+                        self.assertEqual(Path(relative_path).suffix, ".md")
+                        self.assertTrue(resolved.is_file(), str(resolved))
+                    target_content = resolved.read_text(encoding="utf-8")
+                else:
+                    target_content = content
+
+                if separator:
+                    target_without_fences = re.sub(
+                        r"```.*?```",
+                        "",
+                        target_content,
+                        flags=re.DOTALL,
+                    )
+                    heading_slugs = {
+                        re.sub(
+                            r"[^a-z0-9 -]",
+                            "",
+                            heading.lower(),
+                        )
+                        .strip()
+                        .replace(" ", "-")
+                        for heading in re.findall(
+                            r"^#{1,6}\\s+(.+)$",
+                            target_without_fences,
+                            flags=re.MULTILINE,
+                        )
+                    }
+                    with self.subTest(
+                        source=source_path.name,
+                        destination=destination,
+                    ):
+                        self.assertIn(fragment, heading_slugs)
+
+    def test_python_examples_use_the_public_neqsim_gateway(self):
+        combined = "\n".join(self.documents.values())
+        self.assertIn("from neqsim import jneqsim", combined)
+        self.assertNotIn("neqsim.neqsimpython", combined)
+        self.assertNotIn("jpype.startJVM", combined)
+        self.assertNotIn("neqsim.jar", combined)
+        self.assertNotIn("pip install jpype1", combined)
+
+    def test_framework_and_evaluator_boundaries_remain_truthful(self):
+        external = self.documents[EXTERNAL_GUIDE]
+        self.assertNotIn("from pyomo.environ import *", external)
+        self.assertNotIn("m.x[i].value", external)
+        self.assertIn("does not create a live connection", external)
+        self.assertIn("they do not enable result caching", external)
+
+        process_section = external.split("### ProcessSimulationEvaluator", 1)[1]
+        process_section, model_section = process_section.split(
+            "### ProcessModelSimulationEvaluator",
+            1,
+        )
+        model_section = model_section.split("### EvaluationResult", 1)[0]
+        self.assertNotIn("estimateSensitivitiesWithQuality", process_section)
+        self.assertIn("estimateSensitivitiesWithQuality", model_section)
+
+        process_source = PROCESS_EVALUATOR.read_text(encoding="utf-8")
+        model_source = MODEL_EVALUATOR.read_text(encoding="utf-8")
+        self.assertNotIn("estimateSensitivitiesWithQuality", process_source)
+        self.assertIn("estimateSensitivitiesWithQuality", model_source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## D051 — optimizer integration documentation contracts

Refs #2499. This is the single active documentation-quality campaign PR for the frozen D051 rotation-8 batch.

### Frozen scope

- `docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md`
- `docs/process/optimization/OPTIMIZATION_OVERVIEW.md`
- `docs/test_optimizer_documentation.py`

Optimizer production sources and existing focused tests were used as read-only API evidence. No optimizer algorithm, public API, notebook, dependency, or unrelated documentation is changed.

### Confirmed defects and evidence

- **High:** the advertised clean Python setup manually started JPype against an assumed local `neqsim.jar`; this is not the supported public-PyPI `neqsim` gateway.
- **High:** the Pyomo example read `.value` while constructing symbolic rules, freezing construction-time numbers rather than creating a live optimization callback.
- **High:** the API reference attributed `estimateSensitivitiesWithQuality(...)` to `ProcessSimulationEvaluator`, although current source exposes it only on `ProcessModelSimulationEvaluator`.
- **Medium:** the overview used the legacy `neqsim.neqsimpython` import instead of the public `from neqsim import jneqsim` gateway.
- **Medium:** an “expensive-evaluation caching” section demonstrated only evaluation counters; neither method enables result caching.
- **Medium:** cloning guidance implied thread safety without disclosing mutable evaluator counters, definitions, and last-result state.
- **Medium:** 66 internal link occurrences used extensionless destinations contrary to the repository documentation-link contract.
- **Medium:** the table of contents linked to a missing `#related-documentation` heading.
- **Medium:** two Eclipse exporter links targeted nonexistent `#eclipsevfpexporter` anchors rather than `#eclipse-vfp-export`.
- **Low:** both pages duplicated their front-matter titles as H1 headings.
- **Low:** one Java fence retained blockquote prompt prefixes, making the snippet non-copyable.

### Fixes

- Route setup and complete examples through `pip install neqsim` and `from neqsim import jneqsim`; remove manual JVM/JAR assumptions.
- Replace the nonfunctional Pyomo code with an explicit framework boundary: a maintained external-function/PyNumero adapter does not currently exist.
- Rename the counter section to evaluation accounting and state the cache-identity requirements.
- Limit clone guidance to `ProcessSimulationEvaluator` and require one evaluator/process model per concurrent worker.
- Split the evaluator API tables so sensitivity identity/provenance methods are assigned to the class that implements them.
- Remove duplicate H1s, normalize repository links to `.md`, add the missing related-documentation heading, repair both Eclipse anchors, and clean the Java fence.
- Add a focused Python contract that checks front matter, fences, link files and anchors, gateway usage, Pyomo/cache boundaries, and evaluator attribution against current Java source.

### Validation performed

Authoritative current base: `810415b082857cb0963e29f4b85ddbe7f1e3cf36`. The documentation commits were integrated with that exact base by non-forced merge commit `94073571bb137eda59ddb1d1122ea2bbd7479ce5`; the base-only DEXPI changes do not overlap the frozen D051 paths.

Fresh Python/NeqSim environment:

- bootstrap resolution: `online-new-snapshot`
- public-PyPI wheel snapshot: 49 verified wheels
- NeqSim 3.17.0, Python 3.12.13, OpenJDK 17.0.19
- supported-gateway evaluator smoke: **passed**
  - converged and feasible
  - objective: 30.0 bara
  - hard-constraint margin: 7000.000000000004 kg/hr
  - evaluation count: 1

Connector/source validation:

- all **66** internal link and anchor occurrences resolve on current `master`
- current Java source confirms `estimateSensitivitiesWithQuality` exists on `ProcessModelSimulationEvaluator` and not `ProcessSimulationEvaluator`
- current Java source confirms evaluation counters do not implement caching
- transformed Markdown has balanced fences, no duplicate source H1, no raw `jpype.startJVM`, no assumed `neqsim.jar`, no legacy gateway import, and no construction-time Pyomo pseudo-model
- branch contents exactly match the reviewed three-file payload

No equations, images, generated pages, notebooks, or external URLs are changed; equation/notebook visual gates are not applicable.

### VALIDATION PENDING CI

The original exact documentation head `feef1b7ac405682e46ec618839efaa4195c46dcf` passed build/test/Javadoc, Spotless, pre-commit, documentation-search, and CodeQL workflows. Master then advanced by unrelated DEXPI PR #2938, so a fresh complete CI pass is pending on current exact head `94073571bb137eda59ddb1d1122ea2bbd7479ce5`.

A clean local checkout at this exact branch head was not available, and local repository tooling is supporting rather than publication-critical for this campaign. Therefore the following are **not claimed as run locally**:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- pre-commit and pre-push hook stages
- the new contract test inside the complete repository tree
- Jekyll documentation build/render

GitHub CI must verify formatting, the focused contract, documentation build/search, and broader repository checks. Any attributable failure or justified review finding will be repaired on this same PR.

### Exclusions and next scope

This batch does not redesign external optimizer APIs, add a Pyomo bridge, alter sensitivity numerics, or overlap active #2938/#2944. D051 remains in progress until this PR is merged. The next rotation item after merge is D052, scope 1.
