### PR TITLE
fix(flash): reject invalid aqueous multiphase endpoints

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -284,6 +284,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
 | Supplementary stability TPD limit | -1e-6 | Accept a converged amplified-K or composition-perturbation trial only when its reduced TPD exceeds that SSI solve's residual/step resolution and the trial composition is non-trivial |
 | Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for valid trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i)` is non-finite or above `1e-8`, allowing the bounded beta correction below without another stability calculation. An incipient trace-water GAS+OIL endpoint with `min(beta) <= 1e-4` also bypasses the threshold when its confirmed log-fugacity residual is non-finite or at least `1e-8`; the guarded candidate must then pass the strict feasibility and lower-Gibbs gates. |
+| Water-rich cross-algorithm fallback | water feed `>= 0.01` and current `max abs(Delta ln(f_i)) >= 1e-8` or material-balance failure | Evaluate exactly one cold candidate through the alternate ordinary or multiphase path. Prevent reciprocal recursion and replace the endpoint only when the candidate has two distinct bounded phases, normalized beta and compositions, material balance and fugacity residuals below `1e-8`, and a Gibbs reduction larger than `max(1e-6 J, 1e-8 abs(G))`. Valid endpoints incur only the residual acceptance scan. |
 | Trace-water aqueous-stability screen | water feed `< 0.01`, GAS+OIL, `min(beta) <= 0.01`, and `x_water,oil >= 10 z_water` | Use the structural conditions only as a performance gate for an aqueous TPD trial. The TPD result, reduced-active-set convergence below `1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and lower Gibbs energy determine acceptance. Full recursive TPmultiflash is not run. |
 | CPA one-phase aqueous-stability screen | water feed `< 0.01`, one ordinary phase, CPA model, and `f_water / p_water_sat >= 0.8` | Use the fugacity ratio only as a conservative performance gate for the existing aqueous TPD trial. When the trial adds one phase, rebuild the two-phase active set and require beta-solver residual `< 1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and a Gibbs reduction larger than `max(1e-8 J, 1e-12 abs(G))`. The tighter Gibbs tolerance retains independently converged incipient aqueous fractions without treating the saturation screen itself as a stability criterion. |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
@@ -1765,6 +1766,12 @@ Commercial process simulators do not publish all implementation details, but pub
   feasible lower-Gibbs result. That invalid-endpoint retry is restricted to an incipient secondary phase with
   `min(beta) <= 1e-4`, so established valid gas/oil splits avoid even the component residual scan unless they satisfy
   the separate aqueous-stability screen.
+- The same strict gate is reciprocal for a water-rich multiphase endpoint. If phase-appearance cleanup returns an
+  aqueous split with a non-finite or at-least `1e-8` log-fugacity residual, one cold ordinary candidate is evaluated
+  from the unchanged feed. It replaces the multiphase endpoint only when it is independently feasible and lowers
+  extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))`. The accepted ordinary calculation is repeated on the live
+  system to rebuild the cubic/aqueous storage mapping; a recursion guard prevents fallback ping-pong. Already-feasible
+  multiphase states and dry systems do not run the additional flash.
 - A one-phase ordinary CPA endpoint containing trace water uses a cheap water-fugacity screen before the same aqueous
   TPD trial. The screen compares water fugacity in the current phase with pure-water vapor pressure and triggers at a
   ratio of `0.8`, conservatively below nominal saturation. This avoids a TPD calculation for clearly undersaturated

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -284,7 +284,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
 | Supplementary stability TPD limit | -1e-6 | Accept a converged amplified-K or composition-perturbation trial only when its reduced TPD exceeds that SSI solve's residual/step resolution and the trial composition is non-trivial |
 | Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for valid trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i)` is non-finite or above `1e-8`, allowing the bounded beta correction below without another stability calculation. An incipient trace-water GAS+OIL endpoint with `min(beta) <= 1e-4` also bypasses the threshold when its confirmed log-fugacity residual is non-finite or at least `1e-8`; the guarded candidate must then pass the strict feasibility and lower-Gibbs gates. |
-| Water-rich cross-algorithm fallback | water feed `>= 0.01` and current `max abs(Delta ln(f_i)) >= 1e-8` or material-balance failure | Evaluate exactly one cold candidate through the alternate ordinary or multiphase path. Prevent reciprocal recursion and replace the endpoint only when the candidate has two distinct bounded phases, normalized beta and compositions, material balance and fugacity residuals below `1e-8`, and a Gibbs reduction larger than `max(1e-6 J, 1e-8 abs(G))`. Valid endpoints incur only the residual acceptance scan. |
+| Water-rich cross-algorithm fallback | water feed `>= 0.01` and current `max abs(Delta ln(f_i)) >= 1e-8` or material-balance failure | Evaluate exactly one cold candidate through the alternate path: a multiphase GAS+AQUEOUS endpoint may try the ordinary path, while an ordinary endpoint may try the multiphase path. Genuine OIL+AQUEOUS liquid-liquid endpoints remain on the multiphase path. Prevent reciprocal recursion and replace the endpoint only when the candidate has two distinct bounded phases, normalized beta and compositions, material balance and fugacity residuals below `1e-8`, and a Gibbs reduction larger than `max(1e-6 J, 1e-8 abs(G))`. Valid endpoints incur only the residual acceptance scan. |
 | Trace-water aqueous-stability screen | water feed `< 0.01`, GAS+OIL, `min(beta) <= 0.01`, and `x_water,oil >= 10 z_water` | Use the structural conditions only as a performance gate for an aqueous TPD trial. The TPD result, reduced-active-set convergence below `1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and lower Gibbs energy determine acceptance. Full recursive TPmultiflash is not run. |
 | CPA one-phase aqueous-stability screen | water feed `< 0.01`, one ordinary phase, CPA model, and `f_water / p_water_sat >= 0.8` | Use the fugacity ratio only as a conservative performance gate for the existing aqueous TPD trial. When the trial adds one phase, rebuild the two-phase active set and require beta-solver residual `< 1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and a Gibbs reduction larger than `max(1e-8 J, 1e-12 abs(G))`. The tighter Gibbs tolerance retains independently converged incipient aqueous fractions without treating the saturation screen itself as a stability criterion. |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
@@ -1766,12 +1766,13 @@ Commercial process simulators do not publish all implementation details, but pub
   feasible lower-Gibbs result. That invalid-endpoint retry is restricted to an incipient secondary phase with
   `min(beta) <= 1e-4`, so established valid gas/oil splits avoid even the component residual scan unless they satisfy
   the separate aqueous-stability screen.
-- The same strict gate is reciprocal for a water-rich multiphase endpoint. If phase-appearance cleanup returns an
-  aqueous split with a non-finite or at-least `1e-8` log-fugacity residual, one cold ordinary candidate is evaluated
-  from the unchanged feed. It replaces the multiphase endpoint only when it is independently feasible and lowers
-  extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))`. The accepted ordinary calculation is repeated on the live
-  system to rebuild the cubic/aqueous storage mapping; a recursion guard prevents fallback ping-pong. Already-feasible
-  multiphase states and dry systems do not run the additional flash.
+- The same strict gate is reciprocal for a water-rich multiphase GAS+AQUEOUS endpoint. If phase-appearance cleanup
+  returns that phase set with a non-finite or at-least `1e-8` log-fugacity residual, one cold ordinary candidate is
+  evaluated from the unchanged feed. It replaces the multiphase endpoint only when it is independently feasible and
+  lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))`. The accepted ordinary calculation is repeated on the
+  live system to rebuild the cubic/aqueous storage mapping; a recursion guard prevents fallback ping-pong. Genuine
+  OIL+AQUEOUS liquid-liquid endpoints, already-feasible multiphase states, and dry systems do not run the additional
+  flash.
 - A one-phase ordinary CPA endpoint containing trace water uses a cheap water-fugacity screen before the same aqueous
   TPD trial. The screen compares water fugacity in the current phase with pure-water vapor pressure and triggers at a
   ratio of `0.8`, conservatively below nominal saturation. This avoids a TPD calculation for clearly undersaturated

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1199,23 +1199,21 @@ public class TPflash extends Flash {
    * dissolved in a hydrocarbon-labelled phase even when a lower-Gibbs aqueous split exists. Conversely, a multiphase
    * phase-appearance trial can retain an invalid higher-Gibbs aqueous endpoint after its active phase storage changes.
    * An existing aqueous phase label is not by itself proof of equilibrium. Such an endpoint is refined when its
-   * component fugacity residual exceeds
-   * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE} or its component material balance exceeds
-   * {@link #WATER_RICH_MATERIAL_BALANCE_TOLERANCE}. The one-mol-percent feed guard keeps valid trace-water process
-   * flashes outside the minor-phase trace-water screen on the existing fast path. A trace-water gas/oil endpoint whose
-   * fugacity residual is already outside the equilibrium tolerance may still use the cloned stability calculation
-   * because it is not an acceptable result. A cheap aqueous tangent-plane trial and safeguarded multiphase beta solve
-   * are used for trace-water gas/oil endpoints whose small hydrocarbon liquid disproportionately concentrates water.
-   * Full recursive flashing is avoided. A multiphase-enabled water-rich endpoint uses one cold ordinary candidate; an
-   * ordinary endpoint uses the multiphase candidate. The nested candidate cannot start another cross-algorithm
-   * fallback. A candidate replaces the original state only after strict phase-fraction, composition-normalization,
-   * material-balance, fugacity, distinct-composition, and lower-Gibbs checks pass.
+   * component fugacity residual exceeds {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE} or its component material balance
+   * exceeds {@link #WATER_RICH_MATERIAL_BALANCE_TOLERANCE}. The one-mol-percent feed guard keeps valid trace-water
+   * process flashes outside the minor-phase trace-water screen on the existing fast path. A trace-water gas/oil
+   * endpoint whose fugacity residual is already outside the equilibrium tolerance may still use the cloned stability
+   * calculation because it is not an acceptable result. A cheap aqueous tangent-plane trial and safeguarded multiphase
+   * beta solve are used for trace-water gas/oil endpoints whose small hydrocarbon liquid disproportionately
+   * concentrates water. Full recursive flashing is avoided. A multiphase-enabled water-rich endpoint uses one cold
+   * ordinary candidate; an ordinary endpoint uses the multiphase candidate. The nested candidate cannot start another
+   * cross-algorithm fallback. A candidate replaces the original state only after strict phase-fraction,
+   * composition-normalization, material-balance, fugacity, distinct-composition, and lower-Gibbs checks pass.
    * </p>
    */
   private void rescueWaterRichEndpoint() {
     if (!waterRichCrossAlgorithmFallbackAllowed || system.isChemicalSystem() || system.hasIons() || solidCheck
-        || system.isMultiphaseWaxCheck()
-        || system.getNumberOfPhases() > 2) {
+        || system.isMultiphaseWaxCheck() || system.getNumberOfPhases() > 2) {
       return;
     }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1208,8 +1208,8 @@ public class TPflash extends Flash {
    * concentrates water. Full recursive flashing is avoided. A multiphase-enabled water-rich gas/aqueous endpoint uses
    * one cold ordinary candidate; a genuine oil/aqueous liquid-liquid endpoint remains on the multiphase path. An
    * ordinary endpoint uses the multiphase candidate. The nested candidate cannot start another cross-algorithm
-   * fallback. A candidate replaces the original state only after strict phase-fraction,
-   * composition-normalization, material-balance, fugacity, distinct-composition, and lower-Gibbs checks pass.
+   * fallback. A candidate replaces the original state only after strict phase-fraction, composition-normalization,
+   * material-balance, fugacity, distinct-composition, and lower-Gibbs checks pass.
    * </p>
    */
   private void rescueWaterRichEndpoint() {

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1205,9 +1205,10 @@ public class TPflash extends Flash {
    * endpoint whose fugacity residual is already outside the equilibrium tolerance may still use the cloned stability
    * calculation because it is not an acceptable result. A cheap aqueous tangent-plane trial and safeguarded multiphase
    * beta solve are used for trace-water gas/oil endpoints whose small hydrocarbon liquid disproportionately
-   * concentrates water. Full recursive flashing is avoided. A multiphase-enabled water-rich endpoint uses one cold
-   * ordinary candidate; an ordinary endpoint uses the multiphase candidate. The nested candidate cannot start another
-   * cross-algorithm fallback. A candidate replaces the original state only after strict phase-fraction,
+   * concentrates water. Full recursive flashing is avoided. A multiphase-enabled water-rich gas/aqueous endpoint uses
+   * one cold ordinary candidate; a genuine oil/aqueous liquid-liquid endpoint remains on the multiphase path. An
+   * ordinary endpoint uses the multiphase candidate. The nested candidate cannot start another cross-algorithm
+   * fallback. A candidate replaces the original state only after strict phase-fraction,
    * composition-normalization, material-balance, fugacity, distinct-composition, and lower-Gibbs checks pass.
    * </p>
    */
@@ -1233,6 +1234,12 @@ public class TPflash extends Flash {
         && (waterFeedFraction <= 0.0 || !shouldRefineTraceWaterAqueousEndpoint(waterFeedFraction))) {
       return;
     }
+    boolean gasAqueousMultiphaseEndpoint = system.doMultiPhaseCheck() && hasAqueousPhase
+        && system.hasPhaseType(PhaseType.GAS);
+    if (system.doMultiPhaseCheck() && waterFeedFraction >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
+        && !gasAqueousMultiphaseEndpoint) {
+      return;
+    }
     double materialBalanceResidual = maximumComponentMaterialBalanceResidual(system);
     boolean materialBalanceInvalid = !Double.isFinite(materialBalanceResidual)
         || materialBalanceResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE;
@@ -1242,7 +1249,7 @@ public class TPflash extends Flash {
     }
 
     double referenceGibbsEnergy = system.getGibbsEnergy();
-    boolean ordinaryFallback = system.doMultiPhaseCheck()
+    boolean ordinaryFallback = gasAqueousMultiphaseEndpoint
         && waterFeedFraction >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT;
     SystemInterface candidate;
     if (ordinaryFallback) {

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -134,6 +134,8 @@ public class TPflash extends Flash {
   private PhaseType referenceSinglePhaseType = null;
   /** True after the bounded water-bearing ordinary-flash retry has been attempted in this run. */
   private boolean waterBearingRescueAttempted = false;
+  /** Prevents a bounded water-rich cross-algorithm fallback from recursively starting another fallback. */
+  private boolean waterRichCrossAlgorithmFallbackAllowed = true;
   /** Reusable rollback state for GDEM acceleration; transient because it contains no thermodynamic state. */
   private transient double[] accelerationSavedLnK;
   /** Reusable accelerated log K-values; transient because it contains no thermodynamic state. */
@@ -1190,26 +1192,29 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Refines an ordinary water-rich endpoint with the multiphase stability solver.
+   * Refines an invalid water-rich endpoint with the alternate flash path.
    *
    * <p>
    * The ordinary flash searches only the cubic gas/oil roots and can therefore leave a substantial water fraction
-   * dissolved in a hydrocarbon-labelled phase even when a lower-Gibbs aqueous split exists. An existing aqueous phase
-   * label is not by itself proof of equilibrium: phase typing can identify a water-rich phase after the ordinary
-   * gas/oil iteration has stopped. Such an endpoint is refined when its component fugacity residual exceeds
+   * dissolved in a hydrocarbon-labelled phase even when a lower-Gibbs aqueous split exists. Conversely, a multiphase
+   * phase-appearance trial can retain an invalid higher-Gibbs aqueous endpoint after its active phase storage changes.
+   * An existing aqueous phase label is not by itself proof of equilibrium. Such an endpoint is refined when its
+   * component fugacity residual exceeds
    * {@link #PHASE_ROOT_EQUILIBRIUM_TOLERANCE} or its component material balance exceeds
    * {@link #WATER_RICH_MATERIAL_BALANCE_TOLERANCE}. The one-mol-percent feed guard keeps valid trace-water process
    * flashes outside the minor-phase trace-water screen on the existing fast path. A trace-water gas/oil endpoint whose
    * fugacity residual is already outside the equilibrium tolerance may still use the cloned stability calculation
    * because it is not an acceptable result. A cheap aqueous tangent-plane trial and safeguarded multiphase beta solve
    * are used for trace-water gas/oil endpoints whose small hydrocarbon liquid disproportionately concentrates water.
-   * Full recursive multiphase flashing is avoided. A candidate replaces the original state only after a disappearing
-   * phase is removed, the remaining active set is reconverged, and strict phase-fraction, composition-normalization,
+   * Full recursive flashing is avoided. A multiphase-enabled water-rich endpoint uses one cold ordinary candidate; an
+   * ordinary endpoint uses the multiphase candidate. The nested candidate cannot start another cross-algorithm
+   * fallback. A candidate replaces the original state only after strict phase-fraction, composition-normalization,
    * material-balance, fugacity, distinct-composition, and lower-Gibbs checks pass.
    * </p>
    */
   private void rescueWaterRichEndpoint() {
-    if (system.isChemicalSystem() || system.hasIons() || solidCheck || system.isMultiphaseWaxCheck()
+    if (!waterRichCrossAlgorithmFallbackAllowed || system.isChemicalSystem() || system.hasIons() || solidCheck
+        || system.isMultiphaseWaxCheck()
         || system.getNumberOfPhases() > 2) {
       return;
     }
@@ -1226,9 +1231,6 @@ public class TPflash extends Flash {
         break;
       }
     }
-    if (system.doMultiPhaseCheck() && waterFeedFraction >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
-      return;
-    }
     if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
         && (waterFeedFraction <= 0.0 || !shouldRefineTraceWaterAqueousEndpoint(waterFeedFraction))) {
       return;
@@ -1242,14 +1244,32 @@ public class TPflash extends Flash {
     }
 
     double referenceGibbsEnergy = system.getGibbsEnergy();
-    SystemInterface candidate = system.clone();
+    boolean ordinaryFallback = system.doMultiPhaseCheck()
+        && waterFeedFraction >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT;
+    SystemInterface candidate;
+    if (ordinaryFallback) {
+      double totalMoles = system.getTotalNumberOfMoles();
+      double[] feedComposition = system.getzvector();
+      candidate = system.phaseToSystem(0);
+      candidate.setTotalNumberOfMoles(totalMoles);
+      candidate.setMolarComposition(feedComposition);
+      candidate.setNumberOfPhases(2);
+      candidate.setPhaseIndex(0, 0);
+      candidate.setPhaseIndex(1, 1);
+      candidate.setPhaseType(0, PhaseType.GAS);
+      candidate.setPhaseType(1, PhaseType.OIL);
+    } else {
+      candidate = system.clone();
+    }
     try {
-      candidate.setMultiPhaseCheck(true);
+      candidate.setMultiPhaseCheck(!system.doMultiPhaseCheck());
       boolean candidateConverged;
       if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT) {
         candidateConverged = refineTraceWaterAqueousCandidateActiveSet(candidate);
       } else {
-        new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+        TPflash candidateFlash = new TPflash(candidate, candidate.doSolidPhaseCheck());
+        candidateFlash.waterRichCrossAlgorithmFallbackAllowed = false;
+        candidateFlash.run();
         candidateConverged = true;
       }
       boolean incipientCpaAqueousTrial = system.getNumberOfPhases() == 1 && !system.doMultiPhaseCheck()
@@ -1257,7 +1277,11 @@ public class TPflash extends Flash {
       if (candidateConverged && candidate.getNumberOfPhases() == 2 && isBalancedEquilibriumCandidate(candidate)
           && shouldAcceptWaterRichCandidate(candidate, referenceGibbsEnergy, materialBalanceInvalid,
               incipientCpaAqueousTrial)) {
-        copyFlashStateFrom(candidate);
+        if (ordinaryFallback) {
+          runAcceptedOrdinaryWaterRichFallback(candidate);
+        } else {
+          copyFlashStateFrom(candidate);
+        }
       }
     } catch (Exception ex) {
       logger.debug("Water-rich endpoint refinement failed: {}", ex.getMessage());
@@ -2123,6 +2147,38 @@ public class TPflash extends Flash {
     }
     system.normalizeBeta();
     system.init(1);
+  }
+
+  /**
+   * Repeats an accepted cold ordinary fallback directly on the live system.
+   *
+   * <p>
+   * A multiphase trial can move the active aqueous phase to a different internal storage slot. Copying only the
+   * candidate phases back into those mutated slots does not reliably reproduce the candidate cubic-root state. Once an
+   * independent cold ordinary candidate has passed the strict acceptance gate, reset the live system to its feed and
+   * repeat the same bounded ordinary flash. The recursion guard prevents this nested flash from starting another
+   * cross-algorithm fallback.
+   * </p>
+   *
+   * @param acceptedCandidate accepted ordinary candidate providing the feed state
+   */
+  private void runAcceptedOrdinaryWaterRichFallback(SystemInterface acceptedCandidate) {
+    system.setTotalNumberOfMoles(acceptedCandidate.getTotalNumberOfMoles());
+    system.setMolarComposition(acceptedCandidate.getzvector());
+    system.setNumberOfPhases(2);
+    system.setPhaseIndex(0, 0);
+    system.setPhaseIndex(1, 1);
+    system.setPhaseType(0, PhaseType.GAS);
+    system.setPhaseType(1, PhaseType.OIL);
+    boolean multiphaseCheck = system.doMultiPhaseCheck();
+    try {
+      system.setMultiPhaseCheck(false);
+      TPflash fallback = new TPflash(system, system.doSolidPhaseCheck());
+      fallback.waterRichCrossAlgorithmFallbackAllowed = false;
+      fallback.run();
+    } finally {
+      system.setMultiPhaseCheck(multiphaseCheck);
+    }
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousCrossAlgorithmFallbackTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousCrossAlgorithmFallbackTest.java
@@ -1,0 +1,123 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashAqueousCrossAlgorithmFallbackTest {
+  private static final String[] COMPONENTS = { "CO2", "methane", "ethane", "water" };
+  private static final double[] FEED = { 0.543865141103918, 0.2937712952303271, 0.07010605470616459,
+      0.09225750895959021 };
+
+  @Test
+  void multiphaseFlashRejectsInvalidHigherGibbsAqueousEndpoint() {
+    SystemInterface ordinary = createAndFlash(260.0, 100.0, false, false);
+    SystemInterface multiphase = createAndFlash(260.0, 100.0, true, true);
+
+    assertEquivalentEquilibrium(ordinary, multiphase);
+    double firstGibbsEnergy = multiphase.getGibbsEnergy();
+
+    new ThermodynamicOperations(multiphase).TPflash();
+    multiphase.init(3);
+
+    assertEquals(firstGibbsEnergy, multiphase.getGibbsEnergy(), 1.0e-8);
+    assertEquivalentEquilibrium(ordinary, multiphase);
+  }
+
+  @Test
+  void multiphaseFallbackRemainsContinuousAcrossNearbyStates() {
+    double[][] states = { { 260.0, 100.0 }, { 255.0, 100.0 }, { 260.0, 90.0 }, { 260.0, 110.0 },
+        { 265.0, 100.0 }, { 260.0, 100.0 } };
+    SystemInterface multiphase = createSystem(states[0][0], states[0][1], true, true);
+
+    for (double[] state : states) {
+      multiphase.setTemperature(state[0]);
+      multiphase.setPressure(state[1]);
+      new ThermodynamicOperations(multiphase).TPflash();
+      multiphase.init(3);
+
+      SystemInterface ordinary = createAndFlash(state[0], state[1], false, false);
+      assertEquivalentEquilibrium(ordinary, multiphase);
+    }
+  }
+
+  private SystemInterface createAndFlash(double temperature, double pressure, boolean multiphaseCheck,
+      boolean poorBetaGuess) {
+    SystemInterface system = createSystem(temperature, pressure, multiphaseCheck, poorBetaGuess);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private SystemInterface createSystem(double temperature, double pressure, boolean multiphaseCheck,
+      boolean poorBetaGuess) {
+    SystemInterface system = new SystemPrEos(temperature, pressure);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], FEED[componentIndex]);
+    }
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(multiphaseCheck);
+    if (poorBetaGuess) {
+      system.setBeta(0, 1.0e-9);
+      system.setBeta(1, 1.0 - 1.0e-9);
+    }
+    return system;
+  }
+
+  private void assertEquivalentEquilibrium(SystemInterface expected, SystemInterface actual) {
+    assertEquals(2, expected.getNumberOfPhases());
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(PhaseType.GAS, actual.getPhase(0).getType());
+    assertEquals(PhaseType.AQUEOUS, actual.getPhase(1).getType());
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-7);
+    assertEquals(expected.getEnthalpy(), actual.getEnthalpy(), 1.0e-7);
+
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      assertEquals(expected.getPhase(phaseIndex).getType(), actual.getPhase(phaseIndex).getType());
+      assertEquals(expected.getBeta(phaseIndex), actual.getBeta(phaseIndex), 1.0e-10);
+      assertTrue(actual.getBeta(phaseIndex) > 0.0 && actual.getBeta(phaseIndex) < 1.0);
+      assertEquals(expected.getPhase(phaseIndex).getZ(), actual.getPhase(phaseIndex).getZ(), 1.0e-10);
+      assertEquals(expected.getPhase(phaseIndex).getDensity(), actual.getPhase(phaseIndex).getDensity(), 1.0e-7);
+      betaTotal += actual.getBeta(phaseIndex);
+
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        double composition = actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        assertTrue(Double.isFinite(composition) && composition >= 0.0 && composition <= 1.0);
+        assertEquals(expected.getPhase(phaseIndex).getComponent(componentIndex).getx(), composition, 1.0e-10);
+        compositionTotal += composition;
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-10);
+    }
+    assertEquals(1.0, betaTotal, 1.0e-12);
+
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+        recoveredFeed += actual.getBeta(phaseIndex)
+            * actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-10);
+    }
+    assertTrue(maximumLogFugacityResidual(actual) < 1.0e-8);
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double firstLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+    }
+    return maximumResidual;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousCrossAlgorithmFallbackTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousCrossAlgorithmFallbackTest.java
@@ -30,8 +30,8 @@ class TPflashAqueousCrossAlgorithmFallbackTest {
 
   @Test
   void multiphaseFallbackRemainsContinuousAcrossNearbyStates() {
-    double[][] states = { { 260.0, 100.0 }, { 255.0, 100.0 }, { 260.0, 90.0 }, { 260.0, 110.0 },
-        { 265.0, 100.0 }, { 260.0, 100.0 } };
+    double[][] states = { { 260.0, 100.0 }, { 255.0, 100.0 }, { 260.0, 90.0 }, { 260.0, 110.0 }, { 265.0, 100.0 },
+        { 260.0, 100.0 } };
     SystemInterface multiphase = createSystem(states[0][0], states[0][1], true, true);
 
     for (double[] state : states) {
@@ -99,8 +99,7 @@ class TPflashAqueousCrossAlgorithmFallbackTest {
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
       double recoveredFeed = 0.0;
       for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
-        recoveredFeed += actual.getBeta(phaseIndex)
-            * actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        recoveredFeed += actual.getBeta(phaseIndex) * actual.getPhase(phaseIndex).getComponent(componentIndex).getx();
       }
       assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-10);
     }


### PR DESCRIPTION
Advances #2937. This is the sole active TP-flash campaign implementation PR.

## Reproduced problem

A deterministic neutral PR-EOS mixture at 260 K and 100 bara with classic mixing

```
CO2      0.543865141103918
methane  0.2937712952303271
ethane   0.07010605470616459
water    0.09225750895959021
```

returns two GAS+AQUEOUS phases through both paths, but current `master` does not return the same equilibrium:

| path | gas beta | max component balance | max abs log-fugacity residual | extensive Gibbs energy (J) |
|---|---:|---:|---:|---:|
| ordinary TPflash | 0.9078491997365364 | 1.109e-13 | 1.356e-12 | 4401.583736753728 |
| multiphase-enabled TPflash | 0.9078102671530326 | 0.0 | 1.076e-1 | 4611.366932614616 |

The multiphase endpoint is material-balanced but not at fugacity equilibrium and is 209.8 J above the independently converged ordinary split. Repeated execution is deterministic, so this is a stable reproducer rather than timing noise.

## Root cause

`rescueWaterRichEndpoint()` already sends an invalid ordinary water-rich endpoint through a guarded multiphase candidate. It explicitly returned early for water-rich multiphase-enabled endpoints, however, even when the final log-fugacity residual failed the existing `1e-8` acceptance gate.

A simple beta refinement removes the residual but stays on the higher-Gibbs branch. The independently cold ordinary path finds the lower-Gibbs equilibrium. A multiphase phase-appearance trial can also remap the internal aqueous storage slot; copying candidate compositions into the mutated slots did not reproduce the candidate cubic-root state.

## Method

- Make the existing water-rich fallback reciprocal only for an endpoint that already fails the strict balance/fugacity acceptance gate.
- For an invalid GAS+AQUEOUS multiphase-enabled endpoint with at least 0.01 feed mole fraction water, build one cold ordinary candidate from the unchanged feed.
- Prevent the nested candidate from recursively starting another cross-algorithm fallback.
- Accept only an exactly-two-phase candidate with finite bounded beta/compositions, normalized beta/compositions, distinct phases, component balance and log-fugacity residual below `1e-8`, and a Gibbs reduction larger than `max(1e-6 J, 1e-8 abs(G))`.
- Once accepted independently, repeat that cold ordinary calculation on the live system to rebuild the cubic/aqueous storage mapping.
- Preserve the existing ordinary-to-multiphase direction, trace-water TPD path, chemical/ionic exclusions, solid/wax exclusions, genuine OIL+AQUEOUS liquid-liquid and three-phase endpoints, and already-feasible fast path.

This is consistent with Michelsen's requirement that phase-split calculation select a feasible lower-Gibbs equilibrium after stability/phase-set selection; it is a NeqSim-specific bounded fallback, not a claim about undocumented commercial-simulator internals:

- Michelsen (1982), *The isothermal flash problem. Part I. Stability*, https://doi.org/10.1016/0378-3812(82)80001-2
- Michelsen (1982), *The isothermal flash problem. Part II. Phase-split calculation*, https://doi.org/10.1016/0378-3812(82)85002-4

## Before/after evidence

The minimal case now returns the ordinary state exactly through the multiphase path:

- GAS+AQUEOUS, gas beta `0.9078491997365364`
- maximum component-balance residual `1.109e-13`
- maximum log-fugacity residual `1.356e-12`
- Gibbs energy `4401.583736753728 J`
- identical phase fractions and compositions on repeat execution

A deterministic 828-comparison PR/SRK/CPA matrix covering dry/rich hydrocarbons, CO2/water, H2, wet gas, 200-400 K, and 5-300 bara reduced identified ordinary-vs-multiphase disagreements from 4 to 3 and removed this PR aqueous defect. The remaining findings were not hidden or tolerance-relaxed: one invalid ordinary SRK aqueous endpoint and two already-equilibrated small numerical/root differences remain separate #2937 hypotheses.

Nearby PR states at 255/260/265 K and 90/100/110 bara return the same topology, fractions, compositions and properties through both paths within the frozen `1e-10` fraction/composition tolerance; maximum observed fugacity residual was `1.88e-12`.

A warmed single-JVM microbenchmark (200 fresh target flashes, same environment) shows the expected bounded correctness cost on affected states:

| case | baseline | candidate |
|---|---:|---:|
| 260 K target failures / 200 | 200 | 0 |
| 260 K mean runtime | 7.083 ms | 8.537 ms |
| 255 K nearby failures / 200 | 200 | 0 |
| 255 K mean runtime | 6.321 ms | 6.667 ms |

No speedup is claimed. Already-feasible water-rich endpoints run only the pre-existing acceptance checks and do not launch the alternate flash; the extra cold solve is restricted to a confirmed invalid endpoint.

## Tests and tolerances

Added `TPflashAqueousCrossAlgorithmFallbackTest` covering:

- exact standard/multiphase phase-state and property consistency;
- poor initial beta;
- phase-fraction and composition bounds/normalization;
- component material balance (`1e-10`);
- log-fugacity equilibrium (`1e-8`);
- Gibbs, enthalpy, density and Z consistency;
- repeat determinism;
- changed temperature/pressure on the same multiphase system;
- nearby-state continuity.

Local evidence:

- `TPflash.java` compiled with `javac` against the available current-master NeqSim artifact.
- The new two-test class passed through an assertion-enabled local runner.
- Existing `TPflashAqueousResidualRefinementTest` and both `TPmultiflashPhaseDisappearanceTest` cases passed through the same runner.
- The 828-case deterministic comparison matrix completed.
- `python devtools/check_documentation_search.py`: passed (648 Markdown, 1 standalone HTML).
- `git diff --check`: passed.

## VALIDATION COMPLETE

Exact head: `541dce0fb751c45b0800202419fb1a7e7bdf74b4`.

All applicable exact-head workflows pass:

- pre-commit, Spotless, documentation search, PaperLab and CodeQL;
- Java 21 Javadocs and repository agent/skill checks;
- Java 21 fast tests on Ubuntu and Windows;
- all four Java 21 slow-test shards;
- Java 8 compatibility tests on Ubuntu and Windows.

The repaired head preserves genuine OIL+AQUEOUS liquid-liquid endpoints while retaining the narrowly gated reciprocal fallback for invalid GAS+AQUEOUS endpoints. The focused regression, nearby-state/repeatability checks, balance and fugacity gates, documentation update and broader repository suites all pass.

The PR remains mergeable. It is eight commits ahead and one non-overlapping documentation commit behind current `master`; the final comparison contains only the three intended TP-flash files. There are no requested changes or unresolved review threads. Local Maven/Spotless limitations remain infrastructure-only and are superseded by the complete hosted exact-head matrix.

## Compatibility and risk

- Private implementation only; no public API or serialized system format changes.
- No changes to TPmultiflash equations, tolerances, dry hydrocarbon behavior, chemical/electrolyte systems, solid/wax handling, genuine OIL+AQUEOUS liquid-liquid handling, or three-phase acceptance.
- A confirmed invalid water-rich multiphase endpoint may perform two bounded cold ordinary solves (independent qualification, then live-state reconstruction).
- Main risk is phase-storage reconstruction on less common neutral EOS systems; the strict independent acceptance gate, exclusions, nearby-state test, and existing related tests bound that risk.

## Documentation impact

Updated the private-method Javadocs and `docs/thermodynamicoperations/TPflash_algorithm.md` with the reciprocal fallback trigger, recursion guard, thermodynamic acceptance equations, storage-remapping rationale, and performance boundary.
