### PR TITLE
fix(process): normalize split factors and scale multi-phase component moles in Splitter

### DIFF
--- a/src/main/java/neqsim/process/equipment/splitter/Splitter.java
+++ b/src/main/java/neqsim/process/equipment/splitter/Splitter.java
@@ -381,10 +381,11 @@ public class Splitter extends ProcessEquipmentBaseClass implements SplitterInter
       }
       totSplit += splitFactor[i];
     }
-    if (Math.abs(totSplit - 1.0) > 1e-10) {
-      logger.debug("total split factor different from 0 in splitter - totsplit = " + totSplit);
-      logger.debug("setting first split to = " + (1.0 - totSplit));
-      splitFactor[0] = 1.0 - totSplit;
+    if (Math.abs(totSplit - 1.0) > 1e-10 && totSplit > 0) {
+      logger.debug("total split factor different from 1.0 in splitter - totsplit = " + totSplit);
+      for (int i = 0; i < splitNumber; i++) {
+        splitFactor[i] /= totSplit;
+      }
     }
 
     for (int i = 0; i < splitNumber; i++) {
@@ -393,7 +394,10 @@ public class Splitter extends ProcessEquipmentBaseClass implements SplitterInter
       splitStream[i].setThermoSystem(thermoSystem);
       for (int j = 0; j < inletStream.getThermoSystem().getPhase(0).getNumberOfComponents(); j++) {
         int index = inletStream.getThermoSystem().getPhase(0).getComponent(j).getComponentNumber();
-        double moles = inletStream.getThermoSystem().getPhase(0).getComponent(j).getNumberOfmoles();
+        double moles = 0.0;
+        for (int p = 0; p < inletStream.getThermoSystem().getNumberOfPhases(); p++) {
+          moles += inletStream.getThermoSystem().getPhase(p).getComponent(j).getNumberOfmoles();
+        }
         double change = (moles * splitFactor[i] - moles > 0) ? 0.0 : moles * splitFactor[i] - moles;
         splitStream[i].getThermoSystem().addComponent(index, change);
       }

--- a/src/test/java/neqsim/process/equipment/splitter/SplitterTest.java
+++ b/src/test/java/neqsim/process/equipment/splitter/SplitterTest.java
@@ -285,4 +285,26 @@ class SplitterTest {
     neqsim.util.validation.ValidationResult result = splitter.validateSetup();
     assertFalse(result.isValid());
   }
+
+  @Test
+  void testMultiPhaseStreamSplittingPreservesLiquid() {
+    neqsim.thermo.system.SystemInterface multiPhaseFluid = new SystemSrkEos(280.0, 50.0);
+    multiPhaseFluid.addComponent("methane", 0.6);
+    multiPhaseFluid.addComponent("n-heptane", 0.4);
+    multiPhaseFluid.setMixingRule("classic");
+
+    Stream multiPhaseStream = new Stream("multiPhaseStream", multiPhaseFluid);
+    multiPhaseStream.run();
+
+    Splitter splitter = new Splitter("multiPhaseSplitter", multiPhaseStream, 2);
+    splitter.setSplitFactors(new double[] { 0.6, 0.4 });
+    splitter.run();
+
+    double totalHeptaneInlet = multiPhaseStream.getThermoSystem().getComponent("n-heptane").getNumberOfmoles();
+    double split0Heptane = splitter.getSplitStream(0).getThermoSystem().getComponent("n-heptane").getNumberOfmoles();
+    double split1Heptane = splitter.getSplitStream(1).getThermoSystem().getComponent("n-heptane").getNumberOfmoles();
+
+    assertEquals(totalHeptaneInlet * 0.6, split0Heptane, totalHeptaneInlet * 1e-4);
+    assertEquals(totalHeptaneInlet * 0.4, split1Heptane, totalHeptaneInlet * 1e-4);
+  }
 }


### PR DESCRIPTION
## Summary
In Splitter.run(), two issues compromised stream splitting accuracy:
1. When 	otSplit != 1.0, line 387 executed splitFactor[0] = 1.0 - totSplit;, which assigned negative split factors when 	otSplit > 1.0, causing downstream flash failures.
2. Component moles were retrieved only from Phase 0 (Phase(0).getComponent(j).getNumberOfmoles()), meaning liquid oil and water phases were cloned 100% into every split stream regardless of split factor.

## Changes
- Normalized splitFactor[i] /= totSplit proportionally when 	otSplit != 1.0 (and 	otSplit > 0) to prevent negative split factors.
- Summed component moles across all active phases when calculating component splits, ensuring liquid/aqueous phase component moles are scaled accurately across split streams.