### PR TITLE
docs(fielddevelopment): correct overview execution contracts

### DIFF
--- a/docs/fielddevelopment/README.md
+++ b/docs/fielddevelopment/README.md
@@ -3,7 +3,9 @@ title: Field Development Framework Documentation
 description: Field-development documentation for digital field twins spanning exploration through decommissioning.
 ---
 
-This folder contains comprehensive documentation for NeqSim's field development capabilities, enabling the creation of **digital field twins** that provide consistency from exploration through decommissioning.
+This folder documents NeqSim's field-development screening and integration capabilities from concept selection through late life. The APIs combine reservoir assumptions, facility screening, process-model generation, host-capacity checks, economics, emissions, and reservoir-simulator handoffs.
+
+The high-level helpers are screening tools. They do not by themselves provide a calibrated reservoir model, a design-grade well model, or an independently reviewed cost estimate. Preserve the engineering basis, units, fluid characterization, uncertainty, and validation evidence when moving a concept into detailed design.
 
 ---
 
@@ -21,71 +23,21 @@ This folder contains comprehensive documentation for NeqSim's field development 
 
 ---
 
-## The Digital Field Twin Concept
+## Model Continuity and Integration Boundaries
 
-NeqSim's strength is providing **calculation consistency** across the entire field lifecycle:
+NeqSim can preserve thermodynamic consistency across a workflow when the caller explicitly passes or clones the same calibrated `SystemInterface`. The field-development convenience classes do not automatically propagate a tuned fluid through every calculation.
 
-```
-┌──────────────────────────────────────────────────────────────────────────┐
-│                      DIGITAL FIELD TWIN LIFECYCLE                        │
-├──────────────────────────────────────────────────────────────────────────┤
-│                                                                          │
-│  DEVELOPMENT                    OPERATIONS                  LATE-LIFE   │
-│  ───────────                    ──────────                  ─────────   │
-│                                                                          │
-│  ┌─────────┐  ┌─────────┐  ┌───────────┐  ┌────────────┐  ┌──────────┐ │
-│  │ Concept │→ │ Select  │→ │  Design   │→ │  Optimize  │→ │ Decom-   │ │
-│  │Screening│  │& MCDA   │  │& Execute  │  │& Operate   │  │ mission  │ │
-│  └─────────┘  └─────────┘  └───────────┘  └────────────┘  └──────────┘ │
-│       │            │             │              │              │        │
-│       ▼            ▼             ▼              ▼              ▼        │
-│  ┌──────────────────────────────────────────────────────────────────┐  │
-│  │                SAME THERMODYNAMIC FOUNDATION                      │  │
-│  │  • Same fluid (SystemInterface) throughout lifecycle             │  │
-│  │  • Same EoS parameters tuned once, used everywhere               │  │
-│  │  • Consistent properties from reservoir to export                │  │
-│  └──────────────────────────────────────────────────────────────────┘  │
-│                                                                          │
-└──────────────────────────────────────────────────────────────────────────┘
-```
+### PVT to process
 
----
+Create and calibrate the fluid first, then pass a clone to each inlet `Stream`. A generated model from `ConceptToProcessLinker` instead creates a representative SRK screening fluid from the `FieldConcept` inputs. Replace that generated fluid or build the detailed `ProcessSystem` explicitly when tuned PVT behavior is required.
 
-## Key Integration Points
+### Reservoir to facilities
 
-### 1. PVT ↔ Process Integration
-The same `SystemInterface` fluid flows through wells, separators, compressors, and pipelines:
+`ReservoirCouplingExporter.generateVfpProd(String, SystemInterface, int)` accepts a fluid object and produces Eclipse-style VFP keywords. The current implementation uses a screening hydrostatic/friction correlation; it is not a full wellbore or compositional-flow calculation. Configure the export format with `setFormat(ExportFormat)`, retrieve text with `getEclipseKeywords()`, and write it with `exportToFile(String)`. Validate design work against a qualified well and flowline model.
 
-```java
-// Create fluid once with tuned parameters
-SystemInterface reservoir = new SystemSrkCPAstatoil(95, 320);
-reservoir.addComponent("methane", 0.70);
-// ... configure and tune ...
+### Technical screening to economics
 
-// Same fluid used throughout
-Stream wellStream = new Stream("well", reservoir.clone());
-Separator sep = new ThreePhaseSeparator("sep", wellStream);
-// Properties remain consistent
-```
-
-### 2. Reservoir ↔ Facilities Integration
-VFP tables ensure the same thermodynamics apply in both domains:
-
-```java
-ReservoirCouplingExporter exporter = new ReservoirCouplingExporter(processModel);
-exporter.generateVfpProd(1, "PROD-A1");
-exporter.exportToFile("vfp.inc", ExportFormat.ECLIPSE_100);
-// Reservoir simulator now uses NeqSim-consistent thermodynamics
-```
-
-### 3. Economics ↔ Technical Integration
-Decision support tools use process simulation results directly:
-
-```java
-ConceptEvaluator evaluator = new ConceptEvaluator();
-ConceptKPIs kpis = evaluator.evaluate(concept);
-// Economics (NPV, IRR) derived from technical (production, utilities)
-```
+`ConceptEvaluator.evaluate(FieldConcept)` auto-generates a facility configuration and combines simplified production, flow-assurance, safety, emissions, and economics screeners. Treat the resulting KPIs as comparative concept-screening evidence, not as project sanction or design certification.
 
 ---
 
@@ -139,116 +91,175 @@ neqsim.process.fielddevelopment/
 
 ---
 
-## Quick Start Examples
+## Executable Screening Workflow
 
-### Evaluate a Field Concept
+The following Java 8 program exercises the current public APIs for concept evaluation, option ranking, host-capacity holdback, process generation, reservoir export, and SURF cost screening. It validates key results before logging them. Replace the illustrative assumptions and screening correlations with project data and independently reviewed models before using the results for an engineering decision.
+
 ```java
-import neqsim.process.fielddevelopment.concept.*;
-import neqsim.process.fielddevelopment.evaluation.*;
-
-FieldConcept concept = FieldConcept.oilDevelopment("My Field", 8, 5000.0, 0.20);
-ConceptEvaluator evaluator = new ConceptEvaluator();
-ConceptKPIs kpis = evaluator.evaluate(concept);
-
-System.out.println("CAPEX: " + kpis.getTotalCapexMUSD() + " MUSD");
-System.out.println("Field life: " + kpis.getFieldLifeYears() + " years");
-System.out.println("Recovery: " + kpis.getEstimatedRecoveryPercent() + "%");
-System.out.println("CO2 Intensity: " + kpis.getCo2IntensityKgPerBoe() + " kg/boe");
-```
-
-### Compare Standard Development Templates
-```java
-import neqsim.process.fielddevelopment.concept.*;
-
-DevelopmentCaseTemplate tieback = GreenfieldConceptFactory.subseaTieback("Book Tieback");
-DevelopmentCaseTemplate fpso = GreenfieldConceptFactory.standaloneFpso("Book FPSO");
-
-System.out.println(tieback.getSummary());
-System.out.println(fpso.getSummary());
-System.out.println("Tieback process blocks: " + tieback.getFacilityConfig().getBlocks().size());
-```
-
-### Compare Development Options
-```java
-import neqsim.process.fielddevelopment.evaluation.*;
-
-DevelopmentOptionRanker ranker = new DevelopmentOptionRanker();
-
-DevelopmentOption fpso = ranker.addOption("FPSO");
-fpso.setScore(Criterion.NPV, 1200.0);
-fpso.setScore(Criterion.CO2_INTENSITY, 12.0);
-
-DevelopmentOption tieback = ranker.addOption("Tieback");
-tieback.setScore(Criterion.NPV, 650.0);
-tieback.setScore(Criterion.CO2_INTENSITY, 7.0);
-
-ranker.setWeightProfile("balanced");
-RankingResult result = ranker.rank();
-System.out.println("Recommended: " + result.getRankedOptions().get(0).getName());
-```
-
-### Check Host Tie-In Capacity and Holdback
-```java
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.fielddevelopment.concept.DevelopmentCaseTemplate;
+import neqsim.process.fielddevelopment.concept.FieldConcept;
+import neqsim.process.fielddevelopment.concept.GreenfieldConceptFactory;
+import neqsim.process.fielddevelopment.evaluation.ConceptEvaluator;
+import neqsim.process.fielddevelopment.evaluation.ConceptKPIs;
+import neqsim.process.fielddevelopment.evaluation.DevelopmentOptionRanker;
+import neqsim.process.fielddevelopment.evaluation.DevelopmentOptionRanker.Criterion;
+import neqsim.process.fielddevelopment.evaluation.DevelopmentOptionRanker.DevelopmentOption;
+import neqsim.process.fielddevelopment.evaluation.DevelopmentOptionRanker.RankingResult;
+import neqsim.process.fielddevelopment.facility.ConceptToProcessLinker;
+import neqsim.process.fielddevelopment.facility.ConceptToProcessLinker.FidelityLevel;
+import neqsim.process.fielddevelopment.reservoir.ReservoirCouplingExporter;
+import neqsim.process.fielddevelopment.reservoir.ReservoirCouplingExporter.ExportFormat;
+import neqsim.process.fielddevelopment.reservoir.ReservoirCouplingExporter.VfpTable;
 import neqsim.process.fielddevelopment.tieback.HostFacility;
-import neqsim.process.fielddevelopment.tieback.capacity.*;
-
-HostFacility host = HostFacility.builder("Brownfield Host")
-    .gasCapacity(10.0)
-    .build();
-
-ProductionProfileSeries base = new ProductionProfileSeries("base")
-    .addPeriod(2028, 7.0, 0.0, 0.0, 0.0);
-ProductionProfileSeries satellite = new ProductionProfileSeries("satellite")
-    .addPeriod(2028, 4.0, 0.0, 0.0, 0.0);
-
-TieInCapacityResult capacity = new TieInCapacityPlanner(host)
-    .setHostProductionProfile(base)
-    .setSatelliteProductionProfile(satellite)
-    .setAllocationPolicy(CapacityAllocationPolicy.BASE_FIRST)
-    .setHoldbackPolicy(HoldbackPolicy.DEFER_TO_LATER_YEARS)
-    .run();
-
-System.out.println(capacity.toMarkdownTable());
-```
-
-### Generate Process Model from Concept
-```java
-import neqsim.process.fielddevelopment.facility.*;
-
-ConceptToProcessLinker linker = new ConceptToProcessLinker();
-ProcessSystem process = linker.generateProcessSystem(concept, FidelityLevel.PRE_FEED);
-process.run();
-
-double powerMW = linker.getTotalPowerMW(process);
-System.out.println("Total Power Required: " + powerMW + " MW");
-```
-
-### Estimate SURF Costs
-```java
+import neqsim.process.fielddevelopment.tieback.capacity.CapacityAllocationPolicy;
+import neqsim.process.fielddevelopment.tieback.capacity.HoldbackPolicy;
+import neqsim.process.fielddevelopment.tieback.capacity.ProductionProfileSeries;
+import neqsim.process.fielddevelopment.tieback.capacity.TieInCapacityPlanner;
+import neqsim.process.fielddevelopment.tieback.capacity.TieInCapacityResult;
 import neqsim.process.mechanicaldesign.subsea.SubseaCostEstimator;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
 
-// Create estimator with regional factors (Norway, UK, GOM, Brazil, West Africa)
-SubseaCostEstimator estimator = new SubseaCostEstimator(SubseaCostEstimator.Region.NORWAY);
+public final class FieldDevelopmentOverviewExample {
+  private static final Logger logger =
+      LogManager.getLogger(FieldDevelopmentOverviewExample.class);
 
-// Calculate SURF equipment costs
-estimator.calculateTreeCost(10000.0, 7.0, 380.0, true, false);
-System.out.println("Subsea Tree: $" + String.format("%,.0f", estimator.getTotalCost()));
+  private FieldDevelopmentOverviewExample() {}
 
-estimator.calculateManifoldCost(6, 80.0, 380.0, true);
-System.out.println("Manifold: $" + String.format("%,.0f", estimator.getTotalCost()));
+  public static void main(String[] args) throws Exception {
+    FieldConcept concept =
+        FieldConcept.gasTieback("Demo gas tieback", 30.0, 2, 0.8);
+    ConceptKPIs kpis = new ConceptEvaluator().evaluate(concept);
 
-estimator.calculateUmbilicalCost(48.0, 4, 3, 2, 380.0, false);
-System.out.println("Umbilical: $" + String.format("%,.0f", estimator.getTotalCost()));
+    DevelopmentCaseTemplate tieback =
+        GreenfieldConceptFactory.subseaTieback("Book tieback");
+    DevelopmentCaseTemplate fpso =
+        GreenfieldConceptFactory.standaloneFpso("Book FPSO");
 
-estimator.calculateFlexiblePipeCost(1200.0, 8.0, 380.0, true, true);
-System.out.println("Dynamic Riser: $" + String.format("%,.0f", estimator.getTotalCost()));
+    DevelopmentOptionRanker ranker = new DevelopmentOptionRanker();
+    DevelopmentOption fpsoOption = ranker.addOption("FPSO");
+    fpsoOption.setScore(Criterion.NPV, 1200.0);
+    fpsoOption.setScore(Criterion.CO2_INTENSITY, 12.0);
+    DevelopmentOption tiebackOption = ranker.addOption("Tieback");
+    tiebackOption.setScore(Criterion.NPV, 650.0);
+    tiebackOption.setScore(Criterion.CO2_INTENSITY, 7.0);
+    RankingResult ranking = ranker.rank();
+
+    HostFacility host =
+        HostFacility.builder("Brownfield host").gasCapacity(10.0).build();
+    ProductionProfileSeries base =
+        new ProductionProfileSeries("base")
+            .addPeriod(2028, 7.0, 0.0, 0.0, 0.0);
+    ProductionProfileSeries satellite =
+        new ProductionProfileSeries("satellite")
+            .addPeriod(2028, 4.0, 0.0, 0.0, 0.0);
+    TieInCapacityResult capacity =
+        new TieInCapacityPlanner(host)
+            .setHostProductionProfile(base)
+            .setSatelliteProductionProfile(satellite)
+            .setAllocationPolicy(CapacityAllocationPolicy.BASE_FIRST)
+            .setHoldbackPolicy(HoldbackPolicy.DEFER_TO_LATER_YEARS)
+            .run();
+
+    ConceptToProcessLinker linker = new ConceptToProcessLinker();
+    ProcessSystem process =
+        linker.generateProcessSystem(concept, FidelityLevel.CONCEPT);
+    process.run();
+    double powerMW = linker.getTotalPowerMW(process);
+
+    SystemInterface baseFluid = new SystemSrkEos(358.15, 250.0);
+    baseFluid.addComponent("methane", 0.85);
+    baseFluid.addComponent("ethane", 0.08);
+    baseFluid.addComponent("propane", 0.04);
+    baseFluid.addComponent("n-butane", 0.02);
+    baseFluid.addComponent("CO2", 0.01);
+    baseFluid.setMixingRule("classic");
+
+    ReservoirCouplingExporter exporter =
+        new ReservoirCouplingExporter(process);
+    exporter.setFormat(ExportFormat.ECLIPSE_100);
+    exporter.setPressureRange(40.0, 60.0, 2);
+    exporter.setRateRange(500.0, 1000.0, 2);
+    exporter.setWctRange(0.0, 0.5, 2);
+    exporter.setGorRange(100.0, 300.0, 2);
+    VfpTable vfp = exporter.generateVfpProd("PROD-A1", baseFluid, 1);
+    String eclipseKeywords = exporter.getEclipseKeywords();
+
+    Path output = Files.createTempFile("neqsim-vfp-", ".inc");
+    try {
+      exporter.exportToFile(output.toString());
+
+      SubseaCostEstimator cost =
+          new SubseaCostEstimator(SubseaCostEstimator.Region.NORWAY);
+      cost.calculateTreeCost(10000.0, 7.0, 380.0, true, false);
+      double treeCostUSD = cost.getTotalCost();
+      cost.calculateManifoldCost(6, 80.0, 380.0, true);
+      double manifoldCostUSD = cost.getTotalCost();
+      cost.calculateUmbilicalCost(48.0, 4, 3, 2, 380.0, false);
+      double umbilicalCostUSD = cost.getTotalCost();
+      cost.calculateFlexiblePipeCost(1200.0, 8.0, 380.0, true, true);
+      double riserCostUSD = cost.getTotalCost();
+
+      if (kpis.getTotalCapexMUSD() <= 0.0
+          || tieback.getFacilityConfig() == null
+          || fpso.getFacilityConfig() == null
+          || ranking.getRankedOptions().isEmpty()
+          || !capacity.hasHoldback()
+          || process.size() < 2
+          || powerMW < 0.0
+          || vfp.getBhpValues()[0][0][0][0][0]
+              <= vfp.getThpValues()[0]
+          || !eclipseKeywords.contains("VFPPROD")
+          || Files.size(output) == 0L
+          || treeCostUSD <= 0.0
+          || manifoldCostUSD <= 0.0
+          || umbilicalCostUSD <= 0.0
+          || riserCostUSD <= 0.0) {
+        throw new IllegalStateException(
+            "Field-development screening validation failed");
+      }
+
+      logger.info(
+          "Concept {}: CAPEX {} MUSD, field life {} years, "
+              + "recovery {}%, CO2 intensity {} kg/boe",
+          concept.getName(),
+          kpis.getTotalCapexMUSD(),
+          kpis.getFieldLifeYears(),
+          kpis.getEstimatedRecoveryPercent(),
+          kpis.getCo2IntensityKgPerBoe());
+      logger.info(
+          "Recommended option {}, held-back gas {} MSm3, "
+              + "process power {} MW, VFP file {}",
+          ranking.getBestOption().getName(),
+          capacity.getTotalHeldBackGasMSm3(),
+          powerMW,
+          output);
+      logger.info(
+          "Screening costs (USD): tree {}, manifold {}, "
+              + "umbilical {}, flexible riser {}",
+          treeCostUSD,
+          manifoldCostUSD,
+          umbilicalCostUSD,
+          riserCostUSD);
+    } finally {
+      Files.deleteIfExists(output);
+    }
+  }
+}
 ```
+
+Expected checks are qualitative rather than fixed output snapshots: positive screening CAPEX and costs, populated templates and ranking, detected host holdback, a runnable generated process, a VFP bottom-hole pressure above tubing-head pressure, and a non-empty Eclipse keyword file. Results depend on the assumptions and should be reported with their units and screening limitations.
 
 ---
 
 ## SURF Equipment Classes
 
-NeqSim provides comprehensive SURF (Subsea, Umbilical, Riser, Flowline) modeling in `neqsim.process.equipment.subsea`:
+NeqSim provides screening and mechanical-design helpers for SURF (Subsea, Umbilical, Riser, Flowline) equipment in `neqsim.process.equipment.subsea`:
 
 | Class | Description |
 |-------|-------------|
@@ -261,12 +272,12 @@ NeqSim provides comprehensive SURF (Subsea, Umbilical, Riser, Flowline) modeling
 | `FlexiblePipe` | Dynamic risers and static flowlines |
 | `SubseaBooster` | Multiphase pumps and wet gas compressors |
 
-Each equipment type has a dedicated mechanical design class with:
-- Wall thickness and structural calculations
-- Design standard compliance (DNV, API, NORSOK)
-- Regional cost estimation
-- Bill of materials generation
-- JSON export for reporting
+Depending on the equipment type, the mechanical-design helper can provide:
+
+- screening wall-thickness and structural calculations;
+- standard-oriented checks that still require project verification;
+- regionalized screening-cost estimates;
+- bill-of-material and JSON-report outputs.
 
 See [SURF Subsea Equipment Guide](../process/SURF_SUBSEA_EQUIPMENT.md) for detailed documentation.
 

--- a/docs/test_fielddevelopment_overview_documentation.py
+++ b/docs/test_fielddevelopment_overview_documentation.py
@@ -1,0 +1,197 @@
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = DOCS_DIR.parent
+OVERVIEW = DOCS_DIR / "fielddevelopment" / "README.md"
+FIELD_CONCEPT = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/fielddevelopment/concept/FieldConcept.java"
+)
+OPTION_RANKER = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/fielddevelopment/evaluation"
+    / "DevelopmentOptionRanker.java"
+)
+PROCESS_LINKER = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/fielddevelopment/facility"
+    / "ConceptToProcessLinker.java"
+)
+RESERVOIR_EXPORTER = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/fielddevelopment/reservoir"
+    / "ReservoirCouplingExporter.java"
+)
+
+
+def heading_slugs(content):
+    content_without_fences = re.sub(
+        r"```.*?```",
+        "",
+        content,
+        flags=re.DOTALL,
+    )
+    return {
+        re.sub(r"[^a-z0-9 -]", "", heading.lower())
+        .strip()
+        .replace(" ", "-")
+        for heading in re.findall(
+            r"^#{1,6}\s+(.+)$",
+            content_without_fences,
+            flags=re.MULTILINE,
+        )
+    }
+
+
+def resolve_internal_target(source_path, destination):
+    target, _, fragment = unquote(destination).partition("#")
+    if not target:
+        return source_path, fragment
+
+    raw_target = source_path.parent / target
+    candidates = [raw_target]
+    if target.endswith("/"):
+        candidates = [raw_target / "README.md", raw_target / "index.md"]
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve(), fragment
+    raise AssertionError(
+        "Unresolved link from {}: {}".format(source_path, destination)
+    )
+
+
+class FieldDevelopmentOverviewDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.overview = OVERVIEW.read_text(encoding="utf-8")
+        cls.field_concept = FIELD_CONCEPT.read_text(encoding="utf-8")
+        cls.option_ranker = OPTION_RANKER.read_text(encoding="utf-8")
+        cls.process_linker = PROCESS_LINKER.read_text(encoding="utf-8")
+        cls.reservoir_exporter = RESERVOIR_EXPORTER.read_text(
+            encoding="utf-8"
+        )
+
+    def test_structure_and_internal_links_are_source_safe(self):
+        self.assertTrue(self.overview.startswith("---\n"))
+        self.assertEqual(self.overview.count("```") % 2, 0)
+
+        content_without_fences = re.sub(
+            r"```.*?```",
+            "",
+            self.overview,
+            flags=re.DOTALL,
+        )
+        self.assertNotRegex(
+            content_without_fences,
+            re.compile(r"^# ", re.MULTILINE),
+        )
+
+        markdown_links = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+        for destination in markdown_links.findall(self.overview):
+            if destination.startswith(("http://", "https://", "mailto:")):
+                continue
+            target_path, fragment = resolve_internal_target(
+                OVERVIEW,
+                destination,
+            )
+            with self.subTest(destination=destination):
+                self.assertTrue(target_path.is_file())
+                if fragment:
+                    self.assertIn(
+                        fragment,
+                        heading_slugs(
+                            target_path.read_text(encoding="utf-8")
+                        ),
+                    )
+
+    def test_documented_calls_match_current_source(self):
+        for signature in (
+            "public static FieldConcept gasTieback(",
+            "public static FieldConcept oilDevelopment(",
+        ):
+            with self.subTest(field_concept_signature=signature):
+                self.assertIn(signature, self.field_concept)
+
+        for declaration in (
+            "public enum Criterion",
+            "public static class DevelopmentOption",
+            "public static class RankingResult",
+            "public DevelopmentOption addOption(String name)",
+            "public RankingResult rank()",
+        ):
+            with self.subTest(ranker_declaration=declaration):
+                self.assertIn(declaration, self.option_ranker)
+
+        self.assertIn(
+            "public ProcessSystem generateProcessSystem("
+            "FieldConcept concept, FidelityLevel fidelity)",
+            self.process_linker.replace("\n", " "),
+        )
+        for signature in (
+            "public VfpTable generateVfpProd("
+            "String wellName, SystemInterface baseFluid, int tableNumber)",
+            "public void setFormat(ExportFormat format)",
+            "public String getEclipseKeywords()",
+            "public void exportToFile(String filePath) throws IOException",
+        ):
+            with self.subTest(exporter_signature=signature):
+                self.assertIn(
+                    signature,
+                    self.reservoir_exporter.replace("\n", " "),
+                )
+
+        for documented_call in (
+            'FieldConcept.gasTieback("Demo gas tieback", 30.0, 2, 0.8)',
+            "new ConceptEvaluator().evaluate(concept)",
+            'ranker.addOption("FPSO")',
+            "fpsoOption.setScore(Criterion.NPV, 1200.0)",
+            "new TieInCapacityPlanner(host)",
+            "linker.generateProcessSystem(concept, FidelityLevel.CONCEPT)",
+            "process.run();",
+            'exporter.generateVfpProd("PROD-A1", baseFluid, 1)',
+            "exporter.exportToFile(output.toString());",
+            "cost.calculateTreeCost(",
+            "cost.calculateManifoldCost(",
+            "cost.calculateUmbilicalCost(",
+            "cost.calculateFlexiblePipeCost(",
+        ):
+            with self.subTest(documented_call=documented_call):
+                self.assertIn(documented_call, self.overview)
+
+    def test_stale_calls_claims_and_output_patterns_do_not_return(self):
+        for stale_pattern in (
+            "SystemSrkCPAstatoil(95, 320)",
+            "new ReservoirCouplingExporter(processModel)",
+            'generateVfpProd(1, "PROD-A1")',
+            'exportToFile("vfp.inc", ExportFormat.ECLIPSE_100)',
+            "System.out.",
+            "same EoS parameters tuned once, used everywhere",
+            "VFP tables ensure the same thermodynamics",
+            "design standard compliance",
+        ):
+            with self.subTest(stale_pattern=stale_pattern):
+                self.assertNotIn(stale_pattern, self.overview)
+
+        self.assertIn(
+            "public final class FieldDevelopmentOverviewExample",
+            self.overview,
+        )
+        self.assertIn(
+            "public static void main(String[] args) throws Exception",
+            self.overview,
+        )
+        self.assertNotIn("import neqsim.process.fielddevelopment.*", self.overview)
+        self.assertIn("screening hydrostatic/friction correlation", self.overview)
+        self.assertIn(
+            "do not automatically propagate a tuned fluid",
+            self.overview,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/neqsim/process/fielddevelopment/FieldDevelopmentOverviewDocumentationTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/FieldDevelopmentOverviewDocumentationTest.java
@@ -1,0 +1,155 @@
+package neqsim.process.fielddevelopment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import neqsim.process.fielddevelopment.concept.DevelopmentCaseTemplate;
+import neqsim.process.fielddevelopment.concept.FieldConcept;
+import neqsim.process.fielddevelopment.concept.GreenfieldConceptFactory;
+import neqsim.process.fielddevelopment.evaluation.ConceptEvaluator;
+import neqsim.process.fielddevelopment.evaluation.ConceptKPIs;
+import neqsim.process.fielddevelopment.evaluation.DevelopmentOptionRanker;
+import neqsim.process.fielddevelopment.evaluation.DevelopmentOptionRanker.Criterion;
+import neqsim.process.fielddevelopment.evaluation.DevelopmentOptionRanker.DevelopmentOption;
+import neqsim.process.fielddevelopment.evaluation.DevelopmentOptionRanker.RankingResult;
+import neqsim.process.fielddevelopment.facility.ConceptToProcessLinker;
+import neqsim.process.fielddevelopment.facility.ConceptToProcessLinker.FidelityLevel;
+import neqsim.process.fielddevelopment.reservoir.ReservoirCouplingExporter;
+import neqsim.process.fielddevelopment.reservoir.ReservoirCouplingExporter.ExportFormat;
+import neqsim.process.fielddevelopment.reservoir.ReservoirCouplingExporter.VfpTable;
+import neqsim.process.fielddevelopment.tieback.HostFacility;
+import neqsim.process.fielddevelopment.tieback.capacity.CapacityAllocationPolicy;
+import neqsim.process.fielddevelopment.tieback.capacity.HoldbackPolicy;
+import neqsim.process.fielddevelopment.tieback.capacity.ProductionProfileSeries;
+import neqsim.process.fielddevelopment.tieback.capacity.TieInCapacityPlanner;
+import neqsim.process.fielddevelopment.tieback.capacity.TieInCapacityResult;
+import neqsim.process.fielddevelopment.tieback.capacity.TieInPeriodResult;
+import neqsim.process.mechanicaldesign.subsea.SubseaCostEstimator;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Executable regression coverage for the field-development overview.
+ *
+ * @author ESOL
+ * @version 1.0
+ */
+class FieldDevelopmentOverviewDocumentationTest extends neqsim.NeqSimTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void conceptEvaluationTemplatesAndNestedRankingTypesExecute() {
+    FieldConcept concept = FieldConcept.gasTieback("Demo gas tieback", 30.0, 2, 0.8);
+    ConceptKPIs kpis = new ConceptEvaluator().evaluate(concept);
+
+    assertEquals("Demo gas tieback", kpis.getConceptName());
+    assertTrue(kpis.getTotalCapexMUSD() > 0.0);
+    assertTrue(kpis.getFieldLifeYears() > 0.0);
+    assertTrue(kpis.getEstimatedRecoveryPercent() > 0.0);
+    assertTrue(kpis.getCo2IntensityKgPerBoe() >= 0.0);
+
+    DevelopmentCaseTemplate tieback = GreenfieldConceptFactory.subseaTieback("Book tieback");
+    DevelopmentCaseTemplate fpso = GreenfieldConceptFactory.standaloneFpso("Book FPSO");
+
+    assertNotNull(tieback.getFacilityConfig());
+    assertNotNull(fpso.getFacilityConfig());
+    assertFalse(tieback.getSummary().isEmpty());
+    assertFalse(fpso.getSummary().isEmpty());
+
+    DevelopmentOptionRanker ranker = new DevelopmentOptionRanker();
+    DevelopmentOption fpsoOption = ranker.addOption("FPSO");
+    fpsoOption.setScore(Criterion.NPV, 1200.0);
+    fpsoOption.setScore(Criterion.CO2_INTENSITY, 12.0);
+    DevelopmentOption tiebackOption = ranker.addOption("Tieback");
+    tiebackOption.setScore(Criterion.NPV, 650.0);
+    tiebackOption.setScore(Criterion.CO2_INTENSITY, 7.0);
+
+    RankingResult ranking = ranker.rank();
+
+    assertEquals(2, ranking.getRankedOptions().size());
+    assertEquals("FPSO", ranking.getBestOption().getName());
+  }
+
+  @Test
+  void hostCapacityWorkflowReportsTheDocumentedHoldback() {
+    HostFacility host = HostFacility.builder("Brownfield host").gasCapacity(10.0).build();
+    ProductionProfileSeries base =
+        new ProductionProfileSeries("base").addPeriod(2028, 7.0, 0.0, 0.0, 0.0);
+    ProductionProfileSeries satellite =
+        new ProductionProfileSeries("satellite").addPeriod(2028, 4.0, 0.0, 0.0, 0.0);
+
+    TieInCapacityResult capacity = new TieInCapacityPlanner(host).setHostProductionProfile(base)
+        .setSatelliteProductionProfile(satellite).setAllocationPolicy(CapacityAllocationPolicy.BASE_FIRST)
+        .setHoldbackPolicy(HoldbackPolicy.DEFER_TO_LATER_YEARS).run();
+
+    TieInPeriodResult period = capacity.getPeriodResults().get(0);
+    assertTrue(capacity.hasHoldback());
+    assertEquals(3.0, period.getAcceptedSatellite().getGasRateMSm3d(), 1.0e-9);
+    assertEquals(1.0, period.getHeldBackSatellite().getGasRateMSm3d(), 1.0e-9);
+    assertFalse(capacity.toMarkdownTable().isEmpty());
+  }
+
+  @Test
+  void generatedScreeningProcessRunsAndExposesUtilities() {
+    FieldConcept concept = FieldConcept.gasTieback("Demo gas tieback", 30.0, 2, 0.8);
+    ConceptToProcessLinker linker = new ConceptToProcessLinker();
+    ProcessSystem process = linker.generateProcessSystem(concept, FidelityLevel.CONCEPT);
+
+    assertTrue(process.size() >= 5);
+    process.run();
+
+    assertTrue(linker.getTotalPowerMW(process) >= 0.0);
+    assertTrue(linker.getUtilitySummary(process).contains("UTILITY SUMMARY"));
+  }
+
+  @Test
+  void reservoirExportAndSurfScreeningUseCurrentSignatures() throws IOException {
+    SystemInterface baseFluid = new SystemSrkEos(358.15, 250.0);
+    baseFluid.addComponent("methane", 0.85);
+    baseFluid.addComponent("ethane", 0.08);
+    baseFluid.addComponent("propane", 0.04);
+    baseFluid.addComponent("n-butane", 0.02);
+    baseFluid.addComponent("CO2", 0.01);
+    baseFluid.setMixingRule("classic");
+
+    ReservoirCouplingExporter exporter = new ReservoirCouplingExporter();
+    exporter.setFormat(ExportFormat.ECLIPSE_100);
+    exporter.setPressureRange(40.0, 60.0, 2);
+    exporter.setRateRange(500.0, 1000.0, 2);
+    exporter.setWctRange(0.0, 0.5, 2);
+    exporter.setGorRange(100.0, 300.0, 2);
+
+    VfpTable vfp = exporter.generateVfpProd("PROD-A1", baseFluid, 1);
+    String eclipseKeywords = exporter.getEclipseKeywords();
+
+    assertEquals(1, vfp.getTableNumber());
+    assertEquals("PROD-A1", vfp.getWellName());
+    assertTrue(vfp.getBhpValues()[0][0][0][0][0] > vfp.getThpValues()[0]);
+    assertTrue(eclipseKeywords.contains("VFPPROD"));
+
+    Path output = temporaryDirectory.resolve("vfp.inc");
+    exporter.exportToFile(output.toString());
+    String written = new String(Files.readAllBytes(output), StandardCharsets.UTF_8);
+    assertTrue(written.contains("VFPPROD"));
+
+    SubseaCostEstimator cost = new SubseaCostEstimator(SubseaCostEstimator.Region.NORWAY);
+    cost.calculateTreeCost(10000.0, 7.0, 380.0, true, false);
+    assertTrue(cost.getTotalCost() > 0.0);
+    cost.calculateManifoldCost(6, 80.0, 380.0, true);
+    assertTrue(cost.getTotalCost() > 0.0);
+    cost.calculateUmbilicalCost(48.0, 4, 3, 2, 380.0, false);
+    assertTrue(cost.getTotalCost() > 0.0);
+    cost.calculateFlexiblePipeCost(1200.0, 8.0, 380.0, true, true);
+    assertTrue(cost.getTotalCost() > 0.0);
+  }
+}

--- a/src/test/java/neqsim/process/fielddevelopment/FieldDevelopmentOverviewDocumentationTest.java
+++ b/src/test/java/neqsim/process/fielddevelopment/FieldDevelopmentOverviewDocumentationTest.java
@@ -83,10 +83,8 @@ class FieldDevelopmentOverviewDocumentationTest extends neqsim.NeqSimTest {
   @Test
   void hostCapacityWorkflowReportsTheDocumentedHoldback() {
     HostFacility host = HostFacility.builder("Brownfield host").gasCapacity(10.0).build();
-    ProductionProfileSeries base =
-        new ProductionProfileSeries("base").addPeriod(2028, 7.0, 0.0, 0.0, 0.0);
-    ProductionProfileSeries satellite =
-        new ProductionProfileSeries("satellite").addPeriod(2028, 4.0, 0.0, 0.0, 0.0);
+    ProductionProfileSeries base = new ProductionProfileSeries("base").addPeriod(2028, 7.0, 0.0, 0.0, 0.0);
+    ProductionProfileSeries satellite = new ProductionProfileSeries("satellite").addPeriod(2028, 4.0, 0.0, 0.0, 0.0);
 
     TieInCapacityResult capacity = new TieInCapacityPlanner(host).setHostProductionProfile(base)
         .setSatelliteProductionProfile(satellite).setAllocationPolicy(CapacityAllocationPolicy.BASE_FIRST)


### PR DESCRIPTION
## Campaign

Advances documentation-quality campaign #2499, scan D056 / rotation scope 4. The completion ledger remains unchanged until this draft is merged.

## Exact scope

Base: `6481aaf714c5f8d6c3392abfb7c0da3ce2c29a80`  
Head: `791566ca380034027178afa10c817648408e23b7`

Frozen paths:

- `docs/fielddevelopment/README.md`
- `docs/test_fielddevelopment_overview_documentation.py`
- `src/test/java/neqsim/process/fielddevelopment/FieldDevelopmentOverviewDocumentationTest.java`

Open autonomous drafts #2979 and #2632 do not touch these files. The field-development API guide, notebooks, production algorithms, reservoir/well models, DEXPI/diagram work, benchmark framework, and reference index are excluded.

## Confirmed defects and evidence

1. **High — stale reservoir export calls:** the page passed an undefined `processModel`, called nonexistent `generateVfpProd(int, String)`, and called nonexistent `exportToFile(String, ExportFormat)`.
2. **High — uncompilable ranking example:** wildcard package imports do not import nested `DevelopmentOption`, `Criterion`, or `RankingResult` types.
3. **High — incomplete process-linker example:** it omitted `ProcessSystem`, used nested `FidelityLevel` unqualified, and depended on an undefined `concept`.
4. **High — misleading model continuity:** the page promised that a tuned fluid and EOS were automatically reused everywhere. Current `ConceptToProcessLinker` creates a representative SRK screening fluid instead.
5. **High — overstated VFP physics:** the page said VFP tables ensured common thermodynamics. Current `generateVfpProd` accepts a `SystemInterface` but computes BHP with a screening hydrostatic/friction correlation.
6. **Medium — repository-incompatible output:** nine Java fences contained 14 `System.out` calls, prohibited by the repository's example rules.
7. **Medium — unqualified design claims:** SURF helpers were described as comprehensive standards compliance rather than screening and standard-oriented calculations requiring project verification.
8. **High — missing executable contract:** no focused regression compiled/executed the landing-page workflow; the existing documentation test covers a different economics notebook.

## Repairs

- Consolidates incomplete fragments into one complete Java 8 program with explicit imports, Log4j2 output, validation guards, current nested types, current exporter signatures, and safe temporary-file handling.
- Executes concept evaluation, template creation, MCDA ranking, host-capacity holdback, generated process execution, VFP export, and four SURF screening-cost calls.
- Defines the tuned-fluid handoff boundary, the representative-fluid behavior of `ConceptToProcessLinker`, and the screening nature of the current VFP and cost helpers.
- Adds a hermetic front-matter, link, source-signature, example, and stale-pattern contract.
- Adds four focused JUnit tests with quantitative holdback, process, BHP, export, and positive-screening-result assertions.

## Validation completed before publication

Connector/static validation on the exact head:

- exact three-file compare: 2 commits ahead / 0 behind the base;
- Python contract syntax compilation: passed;
- 22 Markdown link occurrences inspected; all 20 internal targets resolve;
- both external GitHub notebook targets exist at the exact base;
- front matter present, no source H1, four balanced fence markers;
- one complete Java fence, no wildcard NeqSim import and no `System.out`;
- changed Python lines are at most 100 characters and changed Java-test lines at most 120 characters;
- no equation, image, notebook, external standards link, production API, or dependency changed;
- final diff contains only the three frozen files and no sensitive material.

## VALIDATION PENDING CI

This runtime has no NeqSim checkout, so these commands were not run locally and are not claimed as passed:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`
- `./mvnw test -Dtest=FieldDevelopmentOverviewDocumentationTest`
- broader Java 8/21 build, tests, Javadocs, Jekyll/search, and CodeQL

GitHub CI is the follow-up validator. The first exact-head pre-commit run found one attributable Spotless wrapping violation in the focused JUnit test. Commit `791566ca380034027178afa10c817648408e23b7` applies the exact formatter diff; on that head, the pre-commit and Spotless workflows pass. Documentation search and CodeQL now pass on the exact head. The Java 21 Javadocs job also passes; fast and slow Java test jobs are still running, so the overall build/test/Javadocs workflow is not yet claimed as passed. Any further attributable formatting, compilation, runtime, link, or review finding will be repaired on this same draft before readiness is classified.

## Documentation impact

User-visible field-development guidance is corrected to match current source and to distinguish screening tools from calibrated PVT, qualified wellbore/process models, and design-grade cost or standards work. No production behavior changes.

## Stop boundary and next scan

This PR stops before the large `API_GUIDE.md`, notebook execution, production-code fixes, model calibration, DEXPI/diagram work, or reference-index changes. After D056 merges, the next rotation scope is PVT, flow assurance, standards, and gas/oil quality.