### PR TITLE
fix(process): preserve liquid phase component moles during tear stream mixing in Recycle

### DIFF
--- a/src/main/java/neqsim/process/equipment/util/Recycle.java
+++ b/src/main/java/neqsim/process/equipment/util/Recycle.java
@@ -314,12 +314,11 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
       for (int i = 0; i < streams.get(k).getThermoSystem().getPhase(0).getNumberOfComponents(); i++) {
         boolean gotComponent = false;
         String componentName = streams.get(k).getThermoSystem().getPhase(0).getComponent(i).getName();
-        // logger.info("adding: " + componentName);
-        // int numberOfPhases = streams.get(k).getThermoSystem().getNumberOfPhases();
 
-        double moles = streams.get(k).getThermoSystem().getPhase(0).getComponent(i).getNumberOfmoles();
-        // logger.info("moles: " + moles + " " +
-        // mixedStream.getThermoSystem().getPhase(0).getNumberOfComponents());
+        double moles = 0.0;
+        for (int p = 0; p < streams.get(k).getThermoSystem().getNumberOfPhases(); p++) {
+          moles += streams.get(k).getThermoSystem().getPhase(p).getComponent(i).getNumberOfmoles();
+        }
         for (int p = 0; p < mixedStream.getThermoSystem().getPhase(0).getNumberOfComponents(); p++) {
           if (mixedStream.getThermoSystem().getPhase(0).getComponent(p).getName().equals(componentName)) {
             gotComponent = true;

--- a/src/test/java/neqsim/process/equipment/util/RecycleTest.java
+++ b/src/test/java/neqsim/process/equipment/util/RecycleTest.java
@@ -1,0 +1,40 @@
+package neqsim.process.equipment.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+public class RecycleTest {
+  @Test
+  void testMixStreamMultiPhasePreservesLiquidMoles() {
+    SystemInterface feedFluid = new SystemSrkEos(280.0, 50.0);
+    feedFluid.addComponent("methane", 0.7);
+    feedFluid.addComponent("n-heptane", 0.3);
+    feedFluid.setMixingRule("classic");
+    Stream inletStream = new Stream("inletStream", feedFluid);
+    inletStream.run();
+
+    SystemInterface tearFluid = new SystemSrkEos(280.0, 50.0);
+    tearFluid.addComponent("methane", 0.5);
+    tearFluid.addComponent("n-heptane", 0.5);
+    tearFluid.setMixingRule("classic");
+    Stream tearStream = new Stream("tearStream", tearFluid);
+    tearStream.run();
+
+    Recycle recycle = new Recycle("testRecycle");
+    recycle.addStream(inletStream);
+    recycle.addStream(tearStream);
+
+    recycle.setOutStream(inletStream.clone());
+    recycle.mixStream();
+
+    double totalHeptaneInlet = inletStream.getThermoSystem().getComponent("n-heptane").getNumberOfmoles();
+    double totalHeptaneTear = tearStream.getThermoSystem().getComponent("n-heptane").getNumberOfmoles();
+    double mixedHeptane = recycle.getMixedStream().getThermoSystem().getComponent("n-heptane").getNumberOfmoles();
+
+    Assertions.assertEquals(totalHeptaneInlet + totalHeptaneTear, mixedHeptane, 1e-6,
+        "Recycle mixStream must preserve component moles from both gas and liquid phases of tear streams");
+  }
+}


### PR DESCRIPTION
## Summary
In Recycle.mixStream(), component moles were retrieved exclusively from Phase 0 (Phase(0).getComponent(i).getNumberOfmoles()). Component moles present in Phase 1 (oil) and Phase 2 (aqueous) of incoming tear streams were ignored, causing multi-phase tear streams to lose 100% of their liquid phase inventory upon mixing.

## Changes
- Summed component moles across all active phases (getPhase(p).getComponent(i).getNumberOfmoles()) in incoming tear streams during mixStream().
- Ensured 100% mass balance preservation for multi-phase tear streams.