### PR TITLE
feat(process): transact local temperature and DP transmitters

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -356,20 +356,23 @@ loop
 tuning, scan-time fidelity, final-element dynamics, deterministic I/O, safety action, or OTS behavior.
 
 
-## Pressure-transmitter transaction coverage
+## Local signal-modifying transmitter transaction coverage
 
-The concrete `PressureTransmitter` participates when it is registered in the `ProcessSystem`. Its snapshot preserves
-the stream binding and the inherited measurement configuration, instrument tags and field value, condition-analysis
-state, discrete-delay queue, first-order-filter memory, injected-fault accumulator, alarm configuration and mutable alarm
-state. The Java `Random` generator is captured independently, including its cached Gaussian value, so a rejected noisy
-sample replays exactly rather than merely repeating the same nominal process input. The alarm object is restored in place
-to preserve references held by alarm and operator interfaces.
+The concrete `PressureTransmitter`, `TemperatureTransmitter`, and `DifferentialPressureTransmitter` participate when
+registered in a `ProcessSystem`. Their snapshots preserve the one- or two-stream binding and the inherited measurement
+configuration, instrument tags and field value, condition-analysis state, discrete-delay queue, first-order-filter
+memory, injected-fault accumulator, alarm configuration, and mutable alarm state. The Java `Random` generator is captured
+independently, including its cached Gaussian value, so a rejected noisy sample replays exactly rather than merely
+repeating the same nominal process input. The alarm object is restored in place to preserve references held by alarm and
+operator interfaces.
 
 A transmitter consumed by a controller must also be registered as a process measurement device; the controller's
 transmitter reference does not transfer ownership of the transmitter's delay, filter, noise, fault, or alarm state.
-Coverage fails closed for `PressureTransmitter` subclasses until they extend the snapshot for subclass fields. It also
-blocks online-signal mode because database reads and their externally visible timing do not yet have a rejected-step
-commit/defer contract.
+Coverage fails closed for subclasses of these transmitter types until they extend the snapshot for subclass fields. It
+also blocks online-signal mode because database reads and their externally visible timing do not yet have a rejected-step
+commit/defer contract. Other measurement-device families are not transaction participants merely because they inherit
+signal configuration; each family must first demonstrate that its measured-value path actually advances that mutable
+signal state and that all subclass-owned state is covered.
 
 This coverage establishes in-memory rollback, deterministic replay, and Java-serialization mechanics. It does not qualify
 sensor accuracy, sample-time or network jitter, alarm or trip integrity, external historian/DCS writes, safety action,

--- a/docs/process/equipment/measurement_devices.md
+++ b/docs/process/equipment/measurement_devices.md
@@ -191,6 +191,11 @@ tt.setUnit("C");
 double temperature = tt.getMeasuredValue();
 ```
 
+When registered in a `ProcessSystem`, concrete local `PressureTransmitter` and `TemperatureTransmitter` instances take
+part in transient step transactions. Rollback restores their stream binding, noise generator, delay/filter/fault state,
+alarm state, and measurement configuration so a rejected sample can be replayed exactly. Subclasses and online-signal
+bindings fail the transaction-coverage preflight until they provide a complete snapshot or external-I/O commit contract.
+
 ### LevelTransmitter
 
 Monitors liquid level in vessels.
@@ -214,6 +219,23 @@ VolumeFlowTransmitter vft = new VolumeFlowTransmitter(stream);
 vft.setUnit("m3/hr");
 double volumeFlow = vft.getMeasuredValue();
 ```
+
+### DifferentialPressureTransmitter
+
+Measures the pressure difference between a high- and low-pressure stream. The sign convention is
+`high pressure - low pressure`.
+
+```java
+import neqsim.process.measurementdevice.DifferentialPressureTransmitter;
+
+DifferentialPressureTransmitter pdt =
+    new DifferentialPressureTransmitter("PDT-101", upstream, downstream);
+double differentialPressure = pdt.getMeasuredValue("bar");
+```
+
+A concrete local differential-pressure transmitter registered in a `ProcessSystem` also participates in transient step
+transactions. Its two stream bindings and signal/alarm state are restored in place on rollback. Subclasses and
+online-signal bindings remain fail-closed.
 
 ### VenturiFlowMeter
 

--- a/src/main/java/neqsim/process/measurementdevice/DifferentialPressureTransmitter.java
+++ b/src/main/java/neqsim/process/measurementdevice/DifferentialPressureTransmitter.java
@@ -1,5 +1,8 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -11,9 +14,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author Even Solbraa
  * @version 1.0
  */
-public class DifferentialPressureTransmitter extends MeasurementDeviceBaseClass {
+public class DifferentialPressureTransmitter extends MeasurementDeviceBaseClass
+    implements TransientStateParticipant<DifferentialPressureTransmitter.DifferentialPressureTransmitterState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000L;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   private StreamInterface highPressureStream;
   private StreamInterface lowPressureStream;
@@ -76,5 +82,68 @@ public class DifferentialPressureTransmitter extends MeasurementDeviceBaseClass 
   @ExcludeFromJacocoGeneratedReport
   public void displayResult() {
     System.out.println(getName() + ": ΔP = " + getMeasuredValue("bar") + " bar");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:differential-pressure:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete differential-pressure transmitter in local in-memory mode.
+   *
+   * @return blocking diagnostic for subclasses or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != DifferentialPressureTransmitter.class) {
+      return "differential-pressure-transmitter subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public DifferentialPressureTransmitterState captureTransientState() {
+    return new DifferentialPressureTransmitterState(getTransientStateIdentity(), highPressureStream, lowPressureStream,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(DifferentialPressureTransmitterState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Differential-pressure transmitter transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Differential-pressure transmitter snapshot identity does not match " + getTransientStateIdentity());
+    }
+    highPressureStream = snapshot.highPressureStream;
+    lowPressureStream = snapshot.lowPressureStream;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable differential-pressure-transmitter rollback point. */
+  public static final class DifferentialPressureTransmitterState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String stateIdentity;
+    private final StreamInterface highPressureStream;
+    private final StreamInterface lowPressureStream;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private DifferentialPressureTransmitterState(String stateIdentity, StreamInterface highPressureStream,
+        StreamInterface lowPressureStream, MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.highPressureStream = highPressureStream;
+      this.lowPressureStream = lowPressureStream;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/TemperatureTransmitter.java
+++ b/src/main/java/neqsim/process/measurementdevice/TemperatureTransmitter.java
@@ -6,6 +6,9 @@
 
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -15,9 +18,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author ESOL
  * @version $Id: $Id
  */
-public class TemperatureTransmitter extends StreamMeasurementDeviceBaseClass {
+public class TemperatureTransmitter extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<TemperatureTransmitter.TemperatureTransmitterState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /**
    * Constructor for TemperatureTransmitter.
@@ -56,6 +62,66 @@ public class TemperatureTransmitter extends StreamMeasurementDeviceBaseClass {
   public void applyFieldValue() {
     if (getTagRole() == InstrumentTagRole.INPUT && hasFieldValue()) {
       stream.setTemperature(getFieldValue(), getUnit());
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:temperature:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete temperature transmitter in local in-memory mode.
+   *
+   * @return blocking diagnostic for subclasses or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != TemperatureTransmitter.class) {
+      return "temperature-transmitter subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public TemperatureTransmitterState captureTransientState() {
+    return new TemperatureTransmitterState(getTransientStateIdentity(), stream,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(TemperatureTransmitterState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Temperature transmitter transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Temperature transmitter snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable temperature-transmitter rollback point. */
+  public static final class TemperatureTransmitterState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private TemperatureTransmitterState(String stateIdentity, StreamInterface stream,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.measurementState = measurementState;
     }
   }
 }

--- a/src/test/java/neqsim/process/measurementdevice/TemperatureAndDifferentialPressureTransmitterTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/TemperatureAndDifferentialPressureTransmitterTransientStateTransactionTest.java
@@ -1,0 +1,254 @@
+package neqsim.process.measurementdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.process.alarm.AlarmConfig;
+import neqsim.process.alarm.AlarmState;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Quantitative rollback, replay, multi-area coverage, and restart evidence for local temperature and
+ * differential-pressure transmitter state.
+ */
+class TemperatureAndDifferentialPressureTransmitterTransientStateTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void multiAreaRollbackRestoresBindingsSignalStateAndExactReplay() {
+    TemperatureTransmitter temperature = new TemperatureTransmitter("TT-100",
+        createStream("temperature source", 330.0, 60.0));
+    StreamInterface originalTemperatureStream = temperature.getStream();
+    DifferentialPressureTransmitter differentialPressure = new DifferentialPressureTransmitter("PDT-100",
+        createStream("high pressure source", 300.0, 70.0), createStream("low pressure source", 300.0, 50.0));
+    StreamInterface originalHighPressureStream = differentialPressure.getHighPressureStream();
+    StreamInterface originalLowPressureStream = differentialPressure.getLowPressureStream();
+
+    configureSignalDynamics(temperature, 8123L);
+    configureSignalDynamics(differentialPressure, 9917L);
+    AlarmConfig temperatureAlarm = AlarmConfig.builder().highLimit(320.0).delay(2.0).unit("K").build();
+    AlarmConfig differentialPressureAlarm = AlarmConfig.builder().highLimit(15.0).delay(2.0).unit("bar").build();
+    temperature.setAlarmConfig(temperatureAlarm);
+    differentialPressure.setAlarmConfig(differentialPressureAlarm);
+    AlarmState originalTemperatureAlarmState = temperature.getAlarmState();
+    AlarmState originalDifferentialPressureAlarmState = differentialPressure.getAlarmState();
+
+    // Establish non-empty delay, filter, Gaussian-cache, drift, and pending-alarm state.
+    temperature.getMeasuredValue();
+    differentialPressure.getMeasuredValue();
+    temperature.getMeasuredValue();
+    differentialPressure.getMeasuredValue();
+    assertTrue(temperature.evaluateAlarm(330.0, 1.0, 1.0).isEmpty());
+    assertTrue(differentialPressure.evaluateAlarm(20.0, 1.0, 1.0).isEmpty());
+
+    ProcessSystem utilitiesArea = new ProcessSystem("utilities area");
+    utilitiesArea.add(temperature);
+    ProcessSystem compressionArea = new ProcessSystem("compression area");
+    compressionArea.add(differentialPressure);
+    assertCompleteCoverage(utilitiesArea.getTransientTransactionCoverage(), 1);
+    assertCompleteCoverage(compressionArea.getTransientTransactionCoverage(), 1);
+
+    ProcessModel model = new ProcessModel();
+    model.add("utilities", utilitiesArea);
+    model.add("compression", compressionArea);
+    assertCompleteCoverage(model.getTransientTransactionCoverage(), 2);
+
+    String temperatureIdentity = temperature.getTransientStateIdentity();
+    String differentialPressureIdentity = differentialPressure.getTransientStateIdentity();
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+    List<Double> trialTemperatures = new ArrayList<Double>();
+    List<Double> trialDifferentialPressures = new ArrayList<Double>();
+    for (int i = 0; i < 4; i++) {
+      trialTemperatures.add(temperature.getMeasuredValue());
+      trialDifferentialPressures.add(differentialPressure.getMeasuredValue());
+    }
+    assertEquals(1, temperature.evaluateAlarm(330.0, 1.0, 2.0).size());
+    assertEquals(1, differentialPressure.evaluateAlarm(20.0, 1.0, 2.0).size());
+
+    temperature.setName("trial temperature");
+    temperature.setUnit("C");
+    temperature.setDelaySteps(0);
+    temperature.setNoiseStdDev(9.0);
+    temperature.setFirstOrderTimeConstant(0.0);
+    temperature.clearFault();
+    temperature.setAlarmConfig(null);
+    temperature.setStream(createStream("trial temperature source", 280.0, 10.0));
+    differentialPressure.setName("trial differential pressure");
+    differentialPressure.setUnit("Pa");
+    differentialPressure.setDelaySteps(0);
+    differentialPressure.setNoiseStdDev(8.0);
+    differentialPressure.setFirstOrderTimeConstant(0.0);
+    differentialPressure.clearFault();
+    differentialPressure.setAlarmConfig(null);
+    transaction.rollback();
+
+    assertEquals(temperatureIdentity, temperature.getTransientStateIdentity());
+    assertEquals(differentialPressureIdentity, differentialPressure.getTransientStateIdentity());
+    assertEquals("TT-100", temperature.getName());
+    assertEquals("PDT-100", differentialPressure.getName());
+    assertEquals("K", temperature.getUnit());
+    assertEquals("bar", differentialPressure.getUnit());
+    assertSame(originalTemperatureStream, temperature.getStream());
+    assertSame(originalHighPressureStream, differentialPressure.getHighPressureStream());
+    assertSame(originalLowPressureStream, differentialPressure.getLowPressureStream());
+    assertSame(temperatureAlarm, temperature.getAlarmConfig());
+    assertSame(differentialPressureAlarm, differentialPressure.getAlarmConfig());
+    assertSame(originalTemperatureAlarmState, temperature.getAlarmState());
+    assertSame(originalDifferentialPressureAlarmState, differentialPressure.getAlarmState());
+
+    for (int i = 0; i < trialTemperatures.size(); i++) {
+      assertEquals(trialTemperatures.get(i), temperature.getMeasuredValue(), 0.0,
+          "temperature rollback must replay Gaussian, drift, filter, and delay state exactly");
+      assertEquals(trialDifferentialPressures.get(i), differentialPressure.getMeasuredValue(), 0.0,
+          "differential-pressure rollback must replay Gaussian, drift, filter, and delay state exactly");
+    }
+    assertEquals(1, temperature.evaluateAlarm(330.0, 1.0, 2.0).size());
+    assertEquals(1, differentialPressure.evaluateAlarm(20.0, 1.0, 2.0).size());
+  }
+
+  @Test
+  void serializedSnapshotsRestoreStableIdentityBindingsAndRandomContinuation() throws Exception {
+    TemperatureTransmitter temperature = new TemperatureTransmitter("TT-200",
+        createStream("temperature source", 315.0, 40.0));
+    DifferentialPressureTransmitter differentialPressure = new DifferentialPressureTransmitter("PDT-200",
+        createStream("high pressure source", 300.0, 80.0), createStream("low pressure source", 300.0, 55.0));
+    configureSignalDynamics(temperature, 123456L);
+    configureSignalDynamics(differentialPressure, 654321L);
+
+    String temperatureIdentity = temperature.getTransientStateIdentity();
+    String differentialPressureIdentity = differentialPressure.getTransientStateIdentity();
+    TemperatureTransmitter.TemperatureTransmitterState temperatureSnapshot = temperature.captureTransientState();
+    DifferentialPressureTransmitter.DifferentialPressureTransmitterState differentialPressureSnapshot = differentialPressure
+        .captureTransientState();
+    double expectedTemperature = temperature.getMeasuredValue();
+    double expectedDifferentialPressure = differentialPressure.getMeasuredValue();
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(temperature);
+      output.writeObject(temperatureSnapshot);
+      output.writeObject(differentialPressure);
+      output.writeObject(differentialPressureSnapshot);
+      serialized = bytes.toByteArray();
+    }
+
+    TemperatureTransmitter restoredTemperature;
+    TemperatureTransmitter.TemperatureTransmitterState restoredTemperatureSnapshot;
+    DifferentialPressureTransmitter restoredDifferentialPressure;
+    DifferentialPressureTransmitter.DifferentialPressureTransmitterState restoredDifferentialPressureSnapshot;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restoredTemperature = (TemperatureTransmitter) input.readObject();
+      restoredTemperatureSnapshot = (TemperatureTransmitter.TemperatureTransmitterState) input.readObject();
+      restoredDifferentialPressure = (DifferentialPressureTransmitter) input.readObject();
+      restoredDifferentialPressureSnapshot = (DifferentialPressureTransmitter.DifferentialPressureTransmitterState) input
+          .readObject();
+    }
+
+    restoredTemperature.restoreTransientState(restoredTemperatureSnapshot);
+    restoredDifferentialPressure.restoreTransientState(restoredDifferentialPressureSnapshot);
+    assertEquals(temperatureIdentity, restoredTemperature.getTransientStateIdentity());
+    assertEquals(differentialPressureIdentity, restoredDifferentialPressure.getTransientStateIdentity());
+    assertEquals(expectedTemperature, restoredTemperature.getMeasuredValue(), 0.0);
+    assertEquals(expectedDifferentialPressure, restoredDifferentialPressure.getMeasuredValue(), 0.0);
+  }
+
+  @Test
+  void foreignSnapshotsAreRejectedWithoutMutation() {
+    TemperatureTransmitter first = new TemperatureTransmitter("TT-300", createStream("first source", 300.0, 20.0));
+    TemperatureTransmitter second = new TemperatureTransmitter("TT-301", createStream("second source", 310.0, 20.0));
+    TemperatureTransmitter.TemperatureTransmitterState foreignSnapshot = first.captureTransientState();
+    StreamInterface secondStream = second.getStream();
+
+    assertThrows(IllegalArgumentException.class, () -> second.restoreTransientState(foreignSnapshot));
+    assertSame(secondStream, second.getStream());
+    assertEquals("TT-301", second.getName());
+  }
+
+  @Test
+  void subclassesAndOnlineBindingsFailCoverageBeforeTrialMutation() {
+    ProcessSystem subclassProcess = new ProcessSystem("transmitter subclass coverage");
+    subclassProcess.add(new StatefulTemperatureTransmitterSubclass(createStream("temperature", 300.0, 20.0)));
+    subclassProcess.add(new StatefulDifferentialPressureTransmitterSubclass(createStream("high pressure", 300.0, 30.0),
+        createStream("low pressure", 300.0, 20.0)));
+    TransientTransactionCoverage subclassCoverage = subclassProcess.getTransientTransactionCoverage();
+    assertEquals(2, subclassCoverage.getProcessElementCount());
+    assertEquals(2, subclassCoverage.getParticipantCount());
+    assertFalse(subclassCoverage.isComplete());
+    assertEquals(2, subclassCoverage.getBlockingIssues().size());
+    assertTrue(subclassCoverage.getBlockingIssues().get(0).contains("subclass-owned mutable state"));
+    assertThrows(IllegalStateException.class, subclassProcess::beginTransientStepTransaction);
+
+    TemperatureTransmitter onlineTemperature = new TemperatureTransmitter("online TT",
+        createStream("online source", 300.0, 20.0));
+    onlineTemperature.setIsOnlineSignal(true, "test plant", "test tag");
+    ProcessSystem onlineProcess = new ProcessSystem("online transmitter coverage");
+    onlineProcess.add(onlineTemperature);
+    TransientTransactionCoverage onlineCoverage = onlineProcess.getTransientTransactionCoverage();
+    assertEquals(1, onlineCoverage.getProcessElementCount());
+    assertEquals(1, onlineCoverage.getParticipantCount());
+    assertFalse(onlineCoverage.isComplete());
+    assertTrue(onlineCoverage.getBlockingIssues().get(0).contains("external I/O"));
+    assertThrows(IllegalStateException.class, onlineProcess::beginTransientStepTransaction);
+  }
+
+  private static void configureSignalDynamics(MeasurementDeviceBaseClass transmitter, long seed) {
+    transmitter.setDelaySteps(2);
+    transmitter.setNoiseStdDev(0.35);
+    transmitter.setRandomSeed(seed);
+    transmitter.setFirstOrderTimeConstant(2.0);
+    transmitter.setFault(SensorFaultType.LINEAR_DRIFT, 0.15);
+  }
+
+  private static void assertCompleteCoverage(TransientTransactionCoverage coverage, int expectedCount) {
+    assertEquals(expectedCount, coverage.getProcessElementCount());
+    assertEquals(expectedCount, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete());
+    assertTrue(coverage.getBlockingIssues().isEmpty());
+  }
+
+  private static Stream createStream(String name, double temperatureKelvin, double pressureBara) {
+    SystemSrkEos fluid = new SystemSrkEos(temperatureKelvin, pressureBara);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream(name, fluid);
+    stream.setTemperature(temperatureKelvin, "K");
+    stream.setPressure(pressureBara, "bara");
+    return stream;
+  }
+
+  private static final class StatefulTemperatureTransmitterSubclass extends TemperatureTransmitter {
+    private static final long serialVersionUID = 1000L;
+    @SuppressWarnings("unused")
+    private double customState;
+
+    private StatefulTemperatureTransmitterSubclass(StreamInterface stream) {
+      super("custom temperature transmitter", stream);
+    }
+  }
+
+  private static final class StatefulDifferentialPressureTransmitterSubclass extends DifferentialPressureTransmitter {
+    private static final long serialVersionUID = 1000L;
+    @SuppressWarnings("unused")
+    private double customState;
+
+    private StatefulDifferentialPressureTransmitterSubclass(StreamInterface highPressureStream,
+        StreamInterface lowPressureStream) {
+      super("custom differential-pressure transmitter", highPressureStream, lowPressureStream);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Advances #2911 as DYN-C006 by adding identity-preserving transient step transactions to the two remaining dependency-ready local signal-modifying transmitter families:

- `TemperatureTransmitter`: preserves its stream binding and all inherited measurement state
- `DifferentialPressureTransmitter`: preserves both high- and low-pressure stream bindings and all inherited measurement state
- both concrete types use stable transaction identities, reject foreign snapshots, serialize snapshots/restart state, and fail closed for subclasses and online/external-I/O bindings
- documentation states the supported boundary and explicitly excludes measurement families whose value paths do not yet apply the inherited signal modifiers

Base: `f34a495b0d893ab46af0518b9ab39301e6602d91`
Head: `29a635dfe3d8c30ae22d4a2f0ef7bd0dbe8f78f1`

## Quantitative evidence

The regression suite verifies:

- ProcessSystem coverage is `1/1` for each transmitter family
- aggregate two-area ProcessModel coverage is `2/2`
- four rejected noisy/filter/delay/drift samples replay bit-exactly for both transmitters (`0.0` tolerance)
- delayed alarms activate on the same accepted sample after rollback
- one- and two-stream object identities are preserved in place
- Java serialization preserves stable transaction identity and exact next-sample continuation
- foreign snapshots are rejected before mutation
- subclass and online-I/O coverage blockers are reported before a trial transaction opens

## Validation

Exact head `29a635dfe3d8c30ae22d4a2f0ef7bd0dbe8f78f1`:

- PASS — focused Maven tests: 8 run, 0 failures, 0 errors, 0 skipped
  - `TemperatureAndDifferentialPressureTransmitterTransientStateTransactionTest`
  - `PressureTransmitterTransientStateTransactionTest`
- PASS — [full build/test/Javadoc](https://github.com/equinor/neqsim/actions/runs/31707027174)
  - Java 8 Ubuntu and Windows
  - Java 21 Ubuntu and Windows
  - all four Java 21 slow-test shards
  - Javadocs and agent/skill cross-reference checks
- PASS — [Spotless format patch](https://github.com/equinor/neqsim/actions/runs/31707027190)
- PASS — [PaperLab Replication Gate](https://github.com/equinor/neqsim/actions/runs/31707027208)
- PASS — [CodeQL Security Analysis](https://github.com/equinor/neqsim/actions/runs/31707027182)
- PASS — local `python devtools/run_spotless.py apply`; second apply produced an identical diff hash
- PASS — local `git diff --check`
- BASE-BLOCKED — [pre-commit](https://github.com/equinor/neqsim/actions/runs/31707027250) fails only on `CO2ImpurityKineticReactor.java` and its test, files unchanged by this PR and repaired in #2983
- BASE-BLOCKED — [documentation search](https://github.com/equinor/neqsim/actions/runs/31707027171) fails only on the two base CO2 impurity guides without YAML front matter, also repaired/removed in #2983
- LOCAL INFRASTRUCTURE LIMITATION — pre-commit/pre-push stages were unavailable locally because the task runtime had no `pre_commit` module; hosted CI ran the stage and isolated the base-owned failures above

## Documentation impact

Updated:

- `docs/process/dynamic-capability-contract.md`
- `docs/process/equipment/measurement_devices.md`

The docs describe snapshot contents, registration requirements, exact replay mechanics, and fail-closed scope.

## Scope boundary

This PR does not change `VolumeFlowTransmitter`, `LevelTransmitter`, `OilLevelTransmitter`, or `WaterLevelTransmitter`: their current measured-value paths bypass `applySignalModifiers(...)`, so adding snapshot APIs alone would overstate dynamic behavior. It also does not enter #2935 species transport or #2907 multiphase closures/slugging.

This is transaction and deterministic-replay mechanics only. It does not qualify sensor accuracy, scan-time or network jitter, alarm/trip integrity, external historian/DCS effects, safety action, virtual commissioning, or OTS readiness. It does not close #2911.

No human or Copilot review comments or unresolved threads are present. The PR remains draft and is **not READY TO MERGE** until the base-owned #2983 repairs land and exact-head required checks rerun successfully.