### PR TITLE
fix(dynamic): propagate parallel transient worker failures

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-dynamic-simulation
 description: "Dynamic simulation guidance for NeqSim. USE WHEN: running transient simulations, modeling startup/shutdown, tuning PID controllers, analyzing pressure/level dynamics, performing blowdown/depressurization, or setting up measurement devices and control loops. Covers runTransient, DynamicProcessHelper, controller tuning, and dynamic equipment configuration."
-last_verified: "2026-08-10"
+last_verified: "2026-08-11"
 ---
 
 # Dynamic Simulation Guidance
@@ -454,13 +454,18 @@ with `process.setTransientThreadPoolSize(n)`. The per-process worker pool is
 created lazily and reused across timesteps; changing the worker count or
 disabling the option retires it. Execution follows cached process-graph levels,
 so upstream groups complete before downstream equipment is submitted while
-independent groups within a level remain parallel. If the caller is interrupted
+independent groups within a level remain parallel. A worker exception propagates to the caller with its runtime type and message,
+cancels later queued groups, prevents downstream dependency levels from being
+submitted, and skips controller, measurement/alarm/history, timestep-counter,
+and calculation-identifier commit phases. The process clock, due-event effects,
+and equipment state already mutated by a same-level sibling or earlier unit are
+not rolled back; treat that timestep as incomplete. If the caller is interrupted
 while waiting, NeqSim restores the interrupt status, cancels queued work without
 interrupting equipment already updating state, does not submit downstream
-levels, and aborts the remaining timestep phases. Treat that timestep as
-incomplete. Graph ordering does not define transient recycle convergence or
-rollback, so keep parallel execution off for recycle loops and other implicit
-couplings until their transient contract is explicitly supported.
+levels, and likewise aborts the remaining timestep phases. Graph ordering does
+not define transient recycle convergence or transactional rollback, so keep
+parallel execution off for recycle loops and other implicit couplings until
+their transient contract is explicitly supported.
 
 ## Python Dynamic Simulation
 

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -107,19 +107,23 @@ findings, `UNCLASSIFIED_DYNAMIC` review items, and known process-level execution
 not yet safe for strict professional qualification. `getExecutionIssues()` exposes those process-level findings
 separately so they are not confused with equipment state ownership or activation.
 
-Two execution modes are explicitly blocked by the current Phase-0 contract:
+Adaptive transient execution remains explicitly blocked by the current Phase-0 contract:
+`runTransientAdaptive(...)` mutates one full timestep and derives a following timestep recommendation without a
+full-step/two-half-step error estimate, rejected-step restore, retry, and one accepted-step commit boundary.
 
-- **parallel transient execution** is not strict-ready while equipment worker failures can be logged/swallowed instead of
-  propagating fail-loudly to abort the physical step. Disabling parallel transient execution avoids that specific worker
-  failure path, but it does not create rejected-step rollback or a whole-model transaction;
-- **adaptive transient execution** is not strict-ready while `runTransientAdaptive(...)` mutates one full timestep and
-  derives a following timestep recommendation without a full-step/two-half-step error estimate, rejected-step restore,
-  retry, and one accepted-step commit boundary.
+Parallel transient execution is no longer blocked solely because of worker error handling. Equipment worker exceptions
+now propagate to the caller, stop later dependency levels, and prevent the controller, measurement/alarm/history,
+timestep-counter, and calculation-identifier commit phases from running. The original runtime exception type and message
+are preserved when it crosses the worker future.
 
-These diagnostics are collected recursively through initialized process modules and preserve `ProcessModel` area paths.
-They make current limitations explicit instead of presenting the modes as qualified transient numerics. Once the
-underlying execution semantics are repaired and quantitatively tested, the corresponding blocker should be removed
-rather than retained as a permanent policy restriction.
+This fail-loud boundary is deliberately narrower than transaction or rollback. The process clock and due-event effects
+occur before equipment execution, and state already mutated by a same-level sibling or earlier equipment is not restored.
+Parallel mode therefore remains unsuitable as evidence of whole-step rollback, transient recycle convergence, or
+qualified adaptive/stiff integration. Passing strict preflight means only that the former swallowed-worker-failure defect
+is absent.
+
+Execution diagnostics are collected recursively through initialized process modules and preserve `ProcessModel` area
+paths. They make remaining limitations explicit instead of presenting an execution mode as quantitatively qualified.
 
 Strict preflight does **not** reject an audited dynamic unit merely because the unit is intentionally inactive, and it
 does not yet reject a state-owning family solely because activation remains `UNVERIFIED`. The preflight is not
@@ -288,8 +292,8 @@ whole-step transaction boundary rather than assumed to come from the process gra
 
 This contract does not yet provide the plant-wide vector ODE/DAE solver required for strongly coupled professional
 dynamics. In particular, it does not add global pressure-flow residual assembly, sparse Jacobians, whole-model timestep
-rejection/rollback, event localization, or multi-rate pipeline subcycling. The strict execution diagnostics make known
-parallel/adaptive limitations explicit; they do not repair those underlying execution paths. Those capabilities build on
+rejection/rollback, event localization, or multi-rate pipeline subcycling. The strict execution diagnostics keep the adaptive blocker explicit, while the parallel failure contract documents its
+remaining non-transactional boundary. Neither provides the missing whole-step transaction. Those capabilities build on
 this contract so the solver can reason explicitly about which objects own dynamic state, which objects are algebraic
 constraints, and which execution modes have qualified transaction/error semantics.
 

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
@@ -559,10 +559,6 @@ public final class DynamicCapabilityReport implements Serializable {
   private static void addExecutionIssues(String areaName, String containerPath, ProcessSystem process,
       List<String> executionIssues) {
     String processName = qualifiedProcessName(areaName, containerPath, process);
-    if (process.isParallelTransientEnabled()) {
-      executionIssues.add(processName
-          + " enables parallel transient execution, whose equipment worker failures are not yet fail-loud; disable parallel transient mode for strict qualification until worker failures propagate and whole-step rollback exists");
-    }
     if (process.isAdaptiveTimestepEnabled()) {
       executionIssues.add(processName
           + " enables adaptive transient execution, but runTransientAdaptive currently mutates one full step and adjusts a following timestep without rejected-step rollback or full-step/two-half-step error estimation");

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4729,9 +4729,10 @@ public class ProcessSystem extends SimulationBaseClass {
    * level execute in parallel; a downstream level is not submitted until every upstream group has completed. Worker
    * exceptions propagate fail-loudly to the caller, stop later groups and dependency levels, and prevent controller,
    * measurement-history, alarm, timestep-counter, and calculation-identifier commit for the failed step. If the caller
-   * is interrupted while waiting, its interrupt status is restored and the wait loop stops. Each dependency level checks
-   * that status before submitting work, so an interrupt at a level boundary does not enqueue downstream equipment.
-   * Already submitted equipment that is queued is cancelled without interrupting tasks already updating state.
+   * is interrupted while waiting, its interrupt status is restored and the wait loop stops. Each dependency level
+   * checks that status before submitting work, so an interrupt at a level boundary does not enqueue downstream
+   * equipment. Already submitted equipment that is queued is cancelled without interrupting tasks already updating
+   * state.
    *
    * <p>
    * This boundary is not a whole-step transaction: the process clock, due-event effects, and state already mutated by

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4726,11 +4726,17 @@ public class ProcessSystem extends SimulationBaseClass {
 
   /**
    * Runs transient calculations in dependency order using the cached process-graph levels. Independent groups within a
-   * level execute in parallel; a downstream level is not submitted until every upstream group has completed. If the
-   * caller is interrupted while waiting, its interrupt status is restored and the wait loop stops. Each dependency
-   * level checks that status before submitting work, so an interrupt at a level boundary does not enqueue downstream
-   * equipment. Already submitted equipment that is queued is cancelled without interrupting tasks already updating
-   * state.
+   * level execute in parallel; a downstream level is not submitted until every upstream group has completed. Worker
+   * exceptions propagate fail-loudly to the caller, stop later groups and dependency levels, and prevent controller,
+   * measurement-history, alarm, timestep-counter, and calculation-identifier commit for the failed step. If the caller
+   * is interrupted while waiting, its interrupt status is restored and the wait loop stops. Each dependency level checks
+   * that status before submitting work, so an interrupt at a level boundary does not enqueue downstream equipment.
+   * Already submitted equipment that is queued is cancelled without interrupting tasks already updating state.
+   *
+   * <p>
+   * This boundary is not a whole-step transaction: the process clock, due-event effects, and state already mutated by
+   * equipment (including same-level siblings) are not rolled back.
+   * </p>
    *
    * @param dt time step in seconds
    * @param id calculation identifier
@@ -4761,11 +4767,7 @@ public class ProcessSystem extends SimulationBaseClass {
               if (stopRequested.get()) {
                 return;
               }
-              try {
-                runUnitTransientSkippingInactive(node.getEquipment(), stepSize, calcId);
-              } catch (Exception ex) {
-                logger.error("Parallel transient equipment execution failed for {}", node.getName(), ex);
-              }
+              runUnitTransientSkippingInactive(node.getEquipment(), stepSize, calcId);
             }
           }
         }));
@@ -4783,8 +4785,11 @@ public class ProcessSystem extends SimulationBaseClass {
           logger.warn("Parallel transient execution interrupted; caller interrupt status restored");
           return false;
         } catch (ExecutionException ex) {
-          Throwable cause = ex.getCause();
-          logger.error("Parallel transient equipment execution failed", cause == null ? ex : cause);
+          stopRequested.set(true);
+          for (int pendingIndex = i + 1; pendingIndex < futures.size(); pendingIndex++) {
+            futures.get(pendingIndex).cancel(false);
+          }
+          throw createWorkerExecutionException("Parallel transient", ex);
         }
       }
     }

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -91,23 +91,23 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertEquals(1, report.getCapabilityCounts().get(DynamicCapability.ALGEBRAIC).intValue());
   }
 
-  /**
-   * Known process-level execution defects are explicit strict-preflight blockers for ProcessSystem and ProcessModel.
-   */
+  /** Parallel transient execution passes strict preflight once worker failures propagate fail-loudly. */
   @Test
-  public void unsafeExecutionModesAreExplicitStrictPreflightBlockers() {
+  public void parallelExecutionIsNotAStandaloneStrictPreflightBlocker() {
     ProcessSystem parallel = new ProcessSystem("parallel area");
     parallel.add(createFeed("parallel feed"));
     parallel.setParallelTransientEnabled(true);
 
     DynamicCapabilityReport parallelReport = DynamicCapabilityReport.from(parallel);
     assertEquals("1.2", parallelReport.getSchemaVersion());
-    assertEquals(1, parallelReport.getExecutionIssues().size());
-    assertTrue(parallelReport.getExecutionIssues().get(0).contains("parallel transient"));
-    assertTrue(parallelReport.getExecutionIssues().get(0).contains("not yet fail-loud"));
-    assertTrue(parallelReport.hasBlockingIssues());
-    assertFalse(parallelReport.isStrictPreflightReady());
+    assertTrue(parallelReport.getExecutionIssues().isEmpty());
+    assertFalse(parallelReport.hasBlockingIssues());
+    assertTrue(parallelReport.isStrictPreflightReady());
+  }
 
+  /** Adaptive execution remains an explicit strict-preflight blocker for ProcessSystem and ProcessModel. */
+  @Test
+  public void adaptiveExecutionIsAnExplicitStrictPreflightBlocker() {
     ProcessSystem adaptive = new ProcessSystem("adaptive area");
     adaptive.add(createFeed("adaptive feed"));
     adaptive.setAdaptiveTimestepEnabled(true);
@@ -119,13 +119,17 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertTrue(adaptiveReport.hasBlockingIssues());
     assertFalse(adaptiveReport.isStrictPreflightReady());
 
+    ProcessSystem parallel = new ProcessSystem("parallel area");
+    parallel.add(createFeed("parallel feed"));
+    parallel.setParallelTransientEnabled(true);
+
     ProcessModel model = new ProcessModel();
     model.add("subsea", parallel);
     model.add("topside", adaptive);
 
     DynamicCapabilityReport modelReport = DynamicCapabilityReport.from(model);
-    assertEquals(2, modelReport.getExecutionIssues().size());
-    assertTrue(containsDiagnostic(modelReport.getExecutionIssues(), "subsea"));
+    assertEquals(1, modelReport.getExecutionIssues().size());
+    assertFalse(containsDiagnostic(modelReport.getExecutionIssues(), "subsea"));
     assertTrue(containsDiagnostic(modelReport.getExecutionIssues(), "topside"));
     assertTrue(modelReport.toJson().contains("executionIssues"));
   }

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientFailureContractTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientFailureContractTest.java
@@ -175,7 +175,6 @@ class ProcessSystemTransientFailureContractTest {
     @Override
     public void runTransient(double initResponse, double dt, UUID id) {
       transientCalls++;
-      setCalculationIdentifier(id);
     }
 
     private int getTransientCalls() {

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientFailureContractTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientFailureContractTest.java
@@ -4,39 +4,112 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemSrkEos;
 
 /** Baseline physical-step failure semantics that parallel execution must preserve. */
 class ProcessSystemTransientFailureContractTest {
   @Test
   void sequentialEquipmentFailureStopsDownstreamExecutionAndStepCommit() {
-    ProcessSystem process = new ProcessSystem("sequential transient failure");
-    FailingTransientEquipment failing = new FailingTransientEquipment("failing unit");
-    RecordingTransientEquipment downstream = new RecordingTransientEquipment("downstream unit");
-    process.add(failing);
-    process.add(downstream);
+    FailureScenario scenario = createFailureScenario("sequential transient failure", false);
+
+    assertFailureBoundary(scenario);
+  }
+
+  @Test
+  void parallelEquipmentFailureMatchesSequentialFailLoudStepBoundary() {
+    FailureScenario scenario = createFailureScenario("parallel transient failure", true);
+
+    assertFailureBoundary(scenario);
+  }
+
+  @Test
+  void processModelStopsLaterAreasAfterParallelAreaFailure() {
+    FailureScenario failingArea = createFailureScenario("failing area", true);
+    ProcessSystem laterArea = new ProcessSystem("later area");
+    RecordingTransientEquipment laterEquipment = new RecordingTransientEquipment("later equipment");
+    laterArea.add(laterEquipment);
+
+    ProcessModel model = new ProcessModel();
+    model.add("failing", failingArea.process);
+    model.add("later", laterArea);
 
     UUID stepId = UUID.randomUUID();
-    IllegalStateException failure = assertThrows(IllegalStateException.class, () -> process.runTransient(1.0, stepId));
+    IllegalStateException failure =
+        assertThrows(IllegalStateException.class, () -> model.runTransient(1.0, stepId));
 
     assertEquals("intentional transient failure", failure.getMessage());
-    assertEquals(1, failing.getTransientCalls());
-    assertEquals(0, downstream.getTransientCalls(), "downstream equipment must not run after a failed unit");
-    assertNotEquals(stepId, process.getCalculationIdentifier(),
+    assertEquals(0, laterEquipment.getTransientCalls(),
+        "a later ProcessModel area must not run after an earlier area fails");
+    assertEquals(0.0, laterArea.getTime(), 0.0,
+        "a later ProcessModel area must not advance its clock after an earlier area fails");
+  }
+
+  private static FailureScenario createFailureScenario(String name, boolean parallel) {
+    Stream dependency = new Stream(name + " dependency", new SystemSrkEos(298.15, 1.0));
+    FailingTransientEquipment failing = new FailingTransientEquipment("failing unit", dependency);
+    RecordingTransientEquipment downstream =
+        new RecordingTransientEquipment("downstream unit", dependency);
+    RecordingController controller = new RecordingController("standalone controller");
+
+    ProcessSystem process = new ProcessSystem(name);
+    process.add(failing);
+    process.add(downstream);
+    process.add(controller);
+    process.setParallelTransientEnabled(parallel);
+    process.setTransientThreadPoolSize(1);
+    return new FailureScenario(process, failing, downstream, controller);
+  }
+
+  private static void assertFailureBoundary(FailureScenario scenario) {
+    UUID stepId = UUID.randomUUID();
+    IllegalStateException failure = assertThrows(IllegalStateException.class,
+        () -> scenario.process.runTransient(1.0, stepId));
+
+    assertEquals("intentional transient failure", failure.getMessage());
+    assertEquals(1, scenario.failing.getTransientCalls());
+    assertEquals(0, scenario.downstream.getTransientCalls(),
+        "downstream equipment must not run after a failed unit");
+    assertEquals(0, scenario.controller.getTransientCalls(),
+        "standalone controllers must not run after equipment failure");
+    assertNotEquals(stepId, scenario.process.getCalculationIdentifier(),
         "a failed physical step must not commit the ProcessSystem calculation identifier");
-    assertEquals(0, process.getHistorySize(), "a failed physical step must not append measurement history");
-    assertEquals(1.0, process.getTime(), 0.0,
-        "the current engine advances time before equipment; whole-step rollback remains a separate Phase-0 dependency");
+    assertEquals(0, scenario.process.getHistorySize(),
+        "a failed physical step must not append measurement history");
+    assertEquals(1.0, scenario.process.getTime(), 0.0,
+        "time advances before equipment; whole-step rollback remains a separate Phase-0 dependency");
+  }
+
+  private static final class FailureScenario {
+    private final ProcessSystem process;
+    private final FailingTransientEquipment failing;
+    private final RecordingTransientEquipment downstream;
+    private final RecordingController controller;
+
+    private FailureScenario(ProcessSystem process, FailingTransientEquipment failing,
+        RecordingTransientEquipment downstream, RecordingController controller) {
+      this.process = process;
+      this.failing = failing;
+      this.downstream = downstream;
+      this.controller = controller;
+    }
   }
 
   private static final class FailingTransientEquipment extends ProcessEquipmentBaseClass {
     private static final long serialVersionUID = 1000L;
+    private final StreamInterface outlet;
     private int transientCalls;
 
-    private FailingTransientEquipment(String name) {
+    private FailingTransientEquipment(String name, StreamInterface outlet) {
       super(name);
+      this.outlet = outlet;
     }
 
     @Override
@@ -50,6 +123,11 @@ class ProcessSystemTransientFailureContractTest {
       throw new IllegalStateException("intentional transient failure");
     }
 
+    @Override
+    public List<StreamInterface> getOutletStreams() {
+      return Collections.singletonList(outlet);
+    }
+
     private int getTransientCalls() {
       return transientCalls;
     }
@@ -57,10 +135,16 @@ class ProcessSystemTransientFailureContractTest {
 
   private static final class RecordingTransientEquipment extends ProcessEquipmentBaseClass {
     private static final long serialVersionUID = 1000L;
+    private final StreamInterface inlet;
     private int transientCalls;
 
     private RecordingTransientEquipment(String name) {
+      this(name, null);
+    }
+
+    private RecordingTransientEquipment(String name, StreamInterface inlet) {
       super(name);
+      this.inlet = inlet;
     }
 
     @Override
@@ -70,6 +154,31 @@ class ProcessSystemTransientFailureContractTest {
 
     @Override
     public void runTransient(double dt, UUID id) {
+      transientCalls++;
+      setCalculationIdentifier(id);
+    }
+
+    @Override
+    public List<StreamInterface> getInletStreams() {
+      return inlet == null ? Collections.<StreamInterface>emptyList()
+          : Collections.singletonList(inlet);
+    }
+
+    private int getTransientCalls() {
+      return transientCalls;
+    }
+  }
+
+  private static final class RecordingController extends ControllerDeviceBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private int transientCalls;
+
+    private RecordingController(String name) {
+      super(name);
+    }
+
+    @Override
+    public void runTransient(double initResponse, double dt, UUID id) {
       transientCalls++;
       setCalculationIdentifier(id);
     }

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTransientFailureContractTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTransientFailureContractTest.java
@@ -42,8 +42,7 @@ class ProcessSystemTransientFailureContractTest {
     model.add("later", laterArea);
 
     UUID stepId = UUID.randomUUID();
-    IllegalStateException failure =
-        assertThrows(IllegalStateException.class, () -> model.runTransient(1.0, stepId));
+    IllegalStateException failure = assertThrows(IllegalStateException.class, () -> model.runTransient(1.0, stepId));
 
     assertEquals("intentional transient failure", failure.getMessage());
     assertEquals(0, laterEquipment.getTransientCalls(),
@@ -55,8 +54,7 @@ class ProcessSystemTransientFailureContractTest {
   private static FailureScenario createFailureScenario(String name, boolean parallel) {
     Stream dependency = new Stream(name + " dependency", new SystemSrkEos(298.15, 1.0));
     FailingTransientEquipment failing = new FailingTransientEquipment("failing unit", dependency);
-    RecordingTransientEquipment downstream =
-        new RecordingTransientEquipment("downstream unit", dependency);
+    RecordingTransientEquipment downstream = new RecordingTransientEquipment("downstream unit", dependency);
     RecordingController controller = new RecordingController("standalone controller");
 
     ProcessSystem process = new ProcessSystem(name);
@@ -75,14 +73,12 @@ class ProcessSystemTransientFailureContractTest {
 
     assertEquals("intentional transient failure", failure.getMessage());
     assertEquals(1, scenario.failing.getTransientCalls());
-    assertEquals(0, scenario.downstream.getTransientCalls(),
-        "downstream equipment must not run after a failed unit");
+    assertEquals(0, scenario.downstream.getTransientCalls(), "downstream equipment must not run after a failed unit");
     assertEquals(0, scenario.controller.getTransientCalls(),
         "standalone controllers must not run after equipment failure");
     assertNotEquals(stepId, scenario.process.getCalculationIdentifier(),
         "a failed physical step must not commit the ProcessSystem calculation identifier");
-    assertEquals(0, scenario.process.getHistorySize(),
-        "a failed physical step must not append measurement history");
+    assertEquals(0, scenario.process.getHistorySize(), "a failed physical step must not append measurement history");
     assertEquals(1.0, scenario.process.getTime(), 0.0,
         "time advances before equipment; whole-step rollback remains a separate Phase-0 dependency");
   }
@@ -160,8 +156,7 @@ class ProcessSystemTransientFailureContractTest {
 
     @Override
     public List<StreamInterface> getInletStreams() {
-      return inlet == null ? Collections.<StreamInterface>emptyList()
-          : Collections.singletonList(inlet);
+      return inlet == null ? Collections.<StreamInterface>emptyList() : Collections.singletonList(inlet);
     }
 
     private int getTransientCalls() {


### PR DESCRIPTION
## Summary

- propagate exceptions from parallel transient equipment workers through their futures, preserving the original runtime exception
- stop later groups and dependency levels after a worker failure and skip controller, measurement/alarm/history, timestep-counter, and calculation-identifier commit phases
- qualify the same fail-loud boundary for sequential and parallel `ProcessSystem`, plus propagation across ordered `ProcessModel` areas
- remove only the repaired parallel strict-preflight blocker; adaptive execution remains blocked
- document the intentionally retained non-transactional boundary: elapsed time, due-event effects, and already-mutated equipment/siblings are not rolled back

## Engineering boundary

This is the #2911 shared transient-engine lane. It does not change one-phase conservative transport (#2935), TwoFluidPipe closures/slugging (#2907/#2909), pressure-flow coupling, adaptive rejection, or whole-model rollback.

Passing strict preflight with parallel mode enabled is not a claim of quantitative dynamics qualification, transient recycle support, safety approval, OTS readiness, or commercial-simulator parity.

## Validation

**VALIDATED AND MERGED** from exact head `bd19cfb512a1701a757fc51c1b0fcee234c8fb78` as merge commit `86ed7be0a1ed9e37eb9af6da9d7d34381ceed77d`.

Exact-head GitHub Actions completed successfully:

- Spotless format patch
- pre-commit/pre-push
- documentation-search coverage
- skills and agents lint
- PaperLab
- CodeQL
- Java 21 Javadoc
- Java 21 fast tests on Ubuntu and Windows
- all four Java 21 slow-test shards
- Java 8 tests on Ubuntu and Windows

Regression coverage:

- `ProcessSystemTransientFailureContractTest`: sequential/parallel exception type and message, downstream suppression, controller suppression, history/calculation-ID non-commit, explicit elapsed-time limitation, and later-area suppression in `ProcessModel`
- `DynamicCapabilityReportTest`: parallel mode no longer creates the repaired execution issue; adaptive mode remains a ProcessSystem/ProcessModel blocker

No local commands were run in the connector-only environment and none are claimed. Initial CI supplied an exact Spotless patch, applied unchanged. A later hosted compile exposed an invalid test-only controller setter call, which was removed before the all-green exact head. Final audit found the six intended files only, no submitted reviews, and no unresolved review threads.

## Documentation impact

Updated the public dynamic capability contract and repository dynamic-simulation skill with the repaired failure semantics and remaining rollback/recycle limitations.

Advances #2911.