### PR TITLE
feat(pipeline): expose local compositional linepack

### DIFF
--- a/docs/fluidmechanics/single_phase_pipe_flow.md
+++ b/docs/fluidmechanics/single_phase_pipe_flow.md
@@ -361,6 +361,9 @@ pipeline.runConservativeTransient(new double[] {0.0, 1800.0, 5400.0},
     new SystemInterface[] {pulseGas, baselineGas}, 60, UUID.randomUUID());
 
 double[] nitrogenMassFractionProfile = pipeline.getConservativeMassFractionProfile("nitrogen");
+double[] totalLinepackByCellKg = pipeline.getConservativeCellInventoryKg();
+double[] nitrogenLinepackByCellKg =
+    pipeline.getConservativeComponentInventoryProfileKg("nitrogen");
 String pythonReadyHistoryJson = pipeline.getSpeciesConservationHistory().toJson();
 ```
 
@@ -371,10 +374,16 @@ For the conservative path, that scheduled mass rate is imposed at the authoritat
 inlet face as $v_{in}=\dot m/(A\rho_{EOS})$, using the same inlet EOS density as the continuity
 matrix. A simultaneous composition/rate event therefore preserves the requested integrated inlet
 mass in each accepted-step report. Solver type `1` preserves the initialized temperature profile;
-this path does not yet solve a dynamic energy equation. The authoritative component profiles and
-outlet accessor are mass fractions; the existing `getOutletMoleFraction(...)` remains explicitly
-molar. Python/JPype callers can pass `JArray(JDouble)` and `JArray(SystemInterface)` and read the
-same report/history objects directly.
+this path does not yet solve a dynamic energy equation. The authoritative component profiles and outlet accessor are mass fractions; the existing
+`getOutletMoleFraction(...)` remains explicitly molar. The local linepack accessors return kg for
+physical finite-volume cells in inlet-to-outlet order and exclude boundary nodes. Total cell
+inventory is retained directly from the accepted hydraulic finite-volume state; component-cell
+inventory is that total multiplied by the conservative component mass fraction. Both arrays are
+also serialized as `finalCellInventoryKg` and `finalComponentCellInventoryKg` in stable report
+JSON. Python/JPype callers can pass `JArray(JDouble)` and `JArray(SystemInterface)` and read the
+same report/history objects directly. Full accepted-step history remains opt-in because retaining
+a cell-by-component matrix for every step increases memory in proportion to components, cells,
+and accepted steps.
 `runTransient(dt, id)` also selects type `1` when conservative mode is enabled. When
 `setStoreSpeciesConservationHistory(true)` is enabled, it retains every internal accepted step from
 that call. Legacy `setCompositionalTracking(true)` still selects type `20` for compatibility and
@@ -419,7 +428,8 @@ yet establish event replay after `ProcessSystem.reset()`, dynamic energy transpo
 appearance, or zero/reversed-flow support.
 
 `OnePhaseSpeciesConservationReport` exposes component names, physical-cell mass-fraction profiles,
-initial/final component inventories, integrated inlet/outlet component masses, absolute and
+final total and component inventories by physical cell, initial/final global component inventories,
+integrated inlet/outlet component masses, absolute and
 relative inventory residuals, boundedness and sum-to-one diagnostics, thermodynamic
 synchronization error, hydraulic/species residual histories, and a per-step
 `SpeciesTransportDiagnostics` object. The diagnostic records the selected method, full-step local

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransport.java
@@ -261,8 +261,9 @@ final class ConservativeSpeciesTransport {
         + ": maximum relative component inventory residual=" + maximumRelativeResidual + " (tolerance "
         + INVENTORY_RELATIVE_TOLERANCE + "), mass-fraction range=[" + minimumMassFraction + ", " + maximumMassFraction
         + "], maximum sum error=" + maximumSumError + " (tolerance " + MASS_FRACTION_TOLERANCE + ").";
-    return new OnePhaseSpeciesConservationReport(reason, componentNames, massFraction, initialInventory, finalInventory,
-        inletMass, outletMass, residual, relativeResidual, maximumRelativeResidual, minimumMassFraction,
+    return new OnePhaseSpeciesConservationReport(reason, componentNames, massFraction, newCellMassKg,
+        initialInventory, finalInventory, inletMass, outletMass, residual, relativeResidual, maximumRelativeResidual,
+        minimumMassFraction,
         maximumMassFraction, maximumSumError, Double.NaN, diagnostics, message);
   }
 
@@ -540,8 +541,8 @@ final class ConservativeSpeciesTransport {
 
   private static OnePhaseSpeciesConservationReport failed(ConservationReason reason, String[] componentNames,
       String message) {
-    return new OnePhaseSpeciesConservationReport(reason, componentNames, new double[0][0], new double[0], new double[0],
-        new double[0], new double[0], new double[0], new double[0], Double.NaN, Double.NaN, Double.NaN, Double.NaN,
-        Double.NaN, message);
+    return new OnePhaseSpeciesConservationReport(reason, componentNames, new double[0][0], new double[0],
+        new double[0], new double[0], new double[0], new double[0], new double[0], new double[0], Double.NaN,
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, message);
   }
 }

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/ConservativeSpeciesTransport.java
@@ -261,9 +261,8 @@ final class ConservativeSpeciesTransport {
         + ": maximum relative component inventory residual=" + maximumRelativeResidual + " (tolerance "
         + INVENTORY_RELATIVE_TOLERANCE + "), mass-fraction range=[" + minimumMassFraction + ", " + maximumMassFraction
         + "], maximum sum error=" + maximumSumError + " (tolerance " + MASS_FRACTION_TOLERANCE + ").";
-    return new OnePhaseSpeciesConservationReport(reason, componentNames, massFraction, newCellMassKg,
-        initialInventory, finalInventory, inletMass, outletMass, residual, relativeResidual, maximumRelativeResidual,
-        minimumMassFraction,
+    return new OnePhaseSpeciesConservationReport(reason, componentNames, massFraction, newCellMassKg, initialInventory,
+        finalInventory, inletMass, outletMass, residual, relativeResidual, maximumRelativeResidual, minimumMassFraction,
         maximumMassFraction, maximumSumError, Double.NaN, diagnostics, message);
   }
 
@@ -541,8 +540,8 @@ final class ConservativeSpeciesTransport {
 
   private static OnePhaseSpeciesConservationReport failed(ConservationReason reason, String[] componentNames,
       String message) {
-    return new OnePhaseSpeciesConservationReport(reason, componentNames, new double[0][0], new double[0],
-        new double[0], new double[0], new double[0], new double[0], new double[0], new double[0], Double.NaN,
-        Double.NaN, Double.NaN, Double.NaN, Double.NaN, message);
+    return new OnePhaseSpeciesConservationReport(reason, componentNames, new double[0][0], new double[0], new double[0],
+        new double[0], new double[0], new double[0], new double[0], new double[0], Double.NaN, Double.NaN, Double.NaN,
+        Double.NaN, Double.NaN, message);
   }
 }

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseSpeciesConservationReport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseSpeciesConservationReport.java
@@ -49,6 +49,8 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
   private final ConservationReason reason;
   private final String[] componentNames;
   private final double[][] massFractionProfile;
+  private final double[] finalCellInventoryKg;
+  private final double[][] finalComponentCellInventoryKg;
   private final double[] initialInventoryKg;
   private final double[] finalInventoryKg;
   private final double[] inletBoundaryMassKg;
@@ -68,38 +70,43 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
   private final String message;
 
   OnePhaseSpeciesConservationReport(ConservationReason reason, String[] componentNames, double[][] massFractionProfile,
-      double[] initialInventoryKg, double[] finalInventoryKg, double[] inletBoundaryMassKg,
-      double[] outletBoundaryMassKg, double[] inventoryResidualKg, double[] relativeInventoryResidual,
-      double maximumRelativeInventoryResidual, double minimumMassFraction, double maximumMassFraction,
-      double maximumMassFractionSumError, double maximumThermodynamicMassFractionError, String message) {
-    this(reason, componentNames, massFractionProfile, initialInventoryKg, finalInventoryKg, inletBoundaryMassKg,
-        outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual, maximumRelativeInventoryResidual,
-        minimumMassFraction, maximumMassFraction, maximumMassFractionSumError, maximumThermodynamicMassFractionError,
-        SpeciesTransportDiagnostics.notRun(), message);
-  }
-
-  OnePhaseSpeciesConservationReport(ConservationReason reason, String[] componentNames, double[][] massFractionProfile,
-      double[] initialInventoryKg, double[] finalInventoryKg, double[] inletBoundaryMassKg,
-      double[] outletBoundaryMassKg, double[] inventoryResidualKg, double[] relativeInventoryResidual,
-      double maximumRelativeInventoryResidual, double minimumMassFraction, double maximumMassFraction,
-      double maximumMassFractionSumError, double maximumThermodynamicMassFractionError,
-      SpeciesTransportDiagnostics transportDiagnostics, String message) {
-    this(reason, componentNames, massFractionProfile, initialInventoryKg, finalInventoryKg, inletBoundaryMassKg,
-        outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual, maximumRelativeInventoryResidual,
-        minimumMassFraction, maximumMassFraction, maximumMassFractionSumError, maximumThermodynamicMassFractionError, 0,
-        new double[0], new double[0], transportDiagnostics, message);
-  }
-
-  private OnePhaseSpeciesConservationReport(ConservationReason reason, String[] componentNames,
-      double[][] massFractionProfile, double[] initialInventoryKg, double[] finalInventoryKg,
+      double[] finalCellInventoryKg, double[] initialInventoryKg, double[] finalInventoryKg,
       double[] inletBoundaryMassKg, double[] outletBoundaryMassKg, double[] inventoryResidualKg,
       double[] relativeInventoryResidual, double maximumRelativeInventoryResidual, double minimumMassFraction,
       double maximumMassFraction, double maximumMassFractionSumError, double maximumThermodynamicMassFractionError,
-      int couplingIterations, double[] maximumMassFractionChangeHistory, double[] densityResidualHistory,
+      String message) {
+    this(reason, componentNames, massFractionProfile, finalCellInventoryKg, initialInventoryKg, finalInventoryKg,
+        inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
+        maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
+        maximumThermodynamicMassFractionError, SpeciesTransportDiagnostics.notRun(), message);
+  }
+
+  OnePhaseSpeciesConservationReport(ConservationReason reason, String[] componentNames, double[][] massFractionProfile,
+      double[] finalCellInventoryKg, double[] initialInventoryKg, double[] finalInventoryKg,
+      double[] inletBoundaryMassKg, double[] outletBoundaryMassKg, double[] inventoryResidualKg,
+      double[] relativeInventoryResidual, double maximumRelativeInventoryResidual, double minimumMassFraction,
+      double maximumMassFraction, double maximumMassFractionSumError, double maximumThermodynamicMassFractionError,
+      SpeciesTransportDiagnostics transportDiagnostics, String message) {
+    this(reason, componentNames, massFractionProfile, finalCellInventoryKg, initialInventoryKg, finalInventoryKg,
+        inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
+        maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
+        maximumThermodynamicMassFractionError, 0, new double[0], new double[0], transportDiagnostics, message);
+  }
+
+  private OnePhaseSpeciesConservationReport(ConservationReason reason, String[] componentNames,
+      double[][] massFractionProfile, double[] finalCellInventoryKg, double[] initialInventoryKg,
+      double[] finalInventoryKg, double[] inletBoundaryMassKg, double[] outletBoundaryMassKg,
+      double[] inventoryResidualKg, double[] relativeInventoryResidual, double maximumRelativeInventoryResidual,
+      double minimumMassFraction, double maximumMassFraction, double maximumMassFractionSumError,
+      double maximumThermodynamicMassFractionError, int couplingIterations,
+      double[] maximumMassFractionChangeHistory, double[] densityResidualHistory,
       SpeciesTransportDiagnostics transportDiagnostics, String message) {
     this.reason = reason;
     this.componentNames = copy(componentNames);
     this.massFractionProfile = copy(massFractionProfile);
+    this.finalCellInventoryKg = copy(finalCellInventoryKg);
+    this.finalComponentCellInventoryKg =
+        componentCellInventory(this.massFractionProfile, this.finalCellInventoryKg);
     this.initialInventoryKg = copy(initialInventoryKg);
     this.finalInventoryKg = copy(finalInventoryKg);
     this.inletBoundaryMassKg = copy(inletBoundaryMassKg);
@@ -126,8 +133,9 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
    */
   public static OnePhaseSpeciesConservationReport notRun() {
     return new OnePhaseSpeciesConservationReport(ConservationReason.NOT_RUN, new String[0], new double[0][0],
-        new double[0], new double[0], new double[0], new double[0], new double[0], new double[0], Double.NaN,
-        Double.NaN, Double.NaN, Double.NaN, Double.NaN, "Conservative species transport has not run.");
+        new double[0], new double[0], new double[0], new double[0], new double[0], new double[0], new double[0],
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
+        "Conservative species transport has not run.");
   }
 
   /** @return reason why transport stopped */
@@ -148,6 +156,16 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
   /** @return defensive copy of component-by-cell mass fractions */
   public double[][] getMassFractionProfile() {
     return copy(massFractionProfile);
+  }
+
+  /** @return defensive copy of final total inventory by physical finite-volume cell in kg */
+  public double[] getFinalCellInventoryKg() {
+    return copy(finalCellInventoryKg);
+  }
+
+  /** @return defensive copy of final component-by-cell inventories in kg */
+  public double[][] getFinalComponentCellInventoryKg() {
+    return copy(finalComponentCellInventoryKg);
   }
 
   /** @return defensive copy of previous-time component inventories in kg */
@@ -250,8 +268,8 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
     }
     String updatedMessage = message + " Thermodynamic mass-fraction synchronization error=" + maximumError
         + " (tolerance " + tolerance + ").";
-    return new OnePhaseSpeciesConservationReport(updatedReason, componentNames, massFractionProfile, initialInventoryKg,
-        finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
+    return new OnePhaseSpeciesConservationReport(updatedReason, componentNames, massFractionProfile, finalCellInventoryKg,
+        initialInventoryKg, finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
         maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
         maximumError, couplingIterations, maximumMassFractionChangeHistory, densityResidualHistory,
         transportDiagnostics, updatedMessage);
@@ -260,19 +278,38 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
   OnePhaseSpeciesConservationReport withCouplingDiagnostics(int iterations, double[] massFractionChangeHistory,
       double[] eosDensityResidualHistory) {
     String updatedMessage = message + " Hydraulic/species fixed point iterations=" + iterations + ".";
-    return new OnePhaseSpeciesConservationReport(reason, componentNames, massFractionProfile, initialInventoryKg,
-        finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
+    return new OnePhaseSpeciesConservationReport(reason, componentNames, massFractionProfile, finalCellInventoryKg,
+        initialInventoryKg, finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
         maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
         maximumThermodynamicMassFractionError, iterations, massFractionChangeHistory, eosDensityResidualHistory,
         transportDiagnostics, updatedMessage);
   }
 
   OnePhaseSpeciesConservationReport withReason(ConservationReason updatedReason, String updatedMessage) {
-    return new OnePhaseSpeciesConservationReport(updatedReason, componentNames, massFractionProfile, initialInventoryKg,
-        finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
+    return new OnePhaseSpeciesConservationReport(updatedReason, componentNames, massFractionProfile, finalCellInventoryKg,
+        initialInventoryKg, finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
         maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
         maximumThermodynamicMassFractionError, couplingIterations, maximumMassFractionChangeHistory,
         densityResidualHistory, transportDiagnostics, updatedMessage);
+  }
+
+  private static double[][] componentCellInventory(double[][] massFractionProfile,
+      double[] finalCellInventoryKg) {
+    if (massFractionProfile.length == 0 || finalCellInventoryKg.length == 0) {
+      return new double[0][0];
+    }
+    double[][] inventory = new double[massFractionProfile.length][finalCellInventoryKg.length];
+    for (int component = 0; component < massFractionProfile.length; component++) {
+      if (massFractionProfile[component].length != finalCellInventoryKg.length) {
+        throw new IllegalArgumentException(
+            "Mass-fraction and cell-inventory profiles must have identical physical-cell dimensions.");
+      }
+      for (int cell = 0; cell < finalCellInventoryKg.length; cell++) {
+        inventory[component][cell] =
+            massFractionProfile[component][cell] * finalCellInventoryKg[cell];
+      }
+    }
+    return inventory;
   }
 
   private static double[] copy(double[] values) {

--- a/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseSpeciesConservationReport.java
+++ b/src/main/java/neqsim/fluidmechanics/flowsolver/onephaseflowsolver/onephasepipeflowsolver/OnePhaseSpeciesConservationReport.java
@@ -98,15 +98,13 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
       double[] finalInventoryKg, double[] inletBoundaryMassKg, double[] outletBoundaryMassKg,
       double[] inventoryResidualKg, double[] relativeInventoryResidual, double maximumRelativeInventoryResidual,
       double minimumMassFraction, double maximumMassFraction, double maximumMassFractionSumError,
-      double maximumThermodynamicMassFractionError, int couplingIterations,
-      double[] maximumMassFractionChangeHistory, double[] densityResidualHistory,
-      SpeciesTransportDiagnostics transportDiagnostics, String message) {
+      double maximumThermodynamicMassFractionError, int couplingIterations, double[] maximumMassFractionChangeHistory,
+      double[] densityResidualHistory, SpeciesTransportDiagnostics transportDiagnostics, String message) {
     this.reason = reason;
     this.componentNames = copy(componentNames);
     this.massFractionProfile = copy(massFractionProfile);
     this.finalCellInventoryKg = copy(finalCellInventoryKg);
-    this.finalComponentCellInventoryKg =
-        componentCellInventory(this.massFractionProfile, this.finalCellInventoryKg);
+    this.finalComponentCellInventoryKg = componentCellInventory(this.massFractionProfile, this.finalCellInventoryKg);
     this.initialInventoryKg = copy(initialInventoryKg);
     this.finalInventoryKg = copy(finalInventoryKg);
     this.inletBoundaryMassKg = copy(inletBoundaryMassKg);
@@ -134,8 +132,7 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
   public static OnePhaseSpeciesConservationReport notRun() {
     return new OnePhaseSpeciesConservationReport(ConservationReason.NOT_RUN, new String[0], new double[0][0],
         new double[0], new double[0], new double[0], new double[0], new double[0], new double[0], new double[0],
-        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
-        "Conservative species transport has not run.");
+        Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, "Conservative species transport has not run.");
   }
 
   /** @return reason why transport stopped */
@@ -268,33 +265,32 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
     }
     String updatedMessage = message + " Thermodynamic mass-fraction synchronization error=" + maximumError
         + " (tolerance " + tolerance + ").";
-    return new OnePhaseSpeciesConservationReport(updatedReason, componentNames, massFractionProfile, finalCellInventoryKg,
-        initialInventoryKg, finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
-        maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
-        maximumError, couplingIterations, maximumMassFractionChangeHistory, densityResidualHistory,
-        transportDiagnostics, updatedMessage);
+    return new OnePhaseSpeciesConservationReport(updatedReason, componentNames, massFractionProfile,
+        finalCellInventoryKg, initialInventoryKg, finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg,
+        inventoryResidualKg, relativeInventoryResidual, maximumRelativeInventoryResidual, minimumMassFraction,
+        maximumMassFraction, maximumMassFractionSumError, maximumError, couplingIterations,
+        maximumMassFractionChangeHistory, densityResidualHistory, transportDiagnostics, updatedMessage);
   }
 
   OnePhaseSpeciesConservationReport withCouplingDiagnostics(int iterations, double[] massFractionChangeHistory,
       double[] eosDensityResidualHistory) {
     String updatedMessage = message + " Hydraulic/species fixed point iterations=" + iterations + ".";
     return new OnePhaseSpeciesConservationReport(reason, componentNames, massFractionProfile, finalCellInventoryKg,
-        initialInventoryKg, finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
-        maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
-        maximumThermodynamicMassFractionError, iterations, massFractionChangeHistory, eosDensityResidualHistory,
-        transportDiagnostics, updatedMessage);
+        initialInventoryKg, finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg,
+        relativeInventoryResidual, maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction,
+        maximumMassFractionSumError, maximumThermodynamicMassFractionError, iterations, massFractionChangeHistory,
+        eosDensityResidualHistory, transportDiagnostics, updatedMessage);
   }
 
   OnePhaseSpeciesConservationReport withReason(ConservationReason updatedReason, String updatedMessage) {
-    return new OnePhaseSpeciesConservationReport(updatedReason, componentNames, massFractionProfile, finalCellInventoryKg,
-        initialInventoryKg, finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg, inventoryResidualKg, relativeInventoryResidual,
-        maximumRelativeInventoryResidual, minimumMassFraction, maximumMassFraction, maximumMassFractionSumError,
-        maximumThermodynamicMassFractionError, couplingIterations, maximumMassFractionChangeHistory,
-        densityResidualHistory, transportDiagnostics, updatedMessage);
+    return new OnePhaseSpeciesConservationReport(updatedReason, componentNames, massFractionProfile,
+        finalCellInventoryKg, initialInventoryKg, finalInventoryKg, inletBoundaryMassKg, outletBoundaryMassKg,
+        inventoryResidualKg, relativeInventoryResidual, maximumRelativeInventoryResidual, minimumMassFraction,
+        maximumMassFraction, maximumMassFractionSumError, maximumThermodynamicMassFractionError, couplingIterations,
+        maximumMassFractionChangeHistory, densityResidualHistory, transportDiagnostics, updatedMessage);
   }
 
-  private static double[][] componentCellInventory(double[][] massFractionProfile,
-      double[] finalCellInventoryKg) {
+  private static double[][] componentCellInventory(double[][] massFractionProfile, double[] finalCellInventoryKg) {
     if (massFractionProfile.length == 0 || finalCellInventoryKg.length == 0) {
       return new double[0][0];
     }
@@ -305,8 +301,7 @@ public final class OnePhaseSpeciesConservationReport implements Serializable {
             "Mass-fraction and cell-inventory profiles must have identical physical-cell dimensions.");
       }
       for (int cell = 0; cell < finalCellInventoryKg.length; cell++) {
-        inventory[component][cell] =
-            massFractionProfile[component][cell] * finalCellInventoryKg[cell];
+        inventory[component][cell] = massFractionProfile[component][cell] * finalCellInventoryKg[cell];
       }
     }
     return inventory;

--- a/src/main/java/neqsim/process/equipment/pipeline/OnePhasePipeLine.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/OnePhasePipeLine.java
@@ -294,6 +294,43 @@ public class OnePhasePipeLine extends Pipeline {
   }
 
   /**
+   * Get the authoritative final total inventory for every physical finite-volume cell.
+   *
+   * @return defensive copy of total cell inventories in kg, in inlet-to-outlet order
+   * @throws IllegalStateException if conservative species transport has not run
+   */
+  public double[] getConservativeCellInventoryKg() {
+    double[] inventory = getSpeciesConservationReport().getFinalCellInventoryKg();
+    if (inventory.length == 0) {
+      throw new IllegalStateException("Conservative species transport has not produced a cell inventory profile.");
+    }
+    return inventory;
+  }
+
+  /**
+   * Get the authoritative final inventory profile for one component.
+   *
+   * @param componentName component name, matched case-insensitively
+   * @return defensive copy of component inventory in kg by physical finite-volume cell
+   * @throws IllegalStateException if conservative species transport has not run
+   * @throws IllegalArgumentException if the component is absent from the report
+   */
+  public double[] getConservativeComponentInventoryProfileKg(String componentName) {
+    OnePhaseSpeciesConservationReport report = getSpeciesConservationReport();
+    String[] componentNames = report.getComponentNames();
+    if (componentNames.length == 0) {
+      throw new IllegalStateException("Conservative species transport has not produced a component profile.");
+    }
+    double[][] profiles = report.getFinalComponentCellInventoryKg();
+    for (int component = 0; component < componentNames.length; component++) {
+      if (componentNames[component].equalsIgnoreCase(componentName)) {
+        return profiles[component];
+      }
+    }
+    throw new IllegalArgumentException("Component is absent from conservative species report: " + componentName);
+  }
+
+  /**
    * Get the authoritative conservative outlet-cell mass fraction for one component.
    *
    * @param componentName component name, matched case-insensitively

--- a/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -160,12 +162,16 @@ public class OnePhasePipeLineCompositionalTest {
     String reportJson = latest.toJson();
     assertTrue(reportJson.contains("\"finalCellInventoryKg\""));
     assertTrue(reportJson.contains("\"finalComponentCellInventoryKg\""));
-    OnePhaseSpeciesConservationReport restored = new Gson().fromJson(reportJson,
-        OnePhaseSpeciesConservationReport.class);
-    assertArrayEquals(latest.getFinalCellInventoryKg(), restored.getFinalCellInventoryKg(), 0.0);
+    Gson gson = new Gson();
+    JsonObject reportJsonObject = JsonParser.parseString(reportJson).getAsJsonObject();
+    double[] restoredCellInventory =
+        gson.fromJson(reportJsonObject.get("finalCellInventoryKg"), double[].class);
+    double[][] restoredComponentCellInventory =
+        gson.fromJson(reportJsonObject.get("finalComponentCellInventoryKg"), double[][].class);
+    assertArrayEquals(latest.getFinalCellInventoryKg(), restoredCellInventory, 0.0);
     for (int component = 0; component < latest.getComponentNames().length; component++) {
       assertArrayEquals(latest.getFinalComponentCellInventoryKg()[component],
-          restored.getFinalComponentCellInventoryKg()[component], 0.0);
+          restoredComponentCellInventory[component], 0.0);
     }
     assertTrue(history.toJson().contains("\"elapsedTimeSeconds\""));
   }

--- a/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
@@ -164,14 +164,13 @@ public class OnePhasePipeLineCompositionalTest {
     assertTrue(reportJson.contains("\"finalComponentCellInventoryKg\""));
     Gson gson = new Gson();
     JsonObject reportJsonObject = JsonParser.parseString(reportJson).getAsJsonObject();
-    double[] restoredCellInventory =
-        gson.fromJson(reportJsonObject.get("finalCellInventoryKg"), double[].class);
-    double[][] restoredComponentCellInventory =
-        gson.fromJson(reportJsonObject.get("finalComponentCellInventoryKg"), double[][].class);
+    double[] restoredCellInventory = gson.fromJson(reportJsonObject.get("finalCellInventoryKg"), double[].class);
+    double[][] restoredComponentCellInventory = gson.fromJson(reportJsonObject.get("finalComponentCellInventoryKg"),
+        double[][].class);
     assertArrayEquals(latest.getFinalCellInventoryKg(), restoredCellInventory, 0.0);
     for (int component = 0; component < latest.getComponentNames().length; component++) {
-      assertArrayEquals(latest.getFinalComponentCellInventoryKg()[component],
-          restoredComponentCellInventory[component], 0.0);
+      assertArrayEquals(latest.getFinalComponentCellInventoryKg()[component], restoredComponentCellInventory[component],
+          0.0);
     }
     assertTrue(history.toJson().contains("\"elapsedTimeSeconds\""));
   }

--- a/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
@@ -160,8 +160,8 @@ public class OnePhasePipeLineCompositionalTest {
     String reportJson = latest.toJson();
     assertTrue(reportJson.contains("\"finalCellInventoryKg\""));
     assertTrue(reportJson.contains("\"finalComponentCellInventoryKg\""));
-    OnePhaseSpeciesConservationReport restored =
-        new Gson().fromJson(reportJson, OnePhaseSpeciesConservationReport.class);
+    OnePhaseSpeciesConservationReport restored = new Gson().fromJson(reportJson,
+        OnePhaseSpeciesConservationReport.class);
     assertArrayEquals(latest.getFinalCellInventoryKg(), restored.getFinalCellInventoryKg(), 0.0);
     for (int component = 0; component < latest.getComponentNames().length; component++) {
       assertArrayEquals(latest.getFinalComponentCellInventoryKg()[component],
@@ -709,8 +709,8 @@ public class OnePhasePipeLineCompositionalTest {
         assertTrue(Double.isFinite(componentCellInventoryKg[component][cell]));
         assertTrue(componentCellInventoryKg[component][cell] >= 0.0);
         componentSumKg += componentCellInventoryKg[component][cell];
-        assertEquals(massFraction[component][cell],
-            componentCellInventoryKg[component][cell] / cellInventoryKg[cell], 1.0e-12);
+        assertEquals(massFraction[component][cell], componentCellInventoryKg[component][cell] / cellInventoryKg[cell],
+            1.0e-12);
       }
       assertEquals(cellInventoryKg[cell], componentSumKg, Math.max(cellInventoryKg[cell], 1.0) * 1.0e-12);
     }

--- a/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/OnePhasePipeLineCompositionalTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.google.gson.Gson;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -140,6 +141,32 @@ public class OnePhasePipeLineCompositionalTest {
     int nitrogen = componentIndex(latest, "nitrogen");
     assertArrayEquals(latest.getMassFractionProfile()[nitrogen], pipe.getConservativeMassFractionProfile("nitrogen"),
         0.0);
+    assertLocalInventoryInvariants(latest);
+    assertArrayEquals(latest.getFinalCellInventoryKg(), pipe.getConservativeCellInventoryKg(), 0.0);
+    assertArrayEquals(latest.getFinalComponentCellInventoryKg()[nitrogen],
+        pipe.getConservativeComponentInventoryProfileKg("NITROGEN"), 0.0);
+    assertEquals(pipe.getConvergenceReport().getFinalFiniteVolumeMassKg(), sum(latest.getFinalCellInventoryKg()),
+        Math.max(pipe.getConvergenceReport().getFinalFiniteVolumeMassKg(), 1.0) * 1.0e-8);
+
+    double[] cellInventoryCopy = latest.getFinalCellInventoryKg();
+    double originalFirstCellInventory = cellInventoryCopy[0];
+    cellInventoryCopy[0] = -1.0;
+    assertEquals(originalFirstCellInventory, latest.getFinalCellInventoryKg()[0], 0.0);
+    double[][] componentInventoryCopy = latest.getFinalComponentCellInventoryKg();
+    double originalFirstComponentInventory = componentInventoryCopy[0][0];
+    componentInventoryCopy[0][0] = -1.0;
+    assertEquals(originalFirstComponentInventory, latest.getFinalComponentCellInventoryKg()[0][0], 0.0);
+
+    String reportJson = latest.toJson();
+    assertTrue(reportJson.contains("\"finalCellInventoryKg\""));
+    assertTrue(reportJson.contains("\"finalComponentCellInventoryKg\""));
+    OnePhaseSpeciesConservationReport restored =
+        new Gson().fromJson(reportJson, OnePhaseSpeciesConservationReport.class);
+    assertArrayEquals(latest.getFinalCellInventoryKg(), restored.getFinalCellInventoryKg(), 0.0);
+    for (int component = 0; component < latest.getComponentNames().length; component++) {
+      assertArrayEquals(latest.getFinalComponentCellInventoryKg()[component],
+          restored.getFinalComponentCellInventoryKg()[component], 0.0);
+    }
     assertTrue(history.toJson().contains("\"elapsedTimeSeconds\""));
   }
 
@@ -256,15 +283,24 @@ public class OnePhasePipeLineCompositionalTest {
     OnePhasePipeLine deterministicPipe = runCoupledEvent(60.0);
     OnePhaseSpeciesConservationReport deterministicReport = deterministicPipe.getSpeciesConservationReport();
     assertArrayEquals(finalReport.getFinalInventoryKg(), deterministicReport.getFinalInventoryKg(), 1.0e-12);
+    assertArrayEquals(finalReport.getFinalCellInventoryKg(), deterministicReport.getFinalCellInventoryKg(), 0.0);
+    assertLocalInventoryInvariants(deterministicReport);
     for (int component = 0; component < finalReport.getComponentNames().length; component++) {
       assertArrayEquals(finalReport.getMassFractionProfile()[component],
           deterministicReport.getMassFractionProfile()[component], 1.0e-12);
+      assertArrayEquals(finalReport.getFinalComponentCellInventoryKg()[component],
+          deterministicReport.getFinalComponentCellInventoryKg()[component], 0.0);
     }
     assertArrayEquals(pipe.getPressureProfile("bara"), deterministicPipe.getPressureProfile("bara"), 1.0e-12);
     assertArrayEquals(pipe.getVelocityProfile(), deterministicPipe.getVelocityProfile(), 1.0e-12);
 
     OnePhasePipeLine halfTimeStepPipe = runCoupledEvent(30.0);
     OnePhaseSpeciesConservationHistory halfTimeStepHistory = halfTimeStepPipe.getSpeciesConservationHistory();
+    OnePhaseSpeciesConservationReport halfTimeStepReport = halfTimeStepPipe.getSpeciesConservationReport();
+    assertLocalInventoryInvariants(halfTimeStepReport);
+    assertEquals(halfTimeStepPipe.getConvergenceReport().getFinalFiniteVolumeMassKg(),
+        sum(halfTimeStepReport.getFinalCellInventoryKg()),
+        Math.max(halfTimeStepPipe.getConvergenceReport().getFinalFiniteVolumeMassKg(), 1.0) * 1.0e-8);
     double halfTimeStepPulseOutlet = last(halfTimeStepHistory.getReport(59).getMassFractionProfile()[nitrogen]);
     assertEquals(pulseOutlet, halfTimeStepPulseOutlet, 1.0e-3,
         "Halving the timestep must not materially change pulse breakthrough.");
@@ -655,6 +691,34 @@ public class OnePhasePipeLineCompositionalTest {
     assertTrue(report.getMinimumMassFraction() >= 0.0, report.getMessage());
     assertTrue(report.getMaximumMassFraction() <= 1.0, report.getMessage());
     assertTrue(report.getMaximumMassFractionSumError() <= 1.0e-12, report.getMessage());
+  }
+
+  private static void assertLocalInventoryInvariants(OnePhaseSpeciesConservationReport report) {
+    double[] cellInventoryKg = report.getFinalCellInventoryKg();
+    double[][] componentCellInventoryKg = report.getFinalComponentCellInventoryKg();
+    double[][] massFraction = report.getMassFractionProfile();
+    assertTrue(cellInventoryKg.length > 0);
+    assertEquals(report.getComponentNames().length, componentCellInventoryKg.length);
+    assertEquals(report.getComponentNames().length, massFraction.length);
+
+    for (int cell = 0; cell < cellInventoryKg.length; cell++) {
+      assertTrue(Double.isFinite(cellInventoryKg[cell]) && cellInventoryKg[cell] > 0.0);
+      double componentSumKg = 0.0;
+      for (int component = 0; component < componentCellInventoryKg.length; component++) {
+        assertEquals(cellInventoryKg.length, componentCellInventoryKg[component].length);
+        assertTrue(Double.isFinite(componentCellInventoryKg[component][cell]));
+        assertTrue(componentCellInventoryKg[component][cell] >= 0.0);
+        componentSumKg += componentCellInventoryKg[component][cell];
+        assertEquals(massFraction[component][cell],
+            componentCellInventoryKg[component][cell] / cellInventoryKg[cell], 1.0e-12);
+      }
+      assertEquals(cellInventoryKg[cell], componentSumKg, Math.max(cellInventoryKg[cell], 1.0) * 1.0e-12);
+    }
+
+    for (int component = 0; component < componentCellInventoryKg.length; component++) {
+      assertEquals(report.getFinalInventoryKg()[component], sum(componentCellInventoryKg[component]),
+          Math.max(report.getFinalInventoryKg()[component], 1.0) * 1.0e-12);
+    }
   }
 
   private static void assertPositiveFiniteState(OnePhasePipeLine pipe) {


### PR DESCRIPTION
## Roadmap

Advances #2935 Stage 2/6 as the one-phase Dynamic Tracking lane. It does not change the shared #2911 transient engine or #2907 multiphase closures.

## Engineering question

Can Java and Python/JPype consumers inspect the accepted conservative one-phase linepack in every physical finite-volume cell, with quantitative identities tying local component inventory to the existing global component and hydraulic inventories?

## Current-master baseline

Base: `802d1729a40e790e6ab3020c13dd93ae8e67f13e`.

The merged solver already makes `newCellMassKg` authoritative for hydraulic finite-volume mass and retains component mass-fraction profiles plus global component inventories. It did not expose the accepted total mass per cell or the corresponding component-by-cell inventory.

## Coherent capability

- retains the accepted hydraulic `newCellMassKg` in `OnePhaseSpeciesConservationReport`;
- derives component-cell inventory as authoritative cell total × conservative mass fraction, without EOS reconstruction, normalization or clipping;
- exposes defensive-copy report getters and `OnePhasePipeLine` convenience accessors by component name;
- serializes `finalCellInventoryKg` and `finalComponentCellInventoryKg` in stable report JSON;
- documents kg units, physical-cell ordering, boundary-node exclusion and opt-in history memory cost.

## Quantitative acceptance evidence

Focused regressions require:

- every total cell inventory is positive and finite;
- every component-cell inventory is finite and non-negative;
- component sums reproduce each cell total within `1e-12` relative;
- component-cell sums reproduce each global final component inventory within `1e-12` relative;
- component/cell-total ratios reproduce the reported mass fractions within `1e-12`;
- the total cell sum matches the hydraulic report's final finite-volume mass within the existing `1e-8` relative contract;
- array getters are defensive and JSON round-trips preserve both matrices exactly;
- repeated 60 s runs preserve local arrays exactly, while the existing 60/30 s timestep sensitivity gates remain active;
- the public component-name API is case-insensitive and Python/JPype-ready.

## Scope boundary

No transport equation, flux, EOS, pressure-flow coupling, timestep, tolerance, history-retention default or failure policy changes. This does not add dynamic energy, phase appearance, zero/reversed flow, multiphase transport, slugging, or #2911 transaction/checkpoint semantics. It is diagnostic evidence, not accountable safety approval.

## Validation complete

Exact head: `ed6f061eff4461be91f4af0d1ea73128419c26e4`.

The previous Windows Java 21 failure was branch-attributable test code, not solver behavior: bare Gson could not deserialize intentionally serialized non-finite primitive diagnostics represented as JSON `null`. The repaired regression now parses and round-trips the two new finite inventory fields directly, preserving the intended JSON contract without changing production code, equations, public APIs or tolerances.

Completed on this exact head:

- Spotless format patch is empty;
- pre-commit and documentation search pass;
- PaperLab and CodeQL pass;
- Java 21 Javadocs, Ubuntu/Windows fast suites and all four slow-test shards pass;
- repository agent/skill checks pass;
- the final diff remains exactly five intended pipeline/test/documentation files;
- no reviews or unresolved threads exist.

- Java 8 Ubuntu and Windows test suites pass.

Local Maven, Spotless, pre-commit and documentation checks were not run and are not claimed as passed. Hosted exact-head CI is the validation authority.

Current `master` is five commits ahead, but those commits affect splitter, compressor/pump/recycle, optimizer and flash files only. The PR remains mergeable with no overlapping file changes; no rebase-only churn was introduced.

## Next dependency

After merge and ledger reconciliation, #2935 can use these local inventories for the next authoritative Java/Python/Colab linepack and breakthrough evidence slice without duplicating #2911 orchestration or #2907 multiphase physics.