### PR TITLE
docs(properties): correct transport API boundaries

### DIFF
--- a/docs/physical_properties/README.md
+++ b/docs/physical_properties/README.md
@@ -155,9 +155,12 @@ After initialization, the most common phase accessors are:
 | Mass density with unit | `getDensity("kg/m3")` | requested unit |
 | Kinematic viscosity | `getPhysicalProperties().getKinematicViscosity()` | m²/s |
 
-Diffusion coefficients are available from the phase's `PhysicalProperties` object. See the
-[diffusivity guide](diffusivity_models.md) for Maxwell-Stefan, Fick, and effective diffusion
-coefficient access.
+Diffusion coefficients are available from the phase's `PhysicalProperties` object. Use
+`getDiffusionCoefficient(i, j)` or `getDiffusionCoefficient(component1, component2)` for a
+Maxwell-Stefan binary coefficient. Call `calcEffectiveDiffusionCoefficients()` before reading an
+effective coefficient with `getEffectiveDiffusionCoefficient(...)`. See the
+[diffusivity guide](diffusivity_models.md) for model selection, Fick coefficients, and complete
+access patterns.
 
 Surface tension requires two existing phases and an initialized interfacial model. Use phase
 guards and follow the complete examples in the

--- a/docs/physical_properties/diffusivity_models.md
+++ b/docs/physical_properties/diffusivity_models.md
@@ -57,10 +57,17 @@ Diffusion coefficients describe the rate of molecular transport due to concentra
 | `"Alkanol amine"` | Aqueous | `AmineDiffusivity` |
 
 **Setting a diffusivity model:**
+
+Select the model on an existing phase, then reinitialize that phase before reading a coefficient:
+
 ```java
-fluid.initPhysicalProperties();
-fluid.getPhase("gas").getPhysicalProperties().setDiffusionCoefficientModel("Fuller-Schettler-Giddings");
-fluid.getPhase("oil").getPhysicalProperties().setDiffusionCoefficientModel("Siddiqi Lucas");
+fluid.getPhase("gas").getPhysicalProperties()
+    .setDiffusionCoefficientModel("Fuller-Schettler-Giddings");
+fluid.getPhase("gas").initPhysicalProperties();
+
+fluid.getPhase("oil").getPhysicalProperties()
+    .setDiffusionCoefficientModel("Siddiqi Lucas");
+fluid.getPhase("oil").initPhysicalProperties();
 ```
 
 ---
@@ -443,116 +450,119 @@ All models pass the following consistency checks:
 
 ## Usage Examples
 
-### Accessing Binary Diffusion Coefficients
+### Binary gas diffusion coefficient
+
+This complete example uses the public `PhysicalProperties` API. The returned Maxwell-Stefan
+coefficient is in m²/s.
 
 ```java
+import neqsim.physicalproperties.system.PhysicalProperties;
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
-// Create and flash fluid
-SystemInterface fluid = new SystemSrkEos(300.0, 10.0);
-fluid.addComponent("methane", 0.9);
-fluid.addComponent("ethane", 0.05);
-fluid.addComponent("CO2", 0.05);
-fluid.setMixingRule("classic");
+public final class GasDiffusivityExample {
+  private GasDiffusivityExample() {}
 
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.TPflash();
+  public static void main(String[] args) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 1.01325);
+    fluid.addComponent("methane", 0.50);
+    fluid.addComponent("nitrogen", 0.50);
+    fluid.setMixingRule("classic");
 
-// Initialize physical properties
-fluid.initPhysicalProperties();
+    new ThermodynamicOperations(fluid).TPflash();
+    fluid.initPhysicalProperties();
 
-// Get binary diffusion coefficients
-double[][] Dij = fluid.getPhase("gas").getPhysicalProperties()
-    .getDiffusivityCalc().getBinaryDiffusionCoefficients();
+    PhysicalProperties properties =
+        fluid.getPhase("gas").getPhysicalProperties();
+    properties.setDiffusionCoefficientModel(
+        "Fuller-Schettler-Giddings");
+    fluid.getPhase("gas").initPhysicalProperties();
 
-// Print diffusion matrix
-int n = fluid.getPhase("gas").getNumberOfComponents();
-for (int i = 0; i < n; i++) {
-    for (int j = 0; j < n; j++) {
-        System.out.println("D[" + i + "][" + j + "] = " + Dij[i][j] + " m2/s");
+    double diffusivityM2PerS =
+        properties.getDiffusionCoefficient("methane", "nitrogen");
+    if (!(diffusivityM2PerS > 0.0)
+        || !Double.isFinite(diffusivityM2PerS)) {
+      throw new IllegalStateException("Invalid binary diffusivity");
     }
+  }
 }
 ```
 
-### Switching Between Gas Models
+Use component indexes with `getDiffusionCoefficient(i, j)` when the caller already owns a
+validated component ordering. The name overload is clearer in user-facing workflows.
+
+### Comparing models
+
+A model setter changes the calculator but does not refresh the stored coefficients. Reinitialize
+the phase after every model change:
 
 ```java
-SystemInterface fluid = new SystemSrkEos(298.15, 1.01325);
-fluid.addComponent("methane", 0.5);
-fluid.addComponent("nitrogen", 0.5);
-fluid.setMixingRule("classic");
+String[] models = {
+  "Chapman-Enskog",
+  "Wilke Lee",
+  "Fuller-Schettler-Giddings"
+};
+for (String model : models) {
+  properties.setDiffusionCoefficientModel(model);
+  fluid.getPhase("gas").initPhysicalProperties();
 
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.TPflash();
+  double diffusivityM2PerS =
+      properties.getDiffusionCoefficient("methane", "nitrogen");
+  if (!(diffusivityM2PerS > 0.0)
+      || !Double.isFinite(diffusivityM2PerS)) {
+    throw new IllegalStateException("Invalid diffusivity for " + model);
+  }
+}
+```
+
+Apply the same sequence to an aqueous or oil phase, using a model key implemented for that phase.
+Do not read the public mutable `diffusivityCalc` field; use the `PhysicalProperties` accessors so
+the example remains on the supported API boundary.
+
+### Effective diffusivity
+
+Effective coefficients are a separate multicomponent calculation. Calculate them before reading
+a component result:
+
+```java
+properties.calcEffectiveDiffusionCoefficients();
+
+int componentCount = fluid.getPhase("gas").getNumberOfComponents();
+for (int component = 0; component < componentCount; component++) {
+  double effectiveDiffusivityM2PerS =
+      properties.getEffectiveDiffusionCoefficient(component);
+  if (!(effectiveDiffusivityM2PerS > 0.0)
+      || !Double.isFinite(effectiveDiffusivityM2PerS)) {
+    throw new IllegalStateException("Invalid effective diffusivity");
+  }
+}
+```
+
+### Amine model set
+
+`initPhysicalProperties(String)` selects a `PhysicalPropertyType` such as `VISCOSITY`; it does
+not select a model set. Configure amine service through `PhysicalPropertyModel.AMINE` before
+initialization:
+
+```java
+import neqsim.physicalproperties.system.PhysicalPropertyModel;
+
+fluid.setPhysicalPropertyModel(PhysicalPropertyModel.AMINE);
 fluid.initPhysicalProperties();
 
-// Compare gas models
-String[] models = {"Chapman-Enskog", "Wilke Lee", "Fuller-Schettler-Giddings"};
-for (String model : models) {
-    fluid.getPhase("gas").getPhysicalProperties().setDiffusionCoefficientModel(model);
-    double D = fluid.getPhase("gas").getPhysicalProperties()
-        .diffusivityCalc.calcBinaryDiffusionCoefficient(0, 1, 0);
-    System.out.println(model + ": D(CH4-N2) = " + D + " m2/s");
-}
+PhysicalProperties aqueousProperties =
+    fluid.getPhase("aqueous").getPhysicalProperties();
+aqueousProperties.setDiffusionCoefficientModel("Alkanol amine");
+fluid.getPhase("aqueous").initPhysicalProperties();
+
+double co2AmineDiffusivityM2PerS =
+    aqueousProperties.getDiffusionCoefficient(0, 1);
 ```
 
-### Liquid-Phase Diffusion in Water
+Confirm the component ordering before using integer indexes. For named components, prefer
+`getDiffusionCoefficient(component1, component2)`.
 
-```java
-SystemInterface fluid = new SystemSrkEos(298.15, 1.01325);
-fluid.addComponent("CO2", 0.01);
-fluid.addComponent("water", 0.99);
-fluid.createDatabase(true);
-fluid.setMixingRule(2);
-
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.TPflash();
-fluid.initPhysicalProperties();
-
-// Compare liquid models
-String[] models = {"Siddiqi Lucas", "Wilke-Chang", "Hayduk-Minhas", "Tyn-Calus"};
-for (String model : models) {
-    fluid.getPhase("aqueous").getPhysicalProperties().setDiffusionCoefficientModel(model);
-    double D = fluid.getPhase("aqueous").getPhysicalProperties()
-        .diffusivityCalc.calcBinaryDiffusionCoefficient(0, 1, 0);
-    System.out.println(model + ": D(CO2-water) = " + D + " m2/s");
-}
-```
-
-### Effective Diffusivity
-
-```java
-// Get effective diffusion coefficient
-double[] Deff = fluid.getPhase("gas").getPhysicalProperties()
-    .getDiffusivityCalc().getEffectiveDiffusionCoefficient();
-
-for (int i = 0; i < n; i++) {
-    String name = fluid.getPhase("gas").getComponent(i).getName();
-    System.out.println("D_eff[" + name + "] = " + Deff[i] + " m2/s");
-}
-```
-
-### Diffusivity in Amine Solutions
-
-```java
-SystemInterface fluid = new SystemSrkCPAstatoil(313.15, 1.0);
-fluid.addComponent("CO2", 0.1);
-fluid.addComponent("water", 0.7);
-fluid.addComponent("MDEA", 0.2);
-fluid.setMixingRule(10);
-
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.TPflash();
-
-// Use amine-specific diffusivity model
-fluid.initPhysicalProperties("AMINE");
-
-double[][] D = fluid.getPhase("aqueous").getPhysicalProperties()
-    .getDiffusivityCalc().getBinaryDiffusionCoefficients();
-
-System.out.println("D_CO2 in amine: " + D[0][1] + " m2/s");
-```
 
 ---
 

--- a/docs/physical_properties/diffusivity_models.md
+++ b/docs/physical_properties/diffusivity_models.md
@@ -563,7 +563,6 @@ double co2AmineDiffusivityM2PerS =
 Confirm the component ordering before using integer indexes. For named components, prefer
 `getDiffusionCoefficient(component1, component2)`.
 
-
 ---
 
 ## Physical Background

--- a/docs/test_physical_properties_navigation.py
+++ b/docs/test_physical_properties_navigation.py
@@ -1,0 +1,157 @@
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = DOCS_DIR.parent
+THERMO_OVERVIEW = DOCS_DIR / "thermo" / "physical_properties.md"
+THERMO_INDEX = DOCS_DIR / "thermo" / "README.md"
+PACKAGE_OVERVIEW = DOCS_DIR / "physical_properties" / "README.md"
+DIFFUSIVITY_GUIDE = DOCS_DIR / "physical_properties" / "diffusivity_models.md"
+SYSTEM_INTERFACE = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/thermo/system/SystemInterface.java"
+)
+PHYSICAL_PROPERTIES = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/physicalproperties/system/PhysicalProperties.java"
+)
+
+
+def heading_slugs(content):
+    content_without_fences = re.sub(r"```.*?```", "", content, flags=re.DOTALL)
+    return {
+        re.sub(r"[^a-z0-9 -]", "", heading.lower()).strip().replace(" ", "-")
+        for heading in re.findall(
+            r"^#{1,6}\s+(.+)$",
+            content_without_fences,
+            flags=re.MULTILINE,
+        )
+    }
+
+
+def resolve_internal_target(source_path, destination):
+    target, _, fragment = unquote(destination).partition("#")
+    if not target:
+        return source_path, fragment
+
+    raw_target = source_path.parent / target
+    candidates = []
+    if target.endswith(".html"):
+        candidates.append(raw_target.with_suffix(".md"))
+    elif target.endswith("/"):
+        candidates.extend((raw_target / "README.md", raw_target / "index.md"))
+    else:
+        candidates.append(raw_target)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve(), fragment
+    raise AssertionError(f"Unresolved link from {source_path}: {destination}")
+
+
+class PhysicalPropertiesDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.documents = {
+            THERMO_OVERVIEW: THERMO_OVERVIEW.read_text(encoding="utf-8"),
+            THERMO_INDEX: THERMO_INDEX.read_text(encoding="utf-8"),
+            PACKAGE_OVERVIEW: PACKAGE_OVERVIEW.read_text(encoding="utf-8"),
+            DIFFUSIVITY_GUIDE: DIFFUSIVITY_GUIDE.read_text(encoding="utf-8"),
+        }
+
+    def test_front_matter_links_fragments_and_fences_are_safe(self):
+        markdown_links = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+        for source_path, content in self.documents.items():
+            content_without_fences = re.sub(
+                r"```.*?```",
+                "",
+                content,
+                flags=re.DOTALL,
+            )
+            with self.subTest(source=source_path.name):
+                self.assertTrue(content.startswith("---\n"))
+                self.assertEqual(content.count("```") % 2, 0)
+                self.assertNotRegex(
+                    content_without_fences,
+                    re.compile(r"^# ", re.MULTILINE),
+                )
+
+            for destination in markdown_links.findall(content):
+                if destination.startswith(("http://", "https://", "mailto:")):
+                    continue
+                target_path, fragment = resolve_internal_target(
+                    source_path,
+                    destination,
+                )
+                if fragment:
+                    with self.subTest(
+                        source=source_path.name,
+                        destination=destination,
+                    ):
+                        self.assertIn(
+                            fragment,
+                            heading_slugs(
+                                target_path.read_text(encoding="utf-8")
+                            ),
+                        )
+
+    def test_documented_api_boundary_matches_current_source(self):
+        system_source = SYSTEM_INTERFACE.read_text(encoding="utf-8")
+        properties_source = PHYSICAL_PROPERTIES.read_text(encoding="utf-8")
+        thermo = self.documents[THERMO_OVERVIEW]
+        package = self.documents[PACKAGE_OVERVIEW]
+        diffusivity = self.documents[DIFFUSIVITY_GUIDE]
+
+        for method in (
+            "getInterphaseProperties()",
+            "initPhysicalProperties()",
+            "setPhysicalPropertyModel(PhysicalPropertyModel",
+        ):
+            with self.subTest(system_method=method):
+                self.assertIn(method, system_source)
+                self.assertIn(method, thermo + package + diffusivity)
+
+        for method in (
+            "getDiffusionCoefficient(int i, int j)",
+            "getDiffusionCoefficient(String comp1, String comp2)",
+            "calcEffectiveDiffusionCoefficients()",
+            "getEffectiveDiffusionCoefficient(String compName)",
+        ):
+            with self.subTest(properties_method=method):
+                self.assertIn(method, properties_source)
+
+        self.assertIn(
+            'getDiffusionCoefficient("methane", "nitrogen")',
+            diffusivity,
+        )
+        self.assertIn("calcEffectiveDiffusionCoefficients()", diffusivity)
+        self.assertIn("getEffectiveDiffusionCoefficient(component)", diffusivity)
+        self.assertIn(
+            "getInterphaseProperties().getSurfaceTension(0, 1)",
+            thermo,
+        )
+
+    def test_stale_api_patterns_do_not_return(self):
+        combined = "\n".join(self.documents.values())
+        for stale_pattern in (
+            'initPhysicalProperties("AMINE")',
+            "getDiffusivityCalc(",
+            ".diffusivityCalc",
+            "getDiffusionCoefficient()",
+            "getInterfacialTension(",
+        ):
+            with self.subTest(stale_pattern=stale_pattern):
+                self.assertNotIn(stale_pattern, combined)
+
+        self.assertNotIn("setMixingRule(7)", self.documents[THERMO_OVERVIEW])
+        self.assertIn(
+            "../physical_properties/README.md",
+            self.documents[THERMO_INDEX],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/thermo/README.md
+++ b/docs/thermo/README.md
@@ -68,7 +68,7 @@ thermo/
 - [Adsorption Isotherm Models](adsorption_isotherms.md): **Complete reference** for all adsorption isotherm models — Langmuir, Extended Langmuir, BET, Freundlich, Sips, DRA potential theory, capillary condensation, and the parameter database.
 - [PVT and Fluid Characterization](pvt_fluid_characterization.md): Building realistic fluid descriptions, including heavy-end handling and lab-data reconciliation.
 - [Thermodynamic Operations](thermodynamic_operations.md): Flash calculations, phase envelopes, and other process-centric operations.
-- [Physical Properties](physical_properties.md): Density, viscosity, surface tension, and transport-property calculations.
+- [Physical Properties](physical_properties.md): Thermodynamic/transport API boundaries and links to the maintained [physical-properties package guide](../physical_properties/README.md).
 - [Attainable Metastability — Volume Balancing Method](attainable_metastability.md): **Superheat / pressure-undershoot limit of a rapidly depressurising liquid** (Log, 2025). Rarefaction-outflow vs. Plesset-Zwick bubble-growth balance, the `n_bub` tuning parameter, and a CO₂ blowdown example.
 
 ---

--- a/docs/thermo/physical_properties.md
+++ b/docs/thermo/physical_properties.md
@@ -1,34 +1,105 @@
 ---
 title: "Physical Property Calculations"
-description: "NeqSim computes phase and mixture properties after thermodynamic initialization. This guide highlights the most used methods and how to choose appropriate models."
-keywords: "physical properties, transport properties, viscosity, thermal conductivity, surface tension, diffusion coefficient, density, Cp, Cv, speed of sound"
+description: "Use NeqSim's phase-specific density and transport-property APIs without confusing thermodynamic, transport, diffusion, or interfacial models."
+keywords: "physical properties, transport properties, viscosity, thermal conductivity, surface tension, diffusion coefficient, density, PhysicalPropertyModel"
 ---
 
-NeqSim computes phase and mixture properties after thermodynamic initialization. This guide highlights the most used methods and how to choose appropriate models.
+NeqSim separates the thermodynamic state from phase-specific transport and interfacial
+properties. Establish equilibrium first, then initialize the physical-property calculations that
+depend on that state. The maintained [physical-properties package guide](../physical_properties/README.md)
+contains complete, executable Java examples and the model tables.
 
-## Density and Compressibility
-- Call `fluid.initPhysicalProperties()` or `fluid.initProperties()` after a flash to populate density (`getDensity()`) and compressibility (`getZ()`).
-- Apply volume-shifted PR/SRK models when liquid density underpredicts lab data.
+## Establish the thermodynamic state first
 
-## Viscosity
-- `getViscosity()` on a phase returns dynamic viscosity. Correlations switch automatically based on system type:
-  - Corresponding-states for gases and light condensates.
-  - Heavy-oil extensions when TBP fractions or high molar masses are present.
-  - Association-corrected viscosity for CPA systems.
-- Use `setMixingRule(7)` or CPA fluids when hydrogen bonding impacts rheology (water, glycols).
+A flash calculation determines the stable phases and their compositions at the requested
+conditions. After the flash, `fluid.initPhysicalProperties()` calculates density and transport
+properties for the phases that exist.
 
-## Thermal Conductivity and Heat Capacity
-- `getThermalConductivity()` provides phase thermal conductivity using dense-gas corrections.
-- `getCp()` and `getEnthalpy()` support energy balances. Reinitialize (`init(3)`) if temperature changes substantially between calls.
+Use this order:
 
-## Surface and Interfacial Tension
-- `getInterfacialTension(phase1, phase2)` calculates tension between phases (e.g., gas-oil, gas-water) using parachor correlations tied to the active EOS.
-- Ensure both phases are present after a flash; otherwise, perform a two-phase flash at representative separator conditions first.
+1. Define temperature, absolute pressure, composition, equation of state, and EOS mixing rule.
+2. Run the applicable flash, such as `new ThermodynamicOperations(fluid).TPflash()`.
+3. Select a `PhysicalPropertyModel` set or an individual phase transport model.
+4. Call `fluid.initPhysicalProperties()`.
+5. Read results from a named phase.
 
-## Diffusion and Mass Transfer
-- `getDiffusionCoefficient()` is available on phases for estimating film and molecular diffusion coefficients.
-- In unit operations, enable mass-transfer calculations to access local Sherwood correlations and film models.
+If temperature, pressure, composition, or phase-equilibrium settings change materially, run the
+appropriate flash again before reinitializing physical properties. Calling
+`initPhysicalProperties()` alone does not perform a new equilibrium calculation.
 
-## Numerical Tips
-- Always flash (`TPflash`, `PHflash`, etc.) before requesting properties; raw composition-only systems do not hold valid properties.
-- When looping over many states, reuse fluids and call `initPhysicalProperties()` after each state change to refresh transport properties without repeating equilibrium calculations.
+## Thermodynamic and physical-property APIs are different
+
+Thermodynamic quantities such as compressibility factor, enthalpy, heat capacity, and phase
+equilibrium come from the active thermodynamic model. Transport-property initialization does not
+replace `init(...)` or a flash calculation for those quantities.
+
+The common phase accessors after physical-property initialization are:
+
+| Quantity | Supported phase accessor |
+|---|---|
+| Mass density | `fluid.getPhase("gas").getDensity("kg/m3")` |
+| Dynamic viscosity | `fluid.getPhase("gas").getViscosity("kg/msec")` |
+| Thermal conductivity | `fluid.getPhase("gas").getThermalConductivity("W/mK")` |
+| Kinematic viscosity | `fluid.getPhase("gas").getPhysicalProperties().getKinematicViscosity()` |
+
+Always identify the phase by type or name and guard for its existence. Phase indexes can change
+when the equilibrium state changes.
+
+## Select the transport-property model explicitly
+
+`fluid.setPhysicalPropertyModel(PhysicalPropertyModel.DEFAULT)` selects a coordinated model set.
+Other supported sets include `WATER`, `SALT_WATER`, `GLYCOL`, `AMINE`, `CO2WATER`, and
+`BASIC`. Select the set before calling `initPhysicalProperties()`.
+
+An EOS mixing rule, such as `fluid.setMixingRule("classic")`, configures thermodynamic mixture
+behavior. It is not a viscosity or conductivity model selector. For a specialized transport
+correlation, select the model on the phase's `PhysicalProperties` object and reinitialize that
+phase. See the [package overview](../physical_properties/README.md),
+[viscosity guide](../physical_properties/viscosity_models.md), and
+[thermal-conductivity guide](../physical_properties/thermal_conductivity_models.md).
+
+## Diffusion coefficients
+
+Diffusion coefficients are exposed by the phase's `PhysicalProperties` object. After selecting a
+diffusion model and reinitializing the phase, use the public accessors with component indexes or
+names:
+
+```java
+double methaneEthaneDiffusivity =
+    fluid.getPhase("gas").getPhysicalProperties()
+        .getDiffusionCoefficient("methane", "ethane");
+```
+
+For effective multicomponent diffusivity, call `calcEffectiveDiffusionCoefficients()` before
+`getEffectiveDiffusionCoefficient(...)`. The
+[diffusivity guide](../physical_properties/diffusivity_models.md) documents model keys, equations,
+units, and executable access patterns.
+
+## Surface and interfacial tension
+
+Interfacial calculations belong to `InterphasePropertiesInterface`, not directly to
+`SystemInterface`. Confirm that both phases exist, initialize physical properties, and access the
+interface through the system:
+
+```java
+double surfaceTensionNPerM =
+    fluid.getInterphaseProperties().getSurfaceTension(0, 1);
+```
+
+Phase numbers must refer to the intended pair in the current equilibrium state. The
+[interfacial-properties guide](../physical_properties/interfacial_properties.md) shows named model
+selection, phase guards, units, and complete examples.
+
+## Engineering use
+
+Transport and interfacial correlations have component, phase, temperature, pressure, and
+composition limits. Validate the selected model against measurements or traceable literature for
+the intended range. Reinitializing a model makes a calculation current; it does not establish that
+the correlation is accurate for a particular design case.
+
+## Related guides
+
+- [Reading fluid properties](reading_fluid_properties.md)
+- [Physical-properties package guide](../physical_properties/README.md)
+- [Flash calculations](flash_calculations_guide.md)
+- [Fluid creation](fluid_creation_guide.md)

--- a/src/test/java/neqsim/physicalproperties/PhysicalPropertiesPackageDocumentationTest.java
+++ b/src/test/java/neqsim/physicalproperties/PhysicalPropertiesPackageDocumentationTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import neqsim.physicalproperties.system.PhysicalProperties;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.FrictionTheoryViscosityMethod;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.LBCViscosityMethod;
+import neqsim.physicalproperties.system.PhysicalProperties;
 import neqsim.physicalproperties.system.PhysicalPropertyModel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;

--- a/src/test/java/neqsim/physicalproperties/PhysicalPropertiesPackageDocumentationTest.java
+++ b/src/test/java/neqsim/physicalproperties/PhysicalPropertiesPackageDocumentationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import neqsim.physicalproperties.system.PhysicalProperties;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.FrictionTheoryViscosityMethod;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.LBCViscosityMethod;
 import neqsim.physicalproperties.system.PhysicalPropertyModel;
@@ -27,6 +28,30 @@ class PhysicalPropertiesPackageDocumentationTest {
     assertPositiveFinite(fluid.getPhase("gas").getThermalConductivity("W/mK"));
     assertPositiveFinite(fluid.getPhase("gas").getDensity("kg/m3"));
     assertPositiveFinite(fluid.getPhase("gas").getPhysicalProperties().getKinematicViscosity());
+  }
+
+  @Test
+  void diffusivityGuideUsesPublicBinaryAndEffectiveAccessors() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 1.01325);
+    fluid.addComponent("methane", 0.50);
+    fluid.addComponent("nitrogen", 0.50);
+    fluid.setMixingRule("classic");
+
+    new ThermodynamicOperations(fluid).TPflash();
+    fluid.initPhysicalProperties();
+
+    PhysicalProperties properties = fluid.getPhase("gas").getPhysicalProperties();
+    properties.setDiffusionCoefficientModel("Fuller-Schettler-Giddings");
+    fluid.getPhase("gas").initPhysicalProperties();
+
+    assertPositiveFinite(properties.getDiffusionCoefficient("methane", "nitrogen"));
+
+    properties.calcEffectiveDiffusionCoefficients();
+    assertPositiveFinite(properties.getEffectiveDiffusionCoefficient("methane"));
+
+    fluid.setPhysicalPropertyModel(PhysicalPropertyModel.AMINE);
+    fluid.initPhysicalProperties();
+    assertPositiveFinite(fluid.getPhase("gas").getViscosity("kg/msec"));
   }
 
   @Test


### PR DESCRIPTION
## Campaign

Advances documentation-quality campaign #2499, scan D054 / rotation scope 2. This draft is in progress until merged; the issue completion ledger is not updated by an open PR.

## Frozen scope

- `docs/thermo/physical_properties.md`
- `docs/thermo/README.md`
- `docs/physical_properties/README.md`
- `docs/physical_properties/diffusivity_models.md`
- `docs/test_physical_properties_navigation.py`
- `src/test/java/neqsim/physicalproperties/PhysicalPropertiesPackageDocumentationTest.java`

Exact base: `f604a089d2a8744efa2beb131789ce17ce4a03f4`  
Initial exact head: `d22afdce61ba77d51cf7d83d6ca8ed5a4545a6e1`  
Current exact head: `3fc2856bbb3efdba9c7a73e979c6be47bf6abedd`

Open PRs #2964–#2967 and #2632 do not touch these paths. `docs/REFERENCE_MANUAL_INDEX.md` is deliberately excluded because #2632 overlaps it and its existing physical-properties entries resolve.

## Confirmed defects and root cause

1. **High — model boundary:** the thermo page recommended EOS `setMixingRule(7)` as rheology configuration. Current source selects transport model sets through `setPhysicalPropertyModel(PhysicalPropertyModel)`.
2. **High — nonexistent interfacial call:** it documented a direct `getInterfacialTension(...)` system call. Current `SystemInterface` exposes `getInterphaseProperties()`, whose public interface provides `getSurfaceTension(...)`.
3. **High — nonexistent diffusion calls:** the thermo page used no-argument `getDiffusionCoefficient()`; the maintained overview and diffusivity guide used nonexistent `getDiffusivityCalc()`.
4. **High — wrong enum boundary:** the diffusivity guide called `initPhysicalProperties("AMINE")`, but that string overload parses `PhysicalPropertyType`, not `PhysicalPropertyModel`.
5. **High — stale-state guidance:** the thermo page suggested changing state and calling only `initPhysicalProperties()`, without re-establishing phase equilibrium.
6. **Medium — discoverability:** the thermo landing page did not lead readers to the maintained, executable physical-properties package guide.

Root cause: a short legacy overview and later package guide evolved independently, while no source-backed documentation contract guarded their API boundary.

## Repairs

- Replaced the stale thermo overview with a source-accurate workflow separating flashes, thermodynamic initialization, physical-property model sets, phase model overrides, diffusion, and interfacial APIs.
- Repaired diffusivity examples to use public `PhysicalProperties` binary/effective accessors, phase reinitialization after model changes, and `PhysicalPropertyModel.AMINE`.
- Removed use of the mutable `diffusivityCalc` field from user examples.
- Linked the thermo landing page to the maintained package guide.
- Added a hermetic Python contract that resolves all changed internal paths/fragments, verifies structure/fences, corroborates documented methods against current Java interfaces, and rejects every stale API pattern.
- Extended the existing focused Java documentation test to execute named binary diffusivity, effective diffusivity, model reselection, and AMINE model-set selection.

## Local validation

Passed against an exact connector-sourced tree for this head:

- `python -m py_compile docs/test_physical_properties_navigation.py`
- `python -m unittest docs/test_physical_properties_navigation.py -v` — 3/3 passed
- `python -m unittest discover -s docs -p 'test_*.py' -v` — 20/20 passed in 0.028 s
- changed-file trailing-whitespace audit — passed
- 120-column audit for the changed Python and Java tests — passed
- connector compare — exactly six frozen files, 8 commits ahead of the exact base; current `master` is 4 unrelated commits ahead and touches none of these paths
- all changed links are internal and resolved; no external URL was added or changed
- no equation, image, notebook, dependency, production API, thermodynamic algorithm, or transport-correlation implementation changed

## Hosted validation on current exact head

Passed:

- Spotless; the inspected `spotless.patch` artifact is zero bytes
- pre-commit
- all 20 documentation contracts, Jekyll build, source/generated search audits, and JavaScript syntax
- CodeQL
- Java 21 Javadocs and agent/skill cross-reference validation
- all four Java 21 Ubuntu slow-test shards
- Java 21 Ubuntu and Windows fast tests
- Java 8 Ubuntu and Windows compatibility tests

The focused Java documentation regression completed successfully on the hosted runner. The PR remains mergeable and conflict-free against current `master`; its four newer commits are unrelated to the six-file documentation scope. Rendered-site browser inspection is not claimed because this workflow exposes no rendered-page artifact.

## Review boundary

No scientific correlation, equation, validation range, or production behavior is changed. This PR corrects API reachability, initialization order, model-selection semantics, and discoverability only. Every human and Copilot thread will be assessed on the latest head before readiness is reported.

## Next scan

After D054 merges, advance to rotation scope 3: process equipment and process simulation.