### PR TITLE
fix(splitter): normalize runtime split factors proportionally

### DIFF
--- a/src/main/java/neqsim/process/equipment/splitter/Splitter.java
+++ b/src/main/java/neqsim/process/equipment/splitter/Splitter.java
@@ -381,10 +381,11 @@ public class Splitter extends ProcessEquipmentBaseClass implements SplitterInter
       }
       totSplit += splitFactor[i];
     }
-    if (Math.abs(totSplit - 1.0) > 1e-10) {
-      logger.debug("total split factor different from 0 in splitter - totsplit = " + totSplit);
-      logger.debug("setting first split to = " + (1.0 - totSplit));
-      splitFactor[0] = 1.0 - totSplit;
+    if (Math.abs(totSplit - 1.0) > 1e-10 && totSplit > 0.0) {
+      logger.debug("total split factor different from 1.0 in splitter - totsplit = " + totSplit);
+      for (int i = 0; i < splitNumber; i++) {
+        splitFactor[i] /= totSplit;
+      }
     }
 
     for (int i = 0; i < splitNumber; i++) {

--- a/src/main/java/neqsim/process/equipment/splitter/Splitter.java
+++ b/src/main/java/neqsim/process/equipment/splitter/Splitter.java
@@ -381,7 +381,11 @@ public class Splitter extends ProcessEquipmentBaseClass implements SplitterInter
       }
       totSplit += splitFactor[i];
     }
-    if (Math.abs(totSplit - 1.0) > 1e-10 && totSplit > 0.0) {
+    if (!Double.isFinite(totSplit) || totSplit <= 0.0) {
+      logger.debug("total split factor is not positive and finite in splitter - totsplit = " + totSplit);
+      Arrays.fill(splitFactor, 0.0);
+      splitFactor[0] = 1.0;
+    } else if (Math.abs(totSplit - 1.0) > 1e-10) {
       logger.debug("total split factor different from 1.0 in splitter - totsplit = " + totSplit);
       for (int i = 0; i < splitNumber; i++) {
         splitFactor[i] /= totSplit;

--- a/src/test/java/neqsim/process/equipment/splitter/SplitterTest.java
+++ b/src/test/java/neqsim/process/equipment/splitter/SplitterTest.java
@@ -75,6 +75,24 @@ class SplitterTest {
   }
 
   @Test
+  void testRunRenormalizesExternallyMutatedSplitFactors() {
+    Splitter splitter = new Splitter("splitter", inletStream, 2);
+    splitter.setSplitFactors(new double[] { 0.6, 0.4 });
+
+    double[] splitFactors = splitter.getSplitFactors();
+    splitFactors[0] = 0.9;
+    splitFactors[1] = 0.6;
+    splitter.run();
+
+    assertEquals(0.6, splitter.getSplitFactor(0), 1e-10);
+    assertEquals(0.4, splitter.getSplitFactor(1), 1e-10);
+    double inletMoles = inletStream.getThermoSystem().getTotalNumberOfMoles();
+    double outletMoles = splitter.getSplitStream(0).getThermoSystem().getTotalNumberOfMoles()
+        + splitter.getSplitStream(1).getThermoSystem().getTotalNumberOfMoles();
+    assertEquals(inletMoles, outletMoles, inletMoles * 1e-4);
+  }
+
+  @Test
   void testNegativeSplitFactorsClampedToZero() {
     Splitter splitter = new Splitter("splitter", inletStream, 2);
     splitter.setSplitFactors(new double[] { -0.5, 1.5 });

--- a/src/test/java/neqsim/process/equipment/splitter/SplitterTest.java
+++ b/src/test/java/neqsim/process/equipment/splitter/SplitterTest.java
@@ -93,6 +93,20 @@ class SplitterTest {
   }
 
   @Test
+  void testRunHandlesZeroTotalSplitFactors() {
+    Splitter splitter = new Splitter("splitter", inletStream, 2);
+    splitter.setSplitFactors(new double[] { 0.0, 0.0 });
+    splitter.run();
+
+    assertEquals(1.0, splitter.getSplitFactor(0), 1e-10);
+    assertEquals(0.0, splitter.getSplitFactor(1), 1e-10);
+    double inletMoles = inletStream.getThermoSystem().getTotalNumberOfMoles();
+    double outletMoles = splitter.getSplitStream(0).getThermoSystem().getTotalNumberOfMoles()
+        + splitter.getSplitStream(1).getThermoSystem().getTotalNumberOfMoles();
+    assertEquals(inletMoles, outletMoles, inletMoles * 1e-4);
+  }
+
+  @Test
   void testNegativeSplitFactorsClampedToZero() {
     Splitter splitter = new Splitter("splitter", inletStream, 2);
     splitter.setSplitFactors(new double[] { -0.5, 1.5 });


### PR DESCRIPTION
## Summary

- normalize non-negative runtime split factors proportionally when they no longer sum to one
- preserve the configured outlet ratio and mass balance instead of making outlet 0 negative
- add regressions for factors mutated through the live array returned by `getSplitFactors()` and for a zero/non-finite total

This extracts the valid part of #2952 and credits @slava98981212 for identifying the unsafe runtime correction.

## Validity review of #2952

The runtime normalization defect is real: after `getSplitFactors()` exposes the internal array, factors `[0.9, 0.6]` reach `run()` with a total of 1.5. The existing correction sets outlet 0 to `1.0 - 1.5 = -0.5`, which is neither normalized nor mass conserving. Proportional normalization produces `[0.6, 0.4]`. A non-positive or non-finite total now preserves the existing deterministic fallback by clearing the factors and routing the inlet to outlet 0, avoiding NaN propagation and mass loss.

The proposed multiphase mole change from #2952 is deliberately excluded. `Component#getNumberOfmoles()` is the component total for the whole thermodynamic system, not the inventory of one phase. Summing that value over phases double-counts or triple-counts the same component and creates mass.

## Validation

Exact head: `370aff0846758fd9228b154dc2e34e08dac929fe`.

- hosted Spotless format patch: passed
- hosted pre-commit checks: passed
- CodeQL Security Analysis: passed
- PaperLab Replication Gate: passed
- Java 21 Javadocs: passed
- Java 21 Ubuntu and Windows fast suites: passed
- all four Java 21 slow-test shards: passed
- Java 8 Ubuntu and Windows suites: passed
- agent/skill cross-reference checks: passed
- focused regressions verify proportional normalization, deterministic zero-total fallback, and inlet/outlet mole conservation
- final diff is limited to `Splitter.java` and `SplitterTest.java`
- no reviews or unresolved inline threads exist

The branch is mergeable. It is four commits behind current `master`, but the intervening commits do not touch the splitter files and GitHub reports no conflict.

Local Maven/JUnit and Spotless could not run because the sandbox could not resolve Maven Central and the offline cache was incomplete. Exact-head hosted CI is the validation authority.

## Documentation impact

None. The public setter already documents and performs factor normalization; this change makes the runtime safety guard preserve that behavior after the exposed array is mutated.