### PR TITLE
feat(diagram): retain governed semantic metadata

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -20,6 +20,9 @@ The initial model provides:
 - explicit source/peer sheet and connector references with machine-readable pair identity;
 - controlled revision history, drawing status, issue purpose, source-graph fingerprint, and
   structured validation diagnostics; and
+- immutable canonical semantic-object snapshots retaining source names, carried stream/connection
+  designations, case-scoped calculated values, explicit units, quantity basis, engineering state,
+  approval state, and provenance; and
 - byte-deterministic JSON for equivalent fresh process models.
 
 The initial automatic partition is deliberately conservative. It does not yet choose sheet sizes,
@@ -46,6 +49,17 @@ if (!documents.isValid()) {
 
 String controlledProposalJson = documents.toJson();
 ```
+
+Use the overload with a final operating-case ID after a successful process run to retain governed
+stream results in the same controlled snapshot. Temperature is stored in K, absolute pressure in
+bara, and mass flow in kg/s. Each value remains `CALCULATED` and `REVIEW_REQUIRED`, identifies its
+case and source semantic object, and includes simulation-result provenance. The topology-only
+overloads remain unchanged and do not read live operating values.
+
+Canonical source names and carried connection names are retained as source designations. They are
+not silently promoted to project-approved equipment tags or line numbers. Project-entered tags and
+stream numbers require their own provenance and review state before they can supersede those source
+designations.
 
 The adapter reuses `ProcessDiagramGraphAdapter`. It does not modify the source `ProcessSystem` or
 `ProcessModel`, and it does not change legacy `toDOT()`, `ProcessDiagramExporter`, native DEXPI 2.0,
@@ -74,3 +88,6 @@ Run the focused regression with:
 The regression verifies deterministic single- and multi-area output, immutable collections,
 unchanged Classic DOT output, distinct parallel cross-sheet connections, reciprocal pair
 cardinality, and fail-visible broken references.
+It also verifies immutable semantic snapshots, unit/case/provenance retention, rejection of
+incompletely governed simulation-result values, warning-only diagnostics for pre-existing generic
+calculation graphs, and unchanged topology-only behavior.

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramDocumentSet.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramDocumentSet.java
@@ -307,9 +307,9 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
     }
 
     /**
-     * Returns the optional external source key.
+     * Returns the stable external source key.
      *
-     * @return external source key, or {@code null}
+     * @return external source key
      */
     public String getExternalKey() {
       return externalKey;
@@ -875,8 +875,8 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
         result.add(new Diagnostic(Severity.ERROR, "DIAGRAM_DOCUMENT_DUPLICATE_SEMANTIC_OBJECT_ID",
             "Semantic object identity is not unique in the document set", object.getId()));
       }
-      if (object.getKind() == EngineeringNode.Kind.CALCULATION
-          && object.getProperties().containsKey("resultValue") && !hasGovernedValueMetadata(object)) {
+      if (object.getKind() == EngineeringNode.Kind.CALCULATION && object.getProperties().containsKey("resultValue")
+          && !hasGovernedValueMetadata(object)) {
         Severity severity = hasProvenanceSource(object, "SIMULATION_RESULT") ? Severity.ERROR : Severity.WARNING;
         result.add(new Diagnostic(severity, "DIAGRAM_DOCUMENT_INCOMPLETE_GOVERNED_VALUE",
             "Calculated value is missing unit, case, engineering state, approval state, or provenance",

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramDocumentSet.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramDocumentSet.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Immutable controlled-document view of one canonical {@link EngineeringGraph}.
@@ -176,6 +177,210 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
       result.put("approvedBy", approvedBy);
       result.put("approvalReference", approvalReference);
       return result;
+    }
+  }
+
+  /** Immutable provenance snapshot carried into the controlled document set. */
+  public static final class ProvenanceRecord implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String sourceType;
+    private final String sourceReference;
+    private final String method;
+    private final String designCaseId;
+    private final String approvalStatus;
+    private final List<String> evidenceReferences;
+
+    private ProvenanceRecord(EngineeringProvenance source) {
+      this.sourceType = source.getSourceType();
+      this.sourceReference = source.getSourceReference();
+      this.method = source.getMethod();
+      this.designCaseId = source.getDesignCaseId();
+      this.approvalStatus = source.getApprovalStatus();
+      this.evidenceReferences = Collections.unmodifiableList(new ArrayList<String>(source.getEvidenceReferences()));
+    }
+
+    /**
+     * Returns the provenance source classification.
+     *
+     * @return source classification
+     */
+    public String getSourceType() {
+      return sourceType;
+    }
+
+    /**
+     * Returns the stable source semantic-object reference.
+     *
+     * @return source reference
+     */
+    public String getSourceReference() {
+      return sourceReference;
+    }
+
+    /**
+     * Returns the calculation or inference method.
+     *
+     * @return method name
+     */
+    public String getMethod() {
+      return method;
+    }
+
+    /**
+     * Returns the operating or design case identity.
+     *
+     * @return case identity
+     */
+    public String getDesignCaseId() {
+      return designCaseId;
+    }
+
+    /**
+     * Returns the approval state carried by the provenance record.
+     *
+     * @return approval state
+     */
+    public String getApprovalStatus() {
+      return approvalStatus;
+    }
+
+    /**
+     * Returns immutable supporting evidence references.
+     *
+     * @return evidence references
+     */
+    public List<String> getEvidenceReferences() {
+      return evidenceReferences;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("sourceType", sourceType);
+      result.put("sourceReference", sourceReference);
+      result.put("method", method);
+      result.put("designCaseId", designCaseId);
+      result.put("approvalStatus", approvalStatus);
+      result.put("evidenceReferences", evidenceReferences);
+      return result;
+    }
+  }
+
+  /** Immutable governed view of one canonical semantic object. */
+  public static final class SemanticObject implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String id;
+    private final EngineeringNode.Kind kind;
+    private final String externalKey;
+    private final String label;
+    private final Map<String, Object> properties;
+    private final List<ProvenanceRecord> provenance;
+
+    private SemanticObject(EngineeringNode source) {
+      this.id = source.getId();
+      this.kind = source.getKind();
+      this.externalKey = source.getExternalKey();
+      this.label = source.getLabel();
+      this.properties = immutablePropertyMap(source.getProperties());
+      List<ProvenanceRecord> records = new ArrayList<ProvenanceRecord>();
+      for (EngineeringProvenance item : source.getProvenance()) {
+        records.add(new ProvenanceRecord(item));
+      }
+      this.provenance = Collections.unmodifiableList(records);
+    }
+
+    /**
+     * Returns the stable canonical semantic-object identity.
+     *
+     * @return semantic-object identity
+     */
+    public String getId() {
+      return id;
+    }
+
+    /**
+     * Returns the canonical semantic-object kind.
+     *
+     * @return object kind
+     */
+    public EngineeringNode.Kind getKind() {
+      return kind;
+    }
+
+    /**
+     * Returns the optional external source key.
+     *
+     * @return external source key, or {@code null}
+     */
+    public String getExternalKey() {
+      return externalKey;
+    }
+
+    /**
+     * Returns the human-readable source label.
+     *
+     * @return source label
+     */
+    public String getLabel() {
+      return label;
+    }
+
+    /**
+     * Returns immutable, key-sorted semantic properties.
+     *
+     * @return semantic properties
+     */
+    public Map<String, Object> getProperties() {
+      return properties;
+    }
+
+    /**
+     * Returns immutable provenance snapshots.
+     *
+     * @return provenance snapshots
+     */
+    public List<ProvenanceRecord> getProvenance() {
+      return provenance;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("id", id);
+      result.put("kind", kind.name());
+      result.put("externalKey", externalKey);
+      result.put("label", label);
+      result.put("properties", properties);
+      List<Map<String, Object>> provenanceMaps = new ArrayList<Map<String, Object>>();
+      for (ProvenanceRecord item : provenance) {
+        provenanceMaps.add(item.toMap());
+      }
+      result.put("provenance", provenanceMaps);
+      return result;
+    }
+
+    private static Map<String, Object> immutablePropertyMap(Map<String, Object> source) {
+      Map<String, Object> result = new TreeMap<String, Object>();
+      for (Map.Entry<String, Object> entry : source.entrySet()) {
+        result.put(entry.getKey(), immutablePropertyValue(entry.getValue()));
+      }
+      return Collections.unmodifiableMap(result);
+    }
+
+    private static Object immutablePropertyValue(Object value) {
+      if (value instanceof Map<?, ?>) {
+        Map<String, Object> result = new TreeMap<String, Object>();
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+          result.put(String.valueOf(entry.getKey()), immutablePropertyValue(entry.getValue()));
+        }
+        return Collections.unmodifiableMap(result);
+      }
+      if (value instanceof List<?>) {
+        List<Object> result = new ArrayList<Object>();
+        for (Object item : (List<?>) value) {
+          result.add(immutablePropertyValue(item));
+        }
+        return Collections.unmodifiableList(result);
+      }
+      return value;
     }
   }
 
@@ -376,6 +581,7 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
   private final IssuePurpose issuePurpose;
   private final String accountableApprovalReference;
   private final List<RevisionEntry> revisionHistory;
+  private final List<SemanticObject> semanticObjects;
   private final List<Drawing> drawings;
   private final List<Diagnostic> diagnostics;
 
@@ -395,8 +601,10 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
       throw new IllegalArgumentException("approved or construction issue requires accountableApprovalReference");
     }
     this.revisionHistory = Collections.unmodifiableList(new ArrayList<RevisionEntry>(revisionHistory));
+    this.semanticObjects = semanticObjects(graph);
     this.drawings = Collections.unmodifiableList(new ArrayList<Drawing>(drawings));
     List<Diagnostic> assessed = new ArrayList<Diagnostic>(diagnostics);
+    assessed.addAll(validateSemanticObjects(semanticObjects));
     assessed.addAll(validate(drawings));
     this.diagnostics = Collections.unmodifiableList(assessed);
   }
@@ -507,6 +715,15 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
     return revisionHistory;
   }
 
+  /**
+   * Returns immutable canonical semantic-object snapshots used by every drawing view.
+   *
+   * @return semantic-object snapshots
+   */
+  public List<SemanticObject> getSemanticObjects() {
+    return semanticObjects;
+  }
+
   public List<Drawing> getDrawings() {
     return drawings;
   }
@@ -542,6 +759,11 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
       revisionMaps.add(entry.toMap());
     }
     result.put("revisionHistory", revisionMaps);
+    List<Map<String, Object>> semanticObjectMaps = new ArrayList<Map<String, Object>>();
+    for (SemanticObject semanticObject : semanticObjects) {
+      semanticObjectMaps.add(semanticObject.toMap());
+    }
+    result.put("semanticObjects", semanticObjectMaps);
     List<Map<String, Object>> drawingMaps = new ArrayList<Map<String, Object>>();
     for (Drawing drawing : drawings) {
       drawingMaps.add(drawing.toMap());
@@ -635,6 +857,64 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
       }
     }
     return result;
+  }
+
+  private static List<SemanticObject> semanticObjects(EngineeringGraph graph) {
+    List<SemanticObject> result = new ArrayList<SemanticObject>();
+    for (EngineeringNode node : graph.getNodes().values()) {
+      result.add(new SemanticObject(node));
+    }
+    return Collections.unmodifiableList(result);
+  }
+
+  private static List<Diagnostic> validateSemanticObjects(List<SemanticObject> objects) {
+    List<Diagnostic> result = new ArrayList<Diagnostic>();
+    Map<String, SemanticObject> objectsById = new LinkedHashMap<String, SemanticObject>();
+    for (SemanticObject object : objects) {
+      if (objectsById.put(object.getId(), object) != null) {
+        result.add(new Diagnostic(Severity.ERROR, "DIAGRAM_DOCUMENT_DUPLICATE_SEMANTIC_OBJECT_ID",
+            "Semantic object identity is not unique in the document set", object.getId()));
+      }
+      if (object.getKind() == EngineeringNode.Kind.CALCULATION
+          && object.getProperties().containsKey("resultValue") && !hasGovernedValueMetadata(object)) {
+        Severity severity = hasProvenanceSource(object, "SIMULATION_RESULT") ? Severity.ERROR : Severity.WARNING;
+        result.add(new Diagnostic(severity, "DIAGRAM_DOCUMENT_INCOMPLETE_GOVERNED_VALUE",
+            "Calculated value is missing unit, case, engineering state, approval state, or provenance",
+            object.getId()));
+      }
+    }
+    return result;
+  }
+
+  private static boolean hasGovernedValueMetadata(SemanticObject object) {
+    Map<String, Object> properties = object.getProperties();
+    return hasPropertyText(properties, "resultUnit") && hasPropertyText(properties, "designCaseId")
+        && (hasPropertyText(properties, "engineeringState") || hasPropertyText(properties, "status"))
+        && (hasPropertyText(properties, "approvalStatus") || hasProvenanceApprovalState(object))
+        && !object.getProvenance().isEmpty();
+  }
+
+  private static boolean hasPropertyText(Map<String, Object> properties, String name) {
+    Object value = properties.get(name);
+    return value != null && !value.toString().trim().isEmpty();
+  }
+
+  private static boolean hasProvenanceApprovalState(SemanticObject object) {
+    for (ProvenanceRecord record : object.getProvenance()) {
+      if (!record.getApprovalStatus().trim().isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasProvenanceSource(SemanticObject object, String sourceType) {
+    for (ProvenanceRecord record : object.getProvenance()) {
+      if (sourceType.equals(record.getSourceType())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static List<EngineeringNode> nodesOfKind(EngineeringGraph graph, EngineeringNode.Kind kind) {

--- a/src/main/java/neqsim/process/processmodel/diagram/ProcessDiagramDocumentSetAdapter.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/ProcessDiagramDocumentSetAdapter.java
@@ -41,6 +41,26 @@ public final class ProcessDiagramDocumentSetAdapter {
   }
 
   /**
+   * Creates one controlled single-area drawing proposal with a governed operating-case snapshot.
+   *
+   * @param processSystem successfully run process system to adapt
+   * @param plantId persistent plant identity
+   * @param revision controlled source revision
+   * @param drawingNumber controlled drawing number
+   * @param title drawing-set title
+   * @param profile requested content profile
+   * @param operatingCaseId stable operating-case identity
+   * @return immutable document-set proposal with unit-explicit calculated values and provenance
+   */
+  public static EngineeringDiagramDocumentSet fromProcessSystem(ProcessSystem processSystem, String plantId,
+      String revision, String drawingNumber, String title, ContentProfile profile, String operatingCaseId) {
+    ProcessDiagramGraphAdapter.Result topology = ProcessDiagramGraphAdapter.fromProcessSystem(processSystem, plantId,
+        revision, operatingCaseId);
+    return EngineeringDiagramDocumentSet.fromGraph(topology.getGraph(), drawingNumber, title, profile,
+        convert(topology.getDiagnostics()));
+  }
+
+  /**
    * Creates one controlled multi-area drawing proposal with reciprocal off-page references.
    *
    * @param processModel multi-area process model to adapt
@@ -55,6 +75,26 @@ public final class ProcessDiagramDocumentSetAdapter {
       String revision, String drawingNumber, String title, ContentProfile profile) {
     ProcessDiagramGraphAdapter.Result topology = ProcessDiagramGraphAdapter.fromProcessModel(processModel, plantId,
         revision);
+    return EngineeringDiagramDocumentSet.fromGraph(topology.getGraph(), drawingNumber, title, profile,
+        convert(topology.getDiagnostics()));
+  }
+
+  /**
+   * Creates one controlled multi-area drawing proposal with a governed operating-case snapshot.
+   *
+   * @param processModel successfully run multi-area process model to adapt
+   * @param plantId persistent plant identity
+   * @param revision controlled source revision
+   * @param drawingNumber controlled drawing number
+   * @param title drawing-set title
+   * @param profile requested content profile
+   * @param operatingCaseId stable plant-wide operating-case identity
+   * @return immutable document-set proposal with unit-explicit calculated values and provenance
+   */
+  public static EngineeringDiagramDocumentSet fromProcessModel(ProcessModel processModel, String plantId,
+      String revision, String drawingNumber, String title, ContentProfile profile, String operatingCaseId) {
+    ProcessDiagramGraphAdapter.Result topology = ProcessDiagramGraphAdapter.fromProcessModel(processModel, plantId,
+        revision, operatingCaseId);
     return EngineeringDiagramDocumentSet.fromGraph(topology.getGraph(), drawingNumber, title, profile,
         convert(topology.getDiagnostics()));
   }

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramDocumentSetAdapterTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramDocumentSetAdapterTest.java
@@ -71,11 +71,9 @@ class ProcessDiagramDocumentSetAdapterTest {
     assertEquals("REVIEW_REQUIRED", pressure.getProperties().get("approvalStatus"));
     assertEquals("SIMULATION_RESULT", pressure.getProvenance().get(0).getSourceType());
     assertEquals("NORMAL-01", pressure.getProvenance().get(0).getDesignCaseId());
-    assertThrows(UnsupportedOperationException.class,
-        () -> pressure.getProperties().put("resultUnit", "psia"));
+    assertThrows(UnsupportedOperationException.class, () -> pressure.getProperties().put("resultUnit", "psia"));
 
-    SemanticObject equipment = findSemanticObject(set, EngineeringNode.Kind.EQUIPMENT, "equipmentName",
-        "10-VA-001");
+    SemanticObject equipment = findSemanticObject(set, EngineeringNode.Kind.EQUIPMENT, "equipmentName", "10-VA-001");
     assertEquals("10-VA-001", equipment.getLabel());
     SemanticObject connection = findSemanticObject(set, EngineeringNode.Kind.PIPE_SEGMENT, "carriedObjectName",
         "10-FEED-001");
@@ -86,9 +84,9 @@ class ProcessDiagramDocumentSetAdapterTest {
   @Test
   void rejectsCalculatedValuesWithoutGovernanceMetadata() {
     EngineeringGraph graph = new EngineeringGraph("INCOMPLETE-VALUE-PLANT", "A");
-    graph.addNode(new EngineeringNode("calculation:pressure", EngineeringNode.Kind.CALCULATION, "pressure",
-        "Pressure").putProperty("resultValue", Double.valueOf(42.0))
-            .addProvenance(new EngineeringProvenance("SIMULATION_RESULT", "equipment:V-001")));
+    graph.addNode(new EngineeringNode("calculation:pressure", EngineeringNode.Kind.CALCULATION, "pressure", "Pressure")
+        .putProperty("resultValue", Double.valueOf(42.0))
+        .addProvenance(new EngineeringProvenance("SIMULATION_RESULT", "equipment:V-001")));
 
     EngineeringDiagramDocumentSet set = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-INCOMPLETE-001",
         "Incomplete governed value", ContentProfile.PFD);
@@ -100,10 +98,10 @@ class ProcessDiagramDocumentSetAdapterTest {
   @Test
   void reportsLegacyCalculationGovernanceGapsWithoutBreakingExistingDocuments() {
     EngineeringGraph graph = new EngineeringGraph("LEGACY-CALCULATION-PLANT", "A");
-    graph.addNode(new EngineeringNode("calculation:pressure", EngineeringNode.Kind.CALCULATION, "pressure",
-        "Pressure").putProperty("resultValue", Double.valueOf(42.0)).putProperty("resultUnit", "bara")
-            .putProperty("status", "CALCULATED")
-            .addProvenance(new EngineeringProvenance("CALCULATION", "legacy-pressure")));
+    graph.addNode(new EngineeringNode("calculation:pressure", EngineeringNode.Kind.CALCULATION, "pressure", "Pressure")
+        .putProperty("resultValue", Double.valueOf(42.0)).putProperty("resultUnit", "bara")
+        .putProperty("status", "CALCULATED")
+        .addProvenance(new EngineeringProvenance("CALCULATION", "legacy-pressure")));
 
     EngineeringDiagramDocumentSet set = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-LEGACY-001",
         "Legacy calculation governance", ContentProfile.PFD);

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramDocumentSetAdapterTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramDocumentSetAdapterTest.java
@@ -83,8 +83,7 @@ class ProcessDiagramDocumentSetAdapterTest {
 
   @Test
   void carriesOneGovernedOperatingCaseAcrossMultiAreaProcessModel() {
-    EngineeringDiagramReferenceFixtures.ModelCase reference = EngineeringDiagramReferenceFixtures
-        .multiAreaFacility();
+    EngineeringDiagramReferenceFixtures.ModelCase reference = EngineeringDiagramReferenceFixtures.multiAreaFacility();
     reference.getProcessModel().run();
 
     EngineeringDiagramDocumentSet set = ProcessDiagramDocumentSetAdapter.fromProcessModel(reference.getProcessModel(),

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramDocumentSetAdapterTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramDocumentSetAdapterTest.java
@@ -82,6 +82,21 @@ class ProcessDiagramDocumentSetAdapterTest {
   }
 
   @Test
+  void carriesOneGovernedOperatingCaseAcrossMultiAreaProcessModel() {
+    EngineeringDiagramReferenceFixtures.ModelCase reference = EngineeringDiagramReferenceFixtures
+        .multiAreaFacility();
+    reference.getProcessModel().run();
+
+    EngineeringDiagramDocumentSet set = ProcessDiagramDocumentSetAdapter.fromProcessModel(reference.getProcessModel(),
+        reference.getCaseId(), "B", "PFD-30-002", "Governed multi-area case", ContentProfile.PFD, "NORMAL-01");
+
+    SemanticObject pressure = findSemanticObject(set, EngineeringNode.Kind.CALCULATION, "quantity", "pressure");
+    assertEquals("NORMAL-01", pressure.getProperties().get("designCaseId"));
+    assertEquals(4, set.getDrawings().get(0).getSheets().size());
+    assertTrue(set.isValid());
+  }
+
+  @Test
   void rejectsCalculatedValuesWithoutGovernanceMetadata() {
     EngineeringGraph graph = new EngineeringGraph("INCOMPLETE-VALUE-PLANT", "A");
     graph.addNode(new EngineeringNode("calculation:pressure", EngineeringNode.Kind.CALCULATION, "pressure", "Pressure")

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramDocumentSetAdapterTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramDocumentSetAdapterTest.java
@@ -14,10 +14,12 @@ import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentPro
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Diagnostic;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Drawing;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.OffPageConnector;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.SemanticObject;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Sheet;
 import neqsim.process.engineering.model.EngineeringGraph;
 import neqsim.process.engineering.model.EngineeringIds;
 import neqsim.process.engineering.model.EngineeringNode;
+import neqsim.process.engineering.model.EngineeringProvenance;
 import neqsim.process.processmodel.ProcessSystem;
 import org.junit.jupiter.api.Test;
 
@@ -49,6 +51,84 @@ class ProcessDiagramDocumentSetAdapterTest {
     assertTrue(first.isValid());
     assertFalse(first.getSourceGraphFingerprint().isEmpty());
     assertThrows(UnsupportedOperationException.class, () -> first.getDrawings().add(first.getDrawings().get(0)));
+    assertThrows(UnsupportedOperationException.class, () -> first.getSemanticObjects().clear());
+  }
+
+  @Test
+  void carriesGovernedOperatingValuesAndSourceDesignationsIntoControlledSnapshot() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    ProcessSystem process = reference.getProcessSystem();
+    process.run();
+
+    EngineeringDiagramDocumentSet set = ProcessDiagramDocumentSetAdapter.fromProcessSystem(process,
+        reference.getCaseId(), "B", "PFD-10-002", "Governed operating case", ContentProfile.PFD, "NORMAL-01");
+
+    SemanticObject pressure = findSemanticObject(set, EngineeringNode.Kind.CALCULATION, "quantity", "pressure");
+    assertEquals("bara", pressure.getProperties().get("resultUnit"));
+    assertEquals("ABSOLUTE", pressure.getProperties().get("quantityBasis"));
+    assertEquals("NORMAL-01", pressure.getProperties().get("designCaseId"));
+    assertEquals("CALCULATED", pressure.getProperties().get("engineeringState"));
+    assertEquals("REVIEW_REQUIRED", pressure.getProperties().get("approvalStatus"));
+    assertEquals("SIMULATION_RESULT", pressure.getProvenance().get(0).getSourceType());
+    assertEquals("NORMAL-01", pressure.getProvenance().get(0).getDesignCaseId());
+    assertThrows(UnsupportedOperationException.class,
+        () -> pressure.getProperties().put("resultUnit", "psia"));
+
+    SemanticObject equipment = findSemanticObject(set, EngineeringNode.Kind.EQUIPMENT, "equipmentName",
+        "10-VA-001");
+    assertEquals("10-VA-001", equipment.getLabel());
+    SemanticObject connection = findSemanticObject(set, EngineeringNode.Kind.PIPE_SEGMENT, "carriedObjectName",
+        "10-FEED-001");
+    assertEquals("MATERIAL", connection.getProperties().get("connectionType"));
+    assertTrue(set.isValid());
+  }
+
+  @Test
+  void rejectsCalculatedValuesWithoutGovernanceMetadata() {
+    EngineeringGraph graph = new EngineeringGraph("INCOMPLETE-VALUE-PLANT", "A");
+    graph.addNode(new EngineeringNode("calculation:pressure", EngineeringNode.Kind.CALCULATION, "pressure",
+        "Pressure").putProperty("resultValue", Double.valueOf(42.0))
+            .addProvenance(new EngineeringProvenance("SIMULATION_RESULT", "equipment:V-001")));
+
+    EngineeringDiagramDocumentSet set = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-INCOMPLETE-001",
+        "Incomplete governed value", ContentProfile.PFD);
+
+    assertFalse(set.isValid());
+    assertTrue(hasDiagnostic(set, "DIAGRAM_DOCUMENT_INCOMPLETE_GOVERNED_VALUE"));
+  }
+
+  @Test
+  void reportsLegacyCalculationGovernanceGapsWithoutBreakingExistingDocuments() {
+    EngineeringGraph graph = new EngineeringGraph("LEGACY-CALCULATION-PLANT", "A");
+    graph.addNode(new EngineeringNode("calculation:pressure", EngineeringNode.Kind.CALCULATION, "pressure",
+        "Pressure").putProperty("resultValue", Double.valueOf(42.0)).putProperty("resultUnit", "bara")
+            .putProperty("status", "CALCULATED")
+            .addProvenance(new EngineeringProvenance("CALCULATION", "legacy-pressure")));
+
+    EngineeringDiagramDocumentSet set = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-LEGACY-001",
+        "Legacy calculation governance", ContentProfile.PFD);
+
+    assertTrue(set.isValid());
+    assertTrue(hasDiagnostic(set, "DIAGRAM_DOCUMENT_INCOMPLETE_GOVERNED_VALUE"));
+  }
+
+  @Test
+  void snapshotsNestedSemanticPropertiesWithoutSharingMutableCollections() {
+    List<String> sourceEvidence = new ArrayList<String>();
+    sourceEvidence.add("calculation:C-001");
+    EngineeringGraph graph = new EngineeringGraph("IMMUTABLE-PROPERTY-PLANT", "A");
+    graph.addNode(new EngineeringNode("equipment:V-001", EngineeringNode.Kind.EQUIPMENT, "V-001", "V-001")
+        .putProperty("evidenceReferences", sourceEvidence));
+
+    EngineeringDiagramDocumentSet set = EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-IMMUTABLE-001",
+        "Immutable semantic properties", ContentProfile.PFD);
+    sourceEvidence.add("calculation:C-002");
+
+    @SuppressWarnings("unchecked")
+    List<String> snapshotEvidence = (List<String>) set.getSemanticObjects().get(0).getProperties()
+        .get("evidenceReferences");
+    assertEquals(1, snapshotEvidence.size());
+    assertThrows(UnsupportedOperationException.class, () -> snapshotEvidence.add("calculation:C-003"));
   }
 
   @Test
@@ -162,5 +242,15 @@ class ProcessDiagramDocumentSetAdapterTest {
       codes.add(diagnostic.getCode());
     }
     return codes.contains(code);
+  }
+
+  private static SemanticObject findSemanticObject(EngineeringDiagramDocumentSet set, EngineeringNode.Kind kind,
+      String property, String value) {
+    for (SemanticObject object : set.getSemanticObjects()) {
+      if (object.getKind() == kind && value.equals(object.getProperties().get(property))) {
+        return object;
+      }
+    }
+    throw new AssertionError("Missing semantic object " + kind + " with " + property + "=" + value);
   }
 }


### PR DESCRIPTION
## Roadmaps

Advances the shared Phase 1 semantic-foundation work in #1332 and #2899 after merged #2961 established the immutable document/drawing/sheet model.

Open-PR evidence is **in progress**, not roadmap completion.

## Engineering question

Can controlled PFD/P&ID document views retain the canonical model's source designations and case-scoped simulation results with explicit units, state and provenance, without changing Classic DOT, native DEXPI, Proteus/P&ID, or existing topology-only APIs?

## Coherent capability

- snapshots every canonical semantic object into the immutable document set;
- preserves stable identity, kind, external key, source label, sorted properties and provenance;
- recursively snapshots nested maps/lists so later source mutation cannot alter the document view;
- adds operating-case overloads for both `ProcessSystem` and multi-area `ProcessModel`;
- retains calculated temperature in K, absolute pressure in bara and mass flow in kg/s with design-case identity, quantity basis, `CALCULATED` state, `REVIEW_REQUIRED` approval state and simulation provenance;
- preserves source equipment and connection names as source designations rather than silently promoting them to approved tags or line numbers;
- fails closed when a value claiming `SIMULATION_RESULT` provenance lacks unit/case/state/approval/provenance;
- emits warning-only diagnostics for older generic calculation graphs with incomplete governance so existing document validity is not broken.

The additive `semanticObjects` JSON member remains under schema v1 because no existing member is removed or reinterpreted and there is no document parser contract requiring a migration.

## Compatibility and engineering limits

- additive Java API; existing overloads remain unchanged;
- existing topology-only adapters do not read live operating values;
- legacy `toDOT()`, `ProcessDiagramExporter`, native DEXPI 2.0, Proteus/P&ID and renderer behavior are untouched;
- no process execution, thermodynamic equation, balance, equipment behavior or layout algorithm changes;
- source designations are not accountable engineering tags;
- generated PFD/P&ID content remains an engineering proposal, not approved-for-design/construction evidence;
- no ISO 10628 or commercial CAE interoperability claim.

## Focused regression coverage

- operating-case value/unit/basis/state/approval/provenance retention for both single-area `ProcessSystem` and four-sheet multi-area `ProcessModel`;
- source equipment and carried-connection designations;
- deep immutability of nested semantic properties;
- fail-closed incomplete simulation-result metadata;
- warning-only compatibility path for generic pre-existing calculation graphs;
- immutable semantic-object collections;
- nearby existing tests continue deterministic JSON, Classic DOT preservation, multi-area sheets, parallel connections and paired off-page references.

## Documentation impact

Updated `docs/integration/engineering-diagram-document-model.md` with the new overload, SI/stated engineering units, designation boundary, governance behavior, compatibility and validation scope. No notebook or catalog change is needed because this is a Java document-model API and the existing guide is its registered entry point.

## Validation

Exact base and current `master`: `f604a089d2a8744efa2beb131789ce17ce4a03f4`  
Initial head: `3312e11d5dbf44aacd1e51892fa362bec343a386`  
Exact current head: `1eb98f944f0a711bec9bd1697894848072533e8d`

Local evidence:

- `git diff --check` — passed.
- Java changed-file line-length audit — passed; no lines over 120 characters.
- `python devtools/check_documentation_search.py` — passed; 651 Markdown and one standalone HTML source audited.
- Final four-file scope/secrets review — passed.
- Local Maven ran with Java 17 and canonical `https://repo.maven.apache.org/maven2/`, but this restricted runtime could not download `com.diffplug.spotless:spotless-maven-plugin:3.9.0`. Local Spotless, pre-commit's Spotless hook, and Maven/JUnit were therefore not claimed as passed.

Hosted formatting repair and exact-head gates:

- The initial hosted Spotless artifact contained formatting-only line wrapping. It was inspected and applied in `284966b8d5488722496b50c69f773a1990bff32e`.
- A later one-line formatter artifact for the multi-area regression was inspected and applied in `1eb98f944f0a711bec9bd1697894848072533e8d`.
- Exact-head Spotless then passed with an inspected zero-byte patch artifact.
- Pre-commit passed.
- Java 21 Javadocs passed.
- Java 21 Ubuntu and Windows fast tests passed.
- All four Java 21 Ubuntu slow-test shards passed.
- Java 8 Ubuntu and Windows compatibility tests passed.
- Documentation source contracts, build, search coverage and JavaScript checks passed.
- CodeQL, PaperLab and agent/skill cross-reference validation passed.
- The complete offshore engineering notebook and process-to-engineering notebook workflows passed.

Review and merge state:

- Both code-quality findings were assessed against the implementation and focused immutability regressions, answered, and resolved as false positives; the suggested `List.copyOf` is also incompatible with Java 8.
- No requested-changes review or unresolved thread remains.
- Exact head is current with `master`, scope-clean, conflict-free and mergeable.
- The PR remains draft; readiness does not authorize marking ready or merging.

## Next dependency

After this tranche merges, the next shared dependency is explicit reviewed tag/stream-number overrides plus revision-impact propagation; layout/sheet authoring and standards qualification remain separate scopes.