### PR TITLE
feat(dynamics): make pressure transmitter state transactional

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -354,3 +354,23 @@ incomplete-coverage blocker until it overrides the transaction contract with a s
 subclass-owned mutable field. Passing this rollback gate establishes transaction mechanics only; it does not qualify
 loop
 tuning, scan-time fidelity, final-element dynamics, deterministic I/O, safety action, or OTS behavior.
+
+
+## Pressure-transmitter transaction coverage
+
+The concrete `PressureTransmitter` participates when it is registered in the `ProcessSystem`. Its snapshot preserves
+the stream binding and the inherited measurement configuration, instrument tags and field value, condition-analysis
+state, discrete-delay queue, first-order-filter memory, injected-fault accumulator, alarm configuration and mutable alarm
+state. The Java `Random` generator is captured independently, including its cached Gaussian value, so a rejected noisy
+sample replays exactly rather than merely repeating the same nominal process input. The alarm object is restored in place
+to preserve references held by alarm and operator interfaces.
+
+A transmitter consumed by a controller must also be registered as a process measurement device; the controller's
+transmitter reference does not transfer ownership of the transmitter's delay, filter, noise, fault, or alarm state.
+Coverage fails closed for `PressureTransmitter` subclasses until they extend the snapshot for subclass fields. It also
+blocks online-signal mode because database reads and their externally visible timing do not yet have a rejected-step
+commit/defer contract.
+
+This coverage establishes in-memory rollback, deterministic replay, and Java-serialization mechanics. It does not qualify
+sensor accuracy, sample-time or network jitter, alarm or trip integrity, external historian/DCS writes, safety action,
+virtual commissioning, or OTS behavior.

--- a/src/main/java/neqsim/process/alarm/AlarmState.java
+++ b/src/main/java/neqsim/process/alarm/AlarmState.java
@@ -306,4 +306,44 @@ public class AlarmState implements Serializable {
   public double getShelveExpiry() {
     return shelveExpiry;
   }
+
+  /**
+   * Creates an independent value copy for transient rollback.
+   *
+   * @return copy containing all alarm transition and shelving state
+   */
+  public AlarmState copy() {
+    AlarmState copy = new AlarmState();
+    copy.activeLevel = activeLevel;
+    copy.acknowledged = acknowledged;
+    copy.pendingLevel = pendingLevel;
+    copy.pendingTimer = pendingTimer;
+    copy.lastValue = lastValue;
+    copy.lastUpdateTime = lastUpdateTime;
+    copy.shelved = shelved;
+    copy.shelveExpiry = shelveExpiry;
+    copy.shelveReason = shelveReason;
+    return copy;
+  }
+
+  /**
+   * Restores a previously captured alarm value to this same object instance.
+   *
+   * @param snapshot alarm state returned by {@link #copy()}
+   */
+  public void restore(AlarmState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Alarm state snapshot cannot be null");
+    }
+    activeLevel = snapshot.activeLevel;
+    acknowledged = snapshot.acknowledged;
+    pendingLevel = snapshot.pendingLevel;
+    pendingTimer = snapshot.pendingTimer;
+    lastValue = snapshot.lastValue;
+    lastUpdateTime = snapshot.lastUpdateTime;
+    shelved = snapshot.shelved;
+    shelveExpiry = snapshot.shelveExpiry;
+    shelveReason = snapshot.shelveReason;
+  }
+
 }

--- a/src/main/java/neqsim/process/measurementdevice/MeasurementDeviceBaseClass.java
+++ b/src/main/java/neqsim/process/measurementdevice/MeasurementDeviceBaseClass.java
@@ -1,5 +1,12 @@
 package neqsim.process.measurementdevice;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -546,4 +553,181 @@ public abstract class MeasurementDeviceBaseClass extends NamedBaseClass implemen
   public void setConditionAnalysisMaxDeviation(double conditionAnalysisMaxDeviation) {
     this.conditionAnalysisMaxDeviation = conditionAnalysisMaxDeviation;
   }
+
+  /**
+   * Returns a blocker for measurement modes whose mutable state is outside the in-memory snapshot boundary.
+   *
+   * @return {@code null} for snapshot-ready local measurements, otherwise a blocking diagnostic
+   */
+  protected String getMeasurementTransientStateCoverageIssue() {
+    if (onlineSignal != null || isOnlineSignal) {
+      return "online measurement binding may perform external I/O and has no rejected-step commit/defer contract";
+    }
+    return null;
+  }
+
+  /**
+   * Captures all mutable state owned by this base measurement device.
+   *
+   * @return independent base-state snapshot
+   */
+  protected final MeasurementDeviceTransientState captureMeasurementDeviceTransientState() {
+    Random currentRandom = random;
+    if (currentRandom == null) {
+      currentRandom = new Random();
+      random = currentRandom;
+    }
+    return new MeasurementDeviceTransientState(getName(), getTagNumber(), unit, maximumValue, minimumValue, logging,
+        onlineSignal, isOnlineSignal, onlineMeasurementValue, onlineMeasurementValueUnit,
+        new ArrayList<Double>(delayBuffer), delaySteps, noiseStdDev, serializeRandom(currentRandom),
+        firstOrderTimeConstant, filteredPreviousValue, conditionAnalysis, conditionAnalysisMessage,
+        conditionAnalysisMaxDeviation, faultType, faultParameter, faultAccumulator, alarmConfig, alarmState.copy(), tag,
+        tagRole, fieldValue, fieldValueSet);
+  }
+
+  /**
+   * Restores base measurement state while preserving this measurement and alarm-state object identities.
+   *
+   * @param snapshot snapshot returned by {@link #captureMeasurementDeviceTransientState()}
+   */
+  protected final void restoreMeasurementDeviceTransientState(MeasurementDeviceTransientState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Measurement device transient snapshot cannot be null");
+    }
+    setName(snapshot.name);
+    setTagNumber(snapshot.tagNumber);
+    unit = snapshot.unit;
+    maximumValue = snapshot.maximumValue;
+    minimumValue = snapshot.minimumValue;
+    logging = snapshot.logging;
+    onlineSignal = snapshot.onlineSignal;
+    isOnlineSignal = snapshot.onlineSignalEnabled;
+    onlineMeasurementValue = snapshot.onlineMeasurementValue;
+    onlineMeasurementValueUnit = snapshot.onlineMeasurementValueUnit;
+    delayBuffer.clear();
+    delayBuffer.addAll(snapshot.delayBuffer);
+    delaySteps = snapshot.delaySteps;
+    noiseStdDev = snapshot.noiseStdDev;
+    random = deserializeRandom(snapshot.randomState);
+    firstOrderTimeConstant = snapshot.firstOrderTimeConstant;
+    filteredPreviousValue = snapshot.filteredPreviousValue;
+    conditionAnalysis = snapshot.conditionAnalysis;
+    conditionAnalysisMessage = snapshot.conditionAnalysisMessage;
+    conditionAnalysisMaxDeviation = snapshot.conditionAnalysisMaxDeviation;
+    faultType = snapshot.faultType;
+    faultParameter = snapshot.faultParameter;
+    faultAccumulator = snapshot.faultAccumulator;
+    alarmConfig = snapshot.alarmConfig;
+    alarmState.restore(snapshot.alarmState);
+    tag = snapshot.tag;
+    tagRole = snapshot.tagRole;
+    fieldValue = snapshot.fieldValue;
+    fieldValueSet = snapshot.fieldValueSet;
+  }
+
+  /**
+   * Serializes {@link Random}'s complete Gaussian generator state without relying on JDK internals.
+   *
+   * @param source random generator to capture
+   * @return serialized generator state
+   */
+  private static byte[] serializeRandom(Random source) {
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(source);
+      output.flush();
+      return bytes.toByteArray();
+    } catch (IOException ex) {
+      throw new IllegalStateException("Could not capture measurement random-generator state", ex);
+    }
+  }
+
+  /**
+   * Recreates a random generator from a captured state.
+   *
+   * @param state serialized generator state
+   * @return restored random generator
+   */
+  private static Random deserializeRandom(byte[] state) {
+    if (state == null) {
+      throw new IllegalArgumentException("Measurement random-generator snapshot cannot be null");
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(state))) {
+      return (Random) input.readObject();
+    } catch (IOException | ClassNotFoundException | ClassCastException ex) {
+      throw new IllegalArgumentException("Could not restore measurement random-generator state", ex);
+    }
+  }
+
+  /** Immutable snapshot of mutable state shared by concrete measurement devices. */
+  protected static final class MeasurementDeviceTransientState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String name;
+    private final String tagNumber;
+    private final String unit;
+    private final double maximumValue;
+    private final double minimumValue;
+    private final boolean logging;
+    private final OnlineSignal onlineSignal;
+    private final boolean onlineSignalEnabled;
+    private final double onlineMeasurementValue;
+    private final String onlineMeasurementValueUnit;
+    private final List<Double> delayBuffer;
+    private final int delaySteps;
+    private final double noiseStdDev;
+    private final byte[] randomState;
+    private final double firstOrderTimeConstant;
+    private final double filteredPreviousValue;
+    private final boolean conditionAnalysis;
+    private final String conditionAnalysisMessage;
+    private final double conditionAnalysisMaxDeviation;
+    private final SensorFaultType faultType;
+    private final double faultParameter;
+    private final double faultAccumulator;
+    private final AlarmConfig alarmConfig;
+    private final AlarmState alarmState;
+    private final String tag;
+    private final InstrumentTagRole tagRole;
+    private final double fieldValue;
+    private final boolean fieldValueSet;
+
+    private MeasurementDeviceTransientState(String name, String tagNumber, String unit, double maximumValue,
+        double minimumValue, boolean logging, OnlineSignal onlineSignal, boolean onlineSignalEnabled,
+        double onlineMeasurementValue, String onlineMeasurementValueUnit, List<Double> delayBuffer, int delaySteps,
+        double noiseStdDev, byte[] randomState, double firstOrderTimeConstant, double filteredPreviousValue,
+        boolean conditionAnalysis, String conditionAnalysisMessage, double conditionAnalysisMaxDeviation,
+        SensorFaultType faultType, double faultParameter, double faultAccumulator, AlarmConfig alarmConfig,
+        AlarmState alarmState, String tag, InstrumentTagRole tagRole, double fieldValue, boolean fieldValueSet) {
+      this.name = name;
+      this.tagNumber = tagNumber;
+      this.unit = unit;
+      this.maximumValue = maximumValue;
+      this.minimumValue = minimumValue;
+      this.logging = logging;
+      this.onlineSignal = onlineSignal;
+      this.onlineSignalEnabled = onlineSignalEnabled;
+      this.onlineMeasurementValue = onlineMeasurementValue;
+      this.onlineMeasurementValueUnit = onlineMeasurementValueUnit;
+      this.delayBuffer = delayBuffer;
+      this.delaySteps = delaySteps;
+      this.noiseStdDev = noiseStdDev;
+      this.randomState = randomState.clone();
+      this.firstOrderTimeConstant = firstOrderTimeConstant;
+      this.filteredPreviousValue = filteredPreviousValue;
+      this.conditionAnalysis = conditionAnalysis;
+      this.conditionAnalysisMessage = conditionAnalysisMessage;
+      this.conditionAnalysisMaxDeviation = conditionAnalysisMaxDeviation;
+      this.faultType = faultType;
+      this.faultParameter = faultParameter;
+      this.faultAccumulator = faultAccumulator;
+      this.alarmConfig = alarmConfig;
+      this.alarmState = alarmState;
+      this.tag = tag;
+      this.tagRole = tagRole;
+      this.fieldValue = fieldValue;
+      this.fieldValueSet = fieldValueSet;
+    }
+  }
+
 }

--- a/src/main/java/neqsim/process/measurementdevice/PressureTransmitter.java
+++ b/src/main/java/neqsim/process/measurementdevice/PressureTransmitter.java
@@ -85,8 +85,7 @@ public class PressureTransmitter extends StreamMeasurementDeviceBaseClass
   /** {@inheritDoc} */
   @Override
   public PressureTransmitterState captureTransientState() {
-    return new PressureTransmitterState(getTransientStateIdentity(), stream,
-        captureMeasurementDeviceTransientState());
+    return new PressureTransmitterState(getTransientStateIdentity(), stream, captureMeasurementDeviceTransientState());
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/PressureTransmitter.java
+++ b/src/main/java/neqsim/process/measurementdevice/PressureTransmitter.java
@@ -1,5 +1,8 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -9,9 +12,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author ESOL
  * @version $Id: $Id
  */
-public class PressureTransmitter extends StreamMeasurementDeviceBaseClass {
+public class PressureTransmitter extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<PressureTransmitter.PressureTransmitterState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /**
    * Constructor for PressureTransmitter.
@@ -52,4 +58,65 @@ public class PressureTransmitter extends StreamMeasurementDeviceBaseClass {
       stream.setPressure(getFieldValue(), getUnit());
     }
   }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:pressure:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete pressure transmitter in local in-memory mode.
+   *
+   * @return blocking diagnostic for subclasses or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != PressureTransmitter.class) {
+      return "pressure-transmitter subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PressureTransmitterState captureTransientState() {
+    return new PressureTransmitterState(getTransientStateIdentity(), stream,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(PressureTransmitterState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Pressure transmitter transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Pressure transmitter snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable pressure-transmitter rollback point. */
+  public static final class PressureTransmitterState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private PressureTransmitterState(String stateIdentity, StreamInterface stream,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.measurementState = measurementState;
+    }
+  }
+
 }

--- a/src/test/java/neqsim/process/measurementdevice/PressureTransmitterTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/PressureTransmitterTransientStateTransactionTest.java
@@ -1,0 +1,222 @@
+package neqsim.process.measurementdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.alarm.AlarmConfig;
+import neqsim.process.alarm.AlarmState;
+import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
+import neqsim.process.dynamics.TransientStepIdentifier;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Quantitative rollback, replay, coverage, and restart evidence for pressure-transmitter state. */
+class PressureTransmitterTransientStateTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void rollbackRestoresSignalAlarmConfigurationBindingsAndExactReplay() {
+    PressureTransmitter transmitter = createTransmitter("PT-100", 50.0);
+    Stream originalStream = (Stream) transmitter.getStream();
+    transmitter.setTagNumber("T-100");
+    transmitter.setMaximumValue(100.0);
+    transmitter.setMinimumValue(0.0);
+    transmitter.setLogging(true);
+    transmitter.setOnlineMeasurementValue(49.5, "bara");
+    transmitter.setDelaySteps(2);
+    transmitter.setNoiseStdDev(0.35);
+    transmitter.setRandomSeed(73013L);
+    transmitter.setFirstOrderTimeConstant(2.0);
+    transmitter.setFault(SensorFaultType.LINEAR_DRIFT, 0.15);
+    transmitter.setConditionAnalysis(false);
+    transmitter.setQualityCheckMessage("captured");
+    transmitter.setConditionAnalysisMaxDeviation(1.25);
+    transmitter.setTag("PT-100");
+    transmitter.setTagRole(InstrumentTagRole.BENCHMARK);
+    transmitter.setFieldValue(49.0);
+    AlarmConfig alarmConfig = AlarmConfig.builder().highLimit(55.0).delay(2.0).unit("bara").build();
+    transmitter.setAlarmConfig(alarmConfig);
+    AlarmState originalAlarmState = transmitter.getAlarmState();
+
+    // Establish non-empty delay/filter/fault/RNG history before the rollback point.
+    transmitter.getMeasuredValue();
+    transmitter.getMeasuredValue();
+
+    ProcessSystem process = new ProcessSystem("pressure transmitter transaction");
+    process.add(transmitter);
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertEquals(1, coverage.getProcessElementCount());
+    assertEquals(1, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete());
+
+    String stateIdentity = transmitter.getTransientStateIdentity();
+    TransientStepTransaction transaction = process.beginTransientStepTransaction();
+    List<Double> trialValues = new ArrayList<Double>();
+    for (int i = 0; i < 4; i++) {
+      trialValues.add(transmitter.getMeasuredValue());
+    }
+    assertTrue(transmitter.evaluateAlarm(60.0, 1.0, 1.0).isEmpty());
+
+    transmitter.setName("trial transmitter");
+    transmitter.setTagNumber("TRIAL");
+    transmitter.setUnit("Pa");
+    transmitter.setMaximumValue(999.0);
+    transmitter.setMinimumValue(-999.0);
+    transmitter.setLogging(false);
+    transmitter.setOnlineMeasurementValue(1.0, "Pa");
+    transmitter.setDelaySteps(0);
+    transmitter.setNoiseStdDev(9.0);
+    transmitter.setRandomSeed(1L);
+    transmitter.setFirstOrderTimeConstant(0.0);
+    transmitter.clearFault();
+    transmitter.setConditionAnalysis(true);
+    transmitter.setQualityCheckMessage("trial");
+    transmitter.setConditionAnalysisMaxDeviation(99.0);
+    transmitter.setTag("TRIAL");
+    transmitter.setTagRole(InstrumentTagRole.INPUT);
+    transmitter.setFieldValue(1.0);
+    transmitter.setAlarmConfig(null);
+    transmitter.setStream(createTransmitter("trial stream transmitter", 70.0).getStream());
+    transaction.rollback();
+
+    assertEquals(stateIdentity, transmitter.getTransientStateIdentity());
+    assertEquals("PT-100", transmitter.getName());
+    assertEquals("T-100", transmitter.getTagNumber());
+    assertSame(originalStream, transmitter.getStream());
+    assertEquals("bar", transmitter.getUnit());
+    assertEquals(100.0, transmitter.getMaximumValue(), 0.0);
+    assertEquals(0.0, transmitter.getMinimumValue(), 0.0);
+    assertTrue(transmitter.isLogging());
+    assertEquals(49.5, transmitter.getOnlineMeasurementValue(), 0.0);
+    assertEquals(2, transmitter.getDelaySteps());
+    assertEquals(0.35, transmitter.getNoiseStdDev(), 0.0);
+    assertEquals(2.0, transmitter.getFirstOrderTimeConstant(), 0.0);
+    assertEquals(SensorFaultType.LINEAR_DRIFT, transmitter.getFaultType());
+    assertEquals(0.15, transmitter.getFaultParameter(), 0.0);
+    assertFalse(transmitter.doConditionAnalysis());
+    assertEquals("captured", transmitter.getConditionAnalysisMessage());
+    assertEquals(1.25, transmitter.getConditionAnalysisMaxDeviation(), 0.0);
+    assertEquals("PT-100", transmitter.getTag());
+    assertEquals(InstrumentTagRole.BENCHMARK, transmitter.getTagRole());
+    assertEquals(49.0, transmitter.getFieldValue(), 0.0);
+    assertSame(alarmConfig, transmitter.getAlarmConfig());
+    assertSame(originalAlarmState, transmitter.getAlarmState());
+
+    for (int i = 0; i < trialValues.size(); i++) {
+      assertEquals(trialValues.get(i), transmitter.getMeasuredValue(), 0.0,
+          "rollback must replay Gaussian, drift, filter, and delay state exactly");
+    }
+    assertTrue(transmitter.evaluateAlarm(60.0, 1.0, 1.0).isEmpty(),
+        "rolled-back pending alarm time must not activate one sample early");
+    assertEquals(1, transmitter.evaluateAlarm(60.0, 1.0, 2.0).size());
+  }
+
+  @Test
+  void pressureTransmitterAndBasePidReplayAsOneProcessTransaction() {
+    PressureTransmitter transmitter = createTransmitter("PT-200", 50.0);
+    transmitter.setNoiseStdDev(0.2);
+    transmitter.setRandomSeed(991L);
+    transmitter.setDelaySteps(1);
+    transmitter.setFirstOrderTimeConstant(1.5);
+
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("PC-200");
+    controller.setTransmitter(transmitter);
+    controller.setUnit("bara");
+    controller.setControllerSetPoint(55.0);
+    controller.setControllerParameters(2.0, 10.0, 0.5);
+
+    ProcessSystem process = new ProcessSystem("instrument controller transaction");
+    process.add(transmitter);
+    process.add(controller);
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertEquals(2, coverage.getProcessElementCount());
+    assertEquals(2, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete());
+
+    UUID stepId = TransientStepIdentifier.deterministicPhysicalStep("instrument-controller-replay", 0L);
+    TransientStepTransaction transaction = process.beginTransientStepTransaction();
+    process.runTransient(0.5, stepId);
+    double trialControllerResponse = controller.getResponse();
+    double trialNextMeasurement = transmitter.getMeasuredValue();
+    transaction.rollback();
+
+    assertEquals(0.0, process.getTime(), 0.0);
+    process.runTransient(0.5, stepId);
+    assertEquals(trialControllerResponse, controller.getResponse(), 1.0e-12);
+    assertEquals(trialNextMeasurement, transmitter.getMeasuredValue(), 0.0);
+    assertEquals(0.5, process.getTime(), 0.0);
+  }
+
+  @Test
+  void serializedSnapshotRestoresStableIdentityAndRandomContinuation() throws Exception {
+    PressureTransmitter transmitter = createTransmitter("PT-300", 50.0);
+    transmitter.setNoiseStdDev(0.5);
+    transmitter.setRandomSeed(123456L);
+    String identity = transmitter.getTransientStateIdentity();
+    PressureTransmitter.PressureTransmitterState snapshot = transmitter.captureTransientState();
+    double expectedNextValue = transmitter.getMeasuredValue();
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(transmitter);
+      output.writeObject(snapshot);
+      serialized = bytes.toByteArray();
+    }
+
+    PressureTransmitter restoredTransmitter;
+    PressureTransmitter.PressureTransmitterState restoredSnapshot;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restoredTransmitter = (PressureTransmitter) input.readObject();
+      restoredSnapshot = (PressureTransmitter.PressureTransmitterState) input.readObject();
+    }
+
+    assertEquals(identity, restoredTransmitter.getTransientStateIdentity());
+    restoredTransmitter.restoreTransientState(restoredSnapshot);
+    assertEquals(identity, restoredTransmitter.getTransientStateIdentity());
+    assertEquals(expectedNextValue, restoredTransmitter.getMeasuredValue(), 0.0);
+  }
+
+  @Test
+  void subclassWithoutExtendedSnapshotIsReportedBeforeMutation() {
+    ProcessSystem process = new ProcessSystem("pressure transmitter subclass coverage");
+    process.add(new StatefulPressureTransmitterSubclass(createTransmitter("source", 50.0).getStream()));
+
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+
+    assertEquals(1, coverage.getProcessElementCount());
+    assertEquals(1, coverage.getParticipantCount());
+    assertFalse(coverage.isComplete());
+    assertTrue(coverage.getBlockingIssues().get(0).contains("subclass-owned mutable state"));
+  }
+
+  private static PressureTransmitter createTransmitter(String name, double pressureBara) {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, pressureBara);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream(name + " stream", fluid);
+    stream.setPressure(pressureBara, "bara");
+    return new PressureTransmitter(name, stream);
+  }
+
+  private static final class StatefulPressureTransmitterSubclass extends PressureTransmitter {
+    private static final long serialVersionUID = 1000L;
+    @SuppressWarnings("unused")
+    private double customState;
+
+    private StatefulPressureTransmitterSubclass(neqsim.process.equipment.stream.StreamInterface stream) {
+      super("custom pressure transmitter", stream);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Advances #2911 with transactional adoption of the concrete local `PressureTransmitter` family.

- snapshots the complete inherited in-memory measurement state: configuration, tag/field integration, delay queue, first-order filter memory, injected-fault accumulator, alarm configuration/state, and Gaussian RNG continuation
- restores the existing alarm-state and transmitter identities in place
- preserves the connected stream binding without claiming ownership of stream physical state
- fails closed for subclasses and for online-signal operation with external I/O
- adds quantitative exact-replay, delayed-alarm, Java-serialization, coverage, and combined pressure-transmitter/base-PID tests
- documents the registration and external-I/O boundaries

This is shared ProcessSystem transaction/orchestration scope owned by #2911. It does not implement or claim #2935 one-phase species transport or #2907 multiphase closures/slugging.

## Quantitative evidence

The new regressions require:

- `1/1` participant coverage for a standalone registered pressure transmitter
- `2/2` participant coverage for a registered pressure transmitter plus base PID
- bit-exact replay (`0.0` tolerance) of Gaussian noise, drift, first-order filtering, and sample delay after rollback
- controller replay within `1e-12` when the instrument and PID advance in one physical step
- delayed alarm activation at the same accepted sample after a rejected trial
- stable transaction identity and RNG continuation across Java serialization
- fail-closed diagnostics for an unqualified pressure-transmitter subclass

## Validation

**CI COMPLETE — HUMAN REVIEW REQUIRED**

Authoritative source/diff inspection completed against master `7334454cb2e3978b9d140f5eac330b5182ce7a02`; exact head is `848e605901eb393885c2eb5d43e73338612f5465`, six commits ahead and zero behind with five intended files.

Exact-head passed:

- hosted Spotless check/patch (the single reported line wrap was applied exactly)
- pre-commit and documentation search
- PaperLab replication gate and CodeQL
- Java 21 Javadocs
- Java 21 fast tests on Linux and Windows
- all four Java 21 slow-test shards
- Java 8 tests on Linux and Windows

GitHub reports the branch mergeable and the final diff is scope-clean. There are no comments, requested changes, or unresolved inline threads, but no accountable human review has been submitted. Because this adds public transactional and serialized behavior, `GOVERNANCE.md` requires the subsystem owner plus one independent maintainer; automated review and CI do not replace that approval. Focused Maven tests were not run locally because the available checkout is not the authoritative branch/base; the complete authoritative hosted matrix passed.

## Boundaries

This establishes in-memory rollback/replay and restart mechanics only. It does not qualify sensor accuracy, scan-time or network jitter, external historian/DCS effects, alarm/trip integrity, safety approval, virtual commissioning, or OTS behavior.

Closes no campaign issue. Advances #2911.
