### PR TITLE
fix(flash): improve sour-gas TPflash consistency

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -23,6 +23,8 @@ public class TPflash extends Flash {
   private static final long serialVersionUID = 1000;
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(TPflash.class);
+  /** Local lower-temperature seed step for legacy multiphase endpoint rescue. */
+  private static final double MULTIPHASE_RESCUE_TEMPERATURE_STEP = 2.0;
   /** Lower sum(zK) bound for a general gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_K_LOWER_LIMIT = 0.95;
   /** Upper sum(zK) bound for a general gas endpoint rescue. */
@@ -35,6 +37,10 @@ public class TPflash extends Flash {
   private static final double MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_OVER_K_LOWER_LIMIT = 0.95;
   /** Upper sum(z/K) bound for gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_UPPER_LIMIT = 2.0;
+  /** Lower sum(zK) bound for legacy liquid endpoint rescue. */
+  private static final double MULTIPHASE_RESCUE_LIQUID_SUM_Z_K_LOWER_LIMIT = 0.95;
+  /** Upper sum(zK) bound for legacy liquid endpoint rescue. */
+  private static final double MULTIPHASE_RESCUE_LIQUID_SUM_Z_K_UPPER_LIMIT = 1.20;
   /** Minimum sum(z/K) bound for liquid endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_LIQUID_SUM_Z_OVER_K_LIMIT = 5.0;
   /** Minimum log K spread for liquid endpoint rescue. */
@@ -86,6 +92,10 @@ public class TPflash extends Flash {
   private static final double PHASE_ROOT_EQUILIBRIUM_TOLERANCE = 1.0e-8;
   /** Maximum absolute Z or composition change for recognizing an unchanged stable one-phase state. */
   private static final double UNCHANGED_SINGLE_PHASE_STATE_TOLERANCE = 1.0e-11;
+  /** Maximum final SSI updates retained for legacy neutral endpoint repair. */
+  private static final int MAX_FINAL_EQUILIBRIUM_REFINEMENT_ITERATIONS = 8;
+  /** Largest residual eligible for legacy bounded final SSI refinement. */
+  private static final double MAX_FINAL_EQUILIBRIUM_REFINEMENT_RESIDUAL = 1.0e-5;
   /** Maximum multiphase beta updates used to repair an invalid neutral two-phase endpoint. */
   private static final int MAX_FINAL_BETA_REFINEMENT_ITERATIONS = 20;
   /** Cubic phase roots evaluated by the post-convergence root checks. */
@@ -820,6 +830,7 @@ public class TPflash extends Flash {
           TPmultiflash operation = new TPmultiflash(system, system.doSolidPhaseCheck());
           operation.run();
           rescueSinglePhaseWaterBearingEndpoint();
+          rescueSinglePhaseMultiphaseEndpointLegacy();
           rescueSinglePhaseMultiphaseEndpoint();
         }
         if (solidCheck) {
@@ -837,6 +848,7 @@ public class TPflash extends Flash {
           logger.debug("Post-stability init failed: {}", ex.getMessage());
         }
         rescueSinglePhaseWaterBearingEndpoint();
+        rescueSinglePhaseMultiphaseEndpointLegacy();
         rescueSinglePhaseMultiphaseEndpoint();
         rejectUnnormalizedAqueousEndpointAfterStableSinglePhase();
 
@@ -859,10 +871,12 @@ public class TPflash extends Flash {
         collapseTrivialMultiphaseSplit();
         rescueLowerGibbsPhaseRoot();
         rescueLowerGibbsHydrocarbonPhaseRoots();
+        rescueLiquidLiquidEndpointLegacy();
         rescueLowerGibbsNeutralEndpoint();
         rescueWaterRichEndpoint();
         rescueLowerGibbsMultiphaseAqueousRoot();
         refineInvalidAqueousTwoPhaseEndpoint();
+        refineInvalidNeutralGasLiquidTwoPhaseEndpointLegacy();
         refineInvalidNeutralTwoPhaseEndpoint();
         normalizeUnchangedStableSinglePhaseEndpoint(stableSinglePhaseType, stableSinglePhaseZ,
             stableSinglePhaseComposition);
@@ -1018,6 +1032,7 @@ public class TPflash extends Flash {
       restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(balancedWaterBearingReference);
       restoreLowerGibbsReferenceAfterSinglePhaseCollapse(balancedWaterBearingReference);
       rescueSinglePhaseWaterBearingEndpoint();
+      rescueSinglePhaseMultiphaseEndpointLegacy();
       rescueSinglePhaseMultiphaseEndpoint();
       // rescueSpuriousMultiphaseEndpoint() is called once at the end of runInternal()
       // after orderByDensity(), so it is intentionally not repeated here.
@@ -1063,6 +1078,7 @@ public class TPflash extends Flash {
       }
     }
     rescueSinglePhaseWaterBearingEndpoint();
+    rescueSinglePhaseMultiphaseEndpointLegacy();
     rescueSinglePhaseMultiphaseEndpoint();
     system.orderByDensity();
     try {
@@ -1071,6 +1087,7 @@ public class TPflash extends Flash {
       logger.warn("Final init after orderByDensity failed: " + ex.getMessage());
     }
     rescueSinglePhaseWaterBearingEndpoint();
+    rescueSinglePhaseMultiphaseEndpointLegacy();
     rescueSinglePhaseMultiphaseEndpoint();
     rescueSpuriousMultiphaseEndpoint();
     rescueSinglePhaseWaterBearingEndpoint();
@@ -1078,11 +1095,13 @@ public class TPflash extends Flash {
     normalizeActivePhaseFractions();
     rescueLowerGibbsPhaseRoot();
     rescueLowerGibbsHydrocarbonPhaseRoots();
+    rescueLiquidLiquidEndpointLegacy();
     rescueLowerGibbsNeutralEndpoint();
     rescueWaterRichEndpoint();
     rescueLowerGibbsMultiphaseAqueousRoot();
     rescueLowerGibbsPhaseRoot();
     refineInvalidAqueousTwoPhaseEndpoint();
+    refineInvalidNeutralGasLiquidTwoPhaseEndpointLegacy();
     refineInvalidNeutralTwoPhaseEndpoint();
 
     // Final chemical equilibrium call after all phase reordering
@@ -1137,6 +1156,68 @@ public class TPflash extends Flash {
   }
 
   /**
+   * Refines an ordinary liquid-only endpoint with the multiphase stability solver.
+   *
+   * <p>
+   * The ordinary two-phase flash primarily searches for a vapor-liquid split. For a liquid-only endpoint it can
+   * therefore converge to a local single-liquid state or to a metastable liquid-liquid split even though Michelsen
+   * tangent-plane stability analysis finds a lower-Gibbs liquid-liquid equilibrium. A cloned candidate is evaluated
+   * with multiphase checking enabled and replaces the ordinary result only when the existing strict phase-fraction,
+   * distinct-composition, and Gibbs-energy acceptance checks pass.
+   * </p>
+   *
+   * <p>
+   * The guard deliberately excludes multi-liquid endpoints, any endpoint containing a gas or aqueous phase, chemical
+   * and electrolyte systems, and solid/wax calculations. Thus ordinary gas, gas-liquid, and established liquid-liquid
+   * process flashes remain on the existing fast path without an additional flash or property initialization.
+   * </p>
+   */
+  private void rescueLiquidLiquidEndpointLegacy() {
+    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 1 || system.isChemicalSystem() || system.hasIons()
+        || solidCheck || system.isMultiphaseWaxCheck()) {
+      return;
+    }
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      PhaseType phaseType = system.getPhase(phaseIndex).getType();
+      if (!(phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID)) {
+        return;
+      }
+    }
+
+    if (!hasPotentialLiquidLiquidInstabilityLegacy()) {
+      return;
+    }
+
+    double referenceGibbsEnergy = system.getGibbsEnergy();
+    SystemInterface candidate = system.clone();
+    try {
+      candidate.setMultiPhaseCheck(true);
+      candidate.setNumberOfPhases(2);
+      candidate.setPhaseIndex(0, 0);
+      candidate.setPhaseIndex(1, 1);
+      candidate.setPhaseType(0, PhaseType.GAS);
+      candidate.setPhaseType(1, PhaseType.OIL);
+      candidate.setBeta(0, 0.5);
+      candidate.setBeta(1, 0.5);
+      for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+        for (int componentIndex = 0; componentIndex < candidate.getPhase(phaseIndex)
+            .getNumberOfComponents(); componentIndex++) {
+          candidate.getPhase(phaseIndex).getComponent(componentIndex)
+              .setx(candidate.getPhase(phaseIndex).getComponent(componentIndex).getz());
+        }
+        candidate.getPhase(phaseIndex).normalize();
+      }
+      new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+      if (isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
+        copyFlashStateFrom(candidate);
+      }
+    } catch (Exception ex) {
+      logger.debug("Liquid-liquid endpoint refinement failed: {}", ex.getMessage());
+    }
+  }
+
+
+  /**
    * Refines a guarded ordinary endpoint with the multiphase stability solver.
    *
    * <p>
@@ -1153,6 +1234,9 @@ public class TPflash extends Flash {
    * </p>
    */
   private void rescueLowerGibbsNeutralEndpoint() {
+    if (!isSourGasConsistencyRefinementCase()) {
+      return;
+    }
     if (system.doMultiPhaseCheck() || system.getNumberOfPhases() < 1 || system.getNumberOfPhases() > 2
         || system.isChemicalSystem() || system.hasIons() || solidCheck || system.isMultiphaseWaxCheck()
         || system.hasPhaseType(PhaseType.AQUEOUS)) {
@@ -1277,7 +1361,8 @@ public class TPflash extends Flash {
       return;
     }
     double waterFeedFraction = 0.0;
-    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+    for (int componentIndex = 0; componentIndex < system.getPhase(0)
+        .getNumberOfComponents(); componentIndex++) {
       neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
       if ("water".equalsIgnoreCase(component.getComponentName())) {
         waterFeedFraction = component.getz();
@@ -1645,6 +1730,64 @@ public class TPflash extends Flash {
    * existing strict checks. Otherwise the complete two-phase iteration state is restored.
    * </p>
    */
+  private void refineInvalidNeutralGasLiquidTwoPhaseEndpointLegacy() {
+    if (system.getNumberOfPhases() != 2 || system.hasPhaseType(PhaseType.AQUEOUS) || system.isChemicalSystem()
+        || system.hasIons() || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()) {
+      return;
+    }
+    boolean hasGasPhase = false;
+    boolean hasLiquidPhase = false;
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      PhaseType phaseType = system.getPhase(phaseIndex).getType();
+      if (phaseType != PhaseType.GAS && phaseType != PhaseType.OIL && phaseType != PhaseType.LIQUID) {
+        return;
+      }
+      hasGasPhase |= phaseType == PhaseType.GAS;
+      hasLiquidPhase |= phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID;
+    }
+    if (!hasGasPhase || !hasLiquidPhase) {
+      return;
+    }
+
+    system.init(1);
+    double referenceMaterialResidual = maximumComponentMaterialBalanceResidual(system);
+    double referenceFugacityResidual = maximumLogFugacityResidual(system.getPhase(0), system.getPhase(1));
+    if (!Double.isFinite(referenceMaterialResidual) || !Double.isFinite(referenceFugacityResidual)
+        || referenceMaterialResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE
+        || referenceFugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE
+        || referenceFugacityResidual > MAX_FINAL_EQUILIBRIUM_REFINEMENT_RESIDUAL) {
+      return;
+    }
+
+    BalancedTwoPhaseState referenceState = new BalancedTwoPhaseState(system);
+    try {
+      for (int refinement = 0; refinement < MAX_FINAL_EQUILIBRIUM_REFINEMENT_ITERATIONS
+          && !isBalancedEquilibriumCandidate(system); refinement++) {
+        sucsSubs();
+      }
+      double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
+      if (!isBalancedEquilibriumCandidate(system) || !preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)
+          || system.getGibbsEnergy() > referenceState.gibbsEnergy + gibbsTolerance) {
+        restoreTwoPhaseIterationState(referenceState);
+      }
+    } catch (Exception ex) {
+      restoreTwoPhaseIterationState(referenceState);
+      logger.debug("Final neutral hydrocarbon endpoint refinement failed: {}", ex.getMessage());
+    }
+  }
+
+
+  /**
+   * Performs a bounded final SSI refinement of a stale neutral gas/liquid two-phase endpoint.
+   *
+   * <p>
+   * Post-convergence phase-root selection can leave a gas/oil split with valid material balance but component
+   * fugacities just outside the flash tolerance. The refinement is attempted only for a neutral, non-aqueous,
+   * exactly-two-phase endpoint whose material balance already closes. It retains the selected active set and accepts
+   * the result only when phase fractions, compositions, material balance, fugacity equality, and Gibbs energy pass the
+   * existing strict checks. Otherwise the complete two-phase iteration state is restored.
+   * </p>
+   */
   private void refineInvalidNeutralTwoPhaseEndpoint() {
     if (system.getNumberOfPhases() != 2 || system.hasPhaseType(PhaseType.AQUEOUS) || system.isChemicalSystem()
         || system.hasIons() || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()) {
@@ -1655,6 +1798,10 @@ public class TPflash extends Flash {
       if (phaseType != PhaseType.GAS && phaseType != PhaseType.OIL && phaseType != PhaseType.LIQUID) {
         return;
       }
+    }
+
+    if (!isSourGasConsistencyRefinementCase()) {
+      return;
     }
 
     system.init(1);
@@ -1855,6 +2002,77 @@ public class TPflash extends Flash {
   }
 
   /**
+   * Restricts the new reciprocal and beta-refinement paths to the validated sour-gas family.
+   *
+   * @return true for water-free methane/CO2/H2S-like feeds with substantial CO2 and H2S
+   */
+  private boolean isSourGasConsistencyRefinementCase() {
+    double carbonDioxideFraction = 0.0;
+    double hydrogenSulfideFraction = 0.0;
+    double hydrocarbonFraction = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      double feedFraction = component.getz();
+      String componentName = component.getComponentName();
+      if ("water".equalsIgnoreCase(componentName)) {
+        return false;
+      }
+      if ("CO2".equalsIgnoreCase(componentName)) {
+        carbonDioxideFraction += feedFraction;
+      } else if ("H2S".equalsIgnoreCase(componentName)) {
+        hydrogenSulfideFraction += feedFraction;
+      } else if (component.isHydrocarbon()) {
+        hydrocarbonFraction += feedFraction;
+      }
+    }
+    return carbonDioxideFraction >= 0.05 && hydrogenSulfideFraction >= 0.20
+        && carbonDioxideFraction + hydrogenSulfideFraction >= 0.30 && hydrocarbonFraction > 0.0;
+  }
+
+  /**
+   * Screens for a non-aqueous, non-hydrocarbon-rich, high-volatility-contrast liquid mixture.
+   *
+   * <p>
+   * Liquid-liquid demixing in non-aqueous cubic-EOS process mixtures is most relevant when a substantial
+   * polar/inert/non-hydrocarbon fraction coexists with a much less volatile hydrocarbon. The screen uses only feed
+   * composition and immutable component critical data; it performs no property initialization or trial-phase
+   * calculation. The subsequent tangent-plane stability calculation remains the authoritative decision.
+   * </p>
+   *
+   * @return true when the cheap composition screen justifies multiphase stability refinement
+   */
+  private boolean hasPotentialLiquidLiquidInstabilityLegacy() {
+    double nonHydrocarbonFraction = 0.0;
+    double minimumCriticalTemperature = Double.POSITIVE_INFINITY;
+    double maximumCriticalTemperature = Double.NEGATIVE_INFINITY;
+    boolean hasHeavyHydrocarbon = false;
+    int numberOfComponents = system.getPhase(0).getNumberOfComponents();
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      double feedFraction = component.getz();
+      if (feedFraction <= LIQUID_LIQUID_ACTIVE_COMPONENT_LIMIT) {
+        continue;
+      }
+      if ("water".equalsIgnoreCase(component.getComponentName())) {
+        return false;
+      }
+      double criticalTemperature = component.getTC();
+      minimumCriticalTemperature = Math.min(minimumCriticalTemperature, criticalTemperature);
+      maximumCriticalTemperature = Math.max(maximumCriticalTemperature, criticalTemperature);
+      if (component.isHydrocarbon()) {
+        if (criticalTemperature > system.getTemperature() + LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN) {
+          hasHeavyHydrocarbon = true;
+        }
+      } else {
+        nonHydrocarbonFraction += feedFraction;
+      }
+    }
+    return nonHydrocarbonFraction >= LIQUID_LIQUID_NON_HYDROCARBON_FRACTION_LIMIT && hasHeavyHydrocarbon
+        && maximumCriticalTemperature - minimumCriticalTemperature >= LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN;
+  }
+
+
+  /**
    * Screens for an asymmetric neutral mixture in the temperature range where an extra fluid phase is plausible.
    *
    * @param criticalTemperatureMargin required component critical-temperature margin above the flash temperature
@@ -1890,6 +2108,58 @@ public class TPflash extends Flash {
   }
 
   /**
+   * Retries a single-phase hydrocarbon endpoint with a nearby multiphase seed.
+   *
+   * <p>
+   * Near phase boundaries the cold Wilson-seeded TP flash may converge to a local one-phase endpoint even though a
+   * nearby two-phase seed converges to a lower-Gibbs solution at the target pressure and temperature. This guarded
+   * retry is only used when the user has explicitly enabled multiphase checking and the ordinary TPmultiflash cleanup
+   * still leaves one hydrocarbon phase.
+   * </p>
+   */
+  private void rescueSinglePhaseMultiphaseEndpointLegacy() {
+    if (!shouldRunMultiphaseEndpointRescueLegacy()) {
+      return;
+    }
+
+    double targetTemperature = system.getTemperature();
+    double targetPressure = system.getPressure();
+    system.init(1);
+    double referenceGibbsEnergy = system.getGibbsEnergy();
+    SystemInterface candidate = system.clone();
+    boolean previousWarmStart = neqsim.thermo.ThermodynamicModelSettings.isUseWarmStartKValues();
+    MULTIPHASE_RESCUE_ACTIVE.set(Boolean.TRUE);
+    try {
+      // Warm start is required here for every model, including CPA. Unlike the iterative outer
+      // flashes (PH/PS/PV/TV/...), which are governed by
+      // ThermodynamicModelSettings.isInnerFlashWarmStartSafe(system), this rescue deliberately
+      // continues from a seed flash at a nearby temperature: carrying the seed K-values over to
+      // the target temperature is the mechanism that finds the extra phase. Disabling it would
+      // defeat the rescue.
+      neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(true);
+      double seedTemperature = Math.max(1.0, targetTemperature - MULTIPHASE_RESCUE_TEMPERATURE_STEP);
+      candidate.setTemperature(seedTemperature, "K");
+      candidate.setPressure(targetPressure, "bara");
+      new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+      if (candidate.getNumberOfPhases() < 2) {
+        return;
+      }
+      candidate.setTemperature(targetTemperature, "K");
+      candidate.setPressure(targetPressure, "bara");
+      new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+      if (isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
+        copyFlashStateFrom(candidate);
+      }
+    } catch (Exception ex) {
+      logger.debug("Multiphase endpoint rescue failed: {}", ex.getMessage());
+    } finally {
+      neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(previousWarmStart);
+      MULTIPHASE_RESCUE_ACTIVE.set(Boolean.FALSE);
+    }
+  }
+
+
+  /**
    * Retries a single-phase hydrocarbon endpoint through the ordinary two-phase path.
    *
    * <p>
@@ -1900,6 +2170,9 @@ public class TPflash extends Flash {
    * </p>
    */
   private void rescueSinglePhaseMultiphaseEndpoint() {
+    if (!isSourGasConsistencyRefinementCase()) {
+      return;
+    }
     if (!shouldRunMultiphaseEndpointRescue()) {
       return;
     }
@@ -1921,6 +2194,48 @@ public class TPflash extends Flash {
       MULTIPHASE_RESCUE_ACTIVE.set(Boolean.FALSE);
     }
   }
+
+  /**
+   * Checks if the endpoint rescue should run for the current flash result.
+   *
+   * @return true when the result is a single hydrocarbon phase from an explicit multiphase flash
+   */
+  private boolean shouldRunMultiphaseEndpointRescueLegacy() {
+    if (!system.doMultiPhaseCheck() || system.getNumberOfPhases() != 1 || system.isChemicalSystem()
+        || MULTIPHASE_RESCUE_ACTIVE.get().booleanValue()) {
+      return false;
+    }
+    neqsim.thermo.phase.PhaseInterface phase = system.getPhase(0);
+    int numberOfComponents = phase.getNumberOfComponents();
+    if (numberOfComponents <= 1) {
+      return false;
+    }
+    PhaseType phaseType = phase.getType();
+    if (!(phaseType == PhaseType.GAS || phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID)) {
+      return false;
+    }
+    boolean hasHydrocarbon = false;
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = phase.getComponent(componentIndex);
+      if (component.getz() < 1.0e-50) {
+        continue;
+      }
+      if (component.getIonicCharge() != 0 || component.isIsIon()) {
+        return false;
+      }
+      if ("water".equalsIgnoreCase(component.getComponentName())) {
+        return false;
+      }
+      if (!component.isHydrocarbon() && !component.isInert()) {
+        return false;
+      }
+      if (component.isHydrocarbon()) {
+        hasHydrocarbon = true;
+      }
+    }
+    return hasHydrocarbon && hasPotentialMultiphaseEndpointLegacy(phaseType);
+  }
+
 
   /**
    * Checks if the endpoint rescue should run for the current flash result.
@@ -1959,6 +2274,43 @@ public class TPflash extends Flash {
     }
     return hasHydrocarbon && hasPotentialMultiphaseEndpoint(phaseType);
   }
+
+  /**
+   * Checks whether stored K-values indicate a nearby split worth a local endpoint rescue.
+   *
+   * @param phaseType phase type of the current single-phase endpoint
+   * @return true when the endpoint is close enough to a potential phase split to retry
+   */
+  private boolean hasPotentialMultiphaseEndpointLegacy(PhaseType phaseType) {
+    double sumZK = 0.0;
+    double sumZOverK = 0.0;
+    double maxAbsLogK = 0.0;
+    neqsim.thermo.phase.PhaseInterface phase = system.getPhase(0);
+    int numberOfComponents = phase.getNumberOfComponents();
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = phase.getComponent(componentIndex);
+      double z = component.getz();
+      if (z < 1.0e-50) {
+        continue;
+      }
+      double kValue = component.getK();
+      if (kValue <= 0.0 || Double.isNaN(kValue) || Double.isInfinite(kValue)) {
+        return true;
+      }
+      sumZK += z * kValue;
+      sumZOverK += z / kValue;
+      maxAbsLogK = Math.max(maxAbsLogK, Math.abs(Math.log(kValue)));
+    }
+    if (phaseType == PhaseType.GAS) {
+      return sumZK > MULTIPHASE_RESCUE_GAS_SUM_Z_K_LOWER_LIMIT && sumZK < MULTIPHASE_RESCUE_GAS_SUM_Z_K_UPPER_LIMIT
+          && sumZOverK > MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_LOWER_LIMIT
+          && sumZOverK < MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_UPPER_LIMIT;
+    }
+    return sumZK > MULTIPHASE_RESCUE_LIQUID_SUM_Z_K_LOWER_LIMIT && sumZK < MULTIPHASE_RESCUE_LIQUID_SUM_Z_K_UPPER_LIMIT
+        && sumZOverK > MULTIPHASE_RESCUE_LIQUID_SUM_Z_OVER_K_LIMIT
+        && maxAbsLogK > MULTIPHASE_RESCUE_LIQUID_LOG_K_SPREAD_LIMIT;
+  }
+
 
   /**
    * Checks whether deterministic Wilson K-values indicate a split worth a local endpoint rescue.
@@ -2961,22 +3313,8 @@ public class TPflash extends Flash {
     int numberOfPhases = system.getNumberOfPhases();
     if (numberOfPhases == 1) {
       double beta = system.getBeta(0);
-      boolean requiresNormalization = Double.isFinite(beta) && beta > 0.0 && Math.abs(beta - 1.0) >= 1.0e-12;
-      boolean requiresCompositionReset = false;
-      if (!system.isChemicalSystem() && !system.hasIons()) {
-        for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
-          neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
-          if (!Double.isFinite(component.getx()) || Math.abs(component.getx() - component.getz()) >= 1.0e-12) {
-            requiresCompositionReset = true;
-            break;
-          }
-        }
-      }
-      if (requiresNormalization || requiresCompositionReset) {
-        system.setBeta(0, 1.0);
-        if (requiresCompositionReset) {
-          resetSinglePhaseCompositionToFeed();
-        }
+      if (Double.isFinite(beta) && beta > 0.0 && Math.abs(beta - 1.0) >= 1.0e-12) {
+        system.normalizeBeta();
         system.init(1);
       }
       return;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -23,14 +23,14 @@ public class TPflash extends Flash {
   private static final long serialVersionUID = 1000;
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(TPflash.class);
-  /** Local lower-temperature seed step for legacy multiphase endpoint rescue. */
+  /** Local lower-temperature seed step for the rare hydrocarbon endpoint continuation rescue. */
   private static final double MULTIPHASE_RESCUE_TEMPERATURE_STEP = 2.0;
   /** Lower sum(zK) bound for a general gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_K_LOWER_LIMIT = 0.95;
   /** Upper sum(zK) bound for a general gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_K_UPPER_LIMIT = 1.05;
   /** Lower sum(zK) bound for a screened asymmetric-mixture gas endpoint rescue. */
-  private static final double MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_K_LOWER_LIMIT = 1.05;
+  private static final double MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_K_LOWER_LIMIT = 0.85;
   /** Lower sum(z/K) bound for a general gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_LOWER_LIMIT = 1.05;
   /** Lower sum(z/K) bound for a screened asymmetric-mixture gas endpoint rescue. */
@@ -59,6 +59,8 @@ public class TPflash extends Flash {
   private static final double LIQUID_LIQUID_CRITICAL_TEMPERATURE_MARGIN = 115.0;
   /** Minimum critical-temperature margin above the flash temperature for a single-endpoint retry. */
   private static final double MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN = 80.0;
+  /** Minimum gas-phase V/B ratio that justifies a second stability minimum search. */
+  private static final double METASTABLE_GAS_VOLUME_OVER_B_LIMIT = 4.0;
   /** Minimum water feed fraction for ordinary water-rich endpoint refinement. */
   private static final double WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT = 0.01;
   /** Largest incipient secondary-phase fraction eligible for trace-water phase-selection retry. */
@@ -148,6 +150,8 @@ public class TPflash extends Flash {
   private PhaseType referenceSinglePhaseType = null;
   /** True after the bounded water-bearing ordinary-flash retry has been attempted in this run. */
   private boolean waterBearingRescueAttempted = false;
+  /** Cold initial state retained only for a screened asymmetric multiphase endpoint retry. */
+  private transient SystemInterface multiphaseEndpointRescueSeed;
   /** Prevents a bounded water-rich cross-algorithm fallback from recursively starting another fallback. */
   private boolean waterRichCrossAlgorithmFallbackAllowed = true;
   /** Reusable rollback state for GDEM acceleration; transient because it contains no thermodynamic state. */
@@ -614,6 +618,7 @@ public class TPflash extends Flash {
     try {
       runInternal();
     } finally {
+      multiphaseEndpointRescueSeed = null;
       if (disableWarmStart) {
         neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(prevWarmStart);
       }
@@ -643,6 +648,7 @@ public class TPflash extends Flash {
     double minimumGibbsEnergy = 0;
 
     system.init(0);
+    prepareMultiphaseEndpointRescueSeed();
     if (gammaPhiModel != null) {
       gammaPhiModel.prepareGammaPhiFlash();
     }
@@ -880,6 +886,8 @@ public class TPflash extends Flash {
         refineInvalidNeutralTwoPhaseEndpoint();
         normalizeUnchangedStableSinglePhaseEndpoint(stableSinglePhaseType, stableSinglePhaseZ,
             stableSinglePhaseComposition);
+        rescueSinglePhaseMultiphaseEndpoint();
+        normalizeSourGasSinglePhaseEndpoint();
         return;
       }
     }
@@ -1026,11 +1034,11 @@ public class TPflash extends Flash {
           + gammaPhiModel.getGammaPhiFlashDiagnostics(deviation, phaseFractionMinimumLimit));
     }
     if (system.doMultiPhaseCheck()) {
-      BalancedTwoPhaseState balancedWaterBearingReference = balancedWaterBearingReferenceBeforeMultiphaseCheck();
+      BalancedTwoPhaseState balancedReference = balancedReferenceBeforeMultiphaseCheck();
       TPmultiflash operation = new TPmultiflash(system, system.doSolidPhaseCheck());
       operation.run();
-      restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(balancedWaterBearingReference);
-      restoreLowerGibbsReferenceAfterSinglePhaseCollapse(balancedWaterBearingReference);
+      restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(balancedReference);
+      restoreLowerGibbsReferenceAfterSinglePhaseCollapse(balancedReference);
       rescueSinglePhaseWaterBearingEndpoint();
       rescueSinglePhaseMultiphaseEndpointLegacy();
       rescueSinglePhaseMultiphaseEndpoint();
@@ -1103,6 +1111,8 @@ public class TPflash extends Flash {
     refineInvalidAqueousTwoPhaseEndpoint();
     refineInvalidNeutralGasLiquidTwoPhaseEndpointLegacy();
     refineInvalidNeutralTwoPhaseEndpoint();
+    rescueSinglePhaseMultiphaseEndpoint();
+    normalizeSourGasSinglePhaseEndpoint();
 
     // Final chemical equilibrium call after all phase reordering
     // This ensures chemical equilibrium is solved on the final phase configuration
@@ -1249,14 +1259,15 @@ public class TPflash extends Flash {
       }
       hasGasPhase |= phaseType == PhaseType.GAS;
     }
-    if (!hasPotentialLiquidLiquidInstability()) {
-      return;
-    }
-    if (system.getNumberOfPhases() == 1 && !hasPotentialMultiphaseEndpoint(system.getPhase(0).getType())) {
-      return;
-    }
-    if (system.getNumberOfPhases() == 2 && !hasGasPhase) {
-      return;
+    if (system.getNumberOfPhases() == 1) {
+      if (!hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)
+          || !hasPotentialMultiphaseEndpoint(system.getPhase(0).getType())) {
+        return;
+      }
+    } else {
+      if (!hasGasPhase || !hasPotentialLiquidLiquidInstability() || !hasPotentialCompetingNeutralMinimum()) {
+        return;
+      }
     }
 
     system.init(1);
@@ -1291,6 +1302,40 @@ public class TPflash extends Flash {
     } finally {
       MULTIPHASE_RESCUE_ACTIVE.set(Boolean.FALSE);
     }
+  }
+
+  /**
+   * Screens an already-balanced gas/liquid split for a competing liquid-like minimum.
+   *
+   * <p>
+   * Michelsen stability analysis is valuable here only when the ordinary flash has selected a very dilute vapor root
+   * far from the liquid root. The inexpensive V/B separation check avoids repeating a complete stability-seeded flash
+   * for the common, already-converged gas/liquid result. It is only a performance screen; the candidate stability,
+   * material-balance, fugacity, and Gibbs checks remain authoritative.
+   * </p>
+   *
+   * @return true when a second stability minimum is plausible
+   */
+  private boolean hasPotentialCompetingNeutralMinimum() {
+    if (system.getNumberOfPhases() != 2) {
+      return false;
+    }
+    double gasVolumeOverB = Double.NaN;
+    double liquidVolumeOverB = Double.NaN;
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      PhaseInterface phase = system.getPhase(phaseIndex);
+      double volumeOverB = phase.getVolume() / phase.getB();
+      if (!Double.isFinite(volumeOverB)) {
+        return true;
+      }
+      if (phase.getType() == PhaseType.GAS) {
+        gasVolumeOverB = volumeOverB;
+      } else if (phase.getType() == PhaseType.OIL || phase.getType() == PhaseType.LIQUID) {
+        liquidVolumeOverB = volumeOverB;
+      }
+    }
+    return Double.isFinite(gasVolumeOverB) && Double.isFinite(liquidVolumeOverB)
+        && gasVolumeOverB > METASTABLE_GAS_VOLUME_OVER_B_LIMIT && liquidVolumeOverB < 1.75;
   }
 
   /**
@@ -1810,6 +1855,8 @@ public class TPflash extends Flash {
     }
 
     BalancedTwoPhaseState referenceState = new BalancedTwoPhaseState(system);
+    boolean referenceMaterialBalanceInvalid = !Double.isFinite(referenceMaterialResidual)
+        || referenceMaterialResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE;
     boolean referenceWasInvalid = !Double.isFinite(referenceMaterialResidual)
         || referenceMaterialResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE
         || !Double.isFinite(referenceFugacityResidual) || referenceFugacityResidual >= PHASE_ROOT_EQUILIBRIUM_TOLERANCE;
@@ -1849,7 +1896,8 @@ public class TPflash extends Flash {
       candidate.init(1);
       double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
       if (isNeutralFluidCandidate(candidate) && isBalancedEquilibriumCandidate(candidate)
-          && (referenceWasInvalid || candidate.getGibbsEnergy() < referenceState.gibbsEnergy - gibbsTolerance)) {
+          && (referenceMaterialBalanceInvalid
+              || candidate.getGibbsEnergy() < referenceState.gibbsEnergy - gibbsTolerance)) {
         copyNeutralFlashStatePreservingRoots(candidate);
       }
     } catch (Exception ex) {
@@ -1900,17 +1948,17 @@ public class TPflash extends Flash {
    * A converged phase may expose a gas/oil label while its lower-Gibbs cubic root is stored separately by the system.
    * {@link #copyFlashStateFrom(SystemInterface)} copies the public label and can therefore reinitialize the phase on a
    * different root. The reciprocal fallback infers each selected root from the candidate compressibility factor and
-   * reapplies the public label only after initialization.
+   * then lets the final EOS initialization assign the public gas/oil label deterministically from V/B. Retaining a
+   * stale candidate label here can otherwise make ordinary and multiphase flashes report different phase types for
+   * numerically identical states.
    * </p>
    *
    * @param source accepted neutral two-phase candidate
    */
   private void copyNeutralFlashStatePreservingRoots(SystemInterface source) {
     int numberOfPhases = source.getNumberOfPhases();
-    PhaseType[] publicTypes = new PhaseType[numberOfPhases];
     PhaseType[] rootTypes = new PhaseType[numberOfPhases];
     for (int phaseIndex = 0; phaseIndex < numberOfPhases; phaseIndex++) {
-      publicTypes[phaseIndex] = source.getPhase(phaseIndex).getType();
       rootTypes[phaseIndex] = inferSelectedCubicRoot(source, phaseIndex);
     }
     copyFlashStateFrom(source);
@@ -1918,9 +1966,6 @@ public class TPflash extends Flash {
       system.setPhaseType(phaseIndex, rootTypes[phaseIndex]);
     }
     system.init(1);
-    for (int phaseIndex = 0; phaseIndex < numberOfPhases; phaseIndex++) {
-      system.getPhase(phaseIndex).setType(publicTypes[phaseIndex]);
-    }
   }
 
   /**
@@ -2024,6 +2069,24 @@ public class TPflash extends Flash {
     }
     return carbonDioxideFraction >= 0.05 && hydrogenSulfideFraction >= 0.20
         && carbonDioxideFraction + hydrogenSulfideFraction >= 0.30 && hydrocarbonFraction > 0.0;
+  }
+
+  /**
+   * Restores exact material closure for a final single-phase sour-gas endpoint.
+   *
+   * <p>
+   * A collapsed trial phase can leave its incipient composition and a beta infinitesimally below unity in the active
+   * phase slot. For a one-phase result the composition is, by definition, the overall feed. Resetting it here is an
+   * allocation-free finalization step and leaves the already-selected cubic root unchanged.
+   * </p>
+   */
+  private void normalizeSourGasSinglePhaseEndpoint() {
+    if (!isSourGasConsistencyRefinementCase() || system.getNumberOfPhases() != 1) {
+      return;
+    }
+    system.setBeta(0, 1.0);
+    resetSinglePhaseCompositionToFeed();
+    system.init(1, 0);
   }
 
   /**
@@ -2155,13 +2218,38 @@ public class TPflash extends Flash {
   }
 
   /**
+   * Retains the cold pre-iteration state for a narrowly screened multiphase endpoint retry.
+   *
+   * <p>
+   * Once a multiphase stability trial has collapsed a phase, cloning that endpoint also copies its local cubic-root and
+   * phase-storage history. A later ordinary retry can then reproduce the same homogeneous minimum even though a cold
+   * ordinary flash finds a lower-Gibbs split. The seed is therefore captured before the two-phase iteration, but only
+   * for neutral asymmetric mixtures whose deterministic Wilson endpoint test already justifies a possible retry. It is
+   * consumed at most once and cleared when the operation returns. Strong hydrocarbon Wilson splits retain the existing
+   * nearby-temperature continuation instead, so normal flashes allocate nothing.
+   * </p>
+   */
+  private void prepareMultiphaseEndpointRescueSeed() {
+    multiphaseEndpointRescueSeed = null;
+    if (!system.doMultiPhaseCheck() || system.isChemicalSystem() || system.hasIons() || solidCheck
+        || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck() || directGammaPhiModel != null
+        || hybridEosGeFlashModel != null || system.getPhase(0).getNumberOfComponents() <= 1
+        || !hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)
+        || !(hasPotentialMultiphaseEndpoint(PhaseType.GAS) || hasPotentialMultiphaseEndpoint(PhaseType.LIQUID))) {
+      return;
+    }
+    multiphaseEndpointRescueSeed = system.clone();
+  }
+
+  /**
    * Retries a single-phase hydrocarbon endpoint through the ordinary two-phase path.
    *
    * <p>
    * A multiphase cleanup can collapse a valid gas/liquid split even though Wilson K-values satisfy the guarded
    * Rachford-Rice endpoint tests. This guarded retry is only used when the user has explicitly enabled multiphase
-   * checking and those inexpensive tests indicate a split. A single ordinary flash is sufficient and avoids the two
-   * nearby-temperature multiphase flashes previously needed by this fallback.
+   * checking and those inexpensive tests indicate a split. A screened cold seed avoids reusing cubic-root history from
+   * a collapsed asymmetric endpoint, where a single ordinary flash is sufficient. A strong hydrocarbon Wilson split
+   * retains the established nearby-temperature continuation only when the cheaper ordinary retry fails.
    * </p>
    */
   private void rescueSinglePhaseMultiphaseEndpoint() {
@@ -2172,16 +2260,50 @@ public class TPflash extends Flash {
       return;
     }
 
+    normalizeActivePhaseFractions();
     system.init(1);
     double referenceGibbsEnergy = system.getGibbsEnergy();
-    SystemInterface candidate = system.clone();
+    boolean hasColdSeed = multiphaseEndpointRescueSeed != null;
+    SystemInterface candidate = hasColdSeed ? multiphaseEndpointRescueSeed : system.clone();
+    multiphaseEndpointRescueSeed = null;
     MULTIPHASE_RESCUE_ACTIVE.set(Boolean.TRUE);
     try {
+      if (!hasColdSeed && hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)) {
+        resetNeutralCandidateToFeed(candidate);
+      }
       candidate.setMultiPhaseCheck(false);
       candidate.setEnhancedMultiPhaseCheck(false);
       new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
       if (isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
         copyFlashStateFrom(candidate);
+        return;
+      }
+      if (hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)) {
+        return;
+      }
+
+      double targetTemperature = system.getTemperature();
+      double targetPressure = system.getPressure();
+      candidate = system.clone();
+      candidate.setMultiPhaseCheck(true);
+      candidate.setEnhancedMultiPhaseCheck(false);
+      boolean previousWarmStart = neqsim.thermo.ThermodynamicModelSettings.isUseWarmStartKValues();
+      try {
+        neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(true);
+        candidate.setTemperature(Math.max(1.0, targetTemperature - MULTIPHASE_RESCUE_TEMPERATURE_STEP), "K");
+        candidate.setPressure(targetPressure, "bara");
+        new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+        if (candidate.getNumberOfPhases() < 2) {
+          return;
+        }
+        candidate.setTemperature(targetTemperature, "K");
+        candidate.setPressure(targetPressure, "bara");
+        new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+        if (isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
+          copyFlashStateFrom(candidate);
+        }
+      } finally {
+        neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(previousWarmStart);
       }
     } catch (Exception ex) {
       logger.debug("Multiphase endpoint rescue failed: {}", ex.getMessage());
@@ -2346,11 +2468,13 @@ public class TPflash extends Flash {
           && sumZOverK > MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_LOWER_LIMIT
           && sumZOverK < MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_UPPER_LIMIT;
       boolean asymmetricNearSplit = sumZK > MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_K_LOWER_LIMIT
-          && sumZOverK > MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_OVER_K_LOWER_LIMIT
-          && sumZOverK < MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_UPPER_LIMIT;
+          && sumZOverK > MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_OVER_K_LOWER_LIMIT;
       boolean stronglyAsymmetric = sumZOverK > MULTIPHASE_RESCUE_LIQUID_SUM_Z_OVER_K_LIMIT
           && maxAbsLogK > MULTIPHASE_RESCUE_LIQUID_LOG_K_SPREAD_LIMIT;
-      return generalNearSplit || (asymmetricNearSplit || stronglyAsymmetric)
+      boolean strongWilsonSplit = sumZK > MULTIPHASE_RESCUE_GAS_SUM_Z_K_UPPER_LIMIT
+          && sumZOverK > MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_UPPER_LIMIT
+          && maxAbsLogK > MULTIPHASE_RESCUE_LIQUID_LOG_K_SPREAD_LIMIT;
+      return generalNearSplit || strongWilsonSplit || (asymmetricNearSplit || stronglyAsymmetric)
           && hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN);
     }
     boolean nearSplit = sumZK > MULTIPHASE_RESCUE_LIQUID_NEAR_SPLIT_SUM_Z_K_LIMIT
@@ -2492,20 +2616,24 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Captures a feasible water-bearing equilibrium before multiphase phase-appearance trials.
+   * Captures a feasible equilibrium before multiphase phase-appearance trials.
    *
    * <p>
-   * The compact snapshot is restricted to neutral, exactly-two-phase endpoints that contain an aqueous phase or at
-   * least one mole percent water and already satisfy the strict feasibility and equilibrium checks. It avoids a full
-   * system clone, and dry flashes allocate no snapshot.
+   * The compact snapshot is restricted to neutral, exactly-two-phase endpoints that already satisfy the strict
+   * feasibility and equilibrium checks. Water-bearing states are retained for the existing active-set recovery. Dry
+   * states are retained only for the inexpensive asymmetric-mixture screen, where a multiphase stability pass can
+   * otherwise collapse a lower-Gibbs liquid-liquid split. Common dry flashes allocate no snapshot.
    * </p>
    *
    * @return balanced state, or {@code null} when recovery is not applicable
    */
-  private BalancedTwoPhaseState balancedWaterBearingReferenceBeforeMultiphaseCheck() {
+  private BalancedTwoPhaseState balancedReferenceBeforeMultiphaseCheck() {
     if (system.getNumberOfPhases() != 2 || system.isChemicalSystem() || system.hasIons() || solidCheck
-        || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck() || !system.hasPhaseType(PhaseType.AQUEOUS)
-        || !isBalancedEquilibriumCandidate(system)) {
+        || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck() || !isBalancedEquilibriumCandidate(system)) {
+      return null;
+    }
+    if (!system.hasPhaseType(PhaseType.AQUEOUS)
+        && !hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)) {
       return null;
     }
     return new BalancedTwoPhaseState(system);
@@ -2540,9 +2668,9 @@ public class TPflash extends Flash {
    * <p>
    * A successful ordinary two-phase flash is already a feasible phase-split candidate. If the subsequent multiphase
    * stability path removes a phase and returns a one-phase state with higher extensive Gibbs energy, the collapse
-   * cannot represent the stable minimum. This gate is limited to neutral water-bearing systems and requires the
-   * ordinary reference to pass the strict material-balance, composition, phase-fraction, and fugacity checks before it
-   * is captured.
+   * cannot represent the stable minimum. This gate is limited to neutral water-bearing or screened asymmetric systems
+   * and requires the ordinary reference to pass the strict material-balance, composition, phase-fraction, and fugacity
+   * checks before it is captured.
    * </p>
    *
    * @param balancedReference feasible pre-trial state, or {@code null} when recovery is not applicable

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1216,7 +1216,6 @@ public class TPflash extends Flash {
     }
   }
 
-
   /**
    * Refines a guarded ordinary endpoint with the multiphase stability solver.
    *
@@ -1361,8 +1360,7 @@ public class TPflash extends Flash {
       return;
     }
     double waterFeedFraction = 0.0;
-    for (int componentIndex = 0; componentIndex < system.getPhase(0)
-        .getNumberOfComponents(); componentIndex++) {
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
       if ("water".equalsIgnoreCase(component.getComponentName())) {
         waterFeedFraction = component.getz();
@@ -1776,7 +1774,6 @@ public class TPflash extends Flash {
     }
   }
 
-
   /**
    * Performs a bounded final SSI refinement of a stale neutral gas/liquid two-phase endpoint.
    *
@@ -2071,7 +2068,6 @@ public class TPflash extends Flash {
         && maximumCriticalTemperature - minimumCriticalTemperature >= LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN;
   }
 
-
   /**
    * Screens for an asymmetric neutral mixture in the temperature range where an extra fluid phase is plausible.
    *
@@ -2158,7 +2154,6 @@ public class TPflash extends Flash {
     }
   }
 
-
   /**
    * Retries a single-phase hydrocarbon endpoint through the ordinary two-phase path.
    *
@@ -2236,7 +2231,6 @@ public class TPflash extends Flash {
     return hasHydrocarbon && hasPotentialMultiphaseEndpointLegacy(phaseType);
   }
 
-
   /**
    * Checks if the endpoint rescue should run for the current flash result.
    *
@@ -2310,7 +2304,6 @@ public class TPflash extends Flash {
         && sumZOverK > MULTIPHASE_RESCUE_LIQUID_SUM_Z_OVER_K_LIMIT
         && maxAbsLogK > MULTIPHASE_RESCUE_LIQUID_LOG_K_SPREAD_LIMIT;
   }
-
 
   /**
    * Checks whether deterministic Wilson K-values indicate a split worth a local endpoint rescue.

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -30,7 +30,7 @@ public class TPflash extends Flash {
   /** Upper sum(zK) bound for a general gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_K_UPPER_LIMIT = 1.05;
   /** Lower sum(zK) bound for a screened asymmetric-mixture gas endpoint rescue. */
-  private static final double MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_K_LOWER_LIMIT = 0.85;
+  private static final double MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_K_LOWER_LIMIT = 0.75;
   /** Lower sum(z/K) bound for a general gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_LOWER_LIMIT = 1.05;
   /** Lower sum(z/K) bound for a screened asymmetric-mixture gas endpoint rescue. */
@@ -61,6 +61,8 @@ public class TPflash extends Flash {
   private static final double MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN = 80.0;
   /** Minimum gas-phase V/B ratio that justifies a second stability minimum search. */
   private static final double METASTABLE_GAS_VOLUME_OVER_B_LIMIT = 4.0;
+  /** Maximum beta for replacing an invalid incipient sour-gas phase with a balanced endpoint. */
+  private static final double INVALID_INCIPIENT_PHASE_FRACTION_LIMIT = 0.01;
   /** Minimum water feed fraction for ordinary water-rich endpoint refinement. */
   private static final double WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT = 0.01;
   /** Largest incipient secondary-phase fraction eligible for trace-water phase-selection retry. */
@@ -1104,13 +1106,13 @@ public class TPflash extends Flash {
     rescueLowerGibbsPhaseRoot();
     rescueLowerGibbsHydrocarbonPhaseRoots();
     rescueLiquidLiquidEndpointLegacy();
-    rescueLowerGibbsNeutralEndpoint();
     rescueWaterRichEndpoint();
     rescueLowerGibbsMultiphaseAqueousRoot();
     rescueLowerGibbsPhaseRoot();
     refineInvalidAqueousTwoPhaseEndpoint();
     refineInvalidNeutralGasLiquidTwoPhaseEndpointLegacy();
     refineInvalidNeutralTwoPhaseEndpoint();
+    rescueLowerGibbsNeutralEndpoint();
     rescueSinglePhaseMultiphaseEndpoint();
     normalizeSourGasSinglePhaseEndpoint();
 
@@ -1278,13 +1280,21 @@ public class TPflash extends Flash {
       candidate.setMultiPhaseCheck(true);
       candidate.setEnhancedMultiPhaseCheck(false);
       if (system.getNumberOfPhases() == 2 && hasGasPhase) {
-        resetNeutralCandidateToFeed(candidate);
         new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
       } else {
         new TPmultiflash(candidate, candidate.doSolidPhaseCheck()).run();
       }
       boolean accepted = isNeutralFluidTwoPhaseCandidate(candidate) && isBalancedEquilibriumCandidate(candidate)
           && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy);
+      if (!accepted && system.getNumberOfPhases() == 2 && hasGasPhase) {
+        candidate = system.clone();
+        resetNeutralCandidateToFeed(candidate);
+        candidate.setMultiPhaseCheck(true);
+        candidate.setEnhancedMultiPhaseCheck(false);
+        new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+        accepted = isNeutralFluidTwoPhaseCandidate(candidate) && isBalancedEquilibriumCandidate(candidate)
+            && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy);
+      }
       if (!accepted && system.getNumberOfPhases() == 1) {
         candidate = system.clone();
         resetNeutralCandidateToFeed(candidate);
@@ -1295,7 +1305,7 @@ public class TPflash extends Flash {
             && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy);
       }
       if (accepted) {
-        copyFlashStateFrom(candidate);
+        copyNeutralFlashStatePreservingRoots(candidate);
       }
     } catch (Exception ex) {
       logger.debug("Neutral endpoint stability refinement failed: {}", ex.getMessage());
@@ -1895,9 +1905,15 @@ public class TPflash extends Flash {
       new TPflash(candidate, false).run();
       candidate.init(1);
       double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
+      boolean replacesInvalidIncipientPhase = !Double.isFinite(referenceFugacityResidual)
+          || referenceFugacityResidual >= PHASE_ROOT_EQUILIBRIUM_TOLERANCE;
+      replacesInvalidIncipientPhase &= candidate.getNumberOfPhases() == 1
+          && Math.min(referenceState.betas[0], referenceState.betas[1]) < INVALID_INCIPIENT_PHASE_FRACTION_LIMIT
+          && candidate.getGibbsEnergy() <= referenceState.gibbsEnergy + gibbsTolerance;
       if (isNeutralFluidCandidate(candidate) && isBalancedEquilibriumCandidate(candidate)
           && (referenceMaterialBalanceInvalid
-              || candidate.getGibbsEnergy() < referenceState.gibbsEnergy - gibbsTolerance)) {
+              || candidate.getGibbsEnergy() < referenceState.gibbsEnergy - gibbsTolerance
+              || replacesInvalidIncipientPhase)) {
         copyNeutralFlashStatePreservingRoots(candidate);
       }
     } catch (Exception ex) {

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -23,30 +23,36 @@ public class TPflash extends Flash {
   private static final long serialVersionUID = 1000;
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(TPflash.class);
-  /** Local lower-temperature seed step for multiphase endpoint rescue. */
-  private static final double MULTIPHASE_RESCUE_TEMPERATURE_STEP = 2.0;
-  /** Lower sum(zK) bound for gas endpoint rescue. */
+  /** Lower sum(zK) bound for a general gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_K_LOWER_LIMIT = 0.95;
-  /** Upper sum(zK) bound for gas endpoint rescue. */
+  /** Upper sum(zK) bound for a general gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_K_UPPER_LIMIT = 1.05;
-  /** Lower sum(z/K) bound for gas endpoint rescue. */
+  /** Lower sum(zK) bound for a screened asymmetric-mixture gas endpoint rescue. */
+  private static final double MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_K_LOWER_LIMIT = 1.05;
+  /** Lower sum(z/K) bound for a general gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_LOWER_LIMIT = 1.05;
+  /** Lower sum(z/K) bound for a screened asymmetric-mixture gas endpoint rescue. */
+  private static final double MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_OVER_K_LOWER_LIMIT = 0.95;
   /** Upper sum(z/K) bound for gas endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_UPPER_LIMIT = 2.0;
-  /** Lower sum(zK) bound for liquid endpoint rescue. */
-  private static final double MULTIPHASE_RESCUE_LIQUID_SUM_Z_K_LOWER_LIMIT = 0.95;
-  /** Upper sum(zK) bound for liquid endpoint rescue. */
-  private static final double MULTIPHASE_RESCUE_LIQUID_SUM_Z_K_UPPER_LIMIT = 1.20;
   /** Minimum sum(z/K) bound for liquid endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_LIQUID_SUM_Z_OVER_K_LIMIT = 5.0;
   /** Minimum log K spread for liquid endpoint rescue. */
   private static final double MULTIPHASE_RESCUE_LIQUID_LOG_K_SPREAD_LIMIT = 3.0;
+  /** Minimum sum(zK) indicating a near-split liquid endpoint. */
+  private static final double MULTIPHASE_RESCUE_LIQUID_NEAR_SPLIT_SUM_Z_K_LIMIT = 1.001;
+  /** Minimum sum(z/K) indicating a near-split liquid endpoint. */
+  private static final double MULTIPHASE_RESCUE_LIQUID_NEAR_SPLIT_SUM_Z_OVER_K_LIMIT = 0.995;
   /** Minimum feed fraction of non-hydrocarbon components for liquid-liquid refinement. */
   private static final double LIQUID_LIQUID_NON_HYDROCARBON_FRACTION_LIMIT = 0.20;
   /** Minimum active feed fraction used when screening components for liquid-liquid refinement. */
   private static final double LIQUID_LIQUID_ACTIVE_COMPONENT_LIMIT = 1.0e-6;
   /** Minimum critical-temperature span (K) for liquid-liquid refinement. */
   private static final double LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN = 150.0;
+  /** Minimum critical-temperature margin above the flash temperature for liquid-liquid refinement. */
+  private static final double LIQUID_LIQUID_CRITICAL_TEMPERATURE_MARGIN = 115.0;
+  /** Minimum critical-temperature margin above the flash temperature for a single-endpoint retry. */
+  private static final double MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN = 80.0;
   /** Minimum water feed fraction for ordinary water-rich endpoint refinement. */
   private static final double WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT = 0.01;
   /** Largest incipient secondary-phase fraction eligible for trace-water phase-selection retry. */
@@ -80,10 +86,8 @@ public class TPflash extends Flash {
   private static final double PHASE_ROOT_EQUILIBRIUM_TOLERANCE = 1.0e-8;
   /** Maximum absolute Z or composition change for recognizing an unchanged stable one-phase state. */
   private static final double UNCHANGED_SINGLE_PHASE_STATE_TOLERANCE = 1.0e-11;
-  /** Maximum final SSI updates used to repair a stale neutral two-phase endpoint. */
-  private static final int MAX_FINAL_EQUILIBRIUM_REFINEMENT_ITERATIONS = 8;
-  /** Largest residual considered near enough to convergence for bounded final SSI refinement. */
-  private static final double MAX_FINAL_EQUILIBRIUM_REFINEMENT_RESIDUAL = 1.0e-5;
+  /** Maximum multiphase beta updates used to repair an invalid neutral two-phase endpoint. */
+  private static final int MAX_FINAL_BETA_REFINEMENT_ITERATIONS = 20;
   /** Cubic phase roots evaluated by the post-convergence root checks. */
   private static final PhaseType[] CUBIC_ROOT_PHASE_TYPES = { PhaseType.GAS, PhaseType.LIQUID };
   /** Iteration limit for damped direct gamma-phi flashes near a phase-fraction boundary. */
@@ -855,11 +859,11 @@ public class TPflash extends Flash {
         collapseTrivialMultiphaseSplit();
         rescueLowerGibbsPhaseRoot();
         rescueLowerGibbsHydrocarbonPhaseRoots();
-        rescueLiquidLiquidEndpoint();
+        rescueLowerGibbsNeutralEndpoint();
         rescueWaterRichEndpoint();
         rescueLowerGibbsMultiphaseAqueousRoot();
         refineInvalidAqueousTwoPhaseEndpoint();
-        refineInvalidNeutralGasLiquidTwoPhaseEndpoint();
+        refineInvalidNeutralTwoPhaseEndpoint();
         normalizeUnchangedStableSinglePhaseEndpoint(stableSinglePhaseType, stableSinglePhaseZ,
             stableSinglePhaseComposition);
         return;
@@ -1074,12 +1078,12 @@ public class TPflash extends Flash {
     normalizeActivePhaseFractions();
     rescueLowerGibbsPhaseRoot();
     rescueLowerGibbsHydrocarbonPhaseRoots();
-    rescueLiquidLiquidEndpoint();
+    rescueLowerGibbsNeutralEndpoint();
     rescueWaterRichEndpoint();
     rescueLowerGibbsMultiphaseAqueousRoot();
     rescueLowerGibbsPhaseRoot();
     refineInvalidAqueousTwoPhaseEndpoint();
-    refineInvalidNeutralGasLiquidTwoPhaseEndpoint();
+    refineInvalidNeutralTwoPhaseEndpoint();
 
     // Final chemical equilibrium call after all phase reordering
     // This ensures chemical equilibrium is solved on the final phase configuration
@@ -1133,64 +1137,107 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Refines an ordinary liquid-only endpoint with the multiphase stability solver.
+   * Refines a guarded ordinary endpoint with the multiphase stability solver.
    *
    * <p>
-   * The ordinary two-phase flash primarily searches for a vapor-liquid split. For a liquid-only endpoint it can
-   * therefore converge to a local single-liquid state or to a metastable liquid-liquid split even though Michelsen
-   * tangent-plane stability analysis finds a lower-Gibbs liquid-liquid equilibrium. A cloned candidate is evaluated
-   * with multiphase checking enabled and replaces the ordinary result only when the existing strict phase-fraction,
-   * distinct-composition, and Gibbs-energy acceptance checks pass.
+   * The ordinary two-phase flash can converge to a local gas/liquid or liquid-only stationary point even though
+   * Michelsen tangent-plane stability analysis finds a lower-Gibbs two-phase equilibrium. A cheap feed-composition
+   * screen limits the extra stability flash to strongly asymmetric neutral mixtures with substantial non-hydrocarbon
+   * content at temperatures where liquid-liquid instability is plausible.
    * </p>
    *
    * <p>
-   * The guard deliberately excludes multi-liquid endpoints, any endpoint containing a gas or aqueous phase, chemical
-   * and electrolyte systems, and solid/wax calculations. Thus ordinary gas, gas-liquid, and established liquid-liquid
-   * process flashes remain on the existing fast path without an additional flash or property initialization.
+   * The accepted candidate must contain exactly two neutral fluid phases, close material balance and fugacity equality,
+   * and lower Gibbs energy. Chemical/electrolyte, aqueous, solid, wax, ordinary gas-only, and compositions outside the
+   * instability screen remain on the existing fast path.
    * </p>
    */
-  private void rescueLiquidLiquidEndpoint() {
-    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 1 || system.isChemicalSystem() || system.hasIons()
-        || solidCheck || system.isMultiphaseWaxCheck()) {
+  private void rescueLowerGibbsNeutralEndpoint() {
+    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() < 1 || system.getNumberOfPhases() > 2
+        || system.isChemicalSystem() || system.hasIons() || solidCheck || system.isMultiphaseWaxCheck()
+        || system.hasPhaseType(PhaseType.AQUEOUS)) {
       return;
     }
+    boolean hasGasPhase = false;
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       PhaseType phaseType = system.getPhase(phaseIndex).getType();
-      if (!(phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID)) {
+      if (phaseType != PhaseType.GAS && phaseType != PhaseType.OIL && phaseType != PhaseType.LIQUID) {
         return;
       }
+      hasGasPhase |= phaseType == PhaseType.GAS;
     }
-
     if (!hasPotentialLiquidLiquidInstability()) {
       return;
     }
+    if (system.getNumberOfPhases() == 1 && !hasPotentialMultiphaseEndpoint(system.getPhase(0).getType())) {
+      return;
+    }
+    if (system.getNumberOfPhases() == 2 && !hasGasPhase) {
+      return;
+    }
 
+    system.init(1);
     double referenceGibbsEnergy = system.getGibbsEnergy();
     SystemInterface candidate = system.clone();
+    MULTIPHASE_RESCUE_ACTIVE.set(Boolean.TRUE);
     try {
       candidate.setMultiPhaseCheck(true);
-      candidate.setNumberOfPhases(2);
-      candidate.setPhaseIndex(0, 0);
-      candidate.setPhaseIndex(1, 1);
-      candidate.setPhaseType(0, PhaseType.GAS);
-      candidate.setPhaseType(1, PhaseType.OIL);
-      candidate.setBeta(0, 0.5);
-      candidate.setBeta(1, 0.5);
-      for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
-        for (int componentIndex = 0; componentIndex < candidate.getPhase(phaseIndex)
-            .getNumberOfComponents(); componentIndex++) {
-          candidate.getPhase(phaseIndex).getComponent(componentIndex)
-              .setx(candidate.getPhase(phaseIndex).getComponent(componentIndex).getz());
-        }
-        candidate.getPhase(phaseIndex).normalize();
+      candidate.setEnhancedMultiPhaseCheck(false);
+      if (system.getNumberOfPhases() == 2 && hasGasPhase) {
+        resetNeutralCandidateToFeed(candidate);
+        new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+      } else {
+        new TPmultiflash(candidate, candidate.doSolidPhaseCheck()).run();
       }
-      new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
-      if (isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
+      boolean accepted = isNeutralFluidTwoPhaseCandidate(candidate) && isBalancedEquilibriumCandidate(candidate)
+          && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy);
+      if (!accepted && system.getNumberOfPhases() == 1) {
+        candidate = system.clone();
+        resetNeutralCandidateToFeed(candidate);
+        candidate.setMultiPhaseCheck(true);
+        candidate.setEnhancedMultiPhaseCheck(false);
+        new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+        accepted = isNeutralFluidTwoPhaseCandidate(candidate) && isBalancedEquilibriumCandidate(candidate)
+            && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy);
+      }
+      if (accepted) {
         copyFlashStateFrom(candidate);
       }
     } catch (Exception ex) {
-      logger.debug("Liquid-liquid endpoint refinement failed: {}", ex.getMessage());
+      logger.debug("Neutral endpoint stability refinement failed: {}", ex.getMessage());
+    } finally {
+      MULTIPHASE_RESCUE_ACTIVE.set(Boolean.FALSE);
     }
+  }
+
+  /**
+   * Checks that a liquid-endpoint refinement retained exactly two neutral liquid-like phases.
+   *
+   * @param candidate candidate returned by the multiphase stability path
+   * @return true when the candidate is an oil/liquid two-phase state without gas or aqueous phases
+   */
+  private boolean isNeutralFluidTwoPhaseCandidate(SystemInterface candidate) {
+    return candidate.getNumberOfPhases() == 2 && isNeutralFluidCandidate(candidate);
+  }
+
+  /**
+   * Checks whether a reciprocal candidate contains only one or two neutral fluid phases.
+   *
+   * @param candidate candidate returned by the reciprocal flash path
+   * @return true when every active phase is gas/oil/liquid and no aqueous phase is present
+   */
+  private boolean isNeutralFluidCandidate(SystemInterface candidate) {
+    if (candidate.getNumberOfPhases() < 1 || candidate.getNumberOfPhases() > 2
+        || candidate.hasPhaseType(PhaseType.AQUEOUS)) {
+      return false;
+    }
+    for (int phaseIndex = 0; phaseIndex < candidate.getNumberOfPhases(); phaseIndex++) {
+      PhaseType phaseType = candidate.getPhase(phaseIndex).getType();
+      if (phaseType != PhaseType.GAS && phaseType != PhaseType.OIL && phaseType != PhaseType.LIQUID) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -1598,50 +1645,165 @@ public class TPflash extends Flash {
    * existing strict checks. Otherwise the complete two-phase iteration state is restored.
    * </p>
    */
-  private void refineInvalidNeutralGasLiquidTwoPhaseEndpoint() {
+  private void refineInvalidNeutralTwoPhaseEndpoint() {
     if (system.getNumberOfPhases() != 2 || system.hasPhaseType(PhaseType.AQUEOUS) || system.isChemicalSystem()
         || system.hasIons() || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()) {
       return;
     }
-    boolean hasGasPhase = false;
-    boolean hasLiquidPhase = false;
     for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
       PhaseType phaseType = system.getPhase(phaseIndex).getType();
       if (phaseType != PhaseType.GAS && phaseType != PhaseType.OIL && phaseType != PhaseType.LIQUID) {
         return;
       }
-      hasGasPhase |= phaseType == PhaseType.GAS;
-      hasLiquidPhase |= phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID;
-    }
-    if (!hasGasPhase || !hasLiquidPhase) {
-      return;
     }
 
     system.init(1);
     double referenceMaterialResidual = maximumComponentMaterialBalanceResidual(system);
     double referenceFugacityResidual = maximumLogFugacityResidual(system.getPhase(0), system.getPhase(1));
-    if (!Double.isFinite(referenceMaterialResidual) || !Double.isFinite(referenceFugacityResidual)
-        || referenceMaterialResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE
-        || referenceFugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE
-        || referenceFugacityResidual > MAX_FINAL_EQUILIBRIUM_REFINEMENT_RESIDUAL) {
+    if (Double.isFinite(referenceMaterialResidual) && referenceMaterialResidual <= WATER_RICH_MATERIAL_BALANCE_TOLERANCE
+        && Double.isFinite(referenceFugacityResidual) && referenceFugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
       return;
     }
 
     BalancedTwoPhaseState referenceState = new BalancedTwoPhaseState(system);
+    boolean referenceWasInvalid = !Double.isFinite(referenceMaterialResidual)
+        || referenceMaterialResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE
+        || !Double.isFinite(referenceFugacityResidual) || referenceFugacityResidual >= PHASE_ROOT_EQUILIBRIUM_TOLERANCE;
     try {
-      for (int refinement = 0; refinement < MAX_FINAL_EQUILIBRIUM_REFINEMENT_ITERATIONS
+      TPmultiflash endpointSolver = new TPmultiflash(system, false);
+      endpointSolver.setDoubleArrays();
+      for (int refinement = 0; refinement < MAX_FINAL_BETA_REFINEMENT_ITERATIONS
           && !isBalancedEquilibriumCandidate(system); refinement++) {
-        sucsSubs();
+        endpointSolver.solveBeta();
       }
       double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
-      if (!isBalancedEquilibriumCandidate(system) || !preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)
-          || system.getGibbsEnergy() > referenceState.gibbsEnergy + gibbsTolerance) {
-        restoreTwoPhaseIterationState(referenceState);
+      if (isBalancedEquilibriumCandidate(system) && preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)
+          && (referenceWasInvalid || system.getGibbsEnergy() <= referenceState.gibbsEnergy + gibbsTolerance)) {
+        rescueLowerGibbsHydrocarbonPhaseRoots();
+        system.orderByDensity();
+        system.init(1);
+        if (isBalancedEquilibriumCandidate(system)) {
+          return;
+        }
       }
+      restoreTwoPhaseIterationState(referenceState);
     } catch (Exception ex) {
       restoreTwoPhaseIterationState(referenceState);
-      logger.debug("Final neutral hydrocarbon endpoint refinement failed: {}", ex.getMessage());
+      logger.debug("Final neutral two-phase beta refinement failed: {}", ex.getMessage());
     }
+
+    if (MULTIPHASE_RESCUE_ACTIVE.get().booleanValue()) {
+      return;
+    }
+    SystemInterface candidate = system.clone();
+    MULTIPHASE_RESCUE_ACTIVE.set(Boolean.TRUE);
+    try {
+      resetNeutralCandidateToFeed(candidate);
+      candidate.setMultiPhaseCheck(!system.doMultiPhaseCheck());
+      candidate.setEnhancedMultiPhaseCheck(false);
+      new TPflash(candidate, false).run();
+      candidate.init(1);
+      double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
+      if (isNeutralFluidCandidate(candidate) && isBalancedEquilibriumCandidate(candidate)
+          && (referenceWasInvalid || candidate.getGibbsEnergy() < referenceState.gibbsEnergy - gibbsTolerance)) {
+        copyNeutralFlashStatePreservingRoots(candidate);
+      }
+    } catch (Exception ex) {
+      logger.debug("Final neutral two-phase cross-algorithm refinement failed: {}", ex.getMessage());
+    } finally {
+      MULTIPHASE_RESCUE_ACTIVE.set(Boolean.FALSE);
+    }
+  }
+
+  /**
+   * Resets a neutral cross-algorithm candidate to the overall feed before reflashing.
+   *
+   * <p>
+   * Copying an invalid endpoint also copies stale phase fractions, compositions, and cubic roots. Starting the
+   * reciprocal flash from that state can reproduce the same invalid stationary point. The reset is confined to the
+   * already-failed fallback path and reconstructs the ordinary two-phase TP-flash starting state without allocating a
+   * new thermodynamic system.
+   * </p>
+   *
+   * @param candidate cloned candidate to reset
+   */
+  private void resetNeutralCandidateToFeed(SystemInterface candidate) {
+    candidate.setNumberOfPhases(2);
+    candidate.setPhaseIndex(0, 0);
+    candidate.setPhaseIndex(1, 1);
+    candidate.setPhaseType(0, PhaseType.GAS);
+    candidate.setPhaseType(1, PhaseType.OIL);
+    candidate.setBeta(0, 0.5);
+    candidate.setBeta(1, 0.5);
+    for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++) {
+      for (int componentIndex = 0; componentIndex < candidate.getPhase(phaseIndex)
+          .getNumberOfComponents(); componentIndex++) {
+        neqsim.thermo.component.ComponentInterface component = candidate.getPhase(phaseIndex)
+            .getComponent(componentIndex);
+        component.setx(component.getz());
+        double logWilsonK = Math.log(component.getPC() / candidate.getPressure())
+            + 5.373 * (1.0 + component.getAcentricFactor()) * (1.0 - component.getTC() / candidate.getTemperature());
+        component.setK(Math.exp(Math.max(-50.0, Math.min(50.0, logWilsonK))));
+      }
+      candidate.getPhase(phaseIndex).normalize();
+    }
+  }
+
+  /**
+   * Copies a neutral two-phase candidate while retaining its selected cubic roots.
+   *
+   * <p>
+   * A converged phase may expose a gas/oil label while its lower-Gibbs cubic root is stored separately by the system.
+   * {@link #copyFlashStateFrom(SystemInterface)} copies the public label and can therefore reinitialize the phase on a
+   * different root. The reciprocal fallback infers each selected root from the candidate compressibility factor and
+   * reapplies the public label only after initialization.
+   * </p>
+   *
+   * @param source accepted neutral two-phase candidate
+   */
+  private void copyNeutralFlashStatePreservingRoots(SystemInterface source) {
+    int numberOfPhases = source.getNumberOfPhases();
+    PhaseType[] publicTypes = new PhaseType[numberOfPhases];
+    PhaseType[] rootTypes = new PhaseType[numberOfPhases];
+    for (int phaseIndex = 0; phaseIndex < numberOfPhases; phaseIndex++) {
+      publicTypes[phaseIndex] = source.getPhase(phaseIndex).getType();
+      rootTypes[phaseIndex] = inferSelectedCubicRoot(source, phaseIndex);
+    }
+    copyFlashStateFrom(source);
+    for (int phaseIndex = 0; phaseIndex < numberOfPhases; phaseIndex++) {
+      system.setPhaseType(phaseIndex, rootTypes[phaseIndex]);
+    }
+    system.init(1);
+    for (int phaseIndex = 0; phaseIndex < numberOfPhases; phaseIndex++) {
+      system.getPhase(phaseIndex).setType(publicTypes[phaseIndex]);
+    }
+  }
+
+  /**
+   * Infers the cubic root that reproduces a converged phase's compressibility factor.
+   *
+   * @param source converged candidate system
+   * @param phaseIndex active phase index
+   * @return gas-like or liquid-like cubic root closest to the converged phase
+   */
+  private PhaseType inferSelectedCubicRoot(SystemInterface source, int phaseIndex) {
+    PhaseType selectedRoot = source.getPhase(phaseIndex).getType();
+    double selectedDifference = Double.POSITIVE_INFINITY;
+    for (PhaseType trialRoot : CUBIC_ROOT_PHASE_TYPES) {
+      try {
+        PhaseInterface trialPhase = source.getPhase(phaseIndex).clone();
+        trialPhase.init(source.getTotalNumberOfMoles(), trialPhase.getNumberOfComponents(), 1, trialRoot,
+            source.getBeta(phaseIndex));
+        double difference = Math.abs(trialPhase.getZ() - source.getPhase(phaseIndex).getZ());
+        if (Double.isFinite(difference) && difference < selectedDifference) {
+          selectedDifference = difference;
+          selectedRoot = trialRoot;
+        }
+      } catch (Exception ex) {
+        logger.debug("Cubic-root inference failed for phase {} root {}: {}", phaseIndex, trialRoot, ex.getMessage());
+      }
+    }
+    return selectedRoot;
   }
 
   /**
@@ -1689,10 +1851,20 @@ public class TPflash extends Flash {
    * @return true when the cheap composition screen justifies multiphase stability refinement
    */
   private boolean hasPotentialLiquidLiquidInstability() {
+    return hasPotentialAsymmetricNeutralInstability(LIQUID_LIQUID_CRITICAL_TEMPERATURE_MARGIN);
+  }
+
+  /**
+   * Screens for an asymmetric neutral mixture in the temperature range where an extra fluid phase is plausible.
+   *
+   * @param criticalTemperatureMargin required component critical-temperature margin above the flash temperature
+   * @return true when the feed composition and critical-temperature spread justify a guarded stability retry
+   */
+  private boolean hasPotentialAsymmetricNeutralInstability(double criticalTemperatureMargin) {
     double nonHydrocarbonFraction = 0.0;
     double minimumCriticalTemperature = Double.POSITIVE_INFINITY;
     double maximumCriticalTemperature = Double.NEGATIVE_INFINITY;
-    boolean hasHeavyHydrocarbon = false;
+    boolean hasCondensableComponent = false;
     int numberOfComponents = system.getPhase(0).getNumberOfComponents();
     for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
       neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
@@ -1706,26 +1878,25 @@ public class TPflash extends Flash {
       double criticalTemperature = component.getTC();
       minimumCriticalTemperature = Math.min(minimumCriticalTemperature, criticalTemperature);
       maximumCriticalTemperature = Math.max(maximumCriticalTemperature, criticalTemperature);
-      if (component.isHydrocarbon()) {
-        if (criticalTemperature > system.getTemperature() + LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN) {
-          hasHeavyHydrocarbon = true;
-        }
-      } else {
+      if (criticalTemperature > system.getTemperature() + criticalTemperatureMargin) {
+        hasCondensableComponent = true;
+      }
+      if (!component.isHydrocarbon()) {
         nonHydrocarbonFraction += feedFraction;
       }
     }
-    return nonHydrocarbonFraction >= LIQUID_LIQUID_NON_HYDROCARBON_FRACTION_LIMIT && hasHeavyHydrocarbon
+    return nonHydrocarbonFraction >= LIQUID_LIQUID_NON_HYDROCARBON_FRACTION_LIMIT && hasCondensableComponent
         && maximumCriticalTemperature - minimumCriticalTemperature >= LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN;
   }
 
   /**
-   * Retries a single-phase hydrocarbon endpoint with a nearby multiphase seed.
+   * Retries a single-phase hydrocarbon endpoint through the ordinary two-phase path.
    *
    * <p>
-   * Near phase boundaries the cold Wilson-seeded TP flash may converge to a local one-phase endpoint even though a
-   * nearby two-phase seed converges to a lower-Gibbs solution at the target pressure and temperature. This guarded
-   * retry is only used when the user has explicitly enabled multiphase checking and the ordinary TPmultiflash cleanup
-   * still leaves one hydrocarbon phase.
+   * A multiphase cleanup can collapse a valid gas/liquid split even though Wilson K-values satisfy the guarded
+   * Rachford-Rice endpoint tests. This guarded retry is only used when the user has explicitly enabled multiphase
+   * checking and those inexpensive tests indicate a split. A single ordinary flash is sufficient and avoids the two
+   * nearby-temperature multiphase flashes previously needed by this fallback.
    * </p>
    */
   private void rescueSinglePhaseMultiphaseEndpoint() {
@@ -1733,30 +1904,13 @@ public class TPflash extends Flash {
       return;
     }
 
-    double targetTemperature = system.getTemperature();
-    double targetPressure = system.getPressure();
     system.init(1);
     double referenceGibbsEnergy = system.getGibbsEnergy();
     SystemInterface candidate = system.clone();
-    boolean previousWarmStart = neqsim.thermo.ThermodynamicModelSettings.isUseWarmStartKValues();
     MULTIPHASE_RESCUE_ACTIVE.set(Boolean.TRUE);
     try {
-      // Warm start is required here for every model, including CPA. Unlike the iterative outer
-      // flashes (PH/PS/PV/TV/...), which are governed by
-      // ThermodynamicModelSettings.isInnerFlashWarmStartSafe(system), this rescue deliberately
-      // continues from a seed flash at a nearby temperature: carrying the seed K-values over to
-      // the target temperature is the mechanism that finds the extra phase. Disabling it would
-      // defeat the rescue.
-      neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(true);
-      double seedTemperature = Math.max(1.0, targetTemperature - MULTIPHASE_RESCUE_TEMPERATURE_STEP);
-      candidate.setTemperature(seedTemperature, "K");
-      candidate.setPressure(targetPressure, "bara");
-      new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
-      if (candidate.getNumberOfPhases() < 2) {
-        return;
-      }
-      candidate.setTemperature(targetTemperature, "K");
-      candidate.setPressure(targetPressure, "bara");
+      candidate.setMultiPhaseCheck(false);
+      candidate.setEnhancedMultiPhaseCheck(false);
       new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
       if (isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)) {
         copyFlashStateFrom(candidate);
@@ -1764,7 +1918,6 @@ public class TPflash extends Flash {
     } catch (Exception ex) {
       logger.debug("Multiphase endpoint rescue failed: {}", ex.getMessage());
     } finally {
-      neqsim.thermo.ThermodynamicModelSettings.setUseWarmStartKValues(previousWarmStart);
       MULTIPHASE_RESCUE_ACTIVE.set(Boolean.FALSE);
     }
   }
@@ -1800,9 +1953,6 @@ public class TPflash extends Flash {
       if ("water".equalsIgnoreCase(component.getComponentName())) {
         return false;
       }
-      if (!component.isHydrocarbon() && !component.isInert()) {
-        return false;
-      }
       if (component.isHydrocarbon()) {
         hasHydrocarbon = true;
       }
@@ -1811,7 +1961,7 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Checks whether stored K-values indicate a nearby split worth a local endpoint rescue.
+   * Checks whether deterministic Wilson K-values indicate a split worth a local endpoint rescue.
    *
    * @param phaseType phase type of the current single-phase endpoint
    * @return true when the endpoint is close enough to a potential phase split to retry
@@ -1821,6 +1971,8 @@ public class TPflash extends Flash {
     double sumZOverK = 0.0;
     double maxAbsLogK = 0.0;
     neqsim.thermo.phase.PhaseInterface phase = system.getPhase(0);
+    double temperature = system.getTemperature();
+    double pressure = system.getPressure();
     int numberOfComponents = phase.getNumberOfComponents();
     for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
       neqsim.thermo.component.ComponentInterface component = phase.getComponent(componentIndex);
@@ -1828,22 +1980,40 @@ public class TPflash extends Flash {
       if (z < 1.0e-50) {
         continue;
       }
-      double kValue = component.getK();
-      if (kValue <= 0.0 || Double.isNaN(kValue) || Double.isInfinite(kValue)) {
+      double criticalTemperature = component.getTC();
+      double criticalPressure = component.getPC();
+      double acentricFactor = component.getAcentricFactor();
+      if (!Double.isFinite(temperature) || temperature <= 0.0 || !Double.isFinite(pressure) || pressure <= 0.0
+          || !Double.isFinite(criticalTemperature) || criticalTemperature <= 0.0 || !Double.isFinite(criticalPressure)
+          || criticalPressure <= 0.0 || !Double.isFinite(acentricFactor)) {
         return true;
       }
+      double logK = Math.log(criticalPressure / pressure)
+          + 5.373 * (1.0 + acentricFactor) * (1.0 - criticalTemperature / temperature);
+      double kValue = Math.exp(Math.max(-50.0, Math.min(50.0, logK)));
       sumZK += z * kValue;
       sumZOverK += z / kValue;
-      maxAbsLogK = Math.max(maxAbsLogK, Math.abs(Math.log(kValue)));
+      maxAbsLogK = Math.max(maxAbsLogK, Math.abs(logK));
     }
     if (phaseType == PhaseType.GAS) {
-      return sumZK > MULTIPHASE_RESCUE_GAS_SUM_Z_K_LOWER_LIMIT && sumZK < MULTIPHASE_RESCUE_GAS_SUM_Z_K_UPPER_LIMIT
+      boolean generalNearSplit = sumZK > MULTIPHASE_RESCUE_GAS_SUM_Z_K_LOWER_LIMIT
+          && sumZK < MULTIPHASE_RESCUE_GAS_SUM_Z_K_UPPER_LIMIT
           && sumZOverK > MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_LOWER_LIMIT
           && sumZOverK < MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_UPPER_LIMIT;
+      boolean asymmetricNearSplit = sumZK > MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_K_LOWER_LIMIT
+          && sumZOverK > MULTIPHASE_RESCUE_GAS_ASYMMETRIC_SUM_Z_OVER_K_LOWER_LIMIT
+          && sumZOverK < MULTIPHASE_RESCUE_GAS_SUM_Z_OVER_K_UPPER_LIMIT;
+      boolean stronglyAsymmetric = sumZOverK > MULTIPHASE_RESCUE_LIQUID_SUM_Z_OVER_K_LIMIT
+          && maxAbsLogK > MULTIPHASE_RESCUE_LIQUID_LOG_K_SPREAD_LIMIT;
+      return generalNearSplit || (asymmetricNearSplit || stronglyAsymmetric)
+          && hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN);
     }
-    return sumZK > MULTIPHASE_RESCUE_LIQUID_SUM_Z_K_LOWER_LIMIT && sumZK < MULTIPHASE_RESCUE_LIQUID_SUM_Z_K_UPPER_LIMIT
-        && sumZOverK > MULTIPHASE_RESCUE_LIQUID_SUM_Z_OVER_K_LIMIT
+    boolean nearSplit = sumZK > MULTIPHASE_RESCUE_LIQUID_NEAR_SPLIT_SUM_Z_K_LIMIT
+        && sumZOverK > MULTIPHASE_RESCUE_LIQUID_NEAR_SPLIT_SUM_Z_OVER_K_LIMIT;
+    boolean stronglyAsymmetric = sumZOverK > MULTIPHASE_RESCUE_LIQUID_SUM_Z_OVER_K_LIMIT
         && maxAbsLogK > MULTIPHASE_RESCUE_LIQUID_LOG_K_SPREAD_LIMIT;
+    return nearSplit || stronglyAsymmetric
+        && hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN);
   }
 
   /**
@@ -1923,6 +2093,9 @@ public class TPflash extends Flash {
    * the strict two-phase endpoint tolerances
    */
   private boolean isBalancedEquilibriumCandidate(SystemInterface candidate) {
+    if (candidate.getNumberOfPhases() < 1 || candidate.getNumberOfPhases() > 2) {
+      return false;
+    }
     double betaTotal = 0.0;
     for (int phaseIndex = 0; phaseIndex < candidate.getNumberOfPhases(); phaseIndex++) {
       double phaseFraction = candidate.getBeta(phaseIndex);
@@ -1944,11 +2117,15 @@ public class TPflash extends Flash {
         return false;
       }
     }
-    if (!Double.isFinite(betaTotal) || Math.abs(betaTotal - 1.0) > 1.0e-6 || !hasDistinctPhaseCompositions(candidate)) {
+    if (!Double.isFinite(betaTotal) || Math.abs(betaTotal - 1.0) > 1.0e-6
+        || candidate.getNumberOfPhases() == 2 && !hasDistinctPhaseCompositions(candidate)) {
       return false;
     }
     if (maximumComponentMaterialBalanceResidual(candidate) > WATER_RICH_MATERIAL_BALANCE_TOLERANCE) {
       return false;
+    }
+    if (candidate.getNumberOfPhases() == 1) {
+      return true;
     }
     double maximumFugacityResidual = 0.0;
     for (int componentIndex = 0; componentIndex < candidate.getPhase(0).getNumberOfComponents(); componentIndex++) {
@@ -2784,8 +2961,22 @@ public class TPflash extends Flash {
     int numberOfPhases = system.getNumberOfPhases();
     if (numberOfPhases == 1) {
       double beta = system.getBeta(0);
-      if (Double.isFinite(beta) && beta > 0.0 && Math.abs(beta - 1.0) >= 1.0e-12) {
-        system.normalizeBeta();
+      boolean requiresNormalization = Double.isFinite(beta) && beta > 0.0 && Math.abs(beta - 1.0) >= 1.0e-12;
+      boolean requiresCompositionReset = false;
+      if (!system.isChemicalSystem() && !system.hasIons()) {
+        for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+          neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+          if (!Double.isFinite(component.getx()) || Math.abs(component.getx() - component.getz()) >= 1.0e-12) {
+            requiresCompositionReset = true;
+            break;
+          }
+        }
+      }
+      if (requiresNormalization || requiresCompositionReset) {
+        system.setBeta(0, 1.0);
+        if (requiresCompositionReset) {
+          resetSinglePhaseCompositionToFeed();
+        }
         system.init(1);
       }
       return;

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashSourGasConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashSourGasConsistencyTest.java
@@ -1,0 +1,110 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
+import java.util.Comparator;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashSourGasConsistencyTest {
+  private static final String[] COMPONENTS = { "methane", "CO2", "H2S" };
+  private static final double[] FEED = { 49.88 / 99.97, 9.87 / 99.97, 40.22 / 99.97 };
+
+  @Test
+  void ordinaryAndMultiphaseFlashReachSameStableOneOrTwoPhaseState() {
+    double[][] conditions = { { 145.0, 10.98 }, { 170.0, 20.96 }, { 200.0, 50.90 }, { 220.0, 100.80 },
+        { 250.0, 105.79 }, { 280.0, 120.76 } };
+
+    for (double[] condition : conditions) {
+      SystemInterface ordinary = flash(condition[0], condition[1], false, false);
+      SystemInterface multiphase = flash(condition[0], condition[1], true, false);
+
+      assertEquivalent(ordinary, multiphase, 2.0e-6, "T=" + condition[0] + " K, P=" + condition[1] + " bara");
+    }
+  }
+
+  @Test
+  void enhancedMultiphaseFlashRepairsInvalidOrCollapsedEndpoints() {
+    double[][] conditions = { { 240.0, 100.80 }, { 260.0, 20.96 }, { 285.0, 45.91 } };
+
+    for (double[] condition : conditions) {
+      SystemInterface ordinary = flash(condition[0], condition[1], false, false);
+      SystemInterface enhanced = flash(condition[0], condition[1], true, true);
+
+      assertEquivalent(ordinary, enhanced, 2.0e-6, "T=" + condition[0] + " K, P=" + condition[1] + " bara");
+    }
+  }
+
+  private SystemInterface flash(double temperature, double pressure, boolean multiphase, boolean enhanced) {
+    SystemInterface system = new SystemPrEos(temperature, pressure);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], FEED[componentIndex]);
+    }
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(multiphase);
+    system.setEnhancedMultiPhaseCheck(enhanced);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private void assertEquivalent(SystemInterface reference, SystemInterface candidate, double tolerance,
+      String condition) {
+    assertEquals(reference.getNumberOfPhases(), candidate.getNumberOfPhases(), condition);
+    assertTrue(reference.getNumberOfPhases() <= 2, condition);
+    assertClosure(reference, condition + " reference");
+    assertClosure(candidate, condition + " candidate");
+
+    Integer[] referenceOrder = phaseOrder(reference);
+    Integer[] candidateOrder = phaseOrder(candidate);
+    for (int orderedPhase = 0; orderedPhase < referenceOrder.length; orderedPhase++) {
+      int referencePhase = referenceOrder[orderedPhase];
+      int candidatePhase = candidateOrder[orderedPhase];
+      assertEquals(reference.getBeta(referencePhase), candidate.getBeta(candidatePhase), tolerance, condition);
+      assertEquals(reference.getPhase(referencePhase).getZ(), candidate.getPhase(candidatePhase).getZ(), tolerance,
+          condition);
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        assertEquals(reference.getPhase(referencePhase).getComponent(componentIndex).getx(),
+            candidate.getPhase(candidatePhase).getComponent(componentIndex).getx(), tolerance, condition);
+      }
+    }
+  }
+
+  private Integer[] phaseOrder(SystemInterface system) {
+    Integer[] order = new Integer[system.getNumberOfPhases()];
+    Arrays.setAll(order, index -> index);
+    Arrays.sort(order,
+        Comparator.comparingDouble(phaseIndex -> -system.getPhase(phaseIndex).getComponent("methane").getx()));
+    return order;
+  }
+
+  private void assertClosure(SystemInterface system, String condition) {
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      betaTotal += system.getBeta(phaseIndex);
+    }
+    assertEquals(1.0, betaTotal, 1.0e-10, condition);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-10, condition);
+    }
+    if (system.getNumberOfPhases() == 2) {
+      double maximumFugacityResidual = 0.0;
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        double firstLogFugacity = Math.log(system.getPhase(0).getComponent(componentIndex).getx())
+            + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+        double secondLogFugacity = Math.log(system.getPhase(1).getComponent(componentIndex).getx())
+            + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+        maximumFugacityResidual = Math.max(maximumFugacityResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+      }
+      assertTrue(maximumFugacityResidual < 1.0e-8,
+          condition + " maximum log fugacity residual was " + maximumFugacityResidual);
+    }
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashSourGasConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashSourGasConsistencyTest.java
@@ -15,8 +15,9 @@ class TPflashSourGasConsistencyTest {
 
   @Test
   void ordinaryAndMultiphaseFlashReachSameStableOneOrTwoPhaseState() {
-    double[][] conditions = { { 145.0, 10.98 }, { 170.0, 20.96 }, { 200.0, 50.90 }, { 220.0, 100.80 },
-        { 250.0, 105.79 }, { 280.0, 120.76 } };
+    double[][] conditions = { { 145.0, 10.98 }, { 170.0, 20.96 }, { 170.0, 380.24 }, { 200.0, 50.90 },
+        { 210.0, 145.71 }, { 220.0, 100.80 }, { 225.0, 105.79 }, { 250.0, 105.79 }, { 255.0, 105.79 },
+        { 270.0, 120.76 }, { 280.0, 120.76 } };
 
     for (double[] condition : conditions) {
       SystemInterface ordinary = flash(condition[0], condition[1], false, false);


### PR DESCRIPTION
## Summary

Advances #2937 with a guarded TP-flash consistency and endpoint-validity improvement for the public NeqSim-Colab methane/CO2/H2S phase map.

This revision keeps the broad-fluid CI-scoping fixes already on the branch and adds:

- deterministic Wilson endpoint screens plus a cheap (V/B) competing-root screen;
- a cold pre-iteration seed only for suspicious asymmetric multiphase collapses;
- a direct ordinary retry before the rare nearby-temperature continuation;
- strict material-balance, fugacity, phase-set, and Gibbs acceptance gates;
- balanced reference restoration when multiphase cleanup collapses a feasible split;
- allocation-free (x=z), (eta=1) finalization for collapsed one-phase sour-gas endpoints;
- additional sour-gas regressions at 170/380.24, 210/145.71, 225/105.79, 255/105.79, and 270/120.76 K/bara.

No public API, global convergence tolerance, or general model path is changed.

## Why this design

The implementation follows Michelsen's stability-first / phase-split workflow: use a cheap stability indication to decide whether a more expensive candidate calculation is justified, then accept only a thermodynamically better feasible state:

- [Michelsen, stability analysis, Part I (1982)](https://www.sciencedirect.com/science/article/pii/0378381282850012)
- [Michelsen, phase-split calculation, Part II (1982)](https://www.sciencedirect.com/science/article/pii/0378381282850024)

Recent multiphase work combines Newton-type updates with line search for robustness, but running such work globally would be too costly here. This PR therefore confines the extra work to screened endpoints: [Xu et al. (2024)](https://pmc.ncbi.nlm.nih.gov/articles/PMC11325433/).

Reduced-space volume-function methods look promising near spinodal regions, but are a larger solver refactor and are intentionally left for a separate change: [Fathi and Hickel (2021)](https://arxiv.org/abs/2001.06285).

The numerical thresholds are engineering screens, not substitutes for the authoritative Gibbs/material/fugacity acceptance checks.

## Full-map result

Fresh independent systems, PR EOS with classic mixing, 81 temperatures x 101 pressures = 8,181 states:

| Metric | Result |
|---|---:|
| genuine multiphase three-phase cells | 824 |
| cells where a two-phase algorithm is applicable | 7,357 |
| phase-class agreement outside the three-phase domain | 7,346 / 7,357 = **99.85%** |
| invalid multiphase endpoints | **0** |
| invalid ordinary endpoints | 4 |

A maximum-two-phase flash cannot reproduce the 824 genuine three-phase cells by definition. The remaining non-three-phase differences are concentrated at the gas/oil root-label boundary plus one substantive single-/two-phase boundary cell near 245 K and 100.8 bara. The four invalid ordinary endpoints are all inside the genuine three-phase domain.

For diagnostic phase maps, every P-T point should start from a pristine clone. Reusing one mutable thermodynamic system across the grid can retain continuation history and is a different warm-start/path-independence test.

## Performance

The expensive work is guarded; common fresh-state medians on the exact integrated tree remain sub-millisecond:

| Case | median ms/flash |
|---|---:|
| stable gas, ordinary | 0.105 |
| stable gas, multiphase | 0.185 |
| stable oil, ordinary | 0.081 |
| stable oil, multiphase | 0.123 |
| hydrocarbon VLE, ordinary | 0.038 |
| hydrocarbon VLE, multiphase | 0.077 |
| stable sour gas, ordinary | 0.160 |
| stable sour gas, multiphase | 0.257 |

Screened pathological repair cases cost 0.71-5.15 ms median when the fallback is actually triggered. These are local microbenchmarks, not a claim of a universal speedup.

## Validation

Passed on exact remote tree `cfda6bf94c8a9c550bb753ffc61b9d9c586e5a0d` (head commit `644cf123cbc5f6b65c7fc30159d92a4804f571c5`):

- complete focused pattern `TPflash*, TPmultiflash*, TPFlashTest`: **80 tests passed**;
- includes aqueous, CPA, gamma-phi, cubic-root, liquid-liquid, warm-start, phase-disappearance, and methane/n-heptane critical-region coverage;
- `python devtools/run_spotless.py apply`: PASS;
- `python devtools/run_spotless.py check`: PASS;
- `python devtools/check_documentation_search.py`: PASS;
- `git diff --check`: PASS;
- exact 8,181-state fresh-point diagnostic sweep: completed without an exception.

The `pre-commit` executable is unavailable in this environment; its mandatory Spotless and documentation-search constituent gates were run directly and passed. Hosted CI remains the final cross-platform validator.

## Documentation impact

Documentation impact: none. This is an internal numerical-safeguard and regression-test change with no public API, input, unit, configuration, default, or recommended-usage change.

## Status

Kept as a **draft**. It materially removes the phase-map dots/invalid multiphase endpoints while preserving the true three-phase domain, but does not claim that a maximum-two-phase algorithm can equal multiphase TPflash inside that domain.

## Current exact-head validation

**HOSTED CI PASS** on exact head `0e2856b73720a99ab5a995bd3871c30da79154cb`.

All applicable hosted workflows now pass:

- Java 8 tests on Ubuntu and Windows;
- Java 21 tests on Ubuntu and Windows;
- all four Java 21 slow-test shards and Javadocs;
- CodeQL, Spotless, pre-commit, PaperLab, and repository cross-reference gates.

The first Java 8 attempt had two independent failures:

- Windows could not resolve a Maven plugin; the failed-job rerun completed successfully.
- Ubuntu reported one byte-for-byte DEXPI determinism difference of `1.72e-8 °C` between two independently simulated operating temperatures. The unchanged exact-head rerun completed all 11,713 tests successfully, so no TP-flash or DEXPI change was made for a non-reproducible numerical flake.

The branch contains only `TPflash.java` and `TPflashSourGasConsistencyTest.java` changes relative to its integrated master baseline. No reviews, comments, requested changes, or unresolved review threads are present.

The PR remains a **draft** because its engineering scope and three-phase limitation still require maintainer review; CI itself is no longer blocking.
