### PR TITLE
perf(process): revert unqualified init-level changes

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -975,7 +975,7 @@ public class Compressor extends TwoPortEquipment
       getThermoSystem().setTemperature(bestTemperature);
       thermoOps.TPflash();
     }
-    getThermoSystem().init(2);
+    getThermoSystem().init(3);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -520,7 +520,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
     if (inStream.getFlowRate("kg/hr") < minimumFlow) {
       thermoSystem = inStream.getThermoSystem().clone();
       thermoSystem.setPressure(pressure, pressureUnit);
-      thermoSystem.init(2);
+      thermoSystem.init(3);
       dH = 0.0;
       if (!isSetEnergyStream()) {
         getEnergyPort("shaftPower").setDuty(0.0);
@@ -537,7 +537,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
       logger.warn("Pump " + getName() + " may be operating in cavitation conditions");
     }
 
-    inStream.getThermoSystem().init(2);
+    inStream.getThermoSystem().init(3);
     double hinn = inStream.getThermoSystem().getEnthalpy();
     double entropy = inStream.getThermoSystem().getEntropy();
 

--- a/src/main/java/neqsim/process/equipment/util/Recycle.java
+++ b/src/main/java/neqsim/process/equipment/util/Recycle.java
@@ -362,7 +362,7 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
   public double calcMixStreamEnthalpy() {
     double enthalpy = 0;
     for (int k = 0; k < streams.size(); k++) {
-      streams.get(k).getThermoSystem().init(2);
+      streams.get(k).getThermoSystem().init(3);
       enthalpy += streams.get(k).getThermoSystem().getEnthalpy();
       // logger.info("total enthalpy k : " + ( ((Stream)
       // streams.get(k)).getThermoSystem()).getEnthalpy());

--- a/src/test/java/neqsim/process/equipment/EquipmentRunInitializationLevelTest.java
+++ b/src/test/java/neqsim/process/equipment/EquipmentRunInitializationLevelTest.java
@@ -3,7 +3,6 @@ package neqsim.process.equipment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
-import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.util.Recycle;
@@ -57,22 +56,6 @@ class EquipmentRunInitializationLevelTest {
   }
 
   @Test
-  void compressorRetainsDerivativeWarmStateBeforeFollowingFlashes() {
-    InitTrackingSystemSrkEos fluid = createGas(298.15, 70.0);
-    Stream feed = new Stream("compressor feed", fluid);
-    feed.setFlowRate(50000.0, "kg/hr");
-    feed.run();
-
-    Compressor compressor = new Compressor("compressor", feed);
-    compressor.setOutletPressure(110.0);
-    fluid.resetFirstInitLevel();
-    compressor.run();
-
-    assertEquals(3, fluid.getFirstInitLevel(),
-        "Compressor inlet derivative state must not be discarded without end-to-end evidence");
-  }
-
-  @Test
   void pumpRetainsDerivativeWarmStateBeforeFollowingFlashes() {
     InitTrackingSystemSrkEos fluid = new InitTrackingSystemSrkEos(303.15, 3.0);
     fluid.addComponent("n-pentane", 0.45);
@@ -90,6 +73,26 @@ class EquipmentRunInitializationLevelTest {
 
     assertEquals(3, fluid.getFirstInitLevel(),
         "Pump inlet derivative state must not be discarded without end-to-end evidence");
+  }
+
+  @Test
+  void lowFlowPumpRetainsDerivativeWarmState() {
+    InitTrackingSystemSrkEos fluid = new InitTrackingSystemSrkEos(303.15, 3.0);
+    fluid.addComponent("n-pentane", 0.45);
+    fluid.addComponent("n-hexane", 0.55);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("low-flow pump feed", fluid);
+    feed.setFlowRate(1.0, "kg/hr");
+    feed.run();
+
+    Pump pump = new Pump("low-flow pump", feed);
+    pump.setOutletPressure(18.0);
+    pump.setMinimumFlow(2.0);
+    fluid.resetFirstInitLevel();
+    pump.run();
+
+    assertEquals(3, fluid.getFirstInitLevel(),
+        "Low-flow pump derivative state must not be discarded without end-to-end evidence");
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/EquipmentRunInitializationLevelTest.java
+++ b/src/test/java/neqsim/process/equipment/EquipmentRunInitializationLevelTest.java
@@ -1,0 +1,110 @@
+package neqsim.process.equipment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Guards initialization work whose removal has not demonstrated a representative end-to-end
+ * process benefit.
+ */
+class EquipmentRunInitializationLevelTest {
+  private static final class InitTrackingSystemSrkEos extends SystemSrkEos {
+    private static final long serialVersionUID = 1000L;
+    private AtomicInteger firstInitLevel = new AtomicInteger(-1);
+
+    InitTrackingSystemSrkEos(double temperature, double pressure) {
+      super(temperature, pressure);
+    }
+
+    @Override
+    public InitTrackingSystemSrkEos clone() {
+      InitTrackingSystemSrkEos cloned = (InitTrackingSystemSrkEos) super.clone();
+      cloned.firstInitLevel = firstInitLevel;
+      return cloned;
+    }
+
+    @Override
+    public void init(int initType) {
+      super.init(initType);
+      if (firstInitLevel != null) {
+        firstInitLevel.compareAndSet(-1, initType);
+      }
+    }
+
+    void resetFirstInitLevel() {
+      firstInitLevel.set(-1);
+    }
+
+    int getFirstInitLevel() {
+      return firstInitLevel.get();
+    }
+  }
+
+  private static InitTrackingSystemSrkEos createGas(double temperature, double pressure) {
+    InitTrackingSystemSrkEos fluid = new InitTrackingSystemSrkEos(temperature, pressure);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.12);
+    fluid.addComponent("propane", 0.05);
+    fluid.addComponent("n-heptane", 0.03);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  @Test
+  void compressorRetainsDerivativeWarmStateBeforeFollowingFlashes() {
+    InitTrackingSystemSrkEos fluid = createGas(298.15, 70.0);
+    Stream feed = new Stream("compressor feed", fluid);
+    feed.setFlowRate(50000.0, "kg/hr");
+    feed.run();
+
+    Compressor compressor = new Compressor("compressor", feed);
+    compressor.setOutletPressure(110.0);
+    fluid.resetFirstInitLevel();
+    compressor.run();
+
+    assertEquals(3, fluid.getFirstInitLevel(),
+        "Compressor inlet derivative state must not be discarded without end-to-end evidence");
+  }
+
+  @Test
+  void pumpRetainsDerivativeWarmStateBeforeFollowingFlashes() {
+    InitTrackingSystemSrkEos fluid = new InitTrackingSystemSrkEos(303.15, 3.0);
+    fluid.addComponent("n-pentane", 0.45);
+    fluid.addComponent("n-hexane", 0.55);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("pump feed", fluid);
+    feed.setFlowRate(30000.0, "kg/hr");
+    feed.run();
+
+    Pump pump = new Pump("pump", feed);
+    pump.setOutletPressure(18.0);
+    pump.calculateAsCompressor(false);
+    fluid.resetFirstInitLevel();
+    pump.run();
+
+    assertEquals(3, fluid.getFirstInitLevel(),
+        "Pump inlet derivative state must not be discarded without end-to-end evidence");
+  }
+
+  @Test
+  void recycleRetainsQualifiedEnthalpyInitializationLevel() {
+    InitTrackingSystemSrkEos fluid = createGas(298.15, 70.0);
+    Stream feed = new Stream("recycle feed", fluid);
+    feed.setFlowRate(10000.0, "kg/hr");
+    feed.run();
+
+    Recycle recycle = new Recycle("recycle");
+    recycle.addStream(feed);
+    fluid.resetFirstInitLevel();
+    recycle.calcMixStreamEnthalpy();
+
+    assertEquals(3, fluid.getFirstInitLevel(),
+        "Recycle initialization must remain qualified by representative convergence evidence");
+  }
+}

--- a/src/test/java/neqsim/process/equipment/EquipmentRunInitializationLevelTest.java
+++ b/src/test/java/neqsim/process/equipment/EquipmentRunInitializationLevelTest.java
@@ -9,8 +9,7 @@ import neqsim.process.equipment.util.Recycle;
 import neqsim.thermo.system.SystemSrkEos;
 
 /**
- * Guards initialization work whose removal has not demonstrated a representative end-to-end
- * process benefit.
+ * Guards initialization work whose removal has not demonstrated a representative end-to-end process benefit.
  */
 class EquipmentRunInitializationLevelTest {
   private static final class InitTrackingSystemSrkEos extends SystemSrkEos {

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorTest.java
@@ -610,12 +610,4 @@ class CompressorTest extends neqsim.NeqSimTest {
     logger.info("  Original speed: " + originalSpeed + " RPM");
     logger.info("  Calculated speed: " + comp.getSpeed() + " RPM");
   }
-
-  @Test
-  void testCompressorRunEfficiencyAndPowerWithInit2() {
-    processOps.run();
-    Assertions.assertTrue(compressor1.getPower() > 0.0);
-    Assertions.assertTrue(compressor1.getOutletStream().getTemperature() > temperature_inlet);
-    Assertions.assertEquals(pressure_Out, compressor1.getOutletStream().getPressure(), 1e-4);
-  }
 }


### PR DESCRIPTION
## Summary

Corrective follow-up to #2953 for the process-performance roadmap #2939.

The merged change reduced four `init(3)` calls to `init(2)` in Compressor, Pump, and Recycle. Exact-source representative A/B measurements did not establish a material process-layer benefit for the Compressor or Pump paths and instead showed repeatable regressions. This draft restores the last evidence-qualified behavior and prevents the directly observable Pump/Recycle calls from drifting again without representative evidence.

## Measured evidence

Baseline was the exact pre-#2953 source; candidate was #2953 with only the changed initialization calls.

- Four-stage Pump `ProcessSystem`: 0.669233 vs 0.685810 ms/run; #2953 was 2.48% slower and won 2/7 forks. Reverting restores the 0.669233 ms/run median, 2.42% faster than the merged candidate. Exact checksum: `1015233.43279179`.
- Prior six-stage audit of the same Pump change in #2698: 8.21% wall-time and 8.48% CPU regression; 3/7 fork wins.
- Three-stage SRK compressor train: 18.635178 vs 18.829971 ms/run; #2953 was 1.05% slower. The paired median suggested only about 2.7% apparent gain, below the roadmap materiality gate and inconsistent with the absolute medians.
- Nearby CPA control: differences remained at noise level.
- Recycle kernel-only loop: 18.49% faster, but no representative `ProcessSystem` recycle-convergence result, iteration-count evidence, or nearby-state robustness control was supplied. Roadmap #2939 excludes retaining kernel-only micro-optimizations without process-layer qualification.

These measurements preserve exact numerical checksums; no thermodynamic result change was observed in the measured cases.

## Changes

- restore `init(3)` in the Compressor entropy-fallback completion;
- restore `init(3)` in normal and low-flow Pump execution;
- restore `init(3)` in Recycle enthalpy accumulation;
- remove the #2953 compressor smoke test that asserted only positive power/temperature/pressure and did not discriminate initialization behavior;
- add focused initialization-level guards for normal Pump, low-flow Pump, and Recycle;
- retain the existing multiphase-CPA compressor regression as the behavioral control for the restored private entropy-fallback path.

## Acceptance and compatibility

- focused initialization guards must pass;
- existing `CompressorCPAHangTest`, Pump, and Recycle regressions must pass;
- proportionate full CI must pass on the exact head;
- public APIs, defaults, serialization shape, cloning contract, thread-safety model, mass/energy balances, phase behavior, and convergence algorithms are unchanged;
- final diff contains only the four restored calls and focused tests.

## Validation

**VALIDATION PENDING FULL CI**

Local validation was attempted from exact master `e8991c41163018299c0eacf8fef96e378a8fca72`:

- `git diff --check`: passed.
- `python devtools/check_documentation_search.py`: passed (650 Markdown pages and 1 standalone HTML page).
- `python devtools/run_spotless.py apply`: blocked; the isolated Maven repository does not contain `spotless-maven-plugin:3.9.0`, and the environment could not resolve it from canonical Maven Central.
- `python devtools/run_spotless.py check`: blocked by the same missing plugin.
- focused Maven command for `EquipmentRunInitializationLevelTest,CompressorCPAHangTest,PumpTest,RecycleTest`: not run; offline Maven lacks `maven-enforcer-plugin:3.6.3`.
- `pre-commit`: unavailable.

Hosted exact-head validation at `bcca19e203686814940cd262779ee1632b458594`:

- PaperLab Replication Gate: passed.
- Pre-commit checks: passed.
- Spotless format patch: passed with an empty final patch after the reviewed Javadoc-only correction.
- CodeQL: passed.
- Java 21 Javadoc: passed.
- All four Java 21 slow-test shards: passed.
- Full Java 21 Linux and Windows test jobs: still in progress.

No blocked check is claimed as passing. Hosted exact-head Linux/Windows tests and the full PR workflow are the remaining validators.

## Documentation impact

Documentation impact: none. This restores internal initialization levels that existed before #2953; it does not change a public API, input, output, unit, default, configuration, recommended usage, or documented numerical contract.

## Limitations

This PR restores the pre-#2953 behavior. It does not prevent a future isolated optimization that demonstrates a material representative `ProcessSystem`/`ProcessModel` gain together with nearby-state, CPA, parallel, convergence, and accuracy controls.