### PR TITLE
docs(process): correct ProcessSystem execution contract

### DIFF
--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -40,39 +40,39 @@ This documentation is organized into the following sections:
 | Section | Description |
 |---------|-------------|
 | [equipment/](equipment/) | Equipment documentation (separators, compressors, etc.) |
-| [equipment/adsorption_bed.md](equipment/adsorption_bed) | **Adsorption bed** — transient simulation, LDF mass transfer, PSA/TSA cycles |
-| [lng_liquefaction.md](lng_liquefaction) | **LNG liquefaction** — closed-loop SMR, C3MR, DMR, and nitrogen-expander templates with common KPIs and literature screening |
-| [mercury_removal.md](mercury_removal) | **Mercury removal guard beds** — chemisorption (PuraSpec), bed loading, breakthrough, degradation, mechanical design, cost |
-| [bioprocessing.md](bioprocessing) | **Bio-processing** — reactors, fermenters, solid-liquid separators, LLE, evaporators, dryers, crystallizers |
-| [neqsim-studio.md](neqsim-studio) | **NeqSim Studio (Python)** — newcomer-friendly process builder: natural language, templates, guided wizard, edit-by-chat, recipe gallery |
+| [equipment/adsorption_bed.md](equipment/adsorption_bed.md) | **Adsorption bed** — transient simulation, LDF mass transfer, PSA/TSA cycles |
+| [lng_liquefaction.md](lng_liquefaction.md) | **LNG liquefaction** — closed-loop SMR, C3MR, DMR, and nitrogen-expander templates with common KPIs and literature screening |
+| [mercury_removal.md](mercury_removal.md) | **Mercury removal guard beds** — chemisorption (PuraSpec), bed loading, breakthrough, degradation, mechanical design, cost |
+| [bioprocessing.md](bioprocessing.md) | **Bio-processing** — reactors, fermenters, solid-liquid separators, LLE, evaporators, dryers, crystallizers |
+| [neqsim-studio.md](neqsim-studio.md) | **NeqSim Studio (Python)** — newcomer-friendly process builder: natural language, templates, guided wizard, edit-by-chat, recipe gallery |
 | [processmodel/](processmodel/) | ProcessSystem and flowsheet management |
 | [energy_streams.md](energy_streams.md) | **Energy streams** — typed heat, shaft-work, and electrical ports, unit-aware duties, graph ordering, and energy-driven equipment |
-| [process_json_export_and_e300_fluids.md](process_json_export_and_e300_fluids) | **Process JSON export** — self-contained ProcessSystem/ProcessModel JSON for MCP, including E300-equivalent component properties and volume correction |
-| [simulation-hooks-and-events.md](simulation-hooks-and-events) | **Lifecycle hooks, event bus, auto-validation** for ProcessSystem and ProcessModel |
-| [model-change-events.md](model-change-events) | **Governed model revisions** — versioned change events, idempotent publication, fingerprints, and durable replay |
-| [model-impact-analysis.md](model-impact-analysis) | **Cross-model impact analysis** — configurable propagation rules, recalculation order, cycle detection, and reapproval work |
+| [process_json_export_and_e300_fluids.md](process_json_export_and_e300_fluids.md) | **Process JSON export** — self-contained ProcessSystem/ProcessModel JSON for MCP, including E300-equivalent component properties and volume correction |
+| [simulation-hooks-and-events.md](simulation-hooks-and-events.md) | **Lifecycle hooks, event bus, auto-validation** for ProcessSystem and ProcessModel |
+| [model-change-events.md](model-change-events.md) | **Governed model revisions** — versioned change events, idempotent publication, fingerprints, and durable replay |
+| [model-impact-analysis.md](model-impact-analysis.md) | **Cross-model impact analysis** — configurable propagation rules, recalculation order, cycle detection, and reapproval work |
 | [safety/](safety/) | Safety systems (PSV, ESD, blowdown) |
-| [controllers.md](controllers) | Process controllers and logic |
-| [unisim-to-neqsim-conversion.md](unisim-to-neqsim-conversion) | **UniSim/HYSYS conversion** — convert `.usc` models to NeqSim with E300 full-fluid transfer and export back to UniSim |
-| [piping_route_builder.md](piping_route_builder) | **STID/E3D line-list piping route builder** — convert route tables into serial Beggs-and-Brill hydraulic models and water-hammer screening handoffs |
+| [controllers.md](controllers.md) | Process controllers and logic |
+| [unisim-to-neqsim-conversion.md](unisim-to-neqsim-conversion.md) | **UniSim/HYSYS conversion** — convert `.usc` models to NeqSim with E300 full-fluid transfer and export back to UniSim |
+| [piping_route_builder.md](piping_route_builder.md) | **STID/E3D line-list piping route builder** — convert route tables into serial Beggs-and-Brill hydraulic models and water-hammer screening handoffs |
 | [water_hammer_implementation.md](../wiki/water_hammer_implementation.md) | **Water hammer/liquid hammer screening** — fast valve closure, pump trip, STID route, tagreader event, and MCP runWaterHammer workflow |
-| [operational_evidence_package.md](operational_evidence_package) | **Operational evidence package** — combine P&ID/STID references, tagreader values, scenario actions, and bottleneck detection |
-| [exergy-analysis.md](exergy-analysis) | **Exergy analysis** — plant-wide destruction hotspots for ProcessSystem and ProcessModel |
-| [production-allocation.md](production-allocation) | **Production allocation** — back-allocate metered production to wells/sources via a linear recovery-factor proxy network (handles recycle/reflux) |
-| [k-value-fast-simulation.md](k-value-fast-simulation) | **Cached K-value fast simulation** — run one rigorous base-case process, freeze separator K-values and fallback splits, then execute fast source-rate scenarios without repeated EOS flashes |
-| [screening_calculators.md](screening_calculators) | **Screening and sizing calculators** — flare radiation (API 521), line sizing/erosion LOF (API RP 14E), flow-induced vibration (AVIFF), pump NPSH, control-valve sizing/noise (IEC 60534), thermowell strength (ASME PTC 19.3), pipeline overpressure protection, orifice metering (GPSA), and crude desalting; with optional process-object bridges |
+| [operational_evidence_package.md](operational_evidence_package.md) | **Operational evidence package** — combine P&ID/STID references, tagreader values, scenario actions, and bottleneck detection |
+| [exergy-analysis.md](exergy-analysis.md) | **Exergy analysis** — plant-wide destruction hotspots for ProcessSystem and ProcessModel |
+| [production-allocation.md](production-allocation.md) | **Production allocation** — back-allocate metered production to wells/sources via a linear recovery-factor proxy network (handles recycle/reflux) |
+| [k-value-fast-simulation.md](k-value-fast-simulation.md) | **Cached K-value fast simulation** — run one rigorous base-case process, freeze separator K-values and fallback splits, then execute fast source-rate scenarios without repeated EOS flashes |
+| [screening_calculators.md](screening_calculators.md) | **Screening and sizing calculators** — flare radiation (API 521), line sizing/erosion LOF (API RP 14E), flow-induced vibration (AVIFF), pump NPSH, control-valve sizing/noise (IEC 60534), thermowell strength (ASME PTC 19.3), pipeline overpressure protection, orifice metering (GPSA), and crude desalting; with optional process-object bridges |
 
 ### Process Design Guide
 
 | Document | Description |
 |----------|-------------|
-| [process_design_guide.md](process_design_guide) | **Complete guide to process design workflow using NeqSim** |
+| [process_design_guide.md](process_design_guide.md) | **Complete guide to process design workflow using NeqSim** |
 
 ### Design Framework (NEW) ✨
 
 | Document | Description |
 |----------|-------------|
-| [DESIGN_FRAMEWORK.md](DESIGN_FRAMEWORK) | **Automated equipment sizing and optimization framework** |
+| [DESIGN_FRAMEWORK.md](DESIGN_FRAMEWORK.md) | **Automated equipment sizing and optimization framework** |
 
 **Key Features:**
 - `AutoSizeable` interface - Equipment auto-sizing from flow requirements
@@ -85,10 +85,10 @@ This documentation is organized into the following sections:
 
 | Document | Description |
 |----------|-------------|
-| [optimization/OPTIMIZATION_AND_CONSTRAINTS.md](optimization/OPTIMIZATION_AND_CONSTRAINTS) | **COMPREHENSIVE: Complete guide to optimization algorithms, constraint types, bottleneck analysis** |
-| [optimization/OPTIMIZATION_OVERVIEW.md](optimization/OPTIMIZATION_OVERVIEW) | When to use which optimizer |
-| [optimization/process-researcher.md](optimization/process-researcher) | **Process researcher** - generate and rank candidate flowsheets from feed/product targets, including reaction routes |
-| [CAPACITY_CONSTRAINT_FRAMEWORK.md](CAPACITY_CONSTRAINT_FRAMEWORK) | Equipment capacity limits and utilization tracking |
+| [optimization/OPTIMIZATION_AND_CONSTRAINTS.md](optimization/OPTIMIZATION_AND_CONSTRAINTS.md) | **COMPREHENSIVE: Complete guide to optimization algorithms, constraint types, bottleneck analysis** |
+| [optimization/OPTIMIZATION_OVERVIEW.md](optimization/OPTIMIZATION_OVERVIEW.md) | When to use which optimizer |
+| [optimization/process-researcher.md](optimization/process-researcher.md) | **Process researcher** - generate and rank candidate flowsheets from feed/product targets, including reaction routes |
+| [CAPACITY_CONSTRAINT_FRAMEWORK.md](CAPACITY_CONSTRAINT_FRAMEWORK.md) | Equipment capacity limits and utilization tracking |
 
 **Key Features:**
 - Five search algorithms: Binary, Golden-Section, Nelder-Mead, Particle Swarm, Gradient Descent
@@ -104,22 +104,22 @@ This documentation is organized into the following sections:
 | Document | Description |
 |----------|-------------|
 | [corrosion/](corrosion/) | **Corrosion analysis module overview** — NORSOK M-506 CO2 corrosion rate + NORSOK M-001 material selection |
-| [corrosion/norsok_m506_corrosion_rate.md](corrosion/norsok_m506_corrosion_rate) | **NORSOK M-506 API** — CO2 corrosion rate prediction with fugacity, pH, correction factors |
-| [corrosion/norsok_m001_material_selection.md](corrosion/norsok_m001_material_selection) | **NORSOK M-001 API** — Material grade recommendation, sour service, chloride SCC |
-| [corrosion/pipeline_corrosion_integration.md](corrosion/pipeline_corrosion_integration) | **Pipeline integration** — Automated corrosion analysis from process simulation |
+| [corrosion/norsok_m506_corrosion_rate.md](corrosion/norsok_m506_corrosion_rate.md) | **NORSOK M-506 API** — CO2 corrosion rate prediction with fugacity, pH, correction factors |
+| [corrosion/norsok_m001_material_selection.md](corrosion/norsok_m001_material_selection.md) | **NORSOK M-001 API** — Material grade recommendation, sour service, chloride SCC |
+| [corrosion/pipeline_corrosion_integration.md](corrosion/pipeline_corrosion_integration.md) | **Pipeline integration** — Automated corrosion analysis from process simulation |
 
 ### Electrical Design Documentation
 
 | Document | Description |
 |----------|-------------|
-| [electrical-design.md](electrical-design) | **Electrical design framework — motor sizing, VFD, cable, transformer, switchgear, hazardous area, equipment-specific designs, plant-wide load analysis** |
+| [electrical-design.md](electrical-design.md) | **Electrical design framework — motor sizing, VFD, cable, transformer, switchgear, hazardous area, equipment-specific designs, plant-wide load analysis** |
 
 ### Dynamic Simulation
 
 | Document | Description |
 |----------|-------------|
-| [dynamic-simulation.md](dynamic-simulation) | **Dynamic simulation helper — auto-instruments a sized steady-state process with transmitters and PID controllers for transient simulation** |
-| [agent-rca-dynamic-fault-benchmark.md](agent-rca-dynamic-fault-benchmark) | **AgentRCA dynamic fault benchmark — normal-only evidence and ranked diagnoses for controlled sensor bias, gas leaks, blockage, and imposed multiphase slugging excitation** |
+| [dynamic-simulation.md](dynamic-simulation.md) | **Dynamic simulation helper — auto-instruments a sized steady-state process with transmitters and PID controllers for transient simulation** |
+| [agent-rca-dynamic-fault-benchmark.md](agent-rca-dynamic-fault-benchmark.md) | **AgentRCA dynamic fault benchmark — normal-only evidence and ranked diagnoses for controlled sensor bias, gas leaks, blockage, and imposed multiphase slugging excitation** |
 
 **Key Features:**
 - `DynamicProcessHelper` — one-call conversion from steady-state to dynamic
@@ -132,7 +132,7 @@ This documentation is organized into the following sections:
 
 | Document | Description |
 |----------|-------------|
-| [instrument-design.md](instrument-design) | **Instrument design framework — ISA-5.1 identification, SIL-rated safety instruments, I/O counting, DCS/SIS cabinet sizing, cost estimation, equipment-specific designs (separator, compressor, heat exchanger, pipeline, valve), plant-wide SystemInstrumentDesign** |
+| [instrument-design.md](instrument-design.md) | **Instrument design framework — ISA-5.1 identification, SIL-rated safety instruments, I/O counting, DCS/SIS cabinet sizing, cost estimation, equipment-specific designs (separator, compressor, heat exchanger, pipeline, valve), plant-wide SystemInstrumentDesign** |
 
 **Key Features:**
 - Equipment-specific designs: Compressor, Pump, Separator, Heater/Cooler, Pipeline
@@ -144,27 +144,27 @@ This documentation is organized into the following sections:
 
 | Document | Description |
 |----------|-------------|
-| [EQUIPMENT_DESIGN_PARAMETERS.md](EQUIPMENT_DESIGN_PARAMETERS) | **Equipment design parameters, autoSize vs MechanicalDesign guide** |
-| [mechanical_design_standards.md](mechanical_design_standards) | Design standards (NORSOK, ASME, API, DNV, etc.) |
-| [process_design_standards_program.md](process_design_standards_program) | Standards priorities, evidence gates, requirement coverage, and change control |
-| [standard_design_kernel_migration.md](standard_design_kernel_migration) | Migrate global editions, metadata factories, mutable calculators, and legacy case execution to typed kernels |
-| [mechanical_design_database.md](mechanical_design_database) | Data sources, database schemas, and CSV configuration |
-| [pipeline_mechanical_design.md](pipeline_mechanical_design) | Pipeline mechanical design (wall thickness, stress, buckling, corrosion) |
-| [dnv_rp_f109_on_bottom_stability.md](dnv_rp_f109_on_bottom_stability) | **DNV-RP-F109 on-bottom stability screening** — typed vertical, transparent absolute-static lateral, and external-response displacement checks with fail-closed readiness |
-| [dnv_st_f101_pipeline_screening.md](dnv_st_f101_pipeline_screening) | **Fail-closed DNV-ST-F101:2021 pipeline limit-state screening with explicit review boundary** |
-| [topside_piping_design.md](topside_piping_design) | **Topside piping design (velocity, support, vibration per ASME B31.3)** |
-| [riser_mechanical_design.md](riser_mechanical_design) | Riser design (catenary, VIV, fatigue per DNV-OS-F201) |
-| [well_mechanical_design.md](well_mechanical_design) | **Well casing/tubing design, barrier verification, cost estimation per NORSOK D-010, API 5CT** |
-| [torg_integration.md](torg_integration) | Technical Requirements Documents (TORG) integration |
-| [field_development_orchestration.md](field_development_orchestration) | Complete design workflow orchestration |
-| [mechanical_design/two_phase_heat_transfer.md](mechanical_design/two_phase_heat_transfer) | **Two-phase heat transfer — Shah condensation, Chen/Gungor-Winterton boiling, Friedel/MSH pressure drop, Ebert-Panchal fouling, incremental zone analysis, tube inserts** |
+| [EQUIPMENT_DESIGN_PARAMETERS.md](EQUIPMENT_DESIGN_PARAMETERS.md) | **Equipment design parameters, autoSize vs MechanicalDesign guide** |
+| [mechanical_design_standards.md](mechanical_design_standards.md) | Design standards (NORSOK, ASME, API, DNV, etc.) |
+| [process_design_standards_program.md](process_design_standards_program.md) | Standards priorities, evidence gates, requirement coverage, and change control |
+| [standard_design_kernel_migration.md](standard_design_kernel_migration.md) | Migrate global editions, metadata factories, mutable calculators, and legacy case execution to typed kernels |
+| [mechanical_design_database.md](mechanical_design_database.md) | Data sources, database schemas, and CSV configuration |
+| [pipeline_mechanical_design.md](pipeline_mechanical_design.md) | Pipeline mechanical design (wall thickness, stress, buckling, corrosion) |
+| [dnv_rp_f109_on_bottom_stability.md](dnv_rp_f109_on_bottom_stability.md) | **DNV-RP-F109 on-bottom stability screening** — typed vertical, transparent absolute-static lateral, and external-response displacement checks with fail-closed readiness |
+| [dnv_st_f101_pipeline_screening.md](dnv_st_f101_pipeline_screening.md) | **Fail-closed DNV-ST-F101:2021 pipeline limit-state screening with explicit review boundary** |
+| [topside_piping_design.md](topside_piping_design.md) | **Topside piping design (velocity, support, vibration per ASME B31.3)** |
+| [riser_mechanical_design.md](riser_mechanical_design.md) | Riser design (catenary, VIV, fatigue per DNV-OS-F201) |
+| [well_mechanical_design.md](well_mechanical_design.md) | **Well casing/tubing design, barrier verification, cost estimation per NORSOK D-010, API 5CT** |
+| [torg_integration.md](torg_integration.md) | Technical Requirements Documents (TORG) integration |
+| [field_development_orchestration.md](field_development_orchestration.md) | Complete design workflow orchestration |
+| [mechanical_design/two_phase_heat_transfer.md](mechanical_design/two_phase_heat_transfer.md) | **Two-phase heat transfer — Shah condensation, Chen/Gungor-Winterton boiling, Friedel/MSH pressure drop, Ebert-Panchal fouling, incremental zone analysis, tube inserts** |
 
 ### Cost Estimation Framework (NEW) ✨
 
 | Document | Description |
 |----------|-------------|
-| [COST_ESTIMATION_FRAMEWORK.md](COST_ESTIMATION_FRAMEWORK) | **Comprehensive capital and operating cost estimation, including scope-safe result reconciliation** |
-| [COST_ESTIMATION_API_REFERENCE.md](COST_ESTIMATION_API_REFERENCE) | **Detailed API reference for cost estimation classes and CostEstimateResult output maps** |
+| [COST_ESTIMATION_FRAMEWORK.md](COST_ESTIMATION_FRAMEWORK.md) | **Comprehensive capital and operating cost estimation, including scope-safe result reconciliation** |
+| [COST_ESTIMATION_API_REFERENCE.md](COST_ESTIMATION_API_REFERENCE.md) | **Detailed API reference for cost estimation classes and CostEstimateResult output maps** |
 
 **Key Features:**
 - Equipment cost estimation using Turton et al. correlations
@@ -180,48 +180,48 @@ This documentation is organized into the following sections:
 
 | Category | Documentation | Classes |
 |----------|--------------|---------|
-| Streams | [streams.md](equipment/streams) | Stream, EnergyStream, VirtualStream |
-| Separators | [separators.md](equipment/separators) | Separator, ThreePhaseSeparator, GasScrubber |
-| Heat Exchangers | [heat_exchangers.md](equipment/heat_exchangers) | Heater, Cooler, HeatExchanger |
-| Compressors | [compressors.md](equipment/compressors) | Compressor, CompressorChart, CompressorWashing |
-| Compressor Deposit / Degradation | [compressor_deposit_degradation.md](compressor_deposit_degradation) | CompressorDeposit, DepositMechanism, DepositSource, CompressorDepositProfile, WashFluid, CompressorDepositWash |
-| Compressor Anti-Surge Control | [compressor_antisurge_control.md](equipment/compressor_antisurge_control) | AntiSurgeController, CompressorMonitor, ThrottlingValve, Recycle |
-| Pumps | [pumps.md](equipment/pumps) | Pump, PumpChart |
-| Expanders | [expanders.md](equipment/expanders) | Expander, TurboExpanderCompressor |
-| Valves | [valves.md](equipment/valves) | ThrottlingValve, SafetyValve, BlowdownValve |
-| **Choke Collapse Analysis** | [choke-collapse.md](choke-collapse) | ChokeCollapseAnalyzer — critical pressure ratio, flashing, cavitation |
-| **Inadvertent Valve Operation** | [inadvertent-valve-operation.md](inadvertent-valve-operation) | InadvertentValveOperationAnalyzer — API 521 §4.4.13 / NORSOK P-002 IVO screening |
-| **Well Chokes** | [well_choke_implementation.md](well_choke_implementation) | Sachdeva, Gilbert choke models, ThrottlingValve integration |
-| Distillation | [distillation.md](equipment/distillation) | DistillationColumn, SimpleTray |
-| Absorbers | [absorbers.md](equipment/absorbers) | SimpleAbsorber, SimpleTEGAbsorber |
-| Ejectors | [ejectors.md](equipment/ejectors) | Ejector |
-| Membranes | [membranes.md](equipment/membranes) | MembraneSeparator |
-| Flares | [flares.md](equipment/flares) | Flare, FlareStack |
-| Electrolyzers | [electrolyzers.md](equipment/electrolyzers) | Electrolyzer, CO2Electrolyzer |
-| Filters | [filters.md](equipment/filters) | Particle, coalescing, strainer, and media filters with dynamic loading and mechanical design |
-| H2S Scavengers | [H2S_scavenger_guide.md](H2S_scavenger_guide) | H2S chemical scavenging (triazine, glyoxal, iron sponge) |
-| **Sulfur Recovery** | [sulfur_recovery.md](sulfur_recovery) | Integrated Claus furnace, WHB, converters, sulfur condensers, TGTU recycle, incineration, and KPIs |
-| Reactors | [reactors.md](equipment/reactors) | GibbsReactor |
-| Pipelines | [pipelines.md](equipment/pipelines) | Pipeline, AdiabaticPipe, TopsidePiping, Riser |
+| Streams | [streams.md](equipment/streams.md) | Stream, EnergyStream, VirtualStream |
+| Separators | [separators.md](equipment/separators.md) | Separator, ThreePhaseSeparator, GasScrubber |
+| Heat Exchangers | [heat_exchangers.md](equipment/heat_exchangers.md) | Heater, Cooler, HeatExchanger |
+| Compressors | [compressors.md](equipment/compressors.md) | Compressor, CompressorChart, CompressorWashing |
+| Compressor Deposit / Degradation | [compressor_deposit_degradation.md](compressor_deposit_degradation.md) | CompressorDeposit, DepositMechanism, DepositSource, CompressorDepositProfile, WashFluid, CompressorDepositWash |
+| Compressor Anti-Surge Control | [compressor_antisurge_control.md](equipment/compressor_antisurge_control.md) | AntiSurgeController, CompressorMonitor, ThrottlingValve, Recycle |
+| Pumps | [pumps.md](equipment/pumps.md) | Pump, PumpChart |
+| Expanders | [expanders.md](equipment/expanders.md) | Expander, TurboExpanderCompressor |
+| Valves | [valves.md](equipment/valves.md) | ThrottlingValve, SafetyValve, BlowdownValve |
+| **Choke Collapse Analysis** | [choke-collapse.md](choke-collapse.md) | ChokeCollapseAnalyzer — critical pressure ratio, flashing, cavitation |
+| **Inadvertent Valve Operation** | [inadvertent-valve-operation.md](inadvertent-valve-operation.md) | InadvertentValveOperationAnalyzer — API 521 §4.4.13 / NORSOK P-002 IVO screening |
+| **Well Chokes** | [well_choke_implementation.md](well_choke_implementation.md) | Sachdeva, Gilbert choke models, ThrottlingValve integration |
+| Distillation | [distillation.md](equipment/distillation.md) | DistillationColumn, SimpleTray |
+| Absorbers | [absorbers.md](equipment/absorbers.md) | SimpleAbsorber, SimpleTEGAbsorber |
+| Ejectors | [ejectors.md](equipment/ejectors.md) | Ejector |
+| Membranes | [membranes.md](equipment/membranes.md) | MembraneSeparator |
+| Flares | [flares.md](equipment/flares.md) | Flare, FlareStack |
+| Electrolyzers | [electrolyzers.md](equipment/electrolyzers.md) | Electrolyzer, CO2Electrolyzer |
+| Filters | [filters.md](equipment/filters.md) | Particle, coalescing, strainer, and media filters with dynamic loading and mechanical design |
+| H2S Scavengers | [H2S_scavenger_guide.md](H2S_scavenger_guide.md) | H2S chemical scavenging (triazine, glyoxal, iron sponge) |
+| **Sulfur Recovery** | [sulfur_recovery.md](sulfur_recovery.md) | Integrated Claus furnace, WHB, converters, sulfur condensers, TGTU recycle, incineration, and KPIs |
+| Reactors | [reactors.md](equipment/reactors.md) | GibbsReactor |
+| Pipelines | [pipelines.md](equipment/pipelines.md) | Pipeline, AdiabaticPipe, TopsidePiping, Riser |
 | **Water Hammer Screening** | [water_hammer_implementation.md](../wiki/water_hammer_implementation.md) | WaterHammerPipe, WaterHammerStudy, MCP runWaterHammer |
-| **Piping Route Builder** | [piping_route_builder.md](piping_route_builder) | PipingRouteBuilder for STID/E3D line-list route hydraulics |
-| **CO2 Well Analysis** | [co2_injection_well_analysis.md](co2_injection_well_analysis) | CO2InjectionWellAnalyzer, ImpurityMonitor, TransientWellbore, CO2FlowCorrections |
-| **LNG Liquefaction** | [lng_liquefaction.md](lng_liquefaction) | LNGProcessBuilder, LNGProcessModel, LNGProcessBenchmark, LNGHeatExchanger |
-| **Hydrogen Production** | [hydrogen_production.md](hydrogen_production) | SMR/ATR/POX route templates, ReformerFurnace, CatalyticTubeReformer, AutothermalReformer, PartialOxidationReactor, PSACascade, Electrolyzer |
-| Looped Networks | [looped_networks.md](equipment/looped_networks) | LoopedPipeNetwork, Hardy Cross solver |
-| Gas Network Operations | [gas_network_operations.md](gas_network_operations) | Conservative mixing, coupled hydraulics, quality, optimization, and linepack |
-| Oil Network Operations | [oil_network_operations.md](oil_network_operations) | Pumps, assays, tanks, parcels, blends, and cargo scheduling |
-| Tanks | [tanks.md](equipment/tanks) | Tank, VesselDepressurization |
-| Wells | [wells.md](equipment/wells) | Well equipment |
-| Subsea Trees | [subsea_trees.md](equipment/subsea_trees) | SubseaTree, valve control |
-| Subsea Manifolds | [subsea_manifolds.md](equipment/subsea_manifolds) | SubseaManifold |
-| Subsea Boosters | [subsea_boosters.md](equipment/subsea_boosters) | SubseaBooster, multiphase pumps |
-| Umbilicals | [umbilicals.md](equipment/umbilicals) | Umbilical systems |
-| Battery Storage | [battery_storage.md](equipment/battery_storage) | BatteryStorage |
-| **Heat Integration** | [heat_integration.md](equipment/heat_integration) | PinchAnalysis, HeatStream |
-| **Power Generation** | [power_generation.md](equipment/power_generation) | GasTurbine, SteamTurbine, HRSG, CombinedCycleSystem, FuelCell, WindTurbine, SolarPanel |
-| Failure Modes | [failure_modes.md](equipment/failure_modes) | EquipmentFailureMode, reliability |
-| Mixers/Splitters | [mixers_splitters.md](equipment/mixers_splitters) | Mixer, Splitter |
+| **Piping Route Builder** | [piping_route_builder.md](piping_route_builder.md) | PipingRouteBuilder for STID/E3D line-list route hydraulics |
+| **CO2 Well Analysis** | [co2_injection_well_analysis.md](co2_injection_well_analysis.md) | CO2InjectionWellAnalyzer, ImpurityMonitor, TransientWellbore, CO2FlowCorrections |
+| **LNG Liquefaction** | [lng_liquefaction.md](lng_liquefaction.md) | LNGProcessBuilder, LNGProcessModel, LNGProcessBenchmark, LNGHeatExchanger |
+| **Hydrogen Production** | [hydrogen_production.md](hydrogen_production.md) | SMR/ATR/POX route templates, ReformerFurnace, CatalyticTubeReformer, AutothermalReformer, PartialOxidationReactor, PSACascade, Electrolyzer |
+| Looped Networks | [looped_networks.md](equipment/looped_networks.md) | LoopedPipeNetwork, Hardy Cross solver |
+| Gas Network Operations | [gas_network_operations.md](gas_network_operations.md) | Conservative mixing, coupled hydraulics, quality, optimization, and linepack |
+| Oil Network Operations | [oil_network_operations.md](oil_network_operations.md) | Pumps, assays, tanks, parcels, blends, and cargo scheduling |
+| Tanks | [tanks.md](equipment/tanks.md) | Tank, VesselDepressurization |
+| Wells | [wells.md](equipment/wells.md) | Well equipment |
+| Subsea Trees | [subsea_trees.md](equipment/subsea_trees.md) | SubseaTree, valve control |
+| Subsea Manifolds | [subsea_manifolds.md](equipment/subsea_manifolds.md) | SubseaManifold |
+| Subsea Boosters | [subsea_boosters.md](equipment/subsea_boosters.md) | SubseaBooster, multiphase pumps |
+| Umbilicals | [umbilicals.md](equipment/umbilicals.md) | Umbilical systems |
+| Battery Storage | [battery_storage.md](equipment/battery_storage.md) | BatteryStorage |
+| **Heat Integration** | [heat_integration.md](equipment/heat_integration.md) | PinchAnalysis, HeatStream |
+| **Power Generation** | [power_generation.md](equipment/power_generation.md) | GasTurbine, SteamTurbine, HRSG, CombinedCycleSystem, FuelCell, WindTurbine, SolarPanel |
+| Failure Modes | [failure_modes.md](equipment/failure_modes.md) | EquipmentFailureMode, reliability |
+| Mixers/Splitters | [mixers_splitters.md](equipment/mixers_splitters.md) | Mixer, Splitter |
 | Utility | [util/](equipment/util/) | Adjuster, Recycle, Calculator |
 
 ---
@@ -377,8 +377,8 @@ process/
 | Equipment | Documentation | Standards |
 |-----------|--------------|-----------|
 | Separators | See SeparatorMechanicalDesign | ASME, BS 5500 |
-| Compressors | [CompressorMechanicalDesign.md](CompressorMechanicalDesign) | API 617, API 672 |
-| Valves | [ValveMechanicalDesign.md](ValveMechanicalDesign) | IEC 60534, ANSI/ISA-75, ASME B16.34 |
+| Compressors | [CompressorMechanicalDesign.md](CompressorMechanicalDesign.md) | API 617, API 672 |
+| Valves | [ValveMechanicalDesign.md](ValveMechanicalDesign.md) | IEC 60534, ANSI/ISA-75, ASME B16.34 |
 
 ---
 
@@ -388,95 +388,108 @@ The `ProcessSystem` class is the container for building and running process flow
 
 ### Basic Usage
 
+The following complete Java 8 program builds and runs a valve-and-separator flowsheet. `run()` is
+the normal entry point; with the default settings it delegates to the topology-aware optimized
+dispatcher and falls back conservatively when parallel execution is not suitable.
+
 ```java
-import neqsim.process.processmodel.ProcessSystem;
-import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
 
-// Create process system
-ProcessSystem process = new ProcessSystem("Gas Processing Plant");
+public final class ProcessSystemQuickStart {
+  private ProcessSystemQuickStart() {}
 
-// Create feed stream
-SystemInterface feed = new SystemSrkEos(300.0, 80.0);
-feed.addComponent("methane", 0.85);
-feed.addComponent("ethane", 0.08);
-feed.addComponent("propane", 0.05);
-feed.addComponent("n-butane", 0.02);
-feed.setMixingRule("classic");
+  public static void main(String[] args) {
+    SystemInterface fluid = new SystemSrkEos(300.0, 80.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.08);
+    fluid.addComponent("propane", 0.05);
+    fluid.addComponent("n-butane", 0.02);
+    fluid.setMixingRule("classic");
 
-Stream feedStream = new Stream("Feed", feed);
-feedStream.setFlowRate(1000.0, "kg/hr");
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
 
-// Add equipment to process
-process.add(feedStream);
+    ThrottlingValve valve = new ThrottlingValve("inlet valve", feed);
+    valve.setOutletPressure(40.0, "bara");
 
-// Letdown valve
-ThrottlingValve valve = new ThrottlingValve("Inlet Valve", feedStream);
-valve.setOutletPressure(40.0, "bara");
-process.add(valve);
+    Separator separator = new Separator("HP separator", valve.getOutletStream());
 
-// Separator
-Separator separator = new Separator("HP Separator", valve.getOutletStream());
-process.add(separator);
+    ProcessSystem process = new ProcessSystem("gas processing plant");
+    process.add(feed);
+    process.add(valve);
+    process.add(separator);
+    process.run();
 
-// Run process (recommended - auto-optimized)
-process.runOptimized();
+    double inletMassFlowKgPerHr = feed.getFlowRate("kg/hr");
+    double gasMassFlowKgPerHr = separator.getGasOutStream().getFlowRate("kg/hr");
+    double liquidMassFlowKgPerHr =
+        separator.getLiquidOutStream().getFlowRate("kg/hr");
+    double relativeMassBalanceError =
+        Math.abs(
+                inletMassFlowKgPerHr
+                    - gasMassFlowKgPerHr
+                    - liquidMassFlowKgPerHr)
+            / inletMassFlowKgPerHr;
 
-// Get results
-System.out.println("Separator gas rate: " +
-    separator.getGasOutStream().getFlowRate("kg/hr") + " kg/hr");
-System.out.println("Separator liquid rate: " +
-    separator.getLiquidOutStream().getFlowRate("kg/hr") + " kg/hr");
+    if (!(gasMassFlowKgPerHr > 0.0)
+        || relativeMassBalanceError > 1.0e-6) {
+      throw new IllegalStateException("Invalid separator result");
+    }
+
+    if (process.hasRecycleLoops()
+        || process.getExecutionPartitionInfo().isEmpty()
+        || process.getReport_json().isEmpty()
+        || process.reportResults().length == 0
+        || process.getStreamSummaryTable().isEmpty()) {
+      throw new IllegalStateException("Incomplete process diagnostics");
+    }
+  }
+}
 ```
 
 ### Execution Strategies
 
-NeqSim provides multiple execution strategies for optimal performance:
+Use `run()` for normal simulations. By default, it delegates to `runOptimized()`, which selects a
+strategy from the current topology:
 
-| Method | Best For | Speedup |
-|--------|----------|---------|
-| `run()` | General use | baseline |
-| `runOptimized()` | **Recommended** | 28-40% |
-| `runParallel()` | Feed-forward (no recycles) | 40-57% |
-| `runHybrid()` | Complex recycle processes | 38% |
+- adjusters force sequential execution because their feedback is not represented by the graph;
+- recycle systems use the hybrid iterative path;
+- feed-forward systems use parallel or dataflow execution when their topology makes that safe;
+- unsupported or interrupted optimized paths fall back to sequential execution.
 
-```java
-// Recommended - auto-selects best strategy
-process.runOptimized();
-
-// Or use specific strategies:
-process.run();           // Sequential (default)
-process.runParallel();   // Parallel (feed-forward only)
-process.runHybrid();     // Hybrid (parallel + iterative)
-```
+`runParallel()` is a lower-level API, throws `InterruptedException`, and should be called directly
+only when the caller deliberately owns interruption handling. The public hybrid entry point is
+`runHybrid(UUID)`, not a no-argument method. Do not assume a fixed speedup: execution time depends
+on topology, unit-operation cost, recycle behavior, runtime, and hardware. Benchmark representative
+cases and confirm that results match the sequential baseline.
 
 ### Analyze Process Topology
 
-```java
-// Check for recycles
-boolean hasRecycles = process.hasRecycleLoops();
-
-// Get detailed execution analysis
-System.out.println(process.getExecutionPartitionInfo());
-```
+Use `hasRecycleLoops()` to detect cycles and `getExecutionPartitionInfo()` to inspect the
+topology-derived execution plan. The complete quick start above executes both calls.
 
 ### Key ProcessSystem Methods
 
 | Method | Description |
 |--------|-------------|
-| `add(equipment)` | Add equipment to process |
-| `run()` | Run sequential simulation |
-| `runOptimized()` | Run with auto-optimized strategy |
-| `runParallel()` | Run with parallel execution |
-| `runHybrid()` | Run with hybrid execution |
-| `runTransient(time, dt)` | Run transient simulation |
+| `add(equipment)` | Add equipment to the process |
+| `run()` | Run using the configured default; optimized dispatch is enabled by default |
+| `runOptimized()` | Select a conservative strategy from the current topology |
+| `runParallel()` | Run independent graph levels in parallel; throws `InterruptedException` |
+| `runHybrid(UUID)` | Low-level hybrid execution for recycle-containing systems |
+| `runTransient()` | Advance one transient step using the configured time step |
 | `getUnit(name)` | Get equipment by name |
-| `hasRecycleLoops()` | Check for recycle loops |
-| `getExecutionPartitionInfo()` | Get execution analysis |
-| `copy()` | Clone the process system |
-| `getReport()` | Get process report |
-| `display()` | Display process summary |
+| `hasRecycleLoops()` | Check whether the process graph contains cycles |
+| `getExecutionPartitionInfo()` | Describe the current execution partition |
+| `copy()` | Deep-copy the process system |
+| `getReport_json()` | Generate the structured JSON report |
+| `reportResults()` | Return equipment result rows |
+| `getStreamSummaryTable()` | Return a formatted stream-property table |
 
 ---
 
@@ -630,7 +643,7 @@ process.add(psv);
 
 ### Blowdown Systems
 
-See [Safety Simulation Roadmap](../safety/SAFETY_SIMULATION_ROADMAP) for detailed safety system documentation.
+See [Safety Simulation Roadmap](../safety/SAFETY_SIMULATION_ROADMAP.md) for detailed safety system documentation.
 
 ---
 
@@ -656,16 +669,12 @@ for (double t = 0; t < simulationTime; t += timeStep) {
 
 ## Process Reports
 
-```java
-// Get JSON report
-String jsonReport = process.getReport_json();
+After a successful run, use `getReport_json()` for the structured process report,
+`reportResults()` for equipment result rows, and `getStreamSummaryTable()` for a formatted stream
+summary. The complete quick start executes all three supported APIs. Treat `display()` as an
+interactive console helper rather than a machine-readable result contract.
 
-// Get tabular report
-String[][] table = process.getUnitOperationsAsTable();
-
-// Display to console
-process.display();
-```
+---
 
 ---
 
@@ -690,17 +699,17 @@ NeqSim includes foundational infrastructure to support the future of process sim
 | **Emissions Tracking** | [sustainability/](sustainability/) | CO2e accounting, regulatory reporting |
 | **Advisory Systems** | [advisory/](advisory/) | Look-ahead predictions with uncertainty |
 | **ML Integration** | [ml/](ml/) | Surrogate models, physics constraint validation |
-| **Safety Scenarios** | [safety/scenario-generation.md](safety/scenario-generation) | Automatic failure scenario generation |
-| **Batch Studies** | [optimization/batch-studies.md](optimization/batch-studies) | Parallel parameter studies |
+| **Safety Scenarios** | [safety/scenario-generation.md](safety/scenario-generation.md) | Automatic failure scenario generation |
+| **Batch Studies** | [optimization/batch-studies.md](optimization/batch-studies.md) | Parallel parameter studies |
 
-See [Future Infrastructure Overview](future-infrastructure) for complete documentation.
+See [Future Infrastructure Overview](future-infrastructure.md) for complete documentation.
 
 ---
 
 ## Related Documentation
 
 - [Equipment Documentation](equipment/) - Detailed equipment guides
-- [Process Logic Framework](../simulation/process_logic_framework) - Logic controllers
-- [Safety Systems](../safety/SAFETY_SIMULATION_ROADMAP) - Safety simulation
-- [Alarm System](../safety/alarm_system_guide) - Process alarms
-- [Future Infrastructure](future-infrastructure) - Digital twin, AI integration, sustainability
+- [Process Logic Framework](../simulation/process_logic_framework.md) - Logic controllers
+- [Safety Systems](../safety/SAFETY_SIMULATION_ROADMAP.md) - Safety simulation
+- [Alarm System](../safety/alarm_system_guide.md) - Process alarms
+- [Future Infrastructure](future-infrastructure.md) - Digital twin, AI integration, sustainability

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -444,7 +444,6 @@ public final class ProcessSystemQuickStart {
     if (process.hasRecycleLoops()
         || process.getExecutionPartitionInfo().isEmpty()
         || process.getReport_json().isEmpty()
-        || process.reportResults().length == 0
         || process.getStreamSummaryTable().isEmpty()) {
       throw new IllegalStateException("Incomplete process diagnostics");
     }
@@ -488,7 +487,6 @@ topology-derived execution plan. The complete quick start above executes both ca
 | `getExecutionPartitionInfo()` | Describe the current execution partition |
 | `copy()` | Deep-copy the process system |
 | `getReport_json()` | Generate the structured JSON report |
-| `reportResults()` | Return equipment result rows |
 | `getStreamSummaryTable()` | Return a formatted stream-property table |
 
 ---
@@ -669,10 +667,11 @@ for (double t = 0; t < simulationTime; t += timeStep) {
 
 ## Process Reports
 
-After a successful run, use `getReport_json()` for the structured process report,
-`reportResults()` for equipment result rows, and `getStreamSummaryTable()` for a formatted stream
-summary. The complete quick start executes all three supported APIs. Treat `display()` as an
-interactive console helper rather than a machine-readable result contract.
+After a successful run, use `getReport_json()` for the structured process report and
+`getStreamSummaryTable()` for a formatted stream summary. The legacy `reportResults()` aggregator
+assumes that every equipment type supplies a non-null row array and is not safe as a general
+flowsheet reporting contract. The complete quick start executes both supported APIs. Treat
+`display()` as an interactive console helper rather than a machine-readable result contract.
 
 ---
 

--- a/docs/test_process_overview_documentation.py
+++ b/docs/test_process_overview_documentation.py
@@ -105,7 +105,6 @@ class ProcessOverviewDocumentationContractTest(unittest.TestCase):
             "public synchronized void runHybrid(UUID id)",
             "public boolean hasRecycleLoops()",
             "public String getExecutionPartitionInfo()",
-            "public String[][] reportResults()",
             "public String getStreamSummaryTable()",
             "public String getReport_json()",
         ):
@@ -117,7 +116,6 @@ class ProcessOverviewDocumentationContractTest(unittest.TestCase):
             "process.hasRecycleLoops()",
             "process.getExecutionPartitionInfo()",
             "process.getReport_json()",
-            "process.reportResults()",
             "process.getStreamSummaryTable()",
         ):
             with self.subTest(documented_call=documented_call):
@@ -127,6 +125,7 @@ class ProcessOverviewDocumentationContractTest(unittest.TestCase):
         for stale_pattern in (
             "process.runHybrid();",
             "getUnitOperationsAsTable()",
+            "process.reportResults()",
             "runTransient(time, dt)",
             "28-40%",
             "40-57%",

--- a/docs/test_process_overview_documentation.py
+++ b/docs/test_process_overview_documentation.py
@@ -1,0 +1,144 @@
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = DOCS_DIR.parent
+PROCESS_OVERVIEW = DOCS_DIR / "process" / "README.md"
+PROCESS_SYSTEM = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/processmodel/ProcessSystem.java"
+)
+
+
+def heading_slugs(content):
+    content_without_fences = re.sub(
+        r"```.*?```",
+        "",
+        content,
+        flags=re.DOTALL,
+    )
+    return {
+        re.sub(r"[^a-z0-9 -]", "", heading.lower())
+        .strip()
+        .replace(" ", "-")
+        for heading in re.findall(
+            r"^#{1,6}\s+(.+)$",
+            content_without_fences,
+            flags=re.MULTILINE,
+        )
+    }
+
+
+def resolve_internal_target(source_path, destination):
+    target, _, fragment = unquote(destination).partition("#")
+    if not target:
+        return source_path, fragment
+
+    raw_target = source_path.parent / target
+    candidates = [raw_target]
+    if target.endswith("/"):
+        candidates = [raw_target / "README.md", raw_target / "index.md"]
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve(), fragment
+    raise AssertionError(
+        "Unresolved link from {}: {}".format(source_path, destination)
+    )
+
+
+class ProcessOverviewDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.overview = PROCESS_OVERVIEW.read_text(encoding="utf-8")
+        cls.process_system = PROCESS_SYSTEM.read_text(encoding="utf-8")
+
+    def test_structure_and_internal_links_are_source_safe(self):
+        self.assertTrue(self.overview.startswith("---\n"))
+        self.assertEqual(self.overview.count("```") % 2, 0)
+
+        content_without_fences = re.sub(
+            r"```.*?```",
+            "",
+            self.overview,
+            flags=re.DOTALL,
+        )
+        self.assertNotRegex(
+            content_without_fences,
+            re.compile(r"^# ", re.MULTILINE),
+        )
+
+        markdown_links = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+        for destination in markdown_links.findall(self.overview):
+            if destination.startswith(("http://", "https://", "mailto:")):
+                continue
+
+            target, _, fragment = destination.partition("#")
+            with self.subTest(destination=destination):
+                if target and not target.endswith("/"):
+                    self.assertTrue(
+                        target.endswith(".md"),
+                        "Documentation source links must include .md",
+                    )
+
+                target_path, resolved_fragment = resolve_internal_target(
+                    PROCESS_OVERVIEW,
+                    destination,
+                )
+                self.assertTrue(target_path.is_file())
+                if fragment:
+                    self.assertEqual(fragment, resolved_fragment)
+                    self.assertIn(
+                        resolved_fragment,
+                        heading_slugs(
+                            target_path.read_text(encoding="utf-8")
+                        ),
+                    )
+
+    def test_process_system_claims_match_current_source(self):
+        for signature in (
+            "public void runOptimized()",
+            "public void runParallel() throws InterruptedException",
+            "public synchronized void runHybrid(UUID id)",
+            "public boolean hasRecycleLoops()",
+            "public String getExecutionPartitionInfo()",
+            "public String[][] reportResults()",
+            "public String getStreamSummaryTable()",
+            "public String getReport_json()",
+        ):
+            with self.subTest(signature=signature):
+                self.assertIn(signature, self.process_system)
+
+        for documented_call in (
+            "process.run();",
+            "process.hasRecycleLoops()",
+            "process.getExecutionPartitionInfo()",
+            "process.getReport_json()",
+            "process.reportResults()",
+            "process.getStreamSummaryTable()",
+        ):
+            with self.subTest(documented_call=documented_call):
+                self.assertIn(documented_call, self.overview)
+
+    def test_stale_execution_and_report_patterns_do_not_return(self):
+        for stale_pattern in (
+            "process.runHybrid();",
+            "getUnitOperationsAsTable()",
+            "runTransient(time, dt)",
+            "28-40%",
+            "40-57%",
+            "`getReport()`",
+        ):
+            with self.subTest(stale_pattern=stale_pattern):
+                self.assertNotIn(stale_pattern, self.overview)
+
+        self.assertIn("public final class ProcessSystemQuickStart", self.overview)
+        self.assertIn("public static void main(String[] args)", self.overview)
+        self.assertNotIn("System.out.println", self.overview)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/test_process_overview_documentation.py
+++ b/docs/test_process_overview_documentation.py
@@ -137,7 +137,10 @@ class ProcessOverviewDocumentationContractTest(unittest.TestCase):
 
         self.assertIn("public final class ProcessSystemQuickStart", self.overview)
         self.assertIn("public static void main(String[] args)", self.overview)
-        self.assertNotIn("System.out.println", self.overview)
+        quick_start = self.overview.split(
+            "public final class ProcessSystemQuickStart", 1
+        )[1].split("```", 1)[0]
+        self.assertNotIn("System.out.println", quick_start)
 
 
 if __name__ == "__main__":

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java
@@ -1,0 +1,58 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+class ProcessSystemDocumentationTest {
+  @Test
+  void processOverviewQuickStartExecutesSupportedDiagnostics() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 80.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.08);
+    fluid.addComponent("propane", 0.05);
+    fluid.addComponent("n-butane", 0.02);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+
+    ThrottlingValve valve = new ThrottlingValve("inlet valve", feed);
+    valve.setOutletPressure(40.0, "bara");
+
+    Separator separator = new Separator("HP separator", valve.getOutletStream());
+
+    ProcessSystem process = new ProcessSystem("gas processing plant");
+    process.add(feed);
+    process.add(valve);
+    process.add(separator);
+    process.run();
+
+    double inletMassFlowKgPerHr = feed.getFlowRate("kg/hr");
+    double gasMassFlowKgPerHr = separator.getGasOutStream().getFlowRate("kg/hr");
+    double liquidMassFlowKgPerHr =
+        separator.getLiquidOutStream().getFlowRate("kg/hr");
+    double relativeMassBalanceError =
+        Math.abs(
+                inletMassFlowKgPerHr
+                    - gasMassFlowKgPerHr
+                    - liquidMassFlowKgPerHr)
+            / inletMassFlowKgPerHr;
+
+    assertTrue(gasMassFlowKgPerHr > 0.0);
+    assertTrue(relativeMassBalanceError < 1.0e-6);
+    assertSame(separator, process.getUnit("HP separator"));
+    assertFalse(process.hasRecycleLoops());
+    assertFalse(process.getExecutionPartitionInfo().isEmpty());
+    assertFalse(process.getReport_json().isEmpty());
+    assertTrue(process.reportResults().length > 0);
+    assertFalse(process.getStreamSummaryTable().isEmpty());
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java
@@ -37,14 +37,9 @@ class ProcessSystemDocumentationTest {
 
     double inletMassFlowKgPerHr = feed.getFlowRate("kg/hr");
     double gasMassFlowKgPerHr = separator.getGasOutStream().getFlowRate("kg/hr");
-    double liquidMassFlowKgPerHr =
-        separator.getLiquidOutStream().getFlowRate("kg/hr");
-    double relativeMassBalanceError =
-        Math.abs(
-                inletMassFlowKgPerHr
-                    - gasMassFlowKgPerHr
-                    - liquidMassFlowKgPerHr)
-            / inletMassFlowKgPerHr;
+    double liquidMassFlowKgPerHr = separator.getLiquidOutStream().getFlowRate("kg/hr");
+    double relativeMassBalanceError = Math.abs(inletMassFlowKgPerHr - gasMassFlowKgPerHr - liquidMassFlowKgPerHr)
+        / inletMassFlowKgPerHr;
 
     assertTrue(gasMassFlowKgPerHr > 0.0);
     assertTrue(relativeMassBalanceError < 1.0e-6);

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java
@@ -47,7 +47,6 @@ class ProcessSystemDocumentationTest {
     assertFalse(process.hasRecycleLoops());
     assertFalse(process.getExecutionPartitionInfo().isEmpty());
     assertFalse(process.getReport_json().isEmpty());
-    assertTrue(process.reportResults().length > 0);
     assertFalse(process.getStreamSummaryTable().isEmpty());
   }
 }


### PR DESCRIPTION
## Campaign

Advances documentation-quality campaign #2499, scan D055 / rotation scope 3. This draft remains in progress until merged; the issue completion ledger is not updated by an open PR.

## Frozen scope

- `docs/process/README.md`
- `docs/test_process_overview_documentation.py`
- `src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java`

Exact base: `3316d1991ad474711e6695619d7606348a0b39c1`  
Current exact head: `a4ef4d969aab4d3cf4d39cb1526294c4ca40c7a1`

Active #2969, #2970, #2971, and #2632 do not modify these three files. Controller/transient, column-telemetry, flash, benchmark-index, equipment-specific, and production execution-policy changes are excluded.

## Confirmed defects and root cause

1. **High — nonexistent execution call:** the landing page called no-argument `runHybrid()`, while current `ProcessSystem` exposes `runHybrid(UUID)` and the supported automatic dispatcher is `run()`/`runOptimized()`.
2. **High — nonexistent reporting call:** it called `getUnitOperationsAsTable()`; current source exposes `getStreamSummaryTable()` and `getReport_json()` as stable general reports.
3. **High — uncompilable parallel fragment:** the direct `runParallel()` example omitted its checked `InterruptedException` contract and was not a complete program.
4. **High — unsupported performance promises:** fixed 28–57% speedups were stated without a topology, benchmark, runtime, or hardware boundary.
5. **High — unverified primary example:** the main flowsheet was a top-level fragment with missing imports and no focused execution regression.
6. **Medium — source navigation:** 93 file destinations omitted `.md`, including entries whose visible labels already promised Markdown files.
7. **High — unsafe legacy result aggregation:** hosted execution proved that `reportResults()` dereferences nullable equipment result arrays and throws for the documented valve/separator flowsheet; it is not safe as a general reporting recommendation.

Root cause: the broad process-package landing page accumulated execution APIs, performance claims, reports, and links independently of current `ProcessSystem` source and executable documentation contracts.

## Repairs

- Replaced the primary fragment with a complete Java 8 valve/separator program that runs the normal topology-aware entry point and checks mass balance, topology diagnostics, and supported reports.
- Documented the current dispatcher boundary: adjusters use sequential execution, recycles use hybrid execution, and suitable feed-forward graphs use parallel/dataflow execution with conservative fallback.
- Replaced fixed speedup promises with representative-case benchmarking guidance.
- Replaced nonexistent reporting and transient signatures with current public APIs, and explicitly bounded the unsafe legacy `reportResults()` aggregator.
- Added `.md` to all 93 file-link destinations while preserving directory links.
- Added a hermetic source-backed contract for structure, links/fragments, exact `ProcessSystem` signatures, required calls, and rejected stale patterns.
- Added focused JUnit execution for the exact flowsheet, mass balance, unit lookup, topology, JSON/equipment/stream reports, and no-cycle result.

## Completed validation

Performed against exact GitHub source on the publication head:

- connector compare: exactly three frozen files, eight commits ahead and two behind current `master` `879eeded80135ad485de4327907fe6c3282cba08`; the intervening controller/flash changes are outside this three-file scope and GitHub reports the PR mergeable
- 111 internal-link occurrences / 105 unique internal destinations: all resolve; zero extensionless file links; no bad fragments
- front matter present; zero source H1 headings; 26 balanced code-fence markers
- stale-pattern audit: no no-argument `runHybrid()`, `getUnitOperationsAsTable()`, false `runTransient(time, dt)`, fixed speedup figures, or `getReport()` claim
- current-source signature corroboration for optimized/parallel/hybrid execution, topology diagnostics, and all three report APIs
- `docs/test_process_overview_documentation.py` Python syntax compilation: passed
- final diff inspected for scope and sensitive material: clean
- hosted Spotless: passed; inspected `spotless.patch` is zero bytes
- first hosted fast suite reproduced the unsafe `reportResults()` path after 11,629 tests; the executable example, regression, and contract now avoid and reject that call
- hosted pre-commit on the previous head: passed after applying the exact first-run formatter finding
- hosted documentation workflow: all documentation contracts, source search, Jekyll build, generated search, and JavaScript syntax passed
- hosted CodeQL, Java 21 Javadocs, and agent/skill cross-references: passed
- no equation, image, notebook, dependency, production algorithm/API, external URL, or standards claim changed

## Exact-head validation complete

All applicable workflows completed successfully on exact head `a4ef4d969aab4d3cf4d39cb1526294c4ca40c7a1`:

- build/test/Javadocs: Java 21 Ubuntu and Windows fast suites, all four slow-test shards, Java 8 Ubuntu and Windows suites, and Java 21 Javadocs passed
- Spotless format patch, pre-commit, documentation-search coverage, and CodeQL passed
- the Spotless workflow artifact remains the inspected empty formatter patch
- GitHub reports the PR mergeable; the final compare contains only the three frozen files
- no human or Copilot review submissions, inline threads, requested changes, or discussion comments remain

This connector-only follow-up did not rerun local commands, so no new local execution is claimed. The complete exact-head hosted workflow set is successful.

## Documentation impact

User-visible process-simulation guidance is corrected. No production behavior changes. The page now describes actual execution/reporting APIs and makes every internal source destination explicit.

## Review boundary

No scientific correlation, thermodynamic model, unit-operation algorithm, controller behavior, transient transaction, or performance benchmark changes. Every human and Copilot thread will be assessed on the latest head before readiness is reported.

## Next scan

After D055 merges, advance to rotation scope 4: engineering design, safety, DEXPI, and field development.