### PR TITLE
fix(pipeline): separate stagnant inner HTC ownership

### DIFF
--- a/CHANGELOG_AGENT_NOTES.md
+++ b/CHANGELOG_AGENT_NOTES.md
@@ -9,6 +9,16 @@
 
 ---
 
+## 2026-08-13 — Independent stagnant inner HTC for TwoFluidPipe cooldown
+
+- `TwoFluidPipe.setStagnantInnerHeatTransferCoefficient(...)` and its getter now own the zero-local-throughput
+  fluid-to-wall coefficient used by the multi-layer transient model. The documented default is 50 W/(m²·K).
+- `setHeatTransferCoefficient(...)` remains the simple-model or configuration-level overall U-value and no longer
+  becomes the closed-flow inner film coefficient. Multi-layer shutdown results are therefore independent of whether
+  that overall coefficient is set before or after radial-layer configuration.
+- Migration: replace post-configuration `setHeatTransferCoefficient(value)` workarounds that intended to set the
+  stagnant fluid film with `setStagnantInnerHeatTransferCoefficient(value)`.
+
 ## 2026-08-12 — Reversible ProcessModel operating actions
 
 - `ProcessModelOperatingAction` adds immutable, serializable action identity, area-qualified

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -587,6 +587,9 @@ pipe.setSurfaceTemperature(4.0, "C"); // Cold seabed
 pipe.configureSubseaThermalModel(0.050, 0.040,
     RadialThermalLayer.MaterialType.PU_FOAM);
 
+// Explicit shutdown assumption; the documented default is also 50 W/(m2 K)
+pipe.setStagnantInnerHeatTransferCoefficient(50.0);
+
 // Set hydrate formation temperature
 pipe.setHydrateFormationTemperature(20.0, "C");
 
@@ -603,6 +606,14 @@ System.out.println(pipe.getThermalSummary());
 
 ### Thermal Calculations
 - **Overall U-value**: Based on series thermal resistance through all layers
+- **Coefficient ownership**: `setHeatTransferCoefficient(...)` is the simple-model or configuration-level overall
+  U-value. In the multi-layer transient model it enables heat transfer but is not reused as a fluid-side film
+  coefficient, so calling it before or after radial-layer configuration does not change closed-flow heat flux.
+- **Closed-flow inner HTC**: `setStagnantInnerHeatTransferCoefficient(...)` controls the zero-throughput fluid-to-wall
+  film coefficient independently. The default is 50 W/(m²·K), a pragmatic gas-rich shutdown assumption; set a
+  case-specific value for the fluid inventory and natural-convection regime being studied.
+- **Flowing inner HTC**: Cells with local face throughput use the model's laminar constant-Nusselt or turbulent
+  Dittus-Boelter correlation instead of the stagnant value.
 - **Transient response**: Explicit finite-difference with thermal mass in each layer
 - **Cooldown time**: Lumped capacitance approximation for shutdown scenarios
 - **Transient advection**: Uses the gas, oil, and water mass flow retained from each conservative AUSM+ integration

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -121,6 +121,9 @@ public class TwoFluidPipe extends Pipeline {
   /** Upper no-slip fraction for the trace-liquid asymptote of the stratified closure. */
   private static final double STRATIFIED_TRACE_LIQUID_TRANSITION = 1.0e-6;
 
+  /** Default closed-flow fluid-side heat-transfer coefficient in W/(m2 K). */
+  private static final double DEFAULT_STAGNANT_INNER_HEAT_TRANSFER_COEFFICIENT = 50.0;
+
   // ============ Geometry ============
 
   /** Total pipe length (m). */
@@ -259,8 +262,11 @@ public class TwoFluidPipe extends Pipeline {
   /** Surface temperature for heat transfer (K). */
   private double surfaceTemperature = 288.15;
 
-  /** Heat transfer coefficient (W/(m²·K)). */
+  /** Overall or simple-model heat transfer coefficient (W/(m²·K)). */
   private double heatTransferCoefficient = 0.0;
+
+  /** Fluid-side heat transfer coefficient used at zero local throughput (W/(m²·K)). */
+  private double stagnantInnerHeatTransferCoefficient = DEFAULT_STAGNANT_INNER_HEAT_TRANSFER_COEFFICIENT;
 
   /** Heat transfer coefficient profile along pipe (W/(m²·K)). */
   private double[] heatTransferProfile = null;
@@ -2196,16 +2202,18 @@ public class TwoFluidPipe extends Pipeline {
    * Calculate inner (fluid-side) heat transfer coefficient based on flow conditions.
    *
    * <p>
-   * Uses Dittus-Boelter correlation for turbulent flow, constant Nusselt for laminar.
+   * Uses the configured stagnant coefficient at zero local face throughput, Dittus-Boelter for turbulent flow, and a
+   * constant Nusselt number for laminar flow. The stagnant coefficient is independent of the overall pipe-to-ambient
+   * coefficient used by the simple thermal model.
    * </p>
    *
    * @param massFlow Mass flow rate [kg/s]
    * @param area Pipe cross-sectional area [m²]
    * @return Inner HTC in W/(m²·K)
    */
-  private double calculateInnerHTC(double massFlow, double area) {
+  double calculateInnerHTC(double massFlow, double area) {
     if (massFlow <= 0 || area <= 0) {
-      return heatTransferCoefficient; // Default
+      return stagnantInnerHeatTransferCoefficient;
     }
 
     SystemInterface fluid = getInletStream().getFluid();
@@ -6417,11 +6425,11 @@ public class TwoFluidPipe extends Pipeline {
   }
 
   /**
-   * Set heat transfer coefficient for convective heat transfer.
+   * Set the overall heat transfer coefficient used by the simple thermal model.
    *
    * <p>
-   * Heat transfer rate: Q = h * A * (T_pipe - T_surface)<br>
-   * where h = heat transfer coefficient (W/(m²·K))<br>
+   * Heat transfer rate: Q = U * A * (T_pipe - T_surface)<br>
+   * where U = overall heat transfer coefficient (W/(m²·K))<br>
    * A = pipe surface area (m²)<br>
    * T_pipe = bulk fluid temperature (K)<br>
    * T_surface = surrounding surface temperature (K)<br>
@@ -6435,7 +6443,13 @@ public class TwoFluidPipe extends Pipeline {
    * <li>Exposed/above-ground pipe: 50-100 W/(m²·K)</li>
    * </ul>
    *
-   * @param heatTransferCoefficient Heat transfer coefficient in W/(m²·K)
+   * <p>
+   * For the multi-layer model, this value enables heat transfer and reports the configuration-level overall U-value; it
+   * is not used as the fluid-side film coefficient. Configure the zero-throughput fluid film with
+   * {@link #setStagnantInnerHeatTransferCoefficient(double)}.
+   * </p>
+   *
+   * @param heatTransferCoefficient overall heat transfer coefficient in W/(m²·K)
    */
   @Override
   public void setHeatTransferCoefficient(double heatTransferCoefficient) {
@@ -6465,13 +6479,43 @@ public class TwoFluidPipe extends Pipeline {
   }
 
   /**
-   * Get the heat transfer coefficient.
+   * Get the overall or simple-model heat transfer coefficient.
    *
-   * @return Heat transfer coefficient in W/(m²·K)
+   * @return overall heat transfer coefficient in W/(m²·K)
    */
   @Override
   public double getHeatTransferCoefficient() {
     return heatTransferCoefficient;
+  }
+
+  /**
+   * Set the fluid-side heat transfer coefficient used at zero local face throughput.
+   *
+   * <p>
+   * This coefficient is used only by the multi-layer transient model when the local cell has no gas, oil, or water
+   * throughput. It represents stagnant fluid-to-inner-wall heat transfer and is independent of the overall
+   * pipe-to-ambient coefficient configured by {@link #setHeatTransferCoefficient(double)}. The default is 50 W/(m2 K),
+   * a pragmatic gas-rich shutdown assumption that should be replaced with a case-specific value when available.
+   * </p>
+   *
+   * @param coefficient stagnant fluid-side heat transfer coefficient in W/(m2 K)
+   * @throws IllegalArgumentException if the coefficient is negative or non-finite
+   */
+  public void setStagnantInnerHeatTransferCoefficient(double coefficient) {
+    if (!Double.isFinite(coefficient) || coefficient < 0.0) {
+      throw new IllegalArgumentException(
+          "Stagnant inner heat transfer coefficient must be finite and non-negative: " + coefficient);
+    }
+    stagnantInnerHeatTransferCoefficient = coefficient;
+  }
+
+  /**
+   * Get the fluid-side heat transfer coefficient used at zero local face throughput.
+   *
+   * @return stagnant fluid-side heat transfer coefficient in W/(m2 K)
+   */
+  public double getStagnantInnerHeatTransferCoefficient() {
+    return stagnantInnerHeatTransferCoefficient;
   }
 
   /**
@@ -7289,7 +7333,8 @@ public class TwoFluidPipe extends Pipeline {
     calc.setAmbientTemperature(surfaceTemperature);
     multilayerLayerTemperatureProfiles = null;
     useMultilayerThermalModel = true;
-    // Update the simple U-value and all thermal ownership flags consistently.
+    // Retain the calculated overall U-value for reporting and activation. Closed-flow inner-film
+    // resistance is owned independently by stagnantInnerHeatTransferCoefficient.
     setHeatTransferCoefficient(calc.calculateOverallUValue());
   }
 
@@ -7327,9 +7372,15 @@ public class TwoFluidPipe extends Pipeline {
     if (useMultilayerThermalModel && thermalCalculator != null) {
       // Use initial fluid temperature
       double initialTemp = getInletStream().getTemperature("K");
+      double configuredInnerHtc = thermalCalculator.getInnerHTC();
       thermalCalculator.setFluidTemperature(initialTemp);
-      thermalCalculator.initializeLayerTemperaturesLinear();
-      return thermalCalculator.calculateCooldownTime(targetK);
+      thermalCalculator.setInnerHTC(stagnantInnerHeatTransferCoefficient);
+      try {
+        thermalCalculator.initializeLayerTemperaturesLinear();
+        return thermalCalculator.calculateCooldownTime(targetK);
+      } finally {
+        thermalCalculator.setInnerHTC(configuredInnerHtc);
+      }
     }
 
     // Simple exponential decay estimate with U-value
@@ -7390,6 +7441,8 @@ public class TwoFluidPipe extends Pipeline {
 
     if (useMultilayerThermalModel && thermalCalculator != null) {
       sb.append("\nMulti-layer model enabled:\n");
+      sb.append(String.format("  Closed-flow inner HTC: %.1f W/(m²·K) (independent)\n",
+          stagnantInnerHeatTransferCoefficient));
       sb.append(thermalCalculator.getSummary());
     } else {
       sb.append(String.format("  U-value: %.2f W/(m²·K)\n", heatTransferCoefficient));

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeClosedThermalTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeClosedThermalTest.java
@@ -213,6 +213,64 @@ class TwoFluidPipeClosedThermalTest {
   }
 
   @Test
+  void closedMultilayerInnerHtcIsIndependentOfOverallCoefficientCallOrder() {
+    PipeFixture configureThenOverride = createInitializedPipe("multilayer-configure-then-override");
+    PipeFixture overrideThenConfigure = createInitializedPipe("multilayer-override-then-configure");
+
+    prepareClosedMultilayerCooldown(configureThenOverride.pipe);
+    configureThenOverride.pipe.setHeatTransferCoefficient(50.0);
+
+    prepareClosedCooldownBoundary(overrideThenConfigure.pipe);
+    overrideThenConfigure.pipe.setHeatTransferCoefficient(50.0);
+    overrideThenConfigure.pipe.configureSubseaThermalModel(0.02, 0.0, RadialThermalLayer.MaterialType.PU_FOAM);
+
+    assertTrue(
+        Math.abs(configureThenOverride.pipe.getHeatTransferCoefficient()
+            - overrideThenConfigure.pipe.getHeatTransferCoefficient()) > 1.0e-6,
+        "The fixture must exercise different configuration-level overall coefficients");
+
+    double configureThenOverrideHtc = configureThenOverride.pipe.calculateInnerHTC(0.0, 1.0);
+    double overrideThenConfigureHtc = overrideThenConfigure.pipe.calculateInnerHTC(0.0, 1.0);
+
+    assertEquals(configureThenOverrideHtc, overrideThenConfigureHtc, 0.0,
+        "Closed multilayer cooldown must not reinterpret the overall coefficient as the stagnant inner HTC");
+    assertEquals(50.0, configureThenOverrideHtc, 0.0);
+
+    double[] configureThenOverrideState = initialLayerTemperatures(configureThenOverride.pipe.getThermalCalculator());
+    double[] overrideThenConfigureState = initialLayerTemperatures(overrideThenConfigure.pipe.getThermalCalculator());
+    double configureThenOverrideWall = TwoFluidPipe.advanceMultilayerCellThermalState(
+        configureThenOverride.pipe.getThermalCalculator(), configureThenOverrideState, 300.0, 280.0,
+        configureThenOverrideHtc, 1.0e-3);
+    double overrideThenConfigureWall = TwoFluidPipe.advanceMultilayerCellThermalState(
+        overrideThenConfigure.pipe.getThermalCalculator(), overrideThenConfigureState, 300.0, 280.0,
+        overrideThenConfigureHtc, 1.0e-3);
+
+    assertArrayEquals(configureThenOverrideState, overrideThenConfigureState, 0.0);
+    assertEquals(configureThenOverrideWall, overrideThenConfigureWall, 0.0);
+    assertEquals(configureThenOverride.pipe.getThermalCalculator().getLastFluidHeatTransferPerLength(),
+        overrideThenConfigure.pipe.getThermalCalculator().getLastFluidHeatTransferPerLength(), 0.0);
+  }
+
+  @Test
+  void stagnantInnerHtcHasDocumentedDefaultAndIndependentSetter() {
+    TwoFluidPipe pipe = new TwoFluidPipe("stagnant-inner-htc-api");
+    assertEquals(50.0, pipe.getStagnantInnerHeatTransferCoefficient(), 0.0);
+    assertEquals(50.0, pipe.calculateInnerHTC(0.0, 1.0), 0.0);
+
+    pipe.setHeatTransferCoefficient(8.0);
+    assertEquals(50.0, pipe.calculateInnerHTC(0.0, 1.0), 0.0);
+
+    pipe.setStagnantInnerHeatTransferCoefficient(75.0);
+    assertEquals(75.0, pipe.getStagnantInnerHeatTransferCoefficient(), 0.0);
+    assertEquals(75.0, pipe.calculateInnerHTC(0.0, 1.0), 0.0);
+
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+        () -> pipe.setStagnantInnerHeatTransferCoefficient(-1.0));
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+        () -> pipe.setStagnantInnerHeatTransferCoefficient(Double.NaN));
+  }
+
+  @Test
   void simpleAndMultilayerCooldownCloseFluidWallAmbientEnergyBalance() {
     PipeFixture simple = createInitializedPipe("simple-energy-balance");
     configureClosedCooldown(simple.pipe);
@@ -275,6 +333,7 @@ class TwoFluidPipeClosedThermalTest {
     PipeFixture fixture = createInitializedPipe("serialized-multilayer-source");
     configureClosedCooldown(fixture.pipe);
     fixture.pipe.configureSubseaThermalModel(0.02, 0.0, RadialThermalLayer.MaterialType.PU_FOAM);
+    fixture.pipe.setStagnantInnerHeatTransferCoefficient(75.0);
     fixture.pipe.runTransient(1.0e-3, TRANSIENT_ID);
 
     TwoFluidPipe copied = (TwoFluidPipe) fixture.pipe.copy();
@@ -283,6 +342,7 @@ class TwoFluidPipeClosedThermalTest {
 
     assertArrayEquals(fixture.pipe.getTemperatureProfile(), copied.getTemperatureProfile(), 0.0);
     assertArrayEquals(fixture.pipe.getWallTemperatureProfile(), copied.getWallTemperatureProfile(), 0.0);
+    assertEquals(75.0, copied.getStagnantInnerHeatTransferCoefficient(), 0.0);
     assertThermalReportCloses(fixture.pipe.getLastThermalEnergyBalanceReport());
     assertThermalReportCloses(copied.getLastThermalEnergyBalanceReport());
   }
@@ -325,6 +385,14 @@ class TwoFluidPipeClosedThermalTest {
     return sum / values.length;
   }
 
+  private double[] initialLayerTemperatures(MultilayerThermalCalculator calculator) {
+    double[] temperatures = new double[calculator.getNumberOfLayers()];
+    for (int layer = 0; layer < temperatures.length; layer++) {
+      temperatures[layer] = calculator.getLayers().get(layer).getTemperature();
+    }
+    return temperatures;
+  }
+
   private void assertThermalReportCloses(TwoFluidThermalEnergyBalanceReport report) {
     assertNotNull(report);
     assertTrue(report.getAcceptedSubsteps() > 0);
@@ -336,11 +404,20 @@ class TwoFluidPipeClosedThermalTest {
   }
 
   private void configureClosedCooldown(TwoFluidPipe pipe) {
+    prepareClosedCooldownBoundary(pipe);
+    pipe.setHeatTransferCoefficient(50.0);
+  }
+
+  private void prepareClosedMultilayerCooldown(TwoFluidPipe pipe) {
+    prepareClosedCooldownBoundary(pipe);
+    pipe.configureSubseaThermalModel(0.02, 0.0, RadialThermalLayer.MaterialType.PU_FOAM);
+  }
+
+  private void prepareClosedCooldownBoundary(TwoFluidPipe pipe) {
     pipe.closeInlet();
     pipe.closeOutlet();
     pipe.setEnableJouleThomson(false);
     pipe.setSurfaceTemperature(280.0, "K");
-    pipe.setHeatTransferCoefficient(50.0);
   }
 
   private PipeFixture createInitializedPipe(String name) {


### PR DESCRIPTION
## Summary

- give closed/zero-throughput multilayer cooldown its own `stagnantInnerHeatTransferCoefficient`
- expose `setStagnantInnerHeatTransferCoefficient(...)` and a getter, with a documented 50 W/(m²·K) default and finite/non-negative validation
- keep `setHeatTransferCoefficient(...)` as the simple-model/configuration-level overall U-value
- make closed-flow multilayer heat flux independent of whether the overall coefficient is set before or after radial-layer configuration
- use the stagnant inner HTC in the standalone cooldown-time calculation without mutating the calculator's configured state
- document ownership, the flowing-cell correlations, and migration from the notebook workaround

## Root cause

At zero local face throughput, `calculateInnerHTC(...)` returned `heatTransferCoefficient`. `configureSubseaThermalModel(...)` also assigned its calculated overall U-value to that property, so one value owned both pipe-to-ambient resistance and the stagnant fluid film. That coupled closed-flow results to API call order and could double-count radial resistance.

## Verification

- `TwoFluidPipeClosedThermalTest`: 17 tests passed
- `TwoFluidPipeIntegrationTest`: 23 tests passed
- regression checks equal stagnant HTC, radial-layer temperatures, wall temperature, and fluid heat flux for both configuration orders
- copy/serialization and invalid-input coverage added
- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- pre-commit and pre-push hooks
- documentation search audit

Local Javadoc generation could not run because the provided runtime has no `javadoc` executable; CI remains the Java-version/build validation authority.

## Compatibility and migration

Existing simple-model overall-U behavior is unchanged. Multilayer closed-flow callers that used `setHeatTransferCoefficient(value)` after layer configuration to set the stagnant film should use `setStagnantInnerHeatTransferCoefficient(value)` instead.

Closes #2977