### PR TITLE
feat(dynamics): transact native control blocks

### DIFF
--- a/docs/process/controllers.md
+++ b/docs/process/controllers.md
@@ -111,7 +111,8 @@ transactions. A rejected step restores their dynamic states, delay buffer, outpu
 configuration, and original transmitter/input bindings. Replaying the same physical-step identifier after rollback
 therefore produces the same deterministic control-block continuation. Repeated evaluation with an already accepted
 physical-step identifier is ignored; use one UUID per physical timestep and reuse it only for refinements inside that
-step.
+step. `TransferFunctionBlock.reset()` also clears the remembered step identifier so a deterministic run can restart
+from the block's initial state.
 
 Subclass instances fail transaction coverage until the subclass supplies a snapshot for its own mutable state. The
 transaction contract is an in-memory rollback mechanism: it does not validate tuning, prove safety integrity, or defer

--- a/docs/process/controllers.md
+++ b/docs/process/controllers.md
@@ -15,6 +15,7 @@ Documentation for controllers, adjusters, recycles, and process logic in NeqSim.
 - [Setters](#setters)
 - [Calculators](#calculators)
 - [PID Controllers](#pid-controllers)
+- [Native Dynamic Control Blocks](#native-dynamic-control-blocks)
 - [Process Logic](#process-logic)
 
 ---
@@ -85,6 +86,36 @@ process.runTransient(1.0, calcId);
 ```
 
 This is in addition to controllers embedded on individual equipment, which continue to work as before.
+
+## Native Dynamic Control Blocks
+
+`TransferFunctionBlock` supplies first-order lag, lead-lag, dead-time, and second-order signal dynamics.
+`LogicBlock` evaluates threshold, fixed, or chained Boolean inputs. Register either block as a system-level
+controller so it is evaluated in the controller phase of each transient step.
+
+```java
+TransferFunctionBlock pressureLag = new TransferFunctionBlock(
+    "PT-filter", TransferFunctionBlock.Type.FIRST_ORDER_LAG);
+pressureLag.setTransmitter(pressureTransmitter);
+pressureLag.setLagTime(5.0);
+pressureLag.setDeadTime(2.0);
+process.add(pressureLag);
+
+LogicBlock tripVote = new LogicBlock("PAHH", LogicBlock.Operator.AND);
+tripVote.addInput(pressureTransmitter, 120.0, LogicBlock.Comparator.GREATER_EQUAL);
+process.add(tripVote);
+```
+
+Both concrete block classes participate in `ProcessSystem` and multi-area `ProcessModel` transient-step
+transactions. A rejected step restores their dynamic states, delay buffer, output, calculation identity,
+configuration, and original transmitter/input bindings. Replaying the same physical-step identifier after rollback
+therefore produces the same deterministic control-block continuation. Repeated evaluation with an already accepted
+physical-step identifier is ignored; use one UUID per physical timestep and reuse it only for refinements inside that
+step.
+
+Subclass instances fail transaction coverage until the subclass supplies a snapshot for its own mutable state. The
+transaction contract is an in-memory rollback mechanism: it does not validate tuning, prove safety integrity, or defer
+external side effects produced by callbacks.
 
 ---
 

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -139,6 +139,14 @@ as standalone process controllers. Duplicate registration of the same object is 
 state identities are rejected. Systems containing a mutable process element without the participant contract, or a
 configured recycle whose shared `RecycleController` state cannot yet be restored in place, fail before opening a trial.
 
+Concrete `TransferFunctionBlock` and `LogicBlock` instances are covered participants. Transfer-function snapshots
+include both lag states, the complete circular dead-time buffer and index, output, physical-step identifier, tuning,
+biases, activity, unit, name, and the original transmitter binding. Logic snapshots include evaluated output,
+physical-step identifier, comparison tolerance, activity, unit, name, and an identity-preserving copy of the input-list
+membership. Both blocks reject duplicate advancement for the same non-null physical-step identifier and allow exact
+continuation after rollback or Java serialization. Subclasses fail closed until they extend the snapshot for any
+additional mutable state.
+
 This is an additive compatibility boundary. Legacy `runTransient(...)`, `reset()`, and
 `runTransientAdaptive(...)` retain their current behavior. Built-in equipment must adopt the participant contract
 family by family with inventory, controller, conservation, timestep, and replay evidence before transactional execution

--- a/src/main/java/neqsim/process/controllerdevice/LogicBlock.java
+++ b/src/main/java/neqsim/process/controllerdevice/LogicBlock.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
 import neqsim.util.NamedBaseClass;
 
@@ -34,7 +35,8 @@ import neqsim.util.NamedBaseClass;
  * @author ESOL
  * @version 1.0
  */
-public class LogicBlock extends NamedBaseClass implements ControllerDeviceInterface {
+public class LogicBlock extends NamedBaseClass
+    implements ControllerDeviceInterface, TransientStateParticipant<LogicBlock.LogicBlockState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
 
@@ -92,6 +94,9 @@ public class LogicBlock extends NamedBaseClass implements ControllerDeviceInterf
 
   /** UUID from last calculation. */
   protected UUID calcIdentifier;
+
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /**
    * Constructor for LogicBlock.
@@ -180,6 +185,15 @@ public class LogicBlock extends NamedBaseClass implements ControllerDeviceInterf
     }
   }
 
+  /**
+   * Get the tolerance used for {@link Comparator#EQUAL} comparisons.
+   *
+   * @return non-negative equality tolerance
+   */
+  public double getEqualityTolerance() {
+    return equalityTolerance;
+  }
+
   /** {@inheritDoc} */
   @Override
   public double getMeasuredValue() {
@@ -219,6 +233,9 @@ public class LogicBlock extends NamedBaseClass implements ControllerDeviceInterf
   /** {@inheritDoc} */
   @Override
   public void runTransient(double initResponse, double dt, UUID id) {
+    if (hasRunTransient(id)) {
+      return;
+    }
     if (!isActive) {
       calcIdentifier = id;
       return;
@@ -260,6 +277,12 @@ public class LogicBlock extends NamedBaseClass implements ControllerDeviceInterf
 
   /** {@inheritDoc} */
   @Override
+  public boolean hasRunTransient(UUID id) {
+    return id != null && id.equals(calcIdentifier);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public double getResponse() {
     return output;
   }
@@ -292,6 +315,55 @@ public class LogicBlock extends NamedBaseClass implements ControllerDeviceInterf
   @Override
   public boolean isActive() {
     return isActive;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "controller:logic-block:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for this concrete logic-block implementation.
+   *
+   * @return blocking diagnostic for subclasses, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != LogicBlock.class) {
+      return "logic-block subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public LogicBlockState captureTransientState() {
+    return new LogicBlockState(getTransientStateIdentity(), getName(), new ArrayList<LogicInput>(inputs), output,
+        isActive, unit, equalityTolerance, calcIdentifier);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(LogicBlockState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Logic-block transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException("Logic-block snapshot identity does not match " + getTransientStateIdentity());
+    }
+    setName(snapshot.name);
+    inputs.clear();
+    inputs.addAll(snapshot.inputs);
+    output = snapshot.output;
+    isActive = snapshot.active;
+    unit = snapshot.unit;
+    equalityTolerance = snapshot.equalityTolerance;
+    calcIdentifier = snapshot.calcIdentifier;
   }
 
   private boolean evaluateAnd(List<Boolean> values) {
@@ -444,6 +516,32 @@ public class LogicBlock extends NamedBaseClass implements ControllerDeviceInterf
     @Override
     public boolean evaluate(double equalityTolerance) {
       return upstream.getOutputBoolean();
+    }
+  }
+
+  /** Immutable rollback point for logic-block configuration, bindings, and evaluated state. */
+  public static final class LogicBlockState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String stateIdentity;
+    private final String name;
+    private final List<LogicInput> inputs;
+    private final double output;
+    private final boolean active;
+    private final String unit;
+    private final double equalityTolerance;
+    private final UUID calcIdentifier;
+
+    private LogicBlockState(String stateIdentity, String name, List<LogicInput> inputs, double output, boolean active,
+        String unit, double equalityTolerance, UUID calcIdentifier) {
+      this.stateIdentity = stateIdentity;
+      this.name = name;
+      this.inputs = inputs;
+      this.output = output;
+      this.active = active;
+      this.unit = unit;
+      this.equalityTolerance = equalityTolerance;
+      this.calcIdentifier = calcIdentifier;
     }
   }
 }

--- a/src/main/java/neqsim/process/controllerdevice/TransferFunctionBlock.java
+++ b/src/main/java/neqsim/process/controllerdevice/TransferFunctionBlock.java
@@ -1,8 +1,10 @@
 package neqsim.process.controllerdevice;
 
+import java.io.Serializable;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
 import neqsim.util.NamedBaseClass;
 
@@ -38,7 +40,8 @@ import neqsim.util.NamedBaseClass;
  * @author ESOL
  * @version 1.0
  */
-public class TransferFunctionBlock extends NamedBaseClass implements ControllerDeviceInterface {
+public class TransferFunctionBlock extends NamedBaseClass
+    implements ControllerDeviceInterface, TransientStateParticipant<TransferFunctionBlock.TransferFunctionState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
   /** Logger object for class. */
@@ -113,6 +116,9 @@ public class TransferFunctionBlock extends NamedBaseClass implements ControllerD
 
   /** UUID from last calculation. */
   protected UUID calcIdentifier;
+
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /**
    * Constructor for TransferFunctionBlock.
@@ -340,9 +346,21 @@ public class TransferFunctionBlock extends NamedBaseClass implements ControllerD
     this.transmitter = device;
   }
 
+  /**
+   * Get the transmitter currently bound to this block.
+   *
+   * @return bound transmitter, or {@code null} when the transient input is supplied directly
+   */
+  public MeasurementDeviceInterface getTransmitter() {
+    return transmitter;
+  }
+
   /** {@inheritDoc} */
   @Override
   public void runTransient(double initResponse, double dt, UUID id) {
+    if (hasRunTransient(id)) {
+      return;
+    }
     if (!isActive) {
       output = initResponse;
       calcIdentifier = id;
@@ -386,6 +404,12 @@ public class TransferFunctionBlock extends NamedBaseClass implements ControllerD
 
   /** {@inheritDoc} */
   @Override
+  public boolean hasRunTransient(UUID id) {
+    return id != null && id.equals(calcIdentifier);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public double getResponse() {
     return output;
   }
@@ -425,6 +449,67 @@ public class TransferFunctionBlock extends NamedBaseClass implements ControllerD
   @Override
   public boolean isActive() {
     return isActive;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "controller:transfer-function:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for this concrete transfer-function implementation.
+   *
+   * @return blocking diagnostic for subclasses, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != TransferFunctionBlock.class) {
+      return "transfer-function subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public TransferFunctionState captureTransientState() {
+    return new TransferFunctionState(getTransientStateIdentity(), getName(), gain, lagTime, leadTime, lagTime2,
+        deadTime, inputBias, outputBias, state1, state2, deadTimeBuffer == null ? null : deadTimeBuffer.clone(),
+        deadTimeWriteIndex, initialized, output, transmitter, unit, isActive, calcIdentifier);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(TransferFunctionState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Transfer-function transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Transfer-function snapshot identity does not match " + getTransientStateIdentity());
+    }
+    setName(snapshot.name);
+    gain = snapshot.gain;
+    lagTime = snapshot.lagTime;
+    leadTime = snapshot.leadTime;
+    lagTime2 = snapshot.lagTime2;
+    deadTime = snapshot.deadTime;
+    inputBias = snapshot.inputBias;
+    outputBias = snapshot.outputBias;
+    state1 = snapshot.state1;
+    state2 = snapshot.state2;
+    deadTimeBuffer = snapshot.deadTimeBuffer == null ? null : snapshot.deadTimeBuffer.clone();
+    deadTimeWriteIndex = snapshot.deadTimeWriteIndex;
+    initialized = snapshot.initialized;
+    output = snapshot.output;
+    transmitter = snapshot.transmitter;
+    unit = snapshot.unit;
+    isActive = snapshot.active;
+    calcIdentifier = snapshot.calcIdentifier;
   }
 
   // --- Private computation methods ---
@@ -557,5 +642,55 @@ public class TransferFunctionBlock extends NamedBaseClass implements ControllerD
     deadTimeBuffer[deadTimeWriteIndex] = currentValue;
     deadTimeWriteIndex = (deadTimeWriteIndex + 1) % deadTimeBuffer.length;
     return delayedOutput;
+  }
+
+  /** Immutable rollback point for transfer-function configuration, bindings, and dynamic state. */
+  public static final class TransferFunctionState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String stateIdentity;
+    private final String name;
+    private final double gain;
+    private final double lagTime;
+    private final double leadTime;
+    private final double lagTime2;
+    private final double deadTime;
+    private final double inputBias;
+    private final double outputBias;
+    private final double state1;
+    private final double state2;
+    private final double[] deadTimeBuffer;
+    private final int deadTimeWriteIndex;
+    private final boolean initialized;
+    private final double output;
+    private final MeasurementDeviceInterface transmitter;
+    private final String unit;
+    private final boolean active;
+    private final UUID calcIdentifier;
+
+    private TransferFunctionState(String stateIdentity, String name, double gain, double lagTime, double leadTime,
+        double lagTime2, double deadTime, double inputBias, double outputBias, double state1, double state2,
+        double[] deadTimeBuffer, int deadTimeWriteIndex, boolean initialized, double output,
+        MeasurementDeviceInterface transmitter, String unit, boolean active, UUID calcIdentifier) {
+      this.stateIdentity = stateIdentity;
+      this.name = name;
+      this.gain = gain;
+      this.lagTime = lagTime;
+      this.leadTime = leadTime;
+      this.lagTime2 = lagTime2;
+      this.deadTime = deadTime;
+      this.inputBias = inputBias;
+      this.outputBias = outputBias;
+      this.state1 = state1;
+      this.state2 = state2;
+      this.deadTimeBuffer = deadTimeBuffer;
+      this.deadTimeWriteIndex = deadTimeWriteIndex;
+      this.initialized = initialized;
+      this.output = output;
+      this.transmitter = transmitter;
+      this.unit = unit;
+      this.active = active;
+      this.calcIdentifier = calcIdentifier;
+    }
   }
 }

--- a/src/main/java/neqsim/process/controllerdevice/TransferFunctionBlock.java
+++ b/src/main/java/neqsim/process/controllerdevice/TransferFunctionBlock.java
@@ -304,6 +304,7 @@ public class TransferFunctionBlock extends NamedBaseClass
     deadTimeBuffer = null;
     deadTimeWriteIndex = 0;
     output = outputBias;
+    calcIdentifier = null;
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/process/controllerdevice/ControlBlockTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ControlBlockTransientStateTransactionTest.java
@@ -1,0 +1,294 @@
+package neqsim.process.controllerdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.dynamics.TransientStepIdentifier;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.measurementdevice.PressureTransmitter;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Quantitative identity, rollback, replay, and restart evidence for native control blocks. */
+class ControlBlockTransientStateTransactionTest extends neqsim.NeqSimTest {
+  private static final double TOLERANCE = 0.0;
+
+  @Test
+  void multiAreaRollbackRestoresBindingsConfigurationStateAndExactReplay() {
+    PressureTransmitter transmitter = createTransmitter(10.0);
+    TransferFunctionBlock transfer = createTransferBlock(transmitter);
+    LogicBlock logic = createLogicBlock(transmitter);
+    ProcessSystem controlArea = new ProcessSystem("control area");
+    controlArea.add(transfer);
+    ProcessSystem safeguardingArea = new ProcessSystem("safeguarding area");
+    safeguardingArea.add(logic);
+    ProcessModel model = new ProcessModel();
+    model.add("control", controlArea);
+    model.add("safeguarding", safeguardingArea);
+
+    UUID initialId = TransientStepIdentifier.deterministicPhysicalStep("control-block-replay", 0L);
+    transfer.runTransient(0.0, 1.0, initialId);
+    logic.runTransient(0.0, 1.0, initialId);
+    double initialTransferOutput = transfer.getOutput();
+    double initialLogicOutput = logic.getOutput();
+    String transferIdentity = transfer.getTransientStateIdentity();
+    String logicIdentity = logic.getTransientStateIdentity();
+
+    TransientTransactionCoverage coverage = model.getTransientTransactionCoverage();
+    assertEquals(2, coverage.getProcessElementCount());
+    assertEquals(2, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete());
+
+    UUID[] stepIds = new UUID[] { TransientStepIdentifier.deterministicPhysicalStep("control-block-replay", 1L),
+        TransientStepIdentifier.deterministicPhysicalStep("control-block-replay", 2L),
+        TransientStepIdentifier.deterministicPhysicalStep("control-block-replay", 3L) };
+    double[] pressures = new double[] { 20.0, 30.0, 15.0 };
+    double[] trialOutputs = new double[pressures.length];
+
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+    for (int i = 0; i < pressures.length; i++) {
+      transmitter.getStream().setPressure(pressures[i], "bara");
+      transfer.runTransient(0.0, 1.0, stepIds[i]);
+      trialOutputs[i] = transfer.getOutput();
+    }
+    logic.runTransient(0.0, 1.0, stepIds[0]);
+    double trialLogicOutput = logic.getOutput();
+
+    transfer.setName("trial transfer");
+    transfer.setGain(9.0);
+    transfer.setLagTime(12.0);
+    transfer.setLagTime2(13.0);
+    transfer.setLeadTime(7.0);
+    transfer.setDeadTime(8.0);
+    transfer.setInputBias(5.0);
+    transfer.setOutputBias(6.0);
+    transfer.setTransmitter(createTransmitter(99.0));
+    transfer.setUnit("trial");
+    transfer.setActive(false);
+    logic.setName("trial logic");
+    logic.addFixedInput(false);
+    logic.setEqualityTolerance(0.25);
+    logic.setUnit("trial");
+    logic.setActive(false);
+    transaction.rollback();
+
+    assertEquals(transferIdentity, transfer.getTransientStateIdentity());
+    assertEquals(logicIdentity, logic.getTransientStateIdentity());
+    assertEquals("TF-100", transfer.getName());
+    assertEquals(2.0, transfer.getGain(), TOLERANCE);
+    assertEquals(4.0, transfer.getLagTime(), TOLERANCE);
+    assertEquals(6.0, transfer.getLagTime2(), TOLERANCE);
+    assertEquals(1.0, transfer.getLeadTime(), TOLERANCE);
+    assertEquals(2.0, transfer.getDeadTime(), TOLERANCE);
+    assertEquals(1.0, transfer.getInputBias(), TOLERANCE);
+    assertEquals(3.0, transfer.getOutputBias(), TOLERANCE);
+    assertSame(transmitter, transfer.getTransmitter());
+    assertEquals("bara", transfer.getUnit());
+    assertTrue(transfer.isActive());
+    assertEquals(initialTransferOutput, transfer.getOutput(), TOLERANCE);
+    assertEquals("LS-100", logic.getName());
+    assertEquals(1, logic.getInputs().size());
+    assertSame(transmitter, logic.getInputs().get(0).getDevice());
+    assertEquals(1.0e-6, logic.getEqualityTolerance(), TOLERANCE);
+    assertEquals("[bool]", logic.getUnit());
+    assertTrue(logic.isActive());
+    assertEquals(initialLogicOutput, logic.getOutput(), TOLERANCE);
+    assertFalse(transfer.hasRunTransient(stepIds[0]));
+    assertFalse(logic.hasRunTransient(stepIds[0]));
+
+    for (int i = 0; i < pressures.length; i++) {
+      transmitter.getStream().setPressure(pressures[i], "bara");
+      transfer.runTransient(0.0, 1.0, stepIds[i]);
+      assertEquals(trialOutputs[i], transfer.getOutput(), TOLERANCE,
+          "rollback must restore the dead-time buffer and both lag states exactly");
+    }
+    logic.runTransient(0.0, 1.0, stepIds[0]);
+    assertEquals(trialLogicOutput, logic.getOutput(), TOLERANCE);
+  }
+
+  @Test
+  void physicalStepIdentityPreventsDuplicateControlStateAdvance() {
+    PressureTransmitter transmitter = createTransmitter(10.0);
+    TransferFunctionBlock transfer = createTransferBlock(transmitter);
+    LogicBlock logic = createLogicBlock(transmitter);
+    UUID initialId = TransientStepIdentifier.deterministicPhysicalStep("control-block-id", 0L);
+    transfer.runTransient(0.0, 1.0, initialId);
+    logic.runTransient(0.0, 1.0, initialId);
+
+    transmitter.getStream().setPressure(20.0, "bara");
+    UUID physicalStepId = TransientStepIdentifier.deterministicPhysicalStep("control-block-id", 1L);
+    transfer.runTransient(0.0, 1.0, physicalStepId);
+    logic.runTransient(0.0, 1.0, physicalStepId);
+    double transferAfterFirstEvaluation = transfer.getOutput();
+    double logicAfterFirstEvaluation = logic.getOutput();
+
+    transmitter.getStream().setPressure(50.0, "bara");
+    transfer.runTransient(0.0, 1.0, physicalStepId);
+    logic.runTransient(0.0, 1.0, physicalStepId);
+
+    assertEquals(transferAfterFirstEvaluation, transfer.getOutput(), TOLERANCE);
+    assertEquals(logicAfterFirstEvaluation, logic.getOutput(), TOLERANCE);
+    assertTrue(transfer.hasRunTransient(physicalStepId));
+    assertTrue(logic.hasRunTransient(physicalStepId));
+  }
+
+  @Test
+  void processSystemTransactionalStepCommitsBothControlBlocksAndClock() {
+    PressureTransmitter transmitter = createTransmitter(20.0);
+    TransferFunctionBlock transfer = createTransferBlock(transmitter);
+    LogicBlock logic = createLogicBlock(transmitter);
+    ProcessSystem process = new ProcessSystem("control-block commit");
+    process.add(transfer);
+    process.add(logic);
+    UUID stepId = TransientStepIdentifier.deterministicPhysicalStep("control-block-commit", 0L);
+
+    process.runTransientTransactional(0.5, stepId);
+
+    assertEquals(0.5, process.getTime(), TOLERANCE);
+    assertEquals(stepId, process.getCalculationIdentifier());
+    assertTrue(transfer.hasRunTransient(stepId));
+    assertTrue(logic.hasRunTransient(stepId));
+    assertEquals(1.0, logic.getOutput(), TOLERANCE);
+  }
+
+  @Test
+  void serializedSnapshotsPreserveStableIdentitiesSharedBindingsAndContinuation() throws Exception {
+    PressureTransmitter transmitter = createTransmitter(10.0);
+    TransferFunctionBlock transfer = createTransferBlock(transmitter);
+    LogicBlock logic = createLogicBlock(transmitter);
+    UUID initialId = TransientStepIdentifier.deterministicPhysicalStep("control-block-restart", 0L);
+    transfer.runTransient(0.0, 1.0, initialId);
+    logic.runTransient(0.0, 1.0, initialId);
+    TransferFunctionBlock.TransferFunctionState transferSnapshot = transfer.captureTransientState();
+    LogicBlock.LogicBlockState logicSnapshot = logic.captureTransientState();
+    String transferIdentity = transfer.getTransientStateIdentity();
+    String logicIdentity = logic.getTransientStateIdentity();
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(transfer);
+      output.writeObject(logic);
+      output.writeObject(transferSnapshot);
+      output.writeObject(logicSnapshot);
+      serialized = bytes.toByteArray();
+    }
+
+    TransferFunctionBlock restoredTransfer;
+    LogicBlock restoredLogic;
+    TransferFunctionBlock.TransferFunctionState restoredTransferSnapshot;
+    LogicBlock.LogicBlockState restoredLogicSnapshot;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restoredTransfer = (TransferFunctionBlock) input.readObject();
+      restoredLogic = (LogicBlock) input.readObject();
+      restoredTransferSnapshot = (TransferFunctionBlock.TransferFunctionState) input.readObject();
+      restoredLogicSnapshot = (LogicBlock.LogicBlockState) input.readObject();
+    }
+
+    restoredTransfer.restoreTransientState(restoredTransferSnapshot);
+    restoredLogic.restoreTransientState(restoredLogicSnapshot);
+    assertEquals(transferIdentity, restoredTransfer.getTransientStateIdentity());
+    assertEquals(logicIdentity, restoredLogic.getTransientStateIdentity());
+    assertSame(restoredTransfer.getTransmitter(), restoredLogic.getInputs().get(0).getDevice());
+
+    PressureTransmitter restoredTransmitter = (PressureTransmitter) restoredTransfer.getTransmitter();
+    restoredTransmitter.getStream().setPressure(25.0, "bara");
+    transmitter.getStream().setPressure(25.0, "bara");
+    UUID nextId = TransientStepIdentifier.deterministicPhysicalStep("control-block-restart", 1L);
+    restoredTransfer.runTransient(0.0, 1.0, nextId);
+    restoredLogic.runTransient(0.0, 1.0, nextId);
+    transfer.runTransient(0.0, 1.0, nextId);
+    logic.runTransient(0.0, 1.0, nextId);
+    assertEquals(transfer.getOutput(), restoredTransfer.getOutput(), TOLERANCE);
+    assertEquals(logic.getOutput(), restoredLogic.getOutput(), TOLERANCE);
+  }
+
+  @Test
+  void foreignSnapshotsAndUnqualifiedSubclassesFailBeforeMutation() {
+    TransferFunctionBlock firstTransfer = createTransferBlock(createTransmitter(10.0));
+    TransferFunctionBlock secondTransfer = createTransferBlock(createTransmitter(20.0));
+    secondTransfer.setGain(7.0);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondTransfer.restoreTransientState(firstTransfer.captureTransientState()));
+    assertEquals(7.0, secondTransfer.getGain(), TOLERANCE);
+
+    LogicBlock firstLogic = createLogicBlock(createTransmitter(10.0));
+    LogicBlock secondLogic = createLogicBlock(createTransmitter(20.0));
+    secondLogic.addFixedInput(true);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondLogic.restoreTransientState(firstLogic.captureTransientState()));
+    assertEquals(2, secondLogic.getInputs().size());
+
+    ProcessSystem process = new ProcessSystem("control-block subclass coverage");
+    process.add(new StatefulTransferSubclass("custom transfer"));
+    process.add(new StatefulLogicSubclass("custom logic"));
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertEquals(2, coverage.getProcessElementCount());
+    assertEquals(2, coverage.getParticipantCount());
+    assertFalse(coverage.isComplete());
+    assertTrue(coverage.getBlockingIssues().get(0).contains("subclass-owned mutable state"));
+    assertTrue(coverage.getBlockingIssues().get(1).contains("subclass-owned mutable state"));
+    assertThrows(IllegalStateException.class, process::beginTransientStepTransaction);
+  }
+
+  private static TransferFunctionBlock createTransferBlock(PressureTransmitter transmitter) {
+    TransferFunctionBlock block = new TransferFunctionBlock("TF-100", TransferFunctionBlock.Type.SECOND_ORDER);
+    block.setGain(2.0);
+    block.setLagTime(4.0);
+    block.setLagTime2(6.0);
+    block.setLeadTime(1.0);
+    block.setDeadTime(2.0);
+    block.setInputBias(1.0);
+    block.setOutputBias(3.0);
+    block.setUnit("bara");
+    block.setTransmitter(transmitter);
+    return block;
+  }
+
+  private static LogicBlock createLogicBlock(PressureTransmitter transmitter) {
+    LogicBlock block = new LogicBlock("LS-100", LogicBlock.Operator.AND);
+    block.addInput(transmitter, 15.0, LogicBlock.Comparator.GREATER_EQUAL);
+    return block;
+  }
+
+  private static PressureTransmitter createTransmitter(double pressureBara) {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, pressureBara);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream("feed", fluid);
+    stream.setPressure(pressureBara, "bara");
+    return new PressureTransmitter("PT-100", stream);
+  }
+
+  private static final class StatefulTransferSubclass extends TransferFunctionBlock {
+    private static final long serialVersionUID = 1000L;
+    @SuppressWarnings("unused")
+    private double customState;
+
+    private StatefulTransferSubclass(String name) {
+      super(name, Type.FIRST_ORDER_LAG);
+    }
+  }
+
+  private static final class StatefulLogicSubclass extends LogicBlock {
+    private static final long serialVersionUID = 1000L;
+    @SuppressWarnings("unused")
+    private double customState;
+
+    private StatefulLogicSubclass(String name) {
+      super(name, Operator.AND);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/controllerdevice/ControlBlockTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ControlBlockTransientStateTransactionTest.java
@@ -142,6 +142,11 @@ class ControlBlockTransientStateTransactionTest extends neqsim.NeqSimTest {
     assertEquals(logicAfterFirstEvaluation, logic.getOutput(), TOLERANCE);
     assertTrue(transfer.hasRunTransient(physicalStepId));
     assertTrue(logic.hasRunTransient(physicalStepId));
+
+    transfer.reset();
+    assertFalse(transfer.hasRunTransient(physicalStepId), "reset must reopen deterministic replay from initial state");
+    transfer.runTransient(0.0, 1.0, physicalStepId);
+    assertTrue(transfer.hasRunTransient(physicalStepId));
   }
 
   @Test

--- a/src/test/java/neqsim/process/controllerdevice/TransferFunctionBlockTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/TransferFunctionBlockTest.java
@@ -183,9 +183,8 @@ class TransferFunctionBlockTest {
     block.setTransmitter(transmitter);
 
     // Run many steps to reach steady state
-    UUID id = UUID.randomUUID();
     for (int i = 0; i < 1000; i++) {
-      block.runTransient(0.0, 1.0, id);
+      block.runTransient(0.0, 1.0, UUID.randomUUID());
     }
 
     // Should converge to K * u = 2.0 * 5.0 = 10.0
@@ -201,16 +200,15 @@ class TransferFunctionBlockTest {
     StubTransmitter transmitter = new StubTransmitter(0.0);
     block.setTransmitter(transmitter);
 
-    UUID id = UUID.randomUUID();
     // Initial step to initialize
-    block.runTransient(0.0, 1.0, id);
+    block.runTransient(0.0, 1.0, UUID.randomUUID());
 
     // Step change in input
     transmitter.setValue(10.0);
 
     // After one time constant (tau=10s, dt=1s), should reach ~63.2% of final value
     for (int i = 0; i < 10; i++) {
-      block.runTransient(0.0, 1.0, id);
+      block.runTransient(0.0, 1.0, UUID.randomUUID());
     }
 
     double expectedApprox = 10.0 * (1.0 - Math.exp(-1.0)); // ~6.32
@@ -228,9 +226,8 @@ class TransferFunctionBlockTest {
     StubTransmitter transmitter = new StubTransmitter(10.0);
     block.setTransmitter(transmitter);
 
-    UUID id = UUID.randomUUID();
     for (int i = 0; i < 2000; i++) {
-      block.runTransient(0.0, 1.0, id);
+      block.runTransient(0.0, 1.0, UUID.randomUUID());
     }
 
     // Steady state: K * u = 1.5 * 10.0 = 15.0
@@ -246,23 +243,21 @@ class TransferFunctionBlockTest {
     StubTransmitter transmitter = new StubTransmitter(0.0);
     block.setTransmitter(transmitter);
 
-    UUID id = UUID.randomUUID();
-
     // Initialize with zero
-    block.runTransient(0.0, 1.0, id);
+    block.runTransient(0.0, 1.0, UUID.randomUUID());
 
     // Step change at t=1
     transmitter.setValue(10.0);
 
     // Run for less than dead time - output should still be ~0
     for (int i = 0; i < 3; i++) {
-      block.runTransient(0.0, 1.0, id);
+      block.runTransient(0.0, 1.0, UUID.randomUUID());
     }
     assertEquals(0.0, block.getOutput(), 0.1);
 
     // Run past dead time - output should reach the step value
     for (int i = 0; i < 5; i++) {
-      block.runTransient(0.0, 1.0, id);
+      block.runTransient(0.0, 1.0, UUID.randomUUID());
     }
     assertEquals(10.0, block.getOutput(), 0.1);
   }
@@ -277,9 +272,8 @@ class TransferFunctionBlockTest {
     StubTransmitter transmitter = new StubTransmitter(4.0);
     block.setTransmitter(transmitter);
 
-    UUID id = UUID.randomUUID();
     for (int i = 0; i < 2000; i++) {
-      block.runTransient(0.0, 1.0, id);
+      block.runTransient(0.0, 1.0, UUID.randomUUID());
     }
 
     // Steady state: K * u = 3.0 * 4.0 = 12.0
@@ -299,9 +293,8 @@ class TransferFunctionBlockTest {
     StubTransmitter transmitter = new StubTransmitter(15.0);
     block.setTransmitter(transmitter);
 
-    UUID id = UUID.randomUUID();
     for (int i = 0; i < 1000; i++) {
-      block.runTransient(0.0, 1.0, id);
+      block.runTransient(0.0, 1.0, UUID.randomUUID());
     }
 
     assertEquals(60.0, block.getOutput(), 0.1);
@@ -317,9 +310,8 @@ class TransferFunctionBlockTest {
     StubTransmitter transmitter = new StubTransmitter(100.0);
     block.setTransmitter(transmitter);
 
-    UUID id = UUID.randomUUID();
     for (int i = 0; i < 100; i++) {
-      block.runTransient(0.0, 1.0, id);
+      block.runTransient(0.0, 1.0, UUID.randomUUID());
     }
     assertTrue(block.getOutput() > 50.0);
 
@@ -349,9 +341,8 @@ class TransferFunctionBlockTest {
     block.setGain(1.0);
     block.setLagTime(1.0);
 
-    UUID id = UUID.randomUUID();
     for (int i = 0; i < 100; i++) {
-      block.runTransient(5.0, 1.0, id);
+      block.runTransient(5.0, 1.0, UUID.randomUUID());
     }
 
     // Steady state should converge to K * u = 1.0 * 5.0 = 5.0
@@ -368,20 +359,19 @@ class TransferFunctionBlockTest {
     StubTransmitter transmitter = new StubTransmitter(0.0);
     block.setTransmitter(transmitter);
 
-    UUID id = UUID.randomUUID();
-    block.runTransient(0.0, 1.0, id);
+    block.runTransient(0.0, 1.0, UUID.randomUUID());
 
     // Step change
     transmitter.setValue(10.0);
 
     // During dead time, output should still be close to zero
-    block.runTransient(0.0, 1.0, id);
-    block.runTransient(0.0, 1.0, id);
+    block.runTransient(0.0, 1.0, UUID.randomUUID());
+    block.runTransient(0.0, 1.0, UUID.randomUUID());
     assertEquals(0.0, block.getOutput(), 0.5);
 
     // After dead time + long enough for lag, should approach steady state
     for (int i = 0; i < 200; i++) {
-      block.runTransient(0.0, 1.0, id);
+      block.runTransient(0.0, 1.0, UUID.randomUUID());
     }
     assertEquals(10.0, block.getOutput(), 0.5);
   }


### PR DESCRIPTION
## Summary

Advances #2911 with DYN-C007: identity-preserving transient-step transactions for NeqSim's concrete native control blocks.

- makes `TransferFunctionBlock` and `LogicBlock` typed `TransientStateParticipant` implementations
- snapshots/restores every mutable dynamic/configuration field, calculation identity, names, units, activity, and original signal bindings
- deep-copies the transfer-function dead-time buffer and restores both lag states for exact rejected-step replay
- preserves logic input-list membership and referenced measurement-device identities
- makes both blocks idempotent for repeated evaluation of the same non-null physical-step UUID
- clears the remembered physical-step UUID when `TransferFunctionBlock.reset()` reinitializes deterministic state
- rejects unqualified subclasses before trial mutation
- adds an additive `TransferFunctionBlock.getTransmitter()` diagnostic accessor
- documents usage, compatibility, and the limits of the rollback evidence

## Quantitative evidence

The new regression suite verifies:

- multi-area `ProcessModel` coverage: **2 process elements / 2 participants / 0 blockers**
- exact (`0.0` tolerance) transfer-function continuation across three replayed pressure steps, including a two-sample delay buffer and two lag states
- exact logic output replay
- `ProcessSystem.runTransientTransactional` commits both blocks and the process clock/calculation identity together
- duplicate evaluation of one physical-step UUID does not advance either block
- reset clears transfer-function step identity and permits deterministic reinitialization
- Java serialization preserves stable participant identities, the shared transmitter binding, and next-step continuation
- foreign snapshots are rejected without mutation
- both subclass families fail coverage before a transaction opens

## Compatibility and boundaries

Legacy callers that already use a fresh UUID per physical timestep retain normal behavior. Reusing one UUID across multiple physical timesteps was inconsistent with the documented #2911 physical-step identity contract; the updated legacy tests now use a fresh UUID per step.

This tranche changes only shared control/orchestration behavior owned by #2911. It does not implement #2935 species transport or #2907 multiphase closures/slugging. Transaction coverage proves rollback mechanics, not control tuning, SIL/safety approval, physical-model validation, or OTS qualification. External callback effects remain outside the rollback boundary.

## Documentation impact

Updated:

- `docs/process/controllers.md` with registration, transaction, UUID/reset, subclass, and safety-boundary guidance
- `docs/process/dynamic-capability-contract.md` with the exact state and identity contract for both native blocks
- production Javadocs for the public accessor, snapshot behavior, identities, and fail-closed coverage

## Validation

Base: `231fc66f42a573853858b3009dbc99a9ac996c1d`
Head: `e231d6256e62b10d7bc178214c114879e7de809e`

Passed locally on the exact source:

- `python devtools/run_spotless.py apply` (stable)
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`
- `./mvnw -q -DskipITs -Dtest=ControlBlockTransientStateTransactionTest,TransferFunctionBlockTest,LogicBlockTest test`
- `./mvnw -q -DskipITs -Dtest=ControlBlockTransientStateTransactionTest,ControllerTransientStateTransactionTest,TransientStepTransactionTest,PressureTransmitterTransientStateTransactionTest,TemperatureAndDifferentialPressureTransmitterTransientStateTransactionTest test`
- `git diff --check`

A writable task-local Maven repository was used because the runtime's `/root/.m2` is read-only.

Hosted GitHub CI passed on the exact head `e231d6256e62b10d7bc178214c114879e7de809e` on August 14, 2026:

- Java 8 and Java 21 tests on Ubuntu and Windows
- all four Java 21 slow-test shards and Javadocs
- Spotless, pre-commit, documentation search, CodeQL, and PaperLab