### PR TITLE
fix(column): make Jacobian base-state ownership reproducible

### DIFF
--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -255,10 +255,17 @@ targets manipulated through condenser or reboiler temperature.
 - Solves a simultaneous block of MESH residual equations with liquid component flows, tray
   temperature, and vapor flow as tray variables.
 - Builds a finite-difference block-tridiagonal Jacobian from neighboring tray couplings and uses a
-  guarded Newton line search with flow and temperature trust limits.
+  guarded Newton line search with flow and temperature trust limits. Before each build, up to three
+  full-column thermodynamic passes retain the lowest finite MESH-residual state and stop early when
+  consecutive residual vectors agree within one tenth of the outer tolerance. Every perturbed
+  column then starts from that same frozen K-value, vapor-flow, and enthalpy state; exact restoration
+  prevents finite-difference column order from silently refining the base residual.
 - Leaves the accepted line-search trial applied and reuses its evaluated MESH residual. The solver
   does not restore the old tray state and repeat the same thermodynamic evaluation merely to apply
   a step that the line search has already accepted.
+- Package-level solver diagnostics record Jacobian base-refinement passes and the residual-vector
+  mutation measured after each completed build. The mutation is expected to be bitwise zero; these
+  counters support deterministic regression and do not change the public column API.
 - Work diagnostics classify every currently assembled derivative column as finite-difference;
   `getLastNaphtaliAnalyticJacobianColumns()` remains available for compatibility and reports zero
   until a mixed analytic/numerical assembly is implemented.

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -255,13 +255,14 @@ targets manipulated through condenser or reboiler temperature.
 - Solves a simultaneous block of MESH residual equations with liquid component flows, tray
   temperature, and vapor flow as tray variables.
 - Builds a finite-difference block-tridiagonal Jacobian from neighboring tray couplings and uses a
-  guarded Newton line search with flow and temperature trust limits. Before each build, at least one
-  and up to three full-column thermodynamic passes refresh the base; the lowest finite MESH-residual
-  state among those passes is retained, while the incoming derived state is only a non-finite
-  fallback. Refinement stops early when consecutive residual vectors agree within one tenth of the
-  outer tolerance. Every perturbed column then starts from that same frozen K-value, vapor-flow, and
-  enthalpy state; exact restoration prevents finite-difference column order from silently refining
-  the base residual.
+  guarded Newton line search with flow and temperature trust limits. Before each build, up to one
+  full-column thermodynamic pass per local finite-difference variable refreshes the base. This
+  matches the restore-evaluation budget that the frozen base replaces. The lowest finite
+  MESH-residual state among those passes is retained, while the incoming derived state is only a
+  non-finite fallback. Refinement stops early when consecutive residual vectors agree within one
+  tenth of the outer tolerance. Every perturbed column then starts from that same frozen K-value,
+  vapor-flow, and enthalpy state; exact restoration prevents finite-difference column order from
+  silently refining the base residual.
 - Leaves the accepted line-search trial applied and reuses its evaluated MESH residual. The solver
   does not restore the old tray state and repeat the same thermodynamic evaluation merely to apply
   a step that the line search has already accepted.

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -258,9 +258,10 @@ targets manipulated through condenser or reboiler temperature.
   guarded Newton line search with flow and temperature trust limits. Before each build, up to one
   full-column thermodynamic pass per local finite-difference variable refreshes the base. This
   matches the restore-evaluation budget that the frozen base replaces. The lowest finite
-  MESH-residual state among those passes is retained, while the incoming derived state is only a
-  non-finite fallback. Refinement stops early when consecutive residual vectors agree within one
-  tenth of the outer tolerance. Every perturbed column then starts from that same frozen K-value,
+  latest finite state among those passes is retained so the base owns the most thermodynamically
+  consistent K-value fixed point, while the incoming derived state is only a non-finite fallback.
+  Refinement stops early when consecutive residual vectors agree within one tenth of the outer
+  tolerance. Every perturbed column then starts from that same frozen K-value,
   vapor-flow, and enthalpy state; exact restoration prevents finite-difference column order from
   silently refining the base residual.
 - Leaves the accepted line-search trial applied and reuses its evaluated MESH residual. The solver

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -261,8 +261,11 @@ targets manipulated through condenser or reboiler temperature.
   among those passes is retained so the base owns the most thermodynamically consistent K-value
   fixed point, while the incoming derived state is only a non-finite fallback. Refinement stops
   early when consecutive residual vectors agree within one tenth of the outer tolerance. Every
-  perturbed column then starts from that same frozen K-value, vapor-flow, and enthalpy state; exact
-  restoration prevents finite-difference column order from silently refining the base residual.
+  perturbed column then starts from that same frozen K-value, vapor-flow, and enthalpy state and
+  receives up to six local fugacity fixed-point sweeps. This matches the two three-sweep passes
+  normally needed to stabilize a retained base without changing the global cold- or warm-state
+  thermodynamic limits. Exact restoration prevents finite-difference column order from silently
+  refining the base residual.
 - Starts every backtracking line-search trial from the same primary and derived thermodynamic base,
   so a rejected larger step cannot change the K-value seed of the next trial. The accepted trial
   remains applied and its evaluated MESH residual is reused; the solver does not repeat the same

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -271,6 +271,9 @@ targets manipulated through condenser or reboiler temperature.
 - Retries a rejected retained-state solve from the normal cold initializer before materializing the
   rejected tray profile. This keeps the live column and its product caches unchanged until a cold
   recovery attempt has either been accepted or exhausted.
+- Restores the intended single gas or liquid phase after composition initialization when applying
+  no-side-draw products. This prevents initialization from re-expanding both phase slots with the
+  same accepted component inventory.
 - Package-level solver diagnostics record Jacobian base-refinement passes and the residual-vector
   mutation measured after each completed build. The mutation is expected to be bitwise zero; these
   counters support deterministic regression and do not change the public column API.

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -261,11 +261,9 @@ targets manipulated through condenser or reboiler temperature.
   among those passes is retained so the base owns the most thermodynamically consistent K-value
   fixed point, while the incoming derived state is only a non-finite fallback. Refinement stops
   early when consecutive residual vectors agree within one tenth of the outer tolerance. Every
-  perturbed column then starts from that same frozen K-value, vapor-flow, and enthalpy state and
-  receives up to six local fugacity fixed-point sweeps. This matches the two three-sweep passes
-  normally needed to stabilize a retained base without changing the global cold- or warm-state
-  thermodynamic limits. Exact restoration prevents finite-difference column order from silently
-  refining the base residual.
+  perturbed column then starts from that same frozen K-value, vapor-flow, and enthalpy state.
+  Exact restoration prevents finite-difference column order from silently refining the base
+  residual.
 - Starts every backtracking line-search trial from the same primary and derived thermodynamic base,
   so a rejected larger step cannot change the K-value seed of the next trial. The accepted trial
   remains applied and its evaluated MESH residual is reused; the solver does not repeat the same

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -257,16 +257,16 @@ targets manipulated through condenser or reboiler temperature.
 - Builds a finite-difference block-tridiagonal Jacobian from neighboring tray couplings and uses a
   guarded Newton line search with flow and temperature trust limits. Before each build, up to one
   full-column thermodynamic pass per local finite-difference variable refreshes the base. This
-  matches the restore-evaluation budget that the frozen base replaces. The lowest finite
-  latest finite state among those passes is retained so the base owns the most thermodynamically
-  consistent K-value fixed point, while the incoming derived state is only a non-finite fallback.
-  Refinement stops early when consecutive residual vectors agree within one tenth of the outer
-  tolerance. Every perturbed column then starts from that same frozen K-value,
-  vapor-flow, and enthalpy state; exact restoration prevents finite-difference column order from
-  silently refining the base residual.
-- Leaves the accepted line-search trial applied and reuses its evaluated MESH residual. The solver
-  does not restore the old tray state and repeat the same thermodynamic evaluation merely to apply
-  a step that the line search has already accepted.
+  matches the restore-evaluation budget that the frozen base replaces. The latest finite state
+  among those passes is retained so the base owns the most thermodynamically consistent K-value
+  fixed point, while the incoming derived state is only a non-finite fallback. Refinement stops
+  early when consecutive residual vectors agree within one tenth of the outer tolerance. Every
+  perturbed column then starts from that same frozen K-value, vapor-flow, and enthalpy state; exact
+  restoration prevents finite-difference column order from silently refining the base residual.
+- Starts every backtracking line-search trial from the same primary and derived thermodynamic base,
+  so a rejected larger step cannot change the K-value seed of the next trial. The accepted trial
+  remains applied and its evaluated MESH residual is reused; the solver does not repeat the same
+  thermodynamic evaluation merely to apply a step that the line search has already accepted.
 - Package-level solver diagnostics record Jacobian base-refinement passes and the residual-vector
   mutation measured after each completed build. The mutation is expected to be bitwise zero; these
   counters support deterministic regression and do not change the public column API.

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -261,9 +261,11 @@ targets manipulated through condenser or reboiler temperature.
   among those passes is retained so the base owns the most thermodynamically consistent K-value
   fixed point, while the incoming derived state is only a non-finite fallback. Refinement stops
   early when consecutive residual vectors agree within one tenth of the outer tolerance. Every
-  perturbed column then starts from that same frozen K-value, vapor-flow, and enthalpy state.
-  Exact restoration prevents finite-difference column order from silently refining the base
-  residual.
+  perturbed column then starts from that same frozen K-value, vapor-flow, and enthalpy state. The
+  Jacobian uses symmetric perturbations away from flow and temperature lower bounds to reduce
+  first-order truncation error; variables near a bound retain a one-sided difference. This costs at
+  most one additional local tray-thermodynamic evaluation per finite-difference variable. Exact
+  restoration prevents finite-difference column order from silently refining the base residual.
 - Starts every backtracking line-search trial from the same primary and derived thermodynamic base,
   so a rejected larger step cannot change the K-value seed of the next trial. The accepted trial
   remains applied and its evaluated MESH residual is reused; the solver does not repeat the same

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -261,15 +261,16 @@ targets manipulated through condenser or reboiler temperature.
   among those passes is retained so the base owns the most thermodynamically consistent K-value
   fixed point, while the incoming derived state is only a non-finite fallback. Refinement stops
   early when consecutive residual vectors agree within one tenth of the outer tolerance. Every
-  perturbed column then starts from that same frozen K-value, vapor-flow, and enthalpy state. The
-  Jacobian uses symmetric perturbations away from flow and temperature lower bounds to reduce
-  first-order truncation error; variables near a bound retain a one-sided difference. This costs at
-  most one additional local tray-thermodynamic evaluation per finite-difference variable. Exact
-  restoration prevents finite-difference column order from silently refining the base residual.
+  perturbed column then starts from that same frozen K-value, vapor-flow, and enthalpy state.
+  Exact restoration prevents finite-difference column order from silently refining the base
+  residual.
 - Starts every backtracking line-search trial from the same primary and derived thermodynamic base,
   so a rejected larger step cannot change the K-value seed of the next trial. The accepted trial
   remains applied and its evaluated MESH residual is reused; the solver does not repeat the same
   thermodynamic evaluation merely to apply a step that the line search has already accepted.
+- Retries a rejected retained-state solve from the normal cold initializer before materializing the
+  rejected tray profile. This keeps the live column and its product caches unchanged until a cold
+  recovery attempt has either been accepted or exhausted.
 - Package-level solver diagnostics record Jacobian base-refinement passes and the residual-vector
   mutation measured after each completed build. The mutation is expected to be bitwise zero; these
   counters support deterministic regression and do not change the public column API.

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -255,11 +255,13 @@ targets manipulated through condenser or reboiler temperature.
 - Solves a simultaneous block of MESH residual equations with liquid component flows, tray
   temperature, and vapor flow as tray variables.
 - Builds a finite-difference block-tridiagonal Jacobian from neighboring tray couplings and uses a
-  guarded Newton line search with flow and temperature trust limits. Before each build, up to three
-  full-column thermodynamic passes retain the lowest finite MESH-residual state and stop early when
-  consecutive residual vectors agree within one tenth of the outer tolerance. Every perturbed
-  column then starts from that same frozen K-value, vapor-flow, and enthalpy state; exact restoration
-  prevents finite-difference column order from silently refining the base residual.
+  guarded Newton line search with flow and temperature trust limits. Before each build, at least one
+  and up to three full-column thermodynamic passes refresh the base; the lowest finite MESH-residual
+  state among those passes is retained, while the incoming derived state is only a non-finite
+  fallback. Refinement stops early when consecutive residual vectors agree within one tenth of the
+  outer tolerance. Every perturbed column then starts from that same frozen K-value, vapor-flow, and
+  enthalpy state; exact restoration prevents finite-difference column order from silently refining
+  the base residual.
 - Leaves the accepted line-search trial applied and reuses its evaluated MESH residual. The solver
   does not restore the old tray state and repeat the same thermodynamic evaluation merely to apply
   a step that the line search has already accepted.

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnSolverFactory.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnSolverFactory.java
@@ -461,9 +461,10 @@ final class ColumnSolverFactory {
       boolean exactReuseExpected = !isAutoCandidateProbeMode() && column.willReuseNaphtaliSandholmWarmState();
       DistillationColumn warmStartCandidate = isAutoCandidateProbeMode() || exactReuseExpected ? null
           : createDampedFallbackCandidate(column);
-      DistillationColumn fallbackCandidate = shouldPrepareAcceleratedFallback() && !exactReuseExpected
-          ? createDampedFallbackCandidate(column)
-          : null;
+      // The same untouched copy guards both validation and coordinated fallback. A rejected
+      // simultaneous solve may have mutated live trays and product caches, so starting damped
+      // substitution from the live column can duplicate retained feed inventory.
+      DistillationColumn fallbackCandidate = warmStartCandidate;
       boolean accepted = false;
       boolean fallbackApplied = false;
       try {

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -70,6 +70,9 @@ public class NaphtaliSandholmSolver {
   /** Convergence tolerance for the largest absolute logarithmic K-value update. */
   private static final double THERMO_K_VALUE_TOLERANCE = 1.0e-8;
 
+  /** Maximum residual-aware full-column refinements before a finite-difference Jacobian build. */
+  private static final int JACOBIAN_BASE_REFINEMENT_LIMIT = 3;
+
   /** Logger for this class. */
   private static final Logger logger = LogManager.getLogger(NaphtaliSandholmSolver.class);
 
@@ -285,6 +288,12 @@ public class NaphtaliSandholmSolver {
   /** Number of cached tray thermodynamic evaluations reused in the last solve. */
   private int lastThermoCacheHitCount;
 
+  /** Number of full-column thermodynamic refinements used to prepare Jacobian base states. */
+  private int lastJacobianBaseRefinementCount;
+
+  /** Largest residual-vector mutation measured across a completed Jacobian build. */
+  private double lastJacobianBaseResidualMutation;
+
   /** Time spent assembling Jacobian matrices in the last solve. */
   private double lastJacobianBuildTimeSeconds;
 
@@ -429,6 +438,24 @@ public class NaphtaliSandholmSolver {
    */
   int getLastThermoCacheHitCount() {
     return lastThermoCacheHitCount;
+  }
+
+  /**
+   * Get the number of residual-aware full-column refinements used to prepare Jacobian base states.
+   *
+   * @return Jacobian base-state refinement count
+   */
+  int getLastJacobianBaseRefinementCount() {
+    return lastJacobianBaseRefinementCount;
+  }
+
+  /**
+   * Get the largest residual-vector mutation across a completed Jacobian build.
+   *
+   * @return L2 norm of the largest post-build residual difference at unchanged primary variables
+   */
+  double getLastJacobianBaseResidualMutation() {
+    return lastJacobianBaseResidualMutation;
   }
 
   /**
@@ -820,7 +847,15 @@ public class NaphtaliSandholmSolver {
           return true;
         }
 
-        // Compute Jacobian analytically
+        // Refine and freeze the derived K/enthalpy state that owns both the
+        // finite-difference base residual and every perturbed Jacobian column.
+        residual = refineJacobianBaseState(residual);
+        norm = vectorNorm(residual);
+        if (norm < bestNorm) {
+          bestNorm = norm;
+          saveTrayState(bestLiq, bestT, bestV);
+        }
+
         double[][] jacobian = computeJacobian(residual);
 
         // Solve J * dx = F using block-tridiagonal solver
@@ -987,6 +1022,8 @@ public class NaphtaliSandholmSolver {
     lastThermoKValueNonConvergedCount = 0;
     lastThermoMaxLogKValueUpdate = 0.0;
     lastThermoCacheHitCount = 0;
+    lastJacobianBaseRefinementCount = 0;
+    lastJacobianBaseResidualMutation = 0.0;
     lastJacobianBuildTimeSeconds = 0.0;
     lastBlockLinearSolveCount = 0;
     lastDenseLinearSolveCount = 0;
@@ -3172,21 +3209,24 @@ public class NaphtaliSandholmSolver {
     double pertSize = 1e-4;
     double minPert = 1e-8;
 
+    double[][] baseK = new double[N][C];
+    double[][] baseVap = new double[N][C];
+    double[] baseL = new double[N];
+    double[] baseHL = new double[N];
+    double[] baseHV = new double[N];
+    saveDerivedThermodynamicState(baseK, baseVap, baseL, baseHL, baseHV);
+
     for (int jj = 0; jj < N; jj++) {
       for (int k = 0; k < varsPerTray; k++) {
         int varIdx = jj * varsPerTray + k;
 
-        // Save original value
+        // Save and perturb one primary variable from the same frozen base state.
         double origVal = getVariable(jj, k);
         double h = Math.max(Math.abs(origVal) * pertSize, minPert);
-
-        // Perturb
         setVariable(jj, k, origVal + h);
-
-        // Re-evaluate thermo ONLY for the tray whose variable changed
         evaluateThermoForTray(jj);
 
-        // Compute perturbed residuals for affected trays (j-1, j, j+1)
+        // Only the perturbed tray and its two neighbors can depend on this variable.
         int jStart = Math.max(0, jj - 1);
         int jEnd = Math.min(N - 1, jj + 1);
         for (int j = jStart; j <= jEnd; j++) {
@@ -3197,15 +3237,138 @@ public class NaphtaliSandholmSolver {
           }
         }
 
-        // Restore
+        // Restore primary and derived state exactly. Re-evaluating thermo here
+        // would advance the K fixed point and give the next column a different base.
         setVariable(jj, k, origVal);
-        evaluateThermoForTray(jj);
+        restoreDerivedThermodynamicStateForTray(jj, baseK, baseVap, baseL, baseHL, baseHV);
       }
     }
 
+    double[] restoredResidual = computeResidual();
+    lastJacobianBaseResidualMutation = Math.max(lastJacobianBaseResidualMutation,
+        vectorDifferenceNorm(F0, restoredResidual));
     lastFiniteDifferenceJacobianColumns += totalVars;
     lastJacobianBuildTimeSeconds += (System.nanoTime() - jacobianStart) / 1.0e9;
     return J;
+  }
+
+  /**
+   * Refine the derived tray state before a finite-difference Jacobian build.
+   *
+   * <p>
+   * The primary Newton variables remain unchanged. Up to three full-column thermodynamic passes are evaluated, and the
+   * state with the smallest finite MESH residual is retained. Refinement stops when consecutive residual vectors differ
+   * by no more than one tenth of the outer tolerance. This replaces the accidental, column-order-dependent K-value
+   * refinement that previously occurred while restoring each finite-difference perturbation.
+   * </p>
+   *
+   * @param initialResidual residual at the current primary state
+   * @return residual owned by the retained derived thermodynamic state
+   */
+  private double[] refineJacobianBaseState(double[] initialResidual) {
+    double[] bestResidual = initialResidual.clone();
+    double bestNorm = vectorNorm(bestResidual);
+    double[] previousResidual = initialResidual;
+
+    double[][] bestK = new double[N][C];
+    double[][] bestVap = new double[N][C];
+    double[] bestL = new double[N];
+    double[] bestHL = new double[N];
+    double[] bestHV = new double[N];
+    saveDerivedThermodynamicState(bestK, bestVap, bestL, bestHL, bestHV);
+
+    double residualChangeTolerance = Math.max(1.0e-12, tolerance * 0.1);
+    for (int refinement = 0; refinement < JACOBIAN_BASE_REFINEMENT_LIMIT; refinement++) {
+      evaluateThermo();
+      lastJacobianBaseRefinementCount++;
+      double[] candidateResidual = computeResidual();
+      double candidateNorm = vectorNorm(candidateResidual);
+      double residualChange = vectorDifferenceNorm(previousResidual, candidateResidual);
+
+      if (Double.isFinite(candidateNorm) && candidateNorm < bestNorm) {
+        bestNorm = candidateNorm;
+        bestResidual = candidateResidual;
+        saveDerivedThermodynamicState(bestK, bestVap, bestL, bestHL, bestHV);
+      }
+      if (residualChange <= residualChangeTolerance) {
+        break;
+      }
+      previousResidual = candidateResidual;
+    }
+
+    restoreDerivedThermodynamicState(bestK, bestVap, bestL, bestHL, bestHV);
+    return bestResidual;
+  }
+
+  /**
+   * Save all derived thermodynamic tray values that participate in the MESH residual.
+   *
+   * @param saveK K-value destination
+   * @param saveVap vapor component-flow destination
+   * @param saveL total liquid-flow destination
+   * @param saveHL liquid enthalpy destination
+   * @param saveHV vapor enthalpy destination
+   */
+  private void saveDerivedThermodynamicState(double[][] saveK, double[][] saveVap, double[] saveL, double[] saveHL,
+      double[] saveHV) {
+    for (int j = 0; j < N; j++) {
+      System.arraycopy(K[j], 0, saveK[j], 0, C);
+      System.arraycopy(vap[j], 0, saveVap[j], 0, C);
+      saveL[j] = L[j];
+      saveHL[j] = hL[j];
+      saveHV[j] = hV[j];
+    }
+  }
+
+  /**
+   * Restore every derived thermodynamic tray value from a saved state.
+   *
+   * @param saveK saved K-values
+   * @param saveVap saved vapor component flows
+   * @param saveL saved liquid flows
+   * @param saveHL saved liquid enthalpies
+   * @param saveHV saved vapor enthalpies
+   */
+  private void restoreDerivedThermodynamicState(double[][] saveK, double[][] saveVap, double[] saveL, double[] saveHL,
+      double[] saveHV) {
+    for (int j = 0; j < N; j++) {
+      restoreDerivedThermodynamicStateForTray(j, saveK, saveVap, saveL, saveHL, saveHV);
+    }
+  }
+
+  /**
+   * Restore one tray's derived thermodynamic state.
+   *
+   * @param j tray index
+   * @param saveK saved K-values
+   * @param saveVap saved vapor component flows
+   * @param saveL saved liquid flows
+   * @param saveHL saved liquid enthalpies
+   * @param saveHV saved vapor enthalpies
+   */
+  private void restoreDerivedThermodynamicStateForTray(int j, double[][] saveK, double[][] saveVap, double[] saveL,
+      double[] saveHL, double[] saveHV) {
+    System.arraycopy(saveK[j], 0, K[j], 0, C);
+    System.arraycopy(saveVap[j], 0, vap[j], 0, C);
+    L[j] = saveL[j];
+    hL[j] = saveHL[j];
+    hV[j] = saveHV[j];
+  }
+
+  /**
+   * Compute the L2 norm of the difference between two vectors.
+   *
+   * @param first first vector
+   * @param second second vector
+   * @return L2 norm of {@code first - second}
+   */
+  private double vectorDifferenceNorm(double[] first, double[] second) {
+    double sum = 0.0;
+    for (int i = 0; i < first.length; i++) {
+      double difference = first[i] - second[i];
+      sum += difference * difference;
+    }
+    return Math.sqrt(sum);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -1007,8 +1007,7 @@ public class NaphtaliSandholmSolver {
           String.format("%.6e", norm));
       // Partial convergence is only acceptable when each component balance still closes; a leaky
       // profile must be reported as not accepted so the column does not present it as a solution.
-      boolean partialConvergenceAccepted =
-          norm < tolerance * 100 && meshClosureAcceptable("partial convergence");
+      boolean partialConvergenceAccepted = norm < tolerance * 100 && meshClosureAcceptable("partial convergence");
       if (!partialConvergenceAccepted && warmStartFromColumn) {
         return retryWithColdInitialization(id);
       }
@@ -1028,10 +1027,10 @@ public class NaphtaliSandholmSolver {
    * Retry a rejected retained-state solve from the column's normal cold initializer.
    *
    * <p>
-   * A rejected warm state must not be materialized on the live column before recovery. Otherwise
-   * the nominal cold retry initializes from tray systems and cached products that already contain
-   * the rejected Newton profile. Clearing the warm-start flag and restarting here keeps the live
-   * column authoritative until either the cold attempt is accepted or its best result is applied.
+   * A rejected warm state must not be materialized on the live column before recovery. Otherwise the nominal cold retry
+   * initializes from tray systems and cached products that already contain the rejected Newton profile. Clearing the
+   * warm-start flag and restarting here keeps the live column authoritative until either the cold attempt is accepted
+   * or its best result is applied.
    * </p>
    *
    * @param id calculation identifier for NeqSim

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -3249,8 +3249,7 @@ public class NaphtaliSandholmSolver {
           int rowBase = j * varsPerTray;
           for (int eq = 0; eq < varsPerTray; eq++) {
             if (centeredDifference) {
-              J[rowBase + eq][varIdx] =
-                  (forwardResidual[j - jStart][eq] - comparisonResidual[eq]) / (2.0 * h);
+              J[rowBase + eq][varIdx] = (forwardResidual[j - jStart][eq] - comparisonResidual[eq]) / (2.0 * h);
             } else {
               J[rowBase + eq][varIdx] = (forwardResidual[j - jStart][eq] - F0[rowBase + eq]) / h;
             }

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -3256,18 +3256,20 @@ public class NaphtaliSandholmSolver {
    * Refine the derived tray state before a finite-difference Jacobian build.
    *
    * <p>
-   * The primary Newton variables remain unchanged. Up to three full-column thermodynamic passes are evaluated, and the
-   * state with the smallest finite MESH residual is retained. Refinement stops when consecutive residual vectors differ
-   * by no more than one tenth of the outer tolerance. This replaces the accidental, column-order-dependent K-value
-   * refinement that previously occurred while restoring each finite-difference perturbation.
+   * The primary Newton variables remain unchanged. At least one and up to three full-column thermodynamic passes are
+   * evaluated, and the state with the smallest finite MESH residual among those refreshed states is retained. The
+   * incoming derived state remains only as a fallback if no refinement is finite. Refinement stops when consecutive
+   * residual vectors differ by no more than one tenth of the outer tolerance. This replaces the accidental,
+   * column-order-dependent K-value refinement that previously occurred while restoring each finite-difference
+   * perturbation.
    * </p>
    *
    * @param initialResidual residual at the current primary state
    * @return residual owned by the retained derived thermodynamic state
    */
   private double[] refineJacobianBaseState(double[] initialResidual) {
-    double[] bestResidual = initialResidual.clone();
-    double bestNorm = vectorNorm(bestResidual);
+    double[] bestResidual = null;
+    double bestNorm = Double.POSITIVE_INFINITY;
     double[] previousResidual = initialResidual;
 
     double[][] bestK = new double[N][C];
@@ -3297,7 +3299,7 @@ public class NaphtaliSandholmSolver {
     }
 
     restoreDerivedThermodynamicState(bestK, bestVap, bestL, bestHL, bestHV);
-    return bestResidual;
+    return bestResidual == null ? initialResidual : bestResidual;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -70,9 +70,6 @@ public class NaphtaliSandholmSolver {
   /** Convergence tolerance for the largest absolute logarithmic K-value update. */
   private static final double THERMO_K_VALUE_TOLERANCE = 1.0e-8;
 
-  /** Maximum residual-aware full-column refinements before a finite-difference Jacobian build. */
-  private static final int JACOBIAN_BASE_REFINEMENT_LIMIT = 3;
-
   /** Logger for this class. */
   private static final Logger logger = LogManager.getLogger(NaphtaliSandholmSolver.class);
 
@@ -3256,12 +3253,12 @@ public class NaphtaliSandholmSolver {
    * Refine the derived tray state before a finite-difference Jacobian build.
    *
    * <p>
-   * The primary Newton variables remain unchanged. At least one and up to three full-column thermodynamic passes are
-   * evaluated, and the state with the smallest finite MESH residual among those refreshed states is retained. The
-   * incoming derived state remains only as a fallback if no refinement is finite. Refinement stops when consecutive
-   * residual vectors differ by no more than one tenth of the outer tolerance. This replaces the accidental,
-   * column-order-dependent K-value refinement that previously occurred while restoring each finite-difference
-   * perturbation.
+   * The primary Newton variables remain unchanged. Up to one full-column thermodynamic pass per local finite-difference
+   * variable is evaluated, matching the restore-evaluation budget that the frozen base replaces. The state with the
+   * smallest finite MESH residual among those refreshed states is retained, while the incoming derived state remains
+   * only as a fallback if no refinement is finite. Refinement stops early when consecutive residual vectors differ by
+   * no more than one tenth of the outer tolerance. This replaces the accidental, column-order-dependent K-value
+   * refinement that previously occurred while restoring each finite-difference perturbation.
    * </p>
    *
    * @param initialResidual residual at the current primary state
@@ -3280,7 +3277,7 @@ public class NaphtaliSandholmSolver {
     saveDerivedThermodynamicState(bestK, bestVap, bestL, bestHL, bestHV);
 
     double residualChangeTolerance = Math.max(1.0e-12, tolerance * 0.1);
-    for (int refinement = 0; refinement < JACOBIAN_BASE_REFINEMENT_LIMIT; refinement++) {
+    for (int refinement = 0; refinement < varsPerTray; refinement++) {
       evaluateThermo();
       lastJacobianBaseRefinementCount++;
       double[] candidateResidual = computeResidual();

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -3217,20 +3217,43 @@ public class NaphtaliSandholmSolver {
       for (int k = 0; k < varsPerTray; k++) {
         int varIdx = jj * varsPerTray + k;
 
-        // Save and perturb one primary variable from the same frozen base state.
+        // Save and perturb one primary variable from the same frozen base state. Use
+        // a centred difference away from the physical lower bounds. The symmetric
+        // evaluation cancels the leading truncation error that made the frozen
+        // forward difference sensitive to the capped local K fixed point. This adds
+        // one tray evaluation per interior variable but does not reintroduce
+        // column-order-dependent state drift.
         double origVal = getVariable(jj, k);
         double h = Math.max(Math.abs(origVal) * pertSize, minPert);
         setVariable(jj, k, origVal + h);
         evaluateThermoForTray(jj);
 
-        // Only the perturbed tray and its two neighbors can depend on this variable.
         int jStart = Math.max(0, jj - 1);
         int jEnd = Math.min(N - 1, jj + 1);
+        double[][] forwardResidual = new double[jEnd - jStart + 1][];
         for (int j = jStart; j <= jEnd; j++) {
-          double[] Fpert = computeResidualForTray(j);
+          forwardResidual[j - jStart] = computeResidualForTray(j);
+        }
+
+        boolean centeredDifference = canUseCenteredJacobianPerturbation(k, origVal, h);
+        if (centeredDifference) {
+          setVariable(jj, k, origVal);
+          restoreDerivedThermodynamicStateForTray(jj, baseK, baseVap, baseL, baseHL, baseHV);
+          setVariable(jj, k, origVal - h);
+          evaluateThermoForTray(jj);
+        }
+
+        // Only the perturbed tray and its two neighbors can depend on this variable.
+        for (int j = jStart; j <= jEnd; j++) {
+          double[] comparisonResidual = centeredDifference ? computeResidualForTray(j) : null;
           int rowBase = j * varsPerTray;
           for (int eq = 0; eq < varsPerTray; eq++) {
-            J[rowBase + eq][varIdx] = (Fpert[eq] - F0[rowBase + eq]) / h;
+            if (centeredDifference) {
+              J[rowBase + eq][varIdx] =
+                  (forwardResidual[j - jStart][eq] - comparisonResidual[eq]) / (2.0 * h);
+            } else {
+              J[rowBase + eq][varIdx] = (forwardResidual[j - jStart][eq] - F0[rowBase + eq]) / h;
+            }
           }
         }
 
@@ -3247,6 +3270,19 @@ public class NaphtaliSandholmSolver {
     lastFiniteDifferenceJacobianColumns += totalVars;
     lastJacobianBuildTimeSeconds += (System.nanoTime() - jacobianStart) / 1.0e9;
     return J;
+  }
+
+  /**
+   * Check whether a Jacobian variable can be perturbed symmetrically without crossing its physical lower bound.
+   *
+   * @param variableIndex local tray-variable index
+   * @param value unperturbed variable value
+   * @param perturbation finite-difference perturbation
+   * @return {@code true} when {@code value - perturbation} remains inside the variable domain
+   */
+  private boolean canUseCenteredJacobianPerturbation(int variableIndex, double value, double perturbation) {
+    double lowerBound = variableIndex == C ? 100.0 : 1.0e-20;
+    return value - perturbation > lowerBound;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -3472,8 +3472,8 @@ public class NaphtaliSandholmSolver {
   }
 
   private void evaluateThermoForTray(int j) {
-    int maximumKValueIterations =
-        warmStartFromColumn ? THERMO_WARM_START_K_VALUE_ITERATIONS : THERMO_K_VALUE_ITERATIONS;
+    int maximumKValueIterations = warmStartFromColumn ? THERMO_WARM_START_K_VALUE_ITERATIONS
+        : THERMO_K_VALUE_ITERATIONS;
     evaluateThermoForTray(j, maximumKValueIterations);
   }
 

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -67,9 +67,6 @@ public class NaphtaliSandholmSolver {
   /** Maximum forced-root fugacity sweeps when refining a retained column state. */
   private static final int THERMO_WARM_START_K_VALUE_ITERATIONS = 3;
 
-  /** Maximum forced-root fugacity sweeps for a perturbed finite-difference state. */
-  private static final int THERMO_JACOBIAN_K_VALUE_ITERATIONS = 6;
-
   /** Convergence tolerance for the largest absolute logarithmic K-value update. */
   private static final double THERMO_K_VALUE_TOLERANCE = 1.0e-8;
 
@@ -3224,7 +3221,7 @@ public class NaphtaliSandholmSolver {
         double origVal = getVariable(jj, k);
         double h = Math.max(Math.abs(origVal) * pertSize, minPert);
         setVariable(jj, k, origVal + h);
-        evaluateThermoForTray(jj, THERMO_JACOBIAN_K_VALUE_ITERATIONS);
+        evaluateThermoForTray(jj);
 
         // Only the perturbed tray and its two neighbors can depend on this variable.
         int jStart = Math.max(0, jj - 1);
@@ -3472,18 +3469,6 @@ public class NaphtaliSandholmSolver {
   }
 
   private void evaluateThermoForTray(int j) {
-    int maximumKValueIterations = warmStartFromColumn ? THERMO_WARM_START_K_VALUE_ITERATIONS
-        : THERMO_K_VALUE_ITERATIONS;
-    evaluateThermoForTray(j, maximumKValueIterations);
-  }
-
-  /**
-   * Evaluate one tray with an explicit K-value fixed-point sweep limit.
-   *
-   * @param j tray index
-   * @param maximumKValueIterations maximum forced-root fugacity sweeps
-   */
-  private void evaluateThermoForTray(int j, int maximumKValueIterations) {
     lastThermoEvaluationCount++;
     double sumLiq = 0;
     for (int i = 0; i < C; i++) {
@@ -3539,6 +3524,8 @@ public class NaphtaliSandholmSolver {
     boolean kConverged = false;
     double finalMaxLogKUpdate = Double.POSITIVE_INFINITY;
     if (kOk) {
+      int maximumKValueIterations = warmStartFromColumn ? THERMO_WARM_START_K_VALUE_ITERATIONS
+          : THERMO_K_VALUE_ITERATIONS;
       for (int sweep = 0; sweep < maximumKValueIterations; sweep++) {
         if (!computeSinglePhaseFugacityCoefficients(y, T[j], Pbar, true, phiV)) {
           kOk = false;

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -67,6 +67,9 @@ public class NaphtaliSandholmSolver {
   /** Maximum forced-root fugacity sweeps when refining a retained column state. */
   private static final int THERMO_WARM_START_K_VALUE_ITERATIONS = 3;
 
+  /** Maximum forced-root fugacity sweeps for a perturbed finite-difference state. */
+  private static final int THERMO_JACOBIAN_K_VALUE_ITERATIONS = 6;
+
   /** Convergence tolerance for the largest absolute logarithmic K-value update. */
   private static final double THERMO_K_VALUE_TOLERANCE = 1.0e-8;
 
@@ -3221,7 +3224,7 @@ public class NaphtaliSandholmSolver {
         double origVal = getVariable(jj, k);
         double h = Math.max(Math.abs(origVal) * pertSize, minPert);
         setVariable(jj, k, origVal + h);
-        evaluateThermoForTray(jj);
+        evaluateThermoForTray(jj, THERMO_JACOBIAN_K_VALUE_ITERATIONS);
 
         // Only the perturbed tray and its two neighbors can depend on this variable.
         int jStart = Math.max(0, jj - 1);
@@ -3469,6 +3472,18 @@ public class NaphtaliSandholmSolver {
   }
 
   private void evaluateThermoForTray(int j) {
+    int maximumKValueIterations =
+        warmStartFromColumn ? THERMO_WARM_START_K_VALUE_ITERATIONS : THERMO_K_VALUE_ITERATIONS;
+    evaluateThermoForTray(j, maximumKValueIterations);
+  }
+
+  /**
+   * Evaluate one tray with an explicit K-value fixed-point sweep limit.
+   *
+   * @param j tray index
+   * @param maximumKValueIterations maximum forced-root fugacity sweeps
+   */
+  private void evaluateThermoForTray(int j, int maximumKValueIterations) {
     lastThermoEvaluationCount++;
     double sumLiq = 0;
     for (int i = 0; i < C; i++) {
@@ -3524,8 +3539,6 @@ public class NaphtaliSandholmSolver {
     boolean kConverged = false;
     double finalMaxLogKUpdate = Double.POSITIVE_INFINITY;
     if (kOk) {
-      int maximumKValueIterations = warmStartFromColumn ? THERMO_WARM_START_K_VALUE_ITERATIONS
-          : THERMO_K_VALUE_ITERATIONS;
       for (int sweep = 0; sweep < maximumKValueIterations; sweep++) {
         if (!computeSinglePhaseFugacityCoefficients(y, T[j], Pbar, true, phiV)) {
           kOk = false;

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -4536,15 +4536,19 @@ public class NaphtaliSandholmSolver {
     double rho = 0.5; // backtracking factor
     int maxBacktrack = 15;
 
-    // Save current state
+    // Save the complete current state. Every backtracking trial must start
+    // from the same primary and derived thermodynamic base; otherwise a
+    // rejected larger step silently changes the K-value seed of the next trial.
     double[][] saveLiq = new double[N][C];
     double[] saveT = new double[N];
     double[] saveV = new double[N];
-    for (int j = 0; j < N; j++) {
-      System.arraycopy(liq[j], 0, saveLiq[j], 0, C);
-      saveT[j] = T[j];
-      saveV[j] = V[j];
-    }
+    saveTrayState(saveLiq, saveT, saveV);
+    double[][] saveK = new double[N][C];
+    double[][] saveVap = new double[N][C];
+    double[] saveL = new double[N];
+    double[] saveHL = new double[N];
+    double[] saveHV = new double[N];
+    saveDerivedThermodynamicState(saveK, saveVap, saveL, saveHL, saveHV);
 
     double bestAlpha = 0.0;
     double bestTrialNorm = Double.POSITIVE_INFINITY;
@@ -4552,8 +4556,9 @@ public class NaphtaliSandholmSolver {
     double lastEvaluatedAlpha = Double.NaN;
 
     for (int bt = 0; bt < maxBacktrack; bt++) {
-      // Trial update
+      // Trial update from one reproducible primary and derived base.
       restoreTrayState(saveLiq, saveT, saveV);
+      restoreDerivedThermodynamicState(saveK, saveVap, saveL, saveHL, saveHV);
       applyUpdate(dx, alpha);
 
       evaluateThermo();
@@ -4581,11 +4586,13 @@ public class NaphtaliSandholmSolver {
 
     if (bestAlpha <= 0.0 || bestResidual == null) {
       restoreTrayState(saveLiq, saveT, saveV);
+      restoreDerivedThermodynamicState(saveK, saveVap, saveL, saveHL, saveHV);
       return new LineSearchResult(0.0, null, Double.POSITIVE_INFINITY);
     }
 
     if (bestAlpha != lastEvaluatedAlpha) {
       restoreTrayState(saveLiq, saveT, saveV);
+      restoreDerivedThermodynamicState(saveK, saveVap, saveL, saveHL, saveHV);
       applyUpdate(dx, bestAlpha);
       evaluateThermo();
       bestResidual = computeResidual();

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -5090,8 +5090,9 @@ public class NaphtaliSandholmSolver {
         gasSystem.setPressure(P[j] / 1e5);
         gasSystem.setTotalNumberOfMoles(V[j] / 3600.0);
         gasSystem.setMolarComposition(y);
-        gasSystem.setNumberOfPhases(1);
         gasSystem.init(0);
+        gasSystem.setNumberOfPhases(1);
+        gasSystem.setPhaseType(0, PhaseType.GAS);
         gasSystem.init(2);
         tray.setCachedGasOutStream(new neqsim.process.equipment.stream.Stream("gas_" + j, gasSystem));
 
@@ -5100,8 +5101,9 @@ public class NaphtaliSandholmSolver {
         liqSystem.setPressure(P[j] / 1e5);
         liqSystem.setTotalNumberOfMoles(L[j] / 3600.0);
         liqSystem.setMolarComposition(x);
-        liqSystem.setNumberOfPhases(1);
         liqSystem.init(0);
+        liqSystem.setNumberOfPhases(1);
+        liqSystem.setPhaseType(0, PhaseType.LIQUID);
         liqSystem.init(2);
         tray.setCachedLiquidOutStream(new neqsim.process.equipment.stream.Stream("liq_" + j, liqSystem));
       }

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -869,6 +869,9 @@ public class NaphtaliSandholmSolver {
             norm = vectorNorm(residual);
             failedSteps++;
             if (failedSteps > 5) {
+              if (warmStartFromColumn) {
+                return retryWithColdInitialization(id);
+              }
               applyResultsToColumn(id, iter, bestNorm, startTime);
               return false;
             }
@@ -926,6 +929,9 @@ public class NaphtaliSandholmSolver {
           failedSteps++;
           logger.warn("NS: NaN/Inf — reverting to best (||F||={})", String.format("%.6e", norm));
           if (failedSteps > 5) {
+            if (warmStartFromColumn) {
+              return retryWithColdInitialization(id);
+            }
             applyResultsToColumn(id, iter, bestNorm, startTime);
             return false;
           }
@@ -999,15 +1005,42 @@ public class NaphtaliSandholmSolver {
 
       logger.warn("Naphtali-Sandholm did not converge in {} iterations, ||F|| = {}", completedNewtonIterations,
           String.format("%.6e", norm));
-      applyResultsToColumn(id, completedNewtonIterations, norm, startTime);
       // Partial convergence is only acceptable when each component balance still closes; a leaky
       // profile must be reported as not accepted so the column does not present it as a solution.
-      return norm < tolerance * 100 && meshClosureAcceptable("partial convergence");
+      boolean partialConvergenceAccepted =
+          norm < tolerance * 100 && meshClosureAcceptable("partial convergence");
+      if (!partialConvergenceAccepted && warmStartFromColumn) {
+        return retryWithColdInitialization(id);
+      }
+      applyResultsToColumn(id, completedNewtonIterations, norm, startTime);
+      return partialConvergenceAccepted;
     } catch (Exception ex) {
       logger.error("Naphtali-Sandholm solver exception", ex);
       logger.error("NS EXCEPTION: {}: {}", ex.getClass().getName(), ex.getMessage());
+      if (warmStartFromColumn) {
+        return retryWithColdInitialization(id);
+      }
       return false;
     }
+  }
+
+  /**
+   * Retry a rejected retained-state solve from the column's normal cold initializer.
+   *
+   * <p>
+   * A rejected warm state must not be materialized on the live column before recovery. Otherwise
+   * the nominal cold retry initializes from tray systems and cached products that already contain
+   * the rejected Newton profile. Clearing the warm-start flag and restarting here keeps the live
+   * column authoritative until either the cold attempt is accepted or its best result is applied.
+   * </p>
+   *
+   * @param id calculation identifier for NeqSim
+   * @return {@code true} if the cold retry converges or meets an accepted closure criterion
+   */
+  private boolean retryWithColdInitialization(UUID id) {
+    logger.info("NS: rejected warm-start state; retrying from cold initialization before applying results");
+    warmStartFromColumn = false;
+    return solve(id);
   }
 
   /** Reset solver telemetry before a new solve. */
@@ -3217,42 +3250,20 @@ public class NaphtaliSandholmSolver {
       for (int k = 0; k < varsPerTray; k++) {
         int varIdx = jj * varsPerTray + k;
 
-        // Save and perturb one primary variable from the same frozen base state. Use
-        // a centred difference away from the physical lower bounds. The symmetric
-        // evaluation cancels the leading truncation error that made the frozen
-        // forward difference sensitive to the capped local K fixed point. This adds
-        // one tray evaluation per interior variable but does not reintroduce
-        // column-order-dependent state drift.
+        // Save and perturb one primary variable from the same frozen base state.
         double origVal = getVariable(jj, k);
         double h = Math.max(Math.abs(origVal) * pertSize, minPert);
         setVariable(jj, k, origVal + h);
         evaluateThermoForTray(jj);
 
+        // Only the perturbed tray and its two neighbors can depend on this variable.
         int jStart = Math.max(0, jj - 1);
         int jEnd = Math.min(N - 1, jj + 1);
-        double[][] forwardResidual = new double[jEnd - jStart + 1][];
         for (int j = jStart; j <= jEnd; j++) {
-          forwardResidual[j - jStart] = computeResidualForTray(j);
-        }
-
-        boolean centeredDifference = canUseCenteredJacobianPerturbation(k, origVal, h);
-        if (centeredDifference) {
-          setVariable(jj, k, origVal);
-          restoreDerivedThermodynamicStateForTray(jj, baseK, baseVap, baseL, baseHL, baseHV);
-          setVariable(jj, k, origVal - h);
-          evaluateThermoForTray(jj);
-        }
-
-        // Only the perturbed tray and its two neighbors can depend on this variable.
-        for (int j = jStart; j <= jEnd; j++) {
-          double[] comparisonResidual = centeredDifference ? computeResidualForTray(j) : null;
+          double[] Fpert = computeResidualForTray(j);
           int rowBase = j * varsPerTray;
           for (int eq = 0; eq < varsPerTray; eq++) {
-            if (centeredDifference) {
-              J[rowBase + eq][varIdx] = (forwardResidual[j - jStart][eq] - comparisonResidual[eq]) / (2.0 * h);
-            } else {
-              J[rowBase + eq][varIdx] = (forwardResidual[j - jStart][eq] - F0[rowBase + eq]) / h;
-            }
+            J[rowBase + eq][varIdx] = (Fpert[eq] - F0[rowBase + eq]) / h;
           }
         }
 
@@ -3269,19 +3280,6 @@ public class NaphtaliSandholmSolver {
     lastFiniteDifferenceJacobianColumns += totalVars;
     lastJacobianBuildTimeSeconds += (System.nanoTime() - jacobianStart) / 1.0e9;
     return J;
-  }
-
-  /**
-   * Check whether a Jacobian variable can be perturbed symmetrically without crossing its physical lower bound.
-   *
-   * @param variableIndex local tray-variable index
-   * @param value unperturbed variable value
-   * @param perturbation finite-difference perturbation
-   * @return {@code true} when {@code value - perturbation} remains inside the variable domain
-   */
-  private boolean canUseCenteredJacobianPerturbation(int variableIndex, double value, double perturbation) {
-    double lowerBound = variableIndex == C ? 100.0 : 1.0e-20;
-    return value - perturbation > lowerBound;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
+++ b/src/main/java/neqsim/process/equipment/distillation/NaphtaliSandholmSolver.java
@@ -3254,27 +3254,27 @@ public class NaphtaliSandholmSolver {
    *
    * <p>
    * The primary Newton variables remain unchanged. Up to one full-column thermodynamic pass per local finite-difference
-   * variable is evaluated, matching the restore-evaluation budget that the frozen base replaces. The state with the
-   * smallest finite MESH residual among those refreshed states is retained, while the incoming derived state remains
-   * only as a fallback if no refinement is finite. Refinement stops early when consecutive residual vectors differ by
-   * no more than one tenth of the outer tolerance. This replaces the accidental, column-order-dependent K-value
-   * refinement that previously occurred while restoring each finite-difference perturbation.
+   * variable is evaluated, matching the restore-evaluation budget that the frozen base replaces. The latest finite
+   * refreshed state is retained so the Jacobian base owns the most thermodynamically consistent K-value fixed point;
+   * the incoming derived state remains only as a fallback if no refinement is finite. Refinement stops early when
+   * consecutive residual vectors differ by no more than one tenth of the outer tolerance. This replaces the accidental,
+   * column-order-dependent K-value refinement that previously occurred while restoring each finite-difference
+   * perturbation.
    * </p>
    *
    * @param initialResidual residual at the current primary state
    * @return residual owned by the retained derived thermodynamic state
    */
   private double[] refineJacobianBaseState(double[] initialResidual) {
-    double[] bestResidual = null;
-    double bestNorm = Double.POSITIVE_INFINITY;
+    double[] retainedResidual = null;
     double[] previousResidual = initialResidual;
 
-    double[][] bestK = new double[N][C];
-    double[][] bestVap = new double[N][C];
-    double[] bestL = new double[N];
-    double[] bestHL = new double[N];
-    double[] bestHV = new double[N];
-    saveDerivedThermodynamicState(bestK, bestVap, bestL, bestHL, bestHV);
+    double[][] retainedK = new double[N][C];
+    double[][] retainedVap = new double[N][C];
+    double[] retainedL = new double[N];
+    double[] retainedHL = new double[N];
+    double[] retainedHV = new double[N];
+    saveDerivedThermodynamicState(retainedK, retainedVap, retainedL, retainedHL, retainedHV);
 
     double residualChangeTolerance = Math.max(1.0e-12, tolerance * 0.1);
     for (int refinement = 0; refinement < varsPerTray; refinement++) {
@@ -3284,19 +3284,18 @@ public class NaphtaliSandholmSolver {
       double candidateNorm = vectorNorm(candidateResidual);
       double residualChange = vectorDifferenceNorm(previousResidual, candidateResidual);
 
-      if (Double.isFinite(candidateNorm) && candidateNorm < bestNorm) {
-        bestNorm = candidateNorm;
-        bestResidual = candidateResidual;
-        saveDerivedThermodynamicState(bestK, bestVap, bestL, bestHL, bestHV);
+      if (Double.isFinite(candidateNorm)) {
+        retainedResidual = candidateResidual;
+        saveDerivedThermodynamicState(retainedK, retainedVap, retainedL, retainedHL, retainedHV);
       }
-      if (residualChange <= residualChangeTolerance) {
+      if (Double.isFinite(candidateNorm) && residualChange <= residualChangeTolerance) {
         break;
       }
       previousResidual = candidateResidual;
     }
 
-    restoreDerivedThermodynamicState(bestK, bestVap, bestL, bestHL, bestHV);
-    return bestResidual == null ? initialResidual : bestResidual;
+    restoreDerivedThermodynamicState(retainedK, retainedVap, retainedL, retainedHL, retainedHV);
+    return retainedResidual == null ? initialResidual : retainedResidual;
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -166,7 +166,12 @@ public class ColumnStudyRegressionTest {
     solver.setMaxIterations(80);
     boolean accepted = solver.solve(new UUID(0L, 1L));
 
-    assertTrue(accepted, "the severely perturbed retained state should recover without coordinated fallback");
+    assertTrue(accepted,
+        () -> "the severely perturbed retained state should recover without coordinated fallback: iterations="
+            + solver.getLastIterations() + ", residual=" + solver.getLastResidualNorm() + ", mass balance="
+            + solver.getLastMassBalanceError() + ", base refinements=" + solver.getLastJacobianBaseRefinementCount()
+            + ", thermo evaluations=" + solver.getLastThermoEvaluationCount() + ", K sweeps="
+            + solver.getLastThermoKValueIterationCount());
     assertTrue(solver.getLastIterations() <= 45,
         "the recovered warm solve should remain well below the 80-iteration cap");
     assertTrue(solver.getLastMassBalanceError() < 1.0e-8, "the recovered state should close total molar balance");

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -181,10 +181,8 @@ public class ColumnStudyRegressionTest {
         Integer.toString(solver.getLastJacobianBaseRefinementCount()));
     testReporter.publishEntry("severe_jacobian_base_residual_mutation",
         Double.toString(solver.getLastJacobianBaseResidualMutation()));
-    testReporter.publishEntry("severe_thermo_evaluations",
-        Integer.toString(solver.getLastThermoEvaluationCount()));
-    testReporter.publishEntry("severe_k_sweeps",
-        Integer.toString(solver.getLastThermoKValueIterationCount()));
+    testReporter.publishEntry("severe_thermo_evaluations", Integer.toString(solver.getLastThermoEvaluationCount()));
+    testReporter.publishEntry("severe_k_sweeps", Integer.toString(solver.getLastThermoKValueIterationCount()));
     assertPhysicalProduct(column.getGasOutStream(), "recovered warm-start gas product");
     assertPhysicalProduct(column.getLiquidOutStream(), "recovered warm-start liquid product");
     assertOverallMassBalance(feedStream, topFeedStream, column);

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -125,7 +125,9 @@ public class ColumnStudyRegressionTest {
     assertTrue(column.solved(), "Column-study case should converge with Naphtali-Sandholm");
     assertEquals(DistillationColumn.SolveStatus.RECONCILED_PRODUCTS, column.getLastSolveStatus(),
         "a no-side-draw direct result should preserve the established reconciled-product status");
-    assertEquals(17, column.getLastIterationCount(), "Newton iteration count guards against premature SR acceptance");
+    assertEquals(DistillationColumn.SolverType.NAPHTALI_SANDHOLM, column.getLastSolverTypeUsed(),
+        "the nominal case must be accepted by the simultaneous solver rather than a premature SR fallback");
+    assertTrue(column.getLastIterationCount() > 0, "the nominal rigorous solve should exercise Newton refinement");
     assertTrayTemperatureProfile(column);
     assertTrayPressureProfile(column);
     assertOverallMassBalance(feedStream, topFeedStream, column);

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnStudyRegressionTest.java
@@ -143,7 +143,7 @@ public class ColumnStudyRegressionTest {
    * </p>
    */
   @Test
-  public void severeWarmStartPerturbationConvergesWithRefinedKValues() {
+  public void severeWarmStartPerturbationConvergesWithRefinedKValues(TestReporter testReporter) {
     SystemInterface baseFluid = createBaseFluid();
     StreamInterface feedStream = createStream("stall_guard_main_feed", baseFluid, MAIN_FEED_COMPOSITION,
         MAIN_FEED_TEMPERATURE_C, MAIN_FEED_PRESSURE_BARA, MAIN_FEED_MASS_FLOW_KG_HR);
@@ -173,6 +173,18 @@ public class ColumnStudyRegressionTest {
         "the recovered warm solve should keep thermodynamic evaluations bounded");
     assertTrue(solver.getLastThermoKValueIterationCount() < 70000,
         "the recovered warm solve should keep forced-root fugacity sweeps bounded");
+    assertTrue(solver.getLastJacobianBaseRefinementCount() > 0,
+        "the difficult solve should exercise residual-aware Jacobian base refinement");
+    assertEquals(0.0, solver.getLastJacobianBaseResidualMutation(), 0.0,
+        "finite-difference assembly must leave the base MESH residual bitwise unchanged");
+    testReporter.publishEntry("severe_jacobian_base_refinements",
+        Integer.toString(solver.getLastJacobianBaseRefinementCount()));
+    testReporter.publishEntry("severe_jacobian_base_residual_mutation",
+        Double.toString(solver.getLastJacobianBaseResidualMutation()));
+    testReporter.publishEntry("severe_thermo_evaluations",
+        Integer.toString(solver.getLastThermoEvaluationCount()));
+    testReporter.publishEntry("severe_k_sweeps",
+        Integer.toString(solver.getLastThermoKValueIterationCount()));
     assertPhysicalProduct(column.getGasOutStream(), "recovered warm-start gas product");
     assertPhysicalProduct(column.getLiquidOutStream(), "recovered warm-start liquid product");
     assertOverallMassBalance(feedStream, topFeedStream, column);

--- a/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
@@ -111,11 +111,39 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
     double[] gasProductMoles = componentMoles(testCase.column.getGasOutStream());
     double[] liquidProductMoles = componentMoles(testCase.column.getLiquidOutStream());
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+      final int diagnosticComponentIndex = componentIndex;
       double feedMoles = gasFeedMoles[componentIndex] + solventFeedMoles[componentIndex];
       double productMoles = gasProductMoles[componentIndex] + liquidProductMoles[componentIndex];
       assertEquals(feedMoles, productMoles, Math.max(1.0e-12, feedMoles * 1.0e-9),
-          COMPONENTS[componentIndex] + " must close across the column");
+          () -> COMPONENTS[diagnosticComponentIndex] + " must close across the column; "
+              + componentClosureDiagnostics(testCase, diagnosticComponentIndex));
     }
+  }
+
+  private static String componentClosureDiagnostics(ColumnCase testCase, int componentIndex) {
+    DistillationColumn column = testCase.column;
+    return "solver=" + column.getLastSolverTypeUsed() + ", status=" + column.getLastSolveStatus() + ", reason="
+        + column.getLastSolveStatusReason() + ", gasFeed=" + componentInventory(testCase.gasFeed, componentIndex)
+        + ", solventFeed=" + componentInventory(testCase.solventFeed, componentIndex) + ", gasProduct="
+        + componentInventory(column.getGasOutStream(), componentIndex) + ", liquidProduct="
+        + componentInventory(column.getLiquidOutStream(), componentIndex);
+  }
+
+  private static String componentInventory(StreamInterface stream, int componentIndex) {
+    SystemInterface system = stream.getThermoSystem();
+    StringBuilder inventory = new StringBuilder();
+    inventory.append(stream.getName()).append("{total=").append(system.getTotalNumberOfMoles()).append(", phases=")
+        .append(system.getNumberOfPhases());
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      inventory.append(", ").append(system.getPhase(phaseIndex).getPhaseTypeName()).append("[beta=")
+          .append(system.getBeta(phaseIndex)).append(", componentInPhase=")
+          .append(system.getPhase(phaseIndex).getComponent(componentIndex).getNumberOfMolesInPhase()).append("]");
+    }
+    if (system.getNumberOfPhases() > 0) {
+      inventory.append(", componentTotal=")
+          .append(system.getPhase(0).getComponent(componentIndex).getNumberOfmoles());
+    }
+    return inventory.append("}").toString();
   }
 
   private static void assertPhysicalProduct(StreamInterface product, String label) {

--- a/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ReboilerOnlySumRatesPhaseStabilityTest.java
@@ -140,8 +140,7 @@ public class ReboilerOnlySumRatesPhaseStabilityTest {
           .append(system.getPhase(phaseIndex).getComponent(componentIndex).getNumberOfMolesInPhase()).append("]");
     }
     if (system.getNumberOfPhases() > 0) {
-      inventory.append(", componentTotal=")
-          .append(system.getPhase(0).getComponent(componentIndex).getNumberOfmoles());
+      inventory.append(", componentTotal=").append(system.getPhase(0).getComponent(componentIndex).getNumberOfmoles());
     }
     return inventory.append("}").toString();
   }


### PR DESCRIPTION
## Problem

Advances #2936 C3 residual/Jacobian derived-state ownership.

At exact base `231fc66f42a573853858b3009dbc99a9ac996c1d`, `computeJacobian(F0)` subtracts one pre-build residual while every finite-difference perturb/restore calls the stateful tray fugacity fixed point. The previously confirmed #2887 reproduction changes residual index 0 from `0.3207609801833712` to `0.3207400566281666` after a Jacobian build with unchanged primary variables. Later columns therefore use a different K/enthalpy base than earlier columns. Naively removing restores saved work but changed residuals; exact snapshot restoration alone made the severe 90 K retained-state case lose closure. Both candidates were rejected.

## Coherent numerical change

- Before each Jacobian build, perform up to one full-column thermodynamic refinement per local finite-difference variable (`components + 2`), with residual-change early exit.
- Base refinement matches—but does not exceed—the tray restore-evaluation budget that the frozen base replaces.
- Retain the latest finite refreshed state so the base owns the most thermodynamically consistent K-value fixed point; use the incoming state only if every refinement is non-finite.
- Stop early when consecutive residual vectors agree within `max(1e-12, 0.1 * outer tolerance)`.
- Snapshot K-values, vapor component flows, total liquid flows and phase enthalpies for the selected base.
- Restore the derived state exactly after every perturbed finite-difference column, so every column and RHS share one base state.
- If a retained-state solve is rejected, restart from the normal cold initializer before applying any tray or product state, so recovery starts from the authoritative live column rather than the rejected Newton profile.
- Restore the complete frozen primary and derived state before every backtracking trial.
- Record base-refinement passes and post-build residual mutation; the latter must be bitwise zero.

This replaces accidental column-order-dependent K refinement with bounded residual-aware refinement and closure-preserving best-state restoration. It does not coalesce EOS work speculatively, loosen tolerances, change equations, alter TPflash, or special-case a mixture.

## Regression and engineering envelope

The realistic 24-component, 11-stage, two-feed hydrocarbon column regression now requires the severe 90 K retained-state solve to:

- recover within the direct simultaneous solver's warm/cold path and the existing 80-iteration cap;
- close total and per-component material balances;
- satisfy scaled MESH residual below `1e-8`;
- retain physical gas/liquid products;
- keep thermo evaluations below 24,000 and forced-root K sweeps below 70,000;
- exercise bounded Jacobian-base refinement; and
- leave the base residual bitwise unchanged after every Jacobian build.

The existing same-class nominal cold case and +10% nearby-feed case continue to guard tray profile, fixed reboiler temperature, total/component closure, exact reuse, nearby convergence and stable thermo/K-sweep work.

## Compatibility and risk

- No public API, serialization field, calculation identity, specification, default, solver-selection or fallback contract changes.
- Package-private telemetry is added for deterministic solver regression.
- Numerical trajectories can change because the previous trajectory depended on finite-difference column order. Acceptance remains governed by the existing MESH, mass, energy and physical-state gates.
- Stop boundary: shared flash algorithms and generic process execution are untouched.

## Documentation impact

Updated `docs/wiki/distillation_column.md` to describe Jacobian base refinement, exact derived-state ownership, retained-state cold recovery, and package-level mutation telemetry.

## Validation

**EXACT-HEAD CI PASSED**

A complete local checkout was prepared at head `5d98c777db3c72f99947923119212b9cdcb2e5b1`. `python devtools/check_documentation_search.py` passed against 652 Markdown pages and one standalone HTML page. Maven then stopped before compilation because the sandbox could not resolve `repo.maven.apache.org`; the canonical endpoint was already in use. The following commands were therefore not run to completion and are not claimed as passed:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`
- Maven focused or broader tests

The initial head produced one hosted Spotless patch affecting only two test-reporter line wraps. That exact patch was applied as `8309f0e5c1432e770e666dc527932488e8824f77`.

CI on that head then exposed three branch-attributable failures: the severe retained-state direct solve fell back, the absorber/stripper fallback produced a doubled methane component total on Windows, and the nominal regression's exact historical Newton count changed from 17 to 11 despite its physical and closure gates passing. Head `99cd5d99b00330c98b444d769d9ca4a63c009247` required at least one refreshed thermodynamic state to own every Jacobian base, preventing a stale incoming K/enthalpy state from winning solely because its pre-refinement residual appeared smaller. Exact-head CI proved that three full-column refreshes still did not recover the established severe retained-state basin: the same direct-solve and Windows fallback failures remained.

Head `85bdf61bce5fb1ec8e827daaddd1015912691075` preserved the former Jacobian's thermodynamic work budget deterministically. Its failure telemetry showed the severe solve stalled after 22 Newton iterations at residual `6.380739783171909`, with 41 base refinements, 7,777 tray thermo evaluations, and 22,954 K sweeps. The larger refinement cap was therefore not limiting; residual-change early exit was active.

Head `0a257bdde1ec1dd05f2a086e2273f685201a90a7` retained the latest finite refreshed K/enthalpy state rather than an earlier state selected only because its MESH norm was smaller. Exact-head CI proved that selection was not the limiting factor: the severe solve again stopped after 22 Newton iterations at residual `6.38073667468969`, with 41 base refinements, 7,777 tray thermo evaluations, and 22,954 K sweeps; Windows again observed the downstream fallback's doubled methane total.

Head `03b8274991d10ece5f7fcd6ebfa5cbe5755d88df` fixed the next evidenced ownership leak in the same Newton path: backtracking now restores the complete frozen primary and derived thermodynamic base before every trial. Exact-head CI showed that repair was numerically neutral; the severe solve again stopped after 22 iterations at residual `6.380736674787233`, while Windows again observed doubled methane after fallback.

Head `639e4137a4ccc5bd3e429877f33a7519039b1b3a` tested the remaining consistency hypothesis identified by that telemetry: a bounded six-sweep cap for each perturbed finite-difference state. Exact-head CI rejected the experiment. The severe case improved from 22 iterations and residual `6.380736674787233` to 14 iterations and residual `5.819587248194702`, but still failed direct convergence; five previously valid column cases also regressed, including the doubled-methane fallback becoming reproducible on Ubuntu. One slow shard separately failed before tests on a transient Maven Central HTTP 429. Current head `5d98c777db3c72f99947923119212b9cdcb2e5b1` therefore reverts only the six-sweep experiment and its documentation, preserving the earlier base-state and line-search ownership fixes, strict regressions, default cold/warm sweep limits, equations, tolerances, acceptance gates, fallback behavior, and public APIs. Exact-head CI on `5d98c777db3c72f99947923119212b9cdcb2e5b1` completed on Ubuntu. Static gates, Javadoc, and slow shards 2–4 passed. Slow shard 1 reproduced the severe retained-state failure unchanged at 22 iterations, residual `6.380736674787233`, mass balance `0.002099469650726581`, 41 base refinements, 7,777 tray thermo evaluations, and 22,954 K sweeps. The Ubuntu fast suite also reproduced the coordinated fallback's exact doubled methane total: expected `8.433407759222309`, actual `16.866815518568295`. Windows was cancelled after the Ubuntu failures, so it is not claimed as validated. The draft remains open; both failures are deterministic branch-attributable blockers. Inspection confirmed that Naphtali fallback runs on a clean pre-accelerator candidate copy before adoption, so no generic fallback or feed-inventory change is justified without further state evidence.

Head `14220e5707680085ef1983a964fd5c700cdad684`, plus hosted-Spotless follow-up `ef7340c897ce52156e582c4ab52b9ae257239f84`, tested bounded centered differences. Exact-head CI rejected that hypothesis: slow shard 1 still stopped after 23 iterations at residual `6.379927730482677`, mass balance `0.002122148512464723`, 42 base refinements, 14,317 tray thermo evaluations, and 42,294 K sweeps. The residual was essentially unchanged while thermodynamic work nearly doubled. Static gates, Javadoc, and slow shards 2–3 passed before the superseding fix was published.

Head `d85a898d4c9937fe8f4d2a736b20f690bcd4700d` reverts the centered-difference experiment and fixes the stronger state-management defect exposed by the paired failures. A rejected warm Newton attempt previously called `applyResultsToColumn(...)` before the advertised cold retry, mutating live tray systems and product caches; the retry therefore initialized from the rejected profile rather than an authoritative column state. Every rejected warm exit now restarts with the normal cold initializer before applying results, with recursion bounded by clearing the warm-start flag. Equations, one-sided Jacobian construction, sweep caps, tolerances, acceptance gates, generic coordinated fallback, and public APIs are unchanged. Local `git diff --check` and documentation-search validation passed. Maven execution remains unavailable locally because the sandbox cannot use its Maven repository and cannot resolve Maven Central. Hosted Spotless identified only two layout changes; exact patch `1271ac31e15e4196e402c3112340d80fe93d8681` is the current head. Exact-head GitHub CI is the execution validator.

Exact-head CI on `1271ac31e15e4196e402c3112340d80fe93d8681` validated the retained-state cold recovery: all four Ubuntu slow shards passed, including the formerly failing severe 90 K regression. Static gates, documentation search, CodeQL, PaperLab, and Javadoc also passed. Windows fast tests still reproduced the exact doubled methane total (`8.433407759222309` expected, `16.866815518568295` actual); Ubuntu fast tests were cancelled after that failure and are not claimed as validated. Re-inspection corrected the earlier fallback conclusion: the adapter created a clean pre-Naphtali copy for warm-result validation, but normal rejected-result fallback passed `null` and therefore ran damped substitution on the mutated live column. Head `723bcc34ac87033cb1e719d10a5fa100b3ca9135` reuses that already-created untouched copy for both validation and coordinated damped fallback. This changes no solver equations, tolerances, acceptance gates, or public API. **Intermediate head superseded; see exact-head validation below.**

Exact-head CI on `1271ac31e15e4196e402c3112340d80fe93d8681` proved the clean in-solver retry repairs the severe direct regression: all four slow shards passed, including 92 tests with zero failures in shard 1. Windows fast still reproduced the exact doubled methane inventory in `ReboilerOnlySumRatesPhaseStabilityTest` (expected `8.433407759222309`, actual `16.866815518568295`), and fail-fast cancelled Ubuntu. Commit `723bcc34ac87033cb1e719d10a5fa100b3ca9135` now makes coordinated Naphtali validation and damped fallback share the same untouched pre-accelerator candidate. Head `922deb6e5708638479ce2f2a23259216e1b20618` adds failure-only inventory diagnostics to the existing regression—solver/status/reason plus product phase count, beta, per-phase component moles, and stored component total—so exact-head CI can identify whether any remaining 2× state originates in candidate adoption, direct Naphtali materialization, or product reconciliation. Hosted Spotless identified one test-only line join; exact formatting follow-up `c4c182b357460636fb572cbcf11034f752ad8c51` is the current head.

Exact-head CI on `c4c182b357460636fb572cbcf11034f752ad8c51` showed that sharing the untouched fallback candidate was numerically neutral and supplied the missing ownership evidence. The failing severe point was a direct `NAPHTALI_SANDHOLM` result with status `RECONCILED_PRODUCTS`, not a coordinated fallback. Both public products exposed two phases with `beta=1.0` in each slot, and both slots repeated the stored component total (gas-product methane `8.038642797669937` twice; liquid-product methane `0.3947649616142083` twice). This identifies the defect in no-side-draw product materialization: it selected one phase before `init(0)`, but `init(0)` re-expanded both phase slots. Current head `6fa9e02da6e42b6d767c101d4ddfacf4e241c7ab` restores the one-phase count and intended gas/liquid root after composition initialization, matching the established `SimpleTray` lifecycle without changing accepted flows, compositions, equations, or gates. Documentation now records the applied-phase ownership rule. Exact-head CI on `6fa9e02da6e42b6d767c101d4ddfacf4e241c7ab` passed in full: pre-commit, Spotless, documentation search, CodeQL, PaperLab, Javadoc, Java 21 fast tests on Ubuntu and Windows, all four Java 21 slow-test shards, and Java 8 tests on Ubuntu and Windows. This includes the formerly failing severe 90 K retained-state regression and the reboiler-only methane closure regression. The PR remains draft for review.

Closes no issue; #2936 remains the persistent campaign roadmap.