### PR TITLE
docs(standards): correct ASTM D6377 execution contract

### DIFF
--- a/docs/standards/astm_d6377_rvp.md
+++ b/docs/standards/astm_d6377_rvp.md
@@ -1,369 +1,154 @@
 ---
-title: "ASTM D6377 - Reid Vapor Pressure"
-description: "ASTM D6377 provides methods for determining vapor pressure of crude oil and petroleum products."
+title: "ASTM D6377 Vapor-Pressure Screening"
+description: "Source-accurate NeqSim workflow for VPCR4, RVP-equivalent correlations, water-free variants, and EOS bubble-point pressure."
 ---
 
-# ASTM D6377 - Reid Vapor Pressure
+NeqSim's `Standard_ASTM_D6377` provides an equation-of-state screening calculation for
+vapor-pressure quantities associated with crude oil and condensate. The class name and method
+labels follow ASTM D6377 and historical ASTM D323 terminology, but the implementation is not the
+prescribed laboratory apparatus or compliance evidence. Use a qualified laboratory result and the
+applicable contract, regulation, and current controlled standard for custody transfer or product
+acceptance.
 
-ASTM D6377 provides methods for determining vapor pressure of crude oil and petroleum products.
+## Quantities and Method Boundaries
 
-## Table of Contents
-- [Overview](#overview)
-- [Vapor Pressure Definitions](#vapor-pressure-definitions)
-- [Implementation](#implementation)
-- [Usage Examples](#usage-examples)
-- [Method Selection](#method-selection)
-- [Correlations](#correlations)
+The class calculates several distinct quantities at one configured reference temperature.
 
----
+| NeqSim result | Current calculation | Interpretation |
+|---|---|---|
+| `TVP` | EOS bubble-point pressure | Thermodynamic screening value for the supplied fluid model |
+| `VPCR4` | Pressure from `TVfractionFlash(0.8)` after the bubble-point solve | NeqSim vapor/liquid-volume-ratio screening result |
+| `RVP_ASTM_D6377` | `0.834 * VPCR4` | NeqSim D6377-labelled RVP-equivalent correlation |
+| `RVP_ASTM_D323_82` | `(0.752 * (100 * VPCR4) + 6.07) / 100` | NeqSim historical D323-labelled correlation |
+| `VPCR4_no_water` | VPCR4 calculation on a clone with water removed | Water-free comparison, calculated lazily |
+| `RVP_ASTM_D323_73_79` | Water-free VPCR4 result | NeqSim historical dry-method label |
 
-## Overview
+These are model outputs, not interchangeable measurements. Report the selected method, reference
+temperature, pressure unit, fluid characterization, equation of state, and mixing rule with every
+result.
 
-**Standard:** ASTM D6377 - Standard Test Method for Determination of Vapor Pressure of Crude Oil: VPCRx (Expansion Method)
+The default method is `VPCR4`. Select a method with the type-safe
+`Standard_ASTM_D6377.RvpMethod` enum and read it through `getRvpResult()`. The structured result
+contains the value in bara, method label, reference temperature in degrees Celsius, and a validity
+flag. Use `getValue("RVP", unit)` only for the currently selected method and
+`getValue("TVP", unit)` for the EOS bubble-point result. Do not call
+`getValue("VPCR4", unit)`; that return-parameter name is not supported by the unit-aware legacy
+getter.
 
-**Purpose:** Determine the vapor pressure of crude oil and condensates for:
-- Safety in storage and transport
-- Product specifications
-- Blending calculations
-- Regulatory compliance
+## State Ownership and Model Selection
 
-**Class:** `Standard_ASTM_D6377`
+`calculate()` sets temperature and pressure and performs flashes on the `SystemInterface`
+supplied to the constructor. Pass a clone when the caller must preserve the original fluid state.
 
----
+The standard does not force SRK or any other equation of state. It uses the supplied system's
+thermodynamic model, composition, characterization, and mixing rule. Vapor-pressure predictions
+can be sensitive to light-end loss, heavy-end characterization, water handling, and binary
+interaction parameters. Validate the chosen fluid model against representative laboratory data.
 
-## Vapor Pressure Definitions
+The default reference temperature is 37.8 degrees Celsius. Changing it is supported by the API,
+but the result must then be reported at that configured temperature rather than presented as a
+37.8 degrees Celsius standard result. The current `isOnSpec()` implementation always returns
+`true`; apply project or contract limits explicitly instead of using it as a compliance check.
 
-### True Vapor Pressure (TVP)
+## Executable Java 8 Workflow
 
-The equilibrium pressure of vapor above a liquid at a specified temperature when vapor/liquid ratio approaches zero.
-
-$$TVP = P_{bubble}(T)$$
-
-### Reid Vapor Pressure (RVP)
-
-The vapor pressure measured at 100°F (37.8°C) in a standardized apparatus with vapor/liquid volume ratio of 4:1.
-
-### VPCR4 (Vapor Pressure at V/L = 4)
-
-The pressure at which 80% by volume is vapor at 37.8°C (100°F).
-
-### VPCR Relationship
-
-Different VPCR ratios are used in various standards:
-- VPCR4: 80% vapor (ASTM D6377)
-- VPCR1: 50% vapor
-- VPCR0.02: ~2% vapor (approximates TVP)
-
----
-
-## Implementation
-
-### Constructor
+The program below preserves the source fluid, selects the D6377-labelled correlation, checks the
+structured result, reads the EOS bubble-point pressure, compares VPCR4 and its water-free variant,
+and converts the selected RVP value to kPa.
 
 ```java
-import neqsim.standards.oilquality.Standard_ASTM_D6377;
-
-// Create standard from fluid
-Standard_ASTM_D6377 rvpStandard = new Standard_ASTM_D6377(thermoSystem);
-```
-
-### Available Methods
-
-| Method Name | Description |
-|-------------|-------------|
-| `VPCR4` | Vapor pressure at V/L = 4 (default) |
-| `VPCR4_no_water` | VPCR4 excluding water |
-| `RVP_ASTM_D6377` | RVP correlation from D6377 |
-| `RVP_ASTM_D323_73_79` | RVP per D323 (1973/1979) |
-| `RVP_ASTM_D323_82` | RVP per D323 (1982) |
-
-### Key Methods
-
-| Method | Description |
-|--------|-------------|
-| `calculate()` | Perform vapor pressure calculations |
-| `getValue("RVP", "bara")` | Get Reid vapor pressure |
-| `getValue("TVP", "bara")` | Get true vapor pressure |
-| `getValue("VPCR4", "bara")` | Get VPCR4 |
-| `setMethodRVP(method)` | Select RVP calculation method |
-| `getMethodRVP()` | Get current method |
-
-### Type-Safe Method Selection and Structured Result
-
-In addition to the legacy string-based API, an `RvpMethod` enum and an immutable `RvpResult`
-are available for type-safe selection and robust result handling. The enum and the string
-labels are interchangeable — each constant carries its legacy label.
-
-```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.standards.oilquality.Standard_ASTM_D6377;
 import neqsim.standards.oilquality.Standard_ASTM_D6377.RvpMethod;
 import neqsim.standards.oilquality.Standard_ASTM_D6377.RvpResult;
-
-Standard_ASTM_D6377 rvp = new Standard_ASTM_D6377(crude);
-
-// Type-safe method selection (equivalent to setMethodRVP("VPCR4"))
-rvp.setMethodRVP(RvpMethod.VPCR4);
-rvp.calculate();
-
-// Structured result for the current method
-RvpResult result = rvp.getRvpResult();
-if (result.isValid()) {
-  System.out.printf("RVP = %.4f bara (%s)%n",
-      result.getValue(), result.getMethod().getLabel());
-}
-
-// Or request a specific method directly
-RvpResult d6377 = rvp.getRvpResult(RvpMethod.RVP_ASTM_D6377);
-```
-
-#### RvpMethod constants
-
-| Constant | Legacy label | Description |
-|----------|--------------|-------------|
-| `RVP_ASTM_D6377` | `RVP_ASTM_D6377` | ASTM D6377 RVPE (RVP equivalent), derived from VPCR4 |
-| `RVP_ASTM_D323_73_79` | `RVP_ASTM_D323_73_79` | ASTM D323-73/79 dry method (water removed before flash) |
-| `RVP_ASTM_D323_82` | `RVP_ASTM_D323_82` | ASTM D323-82 correlation |
-| `VPCR4` | `VPCR4` | Vapor pressure at V/L = 4 (default) |
-| `VPCR4_NO_WATER` | `VPCR4_no_water` | VPCR4 with water removed |
-
-`RvpMethod.fromLabel(label)` resolves a constant from either its legacy string label or its
-enum name, throwing `IllegalArgumentException` for an unknown label.
-
-#### RvpResult fields
-
-`RvpResult` bundles the computed value with its context so callers — especially agentic
-workflows — can detect a failed calculation instead of silently receiving `0` or `NaN`.
-A result is **valid** only when its value is a finite positive number.
-
-| Method | Description |
-|--------|-------------|
-| `getValue()` | Computed RVP value in bara |
-| `getMethod()` | The `RvpMethod` used |
-| `getReferenceTemperatureC()` | Reference temperature in °C |
-| `isValid()` | True if the value is finite and positive |
-| `toJson()` | JSON representation (`value`, `unit`, `method`, `referenceTemperatureC`, `valid`) |
-
-```json
-{
-  "value": 0.4521,
-  "unit": "bara",
-  "method": "VPCR4",
-  "referenceTemperatureC": 37.8,
-  "valid": true
-}
-```
-
----
-
-## Usage Examples
-
-### Basic RVP Calculation
-
-```java
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
-import neqsim.standards.oilquality.Standard_ASTM_D6377;
 
-// Create condensate/crude composition
-SystemInterface crude = new SystemSrkEos(273.15 + 15, 1.01325);
-crude.addComponent("methane", 0.01);
-crude.addComponent("ethane", 0.02);
-crude.addComponent("propane", 0.04);
-crude.addComponent("n-butane", 0.06);
-crude.addComponent("i-butane", 0.03);
-crude.addComponent("n-pentane", 0.08);
-crude.addComponent("i-pentane", 0.05);
-crude.addComponent("n-hexane", 0.10);
-crude.addTBPfraction("C7", 0.15, 100.0/1000.0, 0.72);
-crude.addTBPfraction("C10", 0.20, 142.0/1000.0, 0.78);
-crude.addTBPfraction("C20", 0.26, 282.0/1000.0, 0.85);
-crude.setMixingRule("classic");
+public final class AstmD6377Example {
+  private static final Logger logger = LogManager.getLogger(AstmD6377Example.class);
 
-// Calculate RVP
-Standard_ASTM_D6377 rvpStandard = new Standard_ASTM_D6377(crude);
-rvpStandard.setMethodRVP("VPCR4");
-rvpStandard.calculate();
+  private AstmD6377Example() {}
 
-// Get results
-double tvp = rvpStandard.getValue("TVP", "bara");
-double rvp = rvpStandard.getValue("RVP", "bara");
-double vpcr4 = rvpStandard.getValue("VPCR4", "bara");
+  public static void main(String[] args) {
+    SystemInterface sourceOil = new SystemSrkEos(275.15, 1.0);
+    sourceOil.addComponent("methane", 0.0006538);
+    sourceOil.addComponent("ethane", 0.006538);
+    sourceOil.addComponent("propane", 0.065380);
+    sourceOil.addComponent("n-pentane", 0.154500);
+    sourceOil.addComponent("nC10", 0.545000);
+    sourceOil.setMixingRule(2);
+    sourceOil.init(0);
 
-System.out.println("=== Vapor Pressure Results ===");
-System.out.printf("True Vapor Pressure (TVP) = %.4f bara%n", tvp);
-System.out.printf("Reid Vapor Pressure (RVP) = %.4f bara%n", rvp);
-System.out.printf("VPCR4 = %.4f bara%n", vpcr4);
-```
+    SystemInterface workingFluid = sourceOil.clone();
+    Standard_ASTM_D6377 vaporPressure = new Standard_ASTM_D6377(workingFluid);
+    vaporPressure.setReferenceTemperature(37.8, "C");
+    vaporPressure.setMethodRVP(RvpMethod.RVP_ASTM_D6377);
+    vaporPressure.calculate();
 
-### Comparing Different RVP Methods
+    RvpResult selected = vaporPressure.getRvpResult();
+    RvpResult vpcr4 = vaporPressure.getRvpResult(RvpMethod.VPCR4);
+    RvpResult dryVpcr4 = vaporPressure.getRvpResult(RvpMethod.VPCR4_NO_WATER);
+    double tvpBara = vaporPressure.getValue("TVP", "bara");
+    double selectedRvpKPa = vaporPressure.getValue("RVP", "kPa");
 
-```java
-// Calculate using all available methods
-String[] methods = {"VPCR4", "RVP_ASTM_D6377", "RVP_ASTM_D323_73_79", "RVP_ASTM_D323_82"};
+    requireFinitePositive("selected RVP", selected.getValue());
+    requireFinitePositive("VPCR4", vpcr4.getValue());
+    requireFinitePositive("water-free VPCR4", dryVpcr4.getValue());
+    requireFinitePositive("TVP", tvpBara);
+    requireFinitePositive("selected RVP", selectedRvpKPa);
 
-System.out.println("Method                | RVP (bara)");
-System.out.println("----------------------|----------");
+    logger.info("Selected result {}", selected.toJson());
+    logger.info("TVP {} bara; VPCR4 {} bara; dry VPCR4 {} bara",
+        tvpBara, vpcr4.getValue(), dryVpcr4.getValue());
+    logger.info("Source state remains {} K and {} bara",
+        sourceOil.getTemperature(), sourceOil.getPressure());
+  }
 
-for (String method : methods) {
-    Standard_ASTM_D6377 std = new Standard_ASTM_D6377(crude);
-    std.setMethodRVP(method);
-    std.calculate();
-    double rvp = std.getValue("RVP", "bara");
-    System.out.printf("%-21s | %.4f%n", method, rvp);
+  private static void requireFinitePositive(String name, double value) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalStateException(name + " calculation failed: " + value);
+    }
+  }
 }
 ```
 
-### Effect of Light Ends on RVP
+For a fluid without water, `VPCR4` and `VPCR4_NO_WATER` should agree within numerical
+tolerance. For a water-bearing fluid, the difference is a model sensitivity; it is not permission
+to discard measured water or emulsion effects.
 
-```java
-// Analyze RVP sensitivity to light ends
-double[] methaneContent = {0.0, 0.005, 0.01, 0.02, 0.05};
+## API Contract
 
-System.out.println("Methane (mol%) | RVP (bara)");
-System.out.println("---------------|----------");
+| Operation | Supported use |
+|---|---|
+| `setReferenceTemperature(value, unit)` | Converts the supplied temperature to the internal Celsius reference |
+| `setMethodRVP(RvpMethod)` | Selects the result returned as `RVP` |
+| `calculate()` | Populates TVP, VPCR4, and the two direct correlations |
+| `getRvpResult()` | Returns the selected structured result |
+| `getRvpResult(method)` | Returns a named structured result; water-free variants are evaluated lazily |
+| `getValue("RVP", pressureUnit)` | Converts the selected method result from bara |
+| `getValue("TVP", pressureUnit)` | Converts the EOS bubble-point result from bara |
+| `getMethodRVP()` | Returns the selected legacy method label |
 
-for (double ch4 : methaneContent) {
-    SystemInterface fluid = new SystemSrkEos(273.15 + 15, 1.0);
-    fluid.addComponent("methane", ch4);
-    fluid.addComponent("ethane", 0.02);
-    fluid.addComponent("propane", 0.04);
-    fluid.addComponent("n-butane", 0.08);
-    fluid.addComponent("n-pentane", 0.10);
-    fluid.addTBPfraction("C7", 0.20, 100/1000.0, 0.72);
-    fluid.addTBPfraction("C15", 0.56 - ch4, 200/1000.0, 0.80);
-    fluid.setMixingRule("classic");
-    
-    Standard_ASTM_D6377 std = new Standard_ASTM_D6377(fluid);
-    std.calculate();
-    double rvp = std.getValue("RVP", "bara");
-    
-    System.out.printf("%14.1f | %.4f%n", ch4 * 100, rvp);
-}
-```
+The legacy string setter remains available, but the enum rejects unknown methods before a
+calculation is interpreted. A structured result is valid only when its value is finite and
+positive. It does not establish laboratory repeatability, regulatory acceptance, or fitness for a
+specific product specification.
 
-### Wet vs Dry RVP
+## Engineering Validation Checklist
 
-```java
-// Calculate with and without water
-SystemInterface wetCrude = crude.clone();
-wetCrude.addComponent("water", 0.01);  // 1% water
+Before using a calculated vapor pressure:
 
-Standard_ASTM_D6377 wetStd = new Standard_ASTM_D6377(wetCrude);
-wetStd.calculate();
+1. Preserve a characterized source fluid and run the standard on a clone.
+2. Confirm light ends were not lost during sampling or fluid preparation.
+3. Document heavy-end characterization, equation of state, mixing rule, and water treatment.
+4. Record the exact method label, reference temperature, and absolute pressure unit.
+5. Compare against representative laboratory vapor-pressure data over the operating envelope.
+6. Apply the actual product or custody-transfer limit outside `isOnSpec()`.
+7. Treat discrepancies as model or characterization evidence, not as a reason to tune silently.
 
-double vpcr4Wet = wetStd.getValue("VPCR4", "bara");
-double vpcr4Dry = wetStd.getValue("VPCR4_no_water", "bara");
+## Related Documentation
 
-System.out.printf("VPCR4 (with water) = %.4f bara%n", vpcr4Wet);
-System.out.printf("VPCR4 (dry basis) = %.4f bara%n", vpcr4Dry);
-```
-
----
-
-## Method Selection
-
-### VPCR4 (Default)
-
-Best for:
-- General crude oil characterization
-- Comparison with standard lab measurements
-- Regulatory compliance
-
-### RVP_ASTM_D6377
-
-Correlation from ASTM D6377:
-$$RVP = 0.834 \times VPCR4$$
-
-### RVP_ASTM_D323_82
-
-Correlation from ASTM D323 (1982 edition):
-$$RVP = \frac{0.752 \times (100 \times VPCR4) + 6.07}{100}$$
-
-### RVP_ASTM_D323_73_79
-
-For comparison with historical data using D323 (1973/1979 editions).
-Uses VPCR4 without water contribution.
-
----
-
-## Correlations
-
-### TVP to RVP
-
-Approximate relationship:
-$$RVP \approx 0.75 \times TVP + constant$$
-
-The constant depends on crude composition.
-
-### Temperature Dependence
-
-For estimation at temperatures other than 37.8°C:
-
-$$\log_{10}(P_{vap}) = A - \frac{B}{T + C}$$
-
-Antoine-type equation where A, B, C are crude-specific.
-
-### RVP Specifications
-
-| Product | Typical RVP Limit |
-|---------|-------------------|
-| Crude oil (export) | < 0.7 bara (10 psia) |
-| Stabilized condensate | < 0.5 bara (7 psia) |
-| Gasoline (summer) | < 0.62 bara (9 psi) |
-| Gasoline (winter) | < 0.90 bara (13 psi) |
-
----
-
-## Technical Details
-
-### Calculation Procedure
-
-1. Set temperature to 37.8°C (100°F)
-2. Perform bubble point flash to get TVP
-3. Perform flash at vapor/liquid volume ratio = 4
-4. Apply correlation for RVP estimation
-
-### Reference Conditions
-
-| Parameter | Value |
-|-----------|-------|
-| Temperature | 37.8°C (100°F) |
-| V/L ratio | 4:1 (80% vapor by volume) |
-| Pressure | Equilibrium |
-
-### Equation of State
-
-Uses SRK-EoS for phase equilibrium calculations.
-
----
-
-## Accuracy Considerations
-
-### Factors Affecting Accuracy
-
-1. **Light end characterization** - Accurate C1-C4 composition critical
-2. **Heavy end representation** - TBP fractions affect liquid volume
-3. **Water content** - Can significantly affect measured RVP
-4. **Sample handling** - Light end loss during sampling
-
-### Typical Uncertainty
-
-| Method | Uncertainty |
-|--------|-------------|
-| VPCR4 calculation | ±0.02 bara |
-| RVP correlation | ±0.03-0.05 bara |
-
-### Recommendations
-
-1. Ensure accurate light ends (C1-C5) analysis
-2. Use consistent method for comparison
-3. Report method used with results
-4. Consider water content effects
-
----
-
-## References
-
-1. ASTM D6377 - Standard Test Method for Determination of Vapor Pressure of Crude Oil: VPCRx (Expansion Method)
-2. ASTM D323 - Standard Test Method for Vapor Pressure of Petroleum Products (Reid Method)
-3. ASTM D5191 - Standard Test Method for Vapor Pressure of Petroleum Products and Liquid Fuels (Mini Method)
-4. API MPMS Chapter 8 - Sampling
+- [Oil quality standards overview](oil_quality_standards.md)
+- [Standards package overview](README.md)
+- [TVP and RVP study](../examples/TVP_RVP_Study.md)

--- a/docs/test_astm_d6377_documentation.py
+++ b/docs/test_astm_d6377_documentation.py
@@ -1,0 +1,124 @@
+"""Hermetic contracts for the ASTM D6377 vapor-pressure documentation."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "standards" / "astm_d6377_rvp.md"
+SOURCE = (
+    ROOT
+    / "src"
+    / "main"
+    / "java"
+    / "neqsim"
+    / "standards"
+    / "oilquality"
+    / "Standard_ASTM_D6377.java"
+)
+JAVA_TEST = (
+    ROOT
+    / "src"
+    / "test"
+    / "java"
+    / "neqsim"
+    / "standards"
+    / "oilquality"
+    / "AstmD6377DocumentationTest.java"
+)
+
+
+class AstmD6377DocumentationContractTest(unittest.TestCase):
+    """Guard source accuracy, structure, and executable example coverage."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = DOC.read_text(encoding="utf-8")
+        cls.source = SOURCE.read_text(encoding="utf-8")
+        cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
+
+    def test_jekyll_structure_links_and_fences(self):
+        self.assertRegex(
+            self.doc,
+            r'^---\ntitle: "[^"]+"\ndescription: "[^"]+"\n---\n',
+        )
+        self.assertNotRegex(self.doc, r"(?m)^# ")
+        self.assertEqual(2, self.doc.count("```"))
+        self.assertEqual(1, self.doc.count("```java"))
+
+        for target in re.findall(r"\[[^\]]+\]\(([^)#]+\.md)(?:#[^)]+)?\)", self.doc):
+            resolved = (DOC.parent / target).resolve()
+            self.assertTrue(resolved.is_file(), target)
+
+        self.assertNotIn(r"\[", self.doc)
+        self.assertNotIn(r"\(", self.doc)
+        self.assertEqual(0, self.doc.count("$$") % 2)
+
+    def test_documented_contract_matches_current_source(self):
+        source_patterns = (
+            "public void setMethodRVP(RvpMethod method)",
+            "public RvpResult getRvpResult()",
+            "public RvpResult getRvpResult(RvpMethod method)",
+            'if ("RVP".equals(returnParameter))',
+            'if ("TVP".equals(returnParameter))',
+            "this.thermoSystem.setTemperature(referenceTemperature",
+            "this.thermoSystem.setPressure(",
+            "this.thermoOps.TVfractionFlash(0.8)",
+            "RVP_ASTM_D6377 = 0.834 * VPCR4",
+            "public boolean isOnSpec()",
+        )
+        for pattern in source_patterns:
+            self.assertIn(pattern, self.source)
+
+        required_doc_patterns = (
+            "SystemInterface workingFluid = sourceOil.clone();",
+            "new Standard_ASTM_D6377(workingFluid)",
+            "setMethodRVP(RvpMethod.RVP_ASTM_D6377)",
+            "getRvpResult(RvpMethod.VPCR4)",
+            "getRvpResult(RvpMethod.VPCR4_NO_WATER)",
+            'getValue("TVP", "bara")',
+            'getValue("RVP", "kPa")',
+            "The standard does not force SRK",
+            "current `isOnSpec()` implementation always returns",
+        )
+        for pattern in required_doc_patterns:
+            self.assertIn(pattern, self.doc)
+
+    def test_stale_and_unsafe_patterns_are_rejected(self):
+        rejected = (
+            'getValue("VPCR4", "bara")',
+            "Uses SRK-EoS",
+            "Typical Uncertainty",
+            "Approximate relationship:",
+            "Typical RVP Limit",
+            "System.out",
+            "System.err",
+            "import neqsim.standards.oilquality.*",
+        )
+        for pattern in rejected:
+            self.assertNotIn(pattern, self.doc)
+
+        self.assertNotRegex(self.doc, r"(?m)^\s*Standard_ASTM_D6377\s+\w+\s*=.*thermoSystem")
+        self.assertIn("public final class AstmD6377Example", self.doc)
+
+    def test_focused_java_regression_exercises_every_documented_call(self):
+        calls = (
+            "sourceOil.clone()",
+            "setReferenceTemperature(37.8, \"C\")",
+            "setMethodRVP(RvpMethod.RVP_ASTM_D6377)",
+            "vaporPressure.calculate()",
+            "vaporPressure.getRvpResult()",
+            "vaporPressure.getRvpResult(RvpMethod.VPCR4)",
+            "vaporPressure.getRvpResult(RvpMethod.VPCR4_NO_WATER)",
+            'vaporPressure.getValue("TVP", "bara")',
+            'vaporPressure.getValue("RVP", "kPa")',
+            "selected.toJson()",
+            "vaporPressure.getMethodRVP()",
+        )
+        for call in calls:
+            self.assertIn(call, self.java_test)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/neqsim/standards/oilquality/AstmD6377DocumentationTest.java
+++ b/src/test/java/neqsim/standards/oilquality/AstmD6377DocumentationTest.java
@@ -1,0 +1,94 @@
+package neqsim.standards.oilquality;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.standards.oilquality.Standard_ASTM_D6377.RvpMethod;
+import neqsim.standards.oilquality.Standard_ASTM_D6377.RvpResult;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Executes and verifies the ASTM D6377 vapor-pressure documentation workflow.
+ *
+ * @author ESOL
+ * @version 1.0
+ */
+class AstmD6377DocumentationTest extends NeqSimTest {
+  @Test
+  void documentedTypedWorkflowProducesTraceableResultsAndPreservesSourceState() {
+    SystemInterface sourceOil = createOil();
+    double sourceTemperatureK = sourceOil.getTemperature();
+    double sourcePressureBara = sourceOil.getPressure();
+
+    SystemInterface workingFluid = sourceOil.clone();
+    Standard_ASTM_D6377 vaporPressure = new Standard_ASTM_D6377(workingFluid);
+    vaporPressure.setReferenceTemperature(37.8, "C");
+    vaporPressure.setMethodRVP(RvpMethod.RVP_ASTM_D6377);
+    vaporPressure.calculate();
+
+    RvpResult selected = vaporPressure.getRvpResult();
+    RvpResult vpcr4 = vaporPressure.getRvpResult(RvpMethod.VPCR4);
+    RvpResult dryVpcr4 = vaporPressure.getRvpResult(RvpMethod.VPCR4_NO_WATER);
+    double tvpBara = vaporPressure.getValue("TVP", "bara");
+    double selectedRvpKPa = vaporPressure.getValue("RVP", "kPa");
+
+    assertTrue(selected.isValid());
+    assertTrue(vpcr4.isValid());
+    assertTrue(dryVpcr4.isValid());
+    assertEquals(RvpMethod.RVP_ASTM_D6377, selected.getMethod());
+    assertEquals("RVP_ASTM_D6377", vaporPressure.getMethodRVP());
+    assertEquals(37.8, selected.getReferenceTemperatureC(), 1.0e-12);
+    assertEquals(0.9653068384, selected.getValue(), 1.0e-3);
+    assertEquals(1.1574422523, vpcr4.getValue(), 1.0e-3);
+    assertEquals(vpcr4.getValue(), dryVpcr4.getValue(), 1.0e-6);
+    assertEquals(1.6662983670, tvpBara, 1.0e-3);
+    assertEquals(selected.getValue() * 100.0, selectedRvpKPa, 1.0e-6);
+    assertTrue(tvpBara > vpcr4.getValue());
+    assertTrue(vpcr4.getValue() > selected.getValue());
+
+    JsonObject json = JsonParser.parseString(selected.toJson()).getAsJsonObject();
+    assertEquals("RVP_ASTM_D6377", json.get("method").getAsString());
+    assertEquals("bara", json.get("unit").getAsString());
+    assertTrue(json.get("valid").getAsBoolean());
+
+    assertEquals(sourceTemperatureK, sourceOil.getTemperature(), 0.0);
+    assertEquals(sourcePressureBara, sourceOil.getPressure(), 0.0);
+  }
+
+  @Test
+  void documentedWaterFreeComparisonRespondsToWater() {
+    SystemInterface wetOil = createOil();
+    wetOil.addComponent("water", 0.00545);
+    wetOil.init(0);
+
+    Standard_ASTM_D6377 vaporPressure = new Standard_ASTM_D6377(wetOil.clone());
+    vaporPressure.setReferenceTemperature(37.8, "C");
+    vaporPressure.setMethodRVP(RvpMethod.VPCR4);
+    vaporPressure.calculate();
+
+    RvpResult wetVpcr4 = vaporPressure.getRvpResult();
+    RvpResult dryVpcr4 = vaporPressure.getRvpResult(RvpMethod.VPCR4_NO_WATER);
+
+    assertTrue(wetVpcr4.isValid());
+    assertTrue(dryVpcr4.isValid());
+    assertNotEquals(wetVpcr4.getValue(), dryVpcr4.getValue(), 1.0e-6);
+  }
+
+  private SystemInterface createOil() {
+    SystemInterface oil = new SystemSrkEos(275.15, 1.0);
+    oil.addComponent("methane", 0.0006538);
+    oil.addComponent("ethane", 0.006538);
+    oil.addComponent("propane", 0.065380);
+    oil.addComponent("n-pentane", 0.154500);
+    oil.addComponent("nC10", 0.545000);
+    oil.setMixingRule(2);
+    oil.init(0);
+    return oil;
+  }
+}


### PR DESCRIPTION
## Campaign

Advances documentation-quality campaign #2499, scan D057 / rotation scope 5. The completion ledger remains unchanged until this draft is merged.

## Exact scope

Base: `ef31a3ba78a325b5784a33486bb047a264425412`  
Head: `62e584dbd3d43782903d02050c22f8c856fd5b8e`

Frozen paths:

- `docs/standards/astm_d6377_rvp.md`
- `docs/test_astm_d6377_documentation.py`
- `src/test/java/neqsim/standards/oilquality/AstmD6377DocumentationTest.java`

The standards and reference indexes already expose the page. Other oil-quality guides, production correlations, public APIs, controlled-standard interpretations, external datasets, and notebooks are excluded.

## Confirmed defects and evidence

1. **High — unsupported getter:** the guide recommended `getValue("VPCR4", "bara")`. Current source handles only `"RVP"` and `"TVP"` in the unit-aware getter; other names fall through to the unrelated legacy `RVP` field.
2. **High — non-running examples:** six Java fragments had undefined state or missing imports, no complete class, and 13 prohibited `System.out` calls.
3. **High — false EOS ownership:** the guide said the standard uses SRK. Current `calculate()` flashes the caller-supplied `SystemInterface` and therefore uses its configured EOS and mixing rule.
4. **High — hidden mutation:** `calculate()` changes temperature and pressure and flashes the supplied system directly; the guide did not warn callers to pass a clone when source state must be preserved.
5. **Medium — conflated semantics:** EOS bubble-point TVP, VPCR4, the NeqSim D6377-equivalent correlation, and historical D323-labelled correlations were presented as interchangeable standard measurements.
6. **Medium — unsupported assurance:** fixed uncertainty bands, generic product limits, and a TVP/RVP approximation had no dataset, jurisdiction, product class, or validation basis.
7. **Medium — duplicate Jekyll title:** the front-matter title was repeated as a source H1.

## Repairs

- Replaces the fragments with one complete Java 8 workflow using explicit imports, Log4j2, cloned source state, enum method selection, structured results, VPCR4/water-free comparison, pressure conversion, and fail-closed validation.
- Separates current-source calculations from laboratory measurement and compliance evidence.
- Documents exact supported getter names, lazy water-free behavior, caller-owned EOS selection, direct state mutation, the always-true current `isOnSpec()` boundary, and required engineering validation.
- Adds four hermetic source/structure/example contracts.
- Adds two focused JUnit tests with quantitative RVP, VPCR4, TVP, unit-conversion, JSON, source-state preservation, and water-sensitivity assertions.

## Validation completed before publication

Connector/static validation on the exact head:

- exact three-file compare: 3 commits ahead / 0 behind the base;
- current-source signatures and calculation paths verified against `Standard_ASTM_D6377`;
- all three internal Markdown targets resolve on the branch;
- Jekyll front matter present, no source H1, and one balanced Java fence;
- no `System.out`, `System.err`, wildcard imports, unsupported VPCR4 getter, unsupported uncertainty table, generic product-limit table, or false forced-SRK statement remains;
- changed Python lines are at most 100 characters and Java test lines at most 120 characters;
- final diff contains exactly the frozen paths and no sensitive material;
- no equation, image, external URL, notebook, production source, API, dependency, or index changed.

## Validation status on exact head `62e584d`

Passed in GitHub CI:

- Spotless apply: 4,865 Java files inspected, 0 changed;
- pre-commit checks;
- documentation search coverage;
- CodeQL Java analysis;
- Java 21 Javadocs;
- agent-skill cross-reference verification;
- slow-test shards 2/4 and 3/4.

## VALIDATION PENDING CI

Still running and not claimed as passed:

- Java 21 fast tests on Ubuntu and Windows;
- slow-test shards 1/4 and 4/4;
- completion of the aggregate build/test workflow.

This runtime has no local NeqSim checkout, so the local Spotless, documentation unittest discovery, focused Maven test, and pre-commit commands listed in the publication snapshot were not run locally. Hosted CI is the authoritative follow-up validator. Any attributable formatting, compilation, runtime, link, or review finding will be repaired on this same draft before readiness is classified.

## Documentation impact

The user-visible vapor-pressure guide now matches current source and clearly separates model screening from laboratory or contract compliance. No production behavior or public API changes.

## Stop boundary and next scan

This PR stops before production-correlation changes, the broader oil-quality guide, controlled-standard interpretation, external benchmark data, and notebook work. After D057 merges, the next rotation scope is tutorials, cookbook, troubleshooting, and examples.