### PR TITLE
feat(control): make base PID state transactional

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -339,3 +339,18 @@ constraints, and which execution modes have qualified transaction/error semantic
 The report also does not certify that a model is suitable for a control, relief, HIPPS/SIS, HAZOP, DEXPI/P&ID, virtual
 commissioning, OTS, or other safety-critical study. Those studies require scenario-specific modelling, validation
 evidence, engineering limits, deterministic timing/replay evidence where applicable, and appropriate review.
+
+
+## Base PID controller transaction coverage
+
+The concrete `ControllerDeviceBaseClass` participates in identity-preserving step transactions. Its snapshot covers the
+calculation identifier, PID error history, integral and filtered-derivative state, output/manual/bumpless-transfer
+state,
+clock and performance metrics, event log, gain schedule, transmitter binding, setpoint/tuning/limits, activation state,
+and engineering reference binding. Gain-schedule arrays and event-log membership are defensively copied.
+
+Coverage is deliberately fail-closed for subclasses. A controller subclass inherits the marker interface but reports an
+incomplete-coverage blocker until it overrides the transaction contract with a snapshot that includes every
+subclass-owned mutable field. Passing this rollback gate establishes transaction mechanics only; it does not qualify
+loop
+tuning, scan-time fidelity, final-element dynamics, deterministic I/O, safety action, or OTS behavior.

--- a/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
+++ b/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
@@ -814,7 +814,8 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
         stepResponseTuningMethod, TintValue, derivativeState, oldMeasurement, oldControllerSetPoint,
         derivativeFilterTime, minResponse, maxResponse, isActive, mode, manualOutput, bumplessTransferPending,
         copyGainSchedule(gainSchedule), new ArrayList<ControllerEvent>(eventLog), totalTime, integralAbsoluteError,
-        lastTimeOutsideBand, settlingTolerance, setpointWeight, deadBand, referenceDesignation);
+        lastTimeOutsideBand, settlingTolerance, setpointWeight, deadBand, referenceDesignation,
+        copyReferenceDesignation(referenceDesignation));
   }
 
   /** {@inheritDoc} */
@@ -861,6 +862,7 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
     setpointWeight = snapshot.setpointWeight;
     deadBand = snapshot.deadBand;
     referenceDesignation = snapshot.referenceDesignation;
+    restoreReferenceDesignation(referenceDesignation, snapshot.referenceDesignationState);
   }
 
   /**
@@ -875,6 +877,41 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
       copy.put(entry.getKey(), entry.getValue() == null ? null : entry.getValue().clone());
     }
     return copy;
+  }
+
+  /**
+   * Copies the mutable IEC 81346 designation value while keeping its original binding separately.
+   *
+   * @param source designation to copy
+   * @return independent value copy, or {@code null}
+   */
+  private static neqsim.process.equipment.iec81346.ReferenceDesignation copyReferenceDesignation(
+      neqsim.process.equipment.iec81346.ReferenceDesignation source) {
+    if (source == null) {
+      return null;
+    }
+    return new neqsim.process.equipment.iec81346.ReferenceDesignation(source.getFunctionDesignation(),
+        source.getProductDesignation(), source.getLocationDesignation(), source.getLetterCode(),
+        source.getSequenceNumber());
+  }
+
+  /**
+   * Restores a designation in place so rollback retains the pre-trial binding identity.
+   *
+   * @param target original bound designation
+   * @param state captured designation value
+   */
+  private static void restoreReferenceDesignation(
+      neqsim.process.equipment.iec81346.ReferenceDesignation target,
+      neqsim.process.equipment.iec81346.ReferenceDesignation state) {
+    if (target == null || state == null) {
+      return;
+    }
+    target.setFunctionDesignation(state.getFunctionDesignation());
+    target.setProductDesignation(state.getProductDesignation());
+    target.setLocationDesignation(state.getLocationDesignation());
+    target.setLetterCode(state.getLetterCode());
+    target.setSequenceNumber(state.getSequenceNumber());
   }
 
   /** Immutable snapshot of every base PID field mutated by stepping or supported operational setters. */
@@ -916,6 +953,7 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
     private final double setpointWeight;
     private final double deadBand;
     private final neqsim.process.equipment.iec81346.ReferenceDesignation referenceDesignation;
+    private final neqsim.process.equipment.iec81346.ReferenceDesignation referenceDesignationState;
 
     private ControllerTransientState(String stateIdentity, UUID calcIdentifier, String unit,
         MeasurementDeviceInterface transmitter, double controllerSetPoint, double oldError, double oldoldError,
@@ -925,7 +963,8 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
         double maxResponse, boolean active, ControllerMode mode, double manualOutput, boolean bumplessTransferPending,
         NavigableMap<Double, double[]> gainSchedule, java.util.List<ControllerEvent> eventLog, double totalTime,
         double integralAbsoluteError, double lastTimeOutsideBand, double settlingTolerance, double setpointWeight,
-        double deadBand, neqsim.process.equipment.iec81346.ReferenceDesignation referenceDesignation) {
+        double deadBand, neqsim.process.equipment.iec81346.ReferenceDesignation referenceDesignation,
+        neqsim.process.equipment.iec81346.ReferenceDesignation referenceDesignationState) {
       this.stateIdentity = stateIdentity;
       this.calcIdentifier = calcIdentifier;
       this.unit = unit;
@@ -961,6 +1000,7 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
       this.setpointWeight = setpointWeight;
       this.deadBand = deadBand;
       this.referenceDesignation = referenceDesignation;
+      this.referenceDesignationState = referenceDesignationState;
     }
   }
 

--- a/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
+++ b/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
@@ -6,6 +6,8 @@
 
 package neqsim.process.controllerdevice;
 
+import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
@@ -13,6 +15,7 @@ import java.util.UUID;
 import java.util.function.ToDoubleFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
 import neqsim.util.NamedBaseClass;
 
@@ -29,7 +32,9 @@ import neqsim.util.NamedBaseClass;
  * @author ESOL
  * @version $Id: $Id
  */
-public class ControllerDeviceBaseClass extends NamedBaseClass implements ControllerDeviceInterface {
+public class ControllerDeviceBaseClass extends NamedBaseClass
+    implements ControllerDeviceInterface,
+    TransientStateParticipant<ControllerDeviceBaseClass.ControllerTransientState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
   /** Logger object for class. */
@@ -76,6 +81,8 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
   private double setpointWeight = 1.0;
   private double deadBand = 0.0;
   private neqsim.process.equipment.iec81346.ReferenceDesignation referenceDesignation = new neqsim.process.equipment.iec81346.ReferenceDesignation();
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /**
    * Constructor for ControllerDeviceBaseClass.
@@ -775,4 +782,187 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
     }
     return actualCount > 0 ? sum / actualCount : 0.0;
   }
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "controller:" + transientStateParticipantId;
+  }
+
+  /**
+   * The base snapshot is complete only for this concrete implementation. A subclass must explicitly override the
+   * transaction contract after adding its own fields to a snapshot.
+   *
+   * @return blocking diagnostic for an unqualified subclass, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != ControllerDeviceBaseClass.class) {
+      return "controller subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ControllerTransientState captureTransientState() {
+    return new ControllerTransientState(getTransientStateIdentity(), calcIdentifier, unit, transmitter,
+        controllerSetPoint, oldError, oldoldError, error, response, propConstant, reverseActing, Kp, Ti, Td,
+        stepResponseTuningMethod, TintValue, derivativeState, oldMeasurement, oldControllerSetPoint,
+        derivativeFilterTime, minResponse, maxResponse, isActive, mode, manualOutput, bumplessTransferPending,
+        copyGainSchedule(gainSchedule), new ArrayList<ControllerEvent>(eventLog), totalTime, integralAbsoluteError,
+        lastTimeOutsideBand, settlingTolerance, setpointWeight, deadBand, referenceDesignation);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(ControllerTransientState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Controller transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException("Controller transient snapshot identity does not match "
+          + getTransientStateIdentity());
+    }
+    calcIdentifier = snapshot.calcIdentifier;
+    unit = snapshot.unit;
+    transmitter = snapshot.transmitter;
+    controllerSetPoint = snapshot.controllerSetPoint;
+    oldError = snapshot.oldError;
+    oldoldError = snapshot.oldoldError;
+    error = snapshot.error;
+    response = snapshot.response;
+    propConstant = snapshot.propConstant;
+    reverseActing = snapshot.reverseActing;
+    Kp = snapshot.kp;
+    Ti = snapshot.ti;
+    Td = snapshot.td;
+    stepResponseTuningMethod = snapshot.stepResponseTuningMethod;
+    TintValue = snapshot.tintValue;
+    derivativeState = snapshot.derivativeState;
+    oldMeasurement = snapshot.oldMeasurement;
+    oldControllerSetPoint = snapshot.oldControllerSetPoint;
+    derivativeFilterTime = snapshot.derivativeFilterTime;
+    minResponse = snapshot.minResponse;
+    maxResponse = snapshot.maxResponse;
+    isActive = snapshot.active;
+    mode = snapshot.mode;
+    manualOutput = snapshot.manualOutput;
+    bumplessTransferPending = snapshot.bumplessTransferPending;
+    gainSchedule = copyGainSchedule(snapshot.gainSchedule);
+    eventLog = new ArrayList<ControllerEvent>(snapshot.eventLog);
+    totalTime = snapshot.totalTime;
+    integralAbsoluteError = snapshot.integralAbsoluteError;
+    lastTimeOutsideBand = snapshot.lastTimeOutsideBand;
+    settlingTolerance = snapshot.settlingTolerance;
+    setpointWeight = snapshot.setpointWeight;
+    deadBand = snapshot.deadBand;
+    referenceDesignation = snapshot.referenceDesignation;
+  }
+
+  /**
+   * Copies gain-schedule arrays so later tuning changes cannot mutate a captured rollback point.
+   *
+   * @param source source schedule
+   * @return independent schedule copy
+   */
+  private static NavigableMap<Double, double[]> copyGainSchedule(NavigableMap<Double, double[]> source) {
+    NavigableMap<Double, double[]> copy = new TreeMap<Double, double[]>();
+    for (Map.Entry<Double, double[]> entry : source.entrySet()) {
+      copy.put(entry.getKey(), entry.getValue() == null ? null : entry.getValue().clone());
+    }
+    return copy;
+  }
+
+  /** Immutable snapshot of every base PID field mutated by stepping or supported operational setters. */
+  public static final class ControllerTransientState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String stateIdentity;
+    private final UUID calcIdentifier;
+    private final String unit;
+    private final MeasurementDeviceInterface transmitter;
+    private final double controllerSetPoint;
+    private final double oldError;
+    private final double oldoldError;
+    private final double error;
+    private final double response;
+    private final int propConstant;
+    private final boolean reverseActing;
+    private final double kp;
+    private final double ti;
+    private final double td;
+    private final StepResponseTuningMethod stepResponseTuningMethod;
+    private final double tintValue;
+    private final double derivativeState;
+    private final double oldMeasurement;
+    private final double oldControllerSetPoint;
+    private final double derivativeFilterTime;
+    private final double minResponse;
+    private final double maxResponse;
+    private final boolean active;
+    private final ControllerMode mode;
+    private final double manualOutput;
+    private final boolean bumplessTransferPending;
+    private final NavigableMap<Double, double[]> gainSchedule;
+    private final java.util.List<ControllerEvent> eventLog;
+    private final double totalTime;
+    private final double integralAbsoluteError;
+    private final double lastTimeOutsideBand;
+    private final double settlingTolerance;
+    private final double setpointWeight;
+    private final double deadBand;
+    private final neqsim.process.equipment.iec81346.ReferenceDesignation referenceDesignation;
+
+    private ControllerTransientState(String stateIdentity, UUID calcIdentifier, String unit,
+        MeasurementDeviceInterface transmitter, double controllerSetPoint, double oldError, double oldoldError,
+        double error, double response, int propConstant, boolean reverseActing, double kp, double ti, double td,
+        StepResponseTuningMethod stepResponseTuningMethod, double tintValue, double derivativeState,
+        double oldMeasurement, double oldControllerSetPoint, double derivativeFilterTime, double minResponse,
+        double maxResponse, boolean active, ControllerMode mode, double manualOutput,
+        boolean bumplessTransferPending, NavigableMap<Double, double[]> gainSchedule,
+        java.util.List<ControllerEvent> eventLog, double totalTime, double integralAbsoluteError,
+        double lastTimeOutsideBand, double settlingTolerance, double setpointWeight, double deadBand,
+        neqsim.process.equipment.iec81346.ReferenceDesignation referenceDesignation) {
+      this.stateIdentity = stateIdentity;
+      this.calcIdentifier = calcIdentifier;
+      this.unit = unit;
+      this.transmitter = transmitter;
+      this.controllerSetPoint = controllerSetPoint;
+      this.oldError = oldError;
+      this.oldoldError = oldoldError;
+      this.error = error;
+      this.response = response;
+      this.propConstant = propConstant;
+      this.reverseActing = reverseActing;
+      this.kp = kp;
+      this.ti = ti;
+      this.td = td;
+      this.stepResponseTuningMethod = stepResponseTuningMethod;
+      this.tintValue = tintValue;
+      this.derivativeState = derivativeState;
+      this.oldMeasurement = oldMeasurement;
+      this.oldControllerSetPoint = oldControllerSetPoint;
+      this.derivativeFilterTime = derivativeFilterTime;
+      this.minResponse = minResponse;
+      this.maxResponse = maxResponse;
+      this.active = active;
+      this.mode = mode;
+      this.manualOutput = manualOutput;
+      this.bumplessTransferPending = bumplessTransferPending;
+      this.gainSchedule = gainSchedule;
+      this.eventLog = eventLog;
+      this.totalTime = totalTime;
+      this.integralAbsoluteError = integralAbsoluteError;
+      this.lastTimeOutsideBand = lastTimeOutsideBand;
+      this.settlingTolerance = settlingTolerance;
+      this.setpointWeight = setpointWeight;
+      this.deadBand = deadBand;
+      this.referenceDesignation = referenceDesignation;
+    }
+  }
+
 }

--- a/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
+++ b/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
@@ -32,8 +32,7 @@ import neqsim.util.NamedBaseClass;
  * @author ESOL
  * @version $Id: $Id
  */
-public class ControllerDeviceBaseClass extends NamedBaseClass
-    implements ControllerDeviceInterface,
+public class ControllerDeviceBaseClass extends NamedBaseClass implements ControllerDeviceInterface,
     TransientStateParticipant<ControllerDeviceBaseClass.ControllerTransientState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
@@ -782,6 +781,7 @@ public class ControllerDeviceBaseClass extends NamedBaseClass
     }
     return actualCount > 0 ? sum / actualCount : 0.0;
   }
+
   /** {@inheritDoc} */
   @Override
   public String getTransientStateIdentity() {
@@ -824,8 +824,8 @@ public class ControllerDeviceBaseClass extends NamedBaseClass
       throw new IllegalArgumentException("Controller transient snapshot cannot be null");
     }
     if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
-      throw new IllegalArgumentException("Controller transient snapshot identity does not match "
-          + getTransientStateIdentity());
+      throw new IllegalArgumentException(
+          "Controller transient snapshot identity does not match " + getTransientStateIdentity());
     }
     calcIdentifier = snapshot.calcIdentifier;
     unit = snapshot.unit;
@@ -922,11 +922,10 @@ public class ControllerDeviceBaseClass extends NamedBaseClass
         double error, double response, int propConstant, boolean reverseActing, double kp, double ti, double td,
         StepResponseTuningMethod stepResponseTuningMethod, double tintValue, double derivativeState,
         double oldMeasurement, double oldControllerSetPoint, double derivativeFilterTime, double minResponse,
-        double maxResponse, boolean active, ControllerMode mode, double manualOutput,
-        boolean bumplessTransferPending, NavigableMap<Double, double[]> gainSchedule,
-        java.util.List<ControllerEvent> eventLog, double totalTime, double integralAbsoluteError,
-        double lastTimeOutsideBand, double settlingTolerance, double setpointWeight, double deadBand,
-        neqsim.process.equipment.iec81346.ReferenceDesignation referenceDesignation) {
+        double maxResponse, boolean active, ControllerMode mode, double manualOutput, boolean bumplessTransferPending,
+        NavigableMap<Double, double[]> gainSchedule, java.util.List<ControllerEvent> eventLog, double totalTime,
+        double integralAbsoluteError, double lastTimeOutsideBand, double settlingTolerance, double setpointWeight,
+        double deadBand, neqsim.process.equipment.iec81346.ReferenceDesignation referenceDesignation) {
       this.stateIdentity = stateIdentity;
       this.calcIdentifier = calcIdentifier;
       this.unit = unit;

--- a/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
+++ b/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
@@ -901,8 +901,7 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
    * @param target original bound designation
    * @param state captured designation value
    */
-  private static void restoreReferenceDesignation(
-      neqsim.process.equipment.iec81346.ReferenceDesignation target,
+  private static void restoreReferenceDesignation(neqsim.process.equipment.iec81346.ReferenceDesignation target,
       neqsim.process.equipment.iec81346.ReferenceDesignation state) {
     if (target == null || state == null) {
       return;

--- a/src/main/java/neqsim/process/dynamics/TransientStateParticipant.java
+++ b/src/main/java/neqsim/process/dynamics/TransientStateParticipant.java
@@ -37,6 +37,20 @@ public interface TransientStateParticipant<S extends Serializable> extends Proce
   String getTransientStateIdentity();
 
   /**
+   * Returns a deterministic reason why this implementation cannot provide complete transaction coverage.
+   *
+   * <p>
+   * The default is {@code null}, meaning that the participant is ready to capture. Extensible base classes should
+   * override this method when inherited snapshot logic cannot account for subclass-owned state.
+   * </p>
+   *
+   * @return {@code null} when complete, otherwise a non-empty blocking diagnostic
+   */
+  default String getTransientStateCoverageIssue() {
+    return null;
+  }
+
+  /**
    * Captures the complete mutable state owned by this participant.
    *
    * @return non-null snapshot independent of later participant mutation

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -5184,6 +5184,19 @@ public class ProcessSystem extends SimulationBaseClass {
       }
       participantCount++;
       TransientStateParticipant<?> participant = (TransientStateParticipant<?>) element;
+      String coverageIssue;
+      try {
+        coverageIssue = normalizeTransientStateIdentity(participant.getTransientStateCoverageIssue());
+      } catch (RuntimeException ex) {
+        blockingIssues.add("process element " + describeTransientElement(element)
+            + " failed to report transient state coverage: " + ex.getMessage());
+        continue;
+      }
+      if (coverageIssue != null) {
+        blockingIssues.add("process element " + describeTransientElement(element)
+            + " has incomplete transient state coverage: " + coverageIssue);
+        continue;
+      }
       String stateIdentity;
       try {
         stateIdentity = normalizeTransientStateIdentity(participant.getTransientStateIdentity());

--- a/src/test/java/neqsim/process/controllerdevice/ControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ControllerTransientStateTransactionTest.java
@@ -1,0 +1,162 @@
+package neqsim.process.controllerdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.dynamics.TransientStepIdentifier;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.measurementdevice.PressureTransmitter;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Quantitative rollback, replay, coverage, and restart evidence for the base PID state family. */
+class ControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void rollbackRestoresPidHistoryClockConfigurationIdentityAndReplay() {
+    PressureTransmitter transmitter = createTransmitter(50.0);
+    ControllerDeviceBaseClass controller = createController(transmitter);
+    ProcessSystem process = new ProcessSystem("controller transaction");
+    process.add(controller);
+
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertEquals(1, coverage.getProcessElementCount());
+    assertEquals(1, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete());
+
+    String stateIdentity = controller.getTransientStateIdentity();
+    UUID stepId = TransientStepIdentifier.deterministicPhysicalStep("controller-rollback", 0L);
+    double initialResponse = controller.getResponse();
+
+    TransientStepTransaction transaction = process.beginTransientStepTransaction();
+    controller.runTransient(initialResponse, 1.0, stepId);
+    controller.setTransmitter(createTransmitter(60.0));
+    controller.setControllerSetPoint(70.0);
+    controller.setControllerParameters(9.0, 8.0, 7.0);
+    controller.setMode(ControllerMode.MANUAL);
+    controller.setManualOutput(11.0);
+    assertEquals(1, controller.getEventLog().size());
+    assertTrue(controller.hasRunTransient(stepId));
+    assertTrue(controller.getIntegralAbsoluteError() > 0.0);
+    double trialResponse = controller.getResponse();
+    transaction.rollback();
+
+    assertEquals(stateIdentity, controller.getTransientStateIdentity());
+    transmitter.getStream().setPressure(51.0, "bara");
+    assertEquals(51.0, controller.getMeasuredValue("bara"), 1.0e-12,
+        "rollback must restore the original transmitter binding");
+    assertEquals(0, controller.getEventLog().size());
+    assertFalse(controller.hasRunTransient(stepId));
+    assertEquals(0.0, controller.getIntegralAbsoluteError(), 0.0);
+    assertEquals(initialResponse, controller.getResponse(), 0.0);
+    assertEquals(55.0, controller.getControllerSetPoint(), 0.0);
+    assertEquals(2.0, controller.getKp(), 0.0);
+    assertEquals(10.0, controller.getTi(), 0.0);
+    assertEquals(0.5, controller.getTd(), 0.0);
+    assertEquals(ControllerMode.AUTO, controller.getMode());
+
+    transmitter.getStream().setPressure(50.0, "bara");
+    controller.runTransient(initialResponse, 1.0, stepId);
+    assertEquals(trialResponse, controller.getResponse(), 1.0e-12);
+    assertEquals(1, controller.getEventLog().size());
+    assertEquals(1.0, controller.getEventLog().get(0).getTime(), 0.0);
+  }
+
+  @Test
+  void processSystemTransactionalStepCommitsControllerAndProcessStateTogether() {
+    ControllerDeviceBaseClass controller = createController(createTransmitter(50.0));
+    ProcessSystem process = new ProcessSystem("controller commit");
+    process.add(controller);
+    UUID stepId = TransientStepIdentifier.deterministicPhysicalStep("controller-commit", 0L);
+
+    process.runTransientTransactional(0.5, stepId);
+
+    assertEquals(0.5, process.getTime(), 0.0);
+    assertEquals(stepId, process.getCalculationIdentifier());
+    assertTrue(controller.hasRunTransient(stepId));
+    assertEquals(1, controller.getEventLog().size());
+    assertEquals(0.5, controller.getEventLog().get(0).getTime(), 0.0);
+  }
+
+  @Test
+  void closedSnapshotSurvivesJavaSerializationAndKeepsStableIdentity() throws Exception {
+    ControllerDeviceBaseClass controller = createController(createTransmitter(50.0));
+    String identity = controller.getTransientStateIdentity();
+    ControllerDeviceBaseClass.ControllerTransientState snapshot = controller.captureTransientState();
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(controller);
+      output.writeObject(snapshot);
+      serialized = bytes.toByteArray();
+    }
+
+    ControllerDeviceBaseClass restoredController;
+    ControllerDeviceBaseClass.ControllerTransientState restoredSnapshot;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restoredController = (ControllerDeviceBaseClass) input.readObject();
+      restoredSnapshot = (ControllerDeviceBaseClass.ControllerTransientState) input.readObject();
+    }
+
+    assertEquals(identity, restoredController.getTransientStateIdentity());
+    restoredController.restoreTransientState(restoredSnapshot);
+    assertEquals(identity, restoredController.getTransientStateIdentity());
+    assertEquals(controller.getControllerSetPoint(), restoredController.getControllerSetPoint(), 0.0);
+    assertEquals(controller.getKp(), restoredController.getKp(), 0.0);
+  }
+
+  @Test
+  void subclassWithoutExtendedSnapshotIsReportedBeforeMutation() {
+    ProcessSystem process = new ProcessSystem("subclass coverage");
+    process.add(new StatefulControllerSubclass("custom controller"));
+
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+
+    assertEquals(1, coverage.getProcessElementCount());
+    assertEquals(1, coverage.getParticipantCount());
+    assertFalse(coverage.isComplete());
+    assertTrue(coverage.getBlockingIssues().get(0).contains("subclass-owned mutable state"));
+  }
+
+  private static ControllerDeviceBaseClass createController(PressureTransmitter transmitter) {
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("PC-100");
+    controller.setTransmitter(transmitter);
+    controller.setUnit("bara");
+    controller.setControllerSetPoint(55.0);
+    controller.setControllerParameters(2.0, 10.0, 0.5);
+    controller.setDerivativeFilterTime(0.25);
+    controller.setOutputLimits(0.0, 100.0);
+    controller.setSetpointWeight(0.7);
+    controller.setDeadBand(0.01);
+    controller.addGainSchedulePoint(50.0, 2.0, 10.0, 0.5);
+    return controller;
+  }
+
+  private static PressureTransmitter createTransmitter(double pressureBara) {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, pressureBara);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream("feed", fluid);
+    stream.setPressure(pressureBara, "bara");
+    return new PressureTransmitter("PT-100", stream);
+  }
+
+  private static final class StatefulControllerSubclass extends ControllerDeviceBaseClass {
+    private static final long serialVersionUID = 1000L;
+    @SuppressWarnings("unused")
+    private double customState;
+
+    private StatefulControllerSubclass(String name) {
+      super(name);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/controllerdevice/ControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ControllerTransientStateTransactionTest.java
@@ -2,6 +2,7 @@ package neqsim.process.controllerdevice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -68,6 +69,31 @@ class ControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
     assertEquals(trialResponse, controller.getResponse(), 1.0e-12);
     assertEquals(1, controller.getEventLog().size());
     assertEquals(1.0, controller.getEventLog().get(0).getTime(), 0.0);
+  }
+
+  @Test
+  void rollbackRestoresMutableReferenceDesignationAndOriginalBinding() {
+    ControllerDeviceBaseClass controller = createController(createTransmitter(50.0));
+    neqsim.process.equipment.iec81346.ReferenceDesignation original =
+        neqsim.process.equipment.iec81346.ReferenceDesignation.parse("=A1-B1+P1");
+    controller.setReferenceDesignation(original);
+    ProcessSystem process = new ProcessSystem("controller designation rollback");
+    process.add(controller);
+
+    TransientStepTransaction transaction = process.beginTransientStepTransaction();
+    original.setFunctionDesignation("TRIAL");
+    original.setLetterCode(neqsim.process.equipment.iec81346.IEC81346LetterCode.K);
+    original.setSequenceNumber(9);
+    controller.setReferenceDesignation(
+        neqsim.process.equipment.iec81346.ReferenceDesignation.parse("=OTHER-K9+TRIAL"));
+    transaction.rollback();
+
+    assertSame(original, controller.getReferenceDesignation(),
+        "rollback must restore the original engineering-reference binding");
+    assertEquals("=A1-B1+P1", controller.getReferenceDesignationString());
+    assertEquals(neqsim.process.equipment.iec81346.IEC81346LetterCode.B,
+        controller.getReferenceDesignation().getLetterCode());
+    assertEquals(1, controller.getReferenceDesignation().getSequenceNumber());
   }
 
   @Test

--- a/src/test/java/neqsim/process/controllerdevice/ControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ControllerTransientStateTransactionTest.java
@@ -41,7 +41,7 @@ class ControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
     controller.setTransmitter(createTransmitter(60.0));
     controller.setControllerSetPoint(70.0);
     controller.setControllerParameters(9.0, 8.0, 7.0);
-    controller.setMode(ControllerMode.MANUAL);
+    controller.setMode(ControllerDeviceInterface.ControllerMode.MANUAL);
     controller.setManualOutput(11.0);
     assertEquals(1, controller.getEventLog().size());
     assertTrue(controller.hasRunTransient(stepId));
@@ -61,7 +61,7 @@ class ControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
     assertEquals(2.0, controller.getKp(), 0.0);
     assertEquals(10.0, controller.getTi(), 0.0);
     assertEquals(0.5, controller.getTd(), 0.0);
-    assertEquals(ControllerMode.AUTO, controller.getMode());
+    assertEquals(ControllerDeviceInterface.ControllerMode.AUTO, controller.getMode());
 
     transmitter.getStream().setPressure(50.0, "bara");
     controller.runTransient(initialResponse, 1.0, stepId);

--- a/src/test/java/neqsim/process/controllerdevice/ControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ControllerTransientStateTransactionTest.java
@@ -74,8 +74,8 @@ class ControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
   @Test
   void rollbackRestoresMutableReferenceDesignationAndOriginalBinding() {
     ControllerDeviceBaseClass controller = createController(createTransmitter(50.0));
-    neqsim.process.equipment.iec81346.ReferenceDesignation original =
-        neqsim.process.equipment.iec81346.ReferenceDesignation.parse("=A1-B1+P1");
+    neqsim.process.equipment.iec81346.ReferenceDesignation original = neqsim.process.equipment.iec81346.ReferenceDesignation
+        .parse("=A1-B1+P1");
     controller.setReferenceDesignation(original);
     ProcessSystem process = new ProcessSystem("controller designation rollback");
     process.add(controller);
@@ -84,8 +84,7 @@ class ControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
     original.setFunctionDesignation("TRIAL");
     original.setLetterCode(neqsim.process.equipment.iec81346.IEC81346LetterCode.K);
     original.setSequenceNumber(9);
-    controller.setReferenceDesignation(
-        neqsim.process.equipment.iec81346.ReferenceDesignation.parse("=OTHER-K9+TRIAL"));
+    controller.setReferenceDesignation(neqsim.process.equipment.iec81346.ReferenceDesignation.parse("=OTHER-K9+TRIAL"));
     transaction.rollback();
 
     assertSame(original, controller.getReferenceDesignation(),

--- a/src/test/java/neqsim/process/controllerdevice/ControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ControllerTransientStateTransactionTest.java
@@ -39,6 +39,7 @@ class ControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
 
     TransientStepTransaction transaction = process.beginTransientStepTransaction();
     controller.runTransient(initialResponse, 1.0, stepId);
+    double automaticTrialResponse = controller.getResponse();
     controller.setTransmitter(createTransmitter(60.0));
     controller.setControllerSetPoint(70.0);
     controller.setControllerParameters(9.0, 8.0, 7.0);
@@ -47,7 +48,7 @@ class ControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
     assertEquals(1, controller.getEventLog().size());
     assertTrue(controller.hasRunTransient(stepId));
     assertTrue(controller.getIntegralAbsoluteError() > 0.0);
-    double trialResponse = controller.getResponse();
+    assertEquals(11.0, controller.getResponse(), 0.0);
     transaction.rollback();
 
     assertEquals(stateIdentity, controller.getTransientStateIdentity());
@@ -66,7 +67,7 @@ class ControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
 
     transmitter.getStream().setPressure(50.0, "bara");
     controller.runTransient(initialResponse, 1.0, stepId);
-    assertEquals(trialResponse, controller.getResponse(), 1.0e-12);
+    assertEquals(automaticTrialResponse, controller.getResponse(), 1.0e-12);
     assertEquals(1, controller.getEventLog().size());
     assertEquals(1.0, controller.getEventLog().get(0).getTime(), 0.0);
   }

--- a/src/test/java/neqsim/process/processmodel/TransientStepTransactionTest.java
+++ b/src/test/java/neqsim/process/processmodel/TransientStepTransactionTest.java
@@ -163,10 +163,12 @@ public class TransientStepTransactionTest extends neqsim.NeqSimTest {
     ProcessSystem attachedController = createProcess("attached-controller", controlledUnit);
     TransientTransactionCoverage attachedCoverage = attachedController.getTransientTransactionCoverage();
     assertEquals(2, attachedCoverage.getProcessElementCount());
-    assertEquals(1, attachedCoverage.getParticipantCount());
-    assertFalse(attachedCoverage.isComplete());
-    assertTrue(attachedCoverage.getBlockingIssues().get(0).contains("attached-controller"));
-    assertThrows(IllegalStateException.class, attachedController::beginTransientStepTransaction);
+    assertEquals(2, attachedCoverage.getParticipantCount());
+    assertTrue(attachedCoverage.isComplete());
+    assertTrue(attachedCoverage.getBlockingIssues().isEmpty());
+    try (TransientStepTransaction transaction = attachedController.beginTransientStepTransaction()) {
+      assertEquals(TransientStepTransaction.Status.OPEN, transaction.getStatus());
+    }
     assertEquals(0.0, attachedController.getTime(), TOLERANCE);
   }
 


### PR DESCRIPTION
## Roadmap

Advances #2911 Phase 1 after merged DYN-C003 (#2965): first built-in shared-engine state-family adoption for identity-preserving transient transactions.

This PR owns only base PID/controller state in the shared orchestration lane. It does not change #2935 one-phase species transport or #2907 multiphase closures/slugging.

## Root cause

The merged transaction engine fails closed until every mutable process element supplies a complete typed snapshot. `ControllerDeviceBaseClass` owns integral, derivative, error-history, mode/bumpless-transfer, clock, calculation-identity, event-log, tuning and performance state, but previously had no in-place snapshot/restore contract. Treating every subclass as covered by a base snapshot would also silently omit subclass fields.

## Coherent capability

- `TransientStateParticipant` gains a default fail-closed coverage diagnostic hook.
- `ProcessSystem` evaluates that hook during quantitative preflight before capturing or mutating trial state.
- The concrete `ControllerDeviceBaseClass` supplies a persistent transaction identity and a typed snapshot of all base PID fields mutated by stepping or supported operational setters.
- Restore is in-place: controller and original transmitter identities are retained.
- Gain-schedule arrays and event-log membership are defensively copied.
- Mutable engineering-reference values are captured independently and restored in place, preserving their original binding identity.
- Old serialized controllers lazily acquire the new persistent transaction identity.
- Controller subclasses report an explicit coverage blocker until they override the contract with their own complete snapshot.

## State and numerical basis

Captured state includes the calculation UUID; engineering unit/transmitter binding; setpoint; current/two-step error history; output; direction; Kp/Ti/Td; tuning method; integral and filtered-derivative state; previous measurement/setpoint; derivative filter; output limits; active/mode/manual/bumpless state; gain schedule; event log; controller clock; IAE/settling metrics; deadband/setpoint weight; and engineering-reference binding.

No PID equation, scan order, anti-windup rule, controller default, thermodynamic equation, transport model, or process stepping behavior changes.

## Quantitative regression evidence

`ControllerTransientStateTransactionTest` covers:

- exact 1/1 ProcessSystem transaction coverage for one base PID controller;
- trial mutation followed by in-place rollback of calculation identity, integral/performance state, error/event history, output, setpoint, Kp/Ti/Td, mode and transmitter binding;
- deterministic replay matching the rejected trial response to `1e-12`;
- end-to-end `runTransientTransactional` commit of controller and ProcessSystem clock/identifier;
- Java serialization of both controller and closed snapshot with stable state identity;
- rollback of both in-place engineering-reference mutations and trial rebinding while retaining the original designation object;
- fail-before-mutation diagnostics for a state-owning subclass that has not extended the snapshot.

## Compatibility and limits

Additive Java 8-compatible API. Existing `runTransient` and controller behavior are unchanged. The participant diagnostic hook defaults to ready for existing custom participants, so #2965 implementations remain source compatible.

This is rollback-mechanics evidence, not loop-tuning qualification, sample-time fidelity, final-element dynamics, deterministic external I/O, safety approval or OTS readiness. Other controller classes, measurements, equipment, recycles, parallel-worker quiescence and external event/alarm side effects remain fail-closed.

## Validation

**VALIDATION BLOCKED BY UNRELATED WINDOWS BASELINE FAILURE**

Connector-verified on exact base `c8061c9d05022c501fc89d394be8da6d073a11fa` and exact head `7ab89803c04242d65aa517688ea88d69ec77fe3c`:

- 13 commits ahead / 0 behind and exactly 6 intended files;
- final source, complete PR diff, mergeability and all review threads re-read from the exact GitHub head;
- no human or Copilot review comments or threads are open;
- PaperLab, hosted Spotless, pre-commit/pre-push hooks, documentation search, CodeQL, agent-skill cross-reference validation, Java 21 Javadocs and all four Java 21 Ubuntu slow-test shards passed;
- the Java 21 Windows fast suite compiled production and tests and ran 11,632 tests; the controller transaction regressions passed;
- its only failure was the out-of-diff `InflowPerformanceTest.testCurve:186` assertion (`expected 0.0, was 70.68`; 1 failure, 0 errors);
- one targeted rerun reproduced only that same reservoir-test failure after another complete 25:56 Windows run, so no speculative source change was made in this controller-only PR;
- workflow fail-fast cancelled the Java 21 Ubuntu fast job and consequently skipped Java 8 Ubuntu/Windows jobs. Those gates are not claimed as passed.

Unavailable in this runtime and not claimed as passed:

- local Java/Javac, Maven wrapper, focused JUnit, Spotless, Javadocs, pre-commit/pre-push and documentation build/search.

The branch is therefore not classified READY TO MERGE. Exact-head CI must obtain clean Windows, Ubuntu-fast and Java 8 results; any branch-attributable failure will be repaired on this same draft.

## Deliberate stop boundary

The base PID snapshot stops where subclass-owned controller state begins. The next dependency is explicit adoption by concrete controller/instrument families or another complete built-in state-owning family, followed by full-step/two-half-step adaptive rejection only after a representative process has complete transaction coverage.