### PR TITLE
perf(process): replace redundant init(3) calls with init(2) in equipment run loops

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -1025,7 +1025,7 @@ public class Compressor extends TwoPortEquipment
     }
 
     ThermodynamicOperations thermoOps = new ThermodynamicOperations(getThermoSystem());
-    getThermoSystem().init(3);
+    getThermoSystem().init(2);
     getThermoSystem().initPhysicalProperties(PhysicalPropertyType.MASS_DENSITY);
 
     // Optimization: disable stability analysis for single-phase inlet gas, where no

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -520,7 +520,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
     if (inStream.getFlowRate("kg/hr") < minimumFlow) {
       thermoSystem = inStream.getThermoSystem().clone();
       thermoSystem.setPressure(pressure, pressureUnit);
-      thermoSystem.init(3);
+      thermoSystem.init(2);
       dH = 0.0;
       if (!isSetEnergyStream()) {
         getEnergyPort("shaftPower").setDuty(0.0);
@@ -537,7 +537,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
       logger.warn("Pump " + getName() + " may be operating in cavitation conditions");
     }
 
-    inStream.getThermoSystem().init(3);
+    inStream.getThermoSystem().init(2);
     double hinn = inStream.getThermoSystem().getEnthalpy();
     double entropy = inStream.getThermoSystem().getEntropy();
 

--- a/src/main/java/neqsim/process/equipment/util/Recycle.java
+++ b/src/main/java/neqsim/process/equipment/util/Recycle.java
@@ -362,7 +362,7 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
   public double calcMixStreamEnthalpy() {
     double enthalpy = 0;
     for (int k = 0; k < streams.size(); k++) {
-      streams.get(k).getThermoSystem().init(3);
+      streams.get(k).getThermoSystem().init(2);
       enthalpy += streams.get(k).getThermoSystem().getEnthalpy();
       // logger.info("total enthalpy k : " + ( ((Stream)
       // streams.get(k)).getThermoSystem()).getEnthalpy());

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorTest.java
@@ -610,4 +610,12 @@ class CompressorTest extends neqsim.NeqSimTest {
     logger.info("  Original speed: " + originalSpeed + " RPM");
     logger.info("  Calculated speed: " + comp.getSpeed() + " RPM");
   }
+
+  @Test
+  void testCompressorRunEfficiencyAndPowerWithInit2() {
+    processOps.run();
+    Assertions.assertTrue(compressor1.getPower() > 0.0);
+    Assertions.assertTrue(compressor1.getOutletStream().getTemperature() > temperature_inlet);
+    Assertions.assertEquals(pressure_Out, compressor1.getOutletStream().getPressure(), 1e-4);
+  }
 }


### PR DESCRIPTION
## Summary
Equipment execution routines in Compressor, Pump, and Recycle called init(3) during run steps and recycle enthalpy calculations. init(3) evaluates expensive second-order thermodynamic derivatives (sound speeds, heat capacities, chemical potential derivatives). Standard equipment enthalpy and state updates only require first-order properties computed by init(2).

## Changes
- Replaced getThermoSystem().init(3) with getThermoSystem().init(2) in Compressor.run(), Pump.run(), and Recycle.calcMixStreamEnthalpy().
- Significantly reduces per-iteration execution overhead during flow-sheet simulations without affecting calculation results.