### PR TITLE
docs(tutorials): make GOSP screening example executable

### DIFF
--- a/docs/REFERENCE_MANUAL_INDEX.md
+++ b/docs/REFERENCE_MANUAL_INDEX.md
@@ -83,7 +83,7 @@ NeqSim is distributed under the Apache-2.0 license and can be used via:
 | Learning Paths      | [docs/tutorials/learning-paths.md](tutorials/learning-paths)                     | PVT Engineer, Process Engineer, Developer tracks      |
 | **TEG Dehydration** | [docs/tutorials/teg_dehydration_tutorial.md](tutorials/teg_dehydration_tutorial) | **Mass-conserving equilibrium-contact screening with Java and Python examples** |
 | **Solve Engineering Task** | [docs/tutorials/solve-engineering-task.md](tutorials/solve-engineering-task) | **Complete hands-on guide to the 3-step AI task-solving workflow** |
-| **GOSP Tutorial**   | [docs/tutorials/gosp_tutorial.md](tutorials/gosp_tutorial)                       | **Gas-oil separation plant (multi-stage separation)** |
+| **GOSP Tutorial**   | [docs/tutorials/gosp_tutorial.md](tutorials/gosp_tutorial.md)                       | **Gas-oil separation plant (multi-stage separation)** |
 | **PVT Lab Tests**   | [docs/pvtsimulation/pvt_lab_tests.md](pvtsimulation/pvt_lab_tests)               | **CCE, CVD, DL, separator test simulations**          |
 
 ### Chapter 4: Installation & Setup

--- a/docs/test_gosp_tutorial_documentation.py
+++ b/docs/test_gosp_tutorial_documentation.py
@@ -1,0 +1,115 @@
+"""Contract tests for the GOSP screening tutorial."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TUTORIAL = REPO_ROOT / "docs" / "tutorials" / "gosp_tutorial.md"
+TUTORIAL_INDEX = REPO_ROOT / "docs" / "tutorials" / "index.md"
+REFERENCE_INDEX = REPO_ROOT / "docs" / "REFERENCE_MANUAL_INDEX.md"
+SYSTEM_INTERFACE = (
+    REPO_ROOT / "src" / "main" / "java" / "neqsim" / "thermo" / "system"
+    / "SystemInterface.java"
+)
+STREAM_INTERFACE = (
+    REPO_ROOT / "src" / "main" / "java" / "neqsim" / "process" / "equipment"
+    / "stream" / "StreamInterface.java"
+)
+JAVA_TEST = (
+    REPO_ROOT / "src" / "test" / "java" / "neqsim" / "process" / "equipment"
+    / "separator" / "GospTutorialDocumentationTest.java"
+)
+
+
+class GospTutorialDocumentationTest(unittest.TestCase):
+    """Keep the tutorial executable, discoverable, and explicit about its limits."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tutorial = TUTORIAL.read_text(encoding="utf-8")
+        cls.tutorial_index = TUTORIAL_INDEX.read_text(encoding="utf-8")
+        cls.reference_index = REFERENCE_INDEX.read_text(encoding="utf-8")
+        cls.system_interface = SYSTEM_INTERFACE.read_text(encoding="utf-8")
+        cls.stream_interface = STREAM_INTERFACE.read_text(encoding="utf-8")
+        cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
+
+    def test_front_matter_and_fences_are_well_formed(self):
+        self.assertTrue(self.tutorial.startswith("---\n"))
+        closing = self.tutorial.find("\n---\n", 4)
+        self.assertGreater(closing, 4)
+        body = self.tutorial[closing + 5 :]
+        self.assertIsNone(re.search(r"(?m)^# ", body))
+        self.assertEqual(4, len(re.findall(r"(?m)^```", self.tutorial)))
+        self.assertEqual(1, len(re.findall(r"(?m)^```java$", self.tutorial)))
+
+    def test_tbp_and_vpcr4_api_contracts_match_current_source(self):
+        self.assertRegex(
+            self.system_interface,
+            r"(?s)@param molarMass.*?kg/mol.*?void addTBPfraction",
+        )
+        self.assertIn(
+            "double getRVP(double referenceTemperature, String unit, String returnUnit);",
+            self.stream_interface,
+        )
+        for call in (
+            'addTBPfraction("C11", 0.050, 0.150, 0.78)',
+            'addTBPfraction("C15", 0.040, 0.210, 0.82)',
+            'addTBPfraction("C20", 0.060, 0.350, 0.88)',
+            'getRVP(37.8, "C", "bara")',
+        ):
+            self.assertIn(call, self.tutorial)
+            self.assertIn(call, self.java_test)
+
+    def test_example_has_focused_execution_coverage(self):
+        for token in (
+            "SystemSrkCPAstatoil",
+            "ThreePhaseSeparator",
+            "ThrottlingValve",
+            "ProcessSystem",
+            "relativeMassBalanceError",
+            "getWaterOutStream",
+            "getGasOutStream",
+            "getOilOutStream",
+        ):
+            self.assertIn(token, self.tutorial)
+            self.assertIn(token, self.java_test)
+        self.assertIn("relativeMassBalanceError <= 1.0e-3", self.java_test)
+
+    def test_removed_fragments_and_unsupported_claims_do_not_return(self):
+        stale_patterns = (
+            r"System\.(?:out|err)",
+            r'addTBPfraction\("C11",\s*0\.05,\s*150\.0',
+            r"RVP \(est\)",
+            r"Typical North Sea oil",
+            r"<\s*30\s*mg/L",
+        )
+        for pattern in stale_patterns:
+            self.assertIsNone(re.search(pattern, self.tutorial, re.IGNORECASE))
+        self.assertIn("does not replace a qualified laboratory result", self.tutorial)
+        self.assertIn("Do not apply generic RVP", self.tutorial)
+
+    def test_relative_links_resolve_to_repository_files(self):
+        link_targets = re.findall(r"\[[^]]+\]\(([^)]+)\)", self.tutorial)
+        self.assertGreaterEqual(len(link_targets), 5)
+        for target in link_targets:
+            if "://" in target or target.startswith("#"):
+                continue
+            path_text = target.split("#", 1)[0]
+            resolved = (TUTORIAL.parent / path_text).resolve()
+            self.assertTrue(resolved.is_file(), f"Broken tutorial link: {target}")
+
+    def test_tutorial_is_discoverable_with_exact_file_links(self):
+        self.assertIn(
+            "[Gas-Oil Separation Plant (GOSP)](gosp_tutorial.md)",
+            self.tutorial_index,
+        )
+        self.assertIn(
+            "[docs/tutorials/gosp_tutorial.md](tutorials/gosp_tutorial.md)",
+            self.reference_index,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/tutorials/gosp_tutorial.md
+++ b/docs/tutorials/gosp_tutorial.md
@@ -1,454 +1,200 @@
 ---
-title: Gas-Oil Separation Plant (GOSP) Tutorial
-description: Complete tutorial for modeling gas-oil separation plants in NeqSim. Covers multi-stage separation, HP/MP/LP trains, export pump, and optimization for oil recovery and gas quality.
+title: Gas-Oil Separation Plant Screening Tutorial
+description: Executable NeqSim tutorial for three-stage gas-oil-water separation, mass-balance checks, VPCR4 screening, and engineering model boundaries.
 ---
 
-# Gas-Oil Separation Plant (GOSP) Tutorial
+This tutorial builds a three-stage gas-oil separation screening model. It is intended for
+process-model development and teaching: the calculation predicts equilibrium phase splits at the
+selected pressures, but it does not qualify separator internals, produced-water treatment,
+compression, export specifications, or mechanical design.
 
-This tutorial demonstrates how to model a complete gas-oil separation plant (GOSP) in NeqSim, from wellhead through export. A GOSP separates the well stream into stabilized crude oil, associated gas, and produced water.
+## Engineering Question
 
-## Overview
+For a synthetic water-bearing well fluid, calculate the gas, oil, and aqueous product rates after
+separation at 50, 10, and 2 bara. Check the overall mass balance and calculate a model-based VPCR4
+value for the final oil at 37.8 degrees Celsius.
 
-### Typical GOSP Configuration
+The example uses SRK-CPA because water is present. The supplied TBP molar masses are in kg/mol and
+the densities are specific gravities, matching the current `addTBPfraction` API.
 
+## Process Configuration
+
+```text
+well stream
+    |
+    v
+HP three-phase separator (50 bara) ----> HP gas
+    |
+    +----> HP water
+    |
+    v
+MP valve -> MP separator (10 bara) ----> MP gas + MP water
+    |
+    v
+LP valve -> LP separator (2 bara) -----> LP gas + LP water
+    |
+    v
+export-oil screening stream
 ```
-Well Stream → HP Separator → MP Separator → LP Separator → Oil Export
-                  ↓              ↓              ↓
-              HP Gas         MP Gas         LP Gas → Compression
-                  ↓              ↓              ↓
-                  └──────────────┴──────────────┘
-                              ↓
-                        Gas Compression → Export Gas
-```
 
----
+The three gas streams are separate battery-limit products. A real facility would normally route
+the MP and LP gas through scrubbers, compression, cooling, and recycle before export. Those units
+are deliberately excluded so the phase-split and material-balance contract remains clear.
 
-## Quick Start: 3-Stage Separation
-
-### Java Example
+## Complete Java 8 Example
 
 ```java
-import neqsim.process.processmodel.ProcessSystem;
-import neqsim.process.equipment.separator.Separator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.separator.ThreePhaseSeparator;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.equipment.valve.ThrottlingValve;
-import neqsim.process.equipment.compressor.Compressor;
-import neqsim.process.equipment.heatexchanger.Cooler;
-import neqsim.process.equipment.mixer.Mixer;
-import neqsim.thermo.system.SystemSrkEos;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
 
-public class GOSPSimulation {
-    public static void main(String[] args) {
-        
-        // === CREATE WELL FLUID ===
-        SystemSrkEos wellFluid = new SystemSrkEos(353.15, 50.0);  // 80°C, 50 bara
-        
-        // Typical North Sea oil composition
-        wellFluid.addComponent("nitrogen", 0.005);
-        wellFluid.addComponent("CO2", 0.02);
-        wellFluid.addComponent("methane", 0.35);
-        wellFluid.addComponent("ethane", 0.08);
-        wellFluid.addComponent("propane", 0.06);
-        wellFluid.addComponent("i-butane", 0.02);
-        wellFluid.addComponent("n-butane", 0.03);
-        wellFluid.addComponent("i-pentane", 0.015);
-        wellFluid.addComponent("n-pentane", 0.02);
-        wellFluid.addComponent("n-hexane", 0.025);
-        wellFluid.addComponent("n-heptane", 0.04);
-        wellFluid.addComponent("n-octane", 0.05);
-        wellFluid.addComponent("n-nonane", 0.04);
-        wellFluid.addComponent("nC10", 0.03);
-        wellFluid.addTBPfraction("C11", 0.05, 150.0, 0.78);
-        wellFluid.addTBPfraction("C15", 0.04, 210.0, 0.82);
-        wellFluid.addTBPfraction("C20+", 0.06, 350.0, 0.88);
-        wellFluid.addComponent("water", 0.05);
-        
-        wellFluid.setMixingRule("classic");
-        wellFluid.setMultiPhaseCheck(true);
-        
-        // === BUILD PROCESS ===
-        ProcessSystem gosp = new ProcessSystem();
-        
-        // Well stream
-        Stream wellStream = new Stream("Well Stream", wellFluid);
-        wellStream.setFlowRate(50000.0, "kg/hr");
-        wellStream.setTemperature(80.0, "C");
-        wellStream.setPressure(50.0, "bara");
-        gosp.add(wellStream);
-        
-        // === HP SEPARATOR (1st Stage) ===
-        // Pressure: 40-50 bara typical
-        ThreePhaseSeparator hpSeparator = new ThreePhaseSeparator("HP Separator", wellStream);
-        gosp.add(hpSeparator);
-        
-        Stream hpGas = hpSeparator.getGasOutStream();
-        hpGas.setName("HP Gas");
-        gosp.add(hpGas);
-        
-        Stream hpOil = hpSeparator.getOilOutStream();
-        hpOil.setName("HP Oil");
-        gosp.add(hpOil);
-        
-        Stream hpWater = hpSeparator.getWaterOutStream();
-        hpWater.setName("HP Water");
-        gosp.add(hpWater);
-        
-        // === MP SEPARATOR (2nd Stage) ===
-        // Pressure: 8-15 bara typical
-        ThrottlingValve mpValve = new ThrottlingValve("MP Valve", hpOil);
-        mpValve.setOutletPressure(10.0);
-        gosp.add(mpValve);
-        
-        ThreePhaseSeparator mpSeparator = new ThreePhaseSeparator("MP Separator", 
-            mpValve.getOutletStream());
-        gosp.add(mpSeparator);
-        
-        Stream mpGas = mpSeparator.getGasOutStream();
-        mpGas.setName("MP Gas");
-        gosp.add(mpGas);
-        
-        Stream mpOil = mpSeparator.getOilOutStream();
-        mpOil.setName("MP Oil");
-        gosp.add(mpOil);
-        
-        // === LP SEPARATOR (3rd Stage) ===
-        // Pressure: 1.5-3 bara typical
-        ThrottlingValve lpValve = new ThrottlingValve("LP Valve", mpOil);
-        lpValve.setOutletPressure(2.0);
-        gosp.add(lpValve);
-        
-        ThreePhaseSeparator lpSeparator = new ThreePhaseSeparator("LP Separator", 
-            lpValve.getOutletStream());
-        gosp.add(lpSeparator);
-        
-        Stream lpGas = lpSeparator.getGasOutStream();
-        lpGas.setName("LP Gas");
-        gosp.add(lpGas);
-        
-        Stream exportOil = lpSeparator.getOilOutStream();
-        exportOil.setName("Export Crude");
-        gosp.add(exportOil);
-        
-        // === GAS COMPRESSION ===
-        // LP gas compression to MP pressure
-        Compressor lpCompressor = new Compressor("LP Compressor", lpGas);
-        lpCompressor.setOutletPressure(10.0);
-        gosp.add(lpCompressor);
-        
-        Cooler lpCooler = new Cooler("LP Gas Cooler", lpCompressor.getOutletStream());
-        lpCooler.setOutTemperature(40.0, "C");
-        gosp.add(lpCooler);
-        
-        // Mix LP compressed gas with MP gas
-        Mixer mpGasMixer = new Mixer("MP Gas Mixer");
-        mpGasMixer.addStream(lpCooler.getOutletStream());
-        mpGasMixer.addStream(mpGas);
-        gosp.add(mpGasMixer);
-        
-        // MP to HP compression
-        Compressor mpCompressor = new Compressor("MP Compressor", mpGasMixer.getOutletStream());
-        mpCompressor.setOutletPressure(50.0);
-        gosp.add(mpCompressor);
-        
-        Cooler mpCooler = new Cooler("MP Gas Cooler", mpCompressor.getOutletStream());
-        mpCooler.setOutTemperature(40.0, "C");
-        gosp.add(mpCooler);
-        
-        // Mix with HP gas for export
-        Mixer exportGasMixer = new Mixer("Export Gas Mixer");
-        exportGasMixer.addStream(hpGas);
-        exportGasMixer.addStream(mpCooler.getOutletStream());
-        gosp.add(exportGasMixer);
-        
-        Stream exportGas = exportGasMixer.getOutletStream();
-        exportGas.setName("Export Gas");
-        gosp.add(exportGas);
-        
-        // === RUN SIMULATION ===
-        gosp.run();
-        
-        // === RESULTS ===
-        System.out.println("========== GOSP SIMULATION RESULTS ==========");
-        System.out.println();
-        
-        // Feed summary
-        System.out.println("--- FEED ---");
-        System.out.printf("Well stream: %.1f kg/hr (%.1f bbl/day oil equivalent)%n",
-            wellStream.getFlowRate("kg/hr"),
-            wellStream.getFlowRate("kg/hr") * 24 / 159.0 / 0.85);
-        System.out.printf("Feed GOR: %.0f Sm3/Sm3%n", 
-            wellFluid.getGOR());
-        System.out.println();
-        
-        // Separator performance
-        System.out.println("--- SEPARATOR PERFORMANCE ---");
-        System.out.printf("HP Separator: P=%.1f bara, T=%.1f C%n",
-            hpSeparator.getPressure(), hpSeparator.getTemperature() - 273.15);
-        System.out.printf("  Gas: %.1f kg/hr%n", hpGas.getFlowRate("kg/hr"));
-        System.out.printf("  Oil: %.1f kg/hr%n", hpOil.getFlowRate("kg/hr"));
-        System.out.printf("  Water: %.1f kg/hr%n", hpWater.getFlowRate("kg/hr"));
-        System.out.println();
-        
-        System.out.printf("MP Separator: P=%.1f bara, T=%.1f C%n",
-            mpSeparator.getPressure(), mpSeparator.getTemperature() - 273.15);
-        System.out.printf("  Gas: %.1f kg/hr%n", mpGas.getFlowRate("kg/hr"));
-        System.out.printf("  Oil: %.1f kg/hr%n", mpOil.getFlowRate("kg/hr"));
-        System.out.println();
-        
-        System.out.printf("LP Separator: P=%.1f bara, T=%.1f C%n",
-            lpSeparator.getPressure(), lpSeparator.getTemperature() - 273.15);
-        System.out.printf("  Gas: %.1f kg/hr%n", lpGas.getFlowRate("kg/hr"));
-        System.out.printf("  Oil: %.1f kg/hr%n", exportOil.getFlowRate("kg/hr"));
-        System.out.println();
-        
-        // Product specifications
-        System.out.println("--- PRODUCT SPECIFICATIONS ---");
-        System.out.printf("Export Oil: %.1f kg/hr%n", exportOil.getFlowRate("kg/hr"));
-        System.out.printf("  API Gravity: %.1f%n", 
-            141.5 / (exportOil.getFluid().getDensity("kg/m3") / 1000.0) - 131.5);
-        System.out.printf("  RVP (est): %.2f bara%n", 
-            lpSeparator.getPressure());  // Approximation
-        System.out.println();
-        
-        System.out.printf("Export Gas: %.1f kg/hr (%.2f MSm3/day)%n", 
-            exportGas.getFlowRate("kg/hr"),
-            exportGas.getFlowRate("Sm3/day") / 1e6);
-        System.out.printf("  Methane: %.1f mol%%%n",
-            exportGas.getFluid().getComponent("methane").getx() * 100);
-        System.out.printf("  CO2: %.2f mol%%%n",
-            exportGas.getFluid().getComponent("CO2").getx() * 100);
-        System.out.println();
-        
-        // Compression power
-        System.out.println("--- COMPRESSION DUTY ---");
-        System.out.printf("LP Compressor: %.1f kW%n", lpCompressor.getPower("kW"));
-        System.out.printf("MP Compressor: %.1f kW%n", mpCompressor.getPower("kW"));
-        System.out.printf("Total compression: %.1f kW%n", 
-            lpCompressor.getPower("kW") + mpCompressor.getPower("kW"));
+public final class GospScreeningExample {
+  private static final Logger logger = LogManager.getLogger(GospScreeningExample.class);
+
+  private GospScreeningExample() {}
+
+  public static void main(String[] args) {
+    SystemInterface wellFluid = new SystemSrkCPAstatoil(353.15, 50.0);
+    wellFluid.addComponent("nitrogen", 0.005);
+    wellFluid.addComponent("CO2", 0.020);
+    wellFluid.addComponent("methane", 0.350);
+    wellFluid.addComponent("ethane", 0.080);
+    wellFluid.addComponent("propane", 0.060);
+    wellFluid.addComponent("i-butane", 0.020);
+    wellFluid.addComponent("n-butane", 0.030);
+    wellFluid.addComponent("i-pentane", 0.015);
+    wellFluid.addComponent("n-pentane", 0.020);
+    wellFluid.addComponent("n-hexane", 0.025);
+    wellFluid.addComponent("n-heptane", 0.040);
+    wellFluid.addComponent("n-octane", 0.050);
+    wellFluid.addComponent("n-nonane", 0.040);
+    wellFluid.addComponent("nC10", 0.030);
+    wellFluid.addTBPfraction("C11", 0.050, 0.150, 0.78);
+    wellFluid.addTBPfraction("C15", 0.040, 0.210, 0.82);
+    wellFluid.addTBPfraction("C20", 0.060, 0.350, 0.88);
+    wellFluid.addComponent("water", 0.050);
+    wellFluid.setMixingRule(10);
+    wellFluid.setMultiPhaseCheck(true);
+
+    Stream feed = new Stream("well stream", wellFluid);
+    feed.setFlowRate(50000.0, "kg/hr");
+    feed.setTemperature(80.0, "C");
+    feed.setPressure(50.0, "bara");
+
+    ThreePhaseSeparator hpSeparator = new ThreePhaseSeparator("HP separator", feed);
+    StreamInterface hpOil = hpSeparator.getOilOutStream();
+
+    ThrottlingValve mpValve = new ThrottlingValve("MP valve", hpOil);
+    mpValve.setOutletPressure(10.0, "bara");
+    ThreePhaseSeparator mpSeparator =
+        new ThreePhaseSeparator("MP separator", mpValve.getOutletStream());
+    StreamInterface mpOil = mpSeparator.getOilOutStream();
+
+    ThrottlingValve lpValve = new ThrottlingValve("LP valve", mpOil);
+    lpValve.setOutletPressure(2.0, "bara");
+    ThreePhaseSeparator lpSeparator =
+        new ThreePhaseSeparator("LP separator", lpValve.getOutletStream());
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(hpSeparator);
+    process.add(mpValve);
+    process.add(mpSeparator);
+    process.add(lpValve);
+    process.add(lpSeparator);
+    process.run();
+
+    double gasMassFlow = hpSeparator.getGasOutStream().getFlowRate("kg/hr")
+        + mpSeparator.getGasOutStream().getFlowRate("kg/hr")
+        + lpSeparator.getGasOutStream().getFlowRate("kg/hr");
+    double waterMassFlow = hpSeparator.getWaterOutStream().getFlowRate("kg/hr")
+        + mpSeparator.getWaterOutStream().getFlowRate("kg/hr")
+        + lpSeparator.getWaterOutStream().getFlowRate("kg/hr");
+    StreamInterface exportOil = lpSeparator.getOilOutStream();
+    double oilMassFlow = exportOil.getFlowRate("kg/hr");
+    double feedMassFlow = feed.getFlowRate("kg/hr");
+    double recoveredMassFlow = gasMassFlow + waterMassFlow + oilMassFlow;
+    double relativeMassBalanceError =
+        Math.abs(recoveredMassFlow - feedMassFlow) / feedMassFlow;
+    double vpcr4Bara = exportOil.getRVP(37.8, "C", "bara");
+
+    requireFinitePositive("gas mass flow", gasMassFlow);
+    requireFinitePositive("water mass flow", waterMassFlow);
+    requireFinitePositive("oil mass flow", oilMassFlow);
+    requireFinitePositive("VPCR4", vpcr4Bara);
+    if (relativeMassBalanceError > 1.0e-3) {
+      throw new IllegalStateException(
+          "Relative material-balance error exceeds 0.1%: " + relativeMassBalanceError);
     }
+
+    logger.info("Gas products: {} kg/hr", gasMassFlow);
+    logger.info("Water products: {} kg/hr", waterMassFlow);
+    logger.info("Export-oil screening stream: {} kg/hr", oilMassFlow);
+    logger.info("Relative material-balance error: {}", relativeMassBalanceError);
+    logger.info("Model VPCR4 at 37.8 C: {} bara", vpcr4Bara);
+  }
+
+  private static void requireFinitePositive(String name, double value) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalStateException(name + " is not finite and positive: " + value);
+    }
+  }
 }
 ```
 
-### Python Example
+## Interpret the Results
 
-```python
-from neqsim import jneqsim
+The recovered product mass should match the feed within the stated numerical tolerance. Each gas,
+oil, and water rate is an equilibrium phase-split result for this synthetic fluid and selected
+model; it is not a separator-efficiency guarantee.
 
-# Import classes
-SystemSrkEos = jneqsim.thermo.system.SystemSrkEos
-ProcessSystem = jneqsim.process.processmodel.ProcessSystem
-Stream = jneqsim.process.equipment.stream.Stream
-ThreePhaseSeparator = jneqsim.process.equipment.separator.ThreePhaseSeparator
-ThrottlingValve = jneqsim.process.equipment.valve.ThrottlingValve
-Compressor = jneqsim.process.equipment.compressor.Compressor
-Cooler = jneqsim.process.equipment.heatexchanger.Cooler
-Mixer = jneqsim.process.equipment.mixer.Mixer
+`getRVP(37.8, "C", "bara")` returns NeqSim's VPCR4 model result on a cloned fluid. It is not the
+LP separator pressure and does not replace a qualified laboratory result. See the
+[ASTM D6377 vapor-pressure screening guide](../standards/astm_d6377_rvp.md) for method semantics,
+state ownership, and compliance boundaries.
 
-# Create well fluid
-fluid = SystemSrkEos(273.15 + 80.0, 50.0)
-fluid.addComponent("nitrogen", 0.005)
-fluid.addComponent("CO2", 0.02)
-fluid.addComponent("methane", 0.35)
-fluid.addComponent("ethane", 0.08)
-fluid.addComponent("propane", 0.06)
-fluid.addComponent("i-butane", 0.02)
-fluid.addComponent("n-butane", 0.03)
-fluid.addComponent("i-pentane", 0.015)
-fluid.addComponent("n-pentane", 0.02)
-fluid.addComponent("n-hexane", 0.025)
-fluid.addComponent("n-heptane", 0.04)
-fluid.addComponent("n-octane", 0.05)
-fluid.addTBPfraction("C10+", 0.10, 200.0, 0.82)
-fluid.addComponent("water", 0.05)
-fluid.setMixingRule("classic")
-fluid.setMultiPhaseCheck(True)
+## Pressure Selection
 
-# Build process
-gosp = ProcessSystem()
+Stage pressure changes affect liquid recovery, flash-gas production, vapor pressure, compression
+power, and downstream water handling. Compare candidate pressure sets with freshly constructed
+process cases and record, at minimum:
 
-# Feed
-well = Stream("Well", fluid)
-well.setFlowRate(50000.0, "kg/hr")
-well.setTemperature(80.0, "C")
-well.setPressure(50.0, "bara")
-gosp.add(well)
+1. export-oil and gas mass rates;
+2. VPCR4 or the contract-selected vapor-pressure quantity;
+3. MP/LP gas compression duties and discharge temperatures;
+4. hydrocarbon losses to produced water;
+5. material and energy closure; and
+6. equipment operating envelopes.
 
-# HP Separator
-hp_sep = ThreePhaseSeparator("HP Sep", well)
-gosp.add(hp_sep)
+Maximizing oil mass alone is not a complete optimization objective. Pressure limits, compressor
+maps, heating/cooling duties, product specifications, emissions, and operability must also be
+represented.
 
-# MP Separator
-mp_valve = ThrottlingValve("MP Valve", hp_sep.getOilOutStream())
-mp_valve.setOutletPressure(10.0)
-gosp.add(mp_valve)
+## Model Boundaries
 
-mp_sep = ThreePhaseSeparator("MP Sep", mp_valve.getOutletStream())
-gosp.add(mp_sep)
+| Topic | What this tutorial proves | Additional evidence required |
+|---|---|---|
+| Phase separation | Equilibrium gas/oil/aqueous splits | Internals, residence time, entrainment, foaming, and vessel sizing |
+| Vapor pressure | NeqSim VPCR4 screening at 37.8 degrees Celsius | Qualified laboratory method and applicable product contract |
+| Produced water | Aqueous phase rate leaving each stage | Hydrocyclone/deoiling model, oil-in-water measurement, chemistry, and discharge basis |
+| Gas export | Gas available at three pressure levels | Compression, cooling, scrubbers, recycle, dew-point treatment, and metering |
+| Oil export | Final equilibrium oil stream | BS&W/salt/H2S analysis, export pumping, custody-transfer basis, and specification checks |
+| Floating facility | Thermodynamic screening remains usable | Motion-specific separation performance and accountable mechanical design |
 
-# LP Separator
-lp_valve = ThrottlingValve("LP Valve", mp_sep.getOilOutStream())
-lp_valve.setOutletPressure(2.0)
-gosp.add(lp_valve)
+Do not apply generic RVP, BS&W, salt, H2S, dew-point, heating-value, or discharge limits. These
+limits depend on the product, jurisdiction, receiving system, measurement method, and controlled
+contract or regulation.
 
-lp_sep = ThreePhaseSeparator("LP Sep", lp_valve.getOutletStream())
-gosp.add(lp_sep)
+## Related Documentation
 
-# Run
-gosp.run()
-
-# Results
-print("=== GOSP Results ===")
-print(f"Export Oil: {lp_sep.getOilOutStream().getFlowRate('kg/hr'):.0f} kg/hr")
-print(f"HP Gas: {hp_sep.getGasOutStream().getFlowRate('kg/hr'):.0f} kg/hr")
-print(f"MP Gas: {mp_sep.getGasOutStream().getFlowRate('kg/hr'):.0f} kg/hr")
-print(f"LP Gas: {lp_sep.getGasOutStream().getFlowRate('kg/hr'):.0f} kg/hr")
-```
-
----
-
-## Design Considerations
-
-### Optimal Separator Pressures
-
-The goal is to maximize liquid recovery while meeting product specifications.
-
-| Stage | Typical Pressure | Purpose |
-|-------|------------------|---------|
-| HP | 30-70 bara | Bulk gas removal, maximum gas at high pressure |
-| MP | 8-15 bara | Intermediate separation, gas compression stages |
-| LP | 1.5-3 bara | Final stabilization, meet RVP spec |
-
-### Pressure Optimization
-
-Use NeqSim to find optimal pressures for maximum oil recovery:
-
-```java
-// Iterate to find optimal MP pressure
-double maxOilRecovery = 0;
-double optimalPressure = 0;
-
-for (double mpPressure = 5.0; mpPressure <= 20.0; mpPressure += 1.0) {
-    mpValve.setOutletPressure(mpPressure);
-    gosp.run();
-    
-    double oilRate = exportOil.getFlowRate("kg/hr");
-    if (oilRate > maxOilRecovery) {
-        maxOilRecovery = oilRate;
-        optimalPressure = mpPressure;
-    }
-}
-System.out.printf("Optimal MP pressure: %.1f bara%n", optimalPressure);
-System.out.printf("Maximum oil recovery: %.1f kg/hr%n", maxOilRecovery);
-```
-
----
-
-## Product Specifications
-
-### Export Crude Specifications
-
-| Parameter | Typical Spec | Notes |
-|-----------|--------------|-------|
-| RVP | < 1 bara (14.7 psia) | Reid Vapor Pressure |
-| BS&W | < 0.5% | Basic Sediment & Water |
-| Salt content | < 10 PTB | Pounds per thousand barrels |
-| API gravity | Report | Typically 25-45° API |
-| H₂S | < 10 ppm | Safety requirement |
-
-### Export Gas Specifications
-
-| Parameter | Typical Spec | Notes |
-|-----------|--------------|-------|
-| Hydrocarbon dew point | < 0°C at delivery pressure | Prevent condensation |
-| Water dew point | < -10°C | Prevent hydrates/corrosion |
-| H₂S | < 4 ppm | Pipeline spec |
-| CO₂ | < 2-3 mol% | Customer spec |
-| Gross heating value | 35-43 MJ/Sm³ | Quality spec |
-
----
-
-## Adding Heat Integration
-
-For improved efficiency, add heat exchangers between hot and cold streams:
-
-```java
-// Example: Use hot export oil to preheat incoming well stream
-HeatExchanger feedOilExchanger = new HeatExchanger("Feed/Oil Exchanger");
-feedOilExchanger.setFeedStream(0, wellStream);      // Cold side (well stream in)
-feedOilExchanger.setFeedStream(1, exportOil);       // Hot side (export oil)
-feedOilExchanger.setUAvalue(5000.0);                // Heat transfer coefficient × area
-gosp.add(feedOilExchanger);
-```
-
----
-
-## Water Treatment Integration
-
-For platforms with produced water treatment:
-
-```java
-// Hydrocyclone for oil-in-water removal
-Separator hydrocyclone = new Separator("Hydrocyclone", hpWater);
-gosp.add(hydrocyclone);
-
-// Produced water meets discharge spec (<30 mg/L oil)
-Stream treatedWater = hydrocyclone.getLiquidOutStream();
-treatedWater.setName("Treated Water");
-gosp.add(treatedWater);
-```
-
----
-
-## Common Variations
-
-### Stabilization Column
-
-For deeper stabilization (lower RVP), replace LP separator with a stabilizer column:
-
-```java
-import neqsim.process.equipment.distillation.DistillationColumn;
-
-// Stabilizer column instead of LP separator
-DistillationColumn stabilizer = new DistillationColumn("Stabilizer", 10, true, false);
-stabilizer.addFeedStream(mpOil, 5);  // Feed at middle tray
-stabilizer.setCondenserTemperature(40.0, "C");
-stabilizer.setReboilerTemperature(150.0, "C");
-gosp.add(stabilizer);
-
-Stream stabilizerOverhead = stabilizer.getGasOutStream();
-Stream stabilizedCrude = stabilizer.getLiquidOutStream();
-```
-
-### FPSO Configuration
-
-For floating production, add motion considerations:
-
-```java
-// Use larger separator sizes for FPSO (handle motion effects)
-hpSeparator.setInternalDiameter(3.5);  // meters
-hpSeparator.setLiquidLevel(0.5);       // fraction
-hpSeparator.setSeparatorLength(15.0);  // meters
-```
-
----
-
-## Performance Metrics
-
-Key performance indicators for GOSP operations:
-
-| KPI | Formula | Target |
-|-----|---------|--------|
-| Oil recovery | (Export oil / Feed oil) × 100 | > 98% |
-| Gas compression ratio | Export P / LP P | Minimize |
-| Specific power | kW / MSm³/d gas | Minimize |
-| Uptime | Operating hours / Available hours | > 95% |
-
----
-
-## See Also
-
-- [Separator Equipment](../process/equipment/separators) - Detailed separator documentation
-- [Compressor Guide](../process/equipment/compressors) - Compression calculations
-- [Process Recipes](../cookbook/process-recipes) - Quick recipes
-- [Flow Assurance](../pvtsimulation/flowassurance/) - Flow assurance considerations
+- [Separator equipment](../process/equipment/separators.md)
+- [Compressor equipment](../process/equipment/compressors.md)
+- [Process cookbook](../cookbook/process-recipes.md)
+- [Flow-assurance overview](../pvtsimulation/flowassurance/index.md)
+- [ASTM D6377 vapor-pressure screening](../standards/astm_d6377_rvp.md)

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -36,7 +36,7 @@ Complete walkthroughs for common applications:
 | Tutorial | Description | Level |
 |----------|-------------|-------|
 | **[TEG Gas Dehydration](teg_dehydration_tutorial.md)** | Equilibrium-contact screening with component and total mass balances | Intermediate |
-| **[Gas-Oil Separation Plant (GOSP)](gosp_tutorial.md)** | Multi-stage separation with compression | Intermediate |
+| **[Gas-Oil Separation Plant (GOSP)](gosp_tutorial.md)** | Three-stage separation, material balance, and VPCR4 screening | Intermediate |
 | **[PVT Lab Test Simulations](../pvtsimulation/pvt_lab_tests.md)** | CCE, CVD, DL, separator tests | Intermediate |
 | **[Flow Assurance Overview](../pvtsimulation/flow_assurance_overview.md)** | Hydrates, wax, asphaltenes screening | Intermediate |
 | **[UniSim/HYSYS to NeqSim Conversion](../process/unisim-to-neqsim-conversion.md)** | Convert UniSim `.usc` models to NeqSim | Intermediate |

--- a/src/test/java/neqsim/process/equipment/separator/GospTutorialDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/GospTutorialDocumentationTest.java
@@ -23,16 +23,12 @@ class GospTutorialDocumentationTest extends NeqSimTest {
     feed.setPressure(50.0, "bara");
 
     ThreePhaseSeparator hpSeparator = new ThreePhaseSeparator("HP separator", feed);
-    ThrottlingValve mpValve =
-        new ThrottlingValve("MP valve", hpSeparator.getOilOutStream());
+    ThrottlingValve mpValve = new ThrottlingValve("MP valve", hpSeparator.getOilOutStream());
     mpValve.setOutletPressure(10.0, "bara");
-    ThreePhaseSeparator mpSeparator =
-        new ThreePhaseSeparator("MP separator", mpValve.getOutletStream());
-    ThrottlingValve lpValve =
-        new ThrottlingValve("LP valve", mpSeparator.getOilOutStream());
+    ThreePhaseSeparator mpSeparator = new ThreePhaseSeparator("MP separator", mpValve.getOutletStream());
+    ThrottlingValve lpValve = new ThrottlingValve("LP valve", mpSeparator.getOilOutStream());
     lpValve.setOutletPressure(2.0, "bara");
-    ThreePhaseSeparator lpSeparator =
-        new ThreePhaseSeparator("LP separator", lpValve.getOutletStream());
+    ThreePhaseSeparator lpSeparator = new ThreePhaseSeparator("LP separator", lpValve.getOutletStream());
 
     ProcessSystem process = new ProcessSystem();
     process.add(feed);
@@ -43,18 +39,15 @@ class GospTutorialDocumentationTest extends NeqSimTest {
     process.add(lpSeparator);
     process.run();
 
-    double gasMassFlow = massFlow(hpSeparator.getGasOutStream())
-        + massFlow(mpSeparator.getGasOutStream())
+    double gasMassFlow = massFlow(hpSeparator.getGasOutStream()) + massFlow(mpSeparator.getGasOutStream())
         + massFlow(lpSeparator.getGasOutStream());
-    double waterMassFlow = massFlow(hpSeparator.getWaterOutStream())
-        + massFlow(mpSeparator.getWaterOutStream())
+    double waterMassFlow = massFlow(hpSeparator.getWaterOutStream()) + massFlow(mpSeparator.getWaterOutStream())
         + massFlow(lpSeparator.getWaterOutStream());
     StreamInterface exportOil = lpSeparator.getOilOutStream();
     double oilMassFlow = massFlow(exportOil);
     double feedMassFlow = massFlow(feed);
     double recoveredMassFlow = gasMassFlow + waterMassFlow + oilMassFlow;
-    double relativeMassBalanceError =
-        Math.abs(recoveredMassFlow - feedMassFlow) / feedMassFlow;
+    double relativeMassBalanceError = Math.abs(recoveredMassFlow - feedMassFlow) / feedMassFlow;
     double vpcr4Bara = exportOil.getRVP(37.8, "C", "bara");
 
     assertEquals(50000.0, feedMassFlow, 1.0e-6);

--- a/src/test/java/neqsim/process/equipment/separator/GospTutorialDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/GospTutorialDocumentationTest.java
@@ -1,0 +1,97 @@
+package neqsim.process.equipment.separator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+
+/** Regression coverage for the complete GOSP tutorial example. */
+class GospTutorialDocumentationTest extends NeqSimTest {
+  @Test
+  void threeStageTutorialClosesMaterialBalanceAndCalculatesVpcr4() {
+    SystemInterface wellFluid = createWellFluid();
+    Stream feed = new Stream("well stream", wellFluid);
+    feed.setFlowRate(50000.0, "kg/hr");
+    feed.setTemperature(80.0, "C");
+    feed.setPressure(50.0, "bara");
+
+    ThreePhaseSeparator hpSeparator = new ThreePhaseSeparator("HP separator", feed);
+    ThrottlingValve mpValve =
+        new ThrottlingValve("MP valve", hpSeparator.getOilOutStream());
+    mpValve.setOutletPressure(10.0, "bara");
+    ThreePhaseSeparator mpSeparator =
+        new ThreePhaseSeparator("MP separator", mpValve.getOutletStream());
+    ThrottlingValve lpValve =
+        new ThrottlingValve("LP valve", mpSeparator.getOilOutStream());
+    lpValve.setOutletPressure(2.0, "bara");
+    ThreePhaseSeparator lpSeparator =
+        new ThreePhaseSeparator("LP separator", lpValve.getOutletStream());
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(hpSeparator);
+    process.add(mpValve);
+    process.add(mpSeparator);
+    process.add(lpValve);
+    process.add(lpSeparator);
+    process.run();
+
+    double gasMassFlow = massFlow(hpSeparator.getGasOutStream())
+        + massFlow(mpSeparator.getGasOutStream())
+        + massFlow(lpSeparator.getGasOutStream());
+    double waterMassFlow = massFlow(hpSeparator.getWaterOutStream())
+        + massFlow(mpSeparator.getWaterOutStream())
+        + massFlow(lpSeparator.getWaterOutStream());
+    StreamInterface exportOil = lpSeparator.getOilOutStream();
+    double oilMassFlow = massFlow(exportOil);
+    double feedMassFlow = massFlow(feed);
+    double recoveredMassFlow = gasMassFlow + waterMassFlow + oilMassFlow;
+    double relativeMassBalanceError =
+        Math.abs(recoveredMassFlow - feedMassFlow) / feedMassFlow;
+    double vpcr4Bara = exportOil.getRVP(37.8, "C", "bara");
+
+    assertEquals(50000.0, feedMassFlow, 1.0e-6);
+    assertTrue(gasMassFlow > 0.0);
+    assertTrue(waterMassFlow > 0.0);
+    assertTrue(oilMassFlow > 0.0);
+    assertTrue(relativeMassBalanceError <= 1.0e-3);
+    assertTrue(Double.isFinite(vpcr4Bara));
+    assertTrue(vpcr4Bara > 0.0);
+  }
+
+  private static double massFlow(StreamInterface stream) {
+    return stream.getFlowRate("kg/hr");
+  }
+
+  private static SystemInterface createWellFluid() {
+    SystemInterface wellFluid = new SystemSrkCPAstatoil(353.15, 50.0);
+    wellFluid.addComponent("nitrogen", 0.005);
+    wellFluid.addComponent("CO2", 0.020);
+    wellFluid.addComponent("methane", 0.350);
+    wellFluid.addComponent("ethane", 0.080);
+    wellFluid.addComponent("propane", 0.060);
+    wellFluid.addComponent("i-butane", 0.020);
+    wellFluid.addComponent("n-butane", 0.030);
+    wellFluid.addComponent("i-pentane", 0.015);
+    wellFluid.addComponent("n-pentane", 0.020);
+    wellFluid.addComponent("n-hexane", 0.025);
+    wellFluid.addComponent("n-heptane", 0.040);
+    wellFluid.addComponent("n-octane", 0.050);
+    wellFluid.addComponent("n-nonane", 0.040);
+    wellFluid.addComponent("nC10", 0.030);
+    wellFluid.addTBPfraction("C11", 0.050, 0.150, 0.78);
+    wellFluid.addTBPfraction("C15", 0.040, 0.210, 0.82);
+    wellFluid.addTBPfraction("C20", 0.060, 0.350, 0.88);
+    wellFluid.addComponent("water", 0.050);
+    wellFluid.setMixingRule(10);
+    wellFluid.setMultiPhaseCheck(true);
+    return wellFluid;
+  }
+}


### PR DESCRIPTION
Progresses #2499 (D058 — tutorials/cookbook/troubleshooting/examples rotation).

## Frozen scope

- `docs/tutorials/gosp_tutorial.md`
- `docs/tutorials/index.md`
- `docs/REFERENCE_MANUAL_INDEX.md`
- `docs/test_gosp_tutorial_documentation.py`
- `src/test/java/neqsim/process/equipment/separator/GospTutorialDocumentationTest.java`

No files outside this batch are changed.

## Confirmed defects and root cause

1. **High — factor-1000 TBP molar masses.** The Java and Python fragments supplied 150–350 to `addTBPfraction`, while the current API contract requires kg/mol.
2. **High — incorrect vapor-pressure claim.** The tutorial labelled LP separator pressure as estimated RVP; separator operating pressure is not VPCR4.
3. **High — non-running examples.** Several fragments depended on undeclared variables/imports and had no execution coverage.
4. **High — unsupported produced-water assurance.** A generic separator was called a hydrocyclone and the page asserted a fixed discharge limit without a treatment model, measurement method, jurisdiction, or contract.
5. **Medium — repository-incompatible output.** The examples contained 29 `System.out` calls.
6. **Medium — unsupported scope/specifications.** The page described a synthetic fluid as typical North Sea oil, promised absent export equipment, and presented generic limits as broadly applicable.
7. **Medium — navigation/rendering debt.** Duplicate title structure and extensionless/incorrect internal paths reduced Jekyll reliability and discoverability.

## Fixes

- Replace the disconnected fragments with one complete Java 8 three-stage separator example.
- Use SRK-CPA for the water-bearing synthetic fluid and supply TBP molar masses as 0.150, 0.210, and 0.350 kg/mol.
- Calculate all gas/oil/water product rates and assert an overall relative mass-balance error no greater than 0.1%.
- Calculate model VPCR4 with `getRVP(37.8, "C", "bara")`; state explicitly that this is neither LP separator pressure nor laboratory compliance evidence.
- Use Log4j2 and remove every console-print fragment.
- Add explicit model boundaries for separator performance, produced-water treatment, compression/export, product contracts, and floating-facility design.
- Repair all related-document links and both documentation indexes.
- Add a focused Java regression test that executes every changed API call and a Python documentation contract that protects units, semantics, structure, links, and discoverability.

## Validation completed

- Connector-verified exact branch head: `a496ddfc21a3506f622827ac6fd57a9f92049bc8`, based on master `e0cb19cf1b1cf4c4408c7ec113037661c674f2a6`.
- Connector readback of all five changed blobs: passed.
- Current-source contract check against `SystemInterface.addTBPfraction` (kg/mol): passed.
- Current-source contract check against `StreamInterface.getRVP(double, String, String)`: passed.
- Internal target existence checks for all five related-document links: passed.
- Front matter, no duplicate H1, Markdown fence balance, stale-claim rejection, exact index paths, and Java-test token parity: passed.
- `python -m py_compile d058/docs/test_gosp_tutorial_documentation.py`: exit 0.
- Manual scope/sensitive-material review: five frozen paths only; no credentials, generated binaries, or unrelated edits.

## VALIDATION PENDING CI

Local Maven/pre-commit execution was unavailable. GitHub CI has supplied the following exact-head evidence; unfinished checks remain explicitly pending:

- exact-head pre-commit workflow (including Spotless check and documentation-search hook): **passed**
- exact-head Spotless format-patch workflow: **passed; no further formatter change required**
- exact-head documentation-search workflow: **passed**, including all documentation contract tests and the Jekyll/search build
- exact-head CodeQL: **passed**
- exact-head Javadoc and agent-skill reference checks: **passed**
- full Java fast/slow test matrix, including `GospTutorialDocumentationTest`: running
- rendered-page visual inspection: not performed

No notebook or Python NeqSim execution is in scope for D058, so the NeqSim Python bootstrap is not required.

## Exclusions and next scope

Compression sizing, produced-water treatment design, export pumping, product-specification compliance, FPSO motion performance, and production-code changes are intentionally excluded. After D058 merges and is revalidated on current master, the next rotation target is D059 (standards/regulatory guides).

### CI repair note

The initial pre-commit run identified only Spotless line wrapping in the new Java test. The exact formatter patch was applied in `a496ddfc21a3506f622827ac6fd57a9f92049bc8`; the subsequent Spotless and pre-commit workflows passed.