### PR TITLE
perf(process): avoid redundant ProcessModel confirmation runs

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -2094,6 +2094,7 @@ public class ProcessModel implements Runnable, Serializable {
       publishModelEvent(ProcessEvent.EventType.SIMULATION_COMPLETE, "ProcessModel step mode completed",
           ProcessEvent.Severity.INFO);
     } else {
+      boolean previouslyConverged = modelConverged;
       // Reset convergence tracking
       lastIterationCount = 0;
       modelConverged = false;
@@ -2116,6 +2117,12 @@ public class ProcessModel implements Runnable, Serializable {
       java.util.Set<ProcessSystem> dirtyAreas = null;
       resetAutoTuningRunState();
       applyAutoDefaultTolerance();
+      // A converged model already has populated internal streams, so repeated execution can
+      // safely apply automatic thresholds before the first area pass. Cold execution and
+      // observable lifecycle-hook runs retain the post-pass tuning/confirmation behaviour.
+      if (previouslyConverged && useIncrementalAreaExecution && progressListener == null && !publishEvents) {
+        applyAutoConvergenceTuning();
+      }
 
       int iterations = 0;
       while (!Thread.currentThread().isInterrupted() && iterations < maxIterations) {
@@ -3025,8 +3032,7 @@ public class ProcessModel implements Runnable, Serializable {
    */
   private java.util.Set<ProcessSystem> getDirtyAreasForNextIteration(AreaExecutionPlan plan,
       java.util.Set<Object> changedBoundaryStreams) {
-    if (!useIncrementalAreaExecution || progressListener != null || publishEvents || changedBoundaryStreams == null
-        || changedBoundaryStreams.isEmpty()) {
+    if (!useIncrementalAreaExecution || progressListener != null || publishEvents || changedBoundaryStreams == null) {
       return null;
     }
     java.util.Set<ProcessSystem> dirtyAreas = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
@@ -3054,7 +3060,7 @@ public class ProcessModel implements Runnable, Serializable {
         }
       }
     }
-    if (dirtyAreas.isEmpty() || dirtyAreas.size() >= processes.size()) {
+    if (dirtyAreas.size() >= processes.size()) {
       return null;
     }
     return dirtyAreas;

--- a/src/test/java/neqsim/process/processmodel/ProcessModelExecutionOptimizationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessModelExecutionOptimizationTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
@@ -27,6 +28,64 @@ import neqsim.thermo.system.SystemSrkEos;
  * @version 1.0
  */
 class ProcessModelExecutionOptimizationTest {
+
+  /** ProcessSystem test double that can update one boundary stream on demand. */
+  private static final class BoundaryRecordingProcessSystem extends ProcessSystem {
+    /** Serialization version UID. */
+    private static final long serialVersionUID = 1L;
+
+    /** Boundary stream to update when armed, or {@code null} for a stable area. */
+    private final StreamInterface boundaryToUpdate;
+
+    /** Boundary flow to apply on the next run, or NaN when no update is armed. */
+    private double pendingFlow = Double.NaN;
+
+    /** Number of model-requested area runs. */
+    private int runs;
+
+    /**
+     * Creates a stable or boundary-updating area.
+     *
+     * @param name area name
+     * @param boundaryToUpdate boundary stream to update, or {@code null}
+     */
+    private BoundaryRecordingProcessSystem(String name, StreamInterface boundaryToUpdate) {
+      super(name);
+      this.boundaryToUpdate = boundaryToUpdate;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void run(UUID id) {
+      runs++;
+      if (boundaryToUpdate != null && Double.isFinite(pendingFlow)) {
+        boundaryToUpdate.setFlowRate(pendingFlow, "kg/hr");
+        pendingFlow = Double.NaN;
+      }
+      setCalculationIdentifier(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean solved() {
+      return true;
+    }
+
+    /** @return number of model-requested area runs */
+    private int getRuns() {
+      return runs;
+    }
+
+    /** Clears the area-run counter. */
+    private void resetRuns() {
+      runs = 0;
+    }
+
+    /** @param flowKgPerHour boundary flow to apply on the next area run */
+    private void updateBoundaryOnNextRun(double flowKgPerHour) {
+      pendingFlow = flowKgPerHour;
+    }
+  }
 
   /**
    * Lightweight ProcessSystem that records which execution path ProcessModel selected.
@@ -170,6 +229,72 @@ class ProcessModelExecutionOptimizationTest {
       assertTrue(observedWarmStart.booleanValue(), "warm-start should be active inside child run");
     }
     assertTrue(model.isModelConverged(), "model should converge");
+  }
+
+  /**
+   * Verifies that an unchanged model uses an empty incremental confirmation pass instead of rerunning every area.
+   */
+  @Test
+  void unchangedBoundaryConfirmationDoesNotRerunAreas() {
+    Stream feed = new Stream("feed", createGasFluid());
+    feed.setFlowRate(1000.0, "kg/hr");
+    Heater producer = new Heater("producer", feed);
+    producer.setOutTemperature(298.15);
+    StreamInterface boundary = producer.getOutletStream();
+    Separator consumer = new Separator("consumer", boundary);
+
+    BoundaryRecordingProcessSystem upstream = new BoundaryRecordingProcessSystem("upstream", null);
+    upstream.add(feed);
+    upstream.add(producer);
+    BoundaryRecordingProcessSystem downstream = new BoundaryRecordingProcessSystem("downstream", null);
+    downstream.add(consumer);
+
+    ProcessModel model = new ProcessModel();
+    model.add("upstream", upstream);
+    model.add("downstream", downstream);
+    model.run();
+    upstream.resetRuns();
+    downstream.resetRuns();
+    model.run();
+
+    assertEquals(2, model.getLastIterationCount(), "boundary models retain two convergence observations");
+    assertEquals(1, upstream.getRuns(), "stable upstream should run only on the first observation");
+    assertEquals(1, downstream.getRuns(), "stable downstream should run only on the first observation");
+    assertTrue(model.isModelConverged(), "unchanged boundary model should converge");
+  }
+
+  /**
+   * Verifies that pre-run tuning leaves incremental scheduling active for a changed boundary stream.
+   */
+  @Test
+  void changedBoundaryRerunsOnlyDownstreamArea() {
+    Stream feed = new Stream("feed", createGasFluid());
+    feed.setFlowRate(1000.0, "kg/hr");
+    Heater producer = new Heater("producer", feed);
+    producer.setOutTemperature(298.15);
+    StreamInterface boundary = producer.getOutletStream();
+    Separator consumer = new Separator("consumer", boundary);
+
+    BoundaryRecordingProcessSystem upstream = new BoundaryRecordingProcessSystem("upstream", boundary);
+    upstream.add(feed);
+    upstream.add(producer);
+    BoundaryRecordingProcessSystem downstream = new BoundaryRecordingProcessSystem("downstream", null);
+    downstream.add(consumer);
+
+    ProcessModel model = new ProcessModel();
+    model.setFlowTolerance(1.0e-8);
+    model.add("upstream", upstream);
+    model.add("downstream", downstream);
+    model.run();
+    upstream.resetRuns();
+    downstream.resetRuns();
+    upstream.updateBoundaryOnNextRun(1100.0);
+    model.run();
+
+    assertEquals(2, model.getLastIterationCount(), "changed boundary should be confirmed on a second observation");
+    assertEquals(1, upstream.getRuns(), "clean producer should not rerun");
+    assertEquals(2, downstream.getRuns(), "changed boundary consumer should rerun");
+    assertTrue(model.isModelConverged(), "changed boundary model should converge after downstream confirmation");
   }
 
   /**


### PR DESCRIPTION
## Summary

Advances #2939 with one measured process-layer scheduling optimization for repeated and nearby-state `ProcessModel` execution.

- pre-apply automatic flow-noise thresholds only when the same model previously converged and its internal streams are already populated;
- keep cold execution and observable progress/event lifecycle runs on the existing post-pass tuning path;
- let an empty incremental dirty-area set mean “observe without rerunning equipment” instead of “rerun every area”;
- preserve the mandatory second boundary observation while avoiding duplicate accepted-state equipment work;
- add focused unchanged-boundary and changed-downstream regressions.

No public API, serialized field, convergence tolerance, thermodynamic algorithm, or equipment calculation changes.

## Bottleneck and attribution

On current master `e0cb19cf1b1cf4c4408c7ec113037661c674f2a6`, every run resets automatic thresholds. The first outer pass then applies the same thresholds after equipment execution and marks `autoTuningChanged`, which disables incremental scheduling for the confirmation pass. Separately, an empty changed-boundary set maps to `null`, whose execution meaning is “run every area.”

In a four-area inlet/recycle/compression/delivery model, this produced:

- unchanged repeated run: **8 area executions** for two outer observations;
- nearby-flow run: **8 area executions**, even though only three downstream areas need confirmation.

This PR changes those counts to **4** and **7**, respectively. Cold runs and runs with progress/event hooks retain their prior tuning/confirmation behavior.

## Benchmark methodology

Local-only deterministic harness; OpenJDK 17.0.19, Linux 6.18.35, G1, fixed 512 MiB heap, `-XX:ActiveProcessorCount=2`. Exact current `ProcessModel` source was overlaid on the same NeqSim runtime for baseline/candidate A/B.

Representative four-area case:

- classic-SRK rich gas;
- inlet cooler/separator;
- deterministic gas recycle with mixer/cooler/separator/splitter/heater and a `1e-6` recycle tolerance;
- compressor/after-cooler/scrubber;
- delivery valve/heater/separator;
- 8 warmups and 20 measured runs per fresh JVM;
- seven alternating baseline/candidate pairs.

### Results

| Workload | Baseline median of fork medians | Candidate median | Change | Paired wins | Area runs / 20 solves |
|---|---:|---:|---:|---:|---:|
| unchanged repeated | 83.127 ms | 42.310 ms | **49.10% faster** | **7/7** | 160 → 80 |
| nearby flow 50,000/50,500 kg/h | 82.990 ms | 76.401 ms | **7.94% faster** | **4/7** | 160 → 140 |

The nearby-state result clears the roadmap’s 5% representative end-to-end gate with a majority of paired wins. Raw fork medians are retained in the #2939 ledger update.

Genuinely parallel four-area control, three alternating pairs:

- area runs: **160 → 80**;
- outer iterations: **40 → 20**;
- candidate faster in **3/3** pairs;
- accumulated checksum exactly `26654000.000000000000` for both variants.

Associating SRK-CPA gas/water stable-repeat control:

- area runs: **160 → 80**;
- one diagnostic pair: 1993.356 → 938.916 ms median;
- exact checksum sum `1407041656.9761167` for both variants.

The CPA timing is a control, not a statistical performance claim.

## Accuracy, convergence, and compatibility evidence

Across baseline/candidate representative runs:

- cold checksum: exactly `70352174.47153132`;
- nearby checksum: exactly `70352664.68999666`;
- 20-run stable checksum sum: exactly `1407053293.799934`;
- 20-run nearby alternating checksum sum: exactly `1407048392.3310611`;
- outer convergence observations: unchanged at two for boundary-driven cases;
- non-converged runs: 0;
- recycle iterations: 2;
- recycle flow/temperature residuals: 0;
- model mass-closure error: 0;
- no API or serialized-state field changed;
- no static/shared mutable state added;
- calculation identifiers continue through the existing area execution path.

Cold models are not pre-tuned because downstream streams may not yet be populated. Progress listeners and event publishing also retain full-area callback behavior.

## Validation

Passed on the exact formatted changed blobs now on this branch:

- direct JDK compilation of modified `ProcessModel.java`;
- `ProcessModelExecutionOptimizationTest`: 13/13;
- related convergence, diagnostics, recycle, and execution tests: 54/54;
- `ProcessModelHooksTest`: 10/10;
- total focused/proportionate tests: **77/77**;
- `python devtools/run_spotless.py apply`: exit 0, rerun exit 0;
- `python devtools/run_spotless.py check`: exit 0;
- `python devtools/check_documentation_search.py`: exit 0;
- `git diff --check`: exit 0.

The local `pre-commit` executable was unavailable. Hosted exact-head PaperLab, Spotless format-patch, and pre-commit workflows have passed. CodeQL and the full build/test/Javadoc workflow remain in progress and are not claimed.

**VALIDATION PENDING CI**

## Documentation impact

Documentation impact: none. This is an internal realization of the already-public incremental area-execution contract. It changes no API, option, unit, default, serialization shape, or recommended user workflow; comments and focused tests document the cold/repeated/lifecycle boundaries.

## Scope and limitations

- Benefit applies to repeated converged models and nearby-state reruns where incremental execution is enabled.
- Cold first execution intentionally retains existing threshold-propagation behavior.
- Lifecycle hooks/events intentionally retain full-area execution so callback semantics do not change.
- TPflash, thermodynamic initialization kernels, columns, dynamics, Two-Fluid, and production optimization are untouched.
