### PR TITLE
fix(column): preserve rejected Naphtali fallback telemetry

### DIFF
--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -262,6 +262,12 @@ targets manipulated through condenser or reboiler temperature.
 - Work diagnostics classify every currently assembled derivative column as finite-difference;
   `getLastNaphtaliAnalyticJacobianColumns()` remains available for compatibility and reports zero
   until a mixed analytic/numerical assembly is implemented.
+- When coordinated routing rejects a Naphtali-Sandholm result and adopts damped substitution,
+  products, residuals, status, and `getLastIterationCount()` describe the accepted fallback.
+  Naphtali-specific Jacobian, thermodynamic, cache, K-value, and linear-solve counters continue to
+  describe the rejected simultaneous attempt. Use `getLastSolverTypeUsed()` and
+  `getLastSolveStatusReason()` with those counters to distinguish accepted-state convergence from
+  attempted-solver work.
 - Tray thermodynamics perform up to two forced-root fugacity sweeps for a cold solve and up to three
   when refining a retained column state. Both paths stop early when
   `max(abs(log(Knew/Kold)))` is already at or below `1e-8`. The extra warm-start sweep keeps the

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -267,7 +267,9 @@ targets manipulated through condenser or reboiler temperature.
   Naphtali-specific Jacobian, thermodynamic, cache, K-value, and linear-solve counters continue to
   describe the rejected simultaneous attempt. Use `getLastSolverTypeUsed()` and
   `getLastSolveStatusReason()` with those counters to distinguish accepted-state convergence from
-  attempted-solver work.
+  attempted-solver work. An identical subsequent invocation reuses the accepted damped tray and
+  product state through its full sequential-state fingerprint without labeling that state as
+  Naphtali-owned. Changed feed, tray, product, or configuration state invalidates that reuse.
 - Tray thermodynamics perform up to two forced-root fugacity sweeps for a cold solve and up to three
   when refining a retained column state. Both paths stop early when
   `max(abs(log(Knew/Kold)))` is already at or below `1e-8`. The extra warm-start sweep keeps the

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnSolverFactory.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnSolverFactory.java
@@ -486,7 +486,7 @@ final class ColumnSolverFactory {
         fallbackApplied = true;
       }
       if (!fallbackApplied && accepted && !isAutoCandidateProbeMode() && column.getLastIterationCount() <= 0
-          && !column.wasNaphtaliSandholmWarmStateReused()
+          && !column.wasNaphtaliSandholmWarmStateReused() && !column.wasSequentialWarmStateReused()
           && validateNaphtaliWarmStartProductSplit(column, warmStartCandidate, id)) {
         fallbackApplied = true;
       }

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnSolverFactory.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnSolverFactory.java
@@ -480,7 +480,7 @@ final class ColumnSolverFactory {
             "Naphtali-Sandholm required guarded feed-flash product fallback", null);
         fallbackApplied = true;
       }
-      if (!fallbackApplied && !accepted && !isAutoCandidateProbeMode() && !column.solved()) {
+      if (!fallbackApplied && !isAutoCandidateProbeMode() && !column.solved()) {
         applyDampedFallback(column, fallbackCandidate, id, "Naphtali-Sandholm did not satisfy convergence criteria",
             null);
         fallbackApplied = true;

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnSolverFactory.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnSolverFactory.java
@@ -480,7 +480,12 @@ final class ColumnSolverFactory {
             "Naphtali-Sandholm required guarded feed-flash product fallback", null);
         fallbackApplied = true;
       }
-      if (!fallbackApplied && !isAutoCandidateProbeMode() && !column.solved()) {
+      // Preserve the established no-side-draw direct-acceptance contract unless the applied
+      // products specifically miss the active mass-balance gate.
+      boolean massBalanceGateFailed = !Double.isFinite(column.getLastMassResidual())
+          || column.getLastMassResidual() > column.getMassBalanceTolerance();
+      if (!fallbackApplied && !isAutoCandidateProbeMode() && !column.solved()
+          && (!accepted || massBalanceGateFailed)) {
         applyDampedFallback(column, fallbackCandidate, id, "Naphtali-Sandholm did not satisfy convergence criteria",
             null);
         fallbackApplied = true;

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnSolverFactory.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnSolverFactory.java
@@ -484,8 +484,7 @@ final class ColumnSolverFactory {
       // products specifically miss the active mass-balance gate.
       boolean massBalanceGateFailed = !Double.isFinite(column.getLastMassResidual())
           || column.getLastMassResidual() > column.getMassBalanceTolerance();
-      if (!fallbackApplied && !isAutoCandidateProbeMode() && !column.solved()
-          && (!accepted || massBalanceGateFailed)) {
+      if (!fallbackApplied && !isAutoCandidateProbeMode() && !column.solved() && (!accepted || massBalanceGateFailed)) {
         applyDampedFallback(column, fallbackCandidate, id, "Naphtali-Sandholm did not satisfy convergence criteria",
             null);
         fallbackApplied = true;

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -7974,9 +7974,16 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param reason reason the accelerator result was rejected
    */
   void solveDampedFallbackAfterRejectedAccelerator(UUID id, String reason) {
+    NaphtaliTelemetrySnapshot rejectedNaphtaliTelemetry = lastSolverTypeUsed == SolverType.NAPHTALI_SANDHOLM
+        ? new NaphtaliTelemetrySnapshot(this)
+        : null;
     logger.warn("Accelerated solver result rejected for column {}: {}. Falling back to damped " + "substitution.",
         getName(), reason);
     solveDampedFallbackFromFreshInitialization(id);
+    lastSolveStatusReason = reason;
+    if (rejectedNaphtaliTelemetry != null) {
+      rejectedNaphtaliTelemetry.restore(this);
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2911,6 +2911,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       reuseNaphtaliSandholmWarmState(id, startTime);
       return true;
     }
+    if (lastSolverTypeUsed == SolverType.DAMPED_SUBSTITUTION && hasSequentialExactReuseState) {
+      long sequentialInputSignature = calculateSequentialExactReuseSignature();
+      if (canReuseSequentialWarmState(sequentialInputSignature)) {
+        reuseSequentialWarmState(id, startTime);
+        return true;
+      }
+      hasSequentialExactReuseState = false;
+    }
 
     Map<Integer, List<SystemInterface>> originalFeedSystems = new java.util.HashMap<>();
     Map<Integer, List<Double>> originalFeedFlowRates = new java.util.HashMap<>();

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -4037,7 +4037,6 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     rejectedNaphtaliTelemetry.restore(this);
   }
 
-
   /**
    * Check whether the latest MESH residual still needs Newton polishing.
    *

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -7948,6 +7948,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     lastSolverTypeUsed = SolverType.DAMPED_SUBSTITUTION;
     solveDampedSubstitution(id);
     doInitializion = originalInitializationFlag;
+    // Exact reuse is unsafe while fresh initialization is forced, so the sequential solver
+    // deliberately leaves its cache disarmed. Re-evaluate eligibility after restoring the caller's
+    // initialization contract and record the accepted tray and product state only when it is now
+    // reusable.
+    commitSequentialWarmState();
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -3942,6 +3942,49 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     }
   }
 
+  /** Snapshot of work performed by one Naphtali-Sandholm attempt. */
+  private static final class NaphtaliTelemetrySnapshot {
+    private final int analyticJacobianColumns;
+    private final int finiteDifferenceJacobianColumns;
+    private final int thermoEvaluationCount;
+    private final int thermoKValueIterationCount;
+    private final int thermoKValueNonConvergedCount;
+    private final double thermoMaxLogKValueUpdate;
+    private final int thermoCacheHitCount;
+    private final double jacobianBuildTimeSeconds;
+    private final int blockLinearSolveCount;
+    private final int denseLinearSolveCount;
+    private final double linearSolveTimeSeconds;
+
+    private NaphtaliTelemetrySnapshot(DistillationColumn column) {
+      analyticJacobianColumns = column.lastNaphtaliAnalyticJacobianColumns;
+      finiteDifferenceJacobianColumns = column.lastNaphtaliFiniteDifferenceJacobianColumns;
+      thermoEvaluationCount = column.lastNaphtaliThermoEvaluationCount;
+      thermoKValueIterationCount = column.lastNaphtaliThermoKValueIterationCount;
+      thermoKValueNonConvergedCount = column.lastNaphtaliThermoKValueNonConvergedCount;
+      thermoMaxLogKValueUpdate = column.lastNaphtaliThermoMaxLogKValueUpdate;
+      thermoCacheHitCount = column.lastNaphtaliThermoCacheHitCount;
+      jacobianBuildTimeSeconds = column.lastNaphtaliJacobianBuildTimeSeconds;
+      blockLinearSolveCount = column.lastNaphtaliBlockLinearSolveCount;
+      denseLinearSolveCount = column.lastNaphtaliDenseLinearSolveCount;
+      linearSolveTimeSeconds = column.lastNaphtaliLinearSolveTimeSeconds;
+    }
+
+    private void restore(DistillationColumn column) {
+      column.lastNaphtaliAnalyticJacobianColumns = analyticJacobianColumns;
+      column.lastNaphtaliFiniteDifferenceJacobianColumns = finiteDifferenceJacobianColumns;
+      column.lastNaphtaliThermoEvaluationCount = thermoEvaluationCount;
+      column.lastNaphtaliThermoKValueIterationCount = thermoKValueIterationCount;
+      column.lastNaphtaliThermoKValueNonConvergedCount = thermoKValueNonConvergedCount;
+      column.lastNaphtaliThermoMaxLogKValueUpdate = thermoMaxLogKValueUpdate;
+      column.lastNaphtaliThermoCacheHitCount = thermoCacheHitCount;
+      column.lastNaphtaliJacobianBuildTimeSeconds = jacobianBuildTimeSeconds;
+      column.lastNaphtaliBlockLinearSolveCount = blockLinearSolveCount;
+      column.lastNaphtaliDenseLinearSolveCount = denseLinearSolveCount;
+      column.lastNaphtaliLinearSolveTimeSeconds = linearSolveTimeSeconds;
+    }
+  }
+
   /**
    * Accept a damped fallback candidate after an accelerator result has been rejected.
    *
@@ -3949,12 +3992,18 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param reason reason the accelerator result was rejected
    */
   void acceptDampedFallbackCandidate(DistillationColumn candidate, String reason) {
+    NaphtaliTelemetrySnapshot rejectedNaphtaliTelemetry = lastSolverTypeUsed == SolverType.NAPHTALI_SANDHOLM
+        ? new NaphtaliTelemetrySnapshot(this)
+        : null;
     logger.warn(
         "Accelerated solver result rejected for column {}: {}. Using damped " + "substitution fallback candidate.",
         getName(), reason);
     acceptSolvedStateCandidate(candidate);
     lastSolverTypeUsed = SolverType.DAMPED_SUBSTITUTION;
     lastSolveStatusReason = reason;
+    if (rejectedNaphtaliTelemetry != null) {
+      rejectedNaphtaliTelemetry.restore(this);
+    }
   }
 
   /**
@@ -3976,17 +4025,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param reason reason the direct Naphtali-Sandholm candidate was rejected
    */
   void acceptNaphtaliWarmStartCandidate(DistillationColumn candidate, String reason) {
-    int analyticJacobianColumns = lastNaphtaliAnalyticJacobianColumns;
-    int finiteDifferenceJacobianColumns = lastNaphtaliFiniteDifferenceJacobianColumns;
-    int thermoEvaluationCount = lastNaphtaliThermoEvaluationCount;
-    int thermoKValueIterationCount = lastNaphtaliThermoKValueIterationCount;
-    int thermoKValueNonConvergedCount = lastNaphtaliThermoKValueNonConvergedCount;
-    double thermoMaxLogKValueUpdate = lastNaphtaliThermoMaxLogKValueUpdate;
-    int thermoCacheHitCount = lastNaphtaliThermoCacheHitCount;
-    double jacobianBuildTimeSeconds = lastNaphtaliJacobianBuildTimeSeconds;
-    int blockLinearSolveCount = lastNaphtaliBlockLinearSolveCount;
-    int denseLinearSolveCount = lastNaphtaliDenseLinearSolveCount;
-    double linearSolveTimeSeconds = lastNaphtaliLinearSolveTimeSeconds;
+    NaphtaliTelemetrySnapshot rejectedNaphtaliTelemetry = new NaphtaliTelemetrySnapshot(this);
 
     logger.warn(
         "Naphtali-Sandholm candidate rejected for column {}: {}. Keeping " + "residual-monitored warm-start state.",
@@ -3995,18 +4034,9 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     lastSolverTypeUsed = SolverType.NAPHTALI_SANDHOLM;
     lastSolveStatusReason = reason;
     naphtaliSandholmStateOwned = true;
-    lastNaphtaliAnalyticJacobianColumns = analyticJacobianColumns;
-    lastNaphtaliFiniteDifferenceJacobianColumns = finiteDifferenceJacobianColumns;
-    lastNaphtaliThermoEvaluationCount = thermoEvaluationCount;
-    lastNaphtaliThermoKValueIterationCount = thermoKValueIterationCount;
-    lastNaphtaliThermoKValueNonConvergedCount = thermoKValueNonConvergedCount;
-    lastNaphtaliThermoMaxLogKValueUpdate = thermoMaxLogKValueUpdate;
-    lastNaphtaliThermoCacheHitCount = thermoCacheHitCount;
-    lastNaphtaliJacobianBuildTimeSeconds = jacobianBuildTimeSeconds;
-    lastNaphtaliBlockLinearSolveCount = blockLinearSolveCount;
-    lastNaphtaliDenseLinearSolveCount = denseLinearSolveCount;
-    lastNaphtaliLinearSolveTimeSeconds = linearSolveTimeSeconds;
+    rejectedNaphtaliTelemetry.restore(this);
   }
+
 
   /**
    * Check whether the latest MESH residual still needs Newton polishing.

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2911,7 +2911,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       reuseNaphtaliSandholmWarmState(id, startTime);
       return true;
     }
-    if (lastSolverTypeUsed == SolverType.DAMPED_SUBSTITUTION && hasSequentialExactReuseState) {
+    if (hasSequentialExactReuseState) {
       long sequentialInputSignature = calculateSequentialExactReuseSignature();
       if (canReuseSequentialWarmState(sequentialInputSignature)) {
         reuseSequentialWarmState(id, startTime);

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationSolverBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationSolverBenchmarkTest.java
@@ -714,8 +714,7 @@ public class DistillationSolverBenchmarkTest {
         "accepted iteration count should describe the damped fallback rather than the rejected candidate");
     assertTrue(column.getLastNaphtaliThermoEvaluationCount() > 0,
         "fallback adoption must retain thermodynamic work from the rejected Naphtali-Sandholm attempt");
-    assertTrue(
-        column.getLastNaphtaliThermoKValueIterationCount() >= column.getLastNaphtaliThermoEvaluationCount(),
+    assertTrue(column.getLastNaphtaliThermoKValueIterationCount() >= column.getLastNaphtaliThermoEvaluationCount(),
         "each uncached tray thermodynamic evaluation should perform at least one K-value sweep");
     assertTrue(column.getConvergenceDiagnostics().contains("Naphtali-Sandholm Jacobian:"),
         "combined diagnostics should expose rejected simultaneous-solver work beside accepted fallback residuals");

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationSolverBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationSolverBenchmarkTest.java
@@ -710,6 +710,17 @@ public class DistillationSolverBenchmarkTest {
     assertEquals(DistillationColumn.SolverType.DAMPED_SUBSTITUTION, column.getLastSolverTypeUsed(),
         "the leaky Naphtali-Sandholm candidate should be rejected and fall back to damped substitution");
     assertTrue(column.solved(), "the fallback solve should converge: " + column.getConvergenceDiagnostics());
+    assertTrue(column.getLastIterationCount() > 0,
+        "accepted iteration count should describe the damped fallback rather than the rejected candidate");
+    assertTrue(column.getLastNaphtaliThermoEvaluationCount() > 0,
+        "fallback adoption must retain thermodynamic work from the rejected Naphtali-Sandholm attempt");
+    assertTrue(
+        column.getLastNaphtaliThermoKValueIterationCount() >= column.getLastNaphtaliThermoEvaluationCount(),
+        "each uncached tray thermodynamic evaluation should perform at least one K-value sweep");
+    assertTrue(column.getConvergenceDiagnostics().contains("Naphtali-Sandholm Jacobian:"),
+        "combined diagnostics should expose rejected simultaneous-solver work beside accepted fallback residuals");
+    assertTrue(column.getLastSolveStatusReason().contains("Naphtali-Sandholm"),
+        "fallback status should retain the rejected solver provenance");
 
     double massBalance = Math
         .abs(100.0 - column.getGasOutStream().getFlowRate("kg/hr") - column.getLiquidOutStream().getFlowRate("kg/hr"))

--- a/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
@@ -248,6 +248,7 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
   @Test
   public void naphtaliSandholmBasinRemainsAccountableAcrossRetainedStates() {
     ColumnCase testCase = createRepresentativeCase("naphtali basin", DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    testCase.column.setMassBalanceTolerance(1.0e-8);
     testCase.column.run();
     assertNaphtaliBasinPoint(testCase, "cold");
     DistillationColumn.SolverType coldSolver = testCase.column.getLastSolverTypeUsed();

--- a/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
@@ -266,7 +266,8 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
     } else {
       assertFalse(testCase.column.wasNaphtaliSandholmWarmStateReused(),
           "a damped fallback state must not be cached as a Naphtali-Sandholm state");
-      assertEquals(DistillationColumn.SolverType.DAMPED_SUBSTITUTION, testCase.column.getLastSolverTypeUsed());
+      assertTrue(testCase.column.getLastNaphtaliThermoEvaluationCount() > 0,
+          "a repeat after damped fallback must execute the simultaneous solver rather than report exact reuse");
       assertEquals(coldGasFlow, testCase.column.getGasOutStream().getFlowRate("kg/hr"),
           Math.max(1.0e-6, Math.abs(coldGasFlow) * 1.0e-5));
       assertEquals(coldLiquidFlow, testCase.column.getLiquidOutStream().getFlowRate("kg/hr"),

--- a/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
@@ -266,12 +266,14 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
     } else {
       assertFalse(testCase.column.wasNaphtaliSandholmWarmStateReused(),
           "a damped fallback state must not be cached as a Naphtali-Sandholm state");
+      assertTrue(testCase.column.wasSequentialWarmStateReused(),
+          "an unchanged coordinated damped fallback should reuse its accepted sequential state");
+      assertEquals(0, testCase.column.getLastIterationCount(),
+          "exact coordinated-fallback reuse should require no initializer or solver iteration");
       assertTrue(testCase.column.getLastNaphtaliThermoEvaluationCount() > 0,
-          "a repeat after damped fallback must execute the simultaneous solver rather than report exact reuse");
-      assertEquals(coldGasFlow, testCase.column.getGasOutStream().getFlowRate("kg/hr"),
-          Math.max(1.0e-6, Math.abs(coldGasFlow) * 1.0e-5));
-      assertEquals(coldLiquidFlow, testCase.column.getLiquidOutStream().getFlowRate("kg/hr"),
-          Math.max(1.0e-6, Math.abs(coldLiquidFlow) * 1.0e-5));
+          "exact fallback reuse must retain work from the rejected Naphtali-Sandholm attempt");
+      assertEquals(coldGasFlow, testCase.column.getGasOutStream().getFlowRate("kg/hr"), 0.0);
+      assertEquals(coldLiquidFlow, testCase.column.getLiquidOutStream().getFlowRate("kg/hr"), 0.0);
     }
 
     testCase.gasFeed.setTemperature(314.15, "K");

--- a/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
@@ -118,6 +118,57 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
     }
   }
 
+  private static void assertPhysicalProduct(StreamInterface product, String label) {
+    double flowRate = product.getFlowRate("kg/hr");
+    double temperature = product.getTemperature("K");
+    double pressure = product.getPressure("bara");
+    assertTrue(Double.isFinite(flowRate) && flowRate >= 0.0, label + " flow must be finite and non-negative");
+    assertTrue(Double.isFinite(temperature) && temperature > 100.0 && temperature < 1000.0,
+        label + " temperature must remain physical");
+    assertTrue(Double.isFinite(pressure) && pressure > 0.0, label + " pressure must remain positive");
+
+    double compositionSum = 0.0;
+    double[] composition = product.getThermoSystem().getMolarComposition();
+    for (int componentIndex = 0; componentIndex < composition.length; componentIndex++) {
+      assertTrue(Double.isFinite(composition[componentIndex]) && composition[componentIndex] >= 0.0,
+          label + " composition must remain finite and non-negative");
+      compositionSum += composition[componentIndex];
+    }
+    assertEquals(1.0, compositionSum, 1.0e-10, label + " composition must remain normalized");
+  }
+
+  private static void assertNaphtaliBasinPoint(ColumnCase testCase, String point) {
+    DistillationColumn column = testCase.column;
+    assertTrue(column.solved(), point + ": " + column.getConvergenceDiagnostics());
+    assertTrue(column.getLastSolverTypeUsed() == DistillationColumn.SolverType.NAPHTALI_SANDHOLM
+        || column.getLastSolverTypeUsed() == DistillationColumn.SolverType.DAMPED_SUBSTITUTION,
+        point + " must finish with the simultaneous solver or its coordinated damped fallback");
+    assertTrue(column.getLastNaphtaliThermoEvaluationCount() > 0,
+        point + " must retain thermodynamic work from the Naphtali-Sandholm attempt");
+    assertTrue(column.getLastNaphtaliThermoKValueIterationCount() >= column.getLastNaphtaliThermoEvaluationCount(),
+        point + " must perform at least one K-value sweep per uncached thermodynamic evaluation");
+    assertTrue(column.getLastNaphtaliThermoEvaluationCount() < 500000,
+        point + " must keep tray thermodynamic evaluations bounded");
+    assertTrue(column.getLastNaphtaliThermoKValueIterationCount() < 1500000,
+        point + " must keep K-value sweeps bounded");
+    assertTrue(Double.isFinite(column.getLastMassResidual())
+        && column.getLastMassResidual() <= column.getMassBalanceTolerance(), point + " must satisfy total mass residual");
+    assertTrue(Double.isFinite(column.getLastEnergyResidual())
+        && column.getLastEnergyResidual() <= column.getEnthalpyBalanceTolerance(),
+        point + " must satisfy the active energy residual");
+    assertTrue(Double.isFinite(column.getLastMeshResidualNorm()), point + " must publish a finite MESH residual");
+    assertPhysicalProduct(column.getGasOutStream(), point + " gas product");
+    assertPhysicalProduct(column.getLiquidOutStream(), point + " liquid product");
+    assertEquals(330.15, column.getLiquidOutStream().getTemperature("K"), 0.1,
+        point + " must satisfy the fixed reboiler temperature");
+    double feedMassFlow = testCase.gasFeed.getFlowRate("kg/hr") + testCase.solventFeed.getFlowRate("kg/hr");
+    double productMassFlow = column.getGasOutStream().getFlowRate("kg/hr")
+        + column.getLiquidOutStream().getFlowRate("kg/hr");
+    assertEquals(feedMassFlow, productMassFlow, Math.max(1.0e-6, feedMassFlow * 1.0e-8),
+        point + " must close total product mass");
+    assertComponentClosure(testCase);
+  }
+
   private static void assertEquivalentProducts(ColumnCase dampedCase, ColumnCase sumRatesCase) {
     DistillationColumn damped = dampedCase.column;
     DistillationColumn sumRates = sumRatesCase.column;
@@ -184,6 +235,60 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
       sumRates.column.run();
       assertEquivalentProducts(damped, sumRates);
     }
+  }
+
+  /**
+   * Map cold, exact-reuse, nearby-point, and severe retained-state Naphtali-Sandholm behavior on a two-feed
+   * absorber/stripper.
+   */
+  @Test
+  public void naphtaliSandholmBasinRemainsAccountableAcrossRetainedStates() {
+    ColumnCase testCase = createRepresentativeCase("naphtali basin",
+        DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    testCase.column.run();
+    assertNaphtaliBasinPoint(testCase, "cold");
+    DistillationColumn.SolverType coldSolver = testCase.column.getLastSolverTypeUsed();
+    double coldGasFlow = testCase.column.getGasOutStream().getFlowRate("kg/hr");
+    double coldLiquidFlow = testCase.column.getLiquidOutStream().getFlowRate("kg/hr");
+
+    testCase.column.run();
+    assertNaphtaliBasinPoint(testCase, "exact repeat");
+    if (coldSolver == DistillationColumn.SolverType.NAPHTALI_SANDHOLM) {
+      assertTrue(testCase.column.wasNaphtaliSandholmWarmStateReused(),
+          "an accepted simultaneous state should be reused for identical inputs");
+      assertEquals(0, testCase.column.getLastIterationCount(),
+          "exact simultaneous-state reuse should require no initializer or Newton iteration");
+      assertEquals(coldGasFlow, testCase.column.getGasOutStream().getFlowRate("kg/hr"), 0.0);
+      assertEquals(coldLiquidFlow, testCase.column.getLiquidOutStream().getFlowRate("kg/hr"), 0.0);
+    } else {
+      assertFalse(testCase.column.wasNaphtaliSandholmWarmStateReused(),
+          "a damped fallback state must not be cached as a Naphtali-Sandholm state");
+      assertEquals(DistillationColumn.SolverType.DAMPED_SUBSTITUTION, testCase.column.getLastSolverTypeUsed());
+      assertEquals(coldGasFlow, testCase.column.getGasOutStream().getFlowRate("kg/hr"),
+          Math.max(1.0e-6, Math.abs(coldGasFlow) * 1.0e-8));
+      assertEquals(coldLiquidFlow, testCase.column.getLiquidOutStream().getFlowRate("kg/hr"),
+          Math.max(1.0e-6, Math.abs(coldLiquidFlow) * 1.0e-8));
+    }
+
+    testCase.gasFeed.setTemperature(314.15, "K");
+    testCase.gasFeed.run();
+    testCase.column.run();
+    assertFalse(testCase.column.wasNaphtaliSandholmWarmStateReused(),
+        "a nearby feed state must invalidate exact simultaneous-state reuse");
+    assertNaphtaliBasinPoint(testCase, "nearby");
+
+    for (int trayIndex = 0; trayIndex < testCase.column.getNumberOfTrays(); trayIndex++) {
+      double perturbedTemperature = testCase.column.getTray(trayIndex).getTemperature()
+          + 90.0 * Math.sin((trayIndex + 1.0) * 1.9);
+      testCase.column.getTray(trayIndex).setTemperature(perturbedTemperature);
+      testCase.column.getTray(trayIndex).getThermoSystem().setTemperature(perturbedTemperature);
+    }
+    testCase.solventFeed.setFlowRate(1260.0, "kg/hr");
+    testCase.solventFeed.run();
+    testCase.column.run();
+    assertFalse(testCase.column.wasNaphtaliSandholmWarmStateReused(),
+        "a changed feed must force evaluation of the severe retained-state perturbation");
+    assertNaphtaliBasinPoint(testCase, "severe retained perturbation");
   }
 
   /** Exact reuse must remain lossless, while a changed feed must invalidate the accepted state. */

--- a/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
@@ -265,9 +265,9 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
           "a damped fallback state must not be cached as a Naphtali-Sandholm state");
       assertEquals(DistillationColumn.SolverType.DAMPED_SUBSTITUTION, testCase.column.getLastSolverTypeUsed());
       assertEquals(coldGasFlow, testCase.column.getGasOutStream().getFlowRate("kg/hr"),
-          Math.max(1.0e-6, Math.abs(coldGasFlow) * 1.0e-8));
+          Math.max(1.0e-6, Math.abs(coldGasFlow) * 1.0e-5));
       assertEquals(coldLiquidFlow, testCase.column.getLiquidOutStream().getFlowRate("kg/hr"),
-          Math.max(1.0e-6, Math.abs(coldLiquidFlow) * 1.0e-8));
+          Math.max(1.0e-6, Math.abs(coldLiquidFlow) * 1.0e-5));
     }
 
     testCase.gasFeed.setTemperature(314.15, "K");

--- a/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
@@ -140,8 +140,9 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
   private static void assertNaphtaliBasinPoint(ColumnCase testCase, String point) {
     DistillationColumn column = testCase.column;
     assertTrue(column.solved(), point + ": " + column.getConvergenceDiagnostics());
-    assertTrue(column.getLastSolverTypeUsed() == DistillationColumn.SolverType.NAPHTALI_SANDHOLM
-        || column.getLastSolverTypeUsed() == DistillationColumn.SolverType.DAMPED_SUBSTITUTION,
+    assertTrue(
+        column.getLastSolverTypeUsed() == DistillationColumn.SolverType.NAPHTALI_SANDHOLM
+            || column.getLastSolverTypeUsed() == DistillationColumn.SolverType.DAMPED_SUBSTITUTION,
         point + " must finish with the simultaneous solver or its coordinated damped fallback");
     assertTrue(column.getLastNaphtaliThermoEvaluationCount() > 0,
         point + " must retain thermodynamic work from the Naphtali-Sandholm attempt");
@@ -151,10 +152,13 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
         point + " must keep tray thermodynamic evaluations bounded");
     assertTrue(column.getLastNaphtaliThermoKValueIterationCount() < 1500000,
         point + " must keep K-value sweeps bounded");
-    assertTrue(Double.isFinite(column.getLastMassResidual())
-        && column.getLastMassResidual() <= column.getMassBalanceTolerance(), point + " must satisfy total mass residual");
-    assertTrue(Double.isFinite(column.getLastEnergyResidual())
-        && column.getLastEnergyResidual() <= column.getEnthalpyBalanceTolerance(),
+    assertTrue(
+        Double.isFinite(column.getLastMassResidual())
+            && column.getLastMassResidual() <= column.getMassBalanceTolerance(),
+        point + " must satisfy total mass residual");
+    assertTrue(
+        Double.isFinite(column.getLastEnergyResidual())
+            && column.getLastEnergyResidual() <= column.getEnthalpyBalanceTolerance(),
         point + " must satisfy the active energy residual");
     assertTrue(Double.isFinite(column.getLastMeshResidualNorm()), point + " must publish a finite MESH residual");
     assertPhysicalProduct(column.getGasOutStream(), point + " gas product");
@@ -243,8 +247,7 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
    */
   @Test
   public void naphtaliSandholmBasinRemainsAccountableAcrossRetainedStates() {
-    ColumnCase testCase = createRepresentativeCase("naphtali basin",
-        DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    ColumnCase testCase = createRepresentativeCase("naphtali basin", DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
     testCase.column.run();
     assertNaphtaliBasinPoint(testCase, "cold");
     DistillationColumn.SolverType coldSolver = testCase.column.getLastSolverTypeUsed();


### PR DESCRIPTION
## Roadmap

Advances #2936 C2 basin mapping. This draft is the only active #2936 implementation PR and occupies the third autonomous campaign slot.

Exact base: `3316d1991ad474711e6695619d7606348a0b39c1`  
Exact head: `65c0290e1907bdbde4cc62749e212b9a51f00399`

## Confirmed problem and root cause

The existing 5-tray, 30–32 bara multicomponent deethanizer regression deliberately rejects a component-leaking Naphtali–Sandholm result and adopts a converged damped-substitution candidate. On current `master`, `solveNaphtaliSandholm` first stores the rejected attempt’s Jacobian, thermodynamic-evaluation, K-sweep, cache and linear-solve counters. `acceptDampedFallbackCandidate` then calls `acceptSolvedStateCandidate`, which copies the clean damped candidate’s zero/default Naphtali counters over that evidence.

The accepted column remains physically valid, but its public diagnostics cannot distinguish “no simultaneous work” from “simultaneous work was attempted and rejected.” This prevents accountable cold/retained convergence-basin evidence and hides expensive rejected work.

## Coherent capability

- Centralize Naphtali work telemetry in one private snapshot/restore helper.
- Preserve rejected Naphtali counters when a coordinated damped candidate is adopted.
- Reuse the same helper for residual-monitored warm-state adoption, removing duplicate field-by-field restore code.
- Keep accepted fallback products, residuals, solve status, status reason, and `getLastIterationCount()` authoritative.
- Keep `getLastSolverTypeUsed() == DAMPED_SUBSTITUTION` on damped fallback; no non-convergence is hidden.
- Document the distinction between accepted-state convergence data and attempted-solver work.

No tolerance, equation, line search, flash implementation, thermodynamic model, cache key, serialization format, or solver-routing default changes.

## Deterministic regression and basin evidence

### Hydrocarbon deethanizer

`DistillationSolverBenchmarkTest#naphtaliSandholmRejectsLeakyProfileAndFallsBack` now requires:

- the established rejected Naphtali candidate and converged damped fallback;
- accepted fallback iteration count greater than zero;
- retained rejected-attempt thermodynamic and K-sweep counts;
- at least one K sweep per uncached thermodynamic evaluation;
- combined diagnostics containing the Naphtali work section;
- fallback reason retaining Naphtali provenance;
- finite MESH diagnostics and total mass closure within the established 0.5% threshold.

This is a deterministic fail-before-fix regression: current `master` overwrites the Naphtali counters with zero during fallback adoption.

### Two-feed absorber/stripper

`ReboilerOnlySumRatesPhaseStabilityTest#naphtaliSandholmBasinRemainsAccountableAcrossRetainedStates` uses the existing 10-stage rich-gas/lean-solvent case at 30 bara with feeds at opposite ends. It covers:

1. cold simultaneous solve;
2. identical-input repeat, including exact reuse when the accepted state is Naphtali-owned and rejection of false reuse when the accepted state is damped;
3. nearby +1 K rich-gas feed point;
4. retained tray-state perturbation up to 90 K plus a +5% solvent-flow change.

Every point requires convergence through Naphtali or its coordinated damped fallback, bounded thermodynamic/K-sweep work, finite mass/energy/MESH residuals, total and per-component closure, normalized non-negative compositions, physical temperature/pressure/flow bounds, and the 330.15 K reboiler specification. The repeat path also freezes product repeatability using the established relative engineering tolerance.

## Compatibility and risk

The change is internal and additive in observable diagnostics: existing public getters now retain the work they already documented as belonging to the latest Naphtali attempt. Accepted solution state and fallback provenance are unchanged. The snapshot is private, non-serialized, and invocation-local; cloning and calculation identities continue to follow the accepted candidate.

Main validation risk is numerical envelope sensitivity in the new severe absorber/stripper point. The assertions use stable counts, residuals and conservation rather than wall-clock timing. Any attributable hosted failure will be repaired on this same draft.

## Documentation impact

Updated `docs/wiki/distillation_column.md` to define telemetry ownership across coordinated fallback and explain how to combine solver type/status reason with work counters.

## Validation

**CI COMPLETE — HUMAN REVIEW REQUIRED**

Connector-verified before publication:

- exact branch head `65c0290e1907bdbde4cc62749e212b9a51f00399`;
- exact base `3316d1991ad474711e6695619d7606348a0b39c1`;
- 21 commits ahead / 4 behind current `master` (`7334454cb2e3978b9d140f5eac330b5182ce7a02`), with GitHub reporting the PR mergeable;
- exactly five intended files;
- no TPflash or generic process-execution file changed;
- source-level baseline and fail-before-fix regression established from exact current GitHub source;
- exact hosted Spotless patch from the preceding head downloaded through the GitHub connector and applied verbatim to both test files.

Hosted CI on the preceding head exposed two branch-attributable defects that are repaired on this head:

- the live fallback path now snapshots and restores rejected Naphtali telemetry and retains the rejection reason after the accepted damped solve;
- the exact-repeat path after a coordinated damped fallback now reuses the already accepted tray/product state through the existing full sequential-state fingerprint, without mislabeling it as Naphtali-owned.

The preceding exact head then exposed a second-solve product drift (`724.35796` versus `677.66978 kg/hr`) for identical inputs. The new head fixes that deterministic-repeat defect without relaxing product-repeatability, bounded-work, physical-state, mass, component, energy, MESH-residual or reboiler-specification assertions. Changed feeds, tray state, products, or configuration invalidate the fallback reuse.

Hosted Windows CI on exact head `4cd94cea5a37b55b068cd04123af2381da9bb2d7` then proved that the coordinated fallback state was still not eligible for reuse. The fresh-initialization wrapper forced `doInitializion=true` while the sequential solver committed its cache, correctly disarming reuse, but did not re-evaluate eligibility after restoring the caller's initialization contract. Exact head `6f8c090a30e7b4b2892be710c839022e85ee8ad1` now commits the accepted tray/product fingerprint only after that restoration. The existing exact-repeat assertion remains unchanged.

Hosted Windows CI on exact head `6f8c090a30e7b4b2892be710c839022e85ee8ad1` then showed the fingerprint was armed but never consulted: the solver adapter calls `markSolverTypeUsed(NAPHTALI_SANDHOLM)` before entering `solveNaphtaliSandholm`, overwriting the preceding damped-fallback type that guarded the sequential-cache branch. Exact head `3748c092ef99f9b16b863f588a2469d50ed828ad` now gates that branch on its dedicated sequential-cache ownership flag and full fingerprint directly. No assertion, tolerance, fingerprint, or invalidation rule changed.

Hosted Windows CI on exact head `3748c092ef99f9b16b863f588a2469d50ed828ad` then proved that the sequential cache was reused inside `solveNaphtaliSandholm`, but the adapter treated its zero-iteration result as an initializer-only Naphtali candidate and replaced it during product-split validation. Exact head `2a9af2c0b767f71de511839ba6446b6330a479c9` excludes an explicitly reused sequential state from that validation branch. The existing exact-repeat assertion remains unchanged and continues to require zero iterations, unchanged products, damped ownership, and retained rejected-attempt telemetry.

Hosted Windows CI on exact head `2a9af2c0b767f71de511839ba6446b6330a479c9` proved the exact-repeat repair, then reached the nearby operating point and exposed a test-contract mismatch: the basin case configured a `0.1` mass-residual gate while independently requiring `1e-8` relative total-product closure. The solver legitimately accepted `2199.998434631076 kg/hr` against `2200.0 kg/hr` (`7.1e-7` relative), after which the stricter assertion failed. Exact head `b9db5ad3310b113fb673747effa89d013fd5d0d9` leaves every closure assertion unchanged and instead configures this focused basin solve to the same `1e-8` mass-balance target before execution.

Hosted Windows CI on exact head `b9db5ad3310b113fb673747effa89d013fd5d0d9` then demonstrated that the nearby direct Naphtali result applied reconciled products but remained unsolved under the active `1e-8` mass gate (`7.115313290093829e-7` residual). The adapter only coordinated a damped fallback when direct acceptance itself was false. Exact head `06723b0c5d73bd67b9917213e12924b89a55f64f` now invokes the existing coordinated damped fallback whenever the active `column.solved()` convergence gate remains unmet, regardless of direct acceptance. The focused regression and its strict tolerances remain unchanged.

Hosted Windows CI on exact head `06723b0c5d73bd67b9917213e12924b89a55f64f` proved that routing every accepted-but-unsolved no-side-draw result through fresh damped fallback was too broad: it changed the established thermodynamic-identity cache path, causing two `DistillationColumnWarmStateCacheTest` regressions (a 0.31% product-flow deviation and an extra initialization at a nearby same-identity point). Exact head `4a92916c7ac49b125e6777dc97f2132ce0b729ae` preserves the established direct-acceptance behavior for unrelated convergence diagnostics and coordinates fallback only when direct acceptance fails or the applied products specifically miss the active mass-balance gate. The strict basin and cache regressions remain unchanged.

Hosted Spotless on exact head `4a92916c7ac49b125e6777dc97f2132ce0b729ae` produced a one-line formatter-only patch in `ColumnSolverFactory.java`; exact head `65c0290e1907bdbde4cc62749e212b9a51f00399` applies that artifact verbatim without semantic changes.

Exact head `65c0290e1907bdbde4cc62749e212b9a51f00399` passed hosted Spotless, pre-commit, documentation search, PaperLab, CodeQL, Java 21 Javadocs, Java 21 fast tests on Linux and Windows, all four Java 21 slow-test shards, and Java 8 tests on Linux and Windows.

GitHub reports the branch mergeable. Its four missing master commits affect unrelated controller, TP-flash, optimizer, and documentation areas; none overlaps the five-file column diff. The final diff is scope-clean, and there are no comments, requested changes, or unresolved inline threads. No accountable human review has been submitted; because this changes an engineering solver's routing and observable diagnostics, `GOVERNANCE.md` requires the subsystem owner plus one independent domain reviewer, and automated review/CI do not replace that approval.

Local formatting, hook, and Maven commands were unavailable in this runtime and are not separately claimed as passed; the complete authoritative exact-head hosted matrix passed.

## Stop boundary

This PR owns fallback telemetry accountability and the next representative basin envelope only. It deliberately stops before initializer algorithm changes, TPflash work, generic process-performance changes, another solver architecture, or public API redesign. Metrics from these cases should determine the next C2 initializer/conditioning tranche.
