### PR TITLE
fix(flash): preserve caller Rachford-Rice K array

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/RachfordRice.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/RachfordRice.java
@@ -518,3 +518,56 @@ public class RachfordRice implements Serializable {
         deriv = 0.0;
         gbeta = 0.0;
 
+        for (i = 0; i < system.getNumberOfComponents(); i++) {
+          deriv -= (compArray[i].getz() * (compArray[i].getK() - 1.0) * (1.0 - compArray[i].getK()))
+              / Math.pow((betal + (1 - betal) * compArray[i].getK()), 2);
+          gbeta += compArray[i].getz() * (compArray[i].getK() - 1.0) / (betal + (-betal + 1.0) * compArray[i].getK());
+        }
+
+        if (gbeta < 0) {
+          minBeta = betal;
+        } else {
+          maxBeta = betal;
+        }
+
+        betal -= (gbeta / deriv);
+
+        if (betal > maxBeta) {
+          betal = maxBeta;
+        }
+        if (betal < minBeta) {
+          betal = minBeta;
+        }
+
+        nybeta = 1.0 - betal;
+      }
+      step = gbeta / deriv;
+    } while (Math.abs(step) >= 1.0e-10 && iterations < maxIterations); // &&
+
+    if (nybeta <= phaseFractionMinimumLimit) {
+      // this.phase = 1;
+      nybeta = phaseFractionMinimumLimit;
+    } else if (nybeta >= 1.0 - phaseFractionMinimumLimit) {
+      // this.phase = 0;
+      nybeta = 1.0 - phaseFractionMinimumLimit;
+      // superheated vapour
+    } else {
+      // this.phase = 2;
+    } // two-phase liquid-gas
+
+    this.beta[0] = nybeta;
+    this.beta[1] = 1.0 - nybeta;
+
+    if (iterations >= maxIterations) {
+      throw new neqsim.util.exception.TooManyIterationsException(this, "calcBetaS", maxIterations);
+    }
+    if (Double.isNaN(beta[1])) {
+      /*
+       * for (i = 0; i < numberOfComponents; i++) { System.out.println("K " + compArray[i].getK());
+       * System.out.println("z " + compArray[i].getz()); }
+       */
+      throw new neqsim.util.exception.IsNaNException(this, "calcBetaS", "beta");
+    }
+    return this.beta[0];
+  }
+}

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/RachfordRice.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/RachfordRice.java
@@ -51,7 +51,7 @@ public class RachfordRice implements Serializable {
   /**
    * calcBeta. For gas liquid systems. Method used is defined in method String variable
    *
-   * @param K an array of type double
+   * @param K equilibrium-ratio array; this method does not modify the caller's array
    * @param z an array of type double
    * @return Beta Mole fraction of gas phase
    * @throws neqsim.util.exception.IsNaNException if any.
@@ -71,7 +71,7 @@ public class RachfordRice implements Serializable {
   /**
    * calcBeta. For gas liquid systems. Method based on Michelsen Mollerup, 2001
    *
-   * @param K an array of type double
+   * @param K equilibrium-ratio array; this method does not modify the caller's array
    * @param z an array of type double
    * @return Beta Mole fraction of gas phase
    * @throws neqsim.util.exception.IsNaNException if any.
@@ -226,7 +226,7 @@ public class RachfordRice implements Serializable {
    * calcBetaNielsen2023. For gas liquid systems. Method based on Avoiding round-off error in the Rachford–Rice
    * equation, Nielsen, Lia, 2023
    *
-   * @param K an array of type double
+   * @param K equilibrium-ratio array; this method does not modify the caller's array
    * @param z an array of type double
    * @return Beta Mole fraction of gas phase
    * @throws neqsim.util.exception.IsNaNException if any.
@@ -264,12 +264,14 @@ public class RachfordRice implements Serializable {
       }
       h += z[i] * (K[i] - 1.0) / (1.0 + V * (K[i] - 1.0));
     }
+    double[] workK = K;
     if (h > 0) {
-      for (int i = 0; i < K.length; i++) {
-        if (K[i] < 1e-30) {
+      workK = K.clone();
+      for (int i = 0; i < workK.length; i++) {
+        if (workK[i] < 1e-30) {
           continue; // Skip ions
         }
-        K[i] = 1.0 / K[i];
+        workK[i] = 1.0 / workK[i];
       }
     }
 
@@ -277,19 +279,19 @@ public class RachfordRice implements Serializable {
     double Kmin = Double.MAX_VALUE;
     boolean foundNonIon = false;
 
-    for (int i = 0; i < K.length; i++) {
-      if (K[i] < 1e-30) {
+    for (int i = 0; i < workK.length; i++) {
+      if (workK[i] < 1e-30) {
         continue; // Skip ions
       }
       if (!foundNonIon) {
-        Kmax = K[i];
-        Kmin = K[i];
+        Kmax = workK[i];
+        Kmin = workK[i];
         foundNonIon = true;
       } else {
-        if (K[i] < Kmin) {
-          Kmin = K[i];
-        } else if (K[i] > Kmax) {
-          Kmax = K[i];
+        if (workK[i] < Kmin) {
+          Kmin = workK[i];
+        } else if (workK[i] > Kmax) {
+          Kmax = workK[i];
         }
       }
     }
@@ -307,17 +309,17 @@ public class RachfordRice implements Serializable {
     double a = (alpha - alphaMin) / (alphaMax - alpha);
     double b = 1.0 / (alpha - alphaMin);
 
-    if (c.length != K.length) {
-      c = new double[K.length];
-      d = new double[K.length];
+    if (c.length != workK.length) {
+      c = new double[workK.length];
+      d = new double[workK.length];
     }
-    for (int i = 0; i < K.length; i++) {
-      if (K[i] < 1e-30) {
+    for (int i = 0; i < workK.length; i++) {
+      if (workK[i] < 1e-30) {
         c[i] = 0.0;
         d[i] = 0.0;
         continue; // Skip ions
       }
-      double Ki = K[i];
+      double Ki = workK[i];
       if (Ki < 1e-25) {
         Ki = 1e-25;
       } else if (Ki > 1e25) {
@@ -346,8 +348,8 @@ public class RachfordRice implements Serializable {
       double funkder = 0.0;
       hb = 0.0;
       double hbder = 0.0;
-      for (int i = 0; i < K.length; i++) {
-        if (K[i] < 1e-30) {
+      for (int i = 0; i < workK.length; i++) {
+        if (workK[i] < 1e-30) {
           continue; // Skip ions
         }
         funk -= z[i] * a * (1.0 + a) / (d[i] + a * (1.0 + d[i]));
@@ -516,56 +518,3 @@ public class RachfordRice implements Serializable {
         deriv = 0.0;
         gbeta = 0.0;
 
-        for (i = 0; i < system.getNumberOfComponents(); i++) {
-          deriv -= (compArray[i].getz() * (compArray[i].getK() - 1.0) * (1.0 - compArray[i].getK()))
-              / Math.pow((betal + (1 - betal) * compArray[i].getK()), 2);
-          gbeta += compArray[i].getz() * (compArray[i].getK() - 1.0) / (betal + (-betal + 1.0) * compArray[i].getK());
-        }
-
-        if (gbeta < 0) {
-          minBeta = betal;
-        } else {
-          maxBeta = betal;
-        }
-
-        betal -= (gbeta / deriv);
-
-        if (betal > maxBeta) {
-          betal = maxBeta;
-        }
-        if (betal < minBeta) {
-          betal = minBeta;
-        }
-
-        nybeta = 1.0 - betal;
-      }
-      step = gbeta / deriv;
-    } while (Math.abs(step) >= 1.0e-10 && iterations < maxIterations); // &&
-
-    if (nybeta <= phaseFractionMinimumLimit) {
-      // this.phase = 1;
-      nybeta = phaseFractionMinimumLimit;
-    } else if (nybeta >= 1.0 - phaseFractionMinimumLimit) {
-      // this.phase = 0;
-      nybeta = 1.0 - phaseFractionMinimumLimit;
-      // superheated vapour
-    } else {
-      // this.phase = 2;
-    } // two-phase liquid-gas
-
-    this.beta[0] = nybeta;
-    this.beta[1] = 1.0 - nybeta;
-
-    if (iterations >= maxIterations) {
-      throw new neqsim.util.exception.TooManyIterationsException(this, "calcBetaS", maxIterations);
-    }
-    if (Double.isNaN(beta[1])) {
-      /*
-       * for (i = 0; i < numberOfComponents; i++) { System.out.println("K " + compArray[i].getK());
-       * System.out.println("z " + compArray[i].getz()); }
-       */
-      throw new neqsim.util.exception.IsNaNException(this, "calcBetaS", "beta");
-    }
-    return this.beta[0];
-  }
-}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/RachfordRiceTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/RachfordRiceTest.java
@@ -47,4 +47,17 @@ public class RachfordRiceTest {
       logger.error(e.getMessage());
     }
   }
+
+  @Test
+  void testCalcBetaNielsen2023DoesNotMutateInputArray() {
+    double[] z = new double[] { 0.9, 0.1 };
+    double[] k = new double[] { 5.0, 0.2 };
+    double[] originalK = k.clone();
+
+    RachfordRice rachfordRice = new RachfordRice();
+    double beta = Assertions.assertDoesNotThrow(() -> rachfordRice.calcBetaNielsen2023(k, z));
+
+    Assertions.assertTrue(beta > 0.0 && beta < 1.0);
+    Assertions.assertArrayEquals(originalK, k, 0.0, "The caller's K array must remain unchanged");
+  }
 }


### PR DESCRIPTION
## Summary

Supersedes #2950 with a maintainer-owned branch because the GitHub integration can read but cannot update the contributor fork.

`RachfordRice.calcBetaNielsen2023(double[] K, double[] z)` inverted entries in the caller-provided `K` array in place whenever the midpoint residual selected the reciprocal formulation. That corrupts shared equilibrium-ratio state even though the inversion is only an internal numerical transformation.

## Validity review

This is a real current-master defect, not only a failing-test repair:

- the current implementation executes `K[i] = 1.0 / K[i]` for the reciprocal branch;
- the supplied deterministic case `z = [0.9, 0.1]`, `K = [5.0, 0.2]` enters that branch;
- the transformation is not part of the public method contract and subsequent calculations can observe the modified array.

## Fix

- retain the input array for read-only work;
- clone it only when reciprocal `K` values are required;
- use the working array throughout the transformed solve;
- add a regression test that asserts both a finite interior beta and exact input-array immutability;
- use `assertDoesNotThrow` so the checked solver exceptions are handled and the regression test compiles;
- document the non-mutation contract in the public Javadocs.

Original implementation direction and report: #2950 by @slava98981212.

## Compatibility and risk

No equation, tolerance, phase-fraction limit, convergence criterion, serialized state, or public signature changes. The only additional allocation is one `double[]` clone on the branch that previously mutated the input.

## Documentation impact

Public Javadocs now state that `calcBeta`, `calcBetaMichelsen2001`, and `calcBetaNielsen2023` do not modify the caller's equilibrium-ratio array. No user guide change is needed because behavior is restored to normal input immutability without changing usage.

## Validation

Completed locally on the final source tree:

- `git diff --check` — passed;
- `python devtools/check_documentation_search.py` — passed (649 Markdown pages and one standalone HTML page).

## VALIDATION PENDING CI

Local Maven/JUnit and direct Spotless execution could not complete because the environment could not resolve the canonical Maven Central endpoint and the available offline formatter cache lacked transitive artifacts. The contributor head's hosted Spotless and pre-commit checks passed before this replacement; that does not substitute for fresh checks on this exact head. Fresh hosted checks must compile and execute the regression and broader suites before readiness classification.