### PR TITLE
fix black oil

### DIFF
--- a/src/main/java/neqsim/blackoil/BlackOilConverter.java
+++ b/src/main/java/neqsim/blackoil/BlackOilConverter.java
@@ -460,11 +460,15 @@ public class BlackOilConverter {
     for (int i = 0; i < z.length; i++) {
       z[i] /= sum;
     }
-    sys.setMolarComposition(z);
-    try {
-      sys.setTotalNumberOfMoles(1.0);
-    } catch (Throwable ignored) {
+    // Rebuilding from an emptied fluid clears the stale phase and K-value state left by
+    // the parent flash; setMolarComposition() keeps it and the next flash can converge to
+    // the trivial single-phase solution, silently reporting Rs = 0 for a live oil.
+    sys.setEmptyFluid();
+    for (int i = 0; i < nc; i++) {
+      sys.addComponent(i, z[i]);
     }
+    sys.setTemperature(T);
+    sys.setPressure(P);
     return sys;
   }
 }

--- a/src/main/java/neqsim/process/safety/depressurization/DepressurizationSimulator.java
+++ b/src/main/java/neqsim/process/safety/depressurization/DepressurizationSimulator.java
@@ -243,9 +243,7 @@ public class DepressurizationSimulator implements Serializable {
     // basis produces an energy balance that drives the VU flash to a non-physical state
     // (instant pressure collapse, no cooling). The moles are scaled by adding per-component
     // mole deltas (preserving composition); pressure and temperature are intensive and so
-    // are unchanged. NOTE: setTotalNumberOfMoles(...) MUST NOT be used here because it only
-    // sets the scalar total without re-scaling the component moles, which corrupts the
-    // average molar mass and density.
+    // are unchanged.
     double currentMoles = fluid.getNumberOfMoles();
     double molarMass = fluid.getMolarMass(); // kg/mol
     if (molarMass > 0.0 && currentMoles > 0.0) {
@@ -348,8 +346,7 @@ public class DepressurizationSimulator implements Serializable {
       double newU = (fluid.getInternalEnergy()) + dU;
 
       // Update fluid state by VU flash (constant volume, new internal energy).
-      // Scale the remaining inventory by adding per-component mole deltas (preserving
-      // composition) instead of setTotalNumberOfMoles, which would corrupt the molar mass.
+      // Scale the remaining inventory by adding per-component mole deltas (preserving composition).
       if (mass > 0.0) {
         scaleMoles(newMass / mass);
       }
@@ -383,9 +380,7 @@ public class DepressurizationSimulator implements Serializable {
 
   /**
    * Scale the total mole inventory of the fluid by the given factor while preserving the composition (mole fractions).
-   * Each component's moles are adjusted by adding a delta of {@code currentMoles * (factor - 1)}. This is the correct
-   * way to change the absolute inventory of a closed {@link SystemInterface}; {@code setTotalNumberOfMoles} only sets
-   * the scalar total and leaves the component moles unchanged, corrupting the average molar mass.
+   * Each component's moles are adjusted by adding a delta of {@code currentMoles * (factor - 1)}.
    *
    * @param factor the multiplicative scaling factor for the total moles; values &lt;= 0, NaN or equal to 1 are ignored
    */

--- a/src/main/java/neqsim/process/safety/depressurization/NonEquilibriumBlowdownModel.java
+++ b/src/main/java/neqsim/process/safety/depressurization/NonEquilibriumBlowdownModel.java
@@ -262,9 +262,7 @@ public class NonEquilibriumBlowdownModel implements Serializable {
     double initialFluidVolume = fluid.getVolume("m3");
     if (initialFluidVolume > 0.0) {
       double chargeScale = vesselVolume / initialFluidVolume;
-      // Scale each component's moles so the composition and molar mass are preserved. Using
-      // setTotalNumberOfMoles() instead corrupts the per-component inventory, which collapses the
-      // molar mass to zero and breaks every mass-based balance downstream.
+      // Scale each component's moles so the composition and molar mass are preserved.
       scaleMoles(fluid, chargeScale);
       ops.TPflash();
       fluid.initProperties();

--- a/src/main/java/neqsim/process/safety/depressurization/VesselFillingSimulator.java
+++ b/src/main/java/neqsim/process/safety/depressurization/VesselFillingSimulator.java
@@ -222,7 +222,7 @@ public class VesselFillingSimulator implements Serializable {
     double mass = density * vesselVolume;
 
     // Align the fluid mole basis with the physical vessel inventory (see DepressurizationSimulator
-    // for the rationale; setTotalNumberOfMoles must not be used).
+    // for the rationale).
     double currentMoles = fluid.getNumberOfMoles();
     double molarMass = fluid.getMolarMass();
     if (molarMass > 0.0 && currentMoles > 0.0) {

--- a/src/main/java/neqsim/process/safety/vacuum/VacuumCollapseAnalyzer.java
+++ b/src/main/java/neqsim/process/safety/vacuum/VacuumCollapseAnalyzer.java
@@ -246,9 +246,7 @@ public class VacuumCollapseAnalyzer implements Serializable {
     state.initProperties();
 
     // Align the mole basis so the inventory exactly fills the rigid vessel volume at the
-    // initial blocked-in conditions. Scaling is done per component (preserving composition);
-    // setTotalNumberOfMoles must not be used because it leaves component moles unchanged and
-    // corrupts the average molar mass and density.
+    // initial blocked-in conditions. Scaling is done per component (preserving composition).
     double volumeM3 = state.getVolume("m3");
     if (volumeM3 > 0.0) {
       scaleMoles(state, vesselVolumeM3 / volumeM3);
@@ -339,11 +337,6 @@ public class VacuumCollapseAnalyzer implements Serializable {
 
   /**
    * Scales the absolute inventory of the closed system by the given factor while preserving composition.
-   *
-   * <p>
-   * Implemented as per-component mole additions because {@code setTotalNumberOfMoles} only sets the scalar total and
-   * leaves the component moles unchanged, corrupting the average molar mass and density.
-   * </p>
    *
    * @param state the fluid state to scale
    * @param factor multiplicative scaling factor; values &lt;= 0, NaN, or equal to 1 are ignored

--- a/src/main/java/neqsim/thermo/system/SystemInterface.java
+++ b/src/main/java/neqsim/thermo/system/SystemInterface.java
@@ -2644,7 +2644,8 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
   public void setTotalFlowRate(double flowRate, String flowunit);
 
   /**
-   * Setter for property <code>totalNumberOfMoles</code>.
+   * Setter for property <code>totalNumberOfMoles</code>. The per-component mole numbers are rescaled by the same factor
+   * so the composition is preserved and the sum of the component moles stays equal to the total.
    *
    * @param totalNumberOfMoles Total molar flow rate of fluid in unit mol/sec
    */

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -252,7 +252,7 @@ public abstract class SystemThermo implements SystemInterface {
         tmpPhase.addMolesChemReac(index, moles, moles);
       }
     }
-    setTotalNumberOfMoles(getTotalNumberOfMoles() + moles);
+    setTotalNumberOfMolesRaw(getTotalNumberOfMoles() + moles);
     // TODO: isInitialized = false;
   }
 
@@ -274,7 +274,7 @@ public abstract class SystemThermo implements SystemInterface {
       phaseArray[phaseIndex[i]].addMolesChemReac(index, moles * k, moles);
     }
 
-    setTotalNumberOfMoles(getTotalNumberOfMoles() + moles);
+    setTotalNumberOfMolesRaw(getTotalNumberOfMoles() + moles);
     // TODO: isInitialized = false;
   }
 
@@ -326,7 +326,7 @@ public abstract class SystemThermo implements SystemInterface {
         }
       }
     }
-    setTotalNumberOfMoles(getTotalNumberOfMoles() + moles);
+    setTotalNumberOfMolesRaw(getTotalNumberOfMoles() + moles);
     // TODO: isInitialized = false;
   }
 
@@ -385,7 +385,7 @@ public abstract class SystemThermo implements SystemInterface {
 
     componentNames.add(componentName);
     double k = 1.0;
-    setTotalNumberOfMoles(getTotalNumberOfMoles() + moles);
+    setTotalNumberOfMolesRaw(getTotalNumberOfMoles() + moles);
 
     for (int i = 0; i < getMaxNumberOfPhases(); i++) {
       if (phaseNumber == i) {
@@ -1396,7 +1396,7 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public void clearAll() {
-    setTotalNumberOfMoles(0);
+    setTotalNumberOfMolesRaw(0);
     phaseType[0] = PhaseType.GAS;
     phaseType[1] = PhaseType.LIQUID;
     numberOfComponents = 0;
@@ -2293,7 +2293,7 @@ public abstract class SystemThermo implements SystemInterface {
       totalMolesInSystem = 1.0e-50;
     }
 
-    newSystem.setTotalNumberOfMoles(totalMolesInSystem);
+    ((SystemThermo) newSystem).setTotalNumberOfMolesRaw(totalMolesInSystem);
     ((SystemThermo) newSystem).isInitialized = false;
 
     newSystem.init(0);
@@ -4037,7 +4037,7 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public final void initTotalNumberOfMoles(double change) {
-    setTotalNumberOfMoles(getTotalNumberOfMoles() + change);
+    setTotalNumberOfMolesRaw(getTotalNumberOfMoles() + change);
     // System.out.println("total moles: " + totalNumberOfMoles);
     for (int j = 0; j < numberOfPhases; j++) {
       for (int i = 0; i < numberOfComponents; i++) {
@@ -4206,7 +4206,7 @@ public abstract class SystemThermo implements SystemInterface {
       }
     }
 
-    newSystem.setTotalNumberOfMoles(getPhase(phaseNumber).getNumberOfMolesInPhase());
+    ((SystemThermo) newSystem).setTotalNumberOfMolesRaw(getPhase(phaseNumber).getNumberOfMolesInPhase());
 
     newSystem.init(0);
     newSystem.setNumberOfPhases(1);
@@ -4231,7 +4231,7 @@ public abstract class SystemThermo implements SystemInterface {
       }
     }
 
-    newSystem.setTotalNumberOfMoles(
+    ((SystemThermo) newSystem).setTotalNumberOfMolesRaw(
         getPhase(phaseNumber1).getNumberOfMolesInPhase() + getPhase(phaseNumber2).getNumberOfMolesInPhase());
 
     newSystem.init(0);
@@ -4255,7 +4255,7 @@ public abstract class SystemThermo implements SystemInterface {
       phaseArray[i] = newPhase.clone();
     }
 
-    setTotalNumberOfMoles(newPhase.getNumberOfMolesInPhase());
+    setTotalNumberOfMolesRaw(newPhase.getNumberOfMolesInPhase());
     this.init(0);
     setNumberOfPhases(1);
     setPhaseType(0, newPhase.getType());
@@ -4398,7 +4398,7 @@ public abstract class SystemThermo implements SystemInterface {
   public void removeComponent(String name) {
     name = ComponentInterface.getComponentNameFromAlias(name);
 
-    setTotalNumberOfMoles(getTotalNumberOfMoles() - phaseArray[0].getComponent(name).getNumberOfmoles());
+    setTotalNumberOfMolesRaw(getTotalNumberOfMoles() - phaseArray[0].getComponent(name).getNumberOfmoles());
     for (int i = 0; i < getMaxNumberOfPhases(); i++) {
       getPhase(i).removeComponent(name, getTotalNumberOfMoles(),
           getPhase(i).getComponent(name).getNumberOfMolesInPhase());
@@ -4411,7 +4411,7 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public void removePhase(int specPhase) {
-    setTotalNumberOfMoles(getTotalNumberOfMoles() - getPhase(specPhase).getNumberOfMolesInPhase());
+    setTotalNumberOfMolesRaw(getTotalNumberOfMoles() - getPhase(specPhase).getNumberOfMolesInPhase());
 
     for (int j = 0; j < numberOfPhases; j++) {
       for (int i = 0; i < numberOfComponents; i++) {
@@ -4474,7 +4474,7 @@ public abstract class SystemThermo implements SystemInterface {
     for (int i = 0; i < 2; i++) {
       phaseArray[i] = newPhase.clone();
     }
-    setTotalNumberOfMoles(newPhase.getNumberOfMolesInPhase());
+    setTotalNumberOfMolesRaw(newPhase.getNumberOfMolesInPhase());
   }
 
   /** {@inheritDoc} */
@@ -5546,7 +5546,76 @@ public abstract class SystemThermo implements SystemInterface {
        */
       totalNumberOfMoles = 0;
     }
+    rescaleComponentMoles(totalNumberOfMoles);
     this.totalNumberOfMoles = totalNumberOfMoles;
+  }
+
+  /**
+   * Sets the scalar total-moles field only, leaving the per-component mole numbers untouched. For internal bookkeeping
+   * where the caller has already updated the component moles.
+   *
+   * @param totalNumberOfMoles new total number of moles, negative values are clipped to zero
+   */
+  protected final void setTotalNumberOfMolesRaw(double totalNumberOfMoles) {
+    this.totalNumberOfMoles = totalNumberOfMoles < 0 ? 0.0 : totalNumberOfMoles;
+  }
+
+  /**
+   * Scales every component's mole numbers so they sum to {@code target}, keeping the composition unchanged. Component
+   * moles are what {@code init(0)} divides by the total to get the overall mole fractions, so a total that disagrees
+   * with the component moles makes z sum to something other than one and corrupts the next flash.
+   *
+   * @param target the new total number of moles
+   */
+  private void rescaleComponentMoles(double target) {
+    if (phaseArray == null || numberOfComponents == 0 || phaseArray[phaseIndex[0]] == null) {
+      return;
+    }
+    double current = 0.0;
+    for (int i = 0; i < numberOfComponents; i++) {
+      current += getPhase(0).getComponent(i).getNumberOfmoles();
+    }
+    if (Math.abs(target - current) <= 1.0e-12 * Math.max(1.0, Math.abs(current))) {
+      return;
+    }
+
+    double[] change = new double[numberOfComponents];
+    if (current > 1.0e-100) {
+      double factor = target / current;
+      for (int i = 0; i < numberOfComponents; i++) {
+        change[i] = factor - 1.0;
+      }
+      for (PhaseInterface tmpPhase : phaseArray) {
+        if (tmpPhase == null) {
+          continue;
+        }
+        for (int i = 0; i < numberOfComponents && i < tmpPhase.getNumberOfComponents(); i++) {
+          ComponentInterface comp = tmpPhase.getComponent(i);
+          tmpPhase.addMolesChemReac(i, comp.getNumberOfMolesInPhase() * change[i], comp.getNumberOfmoles() * change[i]);
+        }
+      }
+      return;
+    }
+
+    // Empty fluid: distribute on the stored overall mole fractions, as init(initType > 0) does.
+    double sumz = 0.0;
+    for (int i = 0; i < numberOfComponents; i++) {
+      sumz += getPhase(0).getComponent(i).getz();
+    }
+    if (sumz <= 0.0) {
+      return;
+    }
+    for (int i = 0; i < numberOfComponents; i++) {
+      change[i] = target * getPhase(0).getComponent(i).getz() / sumz;
+    }
+    for (PhaseInterface tmpPhase : phaseArray) {
+      if (tmpPhase == null) {
+        continue;
+      }
+      for (int i = 0; i < numberOfComponents && i < tmpPhase.getNumberOfComponents(); i++) {
+        tmpPhase.addMolesChemReac(i, change[i], change[i]);
+      }
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
+++ b/src/test/java/neqsim/blackoil/BlackOilConverterTest.java
@@ -121,4 +121,53 @@ class BlackOilConverterTest {
     assertEquals(expectedOilDensity, result.rho_o_sc, 0.01 * expectedOilDensity);
     assertEquals(expectedGasDensity, result.rho_g_sc, 0.02 * expectedGasDensity);
   }
+
+  /**
+   * Below the bubble point the solution gas-oil ratio of a live oil must fall smoothly with pressure. A standalone
+   * phase system rebuilt from stale flash state can converge to the trivial single-phase solution, which reports Rs = 0
+   * and Bo = 1 for an oil that plainly carries dissolved gas, so this asserts that Rs stays positive and monotone
+   * rather than merely non-negative.
+   */
+  @Test
+  void testSolutionGasOilRatioDoesNotCollapseBelowBubblePoint() {
+    SystemInterface oil = new SystemPrEos(290.4, 70.0);
+    oil.addComponent("nitrogen", 0.004);
+    oil.addComponent("CO2", 0.008);
+    oil.addComponent("methane", 0.180);
+    oil.addComponent("ethane", 0.035);
+    oil.addComponent("propane", 0.030);
+    oil.addComponent("i-butane", 0.012);
+    oil.addComponent("n-butane", 0.020);
+    oil.addComponent("i-pentane", 0.012);
+    oil.addComponent("n-pentane", 0.015);
+    oil.addComponent("n-hexane", 0.030);
+    oil.addComponent("n-heptane", 0.060);
+    oil.addComponent("n-octane", 0.070);
+    oil.addComponent("n-nonane", 0.064);
+    oil.addComponent("nC10", 0.460);
+    oil.setMixingRule("classic");
+    oil.useVolumeCorrection(true);
+    oil.setMultiPhaseCheck(true);
+
+    double[] pressures = { 20.0, 30.0, 40.0, 50.0, 55.0, 60.0, 65.0, 70.0 };
+    BlackOilConverter.Result result = BlackOilConverter.convert(oil, 290.4, pressures, 1.01325, 288.15);
+
+    double previous = 0.0;
+    for (double pressure : pressures) {
+      double rs = result.pvt.Rs(pressure);
+      assertTrue(rs > 0.0, "Rs collapsed to zero at " + pressure + " bara; the oil is live");
+      assertTrue(rs >= previous - 1.0e-9,
+          "Rs decreased with rising pressure at " + pressure + " bara: " + previous + " -> " + rs);
+      previous = rs;
+    }
+
+    // A dissolved-gas step of this size between neighbouring points is a solver artefact, not
+    // physics; the historical failure jumped from 0 to about 40 Sm3/Sm3 across one bar.
+    double[] finer = { 50.0, 51.0, 52.0, 53.0, 54.0, 55.0, 56.0, 57.0, 58.0 };
+    BlackOilConverter.Result fine = BlackOilConverter.convert(oil, 290.4, finer, 1.01325, 288.15);
+    for (int i = 1; i < finer.length; i++) {
+      double jump = Math.abs(fine.pvt.Rs(finer[i]) - fine.pvt.Rs(finer[i - 1]));
+      assertTrue(jump < 10.0, "Rs jumped by " + jump + " Sm3/Sm3 over one bar near " + finer[i] + " bara");
+    }
+  }
 }

--- a/src/test/java/neqsim/process/safety/depressurization/DepressurizationSimulatorTest.java
+++ b/src/test/java/neqsim/process/safety/depressurization/DepressurizationSimulatorTest.java
@@ -12,8 +12,7 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  *
  * <p>
  * These tests guard the mole-basis scaling fix: the simulator must align the fluid mole inventory with the physical
- * vessel volume by scaling the per-component moles (preserving composition), not via {@code setTotalNumberOfMoles},
- * which only sets the scalar total and corrupts the average molar mass. A correct basis yields a physical cold
+ * vessel volume by scaling the per-component moles, preserving composition. A correct basis yields a physical cold
  * (no-fire) blowdown: monotonic pressure decay, Joule-Thomson cooling, and a self-consistent mass inventory.
  * </p>
  *

--- a/src/test/java/neqsim/thermo/system/SystemThermoTotalNumberOfMolesTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoTotalNumberOfMolesTest.java
@@ -1,0 +1,147 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Regression tests for {@link SystemThermo#setTotalNumberOfMoles(double)}.
+ *
+ * <p>
+ * The setter used to assign the scalar total only, leaving the per-component mole numbers untouched. Since
+ * {@code init(0)} derives the overall mole fractions as {@code z = n_i / totalNumberOfMoles}, that left z summing to
+ * something other than one and the following flash converged on a corrupted feed (typically the trivial single-phase
+ * solution, e.g. Rs = 0 for a live oil in a black-oil conversion).
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class SystemThermoTotalNumberOfMolesTest {
+
+  /** Composition deliberately entered as mol% so the total moles is 100, not 1. */
+  private static SystemInterface buildRichGasInMolePercent() {
+    SystemInterface fluid = new SystemSrkEos(273.15 + 20.0, 60.0);
+    fluid.addComponent("methane", 70.0);
+    fluid.addComponent("ethane", 10.0);
+    fluid.addComponent("propane", 8.0);
+    fluid.addComponent("n-butane", 5.0);
+    fluid.addComponent("n-heptane", 7.0);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  private static double sumComponentMoles(SystemInterface fluid) {
+    double sum = 0.0;
+    for (int i = 0; i < fluid.getPhase(0).getNumberOfComponents(); i++) {
+      sum += fluid.getPhase(0).getComponent(i).getNumberOfmoles();
+    }
+    return sum;
+  }
+
+  private static double sumOverallMoleFractions(SystemInterface fluid) {
+    double sum = 0.0;
+    for (int i = 0; i < fluid.getPhase(0).getNumberOfComponents(); i++) {
+      sum += fluid.getPhase(0).getComponent(i).getz();
+    }
+    return sum;
+  }
+
+  /**
+   * Component moles must be rescaled with the total so the two stay consistent.
+   */
+  @Test
+  public void testComponentMolesFollowTotal() {
+    SystemInterface fluid = buildRichGasInMolePercent();
+    fluid.init(0);
+    double[] zBefore = fluid.getMolarComposition();
+
+    fluid.setTotalNumberOfMoles(1.0);
+    fluid.init(0);
+
+    assertEquals(1.0, fluid.getTotalNumberOfMoles(), 1e-12);
+    assertEquals(1.0, sumComponentMoles(fluid), 1e-10,
+        "sum of component moles must equal the total after setTotalNumberOfMoles");
+    double[] zAfter = fluid.getMolarComposition();
+    for (int i = 0; i < zBefore.length; i++) {
+      assertEquals(zBefore[i], zAfter[i], 1e-10, "composition must be preserved for component " + i);
+    }
+  }
+
+  /**
+   * After {@code init(0)} the overall mole fractions must still sum to one — this is what the old implementation broke.
+   */
+  @Test
+  public void testOverallMoleFractionsStayNormalisedAfterInit() {
+    SystemInterface fluid = buildRichGasInMolePercent();
+    fluid.setTotalNumberOfMoles(1.0);
+    fluid.init(0);
+
+    assertEquals(1.0, sumOverallMoleFractions(fluid), 1e-10,
+        "sum of z must be 1 after setTotalNumberOfMoles + init(0)");
+  }
+
+  /**
+   * The idiom {@code setMolarComposition(z)} followed by {@code setTotalNumberOfMoles(1.0)} must still give a physical
+   * two-phase flash. With the old setter the feed was denormalised by the factor 100 and the flash degenerated.
+   */
+  @Test
+  public void testSetMolarCompositionThenNormaliseGivesSameFlashAsReference() {
+    SystemInterface reference = buildRichGasInMolePercent();
+    new ThermodynamicOperations(reference).TPflash();
+
+    SystemInterface fluid = buildRichGasInMolePercent();
+    fluid.setMolarComposition(reference.getMolarComposition());
+    fluid.setTotalNumberOfMoles(1.0);
+    new ThermodynamicOperations(fluid).TPflash();
+
+    assertEquals(reference.getNumberOfPhases(), fluid.getNumberOfPhases(),
+        "normalising the total moles must not change the number of phases");
+    assertTrue(fluid.getNumberOfPhases() > 1, "the rich gas is two-phase at 20 C and 60 bara");
+    assertEquals(reference.getBeta(0), fluid.getBeta(0), 1e-6, "gas phase fraction must be unchanged");
+    assertEquals(1.0, fluid.getTotalNumberOfMoles(), 1e-9);
+  }
+
+  /**
+   * Rescaling an empty fluid falls back to the stored overall mole fractions, matching {@code init(initType > 0)}.
+   */
+  @Test
+  public void testRescalingAnEmptyFluidRestoresComposition() {
+    SystemInterface fluid = buildRichGasInMolePercent();
+    fluid.init(0);
+    double[] zBefore = fluid.getMolarComposition();
+
+    fluid.setEmptyFluid();
+    fluid.setTotalNumberOfMoles(1.0);
+    fluid.init(0);
+
+    assertEquals(1.0, sumComponentMoles(fluid), 1e-10);
+    double[] zAfter = fluid.getMolarComposition();
+    for (int i = 0; i < zBefore.length; i++) {
+      assertEquals(zBefore[i], zAfter[i], 1e-10, "composition must be restored for component " + i);
+    }
+  }
+
+  /** Setting the total to zero must empty the fluid rather than leave stale component moles. */
+  @Test
+  public void testZeroTotalEmptiesComponentMoles() {
+    SystemInterface fluid = buildRichGasInMolePercent();
+    fluid.setTotalNumberOfMoles(0.0);
+
+    assertEquals(0.0, fluid.getTotalNumberOfMoles(), 1e-30);
+    assertEquals(0.0, sumComponentMoles(fluid), 1e-30);
+  }
+
+  /** Adding components must not be disturbed by the rescaling setter. */
+  @Test
+  public void testAddComponentStillAccumulatesTotal() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.addComponent("ethane", 3.0);
+    fluid.setMixingRule("classic");
+
+    assertEquals(4.0, fluid.getTotalNumberOfMoles(), 1e-12);
+    assertEquals(4.0, sumComponentMoles(fluid), 1e-12);
+  }
+}


### PR DESCRIPTION
# Pull Request

Thank you for contributing to NeqSim! Please complete the following checklist before requesting review:

- [ ] Confirm `./mvnw test` runs successfully
- [ ] Verify code formatting using Checkstyle
- [ ] Update any relevant docs/README
- [ ] Link to an associated issue or discussion
- [ ] Request the applicable `CODEOWNERS` and record independent domain review where required
- [ ] Add an accepted NRC and migration note if this changes a major public contract

See [CONTRIBUTING.md](../CONTRIBUTING.md), [GOVERNANCE.md](../GOVERNANCE.md), and
[the API lifecycle policy](../docs/development/api-lifecycle.md) for the full contribution process.


## Automated engineering follow-up

**CI COMPLETE — GOVERNANCE DECISION REQUIRED**

Exact head `72cb977e2080aaa2b798d3b178c261e02ec86194` is mergeable and two commits ahead / two behind current master `7334454cb2e3978b9d140f5eac330b5182ce7a02`; the missing master commits are unrelated optimizer/documentation work.

Exact-head Spotless, pre-commit, PaperLab, CodeQL, Java 21 Javadocs, Java 21 fast tests on Linux and Windows, all four Java 21 slow-test shards, and Java 8 tests on Linux passed. The first Java 8 Windows run differed only by `6e-11 degC` in an unrelated deterministic DEXPI snapshot; the permitted one-time rerun passed without a source change.

The final ten-file diff has no comments, reviews, requested changes, or unresolved inline threads. However, the PR changes the existing public `SystemInterface.setTotalNumberOfMoles(double)` behavior from scalar assignment to composition-preserving rescaling and spans thermodynamics, black-oil, and safety-owned code. Under `GOVERNANCE.md` and the API lifecycle policy, that requires an accepted NRC, migration/compatibility documentation and accountable human review; automated CI cannot replace those approvals.

Decision required: either (1) sponsor the public-contract change through an NRC and migration path with the required independent maintainer/domain/safety review, or (2) narrow the PR to a black-oil-local repair that preserves the existing public method contract.
