### PR TITLE
fix(thermo): prevent in-place mutation of K vector in Rachford-Rice solver

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/RachfordRice.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/RachfordRice.java
@@ -264,12 +264,14 @@ public class RachfordRice implements Serializable {
       }
       h += z[i] * (K[i] - 1.0) / (1.0 + V * (K[i] - 1.0));
     }
+    double[] workK = K;
     if (h > 0) {
-      for (int i = 0; i < K.length; i++) {
-        if (K[i] < 1e-30) {
+      workK = K.clone();
+      for (int i = 0; i < workK.length; i++) {
+        if (workK[i] < 1e-30) {
           continue; // Skip ions
         }
-        K[i] = 1.0 / K[i];
+        workK[i] = 1.0 / workK[i];
       }
     }
 
@@ -277,19 +279,19 @@ public class RachfordRice implements Serializable {
     double Kmin = Double.MAX_VALUE;
     boolean foundNonIon = false;
 
-    for (int i = 0; i < K.length; i++) {
-      if (K[i] < 1e-30) {
+    for (int i = 0; i < workK.length; i++) {
+      if (workK[i] < 1e-30) {
         continue; // Skip ions
       }
       if (!foundNonIon) {
-        Kmax = K[i];
-        Kmin = K[i];
+        Kmax = workK[i];
+        Kmin = workK[i];
         foundNonIon = true;
       } else {
-        if (K[i] < Kmin) {
-          Kmin = K[i];
-        } else if (K[i] > Kmax) {
-          Kmax = K[i];
+        if (workK[i] < Kmin) {
+          Kmin = workK[i];
+        } else if (workK[i] > Kmax) {
+          Kmax = workK[i];
         }
       }
     }
@@ -307,17 +309,17 @@ public class RachfordRice implements Serializable {
     double a = (alpha - alphaMin) / (alphaMax - alpha);
     double b = 1.0 / (alpha - alphaMin);
 
-    if (c.length != K.length) {
-      c = new double[K.length];
-      d = new double[K.length];
+    if (c.length != workK.length) {
+      c = new double[workK.length];
+      d = new double[workK.length];
     }
-    for (int i = 0; i < K.length; i++) {
-      if (K[i] < 1e-30) {
+    for (int i = 0; i < workK.length; i++) {
+      if (workK[i] < 1e-30) {
         c[i] = 0.0;
         d[i] = 0.0;
         continue; // Skip ions
       }
-      double Ki = K[i];
+      double Ki = workK[i];
       if (Ki < 1e-25) {
         Ki = 1e-25;
       } else if (Ki > 1e25) {
@@ -346,8 +348,8 @@ public class RachfordRice implements Serializable {
       double funkder = 0.0;
       hb = 0.0;
       double hbder = 0.0;
-      for (int i = 0; i < K.length; i++) {
-        if (K[i] < 1e-30) {
+      for (int i = 0; i < workK.length; i++) {
+        if (workK[i] < 1e-30) {
           continue; // Skip ions
         }
         funk -= z[i] * a * (1.0 + a) / (d[i] + a * (1.0 + d[i]));

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/RachfordRiceTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/RachfordRiceTest.java
@@ -47,4 +47,19 @@ public class RachfordRiceTest {
       logger.error(e.getMessage());
     }
   }
+
+  @Test
+  void testCalcBetaNielsen2023NoArrayMutation() {
+    double[] z = new double[] { 0.9, 0.1 };
+    double[] K = new double[] { 5.0, 0.2 };
+    double k0Original = K[0];
+    double k1Original = K[1];
+
+    RachfordRice rachfordRice = new RachfordRice();
+    double beta = rachfordRice.calcBetaNielsen2023(K, z);
+
+    Assertions.assertTrue(beta > 0.0 && beta < 1.0);
+    Assertions.assertEquals(k0Original, K[0], 1e-12, "Input K[0] must not be mutated in-place");
+    Assertions.assertEquals(k1Original, K[1], 1e-12, "Input K[1] must not be mutated in-place");
+  }
 }


### PR DESCRIPTION
## Summary
In RachfordRice.calcBetaNielsen2023, when gas fraction  > 0.5$ ( > 0$), the solver executed K[i] = 1.0 / K[i] directly on the input array K. This mutated the caller's thermodynamic $-vector in place, corrupting subsequent thermodynamic iterations across shared callers.

## Changes
- Cloned input array K to a working array workK = K.clone() when  > 0$ so K values are inverted safely on the local working copy.
- Kept caller's K array state completely untouched.