### PR TITLE
[AI-Assisted] Improve retained-state K-value refinement

### DIFF
--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -262,8 +262,11 @@ targets manipulated through condenser or reboiler temperature.
 - Work diagnostics classify every currently assembled derivative column as finite-difference;
   `getLastNaphtaliAnalyticJacobianColumns()` remains available for compatibility and reports zero
   until a mixed analytic/numerical assembly is implemented.
-- Tray thermodynamics perform up to two forced-root fugacity sweeps and stop after the first when
-  its `max(abs(log(Knew/Kold)))` is already at or below `1e-8`. Diagnostics report the actual sweep
+- Tray thermodynamics perform up to two forced-root fugacity sweeps for a cold solve and up to three
+  when refining a retained column state. Both paths stop early when
+  `max(abs(log(Knew/Kold)))` is already at or below `1e-8`. The extra warm-start sweep keeps the
+  finite-difference residual locally consistent after a nearby operating-point change without
+  adding EOS work to cold solves. Diagnostics report the actual sweep
   count, the number of tray evaluations whose final
   `max(abs(log(Knew/Kold)))` exceeds `1e-8`, and the largest such final update through
   `getLastNaphtaliThermoKValueIterationCount()`,

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -64,6 +64,9 @@ public class NaphtaliSandholmSolver {
   /** Maximum forced-root fugacity fixed-point sweeps for one tray evaluation. */
   private static final int THERMO_K_VALUE_ITERATIONS = 2;
 
+  /** Maximum forced-root fugacity sweeps when refining a retained column state. */
+  private static final int THERMO_WARM_START_K_VALUE_ITERATIONS = 3;
+
   /** Convergence tolerance for the largest absolute logarithmic K-value update. */
   private static final double THERMO_K_VALUE_TOLERANCE = 1.0e-8;
 
@@ -3353,13 +3356,16 @@ public class NaphtaliSandholmSolver {
     }
 
     // Self-consistency loop: K = phi_L(x) / phi_V(y), then y = K x / sum(K x).
-    // Perform at most two sweeps and stop once the existing convergence criterion
-    // is met so already-converged compositions do not pay for a redundant EOS call.
+    // Perform at most two sweeps for a cold state and one additional sweep when
+    // refining a retained state. Stop once the existing convergence criterion is
+    // met so already-converged compositions do not pay for a redundant EOS call.
     boolean kOk = phiOk;
     boolean kConverged = false;
     double finalMaxLogKUpdate = Double.POSITIVE_INFINITY;
     if (kOk) {
-      for (int sweep = 0; sweep < THERMO_K_VALUE_ITERATIONS; sweep++) {
+      int maximumKValueIterations = warmStartFromColumn ? THERMO_WARM_START_K_VALUE_ITERATIONS
+          : THERMO_K_VALUE_ITERATIONS;
+      for (int sweep = 0; sweep < maximumKValueIterations; sweep++) {
         if (!computeSinglePhaseFugacityCoefficients(y, T[j], Pbar, true, phiV)) {
           kOk = false;
           break;

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -131,18 +131,17 @@ public class ColumnStudyRegressionTest {
   }
 
   /**
-   * Reject a severely perturbed warm start without spending the entire Newton iteration budget on repeated non-descent
-   * line-search steps.
+   * Converge a severely perturbed warm start without exhausting the Newton iteration budget.
    *
    * <p>
    * The initialized column-study state is deliberately perturbed by up to 90 K before a direct simultaneous-correction
-   * warm start. The case is outside the local Newton basin, but it remains a finite, realistic multicomponent
-   * hydrocarbon column state. The solver should preserve its best physical state and return control to the coordinated
-   * fallback path once three line-search steps have failed to reduce the MESH residual.
+   * warm start. The case is outside the two-sweep Newton basin, but it remains a finite, realistic multicomponent
+   * hydrocarbon column state. A retained state needs one additional fugacity fixed-point sweep to keep the Newton
+   * residual locally consistent enough for the guarded line search to recover the rigorous solution.
    * </p>
    */
   @Test
-  public void severeWarmStartPerturbationStopsNonDescentNewtonStall() {
+  public void severeWarmStartPerturbationConvergesWithRefinedKValues() {
     SystemInterface baseFluid = createBaseFluid();
     StreamInterface feedStream = createStream("stall_guard_main_feed", baseFluid, MAIN_FEED_COMPOSITION,
         MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
@@ -163,13 +162,19 @@ public class ColumnStudyRegressionTest {
     solver.setMaxIterations(80);
     boolean accepted = solver.solve(new UUID(0L, 1L));
 
-    assertFalse(accepted, "the severely perturbed state must be rejected for coordinated fallback");
-    assertTrue(solver.getLastIterations() <= 30,
-        "the non-descent guard should stop the stalled Newton solve before the 80-iteration cap");
-    assertTrue(solver.getLastMassBalanceError() < 1.0e-3,
-        "the restored best state should preserve total molar closure before fallback");
-    assertPhysicalProduct(column.getGasOutStream(), "stalled warm-start gas product");
-    assertPhysicalProduct(column.getLiquidOutStream(), "stalled warm-start liquid product");
+    assertTrue(accepted, "the severely perturbed retained state should recover without coordinated fallback");
+    assertTrue(solver.getLastIterations() <= 45,
+        "the recovered warm solve should remain well below the 80-iteration cap");
+    assertTrue(solver.getLastMassBalanceError() < 1.0e-8, "the recovered state should close total molar balance");
+    assertTrue(solver.getLastResidualNorm() < 1.0e-8, "the recovered state should satisfy the scaled MESH residual");
+    assertTrue(solver.getLastThermoEvaluationCount() < 24000,
+        "the recovered warm solve should keep thermodynamic evaluations bounded");
+    assertTrue(solver.getLastThermoKValueIterationCount() < 70000,
+        "the recovered warm solve should keep forced-root fugacity sweeps bounded");
+    assertPhysicalProduct(column.getGasOutStream(), "recovered warm-start gas product");
+    assertPhysicalProduct(column.getLiquidOutStream(), "recovered warm-start liquid product");
+    assertOverallMassBalance(feedStream, topFeedStream, column);
+    assertComponentMassBalances(feedStream, topFeedStream, column);
   }
 
   /**
@@ -511,6 +516,8 @@ public class ColumnStudyRegressionTest {
     long changedInletSolveNanos = System.nanoTime() - changedInletStartNanos;
     assertColumnSolveIsValid(column, feedStream, topFeedStream, "10 percent increased-inlet solve");
     int changedInletIterations = column.getLastIterationCount();
+    int changedInletThermo = column.getLastNaphtaliThermoEvaluationCount();
+    int changedInletKSweeps = column.getLastNaphtaliThermoKValueIterationCount();
     ColumnProductSummary changedInletProducts = getProductSummary(column);
 
     logger.info(
@@ -523,8 +530,17 @@ public class ColumnStudyRegressionTest {
     testReporter.publishEntry("cold_solve_ms", Double.toString(nanosToMillis(coldSolveNanos)));
     testReporter.publishEntry("unchanged_warm_solve_ms", Double.toString(nanosToMillis(warmSolveNanos)));
     testReporter.publishEntry("increased_inlet_solve_ms", Double.toString(nanosToMillis(changedInletSolveNanos)));
+    testReporter.publishEntry("increased_inlet_iterations", Integer.toString(changedInletIterations));
+    testReporter.publishEntry("increased_inlet_thermo_evaluations", Integer.toString(changedInletThermo));
+    testReporter.publishEntry("increased_inlet_k_sweeps", Integer.toString(changedInletKSweeps));
     assertTrue(warmStateReused, "unchanged warm solve should reuse the accepted Naphtali-Sandholm state");
     assertEquals(0, warmIterations, "unchanged warm solve should not require initializer or Newton iterations");
+    assertTrue(changedInletIterations <= 4,
+        "the changed-inlet warm solve should converge in at most four Newton iterations");
+    assertTrue(changedInletThermo < 2500,
+        "the changed-inlet warm solve should need fewer than 2500 thermodynamic evaluations");
+    assertTrue(changedInletKSweeps < 7000,
+        "the changed-inlet warm solve should need fewer than 7000 forced-root fugacity sweeps");
   }
 
   /**


### PR DESCRIPTION
## Engineering problem

Naphtali–Sandholm tray thermodynamics currently performs at most two forced-root fugacity fixed-point sweeps for every tray evaluation. That is sufficient for cold initialization and avoids unnecessary EOS work, but a retained column state after an operating-point change can remain materially K-inconsistent after the second sweep.

Because the finite-difference Newton residual and Jacobian then consume that derived state, a difficult but finite warm start can appear non-descent and be rejected to coordinated fallback even though one more bounded thermodynamic refinement recovers a rigorous solution.

Affected scope: retained-state Naphtali–Sandholm solves and their guarded line search. Sequential, inside-out, TP/PH-flash algorithms, cold initialization, exact-result reuse, fallback acceptance criteria and public specifications remain unchanged.

## Change

- retain the existing maximum of two K sweeps for cold tray states;
- allow at most one additional sweep only when `warmStartFromColumn` is active;
- retain the existing `max(abs(log(Knew/Kold))) <= 1e-8` early exit on both paths;
- keep the same K bounds, Wilson fallback, EOS call ordering, MESH tolerance and Newton/globalization logic;
- document the cold/warm distinction and diagnostics.

This is a bounded retained-state conditioning change, not a general TPflash optimization and not mixture-specific damping.

## Regression and engineering evidence

The deterministic case is the existing industrial column-study fixture:

- SRK with classic mixing rule;
- 24 named/pseudo-components;
- two external feeds;
- nine stages with reboiler and no condenser;
- pressure profile, Murphree efficiencies and fixed reboiler temperature;
- total and per-component mass-balance checks;
- physical product flow, temperature and normalized-composition bounds.

### Previously reproduced baseline and candidate evidence

On the previous exact solver/test blobs, which remain unchanged on this PR's current-master base:

| Case | Current two-sweep path | Warm-only third-sweep path |
|---|---:|---:|
| +10% main-feed warm solve, Newton iterations | 7 | 4 |
| +10% main-feed tray thermo evaluations | 4,103 | 2,354 |
| +10% main-feed K sweeps | 8,117 | 6,908 |
| 90 K retained temperature perturbation | rejected to fallback | rigorous convergence |
| 90 K iterations / thermo / K sweeps | rejection path | 40 / 23,496 / 69,398 |
| 90 K total molar error | fallback-bound | 7.08e-14 |
| 90 K scaled MESH residual | not accepted | 2.91e-10 |

The nominal cold path and exact zero-iteration reuse were unchanged. The 10–75 K perturbation basin also converged. At 75 K, the candidate used fewer Newton iterations and tray evaluations but 24% more K sweeps; that tradeoff is retained as an explicit limitation rather than presented as universal work reduction.

A vector-Aitken K accelerator was separately rejected because it destabilized all mapped perturbations and violated closure. An oscillation-only midpoint damper never activated. Neither is included here.

## Tests added/strengthened

- the severe 90 K regression now requires direct rigorous acceptance, total molar error below `1e-8`, scaled MESH residual below `1e-8`, bounded work, total and per-component mass balance, and physical products;
- the nearby +10% feed regression requires at most four Newton iterations, fewer than 2,500 tray thermodynamic evaluations and fewer than 7,000 K sweeps;
- stable work metrics are published through the JUnit reporter; no wall-clock assertion is added.

## Validation status

**Exact-head validation passed on `2659a23733a51372fe19823b46662a41a4b6a513`.**

GitHub CI completed successfully:

- full fast tests on Java 21 and Java 8, on both Ubuntu and Windows;
- all four Java 21 slow-test shards;
- Java 21 Javadocs;
- Spotless format verification and pre-commit checks;
- documentation search coverage;
- CodeQL Security Analysis and PaperLab Replication Gate.

Current branch base is master `1dee5b51f6689d0b383e8d90fece9729132dd6e3`, which includes shared TP-multiflash optimization #2930. The final connector comparison is three commits ahead, zero behind, with exactly three intended files.

The prior candidate validation also completed:

- focused severe and nearby-point regressions: passed;
- full `ColumnStudyRegressionTest`: 9/9 passed;
- complete distillation package: 218 tests, 0 failures/errors, 2 skipped;
- Spotless apply/check and documentation search: passed.

The prior candidate work metrics and balance/residual values above remain the quantitative algorithm comparison; exact-head GitHub CI independently verifies compilation, Java compatibility, formatting, documentation, security, and the full repository test matrix.

## Compatibility and risk

- no public API, serialized field, calculation identity or tolerance change;
- no new mutable state or allocation in the tray hot path;
- cold and exact-reuse paths preserve their existing maximum work;
- retained evaluations may spend one additional EOS call when the second sweep is not converged;
- accepted-state and coordinated fallback gates remain authoritative.

## Documentation impact

Updated `docs/wiki/distillation_column.md` to state the two-sweep cold and three-sweep retained-state bounds, unchanged early-exit tolerance, diagnostic semantics and the reason cold solves incur no added EOS work.

## Remaining limitations

This does not make every K evaluation converge to `1e-8`; three is a bounded warm-state cap. It does not revisit Jacobian restore coalescing, direct pumparound MESH coupling, TPflash algorithms, or generic process-execution performance.

Relates #2936.
Builds on the investigation evidence in #2887.